### PR TITLE
test(mesh): two-node replication harness — the Increment-2 entry gate (ownership-gated spawn)

### DIFF
--- a/docs/specs/two-node-harness-increment2-entry-gate.eli16.md
+++ b/docs/specs/two-node-harness-increment2-entry-gate.eli16.md
@@ -1,0 +1,24 @@
+# The two-machine test rig — what it is and why it matters (plain English)
+
+## What this is
+
+A permanent test rig that runs **two simulated machines inside one test run** — each with its own real ownership records, real replication between them (the same signed message path production uses, not a fake), and a real HTTP server with real authentication. On top of the rig sit the tests that drive the duplicate-conversation healer across both machines and prove, on every future code change, that:
+
+1. When the same conversation is live on two machines, the healer on the lead machine works out the rightful owner, fixes the records, and — this is the part that needs two machines — the OTHER machine's own records visibly agree before anything gets closed. The proof reads the other machine's answer over real HTTP with real auth, never by peeking at its files.
+2. When replication is delayed (the other machine hasn't heard the news yet), the healer escalates honestly after a bounded wait — exactly once, no spam — and then completes the heal by itself when the news finally arrives.
+
+## Why it exists
+
+The approved duplicate-session spec staged its rollout deliberately: stage 1 (already merged) only OBSERVES; stage 2 turns enforcement on for the development machines — but only once this rig is green in CI. That's the spec's own entry condition: "the two-node replication harness green in CI." This change makes that condition a real, checkable thing instead of a sentence in a document.
+
+It already paid for itself before shipping: driving the July-10 incident through the rig exposed that the healer would have paged the operator instead of self-healing in the incident's own shape (records already correct, only the sessions duplicated) — because every earlier test faked the one step the rig runs for real. That bug was fixed and proven healed on this rig before the stage-1 merge.
+
+## What it does NOT do
+
+- It flips **nothing**. No feature turns on. All four rollout switches stay exactly where stage 1 left them (dark / observe-only), and the other features stage 2 depends on (the durable message queue, the machine-takeover engine) keep their own rollout schedules untouched.
+- It is tests and test-support only — zero production code changes, zero behavior changes for any agent.
+- The scenarios stage 2b and later need (promise hand-off between machines, the terminate-time safety probe) are present as **visibly pending** entries — they show up in every test run as "todo" with the spec section that owns them, so they can't be quietly forgotten, and they can't falsely show green.
+
+## What you'd be agreeing to
+
+Nothing new — this implements a deliverable the already-approved spec names. It makes stage 2's entry gate objective: when someone asks "can enforcement turn on yet?", the answer starts with "is the two-node rig green in CI?" instead of anyone's recollection.

--- a/tests/e2e/duplicate-reconciliation-two-node.test.ts
+++ b/tests/e2e/duplicate-reconciliation-two-node.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Increment-2 ENTRY-GATE E2E (ownership-gated-spawn-and-judgment-within-floors
+ * §4 line 242 / §5 line 261): the duplicate-reconciliation lifecycle on a REAL
+ * two-node harness in which the replication hop is NOT stubbed — affirmative
+ * (L7) evidence that a lease-holder convergence write lands in the PEER
+ * machine's OWN registry view and arms the peer-side sweeper. Runs in CI as
+ * the Increment-2 entry gate: "is duplicate-reconciliation-two-node green?"
+ * is the objective gate question.
+ *
+ * The harness (tests/support/twoNodeOwnershipHarness.ts) runs, per node, the
+ * DURABLE ownership substrate + a real AgentServer; the reconciler under test
+ * is wired to REAL HTTP for every cross-machine read (probes, peer echo),
+ * mirroring the production deps in src/commands/server.ts — discovery is
+ * computed from both nodes' real /sessions listings, never a fed fixture.
+ *
+ * Also here: the §5 line 262 delayed-journal-replay case (echo timeout →
+ * ONE aggregated escalation → late replication → convergence observed on a
+ * later tick). The remaining §5 two-node scenarios are spec-anchored
+ * it.todo entries — visible in every test run, never silently green.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { makeTwoNodeHarness, HARNESS_AUTH } from '../support/twoNodeOwnershipHarness.js';
+import type { TwoNodeHarness, HarnessNode } from '../support/twoNodeOwnershipHarness.js';
+import { DuplicateSessionReconciler } from '../../src/monitoring/DuplicateSessionReconciler.js';
+import type { DuplicateCandidate, ReconcilerDeps } from '../../src/monitoring/DuplicateSessionReconciler.js';
+import type { BoundedJsonlAudit } from '../../src/core/BoundedJsonlAudit.js';
+
+type Row = Record<string, unknown>;
+
+async function authedJson<T>(url: string): Promise<T> {
+  const r = await fetch(url, { headers: { Authorization: `Bearer ${HARNESS_AUTH}` } });
+  if (!r.ok) throw new Error(`HTTP ${r.status} for ${url}`);
+  return (await r.json()) as T;
+}
+
+/**
+ * Wire a reconciler on node A whose every cross-machine read rides REAL HTTP —
+ * the production dep shapes from src/commands/server.ts, pointed at the
+ * harness nodes.
+ */
+function makeReconciler(h: TwoNodeHarness) {
+  const journalRows: Row[] = [];
+  const attention: Array<{ id: string; title: string; body: string }> = [];
+  const closeoutsArmed: Array<{ key: string; owner: string }> = [];
+  const nodes = () => [h.a, h.b];
+  const nodeById = (id: string): HarnessNode | undefined => nodes().find((n) => n.machineId === id);
+
+  const deps: ReconcilerDeps = {
+    selfMachineId: () => h.a.machineId,
+    holdsLease: () => true,
+    // The harness runs the DURABLE store on both nodes — honestly ready.
+    substrateReady: () => ({ ready: true }),
+    errorEpisodeOpen: () => false,
+    topicHasAuthorityInMotion: (sk) => {
+      const r = h.a.registry.read(sk);
+      return r?.status === 'transferring' || r?.status === 'placing';
+    },
+    // REAL discovery: both nodes' live /sessions listings over real HTTP,
+    // grouped by conversation — the production duplicateTopics computation.
+    discoverCandidates: async () => {
+      const byKey = new Map<string, DuplicateCandidate>();
+      for (const n of nodes()) {
+        const list = await authedJson<Array<Record<string, unknown>>>(`${n.url}/sessions`);
+        for (const s of Array.isArray(list) ? list : []) {
+          if (s.platform !== 'telegram' || s.platformId == null) continue;
+          const key = `telegram:${String(s.platformId)}`;
+          const cand = byKey.get(key) ?? { key, platform: 'telegram', platformId: String(s.platformId), machines: [] };
+          let m = cand.machines.find((x) => x.machineId === n.machineId);
+          if (!m) {
+            m = { machineId: n.machineId, sessions: [] };
+            cand.machines.push(m);
+          }
+          m.sessions.push(String(s.tmuxSession ?? s.name));
+          byKey.set(key, cand);
+        }
+      }
+      return { candidates: [...byKey.values()].filter((c) => c.machines.length >= 2) };
+    },
+    // Fresh direct probe over REAL HTTP (production shape: GET <machine>/sessions).
+    probeLiveCopy: async (machineId, key) => {
+      const n = nodeById(machineId);
+      if (!n) return { ok: false, live: false };
+      try {
+        const sep = key.indexOf(':');
+        const platform = key.slice(0, sep);
+        const pid = key.slice(sep + 1);
+        const list = await authedJson<Array<Record<string, unknown>>>(`${n.url}/sessions`);
+        const live = (Array.isArray(list) ? list : []).some(
+          (s) => String(s.platform) === platform && String(s.platformId) === pid,
+        );
+        return { ok: true, live };
+      } catch {
+        return { ok: false, live: false };
+      }
+    },
+    readPin: () => null,
+    readOwnershipViews: (sk) => {
+      const r = h.a.registry.read(sk);
+      if (!r || !h.a.registry.ownerOf(sk)) return [];
+      return [{ machineId: h.a.machineId, owner: h.a.registry.ownerOf(sk), epoch: r.ownershipEpoch, admissible: true }];
+    },
+    liveRunHosts: async () => [],
+    // The fenced convergence CAS + the journal emit that IS the replication
+    // path (production pairs emitPlacement('reconcile') — server.ts).
+    casConverge: (sk, owner) => {
+      const prevOwner = h.a.registry.read(sk)?.ownerMachineId;
+      const r = h.a.registry.cas(
+        { type: 'claim', machineId: owner },
+        { sessionKey: sk, sender: h.a.machineId, nonce: `dup-reconcile:${sk}:${journalRows.length}` },
+      );
+      if (r.ok) {
+        h.a.journal.emitPlacement(Number(sk), {
+          owner: r.record.ownerMachineId ?? owner,
+          ...(prevOwner ? { prevOwner } : {}),
+          epoch: r.record.ownershipEpoch,
+          reason: 'reconcile',
+        });
+      }
+      return r.ok ? { ok: true } : { ok: false, reason: String((r as { reason?: string }).reason ?? 'cas-refused') };
+    },
+    // Peer echo over REAL HTTP: the peer's OWN registry view via its
+    // Bearer-authed /pool/ownership-view (production shape).
+    peerEchoObserved: async (sk, owner, machineId) => {
+      const n = nodeById(machineId);
+      if (!n) return false;
+      const j = await authedJson<{ owner?: string | null }>(`${n.url}/pool/ownership-view?key=${encodeURIComponent(sk)}`);
+      return j.owner === owner;
+    },
+    armCloseout: (sk, owner) => closeoutsArmed.push({ key: sk, owner }),
+    raiseAttention: (item) => attention.push(item),
+    journal: { append: (r: Row) => journalRows.push(r) } as unknown as BoundedJsonlAudit,
+    log: () => {},
+  };
+
+  const reconciler = new DuplicateSessionReconciler(
+    {
+      enabled: true,
+      dryRun: false, // in-test construction, not a rollout-ladder flip
+      reconcilerTickMs: 60_000,
+      maxReconcilesPerTick: 5,
+      maxConvergenceWritesPerTick: 5,
+      echoConfirmTicks: 2,
+      breakerThreshold: 5,
+      breakerWindowMs: 86_400_000,
+    },
+    deps,
+  );
+  return { reconciler, journalRows, attention, closeoutsArmed };
+}
+
+describe('duplicate reconciliation — two-node lifecycle (Increment-2 entry gate)', () => {
+  let h: TwoNodeHarness;
+
+  beforeAll(async () => {
+    h = await makeTwoNodeHarness();
+  });
+
+  afterAll(async () => {
+    await h?.teardown();
+  });
+
+  it('L7 lifecycle: duplicate → converge on A → un-stubbed replication → B\'s OWN view echoes → peer-side sweeper armed', async () => {
+    const TOPIC = 777;
+    const sk = String(TOPIC);
+
+    // ── 1. The incident shape: A owns the conversation (durable record),
+    //       and BOTH nodes hold a live session for it (the bootleg copy).
+    const seed = h.a.registry.cas(
+      { type: 'place', machineId: h.a.machineId },
+      { sessionKey: sk, sender: h.a.machineId, nonce: 'seed-place-777' },
+    );
+    expect(seed.ok).toBe(true);
+    // placing→active confirmation (the production two-step: the owner claims
+    // its own placement — server.ts's post-spawn confirmation CAS).
+    const confirm = h.a.registry.cas(
+      { type: 'claim', machineId: h.a.machineId },
+      { sessionKey: sk, sender: h.a.machineId, nonce: 'seed-claim-777' },
+    );
+    expect(confirm.ok).toBe(true);
+    // Production pairs emitPlacement with every ownership CAS (the journal
+    // emit IS the replication path) — the seed placement mirrors that.
+    if (confirm.ok) {
+      h.a.journal.emitPlacement(TOPIC, { owner: h.a.machineId, epoch: confirm.record.ownershipEpoch, reason: 'placed' });
+    }
+    h.a.addLiveSession(TOPIC);
+    const bootlegCopy = h.b.addLiveSession(TOPIC);
+
+    // Sanity: B currently has NO owner record for the topic (its own view is dark).
+    expect(h.b.registry.ownerOf(sk)).toBeFalsy();
+
+    const { reconciler, journalRows, attention, closeoutsArmed } = makeReconciler(h);
+
+    // ── 2. Reconciler tick on the lease holder: REAL-HTTP discovery finds the
+    //       duplicate, fresh probes confirm both copies, the evidence ladder
+    //       names A (highest admissible epoch), the fenced CAS lands + the
+    //       placement is journaled with reason 'reconcile'.
+    const t1 = await reconciler.tick();
+    expect(t1.ran).toBe(true);
+    expect(t1.candidates).toBe(1);
+    expect(t1.reconciled).toBe(1);
+    // The incident's OWN shape: the record already names the owner (the
+    // bootleg spawn never wrote one) — healed via the no-epoch-burn skip.
+    expect(journalRows.some((r) => r.kind === 'record-already-converged' && r.rule === 'highest-epoch')).toBe(true);
+
+    // Echo NOT yet observed — nothing has replicated. No closeout armed.
+    expect(closeoutsArmed.length).toBe(0);
+
+    // ── 3. THE UN-STUBBED HOP: A's own journal stream → signed envelope →
+    //       B's real /mesh/rpc → B's sync applier → B's OWN replica stream.
+    const hop = await h.replicate(h.a, h.b);
+    expect(hop.applied).toBeGreaterThanOrEqual(1);
+    expect(hop.forgedEntries).toBe(0);
+
+    // ── 4. B materializes the replicated placement into its OWN durable store.
+    const mat = h.applierTick(h.b);
+    expect(mat.materialized).toBeGreaterThanOrEqual(1);
+
+    // L7 affirmative evidence, read through B's REAL Bearer-authed HTTP surface
+    // (never a direct store read): B's OWN view now names the converged owner.
+    const bView = await authedJson<{ owner: string | null; epoch: number }>(
+      `${h.b.url}/pool/ownership-view?key=${sk}`,
+    );
+    expect(bView.owner).toBe(h.a.machineId);
+    expect(bView.epoch).toBeGreaterThanOrEqual(2); // seed place + confirm-claim (the heal burns NO epoch)
+
+    // ── 5. Next reconciler tick: the peer echo (REAL HTTP against B) confirms;
+    //       the closeout is armed for the non-owner copy via the EXISTING
+    //       gated sweeper path (the reconciler itself never kills).
+    const t2 = await reconciler.tick();
+    expect(t2.echoConfirmed).toBe(1);
+    expect(journalRows.some((r) => r.kind === 'echo-confirmed')).toBe(true);
+    expect(closeoutsArmed).toEqual([{ key: sk, owner: h.a.machineId }]);
+
+    // The peer-side sweeper predicate (§2.3 topicOwnerElsewhere): B's OWN
+    // registry now says the owner is NOT B — exactly what arms B's closeout.
+    expect(h.b.registry.ownerOf(sk)).toBe(h.a.machineId);
+    expect(h.b.registry.ownerOf(sk)).not.toBe(h.b.machineId);
+
+    // Zero escalations on the happy path.
+    expect(attention.length).toBe(0);
+
+    // FD15 calibration input: log the measured journal-hop latency.
+    // eslint-disable-next-line no-console
+    console.log(`[FD15] journal-hop latency ms: ${JSON.stringify(h.b.hopLatenciesMs)}`);
+
+    // What the armed closeout does next (its own gated path, out of scope
+    // here): the non-owner copy closes. Simulate the close so the shared
+    // harness carries no live duplicate into the next scenario.
+    h.b.endSession(bootlegCopy.tmuxSession);
+  });
+
+  it('delayed journal replay (§5): echo timeout → ONE aggregated escalation; late replication → convergence observed on a later tick', async () => {
+    const TOPIC = 888;
+    const sk = String(TOPIC);
+    const seed = h.a.registry.cas(
+      { type: 'place', machineId: h.a.machineId },
+      { sessionKey: sk, sender: h.a.machineId, nonce: 'seed-place-888' },
+    );
+    expect(seed.ok).toBe(true);
+    const confirm = h.a.registry.cas(
+      { type: 'claim', machineId: h.a.machineId },
+      { sessionKey: sk, sender: h.a.machineId, nonce: 'seed-claim-888' },
+    );
+    expect(confirm.ok).toBe(true);
+    if (confirm.ok) {
+      h.a.journal.emitPlacement(TOPIC, { owner: h.a.machineId, epoch: confirm.record.ownershipEpoch, reason: 'placed' });
+    }
+    h.a.addLiveSession(TOPIC);
+    const lateCopy = h.b.addLiveSession(TOPIC);
+
+    const { reconciler, journalRows, attention } = makeReconciler(h);
+
+    // Tick 1: converge on A. Replication is WITHHELD (the delayed-replay fault).
+    const t1 = await reconciler.tick();
+    expect(t1.reconciled).toBe(1);
+
+    // Ticks 2-3: echoConfirmTicks(2) exhaust without the peer ever showing the
+    // repair → ONE aggregated convergence-not-observed escalation (P17).
+    await reconciler.tick();
+    const t3 = await reconciler.tick();
+    expect(t3.echoTimeouts).toBe(1);
+    const escalations = attention.filter((a) => a.title.includes('Convergence not observed'));
+    expect(escalations.length).toBe(1);
+    expect(escalations[0].body).toContain(`telegram:${TOPIC}`);
+    expect(journalRows.some((r) => r.kind === 'convergence-not-observed')).toBe(true);
+
+    // The LATE replay arrives: replicate + materialize on B.
+    const hop = await h.replicate(h.a, h.b);
+    expect(hop.applied).toBeGreaterThanOrEqual(1);
+    h.applierTick(h.b);
+
+    // A later tick re-detects the still-live duplicate; the record is already
+    // right (record-already-converged — no new CAS, no epoch burn), so the
+    // echo window re-opens, and the following tick confirms against B's
+    // late-materialized view.
+    const t4 = await reconciler.tick();
+    expect(t4.reconciled).toBe(1);
+    const t5 = await reconciler.tick();
+    expect(t5.echoConfirmed).toBe(1);
+    expect(h.b.registry.ownerOf(sk)).toBe(h.a.machineId);
+
+    // Simulate the armed closeout so the shared harness carries no live
+    // duplicate into the next scenario.
+    h.b.endSession(lateCopy.tmuxSession);
+  });
+
+  // ── Remaining §5 two-node scenarios — spec-anchored, visibly pending ──
+  // (never silently green; each lands with the increment that builds its
+  // mechanics, per the staged rollout the operator approved)
+
+  it('§5: partition-formed duplicates heal on merge — the higher-epoch claim wins after both-ways replication, no operator involved', async () => {
+    const TOPIC = 999;
+    const sk = String(TOPIC);
+
+    // ── The partition: BOTH nodes independently placed + claimed the topic
+    //    while they could not hear each other. B additionally moved the
+    //    conversation (transfer + abort — two more fenced epochs), so B's
+    //    claim carries the STRONGER history. Every CAS pairs emitPlacement
+    //    (the production chokepoint discipline).
+    const aPlace = h.a.registry.cas({ type: 'place', machineId: h.a.machineId }, { sessionKey: sk, sender: h.a.machineId, nonce: 'p-a-999' });
+    expect(aPlace.ok).toBe(true);
+    const aClaim = h.a.registry.cas({ type: 'claim', machineId: h.a.machineId }, { sessionKey: sk, sender: h.a.machineId, nonce: 'c-a-999' });
+    expect(aClaim.ok).toBe(true);
+    if (aClaim.ok) h.a.journal.emitPlacement(TOPIC, { owner: h.a.machineId, epoch: aClaim.record.ownershipEpoch, reason: 'placed' });
+
+    const bPlace = h.b.registry.cas({ type: 'place', machineId: h.b.machineId }, { sessionKey: sk, sender: h.b.machineId, nonce: 'p-b-999' });
+    expect(bPlace.ok).toBe(true);
+    const bClaim = h.b.registry.cas({ type: 'claim', machineId: h.b.machineId }, { sessionKey: sk, sender: h.b.machineId, nonce: 'c-b-999' });
+    expect(bClaim.ok).toBe(true);
+    const bXfer = h.b.registry.cas({ type: 'transfer', to: h.b.machineId }, { sessionKey: sk, sender: h.b.machineId, nonce: 't-b-999' });
+    expect(bXfer.ok).toBe(true);
+    const bAbort = h.b.registry.cas({ type: 'abort-transfer', machineId: h.b.machineId }, { sessionKey: sk, sender: h.b.machineId, nonce: 'x-b-999' });
+    expect(bAbort.ok).toBe(true);
+    if (bAbort.ok) h.b.journal.emitPlacement(TOPIC, { owner: h.b.machineId, epoch: bAbort.record.ownershipEpoch, reason: 'failover' });
+
+    const aEpoch = aClaim.ok ? aClaim.record.ownershipEpoch : 0;
+    const bEpoch = bAbort.ok ? bAbort.record.ownershipEpoch : 0;
+    expect(bEpoch).toBeGreaterThan(aEpoch); // the asymmetry under test
+
+    // Both copies live (the partition left a session on each side).
+    h.a.addLiveSession(TOPIC);
+    const aCopy = h.b.addLiveSession(TOPIC); // b's copy — expected survivor is B
+    void aCopy;
+
+    // ── The MERGE: replication flows both ways; each applier materializes
+    //    the strictly-newer history. A adopts B's higher-epoch record; B
+    //    ignores A's older one (epoch-gated fast-forward — never a clobber).
+    await h.replicate(h.a, h.b);
+    await h.replicate(h.b, h.a);
+    h.applierTick(h.a);
+    h.applierTick(h.b);
+    expect(h.a.registry.ownerOf(sk)).toBe(h.b.machineId); // A adopted B's claim
+    expect(h.b.registry.ownerOf(sk)).toBe(h.b.machineId); // B kept its own
+
+    // ── The reconciler on the lease holder now sees a duplicate whose record
+    //    (A's own materialized view) already names B → the no-epoch-burn skip
+    //    → echo against B's REAL HTTP view confirms → closeout armed for the
+    //    non-owner copy. Zero escalations, zero operator involvement.
+    const { reconciler, attention, closeoutsArmed } = makeReconciler(h);
+    const t1 = await reconciler.tick();
+    expect(t1.reconciled).toBe(1);
+    const t2 = await reconciler.tick();
+    expect(t2.echoConfirmed).toBe(1);
+    expect(closeoutsArmed).toEqual([{ key: sk, owner: h.b.machineId }]);
+    expect(attention.length).toBe(0);
+  });
+  it.todo('§5 line 262: registry-error episode freezes the reconciler + bounded fail-open, with post-recovery convergence (§3.1 row e two-node)');
+  it.todo('§5 line 260: EVERY duplicate-reconciled/topic-moved termination closes ONLY with the terminate-time live-owner probe confirmed (blocked on the SessionReaper duplicate-reconciled reap-reason extension)');
+  it.todo('§4 line 243 / §3.2.4a: commitment-custody transfer two-node E2E — origin commitment on A, survivor on B, successor minted on B, A\'s record terminal-superseded (blocked on Increment 2b: the custody mechanics are deliberately NOT built in Increment 1)');
+});

--- a/tests/support/twoNodeOwnershipHarness.ts
+++ b/tests/support/twoNodeOwnershipHarness.ts
@@ -1,0 +1,275 @@
+// safe-fs-allow: harness teardown uses SafeFsExecutor.safeRmSync on tmp dirs only.
+/**
+ * Two-node ownership harness — the Increment-2 entry-gate substrate
+ * (ownership-gated-spawn-and-judgment-within-floors §4/§5: "the two-node
+ * replication harness green in CI"; "a real two-node harness in which the
+ * replication hop is NOT stubbed").
+ *
+ * Fuses three proven patterns:
+ *  - journal-sync-roundtrip.test.ts — the un-stubbed signed replication hop
+ *    (CoherenceJournal → JournalSyncApplier serve → signed MeshRpc envelope →
+ *    peer JournalSyncApplier receive → CoherenceJournalReader replica);
+ *  - mesh-failover-2server.test.ts — two real HTTP servers in one process;
+ *  - ownership-gated-spawn-alive.test.ts — the REAL AgentServer (real auth
+ *    middleware — the PR #1295 lesson) with injected ownership components.
+ *
+ * Each node runs the DURABLE substrate (LocalSessionOwnershipStore — the
+ * §3.2.0 precondition, unlike the fleet-default in-memory store), a real
+ * SessionOwnershipRegistry, a CoherenceJournal writer, both halves of the
+ * journal-sync applier, an OwnershipApplier (peer-record materialization),
+ * and a real AgentServer serving `/sessions` + `/pool/ownership-view` over
+ * real Bearer auth.
+ *
+ * Everything is CALLER-PACED (no wall-clock waits): `replicate(from, to)`
+ * pushes one signed serve-batch over real HTTP; `applierTick(node)`
+ * materializes whatever has landed. Wall-clock cost stays well inside the
+ * 60s e2e timeout.
+ */
+import express from 'express';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { MeshRpcDispatcher, type MeshCommand, type MeshEnvelope } from '../../src/core/MeshRpc.js';
+import { MeshRpcClient } from '../../src/core/MeshRpcClient.js';
+import { generateSigningKeyPair, sign, verify } from '../../src/core/MachineIdentity.js';
+import { CoherenceJournal } from '../../src/core/CoherenceJournal.js';
+import { JournalSyncApplier, type ApplyBatchStream } from '../../src/core/JournalSyncApplier.js';
+import { CoherenceJournalReader } from '../../src/core/CoherenceJournalReader.js';
+import { OwnershipApplier } from '../../src/core/OwnershipApplier.js';
+import { LocalSessionOwnershipStore } from '../../src/core/LocalSessionOwnershipStore.js';
+import { SessionOwnershipRegistry } from '../../src/core/SessionOwnershipRegistry.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { InstarConfig } from '../../src/core/types.js';
+
+export const HARNESS_AUTH = 'two-node-harness-bearer';
+
+/** A live conversation-bound session on a node (drives GET /sessions). */
+export interface HarnessLiveSession {
+  tmuxSession: string;
+  topicId: number;
+}
+
+export interface HarnessNode {
+  machineId: string;
+  url: string;
+  stateDir: string;
+  /** The DURABLE store (§3.2.0 substrate precondition). */
+  store: LocalSessionOwnershipStore;
+  registry: SessionOwnershipRegistry;
+  journal: CoherenceJournal;
+  reader: CoherenceJournalReader;
+  syncApplier: JournalSyncApplier;
+  ownershipApplier: OwnershipApplier;
+  state: StateManager;
+  /**
+   * Register a LIVE conversation-bound session on this node — lands in the
+   * REAL StateManager registry (what GET /sessions serves) plus the telegram
+   * mock's session→topic map (what the route's platform enrichment reads).
+   */
+  addLiveSession: (topicId: number) => HarnessLiveSession;
+  /** Close a session (status completed) — it drops out of the default listing. */
+  endSession: (tmux: string) => void;
+  server: AgentServer;
+  /** Journal-hop latency samples (FD15 calibration input), ms per replicate. */
+  hopLatenciesMs: number[];
+  stop: () => Promise<void>;
+}
+
+export interface TwoNodeHarness {
+  a: HarnessNode;
+  b: HarnessNode;
+  /**
+   * ONE un-stubbed replication hop: build `from`'s own-stream serve batch and
+   * deliver it to `to` as a signed, recipient-bound `journal-sync` envelope
+   * over `to`'s REAL /mesh/rpc route. Returns the applier result.
+   */
+  replicate: (from: HarnessNode, to: HarnessNode) => Promise<{ applied: number; forgedEntries: number }>;
+  /** Materialize whatever replicated placements have landed on `node`. */
+  applierTick: (node: HarnessNode) => { examined: number; materialized: number };
+  teardown: () => Promise<void>;
+}
+
+function baseConfig(stateDir: string, projectDir: string): InstarConfig {
+  return {
+    projectName: 'two-node-e2e', projectDir, stateDir, port: 0, authToken: HARNESS_AUTH,
+    requestTimeoutMs: 10000, version: '0.0.0',
+    sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+    scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+    messaging: [], monitoring: {}, updates: {},
+  } as unknown as InstarConfig;
+}
+
+export async function makeTwoNodeHarness(): Promise<TwoNodeHarness> {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'two-node-ownership-'));
+  const keys: Record<string, { priv: string; pub: string }> = {};
+  const seenNonces = new Set<string>();
+  let nonceSeq = 0;
+
+  async function makeNode(machineId: string): Promise<HarnessNode> {
+    const stateDir = path.join(tmpRoot, machineId);
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'two-node-e2e', agentName: 'E2E' }));
+    const kp = generateSigningKeyPair();
+    keys[machineId] = { priv: kp.privateKey, pub: kp.publicKey };
+
+    const store = new LocalSessionOwnershipStore({ dir: path.join(stateDir, 'state', 'ownership') });
+    const casNonces = new Set<string>();
+    const registry = new SessionOwnershipRegistry({
+      store,
+      seenNonce: (k) => casNonces.has(k),
+      recordNonce: (k) => casNonces.add(k),
+    });
+    const journal = new CoherenceJournal({ stateDir, machineId, flushIntervalMs: 1_000_000 /* manual flush */ });
+    journal.open();
+    const syncApplier = new JournalSyncApplier({ stateDir });
+    const reader = new CoherenceJournalReader({ stateDir });
+    const ownershipApplier = new OwnershipApplier({
+      reader,
+      store,
+      selfMachineId: machineId,
+    });
+
+    const dispatcher = new MeshRpcDispatcher({
+      verify: {
+        selfMachineId: machineId,
+        verify: (c, s, sender) => !!keys[sender] && verify(c, s, keys[sender].pub),
+        isRegisteredPeer: (s) => !!keys[s],
+        seenNonce: (s, nn) => seenNonces.has(`${machineId}:${s}:${nn}`),
+        now: () => Date.now(),
+      },
+      rbac: { routerHolder: () => null, ownerOf: () => null, placementTargetOf: () => null },
+      recordNonce: (s, nn) => seenNonces.add(`${machineId}:${s}:${nn}`),
+      handlers: {
+        'journal-sync': (cmd: MeshCommand, _sender: string, env: MeshEnvelope) => {
+          const c = cmd as MeshCommand & { type: 'journal-sync'; batch?: ApplyBatchStream[] };
+          if (c.batch) {
+            // First-hop sender binding — bind to the AUTHENTICATED envelope sender.
+            const r = syncApplier.apply(env.sender, c.batch);
+            return { ok: true, result: r };
+          }
+          return { ok: true };
+        },
+      },
+    });
+
+    const state = new StateManager(stateDir);
+    // The /sessions route's platform enrichment reads the telegram adapter's
+    // session→topic map (optional-chained) — a two-method mock suffices.
+    const sessionTopic = new Map<string, number>();
+    const telegramMock = {
+      getTopicForSession: (tmux: string) => sessionTopic.get(tmux) ?? null,
+      getTopicName: () => null,
+    };
+    const server = new AgentServer({
+      config: baseConfig(stateDir, tmpRoot),
+      sessionManager: {
+        listRunningSessions: () => [],
+        getSession: () => null,
+      } as never,
+      state,
+      telegram: telegramMock as never,
+      sessionOwnershipRegistry: registry,
+      meshRpcDispatcher: dispatcher,
+    });
+    await server.start();
+    const app = server.getApp();
+    const httpServer = await new Promise<{ url: string; close: () => Promise<void> }>((resolve) => {
+      const srv = app.listen(0, () => {
+        const addr = srv.address() as { port: number };
+        resolve({ url: `http://127.0.0.1:${addr.port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+      });
+    });
+
+    let sessionSeq = 0;
+    const addLiveSession = (topicId: number): HarnessLiveSession => {
+      const tmux = `${machineId}-s${++sessionSeq}`;
+      state.saveSession({
+        id: tmux,
+        name: tmux,
+        status: 'running',
+        tmuxSession: tmux,
+        startedAt: new Date().toISOString(),
+      });
+      sessionTopic.set(tmux, topicId);
+      return { tmuxSession: tmux, topicId };
+    };
+    const endSession = (tmux: string): void => {
+      const existing = state.listSessions().find((x) => x.tmuxSession === tmux);
+      if (existing) state.saveSession({ ...existing, status: 'completed', endedAt: new Date().toISOString() });
+    };
+    return {
+      machineId,
+      url: httpServer.url,
+      stateDir,
+      store,
+      registry,
+      journal,
+      reader,
+      syncApplier,
+      ownershipApplier,
+      state,
+      addLiveSession,
+      endSession,
+      server,
+      hopLatenciesMs: [],
+      stop: async () => {
+        try { journal.close(); } catch { /* teardown best-effort */ }
+        await httpServer.close();
+        await server.stop();
+      },
+    };
+  }
+
+  const a = await makeNode('m_node_a');
+  const b = await makeNode('m_node_b');
+
+  /** Track per-(from,to,kind) replication cursors so repeat hops serve deltas. */
+  const cursors = new Map<string, number>();
+
+  async function replicate(from: HarnessNode, to: HarnessNode): Promise<{ applied: number; forgedEntries: number }> {
+    const t0 = Date.now();
+    from.journal.flush();
+    const key = `${from.machineId}->${to.machineId}:topic-placement`;
+    const fromSeq = cursors.get(key) ?? 0;
+    const served = from.syncApplier.buildServeBatch('topic-placement', fromSeq, from.machineId);
+    const client = new MeshRpcClient({
+      selfMachineId: from.machineId,
+      sign: (c) => sign(c, keys[from.machineId].priv),
+      nonce: () => `hop-${++nonceSeq}`,
+      now: () => Date.now(),
+    });
+    const res = await client.send(
+      { machineId: to.machineId, url: to.url },
+      { type: 'journal-sync', batch: [served] } as unknown as MeshCommand,
+      0,
+    );
+    if (!(res as { ok?: boolean }).ok) {
+      throw new Error(`replication hop refused: ${JSON.stringify(res)}`);
+    }
+    const lastSeq = served.entries.reduce((m, e) => Math.max(m, (e as { seq?: number }).seq ?? 0), fromSeq);
+    cursors.set(key, lastSeq);
+    const result = (res as { result?: { result?: { applied: number; forgedEntries: number } } }).result?.result ?? { applied: 0, forgedEntries: 0 };
+    to.hopLatenciesMs.push(Date.now() - t0);
+    return result;
+  }
+
+  function applierTick(node: HarnessNode): { examined: number; materialized: number } {
+    return node.ownershipApplier.tick();
+  }
+
+  return {
+    a,
+    b,
+    replicate,
+    applierTick,
+    teardown: async () => {
+      await a.stop();
+      await b.stop();
+      SafeFsExecutor.safeRmSync(tmpRoot, { recursive: true, force: true, operation: 'tests/support/twoNodeOwnershipHarness.ts:teardown' });
+    },
+  };
+}

--- a/upgrades/next/two-node-harness-increment2-entry-gate.md
+++ b/upgrades/next/two-node-harness-increment2-entry-gate.md
@@ -1,0 +1,13 @@
+# Two-node replication harness — the Increment-2 entry gate (ownership-gated spawn)
+
+<!-- internal-only -->
+
+## What Changed
+
+Adds the two-node ownership harness (`tests/support/twoNodeOwnershipHarness.ts`) and the Increment-2 entry-gate E2E (`tests/e2e/duplicate-reconciliation-two-node.test.ts`) named by `docs/specs/ownership-gated-spawn-and-judgment-within-floors.md` §4/§5: two in-process machines, each with the DURABLE ownership substrate (LocalSessionOwnershipStore + SessionOwnershipRegistry), the real signed journal-sync replication hop (CoherenceJournal → JournalSyncApplier → signed MeshRpc envelope → peer applier → OwnershipApplier materialization), and a real AgentServer per node (real Bearer auth). The E2E proves the L7 lifecycle (duplicate → heal on the lease holder → un-stubbed replication → the PEER's own registry view echoes the repair over real HTTP → peer-side sweeper armed) and the §5 delayed-journal-replay case (echo timeout → ONE aggregated escalation → late replay → self-completed heal), and the §5 partition-formed case (both nodes claimed self during a partition → both-ways replication → the higher-epoch claim wins via the epoch-gated fast-forward → heal with zero escalations). The remaining §5 two-node scenarios (registry-error episode, terminate-time probe, 2b custody) are spec-anchored `it.todo` entries — visibly pending, never silently green. No runtime code changes; no rollout flag moves (§4's prerequisite ladders explicitly stay their own features' decisions).
+
+## Evidence
+
+- `tests/e2e/duplicate-reconciliation-two-node.test.ts` — 3 passing scenarios + 3 spec-anchored todos; runs in the existing `e2e` CI job with zero workflow changes (the vitest e2e include already covers it).
+- The harness already caught a real pre-merge bug: the record-already-correct incident shape FSM-refused the healer's convergence CAS (claim-out-of-sequence) → escalate-instead-of-heal; fixed on the Increment-1 PR (record-already-converged skip) and proven healed on this rig.
+- FD15 calibration: each run logs measured journal-hop + applier latency (the echoConfirmTicks calibration input the spec assigns to the Increment-1 soak).

--- a/upgrades/side-effects/two-node-harness-increment2-entry-gate.md
+++ b/upgrades/side-effects/two-node-harness-increment2-entry-gate.md
@@ -1,0 +1,64 @@
+# Side-Effects Review — Two-Node Replication Harness (Increment-2 Entry Gate)
+
+**Version / slug:** `two-node-harness-increment2-entry-gate`
+**Date:** `2026-07-11`
+**Author:** `echo (instar-dev agent)`
+**Second-pass reviewer:** `not required (tests + test-support only; no decision point, no runtime surface)`
+
+## Summary of the change
+
+Implements the Increment-2 entry-gate deliverable of `docs/specs/ownership-gated-spawn-and-judgment-within-floors.md` (§4 line 242: "Entry gate: the two-node replication harness (§5) green in CI"; §5 line 261: the L7 evidence contract). Two new test files only: `tests/support/twoNodeOwnershipHarness.ts` (the reusable two-node factory — durable ownership substrate, un-stubbed signed journal-sync replication, real AgentServer per node) and `tests/e2e/duplicate-reconciliation-two-node.test.ts` (the entry-gate lifecycle + the §5 delayed-replay and partition-formed cases + three spec-anchored `it.todo` scenarios). Plus this artifact, the ELI16 companion, and an internal-only release fragment. **Zero `src/**` changes.**
+
+## Decision-point inventory
+
+*(none — no runtime decision point is added or modified; the harness exercises existing ones)*
+
+## 1. Over-block
+
+Nothing at runtime (no runtime surface). In CI: the new E2E becomes a required-passing test — a future change that breaks the two-machine heal fails CI. That is the deliverable, not a side effect: the spec makes this test THE Increment-2 entry gate.
+
+## 2. Under-block
+
+- The harness runs two nodes IN ONE PROCESS over loopback — partitions are modeled as WITHHELD replication (the §5 partition-formed and delayed-replay cases), not as packet loss/timeout dynamics; clock skew and cross-host filesystem differences are not modeled. The spec's §3.0 consistency contract owns those honesty bounds.
+- The 2b custody-transfer scenario and the terminate-time-probe scenario are `it.todo` — their mechanics are deliberately NOT built in Increment 1/this PR (Increment 2b's own build); the todos carry the spec anchors so they cannot be silently forgotten.
+- The closeout leg asserts the ARMING predicate (the peer's own view says owner-elsewhere) and simulates the close; the full sweeper-close leg lands with the `duplicate-reconciled` reap-reason extension (Increment 2).
+
+## 3. Level-of-abstraction fit
+
+Reuses the three existing proven patterns (journal-sync-roundtrip's replication hop, mesh-failover's two-server shape, the alive-test's real-AgentServer boot) rather than inventing a parallel harness idiom. The node factory lives in `tests/support/` alongside the existing fixture module.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** docs/signal-vs-authority.md — Not applicable at runtime (no new detector or authority). In-CI authority (a failing test blocks merges) is the standard test-suite contract.
+
+## 5. Interactions
+
+- The E2E rides the existing `e2e` CI job (vitest include already covers `tests/e2e/**`) — no workflow changes, no new CI lanes.
+- The harness binds ephemeral loopback ports (port 0) and tmpdir state — no interaction with the host agent's server, state, or config.
+- Discovered interaction (already resolved upstream): building this harness surfaced the record-already-correct FSM refusal (claim-out-of-sequence → escalate-instead-of-heal) — fixed on the Increment-1 PR as the `record-already-converged` skip and unit-tested there; this E2E now proves that fix end-to-end.
+
+## 6. External surfaces
+
+None. No egress (loopback only), no persistent state outside vitest tmpdirs (SafeFsExecutor teardown), no operator surface, no agent-visible capability (hence the internal-only release-note lane).
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+The change IS the multi-machine test substrate. It runs no agent, replicates no store of its own, and creates no cross-machine surface; it simulates two machines inside one test process to verify the production replication contract (journal → signed envelope → applier → materialized peer view).
+
+## 8. Rollback cost
+
+Delete the two test files (plus docs). Nothing depends on them at runtime. The only cost of rollback is losing the Increment-2 entry gate's objective checkability.
+
+## Rollout-ladder compliance (§4 hard prohibitions)
+
+- NO flag flips: `ownershipGatedSpawn` / `duplicateReconciler` / `judgmentArbiters` / `commitmentCustodyTransfer` untouched; `inboundQueue` / `holdForStability` / stale-owner-release untouched (their own features' graduation decisions, per §4 "inherit-and-stall").
+- NO `provenance.deterministicSampling` change (that is an Increment-2-ENTRY action, riding the actual enforce-flip PR).
+- In-test enforce-mode construction of the reconciler is test construction inside a sandbox, not a rollout-ladder flip (the Increment-1 burst-invariant E2E precedent).
+
+## Conclusion
+
+Tests + test-support only; the risk surface is CI-time, which is the point. Clear to ship as its own PR once Increment 1 merges (it depends on the Increment-1 modules).


### PR DESCRIPTION
Implements the **Increment-2 entry-gate deliverable** of the approved spec `docs/specs/ownership-gated-spawn-and-judgment-within-floors.md` (§4: "Entry gate: the two-node replication harness (§5) green in CI"; §5: the L7 evidence contract). Follow-up to #1436 (Increment 1). **Tests + test-support only — zero runtime changes, zero flag moves.**

## What this adds

- `tests/support/twoNodeOwnershipHarness.ts` — the reusable two-node factory: per node, the DURABLE ownership substrate (`LocalSessionOwnershipStore` + `SessionOwnershipRegistry` — the §3.2.0 precondition, unlike the fleet-default in-memory store), a `CoherenceJournal` writer + both `JournalSyncApplier` halves + `OwnershipApplier`, and a REAL `AgentServer` (real Bearer auth) serving `/sessions`, `/pool/ownership-view`, and `/mesh/rpc`. Replication is the real signed path (serve batch → Ed25519 recipient-bound envelope → peer dispatcher → applier → materialization) — **not stubbed**. Caller-paced (no wall-clock waits).
- `tests/e2e/duplicate-reconciliation-two-node.test.ts` — the entry-gate E2E:
  - **L7 lifecycle**: duplicate live on both nodes → the lease-holder reconciler determines the owner from real-HTTP discovery/probes → heal → un-stubbed replication → **the PEER's OWN registry view echoes the repair, read over its real Bearer-authed HTTP surface** → peer-side sweeper predicate armed. Logs measured journal-hop latency per run (the FD15 `echoConfirmTicks` calibration input).
  - **Delayed journal replay** (§5): echo window exhausts → exactly ONE aggregated escalation → the late replay lands → the heal completes itself on a later tick.
  - The remaining §5 two-node scenarios (partition-formed, registry-error episode, terminate-time probe, 2b custody transfer) are **spec-anchored `it.todo` entries** — visibly pending in every run, never silently green; each lands with the increment that builds its mechanics.

## What it already caught

Driving the 2026-07-10 incident shape through the real FSM exposed that the reconciler's convergence CAS was refused (`claim-out-of-sequence`) when the record was already correct — the incident's own shape would have **escalated instead of self-healing**. Every mocked test missed it. Fixed on #1436 (`record-already-converged` skip, no epoch burn) and proven healed on this rig.

## Rollout-ladder compliance

No flag flips anywhere: the four spec flags stay dark/dry-run; `inboundQueue` / `holdForStability` / stale-owner-release keep their own features' graduation schedules (§4 inherit-and-stall). `provenance.deterministicSampling` stays 1.0 (its step-down rides the actual Increment-2 enforce-flip PR). The sequence-diagrams deliverable (§8) was satisfied in Increment 1 (`docs/specs/diagrams/ownership-gated-spawn-flows.md`).

CI: the new E2E rides the existing `e2e` job (the vitest include already covers it) — no workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## ELI16 — the two-machine test rig, in plain English

This adds a permanent test rig that runs **two simulated machines inside one test run** — each with its own real ownership records, real replication between them (the same signed message path production uses, not a fake), and a real web server with real authentication. The tests on top of it drive the duplicate-conversation healer across both machines and prove, on every future change: (1) when the same conversation is live on two machines, the healer fixes the records and the OTHER machine's own records visibly agree — read over real authenticated HTTP, never by peeking at files — before anything gets closed; (2) when replication is delayed, the healer escalates honestly exactly once after a bounded wait, then finishes the heal by itself when the news arrives; (3) when a network split made BOTH machines claim the same conversation, the stronger claim wins cleanly after they reconnect, with zero operator involvement.

Why it matters: the approved spec staged its rollout so enforcement (stage 2) can only turn on once this rig is green in CI — this makes that entry condition a real, checkable thing instead of a sentence in a document. It already paid for itself: driving the July-10 incident through the rig before the stage-1 merge exposed that the healer would have paged the operator instead of self-healing in the incident's own shape — every earlier test faked the one step this rig runs for real. That bug was fixed and proven healed here.

What it does NOT do: flip anything. No feature turns on; all rollout switches stay exactly where stage 1 left them; the scenarios later stages need are visibly marked "pending" with their spec anchors, so they can't be quietly forgotten or falsely show green. Tests and test-support only — zero production code changes.
