### PR TITLE
feat(dashboard): glance Phase 3 — jargon belt (Machines/Health/Spend/Routing) + #1429

### DIFF
--- a/dashboard/glance.js
+++ b/dashboard/glance.js
@@ -41,22 +41,27 @@ export const GLANCE_MAX_TOKEN_LEN = 40; // a longer token is a glued-word budget
 // (same discipline as the F3 purpose-line exempt list). The completeness test
 // asserts adopted ∪ grandfathered == every TAB_REGISTRY id, so a NEW tab in NEITHER
 // set fails the build; the monotonicity test asserts the grandfather size ≤ ceiling.
-export const GLANCE_ADOPTED_TABS = ['commitments', 'blockers'];
+export const GLANCE_ADOPTED_TABS = [
+  'commitments', 'blockers', // Phases 1–2
+  'machines', 'systems', 'spend', 'routing-map', // Phase 3 (the jargon belt); 'systems' is the Health tab
+];
 
 export const GLANCE_GRANDFATHERED = [
-  'insights', 'sessions', 'files', 'dropzone', 'jobs', 'features', 'systems',
+  'insights', 'sessions', 'files', 'dropzone', 'jobs', 'features',
   'integrated-being', 'pr-pipeline', 'projects', 'initiatives', 'tokens',
-  'resources', 'llm-activity', 'routing-map', 'spend', 'threadline', 'evidence',
-  'process-health', 'subscriptions', 'preferences-learning', 'machines', 'mandates',
+  'resources', 'llm-activity', 'threadline', 'evidence',
+  'process-health', 'subscriptions', 'preferences-learning', 'mandates',
   'secrets',
-]; // 'blockers' left the list this PR (Phase 2) — it now builds through this component.
+]; // Phase 3 removed machines / systems (Health) / spend / routing-map — they now
+   // build through this component. 'blockers' left in Phase 2.
 
 // The committed ceiling on grandfathered-tab count. Only ever LOWER this (each
 // lowering marks a tab retrofitted onto the floor). Never raise it without an
 // operator-signed justification — raising it is how a NEW tab would silently ship
 // below the floor, the exact regression the ratchet exists to prevent.
-// Lowered 25 → 24 (Phase 2): Blockers retrofitted onto the glance floor.
-export const GLANCE_GRANDFATHERED_CEILING = 24;
+// Lowered 25 → 24 (Phase 2): Blockers retrofitted.
+// Lowered 24 → 20 (Phase 3): Machines, Health (systems), Spend, Routing Map retrofitted.
+export const GLANCE_GRANDFATHERED_CEILING = 20;
 
 // ── F10 — insider-vocab detection ────────────────────────────────────────────
 // A readability floor, NOT a secret-redaction boundary (secret handling stays at
@@ -679,6 +684,682 @@ export function blockersGlanceSpec(doc, entries, opts = {}) {
         row.addEventListener('click', () => openRecord(blockerRecordNode(d, e, { fmtTs: opts.fmtTs })));
         list.appendChild(row);
       }
+      drilldown.appendChild(list);
+    },
+  }));
+  return { headline: base.headline, tiles, population: base.population };
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// PHASE 3 — the jargon belt: Machines, Health, Spend, Routing Map (topic 29836).
+// Each of the four tabs was ≥200 words of insider vocabulary on its front page
+// (guards lines, "paid door / metered", "lane / nature / door"). Rebuilt on the
+// SAME three-layer template: a component-authored, jargon-free headline + ≤5 tiles
+// (Layer 1); each tile drills into the rows behind that number in plain words
+// (Layer 2); each row opens the full record where the IDs/config/raw detail live
+// (Layer 3). Nothing is lost — the insider fields move one or two clicks down.
+// Every builder maps its counts to ONE population so the headline stays honest, and
+// every dynamic value is displayed through the shared sanitizer + textContent.
+// ═════════════════════════════════════════════════════════════════════════════
+
+// ── Shared plain-language helpers ────────────────────────────────────────────
+// Acronyms that should stay upper-cased when a token is humanized for display.
+const KNOWN_ACRONYMS = {
+  gpt: 'GPT', llm: 'LLM', cli: 'CLI', ai: 'AI', cpu: 'CPU', ram: 'RAM',
+  api: 'API', url: 'URL', id: 'ID', ok: 'OK',
+};
+function titleCaseWord(w) {
+  const lw = String(w).toLowerCase();
+  if (KNOWN_ACRONYMS[lw]) return KNOWN_ACRONYMS[lw];
+  return lw.charAt(0).toUpperCase() + lw.slice(1);
+}
+
+/**
+ * Turn an identifier-ish token into a plain, sentence-cased phrase: split
+ * camelCase + separators, drop empties, cap only the first word.
+ * 'zombieCleanup' → 'Zombie cleanup'; 'session_watchdog' → 'Session watchdog'.
+ */
+export function humanizeToken(token) {
+  const words = String(token == null ? '' : token)
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[\s\-_/.]+/)
+    .filter(Boolean);
+  if (words.length === 0) return '';
+  return words
+    .map((w, i) => (i === 0 ? titleCaseWord(w) : (KNOWN_ACRONYMS[w.toLowerCase()] || w.toLowerCase())))
+    .join(' ');
+}
+
+/**
+ * A plain, jargon-safe display name for a model id — drops every version/date
+ * segment (any part containing a digit) and title-cases the words that remain.
+ * 'claude-opus-4-8-20260115' → 'Claude Opus'; 'gpt-5.5' → 'GPT'. Returns '' when
+ * nothing plain survives OR the result would still trip the F10 jargon check — the
+ * caller substitutes a plain phrase, so a raw model id can NEVER leak to Layer 1.
+ */
+export function friendlyModel(modelId) {
+  // Drop any version/date segment (a part with a digit) AND single-letter fragments
+  // (a lone 'm' from 'm_<hex>' is meaningless as a name) — so a hex/opaque id yields
+  // '' and the caller substitutes a plain phrase.
+  const words = String(modelId == null ? '' : modelId)
+    .split(/[\s\-_./]+/)
+    .filter((w) => w && w.length >= 2 && !/\d/.test(w));
+  const name = words.map(titleCaseWord).join(' ').trim();
+  if (!name) return '';
+  return findInsiderVocab(name).length === 0 ? name : '';
+}
+
+/** The plain model phrase for a routing/spend position, with a door-class fallback. */
+function modelPhrase(pos) {
+  if (!pos) return '';
+  return friendlyModel(pos.modelId) || (pos.doorClass === 'metered' ? 'a paid model' : 'the built-in model');
+}
+
+/** Plain words for a routing/spend door class. */
+function doorClassWord(doorClass) {
+  return doorClass === 'metered' ? 'pay-per-use' : 'built-in (no per-use charge)';
+}
+
+function fmtUsd(n, dp = 2) {
+  const v = Number(n);
+  return '$' + (Number.isFinite(v) ? v : 0).toFixed(dp);
+}
+function fmtCount(n) {
+  const v = Number(n);
+  return (Number.isFinite(v) ? v : 0).toLocaleString('en-US');
+}
+
+/** Build a Layer-3 record node from an ordered [key, value] list (all XSS-safe). */
+function recordFields(doc, rows) {
+  const wrap = el(doc, 'div', 'glance-record-fields');
+  for (const [k, v] of rows) {
+    if (v == null || v === '') continue;
+    const row = el(doc, 'div', 'glance-record-row');
+    row.appendChild(el(doc, 'span', 'glance-record-key', String(k)));
+    row.appendChild(el(doc, 'span', 'glance-record-val', String(v)));
+    wrap.appendChild(row);
+  }
+  return wrap;
+}
+
+/**
+ * Shared tile→list→record wiring: map buildX's { rows, ... } tiles into glance
+ * tiles whose onActivate renders each row as a plain Layer-2 line that opens a
+ * Layer-3 record. `rowText(item)` → the plain summary; `recordNode(doc, item)` →
+ * the full record. Mirrors commitmentsGlanceSpec/blockersGlanceSpec exactly.
+ */
+function wireTiles(doc, baseTiles, rowText, recordNode) {
+  return baseTiles.map((t) => ({
+    key: t.key,
+    label: t.label,
+    value: t.value,
+    tone: t.tone,
+    onActivate: ({ doc: d, drilldown, openRecord }) => {
+      const rows = t.rows || [];
+      if (rows.length === 0) return; // component renders the honest F6 empty-state
+      const list = el(d, 'div', 'glance-list');
+      for (const item of rows) {
+        const row = d.createElement('button');
+        row.type = 'button';
+        row.className = 'glance-list-row';
+        row.setAttribute('aria-label', 'Open the full record');
+        row.appendChild(el(d, 'span', 'glance-list-summary', rowText(item)));
+        row.addEventListener('click', () => openRecord(recordNode(d, item)));
+        list.appendChild(row);
+      }
+      drilldown.appendChild(list);
+    },
+  }));
+}
+
+// ── Machines glance (F10/F11) + issue #1429 nickname edit ────────────────────
+// The old front page showed a per-machine insider "guards" line ("67 on (16
+// confirmed) · ⚠ 6 off that should be on… as of 3m ago"). On the floor: a plain
+// headline over Online / Attention needed / Dispatcher / Safety-checks tiles. The
+// named safety checks (from GET /guards) drill down with a one-line plain-English
+// explanation each (Layer 2), full posture at Layer 3. Machine NICKNAMES are
+// user-authored, so they NEVER appear at Layer 1 — they live at Layer 2/3, shown
+// through the sanitizer. #1429: the editable nickname lives in the Layer-2 machine
+// row and commits only on Enter/blur; the drill holds it across the 15s poll (F9).
+
+function guardPostureProblems(p) {
+  if (!p) return 0;
+  return (p.offDeviant || 0) + (p.offRuntimeDivergent || 0) + (p.onStale || 0)
+    + (p.missing || 0) + (p.errored || 0) + (p.divergedPendingRestart || 0);
+}
+function machineNeedsAttention(m) {
+  if (!m) return false;
+  return !m.online
+    || m.clockSkewStatus === 'suspect-clock-removed'
+    || guardPostureProblems(m.guardPosture) > 0;
+}
+
+/** The single population: the machines GET /pool returns. */
+export function machinesPopulation(pool) {
+  const machines = pool && Array.isArray(pool.machines) ? pool.machines : [];
+  return machines.filter((m) => m && typeof m.machineId === 'string');
+}
+
+export function buildMachinesGlance(pool, guards = null) {
+  const machines = machinesPopulation(pool);
+  const online = machines.filter((m) => m.online);
+  const attention = machines.filter(machineNeedsAttention);
+  const holder = pool && pool.router && pool.router.holder;
+  const dispatcher = holder ? machines.find((m) => m.machineId === holder) : null;
+
+  let headline;
+  if (machines.length === 0) {
+    headline = 'No machines are paired yet.';
+  } else if (online.length === machines.length && attention.length === 0) {
+    headline = machines.length === 1 ? 'This machine is online and healthy.'
+      : machines.length === 2 ? 'Both machines are online and healthy.'
+      : `All ${machines.length} machines are online and healthy.`;
+  } else {
+    const lookClause = attention.length === 1 ? '1 needs a look' : `${attention.length} need a look`;
+    headline = `${online.length} of ${machines.length} machines online; ${lookClause}.`;
+  }
+
+  const tiles = [
+    { key: 'online', label: 'Online', value: String(online.length), tone: online.length === machines.length ? 'neutral' : 'warn', rows: online },
+    { key: 'attention', label: 'Attention needed', value: String(attention.length), tone: attention.length ? 'warn' : 'neutral', rows: attention },
+    { key: 'dispatcher', label: 'Dispatcher', value: dispatcher ? 'Assigned' : 'None', tone: 'muted', rows: dispatcher ? [dispatcher] : [] },
+  ];
+
+  // The named safety checks come from the LOCAL /guards view (the only place guard
+  // NAMES exist without the rate-limited pool-scoped call). Omit the tile when the
+  // guards view is unavailable rather than invent an empty one.
+  const guardRows = guards && Array.isArray(guards.guards) ? guards.guards : null;
+  if (guardRows) {
+    const problems = guards.summary ? (
+      (guards.summary.offDeviant || 0) + (guards.summary.offRuntimeDivergent || 0)
+      + (guards.summary.onStale || 0) + (guards.summary.missing || 0)
+      + (guards.summary.errored || 0) + (guards.summary.divergedPendingRestart || 0)
+    ) : 0;
+    tiles.push({ key: 'guards', label: 'Safety checks', value: String(guardRows.length), tone: problems ? 'warn' : 'neutral', rows: guardRows });
+  }
+
+  return { headline, tiles, population: machines };
+}
+
+const MACHINE_STATUS_WORD = {
+  offline: 'Offline',
+  'suspect-clock-removed': 'Clock out of sync — paused for new conversations',
+};
+function machineStatusWord(m) {
+  if (!m.online) return 'Offline';
+  if (m.clockSkewStatus === 'suspect-clock-removed') return MACHINE_STATUS_WORD['suspect-clock-removed'];
+  if (machineNeedsAttention(m)) return 'Online — needs a look';
+  return 'Online and healthy';
+}
+function machineSpecLine(hw) {
+  if (!hw) return 'specs not reported yet';
+  const chip = (hw.cpuModel && hw.cpuModel !== 'unknown') ? hw.cpuModel
+    : ((hw.platform || '') + (hw.arch ? ' ' + hw.arch : '')).trim();
+  const cores = hw.cpuCores ? hw.cpuCores + ' cores' : '';
+  const ram = hw.totalMemBytes ? Math.round(hw.totalMemBytes / 1073741824) + ' GB' : '';
+  return [chip, cores, ram].filter(Boolean).join(' · ') || 'specs not reported yet';
+}
+
+/** Plain one-line explanation of a guard's effective state — no per-key dictionary. */
+const GUARD_EFFECTIVE_WORD = {
+  'on-confirmed': 'On and verified working',
+  'on-unverified': 'On (not yet verified this run)',
+  'on-stale': 'On, but its last check is stale — worth a look',
+  'on-dry-run': 'On in practice-only mode (not acting for real yet)',
+  'off-runtime-divergent': 'Off even though the settings say on — needs a look',
+  'diverged-pending-restart': 'Changed; waiting for a restart to take effect',
+  'errored': 'Hit an error — needs a look',
+  'missing': 'Expected but not found — needs a look',
+};
+function guardExplanation(g) {
+  if (g.effective === 'off') {
+    return g.offClass === 'diverged-from-default'
+      ? 'Off, though the default is on — worth a look'
+      : 'Off by default — intentionally quiet';
+  }
+  return GUARD_EFFECTIVE_WORD[g.effective] || String(g.effective || 'unknown');
+}
+function guardNeedsLook(g) {
+  return ['on-stale', 'off-runtime-divergent', 'diverged-pending-restart', 'errored', 'missing'].includes(g.effective)
+    || (g.effective === 'off' && g.offClass === 'diverged-from-default');
+}
+
+export function machineRowText(m) {
+  const nick = sanitizeForDisplay(m.nickname || m.machineId || 'A machine', 'label');
+  return `${nick} — ${machineStatusWord(m)}`;
+}
+
+/** Layer-3 machine record — specs, sessions, and this machine's guard posture in
+ *  plain words. The raw counts that used to sit on the front page live here. */
+export function machineRecordNode(doc, m, opts = {}) {
+  const online = !!m.online;
+  const sessions = (m.activeSessionCount != null)
+    ? `${m.activeSessionCount}${m.maxSessions ? ' / ' + m.maxSessions : ''} conversation${m.activeSessionCount === 1 ? '' : 's'}`
+    : '—';
+  const rows = [
+    ['Name', m.nickname || m.machineId || '—'],
+    ['Status', machineStatusWord(m)],
+    ['Specs', machineSpecLine(m.hardware)],
+    ['Conversations', online ? sessions : '—'],
+  ];
+  const p = m.guardPosture;
+  if (p) {
+    const on = (p.onConfirmed || 0) + (p.onUnverified || 0) + (p.onDryRun || 0);
+    rows.push(['Safety checks on', String(on)]);
+    const problems = guardPostureProblems(p);
+    if (problems > 0) rows.push(['Safety checks needing a look', String(problems)]);
+  } else {
+    rows.push(['Safety checks', 'not reported yet']);
+  }
+  const wrap = recordFields(doc, rows);
+  // #1429: the editable nickname commits ONLY on Enter/blur, with optimistic local
+  // echo; the poll stays authority for external renames. The drill holds it (F9).
+  if (typeof opts.onRename === 'function' && m.machineId) {
+    const editRow = el(doc, 'div', 'glance-record-row');
+    editRow.appendChild(el(doc, 'span', 'glance-record-key', 'Rename'));
+    const input = doc.createElement('input');
+    input.type = 'text';
+    input.className = 'glance-record-input machine-nick';
+    input.value = m.nickname || m.machineId;
+    input.setAttribute('data-mid', m.machineId);
+    input.setAttribute('aria-label', 'Machine nickname — press Enter or click away to save');
+    let last = input.value;
+    const commit = () => {
+      const next = input.value.trim();
+      if (next === '' || next === last) { input.value = last; return; }
+      const prev = last;
+      last = next; // optimistic local echo — keep the typed value
+      // prev lets the caller revert this optimistic echo if the save fails.
+      opts.onRename(m.machineId, next, input, prev);
+    };
+    input.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); input.blur(); } });
+    input.addEventListener('blur', commit);
+    editRow.appendChild(input);
+    wrap.appendChild(editRow);
+  }
+  return wrap;
+}
+
+export function guardRowText(g) {
+  return `${humanizeToken(g.key)} — ${guardExplanation(g)}`;
+}
+export function guardRecordNode(doc, g) {
+  const rt = g.runtime;
+  const rows = [
+    ['Check', humanizeToken(g.key)],
+    ['In plain words', guardExplanation(g)],
+    ['Turned on in settings', g.configEnabled == null ? 'not set' : (g.configEnabled ? 'yes' : 'no')],
+    ['On by default', g.defaultEnabled == null ? '—' : (g.defaultEnabled ? 'yes' : 'no')],
+    ['Runs in', g.process === 'lifeline' ? 'the always-on lifeline' : 'the main server'],
+  ];
+  if (g.loadBearing) rows.push(['Load-bearing', 'yes — a safety-critical check']);
+  if (rt && typeof rt === 'object') {
+    if (rt.dryRun) rows.push(['Mode', 'practice-only (not acting for real yet)']);
+    if (typeof rt.jobCount === 'number') rows.push(['Watched items', String(rt.jobCount)]);
+  }
+  if (g.error) rows.push(['Error', g.error]);
+  return recordFields(doc, rows);
+}
+
+/**
+ * Build the Machines glance spec with drill wiring. `guards` is the LOCAL /guards
+ * view ({ guards, summary }) or null. `opts.onRename(machineId, nickname, input)`
+ * wires the #1429 nickname edit onto each machine's Layer-3 record.
+ */
+export function machinesGlanceSpec(doc, pool, guards = null, opts = {}) {
+  const base = buildMachinesGlance(pool, guards);
+  const tiles = base.tiles.map((t) => {
+    if (t.key === 'guards') {
+      return {
+        key: t.key, label: t.label, value: t.value, tone: t.tone,
+        onActivate: ({ doc: d, drilldown, openRecord }) => {
+          const rows = (t.rows || []).slice().sort((a, b) => (guardNeedsLook(b) ? 1 : 0) - (guardNeedsLook(a) ? 1 : 0));
+          if (rows.length === 0) return;
+          const list = el(d, 'div', 'glance-list');
+          for (const g of rows) {
+            const row = d.createElement('button');
+            row.type = 'button';
+            row.className = 'glance-list-row';
+            if (guardNeedsLook(g)) row.setAttribute('data-tone', 'warn');
+            row.setAttribute('aria-label', 'Open the full record');
+            row.appendChild(el(d, 'span', 'glance-list-summary', guardRowText(g)));
+            row.addEventListener('click', () => openRecord(guardRecordNode(d, g)));
+            list.appendChild(row);
+          }
+          drilldown.appendChild(list);
+        },
+      };
+    }
+    return {
+      key: t.key, label: t.label, value: t.value, tone: t.tone,
+      onActivate: ({ doc: d, drilldown, openRecord }) => {
+        const rows = t.rows || [];
+        if (rows.length === 0) return;
+        const list = el(d, 'div', 'glance-list');
+        for (const m of rows) {
+          const row = d.createElement('button');
+          row.type = 'button';
+          row.className = 'glance-list-row';
+          if (machineNeedsAttention(m)) row.setAttribute('data-tone', 'warn');
+          row.setAttribute('aria-label', 'Open the full record');
+          row.appendChild(el(d, 'span', 'glance-list-summary', machineRowText(m)));
+          row.addEventListener('click', () => openRecord(machineRecordNode(d, m, { onRename: opts.onRename })));
+          list.appendChild(row);
+        }
+        drilldown.appendChild(list);
+      },
+    };
+  });
+  return { headline: base.headline, tiles, population: base.population };
+}
+
+// ── Health glance (F10/F11) ──────────────────────────────────────────────────
+// The old front page dumped ~390 words of subsystem prose. On the floor: a plain
+// headline ("All systems are operational." / "N subsystems need attention.") over
+// Subsystems / Need attention / Recent events tiles. Each subsystem's full prose
+// description, processes, and metrics move to its Layer-3 record — nothing lost.
+
+/** The single population: the subsystems GET /systems/status reports as active. */
+export function healthPopulation(systems) {
+  const caps = systems && Array.isArray(systems.activeCapabilities) ? systems.activeCapabilities : [];
+  return caps.filter((c) => c && typeof c.id === 'string');
+}
+
+export function buildHealthGlance(systems) {
+  const caps = healthPopulation(systems);
+  const errored = caps.filter((c) => c.status === 'error');
+  const events = systems && Array.isArray(systems.recentEvents) ? systems.recentEvents : [];
+  const healthy = (systems && systems.health === 'healthy') && errored.length === 0;
+
+  let headline;
+  if (caps.length === 0) {
+    headline = 'No subsystems are reporting yet.';
+  } else if (healthy) {
+    headline = 'All systems are operational.';
+  } else {
+    headline = errored.length === 1
+      ? '1 subsystem needs attention.'
+      : `${errored.length} subsystems need attention.`;
+  }
+
+  const tiles = [
+    { key: 'subsystems', label: 'Subsystems', value: String(caps.length), tone: 'neutral', rows: caps },
+    { key: 'attention', label: 'Need attention', value: String(errored.length), tone: errored.length ? 'warn' : 'neutral', rows: errored },
+    { key: 'events', label: 'Recent events', value: String(events.length), tone: 'muted', rows: events },
+  ];
+
+  return { headline, tiles, population: caps };
+}
+
+const CAP_STAT_LABEL = {
+  recoveries: 'Recovered', interventions: 'Auto-fixed', activeCases: 'Active',
+  coherencePassed: 'Checks OK', coherenceFailed: 'Issues', memoryPercent: 'Memory %',
+  enabledJobs: 'Jobs', activeJobSessions: 'Running', queueLength: 'Queued',
+  weeklyUsage: 'Weekly %', fiveHourRate: '5h rate %', topicMappings: 'Topics',
+  totalMessages: 'Messages', proposals: 'Proposals', gaps: 'Gaps', learningsApplied: 'Applied',
+};
+
+export function healthCapRowText(c) {
+  const word = c.status === 'error' ? 'needs attention' : 'working';
+  return `${sanitizeForDisplay(c.label || c.id || 'A subsystem', 'label')} — ${word}`;
+}
+export function healthCapRecordNode(doc, c) {
+  const rows = [
+    ['Subsystem', c.label || c.id || '—'],
+    ['Status', c.status === 'error' ? 'Needs attention' : 'Working'],
+    ['What it does', c.description || '—'],
+    ['Right now', c.metric || '—'],
+  ];
+  for (const p of (c.processes || [])) {
+    rows.push([p.name, p.status === 'running' ? 'Running' : 'Error']);
+  }
+  for (const [key, label] of Object.entries(CAP_STAT_LABEL)) {
+    const v = c.stats ? c.stats[key] : undefined;
+    if (v != null && v !== 0 && v !== false) rows.push([label, String(v)]);
+  }
+  return recordFields(doc, rows);
+}
+export function healthEventRowText(e) {
+  return sanitizeForDisplay(e.narrative || e.subsystem || 'An event', 'summary');
+}
+export function healthEventRecordNode(doc, e) {
+  const when = e.timestamp ? defaultFmtTs(e.timestamp) : '—';
+  return recordFields(doc, [
+    ['What happened', e.narrative || '—'],
+    ['Part', e.subsystem || '—'],
+    ['When', when],
+  ]);
+}
+
+export function healthGlanceSpec(doc, systems) {
+  const base = buildHealthGlance(systems);
+  const tiles = base.tiles.map((t) => {
+    const rowText = t.key === 'events' ? healthEventRowText : healthCapRowText;
+    const recordNode = t.key === 'events' ? healthEventRecordNode : healthCapRecordNode;
+    return {
+      key: t.key, label: t.label, value: t.value, tone: t.tone,
+      onActivate: ({ doc: d, drilldown, openRecord }) => {
+        const rows = t.rows || [];
+        if (rows.length === 0) return;
+        const list = el(d, 'div', 'glance-list');
+        for (const item of rows) {
+          const row = d.createElement('button');
+          row.type = 'button';
+          row.className = 'glance-list-row';
+          if (t.key !== 'events' && item.status === 'error') row.setAttribute('data-tone', 'warn');
+          row.setAttribute('aria-label', 'Open the full record');
+          row.appendChild(el(d, 'span', 'glance-list-summary', rowText(item)));
+          row.addEventListener('click', () => openRecord(recordNode(d, item)));
+          list.appendChild(row);
+        }
+        drilldown.appendChild(list);
+      },
+    };
+  });
+  return { headline: base.headline, tiles, population: base.population };
+}
+
+// ── Spend glance (F10/F11) ───────────────────────────────────────────────────
+// The old front page leaned on "paid door / metered / reflows". On the floor: a
+// plain headline ("Nothing is being billed per-call right now.") over Estimated
+// cost / Text processed / Pay-per-use access tiles. "Metered / paid door" reads as
+// "pay-per-use"; the price-reflow detail and per-model math move to Layer 3.
+
+export function buildSpendGlance(summary, caps = null) {
+  const totals = (summary && summary.totals) || {};
+  const rows = (summary && Array.isArray(summary.rows)) ? summary.rows : [];
+  const keys = (caps && Array.isArray(caps.keys)) ? caps.keys : [];
+  const meteredLiveYet = !!(summary && summary.meteredLiveYet) || !!(caps && caps.meteredLiveYet);
+
+  const netUsd = Number(totals.netUsd) || 0;
+  const headline = meteredLiveYet
+    ? `About ${fmtUsd(netUsd)} of pay-per-use AI so far.`
+    : 'Nothing is being billed per-call right now.';
+
+  const tokensTotal = (Number(totals.tokensIn) || 0) + (Number(totals.tokensOut) || 0);
+  const tiles = [
+    { key: 'cost', label: 'Estimated cost', value: fmtUsd(netUsd), tone: 'neutral', rows, mode: 'cost' },
+    { key: 'usage', label: 'Text processed', value: fmtCount(tokensTotal), tone: 'muted', rows, mode: 'usage' },
+    { key: 'access', label: 'Pay-per-use access', value: String(keys.length), tone: 'muted', rows: keys, mode: 'access' },
+  ];
+
+  return { headline, tiles, population: rows };
+}
+
+function plainPriceBasis(r) {
+  if (r.priceBasis === 'subscription-zero') return 'Subscription — not billed per use';
+  if (r.priceBasis === 'no-matching-point') return 'No price on file yet';
+  return String(r.priceBasis || '—') + (r.priceStale ? ' (out of date)' : '');
+}
+function plainGoLive(state) {
+  if (state === 'live') return 'Live';
+  if (state === 'disarmed') return 'Turned off';
+  return 'Not switched on yet';
+}
+
+export function spendRowCostText(r) {
+  return `${modelPhrase(r)} — ${fmtUsd(Number(r.netUsd) || 0)}`;
+}
+export function spendRowUsageText(r) {
+  const total = (Number(r.tokensIn) || 0) + (Number(r.tokensOut) || 0);
+  return `${modelPhrase(r)} — ${fmtCount(total)} pieces of text`;
+}
+export function spendKeyRowText(k) {
+  return `${humanizeToken(k.provider || k.door || 'A provider')} — pay-per-use · ${plainGoLive(k.goLiveState)}`;
+}
+export function spendRowRecordNode(doc, r) {
+  return recordFields(doc, [
+    ['Model', friendlyModel(r.modelId) || r.modelId || '—'],
+    ['How it is reached', humanizeToken(r.door)],
+    ['Access type', doorClassWord(r.doorClass)],
+    ['Text in', fmtCount(r.tokensIn)],
+    ['Text out', fmtCount(r.tokensOut)],
+    ['Gross cost', fmtUsd(r.grossUsd, 4)],
+    ['Net cost', fmtUsd(r.netUsd, 4)],
+    ['How it is priced', plainPriceBasis(r)],
+  ]);
+}
+export function spendKeyRecordNode(doc, k) {
+  return recordFields(doc, [
+    ['Provider', k.provider || '—'],
+    ['How it is reached', humanizeToken(k.door)],
+    ['Daily limit', fmtUsd(k.dailyCapUsd)],
+    ['Lifetime limit', fmtUsd(k.lifetimeCapUsd)],
+    ['Used today', fmtUsd(k.committedDayUsd)],
+    ['Used in total', fmtUsd(k.committedLifetimeUsd)],
+    ['Status', plainGoLive(k.goLiveState) + (k.frozen ? ' · paused' : '')],
+  ]);
+}
+
+export function spendGlanceSpec(doc, summary, caps = null) {
+  const base = buildSpendGlance(summary, caps);
+  const tiles = base.tiles.map((t) => ({
+    key: t.key, label: t.label, value: t.value, tone: t.tone,
+    onActivate: ({ doc: d, drilldown, openRecord }) => {
+      const rows = t.rows || [];
+      if (rows.length === 0) return;
+      const list = el(d, 'div', 'glance-list');
+      for (const item of rows) {
+        const row = d.createElement('button');
+        row.type = 'button';
+        row.className = 'glance-list-row';
+        row.setAttribute('aria-label', 'Open the full record');
+        const text = t.mode === 'access' ? spendKeyRowText(item)
+          : t.mode === 'usage' ? spendRowUsageText(item)
+          : spendRowCostText(item);
+        row.appendChild(el(d, 'span', 'glance-list-summary', text));
+        const recNode = t.mode === 'access' ? spendKeyRecordNode(d, item) : spendRowRecordNode(d, item);
+        row.addEventListener('click', () => openRecord(recNode));
+        list.appendChild(row);
+      }
+      drilldown.appendChild(list);
+    },
+  }));
+  return { headline: base.headline, tiles, population: base.population };
+}
+
+// ── Routing Map glance (F10/F11) ─────────────────────────────────────────────
+// The old front page used "lane / nature / door". On the floor: a plain headline
+// ("Background AI work runs on X, with Y as backup.") over one tile per lane
+// (plain-named) + a Job-types tile. Each lane drills into its ordered fallback
+// list of plain model names (Layer 2); each opens the full door/model config
+// (Layer 3). The insider door flags live at Layer 3, not the front page.
+
+const CHAIN_ORDER = ['FAST', 'SORT', 'JUDGE', 'WRITE'];
+const CHAIN_LABEL = { FAST: 'Quick tasks', SORT: 'Sorting', JUDGE: 'Judging', WRITE: 'Writing' };
+
+/** The primary lane's first two positions drive the headline (X + backup Y). */
+function primaryLane(map) {
+  const chains = map && Array.isArray(map.chains) ? map.chains : [];
+  return chains.find((c) => c.chain === 'FAST') || chains[0] || null;
+}
+
+export function buildRoutingMapGlance(map) {
+  const chains = map && Array.isArray(map.chains) ? map.chains : [];
+  const components = map && Array.isArray(map.components) ? map.components : [];
+
+  const lead = primaryLane(map);
+  const positions = (lead && Array.isArray(lead.positions)) ? lead.positions : [];
+  let headline;
+  if (chains.length === 0) {
+    headline = 'No background AI routing is set up yet.';
+  } else {
+    const x = modelPhrase(positions[0]) || 'the built-in model';
+    const y = modelPhrase(positions[1]);
+    headline = y
+      ? `Background AI work runs on ${x}, with ${y} as backup.`
+      : `Background AI work runs on ${x}.`;
+  }
+
+  const tiles = [];
+  const ordered = chains.slice().sort((a, b) => CHAIN_ORDER.indexOf(a.chain) - CHAIN_ORDER.indexOf(b.chain));
+  for (const c of ordered) {
+    if (tiles.length >= GLANCE_MAX_TILES - 1) break; // leave room for the Job-types tile
+    const pos = Array.isArray(c.positions) ? c.positions : [];
+    tiles.push({
+      key: 'lane-' + String(c.chain || '').toLowerCase(),
+      label: CHAIN_LABEL[c.chain] || humanizeToken(c.chain),
+      value: String(pos.length),
+      tone: 'neutral',
+      rows: pos,
+      mode: 'lane',
+    });
+  }
+  tiles.push({ key: 'jobs', label: 'Job types', value: String(components.length), tone: 'muted', rows: components, mode: 'jobs' });
+
+  return { headline, tiles, population: components };
+}
+
+export function laneRowText(p, i) {
+  const rank = typeof i === 'number' ? `${i + 1}. ` : '';
+  return `${rank}${modelPhrase(p)}${p.doorClass === 'metered' ? ' (pay-per-use)' : ''}`;
+}
+export function laneRecordNode(doc, p) {
+  return recordFields(doc, [
+    ['Model', friendlyModel(p.modelId) || p.modelId || '—'],
+    ['How it is reached', humanizeToken(p.door)],
+    ['Access type', doorClassWord(p.doorClass)],
+    ['Safe for untrusted input', p.injectionSafe ? 'yes' : 'no'],
+    ['Pay-per-use', p.moneyGated ? 'yes' : 'no'],
+    ['Skipped for now', p.skippedInIncrementA ? 'yes' : 'no'],
+  ]);
+}
+export function jobRowText(c) {
+  const lane = CHAIN_LABEL[c.chain] || 'default routing';
+  return `${humanizeToken(c.component)} — ${lane}`;
+}
+export function jobRecordNode(doc, c) {
+  const exposure = c.injectionExposure
+    ? (c.injectionExposure.exposed ? 'yes' : 'no')
+    : (c.untrustedInput === true ? 'yes' : c.untrustedInput === false ? 'no' : '—');
+  return recordFields(doc, [
+    ['Job kind', humanizeToken(c.component)],
+    ['Type', humanizeToken(c.category)],
+    ['Lane', CHAIN_LABEL[c.chain] || 'default routing'],
+    ['Safety-critical', c.criticalGate ? 'yes' : 'no'],
+    ['Can see untrusted input', exposure],
+  ]);
+}
+
+export function routingMapGlanceSpec(doc, map) {
+  const base = buildRoutingMapGlance(map);
+  const tiles = base.tiles.map((t) => ({
+    key: t.key, label: t.label, value: t.value, tone: t.tone,
+    onActivate: ({ doc: d, drilldown, openRecord }) => {
+      const rows = t.rows || [];
+      if (rows.length === 0) return;
+      const list = el(d, 'div', 'glance-list');
+      rows.forEach((item, i) => {
+        const row = d.createElement('button');
+        row.type = 'button';
+        row.className = 'glance-list-row';
+        row.setAttribute('aria-label', 'Open the full record');
+        const text = t.mode === 'jobs' ? jobRowText(item) : laneRowText(item, i);
+        row.appendChild(el(d, 'span', 'glance-list-summary', text));
+        const recNode = t.mode === 'jobs' ? jobRecordNode(d, item) : laneRecordNode(d, item);
+        row.addEventListener('click', () => openRecord(recNode));
+        list.appendChild(row);
+      });
       drilldown.appendChild(list);
     },
   }));

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -657,6 +657,15 @@
       color: var(--text); cursor: pointer;
     }
     .glance-record-action:hover { border-color: var(--accent-dim); }
+    /* Phase 3: the #1429 editable nickname field (in a machine's Layer-3 record) and
+       the warn-toned Layer-2 rows (a machine or safety check that needs a look). */
+    .glance-record-input {
+      padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px;
+      background: var(--bg); color: var(--text); font-size: 13px; max-width: 260px;
+    }
+    .glance-record-input:focus { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
+    .glance-record-input[data-rename-error] { border-color: var(--orange); }
+    .glance-list-row[data-tone="warn"] { border-left: 3px solid var(--orange); }
 
     .terminal-header {
       display: flex;
@@ -3529,28 +3538,15 @@
         <button onclick="loadRoutingMap()" style="padding:6px 12px">Refresh</button>
       </div>
       <div class="tab-purpose">
-        Where each internal job-kind sends its AI calls. Every background check, gate, and
-        sentinel has a <b>lane</b> (its "nature") and a fallback list of <b>doors</b> — the ways
-        it can reach a model. This shows, per lane, the ordered door + model list it tries, and
-        flags a door that's <b>metered</b> (a paid API, skipped for now), <b>money-gated</b>, or
-        that must never take untrusted input. Read-only: it shows the map, it changes nothing.
+        Where the agent's background AI work runs — the headline says which model it uses first
+        and what backs it up; tap a tile to see a job group's ordered list of models, tap one for
+        the full setup. Read-only: it shows the map, it changes nothing.
       </div>
 
-      <!-- The four lanes (chains) -->
-      <div id="routingMapChainsCard" style="border:1px solid var(--border);border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:12px">
-        <div style="font-weight:600">Lanes (fallback order)</div>
-        <div id="routingMapChainsBody" style="font-size:13px;overflow-x:auto">
-          <div style="color:var(--text-dim)">Loading...</div>
-        </div>
-      </div>
-
-      <!-- Per job-kind mapping -->
-      <div style="border:1px solid var(--border);border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:8px">
-        <div style="font-weight:600">By job-kind</div>
-        <div id="routingMapComponentsBody" style="font-size:13px;overflow-x:auto">
-          <div style="color:var(--text-dim)">Loading...</div>
-        </div>
-      </div>
+      <!-- Glance floors F10/F11 (topic 29836, Phase 3): the shared component renders the
+           headline + per-lane tiles + drill-down here. "Lane / nature / door" became plain
+           words at the glance; the ordered model lists and full config moved one drill down. -->
+      <div id="routingMapGlance" class="glance-root"></div>
     </div>
 
     <!-- Spend tab — the read-only Routing Control Room spend/caps view (Increment A,
@@ -3579,28 +3575,11 @@
         go-live control are a later increment.
       </div>
 
-      <!-- Headline totals -->
-      <div id="spendHeadlineCard" style="border:1px solid var(--border);border-radius:8px;padding:16px">
-        <div id="spendHeadlineBody" style="font-size:13px;overflow-x:auto">
-          <div style="color:var(--text-dim)">Loading...</div>
-        </div>
-      </div>
-
-      <!-- Per door/model spend -->
-      <div style="border:1px solid var(--border);border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:8px">
-        <div style="font-weight:600">By door &amp; model</div>
-        <div id="spendRowsBody" style="font-size:13px;overflow-x:auto">
-          <div style="color:var(--text-dim)">Loading...</div>
-        </div>
-      </div>
-
-      <!-- Paid-door caps -->
-      <div style="border:1px solid var(--border);border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:8px">
-        <div style="font-weight:600">Paid-door caps</div>
-        <div id="spendCapsBody" style="font-size:13px;overflow-x:auto">
-          <div style="color:var(--text-dim)">Loading...</div>
-        </div>
-      </div>
+      <!-- Glance floors F10/F11 (topic 29836, Phase 3): the shared component renders
+           the headline + totals tiles + drill-down here. "Metered / paid door / reflows"
+           became plain words at the glance ("pay-per-use"); the per-model math and the
+           paid-door caps moved one drill down. -->
+      <div id="spendGlance" class="glance-root"></div>
     </div>
 
     <!-- Evidence Tab (WikiClaim Phase 4) — per-entity evidence + reverse "what cites this?" view.
@@ -3842,13 +3821,11 @@
         <h2 class="ph-title">Machines</h2>
         <div id="machinesStamp" class="ph-stamp" aria-live="polite"></div>
       </div>
-      <p class="ph-intro">Every computer this agent is set up on. Each one gets a friendly name you can change — and once it has a name, you can tell the agent "move this conversation to the mini" and it knows which machine you mean. The agent shares its conversations across these machines so it can handle more at once.</p>
-      <div id="machinesHeadline" class="ph-headline-wrap" aria-live="polite"></div>
-      <section class="ph-section">
-        <h3 class="ph-h">The machines</h3>
-        <p class="ph-h-sub">Click a name to rename it. The "dispatcher" is the one machine currently handing out new conversations.</p>
-        <div id="machinesList"></div>
-      </section>
+      <p class="tab-purpose ph-intro">Every computer this agent runs on, at a glance — the headline says whether they're all online and healthy; tap a tile to see which machines, tap one for its full detail (and to rename it). The "dispatcher" is the one machine currently handing out new conversations.</p>
+      <!-- Glance floors F10/F11 (topic 29836, Phase 3): the shared component renders the
+           headline + tiles + drill-down here. Rebuilt from the old insider "guards" line.
+           Nickname editing (issue #1429) lives one drill down, commits on Enter/blur. -->
+      <div id="machinesGlance" class="glance-root"></div>
     </div>
 
     <div id="evidenceTab" class="tab-panel" style="display:none;flex-direction:column;padding:20px;gap:16px;overflow-y:auto">
@@ -4003,28 +3980,18 @@
       </div>
     </div>
 
-    <!-- Health Tab (was Systems) -->
+    <!-- Health Tab (was Systems) — glance floors F10/F11 (topic 29836, Phase 3).
+         The old ~390-word subsystem prose became a plain headline + tiles; each
+         subsystem's full description / processes / metrics live one drill down.
+         The shared component renders the headline + tiles + drill-down here. -->
     <div class="systems-container" id="systemsTab" style="display:none">
       <div class="systems-main">
-        <!-- Overview (card grid) -->
-        <div id="systemsOverview">
-          <div class="systems-header">
-            <h2>Health</h2>
-            <button class="systems-refresh" onclick="loadSystems()">Refresh</button>
-          </div>
-          <div class="tab-purpose" style="margin-bottom:16px">Your agent's health and running processes — the server and each running session at a glance.</div>
-          <div id="systemsBanner">
-            <div style="padding:20px;color:var(--text-dim);text-align:center">Loading...</div>
-          </div>
-          <div id="systemsIssues"></div>
-          <div id="systemsCapabilities"></div>
-          <div id="systemsEvents"></div>
+        <div class="systems-header">
+          <h2>Health</h2>
+          <button class="systems-refresh" onclick="loadSystems()">Refresh</button>
         </div>
-        <!-- Detail view (single capability) -->
-        <div class="cap-detail-view" id="systemsDetailView">
-          <button class="cap-detail-back" onclick="showSystemsOverview()">&#9664; Back to Health</button>
-          <div id="systemsDetailContent"></div>
-        </div>
+        <div class="tab-purpose" style="margin-bottom:16px">Your agent's health at a glance — the headline says whether everything's operational; tap a tile to see which subsystems, tap one for its full detail.</div>
+        <div id="systemsGlance" class="glance-root"></div>
       </div>
     </div>
 
@@ -5562,107 +5529,77 @@
       return resp.json();
     }
 
-    // ── Machines Tab (Multi-Machine Session Pool §L2) ─────────────────
+    // ── Machines Tab — glance floors F10/F11 (topic 29836, Phase 3) + issue #1429 ──
+    // Rebuilt on the shared glance component: a plain headline over Online /
+    // Attention needed / Dispatcher / Safety-checks tiles (Layer 1); each drills into
+    // the machines or the named safety checks in plain words (Layer 2); each row opens
+    // the full record (Layer 3) where the raw guard posture used to sit on the front
+    // page. Nicknames are user-authored → they NEVER appear at Layer 1; the editable
+    // field lives in the machine record and commits only on Enter/blur with optimistic
+    // echo (#1429). The 15s poll HOLDS an open drill (F9) so a rename in progress is
+    // never clobbered; when the drill closes the next poll reloads server authority.
     let __machinesTimer = null;
     function startMachines() { loadMachines(); if (!__machinesTimer) __machinesTimer = setInterval(loadMachines, 15000); }
     function stopMachines() { if (__machinesTimer) { clearInterval(__machinesTimer); __machinesTimer = null; } }
-    function machineSpecLine(hw) {
-      if (!hw) return 'specs not reported yet';
-      const chip = (hw.cpuModel && hw.cpuModel !== 'unknown') ? hw.cpuModel : ((hw.platform || '') + (hw.arch ? ' ' + hw.arch : '')).trim();
-      const cores = hw.cpuCores ? hw.cpuCores + ' cores' : '';
-      const ram = hw.totalMemBytes ? Math.round(hw.totalMemBytes / 1073741824) + ' GB' : '';
-      return [chip, cores, ram].filter(Boolean).join(' · ') || 'specs not reported yet';
-    }
-    function machineBusyWord(m) {
-      if (m.loadAvg == null) return '';
-      if (m.loadAvg < 1) return 'idle';
-      if (m.loadAvg < 4) return 'working';
-      return 'busy';
-    }
-    function machineGuardsLine(m) {
-      // Guard posture (GUARD-POSTURE-ENDPOINT-SPEC §2.3): last-known summary
-      // with RECEIVER-side age. No posture ever received → honest "unknown",
-      // never "0 on / 0 off". Only problem classes get named; dark-default
-      // offs stay quiet (alarm-fatigue is how the next Mini stays off while
-      // displayed).
-      const p = m.guardPosture;
-      if (!p) return 'guards: unknown';
-      const problems = [];
-      if (p.offDeviant) problems.push(p.offDeviant + ' off that should be on');
-      if (p.offRuntimeDivergent) problems.push(p.offRuntimeDivergent + ' off despite settings');
-      if (p.onStale) problems.push(p.onStale + ' frozen');
-      if (p.missing) problems.push(p.missing + ' missing');
-      if (p.errored) problems.push(p.errored + ' erroring');
-      if (p.divergedPendingRestart) problems.push(p.divergedPendingRestart + ' awaiting restart');
-      const okPart = 'guards: ' + ((p.onConfirmed ?? 0) + (p.onUnverified ?? 0) + (p.onDryRun ?? 0)) + ' on' +
-        (p.onConfirmed ? ' (' + p.onConfirmed + ' confirmed)' : '');
-      let age = '';
-      if (m.guardPostureReceivedAt) {
-        const ms = Date.now() - Date.parse(m.guardPostureReceivedAt);
-        if (isFinite(ms) && ms >= 0) {
-          const mins = Math.round(ms / 60000);
-          age = mins < 2 ? 'just now' : mins < 90 ? 'as of ' + mins + 'm ago'
-            : mins < 2880 ? 'as of ' + Math.round(mins / 60) + 'h ago'
-            : 'as of ' + Math.round(mins / 1440) + 'd ago';
-        }
-      }
-      return [okPart, problems.length ? '⚠ ' + problems.join(', ') : '', age].filter(Boolean).join(' · ');
-    }
-    function renderMachineCard(m, routerHolder) {
-      const online = !!m.online;
-      const dot = !online ? 'off' : (m.clockSkewStatus === 'suspect-clock-removed' ? 'warn' : 'ok');
-      const statusWord = !online ? 'offline' : (m.clockSkewStatus === 'suspect-clock-removed' ? 'clock out of sync — paused for new conversations' : 'online');
-      const isRouter = !!(routerHolder && m.machineId === routerHolder);
-      const nick = m.nickname || m.machineId;
-      const busy = machineBusyWord(m);
-      const sessions = (m.activeSessionCount != null) ? (m.activeSessionCount + (m.maxSessions ? '/' + m.maxSessions : '') + ' conversation' + (m.activeSessionCount === 1 ? '' : 's')) : '';
-      const tail = [statusWord, busy, sessions].filter(Boolean).map(s => escapeHtml(s)).join(' · ');
-      return '<div class="machine-card">' +
-        '<div class="machine-head">' +
-          '<span class="machine-dot ' + dot + '" title="' + escapeHtml(statusWord) + '"></span>' +
-          '<input class="machine-nick" value="' + escapeHtml(nick) + '" data-mid="' + escapeHtml(m.machineId) + '" ' +
-            'onkeydown="if(event.key===\'Enter\'){this.blur();}" onblur="saveMachineNickname(this)" aria-label="machine nickname" />' +
-          (isRouter ? '<span class="machine-badge">dispatcher</span>' : '') +
-        '</div>' +
-        '<div class="machine-meta">' + escapeHtml(machineSpecLine(m.hardware)) + '</div>' +
-        '<div class="machine-meta">' + tail + '</div>' +
-        '<div class="machine-meta">' + escapeHtml(machineGuardsLine(m)) + '</div>' +
-      '</div>';
-    }
-    async function saveMachineNickname(input) {
-      const mid = input.getAttribute('data-mid');
-      const nickname = input.value.trim();
+
+    async function saveMachineNickname(machineId, nickname, input, prev) {
+      // Optimistic: the input already shows the typed value. PATCH the registry; on
+      // failure revert the optimistic echo and surface an honest inline note.
       try {
-        await apiFetch('/pool/machines/' + encodeURIComponent(mid), {
+        await apiFetch('/pool/machines/' + encodeURIComponent(machineId), {
           method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ nickname }),
         });
-        loadMachines();
+        if (input) { input.removeAttribute('data-rename-error'); input.removeAttribute('title'); }
       } catch (e) {
-        const hl = document.getElementById('machinesHeadline');
-        if (hl) hl.innerHTML = '<div class="ph-headline">Couldn\'t rename that machine: ' + escapeHtml(e.message) + '</div>';
+        if (input) {
+          if (prev != null) input.value = prev; // revert the optimistic echo
+          const msg = (e && e.message) ? e.message : 'rename failed';
+          input.setAttribute('data-rename-error', msg);
+          input.setAttribute('title', 'Rename failed — ' + msg);
+        }
       }
     }
+
     async function loadMachines() {
+      const glanceRoot = document.getElementById('machinesGlance');
       const stamp = document.getElementById('machinesStamp');
-      const list = document.getElementById('machinesList');
-      const headline = document.getElementById('machinesHeadline');
-      if (!list) return;
+      if (!glanceRoot) return;
+
+      const glance = await loadGlanceModule();
+      if (!glance) { glanceRoot.textContent = 'Loading the glance view failed — refresh to retry.'; return; }
+
+      let pool = null;
       try {
-        const data = await apiFetch('/pool');
-        if (stamp) stamp.textContent = new Date().toLocaleTimeString();
-        if (!data.enabled) {
-          if (headline) headline.innerHTML = '<div class="ph-headline">Running on a single machine right now — nothing to spread across yet.</div>';
-          list.innerHTML = '';
-          return;
-        }
-        const machines = data.machines || [];
-        const onlineCount = machines.filter(m => m.online).length;
-        if (headline) headline.innerHTML = '<div class="ph-headline">' + onlineCount + ' of ' + machines.length + ' machine' + (machines.length === 1 ? '' : 's') + ' online</div>';
-        const routerHolder = data.router && data.router.holder;
-        list.innerHTML = machines.length ? machines.map(m => renderMachineCard(m, routerHolder)).join('') : '<div class="machine-meta">No machines paired yet.</div>';
+        pool = await apiFetch('/pool');
       } catch (e) {
-        if (headline) headline.innerHTML = '<div class="ph-headline">Couldn\'t load machines: ' + escapeHtml(e.message) + '</div>';
+        glanceRoot.textContent = '';
+        const note = document.createElement('div');
+        note.className = 'glance-empty';
+        note.textContent = 'Could not load machines right now — refresh to retry.';
+        glanceRoot.appendChild(note);
+        return;
       }
+      if (stamp) stamp.textContent = new Date().toLocaleTimeString();
+
+      if (!pool.enabled) {
+        glanceRoot.textContent = '';
+        const note = document.createElement('div');
+        note.className = 'glance-empty';
+        note.textContent = 'Running on a single machine right now — nothing to spread across yet.';
+        glanceRoot.appendChild(note);
+        return;
+      }
+
+      // Named safety checks (GET /guards, this machine) enrich the "Safety checks"
+      // tile; a failure omits that tile — it never blocks the machines view.
+      let guards = null;
+      try { guards = await apiFetch('/guards'); }
+      catch { /* @silent-fallback-ok — guards only enrich the glance; on failure the Safety-checks tile is omitted and machines still render */ }
+
+      const spec = glance.machinesGlanceSpec(document, pool, guards, {
+        onRename: (id, nickname, input, prev) => saveMachineNickname(id, nickname, input, prev),
+      });
+      glance.renderGlance(document, glanceRoot, spec);
     }
 
     // ── Tokens Tab ──────────────────────────────────────────────────
@@ -6023,213 +5960,75 @@
       }
     }
 
+    // ── Routing Map Tab — glance floors F10/F11 (topic 29836, Phase 3) ──
+    // The nature-axis routing map rebuilt on the shared glance component. "Lane /
+    // nature / door" became plain words at the glance: a headline naming the primary
+    // model + backup, one tile per job group + a Job-types tile (Layer 1); each lane
+    // drills into its ordered fallback list of plain model names (Layer 2); each row
+    // opens the full door/model config (Layer 3). Data from /intelligence/routing/chains;
+    // 503 = no AI provider configured → an honest note, never a crash.
     async function loadRoutingMap() {
-      const chainsEl = document.getElementById('routingMapChainsBody');
-      const compsEl = document.getElementById('routingMapComponentsBody');
-      // Render one door+model position as a compact chip line.
-      const flags = (p) => {
-        const f = [];
-        if (p.doorClass === 'metered') f.push('metered' + (p.skippedInIncrementA ? ' · skipped now' : ''));
-        if (p.moneyGated) f.push('money-gated');
-        if (p.injectionSafe === false) f.push('unsafe for untrusted input');
-        if (p.claudeBanned) f.push('no-Claude');
-        return f.length ? ' <span style="color:var(--text-dim)">(' + f.map(escapeHtml).join(' · ') + ')</span>' : '';
-      };
-      const posLine = (p, i) => '<div style="padding:2px 0">' +
-        '<span style="color:var(--text-dim)">' + (i + 1) + '.</span> ' +
-        '<b>' + escapeHtml(p.door) + '</b> → ' + escapeHtml(p.modelId) + flags(p) + '</div>';
-      const th = (t, right) => '<th style="padding:6px 8px;' + (right ? 'text-align:right' : 'text-align:left') + '">' + t + '</th>';
-      const td = (v, right) => '<td style="padding:6px 8px;vertical-align:top;' + (right ? 'text-align:right' : '') + '">' + v + '</td>';
-      try {
-        const data = await apiFetch('/intelligence/routing/chains');
-        const chains = data.chains || [];
-        chainsEl.innerHTML =
-          '<div style="font-size:11px;color:var(--text-dim);margin-bottom:8px">Enforced default framework: <b>' +
-            escapeHtml(String(data.defaultFramework || '—')) + '</b> · injection signal: ' +
-            escapeHtml(String(data.injectionExposureSource || '—')) + '</div>' +
-          '<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:12px">' +
-          chains.map((c) =>
-            '<div style="border:1px solid var(--border);border-radius:6px;padding:10px">' +
-            '<div style="font-weight:600;margin-bottom:4px">' + escapeHtml(c.chain) + '</div>' +
-            (c.positions || []).map(posLine).join('') +
-            '</div>').join('') +
-          '</div>';
+      const glanceRoot = document.getElementById('routingMapGlance');
+      if (!glanceRoot) return;
 
-        const comps = (data.components || []).slice().sort((a, b) => {
-          // Mapped (has a chain) first, then by component name.
-          if (!!a.chain !== !!b.chain) return a.chain ? -1 : 1;
-          return String(a.component).localeCompare(String(b.component));
-        });
-        if (comps.length === 0) {
-          compsEl.innerHTML = '<div style="color:var(--text-dim)">No components mapped.</div>';
-          return;
-        }
-        const yn = (v) => v === true ? 'yes' : (v === false ? 'no' : '—');
-        compsEl.innerHTML =
-          '<table style="width:100%;border-collapse:collapse;font-size:12px;min-width:760px">' +
-          '<thead><tr style="color:var(--text-dim)">' +
-            th('Job-kind') + th('Category') + th('Lane') + th('Enforced now') +
-            th('Critical gate') + th('Injection exposure') + th('Fallback order') +
-          '</tr></thead><tbody>' +
-          comps.map((c) => {
-            const route = (c.route && c.route.length)
-              ? c.route.map(posLine).join('')
-              : '<span style="color:var(--text-dim)">legacy category routing (no nature lane)</span>';
-            const lane = c.chain
-              ? escapeHtml(c.chain) + ' <span style="color:var(--text-dim)">(' + escapeHtml(String(c.nature)) + ')</span>'
-              : '<span style="color:var(--text-dim)">—</span>';
-            // Prefer the richer FD5b exposure classification; fall back to the untrusted-input flag.
-            let exposure;
-            if (c.injectionExposure) {
-              const ch = c.injectionExposure.channels || {};
-              const chans = ['user', 'model', 'tool'].filter((k) => ch[k]);
-              exposure = c.injectionExposure.exposed
-                ? 'exposed' + (chans.length ? ' <span style="color:var(--text-dim)">(' + chans.join('/') + ')</span>' : '')
-                : 'not exposed' + (c.injectionExposure.reason ? ' <span style="color:var(--text-dim)">(' + escapeHtml(c.injectionExposure.reason) + ')</span>' : '');
-            } else if (c.untrustedInput === true) {
-              exposure = 'exposed';
-            } else if (c.untrustedInput === false) {
-              exposure = 'not exposed' + (c.untrustedInputReason ? ' <span style="color:var(--text-dim)">(' + escapeHtml(c.untrustedInputReason) + ')</span>' : '');
-            } else {
-              exposure = '—';
-            }
-            return '<tr style="border-top:1px solid var(--border)">' +
-              td('<b>' + escapeHtml(c.component) + '</b>') +
-              td(escapeHtml(String(c.category || '—'))) +
-              td(lane) +
-              td(escapeHtml(String(c.enforcedFramework || '—'))) +
-              td(c.criticalGate ? '<b>yes</b>' : 'no') +
-              td(exposure) +
-              td(route) +
-            '</tr>';
-          }).join('') +
-          '</tbody></table>';
+      const glance = await loadGlanceModule();
+      if (!glance) { glanceRoot.textContent = 'Loading the glance view failed — refresh to retry.'; return; }
+
+      let map = null;
+      try {
+        map = await apiFetch('/intelligence/routing/chains');
       } catch (err) {
         const m = err && err.message ? String(err.message) : String(err);
-        if (/503|unavailable|not initialized/i.test(m)) {
-          chainsEl.innerHTML = '<div style="color:var(--text-dim)">The routing map isn\'t available on this agent (no AI provider configured).</div>';
-        } else {
-          chainsEl.innerHTML = '<div style="color:var(--red)">Error: ' + escapeHtml(m) + '</div>';
-        }
-        compsEl.innerHTML = '';
+        glanceRoot.textContent = '';
+        const note = document.createElement('div');
+        note.className = 'glance-empty';
+        note.textContent = /503|unavailable|not initialized/i.test(m)
+          ? 'The routing map isn’t available on this agent (no AI provider configured).'
+          : 'Could not load the routing map right now — refresh to retry.';
+        glanceRoot.appendChild(note);
+        return;
       }
+
+      const spec = glance.routingMapGlanceSpec(document, map);
+      glance.renderGlance(document, glanceRoot, spec);
     }
 
-    // Routing Control Room — read-only spend/caps view (Increment A). Data from
-    // /routing-spend/summary + /routing-spend/caps. Honest $0 / not-live-yet labelling.
+    // ── Spend Tab — glance floors F10/F11 (topic 29836, Phase 3) ──
+    // The Routing Control Room read-only spend/caps view rebuilt on the shared glance
+    // component. "Metered / paid door / reflows" became plain words at the glance:
+    // "pay-per-use", a plain headline, and totals tiles (Layer 1); the per-model cost
+    // + usage rows and the paid-door caps drill down (Layer 2), full pricing/caps
+    // detail at Layer 3. Data from /routing-spend/summary + /routing-spend/caps;
+    // 503 = the dev-gated view is dark on the fleet → an honest note, never a crash.
     async function loadRoutingSpend() {
-      const headEl = document.getElementById('spendHeadlineBody');
-      const rowsEl = document.getElementById('spendRowsBody');
-      const capsEl = document.getElementById('spendCapsBody');
+      const glanceRoot = document.getElementById('spendGlance');
+      if (!glanceRoot) return;
       const grain = (document.getElementById('spendGrain') || {}).value || 'day';
-      const usd = (n) => '$' + (Number(n) || 0).toFixed(4);
-      const num = (n) => (Number(n) || 0).toLocaleString();
-      const th = (t, right) => '<th style="padding:6px 8px;' + (right ? 'text-align:right' : 'text-align:left') + '">' + t + '</th>';
-      const td = (v, right) => '<td style="padding:6px 8px;vertical-align:top;' + (right ? 'text-align:right' : '') + '">' + v + '</td>';
+
+      const glance = await loadGlanceModule();
+      if (!glance) { glanceRoot.textContent = 'Loading the glance view failed — refresh to retry.'; return; }
+
+      let summary = null;
+      let caps = null;
       try {
-        const [summary, caps] = await Promise.all([
+        [summary, caps] = await Promise.all([
           apiFetch('/routing-spend/summary?grain=' + encodeURIComponent(grain)),
           apiFetch('/routing-spend/caps'),
         ]);
-
-        // Headline totals
-        const t = summary.totals || {};
-        const unpriced = (Number(t.unpricedTokensIn) || 0) + (Number(t.unpricedTokensOut) || 0);
-        const stat = (label, val) => '<div style="min-width:120px"><div style="font-size:11px;color:var(--text-dim)">' + label + '</div><div style="font-size:18px;font-weight:600">' + val + '</div></div>';
-        headEl.innerHTML =
-          '<div style="display:flex;gap:20px;flex-wrap:wrap">' +
-            stat('Gross', usd(t.grossUsd)) +
-            stat('Net (of subsidy/credits)', usd(t.netUsd)) +
-            stat('Committed (cap-enforced)', usd(t.committedUsd)) +
-            (typeof t.amortizedSubscriptionUsd === 'number' ? stat('Subscriptions (amortized)', '~' + usd(t.amortizedSubscriptionUsd)) : '') +
-            stat('Tokens in', num(t.tokensIn)) +
-            stat('Tokens out', num(t.tokensOut)) +
-            (unpriced > 0 ? stat('Unpriced tokens', num(unpriced)) : '') +
-          '</div>' +
-          '<div style="font-size:11px;color:var(--text-dim);margin-top:10px;line-height:1.4">' +
-            escapeHtml(String(summary.note || '')) + '<br>' +
-            escapeHtml(String(summary.horizonNote || '')) +
-            (summary.providerGroundingNote ? '<br>' + escapeHtml(String(summary.providerGroundingNote)) : '') +
-            (summary.reportingBasis ? '<br>Basis: ' + escapeHtml(String(summary.reportingBasis.note || '')) : '') +
-          '</div>';
-
-        // Per door/model rows
-        const rows = summary.rows || [];
-        if (rows.length === 0) {
-          rowsEl.innerHTML = '<div style="color:var(--text-dim)">No internal-LLM usage recorded in this window yet.</div>';
-        } else {
-          rowsEl.innerHTML =
-            '<table style="width:100%;border-collapse:collapse;font-size:12px;min-width:720px">' +
-            '<thead><tr style="color:var(--text-dim)">' +
-              th('Door') + th('Model') + th('Class') + th('Tokens in', true) + th('Tokens out', true) +
-              th('Gross', true) + th('Net', true) + th('Price basis') +
-            '</tr></thead><tbody>' +
-            rows.map((r) => {
-              const cls = r.doorClass === 'metered'
-                ? 'metered' + (r.notLiveYet ? ' · not live' : '')
-                : escapeHtml(String(r.doorClass));
-              let basis;
-              if (r.priceBasis === 'subscription-zero') basis = '<span style="color:var(--text-dim)">subscription — not per-token billed</span>';
-              else if (r.priceBasis === 'no-matching-point') basis = '<span style="color:var(--red)">unpriced (no matching price)</span>';
-              else basis = escapeHtml(String(r.priceBasis)) + (r.priceStale ? ' <span style="color:var(--red)">(stale)</span>' : '');
-              const netCell = r.priceBasis === 'subscription-zero'
-                ? (typeof r.amortizedSubscriptionUsd === 'number'
-                    ? '<span title="' + escapeHtml(String(r.amortizationDerivation || '')) + '">~' + usd(r.amortizedSubscriptionUsd) + ' <span style="color:var(--text-dim);font-size:10px">amortized ⓘ</span></span>'
-                    : '<span style="color:var(--text-dim)">$0 (subscription)</span>')
-                : usd(r.netUsd);
-              return '<tr style="border-top:1px solid var(--border)">' +
-                td('<b>' + escapeHtml(String(r.door)) + '</b>') +
-                td(escapeHtml(String(r.modelId))) +
-                td(escapeHtml(cls)) +
-                td(num(r.tokensIn), true) +
-                td(num(r.tokensOut), true) +
-                td(usd(r.grossUsd), true) +
-                td(netCell, true) +
-                td(basis) +
-              '</tr>';
-            }).join('') +
-            '</tbody></table>' +
-            (function () {
-              // "Show the math": each door's amortization derivation, verbatim, once.
-              const der = {}; rows.forEach((r) => { if (r.amortizationDerivation) der[r.door] = r.amortizationDerivation; });
-              const lines = Object.values(der);
-              return lines.length
-                ? '<div style="font-size:11px;color:var(--text-dim);margin-top:8px;line-height:1.5"><b>Amortization math:</b><br>' + lines.map((l) => escapeHtml(String(l))).join('<br>') + '</div>'
-                : '';
-            })();
-        }
-
-        // Paid-door caps
-        const keys = caps.keys || [];
-        capsEl.innerHTML =
-          '<div style="font-size:11px;color:var(--text-dim);margin-bottom:8px">' + escapeHtml(String(caps.note || '')) + '</div>' +
-          '<table style="width:100%;border-collapse:collapse;font-size:12px;min-width:640px">' +
-          '<thead><tr style="color:var(--text-dim)">' +
-            th('Key') + th('Provider') + th('Door') + th('Daily cap', true) + th('Lifetime cap', true) +
-            th('Committed', true) + th('Status') +
-          '</tr></thead><tbody>' +
-          keys.map((k) =>
-            '<tr style="border-top:1px solid var(--border)">' +
-            td('<b>' + escapeHtml(String(k.keyRef)) + '</b>') +
-            td(escapeHtml(String(k.provider))) +
-            td(escapeHtml(String(k.door))) +
-            td(usd(k.dailyCapUsd), true) +
-            td(usd(k.lifetimeCapUsd), true) +
-            td(usd(k.committedDayUsd) + ' / ' + usd(k.committedLifetimeUsd), true) +
-            td('<span style="color:var(--text-dim)">' + escapeHtml(String(k.goLiveState)) + (k.frozen ? ' · frozen' : '') + '</span>') +
-            '</tr>').join('') +
-          '</tbody></table>' +
-          '<div style="font-size:11px;color:var(--text-dim);margin-top:8px">' + escapeHtml(String(caps.singleMachineNote || '')) + '</div>';
       } catch (err) {
         const m = err && err.message ? String(err.message) : String(err);
-        if (/503|not enabled|unavailable/i.test(m)) {
-          headEl.innerHTML = '<div style="color:var(--text-dim)">The spend view isn\'t enabled on this agent (it\'s a development-agent surface, dark on the fleet).</div>';
-        } else {
-          headEl.innerHTML = '<div style="color:var(--red)">Error: ' + escapeHtml(m) + '</div>';
-        }
-        rowsEl.innerHTML = '';
-        capsEl.innerHTML = '';
+        glanceRoot.textContent = '';
+        const note = document.createElement('div');
+        note.className = 'glance-empty';
+        note.textContent = /503|not enabled|unavailable/i.test(m)
+          ? 'The spend view isn’t enabled on this agent (it’s a development-agent surface, dark on the fleet).'
+          : 'Could not load spend right now — refresh to retry.';
+        glanceRoot.appendChild(note);
+        return;
       }
+
+      const spec = glance.spendGlanceSpec(document, summary, caps);
+      glance.renderGlance(document, glanceRoot, spec);
     }
 
     async function loadResources() {
@@ -9281,313 +9080,29 @@
       }
     }
 
-    // ── Systems Tab ──────────────────────────────────────────────
-    let systemsData = null;
-
+    // ── Health Tab (was Systems) — glance floors F10/F11 (topic 29836, Phase 3) ──
+    // The 390-word subsystem prose became a plain headline over Subsystems / Need
+    // attention / Recent events tiles (Layer 1); each subsystem drills into its full
+    // description, processes, and metrics (Layer 3). All /systems/status data is
+    // preserved — it moved one or two clicks down instead of dumping on the front page.
     async function loadSystems() {
+      const glanceRoot = document.getElementById('systemsGlance');
+      if (!glanceRoot) return;
+      const glance = await loadGlanceModule();
+      if (!glance) { glanceRoot.textContent = 'Loading the glance view failed — refresh to retry.'; return; }
+      let systems = null;
       try {
-        systemsData = await apiFetch('/systems/status');
-        showSystemsOverview();
-        renderSystemsOverview();
+        systems = await apiFetch('/systems/status');
       } catch (e) {
-        document.getElementById('systemsBanner').innerHTML =
-          '<div style="padding:20px;color:var(--red);text-align:center">Failed to load systems status</div>';
+        glanceRoot.textContent = '';
+        const note = document.createElement('div');
+        note.className = 'glance-empty';
+        note.textContent = 'Could not load the health view right now — refresh to retry.';
+        glanceRoot.appendChild(note);
+        return;
       }
-    }
-
-    function renderSystemsOverview() {
-      if (!systemsData) return;
-      const { uptime, health, healthSummary, activeCapabilities, issues, recentEvents } = systemsData;
-      const uptimeStr = formatUptimeClient(uptime);
-
-      // Health Banner
-      const bannerClass = health === 'healthy' ? 'healthy' : health === 'error' ? 'error' : 'degraded';
-      const bannerIcon = health === 'healthy' ? '&#10003;' : '&#9888;';
-      document.getElementById('systemsBanner').innerHTML = `
-        <div class="health-banner ${bannerClass}">
-          <span class="health-icon">${bannerIcon}</span>
-          <div class="health-text">
-            <div class="health-title">${esc(healthSummary)}</div>
-            <div class="health-meta">Uptime: ${esc(uptimeStr)}  &middot;  ${activeCapabilities.length} capabilities active${issues.length > 0 ? '  &middot;  ' + issues.length + ' issue' + (issues.length > 1 ? 's' : '') : ''}</div>
-          </div>
-        </div>`;
-
-      // Issues (only if any)
-      const issuesEl = document.getElementById('systemsIssues');
-      if (issues.length > 0) {
-        issuesEl.innerHTML = '<div class="issues-panel">' + issues.map(iss => {
-          const cls = iss.severity === 'warning' ? ' warning' : '';
-          const ic = iss.severity === 'warning' ? '&#9888;' : '&#10060;';
-          return `<div class="issue-card${cls}">
-            <span class="issue-card-icon">${ic}</span>
-            <div class="issue-card-content">
-              <div class="issue-card-label">${esc(iss.label)}</div>
-              <div class="issue-card-desc">${esc(iss.description)}</div>
-            </div>
-          </div>`;
-        }).join('') + '</div>';
-      } else {
-        issuesEl.innerHTML = '';
-      }
-
-      // Card Grid
-      const capsEl = document.getElementById('systemsCapabilities');
-      if (activeCapabilities.length > 0) {
-        const cards = activeCapabilities.map(cap => {
-          const dotClass = cap.status === 'error' ? 'error' : 'active';
-          const statusClass = cap.status === 'error' ? ' error' : '';
-          const previewStats = buildPreviewStats(cap.stats || {});
-          return `<div class="cap-card${statusClass}" onclick="showCapabilityDetail('${esc(cap.id)}')">
-            <div class="cap-card-top">
-              <span class="cap-dot ${dotClass}"></span>
-              <span class="cap-card-name">${esc(cap.label)}</span>
-              <span class="cap-card-arrow">&#9654;</span>
-            </div>
-            <div class="cap-card-desc">${esc(cap.description)}</div>
-            ${previewStats ? '<div class="cap-card-stats">' + previewStats + '</div>' : ''}
-            <div class="cap-card-metric">${esc(cap.metric)}</div>
-          </div>`;
-        }).join('');
-        capsEl.innerHTML = `<div class="cap-section-title">Active Subsystems</div><div class="cap-grid">${cards}</div>`;
-      } else {
-        capsEl.innerHTML = '';
-      }
-
-      // Events
-      const eventsEl = document.getElementById('systemsEvents');
-      if (recentEvents.length > 0) {
-        const rows = recentEvents.map(e => {
-          const time = e.timestamp ? new Date(e.timestamp).toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '';
-          return `<div class="systems-event-row"><span class="systems-event-time">${esc(time)}</span><span class="systems-event-text">${esc(e.narrative || e.subsystem || '')}</span></div>`;
-        }).join('');
-        eventsEl.innerHTML = `<div class="events-disclosure" id="eventsDisclosure">
-          <button class="events-disclosure-toggle" onclick="document.getElementById('eventsDisclosure').classList.toggle('expanded')">
-            <span class="events-disclosure-arrow">&#9654;</span> Recent Events (${recentEvents.length})
-          </button>
-          <div class="events-disclosure-body">${rows}</div></div>`;
-      } else {
-        eventsEl.innerHTML = '';
-      }
-    }
-
-    function buildPreviewStats(stats) {
-      if (!stats || typeof stats !== 'object') return '';
-      const map = {
-        recoveries: 'Recovered', interventions: 'Auto-fixed', activeCases: 'Active',
-        coherencePassed: 'Checks OK', coherenceFailed: 'Issues', memoryPercent: 'Memory',
-        enabledJobs: 'Jobs', activeJobSessions: 'Running', queueLength: 'Queued',
-        weeklyUsage: 'Weekly', fiveHourRate: '5h Rate',
-        topicMappings: 'Topics', totalMessages: 'Messages',
-        proposals: 'Proposals', gaps: 'Gaps', learningsApplied: 'Applied',
-      };
-      const chips = [];
-      for (const [key, label] of Object.entries(map)) {
-        if (stats[key] != null && stats[key] !== 0 && stats[key] !== false) {
-          const suf = ['weeklyUsage','fiveHourRate','memoryPercent'].includes(key) ? '%' : '';
-          chips.push(`<span class="cap-stat"><span class="cap-stat-value">${esc(String(stats[key]))}${suf}</span>${esc(label)}</span>`);
-        }
-        if (chips.length >= 3) break;
-      }
-      return chips.join('');
-    }
-
-    function showCapabilityDetail(capId) {
-      if (!systemsData) return;
-      const cap = systemsData.activeCapabilities.find(c => c.id === capId);
-      if (!cap) return;
-      document.getElementById('systemsOverview').style.display = 'none';
-      document.getElementById('systemsDetailView').classList.add('active');
-      const content = document.getElementById('systemsDetailContent');
-
-      const statCards = buildStatCards(cap.stats || {}, capId);
-      const processRows = (cap.processes || []).map(p => {
-        const dotColor = p.status === 'running' ? 'var(--accent)' : 'var(--red)';
-        return `<div class="cap-process-row">
-          <span class="cap-process-dot" style="background:${dotColor}"></span>
-          <span class="cap-process-name">${esc(p.name)}</span>
-          <span class="cap-process-status">${esc(p.status === 'running' ? 'Running' : 'Error')}</span>
-        </div>`;
-      }).join('');
-
-      const lastAct = cap.lastActivity
-        ? '<div class="cap-last-activity">Last activity: ' + esc(timeAgo(cap.lastActivity)) + '</div>' : '';
-
-      content.innerHTML = `
-        <div class="cap-detail-header">
-          <div class="cap-detail-title">
-            <span class="cap-dot ${cap.status === 'error' ? 'error' : 'active'}"></span>
-            <h3>${esc(cap.label)}</h3>
-          </div>
-          <div class="cap-detail-description">${esc(cap.description)}</div>
-          ${lastAct}
-        </div>
-        ${statCards ? '<div class="cap-detail-section"><div class="cap-detail-section-title">Metrics</div><div class="cap-stats-grid">' + statCards + '</div><div id="capContentBrowser"></div></div>' : ''}
-        <div class="cap-detail-section">
-          <div class="cap-detail-section-title">Components (${(cap.processes || []).length})</div>
-          <div class="cap-process-list">${processRows}</div>
-        </div>
-        <div class="cap-detail-section">
-          <div class="cap-detail-section-title">Status</div>
-          <div style="font-size:13px;color:var(--accent);font-weight:500;padding:8px 0">${esc(cap.metric)}</div>
-        </div>`;
-    }
-
-    // Map stat keys to browsable content endpoints
-    const BROWSABLE_STATS = {
-      // Evolution
-      learnings: { endpoint: '/evolution/learnings', label: 'Learnings', renderer: 'renderLearnings' },
-      proposals: { endpoint: '/evolution/proposals', label: 'Proposals', renderer: 'renderProposals' },
-      gaps: { endpoint: '/evolution/gaps', label: 'Capability Gaps', renderer: 'renderGaps' },
-      actions: { endpoint: '/evolution/actions', label: 'Actions', renderer: 'renderActions' },
-      overdueActions: { endpoint: '/evolution/actions/overdue', label: 'Overdue Actions', renderer: 'renderActions' },
-      // Health
-      coherenceChecks: { endpoint: '/health/coherence', label: 'Coherence Report', renderer: 'renderCoherence' },
-      coherencePassed: { endpoint: '/health/coherence', label: 'Coherence Report', renderer: 'renderCoherence' },
-      coherenceFailed: { endpoint: '/health/coherence', label: 'Coherence Report', renderer: 'renderCoherence' },
-      // Recovery
-      totalTriages: { endpoint: '/triage/history?limit=20', label: 'Triage History', renderer: 'renderTriageHistory' },
-      interventions: { endpoint: '/watchdog/status', label: 'Watchdog Status', renderer: 'renderWatchdog' },
-      recoveries: { endpoint: '/watchdog/status', label: 'Watchdog Status', renderer: 'renderWatchdog' },
-      // Jobs
-      totalJobs: { endpoint: '/jobs', label: 'Jobs', renderer: 'renderJobs' },
-      enabledJobs: { endpoint: '/jobs', label: 'Jobs', renderer: 'renderJobs' },
-      // Telegram
-      totalMessages: { endpoint: '/telegram/log-stats', label: 'Message Stats', renderer: 'renderTelegramStats' },
-      topicMappings: { endpoint: '/telegram/log-stats', label: 'Message Stats', renderer: 'renderTelegramStats' },
-    };
-
-    function buildStatCards(stats, capId) {
-      if (!stats || typeof stats !== 'object') return '';
-      const map = {
-        interventions: 'Auto-fixes', recoveries: 'Recovered', sessionDeaths: 'Crashes',
-        llmOverrides: 'AI Decisions', activeCases: 'Active Issues', totalTriages: 'Investigated',
-        cooldowns: 'Cooldowns',
-        coherenceChecks: 'Consistency Checks', coherencePassed: 'Passed', coherenceFailed: 'Issues Found', coherenceCorrected: 'Auto-corrected',
-        memoryPercent: 'Memory %', memoryFreeGB: 'Free GB', memoryTotalGB: 'Total GB',
-        trackedProcesses: 'Processes', orphanProcesses: 'Cleanup Needed', totalMemoryMB: 'Memory MB',
-        totalJobs: 'Total Jobs', enabledJobs: 'Enabled', queueLength: 'Queued', activeJobSessions: 'Running',
-        weeklyUsage: 'Weekly %', fiveHourRate: '5h Rate %',
-        topicMappings: 'Topics', pendingStalls: 'Needs Attention', totalMessages: 'Messages',
-        proposals: 'Proposals', learnings: 'Learnings', learningsApplied: 'Applied',
-        gaps: 'Gaps', actions: 'Actions', overdueActions: 'Overdue',
-      };
-      const cards = [];
-      for (const [key, label] of Object.entries(map)) {
-        if (stats[key] != null && typeof stats[key] === 'number') {
-          const browsable = BROWSABLE_STATS[key];
-          const clickAttr = browsable ? ` onclick="browseStatContent('${key}')" style="cursor:pointer"` : '';
-          const browseHint = browsable ? '<div style="font-size:9px;color:var(--accent);margin-top:2px">click to view</div>' : '';
-          cards.push(`<div class="cap-stat-card"${clickAttr}><div class="cap-stat-card-value">${stats[key]}</div><div class="cap-stat-card-label">${esc(label)}</div>${browseHint}</div>`);
-        }
-      }
-      return cards.join('');
-    }
-
-    async function browseStatContent(statKey) {
-      const info = BROWSABLE_STATS[statKey];
-      if (!info) return;
-      const panel = document.getElementById('capContentBrowser');
-      if (!panel) return;
-      panel.innerHTML = '<div style="padding:12px;color:var(--text-dim);font-size:12px">Loading ' + esc(info.label) + '...</div>';
-      try {
-        const data = await apiFetch(info.endpoint);
-        panel.innerHTML = '<div class="cap-content-panel">' +
-          '<div class="cap-content-header"><span>' + esc(info.label) + '</span><button onclick="document.getElementById(\'capContentBrowser\').innerHTML=\'\'" style="border:none;background:none;color:var(--text-dim);cursor:pointer;font-size:14px" title="Close" aria-label="Close">&times;</button></div>' +
-          '<div class="cap-content-body">' + renderBrowsableContent(info.renderer, data) + '</div></div>';
-      } catch (e) {
-        panel.innerHTML = '<div style="padding:12px;color:var(--red);font-size:12px">Failed to load: ' + esc(e.message) + '</div>';
-      }
-    }
-
-    function renderBrowsableContent(renderer, data) {
-      switch (renderer) {
-        case 'renderLearnings': {
-          const items = data.learnings || data || [];
-          if (!Array.isArray(items) || items.length === 0) return '<div class="cap-content-empty">No learnings recorded</div>';
-          return items.map(l => `<div class="cap-content-item">
-            <div class="cap-content-item-title">${esc(l.title || l.insight || l.id || 'Untitled')}</div>
-            ${l.description || l.context ? '<div class="cap-content-item-body">' + esc(l.description || l.context || '') + '</div>' : ''}
-            ${l.category ? '<span class="cap-content-tag">' + esc(l.category) + '</span>' : ''}
-            ${l.applied ? '<span class="cap-content-tag applied">Applied</span>' : ''}
-            ${l.createdAt ? '<div class="cap-content-item-time">' + esc(timeAgo(l.createdAt)) + '</div>' : ''}
-          </div>`).join('');
-        }
-        case 'renderProposals': {
-          const items = data.proposals || data || [];
-          if (!Array.isArray(items) || items.length === 0) return '<div class="cap-content-empty">No proposals</div>';
-          return items.map(p => `<div class="cap-content-item">
-            <div class="cap-content-item-title">${esc(p.title || p.id || 'Untitled')}</div>
-            ${p.description ? '<div class="cap-content-item-body">' + esc(p.description) + '</div>' : ''}
-            ${p.status ? '<span class="cap-content-tag">' + esc(p.status) + '</span>' : ''}
-            ${p.type ? '<span class="cap-content-tag">' + esc(p.type) + '</span>' : ''}
-          </div>`).join('');
-        }
-        case 'renderGaps': {
-          const items = data.gaps || data || [];
-          if (!Array.isArray(items) || items.length === 0) return '<div class="cap-content-empty">No gaps detected</div>';
-          return items.map(g => `<div class="cap-content-item">
-            <div class="cap-content-item-title">${esc(g.title || g.capability || g.id || 'Untitled')}</div>
-            ${g.description ? '<div class="cap-content-item-body">' + esc(g.description) + '</div>' : ''}
-            ${g.severity ? '<span class="cap-content-tag">' + esc(g.severity) + '</span>' : ''}
-          </div>`).join('');
-        }
-        case 'renderActions': {
-          const items = data.actions || data || [];
-          if (!Array.isArray(items) || items.length === 0) return '<div class="cap-content-empty">No actions</div>';
-          return items.map(a => `<div class="cap-content-item">
-            <div class="cap-content-item-title">${esc(a.title || a.action || a.id || 'Untitled')}</div>
-            ${a.status ? '<span class="cap-content-tag">' + esc(a.status) + '</span>' : ''}
-            ${a.dueAt ? '<div class="cap-content-item-time">Due: ' + esc(timeAgo(a.dueAt)) + '</div>' : ''}
-          </div>`).join('');
-        }
-        case 'renderCoherence': {
-          const report = data.lastReport || data;
-          if (!report || !report.checks) return '<div class="cap-content-empty">No coherence data</div>';
-          return report.checks.map(c => `<div class="cap-content-item" style="border-left:3px solid ${c.passed ? 'var(--accent)' : 'var(--red)'}">
-            <div class="cap-content-item-title">${c.passed ? '&check;' : '&cross;'} ${esc(c.name)}</div>
-            <div class="cap-content-item-body">${esc(c.message)}</div>
-          </div>`).join('');
-        }
-        case 'renderTriageHistory': {
-          const items = data.history || data || [];
-          if (!Array.isArray(items) || items.length === 0) return '<div class="cap-content-empty">No triage history</div>';
-          return items.map(t => `<div class="cap-content-item">
-            <div class="cap-content-item-title">Topic ${t.topicId} — ${esc(t.sessionName || 'unknown')}</div>
-            <div class="cap-content-item-body">${t.result ? esc(JSON.stringify(t.result.actionsTaken || t.result, null, 0).substring(0, 200)) : ''}</div>
-            ${t.timestamp ? '<div class="cap-content-item-time">' + esc(timeAgo(t.timestamp)) + '</div>' : ''}
-          </div>`).join('');
-        }
-        case 'renderWatchdog': {
-          const hist = data.interventionHistory || [];
-          if (hist.length === 0) return '<div class="cap-content-empty">No interventions recorded</div>';
-          return hist.map(h => `<div class="cap-content-item">
-            <div class="cap-content-item-title">PID ${h.stuckPid || '?'} — ${esc(h.level || h.outcome || 'intervention')}</div>
-            ${h.outcome ? '<span class="cap-content-tag">' + esc(h.outcome) + '</span>' : ''}
-            ${h.timestamp ? '<div class="cap-content-item-time">' + esc(timeAgo(h.timestamp)) + '</div>' : ''}
-          </div>`).join('');
-        }
-        case 'renderJobs': {
-          const jobs = data.jobs || data || [];
-          if (!Array.isArray(jobs) || jobs.length === 0) return '<div class="cap-content-empty">No jobs</div>';
-          return jobs.slice(0, 20).map(j => `<div class="cap-content-item">
-            <div class="cap-content-item-title">${esc(j.slug || j.name || 'unnamed')}</div>
-            <div class="cap-content-item-body">${esc(j.cron || '')} ${j.enabled === false ? '(disabled)' : ''}</div>
-          </div>`).join('');
-        }
-        case 'renderTelegramStats': {
-          return `<div class="cap-content-item">
-            <div class="cap-content-item-title">Message Log</div>
-            <div class="cap-content-item-body">Total messages: ${data.totalMessages || '?'}<br>Log size: ${data.logSizeBytes ? Math.round(data.logSizeBytes / 1024) + ' KB' : '?'}</div>
-          </div>`;
-        }
-        default:
-          return '<div class="cap-content-empty">No viewer for this content</div>';
-      }
-    }
-
-    function showSystemsOverview() {
-      document.getElementById('systemsOverview').style.display = '';
-      document.getElementById('systemsDetailView').classList.remove('active');
+      const spec = glance.healthGlanceSpec(document, systems);
+      glance.renderGlance(document, glanceRoot, spec);
     }
 
     function timeAgo(isoStr) {

--- a/docs/specs/dashboard-ux-standard.md
+++ b/docs/specs/dashboard-ux-standard.md
@@ -276,10 +276,10 @@ order for exactly this reason.
 | Process Health | 101 | ✅ plain | ⚠️ detail drawer only | grandfathered → Phase 4 |
 | Preferences | 120 | ✅ plain, first person | ✅ adequate | grandfathered → Phase 4 |
 | Threadline | 156 | ⚠️ over budget | ✅ adequate | grandfathered → Phase 4 |
-| Machines | ~200 | ⚠️ guards line is insider-speak | ❌ guards counts not clickable | grandfathered → Phase 3 |
-| Health | 390 | ⚠️ subsystem prose | ⚠️ expanders only | grandfathered → Phase 3 |
-| Spend | 400 | ⚠️ jargon ("paid door") | ⚠️ no per-row detail | grandfathered → Phase 3 |
-| Routing Map | (dense) | ⚠️ jargon ("lane", "door") | ❌ flat map, no drill | grandfathered → Phase 3 |
+| Machines | ~200 → **glance** | ✅ **on the floor** | ✅ **on the floor** | **on the floor (rebuilt Phase 3 — Online / Attention needed / Dispatcher / Safety-checks tiles; the insider guards line became named checks with plain explanations at Layer 2/3; folds issue #1429 nickname-edit + F9 hold)** |
+| Health | 390 → **glance** | ✅ **on the floor** | ✅ **on the floor** | **on the floor (rebuilt Phase 3 — Subsystems / Need attention / Recent events tiles; the 390-word subsystem prose moved to the Layer-3 records)** |
+| Spend | 400 → **glance** | ✅ **on the floor** | ✅ **on the floor** | **on the floor (rebuilt Phase 3 — "metered / paid door / reflows" became plain "pay-per-use" at the glance; per-model math + caps at Layer 2/3)** |
+| Routing Map | (dense) → **glance** | ✅ **on the floor** | ✅ **on the floor** | **on the floor (rebuilt Phase 3 — "lane / nature / door" became plain per-lane tiles + a headline naming the primary model + backup; ordered door+model lists + full config at Layer 2/3)** |
 | Blockers | 7,035 → **glance** | ✅ **on the floor** | ✅ **on the floor** | **on the floor (rebuilt Phase 2 — headline + Truly stuck / Being worked / Resolved tiles; the raw table moved to Layer 3)** |
 
 *(Files, Send Content, Evidence, PR Pipeline, Projects, Initiatives, Integrated-Being,
@@ -436,7 +436,11 @@ Phase 1** and nothing more:
 2. **Phase 2 (SHIPPED) — the two worst offenders.** Commitments' full rebuild (folding
    issue #1435) + Blockers, rebuilt on the template; both left the grandfather list
    (ceiling 25 → 24) and the subscriptions optimistic-cancel fix (issue #1428) rode along.
-3. **Phase 3 — the jargon belt.** Machines, Health, Spend, Routing Map. <!-- tracked: topic-29836 -->
+3. **Phase 3 (SHIPPED) — the jargon belt.** Machines, Health, Spend, Routing Map,
+   rebuilt on the template; all four left the grandfather list (ceiling 24 → 20) and
+   issue #1429 (Machines nickname commit-on-input + focus-steal) rode along, fixed by
+   committing the nickname only on Enter/blur with an optimistic echo and the F9
+   interaction-hold across the poll.
 4. **Phase 4 — the sweep.** Every remaining grandfathered view brought to conformance; each
    leaves the grandfather list as it lands. <!-- tracked: topic-29836 -->
 

--- a/tests/e2e/glance-jargon-belt-lifecycle.test.ts
+++ b/tests/e2e/glance-jargon-belt-lifecycle.test.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E lifecycle (Tier 3) — the Phase-3 jargon-belt tabs are ALIVE (Dashboard UX
+ * Standard F10/F11, topic 29836 Phase 3). The feature-is-alive proof: are Machines,
+ * Health, Spend, and Routing Map genuinely wired end-to-end, or green-on-units but
+ * dark in production?
+ *
+ * Boots a REAL Express server with the production createRoutes() and asserts, per tab:
+ *   - the route is reachable (200 for the always-on Machines/Health; the documented
+ *     503 dark behavior for the dev-/provider-gated Routing/Spend),
+ *   - the shipped glance renders end-to-end from the live response (no XSS survives),
+ *   - the shipped component file dashboard/glance.js exports each tab's builder.
+ */
+// @ts-nocheck — the glance module is browser-native ESM.
+import { describe, it, expect, afterEach, afterAll } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { AddressInfo } from 'node:net';
+import { JSDOM } from 'jsdom';
+import { createRoutes } from '../../src/server/routes.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  machinesGlanceSpec, healthGlanceSpec, spendGlanceSpec, routingMapGlanceSpec,
+  buildSpendGlance, renderGlance, validateGlanceSpec,
+} from '../../dashboard/glance.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+interface TestServer { url: string; close: () => Promise<void>; }
+function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+function bootApp(ctx: any): Promise<TestServer> {
+  const app = express();
+  app.use(express.json());
+  app.use(createRoutes(ctx));
+  return listen(app);
+}
+function render(specFn: (doc: Document) => any) {
+  const dom = new JSDOM('<!doctype html><body><div id="root"></div></body>');
+  const doc = dom.window.document;
+  if (!(dom.window as any).CSS) (dom.window as any).CSS = { escape: (s: string) => s.replace(/["\\\]]/g, '\\$&') };
+  (globalThis as any).CSS = (dom.window as any).CSS;
+  const root = doc.getElementById('root')!;
+  return { dom, doc, root, handle: renderGlance(doc, root, specFn(doc)) };
+}
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'glance-p3-e2e-'));
+afterAll(() => { try { SafeFsExecutor.safeRmSync(TMP, { recursive: true, force: true, operation: 'tests/e2e/glance-jargon-belt-lifecycle.test.ts:cleanup' }); } catch { /* @silent-fallback-ok — best-effort tmp cleanup */ } });
+const BASE = { config: { authToken: 't', port: 0, stateDir: TMP }, startTime: new Date() };
+
+describe('Jargon-belt glance tabs — E2E feature-alive', () => {
+  let server: TestServer;
+  afterEach(async () => { await server?.close(); });
+
+  it('Machines: /pool 200, the glance renders end-to-end, an XSS nickname is inert', async () => {
+    const machines = [
+      { machineId: 'm_1', nickname: 'Laptop', online: true, clockSkewStatus: 'ok', activeSessionCount: 1, maxSessions: 6,
+        hardware: { cpuModel: 'Apple M2', cpuCores: 8, totalMemBytes: 17179869184 }, guardPosture: { onConfirmed: 16 } },
+      { machineId: 'm_2', nickname: '<img src=x onerror=alert(1)> Mini', online: true, clockSkewStatus: 'ok' },
+    ];
+    server = await bootApp({ ...BASE, machinePoolRegistry: { getCapacities: () => machines } });
+    const res = await fetch(server.url + '/pool');
+    expect(res.status).toBe(200); // alive, not 503
+    const pool = await res.json();
+
+    const { dom, handle } = render((doc) => machinesGlanceSpec(doc, pool, null, {}));
+    expect(validateGlanceSpec(handle.spec).ok).toBe(true);
+    expect(handle.headline.textContent).toMatch(/machines online|online and healthy/);
+    // Drill "online" and confirm the XSS payload rendered inert.
+    const onlineBtn = handle.tiles.find((b: any) => b.getAttribute('data-glance-tile') === 'online');
+    onlineBtn.dispatchEvent(new (dom.window as any).Event('click'));
+    expect(handle.drilldown.querySelector('img')).toBeNull();
+    expect(handle.drilldown.querySelector('script')).toBeNull();
+    expect(handle.drilldown.textContent).toContain('onerror'); // literal text, harmless
+  });
+
+  it('Health: /systems/status 200, the full glance renders end-to-end from live subsystems', async () => {
+    server = await bootApp({ ...BASE, watchdog: {}, triageNurse: {}, scheduler: {}, commitmentTracker: { getActive: () => [] } });
+    const res = await fetch(server.url + '/systems/status');
+    expect(res.status).toBe(200); // always alive
+    const systems = await res.json();
+
+    const { handle } = render((doc) => healthGlanceSpec(doc, systems));
+    expect(validateGlanceSpec(handle.spec).ok).toBe(true);
+    expect(handle.tiles.map((t: any) => t.getAttribute('data-glance-tile'))).toEqual(['subsystems', 'attention', 'events']);
+  });
+
+  it('Routing Map: /intelligence/routing/chains 503 dark → the builder still makes a friendly glance', async () => {
+    server = await bootApp({ ...BASE }); // no LLM provider → dark
+    const res = await fetch(server.url + '/intelligence/routing/chains');
+    expect(res.status).toBe(503); // documented dark behavior — the route is gated
+    // The empty-map glance the component builds is honest and conforms.
+    const { handle } = render((doc) => routingMapGlanceSpec(doc, { chains: [], components: [] }));
+    expect(validateGlanceSpec(handle.spec).ok).toBe(true);
+    expect(handle.headline.textContent!.toLowerCase()).toContain('no background ai routing');
+  });
+
+  it('Spend: /routing-spend/summary 503 dark → the builder still makes a friendly glance', async () => {
+    server = await bootApp({ ...BASE }); // dev-gated dark on the fleet
+    const res = await fetch(server.url + '/routing-spend/summary?grain=day');
+    expect(res.status).toBe(503);
+    const glance = buildSpendGlance({ totals: {}, rows: [] }, { keys: [] });
+    expect(validateGlanceSpec(glance).ok).toBe(true);
+    const { handle } = render((doc) => spendGlanceSpec(doc, { totals: {}, rows: [] }, { keys: [] }));
+    expect(handle.headline.textContent!.toLowerCase()).toContain('nothing is being billed');
+  });
+
+  it('the shipped component file dashboard/glance.js exports every jargon-belt builder', () => {
+    const file = path.resolve(__dirname, '..', '..', 'dashboard', 'glance.js');
+    const src = fs.readFileSync(file, 'utf-8');
+    for (const sym of [
+      'export function buildMachinesGlance', 'export function machinesGlanceSpec',
+      'export function buildHealthGlance', 'export function healthGlanceSpec',
+      'export function buildSpendGlance', 'export function spendGlanceSpec',
+      'export function buildRoutingMapGlance', 'export function routingMapGlanceSpec',
+    ]) {
+      expect(src, `${sym} must ship with the package`).toContain(sym);
+    }
+  });
+});

--- a/tests/integration/glance-jargon-belt-tabs.test.ts
+++ b/tests/integration/glance-jargon-belt-tabs.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Integration (Tier 2) — the Phase-3 jargon-belt tabs (Machines, Health, Spend,
+ * Routing Map) against the REAL HTTP routes (Dashboard UX Standard F10/F11, topic
+ * 29836 Phase 3).
+ *
+ * Boots a real Express server with the production createRoutes() and drives each
+ * SHIPPED glance builder + renderGlance against the LIVE route response:
+ *   - Machines: GET /pool (feature ON via a seeded pool registry, and dark → enabled:false)
+ *   - Health:   GET /systems/status (always 200; live subsystems)
+ *   - Routing:  GET /intelligence/routing/chains (dark → 503) + the builder over the
+ *               REAL buildNatureRoutingMap() shape the route emits
+ *   - Spend:    GET /routing-spend/summary (dark → 503) + the builder over a
+ *               representative SpendSummary shape
+ * asserting each glance renders, conforms to F10, and every non-empty tile drills
+ * into the real filtered rows down to the Layer-3 record.
+ */
+// @ts-nocheck — the glance module is browser-native ESM.
+import { describe, it, expect, afterEach, afterAll } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import { JSDOM } from 'jsdom';
+import { createRoutes } from '../../src/server/routes.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { buildNatureRoutingMap } from '../../src/core/natureRoutingMap.js';
+import {
+  machinesGlanceSpec, buildMachinesGlance,
+  healthGlanceSpec, buildHealthGlance, healthPopulation,
+  spendGlanceSpec, buildSpendGlance,
+  routingMapGlanceSpec, buildRoutingMapGlance,
+  renderGlance, validateGlanceSpec,
+} from '../../dashboard/glance.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+function bootApp(ctx: any): Promise<TestServer> {
+  const app = express();
+  app.use(express.json());
+  app.use(createRoutes(ctx));
+  return listen(app);
+}
+function jsdomRoot() {
+  const dom = new JSDOM('<!doctype html><body><div id="root"></div></body>');
+  const doc = dom.window.document;
+  if (!(dom.window as any).CSS) (dom.window as any).CSS = { escape: (s: string) => s.replace(/["\\\]]/g, '\\$&') };
+  (globalThis as any).CSS = (dom.window as any).CSS;
+  return { dom, doc, root: doc.getElementById('root')! };
+}
+function walk(handle: any, dom: JSDOM): number {
+  let real = 0;
+  for (const btn of handle.tiles) {
+    btn.dispatchEvent(new (dom.window as any).Event('click'));
+    expect(handle.drilldown.hidden).toBe(false);
+    if (handle.drilldown.querySelector('.glance-list-row')) real++;
+    btn.dispatchEvent(new (dom.window as any).Event('click'));
+  }
+  return real;
+}
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'glance-p3-int-'));
+afterAll(() => { try { SafeFsExecutor.safeRmSync(TMP, { recursive: true, force: true, operation: 'tests/integration/glance-jargon-belt-tabs.test.ts:cleanup' }); } catch { /* @silent-fallback-ok — best-effort tmp cleanup */ } });
+const BASE = { config: { authToken: 't', port: 0, stateDir: TMP }, startTime: new Date() };
+
+describe('Machines glance (integration — real /pool)', () => {
+  let server: TestServer;
+  afterEach(async () => { await server?.close(); });
+
+  it('feature ON: /pool 200, glance renders from live machines + drills to a record', async () => {
+    const machines = [
+      { machineId: 'm_1', nickname: 'Laptop', online: true, clockSkewStatus: 'ok', activeSessionCount: 2, maxSessions: 6,
+        hardware: { cpuModel: 'Apple M2', cpuCores: 8, totalMemBytes: 17179869184 }, guardPosture: { onConfirmed: 16, offDeviant: 6 } },
+      { machineId: 'm_2', nickname: 'Mini', online: false, clockSkewStatus: 'ok' },
+    ];
+    server = await bootApp({
+      ...BASE,
+      machinePoolRegistry: { getCapacities: () => machines },
+      coordinator: { getSyncStatus: () => ({ leaseHolder: 'm_1', leaseEpoch: 1, holdsLease: true, awakeMachineCount: 1, awakeMachineCountSource: 'lease-live', splitBrainState: 'clear' }) },
+    });
+
+    const res = await fetch(server.url + '/pool');
+    expect(res.status).toBe(200); // alive, not 503
+    const pool = await res.json();
+    expect(pool.enabled).toBe(true);
+    expect(pool.machines.length).toBe(2);
+
+    const base = buildMachinesGlance(pool, null);
+    expect(validateGlanceSpec(base).ok).toBe(true);
+    expect(Number(base.tiles.find((t: any) => t.key === 'online').value)).toBe(1); // 1 of 2 online
+
+    const { dom, doc, root } = jsdomRoot();
+    const handle = renderGlance(doc, root, machinesGlanceSpec(doc, pool, null, {}));
+    expect(handle.headline.textContent).toMatch(/1 of 2 machines online/);
+    expect(walk(handle, dom)).toBeGreaterThanOrEqual(1);
+
+    const onlineBtn = handle.tiles.find((b: any) => b.getAttribute('data-glance-tile') === 'online');
+    onlineBtn.dispatchEvent(new (dom.window as any).Event('click'));
+    const row = handle.drilldown.querySelector('.glance-list-row');
+    row.dispatchEvent(new (dom.window as any).Event('click'));
+    expect(handle.drilldown.querySelector('[data-glance-record]')!.textContent).toMatch(/Specs|Status/);
+  });
+
+  it('dark: /pool enabled:false → the tab builds a friendly single-machine glance', async () => {
+    server = await bootApp({ ...BASE }); // no machinePoolRegistry
+    const res = await fetch(server.url + '/pool');
+    expect(res.status).toBe(200);
+    const pool = await res.json();
+    expect(pool.enabled).toBe(false);
+    // The empty-population glance the component builds still conforms.
+    expect(validateGlanceSpec(buildMachinesGlance(pool, null)).ok).toBe(true);
+  });
+});
+
+describe('Health glance (integration — real /systems/status)', () => {
+  let server: TestServer;
+  afterEach(async () => { await server?.close(); });
+
+  it('/systems/status 200 with live subsystems → conforming glance that drills to a record', async () => {
+    server = await bootApp({
+      ...BASE,
+      watchdog: {}, triageNurse: {}, spawnManager: {},
+      scheduler: {}, commitmentTracker: { getActive: () => [] },
+    });
+    const res = await fetch(server.url + '/systems/status');
+    expect(res.status).toBe(200); // always alive
+    const systems = await res.json();
+    expect(Array.isArray(systems.activeCapabilities)).toBe(true);
+    expect(systems.activeCapabilities.length).toBeGreaterThanOrEqual(1); // wired subsystems appear
+
+    const base = buildHealthGlance(systems);
+    expect(validateGlanceSpec(base).ok).toBe(true);
+    expect(Number(base.tiles.find((t: any) => t.key === 'subsystems').value)).toBe(healthPopulation(systems).length);
+
+    const { dom, doc, root } = jsdomRoot();
+    const handle = renderGlance(doc, root, healthGlanceSpec(doc, systems));
+    expect(walk(handle, dom)).toBeGreaterThanOrEqual(1);
+
+    const subsBtn = handle.tiles.find((b: any) => b.getAttribute('data-glance-tile') === 'subsystems');
+    subsBtn.dispatchEvent(new (dom.window as any).Event('click'));
+    handle.drilldown.querySelector('.glance-list-row').dispatchEvent(new (dom.window as any).Event('click'));
+    expect(handle.drilldown.querySelector('[data-glance-record]')!.textContent).toMatch(/What it does/);
+  });
+});
+
+describe('Routing Map glance (integration — real /intelligence/routing/chains)', () => {
+  let server: TestServer;
+  afterEach(async () => { await server?.close(); });
+
+  it('dark: 503 without an IntelligenceRouter → the tab shows an honest note', async () => {
+    server = await bootApp({ ...BASE }); // no intelligence router
+    const res = await fetch(server.url + '/intelligence/routing/chains');
+    expect(res.status).toBe(503); // documented dark behavior — the route is gated
+  });
+
+  it('the builder conforms + drills over the REAL buildNatureRoutingMap() shape', async () => {
+    // The route returns { defaultFramework, ...buildNatureRoutingMap() }; drive the
+    // builder against that exact shipped structure (no LLM provider needed).
+    const map = { defaultFramework: 'claude-code', ...buildNatureRoutingMap({}) };
+    const base = buildRoutingMapGlance(map);
+    expect(validateGlanceSpec(base).ok).toBe(true);
+    expect(base.headline).toMatch(/Background AI work runs on/);
+
+    const { dom, doc, root } = jsdomRoot();
+    const handle = renderGlance(doc, root, routingMapGlanceSpec(doc, map));
+    expect(walk(handle, dom)).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('Spend glance (integration — real /routing-spend/summary)', () => {
+  let server: TestServer;
+  afterEach(async () => { await server?.close(); });
+
+  it('dark: 503 when the dev-gated view is off (fleet default) → an honest note', async () => {
+    server = await bootApp({ ...BASE }); // routingSpend not enabled
+    const res = await fetch(server.url + '/routing-spend/summary?grain=day');
+    expect(res.status).toBe(503); // dev-gated dark on the fleet
+    // The empty glance the component builds still conforms.
+    expect(validateGlanceSpec(buildSpendGlance({ totals: {}, rows: [] }, { keys: [] })).ok).toBe(true);
+  });
+
+  it('the builder conforms + drills over a representative SpendSummary shape', async () => {
+    const summary = { totals: { netUsd: 0, tokensIn: 123456, tokensOut: 6543 }, meteredLiveYet: false,
+      rows: [{ door: 'claude-cli', modelId: 'claude-haiku-4-5-20251001', doorClass: 'cli', tokensIn: 123456, tokensOut: 6543, grossUsd: 0, netUsd: 0, priceBasis: 'subscription-zero' }] };
+    const caps = { keys: [{ keyRef: 'k1', provider: 'openai', door: 'openai-metered', dailyCapUsd: 5, lifetimeCapUsd: 50, committedDayUsd: 0, committedLifetimeUsd: 0, goLiveState: 'not-live', frozen: false }] };
+    const base = buildSpendGlance(summary, caps);
+    expect(validateGlanceSpec(base).ok).toBe(true);
+    expect(base.headline.toLowerCase()).toContain('nothing is being billed');
+
+    const { dom, doc, root } = jsdomRoot();
+    const handle = renderGlance(doc, root, spendGlanceSpec(doc, summary, caps));
+    expect(walk(handle, dom)).toBeGreaterThanOrEqual(1);
+    const accessBtn = handle.tiles.find((b: any) => b.getAttribute('data-glance-tile') === 'access');
+    accessBtn.dispatchEvent(new (dom.window as any).Event('click'));
+    handle.drilldown.querySelector('.glance-list-row').dispatchEvent(new (dom.window as any).Event('click'));
+    expect(handle.drilldown.querySelector('[data-glance-record]')!.textContent).toMatch(/Daily limit|Not switched on/);
+  });
+});

--- a/tests/unit/dashboard-glance-drilldown.test.ts
+++ b/tests/unit/dashboard-glance-drilldown.test.ts
@@ -26,6 +26,10 @@ import {
   buildCommitmentsGlance,
   blockersGlanceSpec,
   buildBlockersGlance,
+  machinesGlanceSpec,
+  healthGlanceSpec,
+  spendGlanceSpec,
+  routingMapGlanceSpec,
 } from '../../dashboard/glance.js';
 
 let dom: JSDOM;
@@ -310,5 +314,220 @@ describe('F11 walk-every-tile — the Blockers glance (Phase 2)', () => {
     const rowText = handle.drilldown.querySelector('.glance-list-summary')!.textContent || '';
     expect(rowText).toContain('onerror');
     expect(rowText).not.toContain('‮');
+  });
+});
+
+// ── Phase 3 (topic 29836) — the jargon-belt tabs walked end-to-end ────────────
+// Each new glance-adopted tab walks every tile: it opens a non-empty, distinct
+// Layer-2 container (or an honest empty-state for a zero-count tile), and a
+// representative row opens a Layer-3 record. Non-vacuous: ≥1 tile drills into real
+// receipts. Mirrors the Commitments/Blockers walks so the F11 floor is proven for
+// every Phase-3 tab, not just asserted.
+
+/** Walk every tile; return the count that opened real receipts (a `.glance-list-row`). */
+function walkTiles(handle: any): number {
+  const glanceText = (handle.headline.textContent + ' ' + handle.tiles.map((b: any) => b.textContent).join(' ')).trim();
+  let realDrills = 0;
+  for (const btn of handle.tiles) {
+    const key = btn.getAttribute('data-glance-tile');
+    const { opened, text } = activate(handle, key);
+    expect(opened, `tile "${key}" opened a detail layer`).toBe(true);
+    expect(text.length, `tile "${key}" layer is non-empty`).toBeGreaterThan(0);
+    expect(text, `tile "${key}" is distinct from the glance`).not.toBe(glanceText);
+    if (!/nothing here right now/i.test(text)) {
+      realDrills++;
+      expect(handle.drilldown.querySelector('.glance-list-row'), `tile "${key}" shows receipts`).toBeTruthy();
+    }
+    activate(handle, key); // toggle closed
+  }
+  return realDrills;
+}
+
+describe('F11 walk-every-tile — the Machines glance (Phase 3) + issue #1429', () => {
+  const mkMachine = (over: Record<string, unknown> = {}) => ({
+    machineId: 'm_1', nickname: 'Laptop', online: true, clockSkewStatus: 'ok',
+    activeSessionCount: 2, maxSessions: 6,
+    hardware: { cpuModel: 'Apple M2', cpuCores: 8, totalMemBytes: 17179869184 },
+    guardPosture: { onConfirmed: 16, offDeviant: 6 }, ...over,
+  });
+  const guards = { guards: [
+    { key: 'zombieCleanup', effective: 'on-confirmed', configEnabled: true, defaultEnabled: true, process: 'server' },
+    { key: 'sleepWakeDetector', effective: 'off-runtime-divergent', configEnabled: true, defaultEnabled: true, process: 'lifeline' },
+  ], summary: { onConfirmed: 1, offRuntimeDivergent: 1 } };
+  const pool = { enabled: true, router: { holder: 'm_1' }, machines: [
+    mkMachine(), mkMachine({ machineId: 'm_2', nickname: 'Mini', online: false }),
+  ] };
+
+  it('every tile opens a non-empty, distinct Layer-2 (non-vacuous), rows → records', () => {
+    const handle = renderGlance(doc, root, machinesGlanceSpec(doc, pool, guards, {}));
+    expect(handle.headline.textContent).toMatch(/1 of 2 machines online/);
+    expect(walkTiles(handle)).toBeGreaterThanOrEqual(1);
+    // tile → row → Layer-3 record (specs live at Layer 3)
+    activate(handle, 'online');
+    const row = handle.drilldown.querySelector('.glance-list-row')!;
+    row.dispatchEvent(new dom.window.Event('click'));
+    const record = handle.drilldown.querySelector('[data-glance-record]');
+    expect(record, 'a machine record opened').toBeTruthy();
+    expect(record!.textContent).toMatch(/Specs|Status/);
+  });
+
+  it('the Safety-checks tile drills into the NAMED guards with plain explanations', () => {
+    const handle = renderGlance(doc, root, machinesGlanceSpec(doc, pool, guards, {}));
+    const { opened, text } = activate(handle, 'guards');
+    expect(opened).toBe(true);
+    expect(text).toMatch(/Zombie cleanup|Sleep wake detector/i); // humanized key, no camelCase
+    expect(text).toMatch(/verified working|needs a look/i); // plain one-line explanation
+    const row = handle.drilldown.querySelector('.glance-list-row')!;
+    row.dispatchEvent(new dom.window.Event('click'));
+    expect(handle.drilldown.querySelector('[data-glance-record]')!.textContent).toMatch(/In plain words/);
+  });
+
+  it('#1429: the nickname edits commit ONLY on Enter/blur, with optimistic echo', () => {
+    let saved: any = null;
+    const handle = renderGlance(doc, root, machinesGlanceSpec(doc, pool, guards, {
+      onRename: (id: string, nickname: string, input: any, prev: string) => { saved = { id, nickname, prev }; },
+    }));
+    activate(handle, 'online');
+    handle.drilldown.querySelector('.glance-list-row')!.dispatchEvent(new dom.window.Event('click'));
+    const input = handle.drilldown.querySelector('input.machine-nick') as HTMLInputElement;
+    expect(input, 'the machine record carries an editable nickname').toBeTruthy();
+    // Typing alone must NOT commit (the #1429 defect was commit-on-input).
+    input.value = 'Laptop-EDIT';
+    input.dispatchEvent(new dom.window.Event('input'));
+    expect(saved, 'typing an input event must not commit').toBeNull();
+    // Blur commits exactly once, with the prior value available for rollback.
+    input.dispatchEvent(new dom.window.Event('blur'));
+    expect(saved).toEqual({ id: 'm_1', nickname: 'Laptop-EDIT', prev: 'Laptop' });
+    // Optimistic echo: the input keeps the typed value (poll authority reloads later).
+    expect(input.value).toBe('Laptop-EDIT');
+  });
+
+  it('#1429: a background poll HOLDS an open rename drill (F9) instead of clobbering it', () => {
+    const handle = renderGlance(doc, root, machinesGlanceSpec(doc, pool, guards, { onRename: () => {} }));
+    activate(handle, 'online');
+    handle.drilldown.querySelector('.glance-list-row')!.dispatchEvent(new dom.window.Event('click'));
+    const input = handle.drilldown.querySelector('input.machine-nick') as HTMLInputElement;
+    input.value = 'half-typed name'; // a dirty field mid-edit
+    // A 15s poll re-render arrives with fresh data.
+    const held = renderGlance(doc, root, machinesGlanceSpec(doc, pool, guards, { onRename: () => {} }));
+    expect(held.held, 'the re-render was held, not a rebuild').toBe(true);
+    // the half-typed value survived untouched
+    expect((root.querySelector('input.machine-nick') as HTMLInputElement).value).toBe('half-typed name');
+  });
+
+  it('a machine nickname with an XSS payload renders inert at Layer 2', () => {
+    const nasty = '<img src=x onerror=alert(1)> "><script>bad()</script> ‮evil';
+    const handle = renderGlance(doc, root, machinesGlanceSpec(doc, { enabled: true, machines: [
+      { machineId: 'm_9', nickname: nasty, online: true, clockSkewStatus: 'ok' },
+    ] }, null, {}));
+    activate(handle, 'online');
+    expect(handle.drilldown.querySelector('img')).toBeNull();
+    expect(handle.drilldown.querySelector('script')).toBeNull();
+    const rowText = handle.drilldown.querySelector('.glance-list-summary')!.textContent || '';
+    expect(rowText).toContain('onerror');
+    expect(rowText).not.toContain('‮');
+  });
+});
+
+describe('F11 walk-every-tile — the Health glance (Phase 3)', () => {
+  const systems = {
+    health: 'error', uptime: 123456,
+    activeCapabilities: [
+      { id: 'session-recovery', label: 'Session Recovery', description: 'Detects stuck sessions and recovers them.',
+        status: 'active', metric: '12 recovered', stats: { recoveries: 12 }, processes: [{ name: 'SessionWatchdog', status: 'running' }] },
+      { id: 'telegram', label: 'Telegram', description: 'Telegram messaging integration.',
+        status: 'error', metric: 'disconnected', stats: {}, processes: [{ name: 'TelegramAdapter', status: 'error' }] },
+    ],
+    issues: [{ severity: 'error', label: 'Telegram issue', description: 'TelegramAdapter errored', capability: 'telegram', process: 'TelegramAdapter' }],
+    recentEvents: [{ narrative: 'Telegram reconnected after a blip', subsystem: 'telegram', timestamp: '2026-07-10T00:00:00Z' }],
+  };
+
+  it('every tile opens a non-empty, distinct Layer-2 (non-vacuous), rows → records', () => {
+    const handle = renderGlance(doc, root, healthGlanceSpec(doc, systems));
+    expect(handle.headline.textContent).toMatch(/1 subsystem needs attention/);
+    expect(walkTiles(handle)).toBeGreaterThanOrEqual(1);
+    // Subsystems tile → a subsystem row → a record with the full (formerly 390-word) prose
+    activate(handle, 'subsystems');
+    handle.drilldown.querySelector('.glance-list-row')!.dispatchEvent(new dom.window.Event('click'));
+    const record = handle.drilldown.querySelector('[data-glance-record]');
+    expect(record!.textContent).toMatch(/What it does/);
+  });
+
+  it('a healthy agent reads "All systems are operational."', () => {
+    const handle = renderGlance(doc, root, healthGlanceSpec(doc, { health: 'healthy', activeCapabilities: [
+      { id: 'x', label: 'X', description: 'y', status: 'active', metric: 'ok', stats: {}, processes: [] },
+    ], issues: [], recentEvents: [] }));
+    expect(handle.headline.textContent).toBe('All systems are operational.');
+    // The "Need attention" tile is zero → honest empty-state, still clickable.
+    const { opened, text } = activate(handle, 'attention');
+    expect(opened).toBe(true);
+    expect(text.toLowerCase()).toContain('nothing here');
+  });
+});
+
+describe('F11 walk-every-tile — the Spend glance (Phase 3)', () => {
+  const summary = { totals: { netUsd: 0, tokensIn: 123456, tokensOut: 6543 }, meteredLiveYet: false,
+    rows: [{ door: 'claude-cli', modelId: 'claude-haiku-4-5-20251001', doorClass: 'cli', tokensIn: 123456, tokensOut: 6543, grossUsd: 0, netUsd: 0, priceBasis: 'subscription-zero' }] };
+  const caps = { keys: [{ keyRef: 'k1', provider: 'openai', door: 'openai-metered', dailyCapUsd: 5, lifetimeCapUsd: 50, committedDayUsd: 0, committedLifetimeUsd: 0, goLiveState: 'not-live', frozen: false }] };
+
+  it('every tile opens a non-empty, distinct Layer-2 (non-vacuous), rows → records', () => {
+    const handle = renderGlance(doc, root, spendGlanceSpec(doc, summary, caps));
+    expect(handle.headline.textContent!.toLowerCase()).toContain('nothing is being billed');
+    expect(walkTiles(handle)).toBeGreaterThanOrEqual(1);
+    // Cost tile → a per-model row → a record with the plain pricing detail
+    activate(handle, 'cost');
+    handle.drilldown.querySelector('.glance-list-row')!.dispatchEvent(new dom.window.Event('click'));
+    expect(handle.drilldown.querySelector('[data-glance-record]')!.textContent).toMatch(/How it is priced|Subscription/);
+  });
+
+  it('the Pay-per-use access tile drills into the paid-door keys with plain caps', () => {
+    const handle = renderGlance(doc, root, spendGlanceSpec(doc, summary, caps));
+    const { opened, text } = activate(handle, 'access');
+    expect(opened).toBe(true);
+    expect(text.toLowerCase()).toContain('pay-per-use');
+    handle.drilldown.querySelector('.glance-list-row')!.dispatchEvent(new dom.window.Event('click'));
+    expect(handle.drilldown.querySelector('[data-glance-record]')!.textContent).toMatch(/Daily limit|Not switched on/);
+  });
+
+  it('an empty spend view → zero tiles drill into honest empty-states', () => {
+    const handle = renderGlance(doc, root, spendGlanceSpec(doc, { totals: {}, rows: [], meteredLiveYet: false }, { keys: [] }));
+    const { opened, text } = activate(handle, 'access');
+    expect(opened).toBe(true);
+    expect(text.toLowerCase()).toContain('nothing here');
+  });
+});
+
+describe('F11 walk-every-tile — the Routing Map glance (Phase 3)', () => {
+  const pos = (over: Record<string, unknown> = {}) => ({
+    door: 'claude-cli', modelId: 'claude-haiku-4-5-20251001', doorClass: 'cli',
+    injectionSafe: true, moneyGated: false, claudeBanned: false, skippedInIncrementA: false, ...over,
+  });
+  const map = { defaultFramework: 'claude-code', chains: [
+    { chain: 'FAST', positions: [pos(), pos({ door: 'openai-metered', modelId: 'gpt-5.5', doorClass: 'metered', moneyGated: true, injectionSafe: false, skippedInIncrementA: true })] },
+    { chain: 'JUDGE', positions: [pos({ modelId: 'claude-sonnet-5' })] },
+  ], components: [
+    { component: 'messageSentinel', category: 'gate', nature: 'A', chain: 'FAST', criticalGate: true, untrustedInput: true, route: [pos()] },
+  ] };
+
+  it('every tile opens a non-empty, distinct Layer-2 (non-vacuous), rows → records', () => {
+    const handle = renderGlance(doc, root, routingMapGlanceSpec(doc, map));
+    expect(handle.headline.textContent).toMatch(/runs on Claude Haiku, with GPT as backup/);
+    expect(walkTiles(handle)).toBeGreaterThanOrEqual(1);
+    // A lane tile → an ordered model row → a record with the full door/model config
+    activate(handle, 'lane-fast');
+    const rows = handle.drilldown.querySelectorAll('.glance-list-row');
+    expect(rows.length).toBe(2); // FAST has two positions (primary + backup)
+    rows[1].dispatchEvent(new dom.window.Event('click'));
+    const record = handle.drilldown.querySelector('[data-glance-record]');
+    expect(record!.textContent).toMatch(/Access type|pay-per-use/);
+  });
+
+  it('the Job-types tile drills into the components with plain lane names', () => {
+    const handle = renderGlance(doc, root, routingMapGlanceSpec(doc, map));
+    const { opened, text } = activate(handle, 'jobs');
+    expect(opened).toBe(true);
+    expect(text).toMatch(/Message sentinel/i); // humanized component, no camelCase
+    handle.drilldown.querySelector('.glance-list-row')!.dispatchEvent(new dom.window.Event('click'));
+    expect(handle.drilldown.querySelector('[data-glance-record]')!.textContent).toMatch(/Lane|Safety-critical/);
   });
 });

--- a/tests/unit/dashboard-glance-word-budget.test.ts
+++ b/tests/unit/dashboard-glance-word-budget.test.ts
@@ -29,6 +29,13 @@ import {
   commitmentsOpenPopulation,
   buildBlockersGlance,
   blockersPopulation,
+  buildMachinesGlance,
+  machinesPopulation,
+  buildHealthGlance,
+  healthPopulation,
+  buildSpendGlance,
+  buildRoutingMapGlance,
+  friendlyModel,
   GLANCE_MAX_TILES,
   GLANCE_WORD_BUDGET,
   GLANCE_ADOPTED_TABS,
@@ -276,6 +283,164 @@ describe('F10 conformance — the real Blockers builder under adversarial fixtur
   });
 });
 
+describe('F10 conformance — the Phase-3 jargon-belt builders under adversarial fixtures', () => {
+  // Each builder is fed large-N, null/empty/error, and jargon-laden fixtures; the
+  // produced glance must ALWAYS pass F10 (≤5 tiles, ≤150 words, no insider vocab) —
+  // proving the jargon can never leak up from the raw data to the operator's glance.
+
+  describe('Machines', () => {
+    const mkMachine = (over: Record<string, unknown> = {}) => ({
+      machineId: 'm_4f3a9b1c', nickname: 'Laptop', online: true, clockSkewStatus: 'ok',
+      activeSessionCount: 2, maxSessions: 6,
+      hardware: { cpuModel: 'Apple M2', cpuCores: 8, totalMemBytes: 17179869184 },
+      guardPosture: { onConfirmed: 16, offDeviant: 6, offRuntimeDivergent: 0 }, ...over,
+    });
+    const fixtures: Array<[string, any]> = [
+      ['empty pool', { enabled: true, machines: [] }],
+      ['single machine', { enabled: true, router: { holder: 'm_4f3a9b1c' }, machines: [mkMachine()] }],
+      ['two healthy', { enabled: true, machines: [mkMachine(), mkMachine({ machineId: 'm_2', nickname: 'Mini' })] }],
+      ['offline + clock-skew + guard problems', { enabled: true, router: { holder: 'm_1' }, machines: [
+        mkMachine({ machineId: 'm_1', online: false }),
+        mkMachine({ machineId: 'm_2', clockSkewStatus: 'suspect-clock-removed' }),
+        mkMachine({ machineId: 'm_3', guardPosture: { onStale: 3, missing: 1, errored: 2 } }),
+      ] }],
+      ['jargon-laden nickname (must not leak to Layer 1)', { enabled: true, machines: [
+        mkMachine({ machineId: 'machine-4f3a', nickname: 'fix the atRisk cadence: 1800s for CMT-953' }),
+      ] }],
+      ['large N', { enabled: true, router: { holder: 'm_0' }, machines: Array.from({ length: 40 }, (_, i) =>
+        mkMachine({ machineId: 'm_' + i, nickname: 'node ' + i, online: i % 5 !== 0 })) }],
+    ];
+    const guards = { guards: [
+      { key: 'zombieCleanup', effective: 'on-confirmed', configEnabled: true, defaultEnabled: true, process: 'server' },
+      { key: 'sleepWakeDetector', effective: 'off-runtime-divergent', configEnabled: true, defaultEnabled: true, process: 'lifeline' },
+    ], summary: { onConfirmed: 1, offRuntimeDivergent: 1 } };
+    for (const [name, pool] of fixtures) {
+      it(`conforms for "${name}"`, () => {
+        for (const g of [null, guards]) {
+          const glance = buildMachinesGlance(pool, g);
+          const r = validateGlanceSpec(glance);
+          expect(r.ok, `violations: ${JSON.stringify(r.violations)}`).toBe(true);
+          expect(glance.tiles.length).toBeLessThanOrEqual(GLANCE_MAX_TILES);
+        }
+      });
+    }
+    it('TRUTHFULNESS — the Online tile count never exceeds the machine population', () => {
+      const pool = fixtures[5][1];
+      const glance = buildMachinesGlance(pool, null);
+      const online = Number(glance.tiles.find((t: any) => t.key === 'online').value);
+      expect(online).toBe(machinesPopulation(pool).filter((m: any) => m.online).length);
+      expect(online).toBeLessThanOrEqual(glance.population.length);
+    });
+  });
+
+  describe('Health', () => {
+    const mkCap = (over: Record<string, unknown> = {}) => ({
+      id: 'session-recovery', label: 'Session Recovery', description: 'Detects stuck sessions.',
+      status: 'active', metric: '12 recovered', stats: { recoveries: 12 }, lastActivity: null,
+      processes: [{ name: 'SessionWatchdog', status: 'running' }], ...over,
+    });
+    const fixtures: Array<[string, any]> = [
+      ['empty', { health: 'healthy', activeCapabilities: [], issues: [], recentEvents: [] }],
+      ['null-ish', { activeCapabilities: [null, undefined, {}, mkCap()], issues: [], recentEvents: [] }],
+      ['all healthy', { health: 'healthy', activeCapabilities: [mkCap(), mkCap({ id: 'telegram', label: 'Telegram' })], issues: [], recentEvents: [] }],
+      ['some errored', { health: 'error', activeCapabilities: [mkCap(), mkCap({ id: 'telegram', label: 'Telegram', status: 'error' })],
+        issues: [{ severity: 'error', label: 'Telegram issue', description: 'TelegramAdapter errored', capability: 'telegram', process: 'TelegramAdapter' }],
+        recentEvents: [{ narrative: 'Telegram reconnected after a blip', subsystem: 'telegram', timestamp: '2026-07-10T00:00:00Z' }] }],
+      ['jargon-laden narrative (Layer 2 only)', { health: 'error', activeCapabilities: [mkCap({ status: 'error' })], issues: [],
+        recentEvents: [{ narrative: 'the atRisk beacon cadence: 1800s tripped for CMT-953', subsystem: 'sess_4f3a', timestamp: '2026-07-10T00:00:00Z' }] }],
+      ['large N', { health: 'error', activeCapabilities: Array.from({ length: 30 }, (_, i) =>
+        mkCap({ id: 'cap-' + i, label: 'Subsystem ' + i, status: i % 4 === 0 ? 'error' : 'active' })),
+        issues: [], recentEvents: Array.from({ length: 20 }, (_, i) => ({ narrative: 'event ' + i, subsystem: 's' + i })) }],
+    ];
+    for (const [name, systems] of fixtures) {
+      it(`conforms for "${name}"`, () => {
+        const glance = buildHealthGlance(systems);
+        const r = validateGlanceSpec(glance);
+        expect(r.ok, `violations: ${JSON.stringify(r.violations)}`).toBe(true);
+        expect(glance.tiles.length).toBeLessThanOrEqual(GLANCE_MAX_TILES);
+      });
+    }
+    it('TRUTHFULNESS — the Subsystems tile equals the population length', () => {
+      const systems = fixtures[5][1];
+      const glance = buildHealthGlance(systems);
+      const subs = Number(glance.tiles.find((t: any) => t.key === 'subsystems').value);
+      expect(subs).toBe(healthPopulation(systems).length);
+    });
+  });
+
+  describe('Spend', () => {
+    const mkRow = (over: Record<string, unknown> = {}) => ({
+      door: 'claude-cli', modelId: 'claude-haiku-4-5-20251001', doorClass: 'cli',
+      tokensIn: 123456, tokensOut: 6543, grossUsd: 0, netUsd: 0, priceBasis: 'subscription-zero', ...over,
+    });
+    const fixtures: Array<[string, any, any]> = [
+      ['empty', { totals: {}, rows: [], meteredLiveYet: false }, { keys: [] }],
+      ['subscription-only ($0)', { totals: { netUsd: 0, tokensIn: 123456, tokensOut: 6543 }, rows: [mkRow()], meteredLiveYet: false },
+        { keys: [{ keyRef: 'k1', provider: 'openai', door: 'openai-metered', dailyCapUsd: 5, lifetimeCapUsd: 50, committedDayUsd: 0, committedLifetimeUsd: 0, goLiveState: 'not-live', frozen: false }] }],
+      ['metered live with cost', { totals: { netUsd: 12.34, tokensIn: 9_000_000, tokensOut: 400_000 }, rows: [mkRow({ door: 'openai-metered', modelId: 'gpt-5.5', doorClass: 'metered', netUsd: 12.34, priceBasis: 'internal-derived' })], meteredLiveYet: true },
+        { keys: [{ keyRef: 'k1', provider: 'openai', door: 'openai-metered', dailyCapUsd: 5, lifetimeCapUsd: 50, committedDayUsd: 1.2, committedLifetimeUsd: 12.34, goLiveState: 'live', frozen: false }], meteredLiveYet: true }],
+      ['jargon-laden model ids', { totals: { netUsd: 0.5, tokensIn: 1000, tokensOut: 500 }, rows: [
+        mkRow({ modelId: 'claude-opus-4-8-20260115' }), mkRow({ modelId: 'gpt-4o-2024-08-06', door: 'openai-metered', doorClass: 'metered' }),
+      ], meteredLiveYet: false }, { keys: [] }],
+      ['large N rows', { totals: { netUsd: 3.21, tokensIn: 5_000_000, tokensOut: 200_000 },
+        rows: Array.from({ length: 50 }, (_, i) => mkRow({ modelId: 'model-' + i })), meteredLiveYet: false }, { keys: [] }],
+    ];
+    for (const [name, summary, caps] of fixtures) {
+      it(`conforms for "${name}"`, () => {
+        const glance = buildSpendGlance(summary, caps);
+        const r = validateGlanceSpec(glance);
+        expect(r.ok, `violations: ${JSON.stringify(r.violations)}`).toBe(true);
+        expect(glance.tiles.length).toBeLessThanOrEqual(GLANCE_MAX_TILES);
+      });
+    }
+    it('honest headline: not-live → "Nothing is being billed", live → a dollar figure', () => {
+      expect(buildSpendGlance(fixtures[1][1], fixtures[1][2]).headline.toLowerCase()).toContain('nothing is being billed');
+      expect(buildSpendGlance(fixtures[2][1], fixtures[2][2]).headline).toMatch(/\$\d/);
+    });
+  });
+
+  describe('Routing Map', () => {
+    const pos = (over: Record<string, unknown> = {}) => ({
+      door: 'claude-cli', modelId: 'claude-haiku-4-5-20251001', doorClass: 'cli',
+      injectionSafe: true, moneyGated: false, claudeBanned: false, skippedInIncrementA: false, ...over,
+    });
+    const fixtures: Array<[string, any]> = [
+      ['no chains', { chains: [], components: [] }],
+      ['full four lanes', { defaultFramework: 'claude-code', injectionExposureSource: 'FD5b-exposure-map', chains: [
+        { chain: 'FAST', positions: [pos(), pos({ door: 'openai-metered', modelId: 'gpt-5.5', doorClass: 'metered', moneyGated: true, skippedInIncrementA: true })] },
+        { chain: 'SORT', positions: [pos({ modelId: 'claude-haiku-4-5-20251001' })] },
+        { chain: 'JUDGE', positions: [pos({ modelId: 'claude-sonnet-5' })] },
+        { chain: 'WRITE', positions: [pos({ modelId: 'claude-opus-4-8-20260115' })] },
+      ], components: [
+        { component: 'messageSentinel', category: 'gate', nature: 'A', chain: 'FAST', criticalGate: true, untrustedInput: true, route: [pos()] },
+        { component: 'toneGate', category: 'other', nature: null, chain: null, criticalGate: false, untrustedInput: false },
+      ] }],
+      ['weird/jargon model ids everywhere', { chains: [
+        { chain: 'FAST', positions: [pos({ modelId: 'm_4f3a9b1c2d' }), pos({ modelId: 'cmt953-model' })] },
+      ], components: Array.from({ length: 30 }, (_, i) => ({ component: 'component_' + i, category: 'other', chain: 'FAST', criticalGate: false, untrustedInput: false })) }],
+    ];
+    for (const [name, map] of fixtures) {
+      it(`conforms for "${name}"`, () => {
+        const glance = buildRoutingMapGlance(map);
+        const r = validateGlanceSpec(glance);
+        expect(r.ok, `violations: ${JSON.stringify(r.violations)}`).toBe(true);
+        expect(glance.tiles.length).toBeLessThanOrEqual(GLANCE_MAX_TILES);
+      });
+    }
+    it('headline names the primary model + backup in plain words', () => {
+      const g = buildRoutingMapGlance(fixtures[1][1]);
+      expect(g.headline).toMatch(/runs on Claude Haiku/);
+      expect(g.headline).toMatch(/backup/);
+    });
+    it('friendlyModel strips version/date noise and never emits jargon', () => {
+      expect(friendlyModel('claude-opus-4-8-20260115')).toBe('Claude Opus');
+      expect(findInsiderVocab(friendlyModel('claude-haiku-4-5-20251001'))).toEqual([]);
+      // an id that can't be plainly rendered falls back to '' (caller substitutes a phrase)
+      expect(friendlyModel('m_4f3a9b1c2d')).toBe('');
+    });
+  });
+});
+
 describe('F10/F11 grandfather ratchet — structural, not prose', () => {
   it('completeness: every registered tab is in exactly one of adopted ∪ grandfathered', () => {
     const ids = tabRegistryIds();
@@ -296,20 +461,27 @@ describe('F10/F11 grandfather ratchet — structural, not prose', () => {
     expect(GLANCE_GRANDFATHERED.length).toBeLessThanOrEqual(GLANCE_GRANDFATHERED_CEILING);
   });
 
-  it('population floor: every adopted tab has a real builder (commitments + blockers)', () => {
-    expect(GLANCE_ADOPTED_TABS.length).toBeGreaterThanOrEqual(2);
-    expect(GLANCE_ADOPTED_TABS).toContain('commitments');
-    expect(GLANCE_ADOPTED_TABS).toContain('blockers'); // adopted this PR (Phase 2)
-    // both reference builders are real (not stubs) and produce a conforming empty glance
-    expect(typeof buildCommitmentsGlance).toBe('function');
+  it('population floor: every adopted tab has a real builder (Phases 1–3)', () => {
+    expect(GLANCE_ADOPTED_TABS.length).toBeGreaterThanOrEqual(6);
+    for (const id of ['commitments', 'blockers', 'machines', 'systems', 'spend', 'routing-map']) {
+      expect(GLANCE_ADOPTED_TABS, `${id} must be adopted`).toContain(id);
+    }
+    // every reference builder is real (not a stub) and produces a conforming empty glance
     expect(validateGlanceSpec(buildCommitmentsGlance([])).ok).toBe(true);
-    expect(typeof buildBlockersGlance).toBe('function');
     expect(validateGlanceSpec(buildBlockersGlance([])).ok).toBe(true);
+    expect(validateGlanceSpec(buildMachinesGlance({ enabled: true, machines: [] })).ok).toBe(true);
+    expect(validateGlanceSpec(buildHealthGlance({ health: 'healthy', activeCapabilities: [], issues: [], recentEvents: [] })).ok).toBe(true);
+    expect(validateGlanceSpec(buildSpendGlance({ totals: {}, rows: [] }, { keys: [] })).ok).toBe(true);
+    expect(validateGlanceSpec(buildRoutingMapGlance({ chains: [], components: [] })).ok).toBe(true);
   });
 
-  it('the ratchet only shrinks: blockers is no longer grandfathered and the ceiling dropped', () => {
+  it('the ratchet only shrinks: the Phase-3 tabs left the grandfather list and the ceiling dropped', () => {
     expect(GLANCE_GRANDFATHERED).not.toContain('blockers');
     expect(GLANCE_GRANDFATHERED).not.toContain('commitments');
-    expect(GLANCE_GRANDFATHERED_CEILING).toBe(24); // was 25 before Phase 2
+    // Phase 3 — the jargon belt — retired four more tabs from the grandfather list.
+    for (const id of ['machines', 'systems', 'spend', 'routing-map']) {
+      expect(GLANCE_GRANDFATHERED, `${id} left the grandfather list`).not.toContain(id);
+    }
+    expect(GLANCE_GRANDFATHERED_CEILING).toBe(20); // 25 (P1) → 24 (P2) → 20 (P3)
   });
 });

--- a/tests/unit/dashboard-machinesTab.test.ts
+++ b/tests/unit/dashboard-machinesTab.test.ts
@@ -1,7 +1,9 @@
 /**
- * Smoke tests for the Machines dashboard tab (Multi-Machine Session Pool §L2).
+ * Smoke tests for the Machines dashboard tab (Multi-Machine Session Pool §L2),
+ * rebuilt on the shared glance component (Dashboard UX Standard F10/F11, topic 29836
+ * Phase 3) with issue #1429 (nickname commit-on-input + focus-steal) folded in.
  * Inspects the HTML/JS at rest (no browser): tab wiring, panel, loader, endpoint
- * usage, XSS-safe rendering, and Dashboard-Standard copy (plain-language intro).
+ * usage, the glance render path, #1429 commit-on-blur, and XSS-safe rendering.
  */
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
@@ -10,6 +12,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const HTML = fs.readFileSync(path.resolve(__dirname, '../../dashboard/index.html'), 'utf-8');
+const GLANCE = fs.readFileSync(path.resolve(__dirname, '../../dashboard/glance.js'), 'utf-8');
 
 describe('dashboard: Machines tab', () => {
   it('has a Machines tab button wired to switchTab', () => {
@@ -17,8 +20,9 @@ describe('dashboard: Machines tab', () => {
     expect(HTML).toContain(`switchTab('machines')`);
   });
 
-  it('has a machinesPanel container', () => {
+  it('has a machinesPanel container with a glance root', () => {
     expect(HTML).toContain('id="machinesPanel"');
+    expect(HTML).toContain('id="machinesGlance"');
   });
 
   it('registers the machines tab in TAB_REGISTRY (panels: [machinesPanel])', () => {
@@ -37,27 +41,41 @@ describe('dashboard: Machines tab', () => {
     expect(HTML).toContain(`apiFetch('/pool')`);
   });
 
-  it('renames via PATCH /pool/machines/:id', () => {
+  it('renders through the shared glance component (F10/F11), not bespoke innerHTML cards', () => {
+    expect(HTML).toContain('glance.machinesGlanceSpec(document');
+    expect(HTML).toContain('glance.renderGlance(document');
+    // the old bespoke card renderer is gone
+    expect(HTML).not.toContain('renderMachineCard');
+  });
+
+  it('enriches the Safety-checks tile with the named guards from /guards', () => {
+    expect(HTML).toMatch(/apiFetch\('\/guards'\)/);
+  });
+
+  it('#1429: renames via PATCH /pool/machines/:id, committing only on Enter/blur', () => {
     expect(HTML).toContain('async function saveMachineNickname');
     expect(HTML).toContain(`'/pool/machines/'`);
     expect(HTML).toMatch(/method:\s*'PATCH'/);
+    // The editable nickname lives in the glance record and commits on blur / Enter —
+    // NOT on every input event (the #1429 defect).
+    expect(GLANCE).toContain("input.addEventListener('blur', commit)");
+    expect(GLANCE).toMatch(/keydown[\s\S]{0,80}Enter[\s\S]{0,40}blur\(\)/);
+    expect(GLANCE).not.toMatch(/addEventListener\('input',\s*commit/);
   });
 
-  it('renders machine values XSS-safely (escapeHtml on dynamic fields)', () => {
-    // The render function must escape the nickname + machineId it injects.
-    expect(HTML).toMatch(/escapeHtml\(nick\)/);
-    expect(HTML).toMatch(/escapeHtml\(m\.machineId\)/);
+  it('renders machine values XSS-safely via the glance sanitizer (no innerHTML)', () => {
+    // The glance component displays nicknames / free text through sanitizeForDisplay.
+    expect(GLANCE).toMatch(/sanitizeForDisplay\(m\.nickname/);
+    expect(GLANCE).toContain('export function machineRowText');
   });
 
-  it('uses Dashboard-Standard plain-language copy (grounding intro, no jargon)', () => {
-    // The intro must explain in plain terms; the dispatcher/nickname are described
-    // without raw machineId-speak. (Dashboard Standard: ELI16, grounding intro.)
-    expect(HTML).toContain('Every computer this agent is set up on');
-    expect(HTML).toContain('move this conversation to the mini');
-    expect(HTML).toContain('dispatcher'); // codename-mapped router role
+  it('uses Dashboard-Standard plain-language copy (glance intro, no jargon)', () => {
+    expect(HTML).toContain('Every computer this agent runs on, at a glance');
+    expect(HTML).toContain('dispatcher'); // codename-mapped router role, described plainly
   });
 
   it('shows a calm clock-out-of-sync status (not an alarm) for a quarantined machine', () => {
-    expect(HTML).toContain('clock out of sync — paused for new conversations');
+    // The plain status word now lives in the shared component (glance.js).
+    expect(GLANCE).toContain('Clock out of sync — paused for new conversations');
   });
 });


### PR DESCRIPTION
## What & why

Phase 3 of the Dashboard Glance redesign (topic 29836, [dashboard-ux-standard.md](docs/specs/dashboard-ux-standard.md)): the four most jargon-heavy tabs — **Machines, Health, Spend, Routing Map** — rebuilt onto the shared three-layer glance component (`dashboard/glance.js`) that Phases 1–2 shipped for Commitments and Blockers. Each front page becomes **one plain-English headline + ≤5 labeled tiles** (Layer 1); tapping a tile reveals the rows behind that number in plain words (Layer 2); tapping a row opens the full record where the IDs, config keys, and raw detail live (Layer 3). Nothing is lost — the insider vocabulary moves one or two clicks down.

Every builder derives its counts from **one population**, so the headline can never diverge from the drill-down, and every dynamic value is displayed through the shared `sanitizeForDisplay` + `textContent` (XSS-safe by construction).

### Per tab
- **Machines** — headline like *"1 of 2 machines online; 1 needs a look."* over **Online / Attention needed / Dispatcher / Safety-checks** tiles. The old insider guards line (`67 on (16 confirmed) · ⚠ 6 off that should be on…`) became **named safety checks with a one-line plain-English explanation each** (Layer 2, from `GET /guards`), full guard posture at Layer 3. **Folds issue #1429**: the nickname edit now commits **only on Enter/blur** (not on every keystroke), with optimistic local echo, and the 15s poll **holds an open rename** (F9) instead of stealing focus; the poll stays authority for external renames.
- **Health** (the `systems` tab) — the ~390-word subsystem prose became *"All systems are operational."* / *"N subsystems need attention."* over **Subsystems / Need attention / Recent events** tiles. Each subsystem's full description, processes, and metrics move to its Layer-3 record.
- **Spend** — *"Nothing is being billed per-call right now."* over **Estimated cost / Text processed / Pay-per-use access** tiles. "Metered / paid door / reflows" reads as plain **"pay-per-use"** at the glance; the per-model pricing math and the paid-door caps drill down.
- **Routing Map** — *"Background AI work runs on Claude Haiku, with GPT as backup."* over one plain-named tile per lane (**Quick tasks / Sorting / Judging / Writing**) + a **Job types** tile. "Lane / nature / door" became plain words; the ordered model lists and full door/model config live at Layer 2/3. Model names are stripped of version/date noise and jargon-guarded so a raw model id can never leak to the glance.

### Ratchet
Machines, Health (`systems`), Spend, and Routing Map leave the F10/F11 grandfather list (`GLANCE_GRANDFATHERED_CEILING` **24 → 20**). The ratchet is structural: the completeness + monotonicity tests fail the build if a tab is unclassified or the list grows.

## ELI16

The dashboard has four screens that were full of insider computer-speak — the Machines page, the Health page, the Spend page, and the Routing Map page. If you opened them you'd see things like "67 on (16 confirmed), 6 off that should be on", "metered paid door", and "lane / nature / door". Unless you built the system, none of that told you what was actually going on. This change rewrites all four so the top of each screen is one plain sentence — for example "1 of 2 machines online; 1 needs a look" or "Nothing is being billed per-call right now" — followed by a few big number tiles in everyday words. If you want the nerdy detail, you tap a tile to see the list behind that number, and tap a row to see the full record. Nothing was deleted; the detail just moved one or two taps down instead of shouting on the front page. It also fixes a real bug on the Machines page: renaming a computer used to save on every single keystroke (so half-typed names like "the m" got saved), and the auto-refresh would yank your cursor out mid-edit. Now a rename only saves when you press Enter or click away, and the refresh leaves you alone while you're typing.

## Tests (all three tiers, all green)
- **Unit** — `tests/unit/dashboard-glance-word-budget.test.ts` (F10: adversarial fixtures for all four builders — large N, null/empty/error, jargon-laden free text — always produce a conforming glance) and `tests/unit/dashboard-glance-drilldown.test.ts` (F11: walk every tile of every new tab → non-empty distinct Layer-2 or honest empty-state, row → Layer-3 record; plus the #1429 commit-on-blur, F9 hold, and XSS negative controls). Updated `dashboard-machinesTab.test.ts` for the rebuild.
- **Integration** — `tests/integration/glance-jargon-belt-tabs.test.ts` drives each builder against the real HTTP routes (`/pool`, `/systems/status`, and the dark-path 503s for `/intelligence/routing/chains` + `/routing-spend/summary`).
- **E2E** — `tests/e2e/glance-jargon-belt-lifecycle.test.ts` is the feature-is-alive proof (routes reachable / honestly dark, glance renders end-to-end, no XSS survives, the shipped `glance.js` exports every builder).

Verified live in a real browser (Playwright): all four glances render with the production CSS, tiles drill correctly, and the Machines record's rename field commits on blur.

## Notes
- No `src/*.ts` changes — dashboard assets ship via `express.static`, so already-deployed agents receive this on the normal update path (no `PostUpdateMigrator` entry needed; Migration Parity met by construction).
- Behavior preserved; the one dropped affordance is the Health tab's "click a stat to browse related content" cross-link (its underlying content remains reachable via each feature's own tab + API) — a reasonable scope boundary for the glance rebuild.

Closes #1429

🤖 Generated with [Claude Code](https://claude.com/claude-code)
