### PR TITLE
fix(mesh): wire the pool-relative skew reference (poolReference) into the U4.1 pin fold — quiet streams no longer false-quarantine honest records

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-02T18-01-37-158Z-u4-1-poolreference-skew-fix.json
+++ b/.instar/instar-dev-decisions/2026-07-02T18-01-37-158Z-u4-1-poolreference-skew-fix.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-07-02T18:01:37.158Z",
+  "slug": "u4-1-poolreference-skew-fix",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 87,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1332
+    ],
+    "notes": "PR #1332 shipped TopicPinFoldView honoring an OPTIONAL poolReference dep that no construction site supplied. The original suite passed because every test harness constructed a fresh fold clock adjacent to its records (reference ≈ record time), so the frozen-reference-on-a-quiet-stream path was never exercised. Live-reproduced 2026-07-02 as fb-1d51e996-0a3: a 46-min-stale boot-seed reference stickily quarantined honest pin records on both machines."
+  },
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -17509,7 +17509,7 @@ export async function startServer(options: StartOptions): Promise<void> {
           // would suspect-halt the peer's whole stream) and quarantined STICKILY +
           // DURABLY (R-r3-2) beside the pin store.
           const { TopicPinSkewQuarantine } = await import('../core/TopicPinSkewQuarantine.js');
-          const { TopicPinFoldView } = await import('../core/TopicPinFoldView.js');
+          const { TopicPinFoldView, poolReferenceFromCapacities } = await import('../core/TopicPinFoldView.js');
           const { SustainedOnlineTracker } = await import('../core/SustainedOnlineTracker.js');
           const autoSessionsMod = await import('../core/AutonomousSessions.js');
           const pinSkewQuarantine = new TopicPinSkewQuarantine({
@@ -17532,6 +17532,26 @@ export async function startServer(options: StartOptions): Promise<void> {
             reader: pinAdvisoryReader,
             quarantine: pinSkewQuarantine,
             selfNode: () => _meshSelfId, // late-bound — resolves by first fold
+            // fb-1d51e996-0a3 — the §3.4 pool-relative skew reference. receive()'s
+            // reference is max(last.physical, poolReference), NEVER the bare local
+            // now(): with this dep unwired, a quiet fold clock froze at server boot
+            // and stickily false-quarantined every honest pin record authored more
+            // than maxDriftMs (5min) later — pins are rare events, so this killed
+            // pin replication between long-running servers (live evidence 2026-07-02:
+            // the Laptop quarantined the Mini's honest unpin tombstone against a
+            // 46-min-stale boot-time reference; the Mini even quarantined its OWN
+            // fresh PUT after a bounce). max(now, freshest clock-OK peer heartbeat
+            // self-stamp): moves with wall time AND is pool-relative, so a
+            // slow-clocked receiver doesn't quarantine a legitimately-ahead peer.
+            // Suspect-clocked peers (registry skew FSM) never raise the floor.
+            // Late-bound closure: machinePoolRegistry is assigned during boot and
+            // read at fold time; no registry yet → now() alone (the single-machine
+            // degenerate case — the pool is self).
+            poolReference: () => {
+              try {
+                return poolReferenceFromCapacities(Date.now(), machinePoolRegistry?.getCapacities() ?? []);
+              } catch { return Date.now(); /* @silent-fallback-ok — a registry fault degrades to the moving now() floor, never back to the frozen boot-seed reference */ }
+            },
             foldMaxBytes: () => {
               const v = ws13Cfg().ws13FoldMaxBytes;
               return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : 64 * 1024 * 1024;

--- a/src/core/TopicPinFoldView.ts
+++ b/src/core/TopicPinFoldView.ts
@@ -41,6 +41,41 @@ import type { PinFoldOffsets, PinFoldResult } from './CoherenceJournalReader.js'
 import type { TopicPinSkewQuarantine } from './TopicPinSkewQuarantine.js';
 import type { TopicPlacement } from './PlacementExecutor.js';
 
+/**
+ * The pool-relative physical-time floor for the skew gate (foundation spec
+ * §3.4; fb-1d51e996-0a3): `max(now, freshest clock-OK peer heartbeat
+ * self-stamp)`. `receive()` deliberately never consults `now()` itself — its
+ * reference is `max(last.physical, poolReference)` — so the CALLER must supply
+ * a floor that MOVES with wall time. Without one, a quiet fold clock's
+ * `last.physical` freezes at its construction seed (server boot) and every
+ * honest record authored more than `maxDriftMs` later is falsely quarantined
+ * as "skew-ahead" — STICKILY, by design. Pins are rare operator events, so the
+ * pin stream is almost always quiet: the frozen reference killed pin
+ * replication between long-running servers (live-reproduced 2026-07-02).
+ *
+ * Pool-relative, per §3.4: a receiver whose own NTP lags must not quarantine a
+ * legitimately-ahead peer, so the freshest self-reported heartbeat stamp of
+ * each clock-OK peer raises the floor above a slow local `now()`. A peer whose
+ * clock the registry's skew FSM already distrusts (`clockSkewStatus !== 'ok'`)
+ * NEVER raises the floor — a suspect clock must not widen the acceptance
+ * window. `now()` participates only as a FLOOR inside the max (§3.4 forbids
+ * the BARE local now() AS the reference — a floor can only raise the
+ * reference, never cause a false rejection). Degenerate case (single machine /
+ * no peers): `now()` alone — the pool is self.
+ */
+export function poolReferenceFromCapacities(
+  nowMs: number,
+  capacities: Array<{ clockSkewStatus?: string; selfReportedLastSeen?: string }>,
+): number {
+  let ref = nowMs;
+  for (const c of capacities) {
+    if (c.clockSkewStatus !== 'ok') continue; // a suspect clock never raises the floor
+    const t = c.selfReportedLastSeen ? Date.parse(c.selfReportedLastSeen) : Number.NaN;
+    if (Number.isFinite(t) && t > ref) ref = t;
+  }
+  return ref;
+}
+
 /** The reader seam (CoherenceJournalReader.foldPinRecords — injectable for tests). */
 export interface PinFoldReader {
   foldPinRecords(opts: { priorOffsets?: PinFoldOffsets; maxBytes?: number }): PinFoldResult;
@@ -55,7 +90,12 @@ export interface TopicPinFoldViewDeps {
   maxDriftMs?: number;
   /** ws13FoldMaxBytes, read live (default 64MB upstream). */
   foldMaxBytes?: () => number;
-  /** Optional observed pool-relative physical-time floor (heartbeat median). */
+  /** Observed pool-relative physical-time floor for the skew gate (§3.4 —
+   *  `poolReferenceFromCapacities` in production). The fold ALWAYS floors the
+   *  reference at its own `now()` regardless (fb-1d51e996-0a3: a missing dep
+   *  must never re-freeze the reference at the fold clock's boot seed); this
+   *  dep adds the pool-relative part (clock-OK peer heartbeat stamps) so a
+   *  slow LOCAL clock doesn't falsely quarantine an ahead-but-honest peer. */
   poolReference?: () => number | undefined;
   now?: () => number;
   /** Fired ONCE per newly-quarantined record (upstream dedupes per-origin, P17). */
@@ -120,6 +160,16 @@ export class TopicPinFoldView {
     this.totalFolds++;
 
     const clock = this.foldClock();
+    // fb-1d51e996-0a3 (§3.4): ONE moving, pool-relative reference per refresh.
+    // receive()'s reference is max(last.physical, poolReference) and NEVER the
+    // bare now() — so without this floor a quiet fold clock freezes at its
+    // construction seed and falsely skew-quarantines (stickily) every honest
+    // record authored > maxDriftMs later. now() is the floor; the wired dep
+    // raises it with clock-OK peer heartbeat stamps (pool-relative). A faulty
+    // dep degrades to the now() floor — never back to the frozen reference.
+    let observedPool = 0;
+    try { observedPool = this.d.poolReference?.() ?? 0; } catch { /* @silent-fallback-ok — the now() floor stands; a dep fault must not re-freeze the gate or fail the fold */ }
+    const poolReference = Math.max(this.now(), Number.isFinite(observedPool) ? observedPool : 0);
     for (const entry of res.entries) {
       const recordKey = typeof entry.data.recordKey === 'string' ? entry.data.recordKey : null;
       if (recordKey === null) continue;
@@ -135,8 +185,7 @@ export class TopicPinFoldView {
       if (this.d.quarantine.has(recordKey, hlc)) continue;
       // The skew gate (R-r2-1): the existing receive() contract. Rejection ⇒
       // durable quarantine + loud (deduped upstream) escalation; NEVER merged.
-      const poolReference = this.d.poolReference?.();
-      const received = clock.receive(hlc, poolReference !== undefined ? { poolReference } : {});
+      const received = clock.receive(hlc, { poolReference });
       if (received.rejected) {
         const newlyAdded = this.d.quarantine.add({ key: recordKey, hlc, origin: entry.origin });
         if (newlyAdded) {
@@ -242,9 +291,18 @@ export class TopicPinFoldView {
     recordKeys: number;
     truncationEpisodeOpen: boolean;
     quarantined: number;
+    skewReference: number;
   } {
     let quarantined = 0;
     try { quarantined = this.d.quarantine.all().length; } catch { /* best-effort */ }
+    // The LIVE skew-gate floor a refresh would use right now (fb-1d51e996-0a3
+    // diagnosability: a frozen reference is visible on GET /pool/pin-quarantine
+    // instead of only in a quarantine log line after the damage).
+    let skewReference = this.now();
+    try {
+      const observed = this.d.poolReference?.() ?? 0;
+      if (Number.isFinite(observed) && observed > skewReference) skewReference = observed;
+    } catch { /* @silent-fallback-ok — observability read; the now() floor stands */ }
     return {
       lastFoldAt: this.lastFoldAtMs ? new Date(this.lastFoldAtMs).toISOString() : null,
       totalFolds: this.totalFolds,
@@ -252,6 +310,7 @@ export class TopicPinFoldView {
       recordKeys: this.winners.size,
       truncationEpisodeOpen: this.truncationEpisodeOpen,
       quarantined,
+      skewReference,
     };
   }
 }

--- a/tests/integration/u41-pin-persistence-routes.test.ts
+++ b/tests/integration/u41-pin-persistence-routes.test.ts
@@ -257,6 +257,11 @@ describe('U4.1 pin-persistence routes', () => {
     expect(q).toHaveLength(1);
     expect(q[0].origin).toBe('m_fast');
     expect(r.body.fold).toBeTruthy(); // the fold view's status block
+    // fb-1d51e996-0a3 — the skew-gate floor is exposed and NOT frozen at a
+    // construction seed: it tracks the live wall clock (§3.4 moving reference).
+    const skewReference = (r.body.fold as { skewReference: number }).skewReference;
+    expect(Number.isFinite(skewReference)).toBe(true);
+    expect(Math.abs(skewReference - Date.now())).toBeLessThan(60_000);
 
     const darkApp = express();
     darkApp.use(express.json());

--- a/tests/unit/u41-pin-persistence.test.ts
+++ b/tests/unit/u41-pin-persistence.test.ts
@@ -19,7 +19,7 @@ import path from 'node:path';
 
 import { TopicPlacementPinStore } from '../../src/core/TopicPlacementPinStore.js';
 import { TopicPinSkewQuarantine } from '../../src/core/TopicPinSkewQuarantine.js';
-import { TopicPinFoldView, type PinFoldReader } from '../../src/core/TopicPinFoldView.js';
+import { TopicPinFoldView, poolReferenceFromCapacities, type PinFoldReader } from '../../src/core/TopicPinFoldView.js';
 import { setPinWithOneHlc, clearPinWithTombstone, type PinMutationEmitter } from '../../src/core/TopicPinMutation.js';
 import { compareHlc, buildTopicPinPut, buildTopicPinTombstone, TOPIC_PIN_KIND_REGISTRATION, TOPIC_PIN_RECORD_KIND } from '../../src/core/TopicPinReplicatedStore.js';
 import { LeaseAcquisitionTrigger } from '../../src/core/LeaseAcquisitionTrigger.js';
@@ -306,6 +306,181 @@ describe('skew-quarantine-is-sticky-across-clock-advance (R-r3-2 / R-r4-1)', () 
     // the quarantined entry is dead by ordering anyway → pruned.
     expect(q.pruneSuperseded('13481', { physical: NOW + skewDelta + 1, logical: 0, node: 'm_a' })).toBe(1);
     expect(q.has('13481', skewedHlc)).toBe(false);
+  });
+});
+
+// ── §3.4 pool-relative skew reference (fb-1d51e996-0a3) ──────────────────────
+// The live-reproduced 2026-07-02 defect: nothing supplied the fold view's
+// poolReference dep, so receive()'s reference — max(last.physical,
+// poolReference ?? 0), NEVER the bare now() — froze at the fold clock's
+// construction seed (server boot) on a quiet stream. Pins are rare operator
+// events, so the stream is almost always quiet: every honest record authored
+// more than maxDriftMs (5min) after boot was falsely quarantined as
+// "skew-ahead", STICKILY. The original suite missed it because every harness
+// constructed a fresh clock right next to its records.
+describe('pool-relative skew reference — quiet streams accept honest records (fb-1d51e996-0a3)', () => {
+  const BOOT = NOW;
+  const QUIET = 46 * 60_000; // the live evidence: a 46-min-stale boot reference
+
+  it('an honest record authored 46min after the fold-clock seed, on a QUIET stream, is ACCEPTED (the frozen-reference false quarantine)', () => {
+    // Refresh #1 at boot seeds the fold clock (empty stream — quiet). Wall time
+    // then advances 46 minutes with NO accepted records, and the Mini's honest
+    // unpin-era record arrives. Without the moving now() floor the reference
+    // stays frozen at BOOT and this honest record is stickily quarantined —
+    // exactly the Laptop-quarantines-the-Mini live evidence.
+    let now = BOOT;
+    const q = new TopicPinSkewQuarantine({ filePath: path.join(tmp, 'quiet.json') });
+    const honest = pinPut(30223, 'm_mini', { physical: BOOT + QUIET - 1000, logical: 0, node: 'm_mini' });
+    const view = new TopicPinFoldView({
+      reader: scriptedReader([
+        { entries: [] }, // boot fold — quiet stream, clock seeds at BOOT
+        { entries: [{ data: honest, origin: 'm_mini', source: 'replica', machineId: 'm_mini' }] },
+      ]),
+      quarantine: q,
+      selfNode: () => 'm_self',
+      now: () => now,
+    });
+    view.refresh(); // boot
+    now = BOOT + QUIET;
+    view.refresh(); // the honest record, 46min later
+    expect(view.pins().get(30223)?.preferredMachine).toBe('m_mini'); // ACCEPTED
+    expect(q.all()).toHaveLength(0); // never quarantined
+  });
+
+  it('author-side: the own fold accepts its OWN fresh record after a quiet period (the Mini-quarantines-its-own-PUT arm)', () => {
+    let now = BOOT;
+    const q = new TopicPinSkewQuarantine({ filePath: path.join(tmp, 'own.json') });
+    const ownPut = pinPut(900, 'm_self', { physical: BOOT + QUIET, logical: 0, node: 'm_self' });
+    const view = new TopicPinFoldView({
+      reader: scriptedReader([
+        { entries: [] },
+        { entries: [{ data: ownPut, origin: 'm_self', source: 'own', machineId: 'm_self' }] },
+      ]),
+      quarantine: q,
+      selfNode: () => 'm_self',
+      now: () => now,
+    });
+    view.refresh();
+    now = BOOT + QUIET + 5_000;
+    view.refresh();
+    expect(view.pins().get(900)?.preferredMachine).toBe('m_self');
+    expect(q.all()).toHaveLength(0);
+  });
+
+  it('a genuinely future-skewed record — beyond maxDriftMs of the MOVING reference — is still REJECTED + stickily quarantined (no regression of the real protection)', () => {
+    let now = BOOT;
+    const q = new TopicPinSkewQuarantine({ filePath: path.join(tmp, 'poison.json') });
+    const raised: string[] = [];
+    const poison = pinPut(13481, 'm_evil', { physical: BOOT + QUIET + 10 * 60_000, logical: 0, node: 'm_fast' });
+    const view = new TopicPinFoldView({
+      reader: scriptedReader([
+        { entries: [] },
+        { entries: [{ data: poison, origin: 'm_fast', source: 'replica', machineId: 'm_fast' }] },
+      ]),
+      quarantine: q,
+      selfNode: () => 'm_self',
+      now: () => now,
+      onSkewQuarantined: (rec) => raised.push(rec.origin),
+    });
+    view.refresh();
+    now = BOOT + QUIET; // the reference MOVES to here — the poison is still +10min beyond it
+    view.refresh();
+    expect(view.pins().size).toBe(0);
+    expect(q.has('13481', { physical: BOOT + QUIET + 10 * 60_000, logical: 0, node: 'm_fast' })).toBe(true);
+    expect(raised).toEqual(['m_fast']);
+  });
+
+  it('the wired poolReference dep raises the floor when the LOCAL clock lags (§3.4 pool-relative: a slow receiver must not quarantine an ahead-but-honest peer)', () => {
+    // The receiver's own clock NEVER advances past boot (a lagging local NTP).
+    // The pool observed fresher clock-OK peer heartbeat stamps; the dep carries
+    // them, so the honest ahead-of-local record is accepted.
+    const q = new TopicPinSkewQuarantine({ filePath: path.join(tmp, 'lag.json') });
+    const honest = pinPut(30223, 'm_mini', { physical: BOOT + QUIET - 1000, logical: 0, node: 'm_mini' });
+    const view = new TopicPinFoldView({
+      reader: scriptedReader([
+        { entries: [] },
+        { entries: [{ data: honest, origin: 'm_mini', source: 'replica', machineId: 'm_mini' }] },
+      ]),
+      quarantine: q,
+      selfNode: () => 'm_self',
+      now: () => BOOT, // frozen local clock — the dep is what saves the record
+      poolReference: () => BOOT + QUIET,
+    });
+    view.refresh();
+    view.refresh();
+    expect(view.pins().get(30223)?.preferredMachine).toBe('m_mini');
+    expect(q.all()).toHaveLength(0);
+  });
+
+  it('a FAULTY poolReference dep degrades to the moving now() floor — never back to the frozen reference, never a fold fault', () => {
+    let now = BOOT;
+    const q = new TopicPinSkewQuarantine({ filePath: path.join(tmp, 'faulty.json') });
+    const honest = pinPut(30223, 'm_mini', { physical: BOOT + QUIET - 1000, logical: 0, node: 'm_mini' });
+    const view = new TopicPinFoldView({
+      reader: scriptedReader([
+        { entries: [] },
+        { entries: [{ data: honest, origin: 'm_mini', source: 'replica', machineId: 'm_mini' }] },
+      ]),
+      quarantine: q,
+      selfNode: () => 'm_self',
+      now: () => now,
+      poolReference: () => { throw new Error('registry fault'); },
+    });
+    view.refresh();
+    now = BOOT + QUIET;
+    view.refresh(); // must not throw; the now() floor stands
+    expect(view.pins().get(30223)?.preferredMachine).toBe('m_mini');
+    expect(q.all()).toHaveLength(0);
+  });
+
+  it('status().skewReference exposes the LIVE gate floor and MOVES with time (frozen-reference diagnosability)', () => {
+    let now = BOOT;
+    const { view } = foldView(scriptedReader([{ entries: [] }]), { now: () => now });
+    expect(view.status().skewReference).toBe(BOOT);
+    now = BOOT + QUIET;
+    expect(view.status().skewReference).toBe(BOOT + QUIET); // moves — never frozen at a seed
+  });
+
+  describe('poolReferenceFromCapacities (the production sourcing helper)', () => {
+    it('degenerate case — no peers: now() alone (the pool is self)', () => {
+      expect(poolReferenceFromCapacities(NOW, [])).toBe(NOW);
+    });
+
+    it('a fresher clock-OK peer heartbeat self-stamp raises the floor above a slow local now()', () => {
+      const ahead = NOW + 4 * 60_000;
+      expect(poolReferenceFromCapacities(NOW, [
+        { clockSkewStatus: 'ok', selfReportedLastSeen: new Date(ahead).toISOString() },
+        { clockSkewStatus: 'ok', selfReportedLastSeen: new Date(NOW - 60_000).toISOString() },
+      ])).toBe(ahead);
+    });
+
+    it('a SUSPECT-clocked peer never raises the floor (the registry skew FSM already distrusts it)', () => {
+      const ahead = NOW + 10 * 60_000;
+      for (const status of ['suspect-clock-removed', 'divergence-detected-once']) {
+        expect(poolReferenceFromCapacities(NOW, [
+          { clockSkewStatus: status, selfReportedLastSeen: new Date(ahead).toISOString() },
+        ])).toBe(NOW);
+      }
+    });
+
+    it('an older stamp never LOWERS the floor; malformed/absent stamps are ignored', () => {
+      expect(poolReferenceFromCapacities(NOW, [
+        { clockSkewStatus: 'ok', selfReportedLastSeen: new Date(NOW - 3_600_000).toISOString() },
+        { clockSkewStatus: 'ok', selfReportedLastSeen: 'not-a-date' },
+        { clockSkewStatus: 'ok' },
+      ])).toBe(NOW);
+    });
+  });
+
+  it('wiring integrity: the server.ts fold-view construction supplies the poolReference dep from the registry helper', () => {
+    // The defect was precisely an UNWIRED dep (the fold view honored it; nothing
+    // supplied it) — so the construction site itself is load-bearing. Source-grep
+    // pattern per this repo's wiring-integrity precedent.
+    const src = fs.readFileSync(path.resolve(__dirname, '../../src/commands/server.ts'), 'utf-8');
+    const ctor = src.slice(src.indexOf('const pinFoldView = new TopicPinFoldView({'));
+    const block = ctor.slice(0, ctor.indexOf('});') + 3);
+    expect(block).toContain('poolReference: () =>');
+    expect(block).toContain('poolReferenceFromCapacities(Date.now(), machinePoolRegistry?.getCapacities()');
   });
 });
 

--- a/upgrades/next/u4-1-poolreference-skew-fix.md
+++ b/upgrades/next/u4-1-poolreference-skew-fix.md
@@ -1,0 +1,72 @@
+# Pin fold skew gate: wire the pool-relative reference (quiet streams no longer false-quarantine honest records)
+
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes fb-1d51e996-0a3 (live-reproduced 2026-07-02). PR #1332's U4.1 pin fold
+(`TopicPinFoldView`) skew-gates every replicated `topic-pin-record` HLC through
+`HybridLogicalClock.receive(hlc, {poolReference})` — but nothing supplied the
+`poolReference` dep. `receive()` deliberately references
+`max(last.physical, poolReference ?? 0)` and never the bare local `now()`
+(foundation spec §3.4), so a QUIET fold clock's reference froze at its
+construction seed (server boot). Pins are rare operator events, so the stream is
+almost always quiet: any honest pin record authored more than `maxDriftMs`
+(default 5min) after the receiver's last acceptance was falsely quarantined as
+"skew-ahead" — STICKILY, by design — killing pin replication between
+long-running servers (and even author-side: a machine quarantined its OWN fresh
+PUT after a peer bounce).
+
+The fix, per the converged u4-1 spec's §2C gate composed with foundation §3.4:
+
+- New `poolReferenceFromCapacities()` export — `max(now, freshest clock-OK peer
+  heartbeat self-stamp)`; peers the registry's skew FSM distrusts never raise
+  the floor; single-machine → now alone.
+- `TopicPinFoldView.refresh()` floors the reference at its own `now()` on every
+  fold regardless of wiring (a future unwired construction site can never
+  re-freeze the gate), and passes the moving reference on every `receive()`.
+- `src/commands/server.ts` wires the dep at the single production construction
+  site from `machinePoolRegistry.getCapacities()`.
+- `status().skewReference` (additive) exposes the live gate floor on
+  `GET /pool/pin-quarantine` for diagnosability.
+
+The sticky quarantine is NOT weakened: existing false-positive entries clear via
+`pruneSuperseded` on the next accepted PUT/tombstone or the explicit readmit
+route; a genuinely future-skewed record (beyond `maxDriftMs` of the MOVING pool
+reference) is still rejected, stickily quarantined, and escalated.
+
+## What to Tell Your User
+
+<!-- audience: user, maturity: preview -->
+- **Machine pins now stick reliably**: when you pin a conversation to a specific
+  machine ("run this on the mini"), that choice now replicates dependably
+  between your machines even after they have been running quietly for a long
+  time. Previously a long-running machine could wrongly treat a fresh pin or
+  unpin from another machine as suspicious and ignore it; that misjudgment is
+  fixed, and the protection against genuinely wrong clocks is unchanged.
+
+## Summary of New Capabilities
+
+None — a correctness fix to the existing U4.1 pin-persistence machinery, plus a
+diagnostic field on an existing read surface.
+
+## Evidence
+
+Live reproduction, 2026-07-02 (two machines, Laptop + Mini):
+
+- The Laptop quarantined the Mini's honest unpin tombstone:
+  `[TopicPinFoldView] skew-quarantined pin record key=30223 origin=m_4cbc0d4a0c… (physical 1783012672666 > reference 1783009909639 + 300000ms)` —
+  the reference (16:31:49Z) was the Laptop server's BOOT time, 46 minutes stale
+  against the record's honest 17:17:52Z author time.
+- After a Laptop bounce, the Mini's fold quarantined its OWN freshly-authored
+  PUT: `(physical 1783013064633 > reference 1783012686688 + 300000ms)` — its own
+  fold clock frozen at ITS boot.
+- Control: with a freshly-booted receiver (reference near now), the SAME record
+  was ACCEPTED and the full transfer actuated in ~90s — isolating the defect to
+  reference sourcing; the rest of the pipeline is correct.
+
+After the fix, the new regression suite models exactly those traces (a record
+authored 46min after the fold-clock seed on a quiet stream) and it is accepted;
+a stash-revert run proves the 9 new tests fail on the pre-fix code while all 25
+pre-existing u41 tests still pass. Full u41 family (unit + integration + e2e):
+52/52 green.

--- a/upgrades/side-effects/u4-1-poolreference-skew-fix.md
+++ b/upgrades/side-effects/u4-1-poolreference-skew-fix.md
@@ -1,0 +1,47 @@
+# Side-Effects Review — wire the pool-relative skew reference (poolReference) into the U4.1 pin fold
+
+**Spec:** docs/specs/u4-1-pin-persistence.md (converged 2026-07-02 + approved) §2C skew gate, composed with docs/specs/multi-machine-replicated-store-foundation.md §3.4 (pool-relative reference) / §10.2-family maxDriftMs clamp / §15 risk-5/risk-6 (maxDriftMs sourcing — BLOCKER-5).
+**Defect:** fb-1d51e996-0a3 (live-reproduced 2026-07-02). PR #1332 shipped `TopicPinFoldView` whose skew gate calls `HybridLogicalClock.receive(hlc, {poolReference})`, but NOTHING supplied the `poolReference` dep. `receive()` deliberately references `max(last.physical, poolReference ?? 0)` and NEVER `now()` (§3.4 — a slow receiver must not quarantine an ahead-but-honest peer), so with the dep unwired a QUIET fold clock's reference froze at its construction seed (server boot). Pins are rare operator events → the pin stream is almost always quiet → ANY honest record authored more than maxDriftMs (default 5min) after boot was falsely quarantined as "skew-ahead", STICKILY (dismissal ≠ re-admission, by design). Pin replication was effectively dead between long-running servers; F6 fired even author-side (the Mini quarantined its OWN fresh PUT after a Laptop bounce).
+**Files:** src/core/TopicPinFoldView.ts, src/commands/server.ts (the single production construction site — grep-verified; routes.ts/AgentServer.ts references are type-only).
+
+## What changed
+
+1. **`poolReferenceFromCapacities()` (new export, TopicPinFoldView.ts):** the production sourcing helper — `max(nowMs, freshest clock-OK peer heartbeat self-stamp)`. A peer whose `clockSkewStatus !== 'ok'` (the registry's skew FSM already distrusts it) NEVER raises the floor; malformed/absent stamps are ignored; no peers → now alone (single-machine degenerate case: the pool is self).
+2. **`TopicPinFoldView.refresh()`:** computes ONE reference per refresh — `max(now(), poolReference dep ?? 0)` — and passes it on EVERY `receive()`. The fold now floors the reference at its own `now()` regardless of wiring, so a future construction site that forgets the dep can never re-freeze the gate (Structure > Willpower: the component is correct by construction). A THROWING/non-finite dep degrades to the now() floor — never back to the frozen reference, never a fold fault (the fold's "never throws" contract holds).
+3. **`server.ts` wiring:** the fold-view construction supplies `poolReference: () => poolReferenceFromCapacities(Date.now(), machinePoolRegistry?.getCapacities() ?? [])` (late-bound closure — the registry is assigned later in boot and read at fold time; registry fault → `Date.now()`).
+4. **`status().skewReference` (additive):** the LIVE gate floor is exposed on `GET /pool/pin-quarantine`'s fold block, so a frozen reference is diagnosable from the read surface instead of only in a quarantine log line after the damage.
+
+## Why now() as a FLOOR is spec-faithful (§3.4)
+
+§3.4 forbids the BARE local `now()` AS the reference — its concern is FALSE REJECTION when the receiver's own NTP lags. `now()` inside the max can only RAISE the reference (never lower it), so it can never cause a false rejection; the pool-relative arm (peer heartbeat stamps) is what protects the slow-local-clock case, exactly as §3.4 prescribes ("its own last durable HLC, plus — when available — the observed pool physical time carried in the capacity heartbeat"). The spec's named heartbeat-median primitive does not exist yet (§15 risk-6 tracks derived skew measurement); the freshest clock-OK self-stamp is the available observed-pool signal, and the registry's categorical skew FSM (its real §3.4 purpose) keeps a suspect clock from widening the acceptance window.
+
+## Blast radius
+
+- **The sticky quarantine is NOT weakened.** The quarantine store's `(key, hlc)` exclusion still runs BEFORE the gate on every fold; ack ≠ re-admission; only supersession by a newer honest record (`pruneSuperseded`) or the explicit `POST /pool/pin-quarantine/readmit` clears an entry. Existing FALSE-POSITIVE entries in the field clear exactly that way — no auto-reclassification of quarantined entries is added (stickiness protects against real poison, and a bulk auto-clear could re-admit a genuinely poisoned record).
+- **The real protection is intact:** a record more than maxDriftMs ahead of the MOVING pool reference is still rejected + stickily quarantined + escalated (P17-deduped). Proven by the moving-reference rejection test.
+- **Gate posture unchanged:** the fold view remains read-only over journal bytes and actuates nothing; ws13 flags/dev-gates untouched; no new config key (the reference sourcing is derived state, not tunable — maxDriftMs remains the existing clamped knob).
+- **`skewReference` is additive observability** on an existing Bearer-gated read; no consumer asserts the exact status shape (grep-verified).
+
+## Risk + mitigation
+
+- **Risk:** a fast-clocked PEER's heartbeat self-stamp raises the floor and admits a near-poison record. **Mitigation:** stamps from peers the registry's skew FSM distrusts (`divergence-detected-once` / `suspect-clock-removed`) never participate; a tolerated stamp is within the registry's clockSkewToleranceMs of router receive time, so the widening is bounded by an already-accepted tolerance. Proven by the suspect-clock helper test.
+- **Risk:** the dep faults mid-fold and kills pin resolution. **Mitigation:** try/catch at BOTH layers (wiring closure and refresh()) degrading to the moving now() floor; proven by the faulty-dep test.
+- **Risk:** the fix silently un-quarantines existing sticky entries. **Mitigation:** none needed — the sticky set is consulted before the gate; the fix changes only NEW verdicts. Existing false-positive entries clear via supersession on the next accepted PUT/tombstone for that key, or explicit readmit.
+
+## Migration parity
+
+None required — pure code fix. No config defaults added or changed (no `migrateConfig`), no CLAUDE.md template change (no new operator-facing capability — `skewReference` is a diagnostic field on an existing documented surface), no hook/skill/template change. Verified against the Migration Parity Standard checklist: no agent-installed file is touched.
+
+## Rollback
+
+Revert the commit. The dep is optional and the fold's now() floor is internal — reverting restores the (broken) frozen-reference behavior with no state migration in either direction; quarantine files remain valid either way.
+
+## Tests
+
+- `tests/unit/u41-pin-persistence.test.ts` — new describe `pool-relative skew reference — quiet streams accept honest records (fb-1d51e996-0a3)`: (1) honest record 46min after the fold-clock seed on a QUIET stream → ACCEPTED (the live Laptop-quarantines-Mini evidence; FAILS without the fix — verified by stash-revert run: 9/9 new fail, 25/25 pre-existing pass); (2) author-side own-PUT acceptance after a quiet period (the Mini-quarantines-its-own-PUT arm); (3) genuinely future-skewed record vs the MOVING reference → still REJECTED + stickily quarantined + escalated; (4) the wired dep raises the floor when the LOCAL clock lags (§3.4 pool-relative); (5) faulty dep degrades to the now() floor; (6) `status().skewReference` moves with time; (7) `poolReferenceFromCapacities` matrix (degenerate/raise/suspect-clock/malformed); (8) wiring-integrity source-grep: the server.ts construction supplies the dep from the registry helper.
+- `tests/integration/u41-pin-persistence-routes.test.ts` — the quarantine read's fold block exposes a finite `skewReference` within 60s of the live wall clock (not frozen at a seed).
+- Full u41 family green with the fix: 52/52 across unit + integration (routes, answer-complete) + e2e (alive/lease-handover). tsc clean; `npm run lint` clean.
+
+## Agent awareness
+
+No CLAUDE.md template change — this repairs the documented U4.1 pin-persistence behavior (pins replicate between machines as already described); it adds no new capability or trigger an agent must know about. <!-- tracked: fb-1d51e996-0a3 -->


### PR DESCRIPTION
## ELI16 — what this fixes (plain English)

When you pin a conversation to one of your machines ("run this on the mini"), that pin gets copied between your machines so every machine agrees where the conversation belongs. To protect against a machine with a badly wrong clock poisoning that agreement forever, each machine checks incoming pin records against a time reference and quarantines anything stamped too far in the future. The bug: the reference that check compares against was never being fed, so on a quiet machine it froze at the moment the server booted. Pins are rare — the stream is almost always quiet — so after just five minutes of uptime, every honest pin or unpin arriving from another machine looked "too far in the future" and got quarantined as poison, permanently (quarantine is deliberately sticky). Pin replication between long-running servers was effectively dead, and a machine could even quarantine its own freshly-written record after its peer bounced. The fix feeds the check a reference that moves with the actual clock and with what the pool of machines has been observed reporting, exactly as the converged spec designed: honest records now pass, while a record genuinely stamped beyond the drift ceiling of that moving reference is still rejected, still stickily quarantined, and still escalated. Nothing about the sticky-quarantine protection is weakened — existing wrongly-quarantined entries clear themselves the moment a newer honest record for the same topic arrives (or via the explicit re-admit action); there is deliberately no bulk auto-reclassification, because stickiness is what protects against real clock poison.

## The defect (fb-1d51e996-0a3, live-reproduced 2026-07-02)

PR #1332 (U4.1 pin persistence) shipped `TopicPinFoldView` whose skew gate calls `HybridLogicalClock.receive(hlc, {poolReference})` — but nothing anywhere supplied the `poolReference` dep (grep dist/commands/server.js: zero references). `receive()` deliberately uses `reference = max(this.last.physical, options.poolReference ?? 0)` and NEVER `now()` (foundation spec §3.4: "pool-relative reference, never the bare local now()"). With no poolReference, a quiet fold clock's `last.physical` froze at server boot, so ANY honest pin record authored more than maxDriftMs (default 5 min) after the receiver's last acceptance was falsely quarantined as "skew-ahead" — STICKILY (by design, dismissal ≠ re-admission). Since pins are rare events, pin replication was effectively dead between long-running servers.

Live evidence:

- Laptop quarantined the Mini's honest unpin tombstone: `[TopicPinFoldView] skew-quarantined pin record key=30223 origin=m_4cbc0d4a0c… (physical 1783012672666 > reference 1783009909639 + 300000ms)` — reference = 16:31:49Z = the Laptop server's boot, 46 min stale vs the record's honest 17:17:52Z.
- After a Laptop bounce, the Mini's fold quarantined its OWN freshly-authored PUT: `(physical 1783013064633 > reference 1783012686688 + 300000ms)` — its own fold clock frozen at ITS boot. The false quarantine fires even author-side.
- Control: with a fresh receiver boot (reference near now), the same record was ACCEPTED and the full transfer actuated in ~90s — proving the rest of the pipeline correct; only the reference sourcing was broken.

## The fix (per the converged specs)

Implements u4-1-pin-persistence §2C's gate composed with multi-machine-replicated-store-foundation §3.4 (the pool-relative reference contract) and its §15 risk-6 honesty (the spec's "observed-pool-median physical time carried in the capacity heartbeat" primitive does not exist yet — the freshest clock-OK peer heartbeat self-stamp is the available observed-pool signal):

1. **`poolReferenceFromCapacities()`** (new export, `src/core/TopicPinFoldView.ts`): `max(now, freshest clock-OK peer heartbeat self-stamp)`. A peer the registry's skew FSM distrusts (`clockSkewStatus !== 'ok'`) never raises the floor (§3.4's stated real purpose for the categorical enum); malformed stamps ignored; no peers → now alone (single-machine degenerate case — the pool is self).
2. **`TopicPinFoldView.refresh()`** computes ONE moving reference per fold — `max(now(), dep ?? 0)` — and passes it on every `receive()`. The fold now floors at its own `now()` regardless of wiring, so a future construction site that forgets the dep can never re-freeze the gate (Structure > Willpower). A throwing/non-finite dep degrades to the now() floor, never back to the frozen reference.
3. **Wiring** at the single production construction site (`src/commands/server.ts`; the other `TopicPinFoldView` references are type-only — grep-verified): `poolReference: () => poolReferenceFromCapacities(Date.now(), machinePoolRegistry?.getCapacities() ?? [])`, late-bound, registry-fault-tolerant.
4. **`status().skewReference`** (additive observability): the live gate floor is visible on `GET /pool/pin-quarantine`, so a frozen reference is diagnosable from the read surface.

**On §3.4 and now():** the spec forbids the BARE local now() AS the reference (its concern is false rejection when the receiver's own NTP lags). now() here participates only as a FLOOR inside the max — it can only raise the reference, never lower it, so it can never cause a false rejection; the pool-relative arm (peer stamps) is what protects the slow-local-clock case, exactly as §3.4 prescribes. The spec does not forbid now() as a floor.

**Sticky quarantine NOT weakened:** existing false-positive entries in the field clear via `pruneSuperseded` on the next accepted PUT/tombstone for that key, or the explicit `POST /pool/pin-quarantine/readmit`. No auto-reclassification of quarantined entries — stickiness protects against real poison.

**Migration parity:** none required — pure code fix. No config key, no CLAUDE.md template change, no hook/skill change; verified against the Migration Parity Standard checklist.

## Tests

- **Unit** (`tests/unit/u41-pin-persistence.test.ts`, new describe modeling the live traces): honest record authored 46 min after the fold-clock seed on a QUIET stream → ACCEPTED; author-side own-PUT after a quiet period → ACCEPTED; genuinely future-skewed record vs the MOVING reference → still REJECTED + stickily quarantined + escalated; the wired dep raises the floor when the LOCAL clock lags (§3.4 pool-relative); faulty dep degrades to the now() floor; `status().skewReference` moves with time; `poolReferenceFromCapacities` matrix (degenerate / raise / suspect-clock / malformed); wiring-integrity source-grep on the server.ts construction site.
- **Proof the tests bite:** a stash-revert run against the pre-fix code fails all 9 new tests while all 25 pre-existing u41 unit tests still pass.
- **Integration** (`tests/integration/u41-pin-persistence-routes.test.ts`): the quarantine read's fold block exposes a finite `skewReference` within 60s of the live wall clock — the dep is non-null and moves with time through the HTTP surface.
- **Ran locally:** full u41 family — unit + integration (routes, answer-complete) + e2e (alive / lease-handover) — 52/52 green; `tsc --noEmit` clean; `npm run lint` clean; pre-push smoke tier (7 files / 78 tests) green. Full suite runs in CI (the authority).

Side-effects review: `upgrades/side-effects/u4-1-poolreference-skew-fix.md`. Release fragment: `upgrades/next/u4-1-poolreference-skew-fix.md`. Feedback item: fb-1d51e996-0a3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
