### PR TITLE
fix(mentor): make inbox-delivered prompts visible

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-11T06-25-14-083Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-11T06-25-14-083Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-11T06:25:14.083Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 126,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-11T06-25-52-101Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-11T06-25-52-101Z-unknown.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-11T06:25:52.101Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 126,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/MentorVisibleEcho.test.ts",
+      "howCaught": "Each successful mentor delivery starts at most one echo sequence; the pure planner caps it at three ordered sends, and the first failure terminates without retry. Tests prove the three-message steady-state bound and one-shot failure settling."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-11T06-26-39-043Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-11T06-26-39-043Z-unknown.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-11T06:26:39.043Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 126,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/MentorVisibleEcho.test.ts",
+      "howCaught": "Each successful mentor delivery starts at most one echo sequence; the pure planner caps it at three ordered sends, and the first failure terminates without retry. Tests prove the three-message steady-state bound and one-shot failure settling."
+    }
+  },
+  "verdict": "pass"
+}

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -879,6 +879,7 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     minIntervalMs: 600000, // 10-min floor between ticks (anti-forced-cadence)
     maxRoundsPerDay: 24,
     dailySpendCapUsd: 0.5,
+    visibleEcho: true,
     // The "just be Echo" autonomous-fix loop (MENTOR-AUTONOMOUS-FIX-LOOP-SPEC):
     // when enabled, the heartbeat keeps ONE full-tool Opus loop session alive on
     // the manual dogfooding loop (assign → observe → FIX as a fleet PR → report)

--- a/src/core/MentorVisibleEcho.ts
+++ b/src/core/MentorVisibleEcho.ts
@@ -1,0 +1,95 @@
+export const TELEGRAM_TEXT_LIMIT = 4096;
+export const MENTOR_ECHO_MAX_CHUNKS = 3;
+export const MENTOR_ECHO_SHORTENED = '…shortened for chat; full prompt was delivered';
+
+export interface VisibleEchoChunkPlan {
+  messages: string[];
+  bodyChunks: string[];
+  shortened: boolean;
+}
+
+function takeChunk(text: string, capacity: number): [string, string] {
+  if (text.length <= capacity) return [text, ''];
+  const window = text.slice(0, capacity);
+  const newline = window.lastIndexOf('\n');
+  const cut = newline > 0 ? newline + 1 : capacity;
+  return [text.slice(0, cut), text.slice(cut)];
+}
+
+/** Pure Telegram-safe planner. Prefix/part markers are included in the limit. */
+export function planMentorVisibleEcho(
+  body: string,
+  roleTag = '[mentor]',
+  maxChunks = MENTOR_ECHO_MAX_CHUNKS,
+): VisibleEchoChunkPlan {
+  for (let total = 1; total <= maxChunks; total += 1) {
+    let rest = body;
+    const bodyChunks: string[] = [];
+    for (let i = 1; i <= total; i += 1) {
+      const prefix = `${roleTag} (${i}/${total})\n`;
+      const [chunk, next] = takeChunk(rest, TELEGRAM_TEXT_LIMIT - prefix.length);
+      bodyChunks.push(chunk);
+      rest = next;
+    }
+    if (!rest) {
+      return {
+        bodyChunks,
+        messages: bodyChunks.map((chunk, i) => `${roleTag} (${i + 1}/${total})\n${chunk}`),
+        shortened: false,
+      };
+    }
+  }
+
+  let rest = body;
+  const bodyChunks: string[] = [];
+  for (let i = 1; i <= maxChunks; i += 1) {
+    const prefix = `${roleTag} (${i}/${maxChunks})\n`;
+    const tail = i === maxChunks ? `\n\n${MENTOR_ECHO_SHORTENED}` : '';
+    const [chunk, next] = takeChunk(rest, TELEGRAM_TEXT_LIMIT - prefix.length - tail.length);
+    bodyChunks.push(chunk);
+    rest = next;
+  }
+  return {
+    bodyChunks,
+    messages: bodyChunks.map((chunk, i) => {
+      const tail = i === maxChunks - 1 ? `\n\n${MENTOR_ECHO_SHORTENED}` : '';
+      return `${roleTag} (${i + 1}/${maxChunks})\n${chunk}${tail}`;
+    }),
+    shortened: true,
+  };
+}
+
+export interface MentorVisibleEchoOptions {
+  enabled: boolean;
+  bot?: { sendToTopic: (topicId: number, text: string) => Promise<unknown> };
+  topicId?: number;
+  roleTag: string;
+  log?: (line: string) => void;
+  reportFailure?: (reason: string) => void;
+}
+
+export async function sendMentorVisibleEcho(body: string, opts: MentorVisibleEchoOptions): Promise<void> {
+  const log = opts.log ?? console.log;
+  if (!opts.enabled) {
+    log('[mentor-echo] skipped outcome=disabled');
+    return;
+  }
+  if (!opts.bot || opts.topicId === undefined) {
+    log('[mentor-echo] skipped outcome=unconfigured');
+    return;
+  }
+  const plan = planMentorVisibleEcho(body, opts.roleTag);
+  let landed = 0;
+  for (let i = 0; i < plan.messages.length; i += 1) {
+    try {
+      await opts.bot.sendToTopic(opts.topicId, plan.messages[i]);
+      landed += 1;
+    } catch (err) {
+      const reason = `chunk ${i + 1}/${plan.messages.length} failed after ${landed} landed: ${err instanceof Error ? err.message : String(err)}`;
+      console.warn(`[mentor-echo] outcome=partial topic=${opts.topicId} ${reason}`);
+      try { opts.reportFailure?.(reason); } catch { /* @silent-fallback-ok: degradation reporting must never affect canonical delivery */ }
+      return;
+    }
+  }
+  log(`[mentor-echo] outcome=visible topic=${opts.topicId} chunks=${landed} shortened=${plan.shortened}`);
+}

--- a/src/scheduler/MentorOnboardingRunner.ts
+++ b/src/scheduler/MentorOnboardingRunner.ts
@@ -98,6 +98,8 @@ export interface MentorConfig {
    *  deliverA2aMessage, used both in the /a2a/inbox body and the Telegram
    *  fallback), so routing it here moves the entire exchange off the human topic. */
   mentorTopicId?: number;
+  /** Best-effort visible mirror of successful local-inbox mentor delivery. Default on. */
+  visibleEcho?: boolean;
   /**
    * Ordered onboarding backlog the mentor walks the mentee through (capability
    * checks, starter dev tasks). When set, an idle mentee gets the next concrete
@@ -136,6 +138,7 @@ export const DEFAULT_MENTOR_CONFIG: MentorConfig = {
   minIntervalMs: 600_000, // 10 min floor
   maxRoundsPerDay: 24,
   dailySpendCapUsd: 0.5,
+  visibleEcho: true,
   // botToken / menteeBotId / menteeTopicId default undefined → mentor wiring stays
   // dark until they are explicitly configured (per /mentor/bot-setup, future PR).
 };

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -173,6 +173,7 @@ import { BurnThrottleRunbook, type BurnThrottleConfig } from '../monitoring/Burn
 import { BurnVerifier } from '../monitoring/BurnVerifier.js';
 import { LlmRateGate } from '../monitoring/LlmRateGate.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+import { sendMentorVisibleEcho, type MentorVisibleEchoOptions } from '../core/MentorVisibleEcho.js';
 import { registerBurnDetectionSubscriber } from '../monitoring/BurnDetectionSubscriber.js';
 import { NativeModuleHealer } from '../memory/NativeModuleHealer.js';
 import { bridgeNativeHealToDegradation } from '../monitoring/NativeHealDegradationBridge.js';
@@ -3501,6 +3502,8 @@ export class AgentServer {
     /** Telegram fallback bits (mentor→mentee only). */
     telegramBot?: { sendToTopic: (topicId: number, text: string) => Promise<{ messageId: number }> };
     botToken?: string;
+    /** Observability mirror only — never participates in delivery authority. */
+    visibleEcho?: MentorVisibleEchoOptions;
   }): Promise<boolean> {
     const ledger = this.getOrCreateA2aLedger();
     const id = `a2a-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
@@ -3540,6 +3543,13 @@ export class AgentServer {
                 } as never);
               } catch { /* best-effort */ }
               console.log(`[a2a] delivered → ${opts.toAgent} via local /a2a/inbox (role=${opts.role}, corr=${opts.corr})`);
+              if (opts.visibleEcho) {
+                // Observability only: never delay or alter the canonical delivery
+                // return/ledger/outstanding state while Telegram is slow or down.
+                void sendMentorVisibleEcho(opts.body, opts.visibleEcho).catch((err) => {
+                  console.warn(`[mentor-echo] unexpected failure after delivery: ${err instanceof Error ? err.message : String(err)}`);
+                });
+              }
               return true;
             }
             console.warn(`[a2a] local /a2a/inbox refused (to=${opts.toAgent}, role=${opts.role}, reason=${result.reason ?? 'unknown'})`);
@@ -3963,6 +3973,23 @@ export class AgentServer {
               ? { sendToTopic: (t, txt) => telegramBot.sendToTopic(t, txt) }
               : undefined,
             botToken: cfg.botToken,
+            visibleEcho: {
+              enabled: cfg.visibleEcho !== false,
+              bot: telegramBot
+                ? { sendToTopic: (t, txt) => telegramBot.sendToTopic(t, txt) }
+                : undefined,
+              topicId: resolveMentorDeliveryTopic(cfg),
+              roleTag: '[mentor]',
+              reportFailure: (reason) => {
+                DegradationReporter.getInstance().report({
+                  feature: 'mentor.visible-echo',
+                  primary: 'successful inbox-local mentor delivery is mirrored visibly in Telegram',
+                  fallback: 'canonical /a2a/inbox delivery remains successful; operator may see a phantom prompt',
+                  reason,
+                  impact: 'mentor exchange was delivered but its visible chat mirror is partial or absent',
+                });
+              },
+            },
           });
           if (delivered) {
             self.appendMentorSent(options.config.stateDir, {

--- a/tests/unit/AgentServer-mentor-visible-echo-wiring.test.ts
+++ b/tests/unit/AgentServer-mentor-visible-echo-wiring.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import { AgentServer } from '../../src/server/AgentServer.js';
+
+const { listAgents, getAgentToken } = vi.hoisted(() => ({
+  listAgents: vi.fn(),
+  getAgentToken: vi.fn(),
+}));
+vi.mock('../../src/core/AgentRegistry.js', () => ({ listAgents }));
+vi.mock('../../src/messaging/AgentTokenManager.js', () => ({ getAgentToken }));
+
+describe('AgentServer mentor visible-echo wiring', () => {
+  it('runs the echo only inside successful inbox-local delivery, before fallback', () => {
+    const src = fs.readFileSync(new URL('../../src/server/AgentServer.ts', import.meta.url), 'utf8');
+    const localSuccess = src.indexOf('if (result.agentMessage === true)');
+    const echo = src.indexOf('void sendMentorVisibleEcho(opts.body, opts.visibleEcho)');
+    const fallback = src.indexOf('// ── Cross-machine Telegram fallback');
+    expect(localSuccess).toBeGreaterThan(-1);
+    expect(echo).toBeGreaterThan(localSuccess);
+    expect(echo).toBeLessThan(fallback);
+    expect(src.slice(fallback, fallback + 2000)).not.toContain('sendMentorVisibleEcho');
+  });
+
+  it('wires mentor prompts with default-on config, existing bot, and resolved topic', () => {
+    const src = fs.readFileSync(new URL('../../src/server/AgentServer.ts', import.meta.url), 'utf8');
+    expect(src).toContain('enabled: cfg.visibleEcho !== false');
+    expect(src).toContain("roleTag: '[mentor]'");
+    expect(src).toContain('topicId: resolveMentorDeliveryTopic(cfg)');
+    expect(src).toContain("feature: 'mentor.visible-echo'");
+  });
+
+  it('returns canonical local success immediately when the visible bot never resolves, with no fallback post', async () => {
+    listAgents.mockReturnValue([{ name: 'instar-codey', port: 4045 }]);
+    getAgentToken.mockReturnValue('peer-token');
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ agentMessage: true }),
+    } as Response);
+    const appendSent = vi.fn();
+    const server = Object.create(AgentServer.prototype) as AgentServer & Record<string, unknown>;
+    server.config = { projectName: 'echo' } as never;
+    server.getOrCreateA2aLedger = () => ({ appendSent }) as never;
+    const visibleSend = vi.fn(() => new Promise<never>(() => undefined));
+    const fallbackSend = vi.fn(async () => ({ messageId: 99 }));
+
+    const delivered = await Promise.race([
+      (server as any).deliverA2aMessage({
+        fromAgent: 'echo', toAgent: 'instar-codey', role: 'mentor', corr: 'c1', body: 'prompt',
+        allowedRoles: new Set(['mentor']), telegramTopicId: 458, toBotId: '2', botToken: '1:x',
+        telegramBot: { sendToTopic: fallbackSend },
+        visibleEcho: { enabled: true, topicId: 458, roleTag: '[mentor]', bot: { sendToTopic: visibleSend } },
+      }),
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 50)),
+    ]);
+
+    expect(delivered).toBe(true);
+    expect(appendSent).toHaveBeenCalledTimes(1);
+    expect(appendSent.mock.calls[0][0]).toMatchObject({ result: 'sent', transport: 'a2a-inbox-local' });
+    expect(visibleSend).toHaveBeenCalledTimes(1);
+    expect(fallbackSend).not.toHaveBeenCalled();
+    fetchMock.mockRestore();
+  });
+});

--- a/tests/unit/MentorVisibleEcho.test.ts
+++ b/tests/unit/MentorVisibleEcho.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  MENTOR_ECHO_SHORTENED,
+  TELEGRAM_TEXT_LIMIT,
+  planMentorVisibleEcho,
+  sendMentorVisibleEcho,
+} from '../../src/core/MentorVisibleEcho.js';
+
+describe('mentor visible echo', () => {
+  it.each([4096, 4097, 9000])('chunks %i body characters safely and reassembles exactly', (length) => {
+    const body = `${'line payload\n'.repeat(Math.ceil(length / 13))}`.slice(0, length);
+    const plan = planMentorVisibleEcho(body, '[mentor]');
+    expect(plan.shortened).toBe(false);
+    expect(plan.messages.length).toBeLessThanOrEqual(3);
+    expect(plan.messages.every((message) => message.length <= TELEGRAM_TEXT_LIMIT)).toBe(true);
+    expect(plan.bodyChunks.join('')).toBe(body);
+    plan.messages.forEach((message, i) => expect(message).toContain(`[mentor] (${i + 1}/${plan.messages.length})`));
+  });
+
+  it('caps pathological prompts at three messages with an honest shortened tail', () => {
+    const plan = planMentorVisibleEcho('x'.repeat(30_000), '[mentor]');
+    expect(plan.messages).toHaveLength(3);
+    expect(plan.shortened).toBe(true);
+    expect(plan.messages[2]).toContain(MENTOR_ECHO_SHORTENED);
+    expect(plan.messages.every((message) => message.length <= TELEGRAM_TEXT_LIMIT)).toBe(true);
+  });
+
+  it('posts tagged chunks to the configured topic in order', async () => {
+    const sent: Array<{ topic: number; text: string }> = [];
+    await sendMentorVisibleEcho('x'.repeat(9000), {
+      enabled: true,
+      topicId: 458,
+      roleTag: '[mentor]',
+      bot: { sendToTopic: async (topic, text) => { sent.push({ topic, text }); } },
+    });
+    expect(sent).toHaveLength(3);
+    expect(sent.every((row) => row.topic === 458)).toBe(true);
+    expect(sent.map((row) => row.text.replace(/^\[mentor\] \(\d\/\d\)\n/, '')).join('')).toBe('x'.repeat(9000));
+  });
+
+  it('reports one honest partial failure and never retries', async () => {
+    const send = vi.fn(async () => {
+      if (send.mock.calls.length === 2) throw new Error('telegram down');
+    });
+    const report = vi.fn();
+    await sendMentorVisibleEcho('x'.repeat(9000), {
+      enabled: true, topicId: 458, roleTag: '[mentor]', bot: { sendToTopic: send }, reportFailure: report,
+    });
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report.mock.calls[0][0]).toContain('chunk 2/3 failed after 1 landed');
+  });
+
+  it('skips honestly when unconfigured or opted out', async () => {
+    const log = vi.fn();
+    const send = vi.fn();
+    await sendMentorVisibleEcho('prompt', { enabled: true, roleTag: '[mentor]', log });
+    await sendMentorVisibleEcho('prompt', {
+      enabled: false, topicId: 458, roleTag: '[mentor]', bot: { sendToTopic: send }, log,
+    });
+    expect(send).not.toHaveBeenCalled();
+    expect(log.mock.calls.flat().join(' ')).toContain('unconfigured');
+    expect(log.mock.calls.flat().join(' ')).toContain('disabled');
+  });
+});

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -402,38 +402,41 @@ describe('lint-dev-agent-dark-gate', () => {
       // ConfigDefaults (uniform +4 shift, no new/removed entries).
       '745': 'threadline.a2aCheckIn.enabled',
       '876': 'mentor.enabled',
-      '887': 'mentor.autonomousFix.enabled',
-      '902': 'mentee.enabled',
+      // mentor.visibleEcho is a fleet-on child setting under the existing dark
+      // mentor gate. It adds no `enabled: false` row and shifts every later
+      // attribution down by one; the hand-audited dotted-path set is unchanged.
+      '888': 'mentor.autonomousFix.enabled',
+      '903': 'mentee.enabled',
       // evolutionActions.autoExpiry adds a 10-line fleet-on/dry-run-first block;
       // no dark row is added, and every later attribution shifts by +10.
-      '972': 'prGate.classClosure.enabled',
+      '973': 'prGate.classClosure.enabled',
       // +21 lines below: spec #3's multiMachine.seamlessOrchestrator dev-gated
       // sub-block (docs/specs/llm-seamlessness-orchestrator.md) was inserted at the
       // TOP of the multiMachine block; it OMITS `enabled` (rides resolveDevAgentGate),
       // adds no map row, and shifts every subsequent `enabled:` line by +21.
-      '1056': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
-      '1060': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
-      '1067': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
-      '1077': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
-      '1314': 'multiMachine.sessionPool.enabled',
+      '1057': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
+      '1061': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
+      '1068': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
+      '1078': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
+      '1315': 'multiMachine.sessionPool.enabled',
       // #1367's moveIntent dev-gated sub-block was inserted under sessionPool
       // (docs/specs/nickname-move-intent-llm-rebuild.md); it OMITS `enabled` (rides
       // resolveDevAgentGate), adds no map row, and shifts the subsequent lines.
-      '1358': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
-      '1368': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '1397': 'multiMachine.sessionPool.holdForStability.enabled',
+      '1359': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
+      '1369': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '1398': 'multiMachine.sessionPool.holdForStability.enabled',
       // replicated-journal-compaction adds a 5-line compaction default block
       // above stateSync. It uses `run:false` (not an `enabled` gate), so the
       // attributed path set is unchanged and the four rows below shift by +5.
-      '1597': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1598': 'multiMachine.stateSync.threadlinePairing.enabled',
       // commitment-auto-expiry (2026-07-10): a 6-line `commitments.autoExpiry`
       // default sub-block was inserted above `promiseBeacon`/`cartographer`.
       // Its `enabled: true` literal is an explicit fleet-on default, not a dark
       // default, so it adds NO attributed dark-gate row; it shifts the cartographer
       // `enabled: false` rows below it DOWN by +6.
-      '1744': 'cartographer.freshnessSweep.enabled',
-      '1789': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1814': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1745': 'cartographer.freshnessSweep.enabled',
+      '1790': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1815': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/upgrades/eli16/mentor-drive-visible-echo.md
+++ b/upgrades/eli16/mentor-drive-visible-echo.md
@@ -4,6 +4,8 @@ The mentor and mentee are Telegram bots, and Telegram does not deliver one bot's
 
 This change keeps the local inbox as the one authoritative delivery path and adds a separate visible mirror only after the inbox has confirmed success. The mirror uses the mentor's already-configured bot and the same resolved mentor topic. If the mirror is disabled, not configured, or fails, the prompt remains delivered exactly as before: the return value, delivery ledger, outstanding-prompt tracking, and anti-ping-pong protections do not change.
 
+The mirror's child setting is fleet-on only inside the existing dark mentor gate. It is not a new dark-feature gate, so the hand-audited set of dark defaults stays unchanged.
+
 Telegram limits a message to 4096 characters, including labels and part markers. A pure chunk planner accounts for all overhead, prefers line boundaries, labels every part `[mentor] (i/N)`, preserves the original body byte-for-byte for ordinary multi-part prompts, and caps output at three messages. Pathological prompts end with an honest note that chat was shortened while the full prompt was delivered through the inbox. A mid-sequence error stops immediately, logs how many parts landed, and emits one degradation record without retrying.
 
 The mentee-reply direction has no equivalent sender-bot plumbing at this chokepoint, so this change does not manufacture a second transport. That remaining visible-reply channel gap stays tracked by framework issue `mentor-guardian-drive-channel-gap`; the invisible mentor-prompt defect is tracked by `mentor-drive-invisible-prompts`.

--- a/upgrades/eli16/mentor-drive-visible-echo.md
+++ b/upgrades/eli16/mentor-drive-visible-echo.md
@@ -1,0 +1,9 @@
+# Visible automated mentor delivery — ELI16
+
+The mentor and mentee are Telegram bots, and Telegram does not deliver one bot's message to another bot. Instar therefore uses a local server-to-server inbox when both agents are on the same machine. That transport correctly delivers the mentor's prompt, but it is invisible in the Telegram group. The operator sees the mentee answer something that never appeared in chat, which makes the exchange look incoherent.
+
+This change keeps the local inbox as the one authoritative delivery path and adds a separate visible mirror only after the inbox has confirmed success. The mirror uses the mentor's already-configured bot and the same resolved mentor topic. If the mirror is disabled, not configured, or fails, the prompt remains delivered exactly as before: the return value, delivery ledger, outstanding-prompt tracking, and anti-ping-pong protections do not change.
+
+Telegram limits a message to 4096 characters, including labels and part markers. A pure chunk planner accounts for all overhead, prefers line boundaries, labels every part `[mentor] (i/N)`, preserves the original body byte-for-byte for ordinary multi-part prompts, and caps output at three messages. Pathological prompts end with an honest note that chat was shortened while the full prompt was delivered through the inbox. A mid-sequence error stops immediately, logs how many parts landed, and emits one degradation record without retrying.
+
+The mentee-reply direction has no equivalent sender-bot plumbing at this chokepoint, so this change does not manufacture a second transport. That remaining visible-reply channel gap stays tracked by framework issue `mentor-guardian-drive-channel-gap`; the invisible mentor-prompt defect is tracked by `mentor-drive-invisible-prompts`.

--- a/upgrades/next/mentor-drive-visible-echo.md
+++ b/upgrades/next/mentor-drive-visible-echo.md
@@ -1,0 +1,22 @@
+# Visible automated mentor delivery
+
+## What Changed
+
+Successful same-machine mentor prompts delivered through `/a2a/inbox` are now mirrored into the configured mentor Telegram topic. The mirror is best-effort and cannot change canonical delivery success, ledger writes, outstanding-prompt state, or anti-ping-pong behavior. Messages are line-aware chunked under Telegram's 4096-character cap, limited to three posts, and report an honest partial failure without retrying.
+
+## Evidence
+
+- Boundary and chunk-order tests cover 4096, 4097, 9000, and pathological prompt sizes.
+- Failure, opt-out, missing-bot, local-only, config hot-read, mentor-runner, and reply-regression tests pass.
+- Build and docs-coverage pass.
+
+## What to Tell Your User
+
+Automated mentor prompts are now visible in the mentor chat topic instead of arriving invisibly through the server while only the mentee's reply appears. Long prompts are safely split into a small ordered sequence.
+
+## Summary of New Capabilities
+
+- Visible `[mentor]` echo for successful local inbox delivery.
+- Default-on `mentor.visibleEcho` off-switch.
+- Telegram-safe ordered chunking with a three-message flood cap.
+- Honest degradation reporting for partial or failed visible mirrors.

--- a/upgrades/side-effects/mentor-drive-visible-echo.md
+++ b/upgrades/side-effects/mentor-drive-visible-echo.md
@@ -9,6 +9,8 @@
 
 `AgentServer.deliverA2aMessage` accepts an optional observability-only visible echo. On confirmed `a2a-inbox-local` success, mentor delivery mirrors the original body through the existing mentor bot/topic. `MentorVisibleEcho` provides bounded line-aware chunking and one-shot failure reporting. `mentor.visibleEcho` defaults on inside the already-dark mentor system and can be disabled.
 
+CI repair: adding that fleet-on child shifted later line numbers in the dark-gate lint's hand-authored golden attribution map by one. The map was updated by hand; its 25 dotted paths remain unchanged.
+
 ## Decision-point inventory
 
 - Canonical a2a delivery — pass-through — remains authoritative and byte-identical.

--- a/upgrades/side-effects/mentor-drive-visible-echo.md
+++ b/upgrades/side-effects/mentor-drive-visible-echo.md
@@ -1,0 +1,84 @@
+# Side-Effects Review — Visible automated mentor delivery
+
+**Version / slug:** `mentor-drive-visible-echo`
+**Date:** `2026-07-10`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `framework_guard_review`
+
+## Summary of the change
+
+`AgentServer.deliverA2aMessage` accepts an optional observability-only visible echo. On confirmed `a2a-inbox-local` success, mentor delivery mirrors the original body through the existing mentor bot/topic. `MentorVisibleEcho` provides bounded line-aware chunking and one-shot failure reporting. `mentor.visibleEcho` defaults on inside the already-dark mentor system and can be disabled.
+
+## Decision-point inventory
+
+- Canonical a2a delivery — pass-through — remains authoritative and byte-identical.
+- Visible echo eligibility — add — structural: only confirmed local-inbox success, configured bot/topic, and enabled config.
+- Chunk cap — add — hard Telegram/flood invariant, maximum three messages.
+
+## 1. Over-block
+
+No canonical delivery is blocked. An opted-out or unconfigured echo is skipped after delivery. A visible sequence stops after its first failed chunk rather than retrying, preventing a retry storm or reordered duplicates.
+
+## 2. Under-block
+
+The mentee-reply direction lacks sender-bot plumbing at this chokepoint and is not mirrored here. It remains tracked by framework issue `mentor-guardian-drive-channel-gap`. <!-- tracked: framework-issue mentor-guardian-drive-channel-gap --> A process crash after inbox success but before the mirror can still leave that one exchange invisible; the canonical delivery remains durable/audited.
+
+## 3. Level-of-abstraction fit
+
+The single `deliverA2aMessage` chokepoint knows the actual transport outcome, so it is the only layer that can avoid double-posting Telegram fallback while mirroring local inbox success. Chunk planning is extracted as a pure core primitive. The mentor call site retains bot/topic/config ownership.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — the echo is an observability signal after authoritative delivery.
+
+The echo has no blocking power over delivery, the ledger, outstanding state, or anti-ping-pong. Structural Telegram size/flood limits constrain only the mirror transport.
+
+## 5. Interactions
+
+- **Shadowing:** echo runs only after inbox acceptance and ledger append; it cannot shadow delivery.
+- **Double-fire:** fallback delivery never calls the echo; the existing visible Telegram fallback remains singular.
+- **Races:** the fully-contained echo sequence is detached after canonical success so a hung Telegram call cannot delay delivery bookkeeping. Within that sequence, chunks are awaited sequentially; no parallel reorder. Failure stops once.
+- **Feedback loops:** the visible post is ordinary chat output, not a new a2a marker, so it cannot spawn a mentor loop.
+
+## 6. External surfaces
+
+Operators now see mentor prompts in the configured mentor topic. Up to three Telegram posts may result from one successful local delivery. A failed/partial mirror adds one DegradationReporter row and honest log. No ledger schema, topic creation, credential storage, or new endpoint is introduced.
+
+## 6b. Operator-surface quality
+
+No dashboard or form renderer changes; not applicable. The Telegram content leads with a plain role label and ordered part marker, contains no raw transport identifiers, and fits phone width through normal Telegram wrapping.
+
+## 7. Multi-machine posture
+
+**Machine-local by design:** the visible echo attaches only to same-machine `a2a-inbox-local` delivery. Cross-machine Telegram fallback is already visible and therefore must not echo. The bot posts once from the mentor's existing one-voice delivery process. No new durable state or URLs are introduced; the configured topic remains the routing owner.
+
+## 8. Rollback cost
+
+Revert and ship a patch. The additive config key can remain harmlessly unread. No migration, ledger repair, topic cleanup, or agent reset is required.
+
+## Conclusion
+
+The design makes the invisible transport observable without giving the mirror any authority. Independent review caused one material correction: the mirror was detached from the canonical return so a hung Telegram send cannot delay ledger/outstanding bookkeeping. Failure is bounded, loud, and non-retrying; fallback cannot double-post; volume cannot exceed three messages. Clear after reviewer re-check.
+
+## Class-Closure Declaration
+
+- **Defect class:** `unbounded-self-action`
+- **Closure:** guard
+- **Enforcement:** ratchet
+- **Citation:** `tests/unit/MentorVisibleEcho.test.ts`
+- **How caught:** each successful mentor delivery starts at most one echo sequence; the pure planner caps it at three ordered sends, and the first failure terminates without retry. Tests prove the three-message steady-state bound and one-shot failure settling.
+
+## Second-pass review
+
+**Reviewer:** `framework_guard_review`
+**Independent read of the artifact:** concur
+
+Concur with the revised review. The echo launches only after confirmed inbox-local acceptance and the local sent-ledger attempt, but is detached behind a terminal catch, so slow or hung Telegram cannot delay the `true` return that drives mentor sent-ledger/outstanding bookkeeping. The executable test proves a never-resolving visible send starts once while canonical delivery returns within the bound, local transport is ledgered, and the Telegram fallback is never invoked. Helper tests prove ordered messages within 4096 characters, exact reassembly, max-three honest shortening, and one report/no retry on mid-sequence rejection. Default-on remains nested inside the dark mentor configuration; mentee-reply scope remains honestly excluded and tracked.
+
+## Evidence pointers
+
+- `tests/unit/MentorVisibleEcho.test.ts`
+- `tests/unit/AgentServer-mentor-visible-echo-wiring.test.ts`
+- `tests/e2e/mentor-reply-via-inbox.test.ts`


### PR DESCRIPTION
## Summary

- mirror confirmed `a2a-inbox-local` mentor prompts into the existing mentor Telegram topic
- keep the mirror strictly observability-only: detached after canonical acceptance/ledgering, with no effect on delivery result, sent/outstanding state, anti-ping-pong, or fallback
- split safely under Telegram's 4096-character cap with ordered markers, line-aware boundaries, exact ordinary reassembly, and a maximum of three visible posts
- stop on the first chunk failure, report one honest degradation with landed count, and never retry-loop
- add default-on `mentor.visibleEcho` inside the already-dark mentor subsystem

## ELI16 — Show the prompt the mentee is answering

Telegram does not pass messages from one bot to another, so same-machine mentor prompts travel through Instar's local server inbox. That delivery works, but the group chat showed only the mentee's answer, making it look like a response to a phantom prompt. After the inbox confirms delivery, this change starts a separate visible mirror through the mentor's existing bot and topic. The mirror cannot delay or change real delivery—even a hung Telegram call leaves the canonical success and bookkeeping intact. Long prompts are split into at most three ordered Telegram-safe parts; extreme prompts end with an honest shortened-for-chat note because the full body already reached the mentee.

## Framework issues

- `mentor-drive-invisible-prompts` — fixed by this PR.
- `mentor-guardian-drive-channel-gap` — this PR fixes the mentor-prompt direction. The mentee-reply call site does not currently hold sender-bot plumbing, so it is not given a fabricated second transport here; that tracked entry remains the owner for the reply-direction visible channel.

## Verification

- focused mentor/config/reply suite: 39/39 green
- executable hung-echo boundary plus chunk/failure suite: 10/10 green
- build green
- docs coverage green
- independent messaging-path review concurred after requiring the mirror to be detached
- class-closure guard declares and tests the max-three/no-retry convergence bound
- full CI owns the matrix
