### PR TITLE
fix(agent-worktree-reaper): close the enumerate→reclaim TOCTOU (re-validate before delete)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-09T09-08-54-994Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-09T09-08-54-994Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-09T09:08:54.994Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/AgentWorktreeReaper.ts matches session reaper"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 67,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-09T09-25-04-583Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-09T09-25-04-583Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-09T09:25:04.583Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/AgentWorktreeReaper.ts matches session reaper"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 16,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-09T09-25-39-711Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-09T09-25-39-711Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-09T09:25:39.711Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/AgentWorktreeReaper.ts matches session reaper"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 16,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-09T09-26-05-979Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-09T09-26-05-979Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-09T09:26:05.979Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/AgentWorktreeReaper.ts matches session reaper"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 16,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-09T09-26-38-214Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-09T09-26-38-214Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-09T09:26:38.214Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/AgentWorktreeReaper.ts matches session reaper"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 16,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-09T09-27-38-034Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-09T09-27-38-034Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-09T09:27:38.034Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/AgentWorktreeReaper.ts matches session reaper"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 79,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/reaper-toctou-fix.eli16.md
+++ b/docs/specs/reaper-toctou-fix.eli16.md
@@ -1,0 +1,16 @@
+# ELI16 — The worktree cleanup double-checks right before it deletes
+
+## What this is
+Your agent creates temporary copies of the codebase (called "worktrees") when it builds things. A background cleaner ("the reaper") removes the ones that are finished — safely, only when a worktree's branch is already merged, has no unsaved changes, and nothing is using it.
+
+## The bug
+The cleaner works in two steps: first it looks at ALL the worktrees and writes down each one's branch, then a moment later it goes through and deletes the finished ones. The problem is the gap between those two steps. Tonight, a builder grabbed a "finished" worktree in that gap and started a NEW piece of work in it (switching it to a fresh, unmerged branch). But the cleaner was still going off its earlier note that said "this branch is merged" — so it deleted the worktree while a build was live inside it. Nothing was permanently lost, but it was a real race: the cleaner decided based on a stale snapshot.
+
+## The fix
+Right before the cleaner actually deletes a worktree, it now re-checks the LIVE state one more time — is it still on the same branch, still merged, still clean, still idle? If ANYTHING changed since the first look, it backs off and keeps the worktree. A builder can also drop a little "I'm using this" marker file to be extra sure the cleaner leaves it alone.
+
+## The safeguards, plainly
+This change can only ever make the cleaner MORE careful — it can skip a deletion it would have done, but it can never delete something it wouldn't have. Every "I'm not sure" answer means "keep it, don't delete." There's no new setting and no switch to flip; it's always on. If you ever saw the cleaner remove a worktree mid-build, that can't happen this way anymore.
+
+## What you need to decide
+Nothing. It ships with the release and only makes the existing cleanup safer.

--- a/src/monitoring/AgentWorktreeReaper.ts
+++ b/src/monitoring/AgentWorktreeReaper.ts
@@ -101,6 +101,16 @@ export interface AgentWorktreeReaperDeps {
   /** True when the worktree is in use: a live session/index lock OR a running
    *  process whose cwd is inside it. The real "don't yank it" signal. */
   isInUse: (path: string) => boolean;
+  /** The worktree's LIVE currently-checked-out branch, read at RECLAIM time to close
+   *  the enumerate→reclaim TOCTOU: `info.branch` is captured at enumeration, but a
+   *  builder may `git checkout -b <new-unmerged>` before the reaper reaches the
+   *  delete — and `isMerged(info)` would still check the STALE (merged) branch.
+   *  Production: SafeGitExecutor `rev-parse --abbrev-ref HEAD` on the path. */
+  currentBranch: (path: string) => string | null;
+  /** Optional belt-and-suspenders: true when a `.instar-build-active` marker file sits
+   *  at the worktree root — an in-flight builder's explicit "don't reap me" claim.
+   *  Production: fs.existsSync(path/.instar-build-active). */
+  hasActiveBuildMarker?: (path: string) => boolean;
   /** Remove the worktree (git worktree remove). Only called when killsEnabled. */
   removeWorktree: (path: string) => void;
   now?: () => number;
@@ -201,6 +211,18 @@ export class AgentWorktreeReaper extends EventEmitter {
         if (evaln.verdict !== 'reap-eligible') continue;
         if (reaped.length >= this.cfg.maxReapsPerPass) continue; // blast-radius cap
         if (!this.killsEnabled) { continue; } // dry-run: classify, do not delete
+        // EXEC-TIME RE-VALIDATION (close the enumerate→reclaim TOCTOU): `info` was
+        // captured by listWorktrees() at enumeration; a builder may have checked out a
+        // new UNMERGED branch since, yet isMerged(info) checks the STALE branch. Re-read
+        // the LIVE state right before the irreversible delete; on any race, ABORT this
+        // reap (keep) — strictly FEWER reaps, never more (a pure safety tightening).
+        const raceReason = this.reclaimRaceGuard(info);
+        if (raceReason) {
+          evaln.verdict = 'keep';
+          evaln.reason = raceReason;
+          this.emit('reclaim-raced', { path: info.path, reason: raceReason, evaluatedBranch: info.branch });
+          continue;
+        }
         try {
           this.deps.removeWorktree(info.path);
           reaped.push(info.path);
@@ -223,6 +245,35 @@ export class AgentWorktreeReaper extends EventEmitter {
       this.running = false;
     }
     return { ts: this.now(), evaluations, reaped, dryRun: !this.killsEnabled };
+  }
+
+  /**
+   * Re-check the LIVE worktree state at RECLAIM time (after enumeration) to close the
+   * TOCTOU. Returns a KEEP reason string if it raced (a builder changed the branch /
+   * dirtied it / took it in-use / dropped a build marker since evaluation), else null
+   * (safe to reclaim). Fail-closed: any thrown signal → keep('reclaim-recheck-error').
+   * Order mirrors evaluate(): the marker + branch identity first (the load-bearing
+   * TOCTOU checks), then the protect-gates re-confirmed against the STILL-CURRENT branch.
+   */
+  private reclaimRaceGuard(info: WorktreeInfo): string | null {
+    try {
+      if (this.deps.hasActiveBuildMarker?.(info.path)) return 'raced-build-active-marker';
+      // The load-bearing check: has the checked-out branch changed since enumeration?
+      // If so, isMerged(info) (which reads info.branch) is stale and must NOT authorize a delete.
+      const liveBranch = this.deps.currentBranch(info.path);
+      if (liveBranch !== info.branch) return 'raced-changed-since-eval';
+      if (this.deps.isInUse(info.path)) return 'raced-now-in-use';
+      if (!this.deps.isClean(info.path)) return 'raced-now-dirty';
+      // Branch unchanged + clean + idle → info.branch is still current, so re-confirming
+      // isMerged(info) is valid. (Belt: main may have moved, un-merging it.)
+      if (!this.deps.isMerged(info)) return 'raced-now-unmerged';
+      return null;
+    } catch {
+      // @silent-fallback-ok: NOT silent — returns a KEEP reason that is surfaced in the
+      // worktree's verdict/reason (and the reclaim-raced event). Any thrown re-check
+      // signal → keep, the delete-safe direction. Never a swallowed reap.
+      return 'reclaim-recheck-error';
+    }
   }
 
   /** True when this path's removal has failed >= the configured cap (breaker open).

--- a/src/monitoring/agentWorktreeGit.ts
+++ b/src/monitoring/agentWorktreeGit.ts
@@ -286,6 +286,34 @@ export function makeAgentWorktreeReaperDeps(opts: {
       return false;
     },
 
+    currentBranch: (p: string): string | null => {
+      // The LIVE checked-out branch, read at RECLAIM time to close the enumerate→reclaim
+      // TOCTOU. Format matches listWorktrees' info.branch (short name, no refs/heads/).
+      // FAIL-CLOSED: any error → null, which cannot equal a real info.branch, so the
+      // reclaimRaceGuard KEEPS (never reap on an unreadable live branch).
+      try {
+        const b = (readGit(['-C', p, 'rev-parse', '--abbrev-ref', 'HEAD'], p) ?? '').trim();
+        return b && b !== 'HEAD' ? b : null; // 'HEAD' = detached → null
+      } catch {
+        // @silent-fallback-ok: fail-closed — an unreadable live branch returns null,
+        // which can never equal a real info.branch, so the reclaim guard KEEPS (never
+        // reaps on an uncertain branch). The delete-safe direction, not a swallowed bug.
+        return null;
+      }
+    },
+
+    hasActiveBuildMarker: (p: string): boolean => {
+      // Belt-and-suspenders: an in-flight builder's explicit "don't reap me" claim.
+      // FAIL-CLOSED: an error reading the marker is treated as PRESENT (KEEP), the
+      // deletion-safe direction.
+      try { return fs.existsSync(path.join(p, '.instar-build-active')); }
+      catch {
+        // @silent-fallback-ok: fail-closed — an fs error reading the marker is treated
+        // as PRESENT (KEEP), the delete-safe direction. Not a swallowed bug.
+        return true;
+      }
+    },
+
     removeWorktree: (p: string): void => {
       // Deliberately NOT --force: the non-forced form refuses to remove a worktree
       // with uncommitted changes or a lock, so it can never destroy in-flight work.

--- a/tests/unit/agent-worktree-reaper.test.ts
+++ b/tests/unit/agent-worktree-reaper.test.ts
@@ -32,6 +32,8 @@ function deps(over: Partial<AgentWorktreeReaperDeps> = {}): AgentWorktreeReaperD
     isClean: () => true,
     isMerged: () => true,
     isInUse: () => false,
+    currentBranch: () => 'echo/feature', // matches wt() default → reclaim race guard passes
+    hasActiveBuildMarker: () => false,
     removeWorktree: vi.fn(),
     now: () => NOW,
     ...over,
@@ -96,6 +98,62 @@ describe('AgentWorktreeReaper.reap — dry-run + blast radius', () => {
     expect(res.dryRun).toBe(false);
     expect(res.reaped).toHaveLength(2); // capped
     expect(removeWorktree).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('AgentWorktreeReaper.reap — exec-time re-validation closes the enumerate→reclaim TOCTOU', () => {
+  const liveReap = (d: Partial<AgentWorktreeReaperDeps>) =>
+    new AgentWorktreeReaper(deps({ ...d }), { enabled: true, dryRun: false });
+
+  it('(a) branch changed since eval (builder checked out a new unmerged branch) → KEEP, not reaped', async () => {
+    // eval sees info.branch='echo/feature' merged/clean/idle ⇒ reap-eligible; at reclaim the
+    // LIVE branch is a DIFFERENT one, so isMerged(info) is stale and must not authorize a delete.
+    const removeWorktree = vi.fn();
+    const res = await liveReap({ removeWorktree, currentBranch: () => 'echo/dashboard-f5f8' }).reap();
+    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(res.reaped).toEqual([]);
+    expect(res.evaluations[0].verdict).toBe('keep');
+    expect(res.evaluations[0].reason).toBe('raced-changed-since-eval');
+  });
+
+  it('(b) worktree went dirty between eval and reclaim → KEEP', async () => {
+    const removeWorktree = vi.fn();
+    // clean at eval (1st call), dirty at the reclaim re-check (2nd)
+    const isClean = vi.fn().mockReturnValueOnce(true).mockReturnValue(false);
+    const res = await liveReap({ removeWorktree, isClean }).reap();
+    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(res.evaluations[0].reason).toBe('raced-now-dirty');
+  });
+
+  it('(c) worktree became in-use between eval and reclaim → KEEP', async () => {
+    const removeWorktree = vi.fn();
+    // idle at eval (1st), in-use at reclaim re-check (2nd)
+    const isInUse = vi.fn().mockReturnValueOnce(false).mockReturnValue(true);
+    const res = await liveReap({ removeWorktree, isInUse }).reap();
+    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(res.evaluations[0].reason).toBe('raced-now-in-use');
+  });
+
+  it('(d) an .instar-build-active marker at reclaim time → KEEP (builder claim honored)', async () => {
+    const removeWorktree = vi.fn();
+    const res = await liveReap({ removeWorktree, hasActiveBuildMarker: () => true }).reap();
+    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(res.evaluations[0].reason).toBe('raced-build-active-marker');
+  });
+
+  it('(e) genuinely still merged-clean-idle-unchanged at reclaim → REAPS (unchanged happy path)', async () => {
+    const removeWorktree = vi.fn();
+    const res = await liveReap({ removeWorktree }).reap(); // defaults: branch matches, no marker
+    expect(removeWorktree).toHaveBeenCalledTimes(1);
+    expect(res.reaped).toHaveLength(1);
+    expect(res.evaluations[0].verdict).toBe('reap-eligible');
+  });
+
+  it('fail-closed: currentBranch read error (returns null) ≠ info.branch → KEEP, never reap on an unreadable branch', async () => {
+    const removeWorktree = vi.fn();
+    const res = await liveReap({ removeWorktree, currentBranch: () => null }).reap();
+    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(res.evaluations[0].reason).toBe('raced-changed-since-eval');
   });
 
   it('snapshot reports the reclaimable count without side effects', () => {

--- a/upgrades/next/reaper-toctou-fix.md
+++ b/upgrades/next/reaper-toctou-fix.md
@@ -1,0 +1,18 @@
+<!-- bump: patch -->
+
+## What Changed
+
+- **The stale-worktree reaper no longer reaps a worktree that a builder started using between the reaper's check and its delete (AgentWorktreeReaper TOCTOU fix).** The reaper enumerates all worktrees, captures each one's branch, then reaps up to N of them in a later loop. A build worktree whose branch was merged at enumeration but which a builder then `git checkout -b`'d onto a NEW unmerged branch would still be judged "merged" against the STALE branch and deleted mid-build (this happened once tonight). The reaper now RE-READS each worktree's live state — current branch, clean, in-use, merged — immediately before the irreversible delete, and ABORTS (keeps) on any change since evaluation. It is a pure safety tightening: strictly FEWER reaps, never more; fail-closed on any unreadable signal.
+- **New belt-and-suspenders claim:** a `.instar-build-active` marker file at a worktree root is now honored as "in use" — an in-flight builder can drop it to be certain the reaper leaves the worktree alone.
+
+## What to Tell Your User
+
+If your agent's background cleanup ever removed a worktree while a build was actively using it, that race is closed — the cleanup now double-checks the live state right before deleting and backs off if anything changed. Nothing to enable; it lands with the release. It only ever makes the cleanup MORE cautious, never less.
+
+## Summary of New Capabilities
+
+- None user-facing — a safety hardening of the AgentWorktreeReaper. Two new injected signals (`currentBranch`, `hasActiveBuildMarker`) power an execution-time re-validation that closes the enumerate→reclaim time-of-check-to-time-of-use window. No config, no gate (a pure tightening, always on).
+
+## Evidence
+
+`tests/unit/agent-worktree-reaper.test.ts` — 6 new cases pin the guard: branch-changed-since-eval → keep; went-dirty → keep; became-in-use → keep; build-marker-present → keep; still-unchanged → reaps (happy path unchanged); currentBranch-read-error (null) → keep (fail-closed). All 53 reaper tests pass, including the real-git end-to-end reclaim test. The change is delete-safe by construction — every new branch of the guard resolves toward KEEP.

--- a/upgrades/side-effects/reaper-toctou-fix.md
+++ b/upgrades/side-effects/reaper-toctou-fix.md
@@ -1,0 +1,19 @@
+# Side-Effects Review — AgentWorktreeReaper TOCTOU fix
+
+**Slug:** reaper-toctou-fix · **Tier:** 1 (small, pure safety tightening) · **Author:** echo · 2026-07-09
+
+## Phase 1 — Principle check (signal vs authority)
+The AgentWorktreeReaper IS a decision authority (it deletes worktrees). This change does NOT add new brittle blocking authority — it adds MORE signal re-checks (live branch/clean/in-use/merged + a build marker) BEFORE the existing authority acts, and only ever moves the verdict toward KEEP. It feeds the existing delete-authority with fresher signals; it never blocks anything new. Compliant — strictly safer.
+
+## Phase 4 — Side-effects review (all 8)
+1. **Over-block** — Could KEEP a genuinely-reapable worktree if a signal transiently flips (a momentary lock, a slow git read). Harmless + self-correcting: KEEP means "not deleted this pass"; it's re-evaluated next pass. No data loss, ever. This is the intended safe direction.
+2. **Under-block** — Residual: a builder that checks out the SAME branch name with NEW commits between eval and reclaim → currentBranch matches, but the isMerged RE-CHECK against the current branch catches the new (unmerged) commits → keep. A micro-window between the currentBranch read and `git worktree remove` remains, but `removeWorktree` is NON-forced (refuses a dirty/locked worktree) — a second, independent guard on the actual delete. Acceptable.
+3. **Level-of-abstraction fit** — Correct layer. The reaper owns the reap decision; the re-validation belongs exactly at its reclaim point (not a higher/lower layer). No smarter existing gate to feed.
+4. **Signal vs authority** — See Phase 1. The change adds signals to make an existing authority more conservative. No new brittle authority. Ref docs/signal-vs-authority.md.
+5. **Interactions** — Runs AFTER the per-path reclaim-failure breaker and the maxReapsPerPass cap, immediately BEFORE removeWorktree. Does not shadow or double-fire with them. Adds one `reclaim-raced` event (observability). The mutated evaluation (reap-eligible→keep on race) is the same object already pushed to `evaluations`, so the reap-log/pass event reports the honest raced verdict.
+6. **External surfaces** — No API/other-agent/other-user surface change. The verdict/reap-log gains new `raced-*` reasons (pure observability). New OPTIONAL file convention: a `.instar-build-active` marker a builder may drop at a worktree root to claim it; absence = today's behavior.
+7. **Multi-machine posture** — MACHINE-LOCAL BY DESIGN. Each machine's reaper operates only on ITS OWN `.worktrees/` (worktrees are physical checkouts on one disk); currentBranch (local git) and the marker (local fs) are inherently local. No replication needed or wanted — a worktree cannot exist on two machines.
+8. **Rollback cost** — Trivial. Additive change (2 injected deps + 1 guard method + the re-validation call). No config, no migration, no persisted state. Back-out = revert the commit.
+
+## Phase 5 — Second-pass (inline; this fork cannot spawn a subagent)
+Independent adversarial re-read: (a) Could the guard ever make the reaper MORE aggressive? No — every branch of `reclaimRaceGuard` returns a KEEP reason or null; it can only subtract reaps. (b) Could a throw in the guard cause a reap? No — the guard's try/catch returns `reclaim-recheck-error` (KEEP) on any throw. (c) Does the null-branch fail-closed hold? Yes — a null live branch ≠ a non-null info.branch (info.branch is always non-null at reclaim, since evaluate keeps on !info.branch) → raced → keep; test pins this. (d) Marker fail-closed: an fs error reading the marker returns true (KEEP). **Concur with the review** — the change is delete-safe by construction; no concern raised.


### PR DESCRIPTION
## ELI16 — The worktree cleanup now double-checks the live state right before it deletes, so it can't remove a worktree a build just started using

Your agent makes temporary codebase copies ("worktrees") to build in, and a background cleaner ("the reaper") removes the finished ones — but only when a worktree's branch is already merged, has no unsaved changes, and nothing is using it. The cleaner works in two steps: it looks at all the worktrees and notes each branch, then a moment later deletes the finished ones. Tonight a builder grabbed a "finished" worktree in that gap and started new work in it (a fresh unmerged branch), but the cleaner was still going off its stale "this is merged" note and deleted it mid-build. Nothing was permanently lost, but it was a real time-of-check-to-time-of-use race. This fix makes the cleaner re-read the live state — current branch, merged, clean, in-use, plus an optional "I'm using this" marker file — immediately before the irreversible delete, and back off (keep) if anything changed since its first look. It can only ever make the cleanup MORE cautious: every uncertain answer resolves to "keep, don't delete," it's fail-closed everywhere, and there's no config or switch — always on.

## What Changed
- `src/monitoring/AgentWorktreeReaper.ts`: two new injected signals (`currentBranch`, `hasActiveBuildMarker`) + a `reclaimRaceGuard` that re-validates live branch/clean/in-use/merged right before `removeWorktree`, aborting (keep) on any change since enumeration. Emits a `reclaim-raced` event for observability.
- `src/monitoring/agentWorktreeGit.ts`: production impls of the two deps (git `rev-parse --abbrev-ref HEAD`; `fs.existsSync` of `.instar-build-active`), both fail-closed.
- `tests/unit/agent-worktree-reaper.test.ts`: 6 new cases — branch-changed / went-dirty / became-in-use / build-marker / still-unchanged (reaps) / null-branch fail-closed. All 53 reaper tests pass, incl. the real-git e2e.

## Safety
Pure tightening — strictly FEWER reaps, never more. Fail-closed on every unreadable signal. No config, no gate, machine-local by design. Rollback = revert. Side-effects review (all 8) + inline second-pass concur: `upgrades/side-effects/reaper-toctou-fix.md`.
