### PR TITLE
Fix throttle narration floods and drifted subscription status

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-16T01-18-18-221Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-16T01-18-18-221Z-unknown.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-16T01:18:18.221Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 46,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1465
+    ],
+    "notes": "Post-#1465 API evidence made credential drift visible to the dashboard, while live Telegram evidence showed the older burn runbook narrated detector ticks instead of throttle state transitions."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-16T01-18-41-102Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-16T01-18-41-102Z-unknown.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-16T01:18:41.102Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 46,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1465
+    ],
+    "notes": "Post-#1465 API evidence made credential drift visible to the dashboard, while live Telegram evidence showed the older burn runbook narrated detector ticks instead of throttle state transitions."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-16T01-19-05-486Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-16T01-19-05-486Z-unknown.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-16T01:19:05.486Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 46,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1465
+    ],
+    "notes": "Post-#1465 API evidence made credential drift visible to the dashboard, while live Telegram evidence showed the older burn runbook narrated detector ticks instead of throttle state transitions."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-16T01-17-54-000Z-throttle-episode-narration-subscription-drift-ui.json
+++ b/.instar/instar-dev-traces/2026-07-16T01-17-54-000Z-throttle-episode-narration-subscription-drift-ui.json
@@ -1,0 +1,28 @@
+{
+  "version": 3,
+  "sessionId": "telegram-458-tier-1-6",
+  "timestamp": "2026-07-16T01:17:54.000Z",
+  "artifactPath": "upgrades/side-effects/throttle-episode-narration-and-subscription-drift-ui.md",
+  "artifactSha256": "ee06ad839a236d458a43481dc4f450cfae59501e0c8c2d967a03ef61a7b5127f",
+  "specPath": "docs/specs/calm-transient-episode-alerting.md",
+  "coveredFiles": [
+    "src/monitoring/BurnThrottleRunbook.ts"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "Tier 2: narrows an existing autonomous throttle authority to one bounded episode and corrects a display-only credential-health projection.",
+  "secondPass": "true",
+  "reviewerConcurred": false,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [1465],
+    "notes": "Post-#1465 API evidence made credential drift visible to the dashboard, while live Telegram evidence showed the older burn runbook narrated detector ticks instead of throttle state transitions."
+  },
+  "toolchain": {
+    "buildSkill": {
+      "name": "instar-dev",
+      "version": "local",
+      "verified": true
+    }
+  }
+}

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -71,6 +71,14 @@ export function friendlyStatus(status) {
   return STATUS_WORDS[typeof status === 'string' ? status : ''] || 'Unknown';
 }
 
+/** Credential identity is authoritative over enrollment bookkeeping. */
+export function effectiveAccountStatus(account) {
+  if (account && (account.identityDrifted === true || account.identityDrift?.repairState === 'owner-relogin-required')) {
+    return 'needs-reauth';
+  }
+  return account && account.status;
+}
+
 const PROVIDER_WORDS = { anthropic: 'Claude', openai: 'Codex', 'github-copilot': 'Copilot', google: 'Gemini' };
 export function friendlyProvider(provider) {
   return PROVIDER_WORDS[typeof provider === 'string' ? provider : ''] || sanitizeForDisplay(provider, 'label');
@@ -204,7 +212,7 @@ export function renderAccounts(doc, target, accounts, now = Date.now(), inUseAcc
     const head = el(doc, 'div', 'sub-account-head');
     head.appendChild(el(doc, 'span', 'sub-account-nick', sanitizeForDisplay(a && a.nickname, 'label')));
     if (inUse) head.appendChild(el(doc, 'span', 'sub-account-inuse-badge', '● In use now'));
-    head.appendChild(el(doc, 'span', 'sub-account-status', friendlyStatus(a && a.status)));
+    head.appendChild(el(doc, 'span', 'sub-account-status', friendlyStatus(effectiveAccountStatus(a))));
     card.appendChild(head);
     card.appendChild(el(doc, 'div', 'sub-account-meta',
       `${friendlyProvider(a && a.provider)} · ${sanitizeForDisplay(a && a.framework, 'label')}`));
@@ -503,7 +511,8 @@ export function buildMatrixModel(poolScope, pendingScope, transient = {}) {
   for (const a of accountRows) {
     const mid = a && a.machineId;
     if (!a || !a.id || !mid || offlineMachineIds.has(mid)) continue;
-    cellStatus.set(`${a.id}::${mid}`, a.status === 'needs-reauth' ? 'needs-reauth' : (a.status === 'active' ? 'active' : 'other'));
+    const status = effectiveAccountStatus(a);
+    cellStatus.set(`${a.id}::${mid}`, status === 'needs-reauth' ? 'needs-reauth' : (status === 'active' ? 'active' : 'other'));
   }
   // (accountId, machineId) in-progress, correlated on (login.id === accountId, machineId) (FD6 r3 #2).
   // The MAP carries the pending-login RECORD so the in-progress cell can render the COMPLETE

--- a/src/monitoring/BurnThrottleRunbook.ts
+++ b/src/monitoring/BurnThrottleRunbook.ts
@@ -35,12 +35,15 @@ export interface BurnThrottleConfig {
   autoThrottleOnUnknown: boolean;
   /** Throttle duration (default 60min). */
   throttleDurationMs: number;
+  /** Quiet period after an episode closes before the same key may open another. */
+  notificationCooldownMs: number;
 }
 
 export const DEFAULT_BURN_THROTTLE_CONFIG: BurnThrottleConfig = {
   autoThrottle: true,
   autoThrottleOnUnknown: false,
   throttleDurationMs: 60 * 60 * 1000,
+  notificationCooldownMs: 15 * 60 * 1000,
 };
 
 export type RunbookOutcomeKind =
@@ -49,6 +52,7 @@ export type RunbookOutcomeKind =
   | 'alert-only-self-attribution'
   | 'alert-only-snoozed'
   | 'throttle-installed'
+  | 'throttle-suppressed-episode'
   | 'throttle-failed';
 
 export interface RunbookOutcome {
@@ -93,6 +97,7 @@ export class BurnThrottleRunbook {
   private readonly alertTopicId: number;
   private readonly now: () => number;
   private readonly isSnoozed: (key: string) => boolean;
+  private readonly episodes = new Map<string, { closesAt: number; cooldownUntil: number; timer: ReturnType<typeof setTimeout> }>();
 
   constructor(deps: BurnThrottleRunbookDeps) {
     this.gate = deps.gate;
@@ -115,6 +120,27 @@ export class BurnThrottleRunbook {
     const trigger = extractTrigger(event);
     const decidedAt = new Date(this.now()).toISOString();
     const signalId = `${event.timestamp}:${attributionKey}`;
+
+    // Narrate state transitions, never detector ticks. Once a throttle episode
+    // is open, repeated signals for the same component neither reinstall the
+    // throttle nor emit another user-facing notice. The post-close cooldown
+    // also absorbs detector lag around the expiry boundary.
+    const episode = this.episodes.get(attributionKey);
+    if (episode && this.now() < episode.cooldownUntil) {
+      return {
+        kind: 'throttle-suppressed-episode',
+        attributionKey,
+        decidedAt,
+        trigger,
+        reason: this.now() < episode.closesAt
+          ? 'Throttle episode is already open; duplicate signal suppressed.'
+          : 'Throttle episode recently closed; cooldown signal suppressed.',
+      };
+    }
+    if (episode) {
+      clearTimeout(episode.timer);
+      this.episodes.delete(attributionKey);
+    }
 
     // 1. Self-attribution: refuse to throttle the runbook itself, AND emit
     //    a high-severity escalation alert. Per Phase 4 second-pass review §3:
@@ -198,6 +224,7 @@ export class BurnThrottleRunbook {
         capabilityToken: token,
       });
       this.fireTelegram(`${alertText}\n\nI have slowed this component down. It will resume automatically in ${Math.round(this.config.throttleDurationMs / 60000)} minutes, or you can reply STOP to release it sooner.`);
+      this.openEpisode(attributionKey, throttle);
       return {
         kind: 'throttle-installed',
         attributionKey,
@@ -216,6 +243,25 @@ export class BurnThrottleRunbook {
         reason: `Throttle install failed: ${(err as Error).message}`,
       };
     }
+  }
+
+  private openEpisode(attributionKey: string, throttle: InstalledThrottle): void {
+    const closesAt = Date.parse(throttle.expiresAt);
+    const delay = Math.max(0, closesAt - this.now());
+    const timer = setTimeout(() => {
+      const current = this.episodes.get(attributionKey);
+      if (!current || current.timer !== timer) return;
+      this.fireTelegram(
+        `The token-burn slowdown for ${humanize(attributionKey)} has ended automatically. ` +
+        'Normal activity is available again.',
+      );
+    }, delay);
+    timer.unref?.();
+    this.episodes.set(attributionKey, {
+      closesAt,
+      cooldownUntil: closesAt + this.config.notificationCooldownMs,
+      timer,
+    });
   }
 
   private fireTelegram(text: string): void {

--- a/tests/unit/burn-detection-phase-4.test.ts
+++ b/tests/unit/burn-detection-phase-4.test.ts
@@ -13,7 +13,7 @@
  *   - End-to-end: detector emits → runbook decides → gate refuses next call
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import crypto from 'node:crypto';
 
 import { LlmRateGate } from '../../src/monitoring/LlmRateGate.js';
@@ -161,6 +161,8 @@ describe('BurnThrottleRunbook — decision logic', () => {
     sentMessages = [];
   });
 
+  afterEach(() => vi.useRealTimers());
+
   function makeRunbook(config: Partial<Parameters<typeof BurnThrottleRunbook>[0]['config']> = {}, _ignored?: any) {
     return new BurnThrottleRunbook({
       gate,
@@ -179,6 +181,31 @@ describe('BurnThrottleRunbook — decision logic', () => {
     expect(sentMessages).toHaveLength(1);
     expect(sentMessages[0].text).toMatch(/InputDetector/i);
     expect(sentMessages[0].text).toMatch(/slowed/i);
+  });
+
+  it('narrates one open and one close per episode, suppressing same-second ticks and the close cooldown', async () => {
+    vi.useFakeTimers();
+    const runbook = makeRunbook({ throttleDurationMs: 1_000, notificationCooldownMs: 2_000 });
+    const event = makeBurnEvent({ attributionKey: 'InputDetector::flood', trigger: 'absolute-share' });
+
+    expect(runbook.handle(event).kind).toBe('throttle-installed');
+    expect(runbook.handle(event).kind).toBe('throttle-suppressed-episode');
+    expect(runbook.handle(event).kind).toBe('throttle-suppressed-episode');
+    expect(sentMessages).toHaveLength(1);
+
+    now += 1_000;
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sentMessages).toHaveLength(2);
+    expect(sentMessages[1].text).toMatch(/ended automatically/i);
+
+    expect(runbook.handle(event).kind).toBe('throttle-suppressed-episode');
+    expect(sentMessages).toHaveLength(2);
+
+    now += 2_001;
+    const nextEpisode = makeBurnEvent({ attributionKey: 'InputDetector::flood', trigger: 'absolute-share' });
+    nextEpisode.timestamp = '2026-05-15T22:31:00Z';
+    expect(runbook.handle(nextEpisode).kind).toBe('throttle-installed');
+    expect(sentMessages).toHaveLength(3);
   });
 
   it('alert-only-unknown for unknown::* keys by default (no auto-throttle on unknown)', () => {

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -112,6 +112,14 @@ describe('renderAccounts', () => {
     expect(t.querySelector('.sub-account-status')!.textContent).toBe('Active');
     expect(t.querySelectorAll('.sub-quota').length).toBe(2);
   });
+  it('shows needs sign-in when credential identity drift overrides active enrollment bookkeeping', () => {
+    const t = el();
+    renderAccounts(doc, t, [{
+      id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', status: 'active',
+      identityDrifted: true, identityDrift: { repairState: 'owner-relogin-required' },
+    }], NOW);
+    expect(t.querySelector('.sub-account-status')!.textContent).toBe('Needs sign-in');
+  });
   it('renders a Fable 5 bar when the fable window is present', () => {
     const t = el();
     renderAccounts(doc, t, [{
@@ -311,6 +319,20 @@ describe('renderAccountMatrix', () => {
     expect(cell).toBeTruthy();
     expect(cell!.textContent).toContain('✓');
     expect(cell!.querySelector('.sub-matrix-setup')).toBeNull();
+  });
+
+  it('renders an actionable needs-sign-in cell when an active row is identity-drifted', () => {
+    const t = el();
+    renderAccountMatrix(doc, t, {
+      enabled: true,
+      accounts: [{ id: 'a1', email: 'a1@x.com', status: 'active', identityDrifted: true, machineId: 'm1', machineNickname: 'Laptop' }],
+      pool: { selfMachineId: 'm1', failed: [] }, scope: 'pool',
+    }, { enabled: true, logins: [] }, {});
+    const cell = t.querySelector('.sub-matrix-needs-reauth');
+    expect(cell).toBeTruthy();
+    expect(cell!.textContent).toContain('Needs sign-in');
+    expect(cell!.querySelector('.sub-matrix-setup')!.textContent).toBe('Sign in');
+    expect(t.querySelector('.sub-matrix-active')).toBeNull();
   });
 
   it('renders a "Set up" button for a genuinely-empty (reachable) cell', () => {

--- a/upgrades/side-effects/throttle-episode-narration-and-subscription-drift-ui.md
+++ b/upgrades/side-effects/throttle-episode-narration-and-subscription-drift-ui.md
@@ -1,0 +1,43 @@
+# Side-effects review — throttle episode narration and subscription drift UI
+
+## Scope
+
+This follow-up changes two user-facing read/narration seams. Burn-throttle monitoring now reports state transitions instead of every detector tick, and the Subscriptions dashboard treats credential identity drift as stronger evidence than stale enrollment status.
+
+## Behavioral change
+
+For each attribution key, the burn runbook opens one in-memory episode when it installs a bounded throttle. Further signals during that episode are suppressed without reinstalling or extending the throttle. Automatic expiry emits one closing notice, followed by a 15-minute notification cooldown before the same key may open another episode.
+
+Subscription account cards and account-by-machine cells now derive their displayed status from credential identity evidence first. An `identityDrifted` account, or one whose repair state requires an owner re-login, renders as “Needs sign-in” even if its enrollment record still says `active`; the matrix supplies the existing Sign in action.
+
+## Over-block and under-block
+
+The notification cooldown can hide a genuinely new burn signal arriving within 15 minutes of expiry. It cannot extend the throttle or block LLM work: it only suppresses narration and reinstallation during that settling window. Process restart clears episode memory, so a surviving burn may open one fresh episode after restart; the state is intentionally process-local, matching the throttle itself.
+
+The dashboard may show Needs sign-in while an automatic repair is planned or running. That is conservative and reversible on the next healthy pool read; it avoids presenting an identity-incoherent credential as usable.
+
+## Signal and authority
+
+The detector remains signal-only. `BurnThrottleRunbook` remains the existing bounded authority and `LlmRateGate` remains the actuator. The new episode latch narrows repeated authority and messaging; it creates no new blocking surface. Dashboard logic is display-only and consumes post-#1465 API evidence without mutating account state.
+
+## Interactions and settling
+
+- Episode identity is the attribution key, matching the gate key and preventing cross-component suppression.
+- A timer is tied to the installed throttle's actual expiry and is unref'd so it cannot keep the process alive.
+- Duplicate detector ticks return an auditable `throttle-suppressed-episode` outcome while producing no Telegram message.
+- The close notice states only that the bounded slowdown ended; it does not claim the underlying burn disappeared.
+- Matrix precedence retains offline, held, pending, and broken states; identity drift only replaces a falsely healthy active cell with the existing re-login path.
+
+## Multi-machine posture
+
+Burn episodes and throttles are machine-local by design. Subscription pool-scope rows retain their machine identity, and the renderer evaluates drift independently for each reachable account-machine row. Offline machines remain unknown rather than inheriting a drift or healthy judgment from another machine.
+
+## 6b. Operator-surface quality
+
+The grid continues to lead with its primary action: a drifted cell says “Needs sign-in” and presents the existing Sign in button in place. Account cards use the same plain-language health phrase. No repair enum, drift flag, account identifier, credential location, or other raw internal becomes primary content. This change adds no destructive action; the reversible sign-in action remains visually primary. The wording is short and the existing responsive matrix/card layout remains readable at phone width.
+
+## Verification and rollback
+
+Regression tests cover same-second triple signals, exactly one open and one automatic close notice, cooldown suppression, later episode reopening, drift override on account cards, and an actionable needs-sign-in matrix cell. The broader burn Phase 4–6 and Subscriptions renderer/controller suites pass, along with the full lint lane.
+
+Rollback is a code revert. No schema or persistent-state migration is introduced.


### PR DESCRIPTION
## Summary

- narrate burn throttles once when an episode opens and once when its bounded slowdown expires
- suppress repeated detector ticks during the episode and for a 15-minute settling cooldown
- show identity-drifted subscription accounts as Needs sign-in on cards and in the account-by-machine grid
- keep the existing in-dashboard Sign in action available for drifted cells

## ELI16

The monitoring loop used to send a message every time it noticed the same token-burning condition, even while the first automatic slowdown was already active. That is why one incident could produce same-second triples and dozens of notices. This change remembers that the slowdown episode is already open, stays quiet on repeat observations, and sends one final note when the slowdown ends.

Separately, the Subscriptions screen trusted the enrollment label “active” even after the credential check proved that the login belonged to the wrong identity. The screen now trusts the credential-health evidence and says “Needs sign-in,” with the existing Sign in button, until a healthy pool read clears the drift.

## Verification

- 118 focused tests across burn phases 4–6 and Subscriptions unit/integration coverage
- full lint lane
- production TypeScript build
- instar-dev Tier 2 side-effects/trace gate
- coherence gate passed for Telegram topic 458 before push

## Risk / rollback

Episode state is process-local, matching the process-local throttle. A restart may open one fresh episode if the burn survives. The post-close cooldown only suppresses narration/reinstallation; it does not keep calls throttled. Dashboard behavior is display-only. Rollback is a code revert with no migration.