### PR TITLE
fix(slack): re-mint the conversation bind token on Slack session respawn (closes the S7 gap)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-05T02-57-12-581Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-05T02-57-12-581Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-05T02:57:12.581Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 49,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-05T03-17-22-779Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-05T03-17-22-779Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-05T03:17:22.779Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 5,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-05T03-18-47-788Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-05T03-18-47-788Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-05T03:18:47.788Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 5,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-05T03-19-48-348Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-05T03-19-48-348Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-05T03:19:48.348Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 54,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -23,6 +23,7 @@ const execFileAsync = promisify(execFile);
 import { loadConfig, ensureStateDir, detectTmuxPath, detectGeminiPath } from '../core/Config.js';
 import { handleProcessLevelError } from '../core/uncaughtExceptionPolicy.js';
 import { planInboundLossNotices } from '../core/inboundLossRouting.js';
+import { slackRespawnBootstrapIds } from '../core/slackRefreshBinding.js';
 import { configureHostSpawnSemaphore } from '../core/hostSpawnSemaphore.js';
 import { SpawningTopicsRegistry } from '../core/SpawningTopicsRegistry.js';
 import { TopicReachabilityVerifier } from '../monitoring/TopicReachabilityVerifier.js';
@@ -16766,6 +16767,24 @@ export async function startServer(options: StartOptions): Promise<void> {
               const sep = routingKey.indexOf(':');
               const slackChannelId = sep === -1 ? routingKey : routingKey.slice(0, sep);
               const slackThreadTs = sep === -1 ? undefined : routingKey.slice(sep + 1);
+              // durable-conversation-identity §7 (slack-respawn-bind-token fix): a
+              // FRESH Slack spawn passes `bootstrapConversationIds: [conversationId]`
+              // (server.ts fresh-dispatch path) so the session mints INSTAR_BIND_TOKEN
+              // + INSTAR_CONVERSATION_ID and can open durable state (a commitment)
+              // bound to the minted id. This RESPAWN path (used by /sessions/refresh,
+              // quota-swap, restart, restart-all — all funnel through SessionRefresh →
+              // slackRespawner) previously OMITTED it, so a refreshed/quota-swapped
+              // Slack session came up token-less and its durable binds were refused
+              // (fail-closed) → the follow-through fell back to a fragile session-local
+              // timer that dies on the next restart (the live-proven S7 gap). Telegram's
+              // respawn is unaffected because it passes telegramTopicId, which
+              // bindTokenEnvFlags uses as a fallback; Slack has no such fallback.
+              // mintForInbound is an idempotent get-or-create → the SAME minted id the
+              // fresh dispatch resolved for this routingKey. (Helper is unit-tested in
+              // slackRefreshBinding.ts.)
+              const bootstrapIds = slackRespawnBootstrapIds(routingKey, (k) =>
+                conversationRegistry.mintForInbound(k),
+              );
               const newSessionName = await sessionManager.spawnInteractiveSession(
                 followUpPrompt ?? 'Session refreshed — continue where you left off.',
                 undefined,
@@ -16773,6 +16792,7 @@ export async function startServer(options: StartOptions): Promise<void> {
                   resumeSessionId,
                   slackChannelId,
                   slackThreadTs,
+                  ...(bootstrapIds ? { bootstrapConversationIds: bootstrapIds } : {}),
                   ...(accountSwap?.configHome ? { configHome: accountSwap.configHome } : {}),
                   ...(accountSwap?.accountId ? { subscriptionAccountId: accountSwap.accountId } : {}),
                 },

--- a/src/core/slackRefreshBinding.ts
+++ b/src/core/slackRefreshBinding.ts
@@ -92,3 +92,37 @@ export function parseSlackConversationKey(key: string): string | null {
  * Slack↔numeric bridging (PresenceProxy, resume heartbeat).
  */
 export { candidateIdForRoutingKey as slackRoutingKeySyntheticId } from './conversationIdentity.js';
+
+/**
+ * slack-respawn-bind-token fix: resolve the `bootstrapConversationIds` for a Slack
+ * session RESPAWN (the /sessions/refresh, quota-swap, restart, restart-all paths, all
+ * funneling through SessionRefresh → slackRespawner) from its `routingKey`.
+ *
+ * A FRESH Slack spawn passes `bootstrapConversationIds: [conversationId]` so the session
+ * mints `INSTAR_BIND_TOKEN` + `INSTAR_CONVERSATION_ID` (durable-conversation-identity §7)
+ * and can open durable state (a commitment) bound to its minted conversation id. The
+ * respawn path previously OMITTED it, so a refreshed/quota-swapped Slack session came up
+ * token-less and its durable binds were refused (fail-closed) → the follow-through fell
+ * back to a fragile session-local timer that dies on the next restart (the live-proven
+ * S7 gap). This restores parity. `mintForInbound` is an idempotent get-or-create, so it
+ * returns the SAME id the fresh dispatch resolved for this key.
+ *
+ * Fail-toward-respawn: any resolution error → `undefined` (the prior token-less
+ * behavior), NEVER throws — a refresh must never be blocked by id resolution.
+ */
+export function slackRespawnBootstrapIds(
+  routingKey: string,
+  mintForInbound: (key: string) => { id: number | null },
+): number[] | undefined {
+  try {
+    const id = mintForInbound(routingKey).id;
+    return typeof id === 'number' ? [id] : undefined;
+  } catch {
+    /* @silent-fallback-ok: fail-toward-respawn — id resolution must NEVER block a Slack
+       session refresh/quota-swap/restart; a resolution error degrades to `undefined`
+       (the prior token-less behavior), exactly the safe direction. The absence of a bind
+       token only means this respawned session can't open durable state until its next
+       clean spawn — never a lost refresh. */
+    return undefined;
+  }
+}

--- a/tests/unit/slack-respawn-bootstrap-ids.test.ts
+++ b/tests/unit/slack-respawn-bootstrap-ids.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit (Tier 1) — slack-respawn-bind-token fix.
+ *
+ * A FRESH Slack spawn passes `bootstrapConversationIds: [conversationId]` so the session
+ * mints INSTAR_BIND_TOKEN + INSTAR_CONVERSATION_ID and can open durable state bound to its
+ * minted id. The RESPAWN path (refresh/quota-swap/restart → SessionRefresh → slackRespawner)
+ * previously omitted it, so a refreshed Slack session came up token-less and its durable
+ * commitment binds were refused → ephemeral-timer fallback (the live-proven S7 gap).
+ * `slackRespawnBootstrapIds` restores parity by resolving the id from the routing key.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { slackRespawnBootstrapIds } from '../../src/core/slackRefreshBinding.js';
+
+describe('slackRespawnBootstrapIds', () => {
+  it('resolves the minted conversation id → [id] (parity with the fresh Slack spawn)', () => {
+    const mint = vi.fn().mockReturnValue({ id: -1734007126 });
+    expect(slackRespawnBootstrapIds('C0BA4F4E0FP', mint)).toEqual([-1734007126]);
+    expect(mint).toHaveBeenCalledWith('C0BA4F4E0FP');
+  });
+
+  it('passes the full routing key (channel:thread) through to mintForInbound', () => {
+    const mint = vi.fn().mockReturnValue({ id: -42 });
+    expect(slackRespawnBootstrapIds('C0BA4F4E0FP:1783198568.171129', mint)).toEqual([-42]);
+    expect(mint).toHaveBeenCalledWith('C0BA4F4E0FP:1783198568.171129');
+  });
+
+  it('returns undefined when the registry yields a null id (no minted id) — no bind opt', () => {
+    expect(slackRespawnBootstrapIds('C0X', () => ({ id: null }))).toBeUndefined();
+  });
+
+  it('FAILS TOWARD RESPAWN: a throwing registry → undefined, never rethrows (a refresh must not be blocked)', () => {
+    const mint = vi.fn(() => {
+      throw new Error('registry unavailable');
+    });
+    expect(() => slackRespawnBootstrapIds('C0X', mint)).not.toThrow();
+    expect(slackRespawnBootstrapIds('C0X', mint)).toBeUndefined();
+  });
+});

--- a/upgrades/next/slack-respawn-bind-token.md
+++ b/upgrades/next/slack-respawn-bind-token.md
@@ -1,0 +1,41 @@
+---
+user_announcement:
+  - audience: agent-only
+    maturity: stable
+---
+
+## What Changed
+
+Fixed the final live-proven S7 gap: a Slack session that gets **respawned** (via `/sessions/refresh`,
+a quota-swap, a restart, or restart-all — all funnel through `SessionRefresh` → `slackRespawner`) now
+re-mints its conversation bind token. A **fresh** Slack spawn passes `bootstrapConversationIds` so the
+session gets `INSTAR_BIND_TOKEN` + `INSTAR_CONVERSATION_ID` and can open durable state (a commitment)
+bound to its minted conversation id; the respawn path **omitted** it, so a refreshed/quota-swapped Slack
+session came up token-less, its durable binds were refused (fail-closed), and the follow-through fell
+back to a fragile session-local timer that dies on the next restart. The respawn now resolves the
+conversation id from the routing key (idempotent get-or-create) and passes it, restoring parity with the
+fresh spawn. Telegram was unaffected (it has a `telegramTopicId` fallback; Slack had none).
+
+## What to Tell Your User
+
+Nothing proactive — this is an internal robustness fix. If a user ever asks why a Slack promise didn't
+survive a session swap or restart, the answer is that a restarted Slack session used to lose the small
+security key it needs to save a durable, restart-proof promise, so it fell back to a flimsy timer; now
+a restarted Slack session keeps that key, so the durable follow-through survives restarts.
+
+## Summary of New Capabilities
+
+- A refreshed / quota-swapped / restarted Slack session now registers durable, restart-surviving
+  follow-through (a commitment bound to the Slack conversation), matching a fresh spawn.
+- Fail-open: if the conversation-id lookup errors, the respawn proceeds (prior token-less behavior),
+  never blocked.
+- No config, no persistent state, no Telegram change.
+
+## Evidence
+
+- `tests/unit/slack-respawn-bootstrap-ids.test.ts` — 4 cases (id → `[id]`, full `channel:thread` key,
+  `null` → `undefined`, throwing registry → `undefined` / no rethrow).
+- Existing `tests/unit/sessionRefresh-slack.test.ts` (22) stay green; `tsc` clean.
+- Live proof it closes: `docs/investigations/s7-slack-delivery-repro-2026-07-04.md` §9 — Round-1
+  (already-running session) durable bind refused; Round-2 (fresh session) durable `CMT-1922` bound to
+  the minted id. This fix makes the respawn path behave like Round-2.

--- a/upgrades/side-effects/slack-respawn-bind-token.eli16.md
+++ b/upgrades/side-effects/slack-respawn-bind-token.eli16.md
@@ -1,0 +1,46 @@
+# ELI16 — when a Slack session restarts, it now keeps its "durable-memory key"
+
+## The story
+
+There's a safety feature: when you ask the agent (over Slack) to do something later — "post a note in
+5 minutes" — it writes that promise down as a **durable commitment** so it survives even if the agent's
+session restarts. To write it down, the session needs a small **security key** (a bind token) that
+proves it's allowed to save state for *that specific Slack conversation*. The key is handed to the
+session the moment it starts up.
+
+The bug: a Slack session gets restarted fairly often — when the agent swaps to a different account to
+avoid a rate limit, when it's refreshed, or after a crash. Every time a *fresh* session starts for a
+Slack channel, it correctly gets the key. But every time a session was *restarted*, the code forgot to
+hand it the key again. So a restarted Slack session came up **without** its key, couldn't write down the
+durable promise (the save was refused for safety), and fell back to a flimsy in-memory timer instead —
+one that vanishes if the session restarts again. That's exactly the failure we've been chasing: a Slack
+promise that quietly loses its restart-proof backup after the session gets swapped.
+
+We proved this live earlier today, as a real Slack user: a message to an *already-restarted* session →
+the durable save was refused → timer fallback ("if my session had died, this note would not have been
+delivered"); a message to a *fresh* session → durable save worked. Same code, one path missing the key.
+
+## What this change does
+
+It makes the restart path hand the session its key again — the same way the fresh-start path already
+does. When a Slack session restarts, the code now looks up which Slack conversation it belongs to (a
+cheap, repeatable lookup that returns the same id every time) and gives the new session a key scoped to
+that conversation. So a restarted Slack session can write down durable, restart-proof promises again,
+just like a fresh one.
+
+## Why it's safe
+
+- It only *restores* a capability that was accidentally dropped; it adds no new powers. The security
+  gate that checks the key is unchanged — this just makes sure the rightful session actually gets its
+  own key.
+- If the lookup ever fails, it quietly falls back to the old (keyless) behavior instead of crashing —
+  a restart must never be blocked.
+- Telegram was never affected (it had a different fallback); this only fixes the Slack restart path.
+- It's a plain code change with no saved data, so rolling it back is trivial.
+
+## How we know it works
+
+Four small tests check the key-lookup helper: it returns the right conversation id, it passes the full
+channel/thread key through, it returns "no key" when there's no id, and — importantly — it never throws
+even if the lookup blows up (so a refresh can't be blocked). The 22 existing Slack-refresh tests all
+still pass.

--- a/upgrades/side-effects/slack-respawn-bind-token.md
+++ b/upgrades/side-effects/slack-respawn-bind-token.md
@@ -1,0 +1,121 @@
+# Side-Effects Review — Slack session respawn re-mints the conversation bind token
+
+**Version / slug:** `slack-respawn-bind-token`
+**Date:** `2026-07-04`
+**Author:** `Echo`
+**Second-pass reviewer:** `not required (Tier-1)`
+
+## Summary of the change
+
+A FRESH Slack channel spawn passes `bootstrapConversationIds: [conversationId]` to
+`spawnInteractiveSession`, so the session mints `INSTAR_BIND_TOKEN` + `INSTAR_CONVERSATION_ID`
+(durable-conversation-identity §7) and can open durable state — a commitment bound to its minted
+(negative) conversation id. The Slack session **respawn** closure (`slackRespawner` in
+`src/commands/server.ts`, used by `/sessions/refresh`, quota-swap, restart, and restart-all — all
+funnel through `SessionRefresh` → `slackRespawner`) **omitted** `bootstrapConversationIds`. So a
+refreshed/quota-swapped Slack session came up **token-less** (and without `INSTAR_CONVERSATION_ID`),
+its durable commitment binds were **refused fail-closed**, and the follow-through fell back to a
+fragile session-local timer that dies on the next restart. This is the live-proven S7 gap (Round-1 of
+the 2026-07-04 test-as-self proof: an already-running/refreshed Slack session couldn't register a
+durable commitment; a fresh spawn — Round-2 — could, registering `CMT-1922` bound to `-1734007126`).
+Telegram's respawn is unaffected because it passes `telegramTopicId`, which the bind-token env
+resolver uses as a fallback; Slack has no such fallback. Fix: the respawn closure resolves the
+conversation id from the routing key (`conversationRegistry.mintForInbound(routingKey).id`, idempotent
+get-or-create → the SAME id the fresh dispatch resolves) via a new unit-tested helper
+`slackRespawnBootstrapIds` and passes it as `bootstrapConversationIds` — restoring parity with the
+fresh spawn. Files: `src/commands/server.ts` (closure + import), `src/core/slackRefreshBinding.ts`
+(helper), + test.
+
+## Decision-point inventory
+
+- `slackRespawner` closure spawn options (`src/commands/server.ts`) — **modify** — now passes
+  `bootstrapConversationIds` resolved from the routing key.
+- `slackRespawnBootstrapIds` (`src/core/slackRefreshBinding.ts`) — **add** — the pure, tested resolver.
+
+## 1. Over-block / 2. Under-block
+
+No block/allow surface. This RESTORES a capability (durable bind on a respawned Slack session) that was
+mistakenly dropped. Over/under-block not applicable.
+
+## 3. Level-of-abstraction fit
+
+Right layer — the fix is a one-option addition at the respawn spawn site, mirroring the fresh-spawn
+site exactly; the resolution is a tiny pure helper in the existing `slackRefreshBinding` module. No new
+machinery, no new authority.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — no runtime block/allow surface. The bind token it restores is enforced by the EXISTING §7
+  `conversationBindGate` (unchanged); this change only ensures the legitimately-authorized session
+  actually receives its own token on respawn.
+
+## 5. Interactions
+
+- **Shadowing:** none — additive spawn option, mirroring the fresh path.
+- **Double-fire:** none. `mintForInbound` is idempotent (get-or-create), so re-resolving on respawn
+  returns the same id the fresh dispatch used; no duplicate conversation is minted.
+- **Races:** none new — the respawn already spawned a session; this only adds one option to that call.
+- **Feedback loops:** none.
+- **Fail posture:** `slackRespawnBootstrapIds` FAILS TOWARD RESPAWN — any resolution error → `undefined`
+  (the prior token-less behavior), never throws, so a refresh can never be blocked by id resolution.
+
+## 6. External surfaces
+
+- **Install base / agents:** ships with the server; a refreshed Slack session now carries its bind
+  token. No config migration. No behavior change for a session that already had the token (fresh
+  spawns) or for Telegram (unaffected — separate fallback).
+- **External systems:** Slack unchanged (same channel session, same delivery). No new API.
+- **Persistent state:** none — `INSTAR_BIND_TOKEN` lives only in the tmux `-e` env at spawn (stateless,
+  self-authenticating). This change sets it correctly on respawn; nothing is persisted.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN** — `machine-local-justification: physical-credential-locality`. A Slack
+session is a tmux process on the machine that owns the Slack connection; its bind token is minted into
+that process's env at spawn on that machine (the token is a per-session, per-machine credential — the
+§7 secret is machine-local plaintext, same posture as authToken). The respawn happens on the owning
+machine. There is no cross-machine state, notice, durable record, or URL introduced; the fix only
+corrects a spawn-option omission on the local respawn path.
+
+## 8. Rollback cost
+
+Pure code change — revert the closure option, the helper, the import, and the test. No persistent
+state; a rollback returns to the (buggy) token-less respawn. Zero-cost back-out.
+
+## Conclusion
+
+Closes the final live-proven S7 gap: a refreshed/quota-swapped Slack session now re-mints its
+conversation bind token, so durable, restart-surviving follow-through works even after a session
+churn — matching the fresh-spawn path that the 2026-07-04 test-as-self proof showed already works.
+Minimal, parity-restoring, fail-open, unit-tested. Clear to ship.
+
+## Second-pass review (if required)
+
+**Reviewer:** not required (Tier-1)
+
+## Evidence pointers
+
+- `tests/unit/slack-respawn-bootstrap-ids.test.ts` — 4 cases: resolves id → `[id]`, passes the full
+  `channel:thread` routing key, `null` id → `undefined`, throwing registry → `undefined` (fails toward
+  respawn).
+- Existing `tests/unit/sessionRefresh-slack.test.ts` (22) stay green; `tsc` clean.
+- Live proof: `docs/investigations/s7-slack-delivery-repro-2026-07-04.md` §9 (Round-1 refused vs
+  Round-2 durable `CMT-1922`).
+
+## Class-Closure Declaration (display-only mirror)
+
+- **`defectClass`** — `spawn-option-asymmetry` (`novel`; nearestExistingClass: `feature-un-enablable`;
+  includes: a spawn/respawn path that omits an option the parallel fresh-spawn path passes, silently
+  degrading a capability; excludes: an intentionally-different respawn option). Enters
+  `status:"unconfirmed"`, so this fix carries `closure: gap`.
+- **`closure`** — `gap` — a class-level guard (a lint/test asserting respawn spawn-option parity with
+  the fresh-spawn site) is out of scope for this fix.
+- **`guardEvidence`** — n/a for `closure: gap`.
+- **`gap`** — tracked follow-up: "respawn/fresh-spawn option-parity guard — assert the Slack (and other
+  platform) respawn paths pass the same identity/bind options as their fresh-spawn counterparts."


### PR DESCRIPTION
## ELI16 — when a Slack session restarts, it now keeps its "durable-memory key"

When you ask the agent (over Slack) to do something later — "post a note in 5 minutes" — it writes that promise down as a **durable commitment** so it survives a restart. To save it, the session needs a small **security key** (a bind token) proving it may save state for that Slack conversation; the key is handed to the session at startup. The bug: a Slack session gets restarted often (account/quota swaps, refreshes, crashes), and every *restart* forgot to hand the session its key again — so a restarted Slack session came up **without** its key, couldn't save the durable promise (refused for safety), and fell back to a flimsy in-memory timer that vanishes on the next restart. That's exactly the S7 failure: a Slack promise quietly losing its restart-proof backup after a session swap. This makes the restart path hand the session its key again — the same way the fresh-start path already does — by looking up which Slack conversation it belongs to (a cheap, repeatable lookup) and scoping a key to it. Fail-open: if the lookup errors, the restart still proceeds. Telegram was never affected.

## The bug (live-proven)

A FRESH Slack spawn passes `bootstrapConversationIds: [conversationId]` → the session mints `INSTAR_BIND_TOKEN` + `INSTAR_CONVERSATION_ID` (durable-conversation-identity §7) and can open durable state bound to its minted conversation id. The Slack **respawn** closure (`slackRespawner` in `server.ts`; used by `/sessions/refresh`, quota-swap, restart, restart-all — all funnel through `SessionRefresh` → `slackRespawner`) **omitted** it, so a refreshed/quota-swapped Slack session came up token-less, durable binds were refused fail-closed, and the follow-through fell back to a fragile session-local timer. Telegram is unaffected (it passes `telegramTopicId`, which the bind-token env resolver uses as a fallback; Slack has none).

**Proven live** on 2026-07-04 (test-as-self as a real Slack user, deployed v1.3.767): a message to an already-running/refreshed session → durable bind **refused** → timer fallback (the bot's own note: *"Had my session died in those 3 minutes, this note would NOT have been delivered"*); a message to a **fresh** session → durable **CMT-1922** registered, bound to `-1734007126`. Same code, one path missing the key. See `docs/investigations/s7-slack-delivery-repro-2026-07-04.md` §9.

## The fix

The respawn resolves the conversation id from the routing key (`conversationRegistry.mintForInbound(routingKey).id` — idempotent get-or-create → the SAME id the fresh dispatch resolves) via a new pure, unit-tested helper `slackRespawnBootstrapIds`, and passes it as `bootstrapConversationIds` — restoring parity with the fresh spawn. This single change covers `/sessions/refresh`, quota-swap, restart, and restart-all. Fail-open: any resolution error → `undefined` (prior token-less behavior), never blocks a refresh.

## Tests (all green + tsc clean)

- **New** `tests/unit/slack-respawn-bootstrap-ids.test.ts` — 4 cases: id → `[id]`, full `channel:thread` routing key, `null` id → `undefined`, throwing registry → `undefined` (fails toward respawn, never rethrows).
- Existing `tests/unit/sessionRefresh-slack.test.ts` (22) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
