### PR TITLE
fix: mcp-health-autorefresh silently inert on macOS (bare coreutils timeout) — portable runner ladder

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-18T19-53-29-340Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T19-53-29-340Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-18T19:53:29.340Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 16,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-18T19-53-33-077Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T19-53-33-077Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-18T19:53:33.077Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 16,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-18T19-53-39-648Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T19-53-39-648Z-unknown.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-18T19:53:39.648Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 16,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-18T19-54-52-640Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T19-54-52-640Z-unknown.json
@@ -1,0 +1,21 @@
+{
+  "ts": "2026-07-18T19:54:52.640Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 16,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "no new self-action: the added kill() is the perl timeout rung reaping its OWN bounded child probe (process hygiene inside a one-shot session-start probe), not a controller emit; the hook's pre-existing refresh action is unchanged and remains hard-bounded by the once-per-(session,failed-set) marker loop-guard"
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-18T19-55-21-606Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T19-55-21-606Z-unknown.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-07-18T19:55:21.606Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 16,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent since the hook was authored: the probe assumed GNU timeout on PATH. It only manifests on coreutils-less macOS (production Macs without Homebrew coreutils); Linux CI always has timeout, and the error was swallowed by 2>/dev/null || true, so the hook was silently inert rather than failing loudly. Surfaced by the unit test run on such a Mac during the realcheck-utf8 fix cycle."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "no new self-action: the added kill() is the perl timeout rung reaping its OWN bounded child probe (process hygiene inside a one-shot session-start probe), not a controller emit; the hook's pre-existing refresh action is unchanged and remains hard-bounded by the once-per-(session,failed-set) marker loop-guard"
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-18T19-55-25-519Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T19-55-25-519Z-unknown.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-07-18T19:55:25.519Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 16,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent since the hook was authored: the probe assumed GNU timeout on PATH. It only manifests on coreutils-less macOS (production Macs without Homebrew coreutils); Linux CI always has timeout, and the error was swallowed by 2>/dev/null || true, so the hook was silently inert rather than failing loudly. Surfaced by the unit test run on such a Mac during the realcheck-utf8 fix cycle."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "no new self-action: the added kill() is the perl timeout rung reaping its OWN bounded child probe (process hygiene inside a one-shot session-start probe), not a controller emit; the hook's pre-existing refresh action is unchanged and remains hard-bounded by the once-per-(session,failed-set) marker loop-guard"
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-18T19-55-55-914Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T19-55-55-914Z-unknown.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-07-18T19:55:55.914Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 16,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent since the hook was authored: the probe assumed GNU timeout on PATH. It only manifests on coreutils-less macOS (production Macs without Homebrew coreutils); Linux CI always has timeout, and the error was swallowed by 2>/dev/null || true, so the hook was silently inert rather than failing loudly. Surfaced by the unit test run on such a Mac during the realcheck-utf8 fix cycle."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "no new self-action: the added kill() is the perl timeout rung reaping its OWN bounded child probe (process hygiene inside a one-shot session-start probe), not a controller emit; the hook's pre-existing refresh action is unchanged and remains hard-bounded by the once-per-(session,failed-set) marker loop-guard"
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-18T19-56-20-255Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-18T19-56-20-255Z-unknown.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-07-18T19:56:20.255Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 16,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent since the hook was authored: the probe assumed GNU timeout on PATH. It only manifests on coreutils-less macOS (production Macs without Homebrew coreutils); Linux CI always has timeout, and the error was swallowed by 2>/dev/null || true, so the hook was silently inert rather than failing loudly. Surfaced by the unit test run on such a Mac during the realcheck-utf8 fix cycle."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "no new self-action: the added kill() is the perl timeout rung reaping its OWN bounded child probe (process hygiene inside a one-shot session-start probe), not a controller emit; the hook's pre-existing refresh action is unchanged and remains hard-bounded by the once-per-(session,failed-set) marker loop-guard"
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/mcp-autorefresh-timeout-macos.eli16.md
+++ b/docs/specs/mcp-autorefresh-timeout-macos.eli16.md
@@ -1,0 +1,45 @@
+# ELI16 — MCP Auto-Refresh Hook: macOS Timeout Portability Fix
+
+**What is this about?** Instar installs a small helper script on every agent called
+`mcp-health-autorefresh.sh`. Its job: at session start, quietly run `claude mcp list` to
+see whether an important tool server (like Playwright, the browser tool) failed to
+connect this session — and if an allowlisted one did, restart the session once so the
+tool comes back. It's deliberately cautious: dark by default, allowlist-scoped, and
+loop-guarded so it can never restart-loop a machine.
+
+**What broke?** On Macs — which is where instar agents actually run in production — the
+script was silently doing nothing at all. Ever. The line that runs the health check was
+`timeout 45 claude mcp list`: it wraps the command in the standard `timeout` program so a
+hung MCP probe can't stall forever. But macOS doesn't ship `timeout` — that's a GNU
+coreutils tool, present on Linux and only on Macs where someone installed Homebrew
+coreutils. On a Mac without it, "timeout: command not found" was swallowed by the
+script's error redirection, the captured output was empty, and the script hit its
+"no output → exit quietly" guard. Result: the auto-recovery feature was silently inert on
+exactly the platform it was built for. No error, no log, nothing — which is why it went
+unnoticed until a unit test that simulates the check failed on a coreutils-less Mac.
+
+**Why did tests pass in CI?** CI runs on Linux, where `timeout` always exists. The unit
+test that caught this (`PostUpdateMigrator-mcpAutorefresh.test.ts`) only fails on a Mac
+without coreutils — like the production machines.
+
+**What does the fix do?** It gives the script the same portable "timeout ladder" the
+autonomous stop hook already uses for exactly this reason: try `timeout` first (Linux,
+or Macs with coreutils), then `gtimeout` (Homebrew's name for it), then fall back to a
+tiny Perl one-liner that forks the command, arms a 45-second alarm, and kills the whole
+process group if it fires. Perl ships with macOS, so the ladder always has a rung on the
+platforms we run on. The Perl rung uses the correct exit-status mapping (128+signal when
+the child is killed by a signal — the same convention GNU timeout and every shell use),
+so a killed probe is never mistaken for a clean result. If literally none of the three
+runners exist, the script stays dark rather than run the probe unbounded — bounded
+execution is a hard requirement, not a nice-to-have.
+
+**How do existing agents get this?** Automatically. This script is a "built-in hook":
+the updater (`PostUpdateMigrator.migrateHooks`) rewrites it fresh into
+`.instar/hooks/instar/` on every update pass — always-overwrite, never
+install-if-missing — so every deployed Mac gets the fixed script on its next instar
+update, with no manual step. The unit suite verifies this migration-parity behavior.
+
+**Is anything less safe now?** No. All the safety properties are untouched: dark by
+default, explicit-false always wins, allowlist-scoped, the once-per-(session, failed-set)
+hard loop-guard, and backgrounded start. The only change is that the health check now
+actually runs on Macs — bounded, exactly as designed.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -10700,7 +10700,21 @@ for c in "\$(command -v claude 2>/dev/null)" /opt/homebrew/bin/claude "\$HOME"/.
 done
 [ -n "\$CLAUDE_BIN" ] || exit 0
 
-LIST=\$(timeout 45 "\$CLAUDE_BIN" mcp list 2>/dev/null || true)
+# Bounded 'claude mcp list' — portable timeout LADDER (timeout → gtimeout → perl-alarm),
+# mirroring the autonomous stop hook's real-check runner. Bare 'timeout' does not exist
+# on coreutils-less macOS (the platform agents actually run on), which previously left
+# LIST empty and made this hook SILENTLY INERT in production there. The perl rung maps
+# signal-death to 128+signal (GNU-timeout semantics — never \$?>>8 alone, whose high
+# byte is 0 for a signal-killed child). A bounded runner is REQUIRED: with none present
+# we stay dark (exit 0) rather than run the command unbounded.
+LIST=""
+if command -v timeout >/dev/null 2>&1; then
+  LIST=\$(timeout 45 "\$CLAUDE_BIN" mcp list 2>/dev/null || true)
+elif command -v gtimeout >/dev/null 2>&1; then
+  LIST=\$(gtimeout 45 "\$CLAUDE_BIN" mcp list 2>/dev/null || true)
+elif command -v perl >/dev/null 2>&1; then
+  LIST=\$(perl -e 'my(\$t,@c)=@ARGV; my \$p=fork; if(\$p==0){setpgrp(0,0); exec @c or exit 127} \$SIG{ALRM}=sub{kill("-KILL",\$p); exit 124}; alarm(\$t); waitpid(\$p,0); exit((\$?&127) ? 128+(\$?&127) : (\$?>>8))' 45 "\$CLAUDE_BIN" mcp list 2>/dev/null || true)
+fi
 [ -n "\$LIST" ] || exit 0
 
 # Allowlisted servers reporting "Failed to connect"

--- a/upgrades/next/mcp-autorefresh-timeout-macos.md
+++ b/upgrades/next/mcp-autorefresh-timeout-macos.md
@@ -1,0 +1,55 @@
+# Upgrade Fragment — mcp-autorefresh-timeout-macos
+
+<!-- bump: patch -->
+
+## What Changed
+
+The `mcp-health-autorefresh.sh` built-in hook (auto-restart-on-MCP-inaccessible: at
+session start it probes `claude mcp list` and, when an allowlisted MCP like playwright
+failed to connect, performs ONE loop-guarded `/sessions/refresh` so the tool re-registers)
+was **silently inert in production on coreutils-less Macs** — the platform instar agents
+actually run on. Its probe ran `timeout 45 claude mcp list`; bare `timeout` is a GNU
+coreutils binary absent on stock macOS, the command-not-found was swallowed by
+`2>/dev/null || true`, and the empty capture hit the script's quiet-exit guard. No error,
+no log — the recovery feature simply never ran. Linux CI never saw it because `timeout`
+always exists there.
+
+The generated script (authored in `src/core/PostUpdateMigrator.ts` →
+`getMcpHealthAutorefreshHook()`) now bounds the probe with the same portable timeout
+LADDER the autonomous stop hook's real-check runner uses: `timeout` → `gtimeout` →
+perl-alarm fallback (fork + setpgrp + group-KILL on a 45s alarm, exit 124 on timeout,
+and the correct 128+signal exit mapping for a signal-killed child — GNU-timeout
+semantics). With no bounded runner present at all, the script stays dark rather than run
+the probe unbounded. All safety properties are untouched: dark by default,
+explicit-false wins, allowlist-scoped, hard once-per-(session, failed-set) loop-guard.
+
+Migration parity: this hook is always-overwrite in `migrateHooks()`, so every deployed
+agent gets the fixed script automatically on this update — no manual step.
+
+This also fixes the deterministic macOS-only failure of
+`tests/unit/PostUpdateMigrator-mcpAutorefresh.test.ts`.
+
+## What to Tell Your User
+
+If your agent runs on a Mac: a small self-healing feature that was accidentally asleep
+now works. When an important tool server (like the browser tool) fails to come up at the
+start of a session, the agent can restart that session once — automatically and at most
+once — so the tool comes back, instead of quietly running without it. Nothing to
+configure; the feature still respects its existing off-by-default/allowlist settings.
+
+## Summary of New Capabilities
+
+- No new capabilities — a portability fix that makes the existing (config-gated)
+  MCP auto-refresh recovery actually run on macOS, identically to Linux.
+
+## Evidence
+
+- Root cause reproduced on macOS 26 (no `timeout`/`gtimeout` installed): the probe line
+  produced an empty LIST and the script exited silently before any observable action.
+- Perl-rung contract proven live on this machine: hung command bounded (exit 124),
+  normal exit codes passed through (3 → 3), signal-death mapped to 128+signal
+  (SIGTERM → 143), stdout captured intact.
+- `tests/unit/PostUpdateMigrator-mcpAutorefresh.test.ts`: 9/9 pass (previously 1
+  deterministic failure on macOS), including `bash -n` syntax validity and the
+  always-overwrite migration-parity pin.
+- 14 targeted migrator + stop-hook sibling test files: 139/139 pass on this branch.

--- a/upgrades/side-effects/mcp-autorefresh-timeout-macos.md
+++ b/upgrades/side-effects/mcp-autorefresh-timeout-macos.md
@@ -1,0 +1,126 @@
+# Side-Effects Review — MCP Auto-Refresh Hook macOS Timeout Portability
+
+**Version / slug:** `mcp-autorefresh-timeout-macos`
+**Date:** `2026-07-18`
+**Author:** Echo (autonomous, Tier-1 fix cycle, tracked ref CMT-896)
+**Second-pass reviewer:** self-reviewed-final-diff (session-lifecycle adjacent — the hook can trigger a /sessions/refresh — second pass required; performed as a genuinely fresh re-read of this artifact against the final diff; see "Second-pass review" below)
+
+## Summary of the change
+
+`tests/unit/PostUpdateMigrator-mcpAutorefresh.test.ts` ("DEV agent auto-enables…") failed
+deterministically on macOS while Linux CI was green. Root cause: the generated
+`mcp-health-autorefresh.sh` (authored in
+`src/core/PostUpdateMigrator.ts` → `getMcpHealthAutorefreshHook()`) ran its health probe
+as `LIST=$(timeout 45 "$CLAUDE_BIN" mcp list 2>/dev/null || true)`. Bare `timeout` is GNU
+coreutils — absent on coreutils-less Macs (this machine has neither `timeout` nor
+`gtimeout` nor Homebrew). The command-not-found error was swallowed by `2>/dev/null || true`,
+LIST stayed empty, and the script's `[ -n "$LIST" ] || exit 0` guard exited silently —
+so the auto-restart-on-MCP-inaccessible feature was **silently inert in production on
+macOS**, the platform instar agents actually run on. Same platform-gap family as the
+autonomous stop hook's real-check runner fix (previous cycle).
+
+Files modified (single source file):
+- `src/core/PostUpdateMigrator.ts` — the generated hook's probe line becomes a portable
+  bounded-runner LADDER mirroring the stop hook: `timeout` → `gtimeout` → perl-alarm
+  fallback. The perl rung forks, `setpgrp` + group-KILL on a 45s alarm (exit 124), and
+  maps child status with `exit(($?&127) ? 128+($?&127) : ($?>>8))` — GNU-timeout
+  semantics, so a signal-killed probe is never mistaken for a clean exit. If NO bounded
+  runner exists, the script stays dark (exit 0) — it never runs the probe unbounded.
+
+## The eight questions
+
+1. **Over-block** — None identified. On Linux (and Macs with coreutils) the first rung is
+   byte-identical to the old behavior. On coreutils-less Macs the change strictly
+   *enables* previously-dead functionality; it rejects nothing new. The no-runner-at-all
+   case (no timeout, no gtimeout, no perl) exits 0 exactly as the script effectively did
+   before — but now by explicit design with a comment, not by accident.
+2. **Under-block** — The fix closes the silent-inert hole. Remaining, pre-existing and
+   unchanged: a `claude mcp list` that exits 0 but prints garbage is still trusted as a
+   listing (grep simply won't match); the 45s bound is unchanged. The perl rung's
+   KILL-on-alarm is stricter than GNU `timeout`'s default TERM-then-KILL — acceptable
+   here because the probe is read-only (`mcp list` mutates nothing worth a graceful
+   shutdown). No issue identified.
+3. **Level-of-abstraction fit** — Correct layer: the bounded-runner contract lives inside
+   the generated script at the single probe callsite, exactly parallel to the stop hook's
+   ladder (the established in-repo pattern for "bound a command portably"). A shared
+   sourced library for the two ladders would be a bigger refactor of generated-script
+   plumbing than this fix warrants and would couple two independently-shipped hooks;
+   deliberately not done.
+4. **Signal-vs-authority compliance** — Not a message-flow decision point; deterministic
+   exit-status plumbing in an existing dark-by-default hook. The hook's authority shape
+   is unchanged: dark default, explicit-false wins, allowlist scope, hard loop-guard
+   (at most ONE refresh per (session, failed-set)). No brittle blocking heuristic added
+   (`docs/signal-vs-authority.md` reviewed — this adds no gate). No issue identified.
+5. **Interactions** — The ladder only changes HOW the probe is bounded, not what
+   downstream sees: LIST parsing, allowlist matching, marker loop-guard, and the
+   /sessions/refresh call are untouched. On machines with `timeout` (all of CI, most
+   Linux) the executed bytes are the same as before, so zero interaction delta there.
+   The perl rung's process-group KILL cannot touch the parent script (child is
+   `setpgrp`'d into its own group). No double-fire: rungs are exclusive `elif`s.
+6. **External surfaces** — None new. No network, config, API, or route changes. The
+   generated file's content changes (comment + ladder), which the existing unit suite
+   re-pins (`bash -n` syntax validity, safety-invariant greps, migration parity). Agents'
+   observable behavior change: on coreutils-less Macs an allowlisted failed MCP can now
+   actually trigger the (config-gated, loop-guarded) single session refresh — i.e. the
+   feature works as its spec and config already documented.
+7. **Multi-machine posture (Cross-Machine Coherence)** — Machine-local BY DESIGN: the
+   hook runs at session start on the machine hosting the session, probing THAT machine's
+   MCP registrations; its marker state (`.instar/state/mcp-autorefresh-marker.json`) is
+   per-machine and must not replicate (another machine's MCP health is meaningless here).
+   The fix makes behavior machine-uniform across the pool (a Mac and a Linux box now run
+   the same probe contract). No user-facing notice, no durable cross-machine state, no
+   URLs.
+8. **Rollback cost** — Low. Single-file revert of one commit restores the prior generated
+   script; the next migration pass always-overwrites the deployed copy back (same
+   delivery path as the fix). No data migration, no state repair — the marker file format
+   is unchanged. Reverting re-opens the silent-inert-on-macOS hole, so the back-out plan
+   is revert-and-re-fix.
+
+## Migration Parity (explicit)
+
+`migrateHooks()` writes this hook with an unconditional `fs.writeFileSync` into
+`.instar/hooks/instar/mcp-health-autorefresh.sh` on every migration run (always-overwrite,
+never install-if-missing) — verified in code (src/core/PostUpdateMigrator.ts, the
+migrateHooks try-block) and pinned by the passing test "migration parity: migrateHooks
+always-overwrites the hook into hooks/instar/". Deployed Macs therefore receive the fixed
+script automatically on their next instar update; no config or manual step.
+
+## Class-Closure Declaration
+
+- **defectClass:** `unbounded-self-action` — **closure: n/a** (negative declaration).
+  No new self-action is introduced: the diff's added `kill()` is the perl timeout rung
+  reaping its OWN bounded child probe (process hygiene inside a one-shot session-start
+  probe), not a controller emit. The hook's pre-existing self-triggered action (the
+  single `/sessions/refresh`) is unchanged and remains hard-bounded by the
+  once-per-(session, failed-set) marker loop-guard — it structurally cannot loop.
+  Mirrors the machine-readable declaration in the instar-dev trace.
+
+## Second-pass review (self-reviewed-final-diff)
+
+Fresh re-read of the final `git diff` against this artifact:
+
+- **Template-literal escaping audited character-by-character**: every shell `$` in the
+  added block is escaped `\$` (TS template literal), including all perl variables
+  (`\$t`, `\$p`, `\$SIG`, `\$?`); no bare `${` remains that TS would interpolate; the
+  perl program contains no single quotes so the bash single-quoted `-e '…'` wrapping is
+  sound. The generated output was syntax-checked via the suite's `bash -n` test (passes).
+- **Live contract proof re-run** (this machine, no timeout/gtimeout): perl rung returns
+  124 on a hung `sleep 30` with a 2s bound; passes through exit 3; maps SIGTERM death to
+  143; captures stdout correctly. The dev-gate unit test exercises the full script path
+  through the perl rung end-to-end (mock `claude` → probe → dead-port session resolution).
+- **First-pass omission caught and fixed in this artifact**: the initial draft of Q2 did
+  not name the KILL-vs-TERM strictness difference between the perl rung and GNU timeout's
+  default; added with the read-only-probe justification.
+- **Honest scope note**: this branch (off origin/main) does not contain the previous
+  cycle's stop-hook fix — `tests/unit/autonomous-stop-hook-realcheck.test.ts` still shows
+  that one known failure HERE (1 failed | 23 passed), which is the other PR's subject and
+  resolves when both merge. All 14 targeted sibling/migrator files (139 tests) pass on
+  this branch, including the previously-failing mcpAutorefresh suite (9/9).
+- **Checked for other bare-`timeout` callsites in generated scripts** (grep for
+  `timeout N` across `src/core/PostUpdateMigrator.ts`, `src/data/http-hook-templates.ts`,
+  `src/scaffold/`, `src/templates/`, `templates/`, excluding curl's `--connect-timeout`/
+  `--max-time` flags): the line fixed here was the ONLY bare coreutils-`timeout`
+  invocation; no other generated script carries this defect class. Sweep converged clean
+  in one re-pass. <!-- tracked: CMT-896 -->
+- Conclusion: artifact accurate against the final diff; no unlisted side effects found.
+  Reviewer concurs with shipping.


### PR DESCRIPTION
## Summary

The generated `mcp-health-autorefresh.sh` hook invoked bare coreutils `timeout`, which doesn't exist on stock macOS — command-not-found was swallowed and the MCP auto-restart recovery was silently inert in production on Macs. Fix applies the same portable runner ladder as the stop hook (timeout → gtimeout → perl-alarm with correct 124/128+signal exit mapping; no runner → stays dark, never unbounded). Migration parity holds: the hook is always-overwrite in `migrateHooks()`, so deployed Macs receive it on update. Tracked ref: CMT-896. Same platform-gap family as #1513, shipped separately per no-batching.

## ELI16 — a self-healing hook that never actually ran on Macs

**What is this about?** Instar installs a small helper script on every agent called
`mcp-health-autorefresh.sh`. Its job: at session start, quietly run `claude mcp list` to
see whether an important tool server (like Playwright, the browser tool) failed to
connect this session — and if an allowlisted one did, restart the session once so the
tool comes back. It's deliberately cautious: dark by default, allowlist-scoped, and
loop-guarded so it can never restart-loop a machine.

**What broke?** On Macs — which is where instar agents actually run in production — the
script was silently doing nothing at all. Ever. The line that runs the health check was
`timeout 45 claude mcp list`: it wraps the command in the standard `timeout` program so a
hung MCP probe can't stall forever. But macOS doesn't ship `timeout` — that's a GNU
coreutils tool, present on Linux and only on Macs where someone installed Homebrew
coreutils. On a Mac without it, "timeout: command not found" was swallowed by the
script's error redirection, the captured output was empty, and the script hit its
"no output → exit quietly" guard. Result: the auto-recovery feature was silently inert on
exactly the platform it was built for. No error, no log, nothing — which is why it went
unnoticed until a unit test that simulates the check failed on a coreutils-less Mac.

**Why did tests pass in CI?** CI runs on Linux, where `timeout` always exists. The unit
test that caught this (`PostUpdateMigrator-mcpAutorefresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
