### PR TITLE
fix(replication): index replicated witness lookup

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-10T21-38-31-000Z-replicated-witness-index.json
+++ b/.instar/instar-dev-decisions/2026-07-10T21-38-31-000Z-replicated-witness-index.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-10T21:38:31.000Z",
+  "slug": "replicated-witness-index",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [
+    "performance-only derived index for existing replicated-store witness seam",
+    "no new authority, route, config, persistent schema, or external operation",
+    "shared-infra blast radius mitigated by parity fallback and unit/integration/e2e coverage"
+  ],
+  "belowFloor": false,
+  "files": 10,
+  "loc": 0,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-10T21-40-00-552Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-10T21-40-00-552Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-10T21:40:00.552Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 266,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-10T21-38-31-000Z-replicated-witness-index.json
+++ b/.instar/instar-dev-traces/2026-07-10T21-38-31-000Z-replicated-witness-index.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "sessionId": "telegram-458-replicated-witness-index",
+  "timestamp": "2026-07-10T21:38:31.000Z",
+  "artifactPath": "upgrades/side-effects/replicated-witness-index.md",
+  "artifactSha256": "adac4ede30eb8aa3ebaf043bc06589b690d0c74012c08fc5f38daa65c522462d",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/core/CoherenceJournal.ts",
+    "src/core/JournalSyncApplier.ts",
+    "src/core/ReplicatedPeerStreamReader.ts",
+    "tests/e2e/replicated-witness-index-lifecycle.test.ts",
+    "tests/integration/replicated-witness-index.integration.test.ts",
+    "tests/unit/ReplicatedPeerStreamReader.test.ts",
+    "upgrades/eli16/replicated-witness-index.md",
+    "upgrades/next/replicated-witness-index.md",
+    "upgrades/side-effects/replicated-witness-index.md"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Performance-only shared-infra optimization for an existing replicated-store witness seam. No new authority, route, config, persisted schema, or external operation. The index is derived/rebuildable, updated only after durable append boundaries, and parity-falls-back to the legacy scan on mismatch. Blast radius is shared replicated-store infra, so validation includes unit, integration, and e2e lifecycle coverage.",
+  "eli16Path": "upgrades/eli16/replicated-witness-index.md",
+  "sideEffectsPath": "upgrades/side-effects/replicated-witness-index.md",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4457,6 +4457,13 @@ export async function startServer(options: StartOptions): Promise<void> {
           stateDir: config.stateDir,
           registry: replicatedKindRegistry,
           selfMachineId: cjOwnMachineId,
+          logger: (m) => console.log(pc.dim(`  [ws2-witness-index] ${m}`)),
+        });
+        coherenceJournal.setReplicatedRecordCommitObserver((kind, entries) => {
+          replicatedPeerStreamReader?.observeCommittedEntries(kind, entries);
+        });
+        journalSyncApplier?.setReplicatedRecordCommitObserver((_senderMachineId, kind, entries) => {
+          replicatedPeerStreamReader?.observeCommittedEntries(kind, entries);
         });
 
         // Author-side HLC clock — persisted under the journal dir (atomic temp+rename)

--- a/src/core/CoherenceJournal.ts
+++ b/src/core/CoherenceJournal.ts
@@ -375,6 +375,12 @@ export interface CoherenceJournalConfig {
   /** Optional logger; called once per failure class. */
   logger?: (msg: string) => void;
   /**
+   * Optional derived-index observer for replicated records. Called only after a
+   * replicated-kind batch has been written and fdatasync has returned, so callers
+   * never witness data that is merely queued in memory.
+   */
+  onReplicatedRecordsCommitted?: (kind: JournalKind, entries: JournalEntry[]) => void;
+  /**
    * Optional fs seam for fault-injection tests (wedge the flusher). Defaults to
    * node:fs primitives. Only the primitives the flusher uses are seamed.
    */
@@ -498,6 +504,7 @@ export class CoherenceJournal {
   private readonly guardWrite?: (filePath: string) => void;
   private readonly now: () => Date;
   private readonly logger?: (msg: string) => void;
+  private replicatedCommitObserver?: (kind: JournalKind, entries: JournalEntry[]) => void;
   private readonly io: JournalFs;
   /**
    * The replicated-kind registry (WS2 send-side). Injected via
@@ -620,6 +627,7 @@ export class CoherenceJournal {
     this.guardWrite = config.guardWrite;
     this.now = config.now ?? (() => new Date());
     this.logger = config.logger;
+    this.replicatedCommitObserver = config.onReplicatedRecordsCommitted;
     this.io = config.fsImpl ?? realFs();
     const initMs = this.now().getTime();
     this.rateBuckets = {
@@ -815,6 +823,15 @@ export class CoherenceJournal {
    */
   setReplicatedKindRegistry(registry: ReplicatedKindRegistry | undefined): void {
     this.replicatedRegistry = registry;
+  }
+
+  /**
+   * Attach/replace the derived-index observer after boot wiring has constructed
+   * the reader. This observer is NOT authoritative: the journal remains the source
+   * of truth and the observer can always rebuild from disk.
+   */
+  setReplicatedRecordCommitObserver(observer: ((kind: JournalKind, entries: JournalEntry[]) => void) | undefined): void {
+    this.replicatedCommitObserver = observer;
   }
 
   /**
@@ -1232,6 +1249,7 @@ export class CoherenceJournal {
           const top = appended[appended.length - 1].seq;
           this.highWaterSeq[kind] = Math.max(this.highWaterSeq[kind], top);
           this.persistMeta();
+          this.notifyReplicatedRecordsCommitted(kind, appended);
         }
       }
     } catch (e) { /* @silent-fallback-ok: journal observability must never endanger the observed operation (COHERENCE-JOURNAL-SPEC §3.1) */
@@ -1239,6 +1257,24 @@ export class CoherenceJournal {
       this.log('flush', `[coherence-journal] flush failed (swallowed): ${(e as Error)?.message}`);
     } finally {
       this.flushing = false;
+    }
+  }
+
+  private notifyReplicatedRecordsCommitted(kind: JournalKind, appended: QueuedEntry[]): void {
+    if (!this.replicatedRegistry?.isReplicatedKind(kind) || !this.replicatedCommitObserver) return;
+    const entries: JournalEntry[] = [];
+    for (const it of appended) {
+      try {
+        const entry = JSON.parse(it.line) as JournalEntry;
+        if (entry && entry.kind === kind && typeof entry.seq === 'number') entries.push(entry);
+      } catch { /* @silent-fallback-ok: observer notification is derived-index maintenance; the durable journal line remains authoritative and can be rebuilt from disk. */
+      }
+    }
+    if (entries.length === 0) return;
+    try {
+      this.replicatedCommitObserver(kind, entries);
+    } catch (e) { /* @silent-fallback-ok: derived-index observer failure must never endanger journal durability; reader parity/rebuild falls back to the authoritative stream. */
+      this.log('replicated-commit-observer', `[coherence-journal] replicated commit observer failed for ${kind}: ${(e as Error)?.message}`);
     }
   }
 

--- a/src/core/JournalSyncApplier.ts
+++ b/src/core/JournalSyncApplier.ts
@@ -211,6 +211,12 @@ export interface JournalSyncApplierConfig {
    * journal writer + the stateSyncReceive advert read (one source of truth).
    */
   replicatedRegistry?: ReplicatedKindRegistry;
+  /**
+   * Optional derived-index observer for replicated records. Called only after a
+   * peer replica batch has been written and fdatasync has returned, so the index
+   * tracks durable bytes, never uncommitted inbound data.
+   */
+  onReplicatedRecordsCommitted?: (senderMachineId: string, kind: JournalKind, entries: JournalEntry[]) => void;
 }
 
 function realFs(): JournalFs {
@@ -246,6 +252,7 @@ export class JournalSyncApplier {
    *  applier is constructed before the registry is populated (server.ts boot order);
    *  the config option is for tests that have the registry up front. */
   private replicatedRegistry?: ReplicatedKindRegistry;
+  private replicatedCommitObserver?: (senderMachineId: string, kind: JournalKind, entries: JournalEntry[]) => void;
 
   /** In-memory meta cache per peer machine (keyed by RAW machineId). */
   private metaCache = new Map<string, PeerMeta>();
@@ -272,6 +279,7 @@ export class JournalSyncApplier {
     this.io = config.fsImpl ?? realFs();
     this.maxEntryBytes = config.maxEntryBytes ?? APPLIER_MAX_ENTRY_BYTES;
     this.replicatedRegistry = config.replicatedRegistry;
+    this.replicatedCommitObserver = config.onReplicatedRecordsCommitted;
   }
 
   /** The per-entry byte cap for a kind — RAISED for replicated `*-record` kinds so
@@ -292,6 +300,15 @@ export class JournalSyncApplier {
    *  validates + applies instead of suspect-flagging the stream. Idempotent. */
   setReplicatedKindRegistry(registry: ReplicatedKindRegistry | undefined): void {
     this.replicatedRegistry = registry;
+  }
+
+  /**
+   * Attach/replace the derived-index observer after boot wiring has constructed
+   * the peer-stream reader. The replica files remain authoritative; this observer
+   * is only an incremental cache update.
+   */
+  setReplicatedRecordCommitObserver(observer: ((senderMachineId: string, kind: JournalKind, entries: JournalEntry[]) => void) | undefined): void {
+    this.replicatedCommitObserver = observer;
   }
 
   // ---- advert state (for delta requests) ---------------------------------
@@ -830,8 +847,27 @@ export class JournalSyncApplier {
     if (committed > 0) {
       this.degradation.applied += committed;
       result.applied += committed;
+      this.notifyReplicatedRecordsCommitted(senderMachineId, kind, lines.slice(0, committed));
     }
     return committed;
+  }
+
+  private notifyReplicatedRecordsCommitted(senderMachineId: string, kind: JournalKind, lines: string[]): void {
+    if (!this.replicatedRegistry?.isReplicatedKind(kind) || !this.replicatedCommitObserver) return;
+    const entries: JournalEntry[] = [];
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as JournalEntry;
+        if (entry && entry.kind === kind && typeof entry.seq === 'number') entries.push(entry);
+      } catch { /* @silent-fallback-ok: observer notification is derived-index maintenance; replica files remain authoritative and rebuildable. */
+      }
+    }
+    if (entries.length === 0) return;
+    try {
+      this.replicatedCommitObserver(senderMachineId, kind, entries);
+    } catch (e) { /* @silent-fallback-ok: derived-index observer failure must never endanger replica durability or ack accounting; parity/rebuild falls back to disk. */
+      this.log('replicated-commit-observer', `[journal-sync] replicated commit observer failed for ${kind}: ${(e as Error)?.message}`);
+    }
   }
 
   // ---- SERVE side (§3.4 rule 5/7 — own stream only, durably-flushed only) -

--- a/src/core/ReplicatedPeerStreamReader.ts
+++ b/src/core/ReplicatedPeerStreamReader.ts
@@ -31,6 +31,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
 
 import {
   type JournalFs,
@@ -44,6 +45,7 @@ import {
   validateReplicatedEnvelope,
   type ReplicatedKindRegistry,
   type EnvelopeValidationCounters,
+  type StoreFieldSchema,
 } from './ReplicatedRecordEnvelope.js';
 import type { OriginRecord } from './UnionReader.js';
 import type { RawJournalEntry } from './StoreSnapshot.js';
@@ -59,6 +61,19 @@ const NOOP_COUNTERS: EnvelopeValidationCounters = {
   bumpJailReject: () => {},
 };
 
+const STREAM_CHUNK_BYTES = 64 * 1024;
+const WITNESS_KEY_SEPARATOR = '\u0000';
+
+interface WitnessIndexEntry {
+  hlc: HlcTimestamp;
+}
+
+interface RegisteredStreamRecord {
+  store: string;
+  recordKey: string;
+  hlc: HlcTimestamp;
+}
+
 export interface ReplicatedPeerStreamReaderConfig {
   /** Absolute path to the agent's `.instar/` directory (the stateDir). */
   stateDir: string;
@@ -68,6 +83,8 @@ export interface ReplicatedPeerStreamReaderConfig {
   selfMachineId: string;
   /** Optional fs seam for fault-injection tests. Defaults to node:fs. */
   fsImpl?: JournalFs;
+  /** Optional logger for parity/index degradation. */
+  logger?: (msg: string) => void;
 }
 
 function realFs(): JournalFs {
@@ -105,6 +122,10 @@ export class ReplicatedPeerStreamReader {
   private readonly registry: ReplicatedKindRegistry;
   private readonly selfMachineId: string;
   private readonly io: JournalFs;
+  private readonly logger?: (msg: string) => void;
+  private witnessIndexTrusted = true;
+  private readonly witnessIndex = new Map<string, WitnessIndexEntry>();
+  private loggedWitnessParityMismatch = false;
 
   constructor(config: ReplicatedPeerStreamReaderConfig) {
     if (!config) throw new Error('ReplicatedPeerStreamReader: config required');
@@ -116,6 +137,8 @@ export class ReplicatedPeerStreamReader {
     this.registry = config.registry;
     this.selfMachineId = config.selfMachineId;
     this.io = config.fsImpl ?? realFs();
+    this.logger = config.logger;
+    this.rebuildWitnessIndex();
   }
 
   // ── The ReplicatedStoreReader seams ────────────────────────────────────────
@@ -148,6 +171,12 @@ export class ReplicatedPeerStreamReader {
    * resolving (§7.2 err-toward-flag).
    */
   loadWitness(store: string, recordKey: string): HlcTimestamp | undefined {
+    if (this.witnessIndexTrusted) {
+      return this.witnessIndex.get(this.witnessKey(store, recordKey))?.hlc;
+    }
+    // Parity safety valve: if the derived index ever disagrees with a legacy
+    // scan during rebuild, serve the old full-scan answer until a later rebuild
+    // restores parity.
     const records = this.loadOriginRecords(store, recordKey);
     let max: HlcTimestamp | undefined;
     for (const r of records) {
@@ -156,6 +185,45 @@ export class ReplicatedPeerStreamReader {
       }
     }
     return max;
+  }
+
+  /**
+   * Incrementally update the DERIVED witness index after replicated entries have
+   * crossed a durability boundary. The journal/replica streams remain the source
+   * of truth; crash/loss simply rebuilds this map from disk.
+   */
+  observeCommittedEntries(kind: JournalKind, entries: JournalEntry[]): void {
+    const reg = this.registry.getByKind(kind);
+    if (!reg || entries.length === 0) return;
+    for (const entry of entries) {
+      const rec = this.validRegisteredRecord(reg.store, reg.schema, kind, entry);
+      if (!rec) continue;
+      this.putWitness(rec.store, rec.recordKey, rec.hlc, this.witnessIndex);
+    }
+  }
+
+  /** Rebuild the derived witness index from the journal streams and parity-check it. */
+  rebuildWitnessIndex(): void {
+    const next = new Map<string, WitnessIndexEntry>();
+    this.scanRegisteredStreams((rec) => {
+      this.putWitness(rec.store, rec.recordKey, rec.hlc, next);
+    });
+
+    const legacy = this.scanWitnessesLegacy();
+    if (!this.witnessMapsEqual(next, legacy)) {
+      this.witnessIndexTrusted = false;
+      this.witnessIndex.clear();
+      for (const [k, v] of next.entries()) this.witnessIndex.set(k, v);
+      if (!this.loggedWitnessParityMismatch) {
+        this.loggedWitnessParityMismatch = true;
+        this.logger?.('[replicated-peer-stream-reader] witness index parity mismatch; falling back to legacy scan until rebuild parity is restored');
+      }
+      return;
+    }
+
+    this.witnessIndexTrusted = true;
+    this.witnessIndex.clear();
+    for (const [k, v] of next.entries()) this.witnessIndex.set(k, v);
   }
 
   // ── The snapshot-serve seam (replaces loadOwnEntries: () => ({})) ──────────
@@ -239,6 +307,125 @@ export class ReplicatedPeerStreamReader {
       for (const e of read.entries) out.push(e);
     }
     return out;
+  }
+
+  private scanRegisteredStreams(visit: (record: RegisteredStreamRecord) => void): void {
+    for (const store of this.registry.stores()) {
+      const reg = this.registry.getByStore(store);
+      if (!reg) continue;
+      const kind = reg.kind as JournalKind;
+      const files = [
+        ...this.ownStreamFiles(this.selfMachineId, kind),
+        ...this.peerStreamFiles(kind),
+      ];
+      for (const file of files) {
+        this.forEachJournalEntryInFile(file, (entry) => {
+          const rec = this.validRegisteredRecord(store, reg.schema, kind, entry);
+          if (rec) visit(rec);
+        });
+      }
+    }
+  }
+
+  /**
+   * Legacy witness answer used only for parity mode. This intentionally uses the
+   * pre-index materializer so an attribution bug in the derived index is caught
+   * before the index is trusted.
+   */
+  private scanWitnessesLegacy(): Map<string, WitnessIndexEntry> {
+    const out = new Map<string, WitnessIndexEntry>();
+    for (const store of this.registry.stores()) {
+      for (const recordKey of this.materialize(store).keys()) {
+        const records = this.loadOriginRecords(store, recordKey);
+        for (const r of records) {
+          this.putWitness(store, recordKey, r.envelope.hlc, out);
+        }
+      }
+    }
+    return out;
+  }
+
+  private validRegisteredRecord(
+    store: string,
+    schema: StoreFieldSchema,
+    kind: JournalKind,
+    entry: JournalEntry,
+  ): RegisteredStreamRecord | null {
+    if (entry.kind !== kind) return null;
+    const data = entry.data;
+    if (!data || typeof data !== 'object') return null;
+    const result = validateReplicatedEnvelope(data as Record<string, unknown>, schema, NOOP_COUNTERS);
+    if (!result.ok) return null;
+    return {
+      store,
+      recordKey: result.envelope.recordKey,
+      hlc: result.envelope.hlc,
+    };
+  }
+
+  private putWitness(store: string, recordKey: string, hlc: HlcTimestamp, target: Map<string, WitnessIndexEntry>): void {
+    const key = this.witnessKey(store, recordKey);
+    const prior = target.get(key);
+    if (!prior || HybridLogicalClock.compare(hlc, prior.hlc) > 0) {
+      target.set(key, { hlc });
+    }
+  }
+
+  private witnessKey(store: string, recordKey: string): string {
+    return `${store}${WITNESS_KEY_SEPARATOR}${recordKey}`;
+  }
+
+  private witnessMapsEqual(a: Map<string, WitnessIndexEntry>, b: Map<string, WitnessIndexEntry>): boolean {
+    if (a.size !== b.size) return false;
+    for (const [key, av] of a.entries()) {
+      const bv = b.get(key);
+      if (!bv || HybridLogicalClock.compare(av.hlc, bv.hlc) !== 0) return false;
+    }
+    return true;
+  }
+
+  /** Stream a JSONL file forward in fixed chunks. Never materializes the file. */
+  private forEachJournalEntryInFile(filePath: string, visit: (entry: JournalEntry) => void): void {
+    if (!this.io.existsSync(filePath)) return;
+    let fd: number | null = null;
+    try {
+      fd = this.io.openSync(filePath, 'r');
+      const buf = Buffer.alloc(STREAM_CHUNK_BYTES);
+      const decoder = new StringDecoder('utf8');
+      let carry = '';
+      for (;;) {
+        const read = this.io.readSync(fd, buf, 0, buf.length, null);
+        if (read <= 0) break;
+        carry += decoder.write(buf.subarray(0, read));
+        let nl: number;
+        while ((nl = carry.indexOf('\n')) >= 0) {
+          const line = carry.slice(0, nl);
+          carry = carry.slice(nl + 1);
+          this.parseJournalLine(line, visit);
+        }
+      }
+      carry += decoder.end();
+      this.parseJournalLine(carry, visit);
+    } catch { /* @silent-fallback-ok: witness index is derived/rebuildable; unreadable streams are treated like absent witness and parity fallback can use the legacy scan. */
+      return;
+    } finally {
+      if (fd !== null) {
+        try {
+          this.io.closeSync(fd);
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+  }
+
+  private parseJournalLine(line: string, visit: (entry: JournalEntry) => void): void {
+    if (!line) return;
+    try {
+      const obj = JSON.parse(line) as JournalEntry;
+      if (typeof obj.seq === 'number' && typeof obj.kind === 'string') visit(obj);
+    } catch { /* @silent-fallback-ok: tolerant journal readers skip corrupt/torn lines; authoritative repair happens at the journal layer. */
+    }
   }
 
   // ── Path enumeration ───────────────────────────────────────────────────────

--- a/tests/e2e/replicated-witness-index-lifecycle.test.ts
+++ b/tests/e2e/replicated-witness-index-lifecycle.test.ts
@@ -1,0 +1,77 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { CoherenceJournal, type JournalEntry } from '../../src/core/CoherenceJournal.js';
+import { JournalSyncApplier, type ApplyBatchStream } from '../../src/core/JournalSyncApplier.js';
+import { LEARNING_KIND_REGISTRATION, LEARNING_RECORD_KIND, LEARNING_STORE_KEY, buildLearningRecordData, deriveLearningRecordKey } from '../../src/core/LearningsReplicatedStore.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { ReplicatedPeerStreamReader } from '../../src/core/ReplicatedPeerStreamReader.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { HlcTimestamp } from '../../src/core/HybridLogicalClock.js';
+import type { LearningEntry } from '../../src/core/types.js';
+
+const SELF = 'm_self';
+const PEER = 'm_peer';
+
+function registry(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(LEARNING_KIND_REGISTRATION);
+  return r;
+}
+
+function learning(): LearningEntry {
+  return {
+    id: 'LRN-E2E',
+    title: 'rebuild indexed witness',
+    category: 'ops',
+    description: 'rebuilds after memory loss',
+    source: { discoveredAt: '2026-07-10T00:00:00.000Z' },
+    tags: [],
+    applied: false,
+  };
+}
+
+function hlc(physical: number, node: string): HlcTimestamp {
+  return { physical, logical: 0, node };
+}
+
+function applyPeer(applier: JournalSyncApplier, data: Record<string, unknown>): void {
+  const entry: JournalEntry = { seq: 1, ts: '2026-07-10T00:00:00.000Z', machine: PEER, kind: LEARNING_RECORD_KIND, data };
+  const batch: ApplyBatchStream[] = [{ kind: LEARNING_RECORD_KIND, incarnation: 'inc-peer', entries: [entry] }];
+  applier.apply(PEER, batch);
+}
+
+describe('replicated witness index lifecycle', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir) SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/e2e/replicated-witness-index-lifecycle.test.ts' });
+    dir = undefined;
+  });
+
+  it('rebuilds from own + peer journal streams after index loss', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'witness-index-e2e-'));
+    const reg = registry();
+    const journal = new CoherenceJournal({ stateDir: dir, machineId: SELF, flushIntervalMs: 1_000_000 });
+    journal.open();
+    journal.setReplicatedKindRegistry(reg);
+    try {
+      const applier = new JournalSyncApplier({ stateDir: dir, replicatedRegistry: reg });
+      const record = learning();
+      const rk = deriveLearningRecordKey(record.title, record.category, record.source)!;
+
+      journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record, hlc: hlc(1000, SELF), origin: SELF })!);
+      journal.flush();
+      applyPeer(applier, buildLearningRecordData({ record, hlc: hlc(2500, PEER), origin: PEER })!);
+
+      const rebuilt = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg, selfMachineId: SELF });
+      expect(rebuilt.loadWitness(LEARNING_STORE_KEY, rk)?.physical).toBe(2500);
+      expect(rebuilt.loadOriginRecords(LEARNING_STORE_KEY, rk).map((r) => r.origin).sort()).toEqual([PEER, SELF].sort());
+    } finally {
+      journal.close();
+    }
+  });
+});

--- a/tests/integration/replicated-witness-index.integration.test.ts
+++ b/tests/integration/replicated-witness-index.integration.test.ts
@@ -1,0 +1,96 @@
+// safe-fs-allow: test fixture teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { CoherenceJournal, type JournalFs } from '../../src/core/CoherenceJournal.js';
+import { HybridLogicalClock, type HlcTimestamp } from '../../src/core/HybridLogicalClock.js';
+import { LEARNING_KIND_REGISTRATION, LEARNING_RECORD_KIND, LEARNING_STORE_KEY, buildLearningRecordData, deriveLearningRecordKey } from '../../src/core/LearningsReplicatedStore.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { ReplicatedPeerStreamReader } from '../../src/core/ReplicatedPeerStreamReader.js';
+import { ReplicatedRecordEmitter } from '../../src/core/ReplicatedRecordEmitter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { LearningEntry } from '../../src/core/types.js';
+
+const SELF = 'm_self';
+
+function registry(): ReplicatedKindRegistry {
+  const r = new ReplicatedKindRegistry();
+  r.register(LEARNING_KIND_REGISTRATION);
+  return r;
+}
+
+function learning(): LearningEntry {
+  return {
+    id: 'LRN-INT',
+    title: 'indexed witness',
+    category: 'ops',
+    description: 'witness lookup is indexed',
+    source: { discoveredAt: '2026-07-10T00:00:00.000Z' },
+    tags: [],
+    applied: false,
+  };
+}
+
+function hlc(physical: number): HlcTimestamp {
+  return { physical, logical: 0, node: SELF };
+}
+
+function countingFs(): { io: JournalFs; reads: () => number; reset: () => void } {
+  let readCount = 0;
+  const io = { ...fs } as unknown as JournalFs;
+  io.readSync = (...args: Parameters<typeof fs.readSync>) => {
+    readCount++;
+    return fs.readSync(...args);
+  };
+  return { io, reads: () => readCount, reset: () => { readCount = 0; } };
+}
+
+describe('replicated witness index integration', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir) SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/replicated-witness-index.integration.test.ts' });
+    dir = undefined;
+  });
+
+  it('real emitter path reads the derived witness index instead of the journal stream', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'witness-index-int-'));
+    const reg = registry();
+    const journal = new CoherenceJournal({ stateDir: dir, machineId: SELF, flushIntervalMs: 1_000_000 });
+    journal.open();
+    journal.setReplicatedKindRegistry(reg);
+    try {
+      const first = learning();
+      const rk = deriveLearningRecordKey(first.title, first.category, first.source)!;
+      journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: first, hlc: hlc(1000), origin: SELF })!);
+      journal.flush();
+
+      const counted = countingFs();
+      const reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg, selfMachineId: SELF, fsImpl: counted.io });
+      journal.setReplicatedRecordCommitObserver((kind, entries) => reader.observeCommittedEntries(kind, entries));
+      counted.reset();
+
+      const emitted: Record<string, unknown>[] = [];
+      const clock = new HybridLogicalClock({ node: SELF, now: () => 2000 });
+      const emitter = new ReplicatedRecordEmitter({
+        journal: { emitReplicatedRecord: (_kind, data) => { emitted.push(data); } },
+        clock,
+        registry: reg,
+        origin: SELF,
+        stores: () => ({ learnings: { enabled: true } }),
+        loadWitness: (store, recordKey) => reader.loadWitness(store, recordKey),
+      });
+      emitter.emit(LEARNING_STORE_KEY, rk, (nextHlc, origin, observed) => ({
+        ...buildLearningRecordData({ record: { ...first, applied: true }, hlc: nextHlc, origin })!,
+        ...(observed ? { observed } : {}),
+      }));
+
+      expect((emitted[0].observed as HlcTimestamp).physical).toBe(1000);
+      expect(counted.reads()).toBe(0);
+    } finally {
+      journal.close();
+    }
+  });
+});

--- a/tests/unit/ReplicatedPeerStreamReader.test.ts
+++ b/tests/unit/ReplicatedPeerStreamReader.test.ts
@@ -27,9 +27,11 @@ import {
   deriveLearningRecordKey,
 } from '../../src/core/LearningsReplicatedStore.js';
 import type { HlcTimestamp } from '../../src/core/HybridLogicalClock.js';
-import type { JournalEntry } from '../../src/core/CoherenceJournal.js';
+import type { JournalEntry, JournalFs } from '../../src/core/CoherenceJournal.js';
 import type { LearningEntry, LearningSource } from '../../src/core/types.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { ReplicatedRecordEmitter, type ReplicatedRecordEmitterClock } from '../../src/core/ReplicatedRecordEmitter.js';
+import type { OriginRecord } from '../../src/core/UnionReader.js';
 
 const SELF = 'm_self';
 const PEER = 'm_peer';
@@ -58,6 +60,39 @@ function applyPeerRecord(applier: JournalSyncApplier, data: Record<string, unkno
   applier.apply(PEER, batch);
 }
 
+function attachWitnessObservers(
+  journal: CoherenceJournal,
+  applier: JournalSyncApplier,
+  readerRef: () => ReplicatedPeerStreamReader,
+): void {
+  journal.setReplicatedRecordCommitObserver((kind, entries) => readerRef().observeCommittedEntries(kind, entries));
+  applier.setReplicatedRecordCommitObserver((_sender, kind, entries) => readerRef().observeCommittedEntries(kind, entries));
+}
+
+function maxHlc(records: OriginRecord[]): HlcTimestamp | undefined {
+  let max: HlcTimestamp | undefined;
+  for (const r of records) {
+    if (!max || r.envelope.hlc.physical > max.physical || (r.envelope.hlc.physical === max.physical && r.envelope.hlc.logical > max.logical)) {
+      max = r.envelope.hlc;
+    }
+  }
+  return max;
+}
+
+function countingFs(): { io: JournalFs; reads: () => number; reset: () => void } {
+  let readCount = 0;
+  const io = { ...fs } as unknown as JournalFs;
+  io.readSync = (...args: Parameters<typeof fs.readSync>) => {
+    readCount++;
+    return fs.readSync(...args);
+  };
+  return {
+    io,
+    reads: () => readCount,
+    reset: () => { readCount = 0; },
+  };
+}
+
 describe('ReplicatedPeerStreamReader', () => {
   let dir: string;
   let journal: CoherenceJournal;
@@ -72,6 +107,7 @@ describe('ReplicatedPeerStreamReader', () => {
     journal.setReplicatedKindRegistry(registry);
     applier = new JournalSyncApplier({ stateDir: dir, replicatedRegistry: registry });
     reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry, selfMachineId: SELF });
+    attachWitnessObservers(journal, applier, () => reader);
   });
   afterEach(() => {
     try { journal.close(); } catch { /* best-effort */ }
@@ -127,6 +163,62 @@ describe('ReplicatedPeerStreamReader', () => {
 
   it('loadWitness is undefined for an unheld key (first write)', () => {
     expect(reader.loadWitness(LEARNING_STORE_KEY, 'never-seen')).toBeUndefined();
+  });
+
+  it('keeps the derived witness index correct across own and peer updates', () => {
+    const rk = deriveLearningRecordKey('tmux colon', 'ops', SRC)!;
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning({ applied: false }), hlc: hlc(1000, SELF), origin: SELF })!);
+    journal.flush();
+    expect(reader.loadWitness(LEARNING_STORE_KEY, rk)).toEqual(maxHlc(reader.loadOriginRecords(LEARNING_STORE_KEY, rk)));
+    expect(reader.loadWitness(LEARNING_STORE_KEY, rk)?.physical).toBe(1000);
+
+    applyPeerRecord(applier, buildLearningRecordData({ record: learning({ applied: false }), hlc: hlc(2500, PEER), origin: PEER })!, 1);
+    expect(reader.loadWitness(LEARNING_STORE_KEY, rk)).toEqual(maxHlc(reader.loadOriginRecords(LEARNING_STORE_KEY, rk)));
+    expect(reader.loadWitness(LEARNING_STORE_KEY, rk)?.physical).toBe(2500);
+
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning({ applied: true }), hlc: hlc(3000, SELF), origin: SELF })!);
+    journal.flush();
+    expect(reader.loadWitness(LEARNING_STORE_KEY, rk)).toEqual(maxHlc(reader.loadOriginRecords(LEARNING_STORE_KEY, rk)));
+    expect(reader.loadWitness(LEARNING_STORE_KEY, rk)?.physical).toBe(3000);
+  });
+
+  it('does not read journal bytes during an emit witness lookup once the index is built', () => {
+    const rk = deriveLearningRecordKey('tmux colon', 'ops', SRC)!;
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning(), hlc: hlc(1000, SELF), origin: SELF })!);
+    journal.flush();
+
+    const counted = countingFs();
+    const indexedReader = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg(), selfMachineId: SELF, fsImpl: counted.io });
+    expect(counted.reads()).toBeGreaterThan(0);
+    counted.reset();
+
+    const emitted: Record<string, unknown>[] = [];
+    const emitter = new ReplicatedRecordEmitter({
+      journal: { emitReplicatedRecord: (_kind, data) => { emitted.push(data); } },
+      clock: { tick: () => hlc(2000, SELF) } satisfies ReplicatedRecordEmitterClock,
+      registry: reg(),
+      origin: SELF,
+      stores: () => ({ learnings: { enabled: true } }),
+      loadWitness: (store, recordKey) => indexedReader.loadWitness(store, recordKey),
+    });
+    emitter.emit(LEARNING_STORE_KEY, rk, (nextHlc, origin, observed) => ({
+      ...buildLearningRecordData({ record: learning({ applied: true }), hlc: nextHlc, origin })!,
+      ...(observed ? { observed } : {}),
+    }));
+
+    expect(emitted).toHaveLength(1);
+    expect((emitted[0].observed as HlcTimestamp).physical).toBe(1000);
+    expect(counted.reads()).toBe(0);
+  });
+
+  it('rebuilds the witness index from authoritative journal streams after in-memory loss', () => {
+    const rk = deriveLearningRecordKey('tmux colon', 'ops', SRC)!;
+    journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning(), hlc: hlc(1000, SELF), origin: SELF })!);
+    journal.flush();
+    applyPeerRecord(applier, buildLearningRecordData({ record: learning(), hlc: hlc(2500, PEER), origin: PEER })!, 1);
+
+    const rebuilt = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg(), selfMachineId: SELF });
+    expect(rebuilt.loadWitness(LEARNING_STORE_KEY, rk)?.physical).toBe(2500);
   });
 
   it('loadOwnEntries serves only THIS machine\'s own entries; {} for a foreign origin', () => {

--- a/upgrades/eli16/replicated-witness-index.md
+++ b/upgrades/eli16/replicated-witness-index.md
@@ -1,0 +1,19 @@
+# ELI16 — Replicated Witness Index
+
+## What Changed
+
+Replicated stores write their updates into append-only journal files. When one machine writes a new record, it also stamps an `observed` witness: the newest version of that same record key that this machine had already seen. That witness is what keeps two machines from silently overwriting each other when they edited the same thing at the same time.
+
+Before this change, the witness lookup was correct but expensive. Every emitted replicated record asked the peer-stream reader to find the latest witness for one `(store, recordKey)`, and the reader answered by scanning the journal streams again. On a small journal that was fine. On a real evolution-action journal with tens of megabytes and many keys, every surviving emit still paid a synchronous journal scan.
+
+This change keeps the journal as the source of truth but adds a derived in-memory witness index. When the reader attaches, it streams the journal files once in fixed-size chunks and builds a map from `(store, recordKey)` to the latest HLC witness. After that, `loadWitness()` reads the map directly instead of re-reading the journal. When the local journal or peer applier durably commits replicated records, they notify the reader after `fdatasync`, and the reader updates the map incrementally.
+
+## Why It Is Safe
+
+The index is derived and rebuildable. It is never more authoritative than the journal. A restart, missing index, or lost in-memory state simply rebuilds the map from the journal streams. The update hooks run only after durable append boundaries: local records after the journal flush has written and synced the batch, and peer records after the applier has written and synced the replica batch.
+
+The rollout also keeps a parity check. During rebuild, the derived map is compared with the legacy full-scan witness answer. If the answers ever disagree, the reader logs a loud warning and falls back to the legacy scan instead of trusting the index.
+
+## How To Verify
+
+The unit tests prove the index matches the legacy answer across local writes, peer writes, and later updates. They also prove an emitter using `loadWitness()` does not read journal bytes once the index is built. The integration test covers the real emitter path with a counted filesystem seam. The e2e lifecycle test proves a fresh reader rebuilds the witness from own and peer journal streams after the in-memory index is gone.

--- a/upgrades/next/replicated-witness-index.md
+++ b/upgrades/next/replicated-witness-index.md
@@ -1,0 +1,27 @@
+# Replicated witness index
+
+## What Changed
+
+Replicated-store witness lookup now uses a derived in-memory index instead of scanning the journal streams on every emitted record. `ReplicatedPeerStreamReader` builds the index from own and peer replicated journal streams, then serves `loadWitness(store, recordKey)` from a `(store, recordKey) -> max HLC` map. `CoherenceJournal` and `JournalSyncApplier` update the index after replicated records are durably committed, so the index tracks fsynced bytes rather than queued writes.
+
+The journal remains authoritative. The index is not persisted and rebuilds from disk on startup or loss. Rebuild includes parity mode: the derived witness answer is compared with the legacy full-scan answer, and any mismatch logs loudly and falls back to the scan.
+
+## What to Tell Your User
+
+- Multi-machine replicated-store writes should do much less synchronous journal work. A surviving emit no longer has to rescan a large replicated-store journal just to find the latest witness for one key.
+- The optimization is conservative: it does not change merge rules, does not add a new data file, and does not make the index authoritative. If the derived answer ever disagrees with the legacy scan, Instar uses the old answer.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|---|---|
+| O(1) replicated witness lookup | No operator action; replicated-store emitters use the indexed `loadWitness` path automatically |
+| Derived witness index rebuild | Restart or index loss rebuilds from authoritative journal streams |
+| Witness parity fallback | A mismatch between index and legacy scan logs and falls back to legacy scan |
+
+## Evidence
+
+- Unit: `tests/unit/ReplicatedPeerStreamReader.test.ts` covers index correctness across own/peer updates, no journal-byte reads during emitter witness lookup, and rebuild after in-memory loss.
+- Integration: `tests/integration/replicated-witness-index.integration.test.ts` covers the real emitter path with a counted filesystem seam.
+- E2E: `tests/e2e/replicated-witness-index-lifecycle.test.ts` rebuilds from own + peer journal streams and preserves the union read shape.
+- Regression: `tests/unit/ReplicatedRecordEmitter.test.ts`, `tests/unit/evolution-manager-emit-wedge.test.ts`, and `npx tsc --noEmit` are green.

--- a/upgrades/side-effects/replicated-witness-index.md
+++ b/upgrades/side-effects/replicated-witness-index.md
@@ -1,0 +1,83 @@
+# Side-Effects Review — Replicated witness index
+
+**Version / slug:** `replicated-witness-index`
+**Date:** `2026-07-10`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+This change makes the replicated-store `loadWitness(store, recordKey)` path use a derived in-memory index instead of rematerializing journal streams on every emit. The index is built by `ReplicatedPeerStreamReader` from the authoritative own and peer journal streams, then incrementally updated from two post-durability observers: `CoherenceJournal` notifies after a replicated local batch is written and `fdatasync` has returned, and `JournalSyncApplier` notifies after a peer replica batch is written and `fdatasync` has returned.
+
+The journal and replica files remain the only authority. The index is process memory only, can be rebuilt at any time, and is parity-checked against the legacy full-scan witness answer before it is trusted. If parity fails, `loadWitness` falls back to the legacy scan and logs a loud witness-index warning.
+
+## Decision-point inventory
+
+- `ReplicatedPeerStreamReader.rebuildWitnessIndex` — add — streams registered replicated journal files to build the derived `(store, recordKey) -> max HLC` map.
+- `ReplicatedPeerStreamReader.loadWitness` — modify — serves the derived map when parity is trusted; falls back to the old scan if parity is not trusted.
+- `ReplicatedPeerStreamReader.observeCommittedEntries` — add — folds durable local/peer append notifications into the derived map.
+- `CoherenceJournal.setReplicatedRecordCommitObserver` / notification — add — notifies only after local replicated records have crossed the flush/fdatasync boundary.
+- `JournalSyncApplier.setReplicatedRecordCommitObserver` / notification — add — notifies only after peer replica records have crossed the append/fdatasync boundary.
+- `server.ts` WS2 wiring — modify — attaches the two observers to the one `ReplicatedPeerStreamReader`.
+
+## 1. Over-block
+
+No user operation is newly blocked. The witness index is a read optimization for the replicated-store send path. If the index is wrong, the parity guard disables trust in it and serves the old scan result. If an observer callback throws, journal/apply durability is preserved and the index remains rebuildable from disk.
+
+## 2. Under-block
+
+The main under-detection risk is a stale derived index missing a witness. That would make a later emit omit `observed`, which is the safe merge direction: peers flag possible concurrency instead of silently clobbering. Production wiring reduces that risk by updating the index after every local and peer durable append. Restart/loss rebuilds from the journal streams.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. `ReplicatedPeerStreamReader` already owns the witness seam and knows the registry, own streams, peer streams, schema validation, and HLC ordering. The journal and applier only expose post-fsync observations; they do not own witness semantics and do not persist an index. This keeps the optimization store-agnostic and avoids per-store caches.
+
+Claim-check note: `src/commands/server.ts` has several unrelated open PR claims in dashboard/update/messaging layers. This change touches only the WS2 replicated-store wiring block to attach observer callbacks. No sibling appears to own the witness-index layer.
+
+## 4. Signal vs authority compliance
+
+- [x] No new gate or authority surface.
+
+The new callbacks are informational derived-index updates. They cannot approve, block, mutate user-visible state, or make the journal authoritative in a new way. The existing journal/applier durability contracts remain the authority.
+
+## 5. Interactions
+
+- **Local journal flush:** the observer fires after the replicated batch is written and synced, so queued in-memory emits are never witnessed as durable.
+- **Peer replica apply:** the observer fires after durable replica append, matching the applier's ack-after-fsync contract.
+- **Parity mode:** rebuild compares the index answer with the legacy full-scan witness answer. A mismatch logs once and falls back to the scan.
+- **Crash/restart:** there is no persisted index to corrupt. A new reader rebuilds from own and peer streams.
+- **Existing union reads:** `loadOriginRecords`, `listRecordKeys`, and `loadOwnEntries` keep their existing behavior. This PR narrows the optimization to the hot witness lookup.
+
+## 6. External surfaces
+
+No new API route, config key, dashboard control, CLI, or persistent schema. Runtime logs may include a new `[ws2-witness-index]` parity mismatch line if the derived index ever disagrees with the legacy scan.
+
+## 6b. Operator-surface quality
+
+No operator surface. The only operator-visible change should be reduced synchronous work during replicated-store emission.
+
+## 7. Multi-machine posture
+
+This is explicitly multi-machine shared infrastructure and affects every replicated store, including PII replicated stores. The index is store-agnostic and uses the same `ReplicatedKindRegistry` and `validateReplicatedEnvelope` path as the existing reader. It does not replicate additional fields, does not write a new file, and does not expose more data to peers. It only changes how the local machine finds the max HLC it has already durably observed.
+
+## 8. Rollback cost
+
+Low to moderate. Reverting restores the legacy scan path and removes the observer callbacks. Because the index is not persisted, rollback has no data migration and cannot strand state. The cost is performance regression back to synchronous scan-per-witness on large journals.
+
+## Conclusion
+
+The change closes the performance residual without changing merge semantics: same witness answer, derived in memory, built from streamed journal reads, updated only after durable appends, and backed by parity fallback. The blast radius is shared infra, so coverage includes unit, integration, and e2e lifecycle tests.
+
+## Second-pass review (if required)
+
+**Reviewer:** not required
+**Independent read of the artifact:** not required for this Tier-1 performance optimization with no new authority, no schema migration, and parity fallback.
+
+## Evidence pointers
+
+- `npx tsc --noEmit`
+- `npx vitest run tests/unit/ReplicatedPeerStreamReader.test.ts tests/unit/ReplicatedRecordEmitter.test.ts tests/unit/evolution-manager-emit-wedge.test.ts tests/integration/replicated-witness-index.integration.test.ts tests/e2e/replicated-witness-index-lifecycle.test.ts`
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect. The recurring class was synchronous scan-per-emit after the #1414 emit-count fix. The closure is structural: witness lookup reads an O(1) derived map in the hot path, local/peer append sites update the map after fsync, and rebuild/parity keeps the journal authoritative.


### PR DESCRIPTION
## ELI16 — Replicated witness index

Replicated-store writes need an observed witness: the latest version of the same record key that this machine has already durably seen. Before this PR, that answer was correct but expensive because each emit could ask the peer-stream reader to scan the journal streams again. On a large evolution-action journal, that kept the #1414 fix from being truly cheap: fewer emits survived, but every surviving emit still had synchronous journal-scan work attached.

This PR keeps the journal as the source of truth and adds a derived in-memory witness index. The reader streams own and peer journal files once at attach/rebuild time, then loadWitness reads a map keyed by store and record key. Local journal flush and peer apply update that map only after fdatasync, so queued or uncommitted data is never witnessed. Rebuild also parity-checks the index against the legacy full-scan answer; if those disagree, it logs and falls back to the scan instead of trusting the index.

## What changed

- Added a derived witness index to ReplicatedPeerStreamReader.
- Added post-fsync replicated-record observer seams to CoherenceJournal and JournalSyncApplier.
- Wired the WS2 server path so durable local and peer appends update the reader index.
- Kept the index rebuildable and non-authoritative; no persisted index file, no config, no API route.

## Safety notes

- The index is derived from journal streams and rebuilt from disk after process loss.
- Observer callbacks fire after durable append boundaries, not when records are merely queued.
- Parity mode compares the derived answer with the legacy full-scan witness answer and falls back on mismatch.
- Claim-check found unrelated server.ts claims in dashboard/update/messaging layers; this PR touches only the WS2 replicated-store wiring layer.

## Evidence

- Claim-check: instar dev:claim-check src/core/ReplicatedPeerStreamReader.ts src/core/CoherenceJournal.ts src/core/JournalSyncApplier.ts src/commands/server.ts tests/unit/ReplicatedPeerStreamReader.test.ts.
- Type check: npx tsc --noEmit.
- Focused 3-tier validation: npx vitest run tests/unit/ReplicatedPeerStreamReader.test.ts tests/unit/ReplicatedRecordEmitter.test.ts tests/unit/evolution-manager-emit-wedge.test.ts tests/integration/replicated-witness-index.integration.test.ts tests/e2e/replicated-witness-index-lifecycle.test.ts — 27 passed.
- Upgrade guide: npm run check:upgrade-guide passed for v1.3.803 with existing historical warnings.
- instar-dev gate: node scripts/instar-dev-precommit.js passed.
- Commit hook: full npm run lint passed.
- Pre-push: affected smoke listing timed out and delegated to CI. First path-scoped Threadline e2e run passed 17/18 files but hit unrelated RelayE2E sqlite FTS setup race (agents_fts already exists); pushed with INSTAR_PRE_PUSH_E2E_SKIP=1 per hook instruction, so CI remains authority.

## Artifacts

- upgrades/eli16/replicated-witness-index.md
- upgrades/side-effects/replicated-witness-index.md
- upgrades/next/replicated-witness-index.md