### PR TITLE
docs(spec): notification-selectivity — Quiet by Default (converged r3 + operator-approved; reconstruction of the lost June-13 design)

### DIFF
--- a/docs/specs/notification-selectivity.eli16.md
+++ b/docs/specs/notification-selectivity.eli16.md
@@ -92,9 +92,10 @@ one of them is genuinely yours, and saying "change #N" is enough.
 2. **One real tension needs your eyes (new since June 13):** the day AFTER
    you approved this design, we ratified a standard saying a genuinely-stuck
    promise I own should surface to you ONCE. This spec resolves it your
-   June-13 way: stuck-promise notices stay QUIET (dashboard + unread badge +
-   my own boot context + the digest), with a `commitment-deadletter` category
-   you can opt into push anytime. Confirm that's still what you want.
+   June-13 way: stuck-promise notices stay QUIET — dashboard + unread badge +
+   my own boot context (and the daily digest, but ONLY if you've turned that
+   on; it's off by default) — with a `commitment-deadletter` category you can
+   opt into push anytime. Confirm that's still what you want.
 3. **Which messages keep flowing as "part of the conversation"?** Default:
    only messages that answer a live action of yours — real replies, the
    unanswered-message receipt, "couldn't start your session", "your message
@@ -110,7 +111,11 @@ one of them is genuinely yours, and saying "change #N" is enough.
 6. **Where opted-in pushes land.** Default: the one Attention topic (Agent
    Health items keep their 🩺 topic). Never a new topic — already law.
 7. **The push volume cap.** Default: 3 pushes per category per 10 minutes,
-   overflow folds into one summary. Tunable down, never off.
+   plus a global ceiling of 10 per 10 minutes across everything; overflow
+   folds into one summary. Genuinely-significant alerts have their own
+   protected lane, so routine noise can never crowd one out — and an
+   overflowing significant alert is always labeled as what it is. Tunable
+   down, never off.
 8. **How long the quiet inbox remembers.** Default: 30 days / 20,000 entries,
    storm-proof (a repeating notice becomes one row with a count, so a bug
    can't wash out real history).
@@ -135,6 +140,19 @@ one of them is genuinely yours, and saying "change #N" is enough.
     is the final cleanup increment after the fleet has soaked quiet —
     honoring your June-13 call as the end state, not skipping the staged
     rollout's safety.
+14. **One safety check on replies stays advisory at first.** The gate could
+    additionally demand every "reply" correlate to a recent message of yours
+    before it delivers. Eating a slow, legitimate reply would be worse than
+    letting one automated message slip, so at launch this check only MEASURES
+    (every mismatch is logged and audited); it gains blocking power in a
+    later PR only after 14 days of enforcement, 200+ real replies, and zero
+    false alarms — all server-side, nothing changes about how I reply.
+15. **Existing notice settings are grandfathered, not force-quieted.** A
+    couple of today's notices (like reap notices) are effectively ON by
+    default. At the fleet flip, whatever is effectively on for you STAYS on
+    (recorded as your opt-in) — the flip changes the default for everything
+    new, it never silently revokes a standing behavior you may rely on. Turn
+    any of them off with one toggle afterwards.
 
 ## What this is NOT
 

--- a/docs/specs/notification-selectivity.eli16.md
+++ b/docs/specs/notification-selectivity.eli16.md
@@ -150,9 +150,14 @@ one of them is genuinely yours, and saying "change #N" is enough.
 15. **Existing notice settings are grandfathered, not force-quieted.** A
     couple of today's notices (like reap notices) are effectively ON by
     default. At the fleet flip, whatever is effectively on for you STAYS on
-    (recorded as your opt-in) — the flip changes the default for everything
-    new, it never silently revokes a standing behavior you may rely on. Turn
-    any of them off with one toggle afterwards.
+    (recorded as your opt-in), the flip announcement LISTS exactly what got
+    carried over, and the dashboard offers one-tap disable-all — the flip
+    changes the default for everything new, it never silently revokes a
+    standing behavior you may rely on.
+16. **Telegram first.** This ships on Telegram (where all the noise lives
+    today); Slack/WhatsApp/iMessage get the same gate as a tracked follow-up
+    — the machinery is built channel-agnostic so that's a bolt-on, not a
+    redesign.
 
 ## What this is NOT
 

--- a/docs/specs/notification-selectivity.eli16.md
+++ b/docs/specs/notification-selectivity.eli16.md
@@ -1,0 +1,150 @@
+# Quiet by Default — plain-English overview
+
+## What this is
+
+Right now, lots of the agent's internal machinery is allowed to message you on
+Telegram. The recent fix (July 10) stopped the topic spam — every alert now
+lands in the ONE "🔔 Attention" topic instead of spawning its own topic — but
+each alert still *pushes a message at you*, one per event, with no volume
+bound at all. You approved a bigger redesign on June 13 that never shipped
+(its build session was killed the same day and the converged spec file was
+lost). This spec is that redesign, rebuilt against today's code. Your words,
+June 13: automated messages should be "logs only" by default, with "an
+extremely high requirement before sending ANY automated messages to the user,
+unless the user requests to hear specific notifications." And again on July
+10: "we need to be VERY selective about what gets actually sent to the user
+(most should be internal logs)."
+
+The design in one breath: **anything I generate on my own — sentinel notices,
+health checks, watchdog reports, job status, "I'm stuck" notes — goes to my
+internal logs and a dashboard inbox you can check whenever you want. It does
+NOT ping you. You opt in, per category, to anything you actually want pushed.
+Only a tiny, code-reviewed "genuinely significant" class (a security incident,
+data loss, I-cannot-operate) still reaches the one Attention topic on its own
+— and even that is volume-capped. Your normal conversations with me are
+completely untouched.**
+
+## How it works, simply
+
+- Every outbound message gets classified at the **last moment before Telegram
+  delivery**: is this a real reply to something you said, or is it automated?
+  The classification is structural — it keys on where the message came from
+  (the reply pipeline vs. a background feature), never on what the text says.
+  A background feature cannot dress its message up as a "reply" or as a
+  "response to your command" to slip past: those classes must name the exact
+  message of yours they answer, and the review lints pin every emitter to the
+  categories it's allowed to claim. Anything that can't prove itself is
+  treated as automated. (This closes the disguise hole the June-13 review
+  found — and this rebuild's own review round closed four more dodge paths,
+  including features bypassing the funnel entirely.)
+- **Replies to you are never touched.** If I'm answering your message, it
+  sends, exactly as today — and every failure direction bends toward
+  delivering replies, including when two of my machines are mid-update and
+  relaying for each other.
+- **Everything else defaults to quiet**: it's written to a durable store,
+  shows up in a Notifications view on the dashboard (with an unread count),
+  gets logged, and — where it belongs to a project — is routed into the
+  session working that project, so issues surface organically where they
+  matter instead of pinging you out of context. Items belonging to nothing
+  get aged into my own boot context so they can't rot unseen.
+- **You opt in per category** ("push me reap notices", "push me quota alerts")
+  — conversationally or with a dashboard toggle. Opted-in pushes land in the
+  existing Attention topic, never new topics — and even an opted-in category
+  is volume-capped (a buggy feature that fires 500 notices gets you 3 plus
+  one "…and 47 more, see dashboard" summary, never 500 pings).
+- **I cannot opt myself in.** Every opt-in write requires a recorded operator
+  confirmation (your dashboard PIN, or your explicit yes in conversation),
+  is audited, and a burst of opt-in changes raises its own alert. The
+  current opt-in list is always visible on the status page and in the digest.
+- **Nothing is ever silently lost.** If the quiet store itself breaks, that
+  failure is one of the few things loud enough to reach you — with an honest
+  count of anything that couldn't be recorded.
+- A **CI test enforces the whole thing forever**: fire 1,000 automated signals
+  through the real pipeline — if even ONE stray message would push to you
+  without an opt-in, the build fails. Zero, not "a few." A second arm proves
+  an opted-in category stays inside its volume cap.
+
+## What already shipped and stays
+
+The July-10 single-Attention-topic routing, the flood guards and topic budget,
+the tone gate on my conversational messages, the advisory layer that keeps
+jargon/file-paths out of automated job sends, the calm Agent Health lane, and
+duplicate suppression all stay exactly as they are. This spec adds the one
+missing layer they don't have: *whether an automated message should push at
+all* — and fixes one real gap the review found in the July-10 fix itself (the
+hub had no per-source message cap; now it does). Rollout is careful: dark
+first, then observe-only on the dev agent (it logs what it WOULD suppress but
+delivers everything), then enforcement on dev, then the fleet — and the last
+two steps are YOUR flips, made on presented evidence, not mine.
+
+## The decisions you'd be confirming (each has a default — override any)
+
+These are the open questions, in plain English. Each is resolved in the spec
+with a recommended default so the build never has to stop and ask — but every
+one of them is genuinely yours, and saying "change #N" is enough.
+
+1. **What counts as "significant enough to push without opt-in"?** Default: a
+   tiny hardcoded set — security incident, data loss, agent-cannot-operate —
+   each defined with concrete "is / is NOT" examples so it can't erode into a
+   new "urgent" escape hatch. Nothing else, and NO config can add to it (only
+   a code change reviewed at PR time). Even "I'm stuck, I need your call"
+   stays quiet until you opt in — exactly what you said on June 13.
+2. **One real tension needs your eyes (new since June 13):** the day AFTER
+   you approved this design, we ratified a standard saying a genuinely-stuck
+   promise I own should surface to you ONCE. This spec resolves it your
+   June-13 way: stuck-promise notices stay QUIET (dashboard + unread badge +
+   my own boot context + the digest), with a `commitment-deadletter` category
+   you can opt into push anytime. Confirm that's still what you want.
+3. **Which messages keep flowing as "part of the conversation"?** Default:
+   only messages that answer a live action of yours — real replies, the
+   unanswered-message receipt, "couldn't start your session", "your message
+   was lost, resend", and direct responses to commands you typed. Each must
+   cite the specific message of yours it serves; an active chat is not a
+   standing license.
+4. **The daily digest.** Default: OFF. If you turn it on, once a day you get
+   one summary in the Attention topic — counts and category names plus your
+   current opt-in list, never item contents. Purely opt-in.
+5. **How fine-grained the opt-in is.** Default: per category ("reap notices",
+   "quota alerts"), not per feature or per topic. Finer grain later if you
+   want it.
+6. **Where opted-in pushes land.** Default: the one Attention topic (Agent
+   Health items keep their 🩺 topic). Never a new topic — already law.
+7. **The push volume cap.** Default: 3 pushes per category per 10 minutes,
+   overflow folds into one summary. Tunable down, never off.
+8. **How long the quiet inbox remembers.** Default: 30 days / 20,000 entries,
+   storm-proof (a repeating notice becomes one row with a count, so a bug
+   can't wash out real history).
+9. **Multi-machine opt-ins.** Default: one toggle applies everywhere — online
+   machines immediately, offline machines get the change queued and applied
+   when they return; if machines stay out of sync more than a day, you get
+   ONE alert about it.
+10. **Who flips enforcement on.** Default: YOU do, twice (dev first, then
+    fleet), each time on presented evidence: 14 clean days, at least 200 real
+    replies observed, and zero would-have-eaten-a-reply incidents. I present;
+    you flip.
+11. **Who can change opt-ins.** Default: only you — dashboard PIN or your
+    explicit conversational yes, every change audited, bursts of changes
+    alarmed. I can never grant myself push.
+12. **The category list itself.** Default: the 18-category table printed in
+    the spec ships as-is; your approval binds it. The dashboard tab is called
+    "Notifications."
+13. **The end-state of the old behavior.** June 13 you said remove the
+    break-glass entirely. Default here: the off-switch EXISTS during rollout
+    (dark → observe → enforce needs a lever; turning it off after the fleet
+    flip warns you loudly about what it restores), and removing it entirely
+    is the final cleanup increment after the fleet has soaked quiet —
+    honoring your June-13 call as the end state, not skipping the staged
+    rollout's safety.
+
+## What this is NOT
+
+- It does NOT touch your conversations with me — replies flow exactly as
+  today, and every failure mode is biased toward delivering them.
+- It does NOT replace the sentinels/watchdogs — they keep handling their real
+  recovery cases; this governs what leaks through to YOU.
+- It is NOT a new AI judgment call on the delivery path — the classification
+  is deterministic provenance (where the message came from), no LLM, no text
+  matching, nothing to misfire on wording.
+- It does NOT ship live anywhere until you approve this spec — and the June-13
+  "Approved" is recorded as design provenance only; this rebuilt artifact
+  needs your fresh sign-off before any build starts.

--- a/docs/specs/notification-selectivity.md
+++ b/docs/specs/notification-selectivity.md
@@ -45,9 +45,17 @@ lessons-engaged:
 # Notification Selectivity — Quiet by Default
 
 Small glossary for readers outside the project lexicon: **P17** = Bounded
-Notification Surface (topic/volume budgets); **P22** = Self-Heal Before Notify;
-**P23** = single-alerts-topic routing; **ELI16** = the plain-English companion
-document; **the hub** = the "🔔 Attention" Telegram topic created by PR #1417.
+Notification Surface (topic/volume budgets); **P19** = No Unbounded Loops
+(every repeating behavior carries backoff/breaker/cap); **P22** = Self-Heal
+Before Notify; **P23** = single-alerts-topic routing; **ELI16** = the
+plain-English companion document; **the hub** = the "🔔 Attention" Telegram
+topic created by PR #1417; **Standard B** = the spec-review check that an
+operator-notifying watcher declares its self-heal + brakes; **WS2 / WS4.1** =
+the multi-machine replicated-store hardening (type-clamped, untrusted-data
+enveloped) and the durable cross-machine ack (queued intent, revalidated at
+apply time); **the lifeline** = the always-alive guaranteed-reachable session;
+**working-set carrier** = the mechanism that moves a topic's files between
+machines; **guardian-pulse** = the daily meta-monitor digest job.
 
 ## Problem statement
 
@@ -273,7 +281,20 @@ twice. A verdict rendered at `createAttentionItem` rides an internal
 PRE-DECIDED envelope — an unforgeable in-process object (module-private class
 instance, not a string field, so no caller can spoof it as a category) — and
 the funnel honors it without re-classification. The same pass-through carries
-the §6 failure notice and §5 significant pushes.
+the §6 failure notice and §5 significant pushes. A pre-decided envelope is
+**single-use**: consumed on delivery (a unit test pins that a captured
+instance cannot be replayed to skip §5.2 budget re-evaluation), and it
+**never crosses the mesh** — a relayed send is always classified fresh by the
+holder (§2.4).
+
+**How emitters get stamping capability (runtime fit, honestly stated):** the
+callsite→category fit is enforced at BUILD time by the §9 lint; at RUNTIME
+there is no ambient "stamp any category" API to misuse — each emitter module
+receives, at composition-root wiring time, a stamper handle bound to exactly
+its registry-declared categories (the capability-object pattern), so stamping
+outside your declaration requires changing the wiring, which is the lint's
+and the PR review's jurisdiction. No reflection-based runtime module-identity
+check is claimed (JavaScript offers none for free).
 
 ### 2.1 The provenance envelope
 
@@ -311,13 +332,23 @@ Stamping points (each is an existing chokepoint, not new surface):
   TelegramAdapter.ts:921–3225 responding to user-typed commands) stamp
   `command-response` (conversation-serving — a user typed the command), each
   carrying the triggering command message id as `inboundMessageId`.
-- **Raw `apiCall('sendMessage')` bypass closure:** seven callsites today
-  bypass `sendToTopic` entirely (TelegramAdapter.ts:741, 1613, 2399, 3961,
-  4098, 4204, 5115). The build enumerates all seven and either routes each
-  through the funnel or marks it with an in-code justification comment the
-  lint recognizes (e.g. the hub-post internals already carrying a pre-decided
-  envelope); the §9 lint FORBIDS new raw `sendMessage` callsites. Without
-  this, the gate repeats the historical "guard at the wrong layer" dodge.
+- **Raw `apiCall('sendMessage')` bypass closure:** roughly nine callsites
+  today reach the Telegram API without passing `sendToTopic` — including
+  **`TelegramAdapter.send()` (:1235, apiCall :1249/:1256)**, the generic
+  adapter-interface method with a LIVE automated caller
+  (`TelegramConfirmationTransport.ts:114`, ux-confirm prompts), plus leaf
+  sites at :741, :1613, :2399, :3961, :4098, :4204, and both branches of the
+  prompt sender (:5115/:5125). The census in this paragraph is
+  reconstruction-time; **the build re-enumerates by grep at lint-baseline
+  time** (a stale count must never become the lint's blind spot — that was
+  round 2's own finding against this spec's first census). `send()` is an
+  entry point, not a leaf: it is routed through the funnel (or stamps
+  envelopes itself) — ux-confirm prompts classify conversation-serving,
+  bound to the triggering inbound like any §3.2 category. Leaf sites get
+  funnel routing or an in-code justification comment the lint recognizes
+  (e.g. hub-post internals already carrying a pre-decided envelope); the §9
+  lint FORBIDS new raw `sendMessage` callsites. Without this, the gate
+  repeats the historical "guard at the wrong layer" dodge.
 
 ### 2.2 Verified-reply classification (D-7 — closing the disguise hole)
 
@@ -342,12 +373,20 @@ the delivery layer.** A send is `verified-reply` iff ALL of:
    **Promotion exit criteria (FD-9):** after Increment C has run ≥14 days
    with ≥200 reply-path sends observed AND `replyWithoutRecentInbound`
    incidents individually audited to zero false positives, a follow-up PR may
-   promote the check to demotion authority. Until then, the honest residual
-   is stated: an unstamped in-repo caller POSTing to the reply route on an
-   interactive topic classifies as a reply. To shrink that residual
-   structurally, the §9 lint ALSO covers in-repo HTTP calls to
-   `/telegram/reply` (the callsite pattern is lintable), so a feature cannot
-   quietly adopt the route as a push path.
+   promote the check to demotion authority. The audit is ledger-driven and
+   bounded, not an open-ended manual chore: each incident row carries the
+   topic, the send, and the map state needed to judge it, and the metric is
+   expected to be rare — the review is a per-incident checklist over a small
+   set, presented with the FD-12 evidence. **The promotion mechanism is
+   server-minted, zero client-contract change:** the route already tracks the
+   topic's current inbound (`currentInboundByTopic`, routes.ts:12595) and the
+   §2.5 map; promotion means the `verified-reply` stamp additionally requires
+   that server-side binding — no caller ever supplies a nonce or changes
+   telegram-reply.sh. Until then, the honest residual is stated: an unstamped
+   in-repo caller POSTing to the reply route on an interactive topic
+   classifies as a reply. To shrink that residual structurally, the §9 lint
+   ALSO covers in-repo HTTP calls to `/telegram/reply` (the callsite pattern
+   is lintable), so a feature cannot quietly adopt the route as a push path.
 
 Anything that fails 1–3 is `automated`. An automated send cannot BECOME a
 reply by claiming it: there is no caller-settable "I am a reply" field — the
@@ -402,25 +441,36 @@ notified" state anywhere. §9 requires tests per caller class.
 - **Relayed sends** (tokenless standby → lease holder,
   TelegramAdapter.ts:1332–1343): the envelope rides the relay exactly like
   the existing `kindMetadata`, and the DELIVERING machine (the holder — it
-  owns the config and the quiet store) classifies. Two hard rules:
+  owns the config and the quiet store) classifies. Three hard rules:
   - **Trust model, stated:** peer machines are the SAME agent,
-    mesh-authenticated; a relayed `origin` is nonetheless a peer-asserted
-    field arriving over HTTP, so the holder RE-APPLIES the §2.2.3 breadcrumb
-    demotion against its own topic/session state and stamps
-    `relayedOrigin: true` on the ledger row — forged-origin incidence is
-    measurable during dryRun, and the local "no HTTP caller can assert
-    verified-reply" guarantee is honestly scoped to non-mesh callers.
+    mesh-authenticated; nonetheless EVERY relayed envelope field — `origin`,
+    `category`, `significantClass` — is a peer-asserted field arriving over
+    HTTP. The holder classifies a relayed send FRESH: it re-applies the
+    §2.2.3 breadcrumb demotion against its own topic/session state, re-checks
+    the (category, class) pair against ITS OWN §5 table, applies ITS OWN §5.2
+    budgets, and stamps `relayedOrigin: true` on the ledger row. Pre-decided
+    verdicts never cross the mesh (§2). Forged-origin incidence is measurable
+    during dryRun, and the local "no HTTP caller can assert verified-reply"
+    guarantee is honestly scoped to non-mesh callers.
+  - **The relay carrier (how the holder KNOWS it is a relay):** the relay hop
+    is a plain authed POST today, indistinguishable from a local script call
+    — so new-version relays add `{relayed: true, machineId, protocolVersion}`
+    to the relay body. Presence of the marker drives `relayedOrigin` tagging
+    and per-peer version gating; **ABSENCE of the marker on a send the holder
+    can identify as relay-shaped is itself the legacy-skew signal** that
+    triggers the fallback below. (The pool machine registry's advertised
+    versions are the coarse backstop when per-request data is absent.)
   - **Version-skew direction (an envelope-less relayed send):** an OLD-version
     standby relays without an envelope. Classifying that `uncategorized` →
     `record` would EAT a conversational reply — the unsafe direction. So an
     envelope-less relayed send falls back to the already-riding
     `kindMetadata.messageKind` (`reply` → deliver; `automated`/absent →
     record), for a bounded skew window (enforcement on relayed sends
-    additionally gates on the peer's protocol version). Honesty note for the
-    inverse skew: a NEW-version sender relaying to a LEGACY holder degrades
-    toward push (the legacy holder has no gate) — harmless while the fleet is
-    dark/dryRun, gone once Increment D lands, and stated here so nobody
-    mistakes it for a guarantee.
+    additionally gates on the peer's advertised protocol version). Honesty
+    note for the inverse skew: a NEW-version sender relaying to a LEGACY
+    holder degrades toward push (the legacy holder has no gate) — harmless
+    while the fleet is dark/dryRun, gone once Increment D lands, and stated
+    here so nobody mistakes it for a guarantee.
 
 ### 2.5 The inbound recency map (no hot-path disk I/O)
 
@@ -429,12 +479,14 @@ must never run inside `sendToTopic`. The gate reads only an in-memory
 per-topic map maintained on the INBOUND path: for each topic, the last N=20
 inbound user message ids with timestamps (and the current unanswered-message
 id, which the reply route already tracks — `currentInboundByTopic`,
-routes.ts:12595). Rebuilt lazily after restart from the reply route's
-existing state; when the map is cold/unavailable, conversation-serving
-corroboration FAILS OPEN TO DELIVER for the floor categories
-(`cold-start-fallback`, `message-loss-notice` — their trigger IS an inbound)
-and fails CLOSED to record for `command-response`/`presence-standby` (their
-triggering id must be present), each outcome ledger-tagged `mapCold: true`.
+routes.ts:12595). Memory-bounded: topics idle >7 days are LRU-evicted and the
+map caps at ~1,000 tracked topics. Rebuilt lazily after restart from the
+reply route's existing state; when the map is cold/unavailable,
+conversation-serving corroboration FAILS OPEN TO DELIVER for the floor
+categories (`cold-start-fallback`, `message-loss-notice` — their trigger IS
+an inbound) and fails CLOSED to record for
+`command-response`/`presence-standby` (their triggering id must be present),
+each outcome ledger-tagged `mapCold: true`.
 
 ## §3 — Dispositions
 
@@ -496,12 +548,17 @@ push-by-default through the back door and hollow D-1; those are handled at
 Increment D by a one-time `migrateConfig` SNAPSHOT — each agent's current
 lever value is copied into `notifications.push.categories.<id>` (preserving
 the operator's effective choice on that machine), and the lever's DELIVERY
-role retires (its feature-behavior role, if any, is untouched). Increment D's
-"logs-only default everywhere" claim holds because the snapshot preserves
-choices, not defaults. Full consolidation (retiring the legacy keys
-entirely) remains tracked <!-- tracked: 11960 -->. The dashboard toggle is
-never dead: the §4.2 sole-writer route sets BOTH the category key and (when
-declared) the category's legacyGate key, so one toggle is one lever.
+role retires (its feature-behavior role, if any, is untouched). **This is
+INTENTIONAL GRANDFATHERING, named for the operator:** an agent whose
+reap-notice lever was effectively on keeps pushing reap notices after
+Increment D until its operator turns the category off — the flip changes the
+DEFAULT, never a standing effective choice (the ELI16 decision list carries
+this). Increment D's "logs-only default everywhere" claim holds because the
+snapshot preserves choices, not defaults. Full consolidation (retiring the
+legacy keys entirely) remains tracked <!-- tracked: 11960 -->. The dashboard
+toggle is never dead: the §4.2 sole-writer route sets BOTH the category key
+and (when declared) the category's legacyGate key, so one toggle is one
+lever.
 
 ## §4 — The pull surface + opt-in
 
@@ -543,11 +600,19 @@ merge is a documented hazard for nested keys).
 - Non-attention quiet sends land in a new `QuietNotificationStore`
   (`state/quiet-notifications.jsonl`), with storm discipline learned from the
   2026-07-09 EvolutionManager doom-loop and the 17.5k-requests day:
-  - **Coalescing:** a repeat within a rolling window keyed
-    (category, sourceContext) INCREMENTS a `count` on the open row (a new
-    appended coalesce row, event-sourced — never read-modify-write of the
-    file), so a storming source occupies O(1) rows per window, not 17,503 —
-    and cannot evict everyone else's history via the `maxEntries` prune.
+  - **Coalescing (pinned mechanics):** repeats within a rolling window keyed
+    (category, sourceContext) ACCUMULATE IN MEMORY and flush **at most one
+    row per key per window** (on window close, a flush timer, or clean
+    shutdown) — so a 17.5k storm writes O(windows) physical rows, not 17.5k,
+    and cannot evict everyone else's history via the `maxEntries` prune or
+    inflate the boot index rebuild. A crash loses at most the open window's
+    tail count — explicitly accepted; the flushed row carries
+    `coalescedApprox: true` when a crash truncated its window.
+  - **Durability semantics (pinned):** ONE writer (the server process's
+    single appender); appends are line-atomic via O_APPEND; no per-row fsync
+    (the accepted loss window is the crash tail, reconciled against the §7
+    counters); the boot index build SKIPS-and-counts a torn final line;
+    rotation is write-new-segment-then-rename (atomic), never in-place.
   - **Bounded by rotation:** prune enforces `retentionDays`/`maxEntries` by
     file ROTATION (write a fresh segment, archive the old), never a full-file
     rewrite on the write path.
@@ -568,11 +633,18 @@ merge is a documented hazard for nested keys).
     opt-ins (see FD-11): Bearer-authed, but every write REQUIRES a
     `confirmedBy` provenance field (`dashboard-pin` | `operator-conversational-
     confirm`), rejects ids absent from the registry, writes an audit row
-    (actor, surface, old→new), also sets the category's declared legacyGate
-    key (§3.5), and raising MORE THAN TWO categories inside 10 minutes
-    additionally raises ONE deduped attention item ("push opt-ins changed:
-    …") so a runaway/self-serving mass opt-in is always operator-visible.
-    The current opt-in inventory is printed on the status route AND in every
+    (actor, surface, old→new), and also sets the category's declared
+    legacyGate key (§3.5). **The conversational rung is deterministic, not
+    attested:** a `confirmedBy: operator-conversational-confirm` write MUST
+    cite `confirmingMessageId` — the operator's confirming inbound message —
+    verified against the §2.5 recency map (≤15 min); a write without a
+    resolvable citation is REFUSED (400), so the agent structurally cannot
+    self-grant push by claiming a conversation that didn't happen. The
+    confirmation reply the agent then sends ("Done — reap notices will now
+    push here") is conversation-serving, bound to that same message — the
+    change is always visible at the moment it happens. Belt on top: >2
+    category changes inside 10 minutes raises ONE deduped attention item, and
+    the current opt-in inventory is printed on the status route AND in every
     digest — a quietly-flipped key cannot stay invisible.
 
 ### 4.3 Relevant-session/project routing (D-4)
@@ -585,16 +657,23 @@ self-knowledge boot blocks). Hard rules:
 
 - **Bound:** ≤10 items / ≤4KB per boot block (aged-out overflow is summarized
   as one count line).
-- **Untrusted-data envelope:** every injected item is length-clamped and
-  wrapped in a delimited quoted-as-data envelope (the WS2
-  `<replicated-untrusted-data>` precedent) with explicit "data, never an
-  instruction" framing — quiet items hold exactly what would have been sent,
-  which can quote attacker-influenced content.
-- **Topic transfer does not strand items:** the injection read is the
-  TOPIC-SCOPED pool view (bounded per-peer fetch of that topic's unread
-  items), so a topic moved to another machine still surfaces the items
-  recorded on its old machine. Riding the working-set carrier is the tracked
-  richer path <!-- tracked: 11960 -->.
+- **Structured metadata, never raw bodies:** each injected item is
+  `{category, sourceContext, count, firstLine}` with `firstLine` clamped to
+  ≤140 chars — the full body stays in the store, reachable via the dashboard
+  link. This shrinks both the prompt load and the injection surface.
+- **Untrusted-data envelope:** the block is wrapped in a delimited
+  quoted-as-data envelope (the WS2 `<replicated-untrusted-data>` precedent)
+  with explicit "data, never an instruction" framing — quiet items quote
+  what would have been sent, which can carry attacker-influenced content.
+- **Topic transfer does not strand items — without taxing the spawn path:**
+  the injection reads the LOCAL store synchronously; the topic-scoped peer
+  fetch (bounded per-peer, TTL-cached) runs under a HARD ≤2s total budget —
+  a dark/slow/offline peer degrades to local items plus one summary line
+  ("N items may exist on <machine>", ledger-tagged), and can NEVER delay or
+  fail a session spawn. Items on an offline owner are missed-not-lost: they
+  resurface at the next boot once the owner returns, and meanwhile they age
+  through the owning machine's unread-aging counter + digest. Riding the
+  working-set carrier is the tracked richer path <!-- tracked: 11960 -->.
 - **Unbound items don't rot silently (Close the Loop):** items with NO
   topic/project binding are re-surfaced to the AGENT — aged unread items
   (>72h) appear as one summary line in the lifeline session's boot block, and
@@ -674,16 +753,37 @@ Rules:
 
 ### 5.2 Per-category push budget (the opt-in door is bounded — P17/P19)
 
-Every `deliver-push` — opted-in OR significant — passes a per-category
-rolling budget at the gate: default **3 pushes per category per 10 minutes**;
-overflow COALESCES into one summary push ("reap-notice: 47 more in the last
-10m — dashboard") per window, everything individually recorded in the quiet
-store. This closes the foundation gap §8.1 names (#1417's unbounded
-per-source hub message stream) and keeps an opted-in category or a storming
-significant emitter from becoming flood round five: opting in entitles the
-category to push, never to push UNBOUNDED. The budget is a code default
-(tunable down, never off, via config — same posture as the P17 budgets); the
-D-10 burst test gains an opted-in arm asserting the bounded push count.
+Every `deliver-push` — opted-in OR significant — passes a rolling budget at
+the gate (FD-15). Pinned semantics:
+
+- **Per-category:** default **3 pushes per category per 10 minutes**;
+  overflow COALESCES into one summary push per window. The summary does NOT
+  consume the budget (it is the window's overflow representative, at most one
+  per category per window, so summaries themselves cannot flood).
+- **Significant classes ride their OWN lane:** significant pushes are
+  budgeted per (category, class) separately from routine opted-in pushes, so
+  an opted-in routine storm can never crowd out or hide a significant push —
+  and a significant-class overflow summary NAMES the class ("security-
+  incident: 4 more episodes in 10m"), never dressed as routine volume (the
+  P17 criticals-stay-visible precedent).
+- **Global ceiling:** at most **10 pushes per 10 minutes across ALL
+  categories** (the cross-category analog of the P17 global topic ceiling);
+  overflow folds into ONE cross-category summary.
+- **Summary content is pinned** like the digest (§4.5): count + category/
+  class name + the dashboard link — never `sourceContext`, titles, or item
+  text.
+- **Scope honesty:** budgets are per-machine and in-memory (a restart resets
+  the window; pool-wide worst case is budget × machines) — accepted and
+  stated, with P17's delivery-layer bounds as the backstop.
+- Everything coalesced or over-budget is individually recorded in the quiet
+  store — a budget never loses an item, it only bounds pushes.
+
+This closes the foundation gap §8.1 names (#1417's unbounded per-source hub
+message stream) and keeps an opted-in category or a storming significant
+emitter from becoming flood round five: opting in entitles the category to
+push, never to push UNBOUNDED. The budgets are code defaults (tunable down,
+never off, via config — same posture as the P17 budgets); the D-10 burst
+test gains an opted-in arm asserting the bounded push count.
 
 ### 5.4 Composition with Self-Heal Before Notify (P22)
 
@@ -845,8 +945,14 @@ mid-build stop.
 - **FD-7 — Multi-machine opt-in is UNIFIED via the sole-writer durable
   fan-out:** a toggle applies to every machine — online peers immediately,
   offline peers via a durably queued write replayed on their return (the
-  WS4.1 durable-ack precedent); per-machine application state is shown on the
-  status route, and divergence persisting >24h raises ONE deduped attention
+  WS4.1 durable-ack precedent, INCLUDING its load-bearing half:
+  **apply-time revalidation**). Every write carries a per-key monotonic
+  version stamped by the sole-writer; a queued replay applies ONLY-IF-NEWER,
+  so a stale queued opt-in can never resurrect a since-reverted choice. The
+  queue is bounded (per-peer cap; entries expire after 7 days — a
+  permanently-dark peer cannot accumulate forever). Per-machine application
+  state is shown on the status route; the LEASE-HOLDER runs the divergence
+  comparison, and divergence persisting >24h raises ONE deduped attention
   item (loud, not a silent footnote). Durable REPLICATION of the whole
   preferences block remains tracked <!-- tracked: 11960 -->.
 - **FD-8 — Rollout keeps a lever until the cleanup increment** (see DEV-1):
@@ -889,9 +995,17 @@ mid-build stop.
   operator decision** because The Agent Carries the Loop (ratified 2026-06-14,
   one day AFTER the June-13 conversation) expects a genuinely-stuck
   agent-owned obligation to surface ONCE. Under this spec that surfacing is:
-  the quiet store + unread badge + §4.3 lifeline aging + digest — not a
-  Telegram push — unless the operator opts `commitment-deadletter` in. The
-  ELI16 puts this collision in front of the operator explicitly (DEV-6).
+  the quiet store + unread badge + §4.3 lifeline aging (+ the digest ONLY if
+  the operator has enabled it — it defaults OFF, so the honest default path
+  is the dashboard badge + boot-context aging) — not a Telegram push — unless
+  the operator opts `commitment-deadletter` in. The ELI16 puts this collision
+  in front of the operator explicitly (DEV-6).
+- **FD-15 — The push budgets ship as printed (§5.2):** 3 per category per 10
+  minutes + a separate significant lane per (category, class) + a global
+  ceiling of 10 per 10 minutes, overflow always coalescing to one pinned
+  summary. Tunable down via config, never off. These cap what an opted-in
+  operator actually receives, so approval binds them like FD-13 binds the
+  table.
 
 ## Deviations from / extensions to the June-13 design (flagged honestly)
 
@@ -981,17 +1095,24 @@ mid-build stop.
 - **Unit:** classification matrix (every origin × category × opt-in ×
   significant combination; both sides of every boundary); envelope-absent →
   quiet; class-mislabel ignored + audited; category stamped by a module not
-  in `emitterModules` → recorded + audited; §5.2 budget both sides (under →
-  push, over → one coalesced summary + records); fail directions (§2.4 —
-  gate-throw on reply delivers, on automated records; dryRun never writes the
-  quiet store); relay fallback (envelope-less relayed reply delivers via
-  kindMetadata; envelope-less relayed automated records); §6 ladder incl.
-  loss counter, single deduped notice, breaker after 3 episodes, and the
-  recursion pin ("the §6 notice can never classify `record`"); recency-map
-  cold behavior per category (§2.5); coalescing math (storm → O(1) rows);
-  event-sourced acks; registry completeness lint (unique ids, valid
-  dispositions, legacyGates resolve AND default false, emitterModules
-  non-empty).
+  in `emitterModules` → recorded + audited; §5.2 budgets both sides per lane
+  (routine under → push, over → one pinned coalesced summary that does NOT
+  consume budget; significant lane isolated from routine storms; global
+  ceiling folds to one cross-category summary); the pre-decided envelope is
+  single-use (a captured instance cannot replay past the budget); fail
+  directions (§2.4 — gate-throw on reply delivers, on automated records;
+  dryRun never writes the quiet store); relay handling (envelope-less
+  relayed reply delivers via kindMetadata; envelope-less relayed automated
+  records; a relayed pre-decided claim is classified FRESH by the holder);
+  §6 ladder incl. loss counter, single deduped notice, breaker after 3
+  episodes, and the recursion pin ("the §6 notice can never classify
+  `record`"); recency-map cold behavior per category (§2.5) + LRU bounds;
+  coalescing mechanics (storm → ≤1 flushed row per key per window;
+  crash-tail marked `coalescedApprox`); torn-final-line skip at boot;
+  event-sourced acks; the opt-in write refusals (missing/unresolvable
+  `confirmingMessageId` → 400; unregistered id → 400); registry completeness
+  lint (unique ids, valid dispositions, legacyGates resolve AND default
+  false, emitterModules non-empty).
 - **Integration (the D-10 burst invariant, extended):** with enforcement on +
   shipped defaults, fire 1,000 automated emissions through the REAL pipeline
   (mixed categories, unique source labels, unstamped raw `sendToTopic` calls,
@@ -1027,8 +1148,12 @@ mid-build stop.
   `PostUpdateMigrator.migrateConfig` (existence-checked, idempotent).
 - **Increment-D legacy-lever snapshot:** a one-time migration copies each
   default-TRUE legacy lever's CURRENT per-agent value into
-  `push.categories.<id>` (§3.5) — operators' effective choices survive; the
-  fleet default still flips to quiet.
+  `push.categories.<id>` (§3.5) — operators' effective choices survive
+  (intentional grandfathering, named in the ELI16); the fleet default still
+  flips to quiet. **Idempotency pinned:** the snapshot writes a key ONLY IF
+  ABSENT (an operator's Increment-B/C sole-writer choice always beats the
+  legacy lever value) and records a one-time durable migration marker (the
+  `_instar_migrations` precedent), so re-runs are no-ops.
 - CLAUDE.md template (`generateClaudeMd`) gains a "Quiet by Default
   notifications" awareness block (the pull surface, the opt-in trigger
   phrases, the status route) + `migrateClaudeMd` content-sniffed patch.
@@ -1115,7 +1240,7 @@ anchor, not the final tracking grain.
 
 ## Open questions
 
-None — all resolved into Frontloaded Decisions above (FD-1 … FD-14), each
+None — all resolved into Frontloaded Decisions above (FD-1 … FD-15), each
 restated in plain English in the ELI16 companion for the operator to confirm
 or override at approval time. The items that genuinely bend or postdate a
 June-13 decision are flagged as DEV-1 (rollout lever vs "no break-glass"),
@@ -1129,4 +1254,5 @@ reply corroboration).
 | 2026-06-13 | Design converged (3 rounds, 6 internal angles + GPT-5.5 + Gemini external passes) and operator-approved 13:59 PDT (topic 11960, "Approved"). |
 | 2026-06-13 | Build session `Topic spam` reaped at max runtime (~16:02 PDT); worktree + converged spec artifact lost. Only the conversation survived. |
 | 2026-07-09/10 | Operator returns to topic 11960 (fresh spam screenshot); urgent slice ships as PR #1417 (single-alerts-topic routing). Operator reaffirms the selectivity direction verbatim. |
-| 2026-07-10 | This reconstruction authored against main v1.3.802 and committed to a branch at authoring time (the artifact-loss lesson applied); round-1 convergence findings folded (9 reviewers). Awaiting fresh convergence + fresh operator approval. |
+| 2026-07-10 | This reconstruction authored against main v1.3.802 and committed to a branch at authoring time (the artifact-loss lesson applied); round-1 convergence findings folded (9 reviewers). |
+| 2026-07-10 | Round-2 findings folded (8 reviewers + conformance gate): corrected raw-send census incl. `TelegramAdapter.send()`, deterministic opt-in confirmation citation, relay carrier + fresh holder classification, pinned coalesce/durability mechanics, split significant/routine push lanes + global ceiling, FD-7 apply-time revalidation, FD-15. Awaiting round-3 confirmation + fresh operator approval. |

--- a/docs/specs/notification-selectivity.md
+++ b/docs/specs/notification-selectivity.md
@@ -1,0 +1,1132 @@
+---
+title: "Notification Selectivity — Quiet by Default: logs-first automated messaging with category-level push opt-in"
+slug: "notification-selectivity"
+status: "draft — reconstructed (needs fresh operator approval)"
+tier: 2
+created: "2026-07-10"
+author: "echo"
+parent-principle: "Near-Silent Notifications"
+eli16-overview: "docs/specs/notification-selectivity.eli16.md"
+provenance:
+  - "Design approved by operator 2026-06-13 13:59 PDT (topic 11960, verbatim: 'Approved') after three review rounds — recorded here as DESIGN provenance only. The converged spec artifact was LOST: the build session was reaped at max runtime the same day and the spec file died with its worktree; only the design conversation survives."
+  - "Reconstructed 2026-07-10 against canonical main (v1.3.802) after operator reaffirmation (topic 11960, 2026-07-10, verbatim): 'we need to be VERY selective about what gets actually sent to the user (most should be internal logs)'."
+  - "This reconstructed artifact requires FRESH operator sign-off — the June-13 'Approved' binds the design direction, not this document. No approved tag is carried."
+extends:
+  - "docs/specs/attention-single-topic-routing.eli16.md (PR #1417 — the urgent slice that already shipped)"
+  - "docs/specs/notification-ux-coherence.md (the Agent Health lane)"
+  - "docs/specs/attention-topic-flood-guard.md (P17 machinery)"
+  - "docs/specs/notification-emission-gate-brief.md (the #73 emission-authority brief — see Prior Art §PA-9)"
+  - "docs/specs/mature-update-announcements.md (silent-by-default update announcements)"
+lessons-engaged:
+  - "Near-Silent Notifications — this spec IS that standard's enforcement machinery: push only action-required/usable-result; routine goes to a pull surface (parent principle)"
+  - "Structure beats Willpower — the default flips from 'each feature remembers to be quiet' to 'the delivery funnel is quiet unless provenance proves otherwise' (grandparent principle; the June-13 root-cause admission)"
+  - "Conservative Outbound: Act, Don't Notify — the still-unratified disposition standard; this spec builds the enforcement it names (engaged, §PA-8, §D-1)"
+  - "Bounded Notification Surface (P17) — volume bounds unchanged and still load-bearing beneath this gate; the #1417 per-source hub MESSAGE stream gap is surfaced and closed here (engaged, §5.2, §8.1)"
+  - "Notices Route to the Alerts Topic, Never a New One (P23) — every push this gate permits lands in the hub or an existing conversation; never a new topic (engaged, §5, §8)"
+  - "Self-Heal Before Notify (P22) — heal-exhausted escalations land on the attention queue; this gate governs whether that queue PUSHES; §6 carries its own Standard-B declaration (engaged, §5.4, §6)"
+  - "The Agent Carries the Loop — ratified 2026-06-14, ONE DAY AFTER the June-13 design; the temporal collision on decision-request notices is named for fresh operator sign-off (engaged, §DEV-6, FD-14)"
+  - "Distrust Temporary Success — the four-flood recurrence class is closed at the disposition layer, and the opt-in door is bounded so it cannot become flood round five (engaged, §5.2)"
+  - "No Unbounded Loops (P19) — the failure ladder, the push budgets, and the store coalescing all carry declared brakes (engaged, §5.2, §6)"
+  - "Intelligence Infers, Keywords Only Guard — the gate never text-matches; it keys on structural provenance only (engaged, §2)"
+  - "Signal vs. Authority — the gate holds routing authority because its key is structural provenance (the P17 origin-typed ceiling precedent), never brittle content interpretation; content authority stays with the tone gate (engaged, §8)"
+  - "The Operator Channel Is Sacred — inbound-scoped; its outbound corollary honored here: a VERIFIED reply fails toward delivery on any gate malfunction, including the relay-skew path (engaged, §2.4, §6)"
+  - "The Agent Is Always Reachable — corollary-2 resource-rejection notices are conversation-serving floors this gate must never eat (engaged, §3.2)"
+  - "A Refusal Stays a Refusal / silent-loss conservation — quiet-routing is recorded routing, never loss; store failure is counted + surfaced, never silent (engaged, §6)"
+  - "Truthful Provenance — Speak Only as Yourself — session-context surfacing of quiet items speaks as infrastructure, inside an untrusted-data envelope, never as the user (engaged, §4.3)"
+  - "Observable Intelligence / Observability — every gate decision writes a ledger row; dryRun counterfactuals are measurable before enforcement (engaged, §7)"
+  - "Migration Parity — config defaults via ConfigDefaults + PostUpdateMigrator; legacy default-true levers snapshot-migrated; CLAUDE.md template awareness block (engaged, §Migration)"
+  - "Testing Integrity — all three tiers + the zero-stray burst invariant + the opted-in bounded-push arm (engaged, §9)"
+  - "Maturation Path — ships enabled-in-dryRun on development agents, dark on the fleet (engaged, §Rollout)"
+  - "Mobile-Complete Operator Actions — category opt-in is conversational + a dashboard toggle through ONE sole-writer surface; never a hand-built curl (engaged, §4.4)"
+  - "Close the Loop — the opt-in digest + unread-aging counters + agent-facing re-surfacing + tracked deferrals keep quiet items from rotting unseen (engaged, §4.3, §4.5)"
+  - "Cross-Machine Coherence — every new surface declares its posture; the opt-in surface is unified via a durable sole-writer fan-out (engaged, §Multi-machine)"
+---
+
+# Notification Selectivity — Quiet by Default
+
+Small glossary for readers outside the project lexicon: **P17** = Bounded
+Notification Surface (topic/volume budgets); **P22** = Self-Heal Before Notify;
+**P23** = single-alerts-topic routing; **ELI16** = the plain-English companion
+document; **the hub** = the "🔔 Attention" Telegram topic created by PR #1417.
+
+## Problem statement
+
+Four topic-spam floods (2026-05-22 sentinels, 2026-05-28 collaboration-redrive,
+2026-06-05 worktree detector, 2026-06-13 stranded-work detector) each shipped a
+patch, and each patch bounded VOLUME or ROUTING — never the DISPOSITION. The
+operator's June-13 directive flipped the polarity ("We should have an extremely
+high requirement before sending ANY automated messages to the user … By default
+these should be logs only"), the design converged and was approved the same day
+— and then the build session was reaped at max runtime and the converged spec
+was lost with its worktree. On 2026-07-10 the operator reaffirmed: "we need to
+be VERY selective about what gets actually sent to the user (most should be
+internal logs)."
+
+Since June 13, real slices shipped (see Prior Art). The residual gap this spec
+owns, verified against main v1.3.802:
+
+1. **Every attention item still PUSHES a Telegram message.** In the #1417
+   default (`attentionRouting.mode: 'single-topic'`),
+   `TelegramAdapter.createAttentionItem` (src/messaging/TelegramAdapter.ts:3840)
+   → `routeToAttentionHub` (:4224) posts each item into the "🔔 Attention" hub
+   **immediately** via `sendToTopic`. One topic now — but still one push per
+   event, with no logs-only default and no opt-in. Worse (foundation gap this
+   spec surfaces, §8.1): in single-topic mode the hub branch returns BEFORE
+   `AttentionTopicGuard` runs (:3877–3884), and `topicCreationBudget` bounds
+   topic CREATION only — so the per-source hub MESSAGE stream is unbounded
+   today.
+2. **No category-level logs-vs-push surface exists.** Individual features carry
+   scattered booleans (`monitoring.sentinelTelegramEscalation`,
+   `monitoring.reapNotify.enabled`, growth-digest delivery mode…), but there is
+   no registry of automated-message categories, no uniform default, and no
+   single place the operator opts a category into push.
+3. **No dashboard pull surface for suppressed/quiet items.**
+   `state/attention-suppressed.jsonl` (written by
+   `writeSuppressedAttentionLog`, TelegramAdapter.ts:4116) has no HTTP route
+   and no dashboard tab; there is no unread count, no "what did the agent keep
+   quiet?" view.
+4. **No last-hop automated-vs-reply classification.** The one funnel every
+   send passes — `TelegramAdapter.sendToTopic` (TelegramAdapter.ts:1300) — is
+   origin-blind. Provenance exists only in fragments that never combine into a
+   delivery decision: `messageKind` (tone/advisory), `origin` (topic creation
+   only), `lane` (attention), `recipientClass` (tone gate). The tone gate
+   (`checkOutboundMessage`, src/server/routes.ts:2252) is route-scoped and
+   bypassed by every in-process automated caller. And `messageKind` DEFAULTS
+   to `'reply'` when stamps are absent — the exact "disguise an automated
+   message as a reply" hole the June-13 review round 2 found, still open.
+
+## Design decisions carried from the June-13 conversation (binding)
+
+These are the operator's decisions, quoted from topic 11960, and this spec
+implements them without re-litigating:
+
+- **D-1 — Logs-only default, extremely high push bar.** "We should have an
+  extremely high requirement before sending ANY automated messages to the
+  user, unless the user requests to hear specific notifications. By default
+  these should be logs only" (2026-06-13 11:30 PDT). Default for everything
+  agent-generated that is not a reply to the user: internal logs + pull
+  surface. Push is opt-in per category.
+- **D-2 — Pull + opt-in, even for "I'm stuck."** "Even an 'I'm stuck, I need
+  your call' goes to the logs until you choose to turn it on. You'd pull from
+  the dashboard and opt into whatever you want pushed" (Echo's reflection,
+  confirmed by the operator's 11:57 PDT reply that dissolved the emergency
+  allowlist). See DEV-6/FD-14 for the collision with a standard ratified one
+  day later.
+- **D-3 — Sentinels/infra keep their real cases; this governs fall-through.**
+  "We have built in infra/sentinels to handle these cases. What we're managing
+  here are all the cases that fall through the cracks" (11:57 PDT). Recovery
+  machinery is untouched; this spec governs what leaks to the USER.
+- **D-4 — Quiet items log AND route to the relevant session/project.** "They
+  should create logs and notify any relevant sessions/projects/etc, such that
+  the issues can organically arise within those paths" (11:57 PDT).
+- **D-5 — Significant → the ONE Alerts topic, never per-item surfaces.** "If
+  something does come up that is very significant than there should be a
+  single 'Alerts' topic that it can be posted in" (11:57 PDT). Today that
+  topic exists: the #1417 "🔔 Attention" hub.
+- **D-6 — The significance bar lives in source, never config.** From review
+  round 2: the significant list "is hardcoded in source and reviewed at PR
+  time — code can't add to it" (and by extension, config can't either).
+- **D-7 — The gate is the LAST HOP and treats anything not a verified
+  reply-to-the-user as automated.** From review round 2: closes the "disguise
+  an automated message as a normal reply" hole.
+- **D-8 — Conversational replies are unaffected.** "Your normal back-and-forth
+  with me is untouched" — reflected and approved.
+- **D-9 — No standing break-glass.** "Lets remove it" (11:30 PDT) — the old
+  always-push behavior does not survive as a legacy mode in the end state.
+  (See §Rollout and Deviation DEV-1 for how this composes with a staged
+  rollout.)
+- **D-10 — Zero-stray CI enforcement.** "The build now fails if 1,000
+  automated signals produce even one stray message" (approved 13:59 PDT
+  one-screen summary). Zero, not "a few."
+- **D-11 — Opt-in Close-the-Loop digest.** From review round 2: "an OPT-IN
+  daily digest so a genuinely important thing can't rot silently in the logs
+  unseen."
+
+## Prior art / already shipped — and this spec's residual scope
+
+Everything below shipped after June 13 and overlaps materially. This spec
+composes with each; it re-implements none.
+
+- **PA-1 — #1417 single-alerts-topic routing (v1.3.800).**
+  `attentionRouting.mode: 'single-topic'` default: every attention item posts
+  into the ONE hub topic; per-item topics dead by default. **This spec keeps
+  the hub as the sole push destination and changes WHETHER an item pushes at
+  all** (quiet by default; significant or opted-in pushes) — and closes the
+  per-source hub message-stream gap #1417 left open (§5.2, §8.1).
+- **PA-2 — Bounded Notification Surface (P17).** `topicCreationBudget` inside
+  `createForumTopic` (TelegramAdapter.ts:1450, `origin`-typed, auto-by-default),
+  `AttentionTopicGuard`, the burst-invariant test, the funnel lint. Unchanged;
+  still the volume backstop beneath this gate.
+- **PA-3 — Outbound advisory layer.** `src/messaging/OutboundAdvisory.ts` +
+  `POST /messaging/preflight` (routes.ts:12286): deterministic jargon/path/
+  link/TIME_CLAIM checks on scheduler-stamped automated sends. Unchanged —
+  it governs the CONTENT HONESTY of automated sends that will push; this spec
+  governs whether they push. Its env-stamp trio (`INSTAR_MESSAGE_KIND`,
+  `INSTAR_JOB_SLUG`, `INSTAR_SENDER_CLASS`; SessionManager.ts:2544/2835,
+  JobScheduler.ts:981) is a load-bearing provenance input to §2.
+- **PA-4 — The tone gate.** `MessagingToneGate` via `evaluateOutbound`
+  (routes.ts:1855) / `checkOutboundMessage` (:2252): content/behavioral
+  authority over route-delivered conversational sends. Unchanged; disjoint
+  authority (see §8).
+- **PA-5 — Maturity-tagged silent-by-default update announcements.** The
+  post-update notifier already implements per-change `audience: user` opt-in.
+  Unchanged; registered as its own category with its existing gating honored
+  (§3.4).
+- **PA-6 — Agent Health lane.** `lane: 'agent-health'` items route to the
+  calm "🩺 Agent Health" topic (notification-ux-coherence.md). Under this
+  spec the lane becomes a quiet-by-default category like any other (§3.3) —
+  its separate DESTINATION survives for opted-in pushes.
+- **PA-7 — Duplicate suppression + topic-flood guard + budget.** Unchanged,
+  downstream backstops.
+- **PA-8 — "Conservative Outbound: Act, Don't Notify" (registry PROPOSAL,
+  2026-07-04, unratified).** Names the disposition this spec enforces. This
+  spec is its enforcement machinery for the delivery layer; approving this
+  spec is a strong signal the proposal should be ratified, but ratification
+  remains the operator's separate constitutional act.
+- **PA-9 — notification-emission-gate-brief.md (instar-codey, #73 lane).** A
+  draft brief for an emission-authority gate over low-confidence STATUS
+  claims (PresenceProxy "actively working", drop notices). Complementary,
+  narrower concern (signal CONFIDENCE), same principle (signals don't get
+  direct user-facing authority). This spec's category registry reserves the
+  brief's sources; if that brief converges later it plugs in as category
+  dispositions + confidence inputs, not a second gate at a second chokepoint.
+- **PA-10 — SentinelNotifier.** `src/monitoring/SentinelNotifier.ts` — the
+  proven "default log-only, opt-in consolidated push" template
+  (`monitoring.sentinelTelegramEscalation`, default false,
+  ConfigDefaults.ts:714). This spec generalizes exactly that shape to every
+  automated category, and §3.5 defines how such existing per-feature levers
+  map into the registry without double-gating — including the levers that
+  default TRUE (e.g. `monitoring.reapNotify.enabled`, ConfigDefaults.ts:327),
+  which are snapshot-migrated, not laundered (§3.5).
+
+## §1 — The Notification Category Registry (code-defined)
+
+A single source-code registry (`src/messaging/notificationCategories.ts`)
+declaring every automated-message category. **Code-defined and PR-reviewed;
+config can never add, remove, or re-class a category (D-6).**
+
+Each entry:
+
+```ts
+interface NotificationCategory {
+  id: string;                       // e.g. 'reap-notice'
+  description: string;              // plain English, shown on the dashboard
+  disposition: 'quiet'              // DEFAULT: store + logs + pull surface
+             | 'conversation-serving'; // push into the live conversation (§3.2)
+  emitterModules: string[];         // the source modules allowed to emit this
+                                    // category — enforced by the §9 lint
+                                    // (callsite→category fit, not just presence)
+  significantClasses?: SignificantClass[]; // classes THIS category may raise (§5)
+  legacyGate?: string;              // dotted config key of an existing per-feature
+                                    // delivery lever this category honors (§3.5);
+                                    // MUST default false (lint-enforced) — a
+                                    // default-true lever is migrated, never OR'd
+  defaultDestination: 'hub' | 'conversation' | 'agent-health';
+}
+```
+
+v1 categories (grounded in real emitters; the registry ships with a
+completeness lint — see §9). **FD-13 binds this table: operator approval of
+this spec approves the table as printed.**
+
+| id | disposition | notes |
+|----|-------------|-------|
+| `attention-item` | quiet | all `createAttentionItem` emissions not otherwise laned |
+| `agent-health` | quiet | the PA-6 lane; opted-in pushes keep the 🩺 topic |
+| `job-status` | quiet | JobScheduler summaries/alerts (JobScheduler.ts:1539+) |
+| `sentinel-escalation` | quiet | legacyGate: `monitoring.sentinelTelegramEscalation` (defaults false — OR-safe) |
+| `reap-notice` | quiet | lever `monitoring.reapNotify.enabled` defaults TRUE → snapshot-migrated at Increment D, never OR'd (§3.5) |
+| `resume-queue-notice` | quiet | revival/paused notices |
+| `commitment-deadletter` | quiet | PromiseBeacon dead-letters + agent-carried-loop surfacing — FD-14: disposition is an explicit operator decision at approval |
+| `spend-alert` | quiet | SpendAlertResolver / burn alerts |
+| `mesh-alert` | quiet | rope-health, machine-coherence; legacyGate where present + default-false |
+| `tunnel-notice` | quiet | TunnelManager.ts:448 |
+| `advisory-escalation` | quiet | OutboundAdvisory repeated-ignore raiser |
+| `autonomous-heartbeat` | quiet | the liveness line (its local brakes remain) |
+| `update-announcement` | quiet | legacyGate: the PA-5 audience/maturity gating |
+| `selectivity-digest` | quiet | §4.5's own digest (push requires digest opt-in) |
+| `presence-standby` | conversation-serving | 🔭 receipts answer a live unanswered inbound |
+| `cold-start-fallback` | conversation-serving | Always-Reachable corollary-2 notices |
+| `message-loss-notice` | conversation-serving | inbound-queue loss / sender-rejection notices |
+| `command-response` | conversation-serving | replies to user-typed hub/topic commands (TelegramAdapter internal handlers) |
+| `uncategorized` | quiet | ANY unstamped/unregistered automated send (§2.3) |
+
+The registry is deliberately small and coarse in v1 (FD-4): categories map to
+emitter FAMILIES, not individual features. A new feature that never heard of
+the registry emits `uncategorized` → quiet. **Silence is what you get for
+free; push is what you must justify in a PR** — the June-13 inversion.
+
+## §2 — The last-hop selectivity gate
+
+`NotificationSelectivityGate` — a deterministic, synchronous, LLM-free
+classifier invoked inside the two delivery chokepoints:
+
+- `TelegramAdapter.sendToTopic` (TelegramAdapter.ts:1300) — the funnel every
+  send passes;
+- `TelegramAdapter.createAttentionItem` (:3840) — upstream of
+  `routeToAttentionHub`, so a quiet attention item is stored WITHOUT the hub
+  send (the store write is unconditional, exactly as today).
+
+**Single evaluation (no self-double-gating):** `routeToAttentionHub` delivers
+via `sendToTopic`, so both chokepoints would otherwise classify one send
+twice. A verdict rendered at `createAttentionItem` rides an internal
+PRE-DECIDED envelope — an unforgeable in-process object (module-private class
+instance, not a string field, so no caller can spoof it as a category) — and
+the funnel honors it without re-classification. The same pass-through carries
+the §6 failure notice and §5 significant pushes.
+
+### 2.1 The provenance envelope
+
+A new optional `envelope` on `sendToTopic`'s options (alongside the existing
+`kindMetadata`), stamped at ORIGINATION chokepoints — never caller-supplied
+free text:
+
+```ts
+interface OutboundEnvelope {
+  origin: 'verified-reply' | 'automated';
+  category: string;                  // registry id; absent → 'uncategorized'
+  significantClass?: SignificantClass; // honored only per the §5 code table
+  inboundMessageId?: string;         // conversation-serving corroboration (§3.2)
+  sourceContext: string;             // for dedup/audit, mirrors attention items
+  relayedOrigin?: boolean;           // true when the envelope crossed the mesh (§2.4)
+}
+```
+
+Stamping points (each is an existing chokepoint, not new surface):
+
+- **The reply route** (`POST /telegram/reply/:topicId`, routes.ts:12379)
+  stamps `verified-reply` ONLY when the §2.2 verification passes; otherwise
+  `automated` with the category derived from the scheduler stamps.
+- **The scheduler env-stamp trio** (PA-3) already positively marks job
+  sessions; the reply route maps `INSTAR_MESSAGE_KIND=automated` +
+  `INSTAR_JOB_SLUG` → `automated`/`job-status` (or the job's declared
+  category).
+- **In-process emitters** (sentinels, schedulers, attention, tunnel, mesh…)
+  stamp their registry category at their existing send callsites. The sweep
+  of ~40 `sendToTopic` callsites is enumerated in the build plan; the §9
+  funnel lint enforces BOTH envelope presence AND callsite→category fit
+  (an emitter module may only stamp categories whose registry entry names it
+  in `emitterModules`).
+- **TelegramAdapter internal command handlers** (the ~40 sites at
+  TelegramAdapter.ts:921–3225 responding to user-typed commands) stamp
+  `command-response` (conversation-serving — a user typed the command), each
+  carrying the triggering command message id as `inboundMessageId`.
+- **Raw `apiCall('sendMessage')` bypass closure:** seven callsites today
+  bypass `sendToTopic` entirely (TelegramAdapter.ts:741, 1613, 2399, 3961,
+  4098, 4204, 5115). The build enumerates all seven and either routes each
+  through the funnel or marks it with an in-code justification comment the
+  lint recognizes (e.g. the hub-post internals already carrying a pre-decided
+  envelope); the §9 lint FORBIDS new raw `sendMessage` callsites. Without
+  this, the gate repeats the historical "guard at the wrong layer" dodge.
+
+### 2.2 Verified-reply classification (D-7 — closing the disguise hole)
+
+Today `messageKind` DEFAULTS to `'reply'` when stamps are absent — automated
+by omission is treated as conversational. **This spec inverts the default at
+the delivery layer.** A send is `verified-reply` iff ALL of:
+
+1. It arrived via `POST /telegram/reply/:topicId` (or an equivalent
+   adapter-external reply route);
+2. It carries NO automation stamp (`INSTAR_MESSAGE_KIND` unset or `reply`,
+   `INSTAR_SENDER_CLASS` not `script`/`llm-session`-with-job);
+3. The route's existing session-resolution breadcrumbs
+   (`resolveTopicSession`, routes.ts:12461–12503 — today log-only:
+   "kindless send mapping to job session", "class-spoof") corroborate: a send
+   whose resolved topic session is a JOB session claiming replyhood is
+   **demoted to `automated`** — the breadcrumbs are promoted from
+   observability to classification input.
+4. *(Advisory in v1, with a CONCRETE promotion path — FD-9)* the topic has a
+   recorded recent inbound user turn (§2.5's recency map). In v1 this is
+   logged as the named ledger metric `replyWithoutRecentInbound`, NOT a
+   demotion condition (a legitimate hours-late reply must never be eaten).
+   **Promotion exit criteria (FD-9):** after Increment C has run ≥14 days
+   with ≥200 reply-path sends observed AND `replyWithoutRecentInbound`
+   incidents individually audited to zero false positives, a follow-up PR may
+   promote the check to demotion authority. Until then, the honest residual
+   is stated: an unstamped in-repo caller POSTing to the reply route on an
+   interactive topic classifies as a reply. To shrink that residual
+   structurally, the §9 lint ALSO covers in-repo HTTP calls to
+   `/telegram/reply` (the callsite pattern is lintable), so a feature cannot
+   quietly adopt the route as a push path.
+
+Anything that fails 1–3 is `automated`. An automated send cannot BECOME a
+reply by claiming it: there is no caller-settable "I am a reply" field — the
+stamp is minted inside the route handler, in-process, after the checks.
+
+**Honest scope:** this closes the accidental/default hole (unstamped =
+automated at the funnel), the job-session disguise, and — via the reply-route
+lint — the lazy in-repo route adoption. A deliberately adversarial in-repo
+feature is governed by PR review + the lints, not runtime — same trust model
+as every other in-process funnel (safe-git, safe-fs, the P17 ceiling).
+
+### 2.3 The decision function
+
+```
+decide(envelope, topicId) →
+  'deliver'        // verified-reply, or conversation-serving with live-
+                   // exchange corroboration (§3.2)
+| 'deliver-push'   // automated + (significant per §5, or category opted-in
+                   // per §4, or legacyGate enabled per §3.5), WITHIN the
+                   // §5.2 per-category push budget → hub (or the category's
+                   // declared destination)
+| 'record'         // automated, no push entitlement (or budget-exceeded
+                   // overflow, which coalesces per §5.2) → quiet store +
+                   // ledger + logs + §4.3 session routing. NEVER delivered.
+```
+
+Deterministic, synchronous, no blocking I/O: config via `liveConfig.get`
+(mtime-cached in-memory), the static registry, and the §2.5 in-memory recency
+map. No LLM. No text inspection of any kind. No disk reads on the send path.
+
+**Return contract (callers must not mis-read `record` as delivery):**
+`sendToTopic` returns a discriminated result — `{delivered: true, messageId}`
+vs `{delivered: false, recorded: true, quietId}` — and the build sweeps
+callers that branch on a Telegram message id (delivery-retry, dedup
+reservation, relay ACK paths) to handle `recorded` explicitly. A recorded
+send is SUCCESS for the emitter (the notice reached its governed surface);
+it must not trigger delivery retries, and it must not mark "user was
+notified" state anywhere. §9 requires tests per caller class.
+
+### 2.4 Fail directions (explicit, per class)
+
+- `verified-reply` + gate exception/malfunction → **deliver** (the
+  conversational surface fails toward delivery — the outbound corollary of
+  The Operator Channel Is Sacred; an eaten reply is the worst failure this
+  design can produce).
+- `automated` + gate exception → **record**; if recording itself fails → §6.
+- `dryRun: true` → **always deliver**; the ledger records the counterfactual
+  verdict (`wouldRecord: true`). **The quiet store is NOT written during
+  dryRun** — a delivered message must never also sit as an unread quiet item
+  (phantom badges); counterfactual measurement lives in the ledger + the
+  status-route counters only.
+- **Relayed sends** (tokenless standby → lease holder,
+  TelegramAdapter.ts:1332–1343): the envelope rides the relay exactly like
+  the existing `kindMetadata`, and the DELIVERING machine (the holder — it
+  owns the config and the quiet store) classifies. Two hard rules:
+  - **Trust model, stated:** peer machines are the SAME agent,
+    mesh-authenticated; a relayed `origin` is nonetheless a peer-asserted
+    field arriving over HTTP, so the holder RE-APPLIES the §2.2.3 breadcrumb
+    demotion against its own topic/session state and stamps
+    `relayedOrigin: true` on the ledger row — forged-origin incidence is
+    measurable during dryRun, and the local "no HTTP caller can assert
+    verified-reply" guarantee is honestly scoped to non-mesh callers.
+  - **Version-skew direction (an envelope-less relayed send):** an OLD-version
+    standby relays without an envelope. Classifying that `uncategorized` →
+    `record` would EAT a conversational reply — the unsafe direction. So an
+    envelope-less relayed send falls back to the already-riding
+    `kindMetadata.messageKind` (`reply` → deliver; `automated`/absent →
+    record), for a bounded skew window (enforcement on relayed sends
+    additionally gates on the peer's protocol version). Honesty note for the
+    inverse skew: a NEW-version sender relaying to a LEGACY holder degrades
+    toward push (the legacy holder has no gate) — harmless while the fleet is
+    dark/dryRun, gone once Increment D lands, and stated here so nobody
+    mistakes it for a guarantee.
+
+### 2.5 The inbound recency map (no hot-path disk I/O)
+
+`MessageStore` queries are disk-backed (readFileSync + directory scans) and
+must never run inside `sendToTopic`. The gate reads only an in-memory
+per-topic map maintained on the INBOUND path: for each topic, the last N=20
+inbound user message ids with timestamps (and the current unanswered-message
+id, which the reply route already tracks — `currentInboundByTopic`,
+routes.ts:12595). Rebuilt lazily after restart from the reply route's
+existing state; when the map is cold/unavailable, conversation-serving
+corroboration FAILS OPEN TO DELIVER for the floor categories
+(`cold-start-fallback`, `message-loss-notice` — their trigger IS an inbound)
+and fails CLOSED to record for `command-response`/`presence-standby` (their
+triggering id must be present), each outcome ledger-tagged `mapCold: true`.
+
+## §3 — Dispositions
+
+### 3.1 `quiet` (THE default — D-1, D-2)
+
+Store + ledger + log. No Telegram message. The item appears on the dashboard
+pull surface (§4) with an unread badge, and routes to the relevant session
+(§4.3). This includes "I'm stuck, I need your call" decision-request notices
+(D-2 verbatim; see FD-14 for the named operator confirmation of that
+disposition against The Agent Carries the Loop).
+
+### 3.2 `conversation-serving` (the floor that keeps conversations whole)
+
+Push into the live conversation topic — with structural corroboration of a
+live exchange, defined concretely:
+
+- The category is registry-declared conversation-serving AND the emitting
+  module is in its `emitterModules` (lint + runtime check).
+- The envelope carries `inboundMessageId` — the SPECIFIC inbound user message
+  this send serves — and the gate verifies it against the §2.5 recency map.
+  Per-category binding: `command-response` → the command message id,
+  single-use, ≤15-minute window; `presence-standby` → the currently
+  unanswered inbound id (multiple receipts may cite it while it remains
+  unanswered — the standby tiers already brake volume); `cold-start-fallback`
+  / `message-loss-notice` → the triggering inbound id, ≤15-minute window.
+- A conversation-serving send whose corroboration fails is demoted to
+  `record` + an audit row — EXCEPT the two Always-Reachable floor categories
+  under a cold map (§2.5), which fail toward delivery.
+
+These exist because the USER just acted; suppressing them would sever the
+exchange (Always Reachable corollary 2; sender-rejection and loss notices are
+constitutionally mandated). This is D-3's boundary drawn precisely: infra
+serving a live exchange keeps flowing; agent-initiated narration does not.
+An active topic is NOT a standing license: without the specific triggering
+`inboundMessageId`, a conversation-serving claim records.
+
+### 3.3 The Agent Health lane
+
+`agent-health` items become quiet-by-default (they are the canonical
+housekeeping class). When the category is opted in, pushes go to the 🩺 topic
+as today. The lane's separate destination survives; its default delivery does
+not.
+
+### 3.4 Update announcements
+
+PA-5's audience/maturity gating IS this category's legacyGate: an
+announcement that passes the existing `audience: user` promotion pushes; all
+else records. No second lever.
+
+### 3.5 Legacy per-feature levers (no double-gating, no laundering)
+
+Categories with an existing delivery flag declare it as `legacyGate`, under
+one hard rule the §9 lint enforces: **a `legacyGate` key must DEFAULT FALSE.**
+A default-false lever (e.g. `sentinelTelegramEscalation`) OR's with the new
+category opt-in as the push entitlement — one lever, behavior-preserving, the
+operator's existing choice honored. A DEFAULT-TRUE lever (e.g.
+`monitoring.reapNotify.enabled`, ConfigDefaults.ts:327) would launder
+push-by-default through the back door and hollow D-1; those are handled at
+Increment D by a one-time `migrateConfig` SNAPSHOT — each agent's current
+lever value is copied into `notifications.push.categories.<id>` (preserving
+the operator's effective choice on that machine), and the lever's DELIVERY
+role retires (its feature-behavior role, if any, is untouched). Increment D's
+"logs-only default everywhere" claim holds because the snapshot preserves
+choices, not defaults. Full consolidation (retiring the legacy keys
+entirely) remains tracked <!-- tracked: 11960 -->. The dashboard toggle is
+never dead: the §4.2 sole-writer route sets BOTH the category key and (when
+declared) the category's legacyGate key, so one toggle is one lever.
+
+## §4 — The pull surface + opt-in
+
+### 4.1 Config (top-level block, mirroring `outboundAdvisory` conventions)
+
+```jsonc
+"notifications": {
+  "selectivity": {
+    "enabled": false,          // omitted → resolveDevAgentGate (live on dev, dark fleet)
+    "dryRun": true,            // classify + ledger only; deliver everything
+    "push": {
+      "categories": {          // category id → push opt-in (D-1's "unless the
+        // "reap-notice": true // user requests to hear specific notifications")
+      }
+    },
+    "digest": { "enabled": false, "cadence": "daily" },   // §4.5, D-11
+    "quietStore": { "retentionDays": 30, "maxEntries": 20000 }
+  }
+}
+```
+
+Read via `liveConfig.get('notifications.selectivity...', default)` — hot-
+applied, no restart (the block is top-level; `messaging` is an array and
+unreachable for nested keys). Defaults registered in
+`src/config/ConfigDefaults.ts` (`getMigrationDefaults`), migrated by
+`PostUpdateMigrator.migrateConfig` (existence-checked, idempotent).
+
+**Config keys can only opt categories INTO push. No config key can widen the
+significant table (§5), reclass a category, or exempt a source from
+classification (D-6).** `push.categories` is written ONLY by the §4.2
+sole-writer route — never by generic `PATCH /config` (whose one-level-deep
+merge is a documented hazard for nested keys).
+
+### 4.2 The quiet store + routes
+
+- Attention items already persist in the attention store; a quiet-routed item
+  is marked `heldQuiet: true` and simply never generates the hub send. `GET
+  /attention` and the dashboard tab keep working unchanged.
+- Non-attention quiet sends land in a new `QuietNotificationStore`
+  (`state/quiet-notifications.jsonl`), with storm discipline learned from the
+  2026-07-09 EvolutionManager doom-loop and the 17.5k-requests day:
+  - **Coalescing:** a repeat within a rolling window keyed
+    (category, sourceContext) INCREMENTS a `count` on the open row (a new
+    appended coalesce row, event-sourced — never read-modify-write of the
+    file), so a storming source occupies O(1) rows per window, not 17,503 —
+    and cannot evict everyone else's history via the `maxEntries` prune.
+  - **Bounded by rotation:** prune enforces `retentionDays`/`maxEntries` by
+    file ROTATION (write a fresh segment, archive the old), never a full-file
+    rewrite on the write path.
+  - **In-memory index:** built at boot, maintained incrementally; `GET
+    /notifications/quiet` paging and unread counters NEVER scan the JSONL per
+    request.
+  - **Acks are appended rows** (event-sourced mark-read), resolved by the
+    index — no row rewrites, no rewrite races.
+- Routes:
+  - `GET /notifications/quiet` — paged feed (`?category=`, `?unread=`,
+    `?scope=pool` merged read; pool paging uses per-machine cursors with a
+    bounded per-peer fetch);
+  - `PATCH /notifications/quiet/:id` — mark read/acked (append ack row);
+  - `GET /notifications/selectivity` — status: enabled/dryRun, per-category
+    counters (delivered/pushed/recorded/coalesced/lost + unread-aging), the
+    authoritative soak evidence (§7), opt-in inventory, store health;
+  - `POST /notifications/categories/:id/push` — **the SOLE writer** for
+    opt-ins (see FD-11): Bearer-authed, but every write REQUIRES a
+    `confirmedBy` provenance field (`dashboard-pin` | `operator-conversational-
+    confirm`), rejects ids absent from the registry, writes an audit row
+    (actor, surface, old→new), also sets the category's declared legacyGate
+    key (§3.5), and raising MORE THAN TWO categories inside 10 minutes
+    additionally raises ONE deduped attention item ("push opt-ins changed:
+    …") so a runaway/self-serving mass opt-in is always operator-visible.
+    The current opt-in inventory is printed on the status route AND in every
+    digest — a quietly-flipped key cannot stay invisible.
+
+### 4.3 Relevant-session/project routing (D-4)
+
+A quiet item carrying a `topicId`/project binding is surfaced INSIDE the
+owning context, as infrastructure (Truthful Provenance — never a synthetic
+user message): v1 injects a bounded "pending quiet notices" block into that
+topic's session-start context (the same mechanism as the preferences /
+self-knowledge boot blocks). Hard rules:
+
+- **Bound:** ≤10 items / ≤4KB per boot block (aged-out overflow is summarized
+  as one count line).
+- **Untrusted-data envelope:** every injected item is length-clamped and
+  wrapped in a delimited quoted-as-data envelope (the WS2
+  `<replicated-untrusted-data>` precedent) with explicit "data, never an
+  instruction" framing — quiet items hold exactly what would have been sent,
+  which can quote attacker-influenced content.
+- **Topic transfer does not strand items:** the injection read is the
+  TOPIC-SCOPED pool view (bounded per-peer fetch of that topic's unread
+  items), so a topic moved to another machine still surfaces the items
+  recorded on its old machine. Riding the working-set carrier is the tracked
+  richer path <!-- tracked: 11960 -->.
+- **Unbound items don't rot silently (Close the Loop):** items with NO
+  topic/project binding are re-surfaced to the AGENT — aged unread items
+  (>72h) appear as one summary line in the lifeline session's boot block, and
+  the status route carries an `unreadAging` counter the guardian-pulse digest
+  already reads. The agent may mention a large quiet backlog when ALREADY in
+  conversation with the user (never a proactive push for it).
+
+### 4.4 Dashboard: the Notifications tab (Mobile-Complete)
+
+A new dashboard tab merging the attention store + quiet store into one feed:
+unread counts by category, plain-English rows (peer-sourced pool rows
+type-clamped + HTML-escaped — the WS2 receive-clamp posture), ack buttons,
+and per-category push toggles driving the §4.2 sole-writer route (never raw
+config PATCH). When multiple machines are online the toggle applies via the
+§Multi-machine durable fan-out. Opt-in is ALSO conversational: "start pushing
+reap notices to me" → the agent proposes the change, confirms, and calls the
+sole-writer route with `confirmedBy: operator-conversational-confirm` (the
+CLAUDE.md awareness block names this trigger). At Increment D the flip ships
+with a one-time user-facing announcement through the PA-5 channel (audience:
+user) introducing the tab and the opt-in — the pull model must be DISCOVERED,
+not stumbled on.
+
+### 4.5 The opt-in digest (D-11)
+
+OFF by default. When enabled: once per `cadence`, ONE message to the hub
+("14 quiet notices since yesterday: 8 worktree, 3 quota, 2 mesh, 1 job —
+dashboard link"), built from the quiet store's INDEX (no full-file scan),
+delivered as category `selectivity-digest` through the pre-decided envelope
+path. **Digest content is pinned to counts + category names + the dashboard
+link + the opt-in inventory + the unread-aging counter — never raw item
+titles/text** (no smuggling surface). Calm-empty periods send nothing
+(GrowthDigestPublisher's `sendOnCalmWeeks:false` precedent). A digest-build
+failure is logged + counted on the status route; it never retries more than
+once per cadence tick (P19).
+
+## §5 — The significant lane (D-5, D-6)
+
+A small **code table** (`SIGNIFICANT_TABLE` in the registry module) maps
+(category, significantClass) → hub-push-without-opt-in:
+
+```ts
+type SignificantClass = 'security-incident' | 'data-loss' | 'agent-cannot-operate';
+```
+
+Class definitions with examples (FD-1; erosion-resistant by example, not
+vibes):
+
+- `security-incident` — evidence of compromise or credential exposure
+  (mandate-audit chain broken, forged mesh identity, secret found in a public
+  surface). NOT: a failed login, a blocked operation, a suspicious-but-handled
+  input.
+- `data-loss` — user data or agent state has been lost or is imminently being
+  lost (store corruption confirmed, quiet-store double failure §6, tombstone
+  divergence destroying records). NOT: a retryable write failure, a pruned-
+  by-policy record, a rotated log.
+- `agent-cannot-operate` — the agent as a whole cannot serve (no session can
+  spawn AND the lifeline floor is failing). NOT: one wedged session, one
+  rate-limited account, one dark peer — those have owners (sentinels, floors,
+  reconcilers) per D-3. This class is deliberately the narrowest; it is the
+  historical "urgent" escape-hatch shape, so its registry binding is expected
+  to name at most one or two emitter modules.
+
+Rules:
+
+- An emitter self-labeling `significantClass` outside its registry-declared
+  set is **ignored** (recorded quiet + an audit row naming the mislabel) —
+  crying wolf buys nothing; the June-13 round-1 trapdoor fix, applied to
+  classes. Because classes bind to (category, module) pairs and category
+  stamping itself is module-bound (§2.1 lint), a feature cannot borrow a
+  privileged category to borrow its classes.
+- **Episode dedup, defined:** episode key = (category, significantClass,
+  sourceContext), re-raise no sooner than every 6h while the condition
+  persists; a NEW sourceContext is a new episode (and P17/§5.2 budgets bound
+  the aggregate).
+- Extension is a PR to the code table, reviewed like any constitution-adjacent
+  change. No config path exists (D-6).
+
+### 5.2 Per-category push budget (the opt-in door is bounded — P17/P19)
+
+Every `deliver-push` — opted-in OR significant — passes a per-category
+rolling budget at the gate: default **3 pushes per category per 10 minutes**;
+overflow COALESCES into one summary push ("reap-notice: 47 more in the last
+10m — dashboard") per window, everything individually recorded in the quiet
+store. This closes the foundation gap §8.1 names (#1417's unbounded
+per-source hub message stream) and keeps an opted-in category or a storming
+significant emitter from becoming flood round five: opting in entitles the
+category to push, never to push UNBOUNDED. The budget is a code default
+(tunable down, never off, via config — same posture as the P17 budgets); the
+D-10 burst test gains an opted-in arm asserting the bounded push count.
+
+### 5.4 Composition with Self-Heal Before Notify (P22)
+
+Heal-exhausted escalations raise attention items exactly as today; whether
+that item PUSHES is this gate's call — critical-class exhaustions (data-loss
+/ security / cannot-operate) push via the significant lane; routine
+exhaustions are quiet (dashboard + digest + §4.3 routing). P22's "operator
+hears only when self-healing fails" becomes "…and hears it on the surface the
+operator chose."
+
+## §6 — Failure honesty (the log surface is down)
+
+Quiet-routing is only legitimate while recording works. Failure ladder, with
+its Standard-B declaration (this ladder is a notify-on-failure path, so it
+declares its own brakes):
+
+1. Quiet-store write fails → bounded in-line retry (max-attempts: 3, backoff
+   1s/5s/30s, idempotent append — a duplicate row is harmless and reconciled
+   by the index) → on exhaustion, fallback append to
+   `logs/quiet-notifications-fallback.jsonl` (plain JSONL, 2MB rotation).
+2. Fallback also fails (disk full / FS error) → increment an in-memory loss
+   counter; raise ONE deduped `data-loss`-class significant notice ("my quiet
+   notification store is failing — N automated notices could not be recorded
+   since <t>; check disk/dashboard") through the pre-decided envelope path.
+   Brakes: dedupe-key = the §5 episode key (category `attention-item`,
+   sourceContext `selectivity-store-failure`); max-notification-latency:
+   ≤120s from the first double-failure (the notice is raised on the failing
+   tick, not batched); re-raise per the 6h episode rule while failing;
+   breaker: after 3 episodes in 24h the notice states "persistent — manual
+   attention needed" and stops re-raising until recovery; audit-location: the
+   decision ledger + console (metadata only, never message bodies).
+3. Recovery detection = the next successful quiet-store write; a
+   reconciliation ledger row records the total lost count; the counter
+   resets.
+4. **Recursion safety (tested, §9):** the step-2 notice classifies via the
+   hardcoded §5 table to `deliver-push` and writes NO quiet-store entry — it
+   can never re-enter the failure it reports. A unit test pins "the §6 notice
+   can never classify `record`".
+5. The DECISION LEDGER (§7) failing never blocks delivery or recording — it
+   degrades to console + a status flag on `GET /notifications/selectivity`.
+6. While the significant lane itself cannot deliver (Telegram down), the
+   existing PendingRelayStore durability owns retry — unchanged.
+
+## §7 — Observability
+
+- **Decision ledger:** `logs/notification-selectivity.jsonl` — one row per
+  gate decision: `{ts, origin, category, significantClass?, decision, reason,
+  dryRun, wouldRecord?, relayedOrigin?, mapCold?, kindDivergence?, topicId,
+  sourceContext, machineId}`. Bounded rotation (2MB pattern).
+  `kindDivergence` names the case where the tone gate's `messageKind` and
+  this gate's `origin` disagree about one send (dual provenance made visible,
+  never implicit).
+- **dryRun counterfactuals:** while `dryRun: true`, `wouldRecord: true` rows
+  measure exactly what enforcement WILL suppress. Named canary metrics the
+  Increment-C flip is gated on (FD-12): `eatenReplyCounterfactual` (a
+  verified-reply-adjacent send that would demote) and
+  `demotedConversationServing` (a floor category that would record) — both
+  driven to zero; plus `replyWithoutRecentInbound` (FD-9's promotion
+  evidence).
+- **Counters are the authoritative soak evidence** (the rotating ledger is
+  the sample, the per-category counters on `GET /notifications/selectivity`
+  are the record): delivered/pushed/recorded/coalesced/lost/unreadAging per
+  category, plus the canary metrics above.
+- No LLM calls anywhere on the path → no token-audit surface needed
+  (Token-Audit Completeness: zero-spend by construction).
+
+## §8 — Composition (one pipeline, disjoint authorities — no double-gating)
+
+Order of layers for a Telegram-bound emission:
+
+```
+1. ORIGINATION      envelope stamped (reply route / scheduler stamps /
+                    emitter callsites)                                [this spec]
+2. CONTENT layers   tone gate (conversational, route-scoped, unchanged)
+                    outbound advisory preflight (automated job sends,
+                    unchanged)                                        [PA-3/PA-4]
+3. LAST HOP         NotificationSelectivityGate: deliver | deliver-push
+                    | record — evaluated ONCE per send (pre-decided
+                    envelopes pass through, §2)                       [this spec]
+4. DELIVERY         hub routing (#1417) · duplicate suppression ·
+                    AttentionTopicGuard · topicCreationBudget ·
+                    PendingRelayStore                                 [unchanged]
+```
+
+Authority boundaries, explicitly:
+
+- The **tone gate** judges CONTENT of conversational turns. It never decides
+  logs-vs-push. This gate never reads content. A message can be tone-gated
+  AND quiet-routed without conflict (tone verdicts apply to what would be
+  delivered; a recorded message skips delivery, and its stored text is the
+  post-advisory text as-emitted). Where the two layers' provenance fields
+  disagree, the ledger's `kindDivergence` row makes it visible (§7).
+- The **advisory layer** informs automated SENDERS about content. Its
+  NOT-SENT advisory happens at preflight, before this gate; a send that
+  passes advisory but lacks push entitlement records quietly. No conflict:
+  advisory shapes text, selectivity routes it.
+- **P17/P23 machinery** bounds and routes whatever this gate permits to push.
+  This gate reduces their load; it never relaxes them.
+- **Signal vs. Authority:** this gate holds blocking-equivalent ROUTING
+  authority while being deterministic — legitimate because its key is
+  structural provenance (who/where a message came from), the same class of
+  key as the P17 origin-typed ceiling, not brittle content interpretation.
+  Everything content-interpretive on the path remains signal-only or
+  LLM-judged exactly as today.
+
+### 8.1 Foundation gap surfaced (not silently inherited)
+
+#1417's single-topic mode routes EVERY attention item to the hub BEFORE
+`AttentionTopicGuard` runs (TelegramAdapter.ts:3877–3884), and
+`topicCreationBudget` bounds topic creation only — so per-source hub MESSAGE
+volume is unbounded on main today. This spec closes it structurally via §5.2
+(quiet default + bounded push budget). Named here per the lessons-aware
+foundation-audit rule: a spec must surface a foundation flaw, not build
+around it silently. Should this spec be rejected, that gap still needs an
+independent fix.
+
+## Decision points touched
+
+- NEW routing decision at `sendToTopic`/`createAttentionItem`: deliver /
+  deliver-push / record (this spec's core), evaluated once per send.
+- NEW bounded-push decision: the §5.2 per-category budget (coalesce on
+  overflow).
+- PROMOTED: the reply route's class-spoof breadcrumbs (routes.ts:12461–12503)
+  from log-only to classification input (§2.2.3), locally and on the
+  relay-receive hop (§2.4).
+- INVERTED: absence-of-stamps no longer defaults to `'reply'` for delivery
+  purposes (the tone gate's `messageKind` default is untouched for its own
+  content review; divergence is ledger-visible).
+- UNCHANGED: tone gate verdicts, advisory verdicts, P17/P23 budgets, hub
+  find-or-create self-heal, PendingRelayStore retry.
+
+## Frontloaded Decisions
+
+Every open question is resolved here with a default; the ELI16 restates each
+in plain English for operator confirmation at approval time. None require a
+mid-build stop.
+
+- **FD-1 — Significant set ships as `{security-incident, data-loss,
+  agent-cannot-operate}`**, with the §5 positive/negative example definitions.
+  Nothing else pushes without opt-in — including "I need your decision" (D-2,
+  FD-14). Extension is PR-only (D-6).
+- **FD-2 — Conversation-serving floors:** `presence-standby`,
+  `cold-start-fallback`, `message-loss-notice`, `command-response` — each
+  bound to a specific triggering inbound (§3.2). The set is cheap to change
+  ONLY while dryRun holds; from Increment C it is a user-visible interface
+  change, so the flip gate includes the `demotedConversationServing` canary
+  at zero (§7) and any post-enforcement change to the set is operator-
+  confirmed like FD-13.
+- **FD-3 — Digest defaults OFF, daily, to the hub** (D-11); content pinned to
+  counts + inventory, never item text (§4.5).
+- **FD-4 — Opt-in granularity is per-category** in v1; per-source/per-topic
+  granularity deferred <!-- tracked: 11960 -->.
+- **FD-5 — Opted-in pushes land at the category's declared destination**
+  (hub, or 🩺 for agent-health; conversation for conversation-serving).
+  Never a new topic (P23).
+- **FD-6 — Retention 30 days / 20k entries**, enforced by rotation with
+  storm-coalescing (§4.2), prune counts on the status route.
+  Cheap-to-change-after (config, hot-applied, internal store).
+- **FD-7 — Multi-machine opt-in is UNIFIED via the sole-writer durable
+  fan-out:** a toggle applies to every machine — online peers immediately,
+  offline peers via a durably queued write replayed on their return (the
+  WS4.1 durable-ack precedent); per-machine application state is shown on the
+  status route, and divergence persisting >24h raises ONE deduped attention
+  item (loud, not a silent footnote). Durable REPLICATION of the whole
+  preferences block remains tracked <!-- tracked: 11960 -->.
+- **FD-8 — Rollout keeps a lever until the cleanup increment** (see DEV-1):
+  `enabled`/`dryRun` exist through the maturation ladder; the June-13 "no
+  break-glass" (D-9) is honored as the END state — a tracked final increment
+  removes the legacy always-push path after fleet soak
+  <!-- tracked: 11960 -->. Flipping `enabled: false` post-Increment-D emits
+  an operator-visible warning naming the blast radius ("push-everything
+  behavior restored"); `dryRun: true` is the preferred lever short of
+  emergencies.
+- **FD-9 — The recent-inbound reply corroboration (§2.2.4) is advisory-only
+  in v1**, with concrete promotion exit criteria: ≥14 days of Increment-C
+  enforcement, ≥200 observed reply-path sends, and every
+  `replyWithoutRecentInbound` incident audited to zero false positives. (An
+  eaten late reply is strictly worse than a leaked automated push.)
+- **FD-10 — The gate is Telegram-first.** Slack/WhatsApp/iMessage adapters
+  gain the same gate at their send funnels in a follow-up; the envelope type
+  and registry are adapter-agnostic by construction
+  <!-- tracked: 11960 -->.
+- **FD-11 — Opt-in write authority:** the §4.2 route is the SOLE writer;
+  every write carries `confirmedBy` (`dashboard-pin` |
+  `operator-conversational-confirm`) + an audit row; unregistered ids are
+  rejected; >2 category changes in 10 minutes raise one attention item; the
+  inventory prints on status + digest. The agent NEVER opts categories in
+  without a recorded operator confirmation — self-granted push would reopen
+  the exact inversion D-1 closes. (Honest scope: `operator-conversational-
+  confirm` is agent-attested; the PIN path is the strong rung, and the audit
+  + inventory + attention item make a false attestation visible, which is
+  proportionate for a notification preference.)
+- **FD-12 — Enforcement flips are OPERATOR actions:** the Increment-C dev
+  flip (`dryRun: false`) and the Increment-D fleet default flip both require
+  explicit operator confirmation, gated on: 14 clean days, ≥200 reply-path
+  sends observed (an idle window proves nothing), `eatenReplyCounterfactual`
+  = 0, `demotedConversationServing` = 0. The agent PRESENTS the evidence; the
+  operator flips.
+- **FD-13 — The §1 v1 registry table ships as printed;** operator approval of
+  this spec binds the table (18 categories + dispositions + the
+  `uncategorized` default). The dashboard tab is named **Notifications**.
+- **FD-14 — `commitment-deadletter` defaults QUIET (D-2), and this is a named
+  operator decision** because The Agent Carries the Loop (ratified 2026-06-14,
+  one day AFTER the June-13 conversation) expects a genuinely-stuck
+  agent-owned obligation to surface ONCE. Under this spec that surfacing is:
+  the quiet store + unread badge + §4.3 lifeline aging + digest — not a
+  Telegram push — unless the operator opts `commitment-deadletter` in. The
+  ELI16 puts this collision in front of the operator explicitly (DEV-6).
+
+## Deviations from / extensions to the June-13 design (flagged honestly)
+
+- **DEV-1 (deviation, D-9):** June-13 removed the break-glass entirely. This
+  reconstruction ships with `enabled`/`dryRun` levers because the graduated
+  rollout ladder (dark → dev-dryRun → dev-enforce → fleet) is itself a
+  post-June-13 constitutional norm (Maturation Path), and an UNLEVERED flip
+  of every agent's messaging disposition would be reckless. D-9 is honored as
+  the end state (FD-8). **Operator confirmation requested.**
+- **DEV-2 (extension):** the category registry + legacyGate mapping (§3.5)
+  did not exist in the June-13 conversation (the per-feature levers it
+  reconciles mostly shipped after June 13 — #1417, reapNotify, ropeHealth).
+- **DEV-3 (extension):** conversation-serving corroboration (§3.2) — the
+  June-13 conversation established "replies unaffected" (D-8); the explicit
+  structural floor for standby/cold-start/loss notices is drawn here because
+  those notices now exist as constitutional floors (Always Reachable, shipped
+  post-June-13).
+- **DEV-4 (extension):** FD-9's advisory-first stance on inbound
+  corroboration; June-13 round 2 specified the last-hop inversion but not
+  this check's authority level.
+- **DEV-5 (reconciliation):** June-13's "single Alerts topic" is realized as
+  the existing #1417 "🔔 Attention" hub rather than a new topic.
+- **DEV-6 (temporal collision, named for sign-off):** The Agent Carries the
+  Loop was ratified 2026-06-14 — one day after D-2. Its "surface a stuck
+  obligation once" expectation and D-2's "even I'm-stuck goes to logs" pull
+  in opposite directions for decision-request notices. This spec resolves per
+  D-2 + the reaffirmed 2026-07-10 directive (quiet default, FD-14's named
+  surfacing path), and puts the collision in front of the operator in the
+  ELI16 rather than silently picking. **Operator confirmation requested.**
+- **DEV-7 (extension):** the §5.2 per-category push budget — June-13 bounded
+  nothing on the push side because pushes were to be rare; the budget is the
+  Distrust-Temporary-Success hardening that keeps the opt-in door from
+  becoming flood round five, and it also closes the #1417 foundation gap
+  (§8.1).
+
+## Multi-machine posture (Cross-Machine Coherence)
+
+- **Decision ledger + quiet store:** machine-local WRITE (each machine
+  records what IT suppressed), **proxied-on-read** — `GET
+  /notifications/quiet?scope=pool` merges every online machine with
+  per-machine cursors and bounded per-peer fetches, following the
+  `GET /attention?scope=pool` merged-read precedent (its own TTL-cached
+  fan-out, routes.ts:13762/:13852 — NOT the dark-gated PoolPollCache, so the
+  read works wherever attention's pool read works). Peer rows are
+  type-clamped + length-bounded on receive and HTML-escaped in the dashboard
+  (the WS2 receive-clamp posture).
+- **Category opt-in config: UNIFIED** via the FD-7 sole-writer durable
+  fan-out (online peers immediate, offline peers durably queued + replayed,
+  >24h divergence raises one attention item). No machine-local surface is
+  declared here; no `machine-local-justification` marker is required — the
+  per-machine FILE is an implementation detail beneath a unified operator
+  surface with loud divergence detection.
+- **The hub topic id:** machine-shared agent state as shipped by #1417 (boot
+  state key `agent-attention-topic`); unchanged here.
+- **Relayed sends:** envelope rides the relay; the DELIVERING machine
+  classifies, re-applies breadcrumb demotion, and tags `relayedOrigin` (§2.4)
+  — so a topic's quiet items land on its owning machine's store, and §4.3's
+  topic-scoped pool read keeps them visible after a transfer.
+
+## Security posture
+
+- The envelope is minted at in-process chokepoints; no NON-MESH HTTP caller
+  can assert `verified-reply` (the route computes it; request fields cannot
+  set it). On the mesh relay hop the origin is peer-asserted by the same
+  agent's other machine (mesh-authenticated), re-checked by the holder's
+  breadcrumb demotion, and ledger-tagged `relayedOrigin` (§2.4) — stated
+  honestly rather than over-claimed.
+- The internal pre-decided envelope is an unforgeable in-process object
+  (module-private class), so already-decided pushes (§5, §6) cannot be
+  spoofed by stamping a lookalike category (§2).
+- No new push surface: everything this gate can PUSH already existed; the
+  gate only ever narrows delivery. The one new outbound content class (the
+  digest) is pinned to counts + category names (§4.5) — no smuggling surface.
+- The quiet store may contain paths/jargon (it holds exactly what would have
+  been sent); it is served only on Bearer-authed routes + the PIN-gated
+  dashboard — same exposure class as `GET /attention`. Session-start
+  injection wraps every item in the untrusted-data envelope (§4.3).
+- The opt-in write route changes notification preferences only; it cannot
+  touch the significant table, the registry, or any safety gate (D-6); its
+  writes are provenance-stamped, audited, inventory-surfaced, and
+  mass-change-alarmed (FD-11).
+- No LLM on the path: nothing to prompt-inject at the gate; ledger rows quote
+  `sourceContext` as data.
+
+## §9 — Testing (Testing Integrity — all three tiers)
+
+- **Unit:** classification matrix (every origin × category × opt-in ×
+  significant combination; both sides of every boundary); envelope-absent →
+  quiet; class-mislabel ignored + audited; category stamped by a module not
+  in `emitterModules` → recorded + audited; §5.2 budget both sides (under →
+  push, over → one coalesced summary + records); fail directions (§2.4 —
+  gate-throw on reply delivers, on automated records; dryRun never writes the
+  quiet store); relay fallback (envelope-less relayed reply delivers via
+  kindMetadata; envelope-less relayed automated records); §6 ladder incl.
+  loss counter, single deduped notice, breaker after 3 episodes, and the
+  recursion pin ("the §6 notice can never classify `record`"); recency-map
+  cold behavior per category (§2.5); coalescing math (storm → O(1) rows);
+  event-sourced acks; registry completeness lint (unique ids, valid
+  dispositions, legacyGates resolve AND default false, emitterModules
+  non-empty).
+- **Integration (the D-10 burst invariant, extended):** with enforcement on +
+  shipped defaults, fire 1,000 automated emissions through the REAL pipeline
+  (mixed categories, unique source labels, unstamped raw `sendToTopic` calls,
+  attention items at every priority) → **ZERO Telegram sends**; all 1,000
+  recorded (coalesced rows count); significant-class emissions → exactly the
+  deduped, budget-bounded hub messages; a verified reply → delivered
+  untouched. **Opted-in arm (DEV-7):** opt one category in, fire 500 → at
+  most the §5.2 budget of pushes + one coalesced summary per window, all 500
+  recorded. Build fails on ONE stray (D-10 verbatim: zero, not "a few").
+- **Integration (HTTP + relay):** the §4.2 routes; pool-scope merged read
+  with a dark peer; opt-in sole-writer round-trip (confirmedBy required,
+  unregistered id rejected, legacyGate key co-written, mass-change attention
+  item); a relayed send classified on the holder (both skew directions);
+  dryRun counterfactual rows without quiet-store writes.
+- **E2E lifecycle:** production init path — gate wired non-null into the real
+  adapter, routes 200 when enabled (503 dark), dryRun verdicts appear in the
+  ledger for a real automated emission, a real reply flows untouched.
+- **Funnel lints** (`scripts/lint-notification-selectivity.js`, the safe-git/
+  safe-fs pattern):
+  1. every `sendToTopic` callsite carries an envelope (or a recognized
+     pre-decided pass-through);
+  2. callsite→category fit: a module may stamp only categories naming it in
+     `emitterModules`;
+  3. NO new raw `apiCall('sendMessage')` callsites (the existing seven are
+     enumerated with in-code justifications);
+  4. NO new in-repo `POST /telegram/reply` callers outside the sanctioned
+     relay scripts;
+  5. every `legacyGate` key defaults false in ConfigDefaults.
+
+## Migration Parity
+
+- Config defaults: `ConfigDefaults.getMigrationDefaults` +
+  `PostUpdateMigrator.migrateConfig` (existence-checked, idempotent).
+- **Increment-D legacy-lever snapshot:** a one-time migration copies each
+  default-TRUE legacy lever's CURRENT per-agent value into
+  `push.categories.<id>` (§3.5) — operators' effective choices survive; the
+  fleet default still flips to quiet.
+- CLAUDE.md template (`generateClaudeMd`) gains a "Quiet by Default
+  notifications" awareness block (the pull surface, the opt-in trigger
+  phrases, the status route) + `migrateClaudeMd` content-sniffed patch.
+- No hook or skill migrations expected.
+- The `uncategorized` default makes the migration order-safe WITHIN a machine
+  (emitters and gate swap atomically in one dist). The cross-machine skew
+  case is §2.4's relay fallback; enforcement on relayed sends gates on peer
+  protocol version.
+
+## Agent Awareness (template block, summary)
+
+"Automated notices are quiet by default: they land in your dashboard
+Notifications tab + logs, not Telegram. When the user asks 'why didn't you
+ping me about X?' → check `GET /notifications/selectivity` and the quiet
+feed; offer the per-category push opt-in ('want me to push reap notices?' —
+confirmed opt-ins go through the sole-writer route with `confirmedBy`).
+When the user says 'stop pushing X' → clear the category key. NEVER promise
+to push a category that isn't opted in; NEVER opt a category in without the
+user's explicit confirmation."
+
+## Rollout (graduated; the rollback lever is FD-8/DEV-1)
+
+1. **Increment A (dark):** registry + envelope stamping + gate in
+   OBSERVE (`dryRun: true`) + decision ledger + lints. Dev agents live-dryRun
+   (`enabled` omitted → `resolveDevAgentGate`), fleet dark. Zero behavior
+   change anywhere.
+2. **Increment B:** quiet store + routes + dashboard Notifications tab +
+   opt-in surface (read/write, still no suppression).
+3. **Increment C (dev enforcement — OPERATOR flip, FD-12):** `dryRun: false`
+   on dev agents after the FD-12 evidence bar (14 clean days, ≥200 reply
+   sends, both canaries at zero). Quiet categories stop pushing on dev.
+4. **Increment D (fleet — OPERATOR flip, FD-12):** default flips fleet-wide
+   (logs-only default everywhere) + the legacy-lever snapshot migration + the
+   one-time user-facing announcement (§4.4) + awareness block. Rollback at
+   every stage: `dryRun: true` preferred; `enabled: false` restores
+   push-everything instantly (live-config, no restart) and emits the FD-8
+   blast-radius warning.
+5. **Increment E (end-state, D-9):** after fleet soak, remove the legacy
+   always-push path so quiet-by-default is structural, not configured
+   <!-- tracked: 11960 -->. Operator-ratified at that increment, not before.
+
+## Alternatives considered
+
+- **Per-feature opt-outs (status quo):** rejected — four floods proved
+  feature-by-feature willpower fails; the June-13 root-cause admission.
+- **LLM significance judgment on the delivery path:** rejected — adds a
+  fail-closed/fail-open dilemma to every automated send, spends tokens on
+  housekeeping, and violates the deterministic-last-hop requirement
+  (emission-gate brief PA-9 reached the same conclusion).
+- **Priority-keyed gating (HIGH/URGENT always push):** rejected in the
+  June-13 round 1 — the trapdoor: features mark everything critical. Classes
+  are registry-bound per (category, module) instead (§5).
+- **A second gate at the attention layer only:** rejected — attention is one
+  emitter family; the disguise hole, the ~40 direct `sendToTopic` callers,
+  and the seven raw `sendMessage` callsites require the funnel-level last
+  hop plus lint closure of the bypasses.
+- **Blocking at the tone gate:** rejected — route-scoped (in-process callers
+  bypass it), content-judging (wrong key), and its fail-closed direction is
+  wrong for replies.
+
+## Deferred / declined — tracked, not dropped (Close the Loop)
+
+At build start, each deferral below is minted its own commitment (CMT id)
+with follow-through cadence; the topic marker is the reconstruction-time
+anchor, not the final tracking grain.
+
+- Legacy-lever full consolidation into `notifications.push.categories`
+  <!-- tracked: 11960 -->
+- Live-turn quiet-notice injection into running sessions (v1 is session-start
+  only) <!-- tracked: 11960 -->
+- Per-source / per-topic opt-in granularity <!-- tracked: 11960 -->
+- Slack/WhatsApp/iMessage adapter parity for the gate
+  <!-- tracked: 11960 -->
+- Durable cross-machine replication of the notification-preferences block
+  (FD-7's fan-out is the unified surface meanwhile) <!-- tracked: 11960 -->
+- Promotion of the recent-inbound reply corroboration to demotion authority
+  (FD-9 exit criteria) <!-- tracked: 11960 -->
+- Working-set-carrier transport for quiet items on topic transfer (§4.3's
+  pool read is the v1 path) <!-- tracked: 11960 -->
+- Increment E legacy-path removal (D-9 end state) <!-- tracked: 11960 -->
+- Emission-authority confidence gating for status claims (the PA-9 brief's
+  lane — converges separately, plugs into the registry)
+  <!-- tracked: 11960 -->
+
+## Open questions
+
+None — all resolved into Frontloaded Decisions above (FD-1 … FD-14), each
+restated in plain English in the ELI16 companion for the operator to confirm
+or override at approval time. The items that genuinely bend or postdate a
+June-13 decision are flagged as DEV-1 (rollout lever vs "no break-glass"),
+DEV-6/FD-14 (The Agent Carries the Loop collision), and FD-9 (advisory-first
+reply corroboration).
+
+## History
+
+| Date | Event |
+|------|-------|
+| 2026-06-13 | Design converged (3 rounds, 6 internal angles + GPT-5.5 + Gemini external passes) and operator-approved 13:59 PDT (topic 11960, "Approved"). |
+| 2026-06-13 | Build session `Topic spam` reaped at max runtime (~16:02 PDT); worktree + converged spec artifact lost. Only the conversation survived. |
+| 2026-07-09/10 | Operator returns to topic 11960 (fresh spam screenshot); urgent slice ships as PR #1417 (single-alerts-topic routing). Operator reaffirms the selectivity direction verbatim. |
+| 2026-07-10 | This reconstruction authored against main v1.3.802 and committed to a branch at authoring time (the artifact-loss lesson applied); round-1 convergence findings folded (9 reviewers). Awaiting fresh convergence + fresh operator approval. |

--- a/docs/specs/notification-selectivity.md
+++ b/docs/specs/notification-selectivity.md
@@ -1,7 +1,7 @@
 ---
 title: "Notification Selectivity — Quiet by Default: logs-first automated messaging with category-level push opt-in"
 slug: "notification-selectivity"
-status: "draft — reconstructed (needs fresh operator approval)"
+status: "approved — converged r3 + fresh operator sign-off 2026-07-10"
 tier: 2
 created: "2026-07-10"
 author: "echo"
@@ -10,7 +10,7 @@ eli16-overview: "notification-selectivity.eli16.md"
 provenance:
   - "Design approved by operator 2026-06-13 13:59 PDT (topic 11960, verbatim: 'Approved') after three review rounds — recorded here as DESIGN provenance only. The converged spec artifact was LOST: the build session was reaped at max runtime the same day and the spec file died with its worktree; only the design conversation survives."
   - "Reconstructed 2026-07-10 against canonical main (v1.3.802) after operator reaffirmation (topic 11960, 2026-07-10, verbatim): 'we need to be VERY selective about what gets actually sent to the user (most should be internal logs)'."
-  - "This reconstructed artifact requires FRESH operator sign-off — the June-13 'Approved' binds the design direction, not this document. No approved tag is carried."
+  - "FRESH operator sign-off RECEIVED 2026-07-10 13:17 PDT (topic 11960, verbatim: 'Approved with your recommendations') — approving this reconstructed document with the recommended defaults on both named decision points: the significant-lane emergency floor stays (ELI16 item 1), and the rollout lever exists through the staged rollout with full removal as the final cleanup increment (DEV-1)."
 extends:
   - "docs/specs/attention-single-topic-routing.eli16.md (PR #1417 — the urgent slice that already shipped)"
   - "docs/specs/notification-ux-coherence.md (the Agent Health lane)"
@@ -41,6 +41,9 @@ lessons-engaged:
   - "Close the Loop — the opt-in digest + unread-aging counters + agent-facing re-surfacing + tracked deferrals keep quiet items from rotting unseen (engaged, §4.3, §4.5)"
   - "Cross-Machine Coherence — every new surface declares its posture; the opt-in surface is unified via a durable sole-writer fan-out (engaged, §Multi-machine)"
 review-convergence: "2026-07-10T20:02:56.648Z"
+approved: true
+approved-at: "2026-07-10T20:17:00Z"
+approved-by: "operator conversational approval, topic 11960, 2026-07-10 13:17 PDT, 'Approved with your recommendations' (post ELI16 + convergence-report handoff via signed private views)"
 review-iterations: 3
 review-completed-at: "2026-07-10T20:02:56.648Z"
 review-report: "docs/specs/reports/notification-selectivity-convergence.md"

--- a/docs/specs/notification-selectivity.md
+++ b/docs/specs/notification-selectivity.md
@@ -6,7 +6,7 @@ tier: 2
 created: "2026-07-10"
 author: "echo"
 parent-principle: "Near-Silent Notifications"
-eli16-overview: "docs/specs/notification-selectivity.eli16.md"
+eli16-overview: "notification-selectivity.eli16.md"
 provenance:
   - "Design approved by operator 2026-06-13 13:59 PDT (topic 11960, verbatim: 'Approved') after three review rounds — recorded here as DESIGN provenance only. The converged spec artifact was LOST: the build session was reaped at max runtime the same day and the spec file died with its worktree; only the design conversation survives."
   - "Reconstructed 2026-07-10 against canonical main (v1.3.802) after operator reaffirmation (topic 11960, 2026-07-10, verbatim): 'we need to be VERY selective about what gets actually sent to the user (most should be internal logs)'."
@@ -40,6 +40,15 @@ lessons-engaged:
   - "Mobile-Complete Operator Actions — category opt-in is conversational + a dashboard toggle through ONE sole-writer surface; never a hand-built curl (engaged, §4.4)"
   - "Close the Loop — the opt-in digest + unread-aging counters + agent-facing re-surfacing + tracked deferrals keep quiet items from rotting unseen (engaged, §4.3, §4.5)"
   - "Cross-Machine Coherence — every new surface declares its posture; the opt-in surface is unified via a durable sole-writer fan-out (engaged, §Multi-machine)"
+review-convergence: "2026-07-10T20:02:56.648Z"
+review-iterations: 3
+review-completed-at: "2026-07-10T20:02:56.648Z"
+review-report: "docs/specs/reports/notification-selectivity-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 15
+cheap-to-change-tags: 2
+contested-then-cleared: 3
 ---
 
 # Notification Selectivity — Quiet by Default
@@ -56,6 +65,16 @@ enveloped) and the durable cross-machine ack (queued intent, revalidated at
 apply time); **the lifeline** = the always-alive guaranteed-reachable session;
 **working-set carrier** = the mechanism that moves a topic's files between
 machines; **guardian-pulse** = the daily meta-monitor digest job.
+
+How it fits together, in five lines: (1) a code-defined **registry** names
+every automated-message category and its default (quiet); (2) every outbound
+send carries a provenance **envelope** stamped at its origin; (3) a
+deterministic **gate** at the delivery funnel routes each send — replies
+deliver, automated messages record unless opted-in or genuinely significant,
+and every push is volume-budgeted; (4) recorded items land in a **quiet
+store** + dashboard Notifications tab + logs, and route into the owning
+project's session context; (5) the whole thing rolls out dark → observe →
+operator-flipped enforcement, with a zero-stray CI test holding it forever.
 
 ## Problem statement
 
@@ -293,8 +312,11 @@ there is no ambient "stamp any category" API to misuse — each emitter module
 receives, at composition-root wiring time, a stamper handle bound to exactly
 its registry-declared categories (the capability-object pattern), so stamping
 outside your declaration requires changing the wiring, which is the lint's
-and the PR review's jurisdiction. No reflection-based runtime module-identity
-check is claimed (JavaScript offers none for free).
+and the PR review's jurisdiction. Stampers are narrow TYPED factories
+exported only from the wiring module — the §9 lint forbids importing the
+generic envelope constructor anywhere else, so a handle cannot drift into
+general circulation. No reflection-based runtime module-identity check is
+claimed (JavaScript offers none for free).
 
 ### 2.1 The provenance envelope
 
@@ -377,7 +399,9 @@ the delivery layer.** A send is `verified-reply` iff ALL of:
    bounded, not an open-ended manual chore: each incident row carries the
    topic, the send, and the map state needed to judge it, and the metric is
    expected to be rare — the review is a per-incident checklist over a small
-   set, presented with the FD-12 evidence. **The promotion mechanism is
+   set, presented with the FD-12 evidence (automating the incident
+   classification is named future work, after the manual pass establishes
+   the ground truth). **The promotion mechanism is
    server-minted, zero client-contract change:** the route already tracks the
    topic's current inbound (`currentInboundByTopic`, routes.ts:12595) and the
    §2.5 map; promotion means the `verified-reply` stamp additionally requires
@@ -424,7 +448,11 @@ callers that branch on a Telegram message id (delivery-retry, dedup
 reservation, relay ACK paths) to handle `recorded` explicitly. A recorded
 send is SUCCESS for the emitter (the notice reached its governed surface);
 it must not trigger delivery retries, and it must not mark "user was
-notified" state anywhere. §9 requires tests per caller class.
+notified" state anywhere. §9 requires tests per caller class, and through
+Increments A–C a transitional shim LOGS every caller observed consuming a
+`recorded` result (the highest practical breakage risk is a caller silently
+assuming Telegram delivery — the sweep is verified by observation, not
+assumed complete).
 
 ### 2.4 Fail directions (explicit, per class)
 
@@ -465,12 +493,18 @@ notified" state anywhere. §9 requires tests per caller class.
     `record` would EAT a conversational reply — the unsafe direction. So an
     envelope-less relayed send falls back to the already-riding
     `kindMetadata.messageKind` (`reply` → deliver; `automated`/absent →
-    record), for a bounded skew window (enforcement on relayed sends
-    additionally gates on the peer's advertised protocol version). Honesty
-    note for the inverse skew: a NEW-version sender relaying to a LEGACY
-    holder degrades toward push (the legacy holder has no gate) — harmless
-    while the fleet is dark/dryRun, gone once Increment D lands, and stated
-    here so nobody mistakes it for a guarantee.
+    record). **The fallback has a pinned closure condition:** it applies ONLY
+    while an identified REGISTERED peer advertises a legacy protocol version,
+    and it is DEAD the moment no such peer exists — so the relay entry can
+    never linger as a standing reply-disguise for local Bearer-authed
+    callers. The §9 lint additionally forbids any in-repo caller outside the
+    sanctioned relay module from constructing the `{relayed: true}` marker
+    (mesh-signing the marker is the tracked hardening
+    <!-- tracked: 11960 -->). Honesty note for the inverse skew: a
+    NEW-version sender relaying to a LEGACY holder degrades toward push (the
+    legacy holder has no gate) — harmless while the fleet is dark/dryRun,
+    gone once Increment D lands, and stated here so nobody mistakes it for a
+    guarantee.
 
 ### 2.5 The inbound recency map (no hot-path disk I/O)
 
@@ -637,12 +671,16 @@ merge is a documented hazard for nested keys).
     legacyGate key (§3.5). **The conversational rung is deterministic, not
     attested:** a `confirmedBy: operator-conversational-confirm` write MUST
     cite `confirmingMessageId` — the operator's confirming inbound message —
-    verified against the §2.5 recency map (≤15 min); a write without a
-    resolvable citation is REFUSED (400), so the agent structurally cannot
-    self-grant push by claiming a conversation that didn't happen. The
-    confirmation reply the agent then sends ("Done — reap notices will now
-    push here") is conversation-serving, bound to that same message — the
-    change is always visible at the moment it happens. Belt on top: >2
+    verified against the §2.5 recency map (≤15 min) AND resolved to the
+    topic's VERIFIED operator binding (Know Your Principal — in a multi-user
+    topic, another registered user's message is not the operator's consent);
+    a write without a resolvable, operator-bound citation is REFUSED (400),
+    so the agent structurally cannot self-grant push by claiming a
+    conversation that didn't happen. **The confirmation reply is
+    server-minted, not agent-remembered:** the sole-writer route itself emits
+    the conversation-serving confirmation ("Done — reap notices will now push
+    here") into the cited message's topic, so the change is ALWAYS visible at
+    the moment it happens — by structure, not willpower. Belt on top: >2
     category changes inside 10 minutes raises ONE deduped attention item, and
     the current opt-in inventory is printed on the status route AND in every
     digest — a quietly-flipped key cannot stay invisible.
@@ -768,13 +806,27 @@ the gate (FD-15). Pinned semantics:
   P17 criticals-stay-visible precedent).
 - **Global ceiling:** at most **10 pushes per 10 minutes across ALL
   categories** (the cross-category analog of the P17 global topic ceiling);
-  overflow folds into ONE cross-category summary.
+  overflow folds into ONE cross-category summary. The global ceiling applies
+  to ROUTINE (opted-in) pushes; significant-lane pushes are bounded by their
+  own lanes and are never displaced or folded by routine volume — routine
+  storms across many categories cannot consume the headroom a significant
+  push rides on.
 - **Summary content is pinned** like the digest (§4.5): count + category/
   class name + the dashboard link — never `sourceContext`, titles, or item
   text.
 - **Scope honesty:** budgets are per-machine and in-memory (a restart resets
   the window; pool-wide worst case is budget × machines) — accepted and
-  stated, with P17's delivery-layer bounds as the backstop.
+  stated, with P17's delivery-layer bounds as the backstop. The status route
+  reports the pool-wide theoretical maximum (budget × online machines); a
+  lease-holder-coordinated global budget is a tracked follow-up
+  <!-- tracked: 11960 -->.
+- **Key-space bounds (the unique-sourceContext storm — the 2026-06-05 dodge
+  shape):** the §4.2 coalescing accumulator and the §5 episode-dedup map are
+  both keyed on emitter-supplied `sourceContext`, so both carry a TTL + a
+  per-category key cap (the §2.5 recency-map precedent); when a category
+  exceeds its key cap inside a window, further keys coalesce at CATEGORY
+  level (one row/summary for "N distinct sources") — a storm of unique labels
+  buys category-level coalescing, never O(storm) rows or pushes.
 - Everything coalesced or over-budget is individually recorded in the quiet
   store — a budget never loses an item, it only bounds pushes.
 
@@ -947,7 +999,9 @@ mid-build stop.
   offline peers via a durably queued write replayed on their return (the
   WS4.1 durable-ack precedent, INCLUDING its load-bearing half:
   **apply-time revalidation**). Every write carries a per-key monotonic
-  version stamped by the sole-writer; a queued replay applies ONLY-IF-NEWER,
+  version stamped by the sole-writer, machine-qualified (version +
+  machineId tiebreak) so two machines' concurrent writes can never mint
+  colliding versions; a queued replay applies ONLY-IF-NEWER,
   so a stale queued opt-in can never resurrect a since-reverted choice. The
   queue is bounded (per-peer cap; entries expire after 7 days — a
   permanently-dark peer cannot accumulate forever). Per-machine application
@@ -1136,8 +1190,9 @@ mid-build stop.
      pre-decided pass-through);
   2. callsite→category fit: a module may stamp only categories naming it in
      `emitterModules`;
-  3. NO new raw `apiCall('sendMessage')` callsites (the existing seven are
-     enumerated with in-code justifications);
+  3. NO new raw `apiCall('sendMessage')` callsites (the existing
+     grep-enumerated set — ~nine at reconstruction time, re-enumerated at
+     lint-baseline per §2.1 — carries in-code justifications);
   4. NO new in-repo `POST /telegram/reply` callers outside the sanctioned
      relay scripts;
   5. every `legacyGate` key defaults false in ConfigDefaults.
@@ -1153,7 +1208,10 @@ mid-build stop.
   flips to quiet. **Idempotency pinned:** the snapshot writes a key ONLY IF
   ABSENT (an operator's Increment-B/C sole-writer choice always beats the
   legacy lever value) and records a one-time durable migration marker (the
-  `_instar_migrations` precedent), so re-runs are no-ops.
+  `_instar_migrations` precedent), so re-runs are no-ops. The Increment-D
+  announcement (§4.4) explicitly LISTS any grandfathered push categories the
+  agent carried over, with a one-tap disable-all in the dashboard tab — a
+  never-knowingly-chosen default-true lever must not survive invisibly.
 - CLAUDE.md template (`generateClaudeMd`) gains a "Quiet by Default
   notifications" awareness block (the pull surface, the opt-in trigger
   phrases, the status route) + `migrateClaudeMd` content-sniffed patch.
@@ -1206,10 +1264,18 @@ user's explicit confirmation."
 - **Priority-keyed gating (HIGH/URGENT always push):** rejected in the
   June-13 round 1 — the trapdoor: features mark everything critical. Classes
   are registry-bound per (category, module) instead (§5).
+- **SQLite / an embedded event store for the quiet store:** considered — the
+  repo already runs SQLite for `PendingRelayStore`, and the quiet store is
+  admittedly a small event log (append rows + ack rows + an index). JSONL is
+  chosen for v1 because it matches the file-based-state doctrine, the write
+  path is single-process append-only (no concurrent-writer problem SQLite
+  would solve), and the read path is index-only; the store sits behind an
+  interface, so migrating to SQLite if concurrency or indexing outgrows JSONL
+  is an implementation swap, not a spec change.
 - **A second gate at the attention layer only:** rejected — attention is one
   emitter family; the disguise hole, the ~40 direct `sendToTopic` callers,
-  and the seven raw `sendMessage` callsites require the funnel-level last
-  hop plus lint closure of the bypasses.
+  and the grep-enumerated raw `sendMessage` callsites (§2.1) require the
+  funnel-level last hop plus lint closure of the bypasses.
 - **Blocking at the tone gate:** rejected — route-scoped (in-process callers
   bypass it), content-judging (wrong key), and its fail-closed direction is
   wrong for replies.
@@ -1238,14 +1304,18 @@ anchor, not the final tracking grain.
   lane — converges separately, plugs into the registry)
   <!-- tracked: 11960 -->
 
+## Resolution note (why Open questions is empty)
+
+All operator decisions are resolved into Frontloaded Decisions above
+(FD-1 … FD-15), each restated in plain English in the ELI16 companion for
+the operator to confirm or override at approval time. The items that
+genuinely bend or postdate a June-13 decision are flagged as DEV-1 (rollout
+lever vs "no break-glass"), DEV-6/FD-14 (The Agent Carries the Loop
+collision), and FD-9 (advisory-first reply corroboration).
+
 ## Open questions
 
-None — all resolved into Frontloaded Decisions above (FD-1 … FD-15), each
-restated in plain English in the ELI16 companion for the operator to confirm
-or override at approval time. The items that genuinely bend or postdate a
-June-13 decision are flagged as DEV-1 (rollout lever vs "no break-glass"),
-DEV-6/FD-14 (The Agent Carries the Loop collision), and FD-9 (advisory-first
-reply corroboration).
+*(none)*
 
 ## History
 
@@ -1255,4 +1325,5 @@ reply corroboration).
 | 2026-06-13 | Build session `Topic spam` reaped at max runtime (~16:02 PDT); worktree + converged spec artifact lost. Only the conversation survived. |
 | 2026-07-09/10 | Operator returns to topic 11960 (fresh spam screenshot); urgent slice ships as PR #1417 (single-alerts-topic routing). Operator reaffirms the selectivity direction verbatim. |
 | 2026-07-10 | This reconstruction authored against main v1.3.802 and committed to a branch at authoring time (the artifact-loss lesson applied); round-1 convergence findings folded (9 reviewers). |
-| 2026-07-10 | Round-2 findings folded (8 reviewers + conformance gate): corrected raw-send census incl. `TelegramAdapter.send()`, deterministic opt-in confirmation citation, relay carrier + fresh holder classification, pinned coalesce/durability mechanics, split significant/routine push lanes + global ceiling, FD-7 apply-time revalidation, FD-15. Awaiting round-3 confirmation + fresh operator approval. |
+| 2026-07-10 | Round-2 findings folded (8 reviewers + conformance gate): corrected raw-send census incl. `TelegramAdapter.send()`, deterministic opt-in confirmation citation, relay carrier + fresh holder classification, pinned coalesce/durability mechanics, split significant/routine push lanes + global ceiling, FD-7 apply-time revalidation, FD-15. |
+| 2026-07-10 | Round 3 (confirmation): every round-2 fold verified genuine by all six internal reviewers + codex gpt-5.5 + gemini; ZERO material new findings — CONVERGED at iteration 3. Round-3 one-clause minors folded editorially (operator-bound confirmation citations, server-minted confirmation reply, relay-fallback closure condition + marker lint, significant-lane reservation in the global ceiling, sourceContext key caps + category-level coalesce, machine-qualified opt-in versions, grandfathered-category listing + disable-all, record-contract transitional shim, typed stamper factories, SQLite alternative recorded, census-echo fixes, ELI16 item 16). Awaiting fresh operator approval. |

--- a/docs/specs/notification-selectivity.md
+++ b/docs/specs/notification-selectivity.md
@@ -503,7 +503,7 @@ assumed complete).
     callers. The §9 lint additionally forbids any in-repo caller outside the
     sanctioned relay module from constructing the `{relayed: true}` marker
     (mesh-signing the marker is the tracked hardening
-    <!-- tracked: 11960 -->). Honesty note for the inverse skew: a
+    <!-- tracked: CMT-1950 -->). Honesty note for the inverse skew: a
     NEW-version sender relaying to a LEGACY holder degrades toward push (the
     legacy holder has no gate) — harmless while the fleet is dark/dryRun,
     gone once Increment D lands, and stated here so nobody mistakes it for a
@@ -592,7 +592,7 @@ Increment D until its operator turns the category off — the flip changes the
 DEFAULT, never a standing effective choice (the ELI16 decision list carries
 this). Increment D's "logs-only default everywhere" claim holds because the
 snapshot preserves choices, not defaults. Full consolidation (retiring the
-legacy keys entirely) remains tracked <!-- tracked: 11960 -->. The dashboard
+legacy keys entirely) remains tracked <!-- tracked: CMT-1941 -->. The dashboard
 toggle is never dead: the §4.2 sole-writer route sets BOTH the category key
 and (when declared) the category's legacyGate key, so one toggle is one
 lever.
@@ -714,7 +714,7 @@ self-knowledge boot blocks). Hard rules:
   fail a session spawn. Items on an offline owner are missed-not-lost: they
   resurface at the next boot once the owner returns, and meanwhile they age
   through the owning machine's unread-aging counter + digest. Riding the
-  working-set carrier is the tracked richer path <!-- tracked: 11960 -->.
+  working-set carrier is the tracked richer path <!-- tracked: CMT-1947 -->.
 - **Unbound items don't rot silently (Close the Loop):** items with NO
   topic/project binding are re-surfaced to the AGENT — aged unread items
   (>72h) appear as one summary line in the lifeline session's boot block, and
@@ -822,7 +822,7 @@ the gate (FD-15). Pinned semantics:
   stated, with P17's delivery-layer bounds as the backstop. The status route
   reports the pool-wide theoretical maximum (budget × online machines); a
   lease-holder-coordinated global budget is a tracked follow-up
-  <!-- tracked: 11960 -->.
+  <!-- tracked: CMT-1951 -->.
 - **Key-space bounds (the unique-sourceContext storm — the 2026-06-05 dodge
   shape):** the §4.2 coalescing accumulator and the §5 episode-dedup map are
   both keyed on emitter-supplied `sourceContext`, so both carry a TTL + a
@@ -990,7 +990,7 @@ mid-build stop.
 - **FD-3 — Digest defaults OFF, daily, to the hub** (D-11); content pinned to
   counts + inventory, never item text (§4.5).
 - **FD-4 — Opt-in granularity is per-category** in v1; per-source/per-topic
-  granularity deferred <!-- tracked: 11960 -->.
+  granularity deferred <!-- tracked: CMT-1943 -->.
 - **FD-5 — Opted-in pushes land at the category's declared destination**
   (hub, or 🩺 for agent-health; conversation for conversation-serving).
   Never a new topic (P23).
@@ -1011,12 +1011,12 @@ mid-build stop.
   state is shown on the status route; the LEASE-HOLDER runs the divergence
   comparison, and divergence persisting >24h raises ONE deduped attention
   item (loud, not a silent footnote). Durable REPLICATION of the whole
-  preferences block remains tracked <!-- tracked: 11960 -->.
+  preferences block remains tracked <!-- tracked: CMT-1945 -->.
 - **FD-8 — Rollout keeps a lever until the cleanup increment** (see DEV-1):
   `enabled`/`dryRun` exist through the maturation ladder; the June-13 "no
   break-glass" (D-9) is honored as the END state — a tracked final increment
   removes the legacy always-push path after fleet soak
-  <!-- tracked: 11960 -->. Flipping `enabled: false` post-Increment-D emits
+  <!-- tracked: CMT-1948 -->. Flipping `enabled: false` post-Increment-D emits
   an operator-visible warning naming the blast radius ("push-everything
   behavior restored"); `dryRun: true` is the preferred lever short of
   emergencies.
@@ -1028,7 +1028,7 @@ mid-build stop.
 - **FD-10 — The gate is Telegram-first.** Slack/WhatsApp/iMessage adapters
   gain the same gate at their send funnels in a follow-up; the envelope type
   and registry are adapter-agnostic by construction
-  <!-- tracked: 11960 -->.
+  <!-- tracked: CMT-1944 -->.
 - **FD-11 — Opt-in write authority:** the §4.2 route is the SOLE writer;
   every write carries `confirmedBy` (`dashboard-pin` |
   `operator-conversational-confirm`) + an audit row; unregistered ids are
@@ -1254,7 +1254,7 @@ user's explicit confirmation."
    blast-radius warning.
 5. **Increment E (end-state, D-9):** after fleet soak, remove the legacy
    always-push path so quiet-by-default is structural, not configured
-   <!-- tracked: 11960 -->. Operator-ratified at that increment, not before.
+   <!-- tracked: CMT-1948 -->. Operator-ratified at that increment, not before.
 
 ## Alternatives considered
 
@@ -1290,22 +1290,26 @@ with follow-through cadence; the topic marker is the reconstruction-time
 anchor, not the final tracking grain.
 
 - Legacy-lever full consolidation into `notifications.push.categories`
-  <!-- tracked: 11960 -->
+  <!-- tracked: CMT-1941 -->
 - Live-turn quiet-notice injection into running sessions (v1 is session-start
-  only) <!-- tracked: 11960 -->
-- Per-source / per-topic opt-in granularity <!-- tracked: 11960 -->
+  only) <!-- tracked: CMT-1942 -->
+- Per-source / per-topic opt-in granularity <!-- tracked: CMT-1943 -->
 - Slack/WhatsApp/iMessage adapter parity for the gate
-  <!-- tracked: 11960 -->
+  <!-- tracked: CMT-1944 -->
 - Durable cross-machine replication of the notification-preferences block
-  (FD-7's fan-out is the unified surface meanwhile) <!-- tracked: 11960 -->
+  (FD-7's fan-out is the unified surface meanwhile) <!-- tracked: CMT-1945 -->
 - Promotion of the recent-inbound reply corroboration to demotion authority
-  (FD-9 exit criteria) <!-- tracked: 11960 -->
+  (FD-9 exit criteria) <!-- tracked: CMT-1946 -->
 - Working-set-carrier transport for quiet items on topic transfer (§4.3's
-  pool read is the v1 path) <!-- tracked: 11960 -->
-- Increment E legacy-path removal (D-9 end state) <!-- tracked: 11960 -->
+  pool read is the v1 path) <!-- tracked: CMT-1947 -->
+- Increment E legacy-path removal (D-9 end state) <!-- tracked: CMT-1948 -->
 - Emission-authority confidence gating for status claims (the PA-9 brief's
   lane — converges separately, plugs into the registry)
-  <!-- tracked: 11960 -->
+  <!-- tracked: CMT-1949 -->
+- Mesh-signed relayed-marker hardening (§9 relay-marker lint)
+  <!-- tracked: CMT-1950 -->
+- Lease-holder-coordinated pool-global push budget (§5.2)
+  <!-- tracked: CMT-1951 -->
 
 ## Resolution note (why Open questions is empty)
 

--- a/docs/specs/reports/notification-selectivity-convergence.md
+++ b/docs/specs/reports/notification-selectivity-convergence.md
@@ -1,0 +1,260 @@
+# Convergence Report — Notification Selectivity — Quiet by Default
+
+## Cross-model review: codex-cli:gpt-5.5
+
+RAN — clean pass. A real GPT-tier external review ran through the agent's
+codex CLI in ALL THREE rounds (`gpt-5.5`, status `ok` every round), and a
+real Gemini-tier review ran in all three rounds as well
+(`gemini-3.1-pro-preview`, status `ok` every round — a notable break from
+recent convergences where gemini timed out). The Anthropic clean-door
+second-read family was attempted every round and refused with
+`no-supported-framework` (config-dark on this runner) — recorded as its own
+disclosure, never counted toward the cross-model flag.
+
+## ELI10 Overview
+
+The agent's background machinery — watchdogs, health checks, job reports,
+"I noticed something" notes — has been allowed to message the operator on
+Telegram. A July-10 fix stopped these from creating a new Telegram *topic*
+per alert, but every alert still *pushes a message*. This spec is the
+redesign the operator approved on June 13 (and whose converged spec file was
+then lost when its build session was killed): by default, everything the
+agent generates on its own goes to internal logs and a dashboard inbox — it
+does NOT ping the operator. The operator opts in, per category, to anything
+they want pushed. Only a tiny hardcoded class (security incident, data loss,
+agent-cannot-operate) may reach the one Attention topic without an opt-in,
+and even that is volume-capped. Real replies to the operator are untouched,
+and every failure direction bends toward delivering them.
+
+The design is deterministic on purpose: the send-or-log decision keys on
+where a message came from (its provenance), never on what its text says, and
+no AI model sits on the delivery path. A CI test fires 1,000 automated
+signals through the real pipeline and fails the build if even one stray
+message would push without an opt-in.
+
+The main tradeoffs: quiet items must genuinely stay discoverable (the spec
+answers with unread badges, per-project surfacing, aging counters, and an
+opt-in daily digest), and the rollout must not silently change behavior the
+operator relies on (the spec answers with a dark → observe → operator-flipped
+ladder, grandfathering of existing effective choices — listed at flip time
+with one-tap disable-all — and instant rollback levers until the final
+cleanup).
+
+## Original vs Converged
+
+Three review rounds materially hardened the reconstruction:
+
+- **The dodge-class holes got closed with mechanism, not intention.**
+  Originally, a message's category was a label its emitter chose, and
+  "conversation-serving" was corroborated by "the topic is active." Reviewers
+  showed both were fakeable — the same dodge shape as all four historical
+  floods. Now: categories bind to named emitter modules (lint-enforced, with
+  typed wiring-time stamper handles), conversation-serving sends must cite
+  the SPECIFIC operator message they answer, and the raw-send bypasses around
+  the funnel (including a generic `send()` method the first draft's census
+  missed) are enumerated and lint-closed.
+- **The opt-in surface became deterministic.** Originally the agent could
+  write a category opt-in with an attested "the operator confirmed
+  conversationally." Now a conversational opt-in must cite the operator's
+  actual confirming message (verified against the inbound ledger AND the
+  verified-operator binding), the server itself mints the visible
+  confirmation reply, and a write without a valid citation is refused — the
+  agent structurally cannot grant itself push.
+- **The push door got bounded.** Review surfaced that the July-10 hub fix
+  left per-source hub MESSAGE volume unbounded (a real foundation gap, now
+  named in the spec). The converged design adds per-category push budgets, a
+  protected separate lane for significant alerts, a global ceiling, and
+  storm-proof coalescing (including against the unique-source-label dodge),
+  so even an opted-in category can never become flood round five.
+- **Multi-machine honesty.** Relayed sends between the agent's machines now
+  carry an explicit relay marker + protocol version; the delivering machine
+  re-classifies everything fresh; an envelope-less relayed REPLY fails toward
+  delivery (never eaten) under a pinned, self-expiring skew rule; opt-in
+  toggles fan out durably with apply-time revalidation so a stale queued
+  change can never resurrect a reverted choice.
+- **Two decisions were surfaced to the operator instead of silently
+  defaulted:** the rollout keeps an off-lever until a final cleanup increment
+  (bending the June-13 "no break-glass" — flagged DEV-1), and stuck-promise
+  notices staying quiet-by-default collides with a standard ratified one day
+  after the June-13 conversation (flagged DEV-6/FD-14). Both are put in front
+  of the operator in the ELI16 for the fresh sign-off this reconstruction
+  requires anyway.
+
+## Iteration Summary
+
+Internal reviewers ran as Claude subagents of the authoring session
+(model: claude-fable-5, all rounds — no silent drop to opus observed).
+Externals ran per available family, every round (body hash changed each
+round, so no delta-skips).
+
+| Iteration | Standards-Conformance Gate | Cross-model | Reviewers who flagged | Material findings | Spec changes |
+|-----------|---------------------------|-------------|-----------------------|-------------------|--------------|
+| 1 | ran (3 flags: Agent Carries the Loop, Close the Loop, No Deferrals) | codex ok (MINOR), gemini ok (MINOR), claude-code clean-door: refused `no-supported-framework` | all 6 internal (adversarial, integration, lessons SERIOUS; security, scalability, decision-completeness MINOR) + both externals | ~20 (category/corroboration gaming, reply-route inversion gaps, legacyGate laundering, funnel bypasses, self-opt-in, relayed-origin trust, storm mechanics, hot-path I/O, #1417 foundation gap, FD authority gaps…) | v2: emitter-bound categories + inbound-id corroboration, promoted breadcrumbs, sole-writer opt-in route, legacyGate default-false rule + snapshot migration, §5.2 push budget, §2.5 recency map, storm coalescing, untrusted-data injection envelope, FD-11…FD-14, DEV-6/DEV-7 |
+| 2 | ran (1 flag: Agent Carries the Loop — the named DEV-6 operator decision) | codex ok (MINOR), gemini ok (MINOR) | all 6 internal (adversarial SERIOUS; others MINOR) + both externals | 7 (funnel census missed `send()`, opt-in alarm self-quieted, FD-7 replay ordering, relay-carrier unimplementable as written, coalesce-mechanics contradiction, spawn-path pool fetch, record-contract) | v3: corrected census + build-time re-enumeration, deterministic confirmation citations, relay body marker + fresh holder classification, pinned durability/coalesce mechanics, significant/routine lanes + global ceiling, FD-7 versioned revalidation, FD-15, ELI16 items 14–15 |
+| 3 | ran (1 flag: same standing operator-decision flag; lessons-aware judged the surfacing SUFFICIENT in both rounds 2 and 3) | codex ok (MINOR), gemini ok (MINOR) | all 8 flagged only one-clause minors/editorial | **0** | (converged) round-3 minors folded editorially: operator-bound citations, server-minted confirmation, relay-fallback closure + marker lint, significant-lane reservation, sourceContext key caps, machine-qualified versions, grandfathered listing + disable-all, transitional record shim, typed stamper factories, SQLite alternative entry, census-echo fixes, ELI16 item 16 |
+
+## Full Findings Catalog
+
+### Iteration 1 (spec v1 → v2)
+
+**Standards-Conformance Gate (code-backed):** 3 flags — *The Agent Carries
+the Loop* (quiet decision-request notices can swallow a stuck obligation),
+*Close the Loop* (no default cadence re-surfaces quiet items), *No Deferrals*
+(legacy-lever consolidation deferred). Resolutions: DEV-6 + FD-14 named
+operator decision; §4.3 unbound-item aging + lifeline boot surfacing +
+unread-aging counter; deferrals carry tracked markers + build-time CMT
+minting (lessons-aware judged the No-Deferrals form compliant).
+
+**Security (MINOR):** MATERIAL relayed-origin peer-asserted vs posture claim
+→ §2.4 trust model + holder re-demotion + `relayedOrigin` ledger field;
+MATERIAL §4.3 injection lacked untrusted-data envelope → clamps + delimited
+envelope; minors: fallback rotation (→2MB), pool-read clamping/HTML-escape,
+reply-route lint + corroboration residual honesty, skew asymmetry note,
+opt-in id validation.
+
+**Scalability (MINOR):** MATERIAL no storm coalescing (17.5k-row eviction
+risk) → coalescing + rotation-prune + boot index; MATERIAL §2.3 "no I/O"
+contradiction → §2.5 in-memory recency map; minors: §6 recursion pin test,
+counters-as-soak-evidence, event-sourced acks, pool cursors, §4.3 numeric
+bound.
+
+**Adversarial (SERIOUS):** category free-text + fakeable corroboration →
+emitterModules + inbound-id binding; significantClass gaming + undefined
+episode key → registry-bound classes + episode key; reply-route inversion
+incomplete → reply-route lint + FD-9 concrete exit criteria; legacyGate
+laundering (reapNotify default-true) → default-false lint + snapshot
+migration; funnel not total (raw sendMessage sites) → census + lint;
+Bearer self-opt-in → FD-11; minors: relay trust scoping, inactivity-proof
+clean window (→ traffic floor), digest content pinning, pass-through
+spoofing (→ module-private object).
+
+**Integration (SERIOUS):** relayed envelope-less reply eaten under skew →
+kindMetadata fallback; default-true legacyGate defeats D-1 → snapshot at
+Increment D; Standard-A on per-machine opt-in config → unified durable
+fan-out + corrected pool-read citation (attention's own TTL fan-out, not
+PoolPollCache); topic transfer strands quiet items → topic-scoped pool read;
+minors: §6 Standard-B brake declaration, dead toggle (co-write legacyGate),
+sole-writer vs PATCH /config, dryRun store semantics + relay test.
+
+**Decision-completeness (MINOR):** FD-2 cheap tag REJECTED → narrowed +
+demotion canary; M-1 opt-in authority → FD-11; M-2 flip authority + window →
+FD-12; M-3 table binding → FD-13; M-4 block bound + tab name.
+
+**Lessons-aware (SERIOUS):** Agent-Carries-the-Loop temporal collision →
+DEV-6 + FD-14 + `commitment-deadletter` category; #1417 unbounded per-source
+hub stream (foundation gap) → §5.2 budget + §8.1 naming + opted-in burst-test
+arm; minors: unbound-item aging, CMT minting, gate self-composition clause,
+kindDivergence ledger field.
+
+**codex gpt-5.5 (MINOR):** record return contract; envelope-absence lint
+posture; §3.2 window/identity model; quiet-aging policy; significant-class
+definitions; rollback blast-radius warning. All folded (§2.3 contract, §9
+lints, §3.2 concrete bindings, §4.3 aging, §5 examples, FD-8 warning).
+
+**gemini (MINOR):** onboarding/discovery → Increment-D announcement + tab
+intro; multi-machine config consistency → FD-7; glossary; artifact-loss
+process note → History (commit-at-authoring-time).
+
+### Iteration 2 (spec v2 → v3)
+
+**Security (MINOR):** rounds-1 folds verified; minors → relayed
+category/class also peer-asserted (→ holder classifies FRESH, pre-decided
+never crosses mesh), FD-7 apply-time revalidation, §5.2 summary pinning.
+
+**Scalability (MINOR):** MATERIAL coalesce-row self-contradiction →
+in-memory accumulate + ≤1 flushed row/(key,window) + `coalescedApprox`;
+MATERIAL spawn-path cross-machine fetch → local-first + hard ≤2s TTL-cached
+budget + missed-not-lost; minors: recency-map LRU/cap, per-machine budget
+honesty, FD-7 queue TTL/versioning.
+
+**Adversarial (SERIOUS):** M1 census factually wrong (missed
+`TelegramAdapter.send()` + a prompt branch) → corrected census + `send()`
+into the funnel + build-time re-enumeration; M2 the mass-opt-in alarm was
+quiet-routed by this spec's own default (guard guarded nothing) →
+deterministic confirmingMessageId citation, refusal without it; M3 FD-7
+stale-replay resurrection → monotonic only-if-newer; minors: pre-decided
+single-use, runtime emitterModules honesty (→ wiring-time capability
+handles), global ceiling.
+
+**Integration (MINOR):** MATERIAL protocol-version had no carrier → relay
+body `{relayed, machineId, protocolVersion}`, absence = legacy signal;
+MATERIAL same census fix; minors: offline-owner outcome, snapshot idempotency
+(only-if-absent + marker), version authority + divergence-comparison owner.
+
+**Decision-completeness (MINOR):** N-1 budget default unbound → FD-15; N-2
+ELI16 missing FD-9 → item 14. FD-2-narrowed and FD-6 tags upheld.
+
+**Lessons-aware (MINOR):** digest-off honesty in FD-14/ELI16 #2;
+significant-overflow summaries must NAME the class. Conformance flag judged
+SUFFICIENT (deliberately-surfaced operator decision; the standard pins
+non-swallowing + exactly-once, not a delivery channel).
+
+**codex gpt-5.5 (MINOR):** reply-route laundering residual (→ FD-9's
+server-minted promotion mechanism named); grandfathering explicitness (→
+named + ELI16); store durability semantics (→ pinned paragraph); §5.2
+accounting order (→ lanes + summary-does-not-consume-budget); §4.3 raw-body
+injection (→ structured metadata only); glossary depth.
+
+**gemini (MINOR):** lexicon density (→ glossary extension + five-line
+summary); FD-9 manual-audit scalability (→ bounded ledger-driven checklist +
+automation-as-future-work); truncated-context process note (recorded).
+
+### Iteration 3 (confirmation on v3; minors folded editorially into v4)
+
+**Security (MINOR):** rounds-2 folds verified genuine; minors →
+confirmingMessageId must bind to the VERIFIED topic-operator (folded), relay
+fallback needs a pinned closure condition (folded: registered legacy peer
+required, dead when none exists, marker construction lint-restricted).
+
+**Scalability (MINOR):** all resolved; minors → significant-lane reservation
+within the global ceiling (folded), sourceContext-keyed map TTL/caps +
+category-level secondary coalesce (folded).
+
+**Adversarial (MINOR):** all three round-2 MATERIALs verified genuinely
+closed (census verified against source; the citation check judged genuinely
+better than the alarm — fail-closed at write time, self-revealing pushes,
+audit-named citation); minors → stale-"seven" echoes (folded), server-minted
+confirmation reply instead of agent willpower (folded), relay-receive marker
+lint extension (folded).
+
+**Integration (MINOR):** all resolved; minors → stale census echoes
+(folded), machine-qualified version minting (folded).
+
+**Decision-completeness (MINOR):** counts finalized — 15 frontloaded
+decisions, 2 surviving cheap tags, 3 contested-then-cleared; minor → FD-10
+missing from the ELI16 (folded: item 16).
+
+**Lessons-aware (MINOR):** both round-2 minors verified folded; conformance
+flag judgment HOLDS for v3; minor → census echoes (folded).
+
+**codex gpt-5.5 (MINOR):** typed stamper factories + import lint (folded);
+record-contract transitional shim (folded); grandfathered categories listed
+at announcement + one-tap disable-all (folded); SQLite alternatives entry
+(folded); pool-wide max visibility + global-budget follow-up (folded);
+implementation summary (folded).
+
+**gemini (MINOR):** jargon density (glossary + five-line summary stand);
+custom-store philosophy (answered by the SQLite alternatives entry);
+FD-9 manual-audit interim (already noted as future automation). All
+advisory; none required further change.
+
+**Standing conformance flag, disposed honestly:** *The Agent Carries the
+Loop* flags in every round because the spec's quiet default for
+decision-request/dead-letter notices is a genuine tension with that standard
+— resolved BY DESIGN as a named operator decision (DEV-6/FD-14, ELI16 item
+2, "Operator confirmation requested"), per the operator's own June-13 D-2
+and the July-10 reaffirmation. The lessons-aware reviewer examined and
+upheld this disposition in rounds 2 and 3. Spec text cannot clear this flag;
+only the operator's fresh sign-off can.
+
+## Convergence verdict
+
+Converged at iteration 3. The round-3 review of the v3 body produced ZERO
+material findings across all six internal reviewers, both cross-model
+externals, and the conformance gate (whose single remaining flag is the
+deliberately-surfaced DEV-6 operator decision). Round-3 one-clause minors
+were folded editorially per the established final-round precedent and are
+enumerated above. The spec is ready for operator review — NOTE: this is a
+RECONSTRUCTION of the lost June-13 design; the June-13 "Approved" is
+recorded as design provenance only, and the spec carries NO approved tag.
+Fresh operator approval is required before any build starts.


### PR DESCRIPTION
## eli16

This is the plan (not yet the code) for making the agent quiet by default. Today every background feature decides for itself whether to message you, and the result has been walls of alert topics and noisy pings. Under this design, everything automated goes to a quiet inbox you can browse from the dashboard, and only categories you explicitly opt into ever get pushed to Telegram — with a tiny hard-wired emergency floor (security incident, data loss, agent-cannot-operate) that always pushes. A last-hop gate at the delivery funnel treats any message that isn't a verified reply to something you actually said as automated, so no feature can dress its chatter up as conversation. The original version of this plan was approved on June 13 but the finished document was lost when its build session was killed; this is the faithful reconstruction, updated for everything shipped since (including the single-Attention-topic routing fix), re-reviewed to convergence in 3 rounds by six internal reviewers plus GPT-5.5 and Gemini every round (both clean), and freshly approved by the operator on July 10 with the two named judgment calls resolved (emergency floor stays; the rollout keeps an off-switch until the final cleanup increment removes the old push-everything path for good). Eleven deferred follow-ups are each tracked with their own commitment id so nothing rots silently.

## What

Docs-only: the converged + approved spec, its ELI16 companion, and the convergence report. Implementation (Increments A–E) follows separately through /instar-dev.

- `docs/specs/notification-selectivity.md` — frontmatter carries `review-convergence` (r3, cross-model codex gpt-5.5 + gemini clean) AND `approved: true` (operator conversational approval, topic 11960, 2026-07-10 13:17 PDT, 'Approved with your recommendations')
- `docs/specs/notification-selectivity.eli16.md`
- `docs/specs/reports/notification-selectivity-convergence.md`
- Tracked deferrals minted: CMT-1941…CMT-1951

🤖 Generated with [Claude Code](https://claude.com/claude-code)