### PR TITLE
fix: persist context wedge observation

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-21T09-54-04-344Z-context-wedge-seen-latch.json
+++ b/.instar/instar-dev-decisions/2026-07-21T09-54-04-344Z-context-wedge-seen-latch.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T09:54:04.344Z",
+  "slug": "context-wedge-seen-latch",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 66,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-21T09-54-06-590Z-context-wedge-seen-latch.json
+++ b/.instar/instar-dev-decisions/2026-07-21T09-54-06-590Z-context-wedge-seen-latch.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T09:54:06.590Z",
+  "slug": "context-wedge-seen-latch",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 66,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-21T09-54-25-725Z-context-wedge-seen-latch.json
+++ b/.instar/instar-dev-decisions/2026-07-21T09-54-25-725Z-context-wedge-seen-latch.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T09:54:25.725Z",
+  "slug": "context-wedge-seen-latch",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 66,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-21T09-55-08-969Z-context-wedge-seen-latch.json
+++ b/.instar/instar-dev-decisions/2026-07-21T09-55-08-969Z-context-wedge-seen-latch.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T09:55:08.969Z",
+  "slug": "context-wedge-seen-latch",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 66,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-21T09-52-19-793Z-context-wedge-seen-latch-61819aa7.json
+++ b/.instar/instar-dev-traces/2026-07-21T09-52-19-793Z-context-wedge-seen-latch-61819aa7.json
@@ -1,0 +1,51 @@
+{
+  "version": 3,
+  "slug": "context-wedge-seen-latch",
+  "sessionId": "2aaad3e8-d2bb-4548-a5e9-3a5e274845b2",
+  "timestamp": "2026-07-21T09:52:19.793Z",
+  "artifactPath": "upgrades/side-effects/context-wedge-seen-latch.md",
+  "artifactSha256": "18e9985f77c4d4db9b7e3b58c18a90c22a2f8eed9cf4d22d6fde5c346f15a0fb",
+  "specPath": "docs/specs/context-wedge-detection-completeness.md",
+  "coveredFiles": [
+    "docs/specs/context-wedge-detection-completeness.eli16.md",
+    "docs/specs/context-wedge-detection-completeness.md",
+    "docs/specs/reports/context-wedge-detection-completeness-convergence.md",
+    "src/monitoring/SessionMonitor.ts",
+    "src/monitoring/SessionRecovery.ts",
+    "tests/unit/SessionMonitor.test.ts",
+    "tests/unit/context-exhaustion-recovery.test.ts",
+    "upgrades/next/context-wedge-seen-latch.md",
+    "upgrades/side-effects/context-wedge-seen-latch.md"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "Context exhaustion recovery-path change requires converged spec and independent review despite narrow boolean-only scope.",
+  "secondPass": "true",
+  "reviewerConcurred": true,
+  "toolchain": {
+    "buildSkill": {
+      "name": "instar-dev",
+      "version": "5c281366e0da",
+      "verified": true
+    },
+    "reviewSkills": [
+      {
+        "name": "spec-converge",
+        "outcome": "converged",
+        "verified": false,
+        "iterations": 2
+      },
+      {
+        "name": "independent-second-pass",
+        "outcome": "concurred",
+        "verified": false,
+        "iterations": 1
+      }
+    ],
+    "convergence": {
+      "reportPath": "docs/specs/reports/context-wedge-detection-completeness-convergence.md",
+      "iterations": 2,
+      "verified": true
+    }
+  }
+}

--- a/docs/specs/context-wedge-detection-completeness.eli16.md
+++ b/docs/specs/context-wedge-detection-completeness.eli16.md
@@ -1,0 +1,11 @@
+# ELI16 — Remember one fact after the banner scrolls away
+
+Instar already knows how to recognize Claude Code's real context-limit banner. It also already has one recovery engine that decides whether it is safe to act, waits through its existing cooldown, limits attempts, tries `/compact`, and can respawn the session. This change does not redesign any of that.
+
+The failure is simpler: the monitor sees only the latest terminal lines. It can see the real banner on one poll, then lose sight of it after more output scrolls the banner upward. Losing the visible banner currently also loses the fact that the trusted detector already matched it.
+
+The fix remembers exactly one fact per topic: `wedgedSeen=true`. The value is written only after the existing detector matches one of its existing patterns. It survives a server restart in SessionRecovery's existing state file. It has no timestamp, pattern copy, session mapping, confidence score, retry counter, or expiry. It cannot recognize anything new and cannot take action itself.
+
+On later ordinary monitor polls, that remembered true value lets the same SessionRecovery engine inspect and handle the topic even if the banner is no longer in the captured tail. All of SessionRecovery's existing ownership, active-work, cooldown, attempt, compact, and respawn rules still decide what happens. A failed or deferred result leaves the fact remembered but creates no timer or retry. The monitor's existing poll and cooldown remain the only presentation rhythm.
+
+The boolean clears only when the existing engine reports genuine recovery (`recovered:true`) or when an operator uses the explicit manual-clear seam. It never disappears because an hour passed. This makes the banner observation durable without turning the latch into a second detector, validator, scheduler, or recovery engine.

--- a/docs/specs/context-wedge-detection-completeness.md
+++ b/docs/specs/context-wedge-detection-completeness.md
@@ -1,93 +1,122 @@
 ---
-title: "Context-wedge detection completeness — make the LIVE recovery engine fire for the scrolled-out-banner wedge"
+title: "Context-wedge seen latch"
 slug: "context-wedge-detection-completeness"
-author: "echo"
-status: draft
-approved: false
-supersedes: "context-limit-wedge-recovery.md (WITHDRAWN — it proposed a NEW ContextWedgeSentinel family that DUPLICATED the live SessionRecovery engine; caught in spec-converge round 1, reviewer adbfa439 + author re-grounding)"
-parent-principle: "The Agent Is Always Reachable — a session that fast-fails every turn at the context wall until a human manually /compacts is not reachable; the recovery engine EXISTS and runs live, but its DETECTION misses the persistent post-wedge state"
+author: "instar-codey"
+status: approved
+approved: true
+parent-principle: "The Agent Is Always Reachable"
 lessons-engaged:
-  - "Verify the State, Not Its Symbol (the fix is to persist the WEDGED STATE once observed, so a transient banner that scrolls out of the capture window does not drop the detection — the state is the wedge, the banner is only its momentary symbol)"
-  - "Foundation grep evidence (this spec's §1 lists the capability-level grep that the WITHDRAWN spec skipped — grounding against ALL implementations of context-exhaustion recovery, not the one component the author anchored on)"
-  - "Reuse Before Rebuild (the /compact→respawn ladder, attempt cap, cooldown, in-flight-reply capture, and the 2026-06-06 false-positive framing guard ALL already exist in the live engine; this spec adds ONLY detection persistence — no second engine, no double-compact race)"
-  - "No Unbounded Loops (P19: the fix rides the EXISTING SessionRecovery attempt cap + cooldown; the persisted wedged-state has a bounded TTL and is cleared on genuine progress)"
-  - "Distrust Temporary Success (the persisted wedged-state clears ONLY on a genuine output delta BELOW the banner, never on a transient repaint)"
+  - "Verify the State, Not Its Symbol: preserve an existing positive detector result after its banner scrolls away."
+  - "Reuse Before Rebuild: SessionRecovery remains the only recovery authority."
+  - "Signal vs Authority: the latch remembers one boolean and makes no recovery decision."
+review-convergence: "2026-07-21T09:41:31.992Z"
+review-iterations: 2
+review-completed-at: "2026-07-21T09:41:31.992Z"
+review-report: "docs/specs/reports/context-wedge-detection-completeness-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
 single-run-completable: true
+frontloaded-decisions: 4
+cheap-to-change-tags: 0
+contested-then-cleared: 0
 ---
 
-# Context-wedge detection completeness
+# Context-wedge seen latch
 
-## 0. Why this spec exists (and what it replaces)
+## Problem
 
-The context-wall wedge hit the interactive session TWICE in apprenticeship Drive 7: the session fast-failed every turn at "Context limit reached · /compact or /clear to continue" until the operator MANUALLY sent /compact (~55 min unanswered the first time). A first spec (`context-limit-wedge-recovery.md`) proposed adding a THIRD `context-limit` family to `ContextWedgeSentinel` with its own /compact→respawn recovery ladder. **That spec was WITHDRAWN in spec-converge round 1** — the reviewer AND the author's own re-grounding found it duplicated a **live-by-default recovery engine that already implements the exact ladder**. This spec is the correctly-grounded redirect: the recovery already works; the DETECTION misses the persistent post-wedge state. Fix the detection, reuse the engine.
+The live context-exhaustion detector recognizes the existing `CONTEXT_PATTERNS`, and the live `SessionRecovery` engine owns all validation, cooldown, attempt, `/compact`, and respawn behavior. The monitor reads a bounded tmux tail. When a detector-positive banner scrolls out of that tail before the existing recovery path reaches genuine progress, later polls forget the observation.
 
-## 1. Verified foundation (capability-grep evidence — the step the withdrawn spec skipped)
+Here, a **topic** is the existing numeric conversation key passed to `SessionMonitor` and `SessionRecovery`; an **ordinary poll** is the monitor's already-scheduled scan, not a new timer; and **genuine progress** is the existing `RecoveryResult.recovered === true` outcome. Topic identifiers are stable external conversation identities in the current foundation. If an operator deliberately reuses one for a different conversation, the existing manual-clear seam must be invoked first; this increment deliberately adds no mapping heuristic.
 
-**Grep run (the foundation audit at capability level, not one component):**
-```
-grep -rl "detectContextExhaustion\|context.*limit\|conversation too long" src/
-→ QuotaExhaustionDetector.ts, SessionMonitor.ts, SessionRecovery.ts, server.ts, StuckSignatureClassifier.ts, guardManifest.ts …
-grep -rn "detectContextExhaustion" src/
-→ defined QuotaExhaustionDetector.ts:161; called SessionMonitor.ts:287, SessionRecovery.ts:270, server.ts:11085
-```
+## Binding scope
 
-What that grep establishes (all verified against origin/main v1.3.889):
+Add exactly one persisted boolean per numeric topic: `wedgedSeen: true`.
 
-- **`QuotaExhaustionDetector.detectContextExhaustion(tmuxOutput)`** (`QuotaExhaustionDetector.ts:161`) — detects the wall via `CONTEXT_PATTERNS` (banner strings: `context.*limit`, `conversation too long`, `press esc twice…`) with a **hard-won 2026-06-06 false-positive framing guard** (the bare phrase "conversation too long" without CLI recovery framing does NOT fire — born from the topic-13435 flood where a session working ON the feature self-amplified one false positive). Returns `{matched, pattern, confidence}`.
-- **`SessionRecovery.recoverFromContextExhaustion`** (`SessionRecovery.ts:533`) — the LIVE recovery ladder: **Rung 1 `/compact`** (`attemptCompaction`, `server.ts:11070` — presses /compact, polls ≤30s, verifies `!detectContextExhaustion(out).matched`, detects "error during compaction") gated on `!hasActiveProcesses`; **Rung 2** kill + fresh respawn with in-flight-reply capture; plus an **attempt cap** (`shouldAttempt`/`maxAttempts:3`/`cooldownMs:15min`).
-- **Trigger:** `SessionMonitor.checkSession` (`SessionMonitor.ts:287`) calls `detectContextExhaustion(currentOutput)` on every poll, where `currentOutput = captureSessionOutput(sessionName, 30)` (**30-line window**, `:257`). `SessionRecovery.enabled` defaults **true** → this engine is LIVE now, not dark.
-- **`ContextWedgeSentinel`** (`ContextWedgeSentinel.ts`) — a SEPARATE engine for two OTHER fast-fail families (`thinking-block-400`, `aup-rejection`), both recovering via DESTRUCTIVE respawn. It owns the "Cooked for 0s" / "API Error … latest assistant message" fast-fail signatures — which `QuotaExhaustionDetector` does NOT have.
+- Set it only when the unchanged `detectContextExhaustion()` function returns `matched: true` from the unchanged `CONTEXT_PATTERNS` table.
+- Let an ordinary monitor poll continue presenting that remembered boolean to the same `SessionRecovery.checkAndRecover()` instance. The boolean is evidence that the existing detector already matched; it is not a new detector or recovery decision.
+- Clear it only when the existing recovery result reports `recovered: true`, or through an explicit manual-clear method. It never expires by wall clock.
+- Persist it in the existing recovery-state file beside existing attempt state, using the existing recovery-state write owner.
 
-## 2. Root cause (code-grounded, symptom-consistent)
+The stored value contains no timestamp, session name, pattern identifier, retry count, mapping, confidence, expiry, validation result, or pane content. Absence and `false` are equivalent; only `true` rows are serialized.
 
-The live engine keys on the wall **BANNER** inside a **30-line capture window**. After the wedge, each fast-failed turn ("Cooked for 0s") emits NEW lines, scrolling the original banner **up and out of the 30-line window**. `CONTEXT_PATTERNS` has **no fast-fail signature**, so `detectContextExhaustion(last-30-lines)` returns `matched:false` on the persistent post-wedge tail → the live /compact engine **never fires** → the wedge persists until a manual /compact.
+## Frozen foundation
 
-**Why this is the cause, not a guess:** Rung 1 fires on `!hasActiveProcesses`, and a fast-fail wedge runs no child process. Had the engine DETECTED the wedge it would have auto-/compacted (no manual /compact needed). The operator needed to /compact manually → detection missed it → the banner was not in the scanned window. The withdrawn spec's "idle-gate skips the mid-turn wedge" premise was FALSE (the gate is `!hasActiveProcesses`, which a fast-fail wedge PASSES). **Empirical validation step (Verify the State, Not Its Symbol):** confirm against the actual Drive-7 pane capture if still on disk (≈2 days old; may be rotated) before the live flip; the code-level argument is strong but the capture is the ground truth.
+This change does not add or alter:
 
-## 3. Proposed design — persist the wedged STATE (add detection persistence, reuse the engine)
+- a `CONTEXT_PATTERNS` entry or false-positive guard;
+- pane-shape, prompt, silence, provider-wait, or network-wait classification;
+- topic/session mapping validation;
+- a timer, TTL, cooldown, retry, scheduler, or attempt budget;
+- active-work validation, ownership validation, compaction, respawn, notification, or recovery-result semantics;
+- a second sentinel or recovery engine.
 
-### 3.1 The change (small, one detection layer)
-Add a per-topic **wedged-state latch** in the `SessionMonitor` context-exhaustion path (feeding the SAME `detectContextExhaustion` → `SessionRecovery` trigger, unchanged):
-- **Set:** when `detectContextExhaustion(currentOutput).matched` is true for a topic, record `contextWedgedSince[topicId] = now` (alongside the existing `contextExhaustionCooldowns`).
-- **Hold:** on a subsequent poll where the 30-line window NO LONGER contains the banner (it scrolled out) BUT the session is still fast-failing, the latch keeps the topic classified as wedged, so `SessionRecovery.checkAndRecover` is still invoked — the recovery the banner-detection would have triggered is not dropped just because the banner scrolled out.
-- **Clear:** the latch clears ONLY on a **genuine output delta below the banner** — the pane tail advanced with NEW non-fast-fail content (real work resumed / the /compact landed / a fresh prompt is accepting input). A transient repaint never clears it (Distrust Temporary Success).
+`SessionRecovery` remains the sole authority. A remembered boolean reaches the same context-recovery branch, which still applies every existing guard and bound. Any non-success recovery result leaves the boolean set and schedules nothing; later presentation happens only through the monitor's already-existing poll and cooldown.
 
-### 3.2 The load-bearing safety precondition (reviewer M-D)
-The latch MUST be gated by an **active-work-indicator negative check** — `looksActivelyWorking`/`looksGeneratingNow` (`sentinelWiring.ts:171`: spinner / "esc to interrupt" / a live subagent). A session genuinely mid-long-tool-call at high context (a build, a big grep, a subagent) can show the banner as a status hint while STILL working; it must NEVER be /compacted out from under live work. The latch sets/holds ONLY when the active-work indicators are absent (a true fast-fail wedge shows no spinner). This is the protection the withdrawn spec wrongly discarded as "coarse."
+## State transitions
 
-### 3.3 What is REUSED unchanged (no second engine)
-The `/compact`→respawn ladder, the `!hasActiveProcesses` Rung-1 gate, the attempt cap (`maxAttempts:3`/`cooldownMs:15min`), the in-flight-reply capture, and the 2026-06-06 false-positive framing guard — ALL unchanged. This spec adds ONLY detection persistence. **Explicitly REJECTED:** a new `ContextWedgeSentinel` `context-limit` family with its own ladder (the withdrawn design) — it would create two engines watching the same pane, two attempt caps, and a double-compact/double-respawn race.
+| Current | Existing event | Next |
+|---|---|---|
+| absent | existing detector matches | `wedgedSeen=true`, persisted |
+| true | detector no longer matches | true |
+| true | existing recovery returns any non-success result | true |
+| true | existing recovery returns `recovered:true` | absent, persisted |
+| true | explicit manual clear | absent, persisted |
+| absent | process/server restart | absent |
+| true | process/server restart | true, loaded from existing state file |
 
-## Multi-machine posture
+No transition depends on elapsed time.
 
-The context-exhaustion detection + recovery act on **THIS machine's own tmux sessions** — a pane wedge is a local phenomenon; only the machine holding the pane can capture its output or send-keys /compact. Same posture as the existing detector/recovery. No cross-machine surface is introduced (the latch is per-topic in-memory monitor state on the owning machine, rebuilt from the live pane on restart — it is a cache of an observable, not durable authority).
+## API seam
 
-machine-local-justification: hardware-bound-resource
+`SessionRecovery` exposes three deliberately mechanical methods:
 
-## 4. Testing (Testing Integrity — all three tiers)
+- `markContextWedgedSeen(topicId)` — stores `true` and persists; called only after the existing detector matches.
+- `hasContextWedgedSeen(topicId)` — reads the boolean so the monitor can continue calling the existing engine after the banner scrolls away.
+- `clearContextWedgedSeen(topicId)` — explicit manual-intervention seam; successful existing recovery calls the same clear internally.
 
-- **Unit:** (a) banner in window → latch SET; (b) banner scrolls out of the 30-line window while fast-fail tail persists + no active-work indicator → latch HELD → recovery still invoked (the core fix); (c) genuine output delta below the banner → latch CLEARED; (d) active-work indicator present (spinner/subagent) → latch NOT set even with banner visible (no compact out from under work); (e) the existing attempt cap still bounds repeated recovery (re-wedge after /compact → cap → escalate, not loop).
-- **Integration:** a simulated wedged session whose banner scrolls out drives ONE /compact via the EXISTING `SessionRecovery` path (metadata-only audit row); the recovery engine is invoked exactly once per the cap.
-- **E2E:** the detection-persistence is alive on a dev agent in the existing monitor path (logs the held-wedge classification) — "feature is alive."
+Inside `checkAndRecover`, current detector output remains preferred for the existing matched-pattern message. When no current pattern is visible but the boolean is true, the same context-recovery method runs without inventing a replacement pattern identity.
 
-## 5. Deployment, migration, rollback (Maturation + Migration Parity)
+The exact latched-only call is `recoverFromContextExhaustion(topicId, sessionName, null)`. `null` affects message rendering only: the existing method omits its optional current-pattern clause. Cooldown keys remain the existing `context:${sessionName}` key and branch selection remains the existing context-recovery branch. No log or user message claims that the pattern is currently visible.
 
-- The DETECTION persistence is default-on housekeeping (it only changes WHEN the existing engine is invoked, gated by the active-work precondition — it never adds a new destructive action). The RECOVERY it triggers is the existing staged `SessionRecovery` path (already live-by-default with its own cap), so no new rollout stage is introduced; the active-work precondition is the safety.
-- Migration Parity: the change is in built-in monitor code (always-overwritten on update); no per-agent config migration. Agent Awareness: update the CLAUDE.md "Stuck-Context Recovery" section — RECONCILE, do not append: the existing note says the context-wall recovery presses /compact first; add that detection now PERSISTS across a scrolled-out banner so the mid-turn wedge is covered.
-- Rollback: a config flag (`monitoring.contextWedgeLatch.enabled`, default on) disables the latch → detection reverts to banner-in-window-only (today's behavior); no regression, a wedge then needs a manual /compact exactly as before.
+All mutations occur through the single live `SessionRecovery` instance. Its synchronous set mutation and existing whole-record state write serialize the attempt map and boolean map together before control returns to the monitor. Tests assert setting and clearing the boolean preserve existing attempt rows.
 
-## Frontloaded Decisions
+A stale true value cannot bypass a disruptive-action brake. Each presentation still enters `recoverFromContextExhaustion`, where the existing per-session cooldown and maximum-attempt check runs before `/compact`, kill, or respawn. Once exhausted, later polls return `recovered:false` without acting. The boolean's persistence changes memory of the prior signal, not those bounds.
 
-- **FD-A (persist detection, do NOT build a new recovery engine):** the /compact ladder exists and runs live; the gap is detection dropping when the banner scrolls out. Reversible (config flag).
-- **FD-B (clear the latch ONLY on genuine progress, not a repaint):** Distrust Temporary Success — a transient frame change is not recovery.
-- **FD-C (active-work-indicator precondition is mandatory):** the latch never fires while spinner/subagent indicators are present — the protection against compacting live work (reviewer M-D).
-- **FD-D (empirical validation before live flip):** confirm the scroll-out mechanism against the real Drive-7 pane capture if available; the code argument is strong but the capture is ground truth.
+## Acceptance criteria
+
+1. Existing detector fixtures and `CONTEXT_PATTERNS` remain unchanged.
+2. A current positive detector result persists only `{topicId: true}` state.
+3. After current output becomes detector-negative, a true latch still reaches the same context recovery branch.
+4. Every pre-existing ownership, active-process, attempt, cooldown, compact, and respawn guard still applies.
+5. `recovered:true` clears and persists; every existing non-success result does not clear.
+6. Explicit manual clear removes and persists the row.
+7. Restart reloads true rows. Malformed/non-true rows are ignored by the existing tolerant state loader.
+8. No clock, timer, expiry, session mapping, validation layer, retry owner, new pattern, or second engine is introduced.
+9. Focused unit/integration tests, lint, build, and repository push tests pass.
+10. Setting or clearing a boolean preserves every existing recovery-attempt row in the same file.
 
 ## Decision points touched
 
-- **The wedged-state latch (§3.1) — `invariant` (deterministic state machine).** Set on banner-match, hold while fast-failing + no active-work indicator, clear on a genuine output delta. No LLM authorizes it; it is a regex + a bounded-TTL latch feeding the EXISTING recovery trigger. Justification: this is exactly the "static rule at a deterministic detection point" the Judgment-Within-Floors standard permits — the input (banner present / fast-fail tail / active-work indicator / output delta) is structurally observable, not a competing-signals judgment.
-- **The recovery action itself — unchanged, owned by `SessionRecovery`.** Its existing classification (compact-vs-respawn on `!hasActiveProcesses`, capped) is not modified by this spec.
+| Point | Classification (`invariant` / `judgment-candidate`) | Owner |
+|---|---|---|
+| Set boolean | invariant | unchanged detector result only |
+| Read/persist boolean | invariant | recovery-state owner |
+| Clear boolean | invariant | existing `recovered:true` signal or explicit manual intervention |
+| Validate/attempt/recover | `invariant` pass-through — this change does not alter the existing deterministic authority | existing `SessionRecovery` |
+
+## Multi-machine posture
+
+The boolean is stored in the same machine-local recovery-state record as the existing SessionRecovery attempt state. It is a memory of a local detector observation, not a cross-machine authority or ownership record.
+
+machine-local-justification: hardware-bound-resource — the observed tmux pane and recovery engine are local to the machine that owns the session.
+
+## Frontloaded decisions
+
+- Boolean-only means exactly true-or-absent; no metadata may be added in this increment.
+- No time-based clear is permitted.
+- Manual clear is explicit; the latch does not infer manual intervention from pane text or session mapping.
+- Broader detector completeness, silent-wait proof, mapping semantics, and retry policy remain separate work.
 
 ## Open questions
 
-*(none)*
+None.

--- a/docs/specs/context-wedge-detection-completeness.md
+++ b/docs/specs/context-wedge-detection-completeness.md
@@ -1,0 +1,93 @@
+---
+title: "Context-wedge detection completeness — make the LIVE recovery engine fire for the scrolled-out-banner wedge"
+slug: "context-wedge-detection-completeness"
+author: "echo"
+status: draft
+approved: false
+supersedes: "context-limit-wedge-recovery.md (WITHDRAWN — it proposed a NEW ContextWedgeSentinel family that DUPLICATED the live SessionRecovery engine; caught in spec-converge round 1, reviewer adbfa439 + author re-grounding)"
+parent-principle: "The Agent Is Always Reachable — a session that fast-fails every turn at the context wall until a human manually /compacts is not reachable; the recovery engine EXISTS and runs live, but its DETECTION misses the persistent post-wedge state"
+lessons-engaged:
+  - "Verify the State, Not Its Symbol (the fix is to persist the WEDGED STATE once observed, so a transient banner that scrolls out of the capture window does not drop the detection — the state is the wedge, the banner is only its momentary symbol)"
+  - "Foundation grep evidence (this spec's §1 lists the capability-level grep that the WITHDRAWN spec skipped — grounding against ALL implementations of context-exhaustion recovery, not the one component the author anchored on)"
+  - "Reuse Before Rebuild (the /compact→respawn ladder, attempt cap, cooldown, in-flight-reply capture, and the 2026-06-06 false-positive framing guard ALL already exist in the live engine; this spec adds ONLY detection persistence — no second engine, no double-compact race)"
+  - "No Unbounded Loops (P19: the fix rides the EXISTING SessionRecovery attempt cap + cooldown; the persisted wedged-state has a bounded TTL and is cleared on genuine progress)"
+  - "Distrust Temporary Success (the persisted wedged-state clears ONLY on a genuine output delta BELOW the banner, never on a transient repaint)"
+single-run-completable: true
+---
+
+# Context-wedge detection completeness
+
+## 0. Why this spec exists (and what it replaces)
+
+The context-wall wedge hit the interactive session TWICE in apprenticeship Drive 7: the session fast-failed every turn at "Context limit reached · /compact or /clear to continue" until the operator MANUALLY sent /compact (~55 min unanswered the first time). A first spec (`context-limit-wedge-recovery.md`) proposed adding a THIRD `context-limit` family to `ContextWedgeSentinel` with its own /compact→respawn recovery ladder. **That spec was WITHDRAWN in spec-converge round 1** — the reviewer AND the author's own re-grounding found it duplicated a **live-by-default recovery engine that already implements the exact ladder**. This spec is the correctly-grounded redirect: the recovery already works; the DETECTION misses the persistent post-wedge state. Fix the detection, reuse the engine.
+
+## 1. Verified foundation (capability-grep evidence — the step the withdrawn spec skipped)
+
+**Grep run (the foundation audit at capability level, not one component):**
+```
+grep -rl "detectContextExhaustion\|context.*limit\|conversation too long" src/
+→ QuotaExhaustionDetector.ts, SessionMonitor.ts, SessionRecovery.ts, server.ts, StuckSignatureClassifier.ts, guardManifest.ts …
+grep -rn "detectContextExhaustion" src/
+→ defined QuotaExhaustionDetector.ts:161; called SessionMonitor.ts:287, SessionRecovery.ts:270, server.ts:11085
+```
+
+What that grep establishes (all verified against origin/main v1.3.889):
+
+- **`QuotaExhaustionDetector.detectContextExhaustion(tmuxOutput)`** (`QuotaExhaustionDetector.ts:161`) — detects the wall via `CONTEXT_PATTERNS` (banner strings: `context.*limit`, `conversation too long`, `press esc twice…`) with a **hard-won 2026-06-06 false-positive framing guard** (the bare phrase "conversation too long" without CLI recovery framing does NOT fire — born from the topic-13435 flood where a session working ON the feature self-amplified one false positive). Returns `{matched, pattern, confidence}`.
+- **`SessionRecovery.recoverFromContextExhaustion`** (`SessionRecovery.ts:533`) — the LIVE recovery ladder: **Rung 1 `/compact`** (`attemptCompaction`, `server.ts:11070` — presses /compact, polls ≤30s, verifies `!detectContextExhaustion(out).matched`, detects "error during compaction") gated on `!hasActiveProcesses`; **Rung 2** kill + fresh respawn with in-flight-reply capture; plus an **attempt cap** (`shouldAttempt`/`maxAttempts:3`/`cooldownMs:15min`).
+- **Trigger:** `SessionMonitor.checkSession` (`SessionMonitor.ts:287`) calls `detectContextExhaustion(currentOutput)` on every poll, where `currentOutput = captureSessionOutput(sessionName, 30)` (**30-line window**, `:257`). `SessionRecovery.enabled` defaults **true** → this engine is LIVE now, not dark.
+- **`ContextWedgeSentinel`** (`ContextWedgeSentinel.ts`) — a SEPARATE engine for two OTHER fast-fail families (`thinking-block-400`, `aup-rejection`), both recovering via DESTRUCTIVE respawn. It owns the "Cooked for 0s" / "API Error … latest assistant message" fast-fail signatures — which `QuotaExhaustionDetector` does NOT have.
+
+## 2. Root cause (code-grounded, symptom-consistent)
+
+The live engine keys on the wall **BANNER** inside a **30-line capture window**. After the wedge, each fast-failed turn ("Cooked for 0s") emits NEW lines, scrolling the original banner **up and out of the 30-line window**. `CONTEXT_PATTERNS` has **no fast-fail signature**, so `detectContextExhaustion(last-30-lines)` returns `matched:false` on the persistent post-wedge tail → the live /compact engine **never fires** → the wedge persists until a manual /compact.
+
+**Why this is the cause, not a guess:** Rung 1 fires on `!hasActiveProcesses`, and a fast-fail wedge runs no child process. Had the engine DETECTED the wedge it would have auto-/compacted (no manual /compact needed). The operator needed to /compact manually → detection missed it → the banner was not in the scanned window. The withdrawn spec's "idle-gate skips the mid-turn wedge" premise was FALSE (the gate is `!hasActiveProcesses`, which a fast-fail wedge PASSES). **Empirical validation step (Verify the State, Not Its Symbol):** confirm against the actual Drive-7 pane capture if still on disk (≈2 days old; may be rotated) before the live flip; the code-level argument is strong but the capture is the ground truth.
+
+## 3. Proposed design — persist the wedged STATE (add detection persistence, reuse the engine)
+
+### 3.1 The change (small, one detection layer)
+Add a per-topic **wedged-state latch** in the `SessionMonitor` context-exhaustion path (feeding the SAME `detectContextExhaustion` → `SessionRecovery` trigger, unchanged):
+- **Set:** when `detectContextExhaustion(currentOutput).matched` is true for a topic, record `contextWedgedSince[topicId] = now` (alongside the existing `contextExhaustionCooldowns`).
+- **Hold:** on a subsequent poll where the 30-line window NO LONGER contains the banner (it scrolled out) BUT the session is still fast-failing, the latch keeps the topic classified as wedged, so `SessionRecovery.checkAndRecover` is still invoked — the recovery the banner-detection would have triggered is not dropped just because the banner scrolled out.
+- **Clear:** the latch clears ONLY on a **genuine output delta below the banner** — the pane tail advanced with NEW non-fast-fail content (real work resumed / the /compact landed / a fresh prompt is accepting input). A transient repaint never clears it (Distrust Temporary Success).
+
+### 3.2 The load-bearing safety precondition (reviewer M-D)
+The latch MUST be gated by an **active-work-indicator negative check** — `looksActivelyWorking`/`looksGeneratingNow` (`sentinelWiring.ts:171`: spinner / "esc to interrupt" / a live subagent). A session genuinely mid-long-tool-call at high context (a build, a big grep, a subagent) can show the banner as a status hint while STILL working; it must NEVER be /compacted out from under live work. The latch sets/holds ONLY when the active-work indicators are absent (a true fast-fail wedge shows no spinner). This is the protection the withdrawn spec wrongly discarded as "coarse."
+
+### 3.3 What is REUSED unchanged (no second engine)
+The `/compact`→respawn ladder, the `!hasActiveProcesses` Rung-1 gate, the attempt cap (`maxAttempts:3`/`cooldownMs:15min`), the in-flight-reply capture, and the 2026-06-06 false-positive framing guard — ALL unchanged. This spec adds ONLY detection persistence. **Explicitly REJECTED:** a new `ContextWedgeSentinel` `context-limit` family with its own ladder (the withdrawn design) — it would create two engines watching the same pane, two attempt caps, and a double-compact/double-respawn race.
+
+## Multi-machine posture
+
+The context-exhaustion detection + recovery act on **THIS machine's own tmux sessions** — a pane wedge is a local phenomenon; only the machine holding the pane can capture its output or send-keys /compact. Same posture as the existing detector/recovery. No cross-machine surface is introduced (the latch is per-topic in-memory monitor state on the owning machine, rebuilt from the live pane on restart — it is a cache of an observable, not durable authority).
+
+machine-local-justification: hardware-bound-resource
+
+## 4. Testing (Testing Integrity — all three tiers)
+
+- **Unit:** (a) banner in window → latch SET; (b) banner scrolls out of the 30-line window while fast-fail tail persists + no active-work indicator → latch HELD → recovery still invoked (the core fix); (c) genuine output delta below the banner → latch CLEARED; (d) active-work indicator present (spinner/subagent) → latch NOT set even with banner visible (no compact out from under work); (e) the existing attempt cap still bounds repeated recovery (re-wedge after /compact → cap → escalate, not loop).
+- **Integration:** a simulated wedged session whose banner scrolls out drives ONE /compact via the EXISTING `SessionRecovery` path (metadata-only audit row); the recovery engine is invoked exactly once per the cap.
+- **E2E:** the detection-persistence is alive on a dev agent in the existing monitor path (logs the held-wedge classification) — "feature is alive."
+
+## 5. Deployment, migration, rollback (Maturation + Migration Parity)
+
+- The DETECTION persistence is default-on housekeeping (it only changes WHEN the existing engine is invoked, gated by the active-work precondition — it never adds a new destructive action). The RECOVERY it triggers is the existing staged `SessionRecovery` path (already live-by-default with its own cap), so no new rollout stage is introduced; the active-work precondition is the safety.
+- Migration Parity: the change is in built-in monitor code (always-overwritten on update); no per-agent config migration. Agent Awareness: update the CLAUDE.md "Stuck-Context Recovery" section — RECONCILE, do not append: the existing note says the context-wall recovery presses /compact first; add that detection now PERSISTS across a scrolled-out banner so the mid-turn wedge is covered.
+- Rollback: a config flag (`monitoring.contextWedgeLatch.enabled`, default on) disables the latch → detection reverts to banner-in-window-only (today's behavior); no regression, a wedge then needs a manual /compact exactly as before.
+
+## Frontloaded Decisions
+
+- **FD-A (persist detection, do NOT build a new recovery engine):** the /compact ladder exists and runs live; the gap is detection dropping when the banner scrolls out. Reversible (config flag).
+- **FD-B (clear the latch ONLY on genuine progress, not a repaint):** Distrust Temporary Success — a transient frame change is not recovery.
+- **FD-C (active-work-indicator precondition is mandatory):** the latch never fires while spinner/subagent indicators are present — the protection against compacting live work (reviewer M-D).
+- **FD-D (empirical validation before live flip):** confirm the scroll-out mechanism against the real Drive-7 pane capture if available; the code argument is strong but the capture is ground truth.
+
+## Decision points touched
+
+- **The wedged-state latch (§3.1) — `invariant` (deterministic state machine).** Set on banner-match, hold while fast-failing + no active-work indicator, clear on a genuine output delta. No LLM authorizes it; it is a regex + a bounded-TTL latch feeding the EXISTING recovery trigger. Justification: this is exactly the "static rule at a deterministic detection point" the Judgment-Within-Floors standard permits — the input (banner present / fast-fail tail / active-work indicator / output delta) is structurally observable, not a competing-signals judgment.
+- **The recovery action itself — unchanged, owned by `SessionRecovery`.** Its existing classification (compact-vs-respawn on `!hasActiveProcesses`, capped) is not modified by this spec.
+
+## Open questions
+
+*(none)*

--- a/docs/specs/reports/context-wedge-detection-completeness-convergence.md
+++ b/docs/specs/reports/context-wedge-detection-completeness-convergence.md
@@ -1,0 +1,42 @@
+# Convergence Report — Context-wedge seen latch
+
+## Cross-model review: codex-cli:gpt-5.5
+
+A real GPT-tier external pass ran on the boolean-only spec. A Gemini pass was attempted but returned no usable result. The Standards-Conformance Gate was invoked and was unavailable because the local endpoint required an authorization credential not exposed to this worktree.
+
+## ELI10 Overview
+
+Instar already sees the real context-limit banner and already has a recovery engine. The bug is that the banner can scroll outside the small terminal view, causing the next check to forget that the trusted detector had already seen it.
+
+The converged design remembers only `true` for that topic. It adds no clock, copied text, pattern, mapping, retry, or second engine. The same recovery engine keeps every safety decision. The value clears only after that engine reports recovery or an operator explicitly clears it.
+
+## Original vs Converged
+
+The original draft grew into a typed expiring cache with session identity, detector metadata, timing predictions, rollout modes, telemetry, and a new evidence schema into recovery. Review correctly stopped it at the ten-round cap. The operator's final ruling removed all four disputed dimensions at once. The converged design is true-or-absent state only, persisted by SessionRecovery's existing state owner.
+
+The external review then tightened four statements without expanding scope: topic-key reuse is an explicit operator/manual-clear invariant rather than a new mapping heuristic; the latched-only call uses a nullable current-pattern field only for message rendering; existing attempt/cooldown brakes are named as the protection against repeated action; and tests preserve attempt rows while the boolean changes.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|---:|---|---:|---|
+| 1 | security, adversarial, integration, decision-completeness, lessons-aware, codex-cli | 5 | Clarified stable topic invariant, exact nullable-pattern seam, existing action brakes, single-writer persistence, glossary. |
+| 2 | (converged) | 0 | No further body change. External rerun was attempted but degraded without a usable response; round 1 remains the successful cross-family review. |
+
+Standards-Conformance Gate: unavailable — local route rejected the unauthenticated worktree request. Signal-vs-authority was reviewed directly: the boolean is detector memory and SessionRecovery remains the sole authority.
+
+## Full Findings Catalog
+
+| Finding | Perspective | Resolution |
+|---|---|---|
+| A durable topic-only value could attach after deliberate topic-id reuse. | adversarial / codex | Kept the operator's no-mapping ruling; documented stable topic identity and mandatory explicit clear before deliberate reuse. |
+| Latched-only matched-pattern handling was ambiguous. | integration / codex | Specified `null` only for optional message rendering; no synthetic pattern or branch key. |
+| Durable stale signal could repeatedly disrupt. | security / codex | Named and tested the unchanged per-session attempt cap and cooldown, which execute before every disruptive action. |
+| Whole-record persistence could lose attempt state. | integration / codex | Declared the existing single SessionRecovery writer and added preservation assertions. |
+| Local terminology was underspecified. | decision-completeness / codex | Added exact definitions for topic, ordinary poll, and genuine progress. |
+| Foundation could repeat the detector-as-authority mistake. | lessons-aware | Confirmed the detector only sets memory and the existing SessionRecovery engine owns all decisions. |
+| A timer/TTL or session mapping would violate the final ruling. | scalability / adversarial | Explicitly prohibited both; persisted shape remains true-or-absent. |
+
+## Convergence verdict
+
+Converged at iteration 2. The final round found no new material issue inside the operator-ratified boolean-only boundary. There are no unresolved decisions, no cheap-to-change tags, and no hidden recovery authority.

--- a/src/monitoring/SessionMonitor.ts
+++ b/src/monitoring/SessionMonitor.ts
@@ -277,16 +277,27 @@ export class SessionMonitor extends EventEmitter {
     // Run BEFORE health classification because a context-exhausted session
     // appears "alive" with recent output (the error message itself), so it
     // would be classified as 'healthy' and skip all recovery logic.
-    if (alive && currentOutput && this.deps.sessionRecovery) {
+    if (alive && this.deps.sessionRecovery) {
       // Topic-level cooldown survives snapshot cleanup (which happens when sessions die between polls)
       const lastCtxAction = this.contextExhaustionCooldowns.get(topicId);
       const ctxCooldownMs = this.config.notificationCooldownMinutes * 60 * 1000;
       const inCtxCooldown = lastCtxAction && (now - lastCtxAction) < ctxCooldownMs;
+      const ctxCheck = detectContextExhaustion(currentOutput);
+
+      // Persist the existing detector's positive result even when the monitor's
+      // existing presentation cooldown is active. The latch stores no metadata
+      // and owns no recovery decision.
+      if (ctxCheck.matched) {
+        this.deps.sessionRecovery.markContextWedgedSeen?.(topicId);
+      }
 
       if (!inCtxCooldown) {
-        const ctxCheck = detectContextExhaustion(currentOutput);
-        if (ctxCheck.matched) {
-          console.log(`[SessionMonitor] Context exhaustion detected in topic ${topicId} (pattern: ${ctxCheck.pattern})`);
+        if (ctxCheck.matched || this.deps.sessionRecovery.hasContextWedgedSeen?.(topicId)) {
+          if (ctxCheck.matched) {
+            console.log(`[SessionMonitor] Context exhaustion detected in topic ${topicId} (pattern: ${ctxCheck.pattern})`);
+          } else {
+            console.log(`[SessionMonitor] Previously seen context exhaustion remains latched for topic ${topicId}`);
+          }
           this.contextExhaustionCooldowns.set(topicId, now);
           let recoveryResult: RecoveryResult | null = null;
           try {

--- a/src/monitoring/SessionRecovery.ts
+++ b/src/monitoring/SessionRecovery.ts
@@ -191,6 +191,9 @@ export class SessionRecovery extends EventEmitter {
   private config: SessionRecoveryConfig;
   private deps: SessionRecoveryDeps;
   private recoveryAttempts: Map<string, RecoveryAttempt> = new Map();
+  /** Durable memory that the existing context detector matched for a topic.
+   *  True-or-absent only: all recovery judgment remains in this class. */
+  private contextWedgedSeen = new Set<number>();
   private stateFilePath: string;
 
   constructor(config: Partial<SessionRecoveryConfig>, deps: SessionRecoveryDeps) {
@@ -266,13 +269,19 @@ export class SessionRecovery extends EventEmitter {
     // it just can't accept any more input without hitting the same error.
     if (processAlive && this.deps.captureSessionOutput) {
       const tmuxOutput = this.deps.captureSessionOutput(sessionName, 50);
+      let matchedPattern: string | null = null;
       if (tmuxOutput) {
         const contextCheck = detectContextExhaustion(tmuxOutput);
         if (contextCheck.matched) {
-          const result = await this.recoverFromContextExhaustion(topicId, sessionName, contextCheck.pattern || 'unknown');
-          this.logEvent(result, topicId, sessionName);
-          return result;
+          this.markContextWedgedSeen(topicId);
+          matchedPattern = contextCheck.pattern;
         }
+      }
+      if (matchedPattern || this.hasContextWedgedSeen(topicId)) {
+        const result = await this.recoverFromContextExhaustion(topicId, sessionName, matchedPattern);
+        if (result.recovered) this.clearContextWedgedSeen(topicId);
+        this.logEvent(result, topicId, sessionName);
+        return result;
       }
     }
 
@@ -311,6 +320,24 @@ export class SessionRecovery extends EventEmitter {
     }
 
     return { recovered: false, failureType: null, message: 'No mechanical failure detected' };
+  }
+
+  /** Remember only that the unchanged detector has already matched this topic. */
+  markContextWedgedSeen(topicId: number): void {
+    if (this.contextWedgedSeen.has(topicId)) return;
+    this.contextWedgedSeen.add(topicId);
+    this.saveState();
+  }
+
+  /** Mechanical read seam for SessionMonitor; this makes no recovery decision. */
+  hasContextWedgedSeen(topicId: number): boolean {
+    return this.contextWedgedSeen.has(topicId);
+  }
+
+  /** Explicit manual-intervention seam; successful recovery uses this same clear. */
+  clearContextWedgedSeen(topicId: number): void {
+    if (!this.contextWedgedSeen.delete(topicId)) return;
+    this.saveState();
   }
 
   /**
@@ -533,7 +560,7 @@ export class SessionRecovery extends EventEmitter {
   private async recoverFromContextExhaustion(
     topicId: number,
     sessionName: string,
-    matchedPattern: string,
+    matchedPattern: string | null,
   ): Promise<RecoveryResult> {
     const key = `context:${sessionName}`;
 
@@ -567,7 +594,7 @@ export class SessionRecovery extends EventEmitter {
             recovered: true,
             failureType: 'context_exhaustion',
             attemptNumber,
-            message: `Recovered via /compact — conversation preserved (pattern: "${matchedPattern}", attempt ${attemptNumber})`,
+            message: `Recovered via /compact — conversation preserved${matchedPattern ? ` (pattern: "${matchedPattern}", attempt ${attemptNumber})` : ` (attempt ${attemptNumber})`}`,
           };
         }
         // compaction.cleared === false → fall through to the destructive respawn.
@@ -888,6 +915,12 @@ export class SessionRecovery extends EventEmitter {
             }
           }
         }
+        if (data.wedgedSeen && typeof data.wedgedSeen === 'object') {
+          for (const [topic, seen] of Object.entries(data.wedgedSeen)) {
+            const topicId = Number(topic);
+            if (seen === true && Number.isInteger(topicId)) this.contextWedgedSeen.add(topicId);
+          }
+        }
       }
     } catch { // @silent-fallback-ok — corrupt state file means fresh start, which is safe
       // Can't load — start fresh (safe default)
@@ -913,7 +946,9 @@ export class SessionRecovery extends EventEmitter {
         }
       }
 
-      fs.writeFileSync(this.stateFilePath, JSON.stringify({ attempts: data }, null, 2));
+      const wedgedSeen: Record<string, true> = {};
+      for (const topicId of this.contextWedgedSeen) wedgedSeen[String(topicId)] = true;
+      fs.writeFileSync(this.stateFilePath, JSON.stringify({ attempts: data, wedgedSeen }, null, 2));
     } catch { // @silent-fallback-ok — state persistence is best-effort; in-memory state still works
       // Can't save — in-memory state still works for this process lifetime
     }

--- a/tests/unit/SessionMonitor.test.ts
+++ b/tests/unit/SessionMonitor.test.ts
@@ -410,6 +410,29 @@ describe('SessionMonitor', () => {
       await monitor.poll(); // a NEW genuine death -> notify #2
       expect(deps.sendToTopic).toHaveBeenCalledTimes(2);
     });
+
+    it('presents a previously seen boolean to the same recovery after the banner scrolls away', async () => {
+      const mockRecovery = {
+        markContextWedgedSeen: vi.fn(),
+        hasContextWedgedSeen: vi.fn(() => true),
+        checkAndRecover: vi.fn(async () => ({
+          recovered: false, deferred: true, failureType: 'context_exhaustion' as const,
+          message: 'existing recovery deferred',
+        })),
+      };
+      deps = createMockDeps({
+        getActiveTopicSessions: vi.fn(() => new Map([[203, 'session-latched']])),
+        captureSessionOutput: vi.fn(() => ''),
+        sessionRecovery: mockRecovery as any,
+      });
+      monitor = new SessionMonitor(deps, { pollIntervalSec: 60 });
+
+      await monitor.poll();
+
+      expect(mockRecovery.markContextWedgedSeen).not.toHaveBeenCalled();
+      expect(mockRecovery.hasContextWedgedSeen).toHaveBeenCalledWith(203);
+      expect(mockRecovery.checkAndRecover).toHaveBeenCalledWith(203, 'session-latched');
+    });
   });
 
   describe('context-exhaustion notify ledger persistence (survives server restarts)', () => {

--- a/tests/unit/context-exhaustion-recovery.test.ts
+++ b/tests/unit/context-exhaustion-recovery.test.ts
@@ -376,6 +376,47 @@ describe('SessionRecovery — context exhaustion', () => {
     expect(stats.successes.contextExhaustion).toBe(1);
   });
 
+  it('persists a true-only per-topic wedge latch and reuses it after the banner scrolls away', async () => {
+    let output = 'Conversation too long. Press esc twice to go up a few messages and try again.';
+    let active = true;
+    deps = createMockDeps({
+      isSessionAlive: vi.fn(() => true),
+      captureSessionOutput: vi.fn(() => output),
+      hasActiveProcesses: vi.fn(() => active),
+    });
+    recovery = new SessionRecovery({ enabled: true, projectDir: tmpDir, cooldownMs: 0 }, deps);
+
+    const deferred = await recovery.checkAndRecover(42, 'stuck-session');
+    expect(deferred.deferred).toBe(true);
+    expect(recovery.hasContextWedgedSeen(42)).toBe(true);
+    const latchedState = JSON.parse(fs.readFileSync(path.join(tmpDir, '.instar', 'recovery-state.json'), 'utf-8'));
+    expect(latchedState.wedgedSeen).toEqual({ '42': true });
+    expect(latchedState.attempts['context:stuck-session']).toMatchObject({ count: 1 });
+
+    output = 'ordinary prompt output; original banner has scrolled away';
+    active = false;
+    recovery = new SessionRecovery({ enabled: true, projectDir: tmpDir, cooldownMs: 0 }, deps);
+    expect(recovery.hasContextWedgedSeen(42)).toBe(true);
+
+    const recovered = await runWithTimers(() => recovery.checkAndRecover(42, 'stuck-session'));
+    expect(recovered.recovered).toBe(true);
+    expect(recovered.failureType).toBe('context_exhaustion');
+    expect(recovery.hasContextWedgedSeen(42)).toBe(false);
+    const clearedState = JSON.parse(fs.readFileSync(path.join(tmpDir, '.instar', 'recovery-state.json'), 'utf-8'));
+    expect(clearedState.wedgedSeen).toEqual({});
+    expect(clearedState.attempts['context:stuck-session']).toMatchObject({ count: 2 });
+  });
+
+  it('supports explicit manual clearing without a clock or inferred pane validation', () => {
+    deps = createMockDeps();
+    recovery = new SessionRecovery({ enabled: true, projectDir: tmpDir }, deps);
+
+    recovery.markContextWedgedSeen(7);
+    expect(recovery.hasContextWedgedSeen(7)).toBe(true);
+    recovery.clearContextWedgedSeen(7);
+    expect(recovery.hasContextWedgedSeen(7)).toBe(false);
+  });
+
   // ==========================================================================
   // In-flight reply capture — prevents the fresh session from duplicating
   // a reply that the dying session had already sent but hadn't yet committed

--- a/upgrades/next/context-wedge-seen-latch.md
+++ b/upgrades/next/context-wedge-seen-latch.md
@@ -1,0 +1,22 @@
+# Context-wedge seen latch
+
+## What Changed
+
+SessionRecovery now persists a true-or-absent `wedgedSeen` flag per topic after the existing context-exhaustion detector matches. If the banner later scrolls outside the monitor's capture tail, ordinary monitor polls continue presenting the remembered observation to the same recovery engine. Successful recovery or explicit manual intervention clears it.
+
+No detector pattern, timer, TTL, session mapping, retry policy, active-work guard, attempt cap, compaction step, respawn step, or recovery authority changed.
+
+## Evidence
+
+- Focused SessionMonitor and context-exhaustion recovery suites cover 71 assertions.
+- Persistence tests prove true-only state survives reconstruction, preserves attempt rows, clears on existing recovery success, and supports explicit manual clear.
+- TypeScript build passes.
+
+## What to Tell Your User
+
+Instar is less likely to forget a context-limit failure merely because its banner scrolled out of the visible terminal tail. Existing recovery safety rules remain unchanged.
+
+## Summary of New Capabilities
+
+- Durable memory of an already-detected context wedge, scoped per topic.
+- Automatic clearing on genuine recovery and an explicit manual-clear seam.

--- a/upgrades/side-effects/context-wedge-seen-latch.md
+++ b/upgrades/side-effects/context-wedge-seen-latch.md
@@ -1,0 +1,88 @@
+# Side-Effects Review — Context-wedge seen latch
+
+**Version / slug:** `context-wedge-seen-latch`  
+**Date:** `2026-07-21`  
+**Author:** `instar-codey`  
+**Second-pass reviewer:** `independent Codex agent /root/living_doc_canonicalization`
+
+## Summary of the change
+
+`SessionMonitor` records the existing detector's positive context-exhaustion result through a true-only per-topic latch owned and persisted by `SessionRecovery`. `SessionRecovery` may reuse that remembered observation after the banner scrolls away, while retaining its existing ownership, active-work, cooldown, attempt, compact, and respawn authority. Tests cover monitor presentation, persistence, reload, attempt-row preservation, success clear, and manual clear.
+
+## Decision-point inventory
+
+- `detectContextExhaustion` result — pass-through — unchanged detector is the only setter signal.
+- `SessionMonitor` context presentation — modify — current detector match or remembered true signal enters the same existing call, still behind the existing monitor cooldown.
+- `SessionRecovery` context branch — modify — consumes the remembered signal but retains every existing recovery guard and action decision.
+- latch clear — add invariant — only existing `recovered:true` or explicit manual clear.
+
+## 1. Over-block
+
+No new block/allow surface. A deliberately recycled numeric topic id could inherit a stale true value unless the operator uses the explicit manual clear first; the final scope ruling rejects inferred mapping validation, and current topic ids are stable external conversation identities.
+
+## 2. Under-block
+
+The change remembers only context wedges already recognized by the existing patterns. It does not recognize new banner text, silent provider/network waits, or other terminal shapes. A persistence write failure degrades to in-memory behavior for that process, matching the existing recovery-state failure posture.
+
+## 3. Level-of-abstraction fit
+
+The latch is signal memory at the observer/action seam. It does not create a parallel detector or recovery controller. Persistence belongs to `SessionRecovery`, the existing single owner of recovery-state writes; the monitor receives only mechanical mark/read methods.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The unchanged regex detector sets only a boolean. The existing deterministic SessionRecovery policy remains the only action authority and applies ownership, work, cooldown, attempt, compact-verification, and respawn rules.
+
+## 4b. Judgment-point check
+
+No new static heuristic at a competing-signals decision point. True-or-absent persistence is an invariant materialization of a detector result. Competing work/recovery signals remain with the existing SessionRecovery authority.
+
+## 5. Interactions
+
+- **Shadowing:** a current detector match remains preferred; the latch matters only when the current capture is negative.
+- **Double-fire:** one monitor branch calls the one recovery instance at most once per existing monitor cooldown.
+- **Races:** `SessionMonitor.poll()` is already serialized; latch mutations and whole-state writes occur synchronously through the one SessionRecovery instance.
+- **Feedback loops:** failed/deferred recovery retains the boolean but creates no timer. Existing cooldown and attempt exhaustion bound later action.
+
+## 6. External surfaces
+
+The only durable surface is a `wedgedSeen` true-only object in `.instar/recovery-state.json`. No raw pane text, pattern, timestamp, confidence, or session metadata is stored. Users may observe recovery continuing after the original banner scrolls away. No new notification or external-service call is added. The manual-clear method is an internal recovery seam, not a new operator UI or API.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+Machine-local by design (`hardware-bound-resource`): the signal describes a tmux pane and SessionRecovery instance local to the machine owning that session. It emits no new user-facing notice, generates no URL, and creates no pool-wide authority. Topic transfer needs the existing recovery/ownership lifecycle or explicit manual clear; this increment intentionally adds no mapping policy.
+
+## 8. Rollback cost
+
+Revert the code and ship a patch. Old versions ignore the additive `wedgedSeen` field in the recovery-state JSON. No migration is required; the field can remain harmlessly or be manually removed.
+
+## Conclusion
+
+The change is intentionally narrower than the withdrawn expiring typed-latch design. The side-effect review confirms that it adds only durable detector memory, while all action authority and brakes remain in SessionRecovery. The required independent second pass concurred.
+
+## Second-pass review (if required)
+
+**Reviewer:** independent Codex agent `/root/living_doc_canonicalization`  
+**Independent read of the artifact:** concur
+
+Concur with the review. The unchanged detector is the sole setter; persistence is true-or-absent with no metadata; SessionRecovery retains ownership, work, cooldown, attempt, compact, and respawn authority; monitor reuse stays behind the existing cooldown; and clear occurs only on `recovered:true` or the explicit manual seam. No new timer, pattern, mapping, retry owner, engine, or external side effect was introduced.
+
+## Evidence pointers
+
+- `tests/unit/context-exhaustion-recovery.test.ts`
+- `tests/unit/SessionMonitor.test.ts`
+- `docs/specs/reports/context-wedge-detection-completeness-convergence.md`
+
+## Class-Closure Declaration (display-only mirror)
+
+This modifies an existing self-triggered recovery path but adds no new control-loop edge or side effect. `defectClass: unbounded-self-action`; `closure: guard`; `guardEvidence: { enforcementType: ratchet, citation: tests/unit/context-exhaustion-recovery.test.ts, howCaught: the persistence/reload test forces the detector-positive banner to disappear, then proves the same bounded SessionRecovery path still receives the true-only signal while the existing cooldown and maximum-attempt brake remain authoritative }`. The unchanged steady-state brakes are SessionMonitor's poll/cooldown and SessionRecovery's per-session cooldown plus max-attempt cap; `tests/unit/self-action-convergence.test.ts` remains the standing controller ratchet.


### PR DESCRIPTION
## ELI16 — Remember one fact after the banner scrolls away

Instar already recognizes the real context-limit banner and already has one bounded recovery engine. This change remembers only a per-topic true-or-absent wedged-seen fact after the unchanged detector matches, so scrolling the banner outside the capture tail does not erase that observation.

The boolean carries no pattern, timer, TTL, mapping, confidence, retry state, or pane content. The existing SessionRecovery engine retains ownership, active-work, cooldown, attempt, compact, and respawn authority. It clears only on the existing recovered:true signal or explicit manual intervention.

## Evidence

- 71 focused SessionMonitor/context recovery assertions pass.
- 155 assertions pass including the self-action convergence ratchet.
- Real push configuration passes.
- TypeScript build and repository lint pass.
- Independent second-pass review concurs.

## Scope

No new detector pattern, validation layer, mapping logic, timer, retry owner, recovery engine, notification, or external service call.