### PR TITLE
fix(monitoring): weight token burn by fresh cost

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-17T00-41-00-000Z-token-burn-fresh-cost.json
+++ b/.instar/instar-dev-decisions/2026-07-17T00-41-00-000Z-token-burn-fresh-cost.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-17T00:41:00.000Z",
+  "slug": "token-burn-fresh-cost",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "changes the signal that feeds an automatic token-burn throttle runbook",
+    "changes rolling share and rate calculations across all attribution keys"
+  ],
+  "belowFloor": false,
+  "files": 8,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The ledger correctly retained cache-read usage for observability, but BurnDetector reused the gross total for cost-shaped shares and rates. That collapsed cheap warm-cache reuse into fresh spend and could mis-rank sessions. The repair preserves gross totals and adds a separate fresh-cost aggregation consumed only by burn decisions."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/token-burn-detection-and-self-heal.md
+++ b/docs/specs/token-burn-detection-and-self-heal.md
@@ -132,7 +132,10 @@ The column is populated on the write side by the `IntelligenceProvider` chokepoi
 
 ### Threshold logic
 
-Two trigger conditions, OR'd:
+Two trigger conditions, OR'd. Both use **fresh-cost tokens**: gross ledger
+tokens minus cache-read tokens. Cache creation remains cost-bearing; warm-cache
+reads remain visible in gross observability but can never increase a key's burn
+share, current rate, baseline, or projected daily burn.
 
 1. **Absolute share**: a single attribution key consumed > 25% of the agent's total token spend in the last 24h.
 2. **Rolling baseline divergence**: the key's last-1h rate is > 2× its trailing-7-day median rate, AND the 1h rate exceeds a floor of 10M tokens/h (avoid alerting on tiny absolute spend even if relatively spiked).

--- a/src/monitoring/BurnDetector.ts
+++ b/src/monitoring/BurnDetector.ts
@@ -1,6 +1,7 @@
 /**
  * BurnDetector — emits a structured signal when a single attribution_key
- * crosses configured spend thresholds.
+ * crosses configured fresh-cost thresholds. Cache reads remain visible in the
+ * ledger's gross totals but never increase burn share or rate.
  *
  * Phase 3 of docs/specs/token-burn-detection-and-self-heal.md.
  *
@@ -28,6 +29,11 @@
 import type { TokenLedger, AttributionKeyRow } from './TokenLedger.js';
 import type { DegradationReporter } from './DegradationReporter.js';
 import { PRE_ATTRIBUTION_KEY } from './AttributionResolver.js';
+
+/** Backward-compatible for test doubles and older ledger adapters. */
+function burnTokens(row: AttributionKeyRow): number {
+  return row.freshTokens ?? row.totalTokens;
+}
 
 export interface BurnDetectionConfig {
   enabled: boolean;
@@ -156,7 +162,7 @@ export class BurnDetector {
 
     const keys24h = this.ledger.byAttributionKey({ sinceMs: since24h });
     if (keys24h.length === 0) return [];
-    const total24h = keys24h.reduce((sum, k) => sum + k.totalTokens, 0);
+    const total24h = keys24h.reduce((sum, k) => sum + burnTokens(k), 0);
     if (total24h <= 0) return [];
 
     // Update first-seen map.
@@ -171,9 +177,10 @@ export class BurnDetector {
     const keys1hMap = new Map(keys1h.map((k) => [k.attributionKey, k]));
 
     for (const key24h of keys24h) {
-      const share = key24h.totalTokens / total24h;
+      const tokens24h = burnTokens(key24h);
+      const share = tokens24h / total24h;
       const key1h = keys1hMap.get(key24h.attributionKey);
-      const tokens1h = key1h ? key1h.totalTokens : 0;
+      const tokens1h = key1h ? burnTokens(key1h) : 0;
       const projectedDaily = tokens1h * 24;
 
       // Skip exempt runbook self-attribution prefix (defence in depth — Phase 4
@@ -229,7 +236,7 @@ export class BurnDetector {
           const keys7d = this.ledger.byAttributionKey({ sinceMs: since7d });
           const key7d = keys7d.find((k) => k.attributionKey === key24h.attributionKey);
           if (key7d) {
-            baselineMedian7d = key7d.totalTokens / (7 * 24);
+            baselineMedian7d = burnTokens(key7d) / (7 * 24);
             if (tokens1h > this.config.rollingBaselineMultiplier * baselineMedian7d) {
               trigger = 'baseline-divergence';
             }
@@ -244,7 +251,7 @@ export class BurnDetector {
         trigger,
         emittedAt: new Date(now).toISOString(),
         observed: {
-          tokens24h: key24h.totalTokens,
+          tokens24h,
           share24h: share,
           tokensLast1h: tokens1h,
           projectedDaily,

--- a/src/monitoring/BurnVerifier.ts
+++ b/src/monitoring/BurnVerifier.ts
@@ -101,7 +101,7 @@ export class BurnVerifier {
     const sinceMs = this.now() - this.sampleWindowMs;
     const rows = this.ledger.byAttributionKey({ sinceMs });
     const row = rows.find((r) => r.attributionKey === attributionKey);
-    const postThrottleTokens = row ? row.totalTokens : 0;
+    const postThrottleTokens = row ? (row.freshTokens ?? row.totalTokens) : 0;
     const postThrottleRate = postThrottleTokens * (60 * 60 * 1000 / this.sampleWindowMs);
     const ratio = preThrottleRate > 0 ? postThrottleRate / preThrottleRate : 0;
     const successfullyThrottled = ratio < this.successRatio;

--- a/src/monitoring/TokenLedger.ts
+++ b/src/monitoring/TokenLedger.ts
@@ -185,7 +185,10 @@ export interface ProjectRow {
 
 export interface AttributionKeyRow {
   attributionKey: string;
+  /** Gross usage retained for observability, including cache-read tokens. */
   totalTokens: number;
+  /** Cost-weighted burn input: gross usage minus cache-read tokens. */
+  freshTokens?: number;
   eventCount: number;
   firstTs: number;
   lastTs: number;
@@ -1195,6 +1198,7 @@ export class TokenLedger {
         `SELECT
            attribution_key AS attributionKey,
            SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens) AS totalTokens,
+           SUM(input_tokens + output_tokens + cache_creation_tokens) AS freshTokens,
            COUNT(*) AS eventCount,
            MIN(ts) AS firstTs,
            MAX(ts) AS lastTs
@@ -1208,6 +1212,7 @@ export class TokenLedger {
     return rows.map(r => ({
       attributionKey: r.attributionKey,
       totalTokens: Number(r.totalTokens) || 0,
+      freshTokens: Number(r.freshTokens) || 0,
       eventCount: Number(r.eventCount) || 0,
       firstTs: Number(r.firstTs) || 0,
       lastTs: Number(r.lastTs) || 0,

--- a/tests/unit/burn-detection-phase-3.test.ts
+++ b/tests/unit/burn-detection-phase-3.test.ts
@@ -60,6 +60,23 @@ function stubReporter() {
 }
 
 describe('BurnDetector — absolute-share trigger', () => {
+  it('never lets cache reads inflate a key burn share', () => {
+    const ledger = stubLedger([
+      { attributionKey: 'warm-cache', totalTokens: 1_010, freshTokens: 10, eventCount: 1, firstTs: 0, lastTs: 0 },
+      { attributionKey: 'fresh-work', totalTokens: 100, freshTokens: 100, eventCount: 1, firstTs: 0, lastTs: 0 },
+    ]);
+    const detector = new BurnDetector({
+      ledger,
+      reporter: stubReporter(),
+      config: { absoluteShareThreshold: 0.5, coldStartMs: Number.MAX_SAFE_INTEGER },
+      now: () => 1_000_000_000_000,
+    });
+
+    const signals = detector.tick();
+    expect(signals.map((signal) => signal.attributionKey)).toEqual(['fresh-work']);
+    expect(signals[0].observed.share24h).toBeCloseTo(100 / 110);
+  });
+
   it('fires when a single key crosses 25% threshold (the 2026-05-15 case)', () => {
     const ledger = stubLedger([
       { attributionKey: 'InputDetector::abcd1234', totalTokens: 3_000_000_000, eventCount: 100_000, firstTs: 0, lastTs: 0 },
@@ -426,9 +443,24 @@ describe('TokenLedger.byAttributionKey query (Phase 3 wiring)', () => {
     expect(rows).toHaveLength(2);
     const top = rows.find((r) => r.attributionKey === 'InputDetector::aaa')!;
     expect(top.totalTokens).toBe(225);
+    expect(top.freshTokens).toBe(225);
     expect(top.eventCount).toBe(2);
     expect(top.firstTs).toBe(1000);
     expect(top.lastTs).toBe(2000);
+    SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/burn-detection-phase-3.test.ts' });
+  });
+
+  it('reports gross usage but excludes cache reads from fresh burn tokens', () => {
+    const ledger = new TokenLedger({ dbPath, claudeProjectsDir: tmp });
+    ledger.recordEvent({
+      requestId: 'cached', sessionId: 's', ts: 1000,
+      inputTokens: 10, outputTokens: 5, cacheCreationTokens: 20, cacheReadTokens: 10_000,
+      attributionKey: 'warm-cache',
+    });
+
+    const row = ledger.byAttributionKey({ sinceMs: 0 })[0];
+    expect(row.totalTokens).toBe(10_035);
+    expect(row.freshTokens).toBe(35);
     SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/burn-detection-phase-3.test.ts' });
   });
 

--- a/tests/unit/burn-detection-phase-6.test.ts
+++ b/tests/unit/burn-detection-phase-6.test.ts
@@ -74,6 +74,21 @@ describe('BurnVerifier — verification cycle', () => {
     return { byAttributionKey: () => byKeyRows };
   }
 
+  it('cache reads never inflate the post-throttle burn rate', () => {
+    const verifier = new BurnVerifier({
+      ledger: fakeLedger([
+        { attributionKey: 'Warm::cache', totalTokens: 10_416_666, freshTokens: 416_666, eventCount: 50, firstTs: 0, lastTs: 0 },
+      ]) as any,
+      sendTelegram: (_, m) => messages.push(m),
+      now: () => now,
+      schedule: (cb, delay) => scheduled.push({ cb, delay }),
+    });
+
+    const result = verifier.runVerification('Warm::cache', 50_000_000);
+    expect(result.postThrottleRate).toBeCloseTo(4_999_992);
+    expect(result.successfullyThrottled).toBe(true);
+  });
+
   it('successful throttle: post-rate dropped → caught-and-contained message', () => {
     const verifier = new BurnVerifier({
       ledger: fakeLedger([

--- a/upgrades/eli16/token-burn-fresh-cost.md
+++ b/upgrades/eli16/token-burn-fresh-cost.md
@@ -1,0 +1,3 @@
+# ELI16
+
+Reading from a warm cache can involve many tokens while costing very little. Those reused tokens used to make a session look like a major spender. The detector now keeps them in usage reports but leaves them out of burn alerts, so the alarm follows fresh work instead of cheap reuse.

--- a/upgrades/next/token-burn-fresh-cost.md
+++ b/upgrades/next/token-burn-fresh-cost.md
@@ -1,0 +1,17 @@
+# Fresh-cost token-burn detection
+
+## What Changed
+
+Token-burn shares and rates now exclude cache-read tokens while retaining gross usage in the token ledger.
+
+## Evidence
+
+The detector, ledger, attribution, and verification suites pass 66 focused tests. The build also passes.
+
+## What to Tell Your User
+
+Warm-cache sessions no longer look expensive merely because they reuse a large cached prompt. Burn alerts now track the token work that carries meaningful fresh cost.
+
+## Summary of New Capabilities
+
+Burn share, recent rate, baseline comparison, and projected daily burn all use fresh-cost tokens. Cache creation remains counted because it is cost-bearing.

--- a/upgrades/side-effects/token-burn-fresh-cost.md
+++ b/upgrades/side-effects/token-burn-fresh-cost.md
@@ -1,0 +1,9 @@
+# Side-effects review
+
+- Gross token totals remain unchanged for dashboards and general observability.
+- The attribution query adds a separate fresh-cost total equal to gross usage minus cache reads.
+- Existing test doubles remain compatible by falling back to gross totals when the new field is absent.
+- Cache creation and output tokens still count toward burn because they carry fresh cost.
+- Burn alert payload field names remain stable, but their values now represent fresh-cost tokens.
+- BurnVerifier consumes the same attribution rows; its post-throttle comparison therefore measures fresh cost too.
+- Second pass: the invariant is pinned at both the real ledger query and detector decision boundary.


### PR DESCRIPTION
## Summary

Fixes item G: token-burn shares and rates were computed from the ledger's gross total, including cache-read tokens. Warm-cache sessions could therefore dominate burn attribution even though those reused tokens cost almost nothing fresh.

The ledger now retains its existing gross `totalTokens` for observability and exposes a separate `freshTokens` aggregation equal to gross usage minus cache reads. BurnDetector uses fresh cost for the 24-hour denominator, per-key share, last-hour activity, seven-day baseline, and daily projection. BurnVerifier uses the same measure for the post-throttle comparison.

Review invariant: **a cached read must never inflate a session's burn share.**

## ELI16 — Make the spending alarm follow fresh work, not cheap cache reuse

A session can read a very large prompt from a warm cache while paying only a small fraction of the fresh-input cost. The old alarm counted every cached token as if it were newly processed, so an efficient cached session could look like the machine's biggest spender and trigger the wrong slowdown. The ledger still reports those cached tokens so usage remains honest, but the burn detector now subtracts cache reads before calculating shares and rates. Cache creation and generated output still count because they carry real fresh cost. The same fresh-cost measure is used afterward to verify whether a slowdown actually worked.

## Evidence

- 67/67 focused tests passed across detector, verifier, attribution wiring, and token ledger.
- Build passed.
- A real-ledger fixture proves gross 10,035 tokens with 10,000 cached reads yields 35 fresh burn tokens.
- A detector fixture proves a warm-cache key cannot gain burn share from cached reads.
- A verifier fixture proves cached reads cannot inflate the post-throttle rate.

## Scope and compatibility

- Gross ledger totals and general dashboards are unchanged.
- `freshTokens` is additive on attribution rows.
- Existing test doubles and older adapters fall back to `totalTokens` when the additive field is absent.
- Burn alert payload field names remain stable; their values now consistently mean fresh-cost tokens.

## Artifacts

- `docs/specs/token-burn-detection-and-self-heal.md`
- `upgrades/next/token-burn-fresh-cost.md`
- `upgrades/eli16/token-burn-fresh-cost.md`
- `upgrades/side-effects/token-burn-fresh-cost.md`
- `.instar/instar-dev-decisions/2026-07-17T00-41-00-000Z-token-burn-fresh-cost.json`

Ready for line-by-line review. Auto-merge is intentionally not armed.
