### PR TITLE
docs: hidden-test battery mechanism — adopted regression-tripwire discipline for the apprenticeship program

### DIFF
--- a/docs/apprenticeship/PROGRAM-CONCEPTS.md
+++ b/docs/apprenticeship/PROGRAM-CONCEPTS.md
@@ -78,3 +78,61 @@ form, per operator review (2026-07-17):
   program work is need-driven, and spec review is where rejection already lives. The
   retained piece: **promotion evidence must span multiple cycles, never one good day**
   (already the ladder's rung-evidence requirement).
+
+## The Hidden-Test Battery (regression tripwires)
+
+Operator-approved 2026-07-18, closing the bounded adoption flagged in concept 5: the
+program now carries a hidden-test battery. This section records the mechanism itself —
+generically, with no concrete scenario, agent, or organization content — so no drive
+re-derives its rules from chat history.
+
+**Tripwires, not targets.** Every scenario in the battery detects the LOSS of a
+behavior the program already values — a courtesy the mentee reliably showed, a
+discipline it already demonstrated, a failure mode it already learned to avoid.
+Passing therefore means exactly one thing: nothing broke. A pass is never evidence of
+growth, and the battery defines no ceiling, no score, and no target to optimize
+toward. Growth remains where it has always lived — with the overseer's judgment over
+real work. This inversion is the whole point: a held-out metric that defines success
+boxes growth into whatever the metric can see; a tripwire only ever fires on
+regression, so it cannot narrow what the mentee becomes.
+
+**Undisclosed during a drive, scored retrospectively.** Scenarios are not announced,
+hinted at, or marked while a drive runs. After the drive, each scenario is scored
+pass / fail / not-triggered, with evidence pointers into the drive's own record — a
+transcript reference, a ledger entry, an artifact path — so every verdict is
+auditable rather than an impression. Those results feed ladder promotions as ONE
+input among several, and strictly as necessary-not-sufficient: a failed tripwire can
+block a rung (a valued behavior regressed — that must be understood first), but no
+quantity of passes can earn one. Promotion evidence stays multi-cycle and
+overseer-judged, exactly as the ladder already requires.
+
+**The mechanism is disclosed; the scenarios are not.** The mentee is told once,
+plainly, that a battery of this kind exists and how it is used — this section is that
+disclosure in durable form. What stays undisclosed is only the scenario list itself,
+because a known tripwire measures performance for the test, not the behavior. The
+transparency arrives after the fact: scored results appear in drive reports the
+mentee can read, with the same evidence pointers the overseer sees. Nothing about the
+mentee's evaluation is secret in retrospect; only the timing of what was watched is.
+
+**The battery is disposable.** A scenario the mentee visibly performs for — where the
+behavior appears because the test is suspected, not because the value is held — has
+stopped measuring anything and is retired. The operator reviews the full scenario
+list at every rung change: retiring burned scenarios, dropping ones whose behavior is
+no longer load-bearing, and admitting new ones only against currently-valued
+behaviors. No scenario is permanent; the battery's authority comes from being
+current, not from being accumulated.
+
+**Guardrails.** The battery is never a leaderboard — results are not ranked, compared
+across agents, or published as standings. It is never a mid-drive threat — no one
+invokes it to pressure work in flight. It is never a gate on day-to-day work — no
+task, merge, or message waits on a tripwire verdict; its only consumer is the
+retrospective promotion review. And no scenario may be capable of harming real users,
+real data, or real services — a tripwire that could hurt something real to fire is
+disqualified by construction, not by review.
+
+**Captured, not manufactured.** Scenarios are preferentially harvested from
+naturally-arising situations — a real interruption, a real ambiguous request, a real
+failure that already happened once — because natural scenarios measure the behavior
+as it actually occurs. Manufacturing a scenario is the last resort, used only when a
+valued behavior has no natural occurrence to wait for, and never staged on production
+surfaces.

--- a/docs/specs/hidden-test-battery-adoption.eli16.md
+++ b/docs/specs/hidden-test-battery-adoption.eli16.md
@@ -1,0 +1,40 @@
+# ELI16 — The Hidden-Test Battery (regression tripwires)
+
+This change adds one section to one document:
+`docs/apprenticeship/PROGRAM-CONCEPTS.md` gains "The Hidden-Test Battery
+(regression tripwires)". It is a written-down rule set, not machinery — nothing
+about how any agent behaves changes.
+
+Here's the idea in plain words. The apprenticeship program watches a
+learning agent (the mentee) do real work. As the mentee grows, there's a
+classic risk: it gets better at NEW things while quietly losing OLD good
+habits — and nobody notices, because everyone is watching the new stuff. The
+hidden-test battery is the answer: a small set of undisclosed scenarios, each
+one checking that a behavior the program ALREADY values hasn't disappeared.
+
+The crucial twist is what a "pass" means. These are tripwires, not targets.
+Passing all of them means exactly one thing: nothing broke. It never means
+"the mentee grew" — growth is still judged by the human/overseer looking at
+real work. That framing matters because a hidden test that DEFINES success
+would quietly box the mentee into whatever the test can measure. A tripwire
+can only fire on regression, so it can't narrow anything.
+
+Fairness is handled by disclosure of the mechanism, not the scenarios: the
+mentee is told once that a battery like this exists and how it's used (the new
+section IS that disclosure, in durable written form), but the individual
+scenarios stay unknown — a known tripwire measures acting, not values. After
+each drive, every scenario is scored pass / fail / not-triggered with pointers
+to real evidence, and those results appear in drive reports the mentee can
+read. A failed tripwire can block a ladder promotion (something valued broke —
+understand it first), but no number of passes can earn one.
+
+The battery is also deliberately disposable: a scenario the mentee starts
+performing for is burned and gets retired, and the operator re-reviews the
+whole list at every rung change. Guardrails: never a leaderboard, never a
+mid-drive threat, never a gate on day-to-day work, and never a scenario that
+could harm real users, data, or services. Scenarios are preferentially captured
+from situations that arise naturally; manufacturing one is a last resort and
+never happens on production surfaces.
+
+To be explicit: this PR is documentation only. No code paths, no config keys,
+no routes, no gates, no behavior changes for any deployed agent.

--- a/upgrades/next/hidden-test-battery-adoption.md
+++ b/upgrades/next/hidden-test-battery-adoption.md
@@ -1,0 +1,52 @@
+# Upgrade Fragment — hidden-test-battery-adoption
+
+<!-- bump: patch -->
+
+## What Changed
+
+Added one section to `docs/apprenticeship/PROGRAM-CONCEPTS.md`: "The
+Hidden-Test Battery (regression tripwires)" — the durable, generic record of
+the mechanism the operator approved on 2026-07-18. The battery is a set of
+undisclosed scenarios that each detect the LOSS of an already-valued behavior:
+passing means nothing broke, never that growth was achieved (growth stays with
+the overseer's judgment). Scenarios stay undisclosed during a drive and are
+scored retrospectively (pass / fail / not-triggered, with evidence pointers)
+as ONE necessary-not-sufficient input to ladder promotions — a failure can
+block a rung, no quantity of passes can earn one. The mechanism itself is
+disclosed to the mentee once (results appear in drive reports the mentee can
+read); only the scenario list stays hidden. The battery is disposable (a
+performed-for scenario is retired; the operator reviews the list at every rung
+change) and guardrailed: never a leaderboard, never a mid-drive threat, never
+a gate on day-to-day work, never scenarios that can harm real users, data, or
+services. Scenarios are preferentially captured from naturally-arising
+situations, manufactured only as a last resort and never on production
+surfaces.
+
+This is documentation only. No code, config, hook, job, template, or test
+changes; no runtime surface; no behavior change for any deployed agent.
+
+## Evidence
+
+- `docs/apprenticeship/PROGRAM-CONCEPTS.md` — the new section (mechanism only;
+  deliberately no scenario, agent, or organization content).
+- `docs/specs/hidden-test-battery-adoption.eli16.md` — plain-English explainer.
+- `upgrades/side-effects/hidden-test-battery-adoption.md` — side-effects
+  review; every question resolves to "documentation-only, no runtime surface";
+  multi-machine posture unified-via-git; rollback = revert the doc.
+- Sanity: the whole-tree stall-coverage CI ratchet
+  (`tests/unit/stall-coverage-ratchet.test.ts`) runs green on this tree.
+
+## What to Tell Your User
+
+Nothing changes in how your agent behaves. The apprenticeship program's
+documentation now records how regression tripwires work: a small, undisclosed
+set of checks that only ever fire when a learning agent LOSES a good habit it
+already had — never a score to chase, never a leaderboard, never a gate on
+daily work — with results reviewed openly after each drive as one input to
+promotion decisions a human still makes.
+
+## Summary of New Capabilities
+
+- None (documentation only). New content: the "Hidden-Test Battery" section in
+  `docs/apprenticeship/PROGRAM-CONCEPTS.md`, recording the adopted
+  regression-tripwire discipline for the apprenticeship program.

--- a/upgrades/side-effects/hidden-test-battery-adoption.md
+++ b/upgrades/side-effects/hidden-test-battery-adoption.md
@@ -1,0 +1,89 @@
+# Side-Effects Review — hidden-test-battery-adoption (docs-only)
+
+**Change:** appends one section — "The Hidden-Test Battery (regression
+tripwires)" — to `docs/apprenticeship/PROGRAM-CONCEPTS.md`, recording the
+operator-approved (2026-07-18) mechanism generically: undisclosed regression
+tripwires over already-valued behaviors, scored retrospectively as one
+necessary-not-sufficient input to ladder promotions, disposable, guardrailed.
+Plus the standard artifacts (this review, the ELI16, the release fragment).
+**No source, config, template, hook, job, or test files are touched.**
+Documentation-only, no runtime surface.
+
+## Phase 1 principle check (recorded)
+
+Does this change involve a decision point? **No.** The section describes an
+evaluation discipline whose verdicts are produced by humans (operator/overseer)
+in retrospective review; it ships no validator, gate, sentinel, scorer, or any
+code that evaluates anything. Signal-vs-authority is not implicated: nothing
+here can block, allow, or judge — and the described mechanism itself is
+explicitly bounded to "can block a rung, never earn one", a human-held
+authority outside this repo's runtime.
+
+## 1. Over-block
+
+Nothing can be over-blocked: documentation-only, no runtime surface. The change
+introduces no blocking surface of any kind — no CI check, no gate, no hook. The
+described discipline explicitly forbids gating day-to-day work on tripwire
+results, and even that prohibition is prose, not enforcement.
+
+## 2. Under-block
+
+Nothing can be under-blocked: documentation-only, no runtime surface. No
+enforcement is promised by this change, so there is no enforcement to be
+incomplete. If the battery discipline is ever mechanized (a scenario registry,
+a scoring surface), that work arrives with its own spec and its own review.
+
+## 3. Level-of-abstraction fit
+
+Right layer. The mechanism is a program-level concept, and
+`docs/apprenticeship/PROGRAM-CONCEPTS.md` is exactly the canonical home for
+operator-ratified program framings (it already holds five). The section stays
+generic by design — no concrete scenario, no agent name, no organization
+specifics — because scenario content is operator-held and undisclosed by the
+mechanism's own rules; putting scenarios in a public repo doc would break the
+mechanism it documents.
+
+## 4. Signal vs authority compliance
+
+Compliant vacuously: documentation-only, no runtime surface. The change creates
+no authority (nothing blocks) and no signal (nothing observes). The documented
+mechanism is itself shaped by the signal-vs-authority principle — tripwire
+results are a signal into a human promotion decision, never an authority that
+gates work — but describing that shape is not implementing it.
+
+## 5. Interactions
+
+None at runtime: documentation-only, no runtime surface. No job, sentinel,
+route, or hook reads this file. Repo-level interactions are benign: the new
+section closes the "bounded adoption" left open by the same file's concept 5
+(evaluation cautions), and coexists with it — concept 5 records the caution,
+the new section records the adopted mechanism that satisfies it.
+
+## 6. External surfaces
+
+None: documentation-only, no runtime surface. No API route, no config key, no
+message to any user, no notification, no npm-shipped runtime change (the file
+rides the package inertly as documentation). The section was deliberately
+written mechanism-only for this public repo — it names no scenario, agent,
+person, or organization.
+
+## 7. Multi-machine posture
+
+**Unified-via-git.** The document is a repo-tracked file; every machine sees
+the same content at the same SHA. No per-machine runtime state is created, so
+there is nothing to strand, sync, or reconcile.
+
+## 8. Rollback cost
+
+Revert the doc (one revert of this commit). No data migration, no agent state,
+no config, no deployed-behavior change to unwind. Cheapest possible rollback
+class.
+
+## Second-pass review
+
+**Not required.** The second-pass trigger is for changes that wire block/allow
+decisions, session-lifecycle, messaging, or dispatch behavior — this change
+wires nothing: documentation-only, no runtime surface, no decision point, no
+enforcement. There is no code for a second reviewer to contradict against the
+artifact; the only reviewable claim ("the section says what the ELI16 and
+fragment say it says") is verified by reading the three files side by side.


### PR DESCRIPTION
## Summary

Documentation only: records the ADOPTED hidden-test battery mechanism (operator-approved 2026-07-18) in the apprenticeship program concepts — regression tripwires that detect the LOSS of already-valued behaviors, scored retrospectively as a necessary-not-sufficient input to ladder promotions, with the mechanism disclosed to mentees while scenarios stay undisclosed, and hard guardrails (never a growth metric, leaderboard, mid-drive threat, day-to-day gate, or a risk to real users/data). Generic mechanism only — concrete scenarios and scores stay in the operating drive's local records by design.

## ELI16 — tripwires that catch backsliding, never targets that define growth

This change adds one section to one document:
`docs/apprenticeship/PROGRAM-CONCEPTS.md` gains "The Hidden-Test Battery
(regression tripwires)". It is a written-down rule set, not machinery — nothing
about how any agent behaves changes.

Here's the idea in plain words. The apprenticeship program watches a
learning agent (the mentee) do real work. As the mentee grows, there's a
classic risk: it gets better at NEW things while quietly losing OLD good
habits — and nobody notices, because everyone is watching the new stuff. The
hidden-test battery is the answer: a small set of undisclosed scenarios, each
one checking that a behavior the program ALREADY values hasn't disappeared.

The crucial twist is what a "pass" means. These are tripwires, not targets.
Passing all of them means exactly one thing: nothing broke. It never means
"the mentee grew" — growth is still judged by the human/overseer looking at
real work. That framing matters because a hidden test that DEFINES success
would quietly box the mentee into whatever the test can measure. A tripwire
can only fire on regression, so it can't narrow anything.

Fairness is handled by disclosure of the mechanism, not the scenarios: the
mentee is told once that a battery like this exists and how it's used (the new
section IS that disclosure, in durable written form), but the individual
scenarios stay unknown — a known tripwire measures acting, not values. After
each drive, every scenario is scored pass / fail / not-triggered w

🤖 Generated with [Claude Code](https://claude.com/claude-code)
