### PR TITLE
fix: preserve decision trace identity and scope

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-18T18-09-19-578Z-decision-trace-identity.json
+++ b/.instar/instar-dev-decisions/2026-07-18T18-09-19-578Z-decision-trace-identity.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-07-18T18:09:19.578Z",
+  "slug": "decision-trace-identity",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 27,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/instar-dev-precommit.js",
+      "skills/instar-dev/scripts/write-trace.mjs"
+    ],
+    "addedLines": 23,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-18T18-10-49-505Z-decision-trace-identity.json
+++ b/.instar/instar-dev-decisions/2026-07-18T18-10-49-505Z-decision-trace-identity.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-07-18T18:10:49.505Z",
+  "slug": "decision-trace-identity",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 27,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/instar-dev-precommit.js",
+      "skills/instar-dev/scripts/write-trace.mjs"
+    ],
+    "addedLines": 23,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-18T18-11-55-415Z-decision-trace-identity.json
+++ b/.instar/instar-dev-decisions/2026-07-18T18-11-55-415Z-decision-trace-identity.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-07-18T18:11:55.415Z",
+  "slug": "decision-trace-identity",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 27,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/instar-dev-precommit.js",
+      "skills/instar-dev/scripts/write-trace.mjs"
+    ],
+    "addedLines": 23,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/tier-classifier-and-tier1-path-spec.eli16.md
+++ b/docs/specs/tier-classifier-and-tier1-path-spec.eli16.md
@@ -1,5 +1,7 @@
 # Plain-English overview: the gate that suggests a tier and opens a lighter lane
 
+**Constitutional anchor:** This process implements **The Body and the Mind**: deterministic infrastructure supplies risk signals and durable evidence, while the agent retains the contextual tier decision and makes that decision reviewable.
+
 ## What this is
 
 This is the first build step of the tiered-development project you approved. It changes

--- a/docs/specs/tier-classifier-and-tier1-path-spec.md
+++ b/docs/specs/tier-classifier-and-tier1-path-spec.md
@@ -2,6 +2,7 @@
 title: "Tier classifier + Tier-1 PR path (Step A of the tiered development process)"
 date: 2026-06-01
 author: echo
+parent-principle: "The Body and the Mind"
 review-convergence: abbreviated-internal-2026-06-01
 approved: true
 approved-by: Justin

--- a/scripts/instar-dev-precommit.js
+++ b/scripts/instar-dev-precommit.js
@@ -251,14 +251,14 @@ if (bootstrapTrigger) {
 
 let tierSignal = { suggestedTier: 2, sizeTier: 2, riskFloor: 1, reasons: [] };
 let totalChangedLoc = 0;
+let addedLines = 0;
+let deletedLines = 0;
 // Hoisted to module scope (docs/specs/self-action-convergence.md → E3 impl
 // note): addedDiffText is computed in the Step-3.5 block but consumed later by
 // assertSelfActionDeclared at BOTH the enforceTier1 and Tier-2 pass-through call
 // sites. It must outlive the block.
 let addedDiffText = '';
 {
-  let addedLines = 0;
-  let deletedLines = 0;
   try {
     const numstat = execSync(
       `git diff --cached --numstat -- ${inScopeFiles.map((f) => JSON.stringify(f)).join(' ')}`,
@@ -360,7 +360,13 @@ try {
   // path (the existing Step 5 loop will surface the malformed-JSON attempt).
 }
 
-const slug = (freshestTrace && (freshestTrace.slug || freshestTrace.name)) || 'unknown';
+const traceArtifactPath = freshestTrace && (
+  freshestTrace.artifactPath || freshestTrace.sideEffectsPath
+);
+const slug = (freshestTrace && (freshestTrace.slug || freshestTrace.name))
+  || (typeof traceArtifactPath === 'string' && traceArtifactPath.trim()
+    ? path.basename(traceArtifactPath, path.extname(traceArtifactPath))
+    : 'unknown');
 const decision = decideRequirementSet(declaredTier);
 
 // ─── Step 4.55: causal autopsy (directive 2026-06-05) ───────────────────
@@ -411,6 +417,9 @@ const decisionEntryPath = writeDecisionAudit({
   belowFloor,
   files: inScopeFiles.length,
   loc: totalChangedLoc,
+  scopeFiles: inScopeFiles,
+  addedLines,
+  deletedLines,
   causalAutopsy,
   classClosure: (freshestTrace && typeof freshestTrace.classClosure === 'object' && freshestTrace.classClosure) || null,
 });
@@ -1321,7 +1330,7 @@ function blockCommit(files, reason) {
 // fire, the line just evaporated with the worktree). If the commit is later
 // blocked by the gate, the staged line simply rides the retry commit — both
 // lines describe real gate evaluations.
-function writeDecisionAudit({ slug, suggestedTier, declaredTier, riskFloor, riskFloorReasons, belowFloor, files, loc, causalAutopsy = null, classClosure = null }) {
+function writeDecisionAudit({ slug, suggestedTier, declaredTier, riskFloor, riskFloorReasons, belowFloor, files, loc, scopeFiles, addedLines, deletedLines, causalAutopsy = null, classClosure = null }) {
   try {
     fs.mkdirSync(DECISIONS_DIR, { recursive: true });
     const ts = new Date().toISOString();
@@ -1347,6 +1356,12 @@ function writeDecisionAudit({ slug, suggestedTier, declaredTier, riskFloor, risk
       belowFloor,
       files,
       loc,
+      scope: {
+        basis: 'staged-in-scope-additions-plus-deletions',
+        files: scopeFiles,
+        addedLines,
+        deletedLines,
+      },
       // Causal autopsy (directive 2026-06-05): what caused the issue this
       // commit fixes — prior-pr / environment-shift / new-code / latent /
       // unknown, with linked PRs. null = not declared (advisory in slice 1).

--- a/skills/instar-dev/scripts/write-trace.mjs
+++ b/skills/instar-dev/scripts/write-trace.mjs
@@ -212,6 +212,10 @@ const duplicateBuildCheck = readDuplicateBuildCheck();
 
 const trace = {
   version: toolchain ? 3 : 2, // v3 only when enriched; readers ignore unknown fields either way
+  // Stable work-item identity consumed by the pre-commit decision audit.
+  // The filename has always carried this value; omitting it from the payload
+  // made the audit fall back to the untraceable "unknown" bucket.
+  slug,
   sessionId: process.env.INSTAR_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID || 'unknown',
   timestamp,
   artifactPath: artifact,

--- a/tests/unit/instar-dev-precommit-audit-staging.test.ts
+++ b/tests/unit/instar-dev-precommit-audit-staging.test.ts
@@ -225,7 +225,6 @@ describe('instar-dev pre-commit — decision-audit line rides the commit (self-s
       path.join(sandbox, '.instar', 'instar-dev-traces', `${Date.now()}-pass-fixture.json`),
       JSON.stringify({
         phase: 'complete',
-        slug: 'pass-fixture',
         tier: 1,
         coveredFiles: [srcRel, eli16Rel, seRel],
         eli16Path: eli16Rel,
@@ -245,6 +244,12 @@ describe('instar-dev pre-commit — decision-audit line rides the commit (self-s
     );
     expect(entry.verdict).toBe('pass');
     expect(entry.slug).toBe('pass-fixture');
+    expect(entry.scope).toEqual({
+      basis: 'staged-in-scope-additions-plus-deletions',
+      files: [srcRel],
+      addedLines: 1,
+      deletedLines: 0,
+    });
   });
 });
 

--- a/tests/unit/write-trace-tier.test.ts
+++ b/tests/unit/write-trace-tier.test.ts
@@ -91,6 +91,7 @@ describe('write-trace.mjs — tier declaration (Step A)', () => {
     expect(trace).not.toHaveProperty('specPath');
     // Existing fields still present + correct.
     expect(trace.phase).toBe('complete');
+    expect(trace.slug).toBe('widget');
     expect(trace.artifactPath).toBe(artifact);
     expect(trace.coveredFiles).toEqual(['src/a.ts', 'src/b.ts']);
     expect(typeof trace.artifactSha256).toBe('string');

--- a/upgrades/next/decision-trace-identity.md
+++ b/upgrades/next/decision-trace-identity.md
@@ -1,0 +1,19 @@
+# Development decision records now retain their work-item identity
+
+## What Changed
+
+The canonical development trace writer now stores the same work-item identity inside the trace that it already uses in the trace filename. The commit gate also derives that identity from the bound review artifact for older traces and records the exact staged source files plus added/deleted-line basis behind its compact file and line counters.
+
+## Evidence
+
+- Trace-writer and commit-gate focused suites pass together.
+- A legacy-shaped trace without an explicit identity is correctly bound from its side-effects artifact.
+- Decision records expose both their compact counters and the concrete scope used to compute them.
+
+## What to Tell Your User
+
+Internal development audit records are now easier to trace back to the reviewed change and explain exactly what their size counters measured.
+
+## Summary of New Capabilities
+
+- Stable, self-describing development decision evidence across current and legacy trace shapes.

--- a/upgrades/side-effects/decision-trace-identity.md
+++ b/upgrades/side-effects/decision-trace-identity.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — Decision trace identity and scope
+
+**Version / slug:** `decision-trace-identity`
+**Date:** 2026-07-18
+**Author:** Instar Agent (instar-codey)
+**Second-pass reviewer:** required — development commit gate
+
+## Summary of the change
+
+The canonical trace writer persists its artifact-derived work-item identity in the trace body. The commit gate falls back to the bound artifact basename for older trace shapes and expands each decision record with the exact in-scope file list, added lines, deleted lines, and a named counting basis. Legacy `files` and `loc` counters remain for compatible readers.
+
+## Decision-point inventory
+
+The gate's allow/block requirements do not change. This patch changes only the evidence attached to every existing gate evaluation and the identity used to name that evidence.
+
+## 1. Over-block
+
+No new refusal is introduced. Legacy traces remain accepted through deterministic artifact-bound fallback.
+
+## 2. Under-block
+
+The fallback uses only the trace's already-verified review artifact path, never a branch guess or free-form inference. A trace lacking both explicit identity and a bound artifact retains the honest `unknown` value.
+
+## 3. Level-of-abstraction fit
+
+The writer owns the canonical trace shape; the pre-commit audit writer owns the persisted decision schema. Fixing both ends prevents downstream consumers from reconstructing identity or counter semantics heuristically.
+
+## 4. Signal vs authority compliance
+
+Identity and scope are evidence, not authority. The existing declared tier and requirement set still decide which gate path runs.
+
+## 4b. Judgment-point check
+
+No new competing-signals judgment is added. Fallback is closed and deterministic: explicit trace identity, then bound artifact basename, then honest unknown.
+
+## 5. Interactions
+
+- Current trace writers produce explicit identity.
+- Older traces with an artifact bind cleanly without migration.
+- Existing consumers keep reading `files` and `loc`; new consumers can inspect `scope`.
+- Per-decision filenames become stable for canonical traces, reducing the untraceable bucket without changing collision handling.
+
+## 6. External surfaces
+
+Internal JSON evidence gains additive fields. No runtime API, agent state, credential, or operator action changes.
+
+## 6b. Operator-surface quality
+
+The audit becomes explainable: a reviewer can see which source files and line categories produced the compact counters instead of mistaking an in-scope count for the whole PR diff.
+
+## 7. Multi-machine posture
+
+Decision entries remain repository evidence committed with their change. Distinct per-entry paths preserve parallel-branch conflict immunity; no machine-local authority is introduced.
+
+## 8. Rollback cost
+
+A direct revert restores the former trace shape and compact-only audit. Additive fields in already-merged entries remain harmless to older readers.
+
+## Conclusion
+
+The patch improves evidence identity and interpretability without changing gate authority or refusal semantics. Focused writer/gate tests are green.
+
+## Second-pass review
+
+Required because this changes evidence emitted by the development commit gate. Echo exact-head review is the ship gate.
+
+## Class-Closure Declaration
+
+This closes the class where a producer derives a stable identity but fails to persist it in the payload consumed by downstream audit machinery. The guard is a writer round-trip assertion plus a legacy-fallback gate assertion.


### PR DESCRIPTION
## Summary

- persist the artifact-derived work-item identity in canonical development traces
- recover identity from the bound artifact for legacy traces
- make decision-audit size counters self-describing with exact in-scope files and added/deleted-line basis
- add the previously missing constitutional anchor to the approved tier-process spec and its plain-English overview

## ELI16

The trace writer already derived a stable name and used it in the trace filename, but forgot to put that name inside the trace JSON. The commit gate reads the JSON, so valid builds could be recorded under an untraceable “unknown” identity. This stores the name in the payload and gives old traces a deterministic fallback from their already-bound review artifact.

The audit’s compact file and line counters measure only staged source files governed by the development gate, not every file in the pull request. The record now includes those exact files and separate added/deleted counts, making that scope explicit while preserving the old counters for existing readers.

## Evidence

- focused trace-writer and gate suite: 14/14 green
- full lint: green
- build: green
- affected pre-push smoke: 14/14 green
- commit gate passed against the existing approved tier-process spec

## Review provenance

Closes fb-2b24aa04-540 from Echo's exact-head review of PR #1508. Exact-head Echo review is required before merge because this changes development-gate evidence.
