### PR TITLE
fix(messaging): make the outbound-advisory off-switch reachable on array-shaped messaging

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-05T00-07-49-247Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-05T00-07-49-247Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-05T00:07:49.247Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 49,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -4792,7 +4792,7 @@ setTimeout(() => process.exit(0), 2000);
     // "NOT SENT — advisory" transcript line means will treat it as an error
     // and improvise; this section is the awareness (Agent Awareness Standard).
     if (!content.includes('Outbound advisory for automated messages')) {
-      content += `\n**Outbound advisory for automated messages (inform-only)** — When a background job of mine sends a Telegram message, the relay script first runs deterministic checks over the text (raw file paths, dev jargon, machine-local links). If something is flagged, the message is NOT sent yet: an advisory lands in the job session's transcript whose FIRST line is the literal \`NOT SENT — advisory (fix and re-run, or re-run with --ack-advisory to send unchanged)\`. The sender keeps final authority — the advisory layer never blocks, never escalates against the sender, and every error path delivers.\n- **If I see a NOT SENT advisory in my transcript** (PROACTIVE — this is the trigger): FIX the message and re-run the script — restate jargon in plain English; replace a raw file path by publishing a private view and sending the link; replace a localhost link with the public tunnel URL (a localhost link is the one finding \`--ack-advisory\` can NOT deliver — a pre-existing server guard refuses it regardless). Only \`--ack-advisory\` when the flagged content is genuinely right for the user (the override is audited).\n- Audit trail: \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/messaging/advisory-log?limit=50"\`. A job that repeatedly drops its own advised messages raises ONE deduped Attention item to the operator.\n- Conversational replies are unaffected by the jargon/path/link checks — those only run for scheduler-stamped automated job sends.\n- **TIME_CLAIM (accurate time reporting — MANDATED)**: when a topic has an ACTIVE time-boxed (autonomous) session, ANY send to it — automated or conversational — has its elapsed/remaining/percent claims verified against the live session clock. A claim contradicting the clock gets the NOT-SENT advisory: read \`GET /session/clock\` and re-send with the real numbers — NEVER estimate elapsed/remaining time. (Ships dark; rides the development-agent gate at \`messaging.outboundAdvisory.timeClaim.enabled\`.)\n- Off-switch: \`messaging.outboundAdvisory.enabled: false\` in \`.instar/config.json\` (read live — no restart).\n`;
+      content += `\n**Outbound advisory for automated messages (inform-only)** — When a background job of mine sends a Telegram message, the relay script first runs deterministic checks over the text (raw file paths, dev jargon, machine-local links). If something is flagged, the message is NOT sent yet: an advisory lands in the job session's transcript whose FIRST line is the literal \`NOT SENT — advisory (fix and re-run, or re-run with --ack-advisory to send unchanged)\`. The sender keeps final authority — the advisory layer never blocks, never escalates against the sender, and every error path delivers.\n- **If I see a NOT SENT advisory in my transcript** (PROACTIVE — this is the trigger): FIX the message and re-run the script — restate jargon in plain English; replace a raw file path by publishing a private view and sending the link; replace a localhost link with the public tunnel URL (a localhost link is the one finding \`--ack-advisory\` can NOT deliver — a pre-existing server guard refuses it regardless). Only \`--ack-advisory\` when the flagged content is genuinely right for the user (the override is audited).\n- Audit trail: \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/messaging/advisory-log?limit=50"\`. A job that repeatedly drops its own advised messages raises ONE deduped Attention item to the operator.\n- Conversational replies are unaffected by the jargon/path/link checks — those only run for scheduler-stamped automated job sends.\n- **TIME_CLAIM (accurate time reporting — MANDATED)**: when a topic has an ACTIVE time-boxed (autonomous) session, ANY send to it — automated or conversational — has its elapsed/remaining/percent claims verified against the live session clock. A claim contradicting the clock gets the NOT-SENT advisory: read \`GET /session/clock\` and re-send with the real numbers — NEVER estimate elapsed/remaining time. (Ships dark; rides the development-agent gate at \`messaging.outboundAdvisory.timeClaim.enabled\`.)\n- Off-switch: \`outboundAdvisory.enabled: false\` (TOP-LEVEL) in \`.instar/config.json\` (read live — no restart; the block is top-level, NOT nested under \`messaging\` — which is an array of adapters, so a nested key there is unreachable).\n`;
       patched = true;
       result.upgraded.push('CLAUDE.md: added Outbound advisory for automated messages section');
     }
@@ -4804,13 +4804,32 @@ setTimeout(() => process.exit(0), 2000);
     // line. Content-sniff on 'TIME_CLAIM' keeps it idempotent.
     if (content.includes('Outbound advisory for automated messages') && !content.includes('TIME_CLAIM')) {
       const timeClaimBullet = `- **TIME_CLAIM (accurate time reporting — MANDATED)**: when a topic has an ACTIVE time-boxed (autonomous) session, ANY send to it — automated or conversational — has its elapsed/remaining/percent claims verified against the live session clock. A claim contradicting the clock gets the NOT-SENT advisory: read \`GET /session/clock\` and re-send with the real numbers — NEVER estimate elapsed/remaining time. (Ships dark; rides the development-agent gate at \`messaging.outboundAdvisory.timeClaim.enabled\`.)\n`;
-      const offSwitchMarker = '- Off-switch: `messaging.outboundAdvisory.enabled: false`';
+      // Match on the stable prefix (not the config key) so the anchor still finds
+      // the off-switch line whether CLAUDE.md carries the legacy nested key or the
+      // new top-level `outboundAdvisory.enabled` key (off-switch-config-shape fix).
+      const offSwitchMarker = '- Off-switch: `';
       const idx = content.indexOf(offSwitchMarker);
       content = idx !== -1
         ? content.slice(0, idx) + timeClaimBullet + content.slice(idx)
         : content + '\n' + timeClaimBullet;
       patched = true;
       result.upgraded.push('CLAUDE.md: added TIME_CLAIM bullet to Outbound advisory section');
+    }
+
+    // off-switch-config-shape fix (Migration Parity): existing agents' CLAUDE.md
+    // documents the outbound-advisory off-switch at the LEGACY nested key
+    // `messaging.outboundAdvisory.enabled`, which is UNREACHABLE on a real install
+    // (`messaging` is an array) — so the documented off-switch never worked. Swap it
+    // for the reachable TOP-LEVEL `outboundAdvisory.enabled` key. Content-sniff on the
+    // old literal keeps it idempotent (a CLAUDE.md already carrying the new key is
+    // untouched).
+    if (content.includes('Off-switch: `messaging.outboundAdvisory.enabled: false`')) {
+      content = content.replace(
+        /- Off-switch: `messaging\.outboundAdvisory\.enabled: false`[^\n]*/,
+        '- Off-switch: `outboundAdvisory.enabled: false` (TOP-LEVEL) in `.instar/config.json` (read live — no restart; the block is top-level, NOT nested under `messaging` — which is an array of adapters, so a nested key there is unreachable).',
+      );
+      patched = true;
+      result.upgraded.push('CLAUDE.md: moved outbound-advisory off-switch to the reachable top-level key');
     }
 
     // Durable Inbound Message Queue (spec durable-inbound-message-queue, CMT-1118)

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -775,7 +775,7 @@ I declare owner/blockedOn at commitment creation; a later state change goes thro
 - Audit trail: \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/messaging/advisory-log?limit=50"\`. A job that repeatedly drops its own advised messages raises ONE deduped Attention item to the operator.
 - Conversational replies are unaffected by the jargon/path/link checks — those only run for scheduler-stamped automated job sends.
 - **TIME_CLAIM (accurate time reporting — MANDATED)**: when a topic has an ACTIVE time-boxed (autonomous) session, ANY send to it — automated or conversational — has its elapsed/remaining/percent claims verified against the live session clock. A claim contradicting the clock gets the NOT-SENT advisory: read \`GET /session/clock\` and re-send with the real numbers — NEVER estimate elapsed/remaining time. (Ships dark; rides the development-agent gate at \`messaging.outboundAdvisory.timeClaim.enabled\`.)
-- Off-switch: \`messaging.outboundAdvisory.enabled: false\` in \`.instar/config.json\` (read live — no restart).
+- Off-switch: \`outboundAdvisory.enabled: false\` (TOP-LEVEL) in \`.instar/config.json\` (read live — no restart; the block is top-level, NOT nested under \`messaging\` — which is an array of adapters, so a nested key there is unreachable).
 
 **Quota Tracking** — Monitor Claude API usage when configured.
 - Check: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/quota\`

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2301,10 +2301,14 @@ export function createRoutes(ctx: RouteContext): Router {
   // Thresholds are live-config reads — tuning needs no restart.
   const outboundAdvisoryAudit = new OutboundAdvisoryAudit({
     logPath: path.join(ctx.config.stateDir, '..', 'logs', 'outbound-advisory.jsonl'),
+    // Top-level `outboundAdvisory` is the reachable home (messaging is an array);
+    // legacy `messaging.outboundAdvisory` honored as fallback.
     getIgnoreThreshold: () =>
-      ctx.liveConfig?.get<number>('messaging.outboundAdvisory.ignoreEscalationThreshold', 3) ?? 3,
+      (ctx.liveConfig?.get<number | undefined>('outboundAdvisory.ignoreEscalationThreshold', undefined) ??
+        ctx.liveConfig?.get<number>('messaging.outboundAdvisory.ignoreEscalationThreshold', 3)) ?? 3,
     getSlugThreshold: () =>
-      ctx.liveConfig?.get<number>('messaging.outboundAdvisory.ignoreEscalationSlugThreshold', 5) ?? 5,
+      (ctx.liveConfig?.get<number | undefined>('outboundAdvisory.ignoreEscalationSlugThreshold', undefined) ??
+        ctx.liveConfig?.get<number>('messaging.outboundAdvisory.ignoreEscalationSlugThreshold', 5)) ?? 5,
     raiseAttention: (item) =>
       ctx.telegram
         ? ctx.telegram.createAttentionItem({
@@ -11469,7 +11473,18 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       return;
     }
     const kind = coerceMessageKind((req.body ?? {}).messageKind) ?? 'reply';
-    const enabled = ctx.liveConfig?.get<boolean>('messaging.outboundAdvisory.enabled', true) ?? true;
+    // Config home: on a real install `messaging` is an ARRAY of adapter configs,
+    // so `messaging.outboundAdvisory.*` is UNREACHABLE (getNestedValue → undefined
+    // → the default) — which made the documented off-switch a no-op (an operator
+    // could not disable the advisory). Read the reachable TOP-LEVEL `outboundAdvisory`
+    // block; honor the legacy `messaging.outboundAdvisory` as a back-compat fallback.
+    // (Same config-unreachable-on-shape class as PR #1379 — the un-DISABLABLE
+    // sub-class: a default-ON gate whose off-switch is at an unreachable path. The
+    // lint-no-unreachable-messaging-gate guard covers the default-OFF sub-class.)
+    const enabled =
+      (ctx.liveConfig?.get<boolean | undefined>('outboundAdvisory.enabled', undefined) ??
+        ctx.liveConfig?.get<boolean>('messaging.outboundAdvisory.enabled', true)) ??
+      true;
     if (!enabled) {
       // Rollback lever (live config, no restart): behave exactly like a clean
       // preflight so the script proceeds straight to the send.
@@ -11493,7 +11508,8 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     // (standard_development_agent_dark_feature_gate); resolution failure
     // degrades to "no clocks" — fail-open like every detector.
     const timeClaimEnabled = resolveDevAgentGate(
-      ctx.liveConfig?.get<boolean | undefined>('messaging.outboundAdvisory.timeClaim.enabled', undefined),
+      ctx.liveConfig?.get<boolean | undefined>('outboundAdvisory.timeClaim.enabled', undefined) ??
+        ctx.liveConfig?.get<boolean | undefined>('messaging.outboundAdvisory.timeClaim.enabled', undefined),
       ctx.config,
     );
     let activeClocks: ReturnType<typeof readSessionClocks> = [];

--- a/tests/unit/outbound-advisory-config-shape.test.ts
+++ b/tests/unit/outbound-advisory-config-shape.test.ts
@@ -1,0 +1,75 @@
+// safe-git-allow: test fixture cleanup uses fs.rmSync on tmp dirs only.
+/**
+ * Unit (Tier 1) — outbound-advisory off-switch config-shape fix.
+ *
+ * THE BUG (same class as PR #1379): the preflight route read the off-switch at
+ * `messaging.outboundAdvisory.enabled`. On a real install `messaging` is a JSON ARRAY
+ * of adapter configs, so that dot-path resolves undefined → the `true` default → the
+ * DOCUMENTED off-switch (`enabled: false`) had NO effect; an operator could not
+ * disable the advisory. This is the un-DISABLABLE sub-class (default-ON). The fix reads
+ * the reachable TOP-LEVEL `outboundAdvisory.enabled` (legacy nested key honored as a
+ * fallback). Uses a REAL LiveConfig reading a REAL array-shaped config file — the flat
+ * dot-path mock in outbound-advisory-routes.test.ts cannot reproduce the array shape.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { LiveConfig } from '../../src/config/LiveConfig.js';
+
+let tmpDir: string;
+function writeConfig(over: Record<string, unknown>) {
+  fs.writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify({ port: 0, ...over }));
+}
+function makeApp(): express.Express {
+  const liveConfig = new LiveConfig(tmpDir);
+  const ctx = {
+    config: { projectName: 't', projectDir: tmpDir, stateDir: tmpDir, port: 0 } as any,
+    liveConfig,
+    sessionManager: { listRunningSessions: () => [], clearInjectionTracker: () => {} } as any,
+    state: { listSessions: () => [] } as any,
+    telegram: null, scheduler: null, relationships: null, feedback: null, commitmentTracker: null,
+    startTime: new Date(),
+  } as any as RouteContext;
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+const ARRAY_MESSAGING = [
+  { type: 'telegram', enabled: true, config: { botToken: 'x' } },
+  { type: 'slack', enabled: true, config: { botToken: 'y', appToken: 'z' } },
+];
+
+beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oa-shape-')); });
+afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+describe('outbound-advisory off-switch on real (array-shaped) messaging', () => {
+  it('array messaging + TOP-LEVEL outboundAdvisory.enabled:false → the advisory IS disablable', async () => {
+    writeConfig({ messaging: ARRAY_MESSAGING, outboundAdvisory: { enabled: false } });
+    const res = await request(makeApp()).post('/messaging/preflight').send({ text: 'hello', messageKind: 'reply' });
+    expect(res.status).toBe(200);
+    // Before the fix this returned enabled (the off-switch was unreachable). Now the
+    // top-level off-switch works: the route reports disabled and proceeds to send.
+    expect(res.body).toMatchObject({ disabled: true });
+  });
+
+  it('array messaging + NO outboundAdvisory config → enabled by default (not disabled)', async () => {
+    writeConfig({ messaging: ARRAY_MESSAGING });
+    const res = await request(makeApp()).post('/messaging/preflight').send({ text: 'hello', messageKind: 'reply' });
+    expect(res.status).toBe(200);
+    expect(res.body.disabled).not.toBe(true);
+  });
+
+  it('BACK-COMPAT: legacy object-shaped messaging.outboundAdvisory.enabled:false still disables', async () => {
+    writeConfig({ messaging: { outboundAdvisory: { enabled: false } } });
+    const res = await request(makeApp()).post('/messaging/preflight').send({ text: 'hello', messageKind: 'reply' });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ disabled: true });
+  });
+});

--- a/upgrades/next/outbound-advisory-offswitch-config-shape.md
+++ b/upgrades/next/outbound-advisory-offswitch-config-shape.md
@@ -1,0 +1,39 @@
+---
+user_announcement:
+  - audience: agent-only
+    maturity: stable
+---
+
+## What Changed
+
+Fixed the outbound-advisory off-switch, which was silently broken on every real install. The preflight
+route read `messaging.outboundAdvisory.enabled`, but on a real install `messaging` is a JSON **array**
+of adapter configs, so that path resolves `undefined` → the `true` default → the documented off-switch
+(`messaging.outboundAdvisory.enabled: false`) had **no effect** (an operator could not disable the
+advisory). This is the un-DISABLABLE sibling of the PR #1379 un-ENABLABLE bug. The off-switch and tune
+knobs now read from a reachable **top-level `outboundAdvisory`** block (the legacy nested key is
+honored as a back-compat fallback). Existing agents' docs are corrected via a CLAUDE.md migration.
+
+## What to Tell Your User
+
+Nothing proactive — this is an internal fix. If a user ever asks why turning off the automated-message
+advisory did nothing, the answer is that the off-switch was written in a spot the program could not
+read; it now lives at a reachable top-level setting and genuinely works. The advisory is inform-only
+and unchanged otherwise; this only makes its off button work.
+
+## Summary of New Capabilities
+
+- The outbound advisory is now genuinely **disablable** via top-level `outboundAdvisory.enabled: false`.
+- Its tuning knobs (escalation thresholds, the time-claim dev-gate) read from the same reachable
+  top-level block.
+- Legacy object-shaped `messaging.outboundAdvisory` config keeps working (fallback).
+- Existing agents' CLAUDE.md off-switch line is auto-corrected to the reachable key on update.
+
+## Evidence
+
+- `tests/unit/outbound-advisory-config-shape.test.ts` — real LiveConfig + a real array-shaped config:
+  the top-level off-switch disables the advisory (impossible before the fix), default-on when unset,
+  object-shape back-compat.
+- Existing `outbound-advisory-routes` / `outbound-advisory` / `telegram-reply-advisory-script` tests
+  (58) stay green; `tsc` clean; `lint-no-unreachable-messaging-gate` clean.
+- Sibling audit that surfaced it: `docs/investigations/messaging-config-unreachable-audit-2026-07-04.md`.

--- a/upgrades/side-effects/outbound-advisory-offswitch-config-shape.eli16.md
+++ b/upgrades/side-effects/outbound-advisory-offswitch-config-shape.eli16.md
@@ -1,0 +1,41 @@
+# ELI16 — the "off" button for the auto-message advisory didn't do anything
+
+## The story
+
+Instar has an "outbound advisory" — when a background job tries to send you a message, it first checks
+the text for raw file paths, dev jargon, or localhost links and, if it finds any, holds the message so
+the agent can fix it. It's on by default, and the docs told operators they could turn it off by
+setting a switch: `messaging.outboundAdvisory.enabled: false`.
+
+The problem: that switch never worked on a real setup. The config's "messaging" section is a **list**
+of chat platforms, not a labeled box — so a switch addressed as if it were a box *inside* that list
+can't be read. The program looked, found nothing, and used the default ("on"). So an operator who
+tried to turn the advisory off would find it stubbornly still on, with no error explaining why.
+
+This is the same shape of bug we fixed earlier for the promise follow-through feature (PR #1379). That
+one was worse — a feature you could never turn *on*. This one is milder — a feature you can't turn
+*off* — because it defaults to on, so it still works; you just can't disable it.
+
+## What this change does
+
+It moves the switch to a spot the program can actually read: a **top-level `outboundAdvisory`**
+setting, right next to the other real settings instead of buried in the platform list. Setting
+`outboundAdvisory.enabled: false` there now genuinely turns the advisory off. The old (broken) nested
+key is still honored where it *can* be read (for setups that use a box-shaped config), so nothing that
+worked before breaks. The docs are corrected to point at the new switch — both for new agents and, via
+a small automatic update, for agents that already have the old wording in their notes.
+
+## Why it's safe
+
+- The advisory is inform-only — it never blocks your messages — so there's no risk of it wrongly
+  rejecting anything. The only change is that its off-button now works.
+- Old configs keep working (the old key is a fallback), so it's backwards compatible.
+- It's a plain code + docs change; if it were ever wrong, the fix is a simple revert with no leftover
+  data to clean up.
+
+## How we know it works
+
+A new test sets up the config the **real** way — "messaging" as a list — flips the new top-level
+off-switch, and confirms the advisory reports itself disabled (which was impossible before the fix). It
+also checks the default-on behavior when the switch isn't set, and that the old box-shaped config still
+works. The 58 existing advisory tests all still pass.

--- a/upgrades/side-effects/outbound-advisory-offswitch-config-shape.md
+++ b/upgrades/side-effects/outbound-advisory-offswitch-config-shape.md
@@ -1,0 +1,117 @@
+# Side-Effects Review — outbound-advisory off-switch reachable on array-shaped messaging
+
+**Version / slug:** `outbound-advisory-offswitch-config-shape`
+**Date:** `2026-07-04`
+**Author:** `Echo`
+**Second-pass reviewer:** `not required (Tier-1)`
+
+## Summary of the change
+
+The outbound-advisory preflight route read its off-switch (and tuning knobs) at
+`messaging.outboundAdvisory.*`. On a real install `messaging` is a JSON **array** of adapter configs,
+so that dot-path resolves `undefined` → the read's default. For the `enabled` read (default `true`)
+that meant the **documented off-switch (`messaging.outboundAdvisory.enabled: false`) had no effect —
+an operator could not disable the advisory** (the un-DISABLABLE sub-class of the PR #1379 bug). Fix:
+read from the reachable **top-level `outboundAdvisory`** block (canonical), honoring the legacy
+`messaging.outboundAdvisory` as a back-compat fallback. Applied to all four reads
+(`enabled`, `ignoreEscalationThreshold`, `ignoreEscalationSlugThreshold`, `timeClaim.enabled` dev-gate),
+the documented off-switch key in both templates, and an existing-agent CLAUDE.md doc migration.
+Files: `src/server/routes.ts`, `src/core/PostUpdateMigrator.ts`, `src/scaffold/templates.ts`, + test.
+
+## Decision-point inventory
+
+- `POST /messaging/preflight` `enabled` gate (`routes.ts`) — **modify** — top-level-first resolution.
+- `OutboundAdvisoryAudit` threshold reads (`routes.ts`) — **modify** — top-level-first.
+- `timeClaim.enabled` dev-gate value (`routes.ts`) — **pass-through** — sourced top-level-first;
+  `undefined → live-on-dev` semantics unchanged.
+- CLAUDE template off-switch text (both `PostUpdateMigrator` content + `scaffold/templates`) —
+  **modify** — documents the reachable top-level key.
+- `PostUpdateMigrator` TIME_CLAIM anchor marker — **modify** — matched on the stable `- Off-switch: \``
+  prefix so it still anchors regardless of which key the line carries.
+- New `migrateClaudeMd` swap — **add** — updates an existing agent's stale nested-key off-switch line.
+
+## 1. Over-block / 2. Under-block
+
+No block/allow surface change of consequence: the advisory is inform-only and never blocks a message.
+The only behavior change is that the **off-switch now actually works** — an operator who sets
+`outboundAdvisory.enabled: false` disables the advisory (previously impossible). Over-block N/A;
+under-block N/A.
+
+## 3. Level-of-abstraction fit
+
+Right layer — same top-level-first config-read pattern as PR #1379, applied at the read sites. No new
+authority, no new machinery.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — no runtime block/allow surface changes; the advisory remains inform-only. This restores a
+  broken operator control (an off-switch), it does not add gating authority.
+
+## 5. Interactions
+
+- **Shadowing:** none — top-level-first read is a superset of prior behavior; on object-messaging the
+  legacy fallback resolves identically.
+- **Double-fire / races / feedback loops:** none.
+- **Migration marker:** the TIME_CLAIM anchor now matches the stable `- Off-switch: \`` prefix, so it
+  still finds the off-switch line whether CLAUDE.md carries the old nested or the new top-level key —
+  verified the substring is present in both.
+
+## 6. External surfaces
+
+- **Install base / agents:** existing agents get the corrected off-switch DOC via the new
+  `migrateClaudeMd` swap (content-sniff, idempotent) on their next update; new agents via the
+  templates. The CODE fix ships with the server. No config migration needed to keep working (top-level
+  is additive; legacy still honored).
+- **Operator surface:** restores a documented operator control (the off-switch). No new UI/route.
+- **Persistent state / external systems:** none.
+
+## 6b. Operator-surface quality
+
+No dashboard/approval/form surface — not applicable (the off-switch is a config edit, now at a
+reachable key, documented for the operator).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN** — config (`.instar/config.json`) is per-machine; the advisory runs
+per-machine on the sending machine. This change only alters where in the local config the flag is
+read. No cross-machine state, notice, durable state, or URL.
+
+## 8. Rollback cost
+
+Pure code + doc change — revert the reads + template text + the one migration block. No persistent
+state; the top-level key is additive and the legacy fallback preserves prior behavior. Zero-cost
+back-out.
+
+## Conclusion
+
+Restores the outbound-advisory off-switch that was silently broken on every real (array-`messaging`)
+install — the un-DISABLABLE sibling of the PR #1379 un-ENABLABLE bug, found by the sibling audit
+(`docs/investigations/messaging-config-unreachable-audit-2026-07-04.md`). Code + docs + existing-agent
+migration + a real-LiveConfig array-shape test. Clear to ship.
+
+## Second-pass review (if required)
+
+**Reviewer:** not required (Tier-1)
+
+## Evidence pointers
+
+- `tests/unit/outbound-advisory-config-shape.test.ts` — real LiveConfig + real array-shaped config:
+  top-level off-switch disables (was impossible before the fix), default-on when unset, object-shape
+  back-compat.
+- Existing `outbound-advisory-routes` / `outbound-advisory` / `telegram-reply-advisory-script` tests
+  (58) stay green; `tsc` clean; `lint-no-unreachable-messaging-gate` clean.
+
+## Class-Closure Declaration (display-only mirror)
+
+- **`defectClass`** — `config-unreachable-on-shape` (the PR #1379 class; this is its un-DISABLABLE
+  default-ON sub-class).
+- **`closure`** — `gap` — the #1381 lint catches the default-OFF (un-enablable) sub-class; the
+  default-ON un-disablable sub-class (`.get('messaging.*.enabled', true)` with a documented off-switch)
+  is not reliably lint-detectable without false positives (documented in the #1381 side-effects
+  follow-ups). This fix ships the direct regression test + moves the config to the reachable
+  convention; the class-level guard for the un-disablable sub-class remains a tracked gap.
+- **`guardEvidence`** — n/a for `closure: gap`.
+- **`gap`** — tracked in `docs/investigations/messaging-config-unreachable-audit-2026-07-04.md`
+  (follow-up 2) + the #1381 side-effects artifact.


### PR DESCRIPTION
## ELI16 — the "off" button for the auto-message advisory did nothing

Instar's "outbound advisory" checks a background job's outgoing message for raw file paths / jargon / localhost links and holds it for the agent to fix. It's on by default, and the docs said you could turn it off with `messaging.outboundAdvisory.enabled: false`. That switch never worked on a real setup: the config's "messaging" section is a **list** of chat platforms, not a labeled box, so a switch addressed as if it were a box inside that list can't be read — the program used the default ("on"). So an operator who tried to disable it found it stubbornly still on, with no error. Same shape as the earlier PR #1379 bug, milder direction: that one was un-turn-*on*-able (default off); this one is un-turn-*off*-able (default on, so it still works — you just can't disable it). This moves the switch to a reachable **top-level `outboundAdvisory`** setting so it genuinely turns off; the old nested key is still honored where it can be read, and the docs are corrected (new agents + an auto-update for existing ones).

## The bug

`POST /messaging/preflight` read the off-switch at `messaging.outboundAdvisory.enabled`. On a real install `messaging` is a JSON **array** of adapter configs → `LiveConfig.getNestedValue` returns `undefined` → the `true` default → the documented off-switch had **no effect**. This is the un-DISABLABLE (default-ON) sibling of the PR #1379 un-ENABLABLE bug, found by the sibling config-unreachability audit (`docs/investigations/messaging-config-unreachable-audit-2026-07-04.md`).

## The fix

Read the off-switch + tune knobs (`ignoreEscalationThreshold`, `ignoreEscalationSlugThreshold`) + the `timeClaim.enabled` dev-gate from a reachable **top-level `outboundAdvisory`** block; honor the legacy `messaging.outboundAdvisory` as a back-compat fallback (mirrors #1379). Docs updated in both templates + an idempotent `migrateClaudeMd` swap for existing agents; the TIME_CLAIM anchor now matches the stable off-switch prefix so it still anchors regardless of the key.

## Tests (all green)

- **New** `tests/unit/outbound-advisory-config-shape.test.ts` — real LiveConfig + real array-shaped config: top-level off-switch disables (impossible before the fix), default-on when unset, object-shape back-compat.
- 58 existing `outbound-advisory-routes` / `outbound-advisory` / `telegram-reply-advisory-script` tests stay green; `tsc` clean; `lint-no-unreachable-messaging-gate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
