### PR TITLE
fix(attention): readable hub alerts — HTML mode, deduped body, machine nicknames

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-12T03-21-43-273Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-12T03-21-43-273Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-12T03:21:43.273Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 83,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-12T03-22-06-903Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-12T03-22-06-903Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-12T03:22:06.903Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 83,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-12T03-22-28-235Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-12T03-22-28-235Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-12T03:22:28.235Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 83,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-12T03-22-54-033Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-12T03-22-54-033Z-unknown.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-12T03:22:54.033Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 83,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-12T03-23-47-069Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-12T03-23-47-069Z-unknown.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2026-07-12T03:23:47.069Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 83,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "one-shot formatting/naming change: the escalation loop (episode-scoped escalate-once + P19 floor cadence) is unchanged — only the emitted string (nickname vs raw id) and the send formatting (parse_mode HTML, deduped body) changed. No new self-triggered action, retry, or cadence is introduced."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-12T03-24-35-105Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-12T03-24-35-105Z-unknown.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2026-07-12T03:24:35.105Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 83,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "one-shot formatting/naming change: the escalation loop (episode-scoped escalate-once + P19 floor cadence) is unchanged — only the emitted string (nickname vs raw id) and the send formatting (parse_mode HTML, deduped body) changed. No new self-triggered action, retry, or cadence is introduced."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/attention-hub-formatting.eli16.md
+++ b/docs/specs/attention-hub-formatting.eli16.md
@@ -1,0 +1,33 @@
+# Attention-hub message formatting fixes — Plain-English Overview
+
+> The one-line version: the alert messages in the 🔔 Attention topic stop showing code tags, stop saying everything twice, and start calling machines by their names.
+
+## The problem in one breath
+
+The operator's screenshots (2026-07-11) showed alert messages that were technically delivered but painful to read: visible `<b>` and `<i>` code tags where bold and italic text should be, every paragraph printed twice back-to-back, and machines identified by 32-character internal ids instead of "Laptop" or "Mac Mini".
+
+## What already exists
+
+- **The single Attention hub** — every alert posts as one message into one dedicated 🔔 topic. That routing works and is untouched.
+- **A message formatter** — converts the agent's markdown into Telegram's rich format on every send. Senders that already produce Telegram HTML must tag their send so the formatter doesn't mangle it; the older per-alert path did this correctly, the newer hub path forgot to.
+- **Alert authors** — the machine-coherence guard and the connection prober write careful, impact-first alert text. Their convention is that the long body *starts with* the short summary — and the posting code rendered both, hence the doubling.
+- **Machine nicknames** — every machine in the pool already has a user-facing nickname in the shared registry; the connection prober just never looked it up.
+
+## What this adds
+
+Three small, targeted repairs — no behavior change to *when* or *why* alerts fire, only to how they read:
+
+- The hub post now tells the formatter "this is already Telegram HTML" (the same tag the per-alert path always used), so bold renders as bold instead of visible tags.
+- A tiny shared rule: when the long body begins with the summary, print it once. If they're genuinely different, print both — never drop information.
+- The connection prober now asks the registry for a machine's nickname and says "the lan rope to Laptop…" instead of "…to peer m_4cbc0d4a0c…". No nickname available → it honestly falls back to the id.
+
+## The safeguards
+
+- **Opt-in only.** The formatter change is a per-call option; every other message path in the system sends exactly as before, byte for byte.
+- **Never worse than today.** If a rich-format send is rejected by Telegram (rare), it falls back to the plain send — the pre-fix appearance, still delivered.
+- **A broken lookup can't break alerting.** If the nickname lookup throws, the prober falls back to the raw id and keeps probing; naming is cosmetic, delivery is not.
+- **No information loss.** The dedupe only collapses a byte-identical embedded copy of the summary; paraphrased or independent descriptions render in full.
+
+## What the reader needs to decide
+
+Nothing risky — this is a readability repair of messages that were already being sent, covered by 11 new tests across the two affected suites plus a 7-suite regression sweep. The one accepted trade: a rare cross-machine relayed hub post (a standby with no bot token of its own) keeps today's plain rendering — extending that envelope is deliberately out of scope here, and the machine that actually produced the broken posts sends directly, so it's fully fixed by this change.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5460,6 +5460,17 @@ export async function startServer(options: StartOptions): Promise<void> {
             const ropeProber = new RopeRecoveryProber(
               {
                 resolver: meshResolver,
+                // Escalation bodies name machines by NICKNAME (rope-health alert
+                // contract), never by raw machine id — resolved from the same
+                // registry the targets come from.
+                nicknameOf: (machineId: string) => {
+                  try {
+                    return idMgr.loadRegistry().machines?.[machineId]?.nickname ?? null;
+                  } catch {
+                    // @silent-fallback-ok — naming is cosmetic; prober falls back to the id.
+                    return null;
+                  }
+                },
                 // The same validated registry view the transport dials: resolve()
                 // validates URL shape per kind + the LAN-subnet gate, so the probe
                 // can never dial a forbidden host.

--- a/src/core/RopeRecoveryProber.ts
+++ b/src/core/RopeRecoveryProber.ts
@@ -76,6 +76,11 @@ export interface RopeRecoveryProberDeps {
   sendProbe: (target: RopeProbeTarget) => Promise<RopeProbeSendResult>;
   /** Escalate-once sink (deduped per (peer,kind,episode)). Absent = log-only. */
   raiseAttention?: (item: { id: string; title: string; body: string }) => unknown;
+  /** User-facing machine nickname for a peer id (registry `nickname`). The
+   *  escalation BODY must name machines by nickname, never by raw machine id
+   *  (rope-health alert contract: rope KIND + machine NICKNAME only). Absent
+   *  or null → fall back to the raw id (honest, but the 2026-07-11 noise). */
+  nicknameOf?: (machineId: string) => string | null;
   /** Feature-metrics sink (key `rope-recovery-probe`). Absent = no metrics. */
   recordMetric?: (event:
     | 'probe-sent' | 'probe-success' | 'probe-failure' | 'rope-recovered'
@@ -287,7 +292,7 @@ export class RopeRecoveryProber {
         this.escalate(
           `rope-probe-slow-alive:${peer}:${kind}:${ep.openedAt}`,
           `Mesh rope ${kind} answers probes but stays demoted`,
-          `The ${kind} rope to peer ${peer} has answered ${ep.unreclaimedSuccesses} consecutive recovery probes but has not reclaimed preferred status — latency above the reclaim bar. Probing continues at the floor cadence.`,
+          `The ${kind} rope to ${this.peerName(peer)} has answered ${ep.unreclaimedSuccesses} consecutive recovery probes but has not reclaimed preferred status — latency above the reclaim bar. Probing continues at the floor cadence.`,
         );
       }
     } else {
@@ -308,11 +313,25 @@ export class RopeRecoveryProber {
           this.escalate(
             `rope-probe-exhausted:${peer}:${kind}:${ep.openedAt}`,
             `Mesh rope ${kind} not recovering`,
-            `The ${kind} rope to peer ${peer} has failed ${ep.probeFailures} recovery probes; probing continues at the floor rate (${Math.round(this.cfg.floorMs / 60000)} min).`,
+            `The ${kind} rope to ${this.peerName(peer)} has failed ${ep.probeFailures} recovery probes; probing continues at the floor rate (${Math.round(this.cfg.floorMs / 60000)} min).`,
           );
         }
       }
     }
+  }
+
+  /** Nickname-first peer naming for escalation bodies (contract: rope KIND +
+   *  machine NICKNAME, never a raw machine id). Falls back to the raw id when
+   *  no resolver is wired or it has no nickname — a throwing resolver must
+   *  never break the probe loop. */
+  private peerName(machineId: string): string {
+    try {
+      const nick = this.d.nicknameOf?.(machineId);
+      if (typeof nick === 'string' && nick.trim().length > 0) return nick.trim();
+    } catch {
+      // @silent-fallback-ok — naming is cosmetic; the probe loop must not break.
+    }
+    return `peer ${machineId}`;
   }
 
   private escalate(id: string, title: string, body: string): void {

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -1308,6 +1308,13 @@ export class TelegramAdapter implements MessagingAdapter {
        *  hop (spec outbound-jargon-filepath-gap §2.5). Direct sends ignore it
        *  — the local route already consumed it. */
       kindMetadata?: Record<string, unknown>;
+      /** 'html' = the caller already produced ESCAPED Telegram HTML (e.g. the
+       *  attention-hub post) — the send carries `parse_mode: 'HTML'` +
+       *  `_formatMode: 'html'` so applyTelegramFormatter's markdown converter
+       *  does not re-escape the tags into literal `<b>`/`<i>` text (the
+       *  2026-07-11 attention-hub rendering bug). Direct sends only; a relayed
+       *  (tokenless-standby) send keeps today's default formatting. */
+      formatMode?: 'html';
     },
   ): Promise<SendResult> {
     const params: Record<string, unknown> = {
@@ -1341,6 +1348,15 @@ export class TelegramAdapter implements MessagingAdapter {
         throw new Error('telegram outbound relay failed (tokenless standby, router unreachable)');
       }
       result = { message_id: relayed.messageId };
+    } else if (options?.formatMode === 'html') {
+      // Caller-authored, already-escaped Telegram HTML: one deterministic send.
+      // On a rare 400 (malformed entity), fall back to the plain-param send so
+      // the message still delivers (tags visible — never worse than the bug).
+      try {
+        result = await this.apiCall('sendMessage', { ...params, parse_mode: 'HTML', _formatMode: 'html' }) as { message_id: number };
+      } catch {
+        result = await this.apiCall('sendMessage', params) as { message_id: number };
+      }
     } else {
       try {
         result = await this.apiCall('sendMessage', { ...params, parse_mode: 'Markdown' }) as { message_id: number };
@@ -3941,8 +3957,7 @@ export class TelegramAdapter implements MessagingAdapter {
       const detail = [
         `<b>${this.escapeHtml(item.category)}</b> | Priority: ${item.priority}`,
         ``,
-        this.escapeHtml(item.summary),
-        item.description ? `\n${this.escapeHtml(item.description.slice(0, 1000))}` : '',
+        ...attentionBodyBlocks(item.summary, item.description, 1000).map((b) => this.escapeHtml(b)),
         item.sourceContext ? `\n<i>Source: ${this.escapeHtml(item.sourceContext)}</i>` : '',
         ``,
         `Commands: /ack, /done, /wontdo, /reopen`,
@@ -4227,8 +4242,7 @@ export class TelegramAdapter implements MessagingAdapter {
       `${emoji} <b>${this.escapeHtml(item.title)}</b>`,
       `${this.escapeHtml(item.category)} | Priority: ${item.priority}`,
       ``,
-      this.escapeHtml(item.summary),
-      item.description ? `\n${this.escapeHtml(item.description.slice(0, 500))}` : '',
+      ...attentionBodyBlocks(item.summary, item.description, 500).map((b) => this.escapeHtml(b)),
       item.sourceContext ? `\n<i>Source: ${this.escapeHtml(item.sourceContext)}</i>` : '',
     ].filter(Boolean).join('\n');
 
@@ -4242,7 +4256,7 @@ export class TelegramAdapter implements MessagingAdapter {
     }
     if (typeof injected === 'number' && injected > 0) {
       try {
-        await this.sendToTopic(injected, detail);
+        await this.sendToTopic(injected, detail, { formatMode: 'html' });
         return injected;
       } catch (err) {
         console.warn(`[telegram] attention hub send to injected topic ${injected} failed (${err}); self-healing a hub topic`);
@@ -4269,7 +4283,7 @@ export class TelegramAdapter implements MessagingAdapter {
     // Best-effort hub post; the item is already recorded in the attention
     // store. If the hub was deleted out from under us, drop the cached id so
     // it's recreated next time.
-    await this.sendToTopic(topicId, detail).catch(() => { this.attentionHubTopicId = null; }); // @silent-fallback-ok
+    await this.sendToTopic(topicId, detail, { formatMode: 'html' }).catch(() => { this.attentionHubTopicId = null; }); // @silent-fallback-ok
     return topicId;
   }
 
@@ -5592,6 +5606,29 @@ export class TelegramAdapter implements MessagingAdapter {
 
     return data.result;
   }
+}
+
+/**
+ * The summary/description blocks of an attention-item post, WITHOUT the
+ * duplicated paragraph. Episode renderers (machine-coherence, rope probe)
+ * conventionally build `description` as `${summary}\n\n${...}` — rendering
+ * both repeated the same paragraph twice in every hub post (the 2026-07-11
+ * attention-hub duplication bug). When description starts with summary (or
+ * there is no description), exactly one copy renders. Pure for testability;
+ * blocks are UNESCAPED — the caller escapes each before splicing into HTML.
+ */
+export function attentionBodyBlocks(
+  summary: string | null | undefined,
+  description: string | null | undefined,
+  descriptionSlice: number,
+): string[] {
+  const s = (summary ?? '').trim();
+  const d = (description ?? '').trim();
+  if (!d) return s ? [s] : [];
+  const dSliced = d.slice(0, descriptionSlice);
+  if (s && d.startsWith(s)) return [dSliced];
+  // Leading \n preserves the original blank-line separation when joined by '\n'.
+  return s ? [s, `\n${dSliced}`] : [dSliced];
 }
 
 /**

--- a/tests/unit/RopeRecoveryProber.test.ts
+++ b/tests/unit/RopeRecoveryProber.test.ts
@@ -25,7 +25,7 @@ interface Harness {
   clock: { t: number };
   probes: Array<{ at: number }>;
   logs: string[];
-  attention: Array<{ id: string; title: string }>;
+  attention: Array<{ id: string; title: string; body: string }>;
   metrics: string[];
   setProbeResult: (r: Partial<RopeProbeSendResult>) => void;
   tick: () => Promise<void>;
@@ -33,7 +33,7 @@ interface Harness {
   run: (durationMs: number, stepMs?: number) => Promise<void>;
 }
 
-function boot(opts: { dryRun?: boolean; floorMs?: number; exhaustAttempts?: number; midIntervalMs?: number; maxUnreclaimedSuccesses?: number; reopenEpisodeWindowMs?: number } = {}): Harness {
+function boot(opts: { dryRun?: boolean; floorMs?: number; exhaustAttempts?: number; midIntervalMs?: number; maxUnreclaimedSuccesses?: number; reopenEpisodeWindowMs?: number; nicknameOf?: (m: string) => string | null } = {}): Harness {
   const clock = { t: 1_000_000 };
   const resolver = new PeerEndpointResolver({
     config: {
@@ -53,7 +53,7 @@ function boot(opts: { dryRun?: boolean; floorMs?: number; exhaustAttempts?: numb
   });
   const probes: Array<{ at: number }> = [];
   const logs: string[] = [];
-  const attention: Array<{ id: string; title: string }> = [];
+  const attention: Array<{ id: string; title: string; body: string }> = [];
   const metrics: string[] = [];
   let result: RopeProbeSendResult = { typedSuccess: false, detail: 'refused', latencyMs: 20 };
   const prober = new RopeRecoveryProber(
@@ -65,11 +65,12 @@ function boot(opts: { dryRun?: boolean; floorMs?: number; exhaustAttempts?: numb
         return { ...result };
       },
       raiseAttention: (item) => {
-        attention.push({ id: item.id, title: item.title });
+        attention.push({ id: item.id, title: item.title, body: item.body });
       },
       recordMetric: (e) => {
         metrics.push(e);
       },
+      nicknameOf: opts.nicknameOf,
       now: () => clock.t,
       logger: (m) => logs.push(m),
     },
@@ -360,5 +361,46 @@ describe('RopeRecoveryProber — /health view rows', () => {
     expect(row.lastProbeAt).not.toBeNull();
     expect(row.nextProbeDueAt).toBeGreaterThan(row.lastProbeAt!);
     expect(JSON.stringify(row)).not.toContain('http');
+  });
+});
+
+describe('RopeRecoveryProber — escalation bodies name machines by NICKNAME (2026-07-11 raw-id fix)', () => {
+  it('slow-alive escalation body carries the nickname, never the raw machine id', async () => {
+    const h = boot({
+      midIntervalMs: 10_000, maxUnreclaimedSuccesses: 3, floorMs: 900_000,
+      nicknameOf: (m) => (m === PEER ? 'Laptop' : null),
+    });
+    killRope(h);
+    h.setProbeResult({ typedSuccess: true, latencyMs: 9_000 });
+    await h.tick();
+    await h.run(30_000, 10_000);
+    const [esc] = h.attention.filter((a) => a.id.startsWith('rope-probe-slow-alive'));
+    expect(esc).toBeDefined();
+    expect(esc.body).toContain('The tailscale rope to Laptop has answered');
+    expect(esc.body).not.toContain(PEER); // raw id never surfaces to the user
+  });
+
+  it('exhaustion escalation body carries the nickname too', async () => {
+    const h = boot({ exhaustAttempts: 3, midIntervalMs: 10_000, nicknameOf: () => 'Laptop' });
+    killRope(h);
+    h.setProbeResult({ typedSuccess: false });
+    await h.run(60_000, 10_000);
+    const [esc] = h.attention.filter((a) => a.id.startsWith('rope-probe-exhausted'));
+    expect(esc).toBeDefined();
+    expect(esc.body).toContain('The tailscale rope to Laptop has failed');
+    expect(esc.body).not.toContain(PEER);
+  });
+
+  it('no resolver (or no nickname) falls back to the raw id — and a THROWING resolver never breaks the probe loop', async () => {
+    const h = boot({
+      exhaustAttempts: 3, midIntervalMs: 10_000,
+      nicknameOf: () => { throw new Error('registry unreadable'); },
+    });
+    killRope(h);
+    h.setProbeResult({ typedSuccess: false });
+    await h.run(60_000, 10_000);
+    const [esc] = h.attention.filter((a) => a.id.startsWith('rope-probe-exhausted'));
+    expect(esc).toBeDefined();
+    expect(esc.body).toContain(`peer ${PEER}`); // honest fallback
   });
 });

--- a/tests/unit/attention-single-topic-routing.test.ts
+++ b/tests/unit/attention-single-topic-routing.test.ts
@@ -15,13 +15,15 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { TelegramAdapter, type TelegramConfig } from '../../src/messaging/TelegramAdapter.js';
+import { TelegramAdapter, type TelegramConfig, attentionBodyBlocks } from '../../src/messaging/TelegramAdapter.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 interface Recorder {
   forumTopicsCreated: number;
   topicTitles: string[];
   messagesByThread: Map<number, string[]>;
+  /** Full sendMessage params per thread — lets tests assert parse_mode/_formatMode. */
+  sendParamsByThread: Map<number, Array<Record<string, unknown>>>;
   closedTopics: number[];
   failSendToThread: number | null;
 }
@@ -31,6 +33,7 @@ function installApiStub(adapter: TelegramAdapter): Recorder {
     forumTopicsCreated: 0,
     topicTitles: [],
     messagesByThread: new Map(),
+    sendParamsByThread: new Map(),
     closedTopics: [],
     failSendToThread: null,
   };
@@ -50,6 +53,9 @@ function installApiStub(adapter: TelegramAdapter): Recorder {
         const texts = rec.messagesByThread.get(tid) ?? [];
         texts.push(String(params.text ?? ''));
         rec.messagesByThread.set(tid, texts);
+        const allParams = rec.sendParamsByThread.get(tid) ?? [];
+        allParams.push({ ...params });
+        rec.sendParamsByThread.set(tid, allParams);
         return { message_id: threadSeq * 10 + texts.length };
       }
       if (method === 'closeForumTopic') {
@@ -127,6 +133,69 @@ describe('Single-alerts-topic routing (default mode)', () => {
     expect(msg).toContain('x'.repeat(500));
     expect(msg).not.toContain('x'.repeat(501));
     expect(msg).toContain('<i>Source: rope-recovery-probe</i>');
+  });
+
+  it('the hub post rides parse_mode HTML + _formatMode html (the 2026-07-11 literal-tag fix)', async () => {
+    const HUB = 781;
+    makeAdapter({ getAttentionHubTopicId: () => HUB });
+    const rec = installApiStub(adapter);
+
+    await adapter.createAttentionItem({
+      id: 'hub-html-mode',
+      title: 'Machine coherence: my machines have drifted apart',
+      summary: 'drift summary',
+      category: 'machine-coherence',
+      priority: 'HIGH',
+      sourceContext: 'machine-coherence-guard',
+    });
+
+    const [params] = rec.sendParamsByThread.get(HUB)!;
+    // Without these two the default markdown formatter escapes the authored
+    // <b>/<i> tags and the user sees them as literal text in Telegram.
+    expect(params.parse_mode).toBe('HTML');
+    expect(params._formatMode).toBe('html');
+  });
+
+  it('a description that begins with the summary renders the paragraph ONCE (the 2026-07-11 duplication fix)', async () => {
+    const HUB = 782;
+    makeAdapter({ getAttentionHubTopicId: () => HUB });
+    const rec = installApiStub(adapter);
+
+    const summary = 'My machines have drifted apart — Mac Mini and Laptop aren\'t running as the same me.';
+    await adapter.createAttentionItem({
+      id: 'hub-dedupe',
+      title: 'Machine coherence',
+      summary,
+      // Episode renderers build description as `${summary}\n\n${fix}\n\n${tech}`.
+      description: `${summary}\n\nReply fix it and I will align them.\n\nTechnical detail:\nversion · instarVersion`,
+      category: 'machine-coherence',
+      priority: 'HIGH',
+    });
+
+    const [msg] = rec.messagesByThread.get(HUB)!;
+    const occurrences = msg.split('drifted apart').length - 1;
+    expect(occurrences).toBe(1); // summary paragraph exactly once
+    expect(msg).toContain('Reply fix it'); // the description tail still renders
+    expect(msg).toContain('Technical detail:');
+  });
+
+  it('a description that does NOT begin with the summary still renders both blocks', async () => {
+    const HUB = 783;
+    makeAdapter({ getAttentionHubTopicId: () => HUB });
+    const rec = installApiStub(adapter);
+
+    await adapter.createAttentionItem({
+      id: 'hub-both-blocks',
+      title: 'T',
+      summary: 'short impact line',
+      description: 'a longer independent explanation',
+      category: 'general',
+      priority: 'NORMAL',
+    });
+
+    const [msg] = rec.messagesByThread.get(HUB)!;
+    expect(msg).toContain('short impact line');
+    expect(msg).toContain('a longer independent explanation');
   });
 
   it('resolving a hub-routed item NEVER closes the shared hub topic', async () => {
@@ -230,5 +299,26 @@ describe('Single-alerts-topic routing (default mode)', () => {
     );
     const wirings = serverSrc.match(/getAttentionHubTopicId: \(\) => state\.get<number>\('agent-attention-topic'\) \?\? null/g) ?? [];
     expect(wirings.length).toBe(2);
+  });
+});
+
+describe('attentionBodyBlocks (pure) — summary/description dedupe', () => {
+  it('description starting with summary → one block (description only)', () => {
+    expect(attentionBodyBlocks('sum', 'sum\n\nmore detail', 500)).toEqual(['sum\n\nmore detail']);
+  });
+  it('identical summary and description → one block', () => {
+    expect(attentionBodyBlocks('same text', 'same text', 500)).toEqual(['same text']);
+  });
+  it('independent description → both blocks, blank-line separated', () => {
+    expect(attentionBodyBlocks('impact', 'independent detail', 500)).toEqual(['impact', '\nindependent detail']);
+  });
+  it('no description → summary only; nothing → empty', () => {
+    expect(attentionBodyBlocks('impact', null, 500)).toEqual(['impact']);
+    expect(attentionBodyBlocks('impact', undefined, 500)).toEqual(['impact']);
+    expect(attentionBodyBlocks('', '', 500)).toEqual([]);
+  });
+  it('description is clipped to the slice bound', () => {
+    const [only] = attentionBodyBlocks('s', 's' + 'x'.repeat(900), 500);
+    expect(only.length).toBe(500);
   });
 });

--- a/upgrades/next/attention-hub-formatting.md
+++ b/upgrades/next/attention-hub-formatting.md
@@ -1,0 +1,21 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Three rendering bugs in attention-alert messages, all visible in the operator's 🔔 Attention hub on 2026-07-11 (topic 29836 report): (1) **literal `<b>`/`<i>` tags** — the hub post authors Telegram HTML but sent it through `sendToTopic` without the formatter's `_formatMode: 'html'` opt-out, so the default GFM→HTML converter escaped the tags into visible text (the per-item legacy path already passed it; the hub path was missed). `sendToTopic` now accepts `formatMode: 'html'` and the hub post uses it (`parse_mode: 'HTML'` + `_formatMode: 'html'`, with a plain-param fallback on a rare 400). (2) **Every alert paragraph rendered twice** — episode renderers (machine-coherence, rope probe) build `description` as `${summary}\n\n${...}`, and both hub and per-item posts rendered summary AND description. A shared pure helper (`attentionBodyBlocks`) now renders the paragraph once when description begins with summary. (3) **Raw machine ids in rope alerts** (`m_4cbc0d…` instead of "Laptop") — violating the rope-health contract (rope KIND + machine NICKNAME only). `RopeRecoveryProber` now takes an optional `nicknameOf` dep, wired from the machine registry at the server construction site; fallback stays the raw id (honest) and a throwing resolver can never break the probe loop.
+
+## What to Tell Your User
+
+The alert messages in your 🔔 Attention topic are readable now: no more visible `<b>` code tags, no more saying everything twice, and connection alerts name your machines the way you do ("Laptop", "Mac Mini") instead of long internal ids. Same alerts, same information — just formatted like a human wrote them.
+
+## Summary of New Capabilities
+
+- `sendToTopic(..., { formatMode: 'html' })` — opt-in for callers that author escaped Telegram HTML, so the markdown converter doesn't re-escape it.
+- `attentionBodyBlocks(summary, description, slice)` — exported pure helper deduping the summary paragraph in attention posts (hub + per-item paths).
+- `RopeRecoveryProberDeps.nicknameOf` — escalation bodies name machines by registry nickname.
+
+## Evidence
+
+- `tests/unit/attention-single-topic-routing.test.ts` (+3 routed + 5 pure): hub post rides `parse_mode: 'HTML'` + `_formatMode: 'html'`; summary paragraph renders exactly once when description embeds it; independent description still renders both blocks; `attentionBodyBlocks` edge cases (identical, absent, slice bound).
+- `tests/unit/RopeRecoveryProber.test.ts` (+3): slow-alive and exhaustion bodies carry the nickname and never the raw id; a throwing nickname resolver falls back to the id without breaking the probe loop.
+- Full `tsc --noEmit` clean; 118 tests green across the two extended suites + 7 adjacent telegram/attention suites.

--- a/upgrades/next/attention-hub-formatting.md
+++ b/upgrades/next/attention-hub-formatting.md
@@ -6,7 +6,7 @@ Three rendering bugs in attention-alert messages, all visible in the operator's 
 
 ## What to Tell Your User
 
-The alert messages in your 🔔 Attention topic are readable now: no more visible `<b>` code tags, no more saying everything twice, and connection alerts name your machines the way you do ("Laptop", "Mac Mini") instead of long internal ids. Same alerts, same information — just formatted like a human wrote them.
+The alert messages in your 🔔 Attention topic are readable now: no more visible code tags where bold text should be, no more saying everything twice, and connection alerts name your machines the way you do ("Laptop", "Mac Mini") instead of long internal ids. Same alerts, same information — just formatted like a human wrote them.
 
 ## Summary of New Capabilities
 

--- a/upgrades/side-effects/attention-hub-formatting.md
+++ b/upgrades/side-effects/attention-hub-formatting.md
@@ -1,0 +1,65 @@
+# Side-Effects Review — Attention-hub message formatting fixes
+
+**Version / slug:** `attention-hub-formatting`
+**Date:** `2026-07-11`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (no block/allow decision, no lifecycle surface — formatting + naming of already-delivered messages; see §4)`
+
+## Summary of the change
+
+Fixes three rendering bugs reported by the operator (topic 29836, 2026-07-11 screenshots of the 🔔 Attention hub): literal `<b>`/`<i>` tags in hub posts, every alert paragraph rendered twice, and raw machine ids (`m_4cbc0d…`) instead of nicknames in rope alerts. Files: `src/messaging/TelegramAdapter.ts` (a `formatMode: 'html'` option on `sendToTopic`, used by `routeToAttentionHub`; a shared pure `attentionBodyBlocks` dedupe helper used by the hub AND legacy per-item assembly), `src/core/RopeRecoveryProber.ts` (optional `nicknameOf` dep + nickname-first `peerName` in the two escalation bodies), `src/commands/server.ts` (wires `nicknameOf` from the machine registry).
+
+## Decision-point inventory
+
+- No decision point added, modified, or removed. The alerts fire under exactly the same conditions as before; only their TEXT and SEND FORMATTING change. `sendToTopic`'s new `formatMode` branch is opt-in per call — every existing caller is byte-identical in behavior.
+- Pass-through: the tokenless-standby RELAY branch of `sendToTopic` is deliberately untouched — a relayed hub post keeps today's default formatting (documented in the option's doc comment; see §5).
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. Nothing is suppressed: the dedupe renders the same information once instead of twice (the description embeds the summary by construction in the episode renderers), and when description does NOT begin with summary, both blocks render exactly as before.
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. Conservative bounds: the dedupe keys on a strict `startsWith` after trim — a description that paraphrases (rather than embeds) the summary renders both blocks (possible residual near-duplication, acceptable; never information loss). The HTML-mode send falls back to the plain-param send on a 400 (tags visible in that rare case — the pre-fix steady state, never worse).
+
+## 3. Level-of-abstraction fit
+
+Correct layers. The HTML-mode fix is at the send seam (`sendToTopic`) where the formatter contract (`_formatMode`) already lives — mirroring the existing per-item direct-send pattern rather than inventing a parallel path. The dedupe is a shared pure helper used by both assembly sites (hub + per-item), not two divergent patches. The nickname fix respects the prober's dependency-injection shape (a `nicknameOf` dep like its other seams), with resolution wired at the composition root (server.ts) from the same registry the probe targets come from.
+
+## 4. Signal vs authority compliance
+
+Compliant. No authority is created or moved: the prober still only *signals* (raiseAttention), the hub still only *posts*. The `peerName` resolver is wrapped so a throwing registry read can never break the probe loop (signal, not authority — same posture as the existing escalate try/catch). Per `docs/signal-vs-authority.md`, no brittle check gains blocking power.
+
+## 5. Interactions
+
+- **`sendToTopic` callers:** the new branch is strictly opt-in (`options.formatMode === 'html'`); all existing callers hit the unchanged Markdown-first/plain-fallback path. Duplicate-suppression, stall-clear, promise-tracking, and logging bookkeeping run identically for HTML-mode sends (same method body).
+- **Tokenless-standby relay:** a standby without a usable bot token relays hub posts through the Telegram-owning router WITHOUT the format mode — that hop keeps today's (escaped-tags) rendering. Accepted: the observed broken posts came from a machine with its own resolved token (direct path), which this fixes; extending the relay envelope is a separate, wider change. Documented in the option's doc comment.
+- **Legacy per-item mode:** gets the dedupe (shared helper) and already had HTML mode — no behavior divergence introduced between modes.
+- **No double-fire / shadowing:** message assembly is synchronous inside the same functions; no new timer, queue, or listener.
+
+## 6. External surfaces
+
+User-visible text of attention alerts changes (deduped, rendered rich instead of literal tags, nicknames instead of ids). No new API, route, or notification. The alert *content contract* (title, category, priority, source) is unchanged — only duplication and encoding.
+
+## 6b. Operator-surface quality
+
+The Telegram alert message IS an operator surface, so answering although no dashboard file changed:
+
+1. **Leads with its primary action:** unchanged lead (title + priority first); the fix actually surfaces the episode renderers' carefully-ordered impact-first body (summary → fix proposal → technical detail) without the duplicated paragraph burying it.
+2. **Zero raw internals as primary content:** this change is precisely the removal of raw internals — literal `<b>`/`<i>` markup and raw machine ids no longer reach the operator; machines are named by their nicknames ("Laptop"), matching how the operator refers to them.
+3. **De-emphasizes destructive actions:** none exist in these messages (fix-it/leave-it reply prompts are authored upstream and unchanged).
+4. **Plain language at phone width:** the deduped body is roughly half the height on a phone (the screenshots showed the doubled paragraph forcing a scroll per alert); rich formatting (real bold titles, italic source line) restores the intended visual hierarchy.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design, converging via release rollout.** Message assembly runs on the machine that raises the alert; there is no replicated state in this change. The observed bad posts came from the Laptop — it receives this fix through the normal auto-update, which is the only correct distribution path (no config, no migration). The relay (cross-machine) hop is explicitly documented as keeping default formatting (§5). `nicknameOf` reads the machine's own registry copy — nicknames are already registry-synced pool-wide, so both machines resolve the same names. No user-facing notice is added (one-voice unaffected); no durable state; no URLs.
+
+## 8. Rollback cost
+
+Trivial. Revert the three-file diff; no data migration, no state repair. The `formatMode` option and helper are additive; reverting restores the (ugly but delivered) pre-fix rendering.
+
+## Class-Closure Declaration
+
+- **defectClass:** `unbounded-self-action` — **closure: n/a.** This is a one-shot formatting/naming change: the escalation loop it touches (RopeRecoveryProber's episode-scoped escalate-ONCE with P19 floor cadence, and the attention hub's per-item post) is unchanged in trigger, cadence, dedupe, and bounds — only the emitted STRING (nickname vs raw machine id) and the send FORMATTING (parse_mode HTML + deduped body) changed. No new self-triggered action, retry, respawn, or cadence is introduced anywhere in the diff.


### PR DESCRIPTION
## ELI16 — readable alerts, in plain words

The operator's Attention topic was showing alerts with visible code tags where bold text should be, every paragraph printed twice, and machines named by 32-character internal ids. Three small repairs: the hub post now tells the message formatter "this is already rich text" (the tag the older per-alert path always used and the hub path forgot), a tiny shared rule prints the summary paragraph once when the long body starts with it (never dropping an independent description), and connection alerts look up the machine's nickname ("Laptop") from the registry, falling back honestly to the id if there is none. Nothing changes about when or why alerts fire — only how they read. A broken nickname lookup can't break alerting, and a rejected rich-format send falls back to the plain send (the pre-fix look, still delivered).

## What & why (operator report, topic 29836, 2026-07-11)

Screenshots of the 🔔 Attention hub showed three rendering bugs on machine-coherence and rope-recovery-probe alerts.

## Changes

- **`src/messaging/TelegramAdapter.ts`** — `sendToTopic` gains opt-in `formatMode: 'html'` (sends `parse_mode: 'HTML'` + `_formatMode: 'html'`, plain-param fallback on 400); `routeToAttentionHub` uses it. Shared pure `attentionBodyBlocks()` dedupes the summary paragraph in BOTH the hub and legacy per-item assemblies (strict startsWith — an independent description still renders both blocks). All other `sendToTopic` callers byte-identical.
- **`src/core/RopeRecoveryProber.ts`** — optional `nicknameOf` dep; escalation bodies name machines by nickname (`peerName()`, raw-id fallback, throwing resolver can never break the probe loop). Escalation triggers/cadence/dedupe unchanged.
- **`src/commands/server.ts`** — wires `nicknameOf` from the machine registry at the prober construction site.

## Tests (118 green: 33 in the two extended suites + 85 across 7 adjacent suites; tsc clean)

- `attention-single-topic-routing.test.ts` (+8): hub post rides parse_mode HTML + _formatMode html; summary renders once when description embeds it; both blocks when independent; pure-helper edge cases (identical, absent, slice bound).
- `RopeRecoveryProber.test.ts` (+3): slow-alive + exhaustion bodies carry the nickname, never the raw id; throwing resolver falls back without breaking the loop.

## Process

Tier 1 (instar-dev gate passed): ELI16 + side-effects artifact (incl. §6b operator-surface quality, §7 multi-machine posture, class-closure declaration: self-action n/a — the escalation loop is unchanged, only strings/formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)