### PR TITLE
docs(release): fragments for #1467 + #1468 (unblock stranded release)

### DIFF
--- a/upgrades/next/spawn-admission-live-owner.md
+++ b/upgrades/next/spawn-admission-live-owner.md
@@ -1,0 +1,19 @@
+# Spawn admission binds for live remote owners
+
+## What Changed
+
+Session spawn admission now enforces its ownership verdict when a conversation's live owner is another machine, instead of logging a would-refuse in dry-run and spawning a duplicate anyway. The graduation is the narrowest possible row: only a verified-live remote owner with durable inbound custody live is enforced; owner-dark, error, and unowned rows keep their existing dry-run posture, and single-machine installs are unaffected. A refusal forwards the message to the owning machine — it is never dropped.
+
+## What to Tell Your User
+
+On a multi-machine setup, a conversation that lives on one machine can no longer quietly spawn a second session on another machine — the bug where a topic pinned to one computer suddenly answered from the other one, on the wrong model. Messages now always land on the machine that owns the conversation.
+
+## Summary of New Capabilities
+
+- Enforce the spawn-admission refusal for provably-live remote owners (forward, never loss).
+- Report live-owner enforcement state (configured, armed, and any blocking gate) on the admission status surface.
+
+## Evidence
+
+- A 1,000-message burst end-to-end test with a live remote owner produces zero local spawns.
+- Full CI green on PR #1467; owner-dark/error/unowned rows verified unchanged at line level.

--- a/upgrades/next/subscription-status-honesty.md
+++ b/upgrades/next/subscription-status-honesty.md
@@ -1,0 +1,20 @@
+# Throttle episodes and honest account status
+
+## What Changed
+
+Two user-facing honesty fixes. First, throttle notifications are now per-episode: one message when throttling engages, one when it clears, with a 15-minute post-close cooldown — instead of dozens of identical per-tick repeats. Second, the dashboard Subscriptions tab now derives each account's displayed status from its live credential state: an account whose stored login no longer matches its labeled identity (or that is awaiting an owner re-login) shows "needs re-login" instead of an "Active" carried over from enrollment.
+
+## What to Tell Your User
+
+You will no longer get a flood of identical throttle messages — one when it starts, one when it ends. And the Subscriptions tab now tells you honestly when an account needs a fresh sign-in, instead of showing every enrolled account as active.
+
+## Summary of New Capabilities
+
+- Per-episode throttle narration with typed suppressed outcomes and a race-safe auto-close timer.
+- Effective account status on the Subscriptions grid and account header: identity drift or a pending owner re-login renders as needs-re-login, authoritative over enrollment status.
+
+## Evidence
+
+- Unit tests for episode dedup, cooldown, and the stale-timer guard.
+- A render test proving a drifted account's grid cell shows the needs-re-login state.
+- Full CI green on PR #1468.


### PR DESCRIPTION
## Summary
- Add the missing `upgrades/next/` release-note fragments for PR #1467 (spawn-admission live-owner enforcement) and PR #1468 (throttle episode dedup + needs-re-login account status).
- Both PRs merged without fragments, so the publish workflow loud-skipped twice — the fixes are on main but unreleased. Merging this cuts the release that actually deploys them.

## ELI16 — Two finished fixes are sitting in the warehouse because nobody filled out the shipping label; this PR is the shipping label.

The release pipeline only publishes a new version when the merge carries a release-note fragment describing what changed in plain language. The last two fixes merged without one, so the pipeline (correctly, loudly) skipped publishing both times. This PR adds exactly those two notes — nothing else — so the next publish run ships the pending work, including the dashboard "needs re-login" display the operator is waiting on.

## Evidence
- Publish run for merge ccd7754 shows `Publish to npm: skipped` at the release-fragment gate; npm `latest` is still 1.3.836 while main carries both fixes.
- Docs-only diff: two new files under `upgrades/next/`, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)