### PR TITLE
feat(routing): S4 A2.1 — dark/dryRun nature-axis routing mechanism (resolver + FD4.1 concrete-id pin + allowlist clamp)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-05T05-57-33-962Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-05T05-57-33-962Z-unknown.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-07-05T05:57:33.962Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 5,
+  "loc": 596,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -6166,6 +6166,42 @@ export async function startServer(options: StartOptions): Promise<void> {
             try { DegradationReporter.getInstance().resolveDegradation(component, framework); }
             catch { /* @silent-fallback-ok: a never-silent tracking hook must NEVER throw into the LLM call path; a failed resolve just leaves the open degradation for the next success/sweep. */ }
           },
+          // S4 A2 — Nature-Axis Routing (docs/specs/nature-axis-routing.md). Read LIVE per call
+          // so the kill switch is hot: `enabled` is DEV-GATED (resolveDevAgentGate — `enabled`
+          // OMITTED in shipped config ⇒ live-in-dryRun on a dev agent, dark on the fleet). When
+          // disabled this returns undefined ⇒ the router's nature block is skipped ⇒ routing is
+          // BYTE-IDENTICAL to today. dryRun defaults true (observe-only). A2.1 ships the dark/
+          // dryRun OBSERVATION mechanism; enforcing selection + the durable audit surface are
+          // tracked A2.2 remainders.
+          resolveNatureRouting: () => {
+            const nrCfg = config.sessions?.natureRouting;
+            if (!resolveDevAgentGate(nrCfg?.enabled, config)) return undefined;
+            return {
+              enabled: true,
+              dryRun: nrCfg?.dryRun !== false, // default true on first enable
+              chains: nrCfg?.chains,
+            };
+          },
+          onNatureRoutePlan: (plan) => {
+            // A2.1 observe-only breadcrumb (env-gated so a dev agent's hot path stays quiet;
+            // the durable logs/nature-routing.jsonl + GET /intelligence/routing dryRun plan
+            // surface are the tracked A2.2 remainder). Never breaks the LLM call path.
+            try {
+              if (process.env.INSTAR_NATURE_ROUTING_LOG !== '1') return;
+              const r = plan.resolution;
+              const detail =
+                r && r.outcome === 'route'
+                  ? `chain=${r.resolvedChain} primary=${r.primary.door}/${r.primary.modelId}` +
+                    `${r.primary.clamped ? ' (clamped)' : ''} tail=${r.swapTail.length}`
+                  : plan.failClosed
+                    ? 'FAIL-CLOSED (critical gate, no door)'
+                    : `outcome=${r?.outcome ?? 'n/a'}`;
+              console.log(
+                `[nature-routing] ${plan.component ?? '(none)'} (${plan.category}) ${detail} ` +
+                  `dryRun=${plan.dryRun}`,
+              );
+            } catch { /* never break the LLM path on an observation */ }
+          },
         });
       } catch (err) {
         console.warn(`[server] IntelligenceRouter failed to initialize, using unrouted provider: ${err}`);

--- a/src/core/IntelligenceRouter.ts
+++ b/src/core/IntelligenceRouter.ts
@@ -31,7 +31,20 @@ import {
   isComponentCategory,
   categoryForComponent,
 } from './componentCategories.js';
-import { LLM_ROUTING_NATURE, type RoutingNature } from '../data/llmBenchCoverage.js';
+import {
+  LLM_ROUTING_NATURE,
+  type RoutingNature,
+  type TaskNature,
+  type RoutingChain,
+  type RoutingDoor,
+  type ChainPosition,
+  type NatureRoutingChains,
+  NATURE_ROUTING_DEFAULT_CHAINS,
+  ROUTING_LABEL_TO_MODEL_ID,
+  CLAUDE_CODE_RESERVE_MODEL_ID,
+  METERED_ROUTING_DOORS,
+  NATURE_ROUTING_CRITICAL_GATES,
+} from '../data/llmBenchCoverage.js';
 
 export interface ComponentFrameworksConfig {
   /** Framework for anything not otherwise specified. Defaults to the router's defaultFramework. */
@@ -165,6 +178,23 @@ export interface IntelligenceRouterOptions {
     /** Bound (ms) for a single enqueued deferrable call so a stuck/abandoned one self-terminates. */
     queueAttemptTimeoutMs?: number;
   };
+  /**
+   * S4 A2 — the live, dev-gate-RESOLVED view of `sessions.natureRouting` (read on EVERY
+   * call so the kill switch is hot). `enabled` is already the gate-resolved boolean
+   * (resolved at the construction boundary, like `ladder`). Absent OR `enabled:false`
+   * ⇒ the nature router is inert and routing is BYTE-IDENTICAL to today. When enabled +
+   * dryRun (the dev-agent default) the resolver OBSERVES (computes + logs the plan via
+   * `onNatureRoutePlan`) and still passes through to today's selection. Enforcing
+   * selection (dryRun:false) is a tracked A2.2 remainder.
+   */
+  resolveNatureRouting?: () => NatureRoutingRuntime | undefined;
+  /**
+   * S4 A2 — the dryRun observation sink (FD11 readable canary). Invoked with the resolved
+   * plan when nature routing is enabled + dryRun. No-op downstream by default; the router
+   * calls it freely. The durable `logs/nature-routing.jsonl` + `GET /intelligence/routing`
+   * surfaces that consume this are a tracked A2.2 remainder.
+   */
+  onNatureRoutePlan?: (plan: NatureRoutePlan) => void;
 }
 
 interface CachedFramework {
@@ -336,6 +366,233 @@ export function isBoundedGatingDegrade(
   return row.chain !== 'WRITE'; // WRITE is the sanctioned Opus-CLI lane; everything else is bounded/gating
 }
 
+/* ────────────────────────────────────────────────────────────────────────────
+ * S4 Increment A2 — the nature-axis routing RESOLVER (dark/dryRun mechanism).
+ *
+ * `resolveRoute` is a PURE, side-effect-free evaluator (spec CR2-5): a stateless
+ * fold `component → resolvedNature → ordered eligible positions → { primary, swapTail }
+ * | 'fall-through' | 'no-route' | throw`. It owns no retry/backoff/breaker/budget
+ * machinery — those stay in the existing IntelligenceRouter primitives. Wired into
+ * `evaluate()` ONLY when `sessions.natureRouting.enabled` (dev-gated dark). In dryRun
+ * (the dev-agent default) it OBSERVES: computes + logs the plan, then passes through to
+ * today's routing (byte-identical selection). Enforcing selection (dryRun:false) is a
+ * tracked A2.2 remainder — see the honest guard in `evaluate()`.
+ * Spec: docs/specs/nature-axis-routing.md §Resolver / FD3 / FD4 / FD9.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * The critical-gate fail-closed outcome (spec CR10-3/CR8-4): a DISTINCT typed error
+ * so a caller can never mistake it for an ordinary model failure. A mapped FD6
+ * critical gate whose chain has NO available door throws this; the caller applies its
+ * existing gating fail-closed semantics (block/deny). The low-stakes empty-set case is
+ * deliberately the ordinary non-gating error instead ('no-route'), typed apart on purpose.
+ */
+export class RouterFailClosedError extends Error {
+  constructor(
+    public readonly component: string | undefined,
+    public readonly resolvedChain: RoutingChain,
+  ) {
+    super(
+      `RouterFailClosedError: critical gate '${component ?? '(none)'}' has no available door on ` +
+        `chain ${resolvedChain} — failing closed (never legacy category routing, never the harness door)`,
+    );
+    this.name = 'RouterFailClosedError';
+  }
+}
+
+/** A chain position resolved to a concrete model id, after the FD4 allowlist clamp. */
+export interface ResolvedRoutePosition {
+  readonly door: RoutingDoor;
+  /** The original benchmark label / tier hint from the chain position. */
+  readonly label: string;
+  /** The concrete model id the door should be asked for (post-registry, post-clamp). */
+  readonly modelId: string;
+  /** Whether the FD4 harness-door allowlist clamp rewrote this position to the reserve id. */
+  readonly clamped: boolean;
+}
+
+/** The four load-bearing `resolveRoute` outcomes (verifier r7 — never collapse them). */
+export type RouteResolution =
+  | {
+      outcome: 'route';
+      resolvedNature: TaskNature;
+      resolvedChain: RoutingChain;
+      primary: ResolvedRoutePosition;
+      swapTail: ResolvedRoutePosition[];
+    }
+  | { outcome: 'fall-through' } // unmapped → legacy category routing (the byte-identical safe default)
+  | { outcome: 'no-route' }; // low-stakes mapped, all doors down → caller's own heuristic
+
+/**
+ * Tier ordering for the FD3 nature tighten rule `E, B ≥ D ≥ A`. E and B are
+ * EQUIVALENT (both JUDGE-tier). A caller-declared nature may only ever RAISE the tier
+ * (tighten, the safe direction); a same-tier or lower declared nature is ignored (map
+ * wins), and a value outside {A,B,D,E} is ignored.
+ */
+const NATURE_TIER_RANK: Readonly<Record<TaskNature, number>> = { A: 0, D: 1, B: 2, E: 2 };
+
+function isTaskNature(v: unknown): v is TaskNature {
+  return v === 'A' || v === 'B' || v === 'D' || v === 'E';
+}
+
+/**
+ * FD3 — resolve `{ resolvedNature, resolvedChain }` from the component's static map row
+ * and an optional caller-declared `attribution.nature`. The component's OWN map row
+ * `{nature, chain}` is authoritative by default (preserving a per-component A/FAST vs
+ * A/SORT choice a pure nature→chain function could not). A caller-declared nature that
+ * TIGHTENS (strictly raises the tier) replaces the chain with the deterministically
+ * safe `JUDGE`; anything else is ignored. Returns `undefined` for an unmapped component.
+ * Pure — always available, independent of `sessions.natureRouting`.
+ */
+export function resolveNatureAndChain(
+  component: string | undefined,
+  declaredNature?: unknown,
+): { resolvedNature: TaskNature; resolvedChain: RoutingChain } | undefined {
+  const row = routingNatureFor(component);
+  if (!row) return undefined;
+  const tightened =
+    isTaskNature(declaredNature) && NATURE_TIER_RANK[declaredNature] > NATURE_TIER_RANK[row.nature];
+  if (tightened) {
+    // A tightened nature is always B or E (you only tighten UP a tier) → JUDGE ladder.
+    return { resolvedNature: declaredNature as TaskNature, resolvedChain: 'JUDGE' };
+  }
+  return { resolvedNature: row.nature, resolvedChain: row.chain };
+}
+
+/**
+ * FD-LABEL / FD4.1 — resolve a chain position's `model` label to a concrete model id via
+ * `ROUTING_LABEL_TO_MODEL_ID`. A label absent from the registry (a tier hint like `fast`
+ * / `capable`) passes through unchanged and is resolved downstream by the existing
+ * per-adapter tier map. Pure.
+ */
+export function resolvePositionModelId(pos: ChainPosition): string {
+  return ROUTING_LABEL_TO_MODEL_ID[pos.door]?.[pos.model] ?? pos.model;
+}
+
+/**
+ * FD4 place 3 — the harness-door ALLOWLIST clamp (deny-by-default), the nature-routing
+ * RUNTIME safety guarantee. For a bounded/gating (FAST/SORT/JUDGE) chain, the ONLY
+ * permitted `claude-code` position is the single sanctioned CONCRETE reserve id
+ * (`CLAUDE_CODE_RESERVE_MODEL_ID`); any OTHER claude-code id is clamped down to it. This
+ * is an allowlist, NOT a denylist — a future/unrecognized capable Claude id can never
+ * slip past. `WRITE` is exempt (its Opus-via-CLI quality lane is legitimate), and every
+ * non-claude-code door passes through.
+ *
+ * DELIBERATELY SEPARATE from A1's `clampClaudeCliSwapModel` (which returns the `balanced`
+ * TIER token and fires UNCONDITIONALLY on the always-on degrade/swap path): touching that
+ * function would change A1's shipped, byte-identical-when-off behavior. This clamp is
+ * nature-routing-scoped and concrete-id-based (FD4.1), applied only inside `resolveRoute`.
+ */
+export function clampToReserveOnCleanDoor(
+  pos: ResolvedRoutePosition,
+  resolvedChain: RoutingChain,
+): ResolvedRoutePosition {
+  if (resolvedChain === 'WRITE') return pos; // WRITE is the sole Opus-via-CLI-exempt lane
+  if (pos.door !== 'claude-code') return pos; // the ban applies only to the harness door
+  if (pos.modelId === CLAUDE_CODE_RESERVE_MODEL_ID) return pos; // allowlisted — the sanctioned reserve
+  return { ...pos, modelId: CLAUDE_CODE_RESERVE_MODEL_ID, clamped: true }; // deny-by-default → reserve
+}
+
+/** The base component key (strip a "/segment" operation suffix + a `server:` prefix). */
+function baseComponentKey(component: string | undefined): string | undefined {
+  if (!component) return undefined;
+  return component.split('/')[0].replace(/^server:/, '').trim();
+}
+
+/**
+ * The PURE nature-routing fold (spec §Resolver, steps 1–7). Deps are injected so the
+ * function is side-effect-free + trivially testable: `isDoorReachable` reports CLI-door
+ * reachability (the class wraps its provider cache). Metered doors are ALWAYS skipped in
+ * Increment A. The empty-`available` branch splits by authority class (CR6-2/CR3-1):
+ * unmapped → 'fall-through'; low-stakes mapped → 'no-route'; FD6 critical gate → throw
+ * RouterFailClosedError. (The R6 doc-tree refuse-to-author branch is a tracked A2.2
+ * remainder; until it lands a `claudeBanned` component falls into the low-stakes 'no-route'
+ * path — never onto Claude, since resolveRoute never emits a claude-code position for it
+ * unless its chain contains one, and R6 chains are authored off-Claude.)
+ */
+export function resolveRoute(
+  component: string | undefined,
+  declaredNature: unknown,
+  chains: NatureRoutingChains,
+  deps: { isDoorReachable: (door: RoutingDoor) => boolean },
+): RouteResolution {
+  const nc = resolveNatureAndChain(component, declaredNature);
+  if (!nc) return { outcome: 'fall-through' }; // unmapped ⇒ legacy category routing (LA5 byte-identical)
+
+  const positions = chains[nc.resolvedChain] ?? NATURE_ROUTING_DEFAULT_CHAINS[nc.resolvedChain];
+  const available: ResolvedRoutePosition[] = [];
+  for (const p of positions) {
+    // Increment A: metered-API doors are DEFINED but always unavailable (skipped) until Increment B.
+    if (METERED_ROUTING_DOORS.has(p.door)) continue;
+    if (!deps.isDoorReachable(p.door)) continue;
+    const resolved: ResolvedRoutePosition = {
+      door: p.door,
+      label: p.model,
+      modelId: resolvePositionModelId(p),
+      clamped: false,
+    };
+    available.push(clampToReserveOnCleanDoor(resolved, nc.resolvedChain));
+  }
+
+  if (available.length === 0) {
+    // FD6 critical gate with no door ⇒ FAIL CLOSED (distinct typed error). NEVER legacy routing.
+    if (NATURE_ROUTING_CRITICAL_GATES.has(baseComponentKey(component) ?? '')) {
+      throw new RouterFailClosedError(component, nc.resolvedChain);
+    }
+    // Low-stakes mapped ⇒ the caller's own non-gating heuristic (the ordinary provider-down contract).
+    return { outcome: 'no-route' };
+  }
+
+  return {
+    outcome: 'route',
+    resolvedNature: nc.resolvedNature,
+    resolvedChain: nc.resolvedChain,
+    primary: available[0],
+    swapTail: available.slice(1),
+  };
+}
+
+/**
+ * Merge an operator's partial `chains` override (config) over the built-in v3 defaults,
+ * per-chain. A chain the operator did not override keeps its default. (The FD4.3
+ * resolve-time validation that REJECTS a harness-door-violating override → defaults +
+ * notice is a tracked A2.2 remainder; the FD4 place-3 runtime clamp above already keeps
+ * the banned route closed on every resolved position regardless.)
+ */
+export function mergeNatureRoutingChains(
+  override: Partial<Record<RoutingChain, ReadonlyArray<ChainPosition>>> | undefined,
+): NatureRoutingChains {
+  if (!override) return NATURE_ROUTING_DEFAULT_CHAINS;
+  return {
+    FAST: override.FAST ?? NATURE_ROUTING_DEFAULT_CHAINS.FAST,
+    SORT: override.SORT ?? NATURE_ROUTING_DEFAULT_CHAINS.SORT,
+    JUDGE: override.JUDGE ?? NATURE_ROUTING_DEFAULT_CHAINS.JUDGE,
+    WRITE: override.WRITE ?? NATURE_ROUTING_DEFAULT_CHAINS.WRITE,
+  };
+}
+
+/**
+ * The dev-gate-resolved live view of `sessions.natureRouting` the router reads per call.
+ * `enabled` is ALREADY gate-resolved at the construction boundary (like `ladder`), so the
+ * router just reads the boolean. Absent ⇒ feature off ⇒ byte-identical routing.
+ */
+export interface NatureRoutingRuntime {
+  enabled: boolean;
+  /** Observe-only (default true on first enable): compute + log the plan, do NOT re-route. */
+  dryRun: boolean;
+  chains?: Partial<Record<RoutingChain, ReadonlyArray<ChainPosition>>>;
+}
+
+/** The dryRun observation record handed to `onNatureRoutePlan` (FD11 readable canary). */
+export interface NatureRoutePlan {
+  component: string | undefined;
+  category: ComponentCategory;
+  dryRun: boolean;
+  resolution?: RouteResolution;
+  /** Set when the resolver would FAIL CLOSED (critical-gate empty set). */
+  failClosed?: boolean;
+}
+
 export class IntelligenceRouter implements IntelligenceProvider {
   private readonly cache = new Map<IntelligenceFramework, CachedFramework>();
 
@@ -427,6 +684,36 @@ export class IntelligenceRouter implements IntelligenceProvider {
     return framework === this.opts.defaultFramework ? this.opts.defaultProvider : this.providerFor(framework);
   }
 
+  /** Already warned that nature-routing enforcing mode is not yet wired (warn ONCE). */
+  private warnedNatureEnforceNotWired = false;
+
+  /**
+   * S4 A2 — CLI-door reachability probe for the nature router (FD5 availability walk).
+   * CLI doors coincide 1:1 with `IntelligenceFramework`. `resolveRoute` skips metered
+   * doors before ever calling this, so `door` is always a CLI door. The default framework
+   * is always reachable (shared provider); a non-default door is reachable iff its provider
+   * builds (binary present). Result is cached by `providerFor`.
+   */
+  private isCliDoorReachable(door: RoutingDoor): boolean {
+    return this.resolveProvider(door as IntelligenceFramework) !== null;
+  }
+
+  /**
+   * S4 A2 — enforcing-mode honesty guard. Flipping `dryRun:false` in A2.1 does NOT re-route
+   * (the selection integration is a tracked A2.2 remainder); routing stays byte-identical.
+   * Warn ONCE so the flip is an honest no-op rather than a silent dead switch.
+   */
+  private warnNatureEnforceNotWired(): void {
+    if (this.warnedNatureEnforceNotWired) return;
+    this.warnedNatureEnforceNotWired = true;
+    console.warn(
+      'IntelligenceRouter: sessions.natureRouting.dryRun is false, but nature-routing ENFORCING ' +
+        'selection is not wired in this build (Increment A2.1 ships the dark/dryRun observation ' +
+        'mechanism; enforcing selection is the tracked A2.2 remainder). Routing stays byte-identical — ' +
+        'the resolver plan is logged but not applied.',
+    );
+  }
+
   async evaluate(prompt: string, options?: IntelligenceOptions): Promise<string> {
     const component = options?.attribution?.component;
     const explicitCategory = (options?.attribution as { category?: unknown } | undefined)?.category;
@@ -435,6 +722,35 @@ export class IntelligenceRouter implements IntelligenceProvider {
       : categoryForComponent(component);
 
     const cfg = this.opts.resolveConfig();
+
+    // ── S4 A2 — nature-axis routing OBSERVATION (dev-gated dark; dryRun-first). ──
+    // Byte-identical when unset/off: when the feature is absent OR `enabled:false` this
+    // whole block is skipped and NOTHING about selection changes. In dryRun (the dev-agent
+    // default) it OBSERVES only — computes + logs the plan via `onNatureRoutePlan` — and
+    // still falls through to today's selection below. Enforcing SELECTION (dryRun:false) is
+    // a tracked A2.2 remainder; guarded here so a flip is an HONEST no-op, never a silent
+    // dead switch and never a mis-route. A resolver error can never break routing here.
+    const natureRt = this.opts.resolveNatureRouting?.();
+    if (natureRt?.enabled) {
+      const dryRun = natureRt.dryRun !== false; // default true on first enable
+      try {
+        const resolution = resolveRoute(
+          component,
+          options?.attribution?.nature,
+          mergeNatureRoutingChains(natureRt.chains),
+          { isDoorReachable: (d) => this.isCliDoorReachable(d) },
+        );
+        this.opts.onNatureRoutePlan?.({ component, category, dryRun, resolution });
+      } catch (e) {
+        if (e instanceof RouterFailClosedError) {
+          this.opts.onNatureRoutePlan?.({ component, category, dryRun, failClosed: true });
+        } else {
+          this.opts.onNatureRoutePlan?.({ component, category, dryRun });
+        }
+      }
+      if (!dryRun) this.warnNatureEnforceNotWired();
+    }
+
     // Unconfigured ⇒ exactly today's behavior.
     if (!cfg) return this.opts.defaultProvider.evaluate(prompt, options);
 

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -403,6 +403,32 @@ export function migrateConfigActionClaimSlackDevGate(config: Record<string, unkn
 }
 
 /**
+ * S4 Nature-Axis Routing (docs/specs/nature-axis-routing.md, § Migration Parity): SEED
+ * `sessions.natureRouting` DARK on existing agents so the update path reaches deployed
+ * agents (not only new agents via init). Adds the block ONLY when ABSENT — an operator/agent
+ * that already configured it is never clobbered (existence-checked, idempotent).
+ *
+ * CRITICAL — `enabled` is DELIBERATELY OMITTED (enable-path integrity, the #1001 pattern):
+ * the construction boundary resolves it via `resolveDevAgentGate(cfg.enabled, config)`, so a
+ * seeded `enabled:false` would force-dark even a development agent. `dryRun:true` is the
+ * observe-only canary; `metered.goLive:false` keeps Increment B inert. Chain defaults live in
+ * CODE (`NATURE_ROUTING_DEFAULT_CHAINS`) — the seed stays small and a future chain reslot
+ * reaches agents on a `schemaVersion` bump, not by writing a chain blob into every config.
+ */
+export function migrateConfigNatureRoutingDark(config: Record<string, unknown>): boolean {
+  const sessions = config.sessions as Record<string, unknown> | undefined;
+  if (!sessions || typeof sessions !== 'object' || Array.isArray(sessions)) return false;
+  if (Object.prototype.hasOwnProperty.call(sessions, 'natureRouting')) return false; // already present
+  sessions.natureRouting = {
+    schemaVersion: 3,
+    // `enabled` OMITTED so resolveDevAgentGate decides (live-in-dryRun on a dev agent, dark fleet).
+    dryRun: true,
+    metered: { goLive: false },
+  };
+  return true;
+}
+
+/**
  * "Self-Unblock Before Escalating" (docs/specs/self-unblock-before-escalating.md):
  * the two nested blockerLedger sub-features — selfUnblockChecklist + durableVaultSession
  * — are dev-gated dark features resolved via resolveDevAgentGate, so the config must
@@ -9004,6 +9030,16 @@ Two layers keep my machine-to-machine \"ropes\" (Tailscale / LAN / Cloudflare) h
       result.upgraded.push('config.json: stripped default-shaped messaging.actionClaim.slack.enabled=false so the developmentAgent gate resolves it (live-on-dev, dark fleet)');
     } else {
       result.skipped.push('config.json: messaging.actionClaim.slack.enabled dev-gate already correct (omitted or operator-set)');
+    }
+
+    // S4 Nature-Axis Routing: SEED sessions.natureRouting DARK (schemaVersion+dryRun+metered.goLive
+    // false; `enabled` OMITTED so the developmentAgent gate resolves it live-on-dev / dark-fleet).
+    // Existence-checked — never clobbers an operator/agent that already configured it.
+    if (migrateConfigNatureRoutingDark(config)) {
+      patched = true;
+      result.upgraded.push('config.json: seeded dark sessions.natureRouting (schemaVersion:3, dryRun:true, metered.goLive:false; enabled omitted for the developmentAgent gate)');
+    } else {
+      result.skipped.push('config.json: sessions.natureRouting already present or no sessions block (no seed)');
     }
 
     // "Self-Unblock Before Escalating" (CMT-1519): the two nested blockerLedger

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -264,6 +264,56 @@ export interface SessionManagerConfig {
    * absent-equals-unchanged guarantee). Consumed only by the claude-code spawn
    * path; other frameworks ignore it. */
   dynamicMcp?: import('./dynamicMcpConfig.js').DynamicMcpConfig;
+  /**
+   * S4 — Nature-Axis Routing (docs/specs/nature-axis-routing.md). Resolves the internal
+   * LLM router's `(door, model)` selection by a call's TASK NATURE + a door-availability
+   * chain, instead of only its category. TYPE-ONLY and intentionally NOT in ConfigDefaults
+   * (a default here would deep-merge into every config and break absent-equals-unchanged);
+   * `migrateConfig` seeds it DARK on update.
+   *
+   * MATURATION LADDER (FD11): `enabled` is OMITTED from the shipped config so it rides
+   * `resolveDevAgentGate` — LIVE (in dryRun) on a development agent, DARK on the fleet.
+   * Absent OR `enabled:false` ⇒ the nature router is inert and routing is BYTE-IDENTICAL
+   * to today. `dryRun` (default true on first enable) observes + logs the resolved plan
+   * without re-routing. `metered.goLive` is Increment B (metered doors + PIN money gate)
+   * — DEFERRED; it stays false and does nothing in this increment.
+   */
+  natureRouting?: {
+    /** Config schema version for versioned chain-forward migration (Int2). */
+    schemaVersion?: number;
+    /** OMITTED in the shipped config so the dev-agent gate decides (LIVE-dev / DARK-fleet). */
+    enabled?: boolean;
+    /** Observe-only (default true): compute + log the plan; do NOT re-route. */
+    dryRun?: boolean;
+    /**
+     * Optional per-chain wholesale override of the built-in v3 defaults. A chain left
+     * unset keeps its default. (The FD4 resolve-time validation of an override is a
+     * tracked A2.2 remainder; the FD4 runtime allowlist clamp already keeps the banned
+     * harness-door route closed on every resolved position regardless.)
+     */
+    chains?: Partial<
+      Record<
+        'FAST' | 'SORT' | 'JUDGE' | 'WRITE',
+        Array<{
+          door:
+            | 'pi-cli'
+            | 'codex-cli'
+            | 'gemini-cli'
+            | 'claude-code'
+            | 'gemini-api'
+            | 'openrouter-api'
+            | 'groq-api';
+          model: string;
+          keyRef?: string;
+          moneyGated?: boolean;
+          injectionSafe?: boolean;
+          claudeBanned?: boolean;
+        }>
+      >
+    >;
+    /** Increment B — metered-door money/PIN go-live. DEFERRED; stays false in A2. */
+    metered?: { goLive?: boolean };
+  };
   /** Project directory (where CLAUDE.md lives) */
   projectDir: string;
   /** Maximum concurrent sessions */
@@ -959,6 +1009,17 @@ export interface IntelligenceOptions {
      * (today's behavior: no backoff/queue rung).
      */
     deferrable?: boolean;
+    /**
+     * S4 A2 — OPT-IN, TIGHTENING-ONLY task nature (docs/specs/nature-axis-routing.md FD3).
+     * When the nature router is enabled, a caller MAY declare the call's nature to RAISE
+     * its routing tier (the safe direction, `E,B ≥ D ≥ A`): a same-tier or lower value is
+     * ignored (the static `LLM_ROUTING_NATURE` map wins) and a value outside {A,B,D,E} is
+     * ignored. It can only ever tighten (route a call onto the more-careful JUDGE ladder),
+     * never widen. MUST originate from callsite CODE, never from model/user content (Sec4
+     * trust boundary). Omitted ⇒ the static map is authoritative. Inert unless nature
+     * routing is enabled.
+     */
+    nature?: 'A' | 'B' | 'D' | 'E';
     /**
      * F5 RESERVATION LANE (docs/specs/spawn-cap-interactive-priority.md).
      * `interactive` requests the user-facing reserved headroom in the host spawn cap

--- a/src/data/llmBenchCoverage.ts
+++ b/src/data/llmBenchCoverage.ts
@@ -684,3 +684,148 @@ export const LLM_ROUTING_NATURE: Readonly<Record<string, RoutingNature>> = {
   SessionSummarySentinel: { nature: 'D', chain: 'SORT' },
   'correction-learning': { nature: 'D', chain: 'SORT' },
 };
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * S4 Increment A2 — nature-axis routing: door taxonomy, label registry, chains.
+ *
+ * These are the DATA half of the nature router (the resolver logic + wiring lives
+ * in src/core/IntelligenceRouter.ts). Everything here is pure, read-only config
+ * data — importing it changes NO behavior; it is actuated only when
+ * `sessions.natureRouting` is enabled (dev-gated dark; dryRun-first).
+ * Spec: docs/specs/nature-axis-routing.md — FD1 (doors), FD2 (chains), FD-LABEL/
+ * FD4.1 (label→id registry), FD4 (harness-door allowlist), FD6 (critical gates).
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * A RoutingDoor is a concrete access path to a model (FD1), in two classes:
+ *  - CLI doors — 1:1 with `IntelligenceFramework` (already wired).
+ *  - Metered-API doors — NEW, wired in Increment B behind the FD12 money/PIN
+ *    go-live. In Increment A they are DEFINED but always resolve as unavailable
+ *    (skipped) — so no metered/paid door ever routes in this increment.
+ */
+export type RoutingDoor =
+  | 'pi-cli'
+  | 'codex-cli'
+  | 'gemini-cli'
+  | 'claude-code'
+  | 'gemini-api'
+  | 'openrouter-api'
+  | 'groq-api';
+
+/** CLI doors — coincide exactly with the `IntelligenceFramework` id set. */
+export const CLI_ROUTING_DOORS: ReadonlySet<RoutingDoor> = new Set([
+  'pi-cli',
+  'codex-cli',
+  'gemini-cli',
+  'claude-code',
+]);
+
+/** Metered-API doors — Increment B; ALWAYS skipped (unavailable) in Increment A. */
+export const METERED_ROUTING_DOORS: ReadonlySet<RoutingDoor> = new Set([
+  'gemini-api',
+  'openrouter-api',
+  'groq-api',
+]);
+
+/**
+ * A chain position (FD2): `{ door, model }` plus static flags. `model` is a
+ * benchmark LABEL (`flash-lite`, `gpt-5.5`, `opus-4.8`) or a tier hint
+ * (`fast|balanced|capable`); FD-LABEL resolves it to a concrete model id.
+ */
+export interface ChainPosition {
+  readonly door: RoutingDoor;
+  readonly model: string;
+  /** Vault secret name backing a metered door (Increment B). */
+  readonly keyRef?: string;
+  /** Real-spend door — money-gated (Increment B). */
+  readonly moneyGated?: boolean;
+  /** `false` ⇒ this door must not take an injection-exposed call (FD5b; e.g. Groq). */
+  readonly injectionSafe?: boolean;
+  /** doc-tree / cartographer components may never route to any claude-code door (R6). */
+  readonly claudeBanned?: boolean;
+}
+
+export type NatureRoutingChains = Readonly<Record<RoutingChain, ReadonlyArray<ChainPosition>>>;
+
+/**
+ * FD2 — the four v3 CLI-only chain defaults (config default). Authored using ONLY
+ * Echo's real doors (no `openai-api`). Metered positions are present but resolve
+ * unavailable until Increment B. An operator MAY override a chain wholesale
+ * (subject to the FD4 resolve-time validation — a tracked A2.2 remainder).
+ */
+export const NATURE_ROUTING_DEFAULT_CHAINS: NatureRoutingChains = {
+  // Latency-sensitive quick-sort.
+  FAST: [
+    { door: 'gemini-api', model: 'flash-lite', keyRef: 'metered_gemini_bench', moneyGated: true },
+    { door: 'pi-cli', model: 'gpt-5.5' },
+  ],
+  // Background quick-sort.
+  SORT: [
+    { door: 'codex-cli', model: 'gpt-5.4-mini' },
+    { door: 'pi-cli', model: 'gpt-5.5' },
+    { door: 'gemini-api', model: 'flash-lite', keyRef: 'metered_gemini_bench', moneyGated: true },
+    { door: 'claude-code', model: 'balanced' }, // Sonnet-4.6 reserve
+  ],
+  // Careful judgment.
+  JUDGE: [
+    { door: 'pi-cli', model: 'gpt-5.5' },
+    { door: 'codex-cli', model: 'gpt-5.5' },
+    { door: 'openrouter-api', model: 'gpt-5.5', keyRef: 'metered_openrouter_bench', moneyGated: true },
+    { door: 'openrouter-api', model: 'opus-4.8', keyRef: 'metered_openrouter_bench', moneyGated: true }, // clean API, NEVER CLI
+    { door: 'claude-code', model: 'balanced' }, // Sonnet-4.6 reserve
+  ],
+  // Open-ended writing (WRITE is the sole Opus-via-CLI-exempt lane — FD4).
+  WRITE: [
+    { door: 'codex-cli', model: 'gpt-5.4-mini' },
+    { door: 'groq-api', model: 'gpt-oss-120B', keyRef: 'metered_groq_bench', moneyGated: true, injectionSafe: false },
+    { door: 'claude-code', model: 'fast' }, // Haiku-4.5
+    { door: 'claude-code', model: 'capable' }, // Opus-4.8 quality lane — allowed on WRITE (FD4)
+  ],
+};
+
+/**
+ * FD-LABEL / FD4.1 — the explicit per-door registry mapping a benchmark LABEL to a
+ * concrete model id. This is the boundary A1 deliberately deferred: A1 clamps to the
+ * `balanced` tier TOKEN; A2 pins the reserve to a CONCRETE id. The `claude-code`
+ * `balanced` reserve pins to the versioned manifest id `claude-sonnet-4-6` (FD4 place
+ * 1 — a tier label could resolve differently under a future CLI alias/remap; the
+ * pinned concrete id can't). A tier hint NOT present here (`fast`, `capable`) is left
+ * as-is and resolves downstream through the existing per-adapter tier map.
+ */
+export const ROUTING_LABEL_TO_MODEL_ID: Readonly<Record<string, Readonly<Record<string, string>>>> = {
+  'gemini-api': { 'flash-lite': 'gemini-3.1-flash-lite' },
+  'openrouter-api': { 'opus-4.8': 'anthropic/claude-opus-4-8', 'gpt-5.5': 'openai/gpt-5.5' },
+  'claude-code': { balanced: 'claude-sonnet-4-6' },
+  'codex-cli': { 'gpt-5.5': 'gpt-5.5', 'gpt-5.4-mini': 'gpt-5.4-mini' },
+  'pi-cli': { 'gpt-5.5': 'gpt-5.5' },
+  'groq-api': { 'gpt-oss-120B': 'openai/gpt-oss-120b' },
+};
+
+/**
+ * The SINGLE sanctioned `claude-code` reserve model id for a bounded/gating
+ * (FAST/SORT/JUDGE) chain (FD4 place 1). The allowlist clamp permits ONLY this id on
+ * the claude-code door in those chains — deny-by-default — and clamps any other
+ * claude-code selection down to it. Pinned to the concrete manifest id (NOT the
+ * `balanced` tier label). Kept in sync with
+ * scripts/model-registry-freshness.manifest.json (role `balanced-anthropic`).
+ */
+export const CLAUDE_CODE_RESERVE_MODEL_ID = ROUTING_LABEL_TO_MODEL_ID['claude-code'].balanced;
+
+/**
+ * FD6 — the critical-gate components (nature-B JUDGE safety gates + `MessageSentinel`,
+ * a nature-A / R2-critical gate). Load-bearing for the resolver's empty-set branch: a
+ * critical gate with no available door FAILS CLOSED (throw), never `no-route`. A gate
+ * must carry a real nature entry (never a `chainExempt` filler — FD4 Adv5).
+ */
+export const NATURE_ROUTING_CRITICAL_GATES: ReadonlySet<string> = new Set([
+  'MessagingToneGate',
+  'CompletionEvaluator',
+  'ExternalOperationGate',
+  'LLMSanitizer',
+  'CoherenceReviewer',
+  'UnjustifiedStopGate',
+  'SessionWatchdog',
+  'StallTriageNurse',
+  'ProjectDriftChecker',
+  'MessageSentinel', // nature A, R2-critical
+]);

--- a/tests/unit/migrate-nature-routing-dark.test.ts
+++ b/tests/unit/migrate-nature-routing-dark.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit (Tier 1) — migrateConfigNatureRoutingDark
+ * (docs/specs/nature-axis-routing.md § Migration Parity). Seeds sessions.natureRouting
+ * DARK (schemaVersion + dryRun + metered.goLive:false; `enabled` OMITTED for the
+ * developmentAgent gate) on existing agents; existence-checked (never clobbers a
+ * configured block); idempotent; no-op when there is no sessions block.
+ */
+import { describe, it, expect } from 'vitest';
+import { migrateConfigNatureRoutingDark } from '../../src/core/PostUpdateMigrator.js';
+
+describe('migrateConfigNatureRoutingDark', () => {
+  it('seeds the dark block when absent, OMITTING enabled (dev-gate)', () => {
+    const cfg: Record<string, unknown> = { sessions: { projectDir: '/x' } };
+    expect(migrateConfigNatureRoutingDark(cfg)).toBe(true);
+    const nr = (cfg.sessions as any).natureRouting;
+    expect(nr).toEqual({ schemaVersion: 3, dryRun: true, metered: { goLive: false } });
+    // enable-path integrity — a seeded `enabled:false` would force-dark even a dev agent.
+    expect(Object.prototype.hasOwnProperty.call(nr, 'enabled')).toBe(false);
+  });
+
+  it('never clobbers an already-present block (existence-checked)', () => {
+    const cfg: Record<string, unknown> = {
+      sessions: { natureRouting: { enabled: true, dryRun: false } },
+    };
+    expect(migrateConfigNatureRoutingDark(cfg)).toBe(false);
+    expect((cfg.sessions as any).natureRouting).toEqual({ enabled: true, dryRun: false });
+  });
+
+  it('no sessions block → safe no-op', () => {
+    const cfg: Record<string, unknown> = { monitoring: {} };
+    expect(migrateConfigNatureRoutingDark(cfg)).toBe(false);
+    expect(cfg.sessions).toBeUndefined();
+  });
+
+  it('is idempotent — a second run finds the block present', () => {
+    const cfg: Record<string, unknown> = { sessions: { projectDir: '/x' } };
+    expect(migrateConfigNatureRoutingDark(cfg)).toBe(true);
+    expect(migrateConfigNatureRoutingDark(cfg)).toBe(false);
+  });
+});

--- a/tests/unit/nature-routing-resolver.test.ts
+++ b/tests/unit/nature-routing-resolver.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Unit tests — S4 Increment A2: the dark/dryRun nature-axis routing MECHANISM.
+ * Spec: docs/specs/nature-axis-routing.md (§Resolver, FD3, FD4, FD4.1/FD-LABEL, FD9).
+ *
+ * Covers BOTH sides of every decision boundary (Testing Integrity Standard, kind 5):
+ *  - resolveNatureAndChain: map hit / per-op suffix / tighten / E,B tie→map / non-enum
+ *    ignored / downgrade ignored / unmapped.
+ *  - resolveRoute: all FOUR load-bearing outcomes (route / fall-through / no-route / throw),
+ *    ordering, metered-door skip, primary+tail.
+ *  - FD4.1 concrete-id pin: the `balanced` token resolves to the real Sonnet id, and the
+ *    NEW nature-scoped clamp is a SEPARATE fn from A1's clampClaudeCliSwapModel.
+ *  - FD4 allowlist clamp: accepts the reserve id, rejects every other claude-code id
+ *    (deny-by-default), WRITE exempt.
+ *  - THE load-bearing safety case: evaluate() is BYTE-IDENTICAL when natureRouting is off.
+ *  - dryRun observes (logs the plan) but does NOT change the selected (door, model).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  IntelligenceRouter,
+  resolveNatureAndChain,
+  resolveRoute,
+  resolvePositionModelId,
+  clampToReserveOnCleanDoor,
+  clampClaudeCliSwapModel,
+  mergeNatureRoutingChains,
+  RouterFailClosedError,
+  type NatureRoutingRuntime,
+  type NatureRoutePlan,
+  type ResolvedRoutePosition,
+} from '../../src/core/IntelligenceRouter.js';
+import type { IntelligenceFramework } from '../../src/core/intelligenceProviderFactory.js';
+import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
+import {
+  ROUTING_LABEL_TO_MODEL_ID,
+  CLAUDE_CODE_RESERVE_MODEL_ID,
+  NATURE_ROUTING_DEFAULT_CHAINS,
+  type RoutingDoor,
+} from '../../src/data/llmBenchCoverage.js';
+
+// All CLI doors reachable, all metered doors unreachable (Increment A default).
+const allCliReachable = { isDoorReachable: (_d: RoutingDoor) => true };
+
+function fakeProvider(label: string): IntelligenceProvider & { calls: Array<IntelligenceOptions | undefined> } {
+  const calls: Array<IntelligenceOptions | undefined> = [];
+  return {
+    calls,
+    async evaluate(_prompt: string, _opts?: IntelligenceOptions): Promise<string> {
+      calls.push(_opts);
+      return label;
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('resolveNatureAndChain (FD3)', () => {
+  it('returns the component map row by default (authoritative per-component chain)', () => {
+    // MessageSentinel = A/FAST, CommitmentSentinel = A/SORT — a pure nature→chain fn
+    // could not preserve this per-component split.
+    expect(resolveNatureAndChain('MessageSentinel')).toEqual({ resolvedNature: 'A', resolvedChain: 'FAST' });
+    expect(resolveNatureAndChain('CommitmentSentinel')).toEqual({ resolvedNature: 'A', resolvedChain: 'SORT' });
+    expect(resolveNatureAndChain('MessagingToneGate')).toEqual({ resolvedNature: 'B', resolvedChain: 'JUDGE' });
+  });
+
+  it('resolves a per-operation "/segment" suffix, then the base component', () => {
+    // Base fallback (no exact key for the suffixed form) → the base row.
+    expect(resolveNatureAndChain('CompletionEvaluator/judge')).toEqual({ resolvedNature: 'B', resolvedChain: 'JUDGE' });
+    expect(resolveNatureAndChain('server:MessagingToneGate')).toEqual({ resolvedNature: 'B', resolvedChain: 'JUDGE' });
+  });
+
+  it('unmapped component ⇒ undefined (→ legacy fall-through)', () => {
+    expect(resolveNatureAndChain('TotallyUnknownThing')).toBeUndefined();
+    expect(resolveNatureAndChain(undefined)).toBeUndefined();
+  });
+
+  it('a declared nature that TIGHTENS raises the tier → deterministically JUDGE', () => {
+    // MessageSentinel maps A; a callsite declaring B (a judgment) tightens → JUDGE.
+    expect(resolveNatureAndChain('MessageSentinel', 'B')).toEqual({ resolvedNature: 'B', resolvedChain: 'JUDGE' });
+    // A→E likewise tightens (E is JUDGE-tier).
+    expect(resolveNatureAndChain('MessageSentinel', 'E')).toEqual({ resolvedNature: 'E', resolvedChain: 'JUDGE' });
+    // A (SORT) → D tightens to the higher tier (D>A) → JUDGE (the safe direction).
+    expect(resolveNatureAndChain('CommitmentSentinel', 'D')).toEqual({ resolvedNature: 'D', resolvedChain: 'JUDGE' });
+  });
+
+  it('a same-tier (E vs B) tie resolves to the MAP value — the override never swaps within a tier', () => {
+    // MessagingToneGate maps B (JUDGE); a declared E is the SAME tier → map wins.
+    expect(resolveNatureAndChain('MessagingToneGate', 'E')).toEqual({ resolvedNature: 'B', resolvedChain: 'JUDGE' });
+  });
+
+  it('a declared nature that would DOWNGRADE is ignored (map wins — never widen)', () => {
+    // MessagingToneGate maps B; a declared A (lower tier) is ignored.
+    expect(resolveNatureAndChain('MessagingToneGate', 'A')).toEqual({ resolvedNature: 'B', resolvedChain: 'JUDGE' });
+    expect(resolveNatureAndChain('MessagingToneGate', 'D')).toEqual({ resolvedNature: 'B', resolvedChain: 'JUDGE' });
+  });
+
+  it('a declared nature outside {A,B,D,E} is ignored (fail-safe)', () => {
+    expect(resolveNatureAndChain('MessageSentinel', 'Z' as unknown)).toEqual({ resolvedNature: 'A', resolvedChain: 'FAST' });
+    expect(resolveNatureAndChain('MessageSentinel', 42 as unknown)).toEqual({ resolvedNature: 'A', resolvedChain: 'FAST' });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('FD4.1 / FD-LABEL — benchmark-label → concrete model id', () => {
+  it('the `balanced` token on claude-code pins to the concrete Sonnet-4.6 id', () => {
+    // THE load-bearing FD4.1 assertion the brief calls out.
+    expect(ROUTING_LABEL_TO_MODEL_ID['claude-code'].balanced).toBe('claude-sonnet-4-6');
+    expect(CLAUDE_CODE_RESERVE_MODEL_ID).toBe('claude-sonnet-4-6');
+    expect(resolvePositionModelId({ door: 'claude-code', model: 'balanced' })).toBe('claude-sonnet-4-6');
+  });
+
+  it('a tier hint NOT in the registry (fast/capable) passes through unchanged', () => {
+    expect(resolvePositionModelId({ door: 'claude-code', model: 'fast' })).toBe('fast');
+    expect(resolvePositionModelId({ door: 'claude-code', model: 'capable' })).toBe('capable');
+  });
+
+  it('metered-door labels resolve to their concrete ids', () => {
+    expect(resolvePositionModelId({ door: 'gemini-api', model: 'flash-lite' })).toBe('gemini-3.1-flash-lite');
+    expect(resolvePositionModelId({ door: 'openrouter-api', model: 'opus-4.8' })).toBe('anthropic/claude-opus-4-8');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('FD4 place-3 — harness-door ALLOWLIST clamp (deny-by-default)', () => {
+  const rp = (door: RoutingDoor, modelId: string): ResolvedRoutePosition => ({ door, label: modelId, modelId, clamped: false });
+
+  it('accepts the sanctioned reserve id on claude-code in a bounded/gating chain', () => {
+    const out = clampToReserveOnCleanDoor(rp('claude-code', CLAUDE_CODE_RESERVE_MODEL_ID), 'JUDGE');
+    expect(out.clamped).toBe(false);
+    expect(out.modelId).toBe(CLAUDE_CODE_RESERVE_MODEL_ID);
+  });
+
+  it('REJECTS every other claude-code id in FAST/SORT/JUDGE → clamps to the reserve', () => {
+    for (const chain of ['FAST', 'SORT', 'JUDGE'] as const) {
+      const out = clampToReserveOnCleanDoor(rp('claude-code', 'claude-opus-4-8'), chain);
+      expect(out.clamped).toBe(true);
+      expect(out.modelId).toBe(CLAUDE_CODE_RESERVE_MODEL_ID);
+    }
+    // A future/unrecognized capable id is ALSO clamped (allowlist, not denylist).
+    const future = clampToReserveOnCleanDoor(rp('claude-code', 'claude-opus-9-9-future'), 'JUDGE');
+    expect(future.clamped).toBe(true);
+    expect(future.modelId).toBe(CLAUDE_CODE_RESERVE_MODEL_ID);
+  });
+
+  it('WRITE is exempt — claude-code/capable (Opus) passes through unclamped', () => {
+    const out = clampToReserveOnCleanDoor(rp('claude-code', 'capable'), 'WRITE');
+    expect(out.clamped).toBe(false);
+    expect(out.modelId).toBe('capable');
+  });
+
+  it('a non-claude-code door is never touched', () => {
+    const out = clampToReserveOnCleanDoor(rp('pi-cli', 'gpt-5.5'), 'JUDGE');
+    expect(out.clamped).toBe(false);
+    expect(out.modelId).toBe('gpt-5.5');
+  });
+
+  it('is a SEPARATE fn from A1 clampClaudeCliSwapModel — A1 still returns the `balanced` TIER token (untouched)', () => {
+    // A1's always-on degrade/swap clamp must NOT change (byte-identical-when-off depends on it).
+    const a1 = clampClaudeCliSwapModel('claude-code', 'capable');
+    expect(a1).toEqual({ model: 'balanced', clamped: true });
+    expect(a1.model).not.toBe(CLAUDE_CODE_RESERVE_MODEL_ID); // A2 pins a concrete id; A1 keeps the tier token
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('resolveRoute — the four load-bearing outcomes', () => {
+  it("OUTCOME 'route': orders available positions, resolves ids, applies the clamp (primary + tail)", () => {
+    // SORT default = codex-cli → pi-cli → gemini-api(metered) → claude-code/balanced.
+    const res = resolveRoute('CommitmentSentinel', undefined, NATURE_ROUTING_DEFAULT_CHAINS, allCliReachable);
+    expect(res.outcome).toBe('route');
+    if (res.outcome !== 'route') return;
+    expect(res.resolvedChain).toBe('SORT');
+    // gemini-api (metered) is SKIPPED in Increment A — primary is codex-cli, tail is pi-cli then the claude reserve.
+    expect(res.primary).toMatchObject({ door: 'codex-cli', modelId: 'gpt-5.4-mini' });
+    expect(res.swapTail.map((p) => p.door)).toEqual(['pi-cli', 'claude-code']);
+    // The claude-code reserve resolved to the concrete pinned id (allowlisted, not clamped).
+    const reserve = res.swapTail.find((p) => p.door === 'claude-code');
+    expect(reserve?.modelId).toBe(CLAUDE_CODE_RESERVE_MODEL_ID);
+  });
+
+  it("OUTCOME 'fall-through': an unmapped component returns fall-through (→ legacy routing)", () => {
+    expect(resolveRoute('TotallyUnknownThing', undefined, NATURE_ROUTING_DEFAULT_CHAINS, allCliReachable))
+      .toEqual({ outcome: 'fall-through' });
+  });
+
+  it("OUTCOME 'no-route': a low-stakes mapped component with NO available door", () => {
+    // No CLI door reachable AND metered skipped ⇒ empty set; low-stakes ⇒ no-route (caller heuristic).
+    const res = resolveRoute('CommitmentSentinel', undefined, NATURE_ROUTING_DEFAULT_CHAINS, { isDoorReachable: () => false });
+    expect(res).toEqual({ outcome: 'no-route' });
+  });
+
+  it('OUTCOME throw RouterFailClosedError: a CRITICAL GATE with no available door fails CLOSED', () => {
+    // MessagingToneGate (nature B, JUDGE, critical) with every door down ⇒ throw, never no-route/fall-through.
+    expect(() => resolveRoute('MessagingToneGate', undefined, NATURE_ROUTING_DEFAULT_CHAINS, { isDoorReachable: () => false }))
+      .toThrow(RouterFailClosedError);
+    // MessageSentinel is nature-A but R2-critical ⇒ also fail-closed.
+    expect(() => resolveRoute('MessageSentinel', undefined, NATURE_ROUTING_DEFAULT_CHAINS, { isDoorReachable: () => false }))
+      .toThrow(RouterFailClosedError);
+  });
+
+  it('metered doors are always skipped in Increment A (FAST → pi-cli, gemini-api skipped)', () => {
+    const res = resolveRoute('MessageSentinel', undefined, NATURE_ROUTING_DEFAULT_CHAINS, allCliReachable);
+    expect(res.outcome).toBe('route');
+    if (res.outcome !== 'route') return;
+    // FAST default = gemini-api(metered, skipped) → pi-cli. Primary must be pi-cli.
+    expect(res.primary).toMatchObject({ door: 'pi-cli', modelId: 'gpt-5.5' });
+    expect(res.swapTail).toEqual([]);
+  });
+
+  it('a JUDGE route on claude-code is clamped to the reserve id at selection time (place-3 in the fold)', () => {
+    // If ONLY claude-code is reachable, the JUDGE terminal reserve is the primary — and pinned to the reserve id.
+    const onlyClaude = { isDoorReachable: (d: RoutingDoor) => d === 'claude-code' };
+    const res = resolveRoute('MessagingToneGate', undefined, NATURE_ROUTING_DEFAULT_CHAINS, onlyClaude);
+    expect(res.outcome).toBe('route');
+    if (res.outcome !== 'route') return;
+    expect(res.primary).toMatchObject({ door: 'claude-code', modelId: CLAUDE_CODE_RESERVE_MODEL_ID });
+  });
+
+  it('a caller-declared tightening nature reroutes a low-stakes call onto the JUDGE ladder', () => {
+    const res = resolveRoute('CommitmentSentinel', 'B', NATURE_ROUTING_DEFAULT_CHAINS, allCliReachable);
+    expect(res.outcome).toBe('route');
+    if (res.outcome !== 'route') return;
+    expect(res.resolvedChain).toBe('JUDGE'); // not SORT — tightened
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('mergeNatureRoutingChains', () => {
+  it('unset override ⇒ the built-in v3 defaults verbatim', () => {
+    expect(mergeNatureRoutingChains(undefined)).toBe(NATURE_ROUTING_DEFAULT_CHAINS);
+  });
+  it('a partial override replaces only the named chain; others keep the default', () => {
+    const merged = mergeNatureRoutingChains({ SORT: [{ door: 'pi-cli', model: 'gpt-5.5' }] });
+    expect(merged.SORT).toEqual([{ door: 'pi-cli', model: 'gpt-5.5' }]);
+    expect(merged.JUDGE).toBe(NATURE_ROUTING_DEFAULT_CHAINS.JUDGE);
+    expect(merged.FAST).toBe(NATURE_ROUTING_DEFAULT_CHAINS.FAST);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE load-bearing safety case: evaluate() wiring.
+// ─────────────────────────────────────────────────────────────────────────────
+function makeRouterWithNature(nature: NatureRoutingRuntime | undefined, onPlan?: (p: NatureRoutePlan) => void) {
+  const defaultProvider = fakeProvider('claude');
+  const built: Partial<Record<IntelligenceFramework, IntelligenceProvider>> = {};
+  const router = new IntelligenceRouter({
+    defaultProvider,
+    defaultFramework: 'claude-code',
+    resolveConfig: () => undefined, // componentFrameworks unconfigured — the common fleet shape
+    buildProvider: (fw) => built[fw] ?? null,
+    resolveNatureRouting: () => nature,
+    onNatureRoutePlan: onPlan,
+  });
+  return { router, defaultProvider };
+}
+
+describe('evaluate() — nature routing is BYTE-IDENTICAL when unset/off', () => {
+  const opts: IntelligenceOptions = { model: 'capable', attribution: { component: 'MessagingToneGate' } };
+
+  it('natureRouting UNSET ⇒ selection unchanged, onNatureRoutePlan NEVER called', async () => {
+    // THE safety case (named test): the resolve path is bit-for-bit today's behavior when off.
+    const onPlan = vi.fn();
+    const { router, defaultProvider } = makeRouterWithNature(undefined, onPlan);
+    const out = await router.evaluate('p', opts);
+    expect(out).toBe('claude');
+    expect(defaultProvider.calls).toHaveLength(1);
+    expect(defaultProvider.calls[0]).toBe(opts); // SAME options object — nothing rewritten
+    expect(onPlan).not.toHaveBeenCalled();
+  });
+
+  it('natureRouting enabled:false ⇒ still byte-identical, onNatureRoutePlan NEVER called', async () => {
+    const onPlan = vi.fn();
+    const { router, defaultProvider } = makeRouterWithNature({ enabled: false, dryRun: true }, onPlan);
+    const out = await router.evaluate('p', opts);
+    expect(out).toBe('claude');
+    expect(defaultProvider.calls[0]).toBe(opts);
+    expect(onPlan).not.toHaveBeenCalled();
+  });
+
+  it('DRYRUN observes (logs the plan) but does NOT change the selected (door, model)', async () => {
+    const onPlan = vi.fn();
+    const { router, defaultProvider } = makeRouterWithNature({ enabled: true, dryRun: true }, onPlan);
+    const out = await router.evaluate('p', opts);
+    // Selection is UNCHANGED — the same default provider is called with the SAME options.
+    expect(out).toBe('claude');
+    expect(defaultProvider.calls[0]).toBe(opts);
+    // …but the plan WAS observed.
+    expect(onPlan).toHaveBeenCalledTimes(1);
+    const plan = onPlan.mock.calls[0][0] as NatureRoutePlan;
+    expect(plan.dryRun).toBe(true);
+    expect(plan.component).toBe('MessagingToneGate');
+  });
+
+  it("DRYRUN records a critical-gate fail-closed plan WITHOUT throwing into the call path", async () => {
+    // Force fail-closed: default framework 'gemini-cli' is NOT in the JUDGE chain, so pi-cli,
+    // codex-cli, and claude-code all resolve unreachable (buildProvider → null) and the metered
+    // doors are skipped ⇒ empty set for the critical gate MessagingToneGate ⇒ resolveRoute throws.
+    // In dryRun that throw must be SWALLOWED (recorded as failClosed), never surfaced to the caller.
+    const onPlan = vi.fn();
+    const defaultProvider = fakeProvider('gemini');
+    const router = new IntelligenceRouter({
+      defaultProvider,
+      defaultFramework: 'gemini-cli',
+      resolveConfig: () => undefined,
+      buildProvider: () => null,
+      resolveNatureRouting: () => ({ enabled: true, dryRun: true }),
+      onNatureRoutePlan: onPlan,
+    });
+    const out = await router.evaluate('p', { attribution: { component: 'MessagingToneGate' } });
+    expect(out).toBe('gemini'); // dryRun never threw into the call path
+    expect(defaultProvider.calls).toHaveLength(1);
+    const plan = onPlan.mock.calls[0][0] as NatureRoutePlan;
+    expect(plan.failClosed).toBe(true);
+  });
+
+  it('a resolver plan for a mapped critical gate is emitted in dryRun (observability)', async () => {
+    const onPlan = vi.fn();
+    const { router } = makeRouterWithNature({ enabled: true, dryRun: true }, onPlan);
+    await router.evaluate('p', { attribution: { component: 'MessagingToneGate' } });
+    const plan = onPlan.mock.calls[0][0] as NatureRoutePlan;
+    // claude-code default is reachable ⇒ the JUDGE terminal reserve is available ⇒ a route plan.
+    expect(plan.resolution?.outcome).toBe('route');
+  });
+});

--- a/upgrades/nature-routing-a2.eli16.md
+++ b/upgrades/nature-routing-a2.eli16.md
@@ -1,0 +1,50 @@
+# ELI16 — Nature-Axis Routing, Increment A2.1 (the dark/dryRun mechanism)
+
+## The one-sentence version
+
+We taught the internal LLM router how to pick *which model, on which access door* a
+background check should run on — based on the **kind** of thinking the check does — but
+we shipped it **turned off** everywhere except as a silent "here's what I *would* pick"
+observer on a development agent.
+
+## Why
+
+Different internal jobs need different brains. A quick "is this a STOP command?" sort is a
+different task than a careful "should this message be blocked?" judgment. The bench (INSTAR
+v3) measured which model+door combo is best for each kind — and found one combo that's
+actively *dangerous* for careful judgments: Opus running through the Claude Code CLI (the
+CLI wraps every prompt in ~20k tokens of "helpful assistant" framing, which makes a skeptical
+judge go soft — it missed real STOP commands 27% of the time). So routing has to be able to
+say "for a judgment call, NEVER land on that door."
+
+## What this increment actually adds (and what it deliberately doesn't)
+
+**Adds (all pure, all dark):**
+- A **resolver** — a small, side-effect-free function: given a component, it works out the
+  task *nature*, walks an ordered list of `(door, model)` candidates, skips the ones that
+  aren't reachable, and returns the winner + the fallback tail. It has exactly four honest
+  outcomes: a route, "fall through to today's routing" (for a component we haven't mapped),
+  "no route — use your own backup" (for a low-stakes sorter when everything's down), or
+  **throw a distinct fail-closed error** (for a safety gate when everything's down — a gate
+  must fail shut, never open).
+- **FD4.1 — the concrete pin.** A2 finishes the job A1 left: the sanctioned Claude reserve
+  now pins to a *concrete* model id (`claude-sonnet-4-6`), not a tier nickname that could
+  drift. And a **deny-by-default allowlist** clamp: on the Claude door, a judgment/sort call
+  may ONLY use that one reserve id — anything else gets clamped down to it. (Open-ended
+  *writing* is exempt — that's where Opus-via-CLI is legitimately the best tool.)
+- The `sessions.natureRouting` **config knob** (seeded dark on update), the wiring, and the
+  full test suite.
+
+**Doesn't (tracked, not dropped):** the actual *re-routing* (enforcing mode), the injection
+map, the build-time lint, the live-config validator, the durable audit log + dashboard read
+surface, the critical-gate drift notice, and the Fable→Opus migration — those are the ordered
+A2.2 remainder. And **nothing** about the paid metered doors or the money/PIN go-live — that
+is Increment B, deferred and PIN-gated.
+
+## The safety promise
+
+When the feature is **off** (which is everywhere on the fleet), the router behaves **bit-for-bit
+like today** — same door, same model, same everything. That's the whole safety case, and there's
+a named test that asserts it (`natureRouting UNSET ⇒ selection unchanged`). On a dev agent it runs
+in **dryRun**: it computes and logs what it *would* pick, then still does exactly today's thing.
+Flipping it to actually re-route is a later, operator-driven step.

--- a/upgrades/next/nature-routing-a2.md
+++ b/upgrades/next/nature-routing-a2.md
@@ -1,0 +1,64 @@
+---
+user_announcement:
+  - audience: agent-only
+    maturity: experimental
+---
+
+## What Changed
+
+Shipped the dark/dryRun mechanism for Nature-Axis Routing (S4 Increment A2.1) — the internal LLM
+router can now, in principle, choose which model and which access door a background check runs on
+based on the KIND of task it is (a quick sort vs a careful judgment vs open-ended writing), instead
+of only its category. This increment lands the pure resolver + its safety enforcement, wired dark:
+DARK on the fleet, and LIVE-in-dryRun on a development agent (it computes and logs the route it WOULD
+pick, then still does exactly today's thing — it never re-routes yet).
+
+The resolver is a small, side-effect-free fold with four honest outcomes: a resolved route; fall
+through to today's routing (for a component with no nature mapping); no route, use your own heuristic
+(for a low-stakes sorter when every door is down); or a distinct fail-closed error (for a safety gate
+when every door is down — a gate must fail shut, never open). It also finishes the concrete-id pinning
+A1 deferred (FD4.1): the sanctioned Claude reserve now pins to the concrete model id claude-sonnet-4-6,
+and a deny-by-default allowlist clamp keeps a bounded or judgment call on the Claude door pinned to that
+one reserve id — the measured-banned Opus-via-the-Claude-CLI route can never open, even if someone
+hand-edits a chain. Open-ended writing is exempt, since that is where Opus-via-CLI is legitimately best.
+
+The load-bearing safety property is asserted by a named test: when the feature is unset or off, the
+router is bit-for-bit identical to today. A1's always-on clamp is untouched — the new clamp is a
+separate, nature-routing-scoped function.
+
+Deferred and tracked (not dropped): the actual re-routing (enforcing mode), the injection map, the
+build-time lint and live-config validator (FD4 places 1-2; place 3, the runtime clamp, ships here),
+the durable audit log and dashboard read surface, the critical-gate drift notice, and the Fable-to-Opus
+migration. The paid metered doors and the money/PIN go-live are Increment B — deferred and PIN-gated.
+
+## What to Tell Your User
+
+Nothing proactive — this is an internal, turned-off-by-default plumbing change with no user-facing
+surface. If a user ever asks why a background check might one day run on a different model than the one
+they talk to, the plain answer is: the agent measured which model is best at each kind of internal
+check, and this lets it eventually pick the right one for each job — but it is currently just watching
+and learning what it would choose, not changing anything, and turning it fully on is a separate,
+deliberate step the operator takes. Nothing they do changes today, and no setting is required.
+
+## Summary of New Capabilities
+
+- A nature-aware route resolver picks a model and access door by task kind — shipped dark on the fleet,
+  live in dryRun-observe mode on a development agent.
+- A deny-by-default allowlist keeps every bounded or judgment call on the Claude door pinned to the one
+  sanctioned Sonnet reserve id, so the measured-banned Opus-via-CLI route cannot open.
+- The sanctioned reserve is now pinned to a concrete model id, not a tier nickname that could drift.
+- A new config block, seeded dark on update, with the enable flag omitted so it rides the development-
+  agent gate. When off, routing is byte-identical to today.
+
+## Evidence
+
+- tests/unit/nature-routing-resolver.test.ts — 29 cases: the FD3 tighten rule (both sides of every
+  boundary), the four resolveRoute outcomes, the FD4.1 concrete-id pin, the FD4 allowlist clamp
+  (accepts the reserve id, rejects every other Claude id, WRITE exempt), the proof the new clamp is a
+  SEPARATE function from A1's, and the named byte-identical-when-off assertion plus dryRun-observes-but-
+  does-not-re-route.
+- tests/unit/migrate-nature-routing-dark.test.ts — 4 cases: the dark seed omits enabled, never clobbers
+  a configured block, no-ops without a sessions block, and is idempotent.
+- Regression: la4-degrade-path-clamp (13) + intelligence-router (17) + opus-claude-cli-gating-guardrail
+  (14) + llm-routing-nature-ratchet (6) stay green; tsc --noEmit clean.
+- Spec: docs/specs/nature-axis-routing.md — FD3, FD4/FD4.1, FD9 (the A1/A2 increment split).

--- a/upgrades/side-effects/nature-routing-a2.md
+++ b/upgrades/side-effects/nature-routing-a2.md
@@ -1,0 +1,89 @@
+# Side-Effects Review — Nature-Axis Routing, Increment A2.1 (dark/dryRun mechanism)
+
+**Spec:** docs/specs/nature-axis-routing.md (status: **converged — pending operator approval**;
+`review-convergence` tag, NOT `approved:true` — the operator's step). This ships as a **Tier-1**
+change: the smallest independently-landable **dark** unit of FD9's Increment A2. **Parent standards:**
+"Structure > Willpower", "No Silent Degradation to Brittle Fallback", benchmark-cited routing
+(INSTAR-Bench v3, rules R1/R2/R8), the Maturation Path (dev-gated dark), Migration Parity.
+
+**Files:** src/data/llmBenchCoverage.ts, src/core/IntelligenceRouter.ts, src/core/types.ts,
+src/commands/server.ts, src/core/PostUpdateMigrator.ts, tests/unit/nature-routing-resolver.test.ts,
+tests/unit/migrate-nature-routing-dark.test.ts, upgrades/nature-routing-a2.eli16.md,
+upgrades/side-effects/nature-routing-a2.md, upgrades/next/nature-routing-a2.md.
+
+## What changed
+
+1. **src/data/llmBenchCoverage.ts — the DATA half.** New pure, read-only constants: `RoutingDoor`
+   (CLI + metered-API door taxonomy, FD1), `CLI_ROUTING_DOORS` / `METERED_ROUTING_DOORS`,
+   `ChainPosition` + `NATURE_ROUTING_DEFAULT_CHAINS` (the four v3 CLI-only chains, FD2 — metered
+   positions are present but always skipped in Increment A), `ROUTING_LABEL_TO_MODEL_ID` (FD-LABEL/
+   FD4.1 — benchmark-label → concrete model id), `CLAUDE_CODE_RESERVE_MODEL_ID` (the single
+   sanctioned `claude-sonnet-4-6` reserve, FD4 place 1), and `NATURE_ROUTING_CRITICAL_GATES` (FD6).
+   Importing this changes NO behavior — it is data actuated only when the feature is enabled.
+2. **src/core/IntelligenceRouter.ts — the resolver.** New pure exports: `resolveNatureAndChain`
+   (FD3 tighten rule `E,B ≥ D ≥ A`), `resolvePositionModelId` (FD4.1), `clampToReserveOnCleanDoor`
+   (FD4 place-3 allowlist clamp), `resolveRoute` (the stateless fold with the four outcomes),
+   `mergeNatureRoutingChains`, and the `RouterFailClosedError` typed error. Two new
+   `IntelligenceRouterOptions` fields (`resolveNatureRouting`, `onNatureRoutePlan`) and a new,
+   tightly-scoped block in `evaluate()` that OBSERVES when the feature is enabled.
+3. **src/core/types.ts** — the `attribution.nature` opt-in tightening field (FD3) and the
+   `sessions.natureRouting` config schema (type-only, NOT in ConfigDefaults, per the
+   absent-equals-unchanged rule that `componentFrameworks`/`dynamicMcp` follow).
+4. **src/commands/server.ts** — the construction wiring: `resolveNatureRouting` reads config LIVE
+   per call and resolves `enabled` through `resolveDevAgentGate` (live-in-dryRun on a dev agent,
+   dark on the fleet); `onNatureRoutePlan` is an env-gated observe-only breadcrumb.
+5. **src/core/PostUpdateMigrator.ts** — `migrateConfigNatureRoutingDark` seeds `sessions.natureRouting`
+   dark on existing agents (`schemaVersion:3`, `dryRun:true`, `metered.goLive:false`; `enabled`
+   OMITTED for the dev-gate — the #1001 enable-path-integrity pattern), existence-checked + idempotent.
+
+## Explicitly DEFERRED (tracked A2.2 remainder — NOT dropped)
+
+Read this as intentional scope, not omission. This increment ships the pure mechanism + dark/dryRun
+observation. The following are the ordered remainder, each a separate landable change:
+
+- **Enforcing SELECTION** (dryRun:false actually re-routes) — A2.1 wires OBSERVATION only; flipping
+  `dryRun:false` logs a one-time "enforcing not yet wired" warning and stays byte-identical (an honest
+  no-op, never a silent dead switch and never a mis-route).
+- **FD4 places 1 & 2** — the build-time lint (`scripts/lint-nature-chains.mjs`) and the resolve-time
+  live-config validator. **Place 3 (the runtime allowlist clamp) DOES ship here** and is the actual
+  runtime guarantee: it clamps every resolved claude-code FAST/SORT/JUDGE position to the sanctioned
+  reserve id at selection time — so even a hand-edited chain cannot open the banned Opus-via-CLI route.
+  Places 1-2 are defense-in-depth for the build + config-edit surfaces.
+- **FD5b injection-exposure map** + R-rule lints (FD5c) — inert in A2.1 anyway: the only injection-
+  restricted door (`groq-api`) and the R8 Flash-Lite pin are METERED doors, always skipped in Increment
+  A; no CLI door in any chain is injection-restricted.
+- **The durable audit** (`logs/nature-routing.jsonl`) + `GET /intelligence/routing` dryRun plan/diff/
+  `?trace` read surface, the **FD6 aggregated critical-gate drift notice** + baseline, the **FD8
+  Fable→Opus** migration, and the **CLAUDE.md** capability blurb.
+- **Increment B** (metered-door live routing + FD12 money/PIN go-live) — DEFERRED + PIN-gated, an
+  operator step, never autonomous. No metered door routes and no spend ledger is touched here.
+
+## Blast radius
+
+- **Byte-identical when off — THE safety case.** When `sessions.natureRouting` is absent OR
+  `enabled:false` (the fleet default), the new block in `evaluate()` is skipped entirely and selection
+  is bit-for-bit today's. Asserted by name: `natureRouting UNSET ⇒ selection unchanged, onNatureRoutePlan
+  NEVER called` (the same options object is passed through untouched).
+- **A1 is untouched.** `clampClaudeCliSwapModel` (A1's always-on degrade/swap clamp, returning the
+  `balanced` TIER token) is NOT modified — the new `clampToReserveOnCleanDoor` is a SEPARATE, nature-
+  routing-scoped, concrete-id clamp used only inside `resolveRoute`. Touching A1's fn would have changed
+  its shipped byte-identical behavior; a test asserts A1 still returns `{model:'balanced'}`.
+- **dryRun cannot mis-route.** In dryRun the resolver only computes + logs; a resolver throw
+  (critical-gate fail-closed) is swallowed and recorded, never surfaced to the call path.
+- **Hot path.** The observation block runs on every internal LLM call ONLY when the feature is enabled
+  (dev agents). It is a stateless fold over static maps + O(1) door-reachability reads (cached by the
+  provider cache); the breadcrumb log is env-gated so a dev agent's hot path stays quiet.
+- **Config.** The seed is dark, existence-checked, idempotent, `enabled` omitted — it can never
+  force-dark a dev agent nor clobber an operator's config.
+
+## Second-pass review (Phase 5 — required: touches a "gate" / routing-of-safety-gates)
+
+The change routes safety GATES, so it triggers the high-risk second pass. Independent audit focus:
+(a) can the banned Opus-via-CLI route open? — No: the place-3 allowlist clamp is deny-by-default and
+fires on every resolved claude-code bounded/gating position, including a hand-edited chain. (b) can a
+critical gate fail OPEN? — No: the empty-set branch throws a distinct `RouterFailClosedError` for a
+critical gate (never `no-route`, never legacy routing); a unit test asserts both a nature-B gate
+(`MessagingToneGate`) and the nature-A R2-critical gate (`MessageSentinel`) throw. (c) is "off" truly
+inert? — Yes, the byte-identical-when-off test proves it. **Reviewer verdict: Concur with the review.**
+The one residual is that enforcing SELECTION is deferred — but since it is not wired, it cannot
+mis-route; the runtime clamp already makes the future enforcing path safe on its own.


### PR DESCRIPTION
## Summary

S4 **Increment A2.1** — the **smallest independently-landable DARK unit** of FD9 Increment A2: the nature-axis routing **mechanism**, shipped dark on the fleet, live-in-dryRun on a development agent, and **byte-identical when unset/off**. Branches off `main` (includes A1 #1386's LA4 clamp).

## ELI16

We taught the internal LLM router how to pick *which model, on which access door* a background check runs on — based on the **kind** of thinking it does (a quick sort vs a careful judgment vs open-ended writing) — but shipped it **turned off** everywhere except as a silent "here's what I *would* pick" observer on a development agent. The heart is a small, side-effect-free resolver with four honest outcomes: a route; fall through to today's routing (unmapped component); no route → use your own heuristic (a low-stakes sorter when every door is down); or a **distinct fail-closed error** (a safety gate when every door is down — a gate must fail shut, never open). It also finishes the concrete-id pinning A1 deferred (FD4.1): the sanctioned Claude reserve pins to the concrete id `claude-sonnet-4-6`, and a **deny-by-default allowlist** clamp keeps any bounded/judgment call on the Claude door pinned to that one reserve id — so the measured-banned Opus-via-the-Claude-CLI route can never open, even on a hand-edited chain. When the feature is off (the fleet default) the router behaves **bit-for-bit like today** — a named test asserts it.

## What ships (A2.1)

- Pure resolver: `resolveNatureAndChain` (FD3 tighten `E,B ≥ D ≥ A`), `resolveRoute` (the four-outcome fold + `RouterFailClosedError`), `resolvePositionModelId`, `mergeNatureRoutingChains`.
- **FD4.1** `ROUTING_LABEL_TO_MODEL_ID` — the `balanced` token pins to concrete **`claude-sonnet-4-6`**.
- **FD4 place-3** runtime allowlist clamp (`clampToReserveOnCleanDoor`) — a **SEPARATE fn from A1's `clampClaudeCliSwapModel`** (A1's always-on degrade/swap clamp is untouched, preserving byte-identical-when-off).
- `sessions.natureRouting` config schema + dark `migrateConfig` seed (`enabled` omitted → dev-gate).
- Dev-gated dark/dryRun **observation** wiring in `evaluate()`.

## Deferred and TRACKED (not dropped — the ordered A2.2 remainder)

- **Enforcing SELECTION** (dryRun:false re-routes) — A2.1 wires observation only; a `dryRun:false` flip logs a one-time "enforcing not yet wired" warning and stays byte-identical (honest no-op, never a mis-route).
- **FD4 places 1 & 2** — the build-time lint + resolve-time live-config validator. **Place 3 (the runtime clamp) ships here** and is the actual runtime guarantee, so the future enforcing path is already safe against a hand-edited chain.
- FD5b injection map + R-rule lints (inert in A2.1: the only injection-restricted door is metered/skipped); `logs/nature-routing.jsonl` audit + `GET /intelligence/routing` plan/diff/`?trace`; the FD6 aggregated critical-gate drift notice + baseline; the FD8 Fable→Opus migration; the CLAUDE.md blurb.

## Hard boundaries honored

- **Increment B** (metered-door live routing + FD12 money/PIN go-live) — DEFERRED + PIN-gated, an operator step. No metered door routes; no spend ledger touched.
- A1's LA4 clamp is **not** re-done. The spec is **not** marked `approved:true`.

## Tests

- `tests/unit/nature-routing-resolver.test.ts` (29) — both sides of every boundary. **Named byte-identical-when-off assertion:** `natureRouting UNSET ⇒ selection unchanged, onNatureRoutePlan NEVER called`. Plus dryRun-observes-but-does-not-re-route; the FD4.1 concrete-id pin; the FD4 allowlist (accepts reserve, rejects every other Claude id, WRITE exempt); and the proof the new clamp is a separate fn from A1's.
- `tests/unit/migrate-nature-routing-dark.test.ts` (4) — dark seed omits `enabled`, never clobbers, idempotent.
- Regression green: la4-degrade (13) + intelligence-router (17) + opus-gating-guardrail (14) + routing-nature-ratchet (6). `tsc --noEmit` + full `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
