### PR TITLE
fix(pool): resolve scoped peers over mesh endpoints

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-17T20-29-11-861Z-pool-scope-multi-rope-endpoints.json
+++ b/.instar/instar-dev-decisions/2026-07-17T20-29-11-861Z-pool-scope-multi-rope-endpoints.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-17T20:29:11.861Z",
+  "slug": "pool-scope-multi-rope-endpoints",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 9,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -21022,11 +21022,16 @@ export async function startServer(options: StartOptions): Promise<void> {
             const h = coordinator.getSyncStatus().leaseHolder;
             return h && h !== meshSelfId ? peerUrl(h) : null;
           };
+          // Pool-scope readers must use the same validated multi-rope resolver as
+          // routing and lease traffic. A freshly enrolled peer can have live
+          // LAN/Tailscale endpoints without the legacy lastKnownUrl field; the
+          // old filter silently omitted that online machine from every pool view.
           _resolvePeerUrls = () =>
             meshIdMgr
               .getActiveMachines()
-              .filter((m) => m.machineId !== meshSelfId && !!m.entry.lastKnownUrl)
-              .map((m) => ({ machineId: m.machineId, url: m.entry.lastKnownUrl as string }));
+              .filter((m) => m.machineId !== meshSelfId)
+              .map((m) => ({ machineId: m.machineId, url: peerUrl(m.machineId) }))
+              .filter((m): m is { machineId: string; url: string } => m.url != null);
           // EVERY registered non-revoked machine — URL or not — so the /guards
           // pool view can account for each by name (no-known-url is a NAMED row,
           // never a silent omission — GUARD-POSTURE-ENDPOINT-SPEC §2.3).

--- a/tests/unit/peer-presence-wiring.test.ts
+++ b/tests/unit/peer-presence-wiring.test.ts
@@ -49,10 +49,19 @@ describe('server-boot wiring: PeerPresencePuller (HTTP presence transport)', () 
     expect(block).toContain('peerPresenceTimer.unref');
   });
 
-  it('resolves each peer URL via the shared peerUrl helper (lastKnownUrl)', () => {
+  it('resolves each peer URL via the shared multi-rope peerUrl helper', () => {
     const ctorIdx = src.indexOf('new presenceMod.PeerPresencePuller(');
     const block = src.slice(ctorIdx, ctorIdx + 900);
     expect(block).toContain('peerUrl(m.machineId)');
     expect(block).toContain('selfMachineId: meshSelfId');
+  });
+
+  it('uses the shared multi-rope resolver for pool-scope fanout too', () => {
+    const resolverIdx = src.indexOf('_resolvePeerUrls = () =>');
+    expect(resolverIdx).toBeGreaterThan(0);
+    const block = src.slice(resolverIdx, resolverIdx + 600);
+    expect(block).toContain('peerUrl(m.machineId)');
+    expect(block).not.toContain('!!m.entry.lastKnownUrl');
+    expect(block).not.toContain('url: m.entry.lastKnownUrl');
   });
 });

--- a/upgrades/next/pool-scope-multi-rope-endpoints.md
+++ b/upgrades/next/pool-scope-multi-rope-endpoints.md
@@ -1,0 +1,12 @@
+## What Changed
+
+Pool-wide sessions, jobs, attention, and subscription views now discover peers through the same validated LAN/Tailscale/Cloudflare endpoint resolver used by routing and lease traffic. A reachable enrolled machine is no longer silently omitted merely because it lacks the legacy `lastKnownUrl` field.
+
+## What to Tell Your User
+
+Pool-wide dashboard and API views now include reachable enrolled machines across their available mesh connections, even when those machines do not have a legacy URL recorded.
+
+## Summary of New Capabilities
+
+- Pool-scope sessions, jobs, attention, and subscription reads share the validated multi-rope peer resolver.
+- Existing per-peer authentication, timeouts, cache behavior, and honest failure markers remain unchanged.

--- a/upgrades/side-effects/pool-scope-multi-rope-endpoints.md
+++ b/upgrades/side-effects/pool-scope-multi-rope-endpoints.md
@@ -1,0 +1,79 @@
+# Side-Effects Review — Pool-scope multi-rope endpoint resolution
+
+**Version / slug:** `pool-scope-multi-rope-endpoints`
+**Date:** `2026-07-17`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `independent high-risk review — CONCUR, no required fixes`
+
+## Summary of the change
+
+The server's shared `resolvePeerUrls` callback now resolves every active remote
+machine through the existing `peerUrl` helper instead of filtering exclusively
+on the legacy `lastKnownUrl` field. That helper already delegates to
+`PeerEndpointResolver`, which validates and prioritizes enrolled LAN,
+Tailscale, and Cloudflare endpoints. Every route that consumes
+`resolvePeerUrls` therefore sees the same reachable peer set as routing and
+lease traffic.
+
+The live single-agent CROSS-MACHINE failure was a reachable Mini with enrolled
+LAN/Tailscale endpoints but no `lastKnownUrl`: four `?scope=pool` surfaces
+returned HTTP 200 with `peersQueried=0` and no failure marker.
+
+## Decision-point inventory
+
+1. Active remote machine resolves to a validated endpoint: include it in pool
+   fanout. Pinned by source-wiring regression and real two-machine proof.
+2. Active remote machine has no resolvable endpoint: omit it from the URL list,
+   preserving the callback's typed contract and preventing an invalid request.
+3. Self machine: exclude it, preserving the no-recursive-self fanout invariant.
+4. Endpoint priority, subnet validation, health scoring, and fallback selection:
+   unchanged and owned by the existing `PeerEndpointResolver`.
+5. Route-specific timeout, failure markers, merge behavior, auth, and cache:
+   unchanged; only peer discovery is corrected.
+
+## Over-block / Under-block
+
+Over-block risk is limited to a peer whose enrolled endpoints all fail the
+existing resolver's validation or health policy; it remains absent exactly as
+an unusable legacy URL was absent. Under-block risk is that a resolver-selected
+endpoint later fails during the route fetch; each pool surface already contains
+that fault as an explicit per-peer failure rather than failing the whole view.
+
+One limitation remains: `resolvePeerUrls` returns only resolvable peers, so a
+registered machine with no usable endpoint is not itself represented as a
+named `no-known-url` failure on these routes. `/guards?scope=pool` has a wider
+accounting roster for that purpose. This change fixes the demonstrated silent
+omission of a machine that *does* have usable enrolled endpoints.
+
+## Level-of-abstraction fit / Signal vs authority
+
+The change is at the single shared peer-discovery boundary used by all
+pool-scope routes, not duplicated into individual routes. Endpoint selection is
+connectivity signal used for read-only fanout; it does not grant ownership,
+write authority, or placement authority. Existing authenticated peer requests
+and route-local authorization remain unchanged.
+
+**Reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+## External surfaces / Rollback
+
+External behavior changes only for `?scope=pool` and other existing consumers
+of `resolvePeerUrls`: enrolled peers can now contribute through non-legacy mesh
+ropes. No schema, config, state, migration, secret, or destructive action is
+introduced. Rollback is the isolated resolver callback change.
+
+## Evidence pointers
+
+- `tests/unit/peer-presence-wiring.test.ts` pins that pool discovery calls the
+  shared `peerUrl` helper and forbids the legacy-only filter/mapping.
+- 34/34 focused tests passed across peer-presence wiring and sessions/jobs/
+  attention/subscription pool-scope integration suites.
+- `npm run build` passed on Instar 1.3.863.
+- Live candidate on the Laptop against the real Mini changed all four surfaces
+  from `peersQueried=0` to `peersQueried=1`, `peersOk=1`, `failed=[]`; jobs and
+  attention returned rows stamped with both machine IDs.
+- Filed live defect: `fb-3b3996dd-374`.
+- Independent review concurred that the change reuses the validated endpoint
+  authority at a read-only boundary, preserves self/active/null filtering and
+  route-local auth/failure handling, and honestly states the unresolved-peer
+  omission limitation.


### PR DESCRIPTION
## What changed

- Resolve pool-scope peers through the existing validated multi-rope `peerUrl` helper.
- Remove the legacy-only `lastKnownUrl` filter that silently excluded enrolled LAN/Tailscale peers.
- Add a wiring regression, release note, and reviewed side-effects artifact.

## Why

During the live single-agent CROSS-MACHINE Stage 3 matrix, both machines were online and mutually reachable, and both advertised WS44 live. Sessions, jobs, attention, and subscription pool views nevertheless returned HTTP 200 with `peersQueried=0`, `peersOk=0`, and no failure marker. The Mini had valid enrolled LAN/Tailscale endpoints but no legacy `lastKnownUrl`.

## Impact

All existing consumers of `resolvePeerUrls` now discover the same active reachable peers as routing and lease traffic. Endpoint validation, priority, health ordering, authentication, timeouts, caching, and route-local failure handling are unchanged.

## Validation

- 34/34 focused tests passed across peer-presence wiring and four pool-scope integration suites.
- `npm run build` passed.
- `npm run lint` passed (report-only pre-existing warnings only).
- Live Laptop candidate against the real Mini changed all four surfaces to `peersQueried=1`, `peersOk=1`, `failed=[]`; jobs and attention contained both machine IDs.
- Independent high-risk review concurred with no required fixes.
- Live defect: `fb-3b3996dd-374`.

## Review protocol

Echo confirmed line-by-line review of exact head `8e77b5d7ca5a176d15f652b7b18325f1eacfc390`; arm only while that head remains exact.

## ELI16 — Every pooled view uses the same healthy route between machines

The machines could talk over their local-network or Tailscale addresses, but several pooled dashboards still looked only for an older single URL field and therefore acted as if no peer existed. This makes those views use the same validated route selection as messaging and lease traffic, so online peers consistently appear everywhere.
