### PR TITLE
feat: close nine-feature rollout accounting

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-22T00-58-11-939Z-nine-feature-rollout-closure.json
+++ b/.instar/instar-dev-decisions/2026-07-22T00-58-11-939Z-nine-feature-rollout-closure.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-22T00:58:11.939Z",
+  "slug": "nine-feature-rollout-closure",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 338,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-22T00-58-44-925Z-nine-feature-rollout-closure.json
+++ b/.instar/instar-dev-decisions/2026-07-22T00-58-44-925Z-nine-feature-rollout-closure.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-22T00:58:44.925Z",
+  "slug": "nine-feature-rollout-closure",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 338,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-22T01-21-53-851Z-nine-feature-rollout-closure.json
+++ b/.instar/instar-dev-decisions/2026-07-22T01-21-53-851Z-nine-feature-rollout-closure.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-22T01:21:53.851Z",
+  "slug": "nine-feature-rollout-closure",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 28,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/autonomous-throughput-floor.md
+++ b/docs/specs/autonomous-throughput-floor.md
@@ -4,6 +4,14 @@ slug: "autonomous-throughput-floor"
 author: "echo + codey"
 status: converged
 approved: true
+ships-staged: true
+rollout-disposition: active
+rollout-source-pr: 1533
+rollout-flag-path: monitoring.throughputFloor.enabled
+rollout-criteria: "At least one eligible pull/audit observation completes in the evidence window with its bounded audit record preserved."
+rollout-evidence-type: endpoint
+rollout-evidence-ref: /autonomous/throughput-floor
+rollout-metrics-json: '{"cadenceHours":6,"evidenceMaxAgeHours":12,"metrics":[{"id":"observed-throughput-runs","source":"feature-summary","sourceRef":"autonomous-throughput.observed-runs","direction":"at-least","threshold":1,"minSamples":1}]}'
 review-convergence: "2026-07-21 — re-converged at PULL/AUDIT-ONLY v1; action-bearing WIP removed; see reports/autonomous-throughput-floor-convergence.md"
 scope: "PULL/AUDIT-ONLY v1"
 parent-principle: "Observation Needs Structure"

--- a/docs/specs/claim-verification-sentinel.md
+++ b/docs/specs/claim-verification-sentinel.md
@@ -5,6 +5,14 @@ author: "echo"
 parent-principle: "Signal vs. Authority"
 status: approved
 approved: true
+ships-staged: true
+rollout-disposition: active
+rollout-source-pr: 1534
+rollout-flag-path: monitoring.completionClaimVerification.enabled
+rollout-criteria: "The verifier admits at least one candidate claim and retains nonzero classification coverage in the evidence window without becoming an outbound authority."
+rollout-evidence-type: endpoint
+rollout-evidence-ref: /completion-claim-verification/stats
+rollout-metrics-json: '{"cadenceHours":6,"evidenceMaxAgeHours":12,"metrics":[{"id":"classified-completion-claims","source":"feature-summary","sourceRef":"claim-verification.classified-claims","direction":"at-least","threshold":1,"minSamples":1}]}'
 approved-by: "operator blanket pre-approval relayed 2026-07-20 — proceed immediately through build/merge"
 supervision: pre-approved-build-and-merge
 lessons-engaged: [P1, P2, P3, P4, P5, P18, P19, P20, P21, L1, L5, L9]

--- a/docs/specs/context-wedge-detection-completeness.md
+++ b/docs/specs/context-wedge-detection-completeness.md
@@ -4,6 +4,13 @@ slug: "context-wedge-detection-completeness"
 author: "instar-codey"
 status: approved
 approved: true
+rollout-disposition: composed
+rollout-source-pr: 1536
+rollout-owner-feature: context-wedge-sentinel
+rollout-criteria: "A detector-positive context wedge remains latched until the existing SessionRecovery owner records genuine recovery progress."
+rollout-evidence-type: endpoint
+rollout-evidence-ref: /health
+rollout-metrics-json: '{"cadenceHours":6,"evidenceMaxAgeHours":12,"metrics":[{"id":"successful-context-recoveries","source":"feature-summary","sourceRef":"context-recovery.successful-recoveries","direction":"at-least","threshold":1,"minSamples":1}]}'
 parent-principle: "The Agent Is Always Reachable"
 lessons-engaged:
   - "Verify the State, Not Its Symbol: preserve an existing positive detector result after its banner scrolls away."

--- a/docs/specs/cross-rung-coordination-foundation.eli16.md
+++ b/docs/specs/cross-rung-coordination-foundation.eli16.md
@@ -1,0 +1,24 @@
+# Cross-rung coordination foundation — ELI16
+
+PR #1532 supplied shared words and rules, not a switchable feature. The rollout
+registry still names it so none of the nine PRs disappears, but marks it excluded.
+That means it has no rung, metric, flag, or separate graduation decision.
+
+This distinction matters because rollout bookkeeping can accidentally turn every
+pull request into something that looks operational. A document cannot run, fail,
+produce live evidence, or move from a test agent to the fleet. Giving it a pretend
+switch or a permanently green metric would make the dashboard look complete while
+weakening trust in every real feature shown beside it.
+
+The excluded row is therefore positive accounting, not omission. It records source
+PR #1532, points to the documentation foundation, and explains why its rung is empty
+and its metric count is zero. The row stays visible alongside the five active features
+and three composed components, so an audit can prove that all nine source pull
+requests were considered exactly once.
+
+Nothing about exclusion means the documentation is unimportant. Its vocabulary is
+used by the runtime entries, and those entries carry their own real owners, evidence,
+and criteria. It simply means the document is provenance rather than a runtime
+control. If later work ships executable behavior based on it, that behavior must get
+its own source specification and honest rollout classification; this row must never
+be silently upgraded into a feature after the fact.

--- a/docs/specs/cross-rung-coordination-foundation.md
+++ b/docs/specs/cross-rung-coordination-foundation.md
@@ -1,0 +1,52 @@
+---
+title: "Cross-rung coordination foundation provenance"
+slug: "cross-rung-coordination-foundation"
+author: "Instar-codey"
+eli16-overview: "cross-rung-coordination-foundation.eli16.md"
+status: approved
+approved: true
+rollout-disposition: excluded
+rollout-source-pr: 1532
+rollout-exclusion-reason: "Documentation-only foundation: no runtime producer, flag, metric authority, or independently graduatable behavior shipped."
+review-convergence: "2026-07-22T00:54:37.836Z"
+review-iterations: 10
+review-completed-at: "2026-07-22T00:54:37.836Z"
+review-report: "docs/specs/reports/nine-feature-rollout-closure-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5 + gemini-cli:gemini-3.1-pro-preview"
+single-run-completable: true
+frontloaded-decisions: 1
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Cross-rung coordination foundation provenance
+
+PR #1532 shipped the documentation foundation in `docs/CROSS-RUNG-COORDINATION.md`.
+It is intentionally represented in rollout accounting as **excluded**: documentation
+does not become a synthetic feature control, ladder rung, metric, or graduation gate.
+The five active features and three composed components that use the shared vocabulary
+remain accountable through their own source specifications and the existing D7 ledger.
+
+## Acceptance
+
+The lifecycle summary contains one source-PR 1532 row with disposition `excluded`, a
+null rung, zero metrics, and this reason. No config flag or runtime producer is added.
+
+## Multi-machine posture
+
+The excluded provenance row rides the existing canonical initiative registry and
+pool read. It introduces no state, producer, or machine-local surface.
+
+## Decision points touched
+
+| Decision point | Classification | Basis |
+|---|---|---|
+| Documentation exclusion | invariant | The operator-authorized model classifies #1532 as docs-only with no runtime behavior. |
+
+## Frontloaded Decisions
+
+The operator explicitly authorized exclusion rather than a synthetic control.
+
+## Open questions
+
+*(none)*

--- a/docs/specs/feedback-factory-operating-drain.md
+++ b/docs/specs/feedback-factory-operating-drain.md
@@ -9,6 +9,14 @@ review-completed-at: "2026-07-20T17:03:15.423Z"
 review-report: "docs/specs/reports/feedback-factory-operating-drain-convergence.md"
 cross-model-review: "codex-cli:gpt-5.5 + gemini-cli:gemini-3.1-pro-preview"
 approved: true
+ships-staged: true
+rollout-disposition: active
+rollout-source-pr: 1531
+rollout-flag-path: feedbackFactory.drain.enabled
+rollout-criteria: "At least one operated drain run completes without an authority, integrity, or consumer-liveness failure in each evidence window."
+rollout-evidence-type: endpoint
+rollout-evidence-ref: /feedback-factory/drain/status
+rollout-metrics-json: '{"cadenceHours":6,"evidenceMaxAgeHours":12,"metrics":[{"id":"completed-drain-runs","source":"feature-summary","sourceRef":"feedback-factory.completed-runs","direction":"at-least","threshold":1,"minSamples":1}]}'
 approved-at: "2026-07-20T16:53:14.000Z"
 approval-note: "Operator approved with frontier-model Instar agent as default readiness authority and human approval as escalation-only."
 parent-principle: "Canonical Pipeline Operational Completeness — Accepted Intake Must Drain"

--- a/docs/specs/mutual-ssh-autobootstrap.md
+++ b/docs/specs/mutual-ssh-autobootstrap.md
@@ -5,6 +5,14 @@ author: "Instar-codey"
 eli16-overview: "mutual-ssh-autobootstrap.eli16.md"
 status: draft
 approved: true
+ships-staged: true
+rollout-disposition: active
+rollout-source-pr: 1539
+rollout-flag-path: multiMachine.mutualSsh.enabled
+rollout-criteria: "At least one registered peer pair has current bidirectional SSH readiness proof with no blocking reason."
+rollout-evidence-type: endpoint
+rollout-evidence-ref: /multi-machine/mutual-ssh
+rollout-metrics-json: '{"cadenceHours":6,"evidenceMaxAgeHours":12,"metrics":[{"id":"ready-mutual-ssh-peers","source":"feature-summary","sourceRef":"mutual-ssh.ready-peers","direction":"at-least","threshold":1,"minSamples":1}]}'
 review-convergence: "2026-07-19T21:27:13.671Z"
 review-iterations: 4
 review-completed-at: "2026-07-19T21:27:13.671Z"

--- a/docs/specs/nine-feature-rollout-closure.eli16.md
+++ b/docs/specs/nine-feature-rollout-closure.eli16.md
@@ -1,0 +1,29 @@
+# Nine-feature rollout closure — ELI16
+
+Nine recent pull requests need to appear honestly in Instar’s feature-maturation
+view. They are not nine identical features. Five have their own real switches and
+can move through test-agent, development-agent, and fleet rollout stages. Three are
+smaller parts deliberately built into systems that already own the switch and the
+decision. One supplied documentation only.
+
+This change teaches the existing registry those three shapes. The five independent
+features are “active.” The three built-in pieces are “composed”: they name the system
+that owns them and carry their own measurable success rule, but they do not receive
+a fake switch or a separate rollout rung. The documentation-only pull request is
+“excluded,” with a plain reason, so it is counted without pretending prose is runtime
+behavior.
+
+Measurements stay in the D7 maturation ledger that already exists. D7 reads bounded
+numbers from the real feature owners—for example completed drain runs, admitted claim
+checks, successful context recoveries, Slack considered acknowledgments, and mutually
+ready SSH peers. It copies only a number and sample count into its existing evidence
+table. It cannot change the feature, promote it, send a notice, or create another
+source of truth. If a reader is unavailable, throws, is stale, or has too few samples,
+the feature does not pass. There is no made-up green result.
+
+The visible result is a complete nine-row accounting: five active, three composed,
+and one excluded. Active rows show a real rung derived from their existing switch.
+Composed and excluded rows always show no rung. The old database is migrated without
+discarding its history, older peers may omit the new fields, and legacy rollout
+records continue to behave as before. This closes the bookkeeping gap while keeping
+the control model exactly as the shipped components designed it.

--- a/docs/specs/nine-feature-rollout-closure.md
+++ b/docs/specs/nine-feature-rollout-closure.md
@@ -1,0 +1,277 @@
+---
+title: "Drive 8 nine-source-PR placement closure"
+slug: "nine-feature-rollout-closure"
+author: "Instar-codey"
+eli16-overview: "nine-feature-rollout-closure.eli16.md"
+status: approved
+approved: true
+parent-principle: "Maturation Path — Test Agent → Development Agent → Fleet"
+review-convergence: "2026-07-22T00:58:42.397Z"
+review-iterations: 10
+review-completed-at: "2026-07-22T00:58:42.397Z"
+review-report: "docs/specs/reports/nine-feature-rollout-closure-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5 + gemini-cli:gemini-3.1-pro-preview"
+single-run-completable: true
+frontloaded-decisions: 2
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Drive 8 nine-source-PR placement closure
+
+## Architectural overview
+
+The scanner reads each canonical source spec. The reconciler stores one typed
+accounting row on the existing initiative. D7 reads that row's numeric contract,
+samples an existing owner counter, and writes an advisory evaluation to its existing
+ledger. The lifecycle summary returns the accounting row and latest evaluation.
+
+`source spec → scanner → initiative accounting → owner counter → D7 observation → summary`
+
+No arrow points back into a flag or owner: this path observes and reports only.
+
+## Key terms
+
+- **D7:** the existing recurring, advisory feature-maturation evaluator and ledger.
+- **Rung:** `test-agent-live`, `dev-agent-live`, or `fleet` for a feature with its
+  own rollout flag. **Rung-null** means no independent flag or ladder advancement.
+- **Placement closure:** every source PR has one honest accounting row.
+- **Evidence readiness:** D7 has fresh, sufficient samples and the contract is `ready`.
+- **Rollout promotion:** the existing owner authority changes an active feature's rung.
+- **Operational readiness:** operator judgment over applicable origin-local evidence.
+- **Owner surface:** the existing content-free counter or bounded event log from the
+  component that performs the work, exposed through a component-internal read method
+  or a bounded local file reader.
+
+## Problem statement
+
+PRs #1531–#1539 shipped five independently controlled features, three components
+that deliberately compose existing controls, and one documentation-only foundation.
+The shared rollout scanner and D7 maturation ledger cannot currently distinguish
+those shapes. Treating every PR as independent would invent flags and owners; omitting
+the composed and documentation work would make the closure report incomplete.
+The current scanner implicitly models a shipped PR as one independently controlled
+feature, which is exactly the assumption these composed and documentation rows break.
+
+## Proposed design
+
+Extend the existing spec frontmatter scanner, InitiativeTracker record, rollout
+reconciler, blocker-lifecycle ledger, and summary schema. Every source PR has exactly
+one `active`, `composed`, or `excluded` accounting row. Active rows retain their real
+flag and derive one of `test-agent-live`, `dev-agent-live`, or `fleet`. Composed and
+excluded rows are always rung-null. A composed row names its existing owner and owns
+a feature-specific numeric contract, but never gains a rollout control. The excluded
+documentation row has a reason and no metric.
+
+D7 adds a closed `feature-summary` projection-descriptor allowlist. Readers snapshot counters
+already owned by each feature into the existing D7 SQLite observation table. They do
+not write feature state, advance rungs, or create a second store. Missing readers,
+stale observations, and inadequate samples fail closed as insufficient evidence.
+The allowlist is one additional source kind and fixed `sourceRef` entries in D7's
+existing descriptor parser, paired with in-process read callbacks on the existing
+evaluator. It extends the same D7 metric descriptor type and parser; it is not a
+parallel or persisted registry. Unknown refs are rejected while
+parsing the metric contract and therefore produce no observation, but the independently
+parsed source-PR accounting row remains visible and the evaluator records
+`invalid-contract` plus the bounded parser code; scanner tests pin that diagnostic rather than silently
+coercing or dropping the source PR.
+Each allowlisted descriptor is version 1 and fixes its sample definition, freshness
+model, zero-activity posture, and additive-compatibility rule. D7 persists that
+descriptor version on every observation; a future semantic change requires a new
+version/ref rather than silently reinterpreting old evidence.
+The owner owns its counter semantics; the child contract pins the corresponding
+sourceRef/version. An owner change must prove additive compatibility or publish a new
+sourceRef/version and update the child contract through ordinary spec review.
+The existing evaluator scores active and composed contracts; it lists but never scores
+excluded rows. SQLite migrations preserve old observations and make evaluation rung
+nullable. Pool sanitization accepts the additive accounting fields while retaining
+backward compatibility with peers that omit them.
+
+| Data object | Existing owner/store | Key | Mutation authority |
+|---|---|---|---|
+| Source-PR accounting | InitiativeTracker | feature ID + source PR | rollout reconciler from canonical spec |
+| Metric contract | canonical source-spec frontmatter | feature ID + metric ID | reviewed spec only |
+| Numeric observation | D7 SQLite observation table | origin + feature + metric + due time | D7 projection reader |
+| Evaluation | D7 SQLite evaluation table | origin + feature + due slot | D7 evaluator only |
+| Lifecycle summary row | read projection, not stored | origin + feature | none |
+
+A composed contract lives in the child's own source-spec frontmatter, for example:
+`{"source":"feature-summary","sourceRef":"context-recovery.successful-recoveries",
+"direction":"at-least","threshold":1,"minSamples":1}`. D7 writes the observation
+under the child's feature ID, while its callback reads only the named existing owner
+surface; owner and child observations are never blended. If the owner is dark,
+unavailable, or has zero qualifying activity, the child remains
+`insufficient-evidence` and cannot graduate independently.
+`minSamples` reflects the smallest real activity set that proves the child path, and
+`evidenceMaxAgeHours` is no longer than twice the cadence; reviewers set both from
+expected live frequency so rare paths fail closed without masquerading as stale.
+
+A **feature-specific numeric contract** is the child's closed source reference,
+threshold, freshness window, and minimum sample count. An **owner surface** is the
+already-existing content-free counter or bounded event log from the component that
+actually performs the work.
+
+| Row | Own flag | Named owner | Rung | Contract | D7 scored | Can independently graduate | Counted in closure |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Active | yes | self | real ladder rung | yes | yes | yes, through existing promotion authority | yes |
+| Composed | no | existing component | null | yes | yes | no; score is evidence only | yes |
+| Excluded | no | none | null | no | no | no | yes, as provenance |
+
+“Counted in closure” means the source PR has an honest, complete placement row—not
+that it is already operationally ready. A composed row remains an open maturation
+item until its D7 status is `ready`, but that readiness is advisory evidence consumed
+by the operator's existing rollout review; it cannot advance a rung or invoke a
+promotion writer. Thus placement closure for this PR and later evidence closure are
+visible, separate facts.
+
+The summary labels promotion authority explicitly: active rows report `self-owner`,
+composed rows `parent-owner-evidence-only`, and excluded rows `none`. A composed
+`ready` status therefore cannot be mistaken for child-owned promotion.
+
+Example: `#1537 accounted as composed → Slack owner emits a live counter → D7 status
+ready → operator reviews applicable origins → child remains rung-null`.
+
+## Exact accounting
+
+- Active: #1531 feedback drain, #1533 autonomous throughput floor, #1534 claim
+  verification, #1535 blocker lifecycle metrics, #1539 mutual SSH.
+- Composed: #1536 context recovery latch under SessionRecovery, #1537 considered
+  acknowledgment under AmbientContributionGate, #1538 SelfHealGate's first consumer
+  under feedback-factory controls.
+- Excluded: #1532 cross-rung coordination documentation.
+
+## Invariants and failure posture
+
+- No new flag, scheduler, state authority, promotion writer, or notification path.
+- The reconciler observes flags but never writes them.
+- Only closed source references can enter a maturation contract.
+- A projection exception or unavailable source emits no observation and cannot pass.
+- An unknown projection source is rejected by the closed parser and is visible as a
+  distinct `invalid-contract`/`unknown-source-ref` diagnostic; it is never dynamically
+  registered from frontmatter.
+- Accounting parsing and metric-contract parsing are independent: failure in either
+  path must not suppress the other row or diagnostic.
+- A missing live reader or no qualifying event remains `insufficient-evidence`; the
+  named owner evidence endpoint distinguishes unavailable-owner from zero activity
+  without expanding D7 into another health registry.
+- Every allowlisted callback has producer-side sample-definition fixtures. Changing
+  a fixture's semantics without changing descriptor version/sourceRef fails review.
+- Descriptors are point-in-time snapshots with a bounded window sample count; resets
+  create a new observation and never reinterpret prior slots. Each descriptor fixture
+  pins cumulative/windowed/reset behavior.
+- The lifecycle summary lists each closed descriptor's sourceRef, version, threshold,
+  direction, and sample floor for bounded operator discovery.
+- Excluded work has zero metrics; composed work has an owner and null rung.
+- Legacy initiatives without accounting retain their previous evaluation behavior.
+- Migration preserves previous rows and rolls back atomically on failure.
+
+## Multi-machine posture
+
+The canonical initiative registry provides the shared accounting identity. D7
+observations remain machine-local by the already ratified throughput-metrics design,
+and the existing blocker-lifecycle pool read composes per-origin summaries. No new
+machine-local state surface is introduced.
+
+Each composed source is intentionally local to the origin that owns the evidence:
+SessionRecovery's bounded recovery log, the Slack gate's content-free counters, and
+the feedback-defaults SelfHealGate boot result. Zero local activity means inadequate
+samples, not success, and another origin's activity never satisfies the local row.
+The qualifying activity is explicit: the context-recovery fixture exercises a real
+detector-positive recovery; opted-in eligible Slack traffic exercises the real gate;
+and every development source-checkout boot runs the feedback-defaults consumer, whose
+verified `healthy` or `healed` result is a real sample. Tests may exercise the first
+two paths without minting production evidence; D7 records only live owner outputs.
+The causality predicates are exact: #1536 counts only a logged
+`failureType=context_exhaustion && recovered=true` path (the latch is set before that
+path and cleared only after success); #1537 counts only the gate's `react` decision;
+#1538 counts only the first consumer's verified `healthy` or `healed` result.
+There is no synthetic fleet-wide readiness Boolean. Each composed status is
+origin-local and the existing pool route reports origins separately. Operational
+review considers only the origins where that owner is intentionally active: the
+development source-checkout owner for context recovery and feedback self-heal, and
+Slack-enabled origins for considered acknowledgments. Quiet or inapplicable origins
+remain insufficient rather than blocking or falsely satisfying another origin.
+The source-specific rule is: #1536 and #1538 require `ready` on the designated
+development source-checkout owner; #1537 requires `ready` on every origin with an
+opted-in Slack considered channel. Other origins are not inputs to that operational
+review. The pool route preserves each origin so the operator can verify this rule
+without cross-origin evidence substitution.
+Applicability and evidence are read in the same D7 callback at the due slot: source
+checkout/feedback-drain posture for #1536/#1538 and one
+`/permissions/ambient-stats` snapshot for #1537. The pool row's origin plus that named
+evidence endpoint is the review basis; later changes belong to the next due slot.
+If the applicability reader is unavailable, applicability is unknown and the row is
+`insufficient-evidence`; unavailability can never shrink the applicable-origin set.
+
+machine-local-justification: operator-ratified-exception (`docs/specs/throughput-metrics.md` and the existing `blocker-lifecycle-ledger-v1` state-registry owner establish per-origin D7 truth with pool projection).
+
+## Decision points touched
+
+| Decision point | Classification | Basis |
+|---|---|---|
+| Accounting disposition | invariant | Exact operator-authorized mapping of nine source PRs. |
+| Active rung | invariant | Deterministically derived from the existing observed flag posture. |
+| Metric readiness | invariant | Closed threshold, minimum samples, freshness, and missing-evidence fail-closed rules. |
+| Promotion non-authority | invariant | D7 remains advisory and has no advancement authority. |
+
+## Frontloaded Decisions
+
+The operator selected the composed-component model and authorized the exact 5/3/1
+mapping. The operator also required extension of the existing registry and D7 ledger,
+forbidding standalone child controls, fake flags, and parallel stores.
+
+A static manifest was rejected because it could account for provenance but could not
+run the operator-required real graduation criteria for the three composed children.
+The scan remains the static accounting source; D7 supplies only recurring evidence.
+Reusing the blocker-only D7 sources would mislabel unrelated owner counters as blocker
+latency. Adding one closed read-only source kind keeps the existing descriptor shape
+and storage path while avoiding three bespoke stores or semantically false fields.
+A hybrid manifest plus contract references was also rejected: source-spec frontmatter
+is already the reviewed canonical identity and contract path, while a standalone
+manifest would create a second identity list that can drift from those specs.
+A generated, non-authoritative report from scanner output remains acceptable for
+audit convenience; only a hand-maintained identity manifest is rejected.
+OpenTelemetry, Prometheus, or an event transport would add a second metrics transport
+and weaken offline personal-agent operation; bounded local callbacks keep closed-ref
+validation and reuse D7's existing durable observation/pool path.
+Persisting a second owner event stream was rejected because these owners already
+retain the needed bounded counters/log; live bounded reads avoid duplicate durable
+events while D7 remains the sole durable evidence projection.
+A generic internal metric registry would also add a parallel abstraction for only
+eight closed descriptors; D7-specific descriptors preserve its freshness, sampling,
+origin, and evaluation semantics in one reviewed type.
+If the allowlist exceeds 32 descriptors or four producer families, a separately
+converged typed-registry extraction is required; until then each addition is an
+intentional code-reviewed descriptor, callback, and producer fixture.
+
+## Open questions
+
+*(none)*
+
+## Maturation plan
+
+- **test-agent-live:** Run the exact nine-spec scan, 5/3/1 reconciliation, real
+  feature projections, invalid/missing evidence, nullable migrations, and hostile
+  pool fixtures live on Codey. No composed row may acquire a control or rung.
+- **dev-agent-live:** On the designated development owner, verify #1533/#1534/#1535
+  remain visibly built-on and active, every applicable contract receives a fresh D7
+  evaluation each cadence, and mixed legacy peers remain readable.
+- **fleet:** Only each of the five active features' existing promotion authority may
+  advance its real flag-derived rung after its own criterion. Composed/excluded rows
+  remain rung-null; this closure work performs no default flip.
+- **graduation criterion:** All source PRs #1531–#1539 appear exactly once as five
+  active, three composed, and one excluded; every active/composed row has its declared
+  owner, criterion, evidence, and descriptor; zero false-ready evaluations, zero
+  synthetic flags, zero hostile peer acceptance, and no migration loss occur through
+  a seven-day development-owner evidence window.
+- **dark-window:** Review test-agent evidence within 14 days. Any missing contract,
+  unknown applicability, stale evidence, or descriptor drift keeps that row open and
+  advisory without changing owner behavior.
+
+## Verification
+
+Unit tests prove parsing, the closed projection registry, 5/3/1 reconciliation,
+rung-null composed evaluation, excluded non-evaluation, nullable migration, and pool
+sanitization. An integration fixture scans the real nine spec records and asserts each
+source PR appears exactly once with a real contract where required. Typecheck, focused
+tests, full test suite, migration audit, and independent review must pass before merge.

--- a/docs/specs/reports/nine-feature-rollout-closure-convergence.md
+++ b/docs/specs/reports/nine-feature-rollout-closure-convergence.md
@@ -1,0 +1,92 @@
+# Convergence Report — Drive 8 nine-source-PR placement closure
+
+## Cross-model review: codex-cli:gpt-5.5 + gemini-cli:gemini-3.1-pro-preview
+
+Both external model families completed successful review rounds. Gemini timed out in
+three earlier attempts before succeeding; those degraded attempts were retained in
+the iteration record. The live Standards-Conformance endpoint was invoked but returned
+401 for the available session credential, so constitutional automation was
+unavailable; decision-point structure, multi-machine posture, and the existing D7
+constitution were reviewed directly instead.
+
+## ELI10 Overview
+
+Nine source pull requests did not all ship the same kind of thing. Five shipped
+features with real switches, three shipped pieces inside systems that already own the
+switch, and one shipped documentation. This change records those shapes honestly in
+the existing rollout registry: five active, three composed, and one excluded.
+
+The three composed pieces get real measurements but no pretend controls. D7 copies
+small numeric snapshots from their existing owners into its existing evidence ledger.
+Missing, stale, malformed, or undersampled evidence never becomes green. The
+documentation row remains visible as provenance with no rung or metric.
+
+## Original vs Converged
+
+The initial design had the correct 5/3/1 shape but left several operational edges
+implicit. Convergence added a closed descriptor allowlist, explicit source-locality
+and causality rules, distinct invalid-contract diagnostics, nullable-rung migration,
+mixed-version denominator semantics, hostile-peer schema checks, promotion-authority
+labels, descriptor discovery, and a clear separation between placement closure,
+evidence readiness, and rollout promotion.
+
+Implementation review also caught three concrete defects before handoff: candidate
+claims could have matured without classification; hostile pool rows could disagree
+with their claimed counts/rungs; and mixed legacy/accounted peers had inconsistent
+eligible denominators. All were repaired and regression-tested.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec/code changes |
+|---|---|---:|---|
+| 1 | independent implementation reviewer, GPT | 3 | Classified-claim evidence, pool invariants, mixed-version denominator, descriptor clarity |
+| 2 | independent reviewer, GPT | 1 | Added `legacyEligible`; clarified composed contracts and locality |
+| 3 | GPT; Gemini degraded | 0 | Added truth table, parser diagnostics, activity expectations |
+| 4 | GPT; Gemini degraded | 0 | Defined placement vs evidence closure and origin-local review |
+| 5 | GPT + Gemini | 0 | Added terms, exact invalid-contract status, alternatives analysis |
+| 6 | GPT + Gemini | 0 | Added architecture/data-flow, promotion authority, applicability failure posture |
+| 7 | GPT + Gemini | 0 | Added descriptor discovery, causal predicates, embedded D7 rationale |
+| 8 | GPT + Gemini | 0 | Final language and maintainability review; minor advisory notes only |
+| 9 | GPT + Gemini | 0 | Body-unchanged confirmation round; minor terminology advisories |
+| 10 | GPT + Gemini | 0 | Clarified invalid-contract diagnostics, split promotion authority, bounded descriptor-registry extraction, and reset semantics; converged |
+
+Standards-Conformance Gate: unavailable (401 from live endpoint with session
+credential). The failure was advisory and did not bypass the direct standards audit.
+
+## Full Findings Catalog
+
+### Resolved material findings
+
+- **Evidence validity:** `candidateTurns` increments before provider success. The
+  projection now uses `classifiedTurns`; candidate-only traffic is pinned to HOLD.
+- **Peer honesty:** pool sanitization now recomputes accounting counts, enforces
+  disposition/rung and promotion-authority invariants, and rejects hostile bodies.
+- **Backcompat denominator:** `legacyEligible` makes mixed legacy/accounted local and
+  pool summaries mathematically identical.
+- **Migration completeness:** both nullable evaluation rungs and the expanded
+  observation source CHECK preserve rows and recreate indexes transactionally.
+
+### Resolved specification findings
+
+- Defined composed child contract ownership, source locality, causal event predicates,
+  zero-activity semantics, and owner compatibility/version rules.
+- Distinguished accounting, contracts, observations, evaluations, and read summaries.
+- Added exact active/composed/excluded truth table and no-child-promotion invariant.
+- Added explicit alternatives: static/hybrid manifests, generic metrics registries,
+  owner event streams, and external telemetry transports.
+- Added bounded discovery of descriptor refs, versions, thresholds, and sample floors.
+
+### Final-round minor advisories
+
+External reviewers continued to recommend persisting applicability as a separate
+ledger field and periodically reconsidering standard telemetry tooling. Applicability
+is already derived deterministically from the persisted accounting disposition and
+contract, so duplicating it would add drift risk without changing any decision. The
+telemetry-registry extraction threshold is now explicit and bounded. These are
+non-material maintainability advisories, not unresolved behavior or ownership gaps.
+
+## Convergence verdict
+
+Converged at iteration 10. The final round produced no material finding, all user
+decisions are resolved, external GPT and Gemini review both ran successfully, and the
+independent implementation reviewer returned CONCUR. Ready for approved build/merge.

--- a/docs/specs/self-heal-gate.md
+++ b/docs/specs/self-heal-gate.md
@@ -4,6 +4,13 @@ slug: "self-heal-gate"
 author: "echo"
 status: draft
 approved: true
+rollout-disposition: composed
+rollout-source-pr: 1538
+rollout-owner-feature: feedback-factory-operating-drain
+rollout-criteria: "The feedback-factory defaults consumer records at least one verified repair or already-healthy result within its existing bounded governor and episode controls."
+rollout-evidence-type: endpoint
+rollout-evidence-ref: /feedback-factory/drain/status
+rollout-metrics-json: '{"cadenceHours":6,"evidenceMaxAgeHours":12,"metrics":[{"id":"successful-bounded-repairs","source":"feature-summary","sourceRef":"self-heal-gate.successful-repairs","direction":"at-least","threshold":1,"minSamples":1}]}'
 parent-principle: "Capacity Safety — No Unbounded Self-Action"
 review-convergence: "2026-07-21T12:04:51.495Z"
 review-iterations: 6

--- a/docs/specs/slack-considered-acknowledgment-v1.md
+++ b/docs/specs/slack-considered-acknowledgment-v1.md
@@ -5,6 +5,13 @@ author: "instar-codey"
 parent-principle: "Signal vs. Authority"
 status: converging
 approved: true
+rollout-disposition: composed
+rollout-source-pr: 1537
+rollout-owner-feature: slack-organization-integration
+rollout-criteria: "The existing AmbientContributionGate emits a bounded considered acknowledgment for at least one eligible message without adding a second decision authority."
+rollout-evidence-type: endpoint
+rollout-evidence-ref: /permissions/ambient-stats
+rollout-metrics-json: '{"cadenceHours":6,"evidenceMaxAgeHours":12,"metrics":[{"id":"considered-slack-acknowledgments","source":"feature-summary","sourceRef":"slack-decision-gate.considered-acknowledgments","direction":"at-least","threshold":1,"minSamples":1}]}'
 approved-by: "operator blanket pre-approval relayed 2026-07-21"
 supervision: pre-approved-build-and-merge
 lessons-engaged: [P1, P2, P3, P4, P5, P19, P20]

--- a/docs/specs/throughput-metrics.md
+++ b/docs/specs/throughput-metrics.md
@@ -6,6 +6,14 @@ status: draft
 parent-principle: "Signal vs. Authority — raw blocker lifecycle measurements inform diagnosis but never select work, rank workers, notify, block, or act."
 parent-principle-fit: "The existing explicit commitment transition remains the sole mutation authority. The new ledger is derived, raw, nullable, measure-only state; SQLite loss cannot alter commitment success, and no scalar or action consumer exists. The persistence prerequisite additionally enforces Verify State, Not Symbol by acknowledging the authoritative rename rather than treating an exception-swallowing call as proof."
 approved: true # blanket pre-approval from operator directive for post-convergence build/merge
+ships-staged: true
+rollout-disposition: active
+rollout-source-pr: 1535
+rollout-flag-path: monitoring.blockerLifecycleLedger.enabled
+rollout-criteria: "At least one acknowledged blocker lifecycle transition is durably represented while the ledger remains measure-only and non-authoritative."
+rollout-evidence-type: endpoint
+rollout-evidence-ref: /blocker-lifecycle/summary
+rollout-metrics-json: '{"cadenceHours":6,"evidenceMaxAgeHours":12,"metrics":[{"id":"completed-lifecycle-transitions","source":"feature-summary","sourceRef":"blocker-lifecycle.completed-transitions","direction":"at-least","threshold":1,"minSamples":1}]}'
 build-root: "fresh worktree from JKHeadley/main v1.3.890 (6f8bcc6a9); never .dev/instar"
 lessons-engaged:
   - "Structure > Willpower; Signal vs Authority; Judgment Within Floors"

--- a/src/core/FeatureRolloutReconciler.ts
+++ b/src/core/FeatureRolloutReconciler.ts
@@ -14,7 +14,7 @@
  * or ships-staged specs become `active` tracks (anti-flood).
  */
 
-import type { InitiativeTracker, PipelineStage, Initiative, MaturationEvaluationContract } from './InitiativeTracker.js';
+import type { InitiativeTracker, PipelineStage, Initiative, MaturationEvaluationContract, RolloutAccountingDisposition, MaturationLadderRung } from './InitiativeTracker.js';
 import {
   deriveRolloutStage,
   rolloutPhaseStatuses,
@@ -40,6 +40,11 @@ export interface SpecArtifact {
   evidenceSource?: { type: 'log-filter' | 'endpoint'; ref: string; filter?: string };
   promotionCriteria?: string;
   maturationEvaluation?: MaturationEvaluationContract;
+  maturationContractError?: 'invalid-json' | 'oversized' | 'invalid-shape' | 'unknown-source-ref';
+  rolloutDisposition?: RolloutAccountingDisposition;
+  sourcePrNumber?: number;
+  ownerFeatureId?: string;
+  exclusionReason?: string;
   /** An instar-dev trace exists referencing this spec (⇒ at least building). */
   traceExists: boolean;
   prNumber?: number;
@@ -77,6 +82,12 @@ export interface ReconcileSummary {
   regressed: string[];
   skipped: string[];
   unchanged: string[];
+}
+
+export function accountingRung(stage: ReturnType<typeof deriveRolloutStage>): MaturationLadderRung {
+  if (stage === 'live') return 'dev-agent-live';
+  if (stage === 'default-on') return 'fleet';
+  return 'test-agent-live';
 }
 
 export class FeatureRolloutReconciler {
@@ -117,6 +128,14 @@ export class FeatureRolloutReconciler {
     // Rollout observation (ships-staged + merged only).
     const rolloutEligible = Boolean(art.shipsStaged && art.merged && art.flagPath);
     const observedStage = rolloutEligible ? deriveRolloutStage(this.deps.observeFlag(art.flagPath!)) : undefined;
+    const disposition = art.rolloutDisposition ?? (rolloutEligible ? 'active' : undefined);
+    const rolloutAccounting = disposition && art.sourcePrNumber
+      ? { disposition, sourcePrNumber: art.sourcePrNumber,
+        rung: disposition === 'active' && observedStage ? accountingRung(observedStage) : null,
+        ownerFeatureId: art.ownerFeatureId ?? (disposition === 'active' ? art.id : undefined), exclusionReason: art.exclusionReason,
+        evidenceSource: art.evidenceSource, graduationCriterion: art.promotionCriteria,
+        maturationEvaluation: art.maturationEvaluation, maturationContractError: art.maturationContractError }
+      : undefined;
 
     if (!existing) {
       // ── CREATE ──
@@ -134,6 +153,7 @@ export class FeatureRolloutReconciler {
         rollout: rolloutEligible
           ? { flagPath: art.flagPath!, stage: observedStage!, evidenceSource: art.evidenceSource, promotionCriteria: art.promotionCriteria, maturationEvaluation: art.maturationEvaluation }
           : undefined,
+        rolloutAccounting,
       });
       // default-on parks the track as 'paused' (NON-terminal → reopenable on a
       // later regression; 'archived' maps to TaskFlow's terminal `cancelled`
@@ -141,7 +161,9 @@ export class FeatureRolloutReconciler {
       // (genuinely terminal provenance, never reopened).
       if (observedStage && shouldArchiveAtStage(observedStage)) {
         await this.deps.tracker.update(art.id, { status: 'paused', ifMatch: this.deps.tracker.get(art.id)?.version });
-      } else if (!isActive) {
+      } else if (disposition === 'excluded') {
+        await this.deps.tracker.update(art.id, { status: 'paused', ifMatch: this.deps.tracker.get(art.id)?.version });
+      } else if (!isActive && !rolloutAccounting) {
         await this.deps.tracker.update(art.id, { status: 'archived', ifMatch: this.deps.tracker.get(art.id)?.version });
       }
       summary.created.push(art.id);
@@ -163,11 +185,19 @@ export class FeatureRolloutReconciler {
       if (prevStage && isRegression(prevStage, observedStage)) {
         await this.deps.tracker.update(id, { pipelineStage: 'regressed', status: 'active', ifMatch: this.deps.tracker.get(id)?.version });
         await this.applyRolloutStage(id, observedStage);
+        const latest = this.deps.tracker.get(id);
+        if (latest?.rolloutAccounting) await this.deps.tracker.update(id, {
+          rolloutAccounting: { ...latest.rolloutAccounting, rung: accountingRung(observedStage) }, ifMatch: latest.version,
+        });
         summary.regressed.push(id);
         return;
       }
       if (prevStage !== observedStage) {
         await this.applyRolloutStage(id, observedStage);
+        const latest = this.deps.tracker.get(id);
+        if (latest?.rolloutAccounting) await this.deps.tracker.update(id, {
+          rolloutAccounting: { ...latest.rolloutAccounting, rung: accountingRung(observedStage) }, ifMatch: latest.version,
+        });
         if (shouldArchiveAtStage(observedStage)) summary.archived.push(id);
         else summary.advanced.push(id);
         return;
@@ -180,6 +210,12 @@ export class FeatureRolloutReconciler {
         summary.advanced.push(id);
         return;
       }
+    }
+
+    if (rolloutAccounting && JSON.stringify(existing.rolloutAccounting) !== JSON.stringify(rolloutAccounting)) {
+      await this.deps.tracker.update(id, { rolloutAccounting, ifMatch: this.deps.tracker.get(id)?.version });
+      summary.advanced.push(id);
+      return;
     }
 
     if (touched) summary.advanced.push(id);

--- a/src/core/InitiativeTracker.ts
+++ b/src/core/InitiativeTracker.ts
@@ -77,7 +77,7 @@ export type InitiativeKind = 'task' | 'project';
  *  GRADUATED-FEATURE-ROLLOUT-SPEC §4.2-4.3. */
 export type RolloutStage = 'dark' | 'dry-run' | 'live' | 'default-on';
 
-export type MaturationMetricSource = 'blocker-summary' | 'blocker-trend';
+export type MaturationMetricSource = 'blocker-summary' | 'blocker-trend' | 'feature-summary';
 export type MaturationMetricDirection = 'at-least' | 'at-most';
 
 export interface MaturationMetricContract {
@@ -93,6 +93,24 @@ export interface MaturationEvaluationContract {
   cadenceHours: number;
   evidenceMaxAgeHours: number;
   metrics: MaturationMetricContract[];
+}
+
+export type MaturationLadderRung = 'test-agent-live' | 'dev-agent-live' | 'fleet';
+export type RolloutAccountingDisposition = 'active' | 'composed' | 'excluded';
+
+/** Complete rollout-accounting row. Active rows derive rung from the observed
+ * flag; composed/excluded rows are intentionally rung-null and never gain a
+ * control seam of their own. */
+export interface RolloutAccountingInfo {
+  disposition: RolloutAccountingDisposition;
+  sourcePrNumber: number;
+  rung: MaturationLadderRung | null;
+  ownerFeatureId?: string;
+  exclusionReason?: string;
+  evidenceSource?: { type: 'log-filter' | 'endpoint'; ref: string; filter?: string };
+  graduationCriterion?: string;
+  maturationEvaluation?: MaturationEvaluationContract;
+  maturationContractError?: 'invalid-json' | 'oversized' | 'invalid-shape' | 'unknown-source-ref';
 }
 
 /** Typed rollout metadata for a ships-staged feature task. Operational criteria
@@ -232,6 +250,7 @@ export interface Initiative {
   /** Post-ship rollout track (ships-staged features). Present only when the
    *  feature matures behind a flag. Stage is derived from observing flagPath. */
   rollout?: RolloutInfo;
+  rolloutAccounting?: RolloutAccountingInfo;
   /** Immutable exact-key link from the feedback-drain outbox. One work key may
    *  identify at most one Initiative task; semantic matching never substitutes. */
   feedbackWorkKey?: string;
@@ -282,6 +301,7 @@ export interface InitiativeCreateInput {
   ciCheckedAt?: string;
   driftCheck?: boolean;
   rollout?: RolloutInfo;
+  rolloutAccounting?: RolloutAccountingInfo;
   /** Immutable exact-key link from the feedback-drain outbox. */
   feedbackWorkKey?: string;
   rounds?: InitiativeRound[];
@@ -325,6 +345,7 @@ export interface InitiativeUpdateInput {
   unskippedAt?: string | null;
   driftCheck?: boolean;
   rollout?: RolloutInfo | null;
+  rolloutAccounting?: RolloutAccountingInfo | null;
   rounds?: InitiativeRound[];
   sourceDocs?: string[];
   autoAdvance?: boolean;
@@ -1034,6 +1055,7 @@ export class InitiativeTracker {
     if (input.ciCheckedAt !== undefined) initiative.ciCheckedAt = input.ciCheckedAt;
     if (input.driftCheck !== undefined) initiative.driftCheck = input.driftCheck;
     if (input.rollout !== undefined) initiative.rollout = input.rollout;
+    if (input.rolloutAccounting !== undefined) initiative.rolloutAccounting = input.rolloutAccounting;
     if (input.feedbackWorkKey !== undefined) initiative.feedbackWorkKey = input.feedbackWorkKey;
     if (input.rounds !== undefined) initiative.rounds = input.rounds;
     if (input.sourceDocs !== undefined) initiative.sourceDocs = input.sourceDocs;
@@ -1139,6 +1161,9 @@ export class InitiativeTracker {
     if (input.driftCheck !== undefined) next.driftCheck = input.driftCheck;
     if (input.rollout !== undefined) {
       next.rollout = input.rollout === null ? undefined : input.rollout;
+    }
+    if (input.rolloutAccounting !== undefined) {
+      next.rolloutAccounting = input.rolloutAccounting === null ? undefined : input.rolloutAccounting;
     }
     if (input.rounds !== undefined) next.rounds = input.rounds;
     if (input.sourceDocs !== undefined) next.sourceDocs = input.sourceDocs;

--- a/src/core/featureRolloutScan.ts
+++ b/src/core/featureRolloutScan.ts
@@ -15,7 +15,7 @@ import * as path from 'node:path';
 import { SafeGitExecutor } from './SafeGitExecutor.js';
 import type { SpecArtifact } from './FeatureRolloutReconciler.js';
 import type { RolloutFlagObservation } from './featureRollout.js';
-import type { MaturationEvaluationContract, MaturationMetricSource } from './InitiativeTracker.js';
+import type { MaturationEvaluationContract, MaturationMetricSource, RolloutAccountingDisposition } from './InitiativeTracker.js';
 
 const RECENT_MERGE_WINDOW_MS = 14 * 24 * 60 * 60 * 1000; // 14d ⇒ active vs terminal backfill
 
@@ -54,6 +54,12 @@ const MATURATION_SOURCE_REFS: Readonly<Record<MaturationMetricSource, ReadonlySe
     'clear-latency.coverage', 'clear-latency.p95Ms',
   ]),
   'blocker-trend': new Set(['request-to-persist.ratio', 'clear-latency.ratio']),
+  'feature-summary': new Set([
+    'feedback-factory.completed-runs', 'autonomous-throughput.observed-runs',
+    'claim-verification.classified-claims', 'blocker-lifecycle.completed-transitions',
+    'mutual-ssh.ready-peers', 'context-recovery.successful-recoveries',
+    'slack-decision-gate.considered-acknowledgments', 'self-heal-gate.successful-repairs',
+  ]),
 };
 
 export function parseMaturationContract(raw: string | undefined): MaturationContractParseResult | undefined {
@@ -75,7 +81,7 @@ export function parseMaturationContract(raw: string | undefined): MaturationCont
     if (!rawMetric || typeof rawMetric !== 'object' || Array.isArray(rawMetric)) return { ok: false, error: 'invalid-shape' };
     const m = rawMetric as Record<string, unknown>;
     if (typeof m.id !== 'string' || !/^[a-z0-9][a-z0-9-]{0,62}$/.test(m.id) || ids.has(m.id) ||
-        !['blocker-summary', 'blocker-trend'].includes(String(m.source)) || typeof m.sourceRef !== 'string' ||
+        !['blocker-summary', 'blocker-trend', 'feature-summary'].includes(String(m.source)) || typeof m.sourceRef !== 'string' ||
         !['at-least', 'at-most'].includes(String(m.direction)) || typeof m.threshold !== 'number' || !Number.isFinite(m.threshold) ||
         !Number.isInteger(m.minSamples) || (m.minSamples as number) < 1 || (m.minSamples as number) > 100_000) {
       return { ok: false, error: 'invalid-shape' };
@@ -91,6 +97,11 @@ export function parseMaturationContract(raw: string | undefined): MaturationCont
 function maturationContractFrom(fm: Record<string, string>): MaturationEvaluationContract | undefined {
   const parsed = parseMaturationContract(fm['rollout-metrics-json']);
   return parsed?.ok ? parsed.contract : undefined;
+}
+
+function maturationContractErrorFrom(fm: Record<string, string>): MaturationContractError | undefined {
+  const parsed = parseMaturationContract(fm['rollout-metrics-json']);
+  return parsed && !parsed.ok ? parsed.error : undefined;
 }
 
 interface TraceInfo { prNumber?: number; createdAtMs?: number; }
@@ -144,6 +155,12 @@ export function scanSpecArtifacts(repoRoot: string, now: () => number = () => Da
         ? { type: (fm['rollout-evidence-type'] as 'log-filter' | 'endpoint') || 'log-filter', ref: fm['rollout-evidence-ref'], filter: fm['rollout-evidence-filter'] || undefined }
         : undefined,
       maturationEvaluation: maturationContractFrom(fm),
+      maturationContractError: maturationContractErrorFrom(fm),
+      rolloutDisposition: ['active', 'composed', 'excluded'].includes(fm['rollout-disposition'])
+        ? fm['rollout-disposition'] as RolloutAccountingDisposition : undefined,
+      sourcePrNumber: /^\d+$/.test(fm['rollout-source-pr'] ?? '') ? Number(fm['rollout-source-pr']) : undefined,
+      ownerFeatureId: fm['rollout-owner-feature'] || undefined,
+      exclusionReason: fm['rollout-exclusion-reason'] || undefined,
       traceExists,
       prNumber: trace?.prNumber,
       merged,
@@ -271,6 +288,12 @@ export function scanSpecArtifactsCanonical(opts: CanonicalScanOpts): CanonicalSc
         ? { type: (fm['rollout-evidence-type'] as 'log-filter' | 'endpoint') || 'log-filter', ref: fm['rollout-evidence-ref'], filter: fm['rollout-evidence-filter'] || undefined }
         : undefined,
       maturationEvaluation: maturationContractFrom(fm),
+      maturationContractError: maturationContractErrorFrom(fm),
+      rolloutDisposition: ['active', 'composed', 'excluded'].includes(fm['rollout-disposition'])
+        ? fm['rollout-disposition'] as RolloutAccountingDisposition : undefined,
+      sourcePrNumber: /^\d+$/.test(fm['rollout-source-pr'] ?? '') ? Number(fm['rollout-source-pr']) : undefined,
+      ownerFeatureId: fm['rollout-owner-feature'] || undefined,
+      exclusionReason: fm['rollout-exclusion-reason'] || undefined,
       traceExists,
       prNumber: trace?.prNumber,
       merged,

--- a/src/monitoring/BlockerLifecycleLedger.ts
+++ b/src/monitoring/BlockerLifecycleLedger.ts
@@ -30,8 +30,8 @@ export interface BlockerLedgerCounters {
   reconciled: number;
 }
 
-export type MaturationMetricSource = 'blocker-summary' | 'blocker-trend';
-export type MaturationEvaluationStatus = 'ready' | 'hold' | 'stale-evidence' | 'insufficient-evidence' | 'missing-contract' | 'missed-cadence';
+export type MaturationMetricSource = 'blocker-summary' | 'blocker-trend' | 'feature-summary';
+export type MaturationEvaluationStatus = 'ready' | 'hold' | 'stale-evidence' | 'insufficient-evidence' | 'missing-contract' | 'invalid-contract' | 'missed-cadence';
 
 export interface MaturationMetricObservation {
   origin: string; featureId: string; metricId: string; source: MaturationMetricSource;
@@ -40,7 +40,7 @@ export interface MaturationMetricObservation {
 }
 
 export interface MaturationEvaluationRecord {
-  origin: string; featureId: string; rung: string; dueSlotMs: number; evaluatedAtMs: number;
+  origin: string; featureId: string; rung: string | null; dueSlotMs: number; evaluatedAtMs: number;
   status: MaturationEvaluationStatus; passingMetrics: number; totalMetrics: number;
   minNormalizedMargin: number | null; contractHash: string; newestEvidenceAtMs: number | null;
   additionalMissedSlots?: number;
@@ -101,6 +101,47 @@ export class BlockerLifecycleLedger {
         `);
       })();
     }
+    const maturation = this.db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='maturation_evaluations'")
+      .get() as { sql?: string } | undefined;
+    if (maturation?.sql && /rung\s+TEXT\s+NOT\s+NULL/i.test(maturation.sql)) {
+      this.db.transaction(() => this.db!.exec(`
+        DROP INDEX IF EXISTS idx_maturation_evaluation_trend;
+        ALTER TABLE maturation_evaluations RENAME TO maturation_evaluations_v1;
+        CREATE TABLE maturation_evaluations (
+          origin TEXT NOT NULL, feature_id TEXT NOT NULL, rung TEXT,
+          due_slot_ms INTEGER NOT NULL, evaluated_at_ms INTEGER NOT NULL, status TEXT NOT NULL,
+          passing_metrics INTEGER NOT NULL, total_metrics INTEGER NOT NULL,
+          min_normalized_margin REAL, contract_hash TEXT NOT NULL, newest_evidence_at_ms INTEGER,
+          additional_missed_slots INTEGER NOT NULL DEFAULT 0, schema_version INTEGER NOT NULL DEFAULT 2,
+          UNIQUE(origin,feature_id,due_slot_ms)
+        );
+        INSERT INTO maturation_evaluations
+          SELECT origin,feature_id,rung,due_slot_ms,evaluated_at_ms,status,passing_metrics,total_metrics,
+            min_normalized_margin,contract_hash,newest_evidence_at_ms,additional_missed_slots,2
+          FROM maturation_evaluations_v1;
+        DROP TABLE maturation_evaluations_v1;
+      `))();
+    }
+    const observations = this.db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='maturation_metric_observations'")
+      .get() as { sql?: string } | undefined;
+    if (observations?.sql && !observations.sql.includes('feature-summary')) {
+      this.db.transaction(() => this.db!.exec(`
+        DROP INDEX IF EXISTS idx_maturation_observation_latest;
+        ALTER TABLE maturation_metric_observations RENAME TO maturation_metric_observations_v1;
+        CREATE TABLE maturation_metric_observations (
+          origin TEXT NOT NULL, feature_id TEXT NOT NULL, metric_id TEXT NOT NULL,
+          source TEXT NOT NULL CHECK (source IN ('blocker-summary','blocker-trend','feature-summary')),
+          source_ref TEXT NOT NULL, observed_at_ms INTEGER NOT NULL, value REAL NOT NULL,
+          samples INTEGER NOT NULL, descriptor_version INTEGER NOT NULL DEFAULT 1,
+          benchmark_ref TEXT, schema_version INTEGER NOT NULL DEFAULT 2,
+          UNIQUE(origin,feature_id,metric_id,source,source_ref,observed_at_ms)
+        );
+        INSERT INTO maturation_metric_observations
+          SELECT origin,feature_id,metric_id,source,source_ref,observed_at_ms,value,samples,
+            descriptor_version,benchmark_ref,2 FROM maturation_metric_observations_v1;
+        DROP TABLE maturation_metric_observations_v1;
+      `))();
+    }
     this.db.exec(`
         CREATE TABLE IF NOT EXISTS blocker_lifecycle_metrics (
           origin TEXT NOT NULL,
@@ -116,7 +157,7 @@ export class BlockerLifecycleLedger {
           ON blocker_lifecycle_metrics(factor, observed_at_ms);
         CREATE TABLE IF NOT EXISTS maturation_metric_observations (
           origin TEXT NOT NULL, feature_id TEXT NOT NULL, metric_id TEXT NOT NULL,
-          source TEXT NOT NULL CHECK (source IN ('blocker-summary','blocker-trend')),
+          source TEXT NOT NULL CHECK (source IN ('blocker-summary','blocker-trend','feature-summary')),
           source_ref TEXT NOT NULL, observed_at_ms INTEGER NOT NULL, value REAL NOT NULL,
           samples INTEGER NOT NULL, descriptor_version INTEGER NOT NULL DEFAULT 1,
           benchmark_ref TEXT, schema_version INTEGER NOT NULL DEFAULT 1,
@@ -125,7 +166,7 @@ export class BlockerLifecycleLedger {
         CREATE INDEX IF NOT EXISTS idx_maturation_observation_latest ON maturation_metric_observations
           (origin,feature_id,metric_id,source,source_ref,observed_at_ms DESC);
         CREATE TABLE IF NOT EXISTS maturation_evaluations (
-          origin TEXT NOT NULL, feature_id TEXT NOT NULL, rung TEXT NOT NULL,
+          origin TEXT NOT NULL, feature_id TEXT NOT NULL, rung TEXT,
           due_slot_ms INTEGER NOT NULL, evaluated_at_ms INTEGER NOT NULL, status TEXT NOT NULL,
           passing_metrics INTEGER NOT NULL, total_metrics INTEGER NOT NULL,
           min_normalized_margin REAL, contract_hash TEXT NOT NULL, newest_evidence_at_ms INTEGER,

--- a/src/monitoring/BlockerLifecycleService.ts
+++ b/src/monitoring/BlockerLifecycleService.ts
@@ -3,6 +3,7 @@ import crypto from 'node:crypto';
 import type { Initiative, MaturationEvaluationContract } from '../core/InitiativeTracker.js';
 import type { InitiativeTracker } from '../core/InitiativeTracker.js';
 import { BlockerLifecycleLedger, percentile, type BlockerFactor, type BlockerMetricRecord, type MaturationEvaluationRecord, type MaturationEvaluationStatus } from './BlockerLifecycleLedger.js';
+import { DegradationReporter } from './DegradationReporter.js';
 
 type FailureReason = 'insufficient-days' | 'insufficient-samples' | 'zero-denominator';
 
@@ -176,7 +177,18 @@ export class BlockerLifecycleService {
     for (const metric of contract.metrics) {
       if (metric.source === 'feature-summary') {
         let projected: { value: number; samples: number } | null = null;
-        try { projected = this.maturationProjections.get(metric.sourceRef)?.() ?? null; } catch { projected = null; }
+        try {
+          projected = this.maturationProjections.get(metric.sourceRef)?.() ?? null;
+        } catch (error) {
+          DegradationReporter.getInstance().report({
+            feature: 'blocker-lifecycle.maturation-projection',
+            primary: `capture ${metric.sourceRef} owner evidence`,
+            fallback: 'leave the observation absent so maturation remains HOLD',
+            reason: error instanceof Error ? error.message : 'projection callback threw',
+            impact: `${featureId} cannot mature until a later projection succeeds`,
+          });
+          projected = null;
+        }
         if (projected && Number.isFinite(projected.value) && Number.isInteger(projected.samples) && projected.samples >= 0) {
           this.ledger.recordMaturationObservation({ origin: this.origin, featureId, metricId: metric.id,
             source: metric.source, sourceRef: metric.sourceRef, observedAtMs: now,

--- a/src/monitoring/BlockerLifecycleService.ts
+++ b/src/monitoring/BlockerLifecycleService.ts
@@ -14,6 +14,8 @@ export class BlockerLifecycleService {
   private breakerUntil = 0;
   private closed = false;
   private maturationInitiatives: Initiative[] = [];
+  private maturationAccountingInitiatives: Initiative[] = [];
+  private readonly maturationProjections = new Map<string, () => { value: number; samples: number } | null>();
   private readonly onRequest = (event: Record<string, unknown>): void => {
     this.ledger.enqueue({
       origin: this.origin,
@@ -45,6 +47,12 @@ export class BlockerLifecycleService {
     tracker.on('blocker-request-persisted', this.onRequest);
     tracker.on('blocker-episode-closed', this.onClose);
     tracker.on('delivered', this.onDelivered);
+    this.registerMaturationProjection('blocker-lifecycle.completed-transitions', () => {
+      const since = this.now() - 168 * 3_600_000;
+      const samples = (['request-to-persist', 'clear-latency', 'deliverable-completion'] as const)
+        .reduce((total, factor) => total + this.ledger.values(factor, since).filter(row => row.outcome === 'observed').length, 0);
+      return { value: samples, samples };
+    });
     this.schedule(5_000);
     if (initiativeTracker) {
       const evaluate = () => { try { this.evaluateMaturation(initiativeTracker.list()); } catch { /* @silent-fallback-ok — the absent durable slot is surfaced as missed cadence on the next successful pass */ } };
@@ -55,6 +63,13 @@ export class BlockerLifecycleService {
   }
 
   available(): boolean { return this.ledger.available(); }
+
+  /** Register a read-only projection from an existing feature's counters onto
+   * D7. This adds no state owner: the feature remains authoritative and D7
+   * snapshots only the bounded numeric pair at evaluation time. */
+  registerMaturationProjection(sourceRef: string, read: () => { value: number; samples: number } | null): void {
+    this.maturationProjections.set(sourceRef, read);
+  }
 
   localSummary(sinceHours: number): Record<string, unknown> {
     const sinceMs = this.now() - sinceHours * 3_600_000;
@@ -80,12 +95,20 @@ export class BlockerLifecycleService {
   /** D7 recurring scorer. Called only by the existing rollout reconciler cadence. */
   evaluateMaturation(initiatives: Initiative[]): { eligible: number; inserted: number } {
     const now = this.now();
-    const eligible = initiatives.filter(i => i.rollout && i.rollout.stage !== 'default-on')
+    const accounted = initiatives.filter(i => i.rolloutAccounting)
       .sort((a, b) => a.id.localeCompare(b.id)).slice(0, 512);
-    this.maturationInitiatives = eligible.map(i => ({ ...i, rollout: i.rollout ? { ...i.rollout } : undefined }));
+    const eligible = initiatives.filter(i => {
+      if (i.rolloutAccounting) return i.rolloutAccounting.disposition !== 'excluded';
+      return Boolean(i.rollout && i.rollout.stage !== 'default-on');
+    })
+      .sort((a, b) => a.id.localeCompare(b.id)).slice(0, 512);
+    this.maturationAccountingInitiatives = accounted.map(i => ({ ...i, rolloutAccounting: i.rolloutAccounting ? { ...i.rolloutAccounting } : undefined }));
+    this.maturationInitiatives = eligible.map(i => ({ ...i, rollout: i.rollout ? { ...i.rollout } : undefined,
+      rolloutAccounting: i.rolloutAccounting ? { ...i.rolloutAccounting } : undefined }));
     let inserted = 0;
     for (const initiative of eligible) {
-      const contract = initiative.rollout?.maturationEvaluation;
+      const contract = initiative.rolloutAccounting?.maturationEvaluation ?? initiative.rollout?.maturationEvaluation;
+      const rung = initiative.rolloutAccounting ? initiative.rolloutAccounting.rung : initiative.rollout?.stage ?? null;
       const cadenceHours = contract?.cadenceHours ?? 6;
       const cadenceMs = cadenceHours * 3_600_000;
       const dueSlotMs = Math.floor(now / cadenceMs) * cadenceMs;
@@ -97,7 +120,7 @@ export class BlockerLifecycleService {
         for (let n = explicit; n >= 1; n--) {
           const slot = dueSlotMs - n * cadenceMs;
           if (this.ledger.recordMaturationEvaluation({ origin: this.origin, featureId: initiative.id,
-            rung: initiative.rollout!.stage, dueSlotMs: slot, evaluatedAtMs: now, status: 'missed-cadence',
+            rung, dueSlotMs: slot, evaluatedAtMs: now, status: 'missed-cadence',
             passingMetrics: 0, totalMetrics: contract?.metrics.length ?? 0, minNormalizedMargin: null,
             contractHash: this.contractHash(contract), newestEvidenceAtMs: null,
             additionalMissedSlots: n === explicit ? Math.max(0, missed - explicit) : 0 })) inserted++;
@@ -105,8 +128,9 @@ export class BlockerLifecycleService {
       }
       if (!contract) {
         if (this.ledger.recordMaturationEvaluation({ origin: this.origin, featureId: initiative.id,
-          rung: initiative.rollout!.stage, dueSlotMs, evaluatedAtMs: now, status: 'missing-contract',
-          passingMetrics: 0, totalMetrics: 0, minNormalizedMargin: null, contractHash: 'missing', newestEvidenceAtMs: null })) inserted++;
+          rung, dueSlotMs, evaluatedAtMs: now, status: initiative.rolloutAccounting?.maturationContractError ? 'invalid-contract' : 'missing-contract',
+          passingMetrics: 0, totalMetrics: 0, minNormalizedMargin: null,
+          contractHash: initiative.rolloutAccounting?.maturationContractError ?? 'missing', newestEvidenceAtMs: null })) inserted++;
         continue;
       }
       this.captureBlockerObservations(initiative.id, contract, now);
@@ -128,7 +152,7 @@ export class BlockerLifecycleService {
       }
       if (status === 'ready' && passing < contract.metrics.length) status = 'insufficient-evidence';
       if (this.ledger.recordMaturationEvaluation({ origin: this.origin, featureId: initiative.id,
-        rung: initiative.rollout!.stage, dueSlotMs, evaluatedAtMs: now, status, passingMetrics: passing,
+        rung, dueSlotMs, evaluatedAtMs: now, status, passingMetrics: passing,
         totalMetrics: contract.metrics.length, minNormalizedMargin: margins.length ? Math.min(...margins) : null,
         contractHash: this.contractHash(contract), newestEvidenceAtMs: newest })) inserted++;
     }
@@ -150,6 +174,16 @@ export class BlockerLifecycleService {
       ['deliverable-completion', this.completionTrend(now - 90 * 86_400_000, 90)],
     ]);
     for (const metric of contract.metrics) {
+      if (metric.source === 'feature-summary') {
+        let projected: { value: number; samples: number } | null = null;
+        try { projected = this.maturationProjections.get(metric.sourceRef)?.() ?? null; } catch { projected = null; }
+        if (projected && Number.isFinite(projected.value) && Number.isInteger(projected.samples) && projected.samples >= 0) {
+          this.ledger.recordMaturationObservation({ origin: this.origin, featureId, metricId: metric.id,
+            source: metric.source, sourceRef: metric.sourceRef, observedAtMs: now,
+            value: projected.value, samples: projected.samples });
+        }
+        continue;
+      }
       const [factor, field] = metric.sourceRef.split('.') as [BlockerFactor, string];
       const source = metric.source === 'blocker-summary' ? summaries.get(factor) : trends.get(factor);
       const value = source?.[field === 'p95Ms' ? 'p95Ms' : field] as number | null | undefined;
@@ -168,15 +202,34 @@ export class BlockerLifecycleService {
     const latest = new Map<string, MaturationEvaluationRecord>();
     for (const row of rows) latest.set(row.featureId, row);
     const byStatus: Record<MaturationEvaluationStatus, number> = { ready: 0, hold: 0, 'stale-evidence': 0,
-      'insufficient-evidence': 0, 'missing-contract': 0, 'missed-cadence': 0 };
+      'insufficient-evidence': 0, 'missing-contract': 0, 'invalid-contract': 0, 'missed-cadence': 0 };
     for (const row of rows) byStatus[row.status]++;
     const features = [...latest.values()].sort((a, b) => a.featureId.localeCompare(b.featureId)).map(r => ({
       featureId: r.featureId, rung: r.rung, status: r.status, evaluatedAt: new Date(r.evaluatedAtMs).toISOString(),
       passingMetrics: r.passingMetrics, totalMetrics: r.totalMetrics,
       minNormalizedMargin: r.minNormalizedMargin, newestEvidenceAt: r.newestEvidenceAtMs ? new Date(r.newestEvidenceAtMs).toISOString() : null,
     }));
-    return { eligible: this.maturationInitiatives.length, evaluated: latest.size,
-      missedDue: Math.max(0, this.maturationInitiatives.length - latest.size), byStatus, features };
+    const accounting = this.maturationAccountingInitiatives.map(i => ({
+      featureId: i.id, disposition: i.rolloutAccounting!.disposition,
+      status: i.status, flagPath: i.rollout?.flagPath ?? null,
+      promotionAuthority: i.rolloutAccounting!.disposition === 'active' ? 'self-owner'
+        : i.rolloutAccounting!.disposition === 'composed' ? 'parent-owner-evidence-only' : 'none',
+      sourcePrNumber: i.rolloutAccounting!.sourcePrNumber, ownerFeatureId: i.rolloutAccounting!.ownerFeatureId ?? null,
+      rung: i.rolloutAccounting!.rung, graduationCriterion: i.rolloutAccounting!.graduationCriterion ?? null,
+      evidenceSource: i.rolloutAccounting!.evidenceSource ?? null,
+      contractError: i.rolloutAccounting!.maturationContractError ?? null,
+      metricCount: i.rolloutAccounting!.maturationEvaluation?.metrics.length ?? 0,
+      metricDescriptors: (i.rolloutAccounting!.maturationEvaluation?.metrics ?? []).map(metric => ({
+        id: metric.id, source: metric.source, sourceRef: metric.sourceRef, descriptorVersion: 1,
+        direction: metric.direction, threshold: metric.threshold, minSamples: metric.minSamples,
+      })),
+    }));
+    const accountingCounts = { active: 0, composed: 0, excluded: 0 };
+    for (const row of accounting) accountingCounts[row.disposition]++;
+    const eligibleCount = this.maturationInitiatives.length;
+    const legacyEligible = Math.max(0, eligibleCount - accountingCounts.active - accountingCounts.composed);
+    return { eligible: eligibleCount, evaluated: latest.size,
+      missedDue: Math.max(0, eligibleCount - latest.size), byStatus, features, accountingCounts, legacyEligible, accounting };
   }
 
   private maturationTrend(sinceMs: number): Record<string, unknown> {

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -3649,8 +3649,18 @@ export class AgentServer {
             if (row.recovered === true) successful++;
           }
           return { value: successful, samples };
-        } catch { return null; }
-        finally { if (fd !== null) try { fs.closeSync(fd); } catch { /* read-only projection cleanup */ } }
+        } catch (error) {
+          DegradationReporter.getInstance().report({
+            feature: 'blocker-lifecycle.context-recovery-projection',
+            primary: 'read the bounded local recovery event tail',
+            fallback: 'return no observation so maturation remains HOLD',
+            reason: error instanceof Error ? error.message : 'recovery event-log read failed',
+            impact: 'context-recovery evidence remains unavailable until a later successful read',
+          });
+          return null;
+        } finally {
+          if (fd !== null) try { fs.closeSync(fd); } catch { /* @silent-fallback-ok — read-only descriptor cleanup */ }
+        }
       });
       this.blockerLifecycleService.registerMaturationProjection('self-heal-gate.successful-repairs', () => ({
         value: this.feedbackDefaultsSelfHealEvidence.successful, samples: this.feedbackDefaultsSelfHealEvidence.samples,

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -385,6 +385,7 @@ export class AgentServer {
   } | null = null;
   private feedbackDrainBackupTimer: ReturnType<typeof setInterval> | null = null;
   private feedbackDrainPosture: FeedbackDrainPosture = { state: 'unavailable', reason: 'initialization-failure' };
+  private feedbackDefaultsSelfHealEvidence = { successful: 0, samples: 0 };
   private parallelActivityIndex: ParallelActivityIndex | null = null;
   private parallelWorkSentinel: ParallelWorkSentinel | null = null;
   private parallelWorkSentinelTimer: ReturnType<typeof setInterval> | null = null;
@@ -2239,7 +2240,13 @@ export class AgentServer {
               });
             },
             audit: (event) => console.log(`[self-heal-gate] feedback-defaults ${event.event}${event.reason ? ` (${event.reason})` : ''}`),
-          }).catch((error) => console.warn('[self-heal-gate] feedback-defaults attempt failed safely:', error instanceof Error ? error.message : 'unknown'));
+          }).then(result => {
+            this.feedbackDefaultsSelfHealEvidence.samples++;
+            if (result.outcome === 'healed' || result.outcome === 'healthy') this.feedbackDefaultsSelfHealEvidence.successful++;
+          }).catch((error) => {
+            this.feedbackDefaultsSelfHealEvidence.samples++;
+            console.warn('[self-heal-gate] feedback-defaults attempt failed safely:', error instanceof Error ? error.message : 'unknown');
+          });
         }
         if (options.config.developmentAgent === true && sourceCheckout) {
           const backupTick = () => {
@@ -3596,6 +3603,59 @@ export class AgentServer {
       startTime: this.startTime,
     };
     this.routeContext = routeCtx;
+    if (this.blockerLifecycleService) {
+      this.blockerLifecycleService.registerMaturationProjection('feedback-factory.completed-runs', () => {
+        const run = this.feedbackDrain?.service.stats().lastRun;
+        if (!run) return null;
+        return { value: run.state === 'succeeded' || run.state === 'no-op' ? 1 : 0, samples: 1 };
+      });
+      this.blockerLifecycleService.registerMaturationProjection('autonomous-throughput.observed-runs', () => {
+        const runs = routeCtx.autonomousThroughputFloor?.status().runs.length ?? 0;
+        return { value: runs, samples: runs };
+      });
+      this.blockerLifecycleService.registerMaturationProjection('claim-verification.classified-claims', () => {
+        const stats = this.completionClaimVerifier?.stats();
+        if (!stats) return null;
+        return { value: stats.classifiedTurns, samples: stats.candidateTurns };
+      });
+      this.blockerLifecycleService.registerMaturationProjection('mutual-ssh.ready-peers', () => {
+        const status = routeCtx.mutualSshHealth?.() as { pairs?: Array<{ mutual?: boolean }> } | null;
+        if (!status?.pairs) return null;
+        return { value: status.pairs.filter(pair => pair.mutual === true).length, samples: status.pairs.length };
+      });
+      this.blockerLifecycleService.registerMaturationProjection('slack-decision-gate.considered-acknowledgments', () => {
+        const stats = options.slack?.getAmbientStats();
+        if (!stats) return null;
+        const channels = stats.channels;
+        const reacted = channels.reduce((sum, channel) => sum + (channel.silentByReason.react ?? 0), 0);
+        const evaluated = channels.reduce((sum, channel) => sum + channel.evaluated, 0);
+        return { value: reacted, samples: evaluated };
+      });
+      this.blockerLifecycleService.registerMaturationProjection('context-recovery.successful-recoveries', () => {
+        const eventPath = path.join(options.config.projectDir, '.instar', 'recovery-events.jsonl');
+        let fd: number | null = null;
+        try {
+          const size = fs.statSync(eventPath).size;
+          const length = Math.min(size, 64 * 1024);
+          const buffer = Buffer.alloc(length);
+          fd = fs.openSync(eventPath, 'r');
+          fs.readSync(fd, buffer, 0, length, size - length);
+          const rows = buffer.toString('utf8').split('\n').slice(length === size ? 0 : 1).filter(Boolean);
+          let samples = 0; let successful = 0;
+          for (const line of rows) {
+            const row = JSON.parse(line) as { failureType?: string; recovered?: boolean };
+            if (row.failureType !== 'context_exhaustion') continue;
+            samples++;
+            if (row.recovered === true) successful++;
+          }
+          return { value: successful, samples };
+        } catch { return null; }
+        finally { if (fd !== null) try { fs.closeSync(fd); } catch { /* read-only projection cleanup */ } }
+      });
+      this.blockerLifecycleService.registerMaturationProjection('self-heal-gate.successful-repairs', () => ({
+        value: this.feedbackDefaultsSelfHealEvidence.successful, samples: this.feedbackDefaultsSelfHealEvidence.samples,
+      }));
+    }
     const routes = createRoutes(routeCtx);
     this.app.use(routes);
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -25125,13 +25125,14 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     if (kind === 'summary') {
       if (!['eligible', 'evaluated', 'missedDue'].every(k => Number.isSafeInteger(m[k]) && (m[k] as number) >= 0) ||
           !m.byStatus || typeof m.byStatus !== 'object' || !Array.isArray(m.features) || m.features.length > 512) return null;
-      const statuses = ['ready', 'hold', 'stale-evidence', 'insufficient-evidence', 'missing-contract', 'missed-cadence'];
+      const statuses = ['ready', 'hold', 'stale-evidence', 'insufficient-evidence', 'missing-contract', 'invalid-contract', 'missed-cadence'];
       const byStatus = m.byStatus as Record<string, unknown>;
-      if (!statuses.every(k => Number.isSafeInteger(byStatus[k]) && (byStatus[k] as number) >= 0)) return null;
+      if (!statuses.filter(k => k !== 'invalid-contract').every(k => Number.isSafeInteger(byStatus[k]) && (byStatus[k] as number) >= 0) ||
+          !(byStatus['invalid-contract'] === undefined || (Number.isSafeInteger(byStatus['invalid-contract']) && (byStatus['invalid-contract'] as number) >= 0))) return null;
       const features = m.features.map(v => {
         if (!v || typeof v !== 'object') return null;
         const f = v as Record<string, unknown>;
-        if (typeof f.featureId !== 'string' || f.featureId.length > 63 || typeof f.rung !== 'string' ||
+        if (typeof f.featureId !== 'string' || f.featureId.length > 63 || !(f.rung === null || typeof f.rung === 'string') ||
             !statuses.includes(String(f.status)) || !Number.isSafeInteger(f.passingMetrics) || !Number.isSafeInteger(f.totalMetrics) ||
             !(f.minNormalizedMargin === null || (typeof f.minNormalizedMargin === 'number' && Number.isFinite(f.minNormalizedMargin)))) return null;
         return { featureId: f.featureId, rung: f.rung, status: f.status, evaluatedAt: f.evaluatedAt,
@@ -25139,8 +25140,57 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
           minNormalizedMargin: f.minNormalizedMargin, newestEvidenceAt: f.newestEvidenceAt ?? null };
       });
       if (features.some(v => v === null)) return null;
+      const dispositions = ['active', 'composed', 'excluded'];
+      let accounting: unknown[] = []; let accountingCounts: Record<string, unknown> | undefined;
+      if (m.accounting !== undefined || m.accountingCounts !== undefined) {
+        if (!Array.isArray(m.accounting) || m.accounting.length > 512 || !m.accountingCounts || typeof m.accountingCounts !== 'object') return null;
+        if (!Number.isSafeInteger(m.legacyEligible) || (m.legacyEligible as number) < 0) return null;
+        accountingCounts = m.accountingCounts as Record<string, unknown>;
+        if (!dispositions.every(k => Number.isSafeInteger(accountingCounts![k]) && (accountingCounts![k] as number) >= 0)) return null;
+        accounting = m.accounting.map(v => {
+          if (!v || typeof v !== 'object') return null;
+          const a = v as Record<string, unknown>;
+          if (typeof a.featureId !== 'string' || a.featureId.length > 63 || !dispositions.includes(String(a.disposition)) ||
+              typeof a.status !== 'string' || a.status.length > 32 || !(a.flagPath === null || typeof a.flagPath === 'string') ||
+              !['self-owner', 'parent-owner-evidence-only', 'none'].includes(String(a.promotionAuthority)) ||
+              !Number.isSafeInteger(a.sourcePrNumber) || (a.sourcePrNumber as number) < 1 ||
+              !(a.rung === null || ['test-agent-live', 'dev-agent-live', 'fleet'].includes(String(a.rung))) ||
+              !(a.ownerFeatureId === null || typeof a.ownerFeatureId === 'string') ||
+              !(a.graduationCriterion === null || typeof a.graduationCriterion === 'string') ||
+              !(a.evidenceSource === null || (typeof a.evidenceSource === 'object' &&
+                ['endpoint', 'log-filter'].includes(String((a.evidenceSource as Record<string, unknown>).type)) &&
+                typeof (a.evidenceSource as Record<string, unknown>).ref === 'string')) ||
+              !(a.contractError == null || ['invalid-json', 'oversized', 'invalid-shape', 'unknown-source-ref'].includes(String(a.contractError))) ||
+              !Number.isSafeInteger(a.metricCount) || (a.metricCount as number) < 0 || !Array.isArray(a.metricDescriptors) ||
+              a.metricDescriptors.length !== a.metricCount) return null;
+          const metricDescriptors = a.metricDescriptors.map(value => {
+            if (!value || typeof value !== 'object') return null;
+            const d = value as Record<string, unknown>;
+            return typeof d.id === 'string' && ['blocker-summary', 'blocker-trend', 'feature-summary'].includes(String(d.source)) &&
+              typeof d.sourceRef === 'string' && d.descriptorVersion === 1 && ['at-least', 'at-most'].includes(String(d.direction)) &&
+              typeof d.threshold === 'number' && Number.isFinite(d.threshold) && Number.isSafeInteger(d.minSamples) && (d.minSamples as number) > 0
+              ? d : null;
+          });
+          if (metricDescriptors.some(value => value === null)) return null;
+          return { ...a, metricDescriptors };
+        });
+        if (accounting.some(v => v === null)) return null;
+        const actualCounts = { active: 0, composed: 0, excluded: 0 };
+        for (const raw of accounting) {
+          const row = raw as Record<string, unknown>;
+          actualCounts[row.disposition as keyof typeof actualCounts]++;
+          if ((row.disposition === 'active') !== (row.rung !== null)) return null;
+          const expectedAuthority = row.disposition === 'active' ? 'self-owner'
+            : row.disposition === 'composed' ? 'parent-owner-evidence-only' : 'none';
+          if (row.promotionAuthority !== expectedAuthority) return null;
+        }
+        if (dispositions.some(k => actualCounts[k as keyof typeof actualCounts] !== accountingCounts![k]) ||
+            m.eligible !== actualCounts.active + actualCounts.composed + (m.legacyEligible as number)) return null;
+      }
       return { eligible: m.eligible, evaluated: m.evaluated, missedDue: m.missedDue,
-        byStatus: Object.fromEntries(statuses.map(k => [k, byStatus[k]])), features };
+        byStatus: Object.fromEntries(statuses.map(k => [k, byStatus[k] ?? 0])), features,
+        ...(accountingCounts ? { accountingCounts: Object.fromEntries(dispositions.map(k => [k, accountingCounts![k]])),
+          legacyEligible: m.legacyEligible, accounting } : {}) };
     }
     if (!Array.isArray(m.features) || m.features.length > 512) return null;
     return { features: m.features.slice(0, 512) };

--- a/tests/integration/blocker-throughput-pool-routes.test.ts
+++ b/tests/integration/blocker-throughput-pool-routes.test.ts
@@ -14,6 +14,8 @@ const countSummary = { factor: 'deliverable-completion', unit: 'count', recovera
   medianMs: null, p95Ms: null, outcomes: { ...outcomes, observed: 2 } };
 const counters = { attempted: 0, inserted: 0, deduped: 0, failed: 0, queueOverflow: 0, reconciled: 0,
   requestSamplesMissing: 0, requestDroppedCapacity: 0, clearDroppedCapacity: 0, breakerOpen: false };
+const descriptor = { id: 'proof', source: 'feature-summary', sourceRef: 'feedback-factory.completed-runs',
+  descriptorVersion: 1, direction: 'at-least', threshold: 1, minSamples: 1 };
 const days = ['2026-07-15', '2026-07-16', '2026-07-17', '2026-07-18', '2026-07-19', '2026-07-20']
   .map((day, index) => ({ day, count: index < 3 ? 1 : 2 }));
 const countTrend = { factor: 'deliverable-completion', unit: 'count', days,
@@ -27,9 +29,9 @@ function app(peerBody: Record<string, unknown>) {
     ? { ...peerBody, origins: peerBody.origins.map(origin => {
       if (!origin || typeof origin !== 'object') return origin;
       const row = origin as Record<string, unknown>;
-      const maturation = row.counters ? { eligible: 0, evaluated: 0, missedDue: 0,
+      const maturation = row.maturation ?? (row.counters ? { eligible: 0, evaluated: 0, missedDue: 0,
         byStatus: { ready: 0, hold: 0, 'stale-evidence': 0, 'insufficient-evidence': 0,
-          'missing-contract': 0, 'missed-cadence': 0 }, features: [] } : { features: [] };
+          'missing-contract': 0, 'missed-cadence': 0 }, features: [] } : { features: [] });
       return { ...row, maturation };
     }) } : peerBody;
   vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(normalizedPeerBody), { status: 200 })));
@@ -87,5 +89,53 @@ describe('blocker throughput pool schema honesty', () => {
     expect(response.body).toMatchObject({ poolComplete: false,
       failures: [{ machineId: 'peer-a', reason: 'invalid-body' }] });
     expect(response.body.origins).toHaveLength(1);
+  });
+
+  it('rejects accounting counts that do not equal the relayed rows', async () => {
+    const peer = { machineId: 'peer-a', factors: [latencySummary('request-to-persist', 'best-effort'),
+      latencySummary('clear-latency', 'reconcilable'), countSummary], counters,
+    maturation: { eligible: 1, evaluated: 0, missedDue: 1,
+      byStatus: { ready: 0, hold: 0, 'stale-evidence': 0, 'insufficient-evidence': 0, 'missing-contract': 0, 'missed-cadence': 0 },
+      features: [], accountingCounts: { active: 5, composed: 3, excluded: 1 }, legacyEligible: 0, accounting: [
+        { featureId: 'one', disposition: 'active', status: 'active', flagPath: 'x', promotionAuthority: 'self-owner', sourcePrNumber: 1531,
+          ownerFeatureId: 'one', rung: 'test-agent-live', graduationCriterion: 'proof', evidenceSource: null, metricCount: 1, metricDescriptors: [descriptor] },
+      ] } };
+    const response = await request(app({ schemaVersion: 2, origins: [peer] }))
+      .get('/blocker-lifecycle/summary?scope=pool').set('Authorization', `Bearer ${AUTH}`);
+    expect(response.body).toMatchObject({ poolComplete: false,
+      failures: [{ machineId: 'peer-a', reason: 'unsupported-maturation' }] });
+  });
+
+  it('rejects a composed accounting row that invents its own rung', async () => {
+    const peer = { machineId: 'peer-a', factors: [latencySummary('request-to-persist', 'best-effort'),
+      latencySummary('clear-latency', 'reconcilable'), countSummary], counters,
+    maturation: { eligible: 1, evaluated: 0, missedDue: 1,
+      byStatus: { ready: 0, hold: 0, 'stale-evidence': 0, 'insufficient-evidence': 0, 'missing-contract': 0, 'missed-cadence': 0 },
+      features: [], accountingCounts: { active: 0, composed: 1, excluded: 0 }, legacyEligible: 0, accounting: [
+        { featureId: 'child', disposition: 'composed', status: 'active', flagPath: null, promotionAuthority: 'parent-owner-evidence-only', sourcePrNumber: 1538,
+          ownerFeatureId: 'owner', rung: 'test-agent-live', graduationCriterion: 'proof', evidenceSource: null, metricCount: 1, metricDescriptors: [descriptor] },
+      ] } };
+    const response = await request(app({ schemaVersion: 2, origins: [peer] }))
+      .get('/blocker-lifecycle/summary?scope=pool').set('Authorization', `Bearer ${AUTH}`);
+    expect(response.body).toMatchObject({ poolComplete: false,
+      failures: [{ machineId: 'peer-a', reason: 'unsupported-maturation' }] });
+  });
+
+  it('accepts a mixed-version peer with an explicit legacy eligible denominator', async () => {
+    const peer = { machineId: 'peer-a', factors: [latencySummary('request-to-persist', 'best-effort'),
+      latencySummary('clear-latency', 'reconcilable'), countSummary], counters,
+    maturation: { eligible: 2, evaluated: 0, missedDue: 2,
+      byStatus: { ready: 0, hold: 0, 'stale-evidence': 0, 'insufficient-evidence': 0, 'missing-contract': 0, 'missed-cadence': 0 },
+      features: [], accountingCounts: { active: 1, composed: 0, excluded: 1 }, legacyEligible: 1, accounting: [
+        { featureId: 'active', disposition: 'active', status: 'active', flagPath: 'flag', promotionAuthority: 'self-owner', sourcePrNumber: 1531,
+          ownerFeatureId: 'active', rung: 'test-agent-live', graduationCriterion: 'proof', evidenceSource: null, metricCount: 1, metricDescriptors: [descriptor] },
+        { featureId: 'docs', disposition: 'excluded', status: 'paused', flagPath: null, promotionAuthority: 'none', sourcePrNumber: 1532,
+          ownerFeatureId: null, rung: null, graduationCriterion: null, evidenceSource: null, metricCount: 0, metricDescriptors: [] },
+      ] } };
+    const response = await request(app({ schemaVersion: 2, origins: [peer] }))
+      .get('/blocker-lifecycle/summary?scope=pool').set('Authorization', `Bearer ${AUTH}`);
+    expect(response.body.poolComplete).toBe(true);
+    expect(response.body.origins[1].maturation).toMatchObject({ eligible: 2, legacyEligible: 1,
+      accountingCounts: { active: 1, composed: 0, excluded: 1 } });
   });
 });

--- a/tests/unit/BlockerLifecycleMaturation.test.ts
+++ b/tests/unit/BlockerLifecycleMaturation.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
 import { BlockerLifecycleLedger } from '../../src/monitoring/BlockerLifecycleLedger.js';
 import { BlockerLifecycleService } from '../../src/monitoring/BlockerLifecycleService.js';
@@ -48,5 +49,120 @@ describe('BlockerLifecycleService maturation evaluation', () => {
     const summary = service.localSummary(24) as { maturation: { eligible: number; evaluated: number } };
     expect(summary.maturation).toMatchObject({ eligible: 3, evaluated: 3 });
     service.close();
+  });
+
+  it('evaluates active and composed accounting with real projections and reports excluded without evaluating it', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'maturation-accounting-')); dirs.push(dir);
+    const now = 2_000_000_000_000;
+    const ledger = new BlockerLifecycleLedger({ dbPath: path.join(dir, 'ledger.db'), now: () => now });
+    const events = new EventEmitter() as EventEmitter & { getAll(): never[]; update(): Promise<boolean>; getBlockerEpisodeDropBuckets(): Record<string, never> };
+    events.getAll = () => []; events.update = async () => true; events.getBlockerEpisodeDropBuckets = () => ({});
+    const service = new BlockerLifecycleService(events as unknown as CommitmentTracker, ledger, 'm1', () => now);
+    service.registerMaturationProjection('feedback-factory.completed-runs', () => ({ value: 2, samples: 2 }));
+    service.registerMaturationProjection('claim-verification.classified-claims', () => ({ value: 0, samples: 1 }));
+    const metric = { cadenceHours: 6, evidenceMaxAgeHours: 12, metrics: [{ id: 'proof', source: 'feature-summary' as const,
+      sourceRef: 'feedback-factory.completed-runs', direction: 'at-least' as const, threshold: 1, minSamples: 1 }] };
+    const base = { title: 'x', description: 'x', status: 'active', phases: [], currentPhaseIndex: 0,
+      lastTouchedAt: new Date(now).toISOString(), needsUser: false, blockers: [], links: [],
+      createdAt: new Date(now).toISOString(), updatedAt: new Date(now).toISOString(), kind: 'task' } as const;
+    const initiatives = [
+      { ...base, id: 'active', rolloutAccounting: { disposition: 'active', sourcePrNumber: 1531, rung: 'dev-agent-live', maturationEvaluation: metric } },
+      { ...base, id: 'composed', rolloutAccounting: { disposition: 'composed', sourcePrNumber: 1538, rung: null, ownerFeatureId: 'active', maturationEvaluation: metric } },
+      { ...base, id: 'provider-unavailable-claim', rolloutAccounting: { disposition: 'active', sourcePrNumber: 1534, rung: 'test-agent-live', maturationEvaluation: {
+        cadenceHours: 6, evidenceMaxAgeHours: 12, metrics: [{ id: 'classified', source: 'feature-summary',
+          sourceRef: 'claim-verification.classified-claims', direction: 'at-least', threshold: 1, minSamples: 1 }],
+      } } },
+      { ...base, id: 'invalid-contract', rolloutAccounting: { disposition: 'composed', sourcePrNumber: 1538, rung: null,
+        ownerFeatureId: 'active', maturationContractError: 'unknown-source-ref' } },
+      { ...base, id: 'excluded', rolloutAccounting: { disposition: 'excluded', sourcePrNumber: 1532, rung: null, exclusionReason: 'docs-only' } },
+    ] as Initiative[];
+    expect(service.evaluateMaturation(initiatives)).toEqual({ eligible: 4, inserted: 4 });
+    expect(ledger.maturationEvaluations('m1', now - 24 * 3_600_000).map(row => [row.featureId, row.rung, row.status])).toEqual([
+      ['active', 'dev-agent-live', 'ready'], ['composed', null, 'ready'], ['invalid-contract', null, 'invalid-contract'],
+      ['provider-unavailable-claim', 'test-agent-live', 'hold'],
+    ]);
+    const summary = service.localSummary(24) as { maturation: { accountingCounts: unknown; accounting: unknown[] } };
+    expect(summary.maturation.accountingCounts).toEqual({ active: 2, composed: 2, excluded: 1 });
+    expect(summary.maturation.accounting).toHaveLength(5);
+    service.close();
+  });
+
+  it('migrates the existing D7 table to permit an honest null composed rung', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'maturation-migration-')); dirs.push(dir);
+    const dbPath = path.join(dir, 'ledger.db');
+    const old = new Database(dbPath);
+    old.exec(`CREATE TABLE maturation_evaluations (
+      origin TEXT NOT NULL, feature_id TEXT NOT NULL, rung TEXT NOT NULL,
+      due_slot_ms INTEGER NOT NULL, evaluated_at_ms INTEGER NOT NULL, status TEXT NOT NULL,
+      passing_metrics INTEGER NOT NULL, total_metrics INTEGER NOT NULL,
+      min_normalized_margin REAL, contract_hash TEXT NOT NULL, newest_evidence_at_ms INTEGER,
+      additional_missed_slots INTEGER NOT NULL DEFAULT 0, schema_version INTEGER NOT NULL DEFAULT 1,
+      UNIQUE(origin,feature_id,due_slot_ms));`);
+    old.prepare(`INSERT INTO maturation_evaluations
+      (origin,feature_id,rung,due_slot_ms,evaluated_at_ms,status,passing_metrics,total_metrics,contract_hash)
+      VALUES ('m1','legacy','live',1,1,'ready',1,1,'old')`).run();
+    old.close();
+    const ledger = new BlockerLifecycleLedger({ dbPath, now: () => 2_000_000_000_000 });
+    expect(ledger.recordMaturationEvaluation({ origin: 'm1', featureId: 'composed', rung: null,
+      dueSlotMs: 2, evaluatedAtMs: 2, status: 'ready', passingMetrics: 1, totalMetrics: 1,
+      minNormalizedMargin: 0, contractHash: 'new', newestEvidenceAtMs: 2 })).toBe(true);
+    expect(ledger.maturationEvaluations('m1', 0).map(row => [row.featureId, row.rung])).toEqual([
+      ['composed', null], ['legacy', 'live'],
+    ]);
+    ledger.close();
+  });
+
+  it('keeps legacy and accounted tracks in one consistent evaluation denominator', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'maturation-mixed-')); dirs.push(dir);
+    const now = 2_000_000_000_000;
+    const ledger = new BlockerLifecycleLedger({ dbPath: path.join(dir, 'ledger.db'), now: () => now });
+    const events = new EventEmitter() as EventEmitter & { getAll(): never[]; update(): Promise<boolean>; getBlockerEpisodeDropBuckets(): Record<string, never> };
+    events.getAll = () => []; events.update = async () => true; events.getBlockerEpisodeDropBuckets = () => ({});
+    const service = new BlockerLifecycleService(events as unknown as CommitmentTracker, ledger, 'm1', () => now);
+    const base = { title: 'x', description: 'x', status: 'active', phases: [], currentPhaseIndex: 0,
+      lastTouchedAt: new Date(now).toISOString(), needsUser: false, blockers: [], links: [],
+      createdAt: new Date(now).toISOString(), updatedAt: new Date(now).toISOString(), kind: 'task' } as const;
+    const initiatives = [
+      { ...base, id: 'accounted', rolloutAccounting: { disposition: 'active', sourcePrNumber: 1531, rung: 'test-agent-live' } },
+      { ...base, id: 'legacy', rollout: { flagPath: 'legacy', stage: 'dark' } },
+      { ...base, id: 'excluded', rolloutAccounting: { disposition: 'excluded', sourcePrNumber: 1532, rung: null } },
+    ] as Initiative[];
+    expect(service.evaluateMaturation(initiatives).eligible).toBe(2);
+    const summary = service.localSummary(24) as { maturation: { eligible: number; evaluated: number; accounting: unknown[] } };
+    expect(summary.maturation).toMatchObject({ eligible: 2, evaluated: 2 });
+    expect(summary.maturation.accounting).toHaveLength(2);
+    service.close();
+  });
+
+  it('migrates feature-summary observation CHECK constraints without losing rows or the latest index', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'maturation-observation-migration-')); dirs.push(dir);
+    const dbPath = path.join(dir, 'ledger.db');
+    const old = new Database(dbPath);
+    old.exec(`CREATE TABLE maturation_metric_observations (
+      origin TEXT NOT NULL, feature_id TEXT NOT NULL, metric_id TEXT NOT NULL,
+      source TEXT NOT NULL CHECK (source IN ('blocker-summary','blocker-trend')),
+      source_ref TEXT NOT NULL, observed_at_ms INTEGER NOT NULL, value REAL NOT NULL,
+      samples INTEGER NOT NULL, descriptor_version INTEGER NOT NULL DEFAULT 1,
+      benchmark_ref TEXT, schema_version INTEGER NOT NULL DEFAULT 1,
+      UNIQUE(origin,feature_id,metric_id,source,source_ref,observed_at_ms));
+      CREATE INDEX idx_maturation_observation_latest ON maturation_metric_observations
+        (origin,feature_id,metric_id,source,source_ref,observed_at_ms DESC);`);
+    old.prepare(`INSERT INTO maturation_metric_observations
+      (origin,feature_id,metric_id,source,source_ref,observed_at_ms,value,samples,descriptor_version,benchmark_ref)
+      VALUES ('m1','legacy','coverage','blocker-summary','clear-latency.coverage',1,0.9,4,7,'bench')`).run();
+    old.close();
+    const now = 2_000_000_000_000;
+    const ledger = new BlockerLifecycleLedger({ dbPath, now: () => now });
+    expect(ledger.recordMaturationObservation({ origin: 'm1', featureId: 'feature', metricId: 'runs',
+      source: 'feature-summary', sourceRef: 'feedback-factory.completed-runs', observedAtMs: now,
+      value: 1, samples: 1 })).toBe(true);
+    const rows = ledger.maturationObservations('m1', 0);
+    expect(rows.find(row => row.featureId === 'legacy')).toMatchObject({ value: 0.9, samples: 4, descriptorVersion: 7, benchmarkRef: 'bench' });
+    ledger.close();
+    const check = new Database(dbPath, { readonly: true });
+    expect((check.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='maturation_metric_observations'").get() as { sql: string }).sql)
+      .toContain("'feature-summary'");
+    expect(check.prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_maturation_observation_latest'").get()).toBeTruthy();
+    check.close();
   });
 });

--- a/tests/unit/feature-rollout-reconciler.test.ts
+++ b/tests/unit/feature-rollout-reconciler.test.ts
@@ -60,6 +60,29 @@ describe('derivePipelineStage', () => {
 });
 
 describe('FeatureRolloutReconciler', () => {
+  it('accounts five active, three composed, and one excluded without synthetic child controls', async () => {
+    const contract = { cadenceHours: 6, evidenceMaxAgeHours: 12, metrics: [
+      { id: 'proof', source: 'feature-summary' as const, sourceRef: 'feedback-factory.completed-runs', direction: 'at-least' as const, threshold: 1, minSamples: 1 },
+    ] };
+    const active = Array.from({ length: 5 }, (_, n) => art({ id: `active-${n}`, specPath: `docs/specs/active-${n}.md`,
+      merged: true, shipsStaged: true, flagPath: `flags.active${n}`, rolloutDisposition: 'active', sourcePrNumber: 1531 + n,
+      promotionCriteria: 'feature proof', maturationEvaluation: contract }));
+    const composed = Array.from({ length: 3 }, (_, n) => art({ id: `composed-${n}`, specPath: `docs/specs/composed-${n}.md`,
+      merged: true, rolloutDisposition: 'composed', sourcePrNumber: 1536 + n, ownerFeatureId: 'active-0',
+      promotionCriteria: 'component proof', maturationEvaluation: contract }));
+    const excluded = art({ id: 'excluded', specPath: 'docs/specs/excluded.md', merged: true,
+      rolloutDisposition: 'excluded', sourcePrNumber: 1532, exclusionReason: 'docs-only' });
+    await makeReconciler([...active, ...composed, excluded], { flagEnabled: true, flagDryRun: false }).reconcile();
+    const rows = tracker.list().map(i => i.rolloutAccounting).filter(Boolean);
+    expect(rows.filter(r => r!.disposition === 'active')).toHaveLength(5);
+    expect(rows.filter(r => r!.disposition === 'composed')).toHaveLength(3);
+    expect(rows.filter(r => r!.disposition === 'excluded')).toHaveLength(1);
+    expect(tracker.list().filter(i => i.rolloutAccounting?.disposition === 'active')
+      .every(i => i.rolloutAccounting?.ownerFeatureId === i.id)).toBe(true);
+    expect(rows.filter(r => r!.disposition !== 'active').every(r => r!.rung === null)).toBe(true);
+    expect(tracker.list().filter(i => i.rolloutAccounting?.disposition === 'composed').every(i => i.rollout === undefined)).toBe(true);
+  });
+
   it('auto-creates a task at the right pipelineStage (dogfood: a spec appears on its own)', async () => {
     await makeReconciler([art({ approved: true, traceExists: true, prNumber: 42 })]).reconcile();
     const got = tracker.get('feat-x')!;

--- a/tests/unit/featureRolloutScan.test.ts
+++ b/tests/unit/featureRolloutScan.test.ts
@@ -16,6 +16,7 @@ import {
   parseSpecFrontmatter,
   scanSpecArtifacts,
   makeFlagObserver,
+  parseMaturationContract,
 } from '../../src/core/featureRolloutScan.js';
 
 describe('normalizeSpecId', () => {
@@ -99,6 +100,48 @@ describe('makeFlagObserver (read-only)', () => {
   it('defaultEnabled true when the shipped default is on', () => {
     const obs = makeFlagObserver({}, { monitoring: { featX: { enabled: true } } })('monitoring.featX');
     expect(obs.defaultEnabled).toBe(true);
+  });
+});
+
+describe('rollout accounting frontmatter', () => {
+  it('accepts only the closed feature-summary projection registry', () => {
+    const valid = parseMaturationContract(JSON.stringify({ cadenceHours: 6, evidenceMaxAgeHours: 12, metrics: [
+      { id: 'runs', source: 'feature-summary', sourceRef: 'feedback-factory.completed-runs', direction: 'at-least', threshold: 1, minSamples: 1 },
+    ] }));
+    expect(valid?.ok).toBe(true);
+    const unknown = parseMaturationContract(JSON.stringify({ cadenceHours: 6, evidenceMaxAgeHours: 12, metrics: [
+      { id: 'runs', source: 'feature-summary', sourceRef: 'invented.metric', direction: 'at-least', threshold: 1, minSamples: 1 },
+    ] }));
+    expect(unknown).toEqual({ ok: false, error: 'unknown-source-ref' });
+  });
+
+  it('keeps accounting visible while surfacing an invalid metric contract', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'rollout-invalid-contract-'));
+    try {
+      fs.mkdirSync(path.join(repo, 'docs', 'specs'), { recursive: true });
+      fs.writeFileSync(path.join(repo, 'docs', 'specs', 'BAD.md'), `---
+approved: true
+rollout-disposition: composed
+rollout-source-pr: 1538
+rollout-owner-feature: owner
+rollout-metrics-json: '{"cadenceHours":6,"evidenceMaxAgeHours":12,"metrics":[{"id":"bad","source":"feature-summary","sourceRef":"invented.metric","direction":"at-least","threshold":1,"minSamples":1}]}'
+---
+# Bad`);
+      const row = scanSpecArtifacts(repo)[0];
+      expect(row).toMatchObject({ rolloutDisposition: 'composed', sourcePrNumber: 1538,
+        ownerFeatureId: 'owner', maturationContractError: 'unknown-source-ref' });
+      expect(row.maturationEvaluation).toBeUndefined();
+    } finally { SafeFsExecutor.safeRmSync(repo, { recursive: true, force: true, operation: 'invalid contract fixture' }); }
+  });
+
+  it('accounts source PRs 1531-1539 exactly as 5 active, 3 composed, 1 excluded', () => {
+    const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+    const rows = scanSpecArtifacts(root).filter(row => row.sourcePrNumber && row.sourcePrNumber >= 1531 && row.sourcePrNumber <= 1539);
+    expect(rows.map(row => row.sourcePrNumber).sort((a, b) => a! - b!)).toEqual([1531, 1532, 1533, 1534, 1535, 1536, 1537, 1538, 1539]);
+    expect(rows.filter(row => row.rolloutDisposition === 'active')).toHaveLength(5);
+    expect(rows.filter(row => row.rolloutDisposition === 'composed')).toHaveLength(3);
+    expect(rows.filter(row => row.rolloutDisposition === 'excluded')).toHaveLength(1);
+    expect(rows.filter(row => row.rolloutDisposition !== 'excluded').every(row => row.maturationEvaluation?.metrics.length === 1)).toBe(true);
   });
 });
 

--- a/upgrades/side-effects/nine-feature-rollout-closure.md
+++ b/upgrades/side-effects/nine-feature-rollout-closure.md
@@ -1,0 +1,125 @@
+# Side-Effects Review — Nine-feature rollout placement closure
+
+**Version / slug:** `nine-feature-rollout-closure`
+**Date:** `2026-07-21`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** `throughput_second_pass (concurred)`
+
+## Summary of the change
+
+This change accounts for source PRs 1531–1539 in the existing rollout scanner,
+InitiativeTracker, and D7 lifecycle ledger. Five independently controlled features
+are active, three owner-controlled components are composed, and one documentation-only
+source is excluded. Existing owner services provide bounded numeric projections; no
+new rollout control or persistence authority is introduced.
+
+## Decision-point inventory
+
+- `featureRolloutScan` contract parsing — modified — classifies explicit rollout
+  accounting metadata and rejects malformed contracts as invalid evidence.
+- `FeatureRolloutReconciler` placement — modified — maps active controls to rungs while
+  preserving null rungs for composed and excluded rows.
+- `BlockerLifecycleService.evaluateMaturation` — modified — evaluates active and
+  composed evidence through the existing D7 authority; excluded rows remain visible
+  but ineligible.
+- Pool-summary sanitizer — modified — rejects structurally dishonest peer summaries.
+
+## 1. Over-block
+
+Malformed or future-version peer accounting rows are rejected from the pool summary.
+That is intentional boundary validation: accepting a row whose claimed disposition,
+rung, counts, or descriptors disagree would corrupt the denominator. Local legacy rows
+remain supported explicitly through `legacyEligible`.
+
+## 2. Under-block
+
+A structurally valid peer can still report inaccurate underlying owner measurements;
+this change validates the contract envelope, not remote machine integrity. Freshness,
+sample floors, and owner-local projection semantics keep missing or stale evidence from
+becoming green, but Byzantine peers are outside this trusted-agent pool model.
+
+## 3. Level-of-abstraction fit
+
+The scanner owns declarative contract discovery, InitiativeTracker owns placement
+accounting, existing feature services own operational truth, and D7 remains the sole
+maturation evaluator. The implementation extends those existing layers instead of
+adding a parallel registry, synthetic flag, or child-owned promotion authority.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+
+The new projections are numeric observations. They do not promote, block, or mutate
+their owner systems. D7 consumes them under persisted contracts and produces the
+existing HOLD/READY/REGRESSED lifecycle decision. Pool validation is a hard structural
+API invariant, which the principle explicitly permits at system boundaries.
+
+## 4b. Judgment-point check
+
+No new static heuristic is added at a competing-signals judgment point. Thresholds and
+sample floors are explicit feature contracts; disposition/rung relations and peer
+schema checks are enumerable invariants. Promotion remains outside this change.
+
+## 5. Interactions
+
+- **Shadowing:** contract errors become `invalid-contract` before metric evaluation;
+  they cannot be misreported as ordinary missing evidence.
+- **Double-fire:** projections are read-only snapshots and do not trigger owner actions.
+- **Races:** each snapshot tolerates concurrent owner updates; it records a bounded
+  point-in-time value and D7 applies its existing evaluation transaction.
+- **Feedback loops:** maturation output does not write into source metrics or promote a
+  rollout, so no control loop is introduced.
+
+## 6. External surfaces
+
+The blocker lifecycle local and pool summary responses gain accounting rows, metric
+descriptors, exact counts, nullable rungs, and promotion-authority labels. Existing
+legacy response semantics remain represented. The D7 SQLite schema migrates its source
+CHECK and nullable-rung constraint transactionally while preserving rows and indexes.
+There are no new operator actions, URLs, notices, or external-service writes.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Proxied-on-read:** source observations are machine-local truths, while
+`/blocker-lifecycle/summary?scope=pool` merges and strictly validates peer summaries.
+The response preserves per-origin accounting rather than pretending local counters are
+replicated. This emits no user-facing notices, creates no generated URLs, and strands
+no topic-owned state. The existing D7 ledger remains machine-local evidence history;
+pool reads are the cross-machine answer surface.
+
+## 8. Rollback cost
+
+Revert and ship a patch. The ledger migrations are additive/compatibility-preserving;
+older code ignores accounting stored in initiative JSON and can read the recreated D7
+tables. No external state repair or user notification is required.
+
+## Conclusion
+
+The change is clear to ship. Review tightened classified-claim causality, hostile-peer
+invariants, mixed legacy/accounted denominators, nullable-rung migrations, and explicit
+promotion authority. Focused typecheck and 38 rollout/migration tests pass.
+
+## Second-pass review
+
+**Reviewer:** `throughput_second_pass`
+**Independent read of the artifact: concur**
+
+The independent implementation review completed three passes and concurred after the
+claim, pool-integrity, denominator, and migration findings were repaired and tested.
+
+## Evidence pointers
+
+- `tests/unit/featureRolloutScan.test.ts`
+- `tests/unit/feature-rollout-reconciler.test.ts`
+- `tests/unit/BlockerLifecycleMaturation.test.ts`
+- `tests/integration/blocker-throughput-pool-routes.test.ts`
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect and no self-triggered controller — not applicable.

--- a/upgrades/side-effects/nine-feature-rollout-closure.md
+++ b/upgrades/side-effects/nine-feature-rollout-closure.md
@@ -71,6 +71,8 @@ schema checks are enumerable invariants. Promotion remains outside this change.
   point-in-time value and D7 applies its existing evaluation transaction.
 - **Feedback loops:** maturation output does not write into source metrics or promote a
   rollout, so no control loop is introduced.
+- **Degradation visibility:** a throwing owner projection or failed bounded recovery-log
+  read reports through `DegradationReporter`; the observation remains absent/HOLD.
 
 ## 6. External surfaces
 


### PR DESCRIPTION
## ELI16 — honest rollout accounting for nine shipped source PRs

This change makes the rollout dashboard tell the truth about nine recently shipped pull requests. Five are features with their own switches and can move through the test-agent, development-agent, and fleet ladder. Three are working parts of larger systems, so they are measured through the systems that already own them and do not receive fake switches or fake promotion power. One is documentation, so it stays visible for provenance but is not treated as runnable software. Existing counters feed the existing D7 evidence ledger, missing or malformed evidence cannot turn green, and pool-wide summaries verify every peer’s counts and rung claims before including them.

## Summary
- account PRs #1531-#1539 exactly as five active, three composed, and one excluded source
- project real owner metrics into the existing D7 ledger without synthetic controls or a parallel store
- harden nullable-rung/source migrations and pool-summary schema honesty

## Evidence
- TypeScript typecheck passes
- 38 focused rollout, maturation, migration, and pool tests pass
- instar-dev Tier 2 pre-commit gate passes
- independent implementation review: CONCUR

## Specification
- docs/specs/nine-feature-rollout-closure.md
- convergence report: docs/specs/reports/nine-feature-rollout-closure-convergence.md