### PR TITLE
fix: surface stale quota and malformed credentials

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T22-46-35-374Z-quota-snapshot-hardening.json
+++ b/.instar/instar-dev-decisions/2026-07-23T22-46-35-374Z-quota-snapshot-hardening.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-23T22:46:35.374Z",
+  "slug": "quota-snapshot-hardening",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 74,
+  "causalAutopsy": null,
+  "classClosure": {
+    "class": "bounded-read-path-classification",
+    "closure": "n/a",
+    "reason": "No recurring or autonomous action is introduced."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T22-47-35-738Z-quota-snapshot-hardening.json
+++ b/.instar/instar-dev-decisions/2026-07-23T22-47-35-738Z-quota-snapshot-hardening.json
@@ -1,0 +1,21 @@
+{
+  "ts": "2026-07-23T22:47:35.738Z",
+  "slug": "quota-snapshot-hardening",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 74,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The shared OAuth reader intentionally collapsed all read failures to null for compatibility, but the quota poller needed to distinguish malformed stored JSON from an absent login. Separately, the quota route returned measuredAt without interpreting its age, leaving persisted telemetry visually current forever."
+  },
+  "classClosure": {
+    "defectClass": "bounded-read-path-classification",
+    "closure": "n/a",
+    "reason": "The change runs only inside an existing poll invocation or user-driven read request. It adds no retry, timer, self-rescheduling path, or autonomous emitter."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-23T22-24-40-000Z-quota-snapshot-hardening.json
+++ b/.instar/instar-dev-traces/2026-07-23T22-24-40-000Z-quota-snapshot-hardening.json
@@ -1,0 +1,33 @@
+{
+  "version": 3,
+  "slug": "quota-snapshot-hardening",
+  "sessionId": "slack-C0BA4F4E0FP-20260723",
+  "timestamp": "2026-07-23T22:24:40.000Z",
+  "artifactPath": "upgrades/side-effects/quota-snapshot-hardening.md",
+  "artifactSha256": "c6f4c3af81f61f5ecd64b83872f7a8ea7dcca784f37ccc63dcb5e7ed46ed65a8",
+  "specPath": "docs/specs/quota-snapshot-hardening.md",
+  "coveredFiles": [
+    "src/core/OAuthRefresher.ts",
+    "src/core/QuotaPoller.ts",
+    "src/server/routes.ts",
+    "tests/unit/oauth-refresher-async-read.test.ts",
+    "tests/unit/quota-poller.test.ts",
+    "tests/integration/subscription-quota-routes.test.ts"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "A bounded correction to existing quota collection and its existing per-account read route. It adds a closed error classification and additive freshness metadata without new authority, persistence schema, credential exposure, timer, or autonomous action.",
+  "eli16Path": "docs/specs/quota-snapshot-hardening.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/quota-snapshot-hardening.md",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The shared OAuth reader intentionally collapsed all read failures to null for compatibility, but the quota poller needed to distinguish malformed stored JSON from an absent login. Separately, the quota route returned measuredAt without interpreting its age, leaving persisted telemetry visually current forever."
+  },
+  "classClosure": {
+    "defectClass": "bounded-read-path-classification",
+    "closure": "n/a",
+    "reason": "The change runs only inside an existing poll invocation or user-driven read request. It adds no retry, timer, self-rescheduling path, or autonomous emitter."
+  },
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/specs/quota-snapshot-hardening.eli16.md
+++ b/docs/specs/quota-snapshot-hardening.eli16.md
@@ -1,0 +1,16 @@
+# Quota Snapshot Hardening — ELI16
+
+A quota reading is like the fuel gauge in a parked car: the number may have been
+correct when it was measured, but it becomes less trustworthy as time passes.
+Instar used to show the last number without clearly saying when that number was
+old. Quota reads now carry a `staleSnapshot` flag and the age of the reading.
+After two expected polling intervals (30 minutes), the flag becomes true.
+
+There was a second ambiguity in the credential reader. A missing credential and
+a credential file containing broken JSON both became the same empty result.
+Missing data can be retried, but broken credential data needs a fresh login.
+The reader now reports that malformed case with a safe reason code, and the
+quota poller changes the account to `needs-reauth`.
+
+The broken credential text itself is never returned or logged. Only the
+classification leaves the credential boundary.

--- a/docs/specs/quota-snapshot-hardening.md
+++ b/docs/specs/quota-snapshot-hardening.md
@@ -1,0 +1,31 @@
+# Quota Snapshot Hardening
+
+## Problem
+
+Two quota failures were visually indistinguishable from ordinary temporary
+collection gaps:
+
+1. malformed credential JSON resolved to `null`, so the poller silently skipped
+   an account that required a new login;
+2. persisted quota snapshots remained readable indefinitely without saying
+   that their `measuredAt` value was old or invalid.
+
+## Contract
+
+1. The non-blocking credential reader exposes a typed `unparseable` result
+   without returning or logging the raw blob.
+2. The default quota token resolver maps that result to
+   `unparseable-credential-blob`.
+3. The poller marks the account `needs-reauth` for that result. Missing or
+   temporarily unreadable credentials retain the existing retry behavior.
+4. `GET /subscription-pool/:id/quota` returns `staleSnapshot` and
+   `snapshotAgeMs`.
+5. A snapshot is stale after 30 minutes (two missed default 15-minute polling
+   cadences), or immediately when `measuredAt` is missing or invalid.
+6. No snapshot is represented as `staleSnapshot: false`; absence and staleness
+   remain distinct states.
+
+## Security
+
+Failure results contain only a closed reason enum. Credential contents do not
+cross the resolver boundary, enter logs, or appear in HTTP responses.

--- a/src/core/OAuthRefresher.ts
+++ b/src/core/OAuthRefresher.ts
@@ -90,6 +90,10 @@ export interface ClaudeOauth {
   [k: string]: unknown;
 }
 
+export type ClaudeOauthReadResult =
+  | { ok: true; oauth: ClaudeOauth }
+  | { ok: false; reason: 'missing-or-unreadable' | 'unparseable' | 'missing-oauth-block' };
+
 /**
  * A credential store for one config home. `read` returns the RAW JSON string of
  * the stored entry (so the refresher can merge-preserve every field); `write`
@@ -325,14 +329,28 @@ export async function readClaudeOauthAsync(
   configHome: string,
   store: CredentialStore = defaultCredentialStore,
 ): Promise<ClaudeOauth | null> {
+  const result = await readClaudeOauthAsyncDetailed(configHome, store);
+  return result.ok ? result.oauth : null;
+}
+
+/**
+ * Detailed non-blocking read for callers that must distinguish malformed
+ * credential JSON from an absent login. Failure never returns raw material.
+ */
+export async function readClaudeOauthAsyncDetailed(
+  configHome: string,
+  store: CredentialStore = defaultCredentialStore,
+): Promise<ClaudeOauthReadResult> {
   const raw = store.readAsync ? await store.readAsync(configHome) : store.read(configHome);
-  if (!raw) return null;
+  if (!raw) return { ok: false, reason: 'missing-or-unreadable' };
   try {
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     const oauth = parsed?.claudeAiOauth;
-    return oauth && typeof oauth === 'object' ? (oauth as ClaudeOauth) : null;
+    return oauth && typeof oauth === 'object'
+      ? { ok: true, oauth: oauth as ClaudeOauth }
+      : { ok: false, reason: 'missing-oauth-block' };
   } catch {
-    return null; // @silent-fallback-ok: unparseable entry
+    return { ok: false, reason: 'unparseable' };
   }
 }
 

--- a/src/core/QuotaPoller.ts
+++ b/src/core/QuotaPoller.ts
@@ -40,7 +40,7 @@ import type {
   AccountQuotaSnapshot,
 } from './SubscriptionPool.js';
 import {
-  readClaudeOauthAsync,
+  readClaudeOauthAsyncDetailed,
   refreshClaudeToken,
   expandHome,
   type RefreshResult,
@@ -54,15 +54,21 @@ import {
 } from '../providers/adapters/openai-codex/observability/codexRateLimitReader.js';
 
 /**
- * Injectable token resolver — returns an account's OAuth access token or null.
+ * Injectable token resolver — returns an account's OAuth access token, null,
+ * or a closed re-auth reason when the credential itself is malformed.
  * The default (`defaultTokenResolver`) is ASYNC so the per-account keychain read happens OFF the
  * event loop (a slow/contended `securityd` read used to freeze the loop every poll cycle — the
  * dashboard-flap / false-sleep residual). `pollAccount` `await`s the result, so a SYNC resolver
  * (e.g. a test stub returning a plain string) is equally valid — hence the union return type.
  */
+export type TokenResolution =
+  | string
+  | null
+  | { reauthNeeded: true; reason: 'unparseable-credential-blob' };
+
 export type TokenResolver = (
   account: SubscriptionAccount,
-) => string | null | Promise<string | null>;
+) => TokenResolution | Promise<TokenResolution>;
 
 /**
  * Injectable account refresher — exchanges a config home's stored refresh token
@@ -134,10 +140,12 @@ export interface BurnRate {
 }
 
 const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+export const QUOTA_SNAPSHOT_STALE_AFTER_MS = 30 * 60 * 1000;
 
 /**
  * Resolve a claude-code account's OAuth access token from its config home,
- * TRANSIENTLY. Never persisted, never logged. Reads via the shared OAuthRefresher
+ * TRANSIENTLY, or a closed re-auth result for malformed stored JSON. Never
+ * persisted, never logged. Reads via the shared OAuthRefresher
  * locator (macOS keychain `Claude Code-credentials-<sha256(configHome)[0:8]>`,
  * else `<configHome>/.credentials.json`) so the resolver and the refresher always
  * agree on WHERE a config home's credentials live. NOTE: an EXPIRED access token
@@ -146,7 +154,7 @@ const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
  */
 export async function defaultTokenResolver(
   account: SubscriptionAccount,
-): Promise<string | null> {
+): Promise<TokenResolution> {
   if (account.provider !== 'anthropic' || account.framework !== 'claude-code') {
     return null;
   }
@@ -154,8 +162,13 @@ export async function defaultTokenResolver(
   // OFF the event loop via `readClaudeOauthAsync` (promisified `security` spawn). The earlier sync
   // read blocked the loop for the full spawn duration each cycle — under multi-agent `securityd`
   // contention that was seconds, and across N accounts a burst (the residual freeze this fixes).
-  const oauth = await readClaudeOauthAsync(account.configHome);
-  const tok = oauth?.accessToken;
+  const read = await readClaudeOauthAsyncDetailed(account.configHome);
+  if (!read.ok) {
+    return read.reason === 'unparseable'
+      ? { reauthNeeded: true, reason: 'unparseable-credential-blob' }
+      : null;
+  }
+  const tok = read.oauth.accessToken;
   return typeof tok === 'string' && tok.startsWith('sk-ant-oat') ? tok : null;
 }
 
@@ -495,11 +508,16 @@ export class QuotaPoller {
       return snap;
     }
 
-    const token = await this.tokenResolver(slotAccount);
-    if (!token) {
+    const tokenResolution = await this.tokenResolver(slotAccount);
+    if (typeof tokenResolution !== 'string') {
+      if (tokenResolution?.reauthNeeded) {
+        this.markNeedsReauth(slotAccount, tokenResolution.reason);
+        return null;
+      }
       this.logger.warn(`[QuotaPoller] no resolvable token for account ${account.id} — skipping`);
       return null;
     }
+    const token = tokenResolution;
 
     const read = await this.readUsage(token);
     if (read === null) return null; // network failure

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -37,6 +37,7 @@ import { getCurrentBootId } from './boot-id.js';
 import { decideNobodyPollingClaim, sharedG2NobodyPollingLedger } from '../core/nobodyPollingRecovery.js';
 import { canonicalPushKey } from '../core/PrHandLease.js';
 import { enrollPaneSessionName } from '../core/FrameworkLoginDriver.js';
+import { QUOTA_SNAPSHOT_STALE_AFTER_MS } from '../core/QuotaPoller.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -26795,10 +26796,21 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       return;
     }
     const burnRate = ctx.quotaPoller ? ctx.quotaPoller.burnRate(req.params.id) : null;
+    const snapshot = account.lastQuota ?? null;
+    const measuredAtMs = snapshot?.measuredAt ? Date.parse(snapshot.measuredAt) : NaN;
+    const snapshotAgeMs = Number.isFinite(measuredAtMs)
+      ? Math.max(0, Date.now() - measuredAtMs)
+      : null;
+    const staleSnapshot = snapshot !== null && (
+      snapshotAgeMs === null ||
+      snapshotAgeMs > QUOTA_SNAPSHOT_STALE_AFTER_MS
+    );
     res.json({
       accountId: account.id,
-      snapshot: account.lastQuota ?? null,
+      snapshot,
       burnRate,
+      staleSnapshot,
+      snapshotAgeMs,
     });
   });
 

--- a/tests/integration/subscription-quota-routes.test.ts
+++ b/tests/integration/subscription-quota-routes.test.ts
@@ -76,11 +76,39 @@ describe('/subscription-pool quota routes (integration)', () => {
     expect(q1.status).toBe(200);
     expect(q1.body.snapshot.sevenDay.utilizationPct).toBe(71);
     expect(q1.body.burnRate).toBeNull(); // only one sample
+    expect(q1.body.staleSnapshot).toBe(false);
+    expect(q1.body.snapshotAgeMs).toBeGreaterThanOrEqual(0);
 
     await new Promise((r) => setTimeout(r, 5));
     await api('/subscription-pool/poll', { method: 'POST' });
     const q2 = await api('/subscription-pool/claude-1/quota');
     expect(q2.body.burnRate).not.toBeNull();
+  });
+
+  it('GET /subscription-pool/:id/quota visibly flags an old measuredAt snapshot', async () => {
+    pool.update('claude-1', {
+      lastQuota: {
+        source: 'oauth-usage-endpoint-fallback',
+        measuredAt: new Date(Date.now() - 31 * 60 * 1000).toISOString(),
+        sevenDay: { utilizationPct: 71, resetsAt: '2026-06-12T18:59:59Z' },
+      },
+    });
+
+    const quota = await api('/subscription-pool/claude-1/quota');
+    expect(quota.body.staleSnapshot).toBe(true);
+    expect(quota.body.snapshotAgeMs).toBeGreaterThan(30 * 60 * 1000);
+  });
+
+  it('GET /subscription-pool/:id/quota flags an invalid measuredAt as stale', async () => {
+    pool.update('claude-1', {
+      lastQuota: {
+        source: 'oauth-usage-endpoint-fallback',
+        measuredAt: 'not-a-date',
+      },
+    });
+
+    const quota = await api('/subscription-pool/claude-1/quota');
+    expect(quota.body).toMatchObject({ staleSnapshot: true, snapshotAgeMs: null });
   });
 
   it('GET /subscription-pool/:id/quota 404s for an unknown account', async () => {

--- a/tests/unit/oauth-refresher-async-read.test.ts
+++ b/tests/unit/oauth-refresher-async-read.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect } from 'vitest';
 import {
   readClaudeOauth,
   readClaudeOauthAsync,
+  readClaudeOauthAsyncDetailed,
   refreshClaudeToken,
   defaultCredentialStore,
   type CredentialStore,
@@ -87,6 +88,14 @@ describe('readClaudeOauthAsync', () => {
   it('returns null on an unparseable blob (same @silent-fallback as sync)', async () => {
     const store = dualStore('{ not json');
     expect(await readClaudeOauthAsync(HOME, store)).toBeNull();
+  });
+
+  it('reports an unparseable blob without returning its contents', async () => {
+    const store = dualStore('{ not json with secret-shaped material');
+    expect(await readClaudeOauthAsyncDetailed(HOME, store)).toEqual({
+      ok: false,
+      reason: 'unparseable',
+    });
   });
 
   it('prefers readAsync over read when BOTH are present (proves it uses the async path)', async () => {

--- a/tests/unit/quota-poller.test.ts
+++ b/tests/unit/quota-poller.test.ts
@@ -225,6 +225,23 @@ describe('QuotaPoller', () => {
     expect(await p.pollAccount(pool.get('claude-1')!)).toBeNull();
   });
 
+  it('pollAccount surfaces an unparseable credential blob as needs-reauth', async () => {
+    const warnings: string[] = [];
+    const p = new QuotaPoller({
+      pool,
+      fetchImpl: okFetch(LIVE_USAGE_BODY),
+      tokenResolver: () => ({ reauthNeeded: true, reason: 'unparseable-credential-blob' }),
+      logger: { log: () => {}, warn: (message) => warnings.push(message) },
+    });
+    pool.add({ ...ACCT });
+
+    expect(await p.pollAccount(pool.get('claude-1')!)).toBeNull();
+    expect(pool.get('claude-1')!.status).toBe('needs-reauth');
+    expect(warnings).toContain(
+      '[QuotaPoller] account claude-1 → needs-reauth (unparseable-credential-blob)',
+    );
+  });
+
   it('pollAccount flags needs-reauth on a 401 when the refresh token is dead', async () => {
     // 401 AND the refresher reports no usable refresh token → genuine re-auth.
     const p = new QuotaPoller({

--- a/upgrades/next/quota-snapshot-hardening.md
+++ b/upgrades/next/quota-snapshot-hardening.md
@@ -1,0 +1,21 @@
+---
+title: "Quota reads expose broken credentials and stale measurements"
+audience: "operators"
+---
+
+## What Changed
+
+Malformed Claude credential JSON now becomes an explicit re-auth-needed state
+instead of silently skipping quota collection. Per-account quota reads also
+report whether their measurement is stale and how old it is.
+
+## What to Tell Your User
+
+Quota status now says when its last reading is old, and a broken saved login
+asks for authentication again instead of quietly disappearing from polling.
+
+## Summary of New Capabilities
+
+- Classifies malformed credential JSON without exposing its contents.
+- Marks the affected subscription account `needs-reauth`.
+- Adds `staleSnapshot` and `snapshotAgeMs` to per-account quota reads.

--- a/upgrades/side-effects/quota-snapshot-hardening.md
+++ b/upgrades/side-effects/quota-snapshot-hardening.md
@@ -1,0 +1,46 @@
+# Quota snapshot hardening
+
+## 1. Behavioral change
+
+- Malformed Claude credential JSON now moves the matching subscription account
+  to `needs-reauth`.
+- Per-account quota reads now include `staleSnapshot` and `snapshotAgeMs`.
+
+## 2. Compatibility
+
+The response is additive. Existing consumers of `snapshot` and `burnRate`
+continue to work. The existing nullable token-resolver contract remains valid;
+injected resolvers may additionally return the typed re-auth result.
+
+## 3. Operational impact
+
+Quota snapshots become stale after 30 minutes, which is twice the default
+15-minute poll cadence. This does not delete a snapshot or prevent it from being
+displayed; it makes its age visible to consumers.
+
+## 4. Security
+
+Malformed credential contents never leave the credential reader. Logs and pool
+state receive only the closed reason `unparseable-credential-blob`.
+
+## 5. Rollback
+
+Reverting this change restores the previous silent-null resolver behavior and
+removes the additive freshness fields.
+
+## 6. Validation
+
+Unit coverage exercises detailed parsing and the re-auth transition. Integration
+coverage exercises fresh, old, and invalid `measuredAt` values through the HTTP
+route.
+
+## 6b. Operator-surface quality
+
+The read surface distinguishes three states directly: no snapshot, a current
+snapshot, and a stale snapshot. Operators no longer have to infer freshness by
+manually comparing timestamps.
+
+## Class closure
+
+This is a bounded read-path classification fix. It does not introduce a timer,
+retry loop, autonomous controller, or self-action emitter.


### PR DESCRIPTION
## What

- Distinguishes malformed Claude credential JSON from ordinary missing credentials and marks the affected subscription account `needs-reauth`.
- Adds `staleSnapshot` and `snapshotAgeMs` to quota reads, with a 30-minute stale threshold and invalid timestamps treated as stale.
- Keeps credential contents inside the credential boundary and adds focused unit/integration coverage plus operator-facing docs.

## Why

Quota consumers need to know when a displayed number is old, and operators need an actionable re-auth signal when credential data exists but cannot be parsed.

## ELI16

A quota reading is like the fuel gauge in a parked car: the number may have been correct when measured, but it gets less trustworthy with age. Quota reads now say when the reading is stale and how old it is. Separately, broken credential JSON is no longer mistaken for simply missing credentials; it safely tells the poller that a fresh login is needed without exposing the credential text.

## Validation

- Focused quota/OAuth/route tests: 43 passed.
- TypeScript typecheck, lint, and repository invariants: passed.
- Full unit suite: 38,332 passed, 4 skipped, 1 failed across 2,124 files. The sole failure was `tests/unit/routes-stopGate.test.ts` receiving an HTML response during the broad cross-suite run; its immediate isolated rerun passed 12/12, consistent with unrelated cross-suite contamination.
- Pre-push gates completed; affected-test discovery timed out and correctly deferred that portion to CI.