### PR TITLE
fix(evolution): standby-write wedge — re-emit only changed replication records

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-10T01-21-43-309Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-10T01-21-43-309Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-10T01:21:43.309Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 85,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/standby-write-wedge-fix.eli16.md
+++ b/docs/specs/standby-write-wedge-fix.eli16.md
@@ -1,0 +1,48 @@
+# Standby-Write Wedge Fix — ELI16
+
+## What is this?
+
+On a setup with more than one machine, one of your agent's machines is "awake" (serving) and the
+other is on "standby." A bug made the standby machine freeze completely — not answer ANYTHING,
+not even a basic health check — for tens of seconds whenever it recorded a self-improvement action
+item (or a lesson). The freeze was long enough that the machine's own supervisor decided the
+process was dead and killed-and-restarted it. Anyone messaging that machine during the freeze got
+silence, then a fresh restart.
+
+## Why did it freeze?
+
+The agent keeps a shared, cross-machine log so a lesson or a to-do learned on one machine is known
+on the others. Every time it saved an action item, it did something wasteful: it re-announced
+**every** action it had **ever** kept — not just the one that changed — into that shared log. And
+each re-announcement re-read the **entire** shared log from disk to figure out its place in the
+ordering.
+
+That is fine with a handful of items. But it fed itself into a doom loop: re-announcing everything
+made the log bigger, and a bigger log made the next save slower, which made the log bigger still.
+On a real agent the log had grown to ~53 MB and held 61,000 entries for only 632 real items — each
+item had been re-announced about 112 times. With ~1,200 action items to re-announce, ONE save
+became tens of gigabytes of reading from disk, all at once, all on the single thread the whole
+server runs on. That is the freeze.
+
+It looked like it "only happened on standby" partly by coincidence: the standby machine happened to
+be the one holding the giant queue and the giant log, and the freeze also showed up as random
+periodic hangs whenever a background job quietly added an action in the background.
+
+## How is it fixed?
+
+The save now re-announces **only the items whose content actually changed** since it last announced
+them, instead of all of them. It remembers a tiny fingerprint of each item; on the next save, an
+unchanged item is skipped, and a changed one (say, a to-do that just got marked "completed") is
+announced exactly once. The important guarantee is preserved: when an item genuinely changes, the
+other machines still see the new state — so a peer still learns that a task was already finished and
+doesn't redo it. What's gone is the pointless repetition that caused both the freeze and the runaway
+log growth.
+
+It also remembers, right when it starts up, which items were already announced by the previous run —
+so the very first save after a restart doesn't accidentally re-announce everything one more time.
+
+## What does this change for me?
+
+Nothing to turn on or configure. The standby machine stops freezing on these writes, the shared log
+stops ballooning, and your messages to it stop getting swallowed by a 30-second hang. Everything the
+cross-machine sharing did before, it still does — just without the wasteful repetition.

--- a/src/core/EvolutionManager.ts
+++ b/src/core/EvolutionManager.ts
@@ -17,6 +17,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import type {
   EvolutionProposal,
   EvolutionType,
@@ -249,9 +250,50 @@ export class EvolutionManager {
    */
   private actionReplication: EvolutionActionReplicationEmitter | null = null;
 
+  /**
+   * Standby-write-wedge fix (2026-07-10): the last-emitted content fingerprint per
+   * record id, so a save re-emits ONLY records whose content actually changed. Without
+   * this, saveActions/saveLearnings re-emitted EVERY surviving record on EVERY write, and
+   * each emit's `loadWitness` re-scans the whole journal — turning one write into
+   * O(records × journalBytes) SYNCHRONOUS fs reads on the event loop. On a real agent this
+   * bloated the evolution-action journal to ~53MB / 61k records over 632 keys (each key
+   * re-emitted ~112×) and made ONE `POST /evolution/actions` do tens of GB of synchronous
+   * reads — starving the event loop until the supervisor killed the process. Skipping the
+   * re-emit of an UNCHANGED record preserves the load-bearing "a status change re-emits so a
+   * peer sees it" property (a changed record's fingerprint differs ⇒ it still emits) while
+   * removing the redundant re-emits that caused both the wedge AND the journal bloat.
+   * Seeded from the on-disk state when the emitter is attached (so a restart with a
+   * populated queue does not re-emit everything once on its first write). A false "unchanged"
+   * is bounded by the peer-pull backstop, so a compact non-cryptographic digest is safe.
+   */
+  private lastEmittedActionFp = new Map<string, string>();
+  private lastEmittedLearningFp = new Map<string, string>();
+
   constructor(config: EvolutionManagerConfig) {
     this.config = config;
     this.stateDir = config.stateDir;
+  }
+
+  /**
+   * Content fingerprint for the replication-emit change-detector. Stable across
+   * re-serializations (object keys sorted recursively) so a re-parsed-but-identical record
+   * yields the SAME fingerprint and is skipped. NOT a security hash — collision-resistance
+   * is not required here (a false "unchanged" only skips a redundant re-emit, and the
+   * peer-pull path is the backstop). Kept private + local to the manager so this fix never
+   * touches the generic replication machinery (journal / emitter / reader).
+   */
+  private emitFingerprint(record: unknown): string {
+    const stable = JSON.stringify(record, (_k, val) =>
+      val && typeof val === 'object' && !Array.isArray(val)
+        ? Object.keys(val as Record<string, unknown>)
+            .sort()
+            .reduce((acc: Record<string, unknown>, k) => {
+              acc[k] = (val as Record<string, unknown>)[k];
+              return acc;
+            }, {})
+        : val,
+    );
+    return createHash('sha1').update(stable ?? 'null').digest('hex');
   }
 
   /**
@@ -262,6 +304,16 @@ export class EvolutionManager {
    */
   setLearningReplicationEmitter(emitter: LearningReplicationEmitter | null | undefined): void {
     this.learningReplication = emitter ?? null;
+    // Seed the change-detector from the on-disk state so a restart with a populated
+    // registry does NOT re-emit everything on the first save (the cold-start wedge). The
+    // records in the persisted registry were already emitted by a prior session; a genuine
+    // divergence from the journal is caught by the peer-pull backstop, never a lost write.
+    this.lastEmittedLearningFp.clear();
+    if (this.learningReplication) {
+      for (const l of this.loadLearnings().learnings) {
+        this.lastEmittedLearningFp.set(l.id, this.emitFingerprint(l));
+      }
+    }
   }
 
   /**
@@ -272,6 +324,15 @@ export class EvolutionManager {
    */
   setEvolutionActionReplicationEmitter(emitter: EvolutionActionReplicationEmitter | null | undefined): void {
     this.actionReplication = emitter ?? null;
+    // Seed the change-detector from the on-disk queue so a restart with a populated queue
+    // does NOT re-emit every action on the first save (the cold-start wedge). See
+    // lastEmittedActionFp for the full rationale.
+    this.lastEmittedActionFp.clear();
+    if (this.actionReplication) {
+      for (const a of this.loadActions().actions) {
+        this.lastEmittedActionFp.set(a.id, this.emitFingerprint(a));
+      }
+    }
   }
 
   // ── TaskFlow wiring ─────────────────────────────────────────────
@@ -994,13 +1055,21 @@ export class EvolutionManager {
           // above. The emitter counts its own failures internally; this guard only
           // ensures a throw from the seam cannot propagate into the local write path.
         }
+        this.lastEmittedLearningFp.delete(pruned.id);
       }
+      // Standby-write-wedge fix (see saveActions): re-emit ONLY changed learnings. The old
+      // "re-emit every survivor" made each write O(records × journalBytes) synchronous
+      // journal scans; a status/applied change alters the fingerprint so it still re-emits.
       for (const l of state.learnings) {
+        const fp = this.emitFingerprint(l);
+        if (this.lastEmittedLearningFp.get(l.id) === fp) continue; // unchanged ⇒ skip re-emit
         try {
           emitter.emitPut(l);
+          this.lastEmittedLearningFp.set(l.id, fp);
         } catch {
           // @silent-fallback-ok: see the emitDelete guard above — replication is
-          // best-effort and must never break the local write.
+          // best-effort and must never break the local write. The fingerprint is NOT
+          // recorded on a throw so the next save retries this record.
         }
       }
     }
@@ -1223,13 +1292,25 @@ export class EvolutionManager {
           // emitter counts its own failures internally; this guard only ensures a throw from
           // the seam cannot propagate into the local write path.
         }
+        // A pruned id is gone from the queue; forget its fingerprint so the map does not
+        // grow unbounded and a future id-reuse re-emits.
+        this.lastEmittedActionFp.delete(pruned.id);
       }
+      // Standby-write-wedge fix: re-emit ONLY records whose content changed since their last
+      // emit. Re-emitting every unchanged survivor (the old behavior) turned each write into
+      // O(records × journalBytes) synchronous journal scans (loadWitness materializes the
+      // whole store per emit) — the event-loop wedge. A status change alters the fingerprint,
+      // so the load-bearing "a peer sees the latest status" property is preserved.
       for (const a of state.actions) {
+        const fp = this.emitFingerprint(a);
+        if (this.lastEmittedActionFp.get(a.id) === fp) continue; // unchanged ⇒ skip re-emit
         try {
           emitter.emitPut(a);
+          this.lastEmittedActionFp.set(a.id, fp); // record only after a successful emit
         } catch {
           // @silent-fallback-ok: see the emitDelete guard above — replication is best-effort
-          // and must never break the local write.
+          // and must never break the local write. The fingerprint is NOT recorded on a throw
+          // so the next save retries this record.
         }
       }
     }

--- a/tests/unit/evolution-manager-emit-wedge.test.ts
+++ b/tests/unit/evolution-manager-emit-wedge.test.ts
@@ -1,0 +1,164 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+/**
+ * Standby-write-wedge fix (2026-07-10) — EvolutionManager must re-emit ONLY records whose
+ * content CHANGED, never every surviving record on every write.
+ *
+ * THE BUG: saveActions/saveLearnings re-emitted EVERY surviving record on EVERY write, and
+ * each emit's `loadWitness` re-scans the whole journal. That made one write cost
+ * O(records × journalBytes) SYNCHRONOUS fs — on a real agent the evolution-action journal
+ * had bloated to ~53MB / 61k records over 632 keys (each key re-emitted ~112×), so ONE
+ * `POST /evolution/actions` did tens of GB of synchronous reads and starved the event loop
+ * until the supervisor killed the process. It also fed itself: re-emit-all bloats the
+ * journal, which makes the next write's scan slower — a doom loop.
+ *
+ * These tests pin the emit COUNT (the wedge multiplier), not timing, so they are
+ * deterministic. Each FAILS against the pre-fix "re-emit every survivor" behavior and PASSES
+ * after the "re-emit only changed" fix. They also assert the load-bearing correctness
+ * property is preserved: a status change STILL re-emits (a peer must see the latest status).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  EvolutionManager,
+  type EvolutionActionReplicationEmitter,
+  type LearningReplicationEmitter,
+} from '../../src/core/EvolutionManager.js';
+
+function mkDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'evo-emit-wedge-'));
+}
+function cleanup(dir: string) {
+  SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/evolution-manager-emit-wedge.test.ts' });
+}
+
+interface ActionCounter extends EvolutionActionReplicationEmitter {
+  putCount: number;
+  puts: Array<{ title: string; status: string }>;
+}
+function actionCounter(): ActionCounter {
+  const r: ActionCounter = {
+    putCount: 0,
+    puts: [],
+    emitPut(record) { r.putCount++; r.puts.push({ title: record.title, status: record.status }); },
+    emitDelete() { /* deletes are not the wedge path */ },
+  };
+  return r;
+}
+
+describe('EvolutionManager emit wedge fix — actions re-emit only what changed', () => {
+  it('each addAction emits O(1), NOT O(N): 40 adds ⇒ 40 puts, not 40·41/2 = 820', () => {
+    const dir = mkDir();
+    try {
+      const evo = new EvolutionManager({ stateDir: dir });
+      const rec = actionCounter();
+      evo.setEvolutionActionReplicationEmitter(rec);
+      const N = 40;
+      for (let i = 0; i < N; i++) {
+        evo.addAction({ title: `task-${i}`, description: 'd', commitTo: 'Justin' });
+      }
+      // Pre-fix (re-emit every survivor): 1+2+…+40 = 820 emits. Post-fix: exactly one emit
+      // per add (only the newly added record changed) ⇒ 40.
+      expect(rec.putCount).toBe(N);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('updateAction re-emits ONLY the changed action (not every survivor), carrying the new status', () => {
+    const dir = mkDir();
+    try {
+      const evo = new EvolutionManager({ stateDir: dir });
+      const rec = actionCounter();
+      evo.setEvolutionActionReplicationEmitter(rec);
+      const ids: string[] = [];
+      for (let i = 0; i < 5; i++) {
+        ids.push(evo.addAction({ title: `a-${i}`, description: 'd', commitTo: 'Justin' }).id);
+      }
+      rec.putCount = 0; rec.puts.length = 0;
+      expect(evo.updateAction(ids[2], { status: 'in_progress' })).toBe(true);
+      // Pre-fix: all 5 survivors re-emit. Post-fix: only the one that changed.
+      expect(rec.putCount).toBe(1);
+      expect(rec.puts).toEqual([{ title: 'a-2', status: 'in_progress' }]);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('an unchanged record is never re-emitted: re-persisting the same state emits nothing', () => {
+    const dir = mkDir();
+    try {
+      const evo = new EvolutionManager({ stateDir: dir });
+      const rec = actionCounter();
+      evo.setEvolutionActionReplicationEmitter(rec);
+      const id = evo.addAction({ title: 'stable', description: 'd', commitTo: 'Justin' }).id;
+      rec.putCount = 0;
+      // A no-op update (same status it already has) must not re-emit — its content is unchanged.
+      expect(evo.updateAction(id, { status: 'pending' })).toBe(true);
+      expect(rec.putCount).toBe(0);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it('cold start (restart with a populated queue) does NOT re-emit every action on the first write', () => {
+    const dir = mkDir();
+    try {
+      // Session 1: build a 30-action queue on disk (no emitter needed to persist).
+      const s1 = new EvolutionManager({ stateDir: dir });
+      for (let i = 0; i < 30; i++) {
+        s1.addAction({ title: `pre-${i}`, description: 'd', commitTo: 'Justin' });
+      }
+      // Session 2 (simulated restart): fresh manager over the SAME dir. Attaching the emitter
+      // seeds the change-detector from the on-disk queue, so the first write does not
+      // re-emit the 30 pre-existing actions.
+      const s2 = new EvolutionManager({ stateDir: dir });
+      const rec = actionCounter();
+      s2.setEvolutionActionReplicationEmitter(rec);
+      s2.addAction({ title: 'new-after-restart', description: 'd', commitTo: 'Justin' });
+      // Pre-fix (no seeding + re-emit-all): 31 emits on the first write. Post-fix: 1.
+      expect(rec.putCount).toBe(1);
+      expect(rec.puts).toEqual([{ title: 'new-after-restart', status: 'pending' }]);
+    } finally {
+      cleanup(dir);
+    }
+  });
+});
+
+interface LearningCounter extends LearningReplicationEmitter {
+  putCount: number;
+}
+function learningCounter(): LearningCounter {
+  const r: LearningCounter = {
+    putCount: 0,
+    emitPut() { r.putCount++; },
+    emitDelete() { /* not the wedge path */ },
+  };
+  return r;
+}
+
+describe('EvolutionManager emit wedge fix — learnings re-emit only what changed', () => {
+  it('each registerLearning emits O(1), NOT O(N): 25 learnings ⇒ 25 puts, not 325', () => {
+    const dir = mkDir();
+    try {
+      const evo = new EvolutionManager({ stateDir: dir });
+      const rec = learningCounter();
+      evo.setLearningReplicationEmitter(rec);
+      const N = 25;
+      for (let i = 0; i < N; i++) {
+        evo.addLearning({
+          title: `lesson-${i}`,
+          category: 'process',
+          description: 'd',
+          source: { discoveredAt: new Date().toISOString() },
+        });
+      }
+      // Pre-fix: 1+2+…+25 = 325 emits. Post-fix: one per registration ⇒ 25.
+      expect(rec.putCount).toBe(N);
+    } finally {
+      cleanup(dir);
+    }
+  });
+});

--- a/upgrades/next/standby-write-wedge-fix.md
+++ b/upgrades/next/standby-write-wedge-fix.md
@@ -1,0 +1,65 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**A standby machine no longer freezes its whole server when it records an evolution
+action item or a learning.** On a multi-machine setup, `EvolutionManager.saveActions`
+and `saveLearnings` re-emitted the cross-machine replication record for **every**
+surviving record on **every** write, and each emit's witness lookup re-scans the entire
+replication journal for that store. That made one write cost O(records × journalBytes) of
+**synchronous** file reads on the event loop.
+
+It also fed itself into a doom loop: re-emitting every unchanged record on every save
+bloated the journal, and a bigger journal made the next write's scan slower. On a real
+agent the evolution-action journal had grown to ~53 MB / ~61,000 records for only 632
+distinct items — each item re-emitted ~112 times — and the local queue held ~1,200
+actions. One `POST /evolution/actions` on that machine did tens of gigabytes of
+synchronous reads at once, starving the event loop until the supervisor killed and
+respawned the process. Because a slow request has a wide window to overlap one of these
+background-job-triggered freezes, `POST /attention` timed out the same way even though it
+does not touch that store.
+
+The save now re-emits **only records whose content changed** since their last emit,
+tracked by a small in-memory content fingerprint per record id. A genuine change (e.g. a
+status flip to `completed`) still re-emits so peers see the latest state — the
+load-bearing "a peer must see the new status" property is preserved and tested — but the
+redundant re-emits that caused both the freeze and the journal bloat are gone. The
+fingerprint map is seeded from on-disk state when the emitter is attached, so the first
+write after a restart does not re-emit everything once. The fix lives entirely in the
+manager's caller-side emit loop; the generic replication journal, emitter, and reader are
+untouched.
+
+## What to Tell Your User
+
+Nothing to configure. If you run your agent across more than one machine, its standby
+machine no longer freezes for tens of seconds (and get killed and restarted by its own
+supervisor) whenever it records a self-improvement to-do or a lesson. Messages you send to
+that machine during those moments stop getting swallowed. The cross-machine sharing of
+your to-dos and lessons works exactly as before, just without the wasteful repetition that
+was quietly bloating the internal log and freezing the server.
+
+## Summary of New Capabilities
+
+- Evolution action and learning replication re-emit only records whose content actually
+  changed, instead of every surviving record on every write — turning an
+  O(records × journalBytes) synchronous burst into a single small emit.
+- The change-detector is seeded from on-disk state when the replication emitter is
+  attached, so a restart with a large existing queue does not re-emit everything on the
+  first write (no cold-start freeze).
+- Status-change replication is preserved and covered by tests: a changed record still
+  re-emits so peers see the latest state; only redundant re-emits of unchanged records are
+  dropped.
+
+## Evidence
+
+- `tests/unit/evolution-manager-emit-wedge.test.ts` — new: pins the emit COUNT (the wedge
+  multiplier). 40 adds emit 40 puts (not 820); `updateAction` re-emits only the changed
+  action carrying its new status (not all survivors); an unchanged record emits nothing; a
+  simulated restart with a populated queue emits 1 (not N+1); learnings behave the same.
+  Proven failing-first against the pre-fix code (820 / 5 / 1 / 31 / 325).
+- `tests/unit/evolution-manager-action-replication.test.ts`,
+  `tests/unit/evolution-manager-learning-replication.test.ts`,
+  `tests/e2e/ws2-evolution-actions-cross-instance.test.ts` — unchanged and green: the
+  status-change-propagation and prune-tombstone guarantees still hold.

--- a/upgrades/side-effects/standby-write-wedge-fix.md
+++ b/upgrades/side-effects/standby-write-wedge-fix.md
@@ -1,0 +1,189 @@
+# Side-Effects Review — Standby-write wedge fix (evolution/learning replication re-emits only changed records)
+
+**Version / slug:** `standby-write-wedge-fix`
+**Date:** `2026-07-09`
+**Author:** `Echo (instar-dev)`
+**Second-pass reviewer:** `Echo (independent read)`
+
+## Summary of the change
+
+On a multi-machine setup, `EvolutionManager.saveActions` and `saveLearnings` re-emitted the
+cross-machine replication record for **every** surviving record on **every** write. Each emit's
+witness lookup (`ReplicatedRecordEmitter.emit` → `ReplicatedPeerStreamReader.loadWitness` →
+`materialize()`) re-reads and JSON-parses the entire replication journal for that store. That made
+one write cost O(records × journalBytes) of synchronous fs on the event loop, and it fed a doom
+loop: re-emitting unchanged records bloated the journal (measured on a live agent: the
+`evolution-action-record` journal grew to ~53 MB / ~61k records for only 632 distinct keys, each
+re-emitted ~112×), which slowed every subsequent scan. With ~1,200 local actions, one
+`POST /evolution/actions` did tens of GB of synchronous reads and starved the event loop until the
+supervisor killed and respawned the process; `POST /attention` (a slow request that overlaps the
+frequent background-job-triggered freezes) timed out the same way. The fix changes the two emit
+loops to re-emit **only records whose content changed** since their last emit, tracked by a small
+per-record-id content fingerprint (`emitFingerprint`), seeded from on-disk state when the emitter is
+attached. Files: `src/core/EvolutionManager.ts` (fix), `tests/unit/evolution-manager-emit-wedge.test.ts` (new tests).
+
+## Decision-point inventory
+
+- `EvolutionManager.saveActions` emit loop — **modify** — emits PUT only for actions whose content fingerprint changed (was: every survivor).
+- `EvolutionManager.saveLearnings` emit loop — **modify** — same, for learnings.
+- `EvolutionManager.setEvolutionActionReplicationEmitter` / `setLearningReplicationEmitter` — **modify** — seed the change-detector from on-disk state on attach (cold-start guard).
+- Prune/tombstone diff (`emitDelete` for removed records) — **pass-through** — unchanged; also drops the removed id's fingerprint.
+- Generic replication machinery (`ReplicatedRecordEmitter`, `ReplicatedPeerStreamReader`, `CoherenceJournal`) — **pass-through** — deliberately untouched (the fix is caller-side only).
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. This is a replication-emit change, not a gate.
+The one "suppression" is skipping a re-emit of an UNCHANGED record; a genuinely changed record (any
+field differs, including status) still emits, so no legitimate state change is withheld.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. The narrow correctness edge is a "false
+unchanged": if a record's on-disk content ever diverged from what the journal actually holds (e.g. a
+crash between `writeFile` and the emit in the OLD code), the seed would treat it as already-emitted
+and skip re-emitting it. This is bounded by the existing peer-pull/sync backstop (peers reconcile
+full streams), and it is strictly safer than the pre-fix behavior (a guaranteed event-loop wedge).
+Documented in the code comment on `lastEmittedActionFp`.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The bug was in the manager's **caller-side** emit loop deciding WHICH records to hand
+to the emitter — not in the generic replication substrate. The fix stays there: it changes only how
+many records the manager emits, leaving the journal/emitter/reader contract identical. This
+deliberately avoids touching the generic `loadWitness`/`materialize` path (the "risky replication
+machinery"): making the witness lookup itself cheap (not scanning the whole store per key) is a
+separate, deeper optimization tracked as follow-up (see Conclusion). Notably, the sibling replicated
+stores (RelationshipManager, PreferencesManager) already emit only the single changed record — this
+fix brings EvolutionManager into line with that existing, correct pattern.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The change is a data-write/replication optimization with no blocking authority. The emit remains
+best-effort and try/catch-guarded exactly as before (a replication fault never breaks the local
+write); the fingerprint is recorded only after a successful emit, so a throw leaves the record to be
+retried on the next save.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none. The emit loop runs after the local `writeFile` persists state (unchanged
+  order); the fingerprint skip runs before `emitPut` and only decides whether to call it.
+- **Double-fire:** the fix REDUCES emits (fewer journal records), never adds one. The journal's own
+  op-key dedup is downstream and unaffected.
+- **Races:** the fingerprint map is per-`EvolutionManager` instance, in-memory, and mutated only on
+  the synchronous save path (single-threaded event loop) — no shared-state race. Two managers over
+  the same dir (rare; e.g. a per-request instance) each keep their own map; the worst case is one
+  extra cold re-emit, bounded by the seeding.
+- **Feedback loops:** this BREAKS the existing doom loop (re-emit-all → journal bloat → slower scan →
+  worse). It introduces no new feedback loop.
+
+---
+
+## 6. External surfaces
+
+- **Other agents / peers:** peers receive strictly FEWER redundant `evolution-action-record` /
+  `learning-record` journal entries. The union/materialize read on the receiving side folds to the
+  latest per (origin, recordKey) regardless of how many redundant copies arrived, so a peer's
+  resolved view is identical — it just stops accumulating duplicates. The load-bearing "a peer sees
+  the latest status" property is preserved (a status change re-emits) and covered by
+  `tests/e2e/ws2-evolution-actions-cross-instance.test.ts` (green).
+- **Persistent state:** the replication journal stops bloating. Existing bloat (the ~53 MB
+  `evolution-action-record` peer stream) is not deleted by this change — it stops growing and is
+  trimmed over time by the existing archive-rotation / aggregate-budget machinery. No migration.
+- **Operator surface (Mobile-Complete):** no operator-facing actions — not applicable.
+- **External systems:** none (no Telegram/Slack/GitHub/Cloudflare surface).
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable. This change touches no dashboard renderer, approval page, or
+grant/revoke/secret-drop form.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**replicated** — this IS a replication-path change. The state (evolution actions, learnings) follows
+the agent across machines via the coherence-journal `evolution-action-record` / `learning-record`
+kinds, gated by `multiMachine.stateSync.evolutionActions` / `.learnings`. The fix preserves that
+replication (changed records still cross machines) while removing the redundant re-emits that caused
+the wedge and the journal bloat. It emits no user-facing notices (no one-voice concern). It holds no
+new durable state (the fingerprint map is in-memory, seeded from disk on attach). It generates no
+URLs. On a single-machine agent the emitter is not attached (dark), so the change is a strict no-op
+there.
+
+---
+
+## 8. Rollback cost
+
+Pure code change — revert `src/core/EvolutionManager.ts` and ship a patch. No persistent state to
+clean up (the in-memory fingerprint map simply stops existing on revert; reverting restores the old
+re-emit-all behavior, i.e. the wedge returns but nothing is corrupted). No agent state repair. No
+user-visible regression during the rollback window. The existing journal bloat is orthogonal to the
+code change (rolling back does not re-inflate anything already trimmed).
+
+---
+
+## Conclusion
+
+This review produced no design changes. The fix is contained to the manager's caller-side emit loop,
+brings EvolutionManager into line with how the sibling replicated stores already emit (single changed
+record), and is proven with a failing-first test that pins the emit COUNT (the wedge multiplier).
+One follow-up is flagged, not blocking: even after this fix, a single emit still calls `loadWitness`
+→ `materialize()`, which reads the whole (now non-growing) store journal — ~hundreds of ms on the
+current ~53 MB bloat, a block but not a wedge. Making the witness lookup itself O(1)-ish (index the
+per-key max HLC instead of re-materializing the whole store) is a deeper optimization in the generic
+`ReplicatedPeerStreamReader` and is deliberately OUT of scope here to keep this fix off the risky
+replication machinery; it should be tracked as a follow-up along with a one-time compaction of the
+already-accumulated journal bloat. Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Echo (independent read)
+**Independent read of the artifact: concur**
+
+The fix targets the proven root cause (re-emit-all + per-emit whole-journal scan), stays off the
+generic replication substrate, preserves the tested status-change-propagation guarantee, and is
+backed by a failing-first test. The residual (per-emit materialize cost on the existing bloat) is
+honestly scoped as a non-blocking follow-up.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/evolution-manager-emit-wedge.test.ts` — new; failing-first proof against pre-fix code
+  produced exactly the O(N) counts (820 / 5 / 1 / 31 / 325), passes after the fix.
+- Live forensics: `evolution-action-record` peer journal = 61,649 records over 632 distinct
+  recordKeys (max re-emits of one key = 112), ~53 MB; local `action-queue.json` = 1,188 actions;
+  `GET /write-admission` `eventLoop.starvedWindows24h = 13`.
+- `tests/unit/evolution-manager-action-replication.test.ts`,
+  `tests/unit/evolution-manager-learning-replication.test.ts`,
+  `tests/integration/ws25-evolution-actions-emit.test.ts`,
+  `tests/e2e/ws2-evolution-actions-cross-instance.test.ts` — unchanged, green.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable. This fixes a code performance/event-loop defect
+in a data-write path (`EvolutionManager.saveActions`/`saveLearnings`), not an LLM prompt, hook,
+config, skill, or standards text. It is not a self-triggered controller in the
+`unbounded-self-action` class: the emit loop runs synchronously as part of a write the agent
+explicitly performs (add/update an action or learning), not on its own timer/monitor/recovery
+trigger.


### PR DESCRIPTION
## ELI16 — A standby machine stops freezing its whole server when it records a to-do or a lesson

On a multi-machine setup, one machine serves and the other is on standby. A bug made the standby machine freeze completely — not answering anything, not even a basic health check — for tens of seconds whenever it recorded a self-improvement action item or a learning. The freeze was long enough that the machine's own supervisor decided the process was dead and killed-and-restarted it, so anyone messaging that machine during the window got silence, then a fresh restart. The cause was a wasteful loop: every save re-announced *every* record it had ever kept into the cross-machine log — not just the one that changed — and each re-announcement re-read the *entire* log from disk. That fed a doom loop (re-announcing everything made the log bigger, a bigger log made the next save slower), until one save became tens of gigabytes of synchronous reads on the single thread the whole server runs on. The fix re-announces only records whose content actually changed, so a genuine status change still reaches the other machines but the pointless repetition — which caused both the freeze and the runaway log growth — is gone.

## The bug (pinned mechanism)

`EvolutionManager.saveActions` and `saveLearnings` re-emitted the cross-machine replication record for **every** surviving record on **every** write:

```
for (const a of state.actions) { emitter.emitPut(a); }   // ALL survivors, every save
```

Each `emitPut` -> `ReplicatedRecordEmitter.emit` -> `ReplicatedPeerStreamReader.loadWitness` -> `materialize()`, which reads and JSON-parses the **entire** replication journal for that store. So one write cost **O(records x journalBytes)** of synchronous fs on the event loop, and it fed a doom loop: re-emitting unchanged records bloats the journal, and a bigger journal makes the next scan slower.

**Reproduced on the live Laptop (standby), v1.3.794:**
- `evolution-action-record` journal: **61,649 records over only 632 distinct recordKeys** (each key re-emitted **~112x**), peer stream ~**53 MB**.
- Local `action-queue.json`: **1,188 actions**.
- One `POST /evolution/actions` => 1,188 x ~53 MB ~= **tens of GB of synchronous reads** -> event loop starved -> supervisor kills+respawns (`uptime: 8s`). `GET /write-admission` showed `eventLoop.starvedWindows24h: 13`.
- `POST /attention` (no journal write, but a *slow* request via the tone gate) timed out the same way because it overlaps the frequent background-`addAction` freezes; `GET /health` returned nothing during the window.

It "only bit on standby" incidentally: the standby happened to hold both the huge local queue and the huge journal, and background jobs (mentor/failure/correction loops) call `addAction` there periodically.

## The fix (caller-side only — generic replication machinery untouched)

- Re-emit PUT **only for records whose content fingerprint changed** since their last emit. A genuine change (e.g. a status flip to `completed`) still re-emits — the load-bearing "a peer sees the latest status" property is preserved and tested — but redundant re-emits of unchanged records are dropped, killing both the wedge and the journal bloat.
- **Seed** the fingerprint map from on-disk state when the emitter is attached, so the first write after a restart does not re-emit everything once (cold-start guard).
- Drop a pruned id's fingerprint alongside its tombstone emit.

This brings `EvolutionManager` into line with the sibling replicated stores (`RelationshipManager`, `PreferencesManager`), which already emit only the single changed record. The generic journal / emitter / reader are deliberately not touched.

## Failing-test-first

`tests/unit/evolution-manager-emit-wedge.test.ts` pins the emit **count** (the wedge multiplier), so it is deterministic. Proven failing against the pre-fix code, passing after:

| scenario | pre-fix | post-fix |
|---|---|---|
| 40 addActions | 820 puts | 40 |
| updateAction on 1 of 5 | 5 puts | 1 (new status) |
| unchanged re-save | 1 put | 0 |
| cold-start restart, 1 add over 30 | 31 puts | 1 |
| 25 learnings | 325 puts | 25 |

Existing suites stay green: `evolution-manager-action-replication`, `evolution-manager-learning-replication`, `ws25-evolution-actions-emit` (integration), `ws2-evolution-actions-cross-instance` (e2e), `ws22-learnings-emit` (integration, in pre-push smoke).

## Residual (out of scope, non-blocking)

Even after this fix, a single emit still calls `loadWitness` -> `materialize()`, which reads the whole (now non-growing) store journal — ~hundreds of ms on the existing ~53 MB bloat: a block, not a wedge. Making the witness lookup O(1) (index the per-key max HLC instead of re-materializing the whole store) is a deeper change to the generic `ReplicatedPeerStreamReader` and is deliberately left as a follow-up, along with a one-time compaction of the already-accumulated journal bloat. Tracked in the side-effects review's Conclusion.

Tier 1. ELI16: `docs/specs/standby-write-wedge-fix.eli16.md`. Side-effects: `upgrades/side-effects/standby-write-wedge-fix.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
