### PR TITLE
feat(routing): S4 FD5b — injection-exposure static map + resolveRoute injection gate (dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-05T18-27-26-853Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-05T18-27-26-853Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-05T18:27:26.853Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 223,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/nature-axis-routing-fd5b-injection-exposure.eli16.md
+++ b/docs/specs/nature-axis-routing-fd5b-injection-exposure.eli16.md
@@ -1,0 +1,31 @@
+# FD5b — Injection-Exposure Map + Route Gate (Plain-English Overview)
+
+> The one-line version: give every one of my internal AI checks a static "does this handle untrusted content?" label, and make the router refuse to send a check that DOES onto a model door that a bench proved can be fooled by planted instructions.
+
+## The problem in one breath
+
+The nature-axis router (shipping dark) picks which model answers each of my background checks. Some model doors are cheap but NOT safe to feed content that a stranger controls — a bench found one door (a Groq-hosted model) follows instructions hidden inside the text it's told to judge. A check that reads untrusted content (an inbound message, a transcript, a file, another agent's data) must never be routed onto such a door. But deciding "is THIS check exposed to untrusted content?" per call is fragile: forget one callsite and you've silently opened the unsafe route. The spec (FD5b) says the answer must be a STATIC, exhaustive table — decided once at build time, never left to caller diligence.
+
+## What already exists
+
+- **The nature/chain map + the door taxonomy** — `LLM_ROUTING_NATURE` and the chain tables in `src/data/llmBenchCoverage.ts`, including a per-door `injectionSafe` flag (only `groq-api/gpt-oss-120B` is `injectionSafe: false` today, and it is a metered door already skipped in this increment).
+- **`LLM_UNTRUSTED_INPUT`** — a sibling exhaustive table already saying, for every component, whether it judges untrusted content. Injection exposure is the SAME question, so the new map is authored to match it and a test cross-checks the two so they can never drift apart.
+- **`resolveRoute`** — the router's per-call "walk the chain, pick the first available door" function. It runs only when the feature is switched on.
+
+## What this adds
+
+- **`LLM_ROUTING_INJECTION_EXPOSURE`** — a new exhaustive table (one row per known component). Each row says `exposed: true/false` and declares its input-shape (can user / model / tool content enter this call?). The default is `exposed: true` (fail-safe): a component is `false` ONLY when explicitly audited as carrying no untrusted content, with a written reason. A ratchet test fails the build if any component is missing a row, if a row names an unknown component, or if the exposed flag disagrees with the reviewed untrusted-input table.
+- **`resolveInjectionExposure(component)`** — a pure lookup that returns EXPOSED for any unknown/unlabeled component (fail-closed, the safe direction).
+- **The route gate** — inside `resolveRoute`, an injection-exposed component now SKIPS any `injectionSafe: false` door. A tightening-only per-call flag (`attribution.injectionExposed`) can mark a normally-trusted call as exposed, but can never relax a statically-exposed one.
+
+## The safeguards
+
+- **Fail-safe by default** — unknown or unlabeled ⇒ treated as exposed ⇒ never routed onto the unsafe door.
+- **No-op in this increment** — the only unsafe door is also a metered door, which is already skipped until the later paid-door increment. So over the real shipped chains the gate changes NOTHING; a test asserts the exposed and trusted routes are byte-identical.
+- **Byte-identical when off** — the gate lives inside `resolveRoute`, which only runs when `sessions.natureRouting` is enabled. With the feature unset/off, routing is bit-for-bit today's behavior. The pre-existing "byte-identical when off" test and A1's degrade-clamp test are untouched and green.
+- **Fresh, never cached** — exposure is evaluated per call, so the SAME cached door-health verdict still yields a different eligibility for a trusted vs an exposed call (an isolation test proves this).
+- **Can't silently diverge** — the ratchet cross-checks the new map against the reviewed untrusted-input table; a callsite that starts handling untrusted content must flip both, or CI fails.
+
+## What this deliberately does NOT do
+
+No metered-API doors, no money caps, no PIN go-live (that is the paid-door Increment B, deferred + PIN-gated). No flip to enforcing/live (operator-gated). The prompt-anchor fingerprint lint (the FD7 semantic-drift guard that re-checks a row when its prompt source changes) and the FD4.2 R-rule lints (R4/R5/R7/R8 as lints) are the tracked next increments — not built here. The spec is NOT marked approved by this change (the operator's step).

--- a/src/core/IntelligenceRouter.ts
+++ b/src/core/IntelligenceRouter.ts
@@ -44,6 +44,7 @@ import {
   CLAUDE_CODE_RESERVE_MODEL_ID,
   METERED_ROUTING_DOORS,
   NATURE_ROUTING_CRITICAL_GATES,
+  resolveInjectionExposure,
 } from '../data/llmBenchCoverage.js';
 
 export interface ComponentFrameworksConfig {
@@ -636,6 +637,21 @@ function baseComponentKey(component: string | undefined): string | undefined {
 }
 
 /**
+ * FD5b — is THIS call injection-exposed? Composes the STATIC per-component
+ * classification (`resolveInjectionExposure`, fail-safe) with an OPTIONAL per-call
+ * `attribution.injectionExposed` that may only TIGHTEN (mark an otherwise-trusted
+ * call exposed), never relax a statically-exposed component. The static map is
+ * authoritative for the exposed direction; the per-call flag can only raise it.
+ * Pure — the resolver reads only the static data map.
+ */
+export function isComponentInjectionExposed(
+  component: string | undefined,
+  perCallExposed?: boolean,
+): boolean {
+  return resolveInjectionExposure(component) || perCallExposed === true;
+}
+
+/**
  * The PURE nature-routing fold (spec §Resolver, steps 1–7). Deps are injected so the
  * function is side-effect-free + trivially testable: `isDoorReachable` reports CLI-door
  * reachability (the class wraps its provider cache). Metered doors are ALWAYS skipped in
@@ -654,6 +670,14 @@ export function resolveRoute(
     isDoorReachable: (door: RoutingDoor) => boolean;
     /** FD4.3 — called when a live chain is rejected for a harness-door-ban violation (→ defaults). */
     onInvalidChain?: (chain: RoutingChain, violations: NatureChainViolation[]) => void;
+    /**
+     * FD5b — is this call injection-exposed? Injected so the exposure verdict is
+     * evaluated FRESH per call (never served from a cached door-health verdict —
+     * the injection-cache isolation contract, spec §764-766). Defaults to the
+     * STATIC fail-safe classification; the class caller composes in the per-call
+     * `attribution.injectionExposed` tighten via `isComponentInjectionExposed`.
+     */
+    isInjectionExposed?: (component: string | undefined) => boolean;
   },
 ): RouteResolution {
   const nc = resolveNatureAndChain(component, declaredNature);
@@ -671,10 +695,17 @@ export function resolveRoute(
     deps.onInvalidChain?.(nc.resolvedChain, chainViolations);
     positions = NATURE_ROUTING_DEFAULT_CHAINS[nc.resolvedChain];
   }
+  // FD5b — evaluate injection exposure ONCE per call, fresh (never cached with door health).
+  const exposed = (deps.isInjectionExposed ?? resolveInjectionExposure)(component);
   const available: ResolvedRoutePosition[] = [];
   for (const p of positions) {
     // Increment A: metered-API doors are DEFINED but always unavailable (skipped) until Increment B.
     if (METERED_ROUTING_DOORS.has(p.door)) continue;
+    // FD5b injection gate (spec §283-294): an injection-exposed component may never land on a
+    // non-injection-safe door (`injectionSafe: false`, e.g. groq-api/gpt-oss-120B). NO-OP in
+    // Increment A — the only such door is ALSO metered, so it is already skipped above; this
+    // preserves byte-identical behavior while sealing the route structurally for Increment B.
+    if (exposed && p.injectionSafe === false) continue; // reason: injectionUnsafe
     if (!deps.isDoorReachable(p.door)) continue;
     const resolved: ResolvedRoutePosition = {
       door: p.door,
@@ -929,6 +960,12 @@ export class IntelligenceRouter implements IntelligenceProvider {
           {
             isDoorReachable: (d) => this.isCliDoorReachable(d),
             onInvalidChain: (c, v) => this.warnNatureChainRejected(c, v),
+            // FD5b — static exposure OR the per-call tightening flag (never relaxes static).
+            isInjectionExposed: (comp) =>
+              isComponentInjectionExposed(
+                comp,
+                (options?.attribution as { injectionExposed?: unknown } | undefined)?.injectionExposed === true,
+              ),
           },
         );
         this.opts.onNatureRoutePlan?.({ component, category, dryRun, resolution });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1021,6 +1021,18 @@ export interface IntelligenceOptions {
      */
     nature?: 'A' | 'B' | 'D' | 'E';
     /**
+     * S4 FD5b — OPT-IN, TIGHTENING-ONLY injection-exposure flag
+     * (docs/specs/nature-axis-routing.md §289). When the nature router is enabled,
+     * a caller MAY declare `true` to mark an otherwise-statically-trusted call as
+     * carrying untrusted / injection-bearing content — so the door-availability walk
+     * SKIPS any non-injection-safe door (`injectionSafe: false`) for this call. It can
+     * only ever TIGHTEN: `true` raises exposure; it can NEVER relax a component that is
+     * statically `exposed: true` in LLM_ROUTING_INJECTION_EXPOSURE (fail-safe). MUST
+     * originate from callsite CODE, never from model/user content (Sec4 trust boundary).
+     * Omitted ⇒ the static exposure map is authoritative. Inert unless nature routing is enabled.
+     */
+    injectionExposed?: boolean;
+    /**
      * F5 RESERVATION LANE (docs/specs/spawn-cap-interactive-priority.md).
      * `interactive` requests the user-facing reserved headroom in the host spawn cap
      * — set ONLY by a synchronous, user-blocking seam (the operator-facing tone gate /

--- a/src/data/llmBenchCoverage.ts
+++ b/src/data/llmBenchCoverage.ts
@@ -685,6 +685,180 @@ export const LLM_ROUTING_NATURE: Readonly<Record<string, RoutingNature>> = {
   'correction-learning': { nature: 'D', chain: 'SORT' },
 };
 
+// ───────────────────────────────────────────────────────────────────────────
+// S4 FD5b — INJECTION-EXPOSURE static map (docs/specs/nature-axis-routing.md
+// FD5(b) §283-294, semantic-drift row detail §370-384).
+//
+// The `injectionExposure` axis of the per-component routing classification — the
+// PARALLEL exhaustive map the FD5 door-availability walk consults to decide
+// whether a candidate position on a NON-injection-safe door (a door whose
+// ChainPosition carries `injectionSafe: false`, e.g. groq-api/gpt-oss-120B) is
+// eligible for THIS component. It is enforced STATICALLY (not a per-call caller
+// flag) exactly like the nature map: one forgotten callsite must not be able to
+// silently route an injection-exposed call onto a non-injection door.
+//
+// POLARITY — FAIL-SAFE (spec §286): the map DEFAULTS to `exposed: true`. A
+// component is `exposed: false` ONLY when explicitly audited as carrying NO
+// untrusted / injection-bearing content, and that argument is required in the row
+// (`reason`, pinned shrink-only in the ratchet). `resolveInjectionExposure`
+// treats a missing/unknown component as EXPOSED (fail-closed skip) — the safe
+// direction. A per-call `attribution.injectionExposed: true` may only TIGHTEN
+// (mark an otherwise-trusted call exposed), never relax a statically-exposed
+// component (composed in IntelligenceRouter.isComponentInjectionExposed).
+//
+// THE CLASSIFICATION IS THE SAME PREDICATE AS `LLM_UNTRUSTED_INPUT` above — a
+// component carries injection-bearing content iff it judges untrusted content —
+// so this map's `exposed` is authored to MIRROR that reviewed axis, and the
+// ratchet (tests/unit/nature-routing-injection-exposure-ratchet.test.ts)
+// CROSS-CHECKS the two so they can never silently diverge (a callsite that
+// becomes `untrustedInput: true` must also become `exposed: true`, or CI fails).
+// This is the FD5b arm of the FD7 semantic-drift guard that is honoured TODAY;
+// the prompt-anchor fingerprint LINT (spec §376-384) is the separate FD7
+// semantic-drift increment.
+//
+// R8 (spec §308-310): the input-classifier-nature components (InputClassifier,
+// MessageSentinel, TaskClassifier) are injection-exposed and MUST be
+// `exposed: true` — the ratchet pins this so a future edit can't relax them.
+//
+// EACH ROW carries the spec's INPUT-SHAPE DECLARATION (§371: "can user / model /
+// tool content enter this call?"). It is load-bearing here: the ratchet enforces
+// `exposed ⟺ (userContent || modelContent || toolContent)` — an exposed:false row
+// declares all three false (nothing untrusted can enter), an exposed:true row
+// declares at least the channel(s) through which untrusted content arrives.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Can content of each provenance enter this LLM call (spec §371 input-shape declaration)?
+ *  - userContent  → the prompt embeds human/user-authored content (inbound messages, conversation);
+ *  - modelContent → the prompt embeds model/agent-generated content (assistant turns, session output, summaries);
+ *  - toolContent  → the prompt embeds tool output / file / peer-agent / process content. */
+export interface InjectionInputShape {
+  readonly userContent: boolean;
+  readonly modelContent: boolean;
+  readonly toolContent: boolean;
+}
+
+/** One component's static injection-exposure classification (FD5b).
+ *  `exposed` DEFAULTS true (fail-safe); `exposed:false` REQUIRES an argued `reason`
+ *  and an all-false `inputShape` (audited: no untrusted content can enter). */
+export interface InjectionExposure {
+  readonly exposed: boolean;
+  readonly inputShape: InjectionInputShape;
+  /** Required argument WHY the component carries no untrusted content (exposed:false only). */
+  readonly reason?: string;
+}
+
+const EXPOSED_USER: InjectionInputShape = { userContent: true, modelContent: false, toolContent: false };
+const EXPOSED_MODEL: InjectionInputShape = { userContent: false, modelContent: true, toolContent: false };
+const EXPOSED_TOOL: InjectionInputShape = { userContent: false, modelContent: false, toolContent: true };
+const EXPOSED_USER_MODEL: InjectionInputShape = { userContent: true, modelContent: true, toolContent: false };
+const EXPOSED_USER_TOOL: InjectionInputShape = { userContent: true, modelContent: false, toolContent: true };
+const EXPOSED_MODEL_TOOL: InjectionInputShape = { userContent: false, modelContent: true, toolContent: true };
+const EXPOSED_ALL: InjectionInputShape = { userContent: true, modelContent: true, toolContent: true };
+const NOT_EXPOSED: InjectionInputShape = { userContent: false, modelContent: false, toolContent: false };
+
+/** Sugar for the fail-safe default: an exposed row carrying its untrusted input-shape. */
+const exposed = (inputShape: InjectionInputShape): InjectionExposure => ({ exposed: true, inputShape });
+/** Sugar for the audited safe row: not exposed, all channels closed, with the argued reason. */
+const notExposed = (reason: string): InjectionExposure => ({ exposed: false, inputShape: NOT_EXPOSED, reason });
+
+export const LLM_ROUTING_INJECTION_EXPOSURE: Readonly<Record<string, InjectionExposure>> = {
+  // ── Sentinels ──
+  ExternalHogClassifier: exposed(EXPOSED_TOOL), // attacker-controllable process name + argv
+  InputGuard: exposed(EXPOSED_USER),
+  SessionActivitySentinel: exposed(EXPOSED_MODEL), // session tmux output
+  StallTriageNurse: exposed(EXPOSED_MODEL), // session output
+  CommitmentSentinel: exposed(EXPOSED_USER_MODEL), // both sides of a conversation
+  PresenceProxy: exposed(EXPOSED_MODEL), // session-stall over session output
+  MessageSentinel: exposed(EXPOSED_USER), // inbound user message (R8 input-classifier — must stay exposed)
+  ProjectDriftChecker: exposed(EXPOSED_MODEL_TOOL), // session work + files
+  TemporalCoherenceChecker: exposed(EXPOSED_USER_MODEL),
+  CompletionEvaluator: exposed(EXPOSED_MODEL_TOOL), // asserted work over session output/transcript
+  SessionWatchdog: exposed(EXPOSED_MODEL), // stuck-judge over session output
+  ResumeQueueDrainer: exposed(EXPOSED_MODEL_TOOL), // session state before a resume
+  TopicIntentArcCheck: exposed(EXPOSED_USER_MODEL),
+  SlackAdapter: exposed(EXPOSED_MODEL), // stall-confirm over session output
+  InputClassifier: exposed(EXPOSED_USER), // inbound user message (R8 input-classifier — must stay exposed)
+  SessionSummarySentinel: exposed(EXPOSED_MODEL), // summarizes tmux output
+  TelegramAdapter: exposed(EXPOSED_MODEL), // stall-confirm over session output
+
+  // ── Gates ──
+  PromptGate: exposed(EXPOSED_USER_TOOL), // injection detection over inbound content
+  ExternalOperationGate: exposed(EXPOSED_USER_TOOL), // in-content "user already approved" claims
+  WarrantsReplyGate: exposed(EXPOSED_USER),
+  UnjustifiedStopGate: exposed(EXPOSED_MODEL), // stop justification over session state
+  MessagingToneGate: exposed(EXPOSED_ALL), // reviews an outbound draft quoting user/tool content
+  MoveIntentClassifier: exposed(EXPOSED_USER), // inbound user message + conversation
+  HubIntentClassifier: exposed(EXPOSED_USER), // inbound hub message
+  ProfileIntentClassifier: exposed(EXPOSED_USER), // inbound user message + conversation
+  CoherenceReviewer: exposed(EXPOSED_ALL), // reviews outbound coherence (draft + context)
+  LLMSanitizer: exposed(EXPOSED_USER_TOOL), // definitionally judges untrusted inbound content
+  OverrideDetector: exposed(EXPOSED_USER),
+  TaskClassifier: exposed(EXPOSED_USER), // classifies a user task (R8 input-classifier — must stay exposed)
+
+  // ── Reflectors ──
+  JobReflector: exposed(EXPOSED_MODEL_TOOL),
+  crossModelReviewer: exposed(EXPOSED_TOOL), // reviews a spec document (file)
+  SelfKnowledgeTree: exposed(EXPOSED_MODEL_TOOL), // extracts over transcripts
+  TreeTriage: exposed(EXPOSED_TOOL),
+  TopicSummarizer: exposed(EXPOSED_USER_MODEL),
+  ContextualEvaluator: exposed(EXPOSED_USER_MODEL),
+  RelationshipManager: exposed(EXPOSED_USER_MODEL), // extracts relationship facts from conversation
+  StandardsConformanceReviewer: exposed(EXPOSED_TOOL), // artifact-vs-standard over files
+  DiscoveryEvaluator: exposed(EXPOSED_MODEL_TOOL), // subagent output
+  Usher: exposed(EXPOSED_USER), // routes an inbound turn
+  TopicIntentExtractor: exposed(EXPOSED_USER),
+  PreCompactionFlush: exposed(EXPOSED_MODEL_TOOL), // durable facts from a transcript
+  TreeSynthesis: exposed(EXPOSED_TOOL),
+  LLMConflictResolver: exposed(EXPOSED_TOOL), // divergent peer state = untrusted peer data
+  openConversationBrief: exposed(EXPOSED_TOOL), // A2A peer content
+  'a2a-checkin': exposed(EXPOSED_TOOL), // A2A peer-authored threads
+  'correction-learning': exposed(EXPOSED_USER_MODEL),
+  'mentor-stage-b': exposed(EXPOSED_MODEL_TOOL), // mentor signals over mentee output
+  ResumeValidator: exposed(EXPOSED_TOOL), // matches a resume UUID against topic/session state
+
+  // ── Jobs ──
+  PipeSessionSpawner: exposed(EXPOSED_USER_TOOL), // spawns from (possibly user-authored) task descriptions
+  CartographerSweep: exposed(EXPOSED_TOOL), // authors summaries over untrusted CODE
+  StandardsCoverageEnrichment: exposed(EXPOSED_TOOL),
+
+  // ── Argued NOT-EXPOSED (pinned shrink-only) — no live LLM callsite carrying untrusted content.
+  //    This set mirrors LLM_UNTRUSTED_INPUT's argued-false set exactly (cross-checked by the ratchet). ──
+  PromiseBeacon: notExposed(
+    'no live LLM prompt — generateStatusLine/classifyProgress hooks are unwired at the construction site; no untrusted content can enter (matches its untrustedInput/bench-coverage exemption)',
+  ),
+  InteractivePoolCanaryJudge: notExposed(
+    'judges a FIXED known-answer canary probe — the input is a constant, not external content; a planted instruction cannot reach it',
+  ),
+  AutoApprover: notExposed(
+    'mechanical key injection + audit logging, no LLM prompt of its own; the upstream untrusted-judging callsite is InputClassifier.classify()',
+  ),
+  IntegrationGate: notExposed(
+    'no LLM prompt of its own — delegates to JobReflector.reflect(); zero LLM-provider callsites of its own that see untrusted content',
+  ),
+  CoherenceGate: notExposed(
+    'no callsite carries attribution CoherenceGate — all LLM calls flow through CoherenceReviewer.callApi(), classified exposed there',
+  ),
+  InputDetector: notExposed(
+    'attribution-manifest alias only (a legacy prompt-pattern matcher); the live matcher calls with attribution PromptGate, classified exposed there',
+  ),
+};
+
+/**
+ * FD5b — resolve a component's STATIC injection exposure (fail-safe). Strips a
+ * trailing "/segment" operation suffix + a leading "server:" prefix (mirroring
+ * componentCategories.categoryForComponent) then looks the base up in the
+ * exhaustive map. A missing/unknown component resolves EXPOSED (fail-closed): the
+ * safe direction — an unclassified call is treated as if it could carry an
+ * injection, so it is never routed onto a non-injection-safe door. Pure.
+ */
+export function resolveInjectionExposure(component: string | undefined): boolean {
+  if (!component) return true; // fail-closed: no attribution ⇒ assume exposed
+  const base = component.split('/')[0].replace(/^server:/, '').trim();
+  const row = LLM_ROUTING_INJECTION_EXPOSURE[base];
+  if (!row) return true; // unknown component ⇒ exposed (fail-safe skip)
+  return row.exposed;
+}
+
 /* ────────────────────────────────────────────────────────────────────────────
  * S4 Increment A2 — nature-axis routing: door taxonomy, label registry, chains.
  *

--- a/tests/unit/nature-routing-injection-exposure-ratchet.test.ts
+++ b/tests/unit/nature-routing-injection-exposure-ratchet.test.ts
@@ -1,0 +1,159 @@
+/**
+ * FD5b injection-exposure static-map ratchet — the test-side enforcement of the
+ * nature-axis routing injection gate (docs/specs/nature-axis-routing.md §283-294,
+ * semantic-drift row detail §370-384).
+ *
+ * Guarantees, structurally (mirrors the untrustedInput / bench-coverage ratchets):
+ *   1. EXHAUSTIVE over COMPONENT_CATEGORY — every LLM component carries an EXPLICIT
+ *      injection-exposure row (a MISSING key fails) AND every map key names a real
+ *      component (a DANGLING key fails). No default toward the unguarded state.
+ *   2. FAIL-SAFE resolve — an unknown/unmapped/absent component resolves EXPOSED.
+ *   3. The argued NOT-EXPOSED set is pinned SHRINK-ONLY, each with a real reason and
+ *      an all-false input-shape (audited: no untrusted content can enter).
+ *   4. INPUT-SHAPE coherence (spec §371) — `exposed ⟺ (user||model||tool content)`.
+ *   5. CROSS-CHECK vs LLM_UNTRUSTED_INPUT — injection exposure is the SAME predicate
+ *      as untrusted-input, so the two reviewed axes can never silently diverge.
+ *   6. R8 (spec §308-310) — the input-classifier components MUST stay exposed:true.
+ */
+import { describe, it, expect } from 'vitest';
+import { COMPONENT_CATEGORY } from '../../src/core/componentCategories.js';
+import {
+  LLM_ROUTING_INJECTION_EXPOSURE,
+  LLM_UNTRUSTED_INPUT,
+  resolveInjectionExposure,
+  type UntrustedInputFlag,
+} from '../../src/data/llmBenchCoverage.js';
+
+function isUntrustedArguedFalse(v: UntrustedInputFlag): v is { false: string } {
+  return typeof v === 'object' && v !== null && 'false' in v;
+}
+
+// ── Pinned NOT-EXPOSED baseline (2026-07-05). SHRINK-ONLY: flipping a row to
+// exposed:true removes it here; ADDING a name means you are declaring a component
+// carries NO untrusted content — argue the reason in src/data/llmBenchCoverage.ts
+// AND add it here (a visible, reviewed act). It MIRRORS the untrustedInput
+// argued-false set (cross-checked below). ──
+const NOT_EXPOSED_BASELINE = [
+  'PromiseBeacon',
+  'InteractivePoolCanaryJudge',
+  'AutoApprover',
+  'IntegrationGate',
+  'CoherenceGate',
+  'InputDetector',
+].sort();
+
+describe('FD5b injection-exposure static-map ratchet', () => {
+  it('EXHAUSTIVE — every COMPONENT_CATEGORY key has an explicit injection-exposure row (a MISSING entry FAILS)', () => {
+    const missing = Object.keys(COMPONENT_CATEGORY).filter(
+      (k) => !(k in LLM_ROUTING_INJECTION_EXPOSURE),
+    );
+    expect(
+      missing,
+      `LLM component(s) with no injection-exposure row: ${missing.join(', ')}.\n` +
+        'Add each to LLM_ROUTING_INJECTION_EXPOSURE in src/data/llmBenchCoverage.ts — `exposed(<inputShape>)` ' +
+        '(it carries untrusted content) or `notExposed("<argued reason>")` (audited: no untrusted content — ALSO ' +
+        'add it to NOT_EXPOSED_BASELINE in this test). nature-axis-routing.md FD5b §286.',
+    ).toEqual([]);
+  });
+
+  it('no DANGLING entries — every map key names a real COMPONENT_CATEGORY component (a dangling key FAILS)', () => {
+    const dangling = Object.keys(LLM_ROUTING_INJECTION_EXPOSURE).filter(
+      (k) => !(k in COMPONENT_CATEGORY),
+    );
+    expect(
+      dangling,
+      `injection-exposure rows for unknown components: ${dangling.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('FAIL-SAFE — an unknown / unmapped / absent component resolves EXPOSED (fail-closed skip)', () => {
+    expect(resolveInjectionExposure(undefined)).toBe(true);
+    expect(resolveInjectionExposure('TotallyUnknownComponent')).toBe(true);
+    expect(resolveInjectionExposure('')).toBe(true);
+  });
+
+  it('resolve strips the "/segment" suffix and "server:" prefix before lookup', () => {
+    // CompletionEvaluator is exposed:true; a suffixed/prefixed callsite label resolves the same.
+    expect(resolveInjectionExposure('CompletionEvaluator/stop-judge')).toBe(true);
+    expect(resolveInjectionExposure('server:correction-learning')).toBe(true);
+    // InteractivePoolCanaryJudge is exposed:false; its suffixed form stays false.
+    expect(resolveInjectionExposure('InteractivePoolCanaryJudge/probe')).toBe(false);
+  });
+
+  it('the argued NOT-EXPOSED set matches the pinned shrink-only baseline exactly', () => {
+    const actual = Object.entries(LLM_ROUTING_INJECTION_EXPOSURE)
+      .filter(([, v]) => v.exposed === false)
+      .map(([k]) => k)
+      .sort();
+    expect(
+      actual,
+      'The NOT-EXPOSED set drifted from the pinned baseline. Flipping a false→true is a shrink ' +
+        '(remove it from NOT_EXPOSED_BASELINE); adding a new NOT-EXPOSED requires editing this pinned ' +
+        'baseline — a visible, reviewed act.',
+    ).toEqual(NOT_EXPOSED_BASELINE);
+  });
+
+  it('every NOT-EXPOSED row carries a real reason (>= 40 chars) AND an all-false input-shape', () => {
+    for (const [k, v] of Object.entries(LLM_ROUTING_INJECTION_EXPOSURE)) {
+      if (v.exposed !== false) continue;
+      expect((v.reason ?? '').trim().length, `${k}: NOT-EXPOSED reason too short`).toBeGreaterThanOrEqual(40);
+      expect(
+        v.inputShape.userContent || v.inputShape.modelContent || v.inputShape.toolContent,
+        `${k}: NOT-EXPOSED must declare an all-false input-shape (nothing untrusted can enter)`,
+      ).toBe(false);
+    }
+  });
+
+  it('INPUT-SHAPE coherence (spec §371) — exposed ⟺ (userContent || modelContent || toolContent)', () => {
+    const violations: string[] = [];
+    for (const [k, v] of Object.entries(LLM_ROUTING_INJECTION_EXPOSURE)) {
+      const anyChannel = v.inputShape.userContent || v.inputShape.modelContent || v.inputShape.toolContent;
+      if (v.exposed !== anyChannel) {
+        violations.push(`${k}: exposed=${v.exposed} but input-shape any-channel=${anyChannel}`);
+      }
+    }
+    expect(violations, violations.join('\n')).toEqual([]);
+  });
+
+  it('CROSS-CHECK — injection exposure equals the reviewed untrustedInput classification (never diverges)', () => {
+    const mismatches: string[] = [];
+    for (const k of Object.keys(COMPONENT_CATEGORY)) {
+      const exposed = LLM_ROUTING_INJECTION_EXPOSURE[k]?.exposed;
+      const untrusted = LLM_UNTRUSTED_INPUT[k];
+      const untrustedTrue = untrusted === true; // `{false}` or absent ⇒ not untrusted
+      if (exposed !== untrustedTrue) {
+        mismatches.push(`${k}: injectionExposed=${exposed} but untrustedInput=${untrustedTrue}`);
+      }
+    }
+    expect(
+      mismatches,
+      'injection exposure diverged from the untrustedInput axis (same predicate — a component carries ' +
+        'injection-bearing content iff it judges untrusted content):\n' + mismatches.join('\n'),
+    ).toEqual([]);
+  });
+
+  it('the untrustedInput argued-false set and the NOT-EXPOSED set are the same components', () => {
+    const untrustedFalse = Object.entries(LLM_UNTRUSTED_INPUT)
+      .filter(([, v]) => isUntrustedArguedFalse(v))
+      .map(([k]) => k)
+      .sort();
+    expect(untrustedFalse).toEqual(NOT_EXPOSED_BASELINE);
+  });
+
+  it('R8 (spec §308-310) — the input-classifier components are exposed:true and can never be relaxed', () => {
+    for (const c of ['InputClassifier', 'MessageSentinel', 'TaskClassifier']) {
+      expect(LLM_ROUTING_INJECTION_EXPOSURE[c]?.exposed, `${c} must be exposed:true (R8)`).toBe(true);
+      expect(resolveInjectionExposure(c), `${c} must resolve exposed:true (R8)`).toBe(true);
+    }
+  });
+
+  it('the map is non-empty and every row has a well-formed input-shape', () => {
+    expect(Object.keys(LLM_ROUTING_INJECTION_EXPOSURE).length).toBeGreaterThan(0);
+    for (const [k, v] of Object.entries(LLM_ROUTING_INJECTION_EXPOSURE)) {
+      expect(typeof v.exposed, `${k}: exposed must be boolean`).toBe('boolean');
+      for (const ch of ['userContent', 'modelContent', 'toolContent'] as const) {
+        expect(typeof v.inputShape[ch], `${k}: inputShape.${ch} must be boolean`).toBe('boolean');
+      }
+    }
+  });
+});

--- a/tests/unit/nature-routing-resolver.test.ts
+++ b/tests/unit/nature-routing-resolver.test.ts
@@ -27,6 +27,7 @@ import {
   validateNatureRoutingChains,
   validateChainPosition,
   isNatureRoutingChainsValid,
+  isComponentInjectionExposed,
   RouterFailClosedError,
   type NatureRoutingRuntime,
   type NatureRoutePlan,
@@ -38,6 +39,7 @@ import {
   ROUTING_LABEL_TO_MODEL_ID,
   CLAUDE_CODE_RESERVE_MODEL_ID,
   NATURE_ROUTING_DEFAULT_CHAINS,
+  resolveInjectionExposure,
   type RoutingDoor,
   type ChainPosition,
   type NatureRoutingChains,
@@ -448,5 +450,145 @@ describe('FD4.3 is BYTE-IDENTICAL when nature-routing is OFF (the validator neve
     expect(out).toBe('claude');
     expect(defaultProvider.calls[0]).toBe(opts); // SAME object — nothing merged, validated, or rewritten
     expect(onPlan).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FD5b — the injection-exposure gate in resolveRoute (spec §283-294). An
+// injection-EXPOSED component may never land on a NON-injection-safe door
+// (`injectionSafe: false`). NO-OP in Increment A over the real defaults (the only
+// such door, groq-api, is ALSO metered → already skipped), so these tests use a
+// SYNTHETIC chain with a non-injection-safe CLI door to exercise the gate in
+// isolation from the metered dimension.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A SORT chain whose FIRST position is a reachable CLI door marked injectionSafe:false. */
+const UNSAFE_FIRST_SORT: NatureRoutingChains = {
+  FAST: NATURE_ROUTING_DEFAULT_CHAINS.FAST,
+  SORT: [
+    { door: 'pi-cli', model: 'gpt-5.5', injectionSafe: false }, // non-injection-safe CLI door (synthetic)
+    { door: 'codex-cli', model: 'gpt-5.4-mini' },
+  ],
+  JUDGE: NATURE_ROUTING_DEFAULT_CHAINS.JUDGE,
+  WRITE: NATURE_ROUTING_DEFAULT_CHAINS.WRITE,
+};
+
+describe('FD5b injection gate (resolveRoute)', () => {
+  it('an EXPOSED component SKIPS the non-injection-safe door; a NON-exposed component keeps it', () => {
+    // CommitmentSentinel is SORT + statically exposed:true.
+    const asExposed = resolveRoute('CommitmentSentinel', undefined, UNSAFE_FIRST_SORT, {
+      isDoorReachable: () => true,
+      isInjectionExposed: () => true,
+    });
+    expect(asExposed.outcome).toBe('route');
+    if (asExposed.outcome !== 'route') return;
+    // pi-cli (injectionSafe:false) is skipped ⇒ primary is codex-cli.
+    expect(asExposed.primary.door).toBe('codex-cli');
+    expect(asExposed.swapTail.map((p) => p.door)).not.toContain('pi-cli');
+
+    // Same chain + same reachability, but NOT exposed ⇒ the non-injection door is eligible.
+    const asTrusted = resolveRoute('CommitmentSentinel', undefined, UNSAFE_FIRST_SORT, {
+      isDoorReachable: () => true,
+      isInjectionExposed: () => false,
+    });
+    expect(asTrusted.outcome).toBe('route');
+    if (asTrusted.outcome !== 'route') return;
+    expect(asTrusted.primary.door).toBe('pi-cli'); // kept — no injection risk
+  });
+
+  it('defaults to the STATIC map when isInjectionExposed is omitted (CommitmentSentinel is exposed ⇒ skipped)', () => {
+    const res = resolveRoute('CommitmentSentinel', undefined, UNSAFE_FIRST_SORT, {
+      isDoorReachable: () => true,
+    });
+    expect(res.outcome).toBe('route');
+    if (res.outcome !== 'route') return;
+    // No isInjectionExposed dep ⇒ resolveInjectionExposure (static) ⇒ CommitmentSentinel exposed ⇒ pi-cli skipped.
+    expect(res.primary.door).toBe('codex-cli');
+    expect(resolveInjectionExposure('CommitmentSentinel')).toBe(true);
+  });
+
+  it('a critical gate that would land ONLY on a non-injection door when exposed FAILS CLOSED (never routes there)', () => {
+    // Chain: the ONLY reachable position is a non-injection-safe door. MessagingToneGate is a critical
+    // gate ⇒ an exposed call skips it and, with no other door, throws (fail-closed) rather than route unsafe.
+    const unsafeOnlyJudge: NatureRoutingChains = {
+      FAST: NATURE_ROUTING_DEFAULT_CHAINS.FAST,
+      SORT: NATURE_ROUTING_DEFAULT_CHAINS.SORT,
+      JUDGE: [{ door: 'pi-cli', model: 'gpt-5.5', injectionSafe: false }],
+      WRITE: NATURE_ROUTING_DEFAULT_CHAINS.WRITE,
+    };
+    expect(() =>
+      resolveRoute('MessagingToneGate', undefined, unsafeOnlyJudge, {
+        isDoorReachable: () => true,
+        isInjectionExposed: () => true,
+      }),
+    ).toThrow(RouterFailClosedError);
+    // …but a NON-exposed call on the same chain routes onto that door (no injection risk).
+    const trusted = resolveRoute('MessagingToneGate', undefined, unsafeOnlyJudge, {
+      isDoorReachable: () => true,
+      isInjectionExposed: () => false,
+    });
+    expect(trusted.outcome).toBe('route');
+  });
+
+  it('the real default chains are UNAFFECTED by the gate for an exposed component (Increment A no-op)', () => {
+    // groq-api (the only injectionSafe:false default door) is metered ⇒ already skipped; the gate changes nothing.
+    const res = resolveRoute('CommitmentSentinel', undefined, NATURE_ROUTING_DEFAULT_CHAINS, {
+      isDoorReachable: () => true,
+      isInjectionExposed: () => true, // exposed
+    });
+    const resTrusted = resolveRoute('CommitmentSentinel', undefined, NATURE_ROUTING_DEFAULT_CHAINS, {
+      isDoorReachable: () => true,
+      isInjectionExposed: () => false, // trusted
+    });
+    expect(res).toEqual(resTrusted); // identical — no default door is a non-metered injection door
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FD5b — injection-cache isolation (spec §764-766, combined-safety r5). Door
+// HEALTH may be cached; the injection POLICY skip is re-evaluated FRESH per call.
+// resolveRoute recomputes exposure every call from the injected predicate, so the
+// SAME cached door-health verdict yields DIFFERENT eligibility for a trusted vs an
+// exposed call — proving the policy is never baked into a cached full verdict.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('FD5b injection-cache isolation', () => {
+  it('the SAME cached door health yields a DIFFERENT injection verdict per call (policy is fresh, not cached)', () => {
+    // One shared isDoorReachable closure = a single cached door-health source, reused by both calls.
+    let doorHealthQueries = 0;
+    const cachedHealth = {
+      isDoorReachable: (_d: RoutingDoor) => {
+        doorHealthQueries++;
+        return true; // pi-cli + codex-cli both "healthy" (cached)
+      },
+    };
+
+    // Call 1 — a NON-exposed call: pi-cli (injectionSafe:false) is HEALTHY and ELIGIBLE.
+    const trusted = resolveRoute('CommitmentSentinel', undefined, UNSAFE_FIRST_SORT, {
+      ...cachedHealth,
+      isInjectionExposed: () => false,
+    });
+    expect(trusted.outcome === 'route' && trusted.primary.door).toBe('pi-cli');
+
+    // Call 2 — an EXPOSED call within the same "TTL" (same cached health source): pi-cli is STILL healthy
+    // but is skipped by a FRESHLY-evaluated injection policy — NOT served from call 1's full verdict.
+    const exposedCall = resolveRoute('CommitmentSentinel', undefined, UNSAFE_FIRST_SORT, {
+      ...cachedHealth,
+      isInjectionExposed: () => true,
+    });
+    expect(exposedCall.outcome === 'route' && exposedCall.primary.door).toBe('codex-cli');
+    expect(doorHealthQueries).toBeGreaterThan(0); // door health WAS consulted (cached source), yet the verdict diverged
+  });
+
+  it('isComponentInjectionExposed — static exposure OR the per-call tighten (never relaxes static)', () => {
+    // Statically exposed:false — the per-call flag may TIGHTEN it to exposed.
+    expect(isComponentInjectionExposed('InteractivePoolCanaryJudge')).toBe(false);
+    expect(isComponentInjectionExposed('InteractivePoolCanaryJudge', true)).toBe(true); // tightened
+    expect(isComponentInjectionExposed('InteractivePoolCanaryJudge', false)).toBe(false);
+    // Statically exposed:true — the per-call flag can NEVER relax it (fail-safe).
+    expect(isComponentInjectionExposed('MessagingToneGate')).toBe(true);
+    expect(isComponentInjectionExposed('MessagingToneGate', false)).toBe(true); // still exposed
+    // Unknown component — fail-closed exposed regardless of the flag.
+    expect(isComponentInjectionExposed('UnknownThing')).toBe(true);
+    expect(isComponentInjectionExposed(undefined)).toBe(true);
   });
 });

--- a/upgrades/next/nature-axis-routing-fd5b-injection-exposure.md
+++ b/upgrades/next/nature-axis-routing-fd5b-injection-exposure.md
@@ -1,0 +1,25 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Builds FD5b of the (still-dark) nature-axis router (spec: docs/specs/nature-axis-routing.md): the injection-exposure classification and the route gate that keeps an injection-exposed internal check off a non-injection-safe model door.
+
+- **`LLM_ROUTING_INJECTION_EXPOSURE`** (src/data/llmBenchCoverage.ts): a new exhaustive static map — one row per known LLM component, each declaring `exposed` (defaults true / fail-safe) plus an input-shape declaration (can user / model / tool content enter). A component is `exposed:false` only when explicitly audited as carrying no untrusted content, with a written reason. `resolveInjectionExposure()` returns EXPOSED for any unknown component (fail-closed).
+- **The route gate** (src/core/IntelligenceRouter.ts): resolveRoute now skips any door marked `injectionSafe:false` when the component is exposed. A tightening-only per-call `attribution.injectionExposed` flag can raise exposure but can never relax a statically-exposed component.
+- A new ratchet test enforces the map is exhaustive over the component registry (both directions), fail-safe, cross-checked against the reviewed untrusted-input classification, and pins the input-classifier components as exposed. A new resolver-test block covers the gate and the fresh-per-call injection-cache isolation.
+
+NO-OP in this increment: the only non-injection door in the shipped chains is also a metered door, which is already skipped until the later paid-door increment — so over the real chains the gate changes nothing. Dev-gated / dark: the whole nature block runs only when sessions.natureRouting is enabled; unset/off is byte-identical to before (asserted). This is the classification + gate only — NOT the metered-door Increment B, and NOT the go-live flip.
+
+## What to Tell Your User
+
+This is internal plumbing for how I choose which model runs my own background checks — nothing to turn on, and nothing about our conversations changes. In plain terms: I gave each of my internal checks a label saying whether it reads content that could contain hidden instructions from an outside source, and I added a rule so a check that does can never be sent to a cheaper model that a test showed is easier to trick. The routing feature is still off by default, so today this is invisible — it just means the unsafe path is sealed shut in advance, and it defaults to the cautious choice whenever it isn't sure.
+
+## Summary of New Capabilities
+
+- **Injection-exposure map**: a build-enforced, exhaustive table classifying each internal AI check by whether it handles untrusted content, defaulting to the cautious "exposed" when unsure.
+- **Route injection gate**: the model router refuses to place an untrusted-content check onto a model door proven easier to fool, evaluated fresh on every call.
+
+## Evidence
+
+- tests/unit/nature-routing-injection-exposure-ratchet.test.ts (11 tests) and the new FD5b block in tests/unit/nature-routing-resolver.test.ts — green, covering exhaustiveness both directions, fail-safe resolve, the pinned not-exposed set, input-shape coherence, the untrusted-input cross-check, R8, the gate (exposed skips / trusted keeps / critical-gate fail-closed), and injection-cache isolation.
+- `npx tsc --noEmit` clean; the FD4 nature-chains build-lint clean; the sibling untrusted-input / bench-coverage / routing-nature ratchets green; the pre-existing byte-identical-when-off block and A1's degrade-clamp assertion untouched and green.

--- a/upgrades/side-effects/nature-axis-routing-fd5b-injection-exposure.md
+++ b/upgrades/side-effects/nature-axis-routing-fd5b-injection-exposure.md
@@ -1,0 +1,62 @@
+# Side-Effects Review — FD5b: injection-exposure static map + route-resolution injection gate
+
+**Version / slug:** `nature-axis-routing-fd5b-injection-exposure`
+**Date:** `2026-07-05`
+**Author:** `echo (build hand, topic 29723 routing follow-through)`
+**Second-pass reviewer:** `not required (Tier 1 — deterministic static classification + a pure candidate-eligibility filter, dark/dev-gated, byte-identical no-op in Increment A; same surface + precedent as A2.1 FD4-lints #1388)`
+
+## Summary of the change
+
+Builds FD5b of `docs/specs/nature-axis-routing.md` (§283-294): the exhaustive, fail-safe **injection-exposure** classification the nature router consults, plus the resolve-time gate that keeps an injection-exposed component off a non-injection-safe door. Files touched:
+
+- `src/data/llmBenchCoverage.ts` — new `LLM_ROUTING_INJECTION_EXPOSURE` map (exhaustive over `COMPONENT_CATEGORY`, `exposed` defaults true / fail-safe, each row carries the spec §371 input-shape declaration), `InjectionExposure`/`InjectionInputShape` types, and the pure `resolveInjectionExposure(component)` fail-closed resolver.
+- `src/core/IntelligenceRouter.ts` — a new `isInjectionExposed` dep threaded into `resolveRoute`'s availability walk (skips a `injectionSafe:false` position when the component is exposed, reason `injectionUnsafe`), and the exported `isComponentInjectionExposed(component, perCallExposed?)` composer (static OR tighten-only per-call flag), wired at the class caller.
+- `src/core/types.ts` — an OPT-IN, tightening-only `attribution.injectionExposed?: boolean`.
+- Tests — NEW `tests/unit/nature-routing-injection-exposure-ratchet.test.ts` (exhaustiveness both directions, fail-safe resolve, pinned NOT-EXPOSED set + reasons, input-shape coherence, cross-check vs `LLM_UNTRUSTED_INPUT`, R8 pin) and a NEW FD5b block appended to `tests/unit/nature-routing-resolver.test.ts` (the gate + injection-cache isolation). The pre-existing byte-identical block (`nature-routing-resolver.test.ts:261-296`) and A1's clamp assertion (`:161-162`) are UNTOUCHED and green.
+
+## Decision-point inventory
+
+- `FD5b injection gate (resolveRoute availability walk)` — add — a PURE candidate-eligibility filter: an injection-exposed component skips a `injectionSafe:false` door. NO-OP in Increment A (the only such door, `groq-api`, is also metered → already skipped one line above).
+- `LLM_ROUTING_INJECTION_EXPOSURE static classification` — add — build-time DATA (a signal), ratchet-enforced exhaustive + fail-safe; the router consults it, it holds no runtime authority of its own.
+- `attribution.injectionExposed per-call flag` — add — tightening-only; can raise exposure, can NEVER relax a statically-exposed component.
+- `sessions.natureRouting enable/dryRun gate` — pass-through — the whole nature block (and therefore the injection gate) still runs ONLY when enabled.
+
+## 1. Over-block
+
+**What legitimate inputs does this reject that it shouldn't?** In Increment A: none observable. The gate only removes a `injectionSafe:false` position for an exposed component, and the sole such position in the shipped chains (`groq-api/gpt-oss-120B`) is already unconditionally skipped as a metered door — so the resolved route is byte-identical (asserted: "the real default chains are UNAFFECTED"). The fail-safe default (unknown → exposed) could in principle skip a non-injection door for an unclassified component, but the exhaustiveness ratchet guarantees every real component is classified, so "unknown" never occurs for a shipped callsite; the fail-safe only governs a genuinely unregistered label, where skipping the non-injection door is the intended safe direction.
+
+## 2. Under-block
+
+**What failure modes does this still miss?** The classification is static build-time judgment — a callsite whose prompt SILENTLY starts carrying untrusted content while its row stays `exposed:false` is a semantic-drift miss. FD5b mitigates this TODAY via the ratchet cross-check against `LLM_UNTRUSTED_INPUT` (a component that becomes `untrustedInput:true` must also become `exposed:true`, or CI fails) and the input-shape coherence invariant. The full FD7 semantic-drift guard — the prompt-anchor fingerprint LINT (spec §376-384) that re-touches a row when its prompt source changes — is a SEPARATE increment the spec itself defers ("deferred to its own A/B-gated increments"); it is NOT built here. The FD4.2 R-rule lints (R4/R5/R7 injection-exposed-JUDGE bans, R8 Flash-Lite pin as a LINT) are the next increment and are not built here either.
+
+## 3. Level-of-abstraction fit
+
+Correct altitude. The classification lives beside its sibling axes (`LLM_UNTRUSTED_INPUT`, `LLM_ROUTING_NATURE`) in the same data module and rides the same exhaustive-ratchet pattern. The gate is a pure predicate consulted by the existing `resolveRoute` fold (the spec's own framing: "the safety/injection/allowlist/R-rule checks are candidate-eligibility FILTERS … each a pure predicate"), injected as a dep so exposure is evaluated fresh per call — not a new engine, not a new config surface. A smarter gate does not already own this; injection-exposure is intrinsic to routing and has no other home.
+
+## 4. Signal vs authority compliance
+
+Compliant. The injection-exposure map is deterministic build-time DATA (a signal, like the nature map), enforced by an exhaustive ratchet — it is not a brittle runtime check with blocking authority. The gate DOES exercise authority (it removes a candidate door), but only ever in the SAFE direction (toward a more-careful door / fail-closed for a critical gate), on a MODEL-ROUTING decision — it never blocks a user message, never reads or credits a principal identity, never grants anything. The per-call flag can only tighten, never relax, so a forgotten callsite cannot open a non-injection door. `docs/signal-vs-authority.md` satisfied.
+
+## 5. Interactions
+
+Interacts with `resolveRoute` (one skip predicate in the availability loop, placed AFTER the metered skip so the metered `groq-api` is already excluded → guaranteed no-op) and the class `evaluate()` caller (composes the per-call tighten). It does NOT shadow the FD4 harness-door clamp (orthogonal: FD4 governs the claude-code door, FD5b governs `injectionSafe:false` doors) and does not double-fire. Existing resolver tests (all exposed:true real components on default chains) are unaffected because no non-metered default door is a non-injection door. The A1 `clampClaudeCliSwapModel` degrade clamp is untouched (its assertion stays green).
+
+## 6. External surfaces
+
+No external surface. No new HTTP route, CLI command, MCP tool, Telegram/Slack path, or network egress. `attribution.injectionExposed` is an additive optional field — every existing caller is byte-identical (omitted ⇒ static map authoritative).
+
+## 6b. Operator-surface quality
+
+No operator-facing surface added or changed. The `injectionUnsafe` skip reason is an internal code comment/marker for the future FD5 structured-reason-code surface; nothing is emitted to a user yet. No secrets, tokens, or file paths surface anywhere.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+Machine-local by design, and correctly so. The injection-exposure map is static source data compiled into every machine identically; `resolveInjectionExposure` is a pure per-call function over that data with no persisted or replicated state. Each machine resolves the identical verdict for the same component independently — there is no cross-machine state to strand, replicate, or coalesce. A per-call `attribution.injectionExposed` is scoped to the single call on the machine serving it. No lease, ledger, or notice interaction.
+
+## 8. Rollback cost
+
+Low and clean. Revert the PR: the map + resolver + gate predicate + the optional type field drop out; `resolveRoute` returns to the pre-FD5b availability walk (which, in Increment A, produced identical routes). No migration, no persisted state, no config schema change, no data-format change. Because the gate only runs when `natureRouting.enabled` AND is a no-op over the shipped chains, a rollback is invisible to every fleet agent (feature dark) and to any dev agent in dryRun.
+
+## Conclusion
+
+FD5b ships the fail-safe injection-exposure classification and the resolve-time gate that structurally seals an injection-exposed call off a non-injection door — a no-op in Increment A (the one non-injection door is also metered), byte-identical when the feature is off, and dark/dev-gated. The classification is exhaustive and cross-checked against the reviewed `LLM_UNTRUSTED_INPUT` axis so it cannot silently diverge; the prompt-anchor fingerprint LINT (FD7 semantic-drift) and the FD4.2 R-rule lints are the tracked next increments, not built here.


### PR DESCRIPTION
## ELI16

The nature-axis router (shipping dark) picks which model answers each of my internal background checks. A bench found one cheap model door can be tricked by instructions hidden inside the content it is told to judge — so a check that reads untrusted content (an inbound message, a transcript, a file, another agent's data) must never be routed there. This PR builds FD5b of `docs/specs/nature-axis-routing.md`: a static, exhaustive table (`LLM_ROUTING_INJECTION_EXPOSURE`) labelling every component `exposed` (defaults **true** / fail-safe, `false` only when explicitly audited with a written reason), plus a gate in `resolveRoute` that skips any `injectionSafe:false` door when the component is exposed. It is a **no-op in Increment A** (the only such door, `groq-api`, is also metered → already skipped) and **byte-identical** when `sessions.natureRouting` is off. A ratchet keeps the table exhaustive over `COMPONENT_CATEGORY` (both directions), fail-safe on unknowns, and cross-checked against the reviewed `LLM_UNTRUSTED_INPUT` axis so the two can never silently diverge; R8's input-classifier components are pinned exposed. Nothing user-facing changes and nothing is turned on.

## What changed
- **`src/data/llmBenchCoverage.ts`** — `LLM_ROUTING_INJECTION_EXPOSURE` (exhaustive, fail-safe, each row carries the spec §371 input-shape declaration), `InjectionExposure`/`InjectionInputShape` types, and the pure `resolveInjectionExposure()` (unknown → exposed, fail-closed).
- **`src/core/IntelligenceRouter.ts`** — the injection gate in `resolveRoute`'s availability walk (reason `injectionUnsafe`), injected as a fresh-per-call dep, plus `isComponentInjectionExposed()` (static OR tighten-only per-call flag), wired at the class caller.
- **`src/core/types.ts`** — an opt-in, tightening-only `attribution.injectionExposed?: boolean`.
- **Tests** — new `tests/unit/nature-routing-injection-exposure-ratchet.test.ts` + a new FD5b block in `tests/unit/nature-routing-resolver.test.ts` (gate + injection-cache isolation). The pre-existing byte-identical-when-off block and A1's degrade-clamp assertion are untouched and green.

## Scope / boundaries
- Dark / dev-gated; **NOT** Increment B (metered-API doors / money gate / PIN go-live) and **NOT** the go-live flip.
- The FD7 prompt-anchor fingerprint lint and the FD4.2 R-rule lints are the tracked next increments — not built here.
- The spec is **not** marked `approved` by this PR (operator's step).

## Evidence
- `npx vitest run` on both files: 58 tests green (11 ratchet + 47 resolver incl. the new FD5b block).
- `npx tsc --noEmit` clean; the FD4 nature-chains build-lint clean; sibling untrusted-input / bench-coverage / routing-nature ratchets green.
- Tier 1 (deterministic static classification + pure filter, dark, byte-identical no-op) — same surface + precedent as A2.1 FD4-lints (#1388).

🤖 Generated with [Claude Code](https://claude.com/claude-code)