### PR TITLE
feat: add general claim verdict metrics

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-21T20-23-21-641Z-claim-verification-general-verdict-metrics.json
+++ b/.instar/instar-dev-decisions/2026-07-21T20-23-21-641Z-claim-verification-general-verdict-metrics.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T20:23:21.641Z",
+  "slug": "claim-verification-general-verdict-metrics",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 56,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-21T21-29-17-383Z-claim-verification-general-verdict-metrics.json
+++ b/.instar/instar-dev-decisions/2026-07-21T21-29-17-383Z-claim-verification-general-verdict-metrics.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T21:29:17.383Z",
+  "slug": "claim-verification-general-verdict-metrics",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 56,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-21T21-30-29-873Z-claim-verification-general-verdict-metrics.json
+++ b/.instar/instar-dev-decisions/2026-07-21T21-30-29-873Z-claim-verification-general-verdict-metrics.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-21T21:30:29.873Z",
+  "slug": "claim-verification-general-verdict-metrics",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 56,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/CompletionClaimVerifier.ts
+++ b/src/monitoring/CompletionClaimVerifier.ts
@@ -9,7 +9,7 @@ import { ClaimClauseArbiter, type ClaimClauseArbitration } from './ClaimClauseAr
 import { ClaimObservationAdmissionQueue } from './ClaimObservationAdmissionQueue.js';
 import {
   applyClaimCriticalityFloor, assessClaim, prepareClaimObservation, protectedCueGaps,
-  ClaimObservationRecorder, newMessageAttemptId,
+  ClaimObservationRecorder, newMessageAttemptId, type ClaimAssessment, type ClaimCriticality,
 } from './ClaimObservation.js';
 
 export interface CompletionClaim {
@@ -65,8 +65,14 @@ export interface CompletionClaimStats {
   corpusDrops: number;
   retentionFailures: number;
   verdicts: Record<CompletionObservationVerdict, number>;
+  generalVerdicts: Record<ClaimAssessment['verdict'], number>;
+  refutedByCriticality: Record<ClaimCriticality, number>;
+  unverifiableByCriticality: Record<ClaimCriticality, number>;
   updatedAt?: string;
 }
+
+const GENERAL_VERDICTS: ClaimAssessment['verdict'][] = ['supported', 'refuted', 'unverifiable'];
+const CLAIM_CRITICALITIES: ClaimCriticality[] = ['low', 'medium', 'high', 'irreversible-precondition'];
 
 export class CompletionClaimVerifier {
   private readonly arbiter: ClaimClauseArbiter;
@@ -175,6 +181,7 @@ export class CompletionClaimVerifier {
           const assessment = assessClaim(claim, { evidence: prepared.evidence, sessionSnapshot: context.sessionSnapshot,
             commitmentSnapshots: context.commitmentSnapshots, guardSnapshots: context.guardSnapshots });
           const finalCriticality = applyClaimCriticalityFloor(claim);
+          this.bumpGeneralVerdict(assessment.verdict, finalCriticality);
           if (this.opts.recorder && !this.opts.recorder.record({ messageAttemptId, topicId: context.topicId,
             claim, assessment, finalCriticality, dryRun: this.opts.dryRun,
             bootId: this.opts.bootId ?? 'unknown-boot', modelDoor: arbitration.generalModel?.framework,
@@ -263,27 +270,38 @@ export class CompletionClaimVerifier {
     try {
       const parsed = JSON.parse(fs.readFileSync(this.statsFile(), 'utf8')) as Partial<CompletionClaimStats>;
       for (const key of Object.keys(empty) as Array<keyof CompletionClaimStats>) {
-        if (key === 'verdicts' || key === 'updatedAt') continue;
-        if (typeof parsed[key] === 'number' && Number.isFinite(parsed[key]) && (parsed[key] as number) >= 0) {
-          (empty[key] as number) = Math.floor(parsed[key] as number);
-        }
+        if (key === 'verdicts' || key === 'generalVerdicts' || key === 'refutedByCriticality'
+          || key === 'unverifiableByCriticality' || key === 'updatedAt') continue;
+        if (typeof parsed[key] === 'number') (empty[key] as number) = clampCounter(parsed[key] as number);
       }
       if (parsed.verdicts && typeof parsed.verdicts === 'object') for (const verdict of Object.keys(empty.verdicts) as CompletionObservationVerdict[]) {
-        const count = parsed.verdicts[verdict];
-        if (typeof count === 'number' && Number.isFinite(count) && count >= 0) empty.verdicts[verdict] = Math.floor(count);
+        empty.verdicts[verdict] = clampCounter(parsed.verdicts[verdict]);
       }
+      mergeCounterRecord(empty.generalVerdicts, parsed.generalVerdicts, GENERAL_VERDICTS);
+      mergeCounterRecord(empty.refutedByCriticality, parsed.refutedByCriticality, CLAIM_CRITICALITIES);
+      mergeCounterRecord(empty.unverifiableByCriticality, parsed.unverifiableByCriticality, CLAIM_CRITICALITIES);
       if (typeof parsed.updatedAt === 'string') empty.updatedAt = parsed.updatedAt;
     } catch { /* @silent-fallback-ok — counters are signal-only; corrupt/absent state restarts at zero */ }
     return empty;
   }
 
-  private bump(key: Exclude<keyof CompletionClaimStats, 'verdicts' | 'updatedAt'>): void {
-    this.counters[key]++;
+  private bump(key: Exclude<keyof CompletionClaimStats, 'verdicts' | 'generalVerdicts' | 'refutedByCriticality' | 'unverifiableByCriticality' | 'updatedAt'>): void {
+    this.counters[key] = incrementCounter(this.counters[key]);
     this.persistStats();
   }
 
   private bumpVerdict(verdict: CompletionObservationVerdict): void {
-    this.counters.verdicts[verdict]++;
+    this.counters.verdicts[verdict] = incrementCounter(this.counters.verdicts[verdict]);
+    this.persistStats();
+  }
+
+  private bumpGeneralVerdict(verdict: ClaimAssessment['verdict'], criticality: ClaimCriticality): void {
+    this.counters.generalVerdicts[verdict] = incrementCounter(this.counters.generalVerdicts[verdict]);
+    if (verdict === 'refuted') {
+      this.counters.refutedByCriticality[criticality] = incrementCounter(this.counters.refutedByCriticality[criticality]);
+    } else if (verdict === 'unverifiable') {
+      this.counters.unverifiableByCriticality[criticality] = incrementCounter(this.counters.unverifiableByCriticality[criticality]);
+    }
     this.persistStats();
   }
 
@@ -306,7 +324,25 @@ function emptyStats(): CompletionClaimStats {
     falsePositiveDispositions: 0, falseNegativeDispositions: 0, canaryDriftSignals: 0,
     generalAdmittedTurns: 0, generalClaims: 0, protectedCueGaps: 0, coverageIncompleteTurns: 0, corpusDrops: 0, retentionFailures: 0,
     verdicts: { corroborated: 0, 'uncorroborated-contradicted': 0, 'uncorroborated-unknown': 0, 'not-eligible': 0 },
+    generalVerdicts: { supported: 0, refuted: 0, unverifiable: 0 },
+    refutedByCriticality: { low: 0, medium: 0, high: 0, 'irreversible-precondition': 0 },
+    unverifiableByCriticality: { low: 0, medium: 0, high: 0, 'irreversible-precondition': 0 },
   };
+}
+
+function clampCounter(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.min(Number.MAX_SAFE_INTEGER, Math.floor(value)) : 0;
+}
+
+function incrementCounter(value: number): number {
+  return Math.min(Number.MAX_SAFE_INTEGER, value + 1);
+}
+
+function mergeCounterRecord<K extends string>(target: Record<K, number>, source: unknown, keys: readonly K[]): void {
+  if (!source || typeof source !== 'object' || Array.isArray(source)) return;
+  const record = source as Partial<Record<K, unknown>>;
+  for (const key of keys) target[key] = clampCounter(record[key]);
 }
 
 function completionFingerprint(message: string, evidence: TurnEvidence): string {

--- a/tests/integration/metrics-features-routes.test.ts
+++ b/tests/integration/metrics-features-routes.test.ts
@@ -6,15 +6,21 @@
  * 200 + rollup when the ledger is present, 503 when it is null, and the
  * ?feature= filter.
  */
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { createRoutes, type RouteContext } from '../../src/server/routes.js';
 import { FeatureMetricsLedger } from '../../src/monitoring/FeatureMetricsLedger.js';
+import { CompletionClaimVerifier } from '../../src/monitoring/CompletionClaimVerifier.js';
+import type { ExtractedClaim } from '../../src/monitoring/ClaimObservation.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 let ledger: FeatureMetricsLedger | null = null;
 
-function ctxWith(metricsLedger: FeatureMetricsLedger | null): RouteContext {
+function ctxWith(metricsLedger: FeatureMetricsLedger | null, verifier?: CompletionClaimVerifier): RouteContext {
   return {
     config: { projectName: 'test', projectDir: '/tmp', stateDir: '/tmp/.instar', port: 0, sessions: {} as any, scheduler: {} as any } as any,
     sessionManager: { listRunningSessions: () => [] } as any,
@@ -25,14 +31,15 @@ function ctxWith(metricsLedger: FeatureMetricsLedger | null): RouteContext {
     triageNurse: null, topicMemory: null, discoveryEvaluator: null,
     tokenLedger: null,
     featureMetricsLedger: metricsLedger,
+    completionClaimVerifier: verifier ?? null,
     startTime: new Date(),
   } as unknown as RouteContext;
 }
 
-function appWith(metricsLedger: FeatureMetricsLedger | null): express.Express {
+function appWith(metricsLedger: FeatureMetricsLedger | null, verifier?: CompletionClaimVerifier): express.Express {
   const app = express();
   app.use(express.json());
-  app.use('/', createRoutes(ctxWith(metricsLedger)));
+  app.use('/', createRoutes(ctxWith(metricsLedger, verifier)));
   return app;
 }
 
@@ -94,6 +101,37 @@ describe('GET /metrics/features (integration)', () => {
     expect(res.body.features[0].feature).toBe('A');
     // totals still reflect the whole ledger; only the features[] list is filtered.
     expect(res.body.totals.calls).toBe(2);
+  });
+
+  it('surfaces server-admitted-only general refuted and unverifiable-high verdict metrics', async () => {
+    ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claim-metrics-route-'));
+    try {
+      const message = 'The action completed and capacity is four.';
+      const base: ExtractedClaim = {
+        clauseId: 0, kind: 'completion', subjectKind: 'tool-action', predicate: 'tool-action.completed',
+        operand: { type: 'boolean', value: true }, comparator: 'eq',
+        subjectSelector: { type: 'same-turn-action', actionIndex: 0 }, consequence: { relation: 'none', actionClass: 'none' },
+        sourceStartByte: 0, sourceEndByte: Buffer.byteLength(message), referencedEntityHints: [], endorsed: true,
+        negated: false, hedged: false, quoted: false, suggestedCriticality: 'low', confidence: 0.99, tenseScope: 'past',
+      };
+      const claims: ExtractedClaim[] = [base, { ...base, clauseId: 1, kind: 'capacity-limit',
+        subjectKind: 'capacity-model', predicate: 'capacity.limit', operand: { type: 'integer', value: 4, unit: 'lanes' },
+        subjectSelector: { type: 'unresolved' }, tenseScope: 'current' }];
+      const verifier = new CompletionClaimVerifier({ intelligence: {} as any, stateDir, enabled: true,
+        dryRun: true, generalObservation: true, arbiter: { arbitrate: async () => ({
+          authoritative: true, clauses: [], general: { schemaVersion: 1, claims, saturated: false },
+        }) } as any });
+      expect(verifier.enqueue(message, { hadToolCalls: true,
+        toolCalls: [{ tool: 'Bash', actionKind: 'other', ok: false }], truncated: false, unavailable: false, canaryOk: true }))
+        .toEqual({ accepted: true });
+      await vi.waitFor(() => expect(verifier.stats().generalVerdicts.refuted).toBe(1));
+
+      const res = await request(appWith(ledger, verifier)).get('/metrics/features');
+      expect(res.status).toBe(200);
+      expect(res.body.claimVerificationServerAdmittedOnly.generalVerdicts).toMatchObject({ refuted: 1, unverifiable: 1 });
+      expect(res.body.claimVerificationServerAdmittedOnly.unverifiableByCriticality.high).toBe(1);
+    } finally { SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'claim-metrics-route-test' }); }
   });
 });
 

--- a/tests/unit/turn-evidence-completion-verifier.test.ts
+++ b/tests/unit/turn-evidence-completion-verifier.test.ts
@@ -7,7 +7,7 @@ import { CompletionClaimVerifier, decideVerdict } from '../../src/monitoring/Com
 import { CLAIM_ARBITER_PROMPT_ID, buildClaimArbiterPrompt, buildCompletionClaimDecisionContext, ClaimClauseArbiter, parseClauseArbitration, routeActionClaim, splitClaimClauses } from '../../src/monitoring/ClaimClauseArbiter.js';
 import { classifyActionClaim } from '../../src/core/action-claim.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
-import { ClaimObservationRecorder } from '../../src/monitoring/ClaimObservation.js';
+import { ClaimObservationRecorder, type ExtractedClaim } from '../../src/monitoring/ClaimObservation.js';
 
 const user = JSON.stringify({ type: 'user', message: { role: 'user', content: 'do it' } });
 const tool = (id: string, name: string, input: unknown) => JSON.stringify({ message: { role: 'assistant', content: [{ type: 'tool_use', id, name, input }] } });
@@ -236,6 +236,45 @@ describe('CompletionClaimVerifier', () => {
     } finally { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'claim-general-test' }); }
   });
 
+  it('counts known general verdicts and refuted/unverifiable criticality cross-tabs', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claim-general-stats-'));
+    try {
+      const claim = (overrides: Partial<ExtractedClaim>): ExtractedClaim => ({
+        clauseId: 0, kind: 'state-fact', subjectKind: 'session', predicate: 'session.state',
+        operand: { type: 'state-enum', value: 'running', enumVersion: 'v1' }, comparator: 'eq',
+        subjectSelector: { type: 'current-session' }, consequence: { relation: 'none', actionClass: 'none' },
+        sourceStartByte: 0, sourceEndByte: 18, referencedEntityHints: [], endorsed: true, negated: false,
+        hedged: false, quoted: false, suggestedCriticality: 'low', confidence: 0.99, tenseScope: 'current',
+        ...overrides,
+      });
+      const claims: ExtractedClaim[] = [
+        claim({ clauseId: 0 }),
+        claim({ clauseId: 1, kind: 'completion', subjectKind: 'tool-action', predicate: 'tool-action.completed',
+          operand: { type: 'boolean', value: true }, subjectSelector: { type: 'same-turn-action', actionIndex: 0 },
+          tenseScope: 'past' }),
+        claim({ clauseId: 2, kind: 'external-fact', subjectKind: 'external-entity', predicate: 'external.fact',
+          operand: { type: 'none' }, subjectSelector: { type: 'unresolved' }, tenseScope: 'timeless' }),
+        claim({ clauseId: 3, operand: { type: 'state-enum', value: 'stopped', enumVersion: 'v1' },
+          consequence: { relation: 'premise-for', actionClass: 'delete', actionStartByte: 19, actionEndByte: 29 } }),
+      ];
+      const arbiter = { arbitrate: vi.fn().mockResolvedValue({
+        authoritative: true, clauses: [], general: { schemaVersion: 1, claims, saturated: true },
+      }) } as any;
+      const verifier = new CompletionClaimVerifier({ intelligence: {} as any, arbiter, stateDir: dir,
+        enabled: true, dryRun: true, generalObservation: true });
+      await verifier.observe('Session is running. Delete it.', {
+        hadToolCalls: true, toolCalls: [{ tool: 'Bash', actionKind: 'other', ok: false }],
+        truncated: false, unavailable: false, canaryOk: true,
+      }, { sessionSnapshot: { state: 'running', elapsedMs: 1_000, revision: 'r1', observedAt: new Date().toISOString() } });
+
+      expect(verifier.stats()).toMatchObject({
+        generalVerdicts: { supported: 1, refuted: 2, unverifiable: 1 },
+        refutedByCriticality: { low: 0, medium: 0, high: 1, 'irreversible-precondition': 1 },
+        unverifiableByCriticality: { low: 1, medium: 0, high: 0, 'irreversible-precondition': 0 },
+      });
+    } finally { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'claim-general-stats-test' }); }
+  });
+
   it('enqueue returns before the intelligence promise settles', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'completion-detach-'));
     try {
@@ -304,5 +343,25 @@ describe('CompletionClaimVerifier', () => {
       expect(persisted).not.toContain('nothing');
       expect(persisted).not.toContain('zebra-sensitive-target');
     } finally { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'completion-stats-test' }); }
+  });
+
+  it('merges persisted general counters with backward-compatible numeric clamping', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'completion-stats-merge-'));
+    try {
+      fs.mkdirSync(path.join(dir, 'logs'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'logs', 'completion-claim-stats.json'), JSON.stringify({
+        candidateTurns: 4.9,
+        generalVerdicts: { supported: 2.9, refuted: -4, unverifiable: Number.MAX_VALUE },
+        refutedByCriticality: { high: 3.8, 'irreversible-precondition': '9' },
+        unverifiableByCriticality: { low: 1.2, high: null },
+      }));
+      const verifier = new CompletionClaimVerifier({ stateDir: dir, enabled: false, dryRun: true });
+      expect(verifier.stats()).toMatchObject({
+        candidateTurns: 4,
+        generalVerdicts: { supported: 2, refuted: 0, unverifiable: Number.MAX_SAFE_INTEGER },
+        refutedByCriticality: { low: 0, medium: 0, high: 3, 'irreversible-precondition': 0 },
+        unverifiableByCriticality: { low: 1, medium: 0, high: 0, 'irreversible-precondition': 0 },
+      });
+    } finally { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'completion-stats-merge-test' }); }
   });
 });

--- a/upgrades/next/claim-verification-general-verdict-metrics.md
+++ b/upgrades/next/claim-verification-general-verdict-metrics.md
@@ -1,0 +1,23 @@
+# Claim-verification general verdict metrics
+
+## What Changed
+
+Claim verification now records content-free counts for general claim outcomes: supported, refuted, and unverifiable. Refuted and unverifiable totals are also grouped by the final criticality level, including irreversible preconditions. These additive counters live in the existing completion-claim stats file and appear automatically in the existing `/metrics/features` response under `claimVerificationServerAdmittedOnly`.
+
+Persisted counters load safely across upgrades. Missing fields default to zero, while malformed, negative, fractional, non-finite, or oversized values are restored as bounded non-negative safe integers. Claim assessment, criticality floors, delivery, future-claim handling, and action authority are unchanged.
+
+## What to Tell Your User
+
+Instar can now measure how often server-admitted factual claims are supported, refuted, or cannot be verified, including how serious the refuted or unverifiable claims were. This is observation only: it does not block, rewrite, or automatically settle any claim.
+
+## Summary of New Capabilities
+
+- Content-free totals for supported, refuted, and unverifiable general claims.
+- Criticality breakdowns for refuted and unverifiable claims.
+- Backward-compatible, bounded persistence through the existing metrics surface.
+
+## Evidence
+
+- Unit coverage verifies supported, refuted, and unverifiable outcomes across low, high, and irreversible-precondition criticality.
+- Integration coverage admits claims through the existing queue and verifies non-zero refuted and unverifiable-high values at `/metrics/features`.
+- Adjacent claim, route, metrics lifecycle, type, lint, and zero-failure checks pass.

--- a/upgrades/side-effects/claim-verification-general-verdict-metrics.md
+++ b/upgrades/side-effects/claim-verification-general-verdict-metrics.md
@@ -1,0 +1,86 @@
+# Side-Effects Review — Claim-verification general verdict metrics
+
+**Version / slug:** `claim-verification-general-verdict-metrics`
+**Date:** `2026-07-21`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `independent Codex reviewer — concurred`
+**Driving spec:** `docs/specs/claim-verification-sentinel.md` §2.7
+
+## Summary of the change
+
+This increment extends only `CompletionClaimVerifier`'s existing content-free statistics. Each server-admitted general claim now increments a `supported`, `refuted`, or `unverifiable` total immediately after the existing deterministic assessment and criticality-floor calculation. Refuted and unverifiable claims also increment a cross-tab keyed by the final floored criticality. Existing persisted stats load backward-compatibly, and every restored count is floored and clamped to the safe integer range. The existing `/metrics/features` response automatically exposes the new fields beneath `claimVerificationServerAdmittedOnly`; there is no new route, store, extractor, audit, or authority.
+
+## Decision-point inventory
+
+- `assessClaim` verdict — **pass-through only** — the existing verdict is counted; its calculation is unchanged.
+- `applyClaimCriticalityFloor` result — **pass-through only** — the existing final criticality is used as the cross-tab key; the floor is unchanged.
+- Message delivery, legacy claim publication, future-claim handling, and action authorization — **not touched**.
+
+## 1. Over-block
+
+No block/allow surface — over-block is not applicable. A counter write or persistence failure cannot change claim assessment, arbitration, delivery, or action behavior.
+
+## 2. Under-block
+
+No block/allow surface — under-block is not applicable. These aggregates deliberately cover only claims admitted by the existing server observation path. They do not estimate transport misses, eligible coverage, or production recall, and the response keeps the explicit `claimVerificationServerAdmittedOnly` label.
+
+## 3. Level-of-abstraction fit
+
+The change is at the existing owner and read surface. `CompletionClaimVerifier` already owns admitted/evaluated counters and their persisted content-free file; `/metrics/features` already projects `stats()` without a second adapter. Adding a ledger, audit summary, route, or parallel observer would duplicate the foundation and was rejected during the foundation audit.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The new values are aggregate observations only. They cannot withhold, rewrite, send, settle, authorize, promote, or change a criticality floor. General assessments remain automation-ineligible dark-core signals.
+
+## 4b. Judgment-point check
+
+No new static heuristic exists at a competing-signals decision point. The increment counts outputs from the existing assessor and floor without reinterpreting either.
+
+## 5. Interactions
+
+- **Shadowing:** none; the bump occurs after the existing assessment and final floor, before the unchanged recorder call.
+- **Double-fire:** one bump per extracted claim in the one existing general-observation loop. The admission queue remains the sole production caller of observation.
+- **Races:** unchanged process-local stats posture. Atomic temporary-file rename remains the existing persistence mechanism.
+- **Feedback loops:** none. No runtime consumer feeds these counts into assessment, criticality, routing, or delivery.
+- **Persistence compatibility:** old files omit the new maps and therefore start their new fields at zero. Malformed, negative, non-finite, fractional, and oversized counts restore as bounded integers.
+
+## 6. External surfaces
+
+The authenticated read-only `/metrics/features` JSON gains additive fields under the already explicit `claimVerificationServerAdmittedOnly` object. No user notice, external API, URL, action, configuration, or operator control is added. The persisted file remains content-free: it contains only fixed enum keys, integers, and an update timestamp.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Machine-local by design.** The stats describe claims admitted and evaluated by this server process, so origins may legitimately differ. The existing metrics endpoint exposes this machine's server-admitted-only observation; this increment does not claim fleet aggregation or trusted replication. It emits no user-facing notice, holds no topic-transfer authority, and generates no URL.
+
+## 8. Rollback cost
+
+Low. Revert the source and test changes and ship the next patch. Older binaries ignore the additive JSON keys; newer binaries recreate missing keys at zero. No schema migration, data repair, state reset, or destructive cleanup is required.
+
+## Conclusion
+
+The increment is bounded, content-free, backward-compatible, and observe-only. It reuses the sole verifier and sole metrics route, preserves the server-admitted-only denominator, and introduces no authority or parallel infrastructure.
+
+## Second-pass review
+
+**Reviewer:** independent Codex reviewer
+**Independent read of the artifact: concur**
+
+The reviewer found no blocking issue and confirmed that the implementation is confined to the existing verifier stats path, uses the final criticality floor without altering it, preserves all authority boundaries, and clamps persisted counts. Its one test-strengthening suggestion was incorporated: the route integration fixture now enters through `enqueue()` and the real admission queue instead of calling `observe()` directly.
+
+## Evidence pointers
+
+- `tests/unit/turn-evidence-completion-verifier.test.ts`
+- `tests/integration/metrics-features-routes.test.ts`
+- Focused and adjacent suites: 69 tests green; repository lint and zero-silent-fallback ratchet green.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect and no self-triggered controller change — not applicable.


### PR DESCRIPTION
## ELI16 — What changed and why

The completion-claim verifier already assesses claims that have passed the server admission boundary, but its metrics mainly showed extraction/admission activity and the older completion-only verdicts. This PR adds content-free counters for the general claim assessment outcomes, so operators can see whether admitted claims were supported, refuted, or unverifiable without storing claim text.

It also breaks refuted and unverifiable outcomes down by the verifier’s existing final criticality levels: low, medium, high, and irreversible-precondition. The counters are incremented immediately after the existing assessment and criticality-floor calculation, so they report the same decision the verifier already made. No new decision authority is introduced.

## Scope and boundaries

- Extends the existing CompletionClaimVerifier and its existing persisted stats only.
- Adds generalVerdicts plus refutedByCriticality and unverifiableByCriticality.
- Preserves server-admitted-only framing: raw/unadmitted candidate claims never enter these counters.
- Keeps ClaimObservation unchanged.
- Adds no route, extractor, queue, audit log, store, blocking behavior, rewrite behavior, advisory authority, or future-claims behavior.
- Leaves the existing criticality floor unchanged.
- Persisted numeric values are safely clamped and older state without the new maps merges to zero-filled defaults.
- The existing /metrics/features claimVerificationServerAdmittedOnly object surfaces the fields automatically.

## Verification

- Focused unit + integration tier: 29/29 passed after rebasing onto main containing #1543.
- Adjacent claim/correction/metrics coverage: 69/69 passed before rebase; focused coverage rerun after rebase.
- Full lint and TypeScript check passed.
- Repository invariants and diff checks passed.
- Zero-silent-fallback ratchet remains at its established baseline.
- Repository-wide local push suite ran 40,659 tests: 40,623 passed, 16 skipped, 3 todo; 17 failures were confined to unrelated environment-sensitive headless-spawn, Cartographer freshness, feedback-inbox, and other baseline suites. The Cartographer case passed when isolated; no claim-verification test failed. CI remains the merge authority.

## Independent review

An independent reviewer concurred with the implementation and boundary audit. The review confirmed that the change remains observe-only, does not alter criticality floors or ClaimObservation, and does not add routes or authority. Its one minor test-provenance suggestion was incorporated by driving the integration assertion through the real server admission queue.

## Duplicate-build audit

No competing implementation or duplicate infrastructure was found. This increment stays with the existing sole owner and existing metrics read surface.