### PR TITLE
feat(routing): S4 FD4.2 — R-rule structural-exclusion lints (R3–R8) over the nature-axis routing chains (dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-05T19-55-37-761Z-nature-axis-routing-fd42-rrule-lints.json
+++ b/.instar/instar-dev-decisions/2026-07-05T19-55-37-761Z-nature-axis-routing-fd42-rrule-lints.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-05T19:55:37.761Z",
+  "slug": "nature-axis-routing-fd42-rrule-lints",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 387,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "FD4.2 planned increment of the S4 nature-axis routing feature; R8 unblocked by FD5b (#1393) landing the injection-exposure map."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/nature-axis-routing-fd42-rrule-lints.eli16.md
+++ b/docs/specs/nature-axis-routing-fd42-rrule-lints.eli16.md
@@ -1,0 +1,43 @@
+# FD4.2 — R-Rule Structural-Exclusion Lints (Plain-English Overview)
+
+> The one-line version: bake the bench's "never route THIS kind of check to THAT model" rules into build-time and config-load guards, so a future edit can never quietly re-introduce a model placement a benchmark already proved is unsafe.
+
+## The problem in one breath
+
+The nature-axis router (shipping dark) picks which model answers each of my internal background checks. A benchmark found several specific model-for-job placements that are actively dangerous — a cheap model that gets fooled by hidden instructions when it plays a safety judge, a model that burns its whole budget "thinking" and mangles the strict output a bounded check needs, a model that follows planted evidence. The safe chains are already authored to avoid those placements — but "authored to avoid" is a wish: one careless future edit (in the source, or in an operator's config override) could re-add a banned placement and no one would notice. The spec (FD4.2, rules R3–R8) says those exclusions must be STRUCTURAL — enforced by a guard, not by memory.
+
+## What already exists
+
+- **The nature/chain map + door taxonomy** (`src/data/llmBenchCoverage.ts`) — the tables saying which model doors each kind of check may use, plus per-component labels for task-nature and (new, just merged) injection-exposure.
+- **The FD4 harness-door ban** — the first R-rule enforcement, shipped as a build lint (`scripts/lint-nature-chains.mjs`) plus a matching resolve-time/config-load validator, keeping a bounded safety check off the expensive-and-fool-able Claude-CLI route in three independent places.
+- **The FD5b injection-exposure map** — a static, fail-safe table (just merged) saying, for every internal check, whether it reads content an outsider could have tampered with. R8 depends on this.
+
+## What this adds
+
+The remaining R-rule exclusions from the spec, R3 through R8, as structural guards that change NO runtime behavior today (the shipped chains already obey them):
+
+- **R3** — a "qwen-tier" model may never take a strict-format (bounded, terse-JSON) position, where it chronically over-thinks and mangles its own output.
+- **R4** — the consumer Gemini-CLI door may never take an injection-exposed safety-judge (JUDGE) position; a bench showed it follows a judge-directed injection.
+- **R5** — the small gpt-oss-20b / llama-4-scout models may never take a gate (JUDGE) verdict position.
+- **R7** — no DeepSeek door/model may take an injection-exposed JUDGE position.
+- **R6** — doc-tree / cartographer components (which author summaries over untrusted code) may never route to any Claude door.
+- **R8** — my input-classifier checks are marked as reading untrusted content AND are pinned off the cheap Flash-Lite door, whose one reproduced trap-fall is exactly that slot.
+
+R3/R4/R5/R7 are POSITION bans over the authored chains — enforced by both the build lint and the same pure predicate the resolver/config-load already use for the FD4 ban, so a banned operator override is rejected and falls back to the safe defaults. R6/R8 are COMPONENT-scoped pins over the per-component maps (which a config override can never touch), so they are build-lint-only.
+
+## The new pieces
+
+- **`validateChainPositionRRule`** (and its per-chain / combined helpers, in `IntelligenceRouter.ts`) — a pure predicate that flags an R3/R4/R5/R7 violation on one authored chain position. Wired alongside the existing FD4 validator at both config-load and resolve-time, so a violating chain is rejected → built-in default + notice, exactly as the FD4 ban already does.
+- **The extended build lint** (`scripts/lint-nature-chains.mjs`) — now also enforces R3–R8 over the authored chains and maps, and fails the build (fail-closed) on any violation or unparseable map. Wired into `npm run lint`.
+- **Two small component sets** in the data module — the doc-tree/cartographer set (R6) and the input-classifier set (R8) — the structural pins the two component-scoped lints assert over.
+
+## The safeguards
+
+- **No runtime selection change** — the shipped chains are clean, so every new rejection branch is never taken; the metered doors the rules touch (Flash-Lite, Groq) are already skipped in this increment anyway. The point is purely to stop a future edit from authoring a banned placement.
+- **Byte-identical when off** — the resolve-time R-rule check lives inside `resolveRoute`, which only runs when `sessions.natureRouting` is enabled; unset/off is bit-for-bit today's behavior. The pre-existing byte-identical-when-off test and A1's clamp test are untouched and green.
+- **Lint agrees with the validator** — a drift-guard test asserts the build-lint predicate and the TS validator return the same verdict position-by-position for R3/R4/R5/R7, so the two enforcement places can't silently diverge.
+- **Fail-closed** — an empty claude-banned or input-classifier set, or an unparseable map, is a build failure, never a silent pass.
+
+## What this deliberately does NOT do
+
+No runtime selection change, no metered-API doors, no money caps, no PIN go-live (that is the paid-door Increment B, deferred). No flip of the feature to enforcing/live (operator-gated). No change to `resolveRoute`'s selection walk, A1's clamp, or FD5b's map. The spec is NOT marked approved by this change (that is the operator's step) — it stays converged-but-unapproved.

--- a/scripts/lint-nature-chains.mjs
+++ b/scripts/lint-nature-chains.mjs
@@ -166,6 +166,204 @@ export function runNatureChainsLint(src) {
   return { violations, reserveId, chains, labelMap };
 }
 
+/* ────────────────────────────────────────────────────────────────────────────
+ * FD4.2 — the R-rule STRUCTURAL-EXCLUSION lints (R3–R8), enforced at BUILD time.
+ * Spec: docs/specs/nature-axis-routing.md FD5(c) §296-314; LLM-ROUTING-REGISTRY
+ * hard rules #3/#5/#6.
+ *
+ * R3/R4/R5/R7 are POSITION bans over the authored chains — MIRRORING the pure TS
+ * predicate IntelligenceRouter.validateChainPositionRRule (a companion drift-guard
+ * test asserts the two agree). R6/R8 are COMPONENT-scoped structural pins over the
+ * per-component maps that live config can NEVER override, so they are BUILD-LINT
+ * ONLY. All are fail-closed: an unparseable map is a build failure, not a silent pass.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const STRICT_FORMAT_CHAINS = new Set(['FAST', 'SORT']);
+const R3_QWEN = /qwen/i;
+const R4_GEMINI_CLI_DOOR = 'gemini-cli';
+const R5_WEAK_GATE = /gpt-oss-20b|llama-4-scout/i;
+const R7_DEEPSEEK = /deepseek/i;
+
+/**
+ * The FD4.2 R-rule POSITION-ban predicate over one authored position (R3/R4/R5/R7) —
+ * MIRRORS IntelligenceRouter.validateChainPositionRRule. Returns a violation or null.
+ */
+export function rruleViolationForPosition(chain, pos, index, labelMap) {
+  const resolvedModelId = labelMap[pos.door]?.[pos.model] ?? pos.model;
+  const modelText = `${pos.model} ${resolvedModelId}`;
+  const v = (rule, detail) => ({ chain, index, door: pos.door, model: pos.model, resolvedModelId, rule, detail });
+
+  if (STRICT_FORMAT_CHAINS.has(chain) && R3_QWEN.test(modelText)) {
+    return v(
+      'rrule-r3-qwen-strict-format',
+      `${chain}[${index}] ${pos.door}/'${pos.model}' is a qwen-tier model in a strict-format (FAST/SORT) ` +
+        `position — R3: qwen-tier chronically reason-burns and self-clips bounded-contract JSON (0.116/0.028).`,
+    );
+  }
+  if (chain !== 'JUDGE') return null;
+  if (pos.door === R4_GEMINI_CLI_DOOR) {
+    return v(
+      'rrule-r4-gemini-cli-judge',
+      `JUDGE[${index}] is the '${R4_GEMINI_CLI_DOOR}' door — R4: consumer Flash 2.5 fell for a judge-directed ` +
+        `injection; it may never take an injection-exposed JUDGE (safety-gate) position.`,
+    );
+  }
+  if (R5_WEAK_GATE.test(modelText)) {
+    return v(
+      'rrule-r5-weak-model-judge',
+      `JUDGE[${index}] ${pos.door}/'${pos.model}' — R5: gpt-oss-20b / llama-4-scout may never take a gate ` +
+        `(JUDGE) verdict position (injection-credulous / over-conservative contract-breakers).`,
+    );
+  }
+  if (R7_DEEPSEEK.test(modelText) || R7_DEEPSEEK.test(pos.door)) {
+    return v(
+      'rrule-r7-deepseek-judge',
+      `JUDGE[${index}] ${pos.door}/'${pos.model}' is a DeepSeek door/model — R7: DeepSeek may never take an ` +
+        `injection-exposed JUDGE (safety-gate) position.`,
+    );
+  }
+  return null;
+}
+
+/** Extract the quoted string members of a `new Set([ ... ])` const (fail-closed on absence). */
+export function extractStringSet(src, name) {
+  const start = src.indexOf(`export const ${name}`);
+  if (start < 0) throw new Error(`${name} not found in ${path.basename(COVERAGE_SRC)}`);
+  const open = src.indexOf('[', start);
+  const close = src.indexOf(']', open);
+  if (open < 0 || close < 0) throw new Error(`${name}: 'new Set([...])' body not found`);
+  const body = src.slice(open + 1, close);
+  const out = [];
+  const re = /'([^']+)'/g;
+  let m;
+  while ((m = re.exec(body)) !== null) out.push(m[1]);
+  return out;
+}
+
+/** Extract LLM_ROUTING_NATURE as { [component]: chain }. */
+export function extractNatureMap(src) {
+  const body = sliceConstBlock(src, 'LLM_ROUTING_NATURE');
+  const map = {};
+  const re = /(?:'([^']+)'|([A-Za-z_][\w-]*))\s*:\s*\{\s*nature:\s*'[^']+'\s*,\s*chain:\s*'([^']+)'\s*\}/g;
+  let m;
+  while ((m = re.exec(body)) !== null) map[m[1] || m[2]] = m[3];
+  if (Object.keys(map).length === 0) throw new Error('LLM_ROUTING_NATURE parsed empty');
+  return map;
+}
+
+/** Extract LLM_ROUTING_INJECTION_EXPOSURE as { [component]: boolean exposed } from the exposed()/notExposed() sugar. */
+export function extractExposureMap(src) {
+  const body = sliceConstBlock(src, 'LLM_ROUTING_INJECTION_EXPOSURE');
+  const map = {};
+  const re = /(?:'([^']+)'|([A-Za-z_][\w-]*))\s*:\s*(exposed|notExposed)\(/g;
+  let m;
+  while ((m = re.exec(body)) !== null) map[m[1] || m[2]] = m[3] === 'exposed';
+  if (Object.keys(map).length === 0) throw new Error('LLM_ROUTING_INJECTION_EXPOSURE parsed empty');
+  return map;
+}
+
+/**
+ * R6 (build-lint only) — every claude-banned (doc-tree/cartographer) component that HAS a
+ * nature/chain must route through a chain with NO claude-code door position. Structural pin:
+ * a future edit giving a doc-tree component a Claude-containing chain fails the build.
+ */
+export function r6Violations(src, chains) {
+  const banned = extractStringSet(src, 'NATURE_ROUTING_CLAUDE_BANNED_COMPONENTS');
+  if (banned.length === 0) throw new Error('NATURE_ROUTING_CLAUDE_BANNED_COMPONENTS parsed empty (fail-closed)');
+  const natureChain = extractNatureMap(src);
+  const out = [];
+  for (const comp of banned) {
+    const chain = natureChain[comp];
+    if (!chain) continue; // no nature/chain yet ⇒ structurally cannot route anywhere (vacuously off-Claude)
+    const positions = chains[chain] ?? [];
+    positions.forEach((pos, i) => {
+      if (pos.door === 'claude-code') {
+        out.push({
+          chain,
+          index: i,
+          door: pos.door,
+          model: pos.model,
+          resolvedModelId: pos.model,
+          rule: 'rrule-r6-claude-banned-component',
+          detail:
+            `component '${comp}' is Claude-banned (doc-tree/cartographer, R6) but its ${chain} chain routes to a ` +
+            `claude-code door at [${i}] — R6 (absolute): a doc-tree component may never route to any claude-code door.`,
+        });
+      }
+    });
+  }
+  return out;
+}
+
+/**
+ * R8 (build-lint only) — the input-classifier components are pinned off Flash-Lite. Assert
+ * (a) each is `exposed: true` in the injection map (so the FD5b gate skips non-injection doors
+ * for them), and (b) every authored `flash-lite` position sits on a METERED door — so it is
+ * structurally skipped in Increment A and no input-classifier can reach it.
+ */
+export function r8Violations(src, chains) {
+  const inputClassifiers = extractStringSet(src, 'NATURE_ROUTING_INPUT_CLASSIFIER_COMPONENTS');
+  if (inputClassifiers.length === 0)
+    throw new Error('NATURE_ROUTING_INPUT_CLASSIFIER_COMPONENTS parsed empty (fail-closed)');
+  const exposure = extractExposureMap(src);
+  const metered = new Set(extractStringSet(src, 'METERED_ROUTING_DOORS'));
+  const out = [];
+  // (a) each input-classifier must be statically injection-exposed.
+  for (const comp of inputClassifiers) {
+    if (exposure[comp] !== true) {
+      out.push({
+        chain: 'n/a',
+        index: -1,
+        door: 'n/a',
+        model: comp,
+        resolvedModelId: comp,
+        rule: 'rrule-r8-input-classifier-not-exposed',
+        detail:
+          `input-classifier component '${comp}' must be marked injection-exposed (exposed: true) in ` +
+          `LLM_ROUTING_INJECTION_EXPOSURE — R8: so the FD5b gate skips non-injection doors for it. ` +
+          `(found: ${exposure[comp] === false ? 'exposed: false' : 'absent'})`,
+      });
+    }
+  }
+  // (b) any authored flash-lite position must be behind the metered gate (unreachable in Increment A).
+  for (const chain of ['FAST', 'SORT', 'JUDGE', 'WRITE']) {
+    (chains[chain] ?? []).forEach((pos, i) => {
+      if (/flash-lite/i.test(pos.model) && !metered.has(pos.door)) {
+        out.push({
+          chain,
+          index: i,
+          door: pos.door,
+          model: pos.model,
+          resolvedModelId: pos.model,
+          rule: 'rrule-r8-flash-lite-reachable',
+          detail:
+            `${chain}[${i}] places flash-lite on non-metered door '${pos.door}' — R8: Flash-Lite must stay behind ` +
+            `the metered gate so input-classifier components (which walk FAST/SORT) can never land on it.`,
+        });
+      }
+    });
+  }
+  return out;
+}
+
+/** Run ALL FD4.2 R-rule lints (R3–R8) over source text. Returns { violations }. */
+export function runNatureRuleLints(src) {
+  const labelMap = extractLabelMap(src);
+  const chains = extractChains(src);
+  const violations = [];
+  // R3/R4/R5/R7 — position bans over the authored chains.
+  for (const chain of ['FAST', 'SORT', 'JUDGE', 'WRITE']) {
+    chains[chain].forEach((pos, i) => {
+      const v = rruleViolationForPosition(chain, pos, i, labelMap);
+      if (v) violations.push(v);
+    });
+  }
+  // R6/R8 — component-scoped structural pins over the maps.
+  violations.push(...r6Violations(src, chains));
+  violations.push(...r8Violations(src, chains));
+  return { violations, chains, labelMap };
+}
+
 function main() {
   let src;
   try {
@@ -175,26 +373,30 @@ function main() {
     process.exit(1);
   }
   let result;
+  let ruleResult;
   try {
     result = runNatureChainsLint(src);
+    ruleResult = runNatureRuleLints(src);
   } catch (err) {
     console.error(`lint-nature-chains: parse error (fail-closed — an unparseable map is a build failure) — ${err.message}`);
     process.exit(1);
   }
-  if (result.violations.length === 0) {
+  const allViolations = [...result.violations, ...ruleResult.violations];
+  if (allViolations.length === 0) {
     console.log(
-      `lint-nature-chains: OK — every FAST/SORT/JUDGE claude-code position is the pinned reserve ` +
-        `'${result.reserveId}', and no chain emits Fable (FD4 harness-door ban clean).`,
+      `lint-nature-chains: OK — FD4 harness-door ban clean (claude-code FAST/SORT/JUDGE is the pinned reserve ` +
+        `'${result.reserveId}', no Fable), AND the FD4.2 R-rule structural exclusions (R3–R8) all hold.`,
     );
     process.exit(0);
   }
   console.error(
-    'lint-nature-chains: FD4 HARNESS-DOOR BAN VIOLATION(S) in NATURE_ROUTING_DEFAULT_CHAINS ' +
-      '(src/data/llmBenchCoverage.ts):\n' +
-      result.violations.map((v) => `  - [${v.rule}] ${v.detail}`).join('\n') +
+    'lint-nature-chains: NATURE-CHAIN VIOLATION(S) in src/data/llmBenchCoverage.ts ' +
+      '(FD4 harness-door ban and/or FD4.2 R-rule structural exclusions R3–R8):\n' +
+      allViolations.map((v) => `  - [${v.rule}] ${v.detail}`).join('\n') +
       `\n\nThe one permitted claude-code FAST/SORT/JUDGE position is the pinned reserve id ` +
-      `'${result.reserveId}' (author it as the registry-pinned 'balanced' label or the concrete id). ` +
-      `WRITE is exempt for Opus-via-CLI, but NO chain may emit Fable. Spec: docs/specs/nature-axis-routing.md FD4/FD8.`,
+      `'${result.reserveId}'; WRITE is exempt for Opus-via-CLI but NO chain may emit Fable; and the R-rules ` +
+      `(R3 qwen∉strict-format, R4 gemini-cli∉JUDGE, R5 gpt-oss-20b/llama-4-scout∉JUDGE, R6 doc-tree∉claude-code, ` +
+      `R7 DeepSeek∉JUDGE, R8 input-classifiers off Flash-Lite) are structural. Spec: docs/specs/nature-axis-routing.md FD4/FD5c/FD8.`,
   );
   process.exit(1);
 }

--- a/src/core/IntelligenceRouter.ts
+++ b/src/core/IntelligenceRouter.ts
@@ -511,11 +511,15 @@ export function clampToReserveOnCleanDoor(
  * tests: `evaluate() — nature routing is BYTE-IDENTICAL when unset/off`).
  * ──────────────────────────────────────────────────────────────────────────── */
 
-/** The three FD4 static-ban rules a chain position can violate. */
+/** The FD4 static-ban rules + the FD4.2 R-rule position bans a chain position can violate. */
 export type NatureChainBanRule =
   | 'claude-code-non-reserve' // claude-code FAST/SORT/JUDGE resolves to a NON-reserve concrete id (e.g. Opus-family)
   | 'claude-code-tier-label' // claude-code FAST/SORT/JUDGE is an UNPINNED tier label (must be the PINNED concrete reserve id)
-  | 'fable-banned'; // ANY chain position (incl. WRITE) resolves to a Fable model (FD8 §393)
+  | 'fable-banned' // ANY chain position (incl. WRITE) resolves to a Fable model (FD8 §393)
+  | 'rrule-r3-qwen-strict-format' // R3: qwen-tier in a strict-format (FAST/SORT) position — chronic reason-burn self-clipping
+  | 'rrule-r4-gemini-cli-judge' // R4: gemini-cli (consumer Flash 2.5) in an injection-exposed JUDGE position
+  | 'rrule-r5-weak-model-judge' // R5: gpt-oss-20b / llama-4-scout in a gate (JUDGE) position
+  | 'rrule-r7-deepseek-judge'; // R7: any DeepSeek door/model in an injection-exposed JUDGE position
 
 /** One authored chain position that violates the FD4 harness-door ban. */
 export interface NatureChainViolation {
@@ -630,6 +634,119 @@ export function isNatureRoutingChainsValid(chains: NatureRoutingChains): boolean
   return validateNatureRoutingChains(chains).length === 0;
 }
 
+/* ────────────────────────────────────────────────────────────────────────────
+ * FD4.2 — the R-rule POSITION bans (R3/R4/R5/R7), enforced as pure predicates
+ * exactly like the FD4 ban above and mirrored by the build-lint
+ * (scripts/lint-nature-chains.mjs). These are STRUCTURAL exclusions over the
+ * authored chains: a bench-condemned door/model must never appear in the chain
+ * whose consumers it is unsafe for. They change NO runtime selection — the
+ * shipped defaults are clean, so the rejection branch is never taken; the point
+ * is that a future chain edit (source OR an operator `PATCH /config` override)
+ * that reintroduced a banned placement is rejected → built-in defaults + notice.
+ * Spec: docs/specs/nature-axis-routing.md FD5(c) §296-314; LLM-ROUTING-REGISTRY
+ * hard rules #3/#5/#6. (R6/R8 are COMPONENT-scoped map pins — build-lint-only,
+ * since the maps they guard are never operator-overridable.)
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/** Strict-format positions (R3): the bounded strict-JSON/verdict chains. */
+const RRULE_STRICT_FORMAT_CHAINS: ReadonlySet<RoutingChain> = new Set(['FAST', 'SORT']);
+/** R3 — qwen-tier is bench-condemned for bounded contract work (0.116/0.028 reason-burn self-clip). */
+const RRULE_R3_QWEN = /qwen/i;
+/** R4 — the consumer-Flash-2.5 CLI door (fell for a judge-directed injection). */
+const RRULE_R4_GEMINI_CLI_DOOR: RoutingDoor = 'gemini-cli';
+/** R5 — models bench-condemned for gate verdicts (injection-credulous / over-conservative contract-breakers). */
+const RRULE_R5_WEAK_GATE = /gpt-oss-20b|llama-4-scout/i;
+/** R7 — any DeepSeek door/model in an injection-exposed JUDGE slot. */
+const RRULE_R7_DEEPSEEK = /deepseek/i;
+
+/**
+ * Validate ONE chain position against the FD4.2 R-rule position bans (R3/R4/R5/R7).
+ * Returns the first violation or null. Pure. Both the authored LABEL (`pos.model`)
+ * and the REGISTRY-RESOLVED concrete id are checked, so a banned model authored as a
+ * label that resolves to it cannot slip past.
+ */
+export function validateChainPositionRRule(
+  chain: RoutingChain,
+  pos: ChainPosition,
+  index: number,
+): NatureChainViolation | null {
+  const resolvedModelId = ROUTING_LABEL_TO_MODEL_ID[pos.door]?.[pos.model] ?? pos.model;
+  const modelText = `${pos.model} ${resolvedModelId}`;
+  const base = (rule: NatureChainBanRule, detail: string): NatureChainViolation => ({
+    chain,
+    index,
+    door: pos.door,
+    model: pos.model,
+    resolvedModelId,
+    rule,
+    detail,
+  });
+
+  // R3 — qwen-tier never in a strict-format (FAST/SORT) bounded-contract position.
+  if (RRULE_STRICT_FORMAT_CHAINS.has(chain) && RRULE_R3_QWEN.test(modelText)) {
+    return base(
+      'rrule-r3-qwen-strict-format',
+      `chain ${chain}[${index}] (${pos.door}/'${pos.model}') is a qwen-tier model in a strict-format ` +
+        `(FAST/SORT) position — R3: qwen-tier chronically reason-burns and self-clips its own JSON on bounded ` +
+        `contract work (0.116/0.028). Route bounded verdicts to gpt-5.4-mini / flash-lite / the reserve instead.`,
+    );
+  }
+
+  // R4/R5/R7 apply ONLY to the JUDGE (gate) chain — its consumers are the injection-exposed safety gates.
+  if (chain !== 'JUDGE') return null;
+
+  // R4 — gemini-cli (consumer Flash 2.5) never in an injection-exposed JUDGE position.
+  if (pos.door === RRULE_R4_GEMINI_CLI_DOOR) {
+    return base(
+      'rrule-r4-gemini-cli-judge',
+      `chain JUDGE[${index}] is the '${RRULE_R4_GEMINI_CLI_DOOR}' door — R4: consumer Flash 2.5 fell for a ` +
+        `judge-directed injection; it may never take an injection-exposed JUDGE (safety-gate) position.`,
+    );
+  }
+  // R5 — gpt-oss-20b / llama-4-scout never take a gate (JUDGE) verdict position.
+  if (RRULE_R5_WEAK_GATE.test(modelText)) {
+    return base(
+      'rrule-r5-weak-model-judge',
+      `chain JUDGE[${index}] (${pos.door}/'${pos.model}') — R5: gpt-oss-20b (injection-credulous, fabricates ` +
+        `evidence wording) and llama-4-scout (systematic over-conservatism + contract-breaking prose) may never ` +
+        `take a gate (JUDGE) verdict position.`,
+    );
+  }
+  // R7 — any DeepSeek door/model never in an injection-exposed JUDGE position.
+  if (RRULE_R7_DEEPSEEK.test(modelText) || RRULE_R7_DEEPSEEK.test(pos.door)) {
+    return base(
+      'rrule-r7-deepseek-judge',
+      `chain JUDGE[${index}] (${pos.door}/'${pos.model}') is a DeepSeek door/model — R7: DeepSeek may never take ` +
+        `an injection-exposed JUDGE (safety-gate) position.`,
+    );
+  }
+  return null;
+}
+
+/** Validate ONE chain's positions against the FD4.2 R-rule position bans (pure). */
+export function validateNatureRoutingChainRRules(
+  chain: RoutingChain,
+  positions: ReadonlyArray<ChainPosition>,
+): NatureChainViolation[] {
+  const out: NatureChainViolation[] = [];
+  positions.forEach((p, i) => {
+    const v = validateChainPositionRRule(chain, p, i);
+    if (v) out.push(v);
+  });
+  return out;
+}
+
+/** Validate ALL four chains against BOTH the FD4 ban AND the FD4.2 R-rule position bans (pure). */
+export function validateNatureRoutingChainAll(
+  chain: RoutingChain,
+  positions: ReadonlyArray<ChainPosition>,
+): NatureChainViolation[] {
+  return [
+    ...validateNatureRoutingChain(chain, positions),
+    ...validateNatureRoutingChainRRules(chain, positions),
+  ];
+}
+
 /** The base component key (strip a "/segment" operation suffix + a `server:` prefix). */
 function baseComponentKey(component: string | undefined): string | undefined {
   if (!component) return undefined;
@@ -690,7 +807,9 @@ export function resolveRoute(
   // a runtime chain edit can never open the banned route. The per-position clamp below is a
   // belt-and-suspenders third place; this rejection keeps the whole banned chain out.
   let positions = chains[nc.resolvedChain] ?? NATURE_ROUTING_DEFAULT_CHAINS[nc.resolvedChain];
-  const chainViolations = validateNatureRoutingChain(nc.resolvedChain, positions);
+  // FD4 harness-door ban + FD4.2 R-rule position bans (R3/R4/R5/R7) — same predicate
+  // the config-load merge + the build-lint use. Clean defaults ⇒ empty ⇒ byte-identical.
+  const chainViolations = validateNatureRoutingChainAll(nc.resolvedChain, positions);
   if (chainViolations.length > 0) {
     deps.onInvalidChain?.(nc.resolvedChain, chainViolations);
     positions = NATURE_ROUTING_DEFAULT_CHAINS[nc.resolvedChain];
@@ -754,7 +873,8 @@ export function mergeNatureRoutingChains(
   const pick = (c: RoutingChain): ReadonlyArray<ChainPosition> => {
     const ov = override[c];
     if (!ov) return NATURE_ROUTING_DEFAULT_CHAINS[c];
-    const violations = validateNatureRoutingChain(c, ov);
+    // FD4 harness-door ban + FD4.2 R-rule position bans — reject a violating override → default.
+    const violations = validateNatureRoutingChainAll(c, ov);
     if (violations.length > 0) {
       onReject?.(c, violations);
       return NATURE_ROUTING_DEFAULT_CHAINS[c]; // reject the banned override → built-in default

--- a/src/data/llmBenchCoverage.ts
+++ b/src/data/llmBenchCoverage.ts
@@ -1003,3 +1003,44 @@ export const NATURE_ROUTING_CRITICAL_GATES: ReadonlySet<string> = new Set([
   'ProjectDriftChecker',
   'MessageSentinel', // nature A, R2-critical
 ]);
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * S4 FD4.2 / FD5c — the R-rule STRUCTURAL-EXCLUSION component sets (R6, R8).
+ * Spec: docs/specs/nature-axis-routing.md FD5(c) §296-314.
+ *
+ * The R-rule lints split into two kinds. R3/R4/R5/R7 are POSITION bans over the
+ * authored chains (a banned door/model must never appear in a given chain) —
+ * they live as pure predicates in IntelligenceRouter.ts + the build-lint. R6/R8
+ * are COMPONENT-scoped structural pins — they guard the per-component maps
+ * (nature, injection-exposure) that live config can NEVER override, so they are
+ * BUILD-LINT-only (a source edit is the only way to break them, and the lint
+ * catches it). These two sets are the data those two lints assert over.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * R6 (spec §298-307, absolute) — doc-tree / cartographer components carry
+ * `claudeBanned`: NO chain position may route them to any `claude-code` door.
+ * Nature routing must NOT re-open the Claude route `CartographerSweepEngine.
+ * probeRouting()` already forbids (their authoring uses off-Claude doors only:
+ * codex → groq). This set is the structural pin: the FD4.2 R6 lint FAILS the
+ * build if any member is ever given a nature/chain whose positions include a
+ * `claude-code` door — so a future edit can't silently re-open the Claude route.
+ */
+export const NATURE_ROUTING_CLAUDE_BANNED_COMPONENTS: ReadonlySet<string> = new Set([
+  'CartographerSweep', // authors doc-tree summaries over untrusted CODE — Claude-banned (R6)
+]);
+
+/**
+ * R8 (spec §308-310) — the input-classifier-nature components. They are marked
+ * `injectionExposed` (so the FD5b injection gate skips any non-injection-safe
+ * door for them) AND pinned OFF the `gemini-api/flash-lite` position (Flash-Lite's
+ * one reproduced trap-fall is exactly the input-classifier slot). The FD4.2 R8
+ * lint asserts (a) each member is `exposed: true` in LLM_ROUTING_INJECTION_EXPOSURE,
+ * and (b) the `flash-lite` position is behind the metered gate (structurally
+ * unreachable in Increment A) — so no input-classifier can land on Flash-Lite.
+ */
+export const NATURE_ROUTING_INPUT_CLASSIFIER_COMPONENTS: ReadonlySet<string> = new Set([
+  'InputClassifier',
+  'MessageSentinel',
+  'TaskClassifier',
+]);

--- a/tests/unit/nature-routing-rrule-lints.test.ts
+++ b/tests/unit/nature-routing-rrule-lints.test.ts
@@ -1,0 +1,268 @@
+/**
+ * FD4.2 — the R-rule STRUCTURAL-EXCLUSION lints (R3–R8).
+ *
+ * Spec: docs/specs/nature-axis-routing.md FD5(c) §296-314; LLM-ROUTING-REGISTRY
+ * hard rules #3/#5/#6. These are STRUCTURAL checks over the authored chains/maps —
+ * they change NO runtime selection (the shipped defaults are clean, so the resolve/
+ * config-load rejection branch is never taken; the point is that a future edit that
+ * reintroduced a bench-condemned placement is caught).
+ *
+ *   R3 — qwen-tier never in a strict-format (FAST/SORT) bounded-contract position.
+ *   R4 — gemini-cli (consumer Flash 2.5) never in an injection-exposed JUDGE position.
+ *   R5 — gpt-oss-20b / llama-4-scout never take a gate (JUDGE) verdict position.
+ *   R6 — doc-tree/cartographer (claude-banned) components never route to claude-code.
+ *   R7 — any DeepSeek door/model never in an injection-exposed JUDGE position.
+ *   R8 — input-classifier components are injection-exposed AND pinned off Flash-Lite.
+ *
+ * R3/R4/R5/R7 are POSITION bans mirrored in both the build-lint and the pure TS
+ * predicate (a drift guard asserts the two agree). R6/R8 are COMPONENT-scoped map
+ * pins — build-lint only, since the maps they guard are never operator-overridable.
+ * Structure > Willpower.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  NATURE_ROUTING_DEFAULT_CHAINS,
+  type ChainPosition,
+  type RoutingChain,
+} from '../../src/data/llmBenchCoverage.js';
+import {
+  validateChainPositionRRule,
+  validateNatureRoutingChainRRules,
+  validateNatureRoutingChainAll,
+  mergeNatureRoutingChains,
+} from '../../src/core/IntelligenceRouter.js';
+import {
+  runNatureRuleLints,
+  rruleViolationForPosition,
+  r6Violations,
+  r8Violations,
+  extractChains,
+} from '../../scripts/lint-nature-chains.mjs';
+
+const __dirname_test = path.dirname(fileURLToPath(import.meta.url));
+const COVERAGE_SRC_TEXT = fs.readFileSync(
+  path.resolve(__dirname_test, '../../src/data/llmBenchCoverage.ts'),
+  'utf8',
+);
+const LABEL_MAP: Record<string, Record<string, string>> = {};
+
+/**
+ * Build a synthetic llmBenchCoverage-shaped source carrying the blocks the R6/R8
+ * source-parsing lints read. Overridable pieces default to a clean, R-rule-passing shape.
+ */
+function synthSource(opts: {
+  chains?: string;
+  natureMap?: string;
+  exposureMap?: string;
+  claudeBanned?: string;
+  inputClassifiers?: string;
+  metered?: string;
+}): string {
+  const chains =
+    opts.chains ??
+    "  FAST: [{ door: 'pi-cli', model: 'gpt-5.5' }],\n" +
+      "  SORT: [{ door: 'codex-cli', model: 'gpt-5.4-mini' }],\n" +
+      "  JUDGE: [{ door: 'pi-cli', model: 'gpt-5.5' }],\n" +
+      "  WRITE: [{ door: 'codex-cli', model: 'gpt-5.4-mini' }],";
+  const natureMap =
+    opts.natureMap ?? "  MessageSentinel: { nature: 'A', chain: 'FAST' },\n  InputClassifier: { nature: 'A', chain: 'SORT' },";
+  const exposureMap =
+    opts.exposureMap ??
+    "  InputClassifier: exposed(EXPOSED_USER),\n  MessageSentinel: exposed(EXPOSED_USER),\n  TaskClassifier: exposed(EXPOSED_USER),";
+  const claudeBanned = opts.claudeBanned ?? "  'CartographerSweep',";
+  const inputClassifiers = opts.inputClassifiers ?? "  'InputClassifier',\n  'MessageSentinel',\n  'TaskClassifier',";
+  const metered = opts.metered ?? "  'gemini-api',\n  'openrouter-api',\n  'groq-api',";
+  return [
+    "export const ROUTING_LABEL_TO_MODEL_ID: Readonly<Record<string, Readonly<Record<string, string>>>> = {",
+    "  'claude-code': { balanced: 'claude-sonnet-4-6' },",
+    '};',
+    '',
+    'export const LLM_ROUTING_NATURE: Readonly<Record<string, RoutingNature>> = {',
+    natureMap,
+    '};',
+    '',
+    'export const LLM_ROUTING_INJECTION_EXPOSURE: Readonly<Record<string, InjectionExposure>> = {',
+    exposureMap,
+    '};',
+    '',
+    'export const METERED_ROUTING_DOORS: ReadonlySet<RoutingDoor> = new Set([',
+    metered,
+    ']);',
+    '',
+    'export const NATURE_ROUTING_DEFAULT_CHAINS: NatureRoutingChains = {',
+    chains,
+    '};',
+    '',
+    'export const NATURE_ROUTING_CLAUDE_BANNED_COMPONENTS: ReadonlySet<string> = new Set([',
+    claudeBanned,
+    ']);',
+    '',
+    'export const NATURE_ROUTING_INPUT_CLASSIFIER_COMPONENTS: ReadonlySet<string> = new Set([',
+    inputClassifiers,
+    ']);',
+    '',
+  ].join('\n');
+}
+
+describe('FD4.2 R-rule structural-exclusion lints (R3–R8)', () => {
+  it('the REAL authored chain map + maps pass ALL R-rule lints (0 violations)', () => {
+    const { violations } = runNatureRuleLints(COVERAGE_SRC_TEXT);
+    expect(violations, JSON.stringify(violations, null, 2)).toEqual([]);
+  });
+
+  it('the REAL authored chains pass the TS R-rule validator (0 violations)', () => {
+    const out: unknown[] = [];
+    for (const c of ['FAST', 'SORT', 'JUDGE', 'WRITE'] as RoutingChain[]) {
+      out.push(...validateNatureRoutingChainRRules(c, NATURE_ROUTING_DEFAULT_CHAINS[c]));
+    }
+    expect(out).toEqual([]);
+  });
+
+  // ── R3 ──────────────────────────────────────────────────────────────────────
+  it('NEGATIVE R3 — a qwen-tier model in a FAST (strict-format) position FAILS', () => {
+    const pos: ChainPosition = { door: 'groq-api', model: 'qwen-3-32b' };
+    expect(rruleViolationForPosition('FAST', pos, 0, LABEL_MAP)?.rule).toBe('rrule-r3-qwen-strict-format');
+    expect(validateChainPositionRRule('FAST', pos, 0)?.rule).toBe('rrule-r3-qwen-strict-format');
+  });
+  it('POSITIVE R3 — qwen in a WRITE (non-strict-format) position is NOT an R3 violation', () => {
+    const pos: ChainPosition = { door: 'groq-api', model: 'qwen-3-32b' };
+    expect(rruleViolationForPosition('WRITE', pos, 0, LABEL_MAP)).toBeNull();
+    expect(validateChainPositionRRule('WRITE', pos, 0)).toBeNull();
+  });
+
+  // ── R4 ──────────────────────────────────────────────────────────────────────
+  it('NEGATIVE R4 — the gemini-cli door in a JUDGE position FAILS', () => {
+    const pos: ChainPosition = { door: 'gemini-cli', model: 'gemini-flash' };
+    expect(rruleViolationForPosition('JUDGE', pos, 0, LABEL_MAP)?.rule).toBe('rrule-r4-gemini-cli-judge');
+    expect(validateChainPositionRRule('JUDGE', pos, 0)?.rule).toBe('rrule-r4-gemini-cli-judge');
+  });
+  it('POSITIVE R4 — gemini-cli in FAST is NOT an R4 violation (R4 is JUDGE-only)', () => {
+    const pos: ChainPosition = { door: 'gemini-cli', model: 'gemini-flash' };
+    expect(rruleViolationForPosition('FAST', pos, 0, LABEL_MAP)).toBeNull();
+    expect(validateChainPositionRRule('FAST', pos, 0)).toBeNull();
+  });
+
+  // ── R5 ──────────────────────────────────────────────────────────────────────
+  it('NEGATIVE R5 — gpt-oss-20b in a JUDGE position FAILS', () => {
+    const pos: ChainPosition = { door: 'groq-api', model: 'gpt-oss-20b' };
+    expect(rruleViolationForPosition('JUDGE', pos, 0, LABEL_MAP)?.rule).toBe('rrule-r5-weak-model-judge');
+    expect(validateChainPositionRRule('JUDGE', pos, 0)?.rule).toBe('rrule-r5-weak-model-judge');
+  });
+  it('NEGATIVE R5 — llama-4-scout in a JUDGE position FAILS', () => {
+    const pos: ChainPosition = { door: 'groq-api', model: 'llama-4-scout' };
+    expect(rruleViolationForPosition('JUDGE', pos, 0, LABEL_MAP)?.rule).toBe('rrule-r5-weak-model-judge');
+    expect(validateChainPositionRRule('JUDGE', pos, 0)?.rule).toBe('rrule-r5-weak-model-judge');
+  });
+
+  // ── R7 ──────────────────────────────────────────────────────────────────────
+  it('NEGATIVE R7 — a DeepSeek model in a JUDGE position FAILS', () => {
+    const pos: ChainPosition = { door: 'openrouter-api', model: 'deepseek-v4-pro' };
+    expect(rruleViolationForPosition('JUDGE', pos, 0, LABEL_MAP)?.rule).toBe('rrule-r7-deepseek-judge');
+    expect(validateChainPositionRRule('JUDGE', pos, 0)?.rule).toBe('rrule-r7-deepseek-judge');
+  });
+
+  // ── DRIFT GUARD (R3/R4/R5/R7) ────────────────────────────────────────────────
+  it('DRIFT GUARD — lint `rruleViolationForPosition` agrees with TS `validateChainPositionRRule`', () => {
+    const cases: Array<{ chain: RoutingChain; pos: ChainPosition }> = [
+      { chain: 'FAST', pos: { door: 'groq-api', model: 'qwen-3-32b' } }, // R3
+      { chain: 'SORT', pos: { door: 'groq-api', model: 'qwen-3-32b' } }, // R3
+      { chain: 'JUDGE', pos: { door: 'gemini-cli', model: 'gemini-flash' } }, // R4
+      { chain: 'JUDGE', pos: { door: 'groq-api', model: 'gpt-oss-20b' } }, // R5
+      { chain: 'JUDGE', pos: { door: 'groq-api', model: 'llama-4-scout' } }, // R5
+      { chain: 'JUDGE', pos: { door: 'openrouter-api', model: 'deepseek-v4-pro' } }, // R7
+      { chain: 'JUDGE', pos: { door: 'pi-cli', model: 'gpt-5.5' } }, // clean
+      { chain: 'FAST', pos: { door: 'pi-cli', model: 'gpt-5.5' } }, // clean
+    ];
+    for (const { chain, pos } of cases) {
+      const lintV = rruleViolationForPosition(chain, pos, 0, LABEL_MAP);
+      const tsV = validateChainPositionRRule(chain, pos, 0);
+      expect(Boolean(lintV), `${chain}/${pos.model}: lint hasViolation`).toBe(Boolean(tsV));
+      if (lintV && tsV) expect(lintV.rule).toBe(tsV.rule);
+    }
+  });
+
+  // ── R6 (build-lint only) ─────────────────────────────────────────────────────
+  it('NEGATIVE R6 — a claude-banned component whose chain routes to claude-code FAILS', () => {
+    const src = synthSource({
+      natureMap: "  CartographerSweep: { nature: 'D', chain: 'WRITE' },",
+      chains:
+        "  FAST: [{ door: 'pi-cli', model: 'gpt-5.5' }],\n" +
+        "  SORT: [{ door: 'codex-cli', model: 'gpt-5.4-mini' }],\n" +
+        "  JUDGE: [{ door: 'pi-cli', model: 'gpt-5.5' }],\n" +
+        "  WRITE: [{ door: 'claude-code', model: 'capable' }],",
+    });
+    const chains = extractChains(src);
+    const v = r6Violations(src, chains);
+    expect(v.map((x: { rule: string }) => x.rule)).toContain('rrule-r6-claude-banned-component');
+  });
+  it('POSITIVE R6 — a claude-banned component on an off-Claude chain passes', () => {
+    const src = synthSource({
+      natureMap: "  CartographerSweep: { nature: 'D', chain: 'WRITE' },",
+      chains:
+        "  FAST: [{ door: 'pi-cli', model: 'gpt-5.5' }],\n" +
+        "  SORT: [{ door: 'codex-cli', model: 'gpt-5.4-mini' }],\n" +
+        "  JUDGE: [{ door: 'pi-cli', model: 'gpt-5.5' }],\n" +
+        "  WRITE: [{ door: 'codex-cli', model: 'gpt-5.4-mini' }],",
+    });
+    expect(r6Violations(src, extractChains(src))).toEqual([]);
+  });
+  it('R6 fails CLOSED — an empty claude-banned set is a build failure', () => {
+    const src = synthSource({ claudeBanned: '' });
+    expect(() => r6Violations(src, extractChains(src))).toThrow();
+  });
+
+  // ── R8 (build-lint only) ─────────────────────────────────────────────────────
+  it('NEGATIVE R8(a) — an input-classifier marked NOT injection-exposed FAILS', () => {
+    const src = synthSource({
+      exposureMap:
+        "  InputClassifier: notExposed('bogus'),\n  MessageSentinel: exposed(EXPOSED_USER),\n  TaskClassifier: exposed(EXPOSED_USER),",
+    });
+    const v = r8Violations(src, extractChains(src));
+    expect(v.map((x: { rule: string }) => x.rule)).toContain('rrule-r8-input-classifier-not-exposed');
+  });
+  it('NEGATIVE R8(b) — flash-lite placed on a NON-metered (reachable CLI) door FAILS', () => {
+    const src = synthSource({
+      chains:
+        "  FAST: [{ door: 'gemini-cli', model: 'flash-lite' }],\n" +
+        "  SORT: [{ door: 'codex-cli', model: 'gpt-5.4-mini' }],\n" +
+        "  JUDGE: [{ door: 'pi-cli', model: 'gpt-5.5' }],\n" +
+        "  WRITE: [{ door: 'codex-cli', model: 'gpt-5.4-mini' }],",
+    });
+    const v = r8Violations(src, extractChains(src));
+    expect(v.map((x: { rule: string }) => x.rule)).toContain('rrule-r8-flash-lite-reachable');
+  });
+  it('POSITIVE R8 — input-classifiers exposed AND flash-lite behind the metered gate passes', () => {
+    const src = synthSource({
+      chains:
+        "  FAST: [{ door: 'gemini-api', model: 'flash-lite', keyRef: 'k', moneyGated: true }],\n" +
+        "  SORT: [{ door: 'codex-cli', model: 'gpt-5.4-mini' }],\n" +
+        "  JUDGE: [{ door: 'pi-cli', model: 'gpt-5.5' }],\n" +
+        "  WRITE: [{ door: 'codex-cli', model: 'gpt-5.4-mini' }],",
+    });
+    expect(r8Violations(src, extractChains(src))).toEqual([]);
+  });
+
+  // ── Config-load / resolve-time enforcement (R3/R4/R5/R7 via the combined validator) ──
+  it('config-load REJECTS an operator override that violates an R-rule → built-in default', () => {
+    const rejected: RoutingChain[] = [];
+    const merged = mergeNatureRoutingChains(
+      { JUDGE: [{ door: 'gemini-cli', model: 'gemini-flash' }] }, // R4 violation
+      (c) => rejected.push(c),
+    );
+    expect(rejected).toContain('JUDGE');
+    // The banned override is discarded — the JUDGE chain falls back to the lint-clean default.
+    expect(merged.JUDGE).toBe(NATURE_ROUTING_DEFAULT_CHAINS.JUDGE);
+  });
+  it('the combined validator flags BOTH FD4 and R-rule violations on one chain', () => {
+    const viol = validateNatureRoutingChainAll('JUDGE', [
+      { door: 'claude-code', model: 'claude-opus-4-8' }, // FD4 non-reserve
+      { door: 'gemini-cli', model: 'gemini-flash' }, // R4
+    ]);
+    const rules = viol.map((v) => v.rule);
+    expect(rules).toContain('claude-code-non-reserve');
+    expect(rules).toContain('rrule-r4-gemini-cli-judge');
+  });
+});

--- a/upgrades/next/nature-axis-routing-fd42-rrule-lints.md
+++ b/upgrades/next/nature-axis-routing-fd42-rrule-lints.md
@@ -1,0 +1,25 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Builds FD4.2 of the (still-dark) nature-axis router (spec: docs/specs/nature-axis-routing.md §296-314): the R-rule structural-exclusion guards R3–R8 that keep a bench-condemned model placement out of the router's authored chains and per-component maps.
+
+- **R3/R4/R5/R7 position bans** (src/core/IntelligenceRouter.ts + scripts/lint-nature-chains.mjs): a pure predicate (validateChainPositionRRule) and matching build-lint reject a chain that places qwen-tier in a strict-format position (R3), the gemini-cli door in a JUDGE safety-gate position (R4), gpt-oss-20b / llama-4-scout in a JUDGE position (R5), or a DeepSeek door/model in a JUDGE position (R7). Wired into both the config-load merge and the resolve-time chain check alongside the existing FD4 harness-door ban, so a violating operator override is rejected → built-in default.
+- **R6/R8 component-map pins** (src/data/llmBenchCoverage.ts + the build lint): doc-tree/cartographer components (NATURE_ROUTING_CLAUDE_BANNED_COMPONENTS) may never route to any claude-code door (R6); the input-classifier components (NATURE_ROUTING_INPUT_CLASSIFIER_COMPONENTS) must stay injection-exposed and pinned off the Flash-Lite door (R8, using the just-merged FD5b injection-exposure map). These guard per-component maps a config override can never touch, so they are build-lint-only.
+- A new 18-test unit file covers each of R3–R8 (a compliant chain passes, a crafted violation fails with the right reason), the lint↔validator drift guard, fail-closed behavior, and config-load rejection.
+
+NO runtime selection change: the shipped chains already obey every R-rule, so the rejection branches are never taken; the metered doors the rules touch (Flash-Lite, Groq) are already skipped in this increment. Dev-gated / dark: the whole nature block runs only when sessions.natureRouting is enabled; unset/off is byte-identical to before (asserted). This is the guard-lints increment only — NOT the metered-door Increment B, and NOT the go-live flip.
+
+## What to Tell Your User
+
+This is internal plumbing for how I choose which model runs my own background checks — nothing to turn on, and nothing about our conversations changes. In plain terms: a benchmark found a handful of "never use this model for that job" rules — some cheaper models get fooled by hidden instructions when they act as a safety judge, or mangle the strict output a quick check needs. I turned those rules into build-time guards, so a future change to my settings can never quietly re-introduce one of those bad pairings. The routing feature is still off by default, so today this is invisible — it just seals those unsafe choices shut in advance.
+
+## Summary of New Capabilities
+
+- **R-rule exclusion guards**: build-enforced rules that keep bench-condemned model-for-job pairings out of my internal routing — a fool-able judge model off a safety-gate, an over-thinking model off a strict-format check, a doc-tree writer off the Claude door, and my message classifiers off the cheapest easily-tricked door.
+- **Config-safe by construction**: an operator routing override that would re-introduce a banned pairing is rejected and falls back to the safe default, so the exclusions survive any future edit.
+
+## Evidence
+
+- tests/unit/nature-routing-rrule-lints.test.ts (18 tests) — green: the real authored chains + maps pass all R-rules via both the build lint and the TS validator; a crafted violation of each of R3–R8 fails with the correct reason; the lint↔validator drift guard for R3/R4/R5/R7; R6/R8 fail-closed on empty sets; config-load rejection of a violating override; and the combined validator flagging both FD4 and R-rule violations on one chain.
+- npm run lint clean (the extended nature-chains lint passes on the real chains); npx tsc --noEmit clean; the pre-existing byte-identical-when-off block, A1's clamp assertion, the FD5b injection-exposure ratchet, and the FD4 harness-door ratchet all untouched and green.

--- a/upgrades/side-effects/nature-axis-routing-fd42-rrule-lints.md
+++ b/upgrades/side-effects/nature-axis-routing-fd42-rrule-lints.md
@@ -1,0 +1,63 @@
+# Side-Effects Review — FD4.2: R-rule structural-exclusion lints (R3–R8)
+
+**Version / slug:** `nature-axis-routing-fd42-rrule-lints`
+**Date:** `2026-07-05`
+**Author:** `echo (build hand, topic 29723 routing follow-through)`
+**Second-pass reviewer:** `not required (Tier 1 — deterministic static structural exclusions over authored config data + pure candidate-eligibility predicates, dark/dev-gated, byte-identical no-op over the shipped chains; same surface + precedent as the FD4-lints #1388 and FD5b #1393)`
+
+## Summary of the change
+
+Builds FD4.2 of `docs/specs/nature-axis-routing.md` (§296-314): the R-rule structural exclusions R3–R8 over the (still-dark) nature router's authored chains and per-component maps. Files touched:
+
+- `src/data/llmBenchCoverage.ts` — two new component sets: `NATURE_ROUTING_CLAUDE_BANNED_COMPONENTS` (R6, doc-tree/cartographer) and `NATURE_ROUTING_INPUT_CLASSIFIER_COMPONENTS` (R8, the input-classifier pins).
+- `src/core/IntelligenceRouter.ts` — the pure R-rule POSITION-ban predicate `validateChainPositionRRule` (R3/R4/R5/R7) + `validateNatureRoutingChainRRules` + a combined `validateNatureRoutingChainAll`; the `NatureChainBanRule` union extended with the four R-rule tags; the combined validator wired into both `resolveRoute`'s chain-rejection and `mergeNatureRoutingChains`'s config-load rejection alongside the existing FD4 ban.
+- `scripts/lint-nature-chains.mjs` — the build lint extended with R3–R8: `rruleViolationForPosition` (mirrors the TS predicate), source-parsing helpers (`extractStringSet`/`extractNatureMap`/`extractExposureMap`), `r6Violations`/`r8Violations`, and `runNatureRuleLints`; `main()` now fails the build on any FD4 OR R-rule violation.
+- Tests — NEW `tests/unit/nature-routing-rrule-lints.test.ts` (18 tests: real chains pass all R-rules via both lint + TS validator; a crafted violation of each of R3–R8 fails with the right reason; the lint↔validator drift guard for R3/R4/R5/R7; R6/R8 fail-closed on empty sets; config-load rejection of a violating override; the combined validator flagging both FD4 and R-rule violations). The pre-existing byte-identical block (`nature-routing-resolver.test.ts:261-296`), A1's clamp assertion, the FD5b ratchet, and the FD4 harness-door ratchet are UNTOUCHED and green.
+
+## Decision-point inventory
+
+- `FD4.2 R-rule position bans (R3/R4/R5/R7)` — add — pure candidate-eligibility predicates over authored chains; a violating chain is rejected → built-in default (same mechanism as the FD4 ban). NO-OP over the shipped chains (already clean).
+- `FD4.2 R6/R8 component-map pins` — add — build-lint-only structural assertions over per-component maps that a config override can never touch.
+- `resolveRoute chain-rejection` — modify — now runs FD4 + R-rule violations via `validateNatureRoutingChainAll`. Byte-identical for a clean chain (rejection branch untaken).
+- `mergeNatureRoutingChains config-load` — modify — rejects an operator override that violates FD4 OR an R-rule → built-in default + notice.
+- `sessions.natureRouting enable/dryRun gate` — pass-through — the whole nature block still runs ONLY when enabled.
+
+## 1. Over-block
+
+**What legitimate inputs does this reject that it shouldn't?** Over the shipped chains: none. Every default position passes all R-rules (asserted: "the REAL authored chain map + maps pass ALL R-rule lints"), so no route is removed and no chain is rejected. The rules only reject a chain that PLACES a bench-condemned model in an unsafe slot — a placement no legitimate config authors. R3's model match is `qwen`, R5's is `gpt-oss-20b|llama-4-scout`, R7's is `deepseek` — narrow, bench-cited denylist terms that appear in no shipped or plausible-safe chain; R4 bans only the `gemini-cli` DOOR from the JUDGE chain. False-positive surface is effectively nil.
+
+## 2. Under-block
+
+**What failure modes does this still miss?** The R-rule set is exactly the spec's R3–R8 — it does not attempt to catch every conceivable bad placement, only the bench-condemned classes. R6 is a structural pin that is vacuously satisfied today (the cartographer component has no nature/chain yet), so it guards against a FUTURE edit rather than fixing a present defect — that is by design (the spec's "makes their exclusion structural so a future edit can't reintroduce them"). R8's flash-lite guarantee is realized by asserting flash-lite stays behind the metered gate (unreachable in Increment A) rather than a per-component resolve-time skip — the per-component walk-skip would be a SELECTION change, which this increment deliberately does not make (out of scope; the metered-skip already delivers the same runtime guarantee in Increment A). The FD7 prompt-anchor semantic-drift lint remains a separate deferred increment.
+
+## 3. Level-of-abstraction fit
+
+Correct altitude. The R-rule predicates live beside the FD4 ban predicate in `IntelligenceRouter.ts` and ride the identical shape (`NatureChainViolation`, per-position → per-chain → all-chains) and the identical config-load/resolve wiring. The build lint extends the existing `lint-nature-chains.mjs` (the spec's named home for the compile-time place). The two component sets sit beside `NATURE_ROUTING_CRITICAL_GATES` in the same data module. No new engine, config surface, or route.
+
+## 4. Signal vs authority compliance
+
+Compliant. The R-rule maps/predicates are deterministic build-time DATA + pure predicates (signals), enforced by a lint ratchet — not brittle runtime checks with blocking authority. The resolve/config-load rejection DOES exercise authority (it discards a violating chain → safe default), but only ever in the SAFE direction, on a MODEL-ROUTING decision — it never blocks a user message, never reads or credits a principal, never grants anything. `docs/signal-vs-authority.md` satisfied.
+
+## 5. Interactions
+
+Interacts with the FD4 ban (orthogonal and composable: `validateNatureRoutingChainAll` = FD4 violations ∪ R-rule violations; a drift-guard/combined test proves both surface independently on one chain). Placed alongside — never shadowing — FD4; the two target different unsafe placements (FD4 = the claude-code harness door; R3/R4/R5/R7 = qwen/gemini-cli/weak-gate/deepseek by chain). The resolver's existing FD5b injection gate and A1 clamp are untouched (their tests stay green). The build lint's new source-parsing reads the same `llmBenchCoverage.ts` the FD4 lint already parses.
+
+## 6. External surfaces
+
+No external surface. No new HTTP route, CLI command, MCP tool, Telegram/Slack path, or network egress. The lint is a `npm run lint` step (already wired for FD4). No secrets, tokens, or file paths surface anywhere.
+
+## 6b. Operator-surface quality
+
+No operator-facing surface added or changed. The rejection "notice" path is the pre-existing FD4 `onInvalidChain`/`onReject` callback (internal); nothing new is emitted to a user.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+Machine-local by design, and correctly so. The R-rule predicates and maps are static source data compiled into every machine identically; the validators are pure functions over that data with no persisted or replicated state. Each machine resolves the identical verdict independently — there is no cross-machine state to strand, replicate, or coalesce. No lease, ledger, or notice interaction.
+
+## 8. Rollback cost
+
+Low and clean. Revert the PR: the two component sets, the R-rule predicates, and the two wiring call sites (reverting `validateNatureRoutingChainAll` back to `validateNatureRoutingChain`) drop out; the lint returns to FD4-only. No migration, no persisted state, no config schema change, no data-format change. Because the R-rules are a no-op over the shipped chains and only run when `natureRouting.enabled`, a rollback is invisible to every fleet agent (feature dark) and to any dev agent in dryRun.
+
+## Conclusion
+
+FD4.2 ships the R3–R8 structural exclusions as a build lint (extended `lint-nature-chains.mjs`, wired into `npm run lint`) plus resolve-time/config-load rejection for the position bans (R3/R4/R5/R7) mirroring the FD4 ban, and build-lint pins for the component-scoped rules (R6/R8). It changes no runtime selection (the shipped chains are clean; the metered doors it touches are already skipped in Increment A), is byte-identical when the feature is off, and is dark/dev-gated. R8 consumes the just-merged FD5b injection-exposure map. The FD7 prompt-anchor semantic-drift lint and the metered-door Increment B are the tracked next increments, not built here; the spec is NOT marked approved by this change.


### PR DESCRIPTION
## ELI16

The nature-axis router (shipping dark) picks which model answers each of my internal background checks. A benchmark found a handful of "never route THIS kind of check to THAT model" rules — some cheaper models get fooled by hidden instructions when they act as a safety judge, one over-thinks and mangles the strict output a bounded check needs, one follows planted evidence. The safe chains are already authored to avoid those pairings, but "authored to avoid" is a wish: one careless future edit (in source, or in an operator config override) could re-add a banned pairing and nobody would notice.

This builds FD4.2 (spec §296-314): rules R3–R8 as **structural guards** so those exclusions can't be re-introduced.

- **R3** qwen-tier ∉ strict-format (FAST/SORT) positions · **R4** gemini-cli door ∉ injection-exposed JUDGE · **R5** gpt-oss-20b / llama-4-scout ∉ JUDGE gate · **R7** DeepSeek ∉ injection-exposed JUDGE — pure position-ban predicate (`validateChainPositionRRule`) + matching build-lint, wired into `resolveRoute` + `mergeNatureRoutingChains` alongside the existing FD4 harness-door ban (a violating override is rejected → built-in default).
- **R6** doc-tree/cartographer ∉ any claude-code door · **R8** input-classifiers stay injection-exposed AND pinned off Flash-Lite (using the just-merged FD5b injection-exposure map) — build-lint-only pins over per-component maps a config override can never touch.

**Changes no runtime selection**: the shipped chains already obey every R-rule (the rejection branches are never taken), and the metered doors the rules touch (Flash-Lite, Groq) are already skipped in Increment A. Byte-identical when the feature is off; dark/dev-gated. Does NOT touch `resolveRoute`'s selection walk, A1's clamp, or FD5b's map; does NOT build Increment B; does NOT mark the spec approved.

## Tests / gate

- New `tests/unit/nature-routing-rrule-lints.test.ts` (18): real chains pass all R-rules via both lint + TS validator; a crafted violation of each of R3–R8 fails with the right reason; the lint↔validator drift guard (R3/R4/R5/R7); R6/R8 fail-closed on empty sets; config-load rejection of a violating override; combined validator flags both FD4 + R-rule violations.
- `npm run lint` clean (extended nature-chains lint), `tsc --noEmit` clean; byte-identical-when-off, A1 clamp, FD5b + FD4 ratchets untouched and green.
- Tier 1 (converged-but-unapproved spec). Side-effects artifact + ELI16 + release fragment shipped; decision-audit rode the commit.