### PR TITLE
fix: make context-wall recovery bounded and fresh

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T17-39-10-581Z-context-wall-recovery-robustness.json
+++ b/.instar/instar-dev-decisions/2026-07-23T17-39-10-581Z-context-wall-recovery-robustness.json
@@ -1,0 +1,29 @@
+{
+  "ts": "2026-07-23T17:39:10.581Z",
+  "slug": "context-wall-recovery-robustness",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 262,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The context detector already persisted a true-only latch, but recovery recorded an attempt before its active-child veto. Long-lived helper processes therefore consumed retries without any recovery action and could defer forever. Resume maps were cleared only on the existing recovery route rather than at every inbound spawn chokepoint, and PresenceProxy trusted a live process/pane tail after the original context banner scrolled away. The fix makes positive transcript growth the work receipt, preserves deferrals outside attempt accounting, bounds ambiguity, and carries the durable latch through fresh-spawn and honest-status surfaces."
+  },
+  "classClosure": {
+    "failureClass": "Context-wall episodes can be indefinitely deferred or falsely reported as active because helper-process existence is mistaken for model work.",
+    "closure": "All recovery decisions use transcript growth or a bounded ceiling; every inbound respawn consults the latch; standby status consults the same durable state; legacy latch state migrates safely.",
+    "regressionProof": [
+      "transcript growth defers without consuming an attempt",
+      "static transcript recovers despite helper processes",
+      "unknown evidence forces recovery after 30 minutes",
+      "legacy true-only latches survive reload",
+      "PresenceProxy reports a durable latch instead of active work"
+    ]
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T17-39-39-719Z-context-wall-recovery-robustness.json
+++ b/.instar/instar-dev-decisions/2026-07-23T17-39-39-719Z-context-wall-recovery-robustness.json
@@ -1,0 +1,29 @@
+{
+  "ts": "2026-07-23T17:39:39.719Z",
+  "slug": "context-wall-recovery-robustness",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 262,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The context detector already persisted a true-only latch, but recovery recorded an attempt before its active-child veto. Long-lived helper processes therefore consumed retries without any recovery action and could defer forever. Resume maps were cleared only on the existing recovery route rather than at every inbound spawn chokepoint, and PresenceProxy trusted a live process/pane tail after the original context banner scrolled away. The fix makes positive transcript growth the work receipt, preserves deferrals outside attempt accounting, bounds ambiguity, and carries the durable latch through fresh-spawn and honest-status surfaces."
+  },
+  "classClosure": {
+    "failureClass": "Context-wall episodes can be indefinitely deferred or falsely reported as active because helper-process existence is mistaken for model work.",
+    "closure": "All recovery decisions use transcript growth or a bounded ceiling; every inbound respawn consults the latch; standby status consults the same durable state; legacy latch state migrates safely.",
+    "regressionProof": [
+      "transcript growth defers without consuming an attempt",
+      "static transcript recovers despite helper processes",
+      "unknown evidence forces recovery after 30 minutes",
+      "legacy true-only latches survive reload",
+      "PresenceProxy reports a durable latch instead of active work"
+    ]
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T17-40-42-741Z-context-wall-recovery-robustness.json
+++ b/.instar/instar-dev-decisions/2026-07-23T17-40-42-741Z-context-wall-recovery-robustness.json
@@ -1,0 +1,29 @@
+{
+  "ts": "2026-07-23T17:40:42.741Z",
+  "slug": "context-wall-recovery-robustness",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 262,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The context detector already persisted a true-only latch, but recovery recorded an attempt before its active-child veto. Long-lived helper processes therefore consumed retries without any recovery action and could defer forever. Resume maps were cleared only on the existing recovery route rather than at every inbound spawn chokepoint, and PresenceProxy trusted a live process/pane tail after the original context banner scrolled away. The fix makes positive transcript growth the work receipt, preserves deferrals outside attempt accounting, bounds ambiguity, and carries the durable latch through fresh-spawn and honest-status surfaces."
+  },
+  "classClosure": {
+    "failureClass": "Context-wall episodes can be indefinitely deferred or falsely reported as active because helper-process existence is mistaken for model work.",
+    "closure": "All recovery decisions use transcript growth or a bounded ceiling; every inbound respawn consults the latch; standby status consults the same durable state; legacy latch state migrates safely.",
+    "regressionProof": [
+      "transcript growth defers without consuming an attempt",
+      "static transcript recovers despite helper processes",
+      "unknown evidence forces recovery after 30 minutes",
+      "legacy true-only latches survive reload",
+      "PresenceProxy reports a durable latch instead of active work"
+    ]
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/context-wall-recovery-robustness.eli16.md
+++ b/docs/specs/context-wall-recovery-robustness.eli16.md
@@ -1,0 +1,20 @@
+# Context-wall recovery robustness — ELI16
+
+A session at the context wall can look busy for the wrong reason. Browser and
+MCP helpers may still exist even though the model cannot produce another word.
+The old recovery code counted those helper processes as proof of work. It then
+used up one recovery attempt every time it chose to wait, eventually declaring
+recovery exhausted without ever trying to recover.
+
+This change uses the transcript as the work receipt. If the session's own
+transcript grows, it is producing work and recovery waits without spending an
+attempt. If the transcript stays still, recovery tries to compact the
+conversation in place. If that cannot clear the wall, it starts a clean session
+with recent thread history. A persistent latch has a 30-minute ceiling, so
+ambiguous evidence cannot defer forever.
+
+The latch also becomes a guard on every spawn path. While it is present, saved
+resume identifiers are ignored and removed, so a user message, watchdog, or
+other respawn cannot accidentally reload the same overfull conversation.
+Standby status names the latched wall honestly instead of saying the dead
+session is actively working.

--- a/docs/specs/context-wall-recovery-robustness.md
+++ b/docs/specs/context-wall-recovery-robustness.md
@@ -1,0 +1,71 @@
+---
+title: "Context-wall recovery robustness"
+slug: "context-wall-recovery-robustness"
+author: "Instar Agent (instar-codey)"
+parent-principle: "Structure beats Willpower"
+status: "approved"
+approved: true
+approved-by: "Justin-directed priority via Echo dispatch, 2026-07-23"
+review-convergence: "2026-07-23T17:35:00Z"
+review-iterations: 1
+review-completed-at: "2026-07-23T17:35:00Z"
+cross-model-review: "Codex incident trace and boundary review"
+eli16-overview: "context-wall-recovery-robustness.eli16.md"
+single-run-completable: true
+machine-local-justification: process-observer
+self-heal:
+  class: high
+  max-attempts: 3
+  max-wall-clock: 30m
+  backoff: 15m
+  dedupe-key: "context:<sessionName>"
+  breaker: "force fresh recovery after 30m persistent latch"
+  max-notification-latency: 30m
+  audit-location: ".instar/recovery-state.json and recovery:* runtime events"
+  remediation-actions:
+    - "compact in place at a verified static context wall"
+    - "kill and respawn fresh when compaction cannot clear the wall"
+---
+
+# Context-wall recovery robustness
+
+## Problem
+
+A context-exhausted session can keep MCP, browser, or SSH child processes alive
+while producing no transcript output. The recovery path currently interprets
+child-process existence as work, records each postponed check as an attempt, exhausts
+its three-attempt budget, and leaves the durable context latch wedged. A later
+ordinary respawn can then reuse the same overfull transcript.
+
+## Contract
+
+1. Persist the first-seen time of each context-exhaustion latch.
+2. A context-wall evidence wait does not increment the recovery-attempt counter or
+   start its cooldown.
+3. For context exhaustion, work means growth of the session's own transcript
+   across observations. Child-process existence alone is not work.
+4. An unresolved first transcript observation may defer safely, but a latch
+   persisting for 30 minutes bypasses ambiguity and forces bounded recovery.
+5. Try in-place compaction before destructive recovery when the transcript is
+   static. If compaction cannot clear the wall, kill and respawn fresh.
+6. While a topic's latch is set, every Telegram or Slack spawn path must ignore
+   and remove its saved resume UUID. Successful fresh spawn clears the latch.
+7. Existing stall, crash, and error-loop child-process veto behavior remains
+   unchanged.
+8. Presence/standby messaging must name a latched context-exhaustion state even
+   after the original banner scrolls out of the pane tail.
+9. State migration accepts the previous true-only latch representation without
+   crashing or silently clearing the episode.
+
+## Multi-machine posture
+
+The latch, transcript probe, and recovery attempts are machine-local because
+they describe one local tmux process and its local transcript. Ownership gates
+still run before recovery, so a non-owner cannot use this local evidence to
+double-dispatch a peer-owned conversation.
+
+## Rollback
+
+Revert the additive timestamp/probe and spawn guards. The persisted timestamped
+latch remains backward-readable as a truthy object; no destructive migration is
+required.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -45,6 +45,7 @@ import { configureHostSpawnSemaphore } from '../core/hostSpawnSemaphore.js';
 import { SpawningTopicsRegistry } from '../core/SpawningTopicsRegistry.js';
 import { planCredentialIdentityRepair } from '../core/CredentialIdentityRepairPlan.js';
 import { TopicReachabilityVerifier } from '../monitoring/TopicReachabilityVerifier.js';
+import { probeTranscript } from '../monitoring/transcriptProber.js';
 import { SingleInstanceLock, installReleaseHandlers } from '../core/SingleInstanceLock.js';
 import { resolveDevAgentGate, resolveStateSyncStores } from '../core/devAgentGate.js';
 import { resolveAntiThrashKnobs, readingValidity } from '../core/SwapAntiThrash.js';
@@ -553,6 +554,10 @@ let _spawningTopicsRegistryRef: SpawningTopicsRegistry | null = null;
 // Module-level reference for session resume mapping.
 // Set once in startServer() and used by spawnSessionForTopic/respawnSessionForTopic.
 let _topicResumeMap: import('../core/TopicResumeMap.js').TopicResumeMap | null = null;
+// Context-wall recovery latch. These late-bound seams let every Telegram/Slack
+// spawn chokepoint fail fresh while SessionRecovery owns a durable latch.
+let _contextExhaustionFreshRequired: ((topicId: number) => boolean) | null = null;
+let _clearContextExhaustionFreshRequired: ((topicId: number) => void) | null = null;
 
 // ── Multi-Machine Session Pool (§L4) activation refs ──────────────────────
 // The SessionRouter is constructed in startServer()'s mesh block, but the inbound
@@ -1216,6 +1221,14 @@ async function spawnSessionForTopic(
   // TopicResumeMap is authoritative — it saved the UUID for this specific topic at kill time
   // or via the refresh heartbeat. Skip LLM validation (which was failing due to JSONL sampling
   // issues and is redundant for an authoritative source).
+  const contextWallForcesFresh =
+    _contextExhaustionFreshRequired?.(topicId) === true;
+  if (contextWallForcesFresh) {
+    _topicResumeMap?.remove(topicId);
+    console.log(
+      `[spawnSessionForTopic] Context-exhaustion latch active for topic ${topicId} — forcing fresh spawn`,
+    );
+  }
   let resumeSessionId = _topicResumeMap?.get(topicId) ?? undefined;
   if (resumeSessionId) {
     console.log(`[spawnSessionForTopic] Found resume UUID for topic ${topicId}: ${resumeSessionId} (source: TopicResumeMap — trusted)`);
@@ -1342,6 +1355,9 @@ async function spawnSessionForTopic(
     }, 8000);
   }
 
+  if (contextWallForcesFresh) {
+    _clearContextExhaustionFreshRequired?.(topicId);
+  }
   return newSessionName;
 }
 
@@ -8396,7 +8412,18 @@ export async function startServer(options: StartOptions): Promise<void> {
 
           // Check resume map for session continuity (keyed on routing key, so a
           // thread resumes its OWN session and not the channel-root one).
-          const resumeInfo = slackAdapter!.getChannelResume(routingKey);
+          const contextWallForcesFresh =
+            conversationId !== null
+            && _contextExhaustionFreshRequired?.(conversationId) === true;
+          if (contextWallForcesFresh) {
+            slackAdapter!.removeChannelResume(routingKey);
+            console.log(
+              `[slack→session] Context-exhaustion latch active for conversation ${conversationId} — forcing fresh spawn`,
+            );
+          }
+          const resumeInfo = contextWallForcesFresh
+            ? null
+            : slackAdapter!.getChannelResume(routingKey);
           const resumeSessionId = resumeInfo?.uuid ?? undefined;
           if (resumeInfo) {
             slackAdapter!.removeChannelResume(routingKey);
@@ -8490,6 +8517,9 @@ export async function startServer(options: StartOptions): Promise<void> {
               );
               slackAdapter!.trackMessageInjection(channelId, newSessionName, message.content);
               console.log(`[slack→session] ${resumeSessionId ? 'Resumed' : 'Spawned'} "${newSessionName}" for ${isThreadSession ? `thread ${routingKey}` : `channel ${channelId}`}`);
+              if (contextWallForcesFresh && conversationId !== null) {
+                _clearContextExhaustionFreshRequired?.(conversationId);
+              }
             }
           } catch (err) {
             console.error(`[slack] Session spawn failed: ${err instanceof Error ? err.message : err}`);
@@ -10909,6 +10939,18 @@ export async function startServer(options: StartOptions): Promise<void> {
           },
           // P1/P2 cross-check dep — see SessionRecovery.killForRecovery().
           hasActiveProcesses: (name) => sessionManager.hasActiveProcesses(name),
+          probeTranscript: (name) => {
+            const session = sessionManager.listRunningSessions()
+              .find((candidate) => candidate.tmuxSession === name);
+            if (!session?.claudeSessionId) {
+              return { resolved: false, path: '', size: 0, mtime: 0 };
+            }
+            return probeTranscript({
+              framework: session.framework ?? 'claude-code',
+              sessionId: session.claudeSessionId,
+              projectDir: session.cwd ?? config.sessions.projectDir,
+            });
+          },
           respawnSession: async (topicId, _sessionName, recoveryPrompt) => {
             // Check Slack first (synthetic IDs are negative)
             const slackChId = slackProxyChannelMap.get(topicId);
@@ -11172,6 +11214,11 @@ export async function startServer(options: StartOptions): Promise<void> {
         // Clean up after 60 seconds — by then the kill and respawn are done
         setTimeout(() => contextExhaustionKills.delete(sessionName), 60_000);
       });
+      _contextExhaustionFreshRequired = (topicId) =>
+        sessionRecovery?.hasContextWedgedSeen(topicId) === true;
+      _clearContextExhaustionFreshRequired = (topicId) => {
+        sessionRecovery?.clearContextWedgedSeen(topicId);
+      };
       console.log(pc.green('  Session Recovery enabled (mechanical fast-path)'));
     }
 
@@ -13827,6 +13874,9 @@ export async function startServer(options: StartOptions): Promise<void> {
                 const result = await sessionRecovery!.checkAndRecover(topicId, sessionName);
                 return { recovered: result.recovered };
               }
+            : undefined,
+          hasContextExhaustionLatch: sessionRecovery
+            ? (topicId) => sessionRecovery!.hasContextWedgedSeen(topicId)
             : undefined,
           // Shared per-topic mutex — coordinates with PromiseBeacon.
           acquireProxyMutex: (topicId, holder) => proxyCoordinator.tryAcquire(topicId, holder),

--- a/src/monitoring/PresenceProxy.ts
+++ b/src/monitoring/PresenceProxy.ts
@@ -119,6 +119,10 @@ export interface PresenceProxyConfig {
 
   // Optional: context exhaustion auto-recovery
   recoverContextExhaustion?: (topicId: number, sessionName: string) => Promise<{ recovered: boolean }>;
+  /** Durable context-wall latch, used when the original pane banner has
+   * scrolled away. Signal-only for Tier 1/2; Tier 3 may invoke the existing
+   * recovery callback exactly as it does for a live-tail context match. */
+  hasContextExhaustionLatch?: (topicId: number) => boolean;
 
   /**
    * Honest turn-receipts: when a recovery sentinel (ContextWedgeSentinel,
@@ -1107,11 +1111,21 @@ export class PresenceProxy {
   // No-leak: emits ONLY `StuckClassification.message` verbatim with the tier
   // prefix — never concatenates pane-derived text.
   private maybeStuckMessage(
+    topicId: number,
     snapshot: string | null,
     sessionName: string,
     tierLabel: 1 | 2,
   ): string | typeof PRESENCE_SUPPRESS | null {
     if (!this.config.standbyHonestyTiers) return null;
+    if (this.config.hasContextExhaustionLatch?.(topicId)) {
+      if (this.config.isStuckRecoveryActive?.(sessionName)) {
+        return PRESENCE_SUPPRESS;
+      }
+      const prefix = tierLabel === 1
+        ? `${this.prefix} `
+        : `${this.prefix} 2-minute update — `;
+      return `${prefix}This conversation is latched at its context limit and cannot produce another reply until recovery starts.`;
+    }
     if (!snapshot) return null;
     let stuck;
     try {
@@ -1208,7 +1222,7 @@ export class PresenceProxy {
     // not only Tier 3. Substitutes the message string only; scheduling is
     // unchanged below. SUPPRESS = a recovery sentinel owns the voice → send
     // nothing this fire, but still schedule Tier 2.
-    const honest1 = this.maybeStuckMessage(snapshot, state.sessionName, 1);
+    const honest1 = this.maybeStuckMessage(topicId, snapshot, state.sessionName, 1);
     if (honest1 === PRESENCE_SUPPRESS) {
       if (state.cancelled) return;
       state.tier1FiredAt = Date.now();
@@ -1326,7 +1340,7 @@ export class PresenceProxy {
     // Same lift as Tier 1: surface the REAL reason instead of "is still
     // working" at the 2-minute mark. Substitutes the message string only;
     // Tier 3 is still scheduled below in every branch (never gated).
-    const honest2 = this.maybeStuckMessage(snapshot, state.sessionName, 2);
+    const honest2 = this.maybeStuckMessage(topicId, snapshot, state.sessionName, 2);
     if (honest2 === PRESENCE_SUPPRESS) {
       if (state.cancelled) return;
       state.tier2FiredAt = Date.now();
@@ -1474,6 +1488,46 @@ export class PresenceProxy {
         this.cleanupState(topicId);
         return;
       }
+    }
+
+    // A durable context-wall latch outranks the pane tail. The original banner
+    // can scroll away while the session remains unable to answer; reporting
+    // "actively working" in that state is the exact standby-honesty failure.
+    if (this.config.hasContextExhaustionLatch?.(topicId)) {
+      if (this.config.isStuckRecoveryActive?.(state.sessionName)) {
+        this.config.releaseTriageMutex?.(state.sessionName, 'presence-proxy');
+        this.persistState(topicId, state);
+        return;
+      }
+      if (this.config.recoverContextExhaustion) {
+        const result = await this.config.recoverContextExhaustion(topicId, state.sessionName);
+        if (result.recovered) {
+          state.tier3FiredAt = Date.now();
+          state.tier3Assessment = 'waiting';
+          state.tier3Summary = 'Latched context exhaustion — auto-recovered';
+          await this.sendProxyMessage(
+            topicId,
+            '🔄 The session was latched at its context limit — recovery has started with recent history.',
+            3,
+          );
+          this.config.releaseTriageMutex?.(state.sessionName, 'presence-proxy');
+          this.persistState(topicId, state);
+          this.cleanupState(topicId);
+          return;
+        }
+      }
+      state.tier3FiredAt = Date.now();
+      state.tier3Assessment = 'dead';
+      state.tier3Summary = 'Latched context exhaustion';
+      await this.sendProxyMessage(
+        topicId,
+        `${this.prefix} 5-minute check — This conversation is latched at its context limit and cannot produce another reply until recovery succeeds.`,
+        3,
+      );
+      this.config.releaseTriageMutex?.(state.sessionName, 'presence-proxy');
+      this.persistState(topicId, state);
+      this.cleanupState(topicId);
+      return;
     }
 
     // ── Honest turn-receipts: classify a live-but-failing session ──

--- a/src/monitoring/SessionRecovery.ts
+++ b/src/monitoring/SessionRecovery.ts
@@ -29,6 +29,10 @@ import { detectCrashedSession, detectErrorLoop, type CrashInfo, type ErrorLoopIn
 import { truncateJsonlToSafePoint, type TruncationStrategy } from './jsonl-truncator.js';
 import { detectContextExhaustion } from './QuotaExhaustionDetector.js';
 import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
+import {
+  transcriptDelta,
+  type TranscriptProbe,
+} from './transcriptProber.js';
 
 // ============================================================================
 // Types
@@ -42,11 +46,25 @@ export interface SessionRecoveryConfig {
   cooldownMs: number;
   /** Project directory (used to find JSONL files) */
   projectDir: string;
+  /** A context-wall latch older than this forces recovery even when work
+   * evidence remains ambiguous. Default: 30 minutes. */
+  contextExhaustionDeferralCeilingMs: number;
 }
 
 export interface RecoveryAttempt {
   lastAttempt: number;
   count: number;
+}
+
+function isTranscriptProbe(value: unknown): value is TranscriptProbe {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Partial<TranscriptProbe>;
+  return typeof row.resolved === 'boolean'
+    && typeof row.path === 'string'
+    && typeof row.size === 'number'
+    && Number.isFinite(row.size)
+    && typeof row.mtime === 'number'
+    && Number.isFinite(row.mtime);
 }
 
 export interface RecoveryResult {
@@ -86,6 +104,14 @@ export interface SessionRecoveryDeps {
    * to the pre-Phase-2 behavior).
    */
   hasActiveProcesses?: (sessionName: string) => boolean;
+  /**
+   * Session-specific transcript receipt used by context-wall recovery. Growth
+   * is positive proof of work; a static transcript is proof that helper-process
+   * existence alone must not veto recovery.
+   */
+  probeTranscript?: (sessionName: string) => TranscriptProbe;
+  /** Deterministic clock seam for latch ceilings and tests. */
+  now?: () => number;
   /** Respawn a session for a topic, optionally with a recovery prompt */
   respawnSession: (topicId: number, sessionName?: string, recoveryPrompt?: string) => Promise<void>;
   /** Send a message to a topic */
@@ -192,8 +218,12 @@ export class SessionRecovery extends EventEmitter {
   private deps: SessionRecoveryDeps;
   private recoveryAttempts: Map<string, RecoveryAttempt> = new Map();
   /** Durable memory that the existing context detector matched for a topic.
-   *  True-or-absent only: all recovery judgment remains in this class. */
-  private contextWedgedSeen = new Set<number>();
+   * The timestamp supplies the bounded-deferral ceiling; the optional probe is
+   * the prior observation used to prove transcript growth. */
+  private contextWedgedSeen = new Map<number, {
+    firstSeenAt: number;
+    transcript?: TranscriptProbe;
+  }>();
   private stateFilePath: string;
 
   constructor(config: Partial<SessionRecoveryConfig>, deps: SessionRecoveryDeps) {
@@ -203,6 +233,8 @@ export class SessionRecovery extends EventEmitter {
       maxAttempts: config.maxAttempts ?? 3,
       cooldownMs: config.cooldownMs ?? 15 * 60 * 1000,
       projectDir: config.projectDir || process.cwd(),
+      contextExhaustionDeferralCeilingMs:
+        config.contextExhaustionDeferralCeilingMs ?? 30 * 60 * 1000,
     };
     this.deps = deps;
     this.stateFilePath = path.join(this.config.projectDir, '.instar', 'recovery-state.json');
@@ -325,7 +357,7 @@ export class SessionRecovery extends EventEmitter {
   /** Remember only that the unchanged detector has already matched this topic. */
   markContextWedgedSeen(topicId: number): void {
     if (this.contextWedgedSeen.has(topicId)) return;
-    this.contextWedgedSeen.add(topicId);
+    this.contextWedgedSeen.set(topicId, { firstSeenAt: this.now() });
     this.saveState();
   }
 
@@ -338,6 +370,11 @@ export class SessionRecovery extends EventEmitter {
   clearContextWedgedSeen(topicId: number): void {
     if (!this.contextWedgedSeen.delete(topicId)) return;
     this.saveState();
+  }
+
+  /** First detector observation, exposed for honest status surfaces/tests. */
+  getContextWedgedFirstSeenAt(topicId: number): number | null {
+    return this.contextWedgedSeen.get(topicId)?.firstSeenAt ?? null;
   }
 
   /**
@@ -488,8 +525,15 @@ export class SessionRecovery extends EventEmitter {
    *  @returns `'killed'` on a kill we performed; `'deferred-still-working'`
    *           when the work-check vetoed the kill.
    */
-  private async killForRecovery(sessionName: string): Promise<'killed' | 'deferred-still-working'> {
-    if (this.deps.hasActiveProcesses && this.deps.hasActiveProcesses(sessionName)) {
+  private async killForRecovery(
+    sessionName: string,
+    options: { bypassChildProcessVeto?: boolean } = {},
+  ): Promise<'killed' | 'deferred-still-working'> {
+    if (
+      !options.bypassChildProcessVeto
+      && this.deps.hasActiveProcesses
+      && this.deps.hasActiveProcesses(sessionName)
+    ) {
       console.log(
         `[SessionRecovery] "${sessionName}": P1/P2 cross-check found active child processes — `
           + `deferring recovery (JSONL stall but the process is still producing work)`,
@@ -572,9 +616,60 @@ export class SessionRecovery extends EventEmitter {
       };
     }
 
+    // Context-wall work is measured from the session's transcript, not from
+    // helper-process existence. MCP/browser/SSH children can remain alive at a
+    // hard wall while the model produces nothing.
+    const latch = this.contextWedgedSeen.get(topicId)
+      ?? { firstSeenAt: this.now() };
+    this.contextWedgedSeen.set(topicId, latch);
+    const latchAgeMs = Math.max(0, this.now() - latch.firstSeenAt);
+    const ceilingReached =
+      latchAgeMs >= this.config.contextExhaustionDeferralCeilingMs;
+
+    const currentProbe = this.deps.probeTranscript?.(sessionName);
+    const priorProbe = latch.transcript;
+    if (currentProbe) {
+      latch.transcript = currentProbe;
+      this.saveState();
+    }
+    const growth = currentProbe && priorProbe
+      ? transcriptDelta(priorProbe, currentProbe)
+      : 'unknown';
+
+    // With the production transcript seam, only positive transcript growth
+    // proves work. The first/unresolved observation defers safely, but spends
+    // ZERO recovery attempts. The durable ceiling prevents ambiguity from
+    // becoming an infinite wait. Legacy callers without the seam retain their
+    // old child-process check until they are upgraded.
+    const legacyBusyWithoutProbe =
+      !this.deps.probeTranscript
+      && (this.deps.hasActiveProcesses?.(sessionName) ?? false);
+    if (!ceilingReached && (growth === 'grew' || growth === 'unknown' && (
+      this.deps.probeTranscript !== undefined || legacyBusyWithoutProbe
+    ))) {
+      return {
+        recovered: false,
+        failureType: 'context_exhaustion',
+        deferred: true,
+        message: growth === 'grew'
+          ? `Context-exhaustion recovery deferred for ${sessionName} — its transcript is still growing`
+          : `Context-exhaustion recovery deferred for ${sessionName} — waiting for a second transcript observation`,
+      };
+    }
+
+    // A deferral is not an attempt. Count only after the evidence gate has
+    // authorized an actual compaction/kill recovery action.
     const attemptNumber = this.recordAttempt(key);
 
-    this.emit('recovery:context_exhaustion', { topicId, sessionName, matchedPattern, attemptNumber });
+    this.emit('recovery:context_exhaustion', {
+      topicId,
+      sessionName,
+      matchedPattern,
+      attemptNumber,
+      latchAgeMs,
+      ceilingReached,
+      transcriptGrowth: growth,
+    });
 
     // ── Rung 1: non-destructive /compact (preserves the conversation) ──
     // Before killing the session and losing the conversation, try the escalation
@@ -584,8 +679,7 @@ export class SessionRecovery extends EventEmitter {
     // its work). If /compact clears the wall the conversation survives; if it
     // fails (too long to even compact) or times out, we fall through to the
     // destructive fresh respawn — never worse than the prior behavior.
-    const hasChildren = this.deps.hasActiveProcesses?.(sessionName) ?? false;
-    if (!hasChildren && this.deps.attemptCompaction) {
+    if (this.deps.attemptCompaction) {
       try {
         const compaction = await this.deps.attemptCompaction(sessionName);
         if (compaction.cleared) {
@@ -612,7 +706,11 @@ export class SessionRecovery extends EventEmitter {
     // Reached only when /compact was unavailable, declined (active children), or
     // could not clear the wall. The session is stuck at the "conversation too
     // long" prompt and a fresh start is the only remaining recovery.
-    if ((await this.killForRecovery(sessionName)) === 'deferred-still-working') {
+    if ((await this.killForRecovery(sessionName, {
+      // Transcript evidence already made the context-wall decision. A helper
+      // process must not re-veto it here.
+      bypassChildProcessVeto: this.deps.probeTranscript !== undefined || ceilingReached,
+    })) === 'deferred-still-working') {
       return {
         recovered: false, failureType: 'context_exhaustion', attemptNumber, deferred: true,
         message: `Context-exhaustion recovery deferred for ${sessionName} — work-check found active children`,
@@ -886,7 +984,7 @@ export class SessionRecovery extends EventEmitter {
   private shouldAttempt(key: string): boolean {
     const prior = this.recoveryAttempts.get(key);
     if (!prior) return true;
-    if (Date.now() - prior.lastAttempt < this.config.cooldownMs) return false;
+    if (this.now() - prior.lastAttempt < this.config.cooldownMs) return false;
     if (prior.count >= this.config.maxAttempts) return false;
     return true;
   }
@@ -894,7 +992,7 @@ export class SessionRecovery extends EventEmitter {
   private recordAttempt(key: string): number {
     const prior = this.recoveryAttempts.get(key);
     const count = (prior?.count || 0) + 1;
-    this.recoveryAttempts.set(key, { lastAttempt: Date.now(), count });
+    this.recoveryAttempts.set(key, { lastAttempt: this.now(), count });
     this.saveState();
     return count;
   }
@@ -918,7 +1016,22 @@ export class SessionRecovery extends EventEmitter {
         if (data.wedgedSeen && typeof data.wedgedSeen === 'object') {
           for (const [topic, seen] of Object.entries(data.wedgedSeen)) {
             const topicId = Number(topic);
-            if (seen === true && Number.isInteger(topicId)) this.contextWedgedSeen.add(topicId);
+            if (!Number.isInteger(topicId)) continue;
+            if (seen === true) {
+              // Legacy true-only state: keep the latch, start the ceiling clock
+              // now because its historical first-seen time was never recorded.
+              this.contextWedgedSeen.set(topicId, { firstSeenAt: this.now() });
+              continue;
+            }
+            if (seen && typeof seen === 'object') {
+              const row = seen as { firstSeenAt?: unknown; transcript?: unknown };
+              const firstSeenAt = Number(row.firstSeenAt);
+              if (!Number.isFinite(firstSeenAt) || firstSeenAt <= 0) continue;
+              const transcript = isTranscriptProbe(row.transcript)
+                ? row.transcript
+                : undefined;
+              this.contextWedgedSeen.set(topicId, { firstSeenAt, transcript });
+            }
           }
         }
       }
@@ -941,17 +1054,26 @@ export class SessionRecovery extends EventEmitter {
       // Only persist entries less than 1 hour old
       const ONE_HOUR = 60 * 60 * 1000;
       for (const [key, entry] of Array.from(this.recoveryAttempts.entries())) {
-        if (Date.now() - entry.lastAttempt < ONE_HOUR) {
+        if (this.now() - entry.lastAttempt < ONE_HOUR) {
           data[key] = entry;
         }
       }
 
-      const wedgedSeen: Record<string, true> = {};
-      for (const topicId of this.contextWedgedSeen) wedgedSeen[String(topicId)] = true;
+      const wedgedSeen: Record<string, {
+        firstSeenAt: number;
+        transcript?: TranscriptProbe;
+      }> = {};
+      for (const [topicId, state] of this.contextWedgedSeen) {
+        wedgedSeen[String(topicId)] = state;
+      }
       fs.writeFileSync(this.stateFilePath, JSON.stringify({ attempts: data, wedgedSeen }, null, 2));
     } catch { // @silent-fallback-ok — state persistence is best-effort; in-memory state still works
       // Can't save — in-memory state still works for this process lifetime
     }
+  }
+
+  private now(): number {
+    return this.deps.now?.() ?? Date.now();
   }
 
   /**

--- a/tests/unit/context-exhaustion-recovery.test.ts
+++ b/tests/unit/context-exhaustion-recovery.test.ts
@@ -376,7 +376,7 @@ describe('SessionRecovery — context exhaustion', () => {
     expect(stats.successes.contextExhaustion).toBe(1);
   });
 
-  it('persists a true-only per-topic wedge latch and reuses it after the banner scrolls away', async () => {
+  it('persists a timestamped per-topic wedge latch and reuses it after the banner scrolls away', async () => {
     let output = 'Conversation too long. Press esc twice to go up a few messages and try again.';
     let active = true;
     deps = createMockDeps({
@@ -390,8 +390,11 @@ describe('SessionRecovery — context exhaustion', () => {
     expect(deferred.deferred).toBe(true);
     expect(recovery.hasContextWedgedSeen(42)).toBe(true);
     const latchedState = JSON.parse(fs.readFileSync(path.join(tmpDir, '.instar', 'recovery-state.json'), 'utf-8'));
-    expect(latchedState.wedgedSeen).toEqual({ '42': true });
-    expect(latchedState.attempts['context:stuck-session']).toMatchObject({ count: 1 });
+    expect(latchedState.wedgedSeen['42']).toMatchObject({
+      firstSeenAt: expect.any(Number),
+    });
+    // Deferring is not a recovery attempt.
+    expect(latchedState.attempts['context:stuck-session']).toBeUndefined();
 
     output = 'ordinary prompt output; original banner has scrolled away';
     active = false;
@@ -404,7 +407,92 @@ describe('SessionRecovery — context exhaustion', () => {
     expect(recovery.hasContextWedgedSeen(42)).toBe(false);
     const clearedState = JSON.parse(fs.readFileSync(path.join(tmpDir, '.instar', 'recovery-state.json'), 'utf-8'));
     expect(clearedState.wedgedSeen).toEqual({});
-    expect(clearedState.attempts['context:stuck-session']).toMatchObject({ count: 2 });
+    expect(clearedState.attempts['context:stuck-session']).toMatchObject({ count: 1 });
+  });
+
+  it('uses transcript growth as context-wall work evidence without spending an attempt', async () => {
+    let probe = { resolved: true, path: '/tmp/session.jsonl', size: 100, mtime: 10 };
+    deps = createMockDeps({
+      isSessionAlive: vi.fn(() => true),
+      captureSessionOutput: vi.fn(() => 'Conversation too long. Press esc twice to go up a few messages and try again.'),
+      hasActiveProcesses: vi.fn(() => true),
+      probeTranscript: vi.fn(() => probe),
+    });
+    recovery = new SessionRecovery({ enabled: true, projectDir: tmpDir, cooldownMs: 0 }, deps);
+
+    const first = await recovery.checkAndRecover(42, 'stuck-session');
+    expect(first.deferred).toBe(true);
+
+    probe = { ...probe, size: 125, mtime: 20 };
+    const growing = await recovery.checkAndRecover(42, 'stuck-session');
+    expect(growing.deferred).toBe(true);
+    expect(growing.message).toMatch(/transcript is still growing/i);
+
+    const state = JSON.parse(fs.readFileSync(path.join(tmpDir, '.instar', 'recovery-state.json'), 'utf-8'));
+    expect(state.attempts['context:stuck-session']).toBeUndefined();
+    expect(deps.killSession).not.toHaveBeenCalled();
+  });
+
+  it('recovers a static transcript even when leftover helper processes exist', async () => {
+    const probe = { resolved: true, path: '/tmp/session.jsonl', size: 100, mtime: 10 };
+    const respawnSessionFresh = vi.fn(async () => {});
+    deps = createMockDeps({
+      isSessionAlive: vi.fn(() => true),
+      captureSessionOutput: vi.fn(() => 'Conversation too long. Press esc twice to go up a few messages and try again.'),
+      hasActiveProcesses: vi.fn(() => true),
+      probeTranscript: vi.fn(() => probe),
+      respawnSessionFresh,
+    });
+    recovery = new SessionRecovery({ enabled: true, projectDir: tmpDir, cooldownMs: 0 }, deps);
+
+    expect((await recovery.checkAndRecover(42, 'stuck-session')).deferred).toBe(true);
+    const recovered = await runWithTimers(() => recovery.checkAndRecover(42, 'stuck-session'));
+
+    expect(recovered.recovered).toBe(true);
+    expect(deps.killSession).toHaveBeenCalledWith('stuck-session');
+    expect(respawnSessionFresh).toHaveBeenCalled();
+  });
+
+  it('forces recovery after the 30-minute latch ceiling even when transcript evidence stays unknown', async () => {
+    let now = 1_000;
+    const unresolved = { resolved: false, path: '', size: 0, mtime: 0 };
+    const respawnSessionFresh = vi.fn(async () => {});
+    deps = createMockDeps({
+      isSessionAlive: vi.fn(() => true),
+      captureSessionOutput: vi.fn(() => 'Conversation too long. Press esc twice to go up a few messages and try again.'),
+      hasActiveProcesses: vi.fn(() => true),
+      probeTranscript: vi.fn(() => unresolved),
+      respawnSessionFresh,
+      now: () => now,
+    });
+    recovery = new SessionRecovery({
+      enabled: true,
+      projectDir: tmpDir,
+      cooldownMs: 0,
+      contextExhaustionDeferralCeilingMs: 30 * 60_000,
+    }, deps);
+
+    expect((await recovery.checkAndRecover(42, 'stuck-session')).deferred).toBe(true);
+    now += 30 * 60_000 + 1;
+    const recovered = await runWithTimers(() => recovery.checkAndRecover(42, 'stuck-session'));
+
+    expect(recovered.recovered).toBe(true);
+    expect(deps.killSession).toHaveBeenCalledWith('stuck-session');
+    expect(respawnSessionFresh).toHaveBeenCalled();
+  });
+
+  it('loads the legacy true-only latch without clearing the episode', () => {
+    const stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, 'recovery-state.json'),
+      JSON.stringify({ attempts: {}, wedgedSeen: { '77': true } }),
+    );
+    deps = createMockDeps();
+    recovery = new SessionRecovery({ enabled: true, projectDir: tmpDir }, deps);
+
+    expect(recovery.hasContextWedgedSeen(77)).toBe(true);
+    expect(recovery.getContextWedgedFirstSeenAt(77)).toEqual(expect.any(Number));
   });
 
   it('supports explicit manual clearing without a clock or inferred pane validation', () => {

--- a/tests/unit/presence-proxy-honest-receipts.test.ts
+++ b/tests/unit/presence-proxy-honest-receipts.test.ts
@@ -155,6 +155,22 @@ describe('PresenceProxy honest turn-receipts — fireTier3', () => {
     const tooLongMsg = sent.find(s => /conversation.*too long|got too long/i.test(s.text));
     expect(tooLongMsg).toBeUndefined();
   });
+
+  it('durable context latch overrides misleading live-process evidence', async () => {
+    const { proxy, sent, stateDir } = mkProxy({
+      captureSessionOutput: () => '⏺ ordinary stale tail\n✻ Crunching (12s)',
+      hasContextExhaustionLatch: () => true,
+      recoverContextExhaustion: async () => ({ recovered: false }),
+    });
+    cleanup.push(stateDir);
+    const state = seedState(proxy, 105);
+    await (proxy as any).fireTier3(105, state);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].text).toMatch(/context limit|too long/i);
+    expect(sent[0].text).not.toMatch(/actively working|active child/i);
+    expect(state.tier3Assessment).toBe('dead');
+  });
 });
 
 describe('PresenceProxy honest turn-receipts — server.ts wiring (dead-code guard)', () => {
@@ -174,5 +190,10 @@ describe('PresenceProxy honest turn-receipts — server.ts wiring (dead-code gua
     // veto uses — so PresenceProxy stays silent while a sentinel is recovering.
     const block = serverSrc.slice(serverSrc.indexOf('isStuckRecoveryActive:'));
     expect(block.slice(0, 200)).toContain('wedgeRecoveryActive');
+  });
+
+  it('server.ts wires the durable context latch into PresenceProxy', () => {
+    expect(serverSrc).toContain('hasContextExhaustionLatch:');
+    expect(serverSrc).toContain('_contextExhaustionFreshRequired');
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,27 @@
+# Next Release
+
+## What Changed
+
+Context-wall recovery now distinguishes real session work from leftover helper
+processes by observing transcript growth. Waiting no longer consumes recovery
+attempts, and a persistent wall cannot defer recovery beyond 30 minutes.
+
+Any respawn while a context-exhaustion latch is active starts fresh instead of
+resuming the same overfull conversation. Standby status also reports the
+latched wall honestly after its banner scrolls away.
+
+## What to Tell Your User
+
+Long autonomous sessions are less likely to go silently dark at the context
+limit. Instar waits when the session is genuinely producing transcript output,
+but leftover browser or MCP processes no longer prevent recovery forever. If a
+context wall persists, Instar first tries to compact in place and then starts a
+fresh session with recent history if needed.
+
+## Summary of New Capabilities
+
+- Transcript-growth evidence for context-wall recovery.
+- Deferrals that do not spend the recovery-attempt budget.
+- A 30-minute ceiling on persistent context-wall deferral.
+- Fresh-only Telegram and Slack respawns while the context latch is active.
+- Honest standby reporting for a latched context-exhaustion state.

--- a/upgrades/side-effects/context-wall-recovery-robustness.md
+++ b/upgrades/side-effects/context-wall-recovery-robustness.md
@@ -1,0 +1,62 @@
+# Side-Effects Review — Context-wall recovery robustness
+
+**Version / slug:** `context-wall-recovery-robustness`
+**Date:** `2026-07-23`
+**Author:** Instar Agent (instar-codey)
+
+## Summary
+
+This closes a context-wall recovery loop that treated helper-process existence
+as work, consumed attempts on deferral, and later resumed the poisoned
+transcript. The fix reuses transcript-growth evidence, adds a bounded latch
+ceiling, and forces all respawns fresh while the latch exists.
+
+## Decision-point inventory
+
+- Transcript growth is the positive work signal for context exhaustion.
+- Unknown first observation defers without consuming an attempt.
+- A 30-minute persistent latch forces the existing compact-then-fresh ladder.
+- The latch suppresses resume UUID consumption at the Telegram and Slack spawn
+  chokepoints.
+- Ownership recovery gates remain ahead of local recovery.
+
+## Seven-dimension review
+
+1. **Over-block:** a growing transcript still defers recovery; ordinary stall,
+   crash, error-loop, and non-latched respawns retain their prior behavior.
+2. **Under-block:** static or persistently ambiguous context-wall episodes reach
+   the existing fresh recovery path and cannot reload the poisoned transcript.
+3. **Abstraction:** transcript probing supplies evidence; SessionRecovery owns
+   recovery judgment; spawn chokepoints enforce fresh launch.
+4. **Signal vs authority:** transcript growth is a signal. The deterministic
+   latch age, attempt budget, ownership gate, and recovery ladder retain
+   authority.
+5. **Interactions:** compaction remains the first rung; TopicResumeMap and the
+   Slack resume map remain authoritative outside a context latch.
+6. **External surfaces:** no new operator action or network API is added.
+   Standby copy changes only to report the already-durable latch honestly.
+7. **Rollback:** revert the additive guards. Timestamped latch state remains
+   readable and no external state needs repair.
+
+## Multi-machine posture
+
+Machine-local by design under `process-observer`: the evidence describes a
+local pane and transcript. The existing ownership gate prevents local recovery
+from acting on a peer-owned topic.
+
+## Operator surface quality
+
+Not applicable: no operator action or dashboard surface is added or changed.
+
+## Class-Closure Declaration
+
+`unbounded-self-action` closes as a **guard**: deferrals consume zero attempts,
+the latch has a 30-minute ceiling, successful recovery clears it, and the
+existing three-attempt/cooldown breaker bounds actual destructive attempts.
+Boundary tests pin the no-burn and force-after-ceiling behavior.
+
+## Evidence
+
+Unit tests cover attempt accounting, transcript growth/static/unknown evidence,
+legacy state migration, latch ceiling, and honest standby state. Source-wiring
+guards pin Telegram and Slack resume suppression at both spawn chokepoints.


### PR DESCRIPTION
## What changed

- Treat the session transcript—not leftover browser, MCP, or SSH processes—as the work receipt for context-wall recovery.
- Do not consume recovery attempts while waiting for a second transcript observation or while the transcript is still growing.
- Force the existing compact-then-fresh recovery ladder after a context-exhaustion latch persists for 30 minutes.
- Remove saved resume UUIDs at both Telegram and Slack spawn chokepoints while the latch is active.
- Make standby reporting surface the durable context-wall state after the original banner scrolls away.
- Preserve backward compatibility with the prior true-only persisted latch representation.

## Root cause

The recovery path recorded an attempt before checking its active-child veto. Long-lived helper processes could therefore consume all retry attempts without any recovery action. The true-only latch did not provide a bounded ceiling, ordinary spawn paths could reuse the poisoned transcript, and PresenceProxy could mistake a live helper process for model work.

## ELI16

A session at the context wall can look busy for the wrong reason. Browser and MCP helpers may still exist even though the model cannot produce another word. The old recovery code counted those helper processes as proof of work. It then used up one recovery attempt every time it chose to wait, eventually declaring recovery exhausted without ever trying to recover.

This change uses the transcript as the work receipt. If the session own transcript grows, it is producing work and recovery waits without spending an attempt. If the transcript stays still, recovery tries to compact the conversation in place. If that cannot clear the wall, it starts a clean session with recent thread history. A persistent latch has a 30-minute ceiling, so ambiguous evidence cannot wait forever.

The latch also becomes a guard on every spawn path. While it is present, saved resume identifiers are ignored and removed, so a user message, watchdog, or other respawn cannot accidentally reload the same overfull conversation. Standby status names the latched wall honestly instead of saying the dead session is actively working.

## Validation

- Clean full unit suite: 2,120 test files passed; 38,267 tests passed; 4 skipped.
- Focused context-wall suite: 65/65 passed.
- TypeScript validation passed.
- Repository lint and pre-commit instar-dev gate passed.