### PR TITLE
fix(0.5): Slack files.info self-verify + F2 ghost-text exclusion in stuck-input watchdog

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-02T21-24-31-605Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-02T21-24-31-605Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-02T21:24:31.605Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 337,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/p05-filesinfo-ghosttext.eli16.md
+++ b/docs/specs/p05-filesinfo-ghosttext.eli16.md
@@ -1,0 +1,89 @@
+# Slack files.info Self-Check Fix + Ghost-Text Guard for the Stuck-Input Watchdog — ELI16
+
+Two small fixes from the same live audit (roadmap item 0.5), shipped together.
+
+## Fix 1: The Slack "can I read files?" self-check was failing itself for no reason
+
+### What is this?
+
+Every time the agent's Slack connection boots, it runs a quick self-test: "can I
+actually do the things my token says I can?" One of those checks asks Slack's
+`files.info` API about a file that deliberately doesn't exist. The point isn't
+the file — it's proving the API answers at all. If Slack says "file not found,"
+great: the API is alive, our token works, check passed.
+
+The problem: the fake file id we used (`F000SELFTEST`) looked wrong enough that
+Slack rejected it BEFORE even looking for the file — it answered
+`invalid_arguments` instead of `file_not_found`. Our check only knew how to
+treat "file not found" as healthy, so it stamped a big red ❌ on a perfectly
+working connection, at every single boot.
+
+### The fix
+
+Two layers, so it can't regress from either direction:
+
+1. **Use a properly-shaped fake id** (`F0000000000` — the shape Slack expects,
+   just guaranteed not to exist), so a healthy workspace answers the stronger
+   "file not found."
+2. **Teach the check what `invalid_arguments` actually means.** If Slack's
+   validator answered at all, then the network, our login, and the endpoint all
+   just proved themselves — which is everything this check exists to prove. So
+   that answer now counts as a pass too. A real problem (like Slack saying our
+   token is missing the permission) still fails, exactly as before.
+
+## Fix 2: The stuck-input watchdog was pressing Enter at text nobody typed
+
+### What is this?
+
+The agent has a watchdog that looks at each terminal session and asks: "is there
+a typed message sitting at the prompt that never got submitted?" If yes, it
+presses Enter to un-stick it. Useful — messages sometimes get injected but not
+submitted.
+
+But Claude Code's terminal also shows **ghost text**: a dim, gray SUGGESTION the
+model writes into the input box that nobody typed and nobody asked to send. In
+the watchdog's plain screen-capture, dim styling is stripped away — so ghost
+text looks byte-for-byte identical to a real stuck message. During a live run on
+2026-07-02, the watchdog stared at one of these suggestions and pressed Enter at
+it four times.
+
+Nothing bad happened — today, Enter doesn't accept ghost text. But that's luck,
+not safety. If the terminal's UX ever changes so Enter DOES accept the
+suggestion, we'd have a watchdog auto-submitting instructions the model made up
+for itself. That's one UI tweak away from a real problem.
+
+### The fix
+
+Before pressing any key, the watchdog now takes a SECOND look at the screen —
+this time keeping the styling information (the terminal can tell us which
+characters are rendered dim). Then it classifies what it sees:
+
+- **Real input** (normal brightness) → recover it, exactly like before.
+- **Ghost text** (entirely dim) → never press anything at it. Log one line so we
+  can see it happened, and stand down until the text changes.
+- **Can't tell** (the capture failed, the screen changed between the two looks,
+  or the styling is mixed) → do NOT press anything this tick, log it, and look
+  again next tick.
+
+The rule baked in: **when uncertain, the watchdog does nothing.** Pressing Enter
+at fabricated text is the dangerous direction; skipping a tick on a genuinely
+stuck message just means it recovers a few seconds later once the capture reads
+cleanly.
+
+Only the dim attribute is used as the tell — not color. A theme that renders
+text in gray-but-normal brightness must not silently disable real recovery.
+
+### What doesn't change
+
+- Genuine stuck messages still get recovered (tested both ways).
+- The codex-session path is untouched: there the watchdog only ever fires at the
+  exact text it injected itself, so fabricated text can't trigger it by
+  construction.
+
+## How do we know it works?
+
+33 new unit tests: the exact live ghost frame is refused across arbitrarily many
+ticks; the same text at normal brightness still recovers; capture failures,
+raced frames, mixed styling, truecolor "gray that isn't dim," and cross-line dim
+state are all covered; and the Slack check goes green on the exact error the
+live server hit while still failing on `missing_scope` and unknown errors.

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -3124,6 +3124,32 @@ rm()  { "${shimRunner}" rm  "$@"; }
   }
 
   /**
+   * Capture the current output of a tmux session WITH ANSI escape sequences
+   * (`capture-pane -e`) preserved.
+   *
+   * Exists for consumers that need the RENDERING of pane text, not just its
+   * bytes — the F2 ghost-text exclusion in StuckInputSentinel reads the SGR
+   * dim attribute to tell the harness's model-generated composer suggestion
+   * (rendered dim, never typed) apart from genuinely stuck real input, which
+   * are byte-identical once attributes are stripped. Returns null on any
+   * capture failure, exactly like captureOutput.
+   */
+  // RULE 3: EXEMPT — primitive output capture (styled twin of captureOutput
+  // above); the state-detection patterns live in the consumers.
+  captureOutputAnsi(tmuxSession: string, lines: number = 100): string | null {
+    try {
+      return withSyncOp(() => execFileSync(
+        this.config.tmuxPath,
+        ['capture-pane', '-t', `=${tmuxSession}:`, '-p', '-e', '-S', `-${lines}`],
+        { encoding: 'utf-8', timeout: 5000 }
+      ));
+    } catch {
+      // @silent-fallback-ok — capture output, null handled by caller
+      return null;
+    }
+  }
+
+  /**
    * The last `lines` MEANINGFUL rows of a session's pane — blank-fill-immune.
    *
    * `capture-pane -S -N` returns the last N PHYSICAL rows, so in a tall pane

--- a/src/core/StuckInputSentinel.ts
+++ b/src/core/StuckInputSentinel.ts
@@ -27,8 +27,32 @@
  *   4. Skip if the prompt text just appeared (give verifyInjection its 6.5s
  *      window to handle the common race first).
  *   5. If the same prompt text persists across MIN_TICKS_BEFORE_FIRE ticks
- *      without changing AND no activity indicator, fire one recovery action,
- *      then escalate next tick if still stuck.
+ *      without changing AND no activity indicator, verify the text is REAL
+ *      input (see the ghost-text exclusion below), then fire one recovery
+ *      action, then escalate next tick if still stuck.
+ *
+ * Ghost-text exclusion (F2, live finding 2026-07-02): Claude Code renders a
+ * model-generated prompt SUGGESTION ("ghost text") in the composer — dim-styled
+ * (SGR 2, e.g. `ESC[0;2m`), never typed by anyone. In a plain capture-pane
+ * frame the dim attribute is stripped, so ghost text is byte-identical to real
+ * stuck input, and the sentinel fired 4 Enter presses at a fabricated
+ * instruction during the 2026-07-02 live run (harmless today only because
+ * Enter does not accept ghost text — one harness UX change away from a
+ * watchdog auto-submitting a model-fabricated instruction). The invariant this
+ * gate encodes: THE SENTINEL NEVER AUTO-SUBMITS TEXT THE USER (OR AN
+ * AUTHORIZED INJECTOR) DID NOT ACTUALLY TYPE. Before any keypress on the
+ * generic `❯`-prompt path, the sentinel re-captures the pane WITH ANSI escapes
+ * (`capture-pane -e`) and classifies the prompt text's presentation:
+ *   - 'real'         — rendered at normal intensity → proceed with recovery.
+ *   - 'ghost'        — rendered entirely dim → NEVER press keys at it; the
+ *                      record is exhausted until the prompt text changes.
+ *   - 'inconclusive' — ANSI capture failed, frames raced, or mixed styling →
+ *                      fail toward NOT pressing keys this tick (log-only);
+ *                      re-assessed next tick.
+ * The codex marker path is NOT gated: it only ever fires when the exact marker
+ * text we ourselves injected is stuck at the prompt, so the invariant holds
+ * there by construction (and codex's dim placeholder-hint is already excluded
+ * by marker matching).
  *
  * Bounded escalation matches SessionManager.fireStuckInputRecovery:
  *   attempt 0,1 → Enter        attempt 2 → C-m        attempt 3 → Enter+sleep+Enter
@@ -94,9 +118,14 @@ interface SessionStuckRecord {
   consecutiveTicks: number;
   /** How many recovery actions have been fired so far for this text. */
   attempts: number;
-  /** Whether this record is exhausted (max attempts reached, won't fire
-   *  again until the prompt text changes). */
+  /** Whether this record is exhausted (max attempts reached — or the text was
+   *  classified as ghost text — won't fire again until the prompt text
+   *  changes). */
   exhausted: boolean;
+  /** Whether a ghost-text-skip / ghost-check-inconclusive event has already
+   *  been logged for this record's text (one observability row per stuck
+   *  text, not one per tick). */
+  ghostSkipLogged?: boolean;
   /** Deeper-tier escalation phase (after the keypress ladder exhausts).
    *   - 'none': not escalating (keypress ladder still running or escalation off).
    *   - 'requested': a tier-C recovery request is in flight to the lifeline;
@@ -116,8 +145,9 @@ export interface StuckInputEvent {
   promptText: string;
   attempt: number;
   action: 'Enter' | 'C-m' | 'Enter-sleep-Enter'
-    | 'escalate-request' | 'escalate-recovered' | 'escalate-failed' | 'escalate-timeout';
-  outcome: 'fired' | 'fire-error' | 'escalated' | 'recovered' | 'gave-up';
+    | 'escalate-request' | 'escalate-recovered' | 'escalate-failed' | 'escalate-timeout'
+    | 'ghost-text-skip' | 'ghost-check-inconclusive';
+  outcome: 'fired' | 'fire-error' | 'escalated' | 'recovered' | 'gave-up' | 'skipped';
   /** Recovery tier for escalation events (absent for keypress events). */
   tier?: RecoveryTier;
   error?: string;
@@ -135,6 +165,118 @@ const DEFAULT_MAX_ATTEMPTS = 4;
  *  SessionManager.verifyInjection, and CompactionSentinel all agree on the
  *  single canonical "mid-turn footer" tell. */
 const ACTIVITY_INDICATORS: readonly string[] = CLAUDE_WORKING_INDICATORS;
+
+/**
+ * How the stuck prompt text is RENDERED in the live pane (F2 ghost-text
+ * exclusion). Classified from an ANSI capture (`tmux capture-pane -e`):
+ *   - 'real'         — normal intensity: genuinely typed/injected input.
+ *   - 'ghost'        — entirely dim (SGR 2): the harness's model-generated
+ *                      composer suggestion; never actually typed by anyone.
+ *   - 'inconclusive' — cannot prove either way (capture failed, frames raced,
+ *                      mixed styling). The sentinel fails toward NOT pressing.
+ */
+export type PromptTextPresentation = 'real' | 'ghost' | 'inconclusive';
+
+/** One physical pane line decoded from an ANSI capture: the visible text and
+ *  a parallel per-character dim(SGR 2)-active mask. */
+interface AnsiDimLine { text: string; dim: boolean[] }
+
+/**
+ * Decode a `capture-pane -e` frame into visible lines plus a per-character
+ * dim-attribute mask. Tracks SGR state across the whole frame (tmux may or may
+ * not re-emit attributes at line starts). Handles the extended-color forms
+ * (`38;5;n`, `38;2;r;g;b` and their colon-subparam variants) so a truecolor
+ * component value of `2` is never misread as the dim attribute.
+ */
+function parseAnsiDimLines(ansi: string): AnsiDimLine[] {
+  const lines: AnsiDimLine[] = [{ text: '', dim: [] }];
+  let dimActive = false;
+  let i = 0;
+  while (i < ansi.length) {
+    const ch = ansi[i];
+    if (ch === '\x1b') {
+      const csi = /^\x1b\[([0-9;:]*)([@-~])/.exec(ansi.slice(i, i + 64));
+      if (csi) {
+        if (csi[2] === 'm') {
+          const params = csi[1] === '' ? ['0'] : csi[1].split(';');
+          let j = 0;
+          while (j < params.length) {
+            const head = params[j].split(':')[0];
+            if (head === '38' || head === '48' || head === '58') {
+              // Extended color. Colon-subparam form (38:2:r:g:b) is fully
+              // contained in this token; semicolon form consumes the mode +
+              // component params (5;n or 2;r;g;b) without interpreting them.
+              if (!params[j].includes(':')) {
+                const mode = params[j + 1];
+                if (mode === '5') j += 2;
+                else if (mode === '2') j += 4;
+              }
+              j += 1;
+              continue;
+            }
+            if (head === '' || head === '0') dimActive = false;      // full reset
+            else if (head === '2') dimActive = true;                  // dim/faint on
+            else if (head === '22') dimActive = false;                // normal intensity
+            j += 1;
+          }
+        }
+        i += csi[0].length;
+        continue;
+      }
+      // Non-CSI escape — skip ESC + the next byte conservatively.
+      i += 2;
+      continue;
+    }
+    if (ch === '\n') {
+      lines.push({ text: '', dim: [] });
+      i += 1;
+      continue;
+    }
+    if (ch === '\r') { i += 1; continue; }
+    const line = lines[lines.length - 1];
+    line.text += ch;
+    line.dim.push(dimActive);
+    i += 1;
+  }
+  return lines;
+}
+
+/**
+ * Classify how the stuck prompt text is rendered, from an ANSI (`-e`) capture
+ * of the SAME pane. `expectedText` is the stuck text extracted from the plain
+ * capture; when the ANSI frame's own prompt extraction does not reproduce it
+ * exactly (the two captures raced, or the frame has no readable prompt), the
+ * verdict is 'inconclusive' — never a guess.
+ *
+ * Grounded in the 2026-07-02 live F2 evidence: Claude Code's ghost suggestion
+ * rendered with `ESC[0;2m` (dim). Real typed/injected input renders at normal
+ * intensity. Only the dim attribute (SGR 2) is used as the ghost tell —
+ * color-based heuristics were deliberately NOT added (a gray-but-normal-
+ * intensity theme must not disable genuine recovery).
+ *
+ * Exported for unit tests; the live path goes through evaluateSession.
+ */
+export function classifyPromptTextPresentation(ansiPane: string, expectedText: string): PromptTextPresentation {
+  try {
+    const parsed = parseAnsiDimLines(ansiPane);
+    const located = StuckInputSentinel.locatePromptText(parsed.map(l => l.text));
+    if (!located || located.text !== expectedText) return 'inconclusive';
+    const dimMask = parsed[located.lineIdx].dim;
+    let sawDim = false;
+    let sawNormal = false;
+    for (let k = 0; k < located.text.length; k++) {
+      const ch = located.text[k];
+      if (ch === ' ' || ch === '\t') continue; // whitespace carries no styling signal
+      if (dimMask[located.start + k]) sawDim = true;
+      else sawNormal = true;
+    }
+    if (sawDim && !sawNormal) return 'ghost';
+    if (sawNormal && !sawDim) return 'real';
+    return 'inconclusive'; // mixed styling (or no styleable chars) — do not guess
+  } catch {
+    return 'inconclusive'; // any parse failure fails toward NOT pressing keys
+  }
+}
 
 export class StuckInputSentinel {
   private readonly sessionManager: SessionManager;
@@ -312,6 +454,37 @@ export class StuckInputSentinel {
       return;
     }
 
+    // F2 ghost-text exclusion: before pressing ANY key on the generic
+    // `❯`-prompt path, verify the stuck text is REAL input (typed or injected)
+    // and not the harness's dim-rendered, model-generated composer suggestion.
+    // The codex marker path is exempt by construction — it only fires when the
+    // exact text WE injected is stuck at the prompt (see the file header).
+    // Escalation (the maxAttempts branch above) is unreachable for ghost text:
+    // attempts only accrue through this gate, so four 'real' verdicts must
+    // precede any tier-C request.
+    if (!codexMarker) {
+      const presentation = this.assessPromptTextPresentation(tmuxSession, stuckText);
+      if (presentation !== 'real') {
+        // 'ghost' is sticky: the suggestion is never pressable; a prompt-text
+        // change resets the record. 'inconclusive' is transient: re-assess
+        // next tick (a raced capture self-heals; a persistent failure keeps
+        // failing toward NOT pressing keys).
+        if (presentation === 'ghost') existing.exhausted = true;
+        if (!existing.ghostSkipLogged) {
+          existing.ghostSkipLogged = true;
+          this.recordEvent({
+            ts: new Date(now).toISOString(),
+            session: tmuxSession,
+            promptText: stuckText.slice(0, 200),
+            attempt: existing.attempts,
+            action: presentation === 'ghost' ? 'ghost-text-skip' : 'ghost-check-inconclusive',
+            outcome: 'skipped',
+          });
+        }
+        return;
+      }
+    }
+
     // Fire one recovery action and record it.
     const attempt = existing.attempts;
     const action = StuckInputSentinel.actionForAttempt(attempt);
@@ -352,23 +525,59 @@ export class StuckInputSentinel {
    *
    *  Public for unit tests; the live tick goes through evaluateSession. */
   extractPromptText(pane: string): string | null {
-    const lines = pane.split('\n');
+    return StuckInputSentinel.locatePromptText(pane.split('\n'))?.text ?? null;
+  }
+
+  /**
+   * Locate the stuck prompt text within the pane's lines: which line holds it,
+   * the column it starts at, and the trimmed text. This is extractPromptText's
+   * engine, factored out so the ghost-text classifier can map the SAME
+   * located characters onto an ANSI capture's per-character dim mask —
+   * guaranteeing the styling verdict is about exactly the text the plain-frame
+   * extraction saw, never a different region of the pane.
+   */
+  static locatePromptText(lines: string[]): { lineIdx: number; start: number; text: string } | null {
     for (let i = lines.length - 1; i >= 0; i--) {
       const line = lines[i];
       if (!line || !line.includes('❯')) continue;
       // Take everything after the LAST ❯ on the line, trimmed.
       const idx = line.lastIndexOf('❯');
-      const after = line.slice(idx + 1).trim();
-      if (after.length > 0) return after;
+      const after = line.slice(idx + 1);
+      const text = after.trim();
+      if (text.length > 0) {
+        const start = idx + 1 + (after.length - after.trimStart().length);
+        return { lineIdx: i, start, text };
+      }
       // Empty prompt line — look at the immediately-following line for
       // wrapped multi-line input. If that's also empty, no stuck text.
       const next = lines[i + 1];
-      if (next && next.trim().length > 0 && !this.isStatusLine(next)) {
-        return next.trim();
+      if (next && next.trim().length > 0 && !StuckInputSentinel.isStatusLine(next)) {
+        return {
+          lineIdx: i + 1,
+          start: next.length - next.trimStart().length,
+          text: next.trim(),
+        };
       }
       return null;
     }
     return null;
+  }
+
+  /**
+   * F2 ghost-text gate: capture the SAME pane WITH ANSI escapes and classify
+   * how the stuck text is rendered. Every failure path — no ANSI capture
+   * support, capture returned null, capture threw — resolves to
+   * 'inconclusive', which the caller treats as "do NOT press keys this tick".
+   */
+  private assessPromptTextPresentation(tmuxSession: string, expectedText: string): PromptTextPresentation {
+    let ansiPane: string | null;
+    try {
+      ansiPane = this.sessionManager.captureOutputAnsi(tmuxSession, 30);
+    } catch {
+      return 'inconclusive';
+    }
+    if (!ansiPane) return 'inconclusive';
+    return classifyPromptTextPresentation(ansiPane, expectedText);
   }
 
   /** True if the pane currently shows a Claude Code "working" indicator.
@@ -400,8 +609,8 @@ export class StuckInputSentinel {
 
   /** Heuristic: lines that look like Claude Code status/separator content
    *  rather than wrapped input. Used to avoid mistaking a separator for
-   *  wrapped prompt text in extractPromptText. */
-  private isStatusLine(line: string): boolean {
+   *  wrapped prompt text in locatePromptText. */
+  private static isStatusLine(line: string): boolean {
     const t = line.trim();
     if (!t) return true;
     // Long runs of horizontal box-drawing chars are the input-box border.

--- a/src/messaging/slack/SlackAdapter.ts
+++ b/src/messaging/slack/SlackAdapter.ts
@@ -21,7 +21,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import type { MessagingAdapter, Message, OutgoingMessage } from '../../core/types.js';
-import { SlackApiClient } from './SlackApiClient.js';
+import { SlackApiClient, SlackApiError } from './SlackApiClient.js';
 import { SocketModeClient, type SocketModeHandlers } from './SocketModeClient.js';
 import { ChannelManager } from './ChannelManager.js';
 import { FileHandler } from './FileHandler.js';
@@ -36,6 +36,58 @@ const RING_BUFFER_CAPACITY = 50;
 const SLACK_MAX_TEXT_LENGTH = 4000;
 const AUTO_ARCHIVE_DAYS = 7;
 const LOG_PURGE_INTERVAL_MS = 24 * 60 * 60 * 1000; // Daily
+
+/**
+ * Synthetic file id used by the startup self-verify's files.info probe.
+ * WELL-FORMED (Slack file ids are `F` + uppercase alphanumerics) but
+ * guaranteed nonexistent, so a healthy workspace answers `file_not_found`.
+ * The previous probe id (`F000SELFTEST`) tripped Slack's argument validation
+ * instead (`invalid_arguments`), which the old classification counted as an
+ * unexpected FAILURE — a healthy adapter red-flagged itself at every boot
+ * (live server.log 2026-07-02 18:12:27; slack-ai-employee-audit §1).
+ */
+export const FILES_INFO_PROBE_ID = 'F0000000000';
+
+/**
+ * Classify the outcome of the files.info self-verify probe.
+ *
+ * @param probeError null when the call succeeded (ok:true); otherwise the
+ *   Slack error code (SlackApiError.slackError) or error message.
+ *
+ * The check's job is to prove the files.info METHOD — the one the snippet/Post
+ * content path depends on (Method 1) — is reachable and responsive with our
+ * token, beyond the scope header claiming files:read. Both `file_not_found`
+ * (the probe id passed argument validation and reached lookup) and
+ * `invalid_arguments` (Slack's server-side validator rejected the synthetic id
+ * before lookup) prove exactly that: transport, auth, and method dispatch all
+ * answered. Neither is a capability failure — a real file id can't produce
+ * either. `missing_scope` and anything else remain failures.
+ *
+ * Exported for unit tests; _selfVerify is the production caller.
+ */
+export function classifyFilesInfoSelfTest(
+  probeError: string | null,
+): { status: 'pass' | 'fail'; detail: string } {
+  if (probeError === null) {
+    return { status: 'pass', detail: 'API responded (unexpected ok for synthetic probe id)' };
+  }
+  if (probeError.includes('file_not_found')) {
+    return { status: 'pass', detail: 'API responsive (file_not_found for synthetic probe id)' };
+  }
+  if (probeError.includes('invalid_arguments')) {
+    return {
+      status: 'pass',
+      detail: 'API responsive (synthetic probe id rejected at argument validation — endpoint, auth, and transport verified)',
+    };
+  }
+  if (probeError.includes('missing_scope')) {
+    return {
+      status: 'fail',
+      detail: 'Returns missing_scope despite scope header claiming files:read is granted',
+    };
+  }
+  return { status: 'fail', detail: `Unexpected error: ${probeError}` };
+}
 
 export class SlackAdapter implements MessagingAdapter {
   readonly platform = 'slack';
@@ -2130,25 +2182,17 @@ export class SlackAdapter implements MessagingAdapter {
     }
 
     // ── Check 2: files.info API responds correctly ────────────────────
+    // We expect file_not_found (or invalid_arguments — Slack rejecting the
+    // synthetic id at argument validation) for the probe id; either proves
+    // the API is reachable and responsive. See classifyFilesInfoSelfTest.
     if (grantedScopes.includes('files:read')) {
+      let probeError: string | null = null;
       try {
-        const resp = await this.apiClient.call('files.info', { file: 'F000SELFTEST' }) as Record<string, unknown>;
-        // We expect file_not_found for a fake ID — that means the API is working
-        results.push({ check: 'files.info API', status: 'pass', detail: 'API responded (unexpected ok for fake file)' });
+        await this.apiClient.call('files.info', { file: FILES_INFO_PROBE_ID });
       } catch (err) {
-        const msg = (err as Error).message;
-        if (msg.includes('file_not_found')) {
-          results.push({ check: 'files.info API', status: 'pass', detail: 'API responsive (file_not_found for test ID)' });
-        } else if (msg.includes('missing_scope')) {
-          results.push({
-            check: 'files.info API',
-            status: 'fail',
-            detail: 'Returns missing_scope despite scope header claiming files:read is granted',
-          });
-        } else {
-          results.push({ check: 'files.info API', status: 'fail', detail: `Unexpected error: ${msg}` });
-        }
+        probeError = err instanceof SlackApiError ? err.slackError : (err as Error).message;
       }
+      results.push({ check: 'files.info API', ...classifyFilesInfoSelfTest(probeError) });
     } else {
       results.push({
         check: 'files.info API',

--- a/tests/unit/StuckInputSentinel-ghost-text.test.ts
+++ b/tests/unit/StuckInputSentinel-ghost-text.test.ts
@@ -1,0 +1,302 @@
+// safe-git-allow: test file — fs.rmSync is per-test tmpdir cleanup only.
+/**
+ * F2 ghost-text exclusion tests for StuckInputSentinel.
+ *
+ * Live finding F2 (2026-07-02, test-as-self run): Claude Code rendered a
+ * model-generated prompt SUGGESTION ("ghost text") in a session's composer —
+ * dim-styled (`ESC[0;2m`), never typed by anyone — and the sentinel classified
+ * it as stuck real input and fired 4 Enter presses at it
+ * (stuck-input-events.jsonl, outcome "fired"). Enter does not accept ghost
+ * text today, so nothing executed — but that is one harness UX change away
+ * from a watchdog auto-submitting a fabricated instruction.
+ *
+ * THE INVARIANT UNDER TEST: the sentinel never auto-submits text the user (or
+ * an authorized injector) did not actually type. Before any keypress on the
+ * generic `❯`-prompt path, the sentinel re-captures the pane WITH ANSI escapes
+ * and refuses to act unless the text provably renders at normal intensity
+ * ('real'). 'ghost' (entirely dim) and 'inconclusive' (capture failed / frames
+ * raced / mixed styling) both fail toward NOT pressing keys.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { StuckInputSentinel, classifyPromptTextPresentation } from '../../src/core/StuckInputSentinel.js';
+
+const ESC = '\x1b';
+
+// The exact text the live F2 event captured as "stuck input".
+const GHOST_TEXT = 'tas channel-parity: now test the Slack topic';
+
+/** Plain (no-ANSI) pane — what captureOutput sees. Ghost text and real input
+ *  are byte-identical here; that indistinguishability IS the F2 bug. */
+const PLAIN_STUCK_PANE = [
+  '────────────────────────────────────────',
+  `❯ ${GHOST_TEXT}`,
+  '────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n');
+
+/** ANSI frame reproducing the live F2 capture: the suggestion rendered with
+ *  the dim attribute (`ESC[0;2m`), the rest of the chrome normal. */
+const GHOST_ANSI_PANE = [
+  '────────────────────────────────────────',
+  `❯ ${ESC}[0;2m${GHOST_TEXT}${ESC}[0m`,
+  '────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n');
+
+/** ANSI frame of GENUINE stuck input: same text, normal intensity (with the
+ *  prompt char itself colored, as Claude Code renders it). */
+const REAL_ANSI_PANE = [
+  '────────────────────────────────────────',
+  `${ESC}[36m❯${ESC}[0m ${GHOST_TEXT}`,
+  '────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n');
+
+type StubManager = {
+  listRunningSessions: ReturnType<typeof vi.fn>;
+  tmuxSessionExists: ReturnType<typeof vi.fn>;
+  captureOutput: ReturnType<typeof vi.fn>;
+  captureOutputAnsi: ReturnType<typeof vi.fn>;
+  fireStuckInputRecovery: ReturnType<typeof vi.fn>;
+  getStrandedDraftMarker: ReturnType<typeof vi.fn>;
+  clearStrandedDraftMarker: ReturnType<typeof vi.fn>;
+  strandedDraftMarkerSessions: ReturnType<typeof vi.fn>;
+  isMarkerStuckAtPrompt: ReturnType<typeof vi.fn>;
+};
+
+function buildStubManager(
+  panes: Record<string, string>,
+  ansiPanes: Record<string, string | null | (() => string | null)>,
+  markers: Record<string, { marker: string; framework: string }> = {},
+): StubManager {
+  const liveMarkers = new Map(Object.entries(markers).map(([k, v]) => [k, { ...v, injectedAt: 0 }]));
+  return {
+    listRunningSessions: vi.fn(() => Object.keys(panes).map(name => ({ tmuxSession: name }))),
+    tmuxSessionExists: vi.fn((name: string) => name in panes),
+    captureOutput: vi.fn((name: string) => panes[name]),
+    captureOutputAnsi: vi.fn((name: string) => {
+      const a = ansiPanes[name];
+      return typeof a === 'function' ? a() : a;
+    }),
+    fireStuckInputRecovery: vi.fn(),
+    getStrandedDraftMarker: vi.fn((name: string) => liveMarkers.get(name)),
+    clearStrandedDraftMarker: vi.fn((name: string) => { liveMarkers.delete(name); }),
+    strandedDraftMarkerSessions: vi.fn(() => [...liveMarkers.keys()]),
+    isMarkerStuckAtPrompt: vi.fn((pane: string, marker: string) =>
+      pane.split('\n').some(l => (l.includes('❯') || l.includes('›')) && l.includes(marker)),
+    ),
+  };
+}
+
+function buildSentinel(manager: StubManager, opts: Partial<ConstructorParameters<typeof StuckInputSentinel>[1]> = {}) {
+  return new StuckInputSentinel(manager as any, {
+    stateDir: os.tmpdir(),
+    noPersist: true,
+    minTicksBeforeFire: 2,
+    maxAttempts: 4,
+    ...opts,
+  });
+}
+
+describe('classifyPromptTextPresentation — SGR dim decoding', () => {
+  it("classifies the live F2 frame (ESC[0;2m suggestion) as 'ghost'", () => {
+    expect(classifyPromptTextPresentation(GHOST_ANSI_PANE, GHOST_TEXT)).toBe('ghost');
+  });
+
+  it("classifies a bare ESC[2m dim run as 'ghost'", () => {
+    const pane = `❯ ${ESC}[2m${GHOST_TEXT}${ESC}[0m`;
+    expect(classifyPromptTextPresentation(pane, GHOST_TEXT)).toBe('ghost');
+  });
+
+  it("classifies a plain frame with no SGR codes as 'real' (nothing renders dim)", () => {
+    expect(classifyPromptTextPresentation(PLAIN_STUCK_PANE, GHOST_TEXT)).toBe('real');
+  });
+
+  it("classifies normally-styled genuine input as 'real' even with colored chrome", () => {
+    expect(classifyPromptTextPresentation(REAL_ANSI_PANE, GHOST_TEXT)).toBe('real');
+  });
+
+  it("classifies COLORED but normal-intensity text as 'real' (color is not the ghost tell)", () => {
+    const pane = `❯ ${ESC}[36m${GHOST_TEXT}${ESC}[0m`;
+    expect(classifyPromptTextPresentation(pane, GHOST_TEXT)).toBe('real');
+  });
+
+  it("never misreads a truecolor component '2' (38;2;r;g;b) as the dim attribute", () => {
+    // A gray truecolor foreground — visually dim-ish, but NOT SGR 2. A naive
+    // param scan would see the '2' color-space selector and false-classify
+    // every truecolor UI as ghost, disabling genuine recovery.
+    const pane = `❯ ${ESC}[38;2;150;150;150m${GHOST_TEXT}${ESC}[0m`;
+    expect(classifyPromptTextPresentation(pane, GHOST_TEXT)).toBe('real');
+  });
+
+  it('handles the 256-color form (38;5;n) without misreading params', () => {
+    const pane = `❯ ${ESC}[38;5;245m${GHOST_TEXT}${ESC}[0m`;
+    expect(classifyPromptTextPresentation(pane, GHOST_TEXT)).toBe('real');
+  });
+
+  it("treats SGR 22 (normal intensity) as canceling dim — text after it is 'real'", () => {
+    const pane = `❯ ${ESC}[2m${ESC}[22m${GHOST_TEXT}`;
+    expect(classifyPromptTextPresentation(pane, GHOST_TEXT)).toBe('real');
+  });
+
+  it("returns 'inconclusive' on MIXED styling (part dim, part normal)", () => {
+    const half = Math.floor(GHOST_TEXT.length / 2);
+    const pane = `❯ ${ESC}[2m${GHOST_TEXT.slice(0, half)}${ESC}[22m${GHOST_TEXT.slice(half)}`;
+    expect(classifyPromptTextPresentation(pane, GHOST_TEXT)).toBe('inconclusive');
+  });
+
+  it("returns 'inconclusive' when the ANSI frame's prompt text does not match (raced captures)", () => {
+    expect(classifyPromptTextPresentation(GHOST_ANSI_PANE, 'a totally different message')).toBe('inconclusive');
+  });
+
+  it("returns 'inconclusive' when the ANSI frame has no readable prompt", () => {
+    expect(classifyPromptTextPresentation('no prompt here at all', GHOST_TEXT)).toBe('inconclusive');
+  });
+
+  it('classifies wrapped-line ghost text (empty ❯, dim text on the next line)', () => {
+    const pane = ['❯ ', `${ESC}[2mwrapped ghost suggestion${ESC}[0m`, '──────'].join('\n');
+    expect(classifyPromptTextPresentation(pane, 'wrapped ghost suggestion')).toBe('ghost');
+  });
+
+  it('tracks dim state ACROSS lines when tmux does not re-emit attributes per line', () => {
+    // Dim turned on at the end of the prompt line, wrapped text on the next
+    // line with no attribute re-emission — the state must carry.
+    const pane = [`❯ ${ESC}[2m`, 'wrapped ghost suggestion', '──────'].join('\n');
+    expect(classifyPromptTextPresentation(pane, 'wrapped ghost suggestion')).toBe('ghost');
+  });
+});
+
+describe('StuckInputSentinel — F2 ghost-text exclusion (the invariant)', () => {
+  it('NEVER fires a keypress at ghost text, across arbitrarily many ticks', () => {
+    const mgr = buildStubManager({ 'echo-A': PLAIN_STUCK_PANE }, { 'echo-A': GHOST_ANSI_PANE });
+    const sentinel = buildSentinel(mgr);
+
+    for (let i = 0; i < 10; i++) sentinel.tick();
+
+    expect(mgr.fireStuckInputRecovery).not.toHaveBeenCalled();
+    // The gate actually ran (this is not a detection miss):
+    expect(mgr.captureOutputAnsi).toHaveBeenCalled();
+    // Ghost is sticky — exhausted until the prompt text changes, so the gate
+    // does not re-capture ANSI frames every tick forever.
+    const rec = sentinel.getRecordForTest('echo-A');
+    expect(rec?.exhausted).toBe(true);
+    expect(rec?.attempts).toBe(0);
+  });
+
+  it('still recovers GENUINE stuck input (normal-intensity text) — the original mission', () => {
+    const mgr = buildStubManager({ 'echo-A': PLAIN_STUCK_PANE }, { 'echo-A': REAL_ANSI_PANE });
+    const sentinel = buildSentinel(mgr);
+
+    sentinel.tick(); // observation
+    sentinel.tick(); // fire attempt 0
+
+    expect(mgr.fireStuckInputRecovery).toHaveBeenCalledTimes(1);
+    expect(mgr.fireStuckInputRecovery).toHaveBeenCalledWith('echo-A', 0);
+  });
+
+  it('fails toward NOT pressing when the ANSI capture returns null — and is NOT sticky', () => {
+    const mgr = buildStubManager({ 'echo-A': PLAIN_STUCK_PANE }, { 'echo-A': null });
+    const sentinel = buildSentinel(mgr);
+
+    for (let i = 0; i < 5; i++) sentinel.tick();
+
+    expect(mgr.fireStuckInputRecovery).not.toHaveBeenCalled();
+    // Inconclusive is transient: the record is not exhausted, so a later
+    // successful capture can still recover a genuinely stuck message.
+    const rec = sentinel.getRecordForTest('echo-A');
+    expect(rec?.exhausted).toBe(false);
+    // Re-assessed on every fire-eligible tick (ticks 2..5 = 4 attempts).
+    expect(mgr.captureOutputAnsi.mock.calls.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('fails toward NOT pressing when the ANSI capture THROWS', () => {
+    const mgr = buildStubManager({ 'echo-A': PLAIN_STUCK_PANE }, {
+      'echo-A': () => { throw new Error('tmux exploded'); },
+    });
+    const sentinel = buildSentinel(mgr);
+
+    for (let i = 0; i < 5; i++) sentinel.tick();
+
+    expect(mgr.fireStuckInputRecovery).not.toHaveBeenCalled();
+  });
+
+  it('self-heals: a transiently unreadable frame recovers once the capture works', () => {
+    let ansi: string | null = null;
+    const mgr = buildStubManager({ 'echo-A': PLAIN_STUCK_PANE }, { 'echo-A': () => ansi });
+    const sentinel = buildSentinel(mgr);
+
+    sentinel.tick(); // observation
+    sentinel.tick(); // fire-eligible, but ANSI capture null → skip
+    expect(mgr.fireStuckInputRecovery).not.toHaveBeenCalled();
+
+    ansi = REAL_ANSI_PANE; // capture starts working; text provably real
+    sentinel.tick();
+    expect(mgr.fireStuckInputRecovery).toHaveBeenCalledTimes(1);
+    expect(mgr.fireStuckInputRecovery).toHaveBeenCalledWith('echo-A', 0);
+  });
+
+  it('resets a sticky ghost record when the prompt text changes to genuinely typed input', () => {
+    let plain = PLAIN_STUCK_PANE;
+    let ansi = GHOST_ANSI_PANE;
+    const mgr = buildStubManager({ 'echo-A': plain }, { 'echo-A': () => ansi });
+    mgr.captureOutput = vi.fn(() => plain);
+    const sentinel = buildSentinel(mgr);
+
+    sentinel.tick();
+    sentinel.tick();
+    expect(mgr.fireStuckInputRecovery).not.toHaveBeenCalled();
+    expect(sentinel.getRecordForTest('echo-A')?.exhausted).toBe(true);
+
+    // The user actually types a message; it gets stuck for real.
+    plain = PLAIN_STUCK_PANE.replace(GHOST_TEXT, 'a real typed message');
+    ansi = REAL_ANSI_PANE.replace(GHOST_TEXT, 'a real typed message');
+    sentinel.tick(); // new text → fresh record
+    sentinel.tick(); // fire attempt 0
+    expect(mgr.fireStuckInputRecovery).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT gate the codex marker path (marker = text we ourselves injected)', () => {
+    const CODEX_DRAFT = '[telegram:1052] continue running into version issues';
+    const CODEX_MARKER = CODEX_DRAFT.slice(0, 40);
+    const CODEX_PANE = [`› ${CODEX_DRAFT}`, '', '  gpt-5.5 medium'].join('\n');
+    const mgr = buildStubManager(
+      { 'codey-A': CODEX_PANE },
+      {},
+      { 'codey-A': { marker: CODEX_MARKER, framework: 'codex-cli' } },
+    );
+    const sentinel = buildSentinel(mgr);
+
+    sentinel.tick();
+    sentinel.tick();
+
+    expect(mgr.fireStuckInputRecovery).toHaveBeenCalledTimes(1);
+    // The ghost gate never ran for the marker path.
+    expect(mgr.captureOutputAnsi).not.toHaveBeenCalled();
+  });
+
+  it('logs exactly ONE ghost-text-skip observability event per stuck text', () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-ghost-evt-'));
+    try {
+      const mgr = buildStubManager({ 'echo-A': PLAIN_STUCK_PANE }, { 'echo-A': GHOST_ANSI_PANE });
+      const sentinel = buildSentinel(mgr, { stateDir, noPersist: false });
+
+      for (let i = 0; i < 6; i++) sentinel.tick();
+
+      const log = fs.readFileSync(path.join(stateDir, 'stuck-input-events.jsonl'), 'utf-8')
+        .trim().split('\n').map(l => JSON.parse(l));
+      const ghostRows = log.filter(r => r.action === 'ghost-text-skip');
+      expect(ghostRows).toHaveLength(1);
+      expect(ghostRows[0].outcome).toBe('skipped');
+      expect(ghostRows[0].session).toBe('echo-A');
+      expect(ghostRows[0].promptText).toBe(GHOST_TEXT);
+      // And no keypress rows at all.
+      expect(log.filter(r => r.outcome === 'fired')).toHaveLength(0);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/StuckInputSentinel.test.ts
+++ b/tests/unit/StuckInputSentinel.test.ts
@@ -22,6 +22,7 @@ type StubManager = {
   listRunningSessions: ReturnType<typeof vi.fn>;
   tmuxSessionExists: ReturnType<typeof vi.fn>;
   captureOutput: ReturnType<typeof vi.fn>;
+  captureOutputAnsi: ReturnType<typeof vi.fn>;
   fireStuckInputRecovery: ReturnType<typeof vi.fn>;
   getStrandedDraftMarker: ReturnType<typeof vi.fn>;
   clearStrandedDraftMarker: ReturnType<typeof vi.fn>;
@@ -34,10 +35,15 @@ type StubManager = {
  * @param markers per-session stranded-draft marker record. When a session has a
  *   codex marker, the sentinel uses MARKER-based detection (isMarkerStuckAtPrompt
  *   over the pane) instead of the generic `❯`-prompt reader.
+ * @param ansiPanes per-session ANSI (`capture-pane -e`) frames for the F2
+ *   ghost-text gate. Defaults to the plain pane — a frame with no SGR codes
+ *   renders nothing dim, so the gate classifies the text as 'real' and the
+ *   legacy recovery behavior is preserved.
  */
 function buildStubManager(
   panes: Record<string, string | (() => string)>,
   markers: Record<string, { marker: string; framework: string }> = {},
+  ansiPanes: Record<string, string | (() => string)> = {},
 ): StubManager {
   const liveMarkers = new Map(Object.entries(markers).map(([k, v]) => [k, { ...v, injectedAt: 0 }]));
   return {
@@ -46,6 +52,10 @@ function buildStubManager(
     captureOutput: vi.fn((name: string) => {
       const p = panes[name];
       return typeof p === 'function' ? p() : p;
+    }),
+    captureOutputAnsi: vi.fn((name: string) => {
+      const a = ansiPanes[name] ?? panes[name];
+      return typeof a === 'function' ? a() : a;
     }),
     fireStuckInputRecovery: vi.fn(),
     getStrandedDraftMarker: vi.fn((name: string) => liveMarkers.get(name)),

--- a/tests/unit/slack-files-info-selfverify.test.ts
+++ b/tests/unit/slack-files-info-selfverify.test.ts
@@ -1,0 +1,171 @@
+// safe-git-allow: test file — fs.rmSync is per-test tmpdir cleanup only.
+/**
+ * files.info self-verify fix — roadmap 0.5 (slack-ai-employee-audit §1).
+ *
+ * Live defect: the startup self-verify probed files.info with the fabricated
+ * id `F000SELFTEST`, expecting `file_not_found`. Slack rejects that id at
+ * ARGUMENT VALIDATION instead (`invalid_arguments`), which the old
+ * classification counted as an unexpected FAILURE — so a perfectly healthy
+ * adapter logged `❌ files.info API: Unexpected error: … invalid_arguments`
+ * at every boot (live server.log 2026-07-02 18:12:27).
+ *
+ * The fix: (a) probe with a WELL-FORMED synthetic id so a healthy workspace
+ * answers the stronger `file_not_found`; (b) classify `invalid_arguments` as
+ * what it actually proves — the endpoint, auth, and transport all answered —
+ * so the check is robust to Slack-side validator drift in either direction.
+ * `missing_scope` and unknown errors remain failures.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  SlackAdapter,
+  classifyFilesInfoSelfTest,
+  FILES_INFO_PROBE_ID,
+} from '../../src/messaging/slack/SlackAdapter.js';
+import { SlackApiError } from '../../src/messaging/slack/SlackApiClient.js';
+
+describe('classifyFilesInfoSelfTest — probe outcome classification', () => {
+  it('passes on ok (unexpected success for a synthetic id)', () => {
+    expect(classifyFilesInfoSelfTest(null).status).toBe('pass');
+  });
+
+  it('passes on file_not_found (probe id reached lookup)', () => {
+    const r = classifyFilesInfoSelfTest('file_not_found');
+    expect(r.status).toBe('pass');
+    expect(r.detail).toContain('file_not_found');
+  });
+
+  it('passes on invalid_arguments — the live 2026-07-02 regression', () => {
+    // This is the exact shape the live server hit: Slack rejected the
+    // synthetic probe id at argument validation. That proves the endpoint,
+    // auth, and transport all answered — a responsive API, not a failure.
+    const r = classifyFilesInfoSelfTest('invalid_arguments');
+    expect(r.status).toBe('pass');
+    expect(r.detail).toContain('argument validation');
+  });
+
+  it('passes on invalid_arguments embedded in a full error message (non-SlackApiError path)', () => {
+    expect(classifyFilesInfoSelfTest('Slack API files.info failed: invalid_arguments').status).toBe('pass');
+  });
+
+  it('fails on missing_scope (scope header lied)', () => {
+    const r = classifyFilesInfoSelfTest('missing_scope');
+    expect(r.status).toBe('fail');
+    expect(r.detail).toContain('missing_scope');
+  });
+
+  it('fails on invalid_auth', () => {
+    expect(classifyFilesInfoSelfTest('invalid_auth').status).toBe('fail');
+  });
+
+  it('fails on an unknown error', () => {
+    const r = classifyFilesInfoSelfTest('fatal_error');
+    expect(r.status).toBe('fail');
+    expect(r.detail).toContain('fatal_error');
+  });
+});
+
+describe('FILES_INFO_PROBE_ID — probe id shape', () => {
+  it('is a well-formed Slack file id (F + uppercase alphanumerics), maximizing the chance of file_not_found over invalid_arguments', () => {
+    expect(FILES_INFO_PROBE_ID).toMatch(/^F[A-Z0-9]{10,}$/);
+    // And it is NOT the old malformed probe that tripped argument validation.
+    expect(FILES_INFO_PROBE_ID).not.toBe('F000SELFTEST');
+  });
+});
+
+describe('SlackAdapter._selfVerify — wiring (check 2 uses the classifier)', () => {
+  const REQUIRED_SCOPES = [
+    'files:read', 'channels:history', 'channels:read', 'chat:write',
+    'im:history', 'im:read', 'im:write', 'users:read',
+  ];
+
+  let stateDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-slack-sv-'));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // auth.test (check 1: scope header) + files.slack.com (check 3: download).
+    vi.stubGlobal('fetch', vi.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes('auth.test')) {
+        return {
+          headers: new Headers({ 'x-oauth-scopes': REQUIRED_SCOPES.join(',') }),
+        } as unknown as Response;
+      }
+      return {
+        status: 302,
+        headers: new Headers({ location: 'https://files-origin.slack.com/x' }),
+      } as unknown as Response;
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  function buildAdapter(filesInfoBehavior: 'ok' | string): { adapter: SlackAdapter; call: ReturnType<typeof vi.fn> } {
+    const adapter = new SlackAdapter({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      authorizedUserIds: ['U_TEST'],
+      workspaceMode: 'dedicated',
+    } as any, stateDir);
+    const call = vi.fn(async (method: string) => {
+      if (method === 'files.info' && filesInfoBehavior !== 'ok') {
+        throw new SlackApiError(
+          `Slack API files.info failed: ${filesInfoBehavior}`,
+          'files.info',
+          filesInfoBehavior,
+          false,
+        );
+      }
+      return { ok: true };
+    });
+    (adapter as any).apiClient = { call };
+    return { adapter, call };
+  }
+
+  function allOutput(): string {
+    return [...logSpy.mock.calls, ...errorSpy.mock.calls].map(c => c.join(' ')).join('\n');
+  }
+
+  it('reports self-verification PASSED when files.info answers invalid_arguments (the live regression goes green)', async () => {
+    const { adapter, call } = buildAdapter('invalid_arguments');
+    await (adapter as any)._selfVerify();
+
+    // The probe used the well-formed synthetic id.
+    expect(call).toHaveBeenCalledWith('files.info', { file: FILES_INFO_PROBE_ID });
+    const out = allOutput();
+    expect(out).toContain('Self-verification passed');
+    expect(out).not.toContain('❌ files.info API');
+  });
+
+  it('reports self-verification PASSED on file_not_found (healthy workspace)', async () => {
+    const { adapter } = buildAdapter('file_not_found');
+    await (adapter as any)._selfVerify();
+    expect(allOutput()).toContain('Self-verification passed');
+  });
+
+  it('still FAILS the files.info check on missing_scope', async () => {
+    const { adapter } = buildAdapter('missing_scope');
+    await (adapter as any)._selfVerify();
+    const out = allOutput();
+    expect(out).toContain('❌ files.info API');
+    expect(out).toContain('missing_scope');
+  });
+
+  it('still FAILS the files.info check on a genuinely unexpected error', async () => {
+    const { adapter } = buildAdapter('internal_error');
+    await (adapter as any)._selfVerify();
+    expect(allOutput()).toContain('❌ files.info API');
+  });
+});

--- a/upgrades/next/p05-filesinfo-ghosttext.md
+++ b/upgrades/next/p05-filesinfo-ghosttext.md
@@ -1,0 +1,67 @@
+# Slack files.info self-verify fix + ghost-text exclusion in the stuck-input watchdog
+
+<!-- bump: patch -->
+
+## What Changed
+
+Roadmap 0.5, the two code halves (live evidence 2026-07-02):
+
+- **Slack files.info self-verify no longer fails a healthy adapter.** The
+  startup self-verify probed `files.info` with the malformed synthetic id
+  `F000SELFTEST`; Slack rejects that id at server-side argument validation
+  (`invalid_arguments`) before lookup, and the old classifier counted that as
+  an unexpected failure — `❌ files.info API` at every boot on a working
+  connection. Now the probe uses a well-formed synthetic id (`F0000000000`,
+  expecting `file_not_found`), and the classification (extracted to
+  `classifyFilesInfoSelfTest`) treats `invalid_arguments` as what it proves —
+  endpoint, auth, and transport all answered. `missing_scope` and unknown
+  errors still fail.
+
+- **The stuck-input watchdog never presses Enter at ghost text.** Claude Code
+  renders a model-generated composer SUGGESTION dim (`ESC[0;2m`); in a plain
+  `capture-pane` frame the dim attribute is stripped, so ghost text was
+  byte-identical to genuinely stuck input, and the sentinel fired 4 Enter
+  presses at a fabricated instruction during the live run (harmless only
+  because Enter does not currently accept ghost text — one harness UX change
+  away from a watchdog auto-submitting model-fabricated instructions). The
+  sentinel now re-captures the pane WITH ANSI escapes (new
+  `SessionManager.captureOutputAnsi`, `capture-pane -e`) before any keypress on
+  the generic `❯`-prompt path and classifies the presentation: `real` →
+  recover as before; `ghost` (entirely dim) → never press, sticky until the
+  text changes; `inconclusive` (capture failed / frames raced / mixed styling)
+  → **log-only this tick, never Enter** — every uncertain path fails toward
+  not pressing. One `ghost-text-skip` / `ghost-check-inconclusive` event per
+  stuck text lands in `stuck-input-events.jsonl`. The codex marker path is
+  exempt by construction (it only fires at text we ourselves injected).
+
+## What to Tell Your User
+
+<!-- audience: user, maturity: stable -->
+- **A watchdog safety fix**: the helper that un-sticks typed-but-unsubmitted
+  terminal messages could previously mistake the terminal's dim gray
+  auto-suggestion (text nobody typed) for a stuck message and press Enter at
+  it. It now checks how the text is actually rendered and refuses to press
+  anything at a suggestion — and when it can't tell for sure, it does nothing
+  and just logs. Genuinely stuck messages still recover exactly as before.
+
+## Summary of New Capabilities
+
+None user-facing — a boot-diagnostic correctness fix and a watchdog safety
+narrowing. New internal primitive: `SessionManager.captureOutputAnsi` (styled
+twin of `captureOutput`).
+
+## Evidence
+
+- Live server.log 2026-07-02 18:12:27: `❌ files.info API: Unexpected error:
+  Slack API files.info failed: invalid_arguments` on a workspace whose
+  download-path check passed — the probe id, not the capability, was at fault.
+- Live stuck-input-events.jsonl 2026-07-02: 4 `fired` Enter events at the dim
+  suggestion text `tas channel-parity: now test the Slack topic` that no one
+  typed.
+- 33 new unit tests (21 ghost-text + 12 files.info) covering both sides of
+  every decision boundary: the exact live ghost frame refused across
+  arbitrarily many ticks; the same text at normal intensity still recovered;
+  null/throwing/raced captures, mixed styling, truecolor-component-2, SGR 22,
+  cross-line dim state; the live `invalid_arguments` shape goes green while
+  `missing_scope`/unknown still fail. Pre-existing StuckInputSentinel suite
+  green (legacy recovery preserved). Full lint suite exit 0.

--- a/upgrades/side-effects/p05-filesinfo-ghosttext.md
+++ b/upgrades/side-effects/p05-filesinfo-ghosttext.md
@@ -1,0 +1,188 @@
+# Side-Effects Review — Slack files.info self-verify fix + F2 ghost-text exclusion in StuckInputSentinel
+
+**Version / slug:** `p05-filesinfo-ghosttext`
+**Date:** `2026-07-02`
+**Author:** Echo (autonomous, roadmap 0.5)
+**Second-pass reviewer:** self, second pass over the final diff (Tier 1)
+
+## Summary of the change
+
+Two code halves of roadmap item 0.5, both grounded in 2026-07-02 live evidence:
+
+1. **Slack files.info self-verify** (`src/messaging/slack/SlackAdapter.ts`):
+   the startup self-verify probed `files.info` with the malformed synthetic id
+   `F000SELFTEST`; Slack rejects that id at server-side ARGUMENT VALIDATION
+   (`invalid_arguments`) before lookup, and the old classifier counted that as
+   an unexpected FAILURE — a healthy adapter red-flagged itself at every boot.
+   Fix: (a) probe with a WELL-FORMED synthetic id (`F0000000000`) so a healthy
+   workspace answers `file_not_found`; (b) extract the classification into an
+   exported pure function `classifyFilesInfoSelfTest()` that treats
+   `invalid_arguments` as what it proves (endpoint + auth + transport all
+   answered) while `missing_scope` and unknown errors remain failures; (c) use
+   `SlackApiError.slackError` (the structured code) when available instead of
+   substring-matching the whole message.
+
+2. **F2 ghost-text exclusion** (`src/core/StuckInputSentinel.ts` +
+   `src/core/SessionManager.ts`): the sentinel treated Claude Code's DIM
+   model-generated composer suggestion (SGR 2, `ESC[0;2m`) as stuck real input
+   and fired 4 Enter presses at it (live stuck-input-events.jsonl). Fix: before
+   any keypress on the generic `❯`-prompt path, re-capture the pane WITH ANSI
+   escapes (new `SessionManager.captureOutputAnsi`, `capture-pane -e`) and
+   classify the stuck text's presentation: `real` → recover as before; `ghost`
+   (entirely dim) → never press keys, sticky-exhaust until the text changes;
+   `inconclusive` (capture failed / frames raced / mixed styling) → LOG-ONLY
+   this tick, re-assess next tick. One observability event per stuck text
+   (`ghost-text-skip` / `ghost-check-inconclusive`, outcome `skipped`).
+
+## Decision-point inventory
+
+- **Added** (`StuckInputSentinel.evaluateSession`): the ghost-text gate — a new
+  refusal branch between "fire-eligible" and "fire keypress" on the generic
+  prompt path only. The codex marker path is exempt by construction (it only
+  fires at the exact text we ourselves injected). Escalation (tier C) is
+  unreachable for ghost text: attempts only accrue through this gate.
+- **Added** (`classifyPromptTextPresentation` + `parseAnsiDimLines`): pure
+  classification logic. Only the SGR dim attribute (2 / 22 / reset) is the
+  ghost tell; extended-color params (`38;5;n`, `38;2;r;g;b`, colon forms) are
+  skipped so a truecolor component `2` is never misread as dim. The ANSI
+  frame's own prompt extraction must reproduce the plain frame's text EXACTLY,
+  or the verdict is `inconclusive` — the styling verdict is always about the
+  same characters the detection saw.
+- **Modified** (`SlackAdapter._selfVerify` check 2): outcome classification
+  moved to `classifyFilesInfoSelfTest()`; `invalid_arguments` reclassified
+  fail → pass. `missing_scope` and unknown errors keep failing.
+
+## FAIL-DIRECTION (the load-bearing property)
+
+**The sentinel change fails toward LOG-ONLY, never toward Enter.** Every
+uncertain path — ANSI capture unsupported, capture returned null, capture
+threw, the two frames raced (text mismatch), unparseable escapes, mixed
+styling — resolves to `inconclusive`, which withholds the keypress for that
+tick and logs one event. `inconclusive` is deliberately NOT sticky: a raced
+capture self-heals next tick, so a genuinely stuck message is recovered at most
+a few ticks late; a persistent failure keeps failing toward not pressing.
+Pressing Enter at model-fabricated text is the unsafe direction; a delayed
+recovery is the safe cost. The invariant encoded: the sentinel never
+auto-submits text the user (or an authorized injector) did not actually type.
+
+## Roll-up across the seven review dimensions
+
+1. **Over-block**: the ghost gate could suppress recovery of REAL stuck input
+   if the classifier misfires. Mitigations: color is deliberately NOT a tell
+   (only SGR 2); a plain no-SGR frame classifies `real` (legacy behavior
+   preserved — proven by the pre-existing suite passing with the default stub);
+   `inconclusive` is transient, re-assessed every fire-eligible tick; truecolor
+   and 256-color params are param-skipped. Both sides tested.
+2. **Under-block**: ghost text that Claude Code someday renders at NORMAL
+   intensity would not be caught — but then it is visually indistinguishable
+   from typed text and no capture-based tell exists; the dim attribute is the
+   entire live-evidenced signature. The codex-marker exemption cannot leak: it
+   requires a marker WE injected.
+3. **Silent failure**: none added. Every skip logs exactly one
+   `stuck-input-events.jsonl` row (bounded: one per stuck text, not per tick).
+   `captureOutputAnsi` returns null on failure exactly like `captureOutput`.
+4. **Authority creep**: none. The sentinel LOSES authority (a new refusal
+   branch); nothing gains a new write path. The Slack change alters only a
+   boot-time diagnostic verdict, no message flow.
+5. **Fleet blast radius**: both changes are always-on but strictly narrowing.
+   Slack: only installs with a Slack adapter + `files:read` scope run check 2;
+   the reclassification can only flip a false-red to green. Sentinel: one extra
+   `tmux capture-pane -e` per fire-eligible tick per stuck session (rare;
+   bounded by the same tick cadence that already captures panes).
+6. **Rollback**: single-commit revert. No config keys, no migrations, no state
+   format changes. The new JSONL `action` values are additive to an existing
+   log consumers already treat as free-form.
+7. **Observability**: new `ghost-text-skip` / `ghost-check-inconclusive`
+   events in `stuck-input-events.jsonl`; Slack self-verify detail strings name
+   the exact outcome (`argument validation` vs `file_not_found`).
+
+## 3. Level-of-abstraction fit
+
+Right layer, both halves. The ghost gate lives INSIDE the sentinel's own
+fire path (the only place a keypress originates), not as a parallel filter in
+front of it — the same layer that already hosts the activity-indicator refusal
+and the codex-marker strategy choice. The ANSI capture primitive lives in
+`SessionManager` beside `captureOutput` (its styled twin) rather than being
+re-implemented in the sentinel, so future consumers that need rendering (not
+just bytes) reuse it. The Slack classification is a pure exported function at
+adapter level — the self-verify is a boot diagnostic owned by the adapter; no
+higher-layer gate exists (or is needed) for a boot-time health verdict.
+
+## 4. Signal vs authority compliance
+
+**Checkbox: No — this change has no NEW block/allow surface over agent or user
+information flow.** The ghost gate is deterministic (brittle-by-nature) logic,
+but the only "authority" it holds is the power to make the sentinel DO NOTHING
+— it withholds the sentinel's own recovery keypress; it cannot block a message,
+gate information, or constrain the user or agent. The dangerous authority
+(pressing keys into a live session) is what the sentinel already held; this
+change narrows it, fail-safe toward inaction, exactly like the pre-existing
+activity-indicator refusal at the same layer. The Slack half changes a
+boot-diagnostic verdict string; no flow authority at all.
+
+## 5. Interactions
+
+- **Shadowing:** the gate runs AFTER stuck-detection and the min-ticks window
+  and BEFORE `fireStuckInputRecovery` — it cannot shadow detection, escalation
+  handling (which runs earlier in the flow but later in the attempt ladder), or
+  the verifyInjection race-window skip. Nothing runs after it that expects a
+  keypress to have happened (the event log records `skipped` honestly).
+- **Double-fire:** none. The gate only ever REMOVES a fire. The one-event-per-
+  stuck-text latch (`ghostSkipLogged`) prevents log double-fire.
+- **Races:** the plain and ANSI captures are two separate tmux calls; a pane
+  repaint between them is detected by exact text-match and resolves to
+  `inconclusive` (no press) — the race is handled by construction, not by
+  timing assumptions.
+- **Feedback loops:** none; the gate writes no state the detector reads.
+- **Escalation interaction:** tier-C escalation is unreachable for ghost text —
+  attempts only accrue through the gate, so four `real` verdicts must precede
+  any escalation request.
+
+## 6. External surfaces
+
+- **Other agents / install base:** behavior narrows only (fewer keypresses;
+  a false-red boot check goes green). No API, route, config, or template
+  changes. No new dependency.
+- **External systems:** the Slack probe now sends `F0000000000` instead of
+  `F000SELFTEST` to `files.info` — same call count, same scope, still a
+  synthetic id that cannot match a real file.
+- **Persistent state:** two additive `action` values in the existing
+  `stuck-input-events.jsonl` free-form log. No schema, no migration.
+- **Timing/runtime conditions:** tmux `capture-pane -e` support (present in
+  every tmux version instar supports; a failure degrades to `inconclusive`,
+  i.e. log-only).
+- **Operator surface (Mobile-Complete Operator Actions):** no operator-facing
+  actions added or touched.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN, both halves.** The sentinel observes and recovers
+tmux panes that exist only on THIS machine's disk/terminal — the pane, the
+capture, and the keypress are all physically local, like the rest of the
+stuck-input/watchdog family. The Slack self-verify diagnoses THIS machine's
+adapter boot. Neither emits user-facing notices (the sentinel's events are
+housekeeping JSONL; the self-verify writes to the boot log), neither holds
+durable state that could strand on topic transfer, and neither generates URLs.
+
+## 8. Rollback cost
+
+Single-commit revert, shipped as the next patch. No config keys, no
+migrations, no persistent-state cleanup, no agent state repair. During a
+rollback window the only regression users could see is the OLD behavior
+returning (false-red Slack check line; watchdog pressing Enter at ghost text).
+
+## Test coverage
+
+- `tests/unit/StuckInputSentinel-ghost-text.test.ts` (21 tests): the exact live
+  F2 frame refused across 10 ticks; genuine input still recovered; null-capture
+  / throwing-capture / raced-frame / mixed-styling all fail toward not
+  pressing; truecolor + 256-color params not misread; SGR 22 cancels dim;
+  cross-line dim state; wrapped-line ghost; sticky-ghost reset on text change;
+  codex path ungated; exactly one observability event.
+- `tests/unit/slack-files-info-selfverify.test.ts` (12 tests): classifier both
+  sides (ok / file_not_found / invalid_arguments pass; missing_scope /
+  invalid_auth / unknown fail); probe id shape; `_selfVerify` wiring-level test
+  proving the live regression goes green and failures still fail.
+- `tests/unit/StuckInputSentinel.test.ts`: pre-existing suite green with the
+  gate in place (default ANSI stub = plain frame = `real`), proving legacy
+  recovery behavior is preserved.


### PR DESCRIPTION
Two live-defect fixes from the 2026-07-02 audit (roadmap item 0.5), shipped together. Tier 1 (unit). Spec/ELI16: `docs/specs/p05-filesinfo-ghosttext.eli16.md` · side-effects: `upgrades/side-effects/p05-filesinfo-ghosttext.md` · upgrade fragment: `upgrades/next/p05-filesinfo-ghosttext.md`.

## ELI16

Two small fixes that stop the agent from fooling itself. First: every time the agent's Slack connection boots, it self-tests "can I actually look up uploaded files?" by asking Slack about a file that deliberately doesn't exist — the point is proving the API answers, not finding the file. But the fake file id we used looked malformed, so Slack rejected it before even looking, with a different error than the one we expected — and the check stamped a red ❌ on a perfectly healthy connection at every boot. Now we use a properly-shaped fake id, and we also teach the check that "Slack's validator answered you" proves exactly what the check exists to prove (network, login, and endpoint all work), so that answer counts as a pass. A real permission problem still fails, exactly as before. Second: the watchdog that un-sticks frozen terminal input used to see Claude Code's dim grey "suggested text" — a completion the model offers that nobody typed — as real stuck input, because the plain screen-capture strips the dim styling. It then pressed Enter at a fabricated instruction, four times, in a live incident. Now, before pressing anything, the watchdog re-captures the screen WITH styling and checks: dim suggestion → never press; genuinely typed text → recover as before; can't tell → do nothing this tick and just log. Every uncertain path fails toward NOT pressing Enter.

## Fix 1 — Slack `files.info` self-verify (SlackAdapter)

- The startup probe used the malformed synthetic id `F000SELFTEST`; Slack rejects it at argument validation (`invalid_arguments`) **before** lookup, and the old classifier counted that as an unexpected FAILURE → `❌ files.info API` logged on every boot of a healthy adapter.
- Fix: probe with the well-formed synthetic id `F0000000000` (healthy workspace answers `file_not_found`), and extract classification into the exported pure function `classifyFilesInfoSelfTest()` which treats `invalid_arguments` as a pass (endpoint + auth + transport all answered). `missing_scope` / unknown errors still fail.
- Uses the structured `SlackApiError.slackError` code instead of substring-matching the message.

## Fix 2 — F2 ghost-text exclusion (StuckInputSentinel + SessionManager)

- Claude Code renders a model-generated composer suggestion dim (SGR 2, `ESC[0;2m`); in a plain `capture-pane` frame the dim attribute is stripped, so ghost text was byte-identical to genuinely stuck input. The sentinel fired 4 Enter presses at a fabricated instruction (live `stuck-input-events.jsonl`).
- Fix: before any keypress on the generic `❯`-prompt path, re-capture the pane WITH ANSI escapes (new `SessionManager.captureOutputAnsi`, `capture-pane -e`) and classify presentation:
  - `real` → recover as before
  - `ghost` → never press (sticky until the text changes)
  - `inconclusive` (capture failed / raced / mixed styling) → LOG-ONLY this tick
- Every uncertain path fails toward NOT pressing. The codex marker path is exempt by construction (marker text is text we ourselves injected). One observability event per stuck text.

## Testing

- 33 new unit tests (21 ghost-text + 12 files.info), all green.
- Adjacent sweep: 18 test files touching SlackAdapter / StuckInputSentinel / SessionManager capture paths — 227 tests, all green.
- `npm run lint` (tsc + full custom lint chain) exit 0.
- Full 42k suite runs in CI (sharded) — the clean-room authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
