### PR TITLE
feat(dashboard): Fable 5 quota usage bar in Subscriptions tab

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-12T01-49-33-024Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-12T01-49-33-024Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-12T01:49:33.024Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 36,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-12T01-50-26-402Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-12T01-50-26-402Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-12T01:50:26.402Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 36,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-12T01-51-08-189Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-12T01-51-08-189Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-12T01:51:08.189Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 36,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -212,9 +212,10 @@ export function renderAccounts(doc, target, accounts, now = Date.now(), inUseAcc
       card.appendChild(el(doc, 'div', 'sub-account-email', sanitizeForDisplay(a.email, 'label')));
     }
     const q = (a && a.lastQuota) || null;
-    if (q && (q.fiveHour || q.sevenDay)) {
+    if (q && (q.fiveHour || q.sevenDay || q.fable)) {
       if (q.fiveHour) card.appendChild(quotaBar(doc, '5-hour', q.fiveHour.utilizationPct, q.fiveHour.resetsAt, now));
       if (q.sevenDay) card.appendChild(quotaBar(doc, 'Weekly', q.sevenDay.utilizationPct, q.sevenDay.resetsAt, now));
+      if (q.fable) card.appendChild(quotaBar(doc, 'Fable 5', q.fable.utilizationPct, q.fable.resetsAt, now));
     } else {
       card.appendChild(el(doc, 'div', 'sub-account-noquota', 'No quota reading yet.'));
     }

--- a/docs/specs/fable5-quota-dashboard.eli16.md
+++ b/docs/specs/fable5-quota-dashboard.eli16.md
@@ -1,0 +1,35 @@
+# Fable 5 quota usage on the Subscriptions dashboard — Plain-English Overview
+
+> The one-line version: show a "Fable 5" usage bar per account on the Subscriptions dashboard, reading a number the Anthropic usage API already gives us.
+
+## The problem in one breath
+
+Fable 5 has its own weekly usage allowance that is separate from an account's normal limits. The dashboard showed the normal limits (a 5-hour bar and a weekly bar) but never showed Fable 5 — so the only way to know if a Fable 5 pool was maxed out was to try a call and hit the wall.
+
+## What already exists
+
+- **The Subscriptions dashboard tab** — shows each account with a 5-hour usage bar and a weekly usage bar, each with a reset countdown. It reads the account's latest quota snapshot.
+- **The quota poller** — periodically calls Anthropic's usage endpoint for each account and turns the raw response into a small snapshot object (`fiveHour`, `sevenDay`, and a per-model map for Opus/Sonnet).
+- **The multi-machine replication layer** — when the agent runs on more than one machine, each machine's account-usage snapshots are shared with the others through a strict validator that only lets through a known set of fields (anything unknown makes it reject the whole snapshot, on purpose, for safety).
+
+## What this adds
+
+A third bar — **Fable 5** — under the existing two, per account, with its own reset countdown. It only appears when there's a Fable reading to show.
+
+The key discovery: Anthropic's usage response *already* contains Fable 5's weekly usage. It isn't a tidy top-level field like the others; it lives inside a `limits` list as the entry scoped to the model whose display name is "Fable", carrying a percent-used and a reset time. We parse that entry into the same little `{percent, resetsAt}` shape the other bars use, so the dashboard can draw it with the exact same bar component.
+
+## The new pieces
+
+- **A `fable` window on the quota snapshot** — parsed from the usage response's `limits` list. Same shape as the 5-hour and weekly windows, so nothing downstream needs special handling.
+- **One new dashboard bar** — drawn only when a Fable reading exists; otherwise nothing changes.
+
+## The safeguards
+
+- **It's read-only.** This is a display of a number, nothing more. It does not gate, block, filter, or decide anything. It is deliberately NOT wired into the model-escalation or scheduling decisions (those keep using the overall limits only) — feeding Fable into a *decision* would be a different, riskier change.
+- **Multi-machine safety.** The strict cross-machine validator would have rejected any peer's whole snapshot the moment it carried the new `fable` field. We taught it to accept and shape-check `fable` (a real number and a real date, nothing else), so a peer's Fable usage survives sharing instead of nuking that peer's quota on the receiver.
+- **Conservative parsing.** We only treat an entry as Fable when it's a weekly-scoped limit whose model display name is exactly "Fable" and it actually has a percent — so an Opus-scoped or malformed entry is never mistaken for Fable.
+- **Graceful absence.** No Fable reading (freshly-set-up account, unread quota, sparse response) simply means the bar doesn't render — same as the existing bars.
+
+## What the reader needs to decide
+
+Nothing risky. This is an additive, read-only dashboard bar backed by data the API already returns, covered by unit tests on the parser, the renderer, and the replication validator, and live-verified across all four real accounts. The only judgment call already made: keep Fable display-only for now rather than letting it influence which account the agent routes work to. If that turns out wrong, the back-out is reverting four small hunks.

--- a/src/core/QuotaPoller.ts
+++ b/src/core/QuotaPoller.ts
@@ -214,6 +214,32 @@ export function mapUsageResponse(
   }
   if (Object.keys(perModel).length > 0) snap.perModel = perModel;
 
+  // Fable 5 usage is NOT a top-level `seven_day_fable` field — it surfaces as a
+  // scoped weekly limit entry inside `limits[]`, identified by
+  // `scope.model.display_name === 'Fable'` (group 'weekly'). The entry carries a
+  // `percent` (0–100) and a `resets_at`, so we map it into a window with the same
+  // shape as fiveHour/sevenDay. Verified live 2026-07-11 across all pool accounts.
+  const limits = body['limits'];
+  if (Array.isArray(limits)) {
+    for (const entry of limits) {
+      if (!entry || typeof entry !== 'object') continue;
+      const l = entry as Record<string, unknown>;
+      const scope = l.scope as Record<string, unknown> | null | undefined;
+      const model =
+        scope && typeof scope === 'object'
+          ? (scope.model as Record<string, unknown> | null | undefined)
+          : undefined;
+      const displayName = model && typeof model === 'object' ? model.display_name : undefined;
+      if (l.group === 'weekly' && displayName === 'Fable' && l.percent !== undefined) {
+        snap.fable = {
+          utilizationPct: Number(l.percent ?? 0),
+          resetsAt: String(l.resets_at ?? ''),
+        };
+        break;
+      }
+    }
+  }
+
   const extra = body['extra_usage'];
   if (extra && typeof extra === 'object') {
     const e = extra as Record<string, unknown>;

--- a/src/core/SubscriptionAccountMetaReplicatedStore.ts
+++ b/src/core/SubscriptionAccountMetaReplicatedStore.ts
@@ -80,10 +80,10 @@ function validateQuota(v: unknown): Record<string, unknown> | null | undefined {
   if (typeof v !== 'object' || Array.isArray(v)) return null;
   const q = v as Record<string, unknown>;
   const out: Record<string, unknown> = {};
-  const knownQuota = ['fiveHour', 'sevenDay', 'perModel', 'extraUsage', 'source', 'measuredAt'];
+  const knownQuota = ['fiveHour', 'sevenDay', 'fable', 'perModel', 'extraUsage', 'source', 'measuredAt'];
   for (const k of Object.keys(q)) if (!knownQuota.includes(k)) return null; // extra key → reject
 
-  for (const win of ['fiveHour', 'sevenDay'] as const) {
+  for (const win of ['fiveHour', 'sevenDay', 'fable'] as const) {
     if (q[win] !== undefined) {
       const w = q[win];
       if (typeof w !== 'object' || w === null || Array.isArray(w)) return null;

--- a/src/core/SubscriptionPool.ts
+++ b/src/core/SubscriptionPool.ts
@@ -78,6 +78,12 @@ export type SubscriptionAccountStatus =
 export interface AccountQuotaSnapshot {
   fiveHour?: { utilizationPct: number; resetsAt: string };
   sevenDay?: { utilizationPct: number; resetsAt: string };
+  /**
+   * Fable-5 weekly usage window (scope.model.display_name === 'Fable' in the
+   * usage API `limits[]`). Same shape as fiveHour/sevenDay so the dashboard
+   * renders it with the identical quota bar.
+   */
+  fable?: { utilizationPct: number; resetsAt: string };
   perModel?: Record<string, number | null>;
   extraUsage?: {
     isEnabled: boolean;

--- a/tests/unit/quota-poller.test.ts
+++ b/tests/unit/quota-poller.test.ts
@@ -79,6 +79,76 @@ describe('QuotaPoller', () => {
     expect(snap.extraUsage).toBeUndefined();
   });
 
+  // ── Fable 5: the scoped weekly limit (verified live 2026-07-11) ────
+  it('extracts Fable 5 weekly usage from the limits[] scoped entry', () => {
+    const snap = mapUsageResponse(
+      {
+        seven_day: { utilization: 21, resets_at: '2026-07-18T15:59:59Z' },
+        limits: [
+          { kind: 'weekly_all', group: 'weekly', percent: 21, scope: null, is_active: false },
+          {
+            kind: 'weekly_scoped',
+            group: 'weekly',
+            percent: 36,
+            resets_at: '2026-07-18T15:59:59Z',
+            scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+            is_active: true,
+          },
+        ],
+      },
+      'oauth-usage-endpoint-fallback',
+      't',
+    );
+    expect(snap.fable).toEqual({ utilizationPct: 36, resetsAt: '2026-07-18T15:59:59Z' });
+  });
+
+  it('reads a maxed-out Fable 5 window at 100%', () => {
+    const snap = mapUsageResponse(
+      {
+        limits: [
+          {
+            kind: 'weekly_scoped',
+            group: 'weekly',
+            percent: 100,
+            resets_at: '2026-07-15T01:59:59Z',
+            scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+            is_active: true,
+          },
+        ],
+      },
+      'oauth-usage-endpoint-fallback',
+      't',
+    );
+    expect(snap.fable?.utilizationPct).toBe(100);
+  });
+
+  it('leaves fable undefined when no Fable-scoped limit is present', () => {
+    // A non-Fable scoped weekly limit must NOT be mistaken for Fable.
+    const snap = mapUsageResponse(
+      {
+        seven_day: { utilization: 8, resets_at: 'x' },
+        limits: [
+          { kind: 'weekly_all', group: 'weekly', percent: 8, scope: null, is_active: true },
+          {
+            kind: 'weekly_scoped',
+            group: 'weekly',
+            percent: 50,
+            scope: { model: { id: null, display_name: 'Opus' }, surface: null },
+            is_active: false,
+          },
+        ],
+      },
+      'oauth-usage-endpoint-fallback',
+      't',
+    );
+    expect(snap.fable).toBeUndefined();
+  });
+
+  it('leaves fable undefined when limits is absent entirely', () => {
+    const snap = mapUsageResponse(LIVE_USAGE_BODY, 'oauth-usage-endpoint-fallback', 't');
+    expect(snap.fable).toBeUndefined();
+  });
+
   // ── pollAccount lifecycle ─────────────────────────────────────────
   it('pollAccount returns a snapshot on a clean read', async () => {
     const p = new QuotaPoller({ pool, fetchImpl: okFetch(LIVE_USAGE_BODY), tokenResolver: () => 'sk-ant-oat01-x' });

--- a/tests/unit/subscription-account-meta-store.test.ts
+++ b/tests/unit/subscription-account-meta-store.test.ts
@@ -79,6 +79,25 @@ describe('subscription-account-meta schema (WS5.2 §6.1a)', () => {
     expect(validate(wellFormed({ quota: { source: 'made-up-source' } }))).toBeNull();
   });
 
+  it('accepts a fable window and round-trips it (so peers keep Fable-5 usage)', () => {
+    const projection = wellFormed({
+      quota: {
+        fiveHour: { utilizationPct: 42.5, resetsAt: '2026-06-17T00:00:00Z' },
+        fable: { utilizationPct: 100, resetsAt: '2026-07-15T00:00:00Z' },
+        source: 'oauth-usage-endpoint-fallback',
+      },
+    });
+    const out = validate(projection);
+    expect(out).not.toBeNull();
+    expect((out as Record<string, any>).quota.fable).toEqual({ utilizationPct: 100, resetsAt: '2026-07-15T00:00:00Z' });
+  });
+
+  it('REJECTS a malformed fable window (non-numeric pct / bad date / extra key)', () => {
+    expect(validate(wellFormed({ quota: { fable: { utilizationPct: 'lots', resetsAt: '2026-07-15T00:00:00Z' } } }))).toBeNull();
+    expect(validate(wellFormed({ quota: { fable: { utilizationPct: 1, resetsAt: 'not-a-date' } } }))).toBeNull();
+    expect(validate(wellFormed({ quota: { fable: { utilizationPct: 1, resetsAt: '2026-07-15T00:00:00Z', extra: true } } }))).toBeNull();
+  });
+
   it('clamps an over-long nickname to 256 chars rather than rejecting', () => {
     const out = validate(wellFormed({ nickname: 'y'.repeat(300) }));
     expect((out as { nickname: string }).nickname.length).toBe(256);

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -112,6 +112,39 @@ describe('renderAccounts', () => {
     expect(t.querySelector('.sub-account-status')!.textContent).toBe('Active');
     expect(t.querySelectorAll('.sub-quota').length).toBe(2);
   });
+  it('renders a Fable 5 bar when the fable window is present', () => {
+    const t = el();
+    renderAccounts(doc, t, [{
+      id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', status: 'active',
+      lastQuota: {
+        fiveHour: { utilizationPct: 10, resetsAt: '2026-06-07T01:00:00Z' },
+        sevenDay: { utilizationPct: 71, resetsAt: '2026-06-12T00:00:00Z' },
+        fable: { utilizationPct: 100, resetsAt: '2026-07-15T00:00:00Z' },
+      },
+    }], NOW);
+    const bars = t.querySelectorAll('.sub-quota');
+    expect(bars.length).toBe(3);
+    const labels = Array.from(t.querySelectorAll('.sub-quota-label')).map(n => n.textContent);
+    expect(labels).toContain('Fable 5');
+  });
+  it('renders a Fable 5 bar even when it is the only quota window', () => {
+    const t = el();
+    renderAccounts(doc, t, [{
+      id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', status: 'active',
+      lastQuota: { fable: { utilizationPct: 36, resetsAt: '2026-07-18T00:00:00Z' } },
+    }], NOW);
+    expect(t.querySelectorAll('.sub-quota').length).toBe(1);
+    expect(t.querySelector('.sub-quota-label')!.textContent).toBe('Fable 5');
+    expect(t.querySelector('.sub-account-noquota')).toBeNull();
+  });
+  it('shows the no-quota message when no windows at all (fable included) are present', () => {
+    const t = el();
+    renderAccounts(doc, t, [{
+      id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', status: 'active',
+      lastQuota: {},
+    }], NOW);
+    expect(t.querySelector('.sub-account-noquota')).not.toBeNull();
+  });
   it('a malicious nickname survives only as inert text (no element injected)', () => {
     const t = el();
     renderAccounts(doc, t, [{ id: 'x', nickname: '<img src=x onerror=alert(1)>', provider: 'anthropic', framework: 'claude-code', status: 'active' }], NOW);

--- a/upgrades/next/fable5-quota-dashboard.md
+++ b/upgrades/next/fable5-quota-dashboard.md
@@ -1,0 +1,23 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The Subscriptions dashboard now shows a **Fable 5** usage bar per account, alongside the existing 5-hour and Weekly bars. Fable 5 has its own weekly usage allowance that is separate from an account's overall limits, and until now it was invisible on the dashboard. It turns out the Anthropic usage API already exposes this number — not as a top-level field, but as a scoped weekly limit entry inside the response's `limits[]` array (the entry whose `scope.model.display_name === "Fable"`, carrying a `percent` and a `resets_at`). `QuotaPoller.mapUsageResponse()` now parses that entry into a new `fable` window on `AccountQuotaSnapshot` (same `{utilizationPct, resetsAt}` shape as `fiveHour`/`sevenDay`), which flows through the existing `/subscription-pool` passthrough to `dashboard/subscriptions.js`, where `renderAccounts()` draws it as a third quota bar. The multi-machine replicated-store validator (`SubscriptionAccountMetaReplicatedStore`) was also updated to allow + validate the new `fable` window, so a peer machine's Fable usage survives cross-machine replication instead of being rejected wholesale.
+
+## What to Tell Your User
+
+Your Subscriptions dashboard now shows how much of each account's **Fable 5** allowance you've used this week, right under the 5-hour and weekly bars — with its own reset countdown. Fable 5 has a separate weekly pool from your normal limits, so this fills a real blind spot: you can now see at a glance which accounts still have Fable 5 headroom and which are maxed out, without testing a call and hitting the wall.
+
+## Summary of New Capabilities
+
+- `AccountQuotaSnapshot.fable?: { utilizationPct; resetsAt }` — the Fable-5 weekly window, parsed from the usage API `limits[]` `Fable`-scoped entry.
+- Per-account **Fable 5** quota bar in the Subscriptions dashboard tab (rendered only when a Fable reading is present).
+- `fable` added to the cross-machine replicated-store allowlist + validation, so Fable usage survives multi-machine replication.
+
+## Evidence
+
+- `tests/unit/quota-poller.test.ts` (+4: Fable extraction from `limits[]`, maxed-100% read, non-Fable scoped-limit not mistaken for Fable, absent-limits → undefined).
+- `tests/unit/subscriptions-render.test.ts` (+3: Fable bar renders as a third bar, renders as the only window, no-quota message when all windows absent).
+- `tests/unit/subscription-account-meta-store.test.ts` (+2: well-formed `fable` window round-trips through replication; malformed `fable` rejected).
+- Full `tsc --noEmit` clean; 86 tests green across the three touched suites.
+- Live-verified against the real Anthropic usage API across all 4 pool accounts (2026-07-11): adriana 100% (critical), dawn 36%, sagemind 0%, headley 16%.

--- a/upgrades/side-effects/fable5-quota-dashboard.md
+++ b/upgrades/side-effects/fable5-quota-dashboard.md
@@ -1,0 +1,60 @@
+# Side-Effects Review — Fable 5 quota usage on the Subscriptions dashboard
+
+**Version / slug:** `fable5-quota-dashboard`
+**Date:** `2026-07-11`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (read-only display; no block/allow, lifecycle, or gate surface)`
+
+## Summary of the change
+
+Adds a per-account **Fable 5** weekly usage bar to the Subscriptions dashboard tab. Fable 5's weekly allowance is separate from an account's overall limits and was previously invisible. Verified live that the Anthropic `/api/oauth/usage` response already carries it as a scoped weekly limit entry inside `limits[]` (`scope.model.display_name === "Fable"`, with `percent` + `resets_at`). Four files change: (1) `src/core/QuotaPoller.ts` `mapUsageResponse()` parses that entry into a new `fable` window; (2) `src/core/SubscriptionPool.ts` adds `fable?` to `AccountQuotaSnapshot`; (3) `src/core/SubscriptionAccountMetaReplicatedStore.ts` allows + validates the `fable` window so multi-machine replication doesn't reject it; (4) `dashboard/subscriptions.js` `renderAccounts()` draws a third quota bar. No decision points are added or modified — this is a read-only observability display.
+
+## Decision-point inventory
+
+- No decision point is added, modified, or removed. The change reads an already-fetched API field and renders it. It does not gate information flow, block actions, filter messages, or constrain agent behavior.
+- Pass-through only: the new `fable` window rides the existing `snapshot: account.lastQuota` serialization in `routes.ts` and the existing dashboard poll. The replicated-store validator is *widened* (a previously-unknown key that would have caused a wholesale reject is now accepted + shape-validated) — this loosens a validation allowlist by exactly one well-specified field, it does not add a new gate.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. One adjacent note: the multi-machine replicated-store sanitizer would have *rejected the entire quota object* for any peer snapshot carrying the new `fable` key (its allowlist rejects unknown keys wholesale). Adding `fable` to `knownQuota` + a validation branch prevents that over-rejection — i.e., this change *removes* a latent over-block that would otherwise have appeared the moment a newer peer sent a `fable`-bearing snapshot to an older receiver. (The older-receiver direction is unavoidable version skew; documented under Interactions.)
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. The Fable parse is intentionally conservative: it only matches `group === 'weekly'` AND `scope.model.display_name === 'Fable'` AND `percent !== undefined`, so a non-Fable scoped limit (e.g. an Opus-scoped one) is never mistaken for Fable, and a malformed entry is skipped rather than surfaced as a bogus 0%.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The parse lives in `mapUsageResponse` — the single existing translator from the raw usage API into `AccountQuotaSnapshot`, right beside the existing `fiveHour`/`sevenDay`/`perModel` parses it mirrors. The render lives in `renderAccounts`, the existing per-account quota-bar renderer, reusing the existing `quotaBar` primitive. No new module, no re-implementation of an existing primitive, no parallel path.
+
+## 4. Signal vs authority compliance
+
+Compliant. This is pure observability with no authority: it neither blocks nor decides anything. It is a display of a number the API already returns. `docs/signal-vs-authority.md` is satisfied trivially — there is no gate to mis-place authority into. (Note: the Fable window is display-only and is NOT wired into `EscalationGovernor`/`QuotaAwareScheduler` quota-headroom decisions, which continue to use `fiveHour`/`sevenDay` only. Feeding Fable into escalation gating would be a *decision-point* change and is deliberately out of this change's scope — not deferred work, a different feature.)
+
+## 5. Interactions
+
+- **Replicated-store version skew:** an OLDER receiver (pre-this-change) that gets a `fable`-bearing snapshot from a NEWER peer will reject that peer's whole quota object (unknown-key rule) until the older machine updates. This is standard additive-field skew, self-heals on update, and only affects the *pool-scope view of that one peer's quota* transiently — never local data, never a crash. The reverse (newer receiver, older peer with no `fable`) is a no-op. No data loss; the account row still renders (just without that peer's live quota for the skew window).
+- **No shadowing / double-fire / races:** the render is additive (a third `appendChild` after the existing two) inside the same synchronous `renderAccounts` pass; the guard `if (q && (q.fiveHour || q.sevenDay || q.fable))` was widened so a fable-only account still shows bars instead of the "no quota" fallback. The 30s poll re-render already `replaceChildren`s the list wholesale, so the Fable bar participates in the existing refresh with no new timer.
+
+## 6. External surfaces
+
+- **Visible to the user:** yes — one new quota bar in the Subscriptions dashboard tab. No new API route, no new notification, no Telegram surface, no agent-to-agent surface.
+- **Timing/runtime dependence:** the bar renders only when a Fable reading is present in the latest poll; absent that (feature-dark account, unread quota, sparse response) it simply doesn't render — same graceful-absence behavior as the existing bars.
+
+## 6b. Operator-surface quality
+
+The change adds one bar to the Subscriptions dashboard tab (an operator surface). Against the four criteria:
+
+1. **Leads with its primary action.** The Subscriptions tab's job is at-a-glance monitoring; the Fable 5 bar's primary content is the usage itself — a labeled bar reading e.g. "Fable 5 · 100% used · resets in 3d". It sits directly under the existing 5-hour and Weekly bars, so the account's usage story reads top-to-bottom without hunting. No action button is added; the tab's real actions (Set up / sign-in) are untouched and un-shadowed.
+2. **Zero raw internals as primary content.** The bar shows the plain words "Fable 5", a clamped integer percent, and a human reset countdown. It exposes NONE of the API internals used to derive it — not the `limits[]` array, not `weekly_scoped`, not `scope.model.display_name`, not the model codenames (tangelo/nimbus_quill/etc.), not any field name. A user sees "Fable 5", not the plumbing.
+3. **De-emphasizes destructive actions.** None added — the bar is read-only. There is nothing to click, nothing to confirm, nothing destructive.
+4. **Reads in plain language at phone width.** It reuses the exact `quotaBar` component and CSS the existing two bars use, which is already mobile-responsive; the label "Fable 5" plus a short "N% used · resets in …" line fits phone width identically to "5-hour" / "Weekly". Verified the phrasing is plain (no jargon) and the number is glanceable.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Proxied-on-read + replicated.** The per-account quota (now including `fable`) is already carried in the pool-scope Subscriptions view via `SubscriptionAccountMetaReplicatedStore`. This change explicitly updates that replication path: `fable` is added to the `knownQuota` allowlist and gets the same `{utilizationPct:number, resetsAt:ISO-8601}` shape validation as `fiveHour`/`sevenDay`, so a peer machine's Fable usage survives replication rather than being rejected. This was the one non-obvious side-effect the review caught — a naive add (dashboard + collector only) would have made *every* field of a newer peer's quota vanish on the receiver. No user-facing notice is produced (no one-voice concern). No durable state strands on topic transfer (account meta is machine-owned and replicated, not topic-scoped). No generated URL.
+
+## 8. Rollback cost
+
+Trivial. Pure additive display. Back-out = revert the four hunks + tests; no data migration, no agent-state repair. A stale-but-shipped version simply shows the two prior bars. The replicated-store allowlist entry is inert on any machine whose peers never send `fable`.


### PR DESCRIPTION
## ELI16 — Fable 5 usage bar, in plain words

Fable 5 has its own weekly usage pool, separate from an account's normal limits, and the dashboard never showed it — so the only way to know if it was maxed out was to try a call and hit the wall. This adds a "Fable 5" bar per account in the Subscriptions tab, reading a number Claude's usage API already returns (a weekly limit scoped to the model whose display name is "Fable"). It's read-only: it shows a percent-used and a reset countdown, there's nothing to click, and it does not influence any decision the agent makes. The one careful bit — on a multi-machine setup, the new field is added to the cross-machine sharing allowlist and shape-checked, so a peer's Fable number survives sync instead of being rejected wholesale. Full companion: docs/specs/fable5-quota-dashboard.eli16.md.

## What & why

Adds a per-account **Fable 5** weekly usage bar to the Subscriptions dashboard tab, alongside the existing 5-hour and Weekly bars. Fable 5 has its own weekly allowance separate from an account's overall limits, and it was invisible on the dashboard until now (topic 29836 request from Justin).

**Key finding (live-verified 2026-07-11 across all 4 pool accounts):** the Anthropic /api/oauth/usage response already carries Fable-5 usage — not as a top-level field, but as a scoped weekly limit entry in limits[] whose scope.model.display_name === "Fable" (with percent + resets_at). Live values confirmed: adriana 100% (critical), dawn 36%, sagemind 0%, headley 16%.

## Changes

- src/core/QuotaPoller.ts mapUsageResponse() — parse the Fable limits entry into a new fable window on AccountQuotaSnapshot (same {utilizationPct, resetsAt} shape as fiveHour/sevenDay). Conservative match: group==='weekly' AND display_name==='Fable' AND percent present.
- src/core/SubscriptionPool.ts — AccountQuotaSnapshot gains fable?.
- src/core/SubscriptionAccountMetaReplicatedStore.ts — allow + shape-validate the fable window so multi-machine replication doesn't reject a peer's whole quota object on the new key.
- dashboard/subscriptions.js renderAccounts() — draw a "Fable 5" bar when a reading is present.

## Tests (86 green across the 3 suites; full tsc --noEmit clean)

- tests/unit/quota-poller.test.ts (+4): Fable extraction, maxed-100% read, non-Fable scoped limit not mistaken for Fable, absent-limits → undefined.
- tests/unit/subscriptions-render.test.ts (+3): Fable bar as third bar / only window / no-quota fallback.
- tests/unit/subscription-account-meta-store.test.ts (+2): fable window round-trips replication; malformed rejected.

## Process

Read-only display; no gate/authority/lifecycle surface. Tier 1 (instar-dev gate passed): ELI16 + side-effects artifact (incl. §6b operator-surface quality + §7 multi-machine posture) staged & verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
