### PR TITLE
fix(replication): safely compact record journals

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-10T22-44-15-364Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-10T22-44-15-364Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-10T22:44:15.364Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 1,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-10T22-47-43-075Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-10T22-47-43-075Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-10T22:47:43.075Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-10T22-32-41-000Z-replicated-journal-compaction.json
+++ b/.instar/instar-dev-traces/2026-07-10T22-32-41-000Z-replicated-journal-compaction.json
@@ -1,0 +1,28 @@
+{
+  "version": 2,
+  "sessionId": "telegram-458-replicated-journal-compaction",
+  "timestamp": "2026-07-10T22:32:41.000Z",
+  "artifactPath": "upgrades/side-effects/replicated-journal-compaction.md",
+  "artifactSha256": "ca8580b4522851ded314e120f5bfb201c0431ed758db2204bb3b96032e940e5b",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/config/ConfigDefaults.ts",
+    "src/core/ReplicatedJournalCompactor.ts",
+    "src/core/types.ts",
+    "tests/unit/ReplicatedJournalCompactor.test.ts",
+    "tests/unit/lint-dev-agent-dark-gate.test.ts",
+    "tests/integration/replicated-journal-compaction.integration.test.ts",
+    "tests/e2e/replicated-journal-compaction-crash.test.ts",
+    "tests/support/replicatedJournalCompactionFixture.ts",
+    "upgrades/eli16/replicated-journal-compaction.md",
+    "upgrades/next/replicated-journal-compaction.md",
+    "upgrades/side-effects/replicated-journal-compaction.md"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Explicit dry-run-first maintenance path for shared replicated-store disk state. The source journal remains authoritative until an fsynced compacted stream rebuilds an identical witness map and crosses the atomic rename commit point. Three-tier coverage includes interruption before rename.",
+  "eli16Path": "upgrades/eli16/replicated-journal-compaction.md",
+  "sideEffectsPath": "upgrades/side-effects/replicated-journal-compaction.md",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4459,6 +4459,19 @@ export async function startServer(options: StartOptions): Promise<void> {
           selfMachineId: cjOwnMachineId,
           logger: (m) => console.log(pc.dim(`  [ws2-witness-index] ${m}`)),
         });
+        const compactionConfig = config.multiMachine?.coherenceJournal?.replication?.compaction;
+        if (compactionConfig?.run === true) {
+          const { ReplicatedJournalCompactor } = await import('../core/ReplicatedJournalCompactor.js');
+          new ReplicatedJournalCompactor({
+            stateDir: config.stateDir,
+            registry: replicatedKindRegistry,
+            enabled: true,
+            dryRun: compactionConfig.dryRun ?? true,
+            logger: (m) => console.log(pc.dim(`  ${m}`)),
+          }).run();
+          // A real run replaced streams atomically; rebuild from the committed files.
+          if (compactionConfig.dryRun === false) replicatedPeerStreamReader.rebuildWitnessIndex();
+        }
         coherenceJournal.setReplicatedRecordCommitObserver((kind, entries) => {
           replicatedPeerStreamReader?.observeCommittedEntries(kind, entries);
         });

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -1419,7 +1419,12 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     coherenceJournal: {
       flushIntervalMs: 250,
       scannerIntervalMs: 60000,
-      replication: { maxBatchBytes: 262144 },
+      replication: {
+        maxBatchBytes: 262144,
+        // One-shot replicated-record journal compaction. Explicit opt-in only;
+        // first activation reports N -> M without touching disk.
+        compaction: { run: false, dryRun: true },
+      },
       // Working-Set Handoff (WORKING-SET-HANDOFF-SPEC §3.7). NO enable flag
       // here — the feature activates IFF replication.enabled === true (the
       // pull is meaningless without replication's mesh path and must never

--- a/src/core/ReplicatedJournalCompactor.ts
+++ b/src/core/ReplicatedJournalCompactor.ts
@@ -1,0 +1,223 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
+
+import type { JournalEntry, JournalKind } from './CoherenceJournal.js';
+import { HybridLogicalClock, type HlcTimestamp } from './HybridLogicalClock.js';
+import { validateReplicatedEnvelope, type ReplicatedKindRegistry } from './ReplicatedRecordEnvelope.js';
+import { SafeFsExecutor } from './SafeFsExecutor.js';
+
+const CHUNK_BYTES = 64 * 1024;
+const NOOP_COUNTERS = { bumpSchemaReject: () => {}, bumpDroppedField: () => {}, bumpJailReject: () => {} };
+
+export interface ReplicatedJournalCompactionResult {
+  enabled: boolean;
+  dryRun: boolean;
+  originalRecords: number;
+  compactedRecords: number;
+  filesCompacted: number;
+  bytesBefore: number;
+  bytesAfter: number;
+}
+
+export interface ReplicatedJournalCompactorOptions {
+  stateDir: string;
+  registry: ReplicatedKindRegistry;
+  enabled?: boolean;
+  dryRun?: boolean;
+  logger?: (message: string) => void;
+  /** Fault-injection seam: runs after temp fsync and before the atomic rename. */
+  beforeRename?: (source: string, temp: string) => void;
+}
+
+interface Winner { hlc: HlcTimestamp; line: string }
+
+/** One-shot, explicit compactor for registered replicated-record JSONL streams. */
+export class ReplicatedJournalCompactor {
+  constructor(private readonly options: ReplicatedJournalCompactorOptions) {}
+
+  run(): ReplicatedJournalCompactionResult {
+    const enabled = this.options.enabled === true;
+    const dryRun = this.options.dryRun ?? true;
+    const result: ReplicatedJournalCompactionResult = {
+      enabled, dryRun, originalRecords: 0, compactedRecords: 0,
+      filesCompacted: 0, bytesBefore: 0, bytesAfter: 0,
+    };
+    if (!enabled) return result;
+
+    for (const file of this.registeredStreamFiles()) this.compactFile(file, result);
+    const verb = dryRun ? 'would compact' : 'compacted';
+    this.options.logger?.(`[replicated-journal-compaction] ${verb} ${result.originalRecords} records -> ${result.compactedRecords} across ${result.filesCompacted} files`);
+    return result;
+  }
+
+  private compactFile(file: string, total: ReplicatedJournalCompactionResult): void {
+    const parsed = this.registrationForFile(file);
+    if (!parsed) return;
+    // Bounded by live `(origin, recordKey)` cardinality, never historical rows.
+    const winners = new Map<string, Winner>();
+    const beforeWitness = new Map<string, HlcTimestamp>();
+    const passthrough: Winner[] = [];
+    let originalRecords = 0;
+    this.forEachLine(file, (line, entry) => {
+      originalRecords++;
+      const validated = this.validEnvelope(parsed.store, parsed.kind, entry);
+      if (!validated) {
+        passthrough.push({ hlc: { physical: 0, logical: 0, node: '' }, line });
+        return;
+      }
+      const priorWitness = beforeWitness.get(validated.recordKey);
+      if (!priorWitness || HybridLogicalClock.compare(validated.hlc, priorWitness) > 0) {
+        beforeWitness.set(validated.recordKey, validated.hlc);
+      }
+      const key = `${validated.origin}\u0000${validated.recordKey}`;
+      const prior = winners.get(key);
+      if (!prior || HybridLogicalClock.compare(validated.hlc, prior.hlc) > 0) winners.set(key, { hlc: validated.hlc, line });
+    });
+    if (originalRecords === 0 || winners.size + passthrough.length === originalRecords) return;
+
+    const ordered = [...winners.values(), ...passthrough].sort((a, b) => {
+      const ae = JSON.parse(a.line) as JournalEntry;
+      const be = JSON.parse(b.line) as JournalEntry;
+      return ae.seq - be.seq;
+    });
+    const afterWitness = this.witnessMap(ordered);
+    if (!this.witnessMapsEqual(beforeWitness, afterWitness)) {
+      throw new Error(`replicated journal compaction parity failed for ${file}`);
+    }
+
+    const bytesBefore = fs.statSync(file).size;
+    const bytesAfter = ordered.reduce((n, winner) => n + Buffer.byteLength(winner.line) + 1, 0);
+    total.originalRecords += originalRecords;
+    total.compactedRecords += ordered.length;
+    total.filesCompacted++;
+    total.bytesBefore += bytesBefore;
+    total.bytesAfter += bytesAfter;
+    if (this.options.dryRun ?? true) return;
+
+    const temp = `${file}.compact-${process.pid}-${Date.now()}.tmp`;
+    let fd: number | undefined;
+    try {
+      fd = fs.openSync(temp, 'wx', 0o600);
+      for (const winner of ordered) fs.writeSync(fd, `${winner.line}\n`);
+      fs.fdatasyncSync(fd);
+      fs.closeSync(fd);
+      fd = undefined;
+      // Correctness gate: rebuild from the actual compacted bytes, not from the
+      // winner plan. The temp stream must answer every witness exactly as the
+      // original stream before rename is permitted to become the commit point.
+      const rebuiltFromTemp = this.witnessMapFromFile(temp, parsed.store, parsed.kind);
+      if (!this.witnessMapsEqual(beforeWitness, rebuiltFromTemp)) {
+        throw new Error(`replicated journal compaction parity failed for ${file}`);
+      }
+      this.options.beforeRename?.(file, temp);
+      fs.renameSync(temp, file);
+      const dirFd = fs.openSync(path.dirname(file), 'r');
+      try { fs.fsyncSync(dirFd); } finally { fs.closeSync(dirFd); }
+    } catch (error) {
+      if (fd !== undefined) { try { fs.closeSync(fd); } catch { /* best effort */ } }
+      try { SafeFsExecutor.safeUnlinkSync(temp, { operation: 'ReplicatedJournalCompactor.cleanup-temp' }); } catch { /* absent temp is fine */ }
+      throw error;
+    }
+  }
+
+  private registeredStreamFiles(): string[] {
+    const root = path.join(this.options.stateDir, 'state', 'coherence-journal');
+    const dirs = [root, path.join(root, 'peers')];
+    const files: string[] = [];
+    for (const dir of dirs) {
+      let names: string[];
+      try { names = fs.readdirSync(dir); } catch { /* @silent-fallback-ok: an absent journal/peers directory means there are no replicated streams to compact. */ continue; }
+      for (const name of names) {
+        if (!name.endsWith('.jsonl') || name.includes('.quarantine.')) continue;
+        const file = path.join(dir, name);
+        if (this.registrationForFile(file)) files.push(file);
+      }
+    }
+    return files;
+  }
+
+  private registrationForFile(file: string): { store: string; kind: JournalKind } | null {
+    const name = path.basename(file);
+    for (const store of this.options.registry.stores()) {
+      const reg = this.options.registry.getByStore(store);
+      if (!reg) continue;
+      const marker = `.${reg.kind}`;
+      if (name.includes(marker) && /\.jsonl$/.test(name)) return { store, kind: reg.kind as JournalKind };
+    }
+    return null;
+  }
+
+  private validEnvelope(store: string, kind: JournalKind, entry: JournalEntry): { origin: string; recordKey: string; hlc: HlcTimestamp } | null {
+    if (entry.kind !== kind || !entry.data || typeof entry.data !== 'object') return null;
+    const reg = this.options.registry.getByStore(store);
+    if (!reg) return null;
+    const result = validateReplicatedEnvelope(entry.data as Record<string, unknown>, reg.schema, NOOP_COUNTERS);
+    return result.ok ? { origin: result.envelope.origin, recordKey: result.envelope.recordKey, hlc: result.envelope.hlc } : null;
+  }
+
+  private witnessMap(values: Iterable<Winner>): Map<string, HlcTimestamp> {
+    const out = new Map<string, HlcTimestamp>();
+    for (const winner of values) {
+      const entry = JSON.parse(winner.line) as JournalEntry;
+      const parsed = this.registrationForFileKind(entry.kind);
+      if (!parsed) continue;
+      const v = this.validEnvelope(parsed.store, parsed.kind, entry);
+      if (!v) continue;
+      const prior = out.get(v.recordKey);
+      if (!prior || HybridLogicalClock.compare(v.hlc, prior) > 0) out.set(v.recordKey, v.hlc);
+    }
+    return out;
+  }
+
+  private registrationForFileKind(kind: string): { store: string; kind: JournalKind } | null {
+    const reg = this.options.registry.getByKind(kind as JournalKind);
+    return reg ? { store: reg.store, kind: kind as JournalKind } : null;
+  }
+
+  private witnessMapsEqual(a: Map<string, HlcTimestamp>, b: Map<string, HlcTimestamp>): boolean {
+    if (a.size !== b.size) return false;
+    for (const [key, value] of a) {
+      const other = b.get(key);
+      if (!other || HybridLogicalClock.compare(value, other) !== 0) return false;
+    }
+    return true;
+  }
+
+  private witnessMapFromFile(file: string, store: string, kind: JournalKind): Map<string, HlcTimestamp> {
+    const out = new Map<string, HlcTimestamp>();
+    this.forEachLine(file, (_line, entry) => {
+      const value = this.validEnvelope(store, kind, entry);
+      if (!value) return;
+      const prior = out.get(value.recordKey);
+      if (!prior || HybridLogicalClock.compare(value.hlc, prior) > 0) out.set(value.recordKey, value.hlc);
+    });
+    return out;
+  }
+
+  private forEachLine(file: string, visit: (line: string, entry: JournalEntry) => void): void {
+    const fd = fs.openSync(file, 'r');
+    const buffer = Buffer.alloc(CHUNK_BYTES);
+    const decoder = new StringDecoder('utf8');
+    let carry = '';
+    try {
+      for (;;) {
+        const count = fs.readSync(fd, buffer, 0, buffer.length, null);
+        if (count === 0) break;
+        carry += decoder.write(buffer.subarray(0, count));
+        let newline: number;
+        while ((newline = carry.indexOf('\n')) >= 0) {
+          const line = carry.slice(0, newline); carry = carry.slice(newline + 1);
+          this.parseLine(line, visit);
+        }
+      }
+      carry += decoder.end();
+      this.parseLine(carry, visit);
+    } finally { fs.closeSync(fd); }
+  }
+
+  private parseLine(line: string, visit: (line: string, entry: JournalEntry) => void): void {
+    if (!line) return;
+    try { visit(line, JSON.parse(line) as JournalEntry); } catch { /* tolerant journal semantics */ }
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2784,7 +2784,13 @@ export interface CoherenceJournalUserConfig {
    * (WORKING-SET-HANDOFF-SPEC §3.7: the pull is meaningless without
    * replication's mesh path and must never out-activate it).
    */
-  replication?: { enabled?: boolean; maxBatchBytes?: number };
+  replication?: {
+    enabled?: boolean;
+    maxBatchBytes?: number;
+    /** Explicit one-shot replicated-record journal compaction. Disabled by default;
+     * when enabled it still defaults to dry-run until deliberately flipped. */
+    compaction?: { run?: boolean; dryRun?: boolean };
+  };
   /**
    * Working-Set Handoff tunables (WORKING-SET-HANDOFF-SPEC §3.7). All
    * optional; ConfigDefaults carries the shipped literal. Gated on

--- a/tests/e2e/replicated-journal-compaction-crash.test.ts
+++ b/tests/e2e/replicated-journal-compaction-crash.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { ReplicatedJournalCompactor } from '../../src/core/ReplicatedJournalCompactor.js';
+import { createCompactionFixture } from '../support/replicatedJournalCompactionFixture.js';
+
+describe('replicated journal compaction crash boundary', () => {
+  it('keeps the original byte-for-byte intact when interrupted before rename', () => {
+    const f = createCompactionFixture();
+    try {
+      const original = fs.readFileSync(f.file);
+      expect(() => new ReplicatedJournalCompactor({
+        stateDir: f.stateDir, registry: f.registry, enabled: true, dryRun: false,
+        beforeRename: () => { throw new Error('simulated kill before commit point'); },
+      }).run()).toThrow('simulated kill');
+      expect(fs.readFileSync(f.file)).toEqual(original);
+      expect(fs.readdirSync(path.dirname(f.file)).some((name) => name.includes('.compact-'))).toBe(false);
+    } finally { f.cleanup(); }
+  });
+});

--- a/tests/integration/replicated-journal-compaction.integration.test.ts
+++ b/tests/integration/replicated-journal-compaction.integration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import { ReplicatedJournalCompactor } from '../../src/core/ReplicatedJournalCompactor.js';
+import { ReplicatedPeerStreamReader } from '../../src/core/ReplicatedPeerStreamReader.js';
+import { LEARNING_STORE_KEY } from '../../src/core/LearningsReplicatedStore.js';
+import { createCompactionFixture } from '../support/replicatedJournalCompactionFixture.js';
+
+describe('replicated journal compaction integration', () => {
+  it('defaults to dry-run, reports N -> M, and a real run leaves the witness unchanged', () => {
+    const f = createCompactionFixture();
+    try {
+      const beforeBytes = fs.readFileSync(f.file);
+      const before = new ReplicatedPeerStreamReader({ stateDir: f.stateDir, registry: f.registry, selfMachineId: f.machine }).loadWitness(LEARNING_STORE_KEY, f.recordKey);
+      const messages: string[] = [];
+      const dry = new ReplicatedJournalCompactor({ stateDir: f.stateDir, registry: f.registry, enabled: true, logger: (m) => messages.push(m) }).run();
+      expect(dry).toMatchObject({ dryRun: true, originalRecords: 3, compactedRecords: 1 });
+      expect(messages[0]).toContain('would compact 3 records -> 1');
+      expect(fs.readFileSync(f.file)).toEqual(beforeBytes);
+      new ReplicatedJournalCompactor({ stateDir: f.stateDir, registry: f.registry, enabled: true, dryRun: false }).run();
+      const after = new ReplicatedPeerStreamReader({ stateDir: f.stateDir, registry: f.registry, selfMachineId: f.machine }).loadWitness(LEARNING_STORE_KEY, f.recordKey);
+      expect(after).toEqual(before);
+      expect(fs.statSync(f.file).size).toBeLessThan(beforeBytes.length);
+    } finally { f.cleanup(); }
+  });
+});

--- a/tests/support/replicatedJournalCompactionFixture.ts
+++ b/tests/support/replicatedJournalCompactionFixture.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { LEARNING_KIND_REGISTRATION, LEARNING_RECORD_KIND, buildLearningRecordData, deriveLearningRecordKey } from '../../src/core/LearningsReplicatedStore.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { LearningEntry } from '../../src/core/types.js';
+
+export function createCompactionFixture() {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'journal-compact-'));
+  const machine = 'm_compact';
+  const journalDir = path.join(stateDir, 'state', 'coherence-journal'); fs.mkdirSync(journalDir, { recursive: true });
+  const file = path.join(journalDir, `${machine}.${LEARNING_RECORD_KIND}.jsonl`);
+  const registry = new ReplicatedKindRegistry(); registry.register(LEARNING_KIND_REGISTRATION);
+  const record: LearningEntry = { id: 'LRN-1', title: 'same', category: 'ops', description: 'value', source: { discoveredAt: '2026-07-10T00:00:00.000Z' }, tags: [], applied: false };
+  const recordKey = deriveLearningRecordKey(record.title, record.category, record.source)!;
+  const lines = [1, 2, 3].map((seq) => JSON.stringify({ seq, ts: seq, machine, kind: LEARNING_RECORD_KIND, data: buildLearningRecordData({ record: { ...record, applied: seq === 3 }, hlc: { physical: seq, logical: 0, node: machine }, origin: machine }) }));
+  fs.writeFileSync(file, `${lines.join('\n')}\n`);
+  return { stateDir, machine, file, registry, recordKey, cleanup: () => SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'replicated journal compaction fixture' }) };
+}

--- a/tests/unit/ReplicatedJournalCompactor.test.ts
+++ b/tests/unit/ReplicatedJournalCompactor.test.ts
@@ -1,0 +1,37 @@
+// safe-fs-allow: fixtures live only under os.tmpdir and are removed after each test.
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { LEARNING_KIND_REGISTRATION, LEARNING_RECORD_KIND, buildLearningRecordData } from '../../src/core/LearningsReplicatedStore.js';
+import { ReplicatedJournalCompactor } from '../../src/core/ReplicatedJournalCompactor.js';
+import { ReplicatedKindRegistry } from '../../src/core/ReplicatedRecordEnvelope.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { LearningEntry } from '../../src/core/types.js';
+
+const SELF = 'm_compact';
+let dir: string | undefined;
+afterEach(() => { if (dir) SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'ReplicatedJournalCompactor unit fixture' }); dir = undefined; });
+
+function fixture(): { stateDir: string; file: string; registry: ReplicatedKindRegistry } {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'journal-compact-unit-'));
+  const journalDir = path.join(dir, 'state', 'coherence-journal');
+  fs.mkdirSync(journalDir, { recursive: true });
+  const file = path.join(journalDir, `${SELF}.${LEARNING_RECORD_KIND}.jsonl`);
+  const registry = new ReplicatedKindRegistry(); registry.register(LEARNING_KIND_REGISTRATION);
+  const base: LearningEntry = { id: 'LRN-1', title: 'same', category: 'ops', description: 'v', source: { discoveredAt: '2026-07-10T00:00:00.000Z' }, tags: [], applied: false };
+  const lines = [1, 2, 3].map((seq) => JSON.stringify({ seq, ts: seq, machine: SELF, kind: LEARNING_RECORD_KIND, data: buildLearningRecordData({ record: { ...base, applied: seq === 3 }, hlc: { physical: seq, logical: 0, node: SELF }, origin: SELF }) }));
+  fs.writeFileSync(file, `${lines.join('\n')}\n`);
+  return { stateDir: dir, file, registry };
+}
+
+describe('ReplicatedJournalCompactor', () => {
+  it('drops superseded versions while preserving the latest witness', () => {
+    const f = fixture();
+    const result = new ReplicatedJournalCompactor({ stateDir: f.stateDir, registry: f.registry, enabled: true, dryRun: false }).run();
+    expect(result).toMatchObject({ originalRecords: 3, compactedRecords: 1, filesCompacted: 1 });
+    const rows = fs.readFileSync(f.file, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].data.hlc.physical).toBe(3);
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -420,15 +420,18 @@ describe('lint-dev-agent-dark-gate', () => {
       '1348': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
       '1358': 'multiMachine.sessionPool.inboundQueue.enabled',
       '1387': 'multiMachine.sessionPool.holdForStability.enabled',
-      '1582': 'multiMachine.stateSync.threadlinePairing.enabled',
+      // replicated-journal-compaction adds a 5-line compaction default block
+      // above stateSync. It uses `run:false` (not an `enabled` gate), so the
+      // attributed path set is unchanged and the four rows below shift by +5.
+      '1587': 'multiMachine.stateSync.threadlinePairing.enabled',
       // commitment-auto-expiry (2026-07-10): a 6-line `commitments.autoExpiry`
       // default sub-block was inserted above `promiseBeacon`/`cartographer`.
       // Its `enabled: true` literal is an explicit fleet-on default, not a dark
       // default, so it adds NO attributed dark-gate row; it shifts the cartographer
       // `enabled: false` rows below it DOWN by +6.
-      '1729': 'cartographer.freshnessSweep.enabled',
-      '1774': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1799': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1734': 'cartographer.freshnessSweep.enabled',
+      '1779': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1804': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/upgrades/eli16/replicated-journal-compaction.md
+++ b/upgrades/eli16/replicated-journal-compaction.md
@@ -1,0 +1,19 @@
+# ELI16 — Safe replicated-journal compaction
+
+## What changed
+
+Replicated records live in append-only journal files. Historical re-emits left many old versions of the same key on disk even though only the newest version per machine can affect current state. This adds an explicit one-shot compactor that streams each registered record journal, retains the newest HLC version per `(origin, recordKey)`, and reports the before/after record count.
+
+## Why it is safe
+
+The feature is off by default and its first enabled posture is dry-run. A real run writes a separate temporary stream, syncs it to disk, rebuilds the witness answers from those actual bytes, and requires exact parity with the original before an atomic rename. Any error or interruption before rename leaves the original byte-for-byte intact.
+
+That read-back check matters: it validates the bytes that would actually replace the journal, not merely the in-memory compaction plan.
+
+## How to verify
+
+Unit coverage proves superseded versions disappear without changing the winning witness. Integration coverage proves dry-run writes nothing and a real run reclaims bytes with the same rebuilt witness. The crash test interrupts immediately before rename and proves the original survives unchanged.
+
+A fresh install with no journal or peers directory is an explicit no-op: there are no replicated streams to compact.
+
+The hand-authored dark-gate attribution map is updated for the ConfigDefaults line shift; the set of enabled-feature paths does not change.

--- a/upgrades/next/replicated-journal-compaction.md
+++ b/upgrades/next/replicated-journal-compaction.md
@@ -1,0 +1,24 @@
+# Replicated-record journal compaction
+
+## What Changed
+
+- An explicit `multiMachine.coherenceJournal.replication.compaction` one-shot path for registered replicated-record streams.
+- Dry-run-first reporting of record and byte reduction.
+- Atomic temp-file, fdatasync, parity-check, rename, and parent-directory fsync commit discipline.
+
+## What to Tell Your User
+
+The replicated-record journal now has a controlled cleanup path that can reclaim old superseded versions without risking the live journal. It reports what it would change first, and a real run proceeds only after the replacement file proves it answers every witness exactly like the original.
+
+## Summary of New Capabilities
+
+- `run` defaults to `false`.
+- `dryRun` defaults to `true`.
+- Journal input is streamed in fixed-size chunks; memory is bounded by the number and size of live keys, not total journal history.
+- Invalid rows are preserved rather than silently deleted.
+- A real replacement is forbidden unless the witness map rebuilt from the compacted temp stream equals the original witness map.
+- An interrupted run before rename retains the original journal.
+
+## Operator note
+
+Enable the one-shot path in dry-run first and inspect its aggregate `N -> M` report. Set dry-run false only for the controlled compaction run, then turn the run flag back off after completion.

--- a/upgrades/side-effects/replicated-journal-compaction.md
+++ b/upgrades/side-effects/replicated-journal-compaction.md
@@ -1,0 +1,38 @@
+# Side-Effects Review — Replicated journal compaction
+
+## Summary
+
+Adds a store-agnostic, one-shot compactor for registered replicated-record JSONL streams. It streams the source, keeps the HLC-max row per `(origin, recordKey)`, preserves invalid rows, writes a temporary stream, syncs it, rebuilds the compacted witness map, and atomically renames only after parity.
+
+## Decision points
+
+- The path is explicit opt-in and dry-run-first; it never runs merely because replication is enabled.
+- Rename is the only commit point. Temp write, fdatasync, compacted-byte witness rebuild, and parity all precede it.
+- Parity is checked twice: once for the planned winners and again after parsing the persisted temporary stream.
+- A parity mismatch throws, deletes only the temporary file, and keeps the source.
+- Memory scales with live keys, not historical journal rows; the full source is never materialized.
+
+## Interactions and risks
+
+- The compactor runs during server wiring before replicated emitters and pull loops attach, avoiding concurrent record appends during replacement.
+- Sequence numbers on retained rows are preserved. Readers already tolerate sparse history and fold by HLC.
+- Invalid/torn parseable rows are not candidates for supersession and are carried through.
+- After a real rename, the shared reader rebuilds its derived index from committed files.
+- PII record kinds use the same registry/schema validation and gain no new fields or egress.
+- Missing journal or peers directories mean no streams exist yet and are handled as an explicit no-op.
+- ConfigDefaults gains no new `enabled` gate; the hand-authored dark-gate attribution map is advanced by the five inserted lines and retains the same path set.
+
+## Rollback
+
+Turning the run flag off disables the path. Reverting code requires no schema migration. Already-compacted streams remain valid journals containing the same live witnesses; dead intermediate versions are intentionally unrecoverable after a successful parity-checked commit.
+
+## Evidence
+
+- Unit: superseded rows collapse and latest witness survives.
+- Integration: default dry-run reports `3 -> 1` without writing; real run shrinks bytes and preserves reader witness.
+- E2E/crash: injected interruption after temp fsync and before rename leaves the original byte-for-byte intact and cleans the temp.
+- Full lint, TypeScript, build, and the existing witness-index integration test pass.
+
+## Class closure
+
+The disk-bloat class is closed structurally: future controlled compaction uses coded streaming, a derived-witness correctness oracle, and an atomic commit point rather than manual journal editing or in-place mutation.


### PR DESCRIPTION
## ELI16

Replicated-store journals are append-only, so historical re-emits left roughly 61,000 rows on disk even though only about 632 live keys matter. #1425 made witness reads O(1); this closes the disk-side residual with an explicit one-shot compactor.

The compactor streams each registered record journal, keeps the newest HLC version per `(origin, recordKey)`, preserves invalid rows, and reports the before/after count. It is off by default and defaults to dry-run when explicitly invoked.

## Safety

- Never edits the source in place.
- Writes a separate temp stream, fdatasyncs it, rebuilds witnesses from the actual compacted bytes, and requires exact parity with the original witness map.
- Atomic rename is the sole commit point; the parent directory is fsynced afterward.
- Any error or interruption before rename leaves the original byte-for-byte intact and cleans the temp.
- Source reads are fixed-chunk streaming; memory is bounded by live keys rather than journal history.
- Runs during server wiring before replicated emitters and pull loops attach, then rebuilds the derived witness index after a real replacement.

## Validation

- Unit: superseded versions collapse and latest witness survives.
- Integration: dry-run reports `3 -> 1` without writing; real run shrinks bytes and preserves the reader witness.
- E2E/crash: injected interruption after temp fsync and before rename preserves the original byte-for-byte.
- Existing witness-index integration test passes.
- `npm run lint`, `npx tsc --noEmit`, `npm run build`, upgrade-guide check, and instar-dev precommit pass.

## Artifacts

- ELI16, upgrades/next, side-effects review, and fresh Tier-1 trace are included in the commit.
