### PR TITLE
feat(mesh): subprocess failover check — honest green/red verdict for SessionPoolFailoverRunner

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-22T20-40-00-000Z-failover-subprocess-check.json
+++ b/.instar/instar-dev-decisions/2026-07-22T20-40-00-000Z-failover-subprocess-check.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-22T20:40:00.000Z",
+  "slug": "failover-subprocess-check",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 120,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass",
+  "note": "makeSubprocessFailoverCheck: the injectable runFailoverCheck for SessionPoolFailoverRunner (#1552). Runs the merged #1551 real two-node failover E2E as a bounded subprocess and maps HONESTLY: exit0->green, non-zero->red, did-not-run-to-completion->THROW (runner records nothing; a transient infra failure never fabricates a green promotion or red demotion). Process spawn injected = pure module. Additive, dark (only used when the runner is enabled, which is itself dark). Built directly by Echo. tsc clean, 6/6 green."
+}

--- a/src/core/sessionPoolFailoverCheck.ts
+++ b/src/core/sessionPoolFailoverCheck.ts
@@ -1,0 +1,87 @@
+/**
+ * Subprocess failover check — the injectable `runFailoverCheck` for
+ * `SessionPoolFailoverRunner` that produces an HONEST green/red verdict by
+ * running the REAL two-node sessionPool failover E2E as a bounded subprocess.
+ *
+ * Why a subprocess (not an in-process re-implementation): the proven failover
+ * assertion already lives in `tests/e2e/sessionpool-failover-two-node.test.ts`
+ * (the merged #1551 E2E — real two servers, real ownership FSM, real force-claim
+ * takeover). Re-implementing it in-process risks a DIFFERENT, weaker check that
+ * could green a broken failover (the exact honesty-line risk the runner guards).
+ * Running the SAME vitest E2E as a bounded subprocess reuses that trusted
+ * assertion verbatim, so the recorded green means what CI's green means.
+ *
+ * ── Honesty mapping (load-bearing) ──
+ * The runner records green on a genuine pass, red on a genuine regression, and
+ * NOTHING on a throw. This check honours that three-way contract:
+ *   ran to completion, exit 0        → { outcome: 'green' }   (failover proven)
+ *   ran to completion, exit non-zero → { outcome: 'red' }     (real regression)
+ *   did NOT run to completion         → THROW                 (spawn error / timeout
+ *     (or a null exit code)              / harness couldn't run — NOT a failover
+ *                                        verdict; the runner records nothing so a
+ *                                        transient infra failure never masquerades
+ *                                        as a red demotion or a green promotion).
+ *
+ * ── Scope note ──
+ * This check requires the instar SOURCE + a vitest runner on the executing
+ * machine (a dev / test-as-self context). A deployed agent with no source cannot
+ * use it; that agent needs the separate in-process check (a tracked follow-up).
+ * The process spawn itself is INJECTED (`runProcess`) so this module is pure and
+ * unit-tests with zero real subprocess.
+ */
+
+import type { FailoverCheckResult } from './SessionPoolFailoverRunner.js';
+
+/** The default E2E the check runs — the merged #1551 real two-node failover. */
+export const DEFAULT_FAILOVER_E2E_PATH = 'tests/e2e/sessionpool-failover-two-node.test.ts';
+export const DEFAULT_FAILOVER_TIMEOUT_MS = 180_000;
+
+/** Result of the injected process runner. `ranToCompletion:false` = could not run. */
+export interface SubprocessRunResult {
+  /** true iff the runner actually executed the suite to a verdict (exit code known). */
+  ranToCompletion: boolean;
+  /** The process exit code, or null when it did not run to completion. */
+  exitCode: number | null;
+  /** A durable, human-traceable pointer to this run (a log path / run id). */
+  evidenceRef: string;
+}
+
+export interface SubprocessFailoverCheckDeps {
+  /**
+   * Spawn the failover E2E and resolve once it finishes (or times out). MUST
+   * resolve — a spawn failure or timeout resolves with `ranToCompletion:false`,
+   * NOT a rejection, so the mapping below owns the honesty decision.
+   */
+  runProcess: (args: { testPath: string; timeoutMs: number }) => Promise<SubprocessRunResult>;
+  /** Which E2E to run (defaults to the merged two-node failover E2E). */
+  testPath?: string;
+  /** Bounded wall-clock budget for the subprocess. */
+  timeoutMs?: number;
+}
+
+/**
+ * Build the injectable `runFailoverCheck` for `SessionPoolFailoverRunner`. It
+ * runs the real failover E2E as a bounded subprocess and maps the outcome per the
+ * honesty contract above (throws when the check could not run, so the runner
+ * records nothing).
+ */
+export function makeSubprocessFailoverCheck(
+  deps: SubprocessFailoverCheckDeps,
+): () => Promise<FailoverCheckResult> {
+  const testPath = deps.testPath ?? DEFAULT_FAILOVER_E2E_PATH;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_FAILOVER_TIMEOUT_MS;
+  return async (): Promise<FailoverCheckResult> => {
+    const r = await deps.runProcess({ testPath, timeoutMs });
+    if (!r.ranToCompletion || r.exitCode === null) {
+      // Could not run to a verdict → NOT a failover result. Throw so the runner
+      // records nothing (never a fabricated green promotion or red demotion).
+      throw new Error(
+        `sessionPool failover check did not run to completion (evidence: ${r.evidenceRef})`,
+      );
+    }
+    return {
+      outcome: r.exitCode === 0 ? 'green' : 'red',
+      evidenceRef: r.evidenceRef,
+    };
+  };
+}

--- a/tests/unit/sessionPoolFailoverCheck.test.ts
+++ b/tests/unit/sessionPoolFailoverCheck.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  makeSubprocessFailoverCheck,
+  DEFAULT_FAILOVER_E2E_PATH,
+  DEFAULT_FAILOVER_TIMEOUT_MS,
+  type SubprocessRunResult,
+} from '../../src/core/sessionPoolFailoverCheck.js';
+
+function runProcessReturning(result: SubprocessRunResult, capture?: (a: { testPath: string; timeoutMs: number }) => void) {
+  return async (args: { testPath: string; timeoutMs: number }) => {
+    capture?.(args);
+    return result;
+  };
+}
+
+describe('makeSubprocessFailoverCheck — honest verdict mapping', () => {
+  it('exit 0 (ran to completion) → green', async () => {
+    const check = makeSubprocessFailoverCheck({
+      runProcess: runProcessReturning({ ranToCompletion: true, exitCode: 0, evidenceRef: 'run-1' }),
+    });
+    await expect(check()).resolves.toEqual({ outcome: 'green', evidenceRef: 'run-1' });
+  });
+
+  it('exit non-zero (ran to completion) → red', async () => {
+    const check = makeSubprocessFailoverCheck({
+      runProcess: runProcessReturning({ ranToCompletion: true, exitCode: 1, evidenceRef: 'run-2' }),
+    });
+    await expect(check()).resolves.toEqual({ outcome: 'red', evidenceRef: 'run-2' });
+  });
+
+  it('did NOT run to completion → THROWS (so the runner records nothing)', async () => {
+    const check = makeSubprocessFailoverCheck({
+      runProcess: runProcessReturning({ ranToCompletion: false, exitCode: null, evidenceRef: 'spawn-failed' }),
+    });
+    await expect(check()).rejects.toThrow(/did not run to completion/);
+  });
+
+  it('null exit code even if flagged complete → THROWS (no fabricated verdict)', async () => {
+    const check = makeSubprocessFailoverCheck({
+      runProcess: runProcessReturning({ ranToCompletion: true, exitCode: null, evidenceRef: 'no-code' }),
+    });
+    await expect(check()).rejects.toThrow(/did not run to completion/);
+  });
+
+  it('uses the merged two-node failover E2E + a bounded timeout by default', async () => {
+    let seen: { testPath: string; timeoutMs: number } | undefined;
+    const check = makeSubprocessFailoverCheck({
+      runProcess: runProcessReturning({ ranToCompletion: true, exitCode: 0, evidenceRef: 'r' }, (a) => { seen = a; }),
+    });
+    await check();
+    expect(seen?.testPath).toBe(DEFAULT_FAILOVER_E2E_PATH);
+    expect(seen?.timeoutMs).toBe(DEFAULT_FAILOVER_TIMEOUT_MS);
+  });
+
+  it('honours an explicit testPath + timeout override', async () => {
+    let seen: { testPath: string; timeoutMs: number } | undefined;
+    const check = makeSubprocessFailoverCheck({
+      runProcess: runProcessReturning({ ranToCompletion: true, exitCode: 0, evidenceRef: 'r' }, (a) => { seen = a; }),
+      testPath: 'tests/e2e/custom.test.ts',
+      timeoutMs: 5000,
+    });
+    await check();
+    expect(seen).toEqual({ testPath: 'tests/e2e/custom.test.ts', timeoutMs: 5000 });
+  });
+});


### PR DESCRIPTION
Provides the injectable `runFailoverCheck` for `SessionPoolFailoverRunner` (#1552) by running the merged #1551 real two-node failover E2E as a **bounded subprocess**, reusing that trusted assertion verbatim instead of a weaker in-process re-implementation.

**Honest verdict mapping (load-bearing):**
- ran to completion, exit 0 → `green` (failover proven)
- ran to completion, exit non-zero → `red` (real regression → driver auto-reverts)
- did NOT run to completion / null exit → **throws** → runner records NOTHING (a transient infra failure never masquerades as a green promotion or red demotion)

The process spawn is injected (`runProcess`) so the module is pure and unit-tests with zero real subprocess. Dark-by-default via the runner (#1552).

**Tests:** `tests/unit/sessionPoolFailoverCheck.test.ts` 6/6 green; `tsc --noEmit` clean.

**Scope note:** requires instar source + a vitest runner on the executing machine (dev/test-as-self). A deployed no-source agent needs the separate in-process check (tracked follow-up).

## ELI16

When my agent wants to prove a conversation would really survive one of my machines dying, it doesn't just trust a checkbox — it runs the actual two-machine failover test (the merged #1551 one that kills a node mid-task and checks the other machine takes over) as a separate bounded program and reads that program's real pass/fail:

- passes cleanly → counts as **proven safe** (green)
- fails → a **real regression** (red), and the rollout driver automatically steps the agent back down
- couldn't even finish (a hiccup unrelated to failover) → records **nothing** — so a random glitch can never be mistaken for "proven safe" OR "broken"

It's the honest evidence-producer that feeds the mesh-promotion safety gate. Ships dark (nothing promotes until the gated runner is wired), pure + injected.