### PR TITLE
fix: anchor Telegram relay recovery to agent home

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-11T04-12-21-333Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-11T04-12-21-333Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-11T04:12:21.333Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 37,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-11T04-11-44-877Z-telegram-reply-worktree-home-2dac8872.json
+++ b/.instar/instar-dev-traces/2026-07-11T04-11-44-877Z-telegram-reply-worktree-home-2dac8872.json
@@ -1,0 +1,35 @@
+{
+  "version": 3,
+  "sessionId": "46e7cabc-4f2b-439e-a7a2-a88f6a73f395",
+  "timestamp": "2026-07-11T04:11:44.877Z",
+  "artifactPath": "upgrades/side-effects/telegram-reply-worktree-home.md",
+  "artifactSha256": "5c8c810124ead483652a6ab302292dde539fadee7b867d438c5a26a3a83873b9",
+  "coveredFiles": [
+    "src/core/PostUpdateMigrator.ts",
+    "src/templates/scripts/telegram-reply.sh",
+    "tests/integration/telegram-reply-end-to-end.test.ts",
+    "tests/unit/PostUpdateMigrator-telegramReply.test.ts"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "A tightly scoped relay-path correctness fix with deterministic structural ownership, loud invariant refusal, migration parity, and independent high-risk review; no schema or API change.",
+  "eli16Path": "upgrades/eli16/telegram-reply-worktree-home.md",
+  "sideEffectsPath": "upgrades/side-effects/telegram-reply-worktree-home.md",
+  "secondPass": "true",
+  "reviewerConcurred": true,
+  "toolchain": {
+    "buildSkill": {
+      "name": "instar-dev",
+      "version": "5c281366e0da",
+      "verified": true
+    },
+    "reviewSkills": [
+      {
+        "name": "framework_guard_review",
+        "outcome": "concur",
+        "verified": false,
+        "iterations": 1
+      }
+    ]
+  }
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -13269,6 +13269,10 @@ process.stdin.on('end', async () => {
     // Recorded so deployed agents cleanly upgrade to the pre-POST-mint
     // template instead of getting a `.new` candidate.
     '63ca933e2d7c59d92c92d2799afa71b9c75e45caf3ab7c1cb06aa8eb95ba2900',
+    // Pre-worktree-home-resolution version. Shipped through v1.3.813.
+    // Existing agents must receive the constrained agent-home resolver and
+    // loud unknown-id queue refusal rather than an inert `.new` candidate.
+    '89849c10aa30cc83a07d6e7721aa3ebbfd07ab897250c0d0f3e234f079dba153',
   ]);
 
   /**

--- a/src/templates/scripts/telegram-reply.sh
+++ b/src/templates/scripts/telegram-reply.sh
@@ -133,7 +133,21 @@ sys.stdout.write(base64.b64decode(raw, validate=True).decode("utf-8"))
   MSG="$DECODED_MSG"
 fi
 
-# Resolve config-derived values from .instar/config.json (single python3
+# Resolve the owning agent home before reading config or recovery state.
+# Explicit launcher context wins. Otherwise, ONLY the structural .worktrees
+# marker may move us upward; a general config search could cross tenant roots
+# on a multi-agent host. The ordinary agent-home cwd remains unchanged.
+if [ -n "${INSTAR_AGENT_HOME:-}" ]; then
+  AGENT_HOME="$INSTAR_AGENT_HOME"
+else
+  case "$PWD" in
+    */.worktrees/*) AGENT_HOME="${PWD%%/.worktrees/*}" ;;
+    *) AGENT_HOME="$PWD" ;;
+  esac
+fi
+CONFIG_PATH="$AGENT_HOME/.instar/config.json"
+
+# Resolve config-derived values from the owning agent's config (single python3
 # invocation). Env > config > 4040-warn for port. Auth: INSTAR_AUTH_TOKEN env
 # first (SessionManager injects it per spawned session; survives the
 # secret-externalization refactor that moved authToken out of config.json into
@@ -143,11 +157,11 @@ fi
 AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"
 AGENT_ID=""
 CONFIG_PORT=""
-if [ -f ".instar/config.json" ]; then
+if [ -f "$CONFIG_PATH" ]; then
   CONFIG_VALUES=$(python3 -c "
 import json, sys
 try:
-    c = json.load(open('.instar/config.json'))
+    c = json.load(open(sys.argv[1]))
 except Exception:
     sys.exit(0)
 v = c.get('authToken', '')
@@ -156,7 +170,7 @@ print(c.get('projectName', ''))
 print(c.get('port', ''))
 t = (((c.get('messaging') or {}).get('outboundAdvisory') or {}).get('timeoutMs', ''))
 print(t if isinstance(t, (int, float)) else '')
-" 2>/dev/null)
+" "$CONFIG_PATH" 2>/dev/null)
   CONFIG_AUTH=$(printf '%s\n' "$CONFIG_VALUES" | sed -n '1p')
   [ -z "$AUTH_TOKEN" ] && AUTH_TOKEN="$CONFIG_AUTH"
   AGENT_ID=$(printf '%s\n' "$CONFIG_VALUES" | sed -n '2p')
@@ -170,7 +184,7 @@ elif [ -n "$CONFIG_PORT" ]; then
   PORT="$CONFIG_PORT"
 else
   PORT=4040
-  echo "WARN: telegram-reply.sh — no INSTAR_PORT env and no port in .instar/config.json; falling back to 4040" >&2
+  echo "WARN: telegram-reply.sh — no INSTAR_PORT env and no port in $CONFIG_PATH; falling back to 4040" >&2
 fi
 
 # ── Outbound advisory preflight (inform-only; spec outbound-jargon-filepath-gap §2.4) ──
@@ -464,10 +478,15 @@ except Exception:
     # Enqueue (spec § Layer 2b). Path: <stateDir>/state/pending-relay.<agentId>.sqlite
     # Mode 0600 enforced by the Node-side store; the CLI inherits umask, so
     # we explicitly chmod after first create as well.
-    QUEUE_DIR=".instar/state"
-    mkdir -p "$QUEUE_DIR" 2>/dev/null
     # Sanitize agent-id for filename (mirrors src/messaging/pending-relay-store.ts).
     SAFE_AGENT_ID=$(printf '%s' "${AGENT_ID:-unknown}" | tr -c 'A-Za-z0-9._-' '_')
+    if [ "$SAFE_AGENT_ID" = "unknown" ]; then
+      echo "Failed (HTTP $HTTP_CODE): $BODY" >&2
+      echo "  (also: agent id is unknown; refusing to create an undrainable pending-relay.unknown.sqlite store)" >&2
+      exit 1
+    fi
+    QUEUE_DIR="$AGENT_HOME/.instar/state"
+    mkdir -p "$QUEUE_DIR" 2>/dev/null
     QUEUE_DB="${QUEUE_DIR}/pending-relay.${SAFE_AGENT_ID}.sqlite"
 
     # delivery_id — the id was minted BEFORE the initial POST and sent on it

--- a/tests/integration/telegram-reply-end-to-end.test.ts
+++ b/tests/integration/telegram-reply-end-to-end.test.ts
@@ -45,6 +45,35 @@ interface ServerHandle {
   close: () => Promise<void>;
 }
 
+async function runRelay(opts: {
+  cwd: string;
+  topicId: string;
+  message: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ exit: number; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(
+      'bash',
+      [path.join(projectDir, '.claude', 'scripts', 'telegram-reply.sh'), opts.topicId, opts.message],
+      {
+        cwd: opts.cwd,
+        env: {
+          ...process.env,
+          INSTAR_PORT: '',
+          INSTAR_AUTH_TOKEN: '',
+          INSTAR_AGENT_HOME: '',
+          ...opts.env,
+        },
+      },
+    );
+    let stderr = '';
+    child.stdout.on('data', () => {/* swallow */});
+    child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+    child.on('close', (code) => resolve({ exit: code ?? 1, stderr }));
+    child.on('error', (err) => resolve({ exit: 1, stderr: String(err) }));
+  });
+}
+
 function buildServer(opts: {
   agentId: string;
   authToken: string;
@@ -195,5 +224,90 @@ describe('telegram-reply.sh ↔ /events/delivery-failed end-to-end', () => {
     expect(ev.topic_id).toBe(50);
     expect(ev.http_code).toBe(503);
     expect(ev.attempted_port).toBe(server.port);
+  }, 30_000);
+
+  it('resolves a .worktrees cwd to the owning agent home for config and recovery state', async () => {
+    const server = await buildServer({
+      agentId: 'worktree-agent',
+      authToken: 'worktree-token',
+      replyStatus: 503,
+      replyBody: JSON.stringify({ error: 'upstream' }),
+    });
+    fs.writeFileSync(
+      path.join(projectDir, '.instar', 'config.json'),
+      JSON.stringify({ port: server.port, projectName: 'worktree-agent', authToken: 'worktree-token' }),
+    );
+    const worktreeCwd = path.join(projectDir, '.worktrees', 'feature', 'nested');
+    fs.mkdirSync(worktreeCwd, { recursive: true });
+
+    const result = await runRelay({ cwd: worktreeCwd, topicId: '51', message: 'from worktree' });
+    await server.close();
+
+    expect(result.exit).toBe(1);
+    expect(server.replyHits[0]).toMatchObject({
+      authHeader: 'Bearer worktree-token',
+      agentIdHeader: 'worktree-agent',
+    });
+    expect(fs.existsSync(path.join(projectDir, '.instar', 'state', 'pending-relay.worktree-agent.sqlite'))).toBe(true);
+    expect(fs.existsSync(path.join(projectDir, '.worktrees', 'feature', 'nested', '.instar', 'state'))).toBe(false);
+  }, 30_000);
+
+  it('honors INSTAR_AGENT_HOME ahead of the .worktrees cwd marker', async () => {
+    const server = await buildServer({
+      agentId: 'explicit-agent',
+      authToken: 'explicit-token',
+      replyStatus: 503,
+      replyBody: JSON.stringify({ error: 'upstream' }),
+    });
+    const explicitHome = fs.mkdtempSync(path.join(os.tmpdir(), 'tg-reply-explicit-home-'));
+    fs.mkdirSync(path.join(explicitHome, '.instar'), { recursive: true });
+    fs.writeFileSync(
+      path.join(explicitHome, '.instar', 'config.json'),
+      JSON.stringify({ port: server.port, projectName: 'explicit-agent', authToken: 'explicit-token' }),
+    );
+    const worktreeCwd = path.join(projectDir, '.worktrees', 'wrong-owner');
+    fs.mkdirSync(worktreeCwd, { recursive: true });
+
+    try {
+      const result = await runRelay({
+        cwd: worktreeCwd,
+        topicId: '52',
+        message: 'explicit home wins',
+        env: { INSTAR_AGENT_HOME: explicitHome },
+      });
+      await server.close();
+
+      expect(result.exit).toBe(1);
+      expect(server.replyHits[0]).toMatchObject({
+        authHeader: 'Bearer explicit-token',
+        agentIdHeader: 'explicit-agent',
+      });
+      expect(fs.existsSync(path.join(explicitHome, '.instar', 'state', 'pending-relay.explicit-agent.sqlite'))).toBe(true);
+      expect(fs.existsSync(path.join(projectDir, '.instar', 'state', 'pending-relay.explicit-agent.sqlite'))).toBe(false);
+    } finally {
+      try { fs.rmSync(explicitHome, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  }, 30_000);
+
+  it('refuses an unknown agent id loudly without creating an orphan queue', async () => {
+    const server = await buildServer({
+      agentId: 'server-agent',
+      authToken: 'unknown-token',
+      replyStatus: 503,
+      replyBody: JSON.stringify({ error: 'upstream' }),
+    });
+    fs.writeFileSync(
+      path.join(projectDir, '.instar', 'config.json'),
+      JSON.stringify({ port: server.port, authToken: 'unknown-token' }),
+    );
+    const unknownDb = path.join(projectDir, '.instar', 'state', 'pending-relay.unknown.sqlite');
+
+    const result = await runRelay({ cwd: projectDir, topicId: '53', message: 'must stay loud' });
+    await server.close();
+
+    expect(result.exit).toBe(1);
+    expect(result.stderr).toContain('agent id is unknown');
+    expect(result.stderr).toContain('refusing to create an undrainable pending-relay.unknown.sqlite store');
+    expect(fs.existsSync(unknownDb)).toBe(false);
   }, 30_000);
 });

--- a/tests/unit/PostUpdateMigrator-telegramReply.test.ts
+++ b/tests/unit/PostUpdateMigrator-telegramReply.test.ts
@@ -74,6 +74,8 @@ describe('PostUpdateMigrator — telegram-reply.sh 408 migration', () => {
     const script = (migrator as unknown as { getTelegramReplyScript(): string }).getTelegramReplyScript();
     expect(script).toContain('HTTP_CODE" = "408"');
     expect(script).toMatch(/ambiguous/i);
+    expect(script).toContain('INSTAR_AGENT_HOME');
+    expect(script).toContain('refusing to create an undrainable pending-relay.unknown.sqlite store');
   });
 
   it('installs telegram-reply.sh when file is missing', async () => {
@@ -98,6 +100,8 @@ describe('PostUpdateMigrator — telegram-reply.sh 408 migration', () => {
     expect(updated).toMatch(/ambiguous/i);
     expect(updated).toMatch(/X-Instar-AgentId/);
     expect(updated).toMatch(/config\.json/);
+    expect(updated).toContain('INSTAR_AGENT_HOME');
+    expect(updated).toContain('refusing to create an undrainable pending-relay.unknown.sqlite store');
     expect(
       result.upgraded.some(u =>
         u.includes('telegram-reply.sh') &&

--- a/upgrades/eli16/telegram-reply-worktree-home.md
+++ b/upgrades/eli16/telegram-reply-worktree-home.md
@@ -1,0 +1,19 @@
+# ELI16 — Worktree replies return to the owning agent
+
+## What Changed
+
+Instar agents use a small relay script to send a conversational response back to Telegram. That script normally runs from the agent's home directory, where it can read the live server port and agent identity. During development, however, a session can run from a nested Git worktree. The old script treated that worktree as if it were a separate agent home. It could miss the real port, fail its HTTP request, and then save the reply into a database named for an `unknown` agent inside the worktree. No live server owns or drains that database, so the message becomes a ghost row that could surface much later as a duplicate.
+
+The relay now chooses its home conservatively. An explicit `INSTAR_AGENT_HOME` from the launcher wins. Without that variable, the script walks upward only when the current path contains the exact `/.worktrees/` structural marker, stopping immediately before that marker. In every ordinary directory it keeps today's behavior and uses the current directory. It never performs a broad upward search, because that could select another agent's configuration on a shared machine.
+
+## Safety Behavior
+
+Recovery still queues a transiently failed reply when the owning agent identity is known. If the identity is missing and would become `unknown`, the script prints a clear reason and exits non-zero without creating a database. The original message remains visible in the caller's transcript, making the failure recoverable and observable instead of silently stranded.
+
+## Deployment
+
+Fresh installs already source the canonical relay template. Existing agents receive the same template through PostUpdateMigrator: the v1.3.813 shipped-template hash is registered as a known safe predecessor, so an unmodified installed script is backed up and replaced during update while customized scripts retain the existing non-destructive `.new` behavior.
+
+## Evidence
+
+Integration tests execute the real Bash template against a real local HTTP server and SQLite recovery store. They cover worktree cwd resolution, explicit-home precedence, ordinary agent-home behavior, and unknown-id refusal with no orphan database. Unit tests verify migration output contains both safeguards and that historical shipped-template hashes remain complete.

--- a/upgrades/next/telegram-reply-worktree-home.md
+++ b/upgrades/next/telegram-reply-worktree-home.md
@@ -1,0 +1,23 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Telegram replies launched from inside an Instar worktree now resolve the owning agent home before reading relay configuration or writing recovery state. Recovery also refuses loudly when the agent identity is unavailable instead of creating an orphan queue that a server cannot drain.
+
+## What to Tell Your User
+
+Replies sent while development is running inside a worktree now use the same live relay configuration as the owning agent. If identity is genuinely unavailable, the send fails visibly in the session instead of leaving a hidden message that might reappear days later.
+
+## Summary of New Capabilities
+
+- Honors `INSTAR_AGENT_HOME` as the authoritative relay home.
+- Constrains automatic walk-up to the structural `/.worktrees/` marker.
+- Writes recoverable messages into the owning agent's drainable queue.
+- Refuses `pending-relay.unknown.sqlite` creation with a clear non-zero failure.
+- Re-stamps the corrected script onto existing unmodified installs during update.
+
+## Evidence
+
+Real-script integration coverage proves normal agent-home behavior, worktree resolution, explicit-home precedence, and loud unknown-id refusal. Migration tests and the shipped-template SHA ratchet prove fresh installs and existing agents receive the same corrected script.

--- a/upgrades/side-effects/telegram-reply-worktree-home.md
+++ b/upgrades/side-effects/telegram-reply-worktree-home.md
@@ -1,0 +1,77 @@
+# Side-Effects Review — Worktree-safe Telegram relay recovery
+
+**Version / slug:** `telegram-reply-worktree-home`
+**Date:** `2026-07-10`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `framework_guard_review`
+
+## Summary of the change
+
+The canonical `telegram-reply.sh` now resolves its owning agent home from explicit `INSTAR_AGENT_HOME`, otherwise from the exact `/.worktrees/` path marker, otherwise from the unchanged current directory. Config reads and recovery queue writes use that home. Recovery refuses an `unknown` agent id loudly before creating state. PostUpdateMigrator registers the v1.3.813 template SHA so existing unmodified installs receive the fix. Integration and migration tests cover all boundaries.
+
+## Decision-point inventory
+
+- Agent-home resolution — modify — explicit launcher state wins; only a structural worktree marker permits walk-up.
+- Recoverable relay enqueue — modify — known agents retain durable enqueue; unknown identity exits non-zero without an undrainable store.
+- Existing-script migration — modify — the current shipped SHA becomes an allowed predecessor for safe backup-and-replace.
+
+## 1. Over-block
+
+A recoverable relay attempt with a genuinely missing `projectName` exits non-zero rather than queueing locally. This is intentional because a live server cannot drain an `unknown`-keyed queue. The message remains in the calling transcript and the stderr reason is explicit. Agent ids literally named `unknown` are also refused; that reserved value is already the absence fallback and cannot safely identify a drain owner.
+
+## 2. Under-block
+
+An incorrectly supplied but non-empty `INSTAR_AGENT_HOME` can still point at the wrong agent; launcher-provided identity is authoritative and this script cannot independently authenticate filesystem ownership. A cwd with a nonstandard worktree layout lacking the exact marker remains unchanged rather than guessed upward. Customized deployed relay scripts are preserved and receive a `.new` candidate, so their operator must reconcile the update through the existing degradation path.
+
+## 3. Level-of-abstraction fit
+
+The fix lives in the installed relay template because both the config lookup and recovery path are shell-side before the server can participate. It reuses the existing PostUpdateMigrator hash-safe deployment authority rather than adding another installer. The narrow structural marker is the least-powerful resolver that covers the defined worktree convention without cross-tenant discovery.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] This is hard-invariant validation at a transport boundary, not a judgment about message meaning.
+
+The unknown-id refusal has deterministic blocking authority because a queue keyed `unknown` is mechanically undrainable. It does not classify conversational content or intent. The worktree resolver likewise selects from explicit structural ownership signals and performs no semantic judgment.
+
+## 5. Interactions
+
+- **Shadowing:** home resolution runs before config-derived port/auth/id values, so all later paths share one owner. Explicit port/auth environment overrides keep their existing precedence.
+- **Double-fire:** the change prevents an orphan queue from later double-firing; known-id enqueue and delivery-failed emission retain their existing single path and delivery id.
+- **Races:** the change introduces zero shared mutable structures. The queue retains its existing SQLite concurrency and permission behavior.
+- **Feedback loops:** a refused unknown-id attempt cannot enter the redrive loop; it remains loud in the caller transcript instead.
+
+## 6. External surfaces
+
+Worktree-launched Telegram replies now reach the correct local server and recovery database. Unknown-id failures gain a clearer stderr explanation and non-zero status; they create zero persistent database files. Existing unmodified agent scripts are backed up and replaced on update. Routes, credentials, network destinations, and operator actions remain unchanged.
+
+## 6b. Operator-surface quality
+
+Operator surface unchanged; this criterion is not applicable.
+
+## 7. Multi-machine posture
+
+**Machine-local by design:** an agent home, server port, auth injection, and pending-relay database belong to the machine executing the script. The message route continues to use the local owning server, whose existing messaging layer handles user delivery. The change emits zero additional notices, creates zero cross-machine durable records, leaves topic transfer unchanged, and generates zero URLs.
+
+## 8. Rollback cost
+
+Pure script/template and migration-allowlist rollback: revert and ship a patch. Correctly queued rows remain compatible with the existing drain path. Schema and state repair are unnecessary. A rollback would reintroduce the worktree orphan risk until deployed scripts update again.
+
+## Conclusion
+
+The fix closes both halves of issue #1086 without broad filesystem discovery: worktree sessions resolve the owning agent home, and identity-less recovery fails visibly instead of persisting an undrainable ghost. Normal cwd behavior and customized-script preservation remain intact. Clear to ship after independent messaging-path review and CI.
+
+## Second-pass review
+
+**Reviewer:** framework_guard_review
+**Independent read of the artifact:** concur
+
+Home resolution is conservative and correctly ordered: explicit launcher home, exact `/.worktrees/` structural owner, then unchanged cwd. Config and recovery state share that owner; unknown identity stays transcript-visible, exits non-zero, and creates no undrainable queue. The v1.3.813 template SHA matches the migration allowlist entry, customized scripts retain the `.new` path, and the reviewer's focused suite passed 26/26.
+
+## Evidence pointers
+
+- `tests/integration/telegram-reply-end-to-end.test.ts`
+- `tests/unit/PostUpdateMigrator-telegramReply.test.ts`
+- `tests/unit/lint-template-sha-history.test.ts`
+- `tests/unit/migration-relay-script-hash.test.ts`


### PR DESCRIPTION
## ELI16

When the Telegram reply script runs inside a Git worktree, it now finds the owning agent home before reading the server port or writing recovery state. An explicit `INSTAR_AGENT_HOME` wins; otherwise walk-up occurs only across the exact `/.worktrees/` marker. Ordinary agent-home execution is unchanged.

If recovery cannot identify an agent, it now exits non-zero with a clear explanation and refuses to create `pending-relay.unknown.sqlite`. The original message remains visible in the caller transcript instead of becoming an undrainable ghost row.

## Root cause

The installed script read `.instar/config.json` and wrote `.instar/state` relative to cwd. A worktree cwd therefore selected worktree-local state, fell back to port 4040, and queued under the fallback identity `unknown`; no live server owns that store.

## What changed

- Resolve the relay home from explicit launcher state, then the constrained worktree marker, then unchanged cwd.
- Use the resolved home for config and pending-relay state.
- Refuse unknown-id recovery loudly before creating directories or SQLite state.
- Register the v1.3.813 shipped template SHA so existing unmodified installs are backed up and upgraded; customized scripts keep the `.new` path.
- Add both-sided real-script integration and migration-parity coverage.

## Validation

- 40/40 focused relay, migration, historical-SHA, recovery, and delivery-id tests pass.
- `npx tsc --noEmit` passes.
- Full lint and instar-dev commit gate pass.
- Independent outbound-messaging review concurs.
- Pre-push affected-test enumeration timed out and delegated the full matrix to GitHub CI; the documented local E2E skip was used.

Closes #1086.
