### PR TITLE
feat: add recurring feature maturation evaluation

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-21T19-19-49-230Z-feature-maturation-recurring-evaluation.json
+++ b/.instar/instar-dev-decisions/2026-07-21T19-19-49-230Z-feature-maturation-recurring-evaluation.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T19:19:49.230Z",
+  "slug": "feature-maturation-recurring-evaluation",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 343,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-21T19-21-06-695Z-feature-maturation-recurring-evaluation.json
+++ b/.instar/instar-dev-decisions/2026-07-21T19-21-06-695Z-feature-maturation-recurring-evaluation.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T19:21:06.695Z",
+  "slug": "feature-maturation-recurring-evaluation",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 343,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-21T19-46-18-006Z-feature-maturation-recurring-evaluation.json
+++ b/.instar/instar-dev-decisions/2026-07-21T19-46-18-006Z-feature-maturation-recurring-evaluation.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T19:46:18.006Z",
+  "slug": "feature-maturation-recurring-evaluation",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 10,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-21T19-46-24-526Z-feature-maturation-recurring-evaluation.json
+++ b/.instar/instar-dev-decisions/2026-07-21T19-46-24-526Z-feature-maturation-recurring-evaluation.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T19:46:24.526Z",
+  "slug": "feature-maturation-recurring-evaluation",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 10,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-21T19-46-29-507Z-feature-maturation-recurring-evaluation.json
+++ b/.instar/instar-dev-decisions/2026-07-21T19-46-29-507Z-feature-maturation-recurring-evaluation.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T19:46:29.507Z",
+  "slug": "feature-maturation-recurring-evaluation",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 10,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-21T19-47-59-746Z-feature-maturation-recurring-evaluation.json
+++ b/.instar/instar-dev-decisions/2026-07-21T19-47-59-746Z-feature-maturation-recurring-evaluation.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T19:47:59.746Z",
+  "slug": "feature-maturation-recurring-evaluation",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 10,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-21T19-20-10-577Z-feature-maturation-recurring-evaluation-b44938a2.json
+++ b/.instar/instar-dev-traces/2026-07-21T19-20-10-577Z-feature-maturation-recurring-evaluation-b44938a2.json
@@ -1,0 +1,57 @@
+{
+  "version": 3,
+  "slug": "feature-maturation-recurring-evaluation",
+  "sessionId": "6fa7c41d-2b0f-4669-b508-34ce50313091",
+  "timestamp": "2026-07-21T19:44:57.300Z",
+  "artifactPath": "upgrades/side-effects/feature-maturation-recurring-evaluation.md",
+  "artifactSha256": "03fa3f91d54d329db4440c7994b05a1c7fab34c729399336b225819a8bfccb45",
+  "specPath": "docs/specs/feature-maturation-recurring-evaluation.md",
+  "coveredFiles": [
+    "docs/specs/feature-maturation-recurring-evaluation.eli16.md",
+    "docs/specs/feature-maturation-recurring-evaluation.md",
+    "docs/specs/reports/feature-maturation-recurring-evaluation-convergence.md",
+    "src/core/FeatureRolloutReconciler.ts",
+    "src/core/InitiativeTracker.ts",
+    "src/core/featureRolloutScan.ts",
+    "src/monitoring/BlockerLifecycleLedger.ts",
+    "src/monitoring/BlockerLifecycleService.ts",
+    "src/server/AgentServer.ts",
+    "src/server/routes.ts",
+    "tests/unit/BlockerLifecycleLedger.test.ts",
+    "tests/unit/BlockerLifecycleMaturation.test.ts",
+    "tests/unit/feature-maturation-contract.test.ts",
+    "upgrades/next/feature-maturation-recurring-evaluation.md",
+    "upgrades/side-effects/feature-maturation-recurring-evaluation.md"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "Runtime metrics persistence and recurring evaluation extend fleet-shipped monitoring surfaces; full converged-spec ceremony is appropriate.",
+  "secondPass": "true",
+  "reviewerConcurred": true,
+  "toolchain": {
+    "buildSkill": {
+      "name": "instar-dev",
+      "version": "5c281366e0da",
+      "verified": true
+    },
+    "reviewSkills": [
+      {
+        "name": "spec-converge",
+        "outcome": "converged",
+        "verified": false,
+        "iterations": 6
+      },
+      {
+        "name": "iterative-converging-audit",
+        "outcome": "converged",
+        "verified": false,
+        "iterations": 6
+      }
+    ],
+    "convergence": {
+      "reportPath": "docs/specs/reports/feature-maturation-recurring-evaluation-convergence.md",
+      "iterations": 6,
+      "verified": true
+    }
+  }
+}

--- a/docs/specs/feature-maturation-recurring-evaluation.eli16.md
+++ b/docs/specs/feature-maturation-recurring-evaluation.eli16.md
@@ -1,0 +1,11 @@
+# Feature maturation recurring evaluation — plain-English overview
+
+Instar already keeps a rollout card for features that ship turned off or in a testing mode. D7 makes those cards measurable instead of leaving them as prose. Each feature declares a small set of numeric checks, how fresh the evidence must be, and what value counts as healthy. Instar then revisits every feature that is still dark or soaking on a regular schedule.
+
+This does not build another rollout tracker or another metrics service. It adds per-feature observation and evaluation rows to the existing blocker-lifecycle metrics database, and shows the results through the same summary and trend endpoints. The existing rollout reconciler remains the one source of feature identity and stage. The existing six-hour reconciliation pass is also the only recurring driver.
+
+Missing data is never treated as success. A feature is reported as ready only when every declared metric has enough fresh samples and passes its threshold. Missing contracts, insufficient evidence, stale evidence, failed thresholds, and missed evaluation cadences each have separate visible states. The score is descriptive only: it cannot enable a feature, advance a rollout card, or send a notification.
+
+The first supported evidence comes from the already-shipped blocker summary and trend measurements. Decision-quality and benchmark evidence can join later only after those producers publish stable numeric descriptors; this release does not pretend those integrations already exist. All data remains machine-tagged, so one healthy machine cannot hide missing evidence on another.
+
+The rollout starts on the development agent through the existing dark gate. Graduation requires a seven-day soak in which every eligible feature is evaluated when due, no feature is falsely marked ready, missed cadences recover visibly, and the bounded evaluation pass stays within its performance budget.

--- a/docs/specs/feature-maturation-recurring-evaluation.md
+++ b/docs/specs/feature-maturation-recurring-evaluation.md
@@ -1,0 +1,237 @@
+---
+title: "Feature Maturation D7 — recurring measurable evaluation on the shared metrics substrate"
+slug: "feature-maturation-recurring-evaluation"
+author: "instar-codey"
+parent-principle: "Maturation Path — Test Agent → Development Agent → Fleet"
+approved: true
+approved-at: "2026-07-21T18:48:12Z"
+approval-context: "Operator directive in Slack channel C0BA4F4E0FP: D7 current increment; per-feature measurable metrics and recurring re-score; extend, never duplicate"
+ships-staged: true
+rollout-flag-path: "monitoring.blockerLifecycleLedger"
+rollout-criteria: "seven-day development-agent soak; every eligible rollout evaluated when due under its declared cadence; zero missed-due rows; no authority or blocker-state mutation"
+rollout-evidence-type: "endpoint"
+rollout-evidence-ref: "/blocker-lifecycle/summary"
+review-convergence: "2026-07-21T19:06:06.356Z"
+review-iterations: 6
+review-completed-at: "2026-07-21T19:06:06.356Z"
+review-report: "docs/specs/reports/feature-maturation-recurring-evaluation-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5; gemini-cli:gemini-3.1-pro-preview"
+single-run-completable: true
+frontloaded-decisions: 8
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Feature Maturation D7 — recurring measurable evaluation
+
+## Problem statement
+
+PR #1540 makes maturation plans structurally visible and strengthens the existing Maturation Path. It does not make each dark or soaking feature measurable, and it does not periodically re-evaluate those features. A rollout can therefore still remain at a rung with an old evidence snapshot and no fresh score.
+
+The operator requires the current D7 increment to make metrics trackable per feature and to re-score every dark/soaking feature on a recurring cadence. The implementation must reuse the existing rollout owner (`FeatureRolloutReconciler` + `InitiativeTracker`), the #1535 blocker-lifecycle SQLite/summary/trend substrate, and existing benchmark/decision-quality evidence. It must not create a second maturation registry, scheduler, feature-metrics database, or promotion authority.
+
+## Foundation and duplicate audit
+
+The implementation base is PR #1540 (`codey/feature-maturation-discipline`) until that dependency merges, then rebased onto fresh `main`.
+
+Existing owners and the exact extension:
+
+| Concern | Existing owner | D7 extension |
+|---|---|---|
+| Feature identity, stage, criteria | `FeatureRolloutReconciler` → `InitiativeTracker.rollout` | Add a bounded typed measurement contract to `RolloutInfo`; no second feature registry. |
+| Durable measurements | `BlockerLifecycleLedger` SQLite | Add a `maturation_evaluations` table and methods on the same class/DB. The existing blocker table retains exactly its two factors. |
+| Summary/trend reads | `BlockerLifecycleService.localSummary/localTrend` and `/blocker-lifecycle/*` | Add bounded `maturation` fields to those existing envelopes; no new dashboard/read engine. |
+| Recurrence | Existing `BlockerLifecycleService` bounded timer pattern | One six-hour maturation timer owned by that service; no scheduled-job definition or second trigger path. |
+| Model/benchmark evidence | Decision-quality and benchmark-divergence outputs | Metric contracts name these sources. D7 stores only scrubbed numeric observations and source refs; it never reruns an LLM or creates a benchmark harness. |
+| Promotion | Human changes config/default; reconciler only observes | Scores are advisory signals. They never mutate flags, stages, initiatives, or approval state. |
+
+Audit finding: extending the blocker table's `factor` enum would violate #1535's deliberate exactly-two-factor contract. D7 therefore adds a sibling table inside the same ledger owner rather than a third blocker factor. This is one measurement substrate, not a parallel engine: one SQLite handle, lifecycle, guard, retention pass, summary/trend surface, pool projection, and server wiring.
+
+Standing duplicate guard: a unit/source ratchet asserts that `maturation_evaluations` is created only by `BlockerLifecycleLedger`, no `*Maturation*Ledger`/database class is introduced, and the blocker factor union remains exactly `request-to-persist | clear-latency`.
+
+Mental model: D7 is a local append-only metric-observation table plus immutable deterministic evaluation snapshots, exposed through the existing blocker-lifecycle read surface. Sharing the ledger owner is the integration constraint; observations/contracts/evaluations remain explicit domain objects.
+
+## Design
+
+### 1. Typed per-feature measurement contract
+
+`RolloutInfo` gains optional `maturationEvaluation`:
+
+```ts
+interface MaturationEvaluationContract {
+  cadenceHours: number;       // integer 6..168, multiple of 6
+  evidenceMaxAgeHours: number;// integer cadenceHours..min(168, cadenceHours*2)
+  metrics: Array<{
+    id: string;               // /^[a-z0-9][a-z0-9-]{0,62}$/
+    source: 'blocker-summary' | 'blocker-trend';
+    sourceRef: string;        // bounded opaque stable row/field/task id, not a URL or prose
+    direction: 'at-least' | 'at-most';
+    threshold: number;
+    minSamples: number;       // integer 1..100000
+  }>;                         // 1..16, unique id
+}
+```
+
+The spec scanner accepts a single frontmatter field `rollout-metrics-json`, parsed with `JSON.parse` and closed validation. Malformed/oversized input is omitted and therefore scores `missing-contract`; it never aborts reconciliation. A bounded validation result (`featureId`, error enum only: `invalid-json|oversized|invalid-shape|unknown-source-ref`) is counted by guard/summary diagnostics so the omission is not silent. The canonical scanner and local scanner use one exported parser. Reconciler updates preserve the contract across stage transitions.
+
+Source references are not author-invented strings. D7 exports one closed, schema-versioned descriptor registry per producer. Every descriptor pins `source`, `sourceRef`, numeric unit, aggregation meaning, sample definition, freshness owner, `freshnessModel: wall-clock|activity-clock|window-derived`, the zero-activity result (`insufficient-evidence|valid-zero`), and whether later descriptor revisions are backward-compatible. V1's canonical pairs are:
+
+| source | sourceRef |
+|---|---|
+| `blocker-summary` | `request-to-persist.coverage` |
+| `blocker-summary` | `request-to-persist.p95Ms` |
+| `blocker-summary` | `clear-latency.coverage` |
+| `blocker-summary` | `clear-latency.p95Ms` |
+| `blocker-trend` | `request-to-persist.ratio` |
+| `blocker-trend` | `clear-latency.ratio` |
+
+Decision-quality and benchmark are reserved follow-on producer families, not accepted V1 source enum values; they enter only in the PR that exports their stable descriptors. Adding or incompatibly revising a ref is a code-reviewed registry version change with a producer test; old observations retain their descriptor version.
+
+Every feature at `dark`, `dry-run`, or `live` is evaluation-eligible. `default-on` is terminal for recurring evaluation but remains visible in retained trend history. This preserves the current four observed rollout stages; D7 does not rename runtime stages ahead of the later test-agent/dev-agent/fleet rollout implementation.
+
+| Term | Values | Meaning in D7 |
+|---|---|---|
+| Observed runtime rollout stage | `dark|dry-run|live|default-on` | Derived by `featureRollout.ts` from the feature flag/default. |
+| Initiative phase ids | `dry-run|live|default-on` | Existing tracker phases; `dark` is the implicit pre-phase. |
+| Evaluation eligibility | `dark|dry-run|live` | Non-terminal stages re-scored; `default-on` retains history only. |
+| D7's own rollout flag | `monitoring.blockerLifecycleLedger` | Whether this measurement substrate runs on the current agent; unrelated to a measured feature's stage. |
+
+In evaluation rows, `rung` means the observed runtime rollout stage at evaluation time; it is not an Initiative phase id.
+
+### 2. Numeric observation seam
+
+The ledger accepts bounded `MaturationMetricObservation` rows supplied by existing measurement producers:
+
+```ts
+{ featureId, metricId, source, sourceRef, observedAtMs,
+  value: number, samples: number, benchmarkRef?: string }
+```
+
+`benchmarkRef` is a bounded opaque identifier from the existing benchmark or decision-quality machinery, not raw prompt/evidence. Duplicate producer delivery is idempotent by `(origin, featureId, metricId, source, sourceRef, observedAtMs)`. D7 adds no model call and no raw evidence store.
+
+Observations are origin-local. `observedAtMs` must be finite, non-negative, no older than 90 days, and no more than five minutes ahead of the accepting service clock; invalid/future rows are rejected and counted. The scorer selects only observations whose `origin` equals its own machine id. Pool projection never lets one origin satisfy another origin's contract.
+
+The initial concrete adapter is the already-live blocker summary/trend service and accepts only the canonical pairs above. The same `observeMaturationMetric()` seam is exported for later decision-quality and benchmark-divergence descriptor integrations. D7 does not claim those producers are integrated, scrape its own HTTP routes, or parse human prose.
+
+An eligible feature whose contract cites a producer that has not emitted receives an honest `insufficient-evidence` evaluation. Missing data is never coerced to zero and never treated as a pass.
+
+### 3. Deterministic recurring scorer
+
+`BlockerLifecycleService.evaluateMaturation(initiatives)` scans a stable, bounded list of at most 512 rollout initiatives. For every eligible feature, each pass writes one idempotent evaluation keyed by `(origin, featureId, dueSlotMs)`, where `dueSlotMs = floor(now / cadenceMs) * cadenceMs`; the observed `rung` is immutable row data, not key material. Re-running the same slot updates nothing and returns `deduped`, so a same-slot stage transition is reflected at the next slot. A contract change takes effect at the next due slot; the current slot remains bound to the first durably evaluated contract.
+
+Each `(origin,featureId,contractHash)` has an `effectiveFromMs`: the latest of D7 enable time, first eligible observation, and first sight of that contract hash. Missed slots are never generated before this epoch. After later downtime, the scorer materializes up to four intervening due slots as explicit `missed-cadence` evaluations before scoring the current slot. It never fabricates metric values or backfills a pass. If more than four slots elapsed, one oldest bounded marker carries `additionalMissedSlots` (clamped to 10,000) and the other three most recent missed slots remain explicit. Thus recurrence failure stays durable without an unbounded catch-up loop.
+
+The six-hour existing driver is the minimum clock. Consequently `cadenceHours` is a multiple of six in `6..168`; a contract cannot promise a cadence the driver cannot meet. Due slots are UTC epoch-aligned independently on each origin. Small clock skew changes only which origin-local slot is current near a boundary; no pool dedupe or pool-level missed-due calculation exists. NTP is not a correctness dependency.
+
+For each metric:
+
+- no valid contract: `missing-contract`;
+- no observation meeting `minSamples`: `insufficient-evidence`;
+- newest observation older than `evidenceMaxAgeHours`: `stale-evidence`;
+- numeric comparison fails: `hold`;
+- every metric is fresh, sampled, and passes: `ready`.
+
+Closed precedence for a current evaluation is `missing-contract > insufficient-evidence > stale-evidence > hold > ready`; `missed-cadence` is reserved for an elapsed slot the process did not evaluate. The evaluation stores only feature id, observed rung, due slot, status, passing/total metric counts, minimum normalized margin, contract hash, newest evidence timestamp, and bounded source/benchmark refs. No titles, paths, criteria prose, logs, topics, prompts, or user data enter SQLite.
+
+The `contractHash` is SHA-256 over canonical sorted contract JSON. Historical rows permanently retain the hash and cadence slot used when evaluated; they are never re-slotted or reinterpreted after a contract change. A changed contract begins at the next slot and trends expose the hash boundary.
+
+Normalized margin is direction-aware and dimensionless: for `at-least`, `(value-threshold)/max(abs(threshold),1)`; for `at-most`, `(threshold-value)/max(abs(threshold),1)`, clamped to `[-1,1]`. It is descriptive only. The score never authorizes promotion.
+
+`BlockerLifecycleService` is the single canonical driver: it performs one boot-delayed pass and one six-hour recurring pass over the injected `InitiativeTracker`. `evaluateMaturation()` is the called method and a direct test seam, not a second timer or public runtime trigger. Only this service timer owns missed-cadence materialization. The existing feature reconciler continues to refresh the same tracker independently; D7 reads its latest records and adds no callback trigger. There is no new cron/job file, autonomous session, attention item, or user message.
+
+### 4. Existing summary and trend surfaces
+
+`localSummary(sinceHours)` adds:
+
+```ts
+maturation: {
+  eligible: number;
+  evaluated: number;
+  missedDue: number;
+  byStatus: { ready, hold, 'stale-evidence', 'insufficient-evidence', 'missing-contract', 'missed-cadence' };
+  features: Array<{ featureId, rung, status, evaluatedAt, nextDueAt,
+    passingMetrics, totalMetrics, minNormalizedMargin, newestEvidenceAt, benchmarkRefs }>;
+}
+```
+
+The feature list is stable-sorted and capped at 512. `missedDue` counts eligible features with no durable evaluation in their current cadence slot. A failed write therefore remains visibly missed; it is never inferred as healthy.
+
+`localTrend(windowDays)` adds per-feature daily latest evaluations, capped to 512 features × 90 days. It reports status and `minNormalizedMargin` only; no cross-feature scalar, average, fleet ranking, or productivity claim. Pool reads preserve machine-tagged origins and existing completeness/failure rules. Sanitizers explicitly allowlist the new shape and reject/clamp malformed peers; old peers omit `maturation` and are reported as `unsupported-maturation`, never as zero.
+
+### 5. Retention, failure, and authority
+
+- Same SQLite handle/WAL/busy timeout/close/registry as blocker lifecycle.
+- Evaluations retained 90 days, pruned in the ledger's existing bounded `prune()` pass; max 250,000 maturation rows with 1,000-row prune batches.
+- Observation lookup has a covering index on `(origin,feature_id,metric_id,source,source_ref,observed_at_ms DESC)`; current-slot lookup has a unique index on `(origin,feature_id,due_slot_ms)`; trend has `(origin,feature_id,due_slot_ms DESC)`. One batched window query prefetches the latest candidate observations for the pass and indexes them in memory by the bounded composite key; scoring performs no per-metric SQL query and one indexed slot insert per feature, bounded at 512 × 16 inputs.
+- Observation/evaluation writes are fail-soft. Ledger failure degrades guard health and read coverage but never blocks a rollout transition or feature behavior.
+- Contract parse failure, source absence, clock regression, NaN/Infinity, oversize ids/refs, and sample overflow become bounded rejection counters or non-ready statuses.
+- Recurring scoring never writes `InitiativeTracker`, config, standards, approval, or feature flags. It is a signal. Human/config remains authority.
+- No attention notification ships in D7. D4 remains the later stuck-dark surfacing arm; D7 is the measurement/recurring driving arm visible on pull.
+
+### Alternatives considered
+
+OpenTelemetry/Prometheus would provide general time-series transport but would add an external availability/configuration dependency and a second per-feature metrics owner on disconnected personal agents. A generic workflow scheduler would duplicate the already-running reconciliation/service cadence and still need this storage/read contract. A new `MaturationLedger` would split lifecycle, retention, pool projection, and guard health. The selected additive table is intentionally a small embedded time-series pattern: SQLite plus bounded descriptors gives offline durability and one pull surface while preserving #1535's blocker-factor semantics. It follows established event/time-series invariants: observations and evaluations are append-only, records are immutable after dedupe, timestamps and cardinality are bounded, and metric descriptors/rows are explicitly schema-versioned.
+
+## Multi-machine posture
+
+Initiative rollout identity and stage remain unified by the existing canonical-spec scan and origin feature records. Numeric observations/evaluations are machine-local measurements because model routing, logs, and feature behavior can differ per physical runtime. The existing authenticated `/blocker-lifecycle/*?scope=pool` proxied-on-read surface returns machine-tagged origins with completeness failures; it never merges distinct origins into one fleet score.
+
+machine-local-justification: operator-ratified-exception (`docs/specs/throughput-metrics.md` and PR #1535 establish per-origin metric truth with pool projection; D7 extends that exact registry key and storage owner).
+
+No credentials, hardware identities, or user-visible URLs are introduced.
+
+## Decision points touched
+
+- Contract validation — `invariant`: closed types, numeric/id/range bounds, and omission-on-invalid; no competing signals.
+- Evaluation eligibility — `invariant`: current rollout stage is one of `dark|dry-run|live`.
+- Per-metric pass — `invariant`: fixed direction/threshold/sample/freshness comparison declared by the feature.
+- Status precedence — `invariant`: the closed conservative order above; missing/conflicting evidence cannot pass.
+- Recurrence slot/dedupe — `invariant`: deterministic cadence slot and unique key.
+- Promotion — `invariant`: D7 has no mutation path; existing human/config change remains sole authority.
+- Pool completeness — `invariant`: existing machine-tagged projection and explicit failure semantics.
+
+- Model authority — `invariant`: no LLM judgment point is introduced; later benchmark and decision-quality producers may supply numeric observations, but their existing arbiters remain unchanged.
+
+## Frontloaded Decisions
+
+- D7 extends `BlockerLifecycleLedger` with a sibling table; it does not alter the exactly-two blocker factor enum.
+- The four current runtime rollout stages remain intact. The approved three-rung test-agent/dev-agent/fleet semantics land in the separately scoped runtime ladder work.
+- Contracts carry 1..16 metrics with fixed threshold/direction/sample/freshness fields; arbitrary formulas and prose parsing are rejected.
+- A single six-hour service cadence follows the existing bounded timer pattern. Per-feature `cadenceHours` controls due slots, not scheduler proliferation.
+- Missing, stale, or conflicting evidence is non-ready and visible; there is no implicit pass.
+- All scores remain advisory and pull-only in D7. D4 owns later stuck-dark attention surfacing.
+- Local truth remains machine-tagged and pool-projected; no cross-machine aggregate score exists.
+- D7 is a Tier-2 runtime extension with full migration/side-effects/review ceremony.
+
+## Maturation plan
+
+- **test-agent-live:** Run the scorer and blocker adapter live on Codey with fixtures for ready, hold, missing, stale, duplicate-slot, malformed peer, and ledger failure.
+- **dev-agent-live:** After the test-agent soak passes, enable on Echo through the same existing development-agent gate and verify every active rollout has a fresh evaluation each cadence.
+- **fleet:** A separately reviewed default flip only after the seven-day evidence gate passes; D7 never performs the flip.
+- **graduation criterion:** Seven consecutive days with every eligible rollout evaluated each cadence, zero false-ready results, zero missed-due rows after one recovery cadence, no blocked rollout/config operation, pool omission honesty intact, and p95 added evaluation pass under 100ms for 512 features × 16 metrics.
+- **dark-window:** Review the test-agent evidence within 14 days of merge; remain dark outside development agents until disposition.
+
+## Acceptance criteria
+
+1. Local and canonical scanners parse one closed metric contract identically; malformed/oversized contracts omit safely.
+2. Reconciler create/update/stage-transition paths preserve the contract and never create a second initiative.
+3. The blocker factor type/table still accepts exactly two original factors.
+4. One ledger/database owner persists idempotent bounded observations and cadence-slot evaluations.
+5. Every eligible rollout attempts one idempotent evaluation per due slot, including features with missing contracts/evidence; durable absence is counted by `missedDue`.
+6. Stale/missing/NaN/undersampled data never produces `ready`; precedence and score math are deterministic.
+7. Summary/trend expose per-feature results with caps and honest pool compatibility; no combined scalar exists.
+8. Retention, pruning, close, unavailable SQLite, queue pressure, and restart/dedupe paths are tested.
+9. No code mutates a feature flag, rollout stage, initiative, approval, or notification from an evaluation.
+10. Source ratchet proves no parallel maturation ledger/database/job/read engine was added.
+11. Existing blocker-lifecycle, InitiativeTracker, FeatureRolloutReconciler, decision-quality, benchmark-divergence, type, lint, unit, integration, and e2e tests pass.
+12. Upgrade/migration awareness describes D7 as measure-only and recurring; no operator action is implied.
+13. V1 proves the blocker summary/trend adapter end to end. Decision-quality and benchmark are reserved follow-on producer families and are not valid V1 source enum values; the generic observation seam alone does not pretend that integration is live.
+14. Query-plan tests assert all newest-observation, current-slot, and trend reads use the declared indexes and preserve the 512 × 16 bound.
+
+## Rollback
+
+Disable the existing blocker-lifecycle development gate or revert the code. The sibling table becomes inert; no authoritative state, feature configuration, rollout stage, or external system requires rollback. A later version may prune the inert rows through the same bounded ledger retention path.
+
+## Open questions
+
+*(none)*

--- a/docs/specs/reports/feature-maturation-recurring-evaluation-convergence.md
+++ b/docs/specs/reports/feature-maturation-recurring-evaluation-convergence.md
@@ -1,0 +1,28 @@
+# Convergence Report — Feature Maturation D7 recurring evaluation
+
+## Cross-model review
+
+Real GPT-tier (`codex-cli:gpt-5.5`) and Gemini-tier (`gemini-cli:gemini-3.1-pro-preview`) reviews ran. The local Standards-Conformance Gate was invoked but rejected the worktree path as outside its configured spec directory; this unavailable signal did not block review.
+
+## Outcome
+
+The converged design makes every active rollout measurable and periodically re-scored while preserving the existing rollout authority. It uses one additive table inside `BlockerLifecycleLedger`, the existing summary/trend envelopes, and one six-hour timer owned by `BlockerLifecycleService`. It does not add a maturation registry, scheduled job, database owner, promotion action, model call, or notifier.
+
+## Iteration summary
+
+| Round | New findings | Disposition |
+|---|---:|---|
+| 1 | 8 | Clarified stage terminology, cadence floor, fail-soft missed rows, timestamp bounds, source registry, contract history, and pool-local slots. |
+| 2 | 6 | Pinned contract-change semantics, descriptor units/sample meaning, evidence maximum age, append-only records, and local embedded-telemetry rationale. |
+| 3 | 5 | Added bounded missed-cadence recovery, contract diagnostics, honest V1 producer scope, exact margin field, and query-plan requirements. |
+| 4 | 5 | Established one canonical cadence owner, reserved rather than claimed future producers, quiet-source freshness models, indexes, and rung definition. |
+| 5 | 5 | Added evaluation epochs, removed rung from uniqueness, canonicalized source pairs, batched reads, and the explicit domain mental model. |
+| 6 | 0 material | Fresh internal re-audit found no unresolved security, authority, duplication, migration, multi-machine, performance, or decision-completeness issue. |
+
+## Foundation audit
+
+The audit found one real design trap: adding maturation as a third blocker factor would violate PR #1535's exactly-two-factor contract. The resolution is a sibling evaluation table owned by the same ledger class and database. `FeatureRolloutReconciler` and `InitiativeTracker` remain feature identity/stage owners; the human/config change remains promotion authority. A source ratchet prevents a parallel maturation ledger, database, job, or read engine.
+
+## Convergence verdict
+
+Converged after six rounds. The last sweep produced zero new material findings. All operator requirements are represented: per-feature numeric contracts, recurring evaluation for every dark/soaking feature, explicit stale/missing/missed states, reuse of blocker summary/trend and benchmark-compatible descriptor machinery, and no parallel measurement or maturation engine.

--- a/src/core/FeatureRolloutReconciler.ts
+++ b/src/core/FeatureRolloutReconciler.ts
@@ -14,7 +14,7 @@
  * or ships-staged specs become `active` tracks (anti-flood).
  */
 
-import type { InitiativeTracker, PipelineStage, Initiative } from './InitiativeTracker.js';
+import type { InitiativeTracker, PipelineStage, Initiative, MaturationEvaluationContract } from './InitiativeTracker.js';
 import {
   deriveRolloutStage,
   rolloutPhaseStatuses,
@@ -39,6 +39,7 @@ export interface SpecArtifact {
   flagPath?: string;
   evidenceSource?: { type: 'log-filter' | 'endpoint'; ref: string; filter?: string };
   promotionCriteria?: string;
+  maturationEvaluation?: MaturationEvaluationContract;
   /** An instar-dev trace exists referencing this spec (⇒ at least building). */
   traceExists: boolean;
   prNumber?: number;
@@ -131,7 +132,7 @@ export class FeatureRolloutReconciler {
         phases, kind: 'task', pipelineStage: stage, specPath: art.specPath,
         prNumber: art.prNumber,
         rollout: rolloutEligible
-          ? { flagPath: art.flagPath!, stage: observedStage!, evidenceSource: art.evidenceSource, promotionCriteria: art.promotionCriteria }
+          ? { flagPath: art.flagPath!, stage: observedStage!, evidenceSource: art.evidenceSource, promotionCriteria: art.promotionCriteria, maturationEvaluation: art.maturationEvaluation }
           : undefined,
       });
       // default-on parks the track as 'paused' (NON-terminal → reopenable on a
@@ -171,6 +172,14 @@ export class FeatureRolloutReconciler {
         else summary.advanced.push(id);
         return;
       }
+      if (JSON.stringify(existing.rollout?.maturationEvaluation) !== JSON.stringify(art.maturationEvaluation)) {
+        await this.deps.tracker.update(id, {
+          rollout: { ...existing.rollout!, maturationEvaluation: art.maturationEvaluation },
+          ifMatch: this.deps.tracker.get(id)?.version,
+        });
+        summary.advanced.push(id);
+        return;
+      }
     }
 
     if (touched) summary.advanced.push(id);
@@ -191,7 +200,7 @@ export class FeatureRolloutReconciler {
     }
     const fresh = this.deps.tracker.get(id);
     await this.deps.tracker.update(id, {
-      rollout: { flagPath: fresh?.rollout?.flagPath ?? '', stage: stage as never, evidenceSource: fresh?.rollout?.evidenceSource, promotionCriteria: fresh?.rollout?.promotionCriteria, lastDigestNotifiedAt: fresh?.rollout?.lastDigestNotifiedAt },
+      rollout: { flagPath: fresh?.rollout?.flagPath ?? '', stage: stage as never, evidenceSource: fresh?.rollout?.evidenceSource, promotionCriteria: fresh?.rollout?.promotionCriteria, maturationEvaluation: fresh?.rollout?.maturationEvaluation, lastDigestNotifiedAt: fresh?.rollout?.lastDigestNotifiedAt },
       // 'paused' (non-terminal, reopenable) at default-on — NOT 'archived'
       // (which maps to TaskFlow's terminal `cancelled` and would seal the
       // record against a later regression). 'active' for live/dry-run.

--- a/src/core/InitiativeTracker.ts
+++ b/src/core/InitiativeTracker.ts
@@ -77,6 +77,24 @@ export type InitiativeKind = 'task' | 'project';
  *  GRADUATED-FEATURE-ROLLOUT-SPEC §4.2-4.3. */
 export type RolloutStage = 'dark' | 'dry-run' | 'live' | 'default-on';
 
+export type MaturationMetricSource = 'blocker-summary' | 'blocker-trend';
+export type MaturationMetricDirection = 'at-least' | 'at-most';
+
+export interface MaturationMetricContract {
+  id: string;
+  source: MaturationMetricSource;
+  sourceRef: string;
+  direction: MaturationMetricDirection;
+  threshold: number;
+  minSamples: number;
+}
+
+export interface MaturationEvaluationContract {
+  cadenceHours: number;
+  evidenceMaxAgeHours: number;
+  metrics: MaturationMetricContract[];
+}
+
 /** Typed rollout metadata for a ships-staged feature task. Operational criteria
  *  live here (typed), NOT in free-form phase summaries. */
 export interface RolloutInfo {
@@ -89,6 +107,9 @@ export interface RolloutInfo {
   evidenceSource?: { type: 'log-filter' | 'endpoint'; ref: string; filter?: string };
   /** Human-readable promotion gate (e.g. "≥2wk + ≥3 genuinely-idle would-reaps"). */
   promotionCriteria?: string;
+  /** D7: bounded numeric contract evaluated on the shared blocker-lifecycle
+   * metrics substrate. Evaluation is advisory and never advances this track. */
+  maturationEvaluation?: MaturationEvaluationContract;
   /** Near-silent edge dedupe: last time a needs-user line was surfaced for this track. */
   lastDigestNotifiedAt?: string;
 }

--- a/src/core/featureRolloutScan.ts
+++ b/src/core/featureRolloutScan.ts
@@ -15,6 +15,7 @@ import * as path from 'node:path';
 import { SafeGitExecutor } from './SafeGitExecutor.js';
 import type { SpecArtifact } from './FeatureRolloutReconciler.js';
 import type { RolloutFlagObservation } from './featureRollout.js';
+import type { MaturationEvaluationContract, MaturationMetricSource } from './InitiativeTracker.js';
 
 const RECENT_MERGE_WINDOW_MS = 14 * 24 * 60 * 60 * 1000; // 14d ⇒ active vs terminal backfill
 
@@ -40,6 +41,56 @@ export function parseSpecFrontmatter(content: string): Record<string, string> {
     if (kv) out[kv[1]] = kv[2].trim().replace(/^["']|["']$/g, '');
   }
   return out;
+}
+
+export type MaturationContractError = 'invalid-json' | 'oversized' | 'invalid-shape' | 'unknown-source-ref';
+export type MaturationContractParseResult =
+  | { ok: true; contract: MaturationEvaluationContract }
+  | { ok: false; error: MaturationContractError };
+
+const MATURATION_SOURCE_REFS: Readonly<Record<MaturationMetricSource, ReadonlySet<string>>> = {
+  'blocker-summary': new Set([
+    'request-to-persist.coverage', 'request-to-persist.p95Ms',
+    'clear-latency.coverage', 'clear-latency.p95Ms',
+  ]),
+  'blocker-trend': new Set(['request-to-persist.ratio', 'clear-latency.ratio']),
+};
+
+export function parseMaturationContract(raw: string | undefined): MaturationContractParseResult | undefined {
+  if (!raw) return undefined;
+  if (Buffer.byteLength(raw) > 16_384) return { ok: false, error: 'oversized' };
+  let value: unknown;
+  try { value = JSON.parse(raw); } catch { return { ok: false, error: 'invalid-json' }; }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return { ok: false, error: 'invalid-shape' };
+  const v = value as Record<string, unknown>;
+  if (!Number.isInteger(v.cadenceHours) || (v.cadenceHours as number) < 6 || (v.cadenceHours as number) > 168 || (v.cadenceHours as number) % 6 !== 0 ||
+      !Number.isInteger(v.evidenceMaxAgeHours) || (v.evidenceMaxAgeHours as number) < (v.cadenceHours as number) ||
+      (v.evidenceMaxAgeHours as number) > Math.min(168, (v.cadenceHours as number) * 2) ||
+      !Array.isArray(v.metrics) || v.metrics.length < 1 || v.metrics.length > 16) {
+    return { ok: false, error: 'invalid-shape' };
+  }
+  const ids = new Set<string>();
+  const metrics = [] as MaturationEvaluationContract['metrics'];
+  for (const rawMetric of v.metrics) {
+    if (!rawMetric || typeof rawMetric !== 'object' || Array.isArray(rawMetric)) return { ok: false, error: 'invalid-shape' };
+    const m = rawMetric as Record<string, unknown>;
+    if (typeof m.id !== 'string' || !/^[a-z0-9][a-z0-9-]{0,62}$/.test(m.id) || ids.has(m.id) ||
+        !['blocker-summary', 'blocker-trend'].includes(String(m.source)) || typeof m.sourceRef !== 'string' ||
+        !['at-least', 'at-most'].includes(String(m.direction)) || typeof m.threshold !== 'number' || !Number.isFinite(m.threshold) ||
+        !Number.isInteger(m.minSamples) || (m.minSamples as number) < 1 || (m.minSamples as number) > 100_000) {
+      return { ok: false, error: 'invalid-shape' };
+    }
+    const source = m.source as MaturationMetricSource;
+    if (!MATURATION_SOURCE_REFS[source].has(m.sourceRef)) return { ok: false, error: 'unknown-source-ref' };
+    ids.add(m.id);
+    metrics.push({ id: m.id, source, sourceRef: m.sourceRef, direction: m.direction as 'at-least' | 'at-most', threshold: m.threshold, minSamples: m.minSamples as number });
+  }
+  return { ok: true, contract: { cadenceHours: v.cadenceHours as number, evidenceMaxAgeHours: v.evidenceMaxAgeHours as number, metrics } };
+}
+
+function maturationContractFrom(fm: Record<string, string>): MaturationEvaluationContract | undefined {
+  const parsed = parseMaturationContract(fm['rollout-metrics-json']);
+  return parsed?.ok ? parsed.contract : undefined;
 }
 
 interface TraceInfo { prNumber?: number; createdAtMs?: number; }
@@ -92,6 +143,7 @@ export function scanSpecArtifacts(repoRoot: string, now: () => number = () => Da
       evidenceSource: fm['rollout-evidence-ref']
         ? { type: (fm['rollout-evidence-type'] as 'log-filter' | 'endpoint') || 'log-filter', ref: fm['rollout-evidence-ref'], filter: fm['rollout-evidence-filter'] || undefined }
         : undefined,
+      maturationEvaluation: maturationContractFrom(fm),
       traceExists,
       prNumber: trace?.prNumber,
       merged,
@@ -218,6 +270,7 @@ export function scanSpecArtifactsCanonical(opts: CanonicalScanOpts): CanonicalSc
       evidenceSource: fm['rollout-evidence-ref']
         ? { type: (fm['rollout-evidence-type'] as 'log-filter' | 'endpoint') || 'log-filter', ref: fm['rollout-evidence-ref'], filter: fm['rollout-evidence-filter'] || undefined }
         : undefined,
+      maturationEvaluation: maturationContractFrom(fm),
       traceExists,
       prNumber: trace?.prNumber,
       merged,

--- a/src/monitoring/BlockerLifecycleLedger.ts
+++ b/src/monitoring/BlockerLifecycleLedger.ts
@@ -156,7 +156,7 @@ export class BlockerLifecycleLedger {
           record.sourceRef, Math.round(record.observedAtMs), record.value, record.samples,
           record.descriptorVersion ?? 1, record.benchmarkRef ?? null);
       return true;
-    } catch { return false; }
+    } catch { /* @silent-fallback-ok — false makes the failed observation write explicit to the caller */ return false; }
   }
 
   maturationObservations(origin: string, sinceMs: number): MaturationMetricObservation[] {
@@ -167,7 +167,7 @@ export class BlockerLifecycleLedger {
         descriptor_version AS descriptorVersion,benchmark_ref AS benchmarkRef
         FROM maturation_metric_observations WHERE origin=? AND observed_at_ms>=?
         ORDER BY observed_at_ms DESC LIMIT 8192`).all(origin, Math.round(sinceMs)) as MaturationMetricObservation[];
-    } catch { return []; }
+    } catch { /* @silent-fallback-ok — empty evidence fails maturation closed as insufficient evidence */ return []; }
   }
 
   recordMaturationEvaluation(record: MaturationEvaluationRecord): boolean {
@@ -181,7 +181,7 @@ export class BlockerLifecycleLedger {
           record.passingMetrics, record.totalMetrics, record.minNormalizedMargin, record.contractHash,
           record.newestEvidenceAtMs, record.additionalMissedSlots ?? 0);
       return true;
-    } catch { return false; }
+    } catch { /* @silent-fallback-ok — false makes the failed evaluation write explicit to the caller */ return false; }
   }
 
   maturationEvaluations(origin: string, sinceMs: number): MaturationEvaluationRecord[] {
@@ -193,7 +193,7 @@ export class BlockerLifecycleLedger {
         newest_evidence_at_ms AS newestEvidenceAtMs,additional_missed_slots AS additionalMissedSlots
         FROM maturation_evaluations WHERE origin=? AND due_slot_ms>=?
         ORDER BY feature_id,due_slot_ms`).all(origin, Math.round(sinceMs)) as MaturationEvaluationRecord[];
-    } catch { return []; }
+    } catch { /* @silent-fallback-ok — empty history is surfaced as unevaluated/missed cadence */ return []; }
   }
 
   prune(): number {

--- a/src/monitoring/BlockerLifecycleLedger.ts
+++ b/src/monitoring/BlockerLifecycleLedger.ts
@@ -30,6 +30,22 @@ export interface BlockerLedgerCounters {
   reconciled: number;
 }
 
+export type MaturationMetricSource = 'blocker-summary' | 'blocker-trend';
+export type MaturationEvaluationStatus = 'ready' | 'hold' | 'stale-evidence' | 'insufficient-evidence' | 'missing-contract' | 'missed-cadence';
+
+export interface MaturationMetricObservation {
+  origin: string; featureId: string; metricId: string; source: MaturationMetricSource;
+  sourceRef: string; observedAtMs: number; value: number; samples: number;
+  descriptorVersion?: number; benchmarkRef?: string;
+}
+
+export interface MaturationEvaluationRecord {
+  origin: string; featureId: string; rung: string; dueSlotMs: number; evaluatedAtMs: number;
+  status: MaturationEvaluationStatus; passingMetrics: number; totalMetrics: number;
+  minNormalizedMargin: number | null; contractHash: string; newestEvidenceAtMs: number | null;
+  additionalMissedSlots?: number;
+}
+
 export class BlockerLifecycleLedger {
   private db: BetterSqliteDatabase | null = null;
   private unregisterSqlite: (() => void) | null = null;
@@ -60,6 +76,26 @@ export class BlockerLifecycleLedger {
         );
         CREATE INDEX IF NOT EXISTS idx_blocker_lifecycle_window
           ON blocker_lifecycle_metrics(factor, observed_at_ms);
+        CREATE TABLE IF NOT EXISTS maturation_metric_observations (
+          origin TEXT NOT NULL, feature_id TEXT NOT NULL, metric_id TEXT NOT NULL,
+          source TEXT NOT NULL CHECK (source IN ('blocker-summary','blocker-trend')),
+          source_ref TEXT NOT NULL, observed_at_ms INTEGER NOT NULL, value REAL NOT NULL,
+          samples INTEGER NOT NULL, descriptor_version INTEGER NOT NULL DEFAULT 1,
+          benchmark_ref TEXT, schema_version INTEGER NOT NULL DEFAULT 1,
+          UNIQUE(origin,feature_id,metric_id,source,source_ref,observed_at_ms)
+        );
+        CREATE INDEX IF NOT EXISTS idx_maturation_observation_latest ON maturation_metric_observations
+          (origin,feature_id,metric_id,source,source_ref,observed_at_ms DESC);
+        CREATE TABLE IF NOT EXISTS maturation_evaluations (
+          origin TEXT NOT NULL, feature_id TEXT NOT NULL, rung TEXT NOT NULL,
+          due_slot_ms INTEGER NOT NULL, evaluated_at_ms INTEGER NOT NULL, status TEXT NOT NULL,
+          passing_metrics INTEGER NOT NULL, total_metrics INTEGER NOT NULL,
+          min_normalized_margin REAL, contract_hash TEXT NOT NULL, newest_evidence_at_ms INTEGER,
+          additional_missed_slots INTEGER NOT NULL DEFAULT 0, schema_version INTEGER NOT NULL DEFAULT 1,
+          UNIQUE(origin,feature_id,due_slot_ms)
+        );
+        CREATE INDEX IF NOT EXISTS idx_maturation_evaluation_trend ON maturation_evaluations
+          (origin,feature_id,due_slot_ms DESC);
       `);
     } catch { // @silent-fallback-ok — availability is exposed as 503/guard degradation
       this.db = null;
@@ -106,6 +142,60 @@ export class BlockerLifecycleLedger {
     } catch { /* @silent-fallback-ok — empty read pairs with degraded guard counters */ return []; }
   }
 
+  recordMaturationObservation(record: MaturationMetricObservation): boolean {
+    if (!this.db || !Number.isFinite(record.value) || !Number.isFinite(record.observedAtMs) ||
+        !Number.isInteger(record.samples) || record.samples < 0 || record.samples > 100_000 ||
+        !/^[a-z0-9][a-z0-9-]{0,62}$/.test(record.featureId) || !/^[a-z0-9][a-z0-9-]{0,62}$/.test(record.metricId) ||
+        record.sourceRef.length > 128 || (record.benchmarkRef?.length ?? 0) > 128) return false;
+    const now = this.opts.now?.() ?? Date.now();
+    if (record.observedAtMs < now - 90 * 86_400_000 || record.observedAtMs > now + 300_000) return false;
+    try {
+      this.db.prepare(`INSERT OR IGNORE INTO maturation_metric_observations
+        (origin,feature_id,metric_id,source,source_ref,observed_at_ms,value,samples,descriptor_version,benchmark_ref)
+        VALUES (?,?,?,?,?,?,?,?,?,?)`).run(record.origin, record.featureId, record.metricId, record.source,
+          record.sourceRef, Math.round(record.observedAtMs), record.value, record.samples,
+          record.descriptorVersion ?? 1, record.benchmarkRef ?? null);
+      return true;
+    } catch { return false; }
+  }
+
+  maturationObservations(origin: string, sinceMs: number): MaturationMetricObservation[] {
+    if (!this.db) return [];
+    try {
+      return this.db.prepare(`SELECT origin,feature_id AS featureId,metric_id AS metricId,source,
+        source_ref AS sourceRef,observed_at_ms AS observedAtMs,value,samples,
+        descriptor_version AS descriptorVersion,benchmark_ref AS benchmarkRef
+        FROM maturation_metric_observations WHERE origin=? AND observed_at_ms>=?
+        ORDER BY observed_at_ms DESC LIMIT 8192`).all(origin, Math.round(sinceMs)) as MaturationMetricObservation[];
+    } catch { return []; }
+  }
+
+  recordMaturationEvaluation(record: MaturationEvaluationRecord): boolean {
+    if (!this.db) return false;
+    try {
+      this.db.prepare(`INSERT OR IGNORE INTO maturation_evaluations
+        (origin,feature_id,rung,due_slot_ms,evaluated_at_ms,status,passing_metrics,total_metrics,
+         min_normalized_margin,contract_hash,newest_evidence_at_ms,additional_missed_slots)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`).run(record.origin, record.featureId, record.rung,
+          Math.round(record.dueSlotMs), Math.round(record.evaluatedAtMs), record.status,
+          record.passingMetrics, record.totalMetrics, record.minNormalizedMargin, record.contractHash,
+          record.newestEvidenceAtMs, record.additionalMissedSlots ?? 0);
+      return true;
+    } catch { return false; }
+  }
+
+  maturationEvaluations(origin: string, sinceMs: number): MaturationEvaluationRecord[] {
+    if (!this.db) return [];
+    try {
+      return this.db.prepare(`SELECT origin,feature_id AS featureId,rung,due_slot_ms AS dueSlotMs,
+        evaluated_at_ms AS evaluatedAtMs,status,passing_metrics AS passingMetrics,total_metrics AS totalMetrics,
+        min_normalized_margin AS minNormalizedMargin,contract_hash AS contractHash,
+        newest_evidence_at_ms AS newestEvidenceAtMs,additional_missed_slots AS additionalMissedSlots
+        FROM maturation_evaluations WHERE origin=? AND due_slot_ms>=?
+        ORDER BY feature_id,due_slot_ms`).all(origin, Math.round(sinceMs)) as MaturationEvaluationRecord[];
+    } catch { return []; }
+  }
+
   prune(): number {
     if (!this.db) return 0;
     try {
@@ -116,7 +206,12 @@ export class BlockerLifecycleLedger {
       const excess = Math.max(0, count - 250_000);
       const cap = excess > 0 ? this.db.prepare(`DELETE FROM blocker_lifecycle_metrics WHERE rowid IN
         (SELECT rowid FROM blocker_lifecycle_metrics ORDER BY observed_at_ms LIMIT ?)`).run(Math.min(1000, excess)).changes : 0;
-      return old + cap;
+      const maturationCutoff = (this.opts.now?.() ?? Date.now()) - 90 * 86_400_000;
+      const observations = this.db.prepare(`DELETE FROM maturation_metric_observations WHERE rowid IN
+        (SELECT rowid FROM maturation_metric_observations WHERE observed_at_ms<? LIMIT 1000)`).run(maturationCutoff).changes;
+      const evaluations = this.db.prepare(`DELETE FROM maturation_evaluations WHERE rowid IN
+        (SELECT rowid FROM maturation_evaluations WHERE due_slot_ms<? LIMIT 1000)`).run(maturationCutoff).changes;
+      return old + cap + observations + evaluations;
     } catch { /* @silent-fallback-ok — pruning retries on the next bounded pass */ return 0; }
   }
 

--- a/src/monitoring/BlockerLifecycleService.ts
+++ b/src/monitoring/BlockerLifecycleService.ts
@@ -1,14 +1,19 @@
 import type { CommitmentTracker, BlockerEpisode } from './CommitmentTracker.js';
-import { BlockerLifecycleLedger, percentile, type BlockerFactor, type BlockerMetricRecord } from './BlockerLifecycleLedger.js';
+import crypto from 'node:crypto';
+import type { Initiative, MaturationEvaluationContract } from '../core/InitiativeTracker.js';
+import type { InitiativeTracker } from '../core/InitiativeTracker.js';
+import { BlockerLifecycleLedger, percentile, type BlockerFactor, type BlockerMetricRecord, type MaturationEvaluationRecord, type MaturationEvaluationStatus } from './BlockerLifecycleLedger.js';
 
 type FailureReason = 'insufficient-days' | 'insufficient-samples' | 'zero-denominator';
 
 export class BlockerLifecycleService {
   private cursor = 0;
   private timer: ReturnType<typeof setTimeout> | null = null;
+  private maturationTimer: ReturnType<typeof setInterval> | null = null;
   private failures = 0;
   private breakerUntil = 0;
   private closed = false;
+  private maturationInitiatives: Initiative[] = [];
   private readonly onRequest = (event: Record<string, unknown>): void => {
     this.ledger.enqueue({
       origin: this.origin,
@@ -31,10 +36,17 @@ export class BlockerLifecycleService {
     readonly ledger: BlockerLifecycleLedger,
     private readonly origin: string,
     private readonly now: () => number = () => Date.now(),
+    initiativeTracker?: Pick<InitiativeTracker, 'list'>,
   ) {
     tracker.on('blocker-request-persisted', this.onRequest);
     tracker.on('blocker-episode-closed', this.onClose);
     this.schedule(5_000);
+    if (initiativeTracker) {
+      const evaluate = () => { try { this.evaluateMaturation(initiativeTracker.list()); } catch { /* measure-only */ } };
+      setTimeout(evaluate, 10_000).unref?.();
+      this.maturationTimer = setInterval(evaluate, 6 * 60 * 60 * 1000);
+      this.maturationTimer.unref?.();
+    }
   }
 
   available(): boolean { return this.ledger.available(); }
@@ -44,6 +56,7 @@ export class BlockerLifecycleService {
     return {
       machineId: this.origin,
       factors: (['request-to-persist', 'clear-latency'] as const).map(f => this.factorSummary(f, sinceMs)),
+      maturation: this.maturationSummary(sinceMs),
       counters: { ...this.ledger.counters(), ...this.derivedCounters(sinceMs), breakerOpen: this.now() < this.breakerUntil },
     };
   }
@@ -53,7 +66,112 @@ export class BlockerLifecycleService {
     return {
       machineId: this.origin,
       factors: (['request-to-persist', 'clear-latency'] as const).map(f => this.factorTrend(f, sinceMs)),
+      maturation: this.maturationTrend(sinceMs),
     };
+  }
+
+  /** D7 recurring scorer. Called only by the existing rollout reconciler cadence. */
+  evaluateMaturation(initiatives: Initiative[]): { eligible: number; inserted: number } {
+    const now = this.now();
+    const eligible = initiatives.filter(i => i.rollout && i.rollout.stage !== 'default-on')
+      .sort((a, b) => a.id.localeCompare(b.id)).slice(0, 512);
+    this.maturationInitiatives = eligible.map(i => ({ ...i, rollout: i.rollout ? { ...i.rollout } : undefined }));
+    let inserted = 0;
+    for (const initiative of eligible) {
+      const contract = initiative.rollout?.maturationEvaluation;
+      const cadenceHours = contract?.cadenceHours ?? 6;
+      const cadenceMs = cadenceHours * 3_600_000;
+      const dueSlotMs = Math.floor(now / cadenceMs) * cadenceMs;
+      const previous = this.ledger.maturationEvaluations(this.origin, now - 90 * 86_400_000)
+        .filter(r => r.featureId === initiative.id).sort((a, b) => b.dueSlotMs - a.dueSlotMs)[0];
+      if (previous && previous.dueSlotMs < dueSlotMs - cadenceMs) {
+        const missed = Math.floor((dueSlotMs - previous.dueSlotMs) / cadenceMs) - 1;
+        const explicit = Math.min(4, missed);
+        for (let n = explicit; n >= 1; n--) {
+          const slot = dueSlotMs - n * cadenceMs;
+          if (this.ledger.recordMaturationEvaluation({ origin: this.origin, featureId: initiative.id,
+            rung: initiative.rollout!.stage, dueSlotMs: slot, evaluatedAtMs: now, status: 'missed-cadence',
+            passingMetrics: 0, totalMetrics: contract?.metrics.length ?? 0, minNormalizedMargin: null,
+            contractHash: this.contractHash(contract), newestEvidenceAtMs: null,
+            additionalMissedSlots: n === explicit ? Math.max(0, missed - explicit) : 0 })) inserted++;
+        }
+      }
+      if (!contract) {
+        if (this.ledger.recordMaturationEvaluation({ origin: this.origin, featureId: initiative.id,
+          rung: initiative.rollout!.stage, dueSlotMs, evaluatedAtMs: now, status: 'missing-contract',
+          passingMetrics: 0, totalMetrics: 0, minNormalizedMargin: null, contractHash: 'missing', newestEvidenceAtMs: null })) inserted++;
+        continue;
+      }
+      this.captureBlockerObservations(initiative.id, contract, now);
+      const observations = this.ledger.maturationObservations(this.origin, now - contract.evidenceMaxAgeHours * 3_600_000);
+      const latest = new Map<string, (typeof observations)[number]>();
+      for (const row of observations) if (row.featureId === initiative.id && !latest.has(row.metricId)) latest.set(row.metricId, row);
+      let status: MaturationEvaluationStatus = 'ready';
+      let passing = 0; let newest: number | null = null; const margins: number[] = [];
+      for (const metric of contract.metrics) {
+        const row = latest.get(metric.id);
+        if (!row || row.samples < metric.minSamples) { status = 'insufficient-evidence'; continue; }
+        newest = Math.max(newest ?? 0, row.observedAtMs);
+        if (now - row.observedAtMs > contract.evidenceMaxAgeHours * 3_600_000) { if (status === 'ready') status = 'stale-evidence'; continue; }
+        const margin = metric.direction === 'at-least'
+          ? (row.value - metric.threshold) / Math.max(Math.abs(metric.threshold), 1)
+          : (metric.threshold - row.value) / Math.max(Math.abs(metric.threshold), 1);
+        margins.push(Math.max(-1, Math.min(1, margin)));
+        if (margin >= 0) passing++; else if (status === 'ready') status = 'hold';
+      }
+      if (status === 'ready' && passing < contract.metrics.length) status = 'insufficient-evidence';
+      if (this.ledger.recordMaturationEvaluation({ origin: this.origin, featureId: initiative.id,
+        rung: initiative.rollout!.stage, dueSlotMs, evaluatedAtMs: now, status, passingMetrics: passing,
+        totalMetrics: contract.metrics.length, minNormalizedMargin: margins.length ? Math.min(...margins) : null,
+        contractHash: this.contractHash(contract), newestEvidenceAtMs: newest })) inserted++;
+    }
+    return { eligible: eligible.length, inserted };
+  }
+
+  private contractHash(contract: MaturationEvaluationContract | undefined): string {
+    if (!contract) return 'missing';
+    return crypto.createHash('sha256').update(JSON.stringify(contract)).digest('hex');
+  }
+
+  private captureBlockerObservations(featureId: string, contract: MaturationEvaluationContract, now: number): void {
+    const summaries = new Map((['request-to-persist', 'clear-latency'] as const).map(f => [f, this.factorSummary(f, now - 168 * 3_600_000)]));
+    const trends = new Map((['request-to-persist', 'clear-latency'] as const).map(f => [f, this.factorTrend(f, now - 90 * 86_400_000)]));
+    for (const metric of contract.metrics) {
+      const [factor, field] = metric.sourceRef.split('.') as [BlockerFactor, string];
+      const source = metric.source === 'blocker-summary' ? summaries.get(factor) : trends.get(factor);
+      const value = source?.[field === 'p95Ms' ? 'p95Ms' : field] as number | null | undefined;
+      const samples = metric.source === 'blocker-summary' ? Number(source?.completed ?? 0)
+        : Number((source?.secondHalf as { samples?: number } | undefined)?.samples ?? 0);
+      if (typeof value === 'number' && Number.isFinite(value)) this.ledger.recordMaturationObservation({
+        origin: this.origin, featureId, metricId: metric.id, source: metric.source,
+        sourceRef: metric.sourceRef, observedAtMs: now, value, samples,
+      });
+    }
+  }
+
+  private maturationSummary(sinceMs: number): Record<string, unknown> {
+    const rows = this.ledger.maturationEvaluations(this.origin, sinceMs);
+    const latest = new Map<string, MaturationEvaluationRecord>();
+    for (const row of rows) latest.set(row.featureId, row);
+    const byStatus: Record<MaturationEvaluationStatus, number> = { ready: 0, hold: 0, 'stale-evidence': 0,
+      'insufficient-evidence': 0, 'missing-contract': 0, 'missed-cadence': 0 };
+    for (const row of rows) byStatus[row.status]++;
+    const features = [...latest.values()].sort((a, b) => a.featureId.localeCompare(b.featureId)).map(r => ({
+      featureId: r.featureId, rung: r.rung, status: r.status, evaluatedAt: new Date(r.evaluatedAtMs).toISOString(),
+      passingMetrics: r.passingMetrics, totalMetrics: r.totalMetrics,
+      minNormalizedMargin: r.minNormalizedMargin, newestEvidenceAt: r.newestEvidenceAtMs ? new Date(r.newestEvidenceAtMs).toISOString() : null,
+    }));
+    return { eligible: this.maturationInitiatives.length, evaluated: latest.size,
+      missedDue: Math.max(0, this.maturationInitiatives.length - latest.size), byStatus, features };
+  }
+
+  private maturationTrend(sinceMs: number): Record<string, unknown> {
+    const rows = this.ledger.maturationEvaluations(this.origin, sinceMs);
+    const grouped = new Map<string, MaturationEvaluationRecord[]>();
+    for (const row of rows) { const values = grouped.get(row.featureId) ?? []; values.push(row); grouped.set(row.featureId, values); }
+    return { features: [...grouped.entries()].slice(0, 512).map(([featureId, values]) => ({ featureId,
+      evaluations: values.slice(-90).map(v => ({ day: new Date(v.dueSlotMs).toISOString().slice(0, 10), rung: v.rung,
+        status: v.status, minNormalizedMargin: v.minNormalizedMargin, contractHash: v.contractHash })) })) };
   }
 
   guardStatus(): Record<string, unknown> {
@@ -72,6 +190,7 @@ export class BlockerLifecycleService {
   close(): void {
     this.closed = true;
     if (this.timer) clearTimeout(this.timer);
+    if (this.maturationTimer) clearInterval(this.maturationTimer);
     this.tracker.off('blocker-request-persisted', this.onRequest);
     this.tracker.off('blocker-episode-closed', this.onClose);
     this.ledger.close();

--- a/src/monitoring/BlockerLifecycleService.ts
+++ b/src/monitoring/BlockerLifecycleService.ts
@@ -42,7 +42,7 @@ export class BlockerLifecycleService {
     tracker.on('blocker-episode-closed', this.onClose);
     this.schedule(5_000);
     if (initiativeTracker) {
-      const evaluate = () => { try { this.evaluateMaturation(initiativeTracker.list()); } catch { /* measure-only */ } };
+      const evaluate = () => { try { this.evaluateMaturation(initiativeTracker.list()); } catch { /* @silent-fallback-ok — the absent durable slot is surfaced as missed cadence on the next successful pass */ } };
       setTimeout(evaluate, 10_000).unref?.();
       this.maturationTimer = setInterval(evaluate, 6 * 60 * 60 * 1000);
       this.maturationTimer.unref?.();

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -1670,6 +1670,8 @@ export class AgentServer {
           options.commitmentTracker,
           ledger,
           options.meshSelfId ?? options.config.projectName,
+          undefined,
+          options.initiativeTracker,
         );
         options.guardRegistry?.register('monitoring.blockerLifecycleLedger.enabled', () =>
           this.blockerLifecycleService?.guardStatus() as { enabled: boolean });

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -24960,6 +24960,32 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     }
     return out;
   };
+  const sanitizeMaturation = (kind: 'summary' | 'trend', raw: unknown): Record<string, unknown> | null => {
+    if (!raw || typeof raw !== 'object') return null;
+    const m = raw as Record<string, unknown>;
+    if (kind === 'summary') {
+      if (!['eligible', 'evaluated', 'missedDue'].every(k => Number.isSafeInteger(m[k]) && (m[k] as number) >= 0) ||
+          !m.byStatus || typeof m.byStatus !== 'object' || !Array.isArray(m.features) || m.features.length > 512) return null;
+      const statuses = ['ready', 'hold', 'stale-evidence', 'insufficient-evidence', 'missing-contract', 'missed-cadence'];
+      const byStatus = m.byStatus as Record<string, unknown>;
+      if (!statuses.every(k => Number.isSafeInteger(byStatus[k]) && (byStatus[k] as number) >= 0)) return null;
+      const features = m.features.map(v => {
+        if (!v || typeof v !== 'object') return null;
+        const f = v as Record<string, unknown>;
+        if (typeof f.featureId !== 'string' || f.featureId.length > 63 || typeof f.rung !== 'string' ||
+            !statuses.includes(String(f.status)) || !Number.isSafeInteger(f.passingMetrics) || !Number.isSafeInteger(f.totalMetrics) ||
+            !(f.minNormalizedMargin === null || (typeof f.minNormalizedMargin === 'number' && Number.isFinite(f.minNormalizedMargin)))) return null;
+        return { featureId: f.featureId, rung: f.rung, status: f.status, evaluatedAt: f.evaluatedAt,
+          passingMetrics: f.passingMetrics, totalMetrics: f.totalMetrics,
+          minNormalizedMargin: f.minNormalizedMargin, newestEvidenceAt: f.newestEvidenceAt ?? null };
+      });
+      if (features.some(v => v === null)) return null;
+      return { eligible: m.eligible, evaluated: m.evaluated, missedDue: m.missedDue,
+        byStatus: Object.fromEntries(statuses.map(k => [k, byStatus[k]])), features };
+    }
+    if (!Array.isArray(m.features) || m.features.length > 512) return null;
+    return { features: m.features.slice(0, 512) };
+  };
   const blockerPoolRead = async (kind: 'summary' | 'trend', query: string, local: Record<string, unknown>) => {
     const cacheKey = `${kind}?${query}`;
     const cached = blockerPoolCache.get(cacheKey);
@@ -24992,13 +25018,17 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
           if (!origin || typeof origin !== 'object') { failures.push({ machineId: p.machineId, reason: 'invalid-body' }); return; }
           const candidate = origin as Record<string, unknown>;
           const factors = sanitizeBlockerFactors(kind, candidate.factors);
+          const maturation = sanitizeMaturation(kind, candidate.maturation);
           const counters = kind === 'summary' ? sanitizeBlockerCounters(candidate.counters) : null;
+          if (!maturation) {
+            failures.push({ machineId: p.machineId, reason: 'unsupported-maturation' }); return;
+          }
           if (!factors || (kind === 'summary' && !counters)) {
             failures.push({ machineId: p.machineId, reason: 'invalid-body' }); return;
           }
           const sanitized = kind === 'summary'
-            ? { machineId: p.machineId, factors, counters }
-            : { machineId: p.machineId, factors };
+            ? { machineId: p.machineId, factors, maturation, counters }
+            : { machineId: p.machineId, factors, maturation };
           const bytes = Buffer.byteLength(JSON.stringify(sanitized));
           if (responseBytes + bytes > 4 * 1024 * 1024) { failures.push({ machineId: p.machineId, reason: 'truncated' }); return; }
           responseBytes += bytes;

--- a/tests/unit/BlockerLifecycleLedger.test.ts
+++ b/tests/unit/BlockerLifecycleLedger.test.ts
@@ -28,4 +28,32 @@ describe('BlockerLifecycleLedger', () => {
     expect(percentile([9, 1, 5, 3], 0.5)).toBe(3);
     expect(percentile([9, 1, 5, 3], 0.95)).toBe(9);
   });
+
+  it('stores maturation observations and one immutable evaluation per feature slot', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'blocker-ledger-')); dirs.push(dir);
+    const now = 2_000_000_000_000;
+    const ledger = new BlockerLifecycleLedger({ dbPath: path.join(dir, 'ledger.db'), now: () => now });
+    expect(ledger.recordMaturationObservation({ origin: 'm1', featureId: 'feature-a', metricId: 'coverage',
+      source: 'blocker-summary', sourceRef: 'clear-latency.coverage', observedAtMs: now,
+      value: 0.99, samples: 100 })).toBe(true);
+    expect(ledger.maturationObservations('m1', now - 1)).toHaveLength(1);
+    const row = { origin: 'm1', featureId: 'feature-a', rung: 'dark', dueSlotMs: now,
+      evaluatedAtMs: now, status: 'ready' as const, passingMetrics: 1, totalMetrics: 1,
+      minNormalizedMargin: 0.01, contractHash: 'abc', newestEvidenceAtMs: now };
+    expect(ledger.recordMaturationEvaluation(row)).toBe(true);
+    expect(ledger.recordMaturationEvaluation({ ...row, status: 'hold' })).toBe(true);
+    expect(ledger.maturationEvaluations('m1', now - 1)).toEqual([expect.objectContaining({ status: 'ready', featureId: 'feature-a' })]);
+    ledger.close();
+  });
+
+  it('rejects invalid and future maturation observations', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'blocker-ledger-')); dirs.push(dir);
+    const now = 2_000_000_000_000;
+    const ledger = new BlockerLifecycleLedger({ dbPath: path.join(dir, 'ledger.db'), now: () => now });
+    expect(ledger.recordMaturationObservation({ origin: 'm1', featureId: 'bad id', metricId: 'm',
+      source: 'blocker-summary', sourceRef: 'x', observedAtMs: now, value: 1, samples: 1 })).toBe(false);
+    expect(ledger.recordMaturationObservation({ origin: 'm1', featureId: 'ok', metricId: 'm',
+      source: 'blocker-summary', sourceRef: 'x', observedAtMs: now + 300_001, value: 1, samples: 1 })).toBe(false);
+    ledger.close();
+  });
 });

--- a/tests/unit/BlockerLifecycleMaturation.test.ts
+++ b/tests/unit/BlockerLifecycleMaturation.test.ts
@@ -1,0 +1,46 @@
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { BlockerLifecycleLedger } from '../../src/monitoring/BlockerLifecycleLedger.js';
+import { BlockerLifecycleService } from '../../src/monitoring/BlockerLifecycleService.js';
+import type { CommitmentTracker } from '../../src/monitoring/CommitmentTracker.js';
+import type { Initiative } from '../../src/core/InitiativeTracker.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('BlockerLifecycleService maturation evaluation', () => {
+  const dirs: string[] = [];
+  afterEach(() => dirs.splice(0).forEach(dir => SafeFsExecutor.safeRmSync(dir, {
+    recursive: true, force: true, operation: 'tests/unit/BlockerLifecycleMaturation.test.ts',
+  })));
+
+  it('evaluates every non-terminal rollout, including missing evidence and contract', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'maturation-service-')); dirs.push(dir);
+    const now = 2_000_000_000_000;
+    const ledger = new BlockerLifecycleLedger({ dbPath: path.join(dir, 'ledger.db'), now: () => now });
+    const events = new EventEmitter() as EventEmitter & { getAll(): never[]; update(): Promise<boolean>; getBlockerEpisodeDropBuckets(): Record<string, never> };
+    events.getAll = () => [];
+    events.update = async () => true;
+    events.getBlockerEpisodeDropBuckets = () => ({});
+    const service = new BlockerLifecycleService(events as unknown as CommitmentTracker, ledger, 'm1', () => now);
+    const base = { title: 'x', description: 'x', status: 'active', phases: [], currentPhaseIndex: 0,
+      lastTouchedAt: new Date(now).toISOString(), needsUser: false, blockers: [], links: [],
+      createdAt: new Date(now).toISOString(), updatedAt: new Date(now).toISOString(), kind: 'task' } as const;
+    const initiatives = [
+      { ...base, id: 'with-contract', rollout: { flagPath: 'x', stage: 'dark', maturationEvaluation: {
+        cadenceHours: 6, evidenceMaxAgeHours: 12, metrics: [{ id: 'coverage', source: 'blocker-summary',
+          sourceRef: 'clear-latency.coverage', direction: 'at-least', threshold: 0.95, minSamples: 1 }],
+      } } },
+      { ...base, id: 'without-contract', rollout: { flagPath: 'y', stage: 'live' } },
+      { ...base, id: 'terminal', rollout: { flagPath: 'z', stage: 'default-on' } },
+    ] as Initiative[];
+    expect(service.evaluateMaturation(initiatives)).toMatchObject({ eligible: 2 });
+    expect(ledger.maturationEvaluations('m1', now - 24 * 3_600_000).map(r => [r.featureId, r.status])).toEqual([
+      ['with-contract', 'insufficient-evidence'], ['without-contract', 'missing-contract'],
+    ]);
+    const summary = service.localSummary(24) as { maturation: { eligible: number; evaluated: number } };
+    expect(summary.maturation).toMatchObject({ eligible: 2, evaluated: 2 });
+    service.close();
+  });
+});

--- a/tests/unit/feature-maturation-contract.test.ts
+++ b/tests/unit/feature-maturation-contract.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { parseMaturationContract } from '../../src/core/featureRolloutScan.js';
+
+describe('parseMaturationContract', () => {
+  it('accepts the closed blocker source registry', () => {
+    const result = parseMaturationContract(JSON.stringify({ cadenceHours: 6, evidenceMaxAgeHours: 12,
+      metrics: [{ id: 'coverage', source: 'blocker-summary', sourceRef: 'clear-latency.coverage',
+        direction: 'at-least', threshold: 0.95, minSamples: 10 }] }));
+    expect(result).toMatchObject({ ok: true, contract: { cadenceHours: 6 } });
+  });
+
+  it('rejects malformed cadence and reserved producer refs', () => {
+    expect(parseMaturationContract('{')).toEqual({ ok: false, error: 'invalid-json' });
+    expect(parseMaturationContract(JSON.stringify({ cadenceHours: 1, evidenceMaxAgeHours: 2, metrics: [] })))
+      .toEqual({ ok: false, error: 'invalid-shape' });
+    expect(parseMaturationContract(JSON.stringify({ cadenceHours: 6, evidenceMaxAgeHours: 12,
+      metrics: [{ id: 'quality', source: 'decision-quality', sourceRef: 'foo', direction: 'at-least', threshold: 1, minSamples: 1 }] })))
+      .toEqual({ ok: false, error: 'invalid-shape' });
+  });
+});

--- a/upgrades/next/feature-maturation-recurring-evaluation.md
+++ b/upgrades/next/feature-maturation-recurring-evaluation.md
@@ -1,0 +1,24 @@
+# Feature maturation now re-checks measurable evidence on a cadence
+
+## What Changed
+
+- Added bounded per-feature maturation metric contracts to existing rollout records.
+- Extended the existing blocker-lifecycle metrics database and summary/trend surfaces with recurring per-feature evaluation snapshots.
+- Every dark, dry-run, or live rollout now receives an explicit ready, hold, stale, insufficient, missing-contract, or missed-cadence result on the development-agent measurement substrate.
+- Evaluation is measure-only: it cannot enable a feature, advance a rollout, or send a notification.
+
+## What to Tell Your User
+
+Instar can now show whether each feature that is still dark or soaking has fresh, measurable evidence for its next rollout step. Missing or stale evidence stays visible instead of quietly aging out, while promotion remains an operator-controlled decision.
+
+## Summary of New Capabilities
+
+- Track numeric maturation criteria per staged feature.
+- Re-score every active rollout on a recurring cadence.
+- Read per-machine maturation status and history through the existing blocker-lifecycle summary and trend surfaces.
+
+## Evidence
+
+- Focused ledger, scorer, contract-parser, rollout-reconciler, canonical-scan, and lifecycle e2e tests pass.
+- TypeScript and repository lint pass.
+- The duplicate-safety audit preserves the blocker ledger's exactly-two latency factors and prohibits a parallel maturation ledger.

--- a/upgrades/side-effects/feature-maturation-recurring-evaluation.md
+++ b/upgrades/side-effects/feature-maturation-recurring-evaluation.md
@@ -22,7 +22,7 @@ Compliant. Metric comparisons are deterministic signals. They cannot write Initi
 
 ## 5. Failure and rollback
 
-Malformed contracts become missing-contract signals; invalid/future observations are rejected; unavailable SQLite degrades reads and guard health. Disable the existing blocker-lifecycle gate or revert the change. Additive rows become inert and require no destructive rollback.
+Malformed contracts become missing-contract signals; invalid/future observations are rejected; unavailable SQLite degrades reads and guard health. Observation/evaluation write failures return false, and read failures return empty evidence that deterministically becomes insufficient evidence or missed cadence; these fail-soft boundaries are explicitly marked for the repository fallback audit. Disable the existing blocker-lifecycle gate or revert the change. Additive rows become inert and require no destructive rollback.
 
 ## 6. Security and privacy
 

--- a/upgrades/side-effects/feature-maturation-recurring-evaluation.md
+++ b/upgrades/side-effects/feature-maturation-recurring-evaluation.md
@@ -1,0 +1,37 @@
+# Side-effects review — feature maturation recurring evaluation
+
+## Scope
+
+Adds measure-only per-feature observation/evaluation rows to the existing blocker-lifecycle SQLite owner, extends existing rollout metadata, and adds bounded maturation fields to existing summary/trend responses.
+
+## 1. State and persistence
+
+Two additive tables share the existing SQLite handle, WAL policy, close path, registry, 90-day retention, and bounded prune pass. No authoritative rollout or feature state moves into telemetry. Rollout records gain one optional validated contract; old records remain valid.
+
+## 2. Runtime and performance
+
+One boot-delayed and six-hour unref'd evaluation timer runs only when the existing blocker-lifecycle development gate resolves on and an InitiativeTracker is injected. A pass is capped at 512 features and 16 metrics per feature. Reads and writes are indexed and fail-soft; measurement cannot block server boot or feature behavior.
+
+## 3. External and user-visible effects
+
+No outbound message, attention item, external API, model call, flag mutation, or rollout promotion is added. Existing summary/trend JSON gains additive `maturation` fields. Pool peers that predate the field are reported as unsupported rather than as healthy zeros.
+
+## 4. Signal versus authority
+
+Compliant. Metric comparisons are deterministic signals. They cannot write InitiativeTracker, configuration, standards, approvals, or feature flags. Existing human/config promotion authority is unchanged.
+
+## 5. Failure and rollback
+
+Malformed contracts become missing-contract signals; invalid/future observations are rejected; unavailable SQLite degrades reads and guard health. Disable the existing blocker-lifecycle gate or revert the change. Additive rows become inert and require no destructive rollback.
+
+## 6. Security and privacy
+
+Rows contain bounded feature/metric ids, numeric values, sample counts, source enums/refs, stages, hashes, and timestamps only. They contain no prose, prompt, log content, topic/user id, path, credential, or URL. Pool responses remain authenticated and machine-tagged.
+
+## 7. Multi-machine behavior
+
+Measurements remain per-origin because feature traffic and model routing can differ by runtime. The existing authenticated pool read projects tagged origins without a fleet aggregate, so one machine cannot hide another's missing evidence.
+
+## Review conclusion
+
+Concur. The change extends the intended owners, is bounded and reversible, and introduces no new actuation authority.


### PR DESCRIPTION
## ELI16 — Dark features now get regular evidence checkups

Instar often releases a feature in a safe testing state before making it available everywhere. Until now, that feature could remain there with an old or vague idea of what “ready” means. This change lets each feature declare numeric health checks and revisits them every six hours. Missing data, stale data, failed targets, and missed checkups are shown separately instead of being mistaken for success. The result is advice only: Instar cannot turn the feature on or advance its rollout from these scores.

## Implementation

This extends the existing InitiativeTracker rollout records and BlockerLifecycleLedger SQLite/summary/trend substrate. The exactly-two blocker latency factors remain unchanged; maturation uses an additive sibling table, not a parallel engine.

## Evidence

Six convergence rounds with GPT and Gemini; focused post-rebase tests 22/22; type, lint, instar-dev hooks, rollout lifecycle, and canonical scan tests green. One unrelated broad-suite messaging timeout reproduced green in isolation.