### PR TITLE
docs: apprenticeship program concepts (CMT-872) + required rootGap fields on the issue schema

### DIFF
--- a/docs/apprenticeship/PROGRAM-CONCEPTS.md
+++ b/docs/apprenticeship/PROGRAM-CONCEPTS.md
@@ -1,0 +1,80 @@
+# Apprenticeship Program — Core Concepts (operator-ratified framings)
+
+Origin: operator directives, topic 29723, 2026-07-16/17 (Justin). Delivered under CMT-872.
+Relates-to: `docs/specs/APPRENTICESHIP-PROGRAM-PROJECT-DESIGN.md`,
+`docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md` (§13.9 enforces concept 4),
+`docs/apprenticeship/RETRO-HARVEST-PROCEDURE.md`.
+
+These are the program's load-bearing concepts, stated once, canonically, so no drive
+re-derives them from chat history. Each earned its place through live program evidence.
+
+## 1. Mutual substrate improvement (why our loop is stronger than the paper's)
+
+The Weco "first evidence of recursive self-improvement" architecture is two loops: an
+inner agent doing object-level work under a budget, an outer agent rewriting the inner
+agent's machinery, keeping changes only when they beat held-out evaluation.
+
+The apprenticeship program has the same shape with one structural upgrade: **the inner
+agent (mentee) is not just rebuilding his own machinery — he is rebuilding Instar
+itself, the shared substrate BOTH agents run on.** Every merged improvement upgrades
+mentor and mentee alike. Their outer loop improves the inner agent; ours has the inner
+agent improving both agents, gated by the outer. The evaluation gate (review, promotion
+on evidence) is what keeps this recursion safe.
+
+## 2. Role asymmetry, not capability asymmetry
+
+The mentor's advantage today (Instar was built Claude-first) is **temporary debt, not a
+moat**. The program's explicit end state is **framework parity**: any onboarded
+framework fully powers an Instar agent with no structural disadvantage.
+
+What deliberately REMAINS asymmetric is the **roles**: one agent as observer/director,
+one as worker. The separation itself is the leverage — the observer sees what the
+worker cannot (his own stalls, his own blind spots), and collaboration across the
+boundary is where the development speed comes from. Running the two roles on different
+model families adds genuine diversity of judgment on top. Equivalent agents, distinct
+roles, different intelligences: all three properties are intended and none implies the
+others.
+
+## 3. Fractal role-teaching (each layer phases itself upward)
+
+The program teaches roles downward one layer at a time: the operator teaches the mentor
+how to perform the operator's role (the questioning, the standards-level judgment)
+exactly as the mentor teaches the mentee how to perform the mentor's role. "Phasing
+out" means each layer's occupant moves UP a layer as its student becomes independent —
+the mentee becomes his own observer, the mentor inherits more of the operator's role.
+Independence is measured on the instance ladder (R0–R5) with evidence, never assumed.
+
+## 4. Defect entries REQUIRE fundamental-gap analysis (the three questions)
+
+Operator directive, 2026-07-17: observing a mentee failure and logging it is tracking,
+not diagnosis. **Every defect entering a drive's defect matrix MUST carry three fields
+before it counts as logged:**
+
+1. **Infra gap** — what is lacking in current infrastructure that allowed this?
+2. **Sentinel verdict** — does this signal a FAILING sentinel or a MISSING one? (Or
+   `neither-unpromoted`: the guard exists but sits watch-only/dark — a promotion
+   decision, not new machinery.)
+3. **Standard gap** — what standard would have guided past development to close this
+   class ahead of time?
+
+A defect without root-gap analysis is incomplete, the same way a feature without tests
+is incomplete. This converts the operator's questioning into schema (Structure >
+Willpower applied to judgment itself). Enforced on the issue ledger by
+`FRAMEWORK-ONBOARDING-MENTOR-SPEC.md` §13.9 (the three `rootGap*` fields, write-time
+validated). First entries in the new schema: drive-5 defects #9
+(interrupted-conversation stall → the stall-coverage-matrix standard), #10
+(stream-disconnect stall), #11 (operator pin erased by agent-authority unpin).
+
+## 5. Evaluation cautions (operator-bounded)
+
+Two ideas from the recursive-self-improvement literature are adopted only in bounded
+form, per operator review (2026-07-17):
+
+- **Hidden/held-out testing**: any undisclosed test battery must be shown to the
+  operator BEFORE anything hangs on it, and framed as **tripwires, not targets** —
+  regression detection on behaviors already valued, never a score that defines growth.
+  Risk being managed: boxing in growth via narrow metrics.
+- **Rejection-rate discipline**: a research lab's ~90% discard rate does not transfer —
+  program work is need-driven, and spec review is where rejection already lives. The
+  retained piece: **promotion evidence must span multiple cycles, never one good day**
+  (already the ladder's rung-evidence requirement).

--- a/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
+++ b/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
@@ -374,6 +374,13 @@ regressedFromIssueId  if a regression of a previously-fixed issue (nullable)
 playbookStatus      none | candidate | extracted | superseded
 wontFixReason       required when status=wont-fix (§13.7)
 relatedSpec         optional spec slug
+rootGapInfrastructure  REQUIRED (§13.9) — what is lacking in current infrastructure
+                    that allowed this gap?
+rootGapSentinel     REQUIRED (§13.9) — failing | missing | neither-unpromoted: does
+                    this signal a FAILING sentinel or a MISSING one?
+                    (neither-unpromoted = the guard exists but sits watch-only/dark)
+rootGapStandard     REQUIRED (§13.9) — what standard would have guided past
+                    development to close this class ahead of time?
 createdAt / updatedAt
 ```
 Indexes: `framework_issues(dedupKey)`, composite on `(framework, playbookStatus)` for the playbook
@@ -443,6 +450,29 @@ through a single-writer / CAS `mutate()` pattern (the CommitmentTracker preceden
 ticks / multi-framework jobs can't drop observations on `SQLITE_BUSY`. All queries use parameterized
 prepared statements (no string interpolation); enum columns (`bucket`, `status`, `playbookStatus`)
 validated against fixed allowlists on write.
+
+### 13.9 Fundamental-gap analysis is REQUIRED on every issue (the three questions)
+
+Operator directive (2026-07-17, topic 29723, apprenticeship drive 5): observing a
+failure and logging it is tracking, not diagnosis. Every `framework_issues` record
+MUST answer three questions before it counts as logged — write-time validation
+refuses an insert without them, exactly like the `bucket` requirement (§6):
+
+1. **`rootGapInfrastructure`** — what is lacking in current infrastructure that
+   allowed this gap?
+2. **`rootGapSentinel`** — does this signal a FAILING sentinel or a MISSING one?
+   Enum `failing | missing | neither-unpromoted`; the third value names the drive-5
+   recurring case where the guard exists but sits watch-only/dark, so the answer is
+   a promotion decision rather than new machinery.
+3. **`rootGapStandard`** — what standard would have guided past development to close
+   this class ahead of time?
+
+A defect without root-gap analysis is incomplete the same way a feature without tests
+is incomplete. This converts the operator's questioning discipline into schema —
+Structure > Willpower applied to judgment itself. Canonical concept statement:
+`docs/apprenticeship/PROGRAM-CONCEPTS.md` §4. First entries in this schema: drive-5
+defects #9 (interrupted-conversation stall), #10 (stream-disconnect stall), #11
+(operator pin erased by agent-authority unpin).
 
 ## 14. Migration & deployment (three distinct mechanisms — named)
 

--- a/docs/specs/cmt872-apprenticeship-concepts.eli16.md
+++ b/docs/specs/cmt872-apprenticeship-concepts.eli16.md
@@ -1,0 +1,54 @@
+# ELI16 — Apprenticeship program concepts written down + defects must name their root gap
+
+## What this change actually is
+
+Two documentation additions, no code.
+
+First: a new page, `docs/apprenticeship/PROGRAM-CONCEPTS.md`, that writes down the
+four big ideas behind our apprenticeship program (where one AI agent mentors another
+onto Instar). Until now these ideas lived only in chat history with the operator, so
+every new work session had to re-derive them from scattered messages — and sometimes
+got them subtly wrong. Now they're stated once, canonically:
+
+1. **Mutual substrate improvement** — the mentee isn't just improving himself; he's
+   improving Instar, the shared foundation BOTH agents run on. Every fix he lands
+   makes both agents better.
+2. **Role asymmetry, not capability asymmetry** — the mentor isn't assumed to be
+   smarter. The leverage comes from the SPLIT of roles: one agent works, the other
+   observes. The observer sees stalls the worker can't see in himself.
+3. **Fractal role-teaching** — the operator teaches the mentor his role the same way
+   the mentor teaches the mentee. Each layer moves up as its student becomes
+   independent.
+4. **Defects require root-gap analysis** — see below.
+5. Plus two bounded cautions about evaluation (hidden tests are tripwires, not
+   targets; promotion needs evidence across multiple cycles).
+
+Second: the framework-onboarding spec's issue database schema gains three REQUIRED
+fields. Whenever a defect is recorded about a framework being onboarded, the record
+must now answer: (a) what infrastructure gap allowed this? (b) is a watchdog failing,
+missing, or just not yet promoted from watch-only mode? (c) what standard would have
+prevented this class of problem ahead of time? A defect record without those answers
+is refused — the same way a record without a category is refused today.
+
+## What already exists
+
+The concepts were operator-stated in topic 29723 on Jul 16-17. The defect matrix for
+apprenticeship drive 5 already uses the three-question analysis live (defects #9, #10,
+#11 all carry it). The mentor spec's issue schema (§13) already validates other
+required fields at write time.
+
+## What's new
+
+Only the documentation: the canonical concepts page, three schema field definitions in
+the spec's §13.1 table, and a new §13.9 section explaining the requirement.
+
+## Safeguards in plain terms
+
+Nothing at runtime changes with this commit — the mentor-loop feature that would read
+this schema still ships staged/off. When it is built, the validation refuses
+incomplete defect records rather than silently accepting them.
+
+## What you actually need to decide
+
+Nothing — this records decisions the operator already made on Jul 17. If the wording
+of any concept reads wrong, that's the thing to flag.

--- a/upgrades/next/cmt872-apprenticeship-concepts.md
+++ b/upgrades/next/cmt872-apprenticeship-concepts.md
@@ -1,0 +1,26 @@
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+- Added `docs/apprenticeship/PROGRAM-CONCEPTS.md` — the canonical statement of the
+  apprenticeship program's four operator-ratified concepts (mutual substrate
+  improvement; role asymmetry, not capability asymmetry; fractal role-teaching;
+  required fundamental-gap analysis on defects) plus two bounded evaluation cautions
+  (tripwires-not-targets hidden testing; multi-cycle promotion evidence). Origin:
+  operator directives, topic 29723, 2026-07-16/17 (CMT-872).
+- `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md`: the §13.1 issue schema gains three
+  REQUIRED fields — `rootGapInfrastructure`, `rootGapSentinel`
+  (failing | missing | neither-unpromoted), `rootGapStandard` — and a new §13.9
+  defining the write-time requirement: a defect record without root-gap analysis is
+  refused, like a record without a bucket.
+
+## Evidence
+
+- Docs-only diff: `docs/apprenticeship/PROGRAM-CONCEPTS.md` (new),
+  `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md` (schema + §13.9),
+  ELI16 at `docs/specs/cmt872-apprenticeship-concepts.eli16.md`,
+  side-effects review at `upgrades/side-effects/cmt872-apprenticeship-concepts.md`.
+- The three-question analysis is already applied live in apprenticeship drive 5's
+  defect matrix (defects #9, #10, #11) — this lands the canonical documentation and
+  schema definition for it.

--- a/upgrades/side-effects/cmt872-apprenticeship-concepts.md
+++ b/upgrades/side-effects/cmt872-apprenticeship-concepts.md
@@ -1,0 +1,49 @@
+# Side-Effects Review — cmt872-apprenticeship-concepts
+
+**Change:** documentation-only. (a) New `docs/apprenticeship/PROGRAM-CONCEPTS.md`
+(four operator-ratified apprenticeship concepts + evaluation cautions, CMT-872).
+(b) `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md`: three REQUIRED `rootGap*`
+fields added to the §13.1 issue schema + new §13.9 explaining the requirement.
+No runtime code, no tests, no templates, no hooks.
+
+## Phase 1 principle check
+
+Does this change involve a decision point (gates information flow, blocks actions,
+filters messages, constrains agent behavior)? **No.** It is prose: a concepts page and
+a spec schema amendment. The write-time validation §13.9 describes will be a future
+build of the (staged, off-by-default) mentor loop; this commit changes no executable
+path. Signal-vs-authority is not implicated — documentation carries no authority.
+
+## The eight questions
+
+1. **Over-block** — No issue identified. Nothing executable changes; nothing can
+   reject any input.
+2. **Under-block** — No issue identified (nothing enforces yet). Named residual: until
+   the mentor-loop build implements §13.9 validation, the rootGap requirement binds
+   drive practice by convention (already live in drive 5's matrix) rather than by code.
+   That build is governed by the mentor spec's own staged rollout.
+3. **Level-of-abstraction fit** — Correct layer. Concepts page lives in
+   `docs/apprenticeship/` beside RETRO-HARVEST-PROCEDURE.md; the schema change lives in
+   the spec that owns the issue ledger. The drive-workspace matrix template mirrors the
+   same three questions, so judgment structure exists at both layers (program docs +
+   ledger schema).
+4. **Signal vs authority** — Compliant; no authority exists in this change. When built,
+   rootGap validation is a write-time completeness check on a ledger record (like the
+   existing bucket allowlist), not a behavioral gate.
+5. **Interactions** — The mentor spec is converged+approved (2026-05-27). This amends
+   its schema section additively; no existing field is renamed or removed, so no
+   consumer (none built yet for these fields) breaks. §13.8 (Concurrency) numbering is
+   untouched; the new section is §13.9. The concepts page references the spec and vice
+   versa — both references verified present in this diff.
+6. **External surfaces** — None. No user-visible runtime surface, no other-agent
+   surface. The docs ship in the npm package as before.
+7. **Multi-machine posture** — Machine-local BY DESIGN in the trivial sense: these are
+   git-tracked repo docs, identical on every machine via the release; no runtime state,
+   no replication path needed, nothing strands on topic transfer, no URLs generated.
+8. **Rollback cost** — Trivial: revert the docs commit. No data migration, no agent
+   state, no hot-fix pressure.
+
+## Conclusion
+
+Documentation-only, no runtime surface. Tier 1 declared: small, low-risk, records
+operator decisions already made 2026-07-17.


### PR DESCRIPTION
## What

Docs-only, Tier 1. Two additions delivered under CMT-872 (operator directives, topic 29723, 2026-07-16/17):

1. **`docs/apprenticeship/PROGRAM-CONCEPTS.md`** (new) — canonical statement of the apprenticeship program's four operator-ratified concepts: mutual substrate improvement; role asymmetry, not capability asymmetry; fractal role-teaching; required fundamental-gap analysis on defects — plus two bounded evaluation cautions (hidden tests are tripwires-not-targets; promotion evidence must span multiple cycles).
2. **`docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md`** — the §13.1 issue schema gains three REQUIRED fields (`rootGapInfrastructure`, `rootGapSentinel` with enum `failing | missing | neither-unpromoted`, `rootGapStandard`) and a new §13.9 defining the write-time requirement.

No runtime code. The mentor loop that will enforce §13.9 still ships staged/off; the three-question analysis is already applied live in drive 5's defect matrix (defects #9, #10, #11).

## ELI16 — the program's big ideas get written down, and defect reports must name their root cause

Until now, the four big ideas behind our AI-mentors-AI apprenticeship program lived only in chat history with the operator — every new work session had to re-derive them from scattered messages, and sometimes got them subtly wrong. This PR writes them down once, canonically, in a docs page: the mentee improves the shared foundation both agents run on (not just himself); the leverage comes from splitting observer and worker roles, not from one agent being smarter; each layer teaches its role to the layer below and moves up; and every recorded defect must include a root-cause analysis.

That last idea also becomes schema: the framework-onboarding spec's defect database now requires three answers on every record — what infrastructure gap allowed this, is a watchdog failing/missing/just-not-promoted, and what standard would have prevented the whole class ahead of time. A defect record without those answers gets refused, the same way a record without a category is refused today. Observing a failure and logging it is tracking; answering the three questions is diagnosis. Nothing at runtime changes in this PR — it records decisions the operator already made on Jul 17.

Full overview: `docs/specs/cmt872-apprenticeship-concepts.eli16.md`. Side-effects review: `upgrades/side-effects/cmt872-apprenticeship-concepts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
