### PR TITLE
feat(spec-converge): per-family reviewer timeout knob (REVIEWER-DOOR-REWIRING inc2)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-04T23-57-42-193Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-04T23-57-42-193Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-04T23:57:42.193Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 73,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/REVIEWER-DOOR-REWIRING-SPEC-inc2.eli16.md
+++ b/docs/specs/REVIEWER-DOOR-REWIRING-SPEC-inc2.eli16.md
@@ -1,0 +1,44 @@
+# Reviewer-Door Rewiring inc2 — the per-family review timeout knob (plain English)
+
+## What is this?
+
+When Instar's spec-converge tool reviews one of its own design specs, it asks a few
+different AI "reviewers" to read the spec and give an opinion. Three of them are
+external families that run through their own command-line tools: one on OpenAI
+(codex), one on Google (gemini), and — since the previous increment — one on the
+strongest Anthropic model through a clean door. Each of those reviewer calls is
+given a time budget: if the reviewer takes longer than that, the call is cut off
+and recorded as "degraded" (timed out) so the review still finishes instead of
+hanging forever.
+
+Today every family shares the exact same budget: 120 seconds, baked into a
+constant. That is a problem for one reviewer in particular. The Google (gemini)
+model tends to "think" for a long time before answering, so it frequently blows
+past 120 seconds and times out on every round — which means the spec converges
+without ever hearing a real second opinion from that family.
+
+## What does inc2 change?
+
+inc2 adds a single configuration knob — `specConverge.reviewers.timeoutMs` — that
+lets an operator set the time budget **per reviewer family** instead of one value
+for everybody. You can set it two ways:
+
+- A single number, which applies to all three families at once.
+- A small map (`{ default, byFramework }`) that gives one family a bigger budget
+  (say, more headroom for gemini) while leaving the fast ones alone.
+
+Two guardrails keep it safe. First, if you set nothing at all, behavior is
+**exactly** what it is today: 120 seconds for every family, byte-for-byte. Nothing
+on the fleet changes unless someone deliberately turns the knob. Second, whatever
+value you set is clamped to a sane range of 30 to 900 seconds — a typo like "5" or
+"9,999,999" can't create an absurdly short or effectively-infinite timeout.
+
+## What inc2 deliberately does NOT do
+
+This increment only builds the *knob*. It does **not** raise gemini's budget to the
+recommended 600 seconds — that "measure first, then raise" decision belongs to a
+later increment where a maintainer actually watches whether a bigger budget helps
+or just turns fast timeouts into slow bad answers. No default timeout value moves
+in inc2. It is a small, reversible, dark-by-default plumbing change: add the knob,
+thread it through all three families' calls, and prove with tests that an absent
+knob is identical to today and that each family gets its own resolved value.

--- a/skills/spec-converge/scripts/cross-model-review.mjs
+++ b/skills/spec-converge/scripts/cross-model-review.mjs
@@ -253,7 +253,12 @@ async function main() {
   const result = familyEntry
     ? await familyEntry.review({
         promptText: assembled.promptText,
-        timeoutMs: Number.isFinite(timeoutMs) ? timeoutMs : mod.REVIEW_TIMEOUT_MS,
+        // Per-family timeout (REVIEWER-DOOR-REWIRING §3.2 / D6): an explicit
+        // `--timeout-ms` wins; otherwise resolve this family's budget from the
+        // `specConverge.reviewers.timeoutMs` knob (absent ⇒ today's 120s).
+        timeoutMs: Number.isFinite(timeoutMs)
+          ? timeoutMs
+          : mod.resolveReviewerTimeoutMs(reviewerConfig, familyEntry.id),
         detectionOverride: detection,
         reviewerConfig,
       })

--- a/src/core/crossModelReviewer.ts
+++ b/src/core/crossModelReviewer.ts
@@ -72,6 +72,15 @@ import type { IntelligenceOptions } from './types.js';
 export const REVIEW_TIMEOUT_MS = 120_000;
 
 /**
+ * Per-family reviewer-timeout clamp bounds (REVIEWER-DOOR-REWIRING §3.2 / §7 /
+ * D6): a resolved timeout is clamped to [30s, 900s]. A value below the floor
+ * clamps UP to 30s; above the ceiling clamps DOWN to 900s. The 120s default
+ * (`REVIEW_TIMEOUT_MS`) sits inside this range, so an absent knob is unaffected.
+ */
+export const REVIEWER_TIMEOUT_MIN_MS = 30_000;
+export const REVIEWER_TIMEOUT_MAX_MS = 900_000;
+
+/**
  * Total context budget (spec + referenced docs) inlined into the reviewer
  * prompt. codex runs in an empty read-only scratch dir with no repo access,
  * so referenced context MUST be inlined; this bounds the prompt size (spec §2).
@@ -551,6 +560,24 @@ export interface ReviewerConfig {
         /** Optional concrete frontier model override, validated in §1.3. */
         model?: string;
       };
+      /**
+       * Per-family reviewer call timeout (REVIEWER-DOOR-REWIRING §3.2 / D6). EITHER
+       * a single number (milliseconds, applied to ALL families) OR a
+       * `{ default, byFramework }` map for a per-family value. Absent ⇒ today's
+       * 120s default for EVERY family (byte-identical fleet behavior). Each
+       * resolved value is clamped to [30s, 900s]. This knob only adds the
+       * PER-FAMILY budget; it does NOT itself raise any family's default (the
+       * measure-first gemini 600s raise is inc3's dogfood decision). Resolved by
+       * `resolveReviewerTimeoutMs`.
+       */
+      timeoutMs?:
+        | number
+        | {
+            /** Default for any family not named in `byFramework`. */
+            default?: number;
+            /** Per-framework override (milliseconds). */
+            byFramework?: Partial<Record<IntelligenceFramework, number>>;
+          };
     };
   };
 }
@@ -1384,6 +1411,40 @@ export function aggregateRoundOutcomes(
 }
 
 /**
+ * Resolve the per-family reviewer call timeout (REVIEWER-DOOR-REWIRING §3.2 /
+ * §7 / D6) for `frameworkId` from the `specConverge.reviewers.timeoutMs` knob:
+ *
+ *   - absent / non-finite   ⇒ `REVIEW_TIMEOUT_MS` (120s) — today's default for
+ *                             EVERY family (byte-identical fleet behavior).
+ *   - a single number       ⇒ that value applies to ALL families.
+ *   - a `{ default, byFramework }` map ⇒ `byFramework[frameworkId]` if a finite
+ *                             number, else `default` if a finite number, else
+ *                             the 120s default.
+ *
+ * Every non-default resolved value is clamped to [30s, 900s]
+ * (`REVIEWER_TIMEOUT_MIN_MS`..`REVIEWER_TIMEOUT_MAX_MS`). PURE, never throws.
+ * inc2 only ADDS the knob — it changes no family's default value.
+ */
+export function resolveReviewerTimeoutMs(
+  config: ReviewerConfig | undefined,
+  frameworkId: string,
+): number {
+  const knob = config?.specConverge?.reviewers?.timeoutMs;
+  let raw: number | undefined;
+  if (typeof knob === 'number') {
+    raw = knob;
+  } else if (knob && typeof knob === 'object') {
+    const byFw = knob.byFramework?.[frameworkId as IntelligenceFramework];
+    if (typeof byFw === 'number') raw = byFw;
+    else if (typeof knob.default === 'number') raw = knob.default;
+  }
+  // Absent / non-finite ⇒ today's 120s default for EVERY family.
+  if (raw === undefined || !Number.isFinite(raw)) return REVIEW_TIMEOUT_MS;
+  // Clamp 30–900s per family (a below-floor value clamps up; above-ceiling down).
+  return Math.min(REVIEWER_TIMEOUT_MAX_MS, Math.max(REVIEWER_TIMEOUT_MIN_MS, raw));
+}
+
+/**
  * The high-level entry the skill driver calls: detect, and if available run
  * the first available framework's reviewer with the assembled prompt;
  * otherwise return the `unavailable` flag. NEVER throws, NEVER blocks.
@@ -1426,7 +1487,10 @@ export async function runCrossModelReview(args: {
 
   return framework.review({
     promptText: args.assembled.promptText,
-    timeoutMs: args.timeoutMs ?? REVIEW_TIMEOUT_MS,
+    // Per-family timeout (§3.2 / D6): an explicit caller value wins (e.g. the
+    // script's `--timeout-ms` dev override); otherwise resolve the per-family
+    // budget from the `specConverge.reviewers.timeoutMs` knob (absent ⇒ 120s).
+    timeoutMs: args.timeoutMs ?? resolveReviewerTimeoutMs(args.config, framework.id),
     // Hand the already-computed detection down so the entry never re-probes
     // the host (and tests stay hermetic to the injected inputs).
     detectionOverride: detection,

--- a/tests/unit/crossModelReviewer-per-family-timeout.test.ts
+++ b/tests/unit/crossModelReviewer-per-family-timeout.test.ts
@@ -1,0 +1,230 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes per-test mkdtempSync tmpdir.
+//
+// REVIEWER-DOOR-REWIRING inc2 — the per-family reviewer timeout knob
+// (`specConverge.reviewers.timeoutMs`, §3.2 / §7 / D6).
+//
+// Two layers:
+//   1. `resolveReviewerTimeoutMs` — the resolution logic (single number applies
+//      to all families; a `{ default, byFramework }` map overrides per family;
+//      absent ⇒ 120s for EVERY family, byte-identical; clamp [30s, 900s]).
+//   2. Wiring — each family's invocation actually RECEIVES its resolved timeout
+//      (the driver resolves per `framework.id`; the family passes it to
+//      `provider.evaluate`), and an explicit caller value still wins.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  resolveReviewerTimeoutMs,
+  runCrossModelReview,
+  REVIEW_TIMEOUT_MS,
+  REVIEWER_TIMEOUT_MIN_MS,
+  REVIEWER_TIMEOUT_MAX_MS,
+  SUPPORTED_REVIEWER_FRAMEWORKS,
+  type ReviewerConfig,
+} from '../../src/core/crossModelReviewer.js';
+import type { IntelligenceOptions as _IO } from '../../src/core/types.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// The three reviewer families the knob must reach (§3.2 — codex, gemini, claude).
+const FAMILIES = ['codex-cli', 'gemini-cli', 'claude-code'] as const;
+
+const claudeEntry = () => SUPPORTED_REVIEWER_FRAMEWORKS.find((f) => f.id === 'claude-code')!;
+
+/** A stub provider that captures the options (incl. `timeoutMs`) it was called with. */
+function capturingProvider() {
+  const calls: Array<{ prompt: string; options?: _IO }> = [];
+  return {
+    calls,
+    evaluate: async (prompt: string, options?: _IO) => {
+      calls.push({ prompt, options });
+      return 'Verdict: CLEAN\nLooks good.';
+    },
+  };
+}
+
+let tmpDir: string;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reviewer-timeout-test-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeCodexAuth(): string {
+  const p = path.join(tmpDir, 'auth.json');
+  fs.writeFileSync(p, JSON.stringify({ tokens: { access_token: 'oauth-access-token-value' } }), 'utf-8');
+  return p;
+}
+function writeGeminiCreds(): string {
+  const p = path.join(tmpDir, 'gemini-creds.json');
+  fs.writeFileSync(p, JSON.stringify({ access_token: 'gemini-oauth-token' }), 'utf-8');
+  return p;
+}
+
+// Build a ReviewerConfig carrying a given `timeoutMs` knob. Typed `unknown` so
+// the intentionally-malformed inputs (NaN, strings, null) can be exercised.
+const cfg = (timeoutMs: unknown): ReviewerConfig => ({
+  specConverge: { reviewers: { timeoutMs: timeoutMs as never } },
+});
+
+// ── Layer 1: resolveReviewerTimeoutMs ───────────────────────────────────────
+
+describe('resolveReviewerTimeoutMs — absent knob is byte-identical 120s for EVERY family', () => {
+  it('absent config ⇒ exactly 120s (REVIEW_TIMEOUT_MS) for every family', () => {
+    for (const fam of FAMILIES) {
+      expect(resolveReviewerTimeoutMs(undefined, fam)).toBe(120_000);
+      expect(resolveReviewerTimeoutMs(undefined, fam)).toBe(REVIEW_TIMEOUT_MS);
+      expect(resolveReviewerTimeoutMs({}, fam)).toBe(REVIEW_TIMEOUT_MS);
+      // config present but no reviewers/timeoutMs block ⇒ still 120s.
+      expect(resolveReviewerTimeoutMs({ specConverge: { reviewers: {} } }, fam)).toBe(REVIEW_TIMEOUT_MS);
+    }
+  });
+
+  it('a non-number / non-finite knob degrades to the 120s default (never NaN/throw)', () => {
+    for (const bad of [NaN, Infinity, -Infinity, 'oops' as unknown as number, null as unknown as number]) {
+      expect(resolveReviewerTimeoutMs(cfg(bad), 'gemini-cli')).toBe(REVIEW_TIMEOUT_MS);
+    }
+    // a map whose byFramework/default are non-finite ⇒ 120s.
+    expect(resolveReviewerTimeoutMs(cfg({ default: NaN, byFramework: { 'gemini-cli': Infinity } }), 'gemini-cli')).toBe(
+      REVIEW_TIMEOUT_MS,
+    );
+  });
+});
+
+describe('resolveReviewerTimeoutMs — single-number form applies to ALL families', () => {
+  it('one number is used for codex, gemini, AND claude alike', () => {
+    for (const fam of FAMILIES) {
+      expect(resolveReviewerTimeoutMs(cfg(300_000), fam)).toBe(300_000);
+    }
+  });
+});
+
+describe('resolveReviewerTimeoutMs — byFramework map overrides PER family', () => {
+  it('a named family gets its byFramework value; an unnamed family falls back to default', () => {
+    const config = cfg({ default: 200_000, byFramework: { 'gemini-cli': 600_000 } });
+    expect(resolveReviewerTimeoutMs(config, 'gemini-cli')).toBe(600_000); // named override
+    expect(resolveReviewerTimeoutMs(config, 'codex-cli')).toBe(200_000); // falls back to default
+    expect(resolveReviewerTimeoutMs(config, 'claude-code')).toBe(200_000); // falls back to default
+  });
+
+  it('an unnamed family with NO default falls back to the 120s default', () => {
+    const config = cfg({ byFramework: { 'gemini-cli': 500_000 } });
+    expect(resolveReviewerTimeoutMs(config, 'gemini-cli')).toBe(500_000);
+    expect(resolveReviewerTimeoutMs(config, 'codex-cli')).toBe(REVIEW_TIMEOUT_MS);
+  });
+
+  it('the map is genuinely per-family (not uniform): each family resolves independently', () => {
+    const config = cfg({
+      byFramework: { 'codex-cli': 90_000, 'gemini-cli': 600_000, 'claude-code': 300_000 },
+    });
+    expect(resolveReviewerTimeoutMs(config, 'codex-cli')).toBe(90_000);
+    expect(resolveReviewerTimeoutMs(config, 'gemini-cli')).toBe(600_000);
+    expect(resolveReviewerTimeoutMs(config, 'claude-code')).toBe(300_000);
+  });
+});
+
+describe('resolveReviewerTimeoutMs — clamp to [30s, 900s]', () => {
+  it('exports the clamp bounds as 30s / 900s', () => {
+    expect(REVIEWER_TIMEOUT_MIN_MS).toBe(30_000);
+    expect(REVIEWER_TIMEOUT_MAX_MS).toBe(900_000);
+  });
+
+  it('a below-floor value clamps UP to 30s (10s → 30s)', () => {
+    expect(resolveReviewerTimeoutMs(cfg(10_000), 'gemini-cli')).toBe(30_000);
+    expect(resolveReviewerTimeoutMs(cfg(0), 'codex-cli')).toBe(30_000);
+  });
+
+  it('an above-ceiling value clamps DOWN to 900s (2000s → 900s)', () => {
+    expect(resolveReviewerTimeoutMs(cfg(2_000_000), 'gemini-cli')).toBe(900_000);
+  });
+
+  it('an in-range value passes through unchanged (600s)', () => {
+    expect(resolveReviewerTimeoutMs(cfg(600_000), 'gemini-cli')).toBe(600_000);
+  });
+
+  it('clamps within the byFramework map and default too', () => {
+    const config = cfg({ default: 3_000_000, byFramework: { 'codex-cli': 5_000 } });
+    expect(resolveReviewerTimeoutMs(config, 'codex-cli')).toBe(30_000); // byFramework floor
+    expect(resolveReviewerTimeoutMs(config, 'gemini-cli')).toBe(900_000); // default ceiling
+  });
+});
+
+// ── Layer 2: wiring — each family's invocation RECEIVES its resolved timeout ──
+
+describe('wiring — the knob reaches the family call site through the driver (per-family)', () => {
+  const assembled = { promptText: 'PROMPT', truncated: false, bytes: 6 };
+
+  it('codex: the driver resolves codex-cli and passes ITS byFramework timeout to evaluate', async () => {
+    const provider = capturingProvider();
+    const config = cfg({ default: 200_000, byFramework: { 'codex-cli': 90_000, 'gemini-cli': 600_000 } });
+    const r = await runCrossModelReview({
+      assembled,
+      config,
+      detectInputs: { codexPathDetected: '/usr/bin/codex', authJsonPath: writeCodexAuth(), env: {} },
+      providerOverride: provider,
+    });
+    expect(r.status).toBe('ok');
+    expect(r.framework).toBe('codex-cli');
+    expect(provider.calls[0].options?.timeoutMs).toBe(90_000); // codex's own value, NOT gemini's 600s
+  });
+
+  it('gemini: the driver resolves gemini-cli and passes ITS byFramework timeout to evaluate', async () => {
+    const provider = capturingProvider();
+    const config = cfg({ default: 200_000, byFramework: { 'codex-cli': 90_000, 'gemini-cli': 600_000 } });
+    const r = await runCrossModelReview({
+      assembled,
+      config,
+      // codex unavailable → gemini is the first available family.
+      detectInputs: {
+        codexPathDetected: null,
+        geminiPathDetected: '/usr/bin/gemini',
+        geminiOauthCredsPath: writeGeminiCreds(),
+        env: {},
+      },
+      providerOverride: provider,
+    });
+    expect(r.status).toBe('ok');
+    expect(r.framework).toBe('gemini-cli');
+    expect(provider.calls[0].options?.timeoutMs).toBe(600_000); // gemini's own value, NOT codex's 90s
+  });
+
+  it('absent config through the driver ⇒ 120s reaches evaluate (byte-identical)', async () => {
+    const provider = capturingProvider();
+    const r = await runCrossModelReview({
+      assembled,
+      // no `config` at all
+      detectInputs: { codexPathDetected: '/usr/bin/codex', authJsonPath: writeCodexAuth(), env: {} },
+      providerOverride: provider,
+    });
+    expect(r.status).toBe('ok');
+    expect(provider.calls[0].options?.timeoutMs).toBe(REVIEW_TIMEOUT_MS);
+  });
+
+  it('an explicit caller timeout (e.g. --timeout-ms) WINS over the config knob', async () => {
+    const provider = capturingProvider();
+    const config = cfg({ byFramework: { 'codex-cli': 90_000 } });
+    await runCrossModelReview({
+      assembled,
+      config,
+      timeoutMs: 45_000, // explicit override
+      detectInputs: { codexPathDetected: '/usr/bin/codex', authJsonPath: writeCodexAuth(), env: {} },
+      providerOverride: provider,
+    });
+    expect(provider.calls[0].options?.timeoutMs).toBe(45_000); // explicit wins; NOT the 90s knob
+  });
+
+  it('claude: the family passes its resolved per-family timeout to evaluate', async () => {
+    const provider = capturingProvider();
+    const config = cfg({ byFramework: { 'claude-code': 300_000 } });
+    const resolved = resolveReviewerTimeoutMs(config, 'claude-code');
+    expect(resolved).toBe(300_000);
+    const r = await claudeEntry().review({
+      promptText: 'review this spec',
+      timeoutMs: resolved,
+      providerOverride: provider,
+      hardeningSupportedOverride: true,
+    });
+    expect(r.status).toBe('ok');
+    expect(provider.calls[0].options?.timeoutMs).toBe(300_000); // claude's own value reached evaluate
+  });
+});

--- a/upgrades/next/reviewer-door-rewiring-inc2.md
+++ b/upgrades/next/reviewer-door-rewiring-inc2.md
@@ -1,0 +1,60 @@
+---
+user_announcement:
+  - audience: agent-only
+    maturity: experimental
+---
+
+<!-- bump: minor -->
+
+## What Changed
+
+Added a per-family timeout knob for the spec-converge external reviewers:
+`specConverge.reviewers.timeoutMs`. Previously all three external reviewer families
+(codex-cli, gemini-cli, and the inc1 claude-code clean-door family) shared one hardcoded
+120-second call budget. This is **inc2** of REVIEWER-DOOR-REWIRING (§3.2 / §7 / D6).
+
+The knob accepts EITHER a single number (milliseconds, applied to every family) OR a
+`{ default, byFramework }` map that sets a per-family budget with a default fallback. Each
+resolved value is clamped to the range 30s–900s. A new pure resolver
+(`resolveReviewerTimeoutMs(config, frameworkId)`) computes the per-family value and is
+threaded through both invocation paths: the `runCrossModelReview` driver (resolves per the
+detected `framework.id`) and the `cross-model-review.mjs --family` path (resolves per
+`familyEntry.id`). An explicit `--timeout-ms` dev override still wins over the knob.
+
+**Absent config is byte-identical to today**: with no `timeoutMs` set, every family resolves
+to the existing 120-second default — so fleet behavior does not change. inc2 only adds the
+knob; it does NOT raise any family's default value. The rationale for per-family (rather than
+one shared knob) is that gemini-3.1-pro-preview burns large reasoning budgets and needs more
+headroom, whereas codex latency is ~18.5s — a single shared 600s knob would expand the fast
+families' dead-wait for no benefit. The measure-first decision to actually raise gemini's
+budget is deferred to inc3's dogfood checklist.
+
+## What to Tell Your User
+
+Nothing proactive — this is instar-developing-agent tooling and nothing changes unless an
+operator deliberately turns the knob. If a user asks why a spec-review reviewer keeps timing
+out, or whether one reviewer can be given more time than the others: I can now set a separate
+time budget for each reviewer family (for example, more headroom for the Google reviewer,
+which tends to think for longer) instead of one shared limit for all of them. Any value I set
+is kept within a safe 30-second-to-15-minute range, and if I set nothing the behavior is
+exactly what it is today.
+
+## Summary of New Capabilities
+
+- **Per-family reviewer timeout** — the spec-converge external reviewers (codex, gemini, and
+  the development-agent clean-door Anthropic reviewer) can each carry their own call time
+  budget instead of sharing one 120-second limit.
+- **Two config shapes** — a single number for all families, or a per-family map with a default
+  fallback; every value is clamped to a sane 30s–900s range.
+- **Absent = unchanged** — with no config set, every family keeps today's 120-second default,
+  byte-for-byte, on the fleet.
+
+## Evidence
+
+- `tests/unit/crossModelReviewer-per-family-timeout.test.ts` — 16 unit + wiring tests: single
+  number applies to all families; per-family map overrides with default fallback; absent config
+  resolves to exactly 120s for every family (byte-identical); clamp low/high/in-range and within
+  the map; each family's invocation receives its own resolved timeout through the driver
+  (per-family, not uniform); an explicit caller timeout wins over the knob.
+- Existing `crossModelReviewer` unit + integration suites re-run green (105 unit + 10 integration),
+  confirming no behavior change to the inc1 reviewer families.

--- a/upgrades/side-effects/reviewer-door-rewiring-inc2.md
+++ b/upgrades/side-effects/reviewer-door-rewiring-inc2.md
@@ -1,0 +1,110 @@
+# Side-Effects Review — Reviewer-Door Rewiring inc2 (per-family review timeout knob)
+
+**Version / slug:** `reviewer-door-rewiring-inc2`
+**Date:** `2026-07-04`
+**Author:** `echo (build hand)`
+**Tier:** `1`
+**Second-pass reviewer:** `not required (Tier-1: no default value changed, absent-config byte-identical, config-reversible, no durable state / external side-effects; PR is the review surface)`
+
+## Summary of the change
+
+inc2 of REVIEWER-DOOR-REWIRING adds the per-family reviewer-call timeout knob
+(`specConverge.reviewers.timeoutMs`, §3.2 / §7 / D6). It resolves a per-family
+timeout from the config knob and threads it through all three reviewer families'
+invocations (codex-cli, gemini-cli, claude-code). The knob accepts EITHER a single
+number (applies to all families) OR a `{ default, byFramework }` map (per-family
+override with a default fallback). Absent config resolves to today's exact 120s
+default (`REVIEW_TIMEOUT_MS`) for every family — fleet behavior byte-identical.
+Every resolved value is clamped to [30s, 900s]. inc2 ONLY adds the knob: it changes
+no family's default timeout value (the measure-first gemini 600s raise is inc3's
+dogfood decision, not built here).
+
+Files touched:
+
+- `src/core/crossModelReviewer.ts` — new `resolveReviewerTimeoutMs(config, frameworkId)`
+  resolver + `REVIEWER_TIMEOUT_MIN_MS` / `REVIEWER_TIMEOUT_MAX_MS` clamp constants + the
+  `timeoutMs` field on the `ReviewerConfig.specConverge.reviewers` type; `runCrossModelReview`
+  resolves the per-family timeout from the knob (`args.timeoutMs ?? resolveReviewerTimeoutMs(...)`).
+- `skills/spec-converge/scripts/cross-model-review.mjs` — the `--family` path resolves its
+  per-family timeout from the knob when no explicit `--timeout-ms` is passed.
+- `tests/unit/crossModelReviewer-per-family-timeout.test.ts` — new unit + wiring test file (16 tests).
+
+## Decision-point inventory
+
+- `specConverge.reviewers.timeoutMs` config field — **add** — a per-family knob (number OR map). Absent-safe.
+- `resolveReviewerTimeoutMs` — **add** — pure resolver (single-number / byFramework / default / absent) + clamp.
+- `REVIEWER_TIMEOUT_MIN_MS` / `REVIEWER_TIMEOUT_MAX_MS` — **add** — exported clamp bounds (30s / 900s).
+- `runCrossModelReview` timeout resolution — **modify** — resolves per detected `framework.id` (was a bare `?? REVIEW_TIMEOUT_MS`); an explicit caller value still wins.
+- `cross-model-review.mjs --family` timeout resolution — **modify** — resolves per `familyEntry.id`; explicit `--timeout-ms` still wins.
+- No block/allow gate, no HTTP route, no scheduler job, no watcher is introduced or modified.
+- No default timeout VALUE is changed.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+Nothing is rejected. The knob is purely additive and read per-invocation. A garbage
+value (NaN, a string, null, Infinity, a non-finite `default`/`byFramework`) falls back
+to the 120s default rather than throwing or producing a NaN timeout — the resolver is
+pure and never throws. A below-floor or above-ceiling value is clamped, not refused, so a
+misconfiguration still yields a working (bounded) timeout rather than a failed review.
+
+## 2. Under-block
+
+**What bad inputs does this change now allow through that it shouldn't?**
+
+The clamp bounds this precisely: a value below 30s cannot starve a reviewer into an
+instant timeout, and a value above 900s cannot create a 10-round × huge-timeout tail.
+The knob only sets a *time budget*; it grants no authority, changes no egress
+destination, and cannot alter the cross-model flag (that is `crossFamily` semantics from
+inc1, untouched here). An explicit `--timeout-ms` dev override still wins over the knob,
+preserving existing test/dev affordances.
+
+## 3. Blast radius
+
+**If this change is wrong, what breaks and how widely?**
+
+Bounded to the spec-converge external-reviewer call timeouts on a development agent. On
+the fleet the knob is absent, so behavior is byte-identical to today (120s per family) —
+a bug in the resolver could only surface where an operator has deliberately set the knob.
+Worst case of a resolver bug is a wrong (but clamped, 30–900s) timeout on a reviewer call,
+which degrades loudly as a timeout and never blocks convergence (Signal vs. Authority,
+§6). No durable state, no external side-effect, no data migration.
+
+## 4. Reversibility
+
+**How is this rolled back?**
+
+Delete the `specConverge.reviewers.timeoutMs` config value → the resolver returns the 120s
+default for every family. Or revert this PR (constants + resolver + two call-site edits +
+one test file). No persistence, no interface consumed downstream (the field is
+disclosure-free config read per invocation).
+
+## 5. Migration parity
+
+New config field `specConverge.reviewers.timeoutMs` — absent-safe by construction (no
+`migrateConfig` entry needed for fleet correctness; fleet-absence = today's behavior).
+`.instar/config.json` is machine-local (no config replication in instar), so setting the
+knob is a per-machine edit. No settings.json hooks, no CLAUDE.md template section (this is
+instar-developing-agent tooling, not an end-user capability).
+
+## 6. Framework generality
+
+The knob is threaded through the framework-agnostic reviewer registry: the same resolver
+is applied per `framework.id` for codex-cli, gemini-cli, and claude-code alike (and any
+future family added to `SUPPORTED_REVIEWER_FRAMEWORKS`). It routes through the reviewer
+abstraction rather than assuming any single framework; per-framework values are the whole
+point (gemini's reasoning-burn needs more headroom than codex's ~18.5s latency).
+
+## 7. Testing
+
+Unit + wiring (16 tests, `tests/unit/crossModelReviewer-per-family-timeout.test.ts`):
+single-number applies to all families; `byFramework` overrides per family with default
+fallback; **absent config → exactly 120s for every family (byte-identical)**; clamp
+(10s→30s, 2000s→900s, in-range passthrough, clamp within map/default); each family's
+invocation actually receives its resolved timeout through the driver (codex + gemini via
+forced detection, claude via the family entry) — per-family, not uniform; and an explicit
+caller timeout wins over the knob. Existing crossModelReviewer unit + integration suites
+re-run green (105 unit + 10 integration).


### PR DESCRIPTION
## ELI16

When Instar reviews one of its own design specs, it asks three outside AI reviewers to read it — one on OpenAI (codex), one on Google (gemini), and one on the strongest Anthropic model through a clean door (added in inc1). Each reviewer gets a time budget: go over it and the call is cut off and recorded as "timed out" so the review still finishes instead of hanging forever.

Today every reviewer shares one hardcoded budget: 120 seconds. That is too tight for the Google reviewer in particular, which tends to "think" for a long time and so times out on every round — meaning the spec converges without ever hearing a real second opinion from it.

This PR adds a single config knob, `specConverge.reviewers.timeoutMs`, that lets an operator set the time budget PER reviewer family instead of one value for everyone. You can pass a single number (applies to all) or a small `{ default, byFramework }` map that gives one family more headroom while leaving the fast ones alone. Two guardrails keep it safe: with no config set, behavior is byte-for-byte identical to today (120s for every family), and any value you do set is clamped to a sane 30s–900s range.

This is increment 2 of the converged REVIEWER-DOOR-REWIRING spec. It ONLY adds the knob — it does not raise any family's default value (the measure-first gemini raise is inc3's dogfood decision). Fully reversible (delete the config value), no durable state, no new egress.

## What this PR does

Adds `specConverge.reviewers.timeoutMs` — a per-family reviewer-call timeout knob (§3.2 / §7 / D6).

- **`resolveReviewerTimeoutMs(config, frameworkId)`** — a new pure resolver: a single-number knob applies to all families; a `{ default, byFramework }` map resolves `byFramework[id]` → `default` → the 120s default; absent/non-finite → today's 120s default; every non-default value clamped to `[REVIEWER_TIMEOUT_MIN_MS, REVIEWER_TIMEOUT_MAX_MS]` = `[30s, 900s]`. Never throws.
- **Threaded through all three families' invocations** via both call sites: the `runCrossModelReview` driver resolves per the detected `framework.id`, and the `cross-model-review.mjs --family` path resolves per `familyEntry.id`. An explicit `--timeout-ms` dev override still wins.
- **`timeoutMs` field** added to the `ReviewerConfig.specConverge.reviewers` type (number OR `{ default, byFramework }` map).
- No default timeout VALUE is changed; no block/allow gate, HTTP route, scheduler job, or watcher is introduced or modified.

## Tests

`tests/unit/crossModelReviewer-per-family-timeout.test.ts` (16 unit + wiring):

- single-number form applies to all families; `byFramework` map overrides per family with `default` fallback and 120s fallback for unnamed families with no default;
- **absent config → exactly 120s for every family (byte-identical)**; a non-finite/garbage knob degrades to 120s;
- clamp: below-floor `10s → 30s`, above-ceiling `2000s → 900s`, in-range passthrough, and clamp within the map/default;
- **each family's invocation receives its resolved timeout through the driver (per-family, not uniform)** — codex + gemini via forced detection, claude via the family entry;
- an explicit caller timeout wins over the knob.

Existing `crossModelReviewer` unit + integration suites re-run green (105 unit + 10 integration; the pre-push smoke tier ran 138 test cases green including the live inbound-safety STATE test).

## Rollout / safety

Tier-1: dark-by-default (the knob is absent on the fleet), config-reversible, no durable state or new external side-effect destination. Fleet behavior byte-identical when config absent (asserted). Does not touch inc1's shipped reviewer families' defaults, and does not touch inc3/inc4. Operator approval of the converged spec is deliberately left to the operator per the run mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
