### PR TITLE
fix: self-heal retired Codex models

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-11T02-22-54-194Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-11T02-22-54-194Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-11T02:22:54.194Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 75,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/core/CodexCliIntelligenceProvider.ts
+++ b/src/core/CodexCliIntelligenceProvider.ts
@@ -23,7 +23,12 @@ import { mkdtempSync, existsSync, readFileSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { IntelligenceProvider, IntelligenceOptions } from './types.js';
-import { resolveCliModelFlag } from '../providers/adapters/openai-codex/models.js';
+import {
+  CODEX_CHATGPT_FALLBACK_MODEL,
+  resolveCliModelFlag,
+} from '../providers/adapters/openai-codex/models.js';
+import { classifyCodexErrorMessage } from '../providers/adapters/openai-codex/observability/eventNormalizer.js';
+import { KNOWN_CODEX_MODEL_IDS } from './ModelTierEscalation.js';
 import {
   buildCodexChildEnv,
   spawnCodexExecJson,
@@ -356,10 +361,38 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
     } catch {
       execJson = execJsonEnvDefault(); // a throwing resolver must not take the call down
     }
-    if (execJson) {
-      return this.evaluateExecJson(prompt, options, model);
+    try {
+      return await this.evaluateWithModel(prompt, options, model, execJson);
+    } catch (error) {
+      if (
+        model !== CODEX_CHATGPT_FALLBACK_MODEL &&
+        classifyCodexErrorMessage((error as Error).message) === 'unsupported' &&
+        KNOWN_CODEX_MODEL_IDS.includes(CODEX_CHATGPT_FALLBACK_MODEL)
+      ) {
+        // @silent-fallback-ok — deliberate, bounded self-heal for Codex's
+        // exact ChatGPT-account model-retirement signature. The retry uses a
+        // live-verified known-good floor and is never recursively retried.
+        try { options?.onModel?.({ model: CODEX_CHATGPT_FALLBACK_MODEL, framework: 'codex-cli' }); } catch { /* @silent-fallback-ok: onModel is pure observability */ }
+        return this.evaluateWithModel(
+          prompt,
+          options,
+          CODEX_CHATGPT_FALLBACK_MODEL,
+          execJson,
+        );
+      }
+      throw error;
     }
-    return this.evaluatePlain(prompt, options, model);
+  }
+
+  private evaluateWithModel(
+    prompt: string,
+    options: IntelligenceOptions | undefined,
+    model: string,
+    execJson: boolean,
+  ): Promise<string> {
+    return execJson
+      ? this.evaluateExecJson(prompt, options, model)
+      : this.evaluatePlain(prompt, options, model);
   }
 
   /**

--- a/src/providers/adapters/openai-codex/models.ts
+++ b/src/providers/adapters/openai-codex/models.ts
@@ -47,10 +47,9 @@ import type { ModelTier } from '../../types.js';
  * burns ~50–70x more than the old gpt-5.2 on a trivial prompt). This is an
  * unavoidable cost regression — a working model beats a 400-ing one — but it
  * is worth surfacing for the codex rate-limit picture (cf the self-inflicted
- * cheap-call 429 volume). The structural fix (validate the resolved model
- * against a known-good set + auto-fall-back on a "not supported" 400, so the
- * NEXT retirement self-heals instead of breaking the fleet) is a follow-up —
- * see the Drift-risk note below; this change just stops the active bleeding.
+ * cheap-call 429 volume). The structural fix now lives in
+ * CodexCliIntelligenceProvider: the exact ChatGPT-account model-retirement
+ * response retries once on the known-good floor declared below.
  *
  * TOKEN-BURN observation (same trivial "reply OK" prompt, 2026-05-23):
  *   gpt-5.2 = 103 tokens · gpt-5.3-codex = 5,574 · gpt-5.5 = 7,399.
@@ -93,10 +92,8 @@ import type { ModelTier } from '../../types.js';
  * 2026-06-03 is the second such break after the 2026-04-14 `-codex` retirement).
  * This map is a Rule-3 surface and the codex event-normalizer canary catches the
  * resulting upstream errors (auth-classified error events), but the authoritative
- * fix — validate the resolved name against a known-good set and auto-fall-back on
- * a "not supported" 400 so a retirement self-heals — belongs in a dedicated
- * canary/fallback. Follow-up (the structural companion to this stop-the-bleeding
- * re-point).
+ * fix is the bounded retirement fallback in CodexCliIntelligenceProvider. Its
+ * target is validated against KNOWN_CODEX_MODEL_IDS at the retry authority.
  */
 const TIER_TO_MODEL: Record<ModelTier, string> = {
   // fast — cheapest model accepted on the ChatGPT account. Was non-reasoning
@@ -110,6 +107,14 @@ const TIER_TO_MODEL: Record<ModelTier, string> = {
   // heavy — frontier reasoning model; hard problems + the user's main chat.
   capable: 'gpt-5.5',
 };
+
+/**
+ * Live-verified ChatGPT-subscription floor used only when Codex reports that
+ * the requested model has been retired from that surface. Keep this explicit:
+ * changing normal tier defaults and changing the retirement safety floor are
+ * separate operational decisions.
+ */
+export const CODEX_CHATGPT_FALLBACK_MODEL = 'gpt-5.4-mini';
 
 /**
  * Resolve a tier or raw model string to a concrete model name to pass to

--- a/src/providers/adapters/openai-codex/observability/eventNormalizer.ts
+++ b/src/providers/adapters/openai-codex/observability/eventNormalizer.ts
@@ -98,7 +98,7 @@ export function normalizeCodexJsonlEvent(line: string): CanonicalEvent | null {
         type: 'error',
         message,
         recoverable: false,
-        errorKind: classifyErrorMessage(message),
+        errorKind: classifyCodexErrorMessage(message),
       };
     }
 
@@ -109,7 +109,7 @@ export function normalizeCodexJsonlEvent(line: string): CanonicalEvent | null {
         type: 'error',
         message,
         recoverable: true,
-        errorKind: classifyErrorMessage(message),
+        errorKind: classifyCodexErrorMessage(message),
       };
     }
 
@@ -187,8 +187,13 @@ export function normalizeCodexJsonlEvent(line: string): CanonicalEvent | null {
   }
 }
 
-function classifyErrorMessage(message: string): 'auth' | 'quota' | 'rate-limit' | 'timeout' | 'network' | 'malformed-response' | 'unsupported' | 'unknown' {
-  if (/unauthorized|forbidden|401|403|invalid.*token|not supported.*ChatGPT account/i.test(message)) return 'auth';
+export function classifyCodexErrorMessage(message: string): 'auth' | 'quota' | 'rate-limit' | 'timeout' | 'network' | 'malformed-response' | 'unsupported' | 'unknown' {
+  // This is Codex's specific ChatGPT-account model-retirement response. Keep
+  // it ahead of generic auth classification: callers may safely retry this
+  // one condition with a known-good model, but must surface every neighboring
+  // 400/auth/rate-limit/network failure unchanged.
+  if (/The '[^']+' model is not supported when using Codex with a ChatGPT account\.?/i.test(message)) return 'unsupported';
+  if (/unauthorized|forbidden|401|403|invalid.*token/i.test(message)) return 'auth';
   if (/quota|insufficient_quota/i.test(message)) return 'quota';
   if (/rate.?limit|429/i.test(message)) return 'rate-limit';
   if (/timeout|408|504/i.test(message)) return 'timeout';

--- a/tests/integration/codex-model-retirement-fallback.test.ts
+++ b/tests/integration/codex-model-retirement-fallback.test.ts
@@ -1,0 +1,60 @@
+// safe-git-allow: test fixture writes only inside a private temporary directory.
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CodexCliIntelligenceProvider } from '../../src/core/CodexCliIntelligenceProvider.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    SafeFsExecutor.safeRmSync(dir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/integration/codex-model-retirement-fallback.test.ts:afterEach',
+    });
+  }
+});
+
+describe('Codex model-retirement recovery — structured exec integration', () => {
+  it('carries one prompt through retired-model failure to the known-good floor', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-retirement-integration-'));
+    dirs.push(dir);
+    const binary = path.join(dir, 'codex');
+    const calls = path.join(dir, 'calls.txt');
+    const prompts = path.join(dir, 'prompts.txt');
+    fs.writeFileSync(binary, `#!/bin/sh
+OUTFILE=""
+MODEL=""
+PREV=""
+for arg in "$@"; do
+  if [ "$PREV" = "--output-last-message" ]; then OUTFILE="$arg"; fi
+  if [ "$PREV" = "--model" ]; then MODEL="$arg"; fi
+  PREV="$arg"
+done
+cat >> "${prompts}"
+printf '\n' >> "${prompts}"
+echo "$MODEL" >> "${calls}"
+if [ "$MODEL" = "gpt-5.5" ]; then
+  echo "Error 400: The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account." >&2
+  exit 1
+fi
+printf 'RECOVERED' > "$OUTFILE"
+exit 0
+`, { mode: 0o755 });
+
+    const provider = new CodexCliIntelligenceProvider({ codexPath: binary });
+    await expect(provider.evaluate('classify this', { model: 'gpt-5.5' })).resolves.toBe('RECOVERED');
+
+    expect(fs.readFileSync(calls, 'utf-8').trim().split('\n')).toEqual([
+      'gpt-5.5',
+      'gpt-5.4-mini',
+    ]);
+    expect(fs.readFileSync(prompts, 'utf-8').trim().split('\n')).toEqual([
+      'classify this',
+      'classify this',
+    ]);
+  });
+});

--- a/tests/unit/CodexCliIntelligenceProvider.test.ts
+++ b/tests/unit/CodexCliIntelligenceProvider.test.ts
@@ -165,6 +165,71 @@ describe('CodexCliIntelligenceProvider — per-call timeout (IntelligenceOptions
   });
 });
 
+describe('CodexCliIntelligenceProvider — retired-model fallback', () => {
+  function fallbackFixture(firstError: string, fallbackAlsoFails = false): { binary: string; calls: string } {
+    const fixture = fs.mkdtempSync(path.join(tmpDir, 'retired-model-'));
+    const calls = path.join(fixture, 'calls');
+    const binary = path.join(fixture, 'fake-codex');
+    fs.writeFileSync(binary, `#!/bin/sh
+model=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--model" ]; then model="$arg"; fi
+  prev="$arg"
+done
+echo "$model" >> "${calls}"
+if [ "$model" != "gpt-5.4-mini" ]; then
+  echo "${firstError}" >&2
+  exit 1
+fi
+${fallbackAlsoFails ? 'echo "fallback failed" >&2\nexit 1' : 'echo "RECOVERED"\nexit 0'}
+`, { mode: 0o755 });
+    return { binary, calls };
+  }
+
+  function callsFrom(file: string): string[] {
+    return fs.existsSync(file) ? fs.readFileSync(file, 'utf-8').trim().split('\n') : [];
+  }
+
+  it('retries the exact ChatGPT model-retirement failure once on the known-good floor', async () => {
+    const fixture = fallbackFixture(
+      "Error 400: The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.",
+    );
+    const models: string[] = [];
+    const provider = new CodexCliIntelligenceProvider({ codexPath: fixture.binary });
+
+    await expect(provider.evaluate('hi', {
+      model: 'gpt-5.5',
+      onModel: ({ model }) => models.push(model),
+    })).resolves.toBe('RECOVERED');
+    expect(callsFrom(fixture.calls)).toEqual(['gpt-5.5', 'gpt-5.4-mini']);
+    expect(models).toEqual(['gpt-5.5', 'gpt-5.4-mini']);
+  });
+
+  it.each([
+    ['rate limit', 'Error 429: rate limit exceeded'],
+    ['auth', 'Error 401: unauthorized'],
+    ['different 400', 'Error 400: invalid request body'],
+  ])('does not fall back on %s failures', async (_label, message) => {
+    const fixture = fallbackFixture(message);
+    const provider = new CodexCliIntelligenceProvider({ codexPath: fixture.binary });
+
+    await expect(provider.evaluate('hi', { model: 'gpt-5.5' })).rejects.toThrow(message);
+    expect(callsFrom(fixture.calls)).toEqual(['gpt-5.5']);
+  });
+
+  it('surfaces a fallback failure after exactly one retry', async () => {
+    const fixture = fallbackFixture(
+      "Error 400: The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.",
+      true,
+    );
+    const provider = new CodexCliIntelligenceProvider({ codexPath: fixture.binary });
+
+    await expect(provider.evaluate('hi', { model: 'gpt-5.5' })).rejects.toThrow('fallback failed');
+    expect(callsFrom(fixture.calls)).toEqual(['gpt-5.5', 'gpt-5.4-mini']);
+  });
+});
+
 describe('CodexCliIntelligenceProvider — clean-call (no identity, no hooks)', () => {
   // Regression: judgment calls must NOT run in the agent's project dir, or
   // codex loads the full ~26 KB AGENTS.md identity and fires the project's

--- a/tests/unit/codex-cli-provider-execjson.test.ts
+++ b/tests/unit/codex-cli-provider-execjson.test.ts
@@ -87,6 +87,36 @@ afterEach(() => {
 });
 
 describe('exec-json mode (default)', () => {
+  it('self-heals a retired model through the real exec-json spawn path', async () => {
+    const calls = path.join(fixtureDir, 'fallback-calls.txt');
+    const script = path.join(fixtureDir, 'retired-model.sh');
+    fs.writeFileSync(script, `#!/bin/sh
+OUTFILE=""
+MODEL=""
+PREV=""
+for a in "$@"; do
+  if [ "$PREV" = "--output-last-message" ]; then OUTFILE="$a"; fi
+  if [ "$PREV" = "--model" ]; then MODEL="$a"; fi
+  PREV="$a"
+done
+cat > /dev/null
+echo "$MODEL" >> "${calls}"
+if [ "$MODEL" != "gpt-5.4-mini" ]; then
+  echo "Error 400: The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account." >&2
+  exit 1
+fi
+printf '%s' 'RECOVERED-JSON' > "$OUTFILE"
+exit 0
+`, { mode: 0o755 });
+    const provider = new CodexCliIntelligenceProvider({ codexPath: script });
+
+    await expect(provider.evaluate('p', { model: 'gpt-5.5' })).resolves.toBe('RECOVERED-JSON');
+    expect(fs.readFileSync(calls, 'utf-8').trim().split('\n')).toEqual([
+      'gpt-5.5',
+      'gpt-5.4-mini',
+    ]);
+  });
+
   it('passes --json + absolute --output-last-message, keeps ALL hygiene args, moves the prompt to stdin', async () => {
     const provider = new CodexCliIntelligenceProvider({ codexPath: writeFakeCodex() });
     const usages: Array<{ inputTokens: number; outputTokens: number; cachedTokens?: number }> = [];

--- a/tests/unit/providers/adapters/openai-codex/observability/eventNormalizer.test.ts
+++ b/tests/unit/providers/adapters/openai-codex/observability/eventNormalizer.test.ts
@@ -61,12 +61,20 @@ describe('normalizeCodexJsonlEvent', () => {
     }
   });
 
-  it('classifies auth-style errors as auth-kind', () => {
+  it('classifies the exact ChatGPT model-retirement signature as unsupported', () => {
     const result = normalizeCodexJsonlEvent(
-      '{"type":"error","message":"The model is not supported when using Codex with a ChatGPT account."}',
+      '{"type":"error","message":"The \'gpt-5.2\' model is not supported when using Codex with a ChatGPT account."}',
     );
     expect(result?.type).toBe('error');
-    if (result?.type === 'error') expect(result.errorKind).toBe('auth');
+    if (result?.type === 'error') expect(result.errorKind).toBe('unsupported');
+  });
+
+  it('does not classify a different 400 or an auth failure as model retirement', () => {
+    for (const message of ['400 invalid request body', '401 unauthorized']) {
+      const result = normalizeCodexJsonlEvent(JSON.stringify({ type: 'error', message }));
+      expect(result?.type).toBe('error');
+      if (result?.type === 'error') expect(result.errorKind).not.toBe('unsupported');
+    }
   });
 
   it('exports a stable set of recognized event types', () => {

--- a/upgrades/eli16/codex-model-retirement-fallback.md
+++ b/upgrades/eli16/codex-model-retirement-fallback.md
@@ -1,0 +1,21 @@
+# ELI16 — Codex model retirements self-heal
+
+## What Changed
+
+OpenAI can remove a model from the ChatGPT-account Codex surface without changing Instar. Previously, every small internal Codex judgment call using that model would begin failing until a person found the incident and manually changed the tier map. Instar now recognizes Codex's specific model-retirement response and retries that one call once with a live-verified safe model.
+
+## What to Tell Your User
+
+A retired Codex model should no longer take down classifications, gates, tone checks, or commitment checks across the fleet. The recovery is intentionally narrow: it does not swap models for rate limits, login problems, network failures, or unrelated bad requests, so those real problems remain visible instead of being hidden behind a retry.
+
+## Summary of New Capabilities
+
+- Classify Codex's exact ChatGPT-account “model not supported” response as an unsupported-model signal rather than generic authentication failure.
+- Retry once on `gpt-5.4-mini`, the designated live-verified safe floor and a member of Instar's known Codex model registry.
+- Preserve the original failure behavior for 429s, authentication errors, unrelated 400s, timeouts, and network failures.
+- Stop after the fallback attempt and surface its error if it also fails; there is no recursive or unbounded retry path.
+- Apply the same recovery to both the default structured exec path and the legacy plain-output kill-switch path.
+
+## Evidence
+
+Unit coverage proves both sides of the classification boundary, the exact two-model attempt sequence, fallback failure surfacing, and non-retry behavior for neighboring errors. Exec-path coverage drives the real structured spawn helper through retirement and recovery. Existing provider, event-normalizer, lint, build, and three-tier suites remain the release gates.

--- a/upgrades/next/codex-model-retirement-fallback.md
+++ b/upgrades/next/codex-model-retirement-fallback.md
@@ -1,0 +1,23 @@
+# Upgrade Guide — vNEXT
+
+<!-- assembled-by: assemble-next-md -->
+<!-- bump: patch -->
+
+## What Changed
+
+Internal Codex calls now recover automatically when OpenAI retires their selected model from the ChatGPT-account Codex surface.
+
+## What to Tell Your User
+
+A Codex model retirement no longer silently breaks classifications, gates, tone checks, and commitment checks fleet-wide. Instar retries that exact failure once on a known-good safe model while leaving every other error unchanged.
+
+## Summary of New Capabilities
+
+- Exact unsupported-model classification for the ChatGPT-account retirement response.
+- One bounded retry on the live-verified `gpt-5.4-mini` floor.
+- No fallback for rate limits, authentication failures, unrelated 400s, timeouts, or network failures.
+- Equivalent recovery in structured and legacy Codex execution modes.
+
+## Evidence
+
+Boundary unit tests cover retirement recovery, non-retry error classes, and bounded fallback failure. Structured exec-path coverage proves the real spawn path retries with the safe model and succeeds. Full lint, build, and three-tier tests gate release.

--- a/upgrades/side-effects/codex-model-retirement-fallback.md
+++ b/upgrades/side-effects/codex-model-retirement-fallback.md
@@ -1,0 +1,77 @@
+# Side-Effects Review — Codex model-retirement fallback
+
+**Version / slug:** `codex-model-retirement-fallback`
+**Date:** 2026-07-10
+**Author:** Instar-codey
+**Second-pass reviewer:** not required
+
+## Summary of the change
+
+`eventNormalizer.ts` now emits the existing `unsupported` error kind for Codex's exact ChatGPT-account model-retirement response. `CodexCliIntelligenceProvider` consumes that classified signal and retries once using the explicit `gpt-5.4-mini` safe-floor constant, after verifying it remains in `KNOWN_CODEX_MODEL_IDS`. Both structured and legacy exec modes use the same bounded authority.
+
+## Decision-point inventory
+
+- Codex upstream-error classification — modify — distinguish the model-retirement response from generic authentication errors.
+- Internal Codex retry authority — add — permit one safe-floor retry only for the classified retirement signal.
+
+## 1. Over-block
+
+No legitimate request is blocked. A successful first attempt is unchanged. Failures outside the exact retirement signature continue surfacing exactly as before. A caller already using the fallback floor is never retried, preventing a same-model duplicate call.
+
+## 2. Under-block
+
+If OpenAI changes the retirement wording, the new response will surface rather than trigger recovery; this is deliberately fail-loud. The fallback model can itself be retired, in which case its error surfaces after the single retry. API-key-only model availability is not inferred from generic errors.
+
+## 3. Level-of-abstraction fit
+
+The event normalizer owns provider-native error classification. The intelligence provider owns bounded execution recovery and already controls both spawn modes. The retry consumes the shared classified signal rather than creating a second raw-stderr policy. The known-model registry remains the authority for acceptable Codex model identities.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — the brittle provider-signature detector produces the structured `unsupported` signal; the provider's narrowly enumerated recovery policy consumes it.
+
+This is also a constrained protocol invariant, not conversational judgment. The detector cannot retry anything itself. The authority requires the exact classified condition, a different requested model, and a known registry member before acting.
+
+## 5. Interactions
+
+- **Shadowing:** retirement classification runs before generic auth classification so the recoverable condition is no longer swallowed by the broader category.
+- **Double-fire:** `evaluate()` owns the only retry. The mode-specific execution methods do not recurse and do not contain fallback logic.
+- **Races:** there is no shared mutable retry state; the attempt bound is lexical to one evaluation.
+- **Feedback loops:** the fallback invocation bypasses the outer catch, so a second retirement response surfaces instead of feeding back into another retry.
+- **Observability:** `onModel` receives the original model and then the fallback model. Existing usage callbacks still reflect any structured usage that Codex emitted per attempt.
+
+## 6. External surfaces
+
+Codex-backed agents gain automatic continuity for internal judgment calls during a model retirement. No endpoint, configuration, database, credential, user notice, external network integration, generated URL, or operator action is added. Other error types remain externally visible as failures.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Replicated by code rollout.** The fallback policy has no mutable state; every updated machine applies the same constant, classifier, registry check, and attempt bound independently. It emits no user-facing notice, holds no durable state, does not interact with topic transfer, and generates no URLs.
+
+## 8. Rollback cost
+
+Pure code rollback and patch release. No state migration or agent repair is required. During rollback propagation, a newly retired model would again fail loudly rather than corrupt state or silently choose arbitrary models.
+
+## Conclusion
+
+The recovery is intentionally smaller than a generic retry policy: one exact classified provider response, one registry-checked safe floor, one additional attempt. Boundary tests preserve visibility for neighboring errors and prove the fallback cannot loop. Clear to ship after full gates and CI.
+
+## Second-pass review
+
+Not required by the instar-dev high-risk list: this changes an internal provider error-recovery path, not messaging, session lifecycle, dispatch, compaction, trust, coherence, or a sentinel/guard/gate/watchdog.
+
+## Evidence pointers
+
+- `tests/unit/CodexCliIntelligenceProvider.test.ts`
+- `tests/unit/codex-cli-provider-execjson.test.ts`
+- `tests/unit/providers/adapters/openai-codex/observability/eventNormalizer.test.ts`
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect and no self-triggered controller — not applicable.


### PR DESCRIPTION
## ELI16 — Codex model retirements self-heal

OpenAI can remove a model from the ChatGPT-account Codex surface without changing Instar. Previously, that could break every small internal Codex judgment call until someone manually changed the model map. Instar now recognizes only that specific retirement response and retries the call once on a live-verified safe model. Rate limits, login failures, unrelated bad requests, network errors, and a failing fallback still surface normally.

## Summary
- classify Codex's exact ChatGPT-account model-retirement response as unsupported
- retry internal Codex execution exactly once on the registry-checked gpt-5.4-mini safe floor
- preserve original behavior for 429, auth, unrelated 400, timeout, network, and fallback failures

## Verification
- 49 focused provider/model/normalizer unit tests
- structured exec integration exercising retired model -> safe floor with prompt preservation
- lint, typecheck, build, instar-dev trace and release artifacts
- full matrix delegated to CI via the documented local e2e skip