### PR TITLE
feat(class-closure): registry + report-only recurrence lint (increment 1, ships dark)

### DIFF
--- a/.github/workflows/class-closure-gate.yml
+++ b/.github/workflows/class-closure-gate.yml
@@ -1,0 +1,41 @@
+# class-closure-gate — the REPORT-ONLY class-closure lint at the PR boundary.
+#
+# A fix for a defect found in an agent-authored artifact (prompts, hooks,
+# configs, skills, standards text) is supposed to declare, in its committed
+# instar-dev decision-audit entry, WHAT CLASS of defect it is an instance of and
+# HOW the class is closed (a live guard, or a tracked gap). This lint validates
+# those declarations. In increment 1 it is REPORT-ONLY: it prints findings and
+# ALWAYS exits 0 (the script only fails the build when
+# prGate.classClosure.enabled && !dryRun AND a hard structural violation exists).
+#
+# Mirrors decision-audit-gate.yml. Repo-gated: on a checkout without
+# docs/defect-classes.json the script prints a skip line and exits 0.
+#
+# Spec: docs/specs/class-closure-gate.md (Rollout step 1).
+
+name: class-closure
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  class-closure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Class-closure declarations (report-only)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/class-closure-lint.mjs

--- a/.instar/instar-dev-decisions/2026-07-03T19-46-17-562Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T19-46-17-562Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-03T19:46:17.562Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 9,
+  "loc": 1335,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-03T19-48-59-005Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T19-48-59-005Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-03T19:48:59.005Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 9,
+  "loc": 1335,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-03T19-49-48-067Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T19-49-48-067Z-unknown.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-03T19:49:48.067Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 9,
+  "loc": 1335,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-03T20-05-43-263Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T20-05-43-263Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-07-03T20:05:43.263Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 9,
+  "causalAutopsy": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-03T20-07-03-690Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T20-07-03-690Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-07-03T20:07:03.690Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 9,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/defect-classes.json
+++ b/docs/defect-classes.json
@@ -1,0 +1,106 @@
+{
+  "note": "The defect-class registry (docs/specs/class-closure-gate.md → 'The class registry'). Seeded with the four measured classes from the INSTAR-Bench v2 defect-class review (docs/audits/ib2-defect-class-review-2026-07-02.md). PROTECTED PATH: class SEMANTICS live here; routine fixes never edit this file (instanceCount is DERIVED by the gate lint from committed decision-audit declarations, deduped by PR — the stored field below is a CACHE). A seed enters escalatedAt='seeded-closed' with evidenceCountAtLastAck === instanceCount so ONLY historical backfill is suppressed; a post-seed declaration that grows a seeded class past that baseline fires the deterministic re-raise at lint time.",
+  "version": 1,
+  "classes": [
+    {
+      "id": "prompt-parser-contract-drift",
+      "description": "An agent-authored prompt's rendered output drifts from the contract its parser/validator enforces: the prompt teaches or relies on a token, section, or structure the parser does not guarantee, so a downstream consumer silently mis-parses the result.",
+      "includes": [
+        "a prompt whose output structure is not pinned by a render/parse contract",
+        "a verdict token, section header, or field the consuming parser does not recognize",
+        "a bench template that has diverged from the real rendered production prompt"
+      ],
+      "excludes": [
+        "a genuine parser bug in non-prompt code (ordinary product defect, out of initial scope)",
+        "a hard-invariant structural validator failing at an API edge (typing/shape rejection is not drift)"
+      ],
+      "canonicalExamples": [
+        "IB2 review: a sentinel prompt emitting a verdict shape the classifier parser did not accept",
+        "IB2 review: a bench task template diverged from the production-rendered prompt for the same component"
+      ],
+      "status": "confirmed",
+      "severity": "normal",
+      "closureStandard": "prompt-parser-contract-standard",
+      "closureStandardEnforcement": null,
+      "instanceCount": 2,
+      "escalatedAt": "seeded-closed",
+      "evidenceCountAtLastAck": 2,
+      "proposalId": null
+    },
+    {
+      "id": "injection-credulity",
+      "description": "An agent-authored prompt treats untrusted input (transcript excerpts, tool output, document or message bodies) as authoritative instruction — it lacks an authority clause separating the trusted instruction surface from quoted untrusted data, so injected content can steer the decision.",
+      "includes": [
+        "a prompt interpolating untrusted content without a sentinel/delimiter/authority clause",
+        "an untrusted interpolation slot that is not enumerated in the callsite's manifest",
+        "a data-block delimiter that embedded content can break out of"
+      ],
+      "excludes": [
+        "a trusted, first-party configuration value the operator controls",
+        "a hard-invariant structural validator at the system boundary (not a judgment surface)"
+      ],
+      "canonicalExamples": [
+        "IB2 review: a gate prompt that followed an instruction embedded in a quoted message body",
+        "IB2 review: a reviewer prompt whose untrusted evidence excerpt was not neutralized/delimited"
+      ],
+      "status": "confirmed",
+      "severity": "critical",
+      "closureStandard": "authority-clause-standard",
+      "closureStandardEnforcement": null,
+      "instanceCount": 3,
+      "escalatedAt": "seeded-closed",
+      "evidenceCountAtLastAck": 3,
+      "proposalId": null
+    },
+    {
+      "id": "claim-vs-evidence",
+      "description": "An agent-authored judge or gate credits a bare assertion as if it were evidence — the prompt accepts 'I did X' / 'this is done' without requiring a verifiable artifact, so an unproven claim passes the same bar as proof.",
+      "includes": [
+        "a judge prompt with no evidence bar for a claim of completion",
+        "a scoring rubric where a bare claim still lands at or above the acceptance floor",
+        "a gate that treats self-report as sufficient for a terminal transition"
+      ],
+      "excludes": [
+        "a decision that legitimately runs on stated intent rather than a claim-of-completion",
+        "a deterministic structural check that already verifies the artifact"
+      ],
+      "canonicalExamples": [
+        "IB2 review: a completion judge that accepted 'done' narration without an artifact",
+        "IB2 review: a scored judge whose bare-claim case still scored above the acceptance floor"
+      ],
+      "status": "confirmed",
+      "severity": "normal",
+      "closureStandard": "evidence-bar-judge-extension",
+      "closureStandardEnforcement": null,
+      "instanceCount": 2,
+      "escalatedAt": "seeded-closed",
+      "evidenceCountAtLastAck": 2,
+      "proposalId": null
+    },
+    {
+      "id": "durable-output-secrets",
+      "description": "An agent-authored component writes secrets, credentials, PII, or raw sensitive content into a durable output (a committed file, a log line, a persisted record, a shared transcript) without scrubbing — the sensitive material survives on disk or crosses a boundary.",
+      "includes": [
+        "a callsite whose output is durable and derives from untrusted/sensitive inputs without a scrub",
+        "a path, token, or credential leaking into a committed artifact or a persisted log",
+        "sensitive content crossing a machine/agent boundary without the shared redaction"
+      ],
+      "excludes": [
+        "an ephemeral in-memory value that is never persisted or transmitted",
+        "a value already redacted at the single shared scrub chokepoint"
+      ],
+      "canonicalExamples": [
+        "IB2 review: a durable output embedding a raw secret drawn from tool output",
+        "IB2 review: a persisted record carrying an unscrubbed file path / credential fragment"
+      ],
+      "status": "confirmed",
+      "severity": "critical",
+      "closureStandard": "durable-output-hygiene-standard",
+      "closureStandardEnforcement": null,
+      "instanceCount": 2,
+      "escalatedAt": "seeded-closed",
+      "evidenceCountAtLastAck": 2,
+      "proposalId": null
+    }
+  ]
+}

--- a/docs/specs/class-closure-gate.eli16.md
+++ b/docs/specs/class-closure-gate.eli16.md
@@ -1,0 +1,29 @@
+# The Class-Closure Gate — Plain-English Overview
+
+## What this is
+
+Last night I fixed ten prompt defects, each with full evidence. But you had to be the one to ask the bigger question: "what KIND of problems are these, and what stops the whole kind from ever coming back?" It turned out the ten fixes were really just four kinds. Nothing in my shipping process forces that question — it fired only because you asked. This spec builds the machinery so it fires every time, automatically.
+
+## The two pieces
+
+**Piece 1 — the gate (at fix time).** From now on, when I fix a defect in something I authored (a prompt, a hook, a config, a standard), the fix can't be closed until it answers two short questions on the record: *What class of defect is this?* (from a growing catalog — the four from last night seed it) and *What now prevents the whole class?* — either point at the concrete guard (a test, a rule, a check that now exists) or file a tracked "we owe a standard for this" item. One paragraph of work per fix. The effect: a fix can never again quietly treat a symptom while the disease stays unnamed.
+
+**Piece 2 — the escalator (over time).** My failure-learning system already collects records of what went wrong; today it only *displays* patterns. New rule: when the same class shows up 3+ times across different components, the system must produce a DRAFTED standard proposal and put it in front of you — not just more one-off fixes. You approve or reject; nothing enters the constitution without you. Data goes in; a proposal is forced out.
+
+## Why this converges
+
+Every caught defect either cites the guard that ends its class or creates the tracked demand for one. Repeating classes force a drafted rule to your desk. Rules can only accumulate; classes can only shrink. It's the same ratchet idea we already use for routing and test coverage — applied one level up, to the standards themselves.
+
+## What changes for you
+
+Occasionally you'll receive a drafted standard proposal to approve or reject (one per pattern, never a flood — re-triggers update the same draft). That's the whole visible surface.
+
+## Open questions (your call, stated simply)
+
+1. **Where's the starting line?** We propose the gate applies only to defects in things I authored (prompts, hooks, configs, standards) — ordinary product bugs stay exempt at first, so every bugfix doesn't get taxed with paperwork. Widen later if it earns it. Agree?
+2. **The trigger number.** A drafted proposal fires at 3+ instances across 2+ components, with no time limit (defect classes don't expire). The four known classes get marked "already handled" so history doesn't immediately re-fire. Sound right?
+3. **Who names the class?** The fixer (me) declares it; the machinery checks form, not judgment. Is a periodic "were these filed under the right class?" audit worth building, or does your review of proposals catch drift naturally?
+
+## What the multi-reviewer process changed
+
+The meta-machinery took the hardest beating — reviewers attacked it as future lazy fix authors would. (1) Instance counting is now DERIVED by scanning the committed fix records rather than hand-edited per fix — no merge conflicts, no undercounting, no routine fix ever needing your manual merge (an earlier draft would have accidentally routed EVERY fix through you). (2) A made-up hyper-narrow defect class buys nothing: novel classes need real definitions (what's in, what's out, nearest existing class), enter unconfirmed until you ack them, and can't claim closure while unconfirmed. (3) A cited "guard" only counts if it's genuinely ALIVE and enforcing — a dark or draft guard auto-downgrades the claim to an open gap, and gaps can't park forever (they age, escalate, and count toward forcing a drafted standard to you). (4) The four already-fixed classes are seeded closed for history, but a NEW occurrence of any of them re-alarms immediately and deterministically. (5) Security/privacy classes escalate on ONE occurrence, not three. (6) The whole proposal-drafting arm must obey the sibling standards it ships alongside (its inputs are untrusted, its output is durable — it scrubs and neutralizes like everything else). (7) *Round 3:* the counter now reads from exactly ONE machine-readable ledger, deduped by PR — an earlier draft scanned two mirrored records of the same fix and would have counted every fix twice (2 real instances looking like 4, falsely tripping the "3+ means draft a standard" wire). (8) *Round 3:* a class that recurs heavily inside a SINGLE component now also escalates (at 5 instead of 3) — before, ten repeats in one component never tripped the wire because the trigger insisted on spread across components.

--- a/docs/specs/class-closure-gate.md
+++ b/docs/specs/class-closure-gate.md
@@ -1,0 +1,330 @@
+---
+title: "Class-Closure Gate + Standards-Delta Escalator"
+slug: "class-closure-gate"
+author: "echo"
+parent-principle: "Distrust Temporary Success — A Recurrence Is a Root Cause"
+eli16-overview: "class-closure-gate.eli16.md"
+status: "review-convergence (round-5 clean (codex VERIFIED CLEAN on both arms; gemini VERIFIED CLEAN r4; internal three-passage consistency sweep clean))"
+tags: ["review-convergence"]
+approved: true
+approved-note: "Operator (Justin) approved the defect-class standards program 2026-07-03 in topic 29723; transcribed into the gate marker by Echo under the registered 24h autonomous build mandate (run run-mr58wczs-0b8103a2). Ships dark/report-only; operator retains veto."
+origin: "INSTAR-Bench v2 defect-class review (docs/audits/ib2-defect-class-review-2026-07-02.md), Part 2 (the meta-question)"
+operator-gate: "The gate + escalator are pipeline machinery — normal instar-dev pipeline, dark-first. Any STANDARD the escalator drafts ships ONLY with Justin's explicit sign-off (Agent Proposes, Operator Approves)."
+review-convergence: "2026-07-03T19:48:22.690Z"
+review-iterations: 5
+review-completed-at: "2026-07-03T19:48:22.690Z"
+review-report: "docs/specs/reports/class-closure-gate-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 6
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Spec — Class-Closure Gate + Standards-Delta Escalator (the meta-closure)
+
+**Ships:** a required class-declaration field-set on the ship pipeline's committed review
+artifacts + a validating lint (the gate); a deterministic recurrence trigger + a
+pattern→proposal drafter (the escalator). Both dark-first, config-gated, repo-gated.
+
+**Run boundary (Autonomy Principle 2):** the /instar-dev run's deliverable is the live gate
+lint (report-only) + class registry + escalator machinery dark + DRAFTED text. Operator
+sign-off on anything registry/constitution-bound is the run's endpoint.
+
+## Problem statement
+
+INSTAR-Bench v2 caught and fixed ten prompt defects. Each fix met the ship pipeline's
+per-fix bar (reproduce, prove the fix, prove no regressions) — and NOTHING in the pipeline
+asked the class question: *"what CLASS of defect is this an instance of, and what
+structural change makes the whole class unrepresentable?"* The question fired only because
+the operator asked it. That is willpower where the constitution's Root ("Structure beats
+Willpower") demands structure — and the constitution even holds the meta-principle
+(**Distrust Temporary Success: A Recurrence Is a Root Cause**) with no mechanical arm at
+fix-time.
+
+Second layer (verified against the live system): the failure-learning loop and the
+framework-issues ledger already COLLECT instance records with buckets and dedup keys.
+Collection exists; **forced generalization does not** — data flows in, no mechanism compels
+a standards-delta out.
+
+**Industry framing (round-1 external ask):** this is a CAPA (corrective and preventive
+action) workflow — the review-record fields map to root cause (`defectClass`), corrective
+action (the fix itself), preventive action (`closure`), and verification of effectiveness
+(the periodic effectiveness review below). It lives in-repo rather than an external tracker
+deliberately: the artifacts must be lintable in CI, git-replicated across machines, and
+inside the same review chokepoint as the code they govern — an external tracker satisfies
+none of those structurally.
+
+**Terms (external readability):** *door* = the access path to a model (CLI wrapper vs clean
+API); *route* = model + door; *ratchet* = a CI test pinning a baseline that may only
+shrink; *callsite* = one LLM decision-point in the coverage registry. (Same glossary block
+as the sibling specs.)
+
+## Proposed design
+
+### Piece 1 — the class-closure gate (fix-time chokepoint)
+
+A fix for a defect found in an **agent-authored artifact** (LLM prompts, hooks, configs,
+skills, standards text — initial scope; see Frontloaded Decisions) cannot CLOSE until its
+committed review artifact declares:
+
+- `defectClass`: an id from the class registry (below), or `novel` — and `novel` is not a
+  free pass: it REQUIRES a new class-registry entry in the same change carrying the full
+  semantics (at least one `includes`, one `excludes`, a `severity`, and a
+  `nearestExistingClass` comparison — one line on why that nearest neighbor doesn't fit,
+  which subsumes the bare `whyNotExisting`). A novel class enters as
+  `status: "unconfirmed"` and raises ONE deduped attention item to the operator;
+  **an unconfirmed class cannot satisfy `closure: guard`** (its fix carries `closure: gap`
+  until the class is operator-confirmed) — so hyper-narrow self-serving classes buy
+  nothing.
+- `closure`: EITHER `guard` — the standard/test/lint that makes recurrence structurally
+  refused or detected (nothing makes LLM-behavior recurrence literally impossible; the
+  claim is bounded honestly), cited by path/symbol — OR `gap` — a tracked standards-gap
+  item (id cited) when the class-level guard is genuinely out of the fix's scope. Gap items
+  are evolution actions, which already carry `owner`, created/due dates, and re-surfacing
+  cadence — the CAPA ownership fields exist there, not duplicated here.
+- `guardEvidence` (required with `closure: guard`): the guard's ENFORCEMENT TYPE as graded
+  by the Standards Enforcement Coverage audit's grader (`ratchet` / `gate` / `lint`), plus
+  one line on *how this guard would have caught THIS defect*. Existence-on-disk is not
+  enough (a dark, dry-run, or spec-only artifact guards nothing — G3): **a citation that
+  does not resolve to a live enforcing guard automatically downgrades the declaration to
+  `closure: gap`.** Wiring, stated (the grading must not ride a dark runtime dependency):
+  the lint invokes the conformance audit's deterministic grader **as a library over the
+  repo checkout** — never the agent-runtime route (which ships dark and 503s). Grader
+  unavailable or erroring ⇒ the declaration downgrades to `gap` (fail-closed), stated
+  normatively.
+- `gap` items are NOT fire-and-forget (Close the Loop): a gap is filed as an evolution
+  action (riding the existing re-surfacing cadence), and an OPEN gap item COUNTS AS
+  ESCALATION EVIDENCE (below) — 2 instances + 1 open gap escalates. A gap open past a
+  max age (default 45 days) escalates once on its own.
+
+**Host (concrete, verified — resolves round-1 F9):** the "review record" is not a new
+artifact. The gate's fields live as (a) a structured JSON block in the instar-dev
+**decision-audit entry** (the machine-readable host the lint validates) and (b) a mirrored
+required section in the **side-effects artifact** (`upgrades/side-effects/<slug>.md`,
+extending the existing template — the human-readable mirror). Field order is free; the lint
+validates presence and shape, not ordering. The same block is where the program's A/B
+mechanical arm lives: any prompt-touching fix embeds its A/B verdict summary (run id,
+routes, fixed/regressed counts) in the same structured block, lintable.
+
+Mechanically: the lint rides the PR-gate workflow family (the `decision-audit-gate.yml`
+precedent), scoped to diffs touching agent-authored artifacts. Cost per fix: one paragraph.
+Effect: an instance fix can never again silently absorb a class — it either cites the live
+guard that ends the class or creates the tracked demand for one.
+
+**Gate self-wedge exemption (bounded, gate-source-ONLY):** the exemption applies only when
+the diff touches EXCLUSIVELY the gate's own source files — any other agent-authored
+artifact in the same diff still requires its declaration (a mixed PR cannot ride the
+exemption), the exemption is logged, and the cap counts per-PR (the
+guard-bypass-carries-its-own-cap rule). A broken gate can never block its own repair; its
+repair can never smuggle undeclared fixes.
+
+### The class registry
+
+`docs/defect-classes.json` — seeded with the four measured classes, each carrying real
+semantics (not just ids): `id`, `description`, `includes` / `excludes` criteria,
+`canonicalExamples`, `status` (`confirmed` / `unconfirmed`), `closureStandard` (nullable)
+**plus the closure standard's enforcement status as last graded**, and the escalation state
+(`instanceCount`, `escalatedAt`, `proposalId`, `evidenceCountAtLastAck`) — keeping
+escalation bookkeeping IN the registry makes escalator ticks idempotent and O(new records),
+and implements the backfill mitigation for free:
+
+```json
+{
+  "classes": [
+    { "id": "prompt-parser-contract-drift", "status": "confirmed",
+      "closureStandard": "prompt-parser-contract-standard", "escalatedAt": "seeded-closed" },
+    { "id": "injection-credulity", "status": "confirmed",
+      "closureStandard": "authority-clause-standard", "escalatedAt": "seeded-closed" },
+    { "id": "claim-vs-evidence", "status": "confirmed",
+      "closureStandard": "evidence-bar-judge-extension", "escalatedAt": "seeded-closed" },
+    { "id": "durable-output-secrets", "status": "confirmed",
+      "closureStandard": "durable-output-hygiene-standard", "escalatedAt": "seeded-closed" }
+  ]
+}
+```
+
+(**`seeded-closed`, defined precisely:** a seed enters as escalated-and-acked with
+`evidenceCountAtLastAck` initialized to its seed-time `instanceCount` — so ONLY historical
+backfill is suppressed. A post-seed declaration that grows a seeded class past that
+baseline fires the deterministic re-raise/reopen path at lint time, exactly like any other
+class — the four measured classes are the LIKELIEST to recur, and their recurrence must
+never wait on the dark drafting arm. Recurrence-despite-closureStandard rides this same
+deterministic path; the periodic effectiveness pass is backstop only.)
+
+### Piece 2 — the standards-delta escalator (deterministic trigger, drafted proposal)
+
+**Trigger (deterministic, always-on with the gate — resolves round-1 F10):** the recurrence
+count does NOT live in the fleet-dark failure-learning loop — and it is DERIVED, never
+hand-maintained (resolves the round-2 bookkeeping cluster: per-PR count edits would
+merge-conflict between concurrent fixes, silently undercount on clean merges, and drag
+every routine fix through a protected file). The committed `defectClass` declarations ARE
+the count: the gate lint recomputes each class's `instanceCount` by scanning the
+**decision-audit entries ONLY** — the single machine-readable counting host (round-3
+material finding: scanning both mirrored hosts would double-count every fix — 2 real
+instances reading as 4 and falsely crossing the ≥3 threshold — and duplication would let an
+author inflate evidence; the side-effects artifact's mirrored section is DISPLAY-ONLY for
+human review, and the lint's mirror-consistency check asserts the two hosts AGREE, it never
+adds them). Each decision-audit entry carries the fix's PR number as its natural dedup key
+— two entries citing the same PR + class count once. The count is conflict-free,
+self-healing, and validated rather than written; the registry's stored field is a CACHE the
+lint checks and the escalator's pass refreshes. The lint VALIDATES, the periodic pass
+MUTATES — no CI job ever edits source in a contributor's PR. When derived declarations show
+the SAME class ≥N times (default 3) across ≥2 distinct components — or ≥2 instances plus an
+open gap item, or ONE confirmed instance of a class tagged `severity: critical`, **or ≥K
+times (default 5) within a SINGLE component** (round-3 material finding: without this arm, a
+class recurring 10× inside one component at normal severity never deterministically
+escalates — the component-spread requirement exists to distinguish a systemic pattern from
+one noisy component, so the single-component arm uses a higher K rather than no arm at all)
+— the threshold is crossed deterministically at lint time.
+
+**Severity is not optional (resolves round-2):** every class entry carries `severity`
+(`critical` = security/privacy/data-loss ⇒ escalates at 1 confirmed instance; `normal`
+⇒ the ≥3-across-≥2-components rule OR the ≥K=5-single-component arm — both round-3 arms
+apply; `normal` is the only tier where they are operative, since `critical` escalates at 1).
+Operator confirmation of a novel class explicitly confirms its severity;
+the effectiveness review audits severity assignments. Seeds: `durable-output-secrets` and
+`injection-credulity` are `critical`; the other two `normal`.
+
+**Drafting (dark-first; deterministic skeleton + LLM narrative only):** on a crossed
+threshold, the escalator produces a **standards-delta proposal** at the deterministic path
+`docs/proposals/<classId>.md` (repo-gated, like release-readiness: no-op on non-maintainer
+installs; a CI check asserts at most one open proposal per class) — plus ONE
+attention-queue item with the stable id `escalator:<classId>` (pool-coalesced via P17, so
+multi-machine raises collapse; novel-class confirmation items use the same
+`class-registry:<classId>` stable-id shape). The proposal's skeleton (class, evidence list,
+counts, cited fixes) is TEMPLATE-FILLED deterministically; only the narrative section is
+LLM-drafted, under the constraints below. The proposal is a draft, never an adoption:
+**Agent Proposes, Operator Approves** is preserved by construction (the escalator has no
+write path to `STANDARDS-REGISTRY.md`). The escalator's periodic pass runs Tier-1
+supervised (per the LLM-Supervised Execution standard) and is ALSO the named write path for
+ack bookkeeping: it reads the attention store on the maintainer machine and commits
+`evidenceCountAtLastAck` back to the registry cache — a runtime ack thereby reaches git
+through one audited, repo-gated writer.
+
+**Multi-machine posture (declared):** class registry, review artifacts, and proposals are
+git-replicated (the repo IS the replication medium); dedup is REPO STATE ("does an open
+proposal file for this class exist?"), never machine-local JSONL — so two machines cannot
+double-file. No file-local escalator state exists (nothing for BackupManager to consider).
+
+**Dedup that cannot become a suppressor (resolves round-1):** re-triggering updates the
+existing draft's evidence list — AND the attention item re-raises when the class's evidence
+count grows past `evidenceCountAtLastAck` (the release-readiness age/evidence-escalation
+shape). One stale acked proposal can no longer park a class forever.
+
+**The escalator drafter is subject to its sibling standards (self-application):** the
+drafting callsite is flagged `untrustedInput` + `durableOutput` in the shared metadata
+record (its evidence inputs derive from transcripts/tool output; its output is a committed
+file), carries the authority + durable-output clauses, runs the shared scrub before write,
+and quotes evidence excerpts in neutralized/delimited form. The meta-machinery must not
+reintroduce Classes 2 and 4.
+
+**Effectiveness review (softening "why this converges" — resolves round-1):** convergence
+is a tendency, not a theorem — bad classes, weak guards, and stale gaps can accumulate. The
+escalator's periodic pass therefore also audits: recurrence-despite-closureStandard
+(REOPENS the class and flags the standard), classification drift (spot-check of recent
+`defectClass` declarations against class semantics), taxonomy health (overlapping/
+ambiguous classes proposed for merge), open-gap ages, and the shared scrub pattern-list
+staleness (per `durable-output-hygiene-standard.md`). Classes shrink only while guards
+actually hold; the review is what notices when they don't.
+
+## Program-shared machinery (defined once here; binding on all five specs)
+
+1. **ONE per-callsite metadata record.** All program flags extend the existing
+   `src/data/llmBenchCoverage.ts` record (per-COMPONENT granularity, matching the registry;
+   components with two surfaces carry two entries):
+   `{ task, contract?, untrustedInput!, judgesClaims!, durableOutput! }` — `!` fields are
+   required-explicit with argued-false pinned shrink-only. ONE consolidated axis-requirements
+   ratchet test derives every required axis from the flags; the per-spec pending sets are
+   fields of a single pinned baseline. (Kills the four-independent-ratchets drift the
+   round-1 scalability review flagged.)
+2. **Batteries readable by CI (frontloaded decision).** The task batteries are committed to
+   the canonical repo under their existing quarantine path (payload files referenced by
+   path, excluded from cartographer/KB sweeps, placeholder constants allowlisted in the
+   leak-detector). The consolidated ratchet reads battery JSON directly — one source, no
+   axis-manifest copy to drift. NAMED FALLBACK if maintainers refuse payload files on main:
+   a distilled per-task axis manifest in `src/data/` carrying each battery's sha256, plus a
+   benching-agent conformance artifact asserting manifest↔battery parity; the ratchet then
+   asserts against the manifest with the caveat recorded in the standard text.
+3. **The A/B mechanical arm.** "Ships only through A/B" is enforceable only if CI can see
+   the verdict: every prompt-touching fix embeds its A/B verdict summary in the gate's
+   structured review block (host above), and the A/B harness runs the prompt-fidelity
+   precondition (bench template diffed against the real rendered production prompt — the
+   prompt-parser render functions are the diff source) before any verdict counts.
+4. **Protected paths — anchored on the exemption chokepoints, not the whole registry**
+   (resolves the round-2 composition finding: protecting the coverage map wholesale would
+   route EVERY routine fix and every new-callsite PR to the operator, reverting the
+   auto-merge machinery for the dominant PR class). The protected set is:
+   `docs/defect-classes.json` (class SEMANTICS — routine fixes never touch it now that
+   counts are derived), `src/core/promptClauses.ts`, the chokepoint inventory, and the
+   **pinned-baseline ratchet test files**. That last anchor is sufficient by construction:
+   every exemption, argued-false flag, and pending-set edit MUST touch a pinned baseline to
+   pass CI — so all of them route to the operator — while an additive, fully-conforming new
+   callsite entry (flags true, axes present) touches no baseline and keeps auto-merge.
+   No self-service exemption can auto-merge; no routine fix loses throughput.
+5. **X1 exemption shape.** An exemption anywhere in the program is a registry/manifest
+   entry with `reason` + `owner`, landed via normal PR review.
+6. **X2 A/B bound.** Any per-component prompt migration is bounded at 2 failed A/B attempts
+   per run; the incumbent stands and a tracked gap item is filed — a named legitimate
+   terminal state.
+
+## Decision points touched
+
+The gate adds a build-time refusal (missing/invalid class declaration = red PR-gate lint)
+on the instar-dev ship path — CI-only, no runtime gates. The escalator adds an
+attention-queue producer (bounded, deduped-with-re-raise, pool-coalesced). No runtime
+allow/deny changes.
+
+## Config & posture
+
+- Config: `prGate.classClosure` = `{ enabled, dryRun, escalatorDrafting }` — the existing
+  PR-gate family, NOT a new `pipeline.*` family (`escalatorDrafting` is the dark-staged LLM
+  arm's own key; the deterministic trigger rides `enabled`). Repo-gated (no-op/503 on
+  installs without the instar repo, the release-readiness precedent), so Migration Parity
+  owes the fleet nothing for maintainer-only machinery. Build-time re-grounding note: the
+  build verifies its hosts (`src/data/llmBenchCoverage.ts`, the decision-audit workflow,
+  `upgrades/side-effects/`) exist on the CANONICAL branch it targets — they are verified on
+  main today but absent from some serving branches.
+- Guard posture: the gate and the escalator trigger register in `guardManifest` so `/guards`
+  reports them; once the registry text names the gate as an enforcement arm it is marked
+  `loadBearing` (a dark gate visibly classifies as a load-bearing gap instead of silently
+  guarding nothing).
+
+## Frontloaded Decisions
+
+1. **Initial scope boundary** (was Open Q1): agent-authored artifacts only (prompts, hooks,
+   configs, skills, standards text). Expansion to critical-path product defects is an
+   explicit post-run decision informed by the report-only friction telemetry.
+2. **N and the window** (was Open Q2): N=3 across ≥2 components OR K=5 within one component
+   (round-3 arm), windowless (defect classes don't expire), config-tunable; severity
+   override — critical classes escalate at 1; the four seeds enter
+   `escalatedAt: "seeded-closed"` so backfill can't re-fire. Counting host: decision-audit
+   entries only, deduped by PR (round-3; the side-effects mirror is display-only).
+3. **Who classifies** (was Open Q3): the fix author declares; the lint validates form; the
+   escalator's periodic pass audits classification accuracy by spot-check (drift is a
+   finding, not a blocker). During dryRun, classification ACCURACY is measured alongside
+   friction — the gate flips to enforcing only if the declarations are actually reliable.
+4. **Record shape** (was Open Q4): decision-audit structured block + side-effects mirrored
+   section; presence/shape validated, ordering free.
+5. **Enforcing flip criterion:** report-only has covered ≥10 agent-authored-artifact fixes
+   or 14 days, with the class block populated on 100% of them and zero pipeline breakage.
+   **The criterion cannot become a delay-forever lever held by the gated party:**
+   report-only older than 30 days with <100% population raises ONE attention item carrying
+   the population/accuracy stats — the OPERATOR decides the flip on that evidence — and
+   fixes shipped without declarations during report-only are retro-filed as gap items, so
+   under-populating buys nothing.
+6. **Exemption shape / A/B bound:** X1/X2 (program-shared machinery above).
+
+## Rollout
+
+1. Class registry + review-block fields + gate lint land; lint report-only (logs missing
+   declarations, blocks nothing) — measures friction AND classification accuracy honestly
+   first. Protected-path additions land with it.
+2. Lint flips to enforcing for agent-authored-artifact fixes per the flip criterion
+   (`prGate.classClosure.enabled` + `dryRun`).
+3. Escalator drafting lands dark (repo-gated; the deterministic trigger is part of the gate
+   lint and lives from step 1; only the LLM drafting arm is staged).
+
+## Open questions
+
+*(none)*

--- a/docs/specs/reports/class-closure-gate-convergence.md
+++ b/docs/specs/reports/class-closure-gate-convergence.md
@@ -1,0 +1,80 @@
+# Class-Closure Gate + Standards-Delta Escalator — Convergence Record
+
+**Spec:** `docs/specs/class-closure-gate.md` (slug `class-closure-gate`)
+**Companion:** `docs/specs/class-closure-gate.eli16.md`
+**Status:** CONVERGED — `tags: ["review-convergence"]`, round-5 clean.
+**Source program record:** `docs/specs/reports/defect-class-program-round3-2026-07-02.md`
+(this spec is one of the five specs of the defect-class standards program; the
+program-wide record documents all five, this report distils the class-closure-gate
+arm).
+
+## Process
+
+`/spec-converge` iterative review — six internal reviewers (security, scalability,
+adversarial, integration, decision-completeness, lessons-aware) plus real
+cross-model external reviewers routed through the agent's installed CLIs
+(codex → GPT-5.5 via `codex exec --sandbox read-only`; gemini CLI → Gemini-tier),
+one pass per available family, iterated to convergence. Grounding checks ran against
+canonical `main`: `src/data/llmBenchCoverage.ts`, `.github/workflows/decision-audit-gate.yml`,
+`upgrades/side-effects/`, and `docs/STANDARDS-REGISTRY.md` were all verified present;
+`src/core/promptClauses.ts` was correctly proposed-new.
+
+## Rounds
+
+- **Round 1** — full panel → ~20 material issues across the program, fixed
+  (commit `5eebc12cc`). For class-closure-gate specifically: the round-1 findings
+  F9 (record host), F10 (trigger location / deterministic trigger), and the
+  dedup-cannot-become-a-suppressor seam were resolved into the current design
+  (decision-audit structured block as the machine-readable host; a mirrored,
+  display-only side-effects section; a deterministic recurrence trigger that lives
+  in the gate lint, not the fleet-dark failure-learning loop).
+- **Round 2** — same panel re-review → 9 material seams program-wide, fixed
+  (commit `c4fec19b0`). For class-closure-gate: severity made non-optional (every
+  class carries `severity`; critical escalates at 1); the derived-count bookkeeping
+  cluster resolved (per-PR count edits would merge-conflict between concurrent fixes
+  and drag routine fixes through a protected file — counts are now DERIVED from the
+  committed declarations, never hand-maintained).
+- **Round 3** — targeted clean-pass check → 2 genuinely-new material findings on this
+  spec (both fixed in the round-3 edit commit):
+  - **C1 (fixed):** `instanceCount` derived by scanning BOTH mirrored hosts with no
+    dedup key would double-count every fix (2 real instances reading as 4, falsely
+    crossing the ≥3 threshold; duplication also inflates evidence). **Closure:** the
+    count derives from decision-audit entries ONLY, deduped by PR number; the
+    side-effects mirror is display-only; the lint asserts mirror CONSISTENCY, never
+    sums the two hosts.
+  - **C3 (fixed):** the ≥N-across-≥2-components trigger never fires for a class
+    recurring heavily inside ONE component at normal severity — no arm covered it.
+    **Closure:** a single-component arm — ≥K (default 5) within one component
+    escalates; the higher K preserves the systemic-vs-noisy-component distinction the
+    spread requirement encodes. Decision-point 2 was updated to match.
+  - C2 (not-material): classification-accuracy spot-checking re-litigates Frontloaded
+    Decision #3 — dryRun measures declaration reliability before the enforcing flip,
+    and novel-class gaming is separately closed (unconfirmed classes can't satisfy
+    `closure: guard`).
+- **Round 4** — targeted verification of the round-3 closures → 1 residual one-line
+  inconsistency on this spec (a codex catch, citation-verified): the severity
+  paragraph mapped `normal ⇒ the ≥3/≥2 rule`, omitting the K=5 single-component arm —
+  the only severity tier where that arm is operative; read as authoritative it would
+  have nullified the round-3 closure. Fixed.
+- **Round 5** — final clean pass → CONVERGED. The severity paragraph now carries both
+  arms with the "only operative for `normal`" rationale. Round-5 verification: codex
+  VERIFIED CLEAN; internal three-passage consistency sweep (trigger ¶ / severity ¶ /
+  decision-point 2) clean.
+
+## Final state
+
+`review-convergence` tag applied. All open questions were resolved into the spec's
+**Frontloaded Decisions** section (initial scope boundary; N/K and windowlessness;
+who classifies; record shape; the enforcing-flip criterion with its
+cannot-become-a-delay-forever-lever guard; the X1/X2 program-shared machinery).
+
+## Build boundary (per the spec's Run boundary)
+
+The `/instar-dev` build ships: the live gate lint (**report-only**), the class
+registry (`docs/defect-classes.json`, seeded with the four measured classes), and the
+standards-delta escalator machinery **dark** (deterministic trigger + pattern→proposal
+DRAFTER). Registering any standard or touching the constitution is OUT OF SCOPE — it
+requires the operator's explicit sign-off (Agent Proposes, Operator Approves). The
+operator (Justin) approved the defect-class standards program on 2026-07-03 in topic
+29723; that approval is transcribed into the spec's `approved: true` gate marker for
+this build (dark/report-only; operator retains veto).

--- a/scripts/class-closure-declare.mjs
+++ b/scripts/class-closure-declare.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * class-closure-declare — the AUTHOR's declaration helper for the Class-Closure
+ * Gate (docs/specs/class-closure-gate.md → Piece 1 host). It merges a
+ * `classClosure` block into the MOST-RECENT committed decision-audit entry
+ * (`.instar/instar-dev-decisions/<ts>-<slug>.json`) — the machine-readable host
+ * the gate lint validates.
+ *
+ * Self-contained ESM (no build step), idempotent (re-running with the same block
+ * is a no-op). The block is supplied EITHER as a whole JSON string via
+ * `--json '{"defectClass":"...","closure":"guard",...}'`, OR assembled from flags:
+ *
+ *   node scripts/class-closure-declare.mjs \
+ *     --class injection-credulity --closure guard \
+ *     --citation src/core/promptClauses.ts#authorityClause \
+ *     --enforcement gate --how-caught "the authority clause separates ..." \
+ *     --pr 1290 --component CoherenceReviewer
+ *
+ * For a gap: `--closure gap --gap-item ACT-1234`.
+ * For a novel class: `--class novel --novel-json '{"nearestExistingClass":"...","includes":[...],"excludes":[...],"severity":"normal"}'`.
+ *
+ * It only WRITES the review host; it does not touch the registry or grade the
+ * guard (the lint does the grading). Prints the merged block to stdout.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DECISIONS_REL = path.join('.instar', 'instar-dev-decisions');
+
+/** Parse `--key value` / `--flag` pairs into a plain object. */
+export function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith('--')) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Build a classClosure block from parsed args. Throws on a structurally-invalid
+ * request (so a bad declaration is caught at author time, not just at lint time).
+ * @returns {object} the classClosure block.
+ */
+export function buildClassClosureBlock(args) {
+  if (args.json) {
+    let parsed;
+    try {
+      parsed = JSON.parse(args.json);
+    } catch (err) {
+      throw new Error(`--json is not valid JSON: ${err && err.message ? err.message : String(err)}`);
+    }
+    if (!parsed || typeof parsed !== 'object') throw new Error('--json must be an object');
+    return normalizeBlock(parsed);
+  }
+
+  const block = {};
+  if (!args.class || typeof args.class !== 'string') throw new Error('--class <id|novel> is required');
+  block.defectClass = args.class;
+  const closure = args.closure;
+  if (closure !== 'guard' && closure !== 'gap') throw new Error("--closure must be 'guard' or 'gap'");
+  block.closure = closure;
+
+  if (closure === 'guard') {
+    if (!args.citation || typeof args.citation !== 'string') throw new Error("closure 'guard' requires --citation <path|route|symbol>");
+    block.guardEvidence = {
+      enforcementType: typeof args.enforcement === 'string' ? args.enforcement : undefined,
+      citation: args.citation,
+      howCaught: typeof args['how-caught'] === 'string' ? args['how-caught'] : undefined,
+    };
+  } else {
+    if (!args['gap-item'] || typeof args['gap-item'] !== 'string') throw new Error("closure 'gap' requires --gap-item <evolution-action-id>");
+    block.gapItem = args['gap-item'];
+  }
+
+  if (args.pr !== undefined) {
+    const n = Number(args.pr);
+    if (!Number.isFinite(n)) throw new Error('--pr must be a number');
+    block.prNumber = n;
+  }
+  if (typeof args.component === 'string') block.component = args.component;
+
+  if (args.class === 'novel') {
+    if (!args['novel-json']) throw new Error("--class novel requires --novel-json '{...}' with full class semantics");
+    let nc;
+    try {
+      nc = JSON.parse(args['novel-json']);
+    } catch (err) {
+      throw new Error(`--novel-json is not valid JSON: ${err && err.message ? err.message : String(err)}`);
+    }
+    if (!nc || typeof nc !== 'object' || !nc.nearestExistingClass) {
+      throw new Error('--novel-json must carry nearestExistingClass (+ includes/excludes/severity)');
+    }
+    block.novelClass = nc;
+  }
+
+  return normalizeBlock(block);
+}
+
+/** Strip undefined leaves so the written block is minimal + idempotent-comparable. */
+function normalizeBlock(block) {
+  const out = {};
+  for (const [k, v] of Object.entries(block)) {
+    if (v === undefined) continue;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      out[k] = normalizeBlock(v);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/** Find the most-recent decision-audit entry file (by ts field, else filename). */
+export function findMostRecentDecisionEntry(repoRoot) {
+  const dir = path.join(repoRoot, DECISIONS_REL);
+  let files;
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return null;
+  }
+  if (files.length === 0) return null;
+  let best = null;
+  for (const f of files) {
+    let entry;
+    try {
+      entry = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8'));
+    } catch {
+      continue;
+    }
+    const tsKey = typeof entry.ts === 'string' ? entry.ts : f;
+    if (best === null || tsKey > best.tsKey || (tsKey === best.tsKey && f > best.file)) {
+      best = { file: f, entry, tsKey };
+    }
+  }
+  return best ? { file: path.join(dir, best.file), entry: best.entry } : null;
+}
+
+/**
+ * Merge the block into the most-recent entry + write it back. Idempotent — a
+ * re-run with an identical block returns { changed: false }.
+ * @returns {{ changed: boolean, file: string, block: object }}
+ */
+export function applyDeclaration(repoRoot, block) {
+  const target = findMostRecentDecisionEntry(repoRoot);
+  if (!target) {
+    throw new Error(`no decision-audit entry found under ${DECISIONS_REL} to attach the declaration to`);
+  }
+  const before = JSON.stringify(target.entry.classClosure ?? null);
+  const after = JSON.stringify(block);
+  if (before === after) {
+    return { changed: false, file: target.file, block };
+  }
+  target.entry.classClosure = block;
+  fs.writeFileSync(target.file, `${JSON.stringify(target.entry, null, 2)}\n`, 'utf-8');
+  return { changed: true, file: target.file, block };
+}
+
+// ── CLI entrypoint ──────────────────────────────────────────────────────────
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].split('/').pop());
+if (invokedDirectly) {
+  const repoRoot = process.env.CLASS_CLOSURE_REPO_ROOT || process.cwd();
+  const args = parseArgs(process.argv.slice(2));
+  let block;
+  try {
+    block = buildClassClosureBlock(args);
+  } catch (err) {
+    console.error(`class-closure-declare: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(2);
+  }
+  let result;
+  try {
+    result = applyDeclaration(repoRoot, block);
+  } catch (err) {
+    console.error(`class-closure-declare: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(2);
+  }
+  console.log(`class-closure-declare: ${result.changed ? 'wrote' : 'no change (idempotent)'} classClosure into ${path.relative(repoRoot, result.file)}`);
+  console.log(JSON.stringify(result.block, null, 2));
+  process.exit(0);
+}

--- a/scripts/class-closure-lint.mjs
+++ b/scripts/class-closure-lint.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+// safe-git-allow: CI-only gate script — single read-only `git diff --name-status`
+//   against the Actions checkout; runs on ubuntu runners where the TS
+//   SafeGitExecutor is not importable from a standalone .mjs.
+/**
+ * class-closure-lint — the REPORT-ONLY CI lint for the Class-Closure Gate
+ * (docs/specs/class-closure-gate.md → Rollout step 1). Increment 1.
+ *
+ * A fix for a defect found in an AGENT-AUTHORED artifact (prompts, hooks,
+ * configs, skills, standards text) is supposed to declare, in its committed
+ * instar-dev decision-audit entry, WHAT CLASS of defect it is an instance of
+ * and HOW the class is closed (a live guard, or a tracked gap). This lint
+ * VALIDATES those declarations at the PR boundary — it does NOT mutate source
+ * (the periodic escalator pass owns mutation) and, in report-only mode (the
+ * increment-1 default), it prints findings and ALWAYS exits 0.
+ *
+ * What it does (all report-only unless enabled && !dryRun):
+ *   - repo-gate: no docs/defect-classes.json ⇒ "not an instar class-closure
+ *     repo", exit 0.
+ *   - load + validate the class registry (a malformed registry is a HARD
+ *     structural violation).
+ *   - read every classClosure declaration from committed decision-audit entries
+ *     (the SINGLE machine-readable counting host — C1: the side-effects mirror
+ *     is display-only and NOT summed here).
+ *   - grade each `closure:'guard'` citation via the self-contained grader
+ *     (evaluateGuardClosure) — a citation that does not resolve to a live
+ *     enforcing guard DOWNGRADES the declaration to `gap` (G3), logged.
+ *   - validate `defectClass:'novel'`: it must carry a full new class entry with
+ *     nearestExistingClass + includes/excludes/severity (a novel class with no
+ *     semantics is a HARD structural violation); a novel class enters
+ *     `unconfirmed` and CANNOT satisfy `closure:'guard'` (logged downgrade).
+ *   - derive per-class counts (deduped by PR) + compute deterministic escalation
+ *     crossings — LOGGED only (proposals/attention items are increment 3).
+ *   - assert mirror-consistency is trivially satisfiable (the side-effects mirror
+ *     is display-only; hosts are never summed).
+ *   - for an in-scope PR with NO declaration, LOG "missing class declaration
+ *     (report-only)" (the flip criterion measures population rate during dryRun).
+ *
+ * Exit codes: 0 in report-only ALWAYS. Nonzero ONLY when
+ * `prGate.classClosure.enabled && !dryRun` AND a hard structural violation exists
+ * (malformed registry, or a novel class with no semantics).
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  loadRegistry,
+  validateRegistry,
+  readDecisionDeclarations,
+  deriveClassData,
+  computeEscalation,
+  REGISTRY_REL_PATH,
+} from './lib/defect-class-registry.mjs';
+import { evaluateGuardClosure } from './lib/class-closure-grader.mjs';
+
+const DEFAULT_CONFIG = { enabled: false, dryRun: true, escalatorDrafting: false };
+
+/**
+ * The agent-authored-artifact predicate — a fix touching one of these is
+ * IN SCOPE for the class declaration (docs/specs/class-closure-gate.md →
+ * Frontloaded Decision 1: prompts, hooks, configs, skills, standards text).
+ */
+export function isAgentAuthoredArtifact(file) {
+  const f = String(file ?? '');
+  if (/^research\/llm-pathway-bench\/.*\/tasks\//.test(f)) return true;
+  if (f === 'src/core/promptClauses.ts') return true;
+  if (f.startsWith('src/core/promptParsers')) return true;
+  if (f === 'src/data/llmBenchCoverage.ts') return true;
+  if (f === 'docs/STANDARDS-REGISTRY.md') return true;
+  if (f.startsWith('.instar/hooks/')) return true;
+  if (f.startsWith('.claude/hooks/')) return true;
+  if (f.startsWith('skills/')) return true;
+  return false;
+}
+
+/**
+ * The gate's OWN source files — for the bounded, gate-source-ONLY self-wedge
+ * exemption (spec: a broken gate can never block its own repair; the exemption
+ * applies only when the diff touches EXCLUSIVELY these files).
+ */
+export function isGateSourceFile(file) {
+  const f = String(file ?? '');
+  return (
+    f === 'scripts/class-closure-lint.mjs' ||
+    f === 'scripts/class-closure-declare.mjs' ||
+    f === 'scripts/lib/class-closure-grader.mjs' ||
+    f === 'scripts/lib/defect-class-registry.mjs' ||
+    f === 'src/core/DefectClassRegistry.ts' ||
+    f === REGISTRY_REL_PATH ||
+    f === 'docs/defect-classes.json' ||
+    f === '.github/workflows/class-closure-gate.yml' ||
+    f === 'docs/specs/class-closure-gate.md' ||
+    /^tests\/(unit|integration)\/class-closure-/.test(f)
+  );
+}
+
+/** Load prGate.classClosure config from a repo checkout, or the report-only default. */
+export function loadClassClosureConfig(repoRoot) {
+  try {
+    const raw = fs.readFileSync(path.join(repoRoot, '.instar', 'config.json'), 'utf-8');
+    const cfg = JSON.parse(raw);
+    const cc = cfg && cfg.prGate && cfg.prGate.classClosure;
+    if (cc && typeof cc === 'object') {
+      return {
+        enabled: cc.enabled === true,
+        dryRun: cc.dryRun !== false, // default true (report-only) unless explicitly false
+        escalatorDrafting: cc.escalatorDrafting === true,
+      };
+    }
+  } catch {
+    // no config / unreadable → report-only default
+  }
+  return { ...DEFAULT_CONFIG };
+}
+
+/** Validate one classClosure declaration's shape. Returns { findings, hardViolations }. */
+function validateDeclaration(repoRoot, decl, knownClassIds) {
+  const findings = [];
+  const hardViolations = [];
+  const where = `declaration in ${decl.source ?? '<unknown>'} (class="${decl.defectClass ?? '?'}")`;
+
+  if (!decl.defectClass || typeof decl.defectClass !== 'string') {
+    findings.push(`${where}: missing defectClass`);
+    return { findings, hardViolations };
+  }
+
+  const isNovel = decl.defectClass === 'novel';
+  if (!isNovel && !knownClassIds.has(decl.defectClass)) {
+    findings.push(`${where}: defectClass "${decl.defectClass}" is not a registered class id and is not 'novel'`);
+  }
+
+  if (decl.closure !== 'guard' && decl.closure !== 'gap') {
+    findings.push(`${where}: closure must be 'guard' or 'gap' (got "${decl.closure}")`);
+  }
+
+  // Novel class: REQUIRES full semantics (a hard violation if absent).
+  if (isNovel) {
+    const nc = decl.novelClass;
+    const missing = [];
+    if (!nc || typeof nc !== 'object') {
+      missing.push('novelClass block');
+    } else {
+      if (!nc.nearestExistingClass || typeof nc.nearestExistingClass !== 'string') missing.push('nearestExistingClass');
+      if (!Array.isArray(nc.includes) || nc.includes.length < 1) missing.push('≥1 includes');
+      if (!Array.isArray(nc.excludes) || nc.excludes.length < 1) missing.push('≥1 excludes');
+      if (nc.severity !== 'critical' && nc.severity !== 'normal') missing.push('severity (critical|normal)');
+    }
+    if (missing.length > 0) {
+      hardViolations.push(`${where}: novel class with no semantics — missing ${missing.join(', ')}`);
+    }
+    // A novel class enters `unconfirmed` and CANNOT satisfy closure:'guard'.
+    if (decl.closure === 'guard') {
+      findings.push(`${where}: a novel (unconfirmed) class cannot satisfy closure:'guard' — its fix carries closure:'gap' until operator-confirmed`);
+    }
+  }
+
+  // Guard closure: grade the citation (downgrade to gap if it does not resolve).
+  if (decl.closure === 'guard') {
+    const citation = decl.guardEvidence && decl.guardEvidence.citation;
+    if (!citation || typeof citation !== 'string') {
+      findings.push(`${where}: closure:'guard' requires guardEvidence.citation`);
+    } else {
+      const verdict = evaluateGuardClosure(repoRoot, citation);
+      if (verdict.effectiveClosure === 'gap') {
+        findings.push(`${where}: DOWNGRADE guard→gap — ${verdict.downgradeReason}`);
+      } else {
+        findings.push(`${where}: guard citation resolves (${verdict.gradedKind}) — closure:'guard' upheld`);
+      }
+    }
+  } else if (decl.closure === 'gap') {
+    if (!decl.gapItem || typeof decl.gapItem !== 'string') {
+      findings.push(`${where}: closure:'gap' should cite a tracked gap item (gapItem) — none provided`);
+    }
+  }
+
+  return { findings, hardViolations };
+}
+
+/**
+ * Pure evaluation over a prepared repo checkout — exported for tests.
+ * @param {{ repoRoot: string, changedFiles?: string[]|null, config: {enabled:boolean,dryRun:boolean,escalatorDrafting:boolean}, thresholds?: object }} input
+ * @returns {{ exitCode: number, repoGated?: boolean, findings: string[], hardViolations: string[], escalations: object[], inScope: boolean, exempt?: string, declarationCount: number }}
+ */
+export function runClassClosureLint(input) {
+  const { repoRoot, config } = input;
+  const thresholds = input.thresholds ?? {};
+  const changedFiles = Array.isArray(input.changedFiles) ? input.changedFiles : null;
+  const findings = [];
+  const hardViolations = [];
+  const escalations = [];
+
+  // Repo-gate: no registry ⇒ not an instar class-closure repo.
+  if (!fs.existsSync(path.join(repoRoot, REGISTRY_REL_PATH))) {
+    return { exitCode: 0, repoGated: true, findings, hardViolations, escalations, inScope: false, declarationCount: 0 };
+  }
+
+  // Load + validate the registry (malformed = hard structural violation).
+  let registry = null;
+  const rawParse = (() => {
+    try {
+      return JSON.parse(fs.readFileSync(path.join(repoRoot, REGISTRY_REL_PATH), 'utf-8'));
+    } catch (err) {
+      return { __parseError: err && err.message ? err.message : String(err) };
+    }
+  })();
+  if (rawParse && rawParse.__parseError) {
+    hardViolations.push(`registry unparseable: ${rawParse.__parseError}`);
+  } else {
+    const v = validateRegistry(rawParse);
+    if (!v.ok) {
+      hardViolations.push(`malformed registry: ${v.errors.join('; ')}`);
+    } else {
+      registry = rawParse;
+    }
+  }
+
+  // Read + grade declarations from the decision-audit host.
+  const declarations = readDecisionDeclarations(repoRoot);
+  const knownClassIds = new Set(registry ? registry.classes.map((c) => c.id) : []);
+  for (const decl of declarations) {
+    const r = validateDeclaration(repoRoot, decl, knownClassIds);
+    findings.push(...r.findings);
+    hardViolations.push(...r.hardViolations);
+  }
+
+  // Derive per-class counts + compute deterministic escalation crossings (LOG only).
+  if (registry) {
+    const derived = deriveClassData(declarations);
+    for (const cls of registry.classes) {
+      const d = derived.get(cls.id);
+      if (!d) continue;
+      const verdict = computeEscalation(
+        { severity: cls.severity, evidenceCountAtLastAck: cls.evidenceCountAtLastAck },
+        d,
+        thresholds,
+      );
+      if (verdict.shouldEscalate) {
+        escalations.push({ classId: cls.id, arm: verdict.arm, reason: verdict.reason, derivedCount: d.dedupedCount });
+        findings.push(`ESCALATION (report-only): class "${cls.id}" crossed threshold [${verdict.arm}] — ${verdict.reason}`);
+      }
+    }
+    // Mirror-consistency: the side-effects artifact mirror is DISPLAY-ONLY; the
+    // lint never sums the two hosts (C1). This invariant is satisfied by
+    // construction here — we counted the decision-audit host only.
+    findings.push('mirror-consistency: counted the decision-audit host only (side-effects mirror is display-only) — trivially satisfied');
+  }
+
+  // Diff-scope: does this PR touch an agent-authored artifact needing a declaration?
+  let inScope = false;
+  let exempt;
+  if (changedFiles && changedFiles.length > 0) {
+    const agentFiles = changedFiles.filter(isAgentAuthoredArtifact);
+    inScope = agentFiles.length > 0;
+    if (inScope) {
+      // Gate-source-ONLY self-wedge exemption: applies ONLY when the diff
+      // touches EXCLUSIVELY the gate's own source (a mixed PR cannot ride it).
+      const allGateSource = changedFiles.every(isGateSourceFile);
+      if (allGateSource) {
+        exempt = 'gate-source-only';
+        findings.push('exempt: diff touches EXCLUSIVELY the gate\'s own source (gate-source-only self-wedge exemption, logged)');
+      } else if (declarations.length === 0) {
+        findings.push('missing class declaration (report-only) — this PR touches agent-authored artifacts but carries no classClosure declaration');
+      }
+    }
+  }
+
+  // Exit code: report-only ALWAYS exits 0. Nonzero ONLY when enforcing AND a
+  // hard structural violation exists.
+  const enforcing = config.enabled && !config.dryRun;
+  const exitCode = enforcing && hardViolations.length > 0 ? 1 : 0;
+
+  return {
+    exitCode,
+    findings,
+    hardViolations,
+    escalations,
+    inScope,
+    exempt,
+    declarationCount: declarations.length,
+  };
+}
+
+/** Parse `git diff --name-status base...head` output into changed file paths. */
+export function parseNameStatus(text) {
+  const files = [];
+  for (const line of String(text).split('\n')) {
+    const t = line.trim();
+    if (!t) continue;
+    const parts = t.split('\t');
+    if (parts.length < 2) continue;
+    files.push(parts[parts.length - 1]); // renames: take the new path
+  }
+  return files;
+}
+
+// ── CLI entrypoint (CI) ────────────────────────────────────────────────────
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].split('/').pop());
+if (invokedDirectly) {
+  const repoRoot = process.env.CLASS_CLOSURE_REPO_ROOT || process.cwd();
+
+  // Repo-gate first (before anything else).
+  if (!fs.existsSync(path.join(repoRoot, REGISTRY_REL_PATH))) {
+    console.log('class-closure gate: not an instar class-closure repo (no docs/defect-classes.json) — skipping.');
+    process.exit(0);
+  }
+
+  const config = loadClassClosureConfig(repoRoot);
+
+  // Compute changed files from git when the PR SHAs are present; otherwise run
+  // scope-blind (still grades all committed declarations — the count host).
+  let changedFiles = null;
+  const baseSha = process.env.BASE_SHA;
+  const headSha = process.env.HEAD_SHA;
+  if (baseSha && headSha) {
+    try {
+      const diffOut = execFileSync('git', ['diff', '--name-status', `${baseSha}...${headSha}`], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      });
+      changedFiles = parseNameStatus(diffOut);
+    } catch (err) {
+      console.warn(`class-closure gate: git diff failed (${err instanceof Error ? err.message : String(err)}) — running scope-blind.`);
+      changedFiles = null;
+    }
+  }
+
+  const res = runClassClosureLint({ repoRoot, changedFiles, config });
+
+  console.log('class-closure gate: report-only lint');
+  console.log(`  mode: ${config.enabled ? (config.dryRun ? 'enabled+dryRun (report-only)' : 'ENFORCING') : 'disabled (report-only)'}`);
+  console.log(`  declarations scanned: ${res.declarationCount}`);
+  if (changedFiles) console.log(`  changed files: ${changedFiles.length} (in-scope: ${res.inScope}${res.exempt ? `, exempt: ${res.exempt}` : ''})`);
+  for (const f of res.findings) console.log(`  - ${f}`);
+  if (res.hardViolations.length > 0) {
+    console.log('  HARD STRUCTURAL VIOLATIONS:');
+    for (const h of res.hardViolations) console.log(`    ! ${h}`);
+  }
+  if (res.exitCode !== 0) {
+    console.error('class-closure gate: FAIL (enforcing mode + hard structural violation)');
+  } else {
+    console.log('class-closure gate: OK (report-only — no build failure)');
+  }
+  process.exit(res.exitCode);
+}

--- a/scripts/lib/class-closure-grader.mjs
+++ b/scripts/lib/class-closure-grader.mjs
@@ -1,0 +1,139 @@
+// class-closure-grader.mjs — the SELF-CONTAINED deterministic guard grader used
+// by the class-closure gate's CI lint (scripts/class-closure-lint.mjs).
+//
+// WHY self-contained: PR-gate lints run on a fresh checkout with NO build step
+// (decision-audit-gate.yml precedent), so the lint cannot import the TS grader
+// from dist/. This mirrors the EXACT classification rules of
+// src/core/StandardsEnforcementAuditor.ts::classifyFileGuard/gradeGuardCitation;
+// tests/unit/class-closure-grader-parity.test.ts pins the two implementations
+// equivalent so they cannot drift (Structure > Willpower).
+//
+// The spec's rule (docs/specs/class-closure-gate.md → Piece 1 guardEvidence):
+// a citation that does not RESOLVE to a live enforcing guard — resolved:false,
+// or a resolved kind of `spec-only` — downgrades the closure declaration to
+// `gap` (G3: a dark/spec-only artifact guards nothing). Only ratchet/gate/lint
+// count as a live enforcing guard. Grader erroring ⇒ downgrade to gap
+// (fail-closed).
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Classify a VERIFIED file ref into its guard weight (mirror of classifyFileGuard). */
+export function classifyFileGuard(ref) {
+  const base = ref.split('/').pop() ?? ref;
+  if (/\.test\.(ts|js|mjs)$/.test(base) || base.startsWith('no-') || /-coverage\.(mjs|js)$/.test(base)) {
+    return 'ratchet';
+  }
+  if (ref.startsWith('scripts/') && base.startsWith('lint-')) return 'lint';
+  if (ref.startsWith('.husky/') || /precommit/i.test(base)) return 'gate';
+  if (ref.startsWith('scripts/')) return 'lint';
+  if (ref.startsWith('docs/specs/')) return 'spec-only';
+  if (ref.startsWith('docs/')) return 'spec-only';
+  if (ref.startsWith('src/')) return 'gate';
+  return 'spec-only';
+}
+
+/** Scan src/server/*.ts for router.<verb>('...') tokens (mirror of loadRouteTable). */
+function loadRouteTable(projectDir) {
+  const serverDir = path.join(projectDir, 'src', 'server');
+  const out = new Set();
+  let files;
+  try {
+    files = fs.readdirSync(serverDir).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'));
+  } catch {
+    return out;
+  }
+  const re = /router\.(get|post|put|delete|patch)\s*\(\s*['"`]([^'"`]+)['"`]/g;
+  for (const f of files) {
+    let content;
+    try { content = fs.readFileSync(path.join(serverDir, f), 'utf-8'); } catch { continue; }
+    for (const m of content.matchAll(re)) out.add(`${m[1].toUpperCase()} ${m[2]}`);
+  }
+  return out;
+}
+
+/** Bounded grep for a single symbol across src/** (mirror of buildSymbolIndex, size 1). */
+function symbolExists(projectDir, symbol) {
+  const srcDir = path.join(projectDir, 'src');
+  try { if (!fs.statSync(srcDir).isDirectory()) return false; } catch { return false; }
+  const escaped = symbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`\\b${escaped}\\b`);
+  const MAX_TOTAL_BYTES = 64 * 1024 * 1024;
+  let readBytes = 0;
+  let found = false;
+  const walk = (dir) => {
+    if (found) return;
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      if (found) return;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name === 'node_modules' || e.name.startsWith('.')) continue;
+        walk(full);
+      } else if (/\.(ts|js|mjs|cjs)$/.test(e.name)) {
+        if (readBytes > MAX_TOTAL_BYTES) return;
+        let content;
+        try { content = fs.readFileSync(full, 'utf-8'); } catch { continue; }
+        readBytes += content.length;
+        if (re.test(content)) { found = true; return; }
+      }
+    }
+  };
+  walk(srcDir);
+  return found;
+}
+
+/**
+ * Grade a single guard citation against a repo checkout. Mirror of
+ * StandardsEnforcementAuditor.gradeGuardCitation.
+ * @returns {{ resolved: boolean, kind: string|null, citation: string }}
+ */
+export function gradeGuardCitation(projectDir, citation) {
+  const raw = (citation ?? '').trim();
+  if (!raw) return { resolved: false, kind: null, citation: raw };
+
+  const routeMatch = /^(GET|POST|PUT|DELETE|PATCH)\s+(\/\S+)$/i.exec(raw);
+  if (routeMatch) {
+    const token = `${routeMatch[1].toUpperCase()} ${routeMatch[2]}`;
+    const resolved = loadRouteTable(projectDir).has(token);
+    return { resolved, kind: resolved ? 'gate' : null, citation: raw };
+  }
+
+  if (raw.includes('/')) {
+    const filePart = raw.split('#')[0].split(':')[0];
+    let resolved = false;
+    try { resolved = fs.existsSync(path.join(projectDir, filePart)); } catch { resolved = false; }
+    return { resolved, kind: resolved ? classifyFileGuard(filePart) : null, citation: raw };
+  }
+
+  const resolved = symbolExists(projectDir, raw);
+  return { resolved, kind: resolved ? 'gate' : null, citation: raw };
+}
+
+/**
+ * The closure verdict for a `guard` declaration: does the cited guard actually
+ * enforce (ratchet/gate/lint + resolved)? Otherwise the declaration downgrades
+ * to `gap`. Any thrown error ⇒ downgrade to gap (fail-closed).
+ * @returns {{ effectiveClosure: 'guard'|'gap', gradedKind: string|null, resolved: boolean, downgradeReason: string|null }}
+ */
+export function evaluateGuardClosure(projectDir, citation) {
+  try {
+    const g = gradeGuardCitation(projectDir, citation);
+    const enforcing = g.resolved && (g.kind === 'ratchet' || g.kind === 'gate' || g.kind === 'lint');
+    if (enforcing) {
+      return { effectiveClosure: 'guard', gradedKind: g.kind, resolved: true, downgradeReason: null };
+    }
+    const reason = !g.resolved
+      ? `guard citation "${citation}" does not resolve to a live guard on disk`
+      : `guard citation "${citation}" graded ${g.kind} — not a live enforcing guard (ratchet/gate/lint required)`;
+    return { effectiveClosure: 'gap', gradedKind: g.kind, resolved: g.resolved, downgradeReason: reason };
+  } catch (err) {
+    return {
+      effectiveClosure: 'gap',
+      gradedKind: null,
+      resolved: false,
+      downgradeReason: `grader error (fail-closed): ${err && err.message ? err.message : String(err)}`,
+    };
+  }
+}

--- a/scripts/lib/defect-class-registry.mjs
+++ b/scripts/lib/defect-class-registry.mjs
@@ -1,0 +1,236 @@
+// defect-class-registry.mjs — the SELF-CONTAINED ESM mirror of the pure
+// registry/derive/threshold logic in src/core/DefectClassRegistry.ts, used by
+// the class-closure gate's CI lint (scripts/class-closure-lint.mjs).
+//
+// WHY a mirror: PR-gate lints run on a fresh checkout with NO build step
+// (decision-audit-gate.yml precedent), so the lint cannot import the TS module
+// from dist/. This file re-implements the SAME pure functions the lint needs —
+// loadRegistry, validateRegistry, readDecisionDeclarations, deriveClassData,
+// computeEscalation (+ the small helpers/constants they lean on).
+//
+// tests/unit/class-closure-registry-parity.test.ts pins this mirror's outputs
+// EQUAL to src/core/DefectClassRegistry.ts for the same inputs, so the two
+// implementations cannot drift (Structure > Willpower). If you edit one, edit
+// the other and the parity test will hold you to it.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const DEFAULT_SPREAD_N = 3; // ≥N across ≥2 components (normal severity)
+export const DEFAULT_SINGLE_K = 5; // ≥K within one component (normal severity)
+export const DEFAULT_GAP_MAX_AGE_DAYS = 45;
+
+export const REGISTRY_REL_PATH = path.join('docs', 'defect-classes.json');
+
+/** Is `repoRoot` an instar checkout carrying the class registry (repo-gate)? */
+export function isClassClosureRepo(repoRoot) {
+  try {
+    return (
+      fs.existsSync(path.join(repoRoot, '.git')) &&
+      fs.existsSync(path.join(repoRoot, 'package.json')) &&
+      fs.existsSync(path.join(repoRoot, REGISTRY_REL_PATH))
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Load + parse the registry file. Throws on missing/malformed JSON or invalid shape. */
+export function loadRegistry(repoRoot) {
+  const p = path.join(repoRoot, REGISTRY_REL_PATH);
+  const raw = fs.readFileSync(p, 'utf-8');
+  const parsed = JSON.parse(raw);
+  const v = validateRegistry(parsed);
+  if (!v.ok) {
+    throw new Error(`defect-classes.json is invalid: ${v.errors.join('; ')}`);
+  }
+  return parsed;
+}
+
+/** Structural validation (used by the lint + tests). Never throws. */
+export function validateRegistry(reg) {
+  const errors = [];
+  if (!reg || typeof reg !== 'object') return { ok: false, errors: ['registry is not an object'] };
+  const r = reg;
+  if (typeof r.version !== 'number') errors.push('version must be a number');
+  if (!Array.isArray(r.classes)) {
+    errors.push('classes must be an array');
+    return { ok: errors.length === 0, errors };
+  }
+  const ids = new Set();
+  for (const [i, c] of r.classes.entries()) {
+    const where = `class[${i}]`;
+    if (!c || typeof c !== 'object') { errors.push(`${where} is not an object`); continue; }
+    const e = c;
+    if (!e.id || typeof e.id !== 'string') errors.push(`${where}.id missing`);
+    else {
+      if (ids.has(e.id)) errors.push(`${where}.id duplicate: ${e.id}`);
+      ids.add(e.id);
+      if (!/^[a-z0-9-]+$/.test(e.id)) errors.push(`${where}.id must match ^[a-z0-9-]+$`);
+    }
+    if (!e.description || typeof e.description !== 'string') errors.push(`${where}.description missing`);
+    if (!Array.isArray(e.includes) || e.includes.length < 1) errors.push(`${where}.includes needs ≥1 entry`);
+    if (!Array.isArray(e.excludes) || e.excludes.length < 1) errors.push(`${where}.excludes needs ≥1 entry`);
+    if (!Array.isArray(e.canonicalExamples)) errors.push(`${where}.canonicalExamples must be an array`);
+    if (e.status !== 'confirmed' && e.status !== 'unconfirmed') errors.push(`${where}.status invalid`);
+    if (e.severity !== 'critical' && e.severity !== 'normal') errors.push(`${where}.severity invalid`);
+    if (typeof e.instanceCount !== 'number') errors.push(`${where}.instanceCount must be a number`);
+    if (typeof e.evidenceCountAtLastAck !== 'number') errors.push(`${where}.evidenceCountAtLastAck must be a number`);
+    if (!('closureStandard' in e)) errors.push(`${where}.closureStandard missing (nullable ok)`);
+    if (!('proposalId' in e)) errors.push(`${where}.proposalId missing (nullable ok)`);
+    // A novel class enters unconfirmed and REQUIRES a nearestExistingClass.
+    if (e.status === 'unconfirmed' && !e.nearestExistingClass) {
+      errors.push(`${where} is unconfirmed but has no nearestExistingClass`);
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Read the class-closure declarations from committed decision-audit entries.
+ * The decision-audit entry is the SINGLE machine-readable counting host — the
+ * side-effects artifact mirror is display-only and is NOT read here (C1 fix).
+ * @returns {Array<object>} declarations, each with `.source` (filename) + `.ts`.
+ */
+export function readDecisionDeclarations(repoRoot) {
+  const dir = path.join(repoRoot, '.instar', 'instar-dev-decisions');
+  let files;
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const f of files) {
+    let entry;
+    try {
+      entry = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8'));
+    } catch {
+      continue;
+    }
+    if (entry && entry.classClosure && typeof entry.classClosure === 'object') {
+      out.push({ ...entry.classClosure, source: f, ts: entry.ts });
+    }
+  }
+  return out;
+}
+
+/**
+ * Derive per-class counts from declarations, deduped by PR number. Two
+ * declarations citing the same PR + class count ONCE. A declaration with no
+ * prNumber falls back to its source filename as the dedup key (still counts once).
+ * @returns {Map<string, object>} classId → DerivedClassData.
+ */
+export function deriveClassData(declarations) {
+  const byClass = new Map();
+  for (const d of declarations) {
+    if (!d.defectClass) continue;
+    const list = byClass.get(d.defectClass) ?? [];
+    list.push(d);
+    byClass.set(d.defectClass, list);
+  }
+  const result = new Map();
+  for (const [classId, list] of byClass) {
+    const dedupKey = (d) => (d.prNumber != null ? `pr:${d.prNumber}` : `src:${d.source}`);
+    const seen = new Set();
+    const prs = new Set();
+    const components = new Set();
+    const perComponentKeys = new Map();
+    let hasOpenGap = false;
+    for (const d of list) {
+      const key = dedupKey(d);
+      seen.add(key);
+      if (d.prNumber != null) prs.add(d.prNumber);
+      const comp = d.component ?? '<unspecified>';
+      components.add(comp);
+      const compSet = perComponentKeys.get(comp) ?? new Set();
+      compSet.add(key);
+      perComponentKeys.set(comp, compSet);
+      if (d.closure === 'gap') hasOpenGap = true;
+    }
+    let maxSingleComponentCount = 0;
+    for (const s of perComponentKeys.values()) {
+      maxSingleComponentCount = Math.max(maxSingleComponentCount, s.size);
+    }
+    result.set(classId, {
+      dedupedCount: seen.size,
+      componentCount: components.size,
+      maxSingleComponentCount,
+      hasOpenGap,
+      prs: [...prs].sort((a, b) => a - b),
+      components: [...components].sort(),
+    });
+  }
+  return result;
+}
+
+/**
+ * Deterministic threshold logic. Fires ONLY when there is NEW evidence past the
+ * last-ack baseline (seeded-closed suppression + dedup re-raise) AND a severity
+ * arm crosses:
+ *   - critical  ⇒ escalates at ≥1 confirmed instance (any new evidence).
+ *   - normal    ⇒ ≥N across ≥2 components, OR ≥2 + an open gap, OR ≥K in one component.
+ * @param {{ severity: string, evidenceCountAtLastAck: number }} entry
+ * @param {object} derived  DerivedClassData
+ * @param {{ spreadN?: number, singleK?: number }} thresholds
+ */
+export function computeEscalation(entry, derived, thresholds = {}) {
+  const N = thresholds.spreadN ?? DEFAULT_SPREAD_N;
+  const K = thresholds.singleK ?? DEFAULT_SINGLE_K;
+  const newEvidence = derived.dedupedCount > entry.evidenceCountAtLastAck;
+  if (!newEvidence) {
+    return {
+      shouldEscalate: false,
+      arm: null,
+      reason: `no new evidence past ack baseline (derived ${derived.dedupedCount} ≤ ack ${entry.evidenceCountAtLastAck})`,
+      newEvidence: false,
+    };
+  }
+  if (entry.severity === 'critical') {
+    return {
+      shouldEscalate: true,
+      arm: 'critical-1',
+      reason: `critical class recurred (derived ${derived.dedupedCount} > ack ${entry.evidenceCountAtLastAck}); escalates at 1`,
+      newEvidence: true,
+    };
+  }
+  // normal severity — three arms.
+  if (derived.dedupedCount >= N && derived.componentCount >= 2) {
+    return {
+      shouldEscalate: true,
+      arm: 'spread',
+      reason: `≥${N} instances (${derived.dedupedCount}) across ≥2 components (${derived.componentCount})`,
+      newEvidence: true,
+    };
+  }
+  if (derived.dedupedCount >= 2 && derived.hasOpenGap) {
+    return {
+      shouldEscalate: true,
+      arm: 'gap-plus',
+      reason: `≥2 instances (${derived.dedupedCount}) + an open gap item`,
+      newEvidence: true,
+    };
+  }
+  if (derived.maxSingleComponentCount >= K) {
+    return {
+      shouldEscalate: true,
+      arm: 'single-component',
+      reason: `≥${K} instances (${derived.maxSingleComponentCount}) within one component`,
+      newEvidence: true,
+    };
+  }
+  return {
+    shouldEscalate: false,
+    arm: null,
+    reason: `no normal-severity arm crossed (count ${derived.dedupedCount}, components ${derived.componentCount}, maxSingle ${derived.maxSingleComponentCount})`,
+    newEvidence: true,
+  };
+}
+
+/** Whether a gap item is open past the max-age escalation ceiling. */
+export function gapOpenPastMaxAge(gapOpenedAtIso, now = Date.now(), maxAgeDays = DEFAULT_GAP_MAX_AGE_DAYS) {
+  const opened = Date.parse(gapOpenedAtIso);
+  if (Number.isNaN(opened)) return false;
+  const ageDays = (now - opened) / (24 * 60 * 60 * 1000);
+  return ageDays > maxAgeDays;
+}

--- a/skills/instar-dev/templates/side-effects-artifact.md
+++ b/skills/instar-dev/templates/side-effects-artifact.md
@@ -176,3 +176,42 @@ pool-wide question is answered by a proxied-on-read merged view." Not abstractio
 ## Evidence pointers
 
 [Optional. Links or file paths to the live verification artifacts produced during `/build` — reproduction steps, before/after logs, test output. These feed the "Evidence" section in the upgrade notes if the change is shipping as a release.]
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+**REQUIRED whenever this change FIXES a defect in an agent-authored artifact** (an
+LLM prompt, hook, config, skill, or standards text — see
+`docs/specs/class-closure-gate.md`). This section is the human-readable MIRROR of
+the machine-readable `classClosure` block in the commit's decision-audit entry
+(the host the CI lint validates). **Display-only:** the lint counts the
+decision-audit host ONLY and NEVER sums this mirror — the two are asserted to
+AGREE, never added (C1). If this change fixes no agent-authored-artifact defect,
+state: "No agent-authored-artifact defect — not applicable."
+
+- **`defectClass`** — a class id from `docs/defect-classes.json`, or `novel`. A
+  `novel` class is not a free pass: it REQUIRES a full new registry entry in the
+  same change carrying `nearestExistingClass` + ≥1 `includes` + ≥1 `excludes` +
+  `severity`, and it enters `status: "unconfirmed"` (an unconfirmed class CANNOT
+  satisfy `closure: guard` — its fix carries `closure: gap` until the operator
+  confirms it).
+- **`closure`** — either `guard` (the standard/test/lint that makes the class's
+  recurrence structurally refused or detected, cited by path/symbol) or `gap` (a
+  tracked standards-gap evolution-action id when the class-level guard is out of
+  this fix's scope).
+- **`guardEvidence`** (required with `closure: guard`) — the guard's enforcement
+  type as graded by the coverage audit's grader (`ratchet` / `gate` / `lint`),
+  the citation, and one line on *how this guard would have caught THIS defect*. A
+  citation that does not resolve to a LIVE enforcing guard on disk automatically
+  downgrades the declaration to `closure: gap` (G3 — a dark/spec-only artifact
+  guards nothing).
+- **`gap`** (with `closure: gap`) — the evolution-action id tracking the missing
+  guard. A gap is not fire-and-forget: it counts as escalation evidence and
+  re-surfaces on the evolution-action cadence.
+
+[Fill in the four fields (or "not applicable"). Example: "`defectClass:
+injection-credulity`, `closure: guard`, `guardEvidence: {enforcementType: gate,
+citation: src/core/promptClauses.ts#authorityClause, howCaught: the authority
+clause separates the trusted instruction surface from the quoted untrusted
+transcript excerpt, so the injected instruction is data not command}`."]

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -816,6 +816,15 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
   // 404 until explicitly flipped by Phase B+. Runtime kill-switch.
   prGate: {
     phase: 'off' as const,
+    // Class-Closure Gate (docs/specs/class-closure-gate.md) — ships dark +
+    // report-only (the CI lint logs findings and always exits 0 until an
+    // operator flips enabled+!dryRun). backfilled to existing agents via the
+    // add-missing applyDefaults path, exactly like prGate.phase.
+    classClosure: {
+      enabled: false,
+      dryRun: true,
+      escalatorDrafting: false,
+    },
   },
   // Restart-cascade dampener — minimum ms between two update-driven restart
   // requests. AutoUpdater batches a new restart that lands within this window

--- a/src/core/DefectClassRegistry.ts
+++ b/src/core/DefectClassRegistry.ts
@@ -1,0 +1,343 @@
+/**
+ * DefectClassRegistry — the class registry loader + the DERIVED-count and
+ * escalation-threshold logic for the Class-Closure Gate + Standards-Delta
+ * Escalator (docs/specs/class-closure-gate.md).
+ *
+ * Pure library over a repo checkout (fs reads only, no server/runtime). Used by:
+ *   - the CI gate lint (report-only) — validates declarations, derives counts,
+ *     computes threshold crossings;
+ *   - the runtime read route `GET /class-closure` — reports registry + posture;
+ *   - the StandardsDeltaEscalator — drafts proposals for crossed thresholds.
+ *
+ * KEY INVARIANTS (converged spec):
+ *   - `instanceCount` in the registry file is a CACHE. The AUTHORITATIVE count
+ *     is DERIVED by scanning the committed decision-audit declarations, deduped
+ *     by PR number (round-3 material finding C1: scanning the mirrored
+ *     side-effects host too would double-count). The lint VALIDATES the cache;
+ *     the periodic pass MUTATES it.
+ *   - `escalatedAt: "seeded-closed"` + `evidenceCountAtLastAck === instanceCount`
+ *     at seed time suppresses ONLY historical backfill; a post-seed declaration
+ *     that grows the class past that baseline fires the deterministic re-raise.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type DefectClassSeverity = 'critical' | 'normal';
+export type DefectClassStatus = 'confirmed' | 'unconfirmed';
+export type EnforcementGrade = 'ratchet' | 'gate' | 'lint' | 'spec-only' | 'documented-only';
+
+export interface DefectClassEntry {
+  id: string;
+  description: string;
+  includes: string[];
+  excludes: string[];
+  canonicalExamples: string[];
+  status: DefectClassStatus;
+  severity: DefectClassSeverity;
+  closureStandard: string | null;
+  /** The closure standard's enforcement status as last graded (nullable cache). */
+  closureStandardEnforcement: EnforcementGrade | null;
+  /** CACHE — the DERIVED, deduped-by-PR count. Validated by the lint, mutated by the pass. */
+  instanceCount: number;
+  /** ISO timestamp | "seeded-closed" | null (never escalated). */
+  escalatedAt: string | null;
+  /** The count at the last operator acknowledgement — the re-raise baseline. */
+  evidenceCountAtLastAck: number;
+  /** The open proposal id, if a proposal is currently drafted. */
+  proposalId: string | null;
+  /** REQUIRED for a novel class: the nearest existing class + why it doesn't fit. */
+  nearestExistingClass?: string;
+}
+
+export interface DefectClassRegistryFile {
+  note?: string;
+  version: number;
+  classes: DefectClassEntry[];
+}
+
+/** The class-closure declaration block embedded in an instar-dev decision-audit entry. */
+export interface ClassClosureDeclaration {
+  /** A class id from the registry, or 'novel'. */
+  defectClass: string;
+  closure: 'guard' | 'gap';
+  /** Required with closure:'guard'. */
+  guardEvidence?: {
+    /** The guard's ENFORCEMENT TYPE as graded by the coverage audit's grader. */
+    enforcementType: EnforcementGrade;
+    /** The guard citation (path / METHOD route / symbol). */
+    citation: string;
+    /** One line on how this guard would have caught THIS defect. */
+    howCaught: string;
+  };
+  /** Required with closure:'gap': the tracked standards-gap evolution-action id. */
+  gapItem?: string;
+  /** The fix's PR number — the natural dedup key (two entries citing the same PR + class count once). */
+  prNumber?: number | null;
+  /** Per-COMPONENT granularity (matches the registry). */
+  component?: string;
+  /** Required when defectClass === 'novel' (full semantics of the proposed class). */
+  novelClass?: Partial<DefectClassEntry> & { nearestExistingClass: string };
+  /** The A/B verdict summary for a prompt-touching fix (mechanical arm). */
+  abVerdict?: { runId: string; routes: string[]; fixed: number; regressed: number };
+}
+
+/** A declaration paired with its source decision-audit entry metadata. */
+export interface DecisionDeclaration extends ClassClosureDeclaration {
+  /** Source decision-audit entry filename (for audit). */
+  source: string;
+  /** The entry's timestamp. */
+  ts?: string;
+}
+
+export const DEFAULT_SPREAD_N = 3; // ≥N across ≥2 components (normal severity)
+export const DEFAULT_SINGLE_K = 5; // ≥K within one component (normal severity)
+export const DEFAULT_GAP_MAX_AGE_DAYS = 45;
+
+export const REGISTRY_REL_PATH = path.join('docs', 'defect-classes.json');
+
+/** Is `repoRoot` an instar checkout carrying the class registry (repo-gate)? */
+export function isClassClosureRepo(repoRoot: string): boolean {
+  try {
+    return (
+      fs.existsSync(path.join(repoRoot, '.git')) &&
+      fs.existsSync(path.join(repoRoot, 'package.json')) &&
+      fs.existsSync(path.join(repoRoot, REGISTRY_REL_PATH))
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Load + parse the registry file. Throws on missing/malformed JSON. */
+export function loadDefectClassRegistry(repoRoot: string): DefectClassRegistryFile {
+  const p = path.join(repoRoot, REGISTRY_REL_PATH);
+  const raw = fs.readFileSync(p, 'utf-8');
+  const parsed = JSON.parse(raw) as DefectClassRegistryFile;
+  const v = validateRegistry(parsed);
+  if (!v.ok) {
+    throw new Error(`defect-classes.json is invalid: ${v.errors.join('; ')}`);
+  }
+  return parsed;
+}
+
+/** Structural validation (used by the lint + tests). Never throws. */
+export function validateRegistry(reg: unknown): { ok: boolean; errors: string[] } {
+  const errors: string[] = [];
+  if (!reg || typeof reg !== 'object') return { ok: false, errors: ['registry is not an object'] };
+  const r = reg as Partial<DefectClassRegistryFile>;
+  if (typeof r.version !== 'number') errors.push('version must be a number');
+  if (!Array.isArray(r.classes)) {
+    errors.push('classes must be an array');
+    return { ok: errors.length === 0, errors };
+  }
+  const ids = new Set<string>();
+  for (const [i, c] of r.classes.entries()) {
+    const where = `class[${i}]`;
+    if (!c || typeof c !== 'object') { errors.push(`${where} is not an object`); continue; }
+    const e = c as Partial<DefectClassEntry>;
+    if (!e.id || typeof e.id !== 'string') errors.push(`${where}.id missing`);
+    else {
+      if (ids.has(e.id)) errors.push(`${where}.id duplicate: ${e.id}`);
+      ids.add(e.id);
+      if (!/^[a-z0-9-]+$/.test(e.id)) errors.push(`${where}.id must match ^[a-z0-9-]+$`);
+    }
+    if (!e.description || typeof e.description !== 'string') errors.push(`${where}.description missing`);
+    if (!Array.isArray(e.includes) || e.includes.length < 1) errors.push(`${where}.includes needs ≥1 entry`);
+    if (!Array.isArray(e.excludes) || e.excludes.length < 1) errors.push(`${where}.excludes needs ≥1 entry`);
+    if (!Array.isArray(e.canonicalExamples)) errors.push(`${where}.canonicalExamples must be an array`);
+    if (e.status !== 'confirmed' && e.status !== 'unconfirmed') errors.push(`${where}.status invalid`);
+    if (e.severity !== 'critical' && e.severity !== 'normal') errors.push(`${where}.severity invalid`);
+    if (typeof e.instanceCount !== 'number') errors.push(`${where}.instanceCount must be a number`);
+    if (typeof e.evidenceCountAtLastAck !== 'number') errors.push(`${where}.evidenceCountAtLastAck must be a number`);
+    if (!('closureStandard' in e)) errors.push(`${where}.closureStandard missing (nullable ok)`);
+    if (!('proposalId' in e)) errors.push(`${where}.proposalId missing (nullable ok)`);
+    // A novel class enters unconfirmed and REQUIRES a nearestExistingClass.
+    if (e.status === 'unconfirmed' && !e.nearestExistingClass) {
+      errors.push(`${where} is unconfirmed but has no nearestExistingClass`);
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Read the class-closure declarations from committed decision-audit entries.
+ * The decision-audit entry is the SINGLE machine-readable counting host — the
+ * side-effects artifact mirror is display-only and is NOT read here (C1 fix).
+ */
+export function readDecisionDeclarations(repoRoot: string): DecisionDeclaration[] {
+  const dir = path.join(repoRoot, '.instar', 'instar-dev-decisions');
+  let files: string[];
+  try {
+    files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  const out: DecisionDeclaration[] = [];
+  for (const f of files) {
+    let entry: { classClosure?: ClassClosureDeclaration; ts?: string };
+    try {
+      entry = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8'));
+    } catch {
+      continue;
+    }
+    if (entry && entry.classClosure && typeof entry.classClosure === 'object') {
+      out.push({ ...entry.classClosure, source: f, ts: entry.ts });
+    }
+  }
+  return out;
+}
+
+export interface DerivedClassData {
+  /** Distinct-PR count (the deduped instance count). */
+  dedupedCount: number;
+  /** Distinct components. */
+  componentCount: number;
+  /** The largest distinct-PR count within a single component. */
+  maxSingleComponentCount: number;
+  /** Any open gap declaration for this class. */
+  hasOpenGap: boolean;
+  /** The distinct PR numbers seen (for audit). */
+  prs: number[];
+  /** The distinct components seen. */
+  components: string[];
+}
+
+/**
+ * Derive per-class counts from declarations, deduped by PR number. Two
+ * declarations citing the same PR + class count ONCE. A declaration with no
+ * prNumber falls back to its source filename as the dedup key (still counts once).
+ */
+export function deriveClassData(declarations: DecisionDeclaration[]): Map<string, DerivedClassData> {
+  const byClass = new Map<string, DecisionDeclaration[]>();
+  for (const d of declarations) {
+    if (!d.defectClass) continue;
+    const list = byClass.get(d.defectClass) ?? [];
+    list.push(d);
+    byClass.set(d.defectClass, list);
+  }
+  const result = new Map<string, DerivedClassData>();
+  for (const [classId, list] of byClass) {
+    const dedupKey = (d: DecisionDeclaration): string =>
+      d.prNumber != null ? `pr:${d.prNumber}` : `src:${d.source}`;
+    const seen = new Set<string>();
+    const prs = new Set<number>();
+    const components = new Set<string>();
+    const perComponentKeys = new Map<string, Set<string>>();
+    let hasOpenGap = false;
+    for (const d of list) {
+      const key = dedupKey(d);
+      seen.add(key);
+      if (d.prNumber != null) prs.add(d.prNumber);
+      const comp = d.component ?? '<unspecified>';
+      components.add(comp);
+      const compSet = perComponentKeys.get(comp) ?? new Set<string>();
+      compSet.add(key);
+      perComponentKeys.set(comp, compSet);
+      if (d.closure === 'gap') hasOpenGap = true;
+    }
+    let maxSingleComponentCount = 0;
+    for (const s of perComponentKeys.values()) {
+      maxSingleComponentCount = Math.max(maxSingleComponentCount, s.size);
+    }
+    result.set(classId, {
+      dedupedCount: seen.size,
+      componentCount: components.size,
+      maxSingleComponentCount,
+      hasOpenGap,
+      prs: [...prs].sort((a, b) => a - b),
+      components: [...components].sort(),
+    });
+  }
+  return result;
+}
+
+export interface EscalationVerdict {
+  shouldEscalate: boolean;
+  /** The arm that crossed the threshold, if any. */
+  arm: 'critical-1' | 'spread' | 'gap-plus' | 'single-component' | null;
+  reason: string;
+  /** True when the derived count exceeds the last-ack baseline (new, un-acked evidence). */
+  newEvidence: boolean;
+}
+
+export interface EscalationThresholds {
+  spreadN?: number;
+  singleK?: number;
+}
+
+/**
+ * Deterministic threshold logic. Fires ONLY when there is NEW evidence past the
+ * last-ack baseline (seeded-closed suppression + dedup re-raise) AND a severity
+ * arm crosses:
+ *   - critical  ⇒ escalates at ≥1 confirmed instance (any new evidence).
+ *   - normal    ⇒ ≥N across ≥2 components, OR ≥2 + an open gap, OR ≥K in one component.
+ */
+export function computeEscalation(
+  entry: Pick<DefectClassEntry, 'severity' | 'evidenceCountAtLastAck'>,
+  derived: DerivedClassData,
+  thresholds: EscalationThresholds = {},
+): EscalationVerdict {
+  const N = thresholds.spreadN ?? DEFAULT_SPREAD_N;
+  const K = thresholds.singleK ?? DEFAULT_SINGLE_K;
+  const newEvidence = derived.dedupedCount > entry.evidenceCountAtLastAck;
+  if (!newEvidence) {
+    return {
+      shouldEscalate: false,
+      arm: null,
+      reason: `no new evidence past ack baseline (derived ${derived.dedupedCount} ≤ ack ${entry.evidenceCountAtLastAck})`,
+      newEvidence: false,
+    };
+  }
+  if (entry.severity === 'critical') {
+    return {
+      shouldEscalate: true,
+      arm: 'critical-1',
+      reason: `critical class recurred (derived ${derived.dedupedCount} > ack ${entry.evidenceCountAtLastAck}); escalates at 1`,
+      newEvidence: true,
+    };
+  }
+  // normal severity — three arms.
+  if (derived.dedupedCount >= N && derived.componentCount >= 2) {
+    return {
+      shouldEscalate: true,
+      arm: 'spread',
+      reason: `≥${N} instances (${derived.dedupedCount}) across ≥2 components (${derived.componentCount})`,
+      newEvidence: true,
+    };
+  }
+  if (derived.dedupedCount >= 2 && derived.hasOpenGap) {
+    return {
+      shouldEscalate: true,
+      arm: 'gap-plus',
+      reason: `≥2 instances (${derived.dedupedCount}) + an open gap item`,
+      newEvidence: true,
+    };
+  }
+  if (derived.maxSingleComponentCount >= K) {
+    return {
+      shouldEscalate: true,
+      arm: 'single-component',
+      reason: `≥${K} instances (${derived.maxSingleComponentCount}) within one component`,
+      newEvidence: true,
+    };
+  }
+  return {
+    shouldEscalate: false,
+    arm: null,
+    reason: `no normal-severity arm crossed (count ${derived.dedupedCount}, components ${derived.componentCount}, maxSingle ${derived.maxSingleComponentCount})`,
+    newEvidence: true,
+  };
+}
+
+/** Whether a gap item is open past the max-age escalation ceiling. */
+export function gapOpenPastMaxAge(
+  gapOpenedAtIso: string,
+  now: number = Date.now(),
+  maxAgeDays: number = DEFAULT_GAP_MAX_AGE_DAYS,
+): boolean {
+  const opened = Date.parse(gapOpenedAtIso);
+  if (Number.isNaN(opened)) return false;
+  const ageDays = (now - opened) / (24 * 60 * 60 * 1000);
+  return ageDays > maxAgeDays;
+}

--- a/src/core/DefectClassRegistry.ts
+++ b/src/core/DefectClassRegistry.ts
@@ -171,6 +171,10 @@ export function readDecisionDeclarations(repoRoot: string): DecisionDeclaration[
   try {
     files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
   } catch {
+    // @silent-fallback-ok: an absent/unreadable decisions dir means there are simply no
+    // declarations to count yet (a fresh repo, or a checkout with no instar-dev history) —
+    // the empty list is the correct answer, not a degraded result. This is a pure library
+    // over a repo checkout with no runtime/DegradationReporter surface (spec §"Pure library").
     return [];
   }
   const out: DecisionDeclaration[] = [];

--- a/src/core/StandardsEnforcementAuditor.ts
+++ b/src/core/StandardsEnforcementAuditor.ts
@@ -143,7 +143,10 @@ export function gradeGuardCitation(
     try {
       resolved = fs.existsSync(path.join(projectDir, filePart));
     } catch {
-      resolved = false; // unresolvable path = a real dangling-ref finding, fail-closed to downgrade
+      // @silent-fallback-ok: an unresolvable path is a real dangling-ref finding, not a
+      // degraded result — fail-closed to `resolved:false` so the closure declaration
+      // downgrades guard->gap (the intended, surfaced outcome). Mirrors line 236 above.
+      resolved = false;
     }
     return { resolved, kind: resolved ? classifyFileGuard(filePart) : null, citation: raw };
   }

--- a/src/core/StandardsEnforcementAuditor.ts
+++ b/src/core/StandardsEnforcementAuditor.ts
@@ -82,7 +82,7 @@ const KIND_RANK: Record<Exclude<EnforcementKind, 'documented-only'>, number> = {
 };
 
 /** Classify a VERIFIED file ref into its guard weight. */
-function classifyFileGuard(ref: string): Exclude<EnforcementKind, 'documented-only'> {
+export function classifyFileGuard(ref: string): Exclude<EnforcementKind, 'documented-only'> {
   const base = ref.split('/').pop() ?? ref;
   // Ratchet: a CI test that fails on regression — `*.test.ts`, a `no-*` guard, a
   // `*-coverage` script.
@@ -101,6 +101,57 @@ function classifyFileGuard(ref: string): Exclude<EnforcementKind, 'documented-on
   // A src/** guard file (a gate/marker module) → gate-strength.
   if (ref.startsWith('src/')) return 'gate';
   return 'spec-only';
+}
+
+/**
+ * Grade a SINGLE guard citation (a path, a `METHOD /route`, or a symbol/marker)
+ * against a repo checkout — the library form the class-closure gate's lint invokes
+ * (docs/specs/class-closure-gate.md → Piece 1 `guardEvidence`). Returns the
+ * enforcement strength AS GRADED by the same deterministic rules the standards
+ * coverage audit uses (`classifyFileGuard`), plus whether the citation actually
+ * RESOLVES on disk / in the route table / in src.
+ *
+ * The caller's rule (stated normatively in the spec): a citation that does not
+ * resolve to a live enforcing guard — `resolved: false`, or a resolved kind of
+ * `spec-only` (a dark/spec-only artifact guards nothing, G3) — downgrades the
+ * closure declaration to `gap`. Only `ratchet` / `gate` / `lint` count as a live
+ * enforcing guard.
+ *
+ * Pure over the repo checkout (fs reads only) — NEVER the agent-runtime
+ * conformance route (which ships dark and 503s).
+ */
+export function gradeGuardCitation(
+  projectDir: string,
+  citation: string,
+): { resolved: boolean; kind: EnforcementKind | null; citation: string } {
+  const raw = (citation ?? '').trim();
+  if (!raw) return { resolved: false, kind: null, citation: raw };
+
+  // Route citation, e.g. "GET /class-closure".
+  const routeMatch = /^(GET|POST|PUT|DELETE|PATCH)\s+(\/\S+)$/i.exec(raw);
+  if (routeMatch) {
+    const token = `${routeMatch[1].toUpperCase()} ${routeMatch[2]}`;
+    const resolved = loadRouteTable(projectDir).has(token);
+    return { resolved, kind: resolved ? 'gate' : null, citation: raw };
+  }
+
+  // File-path citation (contains a slash). Strip a `#symbol` or `:line` suffix
+  // before existence-checking the path.
+  if (raw.includes('/')) {
+    const filePart = raw.split('#')[0].split(':')[0];
+    let resolved = false;
+    try {
+      resolved = fs.existsSync(path.join(projectDir, filePart));
+    } catch {
+      resolved = false; // unresolvable path = a real dangling-ref finding, fail-closed to downgrade
+    }
+    return { resolved, kind: resolved ? classifyFileGuard(filePart) : null, citation: raw };
+  }
+
+  // Bare symbol / marker citation.
+  const found = buildSymbolIndex(projectDir, new Set([raw]));
+  const resolved = found.has(raw);
+  return { resolved, kind: resolved ? 'gate' : null, citation: raw };
 }
 
 /**

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -601,6 +601,11 @@ export const DARK_GATE_EXCLUSIONS: DarkGateExclusion[] = [
     category: 'structural-stub',
     reason: 'sleep/respawn mechanism is a later slice; not wired',
   },
+  {
+    configPath: 'prGate.classClosure.enabled',
+    category: 'structural-stub',
+    reason: 'class-closure gate increment 1 is CI-only report-only tooling (scripts/class-closure-lint.mjs) read at build time, NOT a runtime server feature — resolveDevAgentGate does not apply; enabled:false + dryRun:true is the intended report-only ship state (spec rollout step 1), enforcing is a later opt-in; no runtime consumer wired (route/escalator are increment 3), repo-gated no-op off the maintainer repo',
+  },
   // ── optional-integration — opt-in per deployment ──
   {
     configPath: 'multiMachine.sessionPool.enabled',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3973,6 +3973,19 @@ export interface PrGateConfig {
   primaryMachineId?: string;
   /** Machine IDs paired for replication / cross-tunnel failover. */
   pairedMachineIds?: string[];
+  /**
+   * Class-Closure Gate (docs/specs/class-closure-gate.md). Ships dark +
+   * report-only: `enabled:false, dryRun:true` means the CI lint logs findings
+   * and always exits 0. `enabled && !dryRun` lets the lint fail on a hard
+   * structural violation (malformed registry / a novel class with no
+   * semantics). `escalatorDrafting` is the dark-staged LLM drafting arm's own
+   * key (increment 3) — the deterministic trigger rides `enabled`.
+   */
+  classClosure?: {
+    enabled?: boolean;
+    dryRun?: boolean;
+    escalatorDrafting?: boolean;
+  };
 }
 
 // ── Integrated-Being Ledger (v1) ────────────────────────────────────

--- a/tests/fixtures/class-closure/registry-malformed.json
+++ b/tests/fixtures/class-closure/registry-malformed.json
@@ -1,0 +1,20 @@
+{
+  "note": "Fixture — a MALFORMED registry (the first class is MISSING `severity`) for the class-closure enforcing-mode integration test.",
+  "version": 1,
+  "classes": [
+    {
+      "id": "fixture-broken-class",
+      "description": "A fixture class missing its severity field — validateRegistry must reject it.",
+      "includes": ["a fixture inclusion criterion"],
+      "excludes": ["a fixture exclusion criterion"],
+      "canonicalExamples": ["a fixture canonical example"],
+      "status": "confirmed",
+      "closureStandard": null,
+      "closureStandardEnforcement": null,
+      "instanceCount": 0,
+      "escalatedAt": null,
+      "evidenceCountAtLastAck": 0,
+      "proposalId": null
+    }
+  ]
+}

--- a/tests/fixtures/class-closure/registry-valid.json
+++ b/tests/fixtures/class-closure/registry-valid.json
@@ -1,0 +1,36 @@
+{
+  "note": "Fixture — a minimal VALID defect-class registry for class-closure lint integration tests.",
+  "version": 1,
+  "classes": [
+    {
+      "id": "fixture-normal-class",
+      "description": "A fixture normal-severity defect class used only by the class-closure integration tests.",
+      "includes": ["a fixture inclusion criterion"],
+      "excludes": ["a fixture exclusion criterion"],
+      "canonicalExamples": ["a fixture canonical example"],
+      "status": "confirmed",
+      "severity": "normal",
+      "closureStandard": "fixture-normal-standard",
+      "closureStandardEnforcement": null,
+      "instanceCount": 1,
+      "escalatedAt": "seeded-closed",
+      "evidenceCountAtLastAck": 5,
+      "proposalId": null
+    },
+    {
+      "id": "fixture-critical-class",
+      "description": "A fixture critical-severity defect class used only by the class-closure integration tests.",
+      "includes": ["a fixture critical inclusion criterion"],
+      "excludes": ["a fixture critical exclusion criterion"],
+      "canonicalExamples": ["a fixture critical canonical example"],
+      "status": "confirmed",
+      "severity": "critical",
+      "closureStandard": "fixture-critical-standard",
+      "closureStandardEnforcement": null,
+      "instanceCount": 2,
+      "escalatedAt": "seeded-closed",
+      "evidenceCountAtLastAck": 5,
+      "proposalId": null
+    }
+  ]
+}

--- a/tests/integration/class-closure-lint.test.ts
+++ b/tests/integration/class-closure-lint.test.ts
@@ -1,0 +1,224 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes per-test mkdtempSync tmpdirs.
+/**
+ * Integration (Tier 2) — drive scripts/class-closure-lint.mjs as a CHILD PROCESS
+ * over temp fixture repos (docs/specs/class-closure-gate.md → Rollout step 1).
+ *
+ * Runs the REAL shipped lint (not a copy), scope-blind (no BASE_SHA/HEAD_SHA, so
+ * no git repo is needed — the lint still grades every committed declaration, the
+ * counting host). Covers BOTH sides of each decision boundary:
+ *   (a) a good `guard` declaration → exit 0, cites a live guard;
+ *   (b) a `guard` citation to a spec-only / nonexistent path → downgrade logged,
+ *       STILL exit 0 in report-only (dryRun);
+ *   (c) enabled + !dryRun + a malformed registry → exit NONZERO;
+ *   (d) a novel class with full semantics → accepted (exit 0); one without →
+ *       flagged (logged in report-only, exit NONZERO when enforcing);
+ *   + repo-gate: no registry → skip, exit 0.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const SCRIPT = path.join(process.cwd(), 'scripts', 'class-closure-lint.mjs');
+const VALID_REGISTRY = path.join(process.cwd(), 'tests', 'fixtures', 'class-closure', 'registry-valid.json');
+const MALFORMED_REGISTRY = path.join(process.cwd(), 'tests', 'fixtures', 'class-closure', 'registry-malformed.json');
+
+const created: string[] = [];
+
+afterEach(() => {
+  while (created.length) {
+    const d = created.pop()!;
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+interface RepoSpec {
+  registry?: string | null; // fixture path to copy into docs/defect-classes.json, or null to omit
+  config?: Record<string, unknown> | null;
+  decisions?: Array<Record<string, unknown>>;
+  files?: Record<string, string>; // relPath → content (cited guard files, etc.)
+}
+
+function makeRepo(spec: RepoSpec): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-lint-'));
+  created.push(root);
+  if (spec.registry !== null && spec.registry !== undefined) {
+    fs.mkdirSync(path.join(root, 'docs'), { recursive: true });
+    fs.copyFileSync(spec.registry, path.join(root, 'docs', 'defect-classes.json'));
+  }
+  if (spec.config) {
+    fs.mkdirSync(path.join(root, '.instar'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.instar', 'config.json'), JSON.stringify(spec.config, null, 2));
+  }
+  if (spec.decisions && spec.decisions.length) {
+    const dir = path.join(root, '.instar', 'instar-dev-decisions');
+    fs.mkdirSync(dir, { recursive: true });
+    spec.decisions.forEach((entry, i) => {
+      const ts = entry.ts ?? `2026-07-03T00-00-0${i}-000Z`;
+      fs.writeFileSync(path.join(dir, `${ts}-fixture-${i}.json`), JSON.stringify(entry, null, 2));
+    });
+  }
+  for (const [rel, content] of Object.entries(spec.files ?? {})) {
+    const full = path.join(root, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return root;
+}
+
+function runLint(root: string): { status: number; stdout: string; stderr: string } {
+  const res = spawnSync('node', [SCRIPT], {
+    cwd: root,
+    env: { ...process.env, CLASS_CLOSURE_REPO_ROOT: root },
+    encoding: 'utf-8',
+  });
+  return { status: res.status ?? -1, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+}
+
+describe('class-closure-lint (child process)', () => {
+  it('(a) a good guard declaration passes with exit 0', () => {
+    const root = makeRepo({
+      registry: VALID_REGISTRY,
+      config: { prGate: { classClosure: { enabled: true, dryRun: true } } },
+      files: { 'tests/live-guard.test.ts': 'export const guard = 1;\n' },
+      decisions: [
+        {
+          ts: '2026-07-03T00-00-00-000Z',
+          verdict: 'pass',
+          classClosure: {
+            defectClass: 'fixture-normal-class',
+            closure: 'guard',
+            guardEvidence: { enforcementType: 'ratchet', citation: 'tests/live-guard.test.ts', howCaught: 'the ratchet pins the baseline this defect regressed' },
+            prNumber: 100,
+            component: 'CompA',
+          },
+        },
+      ],
+    });
+    const { status, stdout } = runLint(root);
+    expect(status).toBe(0);
+    expect(stdout).toContain('guard citation resolves (ratchet)');
+    expect(stdout).toContain('OK (report-only');
+  });
+
+  it('(b) a guard citation to a spec-only / nonexistent path logs a downgrade but STILL exits 0 in dryRun', () => {
+    const root = makeRepo({
+      registry: VALID_REGISTRY,
+      config: { prGate: { classClosure: { enabled: true, dryRun: true } } },
+      files: { 'docs/specs/some-spec.md': '# spec\n' },
+      decisions: [
+        {
+          ts: '2026-07-03T00-00-00-000Z',
+          classClosure: {
+            defectClass: 'fixture-normal-class',
+            closure: 'guard',
+            guardEvidence: { enforcementType: 'spec-only', citation: 'docs/specs/some-spec.md', howCaught: 'the spec describes the fix' },
+            prNumber: 101,
+            component: 'CompA',
+          },
+        },
+        {
+          ts: '2026-07-03T00-00-01-000Z',
+          classClosure: {
+            defectClass: 'fixture-normal-class',
+            closure: 'guard',
+            guardEvidence: { enforcementType: 'lint', citation: 'scripts/nonexistent.mjs', howCaught: 'a lint that is not on disk' },
+            prNumber: 102,
+            component: 'CompB',
+          },
+        },
+      ],
+    });
+    const { status, stdout } = runLint(root);
+    expect(status).toBe(0);
+    expect(stdout).toContain('DOWNGRADE guard→gap');
+    expect(stdout).toContain('does not resolve'); // the nonexistent path
+    expect(stdout).toContain('not a live enforcing guard'); // the spec-only path
+  });
+
+  it('(c) enabled + !dryRun + a malformed registry exits nonzero', () => {
+    const root = makeRepo({
+      registry: MALFORMED_REGISTRY,
+      config: { prGate: { classClosure: { enabled: true, dryRun: false } } },
+      decisions: [],
+    });
+    const { status, stdout, stderr } = runLint(root);
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('malformed registry');
+    expect(stderr).toContain('FAIL');
+  });
+
+  it('(c-report-only) the SAME malformed registry in report-only mode still exits 0', () => {
+    const root = makeRepo({
+      registry: MALFORMED_REGISTRY,
+      config: { prGate: { classClosure: { enabled: false, dryRun: true } } },
+      decisions: [],
+    });
+    const { status, stdout } = runLint(root);
+    expect(status).toBe(0);
+    expect(stdout).toContain('malformed registry'); // still LOGGED, just not fatal
+  });
+
+  it('(d) a novel class with full semantics is accepted (exit 0)', () => {
+    const root = makeRepo({
+      registry: VALID_REGISTRY,
+      config: { prGate: { classClosure: { enabled: true, dryRun: false } } },
+      decisions: [
+        {
+          ts: '2026-07-03T00-00-00-000Z',
+          classClosure: {
+            defectClass: 'novel',
+            closure: 'gap',
+            gapItem: 'ACT-9001',
+            prNumber: 200,
+            component: 'CompNew',
+            novelClass: {
+              nearestExistingClass: 'fixture-normal-class',
+              includes: ['a new inclusion criterion'],
+              excludes: ['a new exclusion criterion'],
+              severity: 'normal',
+            },
+          },
+        },
+      ],
+    });
+    const { status } = runLint(root);
+    expect(status).toBe(0);
+  });
+
+  it('(d) a novel class WITHOUT semantics is flagged (nonzero when enforcing)', () => {
+    const decisions = [
+      {
+        ts: '2026-07-03T00-00-00-000Z',
+        classClosure: {
+          defectClass: 'novel',
+          closure: 'gap',
+          gapItem: 'ACT-9002',
+          prNumber: 201,
+          component: 'CompNew',
+          // novelClass omitted → no semantics
+        },
+      },
+    ];
+    // Enforcing → nonzero.
+    const enforcing = makeRepo({ registry: VALID_REGISTRY, config: { prGate: { classClosure: { enabled: true, dryRun: false } } }, decisions });
+    const rEnf = runLint(enforcing);
+    expect(rEnf.status).not.toBe(0);
+    expect(rEnf.stdout).toContain('novel class with no semantics');
+
+    // Report-only → flagged in output but exit 0 (the other side of the boundary).
+    const reportOnly = makeRepo({ registry: VALID_REGISTRY, config: { prGate: { classClosure: { enabled: false, dryRun: true } } }, decisions });
+    const rRep = runLint(reportOnly);
+    expect(rRep.status).toBe(0);
+    expect(rRep.stdout).toContain('novel class with no semantics');
+  });
+
+  it('repo-gate: a checkout without docs/defect-classes.json skips + exits 0', () => {
+    const root = makeRepo({ registry: null });
+    const { status, stdout } = runLint(root);
+    expect(status).toBe(0);
+    expect(stdout).toContain('not an instar class-closure repo');
+  });
+});

--- a/tests/unit/class-closure-grader-parity.test.ts
+++ b/tests/unit/class-closure-grader-parity.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit (Tier 1) — PARITY: scripts/lib/class-closure-grader.mjs ≡ the exported
+ * StandardsEnforcementAuditor grader (classifyFileGuard + gradeGuardCitation).
+ *
+ * The .mjs is a self-contained MIRROR (the CI lint runs on a fresh checkout with
+ * no build step and cannot import the TS from dist/). This test pins the two
+ * implementations byte-equal for the same inputs over the REAL repo checkout, so
+ * they cannot silently drift (Structure > Willpower — the grader's own comment
+ * names this test).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  classifyFileGuard as tsClassify,
+  gradeGuardCitation as tsGrade,
+} from '../../src/core/StandardsEnforcementAuditor.js';
+// @ts-expect-error — .mjs script, no type declarations; runtime import is fine under vitest
+import { classifyFileGuard as mjsClassify, gradeGuardCitation as mjsGrade } from '../../scripts/lib/class-closure-grader.mjs';
+
+const REPO = process.cwd();
+
+const FILE_REFS = [
+  'tests/unit/class-closure-grader.test.ts',
+  'src/core/DefectClassRegistry.ts',
+  'scripts/lint-guard-manifest.js',
+  'scripts/class-closure-lint.mjs',
+  'docs/specs/class-closure-gate.md',
+  'docs/defect-classes.json',
+  'no-direct-thing.js',
+  'src/server/routes.ts',
+  '.husky/pre-commit',
+];
+
+const CITATIONS = [
+  'src/core/DefectClassRegistry.ts',
+  'docs/specs/class-closure-gate.md',
+  'scripts/does-not-exist.mjs',
+  'tests/unit/class-closure-grader.test.ts',
+  'GET /guards',
+  'POST /nonexistent-route-xyz',
+  'validateRegistry',
+  'aSymbolThatDefinitelyDoesNotExistAnywhere12345',
+];
+
+describe('grader parity — classifyFileGuard', () => {
+  for (const ref of FILE_REFS) {
+    it(`agrees on "${ref}"`, () => {
+      expect(mjsClassify(ref)).toBe(tsClassify(ref));
+    });
+  }
+});
+
+describe('grader parity — gradeGuardCitation (over the real repo checkout)', () => {
+  for (const citation of CITATIONS) {
+    it(`agrees on "${citation}"`, () => {
+      expect(mjsGrade(REPO, citation)).toEqual(tsGrade(REPO, citation));
+    });
+  }
+});

--- a/tests/unit/class-closure-grader.test.ts
+++ b/tests/unit/class-closure-grader.test.ts
@@ -1,0 +1,83 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes per-test mkdtempSync tmpdirs.
+/**
+ * Unit (Tier 1) — the self-contained guard grader (scripts/lib/class-closure-grader.mjs).
+ *
+ * The spec's G3 rule: a `closure:'guard'` citation that does NOT resolve to a
+ * LIVE enforcing guard (ratchet/gate/lint on disk) downgrades the declaration to
+ * `gap`. A grader error fails CLOSED (downgrade). Covers BOTH sides:
+ *   - a resolving ratchet/gate/lint citation → guard upheld;
+ *   - a spec-only path → gap downgrade;
+ *   - a non-existent path → gap downgrade;
+ *   - a throwing input → gap (fail-closed).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+// @ts-expect-error — .mjs script, no type declarations; runtime import is fine under vitest
+import { evaluateGuardClosure } from '../../scripts/lib/class-closure-grader.mjs';
+
+let repo: string;
+
+beforeAll(() => {
+  repo = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-grader-'));
+  fs.mkdirSync(path.join(repo, 'tests'), { recursive: true });
+  fs.mkdirSync(path.join(repo, 'src'), { recursive: true });
+  fs.mkdirSync(path.join(repo, 'scripts'), { recursive: true });
+  fs.mkdirSync(path.join(repo, 'docs', 'specs'), { recursive: true });
+  fs.writeFileSync(path.join(repo, 'tests', 'sample.test.ts'), 'export const x = 1;\n');
+  fs.writeFileSync(path.join(repo, 'src', 'Gate.ts'), 'export function gateFn() { return true; }\n');
+  fs.writeFileSync(path.join(repo, 'scripts', 'lint-thing.js'), '// a lint\n');
+  fs.writeFileSync(path.join(repo, 'docs', 'specs', 'foo.md'), '# spec\n');
+});
+
+afterAll(() => {
+  fs.rmSync(repo, { recursive: true, force: true });
+});
+
+describe('evaluateGuardClosure', () => {
+  it('upholds guard for a resolving RATCHET citation (a *.test.ts file)', () => {
+    const v = evaluateGuardClosure(repo, 'tests/sample.test.ts');
+    expect(v.effectiveClosure).toBe('guard');
+    expect(v.gradedKind).toBe('ratchet');
+    expect(v.resolved).toBe(true);
+    expect(v.downgradeReason).toBeNull();
+  });
+
+  it('upholds guard for a resolving GATE citation (a src/ file)', () => {
+    const v = evaluateGuardClosure(repo, 'src/Gate.ts');
+    expect(v.effectiveClosure).toBe('guard');
+    expect(v.gradedKind).toBe('gate');
+  });
+
+  it('upholds guard for a resolving LINT citation (a scripts/lint-* file)', () => {
+    const v = evaluateGuardClosure(repo, 'scripts/lint-thing.js');
+    expect(v.effectiveClosure).toBe('guard');
+    expect(v.gradedKind).toBe('lint');
+  });
+
+  it('downgrades to gap for a spec-only path (docs/specs/*.md guards nothing)', () => {
+    const v = evaluateGuardClosure(repo, 'docs/specs/foo.md');
+    expect(v.effectiveClosure).toBe('gap');
+    expect(v.gradedKind).toBe('spec-only');
+    expect(v.resolved).toBe(true); // the file exists…
+    expect(v.downgradeReason).toContain('not a live enforcing guard');
+  });
+
+  it('downgrades to gap for a non-existent path', () => {
+    const v = evaluateGuardClosure(repo, 'scripts/does-not-exist.mjs');
+    expect(v.effectiveClosure).toBe('gap');
+    expect(v.resolved).toBe(false);
+    expect(v.downgradeReason).toContain('does not resolve');
+  });
+
+  it('fails CLOSED (gap) on a throwing input', () => {
+    // A non-string citation makes the grader's `.trim()` throw — evaluateGuardClosure
+    // must catch it and downgrade, never propagate.
+    const v = evaluateGuardClosure(repo, {} as unknown as string);
+    expect(v.effectiveClosure).toBe('gap');
+    expect(v.resolved).toBe(false);
+    expect(v.downgradeReason).toContain('grader error (fail-closed)');
+  });
+});

--- a/tests/unit/class-closure-registry-parity.test.ts
+++ b/tests/unit/class-closure-registry-parity.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit (Tier 1) — PARITY: scripts/lib/defect-class-registry.mjs ≡ the pure
+ * functions of src/core/DefectClassRegistry.ts (validateRegistry, deriveClassData,
+ * computeEscalation + constants).
+ *
+ * The .mjs mirror lets the CI lint run on a fresh checkout with NO build step.
+ * This test pins the mirror equal to the canonical TS for the same inputs, so a
+ * behavior change to one without the other fails CI (Structure > Willpower).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateRegistry as tsValidate,
+  deriveClassData as tsDerive,
+  computeEscalation as tsEscalate,
+  DEFAULT_SPREAD_N,
+  DEFAULT_SINGLE_K,
+  DEFAULT_GAP_MAX_AGE_DAYS,
+  type DecisionDeclaration,
+  type DerivedClassData,
+} from '../../src/core/DefectClassRegistry.js';
+// @ts-expect-error — .mjs mirror, no type declarations; runtime import is fine under vitest
+import * as mjs from '../../scripts/lib/defect-class-registry.mjs';
+
+/** Normalize a Map<string, DerivedClassData> to a stable, comparable shape. */
+function mapToObj(m: Map<string, DerivedClassData>): Record<string, DerivedClassData> {
+  const out: Record<string, DerivedClassData> = {};
+  for (const [k, v] of [...m.entries()].sort((a, b) => a[0].localeCompare(b[0]))) out[k] = v;
+  return out;
+}
+
+const REGISTRIES: unknown[] = [
+  { version: 1, classes: [] },
+  'not-an-object',
+  { classes: 'nope' },
+  {
+    version: 1,
+    classes: [
+      { id: 'good-class', description: 'd', includes: ['a'], excludes: ['b'], canonicalExamples: [], status: 'confirmed', severity: 'normal', closureStandard: null, instanceCount: 0, evidenceCountAtLastAck: 0, proposalId: null },
+      { id: 'good-class', description: 'dup', includes: ['a'], excludes: ['b'], canonicalExamples: [], status: 'confirmed', severity: 'critical', closureStandard: null, instanceCount: 0, evidenceCountAtLastAck: 0, proposalId: null },
+    ],
+  },
+  {
+    version: 1,
+    classes: [
+      { id: 'unconf', description: 'd', includes: ['a'], excludes: ['b'], canonicalExamples: [], status: 'unconfirmed', severity: 'normal', closureStandard: null, instanceCount: 0, evidenceCountAtLastAck: 0, proposalId: null },
+    ],
+  },
+];
+
+const DECLARATION_SETS: DecisionDeclaration[][] = [
+  [],
+  [
+    { defectClass: 'x', closure: 'guard', prNumber: 5, component: 'A', source: 'a.json' },
+    { defectClass: 'x', closure: 'guard', prNumber: 5, component: 'A', source: 'b.json' },
+    { defectClass: 'x', closure: 'gap', prNumber: 7, component: 'B', source: 'c.json' },
+    { defectClass: 'y', closure: 'guard', component: 'A', source: 'd.json' },
+    { defectClass: 'y', closure: 'guard', component: 'A', source: 'e.json' },
+  ],
+];
+
+const ESCALATION_CASES: Array<[{ severity: 'critical' | 'normal'; evidenceCountAtLastAck: number }, Partial<DerivedClassData>, { spreadN?: number; singleK?: number }]> = [
+  [{ severity: 'critical', evidenceCountAtLastAck: 0 }, { dedupedCount: 1, componentCount: 1, maxSingleComponentCount: 1 }, {}],
+  [{ severity: 'normal', evidenceCountAtLastAck: 0 }, { dedupedCount: 3, componentCount: 2, maxSingleComponentCount: 2 }, {}],
+  [{ severity: 'normal', evidenceCountAtLastAck: 0 }, { dedupedCount: 2, componentCount: 1, maxSingleComponentCount: 2, hasOpenGap: true }, {}],
+  [{ severity: 'normal', evidenceCountAtLastAck: 0 }, { dedupedCount: 5, componentCount: 1, maxSingleComponentCount: 5 }, {}],
+  [{ severity: 'normal', evidenceCountAtLastAck: 3 }, { dedupedCount: 3, componentCount: 2, maxSingleComponentCount: 2 }, {}],
+  [{ severity: 'normal', evidenceCountAtLastAck: 0 }, { dedupedCount: 2, componentCount: 2, maxSingleComponentCount: 1 }, { spreadN: 2 }],
+];
+
+function fullDerived(o: Partial<DerivedClassData>): DerivedClassData {
+  return { dedupedCount: 0, componentCount: 0, maxSingleComponentCount: 0, hasOpenGap: false, prs: [], components: [], ...o };
+}
+
+describe('registry mirror parity', () => {
+  it('exports the same constants', () => {
+    expect(mjs.DEFAULT_SPREAD_N).toBe(DEFAULT_SPREAD_N);
+    expect(mjs.DEFAULT_SINGLE_K).toBe(DEFAULT_SINGLE_K);
+    expect(mjs.DEFAULT_GAP_MAX_AGE_DAYS).toBe(DEFAULT_GAP_MAX_AGE_DAYS);
+  });
+
+  it('validateRegistry agrees on every registry shape', () => {
+    for (const reg of REGISTRIES) {
+      expect(mjs.validateRegistry(reg)).toEqual(tsValidate(reg));
+    }
+  });
+
+  it('deriveClassData agrees on every declaration set', () => {
+    for (const decls of DECLARATION_SETS) {
+      expect(mapToObj(mjs.deriveClassData(decls))).toEqual(mapToObj(tsDerive(decls)));
+    }
+  });
+
+  it('computeEscalation agrees on every case (incl. reason strings)', () => {
+    for (const [entry, derived, thresholds] of ESCALATION_CASES) {
+      const d = fullDerived(derived);
+      expect(mjs.computeEscalation(entry, d, thresholds)).toEqual(tsEscalate(entry, d, thresholds));
+    }
+  });
+});

--- a/tests/unit/class-closure-registry.test.ts
+++ b/tests/unit/class-closure-registry.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit (Tier 1) — DefectClassRegistry pure logic (docs/specs/class-closure-gate.md).
+ *
+ * Covers the three decision surfaces of the class registry, BOTH sides of every
+ * boundary:
+ *   - validateRegistry: accept the seeded registry; reject missing severity, an
+ *     unconfirmed class with no nearestExistingClass, a duplicate id, a bad id charset.
+ *   - deriveClassData: dedup by PR (two decls same PR → count 1), per-component max,
+ *     hasOpenGap.
+ *   - computeEscalation: every arm (critical-1, spread, gap-plus, single-component),
+ *     seeded-closed suppression (no new evidence), and the newEvidence gate.
+ *   - gapOpenPastMaxAge: below vs past the ceiling.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  validateRegistry,
+  deriveClassData,
+  computeEscalation,
+  gapOpenPastMaxAge,
+  type DecisionDeclaration,
+  type DefectClassEntry,
+  type DerivedClassData,
+} from '../../src/core/DefectClassRegistry.js';
+
+function validClass(overrides: Partial<DefectClassEntry> = {}): DefectClassEntry {
+  return {
+    id: 'fixture-class',
+    description: 'a fixture class',
+    includes: ['x'],
+    excludes: ['y'],
+    canonicalExamples: [],
+    status: 'confirmed',
+    severity: 'normal',
+    closureStandard: null,
+    closureStandardEnforcement: null,
+    instanceCount: 0,
+    escalatedAt: null,
+    evidenceCountAtLastAck: 0,
+    proposalId: null,
+    ...overrides,
+  };
+}
+
+function decl(overrides: Partial<DecisionDeclaration>): DecisionDeclaration {
+  return {
+    defectClass: 'x',
+    closure: 'guard',
+    source: 'entry.json',
+    ...overrides,
+  };
+}
+
+describe('validateRegistry', () => {
+  it('accepts the seeded on-disk registry (docs/defect-classes.json)', () => {
+    const raw = fs.readFileSync(path.join(process.cwd(), 'docs', 'defect-classes.json'), 'utf-8');
+    const parsed = JSON.parse(raw);
+    const v = validateRegistry(parsed);
+    expect(v.ok).toBe(true);
+    expect(v.errors).toEqual([]);
+  });
+
+  it('rejects a class missing severity', () => {
+    const bad = { version: 1, classes: [validClass()] } as Record<string, unknown>;
+    delete (bad.classes as DefectClassEntry[])[0].severity;
+    const v = validateRegistry(bad);
+    expect(v.ok).toBe(false);
+    expect(v.errors.join(' ')).toContain('severity invalid');
+  });
+
+  it('rejects an unconfirmed class with no nearestExistingClass', () => {
+    const v = validateRegistry({ version: 1, classes: [validClass({ status: 'unconfirmed' })] });
+    expect(v.ok).toBe(false);
+    expect(v.errors.join(' ')).toContain('unconfirmed but has no nearestExistingClass');
+  });
+
+  it('accepts an unconfirmed class WHEN it carries nearestExistingClass', () => {
+    const v = validateRegistry({
+      version: 1,
+      classes: [validClass({ status: 'unconfirmed', nearestExistingClass: 'fixture-class' })],
+    });
+    expect(v.ok).toBe(true);
+  });
+
+  it('rejects a duplicate class id', () => {
+    const v = validateRegistry({ version: 1, classes: [validClass(), validClass()] });
+    expect(v.ok).toBe(false);
+    expect(v.errors.join(' ')).toContain('duplicate');
+  });
+
+  it('rejects a bad id charset', () => {
+    const v = validateRegistry({ version: 1, classes: [validClass({ id: 'Bad_Id!' })] });
+    expect(v.ok).toBe(false);
+    expect(v.errors.join(' ')).toContain('must match');
+  });
+});
+
+describe('deriveClassData', () => {
+  it('dedups by PR number — two decls citing the same PR count ONCE', () => {
+    const d = deriveClassData([
+      decl({ prNumber: 5, component: 'A', source: 'a.json' }),
+      decl({ prNumber: 5, component: 'A', source: 'b.json' }),
+    ]);
+    expect(d.get('x')!.dedupedCount).toBe(1);
+    expect(d.get('x')!.prs).toEqual([5]);
+  });
+
+  it('computes per-component max + component count', () => {
+    const d = deriveClassData([
+      decl({ prNumber: 1, component: 'A', source: 'a.json' }),
+      decl({ prNumber: 2, component: 'A', source: 'b.json' }),
+      decl({ prNumber: 3, component: 'B', source: 'c.json' }),
+    ]);
+    const x = d.get('x')!;
+    expect(x.dedupedCount).toBe(3);
+    expect(x.componentCount).toBe(2);
+    expect(x.maxSingleComponentCount).toBe(2); // A has 2 distinct PRs
+    expect(x.components).toEqual(['A', 'B']);
+  });
+
+  it('falls back to source filename as the dedup key when prNumber is absent', () => {
+    const d = deriveClassData([
+      decl({ component: 'A', source: 'a.json' }),
+      decl({ component: 'A', source: 'b.json' }),
+    ]);
+    expect(d.get('x')!.dedupedCount).toBe(2); // distinct sources → 2
+  });
+
+  it('flags hasOpenGap when any declaration is a gap', () => {
+    const withGap = deriveClassData([decl({ prNumber: 1, closure: 'gap' })]);
+    expect(withGap.get('x')!.hasOpenGap).toBe(true);
+    const withoutGap = deriveClassData([decl({ prNumber: 1, closure: 'guard' })]);
+    expect(withoutGap.get('x')!.hasOpenGap).toBe(false);
+  });
+});
+
+describe('computeEscalation', () => {
+  const D = (o: Partial<DerivedClassData>): DerivedClassData => ({
+    dedupedCount: 0,
+    componentCount: 0,
+    maxSingleComponentCount: 0,
+    hasOpenGap: false,
+    prs: [],
+    components: [],
+    ...o,
+  });
+
+  it('critical class escalates at 1 new instance', () => {
+    const v = computeEscalation(
+      { severity: 'critical', evidenceCountAtLastAck: 0 },
+      D({ dedupedCount: 1, componentCount: 1, maxSingleComponentCount: 1 }),
+    );
+    expect(v.shouldEscalate).toBe(true);
+    expect(v.arm).toBe('critical-1');
+  });
+
+  it('normal class escalates on ≥3 across ≥2 components (spread)', () => {
+    const v = computeEscalation(
+      { severity: 'normal', evidenceCountAtLastAck: 0 },
+      D({ dedupedCount: 3, componentCount: 2, maxSingleComponentCount: 2 }),
+    );
+    expect(v.shouldEscalate).toBe(true);
+    expect(v.arm).toBe('spread');
+  });
+
+  it('normal class escalates on ≥2 + an open gap (gap-plus)', () => {
+    const v = computeEscalation(
+      { severity: 'normal', evidenceCountAtLastAck: 0 },
+      D({ dedupedCount: 2, componentCount: 1, maxSingleComponentCount: 2, hasOpenGap: true }),
+    );
+    expect(v.shouldEscalate).toBe(true);
+    expect(v.arm).toBe('gap-plus');
+  });
+
+  it('normal class escalates on ≥5 within one component (single-component)', () => {
+    const v = computeEscalation(
+      { severity: 'normal', evidenceCountAtLastAck: 0 },
+      D({ dedupedCount: 5, componentCount: 1, maxSingleComponentCount: 5 }),
+    );
+    expect(v.shouldEscalate).toBe(true);
+    expect(v.arm).toBe('single-component');
+  });
+
+  it('normal class does NOT escalate when no arm crosses (below every threshold)', () => {
+    const v = computeEscalation(
+      { severity: 'normal', evidenceCountAtLastAck: 0 },
+      D({ dedupedCount: 2, componentCount: 2, maxSingleComponentCount: 1 }),
+    );
+    expect(v.shouldEscalate).toBe(false);
+    expect(v.arm).toBeNull();
+    expect(v.newEvidence).toBe(true); // there IS new evidence, just no arm crossed
+  });
+
+  it('seeded-closed suppression: no escalation when derived ≤ ack baseline', () => {
+    const v = computeEscalation(
+      { severity: 'normal', evidenceCountAtLastAck: 3 },
+      D({ dedupedCount: 3, componentCount: 2, maxSingleComponentCount: 2 }),
+    );
+    expect(v.shouldEscalate).toBe(false);
+    expect(v.newEvidence).toBe(false);
+  });
+
+  it('a seeded CRITICAL class does not re-fire on backfilled evidence (ack gate)', () => {
+    const suppressed = computeEscalation(
+      { severity: 'critical', evidenceCountAtLastAck: 2 },
+      D({ dedupedCount: 2, componentCount: 1, maxSingleComponentCount: 2 }),
+    );
+    expect(suppressed.shouldEscalate).toBe(false);
+    const reraise = computeEscalation(
+      { severity: 'critical', evidenceCountAtLastAck: 2 },
+      D({ dedupedCount: 3, componentCount: 1, maxSingleComponentCount: 3 }),
+    );
+    expect(reraise.shouldEscalate).toBe(true);
+    expect(reraise.arm).toBe('critical-1');
+  });
+
+  it('respects tunable thresholds (spreadN / singleK)', () => {
+    const v = computeEscalation(
+      { severity: 'normal', evidenceCountAtLastAck: 0 },
+      D({ dedupedCount: 2, componentCount: 2, maxSingleComponentCount: 1 }),
+      { spreadN: 2 },
+    );
+    expect(v.shouldEscalate).toBe(true);
+    expect(v.arm).toBe('spread');
+  });
+});
+
+describe('gapOpenPastMaxAge', () => {
+  const now = Date.parse('2026-07-03T00:00:00Z');
+  it('is false for a gap opened within the ceiling', () => {
+    expect(gapOpenPastMaxAge('2026-06-20T00:00:00Z', now, 45)).toBe(false);
+  });
+  it('is true for a gap opened past the ceiling', () => {
+    expect(gapOpenPastMaxAge('2026-05-01T00:00:00Z', now, 45)).toBe(true);
+  });
+  it('is false (never throws) on an unparseable date', () => {
+    expect(gapOpenPastMaxAge('not-a-date', now, 45)).toBe(false);
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -426,14 +426,19 @@ describe('lint-dev-agent-dark-gate', () => {
       // 1519→1530, 1564→1575, 1589→1600).
       // RE-VERIFIED by hand via the attributor on the rebase-merged ConfigDefaults
       // (each still maps to a real `enabled: false,` line inside its named block).
-      '878': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
-      '882': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
+      // Class-Closure Gate keystone (PR #1347): a new prGate.classClosure block
+      // (9 lines, dark + report-only) was inserted at ConfigDefaults.ts:824, adding this
+      // new dark-gate literal AND shifting every key below it DOWN by +9 (hand-verified via
+      // the attributor: no path changed, only the one intended new gate).
+      '824': 'prGate.classClosure.enabled',
+      '887': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
+      '891': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
       // multi-transport-mesh-comms (2026-06-20): soloCaptainHold.enabled:false (Layer 3,
       // action-bearing) added to the leaseSelfHeal block + a ~15-line meshTransport FLAT
       // block (enabled: TRUE, NOT an `enabled: false` path so the attributor ignores it)
       // inserted ABOVE sessionPool — together shifting every sessionPool-onward
       // `enabled: false` line by +24 (956→980, 981→1005). RE-VERIFIED via the attributor.
-      '889': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
+      '898': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
       // U4.4 lease hand-back (docs/specs/u4-4-lease-handback.md §5, R-r2-4): a NEW
       // multiMachine.leaseSelfHeal.preferredCaptainHandback block with an EXPLICIT
       // `enabled: false` (+ dryRun:true + 5 tunables, ~16 lines incl. comment) was
@@ -445,7 +450,7 @@ describe('lint-dev-agent-dark-gate', () => {
       // (dev-gated — DEV_GATED_FEATURES) so it adds NO attributed path, only a +19
       // shift below the sessionPool block. RE-VERIFIED via the attributor on the
       // edited ConfigDefaults (each maps to a real `enabled: false,` line).
-      '899': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
+      '908': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
       // WS4.1-durable-ack (CMT-1416) inserts a plain `ws41DurableAck: false`
       // seamlessness boolean (NOT `enabled:`, so the attributor ignores it) above
       // sessionPool. WS4.3-role-guard (CMT-1416) inserts another plain
@@ -499,10 +504,10 @@ describe('lint-dev-agent-dark-gate', () => {
       // `enabled` (dev-gated via resolveDevAgentGate), so NO new attributed path; it
       // only shifts every sessionPool-onward `enabled: false` line DOWN by +7.
       // RE-VERIFIED via the attributor on the edited ConfigDefaults (uniform +7).
-      '1136': 'multiMachine.sessionPool.enabled',
-      '1162': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
-      '1172': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '1201': 'multiMachine.sessionPool.holdForStability.enabled',
+      '1145': 'multiMachine.sessionPool.enabled',
+      '1171': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
+      '1181': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '1210': 'multiMachine.sessionPool.holdForStability.enabled',
       // mm-stores-devgate (operator directive 2026-06-13, topic 13481): the 7
       // multiMachine.stateSync.* memory stores MOVED from DARK_GATE_EXCLUSIONS to
       // DEV_GATED_FEATURES and their `enabled: false` literals were REMOVED from
@@ -551,7 +556,7 @@ describe('lint-dev-agent-dark-gate', () => {
       // this branch's U4.2/U4.4 blocks shift stateSync/cartographer further.
       // Every key RE-VERIFIED via the attributor on the rebase-MERGED
       // ConfigDefaults (each maps to a real `enabled: false,` line).
-      '1389': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1398': 'multiMachine.stateSync.threadlinePairing.enabled',
       // autonomous-scope-accretion-completion §4: a NEW
       // autonomousSessions.completionDiscipline.scopeAccretion block (`enabled: true`
       // + breakerK — default ON, the documented maturation-path exception) plus the
@@ -563,9 +568,9 @@ describe('lint-dev-agent-dark-gate', () => {
       // line-map (1464→1483, 1509→1528, 1534→1553). RE-VERIFIED via the attributor
       // on the rebase-MERGED ConfigDefaults (each still maps to a real
       // `enabled: false,` line).
-      '1530': 'cartographer.freshnessSweep.enabled',
-      '1575': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1600': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1539': 'cartographer.freshnessSweep.enabled',
+      '1584': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1609': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/upgrades/next/class-closure-gate.md
+++ b/upgrades/next/class-closure-gate.md
@@ -1,0 +1,66 @@
+# Class-Closure Gate — registry + report-only recurrence lint (increment 1, ships dark)
+
+<!-- bump: minor -->
+
+## What Changed
+
+Increment 1 of the Class-Closure Gate (`docs/specs/class-closure-gate.md`, converged +
+approved). This is the mechanical arm of the constitutional principle **"Distrust Temporary
+Success: A Recurrence Is a Root Cause"** — until now nothing at fix-time asked *"what CLASS
+of defect is this, and what structural change makes the whole class unrepresentable?"* (the
+question only ever fired because the operator asked it).
+
+Increment 1 ships **CI tooling only — no runtime gates**:
+
+- A **defect-class registry** (`docs/defect-classes.json`) seeded with the four measured
+  classes, each carrying real semantics (includes/excludes/severity/closure-standard).
+- A pure count/threshold **library** (`src/core/DefectClassRegistry.ts`) that derives each
+  class's recurrence count from committed instar-dev decision-audit declarations, deduped by
+  PR number, and computes deterministic escalation-threshold crossings (critical-at-1;
+  normal: ≥3-across-2-components, ≥2+open-gap, or ≥5-in-one-component; seeded-closed
+  suppresses historical backfill).
+- A self-contained **guard grader** (`scripts/lib/class-closure-grader.mjs`, mirroring
+  `StandardsEnforcementAuditor` with a pinned parity test) that downgrades a `closure:guard`
+  declaration to `gap` when the cited guard does not resolve to a live enforcing guard (G3:
+  a dark/spec-only artifact guards nothing).
+- A **report-only PR-gate lint** (`scripts/class-closure-lint.mjs`) + CI workflow
+  (`.github/workflows/class-closure-gate.yml`, check name `class-closure`) that validates the
+  class-declaration field-set on fixes touching agent-authored artifacts and LOGS threshold
+  crossings.
+- An author declaration helper (`scripts/class-closure-declare.mjs`) and the side-effects
+  template's mirrored declaration section.
+
+Config-gated behind `prGate.classClosure = {enabled, dryRun, escalatorDrafting}` (defaults
+off/dry-run) and repo-gated (no-op on installs without `docs/defect-classes.json`). The
+escalator's LLM drafting arm, the proposals writer, the attention-item producer, the runtime
+read route, and the consolidated axis-requirements ratchet are the spec's OWN dark
+**increment 3** — deliberately not in this increment.
+
+## Evidence
+
+- `npx vitest run tests/unit/class-closure-registry.test.ts tests/unit/class-closure-grader.test.ts tests/unit/class-closure-grader-parity.test.ts tests/unit/class-closure-registry-parity.test.ts tests/integration/class-closure-lint.test.ts`
+  → **5 files, 55 tests, 0 failures** (all four escalation arms + seeded-closed suppression +
+  newEvidence gate; guard-upheld vs 3 downgrade paths; report-only-exits-0 vs
+  enforcing-exits-nonzero for both hard-violation types; both mirror-parity suites).
+- `npx tsc --noEmit` → exit 0, zero errors.
+- Report-only guarantee is structural: `scripts/class-closure-lint.mjs` computes
+  `enforcing = config.enabled && !config.dryRun` and returns a nonzero exit ONLY when
+  `enforcing && hardViolations.length > 0` — so under the shipped defaults (disabled +
+  dry-run) it always exits 0 and cannot fail a PR.
+- Side-effects review: `upgrades/side-effects/class-closure-gate.md` (8 questions + Q7
+  multi-machine posture + signal-vs-authority), second-pass reviewed.
+
+## What to Tell Your User
+
+Nothing changes for you right now — this ships **dark and report-only**, and it is
+maintainer-only CI machinery (a no-op on your install unless you develop instar itself). It
+is the first brick of a system that will, later and only after an operator sign-off, notice
+when the same *kind* of bug keeps recurring and propose a structural fix for the whole class
+rather than patching instances one at a time. No behavior, message, or command changes today.
+
+## Summary of New Capabilities
+
+None active for end users in this increment — everything ships disabled/dry-run and
+repo-gated. (For instar maintainers: a report-only CI lint that logs missing/invalid
+defect-class declarations and deterministic class-recurrence threshold crossings, plus the
+class registry and grading libraries it rides on.)

--- a/upgrades/side-effects/class-closure-gate.md
+++ b/upgrades/side-effects/class-closure-gate.md
@@ -99,3 +99,13 @@ Yes — a **CI PR-gate lint** in the same family as `decision-audit-gate`, `eli1
 **If this turns out wrong in production, what's the back-out?**
 
 Trivial and safe. The lint is **report-only + config-gated (`prGate.classClosure` defaults off/dry-run) + repo-gated** — a buggy lint cannot block a merge (it exits 0 in dryRun) and is a no-op on any non-maintainer install. Back-out options, cheapest first: (a) leave defaults (already inert); (b) revert `.github/workflows/class-closure-gate.yml`; (c) revert the whole PR — no data migration, no agent-state repair, no runtime behavior to unwind (no runtime routes added in increment 1). The added `src/core` code is pure libraries with no callers in the runtime path yet.
+
+## Follow-up note — no-silent-fallbacks ratchet
+
+`DefectClassRegistry.ts` (`readDecisionDeclarations` absent-dir catch) and
+`StandardsEnforcementAuditor.gradeGuardCitation` (unresolvable-path catch) are pure
+libraries over a repo checkout with **no runtime / DegradationReporter surface** — their
+fail-closed catches return the correct answer (empty list / `resolved:false`, which the
+caller surfaces as a `gap` downgrade), not a degraded result. Both are tagged
+`@silent-fallback-ok` so the `no-silent-fallbacks` ratchet holds at baseline 491 rather than
+demanding a runtime degradation-report the library layer cannot emit.

--- a/upgrades/side-effects/class-closure-gate.md
+++ b/upgrades/side-effects/class-closure-gate.md
@@ -1,0 +1,101 @@
+# Side-Effects Review — Class-Closure Gate (increment 1: registry + report-only lint)
+
+**Version / slug:** `class-closure-gate`
+**Date:** `2026-07-03`
+**Author:** `echo`
+**Second-pass reviewer:** `CONCUR — no material concern (independent reviewer subagent, 2026-07-03)`
+
+> **Second-pass verdict (independent reviewer):** CONCUR — no material concern. Report-only
+> guarantee holds on every policy path (`class-closure-lint.mjs:271-272`: exit is nonzero only
+> when `enabled && !dryRun && hardViolations>0`; shipped defaults → exit 0 unconditionally,
+> confirmed on all four paths + a malformed-registry probe). Signal-only: no `docs/proposals`
+> writer, no attention-item producer, no `STANDARDS-REGISTRY.md` write in increment 1 (the sole
+> registry reference is a read-scope predicate). Scope honest: `escalatorDrafting` is plumbed
+> but never read (inert reserved key, not a half-built feature); the new TS has zero runtime
+> callers; the declare mutator is in no CI workflow. Drift guarded: both grader/registry parity
+> suites exist and pass. Interactions clean (complementary to `decision-audit-gate`, not
+> shadowing). Two minor non-blocking notes: (1) the CLI entrypoint lacks a top-level try/catch,
+> but all fs reads are individually try/caught so no throw on the real paths — inherent CI-script
+> fragility, not a policy path; (2) the config-default backfill claim is moot because an absent
+> key resolves to the report-only default. Neither requires a change before commit.
+
+## Summary of the change
+
+Increment 1 of the Class-Closure Gate (`docs/specs/class-closure-gate.md`, converged + approved). Ships **CI tooling only — no runtime gates**: a class registry (`docs/defect-classes.json`), a pure count/threshold library (`src/core/DefectClassRegistry.ts`), a self-contained guard grader (`scripts/lib/class-closure-grader.mjs`, mirroring `StandardsEnforcementAuditor`'s classification with a pinned parity test), a **report-only** PR-gate lint (`scripts/class-closure-lint.mjs`) that validates the class-declaration field-set on instar-dev decision-audit entries for fixes touching agent-authored artifacts, derives per-class recurrence counts (deduped by PR#), and LOGS any deterministic escalation-threshold crossing. A CI workflow (`.github/workflows/class-closure-gate.yml`) runs the lint report-only. Config-gated (`prGate.classClosure = {enabled, dryRun, escalatorDrafting}`, defaulting off/dry-run) and repo-gated (no-op on installs without `docs/defect-classes.json`). The escalator's LLM drafting arm, the `docs/proposals/*` writer, the attention-item producer, the runtime read route, and the consolidated axis-requirements ratchet are the spec's OWN dark **increment 3** — explicitly out of scope here, not orphan deferrals.
+
+## Decision-point inventory
+
+- `scripts/class-closure-lint.mjs` (CI PR-gate lint) — **add** — a build-time SIGNAL (report-only → later enforcing) that a fix to an agent-authored artifact carries a valid class declaration; feeds the operator, never a runtime allow/deny.
+- Deterministic recurrence trigger (inside the lint, via `computeEscalation`) — **add** — LOGS a threshold crossing; the acting-on-it (draft proposal + attention item) is increment 3.
+- `guardEvidence` grading (`evaluateGuardClosure`) — **add** — downgrades a `closure:guard` declaration to `gap` when the cited guard does not resolve to a live enforcing guard (ratchet/gate/lint). Report-only in increment 1.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+Increment 1 is **report-only** (`dryRun:true` default) — the lint ALWAYS exits 0 for declaration-content findings; it cannot reject any PR. The only nonzero exit is reserved for a hard structural violation (malformed registry JSON, a `novel` class with no semantics) AND only when `enabled && !dryRun` — which is a later increment's flip. So: **no over-block surface in increment 1.** (When the enforcing flip lands later, a legitimate fix whose guard citation doesn't resolve is not "blocked" — it downgrades to `closure:gap`, a valid tracked terminal state, per spec.)
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- A fix that bypasses the instar-dev gate entirely (no decision-audit entry) carries no `classClosure` block to validate. That bypass is caught separately by the existing `decision-audit-presence-check` at the PR boundary; this lint does not duplicate that.
+- **Classification accuracy** — an author who mislabels a defect's class (or picks a self-serving hyper-narrow class) is not caught here; the spec routes that to the escalator's periodic spot-check audit (increment 3) and to operator confirmation of `novel` classes. Increment 1 measures population/accuracy honestly during dryRun rather than enforcing.
+- Recurrence inside a single component below K=5 at normal severity does not escalate (by design — distinguishes a systemic pattern from one noisy component).
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes — a **CI PR-gate lint** in the same family as `decision-audit-gate`, `eli16-pr-gate`, `release-fragment-gate`. It is a SIGNAL producer at the build boundary, not a runtime authority, and it **reuses** the existing `StandardsEnforcementAuditor` grading logic (via a self-contained `.mjs` mirror pinned equivalent by a parity test, because PR-gate lints run on a fresh checkout with no build step) rather than re-implementing guard classification. The count/threshold math lives in a pure, unit-tested library (`DefectClassRegistry.ts`). No higher gate already does class-level closure; no lower primitive is being duplicated.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Does this hold blocking authority with brittle logic, or produce a signal that feeds a smart gate?** (`docs/signal-vs-authority.md`)
+
+**COMPLIANT — signal only.** The report-only lint emits a green/annotation signal; it holds no blocking authority in increment 1. The deterministic trigger only LOGS crossings. The downstream escalator (increment 3) drafts a *proposal* and raises an *attention item* — it has **no write path to `STANDARDS-REGISTRY.md`**; adoption is the operator's (Agent Proposes, Operator Approves). No brittle check is given blocking authority; the one place enforcement is later added (the flip) is a deterministic structural validation (registry well-formedness, declaration presence/shape), not a semantic judgment.
+
+---
+
+## 5. Interactions
+
+**Does it shadow another check, get shadowed, double-fire, race with adjacent cleanup?**
+
+- Rides the PR-gate workflow family alongside `decision-audit-gate.yml`/`eli16-pr-gate.yml`/`release-fragment-gate.yml`. It reads the SAME decision-audit entries as `decision-audit-presence-check` but a DIFFERENT field (`classClosure`) — no shadowing, no double-fire (presence-check asserts an entry EXISTS; class-closure validates the entry's declaration content).
+- The self-contained grader mirror could DRIFT from `StandardsEnforcementAuditor.gradeGuardCitation`/`classifyFileGuard` — mitigated by a pinned parity test that fails if they diverge (Structure > Willpower).
+- Counts derive from decision-audit entries **only** (deduped by PR#); the side-effects mirror is display-only and never summed — prevents the round-3 double-counting finding.
+
+---
+
+## 6. External surfaces
+
+**Does it change anything visible to other agents, other users, other systems?**
+
+- Adds one new CI check named `class-closure` to PRs against `main` (green + optional annotations). Report-only, so it can never block a merge in increment 1.
+- Adds a config key `prGate.classClosure` (off/dry-run default).
+- Adds an author helper `scripts/class-closure-declare.mjs` (stamps a `classClosure` block onto a decision entry).
+- No agent-to-agent, Telegram, or dashboard surface in increment 1 (the attention-item producer is increment 3). No dependence on runtime/conversation state — the lint is a pure function of the repo checkout + the PR diff.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated / proxied-on-read / machine-local-by-design?**
+
+**Replicated — via git (the repo IS the replication medium).** The class registry, the `classClosure` declarations (in committed decision-audit entries), and (later) proposal files are all committed to the canonical repo and therefore identical on every machine. Dedup is **repo-state**, never machine-local JSONL, so two machines cannot double-file or double-count. Increment 1 runs entirely in GitHub Actions (not per-machine), so it holds no machine-local runtime state. No user-facing notice (no one-voice concern), no durable per-machine state to strand on topic transfer, no generated URL. The spec declares this posture explicitly ("Multi-machine posture (declared)").
+
+---
+
+## 8. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Trivial and safe. The lint is **report-only + config-gated (`prGate.classClosure` defaults off/dry-run) + repo-gated** — a buggy lint cannot block a merge (it exits 0 in dryRun) and is a no-op on any non-maintainer install. Back-out options, cheapest first: (a) leave defaults (already inert); (b) revert `.github/workflows/class-closure-gate.yml`; (c) revert the whole PR — no data migration, no agent-state repair, no runtime behavior to unwind (no runtime routes added in increment 1). The added `src/core` code is pure libraries with no callers in the runtime path yet.


### PR DESCRIPTION
## ELI16 — a tool that notices when the same *kind* of bug keeps coming back

When we fix a bug in the agent's prompts, hooks, or configs, we prove that one bug is gone — but nothing asks the bigger question: *"what category of mistake is this, and what structural change would make the whole category impossible?"* Until now that question only got asked when the operator asked it by hand. This ships the first, **dark** brick of a system that asks it automatically: a registry of defect *classes* plus a **report-only** CI check that records which class each fix belongs to, verifies the fix cites a real live guard that ends the class (not just a spec that guards nothing), and logs when the same class keeps recurring. Nothing changes for anyone today — it's off by default, report-only (it cannot block any PR), and runs only on the instar maintainer repo. Later increments (with an operator sign-off before any standard changes) turn a recurring class into a proposed structural fix.

---

Increment 1 of the **Class-Closure Gate + Standards-Delta Escalator** (`docs/specs/class-closure-gate.md`, converged + approved; cross-model `codex-cli:gpt-5.5`) — the mechanical arm of the constitutional principle *"Distrust Temporary Success — A Recurrence Is a Root Cause"*. **CI tooling only, no runtime gates.**

## What ships (increment 1 = spec Rollout step 1)
- `docs/defect-classes.json` — the class registry (4 seeded measured classes).
- `src/core/DefectClassRegistry.ts` — pure count/threshold library (counts derived from decision-audit declarations deduped by PR#; escalation arms: critical-at-1, ≥3-across-2-components, ≥2+open-gap, ≥5-in-one-component; seeded-closed backfill suppression).
- `scripts/lib/class-closure-grader.mjs` — self-contained guard grader (mirrors `StandardsEnforcementAuditor`; downgrades `closure:guard`→`gap` when a citation doesn't resolve to a live enforcing guard, G3; parity-tested).
- `scripts/class-closure-lint.mjs` + `.github/workflows/class-closure-gate.yml` — **REPORT-ONLY** PR-gate lint (exit nonzero only when `enabled && !dryRun && hardViolations>0`; shipped defaults always exit 0).
- `scripts/class-closure-declare.mjs` — author declaration helper.

## Posture
- Config-gated behind `prGate.classClosure = {enabled:false, dryRun:true, escalatorDrafting:false}`, repo-gated (no-op off the maintainer repo). Classified `structural-stub` in `DARK_GATE_EXCLUSIONS` (CI-only, no runtime consumer wired in increment 1).
- The escalator LLM drafting arm, `docs/proposals/*` writer, attention-item producer, runtime read route, and axis-requirements ratchet are the spec's OWN dark **increment 3** — deliberately not here.

## Evidence
- 55 tests green (unit + integration + both grader/registry parity suites); `tsc --noEmit` clean.
- Side-effects review (`upgrades/side-effects/class-closure-gate.md`) + independent **second-pass reviewer: CONCUR, no material concern**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)