### PR TITLE
feat(lint): keyword-intent-decision ratchet (report-mode)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-04T05-04-24-312Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-04T05-04-24-312Z-unknown.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-07-04T05:04:24.312Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "causalAutopsy": null,
+  "verdict": "pass"
+}

--- a/docs/audits/keyword-intent-classification-audit-2026-07-03.md
+++ b/docs/audits/keyword-intent-classification-audit-2026-07-03.md
@@ -1,0 +1,62 @@
+# Audit — Keyword/Regex Intent-Classification of Natural Language (2026-07-03)
+
+**Trigger:** Operator directive (Justin, topic 29836, 2026-07-03 ~18:45 PDT) after the move-intent
+sentinel hijacked a discussion message. Core principle he named: *we live in a world of LLMs with
+contextual intelligence; a decision about what a human MEANT must be inferred by an LLM over the
+message AND its conversation context — keyword lists are brittle and violate our standards when they
+make that decision.* Sibling to the existing "an LLM gate must not string-match" standard.
+
+**Proposed standard (draft, being shaped with operator):** *"Intelligence Infers, Keywords Only Guard."*
+A decision about what a human MEANT must be made by an LLM reasoning over the message + conversation
+context. Keyword/phrase/regex lists are permitted ONLY to (1) validate against a fixed closed enum, or
+(2) constrain an LLM's already-inferred choice to a known set. A list that DECIDES natural-language
+intent is a bug.
+
+## Genuine bug-class instances (6) — ranked by user-facing impact
+
+| # | Location | Decides | Wired live? | Impact |
+|---|----------|---------|-------------|--------|
+| 1 | `src/core/topicProfileIngress.ts:73` `parseProfileTrigger()` (FRAMEWORK/THINKING regexes) | "change this topic's framework/model/thinking?" | YES — `server.ts:1663` Telegram inbound; actuates a session respawn | HIGH |
+| 2 | `src/core/NicknameCommand.ts:24` `recognizeNicknameCommand()` (TRANSFER_VERBS/PIN_VERBS) | "move/run this on <machine>?" | YES — `server.ts:17705` `_tryNicknameRelocation`; moves the session | HIGH (the hijack) |
+| 3 | `src/threadline/hubCommands.ts:27-34` `parseHubCommand()` (open/tie regexes) | "bind this conversation?" | YES — `server.ts:1817` intercept; **SWALLOWS the message before the agent sees it** | HIGH |
+| 4 | `src/core/TopicClassifier.ts:119` `scoreKeywords()` | topic category + intent + problem type by keyword-hit density | NO (only self-refs) | MED (latent) |
+| 5 | `src/core/AutonomySkill.ts:81` `INTENT_PATTERNS` | "go autonomous/collaborative/…?" from phrases ("I trust you completely") | NO (exported, unwired) | MED (latent; HIGH if wired) |
+| 6 | `src/core/AgentReadinessScorer.ts:54,63` `scoreText()` | task = agent-ready vs human-led by lexicon density | advisory endpoint only | LOW-MED |
+
+**Priority = the three LIVE-WIRED ones (1,2,3)** — each can eat or reroute a real user message.
+
+## Related (same anti-pattern, on AGENT output not user intent — review under standard)
+- `src/core/action-claim.ts` `classifyActionClaim()` (VERB_LEMMAS + FUTURE_LEAD regexes), wired
+  `routes.ts:20305` — classifies the agent's OWN outbound ("did I promise a future action"),
+  signal-only/high-precision. Not user-intent gating. (`time-claim.ts` is NOT this class — it extracts
+  quantified time claims to fact-check vs a clock.)
+
+## Deliberate safety floor — KEEP (the legitimate exception)
+- `src/core/MessageSentinel.ts:193,213` FAST_STOP_PATTERNS / FAST_PAUSE_PATTERNS — emergency-stop
+  fast-path, "tested before LLM classification" with an LLM stage BACKING it. The operator's described
+  deterministic safety floor. (Note co-located `CONTINUE_PING_TOKENS:260` resume-intent pre-filter.)
+
+## Correct pattern already in use (the conversion template — proven, not invented)
+- `src/core/CoherenceGate.ts` — LLM reviewers via IntelligenceProvider (the reference).
+- `src/core/TopicIntentCapture.ts` / `TopicIntentArcCheck.ts` — cheap pre-filter DROPS obvious noise,
+  passes everything ambiguous to an injected LLM `classifyFn`.
+- `src/monitoring/CommitmentSentinel.ts:68` `isBareContinuation` — exact-match ack drop → LLM.
+- `src/core/crossModelReviewer.ts:399` TIER_WORDS — constrains an LLM's chosen tier to a known set (guardrail, correct).
+
+## Cleared as NOT the bug class (verified)
+Process/tmux-output signature matchers (StuckSignatureClassifier, QuotaExhaustionDetector,
+ContextWedgeSentinel, SessionWatchdog, PresenceProxy, SessionManager terminal/idle patterns, …);
+security scrubbers (PolicyEnforcementLayer, InputGuard, SecretRedactor, JargonDetector, …);
+structured/command/enum validators (SafeGitExecutor verbs, DispatchExecutor BLOCKED_COMMANDS,
+topicProfileValidation enums, TransferByNickname/RelocationNicknameSet planner-guardrails, …);
+`.instar/hooks/instar/*` NL hooks operate on the agent's OWN Stop-hook output / tool calls, not
+user-message intent.
+
+## Next steps (gated on operator finalizing the standard wording)
+1. Operator shapes the draft standard → codify it in `docs/STANDARDS-REGISTRY.md`.
+2. Wire a lint that flags keyword/regex lists tested against message/conversation text in
+   sentinel/gate/classifier code (sibling to the LLM-gate-no-string-match ratchet).
+3. Convert the three live-wired offenders first (#1, #2, #3), rebuilt on the CoherenceGate /
+   cheap-prefilter→LLM template, each through the instar-dev ceremony.
+
+_Source: read-only audit agent sweep of src/core, src/monitoring, src/server, src/messaging, src/threadline, .instar/hooks — 2026-07-03. No files modified._

--- a/docs/specs/lint-keyword-intent-decision-ratchet.eli16.md
+++ b/docs/specs/lint-keyword-intent-decision-ratchet.eli16.md
@@ -1,0 +1,37 @@
+# Keyword-Intent Decision Ratchet — Plain-English Overview
+
+> The one-line version: a new test that keeps watch for code that tries to guess what a person MEANT by matching their words against a fixed keyword list — the exact mistake that once made the agent swallow the operator's message.
+
+## The problem in one breath
+
+On 2026-07-03 the agent had a little rule that decided "is this a move-my-work-to-another-machine command?" by checking the message for verbs like `move`, `run`, `keep`. The operator said "keep the work on the laptop" — plain conversation — and that word `keep` tripped the rule, so the message was treated as a command and eaten before the agent ever read it. Keyword lists are brittle in both directions: they fire on ordinary talk and miss real requests. We live inside an intelligence that understands context, so a decision about what a human meant should be made by that intelligence reasoning over the whole message, not by a lookup table of trigger words.
+
+## What already exists
+
+- **The standard "Intelligence Infers, Keywords Only Guard"** — the just-locked constitutional rule that says: an LLM (with conversation context) decides what a human meant; a keyword/phrase/regex list is never the decider. Only two exceptions survive — validating a value against a fixed closed set (e.g. "is this one of off/low/medium/high?"), and a deliberate safety FLOOR (the emergency-stop fast path) that always has an LLM stage behind it.
+- **The audit** (`docs/audits/keyword-intent-classification-audit-2026-07-03.md`) — a full sweep of the source that found exactly six places doing the bad thing, and carefully cleared everything else (error-message classifiers, security scrubbers, enum validators, and code that reads the agent's OWN output rather than a user's message).
+- **The `no-silent-fallbacks` ratchet** — a sibling test that counts a known class of problems and refuses to let the number grow. This new ratchet copies its shape exactly.
+
+## What this adds
+
+A single new test, `tests/unit/keyword-intent-decision-ratchet.test.ts`, that walks the five source directories, spots the "keyword list decides meaning" pattern, subtracts the audit's cleared cases, and reports how many genuine offenders remain. Today that number is six — the exact list the audit found. The number can only go down; a brand-new offender in a new file would push it up and (once enforcement is switched on) fail the build.
+
+Secondary change: a one-line comment marker, `@intent-safety-floor-ok`, added to `MessageSentinel` (the emergency-stop code). That marker is how a legitimate safety floor declares itself so the ratchet leaves it alone — mirroring the existing `@silent-fallback-ok` convention.
+
+## The new pieces
+
+- **The detector** — two signatures. One finds a named list of natural-language words (like `TRANSFER_VERBS`) that is then tested against a message/text variable. The other finds an inline English-phrase regex (like `/^open this$/`) tested against message text. It deliberately errs toward MISSING a subtle case rather than falsely flagging an innocent enum validator, because a noisy ratchet gets ignored and switched off.
+- **The allowlist** — a short, explicit list of files the detector trips on but that are NOT the mistake (they classify an error message, scrub secrets, pick a cosmetic emoji, or read the agent's own output). Each entry says, in one line, why it's cleared. This is what makes the very first run come out clean instead of noisy.
+- **The safety-floor marker** — `@intent-safety-floor-ok`, so a genuine emergency-stop floor exempts itself in place instead of needing an allowlist edit.
+
+## The safeguards
+
+**Prevents a noisy false alarm.** The detector is tuned to under-report, not over-report, and the allowlist covers every cleared case from the audit, so the landing run flags exactly the six known offenders and nothing innocent.
+
+**Prevents silent scope creep.** The baseline is a hard number (six). Any new keyword-list-decides-meaning code raises the count and is surfaced immediately in the test output, with a "NET-NEW" tag pointing at the offending file.
+
+**Prevents blocking unrelated work during the soak.** It ships in report mode: it prints its findings but never fails CI yet. Only after a clean soak does someone flip one flag to make it enforcing — the same graduated rollout every ratchet here uses.
+
+## What ships when
+
+All at once, in one small PR: the ratchet test, the one-line safety-floor marker, and the design/audit/standard docs it references. It is enforcement-in-report-mode from day one; the flip to hard enforcement is a later, deliberate one-line change after the soak confirms zero false positives in CI.

--- a/docs/specs/lint-keyword-intent-decision-ratchet.md
+++ b/docs/specs/lint-keyword-intent-decision-ratchet.md
@@ -1,0 +1,67 @@
+# Spec (draft) — Lint/Ratchet: "No Keyword List Decides Meaning"
+
+**Enforces:** the constitutional standard *Intelligence Infers, Keywords Only Guard*
+(`docs/specs/standard-intelligence-infers-keywords-only-guard.md`). Sibling to the existing
+`no-silent-fallbacks` ratchet and the "an LLM gate must not string-match" guard. Scoped by the audit
+`docs/audits/keyword-intent-classification-audit-2026-07-03.md`.
+
+## What it catches (the anti-pattern signature)
+A keyword/phrase/regex **list of natural-language words** matched against a **message/conversation/user-text**
+variable to **make a decision** (classify intent, gate/reroute/swallow a message). Concretely, in
+`src/core`, `src/monitoring`, `src/server`, `src/threadline`, `src/messaging`:
+- A `const X = ['word','word',...]` (or a set of anchored NL regexes) whose members are natural-language
+  words/phrases (not identifiers, paths, enum tokens), that is then tested via
+  `.includes(` / `.test(` / `.match(` / `.some(` against a variable named/derived from
+  `text|message|msg|content|body|prompt|turn|conversation|lower(...)`.
+
+## What it must NOT flag (the two survivors + the cleared classes)
+1. **Fixed-enum validators** — arrays that validate an already-structured value against a closed set
+   (`THINKING_MODES`, `EFFORT_LEVELS`, `ISSUE_SEVERITIES`, tier/severity/status enums). Heuristic: the
+   list is compared for MEMBERSHIP of a whole token/field value, not scanned within free prose.
+2. **Declared LLM-backed safety floors** — a deterministic first-strike (emergency-stop `^stop`) that is
+   explicitly annotated as a safety floor AND has an LLM stage behind it. Requires an inline
+   `@intent-safety-floor-ok` marker (new, mirroring `@silent-fallback-ok`) naming the LLM backstop.
+3. **Structured-output enums** — a list used as the ALLOWED SET the model must emit into (the correct
+   pattern); recognizable because the list feeds a schema/enum passed to the IntelligenceProvider, not a
+   `.includes` over model prose.
+4. **Cleared non-intent classes** (from the audit): process/tmux-output signature matchers, security
+   scrubbers/redactors, structured command/path validators, and hook scripts that scan the AGENT's own
+   output. Maintain an explicit allowlist keyed by file+symbol from the audit so these don't regress into
+   noise.
+
+## Mechanism (ratchet, like no-silent-fallbacks)
+- A unit test (`tests/unit/keyword-intent-decision-ratchet.test.ts`) walks the target dirs, applies the
+  signature detector, subtracts the allowlist, and asserts the count ≤ a committed baseline.
+- **Baseline = the 6 audit findings** (3 live + 3 latent) MINUS whatever is fixed by the time it lands
+  (the move-recognizer exemplar removes #2). The number can only DECREASE. A new violation fails CI.
+- Each remaining known offender carries a `// TODO(keyword-intent): convert to LLM-with-context — CMT-N`
+  marker so the ratchet's remaining set is self-documenting (Close the Loop).
+- Detector conservatism: err toward FALSE NEGATIVES (miss a subtle one) over FALSE POSITIVES (flag an
+  enum validator) — a noisy ratchet gets disabled. Pair with the audit allowlist so the initial run is
+  clean-by-construction.
+
+## Rollout
+Ship report-mode first (prints the offender set, does not fail CI) for one cycle to confirm zero false
+positives against the allowlist, then flip to failing. Same graduated discipline as other ratchets.
+
+## Open questions (resolved at implementation)
+1. Detector as a bespoke AST/regex walker vs an eslint custom rule — **RESOLVED: bespoke Node/vitest
+   test**, mirroring `no-silent-fallbacks`. eslint is not wired for custom rules here, and the house style
+   is a self-contained vitest ratchet. The detector is a two-part regex signature (named NL-intent list +
+   a message-like decision test; and an inline NL-phrase regex tested against message text), not an AST
+   walker — deliberately, per the conservatism mandate (a coarser signature that errs toward false
+   negatives, paired with the audit allowlist, over a precise walker that risks flagging enum validators).
+2. Extend scope to `.instar/hooks/instar/*` NL hooks — **RESOLVED: out of scope.** The audit cleared them
+   as operating on the agent's own Stop-hook output / tool calls, not user-message intent. The ratchet
+   scans only the five source dirs (`src/core`, `src/monitoring`, `src/server`, `src/threadline`,
+   `src/messaging`).
+
+## Implementation
+`tests/unit/keyword-intent-decision-ratchet.test.ts` (this ratchet). Baseline `6` (per file), the audit's
+six offenders; the number only decreases. Ships in **report mode** (`ENFORCE = false`) — it prints the
+offender set every run but never fails CI on a net-new violation; flip `ENFORCE = true` after a clean soak
+to make the `<= BASELINE` guard hard. The declared safety floor (`MessageSentinel`) is exempted via a new
+inline `@intent-safety-floor-ok` marker (mirroring `@silent-fallback-ok`); the audit's cleared classes are
+subtracted via an explicit per-file `ALLOWLIST` documented by symbol. Verified clean-by-construction on
+`JKHeadley/main`: exactly the six offenders remain, zero false positives on the enum validators / security
+scrubbers / process-and-error matchers / structured-output parsers.

--- a/docs/specs/standard-intelligence-infers-keywords-only-guard.md
+++ b/docs/specs/standard-intelligence-infers-keywords-only-guard.md
@@ -1,0 +1,66 @@
+# Standard (final draft, pending operator last-look) — Intelligence Infers, Keywords Only Guard
+
+**Destination:** `docs/STANDARDS-REGISTRY.md`, under "The Substrate — model-level truths the framework
+must structurally honor" (sibling to "No Silent Degradation to Brittle Fallback"). Origin: operator
+directive 2026-07-03 (topic 29836), after the move-intent recognizer's keyword verb-list hijacked a
+discussion message. Incorporates the operator's four refinements.
+
+---
+
+### Intelligence Infers, Keywords Only Guard
+
+**Rule.** A decision about what a human MEANT — their intent, their request, whether a message is a
+command or just conversation — is made by an LLM reasoning over the message AND its surrounding
+conversation context. A keyword/phrase/regex list is NEVER the decision-maker for natural-language
+meaning.
+
+**Notice and fight the reflex (the load-bearing awareness).** You are an LLM trained on a world where
+keyword lists WERE how software made decisions. That reflex is in your training, and it is wrong here.
+The moment you reach for `const VERBS = [...]` to classify what someone meant, stop — that is the bias
+firing. An LLM excels precisely when given MORE context, not a restricted list of trigger words. This
+awareness is the standard, not a footnote to it.
+
+**The near-total ban.** A keyword list deciding natural-language meaning is a bug, effectively without
+exception. The only two survivors:
+1. **Validating already-structured input against a fixed, closed enum** (e.g. "is this string one of
+   off/low/medium/high/max?") — this validates a value, it does not infer intent.
+2. **A deliberate, LLM-backed safety FLOOR** — e.g. the emergency-stop fast-path that matches `^stop`
+   before the LLM, WITH an LLM stage behind it. Deterministic first strike for safety, never the sole
+   decision. These are rare and must be justified as safety floors.
+
+**Constrain the model's output with structure, never by matching its prose.** When a decision needs a
+value from a limited/standard set OUT of an LLM, do NOT let the model write free text and then
+keyword-match that text. Make the model emit **structured/constrained output** (schema / enum /
+tool-call) whose allowed values ARE the known set. The known set becomes the enum the model must choose
+from — it is structurally incapable of producing an out-of-set answer, and no code ever string-matches
+model prose. (Example: the move recognizer's target machine is an enum of the real nicknames + `null`,
+emitted by the model, not resolved by matching its words.)
+
+**Benchmarks earn a real job.** Constrained/structured output is only as good as the model's adherence
+to it. Measure which models reliably honor schema/enum output and route these decisions to those. This
+is a concrete, measurable bar — exactly what the benchmark harness should exist to answer.
+
+**In practice.** Route the decision through the shared `IntelligenceProvider` (as `CoherenceGate` does).
+Where latency/cost matters, a cheap structural pre-filter may run first but only to DROP obvious noise
+toward pass-through (as `TopicIntentCapture` does) — it may never itself DECIDE a positive intent.
+Fail-OPEN: on any uncertainty (model down, breaker open, low confidence), do the SAFE thing for that
+surface — for a message-gate that can swallow user input, that means pass the message through to the
+agent, never hijack it.
+
+**Enforcement.** A lint/ratchet flags keyword/phrase/regex lists tested against message or conversation
+text inside sentinel/gate/classifier code (sibling to the existing "an LLM gate must not string-match"
+guard, which was clearly not applied everywhere — three live-wired violators found 2026-07-03). New
+such code must justify itself as one of the two survivors or route through an LLM.
+
+**Earned from.** 2026-07-03 (topic 29836): `NicknameCommand.recognizeNicknameCommand` used a verb list
+(`move/transfer/…/run/continue/resume/keep`) to decide if a message was a "move this to <machine>"
+command; it silently hijacked "keep the work on the laptop" (discussion) as a command and swallowed the
+operator's message before the agent saw it. The audit found six instances of the class, three live-wired
+into the inbound message path. The operator's framing: we live inside intelligence that understands
+context — dumbing its decisions down to string-matching is the antithesis of leveraging it, and it is a
+reflex our own training pushes us toward that we must structurally refuse.
+
+**Traces to the goal.** A sovereign, coherent agent must actually USE the intelligence it is. A keyword
+list is brittle in both directions — it fires on discussion and misses genuine intent — so an agent
+that gates its own perception through keyword lists cannot perceive its principal accurately. Coherence
+of understanding requires inference-with-context, not lookup.

--- a/src/core/MessageSentinel.ts
+++ b/src/core/MessageSentinel.ts
@@ -195,6 +195,17 @@ const SLASH_PAUSE: ReadonlySet<string> = new Set([
 /**
  * Regex patterns for fast-path stop detection.
  * Tested before LLM classification.
+ *
+ * @intent-safety-floor-ok — This is the constitutional survivor #2 of the
+ * "Intelligence Infers, Keywords Only Guard" standard: a deterministic
+ * emergency-stop / pause FAST-PATH that runs BEFORE, and WITH, an LLM stage
+ * behind it (MessageSentinel.classify() routes everything that isn't an
+ * unambiguous fast-stop through the injected LLM classifier). The keyword
+ * lists here (FAST_STOP_PATTERNS / FAST_PAUSE_PATTERNS / CONTINUE_PING_TOKENS
+ * / INTENT_B_ADDITIVE / INTENT_C_QUESTION_STARTS) are a safety floor for a
+ * halt-now signal, never the sole decision-maker for natural-language intent.
+ * See docs/specs/standard-intelligence-infers-keywords-only-guard.md and the
+ * keyword-intent-decision ratchet (tests/unit/keyword-intent-decision-ratchet.test.ts).
  */
 const FAST_STOP_PATTERNS: readonly RegExp[] = [
   /^stop\b/i,                         // "stop" at start of message

--- a/tests/unit/keyword-intent-decision-ratchet.test.ts
+++ b/tests/unit/keyword-intent-decision-ratchet.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Infrastructure ratchet — "Intelligence Infers, Keywords Only Guard".
+ *
+ * Enforces the constitutional standard of the same name
+ * (`docs/specs/standard-intelligence-infers-keywords-only-guard.md`, registered in
+ * `docs/STANDARDS-REGISTRY.md`). Sibling to the `no-silent-fallbacks` ratchet and the
+ * "an LLM gate must not string-match" guard. Scoped by the audit
+ * `docs/audits/keyword-intent-classification-audit-2026-07-03.md`. Design:
+ * `docs/specs/lint-keyword-intent-decision-ratchet.md`.
+ *
+ * THE ANTI-PATTERN IT CATCHES: a keyword / phrase / regex list of NATURAL-LANGUAGE
+ * words matched against a message / conversation / user-text variable to MAKE A
+ * DECISION about what a human meant (classify intent, gate / reroute / swallow a
+ * message). Earned from 2026-07-03: `NicknameCommand`'s verb list hijacked the
+ * operator's discussion message "keep the work on the laptop" as a move command and
+ * swallowed it before the agent ever saw it.
+ *
+ * WHAT IT MUST NOT FLAG (the standard's two survivors + the audit's cleared classes):
+ *   1. Fixed-enum validators (validate a whole value against a closed set).
+ *   2. Declared LLM-backed safety FLOORS (emergency-stop fast-path WITH an LLM stage
+ *      behind it) — annotated with an inline `@intent-safety-floor-ok` marker.
+ *   3. Structured-output enums / parsers (the model emits into a known set; code never
+ *      string-matches model prose).
+ *   4. Cleared non-intent classes: process/tmux/error-message signature matchers,
+ *      security scrubbers/redactors, agent-own-output classifiers, cosmetic selectors,
+ *      quantity extractors, observe-only signal loggers. Held in ALLOWLIST below, keyed
+ *      by file (documented by symbol), reproduced from the audit so the initial run is
+ *      clean-by-construction.
+ *
+ * CONSERVATISM: the detector errs toward FALSE NEGATIVES (miss a subtle one) over FALSE
+ * POSITIVES (flag an enum validator). A noisy ratchet gets disabled. The message-variable
+ * gate + the audit allowlist do the precision work.
+ *
+ * ROLLOUT: ships in REPORT MODE first (`ENFORCE = false`) — it prints the offender set on
+ * every run but never fails CI on a net-new violation. After a clean soak, flip
+ * `ENFORCE = true` to make the `<= BASELINE` ratchet hard, exactly like no-silent-fallbacks.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SRC_DIR = path.resolve(__dirname, '../../src');
+const TARGET_DIRS = ['core', 'monitoring', 'server', 'threadline', 'messaging'];
+
+// ── Detector ────────────────────────────────────────────────────────────────
+
+// Message-like variable names — the receiver or argument of a decision test. These
+// are the names the six offenders actually test against; deliberately does NOT
+// include `msg` / `err.message` / `prompt` (those are error / framework-prompt text,
+// never a user's conversational message — see the property-access exclusion below).
+const MSG_VAR = '(?:text|message|content|body|turn|conversation|lower|trimmed|normText|rawText|userText|goalText|tailLower|t)';
+// receiver form: `text.includes(` / `message.match(` — but NOT a property access like `err.message.`
+const RECV_RE = new RegExp(`(?<![.\\w])${MSG_VAR}\\.(?:includes|match|test|exec|indexOf)\\(`);
+// argument form: `.includes(...text)` / `re.test(normText)` — but NOT `.test(err.message)`
+const ARG_RE = new RegExp(`\\.(?:includes|test|exec|match|some)\\([^)]*(?<![.\\w])${MSG_VAR}\\b`);
+
+// Intent-signalling named list constants (VERB(S)/KEYWORD(S)/SIGNAL(S)/INTENT(S)/
+// PHRASE(S)/TRIGGER(S)/LEXICON/LEMMA(S)). Deliberately excludes bare PATTERN(S) / WORD(S)
+// so the many CREDENTIAL_PATTERNS / TERMINAL_ERROR_PATTERNS / STOPWORDS scrubbers do not
+// trip the name filter — the two offenders that use inline NL-phrase regexes are caught by
+// sub-detector 2 instead.
+const INTENT_NAME_RE = /\bconst\s+([A-Za-z0-9_]*(?:VERB|VERBS|KEYWORD|KEYWORDS|SIGNAL|SIGNALS|INTENT|INTENTS|PHRASE|PHRASES|TRIGGER|TRIGGERS|LEXICON|LEMMA|LEMMAS)[A-Za-z0-9_]*)\b/g;
+
+// A natural-language multi-word phrase inside a regex literal source (two lowercase
+// words separated by a whitespace token: `\s`, `\s+`, or a literal space).
+const NL_PHRASE = /[a-z]{2,}(?:\\s\+?| )[a-z]{2,}/;
+
+const FLOOR_MARKER = '@intent-safety-floor-ok';
+
+function hasMsgTest(src: string): boolean {
+  return RECV_RE.test(src) || ARG_RE.test(src);
+}
+
+interface Flag {
+  rel: string;
+  reasons: string[];
+  floor: boolean;
+}
+
+/** Detect the keyword-intent-decision anti-pattern in one file. Returns null if clean. */
+function detect(filePath: string): Flag | null {
+  const src = fs.readFileSync(filePath, 'utf-8');
+  const rel = path.relative(SRC_DIR, filePath).split(path.sep).join('/');
+  const reasons: string[] = [];
+
+  // sub-detector 1: an intent-named NL list + a message-like decision test in the file.
+  INTENT_NAME_RE.lastIndex = 0;
+  const intentNames: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = INTENT_NAME_RE.exec(src))) {
+    const after = src.slice(m.index, m.index + 1500);
+    const lc = (after.match(/['"][a-z][a-z '\-]{1,}['"]/g) || []).length;
+    const hasRe = /=\s*\[/.test(after) && /\/[^/\n]+\/[gimsuy]*/.test(after);
+    if (lc >= 2 || hasRe) intentNames.push(m[1]);
+  }
+  if (intentNames.length && hasMsgTest(src)) {
+    reasons.push(`sub1:named-list[${intentNames.join(',')}]`);
+  }
+
+  // sub-detector 2: an inline NL-phrase regex tested against a message-like var (same line).
+  const lines = src.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!/\.(?:match|test|exec)\(/.test(line)) continue;
+    const reLits = line.match(/\/(?:\\.|[^/\n\\])+\/[gimsuy]*/g) || [];
+    if (!reLits.some((r) => NL_PHRASE.test(r))) continue;
+    if (RECV_RE.test(line) || ARG_RE.test(line)) {
+      reasons.push(`sub2:inline-nl-regex@${i + 1}`);
+      break;
+    }
+  }
+
+  return reasons.length ? { rel, reasons, floor: src.includes(FLOOR_MARKER) } : null;
+}
+
+function getSourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    if (!fs.existsSync(dir)) return;
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (
+        e.name.endsWith('.ts') &&
+        !e.name.endsWith('.test.ts') &&
+        !e.name.endsWith('.d.ts')
+      ) {
+        out.push(p);
+      }
+    }
+  };
+  for (const d of TARGET_DIRS) walk(path.join(SRC_DIR, d));
+  return out;
+}
+
+// ── The known genuine offenders (audit findings 1-6) ─────────────────────────
+// Each decides what a human MEANT from a keyword/regex list, wired into (or reachable
+// from) the inbound message path. These are the baseline; the number only DECREASES as
+// each is converted to LLM-with-context (the CoherenceGate / cheap-prefilter→LLM template).
+const EXPECTED_OFFENDERS = [
+  'core/topicProfileIngress.ts',   // #1 parseProfileTrigger — framework/model/thinking NL regexes (LIVE)
+  'core/NicknameCommand.ts',       // #2 recognizeNicknameCommand — TRANSFER_VERBS/PIN_VERBS (LIVE — the hijack)
+  'threadline/hubCommands.ts',     // #3 parseHubCommand — open/tie NL regexes (LIVE — swallows the message)
+  'core/TopicClassifier.ts',       // #4 scoreKeywords — TOPIC/INTENT/PROBLEM keyword density (latent)
+  'core/AutonomySkill.ts',         // #5 INTENT_PATTERNS — autonomy phrases (latent, exported/unwired)
+  'core/AgentReadinessScorer.ts',  // #6 scoreText — coordination/judgment lexicon density (advisory)
+].sort();
+
+// ── Allowlist — cleared classes that the detector's signature trips but that are NOT
+// the anti-pattern (audit "cleared" set + survivors). Keyed by file, documented by symbol.
+// A file here is a KNOWN blind spot: a NEW keyword-intent gate added INSIDE one of these
+// files would be masked. Every entry maps to an audit-verified non-intent classification.
+const ALLOWLIST: Record<string, string> = {
+  // Survivor #2 handled by the @intent-safety-floor-ok marker, not this list:
+  //   core/MessageSentinel.ts (emergency-stop fast-path WITH an LLM stage behind it).
+
+  // Agent's OWN outbound classified (not a user message) — signal-only, high-precision.
+  'core/action-claim.ts': 'VERB_LEMMAS/FUTURE_LEAD — classifies the agent\'s own outbound "did I promise a future action"; audit "Related", not user-intent gating.',
+  // Process / error-message signature matchers (classify a thrown error, not user text).
+  'core/crossModelReviewer.ts': 'classifyReviewFailure — classifies an error message (rate-limited/timeout); TIER_WORDS is a structured-output enum (survivor #3).',
+  // Structured LLM-output field parsing (parses the model\'s own response, never gates prose).
+  'core/LLMConflictResolver.ts': 'content.match(/^Machine A intent:/m) — parses structured LLM output fields, not keyword-gating user intent.',
+  // Doc-template migration content matching (CLAUDE.md template text, not a user message).
+  'core/PostUpdateMigrator.ts': 'content.includes(...) over the CLAUDE.md template during migration — not a user-message decision.',
+  // Security scrubber — leak detection over the agent\'s OWN outbound draft (the tone gate).
+  'core/MessagingToneGate.ts': 'CALL_PHRASE/CALL_CMD — detects CLI-command/endpoint leaks in the agent\'s outbound draft; security scrubber, cleared class.',
+  // Advisory, non-authority feature-goal classifier — yields to the author declaration.
+  'core/LiveTestGate.ts': 'looksUserFacing — advisory signal over a feature GOAL (dev spec text), never gates a user message; yields to author declaration.',
+  // Cosmetic topic-icon selection — never gates / reroutes / swallows a message.
+  'messaging/TelegramAdapter.ts': 'TOPIC_EMOJI_KEYWORDS — picks a topic-icon emoji from title words; cosmetic, non-authority.',
+  // Quantity extraction (deadline shorthand → cadence) — like time-claim, not intent gating.
+  'monitoring/CommitmentTracker.ts': 'deadline-shorthand extraction ("by eod" → cadence) from a commitment\'s agreement text; quantity extraction, not intent gating.',
+  // Observe-only correction/preference SIGNAL logging feeding an LLM distiller.
+  'monitoring/HumanAsDetectorLog.ts': 'SIGNAL_RULES — observe-only signal logging that feeds an LLM distiller; never decides a message\'s fate (cheap-prefilter→LLM template).',
+  // A2A reply-warrant heuristic (membership + openers) — decides whether to reply to a PEER agent.
+  'threadline/WarrantsReplyGate.ts': 'CONTROL_PHRASES.has(norm) + opener regexes — A2A reply-warrant heuristic (whole-value membership, survivor #1); never swallows operator input.',
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RATCHET BASELINE — only DECREASE, never increase. The count of genuine offenders
+// (per file). Landed at 6 (the audit's six findings). When an offender is converted to
+// LLM-with-context (and thus stops matching), lower this number.
+// ═══════════════════════════════════════════════════════════════════════════════
+const BASELINE = 6;
+
+// Report mode (graduated rollout). While false, the net-new `<= BASELINE` guard only
+// WARNS — it never fails CI. Flip to true after a clean soak to make it hard.
+const ENFORCE = false;
+
+describe('Keyword-Intent Decision Ratchet ("Intelligence Infers, Keywords Only Guard")', () => {
+  const files = getSourceFiles();
+  const flagged = files.map(detect).filter((f): f is Flag => f !== null);
+  const flaggedRels = new Set(flagged.map((f) => f.rel));
+
+  // Offenders = flagged, minus allowlisted files, minus @intent-safety-floor-ok files.
+  const offenders = flagged
+    .filter((f) => !f.floor && !(f.rel in ALLOWLIST))
+    .map((f) => f.rel)
+    .sort();
+
+  it('scans the target directories', () => {
+    expect(files.length).toBeGreaterThan(100);
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
+  it('detects all six known offenders (detector-alive guard)', () => {
+    for (const off of EXPECTED_OFFENDERS) {
+      expect(flaggedRels.has(off), `detector no longer flags known offender ${off}`).toBe(true);
+      expect(offenders, `known offender ${off} must not be allowlisted/floor-exempted`).toContain(off);
+    }
+  });
+
+  it('the declared safety floor carries the @intent-safety-floor-ok marker', () => {
+    const floors = flagged.filter((f) => f.floor).map((f) => f.rel);
+    expect(floors, 'MessageSentinel must be exempted via the safety-floor marker, not the allowlist')
+      .toContain('core/MessageSentinel.ts');
+  });
+
+  it('no allowlist entry is dead weight (each allowlisted file is actually flagged)', () => {
+    const dead = Object.keys(ALLOWLIST).filter((rel) => !flaggedRels.has(rel));
+    if (dead.length) {
+      console.warn(`\n[keyword-intent] allowlist entries no longer flagged (prune them):\n  ${dead.join('\n  ')}\n`);
+    }
+    // Advisory only — a cleared file being refactored out of the signature must never fail CI.
+    expect(Array.isArray(dead)).toBe(true);
+  });
+
+  it('no new keyword-intent-decision violations beyond the baseline', () => {
+    const beyond = offenders.filter((o) => !EXPECTED_OFFENDERS.includes(o));
+
+    const report = offenders
+      .map((rel) => {
+        const f = flagged.find((x) => x.rel === rel)!;
+        const known = EXPECTED_OFFENDERS.includes(rel) ? '' : '  <-- NET-NEW';
+        return `  ${rel} [${f.reasons.join(', ')}]${known}`;
+      })
+      .join('\n');
+
+    console.warn(
+      `\n[KEYWORD-INTENT] ${offenders.length} keyword-list intent decisions (baseline ${BASELINE}, ` +
+        `mode=${ENFORCE ? 'ENFORCE' : 'REPORT'}):\n${report}\n` +
+        (beyond.length
+          ? `\n  ${beyond.length} NET-NEW violation(s) — convert to LLM-with-context or justify as a survivor:\n  ${beyond.join('\n  ')}\n`
+          : ''),
+    );
+
+    if (ENFORCE) {
+      // Hard ratchet: the count can only decrease.
+      expect(offenders.length).toBeLessThanOrEqual(BASELINE);
+    } else {
+      // Report mode: never fail CI on a net-new violation; only the known baseline is asserted
+      // so the detector + allowlist stay honest (clean-by-construction on current main).
+      expect(EXPECTED_OFFENDERS.every((o) => offenders.includes(o))).toBe(true);
+    }
+  });
+});

--- a/upgrades/next/keyword-intent-decision-ratchet.md
+++ b/upgrades/next/keyword-intent-decision-ratchet.md
@@ -1,0 +1,14 @@
+<!-- audience: agent-only | maturity: preview -->
+
+## What Changed
+
+Added a new CI ratchet, `tests/unit/keyword-intent-decision-ratchet.test.ts`, that enforces the constitutional standard **"Intelligence Infers, Keywords Only Guard"**: a natural-language keyword/phrase/regex list must never be the thing that DECIDES what a human meant (classify intent, gate/reroute/swallow a message). The ratchet walks `src/{core,monitoring,server,threadline,messaging}`, detects the anti-pattern, subtracts an explicit per-file allowlist reproduced from the 2026-07-03 audit (enum validators, security scrubbers, error/process-message classifiers, structured-output parsers, cosmetic selectors, quantity extractors, observe-only signal loggers), exempts declared safety floors carrying a new inline `@intent-safety-floor-ok` marker, and asserts the remaining offender count against a committed baseline of **6** (the audit's six findings — the number can only decrease). It ships in **report mode** (`ENFORCE = false`): it prints offenders every run but never fails CI on a net-new violation until the flag is deliberately flipped after a clean soak. `MessageSentinel` gains the `@intent-safety-floor-ok` marker (the standard's survivor #2 — the emergency-stop fast-path with an LLM stage behind it); no logic change.
+
+## What to Tell Your User
+
+Nothing user-facing — this is an internal development guardrail (agent-only, preview maturity). It is the enforcement arm of the "Intelligence Infers, Keywords Only Guard" standard: it structurally prevents new code that dumbs a "what did the human mean?" decision down to keyword matching, the class of bug that once made the agent swallow the operator's "keep the work on the laptop" as a move command. If asked why a future PR fails this check: the change added a keyword list that decides natural-language intent — convert it to an LLM-with-context decision (the CoherenceGate / cheap-prefilter→LLM template) or justify it as one of the two survivors.
+
+## Summary of New Capabilities
+
+- `tests/unit/keyword-intent-decision-ratchet.test.ts` — report-mode ratchet detecting keyword-list intent decisions; baseline 6; sibling to `no-silent-fallbacks`.
+- New inline marker convention `@intent-safety-floor-ok` (mirroring `@silent-fallback-ok`) for declaring a legitimate LLM-backed safety floor.

--- a/upgrades/side-effects/keyword-intent-decision-ratchet.md
+++ b/upgrades/side-effects/keyword-intent-decision-ratchet.md
@@ -1,0 +1,67 @@
+# Side-Effects Review — Keyword-Intent Decision Ratchet (report-mode)
+
+**Version / slug:** `keyword-intent-decision-ratchet`
+**Date:** `2026-07-03`
+**Author:** `Echo (instar-dev)`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Adds `tests/unit/keyword-intent-decision-ratchet.test.ts`, a bespoke vitest ratchet (sibling to `no-silent-fallbacks`) enforcing the constitutional standard "Intelligence Infers, Keywords Only Guard". It walks `src/{core,monitoring,server,threadline,messaging}`, detects the anti-pattern (a natural-language keyword/phrase/regex list tested against a message/conversation/text variable to DECIDE what a human meant), subtracts an explicit per-file allowlist reproduced from the 2026-07-03 audit, exempts declared safety floors carrying a new `@intent-safety-floor-ok` marker, and asserts the remaining offender count against a committed baseline of `6`. Ships in report mode (`ENFORCE = false`): it prints offenders but does not fail CI on a net-new violation. The only behavioral/in-scope file touched is `src/core/MessageSentinel.ts`, which receives a ~15-line comment adding the `@intent-safety-floor-ok` marker (no logic change). Supporting docs (design spec, audit, standard doc) ship alongside.
+
+## Decision-point inventory
+
+- `keyword-intent-decision detector (test-only)` — add — a static-analysis signature that flags files; it never runs at agent runtime and holds no runtime authority over any message.
+- `MessageSentinel FAST_STOP/FAST_PAUSE fast-path` — pass-through — unchanged logic; only a documentation marker is added declaring it the standard's survivor #2 safety floor.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+None at runtime — this is a CI test, not a message gate. Its only "block" surface is failing CI. In report mode (`ENFORCE = false`) it cannot fail CI on a net-new violation at all; it only asserts the six known offenders are still detected (a detector-alive guard) and prints anything new. A CI-level over-block (flagging an innocent file) is prevented by the allowlist, which reproduces the audit's cleared set: enum validators, security scrubbers, error/process-message classifiers, structured-output parsers, cosmetic selectors, quantity extractors, and observe-only signal loggers. Verified on `JKHeadley/main`: the flagged-minus-allowlist set is exactly the six audit offenders — zero false positives.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+By design, it errs toward false negatives (the conservatism mandate — a noisy ratchet gets disabled). Known blind spots: (a) a NEW keyword-intent gate added INSIDE an already-allowlisted file is masked (the allowlist is keyed by file); each allowlist entry is documented by symbol so a reviewer can spot-check. (b) The detector's message-variable set is tight (`text|message|content|body|t|lower|normText|…`); a keyword gate written against an unusually-named variable would be missed. (c) Scope is the five source dirs only; `.instar/hooks/*` and other trees are out of scope (audit-cleared as agent-output). These are accepted per the standard's "miss a subtle one over flag an enum validator" guidance.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes — it is a build-time static-analysis ratchet (low-level, cheap, deterministic), which is exactly the right layer for "no code should string-match to decide intent." It does NOT attempt to be a runtime authority (that would itself violate the standard it enforces). It mirrors the proven `no-silent-fallbacks` ratchet's shape. The runtime conversions of the six offenders (to LLM-with-context) are separate follow-up work the ratchet's baseline tracks; this change only installs the guard.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change has no runtime block/allow surface. It is a CI test. Its detector is brittle-by-nature (regex signature) but holds NO authority over any user message or agent action; it only counts source-code patterns and, when enforcement is later enabled, gates the build against net-new regressions — the same authority every ratchet here holds. The MessageSentinel marker adds no logic.
+
+[The ratchet is the enforcement arm of a standard whose whole point is that brittle keyword logic must not hold intent-decision authority. The ratchet itself scrupulously avoids doing so: it never inspects a live message, only source text.]
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** Sibling to the `no-silent-fallbacks` ratchet and the "an LLM gate must not string-match" guard; complementary, no shadowing. Runs as an ordinary unit test in the vitest suite.
+- **The `@intent-safety-floor-ok` marker** is new and independent of `@silent-fallback-ok` (different detector); no collision.
+- **MessageSentinel:** the marker is a comment inside the file, above `FAST_STOP_PATTERNS`. It does not alter emergency-stop behavior, imports, or exports.
+- **Migration parity:** none required — this touches no agent-installed files (`.claude/settings.json`, `.instar/config.json`, CLAUDE.md template, hook scripts, built-in skills). It is repo-internal test + docs.
+- **CI:** adds one fast unit test (~3ms). No new dependencies (node `fs`/`path` only).
+
+## 6. Rollback
+
+Deleting `tests/unit/keyword-intent-decision-ratchet.test.ts` and reverting the MessageSentinel comment fully removes the change with no state or data implications. The report-mode flag (`ENFORCE = false`) means even a mis-tuned detector cannot block CI before the deliberate enforcement flip.


### PR DESCRIPTION
Enforces the just-locked constitutional standard **"Intelligence Infers, Keywords Only Guard"** (`docs/specs/standard-intelligence-infers-keywords-only-guard.md`). Sibling to the `no-silent-fallbacks` ratchet; scoped by `docs/audits/keyword-intent-classification-audit-2026-07-03.md`. Design: `docs/specs/lint-keyword-intent-decision-ratchet.md`.

## What this is

`tests/unit/keyword-intent-decision-ratchet.test.ts` walks `src/{core,monitoring,server,threadline,messaging}` and detects the anti-pattern: a natural-language keyword/phrase/regex list tested via `.includes/.test/.match/.some/.exec` against a message/conversation/text variable to DECIDE what a human meant. It subtracts an explicit per-file allowlist reproduced from the audit's cleared + two-survivor set, exempts declared safety floors carrying a new `@intent-safety-floor-ok` inline marker, and asserts the remaining offender count against a committed **baseline of 6** (the audit's six findings — the number only decreases).

Ships in **report mode** (`ENFORCE = false`): prints the offender set every run but never fails CI on a net-new violation. Flip `ENFORCE = true` after a clean soak to make the `<= BASELINE` guard hard — the same graduated rollout as every ratchet here.

`MessageSentinel` gains the `@intent-safety-floor-ok` marker (survivor #2: the emergency-stop fast-path WITH an LLM stage behind it). No logic change.

## ELI16

A new test keeps watch for code that guesses what a person MEANT by matching their words against a fixed keyword list — the exact mistake that made the agent swallow the operator's "keep the work on the laptop" as a move command on 2026-07-03. It walks the five source dirs, flags the pattern, subtracts the audit's cleared cases (enum validators, security scrubbers, error/process-message classifiers, structured-output parsers, cosmetic selectors, quantity extractors, observe-only signal loggers), and reports how many genuine offenders remain — today **6**, the audit's exact list. The number can only go down; a brand-new offender pushes it up and, once enforcement is switched on, fails the build. It ships in report mode so it never blocks unrelated work during the soak; one flag flips it to enforcing later. It errs toward false negatives (miss a subtle one) over false positives (flag an enum validator), because a noisy ratchet gets disabled.

## Verification — ZERO false positives

Ran against `JKHeadley/main`: flagged 17 files → minus 10 allowlisted cleared classes → minus 1 `@intent-safety-floor-ok` floor (MessageSentinel) = **exactly the 6 audit offenders**: `topicProfileIngress`, `NicknameCommand`, `hubCommands`, `TopicClassifier`, `AutonomySkill`, `AgentReadinessScorer`. Every allowlisted case verified against the audit — no enum validator, security scrubber, process/error-message classifier, or structured-output enum is flagged. Test: 5 passing, ~3ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)