### PR TITLE
Close login-loss swap verification tiers

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T08-35-50-493Z-login-loss-trigger-test-closure.json
+++ b/.instar/instar-dev-decisions/2026-07-23T08-35-50-493Z-login-loss-trigger-test-closure.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-23T08:35:50.493Z",
+  "slug": "login-loss-trigger-test-closure",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 4,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/login-loss-trigger-test-closure.md
+++ b/docs/eli16/login-loss-trigger-test-closure.md
@@ -1,0 +1,31 @@
+# Login-loss recovery: proving the safety posture through the real route
+
+The login-loss recovery trigger already exists on current `main`. When a live
+conversation's local account login disappears, Instar can feed that condition
+into the same careful account-swap path used for quota pressure. It does not
+invent a second detector or a second restart mechanism. It uses the account
+identity attached to the conversation's real configuration home, the existing
+anti-thrash brakes, the existing fresh-target selection, and the existing
+last-moment revalidation before a conversation can restart.
+
+This change closes the missing verification layer. The HTTP integration test
+now proves that an account with plenty of quota still becomes a candidate when
+its login is explicitly marked as requiring the owner to log in again. It also
+proves that the default posture records the intended move but calls no swap
+executor. A separate promoted case proves that turning simulation off sends
+the same intent through the already-established swap callback.
+
+The end-to-end test boots the real route, subscription pool, anti-thrash
+engine, ledger, and monitor together. It first observes the simulation-only
+posture over HTTP and verifies no move happens. It then deliberately promotes
+the trigger, waits through the normal dwell brake rather than bypassing it, and
+proves that the exact login-loss intent is dispatched to the established swap
+callback with the fresh healthy account selected.
+
+When the braked login-loss pipeline is wired, the status route also reports
+whether recovery is enabled and whether it is still simulation-only. Without
+that prerequisite brake pipeline, the trigger does not run and no rollout
+posture is advertised. This is observability, not a new control: it does not
+change a session, relax a guard, or create another source of authority.
+Ordinary machines remain dark, development machines remain simulation-first,
+and uncertainty still means no action.

--- a/src/core/ProactiveSwapMonitor.ts
+++ b/src/core/ProactiveSwapMonitor.ts
@@ -252,6 +252,7 @@ export class ProactiveSwapMonitor {
     running: boolean;
     lastResult: ProactiveSwapTickResult | null;
     antiThrash?: { enabled: boolean; dryRun: boolean };
+    loginLoss?: { enabled: boolean; dryRun: boolean };
     brakes?: Record<string, unknown>;
     deferrals?: { active: number; sessions: string[] };
   } {
@@ -269,6 +270,9 @@ export class ProactiveSwapMonitor {
     return {
       ...base,
       ...(knobs ? { antiThrash: { enabled: knobs.enabled, dryRun: knobs.dryRun } } : {}),
+      ...(this.cfg.loginLoss
+        ? { loginLoss: { enabled: this.cfg.loginLoss.enabled, dryRun: this.cfg.loginLoss.dryRun } }
+        : {}),
       brakes: this.cfg.antiThrash.engine.status(this.now()),
       deferrals: { active: this.deferrals.size, sessions: [...this.deferrals.keys()] },
     };

--- a/tests/e2e/subscription-proactive-swap-lifecycle.test.ts
+++ b/tests/e2e/subscription-proactive-swap-lifecycle.test.ts
@@ -16,6 +16,8 @@ import { createRoutes } from '../../src/server/routes.js';
 import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
 import { ProactiveSwapMonitor } from '../../src/core/ProactiveSwapMonitor.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { SwapAntiThrashEngine, resolveAntiThrashKnobs, retentionBoundMs } from '../../src/core/SwapAntiThrash.js';
+import { SwapLedger } from '../../src/core/SwapLedger.js';
 
 interface TestServer { url: string; close: () => Promise<void>; }
 function boot(ctx: any): Promise<TestServer> {
@@ -80,5 +82,86 @@ describe('/subscription-pool/proactive-swap — E2E feature-alive', () => {
     expect(body.enabled).toBe(true);
     expect(body.swapped).toEqual(['echo-subscription-auth-standard']);
     expect(swaps).toEqual([{ sessionName: 'echo-subscription-auth-standard', exhaustedAccountId: 'adriana' }]);
+  });
+
+  it('LOGIN LOSS: the HTTP check keeps dry-run inert, then the promoted trigger is alive end-to-end', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'login-loss-e2e-'));
+    const pool = new SubscriptionPool({ stateDir: dir });
+    let now = Date.parse('2026-07-23T06:00:00Z');
+    pool.add({ id: 'lost', nickname: 'Lost login', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'lost'), email: 'lost@example.com' });
+    pool.add({ id: 'fresh', nickname: 'Fresh login', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'fresh'), email: 'fresh@example.com' });
+    pool.update('lost', {
+      identityDrifted: true,
+      identityDrift: {
+        expectedAccountId: 'lost',
+        actualAccountId: 'missing-local-login',
+        slot: path.join(dir, 'lost'),
+        detectedAt: new Date(now - 60_000).toISOString(),
+        lastConfirmedAt: new Date(now - 60_000).toISOString(),
+        repairState: 'owner-relogin-required',
+      },
+      lastQuota: { sevenDay: { utilizationPct: 8, resetsAt: '2026-07-30T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback', measuredAt: new Date(now - 60_000).toISOString() },
+    });
+    pool.update('fresh', {
+      lastQuota: { sevenDay: { utilizationPct: 4, resetsAt: '2026-07-30T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback', measuredAt: new Date(now - 60_000).toISOString() },
+    });
+
+    const knobs = resolveAntiThrashKnobs(
+      { enabled: true, dryRun: false, quotaFreshnessMs: 7_200_000 },
+      { thresholdPct: 80, tickMs: 180_000 },
+    );
+    const ledger = new SwapLedger({
+      filePath: path.join(dir, 'swap-ledger.jsonl'),
+      windowMs: () => retentionBoundMs(knobs),
+      now: () => now,
+    });
+    const engine = new SwapAntiThrashEngine({ ledger, getKnobs: () => knobs, now: () => now });
+    engine.hydrate();
+    const swaps: string[] = [];
+    const loginLoss = { enabled: true, dryRun: true };
+    const monitor = new ProactiveSwapMonitor({
+      listAccounts: () => pool.list(),
+      listRunningSessions: () => [{
+        sessionName: 'interactive-login-loss',
+        accountId: null,
+        loginLossAccountId: 'lost',
+        refreshable: true,
+        startedAt: new Date(now - 60_000).toISOString(),
+      }],
+      resolveDefaultAccountId: async () => null,
+      swap: async ({ sessionName }) => {
+        swaps.push(sessionName);
+        return { swapped: true, toAccountId: 'fresh' };
+      },
+      antiThrash: { engine, getKnobs: () => knobs },
+      loginLoss,
+      now: () => now,
+    });
+    server = await boot({
+      config: { authToken: 't', stateDir: dir, port: 0 },
+      startTime: new Date(),
+      subscriptionPool: pool,
+      proactiveSwapMonitor: monitor,
+    });
+
+    const dryStatus = await fetch(server.url + '/subscription-pool/proactive-swap');
+    expect(await dryStatus.json()).toMatchObject({
+      enabled: true,
+      loginLoss: { enabled: true, dryRun: true },
+    });
+    const dryCheck = await fetch(server.url + '/subscription-pool/proactive-swap/check', { method: 'POST' });
+    expect(await dryCheck.json()).toMatchObject({ swapped: [], considered: 1 });
+    expect(swaps).toEqual([]);
+
+    loginLoss.dryRun = false;
+    // The dry-run row intentionally starts the normal dwell brake. Promotion
+    // does not bypass it; advance beyond dwell while keeping readings fresh.
+    now += knobs.dwellMs + 1;
+    const liveCheck = await fetch(server.url + '/subscription-pool/proactive-swap/check', { method: 'POST' });
+    expect(await liveCheck.json()).toMatchObject({
+      swapped: ['interactive-login-loss'],
+      considered: 1,
+    });
+    expect(swaps).toEqual(['interactive-login-loss']);
   });
 });

--- a/tests/integration/subscription-proactive-swap-route.test.ts
+++ b/tests/integration/subscription-proactive-swap-route.test.ts
@@ -15,6 +15,8 @@ import { createRoutes } from '../../src/server/routes.js';
 import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
 import { ProactiveSwapMonitor } from '../../src/core/ProactiveSwapMonitor.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { SwapAntiThrashEngine, resolveAntiThrashKnobs, retentionBoundMs } from '../../src/core/SwapAntiThrash.js';
+import { SwapLedger } from '../../src/core/SwapLedger.js';
 
 interface TestServer { url: string; close: () => Promise<void>; }
 async function listen(app: express.Express): Promise<TestServer> {
@@ -31,28 +33,67 @@ describe('proactive-swap routes (integration)', () => {
   let dir: string;
   let swapCalls: Array<{ sessionName: string; exhaustedAccountId: string }>;
 
-  function boot(opts: { withMonitor: boolean; defaultAccountId?: string | null }): Promise<void> {
+  function boot(opts: {
+    withMonitor: boolean;
+    defaultAccountId?: string | null;
+    loginLoss?: { enabled: boolean; dryRun: boolean };
+  }): Promise<void> {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'proactive-int-'));
     swapCalls = [];
     const pool = new SubscriptionPool({ stateDir: dir });
     // "hot" is at pressure; "cool" is the sub-threshold alternate.
     pool.add({ id: 'hot', nickname: 'Hot', provider: 'anthropic', framework: 'claude-code', configHome: '/h/hot', email: 'a@x.io' });
     pool.add({ id: 'cool', nickname: 'Cool', provider: 'anthropic', framework: 'claude-code', configHome: '/h/cool', email: 'b@x.io' });
-    pool.update('hot', { lastQuota: { sevenDay: { utilizationPct: 85, resetsAt: '2026-06-10T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback' } });
-    pool.update('cool', { lastQuota: { sevenDay: { utilizationPct: 10, resetsAt: '2026-06-10T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback' } });
+    const now = Date.parse('2026-06-09T12:00:00Z');
+    pool.update('hot', { lastQuota: { sevenDay: { utilizationPct: 85, resetsAt: '2026-06-10T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback', measuredAt: new Date(now - 60_000).toISOString() } });
+    pool.update('cool', { lastQuota: { sevenDay: { utilizationPct: 10, resetsAt: '2026-06-10T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback', measuredAt: new Date(now - 60_000).toISOString() } });
+
+    if (opts.loginLoss) {
+      pool.update('hot', {
+        identityDrifted: true,
+        identityDrift: {
+          expectedAccountId: 'hot',
+          actualAccountId: 'missing-local-login',
+          slot: '/h/hot',
+          detectedAt: new Date(now - 60_000).toISOString(),
+          lastConfirmedAt: new Date(now - 60_000).toISOString(),
+          repairState: 'owner-relogin-required',
+        },
+        // Login loss, not quota, must be the reason this account is selected.
+        lastQuota: { sevenDay: { utilizationPct: 8, resetsAt: '2026-06-10T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback', measuredAt: new Date(now - 60_000).toISOString() },
+      });
+    }
 
     const ctx: any = { config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), subscriptionPool: pool };
     if (opts.withMonitor) {
+      const knobs = resolveAntiThrashKnobs(
+        { enabled: true, dryRun: false },
+        { thresholdPct: 80, tickMs: 180_000 },
+      );
+      const ledger = new SwapLedger({
+        filePath: path.join(dir, 'swap-ledger.jsonl'),
+        windowMs: () => retentionBoundMs(knobs),
+        now: () => now,
+      });
+      const engine = new SwapAntiThrashEngine({ ledger, getKnobs: () => knobs, now: () => now });
+      engine.hydrate();
       ctx.proactiveSwapMonitor = new ProactiveSwapMonitor({
         listAccounts: () => pool.list(),
         // one untagged interactive session running on the default login
-        listRunningSessions: () => [{ sessionName: 'interactive', accountId: null, startedAt: '2026-06-09T11:00:00Z' }],
+        listRunningSessions: () => [{
+          sessionName: 'interactive',
+          accountId: null,
+          ...(opts.loginLoss ? { loginLossAccountId: 'hot', refreshable: true } : {}),
+          startedAt: '2026-06-09T11:00:00Z',
+        }],
         resolveDefaultAccountId: async () => opts.defaultAccountId ?? null,
         swap: async (a) => {
           swapCalls.push({ sessionName: a.sessionName, exhaustedAccountId: a.exhaustedAccountId });
           return { swapped: true, toAccountId: 'cool' };
         },
-        now: () => Date.parse('2026-06-09T12:00:00Z'),
+        now: () => now,
+        antiThrash: { engine, getKnobs: () => knobs },
+        ...(opts.loginLoss ? { loginLoss: opts.loginLoss } : {}),
       });
     }
     const app = express();
@@ -94,6 +135,33 @@ describe('proactive-swap routes (integration)', () => {
     expect(r.status).toBe(200);
     expect(r.body.swapped).toEqual([]);
     expect(swapCalls).toEqual([]);
+  });
+
+  it('login-loss route exposes dry-run posture and records intent without executing a swap', async () => {
+    await boot({
+      withMonitor: true,
+      defaultAccountId: null,
+      loginLoss: { enabled: true, dryRun: true },
+    });
+    const status = await get('/subscription-pool/proactive-swap');
+    expect(status.body.loginLoss).toEqual({ enabled: true, dryRun: true });
+
+    const check = await post('/subscription-pool/proactive-swap/check');
+    expect(check.status).toBe(200);
+    expect(check.body).toMatchObject({ enabled: true, swapped: [], considered: 1 });
+    expect(swapCalls).toEqual([]);
+  });
+
+  it('login-loss route executes through the existing swap callback only after dry-run promotion', async () => {
+    await boot({
+      withMonitor: true,
+      defaultAccountId: null,
+      loginLoss: { enabled: true, dryRun: false },
+    });
+    const check = await post('/subscription-pool/proactive-swap/check');
+    expect(check.status).toBe(200);
+    expect(check.body.swapped).toEqual(['interactive']);
+    expect(swapCalls).toEqual([{ sessionName: 'interactive', exhaustedAccountId: 'hot' }]);
   });
 
   it('DARK: GET returns 200 { enabled:false } when the monitor is unwired (never 503)', async () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,33 @@
+# Instar Upgrade Guide
+
+## What Changed
+
+When its prerequisite brake pipeline is wired, the existing login-loss
+account-swap trigger now reports its resolved enabled and simulation posture on
+the proactive-swap status route. Dedicated HTTP integration and end-to-end
+tests prove the trigger is inert in simulation and dispatches the exact intent
+to the established swap callback only after deliberate promotion.
+
+## What to Tell Your User
+
+Instar's recovery for a conversation whose local account login disappears is
+now verified through the same live status and check surface used in production.
+You can see whether that recovery is enabled and whether it is still only
+simulating its intended move. The default remains safe: ordinary machines are
+dark, and development agents record what they would do before any live move is
+allowed.
+
+## Summary of New Capabilities
+
+- The proactive-swap status includes the resolved login-loss rollout posture.
+- Integration coverage proves low-quota-use login loss triggers a dry-run
+  intent without executing a swap.
+- End-to-end coverage proves deliberate promotion dispatches the exact intent
+  to the existing guarded swap callback and retains the normal dwell brake.
+
+## Evidence
+
+- `tests/integration/subscription-proactive-swap-route.test.ts`
+- `tests/e2e/subscription-proactive-swap-lifecycle.test.ts`
+- `tests/unit/swap-continuity-wiring.test.ts`
+- `tests/unit/proactive-swap-production-wiring.test.ts`

--- a/upgrades/side-effects/login-loss-trigger-test-closure.md
+++ b/upgrades/side-effects/login-loss-trigger-test-closure.md
@@ -1,0 +1,116 @@
+# Side-Effects Review — login-loss trigger test and observability closure
+
+**Version / slug:** `login-loss-trigger-test-closure`
+**Date:** `2026-07-23`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `Codex safety-review agent`
+
+## Summary of the change
+
+The existing login-loss account-swap trigger is unchanged. This change exposes
+its resolved `enabled` and `dryRun` posture through the existing proactive-swap
+status response and adds dedicated HTTP integration and end-to-end coverage for
+the already-merged trigger. The tests use the real subscription pool,
+anti-thrash engine, ledger, monitor, and route; the swap executor remains
+injected so the suite is hermetic.
+
+## Decision-point inventory
+
+- `ProactiveSwapMonitor.status()` — pass-through — reports the already-resolved
+  login-loss rollout posture without changing it.
+- Existing login-loss candidacy and swap authority — pass-through — exercised
+  by tests but not modified.
+
+## 1. Over-block
+
+No block/allow behavior changes. The status field is observational and the new
+tests do not participate at runtime.
+
+## 2. Under-block
+
+The tests do not emulate a real process kill or external authentication
+provider. Those boundaries remain covered by the existing scheduler and
+session-refresh tests. The new coverage specifically closes the missing route
+composition and feature-alive tiers.
+
+## 3. Level-of-abstraction fit
+
+The posture is surfaced by the monitor that owns the resolved configuration,
+through the route that already exposes that monitor's status. The tests compose
+existing primitives rather than adding a parallel detector, executor, or
+fixture-only implementation.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no new block/allow surface.
+
+The identity-drift signal and existing swap authority are unchanged. The new
+status field is read-only provenance; the tests exercise the current authority
+without adding one.
+
+## 4b. Judgment-point check
+
+No new static heuristic or competing-signals decision point is added.
+
+## 5. Interactions
+
+- **Shadowing:** none; the status data is appended to the existing response.
+- **Double-fire:** none; the tests invoke one on-demand pass at a time.
+- **Races:** the end-to-end promotion honors the existing dwell interval after
+  the dry-run row instead of bypassing it.
+- **Feedback loops:** none; reading status does not alter monitor state.
+
+## 6. External surfaces
+
+When the prerequisite anti-thrash pipeline is wired, the existing status
+response gains an optional `loginLoss` object containing two booleans. Without
+that pipeline the trigger is ineffective and the posture remains omitted.
+Existing clients remain compatible. No notification, credential,
+session-binding, persistence format, or operator action is added.
+
+## 6b. Operator-surface quality
+
+No operator UI surface — not applicable.
+
+## 7. Multi-machine posture
+
+Machine-local by design. A local login and a live session's real configuration
+home are facts of the machine executing that session. The status reports that
+machine's resolved posture. The change emits no user-facing notice, adds no
+durable state, and generates no URL.
+
+## 8. Rollback cost
+
+Revert the status field and tests and ship a patch. No migration, cleanup, agent
+state repair, or credential action is required.
+
+## Conclusion
+
+The change closes the requested integration and end-to-end evidence without
+reimplementing or widening the live recovery authority. It is clear to ship
+after the independent second-pass review concurs.
+
+## Second-pass review
+
+**Reviewer:** Codex safety-review agent
+**Independent read of the artifact:** concur
+
+The reviewer found no dark, dry-run, or session-lifecycle authority regression.
+The review requested narrower wording for the injected swap-callback boundary
+and explicit disclosure that posture visibility depends on the braked pipeline;
+both precision corrections are incorporated above.
+
+## Evidence pointers
+
+- `tests/integration/subscription-proactive-swap-route.test.ts`
+- `tests/e2e/subscription-proactive-swap-lifecycle.test.ts`
+- `tests/unit/swap-continuity-wiring.test.ts`
+- `tests/unit/proactive-swap-production-wiring.test.ts`
+
+## Class-Closure Declaration (display-only mirror)
+
+No new self-triggered controller and no new agent-authored decision defect. The
+prior trigger's existing `unbounded-self-action` guard declaration remains the
+machine-readable closure for its authority.


### PR DESCRIPTION
## Summary

Current `main` already contains the login-loss recovery trigger from PR #1564. This follow-up closes the remaining requested delivery gap without duplicating that implementation:

- exposes the resolved login-loss `enabled` and `dryRun` posture through the existing proactive-swap status response when the prerequisite brake pipeline is wired
- adds an HTTP integration case proving a low-utilization account becomes a candidate because of exact owner-relogin-required drift
- proves dry-run records the intent but never calls the swap executor
- proves explicit promotion dispatches the same login-loss intent through the existing swap callback
- adds an end-to-end feature-alive case using the real subscription pool, swap ledger, anti-thrash engine, monitor, and HTTP route
- preserves the normal dwell brake across dry-run → live promotion

No detector, target selector, session-binding mutator, or swap mechanism was added.

## Root cause

PR #1564 correctly implemented the active recovery path and its unit/production-wiring coverage, but the requested route-level integration and end-to-end login-loss cases were absent. The proactive status response also did not expose the nested trigger's resolved rollout posture.

## ELI16

Imagine a live conversation is using a local account login that suddenly disappears. The account may still show lots of quota remaining, so a quota-only alarm will never fire. Instar already learned how to recognize that exact missing-login condition and feed it into the same careful account-move machinery used when an account is nearing its quota wall.

That runtime trigger is already on `main`. This PR does not build another one. Instead, it proves the existing path at the two missing levels.

The integration test sends a real HTTP check through the proactive-swap route. Its source account is only eight percent used, so quota pressure cannot explain the decision. The account is selected solely because its real local-login state says the owner must log in again. In the default dry-run posture, the monitor considers the session and records the intended move, but the injected swap executor receives no call. When dry-run is deliberately turned off in a separate case, the exact intent is dispatched through the existing callback with the healthy target.

The end-to-end case composes the real subscription pool, persistent swap ledger, anti-thrash engine, proactive monitor, and HTTP routes. It first proves the simulation posture is visible and inert. It then advances through the normal dwell interval—without bypassing the brake—and proves the promoted intent reaches the established swap callback. The real scheduler and session-refresh kill boundary remain covered by the existing unit suite; this PR does not claim that an external process was actually killed in the hermetic test.

The status route now reports the two resolved rollout booleans when the braked login-loss pipeline is wired. If that prerequisite pipeline is absent, the trigger cannot run and no nested posture is advertised. The field is observation only: it grants no authority and changes no session.

In short: the recovery mechanism already existed; this PR makes its dark, dry-run, and promoted behavior visible and proves it through the real route composition.

## Safety

- ordinary machines remain dark through the existing development-agent gate
- dry-run remains the default and exits before the swap callback
- the existing identity-drift signal and owner-relogin predicate are unchanged
- the existing anti-thrash, workload, target freshness, dwell, breaker, cycle-cap, and kill-boundary checks are unchanged
- no direct session binding mutation or default-slot repoint mechanism is introduced
- an independent safety review concurred after narrowing the E2E wording to the actual injected-callback boundary

## Validation

- focused login-loss unit, production-wiring, integration, and E2E suite: 42/42
- affected pre-push smoke suite: 94/94
- TypeScript and repository lint suite: green
- dark-gate ratchet: green
- no-silent-fallback ratchet: green
- machine-coherence manifest ratchet: green
- standards, docs coverage, ELI16, and whitespace gates: green
- complete four-shard suite was run locally before push; shard 1 passed cleanly, while unrelated shared-fixture/auth tests in the other broad shards showed existing order/environment flakes and passed when reproduced in isolation. CI remains the authoritative isolated-shard run.

## Decision audit and side effects

The commit carries the generated development decision-audit record, a Tier-1 ELI16, upgrade notes, and an independently reviewed side-effects artifact.

## Rollback

Revert this commit. No migration, credential repair, session repair, or persistent-format cleanup is required.
