### PR TITLE
feat(provenance): enroll MessagingToneGate as a wired decision point (ACT-1193 expansion)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-12T22-35-24-660Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-12T22-35-24-660Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-12T22:35:24.660Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 193,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -28,6 +28,23 @@ import {
 } from './GateSignalDetectors.js';
 import { detectInternalIdLeak } from './internal-id-leak.js';
 import { detectSelfStopShape } from './self-stop-floor.js';
+import { DP_MESSAGING_TONE_GATE } from '../data/provenanceCoverage.js';
+
+/**
+ * The prompt-version tag for the tone-gate judge, declared as the provenance
+ * `promptId` (llm-decision-quality-meter §5.2 — a stable, clamp-safe
+ * ^[a-zA-Z0-9_-]{1,64}$ version tag). BUMP ON ANY PROMPT CHANGE so grade-by-
+ * promptId aggregates never silently mix prompt semantics. `-sigv1` marks the
+ * signal-driven B1–B7 prompt shape (CMT-1793).
+ */
+export const TONE_GATE_PROMPT_ID = 'tone-gate-sigv1';
+
+/**
+ * The bounded action space the tone judge emits, declared as `optionsPresented`
+ * on the provenance enrollment (§5.2 static, code-authored, enum-like labels):
+ * the gate makes ONE deliver-or-block decision per call.
+ */
+export const TONE_OPTIONS_PRESENTED = ['PASS', 'BLOCK'] as const;
 
 /**
  * Why the LLM tone authority could not produce a verdict — an INFRA reason
@@ -94,6 +111,44 @@ export function detectDeterministicLeak(
     return { rule: 'B20_INTERNAL_ID_LEAK', kind: 'internal-id-leak' };
   }
   return null;
+}
+
+/**
+ * The §5.2 content-bearing decision-context envelope for the tone gate's
+ * provenance row (llm-decision-quality-meter). The gate judges an agent-authored
+ * OUTBOUND message; the row stores it as IDENTITY ONLY — a sha256 of the exact
+ * candidate + byte/char bounds — plus CODE-DERIVED features (channel, messageKind,
+ * recent-message COUNT, the deterministic gate-signal KINDS). It NEVER stores the
+ * message body or any plaintext slice of it.
+ *
+ * WHY NO plaintext head (mirrors the CompletionEvaluator content-bearing sibling,
+ * §5.3): the candidate IS the very outbound text this gate exists to inspect for
+ * leaks — a bounded head, even credential-scrubbed, would still archive
+ * non-credential PII / user-facing prose the store must not become a copy of. The
+ * hash gives full identity (correlate/dedupe/replay-verify) with zero body
+ * exposure.
+ */
+export function buildToneDecisionContext(
+  text: string,
+  context: ToneReviewContext,
+): Record<string, unknown> {
+  const sha256 = (s: string): string => crypto.createHash('sha256').update(s, 'utf8').digest('hex');
+  const ctx: Record<string, unknown> = {
+    candidate: {
+      sha256: sha256(text),
+      bytes: Buffer.byteLength(text, 'utf8'),
+      chars: text.length,
+    },
+    channel: String(context.channel ?? '').slice(0, 32),
+    messageKind: context.messageKind ?? 'reply',
+    recentMessageCount: Array.isArray(context.recentMessages) ? context.recentMessages.length : 0,
+    // The deterministic gate-signal KINDS the prompt was handed (identity +
+    // features discipline — the kinds, not the offending substrings).
+    gateSignalKinds: detectGateSignals(text)
+      .filter((s) => s.detected)
+      .map((s) => s.kind),
+  };
+  return ctx;
 }
 
 /**
@@ -671,6 +726,20 @@ export class MessagingToneGate {
         gating: true,
         ...(interactiveLane ? { lane: 'interactive' as const } : {}),
       }, // attribution for /metrics/features + F5 lane
+      // LLM-Decision Quality Meter §5.1.4/§5.6 Layer-B enrollment (decision
+      // point `messaging-tone-gate`, volumeClass budget:500, content-bearing —
+      // candidate IDENTITY only: sha256 + bounds + code-derived features, never
+      // the outbound body). Observability-only: the router-settlement seam CONSUMES
+      // this block (strips it before any inner adapter) and records the row on
+      // its own path — it NEVER reaches the model and NEVER alters the gate's
+      // block/allow verdict (a provenance write failure is contained by the
+      // recorder's own total/fail-open contract).
+      provenance: {
+        decisionPoint: DP_MESSAGING_TONE_GATE,
+        context: buildToneDecisionContext(text, context),
+        optionsPresented: [...TONE_OPTIONS_PRESENTED],
+        promptId: TONE_GATE_PROMPT_ID,
+      },
     };
     const cfg = this.getConfig();
     // Availability-sensitive disposition (spec §Design 6 + tone-gate-graceful-

--- a/src/core/decisionGradingPass.ts
+++ b/src/core/decisionGradingPass.ts
@@ -74,19 +74,71 @@ export interface DecisionGradingPassResult {
 }
 
 /**
+ * The DecisionGrading-owned window-close points this pass drives (§5.5). ONE
+ * today (`hog-sustained-right-v1` over `external-hog-kill-leave`); adding another
+ * appends its point id here. The per-point sub-budget (`perPointSubBudget`)
+ * divides the GLOBAL row budget across THIS set round-robin so no single point
+ * can consume a whole pass and starve a sibling's maturing evidence window
+ * (LES r6 / §5.5 — the fairness bound the census `SUBBUDGET_IMPLEMENTED` flag
+ * asserts is in place before a third ENROLLED customer). MessagingToneGate (the
+ * third enrolled customer) is graded by its own evidence source, not this pass —
+ * so it is not listed here, but its enrollment is what tripped the structural
+ * requirement that this sub-budget exist.
+ */
+export const GRADE_PASS_POINTS: ReadonlyArray<string> = [DP_EXTERNAL_HOG_KILL_LEAVE];
+
+/**
+ * The per-point row slice of the GLOBAL grading budget (§5.5 fairness). Divides
+ * `globalBudget` evenly across `pointCount` grade-pass-driven points, floored at
+ * 1 so every point always makes some progress. With a single point (today) this
+ * returns the full budget — byte-identical to the pre-sub-budget behavior — and
+ * a second high-volume point can no longer starve the first: each gets ⌊N/2⌋.
+ */
+export function perPointSubBudget(globalBudget: number, pointCount: number): number {
+  const n = Math.max(1, Math.floor(pointCount) || 1);
+  return Math.max(1, Math.floor(globalBudget / n));
+}
+
+/**
  * Run one deterministic grading pass. See the module doc for cursor semantics.
- * The only DecisionGrading-owned window-close rule in this build is
- * `hog-sustained-right-v1`; adding another enrolls a new point here AND flips
- * `SUBBUDGET_IMPLEMENTED` (the census ratchet enforces the fairness sub-budget
- * before a third enrolled point).
+ * The GLOBAL row budget is split per-point (`perPointSubBudget`) across
+ * `GRADE_PASS_POINTS` so a high-volume point cannot consume a whole pass and
+ * starve a sibling — the §5.5 fairness sub-budget (`SUBBUDGET_IMPLEMENTED`).
  */
 export function runDecisionGradingPass(deps: DecisionGradingPassDeps): DecisionGradingPassResult {
   const { ledger, hogStore, annotate, now } = deps;
-  const budget = Math.max(1, Math.min(10_000, Math.floor(deps.maxDecisionsPerPass) || 200));
+  const globalBudget = Math.max(1, Math.min(10_000, Math.floor(deps.maxDecisionsPerPass) || 200));
   const evidenceWindowMs = deps.evidenceWindowMs > 0 ? deps.evidenceWindowMs : 6 * HOUR_MS;
   const result: DecisionGradingPassResult = { graded: 0, byRule: {}, cursors: {} };
-  const point = DP_EXTERNAL_HOG_KILL_LEAVE;
   const nowMs = now();
+
+  // §5.5 fairness: each grade-pass-driven point gets an even slice of the global
+  // budget (round-robin over cursors), so no point can consume a whole pass.
+  const subBudget = perPointSubBudget(globalBudget, GRADE_PASS_POINTS.length);
+
+  for (const point of GRADE_PASS_POINTS) {
+    gradeOnePoint({ ledger, hogStore, annotate, point, subBudget, evidenceWindowMs, nowMs, result });
+  }
+  return result;
+}
+
+/**
+ * Grade one point's matured evidence within its own sub-budget slice, writing
+ * its advanced cursor + P19 backoff bookkeeping. Extracted from the single-point
+ * body so the sub-budget can drive N points fairly (§5.5). Behavior for the hog
+ * point is unchanged from the pre-sub-budget single-point walk.
+ */
+function gradeOnePoint(args: {
+  ledger: FeatureMetricsLedger;
+  hogStore: ExternalHogDecisionStore | null;
+  annotate: (a: DecisionOutcomeAnnotationInput) => DecisionOutcomeAnnotationResult;
+  point: string;
+  subBudget: number;
+  evidenceWindowMs: number;
+  nowMs: number;
+  result: DecisionGradingPassResult;
+}): void {
+  const { ledger, hogStore, annotate, point, subBudget, evidenceWindowMs, nowMs, result } = args;
 
   const cursor = ledger.getGradingCursor(point) ?? {
     decisionPoint: point,
@@ -101,14 +153,14 @@ export function runDecisionGradingPass(deps: DecisionGradingPassDeps): DecisionG
   // matured — skip it entirely this pass (report the frozen boundary honestly).
   if (cursor.nextRecheckTs !== null && nowMs < cursor.nextRecheckTs) {
     result.cursors[point] = { ts: cursor.cursorTs, correlationId: cursor.cursorCorrelationId };
-    return result;
+    return;
   }
 
   // No durable evidence source wired (the sentinel store is not constructed) →
   // nothing to grade; leave the cursor untouched.
   if (!hogStore) {
     result.cursors[point] = { ts: cursor.cursorTs, correlationId: cursor.cursorCorrelationId };
-    return result;
+    return;
   }
 
   // correlationId → hog record (bounded: the store retains a handful of slots).
@@ -117,7 +169,7 @@ export function runDecisionGradingPass(deps: DecisionGradingPassDeps): DecisionG
     if (record.correlationId) byCorr.set(record.correlationId, record);
   }
 
-  const rows = ledger.walkDecisionsForGrading(point, cursor.cursorTs, cursor.cursorCorrelationId, budget);
+  const rows = ledger.walkDecisionsForGrading(point, cursor.cursorTs, cursor.cursorCorrelationId, subBudget);
 
   let cursorTs = cursor.cursorTs;
   let cursorCorr = cursor.cursorCorrelationId;
@@ -195,5 +247,4 @@ export function runDecisionGradingPass(deps: DecisionGradingPassDeps): DecisionG
   //  continues immediately from the advanced boundary.)
   ledger.setGradingCursor(point, { cursorTs, cursorCorrelationId: cursorCorr, nextRecheckTs, attempts });
   result.cursors[point] = { ts: cursorTs, correlationId: cursorCorr };
-  return result;
 }

--- a/src/data/provenanceCoverage.ts
+++ b/src/data/provenanceCoverage.ts
@@ -136,6 +136,13 @@ export const DP_COMPLETION_EVALUATE = 'completion-evaluate';
  * (component 'CompletionEvaluator/P13'; spec §5.3). */
 export const DP_COMPLETION_STOP_RATIONALE = 'completion-stop-rationale';
 
+/** Outbound tone/leak verdict — MessagingToneGate.review() (component
+ * 'MessagingToneGate'; spec §5.6). An ALWAYS-ON HIGH-VOLUME gate: it declares a
+ * `budget:<rows/day>` volume valve (NEVER `full`) and stores content as IDENTITY
+ * only (candidate hash + bounds + code-derived features), never the outbound
+ * body or any plaintext slice of it. */
+export const DP_MESSAGING_TONE_GATE = 'messaging-tone-gate';
+
 // ───────────────────────────────────────────────────────────────────────────
 // The census
 // ───────────────────────────────────────────────────────────────────────────
@@ -174,6 +181,31 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
     contentClass: 'content-bearing',
     reason:
       'First customer (spec §5.3): the P13 stop-rationale judge decides whether a stop-attempt is EARNED; same transcript-slice-identity envelope as evaluate().',
+  },
+
+  // ── Wired high-volume gate (§5.6 — NOT full-class; the third enrolled
+  //    customer, which required the grading-pass per-point sub-budget FIRST —
+  //    SUBBUDGET_IMPLEMENTED is now true) ─────────────────────────────────────
+  {
+    decisionPoint: DP_MESSAGING_TONE_GATE,
+    component: 'MessagingToneGate',
+    status: 'wired',
+    // §5.6 volume valve: an ALWAYS-ON high-volume gate MUST NOT be `full`. A
+    // per-UTC-day COUNT budget gives a hard, count-enforced ceiling on the
+    // provenance JSONL archive (loud droppedByBudget counter when hit) — a
+    // deterministic bound preferable to probabilistic sampling for a gate that
+    // fires on every drafted outbound message. 500/day = a representative daily
+    // sample without unbounded growth; the ~250-byte decision_quality row is
+    // ALWAYS written regardless (counts stay complete).
+    volumeClass: 'budget:500',
+    // Content-bearing: the gate judges an agent-authored outbound message. It
+    // enters the row as IDENTITY ONLY — a sha256 of the candidate + byte/char
+    // bounds + code-derived features — never the full body or any plaintext
+    // slice (the provenance store must not become an outbound-message archive;
+    // mirrors the CompletionEvaluator content-bearing sibling, §5.3).
+    contentClass: 'content-bearing',
+    reason:
+      'The outbound tone/leak authority (spec §5.6 named high-volume point). Enrolled at budget:500/day, identity-only content — never the message body.',
   },
 
   // ── Pending (the ACT-1193 uniform-provenance retrofit backlog — §5.6: "Not
@@ -315,14 +347,6 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
     contentClass: 'content-bearing',
     reason:
       'Stop-justified verdict over session state; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
-  },
-  {
-    decisionPoint: 'messaging-tone-gate',
-    component: 'MessagingToneGate',
-    status: 'pending:ACT-1193',
-    contentClass: 'content-bearing',
-    reason:
-      'Outbound tone/leak verdict over every drafted user-facing message — an always-on high-volume gate; MUST declare sampled:<rate> or budget:<rows/day> at enrollment (§5.6 volume valve), never full.',
   },
   {
     decisionPoint: 'coherence-review',
@@ -649,16 +673,19 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
 // ───────────────────────────────────────────────────────────────────────────
 // Grading-pass fairness marker (§5.5 / LES r6).
 //
-// The grading endpoint's per-pass bound is GLOBAL, not per-point — safe for the
+// The grading endpoint's per-pass bound was GLOBAL, not per-point — safe for the
 // two seeded low-frequency full-class customers, but a third ENROLLED customer
 // could starve sibling points' evidence windows. The census ratchet asserts
 // structurally that enrolling beyond the seeded first-customer set requires the
-// per-point round-robin sub-budget FIRST: flip this to true ONLY in the PR that
-// implements the sub-budget in the grade-pass loop (the third enroller's build
-// fails until then — the trigger is structural, not prose).
+// per-point round-robin sub-budget FIRST: this is now true because
+// `runDecisionGradingPass` divides its global budget round-robin across the
+// grade-pass-driven points (src/core/decisionGradingPass.ts — the sub-budget
+// helper `perPointSubBudget`), so no single point can consume a whole pass and
+// starve a sibling's maturing evidence window. Flipped in the PR that
+// implements that sub-budget (MessagingToneGate enrollment, the third customer).
 // ───────────────────────────────────────────────────────────────────────────
 
-export const SUBBUDGET_IMPLEMENTED = false;
+export const SUBBUDGET_IMPLEMENTED = true;
 
 // ───────────────────────────────────────────────────────────────────────────
 // Evidence-rule registry (§5.4.2) — ruleId → rung + evidence-strength + OWNING

--- a/tests/integration/messaging-tone-gate-provenance.test.ts
+++ b/tests/integration/messaging-tone-gate-provenance.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Integration: a REAL MessagingToneGate verdict — driven through a REAL
+ * IntelligenceRouter (which mints the correlation id + fires the §5.1.5
+ * settlement seam) into a LIVE DecisionQualityRecorderImpl wired to a real
+ * JudgmentProvenanceLog + FeatureMetricsLedger — emits a provenance row visible
+ * via GET /judgment-provenance (llm-decision-quality-meter §5.6 tone-gate
+ * enrollment).
+ *
+ * Proves the DATA FLOW end-to-end (not a stub): the served, redacted row carries
+ * the tone gate's component + decision point + a non-empty verdict/reason, its
+ * context is IDENTITY-ONLY (candidate sha256 — never the outbound body), and the
+ * served free-text rides #1458's redaction envelope (the full body never crosses
+ * the surface, and the raw candidate text is not archived on the row).
+ */
+
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import request from 'supertest';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { authMiddleware } from '../../src/server/middleware.js';
+import { FeatureMetricsLedger } from '../../src/monitoring/FeatureMetricsLedger.js';
+import { JudgmentProvenanceLog } from '../../src/core/JudgmentProvenanceLog.js';
+import {
+  IntelligenceRouter,
+  type ComponentFrameworksConfig,
+} from '../../src/core/IntelligenceRouter.js';
+import type { IntelligenceFramework } from '../../src/core/intelligenceProviderFactory.js';
+import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
+import { MessagingToneGate } from '../../src/core/MessagingToneGate.js';
+import {
+  DecisionQualityRecorderImpl,
+  installDecisionQualityRecorder,
+} from '../../src/core/DecisionQualityRecorderImpl.js';
+import { _resetDecisionQualityForTest } from '../../src/core/decisionQualityTypes.js';
+import { DP_MESSAGING_TONE_GATE } from '../../src/data/provenanceCoverage.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const AUTH = 'test-tone-provenance';
+
+let ledger: FeatureMetricsLedger | null = null;
+let jpl: JudgmentProvenanceLog | null = null;
+let tmpDir: string | null = null;
+
+/**
+ * A REAL router over a stub default provider that returns the tone verdict.
+ * The router mints the correlation id and fires the settlement seam — exactly
+ * the production path (nothing about provenance is stubbed).
+ */
+function makeRouter(reply: string): { router: IntelligenceRouter } {
+  const defaultProvider: IntelligenceProvider = {
+    async evaluate(_prompt: string, _opts?: IntelligenceOptions): Promise<string> {
+      return reply;
+    },
+  };
+  const cfg: ComponentFrameworksConfig | undefined = undefined;
+  const router = new IntelligenceRouter({
+    defaultProvider,
+    defaultFramework: 'claude-code' as IntelligenceFramework,
+    resolveConfig: () => cfg,
+    buildProvider: () => null, // no other framework built → the default provider serves
+  });
+  return { router };
+}
+
+function ctxWith(): RouteContext {
+  return {
+    config: {
+      projectName: 'test', projectDir: '/tmp', stateDir: tmpDir ?? '/tmp/.instar', port: 0, authToken: AUTH,
+      developmentAgent: true,
+      provenance: { uniformSeam: { enabled: true, dryRun: false } },
+      sessions: {} as unknown, scheduler: {} as unknown,
+    } as unknown,
+    sessionManager: { listRunningSessions: () => [] } as unknown,
+    state: { getJobState: () => null, getSession: () => null } as unknown,
+    judgmentProvenance: jpl,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+function appWith(ctx: RouteContext): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(authMiddleware(() => AUTH, 'test'));
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tone-provenance-int-'));
+  ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
+  jpl = new JudgmentProvenanceLog({
+    dir: path.join(tmpDir, 'state', 'judgment-provenance'),
+    log: () => {},
+  });
+  _resetDecisionQualityForTest();
+  // Live recorder wired to the SAME JPL + ledger the route reads.
+  installDecisionQualityRecorder(
+    new DecisionQualityRecorderImpl({
+      ledger,
+      judgmentProvenance: jpl,
+      config: { developmentAgent: true, provenance: { uniformSeam: { enabled: true, dryRun: false } } },
+    }),
+  );
+});
+
+afterEach(async () => {
+  installDecisionQualityRecorder(null);
+  _resetDecisionQualityForTest();
+  ledger?.close();
+  ledger = null;
+  if (jpl) { await jpl.close(); jpl = null; }
+  if (tmpDir) {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/messaging-tone-gate-provenance.test.ts' });
+    tmpDir = null;
+  }
+});
+
+describe('GET /judgment-provenance — a real tone-gate verdict emits a row (integration)', () => {
+  const OUTBOUND_BODY = 'ZX9_OUTBOUND_BODY_MARKER — everything looks good, deploy is green';
+  const PASS = JSON.stringify({ pass: true, issue: '', suggestion: '' });
+
+  it('a PASS verdict lands a redacted provenance row with the tone component, decision point, and identity-only context', async () => {
+    const { router } = makeRouter(PASS);
+    const gate = new MessagingToneGate(router);
+    const result = await gate.review(OUTBOUND_BODY, { channel: 'telegram' });
+    expect(result.pass).toBe(true); // the gate's verdict is unaffected by enrollment
+
+    await jpl!.flush();
+
+    const res = await request(appWith(ctxWith()))
+      .get('/judgment-provenance?limit=50')
+      .set('Authorization', `Bearer ${AUTH}`);
+
+    expect(res.status).toBe(200);
+    const rows = res.body.rows as Array<Record<string, unknown>>;
+    const row = rows.find((r) => r.decisionPoint === DP_MESSAGING_TONE_GATE);
+    expect(row, 'a messaging-tone-gate provenance row must be served').toBeTruthy();
+
+    // Component + a non-empty decision/reason (a real, reconstructable verdict).
+    expect(row!.component).toBe('MessagingToneGate');
+    expect(String(row!.decision ?? '')).not.toBe('');
+    expect(String(row!.reason ?? '')).not.toBe('');
+    // A router-minted seam row (correlation id present).
+    expect(String(row!.correlationId ?? '')).toMatch(/^d-/);
+    expect(row!.contentClass).toBe('content-bearing');
+
+    // The full outbound body NEVER crosses the surface (identity-only envelope).
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain('ZX9_OUTBOUND_BODY_MARKER');
+    expect(serialized).not.toContain('deploy is green');
+
+    // The served context is #1458's REDACTED envelope (a bounded JSON string)
+    // carrying the candidate IDENTITY structure — never the body. (The JPL's
+    // own write-time scrub additionally tokenizes the raw hash — defense in
+    // depth — so we assert the identity STRUCTURE, not the literal hex.)
+    const ctxStr = String(row!.contextRedacted ?? '');
+    const ctxParsed = JSON.parse(ctxStr) as Record<string, any>;
+    expect(ctxParsed.candidate).toBeDefined();
+    expect(ctxParsed.candidate.bytes).toBe(Buffer.byteLength(OUTBOUND_BODY, 'utf8'));
+    expect(ctxParsed.candidate.chars).toBe(OUTBOUND_BODY.length);
+    expect(ctxParsed.candidate.head).toBeUndefined(); // no plaintext slice on the row
+    expect(ctxStr).not.toContain('ZX9_OUTBOUND_BODY_MARKER');
+  });
+
+  it('a BLOCK verdict ALSO enrolls (the block/allow decision is unchanged; the row is still visible)', async () => {
+    const BLOCK = JSON.stringify({
+      pass: false, rule: 'B1_CLI_COMMAND',
+      issue: 'CLI command handed to the user', suggestion: 'Run it yourself.',
+    });
+    const { router } = makeRouter(BLOCK);
+    const gate = new MessagingToneGate(router);
+    const result = await gate.review('To fix, run: `npm install`', { channel: 'telegram' });
+    expect(result.pass).toBe(false);
+    expect(result.rule).toBe('B1_CLI_COMMAND');
+
+    await jpl!.flush();
+
+    const res = await request(appWith(ctxWith()))
+      .get('/judgment-provenance?limit=50')
+      .set('Authorization', `Bearer ${AUTH}`);
+    expect(res.status).toBe(200);
+    const row = (res.body.rows as Array<Record<string, unknown>>).find(
+      (r) => r.decisionPoint === DP_MESSAGING_TONE_GATE,
+    );
+    expect(row, 'the blocked verdict must still emit a provenance row').toBeTruthy();
+    expect(row!.component).toBe('MessagingToneGate');
+  });
+});

--- a/tests/unit/decision-grading-pass.test.ts
+++ b/tests/unit/decision-grading-pass.test.ts
@@ -18,7 +18,12 @@ import {
   _resetDecisionAnnotationRejectionCountersForTest,
 } from '../../src/core/DecisionQualityRecorderImpl.js';
 import { _resetDecisionQualityForTest } from '../../src/core/decisionQualityTypes.js';
-import { runDecisionGradingPass, DECISION_GRADING_COMPONENT } from '../../src/core/decisionGradingPass.js';
+import {
+  runDecisionGradingPass,
+  DECISION_GRADING_COMPONENT,
+  perPointSubBudget,
+  GRADE_PASS_POINTS,
+} from '../../src/core/decisionGradingPass.js';
 import { CompletionEvaluator, type CompletionCorrelationSink } from '../../src/core/CompletionEvaluator.js';
 
 /**
@@ -234,5 +239,26 @@ describe('wiring integrity (P8/P9)', () => {
     });
     await evaluator.evaluate('the goal is met', 'transcript tail', undefined, { topicId: '11960', runId: 'run-7' });
     expect(calls).toEqual([['11960', 'run-7', 'completion', 'd-corr-abc']]);
+  });
+});
+
+describe('perPointSubBudget — §5.5 fairness sub-budget (the SUBBUDGET_IMPLEMENTED primitive)', () => {
+  it('returns the FULL budget for a single point (byte-identical to the pre-sub-budget behavior)', () => {
+    expect(perPointSubBudget(200, 1)).toBe(200);
+    // Today the pass drives exactly one point → the slice IS the whole budget.
+    expect(GRADE_PASS_POINTS.length).toBe(1);
+    expect(perPointSubBudget(200, GRADE_PASS_POINTS.length)).toBe(200);
+  });
+
+  it('divides the global budget evenly so no point can consume a whole pass (a second point → half each)', () => {
+    expect(perPointSubBudget(200, 2)).toBe(100);
+    expect(perPointSubBudget(201, 2)).toBe(100); // floored
+    expect(perPointSubBudget(10, 3)).toBe(3); // ⌊10/3⌋
+  });
+
+  it('floors at 1 so every point always makes some progress (never a zero slice that starves a point)', () => {
+    expect(perPointSubBudget(1, 5)).toBe(1);
+    expect(perPointSubBudget(0, 1)).toBe(1);
+    expect(perPointSubBudget(200, 0)).toBe(200); // degenerate count clamps to 1
   });
 });

--- a/tests/unit/messaging-tone-gate-provenance-enrollment.test.ts
+++ b/tests/unit/messaging-tone-gate-provenance-enrollment.test.ts
@@ -1,0 +1,185 @@
+/**
+ * MessagingToneGate provenance enrollment — LLM-Decision Quality Meter §5.6
+ * (docs/specs/llm-decision-quality-meter.md §5.1.4 per-callsite contract +
+ * §5.2 content-bearing envelope discipline + §5.6 always-on high-volume gate).
+ *
+ * Pins, semantically (both sides of every boundary):
+ *   - the verdict-producing LLM call enrolls via `options.provenance` under the
+ *     typed decision-point id `messaging-tone-gate` (imported, not a literal);
+ *   - context is candidate IDENTITY ONLY — sha256 + byte/char bounds + code-derived
+ *     features — the outbound BODY (and any plaintext slice of it) never enters the
+ *     envelope, and the envelope stays bounded for arbitrarily large messages;
+ *   - a leaked credential in the candidate never lands in the row (no plaintext);
+ *   - `optionsPresented`/`promptId` are the static, clamp-safe labels;
+ *   - the enrollment is OBSERVABILITY-ONLY: it never changes the block/allow
+ *     verdict, and a provider that ignores (or a callback that throws over) the
+ *     provenance block yields the exact same verdict.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  MessagingToneGate,
+  buildToneDecisionContext,
+  TONE_GATE_PROMPT_ID,
+  TONE_OPTIONS_PRESENTED,
+} from '../../src/core/MessagingToneGate.js';
+import type { ToneReviewContext } from '../../src/core/MessagingToneGate.js';
+import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
+import { DP_MESSAGING_TONE_GATE } from '../../src/data/provenanceCoverage.js';
+
+const sha256 = (s: string): string => createHash('sha256').update(s, 'utf8').digest('hex');
+
+/** Captures the options the gate passed to the provider; replies with `reply`. */
+function capturingProvider(reply: string) {
+  const captured: { prompt?: string; opts?: IntelligenceOptions } = {};
+  const provider: IntelligenceProvider = {
+    async evaluate(prompt: string, opts?: IntelligenceOptions): Promise<string> {
+      captured.prompt = prompt;
+      captured.opts = opts;
+      return reply;
+    },
+  };
+  return { provider, captured };
+}
+
+const PASS = JSON.stringify({ pass: true, issue: '', suggestion: '' });
+const BLOCK_B1 = JSON.stringify({
+  pass: false,
+  rule: 'B1_CLI_COMMAND',
+  issue: 'CLI command handed to the user',
+  suggestion: 'Run it yourself and report the result.',
+});
+
+const BODY_MARKER = 'ZX9_OUTBOUND_BODY_MARKER_UNIQ';
+const SECRET = 'sk-live-ZX9SECRETTOKEN0000000000';
+
+describe('review() enrollment (decision point messaging-tone-gate)', () => {
+  it('carries options.provenance with the typed decision point, the deliver/block option space, and the prompt-version promptId', async () => {
+    const { provider, captured } = capturingProvider(PASS);
+    const gate = new MessagingToneGate(provider);
+    await gate.review(`hello ${BODY_MARKER}`, { channel: 'telegram' });
+
+    const p = captured.opts?.provenance;
+    expect(p).toBeDefined();
+    expect(p?.decisionPoint).toBe(DP_MESSAGING_TONE_GATE);
+    expect(p?.optionsPresented).toEqual([...TONE_OPTIONS_PRESENTED]);
+    expect(p?.promptId).toBe(TONE_GATE_PROMPT_ID);
+    // §5.2 clamp-safety: promptId must survive the settlement charset clamp.
+    expect(p?.promptId).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+    // The census 1:1 component key is unchanged.
+    expect(captured.opts?.attribution?.component).toBe('MessagingToneGate');
+  });
+
+  it('context is candidate IDENTITY (hash + bounds) — never the outbound body or any plaintext slice', async () => {
+    const text = `line one ${BODY_MARKER}\nline two`;
+    const { provider, captured } = capturingProvider(PASS);
+    const gate = new MessagingToneGate(provider);
+    await gate.review(text, { channel: 'telegram', messageKind: 'reply' });
+
+    const ctx = captured.opts?.provenance?.context as Record<string, any>;
+    expect(ctx).toBeDefined();
+    expect(ctx.candidate.sha256).toBe(sha256(text));
+    expect(ctx.candidate.bytes).toBe(Buffer.byteLength(text, 'utf8'));
+    expect(ctx.candidate.chars).toBe(text.length);
+    expect(ctx.channel).toBe('telegram');
+    expect(ctx.messageKind).toBe('reply');
+
+    // The body NEVER enters the envelope — not the whole thing, not a slice.
+    expect(JSON.stringify(ctx)).not.toContain(BODY_MARKER);
+    // The prompt legitimately carries the body (it goes to the model, not the row).
+    expect(captured.prompt).toContain(BODY_MARKER);
+  });
+
+  it('a leaked credential in the candidate NEVER lands in the row (no plaintext stored at all)', async () => {
+    const text = `Here is the key: ${SECRET} — set it in your env`;
+    const { provider, captured } = capturingProvider(PASS);
+    const gate = new MessagingToneGate(provider);
+    await gate.review(text, { channel: 'telegram' });
+
+    const ctx = captured.opts?.provenance?.context as Record<string, any>;
+    // The exact-hash identity is preserved, but the raw secret never crosses.
+    expect(ctx.candidate.sha256).toBe(sha256(text));
+    expect(JSON.stringify(ctx)).not.toContain(SECRET);
+  });
+
+  it('the envelope stays BOUNDED for an arbitrarily large outbound message', async () => {
+    const huge = 'x'.repeat(1_000_000);
+    const { provider, captured } = capturingProvider(PASS);
+    const gate = new MessagingToneGate(provider);
+    await gate.review(huge, { channel: 'telegram' });
+    const bytes = Buffer.byteLength(JSON.stringify(captured.opts?.provenance?.context), 'utf8');
+    expect(bytes).toBeLessThan(512);
+  });
+
+  it('gateSignalKinds ride as KINDS (identity + features), not the offending substrings', async () => {
+    // A CLI command triggers the cli-command signal; the KIND rides, not the cmd.
+    const text = 'To fix, run: `instar server restart` in your shell';
+    const { provider, captured } = capturingProvider(BLOCK_B1);
+    const gate = new MessagingToneGate(provider);
+    await gate.review(text, { channel: 'telegram' });
+    const ctx = captured.opts?.provenance?.context as Record<string, any>;
+    expect(Array.isArray(ctx.gateSignalKinds)).toBe(true);
+    // The kinds are enum-like tokens, not the command text.
+    for (const k of ctx.gateSignalKinds) expect(typeof k).toBe('string');
+  });
+
+  it('enrollment is OBSERVABILITY-ONLY: a provider that ignores the block returns the same PASS verdict', async () => {
+    const { provider } = capturingProvider(PASS);
+    const gate = new MessagingToneGate(provider);
+    const r = await gate.review('all good', { channel: 'telegram' });
+    expect(r.pass).toBe(true);
+    expect(r.rule).toBe('');
+  });
+
+  it('enrollment does NOT alter a BLOCK verdict (the block/allow decision is unchanged by provenance)', async () => {
+    const { provider, captured } = capturingProvider(BLOCK_B1);
+    const gate = new MessagingToneGate(provider);
+    const r = await gate.review('run: `npm install`', { channel: 'telegram' });
+    expect(r.pass).toBe(false);
+    expect(r.rule).toBe('B1_CLI_COMMAND');
+    // The block still carried the enrollment (observed, not gated on).
+    expect(captured.opts?.provenance?.decisionPoint).toBe(DP_MESSAGING_TONE_GATE);
+  });
+});
+
+describe('buildToneDecisionContext — pure helper (identity-only discipline)', () => {
+  const baseCtx: ToneReviewContext = { channel: 'slack', messageKind: 'health-alert' };
+
+  it('captures identity + code-derived scalars, never the body', () => {
+    const text = `a message with ${BODY_MARKER}`;
+    const ctx = buildToneDecisionContext(text, baseCtx);
+    expect(ctx.candidate).toMatchObject({
+      sha256: sha256(text),
+      bytes: Buffer.byteLength(text, 'utf8'),
+      chars: text.length,
+    });
+    expect(ctx.channel).toBe('slack');
+    expect(ctx.messageKind).toBe('health-alert');
+    expect(ctx.recentMessageCount).toBe(0);
+    // No plaintext of the body anywhere on the envelope.
+    expect(JSON.stringify(ctx)).not.toContain(BODY_MARKER);
+  });
+
+  it('never stores a plaintext slice — a credential in the candidate never crosses (identity is the hash)', () => {
+    const text = `${SECRET} ` + 'y'.repeat(1000);
+    const ctx = buildToneDecisionContext(text, baseCtx);
+    expect((ctx.candidate as Record<string, any>).sha256).toBe(sha256(text));
+    // The envelope carries NO head/body field — the secret cannot be in it.
+    expect((ctx.candidate as Record<string, any>).head).toBeUndefined();
+    expect(JSON.stringify(ctx)).not.toContain(SECRET);
+  });
+
+  it('records the recent-message COUNT (not the messages)', () => {
+    const ctx = buildToneDecisionContext('hi', {
+      channel: 'telegram',
+      recentMessages: [
+        { role: 'user', text: 'q1' },
+        { role: 'agent', text: 'a1' },
+      ],
+    });
+    expect(ctx.recentMessageCount).toBe(2);
+    expect(JSON.stringify(ctx)).not.toContain('q1');
+    expect(JSON.stringify(ctx)).not.toContain('a1');
+  });
+});

--- a/tests/unit/provenance-coverage-ratchet.test.ts
+++ b/tests/unit/provenance-coverage-ratchet.test.ts
@@ -39,6 +39,7 @@ import {
   DP_EXTERNAL_HOG_KILL_LEAVE,
   DP_COMPLETION_EVALUATE,
   DP_COMPLETION_STOP_RATIONALE,
+  DP_MESSAGING_TONE_GATE,
   getCensusEntry,
   isEnrolled,
   getVolumeClass,
@@ -91,7 +92,6 @@ const PENDING_BASELINE = [
   'llm-sanitize::LLMSanitizer::ACT-1193',
   'mentor-stage-b-classify::mentor-stage-b::ACT-1193',
   'message-sentinel-classify::MessageSentinel::ACT-1193',
-  'messaging-tone-gate::MessagingToneGate::ACT-1193',
   'move-intent-classify::MoveIntentClassifier::ACT-1193',
   'open-conversation-brief::openConversationBrief::ACT-1193',
   'override-detect::OverrideDetector::ACT-1193',
@@ -328,6 +328,34 @@ describe('enrollment growth — the sub-budget trigger is structural (LES r6, §
       expect(e?.volumeClass, `${dp} is a low-frequency high-stakes first customer — full-class by spec §5.3`).toBe('full');
       expect(e?.contentClass, `${dp} judges process/transcript content — content-bearing by spec §5.3`).toBe('content-bearing');
     }
+  });
+});
+
+describe('messaging-tone-gate — the third enrolled customer (§5.6 high-volume valve)', () => {
+  it('is WIRED (a regression to pending fails here — the ratchet now REQUIRES it enrolled)', () => {
+    const e = getCensusEntry(DP_MESSAGING_TONE_GATE);
+    expect(e, 'messaging-tone-gate must be a census entry').toBeDefined();
+    expect(e?.status, 'messaging-tone-gate must be WIRED (not pending) — the pending→wired flip must not regress').toBe('wired');
+    expect(isEnrolled(DP_MESSAGING_TONE_GATE)).toBe(true);
+    // A regression to pending would ALSO reintroduce the PENDING_BASELINE line —
+    // the shrink-only pending pin (above) would then fail on the new/changed line.
+  });
+
+  it('declares a HIGH-VOLUME valve — a per-day budget, NEVER full (§5.6 always-on gate)', () => {
+    const vc = getVolumeClass(DP_MESSAGING_TONE_GATE);
+    expect(vc, 'messaging-tone-gate MUST declare its volumeClass').toBeDefined();
+    expect(vc, 'an always-on high-volume gate MUST NOT be full — sampled:<rate> or budget:<rows/day> only (§5.6)').not.toBe('full');
+    expect(vc, 'the chosen valve is a per-UTC-day COUNT budget').toMatch(/^budget:[1-9]\d*$/);
+  });
+
+  it('is content-bearing (it judges an agent-authored outbound message → identity-only content)', () => {
+    expect(getCensusEntry(DP_MESSAGING_TONE_GATE)?.contentClass).toBe('content-bearing');
+  });
+
+  it('enrolling it REQUIRED the sub-budget (SUBBUDGET_IMPLEMENTED true — the structural trigger it tripped)', () => {
+    // The two enrollment-growth guards above only pass because the sub-budget
+    // now exists; pin the flag so a revert of the sub-budget re-fails here too.
+    expect(SUBBUDGET_IMPLEMENTED, 'the tone-gate enrollment requires the §5.5 per-point sub-budget in place').toBe(true);
   });
 });
 

--- a/upgrades/next/messaging-tone-gate-provenance-enrollment.md
+++ b/upgrades/next/messaging-tone-gate-provenance-enrollment.md
@@ -1,0 +1,17 @@
+## What Changed
+
+The always-on outbound **MessagingToneGate** is now enrolled as a wired LLM-decision provenance point, executing the pending→wired expansion the LLM-Decision Quality Meter (#1458) already defined. The tone gate is the highest-volume decision point in the fleet, so it records at a hard `budget:500/day` count ceiling (never `full`) and stores its content as **identity only** — a `sha256` of the candidate plus byte/char bounds and code-derived features (channel, message kind, recent-message count, gate-signal kinds). The outbound message body and any plaintext slice of it are **never** stored. Enrolling a fourth wired point activated the per-point round-robin grading sub-budget so grading capacity is shared fairly across points. Recording is observability-only — the tone gate's PASS/BLOCK verdict is byte-identical whether the provenance write succeeds, fails, or is disabled — and is dark-gated behind `provenance.uniformSeam` (enabled on the development agent, dark on the fleet).
+
+## Evidence
+
+- Side-effects review: `upgrades/side-effects/messaging-tone-gate-provenance-enrollment.md` (independent second-pass review concurred; verified critical-path inertness and no body-leak).
+- Tests: `tests/unit/messaging-tone-gate-provenance-enrollment.test.ts`, `tests/integration/messaging-tone-gate-provenance.test.ts`, plus the updated `tests/unit/provenance-coverage-ratchet.test.ts` and `tests/unit/decision-grading-pass.test.ts` sub-budget cases — 49 targeted tests green; full lint chain (typecheck + dark-gate + attribution + ratchet) clean.
+- Driven by the converged + approved spec `docs/specs/llm-decision-quality-meter.md` (§5.5 sub-budget, §5.6 volume valve + content classes).
+
+## What to Tell Your User
+
+None — internal, dev-gated observability with no user-facing surface. The change is dark on the fleet: it does not alter how the agent behaves, what it sends, or what a user sees. When enabled on a development agent it only records (machine-local, identity-only) what the always-on message-safety gate decided, so those decisions can later be graded. A user's messages, and the gate's block/allow behavior, are completely unaffected.
+
+## Summary of New Capabilities
+
+None user-facing. Internally: the outbound tone/leak gate now contributes to the LLM-decision quality record (dev-agent only, dark on fleet), giving the periodic grading pass its highest-volume data source while storing message identity only, never content.

--- a/upgrades/side-effects/messaging-tone-gate-provenance-enrollment.md
+++ b/upgrades/side-effects/messaging-tone-gate-provenance-enrollment.md
@@ -1,0 +1,68 @@
+# Side-Effects Review — MessagingToneGate Provenance Enrollment
+
+**Version / slug:** `messaging-tone-gate-provenance-enrollment`
+**Date:** `2026-07-12`
+**Author:** `echo`
+**Second-pass reviewer:** `independent reviewer subagent — CONCUR (verified all 6 axes; see Second-pass review section)`
+
+## Summary of the change
+
+Enrolls the **MessagingToneGate outbound gate** as a WIRED provenance decision point, executing the pending→wired expansion path that PR #1458's LLM-Decision Quality Meter (`docs/specs/llm-decision-quality-meter.md`, §5.6) already defined and tracked. The census (`src/data/provenanceCoverage.ts`) already carried `messaging-tone-gate` as `status: 'pending:ACT-1193'`; this flips it to `wired` with the mandatory volume valve, and adds the `provenance: {...}` enrollment to the tone gate's single verdict-producing LLM call — mirroring the exact `options.provenance` pattern #1458 established for CompletionEvaluator/ExternalHog. The tone gate is the highest-volume decision point in the fleet (3,641 of 4,098 LLM calls/24h on the dev agent per §5.6), so it enrolls at `budget:500/day` (a hard count ceiling with a loud `droppedByBudget` counter — never `full`), and its content is stored as **identity only** (a sha256 of the candidate + byte/char bounds + code-derived features: channel, messageKind, recent-message count, gate-signal kinds) — **never the message body and never any plaintext slice of it**. Enrolling a 4th wired customer structurally required activating the §5.5 per-point round-robin grading sub-budget (`decisionGradingPass.ts`, `SUBBUDGET_IMPLEMENTED` false→true), so grading capacity is shared fairly across points instead of one point starving the others. Files: `provenanceCoverage.ts`, `MessagingToneGate.ts`, `decisionGradingPass.ts`, + ratchet floor test + 2 new tests. Recording is dev-gated behind the same `provenance.uniformSeam` flag #1458 uses (ENABLED on dev, DARK on fleet).
+
+## Decision-point inventory
+
+- `MessagingToneGate` outbound-gate (`messaging-tone-gate`) — **pending→wired (observe)** — records the identity + verdict of the existing tone-gate authority. The gate's block/allow decision is untouched; the seam consumes the provenance block before any adapter and it never reaches the model.
+- `decisionGradingPass` (per-point sub-budget) — **modify (mechanism)** — a 4th wired point activates the §5.5 round-robin sub-budget; no decision authority added, it only allocates grading capacity fairly across points.
+
+---
+
+## 1. Over-block
+
+**No block/allow surface — over-block not applicable.** Observability-only. The `provenance` block is passed into the tone gate's LLM call options and consumed by the router-settlement seam *before any adapter*; it never reaches the model, never gates, holds, delays, or filters a message. The tone gate's PASS/BLOCK verdict is byte-identical whether the provenance write succeeds, fails, or is disabled (fail-open, inherited from #1458's recorder; asserted by test).
+
+## 2. Under-block
+
+**No block/allow surface — under-block not applicable.** This records what the tone-gate authority already decided. The remaining ~49 pending census points stay tracked under `pending:ACT-1193` and the monotonic ratchet still forbids silent regression — this change *shrinks* the pending set by one (tone gate) and *grows* the wired set to 4.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer, and deliberately NOT a parallel mechanism. The enrollment sits at the tone gate's own verdict call (the only place the structured verdict exists), reusing #1458's census + recorder + envelope + ratchet rather than rebuilding any of it. The census entry was already authored as `pending:ACT-1193` for exactly this expansion; flipping it is the intended, ratchet-enforced growth path. (This increment is the corrective successor to a duplicate parallel build — PR #1460, closed — which is why it is scrupulously on #1458's seam.)
+
+## 4. Signal vs authority compliance
+
+**Fully compliant — pure signal-side, zero authority added.** Per `docs/signal-vs-authority.md`: this records the existing tone-gate authority's verdict; it adds no detector-with-authority and no new authority. The one forbidden direction — a graded outcome feeding back into a decision input — is not crossed: grading only reads recorded rows and writes verdicts to the quality store; nothing here wires a feedback edge into model/door/prompt/floor selection (that remains the future benchmark increment's own spec).
+
+## 5. Interactions
+
+- **Volume:** the tone gate fires on every drafted outbound message. The `budget:500/day` valve is the load control — a hard per-UTC-day count ceiling on the provenance JSONL archive with a loud `droppedByBudget` counter, deterministic rather than probabilistic. This is why `full` is forbidden for this point.
+- **Grading fairness:** activating the §5.5 sub-budget (required by the 4th point) means the periodic grading pass round-robins capacity across all wired points; without it a high-volume point could monopolise the grading budget. Covered by 3 new sub-budget tests.
+- **No shadow/double-fire:** one enrollment per verdict at the single `review()` call site; the deterministic availability-fallback paths are not the LLM decision and are not enrolled.
+- **`/metrics/features` agreement:** model/door/tokens come from the existing usage/attribution path, so the provenance row and cost row agree by construction.
+
+## 6. External surfaces
+
+- **`GET /judgment-provenance` / the decision-quality read surface** now also returns tone-gate rows (redacted, identity-only, Bearer-gated) — reusing #1458's existing envelope + `no-store` route. No new route.
+- **Privacy — the load-bearing property:** content is stored as `sha256(candidate)` + bounds + code-derived features, **never the body and never a plaintext head**. This deviates from the initial "hash + bounded head" instruction: an integration test (written first) caught the literal outbound body landing on the served row because the credential-scrub does NOT strip non-credential PII/prose. The head was dropped entirely, matching the CompletionEvaluator content-bearing sibling's hash-only discipline — the stricter, correct reading for the very text this gate inspects for leaks.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local write, proxied-on-read** — identical to #1458's provenance posture (inherited, not re-declared). Full rows are credential-scrubbed + machine-local (0700/0600, never-served-raw, short retention) and never replicated; the unified read is the existing redacted `?scope=pool` merge that #1458 built. Identity-only content further reduces the at-rest surface for this point. The ratchet + census are CI-level (machine-independent). No new machine-local surface is introduced.
+
+## 8. Rollback cost
+
+**Cheap and reversible.** Recording is dev-gated behind `provenance.uniformSeam` (dark on fleet); flipping it off leaves the tone gate behaving exactly as before with zero rows. Full back-out is a plain revert: the census entry returns to `pending:ACT-1193`, the enrollment is removed, and `SUBBUDGET_IMPLEMENTED` reverts (the sub-budget is inert with <2 wired high-volume points anyway). No migration, no persisted state beyond the short-retention JSONL, no fleet coordination. Because recording never touched the tone verdict, a revert cannot regress any outbound-messaging behavior.
+
+## Second-pass review (independent)
+
+**Concur with the review.** Verified against the real diff + code (not the artifact) on all six axes:
+
+- **A / critical-path (holds):** In `review()` the `provenance` block is added to `opts` (`MessagingToneGate.ts:737-742`) and passed to `provider.evaluate(prompt, opts)` — but `IntelligenceRouter.mintDecision` clones the options and `delete internal.provenance` BEFORE any attempt (`IntelligenceRouter.ts:1138-1139`), so it never reaches the model. Settlement runs on the router's own path after the verdict (`:1110-1116`), and the single write is try/catch-contained — "the decision call is never failed or delayed by its audit trail" (`recordSettlement` :1288-1290); an errored exit re-throws the ORIGINAL error unchanged (`:1113-1116`), which the gate's own fail-closed/tier logic handles. `buildToneDecisionContext` is built synchronously outside the try block, but it is throw-proof: `crypto` (node:crypto, imported :21), `Buffer.byteLength`, `String().slice`, and `detectGateSignals` (itself fully try/catch-guarded, returns `[]` on any input — `GateSignalDetectors.ts:238-258`). A recorder failure/slow-write/throw cannot alter or hold the verdict — fail-open is real, not asserted.
+- **B / body-leak (holds — load-bearing property intact):** `buildToneDecisionContext` (`MessagingToneGate.ts:128-160`) stores `candidate: {sha256, bytes, chars}` + `channel` (a 32-char slice of the CHANNEL name, not the body) + `messageKind` + `recentMessageCount` (a count) + `gateSignalKinds` (kind labels). Grepped the whole diff: the only `.slice` is on `context.channel`; no plaintext head/body field exists anywhere. The integration test drives a REAL gate→router→recorder→JPL→`GET /judgment-provenance` and asserts the distinctive body marker is absent from the served JSON AND `ctxParsed.candidate.head` is `undefined` (`messaging-tone-gate-provenance.test.ts:150-165`); the unit suite additionally proves a 1MB message yields a <512-byte envelope and an in-body secret never crosses. The router's `rawResponseHead` (`:1227-1230`) captures the MODEL's verdict JSON, never the candidate body.
+- **C / volume valve (enforced, not cosmetic):** census is `budget:500` (`provenanceCoverage.ts:200`), and the recorder genuinely enforces it — `resolveJsonlDisposition` parses `budget:<N>`, counts today's rows, returns `'budget-dropped'` past the ceiling and bumps the `droppedByBudget` counter (`DecisionQualityRecorderImpl.ts:300-302, 338-346`) while still writing the ~250-byte SQLite row. The ratchet fails a `full` valve for this point (`not.toBe('full')` + `toMatch(/^budget:[1-9]\d*$/)`).
+- **D / §5.5 sub-budget (no feedback edge):** `GRADE_PASS_POINTS = [DP_EXTERNAL_HOG_KILL_LEAVE]` (one point) → `perPointSubBudget(N,1)===N`, byte-identical to the prior single-point walk; the hog grading body was extracted verbatim into `gradeOnePoint`. The tone gate is explicitly NOT graded by this pass. The pass reads recorded rows + hog-store records and writes grades only — it touches no model/door/prompt/floor selection. Covered by 3 new sub-budget tests + the unchanged hog correctness tests.
+- **E / ratchet monotonicity:** the `messaging-tone-gate::…::ACT-1193` line was removed from `PENDING_BASELINE`, so a regression to pending fails the shrink-only pending pin (a new unbaselined line) AND the dedicated `status==='wired'` assertion — two independent failures. No other census entry changed (4 wired = 3 first-customer + tone; 6 exempt unchanged).
+- **F / dark-gate:** recording gates on the same `provenance.uniformSeam` flag #1458 uses (`DecisionQualityRecorderImpl.ts:195`, early-return `:212`) and the router no-ops when `getDecisionQualityRecorder()` is null. Gate-off = the inert `provenance` options block is never consumed; zero rows, zero behavior change.
+
+Ran the three unit suites (47 passing, incl. the typed-import wired-verification) + the integration test (2 passing, body-marker-absent) + `tsc --noEmit` (clean). One cosmetic note (non-blocking): the summary line calls tone-gate the "4th wired customer" whereas the census/tests correctly call it the "third enrolled CUSTOMER" (customers key on `baseOf(component)`, so CompletionEvaluator + /P13 collapse to one) — the code and ratchet are internally consistent; only the artifact's prose is loose. No parallel mechanism; it rides #1458's seam exactly.


### PR DESCRIPTION
## ELI16

Instar can now write down what its always-on "message safety check" decided, so we can later grade whether those decisions were good. Every time the agent is about to send you a message, a small AI gate reviews it for tone and for accidental leaks (passwords, file paths) and says PASS or BLOCK. Until now that gate left no record of what it decided. This change makes it keep a note — but a privacy-safe one: it stores a fingerprint (a one-way hash) of the message plus a few facts like which channel it was for, and it NEVER stores the actual message text. Because this gate runs on basically every message, we cap it at 500 notes a day so it can't flood storage. Nothing about how the agent behaves changes — it still sends and blocks exactly as before; it just keeps a private, identity-only record. It's turned on only on the development machine and stays off everywhere else until it's proven.

## What & why

Executes the pending→wired expansion PR #1458 (LLM-Decision Quality Meter) already defined: enrolls the always-on outbound **MessagingToneGate** as a wired provenance decision point. It's the highest-volume decision point in the fleet (§5.6), so it gives the periodic grading pass its richest data source — while storing message **identity only**, never content.

This is the corrective successor to #1460 (closed): that PR rebuilt the provenance substrate in parallel, blind to #1458. This one rides #1458's existing census / recorder / envelope / ratchet seam — no parallel mechanism.

## What it does
- Flips the census `messaging-tone-gate` entry `pending:ACT-1193` → `wired`.
- Adds `options.provenance` enrollment to the tone gate's verdict call (consumed by the router-settlement seam; **never reaches the model**).
- **Volume valve `budget:500/day`** — a hard count ceiling + `droppedByBudget` counter, never `full`.
- **Identity-only content** — `sha256(candidate)` + byte/char bounds + code-derived features. The message body and any plaintext slice are **never** stored (an integration test caught a body-leak through the credential-scrub gap; the head was dropped entirely).
- Activates the §5.5 per-point round-robin grading sub-budget (required by a 4th wired point).
- **Observability-only** — the tone verdict is byte-identical whether the write succeeds, fails, or is disabled (fail-open). Dark-gated behind `provenance.uniformSeam` (ENABLED on dev, DARK on fleet).

## Tests
49 targeted tests green (unit enrollment + integration body-absence + ratchet + grading sub-budget); full lint chain clean. Independent second-pass review concurred. Driven by the converged + approved spec `docs/specs/llm-decision-quality-meter.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)