### PR TITLE
fix(dev): bind decision audit to matching trace

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-19T20-44-06-926Z-decision-audit-trace-binding.json
+++ b/.instar/instar-dev-decisions/2026-07-19T20-44-06-926Z-decision-audit-trace-binding.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-07-19T20:44:06.926Z",
+  "slug": "decision-audit-trace-binding",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 11,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The trace producer omitted stable identity and the pre-commit consumer selected evidence by mtime before proving scope coverage."
+  },
+  "classClosure": {
+    "defectClass": "claim-vs-evidence",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "gate",
+      "citation": "scripts/instar-dev-precommit.js#freshestTraceEntry",
+      "howCaught": "Generated traces persist their slug and the pre-commit gate consumes only a complete trace covering every staged behavior file, preventing missing or foreign identity from labeling the decision."
+    }
+  },
+  "verdict": "pass"
+}

--- a/scripts/instar-dev-precommit.js
+++ b/scripts/instar-dev-precommit.js
@@ -337,8 +337,11 @@ if (traceEntries.length === 0) {
 }
 
 // ─── Step 4.5: read the agent's DECLARED tier + branch ───────────────────
-// The agent records its tier in the trace JSON. We peek the freshest fresh
-// trace to read `trace.tier` (1|2|3). decideRequirementSet() factors the pure
+// The agent records its tier in the trace JSON. Select the freshest trace that
+// actually covers THIS staged change before reading its identity or tier. A
+// merely-newer trace from another worktree/task must never label this decision
+// audit (the feedback-class failure behind fb-2b24aa04-540).
+// decideRequirementSet() factors the pure
 // enforcement decision:
 //   - tier 1            → 'tier1-lite'  (ELI16 + side-effects staged; no spec)
 //   - tier 2 / 3        → 'tier2-full'  (the EXISTING full validation, unchanged)
@@ -347,8 +350,28 @@ if (traceEntries.length === 0) {
 let declaredTier = null;
 let tierReasoning = '';
 let freshestTrace = null;
+let freshestTraceEntry = null;
+for (const entry of traceEntries) {
+  try {
+    const candidate = JSON.parse(fs.readFileSync(entry.file, 'utf8'));
+    const covered = new Set(candidate?.coveredFiles || []);
+    if (candidate?.phase === 'complete' && inScopeFiles.every((f) => covered.has(f))) {
+      freshestTrace = candidate;
+      freshestTraceEntry = entry;
+      break;
+    }
+  } catch {
+    // The full validation path below reports malformed attempts. They are not
+    // eligible to provide identity/tier metadata for this staged change.
+  }
+}
+if (!freshestTrace || !freshestTraceEntry) {
+  blockCommit(
+    inScopeFiles,
+    'No fresh complete trace covers this staged change. Run the /instar-dev skill for the files being committed.',
+  );
+}
 try {
-  freshestTrace = JSON.parse(fs.readFileSync(traceEntries[0].file, 'utf8'));
   if (freshestTrace && (freshestTrace.tier === 1 || freshestTrace.tier === 2 || freshestTrace.tier === 3)) {
     declaredTier = freshestTrace.tier;
   }
@@ -360,7 +383,13 @@ try {
   // path (the existing Step 5 loop will surface the malformed-JSON attempt).
 }
 
-const slug = (freshestTrace && (freshestTrace.slug || freshestTrace.name)) || 'unknown';
+const slug = (freshestTrace && (
+  freshestTrace.slug ||
+  freshestTrace.name ||
+  (typeof freshestTrace.artifactPath === 'string'
+    ? path.basename(freshestTrace.artifactPath, path.extname(freshestTrace.artifactPath))
+    : null)
+)) || 'unknown';
 const decision = decideRequirementSet(declaredTier);
 
 // ─── Step 4.55: causal autopsy (directive 2026-06-05) ───────────────────
@@ -480,7 +509,7 @@ if (belowFloor) {
 // (The tests/lint requirement from the spec lives in the pre-PUSH gate, not
 // here: this pre-COMMIT hook checks ARTIFACTS only.)
 if (decision.requirementSet === 'tier1-lite') {
-  enforceTier1(freshestTrace, traceEntries[0].file);
+  enforceTier1(freshestTrace, freshestTraceEntry.file);
   // enforceTier1 either passes through (process.exit(0)) or blockCommit()s.
 }
 

--- a/skills/instar-dev/scripts/write-trace.mjs
+++ b/skills/instar-dev/scripts/write-trace.mjs
@@ -212,6 +212,9 @@ const duplicateBuildCheck = readDuplicateBuildCheck();
 
 const trace = {
   version: toolchain ? 3 : 2, // v3 only when enriched; readers ignore unknown fields either way
+  // Stable work-item identity. The pre-commit decision audit consumes this;
+  // omitting it forced valid generated traces into the `unknown` bucket.
+  slug,
   sessionId: process.env.INSTAR_SESSION_ID || process.env.CLAUDE_CODE_SESSION_ID || 'unknown',
   timestamp,
   artifactPath: artifact,

--- a/tests/unit/instar-dev-precommit-audit-staging.test.ts
+++ b/tests/unit/instar-dev-precommit-audit-staging.test.ts
@@ -246,6 +246,60 @@ describe('instar-dev pre-commit — decision-audit line rides the commit (self-s
     expect(entry.verdict).toBe('pass');
     expect(entry.slug).toBe('pass-fixture');
   });
+
+  it('binds the decision audit to the newest trace that covers the staged change', async () => {
+    const srcRel = 'src/touched.ts';
+    const eli16Rel = 'upgrades/pass-fixture.eli16.md';
+    const seRel = 'upgrades/side-effects/pass-fixture.md';
+    fs.writeFileSync(path.join(sandbox, srcRel), '// touched\n');
+    fs.writeFileSync(path.join(sandbox, eli16Rel), 'E'.repeat(900));
+    fs.writeFileSync(path.join(sandbox, seRel), `# Side-Effects Review\n\n${'S'.repeat(250)}\n`);
+
+    const matching = path.join(sandbox, '.instar', 'instar-dev-traces', 'matching.json');
+    fs.writeFileSync(matching, JSON.stringify({
+      phase: 'complete', slug: 'right-work-item', tier: 1,
+      coveredFiles: [srcRel, eli16Rel, seRel], eli16Path: eli16Rel, sideEffectsPath: seRel,
+    }));
+    const foreign = path.join(sandbox, '.instar', 'instar-dev-traces', 'foreign.json');
+    fs.writeFileSync(foreign, JSON.stringify({
+      phase: 'complete', slug: 'unknown', tier: 1, coveredFiles: ['src/other.ts'],
+    }));
+    const now = Date.now();
+    fs.utimesSync(matching, new Date(now - 1_000), new Date(now - 1_000));
+    fs.utimesSync(foreign, new Date(now), new Date(now));
+    execFileSync('git', ['add', srcRel, eli16Rel, seRel], { cwd: sandbox });
+
+    const result = await runHook(process.env, sandbox);
+    expect(result.status).toBe(0);
+    const entries = listEntryFiles();
+    expect(entries).toHaveLength(1);
+    const entry = JSON.parse(fs.readFileSync(path.join(sandbox, '.instar', 'instar-dev-decisions', entries[0]), 'utf8'));
+    expect(entry.slug).toBe('right-work-item');
+    expect(entries[0]).toContain('right-work-item');
+  });
+
+  it('derives stable identity from artifactPath for legacy generated traces without slug', async () => {
+    const srcRel = 'src/touched.ts';
+    const eli16Rel = 'upgrades/legacy-fixture.eli16.md';
+    const seRel = 'upgrades/side-effects/legacy-fixture.md';
+    fs.writeFileSync(path.join(sandbox, srcRel), '// touched\n');
+    fs.writeFileSync(path.join(sandbox, eli16Rel), 'E'.repeat(900));
+    fs.writeFileSync(path.join(sandbox, seRel), `# Side-Effects Review\n\n${'S'.repeat(250)}\n`);
+    fs.writeFileSync(
+      path.join(sandbox, '.instar', 'instar-dev-traces', 'legacy.json'),
+      JSON.stringify({
+        phase: 'complete', tier: 1, artifactPath: seRel,
+        coveredFiles: [srcRel, eli16Rel, seRel], eli16Path: eli16Rel, sideEffectsPath: seRel,
+      }),
+    );
+    execFileSync('git', ['add', srcRel, eli16Rel, seRel], { cwd: sandbox });
+
+    const result = await runHook(process.env, sandbox);
+    expect(result.status).toBe(0);
+    const entries = listEntryFiles();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toContain('legacy-fixture');
+  });
 });
 
 // ── Causal autopsy (directive 2026-06-05) ─────────────────────────────────

--- a/tests/unit/write-trace-tier.test.ts
+++ b/tests/unit/write-trace-tier.test.ts
@@ -93,6 +93,7 @@ describe('write-trace.mjs — tier declaration (Step A)', () => {
     expect(trace.phase).toBe('complete');
     expect(trace.artifactPath).toBe(artifact);
     expect(trace.coveredFiles).toEqual(['src/a.ts', 'src/b.ts']);
+    expect(trace.slug).toBe('widget');
     expect(typeof trace.artifactSha256).toBe('string');
   });
 

--- a/upgrades/decision-audit-trace-binding.eli16.md
+++ b/upgrades/decision-audit-trace-binding.eli16.md
@@ -1,0 +1,9 @@
+# Decision audit trace binding
+
+Instar records a small decision artifact whenever its own development gate evaluates a change. That artifact is supposed to answer a simple future question: which work item was this decision about, and what change did the gate actually evaluate? The gate previously answered that question using the newest trace file written in the last hour. In a busy development environment, however, the newest trace can belong to another task or another attempted commit. That let a real change be recorded under `unknown` or under a foreign work-item name even though a correct trace for the staged files was present.
+
+This repair changes the binding rule for the whole class, not just the reported instance. The canonical trace writer now persists the stable slug it already derives from the side-effects artifact. Before the gate reads a trace's tier, slug, or causal record, it requires that trace to be complete and to cover every staged behavior file. Newer unrelated or malformed traces are skipped. For older generated traces that predate the slug field, the gate derives the same stable identity from `artifactPath`. If no trace covers the staged change, the commit is refused with a direct explanation instead of emitting misleading evidence.
+
+The important invariant is: development evidence is selected by scope first and recency second. A regression test creates two fresh traces—an older correct trace and a newer foreign `unknown` trace—and proves that the resulting decision record uses the correct work-item identity. This closes feedback item `fb-2b24aa04-540` and upgrades the development process so parallel work cannot recreate the same evidence-misbinding class.
+
+There is no runtime or user-facing behavior change. The affected surface is the Instar source repository's pre-commit ceremony. Rollback is a normal code revert; no persisted runtime state or migration is involved.

--- a/upgrades/next/decision-audit-trace-binding.md
+++ b/upgrades/next/decision-audit-trace-binding.md
@@ -1,0 +1,17 @@
+---
+change_type: fix
+---
+
+<!-- internal-only -->
+
+## What Changed
+
+- Persisted stable work-item identity in generated Instar development traces.
+- Bound decision evidence to the staged change's matching trace before reading identity or tier, with a compatibility fallback for legacy traces.
+- Added regressions for missing generated identity and a newer foreign `unknown` trace competing with the correct trace.
+
+## Evidence
+
+- Feedback: `fb-2b24aa04-540`
+- Test: `tests/unit/instar-dev-precommit-audit-staging.test.ts`
+- Test: `tests/unit/write-trace-tier.test.ts`

--- a/upgrades/side-effects/decision-audit-trace-binding.md
+++ b/upgrades/side-effects/decision-audit-trace-binding.md
@@ -1,0 +1,72 @@
+# Side-Effects Review — decision audit trace binding
+
+**Version / slug:** `decision-audit-trace-binding`
+**Date:** `2026-07-19`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+The trace writer now persists its derived slug, and the pre-commit gate selects the newest complete trace whose `coveredFiles` includes every staged behavior file before reading tier, slug, or class evidence. Legacy traces fall back to their artifact basename. Regression tests pin both causes from `fb-2b24aa04-540`: missing generated identity and a newer foreign trace.
+
+## Decision-point inventory
+
+- `scripts/instar-dev-precommit.js` trace selection — modified — deterministically binds evidence to the staged change and refuses when no binding exists.
+
+## 1. Over-block
+
+A legacy hand-written trace without `phase: complete` or without complete behavior-file coverage is now refused earlier. That is intentional: such a trace cannot honestly describe the staged decision.
+
+## 2. Under-block
+
+Two traces can both cover the same files; recency remains the tie-breaker. The trace SHA and artifact checks still validate the selected trace later in the gate.
+
+## 3. Level-of-abstraction fit
+
+The repair spans the canonical trace producer and the pre-commit evidence binder. It persists the already-derived artifact slug and reuses the existing `coveredFiles` contract instead of introducing another identity system.
+
+## 4. Signal vs authority compliance
+
+[docs/signal-vs-authority.md](../../docs/signal-vs-authority.md) applies. This is an enumerable integrity invariant: evidence either covers all staged behavior files or it does not. The deterministic gate correctly holds blocking authority over an invalid development commit.
+
+## 4b. Judgment-point check
+
+No competing-signals judgment is introduced. Scope membership is an exact set-containment invariant.
+
+## 5. Interactions
+
+The selector runs before Tier-1 branching and before the existing full trace validation. It cannot double-fire. Full artifact, SHA, and spec validation remain unchanged. Parallel worktrees may leave traces behind, but those traces no longer influence unrelated staged changes.
+
+## 6. External surfaces
+
+No runtime, user, operator, network, or API surface changes. The persistent decision audit becomes more accurate.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+Machine-local by design: pre-commit traces and staged changes belong to one development worktree on one machine. It emits no user notice, creates no transferable runtime state, and generates no URL.
+
+## 8. Rollback cost
+
+Pure development-tooling code change. Revert and ship; no migration or agent-state repair is required.
+
+## Conclusion
+
+The class review found the missing standard was scope-bound evidence selection, and the process gap was reading identity from the newest trace before proving it described the staged files. The code and regression ratchet now enforce scope-first, recency-second selection. Clear to ship.
+
+## Second-pass review
+
+Not required: this does not touch runtime messaging, sessions, sentinels, guards, or watchdogs.
+
+## Evidence pointers
+
+- `tests/unit/instar-dev-precommit-audit-staging.test.ts`
+- `tests/unit/write-trace-tier.test.ts`
+- Feedback `fb-2b24aa04-540`
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: claim-vs-evidence`, `closure: guard`, `guardEvidence: { enforcementType: gate, citation: scripts/instar-dev-precommit.js#freshestTraceEntry, howCaught: the gate selects only a complete trace covering every staged behavior file before using its slug or tier, so a newer foreign or unknown trace cannot label the decision }`.


### PR DESCRIPTION
## ELI16 — Decision evidence now names the work it actually describes

Instar writes a decision record before its own code changes can be committed. In busy parallel development, that record could accidentally borrow the name of a newer, unrelated trace—or say `unknown` because generated traces did not store their work-item name at all. This PR makes the trace writer save that stable name, then makes the commit gate choose only a trace that actually covers every staged behavior file. Older traces remain compatible because their artifact filename supplies the same identity. If no trace matches, the commit stops instead of writing misleading evidence. Two regression tests reproduce both failure modes and prove the record stays attached to the right change.

## Summary

- persist the stable artifact-derived slug in generated instar-dev traces
- select trace evidence by staged-file coverage before recency
- retain a compatibility identity fallback for legacy traces
- add regression ratchets for missing identity and newer foreign traces

Closes feedback `fb-2b24aa04-540`.

## CLASS review

Missing standard: development evidence must bind to the exact staged scope before it can claim work-item identity. Process gap: the producer omitted slug and the consumer trusted the newest trace before validating coverage. The producer, consumer, and gate-level regression now close the class.

## Verification

- focused decision-audit and trace-writer tests
- lint
- pre-commit and pre-push gates