### PR TITLE
fix(topic-profile): deliver Codex continuation before handoff

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-16T20-43-00-000Z-codex-framework-continuation-history.json
+++ b/.instar/instar-dev-decisions/2026-07-16T20-43-00-000Z-codex-framework-continuation-history.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-07-16T20:43:00.000Z",
+  "slug": "codex-framework-continuation-history",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "session lifecycle surface: framework handoff blocks registration until bootstrap injection",
+    "cross-framework continuity: changes interactive readiness recognition"
+  ],
+  "belowFloor": false,
+  "files": 8,
+  "loc": 100,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The continuation payload was constructed correctly, but readiness detection accepted only Claude UI markers. Codex therefore received the payload after a roughly 105-second timeout, allowing a live user message and a synthetic handoff turn to run first without the prior conversation."
+  },
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -935,9 +935,10 @@ async function spawnSessionForTopic(
   /** Reap-notify spec R2.8 / L13 — explicit per-spawn working directory (the
    *  resume-queue drainer passes a queue entry's recorded cwd so interrupted
    *  worktree work resumes in ITS tree). Omitted = module project dir. */
-  spawnOpts?: { cwd?: string },
+  spawnOpts?: { cwd?: string; awaitInitialInjection?: boolean },
 ): Promise<string> {
-  const msg = latestMessage || 'Session started — send a message to continue.';
+  const hasLatestMessage = typeof latestMessage === 'string' && latestMessage.length > 0;
+  const msg = hasLatestMessage ? latestMessage : 'Session started — send a message to continue.';
 
   // If memory is elevated/critical and we have the reaper, try to free memory
   // by cleaning orphans before spawning. Interactive sessions are NEVER blocked
@@ -1090,14 +1091,19 @@ async function spawnSessionForTopic(
       parts.push(``);
     }
 
-    parts.push(
-      inlineContext,
-      ``,
-      `IMPORTANT: Your response MUST acknowledge and continue the conversation above. Do NOT introduce yourself or ask "how can I help" — the user has been talking to you. Pick up where the conversation left off.`,
-      ``,
-      `The user's latest message:`,
-      `[telegram:${topicId}] ${msg}`,
-    );
+    parts.push(inlineContext, ``);
+    if (hasLatestMessage) {
+      parts.push(
+        `IMPORTANT: Your response MUST acknowledge and continue the conversation above. Do NOT introduce yourself or ask "how can I help" — the user has been talking to you. Pick up where the conversation left off.`,
+        ``,
+        `The user's latest message:`,
+        `[telegram:${topicId}] ${msg}`,
+      );
+    } else {
+      parts.push(
+        `HANDOFF ONLY: No new user message accompanies this framework switch. Load the context above, do not narrate or re-scope it, and wait silently for the next user message.`,
+      );
+    }
 
     bootstrapMessage = parts.join('\n');
   } else {
@@ -1236,6 +1242,7 @@ async function spawnSessionForTopic(
     ...(accountSwap?.accountId ? { subscriptionAccountId: accountSwap.accountId } : {}),
     // R2.8/L13: per-spawn cwd from the resume-queue entry. Unset = projectDir.
     ...(spawnOpts?.cwd ? { cwd: spawnOpts.cwd } : {}),
+    ...(spawnOpts?.awaitInitialInjection ? { awaitInitialInjection: true } : {}),
   });
 
   // Clear the resume entry after successful spawn to prevent stale reuse
@@ -1311,7 +1318,7 @@ async function respawnSessionForTopic(
   topicMemory?: TopicMemory,
   userProfile?: UserProfile,
   recoveryPrompt?: string,
-  options?: { silent?: boolean; configHome?: string; accountId?: string },
+  options?: { silent?: boolean; configHome?: string; accountId?: string; awaitInitialInjection?: boolean },
 ): Promise<void> {
   console.log(`[telegram→session] Session "${targetSession}" needs respawn for topic ${topicId}`);
 
@@ -1359,8 +1366,18 @@ async function respawnSessionForTopic(
     ? `${recoveryPrompt}\n\n${latestMessage || 'Session recovered — continue where you left off.'}`
     : latestMessage;
 
-  const newSessionName = await spawnSessionForTopic(sessionManager, telegram, topicName, topicId, effectiveMessage, topicMemory, userProfile, undefined,
-    (options?.configHome || options?.accountId) ? { configHome: options?.configHome, accountId: options?.accountId } : undefined);
+  const newSessionName = await spawnSessionForTopic(
+    sessionManager,
+    telegram,
+    topicName,
+    topicId,
+    effectiveMessage,
+    topicMemory,
+    userProfile,
+    undefined,
+    (options?.configHome || options?.accountId) ? { configHome: options?.configHome, accountId: options?.accountId } : undefined,
+    options?.awaitInitialInjection ? { awaitInitialInjection: true } : undefined,
+  );
 
   telegram.registerTopicSession(topicId, newSessionName, topicName);
   if (!options?.silent) {
@@ -1639,7 +1656,7 @@ function wireTelegramCallbacks(
     try {
       await respawnSessionForTopic(
         sessionManager, telegram, existingSession, topicId, undefined,
-        topicMemory, undefined, undefined, { silent: true },
+        topicMemory, undefined, undefined, { silent: true, awaitInitialInjection: true },
       );
       return { respawned: true };
     } catch (err) {
@@ -23302,7 +23319,18 @@ export async function startServer(options: StartOptions): Promise<void> {
               const topicName = telegram.getTopicName(n) || `topic-${n}`;
               _orchestratorSpawnInFlight.add(topicKey);
               try {
-                await spawnSessionForTopic(sessionManager, telegram, topicName, n, undefined, topicMemory);
+                await spawnSessionForTopic(
+                  sessionManager,
+                  telegram,
+                  topicName,
+                  n,
+                  undefined,
+                  topicMemory,
+                  undefined,
+                  undefined,
+                  undefined,
+                  { awaitInitialInjection: true },
+                );
                 return { ok: true };
               } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -4331,6 +4331,10 @@ rm()  { "${shimRunner}" rm  "$@"; }
      *  tree, not the module-level project dir. Unset = projectDir (today's
      *  behavior, byte-for-byte). */
     cwd?: string;
+    /** Do not return control to the bridge until the initial bootstrap has
+     * actually been injected. Used for framework handoffs so a newly mapped
+     * session cannot receive a user turn before its continuation context. */
+    awaitInitialInjection?: boolean;
   }): Promise<string> {
     const sanitized = name
       ? name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').slice(0, 40)
@@ -4646,7 +4650,10 @@ rm()  { "${shimRunner}" rm  "$@"; }
         initialMessage: effectiveInitialMessage,
         telegramTopicId: options?.telegramTopicId,
       });
-      this.handleReadyAndInject(tmuxSession, name, effectiveInitialMessage, readyTimeout, options).catch((err) => {
+      const injection = this.handleReadyAndInject(tmuxSession, name, effectiveInitialMessage, readyTimeout, options);
+      if (options?.awaitInitialInjection) {
+        await injection;
+      } else injection.catch((err) => {
         console.error(`[SessionManager] Error during ready-and-inject for "${tmuxSession}": ${err}`);
       });
     }
@@ -5776,8 +5783,9 @@ rm()  { "${shimRunner}" rm  "$@"; }
     // blank lines or separators push them around.
     const tail = lines.slice(-6).join('\n');
 
-    // Primary: the prompt character
-    if (tail.includes('❯')) return true;
+    // Primary: framework prompt characters. Codex uses ›; keeping this probe
+    // Claude-only delayed its continuation bootstrap until the 105s timeout.
+    if (tail.includes('❯') || tail.includes('›')) return true;
 
     // Secondary: permission mode indicators (visible in status bar)
     if (tail.includes('bypass permissions')) return true;

--- a/tests/unit/session-manager-pending-inject-wiring.test.ts
+++ b/tests/unit/session-manager-pending-inject-wiring.test.ts
@@ -119,6 +119,33 @@ describe('SessionManager pending-inject wiring (finding 8d300555)', () => {
     }, { timeout: 5000 });
   });
 
+  it('framework handoff waits for bootstrap injection before returning the new session', async () => {
+    let resolveReady!: (v: boolean) => void;
+    const readyGate = new Promise<boolean>((r) => { resolveReady = r; });
+    vi.spyOn(manager as unknown as { waitForClaudeReadyWithRetry(s: string, t: number): Promise<boolean> }, 'waitForClaudeReadyWithRetry')
+      .mockImplementation(() => readyGate);
+    const injectSpy = vi.spyOn(manager as unknown as { injectMessage(s: string, m: string): void }, 'injectMessage')
+      .mockImplementation(() => undefined);
+
+    let returned = false;
+    const spawning = manager.spawnInteractiveSession('CONTINUATION — prior turn', 'handoff-test', {
+      telegramTopicId: 2271,
+      framework: 'codex-cli',
+      awaitInitialInjection: true,
+    }).then((name) => { returned = true; return name; });
+
+    await vi.waitFor(() => expect(pendingFiles()).toHaveLength(1));
+    expect(returned).toBe(false);
+    resolveReady(true);
+    await spawning;
+    expect(injectSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      'CONTINUATION — prior turn',
+      { firstParty: { source: 'session-bootstrap' } },
+    );
+    expect(returned).toBe(true);
+  });
+
   it('recoverPendingInjects re-delivers into a still-alive session through the readiness path', async () => {
     // Simulate the incident: a record left by the PREVIOUS server process,
     // whose tmux session is still alive.

--- a/tests/unit/session-reap-detect.test.ts
+++ b/tests/unit/session-reap-detect.test.ts
@@ -175,11 +175,12 @@ describe('Session reaping and detection', () => {
       expect(source).toContain('waitForClaudeReady');
     });
 
-    it('waitForClaudeReady checks for Claude-specific prompt character only', () => {
+    it('waitForClaudeReady recognizes Claude and Codex interactive prompt characters', () => {
       source = fs.readFileSync(SOURCE_PATH, 'utf-8');
       // Should ONLY check for Claude Code's specific prompt character (❯)
       // NOT generic shell prompts (> or $) which cause false positives
       expect(source).toContain("'❯'");
+      expect(source).toContain("'›'");
       // Verify it does NOT match generic shell prompts
       const readySection = source.match(/waitForClaudeReady[\s\S]*?return false;\s*\}/);
       expect(readySection).toBeTruthy();

--- a/tests/unit/topic-profile-server-wiring.test.ts
+++ b/tests/unit/topic-profile-server-wiring.test.ts
@@ -65,7 +65,8 @@ describe('server-boot wiring: Topic Profile orchestrator + carrier (TOPIC-PROFIL
     });
 
     it('spawn port drives the real spawnSessionForTopic (not a stub)', () => {
-      expect(depsBlock()).toContain('await spawnSessionForTopic(sessionManager, telegram');
+      expect(depsBlock()).toMatch(/await spawnSessionForTopic\([\s\S]*?sessionManager,[\s\S]*?telegram,/);
+      expect(depsBlock()).toContain('{ awaitInitialInjection: true }');
     });
 
     it('claudeResume + killFresh delegate to the real resume map', () => {

--- a/tests/unit/topic-profile-server-wiring.test.ts
+++ b/tests/unit/topic-profile-server-wiring.test.ts
@@ -69,6 +69,14 @@ describe('server-boot wiring: Topic Profile orchestrator + carrier (TOPIC-PROFIL
       expect(depsBlock()).toContain('{ awaitInitialInjection: true }');
     });
 
+    it('a history-only framework handoff waits silently instead of fabricating a latest message', () => {
+      expect(src).toContain('if (hasLatestMessage)');
+      expect(src).toContain('HANDOFF ONLY: No new user message accompanies this framework switch.');
+      const handoffBranch = src.match(/else \{\s*parts\.push\(\s*`HANDOFF ONLY:[\s\S]*?\);\s*\}/)?.[0];
+      expect(handoffBranch).toBeTruthy();
+      expect(handoffBranch).not.toContain("The user's latest message:");
+    });
+
     it('claudeResume + killFresh delegate to the real resume map', () => {
       expect(depsBlock()).toContain('_topicResumeMap?.getProvenance(n) === \'hook\'');
       expect(depsBlock()).toContain('_topicResumeMap?.remove(Number(topic))');

--- a/upgrades/next/codex-framework-continuation-history.md
+++ b/upgrades/next/codex-framework-continuation-history.md
@@ -1,0 +1,17 @@
+# Codex framework-switch continuation
+
+## What Changed
+
+Framework switches into Codex now recognize the Codex prompt promptly and wait until the continuation
+bootstrap is injected before handing the new session back to the messaging bridge. A switch with no
+new user message loads its history silently instead of inventing a new scope response.
+
+## What to Tell Your User
+
+Switching a live topic from Claude to Codex now carries the recent conversation before Codex can
+answer the next message.
+
+## Summary of New Capabilities
+
+- Framework-aware interactive readiness recognizes both Claude and Codex prompts.
+- Framework handoffs can require bootstrap delivery before session registration completes.

--- a/upgrades/side-effects/codex-framework-continuation-history.md
+++ b/upgrades/side-effects/codex-framework-continuation-history.md
@@ -1,0 +1,26 @@
+# Side-Effects Review — Codex framework-switch continuation
+
+**Date:** 2026-07-16  
+**Author:** instar-codey  
+**Second-pass reviewer:** pending Echo PR review
+
+## Summary
+
+The existing continuation context was correct, but interactive readiness recognized only Claude's
+prompt. Codex therefore waited through the primary and extended readiness timeouts before the
+best-effort injection, while the bridge could already route a new user message to that context-free
+session. The fix recognizes Codex's prompt and makes framework handoffs await the durable bootstrap
+injection before returning. A handoff with no new user message now explicitly loads context silently,
+which also removes the trigger for the observed unsolicited scope narration.
+
+## Interaction review
+
+- Normal cold spawns keep their asynchronous durable pending-inject behavior; only framework handoffs
+  opt into the await.
+- The pending-inject record is still written before readiness and cleared only after injection.
+- Claude readiness remains unchanged; generic shell prompts are still excluded.
+- No endpoint, schema, authority, timer, or history source changes.
+
+## Rollback
+
+Code-only revert. Pending-inject records remain compatible and require no repair.


### PR DESCRIPTION
## What changed

- recognize the Codex `›` composer as an interactive-ready signal instead of waiting through the Claude-only 105-second timeout
- make topic-profile framework handoffs await the durable initial bootstrap injection before the bridge registers/returns the replacement session
- when a handoff has history but no new user message, load it silently rather than asking the new Codex session to generate a synthetic response

## Root cause

The continuation payload and history source were already correct. `SessionManager.waitForClaudeReady` only recognized Claude UI markers, so a Codex receiver could not become ready until the primary plus extended timeout expired. Meanwhile the replacement session was returned and mapped immediately, allowing the operator's next message to arrive before the continuation bootstrap. The later synthetic bootstrap turn also explains the unsolicited scope narration.

## ELI16 — Codex now reads the conversation before it answers

When a topic switched from Claude to Codex, Instar prepared the recent conversation correctly but waited for a Claude-shaped prompt that Codex never displays. Codex could therefore answer your next message before receiving that history. Instar now recognizes Codex's own prompt and does not finish the handoff until the history has actually been delivered. If there is no new user message yet, the new session loads the context quietly and waits instead of inventing a task update.

## Validation

- focused unit/wiring: 46 passing
- broader unit/integration/E2E continuation and framework dispatch suite: green
- full lint/typecheck: passing
- build: passing
- repository invariants: passing

## Side effects

Normal cold spawns keep their asynchronous durable pending-inject behavior. Only framework handoffs opt into waiting. No endpoint, schema, timer, authority, or history-source change.
