### PR TITLE
feat: proactively compact autonomous sessions

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T19-08-05-424Z-proactive-autonomous-compaction.json
+++ b/.instar/instar-dev-decisions/2026-07-23T19-08-05-424Z-proactive-autonomous-compaction.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-23T19:08:05.424Z",
+  "slug": "proactive-autonomous-compaction",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 197,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Recovery began only after a context-wall failure or provider compaction event. Long unattended autonomous runs therefore had no early, idle-safe intervention even though Claude exposed grounded remaining-context telemetry in the pane."
+  },
+  "classClosure": {
+    "failureClass": "Autonomous sessions can reach the context wall despite exposing a safe pre-wall signal.",
+    "closure": "The sentinel is structurally dark, dry-run first, autonomous-and-Claude-only, thresholded at 85% used, fail-closed on indeterminate work state, and cooldown bounded. Unit tests pin every gate and the server wiring."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T19-09-16-019Z-proactive-autonomous-compaction.json
+++ b/.instar/instar-dev-decisions/2026-07-23T19-09-16-019Z-proactive-autonomous-compaction.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-23T19:09:16.019Z",
+  "slug": "proactive-autonomous-compaction",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 197,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Recovery began only after a context-wall failure or provider compaction event. Long unattended autonomous runs therefore had no early, idle-safe intervention even though Claude exposed grounded remaining-context telemetry in the pane."
+  },
+  "classClosure": {
+    "failureClass": "Autonomous sessions can reach the context wall despite exposing a safe pre-wall signal.",
+    "closure": "The sentinel is structurally dark, dry-run first, autonomous-and-Claude-only, thresholded at 85% used, fail-closed on indeterminate work state, and cooldown bounded. Unit tests pin every gate and the server wiring."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T19-09-52-966Z-proactive-autonomous-compaction.json
+++ b/.instar/instar-dev-decisions/2026-07-23T19-09-52-966Z-proactive-autonomous-compaction.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-23T19:09:52.966Z",
+  "slug": "proactive-autonomous-compaction",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 197,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Recovery began only after a context-wall failure or provider compaction event. Long unattended autonomous runs therefore had no early, idle-safe intervention even though Claude exposed grounded remaining-context telemetry in the pane."
+  },
+  "classClosure": {
+    "failureClass": "Autonomous sessions can reach the context wall despite exposing a safe pre-wall signal.",
+    "closure": "The sentinel is structurally dark, dry-run first, autonomous-and-Claude-only, thresholded at 85% used, fail-closed on indeterminate work state, and cooldown bounded. Unit tests pin every gate and the server wiring."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-23T18-39-00-000Z-proactive-autonomous-compaction.json
+++ b/.instar/instar-dev-traces/2026-07-23T18-39-00-000Z-proactive-autonomous-compaction.json
@@ -1,0 +1,35 @@
+{
+  "version": 3,
+  "slug": "proactive-autonomous-compaction",
+  "sessionId": "slack-C0BA4F4E0FP-context-wall-fix3",
+  "timestamp": "2026-07-23T18:39:00.000Z",
+  "artifactPath": "upgrades/side-effects/proactive-autonomous-compaction.md",
+  "artifactSha256": "9c76d13f45e16591c5e10eb31768555ce3707feafc2a58cd935d70ad3f470223",
+  "specPath": "docs/specs/proactive-autonomous-compaction.md",
+  "eli16Path": "docs/specs/proactive-autonomous-compaction.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/proactive-autonomous-compaction.md",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/core/types.ts",
+    "src/monitoring/guardManifest.ts",
+    "src/monitoring/ProactiveCompactionSentinel.ts",
+    "tests/unit/ProactiveCompactionSentinel.test.ts"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "This is bounded autonomous actuation against a live session. The converged design ships dark and dry-run first, uses Claude's own grounded context signal, and requires the canonical work-state probe to affirm an idle boundary before /compact can be injected.",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Recovery began only after a context-wall failure or provider compaction event. Long unattended autonomous runs therefore had no early, idle-safe intervention even though Claude exposed grounded remaining-context telemetry in the pane."
+  },
+  "classClosure": {
+    "failureClass": "Autonomous sessions can reach the context wall despite exposing a safe pre-wall signal.",
+    "closure": "The sentinel is structurally dark, dry-run first, autonomous-and-Claude-only, thresholded at 85% used, fail-closed on indeterminate work state, and cooldown bounded. Unit tests pin every gate and the server wiring."
+  },
+  "secondPass": true,
+  "reviewerConcurred": true,
+  "toolchain": {
+    "buildSkill": "instar-dev",
+    "verified": true
+  }
+}

--- a/docs/specs/proactive-autonomous-compaction.eli16.md
+++ b/docs/specs/proactive-autonomous-compaction.eli16.md
@@ -1,0 +1,17 @@
+# Proactive Autonomous Compaction — ELI16
+
+A long-running agent is like someone filling a notebook while working. If the notebook becomes completely full, recovering is harder and the session may stall. Claude already shows how much notebook space remains.
+
+This feature watches only autonomous Claude sessions. When 85% of the context is used, it waits until Claude is genuinely between turns, then asks Claude to compact its notes. It does nothing while Claude is working, does nothing when the work state is uncertain, and does nothing to normal interactive sessions.
+
+The feature ships off. Its first enabled posture is also observation-only: it records what it would have done without pressing `/compact`.
+
+There are several brakes because an early compaction is useful only when it is
+safer than waiting. A normal chat is excluded. Codex and other frameworks are
+excluded because their context signals and compaction controls differ. If the
+session pane cannot be read, if the percentage is missing, or if the work-state
+probe is unsure whether a tool is still running, the monitor does nothing. A
+per-session cooldown also prevents repeated compaction requests if the display
+does not refresh immediately. Operators can first inspect dry-run logs, then
+enable live behavior explicitly; turning the feature off stops the monitor at
+the next server restart.

--- a/docs/specs/proactive-autonomous-compaction.md
+++ b/docs/specs/proactive-autonomous-compaction.md
@@ -1,0 +1,64 @@
+---
+title: "Proactive autonomous compaction"
+slug: "proactive-autonomous-compaction"
+author: "Instar Agent (instar-codey)"
+parent-principle: "Structure beats Willpower"
+status: "approved"
+approved: true
+approved-by: "Justin-directed context-wall robustness dispatch via Echo, 2026-07-23"
+review-convergence: "2026-07-23T18:39:00Z"
+review-iterations: 1
+review-completed-at: "2026-07-23T18:39:00Z"
+cross-model-review: "Echo incident specification plus Codex boundary review"
+eli16-overview: "proactive-autonomous-compaction.eli16.md"
+single-run-completable: true
+---
+
+# Proactive Autonomous Compaction
+
+Status: implemented, dark by default, dry-run first
+
+## Problem
+
+Long autonomous Claude sessions can reach the context wall while unattended. Recovery after the wall is necessarily more disruptive than compacting before it, but compaction must never interrupt a live turn or affect ordinary interactive sessions.
+
+## Contract
+
+The server may request `/compact` only when every condition is true:
+
+1. `monitoring.proactiveAutonomousCompaction.enabled` is explicitly `true`.
+2. The session is registered to a currently autonomous topic.
+3. The framework is `claude-code`.
+4. Claude's own live pane reports `Context left until auto-compact: N%`.
+5. Used context (`100 - N`) is at or above `thresholdUsedPercent` (default 85).
+6. `SessionManager.checkSessionWorkState` affirmatively returns `idle`.
+7. The per-session cooldown has elapsed.
+
+`working`, `indeterminate`, missing telemetry, non-Claude, non-autonomous, and unregistered sessions are no-ops.
+
+## Rollout
+
+- Absent/false `enabled`: no polling and no behavior change.
+- Enabled with omitted/true `dryRun`: log `would-compact`; do not inject.
+- Enabled with `dryRun:false`: inject the native `/compact` command through the trusted internal recovery channel.
+- Rollback: set `enabled:false`.
+
+## Configuration
+
+```json
+{
+  "monitoring": {
+    "proactiveAutonomousCompaction": {
+      "enabled": true,
+      "dryRun": true,
+      "thresholdUsedPercent": 85,
+      "tickIntervalMs": 60000,
+      "cooldownMs": 1800000
+    }
+  }
+}
+```
+
+## Verification
+
+`tests/unit/ProactiveCompactionSentinel.test.ts` pins the dark default, 85% threshold, dry-run posture, autonomous/framework/idle gates, and cooldown.

--- a/site/src/content/docs/architecture/under-the-hood.md
+++ b/site/src/content/docs/architecture/under-the-hood.md
@@ -393,7 +393,7 @@ credential data, and obsolete route state is pruned after 30 days.
 
 ### `src/monitoring/` — sentinels, watchdogs, observability
 
-`AccountSwitcher`, `AttributionResolver`, `BurnAlertButtons`, `BurnAlertDelivery`, `BurnDetectionSubscriber`, `BurnDetector`, `BurnThrottleRunbook`, `BurnVerifier`, `CoherenceMonitor`, `CommitmentSentinel`, `CommitmentTracker`, `CompactionSentinel`, `CrashLoopPauser`, `CredentialProvider`, `DegradationReporter`, `ErrorCodeExtractor`, `FeedbackAnomalyDetector`, `FrameworkParitySentinel`, `HealthChecker`, `HelperWatchdog`, `HomeostasisMonitor`, `HookEventReceiver`, `InputClassifier`, `InstructionsVerifier`, `LlmQueue`, `LlmRateGate`, `MemoryPressureMonitor`, `NativeHealDegradationBridge`, `OrphanProcessReaper`, `PresenceProxy`, `PromiseBeacon`, `ProviderCostReportStore`, `ProviderReconciliationSweep`, `PromptGate`, `ProxyCoordinator`, `QuotaCollector`, `QuotaExhaustionDetector`, `QuotaManager`, `QuotaNotifier`, `QuotaTracker`, `Redactor`, `ReflectionMetrics`, `ReviewCanaryBattery`, `SessionActivitySentinel`, `SessionCredentialManager`, `SessionMigrator`, `SessionMonitor`, `SessionRecovery`, `SessionWatchdog`, `StallTriageNurse`, `SubagentTracker`, `SystemReviewer`, `TelemetryAuth`, `TelemetryCollector`, `TelemetryHeartbeat`, `TokenLedger`, `TokenLedgerPoller`, `TriageOrchestrator`, `WorktreeMonitor`, `WorktreeReaper`.
+`AccountSwitcher`, `AttributionResolver`, `BurnAlertButtons`, `BurnAlertDelivery`, `BurnDetectionSubscriber`, `BurnDetector`, `BurnThrottleRunbook`, `BurnVerifier`, `CoherenceMonitor`, `CommitmentSentinel`, `CommitmentTracker`, `CompactionSentinel`, `CrashLoopPauser`, `CredentialProvider`, `DegradationReporter`, `ErrorCodeExtractor`, `FeedbackAnomalyDetector`, `FrameworkParitySentinel`, `HealthChecker`, `HelperWatchdog`, `HomeostasisMonitor`, `HookEventReceiver`, `InputClassifier`, `InstructionsVerifier`, `LlmQueue`, `LlmRateGate`, `MemoryPressureMonitor`, `NativeHealDegradationBridge`, `MissingLoginSessionDetector`, `OrphanProcessReaper`, `PresenceProxy`, `ProactiveCompactionSentinel`, `PromiseBeacon`, `ProviderCostReportStore`, `ProviderReconciliationSweep`, `PromptGate`, `ProxyCoordinator`, `QuotaCollector`, `QuotaExhaustionDetector`, `QuotaManager`, `QuotaNotifier`, `QuotaTracker`, `Redactor`, `ReflectionMetrics`, `ReviewCanaryBattery`, `SessionActivitySentinel`, `SessionCredentialManager`, `SessionMigrator`, `SessionMonitor`, `SessionRecovery`, `SessionWatchdog`, `StallTriageNurse`, `SubagentTracker`, `SystemReviewer`, `TelemetryAuth`, `TelemetryCollector`, `TelemetryHeartbeat`, `TokenLedger`, `TokenLedgerPoller`, `TriageOrchestrator`, `WorktreeMonitor`, `WorktreeReaper`.
 
 ### `src/threadline/` — agent-to-agent protocol stack
 
@@ -521,6 +521,14 @@ Enrollment (P2.1) — adding a new account from a phone, expiry-proof:
   logic is pure and unit-tested against real captured-output fixtures.
 
 Spec: `docs/specs/_drafts/subscription-auth-standard-master-spec.md`.
+
+## Proactive compaction (ProactiveCompactionSentinel)
+
+`ProactiveCompactionSentinel` condenses a long-running autonomous session's conversation *before* it hits the context wall, instead of relying on recovery after the wall is reached. It reads Claude's own grounded remaining-context display and, when an autonomous Claude session crosses 85% used, waits for the canonical work-state probe to affirm a genuinely idle turn boundary, then asks the session to compact in place. A cooldown prevents repeated compaction on successive ticks; interactive sessions, non-Claude frameworks, working sessions, and uncertain readings are never touched. Ships dark by default; when enabled it starts in dry-run (recording what it would do) until live mode is explicitly configured.
+
+## Missing-login detection (MissingLoginSessionDetector)
+
+`MissingLoginSessionDetector` correlates two independent facts — a subscription-pool account whose local login has gone missing, and a live session whose real config home belongs to that account — and raises one deduplicated HIGH attention item ("re-login needed") when both hold. It matches sessions by their live config home rather than the recorded account id, because the recorded id is exactly the field that becomes unreliable under identity drift. Signal-only: it never swaps credentials, re-logs anything in, or touches the session.
 
 ## Inter-agent comms (agent-to-agent Telegram primitive)
 

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -12344,6 +12344,73 @@ export async function startServer(options: StartOptions): Promise<void> {
     }
     console.log(pc.green('  CompactionSentinel enabled (verified recovery lifecycle)'));
 
+    // ── Proactive autonomous compaction ───────────────────────────────
+    // Explicit opt-in, dry-run first. Claude already exposes a grounded
+    // percentage in its live pane ("Context left until auto-compact: N%").
+    // At >=85% used, ask for /compact only when the canonical async work-state
+    // probe says IDLE. Working and indeterminate sessions are never touched.
+    const proactiveCompactionCfg = config.monitoring?.proactiveAutonomousCompaction;
+    if (proactiveCompactionCfg?.enabled === true) {
+      const { ProactiveCompactionSentinel } = await import(
+        '../monitoring/ProactiveCompactionSentinel.js'
+      );
+      const parseContextRemaining = (pane: string | null): number | null => {
+        const match = pane?.match(/Context left until auto-compact:\s*([0-9]+)%/i);
+        if (!match) return null;
+        const value = Number(match[1]);
+        return Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : null;
+      };
+      const proactiveCompaction = new ProactiveCompactionSentinel(
+        {
+          listCandidates: async () => Promise.all(sessionManager.listRunningSessions().map(async (session) => {
+            const topic = telegram?.getTopicForSession(session.tmuxSession);
+            let autonomous = false;
+            if (topic != null) {
+              try {
+                autonomous = fs.existsSync(
+                  path.join(config.stateDir, 'autonomous', `${topic}.local.md`),
+                );
+              } catch {
+                // Fail closed: an unreadable registration never grants actuation.
+                autonomous = false;
+              }
+            }
+            return {
+              sessionName: session.tmuxSession,
+              autonomous,
+              framework: session.framework,
+              contextRemainingPercent: parseContextRemaining(
+                sessionManager.captureOutput(session.tmuxSession, 30),
+              ),
+              workState: await sessionManager.checkSessionWorkState(session.tmuxSession),
+            };
+          })),
+          triggerCompact: (sessionName) =>
+            sessionManager.injectInternalMessage(
+              sessionName,
+              '/compact',
+              'proactive-autonomous-compaction',
+            ),
+          audit: (event) => {
+            console.log(
+              `[ProactiveCompaction] ${event.kind} "${event.sessionName}" ` +
+              `at ${event.usedPercent}% used (threshold ${event.thresholdUsedPercent}%)`,
+            );
+          },
+        },
+        proactiveCompactionCfg,
+      );
+      const proactiveCompactionTimer = setInterval(
+        () => { void proactiveCompaction.tick(); },
+        Math.max(10_000, proactiveCompactionCfg.tickIntervalMs ?? 60_000),
+      );
+      proactiveCompactionTimer.unref?.();
+      void proactiveCompaction.tick();
+      console.log(pc.green(
+        `  Proactive autonomous compaction enabled (${proactiveCompactionCfg.dryRun === false ? 'live' : 'dry-run'})`,
+      ));
+    }
+
     // ── Silently-stopped trio: SocketDisconnectSentinel + ActiveWorkSilenceSentinel ──
     // Wire-up post-2026-05-22 incident. Every transition (detect/nudge/recover)
     // lands in the audit log (server logs + JSONL) — the user never sees it.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5753,6 +5753,21 @@ export interface MonitoringConfig {
     dedupeWindowMs?: number;
   };
   /**
+   * Proactive compaction for autonomous Claude sessions. Explicit opt-in only
+   * (dark when absent); dry-run defaults true. It reads Claude's own
+   * "Context left until auto-compact" status and acts only at an idle boundary.
+   */
+  proactiveAutonomousCompaction?: {
+    enabled?: boolean;
+    dryRun?: boolean;
+    /** Used-context threshold percentage (default 85). */
+    thresholdUsedPercent?: number;
+    /** Poll cadence in milliseconds (default 60_000). */
+    tickIntervalMs?: number;
+    /** Per-session action cooldown in milliseconds (default 30 minutes). */
+    cooldownMs?: number;
+  };
+  /**
    * SocketDisconnectSentinel — detects Claude Code's "socket connection closed
    * unexpectedly" family in tracked sessions and runs a bounded recovery loop
    * (notice → Enter retry → verify → escalate via the tone-gated /attention

--- a/src/monitoring/ProactiveCompactionSentinel.ts
+++ b/src/monitoring/ProactiveCompactionSentinel.ts
@@ -1,0 +1,103 @@
+/**
+ * Proactively asks an idle autonomous Claude session to compact before it
+ * reaches the context wall. The caller owns session discovery and the cadence;
+ * this class owns the threshold, idle-boundary, dry-run, and anti-repeat gates.
+ */
+
+export interface ProactiveCompactionCandidate {
+  sessionName: string;
+  autonomous: boolean;
+  framework?: string;
+  contextRemainingPercent: number | null;
+  workState: 'working' | 'idle' | 'indeterminate';
+}
+
+export interface ProactiveCompactionConfig {
+  enabled?: boolean;
+  dryRun?: boolean;
+  /** Compact once used context reaches this percentage. Default 85. */
+  thresholdUsedPercent?: number;
+  /** Minimum spacing between actions for one session. Default 30 minutes. */
+  cooldownMs?: number;
+}
+
+export interface ProactiveCompactionDeps {
+  listCandidates: () => Promise<ProactiveCompactionCandidate[]>;
+  triggerCompact: (sessionName: string) => boolean;
+  now?: () => number;
+  audit?: (event: ProactiveCompactionAuditEvent) => void;
+}
+
+export interface ProactiveCompactionAuditEvent {
+  kind: 'would-compact' | 'compact-triggered' | 'compact-trigger-failed';
+  sessionName: string;
+  usedPercent: number;
+  thresholdUsedPercent: number;
+  at: number;
+}
+
+export class ProactiveCompactionSentinel {
+  private readonly enabled: boolean;
+  private readonly dryRun: boolean;
+  private readonly thresholdUsedPercent: number;
+  private readonly cooldownMs: number;
+  private readonly lastActionAt = new Map<string, number>();
+  private running = false;
+
+  constructor(
+    private readonly deps: ProactiveCompactionDeps,
+    config: ProactiveCompactionConfig = {},
+  ) {
+    this.enabled = config.enabled === true;
+    this.dryRun = config.dryRun !== false;
+    this.thresholdUsedPercent = Math.min(99, Math.max(1, config.thresholdUsedPercent ?? 85));
+    this.cooldownMs = Math.max(1_000, config.cooldownMs ?? 30 * 60_000);
+  }
+
+  async tick(): Promise<void> {
+    if (!this.enabled || this.running) return;
+    this.running = true;
+    try {
+      const now = this.deps.now?.() ?? Date.now();
+      for (const candidate of await this.deps.listCandidates()) {
+        if (!candidate.autonomous || candidate.framework !== 'claude-code') continue;
+        if (candidate.workState !== 'idle' || candidate.contextRemainingPercent == null) continue;
+
+        const usedPercent = 100 - candidate.contextRemainingPercent;
+        if (usedPercent < this.thresholdUsedPercent) continue;
+        const last = this.lastActionAt.get(candidate.sessionName);
+        if (last != null && now - last < this.cooldownMs) continue;
+
+        this.lastActionAt.set(candidate.sessionName, now);
+        if (this.dryRun) {
+          this.audit('would-compact', candidate.sessionName, usedPercent, now);
+          continue;
+        }
+        const accepted = this.deps.triggerCompact(candidate.sessionName);
+        this.audit(
+          accepted ? 'compact-triggered' : 'compact-trigger-failed',
+          candidate.sessionName,
+          usedPercent,
+          now,
+        );
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private audit(
+    kind: ProactiveCompactionAuditEvent['kind'],
+    sessionName: string,
+    usedPercent: number,
+    at: number,
+  ): void {
+    this.deps.audit?.({
+      kind,
+      sessionName,
+      usedPercent,
+      thresholdUsedPercent: this.thresholdUsedPercent,
+      at,
+    });
+  }
+}

--- a/src/monitoring/guardManifest.ts
+++ b/src/monitoring/guardManifest.ts
@@ -728,6 +728,18 @@ export const GUARD_MANIFEST: readonly GuardManifestEntry[] = [
     description: 'Detects provider rate-limit walls and schedules recovery.',
   },
   {
+    key: 'monitoring.proactiveAutonomousCompaction.enabled',
+    kind: 'config',
+    configPath: 'monitoring.proactiveAutonomousCompaction.enabled',
+    defaultEnabled: false,
+    dryRunConfigPath: 'monitoring.proactiveAutonomousCompaction.dryRun',
+    expectedTickMs: 60_000,
+    process: 'server',
+    expectRuntime: false,
+    component: 'ProactiveCompactionSentinel',
+    description: 'At an idle boundary, proactively compacts explicitly opted-in autonomous Claude sessions before they reach the context wall; ships dark and dry-run first.',
+  },
+  {
     key: 'monitoring.parallelWorkSentinel.enabled',
     kind: 'config',
     configPath: 'monitoring.parallelWorkSentinel.enabled',

--- a/tests/unit/ProactiveCompactionSentinel.test.ts
+++ b/tests/unit/ProactiveCompactionSentinel.test.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ProactiveCompactionSentinel,
+  type ProactiveCompactionCandidate,
+} from '../../src/monitoring/ProactiveCompactionSentinel.js';
+
+const candidate = (overrides: Partial<ProactiveCompactionCandidate> = {}): ProactiveCompactionCandidate => ({
+  sessionName: 'autonomous-1',
+  autonomous: true,
+  framework: 'claude-code',
+  contextRemainingPercent: 15,
+  workState: 'idle',
+  ...overrides,
+});
+
+describe('ProactiveCompactionSentinel', () => {
+  it('is dark unless explicitly enabled', async () => {
+    const triggerCompact = vi.fn(() => true);
+    const listCandidates = vi.fn(async () => [candidate()]);
+    const sentinel = new ProactiveCompactionSentinel({ listCandidates, triggerCompact });
+
+    await sentinel.tick();
+
+    expect(listCandidates).not.toHaveBeenCalled();
+    expect(triggerCompact).not.toHaveBeenCalled();
+  });
+
+  it('dry-runs at 85% used without changing the session', async () => {
+    const triggerCompact = vi.fn(() => true);
+    const audit = vi.fn();
+    const sentinel = new ProactiveCompactionSentinel(
+      { listCandidates: async () => [candidate()], triggerCompact, audit, now: () => 50_000 },
+      { enabled: true },
+    );
+
+    await sentinel.tick();
+
+    expect(triggerCompact).not.toHaveBeenCalled();
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'would-compact',
+      usedPercent: 85,
+    }));
+  });
+
+  it('only compacts autonomous Claude sessions at an idle turn boundary', async () => {
+    const triggerCompact = vi.fn(() => true);
+    const sentinel = new ProactiveCompactionSentinel(
+      {
+        listCandidates: async () => [
+          candidate({ sessionName: 'working', workState: 'working' }),
+          candidate({ sessionName: 'interactive', autonomous: false }),
+          candidate({ sessionName: 'codex', framework: 'codex-cli' }),
+          candidate({ sessionName: 'unknown', workState: 'indeterminate' }),
+          candidate({ sessionName: 'safe', contextRemainingPercent: 16 }),
+          candidate({ sessionName: 'eligible' }),
+        ],
+        triggerCompact,
+      },
+      { enabled: true, dryRun: false },
+    );
+
+    await sentinel.tick();
+
+    expect(triggerCompact).toHaveBeenCalledTimes(1);
+    expect(triggerCompact).toHaveBeenCalledWith('eligible');
+  });
+
+  it('cooldown prevents repeated /compact injections on successive ticks', async () => {
+    let now = 10_000;
+    const triggerCompact = vi.fn(() => true);
+    const sentinel = new ProactiveCompactionSentinel(
+      { listCandidates: async () => [candidate()], triggerCompact, now: () => now },
+      { enabled: true, dryRun: false, cooldownMs: 60_000 },
+    );
+
+    await sentinel.tick();
+    now += 30_000;
+    await sentinel.tick();
+    now += 31_000;
+    await sentinel.tick();
+
+    expect(triggerCompact).toHaveBeenCalledTimes(2);
+  });
+
+  it('is wired dark, dry-run first, to the canonical idle probe and /compact command', () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), 'src/commands/server.ts'),
+      'utf8',
+    );
+
+    expect(source).toContain('proactiveCompactionCfg?.enabled === true');
+    expect(source).toContain('checkSessionWorkState(session.tmuxSession)');
+    expect(source).toContain("'/compact'");
+    expect(source).toContain("'proactive-autonomous-compaction'");
+  });
+});

--- a/upgrades/next/proactive-autonomous-compaction.md
+++ b/upgrades/next/proactive-autonomous-compaction.md
@@ -1,0 +1,15 @@
+# Proactive Autonomous Compaction
+
+## What Changed
+
+Autonomous Claude sessions can now compact before reaching the context wall. The feature is explicitly opt-in and starts in dry-run.
+
+## What to Tell Your User
+
+At 85% context used, Instar can wait for an idle turn boundary and prepare a safe context compaction before an unattended autonomous session reaches the wall. It does not interrupt active work, and nothing changes unless the feature is explicitly enabled.
+
+## Summary of New Capabilities
+
+- Dark, config-gated proactive compaction for autonomous Claude sessions.
+- Dry-run-first observation at a configurable used-context threshold.
+- Idle-only actuation with fail-closed handling of uncertain work state.

--- a/upgrades/side-effects/proactive-autonomous-compaction.md
+++ b/upgrades/side-effects/proactive-autonomous-compaction.md
@@ -1,0 +1,8 @@
+# Side effects: proactive autonomous compaction
+
+- Adds an opt-in 60-second monitor only when explicitly enabled.
+- Reads each running Claude pane and the existing autonomous-topic registration.
+- In dry-run, emits audit logs only.
+- In live mode, injects `/compact` only at an affirmatively idle turn boundary.
+- Does not operate on Codex, Gemini, interactive/non-autonomous sessions, or indeterminate work states.
+- Rollback is immediate via `monitoring.proactiveAutonomousCompaction.enabled:false`.


### PR DESCRIPTION
## Summary

- add a dark, config-gated proactive compaction monitor for autonomous Claude sessions
- use Claude’s grounded remaining-context display and trigger at 85% used
- require the canonical work-state probe to affirm an idle turn boundary
- ship dry-run first with cooldown, framework, registration, and uncertainty brakes

## ELI16

A long-running agent is like someone filling a notebook while working. Recovering after the notebook is completely full is harder than condensing it before the last pages are used. Claude already displays how much context remains, so this monitor can notice when an autonomous session reaches 85% used. It waits until Claude is definitely between turns, then—in live mode—asks Claude to compact. Working, uncertain, ordinary interactive, and non-Claude sessions are untouched. The feature is off unless explicitly enabled, and its first enabled posture only records what it would do.

## Verification

- focused sentinel tests: 5 passed
- TypeScript and full lint battery passed
- clean-environment unit suite: 38,273 passed, 4 skipped; one unrelated shared-state route timed out under full-suite load
- exact timed-out file rerun immediately: 52/52 passed

## Rollout

Dark by default. When enabled, dry-run remains the default. Live compaction requires an explicit dry-run-off setting.