### PR TITLE
fix: restore pending login flows after restart

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T22-11-22-176Z-login-flow-restart-recovery.json
+++ b/.instar/instar-dev-decisions/2026-07-23T22-11-22-176Z-login-flow-restart-recovery.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T22:11:22.176Z",
+  "slug": "login-flow-restart-recovery",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 94,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "PendingLoginStore deliberately persisted public flow metadata, but no boot consumer restored the framework process that metadata referred to. The submit route therefore conflated a durable record with a live pane and surfaced transport-style errors after restart."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T22-11-56-698Z-login-flow-restart-recovery.json
+++ b/.instar/instar-dev-decisions/2026-07-23T22-11-56-698Z-login-flow-restart-recovery.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T22:11:56.698Z",
+  "slug": "login-flow-restart-recovery",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 94,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "PendingLoginStore deliberately persisted public flow metadata, but no boot consumer restored the framework process that metadata referred to. The submit route therefore conflated a durable record with a live pane and surfaced transport-style errors after restart."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T22-12-41-843Z-login-flow-restart-recovery.json
+++ b/.instar/instar-dev-decisions/2026-07-23T22-12-41-843Z-login-flow-restart-recovery.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T22:12:41.843Z",
+  "slug": "login-flow-restart-recovery",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 94,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "PendingLoginStore deliberately persisted public flow metadata, but no boot consumer restored the framework process that metadata referred to. The submit route therefore conflated a durable record with a live pane and surfaced transport-style errors after restart."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T22-13-21-007Z-login-flow-restart-recovery.json
+++ b/.instar/instar-dev-decisions/2026-07-23T22-13-21-007Z-login-flow-restart-recovery.json
@@ -1,0 +1,21 @@
+{
+  "ts": "2026-07-23T22:13:21.007Z",
+  "slug": "login-flow-restart-recovery",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 94,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "PendingLoginStore deliberately persisted public flow metadata, but no boot consumer restored the framework process that metadata referred to. The submit route therefore conflated a durable record with a live pane and surfaced transport-style errors after restart."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "Boot recovery is a one-shot pass over the finite durable pending-login set. It runs once per process start, performs at most one re-drive per incomplete record, and has no self-rescheduling path. Dead-flow submit refresh is user-triggered and single-flow bounded."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T22-14-02-085Z-login-flow-restart-recovery.json
+++ b/.instar/instar-dev-decisions/2026-07-23T22-14-02-085Z-login-flow-restart-recovery.json
@@ -1,0 +1,21 @@
+{
+  "ts": "2026-07-23T22:14:02.085Z",
+  "slug": "login-flow-restart-recovery",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 94,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "PendingLoginStore deliberately persisted public flow metadata, but no boot consumer restored the framework process that metadata referred to. The submit route therefore conflated a durable record with a live pane and surfaced transport-style errors after restart."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "Boot recovery is a one-shot pass over the finite durable pending-login set. It runs once per process start, performs at most one re-drive per incomplete record, and has no self-rescheduling path. Dead-flow submit refresh is user-triggered and single-flow bounded."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-23T22-10-01-000Z-login-flow-restart-recovery.json
+++ b/.instar/instar-dev-traces/2026-07-23T22-10-01-000Z-login-flow-restart-recovery.json
@@ -1,0 +1,35 @@
+{
+  "version": 3,
+  "slug": "login-flow-restart-recovery",
+  "sessionId": "slack-C0BA4F4E0FP-20260723",
+  "timestamp": "2026-07-23T22:10:01.000Z",
+  "artifactPath": "upgrades/side-effects/login-flow-restart-recovery.md",
+  "artifactSha256": "e2cab96b24465931d5c9f24731d34bbd36a495b269fa395a6af65453aa47c411",
+  "specPath": "docs/specs/login-flow-restart-recovery.md",
+  "coveredFiles": [
+    "dashboard/subscriptions.js",
+    "src/commands/server.ts",
+    "src/core/EnrollmentWizard.ts",
+    "src/server/routes.ts",
+    "tests/e2e/subscription-enrollment-lifecycle.test.ts",
+    "tests/integration/account-follow-me-submit-code-route.test.ts",
+    "tests/integration/subscriptions-tab.test.ts",
+    "tests/unit/enrollment-wizard.test.ts"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "A bounded correction to an existing login lifecycle: no new route, config, scope, credential surface, state schema, or autonomous authority. It restores the already-durable flow after process restart and classifies stale submissions through existing enrollment machinery.",
+  "eli16Path": "docs/specs/login-flow-restart-recovery.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/login-flow-restart-recovery.md",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "PendingLoginStore deliberately persisted public flow metadata, but no boot consumer restored the framework process that metadata referred to. The submit route therefore conflated a durable record with a live pane and surfaced transport-style errors after restart."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "Boot recovery is a one-shot pass over the finite durable pending-login set. It runs once per process start, performs at most one re-drive per incomplete record, and has no self-rescheduling path. Dead-flow submit refresh is user-triggered and single-flow bounded."
+  },
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -1121,6 +1121,14 @@ export function createController(opts) {
             setRowStatus(row, `✗ ${heldExplanation(r.json.expected, r.json.got, r.json.reason)}`);
             rerenderMatrixFromCache();
             btn.removeAttribute('disabled');
+          } else if (r.json && r.json.code === 'login-expired-fresh-ready') {
+            row.removeAttribute('data-interaction-open');
+            setRowStatus(row, 'That code belonged to an expired sign-in. A fresh sign-in is ready now.');
+            await tick();
+          } else if (r.json && r.json.code === 'login-expired') {
+            row.removeAttribute('data-interaction-open');
+            row.setAttribute('class', 'sub-pending sub-pending-failed');
+            setRowStatus(row, `✗ ${r.json.error || 'That sign-in expired — start a fresh one from its grid cell.'}`);
           } else if (r.json && r.json.code === 'pane-dead') {
             // D5: the attempt's window is gone — flip to the explicit needs-restart state.
             row.removeAttribute('data-interaction-open');
@@ -1308,6 +1316,14 @@ export function createController(opts) {
           cell.removeAttribute('data-interaction-open');
           recordSubmitOutcome('held', { accountId, machineId }, r.json);
           renderCellHeld(cell, accountId, machineId, r.json);
+        } else if (r.json && r.json.code === 'login-expired-fresh-ready') {
+          cell.removeAttribute('data-interaction-open');
+          setCellStatus(cell, 'That code belonged to an expired sign-in. A fresh sign-in is ready now.');
+          await tick();
+        } else if (r.json && r.json.code === 'login-expired') {
+          cell.removeAttribute('data-interaction-open');
+          recordSubmitOutcome('broken', { accountId, machineId }, r.json);
+          rerenderMatrixFromCache();
         } else if (r.json && r.json.code === 'pane-dead') {
           // TERMINAL (D5): the sign-in window is gone — explicit needs-restart state.
           cell.removeAttribute('data-interaction-open');

--- a/docs/specs/login-flow-restart-recovery.eli16.md
+++ b/docs/specs/login-flow-restart-recovery.eli16.md
@@ -1,0 +1,20 @@
+# Login Flow Restart Recovery — ELI16
+
+A sign-in flow has two parts: a saved card describing it, and a live program
+waiting for the code. The card already survived a server restart, but the live
+program died. That made the dashboard look ready even though there was nowhere
+safe to send the code.
+
+Now Instar rebuilds the live part of every unfinished sign-in during startup and
+puts the fresh public link or code back onto the saved card. If someone submits
+an old code after the live window disappeared, Instar refuses to type it,
+creates a fresh sign-in when the account still needs one, and says clearly that
+the old flow expired and the replacement is ready.
+
+This matters for safety as well as clarity. Typing a stale authentication code
+into a dead program could put the code into an ordinary shell prompt instead.
+The new flow checks the live window first and treats its absence as a lifecycle
+event, not as permission to keep trying delivery. If a replacement cannot be
+created honestly, the dashboard says the sign-in expired and offers the normal
+fresh-start action. It never turns that case into a vague server error or claims
+that a replacement exists when it does not.

--- a/docs/specs/login-flow-restart-recovery.md
+++ b/docs/specs/login-flow-restart-recovery.md
@@ -1,0 +1,27 @@
+# Login Flow Restart Recovery
+
+## Problem
+
+Pending-login metadata survived a server restart, but its framework login pane
+did not. A user could therefore submit a code to a durable record whose backing
+process was gone and receive a raw transport-style failure.
+
+## Contract
+
+1. On boot, every non-terminal pending login is re-driven before dashboard
+   traffic is served. The replacement suppresses browser launch and persists
+   only its fresh public URL/code.
+2. A submit against a dead pane never types the stale code. The server refreshes
+   that flow and returns `login-expired-fresh-ready`.
+3. If the record vanished but the pool account still provably needs re-auth, the
+   submit action mints a replacement flow from the account metadata and returns
+   the same fresh-ready response.
+4. If no replacement can honestly be produced, the response is
+   `410 login-expired`, not a bare 404/502.
+5. The dashboard recognizes both lifecycle outcomes and never renders
+   “failed (status)” for them.
+
+## Safety
+
+No credential is stored or returned. A stale code is refused before `sendInput`.
+Boot/dead-pane renewal uses the existing login driver and public-artifact store.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -13516,6 +13516,15 @@ export async function startServer(options: StartOptions): Promise<void> {
         logger: { log: (m) => console.log(m), warn: (m) => console.warn(m) },
       }).asLoginDriver(),
     });
+    // Pending-login metadata is durable, but its framework pane is a process and
+    // therefore never survives this server's restart. Restore every incomplete
+    // flow before serving dashboard traffic so a persisted code is never backed
+    // by a dead pane. Renewal suppresses browser launch and stores only the fresh
+    // public URL/code, preserving the existing credential boundary.
+    const recoveredLogins = await enrollmentWizard.recoverAfterRestart();
+    if (recoveredLogins.length > 0) {
+      console.log(pc.green(`  Restored ${recoveredLogins.length} pending login flow(s) after restart`));
+    }
     // Background auto-reissue sweep — refreshes an expired login code without the
     // operator asking (the pi-live-test gap). Inert with no pending logins; the
     // timer is unref'd so it never holds the process open.

--- a/src/core/EnrollmentWizard.ts
+++ b/src/core/EnrollmentWizard.ts
@@ -256,8 +256,35 @@ export class EnrollmentWizard {
    * abort the sweep.
    */
   async reissueExpired(): Promise<PendingLogin[]> {
+    return this.reissueLogins(this.store.expired(), 'expired');
+  }
+
+  /**
+   * A server restart kills every framework login pane even though the durable
+   * pending-login record survives. Re-drive every non-terminal record once at
+   * boot so the durable flow regains a live backing process and fresh public
+   * URL/code before the dashboard can submit to it.
+   */
+  async recoverAfterRestart(): Promise<PendingLogin[]> {
+    const incomplete = this.store.list().filter((login) =>
+      login.status === 'pending' || login.status === 'expired');
+    return this.reissueLogins(incomplete, 'restart');
+  }
+
+  /** Refresh one known incomplete flow after its backing pane is found dead. */
+  async refresh(id: string): Promise<PendingLogin | null> {
+    const login = this.store.get(id);
+    if (!login || (login.status !== 'pending' && login.status !== 'expired')) return null;
+    const refreshed = await this.reissueLogins([login], 'dead-pane');
+    return refreshed[0] ?? null;
+  }
+
+  private async reissueLogins(
+    logins: PendingLogin[],
+    reason: 'expired' | 'restart' | 'dead-pane',
+  ): Promise<PendingLogin[]> {
     const reissued: PendingLogin[] = [];
-    for (const login of this.store.expired()) {
+    for (const login of logins) {
       try {
         const fresh = await this.driveLogin({
           provider: login.provider,
@@ -275,12 +302,12 @@ export class EnrollmentWizard {
         });
         if (updated) {
           reissued.push(updated);
-          this.logger.log(`[EnrollmentWizard] auto-reissued expired login ${login.id} (reissue #${updated.reissueCount})`);
+          this.logger.log(`[EnrollmentWizard] refreshed ${reason} login ${login.id} (reissue #${updated.reissueCount})`);
         }
       } catch (err) {
         // @silent-fallback-ok: one re-drive failing must not abort the sweep;
         // the login stays expired and is retried next sweep.
-        this.logger.warn(`[EnrollmentWizard] reissue of ${login.id} failed: ${err instanceof Error ? err.message : String(err)}`);
+        this.logger.warn(`[EnrollmentWizard] ${reason} refresh of ${login.id} failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
     return reissued;

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -27146,9 +27146,43 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     }
     // Resolve the pending login → its configHome + framework → the enroll pane session
     // name (derived through the shared helper so it can NEVER drift from enroll-start's spawn).
-    const login = ctx.enrollmentWizard.pending().find((l) => l.id === id);
+    let login = ctx.enrollmentWizard.pending().find((l) => l.id === id);
     if (!login) {
-      res.status(404).json({ error: `no pending login "${id}" is waiting for a code — start the sign-in again from the dashboard grid` });
+      // The operator submitted against a flow that disappeared across a restart
+      // or exhausted cleanup. Never collapse that honest lifecycle state into a
+      // raw 404/502. If the account still provably needs a login, mint its fresh
+      // replacement now and return the public flow so the cell can redraw.
+      const account = ctx.subscriptionPool.get(id);
+      const stillNeedsSignIn = account?.status === 'needs-reauth' || (
+        account?.identityDrifted === true &&
+        (account.identityDrift?.repairState === 'owner-relogin-required' ||
+          account.identityDrift?.actualAccountId === 'missing-local-login')
+      );
+      if (account && stillNeedsSignIn) {
+        try {
+          const freshLogin = await ctx.enrollmentWizard.start({
+            id: account.id,
+            label: account.nickname,
+            provider: account.provider,
+            framework: account.framework,
+            configHome: account.configHome,
+            expectedEmail: account.email,
+            remote: true,
+          });
+          res.status(409).json({
+            code: 'login-expired-fresh-ready',
+            error: 'that code belonged to an expired sign-in — a fresh sign-in is ready now',
+            freshLogin,
+          });
+          return;
+        } catch (err) {
+          console.warn(`[follow-me] expired login refresh failed id=${id}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+      res.status(410).json({
+        code: 'login-expired',
+        error: 'that sign-in has expired — start a fresh sign-in from this account’s grid cell',
+      });
       return;
     }
     // Narrow the authority (codex finding #4): this paste-back path is ONLY for the
@@ -27194,7 +27228,19 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     // affordance — never a "may have closed" guess. Wording floor: the message only references
     // affordances that exist on the surface it lands on (the grid's Retry — never "Approve").
     if (rawFrame == null || !frame.trim()) {
-      res.status(409).json({ code: 'pane-dead', error: `this sign-in's window is no longer running on its machine, so it can't take a code — start the sign-in again from the dashboard grid` });
+      const freshLogin = await ctx.enrollmentWizard.refresh(id);
+      if (freshLogin) {
+        res.status(409).json({
+          code: 'login-expired-fresh-ready',
+          error: 'that code belonged to an expired sign-in — a fresh sign-in is ready now',
+          freshLogin,
+        });
+        return;
+      }
+      res.status(410).json({
+        code: 'login-expired',
+        error: 'that sign-in has expired — start a fresh sign-in from this account’s grid cell',
+      });
       return;
     }
     if (!looksReady || looksLikeShell) {

--- a/tests/e2e/subscription-enrollment-lifecycle.test.ts
+++ b/tests/e2e/subscription-enrollment-lifecycle.test.ts
@@ -75,14 +75,21 @@ describe('/subscription-pool enrollment — E2E feature-alive', () => {
     // Second boot: a FRESH store + wizard over the SAME state dir — the pending
     // login must still be there (it persisted to disk).
     const store2 = new PendingLoginStore({ stateDir: dir });
-    const wizard2 = new EnrollmentWizard({ store: store2, driveLogin: async () => ART });
+    const wizard2 = new EnrollmentWizard({
+      store: store2,
+      driveLogin: async () => ({ ...ART, userCode: 'FRESH-CODE' }),
+    });
+    // Mirrors production boot: persisted metadata alone is insufficient because
+    // the prior process's login pane died with the server.
+    await wizard2.recoverAfterRestart();
     server = await bootApp({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), enrollmentWizard: wizard2 });
     const res = await fetch(server.url + '/subscription-pool/pending-logins');
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.enabled).toBe(true);
     expect(body.logins.map((l: any) => l.id)).toEqual(['codex-1']);
-    expect(body.logins[0].userCode).toBe('AAAA-BBBB');
+    expect(body.logins[0].userCode).toBe('FRESH-CODE');
+    expect(body.logins[0].reissueCount).toBe(1);
   });
 
   it('FEATURE ALIVE: completing a claude-code enrollment leaves its config home interactive-ready (2026-06-09 incident)', async () => {

--- a/tests/integration/account-follow-me-submit-code-route.test.ts
+++ b/tests/integration/account-follow-me-submit-code-route.test.ts
@@ -167,13 +167,36 @@ describe('WS5.2 code paste-back submit-code routes (integration)', () => {
     expect(r.status).toBe(409);
   });
 
-  it('TARGET — enabled + no pending login for id → 404', async () => {
+  it('TARGET — enabled + no pending login for id → honest 410 expired, never bare 404/502', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-code-'));
     const app = express(); app.use(express.json());
     app.use(createRoutes(buildCtx(dir, { dev: true, seedPending: false })));
     server = await listen(app);
     const r = await post('/subscription-pool/follow-me/enroll/fm-1/submit-code', { code: 'ABC123' });
-    expect(r.status).toBe(404);
+    expect(r.status).toBe(410);
+    expect(r.body.code).toBe('login-expired');
+    expect(r.body.error).toMatch(/expired/i);
+  });
+
+  it('TARGET — vanished flow for an account that still needs sign-in → fresh flow minted and returned', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-code-'));
+    const ctx = buildCtx(dir, { dev: true, seedPending: false });
+    const pool = (ctx as unknown as { subscriptionPool: SubscriptionPool }).subscriptionPool;
+    pool.add({
+      id: 'fm-1', nickname: 'main', provider: 'anthropic', framework: 'claude-code',
+      configHome: path.join(dir, '.claude-followme-fm-1'), status: 'needs-reauth',
+      email: 'approved@x.com',
+    });
+    const app = express(); app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+
+    const r = await post('/subscription-pool/follow-me/enroll/fm-1/submit-code', { code: 'OLD-CODE' });
+
+    expect(r.status).toBe(409);
+    expect(r.body.code).toBe('login-expired-fresh-ready');
+    expect(r.body.error).toMatch(/fresh sign-in is ready/i);
+    expect(r.body.freshLogin).toMatchObject({ id: 'fm-1', status: 'pending' });
   });
 
   it('TARGET — enabled + pending login + credential present → code typed into pane → 201 validated + account added', async () => {
@@ -223,7 +246,7 @@ describe('WS5.2 code paste-back submit-code routes (integration)', () => {
     expect(sendInput).not.toHaveBeenCalled();
   });
 
-  it('TARGET — an empty/blank captured frame (dead pane) → 409 with code:pane-dead, no code typed (fail closed)', async () => {
+  it('TARGET — an empty/blank captured frame refreshes the flow and never types the stale code', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-code-'));
     const sendInput = vi.fn(() => true);
     const ctx = buildCtx(dir, { dev: true, seedPending: true, sendInputCapture: sendInput, paneFrame: '' });
@@ -232,13 +255,12 @@ describe('WS5.2 code paste-back submit-code routes (integration)', () => {
     server = await listen(app);
     const r = await post('/subscription-pool/follow-me/enroll/fm-1/submit-code', { code: 'ABC123' });
     expect(r.status).toBe(409);
-    // D5: a DEAD pane is a DISTINCT, machine-readable terminal state — the dashboard maps it
-    // to an explicit "needs a restart" presentation instead of a "may have closed" guess.
-    expect(r.body.code).toBe('pane-dead');
+    expect(r.body.code).toBe('login-expired-fresh-ready');
+    expect(r.body.freshLogin).toMatchObject({ id: 'fm-1', status: 'pending', reissueCount: 1 });
     expect(sendInput).not.toHaveBeenCalled();
   });
 
-  it('TARGET — captureOutput returns null (the pane session is GONE entirely) → 409 pane-dead; wording references the grid, never "Approve"', async () => {
+  it('TARGET — captureOutput null returns expired-with-fresh-ready; wording never references Approve', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-code-'));
     const sendInput = vi.fn(() => true);
     const ctx = buildCtx(dir, { dev: true, seedPending: true, sendInputCapture: sendInput });
@@ -249,10 +271,9 @@ describe('WS5.2 code paste-back submit-code routes (integration)', () => {
     server = await listen(app);
     const r = await post('/subscription-pool/follow-me/enroll/fm-1/submit-code', { code: 'ABC123' });
     expect(r.status).toBe(409);
-    expect(r.body.code).toBe('pane-dead');
-    // D5 wording floor: error copy only references affordances that exist on the surface.
+    expect(r.body.code).toBe('login-expired-fresh-ready');
     expect(r.body.error).not.toContain('Approve');
-    expect(r.body.error).toContain('start the sign-in again');
+    expect(r.body.error).toContain('fresh sign-in is ready');
     expect(sendInput).not.toHaveBeenCalled();
   });
 

--- a/tests/integration/subscriptions-tab.test.ts
+++ b/tests/integration/subscriptions-tab.test.ts
@@ -376,6 +376,30 @@ describe('Subscriptions tab controller (integration)', () => {
     expect(rebuilt.querySelector('.sub-matrix-setup').textContent).toBe('Retry');
   });
 
+  it('a dead-flow submit says expired with a fresh sign-in ready, never a raw failed status', async () => {
+    scriptMatrixHappyPath();
+    fx.script['/subscription-pool/follow-me/submit-code'] = {
+      status: 409,
+      body: {
+        code: 'login-expired-fresh-ready',
+        error: 'that code belonged to an expired sign-in — a fresh sign-in is ready now',
+        freshLogin: { id: 'a1', status: 'pending', verificationUrl: 'https://claude.com/oauth/fresh' },
+      },
+    };
+    const c = ctl();
+    c._state.active = true;
+    const cell = await openCellToSignIn(c);
+    cell.querySelector('.sub-matrix-code-input').value = 'STALE-CODE';
+    cell.querySelector('[data-matrix-code-submit]').click();
+    await flush();
+    await flush();
+
+    const rebuilt = els.matrix.querySelector('[data-cell-key="a1::m2"]');
+    expect(rebuilt.textContent).not.toContain('Couldn’t submit the code');
+    expect(rebuilt.textContent).not.toContain('failed (409)');
+    expect(rebuilt.textContent).toMatch(/sign in|sign-in/i);
+  });
+
   it('D4 (expiry): an episode whose pending login vanishes without an outcome resolves to the explicit expired state — never a silent revert to "Set up"', async () => {
     scriptMatrixHappyPath();
     const c = ctl();

--- a/tests/unit/enrollment-wizard.test.ts
+++ b/tests/unit/enrollment-wizard.test.ts
@@ -118,6 +118,49 @@ describe('EnrollmentWizard', () => {
     expect(store.get('claude-1')?.verificationUrl).toBe('https://claude.com/oauth/2');
   });
 
+  it('restores a durable pending flow after restart with a fresh artifact and no browser pop', async () => {
+    const requests: Parameters<LoginDriver>[0][] = [];
+    const first = new EnrollmentWizard({
+      store, now: () => clock,
+      driveLogin: async () => ({
+        verificationUrl: 'https://claude.com/oauth/old',
+        ttlMs: 15 * 60_000,
+      }),
+    });
+    await first.start({
+      id: 'claude-1', label: 'Claude', provider: 'anthropic',
+      framework: 'claude-code', configHome: '/tmp/claude-1',
+    });
+
+    // A new process loads the same durable store, but its old pane no longer
+    // exists. Boot recovery must re-drive it before traffic is served.
+    const restartedStore = new PendingLoginStore({ stateDir: dir, now: () => clock });
+    const restarted = new EnrollmentWizard({
+      store: restartedStore, now: () => clock,
+      driveLogin: async (req) => {
+        requests.push(req);
+        return { verificationUrl: 'https://claude.com/oauth/fresh', ttlMs: 15 * 60_000 };
+      },
+    });
+    const recovered = await restarted.recoverAfterRestart();
+
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].verificationUrl).toBe('https://claude.com/oauth/fresh');
+    expect(recovered[0].reissueCount).toBe(1);
+    expect(requests[0].openBrowser).toBe(false);
+  });
+
+  it('refreshes a live-but-dead-pane flow and leaves terminal flows untouched', async () => {
+    const w = wizard([
+      { verificationUrl: 'https://claude.com/oauth/old', ttlMs: 15 * 60_000 },
+      { verificationUrl: 'https://claude.com/oauth/fresh', ttlMs: 15 * 60_000 },
+    ]);
+    await w.start({ id: 'claude-1', label: 'Claude', provider: 'anthropic', framework: 'claude-code' });
+    expect((await w.refresh('claude-1'))?.verificationUrl).toBe('https://claude.com/oauth/fresh');
+    w.complete('claude-1');
+    expect(await w.refresh('claude-1')).toBeNull();
+  });
+
   it('a driver failure during reissue is skipped (sweep continues, login stays expired)', async () => {
     let n = 0;
     const w = wizard(async () => {

--- a/upgrades/next/login-flow-restart-recovery.md
+++ b/upgrades/next/login-flow-restart-recovery.md
@@ -1,0 +1,21 @@
+---
+title: "Pending sign-ins recover cleanly after restart"
+audience: "operators"
+---
+
+## What Changed
+
+Unfinished sign-ins regain a live backing process after server restart. Codes
+submitted to a dead or vanished flow now receive an honest expired response,
+with a fresh replacement created when the account still needs sign-in.
+
+## What to Tell Your User
+
+If a restart interrupts sign-in, the dashboard restores a fresh flow instead of
+showing a technical submission failure.
+
+## Summary of New Capabilities
+
+- Restores unfinished login flows during server boot.
+- Replaces dead flows without ever typing their stale code.
+- Shows explicit expired and fresh-ready states in the dashboard.

--- a/upgrades/side-effects/login-flow-restart-recovery.md
+++ b/upgrades/side-effects/login-flow-restart-recovery.md
@@ -1,0 +1,38 @@
+# Login Flow Restart Recovery — Side Effects
+
+## Runtime
+
+- Startup re-drives each durable, non-terminal pending login before serving
+  dashboard traffic.
+- A dead-pane submit may create a fresh provider login process and public
+  verification artifact.
+- Missing flows auto-mint only when the matching pool account is explicitly
+  `needs-reauth` or in an owner-login-required drift episode.
+
+## External
+
+Provider login commands may run once per unfinished flow after server restart.
+Background restoration never opens a browser. No stale submitted code is typed,
+stored, returned, or logged.
+
+## 6b. Operator-surface quality
+
+The affected dashboard cell continues to lead with its primary sign-in action.
+The new states use plain language (“expired” and “a fresh sign-in is ready”),
+with no status codes, process names, paths, or internal identifiers as primary
+content. No destructive action is added or promoted. The copy is short enough
+to read at phone width and directs the operator to the fresh flow already shown
+in the same account cell.
+
+## Rollback
+
+Reverting the wizard, boot wiring, route, and dashboard changes restores the
+prior behavior. The pending-login file schema is unchanged.
+
+## Class-Closure Declaration
+
+- Defect class: `unbounded-self-action`
+- Closure: `n/a`
+- Reason: boot recovery is a one-shot pass over the finite durable pending-login
+  set, with at most one re-drive per incomplete record and no self-rescheduling
+  path. Dead-flow refresh is user-triggered and bounded to one flow.


### PR DESCRIPTION
## What changed

Pending login flows are re-driven during server startup, before dashboard traffic is served. A code submitted against a dead or missing flow is never typed into a stale pane: Instar either creates a fresh login and returns `login-expired-fresh-ready`, or returns the explicit `login-expired` lifecycle outcome. The dashboard renders both cases directly.

## Why

The durable login card survived a restart, but its live login process did not. That left an apparently usable flow with nowhere safe to deliver the authentication code.

## ELI16

A sign-in flow has two parts: a saved card describing it, and a live program waiting for the code. The card already survived a server restart, but the live program died. That made the dashboard look ready even though there was nowhere safe to send the code.

Now Instar rebuilds the live part of every unfinished sign-in during startup and puts the fresh public link or code back onto the saved card. If someone submits an old code after the live window disappeared, Instar refuses to type it, creates a fresh sign-in when the account still needs one, and says clearly that the old flow expired and the replacement is ready.

This is also a safety fix: stale authentication codes can no longer fall through toward an ordinary shell prompt.

## Validation

- 83 focused unit, integration, and end-to-end tests passed
- `npx tsc --noEmit`
- `npm run lint`
- `node scripts/check-repo-invariants.mjs`
- pre-commit and pre-push gates passed (affected-test listing timed out locally; CI remains authoritative)