### PR TITLE
feat: add considered Slack acknowledgments

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-21T10-10-14-565Z-slack-considered-acknowledgment-v1.json
+++ b/.instar/instar-dev-decisions/2026-07-21T10-10-14-565Z-slack-considered-acknowledgment-v1.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T10:10:14.565Z",
+  "slug": "slack-considered-acknowledgment-v1",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 149,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-21T10-11-17-968Z-slack-considered-acknowledgment-v1.json
+++ b/.instar/instar-dev-decisions/2026-07-21T10-11-17-968Z-slack-considered-acknowledgment-v1.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T10:11:17.968Z",
+  "slug": "slack-considered-acknowledgment-v1",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 149,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/reports/slack-considered-acknowledgment-v1-convergence.md
+++ b/docs/specs/reports/slack-considered-acknowledgment-v1-convergence.md
@@ -1,0 +1,28 @@
+# Slack considered acknowledgment v1 — convergence report
+
+## Cross-model review: codex-cli:gpt-5.5 and gemini-cli:gemini-3.1-pro-preview
+
+Both independent model families reviewed the final reviewable body. Gemini's final verdict was CLEAN. Codex reported only minor tradeoff questions already answered explicitly by the spec: the shared proactive cap prevents reaction spam, `eyes` has a fixed documented non-commitment meaning, calibration and action-specific observability are named v2 work, and deterministic acknowledgment rules were rejected because conversational appropriateness is contextual.
+
+The live Standards-Conformance Gate was invoked each round but was degraded because this checkout's constitution registry was unavailable to the running server (`docs/STANDARDS-REGISTRY.md` unreadable from its configured root). This advisory outage did not block convergence; the canonical principles and Signal-vs-Authority documents were reviewed directly.
+
+## What changed during convergence
+
+- Replaced the misleading binary API name with `decideAction()` and specified one exact provider object for `speak | react | silent`.
+- Made malformed fields, unknown fields, incompatible contribution fields, errors, and uncertainty deterministically silent.
+- Fixed the reaction to `eyes`, documented its non-commitment social meaning, and prohibited model-selected emoji.
+- Reused the existing proactive budget, consuming it before the one reaction attempt with no retry or refund.
+- Kept the existing gate as the sole semantic authority and the adapter as an exhaustive mechanical executor.
+- Explicitly excluded new persistence, evidence, analytics, logging, ordering, feedback, calibration, or decision points from v1.
+
+## Iteration record
+
+1. Round 1 surfaced API naming, budget timing, duplicate/already-reacted behavior, and social-meaning ambiguity. All were resolved in the spec. Gemini degraded on timeout; Codex completed.
+2. Round 2 tightened the exact schema, authority/observability boundary, deterministic-alternative rationale, configuration guidance, and v2 follow-ons. Codex and Gemini completed with minor findings; all material points were resolved.
+3. Round 3 reviewed the final body. Gemini was clean. Codex's remaining minor notes repeated deliberate, documented v1 tradeoffs and introduced no material issue.
+
+The six required internal lenses were also applied: security, scalability, adversarial behavior, integration/deployment and multi-machine posture, decision completeness/classification, and lessons/foundation audit. No material issue remained: the surface is opt-in, bounded, one-owner, one-decision, strict-parse, and fail-to-silent; it adds no state or competing authority.
+
+## Final result
+
+Converged at iteration 3. No material findings remain. The approved spec is ready to build.

--- a/docs/specs/slack-considered-acknowledgment-v1.eli16.md
+++ b/docs/specs/slack-considered-acknowledgment-v1.eli16.md
@@ -1,0 +1,23 @@
+## ELI16 — Slack considered acknowledgment v1
+
+### What already exists
+
+In an explicitly opted-in Slack channel, Instar can notice a message that was not addressed to it and make one cautious judgment: should it contribute something useful, or remain silent? A single language-model gate makes that judgment. The default is silence, and any uncertainty, model failure, malformed answer, missing provider, exhausted rate limit, or low confidence also means silence. Ordinary channels remain mention-only.
+
+### What v1 changes
+
+This change gives that same gate one additional option. Instead of choosing only “write a reply” or “do nothing,” it chooses exactly one of three actions: speak, add a small acknowledgment reaction, or stay silent. It does not add another model call or a second classifier. The Slack adapter simply carries out the one result.
+
+The reaction is deliberately fixed to the Slack `eyes` reaction. The model cannot invent an emoji, label the message, or call an arbitrary Slack operation. If it chooses the reaction with enough confidence, Instar reacts to the original message and does not start a conversational turn. If it chooses to speak, the existing full-response path runs. If it chooses silence—or anything goes wrong—nothing is sent.
+
+### Why this is narrow
+
+A reaction is a useful middle ground when a full reply would interrupt people but total silence would feel inattentive. The design remains conservative: the channel must already be opted in, the existing rate budget must be available, and the existing confidence floor still applies. Speaking also continues to require a concrete contribution.
+
+The first version does not learn from reactions, collect social feedback, add action-specific dashboards, persist decisions, compare models, choose among emoji, or calibrate behavior. Those are explicitly separate v2 topics. This release only widens one existing closed decision and connects the new result to Slack’s already-available reaction function.
+
+### Safety and rollback
+
+There is still one semantic authority and one decision per eligible message. The adapter does not independently inspect the message or overrule the gate. Unknown or broken outputs become silence. A failed reaction cannot turn into a reply. Directed messages, commands, unauthorized senders, and channels that did not opt in behave as before.
+
+Rollback is a normal code revert. No database, ledger, migration, or user state is introduced, so returning to the old speak-or-silent behavior needs no cleanup.

--- a/docs/specs/slack-considered-acknowledgment-v1.md
+++ b/docs/specs/slack-considered-acknowledgment-v1.md
@@ -1,0 +1,118 @@
+---
+title: "Slack considered acknowledgment v1"
+slug: "slack-considered-acknowledgment-v1"
+author: "instar-codey"
+parent-principle: "Signal vs. Authority"
+status: converging
+approved: true
+approved-by: "operator blanket pre-approval relayed 2026-07-21"
+supervision: pre-approved-build-and-merge
+lessons-engaged: [P1, P2, P3, P4, P5, P19, P20]
+review-convergence: "2026-07-21T09:51:04.812Z"
+review-iterations: 3
+review-completed-at: "2026-07-21T09:51:04.812Z"
+review-report: "docs/specs/reports/slack-considered-acknowledgment-v1-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 8
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Slack considered acknowledgment v1
+
+The `lessons-engaged` identifiers refer to the canonical principles index in [Instar Design Principles and Lessons](../INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md): build before narrating, define completion, act on observable state, preserve user intent, use infrastructure, bound loops, and keep signals separate from authority.
+
+## Problem statement
+
+Slack considered/ambient mode currently makes one conservative LLM-backed choice for each eligible undirected message: speak or stay silent. Sometimes a full message is intrusive while a lightweight acknowledgment is appropriate. V1 adds that middle outcome without adding another classifier, another decision point, durable state, feedback machinery, or a second outbound authority.
+
+## Scope and proposed design
+
+The live `AmbientContributionGate` remains the only authority for eligible undirected Slack messages. Its one existing provider call returns exactly one closed action: `speak`, `react`, or `silent`. The parser rejects missing, multiple, unknown, or malformed actions. Provider absence, timeout, error, invalid output, low confidence, missing required speak contribution, channel opt-out, and rate-limit exhaustion all deterministically produce `silent`.
+
+The existing conservative prompt and confidence floor remain intact in purpose and posture. The schema changes from a binary `speak` field to one `action` field. `speak` still requires the model to name a concrete contribution and clear the existing confidence floor. `react` must also clear that same floor, but does not require prose because it produces no reply. V1 uses the fixed Slack reaction name `eyes`; the model cannot select an emoji or attach a label. `silent` produces no Slack API call.
+
+The accepted provider object is exact:
+
+| Field | Contract |
+|---|---|
+| `action` | Required string enum: `speak`, `react`, or `silent`. |
+| `confidence` | Required finite JSON number in the closed range `[0,1]`; strings, missing values, `NaN`, and out-of-range values invalidate the result. |
+| `contribution` | Required non-empty string of at most 500 characters only for `speak`; it must be absent for `react` and `silent`. |
+
+Unknown fields, a legacy `speak` field, incompatible field combinations, multiple JSON objects, or non-object roots invalidate the complete result and therefore produce `silent`.
+
+`SlackAdapter._handleMessage` calls `decideAction()` once for an eligible message and branches once. The binary `shouldSpeak()` name is retired so the API cannot conceal its broadened result:
+
+- `speak`: preserve the current path—consume the existing proactive budget and process the message downstream.
+- `react`: consume the existing budget, call the existing `addReaction(channelId, ts, 'eyes')` once, retain the inbound message in the existing bounded channel-history ring, and return without dispatching a conversational turn. The budget is consumed before the fire-and-forget API attempt and is never refunded or retried on Slack failure. Issuing that single attempt completes the `react` branch regardless of Slack's outcome; there is no second action.
+- `silent`: retain the inbound message in the same bounded ring and return without an outbound action.
+
+Directed messages, DMs, commands, unauthorized senders, non-opted channels, and all other Slack paths remain unchanged. Existing inbound event deduplication continues to run before this seam; reconnect redelivery cannot intentionally create a second ambient decision. The existing rate-limit check precedes the LLM call. Accepted `react` consumes the same existing proactive-action budget as `speak`, preventing a reaction-spam bypass without introducing a new counter. The implementation renames the internal `recordSpoke` primitive to reflect this broadened use, but it must not add storage or another limiter. Slack's already-reacted response is benign because `addReaction` already contains all API failures without alert, retry, or fallback-to-speak. An occasional transient failure can therefore consume budget without a visible reaction; v1 deliberately prefers that conservative lost-budget outcome over refund/retry state that could bypass the cap or duplicate an action.
+
+## Decision points touched
+
+| Decision point | Classification | Change |
+|---|---|---|
+| `AmbientContributionGate` action for one eligible undirected Slack message | `judgment-candidate` | The existing context-rich LLM arbiter gains one closed action. Deterministic floor: only an explicitly opted channel with remaining budget, parseable closed output, and confidence at or above the existing threshold can produce an action; every other path ends at `silent`. Bounded action space: `speak | react | silent`. Fallback ladder: provider result → strict parser → deterministic `silent`. |
+| Slack execution of the returned action | `invariant` | Mechanical exhaustive switch over the already-authoritative result: `speak` processes, `react` invokes the existing fixed reaction primitive, `silent` returns. Unknown values are impossible by type and still default to silence at the boundary. |
+
+## Single-decision invariant
+
+There is exactly one semantic judgment and one result per eligible message. The adapter does not independently reinterpret message content, choose between actions, or call another model.
+
+## Signal vs authority
+
+This directly modifies an information-flow decision point. It complies with [Signal vs. Authority](../signal-vs-authority.md): the existing `AmbientContributionGate` remains the single context-rich authority; no regex, keyword list, threshold-only detector, or adapter branch gains semantic authority. Confidence is a required field of that authority's closed contract, and the existing threshold is its conservative execution floor; it does not semantically reclassify one action as another. The Slack adapter only executes the returned closed action. The existing `onDecision` hook continues to receive the canonical decision, and the existing bounded in-memory stats remain available; v1 adds no new logger, durable record, evidence, or action-specific product analytics.
+
+## Security and failure semantics
+
+The message remains untrusted delimited prompt data and keeps the existing 2,000-character bound. Model output is strict closed data, never instructions: only `action`, `confidence`, and `contribution` are accepted, and an unknown or legacy `speak` field invalidates the whole result. The fixed reaction prevents prompt-directed emoji selection, covert labels, or arbitrary Slack method calls. `react` can invoke only `reactions.add` for the original channel and timestamp already authenticated by the Slack receive path. The existing authorization and directedness checks continue to run before ambient eligibility. In v1, `eyes` means only “seen and considered,” never ownership, commitment, approval, or a future response obligation; the fixed meaning is included in the gate prompt. Recipient interpretation cannot be mechanically guaranteed, so ambient opt-in for a channel also accepts this convention; an organization where `eyes` implies ownership should leave that channel out of `enabledChannelIds`.
+
+## Alternatives considered
+
+A deterministic keyword heuristic was rejected because the appropriateness of acknowledgment depends on conversational context, relationship, topic, and whether humans are already handling the exchange; fixed words cannot enumerate that judgment without brittle semantic authority. A user-authored channel policy remains the opt-in floor but cannot safely choose the per-message action. A second reaction classifier was rejected because it would create two decisions for one message. A delayed queue or reaction-after-processing design was rejected because it adds state, ordering, and another lifecycle when v1 only needs an immediate closed choice. Model-selected emoji was rejected because it creates labeling and social-feedback semantics. Extending the existing single LLM enum is the smallest design that preserves context-rich authority and deterministic failure-to-silence.
+
+All uncertainty and failures resolve to `silent`. A reaction API failure is already contained by the existing fire-and-forget `addReaction` primitive and cannot fall through into speaking or retry through another path.
+
+## Bounds and acceptance criteria
+
+- Exactly one `AmbientContributionGate.decideAction()` call per eligible message.
+- Exactly one canonical action returned: `speak`, `react`, or `silent`.
+- Exactly one execution branch; `react` never dispatches `onMessage`, and `speak` never calls `addReaction` through this branch.
+- `react` uses exactly the fixed `eyes` reaction and the original message timestamp.
+- Missing provider, throw, timeout, invalid JSON, unknown/multiple/missing action, low confidence, missing speak contribution, channel opt-out, or exhausted budget returns `silent`.
+- Accepted `speak` and `react` consume the existing shared proactive-action budget; `silent` does not.
+- Directed messages and unauthorized senders do not consult this gate.
+- No new persistence, evidence model, API route, dashboard, config field, model call, queue, scheduler, or feedback loop.
+- Tests cover parser closure, all three actions, exact single-call behavior, reaction execution, no reply on reaction, no reaction on speak/silent, fixed emoji, budget exhaustion, and failure-to-silence.
+
+## V2 follow-ons
+
+The following are named future design topics and are not implemented or stubbed in v1: action-specific analytics or logging, ordering or preference learning, expanded stats, social-feedback ingestion, organization-configurable reaction whitelists and explicit social-meaning guidance, reaction-label semantics, model-vs-deterministic comparison, learned emoji choice, persistence, outcome evidence, lost-reaction measurement/refund/retry, or calibration. <!-- tracked: WS3-V2-CONSIDERED-ACK -->
+
+V1 does not claim those contracts and does not introduce placeholder fields for them. The existing binary ambient stats surface is not expanded into action analytics; a `react` is correctly a non-speak outcome for that legacy read. Any action-specific measurement requires its own reviewed v2 contract.
+
+## Multi-machine posture
+
+**Unified behavior through existing ownership.** This change adds no state. Slack inbound ownership and routing already ensure only the owning machine executes `_handleMessage` for a message, so the one decision and action occur on that owner. The existing ambient rate window remains machine-local legacy state and is not changed by v1; topic ownership prevents concurrent duplicate execution. No notices, durable records, or URLs are added.
+
+## Rollback
+
+Revert the schema/parser and adapter branch in a patch. There is no data migration or state repair. During rollback propagation, the only visible difference is that eligible messages return to binary speak-or-silent behavior.
+
+## Frontloaded Decisions
+
+1. The only actions are `speak`, `react`, and `silent`.
+2. `eyes` is the sole v1 reaction; the model cannot choose it.
+3. `react` uses the same confidence floor and proactive budget as `speak`.
+4. Every uncertain or degraded path is `silent`.
+5. One existing LLM call remains the sole semantic authority.
+6. No action-specific analytics, persistence, evidence, feedback, or calibration ships in v1.
+7. Budget is consumed before a reaction attempt and is not refunded; duplicate/already-reacted Slack errors remain benign under the existing primitive.
+8. Ambient channel configuration documentation states that v1 may add `eyes` as a non-commitment “seen and considered” acknowledgment and that channels where this implies ownership should not opt in.
+
+## Open questions
+
+*(none)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.3.894",
+  "version": "1.3.895",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.3.894",
+      "version": "1.3.895",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.3.894",
+  "version": "1.3.895",
   "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/messaging/slack/SlackAdapter.ts
+++ b/src/messaging/slack/SlackAdapter.ts
@@ -1125,24 +1125,24 @@ export class SlackAdapter implements MessagingAdapter {
 
     if (this.respondMode === 'mention-only' && !isDM && !this._isBotMentioned(text)) {
       // ── Ambient "should I speak?" gate (considered/ambient mode, §5.2) ──────────
-      // This is the ONLY change to undirected handling. The gate can ONLY make the
-      // agent quieter: it runs solely when (1) a gate is attached AND (2) this exact
-      // channel is explicitly opted into proactive contribution. For every other
-      // channel — and whenever no gate is attached at all — behavior is byte-for-byte
-      // the mention-only drop below. FAIL-TO-SILENCE: any failure inside the gate
-      // returns speak=false, so we fall through to the same drop. A speak=true here
-      // means the undirected message is processed exactly like a directed one
-      // (the code below this block is unchanged); directed messages never reach here.
+      // This opt-in gate returns exactly one closed action: speak processes the
+      // message downstream, react makes one fixed eyes-reaction attempt and returns,
+      // and silent only retains bounded history. Every failure/unknown result fails
+      // to silent. With no gate or no channel opt-in, behavior remains the ordinary
+      // mention-only drop; directed messages never reach this branch.
       let ambientSpeak = false;
       if (this.ambientGate && this.ambientGate.isChannelEnabled(channelId)) {
         try {
-          const decision = await this.ambientGate.shouldSpeak({ channelId, text, channelName: undefined });
-          ambientSpeak = decision.speak === true;
-          if (ambientSpeak) {
-            // Consume one unit of the per-channel rolling-window budget only now that
-            // we've committed to processing this proactive turn.
-            this.ambientGate.recordSpoke(channelId);
+          const decision = await this.ambientGate.decideAction({ channelId, text, channelName: undefined });
+          ambientSpeak = decision.action === 'speak';
+          if (decision.action === 'speak') {
+            this.ambientGate.recordAction(channelId);
             console.log(`[slack] ambient gate cleared for ${channelId}: ${decision.reason}${decision.detail ? ` — ${decision.detail}` : ''}`);
+          } else if (decision.action === 'react') {
+            // Consume budget before the one fire-and-forget attempt. The existing
+            // primitive contains failures; there is no retry, refund, or fallback.
+            this.ambientGate.recordAction(channelId);
+            this.addReaction(channelId, ts, 'eyes');
           }
         } catch {
           // Fail-to-silence: any unexpected throw at the call site stays silent too.

--- a/src/messaging/slack/types.ts
+++ b/src/messaging/slack/types.ts
@@ -129,17 +129,20 @@ export interface SlackConfig {
    * Conservative ambient "should I speak?" gate (Slack considered/ambient mode,
    * §5.2). DARK by default — when unset OR `enabledChannelIds` is empty, NO gate is
    * attached and undirected messages are dropped exactly as today (mention-only).
-   * The gate runs ONLY for an explicitly-opted-in channel and can only ever make the
-   * agent quieter (fail-to-silence). See docs/specs/SLACK-ORG-INTEGRATION-SPEC.md §5.2.
+   * The gate runs ONLY for an explicitly-opted-in channel and fails to silence.
+   * It may add the fixed `eyes` reaction, meaning only “seen and considered” — never
+   * ownership, approval, or a promise of follow-up. Do not opt in a channel where
+   * that reaction convention would imply commitment.
+   * See docs/specs/SLACK-ORG-INTEGRATION-SPEC.md §5.2.
    */
   ambientContribution?: {
     /** Channel IDs (C…) explicitly opted into proactive contribution. Default: none. */
     enabledChannelIds?: string[];
-    /** Hard cap on unsolicited messages per channel per window. Conservative default: 1. */
+    /** Hard shared cap on unsolicited messages/reactions per channel per window. Default: 1. */
     maxProactivePerChannel?: number;
     /** Rolling rate-limit window in ms. Default: 1800000 (30 min). */
     windowMs?: number;
-    /** Conservative confidence floor (0-1) for an LLM "speak" verdict. Default: 0.85. */
+    /** Conservative confidence floor (0-1) for an LLM speak/react verdict. Default: 0.85. */
     minConfidence?: number;
   };
   /**

--- a/src/permissions/AmbientContributionGate.ts
+++ b/src/permissions/AmbientContributionGate.ts
@@ -49,6 +49,8 @@ import type { IntelligenceProvider } from '../core/types.js';
 
 /** The gate's decision for a single undirected message. */
 export interface AmbientDecision {
+  /** The one canonical action selected for this message. */
+  action: AmbientAction;
   /** True ONLY when every fail-to-silence condition holds. Default false. */
   speak: boolean;
   /** Machine-readable reason for the decision (for logging / FP measurement). */
@@ -56,6 +58,8 @@ export interface AmbientDecision {
   /** Optional human-readable detail (e.g. the LLM's named contribution). */
   detail?: string;
 }
+
+export type AmbientAction = 'speak' | 'react' | 'silent';
 
 /**
  * Observability — a bounded, in-memory record of a SINGLE silence the gate is
@@ -90,7 +94,7 @@ export interface AmbientSilenceSample {
  */
 export interface AmbientChannelStats {
   channelId: string;
-  /** Every shouldSpeak() call for this channel (spoke + silent). */
+  /** Every decideAction() call for this channel (spoke + non-speak). */
   evaluated: number;
   /** Decisions that returned speak=true. */
   spoke: number;
@@ -127,6 +131,7 @@ export type AmbientDecisionReason =
   | 'llm-unparseable' // (c) failed — LLM verdict could not be read → silent
   | 'llm-declined' // (c) failed — LLM said don't speak → silent
   | 'low-confidence' // (c) failed — below the conservative confidence bar → silent
+  | 'react' // ALL held — acknowledge with the fixed eyes reaction
   | 'speak'; // ALL held — a concrete, meaningful, in-budget contribution
 
 /** Per-channel ambient configuration. Default: ambient OFF. */
@@ -197,7 +202,7 @@ const DEFAULT_NEAR_MISS_DELTA = 0.1;
 const DEFAULT_NEAR_MISS_RING_CAPACITY = 50;
 
 interface RawAmbientVerdict {
-  speak?: unknown;
+  action?: unknown;
   confidence?: unknown;
   contribution?: unknown;
 }
@@ -229,13 +234,9 @@ export class AmbientContributionGate {
 
   /**
    * Rate-limit state lives HERE — a per-channel in-memory ring of the timestamps at
-   * which the gate last returned speak=true. It is recorded by recordSpoke() (called
-   * by _handleMessage only AFTER the gate cleared and the message is actually being
-   * processed), so a speak=true that the caller decides not to act on does not
-   * consume budget. In-memory is acceptable: a restart resetting the window can only
-   * make the agent quieter for a moment (it never over-speaks), which is on the safe
-   * side of the invariant. A future durable counter could replace this without
-   * changing the contract.
+   * which the gate's accepted speak/react action consumed budget. It is recorded by
+   * recordAction() immediately before the caller executes that action. In-memory is
+   * the existing legacy posture; this change adds no persistence or second limiter.
    */
   private readonly proactiveTimestamps: Map<string, number[]> = new Map();
 
@@ -265,23 +266,23 @@ export class AmbientContributionGate {
   }
 
   /**
-   * Decide whether to speak on an UNDIRECTED message in an ambient channel.
-   * FAIL-TO-SILENCE: returns { speak: false } on every degraded/uncertain path.
+   * Select one action for an UNDIRECTED message in an ambient channel.
+   * FAIL-TO-SILENCE: every degraded/uncertain path returns action: silent.
    */
-  async shouldSpeak(input: AmbientGateInput): Promise<AmbientDecision> {
+  async decideAction(input: AmbientGateInput): Promise<AmbientDecision> {
     // (a) Channel opt-in. Default OFF — an un-opted channel never speaks.
     if (!this.enabledChannels.has(input.channelId)) {
-      return this.decide(input.channelId, { speak: false, reason: 'channel-not-opted-in' });
+      return this.decide(input.channelId, { action: 'silent', speak: false, reason: 'channel-not-opted-in' });
     }
 
     // (b) Hard rate-limit. Budget exhausted in the rolling window → silent.
     if (this.isRateLimited(input.channelId)) {
-      return this.decide(input.channelId, { speak: false, reason: 'rate-limited' });
+      return this.decide(input.channelId, { action: 'silent', speak: false, reason: 'rate-limited' });
     }
 
     // (c) LLM judgment. No provider → silent (we never speak on a heuristic guess).
     if (!this.intelligence) {
-      return this.decide(input.channelId, { speak: false, reason: 'no-intelligence' });
+      return this.decide(input.channelId, { action: 'silent', speak: false, reason: 'no-intelligence' });
     }
 
     let raw: string;
@@ -303,44 +304,45 @@ export class AmbientContributionGate {
       });
     } catch {
       // network/timeout/provider failure / circuit open → SILENCE (never escalate).
-      return this.decide(input.channelId, { speak: false, reason: 'llm-error' });
+      return this.decide(input.channelId, { action: 'silent', speak: false, reason: 'llm-error' });
     }
 
     const parsed = parseAmbientVerdict(raw);
     if (!parsed) {
       // Unparseable LLM output is a judgment FAILURE → silence.
-      return this.decide(input.channelId, { speak: false, reason: 'llm-unparseable' });
+      return this.decide(input.channelId, { action: 'silent', speak: false, reason: 'llm-unparseable' });
     }
 
-    // The LLM must explicitly say speak.
-    if (!parsed.speak) {
-      return this.decide(input.channelId, { speak: false, reason: 'llm-declined' });
+    if (parsed.action === 'silent') {
+      return this.decide(input.channelId, { action: 'silent', speak: false, reason: 'llm-declined' });
     }
 
     // Conservative confidence bar. Below it (or no named contribution) → silence.
-    if (parsed.confidence < this.minConfidence || !parsed.contribution) {
+    if (parsed.confidence < this.minConfidence) {
       return this.decide(
         input.channelId,
-        { speak: false, reason: 'low-confidence', detail: parsed.contribution },
+        { action: 'silent', speak: false, reason: 'low-confidence', detail: parsed.contribution },
         parsed.confidence,
       );
+    }
+
+    if (parsed.action === 'react') {
+      return this.decide(input.channelId, { action: 'react', speak: false, reason: 'react' }, parsed.confidence);
     }
 
     // ALL fail-to-silence conditions held → speak.
     return this.decide(
       input.channelId,
-      { speak: true, reason: 'speak', detail: parsed.contribution },
+      { action: 'speak', speak: true, reason: 'speak', detail: parsed.contribution },
       parsed.confidence,
     );
   }
 
   /**
-   * Record that the agent actually spoke proactively in a channel (call AFTER the
-   * gate cleared and _handleMessage commits to processing). Consumes one unit of the
-   * rolling window budget. Idempotency is not required — each proactive turn is one
-   * unit.
+   * Consume one unit of the shared proactive speak/react rolling-window budget.
+   * Call immediately before executing the accepted action.
    */
-  recordSpoke(channelId: string): void {
+  recordAction(channelId: string): void {
     const arr = this.proactiveTimestamps.get(channelId) ?? [];
     arr.push(this.now());
     this.proactiveTimestamps.set(channelId, arr);
@@ -454,45 +456,35 @@ export class AmbientContributionGate {
 }
 
 /**
- * Validate + clamp the LLM's raw JSON into a safe verdict. Returns null when the
- * payload can't be read (→ caller fails to silence). A missing/false `speak` is a
- * VALID parse (it means don't speak), so this only returns null on structural junk.
+ * Strictly validate the LLM's raw JSON into one closed verdict. Any structural,
+ * type, range, or field-combination mismatch returns null and fails to silence.
  */
 function parseAmbientVerdict(
   raw: string,
-): { speak: boolean; confidence: number; contribution?: string } | null {
+): { action: AmbientAction; confidence: number; contribution?: string } | null {
   if (!raw || typeof raw !== 'string') return null;
-
-  const start = raw.indexOf('{');
-  const end = raw.lastIndexOf('}');
-  if (start === -1 || end === -1 || end < start) return null;
 
   let obj: RawAmbientVerdict;
   try {
-    obj = JSON.parse(raw.slice(start, end + 1)) as RawAmbientVerdict;
+    obj = JSON.parse(raw.trim()) as RawAmbientVerdict;
   } catch {
     return null;
   }
 
-  // `speak` must be present and boolean-ish; anything else is unreadable → null,
-  // so the caller fails to silence rather than guessing an affirmative.
-  let speak: boolean;
-  if (typeof obj.speak === 'boolean') speak = obj.speak;
-  else if (obj.speak === 'true') speak = true;
-  else if (obj.speak === 'false') speak = false;
-  else return null;
-
-  // Missing/invalid confidence is treated as the floor (0) — never an optimistic 1.
-  let confidence = typeof obj.confidence === 'number' ? obj.confidence : Number(obj.confidence);
-  if (!Number.isFinite(confidence)) confidence = 0;
-  confidence = Math.max(0, Math.min(1, confidence));
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+  const keys = Object.keys(obj);
+  if (keys.some(key => !['action', 'confidence', 'contribution'].includes(key))) return null;
+  if (obj.action !== 'speak' && obj.action !== 'react' && obj.action !== 'silent') return null;
+  if (typeof obj.confidence !== 'number' || !Number.isFinite(obj.confidence) || obj.confidence < 0 || obj.confidence > 1) return null;
 
   const contribution =
     typeof obj.contribution === 'string' && obj.contribution.trim()
-      ? obj.contribution.trim().slice(0, 500)
+      ? obj.contribution.trim()
       : undefined;
+  if (obj.action === 'speak' && (!contribution || contribution.length > 500)) return null;
+  if (obj.action !== 'speak' && Object.prototype.hasOwnProperty.call(obj, 'contribution')) return null;
 
-  return { speak, confidence, contribution };
+  return { action: obj.action, confidence: obj.confidence, contribution };
 }
 
 /**
@@ -508,12 +500,18 @@ function buildAmbientPrompt(input: AmbientGateInput): { systemPrompt: string; us
     'the failure mode is annoyance. Speak ONLY when you can name a concrete, specific,',
     'genuinely helpful contribution that the people in the channel would welcome —',
     'never to chime in, agree, restate, or interrupt a human-to-human exchange.',
-    'Return ONLY a compact JSON object, no prose, with exactly these keys:',
-    '  "speak":        boolean — true ONLY for a clearly worthwhile unprompted contribution.',
-    '  "confidence":   0.0-1.0 — your confidence that speaking adds clear value AND is welcome.',
+    'Return ONLY one compact JSON object, no prose. Choose exactly one action:',
+    '  "speak" — only for a clearly worthwhile unprompted contribution.',
+    '  "react" — a lightweight seen-and-considered acknowledgment is useful, but prose would intrude.',
+    '  "silent" — the strong default whenever neither action clearly helps.',
+    'Use exactly these fields:',
+    '  "action":       one of "speak", "react", or "silent".',
+    '  "confidence":   0.0-1.0 — your confidence that the chosen non-silent action adds clear value AND is welcome.',
     '                  Be honest; when unsure, return a LOW number. Uncertainty means stay silent.',
-    '  "contribution": one short sentence naming the concrete contribution (omit/empty if not speaking).',
-    'When in doubt, return {"speak": false, "confidence": 0.0}.',
+    '  "contribution": one short sentence naming the concrete contribution; include ONLY for "speak".',
+    'A "react" action always means the fixed eyes reaction: seen and considered, never ownership,',
+    'commitment, approval, or a promise of follow-up. You do not select the emoji.',
+    'When in doubt, return {"action":"silent","confidence":0.0}.',
     'Never output anything but the JSON object.',
   ].join('\n');
 

--- a/tests/unit/slack-ambient-contribution-gate.test.ts
+++ b/tests/unit/slack-ambient-contribution-gate.test.ts
@@ -26,8 +26,9 @@ function fakeProvider(
 
 const CH = 'C_AMBIENT';
 const speakJson = (conf = 0.95) =>
-  `{"speak":true,"confidence":${conf},"contribution":"This looks like the onnxruntime-node CDN flake; a gh run rerun --failed cleared it last week."}`;
-const silentJson = (conf = 0.4) => `{"speak":false,"confidence":${conf}}`;
+  `{"action":"speak","confidence":${conf},"contribution":"This looks like the onnxruntime-node CDN flake; a gh run rerun --failed cleared it last week."}`;
+const silentJson = (conf = 0.4) => `{"action":"silent","confidence":${conf}}`;
+const reactJson = (conf = 0.95) => `{"action":"react","confidence":${conf}}`;
 
 describe('AmbientContributionGate — DARK / opt-in (no config ⇒ never speaks, no LLM call)', () => {
   it('a channel that is NOT opted in stays silent and never calls the LLM', async () => {
@@ -36,7 +37,7 @@ describe('AmbientContributionGate — DARK / opt-in (no config ⇒ never speaks,
       config: { enabledChannelIds: ['C_OTHER'] },
       intelligence: fakeProvider(() => speakJson(), cap),
     });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'engineers stuck on a flaky test again' });
+    const d = await gate.decideAction({ channelId: CH, text: 'engineers stuck on a flaky test again' });
     expect(d.speak).toBe(false);
     expect(d.reason).toBe('channel-not-opted-in');
     expect(cap.calls).toBe(0); // opt-in is checked BEFORE the LLM
@@ -46,7 +47,7 @@ describe('AmbientContributionGate — DARK / opt-in (no config ⇒ never speaks,
     const gate = new AmbientContributionGate({ intelligence: fakeProvider(() => speakJson()) });
     expect(gate.isAnyChannelEnabled()).toBe(false);
     expect(gate.isChannelEnabled(CH)).toBe(false);
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'anything' });
+    const d = await gate.decideAction({ channelId: CH, text: 'anything' });
     expect(d.speak).toBe(false);
     expect(d.reason).toBe('channel-not-opted-in');
   });
@@ -65,7 +66,7 @@ describe('AmbientContributionGate — speak path (ALL fail-to-silence conditions
       config: { enabledChannelIds: [CH], minConfidence: 0.85 },
       intelligence: fakeProvider(() => speakJson(0.95)),
     });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'CI keeps failing on onnxruntime-node' });
+    const d = await gate.decideAction({ channelId: CH, text: 'CI keeps failing on onnxruntime-node' });
     expect(d.speak).toBe(true);
     expect(d.reason).toBe('speak');
     expect(d.detail).toContain('onnxruntime-node');
@@ -77,7 +78,7 @@ describe('AmbientContributionGate — speak path (ALL fail-to-silence conditions
       config: { enabledChannelIds: [CH] },
       intelligence: fakeProvider(() => speakJson(), cap),
     });
-    await gate.shouldSpeak({ channelId: CH, text: 'hello team' });
+    await gate.decideAction({ channelId: CH, text: 'hello team' });
     expect(cap.calls).toBe(1);
     expect(cap.opts?.model).toBe('fast');
     expect(cap.opts?.attribution?.component).toBe('AmbientContributionGate');
@@ -94,7 +95,7 @@ describe('AmbientContributionGate — silence on a low-value / declined verdict'
       config: { enabledChannelIds: [CH] },
       intelligence: fakeProvider(() => silentJson(0.2)),
     });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'lunch plans?' });
+    const d = await gate.decideAction({ channelId: CH, text: 'lunch plans?' });
     expect(d.speak).toBe(false);
     expect(d.reason).toBe('llm-declined');
   });
@@ -104,7 +105,7 @@ describe('AmbientContributionGate — silence on a low-value / declined verdict'
       config: { enabledChannelIds: [CH], minConfidence: 0.85 },
       intelligence: fakeProvider(() => speakJson(0.7)), // below 0.85
     });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'maybe relevant?' });
+    const d = await gate.decideAction({ channelId: CH, text: 'maybe relevant?' });
     expect(d.speak).toBe(false);
     expect(d.reason).toBe('low-confidence');
   });
@@ -112,11 +113,11 @@ describe('AmbientContributionGate — silence on a low-value / declined verdict'
   it('LLM says speak with high confidence but NO named contribution → silent', async () => {
     const gate = new AmbientContributionGate({
       config: { enabledChannelIds: [CH], minConfidence: 0.85 },
-      intelligence: fakeProvider(() => '{"speak":true,"confidence":0.99}'), // no contribution
+      intelligence: fakeProvider(() => '{"action":"speak","confidence":0.99}'), // no contribution
     });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'hmm' });
+    const d = await gate.decideAction({ channelId: CH, text: 'hmm' });
     expect(d.speak).toBe(false);
-    expect(d.reason).toBe('low-confidence');
+    expect(d.reason).toBe('llm-unparseable');
   });
 });
 
@@ -172,7 +173,7 @@ describe('AmbientContributionGate — FAIL-TO-SILENCE (no over-speak on ANY degr
   for (const path of degradedPaths) {
     it(`${path.name} → speak=false (NO over-speak)`, async () => {
       const gate = path.deps();
-      const d = await gate.shouldSpeak({ channelId: CH, text: 'should you speak here?' });
+      const d = await gate.decideAction({ channelId: CH, text: 'should you speak here?' });
       expect(d.speak).toBe(false); // the invariant
       expect(d.reason).toBe(path.expect);
     });
@@ -183,19 +184,55 @@ describe('AmbientContributionGate — FAIL-TO-SILENCE (no over-speak on ANY degr
       config: { enabledChannelIds: [CH] },
       intelligence: fakeProvider(() => '{"speak":1,"confidence":0.99,"contribution":"x"}'),
     });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    const d = await gate.decideAction({ channelId: CH, text: 'x' });
     expect(d.speak).toBe(false);
     expect(d.reason).toBe('llm-unparseable');
   });
 
-  it('missing confidence is treated as 0 (floor), never optimistic — stays silent even on speak:true', async () => {
+  it('missing confidence invalidates the closed result and stays silent', async () => {
     const gate = new AmbientContributionGate({
       config: { enabledChannelIds: [CH], minConfidence: 0.85 },
-      intelligence: fakeProvider(() => '{"speak":true,"contribution":"do the thing"}'),
+      intelligence: fakeProvider(() => '{"action":"speak","contribution":"do the thing"}'),
     });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    const d = await gate.decideAction({ channelId: CH, text: 'x' });
     expect(d.speak).toBe(false);
-    expect(d.reason).toBe('low-confidence');
+    expect(d.reason).toBe('llm-unparseable');
+  });
+
+  it.each([
+    ['legacy speak field', '{"speak":true,"confidence":0.99,"contribution":"x"}'],
+    ['unknown field', '{"action":"react","confidence":0.99,"emoji":"wave"}'],
+    ['string confidence', '{"action":"react","confidence":"0.99"}'],
+    ['out-of-range confidence', '{"action":"react","confidence":2}'],
+    ['react contribution', '{"action":"react","confidence":0.99,"contribution":"x"}'],
+    ['multiple objects', '{"action":"react","confidence":0.99}{"action":"silent","confidence":0}'],
+  ])('%s invalidates the result and fails to silence', async (_name, raw) => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH] },
+      intelligence: fakeProvider(() => raw),
+    });
+    const d = await gate.decideAction({ channelId: CH, text: 'x' });
+    expect(d.action).toBe('silent');
+    expect(d.reason).toBe('llm-unparseable');
+  });
+
+  it('high-confidence react returns the one react action without prose', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85 },
+      intelligence: fakeProvider(() => reactJson()),
+    });
+    const d = await gate.decideAction({ channelId: CH, text: 'status update' });
+    expect(d).toMatchObject({ action: 'react', speak: false, reason: 'react' });
+  });
+
+  it('low-confidence react fails to silence', async () => {
+    const gate = new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], minConfidence: 0.85 },
+      intelligence: fakeProvider(() => reactJson(0.5)),
+    });
+    expect(await gate.decideAction({ channelId: CH, text: 'status update' })).toMatchObject({
+      action: 'silent', reason: 'low-confidence',
+    });
   });
 
   it('observability throw never affects the verdict (best-effort onDecision)', async () => {
@@ -206,7 +243,7 @@ describe('AmbientContributionGate — FAIL-TO-SILENCE (no over-speak on ANY degr
         throw new Error('observability blew up');
       },
     });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'CI flake again' });
+    const d = await gate.decideAction({ channelId: CH, text: 'CI flake again' });
     expect(d.speak).toBe(true); // a thrown hook must not silence-or-amplify the verdict
   });
 });
@@ -219,12 +256,12 @@ describe('AmbientContributionGate — hard per-channel rate-limit (fail-to-silen
     });
 
     // 1st proactive turn clears and consumes the single unit of budget.
-    const first = await gate.shouldSpeak({ channelId: CH, text: 'first contribution' });
+    const first = await gate.decideAction({ channelId: CH, text: 'first contribution' });
     expect(first.speak).toBe(true);
-    gate.recordSpoke(CH); // _handleMessage records after committing to process
+    gate.recordAction(CH); // _handleMessage records after committing to process
 
     // 2nd is rate-limited even though the LLM would still say speak.
-    const second = await gate.shouldSpeak({ channelId: CH, text: 'second contribution' });
+    const second = await gate.decideAction({ channelId: CH, text: 'second contribution' });
     expect(second.speak).toBe(false);
     expect(second.reason).toBe('rate-limited');
   });
@@ -235,8 +272,8 @@ describe('AmbientContributionGate — hard per-channel rate-limit (fail-to-silen
       config: { enabledChannelIds: [CH], maxProactivePerChannel: 1, windowMs: 60_000 },
       intelligence: fakeProvider(() => speakJson(), cap),
     });
-    gate.recordSpoke(CH); // exhaust the budget directly
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'would-be contribution' });
+    gate.recordAction(CH); // exhaust the budget directly
+    const d = await gate.decideAction({ channelId: CH, text: 'would-be contribution' });
     expect(d.speak).toBe(false);
     expect(d.reason).toBe('rate-limited');
     expect(cap.calls).toBe(0);
@@ -250,13 +287,13 @@ describe('AmbientContributionGate — hard per-channel rate-limit (fail-to-silen
       now: () => t,
     });
 
-    expect((await gate.shouldSpeak({ channelId: CH, text: 'first' })).speak).toBe(true);
-    gate.recordSpoke(CH);
-    expect((await gate.shouldSpeak({ channelId: CH, text: 'second' })).reason).toBe('rate-limited');
+    expect((await gate.decideAction({ channelId: CH, text: 'first' })).speak).toBe(true);
+    gate.recordAction(CH);
+    expect((await gate.decideAction({ channelId: CH, text: 'second' })).reason).toBe('rate-limited');
 
     // Advance past the window — the old timestamp expires.
     t += 60_001;
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'after window' });
+    const d = await gate.decideAction({ channelId: CH, text: 'after window' });
     expect(d.speak).toBe(true);
     expect(d.reason).toBe('speak');
   });
@@ -266,7 +303,7 @@ describe('AmbientContributionGate — hard per-channel rate-limit (fail-to-silen
       config: { enabledChannelIds: [CH], maxProactivePerChannel: 0 },
       intelligence: fakeProvider(() => speakJson()),
     });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    const d = await gate.decideAction({ channelId: CH, text: 'x' });
     expect(d.speak).toBe(false);
     expect(d.reason).toBe('rate-limited');
     expect(gate.remainingBudget(CH)).toBe(0);
@@ -278,9 +315,9 @@ describe('AmbientContributionGate — hard per-channel rate-limit (fail-to-silen
       config: { enabledChannelIds: [CH, CH2], maxProactivePerChannel: 1, windowMs: 60_000 },
       intelligence: fakeProvider(() => speakJson()),
     });
-    gate.recordSpoke(CH); // exhaust CH only
-    expect((await gate.shouldSpeak({ channelId: CH, text: 'x' })).reason).toBe('rate-limited');
-    expect((await gate.shouldSpeak({ channelId: CH2, text: 'y' })).speak).toBe(true);
+    gate.recordAction(CH); // exhaust CH only
+    expect((await gate.decideAction({ channelId: CH, text: 'x' })).reason).toBe('rate-limited');
+    expect((await gate.decideAction({ channelId: CH2, text: 'y' })).speak).toBe(true);
   });
 });
 
@@ -289,7 +326,7 @@ describe('AmbientContributionGate — wiring integrity', () => {
     const evalSpy = vi.fn(async () => speakJson());
     const provider: IntelligenceProvider = { evaluate: evalSpy };
     const gate = new AmbientContributionGate({ config: { enabledChannelIds: [CH] }, intelligence: provider });
-    await gate.shouldSpeak({ channelId: CH, text: 'CI flake again' });
+    await gate.decideAction({ channelId: CH, text: 'CI flake again' });
     expect(evalSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -300,7 +337,7 @@ describe('AmbientContributionGate — wiring integrity', () => {
       intelligence: fakeProvider(() => silentJson()),
       onDecision: (d, ch) => seen.push({ d, ch }),
     });
-    await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    await gate.decideAction({ channelId: CH, text: 'x' });
     expect(seen).toHaveLength(1);
     expect(seen[0].ch).toBe(CH);
     expect(seen[0].d.reason).toBe('llm-declined');
@@ -318,7 +355,7 @@ describe('AmbientContributionGate — silence observability aggregate (getStats)
       config: { enabledChannelIds: [CH] },
       intelligence: fakeProvider(() => silentJson(0.2)),
     });
-    await gate.shouldSpeak({ channelId: CH, text: 'lunch?' });
+    await gate.decideAction({ channelId: CH, text: 'lunch?' });
     const stats = gate.getStats();
     const ch = stats.channels.find(c => c.channelId === CH);
     expect(ch).toBeDefined();
@@ -333,7 +370,7 @@ describe('AmbientContributionGate — silence observability aggregate (getStats)
       config: { enabledChannelIds: [CH], minConfidence: 0.85 },
       intelligence: fakeProvider(() => speakJson(0.95)),
     });
-    await gate.shouldSpeak({ channelId: CH, text: 'CI flake again' });
+    await gate.decideAction({ channelId: CH, text: 'CI flake again' });
     const ch = gate.getStats().channels.find(c => c.channelId === CH)!;
     expect(ch.evaluated).toBe(1);
     expect(ch.spoke).toBe(1);
@@ -346,7 +383,7 @@ describe('AmbientContributionGate — silence observability aggregate (getStats)
       config: { enabledChannelIds: [CH], minConfidence: 0.85, nearMissDelta: 0.1 },
       intelligence: fakeProvider(() => speakJson(0.8)),
     });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'maybe relevant' });
+    const d = await gate.decideAction({ channelId: CH, text: 'maybe relevant' });
     expect(d.speak).toBe(false);
     expect(d.reason).toBe('low-confidence');
     const stats = gate.getStats();
@@ -364,7 +401,7 @@ describe('AmbientContributionGate — silence observability aggregate (getStats)
       config: { enabledChannelIds: [CH], minConfidence: 0.85, nearMissDelta: 0.1 },
       intelligence: fakeProvider(() => speakJson(0.3)), // far below 0.75 → not a near-miss
     });
-    await gate.shouldSpeak({ channelId: CH, text: 'unrelated' });
+    await gate.decideAction({ channelId: CH, text: 'unrelated' });
     const stats = gate.getStats();
     const ch = stats.channels.find(c => c.channelId === CH)!;
     expect(ch.silent).toBe(1);
@@ -375,7 +412,7 @@ describe('AmbientContributionGate — silence observability aggregate (getStats)
   it('a confidence-less silence path (not-opted-in / no-intelligence) is never a near-miss', async () => {
     // no-intelligence path: opted-in channel but no provider.
     const gate = new AmbientContributionGate({ config: { enabledChannelIds: [CH] } });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    const d = await gate.decideAction({ channelId: CH, text: 'x' });
     expect(d.reason).toBe('no-intelligence');
     const ch = gate.getStats().channels.find(c => c.channelId === CH)!;
     expect(ch.silent).toBe(1);
@@ -390,20 +427,20 @@ describe('AmbientContributionGate — silence observability aggregate (getStats)
       config: { enabledChannelIds: [CH], minConfidence: 0.85 },
       intelligence: fakeProvider(() => speakJson(0.95)),
     });
-    expect((await speakGate.shouldSpeak({ channelId: CH, text: 'CI flake' })).speak).toBe(true);
+    expect((await speakGate.decideAction({ channelId: CH, text: 'CI flake' })).speak).toBe(true);
 
     const silentGate = new AmbientContributionGate({
       config: { enabledChannelIds: [CH], minConfidence: 0.85 },
       intelligence: fakeProvider(() => speakJson(0.7)),
     });
-    const sd = await silentGate.shouldSpeak({ channelId: CH, text: 'maybe' });
+    const sd = await silentGate.decideAction({ channelId: CH, text: 'maybe' });
     expect(sd.speak).toBe(false);
     expect(sd.reason).toBe('low-confidence');
   });
 
   it('with NO opted-in channel nothing is ever recorded (gate stays dark)', async () => {
     const gate = new AmbientContributionGate({ intelligence: fakeProvider(() => speakJson()) });
-    // The real wiring never even calls shouldSpeak when no channel is enabled, but even
+    // The real wiring never even calls decideAction when no channel is enabled, but even
     // if a stray call lands, it short-circuits at channel-not-opted-in and records that.
     expect(gate.getStats().channels).toHaveLength(0);
     expect(gate.getStats().recentNearMisses).toHaveLength(0);
@@ -416,7 +453,7 @@ describe('AmbientContributionGate — silence observability aggregate (getStats)
       intelligence: fakeProvider(() => speakJson(0.8)), // every one is a near-miss
     });
     for (let i = 0; i < 100; i++) {
-      await gate.shouldSpeak({ channelId: CH, text: `near-miss ${i}` });
+      await gate.decideAction({ channelId: CH, text: `near-miss ${i}` });
     }
     const stats = gate.getStats();
     // The counter keeps the true total; the ring is capped.
@@ -432,8 +469,8 @@ describe('AmbientContributionGate — silence observability aggregate (getStats)
       config: { enabledChannelIds: [CH, CH2], minConfidence: 0.85 },
       intelligence: fakeProvider((prompt) => (prompt.includes('speakme') ? speakJson(0.95) : silentJson(0.2))),
     });
-    await gate.shouldSpeak({ channelId: CH, text: 'speakme please' });
-    await gate.shouldSpeak({ channelId: CH2, text: 'be quiet' });
+    await gate.decideAction({ channelId: CH, text: 'speakme please' });
+    await gate.decideAction({ channelId: CH2, text: 'be quiet' });
     const stats = gate.getStats();
     expect(stats.channels.find(c => c.channelId === CH)!.spoke).toBe(1);
     expect(stats.channels.find(c => c.channelId === CH2)!.silent).toBe(1);
@@ -444,7 +481,7 @@ describe('AmbientContributionGate — silence observability aggregate (getStats)
       config: { enabledChannelIds: [CH] },
       intelligence: fakeProvider(() => silentJson(0.2)),
     });
-    await gate.shouldSpeak({ channelId: CH, text: 'x' });
+    await gate.decideAction({ channelId: CH, text: 'x' });
     const stats = gate.getStats();
     stats.channels[0].silent = 999;
     stats.channels[0].silentByReason['llm-declined'] = 999;
@@ -458,7 +495,7 @@ describe('AmbientContributionGate — silence observability aggregate (getStats)
       config: { enabledChannelIds: [CH], minConfidence: 0.85, nearMissDelta: 0.1 },
       intelligence: fakeProvider(() => speakJson(0.85)), // exactly at the floor → speaks
     });
-    const d = await gate.shouldSpeak({ channelId: CH, text: 'CI flake' });
+    const d = await gate.decideAction({ channelId: CH, text: 'CI flake' });
     expect(d.speak).toBe(true);
     const ch = gate.getStats().channels.find(c => c.channelId === CH)!;
     expect(ch.spoke).toBe(1);

--- a/tests/unit/slack-ambient-gate-wiring.test.ts
+++ b/tests/unit/slack-ambient-gate-wiring.test.ts
@@ -32,6 +32,7 @@ function fakeProvider(responder: () => string, capture?: { calls: number }): Int
 /** Build an adapter in mention-only mode with reactions/user-info stubbed out. */
 function harness(tmp: string) {
   const messages: string[] = [];
+  const reactions: Array<{ channelId: string; timestamp: string; emoji: string }> = [];
   const adapter = new SlackAdapter(
     {
       botToken: 'xoxb-test',
@@ -43,16 +44,19 @@ function harness(tmp: string) {
   );
   adapter.onMessage(async (m) => { messages.push(m.content); });
   // Stub out all outbound Slack Web API touch-points so nothing hits the network.
-  (adapter as any).addReaction = () => {};
+  (adapter as any).addReaction = (channelId: string, timestamp: string, emoji: string) => {
+    reactions.push({ channelId, timestamp, emoji });
+  };
   (adapter as any).removeReaction = () => {};
   (adapter as any).getUserInfo = async (id: string) => ({ id, name: id });
   (adapter as any).botUserId = BOT;
   const handle = (adapter as any)._handleMessage.bind(adapter);
-  return { adapter, handle, messages };
+  return { adapter, handle, messages, reactions };
 }
 
-const speakJson = '{"speak":true,"confidence":0.95,"contribution":"the onnxruntime-node CDN flake — gh run rerun --failed"}';
-const silentJson = '{"speak":false,"confidence":0.2}';
+const speakJson = '{"action":"speak","confidence":0.95,"contribution":"the onnxruntime-node CDN flake — gh run rerun --failed"}';
+const silentJson = '{"action":"silent","confidence":0.2}';
+const reactJson = '{"action":"react","confidence":0.95}';
 
 describe('SlackAdapter ambient gate wiring', () => {
   let tmp: string;
@@ -108,6 +112,23 @@ describe('SlackAdapter ambient gate wiring', () => {
     }));
     await handle({ user: 'U_TEST', text: 'lunch plans?', channel: CH, ts: '5.1' });
     expect(messages).toHaveLength(0); // gate declined → dropped
+  });
+
+  it('ambient channel + gate says REACT → one fixed eyes reaction and no conversational turn', async () => {
+    const { adapter, handle, messages, reactions } = harness(tmp);
+    const cap = { calls: 0 };
+    adapter.setAmbientGate(new AmbientContributionGate({
+      config: { enabledChannelIds: [CH], maxProactivePerChannel: 1 },
+      intelligence: fakeProvider(() => reactJson, cap),
+    }));
+    await handle({ user: 'U_TEST', text: 'deployment completed', channel: CH, ts: '5.2' });
+    expect(cap.calls).toBe(1);
+    expect(messages).toHaveLength(0);
+    expect(reactions).toEqual([{ channelId: CH, timestamp: '5.2', emoji: 'eyes' }]);
+
+    await handle({ user: 'U_TEST', text: 'another update', channel: CH, ts: '5.3' });
+    expect(cap.calls).toBe(1); // shared proactive budget exhausted before another decision call
+    expect(reactions).toHaveLength(1);
   });
 
   it('gate attached but channel NOT opted in → dropped, no LLM call', async () => {

--- a/upgrades/next/slack-considered-acknowledgment-v1.md
+++ b/upgrades/next/slack-considered-acknowledgment-v1.md
@@ -1,0 +1,20 @@
+# Slack ambient mode can acknowledge without interrupting
+
+## What Changed
+
+The existing conservative Slack ambient gate now chooses exactly one of three actions for an eligible undirected message: speak, add the fixed `eyes` reaction, or remain silent. Reactions reuse the existing proactive-action cap and never create a conversational turn. Invalid output, low confidence, provider errors, and reaction uncertainty all resolve to silence.
+
+## What to Tell Your User
+
+In a Slack channel explicitly opted into ambient contribution, the agent may use the eyes reaction to mean “seen and considered” when a written reply would be intrusive. It does not mean ownership, approval, or a future response obligation. Channels where that convention would imply commitment should remain opted out.
+
+## Summary of New Capabilities
+
+- One conservative LLM decision now returns `speak`, `react`, or `silent`.
+- `react` adds exactly one fixed `eyes` reaction and sends no reply.
+- The existing shared proactive cap bounds both speech and reactions.
+
+## Evidence
+
+- Gate and adapter unit coverage verifies the strict closed schema, all three actions, fixed emoji, one provider call, shared budget exhaustion, and fail-to-silent paths.
+- TypeScript build passes.

--- a/upgrades/side-effects/slack-considered-acknowledgment-v1.md
+++ b/upgrades/side-effects/slack-considered-acknowledgment-v1.md
@@ -1,0 +1,80 @@
+# Side-Effects Review — Slack considered acknowledgment v1
+
+**Version / slug:** `slack-considered-acknowledgment-v1`  
+**Date:** `2026-07-21`  
+**Author:** `instar-codey`  
+**Second-pass reviewer:** `instar-codey throughput-floor workstream reviewer`
+
+## Summary of the change
+
+`AmbientContributionGate` expands its one conservative semantic result from binary speak/silent to the closed action `speak | react | silent`. `SlackAdapter` mechanically executes `react` through its existing `addReaction` primitive with fixed `eyes`, buffers the inbound message, and returns without a conversational turn. Tests and Slack config documentation cover the new contract.
+
+## Decision-point inventory
+
+- `AmbientContributionGate.decideAction` — modified judgment authority — one existing context-rich provider call chooses one closed action.
+- `SlackAdapter._handleMessage` ambient branch — modified invariant executor — exhaustive mechanical execution without content reinterpretation.
+
+## 1. Over-block
+
+Strict parsing can turn otherwise understandable but nonconforming provider output into silence. This is intentional: unsolicited activity must never arise from guessed or malformed output.
+
+## 2. Under-block
+
+A confident but socially mistaken `react` can still add `eyes`. Exposure is bounded to explicitly opted channels and the existing shared cap; no deterministic parser can guarantee recipients' interpretation.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The existing context-rich LLM gate retains semantic authority. The adapter reuses the existing low-level reaction primitive and performs no semantic classification.
+
+## 4. Signal vs authority compliance
+
+- [x] Yes — the modified authority is the existing smart gate with conversational context.
+
+No brittle detector gains authority. Strict schema and confidence checks are deterministic safety floors around the one judgment result.
+
+## 4b. Judgment-point check
+
+No static heuristic is added at a competing-signals point. The spec declares the bounded action space, conservative silent floor, existing LLM arbiter, and fallback ladder.
+
+## 5. Interactions
+
+- **Shadowing:** authorization, directedness, channel opt-in, inbound deduplication, and rate exhaustion still precede the model call.
+- **Double-fire:** one returned action enters one branch; react returns before downstream message dispatch.
+- **Races:** no new state. Speak and react consume the same existing machine-local timestamp budget immediately before execution.
+- **Feedback loops:** none; no outcome feedback or retry is added.
+
+## 6. External surfaces
+
+Slack may receive one `reactions.add` call for the original message. The reaction is fixed to `eyes`; failures remain contained by the existing fire-and-forget primitive. No new API, dashboard, operator action, durable state, or timing controller is added.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Unified behavior through existing ownership.** The existing Slack owner handles the inbound event and makes the sole decision. No new state is replicated or stranded. There are no notices, durable records, or generated URLs. The unchanged legacy rate window remains local to the active owner.
+
+## 8. Rollback cost
+
+Pure code rollback: revert the enum/parser and adapter branch and ship a patch. There is no migration or state repair. Users would temporarily return to binary speak-or-silent behavior.
+
+## Conclusion
+
+The change is tightly bounded and fail-to-silent. The principal risks—social ambiguity, malformed model output, duplicate action, and reaction spam—are constrained by opt-in, fixed meaning, strict parsing, single branching, and the existing shared cap. The independent review's one documentation concern was corrected; the change is clear to ship.
+
+## Second-pass review
+
+**Reviewer:** instar-codey throughput-floor workstream reviewer  
+**Independent read of the artifact:** concur
+
+The reviewer verified no authority, state, retry, or analytics creep. It raised one material documentation mismatch: the adapter's legacy comment still claimed the gate could only make the agent quieter. The comment was corrected to describe the closed three-action execution, fixed reaction attempt, and fail-to-silent posture; the reviewer re-read the hunk and concurred with no remaining concern.
+
+## Evidence pointers
+
+- `tests/unit/slack-ambient-contribution-gate.test.ts`
+- `tests/unit/slack-ambient-gate-wiring.test.ts`
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller — not applicable.


### PR DESCRIPTION
## ELI16 — Slack considered acknowledgment v1

Instar can quietly acknowledge an undirected Slack message without interrupting the room. The same conservative gate makes one choice: write a useful reply, add a fixed eyes reaction meaning only seen and considered, or stay silent. Channels must opt in, the existing activity cap still applies, and every error or uncertain result stays silent.

### What already exists

In an explicitly opted-in Slack channel, Instar can notice a message that was not addressed to it and make one cautious judgment: should it contribute something useful, or remain silent? A single language-model gate makes that judgment. The default is silence, and any uncertainty, model failure, malformed answer, missing provider, exhausted rate limit, or low confidence also means silence. Ordinary channels remain mention-only.

### What v1 changes

This change gives that same gate one additional option. Instead of choosing only “write a reply” or “do nothing,” it chooses exactly one of three actions: speak, add a small acknowledgment reaction, or stay silent. It does not add another model call or a second classifier. The Slack adapter simply carries out the one result.

The reaction is deliberately fixed to the Slack `eyes` reaction. The model cannot invent an emoji, label the message, or call an arbitrary Slack operation. If it chooses the reaction with enough confidence, Instar reacts to the original message and does not start a conversational turn. If it chooses to speak, the existing full-response path runs. If it chooses silence—or anything goes wrong—nothing is sent.

### Why this is narrow

A reaction is a useful middle ground when a full reply would interrupt people but total silence would feel inattentive. The design remains conservative: the channel must already be opted in, the existing rate budget must be available, and the existing confidence floor still applies. Speaking also continues to require a concrete contribution.

The first version does not learn from reactions, collect social feedback, add action-specific dashboards, persist decisions, compare models, choose among emoji, or calibrate behavior. Those are explicitly separate v2 topics. This release only widens one existing closed decision and connects the new result to Slack’s already-available reaction function.

### Safety and rollback

There is still one semantic authority and one decision per eligible message. The adapter does not independently inspect the message or overrule the gate. Unknown or broken outputs become silence. A failed reaction cannot turn into a reply. Directed messages, commands, unauthorized senders, and channels that did not opt in behave as before.

Rollback is a normal code revert. No database, ledger, migration, or user state is introduced, so returning to the old speak-or-silent behavior needs no cleanup.
