### PR TITLE
test(view): harden PIN leak fixture

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-17T00-28-00-000Z-pool-view-pin-fixture.json
+++ b/.instar/instar-dev-decisions/2026-07-17T00-28-00-000Z-pool-view-pin-fixture.json
@@ -1,0 +1,19 @@
+{
+  "slug": "pool-view-pin-fixture",
+  "title": "Use a high-entropy pool-view PIN fixture",
+  "date": "2026-07-17",
+  "tier": 1,
+  "tierReasoning": "Test-only fixture hardening with no runtime behavior change.",
+  "decision": "Replace the common literal 1234 with one deterministic high-entropy constant used by both setup and the no-leak assertion.",
+  "causalAutopsy": {
+    "trigger": "The negative substring assertion used a common four-character value.",
+    "rootCause": "The fixture optimized for readability rather than collision resistance in a serialized envelope.",
+    "failureMode": "Unrelated serialized values containing 1234 could cause a false failure, while the assertion did not uniquely identify the test credential.",
+    "repair": "Use a distinctive deterministic PIN fixture and assert against that exact value."
+  },
+  "alternatives": [
+    "Keep 1234 and accept collision risk",
+    "Generate a random PIN per run, reducing failure reproducibility"
+  ],
+  "spec": "docs/specs/MULTI-MACHINE-SEAMLESSNESS-SPEC.md"
+}

--- a/tests/integration/pool-view-link-proxy.test.ts
+++ b/tests/integration/pool-view-link-proxy.test.ts
@@ -40,6 +40,7 @@ import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 const FRONTING = 'm_fronting';
 const HOLDER = 'm_holder';
 const AUTH = 'test-token';
+const VIEW_PIN = 'view-pin-8f4d2c9a7e6b1d35';
 
 interface Server { url: string; close: () => Promise<void>; }
 async function listen(app: express.Express): Promise<Server> {
@@ -74,7 +75,7 @@ describe('WS4.4 pool-view link proxy (§WS4.4 a–e)', () => {
     holderViewer = new PrivateViewer({ viewsDir: path.join(dir, 'holder-views') });
     const view = holderViewer.create('Secret Report', '# Top secret\nholder-only body');
     viewId = view.id;
-    const pinView = holderViewer.create('Pin Report', '# pin gated', '1234');
+    const pinView = holderViewer.create('Pin Report', '# pin gated', VIEW_PIN);
     pinViewId = pinView.id;
 
     jtiStore = new PoolLinkJtiStore({ filePath: path.join(dir, 'pool-link-jtis.json'), now: () => Date.now() });
@@ -289,7 +290,7 @@ describe('WS4.4 pool-view link proxy (§WS4.4 a–e)', () => {
       expect(capturedEnvelope.command.assertion.signature).toBeTruthy();
       // …and NOTHING resembling a raw PIN / dashboard token / view PIN.
       expect(serialized).not.toContain(AUTH); // the fronting authToken (PIN-session credential) never crosses
-      expect(serialized).not.toContain('1234'); // a view PIN never crosses
+      expect(serialized).not.toContain(VIEW_PIN); // the high-entropy view PIN never crosses
       expect(serialized).not.toMatch(/"pin"\s*:/i);
       expect(serialized).not.toMatch(/"password"\s*:/i);
     } finally {

--- a/upgrades/eli16/pool-view-pin-fixture.md
+++ b/upgrades/eli16/pool-view-pin-fixture.md
@@ -1,0 +1,3 @@
+# ELI16
+
+The security test used to search for a very common four-digit pattern. It now searches for a distinctive secret-shaped test value, so finding it really means the PIN leaked.

--- a/upgrades/next/pool-view-pin-fixture.md
+++ b/upgrades/next/pool-view-pin-fixture.md
@@ -10,7 +10,7 @@ The focused eight-test pool-view proxy integration suite passes.
 
 ## What to Tell Your User
 
-The test can no longer pass or fail accidentally because an unrelated value happens to contain the common sequence `1234`.
+The test can no longer pass or fail accidentally because an unrelated value happens to contain the common sequence 1234.
 
 ## Summary of New Capabilities
 

--- a/upgrades/next/pool-view-pin-fixture.md
+++ b/upgrades/next/pool-view-pin-fixture.md
@@ -1,0 +1,17 @@
+# Pool-view PIN leak fixture hardening
+
+## What Changed
+
+The pool-view proxy security test now uses a distinctive high-entropy PIN fixture instead of the short string `1234`.
+
+## Evidence
+
+The focused eight-test pool-view proxy integration suite passes.
+
+## What to Tell Your User
+
+The test can no longer pass or fail accidentally because an unrelated value happens to contain the common sequence `1234`.
+
+## Summary of New Capabilities
+
+No runtime capability changes; this makes the existing raw-PIN boundary proof more precise.

--- a/upgrades/side-effects/pool-view-pin-fixture.md
+++ b/upgrades/side-effects/pool-view-pin-fixture.md
@@ -1,0 +1,7 @@
+# Side-effects review
+
+- Runtime behavior is unchanged; only an integration-test fixture and its matching assertion changed.
+- The PIN remains deterministic so failures are reproducible.
+- The higher-entropy value sharply reduces accidental substring collisions in serialized envelopes.
+- The PIN-gated view coverage continues to use the same fixture through the shared constant.
+- Second pass: focused suite green; no additional seams identified.


### PR DESCRIPTION
## Summary

Hardens the pool-view proxy raw-PIN boundary test by replacing the common literal `1234` with one deterministic, high-entropy fixture constant shared by setup and assertion.

This removes a brittle substring collision: an unrelated serialized value containing `1234` could previously fail the security test even when no PIN crossed the wire. Runtime behavior is unchanged.

## ELI16 — Make the leak detector look for the actual test secret

The security test checks that a private-view PIN never crosses from one machine to another. It used to search the serialized message for `1234`, but those four digits are common and could appear in unrelated IDs or data. The test now creates one distinctive, secret-shaped PIN and searches for that exact same value. If the assertion fails, it points to the credential itself instead of an accidental four-digit overlap. The application code and real PIN handling do not change; this only makes the existing boundary proof more trustworthy and reproducible.

## Evidence

- Focused `pool-view-link-proxy` integration suite: 8/8 passed.
- Diff and whitespace checks passed.
- Tier 1: test-only fixture hardening; no runtime path changes.

## Artifacts

- `upgrades/next/pool-view-pin-fixture.md`
- `upgrades/eli16/pool-view-pin-fixture.md`
- `upgrades/side-effects/pool-view-pin-fixture.md`
- `.instar/instar-dev-decisions/2026-07-17T00-28-00-000Z-pool-view-pin-fixture.json`

Ready for review. Auto-merge is intentionally not armed.