### PR TITLE
fix(reaper): stop reap-log self-flood — transition-dedup + bounded read + rotation

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-03T22-55-01-617Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T22-55-01-617Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-07-03T22:55:01.617Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 163,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/ReapLog.ts
+++ b/src/monitoring/ReapLog.ts
@@ -17,6 +17,43 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 /**
+ * Read only the last `maxBytes` of a file and return its non-empty lines,
+ * newest last. Bounded by construction: an arbitrarily large log is never
+ * loaded whole (the readFileSync-whole-file pattern that froze the event loop
+ * on a 142MB reap-log, 2026-07-03). If the read starts mid-file (the file is
+ * larger than `maxBytes`), the first — possibly partial — line is dropped so a
+ * torn record is never mis-parsed. Never throws; an absent/unreadable file
+ * yields [].
+ */
+function tailLines(filePath: string, maxBytes: number): string[] {
+  let fd: number | undefined;
+  try {
+    const size = fs.statSync(filePath).size;
+    if (size === 0) return [];
+    const readBytes = Math.min(size, maxBytes);
+    const start = size - readBytes;
+    const buf = Buffer.allocUnsafe(readBytes);
+    fd = fs.openSync(filePath, 'r');
+    fs.readSync(fd, buf, 0, readBytes, start);
+    const text = buf.toString('utf-8');
+    const lines = text.split('\n');
+    // Dropped: a leading partial line when we didn't read from byte 0.
+    if (start > 0 && lines.length > 0) lines.shift();
+    return lines.filter((l) => l.trim().length > 0);
+  } catch {
+    return []; // @silent-fallback-ok — absent/unreadable ⇒ no rows.
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* fd already gone */
+      }
+    }
+  }
+}
+
+/**
  * Terminal + initial outcomes of a reap-notice delivery attempt
  * (reap-notify spec R1.3). Records are APPENDED as pairs: one at enqueue
  * (`enqueued`) and one at terminal state — append-only JSONL, latest record
@@ -86,13 +123,57 @@ export interface ReapLogEntry {
   outcome?: ReapNotifyOutcome;
 }
 
+/** Rotate the reap-log once it crosses this many bytes. The current file is
+ *  renamed to `<path>.1` (O(1), no data rewrite) and a fresh file started, so
+ *  the on-disk log can NEVER grow unbounded — even if some future caller floods
+ *  it past the transition-dedup below. One backup generation is retained;
+ *  `read()` merges its tail so recent history survives a rotation boundary. */
+const MAX_LOG_BYTES = 16 * 1024 * 1024;
+/** `read()` only ever pulls the last this-many bytes of a log file, so a large
+ *  reap-log can never be slurped whole into memory (the 142MB readFileSync +
+ *  split that blocked the event loop, 2026-07-03). Generous vs the default
+ *  `limit` of 200 rows (~300 B/row ⇒ ~6.5k rows fit in 2 MB). */
+const TAIL_READ_BYTES = 2 * 1024 * 1024;
+/** Cap on the in-memory transition-dedup map. Live session names are bounded
+ *  (dozens); this is a safety ceiling so a pathological churn of distinct names
+ *  can't grow the map without bound. Oldest entries are pruned first. */
+const MAX_SKIP_STATE = 2000;
+
+/** Optional overrides for the self-limiting caps — primarily so tests can
+ *  trigger rotation without writing 16MB. Production uses the module defaults. */
+export interface ReapLogOptions {
+  maxLogBytes?: number;
+  tailReadBytes?: number;
+  maxSkipState?: number;
+}
+
 export class ReapLog {
   private readonly logPath: string;
   private readonly machineId?: () => string | undefined;
+  private readonly maxLogBytes: number;
+  private readonly tailReadBytes: number;
+  private readonly maxSkipState: number;
+  /** session name → last-LOGGED skip signature (`${reason}::${skipped}`).
+   *  A `recordSkipped` whose signature equals the session's last-logged one is
+   *  the SAME permanent veto being re-evaluated at tick speed (open-commitment,
+   *  not-lease-holder, protected …) — it is NOT re-appended. This is the
+   *  primary cure for the reaper self-inflicted log flood (3218 open-commitment
+   *  + 1608 not-lease-holder repeat rows ⇒ 142MB, 2026-07-03): mirror the
+   *  reaper-audit "log on transition, not every tick" pattern. Cleared when the
+   *  session is reaped so a same-named successor logs its first skip fresh. */
+  private readonly skipState = new Map<string, string>();
+  /** Cheap running estimate of the current log's byte size, so rotation is
+   *  decided WITHOUT a statSync on every append. Seeded from the real size on
+   *  first append, then advanced by each write; re-synced on rotation. -1 =
+   *  not yet seeded. */
+  private approxSize = -1;
 
-  constructor(stateDir: string, machineId?: () => string | undefined) {
+  constructor(stateDir: string, machineId?: () => string | undefined, opts: ReapLogOptions = {}) {
     this.logPath = path.join(stateDir, '..', 'logs', 'reap-log.jsonl');
     this.machineId = machineId;
+    this.maxLogBytes = opts.maxLogBytes ?? MAX_LOG_BYTES;
+    this.tailReadBytes = opts.tailReadBytes ?? TAIL_READ_BYTES;
+    this.maxSkipState = opts.maxSkipState ?? MAX_SKIP_STATE;
   }
 
   recordReaped(e: {
@@ -122,6 +203,9 @@ export class ReapLog {
       ...(e.workEvidence && e.workEvidence.length > 0 ? { workEvidence: e.workEvidence } : {}),
       ...(e.evidenceSource ? { evidenceSource: e.evidenceSource } : {}),
     });
+    // The session is gone — drop its skip-dedup state so a same-named successor
+    // logs its first skip fresh and the map never leaks reaped names.
+    this.forgetSkip(e.session);
   }
 
   /**
@@ -158,6 +242,17 @@ export class ReapLog {
     skipped: string;
     origin?: 'operator' | 'autonomous';
   }): void {
+    // Log-on-transition: a reaper evaluates a permanently-vetoed session
+    // (open-commitment, not-lease-holder, protected, …) on EVERY tick and would
+    // emit an identical `skipped` row each time — 5k+ repeat rows ⇒ a 142MB log
+    // that froze the event loop when read (2026-07-03). Only append when the
+    // skip STATE changes for this session; a re-evaluation with the same
+    // (reason, skipped) is the same veto and is dropped. The reaper keeps
+    // evaluating every tick, so the moment the veto lifts (commitment closes,
+    // lease moves) the state changes and the next skip — or the reap — logs.
+    const sig = `${e.reason}::${e.skipped}`;
+    if (this.skipState.get(e.session) === sig) return;
+    this.rememberSkip(e.session, sig);
     this.append({
       ts: new Date().toISOString(),
       type: 'skipped',
@@ -171,26 +266,74 @@ export class ReapLog {
     });
   }
 
+  /** Record a session's last-logged skip signature, enforcing the map ceiling
+   *  (oldest-first prune — Map preserves insertion order). Re-inserting an
+   *  existing key does not reorder it, which is fine: churny NEW names are the
+   *  growth risk, and those get pruned. */
+  private rememberSkip(session: string, sig: string): void {
+    this.skipState.set(session, sig);
+    while (this.skipState.size > this.maxSkipState) {
+      const oldest = this.skipState.keys().next().value;
+      if (oldest === undefined) break;
+      this.skipState.delete(oldest);
+    }
+  }
+
+  /** Forget a session's skip state — call when the session is gone (reaped) so a
+   *  same-named successor logs its first skip fresh and the map can't leak. */
+  private forgetSkip(session: string): void {
+    this.skipState.delete(session);
+  }
+
   private append(entry: ReapLogEntry): void {
     try {
       fs.mkdirSync(path.dirname(this.logPath), { recursive: true });
-      fs.appendFileSync(this.logPath, JSON.stringify(entry) + '\n');
+      const line = JSON.stringify(entry) + '\n';
+      this.rotateIfNeeded(Buffer.byteLength(line));
+      fs.appendFileSync(this.logPath, line);
+      if (this.approxSize >= 0) this.approxSize += Buffer.byteLength(line);
     } catch {
       // never throw from the audit sink
     }
   }
 
-  /** Read the most-recent `limit` entries (newest last), tolerating partial/corrupt lines. */
-  read(limit = 200): ReapLogEntry[] {
-    let raw: string;
-    try {
-      raw = fs.readFileSync(this.logPath, 'utf-8');
-    } catch {
-      // @silent-fallback-ok — no log file yet means no reaps recorded; an empty
-      // list is the correct answer, not a degraded one.
-      return [];
+  /** Roll the log to `<path>.1` (single retained generation) once it would cross
+   *  MAX_LOG_BYTES, so the file can never grow unbounded. Rename is O(1) — no
+   *  data rewrite on the append hot path (rewriting a large file synchronously
+   *  here would reintroduce the very event-loop stall we're removing). Seeds the
+   *  cheap size estimate from the real file size on first use. */
+  private rotateIfNeeded(incomingBytes: number): void {
+    if (this.approxSize < 0) {
+      try {
+        this.approxSize = fs.statSync(this.logPath).size;
+      } catch {
+        this.approxSize = 0; // absent file ⇒ empty
+      }
     }
-    const lines = raw.split('\n').filter((l) => l.trim().length > 0);
+    if (this.approxSize + incomingBytes <= this.maxLogBytes) return;
+    try {
+      fs.renameSync(this.logPath, `${this.logPath}.1`); // overwrites a prior .1
+    } catch {
+      // @silent-fallback-ok — if the roll fails the append still proceeds; the
+      // read path is tail-bounded so an oversize file is a perf hit, never a
+      // correctness failure.
+    }
+    this.approxSize = 0;
+  }
+
+  /** Read the most-recent `limit` entries (newest last), tolerating partial/corrupt lines.
+   *  Only the last TAIL_READ_BYTES of each file are ever read, so a large log can
+   *  never be slurped whole into memory (the readFileSync-whole-file freeze). If
+   *  the current file's tail doesn't yield enough rows and a rotated `.1` backup
+   *  exists, its tail is merged so recent history survives a rotation boundary. */
+  read(limit = 200): ReapLogEntry[] {
+    const wanted = limit > 0 ? limit : Number.MAX_SAFE_INTEGER;
+    let lines = tailLines(this.logPath, this.tailReadBytes);
+    if (lines.length < wanted) {
+      // Backfill from the rotated generation (older lines first).
+      const older = tailLines(`${this.logPath}.1`, this.tailReadBytes);
+      if (older.length > 0) lines = older.concat(lines);
+    }
     const tail = limit > 0 ? lines.slice(-limit) : lines;
     const out: ReapLogEntry[] = [];
     for (const line of tail) {

--- a/tests/unit/reap-log.test.ts
+++ b/tests/unit/reap-log.test.ts
@@ -169,3 +169,94 @@ describe('ReapLog — normalizer both sides', () => {
     expect(log.read()[0].midWork).toBeUndefined();
   });
 });
+
+/**
+ * Reaper self-inflicted log-flood fix (2026-07-03): a permanently-vetoed
+ * session (open-commitment, not-lease-holder) is re-evaluated every reaper tick
+ * and used to emit an identical `skipped` row each time — 5k+ repeat rows on a
+ * live agent ⇒ a 142MB log that froze the event loop when read whole. The fix
+ * is log-on-transition + a bounded tail read + a size cap.
+ */
+describe('ReapLog — skip flood: log on transition, not every tick', () => {
+  const skip = (session: string, skipped: string, reason = 'age-limit') => ({
+    session,
+    tmuxSession: `tmux-${session}`,
+    reason,
+    skipped,
+  });
+
+  it('does NOT re-append an identical skip for the same session', () => {
+    const log = new ReapLog(stateDir);
+    for (let i = 0; i < 50; i++) log.recordSkipped(skip('tas-1', 'open-commitment'));
+    const rows = log.read().filter((r) => r.type === 'skipped');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].skipped).toBe('open-commitment');
+  });
+
+  it('appends a new row when the skip REASON transitions', () => {
+    const log = new ReapLog(stateDir);
+    log.recordSkipped(skip('tas-1', 'open-commitment'));
+    log.recordSkipped(skip('tas-1', 'open-commitment'));
+    log.recordSkipped(skip('tas-1', 'not-lease-holder')); // transition
+    log.recordSkipped(skip('tas-1', 'not-lease-holder'));
+    const rows = log.read().filter((r) => r.type === 'skipped');
+    expect(rows.map((r) => r.skipped)).toEqual(['open-commitment', 'not-lease-holder']);
+  });
+
+  it('keeps per-session dedup independent (two sessions, same reason, one row each)', () => {
+    const log = new ReapLog(stateDir);
+    log.recordSkipped(skip('tas-1', 'protected'));
+    log.recordSkipped(skip('tas-2', 'protected'));
+    log.recordSkipped(skip('tas-1', 'protected'));
+    log.recordSkipped(skip('tas-2', 'protected'));
+    const rows = log.read().filter((r) => r.type === 'skipped');
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.session).sort()).toEqual(['tas-1', 'tas-2']);
+  });
+
+  it('re-logs a skip after the session is reaped (state forgotten on reap)', () => {
+    const log = new ReapLog(stateDir);
+    log.recordSkipped(skip('tas-1', 'open-commitment'));
+    log.recordSkipped(skip('tas-1', 'open-commitment')); // deduped
+    log.recordReaped({ session: 'tas-1', tmuxSession: 'tmux-tas-1', reason: 'age-limit' });
+    log.recordSkipped(skip('tas-1', 'open-commitment')); // fresh — logs again
+    const skipRows = log.read().filter((r) => r.type === 'skipped');
+    const reapRows = log.read().filter((r) => r.type === 'reaped');
+    expect(skipRows).toHaveLength(2);
+    expect(reapRows).toHaveLength(1);
+  });
+});
+
+describe('ReapLog — bounded read + rotation (can never be slurped/grow unbounded)', () => {
+  it('read(limit) returns the last `limit` rows via a bounded tail read', () => {
+    const log = new ReapLog(stateDir);
+    for (let i = 0; i < 500; i++) {
+      log.recordReaped({ session: `s-${i}`, tmuxSession: `t-${i}`, reason: 'age-limit' });
+    }
+    const rows = log.read(10);
+    expect(rows).toHaveLength(10);
+    expect(rows[9].session).toBe('s-499');
+    expect(rows[0].session).toBe('s-490');
+  });
+
+  it('rotates to <path>.1 past the size cap and read() merges across the boundary', () => {
+    const p = path.join(tmpDir, 'logs', 'reap-log.jsonl');
+    // Tiny cap forces rotation after a few hundred bytes.
+    const log = new ReapLog(stateDir, undefined, { maxLogBytes: 400 });
+    for (let i = 0; i < 40; i++) {
+      log.recordReaped({ session: `s-${i}`, tmuxSession: `t-${i}`, reason: 'age-limit' });
+    }
+    expect(fs.existsSync(`${p}.1`)).toBe(true);
+    // Newest rows survive; read merges the rotated tail to reach older ones.
+    const rows = log.read(20);
+    expect(rows[rows.length - 1].session).toBe('s-39');
+    expect(rows.length).toBeGreaterThan(1);
+    // The live file alone is bounded well under a full 40-row file.
+    expect(fs.statSync(p).size).toBeLessThan(1000);
+  });
+
+  it('does not choke on an absent log (empty read)', () => {
+    const log = new ReapLog(stateDir);
+    expect(log.read()).toEqual([]);
+  });
+});

--- a/upgrades/next/reaper-log-flood-fix.md
+++ b/upgrades/next/reaper-log-flood-fix.md
@@ -1,0 +1,64 @@
+# Reaper log-flood fix — transition-dedup + bounded read + rotation for `reap-log.jsonl`
+
+<!-- bump: patch -->
+
+## What Changed
+
+Three self-limiting changes to `src/monitoring/ReapLog.ts` (the audit trail behind
+`GET /sessions/reap-log`) that stop the reaper from flooding — and freezing on — its own log.
+
+The reaper re-evaluates every session on each tick. When a session **can't** be reaped yet — it
+holds an open commitment, or it belongs to another machine (`not-lease-holder`), or it's
+protected — the reaper skips it and recorded a `skipped` row **every tick**. On a live agent
+that produced 3218 `open-commitment` + 1608 `not-lease-holder` **identical repeat rows** and
+grew `reap-log.jsonl` to **142MB / 463k lines** (observed 2026-07-03). Worse, `read()` did
+`fs.readFileSync(WHOLE file).split('\n')` just to return the last N rows — a 142MB slurp that
+**blocked the event loop** (~90s CPU-bound stalls) whenever the route was queried.
+
+- **Write-side transition dedup (primary cure).** `recordSkipped()` now logs on *transition*:
+  it keeps an in-memory `session → last-logged skip signature (${reason}::${skipped})` map and
+  drops a re-append when the signature is unchanged — mirroring the sibling `reaper-audit.jsonl`
+  "log on change, not every tick" discipline. State is cleared when the session is reaped
+  (`forgetSkip`) so a same-named successor logs fresh and the map can't leak (hard ceiling
+  `MAX_SKIP_STATE`, 2000, oldest-pruned). The reaper still **evaluates** every tick, so the
+  moment a veto lifts the next skip — or the reap — is logged.
+- **Read-side bounded tail.** `read()` now reads only the last `TAIL_READ_BYTES` (2MB) via a
+  positional `readSync`, drops a torn leading line, and merges the rotated `.1` tail if needed —
+  so a large log can never be slurped whole into memory again.
+- **Size-cap rotation (defense-in-depth).** `append()` rolls the file to `<path>.1` (O(1)
+  `renameSync`, no hot-path rewrite) once it crosses `MAX_LOG_BYTES` (16MB), so it can never
+  grow unbounded even if a future caller floods it.
+
+Caps are overridable via an optional `ReapLogOptions` constructor arg (defaults = the module
+constants) purely so tests can trigger rotation cheaply; the production callsite is unchanged.
+
+## Evidence
+
+- `npx vitest run tests/unit/reap-log.test.ts` → **16 tests, 0 failures** (transition-dedup:
+  identical-skip-suppressed, reason-transition-logs, per-session independence, re-log-after-reap;
+  bounded read returns correct last-N; rotation to `.1` + cross-boundary merge + live file
+  bounded; absent-file empty read).
+- `npx vitest run tests/unit/reap-log.test.ts tests/unit/session-reaper.test.ts
+  tests/unit/reap-notifier.test.ts tests/unit/reap-guard.test.ts` → **115 tests, 0 failures**
+  (reaper family regression-clean; `normalizeEntry` whitelist untouched).
+- `npx tsc --noEmit -p tsconfig.json` → **0 errors**.
+- Independent second-pass reviewer: **Concur** — observability-only, touches no kill/keep
+  decision; no operator-needed row hidden; read/rotation off-by-one-clean.
+- Side-effects review: `upgrades/side-effects/reaper-log-flood-fix.md` (8 questions +
+  signal-vs-authority + multi-machine posture + second-pass concurrence).
+
+## What to Tell Your User
+
+If your agent's server ever felt like it "froze for a minute" periodically, or your disk was
+filling up with a giant session-audit log, this is a fix for that. The background tidier that
+closes finished sessions was writing the same "couldn't clean this up yet" note thousands of
+times, and reading that log loaded the whole thing at once. Now it writes the note once and
+reads only the end of the file. Nothing you do changes — your "why did my session vanish?"
+history is still complete (the first skip, every change of reason, and every actual close are
+all still recorded); it just stops the duplicate spam and the stall it caused, and a log that's
+already huge stops growing and gets trimmed automatically.
+
+## Summary of New Capabilities
+
+None — this is a reliability fix to existing behavior, not a new capability. The session-audit
+history keeps the same shape and meaning; it's just bounded and de-duplicated now.

--- a/upgrades/side-effects/reaper-log-flood-fix.eli16.md
+++ b/upgrades/side-effects/reaper-log-flood-fix.eli16.md
@@ -1,0 +1,39 @@
+# Reaper log-flood fix — Plain-English Overview
+
+> The one-line version: the reaper was scribbling the same "couldn't clean this up" note into an audit file thousands of times a minute until the file grew to 142MB and froze the whole server when anything read it — this makes it write the note once and read the file in small bites.
+
+## The problem in one breath
+
+Every agent has a background "reaper" that tidies up finished sessions. When a session CAN'T be tidied yet (it has an open promise to the user, or it belongs to another machine), the reaper politely skips it — and writes a one-line "skipped, here's why" note to an audit log. The bug: it re-checks and re-writes that identical note on every single tick, forever. On a live agent that piled up 3,218 + 1,608 duplicate notes and grew the log to 142MB. Worse, the code that READS that log loaded the entire 142MB into memory at once, which pegged a CPU and froze the server for ~90 seconds each time.
+
+## What already exists
+
+- **The reaper** — the background tidier that decides which sessions to close. Its actual close/keep decisions are correct and are NOT changed by this work.
+- **`reap-log.jsonl`** — the "why did my session vanish?" audit trail. One line per close, one line per refused close. This is the file that ballooned.
+- **`reaper-audit.jsonl`** — a SEPARATE, sibling audit file that already does the right thing: it only writes when a decision CHANGES, not on every tick. It stayed tiny (under half a megabyte). We copy its proven habit.
+
+## What this adds
+
+The reaper's skip-note now follows the same "only write when something changed" rule its sibling already uses. If a session is skipped for the exact same reason as last time, no new note is written. The moment the reason changes — the promise closes, the session moves machines, or it finally gets reaped — a fresh note is written, so the audit trail still tells the true story with none of the spam.
+
+Two more safety belts:
+
+- **Small-bite reading** — reading the log now pulls only the last couple of megabytes off the end of the file instead of the whole thing, so even a giant log can never freeze the server again.
+- **Auto-rotation** — if the file ever crosses 16MB anyway, it's instantly rolled aside to a single backup and a fresh file is started, so it can never grow without bound. Reading transparently stitches the backup back in so recent history is never lost.
+
+## The new pieces
+
+- **Transition dedup (in-memory)** — a tiny table remembering each session's last-written skip reason. It's per-machine, capped at 2,000 entries (sessions are only ever a few dozen in practice), and forgotten the instant a session is reaped so it can't leak. It is NOT allowed to change any close/keep decision — it only decides whether a LOG LINE is worth writing.
+- **Bounded tail reader** — reads the end of the file only. It carefully drops a half-a-line at the read boundary so a torn record is never mis-parsed.
+- **Size-cap rotation** — an instant rename (no slow file rewrite) when the file gets too big.
+
+## The safeguards
+
+- The reaper's real authority — which sessions live or die — is untouched. This is purely about how much it writes and how the file is read.
+- Nothing is lost from the audit story: first-skip, every change-of-reason, and every actual reap are all still recorded. Only the identical-to-last-time repeats are dropped.
+- It's per-machine by design (each machine audits its own reaping), matching the sibling file. No cross-machine syncing to get wrong.
+- Rollback is a one-file revert with no data migration — old fat logs and new backups both read correctly through the new reader.
+
+## What you need to decide
+
+Nothing structural — this is a contained, low-risk hygiene fix with full unit-test coverage (16 focused tests; 115 reaper-family tests green). The one judgment call baked in: we accept losing the per-tick "still skipped at 12:00:01, still skipped at 12:00:02…" heartbeat in exchange for a log that doesn't self-destruct. That trade matches what the sibling audit file already chose, so it's a consistent, already-proven decision rather than a new gamble.

--- a/upgrades/side-effects/reaper-log-flood-fix.md
+++ b/upgrades/side-effects/reaper-log-flood-fix.md
@@ -1,0 +1,90 @@
+# Side-Effects Review — Reaper self-inflicted log-flood fix (ReapLog transition-dedup + bounded read + rotation)
+
+**Version / slug:** `reaper-log-flood-fix`
+**Date:** `2026-07-03`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `reviewer subagent (see appended concurrence)`
+
+## Summary of the change
+
+Three self-limiting changes to `src/monitoring/ReapLog.ts`, the append-only audit trail behind `GET /sessions/reap-log`:
+
+1. **Write-side transition dedup (primary cure).** `recordSkipped()` now logs on TRANSITION only — it keeps an in-memory `session → last-logged skip signature (${reason}::${skipped})` map and drops a re-append when the signature is unchanged. The reaper re-evaluates a permanently-vetoed session (`open-commitment`, `not-lease-holder`, `protected`) on every tick and previously appended an identical `skipped` row each time — on a live agent this produced 3218 `open-commitment` + 1608 `not-lease-holder` repeat rows and grew the log to 142MB / 463k lines (observed 2026-07-03). The dedup state is cleared when the session is reaped (`recordReaped` → `forgetSkip`) so a same-named successor logs fresh and the map cannot leak. The map has a hard ceiling (`MAX_SKIP_STATE`, default 2000, oldest-pruned).
+2. **Read-side bounded tail (fixes the freeze-on-read).** `read()` previously did `fs.readFileSync(WHOLE file).split('\n')` just to return the last `limit` rows — a 142MB slurp + split that blocked the event loop when the route was queried. It now reads only the last `TAIL_READ_BYTES` (default 2MB) of the file via a positional `readSync`, drops a leading partial line, and merges the rotated `.1` tail if the live file doesn't yield enough rows.
+3. **Size-cap rotation (defense-in-depth).** `append()` rolls the file to `<path>.1` (O(1) `renameSync`, no data rewrite on the hot path) once it would cross `MAX_LOG_BYTES` (default 16MB), so the file can never grow unbounded even if a future caller floods it. One backup generation is retained; `read()` merges it.
+
+The caps are overridable via an optional `ReapLogOptions` constructor arg (defaults = module constants) purely so tests can trigger rotation cheaply. The production callsite (`src/commands/server.ts`) is unchanged.
+
+## Decision-point inventory
+
+This change touches NO block/allow/gate decision point. `ReapLog` is a read-only observability sink — the class docstring states it "never gates or mutates a session — it only records." The reaper's keep/kill authority (`SessionManager` / `SessionReaper`) is entirely untouched; only the LOGGING cadence and READ mechanics change.
+
+- `ReapLog.recordSkipped` — modify — logs on transition instead of every tick (observability cadence only).
+- `ReapLog.read` — modify — bounded tail read instead of whole-file slurp (I/O mechanics only).
+- `ReapLog.append` — modify — adds O(1) size-cap rotation (I/O mechanics only).
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. `ReapLog` never blocks a session. The only "suppression" is of DUPLICATE LOG ROWS for an unchanged skip state, which is the intended behavior (mirrors the existing `reaper-audit.jsonl` log-on-transition pattern).
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. In audit-fidelity terms, the analogue is "what does the log no longer record?": it no longer records a fresh row for an UNCHANGED skip state on each tick. It STILL records: the first skip (transition into skipped), every change of skip reason, and every reap. A reviewer asking "is this session still being skipped?" reads the most recent skip row plus the absence of a later reap — the same answer, without 5000 duplicate rows. Loss of the per-tick "still skipped at time T" heartbeat is intentional and matches reaper-audit.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The dedup lives INSIDE `ReapLog` (the class that owns the log), so it covers every caller — not bolted onto the single `reapBlocked` event wiring in `server.ts`, which would leave other/future callers un-deduped. The read/rotation are pure file mechanics that belong on the class that owns the file. This is a detector/observability primitive, not an authority — it produces no signal consumed by any gate. It mirrors the already-shipped `reaper-audit.jsonl` transition pattern rather than inventing a new one.
+
+---
+
+## 4. Signal vs authority compliance
+
+Compliant. The change adds NO blocking authority and NO brittle decision logic in front of any gate. It is a data-sink optimization: fewer duplicate rows written, bounded bytes read. `docs/signal-vs-authority.md` governs decision points; this change has none.
+
+---
+
+## 5. Interactions
+
+- **Mirrors, does not shadow, `reaper-audit.jsonl`.** That sink already logs reaper decisions on transition; this brings `reap-log.jsonl`'s skip rows to the same discipline. They remain separate files with separate purposes.
+- **`recordReaped` → `forgetSkip` ordering.** Reap clears the skip-state so a same-named successor logs fresh. A reap for a session never previously skipped is a harmless no-op delete.
+- **No race with cleanup.** `ReapLog` is synchronous and single-process; the rotation `renameSync` is atomic. A concurrent reader mid-rotation either sees the old file (pre-rename) or the new empty file + `.1` (post-rename) — `read()` merges `.1`, so no window loses the newest rows.
+- **`normalizeEntry` untouched** — the notify/skipped/reaped type + field whitelist that other tests guard is unchanged; all 115 reaper-family unit tests pass.
+
+---
+
+## 6. External surfaces
+
+- **`GET /sessions/reap-log`** — same JSON shape, same newest-last ordering, same `limit` semantics. The only observable difference: far fewer duplicate `skipped` rows, and the route no longer blocks the event loop on a large file. No API contract change.
+- No change visible to other agents or users beyond the route above. No dependency on timing or conversation state.
+- **Pre-existing on-disk bloat is not rewritten by this change.** A file already at 142MB stays until the next rotation trims it (or an operator archives it, as was done live on 2026-07-03). The bounded READ means even a still-large file no longer freezes the loop; the write-side dedup means it stops growing.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** `reap-log.jsonl` is a per-machine audit of that machine's own reap decisions (the log path is under the machine's own `logs/`, and `GET /sessions/reap-log` already reports only the local machine's entries — pool-scope reap history is not a feature). The in-memory `skipState` dedup map is likewise per-process and correctly scoped to the machine doing the reaping. No replication, no proxied read, no cross-machine state. This matches the existing `reaper-audit.jsonl` posture. No topic-transfer, one-voice, or URL-durability concerns (it is not user-facing and generates no links).
+
+---
+
+## 8. Rollback cost
+
+Low. The change is contained to one file (`ReapLog.ts`) plus its unit tests. Back-out is a straight revert — no data migration (the on-disk format is unchanged; older whole-file logs and `.1` backups both read correctly through the new tail reader). If the transition-dedup were ever suspected of hiding a needed row, reverting restores per-tick logging immediately. No agent-state repair, no hot-fix data surgery. The caps are constructor-overridable if a deployment needs different thresholds without a code change.
+
+---
+
+## Second-pass review (independent reviewer subagent)
+
+**Concur with the review.** The change is observability-only and touches no kill/keep decision — the reaper still evaluates every tick, so the transition-dedup can never strand an operator's "why did my session vanish / not get reaped?" answer.
+
+1. **Transition-dedup:** correctly keyed on `${reason}::${skipped}`; suppresses only a byte-identical re-evaluation of the same permanent veto. Any genuine change (veto lifts → reap row always appends since `recordReaped` has no dedup; reason changes → new signature → new row) is still logged. `forgetSkip` on reap prevents both the stale-successor bug and unbounded map growth, backed by the `MAX_SKIP_STATE` oldest-first ceiling. No operator-needed row is hidden.
+2. **Bounded read:** traced the merge/tail logic — older `.1` correctly prepended to newer live, `.slice(-limit)` keeps the newest, leading partial line dropped only when `start > 0`, trailing empty line filtered, `.1` read only when live yields `< wanted`. No off-by-one, no torn record, newest row never dropped, no cross-file duplication (rename→fresh-empty-live).
+3. **Rotation:** O(1) `renameSync` off the hot path; `approxSize` seeded once then advanced per-write (no per-append stat); a pre-existing 142MB file rotates on the first append. On-disk bounded to `live (≤cap) + .1 (≤cap)` since each rotation overwrites the prior `.1`. Concurrent reader sees a consistent pre/post-rename state, both handled by `read()`.
+4. **Signal-vs-authority:** no blocking authority added; `SessionReaper`/`SessionManager` kill logic untouched; audit-sink failures swallow silently rather than perturbing behavior.
+
+No correctness defect found. Tests exercise both sides of the dedup boundary, the rotation/merge boundary, and the absent-file path. Sound to merge.


### PR DESCRIPTION
## What & why

The reaper re-logged an identical `skipped` row **every tick** for permanently-vetoed sessions (open-commitment, not-lease-holder), growing `reap-log.jsonl` to **142MB / 463k lines** on a live agent. `read()` then slurped the whole file (`readFileSync`+`split`) to return the last N rows — a synchronous 142MB read that **blocked the event loop ~90s per query**. This is a top contributor to the periodic server stalls behind user-visible flakiness (RCA topic 30837).

## The fix (ReapLog only — observability, no kill-authority change)

- **Write-side transition dedup** — `recordSkipped()` logs on *transition* (session → last `${reason}::${skipped}` signature), cleared on reap (`forgetSkip`), hard-capped map. Mirrors the sibling `reaper-audit.jsonl` log-on-change discipline. The reaper still **evaluates** every tick, so a lifted veto still produces the next skip/reap row.
- **Read-side bounded tail** — reads only the last 2MB via positional `readSync`, drops a torn leading line, merges the rotated `.1` backup.
- **Size-cap rotation** — O(1) `renameSync` to `.1` past 16MB so the file can never grow unbounded.

Caps are constructor-overridable (defaults = module constants) purely for cheap rotation tests; production callsite unchanged.

## ELI16

The reaper is the background cleaner that closes finished sessions. When a session can't be closed yet (it made a promise to the user, or it lives on another machine), the reaper skips it and writes a "skipped, here's why" note. The bug: it re-wrote that identical note on *every* check, forever — thousands of copies — until the audit file hit 142MB, and then reading that file loaded the whole 142MB at once and froze the server for ~90 seconds. This change makes it write the note only once (and again only when the reason actually changes), read just the end of the file instead of the whole thing, and auto-trim the file so it can never balloon again. The reaper's actual close/keep decisions are untouched — this is purely about how much it writes and how the file is read. Your "why did my session vanish?" history stays complete; only the identical repeats are dropped.

## Evidence

- 16 new unit tests + 115 reaper-family unit tests green; existing reap-log integration + e2e tests green (ran in pre-push gate: 83 passed).
- `tsc --noEmit` → 0 errors. Independent second-pass reviewer: **Concur** (no operator-needed row hidden; read/rotation off-by-one-clean).
- Side-effects review: `upgrades/side-effects/reaper-log-flood-fix.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)