### PR TITLE
docs(apprenticeship): consolidate Slack workstream

### DIFF
--- a/docs/apprenticeship/slack-workstream-retro.md
+++ b/docs/apprenticeship/slack-workstream-retro.md
@@ -1,0 +1,121 @@
+# Slack workstream retrospective and WS5 scope
+
+Date: 2026-07-19  
+Apprenticeship arc: WS3–WS4  
+Evidence: live demo-workspace smoke, feedback entries `fb-b1010093-9db` and `fb-d54eb6d4-8d2`, PR #1518
+
+Status: retrospective evidence is settled; WS5 is scoped but not authorized or implemented.
+
+## Outcome
+
+WS3 and WS4 moved the demo Slack integration from credentials-on-disk to a verified, source-bound conversation path. The final live state proved a distinct `instar-codey-demo` app identity, complete required scopes, explicit demo-channel membership, Socket Mode connectivity, authenticated inbound receipt, observe-only permission decisions, exactly-once ingestion, and thread-session routing. PR #1518 then closed the missing final leg: a spawned session can reply to its originating Slack thread without receiving raw channel or thread authority.
+
+The workstream did not flip the adapter from observe-only to responding. That is the next authority rung and remains an operator decision.
+
+## What was built and proved
+
+### WS3 — provision and observe
+
+- Provisioned a dedicated demo-workspace Slack app and bot for Instar-codey, distinct from Echo's identity.
+- Established the owner-identity administration path, scope matrix, reinstall requirement, channel membership checks, and Socket Mode preflight in the canonical reprovision runbook.
+- Configured the adapter in observe-only mode with a bounded cast and verified authenticated principal resolution.
+- Proved inbound events after subscription repair: one directed root and its thread replies arrived exactly once, produced truthful observe-only permission decisions, and routed to the expected channel/thread session key.
+- Proved outbound transport and delivery-id replay suppression without granting the adapter response authority.
+
+### WS4 — source-bound reply relay
+
+- Added a provider-neutral Slack reply helper for spawned Codex, Claude, and Gemini sessions.
+- Added `POST /slack/session-reply`, accepting only `conversationId` and `text`. The server resolves channel and thread from the bind-gated local conversation registry; the caller cannot select or override a destination.
+- Refused missing/incorrect bindings, caller-supplied destinations or metadata, malformed conversation records, and replicated or foreign-origin targets.
+- Reused the existing Slack tone, idempotency, and send path rather than creating a parallel delivery authority.
+- Added SHA-provenance installation and migration: known shipped helpers may be atomically replaced; customized files are preserved and receive a `.new` candidate; symlinks and unreadable evidence fail closed.
+- Added route, installer, prompt-census, migration, thread-routing, and full CI coverage. PR #1518 merged after exact-head peer approval and green unit, build, integration, and E2E gates.
+
+## Defects surfaced and attribution
+
+| Finding | Surfaced by | Origin / result |
+|---|---|---|
+| The delivered Slack credentials belonged to Echo's existing app, which would have made two agents compete for one Socket Mode identity. | Instar-codey | Provisioning handoff error; connection was contained and cleaned up, and a distinct app identity became a hard precondition. |
+| An operator click-list was handed back for work the agent could perform through an owned provisioning identity. | Justin's correction | Mentor-side process defect; the owner-identity path became explicit, and later shared machinery added an owned-identities self-unblock source plus an advisory task-substitution signal. |
+| A manifest update used replace semantics and unintentionally erased the app's event subscriptions. | Codey's zero-receipt evidence plus Echo's app inspection | Mentor-side provisioning defect; subscriptions were restored, and the runbook now requires export, additive modification, reinstall, and full live diff/read-back. |
+| Socket Mode connected and adapter self-verification passed while no app events were delivered. | Joint live smoke | Diagnosed through Codey's zero-receipt evidence and Echo's app inspection; event-subscription state is now a separate gate, because transport health cannot stand in for subscription health. |
+| Thread routing succeeded, but spawned sessions had no installed Slack reply helper and could not answer the source thread. | Instar-codey live smoke | Framework distribution gap; filed as `fb-d54eb6d4-8d2` and fixed by PR #1518's source-bound relay. |
+
+Attribution matters here because the apprenticeship evidence is about the system, not scorekeeping: Codey caught the identity collision and missing reply surface; Echo named and repaired the two mentor-side errors. Each correction became a durable contract rather than a conversational promise.
+
+## Durable lessons
+
+### Replace-semantics APIs require export → additive change → full diff
+
+A manifest update is not a patch unless the API contract explicitly says so. The safe sequence is:
+
+1. Export the current manifest or configuration.
+2. Add the intended fields to the complete representation.
+3. Submit the complete representation.
+4. Reinstall when grants or tokens are affected.
+5. Diff every safety-relevant field and verify live token scopes, event subscriptions, and membership.
+
+Checking only the field being added would have missed the subscription wipe.
+
+### Provision through the verified owner identity
+
+An agent-created workspace owner or service identity is part of the agent's usable infrastructure while its credential pointer remains valid. Before escalating an app-administration step to the operator, the agent should consult its owned-identity registry and exercise the verified owner path. This does not weaken human-reserved boundaries such as payments, legal assent, CAPTCHA, or the enforcement flip below.
+
+### Socket Mode is not event subscriptions
+
+A successful WebSocket handshake proves transport reachability only. It does not prove that the app is subscribed to `app_mention` or message events, that Slack accepted the subscription set, or that envelopes reach the adapter. Live readiness therefore needs independent evidence for identity, scopes, membership, Socket Mode, event subscriptions, and actual inbound envelopes.
+
+### Attestation consumers must fail closed
+
+`distinctIdentityVerified` was deliberately consumed as an admission fact, not inferred from nearby fields. When a credential refresh omitted the attestation, the runner refused before mutating config or vault state. That refusal was correct even though the omission was accidental. Producers must preserve or reissue attestations; consumers must never reconstruct them from plausibility.
+
+### Authority must stay source-bound
+
+A spawned session needs the ability to answer its conversation, not a general Slack-addressing capability. Passing an opaque conversation id plus a session binding lets the server resolve the destination from verified source evidence. It also makes cross-machine behavior honest: the machine without the local-origin binding refuses instead of posting from ambiguous replicated state.
+
+## WS5 forward scope — demo-channel responding rung
+
+### Goal
+
+Move the existing demo adapter from observing authorized demo-channel traffic to producing real replies in the same demo conversation. This is the first live-user-channel proof toward the AI-employee goal: an authenticated human can direct the agent in Slack and receive a useful, thread-correct response through the normal session lifecycle.
+
+This section is a scope stub, not authorization to build or enable the increment.
+
+### Preconditions
+
+- PR #1518's source-bound relay is installed and migration readiness reports packaged-identical executable bytes.
+- The distinct Codey app identity, required bot scopes, event subscriptions, Socket Mode connection, and demo-channel membership are freshly verified.
+- Authenticated inbound, exactly-once ingestion, principal resolution, and thread-session routing remain green on a disposable canary.
+- The responding cast and demo channels are explicitly bounded; no live operator or production channel is included.
+- Outbound tone review, delivery-id idempotency, source binding, one-voice ownership, and off-authority refusal are enabled and observable.
+- A deterministic rollback exists: return enforcement to observe-only without deleting inbound evidence or conversation history.
+- The operator has reviewed the evidence and explicitly authorized the enforcement transition.
+
+### Authority boundary: observe → respond
+
+Changing `enforced:false` observation into real delivery grants the adapter external speaking authority. Models, sentinels, smoke success, or mentor approval may produce readiness evidence, but none may flip that authority. The transition must remain a named, audited operator action with the exact app, workspace, channel/cast boundary, and rollback posture shown at the decision surface.
+
+The implementation must not hide the flip inside restart, migration, configuration normalization, or a successful test. Missing, stale, unreadable, or conflicting evidence holds the adapter in observe-only mode.
+
+### Required test matrix
+
+| Cell | Required assertion |
+|---|---|
+| Operator authority | Without an explicit valid operator grant, respond mode cannot be enabled; an expired/revoked grant returns the adapter to observe-only. |
+| Authenticated directed root | One authorized human mention produces exactly one admitted session and exactly one source-bound response in the intended location. |
+| Directed thread continuation | A directed reply in the same thread reaches the same thread routing key and produces exactly one in-thread response, never a channel-root fallback. |
+| Ambient traffic | Undirected messages follow the reviewed ambient policy and do not cause accidental speech. |
+| Unauthorized principal | A sender outside the responding cast receives no autonomous response; the refusal is observable without leaking sensitive policy detail. |
+| Caller authority | Spawned sessions cannot supply channel, thread, system metadata, or a foreign conversation id. |
+| Idempotency | Replaying one delivery id produces no duplicate Slack message; ambiguous transport outcomes are reconciled before redrive. |
+| Session recovery | Restart/respawn/compaction preserves the source binding and response contract without repeating a committed effect. |
+| Cross-machine owner-dark | A machine lacking the local-origin conversation/adapter authority refuses; durable custody remains visible and exactly one owning machine speaks after recovery. |
+| One voice | Concurrent sessions or machines cannot both answer the same admitted event. |
+| Tone and content gate | Real conversational output passes the existing semantic tone authority; brittle detectors remain signals, not blocking semantic judges. |
+| Enforcement rollback | Operator disable takes effect immediately and survives restart; open work cannot re-enable responding. |
+| Migration parity | Fresh init, update migration, and recovery install the same helper bytes and render the same destination-free prompt contract. |
+| Cleanup | Canary messages, sessions, grants, and temporary fixtures are removed or returned to their pre-test state with read-back evidence. |
+
+### Acceptance evidence for an operator decision
+
+The eventual WS5 proposal should present the matrix results, exact app/workspace/channel identity, current grant state, known gaps, rollback control, and a short ELI16 description of what enabling response authority changes. A green matrix means the system is ready up to the door; it never opens the door itself.

--- a/upgrades/next/slack-workstream-retro.md
+++ b/upgrades/next/slack-workstream-retro.md
@@ -1,0 +1,20 @@
+# Slack apprenticeship retrospective and WS5 scope
+
+## What Changed
+
+- Added the canonical WS3–WS4 Slack apprenticeship retrospective with attributed defects and durable lessons.
+- Added a non-executing WS5 scope stub for the future demo-channel responding rung, including preconditions, operator-only enforcement authority, rollback, and the required test matrix.
+
+## Evidence
+
+- `docs/apprenticeship/slack-workstream-retro.md`
+- PR #1518 (merge `4f80badcee8e72fd10a4ced155352aeba907199e`) and feedback entries `fb-b1010093-9db`, `fb-d54eb6d4-8d2`
+
+## What to Tell Your User
+
+The Slack demo work is now consolidated into one durable retrospective: what succeeded, what failed, who caught each defect, and the rules those incidents earned. It also defines the next responding-mode rung without enabling it; the operator retains the decision to grant real speaking authority.
+
+## Summary of New Capabilities
+
+- No runtime capability is enabled by this documentation PR.
+- A future WS5 build now has an explicit acceptance matrix and operator-only enforcement boundary.

--- a/upgrades/side-effects/slack-workstream-retro.md
+++ b/upgrades/side-effects/slack-workstream-retro.md
@@ -1,0 +1,45 @@
+# Side-effects review: Slack workstream retrospective and WS5 scope
+
+This is a documentation-only change. It changes no runtime, configuration, credentials, Slack state, or enforcement posture.
+
+## Over-block
+
+None at runtime. The scope intentionally states that observe-to-respond requires an operator decision; this documents the existing authority boundary rather than adding a gate.
+
+## Under-block
+
+The WS5 matrix is a design stub, not executable enforcement. A future implementation must earn each assertion and must not cite this document as permission to flip responding on.
+
+## Level-of-abstraction fit
+
+The apprenticeship retrospective belongs under `docs/apprenticeship/`: it preserves attributed program evidence and converts incidents into reusable development constraints. The forward scope is colocated so the next increment starts from the earned evidence rather than chat archaeology.
+
+## Signal vs authority compliance
+
+The document explicitly separates readiness signals from the operator's authority to move the adapter from observe-only to responding. No detector or model verdict is granted authority.
+
+## Interactions
+
+No runtime interaction. The prose aligns the Slack reprovision runbook, PR #1518's source-bound relay, owned-identity self-unblock posture, and existing operator-only enforcement principle.
+
+## External surfaces
+
+The document is repository-visible. It contains non-secret identifiers only as issue/PR references and no Slack credentials, tokens, private message text, or raw user identifiers.
+
+## Multi-machine posture
+
+The scope requires owner-local refusal, durable custody, and exactly one speaking machine. This review makes no claim that those future cells are already implemented.
+
+## Rollback cost
+
+Documentation-only revert. No data or external-state repair would be required.
+
+## Operator-surface quality
+
+The future decision surface is specified to show exact scope, evidence freshness, known gaps, and rollback. No operator UI is added here.
+
+## Conclusion
+
+The retrospective is an honest consolidation of completed evidence, and the WS5 section is explicitly non-executing. No side-effect concern blocks publication.
+
+The operator-authority boundary remains unchanged by this documentation.

--- a/upgrades/slack-workstream-retro.eli16.md
+++ b/upgrades/slack-workstream-retro.eli16.md
@@ -1,0 +1,11 @@
+# Slack workstream retrospective and WS5 scope — plain-English overview
+
+This change records what Instar-codey and Echo learned while bringing a dedicated demo Slack app from provisioning through a real end-to-end conversation path. It does not turn on any new Slack behavior. The retrospective captures the successful pieces—distinct app identity, verified permissions and channel membership, live inbound events, thread routing, and the source-bound reply relay shipped in PR #1518—and it names the failures that made those contracts necessary.
+
+The most important lesson is that several green-looking signals are narrower than they appear. A connected Socket Mode WebSocket does not prove that Slack event subscriptions survived an app update. A manifest write does not prove a bot token gained the intended scopes. A plausible credential file does not replace a signed or owner-issued identity attestation. And a spawned session does not need arbitrary channel coordinates; it needs a narrowly bound way to answer the conversation that created it.
+
+The document also scopes the next Slack increment without building it. Today the demo adapter observes and records decisions but does not autonomously speak. WS5 would prove a real authorized human can direct the agent in a demo channel and receive one useful, thread-correct response. That observe-to-respond transition is a genuine authority change. Tests and reviewers can show readiness, but only the operator may enable it. The proposed matrix covers authorized and unauthorized senders, ambient traffic, duplicates, recovery, cross-machine owner-dark behavior, one-voice delivery, rollback, migration parity, and cleanup.
+
+The decision this document enables is simple: whether to authorize a future build of WS5 under those boundaries. This PR itself makes no configuration change, touches no Slack workspace, and grants no speaking authority.
+
+Readers should treat the proposed matrix as a future acceptance contract, never as evidence that respond mode is already ready or enabled.


### PR DESCRIPTION
## Summary

- consolidate the WS3–WS4 Slack apprenticeship arc, including attributed defects and durable lessons
- correct the stale inbound-failure summary with the round-three green result and PR #1518 merge
- scope WS5's demo-channel responding rung without building or enabling it
- keep the observe-to-respond enforcement flip explicitly operator-owned and define the future acceptance matrix

## Scope

Documentation only. No Slack workspace, configuration, credential, runtime, or enforcement change.

## Evidence

- lint and repository pre-commit gates pass
- pre-push smoke selects 0 affected tests, as expected for this docs-only diff
- Tier-1 ELI16 and side-effects artifacts included

## ELI16 — What this documentation changes

This PR records the lessons from bringing a dedicated demo Slack app through a real end-to-end conversation, and defines the safety checks for a future responding mode. It does not enable new Slack behavior or grant the agent permission to speak.