### PR TITLE
docs(apprenticeship): CMT-872 program concepts + fundamental-gap defect-matrix template

### DIFF
--- a/docs/apprenticeship/DEFECT-MATRIX-TEMPLATE.md
+++ b/docs/apprenticeship/DEFECT-MATRIX-TEMPLATE.md
@@ -1,0 +1,62 @@
+# Apprenticeship Defect-Matrix Entry Template (fundamental-gap schema)
+
+Status: canonical (operator directive, topic 29723, 2026-07-17). Delivered under CMT-872.
+Relates-to: `docs/apprenticeship/PROGRAM-CONCEPTS.md` (concept 4), `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md`
+
+Every drive that observes mentee defects keeps a defect matrix. This template defines
+the REQUIRED shape of every entry. **A defect without the three fundamental-gap fields
+is incomplete and does not count as logged** — the same way a feature without tests is
+incomplete. Tracking is not diagnosis; the schema forces the diagnosis.
+
+## Entry template
+
+```markdown
+## Defect #N — <one-line title naming the failure>
+
+- **Observed:** <date/time, machine, session — what actually happened, concretely>
+- **Impact:** <what the failure cost: silent stall duration, lost work, user-visible gap>
+- **In whose machinery:** <mentee's own feature / inherited instar surface / external>
+- **Nudge record:** <if the drive nudged: count, timestamps, delivery EVIDENCE (pane
+  capture or ack — never sender exit code), outcome>
+
+### Fundamental-gap analysis (REQUIRED — entry is incomplete without all three)
+
+1. **Infra gap** — What is lacking in current infrastructure that allowed this gap?
+2. **Sentinel verdict** — Does this signal a FAILING sentinel or a MISSING one?
+   (Name the sentinel, or name the absence.)
+3. **Standard gap** — What standard would have guided past development to close this
+   class ahead of time? (Name the existing standard that should have caught it, or the
+   standard that needs to exist.)
+
+### Disposition
+- <who owns the fix (mentee-owned per nudge protocol, or substrate-level), current
+  state: open / diagnosed / fixed / verified, and the evidence reference>
+```
+
+## Rules
+
+1. **The three questions are fields, not prose suggestions.** A reviewer (or the
+   overseer) rejects an entry that leaves any of the three unanswered. This converts
+   operator-level questioning into schema — Structure > Willpower applied to judgment.
+2. **The mentee owns the diagnosis of defects in his own machinery** (nudge protocol:
+   the observer names THAT a stall happened, never why or how to fix it). The matrix
+   entry's fundamental-gap fields are the OUTER loop's independent analysis; the
+   mentee's own diagnosis is recorded in the disposition when it lands.
+3. **Delivery evidence over sender claims.** Any nudge or cross-agent action recorded
+   in an entry cites observable evidence (pane capture, authenticated ack, registry
+   read) — never the sender's exit code or intention (anti-confabulation discipline).
+4. **Root-gap findings feed standards.** When field 3 names a missing standard, the
+   drive opens a tracked item (spec draft, commitment, or evolution action) — a named
+   gap with no tracked loop is a deferral, and Deferral = Deletion.
+
+## Origin
+
+Operator directive (Justin, topic 29723, 2026-07-17), verbatim intent: when observing a
+mentee failure, the immediate questions are "what is lacking in your current
+infrastructure that allowed this gap? Does this signal that a current sentinel is
+failing or that a new sentinel is needed? Is there anything lacking in our Instar
+standards that would have guided past development in a way that would have closed this
+gap ahead of time?" — standardized here so the program approaches issues at the
+fundamental-gap level rather than bandaiding specific instances. First entry logged in
+the new schema: drive-5 defect #9 (interrupted-conversation stall, 2026-07-17 → the
+stall-coverage-matrix standard draft).

--- a/docs/apprenticeship/PROGRAM-CONCEPTS.eli16.md
+++ b/docs/apprenticeship/PROGRAM-CONCEPTS.eli16.md
@@ -1,0 +1,50 @@
+# ELI16 — Apprenticeship program: the core ideas, written down once
+
+## What this change actually is
+
+Two new documentation files, nothing else. No code changes, no behavior changes, no
+new features turning on anywhere.
+
+For the last few days the apprenticeship program (one agent, Echo, mentoring another
+agent, Codey, while Codey does real development work) has been steered by ideas the
+operator stated in chat: what the program is for, what "phasing out" means, and how to
+analyze failures properly. Chat history is a terrible place for load-bearing ideas —
+every new session has to re-derive them, and a paraphrase drifts a little each time.
+This change writes them down once, canonically, in the repo the program lives in.
+
+## What the two files say
+
+**PROGRAM-CONCEPTS.md** captures five operator-ratified ideas:
+
+1. When the mentee improves Instar, he upgrades BOTH agents — the mentee isn't just
+   fixing his own tooling, he's rebuilding the shared platform both agents run on.
+2. The mentor's current advantage is temporary (Instar was built Claude-first). The
+   end goal is parity for every framework. What stays different on purpose is the
+   ROLES: one observer, one worker — that separation is where the leverage comes from.
+3. Each layer teaches its role downward: the operator teaches the mentor how to think
+   like an operator, the same way the mentor teaches the mentee. "Phasing out" means
+   moving up a layer, not disappearing.
+4. A logged failure isn't done until three questions are answered: what infrastructure
+   gap allowed it? Is a watchdog failing, or missing entirely? What standard would have
+   prevented the whole class ahead of time?
+5. Two research ideas (hidden test batteries, high rejection rates) are adopted only in
+   bounded, operator-reviewed form.
+
+**DEFECT-MATRIX-TEMPLATE.md** turns idea 4 into a form: every defect entry in a drive's
+tracking matrix must answer those three questions as required fields, or it doesn't
+count as logged. It also requires evidence (a screen capture, an acknowledgment) for
+any claimed cross-agent action — never just "I sent it."
+
+## What you need to decide
+
+Whether these written framings match what the operator actually meant. They were
+drafted directly from the operator's own messages (topic 29723, July 16-17) and are
+labeled with that origin. If a framing is off, editing the doc is the whole fix —
+there is no code depending on the wording.
+
+## Safeguards, in plain terms
+
+Docs only. Nothing reads these files at runtime. Wrong wording costs an edit, not an
+outage. The riskiest thing about this change is that a future reader treats a
+mis-stated concept as the operator's intent — which is why each section cites its
+origin (operator, topic, date) so it can be checked against the source.

--- a/docs/apprenticeship/PROGRAM-CONCEPTS.md
+++ b/docs/apprenticeship/PROGRAM-CONCEPTS.md
@@ -1,0 +1,74 @@
+# Apprenticeship Program — Core Concepts (operator-ratified framings)
+
+Status: canonical (operator-ratified, topic 29723, 2026-07-16/17)
+Origin: operator directives, topic 29723, 2026-07-16/17 (Justin). Delivered under CMT-872.
+Relates-to: `docs/specs/APPRENTICESHIP-PROGRAM-PROJECT-DESIGN.md`, `docs/specs/framework-stall-coverage-matrix.md` (draft)
+
+These are the program's load-bearing concepts, stated once, canonically, so no drive
+re-derives them from chat history. Each earned its place through live program evidence.
+
+## 1. Mutual substrate improvement (why our loop is stronger than the paper's)
+
+The Weco "first evidence of recursive self-improvement" architecture is two loops: an
+inner agent doing object-level work under a budget, an outer agent rewriting the inner
+agent's machinery, keeping changes only when they beat held-out evaluation.
+
+The apprenticeship program has the same shape with one structural upgrade: **the inner
+agent (mentee) is not just rebuilding his own machinery — he is rebuilding Instar
+itself, the shared substrate BOTH agents run on.** Every merged improvement upgrades
+mentor and mentee alike. Their outer loop improves the inner agent; ours has the inner
+agent improving both agents, gated by the outer. The evaluation gate (review, promotion
+on evidence) is what keeps this recursion safe.
+
+## 2. Role asymmetry, not capability asymmetry
+
+The mentor's advantage today (Instar was built Claude-first) is **temporary debt, not a
+moat**. The program's explicit end state is **framework parity**: any onboarded
+framework fully powers an Instar agent with no structural disadvantage.
+
+What deliberately REMAINS asymmetric is the **roles**: one agent as observer/director,
+one as worker. The separation itself is the leverage — the observer sees what the
+worker cannot (his own stalls, his own blind spots), and collaboration across the
+boundary is where the development speed comes from. Running the two roles on different
+model families adds genuine diversity of judgment on top. Equivalent agents, distinct
+roles, different intelligences: all three properties are intended and none implies the
+others.
+
+## 3. Fractal role-teaching (each layer phases itself upward)
+
+The program teaches roles downward one layer at a time: the operator teaches the mentor
+how to perform the operator's role (the questioning, the standards-level judgment)
+exactly as the mentor teaches the mentee how to perform the mentor's role. "Phasing
+out" means each layer's occupant moves UP a layer as its student becomes independent —
+the mentee becomes his own observer, the mentor inherits more of the operator's role.
+Independence is measured on the instance ladder (R0–R5) with evidence, never assumed.
+
+## 4. Defect entries REQUIRE fundamental-gap analysis (the three questions)
+
+Operator directive, 2026-07-17: observing a mentee failure and logging it is tracking,
+not diagnosis. **Every defect entering a drive's defect matrix MUST carry three fields
+before it counts as logged:**
+
+1. **Infra gap** — what is lacking in current infrastructure that allowed this?
+2. **Sentinel verdict** — does this signal a FAILING sentinel or a MISSING one?
+3. **Standard gap** — what standard would have guided past development to close this
+   class ahead of time?
+
+A defect without root-gap analysis is incomplete, the same way a feature without tests
+is incomplete. This converts the operator's questioning into schema (Structure >
+Willpower applied to judgment itself). First entry in the new schema: drive-5 defect #9
+(interrupted-conversation stall → the stall-coverage-matrix standard).
+
+## 5. Evaluation cautions (operator-bounded)
+
+Two ideas from the recursive-self-improvement literature are adopted only in bounded
+form, per operator review (2026-07-17):
+
+- **Hidden/held-out testing**: any undisclosed test battery must be shown to the
+  operator BEFORE anything hangs on it, and framed as **tripwires, not targets** —
+  regression detection on behaviors already valued, never a score that defines growth.
+  Risk being managed: boxing in growth via narrow metrics.
+- **Rejection-rate discipline**: a research lab's ~90% discard rate does not transfer —
+  program work is need-driven, and spec review is where rejection already lives. The
+  retained piece: **promotion evidence must span multiple cycles, never one good day**
+  (already the ladder's rung-evidence requirement).

--- a/upgrades/next/cmt872-apprenticeship-concepts.md
+++ b/upgrades/next/cmt872-apprenticeship-concepts.md
@@ -1,0 +1,30 @@
+<!-- internal-only -->
+
+# CMT-872 — Apprenticeship program concepts + defect-matrix template (docs)
+
+## What Changed
+
+Two new documentation files under `docs/apprenticeship/`:
+
+- `PROGRAM-CONCEPTS.md` — the five operator-ratified core concepts of the
+  apprenticeship program (mutual substrate improvement; role-not-capability
+  asymmetry; framework parity as the explicit end-goal; fractal role-teaching;
+  bounded evaluation cautions), stated once canonically with origin citations
+  (topic 29723, 2026-07-16/17) so no drive re-derives them from chat history.
+- `DEFECT-MATRIX-TEMPLATE.md` — the required entry shape for drive defect
+  matrices: every defect entry must answer the three fundamental-gap questions
+  (infra gap / sentinel verdict / standard gap) before it counts as logged,
+  with delivery-evidence rules for any recorded cross-agent action.
+
+Documentation only — no runtime code, no behavior change, no new features.
+
+## Evidence
+
+- Both files carry explicit origin citations to the operator directives they
+  encode (topic 29723, 2026-07-16/17).
+- Side-effects review: `upgrades/side-effects/cmt872-apprenticeship-concepts.md`
+  (docs-only conclusion, Tier 1).
+- ELI16 companion: `docs/apprenticeship/PROGRAM-CONCEPTS.eli16.md`.
+- First entry already logged in the new schema: drive-5 defect #9
+  (interrupted-conversation stall, 2026-07-17), recorded in the drive's matrix
+  addendum with all three fields answered.

--- a/upgrades/side-effects/cmt872-apprenticeship-concepts.md
+++ b/upgrades/side-effects/cmt872-apprenticeship-concepts.md
@@ -1,0 +1,44 @@
+# Side-Effects Review — CMT-872 apprenticeship program concepts + defect-matrix template
+
+**Change:** two new documentation files — `docs/apprenticeship/PROGRAM-CONCEPTS.md`
+(five operator-ratified program concepts) and `docs/apprenticeship/DEFECT-MATRIX-TEMPLATE.md`
+(required fundamental-gap fields on defect entries) — plus this artifact and the ELI16
+companion. Documentation-only; no runtime surface.
+
+## Phase 1 — Principle check
+
+Does this change involve a decision point (gating information flow, blocking actions,
+filtering messages, constraining agent behavior)? **No.** It is a data-model-free
+documentation change. No code reads these files. The defect-matrix "requirement" is a
+process convention enforced by drive reviewers (minds), not by any hook or gate (no
+enforcement code is added or modified). Signal-vs-authority does not apply — nothing
+here holds or delegates authority.
+
+## The eight questions
+
+1. **Over-block** — No issue identified. Nothing is blocked; no executable surface.
+2. **Under-block** — No issue identified. The template's "required fields" rule relies
+   on drive-review discipline, not enforcement; that is deliberate (judgment-layer
+   convention, documented as such). If the program later wants structural enforcement,
+   that would be a separate speced change to whatever tool ingests the matrix.
+3. **Level-of-abstraction fit** — Correct layer: program-level docs live in
+   `docs/apprenticeship/` beside RETRO-HARVEST-PROCEDURE.md. The concepts intentionally
+   do NOT live in a spec (they are ratified framings, not a buildable design); the
+   stall-coverage-matrix STANDARD referenced by concept 4 remains a separate spec draft
+   going through /spec-converge on its own track.
+4. **Signal vs authority compliance** — N/A; no detector, no authority, no blocking
+   logic added.
+5. **Interactions** — No issue identified. No existing doc claims to be the canonical
+   concepts statement (checked docs/apprenticeship/ and docs/specs/APPRENTICESHIP-*);
+   the new files cite and link the existing project-design spec rather than shadowing it.
+6. **External surfaces** — Visible to any agent/human reading the repo. Content is
+   operator-ratified framing with origin citations (topic 29723, dates); no secrets, no
+   PII beyond the operator's first name already used throughout the repo's docs.
+7. **Multi-machine posture** — Machine-agnostic BY DESIGN: git-tracked documentation
+   replicates via the repo itself; no machine-local state, no notices, no URLs.
+8. **Rollback cost** — `git revert` of one docs-only commit. No data migration, no
+   agent state, no release-behavior dependency.
+
+## Conclusion
+
+Documentation-only, no runtime surface, rollback is a one-commit revert. Tier 1.


### PR DESCRIPTION
## What Changed

Two new documentation files under `docs/apprenticeship/`:

- **PROGRAM-CONCEPTS.md** — the five operator-ratified core concepts of the apprenticeship program (mutual substrate improvement; role-not-capability asymmetry; framework parity end-goal; fractal role-teaching; bounded evaluation cautions), stated once with origin citations (topic 29723, 2026-07-16/17).
- **DEFECT-MATRIX-TEMPLATE.md** — required entry shape for drive defect matrices: the three fundamental-gap questions (infra gap / sentinel verdict / standard gap) are required fields; delivery-evidence rules for recorded cross-agent actions.

Docs only. No runtime surface. Tier 1 (ELI16 + side-effects artifact staged).

## ELI16 — The program's core ideas, written down once instead of living in chat

For days the apprenticeship program (Echo mentoring Codey while Codey does real development) has been steered by ideas the operator stated in chat messages: what the program is for, what "phasing out" means, and how failures must be analyzed. Chat history is a terrible home for load-bearing ideas — every new session re-derives them and drifts a little each time. This change writes them down once, canonically, in the repo. The second file turns the operator's three diagnostic questions ("what infrastructure gap allowed this? is a watchdog failing or missing? what standard would have prevented the class?") into required form fields on every logged defect, so tracking without diagnosis no longer counts as logged. Nothing reads these files at runtime; wrong wording costs an edit, not an outage.

## Evidence

- Side-effects review: `upgrades/side-effects/cmt872-apprenticeship-concepts.md` (docs-only conclusion)
- ELI16 companion: `docs/apprenticeship/PROGRAM-CONCEPTS.eli16.md`
- Release fragment (internal-only): `upgrades/next/cmt872-apprenticeship-concepts.md`
- First entry in the new schema already logged: drive-5 defect #9 (2026-07-17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)