### PR TITLE
feat(mesh): SessionPoolFailoverRunner — in-agent producer of the failover E2E proof

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-22T19-16-00-000Z-sessionpool-failover-runner.json
+++ b/.instar/instar-dev-decisions/2026-07-22T19-16-00-000Z-sessionpool-failover-runner.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-22T19:16:00.000Z",
+  "slug": "sessionpool-failover-runner",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 210,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass",
+  "note": "SessionPoolFailoverRunner: dark-by-default in-agent producer of the failover E2E result the rollout gate needs. Runs an INJECTED failover check; records green only on a genuine pass, red on a genuine regression, NOTHING on a throw (an infra error is not a verdict — no fabricated green/red). Pure injected deps, not wired to boot = zero runtime effect. Additive. Built directly by Echo; mentee offline. tsc clean, 5/5 green."
+}

--- a/src/core/SessionPoolFailoverRunner.ts
+++ b/src/core/SessionPoolFailoverRunner.ts
@@ -1,0 +1,126 @@
+/**
+ * SessionPoolFailoverRunner — the in-agent PRODUCER of a real failover E2E result
+ * for the Multi-Machine Session Pool rollout gate (§Rollout, Track H).
+ *
+ * The gate is a two-part machine:
+ *   - `SessionPoolE2EResultStore` holds the signed Tier-3 E2E verdict per stage.
+ *   - `StageAdvancer` promotes shadow→live-transfer ONLY on a green prior-stage
+ *     E2E for the CURRENT commit, and auto-reverts on red.
+ *   - `SessionPoolRolloutDriver` (the cadenced driver) turns a recorded green into
+ *     an actual promotion toward an operator ceiling.
+ *
+ * What was missing (the track-H "real-hardware / test-as-self proof" follow-up):
+ * the store is written by the vitest failover E2E in CI, but a DEPLOYED agent has
+ * no green of its OWN — nothing inside a running agent proves that agent's actual
+ * shipped code can fail a live conversation over to its standby and records that
+ * proof. Without an in-agent green, the driver has nothing to promote, so a
+ * deployed agent's sessionPool stays at `shadow` forever (the 2026-07-22 overnight
+ * incident: a mentee agent sat at watch-only, so when its primary machine slept the
+ * standby could not take over).
+ *
+ * This runner closes that gap. On each `tick()` it runs an injected failover CHECK
+ * and, on a genuine pass, records a `green` for the proven stage into the E2E store
+ * — the honest, self-earned proof the driver needs to promote the agent.
+ *
+ * ── Honesty line (load-bearing) ──
+ * A `green` is recorded ONLY from a genuine `green` verdict returned by the check.
+ *   - check → 'green'  ⇒ record green   (the agent proved its own failover)
+ *   - check → 'red'    ⇒ record red     (a real regression — the driver auto-reverts)
+ *   - check THROWS      ⇒ record NOTHING (an infra/availability error is NOT a
+ *                        failover verdict; recording a fabricated green would wrongly
+ *                        promote, recording a fabricated red would wrongly demote —
+ *                        so a throw yields NO verdict and the stage is untouched).
+ * A green feeds a promotion, so the runner NEVER manufactures one from silence.
+ *
+ * ── Dark by default (real authority) ──
+ * A recorded green can promote the agent's sessionPool stage — real authority, same
+ * class as the driver and the reactive swap. So the runner is a strict no-op unless
+ * `enabled()` is true. The decision core is pure (the two-node failover CHECK is
+ * injected) so it tests with zero sessions and zero network; the heavy in-process
+ * two-node check is supplied by the caller in production (a follow-up increment) and
+ * a deterministic fake in tests.
+ *
+ * ── v1 scope ──
+ * The runner ORCHESTRATES (gate → run check → record verdict honestly). It does not
+ * itself implement the two-node failover; that check is injected. This mirrors how
+ * `SessionPoolRolloutDriver` takes an injected `StageAdvancer` rather than embedding
+ * the stage machine.
+ */
+
+import type { SessionPoolE2EResultStore, StageE2EOutcome } from './SessionPoolE2EResultStore.js';
+
+/** The verdict of one in-agent failover check run. */
+export interface FailoverCheckResult {
+  /** 'green' = the agent failed a live conversation over to its standby and it resumed. */
+  outcome: StageE2EOutcome;
+  /** A durable, human-traceable pointer to the run (log path, run id, artifact ref). */
+  evidenceRef: string;
+}
+
+export interface SessionPoolFailoverRunnerDeps {
+  /** The signed E2E result store — the ONLY writer path the runner uses. */
+  resultStore: SessionPoolE2EResultStore;
+  /**
+   * The in-agent failover check. Resolves to a verdict on a genuine run; REJECTS on
+   * an infra/availability error (which the runner treats as "no verdict", not red).
+   */
+  runFailoverCheck: () => Promise<FailoverCheckResult>;
+  /** The commit the running build is on — the recorded verdict is bound to it. */
+  currentCommitSha: () => string;
+  /**
+   * The stage index this failover proves — the PRIOR stage whose green gates the
+   * next advance (e.g. the shadow→live-transfer failover is recorded at the
+   * `shadow` index, which `StageAdvancer.advanceTo('live-transfer')` reads).
+   */
+  provenStage: () => number;
+  /** Dark-by-default master switch: the whole tick is a no-op unless this is true. */
+  enabled: () => boolean;
+  audit?: (event: string, detail: Record<string, unknown>) => void;
+}
+
+export interface FailoverRunTickResult {
+  /** false ⇒ the runner was disabled and did nothing. */
+  ran: boolean;
+  /** The verdict recorded, or 'error' when the check threw (nothing recorded), or null when disabled. */
+  outcome: StageE2EOutcome | 'error' | null;
+  /** true ⇒ a verdict row was written to the store this tick. */
+  recorded: boolean;
+}
+
+export class SessionPoolFailoverRunner {
+  constructor(private readonly d: SessionPoolFailoverRunnerDeps) {}
+
+  /**
+   * Run one failover check and record its verdict honestly. Dark-by-default; a
+   * throwing check records NOTHING (no fabricated verdict).
+   */
+  async tick(): Promise<FailoverRunTickResult> {
+    if (!this.d.enabled()) {
+      return { ran: false, outcome: null, recorded: false };
+    }
+    const stage = this.d.provenStage();
+    const sha = this.d.currentCommitSha();
+    let result: FailoverCheckResult;
+    try {
+      result = await this.d.runFailoverCheck();
+    } catch (err) {
+      // An infra/availability error is NOT a failover verdict — record nothing so
+      // the stage is neither wrongly promoted (fabricated green) nor wrongly
+      // demoted (fabricated red). The next tick re-runs the check.
+      this.d.audit?.('failover-check-errored', {
+        provenStage: stage,
+        commitSha: sha,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return { ran: true, outcome: 'error', recorded: false };
+    }
+    this.d.resultStore.recordResult(stage, result.outcome, sha, result.evidenceRef);
+    this.d.audit?.('failover-result-recorded', {
+      provenStage: stage,
+      commitSha: sha,
+      outcome: result.outcome,
+      evidenceRef: result.evidenceRef,
+    });
+    return { ran: true, outcome: result.outcome, recorded: true };
+  }
+}

--- a/tests/unit/SessionPoolFailoverRunner.test.ts
+++ b/tests/unit/SessionPoolFailoverRunner.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { SessionPoolFailoverRunner, type FailoverCheckResult } from '../../src/core/SessionPoolFailoverRunner.js';
+import type { SessionPoolE2EResultStore, StageE2EOutcome } from '../../src/core/SessionPoolE2EResultStore.js';
+
+const SHA = 'commit-xyz';
+
+/** A recording fake store: captures every recordResult call the runner makes. */
+function fakeStore() {
+  const calls: Array<{ stage: number; result: StageE2EOutcome; commitSha: string; evidenceRef: string }> = [];
+  const store = {
+    recordResult: (stage: number, result: StageE2EOutcome, commitSha: string, evidenceRef: string) => {
+      calls.push({ stage, result, commitSha, evidenceRef });
+      return { stage, result, commitSha, ranAt: 'now', evidenceRef, signature: 'sig' };
+    },
+  } as unknown as SessionPoolE2EResultStore;
+  return { store, calls };
+}
+
+function makeRunner(opts: {
+  enabled: boolean;
+  check: () => Promise<FailoverCheckResult>;
+  provenStage?: number;
+}) {
+  const { store, calls } = fakeStore();
+  const audits: Array<{ event: string; detail: Record<string, unknown> }> = [];
+  const runner = new SessionPoolFailoverRunner({
+    resultStore: store,
+    runFailoverCheck: opts.check,
+    currentCommitSha: () => SHA,
+    provenStage: () => opts.provenStage ?? 1, // shadow index — gates the live-transfer advance
+    enabled: () => opts.enabled,
+    audit: (event, detail) => audits.push({ event, detail }),
+  });
+  return { runner, calls, audits };
+}
+
+describe('SessionPoolFailoverRunner', () => {
+  it('is a strict no-op when disabled — never runs the check, never records', async () => {
+    let checkRan = false;
+    const { runner, calls } = makeRunner({
+      enabled: false,
+      check: async () => { checkRan = true; return { outcome: 'green', evidenceRef: 'ref' }; },
+    });
+    const res = await runner.tick();
+    expect(res).toEqual({ ran: false, outcome: null, recorded: false });
+    expect(checkRan).toBe(false); // dark ⇒ the check is not even invoked
+    expect(calls).toHaveLength(0);
+  });
+
+  it('records a green (bound to the current commit + proven stage) on a genuine pass', async () => {
+    const { runner, calls } = makeRunner({
+      enabled: true,
+      provenStage: 1,
+      check: async () => ({ outcome: 'green', evidenceRef: 'run-42' }),
+    });
+    const res = await runner.tick();
+    expect(res).toEqual({ ran: true, outcome: 'green', recorded: true });
+    expect(calls).toEqual([{ stage: 1, result: 'green', commitSha: SHA, evidenceRef: 'run-42' }]);
+  });
+
+  it('records a red on a genuine failover regression (so the driver can auto-revert)', async () => {
+    const { runner, calls } = makeRunner({
+      enabled: true,
+      check: async () => ({ outcome: 'red', evidenceRef: 'run-43' }),
+    });
+    const res = await runner.tick();
+    expect(res).toEqual({ ran: true, outcome: 'red', recorded: true });
+    expect(calls).toEqual([{ stage: 1, result: 'red', commitSha: SHA, evidenceRef: 'run-43' }]);
+  });
+
+  it('records NOTHING when the check throws — an infra error is not a verdict (honesty line)', async () => {
+    const { runner, calls, audits } = makeRunner({
+      enabled: true,
+      check: async () => { throw new Error('two-node setup failed to bind a port'); },
+    });
+    const res = await runner.tick();
+    expect(res).toEqual({ ran: true, outcome: 'error', recorded: false });
+    expect(calls).toHaveLength(0); // no fabricated green AND no fabricated red
+    expect(audits.some((a) => a.event === 'failover-check-errored')).toBe(true);
+  });
+
+  it('binds the recorded verdict to the LIVE commit sha at tick time (not a stale one)', async () => {
+    // Prove the sha is read per-tick via currentCommitSha (not captured once).
+    const { store, calls } = fakeStore();
+    let sha = 'sha-old';
+    const runner = new SessionPoolFailoverRunner({
+      resultStore: store,
+      runFailoverCheck: async () => ({ outcome: 'green', evidenceRef: 'r' }),
+      currentCommitSha: () => sha,
+      provenStage: () => 1,
+      enabled: () => true,
+    });
+    await runner.tick();
+    sha = 'sha-new';
+    await runner.tick();
+    expect(calls.map((c) => c.commitSha)).toEqual(['sha-old', 'sha-new']);
+  });
+});


### PR DESCRIPTION
## What
`SessionPoolFailoverRunner` — a dark-by-default, in-agent producer of the failover E2E result the multi-machine rollout gate needs.

## Why
The rollout gate (`StageAdvancer` + `SessionPoolRolloutDriver`, #1550) promotes an agent shadow→live-transfer on a green failover E2E and auto-reverts on red. But a **deployed** agent had no green of its own — the real failover E2E (#1551) only writes the store in CI. So a deployed agent's sessionPool stayed at `shadow` forever. That is the 2026-07-22 overnight incident: a mentee agent sat at watch-only, so its standby could not take over when the primary machine slept.

## How
On each `tick()` the runner runs an **injected** failover check and records the verdict honestly:
- pass → record `green` (the agent proved its own failover)
- regression → record `red` (the driver auto-reverts)
- check throws → record **NOTHING** (an infra error is not a verdict — a fabricated green would wrongly promote, a fabricated red would wrongly demote)

Dark-by-default (a recorded green can promote the agent = real authority); pure injected deps (heavy two-node check supplied by the caller in prod, a fake in tests); **not wired to boot = zero runtime effect**. The in-process two-node check + boot wiring are follow-up increments.

## Tests
5/5 unit, both boundaries: disabled no-op (check never runs) · genuine green recorded · genuine red recorded · throw records nothing (honesty line) · verdict bound to the live commit sha. `tsc --noEmit` clean.

## ELI16
Imagine a robot that can hand its work to a backup robot if it falls asleep. Before we trust it to do that for real, it has to *prove* it can — by practicing the handoff and getting a passing grade. This adds the part that runs that practice test inside the robot and writes down the grade. A pass ("green") is the permission slip that lets it graduate to doing real handoffs. The important safety rule: it only ever writes "pass" when it *really* passed. If the test itself breaks (couldn't even run), it writes nothing — never a fake pass (which would wrongly promote it) and never a fake fail (which would wrongly demote it). And it's switched off by default, so nothing changes until someone turns it on.