### PR TITLE
fix: recover silent Slack inbound connections

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T21-11-09-958Z-slack-inbound-recovery-robustness.json
+++ b/.instar/instar-dev-decisions/2026-07-23T21-11-09-958Z-slack-inbound-recovery-robustness.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T21:11:09.958Z",
+  "slug": "slack-inbound-recovery-robustness",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 59,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Thread-scoped Slack sessions introduced composite routing keys, but both recovery loops continued to assume resume-map keys were raw channel IDs. Separately, the existing dead-silence probe relied on successful local send() of undocumented JSON, which cannot establish inbound event delivery. The live incident exposed both latent assumptions together: startup logged channel_not_found for a composite key while the socket stayed OPEN and emitted no events."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-23T21-08-52-300Z-slack-inbound-recovery-robustness.json
+++ b/.instar/instar-dev-traces/2026-07-23T21-08-52-300Z-slack-inbound-recovery-robustness.json
@@ -1,0 +1,27 @@
+{
+  "version": 3,
+  "slug": "slack-inbound-recovery-robustness",
+  "sessionId": "slack-C0BA4F4E0FP-20260723",
+  "timestamp": "2026-07-23T21:08:52.300Z",
+  "artifactPath": "upgrades/side-effects/slack-inbound-recovery-robustness.md",
+  "artifactSha256": "d050fc6057ba49cceddddfe35b5885088041ec59a7b73cf446770f339f0da4fc",
+  "specPath": "docs/specs/slack-inbound-recovery-robustness.md",
+  "coveredFiles": [
+    "src/messaging/slack/SlackAdapter.ts",
+    "src/messaging/slack/SocketModeClient.ts",
+    "tests/unit/slack-safesend.test.ts",
+    "tests/unit/slack-socket-heartbeat.test.ts",
+    "tests/unit/slack-thread-session-routing.test.ts"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "A localized reliability correction to existing Slack recovery and Socket Mode lifecycle paths. It adds no API route, config, scope, state schema, autonomous authority, or migration. Both broken boundaries are directly unit-tested and the existing reconnect/leak suites remain in the focused regression set.",
+  "eli16Path": "docs/specs/slack-inbound-recovery-robustness.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/slack-inbound-recovery-robustness.md",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Thread-scoped Slack sessions introduced composite routing keys, but both recovery loops continued to assume resume-map keys were raw channel IDs. Separately, the existing dead-silence probe relied on successful local send() of undocumented JSON, which cannot establish inbound event delivery. The live incident exposed both latent assumptions together: startup logged channel_not_found for a composite key while the socket stayed OPEN and emitted no events."
+  },
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/specs/slack-inbound-recovery-robustness.eli16.md
+++ b/docs/specs/slack-inbound-recovery-robustness.eli16.md
@@ -1,0 +1,21 @@
+# Slack Inbound Recovery Robustness — ELI16
+
+Imagine Slack gives every channel a mailbox number. A conversation thread has
+the same mailbox number plus a note telling you which folder inside the mailbox
+to use.
+
+Instar saved that combined address so it could reopen the right conversation.
+But after a restart it accidentally handed the whole combined address to
+Slack's mailbox-history API. Slack only accepts the mailbox number, so it
+answered “channel not found” and the recovery check missed the message.
+
+There was a second issue: when Slack went quiet, Instar sent a made-up JSON
+“ping.” The computer could report that it successfully wrote those bytes even
+if Slack was no longer delivering anything back. That was like dropping a note
+into a jammed mail slot and assuming the mail carrier was working.
+
+The fix separates the mailbox number from the thread note before asking for
+history. It also replaces the fake ping with a fresh Socket Mode connection
+after five silent minutes. Instar records when the blind period began, so the
+fresh connection checks history and recovers the newest authorized user message
+that may have arrived meanwhile.

--- a/docs/specs/slack-inbound-recovery-robustness.md
+++ b/docs/specs/slack-inbound-recovery-robustness.md
@@ -1,0 +1,44 @@
+# Slack Inbound Recovery Robustness
+
+## Problem
+
+Slack thread sessions are persisted under routing keys shaped like
+`<channel-id>:<thread-ts>`. Startup and reconnect recovery treated those keys as
+raw Slack channel IDs and passed them to `conversations.history`, which Slack
+rejects with `channel_not_found`.
+
+Socket Mode also treated a successful send of undocumented `{"type":"ping"}`
+JSON as proof that inbound delivery was healthy. Slack ignores that payload, so
+a half-open connection could accept local writes while delivering no events.
+
+## Contract
+
+1. Any session routing key must be reduced to its raw channel ID before it is
+   passed to a Slack channel API.
+2. Multiple channel-root and thread checkpoints for one channel produce one
+   history request, starting at the oldest checkpoint.
+3. Five minutes without any Socket Mode event bounds a potentially half-open
+   connection: the client records a disconnect and rotates the socket.
+4. Recording the disconnect is mandatory because the next successful connection
+   uses that timestamp to recover the latest authorized user message missed
+   during the blind window.
+5. Recovery remains bounded to one replayed user message per raw channel.
+
+## Safety and Failure Behavior
+
+- No new Slack scopes, endpoints, credentials, or message payloads are added.
+- Reconnection uses the existing `apps.connections.open` flow and existing
+  exponential backoff.
+- Stale socket events remain protected by the existing epoch and socket-identity
+  guards.
+- Recovery ignores bot messages, unsupported subtypes, and unauthorized users as
+  before.
+
+## Verification
+
+- Unit coverage proves composite thread keys never reach `conversations.history`.
+- Unit coverage proves checkpoints are deduplicated by raw channel and the
+  oldest timestamp wins.
+- A timer-driven unit test proves dead silence rotates the connection without
+  sending arbitrary JSON.
+- Existing reconnect, socket-leak, and thread-routing suites remain green.

--- a/src/messaging/slack/SlackAdapter.ts
+++ b/src/messaging/slack/SlackAdapter.ts
@@ -2045,11 +2045,11 @@ export class SlackAdapter implements MessagingAdapter {
 
     // Collect channels that had recent sessions (these are the ones users were talking to)
     const channelsToCheck = new Set<string>();
-    for (const [channelId] of this.channelToSession) {
-      channelsToCheck.add(channelId);
+    for (const [routingKey] of this.channelToSession) {
+      channelsToCheck.add(this.parseRoutingKey(routingKey).channelId);
     }
-    for (const [channelId] of this.channelResumeMap) {
-      channelsToCheck.add(channelId);
+    for (const [routingKey] of this.channelResumeMap) {
+      channelsToCheck.add(this.parseRoutingKey(routingKey).channelId);
     }
 
     if (channelsToCheck.size === 0) {
@@ -2120,12 +2120,21 @@ export class SlackAdapter implements MessagingAdapter {
     try {
       // Collect channels from the persisted resume map (loaded from disk in constructor)
       const channelsToCheck = new Map<string, string>(); // channelId → oldest ts to check from
-      for (const [channelId, info] of this.channelResumeMap) {
+      for (const [routingKey, info] of this.channelResumeMap) {
         // Don't skip system channels — _handleMessage filters appropriately
         // Use the savedAt timestamp as the "last known alive" point
         const savedAtMs = new Date(info.savedAt).getTime();
         if (isNaN(savedAtMs)) continue;
-        channelsToCheck.set(channelId, (savedAtMs / 1000).toFixed(6));
+        // Resume maps are keyed by a session routing key. Thread sessions use
+        // `<channelId>:<thread_ts>`, but Slack history APIs accept only the raw
+        // channel id. Collapse every routing key to its API channel and retain
+        // the oldest checkpoint so one fetch covers every session in it.
+        const channelId = this.parseRoutingKey(routingKey).channelId;
+        const existingOldest = channelsToCheck.get(channelId);
+        const savedAtTs = (savedAtMs / 1000).toFixed(6);
+        if (!existingOldest || Number(savedAtTs) < Number(existingOldest)) {
+          channelsToCheck.set(channelId, savedAtTs);
+        }
       }
 
       if (channelsToCheck.size === 0) return;

--- a/src/messaging/slack/SocketModeClient.ts
+++ b/src/messaging/slack/SocketModeClient.ts
@@ -7,13 +7,10 @@
  *
  * Uses Node's built-in WebSocket (Node 22+) or falls back to 'ws' package.
  *
- * CONTRACT-EVIDENCE: EXEMPT — net #1 (_safeSend containment) touches NO Slack
- * Socket Mode API-contract surface. The bytes sent to Slack are byte-identical
- * (the same ack `{ envelope_id }`, the same `{"type":"ping"}`, the same queued
- * payloads); only the local non-OPEN-send guarding (readyState check + try/catch)
- * and the reconnect policy changed. No wire-protocol / envelope shape change, so
- * live-API contract evidence does not apply. Remove this marker when the file's
- * actual API surface next changes.
+ * CONTRACT-EVIDENCE: EXEMPT — dead-silence recovery changes only local socket
+ * lifecycle policy. It removes an undocumented application payload that Slack
+ * ignored and opens a fresh connection through the already-established
+ * apps.connections.open path. No Slack envelope or API request shape changes.
  */
 
 import { SlackApiClient, SlackApiError } from './SlackApiClient.js';
@@ -41,7 +38,7 @@ interface OutboundQueueItem {
 
 const MAX_OUTBOUND_QUEUE = 100;
 const HEARTBEAT_INTERVAL_MS = 30_000;   // Check connection health every 30s
-const DEAD_SILENCE_MS = 300_000;        // 5 min with no events → send liveness probe
+const DEAD_SILENCE_MS = 300_000;        // 5 min with no events → rotate the connection
 const MAX_BACKOFF_MS = 60_000;
 const TOO_MANY_WS_DELAY_MS = 30_000;
 
@@ -350,27 +347,22 @@ export class SocketModeClient {
         return;
       }
 
-      // 2. If no events for DEAD_SILENCE_MS, send a probe to test the connection.
-      //    Slack Socket Mode has no application-level ping/pong — Slack will
-      //    silently ignore any JSON we send. So we test with send(): if it
-      //    throws, the socket is dead at the OS level → force reconnect.
-      //    If send() succeeds, the TCP connection is alive — reset the silence
-      //    timer and check again later.
+      // 2. Slack Socket Mode has no documented application-level ping/pong.
+      //    A successful send of arbitrary JSON proves only that the local TCP
+      //    buffer accepted bytes; it does not prove Slack is still delivering
+      //    events. Bound that half-open state by rotating a silent connection.
+      //    _forceReconnect records the outage before teardown, which lets the
+      //    adapter recover any message that landed during the blind window.
       const sinceLastEvent = Date.now() - this.lastEventAt;
       if (sinceLastEvent > DEAD_SILENCE_MS) {
-        console.log(`[slack-socket] No events for ${Math.round(sinceLastEvent / 60000)}m — sending liveness probe`);
-        // Route through the funnel with reconnectOnFailure: a probe that throws
-        // means the socket is dead at the OS level → _safeSend forces a reconnect.
-        if (this._safeSend('{"type":"ping"}', 'liveness-probe', true)) {
-          // send() succeeded → TCP connection is alive. Reset silence timer
-          // so we don't immediately re-probe on the next tick.
-          this.lastEventAt = Date.now();
-        }
+        console.warn(`[slack-socket] No events for ${Math.round(sinceLastEvent / 60000)}m — rotating connection`);
+        this._forceReconnect('dead silence');
       }
     }, HEARTBEAT_INTERVAL_MS);
   }
 
-  private _forceReconnect(): void {
+  private _forceReconnect(reason = 'forced reconnect'): void {
+    this.handlers.onDisconnected(reason);
     this._teardownSocket(1000, 'force reconnect');
     // Trigger reconnect directly instead of relying on close event — the
     // torn-down socket's close is identity-guarded and will be ignored.

--- a/tests/unit/slack-safesend.test.ts
+++ b/tests/unit/slack-safesend.test.ts
@@ -263,11 +263,11 @@ describe('Wiring-integrity ratchet — every raw socket send funnels through _sa
     ).toEqual([]);
   });
 
-  it('all four logical callsites reference _safeSend', () => {
-    // queueOutbound, the ack, the liveness probe, and the drain.
+  it('all three logical send callsites reference _safeSend', () => {
+    // queueOutbound, the ack, and the drain. Dead-silence recovery reconnects
+    // instead of sending an undocumented application-level ping.
     expect(socketClientSource).toMatch(/queueOutbound\(data: string\): void \{[\s\S]*?this\._safeSend\(data, 'outbound'\)/);
     expect(socketClientSource).toMatch(/this\._safeSend\(JSON\.stringify\(\{ envelope_id: envelope\.envelope_id \}\), 'ack'\)/);
-    expect(socketClientSource).toMatch(/this\._safeSend\('\{"type":"ping"\}', 'liveness-probe', true\)/);
     expect(socketClientSource).toMatch(/_drainQueue\(\): void \{[\s\S]*?this\._safeSend\(pending\[k\]\.data, 'drain'\)/);
   });
 });

--- a/tests/unit/slack-socket-heartbeat.test.ts
+++ b/tests/unit/slack-socket-heartbeat.test.ts
@@ -13,9 +13,10 @@
  * agent that needs to respond within minutes.
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'fs';
 import path from 'path';
+import { SocketModeClient, type SocketModeHandlers } from '../../src/messaging/slack/SocketModeClient.js';
 
 const socketClientPath = path.resolve(__dirname, '../../src/messaging/slack/SocketModeClient.ts');
 const socketClientSource = readFileSync(socketClientPath, 'utf-8');
@@ -39,27 +40,46 @@ describe('Heartbeat timing constants', () => {
 });
 
 describe('Active liveness probe', () => {
-  it('sends a ping probe through the _safeSend funnel when no events for DEAD_SILENCE_MS', () => {
-    // After DEAD_SILENCE_MS of silence, sends a JSON ping via _safeSend (net #1)
-    expect(socketClientSource).toMatch(
-      /sinceLastEvent > DEAD_SILENCE_MS[\s\S]*?_safeSend\('\{"type":"ping"\}', 'liveness-probe', true\)/,
-    );
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
-  it('resets silence timer after a successful probe send (TCP alive)', () => {
-    // _safeSend returning true means the send succeeded → reset lastEventAt so we
-    // don't immediately re-probe on the next tick.
-    expect(socketClientSource).toMatch(
-      /_safeSend\('\{"type":"ping"\}', 'liveness-probe', true\)\) \{[\s\S]*?lastEventAt = Date\.now\(\)/,
-    );
+  it('rotates a connection after DEAD_SILENCE_MS instead of sending an ignored JSON ping', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-23T20:00:00.000Z'));
+    const handlers: SocketModeHandlers = {
+      onEvent: vi.fn(async () => {}),
+      onInteraction: vi.fn(async () => {}),
+      onConnected: vi.fn(),
+      onDisconnected: vi.fn(),
+      onError: vi.fn(),
+    };
+    const client = new SocketModeClient({} as never, handlers);
+    const internal = client as unknown as {
+      started: boolean;
+      ws: { readyState: number };
+      lastEventAt: number;
+      _startHeartbeat(): void;
+      _clearHeartbeat(): void;
+      _forceReconnect(reason?: string): void;
+    };
+    internal.started = true;
+    internal.ws = { readyState: WebSocket.OPEN };
+    internal.lastEventAt = Date.now() - 300_001;
+    const reconnect = vi.spyOn(internal, '_forceReconnect').mockImplementation(() => {});
+
+    internal._startHeartbeat();
+    vi.advanceTimersByTime(30_000);
+
+    expect(reconnect).toHaveBeenCalledOnce();
+    expect(reconnect).toHaveBeenCalledWith('dead silence');
+    expect(socketClientSource).not.toContain('{"type":"ping"}');
+    internal._clearHeartbeat();
   });
 
-  it('forces reconnect via _safeSend reconnectOnFailure when the probe send throws', () => {
-    // The probe passes reconnectOnFailure=true; the funnel force-reconnects on a
-    // caught throw (socket dead at the OS level), guarded by the identity check.
-    expect(socketClientSource).toMatch(/_safeSend\('\{"type":"ping"\}', 'liveness-probe', true\)/);
+  it('records a disconnect before tearing down a forced connection', () => {
     expect(socketClientSource).toMatch(
-      /reconnectOnFailure && this\.started && !this\.reconnecting && this\.ws === sock\) \{[\s\S]*?this\._forceReconnect\(\)/,
+      /_forceReconnect\(reason = 'forced reconnect'\)[\s\S]*?handlers\.onDisconnected\(reason\)[\s\S]*?_teardownSocket/,
     );
   });
 });
@@ -72,7 +92,7 @@ describe('WebSocket readyState check', () => {
 
 describe('_forceReconnect method', () => {
   it('exists as a dedicated method', () => {
-    expect(socketClientSource).toContain('private _forceReconnect(): void');
+    expect(socketClientSource).toContain("private _forceReconnect(reason = 'forced reconnect'): void");
   });
 
   it('clears the heartbeat timer', () => {

--- a/tests/unit/slack-thread-session-routing.test.ts
+++ b/tests/unit/slack-thread-session-routing.test.ts
@@ -290,3 +290,57 @@ describe('inbound _handleMessage carries thread_ts metadata used by routing', ()
     expect(key).toBe(`${CH}:${THREAD_A}`);
   });
 });
+
+describe('missed-message recovery canonicalizes thread routing keys', () => {
+  it('startup recovery queries each raw channel once and keeps its oldest checkpoint', async () => {
+    const { adapter } = makeAdapter({ allChannels: true });
+    const now = Date.now();
+    const oldestMs = now - 120_000;
+    const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+    (adapter as any).channelResumeMap = new Map([
+      [`${CH}:${THREAD_A}`, { uuid: 'a', sessionName: 'a', savedAt: new Date(now - 60_000).toISOString() }],
+      [`${CH}:${THREAD_B}`, { uuid: 'b', sessionName: 'b', savedAt: new Date(oldestMs).toISOString() }],
+    ]);
+    (adapter as any).apiClient = {
+      call: async (method: string, params: Record<string, unknown>) => {
+        calls.push({ method, params });
+        return { messages: [] };
+      },
+    };
+
+    await (adapter as any)._recoverOnStartup();
+
+    expect(calls).toEqual([{
+      method: 'conversations.history',
+      params: {
+        channel: CH,
+        oldest: (oldestMs / 1000).toFixed(6),
+        limit: 20,
+      },
+    }]);
+  });
+
+  it('reconnect recovery never passes a composite routing key to Slack history', async () => {
+    const { adapter } = makeAdapter({ allChannels: true });
+    const calls: Array<Record<string, unknown>> = [];
+    (adapter as any)._lastDisconnectedAt = Date.now() - 1_000;
+    (adapter as any).channelToSession = new Map([
+      [`${CH}:${THREAD_A}`, { sessionName: 'a', registeredAt: new Date().toISOString() }],
+    ]);
+    (adapter as any).channelResumeMap = new Map([
+      [`${CH}:${THREAD_B}`, { uuid: 'b', sessionName: 'b', savedAt: new Date().toISOString() }],
+    ]);
+    (adapter as any).apiClient = {
+      call: async (_method: string, params: Record<string, unknown>) => {
+        calls.push(params);
+        return { messages: [] };
+      },
+    };
+
+    await (adapter as any)._recoverMissedMessages();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].channel).toBe(CH);
+    expect(String(calls[0].channel)).not.toContain(':');
+  });
+});

--- a/upgrades/next/slack-inbound-recovery-robustness.md
+++ b/upgrades/next/slack-inbound-recovery-robustness.md
@@ -1,0 +1,21 @@
+---
+title: "Slack inbound recovery survives thread keys and half-open sockets"
+audience: "operators"
+---
+
+## What Changed
+
+Slack restart recovery now converts thread-scoped session keys back to raw
+channel IDs before reading history. Silent Socket Mode connections are rotated
+instead of being trusted after an ignored JSON ping.
+
+## What to Tell Your User
+
+Slack messages are now recovered reliably after a restart or a silent broken
+connection, including in channels that use thread-scoped sessions.
+
+## Summary of New Capabilities
+
+- Recovers missed Slack messages without sending thread routing keys to channel
+  APIs.
+- Bounds silent half-open Socket Mode connections with an automatic reconnect.

--- a/upgrades/side-effects/slack-inbound-recovery-robustness.md
+++ b/upgrades/side-effects/slack-inbound-recovery-robustness.md
@@ -1,0 +1,23 @@
+# Slack Inbound Recovery Robustness — Side Effects
+
+## Runtime Changes
+
+- A Socket Mode connection with no inbound event for five minutes is rotated
+  through the existing reconnect/backoff path.
+- Forced reconnects now notify the adapter of the disconnect, enabling its
+  existing missed-message recovery after the new socket connects.
+- Startup and reconnect recovery deduplicate thread routing keys to raw Slack
+  channel IDs before history requests.
+
+## External Effects
+
+- Idle Slack installations may call `apps.connections.open` more often: at most
+  once per five-minute silent interval, further bounded by existing backoff.
+- Recovery may issue one `conversations.history` request per raw channel with a
+  recent session.
+- No user message is sent by the connection rotation itself.
+
+## Rollback
+
+Reverting the two Slack source changes restores the prior heartbeat and recovery
+behavior. No stored-state migration or cleanup is required.


### PR DESCRIPTION
## What changed

- Canonicalize channel and thread-session routing keys before Slack history recovery.
- Deduplicate recovery reads by raw channel while retaining the oldest saved checkpoint.
- Replace the ineffective undocumented JSON ping with bounded connection rotation after five silent minutes.
- Record forced disconnects so the existing missed-message recovery runs after reconnection.

## Why

The live Slack inbound incident had two independent recovery gaps. Startup passed a persisted thread key such as `C…:thread_ts` to `conversations.history`, which Slack rejected as `channel_not_found`. Meanwhile, the Socket Mode liveness probe treated a successful local `send()` as evidence of inbound health even though Slack ignores that JSON and a half-open socket can still accept local writes.

## ELI16

Think of a Slack channel as a mailbox number and a thread as a folder note attached to that number. Instar saved both pieces together, then accidentally handed the combined address to an API that accepts only the mailbox number. Slack therefore said the channel did not exist.

The old health check also dropped a made-up ping into the mail slot and assumed delivery was healthy merely because the slot accepted it. Now Instar separates the real mailbox number before reading history. If Slack sends nothing for five minutes, Instar opens a fresh connection, remembers when the blind period began, and checks for the newest authorized user message that may have arrived meanwhile.

## Impact

Slack inbound recovery now works with thread-scoped sessions and bounds silent half-open Socket Mode connections. No new Slack scopes, endpoints, credentials, or persistent-state migrations are introduced.

## Validation

- 103 focused Slack regression tests passed.
- Affected pre-push smoke tier: 24 files / 226 tests passed.
- `npm run lint` passed.
- TypeScript typecheck passed.
- Repository invariants passed.
- Decision-audit, ELI16, release-note, and side-effects artifacts included.