### PR TITLE
fix(decision-quality): stop reporting peer-minted trackers as dead

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T21-11-02-107Z-session-pool-track-d-wiring.json
+++ b/.instar/instar-dev-decisions/2026-07-23T21-11-02-107Z-session-pool-track-d-wiring.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-23T21:11:02.107Z",
+  "slug": "session-pool-track-d-wiring",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 90,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T21-11-15-432Z-session-pool-track-d-wiring.json
+++ b/.instar/instar-dev-decisions/2026-07-23T21-11-15-432Z-session-pool-track-d-wiring.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-23T21:11:15.432Z",
+  "slug": "session-pool-track-d-wiring",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 90,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T21-11-23-430Z-census-pending-tracker-adjudication.json
+++ b/.instar/instar-dev-decisions/2026-07-23T21-11-23-430Z-census-pending-tracker-adjudication.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-23T21:11:23.430Z",
+  "slug": "census-pending-tracker-adjudication",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 90,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T21-11-26-599Z-census-pending-tracker-adjudication.json
+++ b/.instar/instar-dev-decisions/2026-07-23T21-11-26-599Z-census-pending-tracker-adjudication.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-23T21:11:26.599Z",
+  "slug": "census-pending-tracker-adjudication",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 90,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T21-11-30-048Z-census-pending-tracker-adjudication.json
+++ b/.instar/instar-dev-decisions/2026-07-23T21-11-30-048Z-census-pending-tracker-adjudication.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-23T21:11:30.048Z",
+  "slug": "census-pending-tracker-adjudication",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 90,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T21-11-37-536Z-census-pending-tracker-adjudication.json
+++ b/.instar/instar-dev-decisions/2026-07-23T21-11-37-536Z-census-pending-tracker-adjudication.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T21:11:37.536Z",
+  "slug": "census-pending-tracker-adjudication",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 90,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "PROVENANCE_COVERAGE ships pending:ACT-NNNN trackers as source constants but validated them against the machine-local, unreplicated evolution action queue. Latent on a single-machine install; surfaced 2026-07-23 when the Mac Mini (high-water ACT-1119) flagged all 49 entries citing ACT-1193, which lives on the Laptop (high-water ACT-1211). evolutionActions stateSync cannot converge them — the journal-apply side is an explicitly unbuilt rollout stage."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T21-12-15-296Z-census-pending-tracker-adjudication.json
+++ b/.instar/instar-dev-decisions/2026-07-23T21-12-15-296Z-census-pending-tracker-adjudication.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T21:12:15.296Z",
+  "slug": "census-pending-tracker-adjudication",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 90,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "PROVENANCE_COVERAGE ships pending:ACT-NNNN trackers as source constants but validated them against the machine-local, unreplicated evolution action queue. Latent on a single-machine install; surfaced 2026-07-23 when the Mac Mini (high-water ACT-1119) flagged all 49 entries citing ACT-1193, which lives on the Laptop (high-water ACT-1211). evolutionActions stateSync cannot converge them — the journal-apply side is an explicitly unbuilt rollout stage."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T21-12-50-606Z-census-pending-tracker-adjudication.json
+++ b/.instar/instar-dev-decisions/2026-07-23T21-12-50-606Z-census-pending-tracker-adjudication.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T21:12:50.606Z",
+  "slug": "census-pending-tracker-adjudication",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 90,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "PROVENANCE_COVERAGE ships pending:ACT-NNNN trackers as source constants but validated them against the machine-local, unreplicated evolution action queue. Latent on a single-machine install; surfaced 2026-07-23 when the Mac Mini (high-water ACT-1119) flagged all 49 entries citing ACT-1193, which lives on the Laptop (high-water ACT-1211). evolutionActions stateSync cannot converge them — the journal-apply side is an explicitly unbuilt rollout stage."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/census-pending-tracker-adjudication.eli16.md
+++ b/docs/specs/census-pending-tracker-adjudication.eli16.md
@@ -1,0 +1,75 @@
+# ELI16 — Why the agent kept reporting 49 lost to-do items that were never lost
+
+## The situation
+
+Instar keeps a running count of "LLM decision points" — the places in the codebase
+where an AI model makes a judgment call. Some are fully instrumented ("wired"). The
+rest are queued up to be instrumented later, and each of those queued entries points
+at a to-do item that tracks the work: `ACT-1193`.
+
+That pointer is written into the source code. Every copy of Instar ships with the
+same 49 entries all pointing at `ACT-1193`.
+
+## The bug
+
+The agent checks whether that to-do item still exists, so it can shout if the plan
+quietly lost its tracker. Sensible check. The problem is *where* it looked.
+
+The to-do list is **per-machine**. It lives on one computer's disk and does not
+sync to the others. But the pointer that gets checked against it is **baked into
+the shipped code**, identical everywhere.
+
+So on 2026-07-23 the situation was:
+
+- The laptop had 1,211 to-do items, the highest numbered `ACT-1211`, and `ACT-1193`
+  was sitting right there, open.
+- The Mac Mini — the machine that actually runs everything — had 1,063 items, the
+  highest numbered `ACT-1119`, and no `ACT-1193` at all.
+
+The Mini therefore announced that all 49 tracking references were dead.
+
+They weren't. The Mini had just never created a to-do item numbered that high. It
+wasn't looking at a deletion; it was looking at something it had never seen.
+
+## Why the machines don't agree
+
+You'd think the fix is "turn on syncing between the machines." That was my first
+guess too, and it's wrong. The syncing for to-do items is half-built: the sending
+half exists, the receiving half was deliberately left for a later stage. The code
+says so directly — with only its own data, the merge is "a strict no-op." Switching
+it on would change nothing.
+
+## The fix
+
+The key insight is that a to-do list's **highest number so far** tells you something
+useful. If a machine's highest-ever item is number 1,119, and you ask it about item
+1,193, the honest answer isn't "that's dead" — it's "I've never minted a number that
+high, so I genuinely can't tell you."
+
+So the check now sorts trackers into three buckets instead of two:
+
+- **Alive** — it's here and still open. Nothing to say.
+- **Dead** — it's within the range this machine has definitely reached, but it's
+  gone or finished. This is the real alarm, and it still fires exactly as before.
+- **Unverifiable** — it's numbered above anything this machine has ever created, so
+  it was made somewhere else. Reported separately, not as a loss.
+
+## Why not just silence it
+
+Because a genuinely deleted tracker is a real problem worth knowing about, and
+silencing the whole check to kill the noise would throw that away. The point isn't
+fewer alarms, it's alarms that mean something. An alarm that fires on every machine
+you add, forever, for a reason nobody on that machine can act on, trains you to
+ignore alarms — which is worse than having none.
+
+Two smaller judgment calls in the same spirit: a to-do id that's malformed still
+reports as dead rather than hiding in the new bucket (a broken constant is a real
+defect and should stay loud), and a machine with no to-do list at all still reports
+nothing rather than flagging everything (a fresh install shouldn't greet you with 49
+false alarms).
+
+## What this does not touch
+
+Nothing. It's a read-only number on a status page. It doesn't block a message, gate
+a job, or trigger any action. It exists so a human can look at it and know whether
+the enrollment plan still has a tracker attached.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1800,21 +1800,85 @@ function pickDecisionQualityPointFields(row: Record<string, unknown>): Record<st
 }
 
 /**
- * Alive ACT ids (registered AND non-terminal) from the runtime evolution queue
- * — the agent-side half of the §5.6 pending-ref-dead check. null when the queue
- * file is absent/unreadable (⇒ the check is skipped honestly rather than
- * false-flagging every pending ref on an agent that has no queue yet).
+ * Alive ACT ids (registered AND non-terminal) from the runtime evolution queue,
+ * plus the queue's id HIGH-WATER MARK — the agent-side half of the §5.6
+ * pending-ref-dead check. null when the queue file is absent/unreadable (⇒ the
+ * check is skipped honestly rather than false-flagging every pending ref on an
+ * agent that has no queue yet).
+ *
+ * WHY the high-water mark (2026-07-23 false-alarm fix): PROVENANCE_COVERAGE
+ * declares its `pending:ACT-NNNN` tracker ids as SHIPPED SOURCE CONSTANTS —
+ * identical on every install — while the evolution action queue is MACHINE-LOCAL
+ * and unreplicated (the evolutionActions stateSync send side is wired but the
+ * journal-apply side is an unbuilt later rollout stage, so two machines' queues
+ * genuinely diverge and never converge). Measured 2026-07-23: `ACT-1193` is
+ * `pending` on one machine (max id ACT-1211) and simply ABSENT on its peer (max
+ * id ACT-1119) — which made that peer report all 49 pending coverage entries as
+ * dangling trackers. Nothing had been deleted; the peer had never minted an id
+ * that high.
+ *
+ * An id ABOVE the local high-water mark is therefore proof the action was minted
+ * on another machine, NOT proof it was deleted here — a categorically different
+ * (and unactionable-locally) state that must not be reported as a dead tracker.
  */
-function readLiveEvolutionActs(stateDir: string): Set<string> | null {
+export interface LiveEvolutionActs {
+  /** Registered AND non-terminal ids on THIS machine. */
+  readonly alive: ReadonlySet<string>;
+  /** Largest numeric ACT id this machine's queue has ever minted (0 = empty queue). */
+  readonly highWater: number;
+}
+
+/** Numeric suffix of an `ACT-NNNN` id; null when it does not parse. */
+export function parseActOrdinal(id: string): number | null {
+  const m = /^ACT-(\d+)$/.exec(id.trim());
+  if (!m) return null;
+  const n = Number.parseInt(m[1], 10);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+/**
+ * Adjudicate ONE pending coverage tracker against this machine's action queue
+ * (§5.6). Pure + exported so the decision boundary is unit-testable without the
+ * Express surface.
+ *
+ * - `alive`        — registered and non-terminal here; nothing to report.
+ * - `unverifiable` — above this machine's id high-water mark ⇒ minted on a peer
+ *                    whose queue does not replicate here. NOT a deletion.
+ * - `dead`         — within the range this machine has minted, yet absent or
+ *                    terminal ⇒ the tracker genuinely went away. This is the
+ *                    signal the check exists to give, and it is preserved.
+ *
+ * An id that does not parse keeps the strict `dead` reading so a malformed
+ * tracker still surfaces rather than hiding in the unverifiable bucket.
+ */
+export type PendingTrackerVerdict = 'alive' | 'dead' | 'unverifiable';
+
+export function adjudicatePendingTracker(
+  act: string,
+  liveActs: LiveEvolutionActs,
+): PendingTrackerVerdict {
+  if (liveActs.alive.has(act)) return 'alive';
+  const ord = parseActOrdinal(act);
+  if (ord !== null && ord > liveActs.highWater) return 'unverifiable';
+  return 'dead';
+}
+
+function readLiveEvolutionActs(stateDir: string): LiveEvolutionActs | null {
   try {
     const p = path.join(stateDir, 'state', 'evolution', 'action-queue.json');
     if (!fs.existsSync(p)) return null;
     const aq = JSON.parse(fs.readFileSync(p, 'utf-8')) as { actions?: Array<{ id?: string; status?: string }> };
     const alive = new Set<string>();
+    let highWater = 0;
     for (const a of aq.actions ?? []) {
-      if (a.id && (a.status === 'pending' || a.status === 'in_progress')) alive.add(a.id);
+      if (!a.id) continue;
+      // High-water spans EVERY id the queue holds, terminal ones included — a
+      // completed/cancelled action still proves this machine minted that far.
+      const ord = parseActOrdinal(a.id);
+      if (ord !== null && ord > highWater) highWater = ord;
+      if (a.status === 'pending' || a.status === 'in_progress') alive.add(a.id);
     }
-    return alive;
+    return { alive, highWater };
   } catch {
     // @silent-fallback-ok: an unreadable queue ⇒ skip pending-ref-dead (never a
     // false "dead" flag); observe-only surface, never a throw.
@@ -15972,6 +16036,10 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     let pending = 0;
     let exempt = 0;
     const pendingRefDead: string[] = [];
+    // Trackers this machine cannot adjudicate: minted above its own id high-water
+    // mark, i.e. created on a peer whose action queue does not replicate here.
+    // NOT dead — unverifiable locally (see readLiveEvolutionActs).
+    const pendingRefUnverifiable: string[] = [];
     const liveActs = readLiveEvolutionActs(ctx.config.stateDir);
     for (const entry of PROVENANCE_COVERAGE) {
       if (entry.status === 'wired') wired++;
@@ -15979,7 +16047,9 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         pending++;
         if (liveActs !== null) {
           const act = entry.status.slice('pending:'.length);
-          if (!liveActs.has(act)) pendingRefDead.push(`${entry.decisionPoint}:${act}`);
+          const verdict = adjudicatePendingTracker(act, liveActs);
+          if (verdict === 'dead') pendingRefDead.push(`${entry.decisionPoint}:${act}`);
+          else if (verdict === 'unverifiable') pendingRefUnverifiable.push(`${entry.decisionPoint}:${act}`);
         }
       } else if (entry.status.startsWith('exempt:')) exempt++;
     }
@@ -15996,7 +16066,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       sinceHours,
       gate: { enabled: true, dryRun: ctx.config.provenance?.uniformSeam?.dryRun !== false },
       points,
-      censusDebt: { wired, pending, exempt, pendingRefDead, wiredButNoGrader },
+      censusDebt: { wired, pending, exempt, pendingRefDead, pendingRefUnverifiable, wiredButNoGrader },
       counters: totalCounters,
       // The four §5.5 annotation-rejection counters, by class.
       rejections: getDecisionAnnotationRejectionCounters(),

--- a/tests/e2e/decision-quality-alive.test.ts
+++ b/tests/e2e/decision-quality-alive.test.ts
@@ -80,6 +80,11 @@ describe('Decision-Quality E2E lifecycle (feature is alive)', () => {
     expect(res.body.censusDebt.wired).toBeGreaterThanOrEqual(3);
     expect(res.body.censusDebt.pending).toBeGreaterThan(0);
     expect(res.body.censusDebt.wiredButNoGrader).toEqual([]);
+    // Pending-tracker adjudication is alive on the production init path: BOTH
+    // buckets are always surfaced (a peer-minted tracker must be separable from a
+    // genuinely-deleted one, never collapsed into one false "dead" list).
+    expect(Array.isArray(res.body.censusDebt.pendingRefDead)).toBe(true);
+    expect(Array.isArray(res.body.censusDebt.pendingRefUnverifiable)).toBe(true);
     expect(res.body.rejections).toEqual({ enumInvalid: 0, rungMismatch: 0, ownerMismatch: 0, unknownDecisionPoint: 0 });
     // The three first-customer WIRED points are present in the census surface.
     const wiredPoints = (res.body.points as Array<any>).map((p) => p.decisionPoint);

--- a/tests/integration/decision-quality-routes.test.ts
+++ b/tests/integration/decision-quality-routes.test.ts
@@ -177,6 +177,76 @@ describe('GET /decision-quality (integration)', () => {
   });
 });
 
+/**
+ * §5.6 census debt — the pending-tracker adjudication (2026-07-23 false-alarm fix).
+ *
+ * PROVENANCE_COVERAGE declares its `pending:ACT-NNNN` trackers as SHIPPED SOURCE
+ * CONSTANTS (identical on every install) but they are validated against the
+ * MACHINE-LOCAL, unreplicated evolution action queue. A machine that never minted
+ * an id that high has not DELETED the tracker — it has simply never seen it, and
+ * reporting that as a dead tracker is a false alarm by construction (measured:
+ * ACT-1193 pending on one machine at high-water 1211, absent on its peer at
+ * high-water 1119 ⇒ the peer flagged all 49 entries).
+ */
+describe('GET /decision-quality censusDebt — pending-tracker adjudication', () => {
+  const COVERAGE_TRACKER = 'ACT-1193'; // the id PROVENANCE_COVERAGE's pending entries cite
+
+  function writeQueue(actions: Array<{ id: string; status: string }>): void {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dq-census-'));
+    const dir = path.join(tmpDir, 'state', 'evolution');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'action-queue.json'), JSON.stringify({ actions }));
+  }
+
+  async function censusDebt(): Promise<Record<string, any>> {
+    ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
+    const res = await request(appWith(ctxWith({ ledger, developmentAgent: true })))
+      .get('/decision-quality').set('Authorization', `Bearer ${AUTH}`);
+    expect(res.status).toBe(200);
+    return res.body.censusDebt;
+  }
+
+  it('a tracker ABOVE this machine\'s high-water reads unverifiable, never dead (the peer-minted case)', async () => {
+    // High-water 1119 < 1193 ⇒ this machine never minted that far: minted elsewhere.
+    writeQueue([{ id: 'ACT-1119', status: 'pending' }, { id: 'ACT-0004', status: 'completed' }]);
+    const debt = await censusDebt();
+    expect(debt.pendingRefDead).toEqual([]);
+    expect(debt.pendingRefUnverifiable.length).toBe(debt.pending);
+    expect(debt.pendingRefUnverifiable[0]).toContain(COVERAGE_TRACKER);
+  });
+
+  it('a tracker WITHIN high-water range but absent still reads dead (the genuine-deletion signal survives)', async () => {
+    // High-water 1211 > 1193 and 1193 is absent ⇒ genuinely deleted here.
+    writeQueue([{ id: 'ACT-1211', status: 'pending' }]);
+    const debt = await censusDebt();
+    expect(debt.pendingRefUnverifiable).toEqual([]);
+    expect(debt.pendingRefDead.length).toBe(debt.pending);
+    expect(debt.pendingRefDead[0]).toContain(COVERAGE_TRACKER);
+  });
+
+  it('a tracker that is alive locally is flagged by neither list', async () => {
+    writeQueue([{ id: COVERAGE_TRACKER, status: 'pending' }, { id: 'ACT-1211', status: 'completed' }]);
+    const debt = await censusDebt();
+    expect(debt.pendingRefDead).toEqual([]);
+    expect(debt.pendingRefUnverifiable).toEqual([]);
+  });
+
+  it('a TERMINAL tracker within range reads dead (completed ≠ alive), and high-water still counts it', async () => {
+    writeQueue([{ id: COVERAGE_TRACKER, status: 'completed' }]);
+    const debt = await censusDebt();
+    // high-water is 1193 (terminal rows count toward high-water), 1193 is NOT > 1193 ⇒ dead.
+    expect(debt.pendingRefUnverifiable).toEqual([]);
+    expect(debt.pendingRefDead.length).toBe(debt.pending);
+  });
+
+  it('an absent queue flags neither list (unchanged fail-safe — a fresh agent is never false-flagged)', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dq-census-noqueue-'));
+    const debt = await censusDebt();
+    expect(debt.pendingRefDead).toEqual([]);
+    expect(debt.pendingRefUnverifiable).toEqual([]);
+  });
+});
+
 describe('POST /decision-quality/grade-pass (integration)', () => {
   it('turns a matured Phase B backlog row into one visible known outcome through the real routes', async () => {
     ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });

--- a/tests/unit/pending-tracker-adjudication.test.ts
+++ b/tests/unit/pending-tracker-adjudication.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseActOrdinal,
+  adjudicatePendingTracker,
+  type LiveEvolutionActs,
+} from '../../src/server/routes.js';
+
+/**
+ * Unit tier for the §5.6 pending-tracker adjudication (2026-07-23 false-alarm fix).
+ *
+ * PROVENANCE_COVERAGE ships its `pending:ACT-NNNN` trackers as SOURCE CONSTANTS —
+ * byte-identical on every install — but they are validated against the
+ * MACHINE-LOCAL, unreplicated evolution action queue. A machine that never minted
+ * an id that high has not DELETED the tracker; it has never seen it. Collapsing
+ * those two states into one "dead" list is a false alarm by construction, and it
+ * fires on every machine added to a pool.
+ *
+ * Both sides of every decision boundary are covered (Testing Integrity: semantic
+ * correctness over realistic inputs).
+ */
+
+function acts(alive: string[], highWater: number): LiveEvolutionActs {
+  return { alive: new Set(alive), highWater };
+}
+
+describe('parseActOrdinal', () => {
+  it('parses a well-formed ACT id', () => {
+    expect(parseActOrdinal('ACT-1193')).toBe(1193);
+    expect(parseActOrdinal('ACT-0004')).toBe(4);
+    expect(parseActOrdinal('  ACT-7 ')).toBe(7);
+  });
+
+  it('returns null for anything that is not an ACT-<digits> id', () => {
+    for (const bad of ['', 'ACT-', 'ACT-abc', 'CMT-1193', 'ACT-12x', 'act-12', 'ACT-1193-b']) {
+      expect(parseActOrdinal(bad)).toBeNull();
+    }
+  });
+});
+
+describe('adjudicatePendingTracker', () => {
+  it('alive: the tracker is registered and non-terminal on this machine', () => {
+    expect(adjudicatePendingTracker('ACT-1193', acts(['ACT-1193'], 1211))).toBe('alive');
+    // Alive wins even when the id sits above high-water (a defensive ordering check).
+    expect(adjudicatePendingTracker('ACT-1193', acts(['ACT-1193'], 10))).toBe('alive');
+  });
+
+  it('unverifiable: above this machine\'s high-water ⇒ minted on a peer, not deleted here', () => {
+    // The measured production case: peer high-water 1119, tracker 1193.
+    expect(adjudicatePendingTracker('ACT-1193', acts([], 1119))).toBe('unverifiable');
+    // Boundary: strictly greater than high-water.
+    expect(adjudicatePendingTracker('ACT-1120', acts([], 1119))).toBe('unverifiable');
+  });
+
+  it('dead: within the range this machine has minted, yet absent ⇒ genuinely gone', () => {
+    // The origin machine's case: high-water 1211, tracker 1193 absent from alive.
+    expect(adjudicatePendingTracker('ACT-1193', acts([], 1211))).toBe('dead');
+    // Boundary: equal to high-water is NOT above it — this machine minted that far.
+    expect(adjudicatePendingTracker('ACT-1119', acts([], 1119))).toBe('dead');
+  });
+
+  it('dead: a TERMINAL tracker is not alive (completed/cancelled ≠ open)', () => {
+    // A completed action contributes to high-water but never to `alive`.
+    expect(adjudicatePendingTracker('ACT-1193', acts([], 1193))).toBe('dead');
+  });
+
+  it('dead: an unparseable tracker id keeps the STRICT reading (never hidden as unverifiable)', () => {
+    expect(adjudicatePendingTracker('ACT-oops', acts([], 5))).toBe('dead');
+    expect(adjudicatePendingTracker('CMT-1193', acts([], 5))).toBe('dead');
+  });
+
+  it('an empty queue (high-water 0) reports every parseable tracker unverifiable, never dead', () => {
+    // A fresh agent has minted nothing; flagging shipped trackers as deleted there
+    // is precisely the false alarm this fix removes.
+    const fresh = acts([], 0);
+    expect(adjudicatePendingTracker('ACT-1193', fresh)).toBe('unverifiable');
+    expect(adjudicatePendingTracker('ACT-1', fresh)).toBe('unverifiable');
+  });
+});

--- a/upgrades/next/census-pending-tracker-adjudication.md
+++ b/upgrades/next/census-pending-tracker-adjudication.md
@@ -1,14 +1,20 @@
-### Decision-quality census: peer-minted trackers no longer read as "dead"
+## What Changed
 
-`GET /decision-quality` used to report all 49 pending decision-point trackers as
-dangling on any machine that had not personally created the tracking to-do item.
-The tracker id is a shipped source constant; the to-do queue it was checked against
-is machine-local and unreplicated, so a second machine flagged every entry.
+`GET /decision-quality` no longer reports a peer-minted tracking action as a dead tracker.
 
-`censusDebt` now separates the two states: `pendingRefDead` keeps its meaning (a
-tracker within the range this machine has minted, now absent or terminal — the real
-"the plan lost its tracker" alarm) and the additive `pendingRefUnverifiable` carries
-trackers minted above this machine's id high-water mark, i.e. created on a peer.
+Each pending decision point's tracker id is a shipped source constant (`pending:ACT-1193` on all 49 entries), but it was validated against the machine-local, unreplicated evolution action queue. A machine that had never minted an id that high reported every entry as dangling — measured 2026-07-23: the Mac Mini (high-water `ACT-1119`) flagged all 49, while the tracker sat open on the Laptop (high-water `ACT-1211`). The queues cannot converge; evolution-action replication has a wired send side but an explicitly unbuilt apply side.
 
-Read-only observability; gates nothing. `pendingRefDead` is unchanged in name and
-type — it just stops carrying false entries.
+`censusDebt` now separates the two states:
+
+- `pendingRefDead` — a tracker within the range this machine has minted, now absent or terminal. **The real "the plan lost its tracker" alarm, unchanged.**
+- `pendingRefUnverifiable` — additive; a tracker minted above this machine's id high-water mark, i.e. created on a peer.
+
+Read-only observability; gates nothing. `pendingRefDead` keeps its name and type — it just stops carrying false entries.
+
+## Summary of New Capabilities
+
+- `censusDebt.pendingRefUnverifiable` on `GET /decision-quality`: pending trackers this machine cannot adjudicate because they were minted on a peer, reported separately from genuine losses.
+
+## What to Tell Your User
+
+Nothing to do. If you run on more than one machine, the decision-quality census used to report 49 "lost" tracking items on any machine that hadn't personally created them — a false alarm caused by checking a shipped constant against a per-machine to-do list. Those now show up as "made on another machine" rather than "gone". A genuinely deleted tracker still raises the same alarm it always did.

--- a/upgrades/next/census-pending-tracker-adjudication.md
+++ b/upgrades/next/census-pending-tracker-adjudication.md
@@ -1,0 +1,14 @@
+### Decision-quality census: peer-minted trackers no longer read as "dead"
+
+`GET /decision-quality` used to report all 49 pending decision-point trackers as
+dangling on any machine that had not personally created the tracking to-do item.
+The tracker id is a shipped source constant; the to-do queue it was checked against
+is machine-local and unreplicated, so a second machine flagged every entry.
+
+`censusDebt` now separates the two states: `pendingRefDead` keeps its meaning (a
+tracker within the range this machine has minted, now absent or terminal — the real
+"the plan lost its tracker" alarm) and the additive `pendingRefUnverifiable` carries
+trackers minted above this machine's id high-water mark, i.e. created on a peer.
+
+Read-only observability; gates nothing. `pendingRefDead` is unchanged in name and
+type — it just stops carrying false entries.

--- a/upgrades/side-effects/census-pending-tracker-adjudication.md
+++ b/upgrades/side-effects/census-pending-tracker-adjudication.md
@@ -1,0 +1,101 @@
+# Side-effects review — census pending-tracker adjudication
+
+**Change:** `GET /decision-quality` stops reporting a peer-minted tracking action as a
+dead tracker. `censusDebt` gains a second bucket, `pendingRefUnverifiable`.
+
+## What actually changed
+
+`readLiveEvolutionActs()` now returns `{ alive, highWater }` instead of a bare
+`Set`, where `highWater` is the largest `ACT-NNNN` ordinal the local queue has ever
+held (terminal rows included — a completed action still proves this machine minted
+that far). A new pure exported function `adjudicatePendingTracker()` maps one
+tracker to `alive | dead | unverifiable`.
+
+## Why (the defect)
+
+`PROVENANCE_COVERAGE` declares each pending decision point's tracker as a **shipped
+source constant** — `pending:ACT-1193` on all 49 entries, byte-identical on every
+install. That constant was validated against the **machine-local, unreplicated**
+evolution action queue.
+
+Measured 2026-07-23 on the live pool:
+
+| machine | actions | max id | `ACT-1193` | `pendingRefDead` |
+|---|---|---|---|---|
+| Laptop | 1211 | ACT-1211 | present, `pending` | (queue path absent ⇒ check skipped) |
+| Mac Mini | 1063 | ACT-1119 | **absent** | **49 entries flagged** |
+
+Nothing had been deleted. The Mini had simply never minted an id that high. The two
+queues cannot converge: `multiMachine.stateSync.evolutionActions` has a wired send
+side but its journal-apply side is an explicitly unbuilt later rollout stage
+(`server.ts`: *"With only the own origin the union is a strict no-op"*).
+
+So this was a **false alarm by construction**, and it would fire on every machine
+added to a pool, forever.
+
+## Blast radius
+
+- **Surface:** one read-only observability route. `GET /decision-quality`.
+- **Authority:** none. `censusDebt` gates nothing, blocks nothing, and drives no
+  automated action. It is a number a human reads.
+- **Write paths:** none touched. No store, no migration, no config key.
+- **Other consumers of `readLiveEvolutionActs`:** none — `grep` confirms a single
+  callsite. The return-type change is contained to that one block.
+
+## Risk analysis
+
+**The signal this check exists to give is preserved.** A tracker within the range
+this machine has minted, but absent or terminal, still reports `dead`. That is the
+genuine "the plan lost its tracker" case and it is unit-pinned on both sides of the
+boundary (`ACT-1119` at high-water 1119 ⇒ dead; `ACT-1120` at high-water 1119 ⇒
+unverifiable).
+
+**Could this hide a real deletion?** Only if the deleted action's id were *above*
+every id the local queue retains. That requires deleting the highest-numbered action
+AND every action minted after it — at which point the local queue genuinely has no
+evidence the id ever existed here, and "unverifiable" is the honest answer rather
+than a guess. The bucket is surfaced, not suppressed, so a human still sees it.
+
+**Fail-safe direction unchanged.** An absent or unreadable queue still yields
+`null` ⇒ neither bucket ⇒ a fresh agent is never false-flagged. Preserved and
+re-pinned by test.
+
+**Unparseable ids keep the strict reading.** A malformed tracker (`ACT-oops`,
+`CMT-1193`) reports `dead` rather than disappearing into the unverifiable bucket —
+a malformed constant is a real defect and must stay loud.
+
+## API compatibility
+
+`censusDebt.pendingRefDead` keeps its name, type, and meaning; it only stops
+carrying false entries. `pendingRefUnverifiable` is **additive**. Any consumer
+reading the old field keeps working; a consumer that treated a non-empty
+`pendingRefDead` as an alarm will now (correctly) see it empty on non-origin
+machines.
+
+No dashboard or job reads this field today (`grep` across `src/` and
+`src/scaffold/templates/jobs/` returns no consumer), so there is no downstream
+render to update.
+
+## Migration parity
+
+None required. This is server-side route logic with no installed-file, config, hook,
+skill, or CLAUDE.md-template surface. Existing agents pick it up with the normal
+version bump — there is no per-agent state to migrate and no default to backfill.
+
+## Testing
+
+- **Unit** (`tests/unit/pending-tracker-adjudication.test.ts`, 8 tests): both sides
+  of every boundary — alive/dead/unverifiable, the `>` vs `>=` high-water edge,
+  terminal-is-not-alive, unparseable-stays-strict, empty-queue.
+- **Integration** (`tests/integration/decision-quality-routes.test.ts`, +5 tests):
+  the real Express route + auth middleware over a real on-disk queue fixture,
+  asserting each bucket through the actual HTTP response.
+- **E2E** (`tests/e2e/decision-quality-alive.test.ts`): both buckets present in the
+  live shape on the production initialization path.
+
+26 tests green across the three files; `tsc --noEmit` clean on every touched file.
+
+## Rollback
+
+Revert the commit. The route returns to today's behaviour; nothing persists, so
+there is no data to unwind.


### PR DESCRIPTION
## What

`GET /decision-quality` stops reporting a peer-minted tracking action as a **dead tracker**. `censusDebt` gains an additive second bucket, `pendingRefUnverifiable`.

## Why

`PROVENANCE_COVERAGE` declares each pending decision point's tracker as a **shipped source constant** — `pending:ACT-1193` on all 49 entries, byte-identical on every install. That constant was validated against the **machine-local, unreplicated** evolution action queue.

Measured 2026-07-23 on the live pool:

| machine | actions | high-water | `ACT-1193` | reported |
|---|---|---|---|---|
| Laptop | 1211 | `ACT-1211` | present, `pending` | — |
| Mac Mini | 1063 | `ACT-1119` | **absent** | **49 dangling** |

Nothing had been deleted — the Mini had never minted an id that high. The queues cannot converge: `multiMachine.stateSync.evolutionActions` has a wired send side but its journal-apply side is an explicitly unbuilt later rollout stage (`server.ts`: *"With only the own origin the union is a strict no-op"*).

This is a **false alarm by construction**, and it fires on every machine added to a pool, forever.

## How

`readLiveEvolutionActs()` now returns `{ alive, highWater }`, where `highWater` is the largest `ACT-NNNN` ordinal the local queue has ever held (terminal rows included — a completed action still proves this machine minted that far). The new pure exported `adjudicatePendingTracker()` sorts one tracker three ways:

- **alive** — registered and non-terminal here.
- **dead** — within the range this machine has minted, yet absent or terminal. **The real "the plan lost its tracker" alarm, preserved unchanged.**
- **unverifiable** — above high-water ⇒ minted on a peer.

`pendingRefDead` keeps its name, type and meaning; it only stops carrying false entries.

## Safety

- Read-only observability. Gates nothing, blocks nothing, drives no automated action.
- No write path, config key, schema change, or operator surface touched.
- Single callsite for the changed helper (grep-confirmed).
- Fail-safe direction unchanged: an absent/unreadable queue flags **neither** bucket, so a fresh agent is never false-flagged.
- An unparseable tracker id keeps the strict `dead` reading — a malformed constant stays loud rather than hiding in the new bucket.
- No migration parity surface (server-side route logic only; no installed file, hook, skill, or template).

## Tests (all three tiers)

- **Unit** — `tests/unit/pending-tracker-adjudication.test.ts` (8): both sides of every boundary, including the `>` vs `>=` high-water edge, terminal-is-not-alive, unparseable-stays-strict, empty-queue.
- **Integration** — `tests/integration/decision-quality-routes.test.ts` (+5): the real Express route + auth middleware over an on-disk queue fixture, asserting each bucket through the actual HTTP response.
- **E2E** — `tests/e2e/decision-quality-alive.test.ts`: both buckets present in the live shape on the production initialization path.

26 green across the three files; `tsc --noEmit` clean on every touched file.

## ELI16 — Why the agent kept reporting 49 lost to-do items that were never lost

Instar tracks the places where an AI model makes a judgment call. Most aren't instrumented yet, and each of those queued-up entries points at a to-do item that tracks the work — item number 1193.

That pointer is baked into the shipped code, so every copy of Instar has the same 49 entries pointing at the same number. The to-do list it gets checked against, though, lives on **one computer's disk** and doesn't sync to the others.

So: the laptop had 1,211 to-do items and number 1193 was sitting right there, open. The Mac Mini — the machine that actually runs everything — had 1,063 items, the highest numbered 1119, and no 1193 at all. The Mini announced all 49 trackers were dead. They weren't. It had just never created an item numbered that high; it wasn't looking at a deletion, it was looking at something it had never seen.

The obvious fix — "turn on syncing between the machines" — doesn't work, and that's worth knowing. The syncing for to-do items is half-built: the sending half exists, the receiving half was deliberately left for later. The code says so directly. Switching it on would change nothing.

The actual fix uses a simple fact: a to-do list's **highest number so far** tells you something. If a machine's highest-ever item is 1,119 and you ask about 1,193, the honest answer isn't "that's dead" — it's "I've never minted a number that high, so I can't tell you." So trackers now sort into three buckets instead of two, and the genuinely-deleted case still fires exactly as before.

Why not just silence the check? Because a real deleted tracker is worth knowing about, and killing the noise by killing the alarm throws that away. The point isn't fewer alarms — it's alarms that mean something. One that fires on every machine you add, forever, for a reason nobody on that machine can act on, just trains you to ignore alarms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
