### PR TITLE
Fix tolerant legacy cycle reads

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-16T04-47-23-134Z-cycles-integrity-tolerant-read.json
+++ b/.instar/instar-dev-decisions/2026-07-16T04-47-23-134Z-cycles-integrity-tolerant-read.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-16T04:47:23.134Z",
+  "slug": "cycles-integrity-tolerant-read",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 13,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/cycles-integrity-tolerant-read.eli16.md
+++ b/docs/eli16/cycles-integrity-tolerant-read.eli16.md
@@ -1,0 +1,11 @@
+# Legacy apprenticeship cycles remain inspectable — ELI16
+
+The integrity report exists to find old cycle records that no longer line up with the current apprenticeship registry. Those old rows can also contain vocabulary from before the current `kind` list was introduced. Previously, the store applied today's strict write rules while reading history, so one unfamiliar historical value crashed the entire report with a server error.
+
+Reads now preserve the row and represent any out-of-date `kind` as `unknown`. This is deliberately different from writes: a new cycle still has to use one of the supported values and is rejected if it does not. Historical data remains visible without weakening the rules for new data.
+
+The behavior is covered at the store, HTTP route, and real server initialization layers. The integrity endpoint can therefore do its actual job—enumerating legacy inconsistencies—without silently rewriting or deleting the evidence it is inspecting.
+
+## ELI16 — practical result
+
+One strange old label can no longer take down the apprenticeship integrity report. Old rows stay readable and honest; new bad rows are still refused.

--- a/src/monitoring/ApprenticeshipCycleStore.ts
+++ b/src/monitoring/ApprenticeshipCycleStore.ts
@@ -328,6 +328,15 @@ function normalizeKind(raw: unknown): ApprenticeshipCycleKind {
   throw new Error(`kind must be one of ${[...APPRENTICESHIP_CYCLE_AXES, 'unknown'].join(', ')}`);
 }
 
+/** Legacy rows must remain readable even when their historical kind predates the enum. */
+function normalizeStoredKind(raw: unknown): ApprenticeshipCycleKind {
+  try {
+    return normalizeKind(raw);
+  } catch {
+    return 'unknown';
+  }
+}
+
 function normalizeChannel(raw: unknown): ApprenticeshipCycleChannel {
   if (
     typeof raw === 'string' &&
@@ -679,7 +688,7 @@ export class ApprenticeshipCycleStore {
     const oversightTimestamps: string[] = [];
 
     for (const row of rows) {
-      const kind = normalizeKind(row.kind);
+      const kind = normalizeStoredKind(row.kind);
       const channel = normalizeChannel(row.channel);
       // §4a ENFORCEMENT: a mentor-mentee-differential cycle that ran through a
       // `direct-shortcut` (bypassing the dogfooded Telegram-Playwright UX-under-test)
@@ -824,7 +833,7 @@ export class ApprenticeshipCycleStore {
       overseerDifferential: parseJsonArray(row.overseer_diff_json),
       coaching: row.coaching,
       infraItems: parseJsonArray(row.infra_items_json),
-      kind: normalizeKind(row.kind),
+      kind: normalizeStoredKind(row.kind),
       status: row.status,
       channel: normalizeChannel(row.channel),
       operatorSeatUx: parseOperatorSeatUx(row.operator_seat_ux_json),

--- a/tests/e2e/apprenticeship-lifecycle.test.ts
+++ b/tests/e2e/apprenticeship-lifecycle.test.ts
@@ -25,6 +25,7 @@ import request from 'supertest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import DatabaseCtor from 'better-sqlite3';
 import { AgentServer } from '../../src/server/AgentServer.js';
 import { StateManager } from '../../src/core/StateManager.js';
 import type { InstarConfig } from '../../src/core/types.js';
@@ -307,6 +308,39 @@ describe('Apprenticeship Program E2E lifecycle (feature is alive)', () => {
     const retained = await request(app).get('/apprenticeship/instances/miscreated-pending').set(auth());
     expect(retained.status).toBe(200);
     expect(retained.body.status).toBe('abandoned');
+  });
+
+  it('keeps the production integrity route alive with a legacy bad-kind row', async () => {
+    await request(app)
+      .post('/apprenticeship/instances')
+      .set(auth())
+      .send({ id: 'legacy-kind-instance', instanceType: 'mentorship', overseer: 'echo', mentor: 'echo', mentee: 'codey', framework: 'codex-cli', priorInstanceId: null })
+      .expect(201);
+    await request(app)
+      .post('/apprenticeship/instances/legacy-kind-instance/transition')
+      .set(auth())
+      .send({ to: 'active' })
+      .expect(200);
+    await request(app)
+      .post('/apprenticeship/cycles')
+      .set(auth())
+      .send({
+        id: 'legacy-bad-kind-e2e',
+        instanceId: 'legacy-kind-instance',
+        cycleNumber: 1,
+        task: 'legacy',
+        menteeOutput: 'kept',
+        operatorSeatUx: { dupNotices: 0, infraNoiseMsgs: 0, asksOfUser: 0, contentFreeUpdates: 0, modalitiesExercised: ['text'], duringRestartChurn: false },
+      })
+      .expect(201);
+
+    const db = new DatabaseCtor(path.join(stateDir, 'server-data', 'apprenticeship-cycles.db'));
+    db.prepare(`UPDATE apprenticeship_cycles SET kind = 'mentorship' WHERE id = ?`).run('legacy-bad-kind-e2e');
+    db.close();
+
+    const report = await request(app).get('/apprenticeship/cycles/integrity').set(auth());
+    expect(report.status).toBe(200);
+    expect(report.body.scanned).toBeGreaterThanOrEqual(1);
   });
 
   it('full lifecycle: create → transition pending→active gated on the real on-disk harvest', async () => {

--- a/tests/integration/apprenticeship-routes.test.ts
+++ b/tests/integration/apprenticeship-routes.test.ts
@@ -18,6 +18,7 @@ import request from 'supertest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import DatabaseCtor from 'better-sqlite3';
 import { createRoutes } from '../../src/server/routes.js';
 import type { RouteContext } from '../../src/server/routes.js';
 import { authMiddleware } from '../../src/server/middleware.js';
@@ -296,6 +297,25 @@ describe('/apprenticeship routes (integration)', () => {
     expect(report.body).toMatchObject({ scanned: 1, danglingCount: 1, truncated: false });
     expect(report.body.dangling[0]).toMatchObject({ instanceId: 'phantom' });
     expect(store.list()).toHaveLength(1);
+    store.close();
+  });
+
+  it('reports a dangling legacy bad-kind cycle instead of failing the integrity read', async () => {
+    const dbPath = path.join(stateDir, 'legacy-bad-kind.db');
+    let store = new ApprenticeshipCycleStore({ dbPath });
+    store.record({ id: 'legacy-bad-kind', instanceId: 'phantom', cycleNumber: 1, task: 'legacy', menteeOutput: 'kept', operatorSeatUx: UXOK });
+    store.close();
+    const db = new DatabaseCtor(dbPath);
+    db.prepare(`UPDATE apprenticeship_cycles SET kind = 'mentorship' WHERE id = ?`).run('legacy-bad-kind');
+    db.close();
+    store = new ApprenticeshipCycleStore({ dbPath });
+    const app = appWith(ctxFor(stateDir, makeActiveProgram(), store));
+
+    const report = await request(app).get('/apprenticeship/cycles/integrity').set(auth());
+    expect(report.status).toBe(200);
+    expect(report.body).toMatchObject({ scanned: 1, danglingCount: 1 });
+    expect(report.body.dangling[0]).toMatchObject({ cycleId: 'legacy-bad-kind', instanceId: 'phantom' });
+    expect(store.list()).toMatchObject([{ id: 'legacy-bad-kind', kind: 'unknown' }]);
     store.close();
   });
 

--- a/tests/unit/apprenticeship-cycle-store.test.ts
+++ b/tests/unit/apprenticeship-cycle-store.test.ts
@@ -109,6 +109,26 @@ describe('ApprenticeshipCycleStore', () => {
     store.close();
   });
 
+  it('keeps a legacy bad-kind row readable while retaining strict write validation', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'apprenticeship-cycles-legacy-kind-'));
+    tmpDirs.push(tmp);
+    const dbPath = path.join(tmp, 'cycles.db');
+    let store = new ApprenticeshipCycleStore({ dbPath });
+    store.record({ id: 'legacy-bad-kind', instanceId: 'phantom', cycleNumber: 1, task: 'legacy', menteeOutput: 'kept', operatorSeatUx: ux() });
+    store.close();
+
+    const db = new DatabaseCtor(dbPath);
+    db.prepare(`UPDATE apprenticeship_cycles SET kind = 'mentorship' WHERE id = ?`).run('legacy-bad-kind');
+    db.close();
+
+    store = new ApprenticeshipCycleStore({ dbPath });
+    expect(store.list()).toMatchObject([{ id: 'legacy-bad-kind', kind: 'unknown' }]);
+    expect(store.get('legacy-bad-kind')).toMatchObject({ kind: 'unknown' });
+    expect(store.roleCoverage('phantom').unknown).toMatchObject({ fired: true, cycleCount: 1 });
+    expect(() => store.record({ id: 'new-bad-kind', instanceId: 'i', cycleNumber: 2, task: 't', menteeOutput: 'm', kind: 'mentorship', operatorSeatUx: ux() })).toThrow(/kind must be one of/);
+    store.close();
+  });
+
   it('roleCoverage warns when mentor-mentee is dormant while overseer-apprentice has multiple cycles', () => {
     const store = makeStore();
     store.record({ id: 'review-1', instanceId: 'i', cycleNumber: 1, createdAt: '2026-06-03T08:00:00.000Z', task: 't', menteeOutput: 'm', kind: 'overseer-apprentice-devreview', operatorSeatUx: ux() });

--- a/upgrades/next/cycles-integrity-tolerant-read.md
+++ b/upgrades/next/cycles-integrity-tolerant-read.md
@@ -1,0 +1,20 @@
+# Tolerant reads for legacy apprenticeship cycles
+
+## What Changed
+
+Apprenticeship cycle reads now clamp an out-of-enum legacy `kind` to `unknown` instead of throwing. Strict validation remains unchanged for new writes.
+
+## What to Tell Your User
+
+The apprenticeship integrity report can now inspect legacy rows even when an old cycle contains vocabulary that predates today's schema. Historical evidence remains visible, while new invalid cycle kinds are still rejected.
+
+## Summary of New Capabilities
+
+- Tolerant legacy-cycle reads across list, get, role coverage, and integrity reporting
+- Strict validation retained for all new cycle writes
+- Non-mutating recovery from historical out-of-enum kind values
+
+## Evidence
+
+- Unit, integration, and real-server E2E coverage with a bad-kind legacy fixture
+- Framework issue evidence: cycles-integrity-strict-read-500-2026-07-16

--- a/upgrades/side-effects/cycles-integrity-tolerant-read.md
+++ b/upgrades/side-effects/cycles-integrity-tolerant-read.md
@@ -1,0 +1,64 @@
+# Side-Effects Review — Tolerant legacy apprenticeship-cycle reads
+
+**Version / slug:** `cycles-integrity-tolerant-read`
+**Date:** `2026-07-15`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Stored cycle rows use tolerant `kind` normalization on read, mapping unsupported historical values to `unknown`. The strict validator remains the authority for new writes.
+
+## Decision-point inventory
+
+The change separates read compatibility from write admission. It does not add a heuristic gate or new authority.
+
+## 1. Over-block
+
+No legitimate read is newly blocked. New writes retain the existing supported-kind requirement.
+
+## 2. Under-block
+
+Malformed fields other than `kind` retain their existing decoding behavior. This incident and fixture are specifically an out-of-enum historical kind.
+
+## 3. Level-of-abstraction fit
+
+The cycle store is the correct layer because every consumer—list, get, role coverage, and the integrity route—must receive readable historical rows. Fixing only the route would leave other reads crashable.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+Strict write admission remains deterministic authority. The read path reports historical uncertainty as `unknown`; it neither blocks nor fabricates a supported semantic kind.
+
+## 4b. Judgment-point check
+
+No competing-signals judgment is introduced. Membership in the supported enum is an enumerable fact.
+
+## 5. Interactions
+
+Role coverage counts the legacy row in its existing `unknown` bucket. The integrity report continues to compare instance references without rewriting history. The constructor's special `differential-cycle` migration remains compatible.
+
+## 6. External surfaces
+
+Previously failing read APIs return records with `kind: unknown`. No data is changed and no new external operation is introduced.
+
+## 7. Multi-machine posture
+
+Machine-local by existing store design. Each machine tolerantly reads its own historical cycle database; no new replication or generated URL is involved.
+
+## 8. Rollback cost
+
+A hot-fix revert restores strict reads. There is no migration or state repair because the fix performs no writes.
+
+## Conclusion
+
+The change restores the honesty report at the shared decoding boundary while preserving strict creation rules. Clear to ship.
+
+## Second-pass review
+
+Not required: no messaging, session lifecycle, recovery controller, trust, sentinel, guard, or conversational judgment path is touched.
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller — not applicable.


### PR DESCRIPTION
## What changed

- Added a stored-row `kind` normalizer that maps unsupported historical values to `unknown`.
- Kept the existing strict normalizer unchanged for new writes.
- Applied tolerant decoding consistently to list, get, role coverage, and therefore the integrity route.
- Added the same bad-kind legacy fixture at unit, HTTP integration, and real AgentServer E2E layers.

## Root cause

The store reused its strict write validator while decoding persisted rows. A legacy `kind` outside today's enum therefore threw during `list()`, crashing the read-only integrity route on exactly the historical data it exists to enumerate.

## ELI16 — old vocabulary cannot crash the history report

The integrity report is meant to inspect old apprenticeship records. Some of those records can contain labels from before today's allowed list existed. Previously, reading one unfamiliar label stopped the entire report. Reads now keep the row visible and call that label `unknown`; they do not rewrite or delete it. New records still have to use a supported label and remain strictly rejected otherwise.

## User impact

`GET /apprenticeship/cycles/integrity` returns an honest report in the presence of legacy bad-kind rows instead of a 500. Other cycle reads gain the same tolerance without weakening write admission.

## Validation

- 71 focused unit, integration, and real-server E2E tests passed.
- Production build passed.
- Repository lint/invariant checks passed.
- Pre-push scoped E2E gate passed: 333 tests.
- Tier 2 decision record uses slug `cycles-integrity-tolerant-read`, with `belowFloor: false`.

## Evidence

- `cycles-integrity-strict-read-500-2026-07-16`
