### PR TITLE
fix: contain standby scheduler triggers in single-agent CROSS-MACHINE pools

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-17T07-01-52-392Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-17T07-01-52-392Z-unknown.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-07-17T07:01:52.392Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 31,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/job-scheduler-standby-startup.test.ts",
+      "howCaught": "The ratchet covers stable standby and in-flight lease demotion, proves each missed-job evaluation settles with zero spawn, and the scheduler callbacks contain trigger errors so repeated ticks cannot become a crash/restart loop."
+    },
+    "component": "JobScheduler"
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/read-only-standby-scheduler-startup.eli16.md
+++ b/docs/specs/read-only-standby-scheduler-startup.eli16.md
@@ -1,0 +1,34 @@
+# Read-only standby scheduler startup containment — ELI16
+
+An Instar agent can run on two machines while only one machine holds the fenced
+lease that permits shared-state writes. The other machine is a read-only
+standby. During a real single-agent CROSS-MACHINE enrollment test, the new
+standby started normally, learned that the laptop held the lease, and correctly
+made its shared state read-only. A few seconds later its scheduler noticed jobs
+that had been missed while the Mini was offline. It tried those jobs, their gate
+checks failed, and the scheduler attempted to record the skips in shared state.
+That write was correctly refused—but the refusal escaped the startup task and
+terminated the whole server. The supervisor restarted it, producing the same
+crash again. A healthy standby therefore could not remain online long enough to
+serve health checks, appear honestly in the pool, or receive a transferred
+conversation.
+
+The fix restores the invariant that a read-only standby does not run scheduled
+jobs. Every job already passes through one `triggerJob` boundary, so that
+boundary now checks the authoritative `StateManager.readOnly` state before any
+gate, spawn, job-state update, or event append. If the machine is a standby, the
+job is recorded only in the scheduler's machine-local skip ledger and returns a
+normal `skipped` result. No shared write is attempted and the server stays up.
+Because lease demotion can race a job already crossing that boundary, the cron
+callback and delayed startup-missed callback also contain trigger failures;
+the fenced write still refuses, but its rejection cannot terminate the server.
+The lease holder is unchanged: it remains writable and runs the same jobs as
+before. This does not infer ownership from a hostname, clock, or network guess;
+it consumes the fenced lease outcome already enforced by StateManager.
+
+The regression test recreates the important sequence: load a never-run job,
+demote the machine to read-only, trigger the startup-missed path, and prove it
+returns `skipped`, spawns no session, and records exactly one local skip. A
+second case demotes while a gate is in flight and proves the missed-job
+evaluation settles without escaping a rejection. The existing role-guard suite
+remains green, and TypeScript compilation is clean.

--- a/src/scheduler/JobScheduler.ts
+++ b/src/scheduler/JobScheduler.ts
@@ -387,7 +387,16 @@ export class JobScheduler {
         const task = new Cron(job.schedule, async () => {
           // New cron window — reset retry state so we get fresh attempts
           this.clearRetryState(job.slug);
-          await this.triggerJob(job.slug, 'scheduled');
+          try {
+            await this.triggerJob(job.slug, 'scheduled');
+          } catch (err) {
+            // Cron callbacks are a process-lifetime boundary. A lease demotion
+            // can race the pre-trigger read-only check and make a later shared
+            // bookkeeping write throw; contain that refusal (and every other
+            // trigger failure) here rather than creating an unhandled rejection
+            // that terminates the server.
+            console.error(`[scheduler] Scheduled trigger failed for "${job.slug}": ${err}`);
+          }
         });
         this.cronTasks.set(job.slug, task);
       } catch (err) {
@@ -402,9 +411,15 @@ export class JobScheduler {
     const graceMs = this.config.startupGraceMs ?? 5000;
     if (graceMs > 0) {
       console.log(`[scheduler] Startup grace period: ${graceMs}ms before missed-job evaluation`);
-      setTimeout(() => this.checkMissedJobs(scopedJobs), graceMs);
+      setTimeout(() => {
+        this.checkMissedJobs(scopedJobs).catch((err) => {
+          console.error(`[scheduler] Missed-job startup evaluation failed: ${err}`);
+        });
+      }, graceMs);
     } else {
-      this.checkMissedJobs(scopedJobs);
+      this.checkMissedJobs(scopedJobs).catch((err) => {
+        console.error(`[scheduler] Missed-job startup evaluation failed: ${err}`);
+      });
     }
 
     // Ensure every job has a Telegram topic (job-topic coupling)
@@ -457,6 +472,23 @@ export class JobScheduler {
 
     if (this.paused) {
       this.skipLedger.recordSkip(slug, 'paused');
+      return 'skipped';
+    }
+
+    // In the legacy one-awake-machine posture the scheduler is constructed on
+    // the machine that is awake at boot, but it is not torn down if that machine
+    // subsequently loses the fenced lease.  Once StateManager has demoted this
+    // process to a read-only standby, every legacy job path eventually performs
+    // a shared-state write (run state, an event, or both).  Letting a missed-job
+    // pass reach those writes turns the expected refusal into an unhandled
+    // startup rejection and crash-loops the standby.
+    //
+    // Pool-owned sessions have a separate session-scoped write exception, but
+    // scheduler bookkeeping (job state + events) remains shared state.  The
+    // scheduler therefore stays fenced whenever the StateManager is read-only.
+    if (this.state.readOnly) {
+      this.skipLedger.recordSkip(slug, 'role-guard');
+      console.log(`[scheduler] Job "${slug}" skipped — this machine is a read-only standby.`);
       return 'skipped';
     }
 
@@ -1907,7 +1939,15 @@ export class JobScheduler {
     });
 
     for (const { job } of missedJobs) {
-      await this.triggerJob(job.slug, 'missed');
+      try {
+        await this.triggerJob(job.slug, 'missed');
+      } catch (err) {
+        // A demotion can occur after triggerJob's entry check but before a gate
+        // or spawn path records shared bookkeeping. The StateManager refusal is
+        // authoritative; contain it per job so one raced trigger cannot abort
+        // evaluation of the rest or escape the startup callback.
+        console.error(`[scheduler] Missed trigger failed for "${job.slug}": ${err}`);
+      }
     }
   }
 

--- a/tests/unit/job-scheduler-standby-startup.test.ts
+++ b/tests/unit/job-scheduler-standby-startup.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { JobScheduler } from '../../src/scheduler/JobScheduler.js';
+import { createMockSessionManager, createSampleJobsFile, createTempProject } from '../helpers/setup.js';
+import type { JobDefinition, JobSchedulerConfig } from '../../src/core/types.js';
+import type { MockSessionManager, TempProject } from '../helpers/setup.js';
+
+describe('JobScheduler read-only standby startup containment', () => {
+  let project: TempProject;
+  let mockSM: MockSessionManager;
+  let scheduler: JobScheduler;
+
+  beforeEach(() => {
+    project = createTempProject();
+    mockSM = createMockSessionManager();
+  });
+
+  afterEach(() => {
+    project?.state.setReadOnly(false);
+    scheduler?.stop();
+    project.cleanup();
+  });
+
+  it('skips a never-run missed job without touching shared state after demotion', async () => {
+    const jobs: JobDefinition[] = [{
+      slug: 'startup-miss',
+      name: 'Startup Miss',
+      description: 'A job missed while the machine was offline',
+      schedule: '* * * * *',
+      priority: 'medium',
+      expectedDurationMinutes: 5,
+      model: 'sonnet',
+      enabled: true,
+      gate: 'exit 1',
+      execute: { type: 'prompt', value: 'do work' },
+    }];
+    const jobsFile = createSampleJobsFile(project.stateDir, jobs);
+    const config: JobSchedulerConfig = {
+      jobsFile,
+      enabled: true,
+      maxParallelJobs: 1,
+      gateRetries: 1,
+      quotaThresholds: { normal: 50, elevated: 70, critical: 85, shutdown: 95 },
+    };
+    scheduler = new JobScheduler(config, mockSM as any, project.state, project.stateDir);
+    scheduler.start();
+
+    project.state.setReadOnly(true);
+
+    await expect(scheduler.triggerJob('startup-miss', 'missed')).resolves.toBe('skipped');
+    expect(mockSM._spawnCount).toBe(0);
+    const skips = scheduler.getSkipLedger?.()?.getSkips?.({ slug: 'startup-miss' }) ?? [];
+    expect(skips.filter((s) => s.reason === 'role-guard')).toHaveLength(1);
+  });
+
+  it('contains a demotion that races a startup missed-job gate', async () => {
+    const jobs: JobDefinition[] = [{
+      slug: 'raced-startup-miss',
+      name: 'Raced Startup Miss',
+      description: 'Demotes while its gate is in flight',
+      schedule: '* * * * *',
+      priority: 'medium',
+      expectedDurationMinutes: 5,
+      model: 'sonnet',
+      enabled: true,
+      gate: 'sleep 0.1; exit 1',
+      execute: { type: 'prompt', value: 'do work' },
+    }];
+    const jobsFile = createSampleJobsFile(project.stateDir, jobs);
+    scheduler = new JobScheduler({
+      jobsFile,
+      enabled: true,
+      maxParallelJobs: 1,
+      gateRetries: 1,
+      startupGraceMs: 60_000,
+      quotaThresholds: { normal: 50, elevated: 70, critical: 85, shutdown: 95 },
+    }, mockSM as any, project.state, project.stateDir);
+    scheduler.start();
+
+    const evaluation = (scheduler as any).checkMissedJobs(jobs);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    project.state.setReadOnly(true);
+
+    await expect(evaluation).resolves.toBeUndefined();
+    expect(mockSM._spawnCount).toBe(0);
+  });
+});

--- a/upgrades/next/read-only-standby-scheduler-startup.md
+++ b/upgrades/next/read-only-standby-scheduler-startup.md
@@ -1,0 +1,27 @@
+# Read-only standby scheduler startup containment
+
+## What Changed
+
+Multi-machine standbys now stop scheduled jobs at the common trigger boundary
+after fenced-lease demotion makes their state read-only. Startup missed-job
+evaluation returns a normal skip instead of attempting shared bookkeeping and
+crashing the server.
+
+## Evidence
+
+- Added a regression test for a never-run job triggered after read-only
+  demotion.
+- Existing scheduler role-guard suite: 8/8 passed.
+- Focused total: 10/10 passed.
+- TypeScript `--noEmit` compilation passed.
+- Root cause reproduced on a real single-agent CROSS-MACHINE Mini enrollment.
+
+## What to Tell Your User
+
+When your agent runs on multiple machines, a standby can now remain healthy
+after startup even if scheduled jobs were missed while it was offline.
+
+## Summary of New Capabilities
+
+No new capability or setting. This is a reliability fix for existing
+multi-machine standby behavior.

--- a/upgrades/side-effects/read-only-standby-scheduler-startup.md
+++ b/upgrades/side-effects/read-only-standby-scheduler-startup.md
@@ -1,0 +1,171 @@
+# Side-Effects Review — Read-only standby scheduler startup containment
+
+**Version / slug:** `read-only-standby-scheduler-startup`
+**Date:** `2026-07-16`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `independent Codex reviewer`
+
+## Summary of the change
+
+`src/scheduler/JobScheduler.ts` now refuses every scheduled-job trigger while
+the authoritative `StateManager` is read-only. The refusal occurs before job
+gates, claims, spawns, or shared-state bookkeeping and writes only the
+machine-local skip ledger. `tests/unit/job-scheduler-standby-startup.test.ts`
+reproduces the startup-missed-job crash observed on a real paired Mini. Cron
+and startup-missed callback boundaries also contain trigger failures, closing
+the lease-demotion race between the entry check and later bookkeeping.
+
+## Decision-point inventory
+
+- `JobScheduler.triggerJob` — **modified** — returns `skipped` when the machine's
+  authoritative state manager says it is a read-only standby.
+
+---
+
+## 1. Over-block
+
+A job intentionally designed to run independently on every machine is also
+skipped while that machine is read-only. This is required in the current
+architecture because every scheduler execution path writes shared job state or
+events; `perMachineIndependent` bypasses the cross-machine claim, not the shared
+bookkeeping writes. The lease holder continues to run the job, so agent-wide
+cadence is preserved. Truly machine-local standby jobs need a separate
+machine-local scheduler state domain before they can safely run.
+
+---
+
+## 2. Under-block
+
+This does not contain unrelated background components that write through
+StateManager after demotion. It closes the scheduler's single trigger boundary,
+including startup misses, cron ticks, retries, and manual scheduler triggers.
+Direct code that bypasses `triggerJob` is outside the scheduler contract. A
+job already spawned before demotion may still fail its own later shared writes;
+that is governed by the job/session lifecycle rather than this trigger fix.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The trigger boundary is the correct layer: all scheduler entry paths converge
+there before action, and `StateManager.readOnly` is the existing lower-level
+authority derived from the fenced lease. Checking only the failing
+`appendEvent` call would leave spawn and other bookkeeping paths exposed.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this is a deterministic hard-invariant enforcement, not a brittle
+  judgment detector.
+
+The change does hold blocking authority, but its input is the existing
+authoritative read-only state established by the fenced lease. The domain is
+enumerable: shared-state-writing scheduler work either runs on a writable
+machine or does not run. No message meaning, conversational intent, heuristic,
+or threshold is interpreted here.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic is added at a competing-signals decision point. The
+check consumes a hard write-authority invariant; it does not choose between
+work evidence, recency, urgency, or liveness signals.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the read-only check precedes machine scope, WS4.3 role guard,
+  claims, quotas, gates, and spawns. Those paths cannot safely act on a machine
+  whose shared state is already fenced.
+- **Double-fire:** the later WS4.3 guard does not fire because this earlier
+  invariant returns first; one skip-ledger row is produced.
+- **Races:** `StateManager.readOnly` is read live at every trigger. A demotion
+  before the boundary skips. If demotion lands after the check, StateManager
+  still refuses the later write and the cron/startup-missed callback boundaries
+  contain that rejection rather than allowing an unhandled process rejection.
+- **Feedback loops:** the machine-local skip ledger does not alter the lease or
+  cause another trigger.
+
+---
+
+## 6. External surfaces
+
+The visible effect is that a standby stays healthy and reports a scheduler job
+as skipped instead of crash-looping. No API schema, Telegram message, database
+schema, external integration, or operator action changes. There are no new
+operator-facing actions.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design:** the decision is evaluated separately on each
+machine from that machine's live fenced-lease-derived read-only state. The skip
+ledger is also machine-local observability. The behavior converges by authority:
+the writable lease holder runs the job and every read-only peer skips it. The
+change emits no user-facing notice, introduces no durable transferable state,
+and generates no URL.
+
+---
+
+## 8. Rollback cost
+
+Pure code rollback: revert the trigger-boundary check and ship a patch. There is
+no migration or state repair. During rollback propagation, affected standbys
+can resume the prior crash loop when missed jobs are present.
+
+---
+
+## Conclusion
+
+The fix is narrow and clear to ship. The review moved the check to the common
+trigger boundary and confirmed that the authoritative lease-derived read-only
+state—not a new heuristic—owns the decision. Focused scheduler tests and a clean
+typecheck cover the changed path.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** independent Codex reviewer
+**Independent read of the artifact:** concur
+
+The first pass found a check-then-act demotion window and noted that the
+original test proved only a direct trigger, not delayed startup containment.
+The implementation now catches trigger failures at cron and startup-missed
+process-lifetime boundaries, and the ratchet adds an in-flight gate/demotion
+case plus an exact single skip-row assertion. The independent re-review found
+no remaining concern across authority boundaries, active-active behavior, or
+self-action convergence.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/job-scheduler-standby-startup.test.ts`
+- `tests/unit/job-scheduler-role-guard.test.ts`
+- Real Mini terminal: `StateManager is read-only ... Blocked: appendEvent` from
+  `JobScheduler.runGateAsync -> triggerJob -> checkMissedJobs`.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+This modifies the scheduler, a self-triggered controller. `defectClass:
+unbounded-self-action`; `closure: guard`; `guardEvidence: { enforcementType:
+ratchet, citation: tests/unit/job-scheduler-standby-startup.test.ts, howCaught:
+the ratchet covers both demotion before a missed trigger and demotion while its
+gate is in flight, requires the evaluation to settle without rejection, and
+proves zero spawned sessions plus exactly one local skip for the stable-standby
+case; cron and startup callbacks contain any remaining trigger error }`.


### PR DESCRIPTION
## What changed
- Fence scheduler triggers when authoritative StateManager is read-only.
- Contain cron/startup missed-trigger rejections, including lease-demotion TOCTOU.
- Add stable-standby and in-flight-demotion regressions.
- Add ELI16, release fragment, and side-effects review.

## ELI16 — keep the second machine online when it is the standby
One Instar agent can span two machines, but only the lease holder may change shared state. The standby used to notice missed scheduled jobs, correctly refuse their writes, and then crash because that refusal escaped its startup task. This change stops scheduled work at the authoritative read-only boundary and contains lease-demotion races, so the standby stays online while the lease holder behaves exactly as before.

## Root cause
In a single-agent CROSS-MACHINE pool, startup missed-job evaluation could race or follow fenced-lease demotion. Scheduler shared-state bookkeeping then hit the correct read-only refusal, but the rejection escaped the startup callback and crash-looped the standby.

## Impact
Standbys remain online and honestly visible instead of crashing when missed jobs are evaluated. The writable lease holder’s scheduler behavior is unchanged.

## Validation
- Historical CI note: the original 07:09Z ELI16 run failed before this body section was corrected; it was not a full-head green rerun.
- Focused scheduler tests: 10/10
- TypeScript no-emit: pass
- Pre-push smoke: 262/262
- Scoped e2e rerun: 333/333
- Independent high-risk review: concurred
- Live reproduction: codey Mini enrollment on port 4046