### PR TITLE
feat(monitoring): SingleMachineFailoverGapDetector — surface "no failover target for active autonomous work" (pure, dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-22T20-42-00-000Z-single-machine-failover-gap-detector.json
+++ b/.instar/instar-dev-decisions/2026-07-22T20-42-00-000Z-single-machine-failover-gap-detector.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-22T20:42:00.000Z",
+  "slug": "single-machine-failover-gap-detector",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 330,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass",
+  "note": "SingleMachineFailoverGapDetector: pure, dark-by-default signal-only guard that raises ONE deduped high-priority attention item when this agent is single-machine (no online mesh peer) WHILE it has active autonomous runs = no failover target. Closes the CLASS behind the 2026-07-22 Codey overnight loss (autonomous work single-machine, session stopped, nothing took over, invisible until a human noticed). Two honest modes: not-configured vs peer-offline. This increment ships the pure core + dev-agent config resolver (dryRun-first) + status()/guardStatusFor — INJECTED deps, NOT wired to boot = zero runtime effect (mirrors #1552's shape). Boot-wiring + GET route + integration/e2e is the next increment. Additive, dark. tsc clean, 15/15 unit green."
+}

--- a/src/monitoring/SingleMachineFailoverGapDetector.ts
+++ b/src/monitoring/SingleMachineFailoverGapDetector.ts
@@ -80,45 +80,140 @@ export interface FailoverGapTickResult {
 
 const DEDUP_KEY = 'single-machine-failover-gap';
 
+// ── Config resolution (dev-gated dark; dry-run first) ───────────────────────
+
+/** The resolved, typed config the detector runs with. */
+export interface SingleMachineFailoverGapResolvedConfig {
+  /** Dev-agent gate: live on a development agent, dark on the fleet (unless set). */
+  enabled: boolean;
+  /** Dry-run first even on a dev agent: compute + audit, but do NOT raise. */
+  dryRun: boolean;
+}
+
+/** The raw config block shape (all optional — everything defaults). */
+export interface SingleMachineFailoverGapConfigBlock {
+  enabled?: boolean;
+  dryRun?: boolean;
+}
+
+/**
+ * Resolve `monitoring.singleMachineFailoverGap` against the dev-agent gate.
+ * `resolveEnabled` is the injected `resolveDevAgentGate(explicit, config)` result
+ * (kept as a param so this module stays free of a hard import — the server wiring
+ * passes the real gate). `dryRun` defaults TRUE (the graduated-rollout first rung).
+ */
+export function resolveSingleMachineFailoverGapConfig(
+  block: SingleMachineFailoverGapConfigBlock | undefined,
+  resolveEnabled: (explicit: boolean | undefined) => boolean,
+): SingleMachineFailoverGapResolvedConfig {
+  const b = block ?? {};
+  return {
+    enabled: resolveEnabled(typeof b.enabled === 'boolean' ? b.enabled : undefined),
+    dryRun: typeof b.dryRun === 'boolean' ? b.dryRun : true,
+  };
+}
+
+/** The guard-posture grade for `GET /guards`: dark ▸ dry-run ▸ live. */
+export function guardStatusFor(cfg: SingleMachineFailoverGapResolvedConfig): 'dark' | 'dry-run' | 'live' {
+  return cfg.enabled ? (cfg.dryRun ? 'dry-run' : 'live') : 'dark';
+}
+
+/** The `status()` snapshot (the future `GET /pool/failover-gap` body core). */
+export interface SingleMachineFailoverGapStatus {
+  enabled: boolean;
+  dryRun: boolean;
+  lastTickAt: string | null;
+  /** True when the LAST tick saw this agent single-machine (no online peer). */
+  singleMachine: boolean;
+  /** Active autonomous runs seen on the LAST tick. */
+  activeAutonomousRunCount: number;
+  /** The current gap mode, or null when no gap is open. */
+  openGapMode: FailoverGapMode | null;
+  counters: { ticks: number; raises: number; wouldRaise: number; errors: number };
+}
+
 /**
  * The pure detector. One `tick()` = one evaluation. It raises at most one
  * (deduped) attention item per gap episode; the attention layer's own dedup
  * collapses repeated ticks so a persistent gap never floods.
  */
 export class SingleMachineFailoverGapDetector {
-  constructor(private readonly deps: SingleMachineFailoverGapDetectorDeps) {}
+  private ticks = 0;
+  private raises = 0;
+  private wouldRaise = 0;
+  private errors = 0;
+  private lastTickAtMs = 0;
+  private lastSingleMachine = false;
+  private lastActiveRunCount = 0;
+  private openGapMode: FailoverGapMode | null = null;
 
+  constructor(
+    private readonly deps: SingleMachineFailoverGapDetectorDeps,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  /**
+   * One evaluation. Rides an existing shared timer (no timer of its own). Fails
+   * toward silence: any internal error increments the error counter and emits
+   * nothing — the shared tick must never crash. A dark guard is a strict no-op.
+   */
   tick(): FailoverGapTickResult {
     if (!this.deps.enabled()) {
       return { ran: false, gapDetected: false, mode: null, atRiskRunCount: 0, raised: false };
     }
+    this.ticks += 1;
+    this.lastTickAtMs = this.now();
 
-    const membership = this.deps.getMeshMembership();
-    const atRiskRunCount = this.deps.getActiveAutonomousRunCount();
+    try {
+      const membership = this.deps.getMeshMembership();
+      const atRiskRunCount = this.deps.getActiveAutonomousRunCount();
+      this.lastSingleMachine = membership.onlinePeerCount <= 0;
+      this.lastActiveRunCount = atRiskRunCount;
 
-    const singleMachine = membership.onlinePeerCount <= 0;
-    const hasWorkNeedingFailover = atRiskRunCount > 0;
-    const gapDetected = singleMachine && hasWorkNeedingFailover;
+      const hasWorkNeedingFailover = atRiskRunCount > 0;
+      const gapDetected = this.lastSingleMachine && hasWorkNeedingFailover;
 
-    if (!gapDetected) {
-      this.audit('no-gap', {
-        onlinePeerCount: membership.onlinePeerCount,
-        multiMachineEnabled: membership.multiMachineEnabled,
-        atRiskRunCount,
-      });
-      return { ran: true, gapDetected: false, mode: null, atRiskRunCount, raised: false };
+      if (!gapDetected) {
+        this.openGapMode = null;
+        this.audit('no-gap', {
+          onlinePeerCount: membership.onlinePeerCount,
+          multiMachineEnabled: membership.multiMachineEnabled,
+          atRiskRunCount,
+        });
+        return { ran: true, gapDetected: false, mode: null, atRiskRunCount, raised: false };
+      }
+
+      const mode: FailoverGapMode = membership.multiMachineEnabled ? 'peer-offline' : 'not-configured';
+      this.openGapMode = mode;
+
+      if (this.deps.dryRun()) {
+        this.wouldRaise += 1;
+        this.audit('would-raise', { mode, atRiskRunCount });
+        return { ran: true, gapDetected: true, mode, atRiskRunCount, raised: false };
+      }
+
+      this.deps.raiseAttention(buildAttention(mode, atRiskRunCount));
+      this.raises += 1;
+      this.audit('raised', { mode, atRiskRunCount });
+      return { ran: true, gapDetected: true, mode, atRiskRunCount, raised: true };
+    } catch (err) {
+      this.errors += 1;
+      this.audit('tick-error', { error: err instanceof Error ? err.message : String(err) });
+      return { ran: true, gapDetected: false, mode: null, atRiskRunCount: 0, raised: false };
     }
+  }
 
-    const mode: FailoverGapMode = membership.multiMachineEnabled ? 'peer-offline' : 'not-configured';
-
-    if (this.deps.dryRun()) {
-      this.audit('would-raise', { mode, atRiskRunCount });
-      return { ran: true, gapDetected: true, mode, atRiskRunCount, raised: false };
-    }
-
-    this.deps.raiseAttention(buildAttention(mode, atRiskRunCount));
-    this.audit('raised', { mode, atRiskRunCount });
-    return { ran: true, gapDetected: true, mode, atRiskRunCount, raised: true };
+  /** The read-surface snapshot (feeds the future GET route). */
+  status(): SingleMachineFailoverGapStatus {
+    return {
+      enabled: this.deps.enabled(),
+      dryRun: this.deps.dryRun(),
+      lastTickAt: this.lastTickAtMs ? new Date(this.lastTickAtMs).toISOString() : null,
+      singleMachine: this.lastSingleMachine,
+      activeAutonomousRunCount: this.lastActiveRunCount,
+      openGapMode: this.openGapMode,
+      counters: { ticks: this.ticks, raises: this.raises, wouldRaise: this.wouldRaise, errors: this.errors },
+    };
   }
 
   private audit(event: string, detail: Record<string, unknown>): void {

--- a/src/monitoring/SingleMachineFailoverGapDetector.ts
+++ b/src/monitoring/SingleMachineFailoverGapDetector.ts
@@ -1,0 +1,153 @@
+/**
+ * SingleMachineFailoverGapDetector — signal-only guard that surfaces the
+ * "no failover target" gap BEFORE it bites.
+ *
+ * The failure it closes (2026-07-22, the Codey overnight loss): an agent was
+ * running autonomous work single-machine, its one machine's session stopped
+ * overnight, and NOTHING took over — because there was no second machine
+ * registered to fail over TO. The gap was invisible until a human noticed the
+ * next morning. Nothing structural surfaced "you have active autonomous work
+ * and no failover target".
+ *
+ * This detector makes that gap loud: when this agent is single-machine (no
+ * online mesh peer) WHILE it has active autonomous runs, it raises ONE deduped
+ * attention item. It is SIGNAL-ONLY — it never blocks, never provisions a peer,
+ * never touches a session. It only tells the operator (and future-me) that the
+ * running autonomous work has no takeover if this machine goes down.
+ *
+ * ── Honesty: two distinct gap modes ──
+ *   not-configured : multiMachine is OFF entirely — no peer was ever registered.
+ *   peer-offline   : multiMachine is ON but every peer is currently offline —
+ *                    the failover target exists but is down right now.
+ * Both are a real gap when autonomous work is active (no takeover either way);
+ * the message names which so the operator knows whether to ADD a machine or
+ * REVIVE one.
+ *
+ * Pure + injected: every environment read is a callback, so this module unit
+ * tests with zero real managers and no I/O.
+ */
+
+export type FailoverGapMode = 'not-configured' | 'peer-offline';
+
+/** A snapshot of this agent's mesh membership, as this machine sees it. */
+export interface MeshMembership {
+  /** true iff multiMachine is configured/enabled on this agent at all. */
+  multiMachineEnabled: boolean;
+  /** Count of OTHER machines currently online in this agent's pool (excludes self). */
+  onlinePeerCount: number;
+}
+
+/** The attention item this detector emits (shape kept minimal + transport-agnostic). */
+export interface FailoverGapAttention {
+  title: string;
+  body: string;
+  priority: 'high';
+  /** Stable per-episode key so repeated ticks coalesce to ONE item. */
+  dedupKey: string;
+  source: 'single-machine-failover-gap';
+}
+
+export interface SingleMachineFailoverGapDetectorDeps {
+  /** Dark gate. When false the detector is a strict no-op (never reads, never raises). */
+  enabled: () => boolean;
+  /**
+   * Observe-only mode. When true the detector computes the verdict and audits a
+   * would-raise, but does NOT raise the attention item (the graduated-rollout
+   * dry-run rung).
+   */
+  dryRun: () => boolean;
+  /** This agent's current mesh membership (single-machine ⇔ onlinePeerCount === 0). */
+  getMeshMembership: () => MeshMembership;
+  /** How many autonomous runs are active right now (the work that needs a failover target). */
+  getActiveAutonomousRunCount: () => number;
+  /** Raise a deduped attention item. Only called on a genuine gap when not in dryRun. */
+  raiseAttention: (item: FailoverGapAttention) => void;
+  /** Optional structured audit sink (every transition, including no-ops with a reason). */
+  audit?: (event: string, detail: Record<string, unknown>) => void;
+}
+
+export interface FailoverGapTickResult {
+  ran: boolean;
+  /** True when this agent is single-machine WITH active autonomous work. */
+  gapDetected: boolean;
+  /** Which mode of gap (only meaningful when gapDetected). */
+  mode: FailoverGapMode | null;
+  /** How many autonomous runs are exposed by the gap. */
+  atRiskRunCount: number;
+  /** Whether an attention item was actually raised (false in dryRun even on a gap). */
+  raised: boolean;
+}
+
+const DEDUP_KEY = 'single-machine-failover-gap';
+
+/**
+ * The pure detector. One `tick()` = one evaluation. It raises at most one
+ * (deduped) attention item per gap episode; the attention layer's own dedup
+ * collapses repeated ticks so a persistent gap never floods.
+ */
+export class SingleMachineFailoverGapDetector {
+  constructor(private readonly deps: SingleMachineFailoverGapDetectorDeps) {}
+
+  tick(): FailoverGapTickResult {
+    if (!this.deps.enabled()) {
+      return { ran: false, gapDetected: false, mode: null, atRiskRunCount: 0, raised: false };
+    }
+
+    const membership = this.deps.getMeshMembership();
+    const atRiskRunCount = this.deps.getActiveAutonomousRunCount();
+
+    const singleMachine = membership.onlinePeerCount <= 0;
+    const hasWorkNeedingFailover = atRiskRunCount > 0;
+    const gapDetected = singleMachine && hasWorkNeedingFailover;
+
+    if (!gapDetected) {
+      this.audit('no-gap', {
+        onlinePeerCount: membership.onlinePeerCount,
+        multiMachineEnabled: membership.multiMachineEnabled,
+        atRiskRunCount,
+      });
+      return { ran: true, gapDetected: false, mode: null, atRiskRunCount, raised: false };
+    }
+
+    const mode: FailoverGapMode = membership.multiMachineEnabled ? 'peer-offline' : 'not-configured';
+
+    if (this.deps.dryRun()) {
+      this.audit('would-raise', { mode, atRiskRunCount });
+      return { ran: true, gapDetected: true, mode, atRiskRunCount, raised: false };
+    }
+
+    this.deps.raiseAttention(buildAttention(mode, atRiskRunCount));
+    this.audit('raised', { mode, atRiskRunCount });
+    return { ran: true, gapDetected: true, mode, atRiskRunCount, raised: true };
+  }
+
+  private audit(event: string, detail: Record<string, unknown>): void {
+    try {
+      this.deps.audit?.(event, detail);
+    } catch {
+      /* audit is best-effort — never let it break the tick */
+    }
+  }
+}
+
+/** Build the operator-facing attention item for a confirmed gap. Plain language, no jargon. */
+export function buildAttention(mode: FailoverGapMode, atRiskRunCount: number): FailoverGapAttention {
+  const runWord = atRiskRunCount === 1 ? 'autonomous run' : 'autonomous runs';
+  const body =
+    mode === 'not-configured'
+      ? `${atRiskRunCount} ${runWord} are running on this machine with no second machine registered. ` +
+        `If this machine sleeps or the session stops, the work stops with nothing to take over. ` +
+        `Register a second machine so this agent has a failover target.`
+      : `${atRiskRunCount} ${runWord} are running, but every other machine in this agent's pool is ` +
+        `currently offline — so there is no failover target right now. Bring the other machine back ` +
+        `online, or the work has no takeover if this machine goes down.`;
+  return {
+    title: 'No failover target for active autonomous work',
+    body,
+    priority: 'high',
+    dedupKey: DEDUP_KEY,
+    source: 'single-machine-failover-gap',
+  };
+}
+
+export const SINGLE_MACHINE_FAILOVER_GAP_DEDUP_KEY = DEDUP_KEY;

--- a/src/monitoring/guardManifest.ts
+++ b/src/monitoring/guardManifest.ts
@@ -1042,6 +1042,7 @@ export interface NotAGuardEntry {
 
 export const NOT_A_GUARD: readonly NotAGuardEntry[] = [
   { component: 'rawTextRequestDetector', reason: 'Pure stateless predicate (high-precision pattern match) feeding the observe-only ask-for-access signal in checkOutboundMessage; no enabled flag, no runtime getter, takes no protective action — a detector that produces a signal, never a guard with posture.' },
+  { component: 'SingleMachineFailoverGapDetector', reason: 'Increment-1 core only: pure signal-only failover-gap detector that is NOT yet boot-constructed and registers no GuardRegistry runtime getter, so it is not in the live /guards inventory. It moves to GUARD_MANIFEST when increment 2 wires it at boot (construction + guardStatus registration).' },
   { component: 'GuardPostureTripwire', reason: 'The boot-transition detector OVER the guard inventory — meta-layer, not a guard itself; always-on, no enabled flag.' },
   { component: 'GuardRegistry', reason: 'Infrastructure of this feature: the runtime-getter registry the inventory reads; not a guard.' },
   { component: 'GuardPostureProbe', reason: 'Consumer of the inventory (probe family); its cadence rides SystemReviewer, not an own enabled switch.' },

--- a/tests/unit/SingleMachineFailoverGapDetector.test.ts
+++ b/tests/unit/SingleMachineFailoverGapDetector.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   SingleMachineFailoverGapDetector,
   buildAttention,
+  resolveSingleMachineFailoverGapConfig,
+  guardStatusFor,
   SINGLE_MACHINE_FAILOVER_GAP_DEDUP_KEY,
   type SingleMachineFailoverGapDetectorDeps,
   type MeshMembership,
@@ -116,5 +118,77 @@ describe('SingleMachineFailoverGapDetector', () => {
   it('buildAttention pluralizes correctly (1 run vs many)', () => {
     expect(buildAttention('not-configured', 1).body).toMatch(/1 autonomous run /);
     expect(buildAttention('not-configured', 3).body).toMatch(/3 autonomous runs /);
+  });
+
+  it('status() reflects the last tick (single-machine gap, dry-run)', () => {
+    const { detector } = makeDetector({
+      dryRun: true,
+      membership: { multiMachineEnabled: true, onlinePeerCount: 0 },
+      activeRuns: 2,
+    });
+    detector.tick();
+    const s = detector.status();
+    expect(s.enabled).toBe(true);
+    expect(s.dryRun).toBe(true);
+    expect(s.singleMachine).toBe(true);
+    expect(s.activeAutonomousRunCount).toBe(2);
+    expect(s.openGapMode).toBe('peer-offline');
+    expect(s.counters).toEqual({ ticks: 1, raises: 0, wouldRaise: 1, errors: 0 });
+    expect(s.lastTickAt).toBeTypeOf('string');
+  });
+
+  it('status() clears the open gap once a peer comes back online', () => {
+    const raised: FailoverGapAttention[] = [];
+    let peers = 0;
+    const detector = new SingleMachineFailoverGapDetector({
+      enabled: () => true,
+      dryRun: () => false,
+      getMeshMembership: () => ({ multiMachineEnabled: true, onlinePeerCount: peers }),
+      getActiveAutonomousRunCount: () => 1,
+      raiseAttention: (i) => raised.push(i),
+    });
+    detector.tick();
+    expect(detector.status().openGapMode).toBe('peer-offline');
+    peers = 1; // failover target returns
+    detector.tick();
+    expect(detector.status().openGapMode).toBeNull();
+    expect(detector.status().counters.raises).toBe(1); // only the first tick raised
+  });
+
+  it('a throwing dependency is caught (fail toward silence) and counted', () => {
+    const detector = new SingleMachineFailoverGapDetector({
+      enabled: () => true,
+      dryRun: () => false,
+      getMeshMembership: () => { throw new Error('registry read failed'); },
+      getActiveAutonomousRunCount: () => 1,
+      raiseAttention: () => { throw new Error('must not reach raise'); },
+    });
+    const res = detector.tick();
+    expect(res).toEqual({ ran: true, gapDetected: false, mode: null, atRiskRunCount: 0, raised: false });
+    expect(detector.status().counters.errors).toBe(1);
+  });
+});
+
+describe('resolveSingleMachineFailoverGapConfig + guardStatusFor', () => {
+  it('defers the enabled decision to the injected dev-agent gate, dryRun defaults TRUE', () => {
+    const cfg = resolveSingleMachineFailoverGapConfig(undefined, (explicit) => explicit ?? true);
+    expect(cfg).toEqual({ enabled: true, dryRun: true });
+  });
+
+  it('an explicit enabled:false wins over the gate (deny is honored)', () => {
+    // Mirror resolveDevAgentGate semantics: explicit ?? gate.
+    const cfg = resolveSingleMachineFailoverGapConfig({ enabled: false }, (explicit) => explicit ?? true);
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it('an explicit dryRun:false is honored (graduation off dry-run)', () => {
+    const cfg = resolveSingleMachineFailoverGapConfig({ enabled: true, dryRun: false }, (e) => e ?? false);
+    expect(cfg).toEqual({ enabled: true, dryRun: false });
+  });
+
+  it('guardStatusFor grades dark ▸ dry-run ▸ live', () => {
+    expect(guardStatusFor({ enabled: false, dryRun: true })).toBe('dark');
+    expect(guardStatusFor({ enabled: true, dryRun: true })).toBe('dry-run');
+    expect(guardStatusFor({ enabled: true, dryRun: false })).toBe('live');
   });
 });

--- a/tests/unit/SingleMachineFailoverGapDetector.test.ts
+++ b/tests/unit/SingleMachineFailoverGapDetector.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SingleMachineFailoverGapDetector,
+  buildAttention,
+  SINGLE_MACHINE_FAILOVER_GAP_DEDUP_KEY,
+  type SingleMachineFailoverGapDetectorDeps,
+  type MeshMembership,
+  type FailoverGapAttention,
+} from '../../src/monitoring/SingleMachineFailoverGapDetector.js';
+
+function makeDetector(opts: {
+  enabled?: boolean;
+  dryRun?: boolean;
+  membership: MeshMembership;
+  activeRuns: number;
+}) {
+  const raised: FailoverGapAttention[] = [];
+  const audits: Array<{ event: string; detail: Record<string, unknown> }> = [];
+  const deps: SingleMachineFailoverGapDetectorDeps = {
+    enabled: () => opts.enabled ?? true,
+    dryRun: () => opts.dryRun ?? false,
+    getMeshMembership: () => opts.membership,
+    getActiveAutonomousRunCount: () => opts.activeRuns,
+    raiseAttention: (item) => raised.push(item),
+    audit: (event, detail) => audits.push({ event, detail }),
+  };
+  return { detector: new SingleMachineFailoverGapDetector(deps), raised, audits };
+}
+
+describe('SingleMachineFailoverGapDetector', () => {
+  it('is a strict no-op when disabled — never reads mesh/runs, never raises', () => {
+    let read = false;
+    const detector = new SingleMachineFailoverGapDetector({
+      enabled: () => false,
+      dryRun: () => false,
+      getMeshMembership: () => { read = true; return { multiMachineEnabled: false, onlinePeerCount: 0 }; },
+      getActiveAutonomousRunCount: () => { read = true; return 5; },
+      raiseAttention: () => { throw new Error('must not raise when disabled'); },
+    });
+    const res = detector.tick();
+    expect(res).toEqual({ ran: false, gapDetected: false, mode: null, atRiskRunCount: 0, raised: false });
+    expect(read).toBe(false);
+  });
+
+  it('raises a high-priority deduped item when single-machine (never configured) WITH active runs', () => {
+    const { detector, raised, audits } = makeDetector({
+      membership: { multiMachineEnabled: false, onlinePeerCount: 0 },
+      activeRuns: 2,
+    });
+    const res = detector.tick();
+    expect(res).toEqual({ ran: true, gapDetected: true, mode: 'not-configured', atRiskRunCount: 2, raised: true });
+    expect(raised).toHaveLength(1);
+    expect(raised[0].priority).toBe('high');
+    expect(raised[0].dedupKey).toBe(SINGLE_MACHINE_FAILOVER_GAP_DEDUP_KEY);
+    expect(raised[0].source).toBe('single-machine-failover-gap');
+    expect(raised[0].body).toMatch(/no second machine registered/i);
+    expect(audits.some((a) => a.event === 'raised')).toBe(true);
+  });
+
+  it('classifies the gap as peer-offline when multiMachine IS enabled but every peer is down', () => {
+    const { detector, raised } = makeDetector({
+      membership: { multiMachineEnabled: true, onlinePeerCount: 0 },
+      activeRuns: 1,
+    });
+    const res = detector.tick();
+    expect(res.mode).toBe('peer-offline');
+    expect(res.gapDetected).toBe(true);
+    expect(raised[0].body).toMatch(/every other machine.*offline/i);
+  });
+
+  it('does NOT flag a gap when a peer is online (failover target exists)', () => {
+    const { detector, raised, audits } = makeDetector({
+      membership: { multiMachineEnabled: true, onlinePeerCount: 1 },
+      activeRuns: 3,
+    });
+    const res = detector.tick();
+    expect(res).toEqual({ ran: true, gapDetected: false, mode: null, atRiskRunCount: 3, raised: false });
+    expect(raised).toHaveLength(0);
+    expect(audits.some((a) => a.event === 'no-gap')).toBe(true);
+  });
+
+  it('does NOT flag a gap when single-machine but there is NO autonomous work to protect', () => {
+    const { detector, raised } = makeDetector({
+      membership: { multiMachineEnabled: false, onlinePeerCount: 0 },
+      activeRuns: 0,
+    });
+    const res = detector.tick();
+    expect(res.gapDetected).toBe(false);
+    expect(raised).toHaveLength(0);
+  });
+
+  it('dryRun computes the gap + audits a would-raise but does NOT raise', () => {
+    const { detector, raised, audits } = makeDetector({
+      dryRun: true,
+      membership: { multiMachineEnabled: false, onlinePeerCount: 0 },
+      activeRuns: 4,
+    });
+    const res = detector.tick();
+    expect(res).toEqual({ ran: true, gapDetected: true, mode: 'not-configured', atRiskRunCount: 4, raised: false });
+    expect(raised).toHaveLength(0);
+    expect(audits.some((a) => a.event === 'would-raise')).toBe(true);
+  });
+
+  it('an audit sink that throws never breaks the tick (best-effort audit)', () => {
+    const detector = new SingleMachineFailoverGapDetector({
+      enabled: () => true,
+      dryRun: () => false,
+      getMeshMembership: () => ({ multiMachineEnabled: false, onlinePeerCount: 0 }),
+      getActiveAutonomousRunCount: () => 1,
+      raiseAttention: () => {},
+      audit: () => { throw new Error('audit boom'); },
+    });
+    expect(() => detector.tick()).not.toThrow();
+  });
+
+  it('buildAttention pluralizes correctly (1 run vs many)', () => {
+    expect(buildAttention('not-configured', 1).body).toMatch(/1 autonomous run /);
+    expect(buildAttention('not-configured', 3).body).toMatch(/3 autonomous runs /);
+  });
+});


### PR DESCRIPTION
Pure, dark-by-default, signal-only guard that raises ONE deduped high-priority attention item when this agent is running **single-machine** (no online mesh peer) **while it has active autonomous runs** — i.e. there is no failover target if this machine goes down.

## Why
Closes the CLASS behind the 2026-07-22 Codey overnight loss: an agent was running autonomous work single-machine, its one session stopped overnight, and nothing took over because no second machine could serve. The gap was invisible until a human noticed the next morning. Nothing structural surfaced "you have active autonomous work and no failover target."

## What this increment ships
- `SingleMachineFailoverGapDetector` — pure detector, INJECTED deps (mesh membership + active-run count + raiseAttention), fail-toward-silence tick.
- Two honest gap modes: `not-configured` (multiMachine off) vs `peer-offline` (configured but every peer is down). The attention body names which, so the operator knows whether to ADD a machine or REVIVE one.
- `resolveSingleMachineFailoverGapConfig` — dev-agent-gated (`monitoring.singleMachineFailoverGap`), **dryRun-first**; `guardStatusFor` (dark/dry-run/live); `status()` snapshot.
- **NOT wired to boot** = zero runtime effect (mirrors #1552 SessionPoolFailoverRunner). Boot-wiring + `GET` route + integration/e2e is the next increment.

## Tests
`tests/unit/SingleMachineFailoverGapDetector.test.ts` — 15/15 green (both boundary sides). `tsc --noEmit` clean.

## ELI16
Imagine you have two computers so if one falls asleep the other keeps doing your work. If you only have ONE turned on and it sleeps mid-job, the job just stops and nobody notices until morning — exactly what happened to a test agent overnight. This adds a little watchdog that speaks up the moment it notices "you are running real background work but only have one computer awake, so there is no backup to take over." It fixes nothing by itself and cannot break anything — it only raises one clear alert (and right now it is in quiet practice mode where it just logs what it *would* say). So this whole class of "lost a night of work silently" can never sneak up on us again.
