### PR TITLE
feat(intelligence): read-only routing-map surface (GET /intelligence/routing/chains + dashboard tab)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-05T18-56-38-271Z-routing-map-surface.json
+++ b/.instar/instar-dev-decisions/2026-07-05T18-56-38-271Z-routing-map-surface.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-05T18:56:38.271Z",
+  "slug": "routing-map-surface",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 236,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-05T19-00-41-846Z-routing-map-surface.json
+++ b/.instar/instar-dev-decisions/2026-07-05T19-00-41-846Z-routing-map-surface.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-05T19:00:41.846Z",
+  "slug": "routing-map-surface",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 37,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-05T19-01-16-012Z-routing-map-surface.json
+++ b/.instar/instar-dev-decisions/2026-07-05T19-01-16-012Z-routing-map-surface.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-05T19:01:16.012Z",
+  "slug": "routing-map-surface",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 261,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-05T19-01-49-764Z-routing-map-surface.json
+++ b/.instar/instar-dev-decisions/2026-07-05T19-01-49-764Z-routing-map-surface.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-05T19:01:49.764Z",
+  "slug": "routing-map-surface",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 261,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-05T19-15-55-181Z-routing-map-surface.json
+++ b/.instar/instar-dev-decisions/2026-07-05T19-15-55-181Z-routing-map-surface.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-05T19:15:55.181Z",
+  "slug": "routing-map-surface",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 257,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2751,6 +2751,7 @@
           <button class="tab" data-tab="tokens" onclick="switchTab('tokens')">Tokens</button>
           <button class="tab" data-tab="resources" onclick="switchTab('resources')">Resource Usage</button>
           <button class="tab" data-tab="llm-activity" onclick="switchTab('llm-activity')">LLM Activity</button>
+          <button class="tab" data-tab="routing-map" onclick="switchTab('routing-map')">Routing Map</button>
           <button class="tab" data-tab="threadline" onclick="switchTab('threadline')">Threadline</button>
           <button class="tab" data-tab="evidence" onclick="switchTab('evidence')">Evidence</button>
           <button class="tab" data-tab="process-health" onclick="switchTab('process-health')">Process Health</button>
@@ -3332,6 +3333,41 @@
       <div style="border:1px solid var(--border);border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:8px">
         <div style="font-weight:600">By component</div>
         <div id="llmActivityBody" style="font-size:13px;overflow-x:auto">
+          <div style="color:var(--text-dim)">Loading...</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Routing Map tab — the read-only nature-axis routing map (FD11 readable canary,
+         docs/specs/nature-axis-routing.md). For every internal job-kind: which door +
+         model it uses and its full ordered fallback tier list, with injection-safe /
+         money-gated / critical-gate flags. Read-only display; data from
+         /intelligence/routing/chains. No controls — the map only DISPLAYS the routing. -->
+    <div id="routingMapPanel" style="display:none;flex-direction:column;padding:20px;gap:16px;overflow-y:auto">
+      <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap">
+        <h2 style="margin:0">Routing Map</h2>
+        <button onclick="loadRoutingMap()" style="padding:6px 12px">Refresh</button>
+      </div>
+      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+        Where each internal job-kind sends its AI calls. Every background check, gate, and
+        sentinel has a <b>lane</b> (its "nature") and a fallback list of <b>doors</b> — the ways
+        it can reach a model. This shows, per lane, the ordered door + model list it tries, and
+        flags a door that's <b>metered</b> (a paid API, skipped for now), <b>money-gated</b>, or
+        that must never take untrusted input. Read-only: it shows the map, it changes nothing.
+      </div>
+
+      <!-- The four lanes (chains) -->
+      <div id="routingMapChainsCard" style="border:1px solid var(--border);border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:12px">
+        <div style="font-weight:600">Lanes (fallback order)</div>
+        <div id="routingMapChainsBody" style="font-size:13px;overflow-x:auto">
+          <div style="color:var(--text-dim)">Loading...</div>
+        </div>
+      </div>
+
+      <!-- Per job-kind mapping -->
+      <div style="border:1px solid var(--border);border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:8px">
+        <div style="font-weight:600">By job-kind</div>
+        <div id="routingMapComponentsBody" style="font-size:13px;overflow-x:auto">
           <div style="color:var(--text-dim)">Loading...</div>
         </div>
       </div>
@@ -5005,6 +5041,12 @@
         onActivate: () => { if (typeof loadLlmActivity === 'function') loadLlmActivity(); },
       },
       {
+        id: 'routing-map',
+        panels: ['routingMapPanel'],
+        display: ['flex'],
+        onActivate: () => { if (typeof loadRoutingMap === 'function') loadRoutingMap(); },
+      },
+      {
         id: 'threadline',
         panels: ['threadlineTab'],
         display: ['flex'],
@@ -5673,6 +5715,98 @@
           headlineEl.innerHTML = '<div style="color:var(--red)">Error: ' + escapeHtml(m) + '</div>';
         }
         bodyEl.innerHTML = '';
+      }
+    }
+
+    async function loadRoutingMap() {
+      const chainsEl = document.getElementById('routingMapChainsBody');
+      const compsEl = document.getElementById('routingMapComponentsBody');
+      // Render one door+model position as a compact chip line.
+      const flags = (p) => {
+        const f = [];
+        if (p.doorClass === 'metered') f.push('metered' + (p.skippedInIncrementA ? ' · skipped now' : ''));
+        if (p.moneyGated) f.push('money-gated');
+        if (p.injectionSafe === false) f.push('unsafe for untrusted input');
+        if (p.claudeBanned) f.push('no-Claude');
+        return f.length ? ' <span style="color:var(--text-dim)">(' + f.map(escapeHtml).join(' · ') + ')</span>' : '';
+      };
+      const posLine = (p, i) => '<div style="padding:2px 0">' +
+        '<span style="color:var(--text-dim)">' + (i + 1) + '.</span> ' +
+        '<b>' + escapeHtml(p.door) + '</b> → ' + escapeHtml(p.modelId) + flags(p) + '</div>';
+      const th = (t, right) => '<th style="padding:6px 8px;' + (right ? 'text-align:right' : 'text-align:left') + '">' + t + '</th>';
+      const td = (v, right) => '<td style="padding:6px 8px;vertical-align:top;' + (right ? 'text-align:right' : '') + '">' + v + '</td>';
+      try {
+        const data = await apiFetch('/intelligence/routing/chains');
+        const chains = data.chains || [];
+        chainsEl.innerHTML =
+          '<div style="font-size:11px;color:var(--text-dim);margin-bottom:8px">Enforced default framework: <b>' +
+            escapeHtml(String(data.defaultFramework || '—')) + '</b> · injection signal: ' +
+            escapeHtml(String(data.injectionExposureSource || '—')) + '</div>' +
+          '<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px">' +
+          chains.map((c) =>
+            '<div style="border:1px solid var(--border);border-radius:6px;padding:10px">' +
+            '<div style="font-weight:600;margin-bottom:4px">' + escapeHtml(c.chain) + '</div>' +
+            (c.positions || []).map(posLine).join('') +
+            '</div>').join('') +
+          '</div>';
+
+        const comps = (data.components || []).slice().sort((a, b) => {
+          // Mapped (has a chain) first, then by component name.
+          if (!!a.chain !== !!b.chain) return a.chain ? -1 : 1;
+          return String(a.component).localeCompare(String(b.component));
+        });
+        if (comps.length === 0) {
+          compsEl.innerHTML = '<div style="color:var(--text-dim)">No components mapped.</div>';
+          return;
+        }
+        const yn = (v) => v === true ? 'yes' : (v === false ? 'no' : '—');
+        compsEl.innerHTML =
+          '<table style="width:100%;border-collapse:collapse;font-size:12px;min-width:760px">' +
+          '<thead><tr style="color:var(--text-dim)">' +
+            th('Job-kind') + th('Category') + th('Lane') + th('Enforced now') +
+            th('Critical gate') + th('Injection exposure') + th('Fallback order') +
+          '</tr></thead><tbody>' +
+          comps.map((c) => {
+            const route = (c.route && c.route.length)
+              ? c.route.map(posLine).join('')
+              : '<span style="color:var(--text-dim)">legacy category routing (no nature lane)</span>';
+            const lane = c.chain
+              ? escapeHtml(c.chain) + ' <span style="color:var(--text-dim)">(' + escapeHtml(String(c.nature)) + ')</span>'
+              : '<span style="color:var(--text-dim)">—</span>';
+            // Prefer the richer FD5b exposure classification; fall back to the untrusted-input flag.
+            let exposure;
+            if (c.injectionExposure) {
+              const ch = c.injectionExposure.channels || {};
+              const chans = ['user', 'model', 'tool'].filter((k) => ch[k]);
+              exposure = c.injectionExposure.exposed
+                ? 'exposed' + (chans.length ? ' <span style="color:var(--text-dim)">(' + chans.join('/') + ')</span>' : '')
+                : 'not exposed' + (c.injectionExposure.reason ? ' <span style="color:var(--text-dim)">(' + escapeHtml(c.injectionExposure.reason) + ')</span>' : '');
+            } else if (c.untrustedInput === true) {
+              exposure = 'exposed';
+            } else if (c.untrustedInput === false) {
+              exposure = 'not exposed' + (c.untrustedInputReason ? ' <span style="color:var(--text-dim)">(' + escapeHtml(c.untrustedInputReason) + ')</span>' : '');
+            } else {
+              exposure = '—';
+            }
+            return '<tr style="border-top:1px solid var(--border)">' +
+              td('<b>' + escapeHtml(c.component) + '</b>') +
+              td(escapeHtml(String(c.category || '—'))) +
+              td(lane) +
+              td(escapeHtml(String(c.enforcedFramework || '—'))) +
+              td(c.criticalGate ? '<b>yes</b>' : 'no') +
+              td(exposure) +
+              td(route) +
+            '</tr>';
+          }).join('') +
+          '</tbody></table>';
+      } catch (err) {
+        const m = err && err.message ? String(err.message) : String(err);
+        if (/503|unavailable|not initialized/i.test(m)) {
+          chainsEl.innerHTML = '<div style="color:var(--text-dim)">The routing map isn\'t available on this agent (no AI provider configured).</div>';
+        } else {
+          chainsEl.innerHTML = '<div style="color:var(--red)">Error: ' + escapeHtml(m) + '</div>';
+        }
+        compsEl.innerHTML = '';
       }
     }
 

--- a/src/core/natureRoutingMap.ts
+++ b/src/core/natureRoutingMap.ts
@@ -1,0 +1,217 @@
+/**
+ * Nature-axis routing MAP — a pure, read-only composition of the shipped routing
+ * data (docs/specs/nature-axis-routing.md, FD11 "readable canary"). It answers a
+ * single operator question: for every known internal job-kind, which door + model
+ * does it use, and what is its full ordered fallback tier list?
+ *
+ * This module is DATA-ONLY and SIDE-EFFECT-FREE. It reads exported maps from
+ * `llmBenchCoverage` (the four routing chains, the job-kind→nature registry, the
+ * label→model-id registry, the door taxonomy, the critical-gate set, and the
+ * per-component untrusted-input classification) and `componentCategories` (the
+ * known-component list + categories) and composes them into a display structure.
+ * It performs ZERO writes, mutates NO config, and changes NO routing behavior —
+ * it only DESCRIBES the maps the resolver already uses. It backs
+ * `GET /intelligence/routing/chains`.
+ *
+ * Injection-exposure display: three shipped signals — per-position `injectionSafe`
+ * (a door that must not take an injection-exposed call, e.g. Groq), per-component
+ * `LLM_UNTRUSTED_INPUT` (does the component judge attacker-controllable content), and
+ * the per-component FD5b `LLM_ROUTING_INJECTION_EXPOSURE` classification (exposed + the
+ * user/model/tool input channels), surfaced when that map is present on the base.
+ */
+import {
+  NATURE_ROUTING_DEFAULT_CHAINS,
+  LLM_ROUTING_NATURE,
+  ROUTING_LABEL_TO_MODEL_ID,
+  CLI_ROUTING_DOORS,
+  METERED_ROUTING_DOORS,
+  NATURE_ROUTING_CRITICAL_GATES,
+  LLM_UNTRUSTED_INPUT,
+  LLM_ROUTING_INJECTION_EXPOSURE,
+  type RoutingChain,
+  type RoutingDoor,
+  type TaskNature,
+  type ChainPosition,
+} from '../data/llmBenchCoverage.js';
+import { knownComponents, categoryForComponent, type ComponentCategory } from './componentCategories.js';
+
+/** One resolved chain position for display: the door + concrete model id + static flags. */
+export interface RoutingMapPosition {
+  /** The access path to a model (CLI harness or metered API). */
+  readonly door: RoutingDoor;
+  /** `cli` (an installed harness) or `metered` (a paid API door). */
+  readonly doorClass: 'cli' | 'metered';
+  /** The chain position's benchmark label / tier hint. */
+  readonly label: string;
+  /** The concrete model id (label resolved via ROUTING_LABEL_TO_MODEL_ID; a tier hint passes through). */
+  readonly modelId: string;
+  /** `false` only when this door must NOT take an injection-exposed call (FD5b; e.g. Groq WRITE). */
+  readonly injectionSafe: boolean;
+  /** A real-spend door gated behind Increment B's money/PIN go-live. */
+  readonly moneyGated: boolean;
+  /** Vault secret name backing a metered door (Increment B). */
+  readonly keyRef?: string;
+  /** doc-tree / cartographer components may never route to any claude-code door (R6). */
+  readonly claudeBanned: boolean;
+  /**
+   * Metered doors are DEFINED but always skipped (unavailable) in Increment A — so
+   * this position does not actuate today. Purely informational.
+   */
+  readonly skippedInIncrementA: boolean;
+}
+
+/** A full chain (FAST/SORT/JUDGE/WRITE): its ordered position list. */
+export interface RoutingMapChain {
+  readonly chain: RoutingChain;
+  readonly positions: readonly RoutingMapPosition[];
+}
+
+/** One known component's routing entry. */
+export interface RoutingMapComponent {
+  readonly component: string;
+  readonly category: ComponentCategory;
+  /** The task nature (A/B/D/E) — null when the component is unmapped (legacy category routing). */
+  readonly nature: TaskNature | null;
+  /** The routing chain — null when unmapped. */
+  readonly chain: RoutingChain | null;
+  /** A fail-closed critical gate: no available door ⇒ throw, never fall through (FD6). */
+  readonly criticalGate: boolean;
+  /** Does the component judge attacker-controllable content? true / false(+reason) / null(=unclassified). */
+  readonly untrustedInput: boolean | null;
+  /** When `untrustedInput` is false, the argued reason for the exemption. */
+  readonly untrustedInputReason?: string;
+  /**
+   * FD5b injection-exposure classification: whether the component's LLM call can carry
+   * attacker-controllable content, and via which channel(s) (user / model / tool). Present
+   * only when the shipped FD5b `LLM_ROUTING_INJECTION_EXPOSURE` map is on the base.
+   */
+  readonly injectionExposure?: {
+    readonly exposed: boolean;
+    readonly channels: { readonly user: boolean; readonly model: boolean; readonly tool: boolean };
+    readonly reason?: string;
+  };
+  /** The CURRENTLY-enforced legacy framework (live, optional — injected by the route). */
+  readonly enforcedFramework?: string;
+  /** The ordered resolved chain for this component ([] when unmapped). */
+  readonly route: readonly RoutingMapPosition[];
+}
+
+/** The full read-only routing map. */
+export interface NatureRoutingMap {
+  readonly doors: { readonly cli: readonly RoutingDoor[]; readonly metered: readonly RoutingDoor[] };
+  readonly chains: readonly RoutingMapChain[];
+  readonly components: readonly RoutingMapComponent[];
+  /** Which injection-exposure signal the display is sourced from. */
+  readonly injectionExposureSource: 'FD5b-exposure-map' | 'untrusted-input-flag';
+  readonly note: string;
+}
+
+/** The canonical chain order for display. */
+const CHAIN_ORDER: readonly RoutingChain[] = ['FAST', 'SORT', 'JUDGE', 'WRITE'];
+
+/** Resolve a chain position's `model` label to a concrete id (FD-LABEL); a tier hint passes through. Pure. */
+function resolveModelId(pos: ChainPosition): string {
+  return ROUTING_LABEL_TO_MODEL_ID[pos.door]?.[pos.model] ?? pos.model;
+}
+
+/** Compose one display position from a chain position. Pure. */
+function toMapPosition(pos: ChainPosition): RoutingMapPosition {
+  const doorClass: 'cli' | 'metered' = CLI_ROUTING_DOORS.has(pos.door) ? 'cli' : 'metered';
+  return {
+    door: pos.door,
+    doorClass,
+    label: pos.model,
+    modelId: resolveModelId(pos),
+    injectionSafe: pos.injectionSafe !== false, // undefined ⇒ safe; only explicit false ⇒ unsafe
+    moneyGated: pos.moneyGated === true,
+    keyRef: pos.keyRef,
+    claudeBanned: pos.claudeBanned === true,
+    skippedInIncrementA: METERED_ROUTING_DOORS.has(pos.door),
+  };
+}
+
+/** Resolve a component's untrusted-input classification for display. */
+function untrustedFor(component: string): { flag: boolean | null; reason?: string } {
+  const raw = LLM_UNTRUSTED_INPUT[component];
+  if (raw === true) return { flag: true };
+  if (raw && typeof raw === 'object') return { flag: false, reason: raw.false };
+  return { flag: null }; // undeclared
+}
+
+/**
+ * Build the full nature-axis routing map. Pure — reads exported static maps and an
+ * optional live `enforcedFrameworkFor` callback, writes nothing, mutates nothing.
+ */
+export function buildNatureRoutingMap(opts?: {
+  /** Optional live resolver for the CURRENTLY-enforced legacy framework of a component. */
+  enforcedFrameworkFor?: (component: string) => string | undefined;
+}): NatureRoutingMap {
+  // Pre-compose the four canonical chains once (each component reuses these).
+  const chainPositions: Record<RoutingChain, readonly RoutingMapPosition[]> = {
+    FAST: NATURE_ROUTING_DEFAULT_CHAINS.FAST.map(toMapPosition),
+    SORT: NATURE_ROUTING_DEFAULT_CHAINS.SORT.map(toMapPosition),
+    JUDGE: NATURE_ROUTING_DEFAULT_CHAINS.JUDGE.map(toMapPosition),
+    WRITE: NATURE_ROUTING_DEFAULT_CHAINS.WRITE.map(toMapPosition),
+  };
+
+  const chains: RoutingMapChain[] = CHAIN_ORDER.map((chain) => ({
+    chain,
+    positions: chainPositions[chain],
+  }));
+
+  const components: RoutingMapComponent[] = knownComponents().map((component) => {
+    const nc = LLM_ROUTING_NATURE[component];
+    const nature = nc ? nc.nature : null;
+    const chain = nc ? nc.chain : null;
+    const { flag, reason } = untrustedFor(component);
+    const enforcedFramework = opts?.enforcedFrameworkFor?.(component);
+    const ie = LLM_ROUTING_INJECTION_EXPOSURE[component];
+    return {
+      component,
+      category: categoryForComponent(component),
+      nature,
+      chain,
+      criticalGate: NATURE_ROUTING_CRITICAL_GATES.has(component),
+      untrustedInput: flag,
+      ...(reason ? { untrustedInputReason: reason } : {}),
+      ...(ie
+        ? {
+            injectionExposure: {
+              exposed: ie.exposed,
+              channels: {
+                user: ie.inputShape.userContent,
+                model: ie.inputShape.modelContent,
+                tool: ie.inputShape.toolContent,
+              },
+              ...(ie.reason ? { reason: ie.reason } : {}),
+            },
+          }
+        : {}),
+      ...(enforcedFramework ? { enforcedFramework } : {}),
+      route: chain ? chainPositions[chain] : [],
+    };
+  });
+
+  return {
+    doors: {
+      cli: [...CLI_ROUTING_DOORS],
+      metered: [...METERED_ROUTING_DOORS],
+    },
+    chains,
+    components,
+    injectionExposureSource: 'FD5b-exposure-map',
+    note:
+      'Read-only routing MAP: for each internal job-kind, its nature/chain and the ordered ' +
+      'fallback door+model list. Describes the shipped nature-routing chains — it does NOT ' +
+      'reflect live actuation (nature routing is dev-gated/dryRun) and changes no behavior. ' +
+      'Metered (paid-API) doors are skipped in Increment A. Spend/PIN controls are out of scope.',
+  };
+}
+
+/** Look up a single component's routing entry (for the `?trace=<component>` drill-down). */
+export function traceComponent(
+  component: string,
+  opts?: { enforcedFrameworkFor?: (component: string) => string | undefined },
+): RoutingMapComponent | undefined {
+  return buildNatureRoutingMap(opts).components.find((c) => c.component === component);
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -64,6 +64,7 @@ import type { JobScheduler } from '../scheduler/JobScheduler.js';
 import type { InstarConfig, JobPriority } from '../core/types.js';
 import { IntelligenceRouter } from '../core/IntelligenceRouter.js';
 import { knownComponents } from '../core/componentCategories.js';
+import { buildNatureRoutingMap, traceComponent } from '../core/natureRoutingMap.js';
 import { SecretStore } from '../core/SecretStore.js';
 import { secretKeyPaths } from '../core/SecretSync.js';
 import {
@@ -9994,6 +9995,45 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         routedOffDefault: components.filter((c) => c.framework !== defaultFramework).length,
       },
       note: 'Routes INTERNAL component LLM calls only; spawned interactive sessions use topicFrameworks.',
+    });
+  });
+
+  // ── Nature-axis routing MAP (FD11 readable canary; read-only) ─────────
+  // A richer, non-breaking SIBLING of GET /intelligence/routing. Where the legacy
+  // route returns the live category→framework view (IntelligenceRouter.for), this
+  // returns the full nature-axis routing MAP: for every known internal job-kind, its
+  // nature/chain and the ORDERED fallback door+model list, with per-door flags
+  // (injection-safe / money-gated / metered-skipped-in-Increment-A) and per-component
+  // critical-gate + untrusted-input annotations. Composed PURELY from the shipped
+  // static routing maps (docs/specs/nature-axis-routing.md) — it performs ZERO writes,
+  // mutates no config, and changes NO routing behavior; it only DESCRIBES the maps.
+  // `?trace=<component>` drills into a single component. Same Bearer-auth + 503-when-
+  // no-IntelligenceRouter shape as the legacy route above.
+  router.get('/intelligence/routing/chains', (req, res) => {
+    const intel = ctx.intelligence;
+    if (!intel || !(intel instanceof IntelligenceRouter)) {
+      res.status(503).json({ error: 'intelligence router unavailable (no LLM provider configured)' });
+      return;
+    }
+    // Live legacy-framework annotation per component (the "currently enforced" view,
+    // read-only) — lets the map show enforced framework alongside the nature chain.
+    // `intel.for` is a pure registry resolution (the legacy route above calls it bare);
+    // no try/catch — a silent catch here would be a swallowed fallback with no report.
+    const enforcedFrameworkFor = (name: string): string | undefined => intel.for(name).framework;
+    const traceName = typeof req.query.trace === 'string' ? req.query.trace.trim() : '';
+    if (traceName) {
+      const entry = traceComponent(traceName, { enforcedFrameworkFor });
+      if (!entry) {
+        res.status(404).json({ error: `unknown component '${traceName}'` });
+        return;
+      }
+      res.json({ trace: entry });
+      return;
+    }
+    const map = buildNatureRoutingMap({ enforcedFrameworkFor });
+    res.json({
+      defaultFramework: intel.for('__nonexistent__').framework,
+      ...map,
     });
   });
 

--- a/tests/integration/intelligence-routing-chains-route.test.ts
+++ b/tests/integration/intelligence-routing-chains-route.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Integration tests for GET /intelligence/routing/chains — the read-only nature-axis
+ * routing MAP surface (FD11 readable canary, docs/specs/nature-axis-routing.md).
+ *
+ * Exercises the real Express route over a real IntelligenceRouter:
+ *  - 200 + the full routing map (the Tier-3 "feature is alive" test — the single most
+ *    important test: the route returns the map, not 503, when mounted in the server path);
+ *  - the `?trace=<component>` drill-down + a 404 for an unknown component;
+ *  - 503 when intelligence is null OR a plain provider (not a router) — the sibling shape;
+ *  - PURITY: the route performs no writes and mutates no config across calls.
+ */
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { IntelligenceRouter } from '../../src/core/IntelligenceRouter.js';
+import type { IntelligenceProvider } from '../../src/core/types.js';
+
+function fakeProvider(label: string): IntelligenceProvider {
+  return { async evaluate() { return label; } };
+}
+
+function ctxWith(intelligence: IntelligenceProvider | null): RouteContext {
+  return {
+    config: { projectName: 'test', projectDir: '/tmp', stateDir: '/tmp/.instar', port: 0, sessions: {} as any, scheduler: {} as any } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    scheduler: null, telegram: null, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, discoveryEvaluator: null,
+    tokenLedger: null, featureMetricsLedger: null, resourceLedger: null,
+    intelligence,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+function appWith(intelligence: IntelligenceProvider | null): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(ctxWith(intelligence)));
+  return app;
+}
+
+function routerRoutingSentinelsToCodex(): IntelligenceRouter {
+  return new IntelligenceRouter({
+    defaultProvider: fakeProvider('claude'),
+    defaultFramework: 'claude-code',
+    resolveConfig: () => ({ categories: { sentinel: 'codex-cli' } }),
+    buildProvider: () => fakeProvider('codex'),
+  });
+}
+
+describe('GET /intelligence/routing/chains (integration)', () => {
+  it('returns 200 + the full routing map when a router is wired (alive test)', async () => {
+    const res = await request(appWith(routerRoutingSentinelsToCodex())).get('/intelligence/routing/chains');
+    expect(res.status).toBe(200);
+    expect(res.body.defaultFramework).toBe('claude-code');
+    // Doors + the four chains are present.
+    expect(res.body.doors.cli).toEqual(expect.arrayContaining(['claude-code', 'codex-cli', 'pi-cli', 'gemini-cli']));
+    expect(res.body.doors.metered).toEqual(expect.arrayContaining(['gemini-api', 'openrouter-api', 'groq-api']));
+    expect(Array.isArray(res.body.chains)).toBe(true);
+    expect(res.body.chains.map((c: any) => c.chain)).toEqual(['FAST', 'SORT', 'JUDGE', 'WRITE']);
+
+    // A known critical gate resolves to its JUDGE chain with concrete model ids + flags.
+    const tone = res.body.components.find((c: any) => c.component === 'MessagingToneGate');
+    expect(tone).toMatchObject({ nature: 'B', chain: 'JUDGE', criticalGate: true, untrustedInput: true });
+    expect(tone.enforcedFramework).toBe('claude-code'); // gate category ⇒ default framework here
+    expect(tone.route.length).toBeGreaterThan(0);
+    expect(tone.route[0]).toHaveProperty('modelId');
+    expect(tone.route[0]).toHaveProperty('door');
+
+    // A sentinel routed off default reflects the live enforced framework.
+    const presence = res.body.components.find((c: any) => c.component === 'PresenceProxy');
+    expect(presence.enforcedFramework).toBe('codex-cli');
+  });
+
+  it('supports ?trace=<component> and 404s an unknown component', async () => {
+    const app = appWith(routerRoutingSentinelsToCodex());
+    const ok = await request(app).get('/intelligence/routing/chains?trace=MessagingToneGate');
+    expect(ok.status).toBe(200);
+    expect(ok.body.trace.component).toBe('MessagingToneGate');
+    expect(ok.body.trace.chain).toBe('JUDGE');
+
+    const missing = await request(app).get('/intelligence/routing/chains?trace=__nope__');
+    expect(missing.status).toBe(404);
+  });
+
+  it('returns 503 when intelligence is null', async () => {
+    const res = await request(appWith(null)).get('/intelligence/routing/chains');
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/intelligence router unavailable/i);
+  });
+
+  it('returns 503 when intelligence is a plain provider (not a router)', async () => {
+    const res = await request(appWith(fakeProvider('claude'))).get('/intelligence/routing/chains');
+    expect(res.status).toBe(503);
+  });
+
+  it('is PURE — the legacy route is unchanged and repeated calls are byte-identical (no writes)', async () => {
+    const app = appWith(routerRoutingSentinelsToCodex());
+    // The legacy route still returns its own (different) shape — not broken.
+    const legacy = await request(app).get('/intelligence/routing');
+    expect(legacy.status).toBe(200);
+    expect(legacy.body).not.toHaveProperty('chains'); // legacy view is untouched
+
+    // The map route is deterministic across calls (no mutation of shared state).
+    const a = await request(app).get('/intelligence/routing/chains');
+    const b = await request(app).get('/intelligence/routing/chains');
+    expect(a.body).toEqual(b.body);
+  });
+});

--- a/tests/unit/nature-routing-map.test.ts
+++ b/tests/unit/nature-routing-map.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the pure nature-axis routing MAP composer (src/core/natureRoutingMap.ts).
+ * Verifies the map resolves a known component to its expected ordered chain + concrete
+ * model ids + per-position/per-component flags, that the chains resolve correctly, and
+ * that the composer is PURE (no writes, stable across calls, does not mutate its inputs).
+ */
+import { describe, it, expect } from 'vitest';
+import { buildNatureRoutingMap, traceComponent } from '../../src/core/natureRoutingMap.js';
+import {
+  NATURE_ROUTING_DEFAULT_CHAINS,
+  LLM_ROUTING_NATURE,
+  ROUTING_LABEL_TO_MODEL_ID,
+  NATURE_ROUTING_CRITICAL_GATES,
+} from '../../src/data/llmBenchCoverage.js';
+
+describe('buildNatureRoutingMap (pure composition)', () => {
+  it('exposes the four canonical chains in order with resolved model ids', () => {
+    const map = buildNatureRoutingMap();
+    expect(map.chains.map((c) => c.chain)).toEqual(['FAST', 'SORT', 'JUDGE', 'WRITE']);
+
+    const judge = map.chains.find((c) => c.chain === 'JUDGE')!;
+    // JUDGE[0] is pi-cli/gpt-5.5 → resolves to the concrete id via the label registry.
+    expect(judge.positions[0]).toMatchObject({
+      door: 'pi-cli',
+      doorClass: 'cli',
+      label: 'gpt-5.5',
+      modelId: ROUTING_LABEL_TO_MODEL_ID['pi-cli']['gpt-5.5'],
+      moneyGated: false,
+      skippedInIncrementA: false,
+    });
+    // JUDGE contains a metered openrouter position — money-gated + skipped in Increment A.
+    const metered = judge.positions.find((p) => p.door === 'openrouter-api');
+    expect(metered).toMatchObject({ doorClass: 'metered', moneyGated: true, skippedInIncrementA: true });
+    expect(metered!.keyRef).toBe('metered_openrouter_bench');
+  });
+
+  it('flags the Groq WRITE door as unsafe for untrusted input (injectionSafe=false)', () => {
+    const write = buildNatureRoutingMap().chains.find((c) => c.chain === 'WRITE')!;
+    const groq = write.positions.find((p) => p.door === 'groq-api')!;
+    expect(groq.injectionSafe).toBe(false);
+    // Every non-Groq WRITE position defaults to injection-safe.
+    for (const p of write.positions) {
+      if (p.door !== 'groq-api') expect(p.injectionSafe).toBe(true);
+    }
+  });
+
+  it('resolves a known component to its declared nature + chain + full ordered route', () => {
+    const map = buildNatureRoutingMap();
+    // MessagingToneGate is a nature-B JUDGE critical gate.
+    const tone = map.components.find((c) => c.component === 'MessagingToneGate')!;
+    expect(tone.nature).toBe('B');
+    expect(tone.chain).toBe('JUDGE');
+    expect(tone.criticalGate).toBe(true);
+    expect(tone.untrustedInput).toBe(true);
+    // Its route is exactly the resolved JUDGE chain (ordered).
+    const judgeIds = NATURE_ROUTING_DEFAULT_CHAINS.JUDGE.map(
+      (p) => ROUTING_LABEL_TO_MODEL_ID[p.door]?.[p.model] ?? p.model,
+    );
+    expect(tone.route.map((p) => p.modelId)).toEqual(judgeIds);
+    expect(tone.route.map((p) => p.door)).toEqual(NATURE_ROUTING_DEFAULT_CHAINS.JUDGE.map((p) => p.door));
+  });
+
+  it('marks an unmapped component as legacy (null nature/chain, empty route)', () => {
+    const map = buildNatureRoutingMap();
+    const unmapped = map.components.find((c) => !LLM_ROUTING_NATURE[c.component]);
+    expect(unmapped).toBeDefined();
+    expect(unmapped!.nature).toBeNull();
+    expect(unmapped!.chain).toBeNull();
+    expect(unmapped!.route).toEqual([]);
+  });
+
+  it('surfaces the critical-gate set faithfully', () => {
+    const map = buildNatureRoutingMap();
+    const gates = map.components.filter((c) => c.criticalGate).map((c) => c.component).sort();
+    // Only components in the shipped critical-gate set that are also known components.
+    const known = new Set(map.components.map((c) => c.component));
+    const expected = [...NATURE_ROUTING_CRITICAL_GATES].filter((g) => known.has(g)).sort();
+    expect(gates).toEqual(expected);
+  });
+
+  it('surfaces the FD5b injection-exposure classification per component', () => {
+    const map = buildNatureRoutingMap();
+    expect(map.injectionExposureSource).toBe('FD5b-exposure-map');
+    // MessageSentinel is exposed via user content (an inbound user message).
+    const ms = map.components.find((c) => c.component === 'MessageSentinel')!;
+    expect(ms.injectionExposure).toBeDefined();
+    expect(ms.injectionExposure!.exposed).toBe(true);
+    expect(ms.injectionExposure!.channels.user).toBe(true);
+  });
+
+  it('injects the live enforced framework via the callback (read-only annotation)', () => {
+    const map = buildNatureRoutingMap({ enforcedFrameworkFor: () => 'codex-cli' });
+    expect(map.components.every((c) => c.enforcedFramework === 'codex-cli')).toBe(true);
+    // Without the callback, no enforcedFramework key is present.
+    const bare = buildNatureRoutingMap();
+    expect(bare.components.every((c) => c.enforcedFramework === undefined)).toBe(true);
+  });
+
+  it('is PURE — repeated calls are deep-equal and inputs are not mutated', () => {
+    const chainsSnapshot = JSON.stringify(NATURE_ROUTING_DEFAULT_CHAINS);
+    const a = buildNatureRoutingMap();
+    const b = buildNatureRoutingMap();
+    expect(a).toEqual(b);
+    // The shared static input map is untouched.
+    expect(JSON.stringify(NATURE_ROUTING_DEFAULT_CHAINS)).toBe(chainsSnapshot);
+  });
+
+  it('traceComponent returns a single entry or undefined for an unknown name', () => {
+    expect(traceComponent('MessagingToneGate')?.chain).toBe('JUDGE');
+    expect(traceComponent('__does-not-exist__')).toBeUndefined();
+  });
+});

--- a/upgrades/eli16/routing-map-surface.md
+++ b/upgrades/eli16/routing-map-surface.md
@@ -1,0 +1,41 @@
+# Routing Map surface — Plain-English Overview
+
+> The one-line version: a new read-only dashboard page (and the API behind it) that shows, for every internal AI job the agent runs, which "door" and model it uses and its full ordered fallback list — a map you can read, that changes nothing.
+
+## The problem in one breath
+
+Instar routes its background AI work (sentinels, gates, summarizers) across several "doors" — Claude Code, Codex, Gemini, and some paid API doors — each with an ordered fallback list. That routing map already exists in code as static data, but there was no way to actually SEE it: an operator diagnosing an unexpected route had to piece it together from source files and live config. This adds a single readable surface for "which door + model does each job-kind use, and what does it fall back to?"
+
+## What already exists
+
+- **The four routing lanes ("chains")** — `FAST`, `SORT`, `JUDGE`, `WRITE`, each an ordered list of `{door, model}` positions with flags (money-gated, injection-safe, metered). Pure static data in `src/data/llmBenchCoverage.ts`.
+- **The job-kind → lane registry** — a map from each internal component (MessagingToneGate, PresenceProxy, …) to its nature + lane.
+- **The label → concrete-model-id registry** — resolves a benchmark label like `gpt-5.5` to the real model id.
+- **The legacy route `GET /intelligence/routing`** — already shows the live "which framework does each component use" view (a different, narrower question). We do NOT touch it.
+- **The `LLM Activity` dashboard tab** — the existing pattern for a read-only observability tab. We mirror it exactly.
+
+## What this adds
+
+One new read-only API route and one new read-only dashboard tab. The route (`GET /intelligence/routing/chains`) composes the existing static maps into a single structure: every known job-kind, its lane, and its full ordered door+model fallback list, each position annotated (metered/skipped-now, money-gated, unsafe-for-untrusted-input, critical-gate). The dashboard "Routing Map" tab renders that as two clear tables. Nothing is added to the routing logic — the page only DISPLAYS the maps the router already uses.
+
+## The new pieces
+
+- **`buildNatureRoutingMap()`** (a new pure module, `src/core/natureRoutingMap.ts`) — reads the shipped static maps and composes the display structure. It is side-effect-free: it performs zero writes, mutates no config, and changes no routing behavior. It is NOT allowed to select a route, adjust a cap, toggle anything, or touch money/PIN surfaces — it only describes.
+- **`GET /intelligence/routing/chains`** — a Bearer-auth sibling of the existing routing route. Same 503-when-no-router shape. Optional `?trace=<component>` drills into one job-kind. Pure reads.
+- **The "Routing Map" dashboard tab** — a read-only page, no inputs, no buttons that change state, just a Refresh.
+
+## The safeguards
+
+**Prevents any behavior change.** The whole feature is a read of static data plus a live read-only annotation (each component's currently-enforced framework). It never writes, never routes, never flips a flag. The legacy route is left byte-for-byte unchanged, verified by test.
+
+**Prevents scope creep into money/PIN territory.** This is explicitly Surface 3 (the read-only map) of a larger "control room". The write/adjust/go-live controls (Surfaces 1/2, money- and PIN-gated) are out of scope and untouched.
+
+**Prevents a broken map from misleading.** The page states plainly that it shows the shipped map, not live actuation (nature routing is dev-gated / dry-run), and that metered doors are skipped for now — so an operator never mistakes the map for "what ran".
+
+## What ships when
+
+All of it in one PR: the pure module, the route, the dashboard tab, and the tests (unit for the composer, integration/alive for the route returning 200 not 503). It is dark/reversible in the sense that it adds a surface only — removing it is a straight revert with no persistent state.
+
+## What you actually need to decide
+
+Ship a read-only routing-map page + API that displays the existing routing map without changing any routing behavior — yes/no?

--- a/upgrades/next/routing-map-surface.md
+++ b/upgrades/next/routing-map-surface.md
@@ -1,0 +1,20 @@
+<!-- bump: minor -->
+
+## What Changed
+
+Added a READ-ONLY "routing map" surface (Surface 3 of the routing control-room; FD11 readable canary, docs/specs/nature-axis-routing.md).
+
+- New pure composer `src/core/natureRoutingMap.ts` (`buildNatureRoutingMap` / `traceComponent`) that reads the shipped static routing maps (`NATURE_ROUTING_DEFAULT_CHAINS`, `LLM_ROUTING_NATURE`, `ROUTING_LABEL_TO_MODEL_ID`, `NATURE_ROUTING_CRITICAL_GATES`, `LLM_UNTRUSTED_INPUT`, door taxonomy) and composes them into a display structure. Zero writes, mutates no config, changes no routing behavior.
+- New Bearer-auth sibling route `GET /intelligence/routing/chains` — for every `knownComponents()` entry: its nature/chain, the ordered door+model fallback list (each label mapped to its concrete model id), and per-position/per-component flags (door class, injection-safe, money-gated, metered-skipped-in-Increment-A, critical-gate, untrusted-input). Optional `?trace=<component>` drills into one job-kind. Same 503-when-no-IntelligenceRouter shape as the legacy `GET /intelligence/routing`, which is left untouched.
+- New "Routing Map" dashboard tab that renders the map as two tables (the four lanes + a by-job-kind breakdown). Read-only, no controls beyond Refresh.
+- Tests: `tests/unit/nature-routing-map.test.ts` (composition + purity) and `tests/integration/intelligence-routing-chains-route.test.ts` (alive 200-not-503, `?trace`, 503-when-no-router, legacy route unchanged).
+
+Read-only and reversible: no behavior change, no money, no PIN. The write/adjust/go-live controls (Surfaces 1/2, money/PIN-gated) are out of scope.
+
+## Summary of New Capabilities
+
+A new read-only observability surface for the internal LLM routing map — one API route (`GET /intelligence/routing/chains`) and one dashboard tab ("Routing Map"). It lets an operator see, for every internal AI job-kind, which door + model it uses and its full ordered fallback list, without changing any routing behavior.
+
+## What to Tell Your User
+
+- **See where your AI work is routed**: "There's a new Routing Map page in your dashboard. It shows, for every background AI job I run, which model provider it uses and its full ordered backup list if the first one is unavailable — plus a note on any that are paid or reserved. It's read-only: it just shows the map, it doesn't change anything."

--- a/upgrades/side-effects/routing-map-surface.md
+++ b/upgrades/side-effects/routing-map-surface.md
@@ -1,0 +1,117 @@
+# Side-Effects Review — Read-only Routing Map surface (Surface 3)
+
+**Version / slug:** `routing-map-surface`
+**Date:** `2026-07-05`
+**Author:** `Echo (instar-dev build hand)`
+**Second-pass reviewer:** `not required (Tier 1, read-only surface)`
+
+## Summary of the change
+
+Adds a READ-ONLY "routing map" surface: a Bearer-auth API route `GET /intelligence/routing/chains` and a "Routing Map" dashboard tab. For every known internal job-kind (`knownComponents()`), it shows its nature/lane (`LLM_ROUTING_NATURE`), the ordered `NATURE_ROUTING_DEFAULT_CHAINS` fallback positions resolved to concrete model ids (`ROUTING_LABEL_TO_MODEL_ID`), and per-position/per-component flags (door class, per-position injection-safe, money-gated, metered-skipped-in-Increment-A, critical-gate, per-component untrusted-input, and the FD5b `LLM_ROUTING_INJECTION_EXPOSURE` classification — exposed + user/model/tool channels — surfaced now that it is on the rebased base). Files touched: new `src/core/natureRoutingMap.ts` (pure composer), `src/server/routes.ts` (one new sibling route + import), `dashboard/index.html` (nav button + panel + registry entry + `loadRoutingMap()`), and two new tests. It aligns with the spec's FD11 "readable canary" (`docs/specs/nature-axis-routing.md` §475). It composes existing static maps only — it changes NO routing behavior.
+
+## Decision-point inventory
+
+The change adds NO decision point. It is pure display of existing routing decisions.
+
+- `resolveRoute` / selection logic — pass-through (NOT touched; the map imports only the static data maps + `resolvePositionModelId`-equivalent label resolution).
+- `GET /intelligence/routing` (legacy category→framework view) — pass-through (untouched; a sibling route was added instead of extending it, to keep it byte-identical).
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The route only returns data; it never rejects any input except an unknown `?trace=` name (a 404, correct).
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer: an observability read surface, mirroring the existing `GET /intelligence/routing` + `LLM Activity` tab pattern. The composition logic lives in a pure `src/core/natureRoutingMap.ts` module (not in the route handler) so it is unit-testable in isolation and reusable; the route is a thin adapter that adds the one live read-only annotation (each component's currently-enforced legacy framework via `IntelligenceRouter.for`). It re-uses the shipped static maps rather than re-deriving routing — no parallel implementation of routing logic.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** docs/signal-vs-authority.md
+
+- [x] No — this change has no block/allow surface.
+
+It is a pure read. It holds zero authority: it cannot route, gate, block, or mutate anything. It only reads and formats existing data.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none. The new route path (`/intelligence/routing/chains`) is distinct from the legacy `/intelligence/routing`; Express matches the exact path, no overlap. The 503-when-no-router guard mirrors the legacy route.
+- **Double-fire:** none — read-only, idempotent, no events emitted.
+- **Races:** none — reads shared IMMUTABLE static config maps (`NATURE_ROUTING_DEFAULT_CHAINS` etc.) and returns; writes nothing, holds no state.
+- **Feedback loops:** none — it does not feed any system; nothing consumes its output except a human reading the dashboard.
+
+Verified: an integration test asserts the legacy `GET /intelligence/routing` still returns its own shape (no `chains` key) and is not broken by the sibling.
+
+---
+
+## 6. External surfaces
+
+- **Other agents / install base:** none — a new read route + a new dashboard tab, both additive.
+- **External systems:** none — no Telegram/Slack/GitHub/Cloudflare calls; zero egress.
+- **Persistent state:** none — the composer and route write nothing to disk, config, ledgers, or memory. Purity is asserted by test (repeated calls deep-equal; the shared static input map is unchanged after a build).
+- **Operator surface (Mobile-Complete):** the new dashboard tab IS the operator surface, and it is fully phone-reachable via the standard dashboard (PIN-gated) — no API-only action. There is no operator ACTION here (nothing to do but read/refresh), so Mobile-Complete is trivially satisfied.
+- **Timing/runtime:** none.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+This change touches an operator surface (`dashboard/index.html`), so the operator-surface quality review is required.
+
+1. **Leads with the primary action?** Yes. The tab's purpose is to READ the routing map; on arrival it shows the four lanes and the by-job-kind table immediately (the loader fires on tab activation). There is no primary "action" to lead with beyond the content itself; a single Refresh button sits top-right, matching the sibling `LLM Activity` tab.
+2. **Zero raw internals as primary content?** The subject matter here IS technical identifiers (door names and model ids) — that is the whole point of a routing map, exactly as the `LLM Activity` tab shows provider + model names. They are presented in labeled table columns and plain-language flag chips ("metered · skipped now", "money-gated", "unsafe for untrusted input", "no-Claude"), NOT as raw JSON blobs, UUIDs, or hashes. A plain-English intro paragraph frames the page in non-engineer language. There are no inputs asking the operator to paste raw text (verified: the surface has no `<input>`/`<textarea>`; the raw-input lint passes).
+3. **Destructive actions de-emphasized?** No destructive actions exist on this surface (read-only) — nothing to revoke/delete/stop.
+4. **Plain language + phone width?** The lane cards use an auto-fit responsive grid (`minmax(240px,1fr)`) that stacks at phone width; the by-job-kind table lives in an `overflow-x:auto` container (matching the `LLM Activity` table pattern) so it scrolls inside its own box rather than breaking the page. Labels read plainly ("Job-kind", "Lane", "Enforced now", "Critical gate", "Untrusted input", "Fallback order").
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN — pure per-machine observability.** The routing map is composed from static code-shipped data (identical on every machine of the same version) plus each machine's own live enforced-framework read. There is no durable state to strand on a topic transfer, no user-facing notice (so no one-voice gating needed), and no generated URL (so nothing to survive a machine boundary). An operator viewing the tab on any machine sees that machine's map; since the static data is version-pinned, the map is the same across machines at the same version (a version-skew would show honestly via the machine's own model ids). No pool-wide merge is warranted — "which doors does THIS machine's build route to" is a per-machine truth.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** pure additive code change — revert the route + module + dashboard additions and ship as the next patch.
+- **Data migration:** none — no persistent state introduced.
+- **Agent state repair:** none — no existing agents need notification or reset; the surface simply disappears on revert.
+- **User visibility:** none beyond the tab vanishing; no regression to any existing behavior during the rollback window (the legacy route and all routing logic are untouched).
+
+---
+
+## Conclusion
+
+This review produced no design changes. The feature is a pure, additive, read-only observability surface that displays the existing routing map without altering any routing behavior, holding any authority, or writing any state. It is clear to ship. Scope was deliberately confined to Surface 3 (the read-only map); the money/PIN-gated write controls (Surfaces 1/2) are explicitly out of scope and untouched.
+
+---
+
+## Second-pass review (if required)
+
+Not required — Tier 1, read-only surface, no block/allow authority, no persistent state.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/nature-routing-map.test.ts` — composer resolves known components to expected ordered chains + model ids + flags; purity assertion (repeated calls deep-equal, static input unmutated).
+- `tests/integration/intelligence-routing-chains-route.test.ts` — alive test (200 + full map, not 503); `?trace` + 404; 503 when no router; legacy route unchanged; deterministic across calls.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller — not applicable. This change adds no loop/monitor/sentinel/reaper/scheduler/recovery path; it is a passive read surface.


### PR DESCRIPTION
## Summary

Surface 3 of the routing "control room": a **read-only** routing-map surface. For every internal AI job-kind, it shows which door + model it uses and its full ordered fallback tier list. Aligns with the spec's FD11 "readable canary" (`docs/specs/nature-axis-routing.md`).

- **New pure composer** `src/core/natureRoutingMap.ts` (`buildNatureRoutingMap` / `traceComponent`) — reads the shipped static maps (`NATURE_ROUTING_DEFAULT_CHAINS`, `LLM_ROUTING_NATURE`, `ROUTING_LABEL_TO_MODEL_ID`, `NATURE_ROUTING_CRITICAL_GATES`, `LLM_UNTRUSTED_INPUT`, `LLM_ROUTING_INJECTION_EXPOSURE`, door taxonomy) and composes a display structure. Zero writes, no config mutation, no routing-behavior change.
- **New Bearer-auth sibling route** `GET /intelligence/routing/chains` — per `knownComponents()`: nature/chain, the ordered door+model fallback list (labels → concrete model ids), per-position flags (door class, `injectionSafe`, `moneyGated`, metered-skipped-in-Increment-A) and per-component flags (critical-gate, untrusted-input, FD5b injection-exposure). Optional `?trace=<component>` drill-down. Same 503-when-no-`IntelligenceRouter` shape as the legacy `GET /intelligence/routing`, which is **untouched**.
- **New "Routing Map" dashboard tab** — renders the map as two tables (the four lanes + a by-job-kind breakdown). Read-only, no controls beyond Refresh, mobile-legible.

**Hard boundaries honored:** read-only, reversible, zero behavior change, no money, no PIN. No write/adjust/go-live controls (Surfaces 1/2, money/PIN-gated) — explicitly out of scope. `resolveRoute`'s selection logic, the A2.2/FD4.2 lints, A1's clamp, and Increment B are all untouched.

## Tests

- `tests/unit/nature-routing-map.test.ts` — the composer resolves a known component to its expected ordered chain + concrete model ids + flags; FD5b exposure surfaced; critical-gate faithfulness; **purity** (repeated calls deep-equal, static input unmutated).
- `tests/integration/intelligence-routing-chains-route.test.ts` — **alive test** (200 + full map, not 503, mounted in the real server path); `?trace` + 404; 503 when no router; legacy route unchanged; deterministic across calls (no writes).

Tier 1 (read-only surface; FD11 spec converged-but-unapproved). instar-dev gate: side-effects artifact + ELI16 + release fragment staged, decision-audit records ride the commit.

## ELI16

Instar runs a lot of background AI work — sentinels, gates, summarizers — and each one is routed to a "door" (Claude Code, Codex, Gemini, or a paid API door) with an ordered fallback list if the first door is unavailable. That routing map already lived in code as static data, but there was no way to actually *see* it: an operator diagnosing an unexpected route had to piece it together from source files and live config. This PR adds a single readable surface — one API route and one dashboard tab — that shows, for every internal job-kind, which door + model it uses and its full ordered fallback list, with plain-language flags for any door that's paid ("metered"), money-gated, or must never take untrusted input. It's strictly read-only: it composes the *existing* maps and displays them. It changes no routing behavior, holds no authority, writes nothing to disk or config, and touches no money/PIN surface. Removing it is a straight revert with no persistent state. The write/adjust controls are a separate, out-of-scope surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
