### PR TITLE
Swap live sessions away from missing logins

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T05-13-49-812Z-login-loss-account-swap.json
+++ b/.instar/instar-dev-decisions/2026-07-23T05-13-49-812Z-login-loss-account-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-23T05:13:49.812Z",
+  "slug": "login-loss-account-swap",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/swap-continuity-wiring.test.ts",
+      "howCaught": "The login-loss level trigger settles through source repair or one bounded refresh and remains constrained by dwell, in-flight deferral, failure backoff, per-target and per-cycle caps, and the existing thrash breaker."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T05-15-01-418Z-login-loss-account-swap.json
+++ b/.instar/instar-dev-decisions/2026-07-23T05-15-01-418Z-login-loss-account-swap.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-23T05:15:01.418Z",
+  "slug": "login-loss-account-swap",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/swap-continuity-wiring.test.ts",
+      "howCaught": "The login-loss level trigger settles through source repair or one bounded refresh and remains constrained by dwell, in-flight deferral, failure backoff, per-target and per-cycle caps, and the existing thrash breaker."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T05-16-10-432Z-login-loss-account-swap.json
+++ b/.instar/instar-dev-decisions/2026-07-23T05-16-10-432Z-login-loss-account-swap.json
@@ -1,0 +1,28 @@
+{
+  "ts": "2026-07-23T05:16:10.432Z",
+  "slug": "login-loss-account-swap",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "relatedPrs": [
+      1558
+    ],
+    "notes": "PR #1558 established the safe default-session swap path; this extension closes the newly identified login-loss trigger gap."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/swap-continuity-wiring.test.ts",
+      "howCaught": "The login-loss level trigger settles through source repair or one bounded refresh and remains constrained by dwell, in-flight holds, failure backoff, per-target and per-cycle caps, and the existing thrash breaker."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T05-17-06-855Z-login-loss-account-swap.json
+++ b/.instar/instar-dev-decisions/2026-07-23T05-17-06-855Z-login-loss-account-swap.json
@@ -1,0 +1,28 @@
+{
+  "ts": "2026-07-23T05:17:06.855Z",
+  "slug": "login-loss-account-swap",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "relatedPrs": [
+      1558
+    ],
+    "notes": "PR #1558 established the safe default-session swap path; this extension closes the newly identified login-loss trigger gap."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/swap-continuity-wiring.test.ts",
+      "howCaught": "The login-loss level trigger settles through source repair or one bounded refresh and remains constrained by dwell, in-flight holds, failure backoff, per-target and per-cycle caps, and the existing thrash breaker."
+    }
+  },
+  "verdict": "pass"
+}

--- a/docs/side-effects/login-loss-account-swap.side-effects.md
+++ b/docs/side-effects/login-loss-account-swap.side-effects.md
@@ -1,0 +1,10 @@
+# Login-loss account swap — side-effect map
+
+- Persistent state: optional scrubbed `sourceTrigger` on existing swap-ledger rows.
+- Session lifecycle: a promoted live decision can restart one refreshable
+  conversation through the existing SessionRefresh resume funnel.
+- Credentials: no credential write, copy, login, or default-slot mutation.
+- Network: no new egress; existing quota/account/session surfaces only.
+- User-visible output: no new message or attention path.
+- Rollout: fleet-dark; development-agent decision soak; dry-run first.
+- Rollback: disable the nested trigger or revert; quota swaps remain unchanged.

--- a/docs/specs/proactive-default-account-swap.eli16.md
+++ b/docs/specs/proactive-default-account-swap.eli16.md
@@ -58,3 +58,23 @@ than succeeding only through a generic mock.
 
 Rollback is simple: revert the code and publish the next patch. There is no
 data migration, no new configuration, and no new persistent state.
+
+## Login loss: move before the broken key strands the conversation
+
+Quota is not the only reason an account can become unusable. A local login can
+disappear while a conversation is still alive. Instar already detects that
+specific condition and marks it as “the owner must log in again,” but previously
+it only raised an alert. The live conversation could keep running until its next
+authentication boundary and then stop.
+
+The same safe move can now be proposed for that condition. Instar identifies
+the account from the session’s real login folder, chooses a healthy
+same-framework account, waits if the conversation or its helpers are busy, and
+checks again immediately before restart that the original login is still
+missing. If the user repaired it or the session moved meanwhile, nothing is
+killed. The new trigger is off on ordinary machines and dry-runs first on a
+development machine, so it records “this is what I would move” before anyone
+allows it to restart a real conversation.
+
+That missing-login signal waives only the need for quota pressure; every check
+on the destination account and every last-moment safety check still applies.

--- a/docs/specs/proactive-default-account-swap.md
+++ b/docs/specs/proactive-default-account-swap.md
@@ -226,3 +226,32 @@ field needs no migration or repair; older readers ignore it.
 ## Open questions
 
 *(none)*
+
+## 2026-07-22 amendment — login-loss trigger
+
+A live refreshable session may enter the same proactive swap pipeline when its
+effective source account carries the explicit, current login-loss evidence
+`identityDrifted:true` plus either `repairState:owner-relogin-required` or
+`actualAccountId:missing-local-login`. No other identity-drift state authorizes
+a session mutation.
+
+For untagged sessions, candidacy is correlated from the session's real
+`CLAUDE_CONFIG_DIR`/config home, not from `claude auth status` (which is expected
+to be unavailable after login loss) and not from a stale recorded account tag.
+The exact source account is re-resolved from that real config home immediately
+before refresh. The kill boundary then rechecks both source identity and the
+owner-relogin-required episode; repair or movement in the sub-tick window makes
+the intent stale.
+
+Login loss bypasses only quota-source pressure and relative-improvement
+arithmetic. The target must still be local, same-framework, non-drifted, freshly
+measured, and below the existing ceiling. Refreshability, in-flight-work
+hold, dwell, failure backoff, target-per-tick cap, overall cycle cap, ledger
+availability, reversal detection, breaker, and exact-target execute-time
+revalidation remain binding.
+
+The extension has its own development-agent dark gate at
+`subscriptionPool.proactiveSwap.loginLoss.enabled`. The key is omitted from
+defaults; `dryRun:true` is seeded. A dry-run evaluates the exact live decision
+and writes a `sourceTrigger:login-loss` would-swap row but never admits a
+session kill. Real refresh requires an explicit `dryRun:false` promotion.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -12831,7 +12831,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     // Subscription & Auth Standard). Always instantiated; ships DARK because an
     // empty pool is a pure no-op (no background loop, no cost) until an operator
     // enrolls an account. Stores each account's login LOCATION, never tokens.
-    const { SubscriptionPool } = await import('../core/SubscriptionPool.js');
+    const { SubscriptionPool, requiresOwnerRelogin } = await import('../core/SubscriptionPool.js');
     const subscriptionPool = new SubscriptionPool({ stateDir: config.stateDir });
     if (subscriptionPool.size() > 0) {
       console.log(pc.green(`  Subscription pool: ${subscriptionPool.size()} account(s) registered`));
@@ -17852,10 +17852,15 @@ export async function startServer(options: StartOptions): Promise<void> {
                 const k = antiThrashKnobsGetter();
                 return { thresholdPct: k.thresholdPct, targetHeadroomPct: k.targetHeadroomPct, minImprovementPct: k.minImprovementPct };
               },
-              resolveEffectiveAccountId: async (sessionName, sourceWasUntagged) => {
+              resolveEffectiveAccountId: async (sessionName, sourceWasUntagged, sourceTrigger) => {
                 const tagged = state.listSessions({ status: 'running' })
                   .find((s) => s.tmuxSession === sessionName)?.subscriptionAccountId ?? null;
                 if (!sourceWasUntagged || tagged) return tagged;
+                if (sourceTrigger === 'login-loss') {
+                  const realHome = sessionManager.configHomeForSession(sessionName);
+                  if (!realHome) return null;
+                  return subscriptionPool.list().find((a) => a.configHome === realHome)?.id ?? null;
+                }
                 return (await inUseAccountResolver.resolve(subscriptionPool.list())).activeAccountId;
               },
               onReactiveExecuted: (a) => _swapAntiThrashEngine?.recordReactiveExecuted(a),
@@ -17955,12 +17960,19 @@ export async function startServer(options: StartOptions): Promise<void> {
               // Only claude-code sessions ride the claude-account pool (legacy
               // records with no framework default to claude-code).
               .filter((s) => s.framework === undefined || s.framework === 'claude-code')
-              .map((s) => ({
-                sessionName: s.tmuxSession,
-                accountId: s.subscriptionAccountId ?? null,
-                startedAt: s.startedAt,
-                refreshable: _sessionRefresh?.canRefreshSession(s.tmuxSession) ?? false,
-              })),
+              .map((s) => {
+                const realHome = sessionManager.configHomeForSession(s.tmuxSession);
+                const loginLossAccountId = realHome
+                  ? subscriptionPool.list().find((a) => a.configHome === realHome && requiresOwnerRelogin(a))?.id ?? null
+                  : null;
+                return {
+                  sessionName: s.tmuxSession,
+                  accountId: s.subscriptionAccountId ?? null,
+                  loginLossAccountId,
+                  startedAt: s.startedAt,
+                  refreshable: _sessionRefresh?.canRefreshSession(s.tmuxSession) ?? false,
+                };
+              }),
           resolveDefaultAccountId: async () =>
             (await inUseAccountResolver.resolve(subscriptionPool.list())).activeAccountId,
           swap: (a) =>
@@ -17980,6 +17992,10 @@ export async function startServer(options: StartOptions): Promise<void> {
           antiThrash: _swapAntiThrashEngine
             ? { engine: _swapAntiThrashEngine, getKnobs: antiThrashKnobsGetter }
             : undefined,
+          loginLoss: {
+            enabled: resolveDevAgentGate(proactiveCfg.loginLoss?.enabled, config),
+            dryRun: proactiveCfg.loginLoss?.dryRun !== false,
+          },
           // §4 — the in-flight work gate (proactive arm: defer, ceiling-drop).
           // The monitor owns the deferral lifecycle; the gate is stateless.
           workGate: _swapWorkGate

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -2037,6 +2037,14 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
   // (a baked-in false would dark dev agents too — the #1001 shape the dark-gate lint
   // forbids for a dev-gated block).
   subscriptionPool: {
+    proactiveSwap: {
+      // Login-loss swap trigger — DEV-GATED: enabled deliberately omitted.
+      // A dev agent evaluates the exact intent but performs no session kill
+      // until a deliberate dryRun:false promotion. Fleet remains dark.
+      loginLoss: {
+        dryRun: true,
+      },
+    },
     credentialRepointing: {
       dryRun: true,
       manualLeversEnabled: true,

--- a/src/core/ProactiveSwapMonitor.ts
+++ b/src/core/ProactiveSwapMonitor.ts
@@ -52,6 +52,7 @@ import {
   accountAtPressure,
 } from './QuotaAwareScheduler.js';
 import type { SubscriptionAccount } from './SubscriptionPool.js';
+import { requiresOwnerRelogin } from './SubscriptionPool.js';
 import type { SwapAntiThrashEngine, AntiThrashKnobs } from './SwapAntiThrash.js';
 import type { WorkProbeResult } from './SwapWorkGate.js';
 import { governor, consumeAdmissionToken } from '../monitoring/selfaction/governor.js';
@@ -85,6 +86,9 @@ export interface ProactiveSwapSession {
   /** The pool account this session is tagged with, or null if untagged
    *  (untagged ⇒ running on the default config ⇒ resolved via the default login). */
   accountId: string | null;
+  /** Exact account correlated from the session's real config home when that
+   * slot is in an owner-relogin-required episode. */
+  loginLossAccountId?: string | null;
   /** False when the existing SessionRefresh funnel cannot route this session
    *  back to a Telegram or Slack conversation. Omitted preserves legacy callers. */
   refreshable?: boolean;
@@ -127,6 +131,7 @@ export interface ProactiveSwapMonitorConfig {
     targetAccountId?: string;
     callerClass?: 'proactive-swap';
     sourceWasUntagged?: boolean;
+    sourceTrigger?: 'quota-pressure' | 'login-loss';
   }) => Promise<ProactiveSwapOutcome>;
   /** Optional fresh-poll trigger, awaited when an account is in the watch zone. */
   triggerPoll?: () => Promise<unknown>;
@@ -148,6 +153,12 @@ export interface ProactiveSwapMonitorConfig {
   antiThrash?: {
     engine: SwapAntiThrashEngine;
     getKnobs: () => AntiThrashKnobs;
+  };
+  /** Login-loss trigger extension. The master switch is dev-gated in wiring;
+   * dryRun defaults true and records the exact would-swap without a kill. */
+  loginLoss?: {
+    enabled: boolean;
+    dryRun: boolean;
   };
   /** In-flight work deferral (Piece 2). Knobs read live per evaluation. */
   workGate?: {
@@ -176,6 +187,7 @@ interface Candidate {
   startedMs: number;
   /** True when the session carries no tag (resolved via the default slot). */
   untagged: boolean;
+  sourceTrigger: 'quota-pressure' | 'login-loss';
 }
 
 interface DeferralEntry {
@@ -339,18 +351,20 @@ export class ProactiveSwapMonitor {
       defaultAccountId = null; // unknown default source holds safely
     }
     for (const s of this.cfg.listRunningSessions()) {
-      const effectiveAccountId = s.accountId ?? defaultAccountId;
+      const effectiveAccountId = s.accountId ?? s.loginLossAccountId ?? defaultAccountId;
       currentAccountBySession.set(s.sessionName, effectiveAccountId);
       if (s.refreshable === false || !effectiveAccountId) continue;
       const acct = byId.get(effectiveAccountId);
       if (!acct) continue;
-      if (!engine.sourceEligible(acct, nowMs)) continue;
+      const loginLoss = this.cfg.loginLoss?.enabled === true && requiresOwnerRelogin(acct);
+      if (!loginLoss && !engine.sourceEligible(acct, nowMs)) continue;
       const startedMs = s.startedAt ? Date.parse(s.startedAt) : NaN;
       candidates.push({
         sessionName: s.sessionName,
         accountId: effectiveAccountId,
         startedMs: Number.isFinite(startedMs) ? startedMs : 0,
         untagged: s.accountId === null,
+        sourceTrigger: loginLoss ? 'login-loss' : 'quota-pressure',
       });
     }
     candidates.sort((a, b) => b.startedMs - a.startedMs);
@@ -396,6 +410,7 @@ export class ProactiveSwapMonitor {
         targetsUsedThisTick,
         ...(deferralAgeMs !== undefined ? { deferralAgeMs } : {}),
         ...(deferral ? { deferCount: deferral.count } : {}),
+        sourceTrigger: c.sourceTrigger,
       });
       if (verdict.action !== 'execute') continue; // refusal rows already written by the engine
 
@@ -479,7 +494,27 @@ export class ProactiveSwapMonitor {
 
       // Execute — the checked target IS the executed target (I1); the
       // scheduler revalidates the WHOLE decision at execute time (§3.3).
+      // The trigger stays explicit so login loss bypasses only source pressure,
+      // never target freshness, target ceilings, or execution-time safeguards.
       try {
+        if (c.sourceTrigger === 'login-loss' && this.cfg.loginLoss?.dryRun !== false) {
+          engine.recordProactiveExecuted({
+            session: c.sessionName,
+            from: c.accountId,
+            to: verdict.targetAccountId,
+            nowMs,
+            fromUtilPct: verdict.fromUtilPct,
+            toUtilPct: verdict.toUtilPct,
+            sourceTrigger: 'login-loss',
+            dryRun: true,
+            ...(c.untagged ? { sourceWasUntagged: true } : {}),
+          });
+          targetsUsedThisTick.add(verdict.targetAccountId);
+          this.logger.log(
+            `[ProactiveSwap] ${c.sessionName}: would swap off missing login ${c.accountId} → ${verdict.targetAccountId} (dry-run; conversation untouched)`,
+          );
+          continue;
+        }
         // Self-action backpressure admission (observe-only: always allows).
         // An enforce-mode non-allow stands down this candidate — the pressure
         // condition re-fires on the next tick (level-triggered).
@@ -495,6 +530,7 @@ export class ProactiveSwapMonitor {
           targetAccountId: verdict.targetAccountId,
           callerClass: 'proactive-swap',
           ...(c.untagged ? { sourceWasUntagged: true } : {}),
+          sourceTrigger: c.sourceTrigger,
         });
         if (outcome.swapped) {
           engine.recordProactiveExecuted({
@@ -505,6 +541,7 @@ export class ProactiveSwapMonitor {
             fromUtilPct: verdict.fromUtilPct,
             toUtilPct: verdict.toUtilPct,
             ...(c.untagged ? { sourceWasUntagged: true } : {}),
+            sourceTrigger: c.sourceTrigger,
             ...(deferral ? { deferralAgeMs: nowMs - deferral.firstAtMs, deferCount: deferral.count } : {}),
           });
           this.lastSwapAt.set(c.sessionName, nowMs);
@@ -512,8 +549,8 @@ export class ProactiveSwapMonitor {
           targetsUsedThisTick.add(verdict.targetAccountId);
           swapped.push(c.sessionName);
           this.logger.log(
-            `[ProactiveSwap] ${c.sessionName}: pre-emptively swapped off ${c.accountId} → ${outcome.toAccountId ?? verdict.targetAccountId} ` +
-              `(account ≥${this.thresholdPct}% measured — moved before the wall, conversation preserved)`,
+            `[ProactiveSwap] ${c.sessionName}: proactively swapped off ${c.accountId} → ${outcome.toAccountId ?? verdict.targetAccountId} ` +
+              `(${c.sourceTrigger === 'login-loss' ? 'local login missing' : `account ≥${this.thresholdPct}% measured`} — conversation preserved)`,
           );
         } else if (outcome.reason === 'target-revalidation-failed') {
           engine.recordRevalidationRefusal({
@@ -711,6 +748,7 @@ export class ProactiveSwapMonitor {
         accountId: eff,
         startedMs: Number.isFinite(startedMs) ? startedMs : 0,
         untagged: s.accountId === null,
+        sourceTrigger: 'quota-pressure',
       });
     }
     return out;

--- a/src/core/QuotaAwareScheduler.ts
+++ b/src/core/QuotaAwareScheduler.ts
@@ -28,7 +28,7 @@ import type {
   AccountQuotaSnapshot,
   SubscriptionFramework,
 } from './SubscriptionPool.js';
-import { isLocallyExecutable } from './SubscriptionPool.js';
+import { isLocallyExecutable, requiresOwnerRelogin } from './SubscriptionPool.js';
 
 /** The binding window for swap decisions: the 7-day window is the scarce one. */
 export interface SelectionOptions {
@@ -210,7 +210,11 @@ export interface QuotaSwapAntiThrashHooks {
   /** Live knobs for the revalidation arithmetic. */
   getKnobs: () => { thresholdPct: number; targetHeadroomPct: number; minImprovementPct: number };
   /** The session's CURRENT account id (source-identity check, R3-m3). */
-  resolveEffectiveAccountId: (sessionName: string, sourceWasUntagged: boolean) => Promise<string | null>;
+  resolveEffectiveAccountId: (
+    sessionName: string,
+    sourceWasUntagged: boolean,
+    sourceTrigger?: 'quota-pressure' | 'login-loss',
+  ) => Promise<string | null>;
   /** Observe an executed REACTIVE swap (dwell clock-start, hop alerts). */
   onReactiveExecuted?: (args: { session: string; from: string; to: string; nowMs: number }) => void;
   /** Observe a reactive execution failure (§3.6 `failed` rows, kind 'reactive'). */
@@ -272,6 +276,9 @@ export class QuotaAwareScheduler {
     framework?: SubscriptionFramework;
     /** True when the evaluated source came from the default-login resolver. */
     sourceWasUntagged?: boolean;
+    /** Level-triggered source condition. Login loss is revalidated at the same
+     * kill boundary as the untagged default-account identity. */
+    sourceTrigger?: 'quota-pressure' | 'login-loss';
   }): Promise<SwapResult> {
     const { sessionName, exhaustedAccountId, nowMs, targetAccountId } = args;
     const isProactive = targetAccountId !== undefined;
@@ -306,19 +313,31 @@ export class QuotaAwareScheduler {
         }
         // 2. Source identity (R3-m3): a reactive swap that completed in the
         // sub-tick window invalidates the intent — never a second kill.
-        const current = await at.resolveEffectiveAccountId(sessionName, args.sourceWasUntagged === true);
+        const current = await at.resolveEffectiveAccountId(
+          sessionName,
+          args.sourceWasUntagged === true,
+          args.sourceTrigger,
+        );
         if ((args.sourceWasUntagged === true && current !== exhaustedAccountId) ||
             (args.sourceWasUntagged !== true && current !== null && current !== exhaustedAccountId)) {
           return { swapped: false, toAccountId: next.id, reason: 'intent-stale' };
         }
-        // 3. Source pressure, fresh: the wave may have subsided sub-tick.
+        // 3. Source condition, fresh: either quota pressure still exists, or
+        // the exact owner-relogin-required episode still exists. A repaired
+        // login makes the intent stale before the session is killed.
         const source = accounts.find((a) => a.id === exhaustedAccountId);
-        if (!source || !isLocallyExecutable(source) || !at.readingValid(source, nowMs) || bindingUtilization(source.lastQuota) < k.thresholdPct) {
-          return { swapped: false, toAccountId: next.id, reason: 'intent-stale' };
-        }
-        // 4. Improvement delta, fresh (bound 2 at the actual kill point).
-        if (bindingUtilization(source.lastQuota) - bindingUtilization(next.lastQuota) < k.minImprovementPct) {
-          return { swapped: false, toAccountId: next.id, reason: 'target-revalidation-failed' };
+        if (args.sourceTrigger === 'login-loss') {
+          if (!source || !requiresOwnerRelogin(source)) {
+            return { swapped: false, toAccountId: next.id, reason: 'intent-stale' };
+          }
+        } else {
+          if (!source || !isLocallyExecutable(source) || !at.readingValid(source, nowMs) || bindingUtilization(source.lastQuota) < k.thresholdPct) {
+            return { swapped: false, toAccountId: next.id, reason: 'intent-stale' };
+          }
+          // 4. Improvement delta, fresh (bound 2 at the actual kill point).
+          if (bindingUtilization(source.lastQuota) - bindingUtilization(next.lastQuota) < k.minImprovementPct) {
+            return { swapped: false, toAccountId: next.id, reason: 'target-revalidation-failed' };
+          }
         }
       }
     } else {
@@ -341,7 +360,7 @@ export class QuotaAwareScheduler {
     try {
       refreshOutcome = await this.cfg.refreshFn({
         sessionName,
-        reason: `quota-swap: ${exhaustedAccountId} → ${next.id}`,
+        reason: `${args.sourceTrigger === 'login-loss' ? 'login-loss-swap' : 'quota-swap'}: ${exhaustedAccountId} → ${next.id}`,
         configHome: next.configHome,
         accountId: next.id,
         callerClass,

--- a/src/core/SubscriptionPool.ts
+++ b/src/core/SubscriptionPool.ts
@@ -151,6 +151,16 @@ export interface SubscriptionAccount {
   version: number;
 }
 
+/** True only for the explicit local-login-loss drift episode. Drift of a
+ * different kind remains quarantined but does not authorize a session kill. */
+export function requiresOwnerRelogin(account: SubscriptionAccount): boolean {
+  const drift = account.identityDrift;
+  return account.identityDrifted === true && !!drift && (
+    drift.repairState === 'owner-relogin-required' ||
+    drift.actualAccountId === 'missing-local-login'
+  );
+}
+
 /**
  * WS5.2 §6.2 — "locally executable" predicate. An account is executable on THIS
  * machine iff this machine holds it with a real local `configHome` AND a valid

--- a/src/core/SwapAntiThrash.ts
+++ b/src/core/SwapAntiThrash.ts
@@ -184,6 +184,9 @@ export interface ProactiveIntentInput {
   /** Deferral bookkeeping stamped onto refusal rows when this intent is a deferred retry. */
   deferralAgeMs?: number;
   deferCount?: number;
+  /** Login loss bypasses only the source-pressure arithmetic. Every target,
+   * work, dwell, breaker, freshness, and execution-boundary guard still binds. */
+  sourceTrigger?: 'quota-pressure' | 'login-loss';
 }
 
 export type BrakeVerdict =
@@ -634,7 +637,7 @@ export class SwapAntiThrashEngine {
 
     // 6. VERIFY the survivor against bound 2 (relative improvement).
     const fromUtil = sourceValidity.utilPct;
-    if (fromUtil - target.utilPct < k.minImprovementPct) {
+    if (input.sourceTrigger !== 'login-loss' && fromUtil - target.utilPct < k.minImprovementPct) {
       this.recordSimpleRefusal(input, 'no-material-target', nowMs, {
         to: target.acct.id,
         fromUtilPct: fromUtil,
@@ -689,6 +692,7 @@ export class SwapAntiThrashEngine {
     defaultAccountChanged?: boolean;
     sourceWasUntagged?: boolean;
     dryRun?: boolean;
+    sourceTrigger?: 'quota-pressure' | 'login-loss';
   }): void {
     const k = this.getKnobs();
     const row: SwapLedgerRow = {
@@ -706,6 +710,7 @@ export class SwapAntiThrashEngine {
       ...(args.deferCount !== undefined ? { deferCount: args.deferCount } : {}),
       ...(args.defaultAccountChanged ? { defaultAccountChanged: true } : {}),
       ...(args.sourceWasUntagged ? { sourceWasUntagged: true } : {}),
+      ...(args.sourceTrigger ? { sourceTrigger: args.sourceTrigger } : {}),
       ...(args.dryRun ? { dryRun: true } : {}),
     };
 

--- a/src/core/SwapLedger.ts
+++ b/src/core/SwapLedger.ts
@@ -109,6 +109,8 @@ export interface SwapLedgerRow {
   defaultAccountChanged?: boolean;
   /** Source session resolved through the default login; the default itself did not change. */
   sourceWasUntagged?: boolean;
+  /** The level-triggered condition that authorized this proactive intent. */
+  sourceTrigger?: 'quota-pressure' | 'login-loss';
   episodeId?: string;
   episodeKind?: EpisodeKind;
   breakerOpenedAt?: string;

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -74,6 +74,12 @@ export const DEV_GATED_FEATURES: DevGatedFeature[] = [
     justification: 'Ships dryRun:true and fleet-dark. Authority requires fresh bidirectional MachineAuth proof at the current pairing epoch; writes are restricted to the agent-home authorized_keys.',
   },
   {
+    name: 'proactiveSwapLoginLoss',
+    configPath: 'subscriptionPool.proactiveSwap.loginLoss.enabled',
+    description: 'Login-loss extension for the existing live-session proactive account-swap funnel.',
+    justification: 'Ships dryRun:true and fleet-dark. On a development agent it only records the exact would-swap while retaining target freshness, work-in-flight, dwell, breaker, cycle-cap, and kill-boundary source revalidation; a real session refresh requires an explicit dryRun:false promotion.',
+  },
+  {
     name: 'ownershipGatedSpawn',
     configPath: 'multiMachine.sessionPool.ownershipGatedSpawn.enabled',
     description: 'SpawnAdmission — the binding-verdict seam at every conversation-bound session-creating callsite (ownership-gated-spawn-and-judgment-within-floors §3.1, Layer A; the Ownership-Gated Side Effects standard). Consults resolveOwnershipSafe (tri-state, non-throwing) and the router verdict (TOCTOU consumption) before Telegram cold-spawn/respawn + Slack inbound/recovery spawns; never a bootleg local copy of an owned-elsewhere conversation.',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -4139,6 +4139,17 @@ export interface InstarConfig {
          *  (default 1800000 = 30m — 2× the quota poller's 15-min cadence). */
         quotaFreshnessMs?: number;
       };
+      /**
+       * Login-loss extension: a live, refreshable session whose source account
+       * is explicitly `owner-relogin-required` may use the same anti-thrash and
+       * SessionRefresh funnel even when quota is not high. `enabled` is omitted
+       * from defaults so the development-agent gate decides; dryRun defaults
+       * true and records only a would-swap.
+       */
+      loginLoss?: {
+        enabled?: boolean;
+        dryRun?: boolean;
+      };
     };
     /**
      * swap-continuity-antithrash §4/§7 — Piece 2 (the in-flight work gate for

--- a/tests/unit/proactive-swap-production-wiring.test.ts
+++ b/tests/unit/proactive-swap-production-wiring.test.ts
@@ -13,7 +13,15 @@ describe('proactive swap production transport wiring', () => {
   });
 
   it('execute-time effective-source revalidation uses the existing default resolver', () => {
-    expect(server).toContain('resolveEffectiveAccountId: async (sessionName, sourceWasUntagged)');
+    expect(server).toContain('resolveEffectiveAccountId: async (sessionName, sourceWasUntagged, sourceTrigger)');
     expect(server).toContain('inUseAccountResolver.resolve(subscriptionPool.list())');
+  });
+
+  it('dev-gates the login-loss trigger and defaults it to dry-run at production wiring', () => {
+    expect(server).toContain('enabled: resolveDevAgentGate(proactiveCfg.loginLoss?.enabled, config)');
+    expect(server).toContain('dryRun: proactiveCfg.loginLoss?.dryRun !== false');
+    expect(server).toContain('sessionManager.configHomeForSession(s.tmuxSession)');
+    expect(server).toContain('requiresOwnerRelogin(a)');
+    expect(server).toContain("if (sourceTrigger === 'login-loss')");
   });
 });

--- a/tests/unit/swap-continuity-wiring.test.ts
+++ b/tests/unit/swap-continuity-wiring.test.ts
@@ -67,6 +67,21 @@ function acct(id: string, util: number | null): SubscriptionAccount {
   };
 }
 
+function missingLogin(id: string, util: number | null): SubscriptionAccount {
+  return {
+    ...acct(id, util),
+    identityDrifted: true,
+    identityDrift: {
+      expectedAccountId: id,
+      actualAccountId: 'missing-local-login',
+      slot: `/h/.claude-${id}`,
+      detectedAt: new Date(now - 60_000).toISOString(),
+      lastConfirmedAt: new Date(now - 60_000).toISOString(),
+      repairState: 'owner-relogin-required',
+    },
+  };
+}
+
 describe('swap-continuity wiring integrity', () => {
   let dir: string;
   let knobOver: Partial<import('../../src/core/SwapAntiThrash.js').AntiThrashConfigBlock>;
@@ -96,10 +111,11 @@ describe('swap-continuity wiring integrity', () => {
   function makeMonitor(over: {
     engine: SwapAntiThrashEngine | null;
     accounts: SubscriptionAccount[];
-    sessions: Array<{ sessionName: string; accountId: string | null; startedAt?: string; refreshable?: boolean }>;
+    sessions: Array<{ sessionName: string; accountId: string | null; loginLossAccountId?: string | null; startedAt?: string; refreshable?: boolean }>;
     defaultAccountId?: string | null;
     probe?: (s: string) => Promise<WorkProbeResult>;
     continuity?: Partial<{ enabled: boolean; dryRun: boolean; deferralCeilingMs: number }>;
+    loginLoss?: { enabled: boolean; dryRun: boolean };
     swapImpl?: (a: { sessionName: string; exhaustedAccountId: string; targetAccountId?: string }) => Promise<{ swapped: boolean; toAccountId: string | null; reason?: string }>;
   }) {
     const swap = vi.fn(
@@ -112,6 +128,7 @@ describe('swap-continuity wiring integrity', () => {
         over.sessions.map((s) => ({
           sessionName: s.sessionName,
           accountId: s.accountId,
+          ...(s.loginLossAccountId !== undefined ? { loginLossAccountId: s.loginLossAccountId } : {}),
           startedAt: s.startedAt ?? '2026-07-02T14:00:00Z',
           ...(s.refreshable !== undefined ? { refreshable: s.refreshable } : {}),
         })),
@@ -119,6 +136,7 @@ describe('swap-continuity wiring integrity', () => {
       swap,
       now: () => now,
       ...(over.engine ? { antiThrash: { engine: over.engine, getKnobs: knobs } } : {}),
+      ...(over.loginLoss ? { loginLoss: over.loginLoss } : {}),
       ...(over.probe
         ? {
             workGate: {
@@ -255,6 +273,69 @@ describe('swap-continuity wiring integrity', () => {
       const r = await monitor.evaluate();
       expect(r).toEqual({ swapped: [], considered: 0 });
       expect(swap).not.toHaveBeenCalled();
+    });
+
+    it('login-loss trigger dry-runs a low-utilization missing source through the real brake pipeline', async () => {
+      const engine = makeEngine();
+      const { monitor, swap } = makeMonitor({
+        engine,
+        accounts: [missingLogin('lost', 10), acct('fresh', 20)],
+        sessions: [{ sessionName: 'bound', accountId: 'lost', refreshable: true }],
+        probe: async () => idle,
+        loginLoss: { enabled: true, dryRun: true },
+      });
+      const r = await monitor.evaluate();
+      expect(r).toEqual({ swapped: [], considered: 1 });
+      expect(swap).not.toHaveBeenCalled();
+      const rows = fs.readFileSync(path.join(dir, 'state', 'swap-ledger.jsonl'), 'utf8')
+        .trim().split('\n').map((line) => JSON.parse(line));
+      expect(rows.at(-1)).toMatchObject({
+        decision: 'swapped',
+        sourceTrigger: 'login-loss',
+        dryRun: true,
+        from: 'lost',
+        to: 'fresh',
+      });
+    });
+
+    it('login-loss trigger executes only after explicit dry-run promotion', async () => {
+      const engine = makeEngine();
+      const { monitor, swap } = makeMonitor({
+        engine,
+        accounts: [missingLogin('lost', 10), acct('fresh', 20)],
+        sessions: [{ sessionName: 'bound', accountId: 'lost', refreshable: true }],
+        probe: async () => idle,
+        loginLoss: { enabled: true, dryRun: false },
+      });
+      expect(await monitor.evaluate()).toEqual({ swapped: ['bound'], considered: 1 });
+      expect(swap).toHaveBeenCalledWith(expect.objectContaining({
+        exhaustedAccountId: 'lost',
+        targetAccountId: 'fresh',
+        sourceTrigger: 'login-loss',
+      }));
+    });
+
+    it('correlates an untagged missing-login session from its real config-home account when auth status is gone', async () => {
+      const engine = makeEngine();
+      const { monitor, swap } = makeMonitor({
+        engine,
+        accounts: [missingLogin('lost', 10), acct('fresh', 20)],
+        sessions: [{
+          sessionName: 'default-session',
+          accountId: null,
+          loginLossAccountId: 'lost',
+          refreshable: true,
+        }],
+        defaultAccountId: null,
+        probe: async () => idle,
+        loginLoss: { enabled: true, dryRun: false },
+      });
+      expect(await monitor.evaluate()).toEqual({ swapped: ['default-session'], considered: 1 });
+      expect(swap).toHaveBeenCalledWith(expect.objectContaining({
+        exhaustedAccountId: 'lost',
+        sourceWasUntagged: true,
+        sourceTrigger: 'login-loss',
+      }));
     });
 
     it('dryRun keeps the LEGACY decision path (no targetAccountId funnel) while the engine shadows', async () => {
@@ -402,7 +483,7 @@ describe('swap-continuity wiring integrity', () => {
         sourceWasUntagged: true,
       });
       expect(r).toMatchObject({ swapped: false, reason: 'intent-stale' });
-      expect(resolveEffectiveAccountId).toHaveBeenCalledWith('untagged', true);
+      expect(resolveEffectiveAccountId).toHaveBeenCalledWith('untagged', true, undefined);
       expect(refreshFn).not.toHaveBeenCalled();
     });
 
@@ -445,6 +526,40 @@ describe('swap-continuity wiring integrity', () => {
         exhaustedAccountId: 'hot',
         nowMs: now,
         targetAccountId: 'cool',
+      });
+      expect(r).toMatchObject({ swapped: false, reason: 'intent-stale' });
+      expect(refreshFn).not.toHaveBeenCalled();
+    });
+
+    it('revalidates owner-relogin-required at the kill boundary before a login-loss refresh', async () => {
+      const { scheduler, refreshFn } = makeScheduler({
+        accounts: [missingLogin('hot', 10), acct('cool', 20)],
+      });
+      const r = await scheduler.onQuotaPressure({
+        sessionName: 's1',
+        exhaustedAccountId: 'hot',
+        nowMs: now,
+        targetAccountId: 'cool',
+        callerClass: 'proactive-swap',
+        sourceTrigger: 'login-loss',
+      });
+      expect(r.swapped).toBe(true);
+      expect(refreshFn).toHaveBeenCalledWith(expect.objectContaining({
+        reason: 'login-loss-swap: hot → cool',
+      }));
+    });
+
+    it('refuses a login-loss intent when the source login repaired before the kill boundary', async () => {
+      const { scheduler, refreshFn } = makeScheduler({
+        accounts: [acct('hot', 10), acct('cool', 20)],
+      });
+      const r = await scheduler.onQuotaPressure({
+        sessionName: 's1',
+        exhaustedAccountId: 'hot',
+        nowMs: now,
+        targetAccountId: 'cool',
+        callerClass: 'proactive-swap',
+        sourceTrigger: 'login-loss',
       });
       expect(r).toMatchObject({ swapped: false, reason: 'intent-stale' });
       expect(refreshFn).not.toHaveBeenCalled();

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,30 @@
+# Instar Upgrade Guide
+
+## What Changed
+
+Live-session account swapping can now react when the source account's local
+login disappears and requires the owner to log in again. The trigger reuses the
+existing safe refresh path, remains fleet-dark, and begins in dry-run mode.
+
+## What to Tell Your User
+
+An active conversation no longer has to wait for its next authentication
+failure after a local subscription login disappears. Instar can identify the
+affected account from the conversation's real login folder, select a healthy
+same-framework account, and prepare the same conversation-preserving move used
+for quota pressure. It first records what it would do; live moves still require
+an explicit promotion.
+
+## Summary of New Capabilities
+
+- Owner-relogin-required and missing-local-login episodes can trigger the
+  existing proactive live-session account-swap funnel.
+- Untagged default-login sessions are correlated from their real config home.
+- Source repair is rechecked at the kill boundary, and every target, workload,
+  dwell, breaker, and cycle-cap safeguard remains binding.
+
+## Evidence
+
+- `tests/unit/swap-continuity-wiring.test.ts`
+- `tests/unit/proactive-swap-production-wiring.test.ts`
+- `tests/unit/devGatedFeatures-wiring.test.ts`

--- a/upgrades/side-effects/login-loss-account-swap.md
+++ b/upgrades/side-effects/login-loss-account-swap.md
@@ -1,0 +1,87 @@
+# Side-effects review — login-loss account swap
+
+The change extends the existing proactive live-session account swap with one
+new source trigger: explicit local-login loss (`owner-relogin-required` or
+`missing-local-login`). It does not add a second executor, credential store, or
+session lifecycle path.
+
+## Decision-point inventory
+
+- Source candidacy — modified — quota pressure or exact login-loss evidence.
+- Untagged source identity — modified — real config-home correlation survives
+  the expected failure of the auth-status probe.
+- Kill-boundary authority — modified — source identity and login-loss evidence
+  are both revalidated before SessionRefresh.
+- Rollout authority — added — nested development-agent gate plus dry-run-first.
+
+## 1. Over-block
+
+A login-loss session holds when its real config home is unavailable, the
+conversation is not refreshable, target readings are stale/hot, work is busy,
+the ledger/breaker/dwell refuses, or the source condition repairs before the
+kill boundary. These are intentional safe-direction refusals.
+
+## 2. Under-block
+
+Only the exact owner-relogin-required/missing-local-login drift class bypasses
+quota source pressure. Other identity drift remains quarantined and cannot
+authorize a restart. A target must still be local, same-framework, non-drifted,
+freshly measured, and beneath the existing ceiling.
+
+## 3. Level-of-abstraction fit
+
+`ProactiveSwapMonitor` remains the level-triggered intent owner,
+`SwapAntiThrashEngine` remains the brake/target authority,
+`QuotaAwareScheduler` remains the execute-time revalidator, and
+`SessionRefresh` remains the sole session mutation funnel.
+
+## 4. Signal vs authority
+
+Subscription-pool identity drift is a signal until it matches the enumerable
+login-loss state. The actual mutation authority is the conjunction of that
+state, exact real-config-home source identity, refreshability, target validity,
+all anti-thrash brakes, work-idle evidence, and the repeated kill-boundary
+checks. Uncertainty holds.
+
+## 5. Interactions
+
+- Untagged sessions use real config-home correlation because auth status is
+  expected to fail after login loss.
+- A repaired login invalidates an in-flight intent before the kill.
+- Dry-run writes a scrubbed `sourceTrigger:login-loss` would-swap row without
+  consuming a session refresh.
+- Quota-trigger behavior is unchanged.
+
+## 6. External surfaces
+
+No new route or notification exists. The nested config block exposes
+`enabled` and `dryRun`; defaults omit `enabled` and seed `dryRun:true`.
+
+## 7. Multi-machine posture
+
+Machine-local by design: login presence and the session's real config home are
+local execution facts. The target remains a locally executable account; no
+credential is copied between machines.
+
+## 8. Rollback cost
+
+Disable `subscriptionPool.proactiveSwap.loginLoss` or revert. Existing quota
+swaps remain available. No database migration or durable repair is required;
+older ledger readers ignore the optional source-trigger field.
+
+## Class-Closure Declaration
+
+- `unbounded-self-action` — closed by the existing proactive-swap controller
+  guard and ratchets. The level trigger is bounded by dwell, work deferral,
+  failure backoff, per-target and per-cycle caps, breaker, and source repair;
+  `tests/unit/swap-continuity-wiring.test.ts` proves dry-run, live, and
+  kill-boundary settling behavior.
+
+## Evidence
+
+- `tests/unit/swap-continuity-wiring.test.ts`
+- `tests/unit/proactive-swap-production-wiring.test.ts`
+- `tests/unit/devGatedFeatures-wiring.test.ts`
+- `tests/unit/lint-dev-agent-dark-gate.test.ts`
+- The execution-path comment preserves the review's key boundary: login loss
+  bypasses source pressure only, while every target and kill-time guard remains.


### PR DESCRIPTION
## Summary

- extend the existing proactive live-session account swap to exact owner-relogin-required / missing-local-login episodes
- correlate untagged default-login sessions from their real config home and revalidate the source at the kill boundary
- keep the extension fleet-dark and development-gated, with `dryRun:true` as the first posture
- preserve all target freshness, ceiling, workload, dwell, backoff, breaker, and cycle-cap safeguards

## ELI16

Imagine a conversation is using a key that suddenly disappears from the keyring. Until now, Instar could notice the missing key and warn the owner, but the conversation would still be stranded when it next needed that key. This change lets Instar use the same careful account-move machinery it already uses when an account is nearly out of quota. It identifies which login folder the conversation really uses, finds a healthy account for the same framework, waits for busy work to finish, and checks one last time before restarting that the old login is still missing. If the owner logged back in or the conversation moved in the meantime, Instar refuses the stale action. The feature ships off for the fleet and records what it would do before any real restart is allowed.

## Safety and decision audit

- exact login-loss predicate only: identity drift plus owner-relogin-required, or missing-local-login
- login loss bypasses only source quota pressure and relative improvement
- untagged source identity is resolved from the real session config home at candidacy and execution
- source repair at the final boundary returns `intent-stale`
- successful and blocked development-gate evaluations are committed as decision-audit records
- rollback is disabling the nested login-loss gate or reverting; no migration is involved

## Validation

- 231 focused assertions across swap wiring, production wiring, and development-gate wiring
- 719 broader swap/quota/subscription/missing-login regression tests across 45 files
- build green
- lint and all local ratchets green
- full aggregate delegated to CI
