### PR TITLE
fix(messaging): close exact-duplicate send race with in-flight reservation

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-03T23-12-26-219Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-03T23-12-26-219Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-07-03T23:12:26.219Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 95,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/src/messaging/OutboundContentDedup.ts
+++ b/src/messaging/OutboundContentDedup.ts
@@ -36,6 +36,11 @@ export interface OutboundContentDedupConfig {
   minLength?: number;
   /** Cap on remembered fingerprints per topic (ring). Default 50. */
   maxPerTopic?: number;
+  /** How long an in-flight `tryReserve` claim stays live before it auto-expires,
+   *  so a leaked reservation (a send that neither recorded nor released — e.g. a
+   *  crash mid-send) can never permanently suppress a fingerprint. Must comfortably
+   *  exceed the outbound route's own send budget. Default 3min. */
+  reserveTtlMs?: number;
 }
 
 const DEFAULTS: Required<OutboundContentDedupConfig> = {
@@ -43,6 +48,7 @@ const DEFAULTS: Required<OutboundContentDedupConfig> = {
   windowMs: 15 * 60 * 1000,
   minLength: 40,
   maxPerTopic: 50,
+  reserveTtlMs: 3 * 60 * 1000,
 };
 
 /** Normalize for fingerprinting: trim, collapse internal whitespace runs. Two
@@ -66,6 +72,15 @@ export class OutboundContentDedup {
   private readonly cfg: Required<OutboundContentDedupConfig>;
   /** topicId -> (fingerprint -> last-sent epoch ms) */
   private readonly seen = new Map<number, Map<string, number>>();
+  /** topicId -> (fingerprint -> reserved-at epoch ms). An IN-FLIGHT claim taken
+   *  by `tryReserve` BEFORE a send starts and cleared by `record` (success) or
+   *  `releaseReservation` (failure). This closes the check-then-send race that
+   *  `isDuplicate` + record-after-success left open: under a server stall a send
+   *  can be in flight for tens of seconds, and a second identical request that
+   *  arrives in that window used to pass the duplicate check (nothing recorded
+   *  yet) and send a second copy. Reservations auto-expire after `reserveTtlMs`
+   *  so a leaked claim can never permanently suppress a fingerprint. */
+  private readonly reserved = new Map<number, Map<string, number>>();
   private readonly now: () => number;
   /** Optional durable backing so a duplicate is caught ACROSS a restart / across
    *  overlapping processes (the in-memory `seen` Map resets on restart — the exact
@@ -104,8 +119,51 @@ export class OutboundContentDedup {
     return false;
   }
 
+  /** Atomically decide whether `text` may be sent to `topicId`, AND — if so —
+   *  reserve it in-flight so a concurrent/rapid identical send is caught before
+   *  the first one has recorded. Returns:
+   *    - false  ⇒ suppress: an identical text was sent within the window OR is
+   *               currently in flight (a live reservation). The caller must NOT
+   *               send and must NOT release (it doesn't own the reservation).
+   *    - true   ⇒ proceed: the caller now OWNS a reservation and MUST resolve it
+   *               with `record` (on success) or `releaseReservation` (on failure).
+   *  Below-floor text is never deduped → always returns true with no reservation
+   *  (brief acks legitimately repeat). This supersedes the plain `isDuplicate`
+   *  check at the send callsite to close the check-then-send race. */
+  tryReserve(topicId: number, text: string): boolean {
+    if (!this.cfg.enabled) return true;
+    const norm = normalizeForDedup(text);
+    if (norm.length < this.cfg.minLength) return true;
+    const fp = fingerprint(norm);
+    // Already sent within the window (in-memory or durable) → duplicate.
+    if (this.isDuplicate(topicId, text)) return false;
+    // Currently in flight (a live, non-expired reservation) → duplicate.
+    const now = this.now();
+    const resMap = this.reserved.get(topicId);
+    const reservedAt = resMap?.get(fp);
+    if (reservedAt !== undefined && now - reservedAt < this.cfg.reserveTtlMs) return false;
+    // Claim it.
+    let topicRes = this.reserved.get(topicId);
+    if (!topicRes) {
+      topicRes = new Map();
+      this.reserved.set(topicId, topicRes);
+    }
+    topicRes.set(fp, now);
+    this.pruneReserved(topicRes);
+    return true;
+  }
+
+  /** Release an in-flight reservation taken by `tryReserve` — call when the send
+   *  FAILED, so the legitimate retry of the same text isn't wrongly suppressed. */
+  releaseReservation(topicId: number, text: string): void {
+    const norm = normalizeForDedup(text);
+    if (norm.length < this.cfg.minLength) return;
+    this.reserved.get(topicId)?.delete(fingerprint(norm));
+  }
+
   /** Record that `text` was sent to `topicId` now. Call AFTER a successful send.
-   *  No-op for below-floor text (it can never be a dedup target anyway). */
+   *  No-op for below-floor text (it can never be a dedup target anyway). Also
+   *  clears any in-flight reservation for this fingerprint (the send resolved). */
   record(topicId: number, text: string): void {
     if (!this.cfg.enabled) return;
     const norm = normalizeForDedup(text);
@@ -119,6 +177,9 @@ export class OutboundContentDedup {
     const fp = fingerprint(norm);
     topicMap.set(fp, now);
     this.pruneTopic(topicMap);
+    // The send resolved → drop the in-flight reservation; the `seen` record now
+    // carries the (longer) window suppression.
+    this.reserved.get(topicId)?.delete(fp);
     // Mirror to the durable store so a post-restart process sees it. Fail-open.
     this.store?.record(topicId, fp, now);
   }
@@ -133,6 +194,20 @@ export class OutboundContentDedup {
       const oldest = topicMap.keys().next().value; // insertion-ordered
       if (oldest === undefined) break;
       topicMap.delete(oldest);
+    }
+  }
+
+  /** Drop expired reservations (past `reserveTtlMs`), then cap the ring. Keeps a
+   *  leaked reservation from lingering and bounds memory the same way `seen` is. */
+  private pruneReserved(resMap: Map<string, number>): void {
+    const cutoff = this.now() - this.cfg.reserveTtlMs;
+    for (const [fp, at] of resMap) {
+      if (at < cutoff) resMap.delete(fp);
+    }
+    while (resMap.size > this.cfg.maxPerTopic) {
+      const oldest = resMap.keys().next().value; // insertion-ordered
+      if (oldest === undefined) break;
+      resMap.delete(oldest);
     }
   }
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -11564,6 +11564,20 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     )
       return;
 
+    // In-flight reservation (2026-07-03): the isDuplicate pre-check above and the
+    // record-after-success below leave a race — under a server stall a send can be
+    // in flight for tens of seconds, and a second identical request that arrives in
+    // that window passes the pre-check (nothing recorded yet) and sends a duplicate
+    // (the reworded-vs-identical double-send class). tryReserve atomically re-checks
+    // AND claims the fingerprint in one synchronous step, so the loser of the race
+    // is suppressed. Taken AFTER the tone gate (a held/blocked message never
+    // reserves → no leak); resolved by record() on success or releaseReservation()
+    // in the catch on failure. allowDuplicate bypasses it (no reserve, no block).
+    if (!allowDuplicate && !outboundContentDedup.tryReserve(topicId, text)) {
+      console.log(`[telegram/reply] suppressed in-flight duplicate for topic ${topicId} (identical text already sending/sent)`);
+      res.json({ ok: true, topicId, suppressedDuplicate: true });
+      return;
+    }
     try {
       // Capture the SendResult so the response can carry the REAL Telegram
       // messageId. A tokenless-standby relay reads this messageId to decide
@@ -11670,6 +11684,10 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       }
       res.json({ ok: true, topicId, messageId: sendResult?.messageId });
     } catch (err) {
+      // The send failed → release the in-flight reservation so the legitimate
+      // retry of this exact text is not wrongly suppressed as a duplicate. Safe
+      // no-op when nothing was reserved (allowDuplicate / below-floor text).
+      outboundContentDedup.releaseReservation(topicId, text);
       // @silent-fallback-ok — NOT a silent fallback: this catch surfaces a 500 to the
       // caller. The tag exists because the no-silent-fallbacks scanner's fixed 20-line
       // window reaches past this route's end into the next route's `db = null`

--- a/tests/unit/OutboundContentDedup.test.ts
+++ b/tests/unit/OutboundContentDedup.test.ts
@@ -102,6 +102,69 @@ describe('OutboundContentDedup — ring bounds + pruning', () => {
   });
 });
 
+describe('OutboundContentDedup — in-flight reservation (the send-race close)', () => {
+  it('claims on first tryReserve and suppresses a concurrent identical send BEFORE record', () => {
+    let t = 1_000_000;
+    const d = new OutboundContentDedup({}, () => t);
+    // Request A reserves and begins its (slow, stalled) send — no record yet.
+    expect(d.tryReserve(55, STATUS)).toBe(true);
+    // Request B arrives during A's in-flight send: suppressed by the reservation.
+    expect(d.tryReserve(55, STATUS)).toBe(false);
+    expect(d.tryReserve(55, STATUS)).toBe(false);
+  });
+
+  it('after A records success, a later identical send is caught by the window (not the reservation)', () => {
+    let t = 1_000_000;
+    const d = new OutboundContentDedup({ windowMs: 15 * 60 * 1000 }, () => t);
+    expect(d.tryReserve(55, STATUS)).toBe(true);
+    d.record(55, STATUS); // A succeeded → reservation cleared, sent recorded
+    t += 60_000;
+    expect(d.tryReserve(55, STATUS)).toBe(false); // still a duplicate within window
+    expect(d.isDuplicate(55, STATUS)).toBe(true);
+  });
+
+  it('releaseReservation lets the legitimate retry of a FAILED send through', () => {
+    let t = 1_000_000;
+    const d = new OutboundContentDedup({}, () => t);
+    expect(d.tryReserve(55, STATUS)).toBe(true);
+    d.releaseReservation(55, STATUS); // A's send threw → release
+    // The retry (same text) is NOT suppressed.
+    expect(d.tryReserve(55, STATUS)).toBe(true);
+  });
+
+  it('a leaked reservation auto-expires after reserveTtlMs', () => {
+    let t = 1_000_000;
+    const d = new OutboundContentDedup({ reserveTtlMs: 3 * 60 * 1000 }, () => t);
+    expect(d.tryReserve(55, STATUS)).toBe(true); // reserved, never resolved (crash)
+    expect(d.tryReserve(55, STATUS)).toBe(false); // still in flight
+    t += 3 * 60 * 1000 + 1; // past the TTL
+    expect(d.tryReserve(55, STATUS)).toBe(true); // reservation expired → allowed again
+  });
+
+  it('never reserves or suppresses a brief ack (below the length floor)', () => {
+    let t = 0;
+    const d = new OutboundContentDedup({}, () => t);
+    const ack = 'Got it, on it.'; // < 40 chars
+    expect(d.tryReserve(55, ack)).toBe(true);
+    expect(d.tryReserve(55, ack)).toBe(true); // two identical acks both send
+  });
+
+  it('reservations are independent per topic', () => {
+    let t = 0;
+    const d = new OutboundContentDedup({}, () => t);
+    expect(d.tryReserve(1, STATUS)).toBe(true);
+    expect(d.tryReserve(2, STATUS)).toBe(true); // different topic — not blocked
+    expect(d.tryReserve(1, STATUS)).toBe(false); // same topic — in flight
+  });
+
+  it('disabled → no reservation, no suppression', () => {
+    let t = 0;
+    const d = new OutboundContentDedup({ enabled: false }, () => t);
+    expect(d.tryReserve(55, STATUS)).toBe(true);
+    expect(d.tryReserve(55, STATUS)).toBe(true); // disabled → no dedup at all
+  });
+});
+
 describe('helpers', () => {
   it('normalizeForDedup collapses whitespace + trims', () => {
     expect(normalizeForDedup('  a\n\n b   c  ')).toBe('a b c');

--- a/tests/unit/outbound-content-dedup-route.test.ts
+++ b/tests/unit/outbound-content-dedup-route.test.ts
@@ -109,4 +109,38 @@ describe('content-dedup — /telegram/reply chokepoint', () => {
     expect(res.status).toBe(200);
     expect(sendToTopic).toHaveBeenCalledTimes(2);
   });
+
+  // ── In-flight reservation (2026-07-03 double-send race close) ──
+  // The record-after-success dedup left a window: while send A is IN FLIGHT
+  // (slow under a server stall), an identical request B passes the pre-check
+  // (nothing recorded yet) and sends a duplicate. The reservation closes it.
+  it('suppresses an identical send that arrives while the first is still IN FLIGHT', async () => {
+    // Make the FIRST send hang until we release it; the second arrives meanwhile.
+    let releaseA: (v: { messageId: number; topicId: number }) => void = () => {};
+    const inFlight = new Promise<{ messageId: number; topicId: number }>((r) => (releaseA = r));
+    sendToTopic.mockReturnValueOnce(inFlight); // A hangs
+    // (subsequent calls fall back to the default mockResolvedValue)
+
+    const pA = reply(LONG); // A: reserves, then blocks in the in-flight send
+    // Give A's handler time to take the reservation before B arrives.
+    await new Promise((r) => setTimeout(r, 20));
+    const rB = await reply(LONG); // B: identical, arrives during A's in-flight send
+
+    expect(rB.body.suppressedDuplicate).toBe(true); // B suppressed by the reservation
+    releaseA({ messageId: 1, topicId: 12476 }); // let A finish
+    const rA = await pA;
+    expect(rA.status).toBe(200);
+    expect(sendToTopic).toHaveBeenCalledTimes(1); // only A ever reached Telegram
+  });
+
+  it('releases the reservation when the send FAILS, so the legitimate retry goes through', async () => {
+    sendToTopic.mockRejectedValueOnce(new Error('telegram 500')); // A fails
+    const rA = await reply(LONG);
+    expect(rA.status).toBe(500); // A surfaced the failure
+
+    const rB = await reply(LONG); // retry of the exact text
+    expect(rB.status).toBe(200);
+    expect(rB.body.suppressedDuplicate).toBeUndefined(); // NOT suppressed
+    expect(sendToTopic).toHaveBeenCalledTimes(2); // the retry reached Telegram
+  });
 });

--- a/upgrades/next/double-send-inflight-reservation.md
+++ b/upgrades/next/double-send-inflight-reservation.md
@@ -1,0 +1,63 @@
+# Double-send fix — in-flight reservation closes the exact-duplicate send race
+
+<!-- bump: patch -->
+
+## What Changed
+
+Closes a check-then-send race in the existing exact-match outbound duplicate guard
+(`OutboundContentDedup`) at the `/telegram/reply` chokepoint — one mechanism behind the
+user-reported double-sends (RCA topics 30823/30837).
+
+The guard recorded a sent fingerprint only AFTER a successful send. Under a server stall a send
+can be in flight for tens of seconds, and a second identical request arriving in that window
+passed the pre-check (nothing recorded yet) and sent a duplicate. The fix adds an atomic
+**reserve → confirm/release** lifecycle to the SAME exact-match guard:
+
+- `tryReserve(topicId, text)` — synchronously re-checks the sent-window AND claims an in-flight
+  reservation in one step; returns suppress when the text was already sent within the window OR
+  is currently in flight. Auto-expires after `reserveTtlMs` (default 3min) so a leaked claim can
+  never permanently suppress.
+- `releaseReservation(topicId, text)` — clears the claim when the send FAILS, so the legitimate
+  retry is not suppressed.
+- `record()` clears the claim on success (the longer sent-window takes over).
+
+Route wiring: the reservation is taken AFTER the tone gate (a held/blocked message never
+reserves — no leak) and immediately before the send; `releaseReservation` runs in the
+send-failure catch. `allowDuplicate` bypasses it; brief acks (below the length floor) are never
+reserved.
+
+Deliberately scoped: this is the **exact-duplicate** half. The **reworded** near-duplicate is
+NOT hard-blocked here — that requires a similarity threshold, and a brittle similarity detector
+must not hold blocking authority (`docs/signal-vs-authority.md`). The reworded/systemic case is
+routed to the RCA shared-primitives spec (topic 30837), not botched into a brittle blocker here.
+
+## Evidence
+
+- `npx vitest run tests/unit/OutboundContentDedup.test.ts` → **18 tests** (reserve claims;
+  concurrent identical suppressed before record; window catch after record; release-on-failure
+  retry; TTL auto-expiry; brief-ack exemption; per-topic isolation; disabled no-op).
+- `npx vitest run tests/unit/outbound-content-dedup-route.test.ts` → **8 tests** incl. a route
+  test that literally holds one send IN FLIGHT and proves the identical second is suppressed, and
+  that a FAILED send releases the reservation so its retry reaches Telegram.
+- `npx vitest run tests/unit/OutboundContentDedup.test.ts tests/unit/outbound-content-dedup-route.test.ts tests/unit/outbound-dedup-durable.test.ts tests/unit/relayContentDedup.test.ts`
+  → **41 tests, 0 failures**.
+- `npx tsc --noEmit -p tsconfig.json` → **0 errors**.
+- Independent second-pass reviewer (delivery-path audit): **Concur** — no over-block path drops a
+  legitimate message; reservation taken strictly after the tone-gate early-return; failure
+  release + TTL expiry + allowDuplicate bypass all verified line-by-line.
+- Side-effects review: `upgrades/side-effects/double-send-inflight-reservation.md`.
+
+## What to Tell Your User
+
+If you ever saw the agent send you the same message twice, this fixes one cause of it. When the
+server was briefly slow, a message could start sending, and a second identical copy could slip
+out before the first was marked "done." Now the agent claims a message the instant it starts
+sending, so an identical copy can't sneak through that gap — while a failed send still lets its
+retry go through, and short replies like "got it" are never affected. Note this covers *exact*
+duplicates; the case where the same point comes back slightly *reworded* is a harder problem
+being handled separately.
+
+## Summary of New Capabilities
+
+None — this is a reliability fix to existing duplicate-suppression behavior. The reply endpoint
+keeps the same shape; an in-flight duplicate is suppressed the same way an already-sent one is.

--- a/upgrades/side-effects/double-send-inflight-reservation.eli16.md
+++ b/upgrades/side-effects/double-send-inflight-reservation.eli16.md
@@ -1,0 +1,33 @@
+# Double-send in-flight reservation — Plain-English Overview
+
+> The one-line version: when the server was slow, the same message could go out twice because the "have I already sent this?" check happened before the send was marked done — this reserves the message the instant it starts sending, so a second identical copy can't slip through the gap.
+
+## The problem in one breath
+
+Sometimes users saw the same message from the agent twice. One cause: the agent has a guard that says "if I already sent this exact text to this chat recently, don't send it again." But that guard only wrote down "sent!" AFTER the send finished. When the server was stalled, a send could take 30+ seconds — and if a second identical send started during that gap, the guard hadn't written anything down yet, so both went out.
+
+## What already exists
+
+- **The exact-duplicate guard** — already blocks the identical message from being sent twice, and even remembers across restarts (a small durable store). It works fine *once the first send has finished and been recorded*. The gap was only the in-between window.
+- **A separate near-duplicate detector** — notices when two messages are *similar but reworded*. Crucially, this one is only a *hint* fed to the smart safety reviewer; it is deliberately NOT allowed to block on its own, because "80% similar" can mean "a bug repeated itself" OR "the user asked me to say it again," and a dumb similarity score can't tell those apart.
+
+## What this adds
+
+A "reserve" step. The instant the agent decides to send a message, it now *claims* that exact text as in-flight — before the send starts. If a second identical send shows up while the first is still going, it sees the claim and steps aside. When the first send finishes, the claim is upgraded to the normal "already sent" record. If the first send *fails*, the claim is released immediately so the genuine retry can go through. And if something crashes and a claim is never resolved, it auto-expires after a few minutes so it can never permanently block that text.
+
+## The new pieces
+
+- **`tryReserve`** — one atomic step that both checks "already sent or already in flight?" and, if not, claims it. Returns "go ahead" or "stop, it's a duplicate."
+- **`releaseReservation`** — undoes the claim when a send fails, so retries aren't punished.
+- **Auto-expiry** — a claim that's never resolved disappears on its own after ~3 minutes.
+
+## The safeguards
+
+- It only ever suppresses an **exact** duplicate (same text, same chat) — never a reworded message, never a short "got it" ack, and never anything the caller marked "allow duplicate."
+- It is placed AFTER the smart safety reviewer, so a message that reviewer holds for later never gets stuck behind a stale claim.
+- It changes nothing about the *reworded* double-send. That's a harder problem that needs a proper design, because catching "similar" messages with a blunt threshold would start blocking legitimate repeats — exactly the mistake instar's "signal vs authority" rule exists to prevent. That work is tracked separately.
+- Everything is in memory only — nothing new is written to disk, so rolling this back is a clean one-step revert.
+
+## What you need to decide
+
+This is the principle-compliant half of the double-send fix: it closes the exact-duplicate race safely, with full test coverage (unit tests for the reserve/release/expiry lifecycle, plus a route test that literally holds one send in flight and proves the second is suppressed and that a failed send still lets its retry through). The one thing to be aware of: it does NOT stop *reworded* duplicates — that half is intentionally deferred to a proper spec, because doing it naively would violate a core instar principle. So this ships as a real, safe improvement, with the harder half honestly flagged rather than botched.

--- a/upgrades/side-effects/double-send-inflight-reservation.md
+++ b/upgrades/side-effects/double-send-inflight-reservation.md
@@ -1,0 +1,100 @@
+# Side-Effects Review — Double-send in-flight reservation (close the exact-duplicate send race)
+
+**Version / slug:** `double-send-inflight-reservation`
+**Date:** `2026-07-03`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `reviewer subagent (see appended concurrence)`
+
+## Summary of the change
+
+Closes a check-then-send race in the existing EXACT-match outbound duplicate guard (`OutboundContentDedup`) at the `/telegram/reply` chokepoint. The guard recorded a fingerprint only AFTER a successful send, leaving a window: under a server stall a send can be in flight for tens of seconds, and a second identical request arriving in that window passed the pre-check (nothing recorded yet) and sent a duplicate — one mechanism behind the user-reported double-sends (RCA topics 30823/30837).
+
+The fix adds an atomic **reserve → confirm/release** lifecycle to the SAME exact-match guard:
+
+- `OutboundContentDedup.tryReserve(topicId, text)` — synchronously re-checks the sent-window AND claims an in-flight reservation in one step; returns `false` (suppress) if the text was already sent within the window OR is currently reserved (in flight). Reservations auto-expire after `reserveTtlMs` (default 3min) so a leaked claim can never permanently suppress a fingerprint.
+- `OutboundContentDedup.releaseReservation(topicId, text)` — clears the reservation when the send FAILS, so the legitimate retry is not suppressed.
+- `record()` (unchanged call site) now also clears the reservation on success (the longer sent-window takes over).
+
+Route wiring (`src/server/routes.ts`, `/telegram/reply`): the cheap `isDuplicate` pre-check before the tone gate is unchanged (early exit for already-sent duplicates); a new `tryReserve` gate is taken AFTER the tone gate, immediately before the send, and `releaseReservation` is called in the send-failure catch. `allowDuplicate` bypasses the reservation entirely.
+
+Files: `src/messaging/OutboundContentDedup.ts`, `src/server/routes.ts`, plus unit + route tests.
+
+## Decision-point inventory
+
+- `OutboundContentDedup` (exact-match duplicate guard) — modify — adds an in-flight reservation phase to an EXISTING deterministic block. It is NOT a new decision point; it makes the existing one race-safe.
+- `/telegram/reply` send path — modify — the reservation gate is taken before the send and released on failure.
+
+The reservation is placed AFTER the tone gate, so a held/blocked message never reserves (no interaction with the tone gate's own retry/hold path).
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this reject that it shouldn't?** Only an EXACT (whitespace-normalized) duplicate of a message currently in flight to the SAME topic. Concretely: if the agent deliberately sends the byte-identical long message twice to the same topic within ~3 minutes while the first is still sending, the second is suppressed. That is the intended behavior and the existing guard already suppresses the same text once recorded — this only extends it to the in-flight window. Legitimate repeats are protected three ways: (a) brief acks (< `minLength`, default 40) are never reserved or suppressed; (b) `allowDuplicate: true` bypasses it; (c) a DIFFERENT (even slightly reworded) message has a different fingerprint and is never touched. The reworded double-send is explicitly NOT addressed here (see §2) precisely to avoid the brittle-similarity over-block the signal-vs-authority principle warns against.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?** (a) The **reworded** near-duplicate — a resend with changed wording has a different fingerprint and is NOT caught. This is deliberate: catching it requires a similarity threshold, which is a brittle detector that must NOT hold blocking authority (`docs/signal-vs-authority.md` uses this exact example). That case stays a signal to the tone-gate authority and is routed to a proper spec, not this quick-win. (b) A **cross-process/cross-machine** in-flight race (a durable-relay retry from a different process while the first is in flight) — the in-memory reservation is per-process; once the first send records, the existing durable sent-window store catches the retry, but the sub-second cross-process in-flight window is not closed here. Both are named, not silently deferred: the reworded/systemic case is the RCA's shared-primitives spec work (topic 30837); the cross-process reservation is a follow-up tracked below.
+
+<!-- tracked: topic-30823 — reworded near-dup + cross-process in-flight reservation are follow-ups; the reworded case requires the signal-vs-authority-compliant design in the sibling RCA's shared-primitives spec (topic 30837), NOT a brittle hard block here. -->
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The reservation lives INSIDE `OutboundContentDedup` (the class that owns the exact-match guard), so it composes with the existing sent-window logic and durable store rather than being bolted onto the route. The route only sequences reserve → send → confirm/release. This is a deterministic guard becoming race-safe — not a new authority and not a re-implementation of one.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Compliant — and deliberately so.** The reservation strengthens an EXISTING deterministic, EXACT-match block (fingerprint equality) by closing a TOCTOU race. It introduces NO brittle/similarity logic and NO new blocking authority. The reworded near-dup — the case that WOULD require a brittle similarity detector — is explicitly kept OUT (it stays a signal to the tone-gate authority), directly honoring `docs/signal-vs-authority.md`'s canonical warning that a similarity score must not hold blocking authority. This change is the principle-compliant half of the double-send fix.
+
+---
+
+## 5. Interactions
+
+- **Tone gate:** the reservation is taken AFTER the tone gate, so a held/blocked message never reserves — no leak on the tone-gate hold/retry path.
+- **Durable sent-window store:** `tryReserve` calls `isDuplicate`, which already consults the durable store; the reservation is additive (in-memory in-flight only) and never conflicts with the recorded sent-window.
+- **`record` on success / `releaseReservation` on failure / TTL expiry** form a complete lifecycle — every reserved fingerprint is resolved (success clears, failure clears) or auto-expires; no path leaks a permanent suppression.
+- **`allowDuplicate`** short-circuits before `tryReserve` (no reserve, no block), preserving the escape hatch.
+- No double-fire with the delivery-id LRU or the byte-identical pre-check — they suppress different windows and all return the same `suppressedDuplicate: true` shape.
+
+---
+
+## 6. External surfaces
+
+- **`/telegram/reply`** — same response shape. A suppressed in-flight duplicate returns `{ ok: true, suppressedDuplicate: true }` (identical to the existing byte-identical suppression). No new error surface; a genuine send failure still returns 500 (and now releases the reservation).
+- Behavior depends on timing (in-flight window) by nature — but the outcome is deterministic given fingerprint equality; the TTL bounds any timing dependence.
+- No change visible to other agents/users beyond fewer duplicate messages.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local (in-flight state) BY DESIGN, with a named cross-machine follow-up.** The in-flight reservation is per-process in-memory — correct, because the send it guards executes in THIS process. The already-shipped durable `OutboundDedupStore` handles the cross-restart / cross-process SENT-window (once a send records). The remaining sub-second cross-process in-flight window (a durable-relay retry on another machine racing this process's in-flight send) is NOT closed here and is tracked (§2). On a single-machine agent there is no cross-process race and the fix is complete. No user-facing URL/topic-transfer concerns.
+
+---
+
+## 8. Rollback cost
+
+Low. Two files; straight revert restores the prior record-after-success behavior with no data migration (reservations are in-memory only — nothing persisted). The reservation is bypassable at runtime via `allowDuplicate` per-call, and the whole guard is disable-able via `outboundContentDedup.enabled: false` in config. If the reservation were ever suspected of wrongly suppressing, `reserveTtlMs` can be lowered (or the guard disabled) without a code change.
+
+---
+
+## Second-pass review (independent reviewer subagent)
+
+**Concur with the review.** Line-by-line audit of the delivery path confirmed no over-block:
+
+- `tryReserve` is taken strictly AFTER the tone-gate early-return, so a held/blocked message NEVER reserves — the leak-that-would-suppress-the-retry path does not exist.
+- No `await`/`return` sits between `tryReserve` and the awaited `sendToTopic`; the reserve→send is effectively atomic and any throw lands in the catch which calls `releaseReservation`. Failed send → reservation released → retry passes (confirmed by route test).
+- A leaked reservation (crash before resolve) is freed by `reserveTtlMs` (3min) via the expiry check + `pruneReserved`.
+- `!allowDuplicate &&` guards both the pre-check and `tryReserve`; below-`minLength` acks are never reserved.
+- `tryReserve`/`releaseReservation`/`record`/`pruneReserved` have no await between check and claim (single-threaded atomic), correct TTL math, per-topic isolation, bounded map growth.
+- Signal-vs-authority: only the exact fingerprint-equality guard gained the in-flight phase; no similarity logic gains blocking authority (reworded case deliberately excluded).
+
+**Pre-existing, out-of-scope observations (NOT introduced by this change, NOT blocking):** (1) `record()` fires after any non-throwing `sendToTopic` regardless of whether `sendResult.messageId` indicates real delivery — a relay that "succeeds" without delivering could record+suppress a later legitimate resend; this predates the reservation work. (2) `reserveTtlMs` (3min) correctly stays above the outbound send budget (tone-gate rate-limit wait ≤120s).
+
+<!-- tracked: topic-30823 — pre-existing observation: record()-after-non-throwing-send ignores messageId; a non-delivering "success" could suppress a later resend. Predates this change; folds into the RCA shared-primitives spec (topic 30837) alongside the reworded/cross-process work. -->


### PR DESCRIPTION
## What & why

Users saw the same message twice. One cause: the exact-match outbound duplicate guard recorded a sent fingerprint only AFTER a successful send, leaving a check-then-send race — under a server stall a send is in flight for tens of seconds, and a second identical request in that window passed the pre-check (nothing recorded yet) and sent a duplicate.

## The fix

Adds an atomic **reserve → confirm/release** lifecycle to the SAME exact-match guard (`OutboundContentDedup`):
- `tryReserve` claims the fingerprint in one synchronous step — suppresses an identical send that's already sent OR currently in flight.
- `releaseReservation` frees it on send failure so the retry isn't lost.
- `record` clears it on success; reservations auto-expire (`reserveTtlMs`, 3min) so a leaked claim can't permanently suppress.
- Route: reservation taken **after** the tone gate (a held message never reserves — no leak) and before the send; released in the failure catch; `allowDuplicate` bypasses; brief acks never reserved.

## Scope (deliberate)

This is the **exact-duplicate** half. The **reworded** near-dup is NOT hard-blocked here — a similarity threshold is a brittle detector that must not hold blocking authority (`docs/signal-vs-authority.md`). That + the cross-process in-flight window are routed to the shared-primitives spec (RCA topic 30837), not botched into a brittle blocker.

## ELI16

The agent has a guard that says "don't send the same message twice." But it only wrote down "sent!" AFTER the send finished — so when the server was slow and a send took 30+ seconds, a second identical send starting in that gap didn't see anything written yet, and both went out. This makes the agent *reserve* the message the instant it starts sending, so an identical copy can't slip through the gap. If the send fails, the reservation is released so the real retry goes through; if something crashes, the reservation auto-expires after a few minutes so it can never permanently block that text. It only ever affects EXACT duplicates — never reworded messages, never short "got it" acks, never anything marked allow-duplicate. The reworded-duplicate case is a harder problem handled separately, on purpose, because a blunt "these look similar" block would start dropping legitimate repeats.

## Evidence

- 26 tests: unit (reserve/release/TTL/per-topic/disabled) + route (holds one send IN FLIGHT, proves the identical second is suppressed; failed send releases → retry reaches Telegram). 41 dedup-family tests green.
- `tsc --noEmit` → 0 errors. Independent delivery-path second-pass reviewer: **Concur** — no over-block path drops a legitimate message.
- Side-effects review: `upgrades/side-effects/double-send-inflight-reservation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)