### PR TITLE
feat(commitments): add dry-run auto-expiry sweep

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-10T20-49-13-728Z-commitment-auto-expiry.json
+++ b/.instar/instar-dev-decisions/2026-07-10T20-49-13-728Z-commitment-auto-expiry.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-10T20:49:13.728Z",
+  "slug": "commitment-auto-expiry",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 184,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-10T20-50-00-565Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-10T20-50-00-565Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-10T20:50:00.565Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 4,
+  "loc": 184,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-10T20-50-46-395Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-10T20-50-46-395Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-10T20:50:46.395Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 4,
+  "loc": 184,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-10T20-52-11-233Z-commitment-auto-expiry-102fad3d.json
+++ b/.instar/instar-dev-traces/2026-07-10T20-52-11-233Z-commitment-auto-expiry-102fad3d.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "sessionId": "3b6e537d-21c9-4cb7-81f7-9cf9a51be2ef",
+  "timestamp": "2026-07-10T20:52:11.233Z",
+  "artifactPath": "upgrades/side-effects/commitment-auto-expiry.md",
+  "artifactSha256": "ae4106e5ceccda4d613ac039a5e8badfdfb46fed39f3eaefa6ef2a32ba4c9cd9",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/config/ConfigDefaults.ts",
+    "src/core/types.ts",
+    "src/monitoring/CommitmentTracker.ts",
+    "tests/e2e/commitment-auto-expiry-api-lifecycle.test.ts",
+    "tests/integration/commitment-auto-expiry-lifecycle.test.ts",
+    "tests/unit/CommitmentTracker-auto-expiry.test.ts",
+    "upgrades/eli16/commitment-auto-expiry.md",
+    "upgrades/next/commitment-auto-expiry.md",
+    "upgrades/side-effects/commitment-auto-expiry.md"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Small lifecycle cleanup using existing CommitmentTracker ownership/status fields and existing expired terminal state. The only new config key is a dry-run-first rollout dial with conservative defaults; no new external authority, no user-owned mutation, bounded 500-row passes, one aggregate log line, and one coalesced store write per sweep. PR review is the approval surface.",
+  "eli16Path": "upgrades/eli16/commitment-auto-expiry.md",
+  "sideEffectsPath": "upgrades/side-effects/commitment-auto-expiry.md",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -12411,6 +12411,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     const commitmentTracker = new CommitmentTracker({
       stateDir: config.stateDir,
       liveConfig,
+      autoExpiry: config.commitments?.autoExpiry,
       // P1.5 §3.1: the creator stamp — (originMachineId, id) is the
       // cross-machine identity (ids are per-machine sequential counters).
       ...(cjOwnMachineId ? { originMachineId: cjOwnMachineId } : {}),

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -1701,6 +1701,12 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
   // dev-gate lesson). These are the operator's tuning/opt-out dials; dryRun
   // defaults true so the dark→live promotion is the operator's deliberate flip.
   commitments: {
+    autoExpiry: {
+      enabled: true,
+      maxAgeDays: 21,
+      sweepIntervalMs: 21_600_000,
+      dryRun: true,
+    },
     agentOwnedFollowthrough: {
       dryRun: true,
       // externalBlockWindowMs / externalBlockCeilingMs / externalBlockSweepMs:

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3191,6 +3191,21 @@ export interface InstarConfig {
      */
     operationalFacts?: Array<string | { fact: string; updatedAt?: string; machine?: string }>;
   };
+  commitments?: {
+    autoExpiry?: {
+      enabled?: boolean;
+      maxAgeDays?: number;
+      sweepIntervalMs?: number;
+      dryRun?: boolean;
+    };
+    agentOwnedFollowthrough?: {
+      enabled?: boolean;
+      dryRun?: boolean;
+      externalBlockWindowMs?: number;
+      externalBlockCeilingMs?: number;
+      externalBlockSweepMs?: number;
+    };
+  };
   /**
    * Feedback-factory operated-instance config (docs/specs/feedback-factory-migration.md).
    * `receiverPersistence` is the Option-B receiving end: the canonical front (Vercel)

--- a/src/monitoring/CommitmentTracker.ts
+++ b/src/monitoring/CommitmentTracker.ts
@@ -364,6 +364,8 @@ export interface CommitmentTrackerConfig {
   originMachineId?: string;
   /** Check interval in ms. Default: 60_000 (1 minute) */
   checkIntervalMs?: number;
+  /** Auto-expire old agent-owned open commitments. Defaults: enabled, 21d, 6h, dry-run. */
+  autoExpiry?: CommitmentAutoExpiryConfig;
   /** Callback when a violation is detected */
   onViolation?: (commitment: Commitment, detail: string) => void;
   /** Callback when a commitment is verified for the first time */
@@ -376,12 +378,33 @@ export interface CommitmentTrackerConfig {
   escalationWindowMs?: number;
 }
 
+export interface CommitmentAutoExpiryConfig {
+  enabled?: boolean;
+  maxAgeDays?: number;
+  sweepIntervalMs?: number;
+  dryRun?: boolean;
+}
+
+export interface CommitmentAutoExpirySweepReport {
+  timestamp: string;
+  dryRun: boolean;
+  enabled: boolean;
+  maxAgeDays: number;
+  scanned: number;
+  eligible: number;
+  expired: number;
+  capped: boolean;
+}
+
 // ── Implementation ────────────────────────────────────────────────
 
 /** Max depth of the per-id mutate queue. Enqueue beyond this rejects. */
 const MUTATE_QUEUE_MAX_DEPTH = 256;
 /** Max CAS retries when the version drifts under an apply. */
 const MUTATE_CAS_MAX_RETRIES = 5;
+const DEFAULT_AUTO_EXPIRY_MAX_AGE_DAYS = 21;
+const DEFAULT_AUTO_EXPIRY_SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const AUTO_EXPIRY_SWEEP_CAP = 500;
 
 type MutateFn = (c: Commitment) => Commitment | Promise<Commitment>;
 interface MutateQueueEntry {
@@ -396,6 +419,8 @@ export class CommitmentTracker extends EventEmitter {
   private storePath: string;
   private rulesPath: string;
   private interval: ReturnType<typeof setInterval> | null = null;
+  private autoExpiryInterval: ReturnType<typeof setInterval> | null = null;
+  private autoExpiryInitialTimeout: ReturnType<typeof setTimeout> | null = null;
   private nextId: number;
   /**
    * Coalesce the per-mutation full-store writes of a synchronous sweep into ONE
@@ -490,12 +515,25 @@ export class CommitmentTracker extends EventEmitter {
     if (this.interval) return;
 
     const intervalMs = this.config.checkIntervalMs ?? 60_000;
+    const autoExpiry = this.resolveAutoExpiryConfig();
 
     // First verification after a short delay
     setTimeout(() => this.verify(), 15_000);
 
     this.interval = setInterval(() => this.verify(), intervalMs);
     this.interval.unref();
+
+    if (autoExpiry.enabled) {
+      this.autoExpiryInitialTimeout = setTimeout(() => {
+        this.autoExpiryInitialTimeout = null;
+        this.sweepAutoExpiry();
+      }, 30_000);
+      this.autoExpiryInitialTimeout.unref();
+      this.autoExpiryInterval = setInterval(() => {
+        this.sweepAutoExpiry();
+      }, autoExpiry.sweepIntervalMs);
+      this.autoExpiryInterval.unref();
+    }
 
     const active = this.getActive().length;
     if (active > 0) {
@@ -509,6 +547,14 @@ export class CommitmentTracker extends EventEmitter {
     if (this.interval) {
       clearInterval(this.interval);
       this.interval = null;
+    }
+    if (this.autoExpiryInitialTimeout) {
+      clearTimeout(this.autoExpiryInitialTimeout);
+      this.autoExpiryInitialTimeout = null;
+    }
+    if (this.autoExpiryInterval) {
+      clearInterval(this.autoExpiryInterval);
+      this.autoExpiryInterval = null;
     }
   }
 
@@ -767,6 +813,19 @@ export class CommitmentTracker extends EventEmitter {
 
     console.log(`[CommitmentTracker] Delivered ${id}`);
     this.emit('delivered', updated);
+    return updated;
+  }
+
+  /**
+   * Expire a commitment through the same terminal transition used by sweeps.
+   */
+  expire(id: string, reason = 'Expired'): Commitment | null {
+    const existing = this.store.commitments.find(c => c.id === id);
+    if (!existing) return null;
+    if (['expired', 'withdrawn', 'delivered'].includes(existing.status)) return null;
+    const updated = this.expireSync(id, reason, new Date().toISOString());
+    this.refreshThreadIdIndex(updated);
+    this.emit('expired', updated);
     return updated;
   }
 
@@ -1541,6 +1600,60 @@ export class CommitmentTracker extends EventEmitter {
 
   // ── Expiration ─────────────────────────────────────────────────
 
+  sweepAutoExpiry(now = new Date()): CommitmentAutoExpirySweepReport {
+    const config = this.resolveAutoExpiryConfig();
+    const timestamp = now.toISOString();
+    const report: CommitmentAutoExpirySweepReport = {
+      timestamp,
+      dryRun: config.dryRun,
+      enabled: config.enabled,
+      maxAgeDays: config.maxAgeDays,
+      scanned: 0,
+      eligible: 0,
+      expired: 0,
+      capped: false,
+    };
+
+    if (!config.enabled) return report;
+
+    const targets: string[] = [];
+    for (const commitment of this.store.commitments) {
+      report.scanned++;
+      if (!this.isAutoExpiryEligible(commitment, now, config.maxAgeDays)) continue;
+      report.eligible++;
+      if (targets.length < AUTO_EXPIRY_SWEEP_CAP) {
+        targets.push(commitment.id);
+      } else {
+        report.capped = true;
+      }
+    }
+
+    if (!config.dryRun && targets.length > 0) {
+      const reason = `auto-expired: aged out >${config.maxAgeDays}d, presumed completed-but-unclosed`;
+      this.batchingSaves = true;
+      try {
+        for (const id of targets) {
+          const updated = this.expireSync(id, reason, timestamp);
+          this.refreshThreadIdIndex(updated);
+          this.emit('expired', updated);
+          report.expired++;
+        }
+        if (report.expired > 0) this.writeBehavioralRules();
+      } finally {
+        this.batchingSaves = false;
+        if (this.pendingSave) {
+          this.pendingSave = false;
+          this.saveStore();
+        }
+      }
+    }
+
+    console.log(
+      `[CommitmentTracker] Auto-expiry sweep: scanned=${report.scanned} eligible=${report.eligible} expired=${report.expired} dryRun=${report.dryRun} maxAgeDays=${report.maxAgeDays} capped=${report.capped}`,
+    );
+    return report;
+  }
+
   private expireCommitments(): void {
     const now = new Date().toISOString();
     let changed = false;
@@ -1552,12 +1665,7 @@ export class CommitmentTracker extends EventEmitter {
       .map(c => c.id);
 
     for (const id of targets) {
-      this.mutateSync(id, c => ({
-        ...c,
-        status: 'expired',
-        resolvedAt: now,
-        resolution: 'Expired',
-      }));
+      this.expireSync(id, 'Expired', now);
       changed = true;
       const c = this.get(id);
       if (c) console.log(`[CommitmentTracker] Expired ${c.id}: "${c.userRequest}"`);
@@ -1566,6 +1674,48 @@ export class CommitmentTracker extends EventEmitter {
     if (changed) {
       this.writeBehavioralRules();
     }
+  }
+
+  private expireSync(id: string, reason: string, resolvedAt: string): Commitment {
+    return this.mutateSync(id, c => ({
+      ...c,
+      status: 'expired',
+      resolvedAt,
+      resolution: reason,
+    }));
+  }
+
+  private resolveAutoExpiryConfig(): Required<CommitmentAutoExpiryConfig> {
+    return {
+      enabled: this.config.autoExpiry?.enabled ?? true,
+      maxAgeDays: this.positiveNumberOrDefault(
+        this.config.autoExpiry?.maxAgeDays,
+        DEFAULT_AUTO_EXPIRY_MAX_AGE_DAYS,
+      ),
+      sweepIntervalMs: this.positiveNumberOrDefault(
+        this.config.autoExpiry?.sweepIntervalMs,
+        DEFAULT_AUTO_EXPIRY_SWEEP_INTERVAL_MS,
+      ),
+      dryRun: this.config.autoExpiry?.dryRun ?? true,
+    };
+  }
+
+  private positiveNumberOrDefault(value: number | undefined, fallback: number): number {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
+  }
+
+  private isAutoExpiryEligible(commitment: Commitment, now: Date, maxAgeDays: number): boolean {
+    if (commitment.owner !== 'agent') return false;
+    if (commitment.status !== 'pending' && commitment.status !== 'violated') return false;
+    const createdAtMs = Date.parse(commitment.createdAt);
+    if (!Number.isFinite(createdAtMs)) return false;
+    const ageMs = now.getTime() - createdAtMs;
+    if (ageMs <= maxAgeDays * 24 * 60 * 60 * 1000) return false;
+    if (commitment.hardDeadlineAt) {
+      const hardDeadlineMs = Date.parse(commitment.hardDeadlineAt);
+      if (Number.isFinite(hardDeadlineMs) && hardDeadlineMs > now.getTime()) return false;
+    }
+    return true;
   }
 
   // ── Single-writer mutation ─────────────────────────────────────

--- a/tests/e2e/commitment-auto-expiry-api-lifecycle.test.ts
+++ b/tests/e2e/commitment-auto-expiry-api-lifecycle.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { CommitmentTracker } from '../../src/monitoring/CommitmentTracker.js';
+import { LiveConfig } from '../../src/config/LiveConfig.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { InstarConfig } from '../../src/core/types.js';
+
+function createMockSessionManager() {
+  return { listRunningSessions: () => [], getSession: () => null };
+}
+
+describe('Commitment auto-expiry API lifecycle', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let tracker: CommitmentTracker;
+  let server: AgentServer;
+  let app: ReturnType<AgentServer['getApp']>;
+  const AUTH = 'test-commitment-auto-expiry-e2e';
+  const now = new Date('2026-07-10T12:00:00.000Z');
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'commitment-auto-expiry-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), '{}');
+
+    const config: InstarConfig = {
+      projectName: 'commitment-auto-expiry-e2e',
+      projectDir: tmpDir,
+      stateDir,
+      port: 0,
+      authToken: AUTH,
+      requestTimeoutMs: 10000,
+      version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [],
+      monitoring: {},
+      updates: {},
+    } as InstarConfig;
+
+    tracker = new CommitmentTracker({
+      stateDir,
+      liveConfig: new LiveConfig(stateDir),
+      autoExpiry: { enabled: true, maxAgeDays: 21, sweepIntervalMs: 21_600_000, dryRun: false },
+    });
+    server = new AgentServer({
+      config,
+      sessionManager: createMockSessionManager() as any,
+      state: new StateManager(stateDir),
+      commitmentTracker: tracker,
+    });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    tracker.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/e2e/commitment-auto-expiry-api-lifecycle.test.ts',
+    });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}`, 'X-Instar-AgentId': 'commitment-auto-expiry-e2e' });
+
+  it('removes an auto-expired commitment from the active API view while preserving the record', async () => {
+    const created = await request(app)
+      .post('/commitments')
+      .set(auth())
+      .send({
+        type: 'one-time-action',
+        userRequest: 'Merge old PR when CI goes green',
+        agentResponse: 'I will merge when CI is green',
+        topicId: 458,
+      })
+      .expect(201);
+
+    const id = created.body.id;
+    const old = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    await tracker.mutate(id, c => ({ ...c, createdAt: old }));
+
+    expect(tracker.sweepAutoExpiry(now).expired).toBe(1);
+
+    const active = await request(app)
+      .get('/commitments?status=active')
+      .set(auth())
+      .expect(200);
+    expect(active.body.commitments.map((c: any) => c.id)).not.toContain(id);
+
+    const lookup = await request(app)
+      .get(`/commitments/${id}`)
+      .set(auth())
+      .expect(200);
+    expect(lookup.body.status).toBe('expired');
+    expect(lookup.body.resolution).toBe('auto-expired: aged out >21d, presumed completed-but-unclosed');
+  });
+});

--- a/tests/integration/commitment-auto-expiry-lifecycle.test.ts
+++ b/tests/integration/commitment-auto-expiry-lifecycle.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CommitmentTracker } from '../../src/monitoring/CommitmentTracker.js';
+import { LiveConfig } from '../../src/config/LiveConfig.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('CommitmentTracker auto-expiry lifecycle', () => {
+  let dir: string | null = null;
+
+  afterEach(() => {
+    if (dir) {
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/integration/commitment-auto-expiry-lifecycle.test.ts',
+      });
+    }
+    dir = null;
+  });
+
+  it('persists expired commitments and reloads them as inactive terminal records', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'commitment-auto-expiry-int-'));
+    fs.mkdirSync(path.join(dir, 'state'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'config.json'), '{}');
+    const now = new Date('2026-07-10T12:00:00.000Z');
+    const old = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+    const first = new CommitmentTracker({
+      stateDir: dir,
+      liveConfig: new LiveConfig(dir),
+      autoExpiry: { enabled: true, maxAgeDays: 21, sweepIntervalMs: 21_600_000, dryRun: false },
+    });
+    const c = first.record({
+      type: 'one-time-action',
+      userRequest: 'merge when green',
+      agentResponse: 'I will merge it when CI is green',
+    });
+    await first.mutate(c.id, cur => ({ ...cur, createdAt: old }));
+
+    const report = first.sweepAutoExpiry(now);
+    expect(report.expired).toBe(1);
+
+    const second = new CommitmentTracker({
+      stateDir: dir,
+      liveConfig: new LiveConfig(dir),
+      autoExpiry: { enabled: true, maxAgeDays: 21, sweepIntervalMs: 21_600_000, dryRun: false },
+    });
+    expect(second.get(c.id)?.status).toBe('expired');
+    expect(second.getActive().map(active => active.id)).not.toContain(c.id);
+    expect(second.sweepAutoExpiry(now).expired).toBe(0);
+  });
+});

--- a/tests/unit/CommitmentTracker-auto-expiry.test.ts
+++ b/tests/unit/CommitmentTracker-auto-expiry.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CommitmentTracker } from '../../src/monitoring/CommitmentTracker.js';
+import { LiveConfig } from '../../src/config/LiveConfig.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { applyDefaults, getMigrationDefaults } from '../../src/config/ConfigDefaults.js';
+
+function createTmpState(): { stateDir: string; cleanup: () => void } {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'commitment-auto-expiry-'));
+  fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'config.json'), '{}');
+  return {
+    stateDir,
+    cleanup: () => SafeFsExecutor.safeRmSync(stateDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/CommitmentTracker-auto-expiry.test.ts',
+    }),
+  };
+}
+
+function tracker(stateDir: string, dryRun = false): CommitmentTracker {
+  return new CommitmentTracker({
+    stateDir,
+    liveConfig: new LiveConfig(stateDir),
+    autoExpiry: { enabled: true, maxAgeDays: 21, sweepIntervalMs: 21_600_000, dryRun },
+  });
+}
+
+function daysBefore(base: Date, days: number): string {
+  return new Date(base.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+async function ageCommitment(t: CommitmentTracker, id: string, createdAt: string): Promise<void> {
+  await t.mutate(id, c => ({ ...c, createdAt }));
+}
+
+function isStoreWrite(p: unknown): boolean {
+  return typeof p === 'string' && /commitments\.json\.\d+\.tmp$/.test(p);
+}
+
+describe('CommitmentTracker auto-expiry sweep', () => {
+  let stateDir: string;
+  let cleanup: () => void;
+  const now = new Date('2026-07-10T12:00:00.000Z');
+
+  beforeEach(() => {
+    ({ stateDir, cleanup } = createTmpState());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it('expires an agent-owned old pending commitment with the rollout resolution note', async () => {
+    const t = tracker(stateDir);
+    const c = t.record({ type: 'one-time-action', userRequest: 'merge old PR', agentResponse: 'will do it' });
+    await ageCommitment(t, c.id, daysBefore(now, 30));
+
+    const report = t.sweepAutoExpiry(now);
+
+    expect(report).toMatchObject({ eligible: 1, expired: 1, dryRun: false, capped: false });
+    expect(t.get(c.id)).toMatchObject({
+      status: 'expired',
+      resolution: 'auto-expired: aged out >21d, presumed completed-but-unclosed',
+      resolvedAt: now.toISOString(),
+    });
+  });
+
+  it('never expires user-owned old commitments', async () => {
+    const t = tracker(stateDir);
+    const c = t.record({
+      type: 'one-time-action',
+      userRequest: 'user owes input',
+      agentResponse: 'waiting',
+      owner: 'user',
+    });
+    await ageCommitment(t, c.id, daysBefore(now, 30));
+
+    const report = t.sweepAutoExpiry(now);
+
+    expect(report.eligible).toBe(0);
+    expect(t.get(c.id)?.status).toBe('pending');
+  });
+
+  it('does not expire young agent-owned commitments', async () => {
+    const t = tracker(stateDir);
+    const c = t.record({ type: 'one-time-action', userRequest: 'fresh follow-up', agentResponse: 'will do it' });
+    await ageCommitment(t, c.id, daysBefore(now, 5));
+
+    const report = t.sweepAutoExpiry(now);
+
+    expect(report.eligible).toBe(0);
+    expect(t.get(c.id)?.status).toBe('pending');
+  });
+
+  it('does not expire old agent commitments with an unmet future hard deadline', async () => {
+    const t = tracker(stateDir);
+    const c = t.record({
+      type: 'one-time-action',
+      userRequest: 'wait for scheduled cutover',
+      agentResponse: 'will do it by the deadline',
+      hardDeadlineAt: new Date(now.getTime() + 24 * 60 * 60 * 1000).toISOString(),
+    });
+    await ageCommitment(t, c.id, daysBefore(now, 30));
+
+    const report = t.sweepAutoExpiry(now);
+
+    expect(report.eligible).toBe(0);
+    expect(t.get(c.id)?.status).toBe('pending');
+  });
+
+  it('dry-runs by logging eligibility without mutating', async () => {
+    const t = tracker(stateDir, true);
+    const c = t.record({ type: 'one-time-action', userRequest: 'old dry-run', agentResponse: 'will do it' });
+    await ageCommitment(t, c.id, daysBefore(now, 30));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const report = t.sweepAutoExpiry(now);
+
+    expect(report).toMatchObject({ dryRun: true, eligible: 1, expired: 0 });
+    expect(t.get(c.id)?.status).toBe('pending');
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]?.[0]).toContain('eligible=1 expired=0 dryRun=true');
+  });
+
+  it('is idempotent: the second non-dry-run sweep over the same state changes nothing', async () => {
+    const t = tracker(stateDir);
+    const c = t.record({ type: 'one-time-action', userRequest: 'old once', agentResponse: 'will do it' });
+    await ageCommitment(t, c.id, daysBefore(now, 30));
+
+    const first = t.sweepAutoExpiry(now);
+    const second = t.sweepAutoExpiry(now);
+
+    expect(first.expired).toBe(1);
+    expect(second.expired).toBe(0);
+    expect(second.eligible).toBe(0);
+    expect(t.get(c.id)?.status).toBe('expired');
+  });
+
+  it('coalesces auto-expiry store persistence to one write per sweep', async () => {
+    const t = tracker(stateDir);
+    for (let i = 0; i < 12; i++) {
+      const c = t.record({ type: 'one-time-action', userRequest: `old ${i}`, agentResponse: 'will do it' });
+      await ageCommitment(t, c.id, daysBefore(now, 30));
+    }
+
+    const realWrite = fs.writeFileSync.bind(fs);
+    let storeWrites = 0;
+    const spy = vi.spyOn(fs, 'writeFileSync').mockImplementation(((p: any, ...rest: any[]) => {
+      if (isStoreWrite(p)) storeWrites++;
+      return (realWrite as any)(p, ...rest);
+    }) as typeof fs.writeFileSync);
+
+    t.sweepAutoExpiry(now);
+
+    spy.mockRestore();
+    expect(storeWrites).toBe(1);
+  });
+
+  it('backfills commitment auto-expiry defaults without overwriting operator choices', () => {
+    const config: Record<string, unknown> = {
+      commitments: { autoExpiry: { dryRun: false, maxAgeDays: 45 } },
+    };
+    const { patched, changes } = applyDefaults(config, getMigrationDefaults('managed-project'));
+
+    expect(patched).toBe(true);
+    expect((config.commitments as any).autoExpiry).toMatchObject({
+      enabled: true,
+      maxAgeDays: 45,
+      sweepIntervalMs: 21_600_000,
+      dryRun: false,
+    });
+    expect(changes).toContain('commitments.autoExpiry.enabled (added)');
+    expect(changes).toContain('commitments.autoExpiry.sweepIntervalMs (added)');
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -421,9 +421,14 @@ describe('lint-dev-agent-dark-gate', () => {
       '1358': 'multiMachine.sessionPool.inboundQueue.enabled',
       '1387': 'multiMachine.sessionPool.holdForStability.enabled',
       '1582': 'multiMachine.stateSync.threadlinePairing.enabled',
-      '1723': 'cartographer.freshnessSweep.enabled',
-      '1768': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1793': 'cartographer.subtreeNav.llmRerank.enabled',
+      // commitment-auto-expiry (2026-07-10): a 6-line `commitments.autoExpiry`
+      // default sub-block was inserted above `promiseBeacon`/`cartographer`.
+      // Its `enabled: true` literal is an explicit fleet-on default, not a dark
+      // default, so it adds NO attributed dark-gate row; it shifts the cartographer
+      // `enabled: false` rows below it DOWN by +6.
+      '1729': 'cartographer.freshnessSweep.enabled',
+      '1774': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1799': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/upgrades/eli16/commitment-auto-expiry.md
+++ b/upgrades/eli16/commitment-auto-expiry.md
@@ -1,0 +1,19 @@
+# ELI16 — Commitment Auto-Expiry
+
+## What Changed
+
+The commitment tracker now has a quiet cleanup loop for old agent-owned commitments. If an agent promised to follow up, the promise stayed open forever unless another part of the system explicitly closed it. That was fine when there were a few commitments, but the live store now has hundreds of stale agent-owned rows that were probably completed weeks ago and never marked closed. The result is a backlog where the important current promises are mixed with old noise.
+
+This change adds `commitments.autoExpiry`, enabled by default but shipped in `dryRun: true`. The default policy is simple: after 21 days, an open agent-owned commitment with no future hard deadline is eligible to move to the existing terminal `expired` state. User-owned commitments are never touched. Young commitments are never touched. A commitment with an unmet future hard deadline is never touched.
+
+## Why It Is Safe
+
+The cleanup uses the existing terminal status instead of inventing a new lifecycle. The sweep is bounded to 500 commitments per pass and uses the tracker's existing batched-save discipline, so a large first cleanup does not write the whole commitments file once per row. In dry-run mode it only logs the aggregate count it would expire.
+
+The rollout is deliberately conservative. Existing agents receive the config defaults through the normal add-missing migration path, but `dryRun` remains true until an operator flips it. That means the first release proves the candidates and log shape before any live store mutation happens.
+
+## How To Verify
+
+The focused tests create old and young commitments, agent-owned and user-owned commitments, and future-deadline commitments. Only the old agent-owned open row expires. The dry-run test proves the row is not mutated. The idempotency test proves a second sweep over the same state changes zero rows. The write-coalescing test proves twelve expirations produce exactly one commitments-store write for the sweep.
+
+Integration and e2e tests reload the tracker and hit the commitments API after expiry. The expired record is still inspectable, but it disappears from the active commitment view.

--- a/upgrades/next/commitment-auto-expiry.md
+++ b/upgrades/next/commitment-auto-expiry.md
@@ -1,0 +1,26 @@
+# Commitment auto-expiry
+
+## What Changed
+
+Commitment auto-expiry addresses the live backlog shape from 2026-07-10: 652 open commitments, 626 agent-owned and older than 7 days, mostly completed work that was never explicitly closed. `CommitmentTracker` now has a bounded periodic sweep controlled by `commitments.autoExpiry` (`enabled:true`, `maxAgeDays:21`, `sweepIntervalMs:21600000`, `dryRun:true` by default). It targets only old agent-owned open commitments, never `owner:"user"`, never young commitments, and never a commitment with an unmet future `hardDeadlineAt`. Eligible rows move through the existing terminal `expired` state with resolution `auto-expired: aged out >Nd, presumed completed-but-unclosed`.
+
+The sweep copies the existing verify-sweep write discipline: every per-commitment transition marks the store dirty under `batchingSaves`, then flushes exactly one commitments-store write at the end. It is capped at 500 expirations per pass and logs one aggregate line per sweep (`scanned`, `eligible`, `expired`, `dryRun`, `maxAgeDays`, `capped`) rather than one line per row. Dry-run mode logs eligibility without mutating, so this release proves the candidate count and log shape before any cleanup is armed.
+
+## What to Tell Your User
+
+- Old agent-owned follow-up promises now have a cleanup path. By default the system only reports how many stale rows it would expire; when dry-run is later turned off, it will close old agent-owned commitments automatically instead of letting the backlog drown current promises.
+- The cleanup is deliberately conservative: it never touches commitments owned by you, never touches recent commitments, and respects future hard deadlines. The first live cleanup after promotion is expected to catch the existing stale backlog in capped batches and report one aggregate count.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|---|---|
+| Commitment auto-expiry dry run | Config defaults enable the sweep in dry-run mode; watch the aggregate `CommitmentTracker` sweep log |
+| Stale commitment cleanup promotion | Turn off `commitments.autoExpiry.dryRun` after reviewing dry-run counts; rows expire through the existing terminal `expired` state |
+
+## Evidence
+
+- Tier 1: `tests/unit/CommitmentTracker-auto-expiry.test.ts` (8 tests — old agent-owned pending expires; user-owned old row does not; young row does not; future hard deadline does not; dry-run logs without mutation; second sweep is idempotent; persistence coalesces to one store write; ConfigDefaults add-missing migration preserves operator choices).
+- Tier 2: `tests/integration/commitment-auto-expiry-lifecycle.test.ts` (persist expired row, reload tracker, verify it is terminal/inactive and a second sweep changes zero rows).
+- Tier 3: `tests/e2e/commitment-auto-expiry-api-lifecycle.test.ts` (real AgentServer commitments API: expired row disappears from active view but remains inspectable with the auto-expiry resolution).
+- Regression sweep: `tests/unit/CommitmentTracker.test.ts`, `tests/unit/CommitmentTracker-verify-batches-saves.test.ts`, `tests/unit/ConfigDefaults.test.ts`, and `npx tsc --noEmit` are green.

--- a/upgrades/side-effects/commitment-auto-expiry.md
+++ b/upgrades/side-effects/commitment-auto-expiry.md
@@ -1,0 +1,108 @@
+# Side-Effects Review — Commitment auto-expiry
+
+**Version / slug:** `commitment-auto-expiry`
+**Date:** `2026-07-10`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+This change adds a bounded auto-expiry sweep to `src/monitoring/CommitmentTracker.ts`, configures it through top-level `commitments.autoExpiry`, and wires the server construction path to pass that config into the tracker. The sweep targets stale agent-owned open commitments only, uses the existing `expired` terminal state, preserves user-owned commitments, respects future hard deadlines, ships dry-run-first, and coalesces all per-commitment persistence into one store write per sweep. Tests cover unit, integration, and e2e paths.
+
+## Decision-point inventory
+
+- `CommitmentTracker.sweepAutoExpiry` — add — decides whether a commitment is eligible for terminal expiry based on owner, status, age, and future hard deadline.
+- `CommitmentTracker.expire` / `expireSync` — add/modify — centralizes the existing expired-state transition so old `expiresAt` expiry and new auto-expiry use one terminal transition helper.
+- `ConfigDefaults.commitments.autoExpiry` — add — defaults the sweep on, 21-day age, 6-hour cadence, dry-run true.
+
+---
+
+## 1. Over-block
+
+The only possible over-close shape is an old agent-owned open commitment that is still genuinely active but has no hard future deadline recorded. This is why the feature ships with `dryRun: true`: the first rollout logs aggregate eligibility without changing rows. The hard guardrails are also narrow: owner must be exactly `agent`, status must be open (`pending` or `violated`), age must exceed the configured threshold, and a future `hardDeadlineAt` blocks expiry.
+
+User-owned commitments are never eligible. Young commitments are never eligible. Terminal commitments are never eligible.
+
+---
+
+## 2. Under-block
+
+The sweep intentionally misses stale commitments that are marked `verified`, because `verified` is treated as a non-open status for this cleanup even though some old stores may still show it in active-ish views. It also misses old user-owned commitments, old rows with malformed `createdAt`, and old rows with a future hard deadline even if that deadline is probably obsolete. Those are deliberate safety choices for the first rollout.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. `CommitmentTracker` owns the lifecycle state, terminal status semantics, persistence batching, and active-record filtering. Putting the cleanup in an external job would either duplicate those invariants or risk writing the store by hand. The sweep is a mechanical lifecycle policy, not an LLM judgment; it uses explicit structured fields only.
+
+---
+
+## 4. Signal vs authority compliance
+
+- [x] No — this change has no block/allow surface.
+
+The sweep does hold lifecycle authority over a narrow state transition, but it does not block a user, tool, message, or operation. It converts stale structured records to the existing terminal `expired` state. The first release runs in dry-run mode, and the live transition requires an operator config flip.
+
+---
+
+## 5. Interactions
+
+- **Existing `expiresAt` expiry:** still runs inside `verify()` and now routes through `expireSync`, preserving behavior while centralizing the terminal transition.
+- **Write coalescing:** auto-expiry uses the same `batchingSaves` / `pendingSave` pattern documented for the verify sweep. A test asserts twelve expirations produce exactly one commitments-store write.
+- **PromiseBeacon and active views:** expired commitments are terminal; existing active filters already exclude `expired`, so no new filtering contract is needed.
+- **Startup timing:** an initial sweep is scheduled shortly after tracker start, then every configured interval. `stop()` clears both the initial timeout and recurring interval.
+- **Dry-run logs:** the sweep emits one aggregate log line per pass. It does not log per commitment.
+
+---
+
+## 6. External surfaces
+
+- **Config:** new top-level `commitments.autoExpiry` block: `enabled`, `maxAgeDays`, `sweepIntervalMs`, `dryRun`.
+- **Persistent state:** when `dryRun:false`, eligible commitments move to `status:"expired"` with resolution `auto-expired: aged out >Nd, presumed completed-but-unclosed`.
+- **API reads:** active commitment API views shrink after expiry because they already exclude terminal expired rows. Individual records remain inspectable.
+- **Operator surface:** no new operator action or dashboard form. Operators can tune the config through the existing config path.
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated when commitments replication is enabled, otherwise local to the agent store.** The sweep mutates the canonical commitments store through the tracker transition path, so the existing Commitments Coherence replication machinery sees the same terminal-state mutation as any other commitment lifecycle change. It emits no user-facing notices, generates no URLs, and holds no machine-specific runtime state beyond timer handles. If multiple machines run the same agent with replicated commitments, the first machine to expire a row moves it terminal and later sweeps see it as ineligible, making the operation idempotent.
+
+---
+
+## 8. Rollback cost
+
+Low. The shipped default is dry-run, so rollback before promotion is a code/config revert with no data repair. After a future `dryRun:false` promotion, rollback stops future expiry but does not reopen already-expired commitments; that is acceptable because the transition is intentionally terminal and inspectable. If an operator needs to reverse a specific row, they can use existing commitment mutation tools rather than a schema migration.
+
+---
+
+## Conclusion
+
+The change directly addresses commitment backlog rot while preserving the safety floor: dry-run-first rollout, strict owner/age/deadline eligibility, one aggregate log line, bounded 500-row passes, and exactly one store write per sweep. No material side-effect concern remains for the initial dry-run release.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required
+**Independent read of the artifact:** not required for this Tier-1 dry-run-first lifecycle cleanup.
+
+---
+
+## Evidence pointers
+
+- `npx tsc --noEmit`
+- `npx vitest run tests/unit/CommitmentTracker-auto-expiry.test.ts tests/integration/commitment-auto-expiry-lifecycle.test.ts tests/e2e/commitment-auto-expiry-api-lifecycle.test.ts`
+- `npx vitest run tests/unit/CommitmentTracker.test.ts tests/unit/CommitmentTracker-verify-batches-saves.test.ts tests/unit/ConfigDefaults.test.ts`
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable. The new self-triggered loop has an explicit convergence bound: disabled by config, dry-run by default, one initial timeout plus one recurring interval, max 500 state transitions per pass, one aggregate log line, no per-item user-facing output, and one coalesced persistence write per sweep. Guard evidence: `tests/unit/CommitmentTracker-auto-expiry.test.ts` covers dry-run zero mutation, idempotent second sweep, and one-write batching.


### PR DESCRIPTION
## ELI16 — Commitment auto-expiry

The commitment tracker now has a conservative cleanup loop for stale agent-owned promises. The live store had hundreds of old agent-owned commitments that were probably completed but never explicitly closed, so current commitments were buried under old noise. This PR adds an enabled-by-default but dry-run-first sweep: after 21 days, an open agent-owned commitment with no future hard deadline is eligible to move through the existing terminal `expired` status. It never touches user-owned commitments, never touches young commitments, and never touches commitments with an unmet future hard deadline. The sweep is capped at 500 rows per pass, emits one aggregate log line, and uses the existing batched-save discipline so a large cleanup writes the commitments store once per pass instead of once per expired row.

## What Changed

- Added `commitments.autoExpiry` defaults: enabled, 21-day max age, 6-hour sweep interval, dry-run true.
- Wired the server to pass auto-expiry config into `CommitmentTracker`.
- Added `sweepAutoExpiry()` plus a shared expired-state transition helper.
- Scheduled an initial sweep after tracker start and recurring sweeps afterward.
- Added unit, integration, and e2e coverage plus instar-dev artifacts and release-note fragment.

## Evidence

- `npx tsc --noEmit` — clean.
- `npx vitest run tests/unit/CommitmentTracker-auto-expiry.test.ts tests/integration/commitment-auto-expiry-lifecycle.test.ts tests/e2e/commitment-auto-expiry-api-lifecycle.test.ts` — 10 tests passed.
- `npx vitest run tests/unit/CommitmentTracker.test.ts tests/unit/CommitmentTracker-verify-batches-saves.test.ts tests/unit/ConfigDefaults.test.ts` — 115 tests passed.
- Commit hook ran full `npm run lint` plus instar-dev precommit successfully.
- `npm run check:upgrade-guide` passed for v1.3.802 with existing historical warnings only.
- Local pre-push affected-test listing timed out and delegated smoke to CI; unrelated Threadline scoped e2e hit a pre-existing sqlite FTS setup failure, so push used `INSTAR_PRE_PUSH_E2E_SKIP=1` per the hook's own instruction; CI remains authority.

## Rollout / Safety

Ships in dry-run mode. A non-dry-run first sweep naturally catches the existing stale backlog in capped batches and reports the aggregate count. Second sweep over the same state is idempotent: zero additional expirations.
