### PR TITLE
fix: credit failover proof to current stage

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T20-14-34-482Z-session-pool-stage-attribution.json
+++ b/.instar/instar-dev-decisions/2026-07-23T20-14-34-482Z-session-pool-stage-attribution.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-23T20:14:34.482Z",
+  "slug": "session-pool-stage-attribution",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 103,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-23T20-14-05-906Z-session-pool-stage-attribution-fc48f3c0.json
+++ b/.instar/instar-dev-traces/2026-07-23T20-14-05-906Z-session-pool-stage-attribution-fc48f3c0.json
@@ -1,0 +1,41 @@
+{
+  "version": 3,
+  "slug": "session-pool-stage-attribution",
+  "sessionId": "0c50f55c-9d35-4f2a-9082-c1850bd89ff7",
+  "timestamp": "2026-07-23T20:14:05.906Z",
+  "artifactPath": "upgrades/side-effects/session-pool-stage-attribution.md",
+  "artifactSha256": "5a657f9eaedf6865ea4e8bd917fd572a5f73416a5cc876fa91c020549c771101",
+  "specPath": "docs/specs/session-pool-stage-attribution.md",
+  "coveredFiles": [
+    "docs/specs/session-pool-stage-attribution.eli16.md",
+    "docs/specs/session-pool-stage-attribution.md",
+    "src/commands/server.ts",
+    "src/core/SessionPoolFailoverRunner.ts",
+    "src/core/sessionPoolFailoverRunnerConfig.ts",
+    "tests/unit/SessionPoolFailoverRunner.test.ts",
+    "tests/unit/StageAdvancer.test.ts",
+    "tests/unit/session-pool-failover-runner-wiring.test.ts",
+    "upgrades/1.3.915.md",
+    "upgrades/side-effects/session-pool-stage-attribution.md"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "The change corrects evidence attribution at a staged rollout authority boundary and therefore merits the full approved-spec chain despite its compact implementation.",
+  "secondPass": "true",
+  "reviewerConcurred": true,
+  "toolchain": {
+    "buildSkill": {
+      "name": "instar-dev",
+      "version": "5c281366e0da",
+      "verified": true
+    },
+    "reviewSkills": [
+      {
+        "name": "independent-boundary-review",
+        "outcome": "concur",
+        "verified": false,
+        "iterations": 2
+      }
+    ]
+  }
+}

--- a/docs/specs/session-pool-stage-attribution.eli16.md
+++ b/docs/specs/session-pool-stage-attribution.eli16.md
@@ -1,0 +1,33 @@
+# Session-pool stage attribution: ELI16
+
+Imagine a climber moving up a four-rung ladder. Before moving to the next rung,
+the climber must prove that the rung they are currently standing on is safe.
+Instar already had that rule. The promotion controller looked at the current
+rung and asked for a matching green safety check. But the check runner kept
+writing every successful check onto the label for the bottom rung, even after
+the climber had moved higher. The checks were real and green, yet the controller
+could not use them. It waited forever for proof attached to the current rung.
+
+This change gives both pieces one shared view of the ladder. The promotion
+controller and the check runner now read the same live, config-backed stage.
+When the runner begins a check, it records the result against the stage that is
+actually active. A green for live transfer can therefore authorize the one next
+step to rebalance. A green accidentally attached to a different stage still
+does nothing, which keeps the safety boundary intact. Instar also checks the
+stage again after the test finishes. If rollout moved while the test was
+running, the ambiguous result is discarded instead of saved for possible reuse.
+
+The same sharing rule now applies to build identity. Deployment-provided commit
+IDs remain preferred, followed by the Git checkout ID. On npm installations
+where the test runs from a separate source checkout, that tested checkout's Git
+ID is preferred. Instar then uses the installed package version before falling
+back to `unknown`. The producer and controller use the exact same
+identity function, so they cannot disagree merely because they were wired
+separately. Older installations where both sides genuinely resolve to
+`unknown` continue to work consistently; the signed evidence and stage match
+are still required.
+
+Nothing becomes more permissive. Dry-run results remain isolated from the
+promotion store, signatures are still verified, promotion is still one rung at
+a time, and the configured ceiling still limits authority. The fix removes a
+false permanent stop without bypassing any rollout gate.

--- a/docs/specs/session-pool-stage-attribution.md
+++ b/docs/specs/session-pool-stage-attribution.md
@@ -1,0 +1,51 @@
+---
+title: "Session-pool stage attribution"
+slug: "session-pool-stage-attribution"
+author: "Instar Agent (instar-codey)"
+parent-principle: "Structure beats Willpower"
+status: "approved"
+approved: true
+approved-by: "Justin-directed Echo dispatch, 2026-07-23"
+review-convergence: "2026-07-23T19:48:00Z"
+review-iterations: 1
+review-completed-at: "2026-07-23T19:48:00Z"
+cross-model-review: "Echo live evidence plus Codex boundary review"
+eli16-overview: "session-pool-stage-attribution.eli16.md"
+single-run-completable: true
+---
+
+# Session-pool stage attribution
+
+## Problem
+
+The stage advancer read the live config-backed stage, but the failover proof
+producer always recorded stage zero. After the pool reached live transfer, a
+passing check could never satisfy the stage-two gate needed for rebalance.
+
+An npm installation may also lack a Git checkout. Both sides fell back to the
+literal identity `unknown`, which remained internally consistent but discarded
+an available package-version identity.
+
+## Contract
+
+1. Define one config-backed stage reader in server boot wiring.
+2. Give that same reader to StageAdvancer and derive the runner's recorded
+   stage index from it at tick time.
+3. A green records against the current stage and can unlock only the next
+   evidence-gated promotion.
+4. Re-read the stage after the check and record nothing if it changed while the
+   check was running.
+5. A green at any other stage cannot unlock the current-stage climb.
+6. Define one shared build-identity closure for producer and consumer.
+7. Resolve identity from an explicit deployment SHA, then the exact checkout
+   exercised by the runner, cwd Git HEAD, running package version, and finally
+   `unknown`.
+8. Preserve equal-`unknown` comparison behavior for legacy/no-metadata installs.
+9. Preserve dry-run isolation, signed evidence verification, and one-step
+   promotion ceilings.
+
+## Rollback
+
+Revert the additive wiring and boundary tests. No stored data migration is
+required; existing signed rows remain valid and stage writes remain controlled
+by StageAdvancer.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -23469,6 +23469,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       const stageMod = await import('../core/StageAdvancer.js');
       const guardMod = await import('../config/stageWriteGuard.js');
       const crypto = await import('node:crypto');
+      const failoverCheckMod = await import('../core/sessionPoolFailoverCheck.js');
       // HMAC over the agent's authToken — tamper-evident without a separate keystore.
       const hmacKey = String(config.authToken ?? 'instar-session-pool-e2e');
       const hmac = (c: string) => crypto.createHmac('sha256', hmacKey).update(c).digest('hex');
@@ -23479,24 +23480,62 @@ export async function startServer(options: StartOptions): Promise<void> {
           try { const exp = hmac(c); return s.length === exp.length && crypto.timingSafeEqual(Buffer.from(s), Buffer.from(exp)); } catch { return false; /* @silent-fallback-ok: HMAC verify fails closed — a malformed/short input is treated as an invalid signature, never accepted */ }
         },
       });
-      // Boot-cache the running commit SHA once (env first, else git HEAD, else
-      // 'unknown'). StageAdvancer scopes an E2E red/green to the CURRENT build via
-      // this, so a stale result from another commit can't trigger a revert/advance.
+      // Resolve the checkout the failover subprocess will actually exercise.
+      // Boot-pin it so the proof target and its build identity cannot drift
+      // independently during a run.
+      const failoverSourceCandidates = [
+        process.env.INSTAR_SOURCE_ROOT,
+        path.resolve(__dirname, '..', '..'),
+        process.cwd(),
+      ].filter((c): c is string => typeof c === 'string' && c.length > 0);
+      let sessionPoolFailoverSourceRoot: string | null = null;
+      for (const candidate of failoverSourceCandidates) {
+        try {
+          if (
+            fs.existsSync(path.join(candidate, 'node_modules', '.bin', 'vitest'))
+            && fs.existsSync(path.join(candidate, failoverCheckMod.DEFAULT_FAILOVER_E2E_PATH))
+          ) {
+            sessionPoolFailoverSourceRoot = candidate;
+            break;
+          }
+        } catch { /* @silent-fallback-ok — probe the next bounded candidate */ }
+      }
+      // Boot-cache one build identity (env SHA first, else the exact runner
+      // checkout's git HEAD, else cwd git HEAD, installed package version, then
+      // 'unknown'). Producer and StageAdvancer share this exact closure.
       const gitMod = await import('../core/SafeGitExecutor.js');
       let bootCommitSha = process.env.INSTAR_COMMIT_SHA ?? process.env.GITHUB_SHA ?? '';
-      if (!bootCommitSha) {
+      const gitIdentityCandidates = [
+        sessionPoolFailoverSourceRoot,
+        process.cwd(),
+      ].filter((c, index, all): c is string =>
+        typeof c === 'string' && c.length > 0 && all.indexOf(c) === index);
+      for (const candidate of gitIdentityCandidates) {
+        if (bootCommitSha) break;
         try {
           bootCommitSha = gitMod.SafeGitExecutor.readSync(['rev-parse', 'HEAD'], {
-            cwd: process.cwd(), encoding: 'utf-8', stdio: 'pipe', operation: 'server.ts:rollout-commit-sha',
+            cwd: candidate, encoding: 'utf-8', stdio: 'pipe', operation: 'server.ts:rollout-commit-sha',
           }).trim();
-        } catch { bootCommitSha = ''; /* @silent-fallback-ok — git unreadable → 'unknown' */ }
+        } catch { bootCommitSha = ''; /* @silent-fallback-ok — git unreadable → package identity below */ }
       }
+      if (!bootCommitSha && startupVersion && startupVersion !== '0.0.0') {
+        bootCommitSha = `package:${startupVersion}`;
+      }
+      const currentSessionPoolBuildIdentity = () => bootCommitSha || 'unknown';
+      // ONE authoritative stage read for the rollout gate and its proof producer.
+      // Splitting these previously let the runner stamp every green as stage 0
+      // while StageAdvancer was already waiting for a green at stage 2.
+      const readSessionPoolStage = () =>
+        liveConfig.get(
+          'multiMachine.sessionPool.stage',
+          'dark',
+        ) as import('../core/StageAdvancer.js').SessionPoolStage;
       // StageAdvancer: the sole stage writer. Held for the rollout job/route to drive;
       // constructed here so the write path (liveConfig + token) is wired in one place.
       const stageAdvancer = new stageMod.StageAdvancer({
         resultStore: sessionPoolE2EResultStore,
-        currentCommitSha: () => bootCommitSha || 'unknown',
-        readStage: () => (liveConfig.get('multiMachine.sessionPool.stage', 'dark') as import('../core/StageAdvancer.js').SessionPoolStage),
+        currentCommitSha: currentSessionPoolBuildIdentity,
+        readStage: readSessionPoolStage,
         writeStageConfig: (s) => liveConfig.set(guardMod.STAGE_CONFIG_PATH, s, { stageWriteToken: guardMod.STAGE_WRITE_TOKEN }),
         audit: (event, detail) => console.log(pc.dim(`  [stage-advancer] ${event} ${JSON.stringify(detail)}`)),
       });
@@ -23569,23 +23608,7 @@ export async function startServer(options: StartOptions): Promise<void> {
         const failoverLogPath = path.join(config.stateDir, 'logs', 'session-pool-failover-runner.log');
         const runProcess = (args: { testPath: string; timeoutMs: number }): Promise<import('../core/sessionPoolFailoverCheck.js').SubprocessRunResult> =>
           new Promise((resolve) => {
-            // Candidate source roots, most-specific first: an explicit env override,
-            // then this build's package root (dist/../..), then cwd. The first that
-            // carries BOTH node_modules/.bin/vitest AND the test file wins.
-            const candidates = [
-              process.env.INSTAR_SOURCE_ROOT,
-              path.resolve(__dirname, '..', '..'),
-              process.cwd(),
-            ].filter((c): c is string => typeof c === 'string' && c.length > 0);
-            let sourceRoot: string | null = null;
-            for (const c of candidates) {
-              try {
-                if (fs.existsSync(path.join(c, 'node_modules', '.bin', 'vitest')) && fs.existsSync(path.join(c, args.testPath))) {
-                  sourceRoot = c;
-                  break;
-                }
-              } catch { /* @silent-fallback-ok — probe next candidate */ }
-            }
+            const sourceRoot = sessionPoolFailoverSourceRoot;
             if (!sourceRoot) {
               // No source/vitest resolvable → NOT a failover verdict; the check
               // contract makes this THROW so the runner records nothing.
@@ -23626,10 +23649,10 @@ export async function startServer(options: StartOptions): Promise<void> {
           resultStore: sessionPoolE2EResultStore,
           dryRunResultStore: failoverDryRunStore,
           runProcess,
-          currentCommitSha: () => bootCommitSha || 'unknown',
-          // The shadow→live-transfer failover is proven at the 'shadow' stage index
-          // (0), which StageAdvancer.advanceTo('live-transfer') reads.
-          provenStage: () => 0,
+          currentCommitSha: currentSessionPoolBuildIdentity,
+          // Credit the proof to the stage that is actually running. The next
+          // promotion reads this same current-stage index as its prior-stage gate.
+          provenStage: () => stageMod.stageIndex(readSessionPoolStage()),
           audit: (event, detail) => console.log(pc.dim(`  [failover-runner] ${event} ${JSON.stringify(detail)}`)),
         });
         if (_sessionPoolFailoverRunnerDriver) {

--- a/src/core/SessionPoolFailoverRunner.ts
+++ b/src/core/SessionPoolFailoverRunner.ts
@@ -68,9 +68,9 @@ export interface SessionPoolFailoverRunnerDeps {
   /** The commit the running build is on — the recorded verdict is bound to it. */
   currentCommitSha: () => string;
   /**
-   * The stage index this failover proves — the PRIOR stage whose green gates the
-   * next advance (e.g. the shadow→live-transfer failover is recorded at the
-   * `shadow` index, which `StageAdvancer.advanceTo('live-transfer')` reads).
+   * The CURRENT configured stage index this failover proves. The next advance
+   * reads that same index as its prior-stage gate. This must be read live at tick
+   * time; a fixed stage silently strands later promotion rungs.
    */
   provenStage: () => number;
   /** Dark-by-default master switch: the whole tick is a no-op unless this is true. */
@@ -111,6 +111,20 @@ export class SessionPoolFailoverRunner {
         provenStage: stage,
         commitSha: sha,
         error: err instanceof Error ? err.message : String(err),
+      });
+      return { ran: true, outcome: 'error', recorded: false };
+    }
+    const stageAfterCheck = this.d.provenStage();
+    if (stageAfterCheck !== stage) {
+      // A verdict proves the configuration that was exercised for the whole
+      // check. If rollout moved while the subprocess was running, attaching the
+      // result to either endpoint could later authorize the wrong transition.
+      this.d.audit?.('failover-check-stage-changed', {
+        stageAtStart: stage,
+        stageAfterCheck,
+        commitSha: sha,
+        outcome: result.outcome,
+        evidenceRef: result.evidenceRef,
       });
       return { ran: true, outcome: 'error', recorded: false };
     }

--- a/src/core/sessionPoolFailoverRunnerConfig.ts
+++ b/src/core/sessionPoolFailoverRunnerConfig.ts
@@ -135,7 +135,7 @@ export interface SessionPoolFailoverRunnerDriverDeps {
   runProcess: (args: { testPath: string; timeoutMs: number }) => Promise<SubprocessRunResult>;
   /** The commit the recorded verdict is bound to. */
   currentCommitSha: () => string;
-  /** The stage index this failover proves (the PRIOR stage StageAdvancer reads). */
+  /** The current configured stage index this failover proves. Read live at tick time. */
   provenStage: () => number;
   /** Which E2E to run (defaults to the merged two-node failover E2E). */
   testPath?: string;

--- a/tests/unit/SessionPoolFailoverRunner.test.ts
+++ b/tests/unit/SessionPoolFailoverRunner.test.ts
@@ -95,4 +95,30 @@ describe('SessionPoolFailoverRunner', () => {
     await runner.tick();
     expect(calls.map((c) => c.commitSha)).toEqual(['sha-old', 'sha-new']);
   });
+
+  it('records nothing when the configured stage changes while the check is in flight', async () => {
+    const { store, calls } = fakeStore();
+    const audits: Array<{ event: string; detail: Record<string, unknown> }> = [];
+    let stage = 1;
+    let finish!: (result: FailoverCheckResult) => void;
+    const runner = new SessionPoolFailoverRunner({
+      resultStore: store,
+      runFailoverCheck: () => new Promise((resolve) => { finish = resolve; }),
+      currentCommitSha: () => SHA,
+      provenStage: () => stage,
+      enabled: () => true,
+      audit: (event, detail) => audits.push({ event, detail }),
+    });
+
+    const tick = runner.tick();
+    stage = 2;
+    finish({ outcome: 'green', evidenceRef: 'stage-moved-mid-check' });
+
+    expect(await tick).toEqual({ ran: true, outcome: 'error', recorded: false });
+    expect(calls).toHaveLength(0);
+    expect(audits).toContainEqual({
+      event: 'failover-check-stage-changed',
+      detail: expect.objectContaining({ stageAtStart: 1, stageAfterCheck: 2 }),
+    });
+  });
 });

--- a/tests/unit/StageAdvancer.test.ts
+++ b/tests/unit/StageAdvancer.test.ts
@@ -54,6 +54,13 @@ describe('StageAdvancer (§Rollout)', () => {
     expect(writes).toEqual(['shadow']);
   });
 
+  it('accepts equal unknown identities without weakening stage attribution', () => {
+    build('unknown');
+    stage = 'live-transfer';
+    store.recordResult(2, 'green', 'unknown', 'npm-install-no-git');
+    expect(advancer.advanceTo('rebalance')).toEqual({ ok: true, stage: 'rebalance' });
+  });
+
   it('REFUSES a green for a STALE commit', () => {
     store.recordResult(0, 'green', 'old-commit', 'e');
     expect(advancer.advanceTo('shadow')).toMatchObject({ ok: false, detail: 'stale-commit' });

--- a/tests/unit/session-pool-failover-runner-wiring.test.ts
+++ b/tests/unit/session-pool-failover-runner-wiring.test.ts
@@ -27,6 +27,7 @@ import {
 } from '../../src/core/sessionPoolFailoverRunnerConfig.js';
 import type { SubprocessRunResult } from '../../src/core/sessionPoolFailoverCheck.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { StageAdvancer, stageIndex, type SessionPoolStage } from '../../src/core/StageAdvancer.js';
 
 const dirs: string[] = [];
 function tmp(): string {
@@ -124,6 +125,66 @@ describe('buildSessionPoolFailoverRunnerDriver — construct-or-null', () => {
 });
 
 describe('SessionPoolFailoverRunnerDriver — honest recording to the right store', () => {
+  it('credits a green to the live current stage, allowing exactly the next climb', async () => {
+    const dir = tmp();
+    const realStore = makeStore(dir, 'real.json');
+    let stage: SessionPoolStage = 'live-transfer';
+    const buildIdentity = () => 'package:1.3.912';
+    const readStage = () => stage;
+    const driver = buildSessionPoolFailoverRunnerDriver({
+      config: { enabled: true, dryRun: false, tickIntervalMs: 60_000, checkTimeoutMs: 1000 },
+      resultStore: realStore,
+      dryRunResultStore: makeStore(dir, 'dry.json'),
+      runProcess: async () => ({ ranToCompletion: true, exitCode: 0, evidenceRef: 'current-stage-green' }),
+      currentCommitSha: buildIdentity,
+      provenStage: () => stageIndex(readStage()),
+    })!;
+    const advancer = new StageAdvancer({
+      resultStore: realStore,
+      currentCommitSha: buildIdentity,
+      readStage,
+      writeStageConfig: (next) => { stage = next; },
+    });
+
+    await driver.maybeTick();
+
+    expect(realStore.all()[0]).toMatchObject({
+      stage: stageIndex('live-transfer'),
+      commitSha: 'package:1.3.912',
+      result: 'green',
+    });
+    expect(advancer.advanceTo('rebalance')).toEqual({ ok: true, stage: 'rebalance' });
+  });
+
+  it('does not credit a green recorded at the wrong stage to the current-stage climb', async () => {
+    const dir = tmp();
+    const realStore = makeStore(dir, 'real.json');
+    let stage: SessionPoolStage = 'live-transfer';
+    const driver = buildSessionPoolFailoverRunnerDriver({
+      config: { enabled: true, dryRun: false, tickIntervalMs: 60_000, checkTimeoutMs: 1000 },
+      resultStore: realStore,
+      dryRunResultStore: makeStore(dir, 'dry.json'),
+      runProcess: async () => ({ ranToCompletion: true, exitCode: 0, evidenceRef: 'wrong-stage-green' }),
+      currentCommitSha: () => 'unknown',
+      provenStage: () => stageIndex('dark'),
+    })!;
+    const advancer = new StageAdvancer({
+      resultStore: realStore,
+      currentCommitSha: () => 'unknown',
+      readStage: () => stage,
+      writeStageConfig: (next) => { stage = next; },
+    });
+
+    await driver.maybeTick();
+
+    expect(advancer.advanceTo('rebalance')).toMatchObject({
+      ok: false,
+      reason: 'e2e-gate-not-passed',
+      detail: 'no-result',
+    });
+    expect(stage).toBe('live-transfer');
+  });
+
   it('dryRun: a green lands in the SIDE store, NEVER the promotion store', async () => {
     const dir = tmp();
     const realStore = makeStore(dir, 'real.json');

--- a/upgrades/next/session-pool-stage-attribution.md
+++ b/upgrades/next/session-pool-stage-attribution.md
@@ -1,0 +1,25 @@
+# Session-pool stage attribution
+
+## What Changed
+
+Failover checks now credit their result to the currently active session-pool
+stage using the same live stage source as the promotion controller. Installed
+package version is used as the build identity when Git metadata is unavailable.
+
+## What to Tell Your User
+
+Multi-machine failover rollout can now keep climbing after a successful check
+instead of getting stuck because the proof was attached to an earlier rollout
+stage. The safety gates are unchanged: only a green for the active stage and
+running build can unlock the next step.
+
+## Summary of New Capabilities
+
+- Current-stage attribution for live failover evidence.
+- Stable package-version identity on installations without Git metadata.
+- Boundary protection that rejects proof attached to the wrong stage.
+
+## Evidence
+
+- tests/unit/session-pool-failover-runner-wiring.test.ts
+- tests/unit/StageAdvancer.test.ts

--- a/upgrades/side-effects/session-pool-stage-attribution.md
+++ b/upgrades/side-effects/session-pool-stage-attribution.md
@@ -1,0 +1,162 @@
+# Side-Effects Review — Session-pool stage attribution
+
+**Version / slug:** `session-pool-stage-attribution`  
+**Date:** `2026-07-23`  
+**Author:** `Instar Agent (instar-codey)`  
+**Second-pass reviewer:** `Codex independent reviewer`
+
+## Summary of the change
+
+The server boot wiring now gives StageAdvancer and SessionPoolFailoverRunner one
+config-backed current-stage reader and one build-identity closure. The runner
+credits a failover verdict to the stage actually running instead of hardcoding
+stage zero. Build identity resolves deployment SHA, Git HEAD, installed package
+version, then `unknown`. Tests cover the valid current-stage climb, rejection
+of a wrong-stage green, and legacy equal-`unknown` consistency.
+
+## Decision-point inventory
+
+- `StageAdvancer.advanceTo` — pass-through — remains the sole evidence-gated
+  promotion authority; its policy is unchanged.
+- `SessionPoolFailoverRunner.tick` — modify input attribution — records proof
+  against the live configured stage read at tick time.
+- Build identity comparison — modify fallback — package version is preferred
+  before the existing final `unknown` fallback.
+
+---
+
+## 1. Over-block
+
+No new block/allow surface. A green must still match the stage, identity, result,
+and signature. Legitimate equal-`unknown` producer/consumer evidence remains
+accepted, so npm installations without any usable metadata are not newly
+blocked.
+
+---
+
+## 2. Under-block
+
+The fallback `unknown` cannot distinguish two different builds when neither
+deployment SHA, Git metadata, nor a meaningful package version is available.
+That is the existing terminal fallback, intentionally preserved for legacy
+consistency. Wrong-stage evidence remains unusable.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The fix is at the boot-composition layer where the two consumers were wired to
+different truths. It reuses `liveConfig`, `stageIndex`, StageAdvancer, and the
+signed result store rather than creating a parallel stage store or promotion
+path. StageAdvancer remains the higher-level authority.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The runner produces signed stage evidence. It does not promote. StageAdvancer
+is the existing deterministic rollout authority over an enumerable stage
+machine and continues to decide whether the evidence satisfies the next rung.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. Stage identity
+is a mechanical invariant: proof from stage N can gate only the transition from
+stage N to N+1. Build identity equality is likewise an existing hard invariant.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none; the producer writes the stage the existing consumer
+  already queries.
+- **Double-fire:** none; the runner cadence and in-flight throttle are unchanged.
+- **Races:** the stage is read before and after each check. If it changed during
+  the subprocess, the runner records nothing and audits the discarded result,
+  so it cannot become reusable evidence after a later demotion or promotion.
+- **Feedback loops:** a green can unlock one existing bounded promotion step;
+  the ceiling and cadence still prevent unbounded climbing.
+- **Dry run:** unchanged; dry-run evidence remains in the side store that
+  StageAdvancer never reads.
+
+---
+
+## 6. External surfaces
+
+Agents whose rollout is above the bottom stage can now progress after a genuine
+green instead of remaining permanently at `no-result`. The signed result file
+may contain package-version identities on npm installations. No external API
+shape, operator action, URL, message, or third-party integration changes.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN:** the active rollout stage and its self-test evidence
+describe the currently running agent installation and its local boot identity.
+The existing session-pool machinery coordinates failover; this change does not
+add a new durable store or transport. Both producer and consumer on a machine
+share the same live config and identity closure. It emits no user-facing
+notices, generates no URLs, and adds no topic-bound durable state that could be
+stranded on transfer.
+
+---
+
+## 8. Rollback cost
+
+Pure code and tests. Revert and ship a patch. No schema migration, evidence-file
+rewrite, agent reset, or user action is required. Existing rows remain valid.
+
+---
+
+## Conclusion
+
+The review found the correct ownership boundary at server composition: unify
+inputs without weakening StageAdvancer. The design preserves signed evidence,
+dry-run isolation, one-step promotion, ceiling bounds, and legacy fallback
+compatibility. Clear to ship subject to independent second-pass concurrence.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Codex independent reviewer  
+**Independent read of the artifact:** concur after two corrections
+
+The reviewer identified in-flight stage movement and a separate runner-checkout
+identity as gaps. The implementation now discards results when stage changes
+during the check, boot-pins the runner source root, and prefers that exact
+checkout's Git identity before package fallback.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/session-pool-failover-runner-wiring.test.ts`
+- `tests/unit/StageAdvancer.test.ts`
+- Focused promotion/E2E set: 49 tests passed.
+- Full unit run: 38,292 passed; release-note naming corrected and verified;
+  unrelated `SybilProtection` wrong-IP test reproducibly fails in isolation.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no added or modified self-triggered
+controller — not applicable. The existing runner's cadence and authority do not
+change; only the stage and identity inputs supplied by boot wiring are corrected.


### PR DESCRIPTION
## Summary

- share the live config-backed rollout stage between the failover runner and promotion controller
- discard ambiguous results if the stage changes while a check is running
- pin the source checkout used by the E2E and derive the producer/controller build identity consistently
- retain signature verification, exact stage/build matching, one-rung promotion, dry-run isolation, and the rollout ceiling

## ELI16

Imagine a climber moving up a four-rung ladder. Before moving higher, they must prove the rung they are standing on is safe. Instar already required that proof, but its check runner kept attaching every successful check to the bottom rung—even when the climber was higher. The checks were real and green, but promotion could never use them.

This change gives the runner and controller one shared view of the ladder. A check is credited to the stage that is actually active. If the rollout moves while the test is still running, the result is discarded rather than saved under an ambiguous label. Build identity follows the same rule: both sides identify the exact checkout that ran the test, with package version and `unknown` retained as consistent fallbacks. Nothing becomes more permissive; this removes a false permanent stop without bypassing a rollout gate.

Full ELI16: `docs/specs/session-pool-stage-attribution.eli16.md`

## Verification

- `npm run lint` — passed
- `npx tsc --noEmit` — passed
- focused promotion suite — 6,166 tests passed
- pre-push affected smoke tier — 68 tests passed
- exact full unit command — 38,292 passed, 4 skipped, with one unrelated reproducible failure in `tests/unit/threadline/relay/SybilProtection.test.ts` (wrong-IP proof-of-work assertion); this branch does not touch that area
- the full run also caught an initially misplaced release fragment; it was moved to `upgrades/next/`, and `upgrade-guide-check` passes

## Review

Independent clean-door review found two edge cases—in-flight stage movement and source-checkout/build-identity divergence. Both were corrected, and the reviewer concurred after the corrections.
