### PR TITLE
feat(prompt-parser-contract): shared contract library + contract classification + ratchet (defect class 1, dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-03T22-59-53-209Z-prompt-parser-contract-standard.json
+++ b/.instar/instar-dev-decisions/2026-07-03T22-59-53-209Z-prompt-parser-contract-standard.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-03T22:59:53.209Z",
+  "slug": "prompt-parser-contract-standard",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 385,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "INSTAR-Bench v2 defect-class review (2026-07-02, Class 1) surfaced a latent prompt-parser drift (tone gate taught B15, parser accepts only B15_CONTEXT_DEATH_STOP). This ships the report-only inventory + shared contract library; the per-callsite contract tests + render refactor are deferred behind the A/B gate."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/prompt-parser-contract-standard.eli16.md
+++ b/docs/specs/prompt-parser-contract-standard.eli16.md
@@ -1,0 +1,65 @@
+# Prompt↔Parser Contract Standard — Plain-English Overview
+
+## The problem this closes
+
+When one of my AI checks (a "gate" or a classifier) asks a model a question, two
+things have to agree that are written in two different places. The **prompt**
+tells the model what words it's allowed to answer with — say, `PASS` or
+`B15_CONTEXT_DEATH_STOP`. The **parser** is the little piece of code that reads
+the model's answer back and decides what it means. Nothing forced those two
+halves to stay in sync.
+
+On 2026-07-02 a review of my own gates found exactly this break in the tone gate.
+The prompt taught models the *short* name `B15`. The parser only accepted the
+*full* name `B15_CONTEXT_DEATH_STOP` and threw everything else away. So every
+model, on every route, did exactly what the prompt said — answered `B15` — and
+every one of them "failed." It wasn't the models' fault at all; it was ours. One
+tiny test comparing "what the prompt promises" against "what the parser accepts"
+would have caught it before it ever shipped.
+
+## The idea in one sentence
+
+A prompt and its parser are **one contract with two halves**. If the two halves
+can drift apart silently, they eventually will — so make the drift a build
+failure instead of a hope.
+
+## What this ships (all dark / report-only)
+
+- **A shared contract library** (`src/core/promptContract.ts`). It defines the
+  shape of a co-located "promise" a callsite can carry next to its prompt, and a
+  pure helper, `deriveRejectedForms`, that *mechanically generates* the wrong
+  answers a contract test must prove the parser rejects — the case-mangled,
+  chopped-at-the-underscore, separator-stripped forms (including the exact `B15`
+  shape). Generating them by machine matters: a hand-written list of "bad
+  answers" invites lazy, trivially-wrong examples that prove nothing.
+
+- **A classification of every LLM callsite** (`LLM_PARSER_CONTRACT` in
+  `src/data/llmBenchCoverage.ts`), the `contract` sibling of the two axes the
+  earlier defect-class standards added. For each of my ~53 AI components it
+  records, with no default allowed, whether that component's answer is parsed
+  into a *closed set of taught words* (so it needs a prompt↔parser contract
+  test) or genuinely isn't (a free-text summary, a fixed self-check probe, or a
+  component with no live prompt at all — each with a written reason). Forgetting
+  to classify a new callsite fails the build, so the flag can never quietly slip
+  toward "unchecked."
+
+- **A shrink-only ratchet** (`tests/unit/parser-contract-classification-ratchet.test.ts`).
+  The four highest-stakes parsed callsites named in the spec — the tone gate, the
+  external-operation gate, the stop judge, and the input classifier — are pinned
+  as a seed set that can only *graduate* to a real contract test, never quietly
+  drop out of scope. Every other parsed callsite is pinned in a "pending" list
+  that can shrink as tests are written but can't grow silently. A cross-check
+  flags any gate or classifier marked "no contract needed" unless it's been
+  explicitly reviewed onto an allowlist.
+
+## What this deliberately does NOT do
+
+It changes **no** prompt and **no** parser. Not one live check behaves any
+differently after this merges — it is pure inventory and machinery. The actual
+per-callsite contract tests each need the real production prompt refactored into
+a clean, testable render function, and that touches live parsing code — so it's
+deferred to its own carefully-gated increments, one at a time. The constitutional
+registry text that names this a standard also waits for the operator's explicit
+sign-off. This increment is just the honest map of where the work is, plus the
+tool the future tests will use — so a taught-but-unparsed vocabulary becomes a
+red build instead of a silent, 100%-our-fault defect.

--- a/docs/specs/prompt-parser-contract-standard.md
+++ b/docs/specs/prompt-parser-contract-standard.md
@@ -1,0 +1,217 @@
+---
+title: "Prompt↔Parser Contract Standard"
+slug: "prompt-parser-contract-standard"
+author: "echo"
+parent-principle: "Structure beats Willpower"
+eli16-overview: "prompt-parser-contract-standard.eli16.md"
+status: "review-convergence (round-5 clean (codex VERIFIED CLEAN ×2 rounds on the closure; gemini VERIFIED CLEAN r4; internal consistency sweep clean))"
+tags: ["review-convergence"]
+origin: "INSTAR-Bench v2 defect-class review (docs/audits/ib2-defect-class-review-2026-07-02.md), Class 1"
+operator-gate: "Registry/constitution text ships ONLY with Justin's explicit sign-off (Constitutional Traceability). The CI ratchet build ships through the normal instar-dev pipeline."
+---
+
+# Spec — Prompt↔Parser Contract Standard (defect class 1 closure)
+
+**Ships:** standard text → standards registry (operator-gated); enforcement ratchet → CI
+(additive, shrink-only pending set, no runtime behavior change).
+
+**Run boundary (Autonomy Principle 2):** the /instar-dev run's deliverable is the live
+enforcement arm (manifests + contract tests + ratchet) plus the DRAFTED registry text.
+Operator sign-off on the registry text is the run's endpoint, not a mid-run pause.
+
+## Problem statement
+
+An LLM callsite whose output is machine-parsed is one contract with two halves maintained
+separately: the PROMPT promises an output vocabulary/shape; the PARSER accepts one. Nothing
+holds them coherent. INSTAR-Bench v2 proved the failure mode at scale: the tone gate's prompt
+taught models the short rule id ("B15") while its production parser accepts only full
+identifiers ("B15_CONTEXT_DEATH_STOP") and fails closed on the short form. Every model through
+every door obeyed the prompt and "failed" — a 100%-our-fault defect that a single CI test
+would have made unrepresentable.
+
+Standards-registry check (verified against `docs/STANDARDS-REGISTRY.md`, 2026-07-02): the
+closest standard is **Scrape/Parser Fixture Realness**, which governs the parser's INPUT side
+(prove the parser on real bytes). The prompt side of the contract — the output shape the
+prompt promises — is governed by no standard. This spec closes that gap.
+
+**Terms (external readability):** *door* = the access path to a model (CLI wrapper vs clean
+API); *route* = model + door; *ratchet* = a CI test pinning a baseline that may only
+shrink; *callsite* = one LLM decision-point in the coverage registry. (Same glossary block
+as the sibling specs.)
+
+## Proposed design
+
+### 1. The standard (registry text, operator-gated)
+
+New registry entry, working title **"The Prompt and the Parser Are One Contract"**:
+
+> Every LLM callsite whose output is machine-parsed must have a CI contract test that renders
+> the REAL production prompt, enumerates the output vocabulary AND response envelope that
+> prompt promises, and asserts the REAL production parser accepts every promised form — and
+> fail-closes on non-promised forms outside its documented alias policy. Wherever the output
+> vocabulary is enumerable, prompt, parser, and test must consume ONE exported source of
+> truth; a hand-maintained duplicate of the vocabulary is itself contract drift.
+> A prompt and its parser may only change together.
+> Earned from: the tone-gate B15 short-form defect (INSTAR-Bench v2, 2026-07-02) — every model
+> through every door obeyed a prompt whose own parser rejected what it taught.
+
+### 2. Single-source vocabulary (primary form) and the contract manifest (fallback form)
+
+**Primary — generated contract.** For enumerated-verdict callsites (gates, classifiers,
+judges with a closed verdict set), the vocabulary lives in ONE exported constant — **the
+constant is authoritative, and it is the VERDICT vocabulary, never the parser's tolerant
+accepted set** (deriving the taught set from a permissive parser would teach accidental
+permissiveness). The prompt builder interpolates its taught token list FROM that constant;
+the parser's acceptance is membership in constant ∪ documented aliases BY IMPORT; and the
+contract test asserts **set-equality** between the parser's exported accepted set and
+constant ∪ aliases — a parser quietly accepting a hidden superset (legacy alias, plantable
+verdict token) is red CI, not a latent door. A taught-but-undeclared token is then
+*structurally impossible*, not merely tested-against — this closes the manifest-gaming hole
+where a minimal declared subset passes review while the prompt teaches more. (Reviewers:
+this is deliberately the schema/enum single-sourcing pattern rather than a bespoke parallel
+artifact; for envelopes, a schema validator (zod-family) is preferred over hand regex; a
+`promptContract` object is the FALLBACK, not the preferred path.)
+
+**Form election is not self-certified:** each contract entry records
+`form: 'single-source' | 'manifest'`; a `manifest`-form entry on an enumerated-verdict
+callsite requires an X1 argued reason (registry entry, `reason` + `owner`) — "impractical"
+is a reviewed claim, not an author's private call.
+
+**Fallback — co-located manifest.** Where the prompt is prose-shaped and single-sourcing is
+impractical, the callsite co-locates a machine-readable promise with its prompt builder:
+
+```ts
+import { parseToneGateVerdict } from './toneGateParser';
+
+export const promptContract = {
+  // every terminal token/shape the prompt text tells the model to produce
+  promisedOutputs: TONE_GATE_RULE_IDS,            // prefer the shared constant even here
+  // canonical counter-examples the parser must REJECT (fail-closed proof).
+  // MECHANICALLY DERIVED from promisedOutputs (case-mutation, prefix-truncation,
+  // separator-stripping) plus hand-picked extras — a hand-only list invites trivial rejects.
+  rejectedForms: deriveRejectedForms(TONE_GATE_RULE_IDS, ['B15', '']),
+  // known-hazard shapes that must NOT appear ANYWHERE in the full rendered prompt
+  // (outside explicitly-declared negative sections — see §3.1; never scoped to the
+  // self-declared instruction surface)
+  // (the inverse-direction backstop, e.g. bare rule ids the parser rejects)
+  hazardPatterns: [/\bB\d+\b(?!_)/],
+  // the response envelope the prompt promises (JSON shape, field names, quoting rules)
+  envelope: { shape: 'json', verdictField: 'rule' },
+  // alias policy: compatibility forms the parser deliberately accepts (documented, tested)
+  acceptedAliases: [],
+  parser: parseToneGateVerdict,   // FUNCTION REFERENCE, not a string — refactor-safe
+} as const;
+```
+
+Co-location is the point: a prompt edit lands in the same file/diff as the promise, so review
+and CI see contract drift as one change.
+
+### 3. The contract test (per callsite)
+
+A unit test per callsite that:
+1. Renders the real production prompt via the real builder — **through an exported pure
+   render function taking injected config, with synthetic defaults** (no live config, no
+   secrets, no I/O in CI) — and asserts every promised token appears in the rendered
+   instruction surface AND no `hazardPatterns` match appears outside the promised set.
+   **"Instruction surface" is a declared section, not the raw string:** the render function
+   exposes section boundaries (at minimum the positive output-instruction section), and the
+   POSITIVE token assertions ("every promised token appears") run against that section — so a
+   token appearing in a counter-example, comment, or "do not output X" phrasing cannot
+   satisfy the test.
+   **The NEGATIVE hazard scan is NOT scoped to the declared surface** (round-3 material
+   finding): `hazardPatterns` runs over the FULL rendered prompt MINUS explicitly-declared
+   negative sections (counter-example / "do not output" blocks, each declared with a stated
+   reason). Scoping the hazard scan to a self-declared instruction surface would be
+   self-certification — a builder could teach a rejected vocabulary outside its declared
+   section and pass CI (the historical B15 shape: short ids taught in the rule-list section,
+   not the output-instruction sentence). Undeclared content is therefore hazard-scanned by
+   default; a declared negative section is the reviewed exception, never the other way round.
+2. Feeds each promised token, wrapped in the callsite's real response **envelope**, to the
+   REAL parser (via the manifest's function reference) and asserts acceptance — and the same
+   for each documented `acceptedAliases` entry.
+3. Feeds each derived + hand-picked `rejectedForms` entry and asserts the parser's documented
+   fail-closed behavior. The fail-closed boundary is the manifest's declared
+   normalization/alias policy — "non-promised" means outside promised ∪ aliases, so a
+   tolerant parser's deliberate compatibility forms are tested as accepted, not flagged.
+
+**Named cost honestly:** the CI runtime of these tests is negligible (pure string assembly +
+parser calls, no LLM). The dominant build cost is the render-refactor — several production
+builders are private instance methods with live deps (e.g. `MessagingToneGate`'s prompt
+builder) and need an exported pure render function. That refactor, across the in-scope
+callsites, IS the work of this spec.
+
+### 4. The ratchet (coverage enforcement)
+
+This spec does NOT mint its own registry. It extends the existing bench-coverage record
+(`src/data/llmBenchCoverage.ts` — note: `src/data/`, not `src/core/`; the ratchet commits
+landed via PRs #1321/#1329 on canonical main) with a `contract` field on the ONE shared
+per-callsite metadata record used by the whole defect-class program (see the consolidated
+schema in `class-closure-gate.md` §"Program-shared machinery"): a callsite with machine-parsed
+output either names its contract-test file or carries an argued exemption per the program's
+exemption shape (registry entry with `reason` + `owner`, landed via normal PR review — never
+free prose). **Discovery criterion:** the in-scope set is seeded from the coverage registry
+(every entry whose provider call parses output) and held complete by the same lint family
+that enforces LLM-attribution tags — a new `attribution.component` callsite without a
+coverage entry is already red; a coverage entry with parsed output and no `contract`/exemption
+field becomes red with this spec. Same graduation mechanics as wave-2/wave-3: the pending set
+is pinned in-test and can only shrink. New parsed-output callsites conform from birth
+(grandfathering covers only the seeded pending set — a one-line registry edit reverses any
+mistaken grandfather).
+
+## Decision points touched
+
+No runtime gate, route, or block changes. Two runtime-adjacent notes for honesty: (a) the
+single Frontloaded-Decision #3 runtime contract-drift warning is signal-only (never blocks a
+call) and is **deduped once per process per config-hash** — a permanently drifted config
+logs once, not per message on hot routes; (b) everything else is CI-only. The ratchet adds a
+build-time refusal (new parsed callsite without contract = red CI), in the same family as
+the live llm-attribution ratchet, riding the vitest unit suite in `ci.yml` + the husky
+pre-push hook (the established ratchet vehicle). **Discovery dependency, stated:** the
+in-scope set inherits the attribution/coverage lint's completeness — a parsed-output
+callsite missing from the coverage registry is that lint's defect to catch, and this
+standard's blind spot until it does; the dependency is named in the registry text.
+
+## Frontloaded Decisions
+
+1. **Inverse-direction check** (was Open Q1): resolved — mandatory `hazardPatterns` on
+   fallback manifests (asserted against the rendered prompt), and the primary single-source
+   form makes the inverse direction structurally moot for enumerated-verdict callsites.
+   Human prompt review additionally checks for ambiguous vocabulary instructions (recorded as
+   review guidance in the standard text, not a mechanical check).
+2. **Manifest location** (was Open Q2): co-located export (or single-source constant), with
+   the coverage-registry `contract` field as the central index in `src/data/`. No separate
+   contracts registry file.
+3. **Dynamic prompts** (was Open Q3): the contract test renders with synthetic
+   production-default config, plus one render per supported config variant that CHANGES the
+   vocabulary or envelope (a variant that cannot be covered carries an X1 argued exemption
+   naming why). Because config-assembled vocabulary is external-state parsing (Lesson L5:
+   drift needs a canary, not a hope), single-sourced callsites ALSO get a cheap runtime
+   assertion at prompt-build time: if live config yields a taught vocabulary outside the
+   shared constant, the callsite logs a loud contract-drift warning (signal-only — never
+   blocks; deduped once per process per config-hash). By-construction single-sourcing is the
+   preferred answer: config that references the exported vocabulary cannot drift at all.
+4. **Exemption shape** (program-wide X1): an exemption is a registry entry with `reason` +
+   `owner`, landed via normal PR review. Free-text prose outside the registry is not an
+   exemption.
+5. **Immediate CI refusal for new callsites** (contested cheap tag — cleared): shrink-only
+   pending set grandfathers existing callsites; only genuinely-new parsed callsites fail,
+   and a registry edit is the one-line reversal. CI-only; nothing in the non-cheap taxonomy.
+
+## Rollout
+
+0. Export the shared vocabulary constants / pure render functions for the 4 highest-stakes
+   parsed callsites (tone gate, external-op gate, stop judge, input classifier — the
+   shipped-fix set). This is also the prompt-fidelity foundation the A/B protocol needs
+   (see `authority-clause-standard.md` rollout — the bench template is diffed against this
+   same render output before any A/B verdict counts).
+1. Contract tests + `contract` field entries for those 4; ratchet lands with the seeded
+   pending set (report-only inventory happens by construction — the pending set IS the
+   report).
+2. Remaining parsed callsites graduate on the shrink-only schedule.
+3. Registry text ships last, with operator sign-off, citing the live ratchet as its
+   enforcement arm (a standard should point at a guard that already exists — per the
+   Standards Enforcement Coverage audit's `ratchet > gate > lint > spec-only` hierarchy).
+
+## Open questions
+
+*(none — all resolved into Frontloaded Decisions above)*

--- a/src/core/promptContract.ts
+++ b/src/core/promptContract.ts
@@ -1,0 +1,185 @@
+/**
+ * Shared prompt↔parser contract library — the mechanical arm of the
+ * "The Prompt and the Parser Are One Contract" standard (defect class 1 closure;
+ * docs/specs/prompt-parser-contract-standard.md).
+ *
+ * WHY THIS EXISTS (earned): on 2026-07-02 the INSTAR-Bench v2 defect-class
+ * review found the tone gate's PROMPT taught models the short rule id ("B15")
+ * while its production PARSER accepts only the full identifier
+ * ("B15_CONTEXT_DEATH_STOP") and fails closed on the short form. Every model
+ * through every door obeyed the prompt and "failed" — a 100%-our-fault defect.
+ * An LLM callsite whose output is machine-parsed is ONE contract with TWO halves
+ * maintained separately: the prompt promises an output vocabulary/shape; the
+ * parser accepts one. Nothing held them coherent. This module gives that
+ * contract a code artifact — the type of a co-located promise, and a pure
+ * generator for the counter-examples a contract test must prove the parser
+ * REJECTS — so a taught-but-unparsed vocabulary becomes a CI failure instead of
+ * a latent door.
+ *
+ * SCOPE HONESTY (design §2): the PREFERRED form for an enumerated-verdict
+ * callsite is single-sourcing — prompt, parser, and test all consume ONE
+ * exported verdict constant, which makes a taught-but-undeclared token
+ * structurally impossible. The `PromptContract` manifest below is the FALLBACK
+ * form for prose-shaped prompts where single-sourcing is impractical (a reviewed
+ * claim per spec §2, not an author's private call). This module ships DARK: it
+ * introduces no runtime caller and changes NO live prompt or parser behavior.
+ * It is consumed only by the per-callsite CONTRACT TESTS that graduate on the
+ * shrink-only schedule (rollout §1/§2) — each of which renders the REAL
+ * production prompt through an exported pure render function; that render
+ * refactor of the live builders is deferred to its own A/B-gated increments and
+ * is NOT part of this dark increment.
+ */
+
+/**
+ * The election of a contract's form, recorded per coverage entry (spec §2:
+ * "Form election is not self-certified"). A `manifest`-form entry on an
+ * enumerated-verdict callsite requires an X1 argued reason in the registry.
+ */
+export type ContractForm = 'single-source' | 'manifest';
+
+/**
+ * The co-located machine-readable promise for a prose-shaped (fallback-form)
+ * callsite. Co-location is the point (spec §2): a prompt edit lands in the same
+ * file/diff as the promise, so review and CI see contract drift as ONE change.
+ *
+ * The `parser` is a FUNCTION REFERENCE, never a string — refactor-safe (spec §2).
+ * A parser returning a non-null/defined value for an input is treated as
+ * "accepted"; the contract test decides acceptance semantics per callsite.
+ */
+export interface PromptContract<TAccepted = unknown> {
+  /**
+   * Every terminal token/shape the prompt text tells the model to produce.
+   * Prefer the shared verdict constant even here (spec §2).
+   */
+  readonly promisedOutputs: readonly string[];
+  /**
+   * Canonical counter-examples the parser must REJECT (fail-closed proof).
+   * MECHANICALLY DERIVED from `promisedOutputs` via `deriveRejectedForms`
+   * (case-mutation, prefix-truncation, separator-stripping) plus hand-picked
+   * extras — a hand-only list invites trivial rejects (spec §2).
+   */
+  readonly rejectedForms: readonly string[];
+  /**
+   * Known-hazard shapes that must NOT appear anywhere in the full rendered
+   * prompt outside explicitly-declared negative sections (spec §3.1) — the
+   * inverse-direction backstop (e.g. bare rule ids the parser rejects).
+   */
+  readonly hazardPatterns: readonly RegExp[];
+  /**
+   * The response envelope the prompt promises (JSON shape, field names).
+   */
+  readonly envelope: { readonly shape: 'json' | 'text'; readonly verdictField?: string };
+  /**
+   * Compatibility forms the parser DELIBERATELY accepts (documented, tested).
+   * "non-promised" for the fail-closed test means outside promised ∪ aliases.
+   */
+  readonly acceptedAliases: readonly string[];
+  /** The REAL production parser, by reference. */
+  readonly parser: (raw: string) => TAccepted;
+}
+
+/**
+ * Options for {@link deriveRejectedForms}.
+ */
+export interface DeriveRejectedFormsOptions {
+  /**
+   * The separator characters whose stripping/truncation produces a rejected
+   * form. Defaults to `_`, `-`, and a space — the separators that produced the
+   * historical B15 defect ("B15_CONTEXT_DEATH_STOP" → "B15").
+   */
+  readonly separators?: readonly string[];
+}
+
+/**
+ * Toggle a token's letter case in the three ways a lenient model most often
+ * mutates a taught identifier: all-upper, all-lower, and first-letter-flipped.
+ * Purely mechanical — no locale assumptions beyond JS default casing.
+ */
+function caseMutations(token: string): string[] {
+  const out = new Set<string>();
+  out.add(token.toUpperCase());
+  out.add(token.toLowerCase());
+  if (token.length > 0) {
+    const first = token[0];
+    const flippedFirst =
+      first === first.toUpperCase() ? first.toLowerCase() : first.toUpperCase();
+    out.add(flippedFirst + token.slice(1));
+  }
+  return [...out];
+}
+
+/**
+ * Prefix-truncations at each separator boundary — the exact B15 shape: the
+ * model emits the leading segment ("B15") of a compound identifier
+ * ("B15_CONTEXT_DEATH_STOP") that the parser rejects.
+ */
+function prefixTruncations(token: string, separators: readonly string[]): string[] {
+  const out = new Set<string>();
+  for (const sep of separators) {
+    if (!sep) continue;
+    const idx = token.indexOf(sep);
+    if (idx > 0) out.add(token.slice(0, idx));
+  }
+  return [...out];
+}
+
+/**
+ * Separator-stripped forms — the same token with each separator removed
+ * ("B15_CONTEXT_DEATH_STOP" → "B15CONTEXTDEATHSTOP").
+ */
+function separatorStripped(token: string, separators: readonly string[]): string[] {
+  const out = new Set<string>();
+  for (const sep of separators) {
+    if (!sep) continue;
+    if (token.includes(sep)) out.add(token.split(sep).join(''));
+  }
+  return [...out];
+}
+
+/**
+ * Mechanically derive the canonical counter-examples a contract test feeds the
+ * REAL parser to prove its documented fail-closed behavior (spec §2/§3.3).
+ *
+ * For each promised token it produces: case-mutations, prefix-truncations at
+ * each separator, and separator-stripped forms. `extras` (hand-picked shapes,
+ * e.g. the literal short id `B15` and the empty string) are appended. The
+ * result EXCLUDES any form that collides with a genuinely-promised token — a
+ * mutation that equals a real promised output is NOT a rejected form (that would
+ * make the fail-closed assertion contradict the acceptance assertion). The
+ * output is de-duplicated and stably ordered.
+ *
+ * Pure and side-effect-free. It touches no live parser and reads no I/O.
+ *
+ * @param vocabulary the promised output vocabulary (the taught verdict tokens).
+ * @param extras hand-picked additional rejected forms (spec §2: a hand-only
+ *   list invites trivial rejects, so this AUGMENTS the derived set).
+ * @param options separator configuration (defaults to `_ - <space>`).
+ * @returns the derived + hand-picked rejected forms, minus any that collide
+ *   with a promised token, de-duplicated and stably ordered.
+ */
+export function deriveRejectedForms(
+  vocabulary: readonly string[],
+  extras: readonly string[] = [],
+  options: DeriveRejectedFormsOptions = {},
+): string[] {
+  const separators = options.separators ?? ['_', '-', ' '];
+  const promised = new Set(vocabulary);
+  const derived: string[] = [];
+  for (const token of vocabulary) {
+    if (typeof token !== 'string' || token.length === 0) continue;
+    derived.push(
+      ...caseMutations(token),
+      ...prefixTruncations(token, separators),
+      ...separatorStripped(token, separators),
+    );
+  }
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const form of [...derived, ...extras]) {
+    if (promised.has(form)) continue; // a real promised token is never a "rejected form"
+    if (seen.has(form)) continue;
+    seen.add(form);
+    out.push(form);
+  }
+  return out;
+}

--- a/src/data/llmBenchCoverage.ts
+++ b/src/data/llmBenchCoverage.ts
@@ -360,3 +360,203 @@ export const LLM_JUDGES_CLAIMS: Readonly<Record<string, JudgesClaimsFlag>> = {
   CartographerSweep: false, // authors doc-tree summaries over code
   StandardsCoverageEnrichment: false, // enriches standards-coverage rows
 };
+
+// ───────────────────────────────────────────────────────────────────────────
+// Prompt↔parser contract standard (defect class 1 — docs/specs/prompt-parser-
+// contract-standard.md §4)
+//
+// The `contract` axis of the program's shared per-callsite metadata record
+// (class-closure-gate.md §"Program-shared machinery"). It co-locates in THIS
+// file with the bench-coverage record it extends, exactly like the sibling
+// `untrustedInput` (authority-clause) and `judgesClaims` (evidence-bar) axes.
+//
+// THE FIELD IS REQUIRED AND EXPLICIT FOR EVERY COMPONENT_CATEGORY KEY — there is
+// NO DEFAULT. A callsite whose output is machine-parsed into a CLOSED, taught
+// verdict/decision vocabulary (the B15 failure surface: prompt teaches "B15",
+// parser accepts only "B15_CONTEXT_DEATH_STOP") either NAMES its contract-test
+// file (`{ contractTest: '<path>' }`, covered) or is queued in the shrink-only
+// pending set (`{ pending: 'contract-wave-1' | 'contract-wave-2' }`). A callsite
+// with NO such closed-vocabulary parse — no live LLM prompt, a fixed canary, or
+// free-text / open-set CONTENT consumed as data (summaries, extractions,
+// syntheses, briefs, reviews, open-set id routing) — is `{ false: '<reason>' }`
+// and pinned shrink-only in
+// tests/unit/parser-contract-classification-ratchet.test.ts. A silent omission
+// is red CI, so the flag can NEVER default toward the un-contracted state.
+//
+// POLARITY (spec §3: "Undeclared content is hazard-scanned by default"): the
+// default pulls TOWARD "needs a contract" — a callsite is `false` only with an
+// argued reason, exactly like the sibling `untrustedInput` axis defaults toward
+// `true`.
+//
+// WAVE-1 is the spec-named SHIPPED-FIX set (rollout §0/§1): the four
+// highest-stakes parsed callsites — MessagingToneGate (the motivating B15
+// defect), ExternalOperationGate, CompletionEvaluator (stop-judge), and
+// InputClassifier. It is pinned as a seed floor in the ratchet so a
+// highest-stakes callsite can never silently slip out of scope. WAVE-2 is every
+// other enumerated-verdict/decision callsite, graduating on the shrink-only
+// schedule (rollout §2).
+//
+// DARK / REPORT-ONLY: this record is build-time metadata read ONLY by the new
+// pinned ratchet. Nothing here is a contract test yet (those render the REAL
+// production prompt and need the live-builder render refactor, deferred to its
+// own A/B-gated increments — spec rollout §0/§1). The pending set IS the report
+// (spec §4: "report-only inventory happens by construction").
+//
+// A cross-check lint flags any GATE/SENTINEL-category callsite marked `false`
+// for review (these categories most often parse a verdict) — see the ratchet's
+// REVIEWED_FALSE_PARSER_GATE pin.
+// ───────────────────────────────────────────────────────────────────────────
+
+export type ParserContractFlag =
+  | { contractTest: string }
+  | { pending: 'contract-wave-1' | 'contract-wave-2' }
+  | { false: string };
+
+export const LLM_PARSER_CONTRACT: Readonly<Record<string, ParserContractFlag>> = {
+  // ── WAVE-1: the four spec-named highest-stakes parsed callsites (rollout §0) ──
+  MessagingToneGate: { pending: 'contract-wave-1' }, // THE motivating defect: prompt taught "B15", parser accepts only "B15_CONTEXT_DEATH_STOP"
+  ExternalOperationGate: { pending: 'contract-wave-1' }, // parses a closed mutability/reversibility classification
+  CompletionEvaluator: { pending: 'contract-wave-1' }, // the stop-judge surface parses a closed done/blocked/continue verdict
+  InputClassifier: { pending: 'contract-wave-1' }, // parses a closed auto-approve vs relay decision
+
+  // ── WAVE-2: every other enumerated-verdict / decision callsite (rollout §2) ──
+  MessageSentinel: { pending: 'contract-wave-2' }, // closed intent set (pause / emergency / normal)
+  LLMSanitizer: { pending: 'contract-wave-2' }, // parses a closed sanitize verdict/decision
+  WarrantsReplyGate: { pending: 'contract-wave-2' }, // closed should-reply yes/no verdict
+  InputGuard: { pending: 'contract-wave-2' }, // closed input-coherence verdict
+  StallTriageNurse: { pending: 'contract-wave-2' }, // closed stall-triage diagnosis label
+  CommitmentSentinel: { pending: 'contract-wave-2' }, // closed commitment-detected verdict + structured envelope
+  PresenceProxy: { pending: 'contract-wave-2' }, // closed tier-3 stall verdict
+  ProjectDriftChecker: { pending: 'contract-wave-2' }, // closed on-project verdict
+  TemporalCoherenceChecker: { pending: 'contract-wave-2' }, // closed temporal-coherence verdict
+  SessionWatchdog: { pending: 'contract-wave-2' }, // closed stuck verdict
+  ResumeQueueDrainer: { pending: 'contract-wave-2' }, // closed resume-sanity verdict
+  TopicIntentArcCheck: { pending: 'contract-wave-2' }, // closed arc-check classification label
+  TelegramAdapter: { pending: 'contract-wave-2' }, // stall-confirm — closed genuinely-stalled verdict
+  SlackAdapter: { pending: 'contract-wave-2' }, // stall-confirm (byte-identical prompt to Telegram's; parity)
+  PromptGate: { pending: 'contract-wave-2' }, // closed injection-detected verdict
+  UnjustifiedStopGate: { pending: 'contract-wave-2' }, // closed stop-justified verdict
+  OverrideDetector: { pending: 'contract-wave-2' }, // closed override-intent verdict
+  TaskClassifier: { pending: 'contract-wave-2' }, // closed task-type label set
+  ResumeValidator: { pending: 'contract-wave-2' }, // closed resume-UUID match yes/no verdict
+  CoherenceReviewer: { pending: 'contract-wave-2' }, // gate-triage — closed coherence verdict
+
+  // ── Argued false (pinned shrink-only) — no closed-vocabulary verdict parse ──
+  // No live LLM callsite, a fixed canary, or free-text / open-set content.
+  InputDetector: {
+    false:
+      'attribution-manifest alias only (a legacy prompt-pattern matcher); the live matcher calls with attribution PromptGate, contracted there',
+  },
+  SessionActivitySentinel: {
+    false:
+      'authors a free-text activity DIGEST — the product is prose, not a closed verdict vocabulary a prompt teaches and a parser gates on',
+  },
+  PromiseBeacon: {
+    false:
+      'no live LLM prompt — generateStatusLine/classifyProgress hooks are unwired at the construction site; nothing parses a taught vocabulary (matches its bench-coverage exemption)',
+  },
+  InteractivePoolCanaryJudge: {
+    false:
+      'judges a FIXED known-answer canary probe — the expected output is a constant, so the canary is its own contract; a prompt↔parser contract test would re-test the same constant',
+  },
+  SessionSummarySentinel: {
+    false:
+      'extracts task/phase/files as open-set free-text FIELDS — there is no closed taught verdict vocabulary, so the B15 prompt↔parser drift cannot arise here',
+  },
+  AutoApprover: {
+    false:
+      'mechanical key injection + audit logging, no LLM prompt of its own; the upstream parsed decision is InputClassifier.classify(), contracted there',
+  },
+  IntegrationGate: {
+    false:
+      'no LLM prompt of its own — delegates to JobReflector.reflect(); zero LLM-provider callsites of its own that parse a taught vocabulary',
+  },
+  CoherenceGate: {
+    false:
+      'no callsite carries attribution CoherenceGate — all LLM calls flow through CoherenceReviewer.callApi(), contracted there',
+  },
+  JobReflector: {
+    false:
+      'reflection produces free-text content over a job — no closed taught verdict vocabulary a parser gates on (its own bench coverage is wave-3)',
+  },
+  crossModelReviewer: {
+    false:
+      'produces a free-text review of a SPEC document — no closed output vocabulary the prompt teaches and a parser must accept',
+  },
+  SelfKnowledgeTree: {
+    false:
+      'extracts self-knowledge tree fragments as content that is stored/merged — no closed verdict token gates a branch on a taught vocabulary',
+  },
+  TreeTriage: {
+    false:
+      'triages knowledge-tree fragments into content — no closed taught output vocabulary a parser must accept or reject',
+  },
+  TopicSummarizer: {
+    false:
+      'produces a free-text topic summary — the prose is the product; there is no closed vocabulary the prompt teaches and a parser gates on',
+  },
+  ContextualEvaluator: {
+    false:
+      'evaluates context relevance into content — no closed taught verdict vocabulary that a parser accepts a promised form of',
+  },
+  RelationshipManager: {
+    false:
+      'extracts relationship facts as open-set structured content — no closed taught vocabulary a prompt promises and a parser gates on',
+  },
+  StandardsConformanceReviewer: {
+    false:
+      'reviews artifact-vs-standard conformance as content — no closed output vocabulary the prompt teaches and a parser must accept',
+  },
+  DiscoveryEvaluator: {
+    false:
+      'evaluates serendipity discoveries into content — no closed taught verdict vocabulary a parser accepts a promised form of',
+  },
+  Usher: {
+    false:
+      'routes a turn to candidate TOPIC IDS — an OPEN, machine-supplied set, not a closed taught vocabulary the prompt fixes and a parser gates on',
+  },
+  TopicIntentExtractor: {
+    false:
+      'extracts a topic-intent description from a turn — free-text content, not a closed taught verdict vocabulary a parser accepts',
+  },
+  PreCompactionFlush: {
+    false:
+      'extracts durable facts before compaction as free-text content — no closed taught output vocabulary a parser gates on',
+  },
+  TreeSynthesis: {
+    false:
+      'synthesizes knowledge fragments into a free-text answer — the prose is the product, no closed taught verdict vocabulary a parser accepts',
+  },
+  LLMConflictResolver: {
+    false:
+      'resolves divergent multi-machine state into a merged value/content — no closed taught verdict vocabulary a prompt promises and a parser gates on',
+  },
+  openConversationBrief: {
+    false:
+      'generates a free-text A2A conversation brief — the prose is the product, no closed output vocabulary the prompt teaches and a parser must accept',
+  },
+  'a2a-checkin': {
+    false:
+      'summarizes A2A check-in threads into free-text content — no closed taught verdict vocabulary a parser accepts a promised form of',
+  },
+  'correction-learning': {
+    false:
+      'distills recurring corrections into a preference (content) — no closed taught output vocabulary a parser gates on',
+  },
+  'mentor-stage-b': {
+    false:
+      'classifies mentor signals over mentee output into differential content — no closed taught verdict vocabulary a parser gates on (its own bench coverage is wave-3)',
+  },
+  PipeSessionSpawner: {
+    false:
+      'spawns sessions from task descriptions — no LLM output parsed into a closed taught verdict vocabulary',
+  },
+  CartographerSweep: {
+    false:
+      'authors doc-tree summaries over code as free text — the prose is the product, no closed taught output vocabulary a parser gates on',
+  },
+  StandardsCoverageEnrichment: {
+    false:
+      'enriches standards-coverage rows with content — no closed taught verdict vocabulary a prompt promises and a parser accepts',
+  },
+};

--- a/tests/unit/parser-contract-classification-ratchet.test.ts
+++ b/tests/unit/parser-contract-classification-ratchet.test.ts
@@ -1,0 +1,242 @@
+/**
+ * parser-contract classification ratchet — the test-side enforcement of the
+ * Prompt↔Parser Contract standard's classification
+ * (docs/specs/prompt-parser-contract-standard.md §4).
+ *
+ * Guarantees, structurally:
+ *   1. EVERY LLM component in COMPONENT_CATEGORY carries an EXPLICIT `contract`
+ *      classification — there is NO default (same polarity rule as the sibling
+ *      `untrustedInput` and `judgesClaims` axes). A new LLM callsite that forgets
+ *      to classify its prompt↔parser contract story fails CI (a silent omission
+ *      can never default toward the un-contracted state).
+ *   2. No dangling entries (classification keys must name real components).
+ *   3. The WAVE-1 seed set (the four spec-named highest-stakes parsed callsites)
+ *      is pinned EXACTLY — a highest-stakes callsite can never silently slip out
+ *      of scope, and it may only GRADUATE to a named contract test (which removes
+ *      it from the pending set), never be re-labelled away.
+ *   4. The pending set (wave-1 ∪ wave-2) is pinned SHRINK-ONLY: you may graduate
+ *      an entry to `{ contractTest }` (a shrink) but cannot ADD a pending entry
+ *      without editing this pinned baseline — a visible, reviewed act.
+ *   5. The argued-FALSE set is pinned SHRINK-ONLY and each false argues a real
+ *      reason (>= 40 chars — a lazy "n/a" is refused), exactly like the
+ *      bench-coverage exemptions.
+ *   6. CROSS-CHECK: any gate/sentinel-category callsite marked `false` must be on
+ *      the reviewed allowlist. A NEW false in a gate/sentinel category (the
+ *      categories most likely to parse a closed verdict vocabulary) fails until
+ *      it is added to the pinned allowlist — a visible, reviewed act (spec §4).
+ *
+ * Ships DARK/report-only: it wires no runtime gate; it is a pinned-baseline
+ * ratchet in the same family as llm-bench-coverage-ratchet and the sibling
+ * untrusted-input / judges-claims classification ratchets.
+ */
+import { describe, it, expect } from 'vitest';
+import { COMPONENT_CATEGORY } from '../../src/core/componentCategories.js';
+import {
+  LLM_PARSER_CONTRACT,
+  type ParserContractFlag,
+} from '../../src/data/llmBenchCoverage.js';
+
+function isArguedFalse(v: ParserContractFlag): v is { false: string } {
+  return typeof v === 'object' && v !== null && 'false' in v;
+}
+function isPending(v: ParserContractFlag): v is { pending: 'contract-wave-1' | 'contract-wave-2' } {
+  return typeof v === 'object' && v !== null && 'pending' in v;
+}
+
+// ── Pinned WAVE-1 seed (spec §0/§1): the four highest-stakes parsed callsites.
+// A wave-1 entry may only GRADUATE to a named contract test (removing it from
+// this pending list); it can never be re-labelled `false` or dropped silently. ──
+const WAVE1_SEED = [
+  'MessagingToneGate',
+  'ExternalOperationGate',
+  'CompletionEvaluator',
+  'InputClassifier',
+].sort();
+
+// ── Pinned PENDING baseline (2026-07-02). SHRINK-ONLY: graduating an entry to
+// `{ contractTest }` removes it here; ADDING a pending entry means a new parsed
+// callsite — argue it in src/data/llmBenchCoverage.ts AND add it here (a visible,
+// reviewed act). ──
+const PENDING_BASELINE = [
+  // wave-1
+  'MessagingToneGate',
+  'ExternalOperationGate',
+  'CompletionEvaluator',
+  'InputClassifier',
+  // wave-2
+  'MessageSentinel',
+  'LLMSanitizer',
+  'WarrantsReplyGate',
+  'InputGuard',
+  'StallTriageNurse',
+  'CommitmentSentinel',
+  'PresenceProxy',
+  'ProjectDriftChecker',
+  'TemporalCoherenceChecker',
+  'SessionWatchdog',
+  'ResumeQueueDrainer',
+  'TopicIntentArcCheck',
+  'TelegramAdapter',
+  'SlackAdapter',
+  'PromptGate',
+  'UnjustifiedStopGate',
+  'OverrideDetector',
+  'TaskClassifier',
+  'ResumeValidator',
+  'CoherenceReviewer',
+].sort();
+
+// ── Pinned argued-FALSE baseline (2026-07-02). SHRINK-ONLY: flipping a false to
+// a pending/contract entry removes it here; ADDING a name means you are declaring
+// a component has NO closed-vocabulary verdict parse — argue the reason in
+// src/data/llmBenchCoverage.ts AND add it here (a visible, reviewed act). ──
+const ARGUED_FALSE_BASELINE = [
+  'InputDetector',
+  'SessionActivitySentinel',
+  'PromiseBeacon',
+  'InteractivePoolCanaryJudge',
+  'SessionSummarySentinel',
+  'AutoApprover',
+  'IntegrationGate',
+  'CoherenceGate',
+  'JobReflector',
+  'crossModelReviewer',
+  'SelfKnowledgeTree',
+  'TreeTriage',
+  'TopicSummarizer',
+  'ContextualEvaluator',
+  'RelationshipManager',
+  'StandardsConformanceReviewer',
+  'DiscoveryEvaluator',
+  'Usher',
+  'TopicIntentExtractor',
+  'PreCompactionFlush',
+  'TreeSynthesis',
+  'LLMConflictResolver',
+  'openConversationBrief',
+  'a2a-checkin',
+  'correction-learning',
+  'mentor-stage-b',
+  'PipeSessionSpawner',
+  'CartographerSweep',
+  'StandardsCoverageEnrichment',
+].sort();
+
+// ── Pinned REVIEWED-false gate/sentinel allowlist. A gate or sentinel marked
+// `false` is the highest-risk classification (these categories most often parse
+// a closed verdict vocabulary), so each must be explicitly reviewed onto this
+// list. A new gate/sentinel false NOT here fails the cross-check until reviewed. ──
+const REVIEWED_FALSE_PARSER_GATE = [
+  'InputDetector', // sentinel — attribution alias, live matcher is PromptGate
+  'SessionActivitySentinel', // sentinel — free-text activity digest
+  'PromiseBeacon', // sentinel — no live LLM prompt
+  'InteractivePoolCanaryJudge', // sentinel — fixed canary constant
+  'SessionSummarySentinel', // sentinel — open-set free-text fields, no closed vocabulary
+  'AutoApprover', // gate — no LLM prompt of its own
+  'IntegrationGate', // gate — delegates, no own callsite
+  'CoherenceGate', // gate — flows through CoherenceReviewer
+].sort();
+
+describe('parser-contract classification ratchet', () => {
+  it('every COMPONENT_CATEGORY key has an EXPLICIT contract classification (no default)', () => {
+    const missing = Object.keys(COMPONENT_CATEGORY).filter((k) => !(k in LLM_PARSER_CONTRACT));
+    expect(
+      missing,
+      `LLM component(s) with no contract classification: ${missing.join(', ')}.\n` +
+        'Add each to LLM_PARSER_CONTRACT in src/data/llmBenchCoverage.ts as ' +
+        '`{ pending: "contract-wave-2" }` (its output is machine-parsed into a closed verdict ' +
+        'vocabulary — ALSO add it to PENDING_BASELINE in this test) or ' +
+        '`{ false: "<argued reason>" }` (no closed-vocabulary parse — ALSO add it to ' +
+        'ARGUED_FALSE_BASELINE). prompt-parser-contract-standard.md §4.',
+    ).toEqual([]);
+  });
+
+  it('no dangling classification entries (keys must exist in COMPONENT_CATEGORY)', () => {
+    const dangling = Object.keys(LLM_PARSER_CONTRACT).filter((k) => !(k in COMPONENT_CATEGORY));
+    expect(dangling, `classification entries for unknown components: ${dangling.join(', ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('the WAVE-1 seed set is pinned as contract-wave-1 exactly (highest-stakes cannot slip scope)', () => {
+    const actualWave1 = Object.entries(LLM_PARSER_CONTRACT)
+      .filter(([, v]) => isPending(v) && (v as { pending: string }).pending === 'contract-wave-1')
+      .map(([k]) => k)
+      .sort();
+    expect(
+      actualWave1,
+      'The wave-1 seed (the four spec-named highest-stakes parsed callsites) drifted. A wave-1 ' +
+        'callsite may only GRADUATE to a named { contractTest } (removing it here); it can never ' +
+        'be re-labelled or dropped. prompt-parser-contract-standard.md §0/§1.',
+    ).toEqual(WAVE1_SEED);
+  });
+
+  it('the pending set matches the pinned shrink-only baseline exactly', () => {
+    const actualPending = Object.entries(LLM_PARSER_CONTRACT)
+      .filter(([, v]) => isPending(v))
+      .map(([k]) => k)
+      .sort();
+    expect(
+      actualPending,
+      'The pending set drifted from the pinned baseline. Graduating a pending→{ contractTest } is ' +
+        'a shrink (remove it from PENDING_BASELINE); adding a new pending entry requires editing ' +
+        'this pinned baseline — a visible, reviewed act.',
+    ).toEqual(PENDING_BASELINE);
+  });
+
+  it('the argued-FALSE set matches the pinned shrink-only baseline exactly', () => {
+    const actualFalse = Object.entries(LLM_PARSER_CONTRACT)
+      .filter(([, v]) => isArguedFalse(v))
+      .map(([k]) => k)
+      .sort();
+    expect(
+      actualFalse,
+      'The argued-false set drifted from the pinned baseline. Flipping a false→pending/contract is ' +
+        'a shrink (remove it from ARGUED_FALSE_BASELINE); adding a new false requires editing this ' +
+        'pinned baseline — a visible, reviewed act.',
+    ).toEqual(ARGUED_FALSE_BASELINE);
+  });
+
+  it('every argued-false carries a real reason (>= 40 chars)', () => {
+    const lazy = Object.entries(LLM_PARSER_CONTRACT)
+      .filter(([, v]) => isArguedFalse(v))
+      .filter(([, v]) => (v as { false: string }).false.trim().length < 40)
+      .map(([k]) => k);
+    expect(lazy, `argued-false entries with a too-short reason: ${lazy.join(', ')}`).toEqual([]);
+  });
+
+  it('every pending entry names a valid wave', () => {
+    const bad = Object.entries(LLM_PARSER_CONTRACT)
+      .filter(([, v]) => isPending(v))
+      .filter(([, v]) => {
+        const w = (v as { pending: string }).pending;
+        return w !== 'contract-wave-1' && w !== 'contract-wave-2';
+      })
+      .map(([k]) => k);
+    expect(bad, `pending entries with an invalid wave: ${bad.join(', ')}`).toEqual([]);
+  });
+
+  it('cross-check: every gate/sentinel marked false is on the reviewed allowlist', () => {
+    const unreviewed = Object.entries(LLM_PARSER_CONTRACT)
+      .filter(([, v]) => isArguedFalse(v))
+      .map(([k]) => k)
+      .filter((k) => COMPONENT_CATEGORY[k] === 'sentinel' || COMPONENT_CATEGORY[k] === 'gate')
+      .filter((k) => !REVIEWED_FALSE_PARSER_GATE.includes(k));
+    expect(
+      unreviewed,
+      `gate/sentinel component(s) marked contract:false without review: ${unreviewed.join(', ')}.\n` +
+        'A gate or sentinel that does NOT parse a closed verdict vocabulary is the highest-risk ' +
+        'classification. Add it to REVIEWED_FALSE_PARSER_GATE in this test after confirming it ' +
+        'genuinely has no live callsite parsing a taught output vocabulary.',
+    ).toEqual([]);
+  });
+
+  it('the reviewed allowlist has no stale entries (allowlisted names are actually false gates/sentinels)', () => {
+    const stale = REVIEWED_FALSE_PARSER_GATE.filter((k) => {
+      const v = LLM_PARSER_CONTRACT[k];
+      const cat = COMPONENT_CATEGORY[k];
+      return !(v && isArguedFalse(v) && (cat === 'sentinel' || cat === 'gate'));
+    });
+    expect(stale, `stale reviewed-allowlist entries: ${stale.join(', ')}`).toEqual([]);
+  });
+});

--- a/tests/unit/promptContract.test.ts
+++ b/tests/unit/promptContract.test.ts
@@ -1,0 +1,114 @@
+/**
+ * promptContract library tests — the pure contract-manifest helpers of the
+ * Prompt↔Parser Contract standard (docs/specs/prompt-parser-contract-standard.md).
+ *
+ * These cover `deriveRejectedForms`, the mechanical generator for the
+ * counter-examples a per-callsite contract test feeds the REAL parser to prove
+ * its fail-closed behavior. The generator is the anti-gaming arm of the standard
+ * (spec §2: "a hand-only list invites trivial rejects"), so its mutation logic —
+ * the exact B15 prefix-truncation shape included — is pinned here.
+ *
+ * Dark-by-construction: the library has no runtime caller in this increment; it
+ * is exercised only by these tests and, later, by the per-callsite contract
+ * tests that graduate on the shrink-only schedule.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  deriveRejectedForms,
+  type PromptContract,
+  type ContractForm,
+} from '../../src/core/promptContract.js';
+
+describe('deriveRejectedForms', () => {
+  it('derives the historical B15 prefix-truncation shape', () => {
+    const forms = deriveRejectedForms(['B15_CONTEXT_DEATH_STOP']);
+    // The exact defect: the model emits the leading segment the parser rejects.
+    expect(forms).toContain('B15');
+    // Separator-stripped form is also derived.
+    expect(forms).toContain('B15CONTEXTDEATHSTOP');
+  });
+
+  it('derives case mutations (upper / lower / first-letter-flipped)', () => {
+    const forms = deriveRejectedForms(['Warn']);
+    expect(forms).toContain('WARN');
+    expect(forms).toContain('warn');
+  });
+
+  it('first-letter-flip flips only the first character', () => {
+    const forms = deriveRejectedForms(['WARN']);
+    // 'WARN' → flip leading 'W' to 'w', keep the rest → 'wARN'
+    expect(forms).toContain('wARN');
+  });
+
+  it('appends hand-picked extras', () => {
+    const forms = deriveRejectedForms(['B15_CONTEXT_DEATH_STOP'], ['', 'totally-made-up']);
+    expect(forms).toContain('');
+    expect(forms).toContain('totally-made-up');
+  });
+
+  it('EXCLUDES any derived/extra form that collides with a promised token', () => {
+    // 'PASS' is a promised token; its own upper-case mutation must not appear as
+    // a "rejected form" (that would make fail-closed contradict acceptance).
+    const forms = deriveRejectedForms(['PASS', 'block_message']);
+    expect(forms).not.toContain('PASS');
+    // an extra that happens to equal a promised token is also excluded
+    const forms2 = deriveRejectedForms(['PASS'], ['PASS']);
+    expect(forms2).not.toContain('PASS');
+  });
+
+  it('de-duplicates and returns a stable set', () => {
+    const forms = deriveRejectedForms(['A_B', 'A_B']);
+    const counts = new Map<string, number>();
+    for (const f of forms) counts.set(f, (counts.get(f) ?? 0) + 1);
+    for (const [, n] of counts) expect(n).toBe(1);
+  });
+
+  it('honors a custom separator set', () => {
+    const forms = deriveRejectedForms(['ROLE::ADMIN'], [], { separators: [':'] });
+    // prefix-truncation at the first ':' → 'ROLE'
+    expect(forms).toContain('ROLE');
+    // separator-stripped → 'ROLEADMIN'
+    expect(forms).toContain('ROLEADMIN');
+  });
+
+  it('ignores empty / non-string vocabulary entries without throwing', () => {
+    expect(() => deriveRejectedForms(['', 'OK'])).not.toThrow();
+    const forms = deriveRejectedForms(['', 'OK']);
+    // an empty promised token contributes nothing; 'OK' still mutates
+    expect(forms).toContain('ok');
+  });
+
+  it('is a PURE function — the same inputs yield an equal result', () => {
+    const a = deriveRejectedForms(['B15_CONTEXT_DEATH_STOP'], ['B15']);
+    const b = deriveRejectedForms(['B15_CONTEXT_DEATH_STOP'], ['B15']);
+    expect(a).toEqual(b);
+  });
+});
+
+describe('PromptContract type surface', () => {
+  it('a fallback-form manifest type-checks with a real parser reference', () => {
+    const RULE_IDS = ['B15_CONTEXT_DEATH_STOP', 'B16_FATIGUE_STOP'] as const;
+    const parseVerdict = (raw: string): string | null =>
+      (RULE_IDS as readonly string[]).includes(raw) ? raw : null;
+
+    const contract: PromptContract<string | null> = {
+      promisedOutputs: RULE_IDS,
+      rejectedForms: deriveRejectedForms(RULE_IDS, ['B15', '']),
+      hazardPatterns: [/\bB\d+\b(?!_)/],
+      envelope: { shape: 'json', verdictField: 'rule' },
+      acceptedAliases: [],
+      parser: parseVerdict,
+    };
+
+    // The parser reference is real and the derived rejects genuinely reject.
+    expect(contract.parser('B15_CONTEXT_DEATH_STOP')).toBe('B15_CONTEXT_DEATH_STOP');
+    expect(contract.parser('B15')).toBeNull();
+    expect(contract.rejectedForms).toContain('B15');
+    expect(contract.rejectedForms).not.toContain('B16_FATIGUE_STOP');
+  });
+
+  it('ContractForm is the two-value election used by the coverage record', () => {
+    const forms: ContractForm[] = ['single-source', 'manifest'];
+    expect(forms).toHaveLength(2);
+  });
+});

--- a/upgrades/next/prompt-parser-contract-standard.md
+++ b/upgrades/next/prompt-parser-contract-standard.md
@@ -1,0 +1,84 @@
+# Prompt↔Parser Contract Standard — contract classification + ratchet (defect class 1, ships dark)
+
+<!-- bump: minor -->
+
+## What Changed
+
+The mechanical arm of the **"The Prompt and the Parser Are One Contract"** standard
+(`docs/specs/prompt-parser-contract-standard.md`, defect class 1 / `prompt-parser-contract`
+closure), shipped as a self-contained DARK increment — no runtime wiring, no operator-gated
+registry text, no config key, and **no change to any live prompt or parser**. It is the
+structural answer to the 2026-07-02 INSTAR-Bench v2 finding: the tone gate's PROMPT taught
+models the short rule id (`B15`) while its production PARSER accepts only the full identifier
+(`B15_CONTEXT_DEATH_STOP`) and fails closed on the short form — so every model through every
+door obeyed the prompt and "failed." A single CI test comparing what the prompt promises
+against what the parser accepts would have made that defect unrepresentable.
+
+This increment ships **the shared contract library + the per-callsite classification + its CI
+ratchet only**:
+
+- A **shared contract library** (`src/core/promptContract.ts`): the `PromptContract` manifest
+  type (the co-located machine-readable promise a prose-shaped callsite carries next to its
+  prompt) and `deriveRejectedForms` — a pure generator for the counter-examples a contract
+  test feeds the REAL parser to prove its fail-closed behavior (case-mutation,
+  prefix-truncation at each separator — the exact `B15` shape — and separator-stripping, plus
+  hand-picked extras, minus any form that collides with a promised token). Machine-derived by
+  design: a hand-only reject list invites trivial rejects that prove nothing.
+- The **`contract` classification** (`LLM_PARSER_CONTRACT` in `src/data/llmBenchCoverage.ts`):
+  the `contract` axis of the program's ONE shared per-callsite metadata record (sibling of the
+  authority-clause `untrustedInput` and evidence-bar `judgesClaims` axes), required-explicit
+  for every LLM component — no default, so a silent omission is red CI and the flag can never
+  default toward the un-contracted state. The four spec-named highest-stakes parsed callsites
+  (tone gate, external-op gate, stop judge, input classifier) seed `contract-wave-1`; every
+  other enumerated-verdict callsite is `contract-wave-2`; a callsite with no closed-vocabulary
+  parse (no live prompt, a fixed canary, or free-text/open-set content) is an argued `false`.
+- A **classification ratchet** (`tests/unit/parser-contract-classification-ratchet.test.ts`):
+  required-explicit + no-dangling + valid-wave + the wave-1 seed pinned as a floor (a
+  highest-stakes callsite can never silently slip scope) + the pending set pinned shrink-only
+  + the argued-false set pinned shrink-only with a real-reason floor + a gate/sentinel
+  cross-check. Same pinned-baseline family as `llm-bench-coverage-ratchet` and the sibling
+  `untrusted-input-classification-ratchet`.
+
+Deliberately OUT of scope (not orphan deferrals — see `upgrades/side-effects/`):
+
+- The **per-callsite contract tests** and the **live-builder render refactor** (spec rollout
+  §0/§1). A contract test renders the REAL production prompt through an exported pure render
+  function; several production builders are private instance methods with live deps and need
+  that refactor, which TOUCHES live parsing code. It is deferred to its own A/B-gated
+  increments, one callsite at a time — never inside this dark inventory increment.
+- The **runtime contract-drift warning** (spec Frontloaded Decision #3) — a prompt-build-time
+  signal that also touches the live builders; it lands with the single-sourcing migrations.
+- The **registry / constitution text** (spec §1) — operator-gated; ships ONLY with Justin's
+  explicit sign-off. It is DRAFTED in the spec; this run does not edit the standards registry.
+
+## Evidence
+
+- `npx vitest run tests/unit/parser-contract-classification-ratchet.test.ts tests/unit/promptContract.test.ts tests/unit/llm-bench-coverage-ratchet.test.ts`
+  → **3 files, 26 tests, 0 failures** (required-explicit + no-dangling + wave-1 seed floor +
+  shrink-only pending + shrink-only argued-false + real-reason floor + gate/sentinel
+  cross-check + the derive-rejected-forms mutation logic incl. the B15 prefix shape; the
+  pre-existing coverage ratchet still green against the additive record).
+- `npx tsc --noEmit` → exit 0. `npm run lint` → exit 0.
+- Dark-by-construction: `LLM_PARSER_CONTRACT` is build-time metadata read only by the new
+  pinned ratchet; `promptContract.ts` has no runtime caller. It changes NO prompt text and
+  wires NO runtime parser — verified by the absence of any src import of the new module
+  outside tests.
+
+## What to Tell Your User
+
+Nothing changes for you right now — this ships dark, and it is maintainer-only machinery (a
+no-op on your install unless you develop instar itself). What it does is give my own AI checks
+a safety net: the words a check's prompt tells a model to answer with, and the words the code
+behind that check will actually accept, are now recorded together and held in sync by an
+automatic test. That closes a class of bug where a check would quietly reject every correct
+answer because the two halves had drifted apart — a mistake that was entirely mine, never the
+model's. The real per-check tests and any wording changes come later, one at a time, and only
+after careful review.
+
+## Summary of New Capabilities
+
+None active for end users in this increment — everything ships dark and additive. (For instar
+maintainers: a shared prompt↔parser contract library plus a required per-callsite `contract`
+classification with a shrink-only ratchet and a pinned highest-stakes seed floor, so a
+machine-parsed callsite can never silently ship a taught output vocabulary its own parser
+rejects.)

--- a/upgrades/side-effects/prompt-parser-contract-standard.md
+++ b/upgrades/side-effects/prompt-parser-contract-standard.md
@@ -1,0 +1,67 @@
+# Side-Effects Review — Prompt↔Parser Contract Standard (defect class 1, dark increment)
+
+**Version / slug:** `prompt-parser-contract-standard`
+**Date:** `2026-07-03`
+**Author:** `echo`
+**Tier:** `1 (dark increment — additive library + classification + pinned ratchet; no runtime wiring, no live prompt/parser change, no operator-gated text)`
+
+## Summary of the change
+
+The mechanical arm of the "The Prompt and the Parser Are One Contract" standard (defect class 1 closure; `docs/specs/prompt-parser-contract-standard.md`), shipped as a self-contained DARK increment. It ships:
+
+1. **`src/core/promptContract.ts`** — the shared prompt↔parser contract library. The `PromptContract` manifest type (a co-located, machine-readable promise carried next to a prose-shaped prompt), the `ContractForm` election type, and `deriveRejectedForms(vocabulary, extras, options)` — a PURE generator for the fail-closed counter-examples a per-callsite contract test feeds the REAL parser (case-mutation, prefix-truncation at each separator — the exact B15 shape — separator-stripping, plus hand-picked extras, minus any form that collides with a promised token). No runtime caller in this increment.
+2. **`src/data/llmBenchCoverage.ts`** (additive) — `LLM_PARSER_CONTRACT`, the `contract` axis of the program's shared per-callsite metadata record. Required-explicit for every `COMPONENT_CATEGORY` key; the four spec-named highest-stakes callsites seed `contract-wave-1`, other enumerated-verdict callsites are `contract-wave-2`, and a no-closed-vocabulary callsite is `{ false: '<reason>' }`.
+3. **`tests/unit/parser-contract-classification-ratchet.test.ts`** — required-explicit + no-dangling + valid-wave + wave-1 seed floor + shrink-only pending + shrink-only argued-false + real-reason floor + the gate/sentinel cross-check lint.
+4. **`tests/unit/promptContract.test.ts`** — the derive-rejected-forms mutation logic (incl. the B15 prefix shape, collision-exclusion, purity) and the manifest type surface.
+5. **`docs/specs/prompt-parser-contract-standard.md`** + **`.eli16.md`** — the converged spec and its plain-English overview.
+
+## What is DELIBERATELY out of scope (not orphan deferrals)
+
+- **The per-callsite contract tests + the live-builder render refactor (spec rollout §0/§1).** A contract test renders the REAL production prompt through an exported pure render function; several production builders (e.g. `MessagingToneGate`'s prompt builder) are private instance methods with live deps and need that render refactor, which TOUCHES live parsing code. Per the CAREFUL constraint on this defect class (live, load-bearing parsers), that refactor is deferred to its own A/B-gated increments, one callsite at a time, so live parse behavior is UNCHANGED on this merge. The four siblings deferred their behavioral/render arms for exactly this reason; this increment mirrors that.
+- **The runtime contract-drift warning (spec Frontloaded Decision #3 / "Decision points touched" (a)).** A signal-only prompt-build-time assertion that also touches the live builders; it lands with the by-construction single-sourcing migrations, not this inventory increment.
+- **The registry / constitution text (spec §1).** Operator-gated — ships ONLY with Justin's explicit sign-off (spec front-matter `operator-gate`). The registry entry is DRAFTED in the spec; this run does not write `docs/STANDARDS-REGISTRY.md`.
+
+## Decision-point inventory
+
+- `src/core/promptContract.ts` — **add** — a pure library (types + string/array helpers). NO runtime caller in this increment (dark by construction); it changes NO prompt text and NO parser until a per-callsite contract test + render refactor lands through its own gate. No allow/deny surface.
+- `LLM_PARSER_CONTRACT` classification (`src/data/llmBenchCoverage.ts`) — **add** — build-time metadata only. Read by the new pinned ratchet; no runtime consumer. A SIGNAL producer (which callsites parse a taught output vocabulary), never a runtime authority.
+- The two new vitest tests — **add** — CI-only pinned baselines (same family as `llm-bench-coverage-ratchet`). The ratchet gates the build (adding an unclassified callsite / growing the pending or false set silently is red CI), never a runtime path.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+None at runtime — nothing is wired to a runtime allow/deny path, and no live prompt or parser changes, so no model answer that was accepted before is rejected now. At CI/build time the only new red-CI surfaces are: (a) adding a new LLM component to `COMPONENT_CATEGORY` without an explicit `contract` classification, (b) growing the pending or argued-false set without editing the pinned baseline, and (c) marking a gate/sentinel `false` without the reviewed allowlist. All three are intentional, self-describing failures with fix-instructions in the assertion message — the "visible, reviewed act" the standard exists to force, not an over-block of legitimate work.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- This increment adds NO test that a callsite's prompt and parser are ACTUALLY coherent — that is the per-callsite contract test, deferred with its render refactor. So a classified-`pending` callsite can still ship a drifted prompt↔parser until its contract test graduates. This is the known staged-rollout gap, tracked in the spec's rollout §0→§3, not a silent miss — the pending set IS the honest inventory of that remaining work.
+- Classification accuracy is author-judged against a stated criterion (a CLOSED taught verdict vocabulary → needs a contract; free-text / open-set / no-live-prompt → `false`). A mislabel of a gate/sentinel is partly caught by the cross-check (the highest-risk category); a reflector/job mislabeled `false` would pass. The argued-false shrink-only pin makes every such call visible and reviewed at PR time; this seeding PR IS that review.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The contract library is a pure `src/core/` module (the layer where shared prompt/parser scaffolding belongs — sibling to `promptClauses.ts` from the authority-clause standard); the classification extends the ONE shared metadata record the program mandates (`src/data/llmBenchCoverage.ts`), not a new parallel registry; the ratchet is in the established pinned-baseline vitest family. No higher gate already owns "does the prompt's taught vocabulary match the parser"; no lower primitive is duplicated.
+
+## 4. Signal vs authority compliance
+
+The classification and the ratchet are SIGNALS (which callsites parse a taught vocabulary; is the pending/false inventory shrink-only) — they inform the build and the reviewer, never grant or deny a runtime action. `deriveRejectedForms` returns an array; it is inert until a contract test consumes it. No model-produced field is wired to satisfy any authorization check. The library changes no live parser's accept/reject decision.
+
+## 5. Interactions with existing systems
+
+- **`llm-bench-coverage-ratchet` / `untrusted-input-classification-ratchet`** — unaffected: `LLM_PARSER_CONTRACT` is a NEW additive export; the existing `LLM_BENCH_COVERAGE` and `LLM_UNTRUSTED_INPUT` records and their ratchets are untouched (all green post-change). The argued-false membership is consistent with the sibling axes' "no live judging/parsing callsite" reasoning where they overlap (PromiseBeacon, InteractivePoolCanaryJudge, AutoApprover, IntegrationGate, CoherenceGate, InputDetector), and adds the free-text-content reflectors/summarizers on top (which parse no closed verdict vocabulary).
+- **`lint-scrape-fixture-realness`** — the new helper is named `deriveRejectedForms` (not `parse*`/`scrape*`), so it is deliberately outside that lint's `parse*`/`scrape*` surface; it consumes no untrusted real-world text (it operates on a callsite's own declared vocabulary constant).
+- **green-PR auto-merge protected paths** — `src/data/llmBenchCoverage.ts` is already in the class-closure agent-authored-artifact predicate; the pinned ratchet baselines route every future classification/pending/false edit to operator review while a fully-conforming graduation (pending→contractTest) keeps auto-merge (program-shared machinery).
+
+## 6. Failure modes / rollback
+
+Pure additive TypeScript + tests + docs. Rollback = revert the commit; nothing persists state, nothing runs at runtime, no migration, no config key (no agent-side config key exists or is wanted — repo posture only, so no Migration Parity work). `tsc --noEmit` clean, `npm run lint` exit 0, all new + adjacent ratchets green under bounded single-file vitest runs (the machine has intermittent external CPU pressure; verification used bounded runs per the CI-as-gate pattern, full suite gated by CI).
+
+## 7. Second-pass reviewer
+
+Self-review (bounded machine-pressure build). The change is additive, dark, and test-pinned; no runtime surface and no live prompt/parser touched. Key self-checks: (1) confirmed `deriveRejectedForms` never emits a promised token as a "rejected form" (the collision-exclusion test), so a future contract test's accept/reject assertions cannot contradict; (2) confirmed the classification covers all 53 `COMPONENT_CATEGORY` keys exactly once (the required-explicit + no-dangling ratchet asserts it); (3) confirmed the wave-1 seed is exactly the four spec-named highest-stakes callsites; (4) confirmed no `src/` file outside tests imports `promptContract.ts`, so the increment is dark by construction.


### PR DESCRIPTION
The mechanical arm of the **"The Prompt and the Parser Are One Contract"** standard (`docs/specs/prompt-parser-contract-standard.md`, defect class 1 / `prompt-parser-contract` closure — the LAST of the four INSTAR-Bench v2 defect-class siblings). Ships as a self-contained **DARK** increment: no runtime wiring, **no change to any live prompt or parser**, no operator-gated registry text, no config key.

## ELI16

When one of my AI checks asks a model a question, two things written in two different places have to agree: the **prompt** tells the model what words it may answer with (e.g. `B15`), and the **parser** — the code that reads the answer back — decides which words it accepts (e.g. only `B15_CONTEXT_DEATH_STOP`). Nothing forced those halves to stay in sync. On 2026-07-02 the INSTAR-Bench v2 review found exactly this break in the tone gate: the prompt taught the short id `B15`, the parser accepted only the full id and failed closed, so every model on every route obeyed the prompt and "failed" — a 100%-our-fault defect a single CI test would have caught. This PR makes that drift a build failure instead of a hope. It ships a shared contract library (a manifest type + a pure generator, `deriveRejectedForms`, for the wrong-answer counter-examples a contract test must prove the parser rejects — including the exact B15 prefix shape), a required-explicit `contract` classification of all 53 AI callsites (the four highest-stakes ones — tone gate, external-op gate, stop judge, input classifier — seeded as a pinned floor; every other verdict callsite pending; free-text/no-prompt callsites argued false), and a shrink-only ratchet holding it all coherent. It changes **no** live prompt and **no** live parser — the per-callsite contract tests (which render real prompts and need a live-builder refactor) and the registry text are deliberately deferred, one careful A/B-gated step at a time.

## What ships (dark / report-only)

- **`src/core/promptContract.ts`** — the `PromptContract` manifest type + `deriveRejectedForms` (pure: case-mutation, prefix-truncation at each separator — the B15 shape — separator-stripping, collision-excluded, de-duped). **No runtime caller.**
- **`src/data/llmBenchCoverage.ts`** (+`LLM_PARSER_CONTRACT`) — the `contract` axis of the program's shared per-callsite metadata record (sibling of authority-clause `untrustedInput` #1351 and evidence-bar `judgesClaims` #1353). Required-explicit for every `COMPONENT_CATEGORY` key; wave-1 = the 4 spec-named highest-stakes callsites, wave-2 = other verdict callsites, argued `false` = no closed-vocabulary parse.
- **`tests/unit/parser-contract-classification-ratchet.test.ts`** — required-explicit + no-dangling + valid-wave + wave-1 seed floor + shrink-only pending + shrink-only argued-false + real-reason floor + gate/sentinel cross-check.
- **`tests/unit/promptContract.test.ts`** — the derive-rejected-forms mutation logic + type surface.
- Spec + `.eli16` + release fragment + side-effects artifact.

## Deliberately deferred (not orphaned — see side-effects §"out of scope")

- **Per-callsite contract tests + live-builder render refactor** (spec rollout §0/§1) — a contract test renders the REAL production prompt through an exported pure render function; that refactor TOUCHES live parsing code, so it is deferred to its own A/B-gated increments, one callsite at a time. This is the CAREFUL constraint of this defect class: live parse behavior is UNCHANGED on merge.
- **Runtime contract-drift warning** (Frontloaded Decision #3) — also touches live builders; lands with the single-sourcing migrations.
- **Registry / constitution text** (spec §1) — operator-gated; ships only with Justin's explicit sign-off. Drafted in the spec; not written here.

## Evidence

- `npx vitest run tests/unit/parser-contract-classification-ratchet.test.ts tests/unit/promptContract.test.ts tests/unit/llm-bench-coverage-ratchet.test.ts` → **26 tests, 0 failures**; pre-push smoke → **4 files / 32 tests pass**.
- `npx tsc --noEmit` → exit 0. `npm run lint` → exit 0.
- Dark-by-construction: `LLM_PARSER_CONTRACT` is build-time metadata read only by the new ratchet; `promptContract.ts` has no `src/` importer outside tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
