### PR TITLE
fix(tests): de-flake §10.4 circuit-breaker tests — wait on the trip's terminal signal

### DIFF
--- a/tests/unit/TopicProfileOrchestrator.test.ts
+++ b/tests/unit/TopicProfileOrchestrator.test.ts
@@ -57,6 +57,16 @@ async function waitUntil(cond: () => boolean, timeoutMs = 3000): Promise<void> {
   }
 }
 
+// The parked pin becomes visible mid-trip (parkAndRevert assigns entry.parked
+// before its internal flushDurably await yields), so polling parkedFor races
+// the trip's continuation (unpark → breaker-revert audit → disclosure →
+// respawn enqueue). The breaker-revert audit is emitted after every other
+// synchronous trip side-effect — by the time a poll observes it, they have
+// all landed. Wait on that, never on parkedFor.
+async function waitForBreakerTrip(h: Harness): Promise<void> {
+  await waitUntil(() => h.audits.some((a) => a.type === 'breaker-revert'));
+}
+
 interface Harness {
   orch: TopicProfileOrchestrator;
   store: TopicProfileStore;
@@ -641,7 +651,7 @@ describe('circuit breaker (§10.4)', () => {
     });
     await h.store.mutate('7', { model: 'claude-bad-model', updatedBy: OP.updatedBy }, { shiftPrevious: true });
     for (let i = 0; i < 3; i++) h.orch.recordSpawnFailure('7', 'cli-not-found');
-    await waitUntil(() => h.store.parkedFor('7') !== null);
+    await waitForBreakerTrip(h);
     expect(h.store.parkedFor('7')?.profile.model).toBe('claude-bad-model');
     // Reverted to last-known-good (here: the empty pre-pin profile → defaults).
     expect(h.store.resolve('7')?.model ?? null).toBeNull();
@@ -689,7 +699,7 @@ describe('circuit breaker (§10.4)', () => {
     h.cfg.enabled = false;
     h.cfg.dryRun = true;
     for (let i = 0; i < 3; i++) h.orch.recordSpawnFailure('7', 'model-rejected-by-account');
-    await waitUntil(() => h.store.parkedFor('7') !== null);
+    await waitForBreakerTrip(h);
     expect(h.store.resolve('7')?.model ?? null).toBeNull(); // really reverted
     expect(
       h.disclosures.some((d) => d.text.includes("Couldn't launch")),
@@ -700,7 +710,7 @@ describe('circuit breaker (§10.4)', () => {
     const h = makeHarness();
     await h.orch.requestProfileChange('7', { model: 'claude-bad-model' }, OP);
     for (let i = 0; i < 3; i++) h.orch.recordSpawnFailure('7', 'cli-not-found');
-    await waitUntil(() => h.store.parkedFor('7') !== null);
+    await waitForBreakerTrip(h);
 
     const r = await h.orch.requestRecoveryWrite('7', 'reapply', OP);
     expect(r.outcome).toBe('confirm-required');
@@ -724,7 +734,7 @@ describe('circuit breaker (§10.4)', () => {
     const h = makeHarness();
     await h.orch.requestProfileChange('7', { model: 'claude-bad-model' }, OP);
     for (let i = 0; i < 3; i++) h.orch.recordSpawnFailure('7', 'cli-not-found');
-    await waitUntil(() => h.store.parkedFor('7') !== null);
+    await waitForBreakerTrip(h);
 
     const pin = await h.orch.requestProfileChange('7', { model: 'claude-fable-5' }, OP);
     expect(pin.outcome).toBe('applied');
@@ -740,7 +750,7 @@ describe('circuit breaker (§10.4)', () => {
     liveSession(h);
     await h.orch.requestProfileChange('7', { model: 'claude-bad-model' }, OP);
     for (let i = 0; i < 3; i++) h.orch.recordSpawnFailure('7', 'cli-not-found');
-    await waitUntil(() => h.store.parkedFor('7') !== null);
+    await waitForBreakerTrip(h);
     const killsAfterTrip = h.kills.length;
 
     h.cfg.dryRun = true; // gated regime (the shipped dev config)

--- a/upgrades/next/tpo-breaker-flake-fix.md
+++ b/upgrades/next/tpo-breaker-flake-fix.md
@@ -1,0 +1,12 @@
+<!-- internal-only -->
+# fix(tests): de-flake the §10.4 circuit-breaker tests (wait on the trip's terminal signal)
+
+## What Changed
+
+The five circuit-breaker tests in `tests/unit/TopicProfileOrchestrator.test.ts` synchronized on `parkedFor(...) !== null` — an intermediate state that `parkAndRevert` makes visible before its internal `flushDurably` await yields control. Under CI load, the 10ms poll could observe the park and assert on trip effects (un-park, `breaker-revert` audit, disclosure) that had not executed yet, failing the shard intermittently (twice on PR #1320's CI tonight; reproduced locally on iteration 1 of a 15-run loop). The tests now synchronize on the `breaker-revert` audit — emitted after every other synchronous trip side-effect — via a shared `waitForBreakerTrip(h)` helper. Test-only; no runtime source touched.
+
+## Evidence
+
+- Pre-fix: `tests/unit/TopicProfileOrchestrator.test.ts` failed iteration 1/15 of a local repetition loop with the exact CI assertion (`expected [] to include '7'` at the `unparks` check), matching both CI shard 2/4 failures on PR #1320 (runs 28573712457 and its predecessor).
+- Post-fix: 25 consecutive local runs green under concurrent benchmark load on the same machine.
+- Full unit suite green at push (husky pre-push).

--- a/upgrades/side-effects/tpo-breaker-flake-fix.md
+++ b/upgrades/side-effects/tpo-breaker-flake-fix.md
@@ -1,0 +1,16 @@
+# Side-Effects Review — tpo-breaker-flake-fix
+
+**Change:** test-only. `tests/unit/TopicProfileOrchestrator.test.ts` — the five §10.4 circuit-breaker tests waited on `parkedFor('7') !== null`, an intermediate state `parkAndRevert` makes visible before its internal `flushDurably` await yields; under CI load the 10ms poll observed the park and asserted on trip effects (unpark / audit / disclosure) that had not run yet. They now wait on the `breaker-revert` audit — the trip's terminal signal, emitted after every other synchronous trip side-effect — via a shared `waitForBreakerTrip(h)` helper. No `src/` file touched.
+
+1. **Over-block** — none. No runtime decision surface; the tests assert the same behavior with a later, race-free synchronization point.
+2. **Under-block** — none. Coverage is unchanged: every assertion that existed still runs (including `parkedFor` non-null, asserted explicitly after the wait). The wait is stricter, not looser — it requires the full trip, not just the park.
+3. **Level-of-abstraction fit** — considered fixing the production ordering instead (assign `entry.parked` after `flushDurably`). Rejected: the mid-trip visibility is harmless in production (no production consumer polls `parkedFor` during a trip; the store lock serializes real readers), and reordering durable-write vs in-memory state has its own failure-mode tradeoffs (a crash between write and assign). The test was the thing making a timing assumption; the test is the right layer to fix.
+4. **Signal vs authority compliance** — n/a; no decision point, no gate, no blocking authority. Test-only.
+5. **Interactions** — the helper waits on `h.audits`, which each test's fresh harness resets, so no cross-test bleed. The two tests that subsequently call `requestRecoveryWrite` also benefit (they previously raced `durable.breakerTrips` being set mid-trip).
+6. **External surfaces** — none. Nothing visible to agents, users, or other systems changes.
+7. **Multi-machine posture** — n/a (test-only; no state, no replication surface).
+8. **Rollback cost** — `git revert` of one commit restores the old waits; zero data or fleet impact.
+
+**Evidence:** old code failed iteration 1 of a 15-run local loop (same assertion as CI shard 2/4 failures on PR #1320 tonight, twice); fixed code passed 25 consecutive runs under benchmark load on the same machine.
+
+**Second-pass review:** not required — no sentinel/gate/lifecycle runtime code touched (test file only).

--- a/upgrades/tpo-breaker-flake-fix.eli16.md
+++ b/upgrades/tpo-breaker-flake-fix.eli16.md
@@ -1,0 +1,11 @@
+# A flaky safety-net test now waits for the finish line, not the halfway mark
+
+Instar has a "circuit breaker" for conversation settings: if an operator pins a topic to a model that keeps failing to launch, the breaker parks the bad pin, reverts to the last working settings, and restarts the session — so a typo'd model name can never brick a conversation.
+
+The breaker itself works fine. Its TESTS, though, were flaky — they'd pass most of the time and occasionally fail on the build servers (twice tonight alone, blocking an unrelated PR from merging). Flaky tests are poison: every red build that ISN'T real teaches people to ignore red builds.
+
+The root cause is a classic race. When the breaker trips, it does several things in a row: park the bad pin → revert → un-park the resume entry → write an audit record → tell the user → restart the session. The tests waited for the FIRST visible step ("is the pin parked yet?") and then immediately checked ALL the later steps. There's a tiny window where the park is visible but the rest hasn't happened yet — normally sub-millisecond, but on a loaded build machine the test's polling could land exactly inside it and fail on assertions about steps that were still in flight.
+
+The fix: the tests now wait for the audit record — which the breaker writes only AFTER everything else in the trip is done — before checking any of the trip's effects. Same coverage, zero timing dependence. Verified by running the test file 25 times in a row under load (the old version failed on the very first try of a 15-run loop).
+
+No production code changed at all — this is a test-only fix. The breaker behaves exactly as before; its report card just stopped lying about it.


### PR DESCRIPTION
## What

Test-only. The five §10.4 circuit-breaker tests in `tests/unit/TopicProfileOrchestrator.test.ts` synchronized on `parkedFor('7') !== null` — an intermediate state `parkAndRevert` makes visible before its internal `flushDurably` await yields. Under CI load the 10ms poll observed the park and asserted on trip effects (unpark / `breaker-revert` audit / disclosure) still in flight. They now wait on the `breaker-revert` audit — the trip's terminal signal, emitted after every other synchronous trip side-effect — via a shared `waitForBreakerTrip(h)` helper. No `src/` change.

## Why

This flake failed CI shard 2/4 twice tonight on the unrelated PR #1320, costing two full CI cycles. Zero-Failure Standard: a flake is a failure.

## Tests

Pre-fix: reproduced locally on iteration 1 of a 15-run loop with the exact CI assertion (`expected [] to include '7'`). Post-fix: 25 consecutive local runs green under concurrent benchmark load. Full suite green at push.

## ELI16 — a flaky safety-net test now waits for the finish line, not the halfway mark

Instar has a "circuit breaker" for conversation settings: if an operator pins a topic to a model that keeps failing to launch, the breaker parks the bad pin, reverts to the last working settings, and restarts the session — so a typo'd model name can never brick a conversation. The breaker works fine. Its TESTS were flaky — they'd occasionally fail on the build servers (twice tonight, blocking an unrelated change from merging). Flaky tests are poison: every red build that isn't real teaches people to ignore red builds.

The root cause is a classic race. When the breaker trips, it does several things in a row: park the bad pin → revert → un-park → write an audit record → tell the user → restart the session. The tests waited for the FIRST visible step ("is the pin parked yet?") and then immediately checked ALL the later steps. There's a tiny window where the park is visible but the rest hasn't happened — normally sub-millisecond, but on a loaded build machine the test's polling could land inside it. The fix: the tests now wait for the audit record, which the breaker writes only AFTER everything else is done. Same coverage, zero timing dependence. Verified 25 runs in a row under load; the old version failed on try one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)