### PR TITLE
fix continuation expiry recovery

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-18T03-36-00-000Z-continuation-expiry-recovery.json
+++ b/.instar/instar-dev-decisions/2026-07-18T03-36-00-000Z-continuation-expiry-recovery.json
@@ -1,0 +1,19 @@
+{
+  "ts": "2026-07-18T03:36:00.000Z",
+  "slug": "continuation-expiry-recovery",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 98,
+  "causalAutopsy": {
+    "defect": "An expired Codex continuation ledger could only be recovered by recreating its task list, and the continuation CLI could not authenticate after token externalization.",
+    "rootCause": "The API exposed start/complete/stop but no generation-ordered renewal primitive, while the CLI assumed authToken was an inline string.",
+    "fix": "Add an explicit audited renew operation that preserves checklist state, expose expiry timestamps, and resolve INSTAR_AUTH_TOKEN before config fallback.",
+    "prevention": "Unit coverage pins renewal after expiry, completed-task preservation, fresh session binding, and successful continuation of the new generation."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-18T03-43-49-661Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T03-43-49-661Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-18T03:43:49.661Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 9,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/continuation-expiry-recovery.eli16.md
+++ b/docs/specs/continuation-expiry-recovery.eli16.md
@@ -1,0 +1,9 @@
+# Continuation expiry recovery — ELI16 overview
+
+Codex can keep an ordinary task moving across turn boundaries by using a local continuation ledger. That ledger is deliberately bounded: it has a maximum number of continuations and a wall-clock deadline. When either limit is reached, the Stop hook allows the session to stop. Those limits are important because a forgotten task must not turn into an endless self-driving loop.
+
+The missing piece was safe renewal. After a real four-hour drive crossed its deadline, the hook correctly stopped it, but the only practical recovery was to rebuild the checklist or edit local state. Rebuilding risks losing which tasks are already complete; editing a timestamp bypasses the generation ordering and audit trail that make operator stop authoritative. The CLI also failed after authentication moved out of the config file because it still assumed the token was stored inline.
+
+This change adds an explicit renew operation. Renewal reads the structurally valid existing ledger, verifies that work remains, mints a higher generation than the ledger and every stop marker, keeps the checklist byte-for-byte, resets only the bounded time and continuation counters, and waits for the next Stop hook to bind the new session. It records `renewed` in the audit trail so renewal is distinguishable from a brand-new start. Status now exposes both start and expiry timestamps, returning no expiry rather than throwing if old state contains a bad date. The CLI resolves the externalized environment token first while retaining compatibility with older inline configuration.
+
+The safety contract is unchanged: renewal is an explicit authenticated write, all requested limits remain clamped to configuration, operator-stop generations still outrank older work, malformed state is refused, and no automatic component renews a ledger. The result is a safe button for extending an intentional drive, not an unbounded loop.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -272,11 +272,15 @@ const program = new Command();
 
 async function callLocalContinuation(pathname: string, method = 'GET', body?: unknown): Promise<unknown> {
   const cfgPath = path.join(process.cwd(), '.instar', 'config.json');
-  const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8')) as { port?: number; authToken?: string };
+  const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8')) as { port?: number; authToken?: string | { env?: string } };
+  const configuredToken = typeof cfg.authToken === 'string'
+    ? cfg.authToken
+    : (cfg.authToken?.env ? process.env[cfg.authToken.env] : undefined);
+  const authToken = process.env.INSTAR_AUTH_TOKEN ?? configuredToken ?? '';
   const response = await fetch(`http://127.0.0.1:${cfg.port ?? 4040}${pathname}`, {
     method,
     headers: {
-      Authorization: `Bearer ${cfg.authToken ?? ''}`,
+      Authorization: `Bearer ${authToken}`,
       ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
     },
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
@@ -426,6 +430,18 @@ continuationCmd
 continuationCmd.command('status <topic>').action(async (topic) => {
   console.log(JSON.stringify(await callLocalContinuation(`/continuation/${encodeURIComponent(topic)}/status`)));
 });
+
+continuationCmd
+  .command('renew <topic>')
+  .description('Mint a fresh bounded generation while preserving the existing task checklist')
+  .option('--duration <seconds>', 'Duration ceiling', (v: string) => Number(v))
+  .option('--max-continuations <count>', 'Turn ceiling', (v: string) => Number(v))
+  .action(async (topic, opts) => {
+    console.log(JSON.stringify(await callLocalContinuation(`/continuation/${encodeURIComponent(topic)}/renew`, 'POST', {
+      durationSeconds: opts.duration,
+      maxContinuations: opts.maxContinuations,
+    })));
+  });
 
 continuationCmd.command('complete <topic> <ordinal>').action(async (topic, ordinal) => {
   console.log(JSON.stringify(await callLocalContinuation(`/continuation/${encodeURIComponent(topic)}/complete`, 'POST', { ordinal: Number(ordinal) })));

--- a/src/core/CodexTaskContinuationStore.ts
+++ b/src/core/CodexTaskContinuationStore.ts
@@ -158,6 +158,43 @@ export class CodexTaskContinuationStore {
     });
   }
 
+  /** Explicitly mint a fresh bounded generation for the existing task body.
+   * This is the supported recovery path after a duration expiry; callers must
+   * never hand-edit startedAt because that bypasses generation/audit ordering. */
+  renew(topicId: string, input: {
+    sessionId?: string;
+    durationSeconds?: number;
+    maxContinuations?: number;
+  } = {}): ContinuationLedger {
+    if (!this.cfg.enabled) throw new Error('continuation-disabled');
+    if (!/^\d+$/.test(topicId)) throw new Error('invalid-owner');
+    return this.withNamedLock('maintenance', () => this.withLock(topicId, () => {
+      const prior = this.requireValid(topicId);
+      const tasks = parseContinuationTasks(prior.body);
+      if (tasks.length === 0 || tasks.every((task) => !task.open)) throw new Error('no-open-tasks');
+      const tombstone = this.readTombstone(topicId);
+      const generationBase = Math.max(prior.generation, tombstone, this.readGlobalTombstone());
+      if (!Number.isSafeInteger(generationBase) || generationBase >= Number.MAX_SAFE_INTEGER) throw new Error('operator-stop');
+      const now = new Date().toISOString();
+      const ledger: ContinuationLedger = {
+        ...prior,
+        active: true,
+        sessionId: input.sessionId?.trim() || FIRST_STOP_BIND,
+        generation: generationBase + 1,
+        generationId: randomUUID(),
+        startedAt: now,
+        durationSeconds: Math.max(1, Math.min(input.durationSeconds ?? this.cfg.maxDurationSeconds, this.cfg.maxDurationSeconds)),
+        continuationCount: 0,
+        maxContinuations: Math.max(1, Math.min(input.maxContinuations ?? this.cfg.maxContinuations, this.cfg.maxContinuations)),
+        updatedAt: now,
+      };
+      this.write(ledger);
+      try { this.audit(ledger, 'allow', 'open-tasks', tasks.filter((task) => task.open).length, 0); }
+      catch (err) { ledger.active = false; this.write(ledger); throw err; }
+      return ledger;
+    }));
+  }
+
   read(topicId: string): ContinuationLedger | null {
     try {
       const parsed = JSON.parse(fs.readFileSync(this.ledgerPath(topicId), 'utf8')) as ContinuationLedger;

--- a/src/core/CodexTaskContinuationStore.ts
+++ b/src/core/CodexTaskContinuationStore.ts
@@ -39,6 +39,7 @@ export type ContinuationReason =
   | 'continuation-ceiling'
   | 'no-task-structure'
   | 'all-tasks-complete'
+  | 'renewed'
   | 'open-tasks'
   | 'audit-failed'
   | 'lock-unavailable';
@@ -189,7 +190,7 @@ export class CodexTaskContinuationStore {
         updatedAt: now,
       };
       this.write(ledger);
-      try { this.audit(ledger, 'allow', 'open-tasks', tasks.filter((task) => task.open).length, 0); }
+      try { this.audit(ledger, 'allow', 'renewed', tasks.filter((task) => task.open).length, 0); }
       catch (err) { ledger.active = false; this.write(ledger); throw err; }
       return ledger;
     }));

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -775,6 +775,7 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
       endpoints: [
         'GET /continuation/:topic/status',
         'POST /continuation/start',
+        'POST /continuation/:topic/renew',
         'POST /continuation/:topic/complete',
         'POST /continuation/:topic/stop',
         'POST /continuation/stop-all',

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5188,6 +5188,10 @@ export function createRoutes(ctx: RouteContext): Router {
   router.get('/continuation/:topic/status', (req, res) => {
     const store = continuationStore();
     const ledger = store.read(req.params.topic);
+    const startedAtMs = ledger ? Date.parse(ledger.startedAt) : Number.NaN;
+    const expiresAtMs = ledger && Number.isFinite(startedAtMs)
+      ? startedAtMs + ledger.durationSeconds * 1000
+      : Number.NaN;
     res.json({
       enabled: store.enabled,
       active: ledger?.active === true,
@@ -5195,7 +5199,7 @@ export function createRoutes(ctx: RouteContext): Router {
       continuationCount: ledger?.continuationCount ?? 0,
       maxContinuations: ledger?.maxContinuations ?? null,
       startedAt: ledger?.startedAt ?? null,
-      expiresAt: ledger ? new Date(Date.parse(ledger.startedAt) + ledger.durationSeconds * 1000).toISOString() : null,
+      expiresAt: Number.isFinite(expiresAtMs) ? new Date(expiresAtMs).toISOString() : null,
       taskCount: ledger ? parseContinuationTasks(ledger.body).length : 0,
       openTaskCount: ledger ? parseContinuationTasks(ledger.body).filter((t) => t.open).length : 0,
     });

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5194,9 +5194,27 @@ export function createRoutes(ctx: RouteContext): Router {
       topicId: req.params.topic,
       continuationCount: ledger?.continuationCount ?? 0,
       maxContinuations: ledger?.maxContinuations ?? null,
+      startedAt: ledger?.startedAt ?? null,
+      expiresAt: ledger ? new Date(Date.parse(ledger.startedAt) + ledger.durationSeconds * 1000).toISOString() : null,
       taskCount: ledger ? parseContinuationTasks(ledger.body).length : 0,
       openTaskCount: ledger ? parseContinuationTasks(ledger.body).filter((t) => t.open).length : 0,
     });
+  });
+
+  router.post('/continuation/:topic/renew', (req, res) => {
+    if (refuseInadmissibleWrite(req, res, { topicId: req.params.topic })) return;
+    try {
+      const body = req.body as Record<string, unknown>;
+      const ledger = continuationStore().renew(req.params.topic, {
+        sessionId: typeof body.sessionId === 'string' ? body.sessionId : undefined,
+        durationSeconds: typeof body.durationSeconds === 'number' ? body.durationSeconds : undefined,
+        maxContinuations: typeof body.maxContinuations === 'number' ? body.maxContinuations : undefined,
+      });
+      res.status(201).json({ ok: true, topicId: ledger.topicId, generation: ledger.generationId });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : 'invalid-request';
+      res.status(reason === 'continuation-disabled' ? 503 : 400).json({ ok: false, error: reason });
+    }
   });
 
   router.post('/continuation/start', (req, res) => {

--- a/tests/integration/autonomous-sessions-api.test.ts
+++ b/tests/integration/autonomous-sessions-api.test.ts
@@ -182,6 +182,20 @@ describe('Multi-session autonomy API (integration)', () => {
       body: JSON.stringify({ topicId: '458', sessionId: 'codex-session' }),
     });
     expect(await stopped.json()).toMatchObject({ decision: 'deactivate', reason: 'operator-stop' });
+
+    const renewed = await fetch(`${baseUrl}/continuation/458/renew`, { method: 'POST' });
+    expect(renewed.status).toBe(201);
+    const renewedStatus = await (await fetch(`${baseUrl}/continuation/458/status`)).json();
+    expect(renewedStatus).toMatchObject({ active: true, taskCount: 2, openTaskCount: 1 });
+    expect(renewedStatus.startedAt).toBeTypeOf('string');
+    expect(renewedStatus.expiresAt).toBeTypeOf('string');
+
+    const ledgerPath = path.join(project.stateDir, 'continuation', '458.local.json');
+    const corruptTimestamp = JSON.parse(fs.readFileSync(ledgerPath, 'utf8'));
+    corruptTimestamp.startedAt = 'not-a-date';
+    fs.writeFileSync(ledgerPath, JSON.stringify(corruptTimestamp));
+    const corruptStatus = await (await fetch(`${baseUrl}/continuation/458/status`)).json();
+    expect(corruptStatus.expiresAt).toBeNull();
   });
 
   it('POST /autonomous/native-goal/set injects /goal <condition> and flips goal_mode', async () => {

--- a/tests/unit/CodexTaskContinuationStore.test.ts
+++ b/tests/unit/CodexTaskContinuationStore.test.ts
@@ -154,6 +154,28 @@ describe('CodexTaskContinuationStore', () => {
     expect(store.decide('459', 's')).toMatchObject({ decision: 'deactivate', reason: 'invalid-state' });
   });
 
+  it('renews an expired ledger as a fresh audited generation without reopening completed tasks', () => {
+    const dir = temp();
+    const store = live(dir);
+    const first = store.start({ topicId: '458', sessionId: 'old-session', tasks: ['done', 'still open'], durationSeconds: 1 });
+    store.complete('458', 1);
+    first.startedAt = new Date(Date.now() - 2_000).toISOString();
+    first.body = store.read('458')!.body;
+    first.bodyDigest = store.read('458')!.bodyDigest;
+    fs.writeFileSync(path.join(dir, 'continuation', '458.local.json'), JSON.stringify(first));
+    expect(store.decide('458', 'old-session')).toMatchObject({ decision: 'deactivate', reason: 'duration-expired' });
+
+    const renewed = store.renew('458', { durationSeconds: 60 });
+    expect(renewed.generation).toBeGreaterThan(first.generation);
+    expect(renewed.sessionId).toBe('__bind_on_first_stop__');
+    expect(renewed.continuationCount).toBe(0);
+    expect(parseContinuationTasks(renewed.body)).toEqual([
+      { open: false, line: 0 },
+      { open: true, line: 1 },
+    ]);
+    expect(store.decide('458', 'new-session')).toMatchObject({ decision: 'continue', openTaskCount: 1 });
+  });
+
   it('hard-disables without mutating into a continuation', () => {
     const dir = temp();
     live(dir).start({ topicId: '458', sessionId: 's', tasks: ['one'] });

--- a/tests/unit/CodexTaskContinuationStore.test.ts
+++ b/tests/unit/CodexTaskContinuationStore.test.ts
@@ -173,6 +173,7 @@ describe('CodexTaskContinuationStore', () => {
       { open: false, line: 0 },
       { open: true, line: 1 },
     ]);
+    expect(fs.readFileSync(path.join(dir, 'continuation', 'audit.local.jsonl'), 'utf8')).toContain('"reason":"renewed"');
     expect(store.decide('458', 'new-session')).toMatchObject({ decision: 'continue', openTaskCount: 1 });
   });
 

--- a/upgrades/next/continuation-expiry-recovery.md
+++ b/upgrades/next/continuation-expiry-recovery.md
@@ -1,0 +1,3 @@
+# Continuation expiry recovery
+
+Codex task continuation now has a supported `renew` operation for starting a fresh bounded generation without rebuilding or reopening its checklist. Continuation status includes its start and expiry timestamps, and the CLI honors externalized authentication through `INSTAR_AUTH_TOKEN` or the configured environment reference.

--- a/upgrades/next/continuation-expiry-recovery.md
+++ b/upgrades/next/continuation-expiry-recovery.md
@@ -1,3 +1,18 @@
-# Continuation expiry recovery
+## What Changed
 
 Codex task continuation now has a supported `renew` operation for starting a fresh bounded generation without rebuilding or reopening its checklist. Continuation status includes its start and expiry timestamps, and the CLI honors externalized authentication through `INSTAR_AUTH_TOKEN` or the configured environment reference.
+
+## What to Tell Your User
+
+Long Codex task drives can now be safely renewed without losing completed checklist state, and their expiry time is visible.
+
+## Summary of New Capabilities
+
+- Renew an existing continuation ledger as a fresh bounded, audited generation.
+- Inspect the ledger's start and expiry timestamps.
+- Use continuation CLI commands with externalized authentication.
+
+## Evidence
+
+- 17 focused store tests and 12 continuation/autonomy route tests pass.
+- TypeScript build and repository lint pass locally.

--- a/upgrades/side-effects/continuation-expiry-recovery.md
+++ b/upgrades/side-effects/continuation-expiry-recovery.md
@@ -1,0 +1,81 @@
+# Side-Effects Review — continuation expiry recovery
+
+**Version / slug:** `continuation-expiry-recovery`  
+**Date:** `2026-07-17`  
+**Author:** `Instar Agent (instar-codey)`  
+**Second-pass reviewer:** `Echo`
+
+## Summary of the change
+
+Adds an authenticated, generation-ordered renewal primitive to `CodexTaskContinuationStore`, wires it through the continuation API and CLI, exposes bounded expiry in status, and fixes CLI auth resolution after token externalization. It touches the explicit operator authority that creates continuation generations but does not add automatic renewal.
+
+## Decision-point inventory
+
+- `CodexTaskContinuationStore.renew` — add — accepts an explicit authenticated request to mint a fresh bounded generation from a valid checklist with open work.
+- continuation status expiry rendering — add — structural date validation controls whether `expiresAt` is an ISO timestamp or null.
+
+## 1. Over-block
+
+Renewal refuses malformed ledgers and ledgers with no open tasks. A legitimate but hand-corrupted ledger cannot be renewed through this path; that is intentional because adopting unaudited state would weaken operator-stop ordering. No message/content judgment is introduced.
+
+## 2. Under-block
+
+An authenticated caller may renew a still-live ledger and reset its clock/count, just as it may call authenticated `start` with the same tasks. This is not an authority expansion, but operators should use renew for expired or intentionally extended work. The audit's distinct `renewed` reason makes every such action visible.
+
+## 3. Level-of-abstraction fit
+
+The store is the correct layer: it already owns generation ordering, tombstones, locking, bounds, digest validation, and audit writes. Implementing renewal in the CLI or by editing the ledger would duplicate or bypass those invariants. The route remains a thin authenticated adapter.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no message/content judgment surface.
+
+This is deterministic authority over a constrained state machine. Structural validity, open-task presence, generation ordering, and configured numeric bounds are enumerable invariants, not brittle semantic detectors.
+
+## 4b. Judgment-point check
+
+No new static heuristic at a competing-signals decision point. Renewal is an explicit authenticated command; it does not infer whether work deserves renewal.
+
+## 5. Interactions
+
+- **Shadowing:** renewal uses the same maintenance→topic lock order and tombstone maximum as start. An explicit authenticated renewal intentionally mints `max(prior, topic stop, global stop) + 1`, so it is fresh authority that can restart previously stopped work; stale generations still cannot outrank the new stop or renewal.
+- **Double-fire:** no automatic caller is added; duplicate explicit renew requests create successive audited generations, each bounded.
+- **Races:** maintenance and topic locks serialize renew with start, stop-all, and decisions. A corrupt stop marker remains authoritative through the existing sentinel behavior.
+- **Feedback loops:** none; status is read-only and renewal does not schedule itself.
+
+## 6. External surfaces
+
+The CLI gains `continuation renew`; the local API gains `POST /continuation/:topic/renew`; status adds `startedAt` and `expiresAt`. Persistent local ledger and audit state gain a fresh generation and a distinct `renewed` row. There are no external-service calls, generated URLs, or user notices. The action is conversationally phone-completable because the agent can execute it for the operator; no PIN-only human form is introduced.
+
+## 6b. Operator-surface quality
+
+No dashboard or form surface — not applicable.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN:** ordinary-work continuation authority is owned by the specific Codex session and its machine-local Stop hook. The ledger is deliberately excluded from replication so a second machine cannot adopt and continue the same session implicitly. Renewal must be executed against the machine serving that topic/session. It emits no notices, generates no URLs, and its durable state does not claim to follow topic transfer; a transfer requires a fresh explicit generation on the destination.
+
+## 8. Rollback cost
+
+Revert and ship a patch. Existing version-1 ledgers remain readable; the new route/CLI simply disappear. A ledger renewed while the feature was present remains a normal valid generation. No migration or state repair is required.
+
+## Conclusion
+
+The review preserved the bounded safety model and replaced manual state mutation with the existing store's authority. Echo's review prompted a distinct renewal audit reason and corrupt-date fail-safe. The change is clear to ship after the second-pass artifact review and green CI.
+
+## Second-pass review
+
+**Reviewer:** Echo  
+**Independent read of the artifact:** concur — after correcting the first draft's stop-tombstone wording, the reviewer confirmed the artifact accurately characterizes renewal as explicit fresh authority and covers the boundedness, race, audit, and machine-local risks.
+
+## Evidence pointers
+
+- `tests/unit/CodexTaskContinuationStore.test.ts`
+- `tests/integration/autonomous-sessions-api.test.ts`
+- Live topic-458 audit row at `2026-07-18T02:33:11.364Z` records the reproduced `duration-expired` stop.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect and no self-triggered controller was added or modified — not applicable.

--- a/upgrades/side-effects/continuation-expiry-recovery.md
+++ b/upgrades/side-effects/continuation-expiry-recovery.md
@@ -20,7 +20,7 @@ Renewal refuses malformed ledgers and ledgers with no open tasks. A legitimate b
 
 ## 2. Under-block
 
-An authenticated caller may renew a still-live ledger and reset its clock/count, just as it may call authenticated `start` with the same tasks. This is not an authority expansion, but operators should use renew for expired or intentionally extended work. The audit's distinct `renewed` reason makes every such action visible.
+An authenticated caller may renew a stopped, expired, or still-live ledger and reset its clock/count. Post-stop/post-expiry revival is deliberately lower-friction than `start` because it retains the digest-verified checklist, but it mints above the tombstone with the same fresh authority as authenticated `start`; it does not adopt stale authority. Operators should use renew for expired or intentionally extended work. The audit's distinct `renewed` reason makes every such action visible.
 
 ## 3. Level-of-abstraction fit
 


### PR DESCRIPTION
## What changed

- add an authenticated `continuation renew` API/CLI path that mints a fresh bounded generation while preserving the existing checklist and completed items
- resolve the externalized continuation auth token from `INSTAR_AUTH_TOKEN` (or the config's environment reference) instead of assuming an inline string
- expose `startedAt` and `expiresAt` from continuation status

## Why

An ordinary Codex drive crossed a turn boundary after its four-hour ledger window had expired. The Stop hook correctly deactivated it, but recovery required rebuilding the task list manually. The shipped CLI also failed with `Invalid auth token` after auth externalization because it read only the config value.

This supplies a generation-ordered, audited renewal path and makes the deadline visible without weakening the bounded-duration safety contract.

## ELI16 — what this means

The continuation loop is intentionally allowed to run only for a limited time. When that time ended, the old tooling left no safe “continue this same checklist for another bounded window” button. Rebuilding the ledger by hand could accidentally reuse an old deadline or lose which tasks were already finished. This change adds that button: it creates a brand-new, auditable generation, keeps the checklist exactly as it was, resets only the allowed time and turn counters, and waits for the next real session to claim it. It also shows the deadline directly and lets the command-line tool use the externalized credential format already used by the server.

## Validation

- `npx vitest run tests/unit/CodexTaskContinuationStore.test.ts` (17/17)
- `npm run build`
- `git diff --check`
