### PR TITLE
fix(telegram): dedupe local message ingest

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-17T00-56-00-000Z-telegram-local-ingest-dedup.json
+++ b/.instar/instar-dev-decisions/2026-07-17T00-56-00-000Z-telegram-local-ingest-dedup.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-17T00:56:00.000Z",
+  "slug": "telegram-local-ingest-dedup",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "changes canonical conversation-history admission",
+    "suppresses downstream callbacks for duplicate platform events"
+  ],
+  "belowFloor": false,
+  "files": 9,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Telegram polling and cross-machine delivery had retry identity, but the local JSONL append accepted every invocation. The same platform event could therefore create two canonical rows before any owner receipt gate ran. The repair makes the append itself idempotent and seeds identity from the canonical log across restart."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/telegram-local-ingest-dedup.md
+++ b/docs/specs/telegram-local-ingest-dedup.md
@@ -1,0 +1,28 @@
+---
+title: Telegram Local Ingest Deduplication
+status: approved
+date: 2026-07-16
+parent_principle: durable-conversation-identity
+---
+
+# Telegram Local Ingest Deduplication
+
+## Scope
+
+This is the local single-machine message-log axis. It is distinct from remote owner delivery and cross-machine receipt deduplication.
+
+## Invariant
+
+One Telegram platform event produces at most one canonical local message-log row and one downstream message-logged notification. The identity key is direction, topic, and Telegram message ID. Repeated processing of the same event, including processing after an adapter restart, is a no-op at the append seam.
+
+## Settlement order
+
+The canonical JSONL append happens before the identity is remembered in memory. A failed append remains retryable. After a successful append, the tail cache, content version, TopicMemory callback, and event bus advance exactly once.
+
+## Restart and redelivery
+
+On first append, the adapter seeds its identity set from the bounded canonical JSONL. This covers local duplicate polling and the retained-offset path where a rejected forward causes Telegram to redeliver an earlier batch. Remote owner receipts remain a separate injection gate and are not relied upon to protect the local log.
+
+## Compatibility
+
+Both the legacy Telegram writer and the feature-flagged shared MessageLogger obey the same append result. Gross log format and message identifiers do not change.

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -470,6 +470,9 @@ export class TelegramAdapter implements MessagingAdapter {
   private topicToPurpose: Map<number, string> = new Map();
   private registryPath: string;
   private messageLogPath: string;
+  /** Durable append-seam dedupe, seeded from the bounded JSONL on first use. */
+  private loggedMessageKeys = new Set<string>();
+  private messageLogDedupeSeeded = false;
   private offsetPath: string;
   private stateDir: string;
   /** Per-bot state root. Equals stateDir for the primary bot; a namespaced sub-dir for
@@ -3723,23 +3726,13 @@ export class TelegramAdapter implements MessagingAdapter {
   }
 
   private appendToLog(entry: LogEntry): void {
-    // Maintain the per-topic change signal + tail cache FIRST — both paths below
-    // (shared logger / legacy file) persist the same entry, and every logged
-    // message must be visible to getTopicHistory/getTopicContentVersion callers
-    // regardless of which writer is active. Only a topic already seeded gets a
-    // cache append (an unseeded topic seeds lazily from the file on first read).
-    if (typeof entry.topicId === 'number') {
-      this.topicContentVersion.set(entry.topicId, (this.topicContentVersion.get(entry.topicId) ?? 0) + 1);
-      const tail = this.topicTailCache.get(entry.topicId);
-      if (tail) {
-        tail.push(entry);
-        if (tail.length > TelegramAdapter.TAIL_CACHE_LIMIT) tail.shift();
-      }
-    }
+    this.seedMessageLogDedupe();
+    const dedupeKey = this.messageLogDedupeKey(entry);
+    if (this.loggedMessageKeys.has(dedupeKey)) return;
 
     // Phase 1b: Delegate to shared MessageLogger when flag is enabled
     if (this.sharedLogger) {
-      this.sharedLogger.append({
+      const persisted = this.sharedLogger.append({
         messageId: entry.messageId,
         channelId: entry.topicId,
         text: entry.text,
@@ -3751,6 +3744,8 @@ export class TelegramAdapter implements MessagingAdapter {
         platformUserId: entry.telegramUserId,
         platform: 'telegram',
       });
+      if (!persisted) return;
+      this.rememberLoggedEntry(entry, dedupeKey);
       // Also notify the Telegram-specific callback for backward compatibility
       if (this.onMessageLogged) {
         try {
@@ -3795,7 +3790,9 @@ export class TelegramAdapter implements MessagingAdapter {
         reason: `Failed to write message log: ${err instanceof Error ? err.message : String(err)}`,
         impact: 'Conversation history gap — message may be missing from JSONL backup.',
       });
+      return;
     }
+    this.rememberLoggedEntry(entry, dedupeKey);
 
     // Notify subscribers (TopicMemory for SQLite dual-write)
     if (this.onMessageLogged) {
@@ -3824,6 +3821,42 @@ export class TelegramAdapter implements MessagingAdapter {
         senderUsername: entry.senderUsername,
         platformUserId: entry.telegramUserId?.toString(),
       }).catch(err => console.error(`[telegram] EventBus message:logged error: ${err}`));
+    }
+  }
+
+  private messageLogDedupeKey(entry: Pick<LogEntry, 'messageId' | 'topicId' | 'fromUser'>): string {
+    return `${entry.fromUser ? 'in' : 'out'}:${entry.topicId ?? 'root'}:${entry.messageId}`;
+  }
+
+  /** Seed from disk so a process restart or Telegram batch replay stays idempotent. */
+  private seedMessageLogDedupe(): void {
+    if (this.messageLogDedupeSeeded) return;
+    this.messageLogDedupeSeeded = true;
+    if (!fs.existsSync(this.messageLogPath)) return;
+    try {
+      const lines = fs.readFileSync(this.messageLogPath, 'utf-8').split('\n').filter(Boolean);
+      for (const line of lines) {
+        try {
+          const raw = JSON.parse(line) as LogEntry & { channelId?: number };
+          if (typeof raw.messageId !== 'number' || typeof raw.fromUser !== 'boolean') continue;
+          const topicId = raw.topicId ?? raw.channelId ?? null;
+          this.loggedMessageKeys.add(this.messageLogDedupeKey({ messageId: raw.messageId, topicId, fromUser: raw.fromUser }));
+        } catch { /* @silent-fallback-ok — malformed historical rows do not block new logging */ }
+      }
+    } catch (err) {
+      console.error(`[telegram] message-log dedupe seed failed: ${err}`);
+    }
+  }
+
+  /** Update memory only after the canonical append succeeds. */
+  private rememberLoggedEntry(entry: LogEntry, dedupeKey: string): void {
+    this.loggedMessageKeys.add(dedupeKey);
+    if (typeof entry.topicId !== 'number') return;
+    this.topicContentVersion.set(entry.topicId, (this.topicContentVersion.get(entry.topicId) ?? 0) + 1);
+    const tail = this.topicTailCache.get(entry.topicId);
+    if (tail) {
+      tail.push(entry);
+      if (tail.length > TelegramAdapter.TAIL_CACHE_LIMIT) tail.shift();
     }
   }
 

--- a/src/messaging/shared/MessageLogger.ts
+++ b/src/messaging/shared/MessageLogger.ts
@@ -82,12 +82,13 @@ export class MessageLogger {
   /**
    * Append a log entry to the JSONL file.
    */
-  append(entry: LogEntry): void {
+  append(entry: LogEntry): boolean {
     try {
       fs.appendFileSync(this.logPath, JSON.stringify(entry) + '\n');
       this.maybeRotate();
     } catch (err) {
       console.error(`[message-logger] Failed to append to log: ${err}`);
+      return false;
     }
 
     // Notify subscribers
@@ -98,6 +99,7 @@ export class MessageLogger {
         console.error(`[message-logger] onMessageLogged callback failed: ${err}`);
       }
     }
+    return true;
   }
 
   /**

--- a/tests/integration/shared-infra-delegation.test.ts
+++ b/tests/integration/shared-infra-delegation.test.ts
@@ -59,6 +59,42 @@ describe('Shared Infrastructure Delegation', () => {
   }
 
   describe('MessageLogger delegation (Phase 1b)', () => {
+    it.each([false, true])('dedupes one platform message across replay and adapter restart (shared=%s)', async (useSharedMessageLogger) => {
+      const logPath = path.join(stateDir, 'telegram-messages.jsonl');
+      const first = await createAdapter({ useSharedMessageLogger });
+      const firstCallbacks: unknown[] = [];
+      first.onMessageLogged = (entry) => firstCallbacks.push(entry);
+
+      first.logInboundMessage({
+        messageId: 9001,
+        topicId: 42,
+        text: 'one real Telegram message',
+        timestamp: '2026-07-17T00:00:00.000Z',
+      });
+      first.logInboundMessage({
+        messageId: 9001,
+        topicId: 42,
+        text: 'one real Telegram message',
+        timestamp: '2026-07-17T00:00:00.000Z',
+      });
+
+      const restarted = await createAdapter({ useSharedMessageLogger });
+      const restartCallbacks: unknown[] = [];
+      restarted.onMessageLogged = (entry) => restartCallbacks.push(entry);
+      restarted.logInboundMessage({
+        messageId: 9001,
+        topicId: 42,
+        text: 'redelivered after restart',
+        timestamp: '2026-07-17T00:00:00.000Z',
+      });
+
+      const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
+      expect(lines).toHaveLength(1);
+      expect(JSON.parse(lines[0]).text).toBe('one real Telegram message');
+      expect(firstCallbacks).toHaveLength(1);
+      expect(restartCallbacks).toHaveLength(0);
+    });
+
     it('writes to JSONL when flag is disabled (legacy path)', async () => {
       const adapter = await createAdapter({ useSharedMessageLogger: false });
       const logPath = path.join(stateDir, 'telegram-messages.jsonl');
@@ -105,7 +141,7 @@ describe('Shared Infrastructure Delegation', () => {
     });
 
     it('fires onMessageLogged callback in both paths', async () => {
-      for (const useShared of [false, true]) {
+      for (const [index, useShared] of [false, true].entries()) {
         const adapter = await createAdapter({ useSharedMessageLogger: useShared });
         const logged: any[] = [];
 
@@ -113,7 +149,7 @@ describe('Shared Infrastructure Delegation', () => {
         adapterAny.onMessageLogged = (entry: any) => logged.push(entry);
 
         adapterAny.appendToLog({
-          messageId: 1,
+          messageId: index + 1,
           topicId: 42,
           text: `callback test (shared=${useShared})`,
           fromUser: true,

--- a/tests/unit/telegram-messaging.test.ts
+++ b/tests/unit/telegram-messaging.test.ts
@@ -628,30 +628,38 @@ describe('TelegramAdapter messaging', () => {
     });
 
     it('does not advance the poll offset when topic routing rejects', async () => {
+      const redeliveredUpdate = {
+        update_id: 3003,
+        message: {
+          message_id: 703,
+          from: { id: 12345, first_name: 'Test' },
+          chat: { id: -100123456789 },
+          message_thread_id: 55,
+          text: 'Retry after failed forward',
+          date: Math.floor(Date.now() / 1000),
+        },
+      };
       global.fetch = vi.fn()
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({ ok: true, result: [{
-            update_id: 3003,
-            message: {
-              message_id: 703,
-              from: { id: 12345, first_name: 'Test' },
-              chat: { id: -100123456789 },
-              message_thread_id: 55,
-              text: 'Retry after failed forward',
-              date: Math.floor(Date.now() / 1000),
-            },
-          }] }),
+          json: async () => ({ ok: true, result: [redeliveredUpdate] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ ok: true, result: [redeliveredUpdate] }),
         })
         .mockResolvedValue({ ok: true, json: async () => ({ ok: true, result: [] }) });
       adapter.onTopicMessage = async () => { throw new Error('owner unavailable'); };
       vi.spyOn(adapter, 'ensureLifelineTopic').mockResolvedValue(null);
 
       await adapter.start();
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await new Promise(resolve => setTimeout(resolve, 250));
       await adapter.stop();
 
       expect(fs.existsSync(path.join(tmpDir, 'telegram-poll-offset.json'))).toBe(false);
+      const logLines = fs.readFileSync(path.join(tmpDir, 'telegram-messages.jsonl'), 'utf-8').trim().split('\n');
+      expect(logLines).toHaveLength(1);
+      expect(JSON.parse(logLines[0]).messageId).toBe(703);
     });
 
     it('logs incoming messages to JSONL', async () => {

--- a/upgrades/eli16/telegram-local-ingest-dedup.md
+++ b/upgrades/eli16/telegram-local-ingest-dedup.md
@@ -1,0 +1,3 @@
+# ELI16
+
+Telegram can hand the same envelope to the agent again when delivery is retried. The agent now checks the envelope's stable number at the history-book boundary. If that exact envelope is already written, it does not write or announce it a second time.

--- a/upgrades/next/telegram-local-ingest-dedup.md
+++ b/upgrades/next/telegram-local-ingest-dedup.md
@@ -1,0 +1,17 @@
+# Telegram local ingest deduplication
+
+## What Changed
+
+The Telegram message-log append seam now recognizes an already-persisted platform message and suppresses the duplicate row and duplicate downstream callbacks.
+
+## Evidence
+
+The focused Telegram polling and shared-logger suites pass 36 tests, including immediate replay, restart replay, and retained-offset batch redelivery. The build also passes.
+
+## What to Tell Your User
+
+One Telegram message now creates one local conversation-history row, even if Telegram delivers the same event again after a retry or restart.
+
+## Summary of New Capabilities
+
+Local Telegram history is idempotent across both logger implementations and across adapter restarts.

--- a/upgrades/side-effects/telegram-local-ingest-dedup.md
+++ b/upgrades/side-effects/telegram-local-ingest-dedup.md
@@ -1,0 +1,10 @@
+# Side-effects review
+
+- The guard lives at the canonical local append seam, so text, voice, photo, document, lifeline-forwarded, and outbound Telegram log calls share one rule.
+- Identity includes direction and topic as well as platform message ID, preventing unrelated rows from colliding.
+- The dedupe set seeds once from the bounded canonical log, covering process restart without a second state file.
+- Persistence happens before the in-memory identity is recorded; a failed append remains retryable.
+- Tail-cache versions and downstream TopicMemory and event-bus notifications advance only for the first persisted row.
+- Both the legacy writer and shared MessageLogger path return an append verdict and obey the same ordering.
+- One-time JSONL seeding adds a bounded read on the first append; it replaces repeated duplicate rows and does not add a per-message scan.
+- The E retained-offset redelivery path is covered directly: the poll offset stays unadvanced after rejection while repeated batch ingest still leaves one log row.


### PR DESCRIPTION
## Summary

Fixes item I on the explicitly scoped **local single-machine** axis: one real Telegram platform event could be appended twice to the agent's canonical local message log with the identical message ID and timestamp.

The gap was still present on current main. Telegram retry identity and remote owner receipts existed, but `TelegramAdapter.appendToLog` admitted every invocation before those remote protections mattered. The append seam now derives a stable identity from direction, topic, and Telegram message ID; seeds known identities from the bounded canonical JSONL across adapter restart; and suppresses duplicate persistence plus duplicate TopicMemory/event-bus callbacks.

Persistence remains first: the identity is remembered only after the canonical append succeeds, so a failed write stays retryable.

## ELI16 — Write each Telegram envelope into local history once

Telegram may hand the agent the same envelope again when a poll is retried, a process restarts, or a failed cross-machine forward keeps the platform offset open for redelivery. Previously the local history book wrote a new row every time it saw the envelope, even though the envelope carried the same stable Telegram number. Now the history-book boundary checks that number together with its topic and direction. If that exact envelope is already present, the second pass does not add another row or announce another message to search and memory systems. If the first disk write failed, the retry is still allowed because the identity is recorded only after persistence succeeds.

## Evidence

- 105/105 focused tests pass across Telegram polling, shared infrastructure, MessageLogger, and shared-infrastructure E2E.
- Build passes after rebase onto current main.
- Immediate duplicate delivery writes one row and fires one callback in both legacy and shared logger modes.
- A new adapter over the same state rejects the same platform message after restart.
- The E interplay is pinned directly: routing rejection keeps the poll offset unadvanced, Telegram redelivers the same batch event, and the JSONL still contains one row.
- Existing shared logger scale coverage remains green at 10,000 entries.

## Scope and ordering

- Local single-machine conversation-history admission only; remote owner receipt gating remains unchanged.
- Text, voice, photo, document, lifeline-forwarded, and outbound Telegram logging all converge on the same append seam.
- Tail-cache versioning and downstream callbacks advance only for the first persisted row.
- Log schema and platform message IDs are unchanged.

## Artifacts

- `docs/specs/telegram-local-ingest-dedup.md`
- `upgrades/next/telegram-local-ingest-dedup.md`
- `upgrades/eli16/telegram-local-ingest-dedup.md`
- `upgrades/side-effects/telegram-local-ingest-dedup.md`
- `.instar/instar-dev-decisions/2026-07-17T00-56-00-000Z-telegram-local-ingest-dedup.json`

Ready for line-by-line review. Auto-merge is intentionally not armed.
