### PR TITLE
fix(threadline): accept canonical inbound reply evidence

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-19T20-58-42-487Z-unknown.json
+++ b/.instar/instar-dev-decisions/2026-07-19T20-58-42-487Z-unknown.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-07-19T20:58:42.487Z",
+  "slug": "unknown",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 51,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "The canonical ThreadLog migration moved modern inbound evidence without updating the relay-send reply authorization consumer, leaving it bound to the legacy inbox only."
+  },
+  "classClosure": {
+    "defectClass": "claim-vs-evidence",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "gate",
+      "citation": "src/threadline/ThreadlineReplyValidation.ts#isAuthenticatedThreadlineInbound",
+      "howCaught": "The live reply gate now requires exact thread, message, and inbound evidence from either canonical generation while also requiring durable claim authority; the behavioral route regression reproduces modern-only evidence, claim release, and duplicate-claim rejection."
+    }
+  },
+  "verdict": "pass"
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -328,6 +328,7 @@ import { recordInboundAck } from '../threadline/recordInboundAck.js';
 import { recordThreadMessage } from '../threadline/recordThreadMessage.js';
 import { THREAD_ID_RE } from '../threadline/ThreadLog.js';
 import { readThreadHistoryUnion, type CanonicalReadDeps, type AggregateMessage } from '../threadline/canonicalHistoryRead.js';
+import { isAuthenticatedThreadlineInbound } from '../threadline/ThreadlineReplyValidation.js';
 import { computeSymmetryState, localThreadSync, honorPeerThreadSync, type SymmetryState } from '../threadline/threadSymmetry.js';
 import { resolveSingleNegotiatorConfig, readNegotiatorCounts } from '../threadline/NegotiatorLease.js';
 import { evaluateOutboundCredentialShare } from '../threadline/CredentialShareGate.js';
@@ -27940,8 +27941,11 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       return;
     }
     if (typeof inReplyTo === 'string') {
-      const claimedInbound = ctx.listenerManager?.readCanonicalInboxEntry(inReplyTo);
-      if (!claimedInbound || typeof threadId !== 'string' || claimedInbound.threadId !== threadId) {
+      if (!isAuthenticatedThreadlineInbound(
+        { listenerManager: ctx.listenerManager, threadLog: ctx.threadLog },
+        threadId,
+        inReplyTo,
+      )) {
         res.status(400).json({ success: false, error: 'inReplyTo must name an authenticated inbound on this thread.' });
         return;
       }

--- a/src/threadline/ThreadlineReplyValidation.ts
+++ b/src/threadline/ThreadlineReplyValidation.ts
@@ -1,0 +1,43 @@
+import type { ListenerSessionManager } from './ListenerSessionManager.js';
+import type { ThreadLog } from './ThreadLog.js';
+
+export interface ThreadlineReplyValidationSources {
+  listenerManager?: Pick<ListenerSessionManager, 'readCanonicalInboxEntry'> | null;
+  threadLog?: Pick<ThreadLog, 'has' | 'isPathConfined'> | null;
+}
+
+/**
+ * Prove that `inReplyTo` names an authenticated inbound leg on the claimed
+ * thread. During the canonical-log migration, legacy listener traffic lives in
+ * the HMAC inbox while every modern relay funnel writes the hash-chained
+ * per-thread log. Authorization accepts the union of those two authorities.
+ *
+ * Fail closed on malformed input, mismatches, unconfined paths, absent stores,
+ * or read failures.
+ */
+export function isAuthenticatedThreadlineInbound(
+  sources: ThreadlineReplyValidationSources,
+  threadId: unknown,
+  messageId: unknown,
+): boolean {
+  if (typeof threadId !== 'string' || !threadId || typeof messageId !== 'string' || !messageId) return false;
+  // Reply authorization and at-most-once claiming are one invariant. The
+  // ListenerSessionManager currently owns the durable claim ledger, so modern
+  // ThreadLog evidence must not authorize a reply when that claim authority is
+  // unavailable.
+  if (!sources.listenerManager) return false;
+
+  try {
+    const legacy = sources.listenerManager.readCanonicalInboxEntry(messageId);
+    if (legacy?.threadId === threadId) return true;
+  } catch {
+    // One canonical source failing never erases valid evidence from the other.
+  }
+
+  try {
+    return sources.threadLog?.isPathConfined(threadId) === true
+      && sources.threadLog.has(threadId, messageId, 'inbound');
+  } catch {
+    return false;
+  }
+}

--- a/tests/integration/threadline-reap-recovery-wiring.test.ts
+++ b/tests/integration/threadline-reap-recovery-wiring.test.ts
@@ -17,7 +17,8 @@ describe('Threadline reap recovery production wiring', () => {
     const routes = fs.readFileSync(new URL('../../src/server/routes.ts', import.meta.url), 'utf8');
     expect(routes).toContain('Warm Threadline replies require inReplyTo for the current inbound message.');
     expect(routes).toContain('tryClaimReply(inReplyTo, replyClaimOwner)');
-    expect(routes).toContain('claimedInbound.threadId !== threadId');
+    expect(routes).toContain('isAuthenticatedThreadlineInbound(');
+    expect(routes).toContain('{ listenerManager: ctx.listenerManager, threadLog: ctx.threadLog }');
     expect(routes).toContain('inReplyTo must name an authenticated inbound on this thread.');
     expect(routes).toContain('if (res.statusCode >= 400) ctx.listenerManager?.releaseReplyClaim');
   });

--- a/tests/integration/threadline-relay-send-priority.test.ts
+++ b/tests/integration/threadline-relay-send-priority.test.ts
@@ -24,6 +24,7 @@ import { createRoutes } from '../../src/server/routes.js';
 import { StateManager } from '../../src/core/StateManager.js';
 import type { InstarConfig } from '../../src/core/types.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { vi } from 'vitest';
 
 let projectDir: string;
 let stateDir: string;
@@ -33,6 +34,15 @@ let fakeTargetServer: Server;
 let fakeTargetPort: number;
 let capturedEnvelopes: Array<unknown>;
 let tokenFilePath: string;
+const MODERN_THREAD = 'cfe01486-a896-4357-88a8-0251aacd2979';
+const MODERN_INBOUND = 'msg-modern-inbound';
+const activeReplyClaims = new Set<string>();
+const tryClaimReply = vi.fn((messageId: string) => {
+  if (activeReplyClaims.has(messageId)) return false;
+  activeReplyClaims.add(messageId);
+  return true;
+});
+const releaseReplyClaim = vi.fn((messageId: string) => activeReplyClaims.delete(messageId));
 const TEST_TARGET_NAME = `priority-test-target-${randomBytes(3).toString('hex')}`;
 
 describe('/threadline/relay-send caller-supplied priority', () => {
@@ -165,7 +175,20 @@ describe('/threadline/relay-send caller-supplied priority', () => {
       threadlineRouter: null,
       handshakeManager: null,
       threadlineRelayClient: stubRelayClient as any,
-      listenerManager: null,
+      listenerManager: {
+        readCanonicalInboxEntry: vi.fn(() => null),
+        readLatestCanonicalInboxForThread: vi.fn(() => null),
+        tryClaimReply,
+        releaseReplyClaim,
+        retainReplyClaimFailure: vi.fn(),
+        appendCanonicalOutboxEntry: vi.fn(),
+      },
+      threadLog: {
+        isPathConfined: vi.fn(() => true),
+        has: vi.fn((threadId: string, messageId: string, direction: string) =>
+          threadId === MODERN_THREAD && messageId === MODERN_INBOUND && direction === 'inbound'),
+        head: vi.fn(() => ({ count: 0, setAccum: '0'.repeat(64) })),
+      },
       responseReviewGate: null,
       telemetryHeartbeat: null,
       pasteManager: null,
@@ -315,5 +338,49 @@ describe('/threadline/relay-send caller-supplied priority', () => {
     const body = await res.json();
     expect(body.error).toMatch(/Invalid priority/i);
     expect(capturedEnvelopes).toHaveLength(0);
+  });
+
+  it('accepts modern-only inbound evidence, claims it, and releases after delivery', async () => {
+    activeReplyClaims.clear();
+    tryClaimReply.mockClear();
+    releaseReplyClaim.mockClear();
+
+    const res = await fetch(`${baseUrl}/threadline/relay-send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targetAgent: TEST_TARGET_NAME,
+        message: 'canonical modern reply',
+        threadId: MODERN_THREAD,
+        inReplyTo: MODERN_INBOUND,
+        waitForReply: false,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(tryClaimReply).toHaveBeenCalledWith(MODERN_INBOUND, expect.any(String));
+    expect(releaseReplyClaim).toHaveBeenCalledWith(MODERN_INBOUND, expect.any(String));
+    expect(activeReplyClaims.has(MODERN_INBOUND)).toBe(false);
+  });
+
+  it('returns 409 when the modern inbound already has an active reply claim', async () => {
+    activeReplyClaims.add(MODERN_INBOUND);
+    capturedEnvelopes.length = 0;
+
+    const res = await fetch(`${baseUrl}/threadline/relay-send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targetAgent: TEST_TARGET_NAME,
+        message: 'duplicate canonical modern reply',
+        threadId: MODERN_THREAD,
+        inReplyTo: MODERN_INBOUND,
+        waitForReply: false,
+      }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(capturedEnvelopes).toHaveLength(0);
+    activeReplyClaims.clear();
   });
 });

--- a/tests/unit/threadline/ThreadlineReplyValidation.test.ts
+++ b/tests/unit/threadline/ThreadlineReplyValidation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { isAuthenticatedThreadlineInbound } from '../../../src/threadline/ThreadlineReplyValidation.js';
+
+const THREAD = 'cfe01486-a896-4357-88a8-0251aacd2979';
+const MESSAGE = 'msg-1784436346759-dvffo8';
+
+describe('isAuthenticatedThreadlineInbound', () => {
+  it('accepts a verified legacy HMAC inbox entry on the claimed thread', () => {
+    const readCanonicalInboxEntry = vi.fn(() => ({ id: MESSAGE, threadId: THREAD } as never));
+    expect(isAuthenticatedThreadlineInbound({ listenerManager: { readCanonicalInboxEntry } }, THREAD, MESSAGE)).toBe(true);
+  });
+
+  it('accepts a modern canonical ThreadLog inbound when the legacy inbox is empty', () => {
+    const threadLog = {
+      isPathConfined: vi.fn(() => true),
+      has: vi.fn((_threadId: string, _messageId: string, direction: string) => direction === 'inbound'),
+    };
+    expect(isAuthenticatedThreadlineInbound({
+      listenerManager: { readCanonicalInboxEntry: vi.fn(() => null) },
+      threadLog,
+    }, THREAD, MESSAGE)).toBe(true);
+    expect(threadLog.has).toHaveBeenCalledWith(THREAD, MESSAGE, 'inbound');
+  });
+
+  it('never accepts an outbound leg as reply authority', () => {
+    const threadLog = { isPathConfined: vi.fn(() => true), has: vi.fn(() => false) };
+    expect(isAuthenticatedThreadlineInbound({ listenerManager: { readCanonicalInboxEntry: vi.fn(() => null) }, threadLog }, THREAD, MESSAGE)).toBe(false);
+    expect(threadLog.has).toHaveBeenCalledWith(THREAD, MESSAGE, 'inbound');
+  });
+
+  it('fails closed when evidence exists but the reply-claim authority is unavailable', () => {
+    const threadLog = { isPathConfined: vi.fn(() => true), has: vi.fn(() => true) };
+    expect(isAuthenticatedThreadlineInbound({ threadLog }, THREAD, MESSAGE)).toBe(false);
+    expect(threadLog.has).not.toHaveBeenCalled();
+  });
+
+  it('rejects a legacy entry from another thread', () => {
+    const readCanonicalInboxEntry = vi.fn(() => ({ id: MESSAGE, threadId: 'thread-other' } as never));
+    expect(isAuthenticatedThreadlineInbound({ listenerManager: { readCanonicalInboxEntry } }, THREAD, MESSAGE)).toBe(false);
+  });
+
+  it('fails closed for unconfined thread ids before reading the modern log', () => {
+    const threadLog = { isPathConfined: vi.fn(() => false), has: vi.fn(() => true) };
+    expect(isAuthenticatedThreadlineInbound({ listenerManager: { readCanonicalInboxEntry: vi.fn(() => null) }, threadLog }, '../../escape', MESSAGE)).toBe(false);
+    expect(threadLog.has).not.toHaveBeenCalled();
+  });
+
+  it('falls through a broken legacy store to valid modern authority', () => {
+    const listenerManager = { readCanonicalInboxEntry: vi.fn(() => { throw new Error('unreadable'); }) };
+    const threadLog = { isPathConfined: vi.fn(() => true), has: vi.fn(() => true) };
+    expect(isAuthenticatedThreadlineInbound({ listenerManager, threadLog }, THREAD, MESSAGE)).toBe(true);
+  });
+
+  it.each([
+    [undefined, MESSAGE], [THREAD, undefined], ['', MESSAGE], [THREAD, ''], [123, MESSAGE],
+  ])('rejects malformed pointer inputs (%j, %j)', (threadId, messageId) => {
+    expect(isAuthenticatedThreadlineInbound({}, threadId, messageId)).toBe(false);
+  });
+});

--- a/upgrades/next/threadline-canonical-reply-validation.md
+++ b/upgrades/next/threadline-canonical-reply-validation.md
@@ -1,0 +1,24 @@
+---
+change_type: fix
+---
+
+## What Changed
+
+- Threadline reply authorization now recognizes authenticated inbound messages in the modern hash-chained canonical log as well as the legacy listener inbox.
+- Wrong-thread, outbound-only, malformed, unconfined, or unreadable evidence remains fail-closed.
+- Reply evidence cannot authorize a send unless the durable at-most-once claim authority is available.
+
+## What to Tell Your User
+
+Cross-agent conversations no longer stall when a spawned worker replies to a message stored by Threadline's newer canonical history path. The security boundary is unchanged: replies still have to point to the exact authenticated inbound message on the same thread.
+
+## Summary of New Capabilities
+
+- Reliable replies from spawned Threadline sessions across both canonical history generations.
+
+## Evidence
+
+- Feedback: `fb-63d7c1fb-50a`
+- Unit: `tests/unit/threadline/ThreadlineReplyValidation.test.ts`
+- Behavioral route: `tests/integration/threadline-relay-send-priority.test.ts`
+- Wiring: `tests/integration/threadline-reap-recovery-wiring.test.ts`

--- a/upgrades/side-effects/threadline-canonical-reply-validation.md
+++ b/upgrades/side-effects/threadline-canonical-reply-validation.md
@@ -1,0 +1,75 @@
+# Side-Effects Review — Threadline canonical reply validation
+
+**Version / slug:** `threadline-canonical-reply-validation`
+**Date:** `2026-07-19`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `/root/threadline_review` (independent reviewer subagent)
+
+## Summary of the change
+
+The `/threadline/relay-send` reply authorization gate now validates `inReplyTo` against the union of the legacy HMAC listener inbox and the modern hash-chained per-thread log, while requiring the durable reply-claim authority before either source can authorize. A dedicated helper contains the fail-closed policy; unit and behavioral production-route tests pin it. This closes `fb-63d7c1fb-50a`.
+
+## Decision-point inventory
+
+- `isAuthenticatedThreadlineInbound` — added authority helper — decides whether a reply pointer names a durable authenticated inbound on the claimed thread.
+- `/threadline/relay-send` — modified — delegates its existing reply-authorization decision to the union helper.
+
+## 1. Over-block
+
+Valid messages absent from both evidence stores remain rejected. A modern entry with an invalid/unconfined thread id is rejected even if bytes exist, preserving traversal safety. A log read failure rejects unless the legacy store independently proves the pointer. Evidence also fails closed when `ListenerSessionManager`, the durable at-most-once claim authority, is unavailable.
+
+## 2. Under-block
+
+The new path accepts only `direction: inbound`; an outbound leg cannot authorize a reply. `ThreadLog` is populated through the authenticated inbound recording funnels. A local attacker able to rewrite the agent's state directory is outside the existing ThreadLog trust boundary; chain verification is an observability check rather than a per-send hot-path scan.
+
+## 3. Level-of-abstraction fit
+
+The helper sits at the reply authorization chokepoint and consumes the two existing canonical persistence authorities. It does not duplicate authentication or message recording. The migration union belongs here because the decision is specifically “does durable canonical evidence contain this inbound?”
+
+## 4. Signal vs authority compliance
+
+[docs/signal-vs-authority.md](../../docs/signal-vs-authority.md) applies. This gate has deterministic authority over an enumerable security invariant: exact thread id + exact message id + inbound direction in an authenticated canonical store. No semantic judgment or brittle content heuristic is involved.
+
+## 4b. Judgment-point check
+
+No competing-signals judgment. Store membership, direction, and thread confinement are exact invariants.
+
+## 5. Interactions
+
+The helper runs after the warm-worker current-inbound check and before the at-most-once reply claim. It broadens only the evidence source and explicitly couples authorization to availability of claim ownership. Legacy traffic remains byte-for-byte eligible. Modern E2E relay traffic now reaches the same claim gate. The production route test proves acceptance claims then releases after delivery, while an active claim returns 409 without delivery.
+
+## 6. External surfaces
+
+Valid spawned Threadline workers can reply to authenticated inbound messages persisted only in the modern log. Invalid replies still receive the same 400 error shape. No operator action, new endpoint, or external credential is added.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+Machine-local by design under Threadline's single-holder model: both canonical stores belong to the receiving holder and the reply route runs there. Cross-machine relay ingestion writes the modern log before the worker replies. No user notice or URL is generated; durable reply claims remain on the holder.
+
+## 8. Rollback cost
+
+Pure code change. Revert and ship a patch; no schema, migration, or state cleanup is required. Rollback would restore the valid-reply rejection for modern-only inbounds.
+
+## Conclusion
+
+The missing standard was migration-consumer completeness: a new canonical authority must be adopted by every authorization consumer or exposed through an explicit compatibility union. The process gap was a wiring test that pinned the legacy implementation string rather than the semantic two-store contract. The helper and tests close both gaps. Pending required independent review because this touches a messaging authorization gate.
+
+## Second-pass review
+
+**Reviewer:** `/root/threadline_review`
+**Independent read:** concur. The reviewer first blocked the change because modern evidence could authorize when the at-most-once claim authority was absent. After the correction, they independently inspected the diff and reran the focused suite (21/21): authorization now requires claim authority, modern-only evidence reaches claim and post-delivery release, and an active claim returns 409 with no delivery.
+
+## Evidence pointers
+
+- `tests/unit/threadline/ThreadlineReplyValidation.test.ts`
+- `tests/integration/threadline-relay-send-priority.test.ts`
+- `tests/integration/threadline-reap-recovery-wiring.test.ts`
+- Feedback `fb-63d7c1fb-50a`
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: claim-vs-evidence`, `closure: guard`, `guardEvidence: { enforcementType: gate, citation: src/threadline/ThreadlineReplyValidation.ts#isAuthenticatedThreadlineInbound, howCaught: the live reply gate requires exact inbound evidence from either canonical generation and the regression suite reproduces a modern-only authenticated inbound }`.

--- a/upgrades/threadline-canonical-reply-validation.eli16.md
+++ b/upgrades/threadline-canonical-reply-validation.eli16.md
@@ -1,0 +1,9 @@
+# Threadline canonical reply validation
+
+When one Instar agent receives a message from another, its reply must point back to the exact authenticated inbound message. That prevents a worker from inventing a message id or replying across the wrong thread. A recent Threadline migration introduced a newer canonical, hash-chained log that every modern relay path writes, while retaining the older HMAC listener inbox for compatibility. The reply gate accidentally kept checking only the older inbox.
+
+That split produced a bad outcome: the message was authenticated, delivered, and durably present in the new canonical log, but the spawned worker's reply was rejected as unauthenticated. Thread history could therefore look empty to the worker and a valid cross-agent conversation stalled.
+
+This repair defines one fail-closed validation helper over the union of both canonical generations. A reply pointer is accepted when either the legacy HMAC inbox proves the message belongs to that thread or the modern confined hash-chained log proves that exact id exists as an inbound leg, and only when the durable at-most-once claim ledger is available. Outbound legs never qualify. Wrong-thread pointers, malformed ids, path escapes, absent stores, and read failures remain rejected.
+
+The CLASS review found a migration-coherence gap: adding a canonical store is incomplete until every authorization consumer moves to it or explicitly reads a compatibility union. It also found that evidence and at-most-once claiming must remain one invariant. The fix addresses that class in one chokepoint and adds unit tests for both stores and failure modes, plus a behavioral live-route test proving modern-only acceptance, claim release after delivery, and rejection of duplicate claims. This closes feedback `fb-63d7c1fb-50a` without weakening Threadline's authenticated-reply boundary.


### PR DESCRIPTION
## Summary
- validate reply pointers against both legacy HMAC inbox evidence and the modern hash-chained ThreadLog
- require durable claim authority before either source can authorize a reply
- add behavioral route coverage for modern-only acceptance, claim release, and duplicate-claim rejection

Closes feedback `fb-63d7c1fb-50a`.

## CLASS review
Missing standard: migration-consumer completeness — a new canonical authority is not complete until authorization consumers adopt it or an explicit compatibility union. Process gap: the prior wiring test pinned a legacy implementation string instead of the semantic evidence-plus-claim invariant. This PR adds the shared guard and behavioral route ratchet.

## ELI16 — Why valid Threadline replies were rejected
Modern Threadline messages are authenticated and saved in a newer hash-chained history, but the reply gate still looked only in the older listener inbox. A worker could receive a real message and still have its reply rejected. The gate now accepts exact inbound evidence from either history generation, while still requiring the durable claim ledger that prevents two replies racing for the same inbound. Wrong-thread, outbound-only, malformed, or duplicate pointers remain blocked.

## Verification
- focused unit/integration: 21/21
- TypeScript/lint: passed
- scoped Threadline E2E: 333/333
- independent high-risk review: concurred after one required correction