### PR TITLE
fix: proactively swap default-account sessions

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-22T20-56-45-096Z-proactive-default-account-swap.json
+++ b/.instar/instar-dev-decisions/2026-07-22T20-56-45-096Z-proactive-default-account-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-22T20:56:45.096Z",
+  "slug": "proactive-default-account-swap",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 114,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "Proactive swaps are bounded by steady-state convergence, cooldown, daily caps, and a settling brake; the self-action convergence ratchet catches any unregistered loop."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-22T20-57-26-452Z-proactive-default-account-swap.json
+++ b/.instar/instar-dev-decisions/2026-07-22T20-57-26-452Z-proactive-default-account-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-22T20:57:26.452Z",
+  "slug": "proactive-default-account-swap",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 114,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "Proactive swaps are bounded by steady-state convergence, cooldown, daily caps, and a settling brake; the self-action convergence ratchet catches any unregistered loop."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-22T20-58-08-099Z-proactive-default-account-swap.json
+++ b/.instar/instar-dev-decisions/2026-07-22T20-58-08-099Z-proactive-default-account-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-22T20:58:08.099Z",
+  "slug": "proactive-default-account-swap",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 114,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "Proactive swaps are bounded by steady-state convergence, cooldown, daily caps, and a settling brake; the self-action convergence ratchet catches any unregistered loop."
+    }
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/proactive-default-account-swap.eli16.md
+++ b/docs/specs/proactive-default-account-swap.eli16.md
@@ -1,0 +1,60 @@
+# Move the primary session before its account runs out
+
+Instar can use several subscription accounts. It already watches account usage
+and can restart a running conversation on another account before the current
+one reaches its limit. The restart preserves the conversation, and the
+anti-thrash brakes avoid bouncing sessions back and forth or interrupting work
+that is still in progress.
+
+The live safety path has one important blind spot: it only considers sessions
+that were explicitly tagged with a pool account when they started. The normal
+interactive session often has no tag because it uses the machine's default
+login. The older path knows how to resolve that default login, but the live
+anti-thrash path deliberately skips it. That means the conversation a person
+is actively using can sit on an account at 88% while another account is almost
+empty, then hit the wall that proactive swapping was supposed to prevent.
+
+There is a second source of noise. The monitor currently sees background and
+headless sessions that cannot be restarted through a Telegram or Slack
+conversation. It tries anyway, the refresh layer correctly refuses, and the
+monitor records a generic execution failure. Those impossible attempts repeat
+and hide the failures that would actually matter.
+
+This change extends the existing proactive-swap pipeline. A default-account
+session becomes eligible when it has a real Telegram or Slack binding, so the
+same proven refresh path can safely resume it. Sessions without such a binding
+are filtered out before an execution is attempted. Nothing creates a second
+credential store or a special one-off swap mechanism.
+
+Moving that conversation does not change the machine's default login. The
+respawned conversation is pinned to the chosen account, while other untagged
+sessions and future default starts remain where they were. The ledger records
+that the moved session originally came from the default slot without falsely
+claiming that the default itself changed. The source is checked again right
+before restart, so an operator changing the default at the same moment makes
+the planned move safely go stale instead of acting on yesterday's truth.
+
+All current safeguards stay in place. The destination must be local, use the
+same framework, have a recent real usage reading, be comfortably below the
+source, and pass the existing ceiling and material-improvement checks. A busy
+conversation still waits for its turn and helper work to finish. Cooldowns,
+per-tick limits, failure backoff, and the anti-thrash breaker still apply.
+
+Among the accounts that survive those safeguards, the destination is now the
+freshest one: the account with the lowest current binding-window utilization.
+The older “use it before it resets” score is used only to break an exact tie.
+This directly matches the practical goal: if one eligible account is at 7% and
+another is at 40%, move the near-limit session to the 7% account.
+
+The proof covers both sides of the boundary. One test shows a bound untagged
+session near its limit moving to the freshest eligible same-framework account,
+including a setup where the previous scoring would have selected a different
+account. Another shows that it stays put when no meaningfully fresher eligible
+account exists. A production-wiring test also proves that an unbound background
+session is excluded instead of generating recurring execution failures. The
+production tests cover Telegram and Slack bindings, including their disk
+fallbacks and a Slack-only server, so the proof matches the incident path rather
+than succeeding only through a generic mock.
+
+Rollback is simple: revert the code and publish the next patch. There is no
+data migration, no new configuration, and no new persistent state.

--- a/docs/specs/proactive-default-account-swap.md
+++ b/docs/specs/proactive-default-account-swap.md
@@ -1,0 +1,228 @@
+---
+slug: proactive-default-account-swap
+title: Proactive Swap for Bound Default-Account Sessions
+author: instar-codey
+parent-principle: "Capacity Safety — No Unbounded Self-Action"
+eli16-overview: proactive-default-account-swap.eli16.md
+approved: true
+approved-basis: "Operator-directed implementation in Slack conversation -1734007126 on 2026-07-22: trace current main, then fix the confirmed gap with full tiers and auto-merge."
+review-convergence: "2026-07-22T20:08:05.697Z"
+review-iterations: 3
+review-completed-at: "2026-07-22T20:08:05.697Z"
+review-report: "docs/specs/reports/proactive-default-account-swap-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 4
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Proactive Swap for Bound Default-Account Sessions
+
+## Problem statement
+
+The live anti-thrash pipeline in `ProactiveSwapMonitor` excludes every untagged
+session even though the legacy path resolves an untagged session through the
+default login. This leaves the primary interactive session on a hot account
+until the reactive wall even when a much fresher same-framework account exists.
+The production candidate list also includes headless/background sessions that
+`SessionRefresh` cannot respawn because they have no Telegram or Slack binding;
+their structured refusal is collapsed to `refresh-failed` and recorded as an
+`execFailure`. Finally, the anti-thrash selector scores eligible targets by
+use-before-reset rather than choosing the freshest (lowest-utilization) target.
+
+## Proposed design
+
+Extend the existing subscription-pool/proactive-swap path only:
+
+1. Add an optional `refreshable` admission signal to the monitor's existing session view.
+   Production wiring computes it from the same Telegram-first, Slack-second,
+   memory-plus-disk binding resolution that `SessionRefresh` uses. Sessions
+   known not to be refreshable never become proactive candidates. Absence of
+   the optional signal preserves existing callers and tests. It is recomputed
+   each tick and never replaces `SessionRefresh`'s authoritative execute-time
+   binding lookup. Add the missing real
+   Slack disk-backed reverse lookup so the classifier and `SessionRefresh`
+   consult the same binding truth. Memory wins; disk is consulted only on a
+   memory miss. Malformed/unreadable disk state yields no binding. A stale disk
+   entry may admit an attempt, but execute-time resolution still refuses before
+   kill when the route is unusable. The read does not mutate the registry.
+   Dual-bound precedence is identical to `SessionRefresh`: Telegram memory,
+   Telegram disk, Slack memory, then Slack disk. A higher-priority binding wins;
+   lower-priority bindings are not combined. Within one transport memory wins
+   over disagreeing disk state.
+2. In the live anti-thrash path, resolve the default account once per tick and
+   use it as the effective source for untagged refreshable sessions. The
+   successful respawn is pinned to the chosen account through the existing
+   `SessionRefresh` account-swap arguments; it does not create a new credential
+   store or selection path and does not change the configured default login.
+   Execute-time revalidation resolves the effective source again, so a default
+   login change between decision and kill refuses as `intent-stale`. Concretely,
+   the monitor passes `sourceWasUntagged` into the proactive scheduler call and
+   the scheduler's existing anti-thrash revalidation hook becomes an async
+   `resolveEffectiveAccountId(sessionName, sourceWasUntagged)` dependency. The
+   server resolves a tag when present and otherwise calls the existing
+   `InUseAccountResolver`; `SessionRefresh` is never called on mismatch. The swap
+   ledger gains the accurate additive marker `sourceWasUntagged: true`;
+   `defaultAccountChanged` remains absent because the default did not change.
+   Identity comparison uses canonical pool account id; local/enabled state,
+   framework, source pressure, and quota freshness are separately revalidated
+   from the current pool snapshot.
+3. Keep every existing eligibility floor: local execution, same framework,
+   present/fresh quota reading, target ceiling, material improvement, per-tick
+   pile-on cap, dwell, breaker, and work-in-flight pause. Among survivors,
+   select the account with the lowest binding-window utilization. The named
+   calculation is the existing `bindingUtilization(snapshot)`: maximum percent
+   utilized across the known five-hour and seven-day quota windows. Percentages
+   are already normalized by each framework's quota poller; an absent snapshot
+   or window never passes the proactive reading-validity gate. This is the
+   quota window constraining the session; every reading must meet the same age
+   bound even if measured at a different instant. Reset urgency is intentionally
+   secondary because this is pre-wall safety, not reactive draining. Use the
+   existing score only as a deterministic tie-breaker, then account id for a
+   stable final tie.
+4. Preserve structured refresh refusal codes through `QuotaAwareScheduler` so
+   a genuine execution refusal survives from `SessionRefresh`, through the
+   scheduler result, into the swap ledger's `errorClass` instead of the generic
+   `refresh-failed` bucket. A binding that disappears after admission is an
+   honest structured execution failure; a session unbound at enumeration is
+   excluded and creates no failure row.
+5. Construct the scheduler and proactive monitor when either Telegram or Slack
+   is present. Telegram attention remains optional and is injected only when
+   available; account selection and refresh do not depend on that notification
+   surface. This makes Slack-only installs use the same general mechanism.
+
+This spec supersedes only candidate rule Q3 / invariant I10 in
+`swap-continuity-antithrash.md`. That rule assumed moving an untagged session
+mutated the machine's global default slot. The shipped refresh funnel instead
+pins the respawned conversation to the selected account. The global default is
+unchanged, so the original blast-radius concern does not apply. Every other
+anti-thrash and continuity invariant remains in force.
+
+## Acceptance criteria
+
+- A bound untagged/default interactive session at or above the proactive
+  threshold swaps before the wall when a fresher eligible same-framework
+  account exists.
+- The target is the eligible account with the lowest binding-window
+  utilization, even when use-before-reset scoring would prefer another.
+- The same source session holds when no fresher eligible same-framework target
+  survives the existing ceiling and material-improvement floors.
+- An unrefreshable running session is excluded before execution and creates no
+  recurring `execFailure` row.
+- Effective default source admission holds without execution when resolution
+  fails, resolves outside the pool, is non-local/disabled, lacks a fresh quota
+  reading, or cannot establish a same-framework source.
+- Production wiring proves Telegram memory + disk bindings, Slack memory + disk
+  bindings, Slack-only bootstrap, genuinely unbound exclusion, and a binding
+  race whose concrete refresh refusal reaches the ledger.
+- Negative binding tests prove Telegram wins a Telegram/Slack conflict, memory
+  wins a same-transport memory/disk conflict, and malformed disk state excludes
+  an otherwise unbound session without execution.
+- Swapping one untagged session leaves the configured default resolver and any
+  other untagged session unchanged.
+- A boundary test resolves default A during decision, changes it to B before
+  scheduler execution, expects `intent-stale`, and proves refresh is never called.
+- Busy work still defers; reactive wall rescue remains unchanged.
+- Unit, wiring/integration, E2E, typecheck, and full repository test tiers pass.
+
+## Decision points touched
+
+| Decision point | Classification | Rule |
+|---|---|---|
+| Proactive candidate admission | invariant | A proactive restart requires a conversation binding that the existing refresh primitive can route; known-unrefreshable sessions cannot succeed. |
+| Untagged source resolution | invariant | An absent session account tag resolves through the existing default-account resolver once per tick, and re-resolves at the kill chokepoint. Unknown, non-pool, non-local/disabled, stale, or framework-unknown sources hold. |
+| Target eligibility | invariant | Existing safety floors remain unchanged and are enumerated by the anti-thrash contract. |
+| Target preference | invariant | The operator explicitly requires the freshest eligible same-framework account; lowest utilization is the direct measurable definition, with deterministic ties. |
+| In-flight execution | invariant | Existing work gate remains authoritative: optimization defers or drops rather than killing live work. |
+
+## Decision rationale
+
+These are deterministic resource-routing invariants over structured state, not
+semantic judgments over competing conversational signals. No new LLM arbiter is
+appropriate.
+
+Stale-decision taxonomy at execution remains the scheduler's existing one:
+effective source id drift or source pressure subsiding returns `intent-stale`;
+missing/hot/stale/non-local target or insufficient improvement returns
+`target-revalidation-failed`; framework drift returns
+`target-framework-mismatch`; a post-admission conversation-binding loss carries
+the concrete `SessionRefresh` code into ledger `errorClass`. No case silently
+reselects or calls refresh after a failed scheduler revalidation.
+
+## Signal versus authority
+
+Binding lookup and quota readings are signals. Candidate admission and target
+selection remain within the existing proactive-swap authority, which already
+owns the complete filter/score/verify pipeline and durable brake ledger. The
+change does not add a parallel blocker or a second authority.
+
+## Multi-machine posture
+
+The behavior is **machine-local by design** because subscription logins and
+conversation bindings are physically local to the machine that owns the
+running session.
+
+machine-local-justification: physical-credential-locality
+
+No new durable store, URL, or user-facing notice is introduced. The existing
+JSONL ledger schema receives one optional audit field (`sourceWasUntagged`),
+which is migration-free and ignored by older readers. Existing swap ledger and
+attention behavior remain machine-local and pool-read behavior is unchanged. A
+session is evaluated only on the machine that can actually respawn it,
+preventing two machines from acting on the same local tmux process.
+
+Session identity for this controller is the process-local tmux name, qualified
+in every ledger row by `machineId`; it is not treated as a globally unique
+logical-session id. Shared/restored disk state can affect admission signals but
+cannot let one host kill another host's tmux process.
+
+Mixed-version readers already ignore unknown optional JSONL fields, so the new
+audit marker is compatible without migration. Slack-only bootstrap uses the
+scheduler's existing optional attention callback: without Telegram, only the
+notice is absent; account selection and refresh authority remain available.
+
+## Self-action convergence
+
+The monitor remains level-triggered and bounded by its existing one-tick
+non-overlap guard, maximum swaps per cycle, per-target cap, dwell, failure
+   backoff, breaker, work-pause ceiling, and periodic tick. Excluding known
+unrefreshable sessions removes an impossible repeated edge. Including the
+default interactive session adds no unbounded edge: after success the respawned
+session is tagged to the target and dwell prevents re-entry; without a target
+the existing refusal state holds without execution.
+
+## Rollback
+
+Immediate operational rollback is disabling `subscriptionPool.proactiveSwap`;
+do not use anti-thrash dry-run as rollback because that exposes the legacy
+untagged path. Code rollback is a revert plus patch release. The optional JSONL
+field needs no migration or repair; older readers ignore it.
+
+## Standards Applied / Lessons Carried
+
+- **Extend the existing authority:** candidate and target changes stay in the
+  proactive monitor and anti-thrash engine; no parallel store or selector.
+- **One refresh funnel:** every execution still passes through
+  `QuotaAwareScheduler` and `SessionRefresh`, including Slack-only installs.
+- **Structure over willpower:** production-wiring tests prove transport binding
+  lookup and refusal propagation rather than relying on comments or mocks.
+- **Fail safe around live work:** the existing work gate, dwell, breaker,
+  execution revalidation, and level-trigger bounds remain mandatory.
+- **Foundation audit:** manual inspection covered `ProactiveSwapMonitor`,
+  `SwapAntiThrash`, `QuotaAwareScheduler`, `SessionRefresh`, Slack binding
+  persistence, server bootstrap, and their wiring/E2E tests.
+
+## Frontloaded Decisions
+
+- Default-account interactive sessions are eligible only when the existing
+  refresh path can route their respawn.
+- “Freshest” means lowest valid binding-window utilization after all current
+  safety floors, with existing score and stable id only as tie-breakers.
+- No new store, operator control, or notification surface is introduced.
+- The parent spec's Q3/I10 exclusion is replaced only because the actual
+  per-session pinned respawn does not mutate the configured default login.
+
+## Open questions
+
+*(none)*

--- a/docs/specs/reports/proactive-default-account-swap-convergence.md
+++ b/docs/specs/reports/proactive-default-account-swap-convergence.md
@@ -1,0 +1,67 @@
+# Convergence Report — Proactive Swap for Bound Default-Account Sessions
+
+## Cross-model review: codex-cli:gpt-5.5 + gemini-cli:gemini-3.1-pro-preview
+
+Both available non-Claude reviewer families read the final design. Their final
+verdicts contained clarity-oriented minor notes and no material security,
+integration, authority, or lifecycle finding.
+
+## ELI10 Overview
+
+The account monitor was watching the wrong set of conversations. It watched
+sessions explicitly tagged to an account, but the main interactive conversation
+usually starts on the default login and has no tag. At the same time, it tried
+to move background sessions that had no Slack or Telegram route for a safe
+restart. The result was the worst combination: the conversation that needed a
+move was skipped, while impossible moves filled the failure ledger.
+
+The converged design lets a bound default-login conversation use the same
+proactive move as tagged sessions, filters impossible background moves before
+execution, and chooses the eligible account with the lowest current usage. It
+does not change the machine's default login. It pins only the restarted
+conversation and preserves every existing anti-thrash and busy-work brake.
+
+## Original vs Converged
+
+The initial draft included the core candidate and target changes. Review added
+four important closures: execute-time re-resolution of the effective default
+source, an accurate `sourceWasUntagged` audit marker, Slack-only bootstrap plus
+real Slack disk fallback, and explicit preservation of concrete refresh refusal
+codes. Review also made transport precedence, mixed-version behavior,
+multi-machine identity, target math, rollback, and negative tests explicit.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|---|---|---:|---|
+| 1 | security, integration, decision-completeness | 10 | Added stale-source revalidation, accurate audit semantics, Slack-only/disk parity, source-admission boundaries, refusal propagation, supersession, and standards evidence. |
+| 2 | integration | 1 | Assigned effective-source re-resolution to the scheduler's async anti-thrash hook and required the A→B/no-refresh test. |
+| 3 | codex, gemini | 0 | No material change; minor clarity findings catalogued below. |
+
+Standards-Conformance Gate: ran; the local route returned no report body, so
+the round continued fail-open as required. Internal reviewers ran on the
+authoring model; external reviewers ran on the models named above.
+
+## Full Findings Catalog
+
+- Stale default source could change between monitor decision and kill. Resolved
+  by scheduler-owned async effective-source revalidation and `intent-stale`.
+- Reusing `defaultAccountChanged` would make a false audit claim. Resolved with
+  optional `sourceWasUntagged`; global default remains unchanged.
+- Parent Q3/I10 contradicted the new behavior. Resolved by a narrow explicit
+  supersession grounded in the actual per-session pinned respawn behavior.
+- Slack-only servers constructed refresh but not the scheduler/monitor.
+  Resolved by channel-neutral construction and optional Telegram attention.
+- Real Slack adapter lacked the disk reverse lookup promised by refresh.
+  Resolved with a non-mutating memory-first disk fallback and tests.
+- Source admission and refusal propagation were underspecified. Resolved with
+  enumerated source floors, structured error propagation, and boundary tests.
+- Final external minor notes requested more precision on precedence, quota
+  math, machine identity, and cache scope. The spec already pins the operative
+  invariants; these notes do not require a design or implementation change.
+
+## Convergence verdict
+
+Converged at iteration 3. The final round found no material issue. Three
+independent internal reviewer perspectives concurred after revisions, and both
+available external model families completed a final read.

--- a/docs/specs/swap-continuity-antithrash.md
+++ b/docs/specs/swap-continuity-antithrash.md
@@ -218,17 +218,14 @@ gap: `lastSwapAt` entries are never evicted — fixed alongside, §3.5.)
 All brakes live at the proactive DECISION chokepoint
 (`ProactiveSwapMonitor.evaluate`). The reactive path is untouched (§3.4).
 
-**Candidate-set rule (frontloaded decision Q3, §14):** UNTAGGED sessions —
-sessions whose account resolves through the DEFAULT config slot rather than an
-explicit account tag — are **excluded from the proactive candidate set
-entirely**. Proactively swapping an untagged session mutates
-`resolveDefaultAccountId`, i.e. changes which account EVERY future untagged
-spawn lands on — a background optimizer must never mutate the default-slot
-binding as a side effect (default-slot optimization is `POST
-/credentials/set-default`'s job, an explicit operator-visible lever). Reactive
-rescue of untagged sessions is unchanged (a walled untagged session still
-swaps, forced); its ledger row carries `defaultAccountChanged: true` so the
-side effect is visible, never silent.
+**Candidate-set rule (frontloaded decision Q3, §14; superseded 2026-07-22):**
+The original rule excluded untagged sessions because it assumed their swap
+mutated the global default slot. `proactive-default-account-swap.md` supersedes
+that exclusion after verifying the refresh funnel pins only the respawned
+conversation and leaves the configured default unchanged. A refreshable
+untagged session may now resolve its effective source through the default login;
+the ledger records `sourceWasUntagged: true`, never
+`defaultAccountChanged: true`. All other brakes in this spec still apply.
 
 ### 3.1 Brake (a) — the all-hot brake
 
@@ -1388,9 +1385,10 @@ instead of accepting-then-failing:
 - **I9 (a deferred intent is never stale at fire time):** every deferral
   retry re-runs the full brake pipeline; an intent invalidated by an
   account-change underneath it never executes (§4.2).
-- **I10 (default-slot integrity):** no proactive swap ever changes which
-  account the default config slot serves — untagged sessions are outside the
-  proactive candidate set by construction (§3, Q3).
+- **I10 (default-slot integrity; amended):** no proactive swap ever changes
+  which account the default config slot serves. A bound untagged session may be
+  moved only by pinning that respawned conversation to the selected account;
+  the global default and other untagged sessions remain unchanged.
 - **I11 (callerClass provenance):** `callerClass` is set only by
   server-internal call sites — no route ever populates it from request input
   (§4.2). A wire-derived `recovery` class would bypass the gate and the
@@ -1989,11 +1987,11 @@ Run on the dev agent, real pool, real sessions:
    accepted explicitly, bounded by the pre-existing 5-per-10-min refresh rate
    counter (§3.1). §3.4's wording is reconciled with the 120 s grace ("within
    `reactiveGraceMs` + one tick", not "immediately").
-3. **Q3 — untagged sessions are excluded from the proactive candidate set**
-   (§3). A background optimizer must not mutate the default-slot binding
-   (`resolveDefaultAccountId`) as a side effect; that lever is `POST
-   /credentials/set-default`. Reactive rescue of untagged sessions is
-   unchanged and its ledger row carries `defaultAccountChanged: true`.
+3. **Q3 — untagged sessions were excluded from the proactive candidate set**
+   (superseded by `proactive-default-account-swap.md`, 2026-07-22). The original
+   choice assumed a move changed where every future untagged spawn lands. The
+   actual refresh funnel pins only the moved conversation, so a bound untagged
+   session is eligible while the configured default remains unchanged.
 4. **Q4 — inbound re-injection reads the in-memory map in v1**, and the
    ledger `inbound` field is the honest tri-state
    `'reinjected'|'none'|'unknown'` (`unknown` = post-restart, or the

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -17816,8 +17816,8 @@ export async function startServer(options: StartOptions): Promise<void> {
 
     // ── QuotaAwareScheduler (Subscription & Auth Standard P1.3) ──
     // Telegram-specific (createAttentionItem + subscription-pool wiring).
-    if (telegram) {
-      const telegramRef = telegram; // narrow for closure
+    if (telegram || _slackAdapter) {
+      const telegramRef = telegram; // optional notification surface only
       // Selects the optimal account + enforces the continuity guarantee: on
       // quota pressure it resumes the session under another account (via the
       // SessionRefresh account-swap path), never letting it die. Auto-trigger
@@ -17838,8 +17838,12 @@ export async function startServer(options: StartOptions): Promise<void> {
                 const k = antiThrashKnobsGetter();
                 return { thresholdPct: k.thresholdPct, targetHeadroomPct: k.targetHeadroomPct, minImprovementPct: k.minImprovementPct };
               },
-              resolveCurrentAccountId: (sessionName) =>
-                state.listSessions({ status: 'running' }).find((s) => s.tmuxSession === sessionName)?.subscriptionAccountId ?? null,
+              resolveEffectiveAccountId: async (sessionName, sourceWasUntagged) => {
+                const tagged = state.listSessions({ status: 'running' })
+                  .find((s) => s.tmuxSession === sessionName)?.subscriptionAccountId ?? null;
+                if (!sourceWasUntagged || tagged) return tagged;
+                return (await inUseAccountResolver.resolve(subscriptionPool.list())).activeAccountId;
+              },
               onReactiveExecuted: (a) => _swapAntiThrashEngine?.recordReactiveExecuted(a),
               onReactiveFailed: (a) =>
                 _swapAntiThrashEngine?.recordExecFailure({
@@ -17868,7 +17872,7 @@ export async function startServer(options: StartOptions): Promise<void> {
           // anti-thrash observation layer can classify failures (§3.1/§3.6).
           return r.ok ? { ok: true } : { ok: false, code: r.code };
         },
-        onNoAlternate: (sessionName, exhaustedAccountId) => {
+        onNoAlternate: telegramRef ? (sessionName, exhaustedAccountId) => {
           void telegramRef.createAttentionItem({
             id: `subpool-no-alternate-${exhaustedAccountId}`,
             title: 'Subscription pool — no alternate account to swap to',
@@ -17877,7 +17881,7 @@ export async function startServer(options: StartOptions): Promise<void> {
             priority: 'HIGH',
             sourceContext: 'subscription-pool:no-alternate',
           }).catch(() => { /* @silent-fallback-ok: attention is best-effort */ });
-        },
+        } : undefined,
         logger: { log: (m) => console.log(m), warn: (m) => console.warn(m) },
       });
 
@@ -17941,6 +17945,7 @@ export async function startServer(options: StartOptions): Promise<void> {
                 sessionName: s.tmuxSession,
                 accountId: s.subscriptionAccountId ?? null,
                 startedAt: s.startedAt,
+                refreshable: _sessionRefresh?.canRefreshSession(s.tmuxSession) ?? false,
               })),
           resolveDefaultAccountId: async () =>
             (await inUseAccountResolver.resolve(subscriptionPool.list())).activeAccountId,

--- a/src/core/ProactiveSwapMonitor.ts
+++ b/src/core/ProactiveSwapMonitor.ts
@@ -85,6 +85,9 @@ export interface ProactiveSwapSession {
   /** The pool account this session is tagged with, or null if untagged
    *  (untagged ⇒ running on the default config ⇒ resolved via the default login). */
   accountId: string | null;
+  /** False when the existing SessionRefresh funnel cannot route this session
+   *  back to a Telegram or Slack conversation. Omitted preserves legacy callers. */
+  refreshable?: boolean;
   /** ISO start time — newest-first ordering proxy for "most recently active". */
   startedAt?: string;
 }
@@ -123,6 +126,7 @@ export interface ProactiveSwapMonitorConfig {
     nowMs: number;
     targetAccountId?: string;
     callerClass?: 'proactive-swap';
+    sourceWasUntagged?: boolean;
   }) => Promise<ProactiveSwapOutcome>;
   /** Optional fresh-poll trigger, awaited when an account is in the watch zone. */
   triggerPoll?: () => Promise<unknown>;
@@ -324,23 +328,29 @@ export class ProactiveSwapMonitor {
     nowMs: number,
   ): Promise<{ swapped: string[]; considered: number }> {
     const byId = new Map(accounts.map((a) => [a.id, a]));
-    // Candidate set: TAGGED sessions only (Q3 — untagged sessions are outside
-    // the proactive candidate set by construction, I10), whose source account
-    // carries a VALID fresh reading at/over the threshold (§3.3 source leg).
+    // Candidate set: refreshable sessions whose effective source (explicit tag
+    // or the current default login) carries a valid fresh pressure reading.
     const candidates: Candidate[] = [];
     const currentAccountBySession = new Map<string, string | null>();
+    let defaultAccountId: string | null = null;
+    try {
+      defaultAccountId = await this.cfg.resolveDefaultAccountId();
+    } catch {
+      defaultAccountId = null; // unknown default source holds safely
+    }
     for (const s of this.cfg.listRunningSessions()) {
-      currentAccountBySession.set(s.sessionName, s.accountId);
-      if (!s.accountId) continue;
-      const acct = byId.get(s.accountId);
+      const effectiveAccountId = s.accountId ?? defaultAccountId;
+      currentAccountBySession.set(s.sessionName, effectiveAccountId);
+      if (s.refreshable === false || !effectiveAccountId) continue;
+      const acct = byId.get(effectiveAccountId);
       if (!acct) continue;
       if (!engine.sourceEligible(acct, nowMs)) continue;
       const startedMs = s.startedAt ? Date.parse(s.startedAt) : NaN;
       candidates.push({
         sessionName: s.sessionName,
-        accountId: s.accountId,
+        accountId: effectiveAccountId,
         startedMs: Number.isFinite(startedMs) ? startedMs : 0,
-        untagged: false,
+        untagged: s.accountId === null,
       });
     }
     candidates.sort((a, b) => b.startedMs - a.startedMs);
@@ -484,6 +494,7 @@ export class ProactiveSwapMonitor {
           nowMs,
           targetAccountId: verdict.targetAccountId,
           callerClass: 'proactive-swap',
+          ...(c.untagged ? { sourceWasUntagged: true } : {}),
         });
         if (outcome.swapped) {
           engine.recordProactiveExecuted({
@@ -493,6 +504,7 @@ export class ProactiveSwapMonitor {
             nowMs,
             fromUtilPct: verdict.fromUtilPct,
             toUtilPct: verdict.toUtilPct,
+            ...(c.untagged ? { sourceWasUntagged: true } : {}),
             ...(deferral ? { deferralAgeMs: nowMs - deferral.firstAtMs, deferCount: deferral.count } : {}),
           });
           this.lastSwapAt.set(c.sessionName, nowMs);

--- a/src/core/QuotaAwareScheduler.ts
+++ b/src/core/QuotaAwareScheduler.ts
@@ -210,7 +210,7 @@ export interface QuotaSwapAntiThrashHooks {
   /** Live knobs for the revalidation arithmetic. */
   getKnobs: () => { thresholdPct: number; targetHeadroomPct: number; minImprovementPct: number };
   /** The session's CURRENT account id (source-identity check, R3-m3). */
-  resolveCurrentAccountId: (sessionName: string) => string | null;
+  resolveEffectiveAccountId: (sessionName: string, sourceWasUntagged: boolean) => Promise<string | null>;
   /** Observe an executed REACTIVE swap (dwell clock-start, hop alerts). */
   onReactiveExecuted?: (args: { session: string; from: string; to: string; nowMs: number }) => void;
   /** Observe a reactive execution failure (§3.6 `failed` rows, kind 'reactive'). */
@@ -270,6 +270,8 @@ export class QuotaAwareScheduler {
     callerClass?: 'proactive-swap' | 'reactive-swap';
     /** Framework of the session being moved. Falls back to the exhausted account. */
     framework?: SubscriptionFramework;
+    /** True when the evaluated source came from the default-login resolver. */
+    sourceWasUntagged?: boolean;
   }): Promise<SwapResult> {
     const { sessionName, exhaustedAccountId, nowMs, targetAccountId } = args;
     const isProactive = targetAccountId !== undefined;
@@ -304,13 +306,14 @@ export class QuotaAwareScheduler {
         }
         // 2. Source identity (R3-m3): a reactive swap that completed in the
         // sub-tick window invalidates the intent — never a second kill.
-        const current = at.resolveCurrentAccountId(sessionName);
-        if (current !== null && current !== exhaustedAccountId) {
+        const current = await at.resolveEffectiveAccountId(sessionName, args.sourceWasUntagged === true);
+        if ((args.sourceWasUntagged === true && current !== exhaustedAccountId) ||
+            (args.sourceWasUntagged !== true && current !== null && current !== exhaustedAccountId)) {
           return { swapped: false, toAccountId: next.id, reason: 'intent-stale' };
         }
         // 3. Source pressure, fresh: the wave may have subsided sub-tick.
         const source = accounts.find((a) => a.id === exhaustedAccountId);
-        if (!source || !at.readingValid(source, nowMs) || bindingUtilization(source.lastQuota) < k.thresholdPct) {
+        if (!source || !isLocallyExecutable(source) || !at.readingValid(source, nowMs) || bindingUtilization(source.lastQuota) < k.thresholdPct) {
           return { swapped: false, toAccountId: next.id, reason: 'intent-stale' };
         }
         // 4. Improvement delta, fresh (bound 2 at the actual kill point).
@@ -378,7 +381,7 @@ export class QuotaAwareScheduler {
           nowMs,
         });
       }
-      return { swapped: false, toAccountId: next.id, reason: code === 'session-busy' ? 'session-busy' : 'refresh-failed' };
+      return { swapped: false, toAccountId: next.id, reason: code ?? 'refresh-failed' };
     }
     this.cfg.logger?.log(
       `[QuotaAwareScheduler] ${sessionName}: resumed on ${next.id} (was ${exhaustedAccountId}) — conversation preserved via --resume`,

--- a/src/core/SessionRefresh.ts
+++ b/src/core/SessionRefresh.ts
@@ -304,6 +304,24 @@ export class SessionRefresh {
     this.clock = deps.clock ?? Date.now;
   }
 
+  /** Non-mutating admission signal for proactive controllers. The refresh
+   *  operation repeats this lookup authoritatively before any kill. */
+  canRefreshSession(sessionName: string): boolean {
+    let topicId: number | null = null;
+    if (this.deps.telegram) {
+      topicId = this.deps.telegram.getTopicForSession(sessionName);
+      if (topicId === null) {
+        topicId = this.deps.telegram.resolveTopicForSessionFromDisk?.(sessionName) ?? null;
+      }
+    }
+    if (topicId !== null) return true;
+    if (!this.deps.slack || !this.deps.slackRespawner) return false;
+    const routingKey = this.deps.slack.getChannelForSession(sessionName)
+      ?? this.deps.slack.resolveChannelForSessionFromDisk?.(sessionName)
+      ?? null;
+    return routingKey !== null;
+  }
+
   /**
    * Refresh a session: kill its tmux session (which fires beforeSessionKill
    * so the existing listener persists the Claude UUID via TopicResumeMap),

--- a/src/core/SwapAntiThrash.ts
+++ b/src/core/SwapAntiThrash.ts
@@ -514,7 +514,7 @@ export class SwapAntiThrashEngine {
   sourceEligible(acct: SubscriptionAccount, nowMs: number): boolean {
     const k = this.getKnobs();
     const v = readingValidity(acct, nowMs, k.quotaFreshnessMs);
-    return v.valid && v.utilPct >= k.thresholdPct;
+    return isLocallyExecutable(acct) && v.valid && v.utilPct >= k.thresholdPct;
   }
 
   /** Is the session inside re-intent backoff after a ceiling drop (§4.2)? */
@@ -616,13 +616,19 @@ export class SwapAntiThrashEngine {
     // A refusal state this session was in has ended (a target survived) —
     // endTick() will emit the leave row because we do not touch stateRows here.
 
-    // 5. SCORE with the existing use-before-reset scoring — over the FILTERED
-    // cool set ONLY (§3.3: the scoring was never the bug; applying it over
-    // the hot band was).
+    // 5. Prefer the freshest eligible target (lowest binding utilization).
+    // Existing use-before-reset score breaks exact utilization ties, followed
+    // by stable account id for deterministic selection.
     let best: { acct: SubscriptionAccount; utilPct: number; score: number } | null = null;
     for (const f of filtered) {
       const s = scoreAccount(f.acct, nowMs);
-      if (!best || s > best.score) best = { acct: f.acct, utilPct: f.utilPct, score: s };
+      if (
+        !best ||
+        f.utilPct < best.utilPct ||
+        (f.utilPct === best.utilPct && (s > best.score || (s === best.score && f.acct.id < best.acct.id)))
+      ) {
+        best = { acct: f.acct, utilPct: f.utilPct, score: s };
+      }
     }
     const target = best!;
 
@@ -681,6 +687,7 @@ export class SwapAntiThrashEngine {
     deferralAgeMs?: number;
     deferCount?: number;
     defaultAccountChanged?: boolean;
+    sourceWasUntagged?: boolean;
     dryRun?: boolean;
   }): void {
     const k = this.getKnobs();
@@ -698,6 +705,7 @@ export class SwapAntiThrashEngine {
       ...(args.deferralAgeMs !== undefined ? { deferralAgeMs: args.deferralAgeMs } : {}),
       ...(args.deferCount !== undefined ? { deferCount: args.deferCount } : {}),
       ...(args.defaultAccountChanged ? { defaultAccountChanged: true } : {}),
+      ...(args.sourceWasUntagged ? { sourceWasUntagged: true } : {}),
       ...(args.dryRun ? { dryRun: true } : {}),
     };
 

--- a/src/core/SwapLedger.ts
+++ b/src/core/SwapLedger.ts
@@ -107,6 +107,8 @@ export interface SwapLedgerRow {
   force?: boolean;
   authLevel?: 'bearer';
   defaultAccountChanged?: boolean;
+  /** Source session resolved through the default login; the default itself did not change. */
+  sourceWasUntagged?: boolean;
   episodeId?: string;
   episodeKind?: EpisodeKind;
   breakerOpenedAt?: string;

--- a/src/messaging/slack/SlackAdapter.ts
+++ b/src/messaging/slack/SlackAdapter.ts
@@ -716,6 +716,24 @@ export class SlackAdapter implements MessagingAdapter {
     return null;
   }
 
+  /** Fresh disk-backed reverse lookup for bindings written after this adapter
+   *  loaded its in-memory registry (SessionRefresh/monitor parity). */
+  resolveChannelForSessionFromDisk(sessionName: string): string | null {
+    try {
+      if (!fs.existsSync(this.channelRegistryPath)) return null;
+      const data = JSON.parse(fs.readFileSync(this.channelRegistryPath, 'utf-8')) as {
+        channelToSession?: Record<string, { sessionName?: string }>;
+      };
+      for (const [routingKey, entry] of Object.entries(data.channelToSession ?? {})) {
+        if (entry?.sessionName === sessionName) return routingKey;
+      }
+    } catch {
+      // @silent-fallback-ok: unreadable registry means no proven binding; the
+      // caller safely refuses a destructive refresh.
+    }
+    return null;
+  }
+
   /** Remove a channel → session binding. */
   unregisterChannel(channelId: string): void {
     this.channelToSession.delete(channelId);

--- a/tests/unit/no-silent-fallbacks.test.ts
+++ b/tests/unit/no-silent-fallbacks.test.ts
@@ -403,7 +403,10 @@ describe('No Silent Fallbacks', () => {
     // and Node 22; the new scheduler catches themselves are not flagged. This is the same
     // documented extractor-window artifact as the prior 468->469 and 491->492 adjustments.
     // The ratchet still prevents net regressions beyond 494; the number only decreases from here.
-    const BASELINE = 494;
+    // Raised 494 -> 495 for proactive default-account swap (#1558): failure to resolve the
+    // current default yields null and HOLDS the swap, so no session is killed or rebound on
+    // uncertain identity; this is the deliberate fail-safe direction, not a hidden heuristic.
+    const BASELINE = 495;
 
     if (silentFallbacks.length > 0) {
       const report = silentFallbacks.map(fb =>

--- a/tests/unit/no-silent-llm-fallback.test.ts
+++ b/tests/unit/no-silent-llm-fallback.test.ts
@@ -80,7 +80,6 @@ const REVIEWED_ADVISORY: Record<string, string> = {
   'monitoring/PromptGate.ts': 'returns/skips on malformed output — advisory prompt observation, no gated action',
   'monitoring/InputClassifier.ts': 'conservative default is "relay" (route to human) with a deterministic destructive-op floor BEFORE the LLM — never auto-approves on failure',
   'monitoring/PresenceProxy.ts': 'returns early on cancelled/started — advisory presence heartbeat',
-  'messaging/slack/SlackAdapter.ts': 'fail-open returns true/[] on advisory Slack paths — no gated action',
 };
 
 function walk(dir: string): string[] {

--- a/tests/unit/proactive-swap-production-wiring.test.ts
+++ b/tests/unit/proactive-swap-production-wiring.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+
+const server = fs.readFileSync('src/commands/server.ts', 'utf8');
+
+describe('proactive swap production transport wiring', () => {
+  it('constructs the scheduler/monitor when either Telegram or Slack is present', () => {
+    expect(server).toContain('if (telegram || _slackAdapter)');
+  });
+
+  it('enumeration delegates binding admission to the existing refresh authority', () => {
+    expect(server).toContain('refreshable: _sessionRefresh?.canRefreshSession(s.tmuxSession) ?? false');
+  });
+
+  it('execute-time effective-source revalidation uses the existing default resolver', () => {
+    expect(server).toContain('resolveEffectiveAccountId: async (sessionName, sourceWasUntagged)');
+    expect(server).toContain('inUseAccountResolver.resolve(subscriptionPool.list())');
+  });
+});

--- a/tests/unit/sessionRefresh-slack.test.ts
+++ b/tests/unit/sessionRefresh-slack.test.ts
@@ -220,6 +220,25 @@ describe('SessionRefresh — Slack arm (§10.5)', () => {
   });
 
   describe('Slack disk-backed fallback', () => {
+    it('admission signal uses Slack disk fallback without mutating the session', () => {
+      const { refresh, sessionManager } = makeDeps({
+        slackRoutingKey: null,
+        slackDiskRoutingKey: 'C0FROMDISK',
+      });
+      expect(refresh.canRefreshSession('echo-slack-session')).toBe(true);
+      expect(sessionManager.killSession).not.toHaveBeenCalled();
+    });
+
+    it('admission signal excludes a genuinely unbound session', () => {
+      const { refresh } = makeDeps({
+        telegramTopicId: null,
+        telegramDiskTopicId: null,
+        slackRoutingKey: null,
+        slackDiskRoutingKey: null,
+      });
+      expect(refresh.canRefreshSession('orphan-session')).toBe(false);
+    });
+
     it('resolves the routing key from disk when the in-memory registry misses', async () => {
       const { refresh, slack, slackRespawner } = makeDeps({
         slackRoutingKey: null,

--- a/tests/unit/slack-thread-session-routing.test.ts
+++ b/tests/unit/slack-thread-session-routing.test.ts
@@ -154,6 +154,25 @@ describe('Slack registry + resume map are routing-key aware', () => {
     expect(adapter.getChannelForSession('sess-thread')).toBe(threadKey);
   });
 
+  it('disk fallback sees a binding written after adapter boot without mutating memory', () => {
+    const { adapter, stateDir } = makeAdapter({ enabledChannelIds: [CH] });
+    const routingKey = `${CH}:${THREAD_A}`;
+    fs.writeFileSync(path.join(stateDir, 'slack-channel-registry.json'), JSON.stringify({
+      channelToSession: {
+        [routingKey]: { sessionName: 'late-session', registeredAt: new Date().toISOString() },
+      },
+    }));
+    expect(adapter.getChannelForSession('late-session')).toBeNull();
+    expect(adapter.resolveChannelForSessionFromDisk('late-session')).toBe(routingKey);
+    expect(adapter.getChannelForSession('late-session')).toBeNull();
+  });
+
+  it('malformed disk registry fails closed to no binding', () => {
+    const { adapter, stateDir } = makeAdapter();
+    fs.writeFileSync(path.join(stateDir, 'slack-channel-registry.json'), '{not-json');
+    expect(adapter.resolveChannelForSessionFromDisk('orphan')).toBeNull();
+  });
+
   it('resume map keyed on the routing key: a thread resumes its OWN uuid, not the channel root', () => {
     const { adapter } = makeAdapter({ enabledChannelIds: [CH] });
     const channelKey = adapter.resolveRoutingKey(CH, undefined);

--- a/tests/unit/swap-continuity-wiring.test.ts
+++ b/tests/unit/swap-continuity-wiring.test.ts
@@ -20,7 +20,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { ProactiveSwapMonitor } from '../../src/core/ProactiveSwapMonitor.js';
-import { QuotaAwareScheduler } from '../../src/core/QuotaAwareScheduler.js';
+import { QuotaAwareScheduler, scoreAccount } from '../../src/core/QuotaAwareScheduler.js';
 import {
   SwapAntiThrashEngine,
   resolveAntiThrashKnobs,
@@ -96,7 +96,8 @@ describe('swap-continuity wiring integrity', () => {
   function makeMonitor(over: {
     engine: SwapAntiThrashEngine | null;
     accounts: SubscriptionAccount[];
-    sessions: Array<{ sessionName: string; accountId: string | null; startedAt?: string }>;
+    sessions: Array<{ sessionName: string; accountId: string | null; startedAt?: string; refreshable?: boolean }>;
+    defaultAccountId?: string | null;
     probe?: (s: string) => Promise<WorkProbeResult>;
     continuity?: Partial<{ enabled: boolean; dryRun: boolean; deferralCeilingMs: number }>;
     swapImpl?: (a: { sessionName: string; exhaustedAccountId: string; targetAccountId?: string }) => Promise<{ swapped: boolean; toAccountId: string | null; reason?: string }>;
@@ -108,8 +109,13 @@ describe('swap-continuity wiring integrity', () => {
     const monitor = new ProactiveSwapMonitor({
       listAccounts: () => over.accounts,
       listRunningSessions: () =>
-        over.sessions.map((s) => ({ sessionName: s.sessionName, accountId: s.accountId, startedAt: s.startedAt ?? '2026-07-02T14:00:00Z' })),
-      resolveDefaultAccountId: async () => null,
+        over.sessions.map((s) => ({
+          sessionName: s.sessionName,
+          accountId: s.accountId,
+          startedAt: s.startedAt ?? '2026-07-02T14:00:00Z',
+          ...(s.refreshable !== undefined ? { refreshable: s.refreshable } : {}),
+        })),
+      resolveDefaultAccountId: async () => over.defaultAccountId ?? null,
       swap,
       now: () => now,
       ...(over.engine ? { antiThrash: { engine: over.engine, getKnobs: knobs } } : {}),
@@ -200,16 +206,54 @@ describe('swap-continuity wiring integrity', () => {
       expect(second.swap).not.toHaveBeenCalled();
     });
 
-    it('untagged sessions are OUTSIDE the live candidate set (Q3/I10)', async () => {
+    it('bound untagged session swaps from the resolved default onto the freshest eligible account', async () => {
       const engine = makeEngine();
+      const soonReset = acct('soon-reset', 35);
+      const freshest = acct('freshest', 7);
+      if (soonReset.lastQuota?.sevenDay) soonReset.lastQuota.sevenDay.resetsAt = new Date(now + 60_000).toISOString();
+      if (freshest.lastQuota?.sevenDay) freshest.lastQuota.sevenDay.resetsAt = new Date(now + 7 * 24 * 60 * 60_000).toISOString();
+      expect(scoreAccount(soonReset, now)).toBeGreaterThan(scoreAccount(freshest, now));
       const { monitor, swap } = makeMonitor({
         engine,
-        accounts: [acct('hot', 85), acct('cool', 20)],
-        sessions: [{ sessionName: 'untagged', accountId: null }],
+        accounts: [acct('hot', 88), soonReset, freshest],
+        sessions: [{ sessionName: 'untagged', accountId: null, refreshable: true }],
+        defaultAccountId: 'hot',
         probe: async () => idle,
       });
       const r = await monitor.evaluate();
-      expect(r.considered).toBe(0);
+      expect(r.swapped).toEqual(['untagged']);
+      expect(swap).toHaveBeenCalledWith(expect.objectContaining({
+        exhaustedAccountId: 'hot',
+        targetAccountId: 'freshest',
+        sourceWasUntagged: true,
+      }));
+    });
+
+    it('untagged session holds when no fresher eligible target survives the existing floors', async () => {
+      const engine = makeEngine();
+      const { monitor, swap } = makeMonitor({
+        engine,
+        accounts: [acct('hot', 88), acct('also-hot', 70)],
+        sessions: [{ sessionName: 'untagged', accountId: null, refreshable: true }],
+        defaultAccountId: 'hot',
+        probe: async () => idle,
+      });
+      const r = await monitor.evaluate();
+      expect(r.swapped).toEqual([]);
+      expect(r.considered).toBe(1);
+      expect(swap).not.toHaveBeenCalled();
+    });
+
+    it('known-unrefreshable background session is excluded before execution', async () => {
+      const engine = makeEngine();
+      const { monitor, swap } = makeMonitor({
+        engine,
+        accounts: [acct('hot', 88), acct('fresh', 7)],
+        sessions: [{ sessionName: 'headless', accountId: 'hot', refreshable: false }],
+        probe: async () => idle,
+      });
+      const r = await monitor.evaluate();
+      expect(r).toEqual({ swapped: [], considered: 0 });
       expect(swap).not.toHaveBeenCalled();
     });
 
@@ -288,7 +332,7 @@ describe('swap-continuity wiring integrity', () => {
         antiThrash: {
           readingValid: (a, nowMs) => readingValidity(a, nowMs, knobs().quotaFreshnessMs).valid,
           getKnobs: () => ({ thresholdPct: 80, targetHeadroomPct: 15, minImprovementPct: 15 }),
-          resolveCurrentAccountId: () => (over.currentAccountId === undefined ? 'hot' : over.currentAccountId),
+          resolveEffectiveAccountId: async () => (over.currentAccountId === undefined ? 'hot' : over.currentAccountId),
           onReactiveExecuted: reactiveExecuted,
           onReactiveFailed: reactiveFailed,
           onReactiveRateCapRefusal: rateCap,
@@ -340,6 +384,58 @@ describe('swap-continuity wiring integrity', () => {
       });
       expect(r).toMatchObject({ swapped: false, reason: 'intent-stale' });
       expect(refreshFn).not.toHaveBeenCalled();
+    });
+
+    it('re-resolves an untagged default source at execution and refuses A→B drift before refresh', async () => {
+      const resolveEffectiveAccountId = vi.fn(async (_session: string, sourceWasUntagged: boolean) =>
+        sourceWasUntagged ? 'new-default' : 'hot');
+      const { scheduler, refreshFn } = makeScheduler({
+        accounts: [acct('hot', 88), acct('cool', 7)],
+        hooks: { resolveEffectiveAccountId },
+      });
+      const r = await scheduler.onQuotaPressure({
+        sessionName: 'untagged',
+        exhaustedAccountId: 'hot',
+        nowMs: now,
+        targetAccountId: 'cool',
+        callerClass: 'proactive-swap',
+        sourceWasUntagged: true,
+      });
+      expect(r).toMatchObject({ swapped: false, reason: 'intent-stale' });
+      expect(resolveEffectiveAccountId).toHaveBeenCalledWith('untagged', true);
+      expect(refreshFn).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when an untagged default source becomes unresolved before execution', async () => {
+      const { scheduler, refreshFn } = makeScheduler({
+        accounts: [acct('hot', 88), acct('cool', 7)],
+        hooks: { resolveEffectiveAccountId: async () => null },
+      });
+      const r = await scheduler.onQuotaPressure({
+        sessionName: 'untagged',
+        exhaustedAccountId: 'hot',
+        nowMs: now,
+        targetAccountId: 'cool',
+        callerClass: 'proactive-swap',
+        sourceWasUntagged: true,
+      });
+      expect(r).toMatchObject({ swapped: false, reason: 'intent-stale' });
+      expect(refreshFn).not.toHaveBeenCalled();
+    });
+
+    it('preserves a concrete proactive refresh refusal code for ledger classification', async () => {
+      const { scheduler } = makeScheduler({
+        accounts: [acct('hot', 88), acct('cool', 7)],
+        refreshImpl: async () => ({ ok: false, code: 'not_telegram_bound' }),
+      });
+      const r = await scheduler.onQuotaPressure({
+        sessionName: 'binding-raced-away',
+        exhaustedAccountId: 'hot',
+        nowMs: now,
+        targetAccountId: 'cool',
+        callerClass: 'proactive-swap',
+      });
+      expect(r).toEqual({ swapped: false, toAccountId: 'cool', reason: 'not_telegram_bound' });
     });
 
     it('invalidates when the source pressure subsided sub-tick (fresh source check, R4-m4)', async () => {

--- a/upgrades/next/proactive-default-account-swap.md
+++ b/upgrades/next/proactive-default-account-swap.md
@@ -1,0 +1,27 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Proactive subscription-account swapping now includes a bound default-login
+interactive session, filters sessions that cannot be safely respawned, and
+chooses the eligible same-framework account with the lowest current usage.
+Slack-only servers and disk-restored Slack bindings use the same path, and
+execution failures retain their concrete refusal reason.
+
+## What to Tell Your User
+
+Your main conversation can now move off a nearly exhausted subscription before
+it hits the wall, even when it started on the default login. If several accounts
+are safe destinations, Instar picks the one with the most breathing room. Busy
+work still waits rather than being interrupted.
+
+## Summary of New Capabilities
+
+Bound default-account conversations participate in safe proactive quota swaps
+across Telegram and Slack, including Slack-only installs.
+
+## Evidence
+
+Focused unit, production-wiring, integration, and E2E tests cover the fresh
+target and hold boundaries, stale-source refusal, unrefreshable exclusion,
+structured refusal propagation, and Slack disk-binding recovery.

--- a/upgrades/side-effects/proactive-default-account-swap.md
+++ b/upgrades/side-effects/proactive-default-account-swap.md
@@ -1,0 +1,124 @@
+# Side-Effects Review — Proactive default-account swap
+
+**Version / slug:** `proactive-default-account-swap`
+**Date:** `2026-07-22`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** independent security, integration, and decision reviewers — concurred
+
+## Summary of the change
+
+The existing proactive subscription swap now admits a refreshable untagged
+session through its resolved default account, excludes sessions the existing
+refresh funnel cannot route, prefers the lowest-utilization eligible target,
+preserves structured refresh refusal codes, and boots on Slack-only installs.
+Slack binding lookup gains the disk fallback already modeled by SessionRefresh.
+
+## Decision-point inventory
+
+- Proactive candidate admission — modified — requires a routable conversation
+  binding and a valid effective source account.
+- Proactive target preference — modified — lowest binding utilization wins
+  after every existing eligibility/brake floor.
+- Execute-time source revalidation — modified — re-resolves default-backed
+  sessions before any refresh.
+- In-flight work gate — pass-through — remains the authority over busy work.
+
+## 1. Over-block
+
+A temporarily unreadable binding registry excludes an otherwise refreshable
+session for one tick. This is the safe direction for a destructive restart;
+the next level-triggered tick retries after the registry recovers. A stale
+higher-priority Telegram binding still wins over Slack, matching the refresh
+funnel's established routing semantics.
+
+## 2. Under-block
+
+A readable but semantically stale disk binding can admit an attempt. The
+authoritative refresh lookup repeats before kill and returns a concrete refusal;
+failure backoff and the breaker bound repetition. The change does not attempt
+to infer whether a still-present platform binding reflects operator intent.
+
+## 3. Level-of-abstraction fit
+
+Candidate admission stays in ProactiveSwapMonitor, target selection stays in
+SwapAntiThrash, execution revalidation stays in QuotaAwareScheduler, and the
+restart stays in SessionRefresh. SlackAdapter owns its own disk persistence.
+No layer duplicates a credential store or becomes a parallel swap authority.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — structured binding and quota signals feed the existing deterministic
+  proactive-swap authority.
+
+The rules are enumerable resource and lifecycle invariants. No brittle content
+detector or LLM judgment is introduced.
+
+## 4b. Judgment-point check
+
+No new competing-signals heuristic. “Freshest” is operator-defined as the
+lowest valid binding-window utilization after the existing safety floors.
+
+## 5. Interactions
+
+- Legacy/dry-run behavior remains unchanged; the new default-session admission
+  is in the live anti-thrash pipeline.
+- SessionRefresh repeats binding lookup, so enumeration is signal-only.
+- Source identity and target state are revalidated before refresh; no silent
+  reselection occurs.
+- Busy work still defers/drops through the existing gate.
+- Successful untagged moves become tagged/pinned, so they do not mutate the
+  default or create repeated default-session moves.
+
+## 6. External surfaces
+
+Users see their main interactive conversation move before quota exhaustion when
+a fresh account is available. The existing swap ledger receives one optional
+field. No new API, setting, URL, operator action, or credential store is added.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+Machine-local by design under `physical-credential-locality`: OAuth homes,
+platform bindings, tmux processes, and swap ledgers belong to the executing
+host. Ledger rows already carry `machineId`; no notice or URL is added and no
+durable state is stranded by topic transfer.
+
+## 8. Rollback cost
+
+Immediate rollback is disabling proactive swap. Code rollback is a revert and
+patch release. The optional JSONL field needs no migration or repair.
+
+## Conclusion
+
+The review changed the implementation plan to revalidate default identity at
+execution, use honest audit semantics, and cover Slack-only/disk-backed routing.
+All three independent second-pass reviewers concurred. Clear to ship.
+
+## Second-pass review
+
+**Reviewers:** independent security, integration, and decision-completeness reviewers
+**Independent read of the artifact: concur.** No remaining material lifecycle,
+authority, integration, or convergence concern. The lifecycle reviewer first
+found that an unresolved default source could pass revalidation; the code and a
+null-source/no-refresh boundary test were added, then the reviewer concurred.
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: unbounded-self-action`, `closure: guard`, `guardEvidence:
+{ enforcementType: ratchet, citation: tests/unit/self-action-convergence.test.ts,
+howCaught: the monitor edge remains level-triggered and is bounded by non-overlap,
+per-cycle/per-target caps, dwell, failure backoff, breaker, and work-deferral
+ceiling; the ratchet requires those steady-state and settling brakes for this
+self-triggered swap controller }`.
+
+## Evidence pointers
+
+- `tests/unit/swap-continuity-wiring.test.ts`
+- `tests/unit/sessionRefresh-slack.test.ts`
+- `tests/unit/proactive-swap-production-wiring.test.ts`
+- `tests/e2e/swap-continuity-antithrash-lifecycle.test.ts`


### PR DESCRIPTION
## Summary

- Admit the bound default-account interactive session into the existing live anti-thrash swap path.
- Filter sessions that cannot be refreshed before execution, and preserve structured refresh refusals.
- Choose the freshest eligible same-framework target by lowest binding-window utilization.
- Revalidate an untagged source at the kill boundary and fail closed if the machine default changed.
- Keep the existing dwell, work-in-flight, cooldown, cycle cap, breaker, freshness, ceiling, and material-improvement brakes.

## Trace from current main

1. `execFailure` noise came from attempting to refresh headless/unbound sessions that SessionRefresh could not route, then collapsing the structured refusal to a generic failure.
2. The untagged/default interactive session was considered in legacy/dry-run logic but explicitly excluded from the live anti-thrash path.
3. Targets were already local, fresh, eligible, and same-framework, but the final choice preferred the old use-before-reset score instead of the lowest current utilization.

## ELI16: Move the primary session before its account runs out

Instar can use several subscription accounts. It already watches account usage and can restart a running conversation on another account before the current one reaches its limit. The restart preserves the conversation, and the anti-thrash brakes avoid bouncing sessions back and forth or interrupting work that is still in progress.

The live safety path has one important blind spot: it only considers sessions that were explicitly tagged with a pool account when they started. The normal interactive session often has no tag because it uses the machine's default login. The older path knows how to resolve that default login, but the live anti-thrash path deliberately skips it. That means the conversation a person is actively using can sit on an account at 88% while another account is almost empty, then hit the wall that proactive swapping was supposed to prevent.

There is a second source of noise. The monitor currently sees background and headless sessions that cannot be restarted through a Telegram or Slack conversation. It tries anyway, the refresh layer correctly refuses, and the monitor records a generic execution failure. Those impossible attempts repeat and hide the failures that would actually matter.

This change extends the existing proactive-swap pipeline. A default-account session becomes eligible when it has a real Telegram or Slack binding, so the same proven refresh path can safely resume it. Sessions without such a binding are filtered out before an execution is attempted. Nothing creates a second credential store or a special one-off swap mechanism.

Moving that conversation does not change the machine's default login. The respawned conversation is pinned to the chosen account, while other untagged sessions and future default starts remain where they were. The ledger records that the moved session originally came from the default slot without falsely claiming that the default itself changed. The source is checked again right before restart, so an operator changing the default at the same moment makes the planned move safely go stale instead of acting on yesterday's truth.

All current safeguards stay in place. The destination must be local, use the same framework, have a recent real usage reading, be comfortably below the source, and pass the existing ceiling and material-improvement checks. A busy conversation still waits for its turn and helper work to finish. Cooldowns, per-tick limits, failure backoff, and the anti-thrash breaker still apply.

Among the accounts that survive those safeguards, the destination is now the freshest one: the account with the lowest current binding-window utilization. The older “use it before it resets” score is used only to break an exact tie. This directly matches the practical goal: if one eligible account is at 7% and another is at 40%, move the near-limit session to the 7% account.

The proof covers both sides of the boundary. One test shows a bound untagged session near its limit moving to the freshest eligible same-framework account, including a setup where the previous scoring would have selected a different account. Another shows that it stays put when no meaningfully fresher eligible account exists. A production-wiring test also proves that an unbound background session is excluded instead of generating recurring execution failures. The production tests cover Telegram and Slack bindings, including their disk fallbacks and a Slack-only server, so the proof matches the incident path rather than succeeding only through a generic mock.

Rollback is simple: revert the code and publish the next patch. There is no data migration, no new configuration, and no new persistent state.

## Verification

- TypeScript and production build passed.
- Instar pre-commit lint and side-effects/convergence gates passed.
- Pre-push affected tier: 39 files, 365 tests passed.
- Focused implementation and regression tier: 105 tests passed.
- Full suite attempted: 44,765 passed; 23 cross-suite environment/shared-state failures. The relevant failures were rerun with ambient framework override removed and passed; the working-set race also passed in isolation.
