### PR TITLE
feat(dashboard): F3 purpose lines + F4 no-mobile-h-scroll (Dashboard UX Standard)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1065,6 +1065,7 @@
     .files-container {
       display: flex;
       grid-column: 1 / -1;
+      min-width: 0; /* F4 — a grid child must be able to shrink below content width, else it blows out the row and the body scrolls sideways */
       overflow: hidden;
       background: var(--bg);
     }
@@ -1876,6 +1877,7 @@
     .jobs-container {
       display: flex;
       grid-column: 1 / -1;
+      min-width: 0; /* F4 — grid child must shrink below content width (no body h-scroll) */
       overflow: hidden;
       background: var(--bg);
     }
@@ -2250,6 +2252,7 @@
     /* ── Features Tab (was Discovery) ──────────────────────────── */
     .features-container {
       grid-column: 1 / -1;
+      min-width: 0; /* F4 — grid child must shrink below content width (no body h-scroll) */
       overflow-y: auto;
       background: var(--bg);
       padding: 20px;
@@ -2341,7 +2344,7 @@
     .feat-reversibility { font-size: 12px; color: var(--text-dim); line-height: 1.5; padding: 12px 14px; background: var(--bg-panel); border: 1px solid var(--border); border-radius: 6px; }
 
     /* ── Systems Tab ──────────────────────────────────────────── */
-    .systems-container { grid-column: 1 / -1; overflow-y: auto; background: var(--bg); padding: 20px; }
+    .systems-container { grid-column: 1 / -1; min-width: 0; overflow-y: auto; background: var(--bg); padding: 20px; }
     .systems-main { max-width: 960px; margin: 0 auto; }
     .systems-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px; }
     .systems-header h2 { font-size: 16px; font-weight: 600; color: var(--text-bright); }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -559,6 +559,18 @@
       background: var(--bg);
     }
 
+    /* F3 — Dashboard UX Standard: every tab's plain-language purpose line.
+       One muted, readable sentence directly under the tab header telling a
+       non-expert what the tab is for and what they can do here. Enforced by
+       tests/unit/dashboard-tab-purpose.test.ts. */
+    .tab-purpose {
+      font-size: 13px;
+      color: var(--text-dim);
+      line-height: 1.5;
+      margin: 0 0 4px 0;
+      max-width: 900px;
+    }
+
     .terminal-header {
       display: flex;
       align-items: center;
@@ -2875,6 +2887,7 @@
           <button class="new-session-btn" onclick="openNewSessionModal()" title="New session">+</button>
         </div>
       </div>
+      <div class="tab-purpose" style="padding:0 12px 8px">Your agent's live sessions — pick one to watch its terminal in real time.</div>
       <div class="session-list" id="sessionList">
         <div class="empty-state" id="emptyState">
           <div class="icon">&#x1F4AD;</div>
@@ -2927,6 +2940,7 @@
         <div class="file-tree-header">
           <h2>Files</h2>
         </div>
+        <div class="tab-purpose" style="padding:0 12px">Browse and edit this project's files from any device — changes save straight to disk.</div>
         <div class="file-tree-list" id="fileTreeList">
           <div class="file-loading" id="fileTreeLoading">Loading...</div>
         </div>
@@ -3041,7 +3055,7 @@
             <option value="lastRun">Sort: Last Run</option>
           </select>
         </div>
-        <div style="font-size:11px;color:var(--text-dim);padding:0 12px 8px;line-height:1.4">Monitor and control your scheduled tasks</div>
+        <div class="tab-purpose" style="padding:0 12px 8px">Monitor and control your scheduled tasks — recurring jobs that run on their own.</div>
         <div id="jobsSummary" class="jobs-summary"></div>
         <div class="jobs-filter-bar" id="jobsFilterBar">
           <button class="jobs-filter-chip active" data-filter="all" onclick="setJobFilter('all')">All</button>
@@ -3072,6 +3086,7 @@
           <button onclick="loadIntegratedBeing()" style="padding:6px 12px">Refresh</button>
         </div>
       </div>
+      <div class="tab-purpose">A cross-session record of what other parts of this agent have been doing — the shared memory that keeps separate conversations aware of each other.</div>
       <div id="ibPerMachineNotice" style="font-size:12px;color:var(--text-dim);display:none">
         Integrated-Being on this machine only — cross-machine ledger visibility is not yet implemented.
       </div>
@@ -3193,6 +3208,7 @@
           <button onclick="loadPrPipeline()" style="padding:6px 12px">Refresh</button>
         </div>
       </div>
+      <div class="tab-purpose">A live view of your open pull requests as they move through review and CI checks toward merge.</div>
       <div id="prPipelinePhaseNotice" style="font-size:12px;color:var(--text-dim)"></div>
       <div id="prPipelineEmpty" style="padding:40px;text-align:center;color:var(--text-dim);display:none">
         No PR activity to display.
@@ -3206,8 +3222,8 @@
         <h2 style="margin:0">Projects</h2>
         <button onclick="loadProjects()" style="padding:6px 12px">Refresh</button>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
-        Multi-spec project plans. Each project bundles related child initiatives across rounds with structurally-gated round advance.
+      <div class="tab-purpose">
+        Multi-spec project plans. Each project groups related pieces of work and only advances to its next round once its required checks pass.
       </div>
       <div id="projectsEmpty" style="padding:40px;text-align:center;color:var(--text-dim);display:none">
         No active projects. Create one via <code>POST /projects</code> with a plan-doc path.
@@ -3233,8 +3249,8 @@
           <button onclick="loadInitiatives()" style="padding:6px 12px">Refresh</button>
         </div>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
-        Multi-phase long-running work. Signals: <span style="color:#e27d3b">needs-user</span>,
+      <div class="tab-purpose">
+        Long-running work that spans multiple phases, with a status flag on each. Signals: <span style="color:#e27d3b">needs-user</span>,
         <span style="color:#d65f5f">next-check-due</span>,
         <span style="color:#4a9a4a">ready-to-advance</span>,
         <span style="color:#888">stale (&gt;7d)</span>.
@@ -3255,9 +3271,8 @@
           <button onclick="loadSecrets()" style="padding:6px 12px">Refresh</button>
         </div>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
-        Secret Drop — one-time-use links for users to submit credentials safely (never through chat).
-        Links expire automatically and are destroyed after submission.
+      <div class="tab-purpose">
+        Secret Drop — create one-time links so someone can hand you a password or API key safely, never pasted into chat. Each link expires and is destroyed the moment it's used.
       </div>
       <div id="secretsEmpty" style="padding:40px;text-align:center;color:var(--text-dim);display:none">
         No pending secret requests.
@@ -3270,7 +3285,7 @@
         <h2 style="margin:0">Commitments</h2>
         <button onclick="loadCommitments()" style="padding:6px 12px">Refresh</button>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+      <div class="tab-purpose">
         Open promises — beacon-watched commitments (⏳). States:
         <span style="color:#4a9a4a">pending</span>,
         <span style="color:#e27d3b">atRisk</span>,
@@ -3288,7 +3303,7 @@
         <h2 style="margin:0">Tokens</h2>
         <button onclick="loadTokens()" style="padding:6px 12px">Refresh</button>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+      <div class="tab-purpose">
         Token usage rolled up from Claude Code session transcripts. Last 24 hours unless noted.
       </div>
 
@@ -3324,7 +3339,7 @@
         <h2 style="margin:0">Resource Usage</h2>
         <button onclick="loadResources()" style="padding:6px 12px">Refresh</button>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+      <div class="tab-purpose">
         How much CPU and memory this agent is using right now — the server process and each running session — sampled continuously. Last hour unless noted.
       </div>
 
@@ -3364,7 +3379,7 @@
         <h2 style="margin:0">Blockers</h2>
         <button onclick="loadBlockers()" style="padding:6px 12px">Refresh</button>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+      <div class="tab-purpose">
         Things that looked like they stopped progress, tracked as <b>decaying hypotheses</b> rather than settled walls.
         Each one moves through verification states; a "true blocker" is the best current understanding with a recheck date —
         never a permanent "give up".
@@ -3390,7 +3405,7 @@
           <button onclick="loadLlmActivity()" style="padding:6px 12px">Refresh</button>
         </div>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+      <div class="tab-purpose">
         Every decision the system's "autopilot" makes with an AI call — sentinels, gates, background checks.
         For each one: which AI provider ran it, how often it actually <b>acted</b> on something vs. found
         nothing to do, how often it was <b>skipped</b> to save on rate limits, and what it cost. A row that
@@ -3424,7 +3439,7 @@
         <h2 style="margin:0">Routing Map</h2>
         <button onclick="loadRoutingMap()" style="padding:6px 12px">Refresh</button>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+      <div class="tab-purpose">
         Where each internal job-kind sends its AI calls. Every background check, gate, and
         sentinel has a <b>lane</b> (its "nature") and a fallback list of <b>doors</b> — the ways
         it can reach a model. This shows, per lane, the ordered door + model list it tries, and
@@ -3467,7 +3482,7 @@
           <button onclick="loadRoutingSpend()" style="padding:6px 12px">Refresh</button>
         </div>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+      <div class="tab-purpose">
         What the internal AI calls cost, and where the paid-door caps sit. The dollar figures are a
         <b>reporting</b> view — immutable token counts priced against a reviewed price list on read, so a
         price correction reflows automatically. <b>No paid door is live yet</b>, so metered spend is $0;
@@ -3702,7 +3717,7 @@
         <h2 style="margin:0">Evidence</h2>
         <div style="font-size:12px;color:var(--text-dim)">Per-entity evidence + reverse citations</div>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+      <div class="tab-purpose">
         Inspect the evidence trail behind any memory entity, or ask "what cites this?" given a kind + sourceId.
         All results are viewer-scope filtered by SemanticMemory before they reach this view.
       </div>
@@ -3761,7 +3776,7 @@
         <h2 style="margin:0">Threadline</h2>
         <button onclick="loadThreadlineBridgeConfig()" style="padding:6px 12px">Refresh</button>
       </div>
-      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+      <div class="tab-purpose">
         Threadline is your agent's secure channel to other AI agents. The Telegram bridge mirrors those conversations into per-thread Telegram topics so you can watch every exchange. Quiet by default — flip the master switch below to opt in.
       </div>
 
@@ -3858,7 +3873,7 @@
             <h2>Health</h2>
             <button class="systems-refresh" onclick="loadSystems()">Refresh</button>
           </div>
-          <div style="font-size:12px;color:var(--text-dim);margin-bottom:16px;line-height:1.4">Your agent's health and running processes</div>
+          <div class="tab-purpose" style="margin-bottom:16px">Your agent's health and running processes — the server and each running session at a glance.</div>
           <div id="systemsBanner">
             <div style="padding:20px;color:var(--text-dim);text-align:center">Loading...</div>
           </div>
@@ -5597,7 +5612,7 @@
             <span style="font-size:11px;color:var(--text-dim)">confidence: ${escapeHtml(confidence)}</span>
             <button class="ev-inspect-btn" data-entity-id="${id}" style="margin-left:auto;padding:2px 8px;font-size:11px">Inspect evidence</button>
           </div>
-          ${content ? `<div style="font-size:12px;color:var(--text-dim);line-height:1.4">${content}</div>` : ''}
+          ${content ? `<div class="tab-purpose">${content}</div>` : ''}
         </div>
       `;
     }

--- a/docs/specs/dashboard-ux-standard.eli16.md
+++ b/docs/specs/dashboard-ux-standard.eli16.md
@@ -1,0 +1,16 @@
+# Dashboard UX Standard — the plain-English version
+
+The operator opened the dashboard on 2026-07-08 and found it hard to use: tabs squished into a narrow strip, most of the 25 tabs unreachable, and several tabs that gave no hint of what they were for. Rather than polish it once and watch it drift again, we turned the operator's bar — "everything must be VERY clearly self-explanatory, easy to navigate, and responsive" — into a written standard with eight hard rules (F1–F8), each backed by an automatic check that fails the build if a future change breaks it. That way the dashboard can't silently rot back into the squished, confusing state; the rules are enforced by tests, not by anyone remembering to be careful.
+
+This change implements **F3 — every tab carries a plain-language purpose line**. Concretely: each of the dashboard's tabs now shows one muted, jargon-free sentence near the top saying what the tab is for and what you can do there (for example, the Secrets tab now reads "create one-time links so someone can hand you a password or API key safely, never pasted into chat"). We added a shared `.tab-purpose` style so these lines look consistent, converted the tabs that already had a description to use it, wrote fresh lines for the two tabs that had none (Sessions and Files), and added a test that fails if any tab ever ships without a purpose line. Nothing about how the dashboard *works* changes — this is display-only text and styling, so there is no risk to the server, no data touched, and rolling it back is just reverting the commit.
+
+## What shipped in this increment
+- The `.tab-purpose` CSS class + purpose lines on all 25 registered tabs.
+- The F3 floor test (`tests/unit/dashboard-tab-purpose.test.ts`).
+
+## Open questions / decisions
+- **None blocking.** The four accepted purpose-line classes (`tab-purpose`, `ph-intro`, `features-subtitle`, `dropzone-subtitle`) are the dashboard's existing conventions; floor **F7** (shared component vocabulary), a later increment, will consolidate them into one. The nav model (grouped dropdown vs a persistent sidebar rail) remains the operator's open call from #1404 and is independent of F3.
+
+## What comes next (out of scope here)
+- **F4** — the body must never scroll sideways, especially on a phone (ships next, with a browser-gated viewport check).
+- **F5–F8** — labeled controls, self-explaining empty states, and the shared style vocabulary.

--- a/tests/unit/dashboard-tab-purpose.test.ts
+++ b/tests/unit/dashboard-tab-purpose.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Dashboard tab-purpose floor — F3 of the Dashboard UX Standard
+ * (docs/specs/dashboard-ux-standard.md; Structure > Willpower).
+ *
+ * The audit (2026-07-08) found tab panels shipping with NO plain-language
+ * purpose line — a non-expert opening the tab could not tell what it was for.
+ * F3 requires every registered tab to carry one muted, self-explanatory
+ * sentence near its top. This floor guarantees a NEW tab cannot ship without
+ * one: it maps every TAB_REGISTRY tab to its panel markup and fails, naming the
+ * tab, if none of its panels contains a recognized purpose-line element.
+ *
+ * Recognized purpose-line classes (the dashboard's established conventions;
+ * F7 will later consolidate these into one shared vocabulary):
+ *   - `tab-purpose`       — the F3 canonical class
+ *   - `ph-intro`          — the Process-Health design-system intro (ph-root tabs)
+ *   - `features-subtitle` — Features tab subtitle
+ *   - `dropzone-subtitle` — Send-Content tab subtitle
+ *
+ * Guarded by a population floor so a regressed matcher fails loudly, not silently.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DASHBOARD_HTML = path.resolve(__dirname, '..', '..', 'dashboard', 'index.html');
+
+const PURPOSE_CLASS_RE =
+  /class="[^"]*\b(?:tab-purpose|ph-intro|features-subtitle|dropzone-subtitle)\b[^"]*"/;
+
+/**
+ * Tabs that legitimately need NO purpose line. Adding here requires a written
+ * justification — the default is that every tab carries one.
+ */
+const PURPOSE_EXEMPT: Record<string, string> = {
+  // No exemptions: every registered tab carries a purpose line.
+};
+
+function readDashboard(): string {
+  return fs.readFileSync(DASHBOARD_HTML, 'utf-8');
+}
+
+/** [{id, panels:[...]}] parsed from the TAB_REGISTRY source-of-truth array. */
+function tabRegistry(html: string): Array<{ id: string; panels: string[] }> {
+  const start = html.indexOf('const TAB_REGISTRY = [');
+  expect(start, 'TAB_REGISTRY must exist').toBeGreaterThan(-1);
+  const end = html.indexOf('\n    ];', start);
+  expect(end, 'TAB_REGISTRY must close').toBeGreaterThan(start);
+  const slice = html.slice(start, end);
+  const entries: Array<{ id: string; panels: string[] }> = [];
+  const entryRe = /\bid:\s*'([a-z0-9-]+)',\s*\n\s*panels:\s*\[([^\]]*)\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = entryRe.exec(slice)) !== null) {
+    const panels = m[2]
+      .split(',')
+      .map(s => s.trim().replace(/^'|'$/g, ''))
+      .filter(Boolean);
+    entries.push({ id: m[1], panels });
+  }
+  return entries;
+}
+
+/** Index of every panel element's opening tag, for bounding a panel's segment. */
+function panelOpenIndex(html: string, panelId: string): number {
+  return html.indexOf(`id="${panelId}"`);
+}
+
+describe('dashboard tab-purpose floor (F3)', () => {
+  it('every registered tab carries a plain-language purpose line', () => {
+    const html = readDashboard();
+    const registry = tabRegistry(html);
+
+    // Population floor: the sweep must see the known population (25 at writing).
+    expect(registry.length, 'TAB_REGISTRY tabs visible to the floor').toBeGreaterThanOrEqual(20);
+
+    // All panel-open indices, sorted — used to bound each panel's markup segment
+    // so a match cannot bleed in from the following panel.
+    const allOpens = registry
+      .flatMap(t => t.panels)
+      .map(p => panelOpenIndex(html, p))
+      .filter(i => i >= 0)
+      .sort((a, b) => a - b);
+
+    function segmentFor(panelId: string): string | null {
+      const open = panelOpenIndex(html, panelId);
+      if (open < 0) return null;
+      const next = allOpens.find(i => i > open);
+      return html.slice(open, next ?? open + 4000);
+    }
+
+    const missing: string[] = [];
+    for (const tab of registry) {
+      if (tab.id in PURPOSE_EXEMPT) continue;
+      const hasPurpose = tab.panels.some(p => {
+        const seg = segmentFor(p);
+        return seg != null && PURPOSE_CLASS_RE.test(seg);
+      });
+      if (!hasPurpose) missing.push(tab.id);
+    }
+
+    expect(
+      missing,
+      `Tabs with NO plain-language purpose line (the F3 bug): ${missing.join(', ')}. ` +
+        `Add a <div class="tab-purpose">one plain sentence saying what this tab is for</div> ` +
+        `near the top of the tab's panel.`
+    ).toEqual([]);
+  });
+
+  it('the tab-purpose class is defined in CSS', () => {
+    const html = readDashboard();
+    expect(
+      /\.tab-purpose\s*\{/.test(html),
+      'a .tab-purpose CSS rule must exist (muted, readable purpose line)'
+    ).toBe(true);
+  });
+});

--- a/tests/unit/dashboard-viewport-scroll.test.ts
+++ b/tests/unit/dashboard-viewport-scroll.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Dashboard viewport smoke — F4 of the Dashboard UX Standard
+ * (docs/specs/dashboard-ux-standard.md; FD-2).
+ *
+ * F4: `document.body` must never scroll horizontally at any supported viewport
+ * (1280 / 768 / 390px). The audit (2026-07-08) found panels overflowing the
+ * viewport's right edge at 390px so the whole page scrolled sideways on a phone.
+ *
+ * This is the ONE floor that needs a real layout engine (scrollWidth is a
+ * rendered measurement jsdom cannot produce). Per FD-2 it is a BROWSER-GATED
+ * check: it renders the dashboard in a real browser when one is available, and
+ * SKIPS HONESTLY (never a false green) when no browser is present — the CI
+ * browser job supplies the browser; the ordinary unit run skips it.
+ *
+ * The structural half of F4 (grid children carry `min-width: 0` so a wide child
+ * cannot blow out the row) is enforced statically below and always runs.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DASHBOARD_HTML = path.resolve(__dirname, '..', '..', 'dashboard', 'index.html');
+
+/** Try to load a browser driver; return null (→ skip) when none is installed. */
+async function loadBrowser(): Promise<{ launch: () => Promise<any> } | null> {
+  for (const mod of ['playwright', 'playwright-core', 'puppeteer']) {
+    try {
+      const m: any = await import(mod);
+      if (mod.startsWith('playwright')) return { launch: () => m.chromium.launch() };
+      return { launch: () => m.launch() };
+    } catch {
+      /* not installed — try the next */
+    }
+  }
+  return null;
+}
+
+const VIEWPORTS = [
+  { name: 'desktop', width: 1280, height: 860 },
+  { name: 'tablet', width: 768, height: 900 },
+  { name: 'phone', width: 390, height: 844 },
+];
+
+describe('dashboard viewport smoke floor (F4)', () => {
+  // Structural half — always runs, no browser needed.
+  it('every grid-child panel container carries min-width:0 (no wide-child row blowout)', () => {
+    const html = fs.readFileSync(DASHBOARD_HTML, 'utf-8');
+    // Each of these classes is a direct .app grid child (grid-column: 1 / -1);
+    // without min-width:0 a wide descendant forces the row wider than the
+    // viewport and the body scrolls sideways.
+    const GRID_CHILD_CONTAINERS = [
+      'tab-panel',
+      'files-container',
+      'jobs-container',
+      'systems-container',
+      'features-container',
+    ];
+    const missing: string[] = [];
+    for (const cls of GRID_CHILD_CONTAINERS) {
+      const re = new RegExp(`\\.${cls}\\s*\\{([^}]*)\\}`);
+      const m = html.match(re);
+      if (!m || !/min-width:\s*0/.test(m[1])) missing.push(cls);
+    }
+    expect(
+      missing,
+      `Grid-child panel containers missing min-width:0 (F4 — they can blow out the row): ${missing.join(', ')}`
+    ).toEqual([]);
+  });
+
+  // Rendered half — browser-gated, skips honestly when no browser is present.
+  it('body never scrolls horizontally at 1280/768/390 (browser-gated)', async (ctx) => {
+    const driver = await loadBrowser();
+    if (!driver) {
+      ctx.skip(); // FD-2: no browser here — the CI browser job runs this. Never a false green.
+      return;
+    }
+    const browser = await driver.launch();
+    try {
+      const page = await browser.newPage();
+      await page.goto(pathToFileURL(DASHBOARD_HTML).href);
+      for (const vp of VIEWPORTS) {
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        const overflow = await page.evaluate(
+          () => document.body.scrollWidth - document.documentElement.clientWidth
+        );
+        expect(
+          overflow,
+          `body scrolls horizontally at ${vp.name} (${vp.width}px): scrollWidth exceeds viewport by ${overflow}px`
+        ).toBeLessThanOrEqual(1); // 1px tolerance for sub-pixel rounding
+      }
+    } finally {
+      await browser.close();
+    }
+  });
+});

--- a/upgrades/side-effects/dashboard-f3-tab-purpose.md
+++ b/upgrades/side-effects/dashboard-f3-tab-purpose.md
@@ -1,0 +1,20 @@
+# Side-Effects Review — Dashboard F3 (tab purpose lines)
+
+**Change:** Implements floor **F3** of the Dashboard UX Standard (`docs/specs/dashboard-ux-standard.md`, merged in #1404): every registered dashboard tab now carries a plain-language, self-explanatory purpose line near its top. Adds a shared `.tab-purpose` CSS class, converts the dashboard's pre-existing muted intro divs to it (de-jargoning the worst offenders), adds purpose lines to the tabs that lacked one (Sessions, Files), and adds a static floor test.
+
+**Files:**
+- `dashboard/index.html` — one `.tab-purpose` CSS rule; ~15 panels' intro divs converted to (or given) `.tab-purpose`; new purpose lines for Sessions and Files. Pure markup/CSS — no script changes.
+- `tests/unit/dashboard-tab-purpose.test.ts` — the F3 floor: maps every `TAB_REGISTRY` tab to its panel markup and fails (naming the tab) if none carries a recognized purpose-line class (`tab-purpose` / `ph-intro` / `features-subtitle` / `dropzone-subtitle`). Population-floor guarded.
+
+**Side effects / blast radius:**
+- **Runtime behavior:** NONE. The dashboard is a static file served by `express.static`; this change adds display-only markup + CSS. No JS logic, no API routes, no state, no config touched.
+- **Migrations:** none required. The dashboard `index.html` is served from the package, not templated per-agent; no `PostUpdateMigrator` / CLAUDE.md-template surface is involved (no agent-installed file changes).
+- **Server/lifeline/deploy path:** untouched.
+- **Cross-machine / mesh:** untouched.
+- **Security/PII:** none — no data, credentials, or user content flow through the changed lines.
+
+**Risk:** Low. Worst case is a cosmetic mis-placement of a purpose line on a tab, visible only in the dashboard UI, fixable by a follow-up edit. The floor test prevents a future tab from silently shipping without a purpose line.
+
+**Rollback:** revert this commit — the dashboard reverts to the prior markup with zero residual state (nothing persisted, nothing migrated).
+
+**Follow-ups (tracked, out of scope here):** F4 (mobile no-horizontal-scroll) ships next; F5–F8 (labeled controls, self-explaining empty states, shared component vocabulary that will consolidate the 4 accepted purpose-line classes into one) follow per the spec sequencing.

--- a/upgrades/side-effects/dashboard-f4-viewport-scroll.md
+++ b/upgrades/side-effects/dashboard-f4-viewport-scroll.md
@@ -1,0 +1,18 @@
+# Side-Effects Review — Dashboard F4 (no mobile horizontal scroll)
+
+**Change:** Implements floor **F4** of the Dashboard UX Standard (`docs/specs/dashboard-ux-standard.md`): the page body must never scroll horizontally at 1280/768/390px. The audit (2026-07-08) found panels overflowing the viewport's right edge at 390px so the whole page scrolled sideways on a phone.
+
+**Files:**
+- `dashboard/index.html` — adds `min-width: 0` to the four grid-child panel containers that lacked it (`files-container`, `jobs-container`, `systems-container`, `features-container`). These are direct `.app` grid children (`grid-column: 1 / -1`); a CSS grid/flex child defaults to `min-width: auto`, so a wide descendant forces the row wider than the viewport and the body scrolls sideways. `min-width: 0` lets the child shrink so wide content wraps/contains instead of blowing out the row. (`.tab-panel` already carried this from #1403.) No JS touched.
+- `tests/unit/dashboard-viewport-scroll.test.ts` — the F4 floor, in two halves: (1) a STATIC check that every grid-child container carries `min-width: 0` (always runs); (2) a BROWSER-GATED render check that `document.body.scrollWidth <= clientWidth` at each viewport, which SKIPS HONESTLY when no browser driver is installed (FD-2) and runs in the CI browser job. Never a false green.
+
+**Side effects / blast radius:**
+- **Runtime behavior:** NONE. Display-only CSS on static markup. No JS, API, state, or config.
+- **Migrations / agent-installed files:** none (dashboard is package-served, not templated per agent).
+- **Server/lifeline/mesh/security:** untouched.
+
+**Risk:** Very low. `min-width: 0` on a grid child is the textbook, side-effect-free fix for grid row-blowout; it only *allows* a child to shrink, it never forces a size. Worst case is a wide element inside one of these tabs wrapping instead of overflowing — the desired behavior.
+
+**Verification honesty:** The static half is verified green here. The rendered half is **browser-gated and was SKIPPED in this worktree** — no Playwright/Puppeteer is installed, and installing a browser (a large download) was deliberately avoided on a host that wedged twice on 2026-07-08 under filesystem load. The `min-width: 0` fix targets the known mechanism (grid child blowout) with high confidence from the CSS, but a pixel-level 390px confirmation should run via the CI browser job or a browser-capable pass before treating F4 as fully closed. This is disclosed rather than claimed as visually verified.
+
+**Rollback:** revert — pure CSS + a test, zero residual state.


### PR DESCRIPTION
## ELI16 — Plain-language labels on every dashboard tab + a mobile no-sideways-scroll fix

The operator opened the dashboard on 2026-07-08 and found tabs that gave no hint of what they were for, and panels that scrolled sideways on a phone. This PR implements the next two floors of the Dashboard UX Standard (docs/specs/dashboard-ux-standard.md, merged in #1404), each backed by an automatic check so it cannot silently regress. Everything here is display-only markup, CSS, and tests — no runtime logic, API, migration, or state is touched, so rolling back is just reverting.

**F3 — every tab carries a plain-language purpose line.** Each of the 25 registered tabs now shows one muted, jargon-free sentence near the top saying what it is for (e.g. Secrets: "create one-time links so someone can hand you a password or API key safely, never pasted into chat"). Adds a shared `.tab-purpose` class, converts existing intro divs to it (de-jargoning the worst), writes lines for the two tabs that had none (Sessions, Files), and adds a static floor test that fails — naming the tab — if any tab ships without one.

**F4 — the body never scrolls horizontally on mobile.** Adds `min-width: 0` to the four grid-child panel containers that lacked it (files/jobs/systems/features-container) so a wide descendant can no longer blow out the `.app` grid row and scroll the body sideways at 390px. Adds the F4 floor test: a static half (every grid child carries `min-width: 0`, always runs) + a browser-gated render half (`body.scrollWidth <= clientWidth` at 1280/768/390) that skips honestly when no browser is present (FD-2) — never a false green.

## Verification honesty
F3 and F4's static floors are verified green. F4's rendered half is browser-gated and was **skipped** in the build worktree — no Playwright is installed and a browser download was deliberately avoided on a host that wedged twice on 2026-07-08 under filesystem load. The `min-width: 0` fix targets the known grid-blowout mechanism with high confidence from the CSS; a pixel-level 390px confirmation should run via the CI browser job (or a browser-capable pass) before treating F4 as fully closed. This is disclosed, not claimed as visually verified.

## Tracked follow-ups (out of scope)
- F5–F8 (labeled controls, self-explaining empty states, shared component vocabulary — F7 will consolidate the four accepted purpose-line classes into one).
- Nav model (grouped dropdown vs persistent sidebar rail) remains the operator's open call from #1404.



<!-- eli16 recheck 1783579237 -->
