### PR TITLE
fix(monitoring): detect hour-long Codex turns

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-17T03-12-16-671Z-codex-hour-activity.json
+++ b/.instar/instar-dev-decisions/2026-07-17T03-12-16-671Z-codex-hour-activity.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-17T03:12:16.671Z",
+  "slug": "codex-hour-activity",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 7,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/frameworkActivitySignals.ts
+++ b/src/monitoring/frameworkActivitySignals.ts
@@ -108,18 +108,18 @@ const CODEX_CLI_SIGNAL: FrameworkActivitySignal = {
   // that streamed events THEN froze is silence-eligible (the OutputActivity-
   // Tracker's observed-change requirement still gates "frozen before we watched").
   // These are structured JSON markers, not idle status text.
-  toolCallOrSpinner: /Working\s*\(\d+\s*(?:m\s*\d+\s*)?s|•\s*Ran\b|exec\(|shell\(|apply_patch\(|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|\bgenerating\b|"type":\s*"(thread|turn|item)\./i,
+  toolCallOrSpinner: /Working\s*\((?:\d+\s*h\s*)?(?:\d+\s*m\s*)?\d+\s*s|•\s*Ran\b|exec\(|shell\(|apply_patch\(|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|\bgenerating\b|"type":\s*"(thread|turn|item)\./i,
   // Live-only: the working status line + spinner + "generating". Excludes "• Ran"
   // and exec(/shell(/apply_patch( + the event-stream markers, which persist in
   // scrollback / the JSONL after a turn ends.
-  liveActivity: /Working\s*\(\d+\s*(?:m\s*\d+\s*)?s|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|\bgenerating\b/i,
+  liveActivity: /Working\s*\((?:\d+\s*h\s*)?(?:\d+\s*m\s*)?\d+\s*s|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|\bgenerating\b/i,
   // Codex shows a BARE "esc to interrupt" (no "press"/"hit" prefix) inside
   // its working status line, so the Claude-style prefixed pattern never
   // matched a real Codex pane. Match the bare form.
   escapeToInterrupt: /esc to interrupt/i,
   runningIndicator: /\((running|executing|streaming)\)|background terminal running/i,
   promptSignaturesLine:
-    'the working status line "Working (Ns • esc to interrupt)", action bullets ("• Ran ..."), spinner characters (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏), "generating". IDLE (NOT work): the model-name status line "gpt-5.3-codex medium · <dir>" and the placeholder prompt "Find and fix a bug in @filename".',
+    'the working status line "Working (Ns / Nm Ns / Nh Nm Ns • esc to interrupt)", action bullets ("• Ran ..."), spinner characters (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏), "generating". IDLE (NOT work): the model-name status line "gpt-5.3-codex medium · <dir>" and the placeholder prompt "Find and fix a bug in @filename".',
 };
 
 const GEMINI_CLI_SIGNAL: FrameworkActivitySignal = {

--- a/src/monitoring/sentinelWiring.ts
+++ b/src/monitoring/sentinelWiring.ts
@@ -500,6 +500,7 @@ export function stripVolatileStatus(
       line
         .replace(/[⠀-⣿]/g, '') // Braille spinner glyphs
         .replace(escPhrase, '') // the "esc to interrupt" affordance phrase
+        .replace(/\b\d+h\s*\d+m\s*\d+s\b/g, '') // elapsed "10h 19m 44s"
         .replace(/\b\d+m\s*\d+s\b/g, '') // elapsed "26m 16s"
         .replace(/\(\s*\d+\s*s\b/g, '(') // "(12s …" working-status seconds
         .replace(/[↑↓]\s*[\d.,]+\s*k?\s*tokens?/gi, '') // token counter

--- a/tests/unit/codex-activity-signal.test.ts
+++ b/tests/unit/codex-activity-signal.test.ts
@@ -69,6 +69,10 @@ describe('looksActivelyWorking — codex-cli (empirical)', () => {
     expect(looksActivelyWorking('• Working (2m 17s • esc to interrupt)', 'codex-cli')).toBe(true);
   });
 
+  it('keeps detecting the real hour-scale Codex status rendering', () => {
+    expect(looksActivelyWorking('• Working (10h 19m 44s • esc to interrupt)', 'codex-cli')).toBe(true);
+  });
+
   it('does NOT treat the model-name status line alone as working', () => {
     expect(looksActivelyWorking('gpt-5.3-codex medium · ~/proj', 'codex-cli')).toBe(false);
   });

--- a/tests/unit/frameworkActivitySignals.test.ts
+++ b/tests/unit/frameworkActivitySignals.test.ts
@@ -85,6 +85,9 @@ describe('frameworkActivitySignals', () => {
       expect(signal.toolCallOrSpinner.test('Generating response...')).toBe(true);
       // The canonical working status line.
       expect(signal.toolCallOrSpinner.test('• Working (3s • esc to interrupt)')).toBe(true);
+      // Real hour-scale Codex rendering captured from a long-running report.
+      expect(signal.toolCallOrSpinner.test('• Working (10h 19m 44s • esc to interrupt)')).toBe(true);
+      expect(signal.liveActivity.test('• Working (10h 19m 44s • esc to interrupt)')).toBe(true);
       // Casual "working on it" is NOT a Codex render string. Matching it caused
       // idle panes to read as working — the 2026-05-23 stuck-session false positive.
       expect(signal.toolCallOrSpinner.test('working on it')).toBe(false);

--- a/tests/unit/spinner-immune-liveness.test.ts
+++ b/tests/unit/spinner-immune-liveness.test.ts
@@ -38,6 +38,12 @@ describe('stripVolatileStatus — only real content survives', () => {
     expect(stripVolatileStatus(a, 'codex-cli')).toBe(stripVolatileStatus(b, 'codex-cli'));
   });
 
+  it('codex hour-scale clock ticks are normalized away', () => {
+    const a = '• Ran tests\n• Working (10h 19m 44s · esc to interrupt)';
+    const b = '• Ran tests\n• Working (10h 20m 03s · esc to interrupt)';
+    expect(stripVolatileStatus(a, 'codex-cli')).toBe(stripVolatileStatus(b, 'codex-cli'));
+  });
+
   it('does NOT over-strip benign content that merely contains a number+s', () => {
     const out = 'Build completed in 5s\nAll 12 tests passed';
     expect(stripVolatileStatus(out, 'claude-code')).toContain('completed in 5s');

--- a/upgrades/eli16/codex-hour-activity.eli16.md
+++ b/upgrades/eli16/codex-hour-activity.eli16.md
@@ -1,0 +1,7 @@
+# Codex hour-scale activity detection — plain-English overview
+
+Codex displays a live timer while it works. Monitoring already understood the timer in seconds and minutes, but after a turn crossed one hour Codex changed the timer to a form like `10h 19m 44s`. The detector no longer recognized it, so genuinely active long work could look idle.
+
+This change teaches the existing detector that exact hour format. It also prevents the ticking hour timer from looking like fresh model output by removing the duration before comparing successive terminal snapshots. Real new text still changes the comparison, so an unchanged, frozen working screen can still be recognized as stalled.
+
+Nothing is enabled, configured, or migrated. It is a small parsing correction backed by the real hour-scale Codex display and focused tests for both live detection and stalled-output hashing.

--- a/upgrades/next/codex-hour-activity.md
+++ b/upgrades/next/codex-hour-activity.md
@@ -1,0 +1,17 @@
+# Codex hour-scale activity detection
+
+## What Changed
+
+Codex live-activity detection now recognizes the hour-scale working timer that the TUI renders as `Nh Nm Ns`, in addition to its existing seconds and minutes forms. The spinner-immune output hash also ignores that hour timer as it ticks.
+
+## What to Tell Your User
+
+Very long Codex turns no longer lose their “still working” signal after crossing one hour, so monitoring is less likely to mistake genuine long-running work for an idle or stuck session.
+
+## Summary of New Capabilities
+
+Codex activity monitoring handles real seconds, minutes, and hours TUI duration formats.
+
+## Evidence
+
+The hour fixture uses the real Codex rendering `Working (10h 19m 44s • esc to interrupt)`. TypeScript passes, and 36 focused activity and spinner-normalization assertions pass.

--- a/upgrades/side-effects/codex-hour-activity.md
+++ b/upgrades/side-effects/codex-hour-activity.md
@@ -1,0 +1,45 @@
+# Side-Effects Review — Codex hour-scale activity detection
+
+**Date:** 2026-07-16  
+**Author:** instar-codey
+
+## Summary
+
+Extends the existing Codex TUI duration grammar from `Ns` / `Nm Ns` to the real `Nh Nm Ns` hour rendering. The same hour token is removed from the spinner-immune hash so a ticking clock does not masquerade as new model output.
+
+## Decision-point inventory
+
+- `CODEX_CLI_SIGNAL.toolCallOrSpinner` and `.liveActivity`: identify a current Codex working-status line.
+- `stripVolatileStatus`: removes only the exact hour/minute/second duration token before change hashing.
+
+## Seven dimensions
+
+1. **Over-block:** the pattern still requires the literal `Working (` prefix and a complete duration ending in seconds, so ordinary prose containing hours does not become a live signal.
+2. **Under-block:** seconds, minutes, and the observed hour form are pinned. Unknown future formats remain unchanged rather than guessed.
+3. **Abstraction:** duration recognition remains in the shared framework signal; volatile clock normalization remains in its existing hashing boundary.
+4. **Signal vs authority:** the status line is a liveness signal, not proof of semantic progress. Existing unchanged-pane logic can still classify a frozen spinner as stalled.
+5. **Interactions:** idle model-name/composer text and scrollback-persistent action bullets retain their existing behavior.
+6. **External surfaces:** none. No messages, APIs, persistent state, or credentials change.
+7. **Rollback:** code-only revert with no migration or cleanup.
+
+## Judgment-point check
+
+No new semantic judgment is introduced. This is an exact finite grammar extension grounded in an observed Codex TUI rendering.
+
+## Operator-surface quality
+
+No operator surface changes. Monitoring becomes more truthful without asking the user to configure or operate anything.
+
+## Multi-machine posture
+
+Framework pane parsing is machine-local on every host. The same deterministic grammar ships to each machine; no replicated state or cross-machine authority is involved.
+
+## Rollback cost
+
+One code revert. There is no state to repair.
+
+## Evidence pointers
+
+- Real hour form: `Working (10h 19m 44s • esc to interrupt)`.
+- 36 focused unit assertions pass across framework signals, activity classification, and spinner-immune hashing.
+- Full TypeScript check passes.


### PR DESCRIPTION
## Summary

- recognize the real Codex hour timer `Working (10h 19m 44s • esc to interrupt)` as live activity
- preserve existing seconds and minutes recognition
- strip hour-scale clock ticks from spinner-immune output hashes so a frozen pane does not fake progress

## ELI16 — Long Codex turns stay visible to monitoring

Codex changes its live timer as a turn gets longer: seconds become minutes, and after an hour the display becomes a form like `10h 19m 44s`. Monitoring understood the first two forms but not the hour form, so genuine long work could look idle.

This teaches the existing detector the exact hour format and removes that ticking clock before comparing terminal snapshots. Real new text still changes the comparison, so an unchanged frozen screen can still be treated as stalled.

## Grounding and verification

- real hour rendering grounded from an OpenAI Codex issue report: `Working (10h 19m 44s • esc to interrupt)`
- TypeScript passes
- 36 focused assertions pass across framework signals, active-work classification, and spinner-immune hashing
- full repository lint and Tier-1 `/instar-dev` gate pass
