### PR TITLE
fix(topic-profile): report resolved door and model

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-16T20-37-00-000Z-topic-profile-resolved-door-model.json
+++ b/.instar/instar-dev-decisions/2026-07-16T20-37-00-000Z-topic-profile-resolved-door-model.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-07-16T20:37:00.000Z",
+  "slug": "topic-profile-resolved-door-model",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "session lifecycle surface: post-swap applied-state reporting reads the newly spawned session",
+    "shared launch resolution: interactive default-model selection is consumed by builders and session state"
+  ],
+  "belowFloor": false,
+  "files": 8,
+  "loc": 119,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Post-swap disclosure rendered the requested topic profile instead of the applied spawn result, while Codex and Gemini concrete defaults lived only inside their argv builders. This hid the exact default model from operators and left model/tier respawns without a terminal applied-state confirmation."
+  },
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -23319,7 +23319,7 @@ export async function startServer(options: StartOptions): Promise<void> {
               const topicName = telegram.getTopicName(n) || `topic-${n}`;
               _orchestratorSpawnInFlight.add(topicKey);
               try {
-                await spawnSessionForTopic(
+                const spawnedName = await spawnSessionForTopic(
                   sessionManager,
                   telegram,
                   topicName,
@@ -23331,7 +23331,16 @@ export async function startServer(options: StartOptions): Promise<void> {
                   undefined,
                   { awaitInitialInjection: true },
                 );
-                return { ok: true };
+                const spawned = sessionManager.listRunningSessions()
+                  .find((session) => session.tmuxSession === spawnedName);
+                return {
+                  ok: true,
+                  applied: {
+                    ...resolvedToApplied(_resolved),
+                    framework: spawned?.framework ?? _resolved.framework,
+                    model: spawned?.model ?? _resolved.model ?? null,
+                  },
+                };
               } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);
                 let cls: ProfileSpawnFailureClass = 'unknown';

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -74,6 +74,7 @@ import {
   withClaudeUltracodePrompt,
   claudeHeadlessExtraFlags,
   resolveInteractiveFramework,
+  resolveInteractiveLaunchModel,
   resolveModelForFramework,
 } from './frameworkSessionLaunch.js';
 import { frameworkFromEnv } from './intelligenceProviderFactory.js';
@@ -4615,7 +4616,9 @@ rm()  { "${shimRunner}" rm  "$@"; }
       // Left undefined only when no model was pinned (the CLI uses its own
       // account default).
       framework,
-      ...(resolveModelForFramework(framework, launchDefaultModel) ? { model: resolveModelForFramework(framework, launchDefaultModel) } : {}),
+      ...(resolveInteractiveLaunchModel(framework, launchDefaultModel, options?.codexLocalProvider)
+        ? { model: resolveInteractiveLaunchModel(framework, launchDefaultModel, options?.codexLocalProvider) }
+        : {}),
       // P1.3: which subscription-pool account this session runs under (an explicit
       // quota-aware swap/placement, OR the resolver-pinned account for B1 — the
       // user-facing interactive lane is now tagged just like the headless lane).

--- a/src/core/TopicProfileOrchestrator.ts
+++ b/src/core/TopicProfileOrchestrator.ts
@@ -160,6 +160,8 @@ export interface OrchTopicSession {
 export interface RespawnSpawnOutcome {
   ok: boolean;
   failureClass?: ProfileSpawnFailureClass;
+  /** Profile observed on the newly-created session, after launch defaults. */
+  applied?: AppliedProfile;
 }
 
 /** The narrow session surface the orchestrator is allowed to touch. */
@@ -1054,13 +1056,14 @@ export class TopicProfileOrchestrator {
 
     const outcome = await this.deps.sessions.spawn(key, resolved, { method, resumeId });
     if (outcome.ok) {
-      this.recordApplied(key, resolvedToApplied(resolved));
+      const applied = outcome.applied ?? resolvedToApplied(resolved);
+      this.recordApplied(key, applied);
       this.clearSuppression(key);
       if (resolved.framework === 'codex-cli') {
         const cwd = this.deps.sessions.getSessionForTopic(key)?.cwd ?? session.cwd;
         this.codexFenceWindows.set(cwd, this.now() + RESPAWN_PHASE_TTL_MS);
       }
-      this.discloseTerminal(key, slot, resolved, method, lossNote);
+      this.discloseTerminal(key, slot, appliedToResolvedForDisclosure(resolved, applied), method, lossNote);
       this.audit_({ type: 'respawn-applied', topic: key, method, fresh, breakerRevert: task.breakerRevert });
     } else {
       this.recordSpawnFailureInternal(key, outcome.failureClass ?? 'unknown');
@@ -1122,9 +1125,12 @@ export class TopicProfileOrchestrator {
         `was: ${was} → now: ${now} (${slot.changeCount} changes, origins: ${[...slot.origins].join(', ')})`,
       );
     }
+    parts.push(
+      `Now driving this topic: ${renderDoor(resolved.framework)} door, ${resolved.model ?? 'account-default'} model.`,
+    );
     if (method === 'continuation') {
       parts.push(
-        `Switching this topic to ${resolved.framework}. The full transcript can't follow across that boundary, so I'm carrying recent history + memory — continuing from there.`,
+        `The full transcript can't follow across that boundary, so I'm carrying recent history + memory — continuing from there.`,
       );
     }
     if (lossNote) parts.push(lossNote);
@@ -1799,6 +1805,27 @@ function resolvedToPseudo(resolved: ResolvedTopicProfile): TopicProfile {
     updatedAt: '',
     updatedBy: '',
   };
+}
+
+function appliedToResolvedForDisclosure(
+  resolved: ResolvedTopicProfile,
+  applied: AppliedProfile,
+): ResolvedTopicProfile {
+  return {
+    ...resolved,
+    framework: applied.framework,
+    model: applied.model ?? undefined,
+    modelTier: applied.modelTier,
+    thinkingMode: applied.thinkingMode ?? undefined,
+    effort: applied.effort ?? undefined,
+  };
+}
+
+function renderDoor(framework: IntelligenceFramework): string {
+  if (framework === 'codex-cli') return 'Codex';
+  if (framework === 'claude-code') return 'Claude';
+  if (framework === 'gemini-cli') return 'Gemini';
+  return 'Pi';
 }
 
 /** The characteristics a spawn against this resolution applies. */

--- a/src/core/frameworkSessionLaunch.ts
+++ b/src/core/frameworkSessionLaunch.ts
@@ -96,6 +96,26 @@ export function resolveModelForFramework(
 }
 
 /**
+ * Concrete model an interactive launch will use after applying the builder's
+ * own default. Keep user-facing post-spawn reporting on this same seam so a
+ * defaulted model is never guessed independently from the argv builder.
+ */
+export function resolveInteractiveLaunchModel(
+  framework: IntelligenceFramework,
+  configuredModel: string | undefined,
+  codexLocalProvider?: 'ollama' | 'lmstudio',
+): string | undefined {
+  if (framework === 'codex-cli') {
+    if (codexLocalProvider) return configuredModel ?? 'llama3.2:latest';
+    return resolveModelForFramework(framework, configuredModel) ?? 'gpt-5.5';
+  }
+  if (framework === 'gemini-cli') {
+    return resolveModelForFramework(framework, configuredModel) ?? 'gemini-2.5-flash';
+  }
+  return resolveModelForFramework(framework, configuredModel);
+}
+
+/**
  * Build the Codex `-c` config overrides that pin the threadline MCP server to
  * a specific agent's stdio entry. This wins over whatever `[mcp_servers."threadline"]`
  * the SHARED ~/.codex/config.toml currently holds — fixing the multi-agent
@@ -322,9 +342,11 @@ const codexCliBuilder: Builder = (options) => {
   // vocabulary) and pass the model verbatim. Builder also appends
   // --oss --local-provider <p> below.
   const isLocal = options.codexLocalProvider !== undefined;
-  const resolvedModel = isLocal
-    ? (options.defaultModel ?? 'llama3.2:latest')
-    : (resolveModelForFramework('codex-cli', options.defaultModel) ?? 'gpt-5.5');
+  const resolvedModel = resolveInteractiveLaunchModel(
+    'codex-cli',
+    options.defaultModel,
+    options.codexLocalProvider,
+  )!;
 
   // Codex's `resume` is a subcommand (`codex resume <SESSION_ID>`), not a
   // flag. When resuming, insert it as the first argument after the binary
@@ -398,8 +420,7 @@ const geminiCliBuilder: Builder = (options) => {
   // (`--approval-mode default`, no tools) lives ONLY on the one-shot
   // intelligence-provider EVALUATION path (GeminiCliIntelligenceProvider —
   // the analog of `codex exec --sandbox read-only`), never here.
-  const resolvedModel =
-    resolveModelForFramework('gemini-cli', options.defaultModel) ?? 'gemini-2.5-flash';
+  const resolvedModel = resolveInteractiveLaunchModel('gemini-cli', options.defaultModel)!;
   const argv: string[] = [options.binaryPath, '-m', resolvedModel, '--yolo'];
   if (options.resumeSessionId) {
     // Gemini resumes by `latest` or a numeric index. The tracked resume id is

--- a/tests/unit/TopicProfileOrchestrator.test.ts
+++ b/tests/unit/TopicProfileOrchestrator.test.ts
@@ -515,6 +515,16 @@ describe('kill-path precision', () => {
   it('a framework switch PARKS both resume stores before a FRESH kill and discloses the honest loss', async () => {
     const h = makeHarness();
     liveSession(h);
+    h.spawnImpl.fn = async () => ({
+      ok: true,
+      applied: {
+        framework: 'codex-cli',
+        model: 'gpt-5.5',
+        modelTier: null,
+        thinkingMode: null,
+        effort: null,
+      },
+    });
     await h.orch.requestProfileChange('7', { framework: 'codex-cli' }, OP);
     await waitUntil(() => h.spawns.length === 1);
     expect(h.claude.parks).toContain('7:mid-framework-switch');
@@ -522,6 +532,9 @@ describe('kill-path precision', () => {
     expect(h.kills[0].mode).toBe('fresh'); // never the resume-saving kill
     expect(
       h.disclosures.some((d) => d.text.includes("full transcript can't follow")),
+    ).toBe(true);
+    expect(
+      h.disclosures.some((d) => d.text.includes('Now driving this topic: Codex door, gpt-5.5 model.')),
     ).toBe(true);
     // Profile-triggered kill cleared the escalation marker slot.
     expect(h.escalation.cleared).toContain('7');

--- a/tests/unit/frameworkSessionLaunch.test.ts
+++ b/tests/unit/frameworkSessionLaunch.test.ts
@@ -15,6 +15,7 @@ import {
   buildInteractiveLaunch,
   buildHeadlessLaunch,
   resolveInteractiveFramework,
+  resolveInteractiveLaunchModel,
   resolveModelForFramework,
 } from '../../src/core/frameworkSessionLaunch.js';
 import { __resetCodexCapabilityCache } from '../../src/core/codexCapabilities.js';
@@ -151,6 +152,12 @@ describe('frameworkSessionLaunch.buildInteractiveLaunch', () => {
   });
 
   describe('codex-cli', () => {
+    it('reports the same concrete default model the interactive builder launches', () => {
+      expect(resolveInteractiveLaunchModel('codex-cli', undefined)).toBe('gpt-5.5');
+      expect(resolveInteractiveLaunchModel('codex-cli', 'balanced')).toBe('gpt-5.4-mini');
+      expect(resolveInteractiveLaunchModel('codex-cli', undefined, 'ollama')).toBe('llama3.2:latest');
+    });
+
     it('passes --model gpt-5.5 + --dangerously-bypass-approvals-and-sandbox by default (parity with Claude\'s --dangerously-skip-permissions)', () => {
       const spec = buildInteractiveLaunch('codex-cli', {
         binaryPath: '/usr/local/bin/codex',

--- a/tests/unit/modelTier-launchMechanisms.test.ts
+++ b/tests/unit/modelTier-launchMechanisms.test.ts
@@ -66,9 +66,13 @@ describe('§5.2(d) — Session.model seeded at interactive spawn (Int-C3 pin)', 
     const recordIdx = spawnBody.indexOf('const session: Session = {');
     expect(recordIdx, 'interactive Session record creation not found').toBeGreaterThan(-1);
     const record = spawnBody.slice(recordIdx, recordIdx + 2500);
-    // The seeding expression: resolved via resolveModelForFramework from the
-    // post-rate-limit-swap launch model — the honest-oracle contract.
-    expect(record).toMatch(/model:\s*resolveModelForFramework\(framework,\s*launchDefaultModel\)/);
+    // The seeding expression uses the shared interactive launch resolver so
+    // Codex local-provider model pins and post-rate-limit swaps are reported
+    // exactly as they were launched. Keep this assertion semantic rather than
+    // pinning the helper's internal implementation shape.
+    expect(record).toMatch(
+      /resolveInteractiveLaunchModel\(framework,\s*launchDefaultModel,\s*options\?\.codexLocalProvider\)/,
+    );
   });
 
   it('headless spawnSession seeds model from the resolved launch value', () => {

--- a/upgrades/next/topic-profile-resolved-door-model.md
+++ b/upgrades/next/topic-profile-resolved-door-model.md
@@ -1,6 +1,16 @@
 # Exact topic-profile swap confirmation
 
+## What Changed
+
 After a topic changes framework, model, or model tier, the completion message now names the exact
 door and concrete model that the replacement session actually launched. This also covers defaults:
 an unpinned Codex topic reports `Codex door, gpt-5.5 model` because that value comes from the same
 resolver used to build the Codex command, rather than from the requested profile alone.
+
+## What to Tell Your User
+
+After a topic swap, the completion message now tells you the exact door and model that started.
+
+## Summary of New Capabilities
+
+- Post-swap confirmation reports the applied framework door and concrete launch model.

--- a/upgrades/next/topic-profile-resolved-door-model.md
+++ b/upgrades/next/topic-profile-resolved-door-model.md
@@ -1,0 +1,6 @@
+# Exact topic-profile swap confirmation
+
+After a topic changes framework, model, or model tier, the completion message now names the exact
+door and concrete model that the replacement session actually launched. This also covers defaults:
+an unpinned Codex topic reports `Codex door, gpt-5.5 model` because that value comes from the same
+resolver used to build the Codex command, rather than from the requested profile alone.

--- a/upgrades/side-effects/topic-profile.md
+++ b/upgrades/side-effects/topic-profile.md
@@ -140,3 +140,18 @@ Both follow-ups are documentation precision, not behavior defects. No protection
 - Wiring integrity: `tests/unit/topic-profile-server-wiring.test.ts` (20 assertions over the composition root — construction, object-identity late-bind, real-deps-not-noops, lifecycle hooks, carrier mesh verb, the §11 conservative-canary flags, the obligation-7 bridge).
 - Canary both arms: `tests/unit/classifyProfileChange.test.ts` (canary-passed→in-flight, canary-off→resume, idle-unconfirmed→never-in-flight, cross-model/level/off↔on/codex-rollout rows).
 - Recovery ledger: `docs/specs/reports/topic-profile-BUILD-PROGRESS.local.md`.
+
+## 2026-07-16 addendum — resolved door/model confirmation
+
+Post-swap disclosure now consumes the newly spawned session's applied profile. The interactive
+launch default resolver is shared with the Codex and Gemini argv builders, so an unpinned/defaulted
+model is reported from the same decision that launched it. Successful framework, model, and tier
+respawns all emit `Now driving this topic: <Door> door, <concrete model> model.` The fallback text
+`account-default` remains only for doors whose CLI owns an opaque account default (Claude/Pi), where
+inventing a concrete identifier would be dishonest.
+
+Interaction review: the spawn port's optional `applied` result is backward-compatible with existing
+ports and tests; when absent, the orchestrator retains its prior resolved-profile behavior. The
+terminal disclosure still uses the existing audited, duplicate-bypass send path, and no new timer,
+write authority, kill decision, persistent schema, or external endpoint is introduced. Rollback is
+a code-only revert with no data repair.


### PR DESCRIPTION
## What changed

- report the exact door and concrete model after every successful topic-profile framework/model/tier respawn
- return the newly spawned session's applied profile through the orchestration port, so disclosure reflects what launched rather than what was merely requested
- share interactive default-model resolution with the Codex/Gemini argv builders; an unpinned Codex launch and its confirmation now both resolve to `gpt-5.5`
- retain the honest `account-default` label only for CLI-owned opaque defaults (Claude/Pi)

## Root cause

The terminal framework-switch disclosure rendered only `resolved.framework` before/around respawn. It neither observed the post-spawn session record nor applied the interactive builder's own default model. Successful model/tier resume swaps could also complete without any terminal applied-state confirmation.

## User impact

A completion now says, for example: `Now driving this topic: Codex door, gpt-5.5 model.` This includes unpinned defaults and covers framework, model, and tier changes.

## Validation

- unit: 132 passing (`frameworkSessionLaunch`, `TopicProfileOrchestrator`, write surface)
- integration + E2E: 25 passing (`topic-profile-routes`, `topic-profile-lifecycle`)
- full lint/typecheck: passing
- build: passing
- rebased onto current `upstream/main` after #1479 merged

## Side effects

No new endpoint, timer, write authority, persistent schema, or kill decision. The spawn outcome extension is optional for compatibility; older/test ports fall back to the pre-existing resolved profile. The Topic Profile side-effects record includes the interaction/rollback addendum.

## ELI16 — The confirmation now says what actually started

Before this fix, Instar could tell you that a topic switched to Codex without saying which model Codex actually started with. That was especially confusing when you had not pinned a model yourself, because the launch command quietly chose its safe default. The completion message now reads the newly created session and names both pieces plainly—for example, “Codex door, gpt-5.5 model.” The same completion path covers framework, model, and model-tier changes. When a tool owns a private account default that Instar cannot inspect, the message says account-default instead of making up a model name.