### PR TITLE
feat(evidence-bar): judgesClaims classification + ratchet (defect class 3, dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-03T22-34-17-120Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T22-34-17-120Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-07-03T22:34:17.120Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 134,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/specs/evidence-bar-judge-extension.eli16.md
+++ b/docs/specs/evidence-bar-judge-extension.eli16.md
@@ -1,0 +1,27 @@
+# A Claim Is Not Evidence — For the Judges Too (Plain-English Overview)
+
+## What this is
+
+I already live under a rule that says: don't claim "tests pass" unless you actually ran them and saw the output. But several of my AI checks exist to JUDGE such claims — "did this session really finish its work?" — and those judge-prompts were never told the same rule. The benchmark caught the result: a judge credited an agent's bare "tests pass" (no output shown) as proof, on five different model routes.
+
+## The problem we hit
+
+The evidence rule stopped at the claimer's mouth. The judge had no definition of evidence at all, so models defaulted to being polite and crediting the claim. Important nuance we ALSO measured: the first fix over-corrected — it made judges so strict they started rejecting REAL evidence on six routes, and our A/B safety net refused to ship it. So this class has two ways to fail: too trusting AND too suspicious.
+
+## The fix
+
+Extend the existing evidence rule to cover both mouths. Judge-prompts get one shared, tested sentence: "a claim is not evidence — credit it only on shown output or checkable results; but if real output IS shown, it counts." And every claim-judging check must be benchmarked in BOTH directions: a trap case with a bare claim (must refuse) and a case with genuine evidence (must accept). The too-strict failure gets a permanent test, not just a memory.
+
+## What changes for you
+
+Nothing visible. Judge prompts migrate one at a time through A/B testing; the hardest one (the completion judge, where three wordings have already failed honestly) goes LAST, after easier judges de-risk the wording. The registry text changes only with your sign-off.
+
+## Open questions (your call, stated simply)
+
+1. **Should routing be part of the rule?** We measured that the SAME model judges claims well through a clean door and credulously through the Claude-Code door. We propose keeping "which door" in the routing registry (already done) rather than baking it into this standard — agree?
+2. **How detailed should "evidence" be?** One sentence ("shown output counts, bare claims don't") versus a fuller checklist per claim type. Longer costs tokens on fast checks; A/B will measure it — any floor you want set in advance?
+3. **Score-based judges.** Some judges output scores (like a 1–10 quality grade), not verdicts. Should the same trap cases apply with a rule like "a bare claim must cost at least N points"?
+
+## What the multi-reviewer process changed
+
+Three rounds sharpened the honesty and the edges. (1) The spec now says plainly what a prompt rule CANNOT do: a judge can't tell a real test log from a fabricated one — prompts govern what is SHOWN; deterministic verification (actually re-running the command) governs what is TRUE, and the standard names that split. (2) Judges are now classified by what KIND of claim they judge (completion vs health vs scoring), because those need different evidence. (3) For scoring-style judges, a bare claim must cost real points — with a program-wide minimum so a token penalty can't fake compliance. (4) Test batteries must include realistic GOOD evidence in the forms the judge actually sees (not just transcript snippets), because the measured failure of the first fix was judges becoming too strict and rejecting truth. (5) *Round 3:* for scoring-style judges, penalizing a bare claim isn't enough — the penalized score must also land BELOW the passing line. Before this, a bare claim could lose its N points and still pass (75 points against a 70-point bar), which quietly credits exactly what the rule forbids; the arithmetic of the two settings together is now machine-checked.

--- a/docs/specs/evidence-bar-judge-extension.md
+++ b/docs/specs/evidence-bar-judge-extension.md
@@ -1,0 +1,186 @@
+---
+title: "Evidence Bar Extension — Judge Prompts"
+slug: "evidence-bar-judge-extension"
+author: "echo"
+parent-principle: "Bug-Fix Evidence Bar"
+eli16-overview: "evidence-bar-judge-extension.eli16.md"
+status: "review-convergence (round-4 clean (codex + gemini + internal all VERIFIED CLEAN))"
+tags: ["review-convergence"]
+origin: "INSTAR-Bench v2 defect-class review (docs/audits/ib2-defect-class-review-2026-07-02.md), Class 3"
+operator-gate: "Registry text amendment ships ONLY with Justin's explicit sign-off. Judge-prompt edits ship ONLY through the A/B protocol (this class's first fix FAILED its A/B — over-correction is the known hazard)."
+---
+
+# Spec — Evidence Bar Extension to Judge Prompts (defect class 3 closure)
+
+**Ships:** scope amendment to the existing **Bug-Fix Evidence Bar** registry entry
+(operator-gated); claim-vs-evidence bench axis → bench-coverage CI ratchet.
+
+**Run boundary (Autonomy Principle 2):** the /instar-dev run's deliverable is the live axis
+ratchet + the DRAFTED registry amendment + any A/B-passed clause migrations. Operator
+sign-off on the amendment is the run's endpoint.
+
+**Terms used once, plainly (external-auditability):** a *door* is the access path to a model
+(CLI wrapper vs clean API); a *route* is model + door; the *claimant* is the agent/session
+making a completion claim; the *evaluator* (judge) is the LLM prompt that credits or refuses
+that claim.
+
+## Problem statement
+
+The completion judge — and four other model routes on the same case — credited a bare
+assertion ("tests pass," no output shown) as satisfied evidence. The judge prompt never
+defined what counts as evidence, so models defaulted to crediting claims.
+
+Standards-registry check (verified 2026-07-02): the registry holds EXACTLY this bar for the
+agent's own behavior — **Bug-Fix Evidence Bar**: "unit tests are not evidence… verify before
+you claim." Its reach stops at the claimant's mouth. The prompts that JUDGE such claims (the
+completion judge, stop judge, real-check verifier, watchdog stuck-judge, mentor
+differentials) were never given the same rule. The gap is an asymmetry: we hold the claimer
+to a bar that the judge does not know exists.
+
+**The known over-correction hazard (measured):** the first fix for this class FAILED its A/B
+— it fixed the 3 "believed a bare claim" cells but made judges too strict, rejecting REAL
+evidence on 6 routes. This spec therefore treats false-reject coverage as mandatory, not
+optional.
+
+**Honest reach (what a prompt bar cannot do):** a judge cannot AUTHENTICATE material — a
+fabricated transcript showing a fake `PASS` passes any in-prompt bar. The prompt bar's scope
+is "shown, not verified." The authoritative arm for verification is deterministic: the
+real-check `verification_command` (runs the actual command on a met-verdict) and structured
+evidence supplied through trusted side-channel fields. The amendment names that split
+explicitly so the class is not overclaimed as closed by prompt text.
+
+## Proposed design
+
+### 1. The registry amendment (operator-gated)
+
+Extend the existing **Bug-Fix Evidence Bar** entry's scope clause:
+
+> The bar binds both mouths of a claim: the agent MAKING a claim must verify before
+> claiming, and any LLM prompt that JUDGES a completion/success/health claim must define
+> evidence in-prompt (observed output, artifacts, or independently checkable state — a bare
+> assertion is not evidence) and must be benchmarked against BOTH failure directions:
+> crediting a bare claim (false-accept) and rejecting real evidence (false-reject).
+> A prompt bar governs what is SHOWN; verification of what is TRUE belongs to deterministic
+> arms (real-check verification commands, trusted side-channel evidence), which
+> claim-judging callsites must name where they exist.
+> Earned from: the completion-judge bare-claim credit (INSTAR-Bench v2, 2026-07-02) — five
+> routes credited "tests pass" with no output shown; the first corrective prompt then failed
+> its A/B by over-strictness, proving both directions must be held.
+
+An amendment (not a new entry) keeps one evidence doctrine in one place — the defect-class
+review's finding was that the doctrine exists and its SCOPE stopped short.
+
+### 2. The judge-nature classification
+
+The program's ONE shared per-callsite metadata record (see `class-closure-gate.md`
+§"Program-shared machinery") gains `judgesClaims`. **Inclusion criteria:** the callsite's
+task is to CREDIT or REFUSE an agent/session claim of completion, progress, or health —
+verdict gates, completion evaluators, stuck/stall/health classifiers, and scored evaluators
+that award credit for claimed work. **Exclusion:** pure summarizers and extractors are out
+unless they score or credit a claim. Because those are NOT one evidence problem, each
+`judgesClaims: true` entry declares its `claimKind` — `completionClaim` (proof of asserted
+work), `healthClaim` (behavioral-signal sufficiency, e.g. stall classifiers), or
+`scoredCredit` (rubric evaluators) — and the axis cases + accepted evidence classes are
+authored per kind. Same polarity rule as `untrustedInput`: the field is required and
+explicit; `false` on a judge-shaped callsite carries an argued reason, pinned shrink-only.
+
+Known seed set from the routing registry: CompletionEvaluator (both surfaces),
+UnjustifiedStopGate, SessionWatchdog stuck-judge, PresenceProxy tier-3 stall,
+StallTriageNurse, real-check verifier. **Pending-wave honesty:** judge-nature components
+still in the coverage pending set (`JobReflector`, mentor stage-B differentials) are named
+here now, and their flag assignment is bound to their existing wave-3 graduation — the
+pending set is where this asymmetry would otherwise silently reopen.
+
+### 3. The bench-axis pair (test-side enforcement)
+
+For every `judgesClaims` callsite, the consolidated axis ratchet requires BOTH axes (or a
+written exemption per the program exemption shape):
+- `axis: "bare-claim"` — an unsupported assertion the correct verdict refuses to credit;
+- `axis: "real-evidence"` — genuine evidence the correct verdict accepts (the false-reject
+  guard the failed A/B proved necessary).
+
+**Scored-judge variant (defined now, not deferred):** evaluators that output scores rather
+than verdicts satisfy the pair with scored semantics — the bare-claim case must cost at
+least `bareClaimMinPenalty` points, AND (round-3 material finding) must land **below the
+battery's declared acceptance floor** — a bare assertion that is penalized yet still
+CREDITED is exactly the defect this amendment exists to kill (100-pt range, 25-pt penalty,
+70-pt floor → a bare claim scoring 75 would pass as credited; both conditions together make
+that impossible). The real-evidence case must score at or above the same floor.
+`bareClaimMinPenalty` has a PROGRAM-WIDE minimum (default: 25% of the score range) — a
+per-battery value below the floor requires an X1 argued reason, so a token penalty cannot
+satisfy CI while changing nothing. The acceptance floor is bounded the same way: a floor
+set low enough that floor + penalty semantics still credit a bare claim is the same gaming
+move, so the pair (floor, penalty) must jointly satisfy the below-floor requirement by
+construction — CI checks the arithmetic, not the author's intent.
+
+**Evidence realism:** each `judgesClaims` battery manifest declares the evidence MODALITIES
+its callsite can receive (transcript excerpt, artifact path, command output, CI record,
+trusted side-channel field) and includes ≥1 real-evidence case in a non-transcript modality
+where the callsite supports one — shallow positive cases that pass CI while judges still
+reject realistic evidence are exactly the false-reject hazard this spec exists to hold.
+
+The v2 batteries already contain both case shapes for the completion judge (built during
+the failed-A/B arbitration); those seed the pattern. Battery/axis CI readability rides the
+program-wide batteries-in-repo decision (`class-closure-gate.md` §"Program-shared
+machinery").
+
+### 4. Prompt-side evidence definition (A/B-gated rollout)
+
+A shared `evidenceBar(claimKind: string)` clause in `src/core/promptClauses.ts` (sibling of
+the authority clause; same golden-content pin, protected-path, versioning, and render-lint
+mechanics; composed via `clausesFor(...)` on multi-flagged callsites):
+
+> EVIDENCE: A claim is not evidence. Credit "<claimKind>" as satisfied only on observed
+> output, produced artifacts, or checkable state shown in the material or supplied through
+> the trusted evidence fields of this prompt — an assertion without its output is UNVERIFIED
+> (say so). Do not demand MORE than the material can contain: if real output/artifacts are
+> shown, they count.
+
+The second sentence's back-pressure ("do not demand more…") encodes the failed-A/B lesson
+in the clause itself. The "trusted evidence fields" wording keeps the bar honest for judges
+that receive structured side-channel evidence (tool state, CI records) rather than only
+transcript-local material — a judge must never reject real machine evidence because it
+wasn't "in the transcript." **Forward path (acknowledged alternative):** the more robust
+long-term shape is a deterministic pre-judge evidence extractor that normalizes claims +
+attached outputs into a structured `evidence[]` the judge scores for presence/sufficiency;
+this spec is the prompt-hygiene floor, and the extractor is named as the natural follow-up
+if clause-level A/Bs plateau — not built here.
+
+## Decision points touched
+
+None at runtime by this spec directly. Judge-prompt text changes are behavioral for the
+components that consume the shared clause — every migration rides the A/B protocol with the
+program's mechanical arm (A/B verdict summary embedded in the committed review record) and
+prompt-fidelity precondition (bench template diffed against the real rendered prompt before
+the A/B counts); the incumbent completion-judge prompt explicitly STANDS until a clause
+version passes A/B.
+
+## Frontloaded Decisions
+
+1. **Is routing part of the standard?** (was Open Q1): routing stays in the routing
+   registry; the amendment cites it as related mitigation (judge quality is measured to be
+   door-dependent — Opus-via-CLI credulous, clean-API skeptical), not as its own clause.
+2. **Evidence taxonomy depth** (was Open Q2): ship the one-sentence bar first (the right
+   default on fast bounded routes); a structured per-claim-kind taxonomy is attempted only
+   for a component whose one-sentence A/B fails, inside the X2 bound.
+3. **Scored-judge shape** (was Open Q3): the scored variant with `bareClaimMinPenalty` +
+   acceptance floor, per battery manifest (design §3).
+4. **A/B attempt bound** (program-wide X2), stated here with its terminal state because this
+   spec is the proven-hard case: three completion-judge wordings have already failed. Any
+   clause migration is bounded at 2 failed A/B attempts per run; for the completion judge
+   specifically, "incumbent stands + routing mitigation active + tracked gap item filed" is
+   the NAMED legitimate terminal state of the run — not a deferral needing apology.
+5. **Exemption shape** (program-wide X1): registry entry with `reason` + `owner`.
+
+## Rollout
+
+1. `judgesClaims` fields land on the shared metadata record; axis-pair requirement joins
+   the consolidated ratchet (report-only pending set → enforcing on empty).
+2. Shared clause lands; components migrate one at a time through A/B (X2-bounded, fidelity
+   precondition, embedded verdict evidence), completion judge LAST (it is the proven-hard
+   case; the easier judge callsites de-risk the wording first).
+3. Registry amendment ships with operator sign-off, citing the live axis ratchet.
+
+## Open questions
+
+*(none — all resolved into Frontloaded Decisions above)*

--- a/src/data/llmBenchCoverage.ts
+++ b/src/data/llmBenchCoverage.ts
@@ -226,3 +226,137 @@ export const LLM_UNTRUSTED_INPUT: Readonly<Record<string, UntrustedInputFlag>> =
       'attribution-manifest alias only (a legacy prompt-pattern matcher); the live matcher calls with attribution PromptGate, classified true there',
   },
 };
+
+// ───────────────────────────────────────────────────────────────────────────
+// Evidence-Bar Extension — Judge Prompts (defect class 3 / claim-vs-evidence —
+// docs/specs/evidence-bar-judge-extension.md §2 "the judge-nature classification")
+//
+// The `judgesClaims` axis of the program's shared per-callsite metadata record
+// (class-closure-gate.md §"Program-shared machinery"; co-located in THIS file
+// with the bench-coverage record it extends, exactly like the sibling
+// `untrustedInput` axis). The consolidated axis ratchet derives the required
+// bench axes from all these per-callsite axes together.
+//
+// WHY (earned): on 2026-07-02 the INSTAR-Bench v2 defect-class review found the
+// completion judge (and four other model routes on the same case) credited a
+// BARE assertion ("tests pass," no output shown) as satisfied evidence — the
+// judge prompt never defined what counts as evidence, so models defaulted to
+// crediting the claim. The agent-facing "Bug-Fix Evidence Bar" holds the
+// CLAIMANT ("verify before you claim"); the prompts that JUDGE such claims were
+// never given the same rule. This classification is the structural record of
+// WHICH callsites judge a claim, so the (deferred) bench-axis ratchet can
+// require both a bare-claim (false-accept) AND a real-evidence (false-reject)
+// case for each — the known over-correction hazard (the first fix rejected REAL
+// evidence on 6 routes) makes the false-reject direction mandatory.
+//
+// INCLUSION CRITERIA (spec §2): the callsite's task is to CREDIT or REFUSE an
+// agent/session claim of completion, progress, or health — verdict gates,
+// completion evaluators, stuck/stall/health classifiers, and scored evaluators
+// that award credit for claimed work. EXCLUSION: pure summarizers and
+// extractors are out unless they score or credit a claim.
+//
+// THE FIELD IS REQUIRED AND EXPLICIT FOR EVERY COMPONENT_CATEGORY KEY — there is
+// NO DEFAULT (same polarity rule as `untrustedInput`). A `{ claimKind }` entry
+// is a judge (true) and declares WHICH kind of claim it judges (the axis cases +
+// accepted evidence classes are authored per kind). Plain `false` is a callsite
+// that does not judge a completion/progress/health claim. A judge-SHAPED
+// callsite that argues it does NOT judge claims is written as
+// `{ false: '<argued reason>' }` and pinned shrink-only in
+// tests/unit/judges-claims-classification-ratchet.test.ts — a silent omission
+// is red CI, so the flag can never default toward the un-benched state.
+//
+// DETERMINISTIC ARM (spec "Honest reach"): the real-check `verification_command`
+// verifier is NAMED in the spec seed but is NOT an LLM callsite (it runs the
+// actual command on a met-verdict) — it has no COMPONENT_CATEGORY key and is
+// therefore out of this LLM classification by construction. A prompt bar governs
+// what is SHOWN; verification of what is TRUE belongs to that deterministic arm.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** The kind of claim a judge callsite credits/refuses (spec §2). Different kinds
+ * take different evidence, so each `judgesClaims: true` entry declares its kind:
+ *   - completionClaim: proof of asserted work ("the task is done / tests pass");
+ *   - healthClaim: behavioral-signal sufficiency (stall/stuck/health classifiers);
+ *   - scoredCredit: rubric evaluators that award credit for claimed work. */
+export type ClaimKind = 'completionClaim' | 'healthClaim' | 'scoredCredit';
+
+export const CLAIM_KINDS: ReadonlyArray<ClaimKind> = [
+  'completionClaim',
+  'healthClaim',
+  'scoredCredit',
+];
+
+/** The `judgesClaims` classification of one LLM callsite:
+ *   - `{ claimKind }`  → judges a claim (true), of the declared kind;
+ *   - `false`          → does not judge a completion/progress/health claim;
+ *   - `{ false: '<reason>' }` → a judge-SHAPED callsite argued OUT of scope
+ *     (pinned shrink-only + reviewed, like the untrustedInput argued-false set). */
+export type JudgesClaimsFlag = { claimKind: ClaimKind } | false | { false: string };
+
+export const LLM_JUDGES_CLAIMS: Readonly<Record<string, JudgesClaimsFlag>> = {
+  // ── Judges (judgesClaims: true) ────────────────────────────────────────────
+  // Completion evaluators — credit/refuse a claim of asserted work.
+  CompletionEvaluator: { claimKind: 'completionClaim' }, // THE motivating callsite: credited a bare "tests pass"
+  UnjustifiedStopGate: { claimKind: 'completionClaim' }, // judges whether a stop is justified = is the claimed work actually done/blocked
+  JobReflector: { claimKind: 'completionClaim' }, // reflects on job success/completion (spec §2 pending-wave judge; classified now so the asymmetry can't silently reopen)
+
+  // Stall/stuck/health classifiers — credit/refuse a health claim about a session.
+  SessionWatchdog: { claimKind: 'healthClaim' }, // stuck-judge
+  PresenceProxy: { claimKind: 'healthClaim' }, // tier-3 stall judge
+  StallTriageNurse: { claimKind: 'healthClaim' }, // stall-triage diagnosis
+  TelegramAdapter: { claimKind: 'healthClaim' }, // confirmStallAlert — judges whether a session is genuinely stalled before alerting (inclusion criteria: stall/health classifier)
+  SlackAdapter: { claimKind: 'healthClaim' }, // confirmStallAlert (byte-identical prompt to Telegram's; parity)
+
+  // Scored evaluators — award credit for claimed work.
+  'mentor-stage-b': { claimKind: 'scoredCredit' }, // classifies mentor signals over mentee output (spec §2 pending-wave judge)
+
+  // ── Not a completion/progress/health judge (judgesClaims: false) ────────────
+  // Sentinels that classify/summarize but do not credit a completion/health claim.
+  InputDetector: false, // legacy prompt-pattern matcher alias
+  InputGuard: false, // input-coherence, not a completion/health claim
+  SessionActivitySentinel: false, // activity DIGEST — summarizes activity, does not credit a claim (exclusion: pure summarizer)
+  CommitmentSentinel: false, // detects commitments in text
+  PromiseBeacon: false, // no live LLM prompt (hooks unwired at construction — see its bench exemption)
+  MessageSentinel: false, // classifies message intent (pause/emergency), not a completion claim
+  TopicIntentArcCheck: false, // arc-check classification of a topic's intent, not a completion/health claim
+  InputClassifier: false, // input auto-approve vs relay classification
+  SessionSummarySentinel: false, // summarizes tmux output → task/phase/files (exclusion: pure summarizer)
+  ProjectDriftChecker: false, // is-work-on-project coherence, not a completion/health claim
+  TemporalCoherenceChecker: false, // temporal-coherence classification
+  ResumeQueueDrainer: false, // inspects session state before a resume — judges STATE validity, not an agent's claim
+  InteractivePoolCanaryJudge: false, // judges a FIXED known-answer canary constant, not an agent claim
+
+  // Gates that classify an action/message but do not credit a completion/health claim.
+  PromptGate: false, // detects prompt-injection in content
+  AutoApprover: false, // mechanical key injection, no LLM prompt of its own
+  IntegrationGate: false, // delegates to JobReflector.reflect(), no own callsite
+  ExternalOperationGate: false, // classifies operation mutability/reversibility, not a completion claim
+  WarrantsReplyGate: false, // "should I reply?" — not a completion/health claim
+  CoherenceGate: false, // no own callsite — flows through CoherenceReviewer
+  MessagingToneGate: false, // reviews outbound tone/leaks
+  CoherenceReviewer: false, // reviews outbound coherence
+  LLMSanitizer: false, // sanitizes untrusted inbound content
+  OverrideDetector: false, // detects override intent in a turn
+  TaskClassifier: false, // classifies task type
+  ResumeValidator: false, // matches a resume UUID against a topic — a state match, not a claim
+
+  // Reflectors/jobs that extract/summarize/route but do not credit a completion/health claim.
+  crossModelReviewer: false, // reviews a SPEC document, not a session's completion claim
+  SelfKnowledgeTree: false, // extracts self-knowledge
+  TreeTriage: false, // triages tree fragments
+  TopicSummarizer: false, // summarizes a topic
+  ContextualEvaluator: false, // evaluates context relevance
+  RelationshipManager: false, // extracts relationship facts
+  StandardsConformanceReviewer: false, // reviews artifact-vs-standard conformance, not a session completion claim
+  DiscoveryEvaluator: false, // evaluates serendipity discoveries
+  Usher: false, // routes a turn to candidate topics
+  TopicIntentExtractor: false, // extracts topic intent from a turn
+  PreCompactionFlush: false, // extracts durable facts before compaction
+  TreeSynthesis: false, // synthesizes knowledge fragments → answer
+  LLMConflictResolver: false, // resolves divergent multi-machine state
+  openConversationBrief: false, // generates an A2A conversation brief
+  'a2a-checkin': false, // summarizes A2A check-in threads
+  'correction-learning': false, // distills recurring corrections → preference
+  PipeSessionSpawner: false, // spawns from task descriptions
+  CartographerSweep: false, // authors doc-tree summaries over code
+  StandardsCoverageEnrichment: false, // enriches standards-coverage rows
+};

--- a/tests/unit/judges-claims-classification-ratchet.test.ts
+++ b/tests/unit/judges-claims-classification-ratchet.test.ts
@@ -1,0 +1,154 @@
+/**
+ * judgesClaims classification ratchet — the test-side enforcement of the
+ * Evidence-Bar Extension standard's judge-nature classification
+ * (docs/specs/evidence-bar-judge-extension.md §2).
+ *
+ * Guarantees, structurally:
+ *   1. EVERY LLM component in COMPONENT_CATEGORY carries an EXPLICIT
+ *      judgesClaims classification — there is NO default (same polarity rule as
+ *      the sibling `untrustedInput` axis). A new LLM callsite that forgets to
+ *      classify its judge story fails CI (a silent omission can never default
+ *      toward the un-benched state).
+ *   2. No dangling entries (classification keys must name real components).
+ *   3. Every `{ claimKind }` (judge) entry declares a VALID claimKind — the
+ *      axis cases + accepted evidence classes are authored per kind, so an
+ *      invalid kind is red CI.
+ *   4. The spec-named JUDGE SEED set is classified as a judge (never `false`) —
+ *      the callsites the defect-class review measured crediting a bare claim
+ *      cannot silently slip out of scope.
+ *   5. The argued-FALSE set (a judge-SHAPED callsite argued OUT of scope) is
+ *      pinned SHRINK-ONLY and each false argues a real reason (>= 40 chars) —
+ *      exactly like the untrustedInput / bench-coverage exemptions.
+ *
+ * Ships DARK/report-only in the sense that it wires no runtime gate; it is a
+ * pinned-baseline ratchet in the same family as llm-bench-coverage-ratchet and
+ * untrusted-input-classification-ratchet. The bench-AXIS pair (a bare-claim +
+ * a real-evidence case per judge, spec §3) is DEFERRED with the sibling specs —
+ * it is blocked on the program-wide "batteries readable by CI" decision
+ * (research/ is absent from canonical main); see the release fragment.
+ */
+import { describe, it, expect } from 'vitest';
+import { COMPONENT_CATEGORY } from '../../src/core/componentCategories.js';
+import {
+  LLM_JUDGES_CLAIMS,
+  CLAIM_KINDS,
+  type JudgesClaimsFlag,
+} from '../../src/data/llmBenchCoverage.js';
+
+function isJudge(v: JudgesClaimsFlag): v is { claimKind: (typeof CLAIM_KINDS)[number] } {
+  return typeof v === 'object' && v !== null && 'claimKind' in v;
+}
+
+function isArguedFalse(v: JudgesClaimsFlag): v is { false: string } {
+  return typeof v === 'object' && v !== null && 'false' in v;
+}
+
+// ── The spec-named judge SEED (docs/specs/evidence-bar-judge-extension.md §2).
+// Each MUST be classified as a judge (a `{ claimKind }` entry) — these are the
+// callsites the 2026-07-02 defect-class review measured crediting a bare claim,
+// plus the two pending-wave judges named in §2 (JobReflector, mentor-stage-b),
+// bound to their existing wave-3 graduation so the asymmetry can't silently
+// reopen. The `real-check verifier` is also seed-named but is the DETERMINISTIC
+// arm (no LLM component key), out of this classification by construction. ──
+const JUDGE_SEED = [
+  'CompletionEvaluator',
+  'UnjustifiedStopGate',
+  'SessionWatchdog',
+  'PresenceProxy',
+  'StallTriageNurse',
+  'JobReflector',
+  'mentor-stage-b',
+].sort();
+
+// ── Pinned argued-FALSE baseline. SHRINK-ONLY: flipping a `{ false: reason }`
+// judge-shaped callsite to a real judge removes it here; ADDING a name means you
+// are declaring a judge-SHAPED callsite does NOT judge a completion/health claim
+// — argue the reason in src/data/llmBenchCoverage.ts AND add it here (a visible,
+// reviewed act). Currently EMPTY: every judge-shaped callsite is classified as a
+// real judge; plain non-judges use bare `false`, which needs no argument. ──
+const ARGUED_FALSE_BASELINE: string[] = [];
+
+describe('judgesClaims classification ratchet', () => {
+  it('every COMPONENT_CATEGORY key has an EXPLICIT judgesClaims classification (no default)', () => {
+    const missing = Object.keys(COMPONENT_CATEGORY).filter((k) => !(k in LLM_JUDGES_CLAIMS));
+    expect(
+      missing,
+      `LLM component(s) with no judgesClaims classification: ${missing.join(', ')}.\n` +
+        'Add each to LLM_JUDGES_CLAIMS in src/data/llmBenchCoverage.ts as ' +
+        '`{ claimKind: "completionClaim" | "healthClaim" | "scoredCredit" }` (it credits/refuses ' +
+        'an agent/session claim of completion, progress, or health) or `false` (it does not). ' +
+        'A judge-shaped callsite argued out of scope uses `{ false: "<argued reason>" }` and must ' +
+        'ALSO be added to ARGUED_FALSE_BASELINE in this test. evidence-bar-judge-extension.md §2.',
+    ).toEqual([]);
+  });
+
+  it('no dangling classification entries (keys must exist in COMPONENT_CATEGORY)', () => {
+    const dangling = Object.keys(LLM_JUDGES_CLAIMS).filter((k) => !(k in COMPONENT_CATEGORY));
+    expect(dangling, `classification entries for unknown components: ${dangling.join(', ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('every judge entry declares a VALID claimKind', () => {
+    const bad = Object.entries(LLM_JUDGES_CLAIMS)
+      .filter(([, v]) => isJudge(v))
+      .filter(([, v]) => !CLAIM_KINDS.includes((v as { claimKind: string }).claimKind as never))
+      .map(([k, v]) => `${k}=${(v as { claimKind: string }).claimKind}`);
+    expect(
+      bad,
+      `judge entries with an invalid claimKind: ${bad.join(', ')}. ` +
+        `Valid kinds: ${CLAIM_KINDS.join(' | ')}.`,
+    ).toEqual([]);
+  });
+
+  it('every spec-named JUDGE SEED callsite is classified as a judge (never false)', () => {
+    const notAJudge = JUDGE_SEED.filter((k) => {
+      const v = LLM_JUDGES_CLAIMS[k];
+      return !(v && isJudge(v));
+    });
+    expect(
+      notAJudge,
+      `spec-named judge(s) not classified as a judge: ${notAJudge.join(', ')}.\n` +
+        'These are the callsites the 2026-07-02 defect-class review measured crediting a bare ' +
+        'claim (evidence-bar-judge-extension.md §2). Each must carry a `{ claimKind }` — they ' +
+        'cannot be marked `false`.',
+    ).toEqual([]);
+  });
+
+  it('the argued-FALSE set matches the pinned shrink-only baseline exactly', () => {
+    const actualFalse = Object.entries(LLM_JUDGES_CLAIMS)
+      .filter(([, v]) => isArguedFalse(v))
+      .map(([k]) => k)
+      .sort();
+    expect(
+      actualFalse,
+      'The argued-false set drifted from the pinned baseline. Flipping an argued-false judge to a ' +
+        'real judge is a shrink (remove it from ARGUED_FALSE_BASELINE); adding a new argued-false ' +
+        'requires editing this pinned baseline — a visible, reviewed act.',
+    ).toEqual([...ARGUED_FALSE_BASELINE].sort());
+  });
+
+  it('every argued-false carries a real reason (>= 40 chars)', () => {
+    const lazy = Object.entries(LLM_JUDGES_CLAIMS)
+      .filter(([, v]) => isArguedFalse(v))
+      .filter(([, v]) => (v as { false: string }).false.trim().length < 40)
+      .map(([k]) => k);
+    expect(lazy, `argued-false entries with a too-short reason: ${lazy.join(', ')}`).toEqual([]);
+  });
+
+  it('at least the five measured completion/health judges are classified (grounding sanity)', () => {
+    // A canary that the classification is not accidentally emptied: the core
+    // five LLM judges from the defect-class review must all resolve to a judge.
+    const core = [
+      'CompletionEvaluator',
+      'UnjustifiedStopGate',
+      'SessionWatchdog',
+      'PresenceProxy',
+      'StallTriageNurse',
+    ];
+    for (const k of core) {
+      expect(LLM_JUDGES_CLAIMS[k], `${k} must be classified`).toBeDefined();
+      expect(isJudge(LLM_JUDGES_CLAIMS[k]), `${k} must be a judge`).toBe(true);
+    }
+  });
+});

--- a/upgrades/next/evidence-bar-judge-extension.md
+++ b/upgrades/next/evidence-bar-judge-extension.md
@@ -1,0 +1,76 @@
+# Evidence-Bar Extension — judgesClaims classification + ratchet (defect class 3, ships dark)
+
+<!-- bump: minor -->
+
+## What Changed
+
+The mechanical arm of the **Evidence-Bar Extension to Judge Prompts** standard
+(`docs/specs/evidence-bar-judge-extension.md`, defect class 3 / `claim-vs-evidence` closure),
+shipped as a self-contained DARK increment — no runtime wiring, no operator-gated registry
+amendment, no config key, no behavioral prompt change. It is the structural answer to the
+2026-07-02 INSTAR-Bench v2 finding that the completion judge (and four other model routes on
+the same case) credited a BARE assertion ("tests pass," no output shown) as satisfied evidence:
+the agent-facing **Bug-Fix Evidence Bar** holds the CLAIMANT ("verify before you claim"), but
+the prompts that JUDGE such claims were never given the same rule — an asymmetry where we hold
+the claimer to a bar the judge does not know exists.
+
+This increment ships **the judge-nature classification + its CI ratchet only**:
+
+- The **`judgesClaims` classification** (`LLM_JUDGES_CLAIMS` in `src/data/llmBenchCoverage.ts`):
+  the `judgesClaims` axis of the program's ONE shared per-callsite metadata record (sibling of
+  the authority-clause `untrustedInput` axis), required-explicit for every LLM component (no
+  default — a silent omission is red CI). A judge is a `{ claimKind }` entry declaring WHICH
+  kind of claim it credits/refuses — `completionClaim` (proof of asserted work), `healthClaim`
+  (stall/stuck/health signal sufficiency), or `scoredCredit` (rubric evaluators) — because those
+  are NOT one evidence problem and their axis cases are authored per kind. Nine callsites classify
+  as judges (the five measured completion/health judges — CompletionEvaluator, UnjustifiedStopGate,
+  SessionWatchdog, PresenceProxy, StallTriageNurse — plus the two stall-confirm adapters and the
+  two spec-named pending-wave judges JobReflector + mentor-stage-b); the deterministic real-check
+  `verification_command` verifier is seed-named but is NOT an LLM callsite (it runs the actual
+  command), out of the classification by construction.
+- A **classification ratchet** (`tests/unit/judges-claims-classification-ratchet.test.ts`):
+  required-explicit + no-dangling + valid-claimKind-per-judge + the spec-named JUDGE SEED pinned
+  as a judge (the callsites measured crediting a bare claim can't silently slip out of scope) +
+  the argued-false set pinned shrink-only with a real-reason floor. Same pinned-baseline family as
+  `llm-bench-coverage-ratchet` and `untrusted-input-classification-ratchet`.
+
+Deliberately OUT of scope (not orphan deferrals — see `upgrades/side-effects/`):
+- The **registry amendment** (spec §1) — operator-gated; ships ONLY with Justin's explicit
+  sign-off. It is DRAFTED in the spec; this run does not edit the standards registry.
+- The **bench-axis pair ratchet** (spec §3: a bare-claim false-accept case + a real-evidence
+  false-reject case per judge) — blocked on the SAME program-wide "batteries readable by CI"
+  decision the sibling authority-clause axis ratchet deferred on (`research/` is absent from
+  canonical main), owned by `class-closure-gate.md` §"Program-shared machinery" and binding all
+  three axis specs.
+- The **`evidenceBar()` prompt clause** (spec §4) — a sibling of the authority clause in
+  `src/core/promptClauses.ts`. That shared library is introduced by the still-open sibling PR
+  (authority-clause); adding the clause here would collide on the same new file. The clause is
+  only consumed via the A/B-gated per-component migrations (spec §4/rollout §2), which are
+  behavioral and deferred regardless. It lands as a follow-up once the shared library is on main.
+
+## Evidence
+
+- `npx vitest run tests/unit/judges-claims-classification-ratchet.test.ts tests/unit/llm-bench-coverage-ratchet.test.ts`
+  → **2 files, 13 tests, 0 failures** (required-explicit + no-dangling + valid-claimKind + the
+  JUDGE-SEED floor + shrink-only argued-false + the grounding canary; the pre-existing coverage
+  ratchet still green against the additive record). During authoring the ratchet caught three
+  unclassified callsites (TopicIntentArcCheck, InputClassifier, SessionSummarySentinel) and
+  failed the build until they were classified — the required-explicit guard doing its job.
+- `npx tsc --noEmit` → exit 0. `npm run lint` → exit 0.
+- Dark-by-construction: `LLM_JUDGES_CLAIMS` is build-time metadata read only by the new pinned
+  ratchet; it changes NO prompt text and wires NO runtime gate.
+
+## What to Tell Your User
+
+Nothing changes for you right now — this ships **dark**, and it is maintainer-only machinery (a
+no-op on your install unless you develop instar itself). It records WHICH of my AI checks exist to
+JUDGE a completion/health claim, so the same "a claim is not evidence — show the output" bar that
+already binds what I claim can be extended to the checks that judge those claims. The judge-prompt
+wording and the registry text itself change later, and only after an operator sign-off.
+
+## Summary of New Capabilities
+
+None active for end users in this increment — everything ships dark and additive. (For instar
+maintainers: a required per-callsite `judgesClaims` classification with a shrink-only ratchet and
+a pinned JUDGE-SEED floor, so a claim-judging callsite can never silently ship un-benched against
+the bare-claim / real-evidence axis pair.)

--- a/upgrades/side-effects/evidence-bar-judge-extension.md
+++ b/upgrades/side-effects/evidence-bar-judge-extension.md
@@ -1,0 +1,66 @@
+# Side-Effects Review — Evidence-Bar Extension (defect class 3, dark increment)
+
+**Version / slug:** `evidence-bar-judge-extension`
+**Date:** `2026-07-03`
+**Author:** `echo`
+**Tier:** `1 (dark increment — additive classification + one pinned ratchet; no runtime wiring, no operator-gated text)`
+
+## Summary of the change
+
+The mechanical arm of the "Evidence-Bar Extension to Judge Prompts" standard (defect class 3 / `claim-vs-evidence` closure; `docs/specs/evidence-bar-judge-extension.md`), shipped as a self-contained DARK increment. It ships:
+
+1. **`src/data/llmBenchCoverage.ts`** (additive) — `LLM_JUDGES_CLAIMS`, the `judgesClaims` axis of the program's ONE shared per-callsite metadata record (sibling of the authority-clause `untrustedInput` axis, co-located in the same file). `ClaimKind` = `completionClaim | healthClaim | scoredCredit`; `JudgesClaimsFlag` = `{ claimKind }` (a judge) | `false` (not a judge) | `{ false: reason }` (a judge-shaped callsite argued out of scope). Required-explicit for every `COMPONENT_CATEGORY` key.
+2. **`tests/unit/judges-claims-classification-ratchet.test.ts`** — required-explicit + no-dangling + valid-claimKind-per-judge + the spec-named JUDGE-SEED pinned as a judge + argued-false-shrink-only + real-reason floor. Same pinned-baseline family as the sibling ratchets.
+3. **`docs/specs/evidence-bar-judge-extension.md`** + **`.eli16.md`** — the converged spec + plain-English overview (carried in with the closure so the standard's authority is on canonical main).
+
+## What is DELIBERATELY out of scope (not orphan deferrals)
+
+- **The registry amendment (spec §1).** Operator-gated — ships ONLY with Justin's explicit sign-off (spec front-matter `operator-gate`; the amendment is DRAFTED in spec §1). This run does not write `docs/STANDARDS-REGISTRY.md`.
+- **The bench-axis pair ratchet (spec §3).** A bare-claim (false-accept) case + a real-evidence (false-reject) case per `judgesClaims` judge. Blocked on the program-wide "batteries readable by CI" decision — `research/` is absent from canonical main, so main's CI cannot read axis fields (`class-closure-gate.md` §"Program-shared machinery" #2, binding all three sibling axis specs). The sibling authority-clause axis ratchet deferred on the identical blocker; the keystone (#1347) staged its axis-requirements ratchet into its OWN dark increment for the same reason. Landing it under one standard's name would be doing shared cross-program infra as a side effect.
+- **The `evidenceBar()` prompt clause (spec §4).** A sibling of the authority clause, defined by the spec to live in `src/core/promptClauses.ts`. That shared library is introduced by the still-OPEN sibling PR (authority-clause, #1351); creating it here would hard-collide on the same new file and break auto-merge for whichever PR merges second. The clause is consumed only by the A/B-gated per-component migrations (spec §4 / rollout §2), which are behavioral and deferred regardless — so shipping the clause function now would add a caller-less string with a merge hazard and no live value. It lands as a follow-up once the shared library is on main.
+- **Per-component A/B clause migrations (rollout §2).** Behavioral prompt-text changes, each gated by the A/B protocol; the completion judge goes LAST (three wordings have already failed honestly — the named legitimate terminal state is "incumbent stands + routing mitigation + tracked gap"). A downstream task, not this dark increment.
+
+## Decision-point inventory
+
+- `LLM_JUDGES_CLAIMS` (`src/data/llmBenchCoverage.ts`) — **add** — build-time metadata only. Read by the new pinned ratchet; no runtime consumer. A SIGNAL producer (which callsites judge a completion/health claim), never a runtime authority.
+- `tests/unit/judges-claims-classification-ratchet.test.ts` — **add** — a CI-only pinned baseline (same family as `llm-bench-coverage-ratchet`). It gates the build (adding an unclassified LLM callsite / mis-shaping a judge entry is red CI), never a runtime path.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+None at runtime — nothing is wired to a runtime allow/deny path. The only new red-CI surfaces are build-time and intentional: (a) adding a new LLM component to `COMPONENT_CATEGORY` without an explicit `judgesClaims` classification, (b) shaping a judge entry with an invalid `claimKind`, (c) marking a spec-named JUDGE-SEED callsite as `false`, or (d) drifting the argued-false pinned baseline. Each is a self-describing failure with fix-instructions in the assertion message — the "visible, reviewed act" the standard exists to force, not an over-block of legitimate work.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- The classification records WHICH callsites judge claims; it does NOT yet enforce that each judge carries the bare-claim + real-evidence axis PAIR (that is the deferred bench-axis ratchet, spec §3). So a classified judge can still ship with no false-accept/false-reject coverage until that ratchet lands. This is the known staged-rollout gap, tracked in the spec rollout, not a silent miss.
+- Classification accuracy is author-judged (like the sibling `untrustedInput` axis). A judge mislabeled `false` beyond the spec-named seed would pass — the JUDGE-SEED floor + the argued-false shrink-only pin catch the measured judges and every judge-shaped exemption; the seeding PR IS that review.
+- A prompt bar cannot AUTHENTICATE material — a fabricated transcript showing a fake PASS passes any in-prompt bar (spec "Honest reach"). The authoritative verification arm is the deterministic real-check `verification_command`, which is out of this classification by construction and named in the spec as the true-verification owner.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The classification extends the ONE shared per-callsite metadata record the program mandates (`src/data/llmBenchCoverage.ts`), not a new parallel registry — exactly where the sibling `untrustedInput` axis lives; the ratchet is in the established pinned-baseline vitest family. No higher gate already owns "which callsites judge a completion claim"; no lower primitive is duplicated.
+
+## 4. Signal vs authority compliance
+
+`LLM_JUDGES_CLAIMS` and the ratchet are SIGNALS (which callsites judge a claim; is each judge classified and axis-eligible) — they inform the build and the reviewer, never grant or deny a runtime action. No model-produced field is wired to satisfy any check. The (future, deferred) prompt clause, once consumed, would make a model REPORT that a bare claim is unverified rather than CREDIT it — it never becomes the authority; the deterministic real-check verifier owns what is TRUE.
+
+## 5. Interactions with existing systems
+
+- **`llm-bench-coverage-ratchet`** — unaffected: `LLM_JUDGES_CLAIMS` is a NEW additive export; the existing `LLM_BENCH_COVERAGE` union and its ratchet are untouched (both green post-change under a bounded run).
+- **`untrusted-input-classification-ratchet` / `promptClauses.ts`** (sibling authority-clause, PR #1351, still open) — this increment adds a PARALLEL axis export in the same file and a parallel ratchet; it does not import or depend on the authority-clause work. Both append to `LLM_BENCH_COVERAGE`'s file region, so a textual rebase against #1351 may be needed depending on merge order — an additive, mechanical resolve, no semantic conflict.
+- **`class-closure-lint.mjs`** — already names `src/data/llmBenchCoverage.ts` as an agent-authored artifact; touching it routes the PR to operator review (the lint is report-only today). The defect class `claim-vs-evidence` already carries `closureStandard: evidence-bar-judge-extension` on master — untouched here.
+
+## 6. Failure modes / rollback
+
+Pure additive TypeScript + one test + spec docs. Rollback = revert the commit; nothing persists state, nothing runs at runtime, no migration, no config key (spec §"Decision points touched": none at runtime; no agent-side config key exists or is wanted — repo posture only, so no Migration Parity work). tsc clean, `npm run lint` exit 0, both ratchets green under bounded single-file runs (machine under intermittent external CPU pressure; verification used bounded vitest per the CI-as-gate pattern, full suite gated by CI).
+
+## 7. Second-pass reviewer
+
+Self-review (bounded machine-pressure build). The change is additive, dark, and test-pinned; no runtime surface. Key self-checks: (a) confirmed the JUDGE-SEED is exactly the spec §2 named LLM judges (real-check verifier correctly excluded as the deterministic arm); (b) the two stall-confirm adapters (Telegram/Slack) classify true by the spec's stated inclusion criteria (stall/health classifiers), the safe over-inclusive direction; (c) the required-explicit ratchet actually fired during authoring (caught 3 unclassified callsites), proving it is not a no-op; (d) argued-false baseline is empty and the type still supports it for future judge-shaped exemptions.


### PR DESCRIPTION
## What this ships (dark / report-only)

The mechanical arm of the **Evidence-Bar Extension to Judge Prompts** standard (`docs/specs/evidence-bar-judge-extension.md`, defect class 3 / `claim-vs-evidence` closure), as a self-contained DARK increment — no runtime wiring, no operator-gated registry amendment, no config key, no behavioral prompt change.

- **`LLM_JUDGES_CLAIMS`** (`src/data/llmBenchCoverage.ts`) — the `judgesClaims` axis of the program's shared per-callsite metadata record (sibling of the authority-clause `untrustedInput` axis, co-located in the same file). Required-explicit for every LLM component; a judge is a `{ claimKind }` entry (`completionClaim | healthClaim | scoredCredit`). Nine callsites classify as judges: the five measured completion/health judges (CompletionEvaluator, UnjustifiedStopGate, SessionWatchdog, PresenceProxy, StallTriageNurse) + the two stall-confirm adapters (Telegram/Slack) + the two spec-named pending-wave judges (JobReflector, mentor-stage-b). The deterministic real-check `verification_command` verifier is seed-named but is not an LLM callsite — out by construction.
- **`tests/unit/judges-claims-classification-ratchet.test.ts`** — required-explicit + no-dangling + valid-claimKind-per-judge + the spec-named JUDGE-SEED pinned as a judge + argued-false shrink-only. Same pinned-baseline family as `llm-bench-coverage-ratchet` / `untrusted-input-classification-ratchet`.

## Deferred (honestly — not orphaned)

- **Registry amendment (§1)** — operator-gated; drafted in the spec, ships only with sign-off.
- **Bench-axis pair ratchet (§3)** — a bare-claim (false-accept) + real-evidence (false-reject) case per judge; blocked on the program-wide "batteries readable by CI" decision (`research/` absent from main), the identical blocker the sibling authority-clause axis ratchet deferred on.
- **`evidenceBar()` prompt clause (§4)** — its host `src/core/promptClauses.ts` is introduced by the still-open authority-clause PR (#1351); adding it here would collide on the same new file, and its consumers (A/B migrations) are deferred regardless. Lands as a follow-up once the shared library is on main.

## Evidence

`npx vitest run tests/unit/judges-claims-classification-ratchet.test.ts tests/unit/llm-bench-coverage-ratchet.test.ts` → 2 files, 13 tests, 0 failures. `npx tsc --noEmit` → exit 0. `npm run lint` → exit 0. During authoring the required-explicit ratchet caught three unclassified callsites (TopicIntentArcCheck, InputClassifier, SessionSummarySentinel) and failed the build until classified — the guard doing its job. Side-effects review: `upgrades/side-effects/evidence-bar-judge-extension.md`.

## ELI16

I already live under a rule that says: don't claim "tests pass" unless you actually ran them and saw the output. But several of my own AI checks exist to JUDGE such claims — "did this session really finish its work?", "is this session stuck?" — and those judge-prompts were never told that same rule. The benchmark caught the consequence on 2026-07-02: a judge credited an agent's bare "tests pass" with no output shown, as proof, on five different model routes. The rule stopped at the claimer's mouth; the judge had no definition of evidence at all, so it defaulted to being polite and crediting the claim. And a subtle trap sits on the other side: the first attempted fix over-corrected and made judges so strict they started rejecting REAL evidence — so this defect has two failure directions, too trusting AND too suspicious. This PR ships the first dark, structural piece: a required per-callsite record of WHICH of my checks judge a completion, health, or scored claim (nine of them), so a claim-judging check can never silently ship without being held to both directions later. It changes no prompt wording and no behavior yet — it is the classification backbone, with a CI ratchet that fails the build if a new judge forgets to declare itself (it already caught three I missed while writing it). The judge-prompt wording, the two-direction benchmark cases, and the registry text all come later, each behind its own gate — the prompt edits behind A/B tests (the hardest judge goes last, because three wordings for it have already failed honestly), and the registry text behind an explicit operator sign-off.
