### PR TITLE
fix: recover stalled update deferrals

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T23-19-07-858Z-auto-updater-lifeline-coordination.json
+++ b/.instar/instar-dev-decisions/2026-07-23T23-19-07-858Z-auto-updater-lifeline-coordination.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-23T23:19:07.858Z",
+  "slug": "auto-updater-lifeline-coordination",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 91,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T23-24-55-774Z-auto-updater-deferral-retry.json
+++ b/.instar/instar-dev-decisions/2026-07-23T23-24-55-774Z-auto-updater-deferral-retry.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-23T23:24:55.774Z",
+  "slug": "auto-updater-deferral-retry",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 100,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T23-25-42-658Z-auto-updater-deferral-retry.json
+++ b/.instar/instar-dev-decisions/2026-07-23T23-25-42-658Z-auto-updater-deferral-retry.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T23:25:42.658Z",
+  "slug": "auto-updater-deferral-retry",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 100,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Restart deferral intent was persisted, but retry liveness depended on one in-memory timer. The already-installed loop breaker returned without re-arming that timer, leaving this machine's nextRetryAt frozen at 20:48 for more than two hours after an idle window."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T23-30-22-564Z-auto-updater-deferral-retry.json
+++ b/.instar/instar-dev-decisions/2026-07-23T23-30-22-564Z-auto-updater-deferral-retry.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T23:30:22.564Z",
+  "slug": "auto-updater-deferral-retry",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 21,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Restart deferral intent was persisted, but retry liveness depended on one in-memory timer. The already-installed loop breaker returned without re-arming that timer, leaving this machine's nextRetryAt frozen at 20:48 for more than two hours after an idle window."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T23-31-12-190Z-auto-updater-deferral-retry.json
+++ b/.instar/instar-dev-decisions/2026-07-23T23-31-12-190Z-auto-updater-deferral-retry.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-23T23:31:12.190Z",
+  "slug": "auto-updater-deferral-retry",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 21,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Restart deferral intent was persisted, but retry liveness depended on one in-memory timer. The already-installed loop breaker returned without re-arming that timer, leaving this machine's nextRetryAt frozen at 20:48 for more than two hours after an idle window."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-23T23-24-07-565Z-auto-updater-deferral-retry-ba71fa7a.json
+++ b/.instar/instar-dev-traces/2026-07-23T23-24-07-565Z-auto-updater-deferral-retry-ba71fa7a.json
@@ -1,0 +1,42 @@
+{
+  "version": 3,
+  "slug": "auto-updater-deferral-retry",
+  "sessionId": "0c50f55c-9d35-4f2a-9082-c1850bd89ff7",
+  "timestamp": "2026-07-23T23:24:07.565Z",
+  "artifactPath": "upgrades/side-effects/auto-updater-deferral-retry.md",
+  "artifactSha256": "0197b646e7780db58f347b190926c8097b967ca494fe6b4c7d6435be1dcad4a2",
+  "coveredFiles": [
+    "docs/specs/auto-updater-deferral-retry.eli16.md",
+    "docs/specs/auto-updater-deferral-retry.md",
+    "src/core/AutoUpdater.ts",
+    "tests/unit/AutoUpdater.test.ts",
+    "upgrades/next/auto-updater-deferral-retry.md",
+    "upgrades/side-effects/auto-updater-deferral-retry.md"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Focused recovery repair within the existing AutoUpdater and UpdateGate authority boundary; no schema or API change, with lifecycle second-pass review and targeted regression coverage.",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Restart deferral intent was persisted, but retry liveness depended on one in-memory timer. The already-installed loop breaker returned without re-arming that timer, leaving this machine's nextRetryAt frozen at 20:48 for more than two hours after an idle window."
+  },
+  "eli16Path": "docs/specs/auto-updater-deferral-retry.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/auto-updater-deferral-retry.md",
+  "secondPass": "true",
+  "reviewerConcurred": true,
+  "toolchain": {
+    "buildSkill": {
+      "name": "instar-dev",
+      "version": "5c281366e0da",
+      "verified": true
+    },
+    "reviewSkills": [
+      {
+        "name": "updater_deferral_review",
+        "outcome": "concur",
+        "verified": false,
+        "iterations": 2
+      }
+    ]
+  }
+}

--- a/.instar/instar-dev-traces/2026-07-23T23-29-23-652Z-auto-updater-deferral-retry-c519496f.json
+++ b/.instar/instar-dev-traces/2026-07-23T23-29-23-652Z-auto-updater-deferral-retry-c519496f.json
@@ -1,0 +1,42 @@
+{
+  "version": 3,
+  "slug": "auto-updater-deferral-retry",
+  "sessionId": "0c50f55c-9d35-4f2a-9082-c1850bd89ff7",
+  "timestamp": "2026-07-23T23:29:23.652Z",
+  "artifactPath": "upgrades/side-effects/auto-updater-deferral-retry.md",
+  "artifactSha256": "f4dafc8a2d4280ad6f915035c9395d41a13933d885b1e19e7184b1a076cf7b58",
+  "coveredFiles": [
+    "docs/specs/auto-updater-deferral-retry.eli16.md",
+    "docs/specs/auto-updater-deferral-retry.md",
+    "src/core/AutoUpdater.ts",
+    "tests/unit/AutoUpdater.test.ts",
+    "upgrades/next/auto-updater-deferral-retry.md",
+    "upgrades/side-effects/auto-updater-deferral-retry.md"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Focused recovery repair within the existing AutoUpdater and UpdateGate authority boundary; no schema or API change, with lifecycle second-pass review and targeted regression coverage.",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Restart deferral intent was persisted, but retry liveness depended on one in-memory timer. The already-installed loop breaker returned without re-arming that timer, leaving this machine's nextRetryAt frozen at 20:48 for more than two hours after an idle window."
+  },
+  "eli16Path": "docs/specs/auto-updater-deferral-retry.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/auto-updater-deferral-retry.md",
+  "secondPass": "true",
+  "reviewerConcurred": true,
+  "toolchain": {
+    "buildSkill": {
+      "name": "instar-dev",
+      "version": "5c281366e0da",
+      "verified": true
+    },
+    "reviewSkills": [
+      {
+        "name": "updater_deferral_review",
+        "outcome": "concur",
+        "verified": false,
+        "iterations": 2
+      }
+    ]
+  }
+}

--- a/docs/specs/auto-updater-deferral-retry.eli16.md
+++ b/docs/specs/auto-updater-deferral-retry.eli16.md
@@ -1,0 +1,19 @@
+# Auto-Updater Deferral Retry Recovery — ELI16
+
+Imagine an update is downloaded, but Instar waits to restart because someone is
+still working. It writes down “try again in five minutes” and also sets an alarm.
+Previously, the note survived, but the alarm did not. If the alarm disappeared,
+Instar kept seeing that the update was already downloaded and never set another
+alarm. It could run the old code for hours after the work ended.
+
+Now Instar rebuilds the alarm from the saved note whenever it starts. Every
+regular update check also makes sure the alarm still exists. If one retry itself
+fails, another retry is scheduled. Active work is still protected; this only
+prevents a lost alarm from turning a temporary wait into a permanent one.
+
+The activity decision itself is unchanged. Instar still asks its existing
+session-health gate whether real work is active, so this fix does not invent a
+second definition of “idle.” It repairs the delivery mechanism around that
+decision: the saved deadline is the durable truth, the timer is replaceable
+machinery, regular checks verify the machinery remains attached, and stopping
+the updater invalidates older callbacks so they cannot quietly re-arm later.

--- a/docs/specs/auto-updater-deferral-retry.md
+++ b/docs/specs/auto-updater-deferral-retry.md
@@ -1,0 +1,28 @@
+# Auto-Updater Deferral Retry Recovery
+
+## Problem
+
+An installed update can be held while an interactive session is active. The
+deferral details are durable, but the retry timer was memory-only. If that timer
+was cleared, lost, or rejected once, later update checks hit the
+already-installed loop breaker and returned without rebuilding the retry. The
+agent could remain on old in-memory code indefinitely even after becoming idle.
+
+## Contract
+
+- Starting `AutoUpdater` re-arms any persisted active restart deferral.
+- An overdue persisted deadline retries immediately.
+- The already-installed loop breaker also verifies that an active durable
+  deferral has a live timer and repairs it when missing.
+- A rejected deferred-restart attempt records the error and schedules another
+  bounded retry instead of ending the retry loop.
+- The existing `UpdateGate` remains the authority for session activity. Healthy
+  interactive sessions block; idle, dead, unresponsive, and safely idle job
+  sessions do not.
+
+## Evidence
+
+`tests/unit/AutoUpdater.test.ts` covers restart-time re-arming, periodic
+self-repair after deliberate timer loss, and retry continuation after a
+rejected attempt. `tests/unit/UpdateGate.test.ts` continues to cover activity
+classification.

--- a/src/core/AutoUpdater.ts
+++ b/src/core/AutoUpdater.ts
@@ -32,6 +32,8 @@ import { crossesBreaking, writeLifelineRestartSignal } from './version-skew.js';
 import { RestartCascadeDampener, formatLocalTimeHHMM } from './RestartCascadeDampener.js';
 import type { UpdateRestartHandshake } from './UpdateRestartHandshake.js';
 
+const DEFAULT_RESTART_RETRY_MS = 5 * 60_000;
+
 export interface AutoUpdaterConfig {
   /** How often to check for updates, in minutes. Default: 30 */
   checkIntervalMinutes?: number;
@@ -148,6 +150,8 @@ export class AutoUpdater {
   private sessionManager: SessionManagerLike | null = null;
   private sessionMonitor: SessionMonitorLike | null = null;
   private deferralTimer: ReturnType<typeof setTimeout> | null = null;
+  private deferralRetryInFlight = false;
+  private deferralLifecycleGeneration = 0;
   private restartDeferral: RestartDeferralState | null = null;
 
   // Loop prevention — track version mismatch notifications to avoid spam
@@ -234,6 +238,12 @@ export class AutoUpdater {
     // Run first check after a short delay (don't block startup)
     setTimeout(() => this.tick(), 10_000);
 
+    // Restart deferrals are durable, but timers are not. A server/subsystem
+    // restart, or any path that clears an in-memory timer, must not strand an
+    // already-installed update forever. Re-arm from the persisted deadline;
+    // an overdue retry runs immediately.
+    this.ensureDeferredRestartRetry();
+
     // Then run periodically
     this.interval = setInterval(() => this.tick(), intervalMs);
     this.interval.unref(); // Don't prevent process exit
@@ -256,6 +266,7 @@ export class AutoUpdater {
       clearTimeout(this.deferralTimer);
       this.deferralTimer = null;
     }
+    this.deferralLifecycleGeneration++;
     this.gate.reset();
   }
 
@@ -404,6 +415,11 @@ export class AutoUpdater {
             `(POST /updates/apply, or reinstall the shadow).`
           );
         } else if (deferral) {
+          // The loop-breaker intentionally skips re-applying an installed
+          // version. It must still self-heal a missing deferral timer, otherwise
+          // a single lost callback leaves the update installed-but-inactive
+          // indefinitely.
+          this.ensureDeferredRestartRetry();
           console.log(
             `[AutoUpdater] Skipping — v${info.latestVersion} is installed in the shadow install ` +
             `(at ${this.lastApply}) but the running process is still v${info.currentVersion}. ` +
@@ -700,13 +716,7 @@ export class AutoUpdater {
         });
 
         // Schedule a retry at the window start
-        if (this.deferralTimer) clearTimeout(this.deferralTimer);
-        this.deferralTimer = setTimeout(() => {
-          this.deferralTimer = null;
-          console.log(`[AutoUpdater] Restart window reached — attempting restart for v${newVersion}`);
-          this.gatedRestart(newVersion, false);
-        }, waitMs);
-        this.deferralTimer.unref();
+        this.scheduleDeferredRestartRetry(newVersion, waitMs, 'restart window reached');
         return;
       }
       // Idle (no active sessions) — the window has nothing to protect; fall
@@ -854,15 +864,86 @@ export class AutoUpdater {
       );
     }
 
-    // Schedule retry
-    if (this.deferralTimer) {
-      clearTimeout(this.deferralTimer);
-    }
-    this.deferralTimer = setTimeout(async () => {
+    this.scheduleDeferredRestartRetry(
+      newVersion,
+      result.retryInMs ?? DEFAULT_RESTART_RETRY_MS,
+      'session deferral elapsed',
+    );
+  }
+
+  /**
+   * Re-create an in-memory retry from durable deferral state.
+   *
+   * This is called both at startup and from the installed-version loop breaker,
+   * making the periodic update tick a watchdog for a missing timer.
+   */
+  private ensureDeferredRestartRetry(): void {
+    const deferral = this.restartDeferral;
+    if (!deferral?.active || this.deferralTimer || this.deferralRetryInFlight) return;
+
+    const retryAt = deferral.nextRetryAt ? Date.parse(deferral.nextRetryAt) : Number.NaN;
+    const delayMs = Number.isFinite(retryAt)
+      ? Math.max(0, retryAt - Date.now())
+      : DEFAULT_RESTART_RETRY_MS;
+    this.scheduleDeferredRestartRetry(deferral.targetVersion, delayMs, 'durable deferral resumed');
+  }
+
+  private scheduleDeferredRestartRetry(
+    targetVersion: string,
+    delayMs: number,
+    reason: string,
+  ): void {
+    if (this.deferralTimer) clearTimeout(this.deferralTimer);
+    const boundedDelayMs = Math.max(0, delayMs);
+    const generation = this.deferralLifecycleGeneration;
+    this.deferralTimer = setTimeout(() => {
       this.deferralTimer = null;
-      await this.gatedRestart(newVersion);
-    }, result.retryInMs ?? 300_000);
+      if (this.deferralRetryInFlight || generation !== this.deferralLifecycleGeneration) return;
+      this.deferralRetryInFlight = true;
+      console.log(`[AutoUpdater] ${reason} — attempting restart for v${targetVersion}`);
+      void this.retryDeferredRestart(targetVersion, generation).finally(() => {
+        this.deferralRetryInFlight = false;
+        // gatedRestart normally either clears the durable deferral or installs
+        // its next timer. If it did neither, repair the loop only while this
+        // lifecycle generation is still current; stop() invalidates callbacks
+        // scheduled before it, including manually driven updater cycles.
+        if (
+          generation === this.deferralLifecycleGeneration &&
+          !this.deferralTimer
+        ) {
+          this.ensureDeferredRestartRetry();
+        }
+      });
+    }, boundedDelayMs);
     this.deferralTimer.unref();
+  }
+
+  /**
+   * A rejected retry must not terminate the loop. Preserve the durable
+   * deferral and schedule another bounded attempt; successful/blocked attempts
+   * manage their own state and timer through gatedRestart().
+   */
+  private async retryDeferredRestart(targetVersion: string, generation: number): Promise<void> {
+    try {
+      await this.gatedRestart(targetVersion);
+    } catch (err) {
+      this.lastError = err instanceof Error ? err.message : String(err);
+      console.error(`[AutoUpdater] Deferred restart retry failed: ${this.lastError}`);
+      const deferral = this.getActiveRestartDeferral(targetVersion);
+      if (!deferral || generation !== this.deferralLifecycleGeneration) return;
+      const nextRetryAt = new Date(Date.now() + DEFAULT_RESTART_RETRY_MS).toISOString();
+      this.recordRestartDeferral({
+        targetVersion,
+        reason: deferral.reason,
+        currentBlockers: deferral.currentBlockers,
+        nextRetryAt,
+      });
+      this.scheduleDeferredRestartRetry(
+        targetVersion,
+        DEFAULT_RESTART_RETRY_MS,
+        'retry after deferred restart error',
+      );
+    }
   }
 
   /**

--- a/tests/unit/AutoUpdater.test.ts
+++ b/tests/unit/AutoUpdater.test.ts
@@ -27,6 +27,7 @@ function createMockUpdateChecker(overrides?: Partial<UpdateChecker>): UpdateChec
       healthCheck: 'skipped',
     }),
     getInstalledVersion: vi.fn().mockReturnValue('0.9.8'),
+    getShadowInstalledVersion: vi.fn().mockReturnValue('0.9.9'),
     getLastCheck: vi.fn().mockReturnValue(null),
     rollback: vi.fn().mockResolvedValue({ success: false, previousVersion: '0.9.8', restoredVersion: '0.9.8', message: 'No rollback' }),
     canRollback: vi.fn().mockReturnValue(false),
@@ -248,6 +249,143 @@ describe('AutoUpdater', () => {
         nextRetryAt: '2026-05-29T08:05:00.000Z',
         updatedAt: '2026-05-29T08:00:00.000Z',
       });
+    });
+
+    it('re-arms an overdue persisted restart deferral on startup', async () => {
+      const stateFile = path.join(tmpDir, 'state', 'auto-updater.json');
+      fs.writeFileSync(stateFile, JSON.stringify({
+        lastAppliedVersion: '0.9.9',
+        restartDeferral: {
+          active: true,
+          targetVersion: '0.9.9',
+          firstDeferredAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+          reason: '1 active session(s): finished-session',
+          currentBlockers: ['finished-session'],
+          nextRetryAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+          updatedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+        },
+      }));
+
+      const updater = new AutoUpdater(createMockUpdateChecker(), createMockState(), tmpDir);
+      updater.setSessionDeps({ listRunningSessions: vi.fn().mockReturnValue([]) } as any);
+      updater.start();
+
+      await vi.advanceTimersByTimeAsync(2_100);
+
+      expect(fs.existsSync(path.join(tmpDir, 'state', 'restart-requested.json'))).toBe(true);
+      expect(updater.getStatus().restartDeferral).toBeNull();
+      updater.stop();
+    });
+
+    it('repairs a lost deferral timer from durable state on the next update tick', async () => {
+      const stateFile = path.join(tmpDir, 'state', 'auto-updater.json');
+      fs.writeFileSync(stateFile, JSON.stringify({
+        lastAppliedVersion: '0.9.9',
+        restartDeferral: {
+          active: true,
+          targetVersion: '0.9.9',
+          firstDeferredAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+          reason: '1 active session(s): finished-session',
+          currentBlockers: ['finished-session'],
+          nextRetryAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+          updatedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+        },
+      }));
+      const checker = createMockUpdateChecker({
+        check: vi.fn().mockResolvedValue({
+          currentVersion: '0.9.8',
+          latestVersion: '0.9.9',
+          updateAvailable: true,
+          checkedAt: new Date().toISOString(),
+        }),
+      });
+      const updater = new AutoUpdater(checker, createMockState(), tmpDir);
+      updater.setSessionDeps({ listRunningSessions: vi.fn().mockReturnValue([]) } as any);
+      updater.start();
+
+      // Simulate the production failure: the only in-memory retry disappears
+      // while the durable deferral row remains active.
+      clearTimeout((updater as any).deferralTimer);
+      (updater as any).deferralTimer = null;
+
+      await vi.advanceTimersByTimeAsync(12_100);
+
+      expect(checker.applyUpdate).not.toHaveBeenCalled();
+      expect(fs.existsSync(path.join(tmpDir, 'state', 'restart-requested.json'))).toBe(true);
+      expect(updater.getStatus().restartDeferral).toBeNull();
+      updater.stop();
+    });
+
+    it('keeps retrying when a deferred restart attempt rejects', async () => {
+      const stateFile = path.join(tmpDir, 'state', 'auto-updater.json');
+      fs.writeFileSync(stateFile, JSON.stringify({
+        restartDeferral: {
+          active: true,
+          targetVersion: '0.9.9',
+          firstDeferredAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+          reason: '1 active session(s): busy-session',
+          currentBlockers: ['busy-session'],
+          nextRetryAt: new Date(Date.now() - 1_000).toISOString(),
+          updatedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+        },
+      }));
+      const updater = new AutoUpdater(createMockUpdateChecker(), createMockState(), tmpDir);
+      vi.spyOn(updater as any, 'gatedRestart').mockRejectedValueOnce(new Error('transient retry failure'));
+      updater.start();
+
+      await vi.advanceTimersByTimeAsync(1);
+
+      const persisted = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+      expect(persisted.restartDeferral).toMatchObject({
+        active: true,
+        targetVersion: '0.9.9',
+        reason: '1 active session(s): busy-session',
+      });
+      expect(Date.parse(persisted.restartDeferral.nextRetryAt)).toBeGreaterThan(Date.now());
+      expect((updater as any).deferralTimer).not.toBeNull();
+      updater.stop();
+    });
+
+    it('keeps a deferred restart retry single-flight while the watchdog ticks', async () => {
+      const stateFile = path.join(tmpDir, 'state', 'auto-updater.json');
+      fs.writeFileSync(stateFile, JSON.stringify({
+        lastAppliedVersion: '0.9.9',
+        restartDeferral: {
+          active: true,
+          targetVersion: '0.9.9',
+          firstDeferredAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+          reason: '1 active session(s): recently-finished-session',
+          currentBlockers: ['recently-finished-session'],
+          nextRetryAt: new Date(Date.now() - 1_000).toISOString(),
+          updatedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+        },
+      }));
+      const checker = createMockUpdateChecker({
+        check: vi.fn().mockResolvedValue({
+          currentVersion: '0.9.8',
+          latestVersion: '0.9.9',
+          updateAvailable: true,
+          checkedAt: new Date().toISOString(),
+        }),
+      });
+      let releaseRestart!: () => void;
+      const heldRestart = new Promise<void>((resolve) => { releaseRestart = resolve; });
+      const updater = new AutoUpdater(checker, createMockState(), tmpDir);
+      const gatedRestart = vi.spyOn(updater as any, 'gatedRestart').mockReturnValue(heldRestart);
+      updater.start();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(gatedRestart).toHaveBeenCalledTimes(1);
+
+      // The normal 10-second update tick sees the durable overdue deferral
+      // while the first retry is still awaiting its async restart path.
+      await vi.advanceTimersByTimeAsync(11_000);
+      expect(gatedRestart).toHaveBeenCalledTimes(1);
+
+      updater.stop();
+      releaseRestart();
+      await Promise.resolve();
+      expect((updater as any).deferralTimer).toBeNull();
     });
   });
 

--- a/upgrades/next/auto-updater-deferral-retry.md
+++ b/upgrades/next/auto-updater-deferral-retry.md
@@ -1,0 +1,19 @@
+# Auto-updater deferral retries recover after interruption
+
+## What Changed
+
+Installed updates that are waiting for an idle restart now restore their retry
+timer after server startup, repair a missing timer during periodic update
+checks, and continue retrying after transient retry errors.
+
+## What to Tell Your User
+
+Updates waiting for active work to finish will no longer get stuck if their
+retry alarm is interrupted. Instar restores the alarm and switches versions
+once the protected work becomes idle.
+
+## Summary of New Capabilities
+
+- Durable restart deferrals re-arm after server startup.
+- Periodic update checks repair missing deferral timers.
+- Transient retry failures schedule another bounded attempt.

--- a/upgrades/side-effects/auto-updater-deferral-retry.md
+++ b/upgrades/side-effects/auto-updater-deferral-retry.md
@@ -1,0 +1,133 @@
+# Side-Effects Review — Auto-Updater Deferral Retry Recovery
+
+**Version / slug:** `auto-updater-deferral-retry`
+**Date:** `2026-07-23`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `updater_deferral_review`
+
+## Summary of the change
+
+`src/core/AutoUpdater.ts` now treats the persisted restart-deferral deadline as
+durable retry intent. Startup and the already-installed update-check path rebuild
+a missing timer, while rejected retry attempts retain the deferral and schedule
+another bounded five-minute attempt. `tests/unit/AutoUpdater.test.ts` exercises
+restart recovery, deliberate timer loss, and rejected attempts. The existing
+`UpdateGate` remains the sole authority over active-versus-idle session state.
+
+## Decision-point inventory
+
+- `UpdateGate.canRestart` — pass-through — still decides whether active work
+  permits a restart; its classification logic is unchanged.
+- `AutoUpdater.ensureDeferredRestartRetry` — add — mechanically restores a
+  timer from already-authorized durable retry intent.
+- `AutoUpdater.retryDeferredRestart` — add — handles transport/execution errors
+  without making an activity decision.
+
+## 1. Over-block
+
+No new block/allow surface. A future `nextRetryAt` remains respected rather than
+being pulled forward, so restart-window deferrals are not shortened. An invalid
+or missing deadline waits the standard five minutes.
+
+## 2. Under-block
+
+The fix does not repair a corrupted or missing `auto-updater.json`, nor can it
+restart when the supervisor cannot consume `restart-requested.json`. Those are
+separate integrity and supervisor boundaries. The periodic update tick provides
+a second re-arm path if startup re-arming itself is interrupted.
+
+## 3. Level-of-abstraction fit
+
+The change is at the AutoUpdater timer/durability layer. It does not duplicate
+session activity classification: every retry re-enters `gatedRestart`, which
+delegates to `UpdateGate`. The timer is replaceable mechanism; the persisted
+deferral row is durable intent.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no new block/allow surface.
+
+The existing context-rich session-health gate retains restart authority. The new
+code only ensures that gate is asked again at the persisted time.
+
+## 4b. Judgment-point check
+
+No new static heuristic at a competing-signals decision point. Deadline parsing
+is a structural timer operation; active-work judgment remains in `UpdateGate`.
+
+## 5. Interactions
+
+- **Shadowing:** the installed-version loop breaker still prevents reapplying
+  bytes, but now repairs retry machinery before returning.
+- **Double-fire:** one `deferralTimer` plus a `deferralRetryInFlight` latch form
+  the chokepoint. The watchdog refuses to schedule while an async retry is
+  unsettled, preventing duplicate attempts during notification/restart delays.
+- **Races:** startup is wired after session dependencies, so an overdue retry
+  reaches the real activity gate. A simultaneous periodic tick sees either the
+  live timer or in-flight latch and does not add another. `stop()` advances a
+  lifecycle generation, invalidating older callbacks without breaking valid
+  manually driven updater cycles that were never started periodically.
+- **Feedback loops:** blocked retries write a new deadline through the existing
+  path. Unexpected rejection retries use the same five-minute rate floor.
+
+## 6. External surfaces
+
+No API shape or operator action changes. Users may now observe an installed
+update activate after idle where it previously remained stuck. The existing
+restart request file and updater state schema are reused. No new URLs or
+external-service calls are introduced.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+Machine-local by design: update installation, running process version, session
+activity, timers, and restart requests are truths of one machine. Each machine
+owns its own `state/auto-updater.json` and must independently converge onto its
+installed version. This code emits no new user-facing notice, creates no URL,
+and does not move state with topic ownership.
+
+## 8. Rollback cost
+
+Pure code change using the existing state schema. Revert and ship a patch; no
+data migration or agent-state repair is required. Existing persisted deferrals
+remain readable by both old and new code.
+
+## Conclusion
+
+The change closes the lost-timer class without altering restart authority or
+activity detection. Durable intent is now reconnected to replaceable timers at
+startup, during normal polling, and after transient callback failures. The
+independent review additionally produced a single-flight latch and stop-safe
+rescheduling before shipment.
+
+## Second-pass review
+
+**Reviewer:** `updater_deferral_review`
+**Independent read of the artifact:** concur
+
+The single-flight latch closes the double-fire race, the lifecycle generation
+makes stop terminal for older callbacks, and the held-promise test exercises the
+real polling collision. Retry convergence and activity-gate authority are
+preserved.
+
+## Evidence pointers
+
+- `tests/unit/AutoUpdater.test.ts`
+- `tests/unit/UpdateGate.test.ts`
+- `tests/unit/auto-updater-failures.test.ts`
+- `tests/integration/auto-updater-lifeline-handshake.test.ts`
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: unbounded-self-action`, `closure: guard`,
+`guardEvidence: { enforcementType: ratchet, citation:
+tests/unit/AutoUpdater.test.ts, howCaught: the startup, timer-loss, and rejected
+retry tests exercise the control-loop edges; a single deferral timer is the
+chokepoint, the in-flight latch prevents concurrent actions, retries have a
+five-minute rate floor, and a successful or newly blocked evaluation settles
+through gatedRestart rather than accumulating parallel timers }`.


### PR DESCRIPTION
## What changed

- Re-arms durable restart deferrals at startup and on later updater ticks when an in-memory timer is lost.
- Keeps retry attempts single-flight and schedules a bounded follow-up after transient failures.
- Makes stop terminal for callbacks from an older updater lifecycle while preserving manually driven update cycles.
- Reuses UpdateGate as the sole activity/restart authority.

## Why

A real 1.3.916 update on the serving machine persisted a retry for 20:48Z, but the retry loop stopped after the first deferral and missed a later 13-minute idle window. Durable intent survived; the only wake-up path did not.

## ELI16 — Lost update alarms recover

Think of a deferred restart as an alarm clock. The updater correctly wrote down when it should try again, but its live alarm could disappear when the updater process changed state. The note remained on disk forever, while nothing came back to read it.

This change makes the updater check that note both when it starts and whenever its regular update watchdog runs. If the alarm is overdue, it tries the same guarded restart path again. If that attempt temporarily fails, another bounded alarm is scheduled. A single-flight latch prevents the watchdog and timer from starting two restart attempts together, and a lifecycle generation prevents old callbacks from reviving themselves after stop.

The activity rules are unchanged: UpdateGate still decides whether sessions are active and whether restart is safe.

## Validation

- Affected pre-push smoke: 119/119 passed
- Focused updater and full-cycle compatibility suite: 52/52 passed
- TypeScript no-emit check passed
- Lint and repository invariants passed
- Independent lifecycle review identified the watchdog/timer collision; the single-flight fix and held-promise regression test close it