### PR TITLE
feat(initiative): wire deferral recognizer into tone-gate provenance (observe-only)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-22T20-10-00-000Z-deferral-observe-wiring.json
+++ b/.instar/instar-dev-decisions/2026-07-22T20-10-00-000Z-deferral-observe-wiring.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-22T20:10:00.000Z",
+  "slug": "deferral-observe-wiring",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 90,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass",
+  "note": "Wire the deferral-floor recognizer into buildToneDecisionContext as an OBSERVE-ONLY content-free boolean (deferralShapeDetected). Signal for the decision-quality meter + pushback->improvement pipeline; NEVER alters the gate's block/allow verdict; fail-open helper (a detector throw records false). Purely additive to the provenance context. Built directly by Echo. tsc clean; new test 6/6 + existing MessagingToneGate 55/55 green (no regression)."
+}

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -28,6 +28,7 @@ import {
 } from './GateSignalDetectors.js';
 import { detectInternalIdLeak } from './internal-id-leak.js';
 import { detectSelfStopShape } from './self-stop-floor.js';
+import { detectDeferralShape } from './deferral-floor.js';
 import { DP_MESSAGING_TONE_GATE } from '../data/provenanceCoverage.js';
 
 /**
@@ -147,8 +148,28 @@ export function buildToneDecisionContext(
     gateSignalKinds: detectGateSignals(text)
       .filter((s) => s.detected)
       .map((s) => s.kind),
+    // Premature-deferral shape (deferral-floor, OBSERVE-ONLY): a content-free
+    // boolean recording whether this outbound message defers an operational action
+    // to the user that the agent could take itself (the 2026-07-22 self-unblock
+    // correction). It is a SIGNAL for the decision-quality meter + the
+    // pushback->improvement pipeline — the observe phase measures its false-positive
+    // rate before any reminder is ever wired. It NEVER alters the gate's block/allow
+    // verdict, and fails open (a throwing detector records `false`, never breaks the
+    // provenance seam).
+    deferralShapeDetected: safeDeferralShapeDetected(text),
   };
   return ctx;
+}
+
+/** Fail-open wrapper: the observe-only deferral signal must never break the
+ *  provenance context if the detector throws on pathological input. */
+function safeDeferralShapeDetected(text: string): boolean {
+  try {
+    return detectDeferralShape(text).detected;
+  } catch {
+    // @silent-fallback-ok — an observe-only signal; a detector throw records false.
+    return false;
+  }
 }
 
 /**

--- a/tests/unit/tone-gate-deferral-provenance.test.ts
+++ b/tests/unit/tone-gate-deferral-provenance.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { buildToneDecisionContext } from '../../src/core/MessagingToneGate.js';
+import type { ToneReviewContext } from '../../src/core/MessagingToneGate.js';
+
+// Minimal context — every field buildToneDecisionContext reads is optional (?? defaults).
+const CTX = {} as ToneReviewContext;
+
+describe('buildToneDecisionContext — observe-only deferral signal', () => {
+  it('records deferralShapeDetected=true for a premature-deferral message', () => {
+    const ctx = buildToneDecisionContext(
+      'You start Codey on the laptop, or set me up with access and I will do it.',
+      CTX,
+    );
+    expect(ctx.deferralShapeDetected).toBe(true);
+  });
+
+  it('records deferralShapeDetected=false for a genuine decision question', () => {
+    const ctx = buildToneDecisionContext(
+      'Which promotion model do you want — auto-climb or per-step operator-trigger?',
+      CTX,
+    );
+    expect(ctx.deferralShapeDetected).toBe(false);
+  });
+
+  it('records deferralShapeDetected=false for the agent reporting its own action', () => {
+    const ctx = buildToneDecisionContext('I restarted the service and it is healthy now.', CTX);
+    expect(ctx.deferralShapeDetected).toBe(false);
+  });
+
+  it('is CONTENT-FREE: the signal is a plain boolean, never the message text', () => {
+    const text = 'Can you restart Codey for me?';
+    const ctx = buildToneDecisionContext(text, CTX);
+    expect(typeof ctx.deferralShapeDetected).toBe('boolean');
+    // The whole context must never embed the raw message body (identity-only discipline).
+    expect(JSON.stringify(ctx)).not.toContain(text);
+  });
+
+  it('is PURELY ADDITIVE: the existing content-free fields are untouched', () => {
+    const ctx = buildToneDecisionContext('hello there', CTX);
+    // Pre-existing identity fields still present + unchanged in shape.
+    expect((ctx.candidate as { sha256: string }).sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(Array.isArray(ctx.gateSignalKinds)).toBe(true);
+    expect(ctx.messageKind).toBe('reply');
+    // And the new field rides alongside them.
+    expect(ctx).toHaveProperty('deferralShapeDetected');
+  });
+
+  it('fails open: an empty candidate never throws and records false', () => {
+    const ctx = buildToneDecisionContext('', CTX);
+    expect(ctx.deferralShapeDetected).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Wire the deferral-detection recognizer (#1554) into the tone gate's decision-quality provenance as an **observe-only**, content-free boolean `deferralShapeDetected`.

## Why
Follow-up to the 2026-07-22 self-unblock correction: the agent deferred an operational action to the operator it could have done itself. #1554 added the recognizer; this begins measuring it in production. The observe phase feeds the "every user pushback → improvement data" pipeline (the decision-quality meter) and lets us measure the recognizer's false-positive rate **before any reminder is ever wired**.

## How
Adds one field to `buildToneDecisionContext` (the same content-free provenance block that already records `gateSignalKinds`). Safeguards:
- **Observe-only** — it NEVER alters the gate's block/allow verdict (the verdict is the LLM's; provenance is observability only, strip-before-adapter + fail-open).
- **Content-free** — a plain boolean, never the message body.
- **Fails open** — a throwing detector records `false`, never breaks the provenance seam.

## Tests
6/6 new (records true/false correctly for deferral vs decision vs self-report; content-free; purely additive; fail-open on empty) + existing `MessagingToneGate` 55/55 green (no regression). `tsc --noEmit` clean.

## ELI16
Earlier we added a little detector that notices when the helper is about to hand *you* a task it could do itself. This plugs that detector into the helper's private notes so it quietly writes down "was this a hand-off? yes/no" every time it sends a message — just a yes/no checkmark, never the message itself. Nothing changes in what gets sent; we're only *counting*, so we can see how accurate the detector is before we ever let it speak up. And if the detector ever hiccups, it just writes "no" and moves on — it can't break anything.