### PR TITLE
fix: honor fractional autonomous timestamps on macOS

### DIFF
--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -238,6 +238,19 @@ fm_get_raw() {
   printf '%s' "$val"
 }
 
+# Convert the ISO-8601 timestamps written by the autonomous setup path on both
+# macOS/BSD and GNU date. BSD date's strict format rejects fractional seconds,
+# so normalize only a terminal fractional component before parsing. Invalid
+# input remains fail-safe and returns 0.
+iso8601_epoch() {
+  local raw="${1:-}"
+  local normalized
+  normalized=$(printf '%s' "$raw" | sed 's/\.[0-9][0-9]*Z$/Z/')
+  date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$normalized" +%s 2>/dev/null \
+    || date -d "$normalized" +%s 2>/dev/null \
+    || echo "0"
+}
+
 ACTIVE=$(fm_get active)
 if [[ "$ACTIVE" != "true" ]]; then
   exit 0
@@ -530,7 +543,7 @@ if [[ "$GOAL_MODE" == "native" ]]; then
     echo "[autonomous] emergency stop — native /goal cleared" >&2; exit 0
   fi
   if [[ "$DURATION_SECONDS" =~ ^[0-9]+$ ]] && [[ $DURATION_SECONDS -gt 0 ]]; then
-    NG_START=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || date -d "$STARTED_AT" +%s 2>/dev/null || echo 0)
+    NG_START=$(iso8601_epoch "$STARTED_AT")
     if [[ "$NG_START" =~ ^[0-9]+$ ]] && [[ $NG_START -gt 0 ]] && [[ $(( $(date +%s) - NG_START )) -ge $DURATION_SECONDS ]]; then
       notify_terminal_stop "⏰ My autonomous run on \"$(goal_snippet)\" hit its time limit and stopped. Ask me and I'll pick up where I left off."
       run_end_call "duration-expiry (native-goal)"
@@ -557,7 +570,7 @@ fi
 # premature exit (that is the very failure class this hook exists to prevent).
 REMAINING_MIN=""
 if [[ "$DURATION_SECONDS" =~ ^[0-9]+$ ]] && [[ $DURATION_SECONDS -gt 0 ]]; then
-  START_EPOCH=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || date -d "$STARTED_AT" +%s 2>/dev/null || echo "0")
+  START_EPOCH=$(iso8601_epoch "$STARTED_AT")
   if [[ "$START_EPOCH" =~ ^[0-9]+$ ]] && [[ $START_EPOCH -gt 0 ]]; then
     NOW_EPOCH=$(date +%s)
     ELAPSED=$(( NOW_EPOCH - START_EPOCH ))
@@ -1701,14 +1714,14 @@ REPORT_DUE="false"
 NOW_EPOCH=$(date +%s)
 if [[ -z "$LAST_REPORT_AT" ]] || [[ "$LAST_REPORT_AT" == "null" ]]; then
   if [[ -n "$STARTED_AT" ]]; then
-    START_EPOCH_R=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || date -d "$STARTED_AT" +%s 2>/dev/null || echo "0")
+    START_EPOCH_R=$(iso8601_epoch "$STARTED_AT")
     ELAPSED_SINCE_START=$(( NOW_EPOCH - START_EPOCH_R ))
     if [[ $ELAPSED_SINCE_START -ge $REPORT_INTERVAL_SECS ]]; then
       REPORT_DUE="true"
     fi
   fi
 else
-  LAST_REPORT_EPOCH=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$LAST_REPORT_AT" +%s 2>/dev/null || date -d "$LAST_REPORT_AT" +%s 2>/dev/null || echo "0")
+  LAST_REPORT_EPOCH=$(iso8601_epoch "$LAST_REPORT_AT")
   ELAPSED_SINCE_REPORT=$(( NOW_EPOCH - LAST_REPORT_EPOCH ))
   if [[ $ELAPSED_SINCE_REPORT -ge $REPORT_INTERVAL_SECS ]]; then
     REPORT_DUE="true"

--- a/tests/unit/autonomous-stop-hook-topic-keyed.test.ts
+++ b/tests/unit/autonomous-stop-hook-topic-keyed.test.ts
@@ -54,6 +54,7 @@ function writeState(opts: {
   reportChannel?: string;
   iteration?: number;
   durationSeconds?: number;
+  startedAt?: string;
   completionPromise?: string;
   extraFrontmatter?: string;
   task?: string;
@@ -65,11 +66,12 @@ function writeState(opts: {
     reportChannel,
     iteration = 1,
     durationSeconds = 0,
+    startedAt,
     completionPromise = 'ALL_DONE',
     extraFrontmatter = '',
     task = 'Keep building the thing until done.',
   } = opts;
-  const started = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+  const started = startedAt ?? new Date().toISOString().replace(/\.\d+Z$/, 'Z');
   const channelLine = reportChannel ? `\nreport_channel: "${reportChannel}"` : '';
   const content = `---
 active: ${active}
@@ -284,6 +286,40 @@ describe('T5 — existing exit paths preserved', () => {
     writeRegistry({ '9984': 'echo-claude-agent-sdk' });
     const r = runHook({ sessionId: NEW_UUID, tmuxSession: 'echo-claude-agent-sdk' });
     expect(r.decision).not.toBe('block');
+  });
+
+  it('parses a millisecond timestamp to a non-zero epoch', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    expect(future).toMatch(/\.\d{3}Z$/);
+    writeState({
+      sessionId: OLD_UUID,
+      reportTopic: '9984',
+      durationSeconds: 7200,
+      startedAt: future,
+    });
+    writeRegistry({ '9984': 'echo-claude-agent-sdk' });
+
+    const r = runHook({ sessionId: OLD_UUID, tmuxSession: 'echo-claude-agent-sdk' });
+
+    expect(r.decision).toBe('block');
+    expect(r.stderr).not.toContain('started_at unparseable');
+  });
+
+  it('expires a run whose millisecond timestamp is past its duration', () => {
+    const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    expect(past).toMatch(/\.\d{3}Z$/);
+    writeState({
+      sessionId: OLD_UUID,
+      reportTopic: '9984',
+      durationSeconds: 10,
+      startedAt: past,
+    });
+    writeRegistry({ '9984': 'echo-claude-agent-sdk' });
+
+    const r = runHook({ sessionId: OLD_UUID, tmuxSession: 'echo-claude-agent-sdk' });
+
+    expect(r.decision).not.toBe('block');
+    expect(fs.existsSync(path.join(tmpDir, '.instar', 'autonomous-state.local.md'))).toBe(false);
   });
 });
 

--- a/upgrades/next/autonomous-fractional-timestamp-expiry.md
+++ b/upgrades/next/autonomous-fractional-timestamp-expiry.md
@@ -1,0 +1,24 @@
+# Autonomous fractional-timestamp expiry on macOS
+
+## What Changed
+
+The autonomous stop hook now parses ISO-8601 timestamps with fractional seconds on macOS as well as Linux. It normalizes the terminal fractional-second component before using the existing BSD or GNU date parser, while malformed timestamps retain the existing fail-safe behavior and keep the run alive.
+
+The shared parser is used by the standard duration-expiry path, the native-goal expiry path, and the related progress-report timing calculations. No parallel clock or lifecycle path was added.
+
+## What to Tell Your User
+
+Timed autonomous runs on macOS now stop when their configured duration expires even when their recorded start time includes milliseconds. This closes a lifecycle-safety gap that could previously let a timed run continue until it completed or encountered another stopping condition.
+
+## Summary of New Capabilities
+
+- Fractional-second autonomous timestamps work on macOS and Linux.
+- Duration expiry remains fail-safe for genuinely malformed timestamps.
+- Standard and native-goal runs share the same timestamp interpretation.
+
+## Evidence
+
+- A macOS BSD-date check proves the strict millisecond form fails while the normalized form resolves to the exact expected epoch.
+- Behavioral coverage proves a millisecond timestamp yields a valid non-zero epoch.
+- Behavioral coverage proves a run past its duration exits and clears its autonomous state.
+- Build, type, lint, and focused autonomous-hook tests pass.


### PR DESCRIPTION
## What changed

- Added one shared ISO-8601 epoch parser to the existing autonomous stop hook source.
- Normalized only terminal fractional seconds before the existing BSD/GNU date parsing fallback.
- Reused that parser for standard duration expiry, native-goal duration expiry, and progress-report timing.
- Added behavioral regression coverage for both a valid non-zero millisecond epoch and an actually expired millisecond-stamped run.

## Root cause

The autonomous setup path writes timestamps such as `2026-07-21T17:42:00.000Z`, but macOS BSD `date` was called with a strict seconds-only format. Parsing failed, the hook fell back to epoch zero, and its fail-safe correctly avoided a premature exit—but that also silently skipped every configured duration expiry on macOS.

## Validation

- Exact macOS check: strict fractional input is rejected; normalized input resolves to epoch `1784655720`, matching JavaScript's expected epoch.
- Focused autonomous hook suite: 16/16 passing, including both new boundary tests.
- Build and full lint chain passing.
- Release-note validation and pre-push gate passing.
- Full CI matrix is the merge authority; native squash auto-merge will be armed.

## ELI16

Autonomous runs have a written start time and a promised maximum duration. The code that checks whether time is up expected the start time to end at whole seconds, but the code that writes it includes milliseconds. Linux could understand both forms; macOS could not, so it treated the start time as unreadable and safely kept the run alive. That safety choice prevented accidental early stops, but it also meant the real time limit never fired. This change removes only the millisecond portion before asking the operating system to read the timestamp. Both macOS and Linux now calculate the same start moment, while truly malformed timestamps still keep the old fail-safe behavior. Tests prove both halves: a millisecond timestamp becomes the correct non-zero epoch, and a run whose real deadline has passed actually stops and clears its state.
