### PR TITLE
Link dry-run reconciler decisions to outcomes

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-18T18-48-10-330Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T18-48-10-330Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-18T18:48:10.330Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 111,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-18T18-48-16-311Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T18-48-16-311Z-unknown.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-18T18:48:16.311Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 111,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/AutonomousLivenessReconciler.ts
+++ b/src/monitoring/AutonomousLivenessReconciler.ts
@@ -252,6 +252,9 @@ export class AutonomousLivenessReconciler {
   private readonly pressureSurfaced = new Set<number>();
   private lastTickAt: number | null = null;
   private respawnTotal = 0;
+  /** Observe-only decisions awaiting one next-tick outcome classification. */
+  private readonly dryRunFollowups = new Map<number, { decisionId: string; decidedAt: number; startedAtMs: number | null }>();
+  private dryRunDecisionSeq = 0;
   /** Effective inflight TTL (cfg.inflightSpawnTtlMs ?? respawnTimeoutMs + grace). */
   private readonly inflightTtlMs: number;
 
@@ -325,9 +328,50 @@ export class AutonomousLivenessReconciler {
     }
 
     // Hoist the once-per-tick snapshots (criterion 6, pressure gate).
-    const liveTopics = this.safe(() => this.deps.liveTopicSnapshot(), new Set<number>());
+    let liveTopicsEvidence: Set<number> | null = null;
+    try {
+      liveTopicsEvidence = this.deps.liveTopicSnapshot();
+    } catch {
+      // Actuation still fails safe below; evidence classification stays honest.
+    }
+    const liveTopics = liveTopicsEvidence ?? new Set<number>();
     const pressure = this.safe(() => this.deps.pressureTier(), 'critical' as const);
     const queuePaused = this.safeBool(() => this.deps.queuePaused(), false);
+
+    // Close the observe-only evidence loop before making this tick's decisions.
+    // This never actuates: it classifies what happened after the prior
+    // would-respawn so production soak can measure false positives.
+    if (this.cfg.dryRun) {
+      const runsByTopic = new Map(runs.map((run) => [run.topicId, run]));
+      for (const [topicId, pending] of this.dryRunFollowups) {
+        const run = runsByTopic.get(topicId);
+        let outcome = 'still-orphaned';
+        if (!run || run.remainingSeconds <= 0) outcome = 'run-ended';
+        else if (liveTopicsEvidence == null) outcome = 'evidence-unknown';
+        else if (liveTopicsEvidence.has(topicId)) outcome = 'recovered-live';
+        else {
+          try {
+            if (this.deps.operatorStoppedSince(topicId, new Date(pending.startedAtMs ?? 0).toISOString())) {
+              outcome = 'operator-stopped';
+            } else if (this.deps.topicOwnerElsewhere(topicId)) outcome = 'owner-moved';
+            else if (!this.deps.holdsLease()) outcome = 'lease-lost';
+            else if (this.deps.topicInResumeQueue(topicId)) outcome = 'queued-elsewhere';
+          } catch {
+            outcome = 'evidence-unknown';
+          }
+        }
+        this.deps.audit({
+          ts: new Date(now).toISOString(),
+          event: 'would-respawn-followup',
+          topicId,
+          decisionId: pending.decisionId,
+          decidedAt: new Date(pending.decidedAt).toISOString(),
+          outcome,
+          dryRun: true,
+        });
+        this.dryRunFollowups.delete(topicId);
+      }
+    }
 
     const candidateTopics = new Set<number>();
     let actedThisTick = false;
@@ -595,6 +639,7 @@ export class AutonomousLivenessReconciler {
 
     // ── dryRun: log what we WOULD do and actuate nothing ──
     if (this.cfg.dryRun) {
+      const decisionId = `liveness:${topicId}:${now}:${++this.dryRunDecisionSeq}`;
       this.deps.audit({
         ts: new Date(now).toISOString(),
         event: 'would-respawn',
@@ -602,7 +647,9 @@ export class AutonomousLivenessReconciler {
         dryRun: true,
         remainingSeconds: run.remainingSeconds,
         resumeUuid: resumeUuid ? 'present' : 'fresh-fallback',
+        decisionId,
       });
+      this.dryRunFollowups.set(topicId, { decisionId, decidedAt: now, startedAtMs: run.startedAtMs });
       // Shadow the cap (spec adversarial F6): record a shadow redie so the
       // reaper-thrash/cap BEHAVIOR — which real dryRun can't trigger (no real
       // respawn ⇒ no re-die) — still becomes observable as a would-have-capped

--- a/src/monitoring/DuplicateSessionReconciler.ts
+++ b/src/monitoring/DuplicateSessionReconciler.ts
@@ -185,6 +185,15 @@ export class DuplicateSessionReconciler {
   private lastTick: ReconcilerTickReport | null = null;
   private substrateNotReadySince: number | null = null;
   private substratePauseItemRaised = false;
+  /** Observe-only decisions awaiting one subsequent discovery classification. */
+  private readonly dryRunFollowups = new Map<string, {
+    decisionId: string;
+    decidedAt: number;
+    owner: string;
+    rule: 'hard-pin' | 'highest-epoch' | 'live-run';
+    discoveryUnknownLogged: boolean;
+  }>();
+  private dryRunDecisionSeq = 0;
   private counters: Record<string, number> = {
     ticks: 0,
     candidatesSeen: 0,
@@ -247,6 +256,30 @@ export class DuplicateSessionReconciler {
       }
       report.candidates = candidates.length;
       this.counters.candidatesSeen += candidates.length;
+
+      if (this.cfg.dryRun) {
+        const discovered = new Set(candidates.map((candidate) => candidate.key));
+        for (const [key, pending] of this.dryRunFollowups) {
+          if (discovered.has(key)) continue;
+          if (degraded) {
+            if (!pending.discoveryUnknownLogged) {
+              this.journalRow({
+                kind: 'would-converge-followup', key, decisionId: pending.decisionId,
+                decidedAt: new Date(pending.decidedAt).toISOString(),
+                outcome: 'discovery-unknown', degraded, dryRun: true,
+              });
+              pending.discoveryUnknownLogged = true;
+            }
+            continue;
+          }
+          this.journalRow({
+            kind: 'would-converge-followup', key, decisionId: pending.decisionId,
+            decidedAt: new Date(pending.decidedAt).toISOString(),
+            outcome: 'duplicate-not-rediscovered', dryRun: true,
+          });
+          this.dryRunFollowups.delete(key);
+        }
+      }
 
       let reconcilesThisTick = 0;
       let writesThisTick = 0;
@@ -331,12 +364,24 @@ export class DuplicateSessionReconciler {
       // Duplicate no longer exists — close the episode quietly.
       this.episodes.delete(cand.key);
       this.journalRow({ kind: 'duplicate-resolved-before-action', key: cand.key });
+      this.closeDryRunFollowup(cand.key, 'duplicate-resolved-on-fresh-probe');
       return { consumed: true, wrote: false };
     }
 
     // Intended-owner determination (§3.2.2, evidence-ordered).
     const verdict = await this.intendedOwner(sessionKey, cand, ep);
     this.provenanceRow(cand, verdict);
+    const pending = this.dryRunFollowups.get(cand.key);
+    if (pending && this.cfg.dryRun) {
+      const outcome = verdict.kind === 'escalate'
+        ? 'survivor-became-ambiguous'
+        : verdict.owner === pending.owner && verdict.rule === pending.rule
+          ? 'duplicate-persists-survivor-stable'
+          : 'duplicate-persists-survivor-changed';
+      this.closeDryRunFollowup(cand.key, outcome, verdict.kind === 'owner'
+        ? { observedOwner: verdict.owner, observedRule: verdict.rule }
+        : { observedReason: verdict.reason });
+    }
     if (verdict.kind === 'escalate') {
       this.escalateOnce(ep, cand, verdict.reason, report);
       return { consumed: true, wrote: false };
@@ -351,6 +396,7 @@ export class DuplicateSessionReconciler {
 
     ep.convergenceAttempts++;
     if (this.cfg.dryRun) {
+      const decisionId = `duplicate:${cand.key}:${now}:${++this.dryRunDecisionSeq}`;
       report.wouldConverge++;
       this.counters.wouldConverge++;
       this.journalRow({
@@ -362,6 +408,11 @@ export class DuplicateSessionReconciler {
         machines: liveMachines.map((m) => m.machineId),
         attempts: ep.convergenceAttempts,
         dryRun: true,
+        decisionId,
+      });
+      this.dryRunFollowups.set(cand.key, {
+        decisionId, decidedAt: now, owner: verdict.owner, rule: verdict.rule,
+        discoveryUnknownLogged: false,
       });
       // Dry-run counts an episode "handled" — reset so the soak journals each
       // tick's fresh verdict without escalating attempt exhaustion.
@@ -631,6 +682,17 @@ export class DuplicateSessionReconciler {
 
   private journalRow(row: Record<string, unknown>): void {
     this.deps.journal.append({ ts: new Date(this.nowFn()).toISOString(), ...row });
+  }
+
+  private closeDryRunFollowup(key: string, outcome: string, extra: Record<string, unknown> = {}): void {
+    const pending = this.dryRunFollowups.get(key);
+    if (!pending) return;
+    this.journalRow({
+      kind: 'would-converge-followup', key, decisionId: pending.decisionId,
+      decidedAt: new Date(pending.decidedAt).toISOString(),
+      priorOwner: pending.owner, priorRule: pending.rule, outcome, dryRun: true, ...extra,
+    });
+    this.dryRunFollowups.delete(key);
   }
 
   private provenanceRow(cand: DuplicateCandidate, verdict: IntendedOwnerVerdict): void {

--- a/tests/unit/AutonomousLivenessReconciler.test.ts
+++ b/tests/unit/AutonomousLivenessReconciler.test.ts
@@ -335,6 +335,61 @@ describe('AutonomousLivenessReconciler', () => {
       expect(h.audit.some((e) => e.event === 'would-respawn' && e.dryRun === true)).toBe(true);
     });
 
+    it('links a would-respawn to the next-tick recovered-live outcome', async () => {
+      const h = build({ dryRun: true, debounceTicks: 1, debounceWindowSec: 0 });
+      await h.reconciler.tick();
+      const decision = h.audit.find((e) => e.event === 'would-respawn');
+      h.flags.liveTopics.add(100);
+      h.nowMs.v += 1_000;
+      await h.reconciler.tick();
+      expect(h.audit).toContainEqual(expect.objectContaining({
+        event: 'would-respawn-followup',
+        topicId: 100,
+        decisionId: decision?.decisionId,
+        outcome: 'recovered-live',
+        dryRun: true,
+      }));
+    });
+
+    it('classifies a continuing dry-run opportunity as still-orphaned', async () => {
+      const h = build({ dryRun: true, debounceTicks: 1, debounceWindowSec: 0 });
+      await h.reconciler.tick();
+      const decision = h.audit.find((e) => e.event === 'would-respawn');
+      h.nowMs.v += 1_000;
+      await h.reconciler.tick();
+      expect(h.audit).toContainEqual(expect.objectContaining({
+        event: 'would-respawn-followup',
+        decisionId: decision?.decisionId,
+        outcome: 'still-orphaned',
+      }));
+    });
+
+    it('classifies an operator stop without respawning', async () => {
+      const h = build({ dryRun: true, debounceTicks: 1, debounceWindowSec: 0 });
+      await h.reconciler.tick();
+      h.flags.operatorStopped.add(100);
+      h.nowMs.v += 1_000;
+      await h.reconciler.tick();
+      expect(h.audit).toContainEqual(expect.objectContaining({
+        event: 'would-respawn-followup',
+        outcome: 'operator-stopped',
+      }));
+      expect(h.respawned).toHaveLength(0);
+    });
+
+    it('classifies unreadable follow-up evidence as unknown', async () => {
+      const h = build({ dryRun: true, debounceTicks: 1, debounceWindowSec: 0 });
+      await h.reconciler.tick();
+      const original = h.flags.liveTopics;
+      Object.defineProperty(h.flags, 'liveTopics', { get: () => { throw new Error('snapshot unreadable'); }, configurable: true });
+      h.nowMs.v += 1_000;
+      await h.reconciler.tick();
+      expect(h.audit).toContainEqual(expect.objectContaining({
+        event: 'would-respawn-followup', outcome: 'evidence-unknown',
+      }));
+      Object.defineProperty(h.flags, 'liveTopics', { value: original, writable: true, configurable: true });
+    });
+
     it('logs a shadow would-have-capped event in dryRun (adversarial F6)', async () => {
       const h = build({ dryRun: true, respawnCapPerWindow: 2, debounceTicks: 1, debounceWindowSec: 0 });
       // dryRun records a SHADOW redie per would-respawn, so the cap trips and the

--- a/tests/unit/DuplicateSessionReconciler.test.ts
+++ b/tests/unit/DuplicateSessionReconciler.test.ts
@@ -341,6 +341,48 @@ describe('dry-run posture (Increment-1 default)', () => {
     expect(row).toBeTruthy();
     expect(row!.owner).toBe('laptop');
     expect(row!.dryRun).toBe(true);
+    expect(typeof row!.decisionId).toBe('string');
+  });
+
+  it('links a dry-run decision to a stable survivor on the next observation', async () => {
+    const deps = makeDeps({ readPin: vi.fn(() => ({ pinned: true, preferredMachine: 'laptop' })) });
+    const r = new DuplicateSessionReconciler(cfg({ dryRun: true }), deps);
+    await r.tick();
+    const decision = deps.rows.find((x) => x.kind === 'would-converge');
+    await r.tick();
+    expect(deps.rows).toContainEqual(expect.objectContaining({
+      kind: 'would-converge-followup', decisionId: decision?.decisionId,
+      outcome: 'duplicate-persists-survivor-stable', priorOwner: 'laptop', observedOwner: 'laptop',
+    }));
+  });
+
+  it('links a dry-run decision to a duplicate that is no longer discovered', async () => {
+    const deps = makeDeps({ readPin: vi.fn(() => ({ pinned: true, preferredMachine: 'laptop' })) });
+    const r = new DuplicateSessionReconciler(cfg({ dryRun: true }), deps);
+    await r.tick();
+    const decision = deps.rows.find((x) => x.kind === 'would-converge');
+    (deps.discoverCandidates as ReturnType<typeof vi.fn>).mockResolvedValue({ candidates: [] });
+    await r.tick();
+    expect(deps.rows).toContainEqual(expect.objectContaining({
+      kind: 'would-converge-followup', decisionId: decision?.decisionId,
+      outcome: 'duplicate-not-rediscovered',
+    }));
+  });
+
+  it('does not treat degraded non-discovery as duplicate resolution', async () => {
+    const deps = makeDeps({ readPin: vi.fn(() => ({ pinned: true, preferredMachine: 'laptop' })) });
+    const r = new DuplicateSessionReconciler(cfg({ dryRun: true }), deps);
+    await r.tick();
+    const decision = deps.rows.find((x) => x.kind === 'would-converge');
+    (deps.discoverCandidates as ReturnType<typeof vi.fn>).mockResolvedValue({ candidates: [], degraded: 'peer unavailable' });
+    await r.tick();
+    expect(deps.rows).toContainEqual(expect.objectContaining({
+      kind: 'would-converge-followup', decisionId: decision?.decisionId,
+      outcome: 'discovery-unknown',
+    }));
+    expect(deps.rows).not.toContainEqual(expect.objectContaining({
+      decisionId: decision?.decisionId, outcome: 'duplicate-not-rediscovered',
+    }));
   });
 
   it('dry-run on a PERSISTING duplicate journals fresh verdicts until the P19 breaker clamps — never attempt-exhaustion, never unbounded journal spam', async () => {

--- a/upgrades/next/duplicate-safety-outcome-linked-soak.md
+++ b/upgrades/next/duplicate-safety-outcome-linked-soak.md
@@ -1,0 +1,27 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Improves the observe-only soak evidence for duplicate-session and autonomous-liveness reconciliation. Each `would-converge` or `would-respawn` decision now carries a correlation identifier and receives one later classification describing what the next trustworthy observation showed. Degraded or unreadable evidence is labeled unknown instead of being treated as recovery or persistence. Both reconcilers retain their existing dry-run defaults; this change adds no spawn, ownership-write, closeout, notification, or enforcement authority.
+
+Side-effects review: `upgrades/side-effects/duplicate-safety-outcome-linked-soak.md`.
+
+## What to Tell Your User
+
+The duplicate-session and autonomous-run safety monitors now collect better evidence before any future rollout decision. They remain observation-only.
+
+## Summary of New Capabilities
+
+- Outcome-linked dry-run evidence for duplicate survivor decisions.
+- Outcome-linked dry-run evidence for autonomous liveness respawn opportunities.
+- Explicit unknown classifications for degraded discovery or unreadable liveness evidence.
+
+## Evidence
+
+- 102 focused reconciler unit tests pass.
+- 34 relevant integration/E2E tests pass, with three existing TODOs.
+- Full TypeScript/lint and build gates pass.
+- The repository-wide unit suite's one designated flaky messaging failure passed on isolated rerun.
+- Independent session-lifecycle review concurred after two evidence-integrity concerns were fixed.

--- a/upgrades/side-effects/duplicate-safety-outcome-linked-soak.md
+++ b/upgrades/side-effects/duplicate-safety-outcome-linked-soak.md
@@ -1,0 +1,82 @@
+# Side-Effects Review — Outcome-linked reconciler soak evidence
+
+**Version / slug:** `duplicate-safety-outcome-linked-soak`
+**Date:** 2026-07-18
+**Author:** Instar-codey
+**Second-pass reviewer:** independent Codex subagent (concerns resolved)
+
+## Summary of the change
+
+The two observe-only session reconcilers now correlate each dry-run decision with one subsequent observation. `AutonomousLivenessReconciler` classifies whether a would-respawn opportunity recovered, remained orphaned, ended, stopped, moved owner, lost its lease, or entered the queue. `DuplicateSessionReconciler` classifies whether the duplicate disappeared, resolved under fresh probes, persisted with the same survivor, changed survivor evidence, or became ambiguous. The patch changes no feature flag, CAS, closeout, spawn, notification, or enforcement path.
+
+## Decision-point inventory
+
+- `AutonomousLivenessReconciler` dry-run branch — pass-through — records a decision identifier and later observation; it still returns before spawn authority.
+- `DuplicateSessionReconciler` dry-run branch — pass-through — records a decision identifier and later observation; it still returns before CAS and closeout authority.
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. Follow-up classification errors affect soak interpretation only and cannot refuse a spawn, terminate a session, mutate ownership, or notify a user.
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. A process restart between decision and follow-up loses the in-memory correlation; this is intentionally honest rather than reconstructing causality from logs. Duplicate non-rediscovery means only that discovery did not return the key on the next observation, not proof that closeout occurred.
+
+## 3. Level-of-abstraction fit
+
+This is at the detector/observability layer beside the existing dry-run audit writes. It consumes the reconcilers' existing authoritative snapshots and emits bounded classifications. It does not duplicate routing, ownership, spawn, or closeout logic.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The new logic produces review evidence only. Existing deterministic safety floors and authorities remain unchanged, and both components remain dry-run.
+
+## 4b. Judgment-point check
+
+No new static heuristic controls a competing-signals decision. The outcome labels are explicitly observations for later human/reviewer judgment; none selects a survivor or authorizes a respawn.
+
+## 5. Interactions
+
+- **Shadowing:** Follow-ups run before the next tick's decision so they cannot be overwritten by a new decision identifier.
+- **Double-fire:** Each pending entry is deleted immediately after one follow-up row; a topic/key has at most one pending correlation.
+- **Races:** Tick execution is already single-instance per reconciler. State is process-local and bounded by topic/key.
+- **Feedback loops:** The audit rows are not read by either reconciler and therefore cannot alter actuation.
+
+## 6. External surfaces
+
+The only external surface is additional fields and follow-up rows in the existing machine-local audit logs. There are no user-facing notices, routes, URLs, schema migrations, or external service calls. Timing affects which honest next-observation label is recorded; the decision timestamp is preserved for review.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Machine-local BY DESIGN:** both logs describe what one machine's reconciler observed and decided from its local serving/lease context. Pool-wide graduation review can aggregate existing audit artifacts, but the correlation itself must not be replicated because that could falsely join one machine's decision to another machine's observation. No notices, durable authority state, or URLs are added, and no state can strand a topic transfer because pending correlations expire with the process and never actuate.
+
+## 8. Rollback cost
+
+Pure code rollback: revert the four implementation/test files and ship a patch. Existing appended JSONL rows remain harmless unknown event kinds to older readers. No data migration, agent repair, or user-visible rollback is required.
+
+## Conclusion
+
+The change closes the measured soak-evidence gap while preserving the plan's NOT-READY verdicts and observation-only posture. It is safe to ship once the independent session-lifecycle review concurs and CI is green.
+
+## Second-pass review
+
+**Reviewer:** independent Codex subagent
+**Independent read of the artifact:** concur. The first pass found degraded discovery being mislabeled as resolution and safety-defaulted dependency failures being mislabeled as positive outcomes. The implementation now retains degraded duplicate follow-ups with a deduped `discovery-unknown` row, emits `evidence-unknown` for unreadable liveness evidence, and adds per-instance sequence values to decision IDs. The revised changes preserve observe-only authority; pending state remains bounded and 102 focused tests pass.
+
+## Evidence pointers
+
+- 100 focused unit tests passed.
+- 34 relevant integration/E2E tests passed, with three pre-existing TODOs.
+- Full lint/typecheck and build passed.
+- Repository-wide unit suite had one designated flaky messaging test fail; its isolated rerun passed.
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no action-bearing controller modification. The controller changes are observe-only audit signals with no self-action edge; class closure is not applicable.


### PR DESCRIPTION
## ELI16 — Better evidence before automation gets permission

Two safety monitors currently watch for bad situations without fixing them automatically. One notices when the same conversation is running on two computers; the other notices when an autonomous job says it is active but has no live session. Today they can record “I would fix this,” but they do not record what happened next. That makes it hard to tell whether their proposed fix was consistently right or whether the situation recovered on its own.

This change gives each proposed action a receipt number and checks the next trustworthy observation. It can then record plain outcomes such as “the duplicate is still there and the same copy should survive,” “the session came back by itself,” or “the evidence was unavailable.” Unavailable evidence is never counted as success. Most importantly, both monitors remain observation-only: they still cannot close a session, change ownership, or restart a job. This only creates the evidence needed for a later, separately reviewed decision about whether automation is safe.

## What changed

- correlate duplicate `would-converge` decisions with one later trustworthy observation
- correlate liveness `would-respawn` decisions with one later trustworthy observation
- label degraded or unreadable evidence as unknown rather than manufacturing favorable soak outcomes
- preserve both reconcilers in dry-run/observe-only mode
- add focused canaries, side-effects review, and release notes

## Why

Drive 6 Workstream 2 found that both NOT-READY reconcilers lacked outcome-linked production soak evidence. A decision row alone cannot establish whether a survivor choice remained stable or a respawn opportunity was a false positive. This patch closes only that evidence gap; it does not graduate either authority.

Fundamental-gap records: `fb-fe2f0eba-e94` and `fb-7c84704f-41b`.

## Impact

Existing machine-local audit logs gain correlation identifiers and follow-up event rows. There are no new ownership writes, spawns, closeouts, notifications, routes, or feature-flag changes.

## Validation

- 102 focused unit tests passed before rebase; 102 passed after review fixes
- 136 focused/relevant tests passed after rebasing to current canonical main, with 3 existing TODOs
- lint/typecheck and build passed
- repository-wide suite had one designated flaky messaging test fail; isolated rerun passed
- independent session-lifecycle review concurred after degraded/unknown evidence fixes

Side-effects review: `upgrades/side-effects/duplicate-safety-outcome-linked-soak.md`.

