### PR TITLE
feat(dashboard): F5 control labels + F6 empty-state clarity + F7/F8 floors (UX Standard)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -562,7 +562,17 @@
     /* F3 — Dashboard UX Standard: every tab's plain-language purpose line.
        One muted, readable sentence directly under the tab header telling a
        non-expert what the tab is for and what they can do here. Enforced by
-       tests/unit/dashboard-tab-purpose.test.ts. */
+       tests/unit/dashboard-tab-purpose.test.ts.
+
+       F7 — CANONICAL purpose-line class. `.tab-purpose` is the shared vocabulary
+       every NEW tab should use for its purpose line. Three legacy variants still
+       exist and carry their own deliberately-distinct sizing — `.ph-intro`
+       (Process-Health design-system intro, larger), `.features-subtitle`, and
+       `.dropzone-subtitle` — all recognized by the F3 floor test. Per the spec
+       (docs/specs/dashboard-ux-standard.md, FD-3) F7 is soft-first: consolidating
+       those three into `.tab-purpose` is a tracked migration (it changes their
+       visual size, so it is done deliberately, not big-bang). Until then: reach
+       for `.tab-purpose`; do not add a fifth variant or an inline-styled line. */
     .tab-purpose {
       font-size: 13px;
       color: var(--text-dim);
@@ -2950,7 +2960,7 @@
       </div>
       <div class="file-content-panel" id="fileContentPanel">
         <div class="file-content-header" id="fileContentHeader" style="display:none">
-          <button class="files-back-btn" onclick="filesGoBack()">&larr;</button>
+          <button class="files-back-btn" onclick="filesGoBack()" title="Back" aria-label="Back">&larr;</button>
           <div class="breadcrumbs" id="fileBreadcrumbs"></div>
           <div class="file-badges" id="fileBadges"></div>
         </div>
@@ -3229,7 +3239,7 @@
         Multi-spec project plans. Each project groups related pieces of work and only advances to its next round once its required checks pass.
       </div>
       <div id="projectsEmpty" style="padding:40px;text-align:center;color:var(--text-dim);display:none">
-        No active projects. Create one via <code>POST /projects</code> with a plan-doc path.
+        No active projects yet. Ask your agent to start one from a plan document, and it'll appear here.
       </div>
       <div id="projectsList" style="display:flex;flex-direction:column;gap:12px"></div>
     </div>
@@ -3260,7 +3270,7 @@
       </div>
       <div id="initiativesDigest" style="display:none;padding:12px;border:1px solid var(--border);border-radius:6px;background:var(--bg-dim)"></div>
       <div id="initiativesEmpty" style="padding:40px;text-align:center;color:var(--text-dim);display:none">
-        No initiatives to display. Create one via <code>POST /initiatives</code>.
+        No initiatives yet. Ask your agent to create one, and it'll appear here.
       </div>
       <div id="initiativesList" style="display:flex;flex-direction:column;gap:12px"></div>
     </div>
@@ -3945,7 +3955,7 @@
   <!-- WhatsApp QR panel (hidden by default) -->
   <div class="wa-qr-backdrop" id="waQrBackdrop" style="display:none" onclick="closeQrPanel()"></div>
   <div class="wa-qr-panel" id="waQrPanel" style="display:none">
-    <button class="wa-close" onclick="closeQrPanel()">&times;</button>
+    <button class="wa-close" onclick="closeQrPanel()" title="Close" aria-label="Close">&times;</button>
     <h3>WhatsApp Connection</h3>
     <p id="waQrMsg">Scan this QR code with WhatsApp to connect</p>
     <div id="waQrContainer"></div>
@@ -7649,7 +7659,7 @@
 
       detail.innerHTML = '<div class="job-detail-header">'
         + '<div>'
-        + '<button class="back-btn" onclick="jobsGoBack()" style="display:none;margin-right:8px">&larr;</button>'
+        + '<button class="back-btn" onclick="jobsGoBack()" style="display:none;margin-right:8px" title="Back" aria-label="Back">&larr;</button>'
         + '<h3>' + esc(displayName) + '</h3>'
         + '<div class="job-desc">' + esc(job.description || '') + '</div>'
         + '</div>'
@@ -9420,7 +9430,7 @@
       try {
         const data = await apiFetch(info.endpoint);
         panel.innerHTML = '<div class="cap-content-panel">' +
-          '<div class="cap-content-header"><span>' + esc(info.label) + '</span><button onclick="document.getElementById(\'capContentBrowser\').innerHTML=\'\'" style="border:none;background:none;color:var(--text-dim);cursor:pointer;font-size:14px">&times;</button></div>' +
+          '<div class="cap-content-header"><span>' + esc(info.label) + '</span><button onclick="document.getElementById(\'capContentBrowser\').innerHTML=\'\'" style="border:none;background:none;color:var(--text-dim);cursor:pointer;font-size:14px" title="Close" aria-label="Close">&times;</button></div>' +
           '<div class="cap-content-body">' + renderBrowsableContent(info.renderer, data) + '</div></div>';
       } catch (e) {
         panel.innerHTML = '<div style="padding:12px;color:var(--red);font-size:12px">Failed to load: ' + esc(e.message) + '</div>';

--- a/tests/unit/dashboard-assets-resolve.test.ts
+++ b/tests/unit/dashboard-assets-resolve.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Dashboard asset-resolution floor — F8 of the Dashboard UX Standard
+ * (docs/specs/dashboard-ux-standard.md; Structure > Willpower).
+ *
+ * F8: every referenced image/icon asset resolves to a real target (or is
+ * inlined). A broken asset ref renders as a broken-image glyph — the kind of
+ * papercut that makes a dashboard feel unfinished. This floor fails, naming the
+ * ref, if a static local asset reference has no file on disk.
+ *
+ * Scope: local `src="/dashboard/…"` and `src="./…"`/`src="…"` relative refs.
+ * Data-URIs, absolute http(s) URLs, and dynamically-built (`${…}`) srcs are
+ * runtime concerns and are excluded.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DASHBOARD_DIR = path.resolve(__dirname, '..', '..', 'dashboard');
+const DASHBOARD_HTML = path.join(DASHBOARD_DIR, 'index.html');
+
+/** Resolve a `/dashboard/x` or relative `x` ref to a path under the dashboard dir. */
+function resolveRef(ref: string): string | null {
+  if (ref.startsWith('data:') || /^https?:\/\//.test(ref) || ref.includes('${')) return null;
+  const clean = ref.split('?')[0].split('#')[0];
+  if (clean.startsWith('/dashboard/')) return path.join(DASHBOARD_DIR, clean.slice('/dashboard/'.length));
+  if (clean.startsWith('/')) return null; // other server-mounted roots — not our static dir
+  return path.join(DASHBOARD_DIR, clean.replace(/^\.\//, ''));
+}
+
+describe('dashboard asset-resolution floor (F8)', () => {
+  it('every referenced local asset resolves to a real file', () => {
+    const html = fs.readFileSync(DASHBOARD_HTML, 'utf-8');
+
+    const refs = new Set<string>();
+    for (const m of html.matchAll(/\bsrc="([^"]+)"/g)) refs.add(m[1]);
+    for (const m of html.matchAll(/url\((['"]?)([^)'"]+)\1\)/g)) refs.add(m[2]);
+
+    const missing: string[] = [];
+    let checked = 0;
+    for (const ref of refs) {
+      const resolved = resolveRef(ref);
+      if (resolved == null) continue; // excluded (data:/http/dynamic/other-root)
+      checked++;
+      if (!fs.existsSync(resolved)) missing.push(`${ref} → ${path.relative(DASHBOARD_DIR, resolved)}`);
+    }
+
+    // At least the known logo asset must be checked (guards a regressed matcher).
+    expect(checked, 'local asset refs checked by the F8 floor').toBeGreaterThanOrEqual(1);
+
+    expect(
+      missing,
+      `Broken asset references (the F8 bug): ${missing.join(', ')}. ` +
+        `Ship the file under dashboard/, inline it as a data: URI, or fix the path.`
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/dashboard-controls-labeled.test.ts
+++ b/tests/unit/dashboard-controls-labeled.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Dashboard control-labeling floor — F5 of the Dashboard UX Standard
+ * (docs/specs/dashboard-ux-standard.md; Structure > Willpower).
+ *
+ * F5: every interactive control (button) has a discernible label — visible
+ * text, a `title`, or an `aria-label`. The audit (2026-07-08) found a handful
+ * of icon-only buttons (a bare "←" / "×" / "+") whose function a user had to
+ * guess. This floor fails, naming the offender, if any button ships with only
+ * an icon glyph and no accessible label — so a NEW icon-only control cannot
+ * regress silently.
+ *
+ * A button counts as LABELED when its opening tag carries `title=` or
+ * `aria-label=`, OR its inner content contains alphanumeric text (a real word),
+ * OR its content is dynamically interpolated (`${...}` / `' + ...`) — those are
+ * labeled at runtime and cannot be judged statically. It counts as UNLABELED
+ * when its only content is icon glyphs / HTML entities with no accessible name.
+ *
+ * Guarded by a population floor so a regressed matcher fails loudly, not silently.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DASHBOARD_HTML = path.resolve(__dirname, '..', '..', 'dashboard', 'index.html');
+
+/** Match each `<button ...> ... </button>` span (content may include entities). */
+const BUTTON_RE = /<button\b([^>]*)>([\s\S]*?)<\/button>/g;
+
+function isLabeled(openTag: string, inner: string): boolean {
+  // Explicit accessible label on the tag.
+  if (/\b(?:aria-label|title)\s*=/.test(openTag)) return true;
+  // Dynamic content — labeled at runtime, not statically judgeable.
+  if (/\$\{|'\s*\+|"\s*\+|\+\s*'|\+\s*"/.test(inner)) return true;
+  // Strip nested tags + HTML entities, then require a real alphanumeric word.
+  const text = inner
+    .replace(/<[^>]*>/g, '')
+    .replace(/&[a-zA-Z]+;|&#\d+;|&#x[0-9a-fA-F]+;/g, '')
+    .trim();
+  return /[A-Za-z0-9]/.test(text);
+}
+
+describe('dashboard control-labeling floor (F5)', () => {
+  it('every button has a discernible label (text, title, or aria-label)', () => {
+    const html = fs.readFileSync(DASHBOARD_HTML, 'utf-8');
+
+    const unlabeled: string[] = [];
+    let seen = 0;
+    let m: RegExpExecArray | null;
+    while ((m = BUTTON_RE.exec(html)) !== null) {
+      seen++;
+      const [, openTag, inner] = m;
+      if (!isLabeled(openTag, inner)) {
+        // Report a short, findable snippet of the offending button.
+        unlabeled.push(`<button${openTag}>${inner.trim().slice(0, 24)}</button>`);
+      }
+    }
+
+    // Population floor: the sweep must see the known button population.
+    expect(seen, 'buttons visible to the F5 floor').toBeGreaterThanOrEqual(30);
+
+    expect(
+      unlabeled,
+      `Icon-only / unlabeled buttons (the F5 bug): ${unlabeled.join(' | ')}. ` +
+        `Add a title="…" and aria-label="…" naming what the button does.`
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/dashboard-empty-states.test.ts
+++ b/tests/unit/dashboard-empty-states.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Dashboard empty-state floor — F6 of the Dashboard UX Standard
+ * (docs/specs/dashboard-ux-standard.md; Structure > Willpower).
+ *
+ * F6: an empty / resting state must be self-explanatory — it says what will
+ * fill the area (and, where relevant, how), in plain language. Not a blank box,
+ * and not raw developer jargon (`POST /projects`, a curl line) that a
+ * non-technical operator cannot act on. The audit (2026-07-08) found two empty
+ * states instructing the user to "Create one via POST /projects" — meaningless
+ * to the person reading the dashboard.
+ *
+ * This floor scans the dashboard's `*Empty*` resting-state containers and fails,
+ * naming the offender, if one is bare (no real sentence) or leaks API jargon.
+ * (Transient "Loading…" placeholders are a different, acceptable state and are
+ * not resting empty states.)
+ *
+ * Guarded by a population floor so a regressed matcher fails loudly, not silently.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DASHBOARD_HTML = path.resolve(__dirname, '..', '..', 'dashboard', 'index.html');
+
+/** Empty-state containers to audit (id contains "Empty"). */
+const EMPTY_ID_RE = /id="([a-zA-Z]*[Ee]mpty[a-zA-Z]*)"/g;
+
+/** Raw API/developer jargon a non-technical operator cannot act on. */
+const JARGON_RE = /\b(?:POST|GET|PUT|PATCH|DELETE)\s+\/|curl\b|<code>\s*(?:POST|GET|PUT|PATCH|DELETE)\b/i;
+
+function segmentAfter(html: string, id: string): string {
+  const open = html.indexOf(`id="${id}"`);
+  if (open < 0) return '';
+  // Grab a bounded window covering the container's inner markup.
+  return html.slice(open, open + 400);
+}
+
+describe('dashboard empty-state floor (F6)', () => {
+  it('every empty-state container is self-explanatory and jargon-free', () => {
+    const html = fs.readFileSync(DASHBOARD_HTML, 'utf-8');
+
+    const ids = [...html.matchAll(EMPTY_ID_RE)].map(m => m[1]);
+    // Population floor: the known empty-state containers must be visible.
+    expect(new Set(ids).size, 'empty-state containers visible to the F6 floor').toBeGreaterThanOrEqual(6);
+
+    const bare: string[] = [];
+    const jargon: string[] = [];
+    for (const id of new Set(ids)) {
+      const seg = segmentAfter(html, id);
+      const text = seg
+        .replace(/<[^>]*>/g, ' ')
+        .replace(/&[a-zA-Z]+;|&#\d+;|&#x[0-9a-fA-F]+;/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+      // A real explanatory sentence: several words of alphanumeric text.
+      const words = (text.match(/[A-Za-z][A-Za-z']+/g) || []).length;
+      if (words < 4) bare.push(`${id} ("${text.slice(0, 40)}")`);
+      if (JARGON_RE.test(seg)) jargon.push(id);
+    }
+
+    expect(
+      bare,
+      `Bare empty states (F6): ${bare.join(', ')}. Add a plain sentence saying ` +
+        `what fills this area and how.`
+    ).toEqual([]);
+    expect(
+      jargon,
+      `Empty states leaking API jargon (F6): ${jargon.join(', ')}. Replace raw ` +
+        `HTTP/curl instructions with plain language ("ask your agent to …").`
+    ).toEqual([]);
+  });
+});

--- a/upgrades/next/dashboard-f5-f8.md
+++ b/upgrades/next/dashboard-f5-f8.md
@@ -1,0 +1,41 @@
+<!-- bump: patch -->
+
+## What Changed
+
+- **Every dashboard control is now labeled (Dashboard UX Standard F5).** Four icon-only buttons
+  (the Files back arrow, the QR-panel close, the Jobs back arrow, and the capability-content
+  close) shipped as a bare `←` / `×` glyph with no accessible name — a user (or screen reader)
+  had to guess. Each now carries a `title` + `aria-label`. A build-time floor
+  (`dashboard-controls-labeled.test.ts`) fails if any future button ships icon-only.
+- **Empty states speak plain language, not API jargon (F6).** Two empty states told the operator
+  to "Create one via `POST /projects`" / "`POST /initiatives`" — meaningless to the person
+  reading the dashboard. They now say "Ask your agent to start one … and it'll appear here." A
+  floor (`dashboard-empty-states.test.ts`) fails on a bare or jargon-leaking empty state.
+- **Shared purpose-line vocabulary documented (F7, soft-first).** `.tab-purpose` is marked the
+  canonical purpose-line class; the three legacy variants (`ph-intro`, `features-subtitle`,
+  `dropzone-subtitle`) are documented for a tracked, deliberate migration (per spec FD-3, not a
+  big-bang restyle).
+- **Broken-asset floor (F8).** `dashboard-assets-resolve.test.ts` fails if a referenced local
+  image/icon has no file on disk.
+
+## What to Tell Your User
+
+A few more dashboard papercuts are gone: every button now has a readable label (better for
+accessibility too), and the "nothing here yet" messages tell you what to do in plain English
+instead of showing a developer command. Nothing to enable — it lands with the release.
+
+## Summary of New Capabilities
+
+- None — UX polish plus three build-time floors (F5 control labeling, F6 empty-state clarity,
+  F8 asset resolution) that fail the build if a future change regresses them.
+
+## Evidence
+
+`tests/unit/dashboard-controls-labeled.test.ts` (F5): scans every `<button>` in
+`dashboard/index.html`, asserts each has visible text, `title`, or `aria-label` (population floor
+≥30). `tests/unit/dashboard-empty-states.test.ts` (F6): audits the `*Empty*` resting-state
+containers (population floor ≥6) for a real sentence and no `POST /…`/curl jargon.
+`tests/unit/dashboard-assets-resolve.test.ts` (F8): every static local `src`/`url(...)` ref
+resolves to a real file (logo.png confirmed present). All 7 dashboard floor tests green (13
+cases, 1 browser-gated skip). Display-only markup + build-time floors — no runtime surface;
+machine-local static asset; rollback is a plain revert.

--- a/upgrades/side-effects/dashboard-f5-f8.md
+++ b/upgrades/side-effects/dashboard-f5-f8.md
@@ -1,0 +1,22 @@
+# Side-effects review — Dashboard UX Standard floors F5–F8
+
+**Change:** `dashboard/index.html` (F5 button labels, F6 empty-state de-jargoning, F7 canonical-class doc) + three static floor tests (`dashboard-controls-labeled` F5, `dashboard-empty-states` F6, `dashboard-assets-resolve` F8). Spec: `docs/specs/dashboard-ux-standard.md` (converged + approved, shipped in #1404). Tier 1 — display-only markup + build-time CI floors; no runtime `src/` change, no decision logic.
+
+## Phase 1 — Principle check (signal vs authority)
+Does this touch a decision point that gates information flow / blocks actions / constrains agent behavior? **No.** The changes are (a) HTML label/text attributes rendered to the operator and (b) static test files that fail a *build* if the dashboard regresses. The tests are build-time CI floors, not runtime authorities — they never gate a message, session, or agent action. Signal-vs-authority does not apply (no runtime decision surface).
+
+## Phase 4 — Side-effects review
+1. **Over-block:** the floor tests could reject legitimate markup. F5 accepts a button labeled by visible text OR `title` OR `aria-label` OR dynamic (`${…}`/concatenated) content — the full current button population passes; a button labeled *only* by an adjacent element (not itself) would false-flag, acceptable because self-labeling is the accessibility norm and easily satisfied. F6 requires a ≥4-word sentence in each `*Empty*` container — a legitimately terse state would flag, but the 4-word floor is lenient. F8 excludes `data:`/`http(s)`/dynamic `${}` srcs, so only real static local refs are checked. No legitimate current markup is rejected (all 7 dashboard tests green).
+2. **Under-block:** F5 checks `<button>` only, not `<select>`/`<input>` labeling (a tracked F5 follow-up <!-- tracked: topic-29723 -->). F6 audits `*Empty*`-id containers, not every conceivable resting state. F8 checks static local refs only. These are honest partial floors that raise the bar without claiming totality — not regressions.
+3. **Level-of-abstraction fit:** correct layer. A UI-consistency standard is enforced at build time over the shipped markup; there is no smarter runtime gate this should feed (it is not a runtime concern). It extends the existing dashboard-floor test family (`dashboard-tab-purpose`, `dashboard-panel-placement`, `dashboard-nav-reachability`, `dashboard-viewport-scroll`) — same pattern, same layer.
+4. **Signal vs authority compliance:** compliant by absence — no blocking authority added (build-time test, not runtime gate). See Phase 1.
+5. **Interactions:** the new F5/F6/F8 tests are independent scans over `index.html`; none shadows another. The F7 change is a CSS *comment* only — it does not alter the `.tab-purpose` rule and the F3 `dashboard-tab-purpose` test (which recognizes all four purpose-line classes) still passes. No double-fire, no race with cleanup.
+6. **External surfaces:** changes the dashboard HTML the operator sees — 4 icon buttons gain accessible names, 2 empty states lose API jargon ("POST /projects" → plain language). Strictly additive/clarifying; no behavior, endpoint, or data change. No surface visible to other agents/users/systems. No timing/conversation-state dependency.
+7. **Multi-machine posture:** **machine-local BY DESIGN** — `dashboard/index.html` is a static asset shipped in the package and served by each machine's own server; every machine serves the identical shipped file, so there is nothing to replicate, proxy, or transfer. No durable state, no generated URL, no user-facing notice. A single-machine assumption is correct here, not a defect.
+8. **Rollback cost:** trivial — `git revert` the commit. Display-only markup + additive tests; no migration, no agent-state repair, no data change.
+
+## Phase 4.5 — No deferrals
+The two under-block follow-ups (F5 select/input labeling; broader F6 coverage) are tracked <!-- tracked: topic-29723 -->. F7 hard-consolidation is deliberately soft-first per the spec's FD-3, not an orphan deferral. No partial fix of an in-scope item is shipped.
+
+## Phase 5 — Second pass
+Not required: no block/allow, session-lifecycle, coherence, or sentinel/guard/gate/watchdog surface (Tier 1, display-only).


### PR DESCRIPTION
## ELI16 — More dashboard papercuts fixed: readable button labels, plain-English empty states, and enforcing tests

This continues the Dashboard UX Standard (docs/specs/dashboard-ux-standard.md, approved and shipped in #1404) with its next four floors, each backed by a build-time test so it cannot silently regress. Everything here is display-only markup, CSS comments, and tests — no runtime logic, API, migration, or state is touched, so rolling back is just reverting the commit. It builds directly on the F3 (purpose lines) and F4 (mobile no-horizontal-scroll) work.

**F5 — every control is labeled.** Four icon-only buttons (a bare `←` or `×`: the Files back arrow, the QR-panel close, the Jobs back arrow, and the capability-content close) had no accessible name — a user or screen reader had to guess. Each now carries `title` + `aria-label`. A floor test (`dashboard-controls-labeled.test.ts`) fails, naming the offender, if any button ever ships icon-only again.

**F6 — empty states in plain language.** Two empty states instructed the operator to "Create one via `POST /projects`" / "`POST /initiatives`" — developer jargon meaningless to the person reading the dashboard. They now read "Ask your agent to start one … and it'll appear here." A floor (`dashboard-empty-states.test.ts`) fails on a bare or API-jargon empty state.

**F7 — shared vocabulary (soft-first).** `.tab-purpose` is documented as the canonical purpose-line class; the three legacy variants are marked for a tracked, deliberate migration (per spec FD-3 — not a risky big-bang restyle that would change their sizes).

**F8 — no broken assets.** `dashboard-assets-resolve.test.ts` fails if a referenced local image/icon has no file on disk.

### Verification
All 7 dashboard floor tests green (13 cases, 1 browser-gated skip). Honest note: these are static-markup checks; no pixel/browser verification was run this pass (the box's Chrome link is down and a headless install was avoided on a machine that wedged twice today) — but F5/F6/F8 are markup/text/asset checks that don't need a render.

### Tier
Tier 1 (display-only markup + build-time floors; no runtime `src/`). Side-effects review: `upgrades/side-effects/dashboard-f5-f8.md`.
