### PR TITLE
feat(monitoring): red-PR watchdog — surface a self-authored PR stuck RED (signal-only)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-09T09-54-52-946Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-09T09-54-52-946Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-09T09:54:52.946Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 7,
+  "loc": 257,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/red-pr-watchdog.eli16.md
+++ b/docs/specs/red-pr-watchdog.eli16.md
@@ -1,0 +1,39 @@
+# Red-PR Watchdog — Plain-English Overview
+
+> The one-line version: if one of my own pull requests sits RED (a required check failed) for too long, I now raise ONE quiet, self-updating heads-up instead of letting it rot unnoticed.
+
+## The problem in one breath
+
+On 2026-07-08 one of my PRs (#1399) sat red overnight and nobody noticed — the merge watcher only ever acts on *green* PRs, so a PR that goes red and *stays* red is invisible to it. The operator found it on his morning check-in. That is an "operator-found escape": the exact failure the automation is supposed to prevent.
+
+## What already exists
+
+- **Green-PR auto-merge** — a background watcher that, on each tick, lists my own open PRs and merges (or arms GitHub auto-merge on) the ones that are green, mergeable, and not held. It already fetches each PR's check status in that same list call. It has zero interest in a PR that is red — it just skips it.
+- **The attention queue** — the one place I surface things the operator should look at, with built-in coalescing so the same item never floods as many messages.
+- **The check-status reader (`deriveRollup`)** — the helper that collapses a PR's many checks into a single SUCCESS / PENDING / FAILURE verdict.
+
+## What this adds
+
+A **signal-only watchdog** bolted onto the same green-PR watcher tick. After the merge logic runs, it looks at my own open PRs and, for any that have a required check that has been failing longer than a threshold (default 2 hours), it raises ONE attention line: `PR #N red for Xh — <failing check names>`. It never merges, never closes, never blocks anything — it only tells the operator "this one is stuck." The line is de-duplicated per PR (you get one, not one every ten minutes) and only re-raised when the PR gets *older* in red or its failing checks change. The moment the PR goes green, merges, or closes, the memory is cleared so it stops being mentioned.
+
+## The new pieces
+
+- **`redPrWatchdogPass`** — the per-tick sweep. It is allowed only to *raise attention*; it is structurally forbidden from touching the merge/close path. It keeps a small per-PR "already told you" memory so it dedups and age-escalates instead of nagging.
+- **`stuckRedChecks` / `latestRunPerCheck` / `failingChecksFromRollup`** — the pure helpers that turn a PR's raw check list into "which checks are failing, and since when." Reused, no new network calls — the data was already fetched.
+- **A read surface** — `GET /green-pr-automerge` now also reports `stuckRed` (which of my PRs are flagged and for how long) and the watchdog's config, so "why did I get a red-PR alert?" is answerable by reading state, not guessing.
+
+## The safeguards
+
+**Prevents false alarms from a flaky-then-fixed check.** The same investigation surfaced a real correctness bug: the check-status reader did not de-duplicate re-runs, so a stale FAILED run that a later re-run turned green still read as FAILURE. That is fixed at the source — every check is collapsed to its *latest* run before judging — so a PR whose red check was re-run green is correctly seen as not-stuck (and, as a bonus, the green-PR merger no longer refuses to merge such a PR).
+
+**Prevents nagging.** One line per stuck PR. Re-raised only when the red gets older (a new whole-hour bucket) or the failing-check set changes. Cleared on recovery. Unknown failure-times are treated as "don't alert" — the watchdog fails toward silence, never toward crying wolf.
+
+**Prevents scope creep into authority.** It is a detector, not an actor. It cannot merge, cannot close, cannot block a message. If it is wrong, the worst case is a spurious heads-up the operator ignores — never a bad merge.
+
+## What ships when
+
+All of it ships together in one PR: the pure helpers + the correctness fix, the watchdog pass, the config default, the read-surface fields, and full unit + integration tests. It runs only where the parent green-PR watcher already runs (maintainer/dev agents with an analyzable instar repo); on every other install it is inert, exactly like the parent feature.
+
+## What you actually need to decide
+
+Is a **2-hour** default the right "stuck" threshold, and is **default-on wherever the merger is on** the right posture (versus shipping it off and opting in)? The build ships 2h + default-on — a red PR sitting silent is the incident this closes — and the threshold is tunable via `monitoring.greenPrAutoMerge.redPrWatchdog.redThresholdMs` and can be turned off with `enabled: false`.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -18245,6 +18245,9 @@ export async function startServer(options: StartOptions): Promise<void> {
             ...(gpCfg as object),
             agentNamespace,
             repo: 'JKHeadley/instar',
+            // red-pr-watchdog: thread the (optional) config block through explicitly
+            // (the class deep-merges its defaults — enabled:true, redThresholdMs:2h).
+            redPrWatchdog: (gpCfg as { redPrWatchdog?: { enabled?: boolean; redThresholdMs?: number } }).redPrWatchdog,
           } as never);
           if (greenPrAutoMerger.invariantOk) {
             guardLatchStore.markPoolArmed(); // R7: this pool is deliberately armed

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -683,6 +683,10 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       floorDriftCheckTicks: 6,
       floorDriftLookbackPrs: 10,
       floorDriftLookbackCommits: 30,
+      // red-pr-watchdog: signal-only backstop, default on. Raises ONE deduped,
+      // age-escalating attention line when a self-authored open PR is stuck RED
+      // past redThresholdMs (2h). Only runs while the parent watcher is enabled.
+      redPrWatchdog: { enabled: true, redThresholdMs: 7_200_000 },
     },
     // Master gate for Telegram delivery of silently-stopped-sentinel
     // escalations. Default false → sentinel notices are housekeeping and stay

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6181,6 +6181,14 @@ export interface MonitoringConfig {
     armTimeoutMs?: number;
     /** K-consecutive-unconfirmed-arms-on-same-head threshold before the attention line (default 3). */
     unconfirmedArmCeiling?: number;
+    /**
+     * red-pr-watchdog. Signal-only backstop: raise ONE deduped, age-escalating
+     * attention line when a self-authored open PR has a required check stuck RED
+     * past `redThresholdMs` (default 2h). Default on — a red PR sitting silent is
+     * the incident this closes. Only runs while the parent watcher runs (repo +
+     * lease gated); NEVER blocks/merges/closes.
+     */
+    redPrWatchdog?: { enabled?: boolean; redThresholdMs?: number };
   };
   /**
    * Master gate for Telegram delivery of silently-stopped-sentinel escalations

--- a/src/monitoring/GreenPrAutoMerger.ts
+++ b/src/monitoring/GreenPrAutoMerger.ts
@@ -25,6 +25,8 @@ import {
   type HoldMemoryEntry,
   classifyCandidate,
   holdReasonOf,
+  headInNamespace,
+  stuckRedChecks,
   selectOldest,
   debounceHoldRelease,
   applyOutcome,
@@ -167,6 +169,14 @@ export interface GreenPrState {
   identity?: { login: string | null; resolvedAt: number };
   /** Episodes that gave up (surfaced via attention), for the aggregate. */
   attentionLines?: string[];
+  /**
+   * red-pr-watchdog per-PR "already-raised" memory. Keyed by PR number. Present
+   * ⇔ we have surfaced this stuck-red PR; re-raised only when the elapsed-hours
+   * bucket grows OR the failing-check set changes (dedup discipline — ONE item
+   * per stuck PR). Cleared when the PR recovers (goes green) or leaves the open
+   * list (merged/closed).
+   */
+  redPrRaised?: Record<number, { at: number; firstFailAt: number; hours: number; checks: string[] }>;
 }
 
 export interface GreenPrAutoMergerConfig {
@@ -204,6 +214,14 @@ export interface GreenPrAutoMergerConfig {
   armTimeoutMs?: number;
   /** K-consecutive-unconfirmed-arms-on-same-head threshold before the Blocker-D line. */
   unconfirmedArmCeiling?: number;
+  /**
+   * red-pr-watchdog. Signal-only backstop: when a self-authored open PR has a
+   * required check stuck RED past `redThresholdMs`, raise ONE deduped,
+   * age-escalating attention line. Default on (a red PR sitting silent is the
+   * incident this closes — the 2026-07-08 operator-found escape). Runs on the
+   * same repo/lease gate as the merge path; NEVER blocks/merges/closes.
+   */
+  redPrWatchdog?: { enabled?: boolean; redThresholdMs?: number };
 }
 
 type ResolvedConfig = Required<Omit<GreenPrAutoMergerConfig, 'expectedGhLogin'>> & { expectedGhLogin: string };
@@ -230,6 +248,7 @@ const DEFAULTS = {
   armedOverdueReraiseMs: 86_400_000,
   armTimeoutMs: 60_000,
   unconfirmedArmCeiling: 3,
+  redPrWatchdog: { enabled: true, redThresholdMs: 7_200_000 },
 };
 
 export function freshState(): GreenPrState {
@@ -239,6 +258,7 @@ export function freshState(): GreenPrState {
     episodes: {},
     holdMemory: {},
     snapshot: { at: 0, entries: [] },
+    redPrRaised: {},
   };
 }
 
@@ -262,6 +282,12 @@ export class GreenPrAutoMerger extends EventEmitter {
       agentNamespace: cfg.agentNamespace,
       repo: cfg.repo,
       expectedGhLogin: cfg.expectedGhLogin ?? '',
+      // Deep-merge the nested watchdog block so a partial override (e.g. just
+      // `enabled:false`) keeps the other default instead of dropping it.
+      redPrWatchdog: {
+        enabled: cfg.redPrWatchdog?.enabled ?? DEFAULTS.redPrWatchdog.enabled,
+        redThresholdMs: cfg.redPrWatchdog?.redThresholdMs ?? DEFAULTS.redPrWatchdog.redThresholdMs,
+      },
     } as ResolvedConfig;
     // B24 invariant scope (mergerunner-auto-arm-handoff §armTimeoutMs): on the
     // auto path the busy-skip budget is checked against the SHORT armTimeoutMs
@@ -399,6 +425,14 @@ export class GreenPrAutoMerger extends EventEmitter {
     // Build the candidate set (cheap fields) + the Layer-2 snapshot.
     const { eligible, snapshotEntries } = await this.gather(candidates, state);
     state.snapshot = { at: this.deps.now(), entries: snapshotEntries };
+
+    // Red-PR watchdog (red-pr-watchdog): surface my own PRs stuck RED past the
+    // threshold. Runs on every acting/warm-up tick that got a fresh PR list —
+    // same repo/lease gate as the merge path. SIGNAL-ONLY: it only raises
+    // attention (mutations here are persisted by the saveState below, whichever
+    // branch returns). Placed AFTER the merge-candidate gather so a stuck-red PR
+    // is surfaced even on a lease-flap warm-up tenure.
+    this.redPrWatchdogPass(candidates, state);
 
     if (isWarmup) {
       // Seed hold memory + snapshot + reap any orphan; begin merges next tick.
@@ -814,6 +848,93 @@ export class GreenPrAutoMerger extends EventEmitter {
     try {
       await this.deps.postAttentionAggregate(state.attentionLines);
     } catch { /* @silent-fallback-ok: green-pr-automerge fail-safe — skip/refuse, never over-merge; safe-merge is the act-time authority */ /* attention delivery failure is non-fatal to the tick */ }
+  }
+
+  // ---- red-PR watchdog (red-pr-watchdog) ----------------------------------
+
+  /**
+   * SIGNAL-ONLY pass over MY OWN open PRs: raise ONE deduped, age-escalating
+   * attention line for each PR that has a required check stuck RED past
+   * `redThresholdMs`. Never blocks/merges/closes — it only calls refreshAggregate.
+   *
+   * Dedup: per-PR `redPrRaised` memory. First stuck observation raises; after
+   * that, re-raise only when the elapsed-hours bucket GROWS or the failing-check
+   * SET changes. A PR that recovers (no stuck-red checks) or leaves the open list
+   * (merged/closed) has its memory cleared (Close the Loop).
+   *
+   * "My own" is the branch-namespace filter (a pure proxy for author — listOpenPrs
+   * already passes `--author @me`, and PrSummary carries no author field).
+   */
+  private redPrWatchdogPass(prs: PrSummary[], state: GreenPrState): void {
+    const wd = this.cfg.redPrWatchdog;
+    if (!wd || wd.enabled === false) return;
+    const now = this.deps.now();
+    const thresholdMs = wd.redThresholdMs ?? DEFAULTS.redPrWatchdog.redThresholdMs;
+    const raised = (state.redPrRaised ??= {});
+    const openPrNumbers = new Set(prs.map((p) => p.number));
+    const lines: string[] = [];
+
+    for (const pr of prs) {
+      // Only my own PRs (branch-namespace proxy for author).
+      if (!headInNamespace(pr.headRefName, this.cfg.agentNamespace)) continue;
+      const stuck = stuckRedChecks(pr, now, thresholdMs);
+      if (stuck.length === 0) {
+        // Green / recovered / not-yet-stuck → clear any prior raise.
+        if (raised[pr.number]) {
+          delete raised[pr.number];
+          this.deps.audit({ kind: 'green-pr-automerge', event: 'red-pr-recovered', pr: pr.number });
+        }
+        continue;
+      }
+      const checkNames = [...new Set(stuck.map((c) => c.name))].sort();
+      const firstFailAt = Math.min(...stuck.map((c) => c.completedAt));
+      const hours = Math.max(1, Math.round((now - firstFailAt) / 3_600_000));
+      const prior = raised[pr.number];
+      const checksChanged = !prior || prior.checks.join(' ') !== checkNames.join(' ');
+      const aged = !!prior && hours > prior.hours;
+      if (!prior || aged || checksChanged) {
+        raised[pr.number] = { at: now, firstFailAt, hours, checks: checkNames };
+        lines.push(`PR #${pr.number} red for ${hours}h — ${checkNames.join(', ')}`);
+        this.deps.audit({ kind: 'green-pr-automerge', event: 'red-pr-stuck', pr: pr.number, hours, checks: checkNames });
+      }
+    }
+
+    // Clear memory for PRs no longer in the open list (they merged/closed).
+    for (const key of Object.keys(raised)) {
+      const n = Number(key);
+      if (!openPrNumbers.has(n)) {
+        delete raised[n];
+        this.deps.audit({ kind: 'green-pr-automerge', event: 'red-pr-cleared', pr: n, reason: 'closed-or-merged' });
+      }
+    }
+
+    if (lines.length > 0) void this.refreshAggregate(state, lines);
+  }
+
+  /**
+   * The GET /green-pr-automerge read surface for the watchdog: the current
+   * config + the live stuck-red memory (answers "why did I get a red-PR alert?").
+   * `redForMs` is measured from each PR's oldest failing check.
+   */
+  redPrWatchdogView(): {
+    config: { enabled: boolean; redThresholdMs: number };
+    stuckRed: { pr: number; redForMs: number; failingChecks: string[] }[];
+  } {
+    const state = this.deps.loadState();
+    const now = this.deps.now();
+    const raised = state.redPrRaised ?? {};
+    const stuckRed = Object.entries(raised).map(([pr, r]) => ({
+      pr: Number(pr),
+      redForMs: Math.max(0, now - (r.firstFailAt ?? r.at ?? now)),
+      failingChecks: Array.isArray(r.checks) ? r.checks : [],
+    }));
+    return {
+      config: {
+        enabled: this.cfg.redPrWatchdog.enabled !== false,
+        redThresholdMs: this.cfg.redPrWatchdog.redThresholdMs ?? DEFAULTS.redPrWatchdog.redThresholdMs,
+      },
+      stuckRed,
+    };
   }
 
   // ---- runtime control (R9, via GuardLatchStore wired at boot) ------------

--- a/src/monitoring/greenPrAutomergeWiring.ts
+++ b/src/monitoring/greenPrAutomergeWiring.ts
@@ -38,7 +38,7 @@ import {
   type ProtectedPathsVerdict,
   freshState,
 } from './GreenPrAutoMerger.js';
-import type { PrSummary } from './greenPrLogic.js';
+import { latestRunPerCheck, failingChecksFromRollup, FAILING_CONCLUSIONS, type PrSummary } from './greenPrLogic.js';
 
 /** Protected globs (round-4/6): a PR touching these never auto-merges. */
 export const PROTECTED_PATH_PREFIXES = [
@@ -299,19 +299,28 @@ function mapPr(row: Record<string, unknown>): PrSummary {
     // mergerunner-auto-arm-handoff Blocker 4: GitHub-side armed state, derived
     // from the autoMergeRequest field of the widened pr-list projection.
     autoMergeArmed: !!row.autoMergeRequest,
+    // red-pr-watchdog: the latest-run-per-check FAILING checks (no new gh call —
+    // derived from the same rollup the list projection already fetched).
+    failingChecks: failingChecksFromRollup(rollup),
   };
 }
 
-/** Derive a single SUCCESS|PENDING|FAILURE from the statusCheckRollup array. */
+/**
+ * Derive a single SUCCESS|PENDING|FAILURE from the statusCheckRollup array.
+ *
+ * red-pr-watchdog correctness fix: dedup to the LATEST run per check name BEFORE
+ * collapsing. Previously a stale FAILED run superseded by a passing rerun still
+ * short-circuited to 'FAILURE' (the 2026-07-08 bug). latestRunPerCheck keeps only
+ * the newest run of each check, so a green rerun correctly reads SUCCESS.
+ */
 export function deriveRollup(rollup: unknown): string | null {
   if (!Array.isArray(rollup)) return typeof rollup === 'string' ? rollup : null;
   let sawPending = false;
-  for (const c of rollup as Array<Record<string, unknown>>) {
-    const state = String(c.state ?? c.conclusion ?? '').toUpperCase();
-    const status = String(c.status ?? '').toUpperCase();
-    if (status && status !== 'COMPLETED') { sawPending = true; continue; }
-    if (state === 'FAILURE' || state === 'ERROR' || state === 'CANCELLED' || state === 'TIMED_OUT') return 'FAILURE';
-    if (state === 'PENDING' || state === 'EXPECTED' || state === 'IN_PROGRESS' || state === 'QUEUED') sawPending = true;
+  for (const c of latestRunPerCheck(rollup)) {
+    // A check whose latest run has not COMPLETED (an in-progress rerun) is pending.
+    if (c.status && c.status !== 'COMPLETED') { sawPending = true; continue; }
+    if (FAILING_CONCLUSIONS.has(c.conclusion)) return 'FAILURE';
+    if (c.conclusion === 'PENDING' || c.conclusion === 'EXPECTED' || c.conclusion === 'IN_PROGRESS' || c.conclusion === 'QUEUED') sawPending = true;
   }
   return sawPending ? 'PENDING' : 'SUCCESS';
 }

--- a/src/monitoring/greenPrLogic.ts
+++ b/src/monitoring/greenPrLogic.ts
@@ -28,6 +28,97 @@ export interface PrSummary {
    * Blocker 4: GitHub-side armed state is authoritative, not the local episode).
    */
   autoMergeArmed?: boolean;
+  /**
+   * Red-PR watchdog (red-pr-watchdog). The LATEST-run-per-check checks whose
+   * conclusion is a failing one (FAILURE|ERROR|CANCELLED|TIMED_OUT), each with
+   * its `completedAt` ms. Populated by mapPr from the raw statusCheckRollup —
+   * already fetched by the list projection (no new gh call). Absent on a legacy
+   * projection. `completedAt:0` means the timestamp was unknown.
+   */
+  failingChecks?: { name: string; completedAt: number }[];
+}
+
+/**
+ * A single check normalized from a raw statusCheckRollup entry (either a
+ * CheckRun — `name`/`conclusion`/`status`/`startedAt`/`completedAt` — or a
+ * legacy StatusContext — `context`/`state`/`createdAt`). Timestamps are ms
+ * (0 when unknown); `conclusion`/`status` are upper-cased.
+ */
+export interface NormalizedCheck {
+  name: string;
+  conclusion: string;
+  status: string;
+  startedAt: number;
+  completedAt: number;
+}
+
+/** Conclusions that read as a failing (red) check. Kept in lockstep with deriveRollup's FAILURE set. */
+export const FAILING_CONCLUSIONS: ReadonlySet<string> = new Set(['FAILURE', 'ERROR', 'CANCELLED', 'TIMED_OUT']);
+
+/** Coerce a gh timestamp (ISO string or ms number) to ms; 0 when unparseable/absent. */
+function toMs(v: unknown): number {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string' && v) {
+    const t = Date.parse(v);
+    return Number.isFinite(t) ? t : 0;
+  }
+  return 0;
+}
+
+/**
+ * Collapse a raw statusCheckRollup to the LATEST run per check name (group by
+ * name, keep the entry with the max run-time). This is the dedup that fixes the
+ * 2026-07-08 bug: a stale FAILED run superseded by a passing rerun must not read
+ * as failure. Unnamed checks never collapse together (each kept as-is).
+ */
+export function latestRunPerCheck(rollup: unknown): NormalizedCheck[] {
+  if (!Array.isArray(rollup)) return [];
+  const byName = new Map<string, NormalizedCheck>();
+  const anon: NormalizedCheck[] = [];
+  for (const raw of rollup as Array<Record<string, unknown>>) {
+    if (!raw || typeof raw !== 'object') continue;
+    const name = String(raw.name ?? raw.context ?? '').trim();
+    const conclusion = String(raw.conclusion ?? raw.state ?? '').toUpperCase();
+    const status = String(raw.status ?? '').toUpperCase();
+    const startedAt = toMs(raw.startedAt);
+    const completedAt = toMs(raw.completedAt) || toMs(raw.startedAt) || toMs((raw as { createdAt?: unknown }).createdAt);
+    const norm: NormalizedCheck = { name, conclusion, status, startedAt, completedAt };
+    if (!name) { anon.push(norm); continue; }
+    const prev = byName.get(name);
+    if (!prev) { byName.set(name, norm); continue; }
+    // Later run wins: order by best-available run time (startedAt, else completedAt).
+    const prevOrder = prev.startedAt || prev.completedAt;
+    const order = startedAt || completedAt;
+    if (order >= prevOrder) byName.set(name, norm);
+  }
+  return [...byName.values(), ...anon];
+}
+
+/**
+ * The failing (red) checks of a PR's rollup, deduped to the latest run per check.
+ * Each carries its `completedAt` ms so the watchdog can age it. An in-progress
+ * rerun (status != COMPLETED) is never counted as failing even if a prior run
+ * failed — latestRunPerCheck already dropped the superseded run.
+ */
+export function failingChecksFromRollup(rollup: unknown): { name: string; completedAt: number }[] {
+  return latestRunPerCheck(rollup)
+    .filter((c) => (!c.status || c.status === 'COMPLETED') && FAILING_CONCLUSIONS.has(c.conclusion))
+    .map((c) => ({ name: c.name || '(unnamed check)', completedAt: c.completedAt }));
+}
+
+/**
+ * The failing checks of a PR that have been red for at least `thresholdMs`
+ * (measured from each check's `completedAt`). A check with an unknown completed
+ * time (completedAt:0) is NOT counted — we can't prove it has been red long
+ * enough, so we fail toward NOT alerting (signal-only).
+ */
+export function stuckRedChecks(
+  pr: Pick<PrSummary, 'failingChecks'>,
+  now: number,
+  thresholdMs: number,
+): { name: string; completedAt: number }[] {
+  const failing = pr.failingChecks ?? [];
+  return failing.filter((c) => c.completedAt > 0 && now - c.completedAt >= thresholdMs);
 }
 
 export type HoldReason = 'draft' | 'hold-title' | 'hold-label' | null;

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -10492,6 +10492,9 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     // invisible). NON-OPTIONAL — a NUMBER (0) / EMPTY ARRAY when nothing is armed.
     const armedEpisodes = Object.values(state.episodes ?? {}).filter((e) => e.armedAt != null);
     const armed = armedEpisodes.map((e) => ({ pr: e.pr, armedAt: e.armedAt ?? null, armedHead: e.armedHead ?? null, overdue: e.overdue === true }));
+    // red-pr-watchdog: the stuck-red memory + config (answers "why did I get a
+    // red-PR alert?"). NON-OPTIONAL — an EMPTY ARRAY when nothing is stuck red.
+    const wd = ctx.greenPrAutoMerger.redPrWatchdogView();
     res.json({
       lastTickAt: state.lastTickAt ?? null,
       lastSuccessfulListAt: state.lastSuccessfulListAt ?? null,
@@ -10500,6 +10503,8 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       episodes: Object.values(state.episodes ?? {}),
       armedCount: armed.length,
       armed,
+      stuckRed: wd.stuckRed,
+      redPrWatchdog: wd.config,
       snapshot: state.snapshot,
       gate: latch,
       invariantOk: ctx.greenPrAutoMerger.invariantOk,

--- a/tests/integration/green-pr-automerge-routes.test.ts
+++ b/tests/integration/green-pr-automerge-routes.test.ts
@@ -189,6 +189,35 @@ describe('green-pr-automerge routes (integration)', () => {
     expect(res.body.disarmed).toContain(88);
   });
 
+  // ── red-pr-watchdog ─────────────────────────────────────────────────────
+
+  it('GET surfaces redPrWatchdog config + an empty stuckRed[] when nothing is stuck (feature-alive)', async () => {
+    const watcher = fakeWatcher(stateDir, latches);
+    const app = appWith(baseCtx(stateDir, { greenPrAutoMerger: watcher, guardLatchStore: latches }));
+    const res = await request(app).get('/green-pr-automerge');
+    expect(res.status).toBe(200);
+    expect(res.body.stuckRed).toEqual([]); // non-optional, empty when nothing is red
+    expect(res.body.redPrWatchdog).toMatchObject({ enabled: true, redThresholdMs: 7_200_000 });
+  });
+
+  it('a tick over a stuck-red self-authored PR surfaces it in GET stuckRed[]', async () => {
+    const redPr: PrSummary = {
+      number: 1399, title: 'feat: money', labels: [], isDraft: false,
+      headRefName: 'echo/money', headRefOid: 'sha1399', mergeable: 'MERGEABLE', statusRollup: 'FAILURE',
+      failingChecks: [{ name: 'shard 4', completedAt: Date.now() - 3 * 3_600_000 }], // red for ~3h > 2h threshold
+    };
+    const watcher = fakeWatcher(stateDir, latches, [redPr]);
+    const app = appWith(baseCtx(stateDir, { greenPrAutoMerger: watcher, guardLatchStore: latches }));
+    // One tick (warm-up) runs the watchdog and records the stuck-red memory.
+    const tick = await request(app).post('/green-pr-automerge/tick');
+    expect(tick.status).toBe(200);
+    const res = await request(app).get('/green-pr-automerge');
+    expect(res.status).toBe(200);
+    expect(res.body.stuckRed).toHaveLength(1);
+    expect(res.body.stuckRed[0]).toMatchObject({ pr: 1399, failingChecks: ['shard 4'] });
+    expect(res.body.stuckRed[0].redForMs).toBeGreaterThanOrEqual(2 * 3_600_000);
+  });
+
   it('rollback is a null-safe no-op for disarm when the merger is absent (latch still set)', async () => {
     // guardLatchStore present, greenPrAutoMerger null → the route still rolls
     // back the latch and does not throw on the in-line disarm.

--- a/tests/unit/green-pr-red-watchdog.test.ts
+++ b/tests/unit/green-pr-red-watchdog.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tier-1 tests for the red-PR watchdog (red-pr-watchdog).
+ *
+ * Two layers:
+ *  1. The pure rollup helpers — latestRunPerCheck / failingChecksFromRollup /
+ *     stuckRedChecks / the deriveRollup latest-run-dedup fix (the 2026-07-08
+ *     bug: a stale FAILED run superseded by a passing rerun must NOT read
+ *     FAILURE).
+ *  2. The orchestrator pass — redPrWatchdogPass raises ONE deduped,
+ *     age-escalating attention line for a self-authored PR stuck RED past the
+ *     threshold; clears on recovery; skips a green / not-authored-by-me PR.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  latestRunPerCheck,
+  failingChecksFromRollup,
+  stuckRedChecks,
+  type PrSummary,
+} from '../../src/monitoring/greenPrLogic.js';
+import { deriveRollup } from '../../src/monitoring/greenPrAutomergeWiring.js';
+import {
+  GreenPrAutoMerger,
+  freshState,
+  type GreenPrAutoMergerDeps,
+  type GreenPrState,
+} from '../../src/monitoring/GreenPrAutoMerger.js';
+
+const NOW = 1_700_000_000_000; // fixed clock for determinism
+const H = 3_600_000;
+const iso = (ms: number) => new Date(ms).toISOString();
+
+const pr = (over: Partial<PrSummary> = {}): PrSummary => ({
+  number: 100, title: 'feat: x', labels: [], isDraft: false,
+  headRefName: 'echo/feature', headRefOid: 'sha100', mergeable: 'MERGEABLE', statusRollup: 'SUCCESS', ...over,
+});
+
+// ── pure rollup helpers ────────────────────────────────────────────────────
+
+describe('latestRunPerCheck — dedup to the newest run per check name', () => {
+  it('keeps the later run when a check name repeats (by startedAt)', () => {
+    const rollup = [
+      { __typename: 'CheckRun', name: 'shard 4', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: iso(NOW - 3 * H), completedAt: iso(NOW - 3 * H + 60_000) },
+      { __typename: 'CheckRun', name: 'shard 4', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: iso(NOW - 1 * H), completedAt: iso(NOW - 1 * H + 60_000) },
+    ];
+    const latest = latestRunPerCheck(rollup);
+    expect(latest).toHaveLength(1);
+    expect(latest[0].conclusion).toBe('SUCCESS'); // the newer run wins
+  });
+
+  it('keeps distinct check names separate and preserves unnamed checks', () => {
+    const rollup = [
+      { name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: iso(NOW) },
+      { name: 'test', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: iso(NOW), completedAt: iso(NOW) },
+      { context: 'legacy-status', state: 'FAILURE', createdAt: iso(NOW) }, // StatusContext shape
+      { status: 'COMPLETED', conclusion: 'SUCCESS' }, // unnamed → kept as-is
+    ];
+    const latest = latestRunPerCheck(rollup);
+    expect(latest.map((c) => c.name).sort()).toEqual(['', 'legacy-status', 'lint', 'test']);
+    // StatusContext state maps into `conclusion`.
+    expect(latest.find((c) => c.name === 'legacy-status')?.conclusion).toBe('FAILURE');
+  });
+});
+
+describe('failingChecksFromRollup', () => {
+  it('returns only latest-run failing checks with their completedAt', () => {
+    const rollup = [
+      { name: 'shard 1', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: iso(NOW), completedAt: iso(NOW) },
+      { name: 'shard 4', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: iso(NOW - 2 * H), completedAt: iso(NOW - 2 * H) },
+    ];
+    const failing = failingChecksFromRollup(rollup);
+    expect(failing).toHaveLength(1);
+    expect(failing[0].name).toBe('shard 4');
+    expect(failing[0].completedAt).toBe(NOW - 2 * H);
+  });
+
+  it('does NOT report a failing check that a later run turned green (the 2026-07-08 regression)', () => {
+    const rollup = [
+      { name: 'shard 4', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: iso(NOW - 3 * H), completedAt: iso(NOW - 3 * H) },
+      { name: 'shard 4', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: iso(NOW - 1 * H), completedAt: iso(NOW - 1 * H) },
+    ];
+    expect(failingChecksFromRollup(rollup)).toEqual([]);
+  });
+
+  it('treats ERROR / CANCELLED / TIMED_OUT as failing but SKIPPED / NEUTRAL as not', () => {
+    const rollup = [
+      { name: 'a', status: 'COMPLETED', conclusion: 'ERROR', completedAt: iso(NOW) },
+      { name: 'b', status: 'COMPLETED', conclusion: 'TIMED_OUT', completedAt: iso(NOW) },
+      { name: 'c', status: 'COMPLETED', conclusion: 'SKIPPED', completedAt: iso(NOW) },
+      { name: 'd', status: 'COMPLETED', conclusion: 'NEUTRAL', completedAt: iso(NOW) },
+    ];
+    expect(failingChecksFromRollup(rollup).map((c) => c.name).sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('stuckRedChecks', () => {
+  const thresholdMs = 2 * H;
+  it('flags a failing check older than the threshold', () => {
+    const p = pr({ failingChecks: [{ name: 'shard 4', completedAt: NOW - 3 * H }] });
+    expect(stuckRedChecks(p, NOW, thresholdMs)).toHaveLength(1);
+  });
+  it('does NOT flag a fresh failure below the threshold (mid-churn)', () => {
+    const p = pr({ failingChecks: [{ name: 'shard 4', completedAt: NOW - 1 * H }] });
+    expect(stuckRedChecks(p, NOW, thresholdMs)).toEqual([]);
+  });
+  it('does NOT flag a failing check with an unknown completed time (fail toward not-alerting)', () => {
+    const p = pr({ failingChecks: [{ name: 'shard 4', completedAt: 0 }] });
+    expect(stuckRedChecks(p, NOW, thresholdMs)).toEqual([]);
+  });
+  it('a PR with no failing checks is never stuck', () => {
+    expect(stuckRedChecks(pr(), NOW, thresholdMs)).toEqual([]);
+  });
+});
+
+describe('deriveRollup — latest-run dedup fix', () => {
+  it('a stale FAILED run superseded by a passing rerun reads SUCCESS, not FAILURE', () => {
+    const rollup = [
+      { name: 'shard 4', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: iso(NOW - 3 * H) },
+      { name: 'shard 4', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: iso(NOW - 1 * H) },
+    ];
+    expect(deriveRollup(rollup)).toBe('SUCCESS');
+  });
+  it('a genuinely-failed latest run still reads FAILURE', () => {
+    const rollup = [
+      { name: 'shard 4', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: iso(NOW - 3 * H) },
+      { name: 'shard 4', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: iso(NOW - 1 * H) },
+    ];
+    expect(deriveRollup(rollup)).toBe('FAILURE');
+  });
+  it('an in-progress rerun reads PENDING even after a prior failure', () => {
+    const rollup = [
+      { name: 'shard 4', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: iso(NOW - 3 * H) },
+      { name: 'shard 4', status: 'IN_PROGRESS', conclusion: null, startedAt: iso(NOW - 1 * H) },
+    ];
+    expect(deriveRollup(rollup)).toBe('PENDING');
+  });
+  it('all-green reads SUCCESS; a string passthrough is preserved', () => {
+    expect(deriveRollup([{ name: 'a', status: 'COMPLETED', conclusion: 'SUCCESS' }])).toBe('SUCCESS');
+    expect(deriveRollup('SUCCESS')).toBe('SUCCESS');
+    expect(deriveRollup(null)).toBeNull();
+  });
+});
+
+// ── orchestrator pass ───────────────────────────────────────────────────────
+
+interface Harness {
+  deps: GreenPrAutoMergerDeps;
+  state: GreenPrState;
+  audits: Record<string, unknown>[];
+  attentionCalls: string[][];
+}
+
+function harness(prs: PrSummary[], opts: { epoch?: number } = {}): Harness {
+  const state = freshState();
+  const audits: Record<string, unknown>[] = [];
+  const attentionCalls: string[][] = [];
+  const deps: GreenPrAutoMergerDeps = {
+    holdsLease: () => true,
+    leaseEpoch: () => opts.epoch ?? 1,
+    listOpenPrs: async () => prs,
+    protectedPaths: async () => ({ touches: false, unverifiable: false }),
+    refetchPr: async () => ({ title: 'feat', labels: [], isDraft: false, headRefOid: 'sha100', state: 'OPEN', autoMergeRequest: null }),
+    disarmArmedEpisodes: async () => true,
+    resolveGhLogin: async () => 'echo-bot',
+    holdEligible: async () => ({ ok: true }),
+    applyHoldMarker: async () => true,
+    runner: {
+      probeContract: async () => ({ ok: true, version: 2 }),
+      run: async () => ({ outcome: 'merged', confirmedMerged: true }),
+      reapOrphan: async () => ({ reaped: false }),
+    },
+    latches: { isMergeAllowed: () => ({ allowed: true, reason: 'allowed', activeLatchIds: {} }) },
+    postAttentionAggregate: async (lines) => { attentionCalls.push(lines); },
+    audit: (e) => audits.push(e),
+    loadState: () => state,
+    saveState: () => { /* in-place */ },
+    now: () => NOW,
+  };
+  return { deps, state, audits, attentionCalls };
+}
+
+const cfg = { agentNamespace: 'echo', repo: 'JKHeadley/instar', enabled: true, expectedGhLogin: 'echo-bot' };
+const redPr = (over: Partial<PrSummary> = {}) =>
+  pr({ number: 1399, statusRollup: 'FAILURE', failingChecks: [{ name: 'shard 4', completedAt: NOW - 3 * H }], ...over });
+
+describe('redPrWatchdogPass — orchestrator', () => {
+  it('(a) a self-authored PR stuck RED past the threshold raises ONE attention line', async () => {
+    const h = harness([redPr()]);
+    await new GreenPrAutoMerger(h.deps, cfg).tick(); // warm-up tick still runs the watchdog
+    expect(h.attentionCalls).toHaveLength(1);
+    expect(h.attentionCalls[0].some((l) => /PR #1399 red for 3h — shard 4/.test(l))).toBe(true);
+    expect(h.state.redPrRaised?.[1399]).toBeTruthy();
+    expect(h.audits.some((a) => a.event === 'red-pr-stuck' && a.pr === 1399)).toBe(true);
+  });
+
+  it('(b) a fresh failure BELOW the threshold raises nothing (mid-churn)', async () => {
+    const h = harness([redPr({ failingChecks: [{ name: 'shard 4', completedAt: NOW - 1 * H }] })]);
+    await new GreenPrAutoMerger(h.deps, cfg).tick();
+    expect(h.attentionCalls).toHaveLength(0);
+    expect(h.state.redPrRaised?.[1399]).toBeUndefined();
+  });
+
+  it('(c) a stale FAILED run superseded by a passing rerun is NOT stuck-red (the tonight-bug regression)', async () => {
+    // The wiring would have set failingChecks:[] via latestRunPerCheck; model that here.
+    const h = harness([redPr({ statusRollup: 'SUCCESS', failingChecks: [] })]);
+    await new GreenPrAutoMerger(h.deps, cfg).tick();
+    expect(h.attentionCalls).toHaveLength(0);
+    expect(h.state.redPrRaised?.[1399]).toBeUndefined();
+  });
+
+  it('(d) the same stuck PR over two ticks raises ONE item (redPrRaised dedup memory)', async () => {
+    const h = harness([redPr()]);
+    const merger = new GreenPrAutoMerger(h.deps, cfg);
+    await merger.tick(); // warm-up: raises
+    await merger.tick(); // acting: same age + checks → no re-raise
+    expect(h.attentionCalls).toHaveLength(1);
+  });
+
+  it('(e) a green PR raises nothing', async () => {
+    const h = harness([pr({ number: 1399 })]); // statusRollup SUCCESS, no failingChecks
+    await new GreenPrAutoMerger(h.deps, cfg).tick();
+    expect(h.attentionCalls).toHaveLength(0);
+    expect(h.state.redPrRaised?.[1399]).toBeUndefined();
+  });
+
+  it('(f) a PR NOT authored by me (out of namespace) is skipped even if stuck red', async () => {
+    const h = harness([redPr({ headRefName: 'dawn/other' })]);
+    await new GreenPrAutoMerger(h.deps, cfg).tick();
+    expect(h.attentionCalls).toHaveLength(0);
+    expect(h.state.redPrRaised?.[1399]).toBeUndefined();
+  });
+
+  it('clears the raise memory when the PR recovers (goes green)', async () => {
+    const h = harness([redPr()]);
+    const merger = new GreenPrAutoMerger(h.deps, cfg);
+    await merger.tick(); // raised
+    expect(h.state.redPrRaised?.[1399]).toBeTruthy();
+    // Same PR now green.
+    (h.deps as { listOpenPrs: () => Promise<PrSummary[]> }).listOpenPrs = async () => [pr({ number: 1399 })];
+    await merger.tick();
+    expect(h.state.redPrRaised?.[1399]).toBeUndefined();
+    expect(h.audits.some((a) => a.event === 'red-pr-recovered' && a.pr === 1399)).toBe(true);
+  });
+
+  it('clears the raise memory when the PR leaves the open list (merged/closed)', async () => {
+    const h = harness([redPr()]);
+    const merger = new GreenPrAutoMerger(h.deps, cfg);
+    await merger.tick(); // raised
+    (h.deps as { listOpenPrs: () => Promise<PrSummary[]> }).listOpenPrs = async () => [];
+    await merger.tick();
+    expect(h.state.redPrRaised?.[1399]).toBeUndefined();
+    expect(h.audits.some((a) => a.event === 'red-pr-cleared' && a.pr === 1399)).toBe(true);
+  });
+
+  it('re-raises on age escalation (elapsed-hours bucket grows)', async () => {
+    const h = harness([redPr()]);
+    const merger = new GreenPrAutoMerger(h.deps, cfg);
+    await merger.tick(); // raised at 3h
+    // Advance the failing check's age to 5h by re-listing with an older completedAt.
+    (h.deps as { listOpenPrs: () => Promise<PrSummary[]> }).listOpenPrs =
+      async () => [redPr({ failingChecks: [{ name: 'shard 4', completedAt: NOW - 5 * H }] })];
+    await merger.tick();
+    expect(h.attentionCalls).toHaveLength(2);
+    expect(h.attentionCalls[1].some((l) => /red for 5h/.test(l))).toBe(true);
+  });
+
+  it('is a no-op when disabled via config', async () => {
+    const h = harness([redPr()]);
+    await new GreenPrAutoMerger(h.deps, { ...cfg, redPrWatchdog: { enabled: false } }).tick();
+    expect(h.attentionCalls).toHaveLength(0);
+    expect(h.state.redPrRaised?.[1399]).toBeUndefined();
+  });
+
+  it('redPrWatchdogView surfaces config + live stuck-red memory', async () => {
+    const h = harness([redPr()]);
+    const merger = new GreenPrAutoMerger(h.deps, cfg);
+    await merger.tick();
+    const view = merger.redPrWatchdogView();
+    expect(view.config).toEqual({ enabled: true, redThresholdMs: 7_200_000 });
+    expect(view.stuckRed).toHaveLength(1);
+    expect(view.stuckRed[0]).toMatchObject({ pr: 1399, failingChecks: ['shard 4'] });
+    expect(view.stuckRed[0].redForMs).toBe(3 * H);
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -377,30 +377,38 @@ describe('lint-dev-agent-dark-gate', () => {
       '636': 'monitoring.apprenticeshipCycleSla.enabled',
       '644': 'monitoring.geminiCapacityEscalation.enabled',
       '668': 'monitoring.greenPrAutoMerge.enabled',
-      '718': 'threadline.a2aCheckIn.enabled',
-      '849': 'mentor.enabled',
-      '860': 'mentor.autonomousFix.enabled',
-      '875': 'mentee.enabled',
-      '935': 'prGate.classClosure.enabled',
+      // red-pr-watchdog (2026-07-09): a 4-line `redPrWatchdog` default sub-block
+      // (3 comment lines + `redPrWatchdog: { enabled: true, ... }`) was inserted
+      // INSIDE the greenPrAutoMerge block, BELOW its `enabled: false` (668). It
+      // OMITS an `enabled: false` literal (its `enabled: true` is not a dark-gate
+      // row), so it adds NO attributed path — it only shifts every `enabled: false`
+      // line below it DOWN by +4. Path SET unchanged (still 25 entries, same dotted
+      // paths); RE-VERIFIED via attributeEnabledFalsePaths on the edited
+      // ConfigDefaults (uniform +4 shift, no new/removed entries).
+      '722': 'threadline.a2aCheckIn.enabled',
+      '853': 'mentor.enabled',
+      '864': 'mentor.autonomousFix.enabled',
+      '879': 'mentee.enabled',
+      '939': 'prGate.classClosure.enabled',
       // +21 lines below: spec #3's multiMachine.seamlessOrchestrator dev-gated
       // sub-block (docs/specs/llm-seamlessness-orchestrator.md) was inserted at the
       // TOP of the multiMachine block; it OMITS `enabled` (rides resolveDevAgentGate),
       // adds no map row, and shifts every subsequent `enabled:` line by +21.
-      '1019': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
-      '1023': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
-      '1030': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
-      '1040': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
-      '1277': 'multiMachine.sessionPool.enabled',
+      '1023': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
+      '1027': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
+      '1034': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
+      '1044': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
+      '1281': 'multiMachine.sessionPool.enabled',
       // #1367's moveIntent dev-gated sub-block was inserted under sessionPool
       // (docs/specs/nickname-move-intent-llm-rebuild.md); it OMITS `enabled` (rides
       // resolveDevAgentGate), adds no map row, and shifts the subsequent lines.
-      '1321': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
-      '1331': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '1360': 'multiMachine.sessionPool.holdForStability.enabled',
-      '1555': 'multiMachine.stateSync.threadlinePairing.enabled',
-      '1696': 'cartographer.freshnessSweep.enabled',
-      '1741': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1766': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1325': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
+      '1335': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '1364': 'multiMachine.sessionPool.holdForStability.enabled',
+      '1559': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1700': 'cartographer.freshnessSweep.enabled',
+      '1745': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1770': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/upgrades/next/red-pr-watchdog.md
+++ b/upgrades/next/red-pr-watchdog.md
@@ -1,0 +1,76 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+A signal-only **red-PR watchdog** on the existing green-PR auto-merge watcher. Green-PR
+auto-merge only ever acts on GREEN PRs, so a PR of mine that goes RED and *stays* red is
+invisible to it — which is exactly how PR #1399 sat red overnight on 2026-07-08 until the
+operator found it on his morning check-in (an operator-found escape). The watchdog closes
+that gap: after the merge logic runs each tick, it checks my own open PRs and raises ONE
+deduped, age-escalating attention line — `PR #N red for Xh — <failing check names>` — for
+any PR with a required check stuck RED past a threshold (default 2h). It is SIGNAL-ONLY:
+it never merges, closes, or blocks anything.
+
+- `src/monitoring/greenPrLogic.ts` — new pure helpers `latestRunPerCheck` (dedup a rollup
+  to the newest run per check name), `failingChecksFromRollup`, and `stuckRedChecks`; plus
+  a `failingChecks` field on `PrSummary`. **Correctness fix:** `deriveRollup` now dedups to
+  the latest run per check BEFORE collapsing — a stale FAILED run superseded by a passing
+  re-run previously still read `FAILURE` (the exact bug the overnight incident surfaced),
+  which also made the green-PR merger refuse an actually-green PR.
+- `src/monitoring/greenPrAutomergeWiring.ts` — `mapPr` populates `failingChecks` from the
+  same `statusCheckRollup` the list projection already fetches (no new gh call).
+- `src/monitoring/GreenPrAutoMerger.ts` — `tick()` runs `redPrWatchdogPass` after the merge
+  logic; a per-PR `redPrRaised` memory (in state) dedups to ONE item, re-raised only on age
+  escalation or a changed failing-check set, and cleared when the PR goes green / merges /
+  closes. New `redPrWatchdog` config (`{ enabled, redThresholdMs }`, default
+  `{ enabled: true, redThresholdMs: 7_200_000 }`).
+- `src/server/routes.ts` — `GET /green-pr-automerge` now returns `stuckRed[]` +
+  `redPrWatchdog` config so "why did I get a red-PR alert?" is answerable from state.
+- `src/config/ConfigDefaults.ts`, `src/core/types.ts`, `src/commands/server.ts` — the
+  config default, type, and constructor wiring.
+
+The watchdog runs only where the parent green-PR watcher already runs (a maintainer/dev
+agent with an analyzable instar repo + safe-merge); on every other install it is inert,
+exactly like the parent feature.
+
+## What to Tell Your User
+
+- **A pull request of mine that gets stuck RED now surfaces itself.** "If one of my own PRs
+  has a required check that keeps failing for more than a couple of hours, I'll raise a
+  single quiet heads-up in your attention queue — naming the PR, how long it has been red,
+  and which checks are failing — instead of it silently sitting there unmerged. You get one
+  item per stuck PR, not a stream; it updates as the PR ages, and it clears itself the moment
+  the PR goes green, merges, or closes." This only applies on the maintainer agent that runs
+  green-PR auto-merge; it never merges or closes anything on its own — it just tells you.
+- **A subtle merge bug got fixed too.** A PR whose failed check was later re-run green used
+  to still read as failed — which could stop it from auto-merging. Now the newest run of
+  each check wins, so a re-run-green PR is correctly seen as green.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| A self-authored PR stuck RED past 2h raises ONE deduped attention line | Automatic wherever `monitoring.greenPrAutoMerge` is enabled |
+| See which of my PRs are flagged red and for how long | `GET /green-pr-automerge` → `stuckRed[]` + `redPrWatchdog` |
+| Tune the "stuck" threshold or turn the watchdog off | `monitoring.greenPrAutoMerge.redPrWatchdog` = `{ enabled, redThresholdMs }` |
+| Re-run-green PRs are no longer misread as failed | Automatic (`deriveRollup` latest-run dedup) |
+
+## Evidence
+
+- Unit (`tests/unit/green-pr-red-watchdog.test.ts`, 24): the pure helpers on both sides —
+  `latestRunPerCheck` keeps the newest run per check; `failingChecksFromRollup` /
+  `stuckRedChecks` flag past-threshold failures and skip fresh / unknown-time ones; the
+  `deriveRollup` latest-run-dedup regression (stale FAILED + later passing re-run → SUCCESS,
+  not FAILURE); and the orchestrator pass cases (a) raises one line past threshold, (b) none
+  below threshold, (c) re-run-green not stuck, (d) same PR two ticks → ONE item, (e) green →
+  none, (f) not-authored-by-me skipped, plus recovery/close clears, age-escalation re-raise,
+  disabled no-op, and the `redPrWatchdogView` read surface.
+- Unit (existing `green-pr-logic` / `green-pr-automerger` / `green-pr-automerge-wiring` /
+  `green-pr-layer2`, 92): unchanged behavior for single-run rollups — no regression.
+- Integration (`tests/integration/green-pr-automerge-routes.test.ts`, +2): `GET
+  /green-pr-automerge` surfaces `redPrWatchdog` config + an empty `stuckRed[]` when nothing
+  is red (feature-alive), and populates `stuckRed[]` after a tick over a stuck-red PR.
+- `npx tsc --noEmit` clean; the dark-gate ConfigDefaults line-map snapshot updated for the
+  +4 line shift (no new/removed dark features).

--- a/upgrades/side-effects/red-pr-watchdog.md
+++ b/upgrades/side-effects/red-pr-watchdog.md
@@ -1,0 +1,131 @@
+# Side-Effects Review — Red-PR Watchdog
+
+**Version / slug:** `red-pr-watchdog`
+**Date:** `2026-07-09`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `Echo (self, second pass)`
+
+## Summary of the change
+
+A signal-only watchdog on the existing green-PR auto-merge watcher tick. After the merge
+logic runs, `redPrWatchdogPass` sweeps my own open PRs and raises ONE deduped,
+age-escalating attention line for any PR with a required check stuck RED past a threshold
+(default 2h). Files touched: `src/monitoring/greenPrLogic.ts` (new pure helpers
+`latestRunPerCheck` / `failingChecksFromRollup` / `stuckRedChecks`, a `failingChecks` field
+on `PrSummary`, and a correctness fix to `deriveRollup`), `src/monitoring/greenPrAutomergeWiring.ts`
+(`mapPr` populates `failingChecks`; `deriveRollup` dedups first), `src/monitoring/GreenPrAutoMerger.ts`
+(the pass + `redPrRaised` state memory + the `redPrWatchdogView` read + config),
+`src/server/routes.ts` (GET fields), `src/config/ConfigDefaults.ts`, `src/core/types.ts`,
+`src/commands/server.ts` (defaults/type/wiring). It is a DETECTOR only — it never merges,
+closes, arms, or blocks.
+
+## Decision-point inventory
+
+- `redPrWatchdogPass` (GreenPrAutoMerger.tick) — **add** — decides whether to RAISE an
+  attention line for a stuck-red self-authored PR. Signal-only; no blocking/merge authority.
+- `deriveRollup` (greenPrAutomergeWiring) — **modify** — the SUCCESS/PENDING/FAILURE verdict
+  now dedups to the latest run per check first. This IS consumed by the merge candidate
+  gate (`classifyCandidate` reads `statusRollup`), so the change is a correctness improvement
+  to an existing authority's input, not a new authority.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+The watchdog has no block/allow surface — it only raises attention, so it cannot over-block
+a message or a merge. The one behavior it could over-*alert* on is a genuinely-red PR that
+the operator already knows about; that is bounded to ONE deduped line per PR and clears on
+recovery, so the cost is a single ignorable heads-up. The `deriveRollup` fix makes the merge
+gate LESS restrictive (a re-run-green PR that previously read FAILURE now reads SUCCESS) —
+this is the correct direction; safe-merge re-verifies at act time, so a misread here can only
+cause a refusal, never an unintended merge.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- A failing check with an unknown `completedAt` (0) is deliberately NOT flagged — we cannot
+  prove it has been red long enough, so we fail toward silence. A rollup shape that never
+  carries a completed time would therefore never alert. Acceptable: the common case (GitHub
+  Actions CheckRun) always carries `completedAt`.
+- A PR that is red because it is *unmergeable* (conflicts) rather than a failed check is not
+  the watchdog's target — it watches failing checks, not merge conflicts. That is a separate
+  signal the merger already skips on.
+- A PR authored by me but on a branch outside my namespace is skipped (the author proxy is
+  the branch-namespace filter, since `listOpenPrs` already passes `--author @me`).
+
+## 3. Level-of-abstraction fit
+
+Right layer. The green-PR watcher already enumerates my open PRs with their check status
+every tick; the watchdog rides that existing loop and reuses the already-fetched rollup — no
+new gh call, no parallel poller. It feeds the existing attention-queue coalescing rather than
+inventing a new notification surface. A higher layer (a generic PR monitor) would duplicate
+the enumeration; a lower layer (the pure helpers) is where the check-dedup logic correctly
+lives and is unit-tested.
+
+## 4. Signal vs authority compliance
+
+Compliant. Per `docs/signal-vs-authority.md`, the watchdog is a pure SIGNAL producer: its
+only effect is `refreshAggregate` → an attention line. It holds NO blocking authority — it
+cannot merge, close, arm, disarm, or block a message. The brittle part (heuristic "is this
+check stuck red") is confined to the signal; no authority is gated on it. The `deriveRollup`
+change improves an existing detector's accuracy; it does not add a new authority.
+
+## 5. Interactions
+
+- Runs AFTER the merge logic and the Layer-2 snapshot in the same tick, so it never shadows
+  or races the merge path. It only reads `candidates` (already gathered) and writes its own
+  `redPrRaised` state slice + the shared `attentionLines` set.
+- Shares the aggregated attention item (`green-pr-automerge:aggregate`) with the merger's
+  other lines; the P17 attention coalescing dedups the ITEM, and the `redPrRaised` memory
+  dedups the LINE, so the two dedup layers stack rather than fight.
+- The `deriveRollup` fix is consumed by `classifyCandidate` (settled-green gate) — verified
+  no other consumer exists (grep: `deriveRollup` is used only in `mapPr`). Single-run rollups
+  are unchanged, so existing green/pending/failure classification is byte-identical.
+- No double-fire: the watchdog runs once per tick; a busy/disabled/breaker-open/list-failed
+  tick returns before it, so it never runs on stale data.
+
+## 6. External surfaces
+
+Adds two fields to `GET /green-pr-automerge` (`stuckRed`, `redPrWatchdog`) — additive, no
+removed fields, no breaking change to existing consumers. Raises attention lines visible to
+the operator (the intended surface). No change visible to other agents or peers. It depends
+on the green-PR watcher's tick cadence and the gh rollup shape, both already in use.
+
+## 6b. Operator-surface quality
+
+No operator-surface file (no `dashboard/*` renderer, approval page, or grant/secret form) is
+touched — the only operator-visible output is a plain-English attention line and a JSON read
+field, both already-established surfaces. Operator-surface quality: the attention line leads
+with the action ("PR #N red for Xh — <checks>"), exposes no raw internals, and reads at phone
+width. No raw technical input is ever requested from the operator.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN**, inheriting the parent green-PR watcher's posture exactly. The
+green-PR watcher's state (`state/green-pr-automerge.json`) is per-machine and lease-gated —
+ticks run only on the lease holder. The `redPrRaised` memory lives in that same per-machine
+state file and is therefore never replicated; the watchdog only runs on the machine holding
+the serving lease, so there is no double-alert across machines. The attention item it raises
+is one-voice by construction (the shared `green-pr-automerge:aggregate` id + P17 coalescing).
+No durable state strands on topic transfer (it is watcher-state, not topic-state), and it
+generates no cross-machine URLs. This matches how green-pr-automerge already behaves.
+
+## 8. Rollback cost
+
+Cheap. Revert the PR — the watchdog is signal-only, so there is no data migration and no agent
+state to repair (the `redPrRaised` slice is ignored by older code and re-derived each tick).
+Softer levers without a revert: set `monitoring.greenPrAutoMerge.redPrWatchdog.enabled: false`
+to turn just the watchdog off, or raise `redThresholdMs`. The `deriveRollup` fix is the only
+behavioral change to an existing path; if it were ever wrong it would make the merger MORE
+conservative (skip), never over-merge — safe-merge remains the act-time authority.
+
+## Self-action note
+
+`unbounded-self-action`: n/a — the watchdog performs no self-triggered control action (no
+restart / respawn / spawn / kill / swap / retry / re-drive). Its only effect is raising an
+attention line, and that is bounded by the per-PR `redPrRaised` dedup memory (ONE line per
+stuck PR, re-raised only on age-escalation, cleared on recovery) — so it converges under
+sustained pressure rather than emitting unboundedly.


### PR DESCRIPTION
## ELI16 — If one of my own PRs sits RED too long, I now raise ONE quiet heads-up instead of letting it rot unnoticed

Green-PR auto-merge only ever acts on GREEN pull requests, so a PR of mine that goes red and *stays* red is completely invisible to it. That is exactly how PR #1399 sat red overnight on 2026-07-08 until the operator found it on his morning check-in — an operator-found escape, the north-star failure this automation exists to prevent. This change bolts a signal-only watchdog onto the same watcher tick: after the merge logic runs, it checks my own open PRs and raises ONE deduped, age-escalating attention line — "PR #N red for Xh — the failing check names" — for any PR with a required check stuck red past a threshold (default 2 hours). It is a detector, not an actor: it never merges, never closes, never arms, and never blocks a message. You get one item per stuck PR, not a stream; it updates as the PR ages and clears itself the moment the PR goes green, merges, or closes.

The same investigation surfaced a real correctness bug that ships fixed here too: the check-status reader (`deriveRollup`) did not de-duplicate re-runs, so a stale FAILED run that a later re-run turned green still read as FAILURE — which also made the green-PR merger refuse an actually-green PR. Every check is now collapsed to its latest run before judging.

## What this adds

- **`redPrWatchdogPass`** on the green-PR watcher tick — signal-only; a per-PR `redPrRaised` state memory dedups to ONE line and re-raises only on age-escalation or a changed failing-check set; cleared on green/merge/close.
- **Pure helpers** `latestRunPerCheck` / `failingChecksFromRollup` / `stuckRedChecks` and a `failingChecks` field on `PrSummary` — reusing the `statusCheckRollup` the list projection already fetches (no new gh call).
- **`deriveRollup` correctness fix** — dedup to the latest run per check before collapsing.
- **Config** `monitoring.greenPrAutoMerge.redPrWatchdog` = `{ enabled, redThresholdMs }` (default `{ enabled: true, redThresholdMs: 7_200_000 }`).
- **Read surface** — `GET /green-pr-automerge` now returns `stuckRed[]` + `redPrWatchdog` config (answers "why did I get a red-PR alert?").

## Safety

Signal-only — it holds no blocking/merge/close authority, so a false positive is at worst one ignorable heads-up, never a bad merge. It runs only where the parent green-PR watcher runs (an analyzable instar repo + safe-merge, lease-gated); inert everywhere else, exactly like the parent feature. The `deriveRollup` change only ever makes the merge gate MORE conservative, and safe-merge re-verifies at act time.

## Tests

- Unit `tests/unit/green-pr-red-watchdog.test.ts` (24): the pure helpers on both sides, the re-run-green regression (stale FAILED + later passing re-run → SUCCESS not FAILURE), and the orchestrator cases (a) raise past threshold, (b) none below, (c) re-run-green not stuck, (d) same PR two ticks → ONE item, (e) green → none, (f) not-authored-by-me skipped, plus recovery/close clears, age-escalation re-raise, disabled no-op, and the read surface.
- Integration `tests/integration/green-pr-automerge-routes.test.ts` (+2): GET surfaces `redPrWatchdog` config + empty `stuckRed[]` (feature-alive), and populates `stuckRed[]` after a tick over a stuck-red PR.
- Existing green-pr unit tiers unchanged (no regression); `npx tsc --noEmit` clean; dark-gate ConfigDefaults line-map snapshot updated for the +4 shift.

## Ceremony

/instar-dev Tier 1 (signal-only, additive; the below-risk-floor note from the new config key is recorded, not blocking). ELI16 at `docs/specs/red-pr-watchdog.eli16.md`; release fragment `upgrades/next/red-pr-watchdog.md`; side-effects `upgrades/side-effects/red-pr-watchdog.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
