### PR TITLE
feat(slack): test-workspace-scoped principal source for the permission gate (roadmap 0.3)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-03T00-38-34-033Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T00-38-34-033Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-03T00:38:34.033Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 357,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-03T00-40-20-173Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T00-40-20-173Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-03T00:40:20.173Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 357,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-03T00-42-05-485Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T00-42-05-485Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-03T00:42:05.485Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 357,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/SLACK-ORG-TEST-WORKSPACE-RUNBOOK.md
+++ b/docs/specs/SLACK-ORG-TEST-WORKSPACE-RUNBOOK.md
@@ -42,7 +42,8 @@ approval first, not for the operator to do the work.)
 ## Wiring (agent-side, once tokens exist)
 
 1. Add the Slack messaging block to `.instar/config.json` with the tokens, the cast's
-   Slack user IDs in `authorizedUserIds`, and the gate in observe-only:
+   Slack user IDs in `authorizedUserIds`, the gate in observe-only, AND the cast's
+   roles in the **test-workspace principal source** (`permissionGate.testCast`):
    ```json
    {
      "type": "slack", "enabled": true,
@@ -50,18 +51,68 @@ approval first, not for the operator to do the work.)
        "botToken": "xoxb-…", "appToken": "xapp-…",
        "workspaceMode": "shared",
        "authorizedUserIds": ["U_OWNER","U_ADMIN","U_MEMBER","U_CONTRIB"],
-       "permissionGate": { "observeOnly": true }
+       "permissionGate": {
+         "observeOnly": true,
+         "testCast": {
+           "testWorkspace": true,
+           "workspaceId": "T_LIVETEST_WORKSPACE",
+           "principals": [
+             { "slackUserId": "U_OWNER",   "name": "Owner Seat",       "orgRole": "owner" },
+             { "slackUserId": "U_ADMIN",   "name": "Admin Seat",       "orgRole": "admin" },
+             { "slackUserId": "U_MEMBER",  "name": "Member Seat",      "orgRole": "member" },
+             { "slackUserId": "U_CONTRIB", "name": "Contributor Seat", "orgRole": "contributor" }
+           ]
+         }
+       }
      }
    }
    ```
    `observeOnly: true` means the gate **logs** every verdict and **blocks nothing** —
    the safe default for a demo. (`enforce: true` is a later phase, gated on a good
    observed false-positive rate; do NOT set it for the first demo.)
-2. Seed the cast's roles in `users.json` (until the Phase-1 conversational registration
-   UX exists): one `UserProfile` per cast member with `slackUserId` + `orgRole`
-   (`owner`/`admin`/`member`/`contributor`). The outsider is simply **not** registered.
+
+2. **DO NOT seed the cast's roles in `users.json`.** (Superseded — the July-2026 fix.)
+   The cast's roles are resolved by the `permissionGate.testCast` block above, NOT by
+   the production user registry. Two hard reasons the naive `users.json` seed is wrong:
+   - The **fixture-identity guard** (`users/testIdentityMarkers.ts`, silent-loss
+     §2.D "Test Identity Never Enters Production State") REFUSES the cast's ids at
+     both the write and load layers of `users.json` — a seed either throws or is
+     silently skipped on load.
+   - Even if it were allowed, a **registry rebuild silently drops the seed**. That is
+     exactly the 2026-07-01 incident: the silent-loss repair rebuilt `users.json`,
+     the five Slack test-cast principals went with it, and every Slack sender then
+     resolved as an unregistered guest — the FP that this runbook step exists to
+     prevent from ever recurring.
+
+   The `testCast` block avoids BOTH: it lives in the same config as the workspace
+   tokens (so a `users.json` rebuild can't touch it), it admits ONLY fixture-marker
+   ids (the partition invariant), and it is **workspace-scoped** — it resolves the
+   cast ONLY while the adapter's VERIFIED connected team id (`auth.test`) equals
+   `workspaceId`, so it can never leak roles into a production workspace. The required
+   `testWorkspace: true` self-declaration is a deliberate opt-in: without it the block
+   is ignored entirely (zero principals, one loud log line, no production effect). The
+   outsider seat is simply **not** listed → it resolves to an unregistered guest.
+
 3. Restart the agent's server so the Slack adapter picks up the config (a running
    session keeps the config it was spawned with).
+
+### Re-provision checklist (do this every time you rebuild the cast or the registry)
+
+Principal resolution for the live-test cast lives ONLY in `permissionGate.testCast`.
+So whenever you re-provision the workspace, rotate ids, or a `users.json` repair/rebuild
+runs, re-verify the block — a registry rebuild can no longer silently break the gate,
+but a stale/absent `testCast` block still can:
+
+- [ ] `permissionGate.testCast.workspaceId` equals the workspace's REAL team id (the
+      `team_id` Slack returns from `auth.test`; the boot log prints it as `(team T…)`).
+- [ ] `testWorkspace: true` is present (without it the whole block is ignored — watch
+      for the `TestWorkspacePrincipalSource IGNORED … missing … "testWorkspace": true`
+      warning in `logs/server.log`).
+- [ ] Every cast `slackUserId` is a fixture-marker id (registered in
+      `users/testIdentityMarkers.ts`); the boot log reports `N seat(s) admitted, M refused`.
+- [ ] After the restart, run one observe round and confirm the owner seat resolves
+      `owner, registered:true` in `GET /permissions/decisions` (the exact check that
+      catches a lost/mis-scoped cast before `enforce: true` is ever flipped).
 
 ## Running the demonstration
 

--- a/docs/specs/slack-test-workspace-principal-source.eli16.md
+++ b/docs/specs/slack-test-workspace-principal-source.eli16.md
@@ -1,0 +1,47 @@
+# Slack Test-Workspace Principal Source — Plain-English Overview
+
+> The one-line version: give the Slack demo cast a safe home OUTSIDE the real user list, so a routine cleanup of that list can't secretly break who's-allowed-to-do-what — and lock that home to one specific test workspace so those pretend roles can never leak into a real one.
+
+## The problem in one breath
+
+The Slack permission gate decides "is this person allowed to ask for this?" by looking up their role in the user registry (the list of real people the agent knows). For the live demo we had put five fake "cast" identities (a pretend owner, admin, member, contributor, and an outsider) into that same list. On 2026-07-01 a safety repair rebuilt the user list from scratch and — correctly — refused to let fake test identities back in. The cast vanished, and suddenly every Slack sender, including the workspace owner, looked like an unregistered stranger. If we had turned enforcement on that day, the gate would have locked the entire workspace out.
+
+## What already exists
+
+- **The permission gate** — decides allow / refuse / clarify / step-up for each Slack request. Working, in observe-only (logs decisions, blocks nothing). Not the thing being changed.
+- **The user registry (`users.json`)** — the real list of people the agent knows. The gate reads roles from here.
+- **The fixture-identity guard** — a rule that refuses to let test/fake identities into the real user list, at both the write and load steps. This guard is CORRECT and stays untouched; it's the reason the naive "just put the cast back" fix doesn't work.
+- **The Slack adapter** — the piece connected to a specific Slack workspace. It already asks Slack "who am I and where am I connected?" at startup.
+
+## What this adds
+
+A separate, read-only place for the demo cast's roles to live: a small block in the Slack config called the test-workspace principal source. When a Slack message comes in and the gate needs the sender's role, it checks the real user registry FIRST; only if the registry doesn't know them does it fall back to this cast block. The cast block is never allowed to override a real registered person.
+
+Three hard rules make it safe:
+
+- **It only answers for one specific workspace.** The block names the test workspace's id, and the source only resolves the cast while the adapter's *verified* connection (what Slack itself reported at startup) matches that id. In any other workspace the block is completely invisible — not a fallback, not a merge, just gone.
+- **It only accepts fake identities.** Every listed id must match the same fixture-marker rule the production guard uses to *refuse* them. So a real employee's id can never be smuggled into the cast to grab a role.
+- **It must say out loud that it's a test.** The block has to declare `testWorkspace: true`. Without that one line, the whole block is ignored — zero cast members loaded, one loud log line, and the real registry behaves exactly as if no cast existed. You can't switch on a pretend role list by accident.
+
+## The new pieces
+
+- **TestWorkspacePrincipalSource** — holds the cast in memory (id → role), answers "what role is this Slack id?" but ONLY for the sanctioned test workspace and ONLY for fake ids. It takes no state directory and has no way to write anything — it can't touch the real user list, can't create people, can't bind an operator. It only feeds the gate's role lookup.
+- **ChainedUserLookup** — tries the real registry first, then the cast, and stops at the first answer. A broken source is skipped, never allowed to break message handling.
+
+## The safeguards
+
+**Prevents pretend roles leaking into a real workspace.** The source is locked to the verified connected team id from Slack's own startup handshake — config alone is never trusted. Point the adapter at a different workspace and the cast is structurally invisible; production behavior is byte-for-byte identical to having no cast at all.
+
+**Prevents a real person being impersonated.** Only fixture-marker ids are admitted, using the very same matcher the production guard uses to keep fixtures OUT of the real registry. One identity can live in exactly one of the two homes — never both.
+
+**Prevents an accidental activation.** The `testWorkspace: true` self-declaration is required; missing it disables the whole block loudly. And the real registry always wins on lookup, so a cast entry can never shadow or upgrade a genuine registered user.
+
+**Prevents another silent breakage.** Because the cast lives in the Slack config next to the tokens (not in the rebuildable user list), a future registry repair can't drop it. The runbook now spells out the re-provision checklist so the setup step can't quietly rot.
+
+## What ships when
+
+One PR, dark by default. Nothing changes for any agent unless a Slack config explicitly adds the `testCast` block with `testWorkspace: true` — which only the live-test workspace ever will. Enforcement (`enforce: true`) remains a later, separately-gated step that still needs a clean observe round first.
+
+## What you actually need to decide
+
+Are you fine with the demo cast's roles living in the Slack config (workspace-scoped, fixture-only, opt-in) instead of the user registry — the change that lets the scenario harness resolve principals again without ever putting test identities back into production state?

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7138,6 +7138,20 @@ export async function startServer(options: StartOptions): Promise<void> {
                 bucketMs?: number;
               };
             };
+            /**
+             * Sanctioned live-test-workspace scenario cast (roadmap 0.3 entry
+             * condition). Resolves cast principals for the permission gate ONLY —
+             * scoped to the adapter's VERIFIED connected team id, fixture-marker
+             * identities only, production registry always wins. The cast lives in
+             * config (same lifecycle as the workspace tokens) so a users.json
+             * rebuild can never silently drop principal resolution again
+             * (the 2026-07-01 lesson). See SLACK-ORG-INTEGRATION-SPEC.md §6.2.1.
+             */
+            testCast?: {
+              testWorkspace?: boolean;
+              workspaceId?: string;
+              principals?: Array<{ slackUserId: string; name?: string; orgRole: string }>;
+            };
           } | undefined;
           if (pgCfg && (pgCfg.observeOnly || pgCfg.enforce)) {
             const {
@@ -7152,6 +7166,8 @@ export async function startServer(options: StartOptions): Promise<void> {
               RelationshipBehaviorStore,
               RelationshipAnomalyScorer,
               MandateBackedGrantStore,
+              TestWorkspacePrincipalSource,
+              ChainedUserLookup,
             } = await import('../permissions/index.js');
             // Own UserManager instance for verified-principal resolution (the
             // Telegram-block userManager is out of scope here). Reads users.json.
@@ -7245,10 +7261,51 @@ export async function startServer(options: StartOptions): Promise<void> {
                 `[slack] relationship-aware anomaly scorer attached (observe-only baseline; LLM style check ${raCfg.useLlmStyleCheck ? 'ON' : 'off'}; poisoning-resistance: min-age ${pr.minBaselineAgeDays ?? 7}d, rate-cap ${pr.maxObservationsPerWindow ?? 50}/window, decay ${pr.decayHalfLifeWindows ?? 30}w)`,
               );
             }
+            // ── Principal resolution: production registry first; optionally chained
+            // with the sanctioned test-cast source (roadmap 0.3 entry condition).
+            // The cast source is workspace-scoped (VERIFIED connected team id from
+            // auth.test — fail-closed until verified), fixture-marker-only (the
+            // partition invariant: the production registry refuses fixtures, this
+            // source accepts ONLY fixtures — one identity space, two disjoint homes),
+            // and read-only (it never touches users.json; the fixture-identity
+            // guard's production invariant is fully intact).
+            const productionLookup: import('../permissions/index.js').UserLookup = {
+              resolveFromSlackUserId: (id: string) => slackUserManager.resolveFromSlackUserId(id),
+            };
+            let principalLookup: import('../permissions/index.js').UserLookup = productionLookup;
+            const tcCfg = pgCfg.testCast;
+            if (tcCfg && typeof tcCfg.workspaceId === 'string' && tcCfg.workspaceId.trim()
+                && Array.isArray(tcCfg.principals) && tcCfg.principals.length > 0) {
+              try {
+                const adapterForScope = slackAdapter;
+                const testCastSource = new TestWorkspacePrincipalSource({
+                  workspaceId: tcCfg.workspaceId,
+                  testWorkspace: tcCfg.testWorkspace === true,
+                  principals: tcCfg.principals,
+                  getVerifiedWorkspaceId: () => adapterForScope?.getConnectedTeamId() ?? null,
+                });
+                if (testCastSource.disabled) {
+                  // Fail-closed: the source already logged the single loud line
+                  // (missing "testWorkspace: true"). Stay production-registry-only —
+                  // do NOT attach an inert chain, so behavior is byte-identical to
+                  // having no cast configured.
+                } else {
+                  for (const r of testCastSource.rejected) {
+                    console.warn(`[slack] test-cast principal REFUSED (${r.reason}): "${r.slackUserId}" — the cast admits fixture-marker identities only (see users/testIdentityMarkers.ts)`);
+                  }
+                  principalLookup = new ChainedUserLookup([productionLookup, testCastSource]);
+                  console.log(
+                    `[slack] permission-gate test-cast principal source attached: workspace ${tcCfg.workspaceId}, ` +
+                    `${testCastSource.size} seat(s) admitted, ${testCastSource.rejected.length} refused ` +
+                    `(production registry takes precedence; cast inert until the connected team id is verified)`,
+                  );
+                }
+              } catch (tce) {
+                console.warn('[slack] test-cast principal source wiring skipped:', (tce as Error).message);
+              }
+            }
             const observer = new SlackPermissionObserver({
-              resolver: new SlackPrincipalResolver({
-                resolveFromSlackUserId: (id: string) => slackUserManager.resolveFromSlackUserId(id),
-              }),
+              resolver: new SlackPrincipalResolver(principalLookup),
               gate: new SlackPermissionGate({
                 rolePolicy: new RolePolicy(),
                 classifier: intentClassifier,

--- a/src/messaging/slack/SlackAdapter.ts
+++ b/src/messaging/slack/SlackAdapter.ts
@@ -4,6 +4,11 @@
  * Implements the MessagingAdapter interface using Socket Mode (WebSocket)
  * for event intake and the Slack Web API for outbound messages.
  *
+ * CONTRACT-EVIDENCE: EXEMPT — this change only reads an ADDITIONAL field
+ * (`team_id`) from the EXISTING `auth.test` response already called at start and
+ * exposes it via an internal getter. It adds no new Slack Web-API call and
+ * changes no request/response contract, so no live-API contract test applies.
+ *
  * Key design decisions:
  * - DIY app model (each user creates their own Slack app)
  * - Socket Mode (no public URLs, no webhooks)
@@ -56,6 +61,8 @@ export class SlackAdapter implements MessagingAdapter {
   private autoJoinChannels: boolean;
   private respondMode: SlackRespondMode;
   private botUserId: string | null = null;
+  /** VERIFIED connected team id from `auth.test` at start (null until verified). */
+  private connectedTeamId: string | null = null;
 
   // Threads-as-first-class-sessions (§5.3). Resolved once from config. When a
   // channel is opted in, a message carrying a thread_ts routes to a session keyed
@@ -236,12 +243,15 @@ export class SlackAdapter implements MessagingAdapter {
     await Promise.race([connectPromise, timeoutPromise]);
     this.started = true;
 
-    // Fetch bot user ID (needed for @mention detection in shared mode)
+    // Fetch bot user ID (needed for @mention detection in shared mode) and the
+    // VERIFIED connected team id (consumed by the test-cast principal source's
+    // workspace scope check — config alone is never the scope authority).
     try {
       const authResult = await this.apiClient.call('auth.test', {}) as Record<string, unknown>;
       this.botUserId = authResult.user_id as string ?? null;
+      this.connectedTeamId = typeof authResult.team_id === 'string' ? authResult.team_id : null;
       if (this.botUserId) {
-        console.log(`[slack] Bot user ID: ${this.botUserId}`);
+        console.log(`[slack] Bot user ID: ${this.botUserId}${this.connectedTeamId ? ` (team ${this.connectedTeamId})` : ''}`);
       }
     } catch {
       console.warn('[slack] Could not fetch bot user ID — mention detection may not work');
@@ -384,6 +394,15 @@ export class SlackAdapter implements MessagingAdapter {
 
   /** The Slack workspace/team id this adapter is configured for (undefined if unset). */
   getWorkspaceId(): string | undefined { return this.config.workspaceId; }
+
+  /**
+   * The VERIFIED connected workspace/team id, captured from Slack's own
+   * `auth.test` response at adapter start — null until verified (or when
+   * verification failed). This — never config — is the scope authority for the
+   * test-cast principal source: fail-closed, the cast is inert until the
+   * adapter has proven which workspace it is actually connected to.
+   */
+  getConnectedTeamId(): string | null { return this.connectedTeamId; }
 
   /** Get the current workspace behavior config. */
   getWorkspaceConfig(): { mode: SlackWorkspaceMode; autoJoinChannels: boolean; respondMode: SlackRespondMode } {

--- a/src/messaging/slack/types.ts
+++ b/src/messaging/slack/types.ts
@@ -1,5 +1,9 @@
 /**
  * Slack adapter types — configuration, messages, events, and rate limit tiers.
+ *
+ * CONTRACT-EVIDENCE: EXEMPT — this change is type-only (adds the optional
+ * `permissionGate.testCast` config shape); it touches NO Slack Web-API request
+ * or response contract, so no live-API contract test applies.
  */
 
 // ── Configuration ──
@@ -79,6 +83,36 @@ export interface SlackConfig {
   permissionGate?: {
     observeOnly?: boolean;
     enforce?: boolean;
+    /**
+     * Sanctioned live-test-workspace scenario cast (roadmap 0.3 entry condition).
+     * The July-2026 lesson: the cast must NEVER live in the production user
+     * registry (`users.json`) — the fixture-identity guard refuses it there, and
+     * a registry rebuild silently dropped it once already. Carried HERE, in the
+     * same config block as the workspace tokens, the cast shares the workspace
+     * config's lifecycle: a users.json rebuild can never remove it again.
+     *
+     * Scope (fail-closed): entries resolve ONLY while the adapter's VERIFIED
+     * connected team id (`auth.test`) equals `workspaceId`. Partition invariant:
+     * each `slackUserId` MUST match the fixture-identity markers
+     * (`users/testIdentityMarkers.ts`) — a non-fixture UID is refused at load.
+     * The production registry always takes precedence on resolution.
+     *
+     * Self-declaration (fail-closed): the block MUST set `testWorkspace: true` —
+     * without it the whole cast is IGNORED (zero principals, one loud log line,
+     * no production effect). Sanctioning a live-test cast is a deliberate opt-in,
+     * never an implicit side effect of the block being present.
+     */
+    testCast?: {
+      /**
+       * Required self-declaration. The cast loads NOTHING unless this is `true`
+       * (fail-closed to ignoring the block; the production registry is unaffected).
+       */
+      testWorkspace?: boolean;
+      /** The live-test workspace/team id (T…) the cast is scoped to. */
+      workspaceId?: string;
+      /** The cast seats (max 12). `slackUserId` must be a fixture-marker id. */
+      principals?: Array<{ slackUserId: string; name?: string; orgRole: string }>;
+    };
   };
   /**
    * Conservative ambient "should I speak?" gate (Slack considered/ambient mode,

--- a/src/permissions/TestWorkspacePrincipalSource.ts
+++ b/src/permissions/TestWorkspacePrincipalSource.ts
@@ -1,0 +1,236 @@
+/**
+ * TestWorkspacePrincipalSource — the sanctioned, workspace-scoped principal source
+ * for the Slack live-test scenario cast (roadmap 0.3 entry condition).
+ *
+ * WHY THIS EXISTS (the 2026-07-01 lesson): the June scenario drives seeded the
+ * five-seat test cast into the production user registry (`users.json`). The
+ * silent-loss registry rebuild removed them, and the fixture-identity guard
+ * ("Test Identity Never Enters Production State", silent-loss-refusal-conservation
+ * §2.D) now — correctly — refuses to let them back in. Principal resolution for
+ * the live-test workspace therefore needs a home that is NOT the production
+ * registry. This module is that home.
+ *
+ * THE PARTITION INVARIANT (the load-bearing design decision):
+ *   - The production registry REFUSES fixture identities (the existing guard,
+ *     untouched by this module).
+ *   - This source ACCEPTS ONLY fixture identities — every cast entry's
+ *     slackUserId must match the SAME single matcher the production guard uses
+ *     (`matchesTestIdentityToken` from `users/testIdentityMarkers.ts`). A
+ *     non-fixture UID is refused at load, loudly.
+ *   By construction an identity can live in exactly one of the two stores —
+ *   a real employee's UID can never be smuggled into the cast to gain a role
+ *   outside the audited registration path, and standing up a NEW test cast
+ *   structurally forces the fixture-marker list to be updated first (which is
+ *   what keeps the production guard aware of the new fixtures). The single
+ *   matcher can never drift into two lists.
+ *
+ * THE SELF-DECLARATION MARKER (fail-closed to ignoring the cast): the config
+ * object MUST self-declare `testWorkspace: true`. Without that marker the source
+ * refuses to load a SINGLE principal — it disables itself, emits ONE loud log
+ * line, and every lookup returns null (production resolution is byte-identical to
+ * having no cast at all). The marker exists so a cast config can never be
+ * activated by accident: sanctioning a live-test workspace is a deliberate,
+ * self-evident opt-in, never an implicit side effect of the block existing.
+ *
+ * SCOPING (fail-closed): the cast resolves ONLY while the Slack adapter's
+ * VERIFIED connected team id (captured from Slack's own `auth.test` response at
+ * adapter start — never from config alone) equals the configured test
+ * `workspaceId`. Before verification, on verification failure, or when the
+ * adapter is connected to any other workspace, every lookup returns null and
+ * the resolver falls through to its existing safe default (unregistered guest).
+ *
+ * READ-ONLY BY DESIGN: this source never writes anything — not users.json, not
+ * a state file. It is consulted ONLY by the permission gate's principal
+ * resolver (production-registry-first via {@link ChainedUserLookup}); it is
+ * invisible to UserManager, sender auth (`authorizedUserIds`), cross-machine
+ * replication, and every other identity surface.
+ *
+ * Note on imports: `testIdentityMarkers.ts` is dependency-light (node builtins +
+ * a type-only core import), so reusing its matcher keeps the permission module
+ * free of runtime core dependencies — and keeps ONE fixture matcher, not two.
+ *
+ * Design: docs/specs/SLACK-ORG-INTEGRATION-SPEC.md §6.2.1;
+ * runbook: docs/specs/SLACK-ORG-TEST-WORKSPACE-RUNBOOK.md.
+ */
+
+import { matchesTestIdentityToken } from '../users/testIdentityMarkers.js';
+import { ORG_ROLES } from './types.js';
+import type { ResolvedUserRecord, UserLookup } from './SlackPrincipalResolver.js';
+
+/** One seat of the live-test scenario cast (configured in the Slack config block). */
+export interface TestCastEntry {
+  /** The seat's REAL Slack user id in the live-test workspace (must be a fixture-marker id). */
+  slackUserId: string;
+  /** Display name for conversational messages — never a basis for authority. */
+  name?: string;
+  /** The org role this seat plays (owner / admin / member / contributor / …). */
+  orgRole: string;
+}
+
+/** Why a configured cast entry was refused at load. */
+export interface RejectedCastEntry {
+  slackUserId: string;
+  reason:
+    | 'missing-slack-user-id'
+    | 'not-a-fixture-identity'
+    | 'invalid-role'
+    | 'duplicate'
+    | 'cast-cap-exceeded';
+}
+
+/**
+ * Hard ceiling on cast seats. The scenario cast is five seats today; the cap
+ * exists so the test-cast path can never quietly become a shadow user registry.
+ */
+export const MAX_TEST_CAST_SEATS = 12;
+
+export interface TestWorkspacePrincipalSourceOpts {
+  /** The sanctioned live-test workspace/team id (T…) this cast is scoped to. */
+  workspaceId: string;
+  /**
+   * The REQUIRED self-declaration marker. The source refuses to load ANY
+   * principal unless this is exactly `true` — fail-closed to ignoring the cast
+   * (one loud log line, never a crash, never a production-registry effect).
+   */
+  testWorkspace: boolean;
+  /** The configured cast seats. Invalid entries are refused (see {@link RejectedCastEntry}). */
+  principals: TestCastEntry[];
+  /**
+   * Supplier of the adapter's VERIFIED connected team id (from `auth.test`).
+   * Returning null/undefined (not yet verified, verification failed) keeps the
+   * source inert — fail-closed to the resolver's unregistered-guest default.
+   */
+  getVerifiedWorkspaceId: () => string | null | undefined;
+}
+
+/** Why the whole source was disabled at construction (loads zero principals). */
+export type TestCastDisabledReason = 'missing-testWorkspace-marker';
+
+export class TestWorkspacePrincipalSource implements UserLookup {
+  private readonly bySlackId = new Map<string, ResolvedUserRecord>();
+  private readonly workspaceId: string;
+  private readonly getVerifiedWorkspaceId: () => string | null | undefined;
+  /** Entries refused at load (surfaced loudly by the wiring site). */
+  readonly rejected: RejectedCastEntry[] = [];
+  /**
+   * True when the whole source refused to load (the self-declaration marker was
+   * absent). A disabled source holds ZERO principals and resolves everything to
+   * null — production resolution is byte-identical to having no cast configured.
+   */
+  readonly disabled: boolean = false;
+  /** Why the source disabled itself (only set when {@link disabled} is true). */
+  readonly disabledReason?: TestCastDisabledReason;
+
+  constructor(opts: TestWorkspacePrincipalSourceOpts) {
+    if (!opts.workspaceId || typeof opts.workspaceId !== 'string' || !opts.workspaceId.trim()) {
+      throw new Error('TestWorkspacePrincipalSource requires a non-empty workspaceId (the sanctioned live-test workspace)');
+    }
+    // Stored TRIMMED (second-pass review note): Slack's own `team_id` never
+    // carries whitespace, so a config value with a stray space would otherwise
+    // make the scope equality permanently false — an inert cast (fail-closed,
+    // but a silent config foot-gun the boot log alone would have to catch).
+    this.workspaceId = opts.workspaceId.trim();
+    this.getVerifiedWorkspaceId = opts.getVerifiedWorkspaceId;
+
+    // THE SELF-DECLARATION GATE (fail-closed): without an explicit
+    // `testWorkspace: true` the cast is IGNORED entirely — zero principals
+    // loaded, one loud line, no throw, no production impact. The loud line lives
+    // HERE (not only at the wiring site) so the fail-closed guarantee holds for
+    // EVERY caller — Structure > Willpower.
+    if (opts.testWorkspace !== true) {
+      this.disabled = true;
+      this.disabledReason = 'missing-testWorkspace-marker';
+      console.warn(
+        `[slack] TestWorkspacePrincipalSource IGNORED for workspace ${this.workspaceId} — the testCast config is ` +
+        `missing its required "testWorkspace: true" self-declaration. Loading ZERO cast principals (fail-closed; the ` +
+        `production user registry is unaffected). Add "testWorkspace": true to sanction the live-test cast.`,
+      );
+      return; // no principals admitted
+    }
+
+    for (const entry of opts.principals ?? []) {
+      const slackUserId = typeof entry?.slackUserId === 'string' ? entry.slackUserId.trim() : '';
+      if (!slackUserId) {
+        this.rejected.push({ slackUserId: String(entry?.slackUserId ?? ''), reason: 'missing-slack-user-id' });
+        continue;
+      }
+      // THE PARTITION INVARIANT: only fixture-marker identities are admitted.
+      // Same single matcher as the production guard — never a second list.
+      if (!matchesTestIdentityToken(slackUserId)) {
+        this.rejected.push({ slackUserId, reason: 'not-a-fixture-identity' });
+        continue;
+      }
+      if (!entry.orgRole || !(ORG_ROLES as readonly string[]).includes(entry.orgRole)) {
+        this.rejected.push({ slackUserId, reason: 'invalid-role' });
+        continue;
+      }
+      if (this.bySlackId.has(slackUserId)) {
+        this.rejected.push({ slackUserId, reason: 'duplicate' });
+        continue;
+      }
+      if (this.bySlackId.size >= MAX_TEST_CAST_SEATS) {
+        this.rejected.push({ slackUserId, reason: 'cast-cap-exceeded' });
+        continue;
+      }
+      this.bySlackId.set(slackUserId, {
+        // Namespaced id so a cast principal is visibly a test seat in every
+        // ledger row / audit surface it appears in.
+        id: `test-cast:${slackUserId}`,
+        name: entry.name?.trim() || slackUserId,
+        permissions: [entry.orgRole],
+        orgRole: entry.orgRole,
+      });
+    }
+  }
+
+  /** Number of admitted cast seats. */
+  get size(): number {
+    return this.bySlackId.size;
+  }
+
+  /**
+   * Resolve a cast seat — ONLY while the verified connected workspace equals the
+   * sanctioned test workspace. Any uncertainty (no verified id yet, supplier
+   * throw, mismatch) resolves null: fail-closed to unregistered guest.
+   */
+  resolveFromSlackUserId(slackUserId: string): ResolvedUserRecord | null {
+    // A disabled source (missing marker) holds no principals — this is redundant
+    // with the empty map but makes the fail-closed contract explicit.
+    if (this.disabled) return null;
+    let verified: string | null | undefined;
+    try {
+      verified = this.getVerifiedWorkspaceId();
+    } catch {
+      // Fail-closed: an errored verification supplier keeps the cast inert.
+      return null;
+    }
+    if (!verified || verified !== this.workspaceId) return null;
+    return this.bySlackId.get(slackUserId) ?? null;
+  }
+}
+
+/**
+ * ChainedUserLookup — production-registry-first principal resolution.
+ *
+ * Sources are consulted in order; the first non-null record wins. The wiring
+ * site puts the production registry FIRST, so a genuinely registered user can
+ * never be shadowed or role-escalated by a cast entry, and the cast is only
+ * ever a fallback for identities the production registry does not know.
+ * A throwing source is skipped (resolution must never break the message path).
+ */
+export class ChainedUserLookup implements UserLookup {
+  constructor(private readonly sources: UserLookup[]) {}
+
+  resolveFromSlackUserId(slackUserId: string): ResolvedUserRecord | null {
+    for (const source of this.sources) {
+      try {
+        const record = source.resolveFromSlackUserId(slackUserId);
+        if (record) return record;
+      } catch {
+        // A faulty source must never break principal resolution — fall through
+        // to the next source (ultimately the unregistered-guest default).
+      }
+    }
+    return null;
+  }
+}

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -16,3 +16,4 @@ export * from './MandateBackedGrantStore.js';
 export * from './SlackPrincipalResolver.js';
 export * from './SlackPermissionObserver.js';
 export * from './SlackUserRegistry.js';
+export * from './TestWorkspacePrincipalSource.js';

--- a/tests/integration/slack-testcast-principal-pipeline.test.ts
+++ b/tests/integration/slack-testcast-principal-pipeline.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Integration (Tier 2): the test-workspace principal source through the REAL
+ * inbound chokepoint — SlackAdapter._handleMessage (roadmap 0.3 prerequisite).
+ *
+ * The unit suite (tests/unit/slack-test-workspace-principal-source.test.ts)
+ * proves the source's boundaries in isolation. THIS suite proves the production
+ * COMPOSITION — exactly how src/commands/server.ts wires it:
+ *
+ *   productionLookup ──┐
+ *                      ├─ ChainedUserLookup ─ SlackPrincipalResolver ─ observer
+ *   TestWorkspace ─────┘         (gate → PermissionDecisionLedger)
+ *   PrincipalSource (getVerifiedWorkspaceId ← adapter.getConnectedTeamId())
+ *
+ * — driven by synthetic inbound Slack events through the SAME method a real
+ * Socket-Mode event reaches, and asserted against the durable decision ledger.
+ * The headline row is the exact 2026-07-01 regression this feature fixes
+ * (fp-review row 29): the owner seat must resolve `owner, registered:true`
+ * through the LIVE message path — and must resolve as an unregistered guest the
+ * moment the adapter is connected to any other workspace (the scoping proof).
+ *
+ * The verified connected team id is simulated by assigning the same private
+ * field `SlackAdapter.start()` sets from Slack's `auth.test` response — the test
+ * never fakes a different mechanism than production uses. Credential-free: no
+ * Slack tokens, fixture-marker (`livetest-*`) ids only (never a real cast UID).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { SlackAdapter } from '../../src/messaging/slack/SlackAdapter.js';
+import { SlackPermissionObserver } from '../../src/permissions/SlackPermissionObserver.js';
+import { SlackPrincipalResolver, type UserLookup, type ResolvedUserRecord } from '../../src/permissions/SlackPrincipalResolver.js';
+import { PermissionDecisionLedger } from '../../src/permissions/PermissionDecisionLedger.js';
+import {
+  TestWorkspacePrincipalSource,
+  ChainedUserLookup,
+  type TestCastEntry,
+} from '../../src/permissions/TestWorkspacePrincipalSource.js';
+import { buildSliceZeroGate } from '../../src/permissions/testing/SlackScenarioHarness.js';
+
+const TEST_TEAM = 'T_LIVETEST';
+const PROD_TEAM = 'T_SOME_PRODUCTION_WORKSPACE';
+
+// Fixture-marker cast only (`livetest` is a reserved fixture prefix in
+// users/testIdentityMarkers.ts) — the partition invariant admits nothing else.
+const CAST: TestCastEntry[] = [
+  { slackUserId: 'livetest-owner', name: 'Owner Seat', orgRole: 'owner' },
+  { slackUserId: 'livetest-member', name: 'Member Seat', orgRole: 'member' },
+];
+const CAST_IDS = CAST.map((c) => c.slackUserId);
+
+// A benign, non-urgent owner ask that lands allow/within-authority for a
+// registered owner (scenario row 1's text) and refuse/unregistered for a guest.
+const OWNER_ASK = 'push the hotfix to prod when CI is green';
+
+type HandleFn = (e: Record<string, unknown>) => Promise<void>;
+
+function buildPipeline(opts: {
+  stateDir: string;
+  /** Production-registry stand-in consulted FIRST (server.ts order). */
+  production?: UserLookup;
+}) {
+  const adapter = new SlackAdapter(
+    {
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      // Cast ids must be AUTHORIZED to even reach the gate (the documented A1.3
+      // gotcha — an unauthorized sender never produces a decision row).
+      authorizedUserIds: [...CAST_IDS, 'livetest-stranger'],
+      workspaceMode: 'dedicated',
+    } as never,
+    opts.stateDir,
+  );
+  adapter.onMessage(async () => {});
+
+  const production: UserLookup = opts.production ?? { resolveFromSlackUserId: () => null };
+  // EXACTLY the server.ts composition: the scope supplier reads the adapter's
+  // VERIFIED connected team id — config alone is never the scope authority.
+  const source = new TestWorkspacePrincipalSource({
+    workspaceId: TEST_TEAM,
+    testWorkspace: true,
+    principals: CAST,
+    getVerifiedWorkspaceId: () => adapter.getConnectedTeamId(),
+  });
+  const ledger = new PermissionDecisionLedger(opts.stateDir);
+  const observer = new SlackPermissionObserver({
+    resolver: new SlackPrincipalResolver(new ChainedUserLookup([production, source])),
+    gate: buildSliceZeroGate(),
+    ledger,
+  });
+  adapter.setPermissionObserver(observer);
+
+  const handle = (adapter as never as { _handleMessage: HandleFn })._handleMessage.bind(adapter);
+  /** Simulate the verified `auth.test` capture — the SAME private field start() sets. */
+  const setVerifiedTeam = (teamId: string | null) => {
+    (adapter as unknown as { connectedTeamId: string | null }).connectedTeamId = teamId;
+  };
+  return { adapter, handle, ledger, setVerifiedTeam };
+}
+
+describe('test-cast principal source through SlackAdapter._handleMessage (Tier 2)', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-testcast-pipeline-'));
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/integration/slack-testcast-principal-pipeline.test.ts' });
+  });
+
+  it('FEATURE IS ALIVE: in the verified test workspace the owner seat resolves owner/registered through the LIVE path (the row-29 regression)', async () => {
+    const { handle, ledger, setVerifiedTeam } = buildPipeline({ stateDir: tmp });
+    setVerifiedTeam(TEST_TEAM);
+
+    await handle({ user: 'livetest-owner', text: OWNER_ASK, channel: 'D_OWNER', ts: '1' });
+
+    const rows = ledger.readRecent();
+    expect(rows).toHaveLength(1);
+    // The exact check the fp-review's re-provision checklist prescribes before
+    // any enforce flip: the owner seat is `owner, registered:true` — not the
+    // `guest, registered:false` that row 29 recorded after the registry rebuild.
+    expect(rows[0]).toMatchObject({
+      slackUserId: 'livetest-owner',
+      role: 'owner',
+      registered: true,
+      decision: 'allow',
+      basis: 'within-authority',
+      enforced: false, // observe-only stays observe-only — no flag flipped here
+    });
+    expect(rows[0].userId).toBe('test-cast:livetest-owner');
+  });
+
+  it('SCOPE BOUNDARY: connected to a DIFFERENT workspace, the same seat is an unregistered guest through the LIVE path', async () => {
+    const { handle, ledger, setVerifiedTeam } = buildPipeline({ stateDir: tmp });
+    setVerifiedTeam(PROD_TEAM); // verified connection is NOT the sanctioned test workspace
+
+    await handle({ user: 'livetest-owner', text: OWNER_ASK, channel: 'D_OWNER', ts: '2' });
+
+    const rows = ledger.readRecent();
+    expect(rows).toHaveLength(1);
+    // The cast is structurally invisible outside its workspace — the seat gets
+    // production's default treatment (refused on registration, tier ≥ 1).
+    expect(rows[0]).toMatchObject({
+      slackUserId: 'livetest-owner',
+      role: 'guest',
+      registered: false,
+      decision: 'refuse',
+      basis: 'unregistered',
+    });
+  });
+
+  it('FAIL-CLOSED PRE-VERIFICATION: before auth.test verifies the connection, the cast is inert through the LIVE path', async () => {
+    const { handle, ledger } = buildPipeline({ stateDir: tmp });
+    // adapter.start() never ran → getConnectedTeamId() is null (production truth,
+    // not a test contrivance) — the cast must not resolve on config alone.
+    await handle({ user: 'livetest-owner', text: OWNER_ASK, channel: 'D_OWNER', ts: '3' });
+
+    const rows = ledger.readRecent();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ role: 'guest', registered: false, basis: 'unregistered' });
+  });
+
+  it('UNLISTED uid in the verified test workspace stays an unregistered guest (no blanket workspace grant)', async () => {
+    const { handle, ledger, setVerifiedTeam } = buildPipeline({ stateDir: tmp });
+    setVerifiedTeam(TEST_TEAM);
+
+    await handle({ user: 'livetest-stranger', text: OWNER_ASK, channel: 'D_STRANGER', ts: '4' });
+
+    const rows = ledger.readRecent();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ slackUserId: 'livetest-stranger', role: 'guest', registered: false, basis: 'unregistered' });
+  });
+
+  it('PRODUCTION PRECEDENCE: a production-registry record beats the cast for the same uid through the LIVE path', async () => {
+    const productionRec: ResolvedUserRecord = { id: 'u-prod-real', name: 'Real Record', permissions: ['member'], orgRole: 'member' };
+    const production: UserLookup = {
+      resolveFromSlackUserId: (id) => (id === 'livetest-owner' ? productionRec : null),
+    };
+    const { handle, ledger, setVerifiedTeam } = buildPipeline({ stateDir: tmp, production });
+    setVerifiedTeam(TEST_TEAM);
+
+    // The cast lists this uid as OWNER, but production says MEMBER — production
+    // wins, so the member's prod-deploy ask is refused at the role floor (no
+    // cast-driven role escalation is possible, even inside the test workspace).
+    await handle({ user: 'livetest-owner', text: OWNER_ASK, channel: 'D_OWNER', ts: '5' });
+
+    const rows = ledger.readRecent();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      role: 'member',
+      registered: true,
+      userId: 'u-prod-real',
+      decision: 'refuse',
+      basis: 'floor-no-grant',
+    });
+  });
+});

--- a/tests/unit/slack-test-workspace-principal-source.test.ts
+++ b/tests/unit/slack-test-workspace-principal-source.test.ts
@@ -1,0 +1,314 @@
+/**
+ * TestWorkspacePrincipalSource — boundary + wiring tests (roadmap 0.3 prerequisite).
+ *
+ * The permission gate derives roles from the user registry. The 2026-07-01
+ * registry rebuild removed the Slack test-cast principals, and the
+ * fixture-identity guard now refuses test identities in the production registry
+ * — so the scenario cast can no longer resolve. This suite proves the SEPARATE
+ * test-workspace-scoped principal source resolves the cast WITHOUT touching the
+ * production registry, and that every scoping / authority boundary holds on BOTH
+ * sides.
+ *
+ * Fixture-identity note (requirement 7): these tests use clearly-fake `livetest-*`
+ * ids — NEVER a real cast UID. `livetest` is a reserved fixture-marker prefix
+ * (users/testIdentityMarkers.ts), so these ids are admitted by the same single
+ * matcher the production guard uses to REFUSE them from users.json.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import {
+  TestWorkspacePrincipalSource,
+  ChainedUserLookup,
+  MAX_TEST_CAST_SEATS,
+  type TestCastEntry,
+} from '../../src/permissions/TestWorkspacePrincipalSource.js';
+import {
+  SlackPrincipalResolver,
+  type UserLookup,
+  type ResolvedUserRecord,
+} from '../../src/permissions/SlackPrincipalResolver.js';
+
+const TEST_WORKSPACE = 'T_LIVETEST';
+const OTHER_WORKSPACE = 'T_PRODUCTION';
+
+// Clearly-fake cast — every id carries the reserved `livetest` fixture prefix.
+const CAST: TestCastEntry[] = [
+  { slackUserId: 'livetest-owner', name: 'Owner Seat', orgRole: 'owner' },
+  { slackUserId: 'livetest-admin', name: 'Admin Seat', orgRole: 'admin' },
+  { slackUserId: 'livetest-member', name: 'Member Seat', orgRole: 'member' },
+  { slackUserId: 'livetest-contrib', name: 'Contributor Seat', orgRole: 'contributor' },
+];
+
+/** A source scoped to TEST_WORKSPACE with the connected team pinned to `connectedTo`. */
+function makeSource(opts: {
+  connectedTo: string | null | undefined;
+  testWorkspace?: boolean;
+  principals?: TestCastEntry[];
+}) {
+  return new TestWorkspacePrincipalSource({
+    workspaceId: TEST_WORKSPACE,
+    testWorkspace: opts.testWorkspace ?? true,
+    principals: opts.principals ?? CAST,
+    getVerifiedWorkspaceId: () => opts.connectedTo,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('TestWorkspacePrincipalSource — scoping boundary (both sides)', () => {
+  it('matching teamId + LISTED uid → resolves the cast record with its role', () => {
+    const source = makeSource({ connectedTo: TEST_WORKSPACE });
+    const rec = source.resolveFromSlackUserId('livetest-owner');
+    expect(rec).not.toBeNull();
+    expect(rec).toMatchObject({
+      id: 'test-cast:livetest-owner',
+      name: 'Owner Seat',
+      orgRole: 'owner',
+      permissions: ['owner'],
+    });
+  });
+
+  it('matching teamId + UNLISTED uid → null (falls through to unregistered guest)', () => {
+    const source = makeSource({ connectedTo: TEST_WORKSPACE });
+    expect(source.resolveFromSlackUserId('livetest-unlisted')).toBeNull();
+  });
+
+  it('NON-matching teamId + LISTED uid → source structurally invisible (null)', () => {
+    const source = makeSource({ connectedTo: OTHER_WORKSPACE });
+    // Every listed seat resolves null when the connected workspace is not the
+    // sanctioned one — the cast is invisible, not a fallback/merge.
+    for (const entry of CAST) {
+      expect(source.resolveFromSlackUserId(entry.slackUserId)).toBeNull();
+    }
+  });
+
+  it('connected team not yet verified (null) → inert (fail-closed before auth.test)', () => {
+    const source = makeSource({ connectedTo: null });
+    expect(source.resolveFromSlackUserId('livetest-owner')).toBeNull();
+  });
+
+  it('connected team supplier THROWS → inert (fail-closed on a broken supplier)', () => {
+    const source = new TestWorkspacePrincipalSource({
+      workspaceId: TEST_WORKSPACE,
+      testWorkspace: true,
+      principals: CAST,
+      getVerifiedWorkspaceId: () => { throw new Error('auth.test failed'); },
+    });
+    expect(source.resolveFromSlackUserId('livetest-owner')).toBeNull();
+  });
+});
+
+describe('TestWorkspacePrincipalSource — the testWorkspace self-declaration marker (req 3)', () => {
+  it('missing marker → whole source disabled, ZERO seats, logged loudly, never crashes', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const source = makeSource({ connectedTo: TEST_WORKSPACE, testWorkspace: false });
+
+    expect(source.disabled).toBe(true);
+    expect(source.disabledReason).toBe('missing-testWorkspace-marker');
+    expect(source.size).toBe(0);
+    // Even a matching workspace + a listed uid resolves null when disabled.
+    expect(source.resolveFromSlackUserId('livetest-owner')).toBeNull();
+
+    // Exactly one loud line naming the missing marker.
+    const loud = warn.mock.calls.map((c) => String(c[0]));
+    expect(loud.some((l) => /testWorkspace/i.test(l) && /IGNORED|ZERO|fail-closed/i.test(l))).toBe(true);
+  });
+
+  it('marker present but not literally true (e.g. undefined) → disabled (fail-closed)', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const source = new TestWorkspacePrincipalSource({
+      workspaceId: TEST_WORKSPACE,
+      // simulate a config where the field is absent → coerced to false at wiring
+      testWorkspace: undefined as unknown as boolean,
+      principals: CAST,
+      getVerifiedWorkspaceId: () => TEST_WORKSPACE,
+    });
+    expect(source.disabled).toBe(true);
+    expect(source.size).toBe(0);
+  });
+
+  it('marker present (true) → source enabled, seats admitted, NOT disabled', () => {
+    const source = makeSource({ connectedTo: TEST_WORKSPACE, testWorkspace: true });
+    expect(source.disabled).toBe(false);
+    expect(source.disabledReason).toBeUndefined();
+    expect(source.size).toBe(CAST.length);
+  });
+});
+
+describe('TestWorkspacePrincipalSource — the partition invariant (fixture-only admission)', () => {
+  it('a NON-fixture uid is refused at load (never admitted, even with the marker)', () => {
+    const source = makeSource({
+      connectedTo: TEST_WORKSPACE,
+      principals: [
+        { slackUserId: 'livetest-owner', orgRole: 'owner' }, // fixture → admitted
+        { slackUserId: 'U_REAL_EMPLOYEE', orgRole: 'admin' }, // NOT a fixture → refused
+      ],
+    });
+    expect(source.size).toBe(1);
+    expect(source.resolveFromSlackUserId('U_REAL_EMPLOYEE')).toBeNull();
+    expect(source.rejected).toContainEqual({ slackUserId: 'U_REAL_EMPLOYEE', reason: 'not-a-fixture-identity' });
+  });
+
+  it('an invalid orgRole is refused at load', () => {
+    const source = makeSource({
+      connectedTo: TEST_WORKSPACE,
+      principals: [{ slackUserId: 'livetest-owner', orgRole: 'superuser' }],
+    });
+    expect(source.size).toBe(0);
+    expect(source.rejected).toContainEqual({ slackUserId: 'livetest-owner', reason: 'invalid-role' });
+  });
+
+  it('a duplicate uid is refused (one seat per id)', () => {
+    const source = makeSource({
+      connectedTo: TEST_WORKSPACE,
+      principals: [
+        { slackUserId: 'livetest-owner', orgRole: 'owner' },
+        { slackUserId: 'livetest-owner', orgRole: 'admin' },
+      ],
+    });
+    expect(source.size).toBe(1);
+    expect(source.rejected).toContainEqual({ slackUserId: 'livetest-owner', reason: 'duplicate' });
+    // The FIRST valid seat wins — no silent role escalation on a re-declaration.
+    expect(source.resolveFromSlackUserId('livetest-owner')?.orgRole).toBe('owner');
+  });
+
+  it('the cast cap bounds the source (it can never become a shadow registry)', () => {
+    const many: TestCastEntry[] = Array.from({ length: MAX_TEST_CAST_SEATS + 3 }, (_, i) => ({
+      slackUserId: `livetest-seat-${i}`,
+      orgRole: 'member',
+    }));
+    const source = makeSource({ connectedTo: TEST_WORKSPACE, principals: many });
+    expect(source.size).toBe(MAX_TEST_CAST_SEATS);
+    expect(source.rejected.filter((r) => r.reason === 'cast-cap-exceeded')).toHaveLength(3);
+  });
+
+  it('a non-string workspaceId throws (a construction error, not a silent no-op)', () => {
+    expect(() => new TestWorkspacePrincipalSource({
+      workspaceId: '',
+      testWorkspace: true,
+      principals: CAST,
+      getVerifiedWorkspaceId: () => TEST_WORKSPACE,
+    })).toThrow(/workspaceId/);
+  });
+
+  it('a whitespace-padded workspaceId is stored TRIMMED (no permanently-inert cast from a stray space)', () => {
+    // Slack's own team_id never carries whitespace — a padded config value must
+    // still match the verified connected id (second-pass review note).
+    const source = new TestWorkspacePrincipalSource({
+      workspaceId: `  ${TEST_WORKSPACE} `,
+      testWorkspace: true,
+      principals: CAST,
+      getVerifiedWorkspaceId: () => TEST_WORKSPACE,
+    });
+    expect(source.resolveFromSlackUserId('livetest-owner')?.orgRole).toBe('owner');
+  });
+});
+
+describe('ChainedUserLookup — production-registry-first precedence', () => {
+  it('production record WINS over a cast record for the same uid (no shadowing/escalation)', () => {
+    const productionRec: ResolvedUserRecord = { id: 'u-real', name: 'Real', permissions: ['member'], orgRole: 'member' };
+    const production: UserLookup = {
+      resolveFromSlackUserId: (id) => (id === 'livetest-owner' ? productionRec : null),
+    };
+    const cast = makeSource({ connectedTo: TEST_WORKSPACE });
+    const chain = new ChainedUserLookup([production, cast]);
+    // Production is consulted first — its record wins even though the cast has
+    // an 'owner' seat for the same id.
+    expect(chain.resolveFromSlackUserId('livetest-owner')).toBe(productionRec);
+  });
+
+  it('cast is the FALLBACK when production does not know the uid', () => {
+    const production: UserLookup = { resolveFromSlackUserId: () => null };
+    const cast = makeSource({ connectedTo: TEST_WORKSPACE });
+    const chain = new ChainedUserLookup([production, cast]);
+    expect(chain.resolveFromSlackUserId('livetest-admin')?.orgRole).toBe('admin');
+  });
+
+  it('a THROWING source is skipped — resolution never breaks the message path', () => {
+    const boom: UserLookup = { resolveFromSlackUserId: () => { throw new Error('registry read failed'); } };
+    const cast = makeSource({ connectedTo: TEST_WORKSPACE });
+    const chain = new ChainedUserLookup([boom, cast]);
+    expect(chain.resolveFromSlackUserId('livetest-member')?.orgRole).toBe('member');
+  });
+});
+
+describe('Wiring: SlackPrincipalResolver actually consults the source (real construction path)', () => {
+  // This mirrors EXACTLY how src/commands/server.ts composes principal resolution:
+  //   productionLookup → ChainedUserLookup([production, testCastSource]) → SlackPrincipalResolver
+  const production: UserLookup = { resolveFromSlackUserId: () => null }; // no Slack ids in the prod registry
+
+  it('a cast seat resolves to a REGISTERED principal with the seat role (matching workspace)', () => {
+    const cast = makeSource({ connectedTo: TEST_WORKSPACE });
+    const resolver = new SlackPrincipalResolver(new ChainedUserLookup([production, cast]));
+
+    const owner = resolver.resolve('livetest-owner', 'Owner Display');
+    expect(owner).toMatchObject({ slackUserId: 'livetest-owner', role: 'owner', registered: true });
+    expect(owner.userId).toBe('test-cast:livetest-owner');
+
+    const contrib = resolver.resolve('livetest-contrib');
+    expect(contrib).toMatchObject({ role: 'contributor', registered: true });
+  });
+
+  it('an UNLISTED uid in the test workspace resolves to an unregistered guest', () => {
+    const cast = makeSource({ connectedTo: TEST_WORKSPACE });
+    const resolver = new SlackPrincipalResolver(new ChainedUserLookup([production, cast]));
+    const guest = resolver.resolve('livetest-stranger', 'Stranger');
+    expect(guest).toMatchObject({ role: 'guest', registered: false, userId: null });
+  });
+
+  it('production behavior is BYTE-IDENTICAL when the connected workspace is not the test one', () => {
+    // Baseline: resolver with NO cast at all (file-absent → today's behavior).
+    const baseline = new SlackPrincipalResolver(production);
+    // Same resolver but chained with a cast whose adapter is connected ELSEWHERE.
+    const castElsewhere = makeSource({ connectedTo: OTHER_WORKSPACE });
+    const withInvisibleCast = new SlackPrincipalResolver(new ChainedUserLookup([production, castElsewhere]));
+
+    for (const id of ['livetest-owner', 'livetest-admin', 'someone-else']) {
+      expect(withInvisibleCast.resolve(id)).toEqual(baseline.resolve(id));
+    }
+  });
+
+  it('a DISABLED cast (missing marker) is byte-identical to no cast at all', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const baseline = new SlackPrincipalResolver(production); // file-absent baseline
+    const disabledCast = makeSource({ connectedTo: TEST_WORKSPACE, testWorkspace: false });
+    const withDisabledCast = new SlackPrincipalResolver(new ChainedUserLookup([production, disabledCast]));
+
+    for (const id of ['livetest-owner', 'livetest-member', 'anyone']) {
+      expect(withDisabledCast.resolve(id)).toEqual(baseline.resolve(id));
+    }
+  });
+});
+
+describe('Scope of authority (KYP): the source feeds ROLE RESOLUTION ONLY', () => {
+  it('exposes ONLY the UserLookup read contract — no write/registry/operator surface', () => {
+    const source = makeSource({ connectedTo: TEST_WORKSPACE });
+    // The read contract it is allowed to satisfy:
+    expect(typeof source.resolveFromSlackUserId).toBe('function');
+    // It must NOT carry any user-registry WRITE surface…
+    for (const method of ['addUser', 'saveUser', 'setOperator', 'register', 'upsert', 'writeUsers', 'save']) {
+      expect((source as unknown as Record<string, unknown>)[method]).toBeUndefined();
+    }
+    // …nor any inbound-sender-authorization / operator-binding surface.
+    for (const method of ['isAuthorized', 'resolveFromTelegram', 'getOperator', 'validateSender', 'bindOperator']) {
+      expect((source as unknown as Record<string, unknown>)[method]).toBeUndefined();
+    }
+  });
+
+  it('resolving takes NO constructor state dir and performs NO filesystem writes by construction', () => {
+    // The source is constructed from in-memory config only (workspaceId + principals
+    // + a supplier fn) — it has no stateDir, no fs handle, so it structurally
+    // cannot create/modify users.json or any operator-binding file.
+    const source = makeSource({ connectedTo: TEST_WORKSPACE });
+    // Resolve a bunch; the returned records are plain data, namespaced so they can
+    // never be mistaken for a real registry id (which is what operator binding /
+    // sender validation key on).
+    const rec = source.resolveFromSlackUserId('livetest-owner');
+    expect(rec?.id.startsWith('test-cast:')).toBe(true);
+    // No throw, no side effects — resolution is a pure map read behind the scope gate.
+    expect(() => source.resolveFromSlackUserId('livetest-owner')).not.toThrow();
+  });
+});

--- a/upgrades/next/slack-test-workspace-principal-source.md
+++ b/upgrades/next/slack-test-workspace-principal-source.md
@@ -1,0 +1,93 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes the roadmap-0.3 blocker found in the Slack permission-gate false-positive
+review (`docs/audits/slack-permission-fp-review-2026-07.md`, row 29): after the
+2026-07-01 silent-loss registry rebuild, the Slack live-test scenario cast could no
+longer resolve, so every Slack sender — including the workspace owner — resolved as an
+unregistered guest. Root cause: the gate derives roles from the production user registry
+(`users.json`), the rebuild removed the five Slack test-cast principals, and the
+fixture-identity guard (correctly) refuses to let test identities back into the
+production registry.
+
+The fix is a SEPARATE, test-workspace-scoped principal source rather than a registry
+edit:
+
+- **New `TestWorkspacePrincipalSource` + `ChainedUserLookup`** (`src/permissions/`).
+  The gate's `SlackPrincipalResolver` now reads production-registry-FIRST, then the
+  cast as a fallback. A production-registered user can never be shadowed or
+  role-escalated by a cast entry.
+- **Config-carried cast** — `permissionGate.testCast` in the Slack messaging config
+  (`{ testWorkspace, workspaceId, principals[] }`). It lives beside the workspace
+  tokens, so a `users.json` rebuild can never silently drop it again.
+- **Code-enforced workspace scoping** — the cast resolves ONLY while the adapter's
+  VERIFIED connected team id (captured from Slack's own `auth.test` at start, exposed
+  via `SlackAdapter.getConnectedTeamId()`) EXACTLY equals `workspaceId`. Any other
+  workspace → the source is structurally invisible (production behavior byte-identical
+  to no cast). An unlisted uid in the test workspace → today's unregistered-guest default.
+- **Partition invariant** — every cast `slackUserId` must match the SAME fixture-marker
+  matcher (`users/testIdentityMarkers.ts`) the production guard uses to refuse fixtures;
+  a non-fixture id is refused at load. One identity, two disjoint homes.
+- **Fail-closed self-declaration** — the block must set `testWorkspace: true`; without
+  it the whole cast is ignored (zero principals, one loud log line, no production
+  effect). A cast can never be activated by accident.
+- **Authority scope (KYP)** — the source feeds permission-gate role resolution ONLY. It
+  takes no state dir and has no write surface, so it cannot create user-registry
+  entries, cannot feed operator binding, and cannot affect message authorization /
+  sender validation.
+
+The runbook (`docs/specs/SLACK-ORG-TEST-WORKSPACE-RUNBOOK.md`) is patched: the old
+"seed the cast in users.json" step is replaced with the `testCast` config block plus a
+re-provision checklist so a registry rebuild can't silently lose principal resolution
+again. Dark by default — nothing activates without an explicit `testCast` block.
+
+## What to Tell Your User
+
+- **Slack permission demo is more robust**: the test harness that proves the Slack
+  "who's allowed to do what" feature now keeps its demo cast in a safe place that a
+  routine cleanup of your real people-list can't wipe out. This is behind-the-scenes
+  test infrastructure — nothing changes in how I work for you day to day, and the
+  pretend demo roles are locked to the throwaway test workspace so they can never leak
+  into a real one.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Test-workspace-scoped Slack principal cast | Add a `testCast` block (with `testWorkspace: true`, `workspaceId`, `principals`) under the Slack `permissionGate` config — dark unless configured |
+
+## Evidence
+
+Root cause is a live datapoint captured in `docs/audits/slack-permission-fp-review-2026-07.md`:
+row 29 (2026-07-02 18:15:19, the only organic decision row) shows the workspace OWNER
+seat's Slack UID resolving as `role: guest, registered: false` — the same UID that
+resolved as `role: owner, registered: true` in every June scenario row, because the
+2026-07-01 rebuild removed the cast from `users.json`.
+
+The fix is verified by `tests/unit/slack-test-workspace-principal-source.test.ts` (22
+tests, all passing), which exercises BOTH sides of every boundary:
+
+- matching workspace + listed uid → registered role; matching workspace + unlisted uid
+  → guest.
+- non-matching workspace + listed uid → source invisible, and the resolved principal is
+  asserted EQUAL to the no-cast baseline (the scoping proof that roles can't leak into a
+  production workspace).
+- missing `testWorkspace: true` → source disabled, zero seats, loud log line, and
+  byte-identical to no cast.
+- non-fixture uid refused at load; cast cap enforced; production-registry-first
+  precedence; a throwing source skipped.
+- authority-scope assertions: the source exposes only the read contract (no
+  write/registry/operator methods) and takes no state dir.
+
+`tests/integration/slack-testcast-principal-pipeline.test.ts` (5 tests, all passing)
+additionally drives the EXACT server.ts composition through the real inbound chokepoint
+(`SlackAdapter._handleMessage`) and asserts the durable decision-ledger rows: the owner
+seat resolves `owner, registered:true` through the live path (the row-29 regression),
+the same seat is an unregistered guest when connected to any other workspace or before
+`auth.test` verifies the connection, an unlisted uid stays a guest, and a production
+record beats the cast for the same uid.
+
+`npx tsc --noEmit` exits 0.

--- a/upgrades/side-effects/slack-test-workspace-principal-source.md
+++ b/upgrades/side-effects/slack-test-workspace-principal-source.md
@@ -1,0 +1,227 @@
+# Side-Effects Review — Slack test-workspace-scoped principal source
+
+**Version / slug:** `slack-test-workspace-principal-source`
+**Date:** `2026-07-02`
+**Author:** `echo`
+**Second-pass reviewer:** `echo (independent second pass)`
+
+## Summary of the change
+
+Adds a sanctioned, workspace-scoped principal source for the Slack permission gate's
+role resolution, so the live-test scenario cast can resolve WITHOUT being seeded into
+the production user registry (`users.json`). Files touched:
+`src/permissions/TestWorkspacePrincipalSource.ts` (new: `TestWorkspacePrincipalSource`
++ `ChainedUserLookup`), `src/permissions/index.ts` (export), `src/messaging/slack/types.ts`
+(`permissionGate.testCast` config shape incl. the `testWorkspace` marker),
+`src/messaging/slack/SlackAdapter.ts` (capture + expose the VERIFIED connected team id
+from `auth.test`), `src/commands/server.ts` (wire production-registry-first chained
+resolution + fail-closed on the missing marker), the runbook
+(`docs/specs/SLACK-ORG-TEST-WORKSPACE-RUNBOOK.md`), and the unit test suite. The single
+decision point it interacts with is the gate's **principal role resolution** — it FEEDS
+that lookup as a fallback data source; it adds no new block/allow authority.
+
+## Decision-point inventory
+
+- `SlackPrincipalResolver` role resolution (`src/permissions/SlackPrincipalResolver.ts`) — **pass-through / feed** — the resolver now reads from a `ChainedUserLookup` (production registry first, then the test cast) instead of the bare production lookup. The resolver's own logic (registered vs guest, role derivation) is unchanged.
+- `TestWorkspacePrincipalSource.resolveFromSlackUserId` — **add** — a read-only lookup that answers ONLY for the verified test workspace and ONLY for fixture-marker ids; every uncertainty resolves null (fail-closed to the resolver's existing unregistered-guest default).
+- The permission gate's allow/refuse decision — **pass-through** — unchanged; it consumes the resolved principal exactly as before.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No new block/allow surface — the source only resolves an id to a role (or null); the
+gate still owns every allow/refuse decision. The only "rejection" it performs is at
+LOAD time (refusing to admit a cast entry): a non-fixture id, an invalid role, a
+duplicate, or an over-cap entry is dropped from the cast. Those refusals cannot
+over-block a real user, because a refused cast entry simply falls through to production
+resolution (which is the authoritative path anyway). A production-registered user is
+never affected — the production lookup is consulted first and wins.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+The source is deliberately narrow, so the "misses" are by design: it does not itself
+enforce anything (observe-only gate is unchanged), and it does not attempt to detect a
+misconfigured `workspaceId` (a `workspaceId` that never matches the connected team id
+just means the cast stays permanently inert — the safe direction, surfaced by the boot
+log's `admitted/refused` counts and the runbook's re-provision checklist). It also does
+not cover a cast id that a future edit removes from the fixture-marker list — such an id
+would then be refused at load (`not-a-fixture-identity`), which is loud, not silent.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes — it is a low-level, in-memory DATA SOURCE (a `UserLookup` implementation) that feeds
+the existing higher-level `SlackPrincipalResolver`, which in turn feeds the gate. It does
+NOT re-implement role derivation (that stays in `deriveRole`), does NOT re-implement the
+allow/refuse policy (that stays in `SlackPermissionGate`), and does NOT duplicate the
+fixture-identity matcher (it reuses the single `matchesTestIdentityToken` the production
+guard uses — one matcher, never two lists). The workspace-scope check is the one piece of
+new logic, and it lives at exactly the layer that knows the verified connection (a supplier
+reading `SlackAdapter.getConnectedTeamId()`).
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change produces a signal (a resolved role, or null) consumed by an existing smart gate; it holds no block/allow authority.
+
+The source answers "what role, if any, does this id play in the sanctioned test
+workspace?" and nothing more. It never blocks, never sends, never mutates. The
+authoritative allow/refuse decision remains entirely with `SlackPermissionGate`. The
+one gate-shaped decision it makes — "should I answer for this id at all?" — is a
+structural OWNERSHIP check (verified connected team id EXACTLY equals the configured
+workspace id), not a brittle content heuristic, and it fails CLOSED (null) on every
+uncertainty. That is the signal-vs-authority-compliant shape: a cheap structural check
+that only ever WITHHOLDS an answer, never grants an escalation.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** production resolution is consulted FIRST in the chain, so the cast can
+  never shadow a genuinely registered user. The reverse (cast shadowed by production) is
+  intended — a production record always wins. Verified by the `ChainedUserLookup`
+  precedence test.
+- **Double-fire:** none — a single resolution per inbound message; `ChainedUserLookup`
+  returns at the first non-null source.
+- **Races:** none — the cast is built once at wiring time and is immutable thereafter;
+  `resolveFromSlackUserId` is a pure map read behind the scope gate. No shared mutable
+  state, no concurrent writers.
+- **Feedback loops:** none — the source is read-only and does not record or learn.
+- **Fixture-identity guard:** complementary, not conflicting. The production guard refuses
+  fixtures INTO `users.json`; this source admits ONLY fixtures. Same matcher, disjoint
+  homes — an identity lives in exactly one store.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- Other agents on the same machine? No — the source is per-Slack-adapter, in-memory.
+- Other users of the install base? No — dark by default; nothing loads unless a Slack
+  config adds a `testCast` block with `testWorkspace: true`. On a plain install the whole
+  path is inert.
+- External systems? Reads one additional field (`team_id`) from the EXISTING `auth.test`
+  response the adapter already calls at startup. No new Slack API call, no contract change
+  (both changed adapter files carry a `CONTRACT-EVIDENCE: EXEMPT` marker with the reason).
+- Persistent state? None — the source writes nothing (no state dir, no fs handle). It
+  cannot create/modify `users.json`, operator bindings, or any file. This is the load-
+  bearing authority-scope property (KYP): the cast feeds role resolution ONLY.
+- Operator surface (Mobile-Complete Operator Actions)? No operator-facing actions — this is
+  test-harness wiring configured in `.instar/config.json`, not a runtime operator action.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable. This change touches no dashboard renderer, approval
+page, or grant/revoke/secret-drop form.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** A Slack adapter is bound to one workspace and runs on the
+machine serving that Slack connection; the `testCast` config and the verified connected
+team id are properties of THAT machine's live Slack socket. There is no cross-machine
+state to replicate: the cast is read-only config-derived data, not learned/durable state,
+so it neither strands on topic transfer nor needs a pool-wide merged read. It emits no
+user-facing notices (no one-voice concern) and generates no URLs. If the same live-test
+Slack adapter is ever run on two machines, each independently derives the same cast from
+the same config and each independently verifies its own connected team id — no divergence
+is possible because the input is static config plus a per-machine verified connection.
+
+---
+
+## 8. Rollback cost
+
+**Pure code + config change — revert and ship a patch.** No persistent state is created,
+so there is no data migration and no agent-state repair. Because the feature is dark by
+default (nothing activates without an explicit `testCast` block), a rollback has zero
+user-visible surface on any normal install. Removing the `testCast` block from the one
+live-test config (or setting `enforce`/`observeOnly` off) instantly reverts to
+production-registry-only resolution with no restart-order hazards beyond the normal
+"restart to pick up config" rule.
+
+---
+
+## Conclusion
+
+The review produced one substantive design fix during the build: the in-flight code
+lacked the required `testWorkspace: true` self-declaration marker (requirement 3). It was
+added as a fail-closed gate that lives IN the source constructor (not only at the wiring
+site), so the "ignored + one loud log line, no production impact" guarantee holds for
+every caller — Structure over Willpower. The scoping proof (why roles can't leak into a
+production workspace) is the load-bearing property and is covered on both sides by tests:
+matching-workspace resolves the cast; non-matching-workspace is byte-identical to having
+no cast at all. The change is a signal-producing data source with no new authority, dark
+by default, and is clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** echo (independent second pass — the change touches the word "gate")
+**Independent read of the artifact: concur**
+
+Independently re-derived the three safety properties and confirmed each is covered on both
+sides in `tests/unit/slack-test-workspace-principal-source.test.ts`: (1) scope — matching
+team + listed id resolves the role, non-matching team is invisible AND byte-identical to
+the no-cast baseline; (2) partition — a non-fixture id is refused at load and the cap
+bounds the source so it can't become a shadow registry; (3) opt-in — a missing
+`testWorkspace` marker disables the whole source, loudly, and is byte-identical to no cast.
+Also confirmed the authority-scope assertions: the source exposes only the `UserLookup`
+read contract (no write/registry/operator methods) and takes no state dir, so it
+structurally cannot write `users.json` or feed operator binding / sender validation. One
+concern considered and dismissed: the scope check uses the adapter's connected team id
+rather than a per-message `team_id` — but a Slack adapter is bound to exactly one workspace
+(one bot token), so the verified connected team id IS authoritative for every inbound
+message and is strictly stronger than trusting an envelope field. Concur with the review's
+conclusion: clear to ship.
+
+**Second-pass reviewer (dedicated subagent, 2026-07-02): CONCUR.** Independently
+re-verified in code (not from this artifact): (a) no blocking authority — resolution
+returns a record or null only, the gate keeps every allow/refuse; (b) fail-closed on
+disabled/throw/unverified/mismatch; (c) zero changes under `src/users/` (`git diff`),
+production fixture-identity guard fully intact; (d) production-first chain order at the
+wiring site; (e) no fs/write surface, unreachable from sender auth (`isAuthorized` runs
+BEFORE the observer and never consults a `UserLookup`); (f) both test suites re-run green;
+(g) no-`testCast` installs byte-identical (absent/invalid/disabled block leaves the bare
+production lookup; the whole wiring sits in try/catch degrading to production-only). Two
+non-blocking notes, both addressed in this build: the Tier-2 integration suite is staged
+with the commit, and `workspaceId` is now stored TRIMMED (a padded config value can no
+longer yield a permanently-inert cast; covered by a new unit test).
+
+---
+
+## Evidence pointers
+
+- `tests/unit/slack-test-workspace-principal-source.test.ts` — 23 tests, all passing (both
+  sides of scope, marker, partition, chain precedence, wiring, authority-scope, trim).
+- `tests/integration/slack-testcast-principal-pipeline.test.ts` — 5 tests, all passing
+  (Tier 2: the EXACT server.ts composition driven through the real inbound chokepoint
+  `SlackAdapter._handleMessage`, asserted against the durable decision ledger — the
+  row-29 owner-resolves-owner proof, the cross-workspace invisibility proof, fail-closed
+  pre-verification, unlisted-uid guest default, and production-precedence-beats-cast).
+  Tier 3 (E2E route liveness) is not applicable: the feature adds no HTTP routes, and its
+  only wiring site (`server.ts` Slack messaging block) requires live Slack credentials.
+- `npx tsc --noEmit` — exit 0.
+- Root-cause datapoint: `docs/audits/slack-permission-fp-review-2026-07.md` row 29 (the
+  owner seat resolving `guest, registered:false` after the 2026-07-01 registry rebuild).


### PR DESCRIPTION
# feat(slack): test-workspace-scoped principal source for the permission gate (roadmap 0.3)

## ELI16 — the plain-English version

Echo's Slack permission system needs test users to rehearse its rules against, but a safety guard (correctly) bans fake users from the real user list. On July 1 a registry repair rebuilt that real user list and — rightly — refused to let the five pretend "cast" identities (a fake owner, admin, member, contributor, and outsider) back in. Without them, the permission gate has nobody safe to practice on: every rehearsal sender suddenly looked like an unregistered stranger, and if enforcement had been on that day the gate would have locked the whole test workspace out. This change gives the permission gate a separate, clearly-marked test-workspace user source so rehearsals can run without fake identities ever touching the real registry. The cast lives in the Slack config block, is read-only, and only answers inside one named test workspace — verified against what Slack itself reports at connection time, never trusted from config alone. Three hard rules keep it safe: it only works in that one workspace (invisible everywhere else), it only accepts obviously-fake fixture identities (the same matcher the production guard uses to refuse them — so a real person's id can never be smuggled in for a role), and it must declare `testWorkspace: true` out loud or the whole block is ignored with one loud log line. The real registry always wins a lookup, so a registered person can never be shadowed or upgraded by a cast entry. On any install without this config block, behavior is byte-for-byte identical to today. Open questions: none — the design decisions (fail-closed scoping, fixture-only partition, explicit self-declaration, production-first precedence, 12-seat cap) were all settled in the side-effects review with a concurring second pass.

## What changed

- **`src/permissions/TestWorkspacePrincipalSource.ts` (new)** — `TestWorkspacePrincipalSource`: a read-only, in-memory `UserLookup` for the live-test scenario cast. Scoped to the adapter's VERIFIED connected team id (from `auth.test`), admits ONLY fixture-marker identities (`matchesTestIdentityToken` — the same single matcher the production guard uses to refuse them from `users.json`), requires an explicit `testWorkspace: true` self-declaration (otherwise: zero principals loaded, one loud warn, zero production effect), fail-closed (null) on every uncertainty, capped at `MAX_TEST_CAST_SEATS = 12`. Plus `ChainedUserLookup`: production-registry-first resolution, first non-null wins, throwing sources skipped.
- **`src/messaging/slack/SlackAdapter.ts`** — captures `team_id` from the EXISTING `auth.test` call at start and exposes it via `getConnectedTeamId()` (no new Slack API call; `CONTRACT-EVIDENCE: EXEMPT` marker in-file).
- **`src/messaging/slack/types.ts`** — adds the optional `permissionGate.testCast` config shape (type-only).
- **`src/commands/server.ts`** — wires the chain (production lookup first, cast second) ONLY when a valid `testCast` block exists; a disabled/invalid block leaves the bare production lookup — byte-identical to no cast at all. Whole wiring in try/catch degrading to production-only.
- **`docs/specs/SLACK-ORG-TEST-WORKSPACE-RUNBOOK.md`** — re-provision checklist updated for the config-carried cast.
- **`docs/specs/slack-test-workspace-principal-source.eli16.md`** (new), **`upgrades/next/`** + **`upgrades/side-effects/slack-test-workspace-principal-source.md`** — ELI16, release fragment, and the side-effects review (with a concurring dedicated second-pass review).

## Safety properties (each tested on both sides)

1. **Scope** — cast resolves only while the verified connected team id equals the configured test workspace id; any other workspace / pre-verification / supplier throw → null (unregistered-guest default).
2. **Partition invariant** — production registry refuses fixtures; this source accepts ONLY fixtures (same matcher). An identity can live in exactly one store; a real UID can never gain a role through the cast.
3. **Opt-in** — missing `testWorkspace: true` disables the whole source loudly; behavior is byte-identical to no cast (proven against a baseline resolver).
4. **Precedence** — production record beats a cast entry for the same UID (no cast-driven role escalation).
5. **Authority scope** — the source exposes only the `UserLookup` read contract; no write/registry/operator surface, no state dir, structurally cannot touch `users.json`, sender auth, or operator binding.

## Tests

- **Tier 1 (unit)** — `tests/unit/slack-test-workspace-principal-source.test.ts`: 23 tests (both sides of scope, marker, partition, chain precedence, wiring, authority scope, workspace-id trim).
- **Tier 2 (integration)** — `tests/integration/slack-testcast-principal-pipeline.test.ts`: 5 tests driving the EXACT server.ts composition through the REAL inbound chokepoint `SlackAdapter._handleMessage`, asserted against the durable decision ledger — including the fp-review row-29 regression proof (owner seat resolves `owner, registered:true` through the live path) and the cross-workspace invisibility proof.
- **Tier 3 (E2E)** — N/A: the feature adds no HTTP routes; its only wiring site is the server.ts Slack messaging block, which requires live Slack credentials. Rationale recorded in the side-effects artifact. (The e2e-pairing gate scope — `src/server/*.ts` — is untouched.)
- Related suites re-run green post-rebase: 76 tests across the Slack permission/resolver/registry/pipeline suites. `npx tsc --noEmit` exit 0; `npm run lint` clean.

## Rollback

Pure code + config change; dark by default (nothing activates without an explicit `testCast` block with `testWorkspace: true`). Revert the commit, or remove the `testCast` block from the one live-test config.

## Gate note

The commit used the audited `INSTAR_DEV_ALLOW_ORPHAN_DEFERRALS` override for one finding: the referenced spec's §7.7 heading ("Phase-3 adversarial follow-ups") is a historical descriptor of hardenings that already shipped (store + scorer + config wiring + tests landed together), not a deferral promise. The override is logged in `.instar/instar-dev-traces/orphan-deferral-overrides.jsonl`. An in-PR heading rephrase was attempted first but reverted: staging the spec requires staging its ELI16 companion, and fabricating an ELI16 edit to satisfy the gate would be worse than the audited override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
