### PR TITLE
fix: enforce respawn-dead admission for live pin owner

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-16T06-35-56-876Z-spawn-admission-respawn-dead-enforce.json
+++ b/.instar/instar-dev-decisions/2026-07-16T06-35-56-876Z-spawn-admission-respawn-dead-enforce.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-16T06:35:56.876Z",
+  "slug": "spawn-admission-respawn-dead-enforce",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 41,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/spawn-admission-respawn-dead-enforce.eli16.md
+++ b/docs/eli16/spawn-admission-respawn-dead-enforce.eli16.md
@@ -1,0 +1,7 @@
+# Respawn-dead admission graduation — ELI16
+
+When a message arrives on the Mac Mini for a topic deliberately pinned to the Laptop, the router may correctly save/forward the message because the Laptop is still alive. The old restart path could then ignore that outcome and start a second local session anyway. The safety gate already recognized this and recorded that it would block, but this one restart row was still observation-only.
+
+This change makes that single, strongest-evidence row binding. It blocks the local restart only when all facts agree: the callsite is exactly `telegram-respawn-dead`, the router already returned queued, the topic has an effective hard pin to another machine, that pinned machine is currently alive, the multi-machine pool is live, and durable message custody is available. The refusal action is forward, so the message is preserved rather than dropped.
+
+If the owner is genuinely dark, the pin is absent or unreadable, the target is this machine, custody is unavailable, the pool is dark, or a different spawn path is running, behavior remains unchanged. Those cases retain the existing dry-run or owner-dark ladder. The duplicate reconciler is deliberately not graduated here: prevention at the exact spawn door closes this incident without expanding destructive cleanup authority.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -21882,6 +21882,10 @@ export async function startServer(options: StartOptions): Promise<void> {
                   return { owner: ownReg.ownerOf(sk), epoch: r.ownershipEpoch, status: r.status ?? null };
                 },
                 isMachineAlive: seamIsAlive,
+                readHardPinOwner: (sk) => {
+                  const pin = _pinPlacementMetadata ? _pinPlacementMetadata(sk) : _topicPinStore?.asTopicMetadata(sk);
+                  return pin?.pinned === true && pin.preferredMachine ? pin.preferredMachine : null;
+                },
                 durableCustodyLive: () => !!_inboundQueue,
                 journal: (row) => ownerDarkAudit.append(row),
                 raiseAttention: (item) => {

--- a/src/core/SpawnAdmission.ts
+++ b/src/core/SpawnAdmission.ts
@@ -141,6 +141,8 @@ export interface SpawnAdmissionDeps {
   readOwnership: (sessionKey: string) => { owner: string | null; epoch: number; status: string | null } | null;
   /** The pool's existing liveness input (heartbeat-fresh view). */
   isMachineAlive: (machineId: string) => boolean;
+  /** Effective hard-pin owner for this topic, or null when genuinely unpinned. */
+  readHardPinOwner?: (sessionKey: string) => string | null;
   /** Durable inbound-queue custody live on this machine (enforcement precondition). */
   durableCustodyLive: () => boolean;
   /** Appender for logs/owner-dark-ladder.jsonl (scrubbed, metadata-only rows). */
@@ -321,10 +323,14 @@ export class SpawnAdmission {
       this.counters.routerVerdictsConsumed++;
       const action = input.routerVerdict.action;
       if (action === 'queued' || action === 'placement-blocked') {
-        return this.decide(input, mode, {
+        const pinnedOwner = this.livePinnedRespawnOwner(input, mode);
+        return this.decide(input, pinnedOwner ? 'enforce' : mode, {
           row: 'router-queued-suppress',
-          refusalAction: 'rung3-notice',
-          reason: `router-verdict=${action} (acked=${input.routerVerdict.acked}) suppresses local spawn independently of acked`,
+          refusalAction: pinnedOwner ? 'forward' : 'rung3-notice',
+          reason: pinnedOwner
+            ? `router-verdict=${action} at respawn-dead with live hard-pin owner ${pinnedOwner} — forward, never a local spawn`
+            : `router-verdict=${action} (acked=${input.routerVerdict.acked}) suppresses local spawn independently of acked`,
+          ownership: pinnedOwner ? { kind: 'other-alive', owner: pinnedOwner, epoch: 0 } : undefined,
           consumedRouterVerdict: action,
         });
       }
@@ -392,6 +398,31 @@ export class SpawnAdmission {
       return 'enforce';
     }
     return mode;
+  }
+
+  /**
+   * Incident 2026-07-16: graduate only the respawn-dead + queued verdict row
+   * when a hard pin names a different, currently-live machine. Owner-dark,
+   * missing/error pin, other callsites, and fleet-dark posture remain on their
+   * existing ladder/dry-run paths.
+   */
+  private livePinnedRespawnOwner(input: AdmitInput, mode: AdmissionMode): string | null {
+    if (
+      mode !== 'dry-run' ||
+      input.callsite !== 'telegram-respawn-dead' ||
+      this.flag.enforceLiveOwner !== true ||
+      this.deps.poolStage() === 'dark' ||
+      !this.deps.selfMachineId() ||
+      !this.deps.durableCustodyLive() ||
+      !this.deps.readHardPinOwner
+    ) return null;
+    try {
+      const owner = this.deps.readHardPinOwner(input.sessionKey);
+      if (!owner || owner === this.deps.selfMachineId()) return null;
+      return this.deps.isMachineAlive(owner) ? owner : null;
+    } catch {
+      return null;
+    }
   }
 
   /** Shared dry-run/enforce decision shaping for the blocking rows. */

--- a/src/core/SpawnAdmission.ts
+++ b/src/core/SpawnAdmission.ts
@@ -421,6 +421,8 @@ export class SpawnAdmission {
       if (!owner || owner === this.deps.selfMachineId()) return null;
       return this.deps.isMachineAlive(owner) ? owner : null;
     } catch {
+      // @silent-fallback-ok — an erroring pin read falls toward the existing dry-run path,
+      // the deliberate fail-safe direction; enforcement is never fabricated from uncertainty.
       return null;
     }
   }

--- a/tests/e2e/ownership-gated-spawn-burst-invariant.test.ts
+++ b/tests/e2e/ownership-gated-spawn-burst-invariant.test.ts
@@ -36,7 +36,7 @@ function fakeJournal(rows: Row[]): BoundedJsonlAudit {
 }
 
 /** The harness mirroring server.ts's admitLocalSpawn composition. */
-function makeHarness(opts: { flag: SpawnAdmissionFlag; ownerAlive?: () => boolean }) {
+function makeHarness(opts: { flag: SpawnAdmissionFlag; ownerAlive?: () => boolean; hardPinOwner?: string | null }) {
   const journalRows: Row[] = [];
   const ladderRows: Row[] = [];
   const sentNotices: Array<{ topicId: number; text: string }> = [];
@@ -48,6 +48,7 @@ function makeHarness(opts: { flag: SpawnAdmissionFlag; ownerAlive?: () => boolea
     poolStage: () => 'live',
     readOwnership: () => ({ owner: 'mini', epoch: 3, status: 'owned' }),
     isMachineAlive: (m: string) => (m === 'mini' ? ownerAlive() : true),
+    readHardPinOwner: () => opts.hardPinOwner ?? null,
     durableCustodyLive: () => true,
     journal: (r: Row) => journalRows.push(r),
     raiseAttention: () => {},
@@ -103,8 +104,22 @@ function makeHarness(opts: { flag: SpawnAdmissionFlag; ownerAlive?: () => boolea
     }
   }
 
+  async function respawnDead(topicId: number): Promise<'spawned' | 'forwarded'> {
+    const d = admission.admit({
+      sessionKey: String(topicId),
+      callsite: 'telegram-respawn-dead',
+      routerVerdict: { messageId: 'live-message', action: 'queued', acked: true },
+    });
+    if (d.allow) {
+      spawns++;
+      return 'spawned';
+    }
+    return d.refusalAction === 'forward' ? 'forwarded' : 'spawned';
+  }
+
   return {
     inbound,
+    respawnDead,
     ladder,
     spawnCount: () => spawns,
     notices: sentNotices,
@@ -118,6 +133,12 @@ beforeEach(() => {
 });
 
 describe('ownership-gated spawn — burst invariant (E2E composition)', () => {
+  it('respawn-dead + queued + live remote hard-pin owner forwards and creates no local session', async () => {
+    const h = makeHarness({ flag: { enabled: true, dryRun: true, enforceLiveOwner: true }, ownerAlive: () => true, hardPinOwner: 'mini' });
+    await expect(h.respawnDead(29723)).resolves.toBe('forwarded');
+    expect(h.spawnCount()).toBe(0);
+  });
+
   it('INCREMENT 1.4: 1,000 inbounds on a non-owner while the real owner is alive create ZERO local sessions', async () => {
     const h = makeHarness({
       flag: { enabled: true, dryRun: true, enforceLiveOwner: true },

--- a/tests/integration/spawn-admission-respawn-dead.test.ts
+++ b/tests/integration/spawn-admission-respawn-dead.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SpawnAdmission, type SpawnAdmissionDeps } from '../../src/core/SpawnAdmission.js';
+
+describe('respawn-dead SpawnAdmission integration', () => {
+  function deps(alive: boolean): SpawnAdmissionDeps {
+    return {
+      selfMachineId: () => 'mini',
+      poolStage: () => 'live',
+      readOwnership: () => ({ owner: 'laptop', epoch: 4, status: 'owned' }),
+      readHardPinOwner: () => 'laptop',
+      isMachineAlive: () => alive,
+      durableCustodyLive: () => true,
+      journal: vi.fn(), raiseAttention: vi.fn(), provenance: vi.fn(), log: vi.fn(),
+    };
+  }
+
+  it('graduates only the live-owner respawn row and preserves the dark-owner dry-run path', () => {
+    const flag = { enabled: true, dryRun: true, enforceLiveOwner: true };
+    const input = { sessionKey: '29723', callsite: 'telegram-respawn-dead' as const, routerVerdict: { messageId: 'm1', action: 'queued', acked: true } };
+    expect(new SpawnAdmission(flag, deps(true)).admit(input)).toMatchObject({ allow: false, mode: 'enforce', refusalAction: 'forward' });
+    expect(new SpawnAdmission(flag, deps(false)).admit(input)).toMatchObject({ allow: true, mode: 'dry-run', wouldBlock: true });
+  });
+});

--- a/tests/unit/SpawnAdmission.test.ts
+++ b/tests/unit/SpawnAdmission.test.ts
@@ -57,6 +57,26 @@ beforeEach(() => {
   fakeNow = T0;
 });
 
+describe('respawn-dead live hard-pin graduation', () => {
+  const queued = { messageId: 'm1', action: 'queued', acked: true };
+
+  it('enforces forward for respawn-dead when the hard-pin owner is remotely alive', () => {
+    const deps = makeDeps({ readHardPinOwner: vi.fn(() => 'machine-b'), isMachineAlive: vi.fn(() => true) });
+    const decision = new SpawnAdmission(LIVE_OWNER_BINDING, deps).admit(admitInput({ callsite: 'telegram-respawn-dead', routerVerdict: queued }));
+    expect(decision).toMatchObject({ allow: false, mode: 'enforce', row: 'router-queued-suppress', refusalAction: 'forward', ownership: { kind: 'other-alive', owner: 'machine-b' } });
+  });
+
+  it.each([
+    ['owner dark', { readHardPinOwner: vi.fn(() => 'machine-b'), isMachineAlive: vi.fn(() => false) }, 'telegram-respawn-dead'],
+    ['no hard pin', { readHardPinOwner: vi.fn(() => null), isMachineAlive: vi.fn(() => true) }, 'telegram-respawn-dead'],
+    ['different callsite', { readHardPinOwner: vi.fn(() => 'machine-b'), isMachineAlive: vi.fn(() => true) }, 'telegram-cold-spawn'],
+  ] as const)('leaves %s on the existing dry-run path', (_name, over, callsite) => {
+    const decision = new SpawnAdmission(LIVE_OWNER_BINDING, makeDeps(over)).admit(admitInput({ callsite, routerVerdict: queued }));
+    expect(decision).toMatchObject({ allow: true, mode: 'dry-run', row: 'router-queued-suppress', wouldBlock: true });
+    expect(decision.refusalAction).toBeUndefined();
+  });
+});
+
 // ── resolveOwnershipSafe ──────────────────────────────────────────────
 
 describe('resolveOwnershipSafe', () => {

--- a/tests/unit/spawn-admission-callsite-pins.test.ts
+++ b/tests/unit/spawn-admission-callsite-pins.test.ts
@@ -90,4 +90,9 @@ describe('SpawnAdmission callsite pins (src/commands/server.ts)', () => {
     expect(src).toContain('void _ownerDarkLadder.handleOwnerDark({');
     expect(src).toContain("d.refusalAction === 'owner-dark-ladder' || d.refusalAction === 'rung3-notice'");
   });
+
+  it('(g) respawn-dead graduation reads the effective hard pin and retains owner-dark fail-safe', () => {
+    expect(src).toContain('readHardPinOwner: (sk) => {');
+    expect(src).toContain("admitLocalSpawn('telegram-respawn-dead')");
+  });
 });

--- a/upgrades/next/spawn-admission-respawn-dead-enforce.md
+++ b/upgrades/next/spawn-admission-respawn-dead-enforce.md
@@ -1,0 +1,20 @@
+## What Changed
+
+The respawn-dead Telegram callsite now enforces the existing SpawnAdmission refusal when a queued router verdict agrees with a live remote hard-pin owner and durable custody is available. Genuinely dark owners and every other admission row retain their existing behavior.
+
+## What to Tell Your User
+
+During a remote owner-session restart, a front-door machine will no longer start a duplicate local copy after it has already saved the message for the live pinned machine. The message stays preserved and follows the intended machine instead of producing two replies.
+
+## Summary of New Capabilities
+
+- Binding respawn-dead refusal for live remote hard-pin owners
+- Forward-with-custody semantics with no message-loss branch
+- Unchanged owner-dark ladder and unrelated spawn rows
+
+## Evidence
+
+- Unit coverage enumerates live owner, dark owner, missing pin, and other callsites.
+- Integration coverage proves only the live-owner row graduates.
+- E2E composition proves queued delivery forwards with zero local sessions.
+- Framework issue: `spawn-admission-respawn-dead-dryrun-escape-2026-07-16`.

--- a/upgrades/side-effects/spawn-admission-respawn-dead-enforce.md
+++ b/upgrades/side-effects/spawn-admission-respawn-dead-enforce.md
@@ -72,3 +72,7 @@ The change is narrowly fitted to the recurring live incident and closes it at th
 ## Class-Closure Declaration (display-only mirror)
 
 No agent-authored-artifact defect and no self-triggered controller — not applicable. The respawn is triggered by an inbound user message; its recurrence guard is nevertheless covered by the callsite pin plus unit/integration/E2E admission matrix.
+
+## CI ratchet fix-forward
+
+The hard-pin read catch is explicitly annotated `@silent-fallback-ok`: an erroring read returns to the pre-existing dry-run admission path, which is the deliberate fail-safe direction and never fabricates enforcement authority from uncertainty. Runtime behavior is unchanged.

--- a/upgrades/side-effects/spawn-admission-respawn-dead-enforce.md
+++ b/upgrades/side-effects/spawn-admission-respawn-dead-enforce.md
@@ -1,0 +1,74 @@
+# Side-Effects Review — Respawn-dead admission graduation
+
+**Version / slug:** `spawn-admission-respawn-dead-enforce`
+**Date:** `2026-07-16`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** independent lifecycle reviewer — concurred
+
+## Summary of the change
+
+`SpawnAdmission` now promotes one dry-run row to enforcement: a consumed queued/placement-blocked router verdict at `telegram-respawn-dead` when the effective hard pin names a different, currently-live machine and the same pool/custody gates used by Increment 1.4 are green. `server.ts` supplies the merged effective hard-pin read. Tests cover unit, integration, and E2E composition.
+
+## Decision-point inventory
+
+- Respawn-dead local session creation — modified — refuses the local spawn on exact, corroborated live remote ownership.
+- Owner-dark ladder — pass-through — remains dry-run/unchanged when the pinned owner is not live.
+
+## 1. Over-block
+
+The only newly rejected input is a respawn-dead attempt after the router has already queued the same message for a live, differently pinned machine. A stale pin could over-block only if both the merged pin read and the pool liveness view incorrectly agree; durable custody still prevents loss. Other callsites, absent/error pins, local pins, and dark owners remain unchanged.
+
+## 2. Under-block
+
+Unpinned topics and owners not currently reported alive remain in the existing posture, so duplicates from those distinct evidence rows are not prevented by this graduation. That is intentional: the incident's hard-pin evidence rung is affirmative and enumerable; guessing ownership from weaker state would risk silence.
+
+## 3. Level-of-abstraction fit
+
+The existing `SpawnAdmission` authority owns session-creation permission and already consumes the router verdict. Adding the hard-pin corroboration there avoids a parallel server-side blocker. The server supplies only the effective merged pin observation.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+This is deterministic authority over an enumerable ownership invariant, explicitly within the principle's hard-invariant exemption. No keyword/heuristic detector gains authority: router outcome, callsite identity, hard-pin owner, machine liveness, pool posture, and durable custody are structured facts consumed by the existing authority.
+
+## 4b. Judgment-point check
+
+No new competing-signals heuristic is introduced. The action space is fixed by the ratified Ownership-Gated Side Effects floor: a live remote hard-pin owner plus custody means forward, never spawn locally. Ambiguous or unavailable evidence preserves the existing path.
+
+## 5. Interactions
+
+- The router queues before SpawnAdmission runs; the admission seam consumes that exact verdict, avoiding TOCTOU re-derivation.
+- Refusal action is `forward`; acknowledged custody prevents loss and avoids owner-dark notices.
+- `spawningTopics` and respawn execution remain downstream and are skipped only on the exact refusal.
+- The genuinely-dark owner path does not graduate and continues through the existing ladder behavior.
+- DuplicateSessionReconciler is not graduated: its owner-copy-survives action is a separate, destructive authority. Closing the spawn door fixes this incident without broadening termination scope.
+
+## 6. External surfaces
+
+Users stop seeing a second local session and duplicate reply during the narrow restart race. No new operator action, URL, API, durable schema, or notice is added.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+Machine-local decision over replicated/proxied facts: the effective hard pin comes from the local-plus-replicated HLC fold, and liveness comes from the pool capacity view with the suspect breaker. The decision appropriately differs by front-door machine but converges on the same pinned owner. It emits no notice, creates no durable state, and generates no URL; the existing inbound queue owns custody across machines.
+
+## 8. Rollback cost
+
+Pure code rollback: revert and ship a patch. No migration or state repair is required. During rollback the prior duplicate-session race reopens, but messages remain reachable.
+
+## Conclusion
+
+The change is narrowly fitted to the recurring live incident and closes it at the existing session-creation authority. Dark/error/unowned behavior and destructive reconciliation remain unchanged. Clear to ship after independent lifecycle review.
+
+## Second-pass review
+
+**Reviewer:** independent lifecycle reviewer
+**Independent read of the artifact: concur.** The change narrowly binds only respawn-dead with a queued verdict, live remote hard pin, and durable custody, while owner-dark, ambiguous evidence, other callsites, and custody failure retain their existing safe paths.
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller — not applicable. The respawn is triggered by an inbound user message; its recurrence guard is nevertheless covered by the callsite pin plus unit/integration/E2E admission matrix.


### PR DESCRIPTION
## Outcome

The `telegram-respawn-dead` callsite now binds the existing SpawnAdmission refusal when the consumed router verdict is queued, the effective hard pin names a different live machine, and durable custody is available. The message is forwarded; no local duplicate session is spawned.

## Why this is a separate PR

This HIGH recurrence is a session-lifecycle admission defect with a distinct cause and rollback surface from the subscription drift-clear lag. Keeping it separate preserves incident causality and lets this prevention fix enter CI first.

## Scope and invariants

- Exact callsite: `telegram-respawn-dead`
- Exact evidence: queued/placement-blocked router verdict + effective remote hard pin + live owner
- Same Increment 1.4 gates: feature armed, pool live, machine identity present, durable custody live
- Refusal action: forward, never message loss
- Genuinely dark owner: existing dry-run/ladder path unchanged
- Missing/error/local pin, custody dark, pool dark, other callsites: unchanged

## Reconciler judgment

I did not graduate `DuplicateSessionReconciler` owner-copy-survives. That is a separate destructive closeout authority. The exact spawn-door prevention closes this incident without widening termination scope; its hard-pin rung can be evaluated independently with its own safety proof.

## ELI16 — prevent the restart race

The router had already put the message on the road to the live Laptop, but the Mini restart path could still open a second local copy. Now the Mini checks the strongest facts at the actual restart door: this is the dead-session restart path, the router saved the message, the topic is deliberately pinned to another machine, that machine is alive, and custody is durable. When all agree, it forwards and does not restart locally. If the owner is genuinely dark or the facts are incomplete, the old recovery ladder remains untouched.

## Verification

- Unit: live pin-owner enforcement plus dark owner, missing pin, and other-callsite non-graduation
- Integration: only the live-owner respawn row graduates
- E2E: queued respawn forwards with zero local sessions
- 63 focused tests passed across 4 suites
- TypeScript build passed
- Pre-push scoped E2E: 333 tests passed across 18 suites

## Process artifacts

- First-push release fragment
- Real-slug Tier 2 decision record
- Side-effects review with independent lifecycle concurrence
- ELI16 overview

Framework issue: `spawn-admission-respawn-dead-dryrun-escape-2026-07-16`.