### PR TITLE
fix(replication): move witness rebuild after boot

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-11T00-07-57-350Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-11T00-07-57-350Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-11T00:07:57.350Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 117,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-11T00-06-10-000Z-witness-index-async-boot.json
+++ b/.instar/instar-dev-traces/2026-07-11T00-06-10-000Z-witness-index-async-boot.json
@@ -1,0 +1,24 @@
+{
+  "version": 2,
+  "sessionId": "telegram-458-witness-index-async-boot",
+  "timestamp": "2026-07-11T00:06:10.000Z",
+  "artifactPath": "upgrades/side-effects/witness-index-async-boot.md",
+  "artifactSha256": "6bdbe25ca311da8ed2176f196cd045f1b5348183871d1ee077dd2c2499aa63af",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/core/ReplicatedPeerStreamReader.ts",
+    "tests/unit/ReplicatedPeerStreamReader.test.ts",
+    "tests/integration/replicated-witness-index.integration.test.ts",
+    "tests/e2e/replicated-witness-index-lifecycle.test.ts",
+    "upgrades/eli16/witness-index-async-boot.md",
+    "upgrades/next/witness-index-async-boot.md",
+    "upgrades/side-effects/witness-index-async-boot.md"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Boot-critical regression fix to derived replicated-store infrastructure. No authority or schema change; correctness remains on the legacy scan until a generation-fenced, independently parity-checked candidate is complete.",
+  "eli16Path": "upgrades/eli16/witness-index-async-boot.md",
+  "sideEffectsPath": "upgrades/side-effects/witness-index-async-boot.md",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4470,7 +4470,6 @@ export async function startServer(options: StartOptions): Promise<void> {
             logger: (m) => console.log(pc.dim(`  ${m}`)),
           }).run();
           // A real run replaced streams atomically; rebuild from the committed files.
-          if (compactionConfig.dryRun === false) replicatedPeerStreamReader.rebuildWitnessIndex();
         }
         coherenceJournal.setReplicatedRecordCommitObserver((kind, entries) => {
           replicatedPeerStreamReader?.observeCommittedEntries(kind, entries);
@@ -22674,6 +22673,10 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.error('  Boot health beacon stop failed (continuing to bind real server):', err instanceof Error ? err.message : err);
     }
     await server.start();
+    // #1425 regression containment: only begin the cooperative witness-index +
+    // parity scans AFTER the HTTP server is listening. Until publication the
+    // reader serves the legacy witness path, never a partial candidate index.
+    void replicatedPeerStreamReader?.rebuildWitnessIndexAsync();
     void taskFlowSweeper; void taskFlowDueWaker; void divergenceChecker;
 
     // ── No-LOSS recovery: re-run inbound events stranded in 'processing' (spec §8 G3a) ──

--- a/src/core/ReplicatedPeerStreamReader.ts
+++ b/src/core/ReplicatedPeerStreamReader.ts
@@ -71,6 +71,7 @@ interface WitnessIndexEntry {
 interface RegisteredStreamRecord {
   store: string;
   recordKey: string;
+  origin: string;
   hlc: HlcTimestamp;
 }
 
@@ -85,6 +86,8 @@ export interface ReplicatedPeerStreamReaderConfig {
   fsImpl?: JournalFs;
   /** Optional logger for parity/index degradation. */
   logger?: (msg: string) => void;
+  /** Control seam for non-server consumers. The server starts rebuild after listen. */
+  autoRebuild?: boolean;
 }
 
 function realFs(): JournalFs {
@@ -123,9 +126,11 @@ export class ReplicatedPeerStreamReader {
   private readonly selfMachineId: string;
   private readonly io: JournalFs;
   private readonly logger?: (msg: string) => void;
-  private witnessIndexTrusted = true;
+  private witnessIndexTrusted = false;
   private readonly witnessIndex = new Map<string, WitnessIndexEntry>();
   private loggedWitnessParityMismatch = false;
+  private witnessGeneration = 0;
+  private rebuildRunning = false;
 
   constructor(config: ReplicatedPeerStreamReaderConfig) {
     if (!config) throw new Error('ReplicatedPeerStreamReader: config required');
@@ -138,7 +143,10 @@ export class ReplicatedPeerStreamReader {
     this.selfMachineId = config.selfMachineId;
     this.io = config.fsImpl ?? realFs();
     this.logger = config.logger;
-    this.rebuildWitnessIndex();
+    // Boot-critical invariant: constructor performs NO journal scan. Until the
+    // cooperative rebuild + parity pass completes, loadWitness serves the
+    // legacy path. Production starts this explicitly only after server.listen.
+    if (config.autoRebuild === true) setImmediate(() => { void this.rebuildWitnessIndexAsync(); });
   }
 
   // ── The ReplicatedStoreReader seams ────────────────────────────────────────
@@ -200,6 +208,7 @@ export class ReplicatedPeerStreamReader {
       if (!rec) continue;
       this.putWitness(rec.store, rec.recordKey, rec.hlc, this.witnessIndex);
     }
+    this.witnessGeneration++;
   }
 
   /** Rebuild the derived witness index from the journal streams and parity-check it. */
@@ -224,6 +233,43 @@ export class ReplicatedPeerStreamReader {
     this.witnessIndexTrusted = true;
     this.witnessIndex.clear();
     for (const [k, v] of next.entries()) this.witnessIndex.set(k, v);
+  }
+
+  /**
+   * Cooperative post-boot rebuild. Each filesystem read is one fixed chunk and
+   * yields before the next, so journal size cannot monopolize boot/the event loop.
+   * The candidate map is never served until a separate cooperative legacy pass
+   * agrees. A durable append during either pass invalidates publication and queues
+   * a fresh rebuild, preventing a half-built/stale index from becoming trusted.
+   */
+  async rebuildWitnessIndexAsync(): Promise<void> {
+    if (this.rebuildRunning) return;
+    this.rebuildRunning = true;
+    const generation = this.witnessGeneration;
+    try {
+      const next = new Map<string, WitnessIndexEntry>();
+      await this.scanRegisteredStreamsAsync((rec) => this.putWitness(rec.store, rec.recordKey, rec.hlc, next));
+      const legacy = await this.scanWitnessesLegacyAsync();
+      if (generation !== this.witnessGeneration) {
+        setImmediate(() => { void this.rebuildWitnessIndexAsync(); });
+        return;
+      }
+      if (!this.witnessMapsEqual(next, legacy)) {
+        this.witnessIndexTrusted = false;
+        if (!this.loggedWitnessParityMismatch) {
+          this.loggedWitnessParityMismatch = true;
+          this.logger?.('[replicated-peer-stream-reader] witness index parity mismatch; falling back to legacy scan until rebuild parity is restored');
+        }
+        return;
+      }
+      this.witnessIndex.clear();
+      for (const [key, value] of next) this.witnessIndex.set(key, value);
+      this.witnessIndexTrusted = true;
+    } catch { /* @silent-fallback-ok: derived optimization only; legacy witness scanning remains authoritative while an async rebuild fails. */
+      this.witnessIndexTrusted = false;
+    } finally {
+      this.rebuildRunning = false;
+    }
   }
 
   // ── The snapshot-serve seam (replaces loadOwnEntries: () => ({})) ──────────
@@ -327,6 +373,21 @@ export class ReplicatedPeerStreamReader {
     }
   }
 
+  private async scanRegisteredStreamsAsync(visit: (record: RegisteredStreamRecord) => void): Promise<void> {
+    for (const store of this.registry.stores()) {
+      const reg = this.registry.getByStore(store);
+      if (!reg) continue;
+      const kind = reg.kind as JournalKind;
+      const files = [...this.ownStreamFiles(this.selfMachineId, kind), ...this.peerStreamFiles(kind)];
+      for (const file of files) {
+        await this.forEachJournalEntryInFileAsync(file, (entry) => {
+          const rec = this.validRegisteredRecord(store, reg.schema, kind, entry);
+          if (rec) visit(rec);
+        });
+      }
+    }
+  }
+
   /**
    * Legacy witness answer used only for parity mode. This intentionally uses the
    * pre-index materializer so an attribution bug in the derived index is caught
@@ -345,6 +406,19 @@ export class ReplicatedPeerStreamReader {
     return out;
   }
 
+  /** Separate parity fold: latest per (store, key, origin), then max by key. */
+  private async scanWitnessesLegacyAsync(): Promise<Map<string, WitnessIndexEntry>> {
+    const byOrigin = new Map<string, RegisteredStreamRecord>();
+    await this.scanRegisteredStreamsAsync((rec) => {
+      const key = `${rec.store}${WITNESS_KEY_SEPARATOR}${rec.recordKey}${WITNESS_KEY_SEPARATOR}${rec.origin}`;
+      const prior = byOrigin.get(key);
+      if (!prior || HybridLogicalClock.compare(rec.hlc, prior.hlc) > 0) byOrigin.set(key, rec);
+    });
+    const out = new Map<string, WitnessIndexEntry>();
+    for (const rec of byOrigin.values()) this.putWitness(rec.store, rec.recordKey, rec.hlc, out);
+    return out;
+  }
+
   private validRegisteredRecord(
     store: string,
     schema: StoreFieldSchema,
@@ -359,6 +433,7 @@ export class ReplicatedPeerStreamReader {
     return {
       store,
       recordKey: result.envelope.recordKey,
+      origin: result.envelope.origin,
       hlc: result.envelope.hlc,
     };
   }
@@ -412,9 +487,38 @@ export class ReplicatedPeerStreamReader {
       if (fd !== null) {
         try {
           this.io.closeSync(fd);
-        } catch {
-          /* best-effort */
+        } catch { /* @silent-fallback-ok: closing a derived-index read descriptor is best-effort; the authoritative journal remains intact. */
         }
+      }
+    }
+  }
+
+  /** Fixed-chunk cooperative reader: at most one 64 KiB sync read per turn. */
+  private async forEachJournalEntryInFileAsync(filePath: string, visit: (entry: JournalEntry) => void): Promise<void> {
+    if (!this.io.existsSync(filePath)) return;
+    let fd: number | null = null;
+    try {
+      fd = this.io.openSync(filePath, 'r');
+      const buf = Buffer.alloc(STREAM_CHUNK_BYTES);
+      const decoder = new StringDecoder('utf8');
+      let carry = '';
+      for (;;) {
+        const read = this.io.readSync(fd, buf, 0, buf.length, null);
+        if (read <= 0) break;
+        carry += decoder.write(buf.subarray(0, read));
+        let nl: number;
+        while ((nl = carry.indexOf('\n')) >= 0) {
+          const line = carry.slice(0, nl);
+          carry = carry.slice(nl + 1);
+          this.parseJournalLine(line, visit);
+        }
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+      carry += decoder.end();
+      this.parseJournalLine(carry, visit);
+    } finally {
+      if (fd !== null) {
+        try { this.io.closeSync(fd); } catch { /* @silent-fallback-ok: closing a derived-index read descriptor is best-effort; legacy reads remain authoritative. */ }
       }
     }
   }

--- a/tests/e2e/replicated-witness-index-lifecycle.test.ts
+++ b/tests/e2e/replicated-witness-index-lifecycle.test.ts
@@ -52,7 +52,7 @@ describe('replicated witness index lifecycle', () => {
     dir = undefined;
   });
 
-  it('rebuilds from own + peer journal streams after index loss', () => {
+  it('rebuilds from own + peer journal streams after index loss', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'witness-index-e2e-'));
     const reg = registry();
     const journal = new CoherenceJournal({ stateDir: dir, machineId: SELF, flushIntervalMs: 1_000_000 });
@@ -67,7 +67,8 @@ describe('replicated witness index lifecycle', () => {
       journal.flush();
       applyPeer(applier, buildLearningRecordData({ record, hlc: hlc(2500, PEER), origin: PEER })!);
 
-      const rebuilt = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg, selfMachineId: SELF });
+      const rebuilt = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg, selfMachineId: SELF, autoRebuild: false });
+      await rebuilt.rebuildWitnessIndexAsync();
       expect(rebuilt.loadWitness(LEARNING_STORE_KEY, rk)?.physical).toBe(2500);
       expect(rebuilt.loadOriginRecords(LEARNING_STORE_KEY, rk).map((r) => r.origin).sort()).toEqual([PEER, SELF].sort());
     } finally {

--- a/tests/integration/replicated-witness-index.integration.test.ts
+++ b/tests/integration/replicated-witness-index.integration.test.ts
@@ -55,7 +55,7 @@ describe('replicated witness index integration', () => {
     dir = undefined;
   });
 
-  it('real emitter path reads the derived witness index instead of the journal stream', () => {
+  it('real emitter path reads the derived witness index instead of the journal stream', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'witness-index-int-'));
     const reg = registry();
     const journal = new CoherenceJournal({ stateDir: dir, machineId: SELF, flushIntervalMs: 1_000_000 });
@@ -68,7 +68,8 @@ describe('replicated witness index integration', () => {
       journal.flush();
 
       const counted = countingFs();
-      const reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg, selfMachineId: SELF, fsImpl: counted.io });
+      const reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg, selfMachineId: SELF, fsImpl: counted.io, autoRebuild: false });
+      await reader.rebuildWitnessIndexAsync();
       journal.setReplicatedRecordCommitObserver((kind, entries) => reader.observeCommittedEntries(kind, entries));
       counted.reset();
 

--- a/tests/unit/ReplicatedPeerStreamReader.test.ts
+++ b/tests/unit/ReplicatedPeerStreamReader.test.ts
@@ -106,12 +106,29 @@ describe('ReplicatedPeerStreamReader', () => {
     journal.open();
     journal.setReplicatedKindRegistry(registry);
     applier = new JournalSyncApplier({ stateDir: dir, replicatedRegistry: registry });
-    reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry, selfMachineId: SELF });
+    reader = new ReplicatedPeerStreamReader({ stateDir: dir, registry, selfMachineId: SELF, autoRebuild: false });
     attachWitnessObservers(journal, applier, () => reader);
   });
   afterEach(() => {
     try { journal.close(); } catch { /* best-effort */ }
     SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/ReplicatedPeerStreamReader.test.ts' });
+  });
+
+  it('does not scan a large journal on the boot-critical constructor path', () => {
+    const journalDir = path.join(dir, 'state', 'coherence-journal');
+    fs.mkdirSync(journalDir, { recursive: true });
+    const data = buildLearningRecordData({ record: learning(), hlc: hlc(1000, SELF), origin: SELF })!;
+    const line = `${JSON.stringify({ seq: 1, ts: '2026-07-10T00:00:00.000Z', machine: SELF, kind: LEARNING_RECORD_KIND, data })}\n`;
+    fs.writeFileSync(path.join(journalDir, `${SELF}.${LEARNING_RECORD_KIND}.jsonl`), line.repeat(25_000));
+    const counted = countingFs();
+
+    const started = performance.now();
+    const bootReader = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg(), selfMachineId: SELF, fsImpl: counted.io });
+    const elapsedMs = performance.now() - started;
+
+    expect(counted.reads()).toBe(0);
+    expect(elapsedMs).toBeLessThan(50);
+    void bootReader;
   });
 
   it('materializes OWN + PEER records as distinct origins for the same recordKey', () => {
@@ -182,13 +199,15 @@ describe('ReplicatedPeerStreamReader', () => {
     expect(reader.loadWitness(LEARNING_STORE_KEY, rk)?.physical).toBe(3000);
   });
 
-  it('does not read journal bytes during an emit witness lookup once the index is built', () => {
+  it('does not read journal bytes during an emit witness lookup once the index is built', async () => {
     const rk = deriveLearningRecordKey('tmux colon', 'ops', SRC)!;
     journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning(), hlc: hlc(1000, SELF), origin: SELF })!);
     journal.flush();
 
     const counted = countingFs();
-    const indexedReader = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg(), selfMachineId: SELF, fsImpl: counted.io });
+    const indexedReader = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg(), selfMachineId: SELF, fsImpl: counted.io, autoRebuild: false });
+    expect(counted.reads()).toBe(0);
+    await indexedReader.rebuildWitnessIndexAsync();
     expect(counted.reads()).toBeGreaterThan(0);
     counted.reset();
 
@@ -211,13 +230,14 @@ describe('ReplicatedPeerStreamReader', () => {
     expect(counted.reads()).toBe(0);
   });
 
-  it('rebuilds the witness index from authoritative journal streams after in-memory loss', () => {
+  it('rebuilds the witness index from authoritative journal streams after in-memory loss', async () => {
     const rk = deriveLearningRecordKey('tmux colon', 'ops', SRC)!;
     journal.emitReplicatedRecord(LEARNING_RECORD_KIND, buildLearningRecordData({ record: learning(), hlc: hlc(1000, SELF), origin: SELF })!);
     journal.flush();
     applyPeerRecord(applier, buildLearningRecordData({ record: learning(), hlc: hlc(2500, PEER), origin: PEER })!, 1);
 
-    const rebuilt = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg(), selfMachineId: SELF });
+    const rebuilt = new ReplicatedPeerStreamReader({ stateDir: dir, registry: reg(), selfMachineId: SELF, autoRebuild: false });
+    await rebuilt.rebuildWitnessIndexAsync();
     expect(rebuilt.loadWitness(LEARNING_STORE_KEY, rk)?.physical).toBe(2500);
   });
 

--- a/upgrades/eli16/witness-index-async-boot.md
+++ b/upgrades/eli16/witness-index-async-boot.md
@@ -1,0 +1,15 @@
+# ELI16 — Witness index no longer blocks boot
+
+## What changed
+
+The replicated-store witness index used to scan every own and peer journal twice while the server was still booting. A large journal could keep the server from listening long enough for its supervisor to terminate and restart it forever.
+
+The reader constructor now performs zero journal reads. The server starts the rebuild only after it is listening. Rebuild and parity still stream fixed-size chunks, but yield to the event loop after every chunk. Until both passes finish and agree, witness lookups use the established legacy path.
+
+## Why it is safe
+
+No partial candidate index is ever trusted. A durable append increments a generation fence; if anything changes while either pass is running, that candidate is discarded and a new rebuild is queued. A parity mismatch still logs loudly and keeps the legacy path active.
+
+## Evidence
+
+A regression test creates a multi-megabyte journal and proves reader construction performs zero journal reads and returns promptly. Unit, integration, and e2e tests cover legacy-before-ready behavior, async publication, O(1) lookup after publication, and rebuild from own plus peer streams.

--- a/upgrades/next/witness-index-async-boot.md
+++ b/upgrades/next/witness-index-async-boot.md
@@ -1,0 +1,20 @@
+# Witness index boot safety
+
+## What Changed
+
+Large replicated journals no longer delay server boot. Witness-index construction and its parity pass begin only after the server is listening and yield between fixed-size journal chunks.
+
+## What to Tell Your User
+
+Agents with large replicated histories can start normally again. The optimization warms in the background while the existing correct witness lookup remains active.
+
+## Summary of New Capabilities
+
+- Zero journal reads in the peer-stream reader constructor.
+- Post-listen cooperative index and parity rebuild.
+- Generation fencing prevents a stale or half-built index from being published.
+- Existing parity mismatch fallback remains intact.
+
+## Evidence
+
+The regression fixture builds a multi-megabyte replicated journal. Before this fix, construction synchronously read the journal twice; after this fix, construction performs zero journal reads and returns within the bounded threshold, while the post-listen rebuild produces the same witness answer.

--- a/upgrades/side-effects/witness-index-async-boot.md
+++ b/upgrades/side-effects/witness-index-async-boot.md
@@ -1,0 +1,26 @@
+# Side-Effects Review — Witness index async boot
+
+## Summary
+
+Moves replicated witness-index rebuild and parity off the boot-critical path. The server listens first; the reader then scans one fixed chunk per event-loop turn. The index remains untrusted until the complete candidate and independent latest-per-origin parity fold agree.
+
+## Safety and interactions
+
+- Before/during rebuild, witness lookup uses the legacy authoritative scan.
+- A candidate map is local and never served half-built.
+- Durable local or peer appends increment a generation; a changed generation prevents publication and schedules a fresh pass.
+- Parity mismatch or rebuild error leaves the index untrusted and logs/falls back as before.
+- The synchronous rebuild method remains available for explicit tooling/tests, but production boot wiring uses only the post-listen cooperative method.
+- Fixed 64 KiB reads bound each event-loop slice independently of total journal size.
+
+## Regression surface
+
+The shipped regression was a roughly 50 MB peer evolution-action journal causing two synchronous boot scans before listen, exceeding the supervisor window and crash-looping. The new large-journal test pins zero constructor reads and prompt initialization. Existing unit, integration, and e2e index tests now await readiness explicitly where they assert indexed O(1) behavior.
+
+## Rollback
+
+Reverting restores synchronous constructor rebuild and therefore restores the boot wedge. There is no persisted schema or data migration in this fix.
+
+## Class-Closure Declaration
+
+This closes the synchronous-derived-cache-build-on-boot class structurally: constructors do no bulk journal work, serving begins before optimization warmup, chunked work yields, and publication is parity- plus generation-gated.


### PR DESCRIPTION
## ELI16

A large replicated journal could crash-loop boot because #1425 synchronously scanned all streams twice before the server listened. This moves index rebuild and parity after listen and yields after each fixed-size chunk.

## Safety

Until a complete candidate passes the independent legacy parity fold, witness reads use the existing legacy path. Durable appends increment a generation fence; a changed generation discards the candidate and schedules a fresh rebuild. No partial index is trusted.

## Evidence

The regression test creates a multi-megabyte journal and proves construction performs zero journal reads and returns promptly. Unit, integration, e2e, no-silent-fallbacks, typecheck, lint, build, and the instar-dev gate pass locally. Full CI is the authority.