### PR TITLE
Install verified peer SSH access

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T04-54-03-239Z-reliable-peer-machine-execution.json
+++ b/.instar/instar-dev-decisions/2026-07-23T04-54-03-239Z-reliable-peer-machine-execution.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-23T04:54:03.239Z",
+  "slug": "reliable-peer-machine-execution",
+  "suggestedTier": 2,
+  "declaredTier": 3,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 10,
+  "loc": 476,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T04-54-44-104Z-reliable-peer-machine-execution.json
+++ b/.instar/instar-dev-decisions/2026-07-23T04-54-44-104Z-reliable-peer-machine-execution.json
@@ -1,0 +1,30 @@
+{
+  "ts": "2026-07-23T04:54:44.104Z",
+  "slug": "reliable-peer-machine-execution",
+  "suggestedTier": 2,
+  "declaredTier": 3,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 10,
+  "loc": 476,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1539
+    ],
+    "notes": "The prior mutual-SSH phase proved restricted transport but intentionally stopped before standing OS SSH access, leaving autonomous peer execution incomplete."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/mutual-ssh-hardening.test.ts",
+      "howCaught": "Per-machine authorization mutations are event-driven and idempotent; repair attempts are capped by the existing ten-machine sweep and bounded repair breaker, while startup, disable, rotation, and revocation settle by removing managed entries."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T04-55-46-657Z-reliable-peer-machine-execution.json
+++ b/.instar/instar-dev-decisions/2026-07-23T04-55-46-657Z-reliable-peer-machine-execution.json
@@ -1,0 +1,30 @@
+{
+  "ts": "2026-07-23T04:55:46.657Z",
+  "slug": "reliable-peer-machine-execution",
+  "suggestedTier": 2,
+  "declaredTier": 3,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 10,
+  "loc": 476,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1539
+    ],
+    "notes": "The prior mutual-SSH phase proved restricted transport but intentionally stopped before standing OS SSH access, leaving autonomous peer execution incomplete."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/mutual-ssh-hardening.test.ts",
+      "howCaught": "Per-machine authorization mutations are event-driven and idempotent; repair attempts are capped by the existing ten-machine sweep and bounded repair breaker, while startup, disable, rotation, and revocation settle by removing managed entries."
+    }
+  },
+  "verdict": "pass"
+}

--- a/docs/side-effects/reliable-peer-machine-execution.side-effects.md
+++ b/docs/side-effects/reliable-peer-machine-execution.side-effects.md
@@ -1,0 +1,34 @@
+# Side-effects review — reliable peer-machine execution
+
+## Authority and write boundary
+
+The new effect grants the paired machine's dedicated Instar client key access to
+the current agent account. Authority is the conjunction of the existing signed
+advert checks and fresh mutual directional proofs at the registry's current
+pairing epoch. Neither discovery, an advert, nor one directional probe can write.
+
+The only write target is `<account-home>/.ssh/authorized_keys`. Symlinked target
+components are refused; the directory and file are forced to 0700/0600; replacement
+is atomic. Instar owns only `instar-peer-access` lines. Human keys survive byte-for-
+byte as lines, and peer rotation replaces rather than accumulates managed grants.
+
+## Revocation, retries, and partial failure
+
+Peer removal or re-pair epoch change removes the managed line. A crash before rename
+leaves the old canonical file intact. A crash after rename leaves the complete new
+file. Reconciliation is idempotent. Dry-run performs no filesystem mutation.
+Failure stays named in mutual-SSH health; there is no success fallback.
+
+## Signal versus authority
+
+The advert and probe results are signals. `MutualSshVerifier.mutual`, with live boot
+ids, exact generations, pairing epoch, and monotonic freshness, is the authority.
+`PeerAuthorizedKeys` performs no trust decision and accepts only the already
+authorized record passed by the runtime.
+
+## Class closure
+
+This closes the “verified bootstrap never installs standing access” defect class
+with the machine-coherence N5 ratchet, dark-gate golden map, guard manifest, and
+tests for target scope, idempotency, rotation, revocation, dry-run, permissions,
+and symlink refusal.

--- a/docs/specs/mutual-ssh-autobootstrap.eli16.md
+++ b/docs/specs/mutual-ssh-autobootstrap.eli16.md
@@ -1,5 +1,22 @@
 # ELI16 — Instar Mutual SSH-Subsystem Autobootstrap and Continuous Proof
 
+## ACT-897: the verified key now becomes usable
+
+The first version proved that the other machine really owned its advertised SSH
+key, but stopped before putting that key where normal SSH could use it. ACT-897
+adds that last step. After both machines have freshly proved each direction, each
+machine adds the other's dedicated Instar key to the SSH access file for the
+account running that agent.
+
+It ships in rehearsal mode: development agents log what they would change, fleet
+agents stay dark, and no access is granted until dry-run is explicitly removed.
+Instar changes only its own labeled line, preserves human-managed keys, replaces
+old rotated keys, removes revoked peers, and refuses suspicious linked files.
+Then it makes a real SSH login to the other machine, pins that machine's signed
+host key, and runs one fixed harmless print command. If Remote Login is off, the
+account/key is wrong, or the network blocks normal SSH, health says exactly which
+machine is unreachable instead of quietly pretending failover works.
+
 ## What is broken today?
 
 Instar can know that two computers belong to the same agent without knowing that

--- a/docs/specs/mutual-ssh-autobootstrap.md
+++ b/docs/specs/mutual-ssh-autobootstrap.md
@@ -90,6 +90,39 @@ proves A→B, B→A, keyless-first-boot, key drift, endpoint drift, and recovery
 
 ## Security boundary and threat model
 
+### ACT-897 standing peer-execution amendment (2026-07-22)
+
+The restricted subsystem remains the bootstrap verifier, but it now has one
+explicitly separate downstream authority: `multiMachine.peerExecution`. Once
+and only once both current-boot directional proofs are fresh for the same
+MachineAuth principals, pairing epoch, client generations, and host generations,
+the target reconciles the peer advert's signed `clientPublicKey` into the current
+agent account's `~/.ssh/authorized_keys`.
+
+This amendment intentionally supersedes the phase-1 invariant that
+`authorized_keys` remains byte-identical. The broader grant is required for
+reliable peer-machine execution and is independently dark/dev-gated,
+`dryRun:true` by default, and readiness-bearing only after dry-run is disabled.
+The reconciler:
+
+- owns only lines marked `instar-peer-access`; operator lines are preserved;
+- replaces a prior managed key on generation/epoch rotation and removes it on
+  revoke or peer disappearance;
+- refuses symlinked `.ssh` directories and files, writes atomically, and enforces
+  directory `0700` plus file `0600`;
+- never writes sshd configuration, `/etc`, another account, or a global key file;
+- audits would-write/write/revoke outcomes without key bodies or home paths.
+
+The signed advert also carries the real sshd endpoint, account username, and
+host Ed25519 public key when the host exposes them. After installation, the
+source performs a pinned-host-key SSH login with its dedicated key and executes
+the fixed no-side-effect command `printf instar-standing-key-ok`. The standing
+health assertion is deliberately loud: when required, a paired machine without
+fresh mutual proof, the exact installed current-epoch key, and a fresh successful
+real-sshd execution probe is `standing-key-unreachable:<machineId>`, readiness is
+false, and enrollment is blocked. An advert alone, a one-way proof, an old boot,
+an old generation, or a different pairing epoch has no install authority.
+
 Only machines already mutually verified by Instar pairing may participate. The
 MachineAuth signature and pinned machine fingerprint authorize key exchange; an SSH
 host key independently binds the reached endpoint. An unpaired LAN host, a poisoned

--- a/docs/specs/reports/mutual-ssh-autobootstrap-convergence.md
+++ b/docs/specs/reports/mutual-ssh-autobootstrap-convergence.md
@@ -19,6 +19,13 @@ honest blocked reason when the network cannot carry the endpoint.
 
 ## Original vs Converged
 
+ACT-897 is an operator-authorized phase-2 amendment: the phase-1 choice to avoid
+OS `authorized_keys` proved transport identity but could not support autonomous
+execution on the peer machine. The new standing-access authority is separate,
+dark/dev-gated, dry-run-first, current-epoch mutual-proof-gated, agent-account
+scoped, revocable, and readiness-bearing. Phase-1 restricted-subsystem semantics
+remain the verifier and are not duplicated.
+
 The first draft relied on OS sshd and managed `authorized_keys`, which could not meet
 zero-operator setup on a host where Remote Login was disabled. Review replaced that
 with an unprivileged Instar-owned SSH subsystem that rejects shell, exec, SFTP, and

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -21269,6 +21269,17 @@ export async function startServer(options: StartOptions): Promise<void> {
           // Mutual SSH phase 1: the signed HTTP mesh is the bootstrap carrier;
           // the resulting proof itself traverses the restricted SSH subsystem.
           // Hard-dark on fleet, dry-run first on the development agent.
+          const peerExecutionEnabled = resolveDevAgentGate(config.multiMachine?.peerExecution?.enabled, config);
+          if (!peerExecutionEnabled) {
+            try {
+              const { PeerAuthorizedKeys } = await import('../core/PeerAuthorizedKeys.js');
+              new PeerAuthorizedKeys(os.homedir(), false).revokeUnknown(config.projectName, new Set());
+            } catch (error) {
+              // @silent-fallback-ok — disabled-feature cleanup failure is loud;
+              // no runtime starts and no readiness success can mask stale access.
+              console.warn(`[peer-execution] disabled-grant cleanup blocked: ${error instanceof Error ? error.message : String(error)}`);
+            }
+          }
           if (resolveDevAgentGate(config.multiMachine?.mutualSsh?.enabled, config)) {
             try {
               const sshMod = await import('../core/MutualSshRuntime.js');
@@ -21290,6 +21301,15 @@ export async function startServer(options: StartOptions): Promise<void> {
                 ?? privateHosts.find(host => /^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/.test(host))
                 ?? '127.0.0.1';
               const bindPort = portMod.allocatePort(`${config.projectName}-mutual-ssh`, 42000, 49000);
+              const standingHostKey = (() => {
+                if (!peerExecutionEnabled) return null;
+                try { return fs.readFileSync('/etc/ssh/ssh_host_ed25519_key.pub', 'utf8').trim(); }
+                catch {
+                  // @silent-fallback-ok — absence is a named standing endpoint
+                  // readiness blocker; never substitute an unpinned host key.
+                  return null;
+                }
+              })();
               const peers = () => meshIdMgr.getActiveMachines()
                 .filter(row => row.machineId !== meshSelfId)
                 .map(row => ({
@@ -21305,6 +21325,19 @@ export async function startServer(options: StartOptions): Promise<void> {
                 selfMachineFingerprint: machineFingerprint(selfPem),
                 observerBootId: `${meshSelfId}:${process.pid}:${Date.now()}`,
                 bindHost, bindPort, dryRun: config.multiMachine?.mutualSsh?.dryRun !== false,
+                peerExecution: peerExecutionEnabled ? {
+                  // The SSH daemon resolves AuthorizedKeysFile beneath the
+                  // account home; never write a system/global sshd path.
+                  agentHome: os.homedir(),
+                  dryRun: config.multiMachine?.peerExecution?.dryRun !== false,
+                  requiredForReadiness: config.multiMachine?.peerExecution?.requiredForReadiness !== false,
+                } : undefined,
+                localStandingSsh: peerExecutionEnabled && standingHostKey && bindHost !== '127.0.0.1' ? {
+                  host: bindHost,
+                  port: config.multiMachine?.peerExecution?.port ?? 22,
+                  username: os.userInfo().username,
+                  hostPublicKey: standingHostKey,
+                } : undefined,
                 requiredForReadiness: config.multiMachine?.mutualSsh?.requiredForEmployeeRole === true,
                 freshnessMs: config.multiMachine?.mutualSsh?.freshnessMs,
                 cadenceMs: config.multiMachine?.mutualSsh?.cadenceMs,
@@ -21338,6 +21371,11 @@ export async function startServer(options: StartOptions): Promise<void> {
               (globalThis as { __instarMutualSshRuntime?: import('../core/MutualSshRuntime.js').MutualSshRuntime }).__instarMutualSshRuntime = mutualSshRuntime;
               guardRegistry.register('multiMachine.mutualSsh.enabled', () => ({
                 enabled: true, dryRun: config.multiMachine?.mutualSsh?.dryRun !== false,
+                status: mutualSshRuntime?.status() ?? null,
+              }));
+              guardRegistry.register('multiMachine.peerExecution.enabled', () => ({
+                enabled: resolveDevAgentGate(config.multiMachine?.peerExecution?.enabled, config),
+                dryRun: config.multiMachine?.peerExecution?.dryRun !== false,
                 status: mutualSshRuntime?.status() ?? null,
               }));
             } catch (err) {

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -1066,6 +1066,14 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       probeDeadlineMs: 8_000,
       concurrency: 4,
     },
+    // Reliable peer-machine execution. `enabled` is deliberately OMITTED so
+    // resolveDevAgentGate keeps fleet dark; dry-run records the intended
+    // account-home authorized_keys change without granting SSH access.
+    peerExecution: {
+      dryRun: true,
+      requiredForReadiness: true,
+      port: 22,
+    },
     // Seamless LLM Orchestrator (docs/specs/llm-seamlessness-orchestrator.md).
     // A lease-gated tier-1 LLM loop for ANTICIPATORY working-set preload — PROPOSE-
     // ONLY / SIGNAL-ONLY (it never moves a conversation; placement stays with the

--- a/src/core/MutualSshRuntime.ts
+++ b/src/core/MutualSshRuntime.ts
@@ -9,6 +9,8 @@ import { MutualSshProbeScheduler } from './MutualSshProbeScheduler.js';
 import { SshPeerAdmissionStore } from './SshPeerAdmissionStore.js';
 import { SshHostKeyLifecycle, canonicalHostKeyProposal } from './SshHostKeyLifecycle.js';
 import { canonicalSshBootstrapAdvert, validateSshBootstrapAdvert, type SshBootstrapAdvert } from './SshBootstrapAdvert.js';
+import { PeerAuthorizedKeys, type PeerAuthorizedKey } from './PeerAuthorizedKeys.js';
+import { StandingSshVerifier } from './StandingSshVerifier.js';
 
 export interface MutualSshPeer {
   machineId: string;
@@ -26,6 +28,8 @@ export interface MutualSshRuntimeDeps {
   bindHost: string;
   bindPort: number;
   dryRun: boolean;
+  peerExecution?: { agentHome: string; dryRun: boolean; requiredForReadiness: boolean };
+  localStandingSsh?: SshBootstrapAdvert['standingSsh'];
   requiredForReadiness?: boolean;
   freshnessMs?: number;
   cadenceMs?: number;
@@ -68,6 +72,9 @@ export class MutualSshRuntime {
   private stopped = false;
   private readonly startedAtWall = Date.now();
   private readonly proofFile: string;
+  private readonly peerAuthorizedKeys: PeerAuthorizedKeys | null;
+  private readonly standingVerifier = new StandingSshVerifier();
+  private readonly standingEvidence = new Map<string, { deadline: number; targetDigest: string }>();
 
   constructor(private readonly d: MutualSshRuntimeDeps) {
     const freshness = d.freshnessMs ?? 300_000;
@@ -90,11 +97,18 @@ export class MutualSshRuntime {
       notifyExhausted: async (target, failure) => this.audit({ type: 'repair-exhausted', target: target.targetMachineId, failure }),
     }, concurrency);
     this.proofFile = path.join(d.stateDir, 'machine-ssh', 'directional-proofs.json');
+    this.peerAuthorizedKeys = d.peerExecution ? new PeerAuthorizedKeys(d.peerExecution.agentHome, d.peerExecution.dryRun) : null;
     this.invalidatePersistedProofs();
   }
 
   async start(): Promise<void> {
     this.identity = this.identityManager.ensure();
+    if (this.peerAuthorizedKeys) {
+      // A process restart invalidates proof authority. Remove all grants first;
+      // current-boot mutual proof may reinstall them.
+      const result = new PeerAuthorizedKeys(this.d.peerExecution!.agentHome, false).revokeUnknown(this.d.agentId, new Set());
+      if (result.changed) this.audit({ type: 'peer-authorized-key-stale-reconciled', dryRun: result.dryRun });
+    }
     if (!this.d.dryRun) await this.ensureEndpoint();
     await this.tick();
     this.timer = setInterval(() => { void this.tick(); }, this.d.cadenceMs ?? 60_000);
@@ -144,6 +158,7 @@ export class MutualSshRuntime {
         this.d.emitJournalProof?.(proof);
         await this.d.send(target.targetMachineId, { type: 'ssh-proof-publish', proof });
       });
+      await Promise.all(peers.map(peer => this.probeStandingAccess(peer.machineId)));
     } finally { this.running = false; }
   }
 
@@ -189,29 +204,41 @@ export class MutualSshRuntime {
     }
   }
 
-  status(): { enabled: true; dryRun: boolean; listener: boolean; readinessRequired: boolean; ready: boolean; enrollmentState: 'paired' | 'ssh-bootstrap' | 'ssh-bootstrap-blocked' | 'ssh-proving' | 'ready'; blockedReasons: string[]; directions: MutualSshPairHealth[]; pairs: Array<{ machines: string[]; mutual: boolean }> } {
+  status(): { enabled: true; dryRun: boolean; listener: boolean; readinessRequired: boolean; ready: boolean; enrollmentState: 'paired' | 'ssh-bootstrap' | 'ssh-bootstrap-blocked' | 'ssh-proving' | 'ready'; blockedReasons: string[]; directions: MutualSshPairHealth[]; pairs: Array<{ machines: string[]; mutual: boolean; standingKeyInstalled: boolean; standingReachable: boolean }> } {
     const targets = this.d.listPeers().flatMap(peer => { const target = this.targetFor(peer); return target ? [target] : []; });
     const directions = this.controller.health(targets).map(row => ({ ...row, proof: this.proofs.get(this.key(row.sourceMachineId, row.targetMachineId)) ?? row.proof }));
     const pairs = this.d.listPeers().map(peer => {
       const local = this.proofs.get(this.key(this.d.selfMachineId, peer.machineId));
       const remote = this.proofs.get(this.key(peer.machineId, this.d.selfMachineId));
       const advert = this.adverts.get(peer.machineId);
+      const mutual = Boolean(advert && MutualSshVerifier.mutual(local, remote, Date.now(), {
+        monotonicNow: performance.now(),
+        liveBootIds: new Set([this.d.observerBootId, advert.observerBootId]),
+        sourceClientGenerations: new Map([[this.d.selfMachineId, this.identity.clientGeneration], [peer.machineId, advert.clientKeyGeneration]]),
+        targetHostGenerations: new Map([[this.d.selfMachineId, this.identity.hostGeneration], [peer.machineId, advert.hostKeyGeneration]]),
+      }));
+      let standingKeyInstalled = false;
+      try { standingKeyInstalled = Boolean(advert && this.peerAuthorizedKeys?.has(this.authorizedKey(advert))); }
+      catch (error) { this.bootstrapFailures.set(peer.machineId, `standing-key-store:${classifyMutualSshFailure(error)}`); }
       return {
         machines: [this.d.selfMachineId, peer.machineId],
-        mutual: Boolean(advert && MutualSshVerifier.mutual(local, remote, Date.now(), {
-          monotonicNow: performance.now(),
-          liveBootIds: new Set([this.d.observerBootId, advert.observerBootId]),
-          sourceClientGenerations: new Map([[this.d.selfMachineId, this.identity.clientGeneration], [peer.machineId, advert.clientKeyGeneration]]),
-          targetHostGenerations: new Map([[this.d.selfMachineId, this.identity.hostGeneration], [peer.machineId, advert.hostKeyGeneration]]),
-        })),
+        mutual,
+        standingKeyInstalled,
+        standingReachable: Boolean(advert && this.standingEvidence.get(peer.machineId)?.deadline! > performance.now()
+          && this.standingEvidence.get(peer.machineId)?.targetDigest === this.standingTargetDigest(advert)),
       };
     });
     const peerCount = this.d.listPeers().filter(peer => peer.machineId !== this.d.selfMachineId).length;
     const proofReady = peerCount === 0 || (pairs.length === peerCount && pairs.every(pair => pair.mutual));
     const readinessRequired = this.d.requiredForReadiness === true && !this.stopped;
-    const ready = !readinessRequired || proofReady;
-    const enrollmentState = this.stopped || peerCount === 0 ? 'ready' : this.bootstrapFailures.size > 0 ? 'ssh-bootstrap-blocked' : this.d.dryRun || this.adverts.size < peerCount || !this.endpoint ? 'ssh-bootstrap' : proofReady ? 'ready' : 'ssh-proving';
-    return { enabled: true, dryRun: this.d.dryRun, listener: this.endpoint !== null, readinessRequired, ready, enrollmentState, blockedReasons: [...new Set(this.bootstrapFailures.values())].sort(), directions, pairs };
+    const standingRequired = this.d.peerExecution?.requiredForReadiness === true && !this.d.peerExecution.dryRun;
+    const standingReady = !standingRequired || pairs.every(pair => pair.mutual && pair.standingKeyInstalled && pair.standingReachable);
+    const combinedReadinessRequired = readinessRequired || standingRequired;
+    const ready = !combinedReadinessRequired || (proofReady && standingReady);
+    const blockedReasons = [...this.bootstrapFailures.values()];
+    if (standingRequired) for (const pair of pairs) if (!pair.mutual || !pair.standingKeyInstalled || !pair.standingReachable) blockedReasons.push(`standing-key-unreachable:${pair.machines[1]}`);
+    const enrollmentState = this.stopped || peerCount === 0 ? 'ready' : this.bootstrapFailures.size > 0 || (combinedReadinessRequired && !standingReady) ? 'ssh-bootstrap-blocked' : this.d.dryRun || this.adverts.size < peerCount || !this.endpoint ? 'ssh-bootstrap' : proofReady ? 'ready' : 'ssh-proving';
+    return { enabled: true, dryRun: this.d.dryRun, listener: this.endpoint !== null, readinessRequired: combinedReadinessRequired, ready, enrollmentState, blockedReasons: [...new Set(blockedReasons)].sort(), directions, pairs };
   }
 
   revoke(machineId: string): void {
@@ -228,7 +255,10 @@ export class MutualSshRuntime {
     await Promise.race([this.endpoint?.close() ?? Promise.resolve(), new Promise<void>(resolve => setTimeout(resolve, 10_000))]);
     this.endpoint = null;
     this.listen = null;
-    for (const peer of this.d.listPeers()) this.admissionStore.revoke(peer.machineId);
+    for (const peer of this.d.listPeers()) {
+      this.admissionStore.revoke(peer.machineId);
+      this.peerAuthorizedKeys?.revoke(this.d.agentId, peer.machineId);
+    }
   }
 
   private async startEndpoint(): Promise<void> {
@@ -281,6 +311,7 @@ export class MutualSshRuntime {
       sshHostPublicKeys: [this.identity.hostPublicKey], endpoints: this.listen && !isLoopback(this.listen.host) ? [{ ...this.listen, source: 'configured' }] : [],
       issuedAt, expiresAt: new Date(now + Math.min(300_000, this.d.freshnessMs ?? 300_000)).toISOString(),
       ...(transition ? { hostKeyTransitionSignature: this.d.sign(canonicalHostKeyProposal(transition)) } : {}),
+      ...(this.d.localStandingSsh ? { standingSsh: this.d.localStandingSsh } : {}),
     };
     return { ...unsigned, machineSignature: this.d.sign(canonicalSshBootstrapAdvert(unsigned)) };
   }
@@ -298,6 +329,11 @@ export class MutualSshRuntime {
     if (prior && advert.pairingEpoch > prior.pairingEpoch) {
       this.clearPeerEvidence(advert.machineId);
       prior = undefined;
+    }
+    if (prior && (advert.clientKeyGeneration !== prior.clientKeyGeneration || advert.clientPublicKey !== prior.clientPublicKey)) {
+      const revoked = this.peerAuthorizedKeys?.revoke(this.d.agentId, advert.machineId);
+      this.standingEvidence.delete(advert.machineId);
+      if (revoked?.changed) this.audit({ type: 'peer-authorized-key-rotation-revoked', machineId: advert.machineId, dryRun: revoked.dryRun });
     }
     if (prior && advert.hostKeyGeneration === prior.hostKeyGeneration && advert.sshHostPublicKeys[0] !== prior.sshHostPublicKeys[0]) { this.d.notifySecurity?.({ type: 'host-key-substitution', machineId: advert.machineId }); throw new Error('ssh-host-key-substitution'); }
     if (prior && advert.hostKeyGeneration > prior.hostKeyGeneration) {
@@ -343,6 +379,7 @@ export class MutualSshRuntime {
     if (proof.sourceMachineId !== origin) throw new Error('ssh-proof-origin-mismatch');
     this.proofs.set(this.key(proof.sourceMachineId, proof.targetMachineId), proof);
     this.persistProofs();
+    this.reconcilePeerExecution(proof.sourceMachineId === this.d.selfMachineId ? proof.targetMachineId : proof.sourceMachineId);
   }
 
   private promoteProvenHostKey(machineId: string, generation: number): void {
@@ -358,6 +395,9 @@ export class MutualSshRuntime {
   }
 
   private clearPeerEvidence(machineId: string): void {
+    const revoked = this.peerAuthorizedKeys?.revoke(this.d.agentId, machineId);
+    this.standingEvidence.delete(machineId);
+    if (revoked?.changed) this.audit({ type: 'peer-authorized-key-revoked', machineId, dryRun: revoked.dryRun });
     this.admissionStore.revoke(machineId);
     this.endpoint?.revoke(machineId);
     this.adverts.delete(machineId);
@@ -365,6 +405,69 @@ export class MutualSshRuntime {
     this.hostKeys.delete(machineId);
     for (const key of [...this.proofs.keys()]) if (key.startsWith(`${machineId}->`) || key.endsWith(`->${machineId}`)) this.proofs.delete(key);
     this.persistProofs();
+  }
+
+  private reconcilePeerExecution(machineId: string): void {
+    if (!this.peerAuthorizedKeys) return;
+    const peer = this.d.listPeers().find(row => row.machineId === machineId);
+    const advert = this.adverts.get(machineId);
+    if (!peer || !advert || peer.pairingEpoch !== advert.pairingEpoch) return;
+    const local = this.proofs.get(this.key(this.d.selfMachineId, machineId));
+    const remote = this.proofs.get(this.key(machineId, this.d.selfMachineId));
+    if (!MutualSshVerifier.mutual(local, remote, Date.now(), {
+      monotonicNow: performance.now(),
+      liveBootIds: new Set([this.d.observerBootId, advert.observerBootId]),
+      sourceClientGenerations: new Map([[this.d.selfMachineId, this.identity.clientGeneration], [machineId, advert.clientKeyGeneration]]),
+      targetHostGenerations: new Map([[this.d.selfMachineId, this.identity.hostGeneration], [machineId, advert.hostKeyGeneration]]),
+    })) return;
+    try {
+      const result = this.peerAuthorizedKeys.reconcile(this.authorizedKey(advert));
+      if (result.changed) this.audit({ type: 'peer-authorized-key-reconciled', machineId, pairingEpoch: advert.pairingEpoch, clientKeyGeneration: advert.clientKeyGeneration, dryRun: result.dryRun });
+      this.bootstrapFailures.delete(machineId);
+    } catch (error) {
+      this.bootstrapFailures.set(machineId, `standing-key-store:${classifyMutualSshFailure(error)}`);
+    }
+  }
+
+  private async probeStandingAccess(machineId: string): Promise<void> {
+    if (!this.peerAuthorizedKeys || this.d.peerExecution?.dryRun) return;
+    const advert = this.adverts.get(machineId);
+    if (!advert?.standingSsh) {
+      this.standingEvidence.delete(machineId);
+      this.bootstrapFailures.set(machineId, 'standing-ssh-endpoint-missing');
+      return;
+    }
+    try {
+      await this.standingVerifier.probe({ ...advert.standingSsh, clientPrivateKeyPath: this.identity.clientPrivateKeyPath });
+      this.standingEvidence.set(machineId, {
+        deadline: performance.now() + (this.d.freshnessMs ?? 300_000),
+        targetDigest: this.standingTargetDigest(advert),
+      });
+      this.bootstrapFailures.delete(machineId);
+    } catch (error) {
+      this.standingEvidence.delete(machineId);
+      this.bootstrapFailures.set(machineId, `standing-ssh:${classifyMutualSshFailure(error)}`);
+    }
+  }
+
+  private authorizedKey(advert: SshBootstrapAdvert): PeerAuthorizedKey {
+    return {
+      agentId: advert.agentId,
+      machineId: advert.machineId,
+      pairingEpoch: advert.pairingEpoch,
+      clientKeyGeneration: advert.clientKeyGeneration,
+      publicKey: advert.clientPublicKey,
+    };
+  }
+
+  private standingTargetDigest(advert: SshBootstrapAdvert): string {
+    return createHash('sha256').update(JSON.stringify({
+      machineId: advert.machineId,
+      pairingEpoch: advert.pairingEpoch,
+      observerBootId: advert.observerBootId,
+      clientKeyGeneration: advert.clientKeyGeneration,
+      standingSsh: advert.standingSsh ?? null,
+    })).digest('hex');
   }
 
   private maybeRetirePreviousHost(): void {

--- a/src/core/PeerAuthorizedKeys.ts
+++ b/src/core/PeerAuthorizedKeys.ts
@@ -1,0 +1,195 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { utils } from 'ssh2';
+import { SafeFsExecutor } from './SafeFsExecutor.js';
+
+const MARKER = 'instar-peer-access';
+
+export interface PeerAuthorizedKey {
+  agentId: string;
+  machineId: string;
+  pairingEpoch: number;
+  clientKeyGeneration: number;
+  publicKey: string;
+}
+
+/**
+ * Owns only the supplied agent account home's .ssh/authorized_keys and refuses
+ * symlinked write targets.
+ */
+export class PeerAuthorizedKeys {
+  readonly file: string;
+  private activeLockToken: string | null = null;
+
+  constructor(agentHome: string, private readonly dryRun: boolean) {
+    const root = path.resolve(agentHome);
+    this.file = path.join(root, '.ssh', 'authorized_keys');
+    if (path.dirname(path.dirname(this.file)) !== root) throw new Error('peer-authorized-keys-scope-invalid');
+  }
+
+  reconcile(key: PeerAuthorizedKey): { changed: boolean; dryRun: boolean } {
+    return this.withLock(() => {
+      const parsed = parsePublicKey(key.publicKey);
+      const comment = `${MARKER}:${encodeURIComponent(key.agentId)}:${encodeURIComponent(key.machineId)}:${key.pairingEpoch}:${key.clientKeyGeneration}`;
+      const line = `${parsed.type} ${parsed.body} ${comment}`;
+      const current = this.read();
+      const retained = current
+        .split(/\r?\n/)
+        .filter(row => row.length > 0 && !isManagedForMachine(row, key.agentId, key.machineId));
+      retained.push(line);
+      const next = `${retained.join('\n')}\n`;
+      if (next === current) return { changed: false, dryRun: this.dryRun };
+      if (!this.dryRun) this.write(next);
+      return { changed: true, dryRun: this.dryRun };
+    });
+  }
+
+  revoke(agentId: string, machineId: string): { changed: boolean; dryRun: boolean } {
+    return this.withLock(() => {
+      const current = this.read();
+      const retained = current.split(/\r?\n/).filter(row => row.length > 0 && !isManagedForMachine(row, agentId, machineId));
+      const next = retained.length > 0 ? `${retained.join('\n')}\n` : '';
+      if (next === current) return { changed: false, dryRun: this.dryRun };
+      if (!this.dryRun) this.write(next);
+      return { changed: true, dryRun: this.dryRun };
+    });
+  }
+
+  revokeUnknown(agentId: string, activeMachineIds: ReadonlySet<string>): { changed: boolean; dryRun: boolean } {
+    return this.withLock(() => {
+      const current = this.read();
+      const retained = current.split(/\r?\n/).filter(row => {
+        if (row.length === 0) return false;
+        const identity = managedIdentity(row);
+        return !identity || identity.agentId !== agentId || activeMachineIds.has(identity.machineId);
+      });
+      const next = retained.length > 0 ? `${retained.join('\n')}\n` : '';
+      if (next === current) return { changed: false, dryRun: this.dryRun };
+      if (!this.dryRun) this.write(next);
+      return { changed: true, dryRun: this.dryRun };
+    });
+  }
+
+  has(key: PeerAuthorizedKey): boolean {
+    const parsed = parsePublicKey(key.publicKey);
+    return this.read().split(/\r?\n/).some(row =>
+      row === `${parsed.type} ${parsed.body} ${MARKER}:${encodeURIComponent(key.agentId)}:${encodeURIComponent(key.machineId)}:${key.pairingEpoch}:${key.clientKeyGeneration}`,
+    );
+  }
+
+  private read(): string {
+    this.refuseSymlinks();
+    try { return fs.readFileSync(this.file, 'utf8'); }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return '';
+      throw error;
+    }
+  }
+
+  private write(content: string): void {
+    this.assertLockOwner();
+    const dir = path.dirname(this.file);
+    this.refuseSymlinks();
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.chmodSync(dir, 0o700);
+    this.refuseSymlinks();
+    const tmp = path.join(dir, `.authorized_keys.${process.pid}.${randomUUID()}.tmp`);
+    fs.writeFileSync(tmp, content, { mode: 0o600 });
+    this.assertLockOwner();
+    fs.renameSync(tmp, this.file);
+    fs.chmodSync(this.file, 0o600);
+  }
+
+  private refuseSymlinks(): void {
+    for (const target of [path.dirname(this.file), this.file]) {
+      try {
+        if (fs.lstatSync(target).isSymbolicLink()) throw new Error('peer-authorized-keys-symlink-refused');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+    }
+  }
+
+  private withLock<T>(run: () => T): T {
+    if (this.dryRun) return run();
+    const lock = path.join(path.dirname(this.file), '.instar-authorized-keys.lock');
+    const ownerFile = path.join(lock, 'owner.json');
+    fs.mkdirSync(path.dirname(this.file), { recursive: true, mode: 0o700 });
+    let acquired = false;
+    const token = randomUUID();
+    try {
+      try {
+        fs.mkdirSync(lock, { mode: 0o700 });
+        fs.writeFileSync(ownerFile, JSON.stringify({ pid: process.pid, token }), { mode: 0o600 });
+        acquired = true;
+        this.activeLockToken = token;
+      }
+      catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+        let owner: { pid?: unknown; token?: unknown };
+        try { owner = JSON.parse(fs.readFileSync(ownerFile, 'utf8')) as { pid?: unknown; token?: unknown }; }
+        catch { throw new Error('peer-authorized-keys-lock-busy'); }
+        if (typeof owner.pid !== 'number' || !Number.isSafeInteger(owner.pid) || owner.pid < 1 || typeof owner.token !== 'string') throw new Error('peer-authorized-keys-lock-busy');
+        try {
+          process.kill(owner.pid, 0);
+          throw new Error('peer-authorized-keys-lock-busy');
+        } catch (probeError) {
+          if ((probeError as NodeJS.ErrnoException).code !== 'ESRCH') throw probeError;
+        }
+        SafeFsExecutor.safeRmSync(lock, { recursive: true, force: true, operation: 'PeerAuthorizedKeys:remove-stale-lock' });
+        fs.mkdirSync(lock, { mode: 0o700 });
+        fs.writeFileSync(ownerFile, JSON.stringify({ pid: process.pid, token }), { mode: 0o600 });
+        acquired = true;
+        this.activeLockToken = token;
+      }
+      return run();
+    } finally {
+      if (acquired) {
+        try {
+          const owner = JSON.parse(fs.readFileSync(ownerFile, 'utf8')) as { token?: unknown };
+          if (owner.token === token) SafeFsExecutor.safeRmSync(lock, { recursive: true, force: true, operation: 'PeerAuthorizedKeys:release-lock' });
+        } catch {
+          // @silent-fallback-ok — ownership ambiguity fails closed: leave the
+          // lock for liveness-checked recovery rather than delete another owner.
+        }
+      }
+      if (this.activeLockToken === token) this.activeLockToken = null;
+    }
+  }
+
+  private assertLockOwner(): void {
+    if (!this.activeLockToken) throw new Error('peer-authorized-keys-lock-ownership-lost');
+    const ownerFile = path.join(path.dirname(this.file), '.instar-authorized-keys.lock', 'owner.json');
+    try {
+      const owner = JSON.parse(fs.readFileSync(ownerFile, 'utf8')) as { pid?: unknown; token?: unknown };
+      if (owner.pid !== process.pid || owner.token !== this.activeLockToken) throw new Error('peer-authorized-keys-lock-ownership-lost');
+    } catch (error) {
+      if (error instanceof Error && error.message === 'peer-authorized-keys-lock-ownership-lost') throw error;
+      throw new Error('peer-authorized-keys-lock-ownership-lost');
+    }
+  }
+}
+
+function parsePublicKey(value: string): { type: string; body: string } {
+  const [type, body] = value.trim().split(/\s+/, 3);
+  const parsed = utils.parseKey(value);
+  if (type !== 'ssh-ed25519' || !body || parsed instanceof Error || parsed.type !== 'ssh-ed25519') throw new Error('peer-authorized-key-invalid');
+  return { type, body };
+}
+
+function isManagedForMachine(line: string, agentId: string, machineId: string): boolean {
+  const identity = managedIdentity(line);
+  return identity?.agentId === agentId && identity.machineId === machineId;
+}
+
+function managedIdentity(line: string): { agentId: string; machineId: string } | null {
+  const comment = line.trim().split(/\s+/, 3)[2] ?? '';
+  const fields = comment.split(':');
+  if (fields[0] !== MARKER || !fields[1] || !fields[2]) return null;
+  try { return { agentId: decodeURIComponent(fields[1]), machineId: decodeURIComponent(fields[2]) }; }
+  catch {
+    // @silent-fallback-ok — malformed managed comments are untrusted, unmanaged lines
+    return null;
+  }
+}

--- a/src/core/SshBootstrapAdvert.ts
+++ b/src/core/SshBootstrapAdvert.ts
@@ -1,4 +1,5 @@
 import net from 'node:net';
+import { utils } from 'ssh2';
 
 export interface SshBootstrapAdvert {
   machineId: string;
@@ -10,6 +11,7 @@ export interface SshBootstrapAdvert {
   clientPublicKey: string;
   sshHostPublicKeys: string[];
   endpoints: Array<{ host: string; port: number; source: 'tailscale' | 'lan' | 'configured' }>;
+  standingSsh?: { host: string; port: number; username: string; hostPublicKey: string };
   issuedAt: string;
   expiresAt: string;
   hostKeyTransitionSignature?: string;
@@ -22,6 +24,7 @@ export function canonicalSshBootstrapAdvert(advert: Omit<SshBootstrapAdvert, 'ma
     observerBootId: advert.observerBootId, clientKeyGeneration: advert.clientKeyGeneration,
     hostKeyGeneration: advert.hostKeyGeneration, clientPublicKey: advert.clientPublicKey,
     sshHostPublicKeys: advert.sshHostPublicKeys, endpoints: advert.endpoints,
+    ...(advert.standingSsh ? { standingSsh: advert.standingSsh } : {}),
     issuedAt: advert.issuedAt, expiresAt: advert.expiresAt,
     ...(advert.hostKeyTransitionSignature ? { hostKeyTransitionSignature: advert.hostKeyTransitionSignature } : {}),
   });
@@ -36,11 +39,26 @@ export function validateSshBootstrapAdvert(input: unknown, principalMachineId: s
   const issuedAt = Date.parse(row.issuedAt);
   const expiresAt = Date.parse(row.expiresAt);
   if (!Number.isFinite(issuedAt) || !Number.isFinite(expiresAt) || issuedAt > now + 30_000 || expiresAt <= now || expiresAt - now > 300_000) throw new Error('ssh-advert-expired');
-  if (!Array.isArray(row.sshHostPublicKeys) || !/^ssh-ed25519 [A-Za-z0-9+/=]+(?:\s|$)/.test(row.clientPublicKey) || row.sshHostPublicKeys.length < 1 || row.sshHostPublicKeys.length > 2 || row.sshHostPublicKeys.some(key => !/^ssh-ed25519 [A-Za-z0-9+/=]+(?:\s|$)/.test(key))) throw new Error('ssh-advert-key-invalid');
+  if (!Array.isArray(row.sshHostPublicKeys) || !validEd25519Key(row.clientPublicKey) || row.sshHostPublicKeys.length < 1 || row.sshHostPublicKeys.length > 2 || row.sshHostPublicKeys.some(key => !validEd25519Key(key))) throw new Error('ssh-advert-key-invalid');
   if (!Array.isArray(row.endpoints) || row.endpoints.length > 8 || row.endpoints.some(endpoint => !validEndpoint(endpoint))) throw new Error('ssh-advert-endpoint-invalid');
+  if (row.standingSsh !== undefined && (!validStandingEndpoint(row.standingSsh) || !validEd25519Key(row.standingSsh.hostPublicKey))) throw new Error('ssh-advert-standing-endpoint-invalid');
   if (typeof row.observerBootId !== 'string' || row.observerBootId.length < 8 || row.observerBootId.length > 128 || typeof row.machineSignature !== 'string' || row.machineSignature.length < 32 || row.machineSignature.length > 512) throw new Error('ssh-advert-signature-invalid');
   if (row.hostKeyTransitionSignature !== undefined && (typeof row.hostKeyTransitionSignature !== 'string' || row.hostKeyTransitionSignature.length < 32 || row.hostKeyTransitionSignature.length > 512)) throw new Error('ssh-advert-transition-signature-invalid');
   return row;
+}
+
+function validEd25519Key(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const parsed = utils.parseKey(value);
+  return !(parsed instanceof Error) && parsed.type === 'ssh-ed25519';
+}
+
+function validStandingEndpoint(endpoint: SshBootstrapAdvert['standingSsh']): boolean {
+  if (!endpoint || !Number.isInteger(endpoint.port) || endpoint.port < 1 || endpoint.port > 65535) return false;
+  if (!/^[a-z_][a-z0-9_-]{0,31}$/i.test(endpoint.username)) return false;
+  if (net.isIP(endpoint.host) !== 4) return false;
+  const [a, b] = endpoint.host.split('.').map(Number);
+  return a === 10 || (a === 100 && b >= 64 && b <= 127) || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
 }
 
 function validEndpoint(endpoint: SshBootstrapAdvert['endpoints'][number]): boolean {

--- a/src/core/StandingSshVerifier.ts
+++ b/src/core/StandingSshVerifier.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import { Client, utils } from 'ssh2';
+
+export interface StandingSshTarget {
+  host: string;
+  port: number;
+  username: string;
+  hostPublicKey: string;
+  clientPrivateKeyPath: string;
+}
+
+/** Proves that the dedicated key can execute through the host's real sshd. */
+export class StandingSshVerifier {
+  probe(target: StandingSshTarget): Promise<void> {
+    const expected = utils.parseKey(target.hostPublicKey);
+    if (expected instanceof Error || expected.type !== 'ssh-ed25519') throw new Error('standing-ssh-host-key-invalid');
+    return new Promise<void>((resolve, reject) => {
+      const client = new Client();
+      let settled = false;
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        client.end();
+        error ? reject(error) : resolve();
+      };
+      const timer = setTimeout(() => finish(new Error('standing-ssh-timeout')), 8_000);
+      client.once('error', error => { clearTimeout(timer); finish(error); });
+      client.once('ready', () => client.exec('printf instar-standing-key-ok', (error, stream) => {
+        if (error) { clearTimeout(timer); finish(error); return; }
+        let stdout = '';
+        let stderr = '';
+        stream.setEncoding('utf8');
+        stream.on('data', (chunk: Buffer | string) => { stdout += chunk.toString(); });
+        stream.stderr.setEncoding('utf8');
+        stream.stderr.on('data', (chunk: Buffer | string) => { stderr += chunk.toString(); });
+        stream.once('close', (code: number | null) => {
+          clearTimeout(timer);
+          if (code === 0 && stdout === 'instar-standing-key-ok' && stderr === '') finish();
+          else finish(new Error('standing-ssh-exec-failed'));
+        });
+      }));
+      client.connect({
+        host: target.host,
+        port: target.port,
+        username: target.username,
+        privateKey: fs.readFileSync(target.clientPrivateKeyPath),
+        readyTimeout: 7_500,
+        hostVerifier: (key: Buffer) => key.equals(expected.getPublicSSH()),
+        algorithms: { serverHostKey: ['ssh-ed25519'], kex: ['curve25519-sha256', 'curve25519-sha256@libssh.org'] },
+      });
+    });
+  }
+}

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -68,6 +68,12 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
     justification: 'Ships dryRun:true and fleet-dark. The dev canary generates only dedicated keys beneath Instar state and computes would-admit/would-probe evidence; it never touches personal SSH state or accepts a peer session until an explicit dryRun:false flip. No shell, exec, forwarding, SFTP, passwords, or public wildcard bind exists.',
   },
   {
+    name: 'peerExecution',
+    configPath: 'multiMachine.peerExecution.enabled',
+    description: 'Install mutually verified peer client keys into this agent home for standing peer-machine execution.',
+    justification: 'Ships dryRun:true and fleet-dark. Authority requires fresh bidirectional MachineAuth proof at the current pairing epoch; writes are restricted to the agent-home authorized_keys.',
+  },
+  {
     name: 'ownershipGatedSpawn',
     configPath: 'multiMachine.sessionPool.ownershipGatedSpawn.enabled',
     description: 'SpawnAdmission — the binding-verdict seam at every conversation-bound session-creating callsite (ownership-gated-spawn-and-judgment-within-floors §3.1, Layer A; the Ownership-Gated Side Effects standard). Consults resolveOwnershipSafe (tri-state, non-throwing) and the router verdict (TOCTOU consumption) before Telegram cold-spawn/respawn + Slack inbound/recovery spawns; never a bootleg local copy of an owned-elsewhere conversation.',

--- a/src/core/machineCoherenceManifest.ts
+++ b/src/core/machineCoherenceManifest.ts
@@ -101,6 +101,14 @@ export const COHERENCE_CRITICAL_FLAGS: CoherenceCriticalFlag[] = [
     guarantee: 'mutual directional SSH proof readiness — a half-enabled pool cannot establish both directions',
   },
   {
+    key: 'peerExecution.enabled',
+    configPath: 'multiMachine.peerExecution.enabled',
+    resolution: 'dev-gate+dryRun',
+    dryRunConfigPath: 'multiMachine.peerExecution.dryRun',
+    readSource: 'boot',
+    guarantee: 'standing peer key admission — every machine must agree whether mutually verified peers receive agent-home SSH access',
+  },
+  {
     key: 'seamlessness.ws13PinReplicate',
     configPath: 'multiMachine.seamlessness.ws13PinReplicate',
     resolution: 'dev-gate+dryRun',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2487,6 +2487,13 @@ export interface MultiMachineConfig {
     probeDeadlineMs?: number;
     concurrency?: number;
   };
+  /** Standing peer execution via this agent account's authorized_keys. Dev-gated and dry-run-first. */
+  peerExecution?: {
+    enabled?: boolean;
+    dryRun?: boolean;
+    requiredForReadiness?: boolean;
+    port?: number;
+  };
   /**
    * Coordination mode (Gap 1 — Active/Active support).
    * - 'primary-standby': One awake, others standby with failover (default)

--- a/src/monitoring/guardManifest.ts
+++ b/src/monitoring/guardManifest.ts
@@ -65,6 +65,22 @@ export interface GuardManifestEntry {
 }
 
 export const GUARD_MANIFEST: readonly GuardManifestEntry[] = [
+  {
+    key: 'multiMachine.peerExecution.enabled',
+    kind: 'config',
+    configPath: 'multiMachine.peerExecution.enabled',
+    defaultEnabled: false,
+    dryRunConfigPath: 'multiMachine.peerExecution.dryRun',
+    expectedTickMs: 60_000,
+    process: 'server',
+    expectRuntime: true,
+    component: 'MutualSshRuntime',
+    description: 'Standing peer-machine execution: installs only mutually verified, current-epoch peer keys into this agent home and reports unreachable peers as named readiness blockers.',
+    loadBearing: true,
+    criticalPath: 'autonomous execution on a paired peer machine',
+    soakWindowDays: 30,
+    declaredLoadBearingAt: '2026-07-22',
+  },
   // ── Durable Inbound Message Queue (spec §Observability; keys === configPath) ──
   {
     key: 'multiMachine.sessionPool.inboundQueue.enabled',

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -440,17 +440,18 @@ describe('lint-dev-agent-dark-gate', () => {
       // Mutual SSH adds a 12-line dev-gated, dry-run-first block at the top of
       // multiMachine. It has no `enabled: false` literal and therefore shifts
       // every subsequent attribution without changing the audited path set.
-      '1120': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
-      '1124': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
-      '1131': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
-      '1141': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
-      '1378': 'multiMachine.sessionPool.enabled',
+      // ACT-897 peerExecution adds an 8-line dev-gated dry-run block.
+      '1128': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
+      '1132': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
+      '1139': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
+      '1149': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
+      '1386': 'multiMachine.sessionPool.enabled',
       // #1367's moveIntent dev-gated sub-block was inserted under sessionPool
       // (docs/specs/nickname-move-intent-llm-rebuild.md); it OMITS `enabled` (rides
       // resolveDevAgentGate), adds no map row, and shifts the subsequent lines.
-      '1422': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
-      '1432': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '1461': 'multiMachine.sessionPool.holdForStability.enabled',
+      '1430': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
+      '1440': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '1469': 'multiMachine.sessionPool.holdForStability.enabled',
       // replicated-journal-compaction adds a 5-line compaction default block
       // above stateSync. It uses `run:false` (not an `enabled` gate), so the
       // attributed path set is unchanged and the four rows below shift by +5.
@@ -464,16 +465,16 @@ describe('lint-dev-agent-dark-gate', () => {
       // +32 lines, no `enabled:` literals) shift the cartographer rows below.
       // +15 below the #1561 baseline: this row is BELOW the failoverRunner insert,
       // so it carries both the +10 (missingLogin) and +15 (failoverRunner) shifts.
-      '1722': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1730': 'multiMachine.stateSync.threadlinePairing.enabled',
       // commitment-auto-expiry (2026-07-10): a 6-line `commitments.autoExpiry`
       // default sub-block was inserted above `promiseBeacon`/`cartographer`.
       // Its `enabled: true` literal is an explicit fleet-on default, not a dark
       // default, so it adds NO attributed dark-gate row; it shifts the cartographer
       // `enabled: false` rows below it DOWN by +6.
       // Below the failoverRunner insert → both +10 (missingLogin) and +15 shifts.
-      '1901': 'cartographer.freshnessSweep.enabled',
-      '1946': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '1971': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1909': 'cartographer.freshnessSweep.enabled',
+      '1954': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '1979': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/tests/unit/mutual-ssh-autobootstrap.test.ts
+++ b/tests/unit/mutual-ssh-autobootstrap.test.ts
@@ -53,7 +53,8 @@ describe('mutual SSH bootstrap security invariants', () => {
   });
 
   it('rejects public and stale adverts', () => {
-    const base = { machineId: 'a', agentId: 'agent', pairingEpoch: 1, observerBootId: 'boot', clientKeyGeneration: 1, hostKeyGeneration: 1, clientPublicKey: 'ssh-ed25519 AAAA', sshHostPublicKeys: ['ssh-ed25519 AAAA'], issuedAt: new Date().toISOString(), expiresAt: new Date(Date.now() + 60_000).toISOString(), endpoints: [{ host: '8.8.8.8', port: 4045, source: 'lan' }] };
+    const identity = new MachineSshIdentity(temp(), 'agent', 'key-source').ensure();
+    const base = { machineId: 'a', agentId: 'agent', pairingEpoch: 1, observerBootId: 'boot', clientKeyGeneration: 1, hostKeyGeneration: 1, clientPublicKey: identity.clientPublicKey, sshHostPublicKeys: [identity.hostPublicKey], issuedAt: new Date().toISOString(), expiresAt: new Date(Date.now() + 60_000).toISOString(), endpoints: [{ host: '8.8.8.8', port: 4045, source: 'lan' }] };
     expect(() => validateSshBootstrapAdvert(base, 'a', 'agent')).toThrow('endpoint-invalid');
     expect(() => validateSshBootstrapAdvert({ ...base, endpoints: [], expiresAt: new Date(0).toISOString() }, 'a', 'agent')).toThrow('expired');
   });

--- a/tests/unit/mutual-ssh-hardening.test.ts
+++ b/tests/unit/mutual-ssh-hardening.test.ts
@@ -19,7 +19,15 @@ import { MachineSshEndpoint } from '../../src/core/MachineSshEndpoint.js';
 const roots: string[] = [];
 afterEach(() => { for (const root of roots.splice(0)) SafeFsExecutor.safeRmSync(root, { recursive: true, force: true, operation: 'mutual-ssh-hardening.test.ts:cleanup' }); });
 
-const publicKey = (seed: string) => `ssh-ed25519 ${Buffer.from(seed.padEnd(32, seed)).toString('base64')} instar:test`;
+const publicKey = (seed: string) => {
+  const type = Buffer.from('ssh-ed25519');
+  const wire = Buffer.alloc(4 + type.length + 4 + 32);
+  wire.writeUInt32BE(type.length);
+  type.copy(wire, 4);
+  wire.writeUInt32BE(32, 4 + type.length);
+  wire.fill(seed.charCodeAt(0), 4 + type.length + 4);
+  return `ssh-ed25519 ${wire.toString('base64')} instar:test`;
+};
 
 describe('mutual SSH hardened lifecycle', () => {
   it('fences host generations and promotes only a proven quarantined successor', () => {

--- a/tests/unit/peer-authorized-keys.test.ts
+++ b/tests/unit/peer-authorized-keys.test.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { PeerAuthorizedKeys } from '../../src/core/PeerAuthorizedKeys.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const roots: string[] = [];
+function publicKey(seed: number): string {
+  const type = Buffer.from('ssh-ed25519');
+  const wire = Buffer.alloc(4 + type.length + 4 + 32);
+  wire.writeUInt32BE(type.length, 0);
+  type.copy(wire, 4);
+  wire.writeUInt32BE(32, 4 + type.length);
+  wire.fill(seed & 0xff, 4 + type.length + 4);
+  return `ssh-ed25519 ${wire.toString('base64')}`;
+}
+const key = (machineId = 'peer-a', generation = 1) => ({
+  agentId: 'agent', machineId, pairingEpoch: 42, clientKeyGeneration: generation,
+  publicKey: publicKey(generation + machineId.length),
+});
+
+afterEach(() => {
+  for (const root of roots.splice(0)) SafeFsExecutor.safeRmSync(root, { recursive: true, force: true, operation: 'peer-authorized-keys.test.ts:cleanup' });
+});
+
+function home(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-peer-keys-'));
+  roots.push(root);
+  return root;
+}
+
+describe('PeerAuthorizedKeys', () => {
+  it('writes only the agent-home file with restrictive modes and is idempotent', () => {
+    const root = home();
+    const store = new PeerAuthorizedKeys(root, false);
+    expect(store.reconcile(key())).toEqual({ changed: true, dryRun: false });
+    expect(store.reconcile(key())).toEqual({ changed: false, dryRun: false });
+    expect(store.file).toBe(path.join(root, '.ssh', 'authorized_keys'));
+    expect(fs.statSync(path.dirname(store.file)).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(store.file).mode & 0o777).toBe(0o600);
+    expect(store.has(key())).toBe(true);
+  });
+
+  it('replaces rotation, preserves operator lines, and revokes one peer', () => {
+    const root = home();
+    const store = new PeerAuthorizedKeys(root, false);
+    fs.mkdirSync(path.dirname(store.file), { recursive: true });
+    fs.writeFileSync(store.file, 'ssh-ed25519 b3BlcmF0b3I= operator\n');
+    store.reconcile(key('peer-a', 1));
+    store.reconcile(key('peer-a', 2));
+    store.reconcile(key('peer-b'));
+    store.revoke('agent', 'peer-a');
+    const content = fs.readFileSync(store.file, 'utf8');
+    expect(content).toContain('operator');
+    expect(content).not.toContain(':peer-a:');
+    expect(content).toContain(':peer-b:');
+  });
+
+  it('dry-run reports the intended change without touching disk', () => {
+    const store = new PeerAuthorizedKeys(home(), true);
+    expect(store.reconcile(key())).toEqual({ changed: true, dryRun: true });
+    expect(fs.existsSync(store.file)).toBe(false);
+  });
+
+  it('refuses symlinked targets', () => {
+    const other = home();
+    const linkedHome = home();
+    fs.symlinkSync(other, path.join(linkedHome, '.ssh'));
+    expect(() => new PeerAuthorizedKeys(linkedHome, false).reconcile(key())).toThrow('peer-authorized-keys-symlink-refused');
+  });
+
+  it('refuses an active account-wide writer lock without deleting it', () => {
+    const root = home();
+    const store = new PeerAuthorizedKeys(root, false);
+    const lock = path.join(root, '.ssh', '.instar-authorized-keys.lock');
+    fs.mkdirSync(lock, { recursive: true });
+    expect(() => store.reconcile(key())).toThrow('peer-authorized-keys-lock-busy');
+    expect(fs.existsSync(lock)).toBe(true);
+  });
+
+  it('recovers only a lock whose recorded owner process is gone', () => {
+    const root = home();
+    const store = new PeerAuthorizedKeys(root, false);
+    const lock = path.join(root, '.ssh', '.instar-authorized-keys.lock');
+    fs.mkdirSync(lock, { recursive: true });
+    fs.writeFileSync(path.join(lock, 'owner.json'), JSON.stringify({ pid: 2_147_483_647, token: 'dead-owner' }));
+    expect(store.reconcile(key()).changed).toBe(true);
+    expect(fs.existsSync(lock)).toBe(false);
+  });
+});

--- a/tests/unit/standing-ssh-verifier.test.ts
+++ b/tests/unit/standing-ssh-verifier.test.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { Server, utils } from 'ssh2';
+import { afterEach, describe, expect, it } from 'vitest';
+import { MachineSshIdentity } from '../../src/core/MachineSshIdentity.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { StandingSshVerifier } from '../../src/core/StandingSshVerifier.js';
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) SafeFsExecutor.safeRmSync(root, { recursive: true, force: true, operation: 'standing-ssh-verifier.test.ts:cleanup' });
+});
+
+describe('StandingSshVerifier', () => {
+  it('requires the dedicated client key, pins the host key, and proves exec', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-standing-ssh-'));
+    roots.push(root);
+    const clientIdentity = new MachineSshIdentity(root, 'agent', 'client').ensure();
+    const hostIdentity = new MachineSshIdentity(root, 'agent', 'host').ensure();
+    const admitted = utils.parseKey(clientIdentity.clientPublicKey);
+    if (admitted instanceof Error) throw admitted;
+    const server = new Server({ hostKeys: [fs.readFileSync(hostIdentity.hostPrivateKeyPath)] }, connection => {
+      connection.on('authentication', ctx => {
+        if (ctx.method === 'publickey' && ctx.key.algo === admitted.type && ctx.key.data.equals(admitted.getPublicSSH())) ctx.accept();
+        else ctx.reject();
+      });
+      connection.on('ready', () => connection.on('session', accept => {
+        const session = accept();
+        session.on('exec', (acceptExec, _reject, info) => {
+          const stream = acceptExec();
+          if (info.command === 'printf instar-standing-key-ok') {
+            stream.write('instar-standing-key-ok');
+            stream.exit(0);
+          } else stream.exit(1);
+          stream.end();
+        });
+      }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('test-listener-missing');
+      await expect(new StandingSshVerifier().probe({
+        host: '127.0.0.1',
+        port: address.port,
+        username: os.userInfo().username,
+        hostPublicKey: hostIdentity.hostPublicKey,
+        clientPrivateKeyPath: clientIdentity.clientPrivateKeyPath,
+      })).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+});

--- a/upgrades/side-effects/reliable-peer-machine-execution.md
+++ b/upgrades/side-effects/reliable-peer-machine-execution.md
@@ -1,0 +1,115 @@
+# Side-Effects Review — Reliable Peer-Machine Execution
+
+**Version / slug:** `reliable-peer-machine-execution`
+**Date:** 2026-07-22
+**Author:** Instar-codey
+**Second-pass reviewer:** independent Codex security review
+
+## Summary of the change
+
+ACT-897 extends `MutualSshRuntime` so a peer advert that has fresh, current-epoch
+proof in both directions can reconcile its dedicated key into the current agent
+account's `authorized_keys`. It adds `PeerAuthorizedKeys`, a separate dev-gated
+`multiMachine.peerExecution` dry-run-first posture, a signed real-sshd endpoint,
+pinned-host-key execution probe, named readiness failure, N5
+coherence and guard-manifest coverage, and lifecycle tests.
+
+## Decision-point inventory
+
+- Mutual proof authority — modified — fresh bidirectional proof now gates a standing grant.
+- Managed key reconciliation — added — exact peer identity/epoch/generation selects one labeled line.
+- Readiness — modified — required standing access fails loudly when proof or installed key is absent.
+
+## 1. Over-block
+
+Non-Ed25519 keys, symlinked SSH paths, and peers without two fresh current-boot
+directions are refused. Those are intentional security invariants. A host whose OS
+SSH daemon is disabled remains honestly unreachable.
+
+## 2. Under-block
+
+The installed line grants the same account access the host's sshd configuration
+allows; this code does not narrow sshd commands. The feature therefore stays
+fleet-dark and dry-run-first pending explicit rollout. Host-level SSH configuration
+outside the account key file remains operator policy.
+
+## 3. Level-of-abstraction fit
+
+`MutualSshRuntime` remains the authority because it owns signed adverts, pairing
+epochs, generations, and both proofs. `PeerAuthorizedKeys` is a narrow effect
+primitive and cannot decide trust. No parallel pairing or key store is introduced.
+
+## 4. Signal vs authority compliance
+
+Probe and advert data are signals. The blocking authority is the existing enumerable
+cryptographic invariant: exact paired principal, current epoch/generations, live boot
+ids, monotonic freshness, and both directions. No brittle semantic heuristic decides.
+
+## 4b. Judgment-point check
+
+No competing-signals judgment point is added. Authorization is a finite security
+predicate; uncertainty must refuse the grant.
+
+## 5. Interactions
+
+- Rotation replaces the prior managed machine line instead of accumulating access.
+- Peer removal and epoch advancement revoke managed access with proof/admission cleanup.
+- Atomic rename prevents partial canonical files; repeated reconciliation is idempotent.
+- Dry-run audits the intended effect without creating `.ssh` or the file.
+
+## 6. External surfaces
+
+Persistent account SSH authorization changes only when both the feature and
+`dryRun:false` are explicit. Health exposes a scrubbed machine id reason, never key
+bodies or home paths. No new external API or operator action is added.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**machine-local BY DESIGN:** each machine owns its own account key file and physical
+reachability truth. Signed adverts/proofs cross the existing mesh; effective posture
+is fleet-uniform via the machine-coherence manifest. It emits no direct user notice,
+holds no transferable topic state, and generates no URL.
+
+## 8. Rollback cost
+
+Force-dark `multiMachine.peerExecution`, then revert. Managed labeled lines are
+removed through normal peer revocation; an emergency rollback can remove only those
+labeled lines. Operator-managed lines are never selected. No database migration.
+
+## Conclusion
+
+The effect is attached to the existing mutual verifier, scoped to a single account
+file, replay/rotation/revocation fenced, visible in readiness, and contained by
+fleet-dark plus dry-run-first rollout.
+
+## Second-pass review
+
+**Reviewer:** independent Codex security review
+**Independent read:** concur after three disposition rounds. The review first
+rejected restricted-subsystem-only health, cross-agent line collisions, incomplete
+revocation, weak key parsing, and filesystem-error handling; then required
+target-digest-bound evidence and serialized writes; finally required ownership-safe
+dead-lock recovery. The final diff uses a real pinned sshd exec proof, agent+machine
+line ownership, current-boot/off-gate revocation, parsed keys, named failures,
+PID+nonce locking with liveness-checked recovery, and token checks before rename and
+release. Final verdict: APPROVE, no release blockers.
+
+## Evidence pointers
+
+- `tests/unit/peer-authorized-keys.test.ts`
+- `tests/unit/mutual-ssh-autobootstrap.test.ts`
+- `tests/unit/machine-coherence-manifest.test.ts`
+- `tests/unit/lint-dev-agent-dark-gate.test.ts`
+- `tests/unit/lint-guard-manifest.test.ts`
+
+## Class-Closure Declaration
+
+- `unbounded-self-action` — closed by guard. Per-machine authorization mutations
+  are event-driven and idempotent; repair attempts are capped by the existing
+  ten-machine sweep and bounded repair breaker, while startup, disable, rotation,
+  and revocation settle by removing managed entries. Enforcement:
+  `tests/unit/mutual-ssh-hardening.test.ts` (ratchet).


### PR DESCRIPTION
## Summary

- install one managed, machine-scoped Ed25519 key only after fresh bidirectional current-boot mutual proof
- advertise a signed dedicated SSH endpoint and verify it with pinned host-key login plus a harmless exact command
- revoke managed access on startup cleanup, disable, peer removal, epoch change, and key rotation
- keep rollout fleet-dark, development-gated, and dry-run-first

## Why

The earlier mutual-SSH phase proved restricted transport but intentionally stopped before a peer could use the host account's real SSH daemon. That left autonomous peer execution without a durable, independently verifiable login path.

## ELI16 — what this changes

Imagine two trusted machines have already checked each other’s identity in both directions, but they still cannot use the normal locked front door between them. This change lets each machine add one clearly labeled spare key for the other machine—but only after both identity checks are fresh for the machines’ current boots. The key is tied to the exact agent and machine, old keys are removed during rotation or revocation, and ordinary keys the operator added are never selected. Before declaring the door usable, Instar performs a real login against a separately advertised SSH endpoint, pins the host key it was told to expect, and runs only a harmless fixed print command. The feature remains off by default and dry-runs first, so shipping the code does not silently grant access.

## Security boundaries

- only parsed Ed25519 public keys are accepted
- symlinked SSH directories/files are refused
- writes are atomic, serialized, permission-pinned, and ownership-token checked
- standing evidence is bound to the exact machine, epoch, boot, generation, and endpoint digest
- SSH daemon policy remains operator-owned; this change does not claim command restriction

## Validation

- independent security review: APPROVE after four disposition rounds
- `npm run lint`
- `npm run build`
- targeted SSH authorization, verifier, mutual-proof, hardening, dark-gate, manifest, and guard ratchets
- local aggregate sampled 2,114 files and 38,190 passing assertions before environment-sensitive failures were isolated; CI owns the clean full aggregate

## Rollback

Force-dark `multiMachine.peerExecution` and revert. Managed labeled lines are removed by normal cleanup/revocation paths; operator-managed lines are untouched.
