### PR TITLE
feat(playwright): add voluntary standalone seat lease

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-17T03-25-50-058Z-playwright-standalone-seat-lease.json
+++ b/.instar/instar-dev-decisions/2026-07-17T03-25-50-058Z-playwright-standalone-seat-lease.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-17T03:25:50.058Z",
+  "slug": "playwright-standalone-seat-lease",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 89,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/site/src/content/docs/features/playwright-profile-registry.md
+++ b/site/src/content/docs/features/playwright-profile-registry.md
@@ -65,6 +65,13 @@ of starting a second browser against the same profile directory. Expired leases 
 be reclaimed after their recorded deadline, so a crashed session cannot strand the
 seat indefinitely.
 
+Playwright calls made through MCP acquire automatically. Standalone Playwright scripts
+can honor the same lease voluntarily with `instar playwright-seat acquire --holder ...`
+before launching the browser and `instar playwright-seat release --holder ...` in a
+`finally` cleanup. The holder ID must be unique to that active drive invocation and
+reused only for its matching release. Release is ownership-checked, so a cleanup from
+a distinct old or competing drive cannot clear a successor's live lease.
+
 ## Routes
 
 - `GET /playwright-profiles` — list every profile and the accounts it holds (full
@@ -82,6 +89,10 @@ seat indefinitely.
 - `DELETE /playwright-profiles/:id/accounts` — remove an account from a profile.
 - `POST /playwright-profiles/:id/activate` — switch the browser onto a profile (config
   rewrite + session restart; dry-run by default).
+- `POST /playwright-profiles/seat/acquire` — acquire or renew the machine-local shared
+  browser-seat lease.
+- `POST /playwright-profiles/seat/release` — release the lease only when the submitted
+  holder currently owns it.
 
 ## Rollout and safety
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2106,6 +2106,33 @@ program
   .option('-d, --dir <path>', 'Project directory')
   .action(doctor);
 
+// ── Playwright physical-seat lease ──────────────────────────────
+
+const playwrightSeatCmd = program
+  .command('playwright-seat')
+  .description('Voluntarily coordinate standalone Playwright scripts with the host-wide operator-seat lease');
+
+playwrightSeatCmd
+  .command('acquire')
+  .requiredOption('--holder <id>', 'Unique drive-invocation id reused only for its release')
+  .option('--label <label>', 'Human-readable drive label', 'standalone Playwright script')
+  .action(async (opts) => {
+    const { PlaywrightSeatLease } = await import('./core/PlaywrightSeatLease.js');
+    const result = new PlaywrightSeatLease().acquire(opts.holder, opts.label);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    if (!result.acquired) process.exitCode = 2;
+  });
+
+playwrightSeatCmd
+  .command('release')
+  .requiredOption('--holder <id>', 'Same unique drive-invocation id used to acquire')
+  .action(async (opts) => {
+    const { PlaywrightSeatLease } = await import('./core/PlaywrightSeatLease.js');
+    const result = new PlaywrightSeatLease().release(opts.holder);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    if (!result.released && result.reason === 'ownership-mismatch') process.exitCode = 2;
+  });
+
 // ── Channels ─────────────────────────────────────────────────────
 
 const channelsCmd = program

--- a/src/core/PlaywrightSeatLease.ts
+++ b/src/core/PlaywrightSeatLease.ts
@@ -27,6 +27,11 @@ export type PlaywrightSeatLeaseResult =
   | { acquired: true; lease: PlaywrightSeatLeaseRecord }
   | { acquired: false; holderLabel: string; retryAfterMs: number; expiresAt: string };
 
+export type PlaywrightSeatReleaseResult =
+  | { released: true }
+  | { released: false; reason: 'not-held' }
+  | { released: false; reason: 'ownership-mismatch'; holderLabel: string; expiresAt: string };
+
 export interface PlaywrightSeatLeaseOptions {
   filePath?: string;
   now?: () => number;
@@ -79,6 +84,29 @@ export class PlaywrightSeatLease {
       };
       this.persist(lease);
       return { acquired: true, lease };
+    });
+  }
+
+  /**
+   * Voluntary release for standalone browser drives. Only the current holder
+   * can release; a stale script can never clear a successor's live lease.
+   */
+  release(holderId: string): PlaywrightSeatReleaseResult {
+    const id = clamp(holderId, 256);
+    if (!id) throw new Error('holderId is required');
+    return this.withLock(() => {
+      const current = this.read();
+      if (!current) return { released: false, reason: 'not-held' };
+      if (current.holderId !== id) {
+        return {
+          released: false,
+          reason: 'ownership-mismatch',
+          holderLabel: current.holderLabel,
+          expiresAt: current.expiresAt,
+        };
+      }
+      SafeFsExecutor.safeUnlinkSync(this.filePath, { operation: 'PlaywrightSeatLease voluntary release' });
+      return { released: true };
     });
   }
 

--- a/src/core/WriteDomainRegistry.ts
+++ b/src/core/WriteDomainRegistry.ts
@@ -236,7 +236,6 @@ export function buildWriteDomainRegistry(opts: { machineId: string | null }): Wr
       note: 'machine id embedded in the kv key — single writer per file; peers’ copies ride git-sync inertly',
     },
   });
-
   // ── Route seam, wave 1: the P2-6 family (§3.5) ─────────────────────────
   // Both families are machine-local ⇒ admit everywhere — the user-visible
   // P2-6 fix. Stories per §3.1 + frontloaded decision §9.3.
@@ -265,6 +264,17 @@ export function buildWriteDomainRegistry(opts: { machineId: string | null }): Wr
       logical: 'per-machine-path',
       onSharedGitSyncedPath: false,
       note: 'the lease protects browser cookies/user-data physically resident on this host; ~/.instar/state is outside every agent project and git sync',
+    },
+  });
+  reg.add({
+    kind: 'route',
+    method: 'POST',
+    pathPrefix: '/playwright-profiles/seat/release',
+    domain: 'machine-local',
+    story: {
+      logical: 'per-machine-path',
+      onSharedGitSyncedPath: false,
+      note: 'ownership-checked release mutates the same host-wide browser-seat lease outside project git sync',
     },
   });
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -21128,6 +21128,28 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     }
   });
 
+  // POST /playwright-profiles/seat/release — voluntary standalone-script path.
+  // Ownership is checked by the shared lease store, so a late cleanup cannot
+  // release a newer browser drive's lease.
+  router.post('/playwright-profiles/seat/release', (req, res) => {
+    if (refuseInadmissibleWrite(req, res)) return;
+    const holderId = typeof req.body?.holderId === 'string' ? req.body.holderId : '';
+    if (!holderId) {
+      res.status(400).json({ error: 'holderId is required' });
+      return;
+    }
+    try {
+      const result = (ctx.playwrightSeatLease?.() ?? new PlaywrightSeatLease()).release(holderId);
+      if (!result.released && result.reason === 'ownership-mismatch') {
+        res.status(409).json({ error: 'playwright operator seat is held by another drive', ...result });
+        return;
+      }
+      res.json(result);
+    } catch (err) {
+      res.status(503).json({ error: err instanceof Error ? err.message : 'playwright seat lease unavailable' });
+    }
+  });
+
   // GET /playwright-profiles/session-context — the compact boot pointer (?full=1 bypasses the cap).
   router.get('/playwright-profiles/session-context', (req, res) => {
     if (!playwrightFeatureEnabled()) {

--- a/tests/integration/playwright-profile-routes.test.ts
+++ b/tests/integration/playwright-profile-routes.test.ts
@@ -171,6 +171,19 @@ describe('Playwright Profile Registry routes (integration, real createRoutes + a
     expect(conflict.status).toBe(409);
     expect(conflict.body.holderLabel).toBe('topic-1');
     expect(conflict.body.retryAfterMs).toBeGreaterThan(0);
+
+    const wrongRelease = await request(app).post('/playwright-profiles/seat/release').set(auth())
+      .send({ holderId: 'agent-b:topic-2' });
+    expect(wrongRelease.status).toBe(409);
+
+    const release = await request(app).post('/playwright-profiles/seat/release').set(auth())
+      .send({ holderId: 'agent-a:topic-1' });
+    expect(release.status).toBe(200);
+    expect(release.body).toEqual({ released: true });
+
+    const successor = await request(app).post('/playwright-profiles/seat/acquire').set(auth())
+      .send({ holderId: 'agent-b:topic-2', holderLabel: 'topic-2' });
+    expect(successor.status).toBe(200);
   });
 
   it('seat safety remains available when the optional profile registry is dark', async () => {

--- a/tests/unit/PlaywrightSeatLease.test.ts
+++ b/tests/unit/PlaywrightSeatLease.test.ts
@@ -61,4 +61,13 @@ describe('PlaywrightSeatLease', () => {
     expect(acquired.acquired).toBe(true);
     expect(JSON.parse(fs.readFileSync(filePath, 'utf8')).holderId).toBe('agent-a:topic-1');
   });
+
+  it('voluntarily releases only for the current holder', () => {
+    lease().acquire('script-a', 'standalone A');
+    expect(lease().release('script-b')).toMatchObject({ released: false, reason: 'ownership-mismatch' });
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(lease().release('script-a')).toEqual({ released: true });
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(lease().release('script-a')).toEqual({ released: false, reason: 'not-held' });
+  });
 });

--- a/tests/unit/write-domain-registry.test.ts
+++ b/tests/unit/write-domain-registry.test.ts
@@ -148,10 +148,12 @@ describe('wave-1 route entries (§3.5)', () => {
   });
 
   it('the physical Playwright seat lease is machine-local outside git sync', () => {
-    const entry = reg.entryForRoute('POST', '/playwright-profiles/seat/acquire');
-    expect(entry?.domain).toBe('machine-local');
-    expect(entry?.story?.logical).toBe('per-machine-path');
-    expect(entry?.story?.onSharedGitSyncedPath).toBe(false);
+    for (const path of ['/playwright-profiles/seat/acquire', '/playwright-profiles/seat/release']) {
+      const entry = reg.entryForRoute('POST', path);
+      expect(entry?.domain).toBe('machine-local');
+      expect(entry?.story?.logical).toBe('per-machine-path');
+      expect(entry?.story?.onSharedGitSyncedPath).toBe(false);
+    }
   });
 });
 

--- a/upgrades/eli16/playwright-standalone-seat-lease.eli16.md
+++ b/upgrades/eli16/playwright-standalone-seat-lease.eli16.md
@@ -1,0 +1,7 @@
+# Standalone Playwright seat lease — ELI16
+
+Playwright MCP already takes a numbered key before using the shared browser, but a
+one-off Playwright script entered through a side door and skipped the key desk. This
+adds an explicit check-out/check-in path for those scripts. Check-in only works for
+the holder that checked out the key, so an old script cannot accidentally erase a
+new script's reservation.

--- a/upgrades/next/playwright-standalone-seat-lease.md
+++ b/upgrades/next/playwright-standalone-seat-lease.md
@@ -1,0 +1,24 @@
+# Standalone Playwright seat lease
+
+## What Changed
+
+Standalone Playwright scripts can now voluntarily acquire and release the same
+machine-local operator-seat lease used by Playwright MCP calls. Ownership-checked
+release prevents late cleanup from clearing a successor's lease, while idempotent
+cleanup keeps `finally` blocks simple.
+
+## What to Tell Your User
+
+One-off Playwright scripts can coordinate with normal agent browser drives instead of
+quietly bypassing the shared browser-seat lock.
+
+## Summary of New Capabilities
+
+The `playwright-seat` command and authenticated seat-release route expose the existing
+host-wide lease to trusted standalone scripts.
+
+## Evidence
+
+TypeScript and the full lint chain pass. Thirty-nine focused unit/integration tests and
+a real temporary-home CLI smoke cover acquire, conflict, ownership-safe release,
+idempotent cleanup, and successor acquisition.

--- a/upgrades/side-effects/playwright-standalone-seat-lease.md
+++ b/upgrades/side-effects/playwright-standalone-seat-lease.md
@@ -1,0 +1,66 @@
+# Side-Effects Review — standalone Playwright seat lease
+
+**Version / slug:** `playwright-standalone-seat-lease`
+**Date:** `2026-07-16`
+**Tier:** 2
+**Second-pass reviewer:** independent Codex collaboration reviewer — concur
+
+## Summary
+
+Adds an ownership-checked release operation to `PlaywrightSeatLease`, an authenticated
+release route, and a `playwright-seat` CLI acquire/release path so trusted standalone
+Playwright scripts can participate in the existing host-wide lease.
+
+## Decision-point inventory
+
+- `PlaywrightSeatLease.release` — **add** — removes the record only for the current holder.
+- release route — **add** — returns conflict for a different live holder.
+- CLI acquire/release — **add** — exposes the same store to standalone local scripts.
+
+## Over-block / under-block
+
+The existing default-seat lease still conservatively serializes all users of that
+physical seat. Standalone scripts remain voluntary participants: a script that ignores
+this interface can still contend. This change does not pretend to sandbox hostile or
+uncooperative local processes.
+
+## Abstraction and authority
+
+Release belongs in the existing lease store and uses its existing filesystem lock;
+the CLI and route are adapters, not second authorities. Ownership is an exact invariant,
+not an inferred signal. A mismatched holder cannot release, and an absent record is an
+idempotent success for cleanup. Callers must choose a unique ID per active drive
+invocation and reuse it only for that invocation's matching release; intentional ID
+reuse is intentional same-owner renewal semantics.
+
+## Interactions and races
+
+Acquire and release serialize on the same lock. The ownership check and unlink happen
+inside that critical section, preventing a late cleanup from deleting a successor's
+lease. No scheduler, retry loop, notification, or external operation is added.
+
+## External surfaces and cross-machine posture
+
+The new route is authenticated and the CLI is local. Both expose holder labels and
+expiry already present in the acquire surface; no browser credentials or page data are
+read. The state remains **machine-local by design** because the guarded browser profile
+is a physical resource on that machine.
+
+## Rollback
+
+Revert the adapters and release method. Existing lease records remain compatible and
+expire normally; no migration or repair is required.
+
+## Verification
+
+- TypeScript typecheck
+- 39 focused unit/integration tests covering ownership mismatch, successful release,
+  idempotent cleanup, successor acquisition, route behavior, and registry classification
+
+## Second-pass review
+
+**Verdict:** concur. The reviewer confirmed that release ownership checking and unlink
+are atomic under the same host-wide lock as acquire; route authentication/write
+classification, CLI conflict behavior, and machine-local posture are sound. The review's
+nonblocking precision note — explicitly require a unique holder ID per invocation — is
+incorporated in CLI help, docs, and this artifact.


### PR DESCRIPTION
## What changed

- add ownership-checked voluntary release to the existing host-wide Playwright seat lease
- expose acquire/release through a standalone-script CLI and an authenticated release route
- classify release as machine-local and document unique per-invocation holder IDs
- cover mismatch, idempotent cleanup, successor acquisition, route behavior, and registry wiring

## Why

Playwright MCP calls already honor the shared operator-seat lease, but standalone Playwright scripts bypass the MCP hook. They now have a small voluntary path into the same authority.

## ELI16 — one key desk, including the side door

MCP browser calls already check out a key before using the shared browser. One-off scripts entered through a side door and skipped the key desk. This gives them an explicit check-out/check-in path. Check-in only works for the holder that checked out the key, so a distinct old script cannot erase a new script's reservation.

## Validation

- TypeScript and full lint chain: pass
- focused unit/integration suite: 39/39 pass
- pre-push scoped E2E: 333/333 pass
- real temporary-home CLI acquire/release smoke: pass
- independent Tier-2 second pass: CONCUR
- broad E2E: 2,940 pass; three unrelated shared-tmux/subscription-pool failures recorded

## Safety posture

The ownership check and unlink run under the same host-wide lock as acquire. Holder IDs are unique per active drive invocation and reused only for that matching release. State remains machine-local because the guarded browser profile is a physical resource on that host.