### PR TITLE
fix(tone-gate): prompt demands the FULL rule identifier + JSON quote-escaping rule (A/B-proven, 40/0/118)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-02T10-47-29-029Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-02T10-47-29-029Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-07-02T10:47:29.029Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 5,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/tone-gate-rule-id-contract.eli16.md
+++ b/docs/specs/tone-gate-rule-id-contract.eli16.md
@@ -1,0 +1,39 @@
+# The tone gate was teaching models to fail its own test — plain-English overview
+
+Every message an instar agent sends to its user first passes through a quality
+gate: a language model reads the draft and answers, in a small JSON verdict,
+"is this message OK to send, and if not, which rule does it break?" The gate's
+code then reads that verdict. Here's the bug this change fixes: the code that
+READS the verdict insists on the full rule name — something like
+`B15_CONTEXT_DEATH_STOP` — and treats anything else as unreadable, on purpose
+(unreadable verdicts are treated cautiously rather than waved through). But
+the instructions we hand the model literally listed the SHORT names — "rule
+MUST be exactly one of B1–B9, B11, … B15, B16…" — so models did exactly what
+we asked, answered "B15", and the reader rejected it. We told them to say the
+thing we refuse to read. Our own benchmark caught this: on some test cases
+literally every model, through every access route, "failed" the same way —
+which is never a model problem, it's a prompt problem.
+
+What ships here is two small text corrections inside those instructions.
+First, the instructions now say: give the FULL rule name, exactly as written
+in the rule list, never the bare number. Second, a new line tells the model
+how to safely quote the message it's judging: if the draft being judged
+contains quotation marks, the model must not copy them raw into its JSON
+answer (raw quotes inside JSON break it — like closing a sentence's quotation
+mark mid-sentence), and should use single quotes instead. That second fix
+came out of the testing too: we watched a model give a perfectly correct
+verdict that was unreadable purely because it quoted the draft with raw
+quotes.
+
+Nothing about WHAT the gate blocks or allows changes — the rules, their
+meanings, and the gate's authority are untouched. The change was proven with
+an A/B test before shipping: the old and new instructions ran side by side on
+the same 118 test cells across seven different model routes; the new text
+fixed 40 previously-failing cells and broke zero previously-passing ones. A
+small automated test now pins both corrections in place so a future edit
+can't quietly reintroduce the mismatch. If anything ever looked wrong in
+production, the rollback is reverting two sentences of instruction text.
+
+What you need to decide: nothing — this is a repair of a self-contradiction,
+pre-approved under the benchmark program's ratified ship policy (critical
+components ship with a review record attached, which this one carries).

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -1048,9 +1048,10 @@ These rules only fire when the producer has explicitly marked the candidate as a
 ## Response format
 
 Respond EXCLUSIVELY with valid JSON:
+(Escaping rule: when quoting the candidate inside issue/suggestion strings, use single quotes or escaped \\" — a raw double quote inside a JSON string breaks the parser and voids your verdict.)
 {
   "pass": boolean,
-  "rule": "<rule id from the lists above, or empty string if pass is true>",
+  "rule": "<the FULL rule identifier from the lists above, byte-identical to how it appears there (e.g. B15_CONTEXT_DEATH_STOP — never the bare number like B15), or empty string if pass is true>",
   "issue": "<for B1–B7: cite the detected literal artifact. For behavioral rules (B15–B18): state in your own words WHICH intent you detected and WHY this candidate expresses it (1–2 sentences). Empty if pass is true.>",
   "suggestion": "<how to rephrase — empty if pass is true>",
   "structured": {
@@ -1063,7 +1064,7 @@ Respond EXCLUSIVELY with valid JSON:
   }
 }
 
-If pass is true, rule/issue/suggestion must be empty strings. If pass is false, rule MUST be exactly one of B1–B9, B11, B12, B13, B14, B15, B16, B17, B18, B19, or B20 (no other values — inventing rule ids is itself a violation). For a self-stop judgment, keep the structured block CONSISTENT (do not say proposed_stop:false while listing deferred_items; do not say agent_state_reason_present:true while stop_reason_kind is completion/none).
+If pass is true, rule/issue/suggestion must be empty strings. If pass is false, rule MUST be the FULL identifier of exactly one rule from the lists above, byte-identical to how it is written there (e.g. B15_CONTEXT_DEATH_STOP, B16_UNVERIFIED_WALL, B17_FALSE_BLOCKER — NEVER the bare number like "B15"; a bare or invented id fails the parser and is itself a violation). For a self-stop judgment, keep the structured block CONSISTENT (do not say proposed_stop:false while listing deferred_items; do not say agent_state_reason_present:true while stop_reason_kind is completion/none).
 
 Channel: ${channel}
 ${kindSection}${contextSection}${signalsSection}${gateSignalsSection}${styleSection}${agentStateSection}${standingAuthSection}

--- a/tests/unit/messaging-tone-gate-b15.test.ts
+++ b/tests/unit/messaging-tone-gate-b15.test.ts
@@ -78,8 +78,12 @@ describe('MessagingToneGate — B15_CONTEXT_DEATH_STOP', () => {
     const gate = new MessagingToneGate(provider);
     await gate.review('Any candidate.', { channel: 'telegram' });
     const prompt = getPrompt();
-    // The response-format section enumerates allowed rule ids; B15 must be there.
-    expect(prompt).toMatch(/B1[–-]B9.*B11.*B12.*B13.*B14.*B15/);
+    // The response-format constraint demands the FULL rule identifier (the
+    // short-id enumeration was removed 2026-07-02 — it taught models the form
+    // the parser rejects); B15's full id must be citable from the rule lists.
+    expect(prompt).toMatch(/FULL identifier/);
+    expect(prompt).toMatch(/B15_CONTEXT_DEATH_STOP/);
+    expect(prompt).not.toMatch(/rule MUST be exactly one of B1[–-]B9/);
   });
 
   it('accepts B15 as a valid rule id without fail-opening (no invalidRule flag)', async () => {

--- a/tests/unit/messaging-tone-gate-b16.test.ts
+++ b/tests/unit/messaging-tone-gate-b16.test.ts
@@ -77,7 +77,10 @@ describe('MessagingToneGate — B16_UNVERIFIED_WALL', () => {
     const gate = new MessagingToneGate(provider);
     await gate.review('Any candidate.', { channel: 'telegram' });
     const prompt = getPrompt();
-    expect(prompt).toMatch(/B14.*B15.*B16/);
+    // Full-id contract (2026-07-02): B16 is citable via its FULL identifier
+    // in the rule lists; the constraint demands the full form.
+    expect(prompt).toMatch(/B16_UNVERIFIED_WALL/);
+    expect(prompt).toMatch(/FULL identifier/);
   });
 
   it('accepts B16 as a valid rule id without fail-opening (the /goal-style unverified wall)', async () => {

--- a/tests/unit/messaging-tone-gate-b18.test.ts
+++ b/tests/unit/messaging-tone-gate-b18.test.ts
@@ -73,10 +73,11 @@ describe('MessagingToneGate — B18_AUTONOMY_STOP', () => {
     const { provider, getPrompt } = captureProvider({ pass: true, rule: '', issue: '', suggestion: '' });
     const gate = new MessagingToneGate(provider);
     await gate.review('Any candidate.', { channel: 'telegram' });
-    // The LLM must be told B18 is a citable rule id, else it would never cite it.
-    // The enumeration now runs through B20 ("…B17, B18, B19, or B20").
-    expect(getPrompt()).toMatch(/B17,\s*B18/);
-    expect(getPrompt()).toMatch(/or\s*B20/);
+    // The LLM must be told B18 is a citable rule id, else it would never cite
+    // it. Under the full-id contract (2026-07-02) citability comes from the
+    // rule LISTS rendering every full identifier, through B20.
+    expect(getPrompt()).toMatch(/B18_AUTONOMY_STOP/);
+    expect(getPrompt()).toMatch(/B20_INTERNAL_ID_LEAK/);
   });
 
   it('accepts B18 as a valid rule id without fail-opening (no invalidRule flag)', async () => {

--- a/tests/unit/tone-gate-rule-id-contract.test.ts
+++ b/tests/unit/tone-gate-rule-id-contract.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Pins the MessagingToneGate prompt's rule-id output contract.
+ *
+ * INSTAR-Bench v2 finding (2026-07-02, A/B ab-tone-gate2 — 40 cells fixed /
+ * 0 regressed across 7 routes): the prompt used to ENUMERATE SHORT rule ids
+ * ("rule MUST be exactly one of B1–B9, B11, …") while parseResponse demands
+ * the FULL identifier (e.g. B15_CONTEXT_DEATH_STOP) and fails closed on the
+ * short form — the prompt instructed the exact output the parser rejects,
+ * and every model through every door obeyed it. The same A/B round exposed a
+ * second hazard: models quoting the candidate message with RAW double quotes
+ * inside JSON strings, which breaks JSON.parse identically.
+ *
+ * This test pins both fixes at the source-text level so a future prompt edit
+ * cannot silently reintroduce either failure class.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const src = readFileSync(join(__dirname, '../../src/core/MessagingToneGate.ts'), 'utf8');
+
+describe('MessagingToneGate prompt rule-id contract', () => {
+  it('demands the FULL rule identifier in the JSON schema line', () => {
+    expect(src).toContain('the FULL rule identifier from the lists above');
+    expect(src).toContain('never the bare number like B15');
+  });
+
+  it('does NOT enumerate short rule ids as the allowed values', () => {
+    expect(src).not.toContain('rule MUST be exactly one of B1–B9');
+  });
+
+  it('carries the JSON quote-escaping rule for issue/suggestion strings', () => {
+    expect(src).toContain('Escaping rule: when quoting the candidate inside issue/suggestion strings');
+  });
+});

--- a/upgrades/next/tone-gate-rule-id-contract.md
+++ b/upgrades/next/tone-gate-rule-id-contract.md
@@ -1,0 +1,34 @@
+# Tone-gate prompt: full rule-id contract + JSON quote-escaping rule
+
+## What Changed
+Two string corrections inside the MessagingToneGate prompt template
+(src/core/MessagingToneGate.ts): the JSON schema line and the closing
+constraint now demand the FULL rule identifier (e.g. `B15_CONTEXT_DEATH_STOP`)
+instead of enumerating the short ids (`B15`) that `parseResponse` rejects
+fail-closed — the prompt previously instructed the exact output its own parser
+refuses. Added an escaping rule so models quoting the candidate message inside
+`issue`/`suggestion` strings use single quotes instead of raw double quotes
+(raw quotes break `JSON.parse` and void the verdict). A source-level
+contract-pin test (tests/unit/tone-gate-rule-id-contract.test.ts) locks both
+corrections in.
+
+## Evidence
+INSTAR-Bench v2 A/B `ab-tone-gate2`: CLEAN-WIN — 40 previously-failing cells
+fixed, 0 previously-passing cells regressed, 118 cells across 7 routes
+(claude-sonnet/opus/haiku via claude-code, gpt-5.5/gpt-5.5-plain/gpt-5.4-mini
+via codex, gpt-5.5 via pi), infra-class failures excluded from accounting,
+single disputed cell arbitrated at 3 samples. The underlying defect had
+cross-model failure share up to 1.00 (every model, both API and CLI doors,
+obeyed the short-id instruction). Contract-pin test 3/3 green; adjacent
+tone/gate unit tests 36/36 green.
+
+## What to Tell Your User
+The quality gate that reviews my outgoing messages just got more reliable: a
+wording bug in its instructions made models answer in a format the gate
+couldn't read, so some correct verdicts were being lost. The instructions now
+match what the gate expects, proven side-by-side on seven model routes before
+shipping (40 cases fixed, zero broken). You don't need to do anything.
+
+## Summary of New Capabilities
+None new — an existing safety gate now reads its models' verdicts reliably
+across every provider route.

--- a/upgrades/side-effects/tone-gate-rule-id-contract.md
+++ b/upgrades/side-effects/tone-gate-rule-id-contract.md
@@ -1,0 +1,78 @@
+# Side-effects review — MessagingToneGate prompt rule-id contract + escaping rule
+
+**Change:** two string edits inside the tone-gate prompt template (src/core/MessagingToneGate.ts):
+(1) the JSON schema line + closing constraint now demand the FULL rule identifier
+(e.g. B15_CONTEXT_DEATH_STOP) instead of enumerating the short ids ("B15") that
+parseResponse rejects fail-closed; (2) a JSON quote-escaping rule for
+issue/suggestion strings. Plus a source-level contract-pin test.
+
+**Principle check (Phase 1):** the change touches a decision point (the tone
+gate) but adds NO new decision logic and NO new authority — it corrects the
+prompt's own output-format instruction so the EXISTING parser receives what it
+already demands. The prompt previously instructed the exact output the parser
+rejects (a self-contradiction every model obeyed: cross-model failure share up
+to 1.00 in INSTAR-Bench v2). Signal-vs-authority compliant: no brittle check
+gains blocking authority; an existing smart gate becomes reliable.
+
+1. **Over-block** — none identified. The edit does not change WHAT the gate
+   blocks; it changes how the model formats its verdict. A/B evidence: 0
+   previously-passing cells regressed (118 cells, 7 routes, ab-tone-gate2).
+2. **Under-block** — strictly reduced: previously a correct BLOCK verdict with
+   a short rule id was unparseable, so real violations could fall into the
+   parse-failure path. Full-id verdicts now parse, so more true blocks land.
+3. **Level-of-abstraction fit** — right layer: the defect is IN the prompt
+   text, the fix is in the prompt text. The alternative (teaching the parser
+   to accept short ids) would loosen a fail-closed contract and create
+   ambiguity between B1 and B15 prefix families; rejected.
+4. **Signal vs authority** — compliant; see principle check. No authority
+   moved.
+5. **Interactions** — none: no other component parses this prompt's output;
+   the structured self-stop block and rule lists are untouched. The
+   contract-pin test interacts only with the source text.
+6. **External surfaces** — none beyond the model-facing prompt. No API, no
+   config, no user-visible strings. Works identically across providers
+   (evidence spans claude/codex/pi doors and, from the v1 round, groq/gemini).
+7. **Multi-machine posture** — machine-local BY DESIGN: the prompt ships in
+   code; every machine gets it with the release. No replicated state, no
+   URLs, no topic-transfer surface.
+8. **Rollback cost** — trivial: revert the two strings (one commit). No data,
+   no migration, no config. The bench A/B harness re-verifies in ~15 minutes.
+
+**Evidence:** INSTAR-Bench v2 A/B `ab-tone-gate2` — CLEAN-WIN, 40 cells fixed /
+0 regressed / 118 cells over 7 routes (claude-sonnet/opus/haiku, codex
+gpt-5.5/gpt-5.5-plain/gpt-5.4-mini, pi gpt-5.5), with infra-class cells
+excluded from accounting and the single disputed cell arbitrated at 3 samples
+(2/3 pass — sample-0 flake). Verdict JSON:
+research/llm-pathway-bench/results/instar-bench-v2/ab-tone-gate2-verdict.json
+(research tree, agent home). Review record:
+research/llm-pathway-bench/instar-bench-v2/review-records/tone-gate.md.
+
+**Second-pass review:** required (gate keyword) — see appended reviewer note.
+
+## Second-pass review (independent)
+Concur with the review.
+Verified against the actual diff (3 insertions / 2 deletions in
+src/core/MessagingToneGate.ts, prompt-template strings only — no logic, no
+authority moved): (a) the self-contradiction claim is true — the old closing
+constraint enumerated bare short ids ("exactly one of B1–B9, B11, …") while
+`interpret()` (line ~840) requires `VALID_RULES.has(rule)`, a set of FULL
+identifiers only, so an obeyed bare id → retry → fail-closed hold; and
+`parseResponse` JSON.parses the first `{...}` block, so a raw inner double
+quote in issue/suggestion throws → null → the same fail-closed path — the
+escaping-rule claim is also true. (b) Over-block: none — pass:true verdicts
+carry empty rule/issue/suggestion, untouched by both edits; the blocking
+criteria themselves are unchanged; A/B shows 0/118 regressions. I confirmed
+all 19 VALID_RULES appear in the prompt lists as full identifiers, so
+"byte-identical from the lists above" is satisfiable for every rule. (c) No
+other consumer: greps show the only parser of this output is
+parseResponse/interpret in the same file; no production code, test, or
+research file pins the OLD strings (the new pin test asserts their absence);
+the two other tests reading this source (gate-prompts-judge-by-meaning,
+GateSignalDetectors) don't touch the response-format section — all 31 tests
+across the three files pass. One point the artifact UNDERSTATES in its own
+favor: on the tiered operator channel a discipline failure DELIVERS
+(`operatorChannelDeliver`, failedOpenOperatorChannel), so pre-fix a correct
+BLOCK with a short id could fail OPEN there, not merely be held — the fix is
+more load-bearing than claimed. Minor nit, non-blocking: the new prompt text
+says a bare id "fails the parser"; strictly it fails the VALID_RULES check in
+interpret(), but as model-facing prose the effect described is accurate.


### PR DESCRIPTION
Fixes a self-contradiction inside the MessagingToneGate prompt that made every model, through every provider door, produce verdicts the gate's own parser rejects — and on the tiered operator channel, that rejection path could fail OPEN (a correct BLOCK delivered anyway). Proven with a side-by-side A/B before shipping: 40 previously-failing cells fixed, zero previously-passing cells regressed, across 118 cells on seven routes.

## eli16

Every message an instar agent sends to its user first passes through a quality gate: a language model reads the draft and answers, in a small JSON verdict, "is this message OK to send, and if not, which rule does it break?" The gate's code then reads that verdict. Here's the bug this change fixes: the code that READS the verdict insists on the full rule name — something like `B15_CONTEXT_DEATH_STOP` — and treats anything else as unreadable, on purpose. But the instructions we hand the model literally listed the SHORT names — "rule MUST be exactly one of B1–B9, B11, … B15, B16…" — so models did exactly what we asked, answered "B15", and the reader rejected it. We told them to say the thing we refuse to read. Our own benchmark caught this: on some test cases literally every model, through every access route, "failed" the same way — which is never a model problem, it's a prompt problem. Worse, the second-pass review found that on the operator channel this rejection path DELIVERS the message anyway, so a correct "block" verdict written in the short form could effectively fail open.

What ships here is two small text corrections inside those instructions. First, the instructions now say: give the FULL rule name, exactly as written in the rule list, never the bare number. Second, a new line tells the model how to safely quote the message it's judging: raw quotation marks copied into a JSON answer break it, so the model must use single quotes or escaped quotes instead — a hazard we watched break a perfectly correct verdict during testing.

Nothing about WHAT the gate blocks or allows changes — the rules, their meanings, and the gate's authority are untouched. The change was proven with an A/B test before shipping: old and new instructions ran side by side on the same 118 test cells across seven model routes; the new text fixed 40 previously-failing cells and broke zero previously-passing ones. A small automated test now pins both corrections so a future edit can't quietly reintroduce the mismatch. Rollback is reverting two sentences of instruction text.

## Evidence

- INSTAR-Bench v2 A/B `ab-tone-gate2`: **CLEAN-WIN — 40 fixed / 0 regressed / 118 cells** over 7 routes (claude-sonnet/opus/haiku via claude-code, gpt-5.5/gpt-5.5-plain/gpt-5.4-mini via codex, gpt-5.5 via pi), infra-class cells excluded from accounting, single disputed cell arbitrated at 3 samples (2/3 pass — sample-0 flake).
- Underlying defect: cross-model failure share up to **1.00** (ctx-completion-laundering — every model, both API and CLI doors).
- Review record (critical component, ships with record per the 2026-07-02 ratified policy): `research/llm-pathway-bench/instar-bench-v2/review-records/tone-gate.md` in the benching agent's research tree; verdict JSON `ab-tone-gate2-verdict.json`.
- Second-pass reviewer: **Concur** — independently verified the parser demands full ids (`VALID_RULES`, interpret()), the raw-quote JSON hazard, all 19 rules present in full form in the prompt lists, and no other consumer of this output. Found the fix MORE load-bearing than claimed (operator-channel fail-open).
- Tests: new contract-pin test 3/3; adjacent gate tests 36/36.

## Side effects

Reviewed in `upgrades/side-effects/tone-gate-rule-id-contract.md` (staged with the change): no over-block (0/118 regressions), under-block strictly reduced (correct BLOCKs now parse), no authority moved, machine-local by design, rollback = revert two strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
