### PR TITLE
fix: clear identity drift after enrollment completion

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-16T07-36-00-000Z-enrollment-completion-drift-clear-lag.json
+++ b/.instar/instar-dev-decisions/2026-07-16T07-36-00-000Z-enrollment-completion-drift-clear-lag.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-16T07:36:00.000Z",
+  "slug": "enrollment-completion-drift-clear-lag",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 8,
+  "loc": 150,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -561,6 +561,10 @@ export function buildMatrixModel(poolScope, pendingScope, transient = {}) {
       else if (cellStatus.get(key) === 'needs-reauth' && pendingLogin && pendingLogin.paneAlive === false) state = 'broken';
       else if (cellStatus.get(key) === 'needs-reauth' && pendingLogin) state = 'in-progress';
       else if (t && t.state === 'expired') state = 'expired';
+      // A validated completion is newer evidence than the pool snapshot that
+      // still says needs-reauth/identity-drifted. Keep the success ceremony
+      // visible while the targeted post-login verification catches the row up.
+      else if (t && t.state === 'just-verified' && cellStatus.get(key) === 'needs-reauth') state = 'just-verified';
       else if (cellStatus.get(key) === 'needs-reauth') state = 'needs-reauth';
       else if (cellStatus.get(key) === 'active') state = 'active';
       else if ((pendingLogin && pendingLogin.paneAlive === false) || (t && t.state === 'broken')) state = 'broken';

--- a/docs/eli16/enrollment-completion-drift-clear-lag.eli16.md
+++ b/docs/eli16/enrollment-completion-drift-clear-lag.eli16.md
@@ -1,0 +1,7 @@
+# Enrollment completion drift-clear lag — ELI16
+
+After you finish signing an account back in, the server may still remember the identity it saw before login for up to one polling interval. That can leave the account marked as drifted and make the grid briefly say “Needs sign-in” even though sign-in just succeeded.
+
+The completion endpoint now throws away that old identity observation and immediately checks only the repaired account. While that check catches the durable pool row up, the browser's fresh completion result wins over the stale failure label and shows “Set up complete.” Already-active cells keep their existing active styling and success highlight.
+
+If the immediate usage check is temporarily unavailable, enrollment still succeeds. The old identity cache is already invalidated, so the normal scheduled poll retries with fresh evidence.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -24722,6 +24722,25 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     });
   };
 
+  // A completed sign-in has replaced the credential at this slot. Discard the
+  // pre-login identity observation and immediately re-probe only this account;
+  // otherwise identityDrifted remains latched until the next scheduled sweep.
+  // Completion remains successful if the fresh quota read is temporarily
+  // unavailable: the normal poll loop will retry, while the cache is already
+  // invalidated so it cannot reuse pre-login identity evidence.
+  const reverifyCompletedEnrollment = async (
+    login: { id: string; configHome?: string },
+  ): Promise<void> => {
+    const poller = ctx.quotaPoller;
+    const account = ctx.subscriptionPool?.get(login.id);
+    if (!poller || !account) return;
+    poller.invalidateIdentityCache([login.configHome || account.configHome]);
+    try { await poller.pollAccount(account); }
+    catch (err) {
+      console.warn(`[subscription-pool] immediate post-enrollment verification deferred for ${login.id}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
   // P2.1 — the "Pending Logins" surface (the phone/dashboard panel). MUST be
   // registered before GET /subscription-pool/:id, or the param route shadows the
   // literal "pending-logins" segment. 200 { enabled:false } when unwired.
@@ -25395,6 +25414,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
             // Upsert (D5): a re-auth of an EXISTING pool account updates it back to active;
             // only a genuinely-new account is added.
             const acct = upsertValidatedAccount(result.login, result.email);
+            await reverifyCompletedEnrollment(result.login);
             logOutcome('validated');
             // `email` rides along so the dashboard's terminal success state can NAME the
             // verified account ("headley.justin@gmail.com is set up on this machine") —
@@ -25749,6 +25769,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         res.status(404).json({ error: `pending login ${id} not found` });
         return;
       }
+      await reverifyCompletedEnrollment(login);
       res.json({ enabled: true, login });
     } finally {
       plainCompleteInFlight.delete(id);
@@ -25790,6 +25811,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       // Upsert (D5): a re-auth of an EXISTING pool account updates it back to active.
       const { login, email } = result;
       const account = upsertValidatedAccount(login, email);
+      await reverifyCompletedEnrollment(login);
       res.status(201).json({ enabled: true, outcome: 'validated', account });
     } catch (err) {
       const isValidation = err instanceof Error && err.name === 'ValidationError';

--- a/tests/e2e/subscription-enrollment-lifecycle.test.ts
+++ b/tests/e2e/subscription-enrollment-lifecycle.test.ts
@@ -119,4 +119,37 @@ describe('/subscription-pool enrollment — E2E feature-alive', () => {
     expect(cfg.hasTrustDialogAccepted).toBe(true);
     expect(cfg.oauthAccount).toEqual(oauthAccount); // credentials byte-identical
   });
+
+  it('FEATURE ALIVE: completion invalidates and immediately reverifies the repaired slot without a scheduled sweep', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'enroll-e2e-reverify-'));
+    const configHome = path.join(dir, 'codex-1');
+    const account = { id: 'codex-1', configHome, identityDrifted: true };
+    const events: string[] = [];
+    const store = new PendingLoginStore({ stateDir: dir });
+    const wizard = new EnrollmentWizard({ store, driveLogin: async () => ART });
+    server = await bootApp({
+      config: { authToken: 't', stateDir: dir, port: 0 },
+      startTime: new Date(),
+      enrollmentWizard: wizard,
+      subscriptionPool: { get: (id: string) => id === account.id ? account : null },
+      quotaPoller: {
+        invalidateIdentityCache: (slots: string[]) => events.push(`invalidate:${slots.join(',')}`),
+        pollAccount: async (polled: typeof account) => {
+          events.push(`poll:${polled.id}`);
+          polled.identityDrifted = false;
+          return null;
+        },
+      },
+    });
+    const started = await fetch(server.url + '/subscription-pool/enroll', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: account.id, label: 'codex', provider: 'openai', framework: 'codex-cli', configHome }),
+    });
+    expect(started.status).toBe(201);
+
+    const completed = await fetch(server.url + `/subscription-pool/enroll/${account.id}/complete`, { method: 'POST' });
+    expect(completed.status).toBe(200);
+    expect(events).toEqual([`invalidate:${configHome}`, `poll:${account.id}`]);
+    expect(account.identityDrifted).toBe(false);
+  });
 });

--- a/tests/integration/subscription-enrollment-routes.test.ts
+++ b/tests/integration/subscription-enrollment-routes.test.ts
@@ -44,9 +44,13 @@ describe('/subscription-pool enrollment routes (integration)', () => {
   let clock: number;
   let tmuxLog: string;
   let enrollmentCompleteInFlightHook: ((id: string) => void | Promise<void>) | undefined;
+  let invalidatedSlots: string[];
+  let polledAccounts: string[];
 
   beforeEach(async () => {
     enrollmentCompleteInFlightHook = undefined;
+    invalidatedSlots = [];
+    polledAccounts = [];
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'enroll-int-'));
     clock = Date.parse('2026-06-07T00:00:00Z');
     store = new PendingLoginStore({ stateDir: dir, now: () => clock });
@@ -61,6 +65,11 @@ describe('/subscription-pool enrollment routes (integration)', () => {
       startTime: new Date(),
       enrollmentWizard: wizard,
       enrollmentCompleteInFlightHook: (id: string) => enrollmentCompleteInFlightHook?.(id),
+      subscriptionPool: { get: (id: string) => id === 'codex-1' ? { id, configHome: path.join(dir, 'codex-1') } : null },
+      quotaPoller: {
+        invalidateIdentityCache: (slots: string[]) => invalidatedSlots.push(...slots),
+        pollAccount: async (account: { id: string }) => { polledAccounts.push(account.id); return null; },
+      },
     };
     app.use(createRoutes(ctx));
     server = await listen(app);
@@ -137,6 +146,8 @@ describe('/subscription-pool enrollment routes (integration)', () => {
     const done = await api('/subscription-pool/enroll/codex-1/complete', { method: 'POST' });
     expect(done.status).toBe(200);
     expect(done.body.login.status).toBe('completed');
+    expect(invalidatedSlots).toEqual([path.join(dir, 'codex-1')]);
+    expect(polledAccounts).toEqual(['codex-1']);
     const list = await api('/subscription-pool/pending-logins');
     expect(list.body.logins).toEqual([]);
   });

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -561,6 +561,22 @@ describe('renderAccountMatrix', () => {
     expect(cell.querySelector('.sub-matrix-setup')).toBeNull(); // never blinks back to "Set up"
   });
 
+  it('D4: fresh completion wins over a stale needs-reauth pool row', () => {
+    const t = el();
+    const pool = {
+      enabled: true,
+      accounts: [
+        { id: 'a1', email: 'a1@x.com', status: 'needs-reauth', identityDrifted: true, machineId: 'm1', machineNickname: 'Laptop' },
+      ],
+      pool: { selfMachineId: 'm1', failed: [] },
+    };
+    const transient = { 'a1::m1': { state: 'just-verified', at: Date.now() } };
+    renderAccountMatrix(doc, t, pool, { enabled: true, logins: [] }, transient);
+    const cell = t.querySelector('.sub-matrix-just-verified')!;
+    expect(cell.textContent).toContain('Set up complete');
+    expect(t.querySelector('.sub-matrix-needs-reauth')).toBeNull();
+  });
+
   it('D4: an ACTIVE cell with a fresh just-verified transient carries the highlight class + "just set up" wording', () => {
     const t = el();
     const transient = { 'a1::m1': { state: 'just-verified', at: Date.now() } };

--- a/upgrades/next/enrollment-completion-drift-clear-lag.md
+++ b/upgrades/next/enrollment-completion-drift-clear-lag.md
@@ -1,0 +1,21 @@
+# Enrollment completion clears identity drift immediately
+
+## What Changed
+
+Successful account enrollment now invalidates the replaced slot's cached identity and immediately reverifies that account, rather than waiting for the next scheduled quota poll. The Subscriptions grid also keeps a fresh “Set up complete” result visible over a stale Needs sign-in snapshot during that short convergence window.
+
+## What to Tell Your User
+
+When you finish signing an account back in, its grid cell now settles immediately instead of briefly falling back to Needs sign-in. A fresh successful repair stays visibly complete while the account record catches up.
+
+## Summary of New Capabilities
+
+- Immediate targeted identity re-verification after enrollment completion
+- Fresh completion state takes precedence over a stale Needs sign-in snapshot
+- Existing active-cell success highlighting remains unchanged
+
+## Evidence
+
+- Unit coverage locks completed-state render precedence
+- Integration coverage locks cache invalidation before targeted account polling
+- Real-server E2E proves drift clears without waiting for a scheduled sweep

--- a/upgrades/side-effects/enrollment-completion-drift-clear-lag.md
+++ b/upgrades/side-effects/enrollment-completion-drift-clear-lag.md
@@ -1,0 +1,36 @@
+# Side-effects review — enrollment completion drift-clear lag
+
+## Change boundary
+
+All three successful completion paths—plain completion, follow-me completion, and submit-code's validated completion—call one local helper after the credential has been committed. The helper invalidates only the completed login's config-home identity cache entry and polls only the matching pool account. Held, submitted, cancelled, not-found, and failed completions do not reverify.
+
+## State and ordering
+
+The durable enrollment transition happens first. Identity cache invalidation happens before the targeted poll, so pre-login evidence cannot close or preserve drift. The existing QuotaPoller reconciliation remains the sole writer of `identityDrifted`; this route does not duplicate that authority. No timer or background job is introduced.
+
+## Failure direction
+
+A missing pool account or unwired poller preserves existing completion behavior. A temporary targeted-poll failure is logged and leaves the successfully completed enrollment intact; the scheduled poll retries later using the already-invalidated cache. This is fail-toward-fresh-retry, not fail-toward stale identity.
+
+## UI precedence
+
+Only a fresh `just-verified` transient may outrank a stale `needs-reauth` cell. Pending-login liveness, held, cannot-resolve, expired, and offline states retain precedence. Active cells retain their established active state plus success highlight.
+
+## Privacy, security, and multi-machine effects
+
+No credential, token, URL, or code is returned or logged. The helper uses the server-owned completed login and pool account, never request-supplied identity. Reverification is target-local to the machine that completed enrollment; pool replication observes the resulting normal pool update. There is no fan-out or cross-machine write.
+
+## 6b. Operator-surface quality
+
+1. **Primary action first:** unchanged. The cell continues to lead with the setup/sign-in action when action is needed; after completion it leads with the terminal success state.
+2. **Zero raw internals as primary content:** yes. The operator sees “Set up complete,” never cache, poller, drift flags, config homes, or account IDs.
+3. **Destructive actions de-emphasized:** unchanged. This patch adds no destructive action and does not promote cancel, revoke, or removal controls.
+4. **Plain language at phone width:** yes. It reuses the existing compact success label and cell ceremony, adding no new prose or layout that can overflow the matrix cell.
+
+## Rollback and verification
+
+Rollback is code-only and needs no data migration. Unit coverage locks render precedence, integration coverage locks invalidation-before-targeted-poll, and real-server E2E proves completion clears simulated drift without a scheduled sweep.
+
+## Second-pass review
+
+Not required: this change invokes the existing identity-reconciliation authority after a user-completed login; it does not add or widen a gate, session lifecycle action, autonomous trigger, destructive operation, or trust decision.


### PR DESCRIPTION
## Summary
- invalidate the completed slot identity cache and immediately reverify only that pool account across plain, follow-me, and submit-code completion paths
- keep a fresh completed cell state ahead of a stale needs-sign-in snapshot without changing active-cell highlighting
- add unit, integration, and real-server E2E regressions plus the first-push release fragment

## ELI16
After a successful re-login, the server could still remember who owned that credential before login until the next scheduled poll. That left the grid briefly saying Needs sign-in even though setup had finished. Completion now discards that old observation and immediately checks the repaired account; the fresh success state stays visible while the durable row catches up.

## Validation
- 70/70 focused tests across unit, integration, and real-server E2E
- npm run lint
- npm run build
- upgrade guide validation
- Tier-2 instar-dev commit gate
- pre-push affected-test gate against JKHeadley/main

## Scope notes
- reverify failure preserves successful enrollment and retries later from an already-invalidated cache
- no credential, token, URL, or code is logged or returned
- no new authority: QuotaPoller remains the sole identity-drift reconciler
- local Threadline pre-push selection initially used the stale fork base and hit an unrelated shared-SQLite lock after 316 passes; branch tracking was corrected to JKHeadley/main and the documented local E2E bypass was used, with CI retaining authority