### PR TITLE
feat(benchmark): capture the first predictions baseline + map the production model

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T22-36-45-833Z-benchmark-baseline-first-capture.json
+++ b/.instar/instar-dev-decisions/2026-07-23T22-36-45-833Z-benchmark-baseline-first-capture.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T22:36:45.833Z",
+  "slug": "benchmark-baseline-first-capture",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 41,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Benchmark-Divergence Detector shipped with mirror population declared an operational pull step whose ownership was an explicit tracked residual, so no baseline was ever captured and every finding degraded to precondition-failed. Compounding it, the production model serving the highest-volume enrolled pair (gpt-5.4-mini via codex-cli) was absent from the fail-closed normalization table, so that pair resolved no-benched-baseline (unmapped) indefinitely. Surfaced 2026-07-23 while investigating why the drift comparator had produced nothing since it shipped."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T22-37-26-155Z-benchmark-baseline-first-capture.json
+++ b/.instar/instar-dev-decisions/2026-07-23T22-37-26-155Z-benchmark-baseline-first-capture.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T22:37:26.155Z",
+  "slug": "benchmark-baseline-first-capture",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 41,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Benchmark-Divergence Detector shipped with mirror population declared an operational pull step whose ownership was an explicit tracked residual, so no baseline was ever captured and every finding degraded to precondition-failed. Compounding it, the production model serving the highest-volume enrolled pair (gpt-5.4-mini via codex-cli) was absent from the fail-closed normalization table, so that pair resolved no-benched-baseline (unmapped) indefinitely. Surfaced 2026-07-23 while investigating why the drift comparator had produced nothing since it shipped."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/benchmark-baseline-first-capture.eli16.md
+++ b/docs/specs/benchmark-baseline-first-capture.eli16.md
@@ -1,0 +1,84 @@
+# ELI16 — Why the model-quality comparison had never once produced a result
+
+## The setup
+
+There are two ways to ask "is this AI model good at this job?"
+
+One is a **test battery**: a fixed set of tricky cases with known right answers. Run
+a model against them, count how many it gets right. That's a *prediction* — "this
+model should handle roughly 93% of cases like these."
+
+The other is **watching real life**: track what the model actually decides in
+production and how those decisions turn out.
+
+Instar has a piece that compares the two. If the battery says a model should score
+93% and reality says 60%, something is wrong — maybe the prompt drifted, maybe the
+test cases aren't representative, maybe the model changed under you. That comparison
+is the point of the whole exercise.
+
+It had never produced a single result.
+
+## Three reasons, each invisible on its own
+
+**First: there was no battery result on file to compare against.** The design said
+"populating this is an operational step" and marked ownership of that step as a
+known loose end. Nobody ever did it. The comparison therefore reported "can't check
+— no baseline" every time, forever, which from the outside looks a lot like "nothing
+to report."
+
+**Second, and worse: the model that actually does the job wasn't in the lookup
+table.** Production model names and battery model names have to be matched exactly —
+deliberately exactly, because fuzzy matching on model names is how you accidentally
+compare against the wrong thing. The message gate runs on a small GPT model. That
+name simply wasn't in the table. So even with a baseline, the one scenario with real
+traffic would have resolved to "no known match" indefinitely, silently.
+
+The pattern is worth naming: a check that can't run reports the same thing as a check
+that ran and found nothing wrong. Both look like quiet.
+
+**Third: the results we did have were measured against different instructions.** A
+battery result only means something if it tested the instructions the system actually
+runs. The message gate's instructions have grown by about 4,400 characters since the
+last battery — new rules that didn't exist when the scoring happened. So capturing a
+baseline from those old numbers would have produced something that looks
+authoritative and means nothing.
+
+Credit where it's due: the system was built to catch exactly that. It records a
+fingerprint of the instructions it tested and refuses to draw conclusions if they've
+since changed. That guard working is genuinely reassuring — it would have refused to
+grade models against a prompt they never saw.
+
+## What was done
+
+The battery was **re-run against today's actual instructions** rather than
+back-filling old numbers. The bench's copy of the instructions was regenerated from
+the live source first, so it's testing what's really running.
+
+Then the results were saved as the baseline, and the missing model name was added to
+the lookup table.
+
+An unexpected finding fell out of it. Against the *old* instructions, the small GPT
+model running your message gate scored 6 out of 14. Against today's, it scores 14 out
+of 14. The concern going in was that the benchmark had gone stale and quality had
+drifted downward; the actual story is that the instructions got substantially better
+and the benchmark simply hadn't noticed.
+
+## What this doesn't fix
+
+The comparison needs both halves: a prediction *and* a real-world result. This
+supplies a current prediction. The real-world half doesn't exist yet — every decision
+the message gate makes is currently recorded as "outcome unknown," because the piece
+that scores outcomes was never built.
+
+So the honest status is: one half of a two-half problem, and the drift check stays
+quiet until the other half lands. Saying that plainly matters more than presenting a
+captured baseline as a closed loop.
+
+## One thing that cost money
+
+The run was meant to use only models covered by existing subscriptions. The tool
+matches model names as fragments rather than exact strings, so one entry also caught
+a pay-per-use copy of the same model behind a metered account. It billed 87 cents
+against a key with a $25 daily limit. That result was excluded from the baseline,
+which contains subscription-door results only — and the mistake is written down here
+rather than quietly absorbed.

--- a/src/data/benchmarkDivergenceRegistry.ts
+++ b/src/data/benchmarkDivergenceRegistry.ts
@@ -58,6 +58,14 @@ export const MODEL_ID_NORMALIZATION: Readonly<Record<string, string>> = {
   'claude-haiku-4-5-20251001': 'claude-haiku-4-5-20251001',
   'gpt-5.5': 'gpt-5.5',
   'gpt-5.5-codex': 'gpt-5.5-codex',
+  // The model actually serving `messaging-tone-gate` in production (verified
+  // 2026-07-23 on the live meter: attribution.models = ['gpt-5.4-mini'] via
+  // codex-cli). Its absence made the highest-volume enrolled pair report
+  // `no-benched-baseline (unmapped)` — i.e. the one pair with real traffic was
+  // structurally unmeasurable. An identity mapping, like the rest: the battery
+  // reports runs under the same immutable public id production records.
+  'gpt-5.4-mini': 'gpt-5.4-mini',
+  'gemini-2.5-flash': 'gemini-2.5-flash',
   'gemini-2.5-pro': 'gemini-2.5-pro',
   'gemini-3.1-pro': 'gemini-3.1-pro',
 };

--- a/src/data/benchmarkPredictions.json
+++ b/src/data/benchmarkPredictions.json
@@ -1,0 +1,33 @@
+{
+ "_doc": "Content-free INSTAR-Bench predictions mirror (benchmark-divergence-detector FD1). Counts, not just rates, so the prediction carries its own sampling uncertainty. Regenerate by re-running the battery against the CURRENT prompt templates and re-stamping benchedPromptHash.",
+ "capturedAt": "2026-07-23T22:30:00.000Z",
+ "tasks": {
+  "tone-gate": {
+   "perModel": {
+    "gpt-5.4-mini": {
+     "passRate": 1,
+     "passes": 14,
+     "deterministic": 14
+    },
+    "gpt-5.5": {
+     "passRate": 0.9643,
+     "passes": 27,
+     "deterministic": 28
+    },
+    "gemini-2.5-flash": {
+     "passRate": 1,
+     "passes": 14,
+     "deterministic": 14
+    },
+    "claude-haiku-4-5-20251001": {
+     "passRate": 0.9286,
+     "passes": 13,
+     "deterministic": 14
+    }
+   },
+   "benchedPromptSource": "src/core/MessagingToneGate.ts:TONE_GATE_PROMPT_TEMPLATE",
+   "benchedPromptHash": "4ae0cf6b02663c21a695393727bd05662334f0d8f1a9d3e45d8d9b2141208d54",
+   "capturedAt": "2026-07-23T22:30:00.000Z"
+  }
+ }
+}

--- a/tests/unit/benchmarkDivergenceRegistry.test.ts
+++ b/tests/unit/benchmarkDivergenceRegistry.test.ts
@@ -172,8 +172,41 @@ describe('loadBenchmarkMirror (FD1/FD9 — untrusted mirror clamps)', () => {
     expect(resolveMirrorPath('/repo', '/abs/m.json')).toBe('/abs/m.json');
   });
 
-  it('the shipped default mirror is ABSENT — the honest pre-pull state (mirror.present:false ⇒ stale-mirror suppression)', () => {
+  it('the shipped mirror is PRESENT and parses through the real loader (first baseline captured 2026-07-23)', () => {
+    // Was pinned ABSENT while no baseline existed — the honest pre-pull state.
+    // The first battery has now been run against the CURRENT prompt templates, so
+    // the pin flips: what matters from here is that the shipped mirror is
+    // well-formed and survives the FD9 clamps, not that it is missing.
     const repoRoot = path.resolve(__dirname, '../../');
-    expect(fs.existsSync(path.join(repoRoot, DEFAULT_MIRROR_PATH))).toBe(false);
+    const p = path.join(repoRoot, DEFAULT_MIRROR_PATH);
+    expect(fs.existsSync(p)).toBe(true);
+
+    const m = loadBenchmarkMirror(p);
+    expect(m.present).toBe(true);
+    expect(m.capturedAt).toBeTruthy();
+
+    // Every enrolled pair's task must survive the clamps with real counts —
+    // a mirror that parses to an empty perModel is worse than none, because it
+    // reads as "captured" while measuring nothing.
+    const tone = m.tasks['tone-gate'];
+    expect(tone).toBeTruthy();
+    expect(Object.keys(tone.perModel).length).toBeGreaterThan(0);
+    for (const [modelId, stats] of Object.entries(tone.perModel)) {
+      expect(stats.deterministic).toBeGreaterThan(0);
+      expect(stats.passes).toBeLessThanOrEqual(stats.deterministic);
+      expect(Math.abs(stats.passRate - stats.passes / stats.deterministic)).toBeLessThan(0.005);
+      // Every benched model must be normalizable, or the pair silently measures
+      // nothing (`no-benched-baseline (unmapped)`).
+      expect(normalizeModelId(modelId)).not.toBeNull();
+    }
+
+    // The production model serving the tone gate MUST be benched + mapped — its
+    // absence is what made the one pair with real traffic unmeasurable.
+    expect(tone.perModel['gpt-5.4-mini']).toBeTruthy();
+    expect(normalizeModelId('gpt-5.4-mini')).toBe('gpt-5.4-mini');
+
+    // The Q0 precondition: the benched prompt hash must match the LIVE template,
+    // or the detector correctly refuses to draw conclusions from it.
+    expect(tone.benchedPromptHash).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/upgrades/next/benchmark-baseline-first-capture.md
+++ b/upgrades/next/benchmark-baseline-first-capture.md
@@ -1,0 +1,69 @@
+## What Changed
+
+The Benchmark-Divergence Detector now ships with its first captured predictions baseline (`src/data/benchmarkPredictions.json`), so `GET /benchmark-divergence` reports `mirror.present: true` instead of degrading every finding to `precondition-failed`.
+
+Two model ids were added to the fail-closed normalization table, including `gpt-5.4-mini` — the model actually serving `messaging-tone-gate` in production. Its absence meant the one enrolled pair with real traffic resolved as unmapped indefinitely, so the comparator was quietly measuring nothing there.
+
+The baseline was produced by re-running the battery against the CURRENT prompt templates rather than reusing July's numbers: the tone-gate prompt had grown from ~35,500 to ~39,900 characters since that run, so the old results would have been stale-on-arrival and correctly suppressed by the template-hash precondition.
+
+## Summary of New Capabilities
+
+- `GET /benchmark-divergence` has a real baseline to compare against, with per-model counts (not just rates) so prediction-side sampling uncertainty is weighable.
+
+## What to Tell Your User
+
+Nothing to do. The model-quality benchmark now has a current baseline captured against the instructions actually running today, rather than a version from three weeks ago. One honest caveat: this is half of a two-part loop — the comparison also needs real-world outcome grades, which don't exist for this scenario yet, so the drift check stays quiet until that lands.
+
+## Evidence
+
+**Before** — `GET /benchmark-divergence` on the serving machine (2026-07-23, v1.3.914):
+
+```
+{"mirror":{"present":false,"capturedAt":null,"staleDays":null,"stale":true},
+ "summary":{"byVerdict":{},"unmappedModels":[],"missingModelShare":0.02},"findings":[]}
+```
+
+Every comparison degraded to `precondition-failed`; nothing could be measured.
+
+**The unmapped-model defect** — the live meter reports the enrolled pair's
+production model:
+
+```
+messaging-tone-gate → attribution.models: ["gpt-5.4-mini"], frameworks: ["codex-cli"]
+```
+
+`gpt-5.4-mini` was absent from `MODEL_ID_NORMALIZATION`, and FD5 is fail-closed
+exact-match, so that pair resolved `no-benched-baseline (unmapped)` indefinitely.
+
+**The staleness that made a back-fill useless** — benched vs live template size for
+the two enrolled tasks:
+
+| task | benched | live | match? |
+|---|---|---|---|
+| tone-gate | 35,499 chars | 39,886 chars | no |
+| zombie-classify | 2,029 chars | 1,373 chars | no |
+
+Building a mirror from July's numbers would have carried a benched-prompt hash that
+never matches the live template, so the Q0 precondition would have suppressed every
+finding — a captured-looking baseline that measures nothing.
+
+**After** — the battery re-run against the regenerated template (14 deterministic
+cases per route, subscription doors), loaded back through the real
+`loadBenchmarkMirror`:
+
+```
+present=true capturedAt=2026-07-23T22:30:00.000Z
+tasks=tone-gate
+perModel=gpt-5.4-mini,gpt-5.5,gemini-2.5-flash,claude-haiku-4-5-20251001
+benchedPromptHash=4ae0cf6b02663c21…  (= sha256 of the LIVE template)
+normalize(gpt-5.4-mini)=gpt-5.4-mini
+```
+
+Pass rates against the current prompt: `gpt-5.4-mini` 14/14, `gemini-2.5-flash`
+14/14, `gpt-5.5` 27/28, `claude-haiku-4-5` 13/14. Notably `gpt-5.4-mini` scored
+6/14 against the OLD template in July — the prompt improved substantially, which is
+the opposite of the decay the staleness concern assumed.
+
+**Honest limit:** the drift comparison still cannot fire, because the real-world
+side of it (`messaging-tone-gate` outcome grades) is all-`unknown`. This change
+makes the prediction side current and measurable; it does not close the loop.

--- a/upgrades/side-effects/benchmark-baseline-first-capture.md
+++ b/upgrades/side-effects/benchmark-baseline-first-capture.md
@@ -1,0 +1,89 @@
+# Side-effects review — first benchmark predictions baseline
+
+**Change:** ships `src/data/benchmarkPredictions.json` (the first captured
+INSTAR-Bench predictions mirror) and adds two rows to `MODEL_ID_NORMALIZATION`.
+
+## What actually changed
+
+1. `src/data/benchmarkPredictions.json` — new, content-free: per (task, model)
+   `passRate`/`passes`/`deterministic`, the benched prompt source, and the benched
+   prompt hash. No prompts, no case text, no outputs.
+2. `MODEL_ID_NORMALIZATION` — adds `gpt-5.4-mini` and `gemini-2.5-flash`, both
+   identity mappings.
+3. `tests/unit/benchmarkDivergenceRegistry.test.ts` — the pin that asserted the
+   mirror is ABSENT now asserts it is PRESENT and well-formed.
+
+## Why (two real defects, not just "capture a baseline")
+
+**(a) The comparator had no baseline at all.** `GET /benchmark-divergence`
+reported `mirror.present: false`, so every finding degraded to
+`precondition-failed`. Measured on the serving machine 2026-07-23.
+
+**(b) The production model was unmapped — the one pair with traffic was
+structurally unmeasurable.** The live meter reports `messaging-tone-gate` running
+on `gpt-5.4-mini` via codex-cli. That id was absent from the normalization table,
+and FD5 is (correctly) fail-closed exact-match, so the pair resolved
+`no-benched-baseline (unmapped)` — indefinitely, and quietly. A comparator that
+reports "nothing to compare" forever looks identical to one reporting health.
+
+**(c) The pre-existing bench results were stale against a drifted prompt.** The
+July battery scored a tone-gate prompt of 35,499 chars; the live template is
+39,886. Building a mirror from those numbers would have been stale-on-arrival —
+the Q0 template-hash precondition would have (correctly) suppressed every finding.
+So the battery was **re-run against the current template**, not back-filled.
+
+## How the numbers were produced
+
+The bench task's template file was regenerated from the live
+`TONE_GATE_PROMPT_TEMPLATE` export: verbatim rules body + the harness's single
+per-case slot, which is exactly the declared `promptFidelity` for this task. The
+battery then ran 14 deterministic cases per route.
+
+`benchedPromptHash` is the sha256 of the LIVE exported template, so the detector's
+Q0 precondition passes only while the prompt genuinely matches — and starts failing
+the moment it drifts again, which is the intended tripwire.
+
+## Blast radius
+
+- **Surface:** one read-only observability route (`GET /benchmark-divergence`).
+- **Authority:** none. Findings are `advisory: true` by construction; nothing gates.
+- **Data:** a static JSON file read through existing FD9 clamps. A malformed mirror
+  is already a first-class `present: false` state, never a throw.
+- **Fail direction unchanged:** an unmapped model still resolves fail-closed.
+
+## Risk analysis
+
+**Could this manufacture a false finding?** Only if the real-world side had a rate
+to compare — it does not. `messaging-tone-gate` currently settles every decision
+`unknown`, so the detector has no real grade-rate and every comparison stays
+non-actionable. **This ships one half of a two-halves loop, and that is stated
+rather than implied**: the mirror makes the benchmark current; it does not make the
+drift comparison useful until outcome grading lands.
+
+**Sample size honesty.** 14 deterministic cases per model is a small battery. FD3's
+Wilson half-width term already accounts for that on the prediction side (a 14-case
+battery carries roughly ±0.25 at p=0.5), so a small battery *widens* the flag
+threshold rather than manufacturing divergence. The counts — not just the rates —
+are recorded precisely so that math can run.
+
+**Cost.** The run was intended to use subscription doors only. One metered
+OpenRouter route matched the inclusion filter by substring (`claude-haiku` matched
+`or-claude-haiku-45`) and billed **$0.87** against a key with a $25 daily / $60
+lifetime cap. Disclosed rather than absorbed; that route's result is EXCLUDED from
+the mirror, which carries subscription-door results only.
+
+## Migration parity
+
+None required. A shipped data file and a source constant; existing agents pick both
+up with the normal version bump. No installed-file, config, hook, or template
+surface.
+
+## Testing
+
+Registry suite (14), core (unchanged), analyzer, routes, E2E alive, migration and
+job-template suites — 97 green. `tsc --noEmit` clean.
+
+## Rollback
+
+Delete the JSON (the loader returns to `present: false`, today's behaviour) or
+revert the commit. Nothing persists; no state to unwind.


### PR DESCRIPTION
## What

Ships the **first captured INSTAR-Bench predictions baseline** and maps the model that actually serves the highest-volume enrolled decision point.

## Why — the comparator had never produced a result, for three compounding reasons

Each was individually invisible, and together they made the drift check inert since it shipped.

**1. No baseline existed.** Mirror population was declared an operational pull step whose ownership was an explicit tracked residual (Non-scope in the parent spec). It was never done. Measured on the serving machine, 2026-07-23:

```json
{"mirror":{"present":false,"capturedAt":null,"stale":true},
 "summary":{"byVerdict":{},"unmappedModels":[],"missingModelShare":0.02},"findings":[]}
```

**2. The production model was unmapped — so the one pair with traffic was structurally unmeasurable.** The live meter reports the enrolled pair running on `gpt-5.4-mini` via `codex-cli`. That id was absent from `MODEL_ID_NORMALIZATION`, and FD5 is (correctly) fail-closed exact-match, so the pair resolved `no-benched-baseline (unmapped)` — indefinitely, and quietly.

**3. The existing bench results were measured against a drifted prompt.**

| task | benched | live | match? |
|---|---|---|---|
| tone-gate | 35,499 chars | 39,886 chars | no |
| zombie-classify | 2,029 chars | 1,373 chars | no |

Back-filling from July's numbers would have shipped a mirror whose `benchedPromptHash` never matches the live template — correctly suppressed by the Q0 precondition. A captured-looking baseline that measures nothing.

**The pattern worth naming:** a check that *cannot* run reports the same thing as a check that ran and found nothing wrong. Both look like quiet.

## How

The bench task's template was **regenerated from the live `TONE_GATE_PROMPT_TEMPLATE` export** — verbatim rules body plus the harness's single per-case slot, which is exactly the declared `promptFidelity` for this task — and the battery was **re-run** against it (14 deterministic cases per route, subscription doors).

`benchedPromptHash` is the sha256 of the live exported template, so Q0 passes only while the prompt genuinely matches, and starts failing the moment it drifts again. That is the intended tripwire, now armed.

Verified back through the real loader:

```
present=true capturedAt=2026-07-23T22:30:00.000Z
perModel=gpt-5.4-mini,gpt-5.5,gemini-2.5-flash,claude-haiku-4-5-20251001
benchedPromptHash=4ae0cf6b02663c21…  (= sha256 of the LIVE template)
normalize(gpt-5.4-mini)=gpt-5.4-mini
```

Pass rates vs the current prompt: `gpt-5.4-mini` 14/14 · `gemini-2.5-flash` 14/14 · `gpt-5.5` 27/28 · `claude-haiku-4-5` 13/14. **`gpt-5.4-mini` scored 6/14 against the OLD template** — the prompt improved substantially, which is the opposite of the decay the staleness concern assumed.

## Honest limits

- **This is one half of a two-half loop.** The comparison also needs a real-world grade-rate, and `messaging-tone-gate` settles every decision `unknown` today. The drift check stays quiet until outcome grading lands. Stated rather than implied.
- **Small battery, deliberately weighed.** 14 deterministic cases per model. FD3's Wilson half-width already accounts for prediction-side noise (±~0.25 at p=0.5 for n=14), so a small battery *widens* the flag threshold rather than manufacturing divergence — which is why counts, not just rates, are recorded.
- **Cost disclosure.** The run was intended to use subscription doors only. One metered OpenRouter route matched the inclusion filter by substring (`claude-haiku` matched `or-claude-haiku-45`) and billed **$0.87** against a key with a $25 daily / $60 lifetime cap. That route's result is **excluded** from the mirror.

## Safety

Read-only observability. Findings are `advisory: true` by construction; nothing gates. A static JSON file read through existing FD9 clamps, where a malformed mirror is already a first-class `present:false` state rather than a throw. Unmapped models still resolve fail-closed. No migration surface.

## Tests

Registry (14, with the pin flipped from mirror-ABSENT to mirror-PRESENT-and-well-formed: every benched model must normalize, counts must agree with rates, the production model must be present, and the hash must be well-formed), plus core, analyzer, routes, E2E-alive, migration and job-template suites — **97 green**. `tsc --noEmit` clean.

## ELI16 — Why the model-quality comparison had never once produced a result

There are two ways to ask "is this AI model good at this job?" One is a test battery: a fixed set of tricky cases with known answers — that's a *prediction*. The other is watching real life. Instar has a piece that compares the two, because when the battery says 93% and reality says 60%, something is wrong. It had never produced a single result.

Three reasons, each invisible alone. There was no battery result on file — populating it was marked as someone's job and nobody did it. The model that actually does the work wasn't in the name-matching table, so even with a baseline, the one scenario with real traffic would have resolved to "no known match" forever. And the results we *did* have were measured against different instructions: the message gate's instructions have grown by ~4,400 characters since that battery ran.

That third one matters most, because capturing a baseline from the old numbers would have produced something that looks authoritative and means nothing. Credit to the design: it fingerprints the instructions it tested and refuses to draw conclusions if they've changed. That guard working is genuinely reassuring — it would have refused to grade models against a prompt they never saw.

So the battery was re-run against today's actual instructions rather than back-filled. An unexpected finding fell out: the small GPT model running the message gate scored 6/14 against the old instructions and 14/14 against today's. The worry was that quality had drifted downward; the real story is that the instructions got substantially better and the benchmark hadn't noticed.

What this doesn't fix: the comparison needs both halves. This supplies a current prediction. The real-world half doesn't exist yet — every decision the gate makes is recorded as "outcome unknown," because the piece that scores outcomes was never built. One half of a two-half problem, said plainly rather than dressed up as a closed loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
