### PR TITLE
feat(routing): S4 A2.2 — enforcing nature-axis selection (dev-gated dark, dryRun-defaulted)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-05T23-44-50-324Z-nature-routing-a2-2-enforcing.json
+++ b/.instar/instar-dev-decisions/2026-07-05T23-44-50-324Z-nature-routing-a2-2-enforcing.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-05T23:44:50.324Z",
+  "slug": "nature-routing-a2.2-enforcing",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 192,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "Planned increment A2.2 of FD9; not a fix — it lands the enforcing half the A2.1 ship deliberately deferred (the retired warnNatureEnforceNotWired no-op)."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/core/IntelligenceRouter.ts
+++ b/src/core/IntelligenceRouter.ts
@@ -185,15 +185,18 @@ export interface IntelligenceRouterOptions {
    * (resolved at the construction boundary, like `ladder`). Absent OR `enabled:false`
    * ⇒ the nature router is inert and routing is BYTE-IDENTICAL to today. When enabled +
    * dryRun (the dev-agent default) the resolver OBSERVES (computes + logs the plan via
-   * `onNatureRoutePlan`) and still passes through to today's selection. Enforcing
-   * selection (dryRun:false) is a tracked A2.2 remainder.
+   * `onNatureRoutePlan`) and still passes through to today's selection. When enabled +
+   * `dryRun:false` (the operator's deliberate post-soak flip — A2.2) the resolved plan
+   * REPLACES today's selection: the primary `(door, model)` is used and the swapTail feeds
+   * the existing failure-swap loop.
    */
   resolveNatureRouting?: () => NatureRoutingRuntime | undefined;
   /**
-   * S4 A2 — the dryRun observation sink (FD11 readable canary). Invoked with the resolved
-   * plan when nature routing is enabled + dryRun. No-op downstream by default; the router
-   * calls it freely. The durable `logs/nature-routing.jsonl` + `GET /intelligence/routing`
-   * surfaces that consume this are a tracked A2.2 remainder.
+   * S4 A2 — the resolved-plan observation sink (FD11 readable canary). Invoked with the
+   * resolved plan on EVERY nature-routing call (dryRun AND enforcing) so the plan is always
+   * observable. No-op downstream by default; the router calls it freely. The durable
+   * `logs/nature-routing.jsonl` + `GET /intelligence/routing` surfaces that consume this,
+   * and the FD6 critical-gate drift notice / baseline, are tracked follow-ups.
    */
   onNatureRoutePlan?: (plan: NatureRoutePlan) => void;
 }
@@ -368,16 +371,17 @@ export function isBoundedGatingDegrade(
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
- * S4 Increment A2 — the nature-axis routing RESOLVER (dark/dryRun mechanism).
+ * S4 Increment A2 — the nature-axis routing RESOLVER.
  *
  * `resolveRoute` is a PURE, side-effect-free evaluator (spec CR2-5): a stateless
  * fold `component → resolvedNature → ordered eligible positions → { primary, swapTail }
  * | 'fall-through' | 'no-route' | throw`. It owns no retry/backoff/breaker/budget
  * machinery — those stay in the existing IntelligenceRouter primitives. Wired into
  * `evaluate()` ONLY when `sessions.natureRouting.enabled` (dev-gated dark). In dryRun
- * (the dev-agent default) it OBSERVES: computes + logs the plan, then passes through to
- * today's routing (byte-identical selection). Enforcing selection (dryRun:false) is a
- * tracked A2.2 remainder — see the honest guard in `evaluate()`.
+ * (the dev-agent default, A2.1) it OBSERVES: computes + logs the plan, then passes through
+ * to today's routing (byte-identical selection). When `dryRun:false` (A2.2, the operator's
+ * deliberate post-soak flip) the resolved plan REPLACES today's selection — the primary
+ * `(door, model)` is used and the swapTail feeds the existing failure-swap loop verbatim.
  * Spec: docs/specs/nature-axis-routing.md §Resolver / FD3 / FD4 / FD9.
  * ──────────────────────────────────────────────────────────────────────────── */
 
@@ -1002,9 +1006,6 @@ export class IntelligenceRouter implements IntelligenceProvider {
     return framework === this.opts.defaultFramework ? this.opts.defaultProvider : this.providerFor(framework);
   }
 
-  /** Already warned that nature-routing enforcing mode is not yet wired (warn ONCE). */
-  private warnedNatureEnforceNotWired = false;
-
   /**
    * S4 A2 — CLI-door reachability probe for the nature router (FD5 availability walk).
    * CLI doors coincide 1:1 with `IntelligenceFramework`. `resolveRoute` skips metered
@@ -1014,22 +1015,6 @@ export class IntelligenceRouter implements IntelligenceProvider {
    */
   private isCliDoorReachable(door: RoutingDoor): boolean {
     return this.resolveProvider(door as IntelligenceFramework) !== null;
-  }
-
-  /**
-   * S4 A2 — enforcing-mode honesty guard. Flipping `dryRun:false` in A2.1 does NOT re-route
-   * (the selection integration is a tracked A2.2 remainder); routing stays byte-identical.
-   * Warn ONCE so the flip is an honest no-op rather than a silent dead switch.
-   */
-  private warnNatureEnforceNotWired(): void {
-    if (this.warnedNatureEnforceNotWired) return;
-    this.warnedNatureEnforceNotWired = true;
-    console.warn(
-      'IntelligenceRouter: sessions.natureRouting.dryRun is false, but nature-routing ENFORCING ' +
-        'selection is not wired in this build (Increment A2.1 ships the dark/dryRun observation ' +
-        'mechanism; enforcing selection is the tracked A2.2 remainder). Routing stays byte-identical — ' +
-        'the resolver plan is logged but not applied.',
-    );
   }
 
   /** Chains already warned about as rejected (warn ONCE per chain, never per call). */
@@ -1062,13 +1047,21 @@ export class IntelligenceRouter implements IntelligenceProvider {
 
     const cfg = this.opts.resolveConfig();
 
-    // ── S4 A2 — nature-axis routing OBSERVATION (dev-gated dark; dryRun-first). ──
+    // ── S4 A2 — nature-axis routing (dev-gated dark; dryRun-first). ──
     // Byte-identical when unset/off: when the feature is absent OR `enabled:false` this
     // whole block is skipped and NOTHING about selection changes. In dryRun (the dev-agent
     // default) it OBSERVES only — computes + logs the plan via `onNatureRoutePlan` — and
-    // still falls through to today's selection below. Enforcing SELECTION (dryRun:false) is
-    // a tracked A2.2 remainder; guarded here so a flip is an HONEST no-op, never a silent
-    // dead switch and never a mis-route. A resolver error can never break routing here.
+    // still falls through to today's selection below. When ENFORCING (`dryRun:false`, the
+    // operator's deliberate flip after the dryRun soak — A2.2) the resolved plan REPLACES
+    // today's selection (spec §Resolver steps 8-9): the primary `(door, model)` becomes the
+    // selection and the `swapTail` feeds the EXISTING failure-swap loop verbatim. A resolver
+    // error can never break routing here — the DESIGNED critical-gate fail-closed throw
+    // (`RouterFailClosedError`) propagates on the real path so the gate caller applies its
+    // own fail-closed semantics; any UNEXPECTED resolver error falls through to today's
+    // selection (fail-safe). In dryRun EVERY outcome (route / no-route / throw) is recorded
+    // only — nothing is ever withheld or re-routed.
+    let enforced: { primary: ResolvedRoutePosition; swapTail: ResolvedRoutePosition[] } | undefined;
+    let enforcedNoRoute = false;
     const natureRt = this.opts.resolveNatureRouting?.();
     if (natureRt?.enabled) {
       const dryRun = natureRt.dryRun !== false; // default true on first enable
@@ -1089,25 +1082,68 @@ export class IntelligenceRouter implements IntelligenceProvider {
           },
         );
         this.opts.onNatureRoutePlan?.({ component, category, dryRun, resolution });
+        if (!dryRun) {
+          // ENFORCE (A2.2): the resolved plan becomes the actual selection.
+          if (resolution.outcome === 'route') {
+            enforced = { primary: resolution.primary, swapTail: resolution.swapTail };
+          } else if (resolution.outcome === 'no-route') {
+            // Low-stakes mapped, all chain doors down ⇒ the caller's OWN non-gating heuristic
+            // (the ordinary provider-down contract) — NEVER legacy category routing, so the
+            // harness door can't re-open for a nature-routed component (spec §573-581).
+            enforcedNoRoute = true;
+          }
+          // 'fall-through' (unmapped) ⇒ leave enforcement unset → today's category routing below.
+        }
       } catch (e) {
         if (e instanceof RouterFailClosedError) {
           this.opts.onNatureRoutePlan?.({ component, category, dryRun, failClosed: true });
+          // ENFORCE (A2.2): a mapped FD6 critical gate with no available door FAILS CLOSED on
+          // the real path — the caller applies its gating fail-closed semantics (block/deny),
+          // never legacy routing and never the harness door. In dryRun the throw is swallowed
+          // (observe-and-record only), never surfaced to the call path.
+          if (!dryRun) throw e;
         } else {
+          // An UNEXPECTED resolver error (the pure fold only THROWS `RouterFailClosedError` by
+          // design). Record it and fall through to today's selection — an unexpected error must
+          // never break routing (fail-safe); a real empty-set critical gate is the typed error
+          // above, never this branch.
           this.opts.onNatureRoutePlan?.({ component, category, dryRun });
         }
       }
-      if (!dryRun) this.warnNatureEnforceNotWired();
     }
 
-    // Unconfigured ⇒ exactly today's behavior.
-    if (!cfg) return this.opts.defaultProvider.evaluate(prompt, options);
+    // ENFORCE 'no-route': raise the ordinary non-gating error the caller already catches into
+    // its heuristic (tracked never-silent). NEVER legacy category routing (harness-door re-open).
+    if (enforcedNoRoute) {
+      this.opts.onHeuristicFallthrough?.(component ?? '(none)', this.opts.defaultFramework);
+      throw new Error(
+        `IntelligenceRouter: nature-routing 'no-route' — no available door for low-stakes ` +
+          `'${component ?? '(none)'}' (all chain doors unreachable); caller uses its heuristic.`,
+      );
+    }
 
-    const framework = this.resolveFramework(component, category, cfg);
+    // Selection: an enforced nature plan supersedes category routing (its primary door is
+    // guaranteed reachable — the resolver only emits reachable CLI doors). Otherwise today's
+    // behavior: unconfigured componentFrameworks ⇒ the default provider verbatim.
+    let framework: IntelligenceFramework;
+    let evalOptions = options;
+    if (enforced) {
+      framework = enforced.primary.door as IntelligenceFramework; // resolver emits CLI doors only
+      // The resolved primary's CONCRETE model id REPLACES the caller's tier hint (spec step 8).
+      // It is already reserve-clamped by the resolver (clampToReserveOnCleanDoor); a concrete id
+      // rides `options.model` verbatim to the provider (the adapters resolve tier-or-id).
+      evalOptions = { ...(options ?? {}), model: enforced.primary.modelId as IntelligenceOptions['model'] };
+    } else {
+      if (!cfg) return this.opts.defaultProvider.evaluate(prompt, options);
+      framework = this.resolveFramework(component, category, cfg);
+    }
     const primary = this.resolveProvider(framework);
 
     // Provider unavailable (binary missing / not built) — unchanged: degrade or error.
+    // (`cfg?.` because an enforced nature plan may have superseded category routing with a
+    // null `cfg`; an enforced primary door is always reachable, so this branch stays legacy.)
     if (!primary) {
-      if ((cfg.fallback ?? 'default') === 'none') {
+      if ((cfg?.fallback ?? 'default') === 'none') {
         throw new Error(
           `IntelligenceRouter: framework '${framework}' for component '${component ?? '(none)'}' ` +
             `is unavailable and fallback is 'none'.`,
@@ -1167,14 +1203,23 @@ export class IntelligenceRouter implements IntelligenceProvider {
     const deferrable = !gating && options?.attribution?.deferrable === true;
     const ladder = this.opts.ladder;
     // Framework-swap applies to a gating OR a deferrable call (both ladder paths include it).
-    const swapTargets = (gating || deferrable) && cfg.failureSwap ? cfg.failureSwap : [];
+    // An enforced nature plan supplies the resolved `swapTail` (each a door + concrete model,
+    // already reserve-clamped); the legacy path supplies the config `failureSwap` frameworks
+    // (each taking the caller's tier, clamped per-door in the loop). BOTH ride the SAME
+    // gating||deferrable gate and the SAME loop below — the spec's "reuse verbatim".
+    const swapPositions: ReadonlyArray<{ door: IntelligenceFramework; model?: string }> =
+      gating || deferrable
+        ? enforced
+          ? enforced.swapTail.map((p) => ({ door: p.door as IntelligenceFramework, model: p.modelId }))
+          : (cfg?.failureSwap ?? []).map((fw) => ({ door: fw }))
+        : [];
     // GATING budget: a single hard wall-clock deadline over the whole gating failure path so an
     // awaited gate stays responsive (no stacking rungs). Deferrable calls are not budgeted this way.
     const gatingDeadlineAt = gating && ladder ? Date.now() + ladder.gatingLadderBudgetMs : undefined;
 
     let err: unknown;
     try {
-      const mainResult = await primary.evaluate(prompt, options);
+      const mainResult = await primary.evaluate(prompt, evalOptions);
       this.opts.onResolved?.(component ?? '(none)', framework); // a real answer → auto-resolve any open degradation
       return mainResult;
     } catch (firstErr) {
@@ -1189,7 +1234,7 @@ export class IntelligenceRouter implements IntelligenceProvider {
           const delay = Math.min(b.baseMs * Math.pow(b.factor, attempt), b.ceilingMs);
           const jittered = Math.min(Math.floor(delay * (0.5 + Math.random() * 0.5)), b.maxWaitMs);
           try {
-            const boResult = await primary.evaluate(prompt, { ...(options ?? {}), rateLimitWaitMs: jittered });
+            const boResult = await primary.evaluate(prompt, { ...(evalOptions ?? {}), rateLimitWaitMs: jittered });
             this.opts.onResolved?.(component ?? '(none)', framework); // recovered on backoff → auto-resolve
             return boResult;
           } catch (retryErr) {
@@ -1198,12 +1243,12 @@ export class IntelligenceRouter implements IntelligenceProvider {
           }
         }
       }
-      if (swapTargets.length === 0) {
+      if (swapPositions.length === 0) {
         // RUNG (c) — DEFERRABLE queue: no swap configured, but a deferrable call can WAIT for capacity
         // in the LlmQueue before dropping to its heuristic. gating can never reach here (deferrable =
         // !gating && …) — the D5 queue-skip invariant is structural.
         if (deferrable) {
-          const q = await this.tryDeferrableQueue(primary, prompt, options, component ?? '(none)', framework, category);
+          const q = await this.tryDeferrableQueue(primary, prompt, evalOptions, component ?? '(none)', framework, category);
           if (q.ok) return q.result;
         }
         // Non-gating ⇒ the caller will swallow this into its heuristic — track it (never-silent).
@@ -1228,7 +1273,8 @@ export class IntelligenceRouter implements IntelligenceProvider {
       const budgetMs = isValidMs(this.opts.swapTotalBudgetMs) ? this.opts.swapTotalBudgetMs : undefined;
       const monotonicNow = this.opts.monotonicNow ?? (() => performance.now());
       const swapStartedAt = monotonicNow();
-      for (const target of swapTargets) {
+      for (const t of swapPositions) {
+        const target = t.door;
         // GATING budget: if the awaited gate's total wall-clock budget is consumed, stop swapping
         // and fail closed now (responsiveness over completeness — spec §3a). Deferrable calls have
         // no such deadline (gatingDeadlineAt is undefined for them).
@@ -1247,35 +1293,47 @@ export class IntelligenceRouter implements IntelligenceProvider {
           // otherwise-UNcapped attempt (no per-target cap, global ≤0/unset).
           cap = cap === undefined ? remaining : Math.min(cap, remaining);
         }
-        // SAFETY (S2, R1/R2): a bounded/gating swap onto claude-code that requests
-        // the `capable` tier would resolve to Opus-via-Claude-CLI — the measured-banned
-        // door (81.7% vs 99.1% API). Clamp it down to `balanced` (Sonnet CLI reserve).
-        // Only ever narrows a dangerous fallback; never upgrades/blocks a call.
-        const { model: clampedModel, clamped: modelClamped } = clampClaudeCliSwapModel(
-          target,
-          options?.model,
-        );
-        if (modelClamped) {
-          this.opts.onDegrade?.({
-            component: component ?? '(none)',
-            category,
-            from: framework,
-            to: target,
-            reason:
-              `failure-swap-model-clamp: '${target}' capable→balanced ` +
-              `(Opus-via-Claude-CLI is banned for bounded/gating verdicts — R1/R2)`,
-          });
+        // Model for this swap attempt:
+        //  - NATURE-enforced position (`t.model` set): its OWN concrete model id, already
+        //    reserve-clamped by the resolver (`clampToReserveOnCleanDoor`) — so it always
+        //    overrides the base options.model, and the A1 tier-clamp below is a no-op on it.
+        //  - LEGACY position (`t.model` undefined): the caller's tier, clamped per SAFETY
+        //    (S2, R1/R2) — a bounded/gating swap onto claude-code requesting `capable` would
+        //    resolve to Opus-via-Claude-CLI (the measured-banned door, 81.7% vs 99.1%); clamp
+        //    it down to `balanced` (Sonnet CLI reserve). Only ever narrows; never upgrades.
+        let attemptModel: IntelligenceOptions['model'] | undefined;
+        let overrideModel: boolean;
+        if (t.model !== undefined) {
+          attemptModel = t.model as IntelligenceOptions['model'];
+          overrideModel = true;
+        } else {
+          const clamp = clampClaudeCliSwapModel(target, options?.model);
+          attemptModel = clamp.model;
+          overrideModel = clamp.clamped;
+          if (clamp.clamped) {
+            this.opts.onDegrade?.({
+              component: component ?? '(none)',
+              category,
+              from: framework,
+              to: target,
+              reason:
+                `failure-swap-model-clamp: '${target}' capable→balanced ` +
+                `(Opus-via-Claude-CLI is banned for bounded/gating verdicts — R1/R2)`,
+            });
+          }
         }
         // Pass the cap through as the provider's per-call timeout so the subprocess
         // self-terminates at the bound (no AbortSignal exists on IntelligenceOptions).
+        // Base is `evalOptions` (byte-identical to `options` on the legacy path); an enforced
+        // position's model always overrides it below.
         const attemptOptions: IntelligenceOptions | undefined =
-          cap !== undefined || modelClamped
+          cap !== undefined || overrideModel
             ? {
-                ...(options ?? {}),
+                ...(evalOptions ?? {}),
                 ...(cap !== undefined ? { timeoutMs: cap } : {}),
-                ...(modelClamped ? { model: clampedModel } : {}),
+                ...(overrideModel ? { model: attemptModel } : {}),
               }
-            : options;
+            : evalOptions;
         try {
           // withSwapTimeout keeps the shipped, crash-safe Promise.race pattern
           // (InputGuard precedent): it attaches a settlement handler to EACH input,
@@ -1319,7 +1377,7 @@ export class IntelligenceRouter implements IntelligenceProvider {
       // for capacity in the LlmQueue before dropping to its heuristic (the gentle order, §3b.3). A
       // gating call NEVER reaches here (deferrable = !gating && …) — D5 queue-skip is structural.
       if (deferrable) {
-        const q = await this.tryDeferrableQueue(primary, prompt, options, component ?? '(none)', framework, category);
+        const q = await this.tryDeferrableQueue(primary, prompt, evalOptions, component ?? '(none)', framework, category);
         if (q.ok) return q.result;
       }
       // Every swap target is also down → re-throw so the (gating) caller fails CLOSED,

--- a/tests/unit/nature-routing-resolver.test.ts
+++ b/tests/unit/nature-routing-resolver.test.ts
@@ -330,6 +330,140 @@ describe('evaluate() — nature routing is BYTE-IDENTICAL when unset/off', () =>
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// A2.2 — ENFORCING selection (`dryRun:false`). THE load-bearing new case: the
+// resolved plan ACTUALLY CHANGES the selected (door, model) and the swapTail
+// drives the failure-swap. Spec §Resolver steps 8-9. Every test asserts the
+// selection DIVERGED from today's default-provider path.
+// ─────────────────────────────────────────────────────────────────────────────
+function failingProvider(msg: string): IntelligenceProvider & { calls: Array<IntelligenceOptions | undefined> } {
+  const calls: Array<IntelligenceOptions | undefined> = [];
+  return {
+    calls,
+    async evaluate(_prompt: string, _opts?: IntelligenceOptions): Promise<string> {
+      calls.push(_opts);
+      throw new Error(msg);
+    },
+  };
+}
+
+/** A router whose default door is claude-code, with an explicit set of reachable non-default doors. */
+function makeEnforcingRouter(
+  built: Partial<Record<IntelligenceFramework, IntelligenceProvider>>,
+  opts?: { defaultProvider?: ReturnType<typeof fakeProvider>; defaultFramework?: IntelligenceFramework; onHeuristic?: (c: string, f: string) => void },
+) {
+  const defaultProvider = opts?.defaultProvider ?? fakeProvider('claude-default');
+  const router = new IntelligenceRouter({
+    defaultProvider,
+    defaultFramework: opts?.defaultFramework ?? 'claude-code',
+    resolveConfig: () => undefined, // the common fleet shape — componentFrameworks unconfigured
+    buildProvider: (fw) => built[fw] ?? null,
+    resolveNatureRouting: () => ({ enabled: true, dryRun: false }),
+    onHeuristicFallthrough: opts?.onHeuristic,
+  });
+  return { router, defaultProvider };
+}
+
+describe('evaluate() — A2.2 ENFORCING selection changes (door, model) when dryRun:false', () => {
+  it('ENFORCES the resolved primary door + concrete model — selection DIVERGES from the default', async () => {
+    // SORT: CommitmentSentinel → codex-cli/gpt-5.4-mini (primary) → pi-cli → gemini-api(skip) → claude reserve.
+    const codex = fakeProvider('codex-answer');
+    const pi = fakeProvider('pi-answer');
+    const { router, defaultProvider } = makeEnforcingRouter({ 'codex-cli': codex, 'pi-cli': pi });
+    // The caller asked for the 'capable' TIER on the default door — enforcement must OVERRIDE both.
+    const out = await router.evaluate('p', { model: 'capable', attribution: { component: 'CommitmentSentinel' } });
+    expect(out).toBe('codex-answer'); // answer came from codex — NOT the claude default
+    expect(codex.calls).toHaveLength(1);
+    expect(defaultProvider.calls).toHaveLength(0); // the default (harness) door was NOT used
+    // The resolved CONCRETE model id replaced the caller's 'capable' tier hint (spec step 8).
+    expect(codex.calls[0]?.model).toBe('gpt-5.4-mini');
+  });
+
+  it('the swapTail drives the failure-swap: primary fails → next door+model in the resolved chain serves', async () => {
+    // Same SORT chain, but the primary (codex) FAILS. gating:true opens the swap loop; the resolved
+    // swapTail [pi-cli/gpt-5.5, claude-code/reserve] must take over on its OWN model.
+    const codex = failingProvider('codex-boom');
+    const pi = fakeProvider('pi-answer');
+    const { router } = makeEnforcingRouter({ 'codex-cli': codex, 'pi-cli': pi });
+    const out = await router.evaluate('p', { model: 'capable', attribution: { component: 'CommitmentSentinel', gating: true } });
+    expect(out).toBe('pi-answer'); // swapped down the resolved tail to pi-cli
+    expect(codex.calls).toHaveLength(1); // primary attempted
+    expect(pi.calls).toHaveLength(1); // swapTail served
+    expect(pi.calls[0]?.model).toBe('gpt-5.5'); // pi's OWN resolved model, not the primary's / caller's tier
+  });
+
+  it('a metered primary position is SKIPPED (Increment A) — selection lands on the next CLI door', async () => {
+    // FAST: MessageSentinel → gemini-api (metered, ALWAYS skipped in Increment A) → pi-cli/gpt-5.5.
+    const pi = fakeProvider('pi-answer');
+    const { router, defaultProvider } = makeEnforcingRouter({ 'pi-cli': pi });
+    const out = await router.evaluate('p', { model: 'fast', attribution: { component: 'MessageSentinel' } });
+    expect(out).toBe('pi-answer');
+    expect(defaultProvider.calls).toHaveLength(0);
+    expect(pi.calls[0]?.model).toBe('gpt-5.5'); // gemini-api never reached
+  });
+
+  it('a JUDGE gate landing on claude-code enforces the CONCRETE reserve id (not the caller tier, never Opus)', async () => {
+    // MessagingToneGate JUDGE with ONLY claude-code reachable ⇒ the terminal reserve is the primary.
+    // The caller's 'capable' (→ Opus, the banned door) must be REPLACED by the pinned Sonnet reserve id.
+    const claude = fakeProvider('claude-reserve-answer');
+    const { router } = makeEnforcingRouter({}, { defaultProvider: claude }); // pi/codex unreachable → claude only
+    const out = await router.evaluate('p', { model: 'capable', attribution: { component: 'MessagingToneGate' } });
+    expect(out).toBe('claude-reserve-answer');
+    expect(claude.calls[0]?.model).toBe(CLAUDE_CODE_RESERVE_MODEL_ID); // 'capable' → concrete Sonnet reserve id
+    expect(claude.calls[0]?.model).not.toBe('capable');
+  });
+
+  it('a mapped CRITICAL GATE with NO available door FAILS CLOSED on the real path (throws, never the harness door)', async () => {
+    // MessagingToneGate JUDGE; default door gemini-cli is NOT in the JUDGE chain and every other door is
+    // unreachable ⇒ empty set ⇒ RouterFailClosedError PROPAGATES (the caller applies fail-closed).
+    const gemini = fakeProvider('gemini-default');
+    const { router } = makeEnforcingRouter({}, { defaultProvider: gemini, defaultFramework: 'gemini-cli' });
+    await expect(router.evaluate('p', { attribution: { component: 'MessagingToneGate' } })).rejects.toThrow(RouterFailClosedError);
+    expect(gemini.calls).toHaveLength(0); // NEVER fell through to the default (harness) door
+  });
+
+  it("a low-stakes component with NO available door raises the ordinary heuristic error (never legacy routing)", async () => {
+    // CommitmentSentinel SORT, every chain door unreachable (default gemini-cli not in SORT) ⇒ 'no-route'
+    // ⇒ the ordinary non-gating error the caller catches into its heuristic; NEVER the default door.
+    const onHeuristic = vi.fn();
+    const gemini = fakeProvider('gemini-default');
+    const { router } = makeEnforcingRouter({}, { defaultProvider: gemini, defaultFramework: 'gemini-cli', onHeuristic });
+    await expect(router.evaluate('p', { attribution: { component: 'CommitmentSentinel' } })).rejects.toThrow(/no-route/);
+    expect(gemini.calls).toHaveLength(0); // NEVER routed to the default (harness) door — spec §573-581
+    expect(onHeuristic).toHaveBeenCalledTimes(1); // tracked never-silent
+  });
+
+  it("an UNMAPPED component falls through to today's routing under enforcement (no re-route)", async () => {
+    // TotallyUnknownThing has no nature map row ⇒ 'fall-through' ⇒ legacy path (here: default provider).
+    const { router, defaultProvider } = makeEnforcingRouter({});
+    const opts: IntelligenceOptions = { model: 'capable', attribution: { component: 'TotallyUnknownThing' } };
+    const out = await router.evaluate('p', opts);
+    expect(out).toBe('claude-default');
+    expect(defaultProvider.calls[0]).toBe(opts); // SAME options object — nothing rewritten for an unmapped call
+  });
+
+  it('dryRun:true still OBSERVES only — enforcing changes NOTHING (byte-identical selection)', async () => {
+    // Same reachable doors as the enforcing test, but dryRun:true ⇒ the plan is logged, selection unchanged.
+    const codex = fakeProvider('codex-answer');
+    const defaultProvider = fakeProvider('claude-default');
+    const onPlan = vi.fn();
+    const router = new IntelligenceRouter({
+      defaultProvider,
+      defaultFramework: 'claude-code',
+      resolveConfig: () => undefined,
+      buildProvider: (fw) => (fw === 'codex-cli' ? codex : null),
+      resolveNatureRouting: () => ({ enabled: true, dryRun: true }),
+      onNatureRoutePlan: onPlan,
+    });
+    const opts: IntelligenceOptions = { model: 'capable', attribution: { component: 'CommitmentSentinel' } };
+    const out = await router.evaluate('p', opts);
+    expect(out).toBe('claude-default'); // UNCHANGED — codex NOT used in dryRun
+    expect(codex.calls).toHaveLength(0);
+    expect(defaultProvider.calls[0]).toBe(opts); // SAME options object
+    expect((onPlan.mock.calls[0][0] as NatureRoutePlan).resolution?.outcome).toBe('route'); // …but observed
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // FD4.3 — the resolve-time + config-load CHAIN VALIDATOR (the pure predicate that
 // rejects a banned chain at config LOAD and at RESOLVE time). Spec §221-225 / §Resolver
 // step 3 / FD8 §393. The runtime companion to the build-lint; dev-gated / byte-identical

--- a/upgrades/nature-routing-a2.2-enforcing.eli16.md
+++ b/upgrades/nature-routing-a2.2-enforcing.eli16.md
@@ -1,0 +1,50 @@
+# ELI16 — Nature-Axis Routing, Increment A2.2 (enforcing selection)
+
+## The one-sentence version
+
+We took the nature-routing resolver that has been silently watching ("here's the model+door
+I *would* pick") and wired it so that, when an operator deliberately flips it on, it *actually*
+picks — the resolved model and access door become the real selection, and its fallback list
+drives the real failover.
+
+## Why
+
+Increment A2.1 shipped a resolver: given an internal check, it works out the *kind* of thinking
+the check does (a quick sort, a careful judgment, open-ended writing), walks an ordered list of
+`(door, model)` candidates, and returns the winner plus a fallback tail. But it was a spectator —
+it computed the plan, logged it, and then still did exactly today's routing. That was the honest,
+observe-first step. A2.2 is the step where the plan becomes the decision. Nothing about the
+resolver's *choice* changes; what changes is that the choice is now applied.
+
+## What already exists (and stays exactly as-is)
+
+- **The resolver** (`resolveRoute`) — the pure, side-effect-free fold with four honest outcomes:
+  a resolved route; "fall through to today's routing" (for an unmapped component); "no route —
+  use your own backup heuristic" (for a low-stakes sorter when every door is down); or **throw a
+  distinct fail-closed error** (for a safety gate when every door is down — a gate must fail shut).
+- **The safety clamps** — the deny-by-default allowlist that pins any Claude-door bounded/judgment
+  call to the single sanctioned Sonnet reserve id (so the measured-banned Opus-via-Claude-CLI route
+  can never open), the FD4 chain validators, and A1's always-on degrade clamp. None of these change.
+- **The failure-swap loop** — the existing machinery that, on a runtime failure, tries the next
+  door with per-target timeouts, a total budget, a rate-limit backoff, and honest degrade notes.
+
+## What this adds
+
+When the feature is enabled AND the operator has deliberately turned off dryRun, the resolved plan
+**replaces** today's selection: the primary `(door, model)` becomes the door and model the call runs
+on, and the resolved fallback tail feeds the *existing* failure-swap loop verbatim — each fallback
+position carrying its own concrete model. The four outcomes are honored on this real path: a fail-
+closed gate now actually throws (its caller blocks/denies, never falls open); a low-stakes empty set
+raises the ordinary "use your heuristic" error the caller already catches (never today's category
+routing, so the harness door can't sneak back in); an unmapped component falls through to today's
+routing unchanged. The old one-time "enforcing not yet wired" warning is retired — it is now real.
+
+## The safety promise
+
+When the feature is **off or unset** (the fleet default), the router is **bit-for-bit like today** —
+same door, same model, same options object passed through untouched. The named byte-identical test
+still guards this. In **dryRun** (the dev-agent default) it is still a spectator: it observes and logs,
+changes nothing. Only a deliberate operator flip of `dryRun:false` — after reviewing the dryRun plan —
+ever activates the re-routing. No defaults changed; the fleet stays dark; the metered paid doors stay
+skipped (that is Increment B, still deferred and PIN-gated). This change makes the switch *real*, but
+leaves it *off*.

--- a/upgrades/next/nature-routing-a2.2-enforcing.md
+++ b/upgrades/next/nature-routing-a2.2-enforcing.md
@@ -1,0 +1,61 @@
+---
+user_announcement:
+  - audience: agent-only
+    maturity: experimental
+---
+
+## What Changed
+
+Wired the enforcing half of Nature-Axis Routing (S4 Increment A2.2). The internal LLM router's
+nature resolver — which since A2.1 has only watched, computing and logging the model + access door it
+WOULD pick for a background check — can now actually apply that choice. When the feature is enabled AND
+an operator has deliberately turned dryRun off, the resolved primary (door, model) becomes the real
+selection and the resolver's fallback list drives the real failover, each fallback position carrying its
+own concrete model. The routing switch is now real machinery — but it stays off by default, so nothing
+changes until it is deliberately turned on.
+
+This preserves the maturation ladder A2.1 shipped: DARK on the fleet, and LIVE-in-dryRun on a development
+agent (still observe-and-log only). No default was changed, the enable flag is still omitted so it rides
+the development-agent gate, and the metered paid doors stay skipped (that is Increment B, still deferred
+and PIN-gated). The old one-time "enforcing not yet wired" warning is retired, since it is now real.
+
+The four resolver outcomes are honored on the real path: a resolved route applies the chosen door and
+concrete model; an unmapped component falls through to today's routing untouched; a low-stakes sorter
+with every door down raises the ordinary "use your own heuristic" error its caller already catches (never
+today's category routing, so the Claude harness door can never sneak back in); and a safety gate with
+every door down fails closed with a distinct typed error, so its caller blocks or denies rather than
+falling open. Every existing safety clamp — the deny-by-default Claude-reserve allowlist, the FD4 chain
+validators, A1's always-on degrade clamp — is reused unchanged.
+
+## What to Tell Your User
+
+Nothing proactive — this is an internal, off-by-default plumbing change with no user-facing surface. If a
+user ever asks why a background check might one day run on a different model than the one they talk to, the
+plain answer is: the agent measured which model is best at each kind of internal check, and this lets it
+eventually run the right one for each job. Right now it is off; on a development agent it only watches and
+logs what it would choose. Turning it fully on is a separate, deliberate step the operator takes after
+reviewing what it would do. Nothing the user does changes today, and no setting is required.
+
+## Summary of New Capabilities
+
+- The nature resolver's plan can now become the real selection: when the feature is enabled and dryRun is
+  deliberately turned off, the chosen (door, model) is applied and the fallback tail drives the real
+  failure-swap. Shipped dark on the fleet, dryRun-observe on a development agent.
+- A safety gate with no reachable door now actually fails closed on the enforcing path (distinct typed
+  error → the caller blocks/denies), and a low-stakes sorter with no door degrades to its own heuristic —
+  never to legacy category routing, so the measured-banned Claude harness door cannot re-open.
+- When the feature is off or unset (the fleet default), routing is byte-identical to today — the same
+  options object is passed through untouched. No default was flipped; the metered doors stay skipped.
+
+## Evidence
+
+- tests/unit/nature-routing-resolver.test.ts — new enforcing suite proving selection DIVERGES under
+  dryRun:false: it routes to the resolved primary door with its concrete model (the default provider is
+  NOT used); the swapTail drives the failure-swap when the primary fails (the next door serves on its OWN
+  model); a metered primary is skipped; a JUDGE gate on claude-code enforces the concrete Sonnet reserve
+  id (not the caller's `capable` tier, never Opus); a critical gate with no door throws RouterFailClosedError
+  on the real path (never the harness door); a low-stakes empty set raises the ordinary heuristic error
+  (never legacy routing); an unmapped component falls through; and dryRun:true still observes only.
+- Byte-identical-when-off and dryRun-observes tests remain green; A1 clamp, FD5b injection, FD4/FD4.2
+  lints, and the llm-routing-nature / injection-exposure ratchets all stay green; tsc --noEmit clean.
+- Spec: docs/specs/nature-axis-routing.md — §Resolver steps 8-9, FD9 (the A1/A2 increment split).

--- a/upgrades/side-effects/nature-routing-a2.2-enforcing.md
+++ b/upgrades/side-effects/nature-routing-a2.2-enforcing.md
@@ -1,0 +1,142 @@
+# Side-Effects Review — Nature-Axis Routing, Increment A2.2 (enforcing selection)
+
+**Spec:** docs/specs/nature-axis-routing.md (status: **converged — pending operator approval**;
+`review-convergence` tag, NOT `approved:true` — the operator's step). **Tier-1** change: the enforcing
+wiring for FD9's Increment A2, riding the same dev-gated dark / dryRun-defaulted ladder A2.1 shipped on.
+**Parent standards:** "Structure > Willpower", "No Silent Degradation to Brittle Fallback", benchmark-
+cited routing (INSTAR-Bench v3, rules R1/R2), the Maturation Path (dev-gated dark; the operator's
+deliberate `dryRun:false` flip is the only activation), Migration Parity (no new config, no default flip).
+
+**Date:** 2026-07-05
+**Author:** Echo (build hand, topic 29723)
+**Second-pass reviewer:** required (touches routing-of-safety-gates) — see §Second-pass.
+
+**Files:** src/core/IntelligenceRouter.ts, tests/unit/nature-routing-resolver.test.ts,
+upgrades/nature-routing-a2.2-enforcing.eli16.md, upgrades/side-effects/nature-routing-a2.2-enforcing.md,
+upgrades/next/nature-routing-a2.2-enforcing.md.
+
+## Summary of the change
+
+`IntelligenceRouter.evaluate()`'s nature block previously OBSERVED (logged the resolved plan) and then
+fell through to today's selection even with `dryRun:false`, guarded by a one-time "enforcing not yet
+wired" warning. This change makes `dryRun:false` ACTUALLY enforce (spec §Resolver steps 8-9): on outcome
+`route` the resolved primary `(door, model)` replaces `resolveFramework()`'s door + the caller's tier,
+and the resolved `swapTail` feeds the EXISTING failure-swap loop (each tail position carrying its own
+concrete model). On `no-route` it raises the ordinary non-gating heuristic error (never legacy routing);
+on a critical-gate empty set it re-throws `RouterFailClosedError`; on `fall-through` (unmapped) it uses
+today's routing untouched. The obsolete warning method + field are removed.
+
+## Decision-point inventory
+
+- `IntelligenceRouter.evaluate() — nature block` — modify — was observe-only; now, when
+  `enabled && !dryRun`, applies the resolved plan.
+- `IntelligenceRouter.evaluate() — framework/model selection` — modify — `framework`/`evalOptions`
+  now derive from the enforced primary when a plan is enforced, else today's category routing.
+- `IntelligenceRouter.evaluate() — failure-swap loop` — pass-through/extend — same loop, now driven by
+  either the resolved `swapTail` (per-position concrete model) or today's `cfg.failureSwap` frameworks.
+- `warnNatureEnforceNotWired()` + `warnedNatureEnforceNotWired` — remove — the no-op is now real wiring.
+- `resolveRoute` / `clampToReserveOnCleanDoor` / `mergeNatureRoutingChains` / the FD4/FD4.2 validators —
+  pass-through — UNCHANGED (A2.2 consumes them; it does not weaken them).
+
+---
+
+## 1. Over-block
+
+The only "block" surface is the critical-gate fail-closed throw. On the real path a mapped FD6 critical
+gate whose chain has NO available door throws `RouterFailClosedError` → the caller blocks/denies. This
+can only fire when EVERY door in the gate's chain is unreachable (metered doors are skipped in Increment
+A, so realistically all CLI doors down). That is the correct fail-closed direction for a safety gate; it
+is not an over-block of legitimate traffic — a reachable door always routes. In dryRun the same throw is
+swallowed (observe-only), so the enforcing throw only ever happens on the operator's deliberate flip.
+
+---
+
+## 2. Under-block
+
+`no-route` (low-stakes empty set) deliberately does NOT block — it raises the ordinary non-gating error
+the caller catches into its heuristic. This is spec-mandated (§573-581): a low-stakes sorter degrades to
+its own heuristic, exactly as it does today when its provider is down. It is NOT a safety gate, so not
+blocking is correct. An UNEXPECTED (non-`RouterFailClosedError`) resolver error also does not block — it
+is recorded and falls through to today's routing (fail-safe), because the pure fold only throws the typed
+error by design; a different throw is a bug and must not break routing.
+
+---
+
+## 3. Silent failure / silent degradation
+
+No silent path. `no-route` calls `onHeuristicFallthrough` before throwing (never-silent tracking). Every
+swap attempt emits an `onDegrade` note; a successful swap emits the served-by note; a fail-closed gate
+throws a distinct typed error the caller cannot mistake for a model failure. The enforcing primary always
+routes through `resolveProvider` (a real provider), never a heuristic pretending to be an answer. The
+retired warning was itself the only "honest no-op" scaffolding; removing it removes a now-false statement.
+
+---
+
+## 4. Byte-identical-when-off (THE safety case)
+
+When `sessions.natureRouting` is absent OR `enabled:false` (the fleet default), the nature block is
+skipped entirely: `enforced` stays undefined, `enforcedNoRoute` false, and `evalOptions` remains the SAME
+`options` object reference. Selection is bit-for-bit today's. In dryRun the plan is logged but `enforced`
+stays undefined (only set when `!dryRun`), so selection is still unchanged. Asserted by the named test
+`natureRouting UNSET ⇒ selection unchanged` (same options object) and the FD4.3 banned-chain-when-off
+test, both green. A new test (`dryRun:true still OBSERVES only`) proves enforcing changes nothing in
+dryRun even with a reachable alternate door.
+
+---
+
+## 5. Model-selection correctness (the concrete-id path)
+
+The resolved primary's CONCRETE model id (e.g. `gpt-5.4-mini`, `claude-sonnet-4-6`) is placed on
+`options.model` and rides verbatim to the provider — the CLI adapters (`resolveCliFlag` /
+`resolveCliModelFlag`) return a concrete id as-is and only map the three tier tokens, so a concrete id is
+honored. The claude-code reserve is already reserve-clamped by the resolver, so the caller's `capable`
+(→ Opus, the banned door) is replaced by the pinned Sonnet reserve id — asserted by the enforcing test
+`a JUDGE gate landing on claude-code enforces the CONCRETE reserve id`. Metered doors remain skipped
+(Increment A) — asserted by `a metered primary position is SKIPPED`.
+
+---
+
+## 6. Blast radius
+
+- **Scope of the real path:** only when `enabled && dryRun:false` — i.e. an operator's deliberate flip
+  after the dryRun soak. Dev agents default to dryRun; the fleet is dark. No default is changed.
+- **A1 / A2.1 untouched:** `clampClaudeCliSwapModel` (A1 tier clamp), `clampToReserveOnCleanDoor`,
+  `resolveRoute`, the FD4/FD4.2 validators are consumed as-is, not modified. All their tests stay green.
+- **The failure-swap loop:** reused verbatim, gated on `gating||deferrable` exactly as today; nature
+  positions ride the same per-target timeout / total-budget / backoff / degrade machinery. A legacy
+  swap (no nature plan) is byte-identical (base is `evalOptions`, which === `options` off the nature
+  path; no reference-equality assertion in the swap tests regresses).
+- **`cfg` nullability:** the `if (!cfg) return default` short-circuit now lives in the non-enforced
+  branch; downstream `cfg?.fallback` / `cfg?.failureSwap` use optional chaining so an enforced plan with
+  a null `cfg` (the common fleet shape) is safe. The enforced primary door is always reachable (the
+  resolver only emits reachable CLI doors), so the `!primary` degrade path is not reached under
+  enforcement.
+
+## Explicitly DEFERRED (tracked remainder — NOT dropped)
+
+- **FD6 critical-gate drift NOTICE + baseline** — depends on the durable `state/nature-routing-baseline.json`
+  store + N=3 debounce + aggregation, which the spec classifies as an "orthogonal surface AROUND the fold"
+  and whose PIN-approved baseline MUTATION is explicitly operator-only / out of this scope. The
+  `onNatureRoutePlan` hook already records the resolved plan for a future drift tracker to consume.
+- **R6 doc-tree refuse-to-author branch (FD5c)** — DORMANT in Increment A: no component in the shipped
+  nature map carries `claudeBanned`, and R6 chains are authored off-Claude, so a claudeBanned empty set
+  already resolves to `no-route` → the caller's heuristic (which for `CartographerSweepEngine` IS
+  refuse-rather-than-Claude). A dedicated refuse-to-author router branch is a separate concern.
+- **Increment B** — metered live routing + FD12 money/PIN go-live. Untouched; `metered.goLive` stays
+  false and unreferenced by this change.
+- **The durable audit log + `GET /intelligence/routing` enforced-diff surface** — the read surfaces are a
+  tracked follow-up; enforcement does not require them.
+
+## Second-pass review (Phase 5 — required: routes safety GATES)
+
+This change makes safety-gate routing REAL, so it triggers the high-risk second pass. Focus:
+(a) can the banned Opus-via-CLI route open under enforcement? — No: the resolved position is already
+reserve-clamped, and the enforced model is the concrete Sonnet reserve id, asserted by the JUDGE-reserve
+enforcing test. (b) can a critical gate fail OPEN under enforcement? — No: the empty-set critical gate
+re-throws `RouterFailClosedError` on the real path (asserted `rejects.toThrow(RouterFailClosedError)`,
+default provider NOT called), and `no-route` is reserved for non-critical low-stakes components only.
+(c) is "off" still truly inert? — Yes, the byte-identical-when-off tests remain green and a new
+dryRun-observes-only enforcing test proves the flip is the sole activation. **Reviewer focus verdict:
+the enforcing path preserves every safety invariant the resolver already guaranteed; the only new risk
+is the model-application boundary (concrete id on `options.model`), which is covered by the concrete-id
+enforcing tests and the pre-existing adapter tier-or-id resolution.**


### PR DESCRIPTION
## ELI16 — enforcing nature-axis selection

We took the internal LLM router's nature resolver — which since A2.1 has only *watched* (computing and logging which model + access door it *would* pick for a background check, then still doing today's routing) — and wired it so the plan can become the real decision. When the feature is enabled AND an operator deliberately turns dryRun off, the resolved model + door become the actual selection and the resolver's fallback list drives the real failover, each fallback carrying its own concrete model. It stays **off by default**: the fleet is dark, dev agents run in dryRun-observe, and nothing changes until the operator flips it. A safety gate with no reachable door now actually fails closed; a low-stakes sorter with no door falls back to its own heuristic (never today's category routing, so the measured-banned Claude harness door can't sneak back in). When off or unset, routing is bit-for-bit identical to today.

## S4 A2.2 — enforcing nature-axis selection

Wires the enforcing half of FD9 Increment A2 for nature-axis routing. Since A2.1, `IntelligenceRouter.evaluate()` computed and logged the resolved route plan, then still did today's routing (an honest observe-only no-op even at `dryRun:false`). **A2.2 makes the plan the decision:** when `sessions.natureRouting.enabled && dryRun === false`, the resolved plan REPLACES today's selection (spec §Resolver steps 8-9).

### What it does
- **Primary applied:** the resolved primary `(door, model)` becomes the framework + the concrete model on `options.model` (replacing `resolveFramework()` + the caller's tier). The claude-code reserve is already pinned to the concrete Sonnet id by the resolver — so a `capable` (Opus) request lands on the sanctioned reserve, never the banned Opus-via-CLI door.
- **swapTail drives the failover:** the resolved `swapTail` feeds the **existing** failure-swap loop verbatim (gated on `gating||deferrable` exactly as today), each tail position carrying its own concrete model. No parallel swap mechanism.
- **Four outcomes honored on the real path:** `route` applies; `no-route` (low-stakes empty set) raises the ordinary non-gating heuristic error the caller already catches — **never legacy routing**, so the harness door can't re-open; a critical-gate empty set re-throws `RouterFailClosedError` (caller fails closed); `fall-through` (unmapped) uses today's routing untouched.
- The obsolete `warnNatureEnforceNotWired` no-op + its field are removed — it is now real machinery.

### Stays dev-gated dark + dryRun-defaulted
Changes **no defaults**: `dryRun` stays true, the enable flag stays omitted (rides `resolveDevAgentGate`), the fleet stays dark, metered doors stay skipped (Increment B deferred; `metered.goLive` untouched). **Byte-identical when off/unset** is preserved and asserted by the named test (same `options` object passed through). A1's clamp, `resolveRoute`, `clampToReserveOnCleanDoor`, and the FD4/FD4.2 validators are consumed unchanged. Only an operator's deliberate `dryRun:false` flip — after reviewing the dryRun plan — ever activates re-routing.

### Deferred (tracked, not dropped)
- **FD6 critical-gate drift notice + baseline** — depends on the operator-only `state/nature-routing-baseline.json` store + PIN-approved mutation (an "orthogonal surface AROUND the fold" per FD9; out of A2.2 scope). `onNatureRoutePlan` already records the plan for a future drift tracker.
- **R6 doc-tree refuse-to-author branch** — DORMANT in Increment A: no mapped component carries `claudeBanned`, and its chains are off-Claude, so an empty set already resolves to `no-route` → the caller's own refuse-rather-than-Claude heuristic.

### Tests
New enforcing suite in `tests/unit/nature-routing-resolver.test.ts` proves selection **diverges** under `dryRun:false`:
- `ENFORCES the resolved primary door + concrete model — selection DIVERGES from the default`
- `the swapTail drives the failure-swap: primary fails → next door+model in the resolved chain serves`
- `a metered primary position is SKIPPED (Increment A)`
- `a JUDGE gate landing on claude-code enforces the CONCRETE reserve id (not the caller tier, never Opus)`
- `a mapped CRITICAL GATE with NO available door FAILS CLOSED on the real path (throws, never the harness door)`
- `a low-stakes component with NO available door raises the ordinary heuristic error (never legacy routing)`
- `an UNMAPPED component falls through to today's routing under enforcement`
- `dryRun:true still OBSERVES only — enforcing changes NOTHING (byte-identical selection)`

Full unit suite green; `tsc --noEmit` clean; lint (incl. `lint-nature-chains`, `lint-no-opus-claude-cli-gating`) clean. Rebased onto latest main (includes #1396/#1397; no conflicts — they don't touch `IntelligenceRouter.ts`).

**Spec:** `docs/specs/nature-axis-routing.md` (status: converged — pending operator approval; **not** `approved:true`). Tier 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ci: refresh eli16 description check -->
