### PR TITLE
fix: align secret-key diagnostics with configured policy

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-18T17-54-39-180Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T17-54-39-180Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-18T17:54:39.180Z",
+  "slug": "unknown",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 5,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/secret-key-diagnostic-policy.eli16.md
+++ b/docs/specs/secret-key-diagnostic-policy.eli16.md
@@ -1,0 +1,11 @@
+# Secret-Key Diagnostic Policy — Plain-English Overview
+
+The agent already lets each machine choose where its private vault key lives. A normal desktop may use the operating system keychain, while a headless machine may deliberately keep the key in protected local state because its background process cannot reliably open a login keychain. That choice is explicit security policy, not a guess made by diagnostics.
+
+The problem was that the machine health command opened the vault without passing that configured choice. It could therefore describe a file-keyed machine as “keychain-backed,” even though the runtime writers correctly followed the file-key policy. The vault remained encrypted, but the health report could send an operator toward the wrong diagnosis during an outage.
+
+This change makes the health command consume the same existing policy as the vault writers. It does not invent a new key backend, move keys between machines, expose secret values, or automatically change anyone’s configuration. It only makes the diagnostic view agree with the authoritative configured policy.
+
+The adjacent secret-sync regression test also becomes stricter. That test examines one bounded region of the server composition file and counts the two places that must inherit the policy. Previously it proved only that the start marker existed. If the end marker were renamed, the scan could silently continue to the end of the file and pass for the wrong reason. The test now proves both markers exist in the correct order before it examines the region.
+
+The safety rule is simple: security diagnostics derive their labels from the same policy that controls runtime behavior, and source-scanning tests prove every boundary they depend on. Rollback is a small code revert; there is no data migration or persistent format change.

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -760,7 +760,10 @@ export async function doctor(options: DoctorOptions): Promise<void> {
 
   // 6. Secret Store
   try {
-    const secretStore = new SecretStore({ stateDir: config.stateDir });
+    const secretStore = new SecretStore({
+      stateDir: config.stateDir,
+      forceFileKey: config.secrets?.forceFileKey,
+    });
     if (secretStore.exists) {
       const keychainLabel = secretStore.isKeychainBacked ? 'keychain-backed' : 'file-backed key';
       checks.push({ name: 'Secret store', status: 'ok', detail: `Encrypted (${keychainLabel})` });

--- a/tests/unit/machine-doctor-key-policy-wiring.test.ts
+++ b/tests/unit/machine-doctor-key-policy-wiring.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/** Reintroduction guard for fb-49c697aa-383. */
+describe('machine doctor secret-key policy wiring', () => {
+  it('constructs its diagnostic SecretStore with the configured key policy', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src', 'commands', 'machine.ts'),
+      'utf8',
+    );
+    const startMarker = '// 6. Secret Store';
+    const endMarker = '// 7. Git signing';
+    const start = source.indexOf(startMarker);
+    const end = source.indexOf(endMarker);
+    expect(start, 'secret-store diagnostic start marker must exist').toBeGreaterThanOrEqual(0);
+    expect(end, 'secret-store diagnostic end marker must exist').toBeGreaterThan(start);
+
+    const diagnostic = source.slice(start, end);
+    expect(diagnostic).toMatch(
+      /new SecretStore\(\{\s*stateDir:\s*config\.stateDir,\s*forceFileKey:\s*config\.secrets\?\.forceFileKey,?\s*\}\)/,
+    );
+  });
+});

--- a/tests/unit/secret-sync-key-policy-wiring.test.ts
+++ b/tests/unit/secret-sync-key-policy-wiring.test.ts
@@ -17,11 +17,14 @@ describe('secret-sync SecretStore key-policy wiring', () => {
       'utf8',
     );
 
-    const secretSyncRegion = source.slice(
-      source.indexOf('// ── Secret-sync inbound handler'),
-      source.indexOf('// ── Durable Inbound Message Queue: engine construction'),
-    );
-    expect(secretSyncRegion).not.toBe('');
+    const startMarker = '// ── Secret-sync inbound handler';
+    const endMarker = '// ── Durable Inbound Message Queue: engine construction';
+    const start = source.indexOf(startMarker);
+    const end = source.indexOf(endMarker);
+    expect(start, 'secret-sync start marker must exist').toBeGreaterThanOrEqual(0);
+    expect(end, 'secret-sync end marker must exist').toBeGreaterThan(start);
+
+    const secretSyncRegion = source.slice(start, end);
 
     const inheritedPolicy = secretSyncRegion.match(
       /forceFileKey:\s*config\.secrets\?\.forceFileKey/g,

--- a/upgrades/next/secret-key-diagnostic-policy.md
+++ b/upgrades/next/secret-key-diagnostic-policy.md
@@ -1,0 +1,20 @@
+# Secret-key diagnostics now report the configured policy
+
+## What Changed
+
+`instar doctor` now opens the encrypted secret store with the same configured key-backend policy used by runtime writers. A machine explicitly configured for a protected file-backed key is therefore reported as file-backed instead of being mislabeled from a different default resolution path.
+
+The secret-sync production-wiring regression test also now proves that both of its source-region boundary markers exist before counting constructor options. A renamed boundary can no longer silently widen the test to the rest of the server file.
+
+## Evidence
+
+- Focused policy-wiring and boundary-guard tests pass.
+- A dedicated reintroduction guard pins machine-doctor policy inheritance.
+
+## What to Tell Your User
+
+Machine diagnostics now describe the secret-key storage policy the machine is actually configured to use.
+
+## Summary of New Capabilities
+
+- More trustworthy secret-store diagnostics on headless and explicitly file-keyed machines.

--- a/upgrades/side-effects/secret-key-diagnostic-policy.md
+++ b/upgrades/side-effects/secret-key-diagnostic-policy.md
@@ -1,0 +1,68 @@
+# Side-Effects Review — Secret-key diagnostic policy
+
+**Version / slug:** `secret-key-diagnostic-policy`
+**Date:** 2026-07-18
+**Author:** Instar Agent (instar-codey)
+**Second-pass reviewer:** not required
+
+## Summary of the change
+
+Machine doctor passes `config.secrets.forceFileKey` to its read-only `SecretStore`, and two source-scanning regression tests now validate their region boundaries explicitly. This closes the three review findings concerning diagnostic-policy disagreement and a fragile end marker without changing vault data or key selection semantics.
+
+## Decision-point inventory
+
+No new block, allow, dispatch, or semantic judgment is introduced. An existing explicit configuration value reaches an existing read-only diagnostic store.
+
+## 1. Over-block
+
+Not applicable: the command remains diagnostic and does not prevent an operation.
+
+## 2. Under-block
+
+The change does not infer policy from whether a machine looks headless. It preserves the operator’s configured choice and reports that choice through the existing `SecretStore` resolution.
+
+## 3. Level-of-abstraction fit
+
+Policy propagation belongs at the `SecretStore` construction site. Boundary validation belongs in the source-level tests that rely on those markers.
+
+## 4. Signal vs authority compliance
+
+The configured key policy remains authoritative. The diagnostic label is a derived signal and cannot alter the policy.
+
+## 4b. Judgment-point check
+
+No competing-signals judgment point is added.
+
+## 5. Interactions
+
+- No new writers, events, retries, or races.
+- The doctor command may initialize key resolution exactly as before; only its existing policy input is now consistent.
+- Marker assertions fail loudly if server section labels drift, preventing unrelated code from satisfying the constructor count.
+
+## 6. External surfaces
+
+Only the accuracy of the existing human-readable doctor label changes. No API, credential, secret value, or persistence format changes.
+
+## 6b. Operator-surface quality
+
+The corrected label is more actionable because it names the configured backend rather than a contradictory default-path result.
+
+## 7. Multi-machine posture
+
+The vault key remains machine-local. This change neither replicates key material nor changes secret-sync transport; it only aligns one machine’s diagnostic read with that machine’s policy.
+
+## 8. Rollback cost
+
+A direct revert restores the former diagnostic construction and test assertions. No migration is needed.
+
+## Conclusion
+
+The change narrows diagnostic ambiguity and strengthens a regression boundary without expanding authority or persistence. Focused tests are green.
+
+## Second-pass review
+
+Not required: messaging, session lifecycle, recovery, and guard behavior are unchanged.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact controller or self-triggered loop is involved.


### PR DESCRIPTION
## Summary

- make `instar doctor` construct its diagnostic vault with the configured file-key policy
- make the secret-sync source guard prove both scan boundaries before counting wiring
- add a dedicated machine-doctor reintroduction guard

## ELI16

A headless machine may deliberately keep its encrypted-vault key in protected local state because a background process cannot reliably use the login keychain. Runtime writers already honor that choice, but the health command opened the vault through the default path and could describe the machine as keychain-backed. This passes the same explicit policy into the diagnostic read. It does not move keys, expose secrets, or change anyone’s configuration.

The adjacent source-scanning test also proves both section markers exist in the right order, so a renamed end marker cannot silently widen the scan and pass for the wrong reason.

## Evidence

- focused policy-wiring tests: 2/2 green
- full lint: green
- build: green
- development preflight: green
- affected pre-push smoke: 2/2 green

## Review provenance

Closes follow-ups fb-49c697aa-383 and fb-9896605c-700 from Echo's exact-head review of PR #1508. The decision-artifact traceability follow-up is intentionally split into a separate gate-focused PR.
