### PR TITLE
feat(initiative): deferral-detection floor — recognizer for premature deferral to the user

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-22T19-16-00-000Z-sessionpool-failover-runner.json
+++ b/.instar/instar-dev-decisions/2026-07-22T19-16-00-000Z-sessionpool-failover-runner.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-22T19:16:00.000Z",
+  "slug": "sessionpool-failover-runner",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 210,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass",
+  "note": "SessionPoolFailoverRunner: dark-by-default in-agent producer of the failover E2E result the rollout gate needs. Runs an INJECTED failover check; records green only on a genuine pass, red on a genuine regression, NOTHING on a throw (an infra error is not a verdict — no fabricated green/red). Pure injected deps, not wired to boot = zero runtime effect. Additive. Built directly by Echo; mentee offline. tsc clean, 5/5 green."
+}

--- a/.instar/instar-dev-decisions/2026-07-22T19-47-00-000Z-deferral-detection-floor.json
+++ b/.instar/instar-dev-decisions/2026-07-22T19-47-00-000Z-deferral-detection-floor.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-22T19:47:00.000Z",
+  "slug": "deferral-detection-floor",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 200,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass",
+  "note": "deferral-floor: deterministic, high-precision recognizer for the premature-deferral shape (user-directed request + operational-unblock action, minus genuine-decision/credential overrides) — the structural fix for the 2026-07-22 self-unblock correction (agent asked operator to do what it could do itself). Sibling of self-stop-floor. Pure, unwired = zero runtime effect; ships signal-only + observe-only first. Additive. Built directly by Echo. tsc clean, 12/12 green, both boundaries."
+}

--- a/src/core/SessionPoolFailoverRunner.ts
+++ b/src/core/SessionPoolFailoverRunner.ts
@@ -1,0 +1,126 @@
+/**
+ * SessionPoolFailoverRunner — the in-agent PRODUCER of a real failover E2E result
+ * for the Multi-Machine Session Pool rollout gate (§Rollout, Track H).
+ *
+ * The gate is a two-part machine:
+ *   - `SessionPoolE2EResultStore` holds the signed Tier-3 E2E verdict per stage.
+ *   - `StageAdvancer` promotes shadow→live-transfer ONLY on a green prior-stage
+ *     E2E for the CURRENT commit, and auto-reverts on red.
+ *   - `SessionPoolRolloutDriver` (the cadenced driver) turns a recorded green into
+ *     an actual promotion toward an operator ceiling.
+ *
+ * What was missing (the track-H "real-hardware / test-as-self proof" follow-up):
+ * the store is written by the vitest failover E2E in CI, but a DEPLOYED agent has
+ * no green of its OWN — nothing inside a running agent proves that agent's actual
+ * shipped code can fail a live conversation over to its standby and records that
+ * proof. Without an in-agent green, the driver has nothing to promote, so a
+ * deployed agent's sessionPool stays at `shadow` forever (the 2026-07-22 overnight
+ * incident: a mentee agent sat at watch-only, so when its primary machine slept the
+ * standby could not take over).
+ *
+ * This runner closes that gap. On each `tick()` it runs an injected failover CHECK
+ * and, on a genuine pass, records a `green` for the proven stage into the E2E store
+ * — the honest, self-earned proof the driver needs to promote the agent.
+ *
+ * ── Honesty line (load-bearing) ──
+ * A `green` is recorded ONLY from a genuine `green` verdict returned by the check.
+ *   - check → 'green'  ⇒ record green   (the agent proved its own failover)
+ *   - check → 'red'    ⇒ record red     (a real regression — the driver auto-reverts)
+ *   - check THROWS      ⇒ record NOTHING (an infra/availability error is NOT a
+ *                        failover verdict; recording a fabricated green would wrongly
+ *                        promote, recording a fabricated red would wrongly demote —
+ *                        so a throw yields NO verdict and the stage is untouched).
+ * A green feeds a promotion, so the runner NEVER manufactures one from silence.
+ *
+ * ── Dark by default (real authority) ──
+ * A recorded green can promote the agent's sessionPool stage — real authority, same
+ * class as the driver and the reactive swap. So the runner is a strict no-op unless
+ * `enabled()` is true. The decision core is pure (the two-node failover CHECK is
+ * injected) so it tests with zero sessions and zero network; the heavy in-process
+ * two-node check is supplied by the caller in production (a follow-up increment) and
+ * a deterministic fake in tests.
+ *
+ * ── v1 scope ──
+ * The runner ORCHESTRATES (gate → run check → record verdict honestly). It does not
+ * itself implement the two-node failover; that check is injected. This mirrors how
+ * `SessionPoolRolloutDriver` takes an injected `StageAdvancer` rather than embedding
+ * the stage machine.
+ */
+
+import type { SessionPoolE2EResultStore, StageE2EOutcome } from './SessionPoolE2EResultStore.js';
+
+/** The verdict of one in-agent failover check run. */
+export interface FailoverCheckResult {
+  /** 'green' = the agent failed a live conversation over to its standby and it resumed. */
+  outcome: StageE2EOutcome;
+  /** A durable, human-traceable pointer to the run (log path, run id, artifact ref). */
+  evidenceRef: string;
+}
+
+export interface SessionPoolFailoverRunnerDeps {
+  /** The signed E2E result store — the ONLY writer path the runner uses. */
+  resultStore: SessionPoolE2EResultStore;
+  /**
+   * The in-agent failover check. Resolves to a verdict on a genuine run; REJECTS on
+   * an infra/availability error (which the runner treats as "no verdict", not red).
+   */
+  runFailoverCheck: () => Promise<FailoverCheckResult>;
+  /** The commit the running build is on — the recorded verdict is bound to it. */
+  currentCommitSha: () => string;
+  /**
+   * The stage index this failover proves — the PRIOR stage whose green gates the
+   * next advance (e.g. the shadow→live-transfer failover is recorded at the
+   * `shadow` index, which `StageAdvancer.advanceTo('live-transfer')` reads).
+   */
+  provenStage: () => number;
+  /** Dark-by-default master switch: the whole tick is a no-op unless this is true. */
+  enabled: () => boolean;
+  audit?: (event: string, detail: Record<string, unknown>) => void;
+}
+
+export interface FailoverRunTickResult {
+  /** false ⇒ the runner was disabled and did nothing. */
+  ran: boolean;
+  /** The verdict recorded, or 'error' when the check threw (nothing recorded), or null when disabled. */
+  outcome: StageE2EOutcome | 'error' | null;
+  /** true ⇒ a verdict row was written to the store this tick. */
+  recorded: boolean;
+}
+
+export class SessionPoolFailoverRunner {
+  constructor(private readonly d: SessionPoolFailoverRunnerDeps) {}
+
+  /**
+   * Run one failover check and record its verdict honestly. Dark-by-default; a
+   * throwing check records NOTHING (no fabricated verdict).
+   */
+  async tick(): Promise<FailoverRunTickResult> {
+    if (!this.d.enabled()) {
+      return { ran: false, outcome: null, recorded: false };
+    }
+    const stage = this.d.provenStage();
+    const sha = this.d.currentCommitSha();
+    let result: FailoverCheckResult;
+    try {
+      result = await this.d.runFailoverCheck();
+    } catch (err) {
+      // An infra/availability error is NOT a failover verdict — record nothing so
+      // the stage is neither wrongly promoted (fabricated green) nor wrongly
+      // demoted (fabricated red). The next tick re-runs the check.
+      this.d.audit?.('failover-check-errored', {
+        provenStage: stage,
+        commitSha: sha,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return { ran: true, outcome: 'error', recorded: false };
+    }
+    this.d.resultStore.recordResult(stage, result.outcome, sha, result.evidenceRef);
+    this.d.audit?.('failover-result-recorded', {
+      provenStage: stage,
+      commitSha: sha,
+      outcome: result.outcome,
+      evidenceRef: result.evidenceRef,
+    });
+    return { ran: true, outcome: result.outcome, recorded: true };
+  }
+}

--- a/src/core/deferral-floor.ts
+++ b/src/core/deferral-floor.ts
@@ -1,0 +1,180 @@
+/**
+ * Deterministic premature-deferral floor — a no-LLM recognizer for the
+ * "defer-an-operational-action-to-the-user" shape in an AGENT-OUTBOUND message.
+ *
+ * Why this exists (the 2026-07-22 correction): the agent asked the operator to
+ * perform an operational action it could have done itself ("you start Codey, or
+ * set me up with access") INSTEAD of exhausting its own routes first — a single
+ * multi-machine agent with a live node on the very machine that needed action.
+ * That violates the "Self-Unblock Before Escalating" standard. The operator's
+ * directive: "a sentinel that detects when you are deferring to the user and
+ * reminds you to re-check your available routes ... before deferring."
+ *
+ * This is the deterministic recognizer for that sentinel — a sibling of
+ * self-stop-floor.ts. It flags the SHAPE (a user-directed request conjoined with
+ * an operational-unblock action), NOT the intent: a deferral AFTER genuine route
+ * exhaustion is legitimate (self-unblock Rung 2). So the sentinel that consumes
+ * this signal REMINDS ("did you re-scan your routes first?"), it does not assert
+ * the deferral is wrong — exactly the operator's framing.
+ *
+ * Threat model: initiative-drift correction, NOT a security boundary. It ships
+ * SIGNAL-ONLY and OBSERVE-ONLY first (record the detection, measure the
+ * false-positive rate against real outbound traffic) before any reminder is
+ * wired — the observe phase is itself the benchmark datum the "every user
+ * pushback -> improvement data" pipeline consumes.
+ *
+ * Precision design (two-axis conjunction, mirrors self-stop-floor):
+ *   (A) a USER-DIRECTED REQUEST marker (the agent asking the operator to act), AND
+ *   (B) an OPERATIONAL-UNBLOCK ACTION marker (start/restart/run/install/grant/
+ *       enable/… — a thing an agent could plausibly do itself), AND
+ *   (C) NO legitimate-deferral override (a genuine DECISION only the operator can
+ *       make, or an operator-only CREDENTIAL the agent cannot produce).
+ * Requiring BOTH axes plus the override guard keeps it high-precision: a genuine
+ * design question ("which promotion model do you want?") carries no operational
+ * action; a real credential ask ("I need your password") is de-fanged by (C).
+ */
+
+export interface DeferralFloorResult {
+  /** True when the text expresses the premature-deferral shape. */
+  detected: boolean;
+  /** The user-directed request phrase that matched (for the audit issue). */
+  requestMatch?: string;
+  /** The operational-unblock action phrase that matched (for the audit issue). */
+  actionMatch?: string;
+}
+
+/**
+ * (A) USER-DIRECTED REQUEST markers — the agent asking the OPERATOR to do
+ * something. ILLUSTRATIVE of the shape, matched case-insensitively as substrings.
+ * Broad on this axis because axis (B) is what makes a match high-precision.
+ */
+const REQUEST_MARKERS: readonly string[] = [
+  'can you',
+  'could you',
+  'would you',
+  'will you',
+  'please ',
+  "you'll need to",
+  'you will need to',
+  'you need to',
+  'you have to',
+  'if you can',
+  'if you could',
+  'on your end',
+  'from your side',
+  'on your side',
+  'i need you to',
+  'i need you',
+  'want you to',
+  'set me up',
+  'grant me',
+  'give me access',
+  'get me access',
+  'you start',
+  'you restart',
+  'you do it',
+  'do it yourself',
+  'start it yourself',
+  'yourself, or', // "you start it yourself, or set me up..."
+  'your call on getting', // "still yours to call on getting Codey back"
+  'still yours to',
+  'yours to call',
+];
+
+/**
+ * (B) OPERATIONAL-UNBLOCK ACTION markers — the mechanical thing being deferred,
+ * i.e. something an agent with the right access could do itself. Kept to
+ * operational verbs so a DECISION deferral ("which do you want") does not match.
+ */
+const ACTION_MARKERS: readonly string[] = [
+  'restart',
+  're-start',
+  'reboot',
+  'kickstart',
+  'kick start',
+  'start codey',
+  'start it',
+  'start the',
+  'spin up',
+  'spin it up',
+  'run the',
+  'run it',
+  'launch',
+  'install the',
+  'install my',
+  'add the key',
+  'add my key',
+  'drop that key',
+  'drop the key',
+  'enable ',
+  'turn on',
+  'flip on',
+  'flipped on',
+  'log in',
+  'log into',
+  'grant',
+  'access to the',
+  'access and',
+  'set up access',
+  'ssh',
+];
+
+/**
+ * (C) LEGITIMATE-DEFERRAL overrides — when present, the deferral is a genuine
+ * DECISION only the operator can make, or an operator-only CREDENTIAL the agent
+ * cannot produce. High-confidence and narrow: a real taste/design/approval call,
+ * or a secret only the human holds. When any is present the floor does NOT flag —
+ * a genuine question or a true Rung-2 credential ask is not premature deferral.
+ */
+const LEGIT_OVERRIDES: readonly string[] = [
+  'which do you want',
+  'which would you',
+  'do you want me to',
+  'your call on the',
+  'your call: ',
+  'your decision',
+  'up to you which',
+  'up to you whether',
+  'which approach',
+  'which model',
+  'auto-climb or',
+  'do you approve',
+  'approve the',
+  'sign off on',
+  'are you okay with',
+  'is it okay to',
+  'okay to proceed',
+  'need your password',
+  'need a password',
+  'your api key',
+  'your credential',
+  'a secret only you',
+  'only you can produce',
+];
+
+function firstMatch(haystack: string, needles: readonly string[]): string | undefined {
+  for (const n of needles) {
+    if (haystack.includes(n)) return n;
+  }
+  return undefined;
+}
+
+/**
+ * Detect the premature-deferral shape in an AGENT-OUTBOUND message. Detection
+ * requires BOTH a user-directed REQUEST marker AND an operational-unblock ACTION
+ * marker, and NO legitimate-deferral override. Pure and synchronous (no LLM).
+ */
+export function detectDeferralShape(text: string): DeferralFloorResult {
+  if (!text) return { detected: false };
+  const hay = text.toLowerCase();
+
+  // A genuine decision or an operator-only credential de-fangs the whole message.
+  if (firstMatch(hay, LEGIT_OVERRIDES)) return { detected: false };
+
+  const requestMatch = firstMatch(hay, REQUEST_MARKERS);
+  if (!requestMatch) return { detected: false };
+  const actionMatch = firstMatch(hay, ACTION_MARKERS);
+  if (!actionMatch) return { detected: false };
+
+  return { detected: true, requestMatch, actionMatch };
+}

--- a/tests/unit/SessionPoolFailoverRunner.test.ts
+++ b/tests/unit/SessionPoolFailoverRunner.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { SessionPoolFailoverRunner, type FailoverCheckResult } from '../../src/core/SessionPoolFailoverRunner.js';
+import type { SessionPoolE2EResultStore, StageE2EOutcome } from '../../src/core/SessionPoolE2EResultStore.js';
+
+const SHA = 'commit-xyz';
+
+/** A recording fake store: captures every recordResult call the runner makes. */
+function fakeStore() {
+  const calls: Array<{ stage: number; result: StageE2EOutcome; commitSha: string; evidenceRef: string }> = [];
+  const store = {
+    recordResult: (stage: number, result: StageE2EOutcome, commitSha: string, evidenceRef: string) => {
+      calls.push({ stage, result, commitSha, evidenceRef });
+      return { stage, result, commitSha, ranAt: 'now', evidenceRef, signature: 'sig' };
+    },
+  } as unknown as SessionPoolE2EResultStore;
+  return { store, calls };
+}
+
+function makeRunner(opts: {
+  enabled: boolean;
+  check: () => Promise<FailoverCheckResult>;
+  provenStage?: number;
+}) {
+  const { store, calls } = fakeStore();
+  const audits: Array<{ event: string; detail: Record<string, unknown> }> = [];
+  const runner = new SessionPoolFailoverRunner({
+    resultStore: store,
+    runFailoverCheck: opts.check,
+    currentCommitSha: () => SHA,
+    provenStage: () => opts.provenStage ?? 1, // shadow index — gates the live-transfer advance
+    enabled: () => opts.enabled,
+    audit: (event, detail) => audits.push({ event, detail }),
+  });
+  return { runner, calls, audits };
+}
+
+describe('SessionPoolFailoverRunner', () => {
+  it('is a strict no-op when disabled — never runs the check, never records', async () => {
+    let checkRan = false;
+    const { runner, calls } = makeRunner({
+      enabled: false,
+      check: async () => { checkRan = true; return { outcome: 'green', evidenceRef: 'ref' }; },
+    });
+    const res = await runner.tick();
+    expect(res).toEqual({ ran: false, outcome: null, recorded: false });
+    expect(checkRan).toBe(false); // dark ⇒ the check is not even invoked
+    expect(calls).toHaveLength(0);
+  });
+
+  it('records a green (bound to the current commit + proven stage) on a genuine pass', async () => {
+    const { runner, calls } = makeRunner({
+      enabled: true,
+      provenStage: 1,
+      check: async () => ({ outcome: 'green', evidenceRef: 'run-42' }),
+    });
+    const res = await runner.tick();
+    expect(res).toEqual({ ran: true, outcome: 'green', recorded: true });
+    expect(calls).toEqual([{ stage: 1, result: 'green', commitSha: SHA, evidenceRef: 'run-42' }]);
+  });
+
+  it('records a red on a genuine failover regression (so the driver can auto-revert)', async () => {
+    const { runner, calls } = makeRunner({
+      enabled: true,
+      check: async () => ({ outcome: 'red', evidenceRef: 'run-43' }),
+    });
+    const res = await runner.tick();
+    expect(res).toEqual({ ran: true, outcome: 'red', recorded: true });
+    expect(calls).toEqual([{ stage: 1, result: 'red', commitSha: SHA, evidenceRef: 'run-43' }]);
+  });
+
+  it('records NOTHING when the check throws — an infra error is not a verdict (honesty line)', async () => {
+    const { runner, calls, audits } = makeRunner({
+      enabled: true,
+      check: async () => { throw new Error('two-node setup failed to bind a port'); },
+    });
+    const res = await runner.tick();
+    expect(res).toEqual({ ran: true, outcome: 'error', recorded: false });
+    expect(calls).toHaveLength(0); // no fabricated green AND no fabricated red
+    expect(audits.some((a) => a.event === 'failover-check-errored')).toBe(true);
+  });
+
+  it('binds the recorded verdict to the LIVE commit sha at tick time (not a stale one)', async () => {
+    // Prove the sha is read per-tick via currentCommitSha (not captured once).
+    const { store, calls } = fakeStore();
+    let sha = 'sha-old';
+    const runner = new SessionPoolFailoverRunner({
+      resultStore: store,
+      runFailoverCheck: async () => ({ outcome: 'green', evidenceRef: 'r' }),
+      currentCommitSha: () => sha,
+      provenStage: () => 1,
+      enabled: () => true,
+    });
+    await runner.tick();
+    sha = 'sha-new';
+    await runner.tick();
+    expect(calls.map((c) => c.commitSha)).toEqual(['sha-old', 'sha-new']);
+  });
+});

--- a/tests/unit/deferral-floor.test.ts
+++ b/tests/unit/deferral-floor.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { detectDeferralShape } from '../../src/core/deferral-floor.js';
+
+describe('detectDeferralShape — premature-deferral recognizer', () => {
+  // ── DETECTS: an operational action deferred to the operator the agent could take itself ──
+  it('flags the canonical 2026-07-22 miss (asking the operator to start/grant instead of self-serving)', () => {
+    const r = detectDeferralShape('You start Codey on the laptop, or set me up with access and I will do it.');
+    expect(r.detected).toBe(true);
+    expect(r.requestMatch).toBeTruthy();
+    expect(r.actionMatch).toBeTruthy();
+  });
+
+  it('flags "can you restart …"', () => {
+    expect(detectDeferralShape('Can you restart Codey on the laptop for me?').detected).toBe(true);
+  });
+
+  it('flags "you\'ll need to install …"', () => {
+    expect(detectDeferralShape("You'll need to install the key on the laptop.").detected).toBe(true);
+  });
+
+  it('flags "grant me … access …"', () => {
+    expect(detectDeferralShape('Grant me SSH access and I can take it from there.').detected).toBe(true);
+  });
+
+  it('flags "please restart it yourself"', () => {
+    expect(detectDeferralShape('Please restart it yourself when you get a chance.').detected).toBe(true);
+  });
+
+  // ── DOES NOT flag: a genuine DECISION only the operator can make, or an operator-only CREDENTIAL ──
+  it('does NOT flag a genuine design decision (which model?)', () => {
+    expect(detectDeferralShape('Which promotion model do you want — auto-climb or per-step operator-trigger?').detected).toBe(false);
+  });
+
+  it('does NOT flag an approval request for an irreversible action', () => {
+    expect(detectDeferralShape('Do you approve deploying this to production?').detected).toBe(false);
+  });
+
+  it('does NOT flag a genuine operator-only credential ask (Rung 2)', () => {
+    expect(detectDeferralShape('I need your password to unlock the vault — no other path to it.').detected).toBe(false);
+  });
+
+  it('does NOT flag a "which approach" decision', () => {
+    expect(detectDeferralShape('Which approach should we take here?').detected).toBe(false);
+  });
+
+  // ── DOES NOT flag: the agent reporting its OWN action (no user-directed request) ──
+  it('does NOT flag the agent reporting work it did itself', () => {
+    expect(detectDeferralShape('I restarted the service and it is healthy now.').detected).toBe(false);
+  });
+
+  it('does NOT flag incidental advice mentioning an action but no request-to-act', () => {
+    // "you can restart" is not in the request-marker set on purpose (advice, not a deferral).
+    expect(detectDeferralShape('You can restart your machine anytime; it will not affect the run.').detected).toBe(false);
+  });
+
+  it('empty / whitespace is never flagged', () => {
+    expect(detectDeferralShape('').detected).toBe(false);
+    expect(detectDeferralShape('   ').detected).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
`deferral-floor.ts` — a deterministic, high-precision recognizer for the "defer-an-operational-action-to-the-user" shape in an agent-outbound message. The structural fix for the 2026-07-22 self-unblock correction.

## Why
The agent asked the operator to perform an operational action it could have done itself ("you start Codey on the laptop, or set me up with access") instead of exhausting its own routes first — a violation of **Self-Unblock Before Escalating**. Operator directive: *"a sentinel that detects when you are deferring to the user and reminds you to re-check your available routes ... before deferring."*

## How
Two-axis conjunction (mirrors `self-stop-floor`), high-precision: a user-directed **REQUEST** marker AND an operational-unblock **ACTION** marker (start/restart/run/install/grant/enable/…), minus a **legitimate-deferral override** (a genuine decision only the operator can make, or an operator-only credential). It flags the *shape*, not the intent — a deferral after genuine route exhaustion is legitimate (Rung 2), so the consuming sentinel **reminds**, it never asserts wrongness or blocks. Pure/synchronous (no LLM); **unwired = zero runtime effect**. Ships signal-only + observe-only first — and that observe phase measures the false-positive rate, which is itself the benchmark datum the "every user pushback → improvement data" pipeline consumes.

## Tests
12/12, both boundaries: detects the canonical miss + "can you restart", "you'll need to install", "grant me access", "please restart it yourself"; does NOT flag a genuine design decision, an approval request, an operator-only credential ask, or the agent reporting its own action.

## ELI16
Picture a helper who, the moment something's hard, asks *you* to do it — even when the helper could've done it themselves. This adds a little detector that notices when the helper is about to hand a task back to you that it could handle, so it can pause and double-check its own options first ("wait — can I get there through my other machine?"). It's careful only to flag real hand-offs of do-able tasks, not genuine questions where your decision is actually needed (which model? do you approve this?) or a password only you have. And it starts out just *watching and counting* — it doesn't nag or block anything yet — so we can see how accurate it is before it ever speaks up.