### PR TITLE
Surface repeated deferral patterns

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T06-15-37-661Z-act-896-deferral-pattern-sentinel.json
+++ b/.instar/instar-dev-decisions/2026-07-23T06-15-37-661Z-act-896-deferral-pattern-sentinel.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-23T06:15:37.661Z",
+  "slug": "act-896-deferral-pattern-sentinel",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 3,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/DeferralPatternSentinel.test.ts",
+      "howCaught": "Strict dark no-read and dry-run no-emission bounds prevent autonomous action in increment 1; the stable Attention dedupe key is tested across repeated counts, and future boot wiring must re-prove real-funnel idempotency."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T06-16-21-902Z-act-896-deferral-pattern-sentinel.json
+++ b/.instar/instar-dev-decisions/2026-07-23T06-16-21-902Z-act-896-deferral-pattern-sentinel.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-07-23T06:16:21.902Z",
+  "slug": "act-896-deferral-pattern-sentinel",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 3,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "The canonical single-message deferral recognizer already existed; this increment adds the requested bounded aggregate pattern signal without duplicating recognition or storage."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/DeferralPatternSentinel.test.ts",
+      "howCaught": "Strict dark no-read and dry-run no-emission bounds prevent autonomous action in increment 1; the stable Attention dedupe key is tested across repeated counts, and future boot wiring must re-prove real-funnel idempotency."
+    }
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T06-29-25-942Z-act-896-deferral-pattern-sentinel.json
+++ b/.instar/instar-dev-decisions/2026-07-23T06-29-25-942Z-act-896-deferral-pattern-sentinel.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-23T06:29:25.942Z",
+  "slug": "act-896-deferral-pattern-sentinel",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/DeferralPatternSentinel.test.ts",
+      "howCaught": "Strict dark no-read and dry-run no-emission bounds prevent autonomous action in increment 1; the stable Attention dedupe key is tested across repeated counts, and future boot wiring must re-prove real-funnel idempotency."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T06-30-47-621Z-act-896-deferral-pattern-sentinel.json
+++ b/.instar/instar-dev-decisions/2026-07-23T06-30-47-621Z-act-896-deferral-pattern-sentinel.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-07-23T06:30:47.621Z",
+  "slug": "act-896-deferral-pattern-sentinel",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "The canonical single-message deferral recognizer already existed; this increment adds the requested bounded aggregate pattern signal without duplicating recognition or storage."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/DeferralPatternSentinel.test.ts",
+      "howCaught": "Strict dark no-read and dry-run no-emission bounds prevent autonomous action in increment 1; the stable Attention dedupe key is tested across repeated counts, and future boot wiring must re-prove real-funnel idempotency."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T06-31-53-056Z-act-896-deferral-pattern-sentinel.json
+++ b/.instar/instar-dev-decisions/2026-07-23T06-31-53-056Z-act-896-deferral-pattern-sentinel.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-07-23T06:31:53.056Z",
+  "slug": "act-896-deferral-pattern-sentinel",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "The projection intentionally treats absent or unreadable observability files as no observations, but the new catch site lacked the repository's explicit silent-fallback posture marker."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/no-silent-fallbacks.test.ts",
+      "howCaught": "The hard no-silent-fallbacks ratchet rejected the new catch site in CI; the focused regression now holds the global count at its existing ceiling while the sentinel remains dark and non-actuating."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T06-33-03-844Z-act-896-deferral-pattern-sentinel.json
+++ b/.instar/instar-dev-decisions/2026-07-23T06-33-03-844Z-act-896-deferral-pattern-sentinel.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-07-23T06:33:03.844Z",
+  "slug": "act-896-deferral-pattern-sentinel",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "The projection intentionally treats absent or unreadable observability files as no observations, but the new catch site lacked the repository's explicit silent-fallback posture marker."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/no-silent-fallbacks.test.ts",
+      "howCaught": "The hard no-silent-fallbacks ratchet rejected the new catch site in CI; the focused regression now holds the global count at its existing ceiling while the sentinel remains dark and non-actuating."
+    }
+  },
+  "verdict": "pass"
+}

--- a/src/core/JudgmentProvenanceLog.ts
+++ b/src/core/JudgmentProvenanceLog.ts
@@ -172,6 +172,15 @@ export interface ProvenanceRow {
 /** The HTTP-served view: everything EXCEPT the machine-local full context. */
 export type RedactedProvenanceRow = Omit<ProvenanceRow, 'contextFull'>;
 
+/** Internal, content-free projection consumed by DeferralPatternSentinel.
+ * Never HTTP-served: it exposes only timestamp, the canonical recognizer boolean,
+ * and the candidate identity hash already present in tone provenance. */
+export interface DeferralPatternProvenanceObservation {
+  observedAt: number;
+  deferralShapeDetected: boolean;
+  candidateSha256: string;
+}
+
 export interface JudgmentProvenanceLogOptions {
   /** Absolute directory, canonically `<agent>/state/judgment-provenance`. */
   dir: string;
@@ -494,6 +503,69 @@ export class JudgmentProvenanceLog {
           out.push(redacted);
         } catch {
           /* @silent-fallback-ok: a torn/corrupt row is skipped — the read surface is observability. */
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Internal typed projection over the EXISTING provenance store for ACT-896.
+   * This is intentionally not a second ledger and not an HTTP surface. Corrupt,
+   * truncated, non-tone, or shape-invalid rows are skipped toward silence.
+   */
+  async readDeferralPatternObservations(opts?: {
+    limit?: number;
+    sinceMs?: number;
+  }): Promise<DeferralPatternProvenanceObservation[]> {
+    const limit = Math.min(Math.max(opts?.limit ?? 1_000, 1), 10_000);
+    const sinceMs = opts?.sinceMs;
+    await this.flush();
+    const out: DeferralPatternProvenanceObservation[] = [];
+    let files: string[];
+    try {
+      files = (await fsp.readdir(this.dir))
+        .filter((f) => /^\d{4}-\d{2}-\d{2}\.jsonl$/.test(f))
+        .sort()
+        .reverse();
+    } catch {
+      return [];
+    }
+    for (const f of files) {
+      if (out.length >= limit) break;
+      let content: string;
+      try {
+        content = await fsp.readFile(path.join(this.dir, f), 'utf-8');
+      } catch {
+        continue;
+      }
+      for (const line of content.split('\n').filter(Boolean).reverse()) {
+        if (out.length >= limit) break;
+        try {
+          const row = JSON.parse(line) as ProvenanceRow;
+          if (row.kind !== 'decision' || row.decisionPoint !== 'messaging-tone-gate') continue;
+          const observedAt = Date.parse(row.ts);
+          if (!Number.isFinite(observedAt) || (sinceMs !== undefined && observedAt < sinceMs)) continue;
+          const context = row.contextFull;
+          if (!context || typeof context !== 'object' || Array.isArray(context)) continue;
+          const c = context as Record<string, unknown>;
+          const candidate = c.candidate;
+          if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) continue;
+          const candidateSha256 = (candidate as Record<string, unknown>).sha256;
+          if (
+            typeof c.deferralShapeDetected !== 'boolean' ||
+            typeof candidateSha256 !== 'string' ||
+            !/^[0-9a-f]{64}$/i.test(candidateSha256)
+          ) {
+            continue;
+          }
+          out.push({
+            observedAt,
+            deferralShapeDetected: c.deferralShapeDetected,
+            candidateSha256: candidateSha256.toLowerCase(),
+          });
+        } catch {
+          /* @silent-fallback-ok — internal observability projection skips torn rows */
         }
       }
     }

--- a/src/core/JudgmentProvenanceLog.ts
+++ b/src/core/JudgmentProvenanceLog.ts
@@ -529,6 +529,7 @@ export class JudgmentProvenanceLog {
         .sort()
         .reverse();
     } catch {
+      /* @silent-fallback-ok — absent provenance storage means no observations. */
       return [];
     }
     for (const f of files) {
@@ -537,6 +538,7 @@ export class JudgmentProvenanceLog {
       try {
         content = await fsp.readFile(path.join(this.dir, f), 'utf-8');
       } catch {
+        /* @silent-fallback-ok — internal observability projection skips unreadable days. */
         continue;
       }
       for (const line of content.split('\n').filter(Boolean).reverse()) {

--- a/src/monitoring/DeferralPatternSentinel.ts
+++ b/src/monitoring/DeferralPatternSentinel.ts
@@ -1,0 +1,232 @@
+/**
+ * DeferralPatternSentinel — signal-only accumulation over the canonical
+ * premature-deferral recognizer's EXISTING tone-decision provenance rows.
+ *
+ * Increment 1 is deliberately pure/injected and NOT boot-wired. It owns no
+ * timer, store, route, or recognizer. The caller supplies the already-persisted
+ * content-free observations produced by `detectDeferralShape()` through
+ * `buildToneDecisionContext()`; this sentinel only asks whether enough recent,
+ * distinct positive observations form a pattern worth one deduped Attention
+ * item.
+ *
+ * The observation projection itself belongs to JudgmentProvenanceLog so callers
+ * cannot accidentally grow a second reader over the canonical JSONL store.
+ */
+
+export interface DeferralPatternObservation {
+  /** Timestamp of the existing tone-decision provenance row. */
+  observedAt: number;
+  /** Existing content-free recognizer output. */
+  deferralShapeDetected: boolean;
+  /** Existing candidate sha256; used only to avoid counting replayed rows twice. */
+  candidateSha256: string;
+}
+
+export interface DeferralPatternAttention {
+  title: string;
+  body: string;
+  priority: 'high';
+  dedupKey: string;
+  source: 'deferral-pattern-sentinel';
+}
+
+export interface DeferralPatternSentinelConfig {
+  enabled?: boolean;
+  dryRun?: boolean;
+  /** Distinct positive observations required to call the accumulation a pattern. */
+  threshold?: number;
+  /** Only observations this recent participate. */
+  windowMs?: number;
+}
+
+export interface DeferralPatternSentinelResolvedConfig {
+  enabled: boolean;
+  dryRun: boolean;
+  threshold: number;
+  windowMs: number;
+}
+
+export interface DeferralPatternSentinelDeps {
+  enabled: () => boolean;
+  dryRun: () => boolean;
+  threshold: () => number;
+  windowMs: () => number;
+  /** Reads the existing provenance surface. This sentinel creates no parallel store. */
+  getObservations: () => DeferralPatternObservation[];
+  raiseAttention: (item: DeferralPatternAttention) => void;
+  audit?: (event: string, detail: Record<string, unknown>) => void;
+}
+
+export interface DeferralPatternTickResult {
+  ran: boolean;
+  patternDetected: boolean;
+  distinctDeferrals: number;
+  raised: boolean;
+}
+
+export interface DeferralPatternSentinelStatus {
+  enabled: boolean;
+  dryRun: boolean;
+  threshold: number;
+  windowMs: number;
+  lastTickAt: string | null;
+  distinctDeferrals: number;
+  patternDetected: boolean;
+  counters: { ticks: number; raises: number; wouldRaise: number; errors: number };
+}
+
+const DEFAULT_THRESHOLD = 3;
+const DEFAULT_WINDOW_MS = 7 * 24 * 60 * 60_000;
+const DEDUP_KEY = 'premature-deferral-pattern';
+
+export function resolveDeferralPatternSentinelConfig(
+  block: DeferralPatternSentinelConfig | undefined,
+  resolveEnabled: (explicit: boolean | undefined) => boolean,
+): DeferralPatternSentinelResolvedConfig {
+  const b = block ?? {};
+  return {
+    enabled: resolveEnabled(typeof b.enabled === 'boolean' ? b.enabled : undefined),
+    dryRun: typeof b.dryRun === 'boolean' ? b.dryRun : true,
+    threshold: positiveIntegerOr(b.threshold, DEFAULT_THRESHOLD),
+    windowMs: positiveIntegerOr(b.windowMs, DEFAULT_WINDOW_MS),
+  };
+}
+
+export function guardStatusFor(
+  cfg: DeferralPatternSentinelResolvedConfig,
+): 'dark' | 'dry-run' | 'live' {
+  return cfg.enabled ? (cfg.dryRun ? 'dry-run' : 'live') : 'dark';
+}
+
+/**
+ * Count distinct positive observations inside [now-windowMs, now].
+ * Future-dated, malformed, negative, and replayed rows do not contribute.
+ */
+export function countRecentDistinctDeferrals(
+  observations: DeferralPatternObservation[],
+  now: number,
+  windowMs: number,
+): number {
+  const floor = now - Math.max(1, windowMs);
+  const hashes = new Set<string>();
+  for (const row of observations) {
+    if (
+      row.deferralShapeDetected !== true ||
+      !Number.isFinite(row.observedAt) ||
+      row.observedAt < floor ||
+      row.observedAt > now ||
+      !/^[0-9a-f]{64}$/i.test(row.candidateSha256)
+    ) {
+      continue;
+    }
+    hashes.add(row.candidateSha256.toLowerCase());
+  }
+  return hashes.size;
+}
+
+export class DeferralPatternSentinel {
+  private ticks = 0;
+  private raises = 0;
+  private wouldRaise = 0;
+  private errors = 0;
+  private lastTickAtMs = 0;
+  private lastDistinctDeferrals = 0;
+  private lastPatternDetected = false;
+
+  constructor(
+    private readonly deps: DeferralPatternSentinelDeps,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  tick(): DeferralPatternTickResult {
+    if (!this.deps.enabled()) {
+      return { ran: false, patternDetected: false, distinctDeferrals: 0, raised: false };
+    }
+
+    this.ticks += 1;
+    this.lastTickAtMs = this.now();
+    try {
+      const threshold = positiveIntegerOr(this.deps.threshold(), DEFAULT_THRESHOLD);
+      const windowMs = positiveIntegerOr(this.deps.windowMs(), DEFAULT_WINDOW_MS);
+      const distinctDeferrals = countRecentDistinctDeferrals(
+        this.deps.getObservations(),
+        this.lastTickAtMs,
+        windowMs,
+      );
+      const patternDetected = distinctDeferrals >= threshold;
+      this.lastDistinctDeferrals = distinctDeferrals;
+      this.lastPatternDetected = patternDetected;
+
+      if (!patternDetected) {
+        this.audit('no-pattern', { distinctDeferrals, threshold, windowMs });
+        return { ran: true, patternDetected: false, distinctDeferrals, raised: false };
+      }
+      if (this.deps.dryRun()) {
+        this.wouldRaise += 1;
+        this.audit('would-raise', { distinctDeferrals, threshold, windowMs });
+        return { ran: true, patternDetected: true, distinctDeferrals, raised: false };
+      }
+
+      this.deps.raiseAttention(buildAttention(distinctDeferrals, windowMs));
+      this.raises += 1;
+      this.audit('raised', { distinctDeferrals, threshold, windowMs });
+      return { ran: true, patternDetected: true, distinctDeferrals, raised: true };
+    } catch (err) {
+      this.errors += 1;
+      this.lastPatternDetected = false;
+      this.audit('tick-error', { error: err instanceof Error ? err.message : String(err) });
+      return { ran: true, patternDetected: false, distinctDeferrals: 0, raised: false };
+    }
+  }
+
+  status(): DeferralPatternSentinelStatus {
+    return {
+      enabled: this.deps.enabled(),
+      dryRun: this.deps.dryRun(),
+      threshold: positiveIntegerOr(this.deps.threshold(), DEFAULT_THRESHOLD),
+      windowMs: positiveIntegerOr(this.deps.windowMs(), DEFAULT_WINDOW_MS),
+      lastTickAt: this.lastTickAtMs ? new Date(this.lastTickAtMs).toISOString() : null,
+      distinctDeferrals: this.lastDistinctDeferrals,
+      patternDetected: this.lastPatternDetected,
+      counters: {
+        ticks: this.ticks,
+        raises: this.raises,
+        wouldRaise: this.wouldRaise,
+        errors: this.errors,
+      },
+    };
+  }
+
+  private audit(event: string, detail: Record<string, unknown>): void {
+    try {
+      this.deps.audit?.(event, detail);
+    } catch {
+      /* @silent-fallback-ok — observability must never break the sentinel */
+    }
+  }
+}
+
+export function buildAttention(
+  distinctDeferrals: number,
+  windowMs: number,
+): DeferralPatternAttention {
+  const days = Math.max(1, Math.ceil(windowMs / (24 * 60 * 60_000)));
+  return {
+    title: 'Repeated operational work was deferred to the user',
+    body:
+      `${distinctDeferrals} distinct outbound messages in the last ${days} days matched the ` +
+      `premature-deferral shape. This is a pattern signal, not a verdict on any one message. ` +
+      `Review whether available self-unblock routes were exhausted before asking the user to act.`,
+    priority: 'high',
+    dedupKey: DEDUP_KEY,
+    source: 'deferral-pattern-sentinel',
+  };
+}
+
+function positiveIntegerOr(value: number | undefined, fallback: number): number {
+  return Number.isInteger(value) && (value ?? 0) > 0 ? value! : fallback;
+}
+
+export const DEFERRAL_PATTERN_DEDUP_KEY = DEDUP_KEY;
+export const DEFERRAL_PATTERN_DEFAULT_THRESHOLD = DEFAULT_THRESHOLD;
+export const DEFERRAL_PATTERN_DEFAULT_WINDOW_MS = DEFAULT_WINDOW_MS;

--- a/src/monitoring/guardManifest.ts
+++ b/src/monitoring/guardManifest.ts
@@ -1097,6 +1097,7 @@ export interface NotAGuardEntry {
 }
 
 export const NOT_A_GUARD: readonly NotAGuardEntry[] = [
+  { component: 'DeferralPatternSentinel', reason: 'Increment-1 core only: pure injected-deps detector over the existing judgment-provenance store; NOT boot-constructed and registers no runtime getter yet, so it is absent from the live /guards inventory. It moves to GUARD_MANIFEST when a later increment wires it at boot.' },
   { component: 'rawTextRequestDetector', reason: 'Pure stateless predicate (high-precision pattern match) feeding the observe-only ask-for-access signal in checkOutboundMessage; no enabled flag, no runtime getter, takes no protective action — a detector that produces a signal, never a guard with posture.' },
   { component: 'GuardPostureTripwire', reason: 'The boot-transition detector OVER the guard inventory — meta-layer, not a guard itself; always-on, no enabled flag.' },
   { component: 'GuardRegistry', reason: 'Infrastructure of this feature: the runtime-getter registry the inventory reads; not a guard.' },

--- a/tests/unit/DeferralPatternSentinel.test.ts
+++ b/tests/unit/DeferralPatternSentinel.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFERRAL_PATTERN_DEDUP_KEY,
+  DeferralPatternSentinel,
+  buildAttention,
+  countRecentDistinctDeferrals,
+  guardStatusFor,
+  resolveDeferralPatternSentinelConfig,
+  type DeferralPatternAttention,
+  type DeferralPatternObservation,
+  type DeferralPatternSentinelDeps,
+} from '../../src/monitoring/DeferralPatternSentinel.js';
+import { buildToneDecisionContext, type ToneReviewContext } from '../../src/core/MessagingToneGate.js';
+
+const NOW = Date.parse('2026-07-22T20:00:00.000Z');
+const DAY = 24 * 60 * 60_000;
+const hash = (n: number): string => n.toString(16).padStart(64, '0');
+const positive = (n: number, at = NOW): DeferralPatternObservation => ({
+  observedAt: at,
+  deferralShapeDetected: true,
+  candidateSha256: hash(n),
+});
+
+function harness(opts: {
+  enabled?: boolean;
+  dryRun?: boolean;
+  threshold?: number;
+  windowMs?: number;
+  observations?: DeferralPatternObservation[];
+}) {
+  const raised: DeferralPatternAttention[] = [];
+  const audits: Array<{ event: string; detail: Record<string, unknown> }> = [];
+  const deps: DeferralPatternSentinelDeps = {
+    enabled: () => opts.enabled ?? true,
+    dryRun: () => opts.dryRun ?? false,
+    threshold: () => opts.threshold ?? 3,
+    windowMs: () => opts.windowMs ?? 7 * DAY,
+    getObservations: () => opts.observations ?? [],
+    raiseAttention: (item) => raised.push(item),
+    audit: (event, detail) => audits.push({ event, detail }),
+  };
+  return { sentinel: new DeferralPatternSentinel(deps, () => NOW), raised, audits };
+}
+
+describe('DeferralPatternSentinel', () => {
+  it('is dark as a strict no-op: it does not read the existing provenance surface', () => {
+    const getObservations = vi.fn(() => [positive(1), positive(2), positive(3)]);
+    const raiseAttention = vi.fn();
+    const sentinel = new DeferralPatternSentinel({
+      enabled: () => false,
+      dryRun: () => false,
+      threshold: () => 3,
+      windowMs: () => 7 * DAY,
+      getObservations,
+      raiseAttention,
+    });
+    expect(sentinel.tick()).toEqual({
+      ran: false, patternDetected: false, distinctDeferrals: 0, raised: false,
+    });
+    expect(getObservations).not.toHaveBeenCalled();
+    expect(raiseAttention).not.toHaveBeenCalled();
+  });
+
+  it('does not surface below the threshold (N-1 boundary)', () => {
+    const { sentinel, raised, audits } = harness({ observations: [positive(1), positive(2)] });
+    expect(sentinel.tick()).toEqual({
+      ran: true, patternDetected: false, distinctDeferrals: 2, raised: false,
+    });
+    expect(raised).toEqual([]);
+    expect(audits.at(-1)?.event).toBe('no-pattern');
+  });
+
+  it('surfaces exactly at the threshold (N boundary) as ONE stable deduped Attention item', () => {
+    const { sentinel, raised } = harness({
+      observations: [positive(1), positive(2), positive(3)],
+    });
+    expect(sentinel.tick()).toEqual({
+      ran: true, patternDetected: true, distinctDeferrals: 3, raised: true,
+    });
+    expect(raised).toHaveLength(1);
+    expect(raised[0]).toMatchObject({
+      dedupKey: DEFERRAL_PATTERN_DEDUP_KEY,
+      priority: 'high',
+      source: 'deferral-pattern-sentinel',
+    });
+    expect(raised[0].body).toMatch(/pattern signal, not a verdict/i);
+  });
+
+  it('consumes the existing tone-provenance recognizer result instead of re-recognizing text', () => {
+    const messages = [
+      'Can you restart Codey on the laptop for me?',
+      "You'll need to install the key on the laptop.",
+      'Grant me SSH access and I can take it from there.',
+    ];
+    const observations = messages.map((message) => {
+      const context = buildToneDecisionContext(message, {} as ToneReviewContext);
+      const candidate = context.candidate as { sha256: string };
+      return {
+        observedAt: NOW,
+        deferralShapeDetected: context.deferralShapeDetected === true,
+        candidateSha256: candidate.sha256,
+      };
+    });
+    const { sentinel, raised } = harness({ observations });
+    expect(sentinel.tick().patternDetected).toBe(true);
+    expect(raised).toHaveLength(1);
+  });
+
+  it('dryRun-first computes and audits would-raise without creating Attention', () => {
+    const { sentinel, raised, audits } = harness({
+      dryRun: true,
+      observations: [positive(1), positive(2), positive(3)],
+    });
+    expect(sentinel.tick().patternDetected).toBe(true);
+    expect(sentinel.tick().raised).toBe(false);
+    expect(raised).toEqual([]);
+    expect(audits.filter((a) => a.event === 'would-raise')).toHaveLength(2);
+    expect(sentinel.status().counters).toEqual({
+      ticks: 2, raises: 0, wouldRaise: 2, errors: 0,
+    });
+  });
+
+  it('deduplicates replayed provenance rows by the existing candidate sha256', () => {
+    const { sentinel, raised } = harness({
+      observations: [positive(1), positive(1), positive(2), positive(2)],
+    });
+    expect(sentinel.tick().distinctDeferrals).toBe(2);
+    expect(raised).toEqual([]);
+  });
+
+  it('fails toward silence when the injected read surface throws', () => {
+    const sentinel = new DeferralPatternSentinel({
+      enabled: () => true,
+      dryRun: () => false,
+      threshold: () => 3,
+      windowMs: () => 7 * DAY,
+      getObservations: () => { throw new Error('provenance unavailable'); },
+      raiseAttention: () => { throw new Error('must not raise'); },
+    }, () => NOW);
+    expect(sentinel.tick()).toEqual({
+      ran: true, patternDetected: false, distinctDeferrals: 0, raised: false,
+    });
+    expect(sentinel.status().counters.errors).toBe(1);
+  });
+
+  it('contains a throwing audit sink and still raises the signal', () => {
+    const sentinel = new DeferralPatternSentinel({
+      enabled: () => true,
+      dryRun: () => false,
+      threshold: () => 1,
+      windowMs: () => DAY,
+      getObservations: () => [positive(1)],
+      raiseAttention: () => {},
+      audit: () => { throw new Error('audit down'); },
+    }, () => NOW);
+    expect(() => sentinel.tick()).not.toThrow();
+    expect(sentinel.status().counters.raises).toBe(1);
+  });
+});
+
+describe('countRecentDistinctDeferrals boundaries', () => {
+  it('includes the exact lower window edge and current instant', () => {
+    expect(countRecentDistinctDeferrals(
+      [positive(1, NOW - 7 * DAY), positive(2, NOW)],
+      NOW,
+      7 * DAY,
+    )).toBe(2);
+  });
+
+  it('excludes one millisecond stale, future, negative, and malformed rows', () => {
+    expect(countRecentDistinctDeferrals([
+      positive(1, NOW - 7 * DAY - 1),
+      positive(2, NOW + 1),
+      { ...positive(3), deferralShapeDetected: false },
+      { ...positive(4), candidateSha256: 'not-a-hash' },
+    ], NOW, 7 * DAY)).toBe(0);
+  });
+});
+
+describe('config, posture, status, and attention rendering', () => {
+  it('is dry-run-first and delegates omitted enabled to the injected dark gate', () => {
+    expect(resolveDeferralPatternSentinelConfig(undefined, (explicit) => explicit ?? false))
+      .toEqual({ enabled: false, dryRun: true, threshold: 3, windowMs: 7 * DAY });
+  });
+
+  it('honors explicit values and normalizes unsafe numeric values to bounded defaults', () => {
+    expect(resolveDeferralPatternSentinelConfig(
+      { enabled: true, dryRun: false, threshold: 4, windowMs: 2 * DAY },
+      (explicit) => explicit ?? false,
+    )).toEqual({ enabled: true, dryRun: false, threshold: 4, windowMs: 2 * DAY });
+    expect(resolveDeferralPatternSentinelConfig(
+      { threshold: 0, windowMs: Number.NaN },
+      () => true,
+    )).toMatchObject({ threshold: 3, windowMs: 7 * DAY });
+  });
+
+  it('grades dark, dry-run, and live postures', () => {
+    const base = { threshold: 3, windowMs: 7 * DAY };
+    expect(guardStatusFor({ ...base, enabled: false, dryRun: true })).toBe('dark');
+    expect(guardStatusFor({ ...base, enabled: true, dryRun: true })).toBe('dry-run');
+    expect(guardStatusFor({ ...base, enabled: true, dryRun: false })).toBe('live');
+  });
+
+  it('status exposes content-free aggregate state only', () => {
+    const { sentinel } = harness({ dryRun: true, observations: [positive(1), positive(2), positive(3)] });
+    sentinel.tick();
+    expect(sentinel.status()).toMatchObject({
+      enabled: true,
+      dryRun: true,
+      threshold: 3,
+      windowMs: 7 * DAY,
+      distinctDeferrals: 3,
+      patternDetected: true,
+      counters: { ticks: 1, raises: 0, wouldRaise: 1, errors: 0 },
+    });
+    expect(sentinel.status().lastTickAt).toBe('2026-07-22T20:00:00.000Z');
+  });
+
+  it('buildAttention uses the same stable dedup key across counts', () => {
+    expect(buildAttention(3, 7 * DAY).dedupKey).toBe(buildAttention(9, 7 * DAY).dedupKey);
+  });
+});

--- a/tests/unit/JudgmentProvenanceLog.test.ts
+++ b/tests/unit/JudgmentProvenanceLog.test.ts
@@ -112,6 +112,51 @@ describe('redaction (write-time scrub; machine-local full context)', () => {
   });
 });
 
+describe('ACT-896 deferral-pattern internal projection', () => {
+  it('reads content-free observations from canonical tone provenance only', async () => {
+    const log = makeLog();
+    log.recordDecision(decisionInput({
+      decisionPoint: 'messaging-tone-gate',
+      context: {
+        candidate: { sha256: 'a'.repeat(64), bytes: 20, chars: 20 },
+        deferralShapeDetected: true,
+      },
+    }));
+    log.recordDecision(decisionInput({
+      decisionPoint: 'some-other-gate',
+      context: {
+        candidate: { sha256: 'b'.repeat(64) },
+        deferralShapeDetected: true,
+      },
+    }));
+
+    expect(await log.readDeferralPatternObservations()).toEqual([{
+      observedAt: T0,
+      deferralShapeDetected: true,
+      candidateSha256: 'a'.repeat(64),
+    }]);
+  });
+
+  it('skips malformed/truncated contexts and honors the exact since boundary', async () => {
+    const log = makeLog();
+    log.recordDecision(decisionInput({
+      decisionPoint: 'messaging-tone-gate',
+      context: { candidate: { sha256: 'c'.repeat(64) }, deferralShapeDetected: false },
+    }));
+    log.recordDecision(decisionInput({
+      decisionPoint: 'messaging-tone-gate',
+      context: { candidate: { sha256: 'not-a-hash' }, deferralShapeDetected: true },
+    }));
+
+    expect(await log.readDeferralPatternObservations({ sinceMs: T0 })).toEqual([{
+      observedAt: T0,
+      deferralShapeDetected: false,
+      candidateSha256: 'c'.repeat(64),
+    }]);
+    expect(await log.readDeferralPatternObservations({ sinceMs: T0 + 1 })).toEqual([]);
+  });
+});
+
 describe('64KB per-row clamp', () => {
   it('a ~100KB context is truncated + flagged, and the row on disk stays under the clamp', async () => {
     const log = makeLog();

--- a/upgrades/next/act-896-deferral-pattern-sentinel.md
+++ b/upgrades/next/act-896-deferral-pattern-sentinel.md
@@ -1,0 +1,19 @@
+<!-- internal-only -->
+
+# ACT-896 — Deferral pattern sentinel, increment 1
+
+## What Changed
+
+Added the pure, injected core of a signal-only sentinel that consumes the canonical
+premature-deferral recognizer's existing content-free tone-provenance observations.
+At the configured recent-distinct threshold it produces one stable, deduped
+Attention input. It is dark by default, dry-run first, fails toward silence, owns
+no parallel recognizer or storage, and is intentionally not boot-wired in this
+increment.
+
+## Evidence
+
+Unit coverage locks dark/no-read, below/exact threshold, canonical-recognizer
+consumption, replay dedupe, time-window edges, malformed/negative/future exclusion,
+dry-run/live behavior, fail-toward-silence, audit containment, config posture,
+content-free status, and stable Attention dedupe.

--- a/upgrades/next/act-896-deferral-pattern-sentinel.md
+++ b/upgrades/next/act-896-deferral-pattern-sentinel.md
@@ -1,5 +1,3 @@
-<!-- internal-only -->
-
 # ACT-896 — Deferral pattern sentinel, increment 1
 
 ## What Changed
@@ -10,6 +8,20 @@ At the configured recent-distinct threshold it produces one stable, deduped
 Attention input. It is dark by default, dry-run first, fails toward silence, owns
 no parallel recognizer or storage, and is intentionally not boot-wired in this
 increment.
+
+## What to Tell Your User
+
+Instar now has the inert core needed to notice when several recent messages share
+the same premature “hand this back to the user” pattern. This increment does not
+send an alert yet: it starts dark, defaults to dry-run, and has no boot wiring.
+When a later increment connects it to Attention, repeated matches will collapse
+into one review item rather than creating notification noise.
+
+## Summary of New Capabilities
+
+- Content-free aggregation over the existing deferral recognizer provenance.
+- Stable dedupe identity for one eventual Attention item.
+- Dark, dry-run-first posture with no new matcher, ledger, timer, or boot path.
 
 ## Evidence
 

--- a/upgrades/side-effects/act-896-deferral-pattern-sentinel.md
+++ b/upgrades/side-effects/act-896-deferral-pattern-sentinel.md
@@ -1,0 +1,171 @@
+# Side-Effects Review — ACT-896 deferral pattern sentinel
+
+**Version / slug:** `act-896-deferral-pattern-sentinel`
+**Date:** `2026-07-22`
+**Author:** `Instar-codey Stream 2`
+**Second-pass reviewer:** `Codex independent reviewer (act896_second_pass)`
+
+## Summary of the change
+
+`src/monitoring/DeferralPatternSentinel.ts` adds increment 1 of a pure, injected,
+dark-by-default and dry-run-first pattern sentinel. It consumes the canonical
+`detectDeferralShape()` result already stored as `deferralShapeDetected` in
+tone-decision provenance, counts recent distinct positive candidate identities,
+and produces one stable deduped Attention input at threshold. It adds no matcher,
+store, route, timer, or boot wiring. `JudgmentProvenanceLog` gains a narrow
+machine-local typed projection over those existing rows; no full context or text
+leaves that store.
+
+## Decision-point inventory
+
+- `DeferralPatternSentinel.tick()` — add — decides whether accumulated,
+  identity-only observations constitute a pattern signal; it never blocks,
+  rewrites, delays, or otherwise controls an outbound message.
+- Dry-run/live emission branch — add — dry-run audits only; live calls the
+  injected Attention sink with a stable idempotency key.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. A false positive can create an
+Attention item only after the live posture is deliberately enabled; increment 1 is
+not wired and the default is dry-run.
+
+---
+
+## 2. Under-block
+
+The sentinel misses semantically equivalent deferrals the canonical recognizer
+does not detect, observations outside the configured window, and repeated
+deferrals with byte-identical candidate hashes. The last exclusion is intentional:
+replayed provenance rows must not manufacture a pattern.
+
+---
+
+## 3. Level-of-abstraction fit
+
+This is an aggregate signal producer above the existing low-level recognizer and
+existing provenance store. It does not duplicate either. Its output feeds the
+existing Attention authority/funnel through an injected callback in a later wiring
+increment.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The deterministic threshold creates an operator-visible signal only. It has no
+authority over messaging or agent action.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No static heuristic is added at a competing-signals decision point. The threshold
+only determines when accumulated observations are worth surfacing; it does not
+judge whether any individual deferral was wrong and the Attention body says so.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none; the canonical recognizer remains the sole matcher.
+- **Double-fire:** the stable `premature-deferral-pattern` key lets the existing
+  Attention store coalesce repeated live ticks into one item.
+- **Races:** increment 1 owns no mutable shared state or timer; observations arrive
+  as an injected snapshot and are deduped locally by candidate hash.
+- **Feedback loops:** Attention output is not fed back into tone provenance.
+
+---
+
+## 6. External surfaces
+
+No external surface is boot-wired in increment 1. The only durable data it is
+designed to read already exists in tone-decision provenance. The status snapshot
+contains aggregate counts and timestamps only, never message text or hashes.
+There are no operator-facing actions.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+Machine-local by design for increment 1: it reads each machine's existing,
+machine-local tone provenance through a new content-free internal projection.
+A later wiring increment must choose a one-voice owner for Attention emission;
+increment 1 emits no notice, strands no new durable state, and generates no URL.
+
+---
+
+## 8. Rollback cost
+
+Revert the module, tests, and internal release fragment. There is no migration,
+new persistent state, live registration, or agent-state repair.
+
+---
+
+## Conclusion
+
+The design closes the requested increment without widening authority: canonical
+recognition and storage stay canonical, aggregation is pure and content-free,
+and every active surface remains injected and inert until a separately reviewed
+boot-wiring increment.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Codex independent reviewer (`act896_second_pass`)
+**Independent read of the artifact:** concur
+
+The reviewer confirmed signal-only authority, pure/injected construction, dark
+default, dry-run-first behavior, boundary coverage, and absence of boot wiring.
+It asked that the artifact state two seams precisely: repeated live callback
+invocations rely on the existing Attention funnel for durable one-item
+idempotency, and the provenance store needed a typed internal projection. Both
+are now explicit, and the latter was added to `JudgmentProvenanceLog`.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/DeferralPatternSentinel.test.ts`
+- `tests/unit/deferral-floor.test.ts`
+- `tests/unit/tone-gate-deferral-provenance.test.ts`
+- `tests/unit/JudgmentProvenanceLog.test.ts` (canonical-store projection)
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+**`defectClass`:** `unbounded-self-action`
+
+This sentinel's possible self-action is a request to create one deduped
+notification. The control-loop
+edge is `existing provenance snapshot → threshold signal → Attention idempotency
+key`. Repeated live ticks may call the injected sink, so the one-item steady-state
+bound is conditional on the later adapter preserving that stable key through the
+existing Attention idempotency funnel. Dark and dry-run are settling brakes, and
+increment 1 has no timer or boot edge at all. The ratchet is
+`tests/unit/self-action-convergence.test.ts`.
+
+- **`guardEvidence.howCaught`:** unit tests prove strict dark no-read, dry-run
+  no-emission, and a stable dedupe key across counts/ticks; the existing Attention
+  funnel provides durable idempotency when wired.
+- **`structuralGuard`:** canonical recognizer import boundary plus injected
+  `raiseAttention` and stable `DEFERRAL_PATTERN_DEDUP_KEY`.
+- **`classClosed`:** yes for increment 1's shipped posture because there is no
+  autonomous trigger or boot edge. Live class closure must be re-proven by the
+  wiring increment against the real Attention idempotency funnel.

--- a/upgrades/side-effects/act-896-deferral-pattern-sentinel.md
+++ b/upgrades/side-effects/act-896-deferral-pattern-sentinel.md
@@ -145,6 +145,8 @@ are now explicit, and the latter was added to `JudgmentProvenanceLog`.
 - `tests/unit/deferral-floor.test.ts`
 - `tests/unit/tone-gate-deferral-provenance.test.ts`
 - `tests/unit/JudgmentProvenanceLog.test.ts` (canonical-store projection)
+- `tests/unit/no-silent-fallbacks.test.ts` (absent/unreadable observability files
+  are explicitly classified and do not raise the repository fallback baseline)
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a signal-only sentinel for repeated judgment deferrals. It reads the existing canonical judgment-provenance log, detects a configurable number of matching deferrals inside a time window, and emits a stable, deduplicated observation for downstream monitoring.

## ELI16

Today, one cautious deferral can look exactly like a recurring behavior pattern unless someone manually compares many records. This change adds a smoke alarm: it notices when the same kind of “defer this decision” event keeps happening close together and raises one structured signal. It does not make decisions, change behavior, or start any automatic repair. It is deliberately dark and unwired in production so we can validate the signal before deciding whether it should influence anything.

## Safety

- No production wiring or automatic action.
- Reads through the canonical typed provenance projection; no parallel reader or store.
- Content-free observations only.
- Stable deduplication key prevents repeated alerts for the same pattern.
- Dry-run-first posture, with an explicit guard-manifest entry.

## Validation

- 45 focused unit tests passed.
- Guard-manifest suite passed.
- Typecheck and lint passed.
- Repository pre-push gate passed; affected-test enumeration timed out and correctly deferred the full shard authority to CI.

## Rollback

Revert this PR. Because the sentinel is not wired into production behavior, rollback has no data migration or runtime-state implications.
