### PR TITLE
feat(mesh): SessionPoolRolloutDriver — the missing rollout-gate driver

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-22T18-09-54-840Z-sessionpool-rollout-driver.json
+++ b/.instar/instar-dev-decisions/2026-07-22T18-09-54-840Z-sessionpool-rollout-driver.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-22T18:09:54.840Z",
+  "slug": "sessionpool-rollout-driver",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 248,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass",
+  "note": "Additive, dark-by-default, unwired rollout-gate driver + unit tests (both boundary sides). Built directly by Echo; mentee builder offline. Typecheck clean, 7/7 unit green."
+}

--- a/src/core/SessionPoolRolloutDriver.ts
+++ b/src/core/SessionPoolRolloutDriver.ts
@@ -1,0 +1,107 @@
+/**
+ * SessionPoolRolloutDriver — the cadenced DRIVER for the Multi-Machine Session
+ * Pool rollout gate (§Rollout, Track H). `StageAdvancer` is the mechanical gate
+ * (the SOLE writer of `multiMachine.sessionPool.stage`, gated on a green prior-
+ * stage E2E, auto-reverting on red) — but the gate is inert on its own: a
+ * StageAdvancer that nothing CALLS never advances anything. The track-H wiring
+ * note says so explicitly: "StageAdvancer is constructed but not driven yet — the
+ * rollout job that calls advanceTo/reconcile is a later step."
+ *
+ * That "later step" is this driver. On each `tick()` it:
+ *   1. RECONCILES FIRST — a red regression on the current stage must revert to the
+ *      prior safe stage BEFORE any advance is attempted (safety before progress).
+ *   2. ATTEMPTS ONE ADVANCE toward an operator-authorized CEILING — at most one
+ *      stage per tick, and never past the ceiling the operator opted the agent up
+ *      to. The advance itself is still fully gated by `StageAdvancer.advanceTo`
+ *      (green prior-stage E2E for the current commit) — this driver adds cadence
+ *      and an operator ceiling, it NEVER weakens the gate.
+ *
+ * Why this matters (the 2026-07-22 overnight incident): an agent whose sessionPool
+ * sat at `shadow` (watch-only) had nothing to promote it to `live-transfer`, so
+ * when its primary machine slept the standby node could not take over. The gate
+ * machinery existed; the driver that turns a passing failover E2E into an actual
+ * promotion did not. This is that driver.
+ *
+ * ── Dark by default (real authority) ──
+ * Advancing the sessionPool stage changes cross-machine session-migration
+ * behavior — real authority, same class as the reactive swap. So the driver is a
+ * strict no-op unless `enabled()` is true, AND it never advances past
+ * `targetCeiling()` (default `'dark'` ⇒ even when enabled, no auto-advance until
+ * an operator names a ceiling). The decision core is pure (injected deps) so it
+ * tests with zero sessions and zero network.
+ *
+ * ── v1 scope note ──
+ * When disabled the driver does NOTHING — including no reconcile. A red-regression
+ * auto-revert therefore only runs while the driver is enabled; a dark agent's
+ * stage simply stays where its config put it (there is no auto-driving at all).
+ * Coupling reconcile to the enable flag keeps the first increment all-or-nothing
+ * and inert-when-dark; a future increment may split "always reconcile / gate only
+ * the advance" if an operator wants revert-without-advance.
+ */
+
+import { StageAdvancer, STAGES, stageIndex, type SessionPoolStage } from './StageAdvancer.js';
+
+export interface SessionPoolRolloutDriverDeps {
+  advancer: StageAdvancer;
+  /** Dark-by-default master switch: the whole tick is a no-op unless this is true. */
+  enabled: () => boolean;
+  /**
+   * The highest stage the operator has authorized this agent to roll out to. The
+   * driver advances toward it but NEVER past it. Default `'dark'` ⇒ no auto-advance
+   * (reconcile still runs when enabled). An invalid value is treated as `'dark'`.
+   */
+  targetCeiling?: () => SessionPoolStage;
+  audit?: (event: string, detail: Record<string, unknown>) => void;
+}
+
+export interface RolloutTickResult {
+  /** false ⇒ the driver was disabled and did nothing. */
+  ran: boolean;
+  /** The stage after reconcile (== current when no regression, the prior stage on a red revert). */
+  reconciledTo: SessionPoolStage | null;
+  /** The stage advanced TO this tick, or null if no advance happened. */
+  advancedTo: SessionPoolStage | null;
+  /** Why an advance did NOT happen this tick (null when one did, or when disabled). */
+  advanceSkippedReason: 'at-ceiling' | 'e2e-gate-not-passed' | 'already-at-or-past' | 'invalid-stage' | null;
+}
+
+const DARK: SessionPoolStage = 'dark';
+
+export class SessionPoolRolloutDriver {
+  constructor(private readonly d: SessionPoolRolloutDriverDeps) {}
+
+  /**
+   * One rollout cycle: reconcile (revert on red) then attempt a single gated
+   * advance toward the operator ceiling. Safe to call on any cadence; idempotent
+   * once at the ceiling with no fresh E2E. Never throws for a normal decision.
+   */
+  tick(): RolloutTickResult {
+    if (!this.d.enabled()) {
+      return { ran: false, reconciledTo: null, advancedTo: null, advanceSkippedReason: null };
+    }
+
+    // 1. Safety first: a red regression on the current stage reverts BEFORE any advance.
+    const reconciledTo = this.d.advancer.reconcile();
+
+    // 2. Resolve the operator ceiling (clamp an invalid/absent value to the dark floor).
+    const rawCeiling = this.d.targetCeiling ? this.d.targetCeiling() : DARK;
+    const ceiling: SessionPoolStage = stageIndex(rawCeiling) >= 0 ? rawCeiling : DARK;
+
+    const currentIdx = stageIndex(reconciledTo);
+    const ceilingIdx = stageIndex(ceiling);
+
+    // Already at or above the authorized ceiling — nothing to advance.
+    if (currentIdx >= ceilingIdx) {
+      return { ran: true, reconciledTo, advancedTo: null, advanceSkippedReason: 'at-ceiling' };
+    }
+
+    // 3. Attempt exactly one gated advance. StageAdvancer enforces the green E2E gate.
+    const nextStage = STAGES[currentIdx + 1];
+    const res = this.d.advancer.advanceTo(nextStage);
+    if (res.ok) {
+      this.d.audit?.('rollout-advanced', { from: reconciledTo, to: res.stage, ceiling });
+      return { ran: true, reconciledTo, advancedTo: res.stage, advanceSkippedReason: null };
+    }
+    return { ran: true, reconciledTo, advancedTo: null, advanceSkippedReason: res.reason };
+  }
+}

--- a/tests/unit/SessionPoolRolloutDriver.test.ts
+++ b/tests/unit/SessionPoolRolloutDriver.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { SessionPoolRolloutDriver } from '../../src/core/SessionPoolRolloutDriver.js';
+import { StageAdvancer, type SessionPoolStage } from '../../src/core/StageAdvancer.js';
+import type { SessionPoolE2EResultStore, StageE2EResult } from '../../src/core/SessionPoolE2EResultStore.js';
+
+const SHA = 'commit-abc';
+
+/** A minimal in-memory result store: the only two methods StageAdvancer calls. */
+function fakeStore(rows: Partial<Record<number, StageE2EResult>>): SessionPoolE2EResultStore {
+  return {
+    getLatestForStage: (idx: number) => rows[idx] ?? null,
+    // A row present in the map is considered signature-valid for the test.
+    verify: (row: StageE2EResult) => !!row,
+  } as unknown as SessionPoolE2EResultStore;
+}
+
+function row(stage: number, result: 'green' | 'red', commitSha = SHA): StageE2EResult {
+  return { stage, result, commitSha, ranAt: '2026-07-22T00:00:00Z', evidenceRef: `ref-${stage}`, signature: 'sig' } as StageE2EResult;
+}
+
+/** Build a driver over a REAL StageAdvancer with an in-memory stage var. */
+function harness(opts: {
+  initialStage: SessionPoolStage;
+  results: Partial<Record<number, StageE2EResult>>;
+  enabled: boolean;
+  ceiling?: SessionPoolStage;
+}) {
+  let stage = opts.initialStage;
+  const advancer = new StageAdvancer({
+    resultStore: fakeStore(opts.results),
+    currentCommitSha: () => SHA,
+    readStage: () => stage,
+    writeStageConfig: (s) => { stage = s; },
+  });
+  const driver = new SessionPoolRolloutDriver({
+    advancer,
+    enabled: () => opts.enabled,
+    targetCeiling: () => opts.ceiling ?? 'dark',
+  });
+  return { driver, getStage: () => stage };
+}
+
+describe('SessionPoolRolloutDriver', () => {
+  it('is a strict no-op when disabled — no reconcile, no advance', () => {
+    const { driver, getStage } = harness({
+      initialStage: 'shadow',
+      results: { 1: row(1, 'green') }, // a green that WOULD promote if enabled
+      enabled: false,
+      ceiling: 'live-transfer',
+    });
+    const r = driver.tick();
+    expect(r.ran).toBe(false);
+    expect(r.advancedTo).toBeNull();
+    expect(getStage()).toBe('shadow'); // untouched
+  });
+
+  it('advances one stage when the prior-stage E2E is green and below the ceiling', () => {
+    const { driver, getStage } = harness({
+      initialStage: 'shadow',
+      results: { 1: row(1, 'green') }, // green for stage 'shadow' (idx 1) gates advance to 'live-transfer' (idx 2)
+      enabled: true,
+      ceiling: 'live-transfer',
+    });
+    const r = driver.tick();
+    expect(r.ran).toBe(true);
+    expect(r.advancedTo).toBe('live-transfer');
+    expect(r.advanceSkippedReason).toBeNull();
+    expect(getStage()).toBe('live-transfer');
+  });
+
+  it('refuses to advance when no green E2E exists (gate not passed)', () => {
+    const { driver, getStage } = harness({
+      initialStage: 'shadow',
+      results: {}, // no results at all
+      enabled: true,
+      ceiling: 'live-transfer',
+    });
+    const r = driver.tick();
+    expect(r.ran).toBe(true);
+    expect(r.advancedTo).toBeNull();
+    expect(r.advanceSkippedReason).toBe('e2e-gate-not-passed');
+    expect(getStage()).toBe('shadow'); // stays put — the gate held
+  });
+
+  it('never advances past the operator ceiling even with a green E2E', () => {
+    const { driver, getStage } = harness({
+      initialStage: 'shadow',
+      results: { 1: row(1, 'green') },
+      enabled: true,
+      ceiling: 'shadow', // ceiling == current
+    });
+    const r = driver.tick();
+    expect(r.ran).toBe(true);
+    expect(r.advancedTo).toBeNull();
+    expect(r.advanceSkippedReason).toBe('at-ceiling');
+    expect(getStage()).toBe('shadow');
+  });
+
+  it('default ceiling "dark" means enabled-but-no-advance (safety default)', () => {
+    const { driver, getStage } = harness({
+      initialStage: 'dark',
+      results: { 0: row(0, 'green') },
+      enabled: true,
+      // no ceiling ⇒ defaults to 'dark'
+    });
+    const r = driver.tick();
+    expect(r.ran).toBe(true);
+    expect(r.advancedTo).toBeNull();
+    expect(r.advanceSkippedReason).toBe('at-ceiling');
+    expect(getStage()).toBe('dark');
+  });
+
+  it('reconciles FIRST: a red regression on the current stage reverts before any advance', () => {
+    const { driver, getStage } = harness({
+      initialStage: 'live-transfer',
+      // current stage 'live-transfer' (idx 2) recorded RED for this commit → must revert to 'shadow'.
+      // No green for 'shadow' (idx 1) so it cannot immediately re-advance.
+      results: { 2: row(2, 'red') },
+      enabled: true,
+      ceiling: 'live-transfer',
+    });
+    const r = driver.tick();
+    expect(r.ran).toBe(true);
+    expect(r.reconciledTo).toBe('shadow');            // reverted
+    expect(r.advancedTo).toBeNull();                  // did not bounce straight back up
+    expect(r.advanceSkippedReason).toBe('e2e-gate-not-passed');
+    expect(getStage()).toBe('shadow');
+  });
+
+  it('a stale red from a PRIOR commit is not a regression — no revert', () => {
+    const { driver, getStage } = harness({
+      initialStage: 'live-transfer',
+      results: { 2: row(2, 'red', 'old-commit') }, // red but for a different commit
+      enabled: true,
+      ceiling: 'live-transfer',
+    });
+    const r = driver.tick();
+    expect(r.reconciledTo).toBe('live-transfer'); // unchanged
+    expect(getStage()).toBe('live-transfer');
+  });
+});


### PR DESCRIPTION
## What & why

`StageAdvancer` is the mechanical rollout gate for the Multi-Machine Session Pool — the sole writer of `multiMachine.sessionPool.stage`, promoting only on a green prior-stage E2E and auto-reverting on red. But it is **inert on its own**: the track-H wiring note says so explicitly — *"StageAdvancer is constructed but not driven yet — the rollout job that calls advanceTo/reconcile is a later step."*

This PR adds that missing driver. On each `tick()` it:
1. **Reconciles first** — a red regression on the current stage reverts to the prior safe stage *before* any advance (safety before progress).
2. **Attempts one gated advance** toward an operator-authorized ceiling — at most one stage per tick, never past the ceiling. The advance stays fully gated by `StageAdvancer.advanceTo` (green prior-stage E2E for the current commit); the driver only adds cadence + a ceiling, it never weakens the gate.

**Incident motivation (2026-07-22):** an agent whose sessionPool sat at `shadow` (watch-only) had nothing to promote it to `live-transfer`, so when its primary machine slept the standby node could not take over. The gate machinery existed; the driver that turns a passing failover E2E into an actual promotion did not. This is that driver.

## Scope / safety
- **Dark by default** — a strict no-op unless `enabled()` is true, and never advances past `targetCeiling()` (default `'dark'` ⇒ no auto-advance even when enabled).
- **Not yet wired to boot** — this PR is the pure decision core + tests only, so it has **zero runtime effect** until a follow-up wires it into the server tick. That follow-up, and the real two-node failover E2E that produces the green result it consumes, are the next increments.
- Pure injected deps (the pattern the codebase already uses) — tests with zero sessions, zero network.

## Tests
`tests/unit/SessionPoolRolloutDriver.test.ts` — 7 cases, both boundary sides: disabled no-op; advance-on-green; refuse-without-green; never-past-ceiling; default-dark-ceiling; reconcile-first red-revert; stale-red-from-prior-commit ignored. Typecheck clean project-wide; 7/7 green.

## ELI16
Instar can run one agent across two machines so that if one machine goes to sleep, the other picks up the conversation. There's a safety ladder for turning this on: an agent only moves up a rung after a real test proves the hand-off works, and it automatically drops back down if a later test fails. The ladder was built, but nobody built the little worker that actually *climbs* it — so agents got stuck on the bottom "just watch" rung forever. That's exactly why, one night, an agent's laptop went to sleep and its other machine just watched instead of taking over. This change adds that missing worker: every so often it checks "did the hand-off test pass? then move up one rung" and "did a test just fail? then move back down one rung." It's off by default and does nothing until someone turns it on and says how far up it's allowed to go, so it's safe to merge now while the rest is built.

---
Built directly by Echo (the mentee builder was offline); typecheck clean, 7/7 unit tests green. Not wired to boot yet — safe, additive, dark.
