### PR TITLE
fix(tunnel): reachability probe retries across a bounded grace window (edge-propagation race killed healthy named tunnels)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-10T01-08-56-573Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-10T01-08-56-573Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-10T01:08:56.573Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 45,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/tunnel-probe-grace.eli16.md
+++ b/docs/specs/tunnel-probe-grace.eli16.md
@@ -1,0 +1,27 @@
+# Tunnel Reachability Grace Window — Plain-English Overview
+
+> The one-line version: when the agent's public tunnel comes up, give the internet a few seconds to notice before declaring it dead — a single too-early check was killing perfectly healthy tunnels and leaving agents link-less for hours.
+
+## The problem in one breath
+
+Every instar agent can expose itself to the internet through a Cloudflare tunnel — that's what makes the dashboard, private views, and remote access work from your phone. When the tunnel process starts, the agent checks "can the world actually reach me?" by fetching its own public URL once. But Cloudflare's edge needs a few seconds after a tunnel connects before it starts routing traffic — during that window it answers with an error even though the tunnel is fine. The agent's single, immediate check kept landing inside that window, concluding "unreachable," killing the healthy tunnel, and falling back to throwaway quick tunnels that Cloudflare rate-limits. End state: the tunnel system gives up ("exhausted") and retries every 15 minutes — hitting the exact same too-early check every time, forever. We watched this live on the instar-codey agent on 2026-07-09: its tunnel config was perfect (a hand-started tunnel served traffic within 6 seconds), but the agent had been link-less for hours, its dashboard-link job failing every 80 seconds and flooding its health report with two dozen degradation notices.
+
+## What already exists
+
+- **The tunnel manager** — starts the tunnel process, checks reachability, and walks a ladder of fallbacks (named tunnel → quick tunnel → consent-gated relay) with a lifecycle state machine and retry backoff. All of that stays exactly as it is.
+- **The reachability check itself** — one HTTP fetch of the agent's own public `/health` URL. This is the only piece that changes.
+
+## What this adds
+
+The reachability check now retries over a short grace window before giving a "dead" verdict: check, and if it fails, wait 2 seconds and check again, then 4, then 6 — four attempts in total, roughly twenty seconds of patience at most. The first success ends the loop immediately, so a healthy tunnel passes exactly as fast as before. Only a tunnel that fails every attempt across the whole window is declared unreachable and torn down. If the agent is shutting down mid-window, the loop bails instantly instead of sleeping through it.
+
+## The safeguards
+
+- **Nothing gets more permissive about real failures** — a genuinely dead tunnel is still detected and torn down; it just takes a few bounded seconds longer, after which every existing fallback (quick tunnel, relay consent, 15-minute retry) behaves exactly as today.
+- **No new authority** — the check stays a yes/no signal feeding the existing lifecycle machinery; nothing new can block or kill anything.
+- **Shutdown-aware** — stopping the agent never waits out the grace window.
+- **Test seam, not a config knob** — tests inject millisecond delays so the suite stays fast; there is no new user-facing configuration to misconfigure.
+
+## What you actually need to decide
+
+Nothing — this is a small resilience bug fix with an obvious revert (it's one code path, no data or config changes). The observable effect for users is that agents with named tunnels stop mysteriously losing their public link after a restart or a transient Cloudflare hiccup, and the "exhausted, retrying forever" failure mode heals itself on the next retry instead of replaying the race.

--- a/src/tunnel/TunnelManager.ts
+++ b/src/tunnel/TunnelManager.ts
@@ -111,6 +111,11 @@ export interface TunnelManagerInjections {
   providers?: TunnelProvider[];
   notifierSink?: NotifierSink;
   fetch?: typeof fetch;
+  /**
+   * Test seam: override the reachability-probe retry schedule (see
+   * REACHABILITY_RETRY_DELAYS_MS) so unit tests don't sleep real seconds.
+   */
+  reachabilityRetryDelaysMs?: number[];
 }
 
 /**
@@ -145,6 +150,20 @@ const MAX_BACKOFF_MS = 5 * 60_000;
 const MAX_BACKOFF_ATTEMPTS = 10;
 const REACHABILITY_TIMEOUT_MS = 8_000;
 /**
+ * Reachability-probe grace window. Right after cloudflared registers a
+ * named-tunnel connection, the Cloudflare edge can keep serving 530 for
+ * a few seconds while the route propagates. A single immediate probe
+ * mistakes that propagation window for a dead link, kills the healthy
+ * tunnel, falls through to quick tunnels (which can be rate-limited),
+ * and strands the lifecycle in `exhausted` — where the 15-min retry
+ * replays the exact same race indefinitely (observed on instar-codey
+ * 2026-07-09: a manually-started connector served HTTP 200 within ~6s
+ * while the manager kept declaring reachability-failed). Probe up to
+ * `delays.length + 1` times, sleeping the next delay between attempts,
+ * before declaring reachability-failed.
+ */
+const REACHABILITY_RETRY_DELAYS_MS = [2_000, 4_000, 6_000];
+/**
  * Post-exhausted retry cadence — the minimum-viable "self-heal"
  * placeholder for PR 2. After the bounded startup-reconnect ladder
  * exhausts (MAX_BACKOFF_ATTEMPTS), the manager keeps probing the
@@ -178,6 +197,7 @@ export class TunnelManager extends EventEmitter {
   private readonly providers: TunnelProvider[];
   private notifier: TunnelNotifier | null;
   private readonly fetcher: typeof fetch;
+  private readonly reachabilityRetryDelaysMs: number[];
 
   private currentHandle: TunnelProviderHandle | null = null;
   private currentProviderName: ProviderName | null = null;
@@ -229,6 +249,8 @@ export class TunnelManager extends EventEmitter {
       ? new TunnelNotifier({ sink: injections.notifierSink })
       : null;
     this.fetcher = injections?.fetch ?? globalThis.fetch.bind(globalThis);
+    this.reachabilityRetryDelaysMs =
+      injections?.reachabilityRetryDelaysMs ?? REACHABILITY_RETRY_DELAYS_MS;
 
     this._legacyState = {
       url: null,
@@ -1025,8 +1047,26 @@ export class TunnelManager extends EventEmitter {
     }, POST_EXHAUSTED_RETRY_INTERVAL_MS);
   }
 
-  /** HTTP probe through the public URL — confirms the link actually serves. */
+  /**
+   * HTTP probe through the public URL — confirms the link actually
+   * serves. Retries across a bounded grace window (see
+   * REACHABILITY_RETRY_DELAYS_MS) so the edge-propagation 530s that
+   * follow connector registration don't get a healthy tunnel killed.
+   * A shutdown mid-window bails immediately instead of sleeping it out.
+   */
   private async probeReachability(url: string): Promise<boolean> {
+    const delays = this.reachabilityRetryDelaysMs;
+    for (let attempt = 0; ; attempt++) {
+      if (await this.probeReachabilityOnce(url)) return true;
+      if (this._stopped) return false; // shutting down — don't wait out the grace window
+      const delayMs = delays[attempt];
+      if (delayMs === undefined) return false; // grace window exhausted — genuinely unreachable
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  /** One probe attempt — a non-ok response or any fetch error reads as "not reachable yet". */
+  private async probeReachabilityOnce(url: string): Promise<boolean> {
     try {
       const controller = new AbortController();
       const t = setTimeout(() => controller.abort(), REACHABILITY_TIMEOUT_MS);
@@ -1036,6 +1076,9 @@ export class TunnelManager extends EventEmitter {
       clearTimeout(t);
       return res.ok;
     } catch {
+      // @silent-fallback-ok: probe failure IS the signal — `false` is the
+      // datum the retry loop and callers act on (recordAttempt with
+      // reachability-failed); nothing is swallowed.
       return false;
     }
   }

--- a/tests/unit/TunnelManager.test.ts
+++ b/tests/unit/TunnelManager.test.ts
@@ -129,7 +129,9 @@ describe('TunnelManager (provider/tier architecture)', () => {
         stateDir: project.stateDir,
         ...configOverrides,
       },
-      { providers, fetch: fetcher },
+      // 1ms probe-retry delays: keep the reachability grace window
+      // (probe retries) semantically intact without real sleeps.
+      { providers, fetch: fetcher, reachabilityRetryDelaysMs: [1] },
     );
     // EventEmitter throws on unhandled 'error' — every failure path
     // emits it, so absorb by default; tests assert via rejections.

--- a/tests/unit/tunnel-consent-state-machine.test.ts
+++ b/tests/unit/tunnel-consent-state-machine.test.ts
@@ -203,7 +203,8 @@ describe('TunnelManager — grantConsent', () => {
     const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, url: 'https://broken.example' });
     const mgr = new TunnelManager(
       { ...baseConfig, stateDir },
-      { providers: [tier1, tier2], fetch: badFetch },
+      // 1ms probe-retry delays: keep the reachability grace window fast.
+      { providers: [tier1, tier2], fetch: badFetch, reachabilityRetryDelaysMs: [1] },
     );
     await expect(mgr.start()).rejects.toBeInstanceOf(Error);
 

--- a/tests/unit/tunnel-manager-rewrite.test.ts
+++ b/tests/unit/tunnel-manager-rewrite.test.ts
@@ -136,7 +136,8 @@ describe('TunnelManager (rewrite) — reachability probe', () => {
     });
     const mgr = new TunnelManager(
       { ...baseConfig, stateDir },
-      { providers: [named, quick], fetch },
+      // 1ms probe-retry delays: keep the reachability grace window fast.
+      { providers: [named, quick], fetch, reachabilityRetryDelaysMs: [1] },
     );
     const url = await mgr.start();
     expect(url).toBe('https://quick.example');
@@ -152,10 +153,49 @@ describe('TunnelManager (rewrite) — reachability probe', () => {
       req.includes('broken.example') ? badResponse() : okResponse());
     const mgr = new TunnelManager(
       { ...baseConfig, stateDir },
-      { providers: [named, quick], fetch },
+      // 1ms probe-retry delays: keep the reachability grace window fast.
+      { providers: [named, quick], fetch, reachabilityRetryDelaysMs: [1] },
     );
     await mgr.start();
     expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('tolerates edge-propagation failures: a probe that fails then recovers within the grace window keeps the tunnel', async () => {
+    // Regression: a named tunnel's edge can serve 530 for a few seconds
+    // right after connector registration. A single-shot probe used to
+    // kill the healthy tunnel (reachability-failed → quick-tunnel
+    // rate-limit → permanently exhausted). The probe must retry within
+    // the grace window and keep the provider once the edge catches up.
+    const stop = vi.fn(async () => undefined);
+    const named = mockProvider({ name: 'cloudflare-named', url: 'https://propagating.example', stop });
+    let probes = 0;
+    const fetch = vi.fn(async () => {
+      probes += 1;
+      return probes <= 2 ? badResponse() : okResponse(); // 530-ish, 530-ish, then healthy
+    });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [named], fetch, reachabilityRetryDelaysMs: [1, 1, 1] },
+    );
+    const url = await mgr.start();
+    expect(url).toBe('https://propagating.example');
+    expect(stop).not.toHaveBeenCalled(); // the healthy tunnel was never torn down
+    expect(fetch).toHaveBeenCalledTimes(3); // failed twice, recovered on the third attempt
+    expect(mgr.lifecycleState.lastState).toBe('active');
+  });
+
+  it('declares reachability-failed only after exhausting the full grace window', async () => {
+    const stop = vi.fn(async () => undefined);
+    const named = mockProvider({ name: 'cloudflare-named', url: 'https://dead.example', stop });
+    const fetch = vi.fn(async () => badResponse());
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [named], fetch, reachabilityRetryDelaysMs: [1, 1] },
+    );
+    mgr.disableAutoReconnect();
+    await expect(mgr.start()).rejects.toThrow(/reachability-failed/);
+    expect(fetch).toHaveBeenCalledTimes(3); // delays.length + 1 attempts
+    expect(stop).toHaveBeenCalledTimes(1); // torn down only after the window closed
   });
 });
 

--- a/upgrades/next/tunnel-probe-grace.md
+++ b/upgrades/next/tunnel-probe-grace.md
@@ -1,0 +1,21 @@
+# fix(tunnel): reachability probe retries across a grace window — healthy named tunnels no longer get killed by edge-propagation 530s
+
+## What Changed
+
+`TunnelManager.probeReachability` (the "can the world reach my public URL?" check that runs before a freshly-started tunnel is declared active) was a single-shot HTTP probe. Cloudflare's edge routinely serves 530 for a few seconds after a named tunnel's connector registers, so the one immediate probe kept landing inside that propagation window: the manager declared `reachability-failed`, tore down the healthy tunnel, fell through to quick tunnels (rate-limited, error 1015), and stranded the lifecycle in `exhausted` — where the 15-minute post-exhausted retry replayed the identical race forever. Observed live on the instar-codey agent 2026-07-09: link-less for hours with a perfectly working tunnel config (a hand-started connector served HTTP 200 within ~6s), its dashboard-link-refresh job failing every ~80s and flooding `/health` with truncated-run-record degradations.
+
+The probe now retries across a bounded grace window — delays of 2s/4s/6s between attempts (4 attempts total), first success returns immediately, and a manager shutdown bails out of the window instantly. The single-shot probe moved to `probeReachabilityOnce`, byte-identical. A new `TunnelManagerInjections.reachabilityRetryDelaysMs` constructor seam lets tests drive the loop with millisecond delays (no user-facing config knob). All three probe call sites (`driveTier1`, `runSelfHealCheck`, the consent-grant relay start) inherit the grace window uniformly.
+
+## Evidence
+
+- Root-cause reproduction on instar-codey (port 4044): `GET /tunnel` stuck at `{state: "exhausted", lastFailureReason: "reachability-failed"}` while a manually-run `cloudflared tunnel --config .instar/cloudflared-named.yml run` registered 4 connections in ~2s and the public `/health` served HTTP 200 within ~6s of spawn — the config, credentials, and DNS were all healthy; only the probe timing was wrong.
+- 2 new unit regression tests in `tests/unit/tunnel-manager-rewrite.test.ts`: a probe that fails twice then recovers within the window keeps the tunnel (provider never torn down, lifecycle `active`); an always-failing probe is declared `reachability-failed` only after `delays.length + 1` attempts and the handle is torn down exactly once.
+- Full tunnel unit suite green: 160 tests across 10 files in ~2.5s (failing-probe paths in existing tests now inject 1ms delays via the new seam, so no real sleeps entered the suite).
+
+## What to Tell Your User
+
+If my public link (dashboard, private views) ever seemed to die after a restart or a brief Cloudflare hiccup and not come back, this was likely why: I used to check my own public URL exactly once, a moment too early, and treat Cloudflare's few-second warm-up as "the tunnel is dead." Now I give that check a short grace window (up to ~20 seconds of patience) before concluding anything, so a healthy tunnel survives its own startup and a stuck "exhausted, retrying forever" state heals itself on the next retry. Nothing changes when the tunnel is genuinely down — I still detect that and fall back exactly as before, just a few seconds later.
+
+## Summary of New Capabilities
+
+- None user-facing — this is a resilience fix. Named/quick tunnel startup and the self-heal probe now tolerate Cloudflare edge-propagation delay instead of killing healthy tunnels.

--- a/upgrades/side-effects/tunnel-probe-grace.md
+++ b/upgrades/side-effects/tunnel-probe-grace.md
@@ -1,0 +1,79 @@
+# Side-Effects Review — Tunnel reachability-probe grace window
+
+**Version / slug:** `tunnel-probe-grace`
+**Date:** `2026-07-09`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** `not required` (no messaging block/allow, no session lifecycle, no sentinel/guard/gate/watchdog surface — the change tightens an existing tunnel-internal detector's evidence window)
+
+## Summary of the change
+
+`TunnelManager.probeReachability` was a single-shot HTTP probe: one non-ok response (or one fetch error) was enough to declare a freshly-started tunnel unreachable, tear it down, and record `reachability-failed`. For Cloudflare named tunnels the edge routinely serves 530 for a few seconds after the connector registers ("edge propagation"), so the single immediate probe raced that window, killed healthy tunnels, fell through to quick tunnels (which can be rate-limited, error 1015), and stranded the lifecycle in `exhausted` — where the 15-minute post-exhausted retry replays the identical race indefinitely. Observed live on instar-codey 2026-07-09: the manager kept declaring `reachability-failed` while a manually-started connector on the same config served HTTP 200 within ~6 seconds. The change makes `probeReachability` retry across a bounded grace window (default delays 2s/4s/6s → up to 4 attempts, ~12s of waiting plus per-attempt 8s timeouts worst-case), bailing immediately when the manager is stopping. The single-shot probe moves to `probeReachabilityOnce`, unchanged. A new `TunnelManagerInjections.reachabilityRetryDelaysMs` test seam lets tests run the loop with 1ms delays. Files: `src/tunnel/TunnelManager.ts`, `tests/unit/tunnel-manager-rewrite.test.ts` (2 new regression tests), `tests/unit/TunnelManager.test.ts` + `tests/unit/tunnel-consent-state-machine.test.ts` (fast-delay injections so failing-probe paths don't sleep real seconds).
+
+## Decision-point inventory
+
+- `TunnelManager.probeReachability` (all three call sites: `driveTier1`, `runSelfHealCheck`, consent-grant relay start) — **modify** — the reachable/unreachable verdict now requires the full grace window of failures before reading "unreachable"; a single success still reads "reachable" immediately.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No issue identified. The change is strictly in the permissive direction: everything that previously passed the probe still passes on the first attempt with identical latency; nothing new is rejected.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+A tunnel that is genuinely dead now takes up to ~12s of retry delays (plus up to 8s per-attempt timeout) longer to be declared failed on each provider attempt. That slightly delays fallback to the next provider (quick tunnel / Tier-2 relay) and lengthens `start()`'s failure path at boot. This is bounded and deliberate — the cost of not killing healthy tunnels. An edge that takes LONGER than the ~20s window to propagate would still be misread as unreachable; the window covers the observed single-digit-seconds propagation with margin, and the post-exhausted retry (15 min) remains the backstop for pathological cases — with the crucial difference that each retry now also carries the grace window, so it can actually succeed instead of replaying the race.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The probe is a detector inside TunnelManager; the lifecycle state machine is the authority that acts on its verdict. The fix widens the detector's evidence window rather than adding any new authority or a parallel check. No higher-level gate exists for tunnel reachability that this should feed instead; the lifecycle IS that gate and is unchanged.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Does this hold blocking authority with brittle logic, or does it produce a signal that feeds a smart gate?**
+
+Compliant. The probe produces a boolean signal consumed by the existing lifecycle authority. The change makes the signal LESS brittle (multiple observations before a negative verdict) and adds no blocking authority anywhere. Reference: `docs/signal-vs-authority.md`.
+
+---
+
+## 5. Interactions
+
+**Does it shadow another check, get shadowed by one, double-fire, race with adjacent cleanup?**
+
+- `runSelfHealCheck` (100s cadence while relay-active) now holds its probe up to ~20s longer on a failing Tier-1 attempt. The check is async and single-flight (`_switchingBack` guard unchanged); a slower negative verdict cannot double-fire or overlap the next tick's decision because the self-heal counter reset happens after the probe returns, same as before.
+- The `_stopped` bail inside the retry loop means shutdown does not wait out the grace window — `stop()`/`forceStop()` interactions are unchanged.
+- The consent-grant path holds the pending-consent nonce cleared BEFORE the probe (unchanged), so the longer probe cannot be raced by a replayed grant.
+- No other component reads probe timing; the lifecycle transitions and `recordAttempt` calls are byte-identical in ordering.
+
+---
+
+## 6. External surfaces
+
+**Does it change anything visible to other agents, other users, other systems?**
+
+Boot/`start()` latency on the genuinely-unreachable path grows by the grace window (bounded, seconds). The probe still targets only the tunnel's own `/health` — up to 3 additional HTTP GETs per failed attempt against the agent's own public hostname; no new external calls. No API shape, config schema, or persisted-state change (the new injection field is a constructor-only test seam, not config).
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** A tunnel is a per-machine process fronting that machine's own port; its reachability verdict is meaningful only on the machine running the connector. Nothing here replicates or needs a merged read. The existing tunnel-lifecycle attention/notifier surfaces are unchanged. No user-facing notice text changes, no durable state that could strand on topic transfer, no generated URLs.
+
+---
+
+## 8. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Revert the commit and release — the change is a pure code-path change with no data migration, no config schema change, no persisted-state format change. Worst plausible failure mode is the longer failure path at boot (seconds), which is inconvenient, not damaging. No agent state repair needed.


### PR DESCRIPTION
## ELI16

When an instar agent starts its public tunnel (the thing that makes the dashboard and private links reachable from your phone), it checks its own public URL once to confirm the world can reach it. Cloudflare needs a few seconds after a tunnel connects before it starts routing traffic, and during that warm-up it answers with an error even though the tunnel is fine. The old check ran exactly once, immediately — so it kept landing inside that warm-up window, deciding "unreachable," killing the perfectly healthy tunnel, and falling back to throwaway quick tunnels that Cloudflare rate-limits. The tunnel system then gave up ("exhausted") and retried every 15 minutes, hitting the same too-early check forever. We watched instar-codey sit link-less for hours on 2026-07-09 with a flawless tunnel config — a hand-started tunnel served traffic within 6 seconds — while its dashboard-link job failed every 80 seconds. The fix: the check now retries over a short grace window (2s/4s/6s pauses, four tries, ~20 seconds of patience max) before declaring the tunnel dead. A healthy tunnel passes as fast as before (first success returns immediately); a genuinely dead one is still detected and torn down, just a few seconds later; shutting down mid-window bails instantly. Tests drive the retry loop with millisecond delays through a constructor-only test seam — no new config knob, no data changes, one-commit revert.

## Root cause

`TunnelManager.probeReachability` was single-shot: one non-ok response (Cloudflare edge 530 during propagation) → `reachability-failed` → healthy tunnel torn down → quick-tunnel fallback (rate-limited 1015) → lifecycle `exhausted` → the 15-min post-exhausted retry replays the identical race indefinitely.

## Change

- `probeReachability` retries across `REACHABILITY_RETRY_DELAYS_MS = [2s, 4s, 6s]` (attempts = delays + 1), returns on first success, bails on `_stopped`.
- Single-shot body moved to `probeReachabilityOnce` (byte-identical; `@silent-fallback-ok` on the catch — probe failure IS the signal).
- New `TunnelManagerInjections.reachabilityRetryDelaysMs` test seam; existing failing-probe tests inject `[1]` ms.
- All three call sites (`driveTier1`, `runSelfHealCheck`, consent-grant relay start) inherit the window uniformly.

## Evidence

- Live repro on instar-codey: `GET /tunnel` stuck `exhausted/reachability-failed`; manual `cloudflared tunnel --config .instar/cloudflared-named.yml run` registered 4 connections in ~2s, public `/health` HTTP 200 within ~6s.
- 2 new regression tests (probe fails twice then recovers → tunnel kept + `active`; always-failing probe → torn down exactly once after full window).
- 160 tunnel unit tests green in ~2.5s.

## Tier

Tier 1 (declared, trace + audit row committed): focused resilience fix, no new capability/authority/config/migration surface, one-commit revert. ELI16 + side-effects artifact staged (`upgrades/side-effects/tunnel-probe-grace.md`, `docs/specs/tunnel-probe-grace.eli16.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
