### PR TITLE
fix(permissions): member-seat gate false-positive — allow harmless conversational asks (fb-e5b8b021-b74)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-03T22-35-39-511Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T22-35-39-511Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-07-03T22:35:39.511Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 78,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/permissions/IntentClassifier.ts
+++ b/src/permissions/IntentClassifier.ts
@@ -36,6 +36,45 @@ const WRITE_VERB = /\b(post|create|file a ticket|open a ticket|schedule|add a|wr
 const OP_VERB = /\b(run|trigger|kick off|start|rerun|re-run)\b/;
 const OP_NOUN = /\b(job|task|script|pipeline|staging|test|tests|build)\b/;
 
+// ── Conversational self-post detection (member-seat false-positive fix) ──────────
+// A "post a check-in note here in 5 minutes" is the bot AUTHORING conversational
+// content into the CURRENT conversation — not an organizational write. It carries
+// no floor signal (floor detection runs FIRST and always wins) and no org-write /
+// external side-effect. Such a request is conversational (T1 read/draft level), so
+// an ordinary member may direct it — the earlier blanket T2 low-write classification
+// wrongly put it above the member ceiling and refused every member.
+//
+// A verb that FRAMES posting/scheduling conversational content...
+const SELF_POST_VERB = /\b(post|drop|leave|put|write|schedule|set|send|remind|share)\b/;
+// ...applied to a conversational-content noun (a note, check-in, reminder, update…).
+const CONVERSATIONAL_NOUN =
+  /\b(note|notes|check[- ]?in|checkin|reminder|reminders|heads[- ]?up|update|updates|standup|stand[- ]?up|message|ping|nudge)\b/;
+// An organizational-write or EXTERNAL side-effect marker — its presence means this is
+// NOT a harmless conversational post but a genuine low-write/external action that must
+// keep its higher tier (a ticket, a record, another/named channel, a doc, a calendar
+// hold, an email, an outside party). Any match disqualifies the conversational path.
+const ORG_WRITE_OR_EXTERNAL_MARKER =
+  /\b(ticket|tickets|jira|linear|asana|notion|confluence|wiki|calendar|invite|record|records|doc|docs|document|documents|announcement|announcements|another channel|other channel|email|e-mail|invoice|spreadsheet|sheet|client|clients|customer|customers|vendor|vendors|external|outside|partner|press|public)\b|#[a-z0-9][\w-]*/i;
+// An operational marker — asking the bot to RUN/DEPLOY/execute something is never a
+// conversational post, even if phrased as "post a note to run …". Disqualifies too.
+const OPERATIONAL_MARKER =
+  /\b(run|trigger|execute|kick off|deploy|rerun|re-run|migrat\w+|job|pipeline|build|script)\b/;
+
+/**
+ * Is this a harmless conversational self-post (a note / check-in / reminder / status
+ * update the bot would post into the CURRENT conversation)? Deterministic and
+ * conservative: it requires BOTH a self-post verb AND a conversational-content noun,
+ * and it disqualifies on ANY organizational-write / external / operational marker.
+ * Floor actions are already handled (and short-circuited) before this runs, so this
+ * only ever sees non-floor text. Requiring both a post-verb AND a content-noun keeps
+ * plain chatter ("just checking in, how's it going?") at T0 rather than promoting it.
+ */
+export function isConversationalSelfPost(t: string): boolean {
+  if (ORG_WRITE_OR_EXTERNAL_MARKER.test(t)) return false;
+  if (OPERATIONAL_MARKER.test(t)) return false;
+  return SELF_POST_VERB.test(t) && CONVERSATIONAL_NOUN.test(t);
+}
+
 /** Does the text CLAIM an authorization from some named party ("X said it's fine")? */
 export function mentionsClaimedAuthority(text: string): boolean {
   const t = text.toLowerCase();
@@ -49,8 +88,9 @@ function intent(
   confidence: number,
   directed: boolean,
   floorAction?: FloorAction,
+  conversational?: boolean,
 ): RequestIntent {
-  return { action, tier, floorAction, confidence, directed };
+  return { action, tier, floorAction, confidence, directed, conversational };
 }
 
 /**
@@ -94,6 +134,13 @@ export class HeuristicIntentClassifier implements IntentClassifier {
     // ── Non-floor tiers ──
     if (OP_VERB.test(t) && OP_NOUN.test(t)) {
       return intent('operational', 3, 0.78, directed);
+    }
+    // Harmless conversational self-post (note/check-in/reminder into the current
+    // conversation, no org/external/operational marker) → T1, not the T2 low-write
+    // that wrongly refused ordinary members. Checked BEFORE the generic WRITE_VERB
+    // branch so "post a check-in note here" isn't swept up as a low-write.
+    if (isConversationalSelfPost(t)) {
+      return intent('conversational-post', 1, 0.78, directed, undefined, true);
     }
     if (WRITE_VERB.test(t)) {
       return intent('low-write', 2, 0.78, directed);

--- a/src/permissions/LlmIntentClassifier.ts
+++ b/src/permissions/LlmIntentClassifier.ts
@@ -48,7 +48,8 @@ export type LlmIntentDegradeReason =
   | 'no-intelligence' // no provider configured
   | 'error' // provider threw / timed out / circuit open
   | 'unparseable' // LLM returned something we couldn't read as a verdict
-  | 'floor-deterministic'; // heuristic flagged a floor candidate → LLM intentionally skipped
+  | 'floor-deterministic' // heuristic flagged a floor candidate → LLM intentionally skipped
+  | 'conversational-deterministic'; // heuristic flagged a benign conversational self-post → LLM intentionally skipped
 
 export interface LlmIntentClassifierDeps {
   /**
@@ -106,6 +107,19 @@ export class LlmIntentClassifier implements IntentClassifier {
     // floor candidate into an allow-shaped low tier.
     if (floorRead.floorAction || floorRead.tier >= 4) {
       this.report('floor-deterministic');
+      return floorRead;
+    }
+
+    // Symmetric to the floor: a recognized-benign CONVERSATIONAL self-post (a
+    // note/check-in/reminder into the current conversation — deterministically
+    // cleared of any floor/org-write/external/operational marker) is returned AS-IS
+    // and the LLM is never consulted. This is the member-seat fix's load-bearing
+    // half: reconcile() only ever ESCALATES the tier (Math.max), so without this
+    // short-circuit the LLM would re-classify "post a note" up to T2 and re-refuse
+    // the member. The deterministic conversational read is the authority here, just
+    // as the deterministic floor read is above.
+    if (floorRead.conversational) {
+      this.report('conversational-deterministic');
       return floorRead;
     }
 

--- a/src/permissions/types.ts
+++ b/src/permissions/types.ts
@@ -83,6 +83,19 @@ export interface RequestIntent {
    * request is never authorized.
    */
   directed: boolean;
+  /**
+   * True iff this is a recognized HARMLESS CONVERSATIONAL self-post — the bot
+   * authoring a note / check-in / reminder / status update into the CURRENT
+   * conversation, carrying NO floor signal and NO organizational-write or external
+   * side-effect (a ticket, a record, another channel, a calendar hold, an email).
+   * Such a request is conversational, not an authority-requiring org action, so it
+   * is classified at the read/draft tier (T1) rather than the low-write tier (T2)
+   * — an ordinary member may direct it. This is set DETERMINISTICALLY by the
+   * heuristic (floor detection still runs first and always wins) and, like the
+   * floor, is NOT subject to upward re-classification by the LLM judgment band
+   * (see LlmIntentClassifier). Absent/false for everything else.
+   */
+  conversational?: boolean;
 }
 
 /** Relationship/behavioral anomaly assessment for this principal+request. */

--- a/tests/integration/slack-permission-pipeline.test.ts
+++ b/tests/integration/slack-permission-pipeline.test.ts
@@ -114,6 +114,72 @@ describe('test-as-self-for-Slack — full pipeline through SlackAdapter._handleM
     expect(rows[0].registered).toBe(false);
   });
 
+  // ── member-seat conversational fix (fb-e5b8b021-b74) through the ENFORCE path ──
+  it('ENFORCING: an ordinary member\'s harmless conversational ask is ALLOWED (not challenged) and reaches the session', async () => {
+    // Build an ENFORCING observer over the same Slice-0 gate/resolver.
+    const enforcing = new SlackPermissionObserver({
+      resolver: new SlackPrincipalResolver(new CastUserLookup()),
+      gate: buildSliceZeroGate(),
+      ledger,
+      enforce: true,
+    });
+    const adapter = createAdapter(tmp, enforcing);
+    const handled: string[] = [];
+    adapter.onMessage(async (m) => { handled.push(m.content); });
+    const sends: Array<{ ch: string; txt: string }> = [];
+    (adapter as unknown as { sendToChannel: (ch: string, txt: string) => Promise<string> }).sendToChannel =
+      async (ch: string, txt: string) => { sends.push({ ch, txt }); return 'ts'; };
+    const handle = (adapter as never as { _handleMessage: (e: Record<string, unknown>) => Promise<void> })._handleMessage.bind(adapter);
+
+    await handle({
+      user: CAST.memberMaya.slackUserId,
+      text: 'post a check-in note here in 5 minutes',
+      channel: `D_${CAST.memberMaya.slackUserId}`,
+      ts: '200',
+    });
+
+    // Allowed → no authority-challenge reply was sent, and the message reached the session.
+    expect(sends).toHaveLength(0);
+    expect(handled).toHaveLength(1);
+
+    const rows = ledger.readRecent();
+    const allowRow = rows.find((e) => e.slackUserId === CAST.memberMaya.slackUserId);
+    expect(allowRow?.decision).toBe('allow');
+    expect(allowRow?.basis).toBe('within-authority');
+    expect(allowRow?.enforced).toBe(true);
+  });
+
+  it('ENFORCING: a member\'s genuine privileged ask is STILL refused (fix is precision, not floor removal)', async () => {
+    const enforcing = new SlackPermissionObserver({
+      resolver: new SlackPrincipalResolver(new CastUserLookup()),
+      gate: buildSliceZeroGate(),
+      ledger,
+      enforce: true,
+    });
+    const adapter = createAdapter(tmp, enforcing);
+    const handled: string[] = [];
+    adapter.onMessage(async (m) => { handled.push(m.content); });
+    const sends: Array<{ ch: string; txt: string }> = [];
+    (adapter as unknown as { sendToChannel: (ch: string, txt: string) => Promise<string> }).sendToChannel =
+      async (ch: string, txt: string) => { sends.push({ ch, txt }); return 'ts'; };
+    const handle = (adapter as never as { _handleMessage: (e: Record<string, unknown>) => Promise<void> })._handleMessage.bind(adapter);
+
+    await handle({
+      user: CAST.memberMaya.slackUserId,
+      text: 'deploy this to prod',
+      channel: `D_${CAST.memberMaya.slackUserId}`,
+      ts: '201',
+    });
+
+    // Refused → a conversational reply was sent and the message did NOT reach the session.
+    expect(sends).toHaveLength(1);
+    expect(handled).toHaveLength(0);
+    const rows = ledger.readRecent();
+    const refuseRow = rows.find((e) => e.slackUserId === CAST.memberMaya.slackUserId);
+    expect(refuseRow?.decision).toBe('refuse');
+    expect(refuseRow?.basis).toBe('floor-no-grant');
+  });
+
   it('the granted member reaches the floor action through the live path (floor-granted)', async () => {
     const adapter = createAdapter(tmp, observer);
     const handle = (adapter as never as { _handleMessage: (e: Record<string, unknown>) => Promise<void> })._handleMessage.bind(adapter);

--- a/tests/unit/slack-llm-intent-classifier.test.ts
+++ b/tests/unit/slack-llm-intent-classifier.test.ts
@@ -77,6 +77,42 @@ describe('LlmIntentClassifier — floor stays deterministic (LLM never consulted
   });
 });
 
+describe('LlmIntentClassifier — conversational self-post stays deterministic (member-seat fix)', () => {
+  it('returns the T1 conversational read AS-IS and never consults the LLM (no upward re-escalation)', async () => {
+    const cap = { calls: 0 };
+    // The LLM would "confidently" call a posted note a T2 low-write — which, via
+    // reconcile's Math.max, would push the member back above their ceiling. The
+    // deterministic conversational short-circuit prevents that: the LLM is never called.
+    const c = new LlmIntentClassifier({
+      intelligence: fakeProvider(() => '{"action":"post-note","tier":2,"directed":true,"confidence":0.95}', cap),
+    });
+    const i = await c.classify('post a check-in note here in 5 minutes', { directed: true });
+    expect(i.tier).toBe(1);
+    expect(i.conversational).toBe(true);
+    expect(cap.calls).toBe(0);
+  });
+
+  it('reports the conversational-deterministic degrade reason', async () => {
+    const reasons: LlmIntentDegradeReason[] = [];
+    const c = new LlmIntentClassifier({
+      intelligence: fakeProvider(() => '{"action":"post-note","tier":2,"directed":true,"confidence":0.9}'),
+      onDegrade: (r) => reasons.push(r),
+    });
+    await c.classify('drop a quick reminder in this channel', { directed: true });
+    expect(reasons).toContain('conversational-deterministic');
+  });
+
+  it('THROUGH THE GATE: a member conversational self-post is ALLOWED even with an escalating LLM', async () => {
+    const classifier = new LlmIntentClassifier({
+      intelligence: fakeProvider(() => '{"action":"post-note","tier":2,"directed":true,"confidence":0.95}'),
+    });
+    const gate = new SlackPermissionGate({ classifier, anomalyScorer: new NullAnomalyScorer() });
+    const v = await gate.evaluate({ principal: p({ role: 'member' }), text: 'post a check-in note here in 5 minutes', directed: true });
+    expect(v.decision).toBe('allow');
+    expect(v.basis).toBe('within-authority');
+  });
+});
+
 describe('LlmIntentClassifier — judgment band (non-floor) refinement via the LLM', () => {
   it('uses the LLM verdict for a non-floor message (correct tier + action + directedness)', async () => {
     const c = new LlmIntentClassifier({
@@ -171,8 +207,10 @@ describe('LlmIntentClassifier — FAIL-CLOSED (no silent degradation, never a si
       intelligence: fakeProvider(() => 'I am not JSON at all, just chatty prose.'),
       onDegrade: (r) => reasons.push(r),
     });
-    const i = await c.classify('post a quick note in the channel', { directed: true });
-    const h = await heuristic.classify('post a quick note in the channel', { directed: true });
+    // A genuine non-floor low-write (a ticket) — NOT a conversational self-post, so
+    // the LLM path actually runs and its unparseable output falls back to the heuristic.
+    const i = await c.classify('file a ticket for the login bug', { directed: true });
+    const h = await heuristic.classify('file a ticket for the login bug', { directed: true });
     expect(i).toEqual(h);
     expect(reasons).toContain('unparseable');
   });
@@ -181,8 +219,8 @@ describe('LlmIntentClassifier — FAIL-CLOSED (no silent degradation, never a si
     const c = new LlmIntentClassifier({
       intelligence: fakeProvider(() => '{"action":"weird","tier":9,"directed":true,"confidence":0.9}'),
     });
-    const i = await c.classify('post a note', { directed: true });
-    const h = await heuristic.classify('post a note', { directed: true });
+    const i = await c.classify('file a ticket for the login bug', { directed: true });
+    const h = await heuristic.classify('file a ticket for the login bug', { directed: true });
     expect(i).toEqual(h);
   });
 

--- a/tests/unit/slack-permission-gate.test.ts
+++ b/tests/unit/slack-permission-gate.test.ts
@@ -90,9 +90,46 @@ describe('HeuristicIntentClassifier', () => {
 
   it('classifies non-floor tiers', async () => {
     expect((await c.classify('summarize the thread', { directed: true })).tier).toBe(1);
-    expect((await c.classify('post a note in the channel', { directed: true })).tier).toBe(2);
+    // A harmless conversational self-post (a note into the current channel) is T1,
+    // NOT the T2 low-write that wrongly refused ordinary members (fb-e5b8b021-b74).
+    expect((await c.classify('post a note in the channel', { directed: true })).tier).toBe(1);
+    // A genuine low-write with an organizational side-effect (a ticket) stays T2.
+    expect((await c.classify('file a ticket for the login bug', { directed: true })).tier).toBe(2);
     expect((await c.classify('run the staging test job', { directed: true })).tier).toBe(3);
     expect((await c.classify('lol nice', { directed: true })).tier).toBe(0);
+  });
+
+  it('conversational self-post detection: both sides of the boundary', async () => {
+    // ── HARMLESS conversational self-posts → T1, conversational:true ──
+    for (const text of [
+      'post a check-in note here in 5 minutes',
+      'drop a quick note in this channel',
+      'schedule a reminder for the team',
+      'post a status update here',
+      'remind us with a standup note',
+    ]) {
+      const i = await c.classify(text, { directed: true });
+      expect(i.tier, `"${text}" should be T1`).toBe(1);
+      expect(i.conversational, `"${text}" should be conversational`).toBe(true);
+    }
+
+    // ── Genuine org-write / external / operational → NOT conversational, higher tier ──
+    for (const text of [
+      'file a ticket for the login bug', // org-write side-effect (ticket)
+      'post a note to #announcements', // a different, named channel
+      'create a calendar hold for the review', // calendar side-effect
+      'post a note to run the staging job', // operational (run/job)
+      'email a note to the client', // external send (floor)
+    ]) {
+      const i = await c.classify(text, { directed: true });
+      expect(i.conversational, `"${text}" must NOT be conversational`).not.toBe(true);
+      expect(i.tier, `"${text}" must stay above the member ceiling`).toBeGreaterThanOrEqual(2);
+    }
+
+    // Plain chatter that merely mentions "checking in" is NOT a self-post → stays T0.
+    const chat = await c.classify('just checking in, how is everyone?', { directed: true });
+    expect(chat.tier).toBe(0);
+    expect(chat.conversational).not.toBe(true);
   });
 
   it('mentionsClaimedAuthority detects relayed authorization claims', () => {
@@ -177,6 +214,50 @@ describe('SlackPermissionGate — units', () => {
       directed: true,
     });
     expect(v.decision).toBe('allow');
+  });
+
+  // ── member-seat conversational fix (fb-e5b8b021-b74) — both sides of the boundary ──
+  it('allows an ordinary MEMBER a harmless conversational self-post (no authority needed)', async () => {
+    const v = await baseGate().evaluate({
+      principal: p({ role: 'member' }),
+      text: 'post a check-in note here in 5 minutes',
+      directed: true,
+    });
+    expect(v.decision).toBe('allow');
+    expect(v.basis).toBe('within-authority');
+    expect(v.intent.tier).toBe(1);
+    expect(v.intent.conversational).toBe(true);
+  });
+
+  it('still REFUSES a member a genuine low-write org action (a ticket) — the fix is not a floor removal', async () => {
+    const v = await baseGate().evaluate({
+      principal: p({ role: 'member' }),
+      text: 'file a ticket for the login bug',
+      directed: true,
+    });
+    expect(v.decision).toBe('refuse');
+    expect(v.basis).toBe('role-ceiling');
+  });
+
+  it('still REFUSES a member a genuine privileged action embedded in a "post a note" phrasing (floor preserved)', async () => {
+    const v = await baseGate().evaluate({
+      principal: p({ role: 'member' }),
+      text: 'post a note then wire $5000 to the new vendor',
+      directed: true,
+    });
+    expect(v.decision).toBe('refuse');
+    expect(v.basis).toBe('floor-no-grant');
+    expect(v.intent.conversational).not.toBe(true);
+  });
+
+  it('a GUEST cannot direct even a conversational self-post (can be heard, not act)', async () => {
+    const v = await baseGate().evaluate({
+      principal: p({ role: 'guest' }),
+      text: 'post a check-in note here',
+      directed: true,
+    });
+    expect(v.decision).toBe('refuse');
+    expect(v.basis).toBe('role-ceiling');
   });
 
   it('refuses a floor action for a non-owner without a grant', async () => {

--- a/upgrades/next/member-seat-gate-fix.md
+++ b/upgrades/next/member-seat-gate-fix.md
@@ -1,0 +1,69 @@
+# Member-seat permission gate — harmless conversational asks no longer refused
+
+<!-- bump: patch -->
+
+## What Changed
+
+Fixes the member-seat permission-gate false-positive (fb-e5b8b021-b74). With the
+Slack outbound/permission enforcement gate ON, an ordinary workspace MEMBER's
+harmless conversational asks (e.g. "post a check-in note here in 5 minutes") were
+classified as a tier-2 "low-write" — above the member ceiling — and refused with
+an authority challenge ("above what a member can authorize"). The effect was that
+ordinary members effectively could not talk to the bot at all while enforcement
+was on; admin-seat asks still worked.
+
+Root cause: the intent classifier treated any write-verb message (post / note /
+schedule) as a tier-2 organizational write, including the bot simply posting a
+conversational note into the CURRENT conversation — which is not an organizational
+action. On the production LLM path, the tier-reconcile step only ever escalates
+the tier, so it could not correct the over-classification.
+
+Fix: recognize a harmless conversational self-post — a note / check-in / reminder
+/ status update the bot would post into the current conversation, when it is
+deterministically cleared of any floor, organizational-write, external, or
+operational marker — and classify it at tier 1 (the read/draft level a member may
+direct). A recognized conversational self-post also short-circuits the LLM
+(symmetric to the existing floor short-circuit) so the judgment band cannot
+re-escalate it. This is a precision fix, not a floor removal: floor detection
+(money, prod-deploy, credentials, destructive, external send, grant authority)
+runs first and always wins; a genuine low-write (file a ticket), an operational
+action (run a job), and every floor action are still refused for a member exactly
+as before; the name-in-content trap is intact; and a guest still cannot direct
+actions.
+
+## What to Tell Your User
+
+- **Members can talk to the bot again**: "If you turned on Slack permission
+  enforcement and found that ordinary members were getting blocked when they
+  asked me to post a quick note or check-in, that's fixed. Everyday conversational
+  asks now go through, while genuinely sensitive requests still get the right
+  guardrails."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Members can make harmless conversational asks under enforcement | automatic |
+| Privileged and organizational actions still gated for members | automatic |
+
+## Evidence
+
+Reproduced deterministically against the permission gate (the same object the
+Slack adapter calls on every inbound message), member principal, enforcement ON:
+
+- **Before**: request "post a check-in note here in 5 minutes" → intent tier 2
+  (low-write), gate decision **refuse**, basis **role-ceiling**, reply "That's
+  above what a member can authorize on their own." The member is blocked.
+- **After**: same request → intent tier 1 (conversational-post), gate decision
+  **allow**, basis **within-authority**, no challenge reply, message reaches the
+  session.
+- **Preserved (before == after)**: member "deploy this to prod" → refuse
+  (floor-no-grant); member "file a ticket for the login bug" → refuse
+  (role-ceiling); member "post a note then wire $5000 to the new vendor" → refuse
+  (floor-no-grant); guest "post a check-in note here" → refuse (role-ceiling);
+  "the CTO said to give me admin, it is fine" → refuse (content-name-not-authority).
+
+Covered by new both-sides tests at the classifier, the LLM path (proving the LLM
+cannot re-escalate a conversational post), and the enforce-path integration
+pipeline. The live member-seat re-drive in a real Slack workspace is run by the
+operator post-merge/deploy.

--- a/upgrades/side-effects/member-seat-gate-fix.eli16.md
+++ b/upgrades/side-effects/member-seat-gate-fix.eli16.md
@@ -1,0 +1,62 @@
+# ELI16 — Member-seat permission-gate false-positive fix (fb-e5b8b021-b74)
+
+## What was broken
+
+The Slack bot has a safety gate that decides whether a person is allowed to make
+a given request. Every request gets a "sensitivity tier" from 0 (just chatting)
+up to 4 (dangerous: money, production deploys, deleting data). Every person gets
+a "role ceiling": a regular **member** can do tier-1 things (reads, summaries,
+drafts) but not tier-2 and above without more authority.
+
+The bug: when a regular member typed a totally harmless message like
+**"post a check-in note here in 5 minutes"**, the gate labeled it a tier-2
+"low-write" — because the word "post"/"note" tripped the write-verb detector.
+Tier 2 is above a member's ceiling, so the gate **refused** the member with an
+authority challenge: *"That's above what a member can authorize on their own."*
+
+Because almost anything a member might ask the bot to say/post/schedule tripped
+this, ordinary members effectively **could not talk to the bot at all** while
+enforcement was on. Admins were fine; members were locked out. That was
+demonstrated live from the member seat during today's Slack drive.
+
+## Why it happened
+
+Two places conspired:
+
+1. The **heuristic classifier** treated ANY message containing a write verb
+   (`post`, `note`, `schedule`, …) as a tier-2 low-write — including the bot
+   simply posting a conversational note into the CURRENT channel, which isn't an
+   organizational action at all.
+2. The **LLM classifier** (used in production) couldn't rescue it: its reconcile
+   step only ever RAISES the tier (`Math.max`), never lowers it. So even when the
+   LLM correctly read the message as conversational, the tier was clamped back up
+   to the heuristic's wrong tier-2.
+
+## The fix
+
+We taught the classifier to recognize a **harmless conversational self-post** — a
+note / check-in / reminder / status update the bot would post into the current
+conversation — and classify it at **tier 1** (the same level as a draft), which a
+member IS allowed to direct. The recognition is deterministic and conservative:
+
+- It fires only when BOTH a post-style verb AND a conversational-content noun are
+  present (so plain chatter like "just checking in" stays tier 0).
+- It is disqualified by ANY organizational-write, external, or operational marker
+  — a ticket, a record, another named channel (`#…`), a calendar hold, an email,
+  or a "run/deploy/job". Those keep their higher tier.
+- Floor detection (money, prod-deploy, credentials, destructive, external-send,
+  grant-authority) runs FIRST and always wins, so a privileged action hidden
+  inside a "post a note" phrasing is still caught and refused.
+
+To make it stick on the production LLM path, a recognized conversational self-post
+short-circuits the LLM entirely (just like a floor action does), so the judgment
+band can't re-escalate it back to tier 2.
+
+## What did NOT change
+
+This is a precision fix, not a floor removal. A member asking for a genuine
+low-write (file a ticket), an operational action (run a job), or any privileged
+floor action is STILL refused exactly as before. The "someone said it's fine"
+name-in-content trap still fires on floor actions. Guests still cannot direct
+actions. Only the harmless conversational note/check-in case moved from
+wrongly-refused to correctly-allowed.

--- a/upgrades/side-effects/member-seat-gate-fix.md
+++ b/upgrades/side-effects/member-seat-gate-fix.md
@@ -1,0 +1,92 @@
+# Side-Effects Review — Member-seat permission-gate false-positive fix
+
+**Slug:** `member-seat-gate-fix`
+**Date:** 2026-07-03
+**Author:** Echo (instar-dev)
+**Defect:** fb-e5b8b021-b74 (member-seat conversational asks refused as "above what a member can authorize")
+**Tier:** 1 (small, low-risk, reversible precision fix to an intent classifier)
+
+## Summary of the change
+
+With the Slack outbound/permission enforcement gate ON, an ordinary workspace
+MEMBER's harmless conversational asks (e.g. "post a check-in note here in 5
+minutes") were classified tier-2 "low-write", which exceeds the member ceiling
+(tier 1), so the gate refused them with an authority challenge. Effect: ordinary
+members effectively could not talk to the bot while enforcement was on.
+
+Root cause (two-part):
+- `HeuristicIntentClassifier` classified ANY write-verb message (`post`/`note`/
+  `schedule`/…) as tier-2 low-write — including the bot posting a conversational
+  note into the CURRENT conversation, which is not an organizational action.
+- `LlmIntentClassifier.reconcile()` only escalates the tier (`Math.max`), never
+  lowers it, so the production LLM path could not correct the over-classification.
+
+Fix: recognize a harmless conversational self-post (note / check-in / reminder /
+status update into the current conversation, with no floor/org-write/external/
+operational marker) as tier 1 (read/draft level) which a member may direct. A
+recognized conversational self-post also short-circuits the LLM (symmetric to the
+floor short-circuit) so the judgment band cannot re-escalate it.
+
+**Files changed (source):**
+- `src/permissions/types.ts` — add `conversational?: boolean` to `RequestIntent`.
+- `src/permissions/IntentClassifier.ts` — add `isConversationalSelfPost()` +
+  regexes; new deterministic branch (ordered after floor + operational, before
+  the generic WRITE_VERB branch) returns tier 1 / `conversational: true`.
+- `src/permissions/LlmIntentClassifier.ts` — new `conversational-deterministic`
+  degrade reason + short-circuit returning the deterministic conversational read
+  as-is (LLM never consulted, never re-escalated).
+
+**Files changed (tests):** `tests/unit/slack-permission-gate.test.ts`,
+`tests/unit/slack-llm-intent-classifier.test.ts`,
+`tests/integration/slack-permission-pipeline.test.ts` — both-sides boundary
+coverage (member conversational ask allowed; member genuine tier-2/floor still
+refused; guest still refused; LLM cannot re-escalate; enforce-path pipeline).
+
+## Decision-point inventory
+
+- Harmless conversational note/check-in/reminder self-post in the current channel
+  → **downgrade** to tier 1 (member-allowed).
+- Any org-write/external marker (ticket, record, `#channel`, calendar, email,
+  outside party) → **keep** tier 2+ (unchanged).
+- Any operational marker (run/deploy/job/pipeline) → **keep** operational tier
+  (unchanged).
+- Any floor signal → **unchanged** (floor detection runs first and always wins).
+- Plain chatter that merely mentions "checking in" (no post verb) → **unchanged**
+  (stays tier 0).
+
+## 1–7. Analysis (behavioral / security / reversibility)
+
+- **Behavioral:** the ONLY behavior change is that a narrow, deterministically
+  recognized class of harmless conversational self-posts moves from tier 2 to
+  tier 1 — allowing an ordinary member to direct them. Every other classification
+  is byte-identical.
+- **Security / not weakening the gate:** the fix cannot widen access to a
+  privileged action. Floor detection (money / prod-deploy / credential-access /
+  destructive-data / external-send / grant-authority) is ordered FIRST in the
+  heuristic and short-circuits before the conversational branch, and the LLM
+  reconcile still drops any LLM-asserted floor. The conversational path is
+  additionally disqualified by any org-write, external, or operational marker.
+  The "X said it's fine" name-in-content trap (`content-name-not-authority`) is on
+  floor actions and is untouched. Guests still cannot direct actions (tier-1 needs
+  the member ceiling). Unregistered principals are still refused. This is a
+  precision fix, not a floor removal — verified by both-sides tests.
+- **LLM injection surface:** because a recognized conversational self-post
+  short-circuits the LLM, untrusted message content can neither raise nor lower
+  the tier on that path; and on every other path the existing never-widen
+  reconcile clamp is unchanged.
+- **Reversibility:** fully reversible by reverting the commit. No migration, no
+  config, no schema, no state format, no new dependency, no new failure mode.
+- **Framework generality:** the change is pure classification logic in the
+  permission module; it does not touch session launch/inject and is
+  framework-agnostic (no Claude-specific assumption).
+
+## Evidence pointers
+
+- Typecheck: `tsc --noEmit` — 0 errors.
+- Targeted tests: `slack-permission-gate`, `slack-llm-intent-classifier`,
+  `slack-permission-pipeline`, `slack-permission-enforce`,
+  `slack-permission-wiring`, `slack-scenario-audit-harness`,
+  `slack-relationship-anomaly`, `permissions-routes`,
+  `slack-testcast-principal-pipeline`, `intent-llm-judge*`, ambient gate — all
+  green (both-sides boundary + enforce-path pipeline).
+- Live re-drive from the member seat is driven post-merge/deploy by the operator.


### PR DESCRIPTION
## ELI16 — Ordinary Slack members were wrongly blocked from asking the bot to post a simple note; now they aren't.

The permission gate scores each request 0–4 for sensitivity. A regular "member" is allowed level-1 things (reads, drafts). The bug: a harmless ask like *"post a check-in note here in 5 minutes"* got scored level-2 (a "write") just because it contained the word "post"/"note", so the gate refused it as *"above what a member can authorize."* That effectively locked members out of talking to the bot while enforcement was on. The fix teaches the gate that the bot posting a note/check-in/reminder into the current conversation is level-1 conversation, not a level-2 organizational action — so members can make these asks, while genuinely sensitive actions (deploys, money, tickets, "someone said it's fine") still get refused exactly as before.

## Summary

Fixes **fb-e5b8b021-b74** — the member-seat permission-gate false-positive, live-reproduced from the MEMBER cast seat during today's Slack drive.

With the Slack outbound/permission enforcement gate ON, an ordinary workspace MEMBER's harmless conversational asks (e.g. *"post a check-in note here in 5 minutes"*) were intercepted with an authority challenge and refused as *"above what a member can authorize."* Admin-seat asks worked; member-seat asks were wrongly blocked — so ordinary members effectively could not talk to the bot at all while enforcement was on.

## Root cause

Two places conspired:

1. **`HeuristicIntentClassifier`** classified any write-verb message (`post`/`note`/`schedule`/…) as a **tier-2 low-write** — above the member ceiling (tier 1) — including the bot simply posting a conversational note into the CURRENT conversation, which is not an organizational action. `SlackPermissionGate` → `roleCoversTier('member', 2)` = false → `refuse` / `role-ceiling`.
2. **`LlmIntentClassifier.reconcile()`** only ever escalates the tier (`Math.max(floorRead.tier, llm.tier)`), never lowers it — so the production LLM path could not correct the over-classification even when the LLM read the message as conversational.

## Fix (precision, not a floor removal)

Recognize a **harmless conversational self-post** — a note / check-in / reminder / status update the bot would post into the current conversation, deterministically cleared of any floor / organizational-write / external / operational marker — and classify it at **tier 1** (read/draft level), which a member may direct. A recognized conversational self-post also **short-circuits the LLM** (symmetric to the existing floor short-circuit) so the judgment band can't re-escalate it back to tier 2.

Preserved exactly as before: floor detection runs first and always wins; genuine low-writes (file a ticket), operational actions (run a job), and every floor action still refuse for a member; the name-in-content ("X said it's fine") trap is intact; guests still cannot direct actions.

**Files:** `src/permissions/types.ts`, `src/permissions/IntentClassifier.ts`, `src/permissions/LlmIntentClassifier.ts`.

## Tests (all three tiers, both sides of the boundary)

- **Unit** (`slack-permission-gate`): conversational self-post both-sides matrix; member conversational ask → allow; member ticket/floor → still refuse; guest → still refuse.
- **LLM path** (`slack-llm-intent-classifier`): conversational read stays deterministic, LLM never consulted, cannot re-escalate; through-the-gate member allow with an escalating LLM.
- **Integration enforce-path** (`slack-permission-pipeline`): member conversational ask allowed and reaches the session; member privileged ask still refused + reply sent.

tsc clean; targeted + wider slack/permission/intent suites green; lint clean.

The live member-seat re-drive in a real Slack workspace is run by the operator post-merge/deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)