### PR TITLE
fix: make subscriptions layout fluid

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1067,6 +1067,16 @@
       line-height: 1.55;
       color: var(--text-bright);
     }
+    /* Subscriptions is an operational matrix, not a prose reading column.
+       Keep Process Health's calm 760px measure scoped to .ph-root while this
+       tab uses the full app canvas with responsive gutters. */
+    .subscriptions-root {
+      grid-column: 1 / -1;
+      max-width: none;
+      width: 100%;
+      min-width: 0;
+      box-sizing: border-box;
+    }
     .ph-title { font-size: 22px; font-weight: 600; color: var(--text-bright); line-height: 1.5; }
     .ph-stamp { font-size: 14px; color: var(--text-dim); }
     .ph-headline-wrap { margin: 4px 0 8px; }
@@ -3615,6 +3625,7 @@
       .sub-empty, .sub-disabled { font-size:13px; opacity:.7; padding:8px 0; }
       /* account-machine-matrix grid */
       .sub-matrix { border-collapse:collapse; width:100%; font-size:13px; }
+      #subMatrix { width:100%; min-width:0; overflow-x:auto; }
       .sub-matrix th, .sub-matrix td { border:1px solid var(--border,#2a2a2a); padding:8px 10px; text-align:center; vertical-align:top; }
       .sub-matrix-acct { text-align:left; font-weight:600; word-break:break-all; }
       .sub-matrix-mach { font-weight:600; }
@@ -3634,6 +3645,9 @@
       .sub-matrix-cancel, .sub-matrix-collapse { margin-top:4px; margin-left:4px; padding:2px 8px; cursor:pointer; font-size:11px; opacity:.85; }
       .sub-matrix-held-detail { font-size:11px; color:#f87171; margin-top:4px; }
       .sub-matrix-done-detail { font-size:11px; margin-top:4px; }
+      .sub-matrix-outcome { margin-top:6px; padding:7px 8px; border-radius:7px; text-align:left; font-size:12px; line-height:1.4; }
+      .sub-matrix-outcome-done { color:#22c55e; background:rgba(22,163,74,.10); border:1px solid rgba(22,163,74,.35); }
+      .sub-matrix-outcome-failed { color:#fca5a5; background:rgba(248,113,113,.08); border:1px solid rgba(248,113,113,.30); }
       .sub-matrix-cell.sub-matrix-held .sub-matrix-glyph, .sub-matrix-cell.sub-matrix-expired .sub-matrix-glyph, .sub-matrix-cell.sub-matrix-broken .sub-matrix-glyph { color:#f87171; }
       .sub-matrix-cell.sub-matrix-done .sub-matrix-glyph { color:#22c55e; font-weight:600; }
       .sub-matrix-cell.sub-matrix-just-verified { background:rgba(22,163,74,.14); outline:2px solid #16a34a; animation:subVerifiedPulse 1.2s ease-in-out 3; }
@@ -3644,10 +3658,16 @@
       .sub-pending-failed-head { color:#f87171; font-weight:600; }
       .sub-pending-outcome-body { font-size:12px; opacity:.85; margin-top:4px; }
       .sub-pending-status { font-size:12px; opacity:.85; margin-top:6px; }
+      @media (max-width: 600px) {
+        .subscriptions-root { padding:18px 14px !important; gap:18px !important; }
+        .subscriptions-root .ph-h-sub { font-size:14px; }
+        .sub-matrix { min-width:620px; }
+        .sub-account { padding:12px; }
+      }
     </style>
-    <div id="subscriptionsPanel" class="ph-root" style="display:none;flex-direction:column;padding:28px;gap:24px;overflow-y:auto">
+    <div id="subscriptionsPanel" class="tab-panel subscriptions-root" style="display:none;flex-direction:column;padding:28px;gap:24px;overflow-y:auto">
       <h2 class="ph-title">Subscriptions</h2>
-      <p class="ph-intro">Your subscription accounts and how much of each is left before it resets — plus any logins waiting for you to approve on your phone.</p>
+      <p class="ph-intro">Your subscription accounts, where each one is set up, and how much usage remains before it resets.</p>
       <!-- One-tap follow-me Approve card(s) — rendered only when another machine could use one of
            your subscriptions (ws52-operator-tap-not-text Part A). Leads the panel as the primary
            action when present; silent otherwise. -->
@@ -3664,11 +3684,6 @@
         <h3 class="ph-h">Accounts</h3>
         <p class="ph-h-sub">Each account’s live usage (5-hour and weekly) and when it resets.</p>
         <div id="subAccounts"></div>
-      </section>
-      <section class="ph-section">
-        <h3 class="ph-h">Pending logins</h3>
-        <p class="ph-h-sub">A mirror of every sign-in still in flight (each grid cell above carries its own complete flow) — plus explicit “done” and “didn’t finish” cards. An expired code is re-issued automatically.</p>
-        <div id="subPending"></div>
       </section>
     </div>
 
@@ -8831,7 +8846,6 @@
       if (!__subController) {
         const els = {
           accounts: document.getElementById('subAccounts'),
-          pending: document.getElementById('subPending'),
           followMe: document.getElementById('subFollowMe'),
           matrix: document.getElementById('subMatrix'),
         };

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -726,6 +726,10 @@ export function renderAccountMatrix(doc, target, poolScope, pendingScope, transi
           td.appendChild(el(doc, 'div', 'sub-matrix-held-detail',
             'Its sign-in window closed before finishing — tap Retry to start a fresh sign-in.'));
         }
+        if (c.state === 'expired') {
+          td.appendChild(el(doc, 'div', 'sub-matrix-outcome sub-matrix-outcome-failed',
+            'Didn’t finish — the sign-in link expired before this account was set up.'));
+        }
         td.appendChild(btn);
       } else if (c.state === 'in-progress' && c.login && c.login.verificationUrl) {
         // The cell carries the COMPLETE flow, rebuilt from SERVER pending-login state
@@ -743,6 +747,10 @@ export function renderAccountMatrix(doc, target, poolScope, pendingScope, transi
           : (justVerified && c.state === 'active' ? 'Active — just set up' : MATRIX_CELL_WORD[c.state]);
         const glyph = MATRIX_CELL_GLYPH[c.state] || '';
         td.appendChild(el(doc, 'span', 'sub-matrix-glyph', `${glyph} ${word}`.trim()));
+        if (justVerified) {
+          td.appendChild(el(doc, 'div', 'sub-matrix-outcome sub-matrix-outcome-done',
+            'Done — this account is set up on this machine.'));
+        }
         // An in-progress (◷) cell gets a tappable Cancel so a mis-tapped setup can be
         // reversed (abandon the login + tear down its pane). Emitted on the DURABLE
         // re-rendered cell (not just the live sign-in DOM) so it survives the poll loop.

--- a/docs/specs/subscriptions-fluid-layout.eli16.md
+++ b/docs/specs/subscriptions-fluid-layout.eli16.md
@@ -1,0 +1,17 @@
+# Subscriptions fluid layout — ELI16
+
+The Subscriptions page is a working control panel, not a narrow article. Its
+account-by-machine grid was accidentally placed inside the same 760-pixel-wide
+container used to make Process Health prose comfortable to read. On a wide
+monitor, that left most of the screen empty and squeezed the useful controls
+into about one quarter of the page.
+
+This change gives Subscriptions its own full-width container while leaving
+Process Health alone. Desktop screens use the available space; phone screens
+use smaller gutters and can scroll the matrix sideways without clipping it.
+
+It also removes the separate Pending logins section. That section had become a
+duplicate after every grid cell learned to carry its full sign-in flow. The few
+unique completion messages now live in the cell that owns the sign-in: a green
+“Done” card after success and a clear “Didn’t finish” card with Retry when a
+link expires.

--- a/docs/specs/subscriptions-fluid-layout.md
+++ b/docs/specs/subscriptions-fluid-layout.md
@@ -1,0 +1,42 @@
+---
+title: "Subscriptions fluid layout and mirror removal"
+slug: "subscriptions-fluid-layout"
+author: "Instar Agent (instar-codey)"
+parent-principle: "Structure beats Willpower"
+status: "approved"
+approved: true
+approved-by: "Justin-directed operator escalation via Echo dispatch, 2026-07-23"
+review-convergence: "2026-07-23T18:25:00Z"
+review-iterations: 1
+review-completed-at: "2026-07-23T18:25:00Z"
+cross-model-review: "Echo first-hand browser diagnosis plus Codex boundary review"
+eli16-overview: "subscriptions-fluid-layout.eli16.md"
+single-run-completable: true
+---
+
+# Subscriptions fluid layout and mirror removal
+
+## Problem
+
+The Subscriptions tab borrowed the Process Health reading-column class. At a
+2560px viewport, its operational matrix was constrained to 760px and rendered
+at roughly 27% width. The tab also retained a Pending logins section after the
+complete sign-in flow had moved into each account-machine grid cell.
+
+## Contract
+
+1. Subscriptions owns a fluid, full-grid container with responsive gutters.
+2. The Process Health `.ph-root` reading measure remains unchanged.
+3. The account-machine matrix uses available width at desktop sizes and remains
+   reachable through bounded horizontal scrolling on narrow mobile screens.
+4. Delete the Pending logins section from the dashboard markup and controller
+   mounts. Keep the pending-login API because the grid consumes it as state.
+5. Render explicit “Done” and “Didn’t finish” outcome cards in the owning grid
+   cell, including Retry for an expired flow.
+6. Structural tests pin the fluid-container boundary and deprecated-section
+   deletion.
+
+## Rollback
+
+Revert the Subscriptions-specific container and restore the former section. No
+stored state or API migration is involved.

--- a/tests/unit/dashboard-panel-placement.test.ts
+++ b/tests/unit/dashboard-panel-placement.test.ts
@@ -145,4 +145,17 @@ describe('dashboard panel placement floor', () => {
     expect(slice.includes('<main ')).toBe(false);
     expect(slice.includes('.tab-panel {')).toBe(false);
   });
+
+  it('Subscriptions owns a fluid container and no longer mounts the deprecated pending-logins mirror', () => {
+    const html = readDashboard();
+    const panel = html.match(/<div id="subscriptionsPanel"[^>]*>/)?.[0] ?? '';
+    const fluidRule = html.match(/\.subscriptions-root\s*\{[^}]*\}/)?.[0] ?? '';
+
+    expect(panel).toContain('subscriptions-root');
+    expect(panel).not.toContain('ph-root');
+    expect(fluidRule).toContain('max-width: none');
+    expect(fluidRule).toContain('min-width: 0');
+    expect(html).not.toContain('<div id="subPending"');
+    expect(html).not.toContain('<h3 class="ph-h">Pending logins</h3>');
+  });
 });

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -539,6 +539,7 @@ describe('renderAccountMatrix', () => {
     renderAccountMatrix(doc, t, pool, { enabled: true, logins: [] }, transient);
     const cell = t.querySelector('.sub-matrix-expired')!;
     expect(cell.textContent).toContain('Sign-in link expired');
+    expect(cell.querySelector('.sub-matrix-outcome-failed')!.textContent).toContain('Didn’t finish');
     expect(cell.querySelector('.sub-matrix-setup')!.textContent).toBe('Retry');
   });
 
@@ -558,6 +559,7 @@ describe('renderAccountMatrix', () => {
     const cell = t.querySelector('.sub-matrix-just-verified')!;
     expect(cell).toBeTruthy();
     expect(cell.textContent).toContain('Set up complete');
+    expect(cell.querySelector('.sub-matrix-outcome-done')!.textContent).toContain('Done');
     expect(cell.querySelector('.sub-matrix-setup')).toBeNull(); // never blinks back to "Set up"
   });
 
@@ -584,6 +586,7 @@ describe('renderAccountMatrix', () => {
     const cell = t.querySelector('.sub-matrix-active')!;
     expect(cell.getAttribute('class')).toContain('sub-matrix-just-verified');
     expect(cell.textContent).toContain('just set up');
+    expect(cell.querySelector('.sub-matrix-outcome-done')!.textContent).toContain('Done');
   });
 });
 

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,30 @@
+# Upgrade Guide — vNEXT
+
+<!-- assembled-by: assemble-next-md -->
+<!-- bump: patch -->
+
+## What Changed
+
+The dashboard Subscriptions tab now uses the full operational canvas instead of
+the Process Health reading-column width. Its deprecated Pending logins mirror
+is removed; completed and expired sign-ins report directly in their owning
+account-machine cell.
+
+## What to Tell Your User
+
+Subscriptions is easier to use on both wide monitors and phones. The
+account-by-machine grid has room to breathe, and sign-in progress and outcomes
+now stay in the cell where the sign-in was started instead of being duplicated
+in a separate panel.
+
+## Summary of New Capabilities
+
+- Fluid desktop layout with mobile-safe matrix scrolling.
+- In-cell “Done” and “Didn’t finish” sign-in outcomes.
+- One canonical sign-in surface instead of a duplicate Pending logins panel.
+
+## Evidence
+
+- `tests/unit/subscriptions-render.test.ts`
+- `tests/unit/dashboard-panel-placement.test.ts`
+- `tests/integration/subscriptions-tab.test.ts`

--- a/upgrades/side-effects/subscriptions-fluid-layout.md
+++ b/upgrades/side-effects/subscriptions-fluid-layout.md
@@ -1,0 +1,43 @@
+# Side-Effects Review — Subscriptions fluid layout
+
+**Version / slug:** `subscriptions-fluid-layout`
+**Date:** `2026-07-23`
+**Author:** Instar Agent (instar-codey)
+
+## Summary
+
+Subscriptions now owns a fluid operational layout instead of inheriting Process
+Health’s reading-column width. The deprecated Pending logins mirror is removed,
+with terminal outcome copy carried by the owning matrix cell.
+
+## Decision-point inventory
+
+- `.subscriptions-root` owns width and responsive gutters.
+- `.ph-root` is unchanged.
+- The pending-login endpoint remains because it feeds the matrix state model.
+- Expired and completed flows render explicit in-cell outcome cards.
+
+## Seven-dimension review
+
+1. **Over-block:** narrow viewports retain access through horizontal matrix
+   scrolling; no controls are hidden.
+2. **Under-block:** a structural test fails if Subscriptions regains `.ph-root`
+   or the deprecated `subPending` mount returns.
+3. **Abstraction:** layout belongs to dashboard CSS; terminal presentation
+   belongs to the existing matrix renderer.
+4. **Signal vs authority:** pending-login and pool reads remain authoritative;
+   the UI only projects them.
+5. **Interactions:** controller polling and API contracts are unchanged.
+6. **External surfaces:** only the Subscriptions dashboard tab changes.
+7. **Rollback:** markup/CSS/renderer revert; no data repair.
+
+## Operator surface quality
+
+The matrix uses the available desktop canvas, has mobile gutters, and keeps
+terminal feedback next to the action that produced it. No duplicate panel asks
+the operator to reconcile two copies of one flow.
+
+## Evidence
+
+Renderer, panel-placement, tab-purpose, and Subscriptions integration tests
+cover both the fluid boundary and outcome presentation.


### PR DESCRIPTION
## Summary

- give Subscriptions its own fluid, full-width dashboard container without changing other `.ph-root` panels
- remove the duplicate Pending logins section
- place explicit Done / Didn’t finish outcomes inside the owning account cells
- add structural and renderer regression coverage

## ELI16

The Subscriptions page was accidentally borrowing a narrow wrapper built for reading text-heavy Process Health pages. On a wide monitor, that wrapper stopped growing at 760px, so the account matrix occupied only a small strip of the screen. This PR gives only Subscriptions a fluid wrapper, keeps the account table horizontally usable on phones, and moves completion/failure messages into the account cells they describe.

## Verification

- `npx vitest run tests/unit/subscriptions-render.test.ts tests/unit/dashboard-panel-placement.test.ts tests/unit/dashboard-tab-purpose.test.ts tests/integration/subscriptions-tab.test.ts` — 81 passed
- pre-commit lint gate passed
- pre-push affected-test listing timed out; CI remains authoritative

## Done-claim rule

Opening or merging this PR is not completion. Echo must verify the deployed dashboard at wide and mobile widths and send screenshots before this lane is claimed done.