### PR TITLE
fix(lifeline): stop false "Server is restarting" notice when server is healthy

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-17T19-55-52-344Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-17T19-55-52-344Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-17T19:55:52.344Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 82,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-17T19-56-51-475Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-17T19-56-51-475Z-unknown.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-17T19:56:51.475Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 82,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "One-shot, user-message-driven notice: the lifeline sends this queued-ack in direct response to a single inbound user message when a forward fails. It is not a self-triggered loop/monitor/sentinel/reaper/scheduler/recovery path. The matched verbs (restarting/reconnect) appear only in the notice text and comments, not in any self-firing controller."
+  },
+  "verdict": "pass"
+}

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -69,6 +69,7 @@ import { RestartOrchestrator } from './RestartOrchestrator.js';
 import { writeWakeRequestIfSlept } from './agentSleepWake.js';
 import { detectLaunchdSupervised } from './detectLaunchdSupervised.js';
 import { LifelineDriftPromoter, DRIFT_RESTART_PENDING_NOTICE_FILE } from './LifelineDriftPromoter.js';
+import { buildQueuedNotice } from './queuedNotice.js';
 import {
   LifelineHealthWatchdog,
   DEFAULT_WATCHDOG_THRESHOLDS,
@@ -1211,7 +1212,8 @@ export class TelegramLifeline {
         await this.sendToTopic(topicId, '✓ Delivered');
         return;
       }
-      // Server appears healthy but forward failed — queue with accurate message
+      // Server appears healthy but forward failed — queue and tell the user we
+      // are reconnecting (NOT that the server is restarting: it is confirmed up).
       this.queue.enqueue({
         id: `tg-${msg.message_id}`,
         topicId,
@@ -1223,7 +1225,7 @@ export class TelegramLifeline {
       });
       if (this.shouldSendQueueAck(topicId)) {
         await this.sendToTopic(topicId,
-          `Server is restarting. Your message has been queued (${this.queue.length} in queue). It will be delivered when the server recovers.`
+          buildQueuedNotice('message', this.queue.length, /* serverHealthy */ true)
         );
       }
       return;
@@ -1243,7 +1245,7 @@ export class TelegramLifeline {
     // Notify user that message is queued (rate-limited to prevent spam during restart loops)
     if (this.shouldSendQueueAck(topicId)) {
       await this.sendToTopic(topicId,
-        `Server is temporarily down. Your message has been queued (${this.queue.length} in queue). It will be delivered when the server recovers.`
+        buildQueuedNotice('message', this.queue.length, /* serverHealthy */ false)
       );
     }
   }
@@ -1291,15 +1293,9 @@ export class TelegramLifeline {
     });
 
     if (this.shouldSendQueueAck(topicId)) {
-      if (this.supervisor.healthy) {
-        await this.sendToTopic(topicId,
-          `Server is restarting. Your photo has been queued (${this.queue.length} in queue). It will be delivered when the server recovers.`
-        );
-      } else {
-        await this.sendToTopic(topicId,
-          `Server is temporarily down. Your photo has been queued (${this.queue.length} in queue). It will be delivered when the server recovers.`
-        );
-      }
+      await this.sendToTopic(topicId,
+        buildQueuedNotice('photo', this.queue.length, this.supervisor.healthy)
+      );
     }
   }
 
@@ -1403,15 +1399,9 @@ export class TelegramLifeline {
     });
 
     if (this.shouldSendQueueAck(topicId)) {
-      if (this.supervisor.healthy) {
-        await this.sendToTopic(topicId,
-          `Server is restarting. Your file has been queued (${this.queue.length} in queue). It will be delivered when the server recovers.`
-        );
-      } else {
-        await this.sendToTopic(topicId,
-          `Server is temporarily down. Your file has been queued (${this.queue.length} in queue). It will be delivered when the server recovers.`
-        );
-      }
+      await this.sendToTopic(topicId,
+        buildQueuedNotice('file', this.queue.length, this.supervisor.healthy)
+      );
     }
   }
 

--- a/src/lifeline/queuedNotice.ts
+++ b/src/lifeline/queuedNotice.ts
@@ -1,0 +1,50 @@
+/**
+ * queuedNotice — the user-facing "your message was queued" text the lifeline
+ * sends when it cannot forward a message to the server right now.
+ *
+ * Why this is its own module (bug fix, reported by peer agent Luna/Sagemind
+ * 2026-07-17): the lifeline has TWO distinct "couldn't deliver right now"
+ * states, and they must never be conflated in the user-facing text:
+ *
+ *   - serverHealthy === false → the server is genuinely down / unreachable.
+ *       Historical wording: "Server is temporarily down. …" (accurate).
+ *
+ *   - serverHealthy === true  → the server is confirmed UP, but THIS forward
+ *       failed (a transient 10s timeout / 5xx / 503-boot / connection blip).
+ *       The old code told the user "Server is restarting." — which is false
+ *       and alarming: nothing restarted. This branch is a reconnect, not a
+ *       restart, so the notice must say so.
+ *
+ * Centralizing the wording here (instead of three inline if/else blocks in
+ * TelegramLifeline) makes the healthy-vs-down distinction a single, tested
+ * decision — the message and photo/file handlers all route through it.
+ */
+
+export type QueuedItemKind = 'message' | 'photo' | 'file';
+
+/**
+ * Build the user-facing queued-notice text.
+ *
+ * @param kind          which noun to use ("message" | "photo" | "file")
+ * @param queueLength   current number of items in the durable queue
+ * @param serverHealthy the supervisor's live health verdict at send time
+ */
+export function buildQueuedNotice(
+  kind: QueuedItemKind,
+  queueLength: number,
+  serverHealthy: boolean,
+): string {
+  const noun = kind; // 'message' | 'photo' | 'file' are already the display nouns
+  if (serverHealthy) {
+    // Healthy server + failed forward → reconnecting, NOT restarting.
+    return (
+      `I'm having trouble reaching my server right now — your ${noun} is queued ` +
+      `(${queueLength} in queue) and I'll deliver it as soon as I reconnect.`
+    );
+  }
+  // Genuinely-down server (unchanged wording — preserves the accurate message).
+  return (
+    `Server is temporarily down. Your ${noun} has been queued (${queueLength} in queue). ` +
+    `It will be delivered when the server recovers.`
+  );
+}

--- a/tests/unit/lifeline/queuedNotice.test.ts
+++ b/tests/unit/lifeline/queuedNotice.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { buildQueuedNotice } from '../../../src/lifeline/queuedNotice.js';
+
+describe('buildQueuedNotice', () => {
+  describe('healthy server + failed forward (the bug: must NOT say "restarting")', () => {
+    for (const kind of ['message', 'photo', 'file'] as const) {
+      it(`does not claim a restart when the server is healthy (${kind})`, () => {
+        const notice = buildQueuedNotice(kind, 3, /* serverHealthy */ true);
+        // The core regression guard: a confirmed-healthy server must never be
+        // reported to the user as "restarting" or "down".
+        expect(notice.toLowerCase()).not.toContain('restart');
+        expect(notice.toLowerCase()).not.toContain('temporarily down');
+        // It reflects the real state: reconnecting after a transient failure.
+        expect(notice.toLowerCase()).toContain('reconnect');
+        expect(notice).toContain(kind);
+        expect(notice).toContain('(3 in queue)');
+      });
+    }
+  });
+
+  describe('genuinely-down server (unchanged, accurate wording preserved)', () => {
+    for (const kind of ['message', 'photo', 'file'] as const) {
+      it(`still says "temporarily down" when the server is unhealthy (${kind})`, () => {
+        const notice = buildQueuedNotice(kind, 1, /* serverHealthy */ false);
+        expect(notice).toContain('Server is temporarily down.');
+        expect(notice).not.toContain('restarting');
+        expect(notice).toContain(kind);
+        expect(notice).toContain('(1 in queue)');
+        expect(notice).toContain('delivered when the server recovers');
+      });
+    }
+  });
+
+  it('produces byte-identical down-branch text to the pre-fix wording (no churn)', () => {
+    // Guards against accidental wording drift in the down branch, which existing
+    // dedup / snapshot behavior may depend on.
+    expect(buildQueuedNotice('message', 2, false)).toBe(
+      'Server is temporarily down. Your message has been queued (2 in queue). It will be delivered when the server recovers.',
+    );
+    expect(buildQueuedNotice('photo', 2, false)).toBe(
+      'Server is temporarily down. Your photo has been queued (2 in queue). It will be delivered when the server recovers.',
+    );
+    expect(buildQueuedNotice('file', 2, false)).toBe(
+      'Server is temporarily down. Your file has been queued (2 in queue). It will be delivered when the server recovers.',
+    );
+  });
+
+  it('the healthy and down notices are always distinct for the same inputs', () => {
+    for (const kind of ['message', 'photo', 'file'] as const) {
+      expect(buildQueuedNotice(kind, 5, true)).not.toBe(buildQueuedNotice(kind, 5, false));
+    }
+  });
+});

--- a/upgrades/next/lifeline-reconnect-notice.eli16.md
+++ b/upgrades/next/lifeline-reconnect-notice.eli16.md
@@ -1,0 +1,29 @@
+# Lifeline "reconnecting" notice — Plain-English Overview
+
+> The one-line version: when my server is healthy but a single message hand-off hiccups, I now tell you "I'm reconnecting, your message is queued" instead of the false, alarming "Server is restarting."
+
+## The problem in one breath
+
+The lifeline is the small always-on process that watches Telegram and hands your messages to my main server. When it can't hand a message off right now, it queues the message and sends you a heads-up. There are two very different reasons a hand-off can fail — the server is genuinely down, OR the server is perfectly healthy and just one hand-off blipped (a brief network timeout). The old code sent the SAME scary "Server is restarting. Your message has been queued…" text for BOTH cases. So when the server was confirmed up and running, you could still get told it was restarting — which never happened. It's harmless (your message is never lost — it queues and delivers) but it erodes trust, because the agent cried "restart" when nothing restarted.
+
+## What already exists
+
+- **The lifeline** — the tiny watchdog process that forwards your Telegram messages to the server and queues them if it can't. Already durable: queued messages survive and replay.
+- **The server health check** — the lifeline always knows whether the server is up (`supervisor.healthy`). That verdict was already available at the exact spot where the wrong message was sent; the code just wasn't using it to pick the right words.
+- **The genuinely-down message** — for a truly-down server the lifeline already said the accurate "Server is temporarily down…", and that wording is unchanged.
+
+## What this adds
+
+One small, tested helper (`buildQueuedNotice`) now decides the notice wording from the live health verdict. When the server is healthy but the hand-off failed, you get: "I'm having trouble reaching my server right now — your message is queued (N in queue) and I'll deliver it as soon as I reconnect." When the server is genuinely down, you get the exact same accurate "temporarily down" message as before. The three places that send this notice (text, photo, file) all route through the one helper, so they can never drift apart again.
+
+## The new pieces
+
+- **`buildQueuedNotice(kind, queueLength, serverHealthy)`** — a pure, side-effect-free function that returns the right notice text. It is NOT allowed to make any decision about delivery or restarts; it only chooses words from a health verdict it is handed. That line matters: the authority to restart still lives entirely in the existing restart machinery — this helper just describes the current state honestly.
+
+## The safeguards
+
+The genuinely-down wording is byte-for-byte identical to before (a test locks that in, so no downstream dedup behavior shifts). A unit test proves the healthy-but-failed branch never contains the words "restart" or "temporarily down", and always mentions "reconnect"; and that the two states always produce different text. Scope is deliberately tight: the drift-promoter threshold question and the callback-query down-message are explicitly out of scope and were left untouched.
+
+## What you actually need to decide
+
+Nothing risky. This is a wording/logic bug fix with no new capability, no config, no state, and no schema change. The only judgment call is the exact replacement wording, which reads in plain language and is honest about what's happening. If it turns out wrong, the back-out is a one-line revert.

--- a/upgrades/next/lifeline-reconnect-notice.md
+++ b/upgrades/next/lifeline-reconnect-notice.md
@@ -1,0 +1,34 @@
+## What Changed
+
+When the lifeline can't hand a message off to the server but the server is
+confirmed **healthy** (a transient timeout / 5xx / connection blip on a single
+forward), the queued-message notice no longer says the false, alarming
+"Server is restarting." It now reflects the real state: "I'm having trouble
+reaching my server right now — your message is queued (N in queue) and I'll
+deliver it as soon as I reconnect." The genuinely-down message
+("Server is temporarily down…") is unchanged. The message, photo, and file
+handlers all route through one shared helper (`buildQueuedNotice`) so the two
+states can't drift apart again.
+
+## What to Tell Your User
+
+If a message of yours briefly can't be delivered while my server is actually
+up, you'll now see an honest "reconnecting, your message is queued" note
+instead of a scary "Server is restarting" alarm. Nothing about delivery
+changed — your message was never lost; it queues and delivers as before. This
+only fixes the wording so it stops claiming a restart that never happened.
+
+## Summary of New Capabilities
+
+No new setting. This is a bug fix to an existing user-facing notice.
+
+## Evidence
+
+- New unit test (`tests/unit/lifeline/queuedNotice.test.ts`, 8 cases) proves the
+  healthy-but-forward-failed branch never says "restart" or "temporarily down"
+  and always says "reconnect", and that the genuinely-down wording is preserved
+  byte-for-byte.
+- Full lifeline unit suite passes (18 files / 160 tests); TypeScript build and
+  `pnpm build` are clean; exactly one "Server is restarting" string remains in
+  the compiled lifeline (the separate callback-query server-down case, out of
+  scope).

--- a/upgrades/side-effects/lifeline-reconnect-notice.md
+++ b/upgrades/side-effects/lifeline-reconnect-notice.md
@@ -1,0 +1,121 @@
+# Side-Effects Review — Lifeline "reconnecting" notice (fix false "Server is restarting")
+
+**Version / slug:** `lifeline-reconnect-notice`
+**Date:** `2026-07-17`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `Echo (Phase-5 self-review — see below)`
+
+## Summary of the change
+
+The lifeline forwards inbound Telegram messages to the server and, when it cannot forward right now, queues the message and sends the user a heads-up. There are two distinct "couldn't deliver right now" states — the server is genuinely **down** (`supervisor.healthy === false`) versus the server is **healthy but this one forward failed** (transient 10s timeout / 5xx / 503-boot / connection blip, `supervisor.healthy === true` and `forwardToServer()` returned non-`ok`). The healthy-but-failed branch was sending the user the false, alarming `Server is restarting. Your message has been queued…` even though the server was confirmed up. Reported by peer agent Luna (Sagemind) 2026-07-17, verified against source; it also hit operator Justin directly.
+
+Files touched:
+- `src/lifeline/queuedNotice.ts` (new) — a pure helper `buildQueuedNotice(kind, queueLength, serverHealthy)` that centralizes the notice wording.
+- `src/lifeline/TelegramLifeline.ts` — the four queue-ack call sites (text healthy-fail, text down, photo, file/document) now route through the helper; the two photo/file inline `if/else` blocks collapse to one call each.
+- `tests/unit/lifeline/queuedNotice.test.ts` (new) — unit coverage.
+
+## Decision-point inventory
+
+- `TelegramLifeline` queue-ack wording (text/photo/file handlers) — **modified (wording/logic only)** — picks the user-facing notice string from the live `supervisor.healthy` verdict. This is a message-*wording* decision, not a message *block/allow* or delivery decision. No gating authority added, removed, or changed.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The change never suppresses, delays, or rejects a message; it only chooses the text of a heads-up that is already being sent (still gated by the unchanged `shouldSendQueueAck` rate-limiter). Message queueing/delivery is entirely unchanged.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. The queued message still enqueues and replays exactly as before; the only behavioral delta is the words in the notice.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The wording decision belongs precisely where the send happens — the lifeline handler that already holds the `supervisor.healthy` verdict and the queue length. The new helper is a pure string builder (lowest sensible level: no I/O, no decision authority). It does not re-implement or run parallel to any existing gate; it consumes a health verdict the caller already computed. Centralizing the three previously-duplicated sites into one tested function is a strict simplification (DRY), not a new abstraction competing with an existing one.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** docs/signal-vs-authority.md
+
+- [x] No — this change has no block/allow surface.
+
+`buildQueuedNotice` holds ZERO authority: it neither restarts anything, nor decides whether to send, nor gates delivery. It is handed a health SIGNAL (`supervisor.healthy`, computed by the existing supervisor) and returns descriptive text. The authority to restart the lifeline remains entirely with the existing `RestartOrchestrator` / `LifelineDriftPromoter`; this change deliberately stops the notice from *asserting* a restart the system did not perform — i.e. it makes the user-facing text HONEST about the current state rather than claiming an action. No brittle logic gains blocking authority.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. The wording is chosen from a single, enumerable boolean (`serverHealthy` true/false) — an invariant two-state fork, not a point where multiple live signals conflict. There is no arbiter needed and none added.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none. The notice send sits after `shouldSendQueueAck` (unchanged) and does not run before/after any gate whose outcome it could mask.
+- **Double-fire:** none introduced. The version-skew path (`handleVersionSkew`, fired on a 426) is a separate code path and is untouched; this change does not add a second notice.
+- **Races:** none new. `this.queue.length` is read at send time exactly as before; no new shared state is introduced (the helper is stateless/pure).
+- **Feedback loops:** none. The text is terminal output to the user; it feeds nothing back into the forward/queue machinery.
+- **Down-branch wording preserved byte-for-byte:** the `serverHealthy === false` output is identical to the previous inline strings (locked by a test), so any downstream that keys on that exact text (e.g. the duplicate-message dedup window) sees no change.
+
+---
+
+## 6. External surfaces
+
+- **Other agents / install base:** ships in the instar package `dist/`; every agent gets the corrected wording when it updates and its lifeline restarts onto the new version. No migration needed — the lifeline is compiled package code, not an agent-installed file (`.claude/settings.json`, config defaults, CLAUDE.md template, hook scripts, or built-in skills), so `PostUpdateMigrator` is not involved.
+- **Telegram:** the only external-visible change is the improved notice text a user reads when a forward transiently fails. No API shape, topic, or delivery-path change.
+- **Persistent state:** none. No schema, ledger, or state-file change.
+- **Timing/runtime:** the branch is selected from the live `supervisor.healthy` at send time — same input the old code had at the same spot.
+- **Operator surface (Mobile-Complete):** no operator-facing actions added or touched. This is a USER-facing message, not an operator action/approval/grant surface.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable. This change touches a **user-facing** Telegram notice, not a dashboard renderer, approval page, or grant/revoke/secret-drop form. (For completeness on the user-facing text quality: the new notice leads with the real state in plain language — "I'm having trouble reaching my server right now — your message is queued (N in queue) and I'll deliver it as soon as I reconnect." — exposes no raw internals, and is honest rather than alarming.)
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN.** The lifeline is a per-machine process: each machine's lifeline forwards to that machine's own server and its `supervisor.healthy` verdict is about the local server. The notice is emitted by whichever machine actually received and tried to forward the user's message, so there is no cross-machine state to replicate or proxy. It emits a user-facing notice, but one-voice gating is not newly needed: the send is already governed by the existing per-topic `shouldSendQueueAck` rate-limiter and the pre-existing duplicate-message suppression window — this change alters only the words, not the send cadence or the number of voices. No durable state (nothing to strand on topic transfer) and no generated URLs.
+
+---
+
+## 8. Rollback cost
+
+Pure code change — revert the two source files (and the new helper/test) and ship as the next patch. No persistent state, no data migration, no agent-state repair, no user-visible regression during the rollback window (worst case is the old wording returns). One-line-scale back-out.
+
+---
+
+## Conclusion
+
+The review confirms a tightly-scoped, low-risk wording/logic fix with no decision-point authority, no block/allow surface, no persistent state, and no multi-machine coherence hazard. The design change made during review was to extract the wording into a single pure helper (rather than edit three inline strings), which both makes the fix unit-testable in isolation and removes the duplicated photo/file `if/else` — closing the "three copies drift apart" failure mode structurally. The genuinely-down wording is preserved byte-for-byte to avoid any downstream dedup/text-matching side effect. Scope was deliberately held to the three reported sites; the drift-promoter threshold question and the callback-query down-message were left untouched (flagged to the reporter as separate items). Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Echo (self, Phase-5 — the change touches the messaging/lifeline path)
+**Independent read of the artifact: concur**
+
+Concur with the review. Re-verified independently: (1) the only remaining `Server is restarting` string in `TelegramLifeline.ts` is the callback-query genuine-`!supervisor.healthy` branch (out of scope, and at least plausibly-true in a down state); (2) all four queue-ack sites now route through `buildQueuedNotice`; (3) the down-branch bytes are unchanged (test-locked); (4) no self-triggered action is added — the notice is a one-shot response to an inbound user message, not a self-firing loop. No concern raised.
+
+---
+
+## Evidence pointers
+
+- `npx tsc --noEmit` — clean (exit 0).
+- `npx vitest run tests/unit/lifeline/queuedNotice.test.ts` — 8/8 pass.
+- `npx vitest run tests/unit/lifeline/` — 18 files / 160 tests pass (no regression).
+- `pnpm build` — dist compiles; `dist/lifeline/queuedNotice.js` present; exactly 1 `Server is restarting` remains in `dist/lifeline/TelegramLifeline.js` (the intentional callback-down site).
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+Not a self-triggered controller and not a fix to an agent-authored artifact (prompt/hook/config/skill/standards text). This is a fix to compiled TypeScript runtime behavior — a one-shot, user-message-driven notice, not a loop/monitor/sentinel/reaper/scheduler/recovery path. `unbounded-self-action` class: `n/a` — one-shot user-driven action, not a self-triggered loop.


### PR DESCRIPTION
## ELI16 — Stop the lifeline crying "Server is restarting" when the server is actually fine

When a single message hand-off briefly fails but my server is up, I used to tell you "Server is restarting" — which never happened and is alarming. Now I say the honest thing: "I'm having trouble reaching my server right now — your message is queued and I'll deliver it as soon as I reconnect." Your message was never lost either way; this only fixes the wording so it stops claiming a restart that didn't occur. (Full plain-English overview: `upgrades/next/lifeline-reconnect-notice.eli16.md`.)

## What & why

The lifeline's **healthy-but-forward-failed** branch (`supervisor.healthy === true` and `forwardToServer()` returned non-`ok` — a transient 10s timeout / 5xx / 503-boot / connection blip) told the user `Server is restarting. Your message has been queued…` even though the server was **confirmed up**. Alarming and false — nothing restarted.

Reported by peer agent **Luna (Sagemind)** 2026-07-17, verified against source; it also hit operator Justin directly.

Root-cause note: at patch drift 18 (same major.minor) the handshake returns `accept-with-patch-info` → **200** (forward succeeds), so the drift is *not* what fails the forward — the notice fires on a genuine transient forward failure while healthy. The drift-promoter already has a 1h `maxDeferMs` cap and its threshold is 20 (>18), so those are separate items (left out of scope, flagged to the reporter).

## The fix

- New pure helper `src/lifeline/queuedNotice.ts` → `buildQueuedNotice(kind, queueLength, serverHealthy)` picks the wording from the live health verdict:
  - healthy + forward failed → *"I'm having trouble reaching my server right now — your message is queued (N in queue) and I'll deliver it as soon as I reconnect."* (reconnecting, **not** restarting)
  - genuinely down → the unchanged, accurate *"Server is temporarily down…"* (byte-for-byte identical)
- The text/photo/file queue-ack sites all route through the one helper, collapsing the duplicated photo/file `if/else` — the two states can't drift apart again.

## Scope held tight (non-goals)

- Drift-promoter 20-vs-18 threshold — untouched.
- Callback-query genuine-server-down message (`!supervisor.healthy`, line ~1427) — untouched (out of Luna's report; at least plausibly-true in a down state).

## Tests / evidence

- New `tests/unit/lifeline/queuedNotice.test.ts` (8 cases): healthy branch never says "restart"/"temporarily down" and always says "reconnect"; down wording preserved byte-for-byte; the two states are always distinct.
- Full lifeline unit suite green (18 files / 160 tests); `tsc --noEmit` + `pnpm build` clean; exactly one `Server is restarting` remains in the compiled lifeline (the intentional callback-down site).

Tier 1 (small/low-risk wording+logic fix). Side-effects + ELI16 artifacts included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
