### PR TITLE
feat(intelligence): per-target failure-swap timeout — fixes gemini-swap-timeout

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-03T00-59-49-618Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T00-59-49-618Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-03T00:59:49.618Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 256,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-03T01-01-42-219Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T01-01-42-219Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-03T01:01:42.219Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 256,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/per-target-swap-timeout-spec.md
+++ b/docs/specs/per-target-swap-timeout-spec.md
@@ -1,0 +1,260 @@
+---
+title: "Per-Target Failure-Swap Timeout"
+slug: "per-target-swap-timeout"
+author: "echo"
+eli16-overview: "per-target-swap-timeout.eli16.md"
+review-convergence: "2026-07-01T03:50:54.264Z"
+review-iterations: 3
+review-completed-at: "2026-07-01T03:50:54.264Z"
+review-report: "docs/specs/reports/per-target-swap-timeout-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 8
+cheap-to-change-tags: 2
+contested-then-cleared: 1
+approved: true
+approved-by: "justin (blanket pre-approval, autonomous run topic 29723, 2026-07-01)"
+parent-principle: "No Silent Degradation to Brittle Fallback"
+parent-principle-fit: "The failure-swap engine (IntelligenceRouter.failureSwap for gating calls) IS this standard's in-practice mechanism — swap provider before failing closed, never silently degrade. A swap target whose natural latency exceeds the flat 5s cap (gemini p50 8.5s) can structurally NEVER succeed: the swap looks protective while being fake-protective for that target, the exact fake-safety failure mode the standard names. Per-target caps sized to measured latency make the mandated provider-swap genuinely viable; the total budget keeps the standard's other arm (fail closed, bounded) honest."
+---
+
+# Spec — Per-Target Failure-Swap Timeout (fixes gemini-swap-timeout)
+
+**Status:** draft (pre-spec-converge) · **Origin:** llm-pathway-characterization project, R4 finding.
+**Ships:** dark/reversible, config-gated, additive — default behavior byte-identical to today.
+
+## Problem statement
+
+`IntelligenceRouter` failure-swap uses ONE global cap `swapAttemptTimeoutMs` (default 5000ms,
+`server.ts` `config.intelligence?.swapAttemptTimeoutMs ?? 5000`). Each swap attempt races this cap
+and passes it to the target as `timeoutMs` (subprocess SIGTERMs at the bound).
+
+**Measured (llm-pathway-bench, N=30, uncontended):** gemini-flash p50 = 8,538ms, p95 = 15,726ms.
+The 5s cap is BELOW gemini's median, so whenever gemini is a swap target it is killed at 5s before
+it can answer on the majority of attempts — it reliably wastes a full 5s swap slot then fails
+("poisoning the failover tail"). Other targets have different natural speeds too (claude ~3s p50 /
+~6s p95, pi ~4.6s / ~7s, codex ~18s / ~43s), so a single cap cannot fit all.
+
+## Fix
+
+Make the swap cap resolvable PER TARGET FRAMEWORK, with an explicit validation contract, a
+per-attempt clamp, AND a total swap-budget ceiling that bounds the fail-closed tail.
+
+### `resolveCap` — exact contract (addresses validation / zero-is-falsy / byte-identical findings)
+
+```
+# isValid(x) := typeof x === 'number' && Number.isFinite(x) && x > 0
+
+resolveCap(target, globalCap, byFramework, maxCap):
+  perTarget = byFramework?.[target]
+  candidate = isValid(perTarget) ? perTarget : (isValid(globalCap) ? globalCap : undefined)
+  if candidate === undefined: return undefined            # no cap (today's behavior when global ≤0/unset)
+  effMax = isValid(maxCap) ? maxCap : 120000              # maxCap itself validated; invalid → default 120s
+  return Math.min(candidate, effMax)                      # per-attempt clamp (never exceeds maxCap)
+
+# At each swap-loop iteration, the EFFECTIVE cap also honors the remaining total budget:
+attemptCap(target, ...):
+  cap = resolveCap(target, globalCap, byFramework, maxCap)
+  if swapTotalBudgetMs is set (isValid):                  # unset ⇒ no budget enforcement (semantics unchanged)
+    remaining = swapTotalBudgetMs - elapsedSinceFirstSwap
+    if remaining <= 250: STOP loop, fall closed           # too little budget left to bother (fixed 250ms floor)
+    cap = (cap === undefined) ? remaining : min(cap, remaining)   # budget bounds even an un-capped attempt
+  pass `cap` as the attempt's timeoutMs (undefined ⇒ no timer, only when no cap AND no budget)
+```
+
+- **Monotonic clock (round-3 external finding):** `elapsedSinceFirstSwap` MUST be a MONOTONIC elapsed
+  time (`performance.now()` / `process.hrtime`), NOT `Date.now()` — a wall-clock jump (NTP step, DST)
+  must not make the budget spuriously short or long. `swapTotalBudgetMs` validation is `isFinite && >0`;
+  a value `< 250` passes validation but simply disables swapping on the first attempt (fail-SAFE — an
+  absurd misconfig fails closed, never open).
+- **Provider timeout contract:** passing `cap` as `timeoutMs` bounds the attempt only if the provider
+  HONORS `timeoutMs` as a hard subprocess deadline (the existing CLI providers SIGTERM at the bound;
+  see the codex process-group-kill note in the pathway-characterization findings). A provider that
+  ignores `timeoutMs` could overrun — the `Promise.race` timer still resolves the swap decision at the
+  cap, but the orphaned subprocess is the provider's own kill-path responsibility (unchanged by this spec).
+
+- **Validation is uniform and total:** a per-framework value that is `0`, negative, `NaN`,
+  `Infinity`, or a non-number is INVALID and FALLS THROUGH to the global (never "no cap", never an
+  immediate-0ms kill, never a `NaN`→`setTimeout` instant-fire). Selection uses a presence + `typeof`
+  guard, **never `||`** (the zero-is-falsy lesson) — but note the deliberate design choice in FD5:
+  per-framework CANNOT express "unbounded" (only the global's ≤0/unset does), which closes the
+  accidental-uncap footgun the reviewers flagged.
+- **Per-attempt clamp:** the resolved cap is clamped to `maxCap` (`swapAttemptTimeoutMsMax`, default
+  120000ms) so a huge/typo'd value cannot create an effectively unbounded subprocess that pins a
+  host spawn-cap slot.
+
+### Bounding the fail-closed tail (total swap budget) — addresses the ~85s reachability finding
+
+Per-target caps remove the old uniform `cap × (1+tail)` ceiling; a naive Σ of the recommended values
+is ~85s, which would hold a gating call (e.g. the tone gate → a user's outbound message) that long
+before failing closed — a reachability regression. Fix: a wall-clock **total swap budget**
+`swapTotalBudgetMs` that bounds the WHOLE swap tail, made truly load-bearing (round-2 finding):
+
+- **The budget clamps each in-flight attempt, not just the loop gate.** The effective cap for each
+  attempt is `min(resolvedCap, budgetRemaining)` where `budgetRemaining = swapTotalBudgetMs − elapsedSinceFirstSwap`.
+  Checking the budget only BEFORE each attempt is insufficient — an attempt admitted at
+  `budget − ε` would still run its full per-target cap, so worst-case would be `budget + maxCap`
+  (~150s at defaults), NOT `≤ budget`. Clamping each attempt to the remainder makes the ceiling
+  literally `≤ swapTotalBudgetMs`. If `budgetRemaining` is ≤ a small floor (e.g. 250ms — too little
+  time to be worth an attempt), the loop stops and falls closed.
+- **The budget DEFAULTS UNSET (dark, truly byte-identical).** With `swapTotalBudgetMs` unset there is
+  NO total-budget enforcement — behavior is byte-identical to today for ANY existing `failureSwap`
+  configuration (including >6 targets, a high custom global cap, or legacy unbounded router
+  construction). The budget engages ONLY when the operator sets it. The operator SHOULD set it
+  alongside the per-framework caps (recommended `swapTotalBudgetMs: 40000`); the recommended-values
+  block ships them together as one opt-in (FD8), so the reachability guarantee and the per-target
+  caps arrive as a package, never a partial config that regresses the tail.
+- So: per-target caps tune each attempt; `swapAttemptTimeoutMsMax` clamps any single attempt; the
+  total budget (when set) bounds the whole tail — three layers, all off by default.
+
+### Change surface (localized, additive)
+- `types.ts`: add optional `intelligence.swapAttemptTimeoutMsByFramework?: Partial<Record<IntelligenceFramework, number>>`
+  (typed to the framework union so an unknown/misspelled key is a compile-time smell; a stray key at
+  runtime simply falls through to global — no effect, logged as an unknown-key warning), plus
+  optional `intelligence.swapAttemptTimeoutMsMax?: number` and `intelligence.swapTotalBudgetMs?: number`.
+- `IntelligenceRouter` opts: add the three fields above.
+- `server.ts`: thread all three from `config.intelligence?.*` into the router opts (alongside the
+  existing `swapAttemptTimeoutMs`). The global still threads as `?? 5000`.
+- `IntelligenceRouter` swap loop: move cap resolution INSIDE the `for (const target ...)` loop —
+  `const cap = resolveCap(target, this.opts.swapAttemptTimeoutMs, this.opts.swapAttemptTimeoutMsByFramework, maxCap)`
+  — build `attemptOptions`/the timeout from the per-target `cap`, and check the total-budget before
+  each attempt. **Clear the timeout timer on settle** (a `withTimeout(promise, cap, label)` helper
+  that clears the timer in a `finally`) so a fast success does not leak a pending timer (codex-review
+  finding: avoidable timer churn under many calls).
+
+### Backward compatibility (dark/reversible) — precise
+- All three new fields default UNSET. With them unset, `resolveCap` returns the global
+  `swapAttemptTimeoutMs` (server-threaded as `?? 5000`) for every target, the per-attempt clamp is a
+  no-op (maxCap defaults 120s ≫ 5s), and there is NO total-budget enforcement (`swapTotalBudgetMs`
+  unset) — so the **routing/timeout semantics are unchanged under the default config** for ANY existing
+  `failureSwap` config (any target count, any global cap, legacy unbounded router construction). The
+  one internal difference is the timer-clear (clearing the `setTimeout` on settle) — a desirable
+  cleanup with no user-facing routing effect, though timer lifecycle / event-loop liveness differ
+  internally (so "byte-identical" is scoped to routing/timeout behavior, not literally every internal
+  effect). No `migrateConfig` needed (additive optional config; absence preserves current).
+- Recommended values (documented, operator opts in — NOT a shipped default, to keep the ship dark):
+  `swapAttemptTimeoutMsByFramework = { "claude-code": 8000, "pi-cli": 9000, "gemini-cli": 18000, "codex-cli": 45000 }`
+  (each ≥ measured p95 with margin; codex lowered 50000→45000 to sit under a sane total budget), with
+  `swapTotalBudgetMs` raised to e.g. 40000 if the operator wants the full tail. Caps SHOULD stay ≤ the
+  circuit breaker's failure threshold so a chronically-slow target still trips the breaker rather than
+  being kept alive indefinitely (see Safety). Setting these is the actual fix; shipping the mechanism
+  is this spec.
+- **Ordering matters:** the swap loop is sequential, so `failureSwap` target ORDER is latency-load-
+  bearing (a high-cap target early blocks faster later ones up to its cap or the budget). Operators
+  SHOULD order `failureSwap` fastest-first; cap ≠ priority. Documented so mis-ordering is a known knob.
+- Rollback: remove the config block → instant revert to the global cap.
+
+## Safety / invariants preserved
+- **The fail-closed tail is bounded by the TOTAL BUDGET (when set), including in-flight attempts.**
+  Because each attempt's effective cap is `min(resolvedCap, budgetRemaining)`, the worst-case swap-tail
+  latency is `≤ swapTotalBudgetMs` — literally, not "up to a per-target cap over." (Round-2 finding:
+  gating the budget only BEFORE each attempt left a `budget + maxCap` overrun; clamping each attempt to
+  the remainder closes it.) When `swapTotalBudgetMs` is UNSET (the dark default), there is no total-budget
+  ceiling and behavior is byte-identical to today. Note: user-visible latency ALSO includes the primary
+  attempt up to its own provider/circuit behavior BEFORE the swap tail — the budget bounds only the swap
+  tail, which is what this change affects.
+- **Per-attempt clamp** (`swapAttemptTimeoutMsMax`, default 120s) bounds any single attempt, so a
+  huge/typo'd cap cannot create an effectively unbounded subprocess that pins a host spawn-cap slot.
+- **Cap vs circuit breaker:** a per-target cap set ABOVE the breaker's failure threshold could keep a
+  chronically-slow-but-eventually-succeeding target answering so the breaker never opens. Guidance:
+  caps SHOULD stay ≤ the breaker's failure sensitivity; timed-out swap attempts still count toward the
+  breaker (unchanged). Documented as an operator constraint on the recommended values.
+- **Host spawn-cap interaction:** larger caps hold a host-wide spawn semaphore slot (fork-bomb ceiling,
+  default 8) up to ~10× longer than the old 5s. Under concurrent gating load this reduces effective
+  throughput; the total budget is the primary mitigation, and very-slow frameworks (codex) SHOULD be
+  ordered last / capped conservatively so they don't hold slots during a burst.
+- The `Promise.race` crash-safe pattern is unchanged (per-input settlement handler; late reject/resolve
+  handled); the added `withTimeout` helper only CLEARS the timer on settle (no behavior change). The
+  cap still flows to the subprocess as `timeoutMs`. Only `attribution.gating` calls with configured
+  `failureSwap` targets are affected (unchanged scope).
+- **Signal-vs-Authority (foundation note):** a static cap holds kill-authority over whether a provider
+  answers, blind to real latency — the root shape of the original incident. Static per-target caps
+  reduce the mis-fit but can still recur on operator misconfig or latency drift; auto-tuning from live
+  latency (FD3, out of scope) is the eventual calibration. The misfit itself is a signal, not fully
+  resolved — noted as a recurrence vector for the follow-up. <!-- tracked: CMT-1889 -->
+
+## Testing (per Testing-Integrity Standard — Tier-3 carve-out justified)
+This change adds NO HTTP route (it is an internal routing-timeout knob), so per the Testing-Integrity
+Standard's no-route carve-out there is no Tier-3 "feature-alive/200" e2e — Tiers 1 + 2 apply. Stated
+explicitly rather than claiming "all three tiers."
+- **Unit — `resolveCap`:** per-framework valid value used; per-framework present-but-INVALID (0, -1,
+  NaN, Infinity, "18000" string) FALLS THROUGH to global (not no-cap, not immediate-fire); unknown
+  key falls through to global; unset map → global; global ≤0/unset → undefined; resolved cap clamped
+  to `maxCap`. (Both-sides: valid vs each invalid class.)
+- **Unit — total budget clamps in-flight attempts:** with `swapTotalBudgetMs` set, an attempt admitted
+  near the budget edge gets an effective cap of `min(resolvedCap, budgetRemaining)` (NOT its full cap) —
+  assert the worst-case tail is `≤ swapTotalBudgetMs`, and the loop falls closed when remaining ≤ 250ms.
+  Regression: `swapTotalBudgetMs` UNSET → no budget enforcement, tail identical to per-cap-only behavior.
+- **Unit — value validation:** an invalid `swapAttemptTimeoutMsMax` (0/NaN/negative) → 120s default; an
+  invalid `swapTotalBudgetMs` → treated as unset (no enforcement).
+- **Unit — timer clear:** a fast success clears the pending timeout timer (no leaked timer).
+- **Unit (wiring):** router opts carry all three new fields; server threads them from config.
+- **Integration:** primary throws, gemini swap target with an 18s cap + an 8.5s-latency stub → swap
+  SUCCEEDS (previously timed out at 5s). Regression: no per-framework config → identical to the
+  existing single-cap integration test.
+
+## Ships-inert mitigation (Close the Loop — addresses "the field bug isn't fixed until opt-in")
+Because the ship is dark (empty default), gemini keeps dying at 5s until an operator sets the values —
+a dark ship that is never turned on is deferral = deletion. <!-- tracked: CMT-1889 --> So Fix-A DELIVERY (not just this spec)
+MUST: (1) surface the recommended `swapAttemptTimeoutMsByFramework` values to the operator as a
+one-tap go/no-go (per "operators act in taps, not text"), AND (2) register a tracked commitment so the
+opt-in is followed through, not merely made possible. The spec ships the mechanism; the delivery
+closes the loop.
+
+## Surface note (Agent Awareness Standard)
+No dashboard tab, no CLAUDE.md-template capability, no agent-facing API — this is an internal tuning
+knob, so no Agent Awareness template update is required. Stated to preempt the standard's question.
+
+## Out of scope
+- Auto-tuning caps from live latency (future). This ships static, operator-set caps.
+- Changing the DEFAULT cap value or shipping the recommended map as a default (would be behavioral →
+  separate go/no-go; this spec keeps the ship dark).
+
+## Decision points touched
+- **Modifies** the failure-swap timeout resolution in `IntelligenceRouter` (a routing/degrade path,
+  NOT a block/allow gate). No new block/allow gate is introduced or removed.
+- The swap only fires for `attribution.gating` calls with configured `failureSwap` targets — scope
+  unchanged. This spec changes only HOW LONG each target is given, per-target vs one flat cap.
+
+## Frontloaded Decisions
+- **FD1 — Default remains the current global cap (dark ship).** `swapAttemptTimeoutMsByFramework`
+  ships UNSET; with it unset behavior is byte-identical to today (global `swapAttemptTimeoutMs ?? 5000`).
+  The recommended per-framework values are documented for the operator to opt into, NOT shipped as a
+  default. Rationale: keep the ship dark/reversible; changing the effective default is a separate
+  behavioral decision. (Reversible: it's config; empty map = today.)
+- **FD2 — Resolution order is fixed:** `byFramework[target]` → global `swapAttemptTimeoutMs` →
+  undefined (no cap). Deterministic, no ambiguity.
+- **FD3 — No auto-tuning.** Caps are static operator-set values this round. Live-latency auto-tuning
+  is explicitly out of scope (future spec). Cheap-to-change-after: the mechanism is additive config;
+  auto-tuning can layer on later without reworking this.
+- **FD4 — Multi-machine posture: machine-local BY DESIGN.** The swap cap is a per-call routing
+  parameter read from local config at call time; it holds no durable cross-machine state, emits no
+  user-facing notice, and generates no URL. Each machine reads its own config. No replication needed.
+- **FD5 — Invalid/zero/negative per-framework value semantics (the load-bearing new decision).** A
+  per-framework value takes effect ONLY if `typeof === 'number' && Number.isFinite && > 0`; any other
+  value (0, negative, NaN, Infinity, non-number, or an unknown/misspelled key) FALLS THROUGH to the
+  global cap — it NEVER means "no cap" and NEVER produces an immediate-0ms kill. Deliberate consequence:
+  per-framework config CANNOT express "unbounded for this target" (only the global's ≤0/unset does) —
+  this closes the accidental-uncap footgun. Selection uses a presence + `typeof` guard, never `||`.
+- **FD6 — Bound the fail-closed tail with a total budget that clamps EACH attempt (not just the loop
+  gate).** `swapTotalBudgetMs` DEFAULTS UNSET (no enforcement ⇒ byte-identical to today for any existing
+  config, including >6 targets / high global cap / legacy unbounded router construction — the round-2
+  backward-compat finding). When SET, each attempt's effective cap is `min(resolvedCap, budgetRemaining)`
+  and the loop falls closed once `budgetRemaining ≤ 250ms`, so worst-case swap-tail latency is literally
+  `≤ swapTotalBudgetMs` (gating the budget only BEFORE each attempt was insufficient — an attempt admitted
+  at `budget−ε` would overrun by a full cap). The operator sets it alongside the per-framework caps
+  (recommended 40000) as ONE opt-in package (FD8) so the caps and their reachability ceiling arrive
+  together, never a partial config that regresses the tail.
+- **FD7 — Per-attempt clamp + value validation + timer hygiene.** Resolved caps are clamped to
+  `swapAttemptTimeoutMsMax` (default 120s; the maxCap VALUE is itself validated `isFinite && >0`, invalid
+  → the 120s default) so a typo can't create an unbounded attempt. `swapTotalBudgetMs` is likewise
+  validated (invalid → treated as unset ⇒ no enforcement). The timeout timer is cleared on settle (a
+  `withTimeout` helper) to avoid leaked timers. All internal-safety, no observable behavior change at the
+  default (all-unset) config. Cheap-to-change-after: pure internals behind the dark default.
+- **FD8 — Delivery closes the loop (not just the mechanism).** Shipping the mechanism dark is not the
+  end state: Fix-A delivery surfaces the recommended values to the operator as a one-tap go/no-go AND
+  registers a tracked commitment, so the gemini bug is actually fixed (opt-in followed through), not
+  merely made fixable. This is a delivery obligation, tracked outside this spec's code change.
+
+## Open questions
+*(none)*

--- a/docs/specs/per-target-swap-timeout.eli16.md
+++ b/docs/specs/per-target-swap-timeout.eli16.md
@@ -1,0 +1,25 @@
+# Per-Target Backup-Route Deadline — Plain-English Overview
+
+## What this is
+
+When the agent needs an AI model to make a quick safety decision (like "is this message an emergency stop?") and its first-choice tool fails, it tries a *backup* tool instead. To avoid getting stuck, each backup attempt has a deadline — a stopwatch that kills the attempt if it takes too long. Right now that deadline is a single number (5 seconds) applied to *every* backup tool the same way.
+
+## The problem
+
+Different AI tools answer at very different speeds. We measured them: Claude answers in about 3 seconds, pi in about 4.6 seconds, gemini in about 8.5 seconds, and codex in about 18 seconds (sometimes much longer). The one-size-fits-all 5-second deadline is *shorter than gemini's normal answer time*. So whenever gemini is used as a backup, it gets killed at 5 seconds — before it ever had a chance to answer. It just wastes 5 seconds and then fails. In practice, gemini as a backup route is broken: it can almost never succeed, no matter how healthy it is.
+
+## The fix
+
+Instead of one shared 5-second deadline, let each tool have its *own* deadline that matches how fast it actually is — gemini gets ~18 seconds, the fast tools keep their short deadlines. That way a backup attempt gets a fair chance to answer, and we stop throwing away time on attempts we killed too early.
+
+## What changes for the operator
+
+Nothing, unless you turn it on. This ships "dark": by default the behavior is exactly the same as today (the single 5-second deadline for everyone). The new per-tool deadlines are an optional setting you can switch on when you want. If you ever want to undo it, you just delete the setting and it snaps back to the old behavior instantly. Nothing is forced live.
+
+## Why it's safe
+
+The change is tiny and additive — it only adds a new optional setting and moves where the deadline is looked up (so it can be per-tool). It doesn't touch which calls use a backup, doesn't add any new "block this" powers, and keeps the same crash-safe pattern that was already there. The total time a chain of backups can take is still bounded. And because it ships off by default, there's zero risk to the running agent until someone deliberately sets the new values.
+
+## The tradeoff
+
+With per-tool deadlines set, a backup chain's worst-case time can be a little longer than the old flat 5-seconds-each — because we're now *willing to wait* for a slower tool that can actually succeed, instead of killing it early and falling through to nothing. That's the point: a backup that succeeds in 9 seconds beats one that "fails fast" in 5 and leaves the agent with no answer at all.

--- a/docs/specs/reports/per-target-swap-timeout-convergence.md
+++ b/docs/specs/reports/per-target-swap-timeout-convergence.md
@@ -1,0 +1,93 @@
+# Convergence Report — Per-Target Failure-Swap Timeout
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass ran through the agent's codex CLI on ALL THREE rounds (verdicts:
+MINOR ISSUES → MINOR ISSUES → MINOR ISSUES, each fully folded in). The gemini-2.5-pro external
+pass ran CLEAN on rounds 1 and 2 and degraded (timeout) on round 3; per the aggregate rule a
+successful external pass in a round yields the clean RAN flag, so the spec received genuine
+cross-model review. No ⚠ — this is the clean-pass state.
+
+## ELI10 Overview
+
+The agent uses AI models to make fast safety decisions (like "is this an emergency stop?"). When
+its first-choice model fails, it tries a backup — with a stopwatch that kills the attempt if it
+takes too long. Today that stopwatch is one number (5 seconds) for every backup model. But models
+answer at wildly different speeds: our benchmark measured Claude at ~3s, pi ~4.6s, gemini ~8.5s,
+codex ~18s. So the 5-second stopwatch is *shorter than gemini's normal answer time* — gemini gets
+killed before it can ever answer, making it useless as a backup.
+
+This spec lets each model have its own stopwatch that matches its real speed. It ships "dark": by
+default nothing changes; an operator opts in when they want. To make sure a slow model can't hold
+up a user's message forever, there's also an overall time budget for the whole backup chain — and
+(the key thing review caught) that budget now trims each attempt so the chain can *never* exceed
+it, not just "check before starting."
+
+If it ships and the operator turns it on: gemini becomes a working backup, and the total time a
+backup chain can take is guaranteed to stay under the budget. If they don't turn it on, behavior is
+exactly as today. The tradeoff: a backup chain that's *allowed* to wait for a slower-but-succeeding
+model can take a bit longer than one that "fails fast" — but a backup that succeeds beats one that
+gives up early and leaves the agent with no answer.
+
+## Original vs Converged
+
+The original spec was a small, correct idea — "give each model its own timeout" — but review
+hardened it in three important ways:
+
+1. **The safety timeout could be turned into a footgun.** Originally a per-model value of `0` or a
+   typo could either kill every attempt instantly (a `NaN` timer fires immediately) or accidentally
+   remove the timeout entirely. Converged: a strict validation rule — a per-model value only counts
+   if it's a real positive finite number, otherwise it falls back to the global default. You *can't*
+   accidentally uncap or instant-kill a model.
+
+2. **"Bounded" wasn't actually bounded.** The first attempt at a total time budget only checked the
+   clock *before* starting each backup — so a slow model admitted at the last second could still run
+   its full time and blow past the budget (worst case ~150 seconds, worse than the problem it was
+   fixing — this would have held up a user's outgoing message). Converged: each attempt is trimmed to
+   the *remaining* budget, so the total is now genuinely guaranteed to stay under the limit. This was
+   the single most important catch, found independently by every reviewer.
+
+3. **It would have shipped and done nothing.** Because it's off by default, gemini stays broken until
+   someone turns it on — a fix that's never applied. Converged: turning it on is delivered as a
+   one-tap operator choice bundled with the recommended values, plus a tracked follow-up so the loop
+   is actually closed, not just closable.
+
+Plus smaller precision fixes: use a monotonic clock (so a system clock change can't corrupt the
+budget), typed config keys (so a misspelled model name is caught), timer cleanup, and honest wording
+about exactly what "unchanged by default" covers.
+
+## Iteration Summary
+
+Standards-Conformance Gate: ran each round (0 flags).
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | security, scalability, adversarial, integration, decision-completeness, lessons-aware, codex-ext (gemini-ext CLEAN) | 8 | Added resolveCap validation contract (FD5), total swap budget (FD6), per-attempt clamp + timer-clear (FD7), delivery-closes-loop (FD8), typed keys, breaker/ordering/semaphore notes, P4 test carve-out, dashboard note, precise byte-identical wording |
+| 2 | scalability, security, adversarial, integration, decision-completeness, lessons-aware, codex-ext (gemini-ext CLEAN) — ALL raised the SAME finding (NF1) | 1 | Each attempt clamped to `min(cap, budgetRemaining)` → tail literally ≤ budget; `swapTotalBudgetMs` defaults UNSET (true byte-identical); maxCap/budget values validated |
+| 3 | 6 internal ALL CONVERGED; codex-ext 3 minor clarifications (gemini-ext degraded/timeout) | 0 material (3 minor clarifications folded in) | Monotonic clock for elapsed; softened "byte-identical" → "routing/timeout semantics unchanged"; stated the provider timeoutMs-hard-deadline contract; sub-250ms budget fail-safe note |
+
+## Full Findings Catalog
+
+**Round 1 (8 material):**
+- [H] resolveCap invalid-value semantics undefined (security, adversarial, integration, decision-completeness, lessons-aware) → FD5: validate `number && isFinite && >0`, invalid falls through to global, never no-cap/instant-fire; never `||` (zero-is-falsy lesson).
+- [H] No upper clamp + unbounded total tail (~85s) → reachability regression (security, scalability, adversarial, lessons-aware) → per-attempt clamp `swapAttemptTimeoutMsMax` (FD7) + total budget `swapTotalBudgetMs` (FD6).
+- [M] Cap can mask a degraded provider from the circuit breaker (adversarial) → Safety note: caps ≤ breaker threshold; timed-out attempts still counted.
+- [M] Sequential loop → target ORDER is latency-load-bearing (scalability, adversarial) → documented (fast-first; cap ≠ priority).
+- [M] Long caps hold host spawn-semaphore slots ~10× longer (scalability, security) → Safety note; total budget mitigates.
+- [M] Ships-inert / Close-the-Loop — dark default means gemini stays broken until opt-in (lessons-aware) → FD8: one-tap go/no-go + tracked commitment.
+- [M] codex-ext: typed keys (`Partial<Record<IntelligenceFramework>>`) to stop typo-silent-fallback; timer-leak (clear the setTimeout on settle); "byte-identical" too strong; total-bound ignores primary attempt → all folded in.
+- [L] Testing tier label — no HTTP route → no Tier-3 e2e (lessons-aware) → stated the Testing-Integrity no-route carve-out; [L] Signal-vs-Authority static-cap recurrence vector → noted; [L] dashboard/Agent-Awareness → "internal knob" note.
+
+**Round 2 (1 material — unanimous):**
+- [H] NF1: total budget only gated BEFORE each attempt, so worst-case = `budget + maxCap` (~150s), not `≤ budget` — the Safety invariant was false, reopening the reachability regression FD6 exists to close. Found independently by scalability, security, adversarial, integration, decision-completeness, lessons-aware, AND codex-ext. → Each attempt clamped to `min(resolvedCap, budgetRemaining)`; loop falls closed at remaining ≤ 250ms; budget defaults UNSET (codex backward-compat catch: `6×global` default would have changed behavior for configs with >6 targets / high global cap).
+
+**Round 3 (0 material; 3 minor clarifications folded in):**
+- 6 internal reviewers verified the NF1 fix makes worst-case tail literally ≤ budget, no starvation (250ms floor), all decisions frontloaded, "Open questions: none" honest, accurate-bound lesson satisfied, byte-identical confirmed for all configs. Non-material nits noted (sub-250 budget misconfig, "e.g." phrasing).
+- codex-ext (minor, folded in): use a MONOTONIC clock for `elapsedSinceFirstSwap` (a wall-clock jump must not corrupt the budget); soften "byte-identical" to "routing/timeout semantics unchanged" + note timer-cleanup as an internal difference; state that a provider must honor `timeoutMs` as a hard subprocess deadline (existing behavior).
+
+## Convergence verdict
+
+Converged at iteration 3. The six internal reviewers unanimously found zero material findings in
+round 3; the round-3 external raised three minor, non-design-changing clarifications which were
+folded into the spec. `## Open questions` is empty (all eight decisions frontloaded, FD1–FD8). The
+spec is ready for user review and approval.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5800,6 +5800,14 @@ export async function startServer(options: StartOptions): Promise<void> {
           // §4.5: per-attempt swap timeout, inline-defaulted to 5s (no ConfigDefaults
           // entry — codexExecJson precedent; absent ⇒ 5s, present ⇒ operator's value).
           swapAttemptTimeoutMs: config.intelligence?.swapAttemptTimeoutMs ?? 5000,
+          // Per-target swap caps + clamp + total budget (docs/specs/
+          // per-target-swap-timeout-spec.md): all three thread through UNSET by
+          // default — dark ship, byte-identical routing behavior until the operator
+          // opts in. Validation (invalid → fall-through / 120s default / treated
+          // unset) happens inside the router's resolveSwapCap, never here.
+          swapAttemptTimeoutMsByFramework: config.intelligence?.swapAttemptTimeoutMsByFramework,
+          swapAttemptTimeoutMsMax: config.intelligence?.swapAttemptTimeoutMsMax,
+          swapTotalBudgetMs: config.intelligence?.swapTotalBudgetMs,
           // The dedicated queue for the DEFERRABLE queue rung (§3b.3); undefined when the rung is
           // dark ⇒ the rung is a no-op (a deferrable call falls straight to its heuristic, as before).
           llmQueue: degradationLadderQueue,

--- a/src/core/IntelligenceRouter.ts
+++ b/src/core/IntelligenceRouter.ts
@@ -94,6 +94,37 @@ export interface IntelligenceRouterOptions {
    */
   swapAttemptTimeoutMs?: number;
   /**
+   * Per-TARGET-framework swap-attempt caps in ms (per-target-swap-timeout-spec.md).
+   * Resolution per swap target: `byFramework[target]` (if valid: finite number > 0)
+   * → the global `swapAttemptTimeoutMs` (if valid) → undefined (no cap). An INVALID
+   * per-framework value (0, negative, NaN, Infinity, non-number) FALLS THROUGH to
+   * the global — never "no cap", never an immediate-0ms kill (FD5). DEFAULT UNSET ⇒
+   * the global cap applies to every target — byte-identical routing behavior to today.
+   */
+  swapAttemptTimeoutMsByFramework?: Partial<Record<IntelligenceFramework, number>>;
+  /**
+   * Clamp (ms) on any single resolved swap-attempt cap, so a huge/typo'd value
+   * cannot create an effectively unbounded subprocess that pins a host spawn-cap
+   * slot (FD7). The value is itself validated (finite > 0); invalid/unset ⇒ 120000.
+   */
+  swapAttemptTimeoutMsMax?: number;
+  /**
+   * Wall-clock TOTAL budget (ms) over the WHOLE failure-swap tail (FD6). UNSET ⇒ no
+   * budget enforcement — semantics unchanged from today (the dark default). When set,
+   * each attempt's effective cap is `min(resolvedCap, budgetRemaining)` — measured on
+   * a MONOTONIC clock, never Date.now() — and the loop stops and falls closed once
+   * `budgetRemaining ≤ 250ms`, so worst-case swap-tail latency is literally ≤ this
+   * value (the budget clamps each IN-FLIGHT attempt, not just the loop gate). An
+   * invalid value (0, negative, NaN, non-number) is treated as unset.
+   */
+  swapTotalBudgetMs?: number;
+  /**
+   * Test seam: the monotonic clock used for the total-budget elapsed measurement.
+   * Defaults to `performance.now()` — a wall-clock jump (NTP step, DST) must not
+   * make the budget spuriously short or long (round-3 external finding).
+   */
+  monotonicNow?: () => number;
+  /**
    * Build a provider for a non-default framework, with its OWN circuit breaker.
    * Returns null when that framework's binary isn't available. Called at most
    * once per framework (result cached). MUST NOT throw (catch internally).
@@ -140,6 +171,89 @@ interface CachedFramework {
 }
 
 /**
+ * Runtime framework ids for the unknown-key hygiene warning on
+ * `swapAttemptTimeoutMsByFramework` (per-target-swap-timeout-spec.md, change
+ * surface). The TYPE is the compile-time guard; this set catches a stray key
+ * arriving from raw JSON config at runtime (no effect — warn once, ignore).
+ */
+const KNOWN_FRAMEWORKS: ReadonlySet<string> = new Set(['claude-code', 'codex-cli', 'gemini-cli', 'pi-cli']);
+
+/** Default clamp on any single resolved swap-attempt cap (per-target-swap-timeout-spec.md FD7). */
+const DEFAULT_SWAP_ATTEMPT_TIMEOUT_MAX_MS = 120_000;
+
+/**
+ * Below this much remaining total budget (ms), a swap attempt is not worth
+ * admitting — the loop stops and falls closed (per-target-swap-timeout-spec.md
+ * FD6, fixed floor). A configured `swapTotalBudgetMs` below this value passes
+ * validation but simply disables swapping on the first attempt (fail-SAFE).
+ */
+const SWAP_BUDGET_MIN_REMAINING_MS = 250;
+
+/**
+ * The spec's uniform validity contract for every timeout/budget value:
+ * `typeof x === 'number' && Number.isFinite(x) && x > 0`. `0`, negatives, NaN,
+ * Infinity, and non-numbers are all INVALID — selection never uses `||` (the
+ * zero-is-falsy lesson).
+ */
+function isValidMs(x: unknown): x is number {
+  return typeof x === 'number' && Number.isFinite(x) && x > 0;
+}
+
+/**
+ * resolveSwapCap — per-TARGET swap-attempt cap resolution
+ * (docs/specs/per-target-swap-timeout-spec.md, `resolveCap` contract).
+ *
+ * Resolution: `byFramework[target]` (if valid) → `globalCap` (if valid) →
+ * `undefined` (no cap — today's behavior when the global is ≤0/unset). An
+ * INVALID per-framework value (0, negative, NaN, Infinity, non-number) FALLS
+ * THROUGH to the global — it NEVER means "no cap" and NEVER produces an
+ * immediate-0ms kill (FD5: per-framework config cannot express "unbounded";
+ * only the global's ≤0/unset does — closes the accidental-uncap footgun).
+ * The resolved cap is clamped to `maxCap` (itself validated; invalid → 120s
+ * default) so a huge/typo'd value cannot pin a host spawn-cap slot unbounded.
+ *
+ * Exported for direct unit testing (pure function, no router state).
+ */
+export function resolveSwapCap(
+  target: IntelligenceFramework,
+  globalCap: number | undefined,
+  byFramework: Partial<Record<IntelligenceFramework, number>> | undefined,
+  maxCap: number | undefined,
+): number | undefined {
+  const perTarget = byFramework?.[target];
+  const candidate = isValidMs(perTarget) ? perTarget : isValidMs(globalCap) ? globalCap : undefined;
+  if (candidate === undefined) return undefined;
+  const effMax = isValidMs(maxCap) ? maxCap : DEFAULT_SWAP_ATTEMPT_TIMEOUT_MAX_MS;
+  return Math.min(candidate, effMax);
+}
+
+/**
+ * withSwapTimeout — the shipped Promise.race crash-safe pattern (per-input
+ * settlement handlers; a late reject/resolve from the abandoned attempt is
+ * handled/ignored), PLUS timer hygiene: the pending timeout timer is CLEARED
+ * on settle in a `finally` so a fast success does not leak a timer per call
+ * (per-target-swap-timeout-spec.md FD7 / codex-review finding). The rejection
+ * message format (`swap-attempt-timeout: <target> (<cap>ms)`) is load-bearing —
+ * the swap loop's degrade-reason detection prefix-matches it.
+ */
+async function withSwapTimeout<T>(promise: Promise<T>, capMs: number, target: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`swap-attempt-timeout: ${target} (${capMs}ms)`)),
+          capMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
  * Is this a rate-limit / usage-limit / 429 error? The circuit-breaking provider wraps these as a
  * `RateLimitError` (name-checked, no import needed); we also duck-type the message so a provider
  * that throws a plain Error on a limit is still recognized. Used by the deferrable backoff rung to
@@ -153,7 +267,33 @@ function isRateLimitError(e: unknown): boolean {
 export class IntelligenceRouter implements IntelligenceProvider {
   private readonly cache = new Map<IntelligenceFramework, CachedFramework>();
 
+  /** Unknown byFramework keys already warned about (warn ONCE per key, never per call). */
+  private warnedUnknownCapKeys?: Set<string>;
+
   constructor(private readonly opts: IntelligenceRouterOptions) {}
+
+  /**
+   * Unknown-key hygiene (per-target-swap-timeout-spec.md, change surface): a stray/
+   * misspelled key arriving from raw JSON config has NO effect (that target simply
+   * falls through to the global cap) — but it is logged once so the typo is visible
+   * instead of silently ignored. Type-level the map is keyed to the framework union;
+   * this is the runtime backstop.
+   */
+  private warnUnknownSwapCapKeys(
+    byFramework: Partial<Record<IntelligenceFramework, number>> | undefined,
+  ): void {
+    if (!byFramework) return;
+    for (const key of Object.keys(byFramework)) {
+      if (KNOWN_FRAMEWORKS.has(key)) continue;
+      if (!this.warnedUnknownCapKeys) this.warnedUnknownCapKeys = new Set();
+      if (this.warnedUnknownCapKeys.has(key)) continue;
+      this.warnedUnknownCapKeys.add(key);
+      console.warn(
+        `IntelligenceRouter: unknown framework key '${key}' in swapAttemptTimeoutMsByFramework — ` +
+          `ignored (that key has no effect; targets fall through to the global cap)`,
+      );
+    }
+  }
 
   /**
    * The framework the default (shared, global-breaker) provider speaks — i.e. the
@@ -303,18 +443,23 @@ export class IntelligenceRouter implements IntelligenceProvider {
         if (!gating) this.opts.onHeuristicFallthrough?.(component ?? '(none)', framework);
         throw err; // not gating/deferrable, or no swap configured ⇒ today's behavior
       }
-      // §4.5 bounded per-attempt swap timeout: a positive cap races each attempt so a
-      // slow-but-not-erroring provider is abandoned at the cap (total swap latency ≤
-      // cap × (1 + tail.length)) instead of stacking long waits and re-creating the
-      // very stall this policy exists to prevent. The cap also flows through to the
+      // §4.5 bounded per-attempt swap timeout, now resolved PER TARGET
+      // (docs/specs/per-target-swap-timeout-spec.md): each attempt's cap resolves
+      // `byFramework[target]` → global → undefined, clamped to `maxCap`, so a
+      // slow-but-honest target (gemini p50 ≈ 8.5s) can be GIVEN its measured time
+      // instead of being killed at a one-size-fits-all 5s. When a TOTAL budget is
+      // set, each attempt is additionally clamped to the remaining budget (monotonic
+      // clock) and the loop falls closed once < 250ms remains — so the whole tail is
+      // literally ≤ swapTotalBudgetMs. All three knobs default UNSET ⇒ byte-identical
+      // routing behavior to the single global cap. The cap also flows through to the
       // provider as `timeoutMs` so the CLI subprocess SIGTERMs itself at the same bound.
-      const capMs = this.opts.swapAttemptTimeoutMs;
-      const cap = typeof capMs === 'number' && capMs > 0 ? capMs : undefined;
-      // Pass the cap through as the provider's per-call timeout so the subprocess
-      // self-terminates at the bound (no AbortSignal exists on IntelligenceOptions).
-      const attemptOptions: IntelligenceOptions | undefined = cap
-        ? { ...(options ?? {}), timeoutMs: cap }
-        : options;
+      const globalCapMs = this.opts.swapAttemptTimeoutMs;
+      const byFramework = this.opts.swapAttemptTimeoutMsByFramework;
+      this.warnUnknownSwapCapKeys(byFramework);
+      const maxCapMs = this.opts.swapAttemptTimeoutMsMax;
+      const budgetMs = isValidMs(this.opts.swapTotalBudgetMs) ? this.opts.swapTotalBudgetMs : undefined;
+      const monotonicNow = this.opts.monotonicNow ?? (() => performance.now());
+      const swapStartedAt = monotonicNow();
       for (const target of swapTargets) {
         // GATING budget: if the awaited gate's total wall-clock budget is consumed, stop swapping
         // and fail closed now (responsiveness over completeness — spec §3a). Deferrable calls have
@@ -323,22 +468,32 @@ export class IntelligenceRouter implements IntelligenceProvider {
         if (target === framework) continue; // don't retry the framework that just failed
         const tp = this.resolveProvider(target);
         if (!tp) continue; // target binary missing → skip
+        let cap = resolveSwapCap(target, globalCapMs, byFramework, maxCapMs);
+        if (budgetMs !== undefined) {
+          const remaining = budgetMs - (monotonicNow() - swapStartedAt);
+          // Too little budget left to be worth an attempt → stop, fall closed (FD6).
+          if (remaining <= SWAP_BUDGET_MIN_REMAINING_MS) break;
+          // The budget clamps each IN-FLIGHT attempt, not just the loop gate — an
+          // attempt admitted at budget−ε must NOT run its full per-target cap
+          // (worst case would be budget + maxCap, not ≤ budget). It also bounds an
+          // otherwise-UNcapped attempt (no per-target cap, global ≤0/unset).
+          cap = cap === undefined ? remaining : Math.min(cap, remaining);
+        }
+        // Pass the cap through as the provider's per-call timeout so the subprocess
+        // self-terminates at the bound (no AbortSignal exists on IntelligenceOptions).
+        const attemptOptions: IntelligenceOptions | undefined =
+          cap !== undefined ? { ...(options ?? {}), timeoutMs: cap } : options;
         try {
-          // Promise.race is the shipped, crash-safe pattern (InputGuard precedent):
-          // it attaches a settlement handler to EACH input, so a late rejection from
-          // an abandoned attempt is already handled (no unhandledRejection) and a late
-          // resolve is ignored. NEVER a detached/awaited handle.
-          const result = cap
-            ? await Promise.race([
-                tp.evaluate(prompt, attemptOptions),
-                new Promise<never>((_, reject) =>
-                  setTimeout(
-                    () => reject(new Error(`swap-attempt-timeout: ${target} (${cap}ms)`)),
-                    cap,
-                  ),
-                ),
-              ])
-            : await tp.evaluate(prompt, attemptOptions);
+          // withSwapTimeout keeps the shipped, crash-safe Promise.race pattern
+          // (InputGuard precedent): it attaches a settlement handler to EACH input,
+          // so a late rejection from an abandoned attempt is already handled (no
+          // unhandledRejection) and a late resolve is ignored. NEVER a detached/
+          // awaited handle. It additionally CLEARS the timer on settle (FD7) so a
+          // fast success does not leak a pending timer.
+          const result =
+            cap !== undefined
+              ? await withSwapTimeout(tp.evaluate(prompt, attemptOptions), cap, target)
+              : await tp.evaluate(prompt, attemptOptions);
           this.opts.onDegrade?.({
             component: component ?? '(none)',
             category,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3208,6 +3208,47 @@ export interface InstarConfig {
      */
     swapAttemptTimeoutMs?: number;
     /**
+     * Per-TARGET-framework swap-attempt caps in ms for the failure-swap loop
+     * (docs/specs/per-target-swap-timeout-spec.md). Resolution per swap target:
+     * `byFramework[target]` (if a valid finite number > 0) → the global
+     * `swapAttemptTimeoutMs` → no cap. An INVALID per-framework value (0, negative,
+     * NaN, non-number) FALLS THROUGH to the global — it never means "no cap" and
+     * never produces an immediate-0ms kill (FD5: per-framework config cannot
+     * express "unbounded"; only the global's ≤0/unset does). DEFAULT UNSET ⇒ the
+     * global cap applies to every target, byte-identical to today (dark ship;
+     * deliberately kept out of ConfigDefaults/migrateConfig like
+     * swapAttemptTimeoutMs, so absence is the default state).
+     * Recommended opt-in package (set TOGETHER with swapTotalBudgetMs — FD8, so
+     * the caps and their reachability ceiling arrive as one package):
+     * `{ "claude-code": 8000, "pi-cli": 9000, "gemini-cli": 18000, "codex-cli": 45000 }`
+     * with `swapTotalBudgetMs: 40000` (each cap ≥ the framework's measured p95 with
+     * margin — llm-pathway-bench N=30). NOTE: the swap loop is sequential, so
+     * `failureSwap` target ORDER is latency-load-bearing — order fastest-first
+     * (cap ≠ priority), and keep caps ≤ the circuit breaker's failure sensitivity
+     * so a chronically-slow target still trips the breaker.
+     */
+    swapAttemptTimeoutMsByFramework?: Partial<
+      Record<'claude-code' | 'codex-cli' | 'gemini-cli' | 'pi-cli', number>
+    >;
+    /**
+     * Clamp (ms) on any single resolved swap-attempt cap, so a huge/typo'd
+     * per-framework value cannot create an effectively unbounded subprocess that
+     * pins a host spawn-cap slot (per-target-swap-timeout-spec.md FD7). The value
+     * is itself validated (finite > 0); invalid/unset ⇒ 120000 (120s).
+     */
+    swapAttemptTimeoutMsMax?: number;
+    /**
+     * Wall-clock TOTAL budget (ms) over the WHOLE failure-swap tail
+     * (per-target-swap-timeout-spec.md FD6). UNSET ⇒ no total-budget enforcement —
+     * semantics unchanged from today (the dark default). When set, each swap
+     * attempt's effective cap is `min(resolvedCap, budgetRemaining)` on a MONOTONIC
+     * clock and the loop stops and falls closed once ≤ 250ms remains — so the
+     * worst-case swap-tail latency is literally ≤ this value. An invalid value
+     * (0, negative, NaN, non-number) is treated as unset (no enforcement).
+     * Recommended alongside the per-framework caps: 40000.
+     */
+    swapTotalBudgetMs?: number;
+    /**
      * Pinned-callsite model overrides (docs/LLM-ROUTING-REGISTRY.md "Risk items"
      * #3/#5/#6/#7 — the hardcoded-model callsites that bypass the router).
      * INLINE-DEFAULTED at each callsite (the codexExecJson/swapAttemptTimeoutMs

--- a/tests/integration/per-target-swap-timeout.test.ts
+++ b/tests/integration/per-target-swap-timeout.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Integration tests for the PER-TARGET failure-swap timeout
+ * (docs/specs/per-target-swap-timeout-spec.md — fixes gemini-swap-timeout).
+ *
+ * Wires an IntelligenceRouter EXACTLY like the server construction site
+ * (src/commands/server.ts): the layered resolveConfig over the computed default
+ * (provider-fallback-default-policy §4.6) plus the three new knobs threaded from
+ * a config object with the same `config.intelligence?.*` expressions the server
+ * uses. Then exercises the spec's integration scenario end-to-end:
+ *
+ *  - Fix: the primary (codex, per the computed sentinel default) throws; the
+ *    gemini swap target has an 18s per-target cap and an 8.5s-latency stub →
+ *    the swap SUCCEEDS (previously killed at the 5s global).
+ *  - Regression: NO per-framework config → identical to the existing single-cap
+ *    behavior (the same 8.5s stub is abandoned at 5s and the call fails closed).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { IntelligenceRouter, type ComponentFrameworksConfig } from '../../src/core/IntelligenceRouter.js';
+import { resolveInternalFrameworkDefault } from '../../src/core/internalFrameworkDefault.js';
+import type { IntelligenceFramework } from '../../src/core/intelligenceProviderFactory.js';
+import type { IntelligenceProvider, IntelligenceOptions, InstarConfig } from '../../src/core/types.js';
+
+// A gating call from a SENTINEL component: under the computed default (active set
+// codex+gemini+claude) the sentinel category routes to codex-cli — so codex is the
+// PRIMARY that fails, and gemini is reached via the failure-swap tail.
+const GATING: IntelligenceOptions = { attribution: { component: 'PresenceProxy', gating: true } };
+
+/** A provider that resolves after `latencyMs` (fake-timer setTimeout). Records the timeoutMs it saw. */
+function latencyProvider(label: string, latencyMs: number): IntelligenceProvider & { sawTimeoutMs: number | undefined } {
+  return {
+    sawTimeoutMs: undefined,
+    evaluate(this: { sawTimeoutMs?: number }, _p: string, opts?: IntelligenceOptions) {
+      this.sawTimeoutMs = opts?.timeoutMs;
+      return new Promise<string>((res) => { setTimeout(() => res(label), latencyMs); });
+    },
+  };
+}
+
+/**
+ * Build the router the way src/commands/server.ts does: operator did NOT set
+ * componentFrameworks (computed default + §4.6 layering, with the live block's
+ * failureSwap slot winning), and the four timeout knobs thread from
+ * `config.intelligence` with the server's exact expressions — `?? 5000` for the
+ * global, UNSET pass-through for the three new fields.
+ */
+function serverWiredRouter(
+  config: Pick<InstarConfig, 'intelligence'>,
+  providers: Partial<Record<IntelligenceFramework, IntelligenceProvider>>,
+  failureSwap: IntelligenceFramework[],
+): IntelligenceRouter {
+  const computedDefault = resolveInternalFrameworkDefault(['codex-cli', 'gemini-cli', 'claude-code']);
+  const live: ComponentFrameworksConfig = { failureSwap };
+  return new IntelligenceRouter({
+    defaultProvider: {
+      async evaluate() { throw new Error('claude default should not serve in this scenario'); },
+    },
+    defaultFramework: 'claude-code',
+    resolveConfig: () => ({
+      ...computedDefault,
+      ...live,
+      categories: { ...computedDefault.categories },
+      ...(live.failureSwap !== undefined ? { failureSwap: live.failureSwap } : {}),
+    }),
+    buildProvider: (fw) => providers[fw] ?? null,
+    // ↓ the server's exact threading expressions (src/commands/server.ts)
+    swapAttemptTimeoutMs: config.intelligence?.swapAttemptTimeoutMs ?? 5000,
+    swapAttemptTimeoutMsByFramework: config.intelligence?.swapAttemptTimeoutMsByFramework,
+    swapAttemptTimeoutMsMax: config.intelligence?.swapAttemptTimeoutMsMax,
+    swapTotalBudgetMs: config.intelligence?.swapTotalBudgetMs,
+    monotonicNow: () => Date.now(), // fake-timer-driven monotonic stand-in
+  });
+}
+
+const codexPrimaryDown: IntelligenceProvider = {
+  async evaluate() { throw new Error('codex primary down'); },
+};
+
+describe('per-target swap timeout — server-wired integration', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('FIX: gemini (8.5s latency) with the recommended 18s per-target cap is served on swap', async () => {
+    const gemini = latencyProvider('gemini-answer', 8500);
+    const router = serverWiredRouter(
+      {
+        intelligence: {
+          // the operator's opt-in package (FD8) — recommended values from the spec
+          swapAttemptTimeoutMsByFramework: { 'gemini-cli': 18000 },
+          swapTotalBudgetMs: 40000,
+        },
+      },
+      { 'codex-cli': codexPrimaryDown, 'gemini-cli': gemini },
+      ['gemini-cli'],
+    );
+    const p = router.evaluate('is this an emergency stop?', GATING);
+    await vi.advanceTimersByTimeAsync(8500);
+    expect(await p).toBe('gemini-answer');
+    expect(gemini.sawTimeoutMs).toBe(18000); // per-target cap reached the subprocess bound
+  });
+
+  it('REGRESSION: no per-framework config → the flat 5s global still kills the same 8.5s target (byte-identical to today)', async () => {
+    const gemini = latencyProvider('gemini-answer', 8500);
+    const router = serverWiredRouter(
+      { intelligence: {} }, // nothing set — the dark default
+      { 'codex-cli': codexPrimaryDown, 'gemini-cli': gemini },
+      ['gemini-cli'],
+    );
+    const p = router.evaluate('is this an emergency stop?', GATING);
+    const rejection = expect(p).rejects.toThrow('codex primary down');
+    await vi.advanceTimersByTimeAsync(5001);
+    await rejection; // abandoned at the 5s global → no targets left → fail closed
+    expect(gemini.sawTimeoutMs).toBe(5000); // the global cap, exactly today's behavior
+  });
+
+  it('REGRESSION: config.intelligence entirely absent → same single-cap behavior (?? 5000 path)', async () => {
+    const gemini = latencyProvider('gemini-answer', 8500);
+    const router = serverWiredRouter(
+      {}, // no intelligence block at all
+      { 'codex-cli': codexPrimaryDown, 'gemini-cli': gemini },
+      ['gemini-cli'],
+    );
+    const p = router.evaluate('x', GATING);
+    const rejection = expect(p).rejects.toThrow('codex primary down');
+    await vi.advanceTimersByTimeAsync(5001);
+    await rejection;
+    expect(gemini.sawTimeoutMs).toBe(5000);
+  });
+});

--- a/tests/unit/per-target-swap-timeout.test.ts
+++ b/tests/unit/per-target-swap-timeout.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Unit tests for the PER-TARGET failure-swap timeout
+ * (docs/specs/per-target-swap-timeout-spec.md — fixes gemini-swap-timeout).
+ *
+ * Covers the spec's test plan:
+ *  - resolveSwapCap contract: per-framework valid value used; present-but-INVALID
+ *    (0, -1, NaN, Infinity, "18000" string) FALLS THROUGH to global (not no-cap,
+ *    not immediate-fire); unknown key → global; unset map → global; global
+ *    ≤0/unset → undefined; clamp to maxCap; invalid maxCap → 120s default.
+ *  - The gemini fix: an 8.5s-latency target with an 18s per-target cap SUCCEEDS
+ *    (previously killed at the 5s global); regression without the map → killed at 5s.
+ *  - FD6 total budget: clamps each IN-FLIGHT attempt (worst-case tail ≤ budget);
+ *    falls closed when remaining ≤ 250ms; UNSET → no enforcement; invalid → unset;
+ *    a sub-250ms budget disables swapping fail-SAFE; bounds an un-capped attempt.
+ *  - FD7 timer hygiene: a fast success clears the pending timeout timer.
+ *  - Wiring: router opts carry all three new fields; server threads them from config.
+ *  - Unknown-key hygiene: a stray byFramework key warns once and has no effect.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { IntelligenceRouter, resolveSwapCap } from '../../src/core/IntelligenceRouter.js';
+import type { IntelligenceFramework } from '../../src/core/intelligenceProviderFactory.js';
+import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
+
+const GATING: IntelligenceOptions = { attribution: { component: 'ExternalOperationGate', gating: true } };
+
+function throwingProvider(msg = 'down'): IntelligenceProvider {
+  return { async evaluate() { throw new Error(msg); } };
+}
+
+/** A provider that NEVER resolves — a slow-but-not-erroring target. Records the timeoutMs it saw. */
+function slowProvider(): IntelligenceProvider & { sawTimeoutMs: number | undefined; called: boolean } {
+  return {
+    sawTimeoutMs: undefined,
+    called: false,
+    evaluate(this: { sawTimeoutMs?: number; called: boolean }, _p: string, opts?: IntelligenceOptions) {
+      this.called = true;
+      this.sawTimeoutMs = opts?.timeoutMs;
+      return new Promise<string>(() => { /* hang forever */ });
+    },
+  };
+}
+
+/** A provider that resolves after `latencyMs` (fake-timer setTimeout). Records the timeoutMs it saw. */
+function latencyProvider(label: string, latencyMs: number): IntelligenceProvider & { sawTimeoutMs: number | undefined } {
+  return {
+    sawTimeoutMs: undefined,
+    evaluate(this: { sawTimeoutMs?: number }, _p: string, opts?: IntelligenceOptions) {
+      this.sawTimeoutMs = opts?.timeoutMs;
+      return new Promise<string>((res) => { setTimeout(() => res(label), latencyMs); });
+    },
+  };
+}
+
+describe('resolveSwapCap — exact contract (FD5/FD7)', () => {
+  const BY: Partial<Record<IntelligenceFramework, number>> = { 'gemini-cli': 18000 };
+
+  it('a VALID per-framework value is used for that target', () => {
+    expect(resolveSwapCap('gemini-cli', 5000, BY, undefined)).toBe(18000);
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['string "18000"', '18000' as unknown as number],
+  ])('a present-but-INVALID per-framework value (%s) FALLS THROUGH to the global — never no-cap, never 0ms', (_name, bad) => {
+    const by = { 'gemini-cli': bad } as Partial<Record<IntelligenceFramework, number>>;
+    expect(resolveSwapCap('gemini-cli', 5000, by, undefined)).toBe(5000);
+  });
+
+  it('a target NOT in the map falls through to the global', () => {
+    expect(resolveSwapCap('codex-cli', 5000, BY, undefined)).toBe(5000);
+  });
+
+  it('unset map → global; global unset → undefined (no cap, today\'s behavior)', () => {
+    expect(resolveSwapCap('gemini-cli', 5000, undefined, undefined)).toBe(5000);
+    expect(resolveSwapCap('gemini-cli', undefined, undefined, undefined)).toBeUndefined();
+  });
+
+  it('global ≤0 (invalid) with no per-framework value → undefined (no cap)', () => {
+    expect(resolveSwapCap('gemini-cli', 0, undefined, undefined)).toBeUndefined();
+    expect(resolveSwapCap('gemini-cli', -5, undefined, undefined)).toBeUndefined();
+  });
+
+  it('an INVALID per-framework value with an unset/invalid global → undefined (falls through the whole chain)', () => {
+    const by = { 'gemini-cli': 0 } as Partial<Record<IntelligenceFramework, number>>;
+    expect(resolveSwapCap('gemini-cli', undefined, by, undefined)).toBeUndefined();
+    expect(resolveSwapCap('gemini-cli', 0, by, undefined)).toBeUndefined();
+  });
+
+  it('the resolved cap is clamped to maxCap (per-attempt clamp)', () => {
+    const by = { 'codex-cli': 500000 } as Partial<Record<IntelligenceFramework, number>>;
+    expect(resolveSwapCap('codex-cli', 5000, by, 120000)).toBe(120000);
+    // global route clamps too
+    expect(resolveSwapCap('pi-cli', 300000, undefined, 120000)).toBe(120000);
+  });
+
+  it('an INVALID maxCap (0 / NaN / negative) → the 120s default clamp', () => {
+    const by = { 'codex-cli': 500000 } as Partial<Record<IntelligenceFramework, number>>;
+    expect(resolveSwapCap('codex-cli', 5000, by, 0)).toBe(120000);
+    expect(resolveSwapCap('codex-cli', 5000, by, NaN)).toBe(120000);
+    expect(resolveSwapCap('codex-cli', 5000, by, -1)).toBe(120000);
+    // a valid small value below the default is NOT clamped
+    expect(resolveSwapCap('gemini-cli', 5000, { 'gemini-cli': 18000 }, undefined)).toBe(18000);
+  });
+});
+
+describe('the gemini fix — per-target cap gives a slow-but-honest target its measured time', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('an 8.5s-latency gemini target with an 18s per-target cap SUCCEEDS (was killed at the 5s global)', async () => {
+    const gemini = latencyProvider('gemini', 8500);
+    const router = new IntelligenceRouter({
+      defaultProvider: throwingProvider('claude down'),
+      defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['gemini-cli'] }),
+      buildProvider: (fw) => (fw === 'gemini-cli' ? gemini : null),
+      swapAttemptTimeoutMs: 5000,
+      swapAttemptTimeoutMsByFramework: { 'gemini-cli': 18000 },
+    });
+    const p = router.evaluate('x', GATING);
+    await vi.advanceTimersByTimeAsync(8500);
+    expect(await p).toBe('gemini');
+    // the PER-TARGET cap (not the 5s global) flowed through as the provider timeoutMs
+    expect(gemini.sawTimeoutMs).toBe(18000);
+  });
+
+  it('REGRESSION: with no per-framework map the same target is killed at the 5s global (today\'s behavior)', async () => {
+    const gemini = latencyProvider('gemini', 8500);
+    const router = new IntelligenceRouter({
+      defaultProvider: throwingProvider('claude down'),
+      defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['gemini-cli'] }),
+      buildProvider: (fw) => (fw === 'gemini-cli' ? gemini : null),
+      swapAttemptTimeoutMs: 5000,
+    });
+    const p = router.evaluate('x', GATING);
+    const rejection = expect(p).rejects.toThrow('claude down');
+    await vi.advanceTimersByTimeAsync(5001);
+    await rejection; // gemini abandoned at 5s → no targets left → original error rethrows
+    expect(gemini.sawTimeoutMs).toBe(5000);
+  });
+});
+
+describe('FD6 total swap budget (swapTotalBudgetMs)', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Date.now is faked by vi.useFakeTimers and advances with advanceTimersByTimeAsync,
+  // giving a deterministic stand-in for the monotonic clock in tests.
+  const fakeMonotonic = () => Date.now();
+
+  it('the budget clamps an IN-FLIGHT attempt: an attempt admitted under a smaller remainder gets min(cap, remaining)', async () => {
+    const codex = slowProvider();
+    const router = new IntelligenceRouter({
+      defaultProvider: throwingProvider('claude down'),
+      defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['codex-cli'] }),
+      buildProvider: (fw) => (fw === 'codex-cli' ? codex : null),
+      swapAttemptTimeoutMs: 5000,
+      swapAttemptTimeoutMsByFramework: { 'codex-cli': 45000 },
+      swapTotalBudgetMs: 10000,
+      monotonicNow: fakeMonotonic,
+    });
+    const p = router.evaluate('x', GATING);
+    const rejection = expect(p).rejects.toThrow('claude down');
+    await vi.advanceTimersByTimeAsync(10001);
+    await rejection;
+    // NOT the full 45s per-target cap — clamped to the 10s budget remainder.
+    expect(codex.sawTimeoutMs).toBe(10000);
+  });
+
+  it('worst-case swap-tail latency is literally ≤ swapTotalBudgetMs across multiple attempts', async () => {
+    const slow1 = slowProvider();
+    const slow2 = slowProvider();
+    const router = new IntelligenceRouter({
+      defaultProvider: throwingProvider('claude down'),
+      defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['codex-cli', 'gemini-cli'] }),
+      buildProvider: (fw) => (fw === 'codex-cli' ? slow1 : fw === 'gemini-cli' ? slow2 : null),
+      swapAttemptTimeoutMs: 5000,
+      swapTotalBudgetMs: 6000,
+      monotonicNow: fakeMonotonic,
+    });
+    let settledAt: number | undefined;
+    const start = Date.now();
+    const p = router.evaluate('x', GATING).catch(() => { settledAt = Date.now(); });
+    // attempt 1: cap = min(5000, 6000) = 5000; attempt 2: remaining 1000 → cap 1000.
+    await vi.advanceTimersByTimeAsync(6001);
+    await p;
+    expect(slow1.sawTimeoutMs).toBe(5000);
+    expect(slow2.sawTimeoutMs).toBe(1000); // the in-flight clamp, not the full 5s cap
+    expect(settledAt! - start).toBeLessThanOrEqual(6000 + 1); // tail ≤ budget
+  });
+
+  it('falls closed when the remaining budget is ≤ the 250ms floor — a viable later target is NOT admitted', async () => {
+    const slow = slowProvider();
+    const fast = { calls: 0, async evaluate() { this.calls++; return 'pi'; } };
+    const router = new IntelligenceRouter({
+      defaultProvider: throwingProvider('claude down'),
+      defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['codex-cli', 'pi-cli'] }),
+      buildProvider: (fw) =>
+        fw === 'codex-cli' ? slow : fw === 'pi-cli' ? (fast as unknown as IntelligenceProvider) : null,
+      swapAttemptTimeoutMs: 5000,
+      swapTotalBudgetMs: 5200, // attempt 1 burns 5000 → remaining 200 ≤ 250 → stop
+      monotonicNow: fakeMonotonic,
+    });
+    const p = router.evaluate('x', GATING);
+    const rejection = expect(p).rejects.toThrow('claude down');
+    await vi.advanceTimersByTimeAsync(5201);
+    await rejection;
+    expect(fast.calls).toBe(0); // loop fell closed instead of admitting a 200ms attempt
+  });
+
+  it('REGRESSION: budget UNSET → no enforcement; tail identical to per-cap-only behavior', async () => {
+    const slow1 = slowProvider();
+    const slow2 = slowProvider();
+    const fast = { calls: 0, async evaluate() { this.calls++; return 'pi'; } };
+    const router = new IntelligenceRouter({
+      defaultProvider: throwingProvider('claude down'),
+      defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['codex-cli', 'gemini-cli', 'pi-cli'] }),
+      buildProvider: (fw) =>
+        fw === 'codex-cli' ? slow1 : fw === 'gemini-cli' ? slow2 : fw === 'pi-cli' ? (fast as unknown as IntelligenceProvider) : null,
+      swapAttemptTimeoutMs: 5000,
+      // swapTotalBudgetMs deliberately UNSET
+      monotonicNow: fakeMonotonic,
+    });
+    const p = router.evaluate('x', GATING);
+    await vi.advanceTimersByTimeAsync(10001); // 2 × 5s abandonments, then pi serves
+    expect(await p).toBe('pi');
+    expect(slow1.sawTimeoutMs).toBe(5000);
+    expect(slow2.sawTimeoutMs).toBe(5000); // full cap — no budget clamp
+    expect(fast.calls).toBe(1);
+  });
+
+  it('an INVALID budget (0 / NaN / negative) is treated as unset — no enforcement', async () => {
+    for (const bad of [0, NaN, -100]) {
+      const slow = slowProvider();
+      const fast = { async evaluate() { return 'pi'; } };
+      const router = new IntelligenceRouter({
+        defaultProvider: throwingProvider('claude down'),
+        defaultFramework: 'claude-code',
+        resolveConfig: () => ({ failureSwap: ['codex-cli', 'pi-cli'] }),
+        buildProvider: (fw) =>
+          fw === 'codex-cli' ? slow : fw === 'pi-cli' ? (fast as unknown as IntelligenceProvider) : null,
+        swapAttemptTimeoutMs: 5000,
+        swapTotalBudgetMs: bad,
+        monotonicNow: fakeMonotonic,
+      });
+      const p = router.evaluate('x', GATING);
+      await vi.advanceTimersByTimeAsync(5001);
+      expect(await p).toBe('pi'); // no budget stop — the swap proceeded past the slow target
+      expect(slow.sawTimeoutMs).toBe(5000); // no budget clamp on the attempt either
+    }
+  });
+
+  it('a sub-250ms budget passes validation but disables swapping on the FIRST attempt (fail-SAFE, never fail-open)', async () => {
+    const slow = slowProvider();
+    const router = new IntelligenceRouter({
+      defaultProvider: throwingProvider('claude down'),
+      defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['codex-cli'] }),
+      buildProvider: (fw) => (fw === 'codex-cli' ? slow : null),
+      swapAttemptTimeoutMs: 5000,
+      swapTotalBudgetMs: 200, // valid (>0) but below the 250ms floor
+      monotonicNow: fakeMonotonic,
+    });
+    await expect(router.evaluate('x', GATING)).rejects.toThrow('claude down');
+    expect(slow.called).toBe(false); // no attempt was admitted at all
+  });
+
+  it('the budget bounds even an UN-capped attempt (global unset ⇒ cap = remaining budget)', async () => {
+    const slow = slowProvider();
+    const router = new IntelligenceRouter({
+      defaultProvider: throwingProvider('claude down'),
+      defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['codex-cli'] }),
+      buildProvider: (fw) => (fw === 'codex-cli' ? slow : null),
+      // no swapAttemptTimeoutMs at all (legacy unbounded router construction)
+      swapTotalBudgetMs: 3000,
+      monotonicNow: fakeMonotonic,
+    });
+    const p = router.evaluate('x', GATING);
+    const rejection = expect(p).rejects.toThrow('claude down');
+    await vi.advanceTimersByTimeAsync(3001);
+    await rejection;
+    expect(slow.sawTimeoutMs).toBe(3000); // the budget remainder became the attempt cap
+  });
+});
+
+describe('FD7 timer hygiene — the timeout timer is cleared on settle', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('a fast swap success leaves NO pending timer (no leak per call)', async () => {
+    const fast = { async evaluate() { return 'codex'; } };
+    const router = new IntelligenceRouter({
+      defaultProvider: throwingProvider('claude down'),
+      defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['codex-cli'] }),
+      buildProvider: (fw) => (fw === 'codex-cli' ? (fast as unknown as IntelligenceProvider) : null),
+      swapAttemptTimeoutMs: 5000,
+    });
+    expect(await router.evaluate('x', GATING)).toBe('codex');
+    // Before FD7 a pending 5s reject timer leaked here on every fast success.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe('wiring — router opts carry the three new fields; server threads them from config', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('all three fields take effect end-to-end through the router opts (maxCap clamps a per-target cap)', async () => {
+    const slow = slowProvider();
+    const router = new IntelligenceRouter({
+      defaultProvider: throwingProvider('claude down'),
+      defaultFramework: 'claude-code',
+      resolveConfig: () => ({ failureSwap: ['gemini-cli'] }),
+      buildProvider: (fw) => (fw === 'gemini-cli' ? slow : null),
+      swapAttemptTimeoutMs: 5000,
+      swapAttemptTimeoutMsByFramework: { 'gemini-cli': 300000 }, // typo'd huge cap
+      swapAttemptTimeoutMsMax: 7000, // clamp wins
+      swapTotalBudgetMs: 40000,
+      monotonicNow: () => Date.now(),
+    });
+    const p = router.evaluate('x', GATING);
+    const rejection = expect(p).rejects.toThrow('claude down');
+    await vi.advanceTimersByTimeAsync(7001);
+    await rejection;
+    expect(slow.sawTimeoutMs).toBe(7000); // clamped, not 300000
+  });
+
+  it('server.ts threads all three fields from config.intelligence into the router opts', () => {
+    const src = readFileSync(join(process.cwd(), 'src/commands/server.ts'), 'utf8');
+    expect(src).toContain('swapAttemptTimeoutMsByFramework: config.intelligence?.swapAttemptTimeoutMsByFramework');
+    expect(src).toContain('swapAttemptTimeoutMsMax: config.intelligence?.swapAttemptTimeoutMsMax');
+    expect(src).toContain('swapTotalBudgetMs: config.intelligence?.swapTotalBudgetMs');
+  });
+});
+
+describe('unknown-key hygiene', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('a stray byFramework key warns ONCE and has no effect (targets fall through to the global)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const fast = { async evaluate() { return 'codex'; } };
+      const router = new IntelligenceRouter({
+        defaultProvider: throwingProvider('claude down'),
+        defaultFramework: 'claude-code',
+        resolveConfig: () => ({ failureSwap: ['codex-cli'] }),
+        buildProvider: (fw) => (fw === 'codex-cli' ? (fast as unknown as IntelligenceProvider) : null),
+        swapAttemptTimeoutMs: 5000,
+        swapAttemptTimeoutMsByFramework: { 'cursor-cli': 10000 } as never,
+      });
+      expect(await router.evaluate('x', GATING)).toBe('codex');
+      expect(await router.evaluate('x', GATING)).toBe('codex'); // second swap pass
+      const unknownKeyWarns = warn.mock.calls.filter((c) => String(c[0]).includes("unknown framework key 'cursor-cli'"));
+      expect(unknownKeyWarns).toHaveLength(1); // once, not per call
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/upgrades/next/per-target-swap-timeout.md
+++ b/upgrades/next/per-target-swap-timeout.md
@@ -1,0 +1,83 @@
+# Per-target failure-swap timeout (fixes gemini-swap-timeout)
+
+<!-- bump: minor -->
+
+## What Changed
+
+The IntelligenceRouter failure-swap loop bounded EVERY swap attempt with one
+global cap (`intelligence.swapAttemptTimeoutMs`, default 5000ms). Measured
+provider latency (llm-pathway-bench, N=30, uncontended) shows gemini-flash's
+p50 is 8,538ms — ABOVE the 5s cap — so whenever gemini was a swap target it was
+SIGTERMed before it could answer on the majority of attempts: it reliably
+burned a full 5s swap slot and then failed, poisoning the failover tail
+(the R4 gemini-swap-timeout finding).
+
+Per `docs/specs/per-target-swap-timeout-spec.md` (review-converged 2026-07-01,
+approved), the cap now resolves PER TARGET FRAMEWORK with three new optional
+`intelligence` config fields, all defaulting UNSET (dark ship — routing/timeout
+behavior is byte-identical to today until an operator opts in):
+
+- `swapAttemptTimeoutMsByFramework` — per-target caps. Resolution per swap
+  target: `byFramework[target]` (valid = finite number > 0) → the global
+  `swapAttemptTimeoutMs` → no cap. An INVALID value (0, negative, NaN,
+  non-number) falls through to the global — never "no cap", never a 0ms kill
+  (FD5: per-framework config cannot express "unbounded"; only the global's
+  ≤0/unset does). Recommended opt-in package:
+  `{ "claude-code": 8000, "pi-cli": 9000, "gemini-cli": 18000, "codex-cli": 45000 }`.
+- `swapAttemptTimeoutMsMax` — clamp on any single resolved cap (invalid/unset
+  ⇒ 120s) so a typo'd huge value cannot pin a host spawn-cap slot unbounded.
+- `swapTotalBudgetMs` — wall-clock TOTAL budget over the whole swap tail
+  (recommended 40000, set together with the per-target caps). When set, each
+  attempt's effective cap is `min(resolvedCap, budgetRemaining)` on a MONOTONIC
+  clock (never Date.now()), and the loop stops and falls closed once ≤250ms
+  remains — so the worst-case swap tail is literally ≤ the budget. Unset ⇒ no
+  enforcement (today's semantics).
+
+Also: the swap timeout timer is now cleared on settle (`withSwapTimeout`
+helper) so a fast success no longer leaks a pending timer per call; a stray/
+misspelled `byFramework` key warns once and is ignored (falls through to the
+global). The `swap-attempt-timeout:` degrade-reason format is unchanged.
+`failureSwap` ORDER remains latency-load-bearing (sequential loop) — order
+fastest-first; keep caps ≤ the circuit breaker's failure sensitivity.
+
+Rollback: remove the config block → instant revert to the global cap. No
+migrateConfig entry (absence is the default state, codexExecJson precedent).
+
+## What to Tell Your User
+
+<!-- audience: agent-only, maturity: preview -->
+- **Backup AI routes now get fair deadlines (off until you opt in)**: when my
+  main AI route fails mid-decision, I try backups — but every backup shared one
+  five-second deadline, and one of my backups (gemini) usually needs about nine
+  seconds, so it was being cut off before it could ever answer. I can now give
+  each backup its own deadline matched to how fast it really is, plus an
+  overall time limit so a chain of backups can never keep you waiting too long.
+  Nothing changes until we turn it on — if you'd like, I can enable the
+  recommended settings for you and undo it just as easily.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Per-target swap-attempt caps | `intelligence.swapAttemptTimeoutMsByFramework` in `.instar/config.json` (unset = today's global cap) |
+| Per-attempt clamp | `intelligence.swapAttemptTimeoutMsMax` (invalid/unset ⇒ 120s) |
+| Total swap-tail budget | `intelligence.swapTotalBudgetMs` (unset = no budget enforcement) |
+
+## Evidence
+
+- Live measurement (the bug): llm-pathway-bench R4 characterization, N=30
+  uncontended — gemini-flash p50 = 8,538ms, p95 = 15,726ms vs the 5,000ms flat
+  cap: every median-speed gemini swap attempt was killed at the cap before it
+  could answer (observed as `swap-attempt-timeout: gemini-cli` degrade reasons;
+  the attempt burned the full 5s slot and produced nothing). Other measured
+  targets for scale: claude ~3s p50 / ~6s p95, pi ~4.6s / ~7s, codex ~18s / ~43s
+  — no single cap fits all four.
+- After (mechanism, exercised end-to-end in-process): with the recommended 18s
+  gemini cap, an 8.5s-latency gemini target is SERVED on swap
+  (`tests/integration/per-target-swap-timeout.test.ts`, wired with the server's
+  exact threading expressions); with no per-framework config the same target is
+  abandoned at exactly 5s and the call fails closed — byte-identical to before
+  (regression tests pin the cap value the provider subprocess receives).
+- The field fix requires the operator opt-in (dark ship); the delivery
+  follow-through is tracked as commitment CMT-1889 (surface the recommended
+  values as a one-tap go/no-go).

--- a/upgrades/side-effects/per-target-swap-timeout.md
+++ b/upgrades/side-effects/per-target-swap-timeout.md
@@ -1,0 +1,120 @@
+# Side-Effects Review — Per-Target Failure-Swap Timeout (fixes gemini-swap-timeout)
+
+**Version / slug:** `per-target-swap-timeout`
+**Date:** `2026-07-02`
+**Author:** `echo (instar-dev agent)`
+**Second-pass reviewer:** `required — the change modifies timeout resolution on the failure-swap path that serves GATING calls (the tone gate rides it)`
+
+## Summary of the change
+
+The IntelligenceRouter failure-swap loop used ONE global per-attempt timeout (`intelligence.swapAttemptTimeoutMs`, default 5s) for every swap target. Measured provider latency (llm-pathway-bench, N=30) shows gemini's p50 is ~8.5s — the 5s cap sits BELOW gemini's median, so gemini as a swap target was reliably killed before it could answer, wasting a full swap slot ("poisoning the failover tail"). This change makes the cap resolvable PER TARGET FRAMEWORK (`intelligence.swapAttemptTimeoutMsByFramework`), adds a per-attempt clamp (`swapAttemptTimeoutMsMax`, invalid/unset ⇒ 120s), and adds an optional wall-clock TOTAL swap budget (`swapTotalBudgetMs`) that clamps each in-flight attempt to the remaining budget on a MONOTONIC clock, bounding the whole fail-closed tail to literally ≤ budget. All three fields default UNSET — routing/timeout behavior is byte-identical to today until an operator opts in (dark ship). Files touched: `src/core/IntelligenceRouter.ts` (resolveSwapCap, withSwapTimeout, per-target loop resolution, unknown-key hygiene), `src/core/types.ts` (three optional config fields), `src/commands/server.ts` (threads the three fields), `tests/unit/per-target-swap-timeout.test.ts`, `tests/integration/per-target-swap-timeout.test.ts`, spec + ELI16 + convergence report under `docs/specs/`. Spec: `docs/specs/per-target-swap-timeout-spec.md` (review-converged 2026-07-01, approved).
+
+## Decision-point inventory
+
+- `IntelligenceRouter failure-swap loop` (`src/core/IntelligenceRouter.ts` `evaluate()`) — **modify** — a routing/degrade path (which fallback provider gets how long), NOT a block/allow gate. No new gate is introduced or removed; the swap still fires only for `attribution.gating`/`deferrable` calls with configured `failureSwap` targets (scope unchanged). What changed is only HOW LONG each target is given (per-target vs one flat cap) and a new optional total-budget stop that falls CLOSED (the safe direction for gating calls).
+- `Gating ladder deadline` (`gatingLadderBudgetMs`) — **pass-through** — still checked first at each loop iteration, unchanged.
+
+**Phase 1 principle-check answer (recorded):** the change touches a decision point only in the routing/degrade sense — it does not gate information flow by content, block actions by meaning, or filter messages. Timeout resolution is deterministic mechanics (a wall-clock bound on a subprocess attempt), in the signal-vs-authority carve-out class of structural/transport mechanics, not a judgment decision. No brittle check gains blocking authority.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+At the default (all three fields unset): none — resolution degenerates to exactly today's single global cap; the regression tests assert the 5s behavior byte-for-byte (same cap value passed through as `timeoutMs`, same fail-closed rethrow).
+
+When an operator opts in: two deliberate "rejections" exist and both are the spec's explicit fail-SAFE choices, not accidents. (a) A `swapTotalBudgetMs` set below the 250ms floor disables swapping on the first attempt — an absurd misconfig fails CLOSED (no swap) rather than open (unbounded swap). (b) When the remaining budget is ≤ 250ms, a viable fast target later in the tail is NOT admitted — the loop falls closed. Both are unit-tested. A per-framework value that is invalid (0, negative, NaN, non-number) can never over-block: it falls through to the global, never to "no cap" and never to a 0ms instant kill (FD5, tested for every invalid class).
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **The dark default does not fix the field bug.** Gemini keeps dying at 5s until an operator sets the recommended values — this is the spec's own "ships-inert" finding. Mitigation is a DELIVERY obligation (FD8): surface the recommended values as a one-tap go/no-go and track the opt-in as a commitment (registered: CMT — see Conclusion). Tracked, not silently dropped.
+- **A provider that ignores `timeoutMs` can overrun its cap as an orphaned subprocess.** The `Promise.race` timer still resolves the swap decision at the cap (the loop advances on time), but the subprocess kill is the provider's own responsibility — unchanged by this change and already true of the existing global cap (spec: provider timeout contract).
+- **Operator misconfig within valid ranges:** a per-target cap set above the circuit breaker's failure sensitivity could keep a chronically-slow target alive without tripping the breaker; a slow target ordered FIRST in `failureSwap` delays faster ones up to its cap (order is latency-load-bearing). Both are documented operator constraints in the spec and the types.ts JSDoc — static caps remain blind to live latency drift by design (auto-tuning is explicitly out of scope, FD3 <!-- tracked: CMT-1889 -->).
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The failure-swap loop in `IntelligenceRouter` is the ONLY place that owns swap-attempt timing, and the change modifies exactly that resolution point (cap resolution moved inside the per-target loop). It does not re-implement any primitive: it reuses the existing `Promise.race` pattern (now wrapped in `withSwapTimeout`, which only adds timer-clear-on-settle), the existing `timeoutMs` provider pass-through contract, and the existing `onDegrade` observability channel (`swap-attempt-timeout:` reason format preserved byte-for-byte so DegradationReporter/metrics consumers are unaffected). The config lives in the existing `intelligence` block alongside the global cap it extends. No higher layer (LlmQueue, circuit breaker, gating ladder) owns per-attempt timing; no lower layer duplicates it.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The change has no judgment-based block/allow surface: it is timeout mechanics on a routing/degrade path (the signal-vs-authority carve-out class: structural bounds, not content judgment). The one nuance — acknowledged in the spec's foundation note — is that a static cap holds kill-authority over whether a provider ATTEMPT survives, blind to real latency; that mis-fit is the root shape of the original incident. This change REDUCES the mis-fit (caps sized per target to measured p50/p95) without adding any new authority, and the residual (static caps can drift from live latency) is explicitly flagged as a recurrence vector for the auto-tuning follow-up (FD3, out of scope <!-- tracked: CMT-1889 -->). Timed-out attempts still count toward the per-framework circuit breaker (unchanged), so the breaker — the existing authority over provider health — keeps its signal supply.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the gating-ladder deadline (`gatingLadderBudgetMs`) is checked FIRST at each loop iteration, before the new budget check — an active ladder still wins (unchanged precedence). The new total budget only ADDS a stop; it cannot extend the ladder's deadline. Verified in code order.
+- **Double-fire:** the per-attempt timer and the provider's own `timeoutMs` SIGTERM fire at the SAME bound (the cap is passed through as `timeoutMs`, exactly as before) — by design, not a race: the race timer decides the swap, the subprocess bound kills the process. The budget-clamped cap keeps them identical (the clamped value is what flows through).
+- **Races:** `withSwapTimeout` preserves the shipped crash-safe `Promise.race` semantics (per-input settlement handlers; late reject swallowed, late resolve ignored — both re-covered by the existing N1 tests, which still pass unmodified). The only addition is `clearTimeout` in a `finally`, which cannot race the rejection (a fired timer's clear is a no-op).
+- **Feedback loops:** timed-out swap attempts still count toward the target's circuit breaker (unchanged), so a chronically-timing-out target still trips its breaker and gets skipped fast on later calls — no new loop. The spec documents the operator constraint that caps SHOULD stay ≤ the breaker's failure sensitivity.
+- **Config layering:** the three new fields ride `IntelligenceRouterOptions`, NOT `ComponentFrameworksConfig` — so the §4.6 computed-default/live-override layering in `resolveConfig` is untouched (verified: the layered-resolveConfig tests pass unmodified).
+
+---
+
+## 6. External surfaces
+
+- **Other agents / install base:** none until opt-in — all three fields default unset and there is no `migrateConfig` entry (absence is the default state, codexExecJson precedent), so no deployed agent's config changes on update.
+- **External systems:** none. No new network calls, no new subprocess kinds — only how long an existing swap subprocess is given.
+- **Persistent state:** none. Per-call resolution from live opts; no ledger, no file, no store.
+- **Timing/runtime conditions:** the budget uses a MONOTONIC clock (`performance.now()`), never `Date.now()`, so an NTP step/DST jump cannot warp it (round-3 external finding; the gating-ladder's existing `Date.now()` deadline is unchanged — out of this change's scope). Observability: a cap firing emits the same `swap-attempt-timeout:` degrade reason as today (format preserved), visible in DegradationReporter and `/metrics/features`.
+- **Operator surface (Mobile-Complete Operator Actions):** no operator-facing action is added — the knobs are config fields. The FD8 delivery obligation (one-tap go/no-go for the recommended values) is where the operator surface will live; it is a tracked commitment (see Conclusion), deliberately outside this spec's code change per the approved spec.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable (no dashboard/approval/grant/revoke/secret-drop file is staged; the change is config + router internals + tests).
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN** (spec FD4). The swap cap is a per-call routing parameter read from each machine's local config at call time. It holds no durable cross-machine state (nothing to strand on topic transfer), emits no user-facing notice (no one-voice gating needed), and generates no URL (nothing to survive machine boundaries). Each machine's providers have that machine's latency characteristics, so per-machine values are the correct scope; an operator who wants uniform values sets them per machine's config. No replication path needed.
+
+---
+
+## 8. Rollback cost
+
+Pure code change with a dark default — two independent rollback levers, both cheap:
+
+- **Operator-level (instant, no release):** remove the `swapAttemptTimeoutMsByFramework` / `swapAttemptTimeoutMsMax` / `swapTotalBudgetMs` block from `.instar/config.json` → instant revert to the global-cap behavior (spec: "Rollback: remove the config block → instant revert").
+- **Code-level:** revert the commit, ship as next patch. No persistent state, no data migration, no agent state repair, no user-visible regression during the rollback window (the default path is byte-identical for routing/timeout semantics; the only internal difference is the timer-clear-on-settle hygiene, which is behavior-neutral for routing).
+
+---
+
+## Conclusion
+
+The review confirms the change is a localized, additive, dark-shipped modification of the failure-swap timeout resolution with no new block/allow authority, no persistent state, no external surface until opt-in, and a two-lever rollback. The design decisions that the review leaned on hardest — FD5 (invalid per-framework values fall through to the global, closing the accidental-uncap footgun), FD6 (the total budget clamps each IN-FLIGHT attempt so the tail is literally ≤ budget, and falls CLOSED at the floor), FD7 (maxCap clamp + validated knobs + timer hygiene) — are all unit-tested on both sides of every boundary (valid vs each invalid class). Two items are flagged, both already tracked: (1) the FD8 delivery obligation (the dark ship fixes nothing until the operator opts in — the recommended-values go/no-go + commitment is registered as CMT-1889 and is delivery work outside this spec's code change per the approved spec); (2) static caps remain blind to latency drift — the auto-tuning follow-up <!-- tracked: CMT-1889 --> (FD3) rides the same tracked commitment's context. Clear to ship pending second-pass concurrence (required: the change sits on the path that serves gating calls).
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** claude (independent second-pass subagent)
+
+**Independent read of the artifact: concur** — Verified against the working-tree diff (`src/core/IntelligenceRouter.ts`, `src/core/types.ts`, `src/commands/server.ts`) and all 56 tests (25 + 3 new; the 11 + 17 pre-existing pass unmodified): the code matches the spec's resolveCap contract exactly (isFinite && >0 validation, byFramework→global→undefined fall-through, maxCap clamp with invalid→120s default, in-flight `min(cap, remaining)` budget clamp on `performance.now()`, 250ms-floor fall-closed, budget-unset ⇒ no enforcement), no brittle check gains blocking authority (the unknown-key check is warn-once signal-only; the budget stop is a deterministic resource bound in the signal-vs-authority carve-out class), and the ladder-deadline-before-budget precedence, breaker counting, Promise.race crash-safety, finally-clause timer clear, and `swap-attempt-timeout:` prefix format are all true in the code as claimed — with one non-blocking precision note: the "byte-identical at default for ANY global cap" claim is overbroad for the exotic-but-JSON-reachable case of a pre-existing `swapAttemptTimeoutMs > 120000`, which the (spec-mandated, FD7-intended) default maxCap now clamps to 120s even with all three new fields unset — a fail-safe-direction change worth knowing in forensics, not a ship blocker.
+
+---
+
+## Evidence pointers
+
+- Unit: `tests/unit/per-target-swap-timeout.test.ts` (25 tests — resolveSwapCap contract incl. every invalid class, the gemini 8.5s fix + 5s regression, FD6 budget in-flight clamp/floor/unset/invalid/uncapped-bound, FD7 timer clear, wiring incl. server threading scan, unknown-key warn-once).
+- Integration: `tests/integration/per-target-swap-timeout.test.ts` (3 tests — server-exact wiring: the FD8 recommended-values package serves gemini at 8.5s under an 18s cap; no-config and absent-intelligence-block regressions pin the 5s global byte-for-byte).
+- Pre-existing behavior locked: `tests/unit/provider-fallback-swap-timeout.test.ts` (11 tests) and `tests/unit/intelligence-router.test.ts` (17 tests) pass UNMODIFIED against the new code.
+- Tier-3 carve-out: no HTTP route is added (internal routing-timeout knob), so per the Testing-Integrity Standard's no-route carve-out there is no "feature-alive/200" e2e; Tiers 1 + 2 apply (stated in the spec's Testing section).
+- Measured basis: llm-pathway-bench N=30 (gemini p50 8,538ms / p95 15,726ms; claude ~3s/~6s; pi ~4.6s/~7s; codex ~18s/~43s).


### PR DESCRIPTION
Implements the approved, review-converged spec `docs/specs/per-target-swap-timeout-spec.md` (review-convergence 2026-07-01, approved by justin — blanket pre-approval, autonomous run topic 29723). Fixes the R4 **gemini-swap-timeout** finding from the llm-pathway-characterization project.

## ELI16 — each backup AI route gets its own fair deadline

When the agent needs an AI model for a quick safety decision and its first-choice tool fails, it tries backup tools. Each backup attempt has a deadline so the agent never gets stuck waiting. Today that deadline is one shared number — 5 seconds for every backup. The problem: different AI tools answer at very different speeds, and we measured them. Gemini normally needs about 8.5 seconds — more than the 5-second deadline — so whenever gemini is the backup it gets killed before it can ever answer. It just wastes five seconds and then fails, every time. In practice gemini as a backup route is broken no matter how healthy it is. This change lets each tool have its own deadline matched to how fast it really is (gemini gets ~18 seconds, fast tools keep short ones), adds a safety clamp so a typo'd huge deadline can't hang a slot, and adds an optional overall time budget so a chain of backups can never keep a user waiting longer than a fixed ceiling. Nothing changes until the operator turns it on: all three settings ship unset, and with them unset the behavior is exactly today's single 5-second deadline. Removing the settings reverts instantly.

## What changed

- **`src/core/IntelligenceRouter.ts`** — swap-attempt cap resolution moved INSIDE the per-target loop via a new exported pure `resolveSwapCap(target, globalCap, byFramework, maxCap)`:
  - Resolution: `byFramework[target]` (valid = finite number > 0) → global `swapAttemptTimeoutMs` → undefined (no cap). An INVALID per-framework value (0, negative, NaN, Infinity, non-number) falls through to the global — never "no cap", never a 0ms kill (**FD5**: per-framework config cannot express "unbounded"; only the global's ≤0/unset does).
  - Per-attempt clamp to `swapAttemptTimeoutMsMax` (itself validated; invalid/unset ⇒ 120s) (**FD7**).
  - Optional total swap budget `swapTotalBudgetMs` (**FD6**): each attempt's effective cap is `min(resolvedCap, budgetRemaining)` on a MONOTONIC clock (`performance.now()`, never `Date.now()`); the loop stops and falls closed once ≤250ms remains — worst-case swap tail is literally ≤ budget. Unset ⇒ no enforcement.
  - `withSwapTimeout` helper: same crash-safe `Promise.race` pattern (late reject swallowed, late resolve ignored), now clearing the timer on settle (no leaked timer per fast success). The `swap-attempt-timeout:` degrade-reason format is preserved byte-for-byte.
  - Unknown/misspelled `byFramework` key from raw JSON config: warn once, no effect (falls through to global).
- **`src/core/types.ts`** — three new optional `intelligence` fields (`swapAttemptTimeoutMsByFramework`, `swapAttemptTimeoutMsMax`, `swapTotalBudgetMs`), typed to the framework union, documented with the recommended opt-in package and the failureSwap-order + breaker-sensitivity operator constraints.
- **`src/commands/server.ts`** — threads the three fields from `config.intelligence?.*` into the router opts (unset pass-through; the global still threads `?? 5000`).
- **Dark/reversible (FD1)**: all three fields default UNSET → routing/timeout semantics byte-identical to today for any existing `failureSwap` config. No `migrateConfig` entry (absence is the default state, codexExecJson precedent). Rollback: remove the config block.
- Recommended values (operator opt-in, NOT a shipped default): `{ "claude-code": 8000, "pi-cli": 9000, "gemini-cli": 18000, "codex-cli": 45000 }` + `swapTotalBudgetMs: 40000` — each ≥ measured p95 with margin (llm-pathway-bench N=30: gemini p50 8,538ms / p95 15,726ms).

## Tests

- **Unit** (`tests/unit/per-target-swap-timeout.test.ts`, 25 tests): full `resolveSwapCap` contract incl. every invalid class (0 / -1 / NaN / Infinity / string), unknown-key + unset-map + global-unset paths, maxCap clamp + invalid-maxCap default; the gemini 8.5s fix + the 5s regression; FD6 budget in-flight clamp (`min(cap, remaining)` verified via the timeoutMs the provider receives), tail ≤ budget across attempts, 250ms-floor fall-closed, budget-unset regression, invalid-budget-treated-unset, sub-250ms budget fail-SAFE, budget bounding an uncapped attempt; FD7 timer clear; wiring (opts end-to-end + server threading scan); unknown-key warn-once.
- **Integration** (`tests/integration/per-target-swap-timeout.test.ts`, 3 tests): router wired with the server's exact threading expressions + the §4.6 computed-default layering — the FD8 recommended package serves gemini at 8.5s under an 18s cap; no-config and absent-intelligence-block regressions pin the 5s global byte-for-byte.
- Pre-existing behavior locked: `provider-fallback-swap-timeout.test.ts` (11) and `intelligence-router.test.ts` (17) pass UNMODIFIED.
- **Tier-3 carve-out** (stated per the Testing-Integrity Standard): no HTTP route is added — internal routing-timeout knob — so no "feature-alive/200" e2e; Tiers 1 + 2 apply.

## Process

- Spec + ELI16 + convergence report shipped under `docs/specs/` (frontmatter carries `review-convergence` + `approved: true`).
- Side-effects artifact: `upgrades/side-effects/per-target-swap-timeout.md` — second-pass reviewer (independent subagent) **concurred**, with one recorded non-blocking precision note (a pre-existing global cap > 120s is now clamped by the default maxCap — spec-mandated FD7, fail-safe direction).
- Release-note fragment: `upgrades/next/per-target-swap-timeout.md` (bump: minor; user announcement maturity-tagged agent-only/preview — the ship is dark).
- **FD8 delivery obligation tracked**: commitment **CMT-1889** registered (surface the recommended values to the operator as a one-tap go/no-go after merge) — the mechanism ships here; the opt-in delivery closes the loop. The FD3 auto-tuning follow-up rides the same tracked commitment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
