### PR TITLE
fix: recover disabled standby autostart

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T20-54-06-065Z-second-node-autostart-recovery.json
+++ b/.instar/instar-dev-decisions/2026-07-23T20-54-06-065Z-second-node-autostart-recovery.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-23T20:54:06.065Z",
+  "slug": "second-node-autostart-recovery",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 48,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-23T20-44-56-900Z-second-node-autostart-recovery-ffb30d25.json
+++ b/.instar/instar-dev-traces/2026-07-23T20-44-56-900Z-second-node-autostart-recovery-ffb30d25.json
@@ -1,0 +1,31 @@
+{
+  "version": 3,
+  "slug": "second-node-autostart-recovery",
+  "sessionId": "0c50f55c-9d35-4f2a-9082-c1850bd89ff7",
+  "timestamp": "2026-07-23T20:44:56.900Z",
+  "artifactPath": "upgrades/side-effects/second-node-autostart-recovery.md",
+  "artifactSha256": "b8fa86fac129c0a74df07976eb75249ac00ae0b483799e7e168cba4004b0de7e",
+  "coveredFiles": [
+    "docs/specs/second-node-autostart-recovery.eli16.md",
+    "docs/specs/second-node-autostart-recovery.md",
+    "src/commands/setup.ts",
+    "tests/unit/agent-robustness.test.ts",
+    "tests/unit/launchctl-load-guard.test.ts",
+    "upgrades/next/second-node-autostart-recovery.md",
+    "upgrades/side-effects/second-node-autostart-recovery.md"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Small deterministic recovery fix with no new API, data schema, or authority surface; live two-node reproduction and focused launchd tests cover both failure boundaries.",
+  "eli16Path": "docs/specs/second-node-autostart-recovery.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/second-node-autostart-recovery.md",
+  "secondPass": "not-required",
+  "reviewerConcurred": null,
+  "toolchain": {
+    "buildSkill": {
+      "name": "instar-dev",
+      "version": "5c281366e0da",
+      "verified": true
+    }
+  }
+}

--- a/docs/specs/second-node-autostart-recovery.eli16.md
+++ b/docs/specs/second-node-autostart-recovery.eli16.md
@@ -1,0 +1,19 @@
+# Second-node autostart recovery: ELI16
+
+Imagine a standby computer has a valid ignition key but its starter switch was
+turned off. Reinstalling the starter replaced all the right parts, then tried
+to start the engine without turning the switch back on. macOS returned a vague
+error, and the standby computer stayed absent.
+
+There was a second trap in the repair path. Instar keeps a stable shortcut to
+Node so upgrades do not break startup. If the repair command itself was launched
+through that shortcut, it could choose the shortcut as its own destination.
+That is like replacing a road sign with another sign pointing back to itself:
+the real road becomes unreachable.
+
+The installer now turns the exact service switch back on before asking macOS
+to start it. It also searches all Node locations on PATH and refuses to use its
+managed shortcut as the shortcut's target. A paired standby can therefore
+recover into the live pool after being disabled, without corrupting its next
+boot.
+

--- a/docs/specs/second-node-autostart-recovery.md
+++ b/docs/specs/second-node-autostart-recovery.md
@@ -1,0 +1,31 @@
+# Second-node autostart recovery
+
+## Problem
+
+A paired standby node could remain absent from the live session pool after its
+LaunchAgent label had been disabled. Re-running `instar autostart install`
+wrote a valid plist but attempted `bootstrap` while the label was still
+disabled, which macOS reported only as an input/output error.
+
+The repair command could also corrupt `.instar/bin/node` when invoked through
+that managed symlink. Candidate discovery selected the symlink itself and
+rewrote it as a self-referential link, preventing future boots.
+
+## Contract
+
+1. Installing macOS autostart explicitly enables the exact agent label before
+   bootstrapping its plist.
+2. Node candidate discovery considers every PATH entry, not just the first
+   `node`.
+3. The managed `.instar/bin/node` path is never eligible to become its own
+   target.
+4. If no real Node binary exists outside the managed link, installation fails
+   explicitly instead of writing a self-loop.
+
+## Evidence
+
+- `tests/unit/launchctl-load-guard.test.ts`
+- `tests/unit/agent-robustness.test.ts`
+- `tests/unit/init-join-launchd-handoff.test.ts`
+- `tests/e2e/launchd-node-boot-wrapper.test.ts`
+

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -775,6 +775,19 @@ export function launchctlLoadAllowed(): boolean {
   return !process.env.VITEST && !process.env.INSTAR_SKIP_LAUNCHCTL_LOAD;
 }
 
+export function macOSAutoStartLoadCommands(
+  label: string,
+  plistPath: string,
+  uid: number,
+): Array<[string, string[]]> {
+  const domain = `gui/${uid}`;
+  return [
+    ['launchctl', ['bootout', domain, plistPath]],
+    ['launchctl', ['enable', `${domain}/${label}`]],
+    ['launchctl', ['bootstrap', domain, plistPath]],
+  ];
+}
+
 export function installAutoStart(projectName: string, projectDir: string, hasTelegram: boolean): boolean {
   const platform = process.platform;
 
@@ -859,6 +872,17 @@ function resolveNodeCandidates(): string[] {
     if (current && fs.existsSync(current)) candidates.add(current);
   } catch { /* not found */ }
 
+  // 1b. Every PATH entry, not only the first `which node` result. The first
+  // result can be this agent's own .instar/bin/node symlink. If that symlink is
+  // being repaired, selecting it as its own target creates a self-loop and
+  // makes the agent unbootable. A later PATH entry commonly contains the real
+  // NVM/asdf/Homebrew binary we need.
+  for (const dir of (process.env.PATH ?? '').split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, 'node');
+    if (fs.existsSync(candidate)) candidates.add(candidate);
+  }
+
   // 2. process.execPath — the node that's running THIS process right now
   if (fs.existsSync(process.execPath)) candidates.add(process.execPath);
 
@@ -884,6 +908,12 @@ function resolveNodeCandidates(): string[] {
   } catch { /* brew not installed or node not installed via brew */ }
 
   return [...candidates];
+}
+
+/** Remove the managed symlink itself from the target candidate set. */
+export function excludeManagedNodeSymlink(candidates: string[], symlinkPath: string): string[] {
+  const managed = path.resolve(symlinkPath);
+  return candidates.filter((candidate) => path.resolve(candidate) !== managed);
 }
 
 /**
@@ -997,8 +1027,13 @@ export function ensureStableNodeSymlink(projectDir: string): string {
   const nativeModuleExists = fs.existsSync(nativeModulePath);
 
   // Resolve all available node paths and pick the most durable ABI-compatible one
-  const candidates = resolveNodeCandidates();
-  const durablePath = pickDurableNodePath(candidates, nativeModulePath) ?? findNodePath();
+  const candidates = excludeManagedNodeSymlink(resolveNodeCandidates(), symlinkPath);
+  const fallback = findNodePath();
+  const durablePath = pickDurableNodePath(candidates, nativeModulePath)
+    ?? (path.resolve(fallback) !== path.resolve(symlinkPath) ? fallback : undefined);
+  if (!durablePath) {
+    throw new Error(`No real Node binary found outside managed symlink ${symlinkPath}`);
+  }
 
   // Check if symlink exists and already points to a valid target.
   try {
@@ -1775,12 +1810,17 @@ ${argsXml}
 
     // Load the agent (skipped under test — see launchctlLoadAllowed).
     if (launchctlLoadAllowed()) {
+      const commands = macOSAutoStartLoadCommands(label, plistPath, process.getuid?.() ?? 501);
       try {
         // Unload first if already loaded
-        execFileSync('launchctl', ['bootout', `gui/${process.getuid?.() ?? 501}`, plistPath], { stdio: 'ignore' });
+        execFileSync(commands[0][0], commands[0][1], { stdio: 'ignore' });
       } catch { /* not loaded yet — fine */ }
 
-      execFileSync('launchctl', ['bootstrap', `gui/${process.getuid?.() ?? 501}`, plistPath], { stdio: 'ignore' });
+      // A previously disabled label makes bootstrap fail with the opaque
+      // launchctl "Input/output error" even when the plist is valid. Installing
+      // auto-start is an explicit request to re-enable this exact service.
+      execFileSync(commands[1][0], commands[1][1], { stdio: 'ignore' });
+      execFileSync(commands[2][0], commands[2][1], { stdio: 'ignore' });
     }
 
     // Ensure the user-machine fleet watchdog is installed alongside this agent.

--- a/tests/unit/agent-robustness.test.ts
+++ b/tests/unit/agent-robustness.test.ts
@@ -81,6 +81,14 @@ describe('Agent Robustness', () => {
       const target = fs.readlinkSync(symlinkPath);
       expect(fs.existsSync(target)).toBe(true);
     });
+
+    it('never selects the managed node symlink as its own target', async () => {
+      const { excludeManagedNodeSymlink } = await import('../../src/commands/setup.js');
+      const managed = path.join(tmpHome, 'agent', '.instar', 'bin', 'node');
+      const realNode = path.join(tmpHome, '.nvm', 'versions', 'node', 'v24', 'bin', 'node');
+
+      expect(excludeManagedNodeSymlink([managed, realNode], managed)).toEqual([realNode]);
+    });
   });
 
   describe('withLockSync force recovery', () => {

--- a/tests/unit/launchctl-load-guard.test.ts
+++ b/tests/unit/launchctl-load-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { launchctlLoadAllowed } from '../../src/commands/setup.js';
+import { launchctlLoadAllowed, macOSAutoStartLoadCommands } from '../../src/commands/setup.js';
 
 /**
  * Track C follow-up (test-hygiene): the real `launchctl bootstrap` is gated so
@@ -31,5 +31,17 @@ describe('launchctlLoadAllowed (test-hygiene guard)', () => {
     delete process.env.VITEST;
     delete process.env.INSTAR_SKIP_LAUNCHCTL_LOAD;
     expect(launchctlLoadAllowed()).toBe(true);
+  });
+
+  it('re-enables an explicitly installed service before bootstrap', () => {
+    expect(macOSAutoStartLoadCommands(
+      'ai.instar.instar-codey',
+      '/Users/test/Library/LaunchAgents/ai.instar.instar-codey.plist',
+      501,
+    )).toEqual([
+      ['launchctl', ['bootout', 'gui/501', '/Users/test/Library/LaunchAgents/ai.instar.instar-codey.plist']],
+      ['launchctl', ['enable', 'gui/501/ai.instar.instar-codey']],
+      ['launchctl', ['bootstrap', 'gui/501', '/Users/test/Library/LaunchAgents/ai.instar.instar-codey.plist']],
+    ]);
   });
 });

--- a/upgrades/next/second-node-autostart-recovery.md
+++ b/upgrades/next/second-node-autostart-recovery.md
@@ -1,0 +1,21 @@
+---
+title: "Standby machines recover autostart safely"
+audience: "operators"
+---
+
+## What Changed
+
+Paired macOS standby machines can now recover when their Instar LaunchAgent was
+previously disabled. Reinstalling autostart re-enables the service before
+loading it, and the stable Node launcher can no longer accidentally point to
+itself during repair.
+
+## What to Tell Your User
+
+Your standby Mac can now recover its automatic Instar startup after the service
+was disabled, without creating a broken self-referencing Node launcher.
+
+## Summary of New Capabilities
+
+- Recovers a disabled macOS LaunchAgent before loading it.
+- Selects a real Node executable instead of the managed launcher symlink.

--- a/upgrades/side-effects/second-node-autostart-recovery.md
+++ b/upgrades/side-effects/second-node-autostart-recovery.md
@@ -1,0 +1,93 @@
+# Side-Effects Review — Second-node autostart recovery
+
+**Version / slug:** `second-node-autostart-recovery`  
+**Date:** `2026-07-23`  
+**Author:** `Instar-codey`  
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`src/commands/setup.ts` now re-enables the exact macOS LaunchAgent label before
+bootstrap and prevents `.instar/bin/node` from becoming its own symlink target.
+The change modifies deterministic installation and executable-selection
+decisions; it does not change session routing or lease authority.
+
+## Decision-point inventory
+
+- `ensureStableNodeSymlink` — modify — chooses a real Node target outside the managed link.
+- `installMacOSLaunchAgent` — modify — re-enables the requested label before bootstrap.
+
+## 1. Over-block
+
+A PATH containing only the managed self-link now fails explicitly. That input
+cannot boot Node successfully, so refusing to write the link is intentional.
+
+## 2. Under-block
+
+This does not repair unrelated plist corruption, missing Node installations, or
+keychain/vault divergence. Those remain independently surfaced failures.
+
+## 3. Level-of-abstraction fit
+
+Both fixes sit at the installation primitive that owns the symlink and
+LaunchAgent lifecycle. No parallel recovery controller is introduced.
+
+## 4. Signal vs authority compliance
+
+- [x] No — this change has no block/allow surface.
+
+The installer performs an explicitly requested, deterministic service action.
+
+## 4b. Judgment-point check
+
+No new static heuristic at a competing-signals decision point. Exact path
+identity and exact launchd label state are enumerable invariants.
+
+## 5. Interactions
+
+- **Shadowing:** existing plist validation still runs before launchctl.
+- **Double-fire:** bootout remains idempotent; enable targets one exact label.
+- **Races:** launchctl serializes bootout, enable, and bootstrap in order.
+- **Feedback loops:** none; this is an operator-invoked installation path.
+
+## 6. External surfaces
+
+macOS agents whose exact label was disabled can be reinstalled successfully.
+The persistent plist format and CLI surface are unchanged. No new
+operator-facing action is added.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**machine-local BY DESIGN** — LaunchAgent state and Node executable paths are
+properties of each physical machine. No notices, replicated durable state, or
+URLs are created. Pool behavior benefits only after that machine boots normally.
+
+## 8. Rollback cost
+
+Pure code change: revert and ship a patch. Existing enabled services and valid
+symlinks need no cleanup.
+
+## Conclusion
+
+The review found no authority expansion. The design fails safely when no real
+Node target exists and restores an explicitly requested disabled service. Clear
+to ship.
+
+## Second-pass review (if required)
+
+Not required.
+
+## Evidence pointers
+
+- `tests/unit/agent-robustness.test.ts`
+- `tests/unit/launchctl-load-guard.test.ts`
+- Live two-node proof on Codey Mini, topic 3928.
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable.
+


### PR DESCRIPTION
## Summary

- re-enable the exact macOS LaunchAgent label before bootstrapping an explicitly reinstalled service
- search every PATH entry for Node and exclude the managed `.instar/bin/node` link from its own target candidates
- fail explicitly if no real Node binary exists instead of writing a self-referential symlink

## ELI16

Imagine a standby computer has a valid ignition key but its starter switch was turned off. Reinstalling the starter replaced all the right parts, then tried to start the engine without turning the switch back on. macOS returned a vague error, and the standby computer stayed absent.

There was a second trap: Instar keeps a stable shortcut to Node so upgrades do not break startup. If repair was launched through that shortcut, it could choose the shortcut as its own destination—like a road sign pointing back to itself.

The installer now turns the exact service switch back on before asking macOS to start it. It searches all Node locations and refuses to use its managed shortcut as the target. A paired standby can recover into the live pool without corrupting its next boot.

## Live proof

- repaired and enabled the Codey Mini LaunchAgent
- upgraded its shadow install to 1.3.915 and Codex CLI to 0.145.0
- authoritatively pinned topic 3928 to Codey Mini; placement reported `owner=Codey Mini`, `reason=pinned`, `pinState=actuated`, `ownershipLeaseState=held`
- session listing reported `Codey Mini Serve Proof 2` running on machine `m_81f02913ba80ba9333a851f89aebf479`
- Mini delivered a real Telegram reply
- bounded failover: laptop server stopped; Mini became sole live holder at epoch 20540 with split-brain clear and delivered a second reply; laptop restored at epoch 20541 with both machines online and split-brain clear

## Verification

- `npm run lint` — passed
- `npx tsc --noEmit` — passed
- focused LaunchAgent/Node suite — 55 tests passed
