### PR TITLE
feat(slack): GFM→mrkdwn outbound formatter at the single send chokepoint (roadmap 0.1)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-02T21-25-55-224Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-02T21-25-55-224Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-02T21:25:55.224Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 6,
+  "loc": 620,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,11 @@ src/
                   # 'markdown' — flip to 'legacy-passthrough' in .instar/config.json
                   # for byte-for-byte rollback; per-call `_formatMode: 'html'` opt-out
                   # for callers already producing Telegram HTML),
+                  # slack/SlackMrkdwnFormatter (GFM→mrkdwn for Slack; default
+                  # 'mrkdwn' — flip to 'legacy-passthrough' in the slack messaging
+                  # config block for byte-for-byte rollback; per-call
+                  # `formatMode: 'legacy-passthrough'` opt-out for callers already
+                  # producing mrkdwn),
                   # MessageRouter (topic → adapter routing),
                   # DeliveryRetryManager (retry on failed delivery),
                   # PendingRelayStore (durable SQLite queue for Telegram relay;

--- a/docs/specs/slack-mrkdwn-formatter.eli16.md
+++ b/docs/specs/slack-mrkdwn-formatter.eli16.md
@@ -1,0 +1,70 @@
+# Slack replies render natively (GFM→mrkdwn formatter) — ELI16
+
+## What is this?
+
+When your agent writes a message, it writes in normal GitHub-style markdown —
+`**bold**`, `# headings`, `[click here](https://…)`, `- bullet points`,
+```` ```code blocks``` ````. That's the same dialect it uses everywhere.
+
+The problem: Slack does NOT speak that dialect. Slack has its own flavor called
+*mrkdwn*, where bold is a SINGLE asterisk (`*bold*`), links look like
+`<https://…|click here>`, there are no real headings, and there are no tables.
+So when the agent sent its GitHub-style text straight to Slack, Slack showed it
+raw: your users literally saw `**bold**` with the asterisks, bracket-and-paren
+link soup, and `#` characters in front of titles. It looked broken.
+
+This change adds a small translator that sits at the exact spot where every
+Slack message leaves the agent. Right before the text goes out, it rewrites the
+GitHub markdown into Slack's mrkdwn. Now bold is bold, links are clickable,
+lists get real bullets (`•`), code stays monospaced, headings become bold lines
+(the closest Slack has), and tables become code blocks so their columns still
+line up. Your users just see a nicely formatted message.
+
+## How does it work?
+
+There's one "chokepoint" inside the Slack adapter — a single private function
+(`formattedApiCall`) that every user-visible send now goes through: the normal
+reply, threaded replies, message edits, and private "only you can see this"
+messages. Because they ALL funnel through that one spot, the translation
+happens once, consistently, everywhere — there's no way for one path to forget
+to format.
+
+The translator itself is careful about a few tricky things:
+
+- **Code is sacred.** Anything inside backticks or a fenced code block is pulled
+  out FIRST and never touched, so a code sample that literally contains
+  `**stars**` stays literal instead of turning bold.
+- **It escapes exactly once.** Slack requires the three characters `&`, `<`, `>`
+  to be written as `&amp;`, `&lt;`, `&gt;`. The translator does that a single
+  time — it can never double-escape and produce `&amp;amp;`.
+- **Links are checked for safety.** Only `http`, `https`, and `mailto` links get
+  turned into clickable Slack links. A sneaky `javascript:` link is left as
+  plain text, so a message can't smuggle a dangerous link.
+- **It won't hang on huge or hostile input.** Anything over 32KB skips the
+  conversion and goes out as-is, and there are length limits on every pattern so
+  a crafted message can't make it spin forever.
+
+## Can I turn it off?
+
+Yes, two ways, and both were built in on purpose:
+
+1. **Global rollback.** Put `formatMode: 'legacy-passthrough'` in the Slack
+   section of your config and the agent goes back to the exact old behavior —
+   byte-for-byte, no translation at all. This is the "undo" lever if the new
+   formatting ever misbehaves.
+2. **Per-message opt-out.** A caller that already wrote proper Slack mrkdwn (a
+   few internal system messages do) can say "leave mine alone" for just that one
+   message, so it isn't double-translated.
+
+It's ON by default — because a message that renders correctly is what everyone
+wants — but the off switch is one config line away.
+
+## Is it risky?
+
+Low risk. It only changes how OUTGOING Slack text is formatted; it doesn't
+touch how messages come IN, doesn't gate or block anything, and doesn't add any
+new network calls. Block Kit messages (the fancy button/card payloads) are left
+completely alone, since those are authored deliberately. If anything looks off,
+the one-line config rollback restores the old behavior instantly. It mirrors the
+same pattern already proven on the Telegram side (GFM→HTML), so this is a
+well-trodden path, just pointed at Slack's dialect instead.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -6137,7 +6137,10 @@ export async function startServer(options: StartOptions): Promise<void> {
                     await _slackAdapter.relayPrompt(channelId, prompt.id, question, options);
                   } else {
                     await _slackAdapter.sendToChannel(channelId,
-                      `⏳ *Agent needs your input:*\n${question}\n\n_Reply in this channel to respond._`
+                      `⏳ *Agent needs your input:*\n${question}\n\n_Reply in this channel to respond._`,
+                      // Already-authored mrkdwn (single-asterisk bold) — opt out
+                      // of the GFM->mrkdwn converter (roadmap 0.1).
+                      { formatMode: 'legacy-passthrough' }
                     );
                   }
                   console.log(`[PromptGate] Relayed ${prompt.type} prompt to Slack channel ${channelId}`);

--- a/src/messaging/slack/SlackAdapter.ts
+++ b/src/messaging/slack/SlackAdapter.ts
@@ -28,7 +28,9 @@ import { FileHandler } from './FileHandler.js';
 import { RingBuffer } from './RingBuffer.js';
 import { MessageLogger, type LogEntry } from '../shared/MessageLogger.js';
 import type { SlackConfig, SlackMessage, PendingPrompt, InteractionPayload, InteractionAction, SlackWorkspaceMode, SlackRespondMode } from './types.js';
-import { sanitizeDisplayName, validateChannelId, escapeMrkdwn } from './sanitize.js';
+import { sanitizeDisplayName, validateChannelId } from './sanitize.js';
+import { applySlackFormatter, type SlackFormatMode } from './SlackMrkdwnFormatter.js';
+import type { SlackApiResponse } from './SlackApiClient.js';
 import type { SlackPermissionObserver } from '../../permissions/SlackPermissionObserver.js';
 import type { AmbientContributionGate } from '../../permissions/AmbientContributionGate.js';
 
@@ -330,10 +332,28 @@ export class SlackAdapter implements MessagingAdapter {
         params.thread_ts = (message as unknown as Record<string, unknown>).threadTs;
       }
 
-      lastResult = await this.apiClient.call('chat.postMessage', params);
+      lastResult = await this.formattedApiCall('chat.postMessage', params);
     }
 
     return lastResult;
+  }
+
+  /**
+   * The single outbound formatting chokepoint (roadmap 0.1) — every
+   * user-visible send (chat.postMessage / chat.update / chat.postEphemeral)
+   * funnels through here so agent-authored GitHub markdown renders as native
+   * Slack mrkdwn instead of literal `**asterisks**`.
+   *
+   * Mirrors TelegramAdapter.apiCall + applyTelegramFormatter: default ON
+   * ('mrkdwn'); rollback via `formatMode: 'legacy-passthrough'` in the slack
+   * messaging config block; per-call opt-out via `params._formatMode` (set by
+   * `sendToChannel`'s `options.formatMode`) for callers that already author
+   * mrkdwn. Non-send methods and Block Kit payloads pass through unchanged —
+   * see applySlackFormatter for the exact skip rules.
+   */
+  private formattedApiCall(method: string, params: Record<string, unknown>): Promise<SlackApiResponse> {
+    const { outgoingParams } = applySlackFormatter(method, params, this.config.formatMode);
+    return this.apiClient.call(method, outgoingParams);
   }
 
   onMessage(handler: (message: Message) => Promise<void>): void {
@@ -471,12 +491,19 @@ export class SlackAdapter implements MessagingAdapter {
    * routing key here: if `channelId` contains ':' we split it and thread the reply
    * under the embedded thread_ts. An explicit `options.thread_ts` always wins.
    */
-  async sendToChannel(channelId: string, text: string, options?: { thread_ts?: string }): Promise<string> {
+  async sendToChannel(
+    channelId: string,
+    text: string,
+    options?: { thread_ts?: string; formatMode?: SlackFormatMode },
+  ): Promise<string> {
     const parsed = this.parseRoutingKey(channelId);
     const params: Record<string, unknown> = { channel: parsed.channelId, text };
     const threadTs = options?.thread_ts ?? parsed.threadTs;
     if (threadTs) params.thread_ts = threadTs;
-    const result = await this.apiClient.call('chat.postMessage', params);
+    // Per-call formatter opt-out for callers that already author mrkdwn
+    // (stripped from params inside the formatting funnel, never sent to Slack).
+    if (options?.formatMode) params._formatMode = options.formatMode;
+    const result = await this.formattedApiCall('chat.postMessage', params);
     return result.ts as string;
   }
 
@@ -492,7 +519,7 @@ export class SlackAdapter implements MessagingAdapter {
 
   /** Update an existing message. */
   async updateMessage(channelId: string, timestamp: string, text: string): Promise<void> {
-    await this.apiClient.call('chat.update', { channel: channelId, ts: timestamp, text });
+    await this.formattedApiCall('chat.update', { channel: channelId, ts: timestamp, text });
   }
 
   /** Pin a message. */
@@ -502,14 +529,16 @@ export class SlackAdapter implements MessagingAdapter {
 
   /** Send an ephemeral message (visible only to one user). */
   async postEphemeral(channelId: string, userId: string, text: string): Promise<void> {
-    await this.apiClient.call('chat.postEphemeral', { channel: channelId, user: userId, text });
+    await this.formattedApiCall('chat.postEphemeral', { channel: channelId, user: userId, text });
   }
 
   /** Send a message with Block Kit blocks. */
   async sendBlocks(channelId: string, blocks: unknown[], text?: string): Promise<string> {
     const params: Record<string, unknown> = { channel: channelId, blocks };
     if (text) params.text = text; // Fallback text for notifications
-    const result = await this.apiClient.call('chat.postMessage', params);
+    // Routed through the formatting funnel for uniformity — Block Kit payloads
+    // are skipped there by rule (blocks are authored deliberately).
+    const result = await this.formattedApiCall('chat.postMessage', params);
     return result.ts as string;
   }
 

--- a/src/messaging/slack/SlackMrkdwnFormatter.ts
+++ b/src/messaging/slack/SlackMrkdwnFormatter.ts
@@ -1,0 +1,545 @@
+/**
+ * SlackMrkdwnFormatter — server-side formatter that converts agent-authored
+ * GitHub-flavored markdown into Slack mrkdwn on outbound sends (roadmap 0.1).
+ *
+ * Mirrors the TelegramMarkdownFormatter pattern (src/messaging/
+ * TelegramMarkdownFormatter.ts): default ON ('mrkdwn'), config rollback to
+ * 'legacy-passthrough' (byte-for-byte), per-call `_formatMode` opt-out for
+ * callers that already produce mrkdwn.
+ *
+ * Wired at the single SlackAdapter outbound chokepoint (formattedApiCall) so
+ * every chat.postMessage / chat.update / chat.postEphemeral send funnels
+ * through it. See applySlackFormatter() below.
+ *
+ * Conversion contract (GFM → mrkdwn):
+ *   **bold**        → *bold*
+ *   __bold__        → *bold*
+ *   *italic*        → _italic_        (tight word-boundary rule; `3*5` untouched)
+ *   _italic_        → _italic_        (already mrkdwn — passes through)
+ *   ***both***      → *_both_*
+ *   ~~strike~~      → ~strike~
+ *   `code`          → `code`          (content &<> escaped, otherwise verbatim)
+ *   ```fenced```    → ```fenced```    (language tag dropped; content escaped)
+ *   [text](url)     → <url|text>      (scheme allowlist; unsafe → literal)
+ *   # Heading       → *Heading*       (Slack has no headings)
+ *   - bullet        → • bullet
+ *   1. numbered     → 1. numbered     (passes through — reads natively)
+ *   > quote         → > quote         (preserved; Slack renders quotes)
+ *   | tables |      → fenced code block (Slack has no tables)
+ *   --- / *** / ___ → ─ rule line
+ *   emoji + :shortcodes: untouched
+ *
+ * Escaping: Slack's API contract requires `&`, `<`, `>` HTML-entity-escaped in
+ * the text payload; Slack decodes exactly these three entities everywhere
+ * (including code blocks), so we escape ONCE per segment — prose and code
+ * segment contents alike — and never re-process extracted segments (sentinel
+ * placeholders make double-escaping structurally impossible).
+ */
+
+import { escapeMrkdwn } from './sanitize.js';
+
+export type SlackFormatMode = 'mrkdwn' | 'legacy-passthrough';
+
+export interface SlackFormatResult {
+  /** The rendered mrkdwn output (or the raw input, for `legacy-passthrough`). */
+  text: string;
+  /** The mode actually applied. */
+  modeApplied: SlackFormatMode;
+  /** Conversion was bypassed (input > 32KB ReDoS guard); raw text returned. */
+  conversionSkipped: boolean;
+  /** For `legacy-passthrough`: the formatter declined to transform the bytes. */
+  legacyPassthrough: boolean;
+}
+
+/** 32KB hard cap. Above this, markdown conversion is skipped (ReDoS defense). */
+export const MAX_INPUT_LENGTH = 32_768;
+
+/** Max chars scanned forward in the balanced-paren URL walker. */
+const URL_SCAN_MAX = 2048;
+
+// ─── Placeholder sentinels ──────────────────────────────────────────────────
+// Same scheme as TelegramMarkdownFormatter: Supplementary-PUA-B
+// (U+100000..U+10FFFD) — near-zero real-world usage. We strip this range from
+// input BEFORE inserting any sentinel, so collision is structurally impossible.
+
+const PUA_B_START = 0x100000;
+const BLOCK_SIZE = 0x4000; // 16384 entries per kind — plenty
+const SENTINEL_CLOSE = String.fromCodePoint(0x10fffd);
+
+const KIND_PRE = 0; // fenced code blocks (rendered ```…```)
+const KIND_TABLE = 1; // tables (rendered as fenced code blocks)
+const KIND_CODE = 2; // inline code spans
+const KIND_RAW = 3; // already-final mrkdwn (bold/heading output) — spliced verbatim
+
+function makeSentinel(kind: number, n: number): string {
+  if (n < 0 || n >= BLOCK_SIZE) {
+    throw new Error(`sentinel index out of range: ${n}`);
+  }
+  const code = PUA_B_START + kind * BLOCK_SIZE + n;
+  return SENTINEL_CLOSE + String.fromCodePoint(code) + SENTINEL_CLOSE;
+}
+
+function decodeSentinelCodepoint(cp: number): { kind: number; n: number } | null {
+  const offset = cp - PUA_B_START;
+  if (offset < 0) return null;
+  const kind = Math.floor(offset / BLOCK_SIZE);
+  const n = offset % BLOCK_SIZE;
+  if (kind > 3) return null;
+  return { kind, n };
+}
+
+/** Strip the entire Supplementary-PUA-B range from user input. */
+function stripPuaB(s: string): string {
+  return s.replace(/[\u{100000}-\u{10FFFD}]/gu, '');
+}
+
+/** Strip NUL bytes. Always step 0. */
+function stripNul(s: string): string {
+  return s.replace(/\x00/g, '');
+}
+
+// ─── URL safety ─────────────────────────────────────────────────────────────
+
+const SAFE_SCHEMES = new Set(['http', 'https', 'mailto']);
+
+/**
+ * Check a URL against the scheme allowlist using WHATWG URL parsing.
+ * Returns the trimmed URL string on success, or null on reject.
+ * javascript:, data:, file: etc. are refused — the link stays literal text.
+ */
+function isSafeUrl(raw: string): string | null {
+  const trimmed = raw.replace(/^[\s\x00-\x1f]+/, '');
+  if (!trimmed) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  const scheme = parsed.protocol.toLowerCase().replace(':', '');
+  if (!SAFE_SCHEMES.has(scheme)) return null;
+  return trimmed;
+}
+
+// ─── Extraction: fenced code, tables, inline code ──────────────────────────
+
+interface Segments {
+  pre: string[];
+  table: string[];
+  code: string[];
+  raw: string[];
+}
+
+/**
+ * Extract fenced code blocks. Replaces each with a PUA sentinel. Content is
+ * &<>-escaped (Slack decodes these entities inside code blocks) and re-fenced
+ * without the language tag (mrkdwn has no syntax highlighting).
+ */
+function extractFencedCode(text: string, pre: string[]): string {
+  const out: string[] = [];
+  let i = 0;
+  while (i < text.length) {
+    if (text.startsWith('```', i)) {
+      const start = i + 3;
+      const end = text.indexOf('```', start);
+      if (end === -1) {
+        // No closing fence — emit literal backticks, keep scanning.
+        out.push('```');
+        i += 3;
+        continue;
+      }
+      // Optional language tag on the opening line (skip to first \n).
+      let contentStart = start;
+      const nl = text.indexOf('\n', start);
+      if (nl !== -1 && nl < end) {
+        contentStart = nl + 1;
+      }
+      let inner = text.slice(contentStart, end);
+      // Trim ONE trailing newline so the closing fence hugs the content.
+      if (inner.endsWith('\n')) inner = inner.slice(0, -1);
+      const idx = pre.length;
+      pre.push('```' + '\n' + escapeMrkdwn(inner) + '\n' + '```');
+      out.push(makeSentinel(KIND_PRE, idx));
+      i = end + 3;
+    } else {
+      out.push(text[i]);
+      i++;
+    }
+  }
+  return out.join('');
+}
+
+/**
+ * Extract markdown table blocks (pipe rows + an alignment separator row).
+ * Slack has no table rendering — the whole block becomes a fenced code block
+ * so columns keep their monospace alignment.
+ */
+function extractTables(text: string, table: string[]): string {
+  const lines = text.split('\n');
+  const isRow = (s: string) => /^\s*\|.{1,2000}\|\s*$/.test(s);
+  const isSep = (s: string) => /^\s*\|[\s\-:|]{1,2000}\|\s*$/.test(s);
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (isRow(lines[i])) {
+      const block: string[] = [];
+      let hasSep = false;
+      let j = i;
+      while (j < lines.length && isRow(lines[j])) {
+        if (isSep(lines[j])) {
+          hasSep = true;
+        } else {
+          block.push(lines[j]);
+        }
+        j++;
+      }
+      if (hasSep && block.length > 0) {
+        const escaped = block.map(escapeMrkdwn).join('\n');
+        const idx = table.length;
+        table.push('```' + '\n' + escaped + '\n' + '```');
+        out.push(makeSentinel(KIND_TABLE, idx));
+        i = j;
+        continue;
+      }
+    }
+    out.push(lines[i]);
+    i++;
+  }
+  return out.join('\n');
+}
+
+/** Extract inline code spans (`x`). Non-greedy, newline-bounded. */
+function extractInlineCode(text: string, code: string[]): string {
+  return text.replace(/`([^`\n]{1,500})`/g, (_m, inner: string) => {
+    const idx = code.length;
+    code.push('`' + escapeMrkdwn(inner) + '`');
+    return makeSentinel(KIND_CODE, idx);
+  });
+}
+
+// ─── Blockquotes ────────────────────────────────────────────────────────────
+
+/**
+ * Restore blockquote markers that the prose escape turned into `&gt;`.
+ * Runs AFTER escapeMrkdwn: a leading run of `&gt;` on a line was a GFM quote
+ * marker — Slack needs the literal `>` there to render the quote bar.
+ */
+function restoreBlockquotes(text: string): string {
+  return text.replace(/^((?:&gt;\s?)+)/gm, (run) => run.replace(/&gt;/g, '>'));
+}
+
+// ─── Emphasis / headings / bullets / rules / links ──────────────────────────
+
+/**
+ * Tight italic boundary — same rule as the Telegram formatter: requires a
+ * word-boundary-like context on both sides so `3*5`, `f(x) = x * y`, `a*b*c`
+ * are untouched. Bounded quantifier (ReDoS defense).
+ */
+const TIGHT_ITALIC = /(^|[\s(,.;:!?])\*(?!\s)([^*\n]{1,200}?)(?<!\s)\*(?=$|[\s),.;:!?])/g;
+
+/**
+ * Order is load-bearing (the mrkdwn output alphabet overlaps the GFM input
+ * alphabet, unlike Telegram HTML):
+ *   1. tight italic *x* → _x_ FIRST — it cannot match `**`/`***` runs (its
+ *      content class excludes '*'), and running it first means it can never
+ *      re-match the single-asterisk output of the bold conversions.
+ *   2. bold-italic / bold / __bold__ are then emitted as RAW sentinels so no
+ *      later pass (or a second formatter application) can re-interpret them.
+ *      Because RAW content is spliced verbatim, links INSIDE the emphasis
+ *      (`**see [docs](url)**`) are converted at emission time — the main
+ *      convertLinks pass never sees RAW content. (The Telegram formatter keeps
+ *      emphasis output inline so its later link pass covers this case; the
+ *      sentinel approach must do it here instead.)
+ *   3. strikethrough last (its alphabet '~' is disjoint).
+ */
+function applyEmphasis(text: string, raw: string[]): string {
+  const emitRaw = (mrkdwn: string): string => {
+    const idx = raw.length;
+    raw.push(mrkdwn);
+    return makeSentinel(KIND_RAW, idx);
+  };
+  // 1. Tight italic (asterisk form). Underscore italic `_x_` is already valid
+  //    mrkdwn and passes through untouched. Italic output stays INLINE, so
+  //    links inside italic are handled by the main convertLinks pass.
+  text = text.replace(TIGHT_ITALIC, (_m, lead: string, inner: string) => `${lead}_${inner}_`);
+  // 2a. Bold-italic (triple asterisk).
+  text = text.replace(/\*\*\*([^*\n]{1,200}?)\*\*\*/g, (_m, inner: string) =>
+    emitRaw(`*_${convertLinks(inner)}_*`));
+  // 2b. Bold (double asterisk).
+  text = text.replace(/\*\*([^*\n]{1,200}?)\*\*/g, (_m, inner: string) =>
+    emitRaw(`*${convertLinks(inner)}*`));
+  // 2c. Bold (double underscore — GFM strong). Word-boundary constrained:
+  //     GFM underscore emphasis never applies intraword (`my__var__name`).
+  text = text.replace(
+    /(^|[\s(,.;:!?])__(?!\s)([^_\n]{1,200}?)(?<!\s)__(?=$|[\s),.;:!?])/gm,
+    (_m, lead: string, inner: string) => `${lead}${emitRaw(`*${convertLinks(inner)}*`)}`,
+  );
+  // 3. Strikethrough.
+  text = text.replace(/~~([^~\n]{1,200}?)~~/g, '~$1~');
+  return text;
+}
+
+/**
+ * Headings → one bold line (Slack has no headings). Any emphasis markers the
+ * earlier passes left INSIDE the title (as RAW sentinels) splice back inside
+ * the bold wrapper — mrkdwn tolerates `*a *b* c*` poorly, so we strip nested
+ * bold sentinels back to their inner text via the raw store when the whole
+ * title is a single RAW bold; otherwise we wrap as-is (best-effort, same
+ * spirit as the Telegram formatter's <b> wrap).
+ */
+function applyHeadings(text: string, raw: string[]): string {
+  // Whitespace classes are [ \t] (never \s): a trailing \s* would swallow the
+  // newline AND the blank line after the heading under the /m flag.
+  return text.replace(/^(#{1,6})[ \t]+(.{1,2000}?)[ \t]*#*[ \t]*$/gm, (_m, _h: string, title: string) => {
+    // If the entire title is exactly one RAW sentinel (e.g. `# **Bold**`),
+    // unwrap it so we don't emit nested bold markers.
+    const soleRaw = title.match(/^\u{10FFFD}([\u{100000}-\u{10FFFC}])\u{10FFFD}$/u);
+    if (soleRaw) {
+      const dec = decodeSentinelCodepoint(soleRaw[1].codePointAt(0)!);
+      if (dec && dec.kind === KIND_RAW) {
+        const inner = raw[dec.n] ?? '';
+        // raw entries for bold are `*…*` already — reuse verbatim.
+        if (inner.startsWith('*') && inner.endsWith('*')) return inner;
+      }
+    }
+    const idx = raw.length;
+    // Heading titles become RAW (spliced verbatim), so links inside a heading
+    // (`# See [docs](url)`) must be converted here — the main convertLinks
+    // pass never sees RAW content.
+    raw.push(`*${convertLinks(title)}*`);
+    return makeSentinel(KIND_RAW, idx);
+  });
+}
+
+/** Bullets → • (indent preserved). Numbered lists pass through as-is. */
+function applyBullets(text: string): string {
+  return text.replace(/^(\s{0,20})[-*+]\s+/gm, '$1• ');
+}
+
+/** Horizontal rules → a light box-drawing line (Slack has no <hr>). */
+function applyHorizontalRules(text: string): string {
+  return text.replace(/^\s{0,3}(?:-{3,}|\*{3,}|_{3,})\s*$/gm, '──────────');
+}
+
+/**
+ * `[text](url)` → `<url|text>` with a balanced-paren URL scanner (Wikipedia
+ * URLs with parens parse correctly). Runs on post-escape text, so the URL's
+ * `&` is already `&amp;` — exactly what Slack's link syntax requires. A `|`
+ * inside the URL is %-encoded (it would terminate the link); unsafe schemes
+ * leave the whole construct as literal text.
+ */
+function convertLinks(text: string): string {
+  const out: string[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch !== '[') {
+      out.push(ch);
+      i++;
+      continue;
+    }
+    // Find matching ] on the same line, bounded length.
+    let j = i + 1;
+    let foundClose = -1;
+    const maxTextEnd = Math.min(text.length, i + 1 + 500);
+    while (j < maxTextEnd) {
+      const c = text[j];
+      if (c === '\n') break;
+      if (c === ']') {
+        foundClose = j;
+        break;
+      }
+      j++;
+    }
+    if (foundClose === -1 || text[foundClose + 1] !== '(') {
+      out.push(ch);
+      i++;
+      continue;
+    }
+    const visibleText = text.slice(i + 1, foundClose);
+    // Walk the URL with paren balance.
+    let k = foundClose + 2;
+    let depth = 1;
+    const urlStart = k;
+    const scanEnd = Math.min(text.length, urlStart + URL_SCAN_MAX);
+    let urlEnd = -1;
+    while (k < scanEnd) {
+      const c = text[k];
+      if (c === '\n') break;
+      if (c === '\\' && k + 1 < scanEnd) {
+        k += 2;
+        continue;
+      }
+      if (c === '(') depth++;
+      else if (c === ')') {
+        depth--;
+        if (depth === 0) {
+          urlEnd = k;
+          break;
+        }
+      }
+      k++;
+    }
+    if (urlEnd === -1) {
+      out.push(text.slice(i, foundClose + 2));
+      i = foundClose + 2;
+      continue;
+    }
+    const rawUrl = text.slice(urlStart, urlEnd);
+    const safeUrl = isSafeUrl(rawUrl);
+    if (safeUrl === null) {
+      out.push(text.slice(i, urlEnd + 1));
+      i = urlEnd + 1;
+      continue;
+    }
+    out.push(`<${safeUrl.replace(/\|/g, '%7C')}|${visibleText}>`);
+    i = urlEnd + 1;
+  }
+  return out.join('');
+}
+
+// ─── Splice ─────────────────────────────────────────────────────────────────
+
+function splicePlaceholders(text: string, seg: Segments): string {
+  const re = /\u{10FFFD}([\u{100000}-\u{10FFFC}])\u{10FFFD}/gu;
+  // RAW entries may reference other sentinels (a heading wrapping a bold);
+  // splice repeatedly until stable (bounded — nesting depth is tiny).
+  for (let pass = 0; pass < 4; pass++) {
+    if (!re.test(text)) break;
+    re.lastIndex = 0;
+    text = text.replace(re, (_m, ch: string) => {
+      const cp = ch.codePointAt(0)!;
+      const dec = decodeSentinelCodepoint(cp);
+      if (!dec) return '';
+      if (dec.kind === KIND_PRE) return seg.pre[dec.n] ?? '';
+      if (dec.kind === KIND_TABLE) return seg.table[dec.n] ?? '';
+      if (dec.kind === KIND_CODE) return seg.code[dec.n] ?? '';
+      if (dec.kind === KIND_RAW) return seg.raw[dec.n] ?? '';
+      return '';
+    });
+    re.lastIndex = 0;
+  }
+  return text;
+}
+
+// ─── Main entry ─────────────────────────────────────────────────────────────
+
+function convertMarkdownToMrkdwn(text: string): string {
+  const seg: Segments = { pre: [], table: [], code: [], raw: [] };
+
+  // 1. Extract literal segments (never re-processed → no double-escaping).
+  text = extractFencedCode(text, seg.pre);
+  text = extractTables(text, seg.table);
+  text = extractInlineCode(text, seg.code);
+  // 2. Escape remaining prose ONCE (&, <, > — Slack's three specials).
+  text = escapeMrkdwn(text);
+  // 3. Restore blockquote markers the escape consumed.
+  text = restoreBlockquotes(text);
+  // 4. Emphasis (italic → bold family → strike; see order note).
+  text = applyEmphasis(text, seg.raw);
+  // 5. Headings → bold line.
+  text = applyHeadings(text, seg.raw);
+  // 6. Horizontal rules (before bullets: a `***` rule must not become `• `).
+  text = applyHorizontalRules(text);
+  // 7. Bullets → •.
+  text = applyBullets(text);
+  // 8. Links → <url|text>.
+  text = convertLinks(text);
+  // 9. Splice literal segments back.
+  return splicePlaceholders(text, seg);
+}
+
+/**
+ * Format text for a Slack send.
+ *
+ * `'mrkdwn'` (default): convert GFM → mrkdwn per the contract above.
+ * `'legacy-passthrough'`: byte-for-byte unchanged — the rollback mode AND the
+ * per-call opt-out for callers that already author mrkdwn.
+ */
+export function formatForSlack(
+  text: string,
+  mode: SlackFormatMode = 'mrkdwn',
+): SlackFormatResult {
+  if (mode === 'legacy-passthrough') {
+    return {
+      text,
+      modeApplied: 'legacy-passthrough',
+      conversionSkipped: false,
+      legacyPassthrough: true,
+    };
+  }
+
+  // Step 0: strip NUL, then PUA-B (sentinel-collision defense).
+  let working = stripNul(text);
+  working = stripPuaB(working);
+
+  // ReDoS guard: oversized input skips conversion (raw bytes preserved —
+  // exactly today's pre-formatter behavior).
+  if (working.length > MAX_INPUT_LENGTH) {
+    return {
+      text,
+      modeApplied: 'mrkdwn',
+      conversionSkipped: true,
+      legacyPassthrough: false,
+    };
+  }
+
+  return {
+    text: convertMarkdownToMrkdwn(working),
+    modeApplied: 'mrkdwn',
+    conversionSkipped: false,
+    legacyPassthrough: false,
+  };
+}
+
+// ─── Wire-up helper (the single outbound chokepoint contract) ───────────────
+
+/** Slack Web API methods whose `text` is a user-visible message body. */
+const SEND_METHODS = new Set(['chat.postMessage', 'chat.update', 'chat.postEphemeral']);
+
+/**
+ * Shared formatter wire-up used by SlackAdapter.formattedApiCall — the Slack
+ * sibling of applyTelegramFormatter. Pure function for testability.
+ *
+ * - Non-send methods pass through unchanged.
+ * - `params._formatMode` is the per-call override (stripped before the HTTP
+ *   call): `'legacy-passthrough'` = "my bytes are already mrkdwn, don't touch".
+ * - Block Kit sends (`params.blocks`) pass through — blocks are authored
+ *   deliberately; `text` is only the notification fallback.
+ * - `params.mrkdwn === false` passes through — the caller asked Slack for
+ *   plain text; converting would be nonsense.
+ * - Mode resolution: per-call → config → `'mrkdwn'` (default ON, post-cutover;
+ *   rollback via `formatMode: 'legacy-passthrough'` in the slack messaging
+ *   config block).
+ */
+export function applySlackFormatter(
+  method: string,
+  params: Record<string, unknown>,
+  configMode: SlackFormatMode | undefined,
+): {
+  outgoingParams: Record<string, unknown>;
+  didFormat: boolean;
+} {
+  const callerMode = (params as { _formatMode?: SlackFormatMode })._formatMode;
+  // Strip internal flags before sending to the Slack API.
+  const stripped: Record<string, unknown> = { ...params };
+  delete (stripped as { _formatMode?: SlackFormatMode })._formatMode;
+
+  const mode: SlackFormatMode = callerMode ?? configMode ?? 'mrkdwn';
+
+  if (
+    !SEND_METHODS.has(method) ||
+    mode === 'legacy-passthrough' ||
+    typeof stripped.text !== 'string' ||
+    stripped.blocks !== undefined ||
+    stripped.mrkdwn === false
+  ) {
+    return { outgoingParams: stripped, didFormat: false };
+  }
+
+  const result = formatForSlack(stripped.text, mode);
+  return {
+    outgoingParams: { ...stripped, text: result.text },
+    didFormat: !result.legacyPassthrough && !result.conversionSkipped,
+  };
+}

--- a/src/messaging/slack/index.ts
+++ b/src/messaging/slack/index.ts
@@ -10,6 +10,12 @@ export { FileHandler } from './FileHandler.js';
 export { RingBuffer } from './RingBuffer.js';
 export type { SlackConfig, SlackMessage, SlackUser, SlackChannel } from './types.js';
 export * from './sanitize.js';
+export {
+  formatForSlack,
+  applySlackFormatter,
+  MAX_INPUT_LENGTH as SLACK_FORMATTER_MAX_INPUT_LENGTH,
+} from './SlackMrkdwnFormatter.js';
+export type { SlackFormatMode, SlackFormatResult } from './SlackMrkdwnFormatter.js';
 
 // Register with the adapter registry at module load time
 import { registerAdapter } from '../AdapterRegistry.js';

--- a/src/messaging/slack/types.ts
+++ b/src/messaging/slack/types.ts
@@ -50,6 +50,17 @@ export interface SlackConfig {
    * DMs always use "all" mode regardless of this setting.
    */
   respondMode?: SlackRespondMode;
+  /**
+   * Outbound GFM→mrkdwn formatter mode (roadmap 0.1). Default `'mrkdwn'` —
+   * agent-authored GitHub-flavored markdown is converted to native Slack
+   * mrkdwn at the outbound chokepoint (so `**bold**` renders bold instead of
+   * as literal asterisks). Flip to `'legacy-passthrough'` for byte-for-byte
+   * pre-formatter behavior (the rollback lever, mirroring
+   * `telegramFormatMode`). Callers that already author mrkdwn opt out
+   * per-call via `sendToChannel(..., { formatMode: 'legacy-passthrough' })`.
+   * See src/messaging/slack/SlackMrkdwnFormatter.ts.
+   */
+  formatMode?: 'mrkdwn' | 'legacy-passthrough';
   /** Audio file transcription provider */
   audioTranscriptionProvider?: 'groq' | 'openai';
   /** Stall detection timeout in minutes (default: 5) */

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -12186,7 +12186,15 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       return;
 
     try {
-      const ts = await ctx.slack.sendToChannel(channelId, text, { thread_ts });
+      // Per-call formatter opt-out (roadmap 0.1): a caller that already
+      // authors Slack mrkdwn passes metadata.formatMode 'legacy-passthrough'
+      // so the GFM->mrkdwn converter does not re-process its bytes.
+      const requestedFormatMode = metadata?.formatMode;
+      const formatMode =
+        requestedFormatMode === 'legacy-passthrough' || requestedFormatMode === 'mrkdwn'
+          ? requestedFormatMode
+          : undefined;
+      const ts = await ctx.slack.sendToChannel(channelId, text, { thread_ts, formatMode });
 
       // Notify onMessageLogged that the agent responded (so PresenceProxy cancels standby)
       if (ctx.slack.onMessageLogged) {

--- a/tests/integration/slack-mrkdwn-reply-route.test.ts
+++ b/tests/integration/slack-mrkdwn-reply-route.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration: POST /slack/reply/:channelId applies the GFM→mrkdwn formatter
+ * at the outbound funnel (roadmap 0.1).
+ *
+ * Mounts the real Express router with a real SlackAdapter (Socket Mode never
+ * started; the API transport is stubbed BELOW the formatting funnel so no
+ * network call happens). Verifies the full HTTP pipeline:
+ *   - a GFM reply is converted to mrkdwn by the time it reaches the Slack API
+ *   - metadata.formatMode 'legacy-passthrough' opts a single call out
+ *   - the config rollback ('legacy-passthrough') restores byte-for-byte sends
+ *   - /internal/slack-forward rides the same funnel
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { SlackAdapter } from '../../src/messaging/slack/SlackAdapter.js';
+import type { SlackConfig } from '../../src/messaging/slack/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let tmp: string | null = null;
+
+const CH = 'C_MAIN';
+
+function makeSlack(stateDir: string, configOverrides: Partial<SlackConfig> = {}) {
+  const posted: Array<{ method: string; params: Record<string, unknown> }> = [];
+
+  const adapter = new SlackAdapter(
+    {
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      authorizedUserIds: ['U_TEST'],
+      workspaceMode: 'dedicated',
+      ...configOverrides,
+    } as SlackConfig,
+    stateDir,
+  );
+
+  // Stub the transport UNDER the formatter funnel — capture what would hit
+  // the Slack Web API; the formatting chokepoint itself is production code.
+  (adapter as unknown as { apiClient: unknown }).apiClient = {
+    call: async (method: string, params: Record<string, unknown>) => {
+      posted.push({ method, params });
+      return { ok: true, ts: '1700000001.000001' };
+    },
+  };
+
+  return { adapter, posted };
+}
+
+function appWith(slack: SlackAdapter, stateDir: string): express.Express {
+  const ctx = {
+    config: { projectName: 'test', projectDir: '/tmp', stateDir, port: 0, users: [], sessions: {} as unknown, scheduler: {} as unknown },
+    sessionManager: { listRunningSessions: () => [] },
+    state: { getJobState: () => null, getSession: () => null },
+    scheduler: null, telegram: null, slack, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, discoveryEvaluator: null,
+    tokenLedger: null, featureMetricsLedger: null, resourceLedger: null,
+    messagingToneGate: null, // tone gate not configured → checkOutboundMessage passes through
+    startTime: new Date(),
+  } as unknown as RouteContext;
+
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+afterEach(() => {
+  if (tmp) {
+    SafeFsExecutor.safeRmSync(tmp, {
+      recursive: true,
+      force: true,
+      operation: 'tests/integration/slack-mrkdwn-reply-route.test.ts',
+    });
+    tmp = null;
+  }
+});
+
+describe('POST /slack/reply/:channelId — GFM→mrkdwn funnel (integration)', () => {
+  it('converts a GFM reply to mrkdwn at the Slack API boundary', async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-mrkdwn-reply-'));
+    const { adapter, posted } = makeSlack(tmp);
+    const app = appWith(adapter, tmp);
+
+    const res = await request(app)
+      .post(`/slack/reply/${CH}`)
+      .send({ text: '**Done** — see [the PR](https://github.com/x/y/pull/1).\n\n- tests green' });
+
+    expect(res.status).toBe(200);
+    expect(posted.length).toBe(1);
+    expect(posted[0].method).toBe('chat.postMessage');
+    expect(posted[0].params.text).toBe(
+      '*Done* — see <https://github.com/x/y/pull/1|the PR>.\n\n• tests green',
+    );
+  });
+
+  it('metadata.formatMode legacy-passthrough opts a single reply out (already-mrkdwn caller)', async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-mrkdwn-reply-'));
+    const { adapter, posted } = makeSlack(tmp);
+    const app = appWith(adapter, tmp);
+
+    const mrkdwn = '*already mrkdwn* with <https://x.co|a link>';
+    const res = await request(app)
+      .post(`/slack/reply/${CH}`)
+      .send({ text: mrkdwn, metadata: { formatMode: 'legacy-passthrough' } });
+
+    expect(res.status).toBe(200);
+    expect(posted[0].params.text).toBe(mrkdwn);
+    expect('_formatMode' in posted[0].params).toBe(false);
+  });
+
+  it('an invalid metadata.formatMode is ignored (default conversion applies)', async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-mrkdwn-reply-'));
+    const { adapter, posted } = makeSlack(tmp);
+    const app = appWith(adapter, tmp);
+
+    const res = await request(app)
+      .post(`/slack/reply/${CH}`)
+      .send({ text: '**b**', metadata: { formatMode: 'nonsense' } });
+
+    expect(res.status).toBe(200);
+    expect(posted[0].params.text).toBe('*b*');
+  });
+
+  it("config rollback formatMode:'legacy-passthrough' restores byte-for-byte replies", async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-mrkdwn-reply-'));
+    const { adapter, posted } = makeSlack(tmp, { formatMode: 'legacy-passthrough' });
+    const app = appWith(adapter, tmp);
+
+    const raw = '**untouched** & <raw>';
+    const res = await request(app).post(`/slack/reply/${CH}`).send({ text: raw });
+
+    expect(res.status).toBe(200);
+    expect(posted[0].params.text).toBe(raw);
+  });
+
+  it('threaded replies format AND keep their thread_ts', async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-mrkdwn-reply-'));
+    const { adapter, posted } = makeSlack(tmp);
+    const app = appWith(adapter, tmp);
+
+    const res = await request(app)
+      .post(`/slack/reply/${CH}`)
+      .send({ text: '**in thread**', thread_ts: '1700000000.000100' });
+
+    expect(res.status).toBe(200);
+    expect(posted[0].params.thread_ts).toBe('1700000000.000100');
+    expect(posted[0].params.text).toBe('*in thread*');
+  });
+
+  it('/internal/slack-forward rides the same funnel', async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-mrkdwn-reply-'));
+    const { adapter, posted } = makeSlack(tmp);
+    const app = appWith(adapter, tmp);
+
+    const res = await request(app)
+      .post('/internal/slack-forward')
+      .send({ channelId: CH, text: '# Replayed\n**bold**' });
+
+    expect(res.status).toBe(200);
+    expect(posted[0].params.text).toBe('*Replayed*\n*bold*');
+  });
+});

--- a/tests/unit/slack-mrkdwn-formatter.test.ts
+++ b/tests/unit/slack-mrkdwn-formatter.test.ts
@@ -1,0 +1,395 @@
+/**
+ * SlackMrkdwnFormatter unit tests (roadmap 0.1).
+ *
+ * Covers every conversion case in the module contract (bold / italic /
+ * bold-italic / strike / inline + fenced code / links / lists / quotes /
+ * headings / tables / horizontal rules / emoji), mixed documents, the
+ * escaping rules (&, <, > escaped exactly once; code segments never
+ * re-processed), the legacy-passthrough rollback + per-call opt-out, and the
+ * applySlackFormatter wire-up helper's skip rules.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  formatForSlack,
+  applySlackFormatter,
+  MAX_INPUT_LENGTH,
+  type SlackFormatMode,
+} from '../../src/messaging/slack/SlackMrkdwnFormatter.js';
+
+const fmt = (text: string, mode: SlackFormatMode = 'mrkdwn') =>
+  formatForSlack(text, mode).text;
+
+describe('formatForSlack — emphasis', () => {
+  it('converts **bold** to *bold*', () => {
+    expect(fmt('this is **bold** text')).toBe('this is *bold* text');
+  });
+
+  it('converts __bold__ to *bold*', () => {
+    expect(fmt('this is __bold__ text')).toBe('this is *bold* text');
+  });
+
+  it('does NOT convert intraword double underscores (snake_case identifiers)', () => {
+    expect(fmt('the my__var__name identifier')).toBe('the my__var__name identifier');
+  });
+
+  it('converts *italic* to _italic_', () => {
+    expect(fmt('this is *italic* text')).toBe('this is _italic_ text');
+  });
+
+  it('leaves _italic_ as _italic_ (already mrkdwn)', () => {
+    expect(fmt('this is _italic_ text')).toBe('this is _italic_ text');
+  });
+
+  it('converts ***bold italic*** to *_bold italic_*', () => {
+    expect(fmt('a ***both*** b')).toBe('a *_both_* b');
+  });
+
+  it('converts ~~strike~~ to ~strike~', () => {
+    expect(fmt('a ~~gone~~ b')).toBe('a ~gone~ b');
+  });
+
+  it('bold output is NOT re-eaten by the italic pass (order regression guard)', () => {
+    // If bold ran before italic without protection, *bold* would become _bold_.
+    expect(fmt('**bold** and *it*')).toBe('*bold* and _it_');
+  });
+
+  it('leaves math/glob asterisks untouched (tight italic boundary)', () => {
+    expect(fmt('3*5 and f(x) = x * y and a*b*c')).toBe('3*5 and f(x) = x * y and a*b*c');
+  });
+
+  it('supports underscore italic nested inside bold', () => {
+    expect(fmt('**a _b_ c**')).toBe('*a _b_ c*');
+  });
+});
+
+describe('formatForSlack — code', () => {
+  it('passes inline code through as mrkdwn inline code', () => {
+    expect(fmt('run `pnpm build` now')).toBe('run `pnpm build` now');
+  });
+
+  it('does not convert markdown inside inline code', () => {
+    expect(fmt('literal `**not bold**` here')).toBe('literal `**not bold**` here');
+  });
+
+  it('preserves fenced blocks and drops the language tag', () => {
+    expect(fmt('```ts\nconst a = 1;\n```')).toBe('```\nconst a = 1;\n```');
+  });
+
+  it('does not convert markdown inside fenced blocks', () => {
+    expect(fmt('```\n**raw** and [x](y)\n```')).toBe('```\n**raw** and [x](y)\n```');
+  });
+
+  it('escapes &, <, > inside code segments exactly once', () => {
+    expect(fmt('`a < b && c > d`')).toBe('`a &lt; b &amp;&amp; c &gt; d`');
+    expect(fmt('```\nList<Map<K, V>>\n```')).toBe('```\nList&lt;Map&lt;K, V&gt;&gt;\n```');
+  });
+
+  it('emits unclosed fences as literal backticks', () => {
+    expect(fmt('```\nunterminated')).toBe('```\nunterminated');
+  });
+
+  it('degrades gracefully on nested code fences (4-backtick outer), never crashing', () => {
+    // GFM 4-backtick outer fences are out of contract (parity with the
+    // Telegram formatter's scanner): the first ``` pair wins. Pinned so the
+    // degradation stays graceful — content preserved, no markdown leakage.
+    expect(fmt('````\ncode with ``` inside\n````')).toBe(
+      '```\ncode with \n``` inside\n````',
+    );
+  });
+
+  it('equal-fence nesting closes at the first fence; trailing fence stays literal', () => {
+    expect(fmt('```\na **not bold** b\n```\ntail\n```')).toBe(
+      '```\na **not bold** b\n```\ntail\n```',
+    );
+  });
+});
+
+describe('formatForSlack — escaping (Slack specials)', () => {
+  it('escapes &, <, > in prose', () => {
+    expect(fmt('salt & pepper, a < b, c > d')).toBe(
+      'salt &amp; pepper, a &lt; b, c &gt; d',
+    );
+  });
+
+  it('never double-escapes: one pass over prose, code extracted first', () => {
+    const out = fmt('a & b `c & d`');
+    expect(out).toBe('a &amp; b `c &amp; d`');
+    expect(out).not.toContain('&amp;amp;');
+  });
+
+  it('escapes raw angle-bracket sequences so Slack cannot parse them as entities', () => {
+    // A raw <@U123> in agent GFM output is DATA, not a mention.
+    expect(fmt('mention syntax is <@U123>')).toBe('mention syntax is &lt;@U123&gt;');
+  });
+});
+
+describe('formatForSlack — links', () => {
+  it('converts [text](url) to <url|text>', () => {
+    expect(fmt('see [the docs](https://example.com/a)')).toBe(
+      'see <https://example.com/a|the docs>',
+    );
+  });
+
+  it('handles Wikipedia-style balanced parens in URLs', () => {
+    expect(fmt('[entity](https://en.wikipedia.org/wiki/Entity_(computer_science))')).toBe(
+      '<https://en.wikipedia.org/wiki/Entity_(computer_science)|entity>',
+    );
+  });
+
+  it('escapes & in the URL (post-escape URL is what Slack link syntax wants)', () => {
+    expect(fmt('[q](https://example.com/?a=1&b=2)')).toBe(
+      '<https://example.com/?a=1&amp;b=2|q>',
+    );
+  });
+
+  it('percent-encodes | in the URL (it would terminate the link)', () => {
+    expect(fmt('[x](https://example.com/a|b)')).toBe('<https://example.com/a%7Cb|x>');
+  });
+
+  it('refuses unsafe schemes and leaves the construct literal', () => {
+    // eslint-disable-next-line no-script-url
+    const out = fmt('[click](javascript:alert(1))');
+    expect(out).not.toContain('<javascript:');
+    expect(out).toContain('[click](javascript:alert(1))');
+  });
+
+  it('allows mailto links', () => {
+    expect(fmt('[mail me](mailto:a@b.co)')).toBe('<mailto:a@b.co|mail me>');
+  });
+
+  it('converts links inside **bold** (RAW-sentinel content is link-converted at emission)', () => {
+    expect(fmt('**see [docs](https://x.co) now**')).toBe('*see <https://x.co|docs> now*');
+  });
+
+  it('converts links inside ***bold-italic*** and __bold__', () => {
+    expect(fmt('***see [d](https://x.co)***')).toBe('*_see <https://x.co|d>_*');
+    expect(fmt('__see [d](https://x.co)__')).toBe('*see <https://x.co|d>*');
+  });
+
+  it('converts links inside *italic* (inline path through the main link pass)', () => {
+    expect(fmt('read *the [guide](https://x.co) first* ok')).toBe(
+      'read _the <https://x.co|guide> first_ ok',
+    );
+  });
+
+  it('converts links inside headings', () => {
+    expect(fmt('# See [docs](https://x.co)')).toBe('*See <https://x.co|docs>*');
+  });
+
+  it('leaves an unsafe-scheme link inside bold literal (same rule as prose)', () => {
+    // eslint-disable-next-line no-script-url
+    expect(fmt('**[x](javascript:alert(1))**')).toBe('*[x](javascript:alert(1))*');
+  });
+
+  it('leaves bare URLs untouched (Slack auto-links them); only & is entity-escaped', () => {
+    expect(fmt('visit https://example.com/path now')).toBe('visit https://example.com/path now');
+    // Slack decodes &amp; back to & everywhere, so the link target is preserved.
+    expect(fmt('see https://x.co/?a=1&b=2')).toBe('see https://x.co/?a=1&amp;b=2');
+  });
+
+  it('does not italicize/bold inside bare URLs with underscores', () => {
+    expect(fmt('https://en.wikipedia.org/wiki/Snake_case and https://x.co/__init__/done')).toBe(
+      'https://en.wikipedia.org/wiki/Snake_case and https://x.co/__init__/done',
+    );
+  });
+});
+
+describe('formatForSlack — block structure', () => {
+  it('converts headings to bold lines', () => {
+    expect(fmt('# Title')).toBe('*Title*');
+    expect(fmt('## Sub')).toBe('*Sub*');
+    expect(fmt('### Deep')).toBe('*Deep*');
+  });
+
+  it('does not double-wrap a fully-bold heading', () => {
+    expect(fmt('# **Bold title**')).toBe('*Bold title*');
+  });
+
+  it('converts dash/star/plus bullets to •, preserving indent', () => {
+    expect(fmt('- one\n* two\n+ three\n  - nested')).toBe(
+      '• one\n• two\n• three\n  • nested',
+    );
+  });
+
+  it('passes numbered lists through as-is', () => {
+    expect(fmt('1. first\n2. second')).toBe('1. first\n2. second');
+  });
+
+  it('preserves > blockquotes (marker survives the escape pass)', () => {
+    expect(fmt('> quoted line')).toBe('> quoted line');
+    expect(fmt('> multi\n> line')).toBe('> multi\n> line');
+  });
+
+  it('escapes a mid-line > normally (only line-leading markers are quotes)', () => {
+    expect(fmt('a -> b')).toBe('a -&gt; b');
+  });
+
+  it('renders tables as fenced code blocks', () => {
+    const table = '| a | b |\n|---|---|\n| 1 | 2 |';
+    expect(fmt(table)).toBe('```\n| a | b |\n| 1 | 2 |\n```');
+  });
+
+  it('converts horizontal rules to a rule line', () => {
+    expect(fmt('above\n---\nbelow')).toBe('above\n──────────\nbelow');
+    expect(fmt('above\n***\nbelow')).toBe('above\n──────────\nbelow');
+    expect(fmt('above\n___\nbelow')).toBe('above\n──────────\nbelow');
+  });
+});
+
+describe('formatForSlack — emoji and shortcodes', () => {
+  it('leaves unicode emoji untouched', () => {
+    expect(fmt('done ✅ ship 🚀')).toBe('done ✅ ship 🚀');
+  });
+
+  it('leaves :shortcodes: untouched', () => {
+    expect(fmt('nice :tada: work :+1:')).toBe('nice :tada: work :+1:');
+  });
+});
+
+describe('formatForSlack — mixed documents', () => {
+  it('converts a realistic agent reply end-to-end', () => {
+    const input = [
+      '# Status update',
+      '',
+      'The build is **green** — see [CI](https://ci.example.com/run?id=1&x=2).',
+      '',
+      '- fixed the *flaky* test',
+      '- bumped `vitest` to 2.x',
+      '',
+      '```bash',
+      'pnpm test && echo "ok"',
+      '```',
+      '',
+      '> Zero-Failure standard upheld.',
+    ].join('\n');
+    const expected = [
+      '*Status update*',
+      '',
+      'The build is *green* — see <https://ci.example.com/run?id=1&amp;x=2|CI>.',
+      '',
+      '• fixed the _flaky_ test',
+      '• bumped `vitest` to 2.x',
+      '',
+      '```',
+      'pnpm test &amp;&amp; echo "ok"',
+      '```',
+      '',
+      '> Zero-Failure standard upheld.',
+    ].join('\n');
+    expect(fmt(input)).toBe(expected);
+  });
+
+  it('handles a table plus prose plus emphasis together', () => {
+    const input = 'Summary **matters**\n\n| k | v |\n|---|---|\n| a | 1 |\n\ntail';
+    expect(fmt(input)).toBe('Summary *matters*\n\n```\n| k | v |\n| a | 1 |\n```\n\ntail');
+  });
+});
+
+describe('formatForSlack — modes and guards', () => {
+  it('legacy-passthrough is byte-for-byte (rollback + already-mrkdwn opt-out)', () => {
+    const already = '*bold mrkdwn* and <https://x.co|link> & raw';
+    const r = formatForSlack(already, 'legacy-passthrough');
+    expect(r.text).toBe(already);
+    expect(r.legacyPassthrough).toBe(true);
+    expect(r.modeApplied).toBe('legacy-passthrough');
+  });
+
+  it('idempotency via opt-out: formatting once then passing through changes nothing', () => {
+    const once = fmt('**bold** and *it* and [l](https://x.co)');
+    const twice = formatForSlack(once, 'legacy-passthrough').text;
+    expect(twice).toBe(once);
+  });
+
+  it('skips conversion above MAX_INPUT_LENGTH (ReDoS guard) and preserves bytes', () => {
+    const big = '**x** '.repeat(Math.ceil(MAX_INPUT_LENGTH / 6) + 10);
+    const r = formatForSlack(big, 'mrkdwn');
+    expect(r.conversionSkipped).toBe(true);
+    expect(r.text).toBe(big);
+  });
+
+  it('strips NUL bytes and PUA-B sentinels from input (collision defense)', () => {
+    const evil = 'a\x00b' + String.fromCodePoint(0x100001) + 'c';
+    expect(fmt(evil)).toBe('abc');
+  });
+});
+
+describe('applySlackFormatter — wire-up helper', () => {
+  it('formats chat.postMessage text with default mode (undefined config → mrkdwn ON)', () => {
+    const r = applySlackFormatter('chat.postMessage', { channel: 'C1', text: '**b**' }, undefined);
+    expect(r.didFormat).toBe(true);
+    expect(r.outgoingParams.text).toBe('*b*');
+  });
+
+  it('formats chat.update and chat.postEphemeral too', () => {
+    expect(
+      applySlackFormatter('chat.update', { channel: 'C1', ts: '1', text: '**b**' }, undefined)
+        .outgoingParams.text,
+    ).toBe('*b*');
+    expect(
+      applySlackFormatter('chat.postEphemeral', { channel: 'C1', user: 'U1', text: '**b**' }, undefined)
+        .outgoingParams.text,
+    ).toBe('*b*');
+  });
+
+  it('bypasses non-send methods', () => {
+    const r = applySlackFormatter('conversations.list', { types: 'public_channel' }, 'mrkdwn');
+    expect(r.didFormat).toBe(false);
+    expect(r.outgoingParams).toEqual({ types: 'public_channel' });
+  });
+
+  it('bypasses when config mode is legacy-passthrough (the rollback lever)', () => {
+    const r = applySlackFormatter(
+      'chat.postMessage',
+      { channel: 'C1', text: '**b**' },
+      'legacy-passthrough',
+    );
+    expect(r.didFormat).toBe(false);
+    expect(r.outgoingParams.text).toBe('**b**');
+  });
+
+  it('honors the per-call _formatMode opt-out and strips it from outgoing params', () => {
+    const r = applySlackFormatter(
+      'chat.postMessage',
+      { channel: 'C1', text: '*already mrkdwn*', _formatMode: 'legacy-passthrough' },
+      'mrkdwn',
+    );
+    expect(r.didFormat).toBe(false);
+    expect(r.outgoingParams.text).toBe('*already mrkdwn*');
+    expect('_formatMode' in r.outgoingParams).toBe(false);
+  });
+
+  it('per-call mode WINS over config rollback (explicit mrkdwn on a passthrough config)', () => {
+    const r = applySlackFormatter(
+      'chat.postMessage',
+      { channel: 'C1', text: '**b**', _formatMode: 'mrkdwn' },
+      'legacy-passthrough',
+    );
+    expect(r.didFormat).toBe(true);
+    expect(r.outgoingParams.text).toBe('*b*');
+  });
+
+  it('bypasses Block Kit sends (blocks are authored deliberately)', () => {
+    const r = applySlackFormatter(
+      'chat.postMessage',
+      { channel: 'C1', blocks: [{ type: 'section' }], text: '**fallback**' },
+      'mrkdwn',
+    );
+    expect(r.didFormat).toBe(false);
+    expect(r.outgoingParams.text).toBe('**fallback**');
+  });
+
+  it('bypasses mrkdwn:false sends (caller asked Slack for plain text)', () => {
+    const r = applySlackFormatter(
+      'chat.postMessage',
+      { channel: 'C1', text: '**b**', mrkdwn: false },
+      'mrkdwn',
+    );
+    expect(r.didFormat).toBe(false);
+    expect(r.outgoingParams.text).toBe('**b**');
+  });
+
+  it('bypasses when text is not a string', () => {
+    const r = applySlackFormatter('chat.postMessage', { channel: 'C1' }, 'mrkdwn');
+    expect(r.didFormat).toBe(false);
+  });
+});

--- a/tests/unit/slack-mrkdwn-wireup.test.ts
+++ b/tests/unit/slack-mrkdwn-wireup.test.ts
@@ -1,0 +1,134 @@
+/**
+ * SlackMrkdwnFormatter wire-up tests (roadmap 0.1) — wiring integrity.
+ *
+ * Verifies the REAL SlackAdapter delegates every user-visible outbound path
+ * (send / sendToChannel / updateMessage / postEphemeral) through the real
+ * formatter funnel (formattedApiCall → applySlackFormatter), that the config
+ * rollback ('legacy-passthrough') restores byte-for-byte behavior, that the
+ * per-call opt-out works end-to-end through sendToChannel's options, and that
+ * Block Kit sends are never touched.
+ *
+ * Mirrors tests/unit/telegram-format-wireup.test.ts: the API client transport
+ * is stubbed BELOW the funnel (capture params, no network), so what we assert
+ * is exactly what would hit the Slack Web API.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SlackAdapter } from '../../src/messaging/slack/SlackAdapter.js';
+import type { SlackConfig } from '../../src/messaging/slack/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let tmp: string | null = null;
+
+afterEach(() => {
+  if (tmp) {
+    SafeFsExecutor.safeRmSync(tmp, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/slack-mrkdwn-wireup.test.ts',
+    });
+    tmp = null;
+  }
+});
+
+function makeAdapter(configOverrides: Partial<SlackConfig> = {}) {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-mrkdwn-wireup-'));
+  const adapter = new SlackAdapter(
+    {
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      authorizedUserIds: ['U_TEST'],
+      workspaceMode: 'dedicated',
+      ...configOverrides,
+    } as SlackConfig,
+    tmp,
+  );
+  const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+  // Stub the transport UNDER the formatting funnel — the funnel itself
+  // (formattedApiCall → applySlackFormatter) is the real production code.
+  (adapter as unknown as { apiClient: unknown }).apiClient = {
+    call: async (method: string, params: Record<string, unknown>) => {
+      calls.push({ method, params });
+      return { ok: true, ts: '1700000001.000001' };
+    },
+  };
+  return { adapter, calls };
+}
+
+describe('SlackAdapter → formatter wiring integrity', () => {
+  it('sendToChannel delegates to the REAL formatter (GFM in, mrkdwn out at the API boundary)', async () => {
+    const { adapter, calls } = makeAdapter();
+    await adapter.sendToChannel('C123', '**bold** and [docs](https://example.com)');
+    expect(calls.length).toBe(1);
+    expect(calls[0].method).toBe('chat.postMessage');
+    // Real conversion happened — not a no-op, not a stub.
+    expect(calls[0].params.text).toBe('*bold* and <https://example.com|docs>');
+  });
+
+  it('send() (OutgoingMessage path) formats each chunk', async () => {
+    const { adapter, calls } = makeAdapter();
+    await adapter.send({
+      userId: 'U_TEST',
+      content: '# Update\n\n- **done**',
+      channel: { type: 'slack', identifier: 'C123' },
+    });
+    expect(calls.length).toBe(1);
+    expect(calls[0].params.text).toBe('*Update*\n\n• *done*');
+  });
+
+  it('updateMessage formats through the same funnel', async () => {
+    const { adapter, calls } = makeAdapter();
+    await adapter.updateMessage('C123', '1700000000.000001', '**edited**');
+    expect(calls[0].method).toBe('chat.update');
+    expect(calls[0].params.text).toBe('*edited*');
+  });
+
+  it('postEphemeral formats through the same funnel', async () => {
+    const { adapter, calls } = makeAdapter();
+    await adapter.postEphemeral('C123', 'U_TEST', '**private** note');
+    expect(calls[0].method).toBe('chat.postEphemeral');
+    expect(calls[0].params.text).toBe('*private* note');
+  });
+
+  it('sendBlocks passes Block Kit payloads through untouched', async () => {
+    const { adapter, calls } = makeAdapter();
+    const blocks = [{ type: 'section', text: { type: 'mrkdwn', text: '*authored*' } }];
+    await adapter.sendBlocks('C123', blocks, '**fallback**');
+    expect(calls[0].params.blocks).toEqual(blocks);
+    // Fallback text untouched — blocks callers author their payloads deliberately.
+    expect(calls[0].params.text).toBe('**fallback**');
+  });
+
+  it("config rollback formatMode:'legacy-passthrough' restores byte-for-byte sends", async () => {
+    const { adapter, calls } = makeAdapter({ formatMode: 'legacy-passthrough' });
+    const raw = '**untouched** [x](https://y.z) & <raw>';
+    await adapter.sendToChannel('C123', raw);
+    expect(calls[0].params.text).toBe(raw);
+  });
+
+  it('per-call opt-out via sendToChannel options wins over the default-ON config', async () => {
+    const { adapter, calls } = makeAdapter();
+    const mrkdwn = '*already mrkdwn* with <https://x.co|link>';
+    await adapter.sendToChannel('C123', mrkdwn, { formatMode: 'legacy-passthrough' });
+    expect(calls[0].params.text).toBe(mrkdwn);
+    // The internal flag never reaches the Slack API.
+    expect('_formatMode' in calls[0].params).toBe(false);
+  });
+
+  it('thread routing still works through the funnel (thread_ts preserved)', async () => {
+    const { adapter, calls } = makeAdapter();
+    await adapter.sendToChannel('C123', '**t**', { thread_ts: '1700000000.000100' });
+    expect(calls[0].params.thread_ts).toBe('1700000000.000100');
+    expect(calls[0].params.text).toBe('*t*');
+  });
+
+  it('routing-key sends (channel:thread) format AND thread correctly', async () => {
+    const { adapter, calls } = makeAdapter();
+    await adapter.sendToChannel('C123:1700000000.000200', '**via key**');
+    expect(calls[0].params.channel).toBe('C123');
+    expect(calls[0].params.thread_ts).toBe('1700000000.000200');
+    expect(calls[0].params.text).toBe('*via key*');
+  });
+});

--- a/upgrades/next/slack-mrkdwn-formatter.md
+++ b/upgrades/next/slack-mrkdwn-formatter.md
@@ -1,0 +1,64 @@
+# Slack replies render natively: GFM→mrkdwn formatter at the outbound funnel
+
+<!-- bump: patch -->
+
+## What Changed
+
+Roadmap 0.1. Agent-authored GitHub-flavored markdown sent to Slack used to
+arrive as raw bytes — `**bold**` rendered as literal asterisks, `[text](url)`
+as bracket soup, `# headings` as pound signs. Slack speaks its own dialect
+(mrkdwn: `*bold*`, `<url|text>`, no headings/tables), so the fix is a
+server-side converter at the single outbound chokepoint, mirroring the
+existing `TelegramMarkdownFormatter` (GFM→HTML) pattern:
+
+- New `src/messaging/slack/SlackMrkdwnFormatter.ts` — pure GFM→mrkdwn
+  converter: bold/italic/bold-italic/strike, inline + fenced code (language
+  tag dropped, contents `&<>`-escaped exactly once via sentinel extraction —
+  double-escaping structurally impossible), `[text](url)` → `<url|text>` with
+  a scheme allowlist (javascript:/data: stay literal) and balanced-paren URL
+  parsing, headings → bold lines, bullets → `•`, blockquotes preserved,
+  tables → fenced code blocks, horizontal rules → a rule line. 32KB ReDoS
+  guard (oversized input passes through raw), NUL + PUA-B stripping
+  (sentinel-collision defense).
+- `SlackAdapter` gains one private funnel, `formattedApiCall()` — every
+  user-visible send (`send`, `sendToChannel`, `updateMessage`,
+  `postEphemeral`, `sendBlocks`) now routes through it. Block Kit payloads,
+  `mrkdwn:false` sends, and non-send methods pass through untouched.
+- Default ON (`'mrkdwn'`). Rollback lever: `formatMode:
+  'legacy-passthrough'` in the slack messaging config block restores
+  byte-for-byte pre-formatter behavior (mirrors `telegramFormatMode`).
+  Per-call opt-out for callers that already author mrkdwn:
+  `sendToChannel(..., { formatMode: 'legacy-passthrough' })` /
+  `metadata.formatMode` on `POST /slack/reply/:channelId` (the internal
+  `_formatMode` flag is stripped before the bytes reach the Slack API).
+- The one internal callsite that hand-authors mrkdwn (the PromptGate relay
+  fallback in `server.ts`) is tagged with the per-call opt-out; all other
+  internal sends are plain English or agent-authored GFM (audited).
+
+Tests: 74 new across two tiers — unit (formatter contract: every conversion
+case, escaping, guards, wire-up helper skip rules; wiring integrity: the REAL
+adapter delegates every outbound path through the real funnel) + integration
+(the full `POST /slack/reply/:channelId` and `/internal/slack-forward` HTTP
+pipeline, transport stubbed below the funnel).
+
+## What to Tell Your User
+
+<!-- audience: user, maturity: stable -->
+- **Slack messages now look right**: when your agent replies in Slack, its
+  formatting renders natively — bold is bold, links are clickable, lists get
+  real bullets, and code blocks stay monospaced — instead of showing raw
+  `**asterisks**` and bracket syntax. Nothing to configure; if you ever want
+  the old raw behavior back, one config flag restores it exactly.
+
+## Summary of New Capabilities
+
+- Slack messages render natively formatted (bold/italic/links/lists/code/
+  quotes) with a config rollback (`formatMode: 'legacy-passthrough'`) and a
+  per-call opt-out for already-mrkdwn callers.
+
+## Evidence
+
+- 74/74 new tests green (unit formatter contract, adapter wiring integrity,
+  HTTP route integration); full unit suite green; `npm run lint` clean.
+- Live-proof clause (run by the orchestrator post-merge): a formatted message
+  renders natively in a real Slack channel.

--- a/upgrades/next/slack-mrkdwn-formatter.md
+++ b/upgrades/next/slack-mrkdwn-formatter.md
@@ -47,8 +47,8 @@ pipeline, transport stubbed below the funnel).
 - **Slack messages now look right**: when your agent replies in Slack, its
   formatting renders natively — bold is bold, links are clickable, lists get
   real bullets, and code blocks stay monospaced — instead of showing raw
-  `**asterisks**` and bracket syntax. Nothing to configure; if you ever want
-  the old raw behavior back, one config flag restores it exactly.
+  asterisks and bracket syntax. Nothing to configure; if you ever want the
+  old raw behavior back, one setting restores it exactly.
 
 ## Summary of New Capabilities
 

--- a/upgrades/side-effects/slack-mrkdwn-formatter.md
+++ b/upgrades/side-effects/slack-mrkdwn-formatter.md
@@ -1,0 +1,143 @@
+# Side-Effects Review — SlackMrkdwnFormatter (GFM→mrkdwn outbound formatter)
+
+**Version / slug:** `slack-mrkdwn-formatter`
+**Date:** `2026-07-02`
+**Author:** Echo (autonomous)
+**Tier:** 1 (small, low-risk, additive outbound-formatting transform mirroring the shipped `TelegramMarkdownFormatter`)
+**Second-pass reviewer:** self (genuine second pass over the final diff — see Evidence)
+
+## Summary of the change
+
+Agent-authored GitHub-flavored markdown sent to Slack used to arrive raw —
+`**bold**` rendered as literal asterisks, `[text](url)` as bracket soup, `#`
+headings as pound signs. This adds a server-side GFM→mrkdwn converter at the
+single outbound Slack chokepoint, mirroring the existing
+`TelegramMarkdownFormatter` (GFM→HTML) pattern.
+
+Files added:
+- `src/messaging/slack/SlackMrkdwnFormatter.ts` — pure converter
+  (`formatForSlack` + the `applySlackFormatter` wire-up helper). Bold / italic /
+  bold-italic / strike; inline + fenced code (language tag dropped, contents
+  `&<>`-escaped exactly once via PUA-sentinel extraction so double-escaping is
+  structurally impossible); `[text](url)` → `<url|text>` with a scheme
+  allowlist (`http`/`https`/`mailto`; others stay literal) and balanced-paren
+  URL parsing; headings → bold lines; bullets → `•`; blockquotes preserved;
+  tables → fenced code blocks; horizontal rules → a rule line. 32KB ReDoS guard
+  (oversized input passes through raw); NUL + Supplementary-PUA-B stripping
+  (sentinel-collision defense).
+- `tests/unit/slack-mrkdwn-formatter.test.ts` — formatter contract + wire-up
+  helper skip rules.
+- `tests/unit/slack-mrkdwn-wireup.test.ts` — wiring integrity: the REAL
+  `SlackAdapter` delegates every user-visible outbound path through the real
+  funnel.
+- `tests/integration/slack-mrkdwn-reply-route.test.ts` — the full
+  `POST /slack/reply/:channelId` + `/internal/slack-forward` HTTP pipeline
+  (transport stubbed BELOW the funnel).
+- `upgrades/next/slack-mrkdwn-formatter.md` — release fragment.
+- `docs/specs/slack-mrkdwn-formatter.eli16.md` — plain-English ELI16.
+
+Files modified:
+- `src/messaging/slack/SlackAdapter.ts` — one new private funnel
+  `formattedApiCall()`; `send`, `sendToChannel`, `updateMessage`,
+  `postEphemeral`, and `sendBlocks` now route their `chat.postMessage` /
+  `chat.update` / `chat.postEphemeral` calls through it. `sendToChannel` gains a
+  `formatMode` option that sets the internal `_formatMode` per-call flag.
+  `escapeMrkdwn` removed from the import (now used only inside the formatter).
+- `src/messaging/slack/types.ts` — `SlackConfig.formatMode?: 'mrkdwn' | 'legacy-passthrough'`.
+- `src/messaging/slack/index.ts` — re-exports the formatter public surface.
+- `src/server/routes.ts` — `POST /slack/reply/:channelId` reads
+  `metadata.formatMode` (validated to the two legal values, else `undefined`)
+  and passes it to `sendToChannel`.
+- `src/commands/server.ts` — the one internal callsite that hand-authors mrkdwn
+  (the PromptGate relay fallback) is tagged `{ formatMode: 'legacy-passthrough' }`.
+- `CLAUDE.md` — architecture note under `messaging/`.
+
+## Which outbound paths now transform (the load-bearing behavior change)
+
+Transform applies ONLY to message-body sends: `chat.postMessage`,
+`chat.update`, `chat.postEphemeral`. Concretely: `SlackAdapter.send` (the
+OutgoingMessage chunked path), `sendToChannel`, `updateMessage`,
+`postEphemeral`, and the `text` fallback slot of `sendBlocks`. Everything else
+(`reactions.add/remove`, `pins.add`, `users.info`, `conversations.*`,
+`files.info`, `auth.test`) still calls `apiClient.call` directly and is
+untouched — verified by grep.
+
+Skip rules (pass through byte-for-byte, `didFormat:false`):
+- non-send methods,
+- config `formatMode: 'legacy-passthrough'`,
+- per-call `_formatMode: 'legacy-passthrough'`,
+- `params.blocks` present (Block Kit authored deliberately; `text` is only the
+  notification fallback),
+- `params.mrkdwn === false` (caller explicitly asked Slack for plain text),
+- `text` not a string.
+
+## The rollback lever + per-call opt-out (both verified by test)
+
+- **Global rollback:** `formatMode: 'legacy-passthrough'` in the slack messaging
+  config block → byte-for-byte pre-formatter behavior (mirrors
+  `telegramFormatMode`). Verified in both the wireup and route integration tests.
+- **Per-call opt-out:** `sendToChannel(..., { formatMode: 'legacy-passthrough' })`
+  and `metadata.formatMode` on `POST /slack/reply/:channelId`. The internal
+  `_formatMode` flag is stripped inside `applySlackFormatter` before params reach
+  the Slack API (asserted: `'_formatMode' in outgoingParams === false`).
+- **Precedence:** per-call → config → default `'mrkdwn'`. A per-call `'mrkdwn'`
+  wins over a `'legacy-passthrough'` config (tested).
+
+## Roll-up across the seven review dimensions
+
+1. **Over-block**: none. The formatter never blocks or drops a message; the
+   worst case (oversized / passthrough) is the exact old raw-bytes behavior.
+2. **Under-block**: N/A — not a gate. Escaping is if anything MORE conservative
+   than before (raw `<@U123>` is now `&lt;@U123&gt;`, so agent DATA can no longer
+   be misread by Slack as a live mention/entity).
+3. **Level-of-abstraction fit**: correct. The transform lives at one private
+   adapter chokepoint (`formattedApiCall`) — the Slack sibling of
+   `TelegramAdapter.apiCall` + `applyTelegramFormatter` — so all send paths get
+   it uniformly and the pure functions are unit-testable in isolation.
+4. **Signal-vs-authority compliance**: N/A to message-flow authority. This is a
+   presentational transform, not a decision gate; it never blocks, delays, or
+   suppresses a send. No silent try/catch — the formatter has no catch that
+   swallows errors; oversized input is an explicit, tested passthrough.
+5. **Interactions**: reads one new config field (`config.formatMode`), no shared
+   mutable state, no new timers. Idempotency: running the formatter, then
+   passing the result through `legacy-passthrough`, is a fixed point (tested).
+   Note: applying the `mrkdwn` transform TWICE is not idempotent (e.g. `*x*`
+   would re-italicize), which is exactly why already-mrkdwn callers use the
+   opt-out — the one internal such callsite (PromptGate fallback) is tagged.
+6. **External surfaces**: no NEW network calls, endpoints, or files. The only
+   external-facing change is the shape of the `text` field already being sent to
+   the Slack Web API. Link scheme allowlist means agent output cannot emit a
+   clickable `javascript:`/`data:` link.
+7. **Rollback cost**: low. Single revertable commit; the new module is additive;
+   every adapter change is a call-site swap to the funnel. Zero persistent
+   state, zero migration. Instant runtime rollback via the config flag without a
+   redeploy.
+
+## Migration-parity note
+
+This is agent-runtime source (`src/…`), not an agent-installed file
+(`.claude/settings.json` hooks, `.instar/config.json` defaults, CLAUDE.md
+template, hook scripts, or built-in skills), so no `PostUpdateMigrator` entry is
+required — existing agents pick it up on the normal server update. The new
+`formatMode` config field is optional and defaults to `'mrkdwn'` when absent, so
+no config migration is needed. The repo `CLAUDE.md` note is documentation, not
+the scaffold template (`src/scaffold/templates.ts`); no user-facing capability
+endpoint or proactive trigger is added, so no template change is warranted.
+
+## Credential-handling note
+
+None. The change touches no secrets, tokens, or credentials.
+
+## Evidence pointers
+
+- `npx tsc --noEmit` — clean (exit 0).
+- `npx vitest run` on the three new files — 74/74 pass (formatter contract +
+  escaping + guards + wire-up skip rules; adapter wiring integrity across every
+  outbound path; HTTP route integration incl. rollback + per-call opt-out +
+  `/internal/slack-forward`).
+- Second-pass self-review of the final diff: confirmed the funnel is genuinely
+  wired (grep: all message-body sends route through `formattedApiCall`; the
+  removed `escapeMrkdwn` import has no remaining reference in `SlackAdapter.ts`),
+  the rollback lever + per-call opt-out exist and are exercised end-to-end, and
+  `applySlackFormatter` is a live dependency of `formattedApiCall` (not a dead
+  export).


### PR DESCRIPTION
## ELI16

When Echo (or any instar agent) writes a reply, it writes in GitHub-flavored markdown — double asterisks for bold, square-bracket links, pound-sign headings. Telegram already gets that translated into what Telegram understands, but Slack was getting the raw bytes: users literally saw **asterisks**, [bracket](soup), and pound signs instead of bold text, clickable links, and headings. Slack speaks its own little formatting dialect called mrkdwn (single asterisks for bold, links written as url-pipe-text, no headings or tables at all). This change adds a translator that sits at the one doorway every outgoing Slack message already passes through, so everything the agent sends gets converted right before it leaves — bold becomes real bold, links become clickable, bullet lists get real bullets, code blocks stay monospaced, and tables (which Slack cannot render) are wrapped in a monospaced block so their columns still line up. Nothing else changes: messages built with Slack's Block Kit, messages explicitly marked as raw, and everything that is not a send pass through untouched. It is on by default, and one config setting (or a per-call flag) restores the exact old raw behavior if anyone ever wants it back.

## What Changed

Roadmap 0.1 — mirrors the shipped `TelegramMarkdownFormatter` (GFM→HTML) pattern, for Slack.

- **New `src/messaging/slack/SlackMrkdwnFormatter.ts`** — pure GFM→mrkdwn converter (`formatForSlack` + `applySlackFormatter` wire-up helper): bold / italic / bold-italic / strike, inline + fenced code (language tag dropped; contents `&<>`-escaped exactly once via PUA-sentinel extraction, so double-escaping is structurally impossible), `[text](url)` → `<url|text>` with a scheme allowlist (`javascript:` / `data:` stay literal) and balanced-paren URL parsing, headings → bold lines, bullets → `•`, blockquotes preserved, tables → fenced code blocks, horizontal rules → a rule line. 32KB ReDoS guard (oversized input passes through raw), NUL + PUA-B stripping (sentinel-collision defense).
- **`SlackAdapter` gains one private funnel `formattedApiCall()`** — `send`, `sendToChannel`, `updateMessage`, `postEphemeral`, `sendBlocks` all route through it. Block Kit payloads, `mrkdwn:false` sends, and non-send methods pass through untouched.
- **Default ON (`'mrkdwn'`).** Rollback lever: `formatMode: 'legacy-passthrough'` in the slack messaging config block restores byte-for-byte pre-formatter behavior (mirrors `telegramFormatMode`). Per-call opt-out: `sendToChannel(..., { formatMode })` / `metadata.formatMode` on `POST /slack/reply/:channelId` (the internal `_formatMode` flag is stripped before bytes reach the Slack API).
- The one internal callsite that hand-authors mrkdwn (the PromptGate relay fallback in `server.ts`) is tagged with the per-call opt-out; all other internal sends are plain English or agent-authored GFM (audited).

## Tests

74 new tests across two tiers, all green:

- `tests/unit/slack-mrkdwn-formatter.test.ts` (59) — formatter contract: every conversion case, escaping, guards, wire-up helper skip rules.
- `tests/unit/slack-mrkdwn-wireup.test.ts` (9) — wiring integrity: the REAL adapter delegates every outbound path through the real funnel; config rollback + per-call opt-out.
- `tests/integration/slack-mrkdwn-reply-route.test.ts` (6) — full `POST /slack/reply/:channelId` and `/internal/slack-forward` HTTP pipeline, transport stubbed below the funnel.

Also: `npm run lint` clean (tsc + all custom lints); Slack contract tests run against the live Slack API pre-push (evidence recorded).

## Rollback

Config: `formatMode: 'legacy-passthrough'` in the slack messaging config block — restores byte-for-byte passthrough. Per-call: `{ formatMode: 'legacy-passthrough' }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
