### PR TITLE
feat(monitoring): MissingLoginSessionDetector — alert when a live session runs on a missing login

### DIFF
--- a/.instar/instar-dev-decisions/20260723T002150-missing-login-session-detector.json
+++ b/.instar/instar-dev-decisions/20260723T002150-missing-login-session-detector.json
@@ -1,0 +1,15 @@
+{
+  "ts": "2026-07-23T00:21:50.000Z",
+  "slug": "missing-login-session-detector",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 400,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass",
+  "note": "MissingLoginSessionDetector increment 1 — pure core + unit tests. Closes the 2026-07-22 justin-gmail silent auth-death: a live session ran on an account whose LOCAL login went missing (subscription-pool identityDrift repairState owner-relogin-required / actualAccountId missing-local-login) while the account still had ~92% quota free; it coasted on a cached credential, then walled on auth and went SILENT ~2.5h with NO alert to the operator (they had to notice manually). The pool detected the drift but raised no alert, and the reactive standby StuckSignatureClassifier only fires on a user message (none came for hours) — so a proactive detector is genuinely missing. This detector correlates two facts the others do not join: an account whose login is gone AND a live session bound to that account's config home right now; on a match it raises ONE deduped HIGH attention item naming the account + that a re-login is needed. SIGNAL-ONLY — never swaps, re-logins, or touches a session. Pure + injected deps (zero I/O in unit tests), fails toward silence. Increment 1 is NOT boot-wired (registers no runtime getter) -> classified NOT_A_GUARD (moves to GUARD_MANIFEST when a later increment wires it, mirroring the SingleMachineFailoverGapDetector core->wiring path). Additive, dark by construction (config resolver defaults dryRun:true + dev-agent gate). tsc clean; 13/13 unit green; npm run lint clean."
+}

--- a/src/monitoring/MissingLoginSessionDetector.ts
+++ b/src/monitoring/MissingLoginSessionDetector.ts
@@ -1,0 +1,270 @@
+/**
+ * MissingLoginSessionDetector — signal-only guard that surfaces the
+ * "a live session is running on an account whose login has gone missing" gap
+ * BEFORE the session dies silently.
+ *
+ * The failure it closes (2026-07-22, the justin-gmail silent auth-death): a live
+ * autonomous session was running on an account whose LOCAL LOGIN went missing
+ * (the subscription pool flagged `identityDrift.repairState ===
+ * 'owner-relogin-required'`, `actualAccountId === 'missing-local-login'`) while
+ * that account still had ~92% of its quota free. The session coasted on a cached
+ * credential, then — once that credential expired — every turn began failing on
+ * auth and the session went SILENT for ~2.5 hours. NOTHING alerted the operator;
+ * they had to notice the silence themselves and re-login by hand. The drift WAS
+ * detected by the pool, but it was never raised as an alert, and the reactive
+ * standby classifier only fires when the user sends a message (which, for hours,
+ * they did not).
+ *
+ * This detector makes that gap loud + PROACTIVE: when a live session is bound to
+ * an account whose login is missing, it raises ONE deduped attention item naming
+ * the account and that a re-login is needed. It is SIGNAL-ONLY — it never swaps
+ * accounts, never re-logins, never touches a session. It only tells the operator
+ * (and future-me) that a running session is about to wall on a missing login.
+ *
+ * Why it is distinct from the existing surfaces (not a duplicate):
+ *   - The subscription pool DETECTS the drift, but raises no alert on it.
+ *   - The honest-standby StuckSignatureClassifier can name an auth failure, but
+ *     only reactively — when the user messages. A heads-down run with no inbound
+ *     message falls through it (exactly what happened). This fires proactively.
+ *   - It correlates two facts the others don't join: "login is gone" AND "a live
+ *     session depends on that account right now" — drift alone is not urgent;
+ *     drift under a live session is.
+ *
+ * Pure + injected: every environment read is a callback, so this module unit
+ * tests with zero real managers and no I/O.
+ */
+
+/** An account whose LOCAL login has gone missing (re-login required to recover). */
+export interface MissingLoginAccount {
+  accountId: string;
+  /** The login "slot" (config home) the account serves from — how a session is matched to it. */
+  configHome: string;
+}
+
+/** A live session and the login slot (config home) it is currently running on. */
+export interface LiveSessionBinding {
+  sessionName: string;
+  configHome: string;
+  /** Optional topic id, purely for the operator-facing message (never load-bearing). */
+  topicId?: number | null;
+}
+
+/** The attention item this detector emits (shape kept minimal + transport-agnostic). */
+export interface MissingLoginAttention {
+  title: string;
+  body: string;
+  priority: 'high';
+  /** Stable per-episode key so repeated ticks coalesce to ONE item. */
+  dedupKey: string;
+  source: 'missing-login-session';
+}
+
+export interface MissingLoginSessionDetectorDeps {
+  /** Dark gate. When false the detector is a strict no-op (never reads, never raises). */
+  enabled: () => boolean;
+  /**
+   * Observe-only mode. When true the detector computes the verdict and audits a
+   * would-raise, but does NOT raise the attention item (the graduated-rollout
+   * dry-run rung).
+   */
+  dryRun: () => boolean;
+  /** Accounts whose local login is currently missing (owner-relogin-required). */
+  getMissingLoginAccounts: () => MissingLoginAccount[];
+  /** The live sessions and which login slot (config home) each runs on. */
+  getLiveSessions: () => LiveSessionBinding[];
+  /** Raise a deduped attention item. Only called on a genuine gap when not in dryRun. */
+  raiseAttention: (item: MissingLoginAttention) => void;
+  /** Optional structured audit sink (every transition, including no-ops with a reason). */
+  audit?: (event: string, detail: Record<string, unknown>) => void;
+}
+
+/** One affected pairing: a missing-login account with the live sessions depending on it. */
+export interface StrandedSession {
+  accountId: string;
+  sessionNames: string[];
+}
+
+export interface MissingLoginTickResult {
+  ran: boolean;
+  /** True when at least one live session is running on a missing-login account. */
+  gapDetected: boolean;
+  /** The affected account→sessions pairings (empty when no gap). */
+  stranded: StrandedSession[];
+  /** Whether an attention item was actually raised (false in dryRun even on a gap). */
+  raised: boolean;
+}
+
+const DEDUP_KEY = 'missing-login-session';
+
+// ── Config resolution (dev-gated dark; dry-run first) ───────────────────────
+
+/** The resolved, typed config the detector runs with. */
+export interface MissingLoginSessionResolvedConfig {
+  /** Dev-agent gate: live on a development agent, dark on the fleet (unless set). */
+  enabled: boolean;
+  /** Dry-run first even on a dev agent: compute + audit, but do NOT raise. */
+  dryRun: boolean;
+}
+
+/** The raw config block shape (all optional — everything defaults). */
+export interface MissingLoginSessionConfigBlock {
+  enabled?: boolean;
+  dryRun?: boolean;
+}
+
+/**
+ * Resolve `monitoring.missingLoginSession` against the dev-agent gate.
+ * `resolveEnabled` is the injected `resolveDevAgentGate(explicit, config)` result
+ * (kept as a param so this module stays free of a hard import — the server wiring
+ * passes the real gate). `dryRun` defaults TRUE (the graduated-rollout first rung).
+ */
+export function resolveMissingLoginSessionConfig(
+  block: MissingLoginSessionConfigBlock | undefined,
+  resolveEnabled: (explicit: boolean | undefined) => boolean,
+): MissingLoginSessionResolvedConfig {
+  const b = block ?? {};
+  return {
+    enabled: resolveEnabled(typeof b.enabled === 'boolean' ? b.enabled : undefined),
+    dryRun: typeof b.dryRun === 'boolean' ? b.dryRun : true,
+  };
+}
+
+/** The guard-posture grade for `GET /guards`: dark ▸ dry-run ▸ live. */
+export function guardStatusFor(cfg: MissingLoginSessionResolvedConfig): 'dark' | 'dry-run' | 'live' {
+  return cfg.enabled ? (cfg.dryRun ? 'dry-run' : 'live') : 'dark';
+}
+
+/** The `status()` snapshot (the future `GET /pool/missing-login` body core). */
+export interface MissingLoginSessionStatus {
+  enabled: boolean;
+  dryRun: boolean;
+  lastTickAt: string | null;
+  /** The affected account→sessions pairings seen on the LAST tick. */
+  stranded: StrandedSession[];
+  counters: { ticks: number; raises: number; wouldRaise: number; errors: number };
+}
+
+/**
+ * The pure detector. One `tick()` = one evaluation. It raises at most one
+ * (deduped) aggregate attention item per episode; the attention layer's own
+ * dedup collapses repeated ticks so a persistent gap never floods.
+ */
+export class MissingLoginSessionDetector {
+  private ticks = 0;
+  private raises = 0;
+  private wouldRaise = 0;
+  private errors = 0;
+  private lastTickAtMs = 0;
+  private lastStranded: StrandedSession[] = [];
+
+  constructor(
+    private readonly deps: MissingLoginSessionDetectorDeps,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  /**
+   * One evaluation. Rides an existing shared timer (no timer of its own). Fails
+   * toward silence: any internal error increments the error counter and emits
+   * nothing — the shared tick must never crash. A dark guard is a strict no-op.
+   */
+  tick(): MissingLoginTickResult {
+    if (!this.deps.enabled()) {
+      return { ran: false, gapDetected: false, stranded: [], raised: false };
+    }
+    this.ticks += 1;
+    this.lastTickAtMs = this.now();
+
+    try {
+      const missing = this.deps.getMissingLoginAccounts();
+      const sessions = this.deps.getLiveSessions();
+
+      const stranded = computeStranded(missing, sessions);
+      this.lastStranded = stranded;
+
+      if (stranded.length === 0) {
+        this.audit('no-gap', {
+          missingLoginAccounts: missing.length,
+          liveSessions: sessions.length,
+        });
+        return { ran: true, gapDetected: false, stranded: [], raised: false };
+      }
+
+      if (this.deps.dryRun()) {
+        this.wouldRaise += 1;
+        this.audit('would-raise', { stranded });
+        return { ran: true, gapDetected: true, stranded, raised: false };
+      }
+
+      this.deps.raiseAttention(buildAttention(stranded));
+      this.raises += 1;
+      this.audit('raised', { stranded });
+      return { ran: true, gapDetected: true, stranded, raised: true };
+    } catch (err) {
+      this.errors += 1;
+      this.audit('tick-error', { error: err instanceof Error ? err.message : String(err) });
+      return { ran: true, gapDetected: false, stranded: [], raised: false };
+    }
+  }
+
+  /** The read-surface snapshot (feeds the future GET route). */
+  status(): MissingLoginSessionStatus {
+    return {
+      enabled: this.deps.enabled(),
+      dryRun: this.deps.dryRun(),
+      lastTickAt: this.lastTickAtMs ? new Date(this.lastTickAtMs).toISOString() : null,
+      stranded: this.lastStranded,
+      counters: { ticks: this.ticks, raises: this.raises, wouldRaise: this.wouldRaise, errors: this.errors },
+    };
+  }
+
+  private audit(event: string, detail: Record<string, unknown>): void {
+    try {
+      this.deps.audit?.(event, detail);
+    } catch {
+      /* audit is best-effort — never let it break the tick */
+    }
+  }
+}
+
+/**
+ * Pure correlation: for each missing-login account, collect the live sessions
+ * bound to its login slot (config home). Only accounts with ≥1 dependent live
+ * session are stranded (drift alone, with no session on it, is not a gap).
+ */
+export function computeStranded(
+  missing: MissingLoginAccount[],
+  sessions: LiveSessionBinding[],
+): StrandedSession[] {
+  const out: StrandedSession[] = [];
+  for (const acct of missing) {
+    const names = sessions
+      .filter((s) => s.configHome && s.configHome === acct.configHome)
+      .map((s) => s.sessionName);
+    if (names.length > 0) {
+      out.push({ accountId: acct.accountId, sessionNames: names });
+    }
+  }
+  return out;
+}
+
+/** Build the operator-facing attention item for a confirmed gap. Plain language, no jargon. */
+export function buildAttention(stranded: StrandedSession[]): MissingLoginAttention {
+  const totalSessions = stranded.reduce((n, s) => n + s.sessionNames.length, 0);
+  const sessionWord = totalSessions === 1 ? 'session' : 'sessions';
+  const acctList = stranded.map((s) => s.accountId).join(', ');
+  const acctWord = stranded.length === 1 ? 'account' : 'accounts';
+  const body =
+    `${totalSessions} live ${sessionWord} ${totalSessions === 1 ? 'is' : 'are'} running on ${acctWord} ` +
+    `whose login has gone missing (${acctList}). The session works only until its cached credential ` +
+    `expires — then every turn fails on authentication and it goes silent with no error to you. ` +
+    `Re-login to that account now to keep it from going dark.`;
+  return {
+    title: 'A live session is running on a missing login',
+    body,
+    priority: 'high',
+    dedupKey: DEDUP_KEY,
+    source: 'missing-login-session',
+  };
+}
+
+export const MISSING_LOGIN_SESSION_DEDUP_KEY = DEDUP_KEY;

--- a/src/monitoring/guardManifest.ts
+++ b/src/monitoring/guardManifest.ts
@@ -1062,6 +1062,7 @@ export interface NotAGuardEntry {
 
 export const NOT_A_GUARD: readonly NotAGuardEntry[] = [
   { component: 'rawTextRequestDetector', reason: 'Pure stateless predicate (high-precision pattern match) feeding the observe-only ask-for-access signal in checkOutboundMessage; no enabled flag, no runtime getter, takes no protective action — a detector that produces a signal, never a guard with posture.' },
+  { component: 'MissingLoginSessionDetector', reason: 'Increment-1 core only: pure injected-deps detector for the "live session on a missing-login account" alert; NOT boot-constructed and registers no runtime getter yet, so it is absent from the live /guards inventory. MOVES to GUARD_MANIFEST when a later increment wires it at boot (mirrors the SingleMachineFailoverGapDetector core→wiring path).' },
   { component: 'GuardPostureTripwire', reason: 'The boot-transition detector OVER the guard inventory — meta-layer, not a guard itself; always-on, no enabled flag.' },
   { component: 'GuardRegistry', reason: 'Infrastructure of this feature: the runtime-getter registry the inventory reads; not a guard.' },
   { component: 'GuardPostureProbe', reason: 'Consumer of the inventory (probe family); its cadence rides SystemReviewer, not an own enabled switch.' },

--- a/tests/unit/MissingLoginSessionDetector.test.ts
+++ b/tests/unit/MissingLoginSessionDetector.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MissingLoginSessionDetector,
+  buildAttention,
+  computeStranded,
+  resolveMissingLoginSessionConfig,
+  guardStatusFor,
+  MISSING_LOGIN_SESSION_DEDUP_KEY,
+  type MissingLoginSessionDetectorDeps,
+  type MissingLoginAccount,
+  type LiveSessionBinding,
+  type MissingLoginAttention,
+} from '../../src/monitoring/MissingLoginSessionDetector.js';
+
+function makeDetector(opts: {
+  enabled?: boolean;
+  dryRun?: boolean;
+  missing: MissingLoginAccount[];
+  sessions: LiveSessionBinding[];
+}) {
+  const raised: MissingLoginAttention[] = [];
+  const audits: Array<{ event: string; detail: Record<string, unknown> }> = [];
+  const deps: MissingLoginSessionDetectorDeps = {
+    enabled: () => opts.enabled ?? true,
+    dryRun: () => opts.dryRun ?? false,
+    getMissingLoginAccounts: () => opts.missing,
+    getLiveSessions: () => opts.sessions,
+    raiseAttention: (item) => raised.push(item),
+    audit: (event, detail) => audits.push({ event, detail }),
+  };
+  return { detector: new MissingLoginSessionDetector(deps), raised, audits };
+}
+
+describe('MissingLoginSessionDetector', () => {
+  it('is a strict no-op when disabled — never reads accounts/sessions, never raises', () => {
+    let read = false;
+    const detector = new MissingLoginSessionDetector({
+      enabled: () => false,
+      dryRun: () => false,
+      getMissingLoginAccounts: () => { read = true; return [{ accountId: 'a', configHome: '/h' }]; },
+      getLiveSessions: () => { read = true; return [{ sessionName: 's', configHome: '/h' }]; },
+      raiseAttention: () => { throw new Error('must not raise when disabled'); },
+    });
+    const res = detector.tick();
+    expect(res).toEqual({ ran: false, gapDetected: false, stranded: [], raised: false });
+    expect(read).toBe(false);
+  });
+
+  it('raises a high-priority deduped item when a live session runs on a missing-login account', () => {
+    const { detector, raised, audits } = makeDetector({
+      missing: [{ accountId: 'justin-gmail', configHome: '/home/.claude-x' }],
+      sessions: [{ sessionName: 'echo-run', configHome: '/home/.claude-x', topicId: 29723 }],
+    });
+    const res = detector.tick();
+    expect(res.ran).toBe(true);
+    expect(res.gapDetected).toBe(true);
+    expect(res.raised).toBe(true);
+    expect(res.stranded).toEqual([{ accountId: 'justin-gmail', sessionNames: ['echo-run'] }]);
+    expect(raised).toHaveLength(1);
+    expect(raised[0].priority).toBe('high');
+    expect(raised[0].dedupKey).toBe(MISSING_LOGIN_SESSION_DEDUP_KEY);
+    expect(raised[0].source).toBe('missing-login-session');
+    expect(raised[0].body).toMatch(/justin-gmail/);
+    expect(raised[0].body).toMatch(/re-login/i);
+    expect(audits.some((a) => a.event === 'raised')).toBe(true);
+  });
+
+  it('does NOT raise when a missing-login account has no live session on it (drift alone is not a gap)', () => {
+    const { detector, raised, audits } = makeDetector({
+      missing: [{ accountId: 'idle-acct', configHome: '/home/.claude-idle' }],
+      sessions: [{ sessionName: 'echo-run', configHome: '/home/.claude-healthy' }],
+    });
+    const res = detector.tick();
+    expect(res.gapDetected).toBe(false);
+    expect(res.raised).toBe(false);
+    expect(res.stranded).toEqual([]);
+    expect(raised).toHaveLength(0);
+    expect(audits.some((a) => a.event === 'no-gap')).toBe(true);
+  });
+
+  it('does NOT raise when there are no missing-login accounts at all', () => {
+    const { detector, raised } = makeDetector({
+      missing: [],
+      sessions: [{ sessionName: 'echo-run', configHome: '/home/.claude-x' }],
+    });
+    const res = detector.tick();
+    expect(res.gapDetected).toBe(false);
+    expect(raised).toHaveLength(0);
+  });
+
+  it('dry-run computes the gap + counts a would-raise but does NOT raise', () => {
+    const { detector, raised, audits } = makeDetector({
+      dryRun: true,
+      missing: [{ accountId: 'justin-gmail', configHome: '/home/.claude-x' }],
+      sessions: [{ sessionName: 'echo-run', configHome: '/home/.claude-x' }],
+    });
+    const res = detector.tick();
+    expect(res.gapDetected).toBe(true);
+    expect(res.raised).toBe(false);
+    expect(raised).toHaveLength(0);
+    expect(audits.some((a) => a.event === 'would-raise')).toBe(true);
+    expect(detector.status().counters.wouldRaise).toBe(1);
+    expect(detector.status().counters.raises).toBe(0);
+  });
+
+  it('aggregates multiple affected accounts into ONE deduped item', () => {
+    const { detector, raised } = makeDetector({
+      missing: [
+        { accountId: 'acct-a', configHome: '/h/a' },
+        { accountId: 'acct-b', configHome: '/h/b' },
+      ],
+      sessions: [
+        { sessionName: 's1', configHome: '/h/a' },
+        { sessionName: 's2', configHome: '/h/b' },
+        { sessionName: 's3', configHome: '/h/b' },
+      ],
+    });
+    const res = detector.tick();
+    expect(res.gapDetected).toBe(true);
+    expect(raised).toHaveLength(1);
+    expect(res.stranded).toEqual([
+      { accountId: 'acct-a', sessionNames: ['s1'] },
+      { accountId: 'acct-b', sessionNames: ['s2', 's3'] },
+    ]);
+    expect(raised[0].body).toMatch(/acct-a/);
+    expect(raised[0].body).toMatch(/acct-b/);
+  });
+
+  it('fails toward silence: a throwing reader increments errors and raises nothing', () => {
+    const raised: MissingLoginAttention[] = [];
+    const detector = new MissingLoginSessionDetector({
+      enabled: () => true,
+      dryRun: () => false,
+      getMissingLoginAccounts: () => { throw new Error('boom'); },
+      getLiveSessions: () => [],
+      raiseAttention: (item) => raised.push(item),
+    });
+    const res = detector.tick();
+    expect(res.ran).toBe(true);
+    expect(res.gapDetected).toBe(false);
+    expect(raised).toHaveLength(0);
+    expect(detector.status().counters.errors).toBe(1);
+  });
+
+  it('status() reflects ticks, last stranded set, and timestamp', () => {
+    const { detector } = makeDetector({
+      missing: [{ accountId: 'justin-gmail', configHome: '/h/x' }],
+      sessions: [{ sessionName: 'echo-run', configHome: '/h/x' }],
+    });
+    detector.tick();
+    const st = detector.status();
+    expect(st.enabled).toBe(true);
+    expect(st.dryRun).toBe(false);
+    expect(st.counters.ticks).toBe(1);
+    expect(st.counters.raises).toBe(1);
+    expect(st.lastTickAt).not.toBeNull();
+    expect(st.stranded).toEqual([{ accountId: 'justin-gmail', sessionNames: ['echo-run'] }]);
+  });
+});
+
+describe('computeStranded (pure correlation)', () => {
+  it('matches sessions to accounts by config home only', () => {
+    const stranded = computeStranded(
+      [{ accountId: 'a', configHome: '/h/a' }],
+      [
+        { sessionName: 's1', configHome: '/h/a' },
+        { sessionName: 's2', configHome: '/h/other' },
+      ],
+    );
+    expect(stranded).toEqual([{ accountId: 'a', sessionNames: ['s1'] }]);
+  });
+
+  it('ignores a session with an empty config home (never false-matches an empty account slot)', () => {
+    const stranded = computeStranded(
+      [{ accountId: 'a', configHome: '' }],
+      [{ sessionName: 's1', configHome: '' }],
+    );
+    expect(stranded).toEqual([]);
+  });
+});
+
+describe('resolveMissingLoginSessionConfig / guardStatusFor', () => {
+  it('defaults dryRun to true (graduated-rollout first rung) and honors the dev gate', () => {
+    const cfg = resolveMissingLoginSessionConfig(undefined, (explicit) => explicit ?? true);
+    expect(cfg).toEqual({ enabled: true, dryRun: true });
+    expect(guardStatusFor(cfg)).toBe('dry-run');
+  });
+
+  it('explicit enabled:false → dark; enabled + dryRun:false → live', () => {
+    expect(guardStatusFor(resolveMissingLoginSessionConfig({ enabled: false }, (e) => e ?? true))).toBe('dark');
+    expect(
+      guardStatusFor(resolveMissingLoginSessionConfig({ enabled: true, dryRun: false }, (e) => e ?? false)),
+    ).toBe('live');
+  });
+});
+
+describe('buildAttention', () => {
+  it('names the account and uses singular/plural correctly', () => {
+    const one = buildAttention([{ accountId: 'justin-gmail', sessionNames: ['s1'] }]);
+    expect(one.body).toMatch(/1 live session is running/);
+    expect(one.body).toMatch(/account/);
+    const many = buildAttention([
+      { accountId: 'a', sessionNames: ['s1', 's2'] },
+      { accountId: 'b', sessionNames: ['s3'] },
+    ]);
+    expect(many.body).toMatch(/3 live sessions are running/);
+    expect(many.body).toMatch(/accounts/);
+  });
+});


### PR DESCRIPTION
## What & why

Closes the **2026-07-22 silent auth-death**: a live autonomous session was running on an account whose **local login went missing** (`identityDrift.repairState === 'owner-relogin-required'`, `actualAccountId === 'missing-local-login'`) while that account still had **~92% of its quota free**. It coasted on a cached credential, then walled on authentication and went **silent for ~2.5 hours** with no error surfaced — the operator had to notice and re-login by hand.

The pool **detected** the drift but raised **no alert**, and the reactive `StuckSignatureClassifier` only fires when the user sends a message (none came for hours). A **proactive** detector was genuinely missing.

## What this adds

`MissingLoginSessionDetector` — a pure, signal-only guard correlating two facts the existing surfaces don't join: **an account whose login is gone** AND **a live session bound to that account's config home right now**. On a match it raises **ONE deduped HIGH attention item** naming the account + that a re-login is needed. It never swaps accounts, re-logins, or touches a session.

- Pure + injected deps, fails toward silence, dark by construction (`dryRun: true` default + dev-agent gate).
- **Increment 1** = core + 13 unit tests (both boundary sides); NOT boot-wired yet (`NOT_A_GUARD`; moves to `GUARD_MANIFEST` on a later wiring increment).

## Tests
`tsc --noEmit` clean · 13/13 unit green · full `npm run lint` clean.

## ELI16
Imagine you're logged into an app, and it quietly forgets your password behind the scenes. For a bit it still works because it remembered you from before — but the moment that memory runs out, every click just does nothing, silently, and nobody tells you why. That's what happened: a background worker ran on an account that got logged out, kept going on a leftover pass, then froze with no warning for two-plus hours until a human noticed.

This adds a small watcher that checks "is any worker running on a logged-out account?" — and if so, raises a loud flag ("this account needs a fresh login or the worker goes dark"). It doesn't fix it itself (that's a separate, riskier job); it just makes the problem impossible to miss instead of a silent freeze. Ships off by default and, when on, starts watch-only so it proves it flags the right thing before it ever pings anyone.