### PR TITLE
Fix subscription cell login integrity

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-16T04-31-14-281Z-subscription-cell-login-integrity.json
+++ b/.instar/instar-dev-decisions/2026-07-16T04-31-14-281Z-subscription-cell-login-integrity.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-16T04:31:14.281Z",
+  "slug": "subscription-cell-login-integrity",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 28,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3644,7 +3644,7 @@
            the dashboard (PIN → sign-in link → paste the code). Hidden when there's nothing to show. -->
       <section class="ph-section">
         <h3 class="ph-h">Accounts on each machine</h3>
-        <p class="ph-h-sub">Which subscription is set up on which machine. Tap “Set up” on an empty cell to add one — you’ll enter your PIN, open the sign-in link, and paste the code right here.</p>
+        <p class="ph-h-sub">Which subscription is set up on which machine. Tap “Set up” on an empty cell, or “Sign in” on a cell that needs attention — you’ll enter your PIN, open the sign-in link, and paste the code right here.</p>
         <div id="subMatrix"></div>
       </section>
       <section class="ph-section">

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -512,7 +512,13 @@ export function buildMatrixModel(poolScope, pendingScope, transient = {}) {
     const mid = a && a.machineId;
     if (!a || !a.id || !mid || offlineMachineIds.has(mid)) continue;
     const status = effectiveAccountStatus(a);
-    cellStatus.set(`${a.id}::${mid}`, status === 'needs-reauth' ? 'needs-reauth' : (status === 'active' ? 'active' : 'other'));
+    const key = `${a.id}::${mid}`;
+    const next = status === 'needs-reauth' ? 'needs-reauth' : (status === 'active' ? 'active' : 'other');
+    // Pool reads may contain more than one observation for the same account/machine.
+    // Safety state is monotonic within a render: a later stale Active row must never
+    // overwrite a live identity-drift verdict.
+    const prior = cellStatus.get(key);
+    cellStatus.set(key, prior === 'needs-reauth' || next === 'needs-reauth' ? 'needs-reauth' : next);
   }
   // (accountId, machineId) in-progress, correlated on (login.id === accountId, machineId) (FD6 r3 #2).
   // The MAP carries the pending-login RECORD so the in-progress cell can render the COMPLETE
@@ -546,20 +552,22 @@ export function buildMatrixModel(poolScope, pendingScope, transient = {}) {
       if (m.offline) state = 'offline';                              // whole column offline (FD6)
       else if (t && t.state === 'held') state = 'held';
       else if (t && t.state === 'cant-resolve') state = 'cant-resolve';
-      else if (cellStatus.get(key) === 'active') state = 'active';
-      // just-verified BRIDGES the gap between a client-observed successful enrollment and the
-      // next pool read that shows the account active — the cell must flip to an unmistakable
-      // verified presentation the moment the enrollment verifies (topic 29836 D4), never blink
-      // back to a "Set up" button while the server catches up.
-      else if (t && t.state === 'just-verified') state = 'just-verified';
+      // Durable pending state wins over enrollment bookkeeping after restart: the
+      // full flow rehydrates into its cell even if the pool row still says Active.
       // broken (D5): the server says this attempt's sign-in pane is DEAD (record ⟂ pane
       // reconciliation) — or the client just watched a code-submit refuse with pane-dead.
       // Presenting it as submittable would be a lie; it gets an explicit needs-restart
       // presentation with a working Retry (start-cell supersedes the zombie atomically).
-      else if ((pendingLogin && pendingLogin.paneAlive === false) || (t && t.state === 'broken')) state = 'broken';
-      else if (pendingLogin) state = 'in-progress';
+      else if (cellStatus.get(key) === 'needs-reauth' && pendingLogin && pendingLogin.paneAlive === false) state = 'broken';
+      else if (cellStatus.get(key) === 'needs-reauth' && pendingLogin) state = 'in-progress';
       else if (t && t.state === 'expired') state = 'expired';
       else if (cellStatus.get(key) === 'needs-reauth') state = 'needs-reauth';
+      else if (cellStatus.get(key) === 'active') state = 'active';
+      else if ((pendingLogin && pendingLogin.paneAlive === false) || (t && t.state === 'broken')) state = 'broken';
+      else if (pendingLogin) state = 'in-progress';
+      // just-verified bridges the short interval before the pool row becomes active.
+      // Once active, keep state=active and carry this transient as the highlight detail.
+      else if (t && t.state === 'just-verified') state = 'just-verified';
       else state = 'empty';                                          // → "Set up" button
       rowCells.push({
         accountId: acct.accountId, machineId: m.machineId, state,

--- a/docs/eli16/subscription-cell-login-integrity.eli16.md
+++ b/docs/eli16/subscription-cell-login-integrity.eli16.md
@@ -1,0 +1,11 @@
+# Subscription cell login integrity — ELI16
+
+The account-by-machine cell is the operator's single source of truth. If a credential's live identity no longer matches the account label, that cell must say “Needs sign-in” and offer the PIN-gated Sign in action. It must never keep saying Active because an older observation arrived later.
+
+If a sign-in is already underway, its durable pending-login record reconstructs the complete link-and-code flow inside that same cell after a server or browser restart. Client-only repair state is not required for recovery. A stale Active pool row can no longer hide the durable flow when the account is drifted.
+
+Automatic link renewal is maintenance, not consent to open the operator's browser. Renewal still starts the provider login process long enough to mint a fresh public link/code and updates the durable record, but passes a browser-suppression environment to the CLI. An explicit first start remains browser-enabled, and clicking the cell's Sign in link is the deliberate re-open action.
+
+## ELI16 — practical result
+
+No more OAuth tabs appearing every few minutes while an unused flow renews. A wrong-account login reads honestly in the grid, can be repaired from its cell, and remains attached to that cell across restarts.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -13179,7 +13179,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     // a 2nd account never clobbers the 1st.
     const { PendingLoginStore } = await import('../core/PendingLoginStore.js');
     const { EnrollmentWizard } = await import('../core/EnrollmentWizard.js');
-    const { FrameworkLoginDriver, enrollPaneSessionName } = await import('../core/FrameworkLoginDriver.js');
+    const { FrameworkLoginDriver, enrollPaneSessionName, enrollmentBrowserEnv } = await import('../core/FrameworkLoginDriver.js');
     const DEFAULT_ENROLL_LOGIN_COMMANDS: Record<string, string> = {
       'claude-code': 'claude auth login',
       'codex-cli': 'codex login',
@@ -13228,15 +13228,15 @@ export async function startServer(options: StartOptions): Promise<void> {
           }
           return sessionManager.captureOutput(session, 120) || '';
         },
-        spawn: async ({ framework, configHome }) => {
+        spawn: async ({ framework, configHome, openBrowser }) => {
           const tmuxPath = detectTmuxPath();
           if (!tmuxPath) throw new Error('tmux not available for enrollment login');
           const baseCmd = enrollLoginCommands[framework] ?? `${framework} login`;
           // env-prefix sets the per-account config home for the login process so
           // the credential lands in its own slot (CLAUDE_CONFIG_DIR isolation).
-          const cmd = configHome
-            ? `env CLAUDE_CONFIG_DIR=${JSON.stringify(configHome)} ${baseCmd}`
-            : baseCmd;
+          const env = { ...(configHome ? { CLAUDE_CONFIG_DIR: configHome } : {}), ...enrollmentBrowserEnv(openBrowser) };
+          const prefix = Object.entries(env).map(([k, v]) => `${k}=${JSON.stringify(v)}`).join(' ');
+          const cmd = prefix ? `env ${prefix} ${baseCmd}` : baseCmd;
           const session = enrollPaneSessionName(framework, configHome);
           try {
             execFileSync(tmuxPath, ['kill-session', '-t', `=${session}`], { stdio: 'ignore' });

--- a/src/core/EnrollmentWizard.ts
+++ b/src/core/EnrollmentWizard.ts
@@ -52,6 +52,9 @@ export type LoginDriver = (req: {
    *  passes a larger value (cloud→provider latency + the two-code Claude window);
    *  omitted ⇒ the driver's own default (the local-LAN budget). */
   scrapeTimeoutMs?: number;
+  /** Consent boundary: only an explicit operator initiation may open a browser.
+   *  Background renewal still mints a fresh URL/code, but suppresses browser launch. */
+  openBrowser?: boolean;
 }) => Promise<LoginArtifact>;
 
 /**
@@ -214,6 +217,7 @@ export class EnrollmentWizard {
         framework: input.framework,
         kind,
         configHome: input.configHome,
+        openBrowser: true,
         // Threaded only for remote drives; omitted ⇒ the driver's local-LAN default.
         ...(input.remote && typeof input.remoteScrapeTimeoutMs === 'number'
           ? { scrapeTimeoutMs: input.remoteScrapeTimeoutMs }
@@ -260,6 +264,9 @@ export class EnrollmentWizard {
           framework: login.framework,
           kind: login.kind,
           configHome: login.configHome,
+          // Renewal is maintenance, not fresh operator consent. The new URL/code
+          // is stored and rendered; never pop a browser on a timer tick.
+          openBrowser: false,
         });
         const updated = this.store.reissue(login.id, {
           verificationUrl: fresh.verificationUrl,

--- a/src/core/FrameworkLoginDriver.ts
+++ b/src/core/FrameworkLoginDriver.ts
@@ -46,6 +46,15 @@ export interface FrameworkLoginRequest {
   kind: LoginFlowKind;
   /** The account's CLAUDE_CONFIG_DIR — isolates this login to its own slot. */
   configHome?: string;
+  /** False for background renewal; production must suppress browser launch. */
+  openBrowser?: boolean;
+}
+
+/** Environment prefix used by login commands when no operator initiated this drive.
+ * Claude Code honors BROWSER as its opener; `true` accepts the open request without
+ * launching an application while the CLI still prints the URL for capture. */
+export function enrollmentBrowserEnv(openBrowser: boolean | undefined): Record<string, string> {
+  return openBrowser === false ? { BROWSER: 'true' } : {};
 }
 
 /** Injected I/O so the driver is decoupled + hermetically testable. */
@@ -137,12 +146,14 @@ export class FrameworkLoginDriver {
     kind: LoginFlowKind;
     configHome?: string;
     scrapeTimeoutMs?: number;
+    openBrowser?: boolean;
   }): Promise<LoginArtifact> {
     const { session } = await this.deps.spawn({
       provider: req.provider,
       framework: req.framework,
       kind: req.kind,
       configHome: req.configHome,
+      openBrowser: req.openBrowser,
     });
     const budgetMs =
       typeof req.scrapeTimeoutMs === 'number' && Number.isFinite(req.scrapeTimeoutMs) && req.scrapeTimeoutMs > 0

--- a/tests/e2e/subscriptions-tab-lifecycle.test.ts
+++ b/tests/e2e/subscriptions-tab-lifecycle.test.ts
@@ -147,6 +147,27 @@ describe('/subscription-pool — Subscriptions tab E2E feature-alive', () => {
     expect(code.value).toBe('HALF-TYPED');
   });
 
+  it('restart-safe truth: live identity drift renders in-cell sign-in, then durable pending state rehydrates the full flow', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sub-tab-e2e-'));
+    const pool = new SubscriptionPool({ stateDir: dir });
+    pool.add({ id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c1', email: 'a1@x.com' });
+    pool.update('a1', { status: 'active', identityDrifted: true, identityDrift: { expectedAccountId: 'a1', actualAccountId: 'other', detectedAt: '2026-06-07T00:00:00Z', slot: '/h/.c1', repairState: 'planned' } });
+    const store = new PendingLoginStore({ stateDir: dir, now: () => Date.parse('2026-06-07T00:00:00Z') });
+    const wizard = new EnrollmentWizard({ store, now: () => Date.parse('2026-06-07T00:00:00Z'), driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth/renewed', ttlMs: 15 * 60_000 }) });
+    server = await bootApp({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), meshSelfId: 'm-self', subscriptionPool: pool, enrollmentWizard: wizard });
+
+    let mounted = mountTab(server.url);
+    await mounted.c.tick();
+    expect(mounted.els.matrix.textContent).toContain('Needs sign-in');
+    expect(mounted.els.matrix.querySelector('[data-matrix-setup]').textContent).toBe('Sign in');
+
+    await wizard.start({ id: 'a1', label: 'personal', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c1', expectedEmail: 'a1@x.com' });
+    mounted = mountTab(server.url); // fresh controller/DOM: restart, zero client-only state
+    await mounted.c.tick();
+    expect(mounted.els.matrix.querySelector('.sub-matrix-in-progress')).toBeTruthy();
+    expect(mounted.els.matrix.querySelector('.sub-matrix-signin').getAttribute('href')).toContain('/renewed');
+  });
+
   it('feature OFF: both routes 200 { enabled:false } → friendly not-set-up copy', async () => {
     server = await bootApp({ config: { authToken: 't', stateDir: '/tmp/.instar', port: 0 }, startTime: new Date() });
     // Routes are alive (not 503).

--- a/tests/integration/subscriptions-tab.test.ts
+++ b/tests/integration/subscriptions-tab.test.ts
@@ -136,6 +136,51 @@ describe('Subscriptions tab controller (integration)', () => {
 
   // ── topic 29836 D1–D5: the matrix "Set up" flow through the SHIPPED controller ──
 
+  it('restart rehydrates a drifted cell and its durable pending flow; stale Active cannot overwrite drift', async () => {
+    const pool = {
+      enabled: true,
+      accounts: [
+        { id: 'a1', email: 'a1@x.com', status: 'active', identityDrifted: true, machineId: 'm1', machineNickname: 'Laptop' },
+        // A duplicate stale observation reproduces the live overwrite regression.
+        { id: 'a1', email: 'a1@x.com', status: 'active', identityDrifted: false, machineId: 'm1', machineNickname: 'Laptop' },
+      ],
+      pool: { selfMachineId: 'm1', failed: [] }, scope: 'pool',
+    };
+    const pending = { enabled: true, logins: [{
+      id: 'a1', machineId: 'm1', paneAlive: true, kind: 'url-code-paste',
+      verificationUrl: 'https://claude.com/oauth/renewed', expectedEmail: 'a1@x.com',
+      ttlExpiresAt: '2999-01-01T00:00:00Z',
+    }] };
+    fx.script['/subscription-pool'] = { body: ACCOUNTS_OK };
+    fx.script['/subscription-pool/pending-logins?scope=pool'] = { body: pending };
+    fx.script['/subscription-pool?scope=pool'] = { body: pool };
+
+    const first = ctl(); first._state.active = true; await first.tick();
+    expect(els.matrix.querySelector('[data-cell-key="a1::m1"] .sub-matrix-signin')).toBeTruthy();
+
+    // A brand-new controller models a server/browser restart: no client transient
+    // or repairState survives. Durable pool drift + pending login reconstruct the cell.
+    const restarted = ctl(); restarted._state.active = true; await restarted.tick();
+    const cell = els.matrix.querySelector('[data-cell-key="a1::m1"]');
+    expect(cell.className).toContain('sub-matrix-in-progress');
+    expect(cell.textContent).toContain('Signing in');
+    expect(cell.querySelector('.sub-matrix-signin')).toBeTruthy();
+  });
+
+  it('a drifted cell without a pending flow is honest and PIN-actionable', async () => {
+    fx.script['/subscription-pool'] = { body: ACCOUNTS_OK };
+    fx.script['/subscription-pool/pending-logins?scope=pool'] = { body: NO_PENDING };
+    fx.script['/subscription-pool?scope=pool'] = { body: {
+      enabled: true,
+      accounts: [{ id: 'a1', email: 'a1@x.com', status: 'active', identityDrifted: true, machineId: 'm1', machineNickname: 'Laptop' }],
+      pool: { selfMachineId: 'm1', failed: [] }, scope: 'pool',
+    } };
+    const c = ctl(); c._state.active = true; await c.tick();
+    const cell = els.matrix.querySelector('[data-cell-key="a1::m1"]');
+    expect(cell.textContent).toContain('Needs sign-in');
+    expect(cell.querySelector('[data-matrix-setup]').textContent).toBe('Sign in');
+  });
+
   const POOL_SCOPE = {
     enabled: true,
     accounts: [

--- a/tests/unit/enrollment-wizard.test.ts
+++ b/tests/unit/enrollment-wizard.test.ts
@@ -101,6 +101,23 @@ describe('EnrollmentWizard', () => {
     expect(w.pending()[0].userCode).toBe('7EHB-L23HC');
   });
 
+  it('auto-reissue refreshes the stored link without browser-open consent', async () => {
+    const requests: Parameters<LoginDriver>[0][] = [];
+    const w = new EnrollmentWizard({
+      store, now: () => clock,
+      driveLogin: async (req) => {
+        requests.push(req);
+        return { verificationUrl: `https://claude.com/oauth/${requests.length}`, ttlMs: 15 * 60_000 };
+      },
+    });
+    await w.start({ id: 'claude-1', label: 'Claude', provider: 'anthropic', framework: 'claude-code' });
+    clock = T0 + 16 * 60_000;
+    const renewed = await w.reissueExpired();
+    expect(requests.map((r) => r.openBrowser)).toEqual([true, false]);
+    expect(renewed[0].verificationUrl).toBe('https://claude.com/oauth/2');
+    expect(store.get('claude-1')?.verificationUrl).toBe('https://claude.com/oauth/2');
+  });
+
   it('a driver failure during reissue is skipped (sweep continues, login stays expired)', async () => {
     let n = 0;
     const w = wizard(async () => {

--- a/tests/unit/framework-login-driver.test.ts
+++ b/tests/unit/framework-login-driver.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { FrameworkLoginDriver, enrollPaneSessionName } from '../../src/core/FrameworkLoginDriver.js';
+import { FrameworkLoginDriver, enrollPaneSessionName, enrollmentBrowserEnv } from '../../src/core/FrameworkLoginDriver.js';
 import { loadCapturedFixture } from '../helpers/loadCapturedFixture.js';
 
 describe('enrollPaneSessionName (shared pane-name source of truth — ws52-code-paste-back / codex #1)', () => {
@@ -23,6 +23,14 @@ describe('enrollPaneSessionName (shared pane-name source of truth — ws52-code-
     const configHome = '/Users/x/.instar/agents/echo/.claude-followme-adriana';
     const slug = configHome.replace(/[^a-zA-Z0-9]+/g, '-').slice(-24);
     expect(enrollPaneSessionName('claude-code', configHome)).toBe(`instar-enroll-claude-code-${slug}`);
+  });
+});
+
+describe('enrollmentBrowserEnv consent boundary', () => {
+  it('suppresses the provider browser opener only for background renewal', () => {
+    expect(enrollmentBrowserEnv(false)).toEqual({ BROWSER: 'true' });
+    expect(enrollmentBrowserEnv(true)).toEqual({});
+    expect(enrollmentBrowserEnv(undefined)).toEqual({});
   });
 });
 

--- a/upgrades/next/subscription-cell-login-integrity.md
+++ b/upgrades/next/subscription-cell-login-integrity.md
@@ -1,0 +1,23 @@
+# Subscription cell login integrity
+
+## What Changed
+
+Pending-login renewal now refreshes its durable link/code without opening a browser. The Subscriptions matrix gives identity drift precedence over stale active observations, makes needs-sign-in cells PIN-actionable, and reconstructs an in-progress cell flow from durable pending-login state after restart.
+
+## What to Tell Your User
+
+The Subscriptions grid is now the reliable place to repair an account. A mismatched login says Needs sign-in and can be restarted directly from that cell. Unused sign-in links can renew quietly without repeatedly opening OAuth tabs, and an in-progress repair remains in its cell after the server restarts.
+
+## Summary of New Capabilities
+
+- Consent-safe pending-login renewal with no automatic browser opening
+- Honest, precedence-safe Needs sign-in matrix cells
+- PIN-gated repair initiation from an existing drifted cell
+- Restart-safe in-cell sign-in flow rehydration from durable state
+
+## Evidence
+
+- Unit coverage proves explicit starts allow browser opening while renewal suppresses it and stores the new URL
+- Integration coverage reproduces stale Active overwriting drift and reconstructs a flow with a fresh controller
+- Real-server end-to-end coverage proves drift labeling, cell action, and pending-flow rehydration
+- Framework issue evidence: pending-login-reissue-opens-browser-2026-07-16 and matrix-cell-drift-render-restart-regression-2026-07-16

--- a/upgrades/side-effects/subscription-cell-login-integrity.md
+++ b/upgrades/side-effects/subscription-cell-login-integrity.md
@@ -1,0 +1,70 @@
+# Side-Effects Review — Subscription cell login integrity
+
+**Version / slug:** `subscription-cell-login-integrity`
+**Date:** `2026-07-15`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Background enrollment renewal now carries an explicit no-browser consent flag through EnrollmentWizard and FrameworkLoginDriver into production command wiring. The dashboard matrix aggregates same-cell identity truth with needs-sign-in precedence and lets durable pending state reconstruct the in-cell flow after restart.
+
+## Decision-point inventory
+
+- Browser-open consent — modified invariant: explicit initiation may open; timed renewal may not.
+- Same-cell status precedence — modified invariant: identity drift outranks stale Active.
+- Restart reconstruction — modified invariant: durable pending state outranks drifted enrollment bookkeeping.
+
+## 1. Over-block
+
+Renewal will not automatically focus a newly refreshed provider URL. This is intentional: an operator who did not just initiate the action must not receive unsolicited browser tabs. The refreshed link remains tappable in the cell.
+
+## 2. Under-block
+
+Browser suppression relies on the provider CLI honoring the standard BROWSER environment variable. The command still mints and captures the public artifact. A future provider CLI that ignores BROWSER would require provider-specific suppression; the request-level consent flag and tests make that boundary visible.
+
+## 3. Level-of-abstraction fit
+
+EnrollmentWizard owns initiation versus maintenance intent; FrameworkLoginDriver transports it; production spawn wiring translates it to process environment. Dashboard precedence belongs in the pure matrix model, where all durable inputs meet.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+These are deterministic consent and structured-state invariants, not heuristic interpretation. No brittle detector is given judgment authority.
+
+## 4b. Judgment-point check
+
+No competing-signals heuristic is added. Explicit versus timer initiation and drift/pending/active status are enumerable facts with conservative precedence.
+
+## 5. Interactions
+
+Initial enrollment remains browser-enabled. Renewal still replaces the stored URL/code and increments its counter. A clean active row still wins over a stale completed pending row, preserving the existing just-verified transition; pending wins only while the cell is in needs-sign-in safety state.
+
+## 6. External surfaces
+
+Operators stop receiving unsolicited tabs. Drifted cells change from Active to Needs sign-in and expose the existing PIN-gated flow. No secrets, tokens, new external calls, or new routes are introduced.
+
+## 6b. Operator-surface quality
+
+The primary repair action is directly in the affected cell; no raw identifiers lead; no destructive action is added; the existing phone-width cell flow is reused.
+
+## 7. Multi-machine posture
+
+Machine-local by existing credential design: a login and its browser process belong to the machine holding that credential slot. Pool-scope reads merge durable per-machine accounts and pending logins into one dashboard. No notices or generated Instar URLs are added.
+
+## 8. Rollback cost
+
+A hot-fix revert restores prior behavior. Stored pending-login schema is unchanged, so no data migration or state repair is required.
+
+## Conclusion
+
+The repair makes the cell authoritative without creating a second workflow, preserves the existing successful-enrollment ceremony, and restores browser-open consent. Clear to ship.
+
+## Second-pass review
+
+Not required: no messaging, session lifecycle, trust, recovery controller, sentinel, guard, or conversational judgment path is touched.
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller — not applicable.


### PR DESCRIPTION
## What changed

- Distinguishes explicit enrollment from automatic pending-login renewal, suppressing browser launch only for renewal while still minting and storing a fresh link.
- Makes identity drift monotonic within an account × machine cell so a stale Active observation cannot overwrite Needs sign-in.
- Gives durable pending-login state precedence for drifted cells, allowing the in-cell flow to reconstruct after a server restart.
- Keeps the existing PIN-gated Sign in action in the affected cell as the single repair surface.

## Root cause

Enrollment renewal reused the same login-driver path as an explicit start without carrying browser-open consent. Separately, matrix observations were reduced by arrival order, so duplicate stale Active data could overwrite drift truth, and the render order hid durable pending state behind Active/needs-reauth bookkeeping.

## User impact

Automatic renewal no longer opens unsolicited OAuth tabs. Drifted credentials render honestly as Needs sign-in, can be repaired in place, and an in-progress repair survives controller/server reconstruction.

## ELI16 — the account cell tells the truth and remembers repairs

Think of each account × machine cell as the dashboard's single status light and repair button for that login. If the machine is signed into the wrong identity, the cell now says Needs sign-in even when an older duplicate record still says Active. Starting the repair remains a deliberate, PIN-gated action in that same cell.

If the server restarts while sign-in is underway, the durable pending-login record rebuilds the link-and-code flow in the cell; the repair is not held only in temporary browser memory. When an unused link renews in the background, Instar quietly stores the fresh link without opening another OAuth tab. Explicit first-time starts still open the provider page normally.

## Validation

- 77 focused unit, integration, and end-to-end tests passed.
- Production build passed.
- Repository invariant checks passed.
- Pre-push scoped end-to-end gate passed: 333 tests.
- Tier 2 trace uses the approved, converged account-machine-matrix spec with slug `subscription-cell-login-integrity` and no below-floor override.

## Evidence

- `pending-login-reissue-opens-browser-2026-07-16`
- `matrix-cell-drift-render-restart-regression-2026-07-16`

ELI16: `docs/eli16/subscription-cell-login-integrity.eli16.md`