### PR TITLE
fix: surface messages lost during respawn collision

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-11T10-39-39-024Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-11T10-39-39-024Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-11T10:39:39.024Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 23,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-11T10-40-06-835Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-11T10-40-06-835Z-unknown.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-11T10:40:06.835Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 23,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "one-shot user-driven custody notice emitted only when an inbound message collides with an already-running respawn; not a self-triggered loop"
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-11T10-40-39-947Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-11T10-40-39-947Z-unknown.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-11T10:40:39.947Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 23,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "one-shot user-driven custody notice emitted only when an inbound message collides with an already-running respawn; not a self-triggered loop"
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-11T10-41-08-751Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-11T10-41-08-751Z-unknown.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-11T10:41:08.751Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 23,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "one-shot user-driven custody notice emitted only when an inbound message collides with an already-running respawn; not a self-triggered loop"
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-11T10-40-52-587Z-silent-respawn-collision-notice-40174f3b.json
+++ b/.instar/instar-dev-traces/2026-07-11T10-40-52-587Z-silent-respawn-collision-notice-40174f3b.json
@@ -1,0 +1,22 @@
+{
+  "version": 2,
+  "sessionId": "46e7cabc-4f2b-439e-a7a2-a88f6a73f395",
+  "timestamp": "2026-07-11T10:40:52.587Z",
+  "artifactPath": "upgrades/side-effects/silent-respawn-collision-notice.md",
+  "artifactSha256": "b290d7bff18dcb965ca1c4d8b1544b8afcd4b87c908f22cf5995b9a34dfd9fba",
+  "specPath": "docs/specs/durable-inbound-message-queue.md",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/messaging/ColdStartFallbackReply.ts"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "Messaging custody change in respawn routing; narrow notice-only behavior with existing safety gates unchanged",
+  "secondPass": "true",
+  "reviewerConcurred": true,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "one-shot user-driven custody notice emitted only when an inbound message collides with an already-running respawn; not a self-triggered loop"
+  }
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -75,6 +75,7 @@ import { BootHealthBeacon } from '../server/BootHealthBeacon.js';
 import { TelegramAdapter, TOPIC_STYLE, selectTopicEmoji } from '../messaging/TelegramAdapter.js';
 import { getTelegramInboundDir } from '../messaging/shared/telegramInboundFiles.js';
 import { buildColdStartFallbackReply } from '../messaging/ColdStartFallbackReply.js';
+import { sendRespawnCollisionNotice } from '../messaging/ColdStartFallbackReply.js';
 import { RelationshipManager } from '../core/RelationshipManager.js';
 import { ClaudeCliIntelligenceProvider } from '../core/ClaudeCliIntelligenceProvider.js';
 import { wrapIntelligenceWithCircuitBreaker, getFeatureMetricsRecorder } from '../core/CircuitBreakingIntelligenceProvider.js';
@@ -2707,6 +2708,9 @@ export function wireTelegramRouting(
           if (!admitLocalSpawn('telegram-respawn-context-exhausted')) return;
           if (spawningTopics.has(topicId)) {
             console.log(`[telegram→session] Spawn already in progress for topic ${topicId} — skipping duplicate respawn`);
+            void sendRespawnCollisionNotice(telegram.sendToTopic.bind(telegram), topicId).catch((err) => {
+              console.error(`[telegram→session] Failed to send respawn-collision loss notice for topic ${topicId}:`, err);
+            });
             return;
           }
           const _spawnTokA = spawningTopics.add(topicId);
@@ -2729,6 +2733,9 @@ export function wireTelegramRouting(
           // message triggers a new respawn → multiple concurrent spawns → chaos.
           if (spawningTopics.has(topicId)) {
             console.log(`[telegram→session] Spawn already in progress for topic ${topicId} — skipping duplicate respawn`);
+            void sendRespawnCollisionNotice(telegram.sendToTopic.bind(telegram), topicId).catch((err) => {
+              console.error(`[telegram→session] Failed to send respawn-collision loss notice for topic ${topicId}:`, err);
+            });
             return;
           }
           const _spawnTokB = spawningTopics.add(topicId);

--- a/src/messaging/ColdStartFallbackReply.ts
+++ b/src/messaging/ColdStartFallbackReply.ts
@@ -52,6 +52,22 @@ export interface ColdStartFallbackReply {
   lifelineTopicId: number | null;
 }
 
+/** Honest custody notice for a message that collided with an active respawn. */
+export const RESPAWN_COLLISION_NOTICE =
+  `I got this message while the session was already restarting, so it was not queued or delivered. ` +
+  `Please resend it once the restart finishes.`;
+
+/**
+ * Route the collision notice through the adapter's deterministic topic-send
+ * funnel. Kept injectable so the exact user-visible send is behaviorally tested.
+ */
+export async function sendRespawnCollisionNotice(
+  sendToTopic: (topicId: number, text: string) => Promise<unknown>,
+  topicId: number,
+): Promise<void> {
+  await sendToTopic(topicId, RESPAWN_COLLISION_NOTICE);
+}
+
 /**
  * Classify a spawn/restart error into a user-facing reason. String inspection is
  * acceptable here because this is a SIGNAL (a help message), not an authority gate —

--- a/tests/unit/respawn-collision-notice.test.ts
+++ b/tests/unit/respawn-collision-notice.test.ts
@@ -10,6 +10,15 @@ import type { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
 import type { SessionManager } from '../../src/core/SessionManager.js';
 import type { Message } from '../../src/core/types.js';
 
+// The regression intentionally drives the real respawn wiring. Keep that path
+// real, but fence the production scaffold boundary: server.ts captures the
+// checkout cwd as its projectDir at module load, and a real spawn otherwise
+// renders identity shadows into the test runner's checkout.
+vi.mock('../../src/core/IdentityRenderer.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../src/core/IdentityRenderer.js')>(),
+  ensureFrameworkIdentityFile: vi.fn(() => null),
+}));
+
 describe('respawn collision custody notice', () => {
   it('reaches the deterministic topic-send funnel with honest loss wording', async () => {
     const sent: Array<{ topicId: number; text: string }> = [];

--- a/tests/unit/respawn-collision-notice.test.ts
+++ b/tests/unit/respawn-collision-notice.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  RESPAWN_COLLISION_NOTICE,
+  sendRespawnCollisionNotice,
+} from '../../src/messaging/ColdStartFallbackReply.js';
+import { wireTelegramRouting } from '../../src/commands/server.js';
+import type { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import type { SessionManager } from '../../src/core/SessionManager.js';
+import type { Message } from '../../src/core/types.js';
+
+describe('respawn collision custody notice', () => {
+  it('reaches the deterministic topic-send funnel with honest loss wording', async () => {
+    const sent: Array<{ topicId: number; text: string }> = [];
+    await sendRespawnCollisionNotice(async (topicId, text) => {
+      sent.push({ topicId, text });
+      return { ok: true };
+    }, 458);
+
+    expect(sent).toEqual([{ topicId: 458, text: RESPAWN_COLLISION_NOTICE }]);
+    expect(sent[0].text).toContain('not queued or delivered');
+    expect(sent[0].text).toContain('Please resend');
+  });
+
+  it('tells the user exactly once when a second inbound collides with an unresolved respawn', async () => {
+    const sent: string[] = [];
+    let releaseSpawn!: (name: string) => void;
+    const heldSpawn = new Promise<string>((resolve) => { releaseSpawn = resolve; });
+    const spawnInteractiveSession = vi.fn(() => heldSpawn);
+    const injectTelegramMessage = vi.fn();
+    const rawAdapter = {
+      onTopicMessage: null as null | ((message: Message) => Promise<void>),
+      isAuthorizedSender: () => true,
+      handleCommand: async () => false,
+      getTopicName: () => 'dev-task',
+      getSessionForTopic: () => 'dead-session',
+      getTopicHistory: () => [],
+      getLifelineTopicId: () => null,
+      resolveTopicName: async () => 'dev-task',
+      registerTopicSession: vi.fn(),
+      sendToTopic: async (_topicId: number, text: string) => { sent.push(text); },
+      isPolling: false,
+    };
+    const sessionManager = {
+      isSessionAlive: () => false,
+      captureOutput: () => '',
+      clearSessionFrameworkCache: vi.fn(),
+      spawnInteractiveSession,
+      injectTelegramMessage,
+    } as unknown as SessionManager;
+    wireTelegramRouting(rawAdapter as unknown as TelegramAdapter, sessionManager);
+
+    const message = (id: string, content: string): Message => ({
+      id,
+      userId: '8820318295',
+      content,
+      channel: { type: 'telegram', identifier: '458' },
+      receivedAt: '2026-07-11T00:00:00Z',
+      metadata: { messageThreadId: 458, telegramUserId: 8820318295, firstName: 'Echo' },
+    } as Message);
+
+    await rawAdapter.onTopicMessage!(message('tg-1', 'first message'));
+    await vi.waitFor(() => expect(spawnInteractiveSession).toHaveBeenCalledTimes(1));
+    await rawAdapter.onTopicMessage!(message('tg-2', 'second message'));
+
+    expect(sent.filter((text) => text === RESPAWN_COLLISION_NOTICE)).toEqual([RESPAWN_COLLISION_NOTICE]);
+    expect(spawnInteractiveSession).toHaveBeenCalledTimes(1);
+    expect(injectTelegramMessage).not.toHaveBeenCalled();
+
+    // Let the detached respawn settle after the collision assertions.
+    releaseSpawn('replacement-session');
+  });
+
+  it('is wired into both dead-session respawn collision guards', () => {
+    const source = fs.readFileSync(path.resolve('src/commands/server.ts'), 'utf8');
+    const calls = source.match(/sendRespawnCollisionNotice\(telegram\.sendToTopic\.bind\(telegram\), topicId\)/g) ?? [];
+    expect(calls).toHaveLength(2);
+  });
+
+  it('does not move the sentinel-before-exactly-once safety ordering', () => {
+    const source = fs.readFileSync(path.resolve('src/server/routes.ts'), 'utf8');
+    expect(source.indexOf('Sentinel intercept (P0 safety')).toBeGreaterThan(-1);
+    expect(source.indexOf('Exactly-once ingress gate')).toBeGreaterThan(source.indexOf('Sentinel intercept (P0 safety'));
+  });
+});

--- a/upgrades/eli16/silent-respawn-collision-notice.md
+++ b/upgrades/eli16/silent-respawn-collision-notice.md
@@ -1,0 +1,6 @@
+# Silent respawn collision notice — ELI16
+
+Imagine a session is broken and Instar is already starting its replacement. If another message arrives during that small window, the old code noticed that a restart was underway and simply returned. The message was neither queued nor delivered, and the user received no warning.
+
+Instar now sends a precise notice for that collision: the message was not queued or delivered, so resend it after the restart finishes. The first message still follows the existing durable pending-injection machinery. This change does not invent a second queue and does not alter emergency-stop, pause, or duplicate-message safety ordering.
+

--- a/upgrades/next/silent-respawn-collision-notice.md
+++ b/upgrades/next/silent-respawn-collision-notice.md
@@ -1,0 +1,22 @@
+# Silent respawn collision notice
+
+## What Changed
+
+When a Telegram message arrives while a dead session is already being respawned, Instar now tells the user that this particular message was not queued or delivered and asks them to resend it after the restart. This closes the remaining single-machine silent-loss path without adding another queue.
+
+## What to Tell Your User
+
+If a message collides with an in-progress session restart, you will now receive an honest resend instruction instead of waiting indefinitely for a message that was never accepted into custody.
+
+## Summary of New Capabilities
+
+- Detects both normal and context-exhaustion respawn collisions.
+- Routes one deterministic custody notice through the existing Telegram topic-send funnel.
+- Preserves sentinel-before-dedup ordering and all existing emergency-stop, pause, and exactly-once behavior.
+
+## Evidence
+
+- `tests/unit/respawn-collision-notice.test.ts`
+- `tests/integration/telegram-forward-sentinel-intercept.test.ts`
+- `tests/integration/exactly-once-ingress.test.ts`
+

--- a/upgrades/side-effects/silent-respawn-collision-notice.md
+++ b/upgrades/side-effects/silent-respawn-collision-notice.md
@@ -1,0 +1,86 @@
+# Side-Effects Review — Silent respawn collision notice
+
+**Version / slug:** `silent-respawn-collision-notice`
+**Date:** `2026-07-11`
+**Author:** `instar-codey`
+**Second-pass reviewer:** framework_guard_review (Banach)
+
+## Summary of the change
+
+The two dead-session respawn collision guards in `wireTelegramRouting` no longer return silently. They send a deterministic, honest custody notice through the existing Telegram topic-send funnel before returning. No queue, persistence format, config, or authority surface is added.
+
+## Decision-point inventory
+
+- Context-exhaustion dead-session respawn collision — modified — sends the loss notice, then preserves the existing return.
+- Ordinary dead-session respawn collision — modified — sends the loss notice, then preserves the existing return.
+- Initial respawn and durable pending-inject paths — pass-through — unchanged.
+- Sentinel kill/pause intercept and exactly-once ingress gate — pass-through — unchanged and remain in their existing order.
+
+---
+
+## 1. Over-block
+
+No new block/allow surface exists. The colliding message was already rejected by the active-spawn guard; the change only makes that pre-existing lack of custody visible. The notice does not suppress, deduplicate, pause, or kill any message or session.
+
+## 2. Under-block
+
+The notice is dispatched asynchronously through the existing adapter. If Telegram delivery itself fails, the existing adapter failure behavior and error logging apply; this change does not claim external delivery succeeded. It also intentionally does not retry or queue the colliding user message, avoiding duplicate injection into a session whose startup ownership is already in flight.
+
+## 3. Level-of-abstraction fit
+
+The collision guard is the only layer that knows the message was refused specifically because another respawn owns the topic. The wording and injectable send helper live beside the existing cold-start fallback reply machinery, keeping user-facing spawn failure notices in one messaging module.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The notice is a truthful signal about custody already declined by existing control flow. It creates no authority and makes no semantic inference about the user's message.
+
+## 5. Interactions
+
+- **Shadowing:** Both reachable dead-session collision guards receive identical behavior; neither shadows the other.
+- **Double-fire:** Each inbound traverses only one of the mutually exclusive dead-session branches, so at most one notice is attempted.
+- **Races:** The existing `spawningTopics` ownership remains unchanged. The notice does not mutate it or wait on the spawn.
+- **Feedback loops:** The notice asks for an explicit resend after restart; it does not self-trigger another spawn or injection.
+
+## 6. External surfaces
+
+Telegram users may see one new message: “I got this message while the session was already restarting, so it was not queued or delivered. Please resend it once the restart finishes.” No dashboard, API, config, schema, URL, or other external surface changes.
+
+## 6b. Operator-surface quality
+
+The wording distinguishes receipt by the bridge from custody by the session, states exactly what failed, and gives one concrete recovery action. It does not falsely promise that the message is queued.
+
+## 7. Multi-machine posture
+
+Machine-local by design and fully functional with `multiMachine.sessionPool.inboundQueue` dark. It uses the local respawn ownership set and the existing Telegram adapter. No cross-machine state or dark feature is required.
+
+## 8. Rollback cost
+
+Pure code rollback: revert the helper, two call sites, tests, and release artifacts. No durable state or data migration requires repair.
+
+## Conclusion
+
+Clear to ship. The change closes the reachable silent-loss collision without changing queue semantics or safety authority.
+
+## Second-pass review (required: messaging/information-flow path)
+
+**Reviewer:** framework_guard_review (Banach)
+**Independent read:** Concurred after requesting an executable routing regression. The final test holds the first respawn unresolved, drives a second inbound through `wireTelegramRouting`, and proves exactly one loss notice, one spawn total, and zero injection. The reviewer confirmed both production guards preserve the existing return and that `src/server/routes.ts` safety ordering is untouched.
+
+## Evidence pointers
+
+- `tests/unit/respawn-collision-notice.test.ts`
+- `tests/unit/cold-start-fallback-reply.test.ts`
+- `tests/unit/cold-start-fallback-wiring.test.ts`
+- `tests/integration/telegram-forward-sentinel-intercept.test.ts`
+- `tests/integration/exactly-once-ingress.test.ts`
+- `tests/unit/no-silent-fallbacks.test.ts`
+
+## Class-Closure Declaration (display-only mirror)
+
+- **Defect class:** `unbounded-self-action`
+- **Closure:** `n/a`
+- **Reason:** One-shot user-driven custody notice emitted only when an inbound message collides with an already-running respawn; not a self-triggered loop.


### PR DESCRIPTION
## ELI16

When a second Telegram message arrives while a dead session is already restarting, Instar now says that message was not queued or delivered and asks the user to resend after the restart. It no longer disappears silently.

## Built target

**PRIMARY:** `respawn-queued-message-not-injected-codex`.

Grounding found the original June 5 durable-injection failure closed on current main: pending custody is recorded before readiness (`src/core/SessionManager.ts:4631-4644`), cleared only after injection (`src/core/SessionManager.ts:4673-4685`), retained/re-recorded across resume fallback (`src/core/SessionManager.ts:4695-4754`), and boot recovery redelivers or reports loss (`src/core/SessionManager.ts:4793-4814`).

A separate reachable single-machine path remained open with inboundQueue dark: both dead-session collision guards returned silently when `spawningTopics` already owned the topic. This PR adds an honest resend notice at `src/commands/server.ts:2709-2714` and `src/commands/server.ts:2734-2739`, using the existing topic-send funnel in `src/messaging/ColdStartFallbackReply.ts:55-68`.

## Other target grounding

**FALLBACK:** `telegram-forward-sentinel-pause-no-resume-idle-session` is stale/closed by current operator-channel-sacred behavior. Only deterministic explicit pause is consumed; nondeterministic/capacity pause routes through (`src/core/MessageSentinel.ts:417-449`). The forward route preserves sentinel interception before exactly-once (`src/server/routes.ts:18516-18594`, `src/server/routes.ts:18631-18638`). Explicit pause is acknowledged as a control directive, while substantive false-positive pause classifications deliver normally; there is no held inbound queue waiting for a later message.

## Safety and tests

- Executable regression holds one respawn open, sends a second inbound, and proves exactly one loss notice, one spawn total, and zero injection.
- Exact notice text is asserted at the send funnel.
- Sentinel emergency-stop/pause and exactly-once suites remain green and their production route is untouched.
- Single-machine behavior requires no multiMachine flag.
- Independent Tier-2 messaging review concurred.

Validation: 36 focused tests passed; affected smoke 39/39; `npx tsc --noEmit`; lint and instar-dev precommit gates passed. The unrelated local Threadline sqlite-lock e2e flake was bypassed with the documented skip; full GitHub CI is authoritative.