### PR TITLE
feat(dashboard): glance Phase 2 — Commitments + Blockers rebuild (F10/F11)

### DIFF
--- a/dashboard/glance.js
+++ b/dashboard/glance.js
@@ -41,21 +41,22 @@ export const GLANCE_MAX_TOKEN_LEN = 40; // a longer token is a glued-word budget
 // (same discipline as the F3 purpose-line exempt list). The completeness test
 // asserts adopted ∪ grandfathered == every TAB_REGISTRY id, so a NEW tab in NEITHER
 // set fails the build; the monotonicity test asserts the grandfather size ≤ ceiling.
-export const GLANCE_ADOPTED_TABS = ['commitments'];
+export const GLANCE_ADOPTED_TABS = ['commitments', 'blockers'];
 
 export const GLANCE_GRANDFATHERED = [
   'insights', 'sessions', 'files', 'dropzone', 'jobs', 'features', 'systems',
   'integrated-being', 'pr-pipeline', 'projects', 'initiatives', 'tokens',
   'resources', 'llm-activity', 'routing-map', 'spend', 'threadline', 'evidence',
   'process-health', 'subscriptions', 'preferences-learning', 'machines', 'mandates',
-  'blockers', 'secrets',
-];
+  'secrets',
+]; // 'blockers' left the list this PR (Phase 2) — it now builds through this component.
 
 // The committed ceiling on grandfathered-tab count. Only ever LOWER this (each
 // lowering marks a tab retrofitted onto the floor). Never raise it without an
 // operator-signed justification — raising it is how a NEW tab would silently ship
 // below the floor, the exact regression the ratchet exists to prevent.
-export const GLANCE_GRANDFATHERED_CEILING = 25;
+// Lowered 25 → 24 (Phase 2): Blockers retrofitted onto the glance floor.
+export const GLANCE_GRANDFATHERED_CEILING = 24;
 
 // ── F10 — insider-vocab detection ────────────────────────────────────────────
 // A readability floor, NOT a secret-redaction boundary (secret handling stays at
@@ -425,25 +426,40 @@ export function commitmentsOpenPopulation(commitments) {
 
 export function buildCommitmentsGlance(commitments, now = Date.now()) {
   const open = commitmentsOpenPopulation(commitments);
-  const dueSoon = open.filter((c) => c.atRisk === true);
+  // OVERDUE TAKES PRECEDENCE over due-soon (issue #1435 §3): a promise whose HARD
+  // deadline is already in the past is OVERDUE, never merely "due soon". The old
+  // build classified due-soon purely from atRisk, so a stale beacon record a month
+  // past its hard deadline showed as "due soon" — the reported defect. Classify
+  // overdue FIRST, then take due-soon over the REMAINDER (atRisk but not overdue).
+  const overdue = open.filter((c) => c.hardDeadlineAt && Date.parse(c.hardDeadlineAt) < now);
+  const overdueSet = new Set(overdue);
+  const dueSoon = open.filter((c) => c.atRisk === true && !overdueSet.has(c));
   const waiting = open.filter((c) => c.blockedOn === 'user-input' || c.blockedOn === 'user-authorization');
   const quiet = open.filter((c) => c.beaconSuppressed === true);
-  const overdue = open.filter((c) => c.hardDeadlineAt && Date.parse(c.hardDeadlineAt) < now);
 
   // Component-authored, jargon-free headline — honest to the one population.
+  // Count-aware verb agreement (#1435 §2): "1 needs" / "2 need", "1 is" / "2 are".
   let headline;
   if (open.length === 0) {
     headline = "You have no open promises right now.";
   } else {
-    const soonClause = dueSoon.length > 0 ? `${dueSoon.length} need attention soon` : 'none need attention soon';
-    const overdueClause = overdue.length > 0 ? `${overdue.length} overdue` : 'none overdue';
+    const soonClause = dueSoon.length === 0 ? 'none need attention soon'
+      : dueSoon.length === 1 ? '1 needs attention soon'
+      : `${dueSoon.length} need attention soon`;
+    const overdueClause = overdue.length === 0 ? 'none are overdue'
+      : overdue.length === 1 ? '1 is overdue'
+      : `${overdue.length} are overdue`;
     const noun = open.length === 1 ? 'open promise' : 'open promises';
     headline = `I'm carrying ${open.length} ${noun}; ${soonClause}, ${overdueClause}.`;
   }
 
+  // Every number the headline states now has a tile to drill into (#1435 §1): the
+  // "overdue" count gets its own OVERDUE tile — the most actionable state, so we add
+  // the tile rather than dropping the clause. Five tiles = the F10 max.
   const tiles = [
     { key: 'open', label: 'Open', value: String(open.length), tone: 'neutral', rows: open },
     { key: 'due-soon', label: 'Due soon', value: String(dueSoon.length), tone: dueSoon.length ? 'warn' : 'neutral', rows: dueSoon },
+    { key: 'overdue', label: 'Overdue', value: String(overdue.length), tone: overdue.length ? 'warn' : 'neutral', rows: overdue },
     { key: 'waiting', label: 'Waiting on you', value: String(waiting.length), tone: waiting.length ? 'warn' : 'neutral', rows: waiting },
     { key: 'quiet', label: 'Quiet', value: String(quiet.length), tone: 'muted', rows: quiet },
   ];
@@ -524,6 +540,143 @@ export function commitmentsGlanceSpec(doc, commitments, opts = {}) {
         row.setAttribute('aria-label', 'Open the full record');
         row.appendChild(el(d, 'span', 'glance-list-summary', commitmentRowText(c)));
         row.addEventListener('click', () => openRecord(commitmentRecordNode(d, c, { onDeliver: opts.onDeliver })));
+        list.appendChild(row);
+      }
+      drilldown.appendChild(list);
+    },
+  }));
+  return { headline: base.headline, tiles, population: base.population };
+}
+
+// ── Blockers reference builder (the Phase-2 rebuild) ──────────────────────────
+// Turns the /blockers ledger entries into a glance spec. A blocker is a DECAYING
+// HYPOTHESIS, not a settled wall (docs/specs/dashboard-ux-standard.md): each entry
+// moves through a pipeline (candidate → authority-checked → access-requested →
+// dry-run → live-run) and terminates as either RESOLVED (it turned out not to be a
+// wall) or a TRUE-BLOCKER (the best current understanding, with a recheck date —
+// never "stop trying"). Every tile maps to a state predicate over ONE population
+// (the non-archived ledger entries GET /blockers returns), so the counts are honest
+// and each headline number has exactly one tile to drill into. The full record
+// (id, state, timestamps, terminal detail) lives at Layer 3, one click below the
+// plain-language row — the ~7,000-word raw table is gone from the front page but
+// nothing is lost, only moved down a layer.
+
+const BLOCKER_NON_TERMINAL = new Set([
+  'candidate', 'authority-checked', 'access-requested', 'dry-run', 'live-run',
+]);
+
+// Plain-word state names for the Layer-3 record (the raw state token stays honest to
+// the ledger but reads as everyday language, never insider jargon at the glance).
+const BLOCKER_STATE_WORD = {
+  'candidate': 'Just spotted',
+  'authority-checked': 'Checked who can clear it',
+  'access-requested': 'Asked you for access',
+  'dry-run': 'Trying it safely first',
+  'live-run': 'Attempting it for real',
+  'resolved': 'Resolved — not a wall after all',
+  'true-blocker': 'Truly stuck for now (recheck scheduled)',
+};
+
+/** The single population: the non-archived ledger entries GET /blockers returns. */
+export function blockersPopulation(entries) {
+  return (Array.isArray(entries) ? entries : []).filter((e) => e && typeof e.state === 'string');
+}
+
+export function buildBlockersGlance(entries) {
+  const all = blockersPopulation(entries);
+  const working = all.filter((e) => BLOCKER_NON_TERMINAL.has(e.state));
+  const stuck = all.filter((e) => e.state === 'true-blocker');
+  const resolved = all.filter((e) => e.state === 'resolved');
+
+  // Component-authored, jargon-free headline — honest to the one population, with
+  // count-aware verb agreement.
+  let headline;
+  if (all.length === 0) {
+    headline = 'No blockers are being tracked right now.';
+  } else {
+    const stuckClause = stuck.length === 0 ? 'Nothing is truly stuck right now'
+      : stuck.length === 1 ? '1 thing is truly stuck right now'
+      : `${stuck.length} things are truly stuck right now`;
+    const workClause = working.length === 0 ? 'none are being worked'
+      : working.length === 1 ? '1 is being worked'
+      : `${working.length} are being worked`;
+    headline = `${stuckClause}; ${workClause}.`;
+  }
+
+  const tiles = [
+    { key: 'stuck', label: 'Truly stuck', value: String(stuck.length), tone: stuck.length ? 'warn' : 'neutral', rows: stuck },
+    { key: 'working', label: 'Being worked', value: String(working.length), tone: 'neutral', rows: working },
+    { key: 'resolved', label: 'Resolved', value: String(resolved.length), tone: 'muted', rows: resolved },
+  ];
+
+  return { headline, tiles, population: all };
+}
+
+/** One plain-word Layer-2 row for a blocker — the plain-language framing that opened
+ *  it (its detectedText). IDs/timestamps/state machinery are Layer 3, not here. */
+export function blockerRowText(e) {
+  return sanitizeForDisplay(e.detectedText || e.origin || 'A blocker', 'summary');
+}
+
+/**
+ * Layer-3 full record for a blocker — every existing column plus terminal detail,
+ * one click below the plain Layer-2 row. All values via textContent (XSS-safe):
+ * detectedText / origin / terminal free text are UNTRUSTED and are displayed, never
+ * interpreted. This is where the raw state token, id, and timestamps legitimately
+ * live (they used to be dumped on the front page).
+ */
+export function blockerRecordNode(doc, e, opts = {}) {
+  const fmtTs = opts.fmtTs || defaultFmtTs;
+  const wrap = el(doc, 'div', 'glance-record-fields');
+  const rows = [
+    ['What looked stuck', e.detectedText || '—'],
+    ['state', BLOCKER_STATE_WORD[e.state] || e.state || '—'],
+    ['id', e.id || '—'],
+    ['opened by', e.origin || '—'],
+    ['first seen', fmtTs(e.createdAt)],
+    ['last update', fmtTs(e.updatedAt)],
+  ];
+  const t = e.terminal;
+  if (t && t.kind === 'resolved') {
+    rows.push(['outcome', 'Resolved — it turned out not to be a wall']);
+    if (t.playbookPath) rows.push(['playbook', t.playbookPath]);
+  } else if (t && t.kind === 'true-blocker') {
+    rows.push(['outcome', `Best current understanding (${t.reasonKind || 'reason unknown'}) — not "give up"`]);
+    if (t.recheckAfter) rows.push(['recheck after', fmtTs(t.recheckAfter)]);
+  }
+  for (const [k, v] of rows) {
+    const row = el(doc, 'div', 'glance-record-row');
+    row.appendChild(el(doc, 'span', 'glance-record-key', String(k)));
+    row.appendChild(el(doc, 'span', 'glance-record-val', String(v)));
+    wrap.appendChild(row);
+  }
+  return wrap;
+}
+
+/**
+ * Build the FULL Blockers glance spec with drill wiring — importable by index.html
+ * AND the three test tiers. Each tile's onActivate renders the filtered ledger
+ * entries as plain Layer-2 rows; each row opens the Layer-3 record. Population +
+ * counts come from buildBlockersGlance (one denominator, honest counts).
+ */
+export function blockersGlanceSpec(doc, entries, opts = {}) {
+  const base = buildBlockersGlance(entries);
+  const tiles = base.tiles.map((t) => ({
+    key: t.key,
+    label: t.label,
+    value: t.value,
+    tone: t.tone,
+    onActivate: ({ doc: d, drilldown, openRecord }) => {
+      const rows = t.rows || [];
+      if (rows.length === 0) return; // component renders the honest F6 empty-state
+      const list = el(d, 'div', 'glance-list');
+      for (const e of rows) {
+        const row = d.createElement('button');
+        row.type = 'button';
+        row.className = 'glance-list-row';
+        row.setAttribute('aria-label', 'Open the full record');
+        row.appendChild(el(d, 'span', 'glance-list-summary', blockerRowText(e)));
+        row.addEventListener('click', () => openRecord(blockerRecordNode(d, e, { fmtTs: opts.fmtTs })));
         list.appendChild(row);
       }
       drilldown.appendChild(list);

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3455,25 +3455,27 @@
       </div>
     </div>
 
-    <!-- Blockers tab — Blocker Ledger read surface (Phase 1).
+    <!-- Blockers tab — Blocker Ledger read surface, rebuilt on the glance template
+         (Dashboard UX Standard F10/F11, topic 29836 Phase 2).
          A blocker is a DECAYING HYPOTHESIS, not a settled wall: each entry moves through
          candidate → authority-checked → access-requested → dry-run → live-run → resolved /
          true-blocker. A true-blocker is "best current understanding — recheck after <date>",
          never "stop trying". Read-only here; data from GET /blockers. detectedText and all
-         free-text are UNTRUSTED and HTML-escaped before render. 503 = feature off. -->
+         free-text are UNTRUSTED — the shared glance component renders every value through
+         sanitizeForDisplay + textContent (never innerHTML). 503 = feature off. -->
     <div id="blockersPanel" class="tab-panel" style="display:none;flex-direction:column;padding:20px;gap:16px;overflow-y:auto">
       <div style="display:flex;justify-content:space-between;align-items:center">
         <h2 style="margin:0">Blockers</h2>
         <button onclick="loadBlockers()" style="padding:6px 12px">Refresh</button>
       </div>
       <div class="tab-purpose">
-        Things that looked like they stopped progress, tracked as <b>decaying hypotheses</b> rather than settled walls.
-        Each one moves through verification states; a "true blocker" is the best current understanding with a recheck date —
-        never a permanent "give up".
+        Things that looked like they stopped progress, tracked as <b>decaying hypotheses</b> rather than settled walls —
+        the headline says where things stand; tap a tile to see which ones, tap one for the full record.
+        A "truly stuck" blocker is the best current understanding with a recheck date, never a permanent "give up".
       </div>
-      <div id="blockersBody" style="border:1px solid var(--border);border-radius:8px;padding:16px;font-size:13px">
-        <div style="color:var(--text-dim)">Loading...</div>
-      </div>
+      <!-- Glance floors F10/F11 (topic 29836): the shared component renders the
+           headline + tiles + drill-down here. -->
+      <div id="blockersGlance" class="glance-root"></div>
     </div>
 
     <!-- LLM Activity tab — Observable Intelligence (docs/specs/observable-intelligence.md).
@@ -6305,79 +6307,43 @@
       }
     }
 
-    // ── Blockers Tab (Blocker Ledger Phase 1 read surface) ──────────
-    // A blocker is a decaying hypothesis, not a settled wall. Read-only.
-    // detectedText + all free-text are UNTRUSTED → escapeHtml before render.
-    function blockerStateBadge(state) {
-      const colors = {
-        'candidate':         'var(--text-dim)',
-        'authority-checked': '#6ea8fe',
-        'access-requested':  '#6ea8fe',
-        'dry-run':           '#d6a700',
-        'live-run':          '#d6a700',
-        'resolved':          'var(--accent)',
-        'true-blocker':      'var(--red)',
-      };
-      const bg = colors[state] || 'var(--text-dim)';
-      return '<span style="display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;' +
-        'font-weight:600;color:#fff;white-space:nowrap;background:' + bg + '">' +
-        escapeHtml(String(state || 'unknown')) + '</span>';
-    }
-    function blockerTerminalLine(entry) {
-      const t = entry && entry.terminal;
-      if (!t) return '';
-      if (t.kind === 'resolved') {
-        const path = t.playbookPath ? ' · playbook: ' + escapeHtml(String(t.playbookPath)) : '';
-        return '<div style="font-size:12px;color:var(--accent);margin-top:4px">Resolved' + path + '</div>';
-      }
-      if (t.kind === 'true-blocker') {
-        // NEVER frame a true-blocker as settled / "stop trying" — it's a decaying hypothesis.
-        const reason = t.reasonKind ? escapeHtml(String(t.reasonKind)) : 'unknown reason';
-        const recheck = t.recheckAfter ? fmtRelTime(t.recheckAfter) : 'unscheduled';
-        return '<div style="font-size:12px;color:var(--red);margin-top:4px">Current hypothesis (' + reason +
-          ') — recheck after ' + escapeHtml(recheck) + '</div>';
-      }
-      return '';
-    }
+    // ── Blockers Tab — glance floors F10/F11 (topic 29836, Phase 2) ──
+    // A blocker is a decaying hypothesis, not a settled wall. Rebuilt on the shared
+    // glance component: a plain-English headline + tiles (Layer 1); each tile drills
+    // into the filtered ledger entries as plain sentences (Layer 2); each row opens
+    // the full record with state/id/timestamps/terminal detail (Layer 3). detectedText
+    // + all free text are UNTRUSTED → the component renders every value through
+    // sanitizeForDisplay + textContent (never innerHTML), so this is XSS-safe by
+    // construction (an improvement over the old escapeHtml-into-innerHTML table).
     async function loadBlockers() {
-      const bodyEl = document.getElementById('blockersBody');
+      const glanceRoot = document.getElementById('blockersGlance');
+      if (!glanceRoot) return;
+
+      const glance = await loadGlanceModule();
+      if (!glance) {
+        glanceRoot.textContent = 'Loading the glance view failed — refresh to retry.';
+        return;
+      }
+
+      let resp = null;
       try {
-        const resp = await apiFetch('/blockers');
-        const entries = (resp && resp.entries) || [];
-        if (entries.length === 0) {
-          bodyEl.innerHTML = '<div style="color:var(--text-dim)">No blockers recorded' +
-            ((resp && resp.total != null) ? ' (total ' + escapeHtml(String(resp.total)) + ')' : '') + '.</div>';
-          return;
-        }
-        bodyEl.innerHTML =
-          '<table style="width:100%;border-collapse:collapse;font-size:13px">' +
-            '<thead><tr style="text-align:left;color:var(--text-dim)">' +
-              '<th style="padding:6px 8px">State</th>' +
-              '<th style="padding:6px 8px">ID</th>' +
-              '<th style="padding:6px 8px">Detected</th>' +
-              '<th style="padding:6px 8px">Origin</th>' +
-              '<th style="padding:6px 8px;text-align:right">Updated</th>' +
-            '</tr></thead><tbody>' +
-            entries.map(e =>
-              '<tr style="border-top:1px solid var(--border);vertical-align:top">' +
-                '<td style="padding:6px 8px">' + blockerStateBadge(e.state) + '</td>' +
-                '<td style="padding:6px 8px;font-family:monospace;color:var(--text-dim)">' + escapeHtml(String(e.id || '—')) + '</td>' +
-                '<td style="padding:6px 8px">' + escapeHtml(String(e.detectedText || '')) + blockerTerminalLine(e) + '</td>' +
-                '<td style="padding:6px 8px">' + escapeHtml(String(e.origin || '—')) + '</td>' +
-                '<td style="padding:6px 8px;text-align:right;white-space:nowrap">' + escapeHtml(fmtRelTime(e.updatedAt || e.createdAt)) + '</td>' +
-              '</tr>'
-            ).join('') +
-            '</tbody></table>';
+        resp = await apiFetch('/blockers');
       } catch (err) {
         const m = err && err.message ? String(err.message) : String(err);
+        glanceRoot.textContent = '';
+        const note = document.createElement('div');
+        note.className = 'glance-empty';
         // 503 → the Blocker Ledger feature is off (monitoring.blockerLedger.enabled false, the default).
-        if (/503|unavailable|disabled|not initialized/i.test(m)) {
-          bodyEl.innerHTML = '<div style="color:var(--text-dim)">Blocker Ledger isn\'t turned on yet ' +
-            '(enable <code>monitoring.blockerLedger.enabled</code>).</div>';
-        } else {
-          bodyEl.innerHTML = '<div style="color:var(--red)">Error: ' + escapeHtml(m) + '</div>';
-        }
+        note.textContent = /503|unavailable|disabled|not initialized/i.test(m)
+          ? 'Blocker tracking isn’t turned on for this agent yet.'
+          : 'Could not load blockers right now — refresh to retry.';
+        glanceRoot.appendChild(note);
+        return;
       }
+
+      const entries = (resp && Array.isArray(resp.entries)) ? resp.entries : [];
+      const spec = glance.blockersGlanceSpec(document, entries, {});
+      glance.renderGlance(document, glanceRoot, spec);
     }
 
     // ── Threadline → Telegram bridge settings ──────────────────

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -522,7 +522,16 @@ export function buildMatrixModel(poolScope, pendingScope, transient = {}) {
     for (const m of machineList) {
       const key = `${acct.accountId}::${m.machineId}`;
       const t = transient[key] || null;
-      const pendingLogin = inProgress.get(key) || null;
+      // OPTIMISTIC CANCEL (issue #1428): a confirmed cancel (2xx) drops a `cancelled`
+      // transient so the cell resets AT CLICK TIME instead of showing the stale
+      // in-flight flow for one poll cycle (~40s). It SUPPRESSES the cached
+      // pending-login (which the next poll hasn't dropped yet), letting the cell fall
+      // through to its true underlying state ("Sign in" / "Set up"). The transient is
+      // cleared on the very next poll (purgeTransients), so if the cancel actually
+      // FAILED server-side the fresh pending-login re-shows the flow — the poll stays
+      // the authority.
+      const cancelled = t && t.state === 'cancelled';
+      const pendingLogin = cancelled ? null : (inProgress.get(key) || null);
       let state;
       if (m.offline) state = 'offline';                              // whole column offline (FD6)
       else if (t && t.state === 'held') state = 'held';
@@ -849,6 +858,11 @@ export function createController(opts) {
       if (!entry || typeof entry.at !== 'number') continue;
       if (entry.state === 'just-verified' && t - entry.at > JUST_VERIFIED_TTL_MS) delete state.matrixTransient[key];
       if ((entry.state === 'expired' || entry.state === 'broken') && t - entry.at > EXPIRED_TTL_MS) delete state.matrixTransient[key];
+      // The optimistic `cancelled` bridge (issue #1428) lives for exactly one poll:
+      // purgeTransients runs inside render() with the FRESH server bodies in hand, so
+      // clearing it here hands authority back to the poll — a still-pending login
+      // (cancel actually failed) re-derives 'in-progress' on this same render.
+      if (entry.state === 'cancelled') delete state.matrixTransient[key];
     }
     state.recentOutcomes = state.recentOutcomes
       .filter((o) => o && typeof o.at === 'number' && now() - o.at <= OUTCOME_TTL_MS)
@@ -1328,13 +1342,19 @@ export function createController(opts) {
       try {
         const r = await postJson(URLS.cancel, { machineId, id: accountId });
         if (r.ok && r.json && (r.json.cancelled || r.json.alreadyTerminal)) {
-          // TERMINAL (cancelled): the episode is over — release the hold so the next
-          // rebuild replaces the flow with a fresh "Set up" from server state.
+          // TERMINAL (cancelled): the episode is over. OPTIMISTIC RESET (issue #1428):
+          // drop a `cancelled` transient + release the hold, then rebuild the cell NOW
+          // from cache so the operator sees the in-flight flow disappear immediately —
+          // not after the next ~40s poll. The transient suppresses the stale cached
+          // pending-login until the next real poll reconciles (and stays authority if
+          // the cancel actually failed). Keep a status line as the fallback for the
+          // rare case where another open interaction defers the full rebuild.
           const key = `${accountId}::${machineId}`;
-          delete state.matrixTransient[key];
           delete state.matrixEpisodes[key];
+          state.matrixTransient[key] = { state: 'cancelled', at: now() };
           cell.removeAttribute('data-interaction-open');
           setCellStatus(cell, 'Cancelled — you can set this up again.');
+          rerenderMatrixFromCache();
         } else {
           const msg = (r.json && (r.json.error || r.json.reason)) ? (r.json.error || r.json.reason) : `failed (${r.status})`;
           setCellStatus(cell, `Couldn’t cancel: ${msg}`);

--- a/docs/specs/dashboard-ux-standard.md
+++ b/docs/specs/dashboard-ux-standard.md
@@ -265,7 +265,7 @@ order for exactly this reason.
 | View | Front-page words | Glance (F10) today | Drill-down (F11) today | Baseline |
 |---|---|---|---|---|
 | Insights | 86 | ✅ the model to copy | ✅ button per takeaway | conforming (reference pattern) |
-| Commitments | 972 → **glance** | ✅ **adopted this PR** | ✅ **adopted this PR** | **on the floor (reference impl)** |
+| Commitments | 972 → **glance** | ✅ **on the floor** | ✅ **on the floor** | **on the floor (full rebuild, Phase 2 — folds #1435: Overdue tile, plural grammar, overdue≠due-soon)** |
 | Tokens | 28 | ✅ lean | ⚠️ summaries not clickable | grandfathered → Phase 4 |
 | Secrets | 36 | ✅ lean | ✅ adequate | grandfathered → Phase 4 |
 | Resource Usage | 40 | ✅ lean | ⚠️ summaries not clickable | grandfathered → Phase 4 |
@@ -280,7 +280,7 @@ order for exactly this reason.
 | Health | 390 | ⚠️ subsystem prose | ⚠️ expanders only | grandfathered → Phase 3 |
 | Spend | 400 | ⚠️ jargon ("paid door") | ⚠️ no per-row detail | grandfathered → Phase 3 |
 | Routing Map | (dense) | ⚠️ jargon ("lane", "door") | ❌ flat map, no drill | grandfathered → Phase 3 |
-| Blockers | 7,035 | ❌ full DB table on one page | ❌ everything dumped at once | grandfathered → Phase 2 |
+| Blockers | 7,035 → **glance** | ✅ **on the floor** | ✅ **on the floor** | **on the floor (rebuilt Phase 2 — headline + Truly stuck / Being worked / Resolved tiles; the raw table moved to Layer 3)** |
 
 *(Files, Send Content, Evidence, PR Pipeline, Projects, Initiatives, Integrated-Being,
 Features, Systems get the same treatment in the Phase-4 sweep; they are mid-pack and
@@ -433,8 +433,9 @@ Phase 1** and nothing more:
    written into this standard with the two enforcement tests; the shared `dashboard/glance.js`
    component; and ONE view (Commitments) wired onto it as the living example (glance layer +
    drill into the existing list as Layer 2, full record as Layer 3).
-2. **Phase 2 — the two worst offenders.** Commitments' full rebuild + Blockers, rebuilt on
-   the template. <!-- tracked: topic-29836 -->
+2. **Phase 2 (SHIPPED) — the two worst offenders.** Commitments' full rebuild (folding
+   issue #1435) + Blockers, rebuilt on the template; both left the grandfather list
+   (ceiling 25 → 24) and the subscriptions optimistic-cancel fix (issue #1428) rode along.
 3. **Phase 3 — the jargon belt.** Machines, Health, Spend, Routing Map. <!-- tracked: topic-29836 -->
 4. **Phase 4 — the sweep.** Every remaining grandfathered view brought to conformance; each
    leaves the grandfather list as it lands. <!-- tracked: topic-29836 -->

--- a/tests/e2e/glance-blockers-tab-lifecycle.test.ts
+++ b/tests/e2e/glance-blockers-tab-lifecycle.test.ts
@@ -1,0 +1,126 @@
+/**
+ * E2E lifecycle (Tier 3) — Blockers glance is ALIVE (Dashboard UX Standard F10/F11,
+ * topic 29836 Phase 2). The single most important test for the feature: is it
+ * genuinely wired end-to-end, or green-on-units but dark in production?
+ *
+ * Boots a REAL Express server with the production createRoutes() and asserts:
+ *   - feature ON (a real BlockerLedger seeded with entries): /blockers returns 200
+ *     (never 503), the full glance renders end-to-end from live data, and no injected
+ *     <script> survives the round-trip.
+ *   - feature OFF (no ledger → 503, the documented dark behavior): the tab's glance
+ *     builder still produces a friendly empty glance, never a crash.
+ *   - the shipped component file dashboard/glance.js exports the Blockers builder
+ *     (deployed via the package's static serving, not a stub).
+ */
+// @ts-nocheck — the glance module is browser-native ESM.
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { AddressInfo } from 'node:net';
+import { JSDOM } from 'jsdom';
+import { createRoutes } from '../../src/server/routes.js';
+import { BlockerLedger } from '../../src/monitoring/BlockerLedger.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { blockersGlanceSpec, renderGlance, validateGlanceSpec, buildBlockersGlance } from '../../dashboard/glance.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+interface TestServer { url: string; close: () => Promise<void>; }
+function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+function bootApp(ctx: any): Promise<TestServer> {
+  const app = express();
+  app.use(express.json());
+  app.use(createRoutes(ctx));
+  return listen(app);
+}
+
+function seedLedger(stateDir: string, entries: any[]): void {
+  const dir = path.join(stateDir, 'state');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'blocker-ledger.json'),
+    JSON.stringify({ version: 1, lastModified: '2026-07-09T00:00:00.000Z', nextId: entries.length + 1, entries }, null, 2));
+}
+
+function render(entries: any[]) {
+  const doc = new JSDOM('<!doctype html><body><div id="root"></div></body>').window.document;
+  const root = doc.getElementById('root')!;
+  const spec = blockersGlanceSpec(doc, entries);
+  const handle = renderGlance(doc, root, spec);
+  return { doc, root, handle };
+}
+
+describe('Blockers glance — E2E feature-alive', () => {
+  let server: TestServer;
+  let dir: string;
+
+  afterEach(async () => {
+    await server?.close();
+    try { if (dir) SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/e2e/glance-blockers-tab-lifecycle.test.ts:cleanup' }); } catch { /* @silent-fallback-ok — best-effort tmp cleanup */ }
+  });
+
+  it('feature ON: /blockers 200, the glance renders end-to-end, no XSS survives', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'glance-blk-e2e-'));
+    seedLedger(dir, [
+      { id: 'BLK-001', version: 1, state: 'live-run', detectedText: 'the vendor <img src=x onerror=alert(1)> has not replied',
+        origin: 'sess-1', createdAt: '2026-07-01T00:00:00Z', updatedAt: '2026-07-09T09:00:00Z', history: [] },
+      { id: 'BLK-002', version: 5, state: 'true-blocker', detectedText: 'need the operator password for the bank portal',
+        origin: 'sess-1', createdAt: '2026-07-04T00:00:00Z', updatedAt: '2026-07-09T06:00:00Z', history: [],
+        terminal: { kind: 'true-blocker', reasonKind: 'operator-only-secret', rebuttal: 'vault miss',
+          failedAttempt: { type: 'self-fetch', at: '2026-07-09T05:00:00Z', detail: 'miss', succeeded: false },
+          accessRequestRef: 'relay-1', gateDecisionHash: 'deadbeef', at: '2026-07-09T06:00:00Z',
+          recheckAfter: '2026-08-01T00:00:00Z', noEvidenceResettleCount: 0 } },
+    ]);
+    const ledger = new BlockerLedger({ stateDir: dir });
+
+    server = await bootApp({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), blockerLedger: ledger });
+
+    const res = await fetch(server.url + '/blockers');
+    expect(res.status).toBe(200); // alive, not 503
+    const body = await res.json();
+    expect(body.entries.length).toBe(2);
+
+    const { handle } = render(body.entries);
+    expect(validateGlanceSpec(handle.spec).ok).toBe(true);
+    expect(handle.tiles.length).toBe(3); // Truly stuck · Being worked · Resolved
+    expect(handle.headline.textContent).toMatch(/1 thing is truly stuck/i);
+
+    // Drill "Being worked" and confirm the XSS payload rendered inert.
+    const workingBtn = handle.tiles.find((b: any) => b.getAttribute('data-glance-tile') === 'working');
+    workingBtn.dispatchEvent(new (handle.drilldown.ownerDocument.defaultView as any).Event('click'));
+    expect(handle.drilldown.querySelector('img')).toBeNull();
+    expect(handle.drilldown.querySelector('script')).toBeNull();
+    expect(handle.drilldown.textContent).toContain('onerror'); // literal text, harmless
+  });
+
+  it('feature OFF: /blockers 503 (dark) → the tab still builds a friendly empty glance, not a crash', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'glance-blk-e2e-off-'));
+    server = await bootApp({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date() }); // no blockerLedger
+    const res = await fetch(server.url + '/blockers');
+    expect(res.status).toBe(503); // documented dark behavior — the route is gated
+
+    // The glance the component builds for the empty/dark case is honest and conforms.
+    const glance = buildBlockersGlance([]);
+    expect(validateGlanceSpec(glance).ok).toBe(true);
+    expect(glance.headline.toLowerCase()).toContain('no blockers');
+    const { handle } = render([]);
+    expect(handle.headline.textContent!.toLowerCase()).toContain('no blockers');
+  });
+
+  it('the shipped component file dashboard/glance.js exports the Blockers builder (deployed)', () => {
+    const file = path.resolve(__dirname, '..', '..', 'dashboard', 'glance.js');
+    expect(fs.existsSync(file), 'dashboard/glance.js must ship with the package').toBe(true);
+    const src = fs.readFileSync(file, 'utf-8');
+    expect(src).toContain('export function buildBlockersGlance');
+    expect(src).toContain('export function blockersGlanceSpec');
+  });
+});

--- a/tests/e2e/glance-commitments-tab-lifecycle.test.ts
+++ b/tests/e2e/glance-commitments-tab-lifecycle.test.ts
@@ -79,7 +79,7 @@ describe('Commitments glance — E2E feature-alive', () => {
 
     const { handle } = render(body.commitments);
     expect(validateGlanceSpec(handle.spec).ok).toBe(true);
-    expect(handle.tiles.length).toBe(4);
+    expect(handle.tiles.length).toBe(5); // Open · Due soon · Overdue · Waiting · Quiet (#1435 Overdue tile)
     expect(handle.headline.textContent).toMatch(/carrying 2 open promises/i);
 
     // Drill "Open" and confirm the XSS payload rendered inert (textContent, no element).

--- a/tests/integration/glance-blockers-tab.test.ts
+++ b/tests/integration/glance-blockers-tab.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration (Tier 2) — Blockers glance against the REAL /blockers HTTP pipeline
+ * (Dashboard UX Standard F10/F11, topic 29836 Phase 2).
+ *
+ * Boots a real Express server with the production createRoutes() + a real
+ * BlockerLedger (seeded on disk with entries in every state bucket), fetches
+ * GET /blockers over HTTP, and drives the SHIPPED blockersGlanceSpec + renderGlance
+ * against the live response — asserting the glance renders, conforms to F10, the
+ * tile counts partition the served list, and every non-empty tile drills into the
+ * real filtered entries down to the Layer-3 record.
+ */
+// @ts-nocheck — the glance module is browser-native ESM.
+import { describe, it, expect, afterEach } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { JSDOM } from 'jsdom';
+import { createRoutes } from '../../src/server/routes.js';
+import { BlockerLedger } from '../../src/monitoring/BlockerLedger.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  blockersGlanceSpec,
+  buildBlockersGlance,
+  blockersPopulation,
+  validateGlanceSpec,
+  renderGlance,
+} from '../../dashboard/glance.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+function bootApp(ctx: any): Promise<TestServer> {
+  const app = express();
+  app.use(express.json());
+  app.use(createRoutes(ctx));
+  return listen(app);
+}
+
+/** Seed a blocker-ledger store on disk so a real BlockerLedger loads entries in every
+ *  state bucket (non-terminal / true-blocker / resolved) without the heavy settle path. */
+function seedLedger(stateDir: string): void {
+  const dir = path.join(stateDir, 'state');
+  fs.mkdirSync(dir, { recursive: true });
+  const store = {
+    version: 1,
+    lastModified: '2026-07-09T00:00:00.000Z',
+    nextId: 5,
+    entries: [
+      { id: 'BLK-001', version: 1, state: 'live-run', detectedText: 'the vendor has not sent the API key yet',
+        origin: 'sess-1', createdAt: '2026-07-01T00:00:00Z', updatedAt: '2026-07-09T09:00:00Z', history: [] },
+      { id: 'BLK-002', version: 1, state: 'candidate', detectedText: 'cannot reach the deploy host',
+        origin: 'sess-1', createdAt: '2026-07-02T00:00:00Z', updatedAt: '2026-07-09T08:00:00Z', history: [] },
+      { id: 'BLK-003', version: 3, state: 'resolved', detectedText: 'thought the token was missing but it was there',
+        origin: 'sess-1', createdAt: '2026-07-03T00:00:00Z', updatedAt: '2026-07-09T07:00:00Z', history: [],
+        terminal: { kind: 'resolved', playbookPath: '.claude/skills/x/SKILL.md', at: '2026-07-09T07:00:00Z' } },
+      { id: 'BLK-004', version: 5, state: 'true-blocker', detectedText: 'need the operator password for the bank portal',
+        origin: 'sess-1', createdAt: '2026-07-04T00:00:00Z', updatedAt: '2026-07-09T06:00:00Z', history: [],
+        terminal: { kind: 'true-blocker', reasonKind: 'operator-only-secret', rebuttal: 'vault miss',
+          failedAttempt: { type: 'self-fetch', at: '2026-07-09T05:00:00Z', detail: 'vault decrypt miss', succeeded: false },
+          accessRequestRef: 'relay-1', gateDecisionHash: 'deadbeef', at: '2026-07-09T06:00:00Z',
+          recheckAfter: '2026-08-01T00:00:00Z', noEvidenceResettleCount: 0 } },
+    ],
+  };
+  fs.writeFileSync(path.join(dir, 'blocker-ledger.json'), JSON.stringify(store, null, 2));
+}
+
+describe('Blockers glance (integration — real /blockers)', () => {
+  let server: TestServer;
+  let dir: string;
+
+  afterEach(async () => {
+    await server?.close();
+    try { if (dir) SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/glance-blockers-tab.test.ts:cleanup' }); } catch { /* @silent-fallback-ok — best-effort tmp cleanup */ }
+  });
+
+  it('renders a conforming glance from the live HTTP response and drills into the real list', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'glance-blk-int-'));
+    seedLedger(dir);
+    const ledger = new BlockerLedger({ stateDir: dir });
+
+    server = await bootApp({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), blockerLedger: ledger });
+
+    const res = await fetch(server.url + '/blockers');
+    expect(res.status).toBe(200); // alive, not 503
+    const body = await res.json();
+    expect(Array.isArray(body.entries)).toBe(true);
+    expect(body.entries.length).toBe(4);
+
+    // Build + validate the glance from the REAL response.
+    const base = buildBlockersGlance(body.entries);
+    expect(validateGlanceSpec(base).ok).toBe(true);
+    const pop = blockersPopulation(body.entries);
+    const sum = base.tiles.reduce((n: number, t: any) => n + Number(t.value), 0);
+    expect(sum).toBe(pop.length); // partition: 2 working + 1 stuck + 1 resolved = 4
+
+    // Render + walk every tile against the live data.
+    const doc = new JSDOM('<!doctype html><body><div id="root"></div></body>').window.document;
+    const root = doc.getElementById('root')!;
+    const spec = blockersGlanceSpec(doc, body.entries);
+    const handle = renderGlance(doc, root, spec);
+    expect(handle.headline.textContent).toMatch(/1 thing is truly stuck/);
+
+    let realDrills = 0;
+    for (const btn of handle.tiles) {
+      btn.dispatchEvent(new (doc.defaultView as any).Event('click'));
+      expect(handle.drilldown.hidden).toBe(false);
+      if (handle.drilldown.querySelector('.glance-list-row')) realDrills++;
+      btn.dispatchEvent(new (doc.defaultView as any).Event('click')); // toggle closed
+    }
+    expect(realDrills).toBeGreaterThanOrEqual(1);
+
+    // The "Truly stuck" tile drills into exactly the 1 true-blocker, and its row opens
+    // a Layer-3 record with the raw id + the recheck date (decaying-hypothesis honesty).
+    const stuckBtn = handle.tiles.find((b: any) => b.getAttribute('data-glance-tile') === 'stuck');
+    stuckBtn.dispatchEvent(new (doc.defaultView as any).Event('click'));
+    const rows = handle.drilldown.querySelectorAll('.glance-list-row');
+    expect(rows.length).toBe(1);
+    rows[0].dispatchEvent(new (doc.defaultView as any).Event('click'));
+    const record = handle.drilldown.querySelector('[data-glance-record]');
+    expect(record).toBeTruthy();
+    expect(record!.textContent).toContain('BLK-004');
+    expect(record!.textContent).toMatch(/recheck after/i);
+  });
+
+  it('GET /blockers 503 when the ledger is dark → the tab shows an honest note, never a crash', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'glance-blk-dark-'));
+    server = await bootApp({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date() }); // no blockerLedger
+    const res = await fetch(server.url + '/blockers');
+    expect(res.status).toBe(503);
+    // The empty-population glance the component builds for the dark case still conforms.
+    const glance = buildBlockersGlance([]);
+    expect(validateGlanceSpec(glance).ok).toBe(true);
+    expect(glance.headline.toLowerCase()).toContain('no blockers');
+  });
+});

--- a/tests/unit/dashboard-glance-drilldown.test.ts
+++ b/tests/unit/dashboard-glance-drilldown.test.ts
@@ -24,6 +24,8 @@ import {
   patchGlanceCounts,
   commitmentsGlanceSpec,
   buildCommitmentsGlance,
+  blockersGlanceSpec,
+  buildBlockersGlance,
 } from '../../dashboard/glance.js';
 
 let dom: JSDOM;
@@ -195,11 +197,118 @@ describe('F11 — the real Commitments glance, walked end-to-end', () => {
     const spec = commitmentsGlanceSpec(doc, commitments, { now: NOW });
     const handle = renderGlance(doc, root, spec);
     expect(handle.headline.textContent).toContain('4');
-    expect(handle.tiles.length).toBe(4);
+    expect(handle.tiles.length).toBe(5); // Open · Due soon · Overdue · Waiting · Quiet (#1435 Overdue tile)
 
     // Walk: Open → 4 rows; each row → a record
     const open = activate(handle, 'open');
     expect(open.opened).toBe(true);
     expect(handle.drilldown.querySelectorAll('.glance-list-row').length).toBe(4);
+  });
+
+  it('#1435: an overdue promise gets its own Overdue tile that drills, and is NOT double-counted as due-soon', () => {
+    // A stale beacon record: atRisk AND a hard deadline a month in the past. It must
+    // classify as OVERDUE (not "due soon"), and the "overdue" headline number has a tile.
+    const commitments = [
+      mk({ id: 'CMT-9', agentResponse: 'send the code the moment it lands', atRisk: true,
+        hardDeadlineAt: new Date(NOW - 30 * 24 * 3600e3).toISOString() }),
+    ];
+    const counts = commitmentTileCounts(commitments);
+    expect(counts.overdue).toBe(1);
+    expect(counts.dueSoon).toBe(0); // overdue takes precedence — not double-counted
+
+    const spec = commitmentsGlanceSpec(doc, commitments, { now: NOW });
+    const handle = renderGlance(doc, root, spec);
+    expect(handle.headline.textContent).toMatch(/1 is overdue/);
+    expect(handle.headline.textContent).toMatch(/none needs? attention soon/);
+    // The Overdue tile exists and drills into the 1 overdue promise (F11: every
+    // headline number has a tile).
+    const { opened, text } = activate(handle, 'overdue');
+    expect(opened).toBe(true);
+    expect(text.toLowerCase()).not.toContain('nothing here');
+    expect(handle.drilldown.querySelector('.glance-list-row')).toBeTruthy();
+  });
+});
+
+// Small local helper: read the commitment tile counts from the real builder.
+function commitmentTileCounts(commitments: any[]) {
+  const g = buildCommitmentsGlance(commitments, NOW);
+  const val = (k: string) => Number(g.tiles.find((t: any) => t.key === k).value);
+  return { overdue: val('overdue'), dueSoon: val('due-soon'), open: val('open') };
+}
+
+describe('F11 walk-every-tile — the Blockers glance (Phase 2)', () => {
+  const bmk = (over: Record<string, unknown> = {}) => ({
+    id: 'BLK-x', version: 1, state: 'live-run', detectedText: 'a thing that looked stuck',
+    origin: 'sess-1', createdAt: '2026-07-01T00:00:00Z', updatedAt: '2026-07-09T00:00:00Z',
+    history: [], ...over,
+  });
+
+  it('every tile opens a non-empty, distinct Layer-2 container (non-vacuous walk)', () => {
+    const entries = [
+      bmk({ id: 'BLK-1', state: 'live-run', detectedText: 'the vendor has not sent the API key yet' }),
+      bmk({ id: 'BLK-2', state: 'candidate', detectedText: 'cannot reach the deploy host' }),
+      bmk({ id: 'BLK-3', state: 'resolved', detectedText: 'thought the token was missing',
+        terminal: { kind: 'resolved', playbookPath: '.claude/skills/x/SKILL.md', at: '2026-07-09T00:00:00Z' } }),
+      bmk({ id: 'BLK-4', state: 'true-blocker', detectedText: 'need the operator password for the bank portal',
+        terminal: { kind: 'true-blocker', reasonKind: 'operator-only-secret', recheckAfter: '2026-08-01T00:00:00Z' } }),
+    ];
+    const spec = blockersGlanceSpec(doc, entries);
+    const handle = renderGlance(doc, root, spec);
+
+    const glanceText = handle.headline.textContent + ' ' + handle.tiles.map((b: any) => b.textContent).join(' ');
+    let realDrills = 0;
+    for (const btn of handle.tiles) {
+      const key = btn.getAttribute('data-glance-tile');
+      const { opened, text } = activate(handle, key);
+      expect(opened, `tile "${key}" opened`).toBe(true);
+      expect(text.length, `tile "${key}" non-empty`).toBeGreaterThan(0);
+      expect(text).not.toBe(glanceText.trim());
+      if (!/nothing here right now/i.test(text)) {
+        realDrills++;
+        expect(handle.drilldown.querySelector('.glance-list-row'), `tile "${key}" shows receipts`).toBeTruthy();
+      }
+      activate(handle, key); // toggle closed
+    }
+    expect(realDrills, 'at least one blocker tile drilled into real receipts').toBeGreaterThanOrEqual(1);
+  });
+
+  it('drills tile → row → Layer-3 record with the raw state/id/recheck detail', () => {
+    const entries = [
+      bmk({ id: 'BLK-7', state: 'true-blocker', detectedText: 'need the bank portal password',
+        terminal: { kind: 'true-blocker', reasonKind: 'operator-only-secret', recheckAfter: '2026-08-01T00:00:00Z' } }),
+    ];
+    const spec = blockersGlanceSpec(doc, entries);
+    const handle = renderGlance(doc, root, spec);
+    activate(handle, 'stuck');
+    const row = handle.drilldown.querySelector('.glance-list-row');
+    expect(row, 'a Layer-2 row exists').toBeTruthy();
+    row!.dispatchEvent(new dom.window.Event('click'));
+    const record = handle.drilldown.querySelector('[data-glance-record]');
+    expect(record, 'a Layer-3 record opened').toBeTruthy();
+    expect(record!.textContent).toContain('BLK-7'); // raw id lives at Layer 3
+    expect(record!.textContent).toMatch(/recheck after/i); // decaying-hypothesis honesty preserved
+    expect(record!.textContent).not.toMatch(/give up/i); // never framed as "stop trying"
+  });
+
+  it('an empty ledger → conforming glance + zero-count tiles open honest empty-states', () => {
+    const spec = blockersGlanceSpec(doc, []);
+    const handle = renderGlance(doc, root, spec);
+    expect(handle.headline.textContent!.toLowerCase()).toContain('no blockers');
+    const { opened, text } = activate(handle, 'stuck');
+    expect(opened).toBe(true);
+    expect(text.toLowerCase()).toContain('nothing here');
+  });
+
+  it('XSS: an <img onerror> / RLO-bidi in detectedText renders inert', () => {
+    const nasty = '<img src=x onerror=alert(1)> "><script>bad()</script> ‮evil';
+    const spec = blockersGlanceSpec(doc, [{ id: 'BLK-9', state: 'candidate', detectedText: nasty,
+      origin: 's', createdAt: '2026-07-01T00:00:00Z', updatedAt: '2026-07-01T00:00:00Z', history: [] }]);
+    const handle = renderGlance(doc, root, spec);
+    activate(handle, 'working');
+    expect(handle.drilldown.querySelector('img')).toBeNull();
+    expect(handle.drilldown.querySelector('script')).toBeNull();
+    const rowText = handle.drilldown.querySelector('.glance-list-summary')!.textContent || '';
+    expect(rowText).toContain('onerror');
+    expect(rowText).not.toContain('‮');
   });
 });

--- a/tests/unit/dashboard-glance-word-budget.test.ts
+++ b/tests/unit/dashboard-glance-word-budget.test.ts
@@ -27,6 +27,8 @@ import {
   countGlanceWords,
   buildCommitmentsGlance,
   commitmentsOpenPopulation,
+  buildBlockersGlance,
+  blockersPopulation,
   GLANCE_MAX_TILES,
   GLANCE_WORD_BUDGET,
   GLANCE_ADOPTED_TABS,
@@ -193,6 +195,87 @@ describe('F10 conformance — the real Commitments builder under adversarial fix
   });
 });
 
+describe('F10 #1435 folds — the Commitments builder', () => {
+  const mk = (over: Record<string, unknown>) => ({
+    beaconEnabled: true, status: 'pending', atRisk: false, beaconSuppressed: false,
+    blockedOn: 'none', ...over,
+  });
+  const now = Date.parse('2026-07-10T00:00:00Z');
+
+  it('adds an Overdue tile so every headline number has a drill-down (F11 gap #1435 §1)', () => {
+    const g = buildCommitmentsGlance([mk({ hardDeadlineAt: new Date(now - 1000).toISOString() })], now);
+    expect(g.tiles.map((t: any) => t.key)).toContain('overdue');
+    expect(g.tiles.length).toBe(5);
+    expect(validateGlanceSpec(g).ok).toBe(true);
+  });
+
+  it('a past HARD deadline is OVERDUE, never "due soon" (#1435 §3)', () => {
+    // atRisk AND a month-past hard deadline → overdue only, not double-counted as due-soon.
+    const stale = mk({ atRisk: true, hardDeadlineAt: new Date(now - 30 * 864e5).toISOString() });
+    const g = buildCommitmentsGlance([stale], now);
+    const val = (k: string) => Number(g.tiles.find((t: any) => t.key === k).value);
+    expect(val('overdue')).toBe(1);
+    expect(val('due-soon')).toBe(0);
+    expect(g.headline).toMatch(/1 is overdue/);
+  });
+
+  it('count-aware pluralization: "1 needs" / "2 need" (#1435 §2)', () => {
+    const one = buildCommitmentsGlance([mk({ atRisk: true })], now);
+    expect(one.headline).toMatch(/1 needs attention soon/);
+    const two = buildCommitmentsGlance([mk({ atRisk: true }), mk({ atRisk: true })], now);
+    expect(two.headline).toMatch(/2 need attention soon/);
+  });
+});
+
+describe('F10 conformance — the real Blockers builder under adversarial fixtures', () => {
+  const bmk = (over: Record<string, unknown>) => ({
+    id: 'BLK-x', version: 1, state: 'live-run', detectedText: 'a thing that looked stuck',
+    origin: 'sess-1', createdAt: '2026-07-01T00:00:00Z', updatedAt: '2026-07-09T00:00:00Z',
+    history: [], ...over,
+  });
+
+  const fixtures: Array<[string, any[]]> = [
+    ['empty', []],
+    ['null-ish', [null, undefined, {}, { id: 'x' /* no state */ }]],
+    ['large N', Array.from({ length: 500 }, (_, i) => bmk({
+      id: `BLK-${i}`,
+      state: ['candidate', 'authority-checked', 'access-requested', 'dry-run', 'live-run', 'resolved', 'true-blocker'][i % 7],
+      detectedText: `blocker number ${i} — the vendor has not replied since June ${1 + (i % 28)}`,
+    }))],
+    ['jargon-laden detectedText', [bmk({
+      state: 'true-blocker',
+      detectedText: 'fix the atRisk cadence: 1800s for CMT-953 — id m_4f3a9b',
+      terminal: { kind: 'true-blocker', reasonKind: 'operator-only-secret', recheckAfter: '2026-08-01T00:00:00Z' },
+    })]],
+    ['all truly stuck', Array.from({ length: 4 }, (_, i) => bmk({ id: `BLK-${i}`, state: 'true-blocker' }))],
+    ['all resolved', Array.from({ length: 3 }, (_, i) => bmk({ id: `BLK-${i}`, state: 'resolved' }))],
+  ];
+
+  for (const [name, entries] of fixtures) {
+    it(`produces a conforming glance for the "${name}" fixture`, () => {
+      const glance = buildBlockersGlance(entries);
+      const r = validateGlanceSpec(glance);
+      expect(r.ok, `violations: ${JSON.stringify(r.violations)}`).toBe(true);
+      expect(glance.tiles.length).toBeLessThanOrEqual(GLANCE_MAX_TILES);
+    });
+  }
+
+  it('TRUTHFULNESS — tile counts sum to the population and partition it', () => {
+    const entries = fixtures[2][1]; // large N
+    const glance = buildBlockersGlance(entries);
+    const pop = blockersPopulation(entries);
+    const sum = glance.tiles.reduce((n: number, t: any) => n + Number(t.value), 0);
+    expect(sum).toBe(pop.length); // every entry lands in exactly one tile — nothing lost
+    expect(glance.population.length).toBe(pop.length);
+  });
+
+  it('the headline leads with the "truly stuck" state in plain words', () => {
+    expect(buildBlockersGlance([]).headline.toLowerCase()).toContain('no blockers');
+    expect(buildBlockersGlance([bmk({ state: 'true-blocker' })]).headline).toMatch(/1 thing is truly stuck/);
+    expect(buildBlockersGlance([bmk({ state: 'live-run' })]).headline).toMatch(/nothing is truly stuck/i);
+  });
+});
+
 describe('F10/F11 grandfather ratchet — structural, not prose', () => {
   it('completeness: every registered tab is in exactly one of adopted ∪ grandfathered', () => {
     const ids = tabRegistryIds();
@@ -213,11 +296,20 @@ describe('F10/F11 grandfather ratchet — structural, not prose', () => {
     expect(GLANCE_GRANDFATHERED.length).toBeLessThanOrEqual(GLANCE_GRANDFATHERED_CEILING);
   });
 
-  it('population floor: at least one tab is on the glance floor with a real builder', () => {
-    expect(GLANCE_ADOPTED_TABS.length).toBeGreaterThanOrEqual(1);
+  it('population floor: every adopted tab has a real builder (commitments + blockers)', () => {
+    expect(GLANCE_ADOPTED_TABS.length).toBeGreaterThanOrEqual(2);
     expect(GLANCE_ADOPTED_TABS).toContain('commitments');
-    // the reference builder is real (not a stub)
+    expect(GLANCE_ADOPTED_TABS).toContain('blockers'); // adopted this PR (Phase 2)
+    // both reference builders are real (not stubs) and produce a conforming empty glance
     expect(typeof buildCommitmentsGlance).toBe('function');
     expect(validateGlanceSpec(buildCommitmentsGlance([])).ok).toBe(true);
+    expect(typeof buildBlockersGlance).toBe('function');
+    expect(validateGlanceSpec(buildBlockersGlance([])).ok).toBe(true);
+  });
+
+  it('the ratchet only shrinks: blockers is no longer grandfathered and the ceiling dropped', () => {
+    expect(GLANCE_GRANDFATHERED).not.toContain('blockers');
+    expect(GLANCE_GRANDFATHERED).not.toContain('commitments');
+    expect(GLANCE_GRANDFATHERED_CEILING).toBe(24); // was 25 before Phase 2
   });
 });

--- a/tests/unit/follow-me-controller-wiring.test.ts
+++ b/tests/unit/follow-me-controller-wiring.test.ts
@@ -218,4 +218,95 @@ describe('subscriptions controller — follow-me card wiring', () => {
     expect(h.calls.find((c) => c.url === '/subscription-pool/matrix/start-cell')).toBeUndefined();
     expect(h.els.matrix.textContent.toLowerCase()).toContain('pin');
   });
+
+  // ── #1428: a confirmed cancel resets the cell OPTIMISTICALLY (at click time) ──
+  function makeCancelHarness(cancelResponse) {
+    const dom = new JSDOM('<!doctype html><body><div id="fm"></div><div id="mx"></div></body>');
+    const doc = dom.window.document;
+    dom.window.confirm = () => true; // approve the "Cancel this in-progress setup?" guard
+    const els = {
+      accounts: doc.createElement('div'), pending: doc.createElement('div'),
+      followMe: doc.getElementById('fm'), matrix: doc.getElementById('mx'),
+    };
+    const calls = [];
+    const fetchImpl = (url, o = {}) => {
+      calls.push({ url, method: o.method || 'GET', body: o.body ? JSON.parse(o.body) : undefined });
+      const ok = (json, status = 200) => Promise.resolve({ ok: true, status, json: () => Promise.resolve(json) });
+      if (url === '/subscription-pool') return ok({ enabled: true, accounts: [] });
+      if (url === '/subscription-pool?scope=pool') return ok({
+        enabled: true, scope: 'pool',
+        // a1 needs-reauth on m1 → after a confirmed cancel the cell returns to "Sign in".
+        accounts: [{ id: 'a1', email: 'a1@x.com', status: 'needs-reauth', machineId: 'm1', machineNickname: 'Laptop' }],
+        pool: { selfMachineId: 'm1', failed: [] },
+      });
+      // A still-cached pending login for a1 × m1 → the cell renders the in-flight flow + Cancel.
+      if (url.startsWith('/subscription-pool/pending-logins')) return ok({ enabled: true, logins: [
+        { id: 'a1', machineId: 'm1', verificationUrl: 'https://claude.com/oauth', ttlExpiresAt: '2999-01-01T00:00:00Z' },
+      ] });
+      if (url === '/subscription-pool/in-use') return ok({ activeAccountId: null });
+      if (url === '/subscription-pool/follow-me/scan') return ok({ enabled: true, offered: [] });
+      if (url === '/subscription-pool/follow-me/cancel') return ok(cancelResponse);
+      return ok({});
+    };
+    const ctrl = createController({ doc, els, fetchImpl, schedule: () => 0, cancel: () => {} });
+    ctrl._state.active = true;
+    return { doc, els, calls, ctrl };
+  }
+
+  it('a confirmed cancel (2xx {cancelled}) resets the cell to "Sign in" AT CLICK TIME (no ~40s stale window)', async () => {
+    const h = makeCancelHarness({ cancelled: true });
+    await h.ctrl.tick();
+    // the in-flight cell rendered with a Cancel button
+    const cancel = Array.from(h.els.matrix.querySelectorAll('[data-matrix-cancel]'))
+      .find((b) => b.getAttribute('data-account-id') === 'a1' && b.getAttribute('data-machine-id') === 'm1');
+    expect(cancel, 'the in-progress cell shows a Cancel affordance').toBeTruthy();
+    expect(h.els.matrix.querySelector('.sub-matrix-in-progress')).toBeTruthy();
+
+    cancel.click();
+    await flush();
+
+    // the cancel relay was POSTed…
+    const cancelCall = h.calls.find((c) => c.url === '/subscription-pool/follow-me/cancel');
+    expect(cancelCall?.method).toBe('POST');
+    expect(cancelCall?.body).toMatchObject({ id: 'a1', machineId: 'm1' });
+    // …and the cell reset IMMEDIATELY: no more in-flight flow, an actionable "Sign in" instead.
+    expect(h.els.matrix.querySelector('.sub-matrix-in-progress'), 'flow gone at click time').toBeNull();
+    const signIn = Array.from(h.els.matrix.querySelectorAll('.sub-matrix-setup'))
+      .find((b) => b.getAttribute('data-account-id') === 'a1' && b.getAttribute('data-machine-id') === 'm1');
+    expect(signIn?.textContent).toBe('Sign in');
+  });
+
+  it('a FAILED cancel (non-2xx) leaves the flow in place and surfaces the reason (poll stays authority)', async () => {
+    const dom = new JSDOM('<!doctype html><body><div id="mx"></div></body>');
+    const doc = dom.window.document;
+    dom.window.confirm = () => true;
+    const els = { accounts: doc.createElement('div'), pending: doc.createElement('div'), matrix: doc.getElementById('mx') };
+    const calls = [];
+    const fetchImpl = (url, o = {}) => {
+      calls.push({ url, method: o.method || 'GET', body: o.body ? JSON.parse(o.body) : undefined });
+      const ok = (json, status = 200) => Promise.resolve({ ok: true, status, json: () => Promise.resolve(json) });
+      if (url === '/subscription-pool?scope=pool') return ok({
+        enabled: true, scope: 'pool',
+        accounts: [{ id: 'a1', email: 'a1@x.com', status: 'needs-reauth', machineId: 'm1', machineNickname: 'Laptop' }],
+        pool: { selfMachineId: 'm1', failed: [] },
+      });
+      if (url.startsWith('/subscription-pool/pending-logins')) return ok({ enabled: true, logins: [
+        { id: 'a1', machineId: 'm1', verificationUrl: 'https://claude.com/oauth', ttlExpiresAt: '2999-01-01T00:00:00Z' },
+      ] });
+      if (url === '/subscription-pool') return ok({ enabled: true, accounts: [] });
+      if (url === '/subscription-pool/in-use') return ok({ activeAccountId: null });
+      if (url === '/subscription-pool/follow-me/scan') return ok({ enabled: true, offered: [] });
+      if (url === '/subscription-pool/follow-me/cancel') return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({ error: 'relay down' }) });
+      return ok({});
+    };
+    const ctrl = createController({ doc, els, fetchImpl, schedule: () => 0, cancel: () => {} });
+    ctrl._state.active = true;
+    await ctrl.tick();
+    const cancel = els.matrix.querySelector('[data-matrix-cancel]');
+    cancel.click();
+    await flush();
+    // The flow is NOT reset optimistically on a failed cancel — the in-progress cell stays.
+    expect(els.matrix.querySelector('.sub-matrix-in-progress')).toBeTruthy();
+    expect(els.matrix.textContent.toLowerCase()).toContain('couldn’t cancel');
+  });
 });

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -325,6 +325,47 @@ describe('renderAccountMatrix', () => {
     expect(cell!.querySelector('.sub-matrix-setup')).toBeNull();
   });
 
+  it('#1428: a `cancelled` transient SUPPRESSES a still-cached pending login so the cell resets immediately', () => {
+    // A needs-reauth account with a still-cached in-flight login: after a confirmed
+    // cancel, the optimistic `cancelled` transient must drop the stale flow AT ONCE
+    // (not after the next ~40s poll) — the cell falls through to its true underlying
+    // "Sign in" state instead of rendering ◷ Signing in.
+    const pool = {
+      enabled: true,
+      accounts: [{ id: 'a3', email: 'a3@x.com', status: 'needs-reauth', machineId: 'm1', machineNickname: 'Laptop' }],
+      pool: { selfMachineId: 'm1', failed: [] },
+      scope: 'pool',
+    };
+    const pending = { enabled: true, logins: [{ id: 'a3', machineId: 'm1', verificationUrl: 'https://x/y', ttlExpiresAt: Date.now() + 60000 }] };
+
+    // Without the transient: the cached pending login renders the in-flight flow.
+    const before = el();
+    renderAccountMatrix(doc, before, pool, pending, {});
+    expect(before.querySelector('.sub-matrix-in-progress'), 'stale flow shows without the transient').toBeTruthy();
+
+    // With the `cancelled` transient: the flow is gone; the cell is the clean "Sign in".
+    const after = el();
+    renderAccountMatrix(doc, after, pool, pending, { 'a3::m1': { state: 'cancelled', at: Date.now() } });
+    expect(after.querySelector('.sub-matrix-in-progress'), 'no in-flight flow after cancel').toBeNull();
+    const btn = Array.from(after.querySelectorAll('.sub-matrix-setup'))
+      .find((b) => b.getAttribute('data-account-id') === 'a3' && b.getAttribute('data-machine-id') === 'm1');
+    expect(btn, 'the cell reset to an actionable Sign-in button').toBeTruthy();
+    expect(btn!.textContent).toBe('Sign in');
+  });
+
+  it('#1428: buildMatrixModel drops a stale pending login under a `cancelled` transient (poll stays authority)', () => {
+    // The model-level proof: with the transient the cell is NOT in-progress; the next
+    // poll clears the transient (tested in the controller) so a genuinely-failed cancel
+    // re-derives in-progress from the fresh server state.
+    const held = buildMatrixModel(poolScope, pendingScope, { 'a2::m1': { state: 'cancelled', at: Date.now() } });
+    const cell = held.rows.flatMap((r) => r.cells).find((c) => c.accountId === 'a2' && c.machineId === 'm1');
+    expect(cell!.state).not.toBe('in-progress');
+    // negative control: WITHOUT the transient the same cached login IS in-progress.
+    const live = buildMatrixModel(poolScope, pendingScope, {});
+    const liveCell = live.rows.flatMap((r) => r.cells).find((c) => c.accountId === 'a2' && c.machineId === 'm1');
+    expect(liveCell!.state).toBe('in-progress');
+  });
+
   it('renders a "Sign in" button (with the "Needs sign-in" word above it) for a needs-reauth cell', () => {
     // a3 exists on a reachable machine but its login expired (status needs-reauth) → the cell must
     // be ACTIONABLE: the status word AND a "Sign in" button carrying the (account, machine) ids.

--- a/upgrades/next/glance-p2-commitments-blockers.md
+++ b/upgrades/next/glance-p2-commitments-blockers.md
@@ -1,0 +1,56 @@
+# Dashboard glance Phase 2 — Commitments rebuild + Blockers on the glance template
+
+change_type: feature
+
+## What Changed
+
+Phase 2 of the operator-approved four-phase glance rollout (topic 29836). The two worst
+"wall of raw records" tabs are rebuilt on the shared glance component (F10/F11), and two
+filed issues fold in:
+
+- **Commitments — full rebuild + issue #1435.** The headline now has a matching tile for
+  every number it states: an **Overdue** tile joins Open / Due soon / Waiting on you /
+  Quiet. Grammar is count-aware ("1 needs attention soon", "1 is overdue"). And the
+  classification is fixed: a promise whose **hard deadline has already passed is Overdue,
+  never "Due soon"** — a stale record a month past its deadline is no longer mislabelled.
+- **Blockers — rebuilt on the template.** The old ~7,000-word raw table that filled the
+  whole page is replaced by a one-sentence headline ("N things are truly stuck; K being
+  worked") over three tiles — **Truly stuck · Being worked · Resolved**. Tap a tile to see
+  which blockers (in plain sentences); tap one for the full record (state, id, timestamps,
+  recheck date). Nothing is lost — every column moved down a layer. The "decaying
+  hypothesis, not a wall" framing is preserved: a truly-stuck blocker is "the best current
+  understanding with a recheck date", never "give up".
+- **Subscriptions — issue #1428.** When you cancel an in-progress sign-in, the cell now
+  clears **immediately** instead of showing the stale sign-in flow for ~40 seconds until
+  the next refresh. If the cancel actually failed server-side, the next poll still corrects
+  it (the poll stays the authority).
+- Both rebuilt tabs left the grandfathered list (the ratchet ceiling dropped 25 → 24), so
+  they are now held to the same glance floor as every new view.
+
+## What to Tell Your User
+
+Two of your busiest dashboard tabs are now readable at a glance. **Commitments** leads with
+a plain sentence about where your promises stand, with a big tile for each state — including
+a new **Overdue** tile — and correctly separates "overdue" from "due soon" (a promise past
+its deadline is now shown as overdue). **Blockers** no longer dumps a giant table on the
+page: you get a one-line summary and a few tiles (Truly stuck / Being worked / Resolved), and
+you tap to drill into the details. And when you cancel a subscription sign-in, the tile
+resets right away instead of lingering for half a minute. Tap any tile to see which items are
+behind that number, and tap one for its full record — nothing was removed, it just moved a
+tap or two down.
+
+## Summary of New Capabilities
+
+- The **Commitments** dashboard tab now has an Overdue tile, count-aware grammar, and a
+  corrected overdue-vs-due-soon classification (issue #1435).
+- The **Blockers** dashboard tab is rebuilt as a glance (headline + Truly stuck / Being
+  worked / Resolved tiles → filtered rows → full record), replacing the old raw table.
+- A cancelled subscription sign-in now resets its cell immediately (issue #1428).
+
+## Evidence
+
+- Unit: `tests/unit/dashboard-glance-word-budget.test.ts` (43), `tests/unit/dashboard-glance-drilldown.test.ts` (13), `tests/unit/subscriptions-render.test.ts`, `tests/unit/follow-me-controller-wiring.test.ts`.
+- Integration: `tests/integration/glance-blockers-tab.test.ts` (real `/blockers` + BlockerLedger), `tests/integration/glance-commitments-tab.test.ts`.
+- E2E: `tests/e2e/glance-blockers-tab-lifecycle.test.ts`, `tests/e2e/glance-commitments-tab-lifecycle.test.ts` (feature-alive: 200 with the feature on, honest empty/503 with it off, no XSS survives).
+- Live browser render (Playwright): both tabs rendered end-to-end against realistic payloads — Commitments "I'm carrying 5 open promises; 1 needs attention soon, 1 is overdue." with the Overdue tile drilling into a past-deadline promise's record; Blockers "1 thing is truly stuck right now; 2 are being worked." drilling into the true-blocker's full record.
+- Spec: `docs/specs/dashboard-ux-standard.md` (F10/F11, conformance table updated — Commitments + Blockers now on the floor).

--- a/upgrades/side-effects/glance-p2-commitments-blockers.md
+++ b/upgrades/side-effects/glance-p2-commitments-blockers.md
@@ -1,0 +1,118 @@
+# Side-Effects Review — Dashboard glance Phase 2: Commitments rebuild + Blockers + #1428
+
+**Version / slug:** `glance-p2-commitments-blockers`
+**Date:** `2026-07-10`
+**Author:** `echo (instar-dev agent)`
+**Second-pass reviewer:** `not required` (no block/allow, session-lifecycle, gate/sentinel/watchdog, or compaction surface — a client-side dashboard render change)
+
+## Summary of the change
+
+Phase 2 of the operator-approved glance rollout (topic 29836, spec `docs/specs/dashboard-ux-standard.md`, F10/F11). Three view-layer changes, all in `dashboard/*.js` + `dashboard/index.html`, plus tests — **no `src/*.ts` runtime code is touched**:
+
+1. **Commitments full rebuild** — `buildCommitmentsGlance`/`commitmentsGlanceSpec` in `dashboard/glance.js` now fold issue #1435: an **Overdue tile** (so every headline number drills down), **count-aware pluralization** ("1 needs" / "2 need", "1 is overdue"), and a **classification fix** — a promise whose HARD deadline is past is **overdue, never "due soon"** (overdue is computed first; due-soon is taken over the remainder, so a stale beacon record a month past its deadline is no longer double-counted). Five tiles now: Open · Due soon · Overdue · Waiting on you · Quiet.
+2. **Blockers rebuild** — the old ~7,000-word raw table (built with `escapeHtml`-into-`innerHTML`) is replaced by the shared glance component. New pure builders `buildBlockersGlance` / `blockerRowText` / `blockerRecordNode` / `blockersGlanceSpec`. Headline ("N things are truly stuck; K being worked") + three tiles (Truly stuck / Being worked / Resolved) that partition the ledger population; each tile drills to plain-sentence rows; each row opens the full record (state, id, origin, timestamps, terminal detail) at Layer 3. `loadBlockers()` in `index.html` rewired onto it.
+3. **Subscriptions optimistic cancel (issue #1428)** — a confirmed cancel (2xx) now drops a short-lived `cancelled` transient that suppresses the still-cached pending-login and rebuilds the cell AT CLICK TIME (no ~40s stale window). `purgeTransients()` clears it on the very next poll, so the poll stays authoritative if the cancel actually failed.
+4. **Conformance ratchet** — `blockers` moved from `GLANCE_GRANDFATHERED` to `GLANCE_ADOPTED_TABS`; `GLANCE_GRANDFATHERED_CEILING` lowered 25 → 24. The ratchet only shrinks.
+
+## Decision-point inventory
+
+- **Commitments overdue-vs-due-soon classification** (`buildCommitmentsGlance`) — *modify* — overdue now takes precedence; pure derivation from existing server fields, no new authority.
+- **Blockers state → tile bucketing** (`buildBlockersGlance`) — *add* — pure classification of the `/blockers` ledger population into working / stuck / resolved; no new authority, no new endpoint.
+- **Subscriptions cell state derivation** (`buildMatrixModel`) — *modify* — a `cancelled` transient suppresses a stale cached pending-login; a display-only override cleared each poll.
+- No block/allow, message-filter, or dispatch decision point is touched.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The classification changes decide which *tile* a record appears under (display grouping), never whether a record is admitted or an action allowed. A commitment/blocker is never dropped: the Commitments population is unchanged (`beaconEnabled && status==='pending'`), and the Blockers tiles partition the full `/blockers` population (a test asserts the tile counts sum to the population length — nothing is filtered out).
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. Worst case for the #1428 optimistic reset is a *display* lag, not a missed block: if a cancel POST returns 2xx but the server actually failed to cancel, the `cancelled` transient hides the flow for at most one poll cycle, then `purgeTransients` clears it and the fresh pending-login re-renders the in-flight flow (poll is authority). A pasted code during that window still hits the submit route's existing pane-liveness guard (the dangerous half was already closed per #1428) — this change does not touch that guard.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. All logic is a **stateless client-side renderer** deriving display from data the tab already fetches — the lowest-risk layer for a UX change. It reuses the shared `dashboard/glance.js` component (built in Phase 1) rather than re-implementing per-tab markup, and reuses the shipped `sanitizeForDisplay` + `hasOpenInteraction` primitives. No server route, config, or gate is added or changed; the Blockers glance drills into the existing `GET /blockers`, the Commitments glance into the existing `GET /commitments`.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+It is pure presentation: it renders records into a headline + tiles + drill-downs. It holds no authority over any action, message, or session. The `cancelled` transient is a display hint that self-clears on the next authoritative poll — it never decides an outcome.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The Commitments/Blockers glances replace the tabs' own prior renderers (the old blockers table + its now-removed `blockerStateBadge`/`blockerTerminalLine` helpers were deleted; no other caller referenced them — verified by grep). No server-side check is shadowed.
+- **Double-fire:** None. `loadBlockers`/`loadCommitments` are idempotent renders triggered by tab activation + Refresh; `renderGlance` replaces (never appends) the DOM, so repeated renders can't leak detached nodes/listeners.
+- **Races:** The `cancelled` transient shares `state.matrixTransient` with the existing poll loop. It is set after the cancel POST resolves (server has processed the cancel), read by `buildMatrixModel`, and cleared in `purgeTransients` — which runs inside `render()` only after a *fresh* `/pending-logins` fetch succeeds (a fetch failure early-returns before `render()`), so clearing it always hands authority to real server state. The F9 hold (`data-interaction-open`) is respected: the optimistic rebuild removes the cell's own hold first, and `rerenderMatrixFromCache` still skips while any OTHER interaction is open (the status line is the fallback there, and the next poll catches up).
+- **Feedback loops:** None.
+
+---
+
+## 6. External surfaces
+
+- **Other agents / other users:** None — a client-side render change shipped in the package `dashboard/` directory (served via `express.static`), reaching deployed agents on the normal update path (no `PostUpdateMigrator` entry needed, same as Phase 1).
+- **External systems:** None.
+- **Persistent state:** None — the glance persists nothing; `matrixTransient` is in-memory dashboard state only.
+- **Operator surface (Mobile-Complete):** The Commitments "Mark delivered" action is preserved and phone-completable at Layer 3. The Blockers tab is read-only (as before). The Subscriptions cancel/sign-in flow is unchanged except that a confirmed cancel now resets the cell faster. No new operator action is introduced without a surface.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+Touches `dashboard/glance.js`, `dashboard/index.html`, `dashboard/subscriptions.js` — REQUIRED, and it is the whole point of the change.
+
+1. **Leads with the primary action?** Yes. Both tabs now open on a one-sentence plain-English headline + big labeled tiles — the answer ("where do my promises / blockers stand?") is the first thing rendered, not a wall of records. The old Blockers page-one was a ~7,000-word raw table; it is gone from Layer 1.
+2. **Zero raw internals as primary content?** Yes, and enforced. The F10 validator scans the concatenated headline + every tile label + value and refuses to build a glance carrying internal IDs, cadences, config keys, or insider terms. Raw internals (id `BLK-004`, `cadence 1800s`, state slugs, recheck timestamps) live only at Layer 3, one or two taps down. Verified live in-browser: the Commitments headline reads "I'm carrying 5 open promises; 1 needs attention soon, 1 is overdue."; the Blockers headline reads "1 thing is truly stuck right now; 2 are being worked."
+3. **Destructive actions de-emphasized?** No destructive action is added. "Mark delivered" (Commitments) is a constructive Layer-3 action; the Blockers tab is read-only. The Subscriptions Cancel affordance is unchanged in prominence.
+4. **Plain language + phone width?** Labels read the way a non-engineer speaks ("Truly stuck", "Being worked", "Due soon", "Overdue"). The glance uses the shared responsive `.glance-*` CSS shipped + browser-verified in Phase 1 (flex tiles, `overflow-x` contained). No new bespoke inline styles. State words at Layer 3 are humanized ("Truly stuck for now (recheck scheduled)", never a raw `true-blocker` slug at the glance). The decaying-hypothesis framing is preserved — a true-blocker is "best current understanding … not 'give up'", never "stop trying".
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN — pure client-side renderer, no machine-divergent state.** `dashboard/glance.js` persists nothing, reads no config, and holds no server state; it renders whatever data the adopting tab already fetches and inherits that endpoint's posture. The Blockers glance drills into `GET /blockers` (a per-machine ledger read, unchanged by this PR); the Commitments glance into `GET /commitments` (posture unchanged). It emits no user-facing notices (no one-voice concern), holds no durable state (nothing to strand on topic transfer), and generates no URLs. The Subscriptions matrix already reads pool-scope (`?scope=pool`) so a login started on another machine surfaces here; the `cancelled` transient is per-dashboard-session in-memory display state that self-clears on the next poll — it introduces no new cross-machine surface.
+
+---
+
+## 8. Rollback cost
+
+Pure client-side code change — revert the `dashboard/*` files and ship a patch. No persistent state, no data migration, no agent-state repair. During the rollback window a user would see the previous glance/table render; no functional regression (the underlying routes are untouched). The conformance-ratchet constants revert with the file.
+
+---
+
+## Conclusion
+
+The review produced no design changes and flags no concerns. The change is confined to the presentation layer, reuses the Phase-1 component and its safety contract (`sanitizeForDisplay` + `textContent`, no `innerHTML`) — which is a security *improvement* for Blockers over the old `escapeHtml`-into-`innerHTML` table — and is fully enforced by the F10 word-budget and F11 drill-down ratchets now covering both rebuilt tabs across all three test tiers, plus a live in-browser render of both tabs. Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+Not required — no block/allow, session-lifecycle, gate/sentinel/watchdog, coherence, or compaction surface is touched. (This is a client-side dashboard render change; the qualifying triggers in `/instar-dev` Phase 5 do not apply.)
+
+---
+
+## Evidence pointers
+
+- Unit: `tests/unit/dashboard-glance-word-budget.test.ts` (43), `tests/unit/dashboard-glance-drilldown.test.ts` (13), `tests/unit/subscriptions-render.test.ts` (+2 for #1428), `tests/unit/follow-me-controller-wiring.test.ts` (+2 for #1428 both sides of the boundary).
+- Integration: `tests/integration/glance-blockers-tab.test.ts` (real `/blockers` route + BlockerLedger), `tests/integration/glance-commitments-tab.test.ts`.
+- E2E: `tests/e2e/glance-blockers-tab-lifecycle.test.ts` (feature ON 200 / dark 503 / shipped-file check), `tests/e2e/glance-commitments-tab-lifecycle.test.ts`.
+- Live browser render (Playwright, stubbed-route harness): Commitments headline "I'm carrying 5 open promises; 1 needs attention soon, 1 is overdue." with an Overdue tile drilling to CMT-101 (past hard deadline, classified overdue not due-soon) → Layer-3 record with cadence 1800s + Mark-delivered; Blockers headline "1 thing is truly stuck right now; 2 are being worked." with Truly-stuck drilling to BLK-004 → Layer-3 record showing "recheck after" and "not 'give up'".
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable. The #1435 (overdue misclassification / missing tile / grammar) and #1428 (stale cancel window) fixes are defects in runtime client-side dashboard code, not in an LLM prompt, hook, config, skill, or standards text. This change adds no self-triggered controller (the `cancelled` transient is a display hint cleared each poll, not a loop/monitor/sentinel/reaper/scheduler/recovery path that fires a restart/swap/respawn/spawn/notify/retry/kill). The recurrence of an over-budget or jargon-carrying or dead-end glance for these two tabs is now structurally refused by `validateGlanceSpec` + the F10/F11 ratchets (`tests/unit/dashboard-glance-word-budget.test.ts`, `tests/unit/dashboard-glance-drilldown.test.ts`), which render both rebuilt tabs' real builders under adversarial fixtures.


### PR DESCRIPTION
Phase 2 of the operator-approved glance rollout (topic 29836, spec `docs/specs/dashboard-ux-standard.md`, floors F10/F11). Rebuilds the two worst "wall of raw records" dashboard tabs on the shared glance component and folds in two filed issues. **No `src/*.ts` runtime code is touched — this is entirely `dashboard/*` view code + tests.**

Closes #1435
Closes #1428

## ELI16

Two of the busiest dashboard tabs used to greet you with a wall of technical records. This change turns them into a "read it at a glance" layout: one plain-English sentence at the top, a few big labelled tiles, and everything else one tap down. **Commitments** now leads with "I'm carrying 5 open promises; 1 needs attention soon, 1 is overdue." It gained an **Overdue** tile so every number in that sentence is tappable, its grammar counts correctly ("1 needs", not "1 need"), and — the real bug from issue #1435 — a promise whose hard deadline is already in the past is now shown as **overdue** instead of being mislabelled "due soon." **Blockers** no longer dumps a ~7,000-word table on the page; it shows "1 thing is truly stuck right now; 2 are being worked" over three tiles (Truly stuck / Being worked / Resolved), and you tap a tile to see which ones and tap one for its full record — nothing was deleted, it just moved down a layer, and the "this is a decaying hypothesis, not give up" framing is preserved. Separately (issue #1428), cancelling a subscription sign-in now clears the cell immediately instead of showing the stale flow for ~40 seconds; the next poll still corrects it if the cancel actually failed, so the server stays the source of truth. Both rebuilt tabs left the grandfathered list, so they're now held to the same enforced glance floor as every new view.

## What changed

- **Commitments — full rebuild (#1435).** `buildCommitmentsGlance`/`commitmentsGlanceSpec`: added an **Overdue** tile (so every headline number drills down — F11's own rule), count-aware pluralization, and a classification fix so a past hard-deadline is **overdue, not "due soon"** (overdue computed first; due-soon taken over the remainder — no double-counting of stale beacon records). Tiles: Open · Due soon · Overdue · Waiting on you · Quiet.
- **Blockers — rebuilt on the template.** The raw `escapeHtml`-into-`innerHTML` table is replaced by the shared glance component (a security improvement — everything now flows through `sanitizeForDisplay` + `textContent`). New pure builders `buildBlockersGlance` / `blockerRowText` / `blockerRecordNode` / `blockersGlanceSpec`; three tiles that **partition** the ledger population; each row → full Layer-3 record (state/id/origin/timestamps/terminal detail).
- **Subscriptions (#1428).** A confirmed cancel (2xx) drops a short-lived `cancelled` transient that suppresses the still-cached pending-login and rebuilds the cell at click time; `purgeTransients` clears it on the next poll, so the poll stays authoritative if the cancel actually failed.
- **Conformance ratchet.** `blockers` moved from `GLANCE_GRANDFATHERED` to `GLANCE_ADOPTED_TABS`; `GLANCE_GRANDFATHERED_CEILING` lowered 25 → 24. The ratchet only shrinks. Spec conformance table updated.

## Testing (all three tiers, both rebuilt tabs)

- **Unit** — `dashboard-glance-word-budget.test.ts` (43): F10 validator + the real Commitments **and** Blockers builders under adversarial fixtures (large N, null/empty, jargon-laden free text, all-stuck/all-resolved), the #1435 folds, and the grandfather ratchet (completeness + monotonicity, ceiling = 24). `dashboard-glance-drilldown.test.ts` (13): F11 walk-every-tile for both tabs, tile → row → Layer-3 record, zero-count empty-states, XSS-inert, F9 hold. `subscriptions-render.test.ts` + `follow-me-controller-wiring.test.ts`: #1428 both sides of the boundary (confirmed cancel resets at click time; failed cancel leaves the flow, poll stays authority).
- **Integration** — `glance-blockers-tab.test.ts` (real `/blockers` route + a real `BlockerLedger`), `glance-commitments-tab.test.ts`.
- **E2E** — `glance-blockers-tab-lifecycle.test.ts` + `glance-commitments-tab-lifecycle.test.ts` (feature ON → 200 renders, feature dark → honest empty/503, shipped-file check, no injected `<script>` survives).
- **Live browser render (Playwright)** — both tabs rendered end-to-end against realistic payloads; the Overdue tile drilled into a past-deadline promise's record (cadence 1800s, Mark-delivered preserved), the Truly-stuck tile into the true-blocker's record (recheck date, "not 'give up'").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
