### PR TITLE
docs(release): v1.3.802 version-named side-effects pairing (unblocks post-release local pushes)

### DIFF
--- a/upgrades/side-effects/1.3.802.md
+++ b/upgrades/side-effects/1.3.802.md
@@ -1,0 +1,31 @@
+# Side-Effects Review — v1.3.802 (version-named pairing)
+
+This is the version-named pairing for the v1.3.802 release, completing the
+rename step the release cut is expected to perform alongside the
+`NEXT.md → 1.3.802.md` guide rename (see `scripts/pre-push-gate.js` check 5:
+"the fragment/NEXT.md -> <version>.md rename pairs with an artifact rename").
+The release flow did not perform the artifact half of the pairing, which makes
+check 5 false-positive on every docs-only push from a clean post-release tree
+— the same recurrence previously repaired for v1.3.492
+(`upgrades/side-effects/1.3.492.md`).
+
+The actual side-effects reviews for everything shipped in the
+v1.3.800–v1.3.802 window are:
+
+- `upgrades/side-effects/attention-single-topic-routing.md`
+  (#1417, v1.3.800 — single-alerts-topic routing; every alert lands in the
+  ONE Attention hub by default)
+- `upgrades/side-effects/self-action-governor.md`
+  (#1418, v1.3.801 — SelfActionGovernor unified self-action backpressure
+  chokepoint, observe-only fleet-wide)
+- `upgrades/side-effects/session-listing-hygiene.md`
+  (#1419, v1.3.802 — bounded finished-session retention, active-by-default
+  `GET /sessions`, genuine cross-machine duplicate flag)
+
+Those artifacts are left in place under their slug names because each release
+guide's Evidence section cites them by those paths. This file exists so the
+repo state matches the gate's documented post-release expectation. The
+underlying gap (release automation never renames artifacts) remains logged in
+the framework-issues ledger under dedupKey
+`pre-push-gate-versioned-artifact-fallback`; this is its second observed
+recurrence after v1.3.492.


### PR DESCRIPTION
## eli16

After every release, our safety gate expects two renamed files to exist as a pair: the release notes (which the release robot creates) and a matching side-effects review file (which the robot forgets to create — it has forgotten twice now, first at v1.3.492 and again at v1.3.802). Because the second file was missing, anyone trying to push even a harmless docs-only change from a freshly-updated machine got refused by the gate with a confusing error about missing review artifacts. This change adds the missing pairing file for v1.3.802, exactly mirroring how the v1.3.492 recurrence was repaired. The file points at the three real side-effects reviews that shipped in this release window (the single-alerts-topic routing fix, the self-action governor, and the session-listing hygiene work), so nothing is fabricated — it is an index completing the expected naming convention. The underlying robot gap stays tracked in the framework-issues ledger; if it recurs a third time the automation itself should be fixed rather than hand-repairing again.

## What

Adds `upgrades/side-effects/1.3.802.md` — the version-named pairing check 5 of `scripts/pre-push-gate.js` expects post-release-cut. Docs-only.

## Why now

The notification-selectivity spec branch (docs-only) cannot be pushed from any local tree until this exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)