### PR TITLE
fix(pool): refresh queue capability after boot

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-17T20-13-13-432Z-ws11-capability-refresh-after-queue-boot.json
+++ b/.instar/instar-dev-decisions/2026-07-17T20-13-13-432Z-ws11-capability-refresh-after-queue-boot.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-17T20:13:13.432Z",
+  "slug": "ws11-capability-refresh-after-queue-boot",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -555,6 +555,9 @@ let _confirmLocalSessionPoolClaim: ((sessionKey: string) => boolean) | null = nu
 // The custody engine (null = feature dark / gate failed / invariants violated —
 // every consumer treats null as "refused → today's fall-through").
 let _inboundQueue: import('../core/QueueDrainLoop.js').QueueDrainLoop | null = null;
+// Late-bound self-capacity refresh. The heartbeat writer is constructed before
+// the durable inbound queue, whose live handle is one of the advertised fields.
+let _refreshPoolHeartbeat: () => void = () => {};
 // Module-level handle for the machine-coherence guard (machine-coherence-guard
 // §6) so `GET /pool/machine-coherence` can read the sentinel constructed deep in
 // the mesh peer-presence wiring. Null when the guard is dark (route 503s).
@@ -19181,6 +19184,7 @@ export async function startServer(options: StartOptions): Promise<void> {
               )
               .catch(() => { /* @silent-fallback-ok — G2 eval is best-effort signal */ });
           };
+          _refreshPoolHeartbeat = refreshPool;
           refreshPool();
           const poolTimer = setInterval(refreshPool, 30_000);
           if (typeof poolTimer.unref === 'function') poolTimer.unref();
@@ -21900,6 +21904,13 @@ export async function startServer(options: StartOptions): Promise<void> {
                 const tickHandle = setInterval(() => { void _inboundQueue?.tick(); }, qcfg.drainTickMs);
                 tickHandle.unref?.();
                 console.log(pc.dim(`  [inbound-queue] engine live — tick every ${qcfg.drainTickMs}ms, tenure ${_inboundQueue.currentTenure()}`));
+                // WS1.1 capability truth is late-bound to `_inboundQueue`, but the
+                // first self heartbeat is emitted earlier in boot while that handle
+                // is still null. Refresh immediately now that durable receive is
+                // genuinely live; otherwise peers retain `ws11DeliverReceive:false`
+                // until a later beat and queue/fall through instead of forwarding
+                // during the boot window (live CROSS-MACHINE finding, 2026-07-17).
+                _refreshPoolHeartbeat();
 
                 // Survivor arm (spec §5.1, loss window 1): the machine that
                 // holds the routing role checks — once heartbeats have had a

--- a/tests/unit/ws11-dispatch-to-owner-wiring.test.ts
+++ b/tests/unit/ws11-dispatch-to-owner-wiring.test.ts
@@ -71,6 +71,13 @@ describe('WS1.1 — server wiring seams (at-rest)', () => {
     expect(serverSrc).toMatch(/seamlessnessFlags: \{[^}]*ws11DeliverReceive: !!_inboundQueue/);
   });
 
+  it('refreshes the self heartbeat immediately after the late-bound inbound queue becomes live', () => {
+    const queueBoot = serverSrc.match(
+      /_inboundQueue = new qdlMod\.QueueDrainLoop\([\s\S]{0,7000}?\[inbound-queue\] engine live[\s\S]{0,900}?_refreshPoolHeartbeat\(\);/,
+    );
+    expect(queueBoot).not.toBeNull();
+  });
+
   it('the drain spawn boundary re-checks ownership and bounces non-owner spawns to un-routable', () => {
     const seam = serverSrc.match(/_ownershipReadForDrain && _meshSelfId[\s\S]{0,400}/);
     expect(seam, 'drain spawn-boundary re-check missing').toBeTruthy();

--- a/upgrades/next/ws11-capability-refresh-after-queue-boot.md
+++ b/upgrades/next/ws11-capability-refresh-after-queue-boot.md
@@ -1,0 +1,20 @@
+# Refresh forwarding capability when the durable queue starts
+
+## What Changed
+
+When the durable inbound queue starts late in server boot, Instar now immediately refreshes the machine's pool heartbeat. Peers therefore see `ws11DeliverReceive:true` as soon as the receive path is actually live instead of retaining the earlier boot-time `false` advert.
+
+## Evidence
+
+- Added a wiring regression test that pins the heartbeat refresh immediately after successful queue construction.
+- `tests/unit/ws11-dispatch-to-owner-wiring.test.ts`: 8/8 passing.
+- TypeScript build passing.
+- Live single-agent CROSS-MACHINE reproduction: both machines had live inbound queues while the pool advert remained false, causing a known-remote-owner message to queue without custody and fall through to a duplicate local spawn.
+
+## What to Tell Your User
+
+Cross-machine message forwarding becomes ready as soon as the receiving machine's durable queue starts, closing a short boot window that could make another machine treat it as unable to receive.
+
+## Summary of New Capabilities
+
+No new user-facing control. This makes the existing cross-machine forwarding capability advertise its live state promptly and honestly.

--- a/upgrades/side-effects/ws11-capability-refresh-after-queue-boot.md
+++ b/upgrades/side-effects/ws11-capability-refresh-after-queue-boot.md
@@ -1,0 +1,78 @@
+# Side-Effects Review — WS1.1 capability refresh after queue boot
+
+**Version / slug:** `ws11-capability-refresh-after-queue-boot`
+**Date:** `2026-07-17`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `pending`
+
+## Summary of the change
+
+After `QueueDrainLoop` is successfully constructed in `src/commands/server.ts`, the existing `refreshPool()` heartbeat writer is invoked immediately. This republishes the already-existing live capability fields from their late-bound runtime handles. The change touches the cross-machine forwarding readiness decision consumed by `SessionRouter.ownerSupportsForward`; it does not alter ownership, queue custody, placement, or forwarding policy.
+
+## Decision-point inventory
+
+- `SessionRouter.ownerSupportsForward` input — pass-through — the change makes its existing authenticated heartbeat signal current immediately after queue startup.
+- Queue construction invariant — pass-through — refresh occurs only after successful construction and does not run on the queue-dark or construction-failed branches.
+
+## 1. Over-block
+
+No new block rule is added. A peer can now begin forwarding sooner after boot. The existing capability contract is handle-based (`!!_inboundQueue`): successful construction advertises receive capability, and this change advances that same signal without claiming runtime-health withdrawal. A later internal queue degradation does not currently clear the handle or withdraw the advert; that pre-existing limitation remains visible in the under-block analysis.
+
+## 2. Under-block
+
+This does not make forwarding safe when the durable queue is deliberately disabled, when the owner is unreachable, or when the owner advert is stale for other reasons. It also does not add runtime-health withdrawal after successful queue construction: if the queue later degrades internally while its handle remains assigned, peers continue to see the existing handle-based capability. Those paths remain governed by the existing queue, ownership, SpawnAdmission, degradation reporting, and owner-dark policies.
+
+## 3. Level-of-abstraction fit
+
+The fix is at the capability producer, not in `SessionRouter`: the router already consumes the correct authenticated capability. Re-deriving queue state remotely or weakening the conservative capability gate would be the wrong layer. `refreshPool()` is the single existing heartbeat authority and is reused unchanged.
+
+## 4. Signal vs authority compliance
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+
+The change refreshes an objective runtime capability signal. It neither adds a new judgment rule nor grants a low-context detector independent blocking authority. The existing deterministic gate is an enumerable compatibility invariant: do not forward into a peer that has not advertised durable receive.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. Queue construction is an objective runtime invariant, and the existing router policy remains unchanged.
+
+## 5. Interactions
+
+- **Shadowing:** no policy is shadowed; the refresh feeds the same `MachinePoolRegistry.recordHeartbeat` path as scheduled beats.
+- **Double-fire:** a scheduled beat may occur adjacent to this refresh. `recordHeartbeat` is idempotent for capability state, so the duplicate observation is harmless.
+- **Races:** refresh runs synchronously after `_inboundQueue` assignment; it cannot advertise true before construction succeeds.
+- **Feedback loops:** peer pullers consume the advert but do not mutate the local queue handle.
+
+## 6. External surfaces
+
+Other machines see the capability become true immediately rather than on a later heartbeat. No response schema, operator action, URL, persistent payload, or external-service API changes. The only behavioral consequence is that already-authorized cross-machine forwarding can start promptly.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated** — the queue's live receive capability is published through the authenticated machine-capacity heartbeat and consumed from `MachinePoolRegistry` by peers. This change explicitly closes a cross-machine boot-order gap. It emits no user-facing notice, holds no new durable state, and generates no URL.
+
+## 8. Rollback cost
+
+Pure code change: revert the refresh call and ship a patch. No data migration or agent-state repair is required. Rollback restores the prior bounded stale-false boot window.
+
+## Conclusion
+
+The change reuses the existing capability authority and changes only refresh timing. It closes the live-observed stale-false boot window without weakening the conservative version-skew gate or changing custody semantics. Clear for an independent high-risk second pass.
+
+## Second-pass review (if required)
+
+**Reviewer:** Poincare (`continuation_impl_review`)
+**Independent read of the artifact:** concur after correction — the first pass caught and removed an inaccurate claim that a later heartbeat withdraws capability after internal queue degradation; implementation timing and authority boundaries otherwise concurred.
+
+## Evidence pointers
+
+- `tests/unit/ws11-dispatch-to-owner-wiring.test.ts`
+- Live topic-3462 reproduction in topic 458, 2026-07-17 12:53 PDT.
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## What changed

- Refresh the local machine-pool heartbeat immediately after `QueueDrainLoop` becomes live.
- Add a source-wiring regression test that locks the refresh behind queue construction and wiring.
- Record the upgrade note and reviewed side-effects artifact.

## Why

During a live two-machine ownership proof, the first heartbeat was emitted before the inbound queue existed. The machine therefore advertised `ws11=false` and `ws12=false` for the remainder of the heartbeat interval. A non-owner received a real message during that window, treated the converged owner as incapable, and spawned a duplicate local session.

The existing queue and pool substrate was correct; its readiness advertisement was stale because of boot ordering.

## Impact

Once the queue is constructed, the machine immediately advertises its real WS11/WS12 capability. Cross-machine dispatch can use the converged owner without waiting for the next periodic heartbeat, closing the observed duplicate-spawn window.

## Validation

- 42 targeted unit/integration tests passed (`ws11-dispatch-to-owner-wiring`, `SessionRouter`, `peer-presence-roundtrip`).
- `npm run lint` passed (report-only pre-existing warnings only).
- `npm run build` passed.
- Live candidate deployment on both test machines immediately changed advertised readiness to `ws11=true`, `ws12=true`.
- Follow-up real-topic ingress forwarded to the remote owner with no local duplicate spawn.
- Independent high-risk review concurred on the final artifact after one documentation correction.

## Review protocol

Echo confirmed line-by-line review of exact head `06ba5f71d1920c54aa0710d79faab579e70e034d`; arm only while that head remains exact.

## ELI16 — Machines advertise their real readiness as soon as startup finishes

Two machines could both be healthy, but one briefly advertised that it could not receive forwarded work because its first status update happened too early in startup. This refreshes that status as soon as the queue is ready, preventing the other machine from mistakenly starting a duplicate session during that window.
