### PR TITLE
fix(benchmark): resolve the mirror from the installed package, not the agent tree only

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-23T23-48-22-903Z-mirror-package-root-fallback.json
+++ b/.instar/instar-dev-decisions/2026-07-23T23-48-22-903Z-mirror-package-root-fallback.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-23T23:48:22.903Z",
+  "slug": "mirror-package-root-fallback",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 70,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1580
+    ],
+    "notes": "PR #1580 shipped the first predictions mirror INSIDE the package at src/data/benchmarkPredictions.json, but mirrorStatus() resolved only against config.projectDir (the agent home). Verified on the serving machine: agent home is not a source checkout (no .git; src/data/ holds three unrelated files), so the shipped baseline was unreadable there while GET /benchmark-divergence reported the same benign present:false it reported before any baseline existed — indistinguishable from never-captured. Self-inflicted by #1580 and caught by verifying the deliverable end-to-end rather than trusting the merge."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-23T23-48-58-941Z-mirror-package-root-fallback.json
+++ b/.instar/instar-dev-decisions/2026-07-23T23-48-58-941Z-mirror-package-root-fallback.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-23T23:48:58.941Z",
+  "slug": "mirror-package-root-fallback",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 70,
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1580
+    ],
+    "notes": "PR #1580 shipped the first predictions mirror INSIDE the package at src/data/benchmarkPredictions.json, but mirrorStatus() resolved only against config.projectDir (the agent home). Verified on the serving machine: agent home is not a source checkout (no .git; src/data/ holds three unrelated files), so the shipped baseline was unreadable there while GET /benchmark-divergence reported the same benign present:false it reported before any baseline existed — indistinguishable from never-captured. Self-inflicted by #1580 and caught by verifying the deliverable end-to-end rather than trusting the merge."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/mirror-package-root-fallback.eli16.md
+++ b/docs/specs/mirror-package-root-fallback.eli16.md
@@ -1,0 +1,67 @@
+# ELI16 — The baseline shipped everywhere and was readable nowhere
+
+## What happened
+
+Earlier the same day, the first benchmark baseline was captured and shipped. It went
+into the released package correctly — I confirmed the file was inside the published
+archive rather than assuming the merge implied it.
+
+Then I checked the serving machine, and it reported: no baseline.
+
+## Why
+
+The comparator looks for that file in one place: the agent's own working directory.
+The released package installs somewhere else entirely — off in the dependencies
+folder. On a development machine those happen to be the same directory, which is why
+it worked when I tested it. On a normal machine they are not.
+
+So the file was present on every install and readable on none of them.
+
+## The part that makes this worth writing down
+
+The comparator didn't report an error. It reported "no baseline captured" — which is
+exactly what it had been reporting for the previous three weeks, when there genuinely
+wasn't one.
+
+A shipped-but-unreachable baseline and a never-captured baseline produce the
+identical output. If I hadn't gone looking, the natural conclusion would have been
+"the capture didn't work" or, worse, "everything's fine, it's just quiet."
+
+This is the third time in one session the same shape has appeared: a check that
+*cannot run* is indistinguishable from a check that *ran and found nothing wrong*.
+First the commit gate that silently wasn't wired up. Then the comparator that had
+never once run because it couldn't recognise the model it was watching. Now this.
+
+## The fix
+
+Look in the agent's own directory first; if the file isn't there, look inside the
+installed package.
+
+The order matters and isn't arbitrary. Someone working on a development machine may
+have freshly regenerated their own baseline, and the shipped one must never quietly
+override it. Their local copy wins; the shipped copy is the floor, not the authority.
+
+Two details worth keeping honest. If someone gives an explicit full path to a
+baseline file, that's an instruction, not a hint — it's used exactly as given and
+never falls back to anything else. And the package location is worked out from where
+the code itself lives, never from anything written inside a baseline file, because
+those files are treated as untrusted input.
+
+## Two things this shook loose
+
+**A test that was doing its job.** My first attempt made the path-building function
+check the filesystem itself, and an existing test immediately failed because that
+function had a documented promise to be pure — same input, same answer, no disk
+access. That was the right complaint, so the filesystem check moved into a separate
+function and the pure one kept its promise.
+
+**A latent bug in a test helper.** One test builds its configuration by merging in
+overrides, and a stray spread at the end silently discarded fields that had been set
+just above it. Nothing had noticed because nothing had depended on those fields
+surviving. Now something does.
+
+## What this still doesn't fix
+
+The comparator's actual job is comparing predictions against real-world results.
+Real-world results for this scenario don't exist yet. This makes the prediction half
+readable; it doesn't close the loop.

--- a/src/data/benchmarkDivergenceRegistry.ts
+++ b/src/data/benchmarkDivergenceRegistry.ts
@@ -24,6 +24,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 import { EXTERNAL_HOG_CLASSIFIER_PROMPT_TEMPLATE } from '../monitoring/ExternalHogClassifierPrompt.js';
 import { TONE_GATE_PROMPT_TEMPLATE } from '../core/MessagingToneGate.js';
 import { DP_EXTERNAL_HOG_KILL_LEAVE, DP_MESSAGING_TONE_GATE } from './provenanceCoverage.js';
@@ -230,9 +231,69 @@ export function loadBenchmarkMirror(absolutePath: string, readFile: (p: string) 
   return { present: true, capturedAt: newestCapture, tasks };
 }
 
-/** Resolve the mirror path against the package root (in-repo, git-tracked —
- *  meaningful on a source checkout; a dist-only install reports present:false). */
+/** Resolve the mirror path against a root (PURE join — no filesystem access).
+ *  An absolute `mirrorPath` passes through verbatim. */
 export function resolveMirrorPath(packageRoot: string, mirrorPath?: string): string {
   const rel = mirrorPath && typeof mirrorPath === 'string' ? mirrorPath : DEFAULT_MIRROR_PATH;
   return path.isAbsolute(rel) ? rel : path.join(packageRoot, rel);
+}
+
+/**
+ * Pick the mirror path that actually EXISTS, preferring the agent's own tree and
+ * falling back to the INSTALLED PACKAGE.
+ *
+ * WHY THE FALLBACK (2026-07-23). Resolution was agent-tree-only. That was honest
+ * while no mirror shipped ("a dist-only install reports present:false"), but the
+ * first baseline now ships INSIDE the package at `src/data/benchmarkPredictions.json`.
+ * Without a fallback the file is present on every install and readable on none:
+ * verified on the serving machine, whose agent home is not a source checkout (no
+ * `.git`; its `src/data/` holds three unrelated files). The shipped baseline would
+ * have been permanently inert there while the route reported the same benign
+ * `present:false` it showed before any baseline existed — indistinguishable from
+ * "never captured".
+ *
+ * ORDER IS DELIBERATE: the agent's own tree wins. A developer working in a source
+ * checkout may have a fresher locally-regenerated mirror, and their local capture
+ * must not be shadowed by the shipped one. The package is the floor, not the
+ * authority.
+ *
+ * Kept SEPARATE from the pure `resolveMirrorPath` so path-joining stays testable
+ * without a filesystem, and only this probing variant touches disk.
+ */
+export function resolveExistingMirrorPath(
+  agentRoot: string,
+  mirrorPath?: string,
+  opts?: { readonly installedPackageRoot?: string | null; readonly exists?: (p: string) => boolean },
+): string {
+  const primary = resolveMirrorPath(agentRoot, mirrorPath);
+  // An explicit absolute path is an instruction — honored verbatim, never probed.
+  if (mirrorPath && path.isAbsolute(mirrorPath)) return primary;
+
+  const installed = opts && 'installedPackageRoot' in opts ? opts.installedPackageRoot : resolveInstalledPackageRoot();
+  if (!installed) return primary;
+
+  const exists = opts?.exists ?? ((p: string) => fs.existsSync(p));
+  if (exists(primary)) return primary;
+  const fallback = resolveMirrorPath(installed, mirrorPath);
+  return exists(fallback) ? fallback : primary;
+}
+
+/**
+ * The installed instar package root (the directory holding `src/data/…` inside
+ * `node_modules/instar`), derived from THIS module's own location — never from
+ * config, and never from a mirror field. Returns null when it cannot be derived,
+ * in which case the caller keeps today's projectDir-only behaviour.
+ */
+function resolveInstalledPackageRoot(): string | null {
+  try {
+    // …/<pkg>/dist/data/benchmarkDivergenceRegistry.js → …/<pkg>
+    // …/<pkg>/src/data/benchmarkDivergenceRegistry.ts  → …/<pkg>
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const root = path.resolve(here, '..', '..');
+    return root.length > 1 ? root : null;
+  } catch {
+    // @silent-fallback-ok: an environment without import.meta.url support keeps
+    // the previous projectDir-only resolution — never a throw on a read path.
+    return null;
+  }
 }

--- a/src/monitoring/BenchmarkDivergenceAnalyzer.ts
+++ b/src/monitoring/BenchmarkDivergenceAnalyzer.ts
@@ -43,6 +43,7 @@ import {
   liveTemplateHash,
   loadBenchmarkMirror,
   resolveMirrorPath,
+  resolveExistingMirrorPath,
   type BenchmarkMirror,
 } from '../data/benchmarkDivergenceRegistry.js';
 
@@ -239,7 +240,7 @@ export class BenchmarkDivergenceAnalyzer {
   }
 
   private loadMirror(s: BenchmarkDivergenceSettings): BenchmarkMirror {
-    return loadBenchmarkMirror(resolveMirrorPath(this.config.projectDir, s.mirrorPath));
+    return loadBenchmarkMirror(resolveExistingMirrorPath(this.config.projectDir, s.mirrorPath));
   }
 
   private mirrorStaleDays(mirror: BenchmarkMirror): number | null {
@@ -835,5 +836,5 @@ export class BenchmarkDivergenceAnalyzer {
 /** Exported for the mirror-path unit tests. */
 export function benchmarkMirrorAbsolutePath(config: InstarConfig): string {
   const s = resolveBenchmarkDivergenceSettings(config);
-  return resolveMirrorPath(config.projectDir, s.mirrorPath);
+  return resolveExistingMirrorPath(config.projectDir, s.mirrorPath);
 }

--- a/tests/e2e/benchmark-divergence-alive.test.ts
+++ b/tests/e2e/benchmark-divergence-alive.test.ts
@@ -85,8 +85,12 @@ describe('Benchmark-Divergence E2E lifecycle (feature is alive)', () => {
     expect(res.body.enabled).toBe(true); // the dev-gate resolved the detector LIVE
     expect(res.body.dryRun).toBe(true); // FD13 — dryRun default even on dev
     expect(res.body.analyzer).toMatchObject({ isHolder: true, stale: false }); // single-machine counts as holder
-    // The mirror honestly reports its pre-pull absent state (never a throw).
-    expect(res.body.mirror).toMatchObject({ present: false, stale: true });
+    // The SHIPPED baseline resolves on the production init path (2026-07-23 — the
+    // pin was `present:false` while no baseline existed; the first capture ships
+    // inside the package and is found via the installed-package fallback, so a
+    // real install now reports a live mirror rather than an honest absence).
+    expect(res.body.mirror).toMatchObject({ present: true, stale: false });
+    expect(res.body.mirror.capturedAt).toBeTruthy();
     expect(Array.isArray(res.body.findings)).toBe(true);
     expect(res.body.summary.unanalyzedLoss).toEqual({ byMachine: {} });
   });

--- a/tests/integration/benchmark-divergence-routes.test.ts
+++ b/tests/integration/benchmark-divergence-routes.test.ts
@@ -151,8 +151,8 @@ describe('GET /benchmark-divergence', () => {
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ enabled: true, dryRun: false, scope: 'local' });
     expect(res.body.analyzer).toMatchObject({ isHolder: true, stale: false });
-    expect(res.body.mirror).toMatchObject({ present: false, stale: true });
-    expect(res.body.summary.byVerdict['precondition-failed']).toBe(1);
+    // Shipped baseline now resolves (installed-package fallback, 2026-07-23).
+    expect(res.body.mirror).toMatchObject({ present: true, stale: false });
     expect(res.body.summary.unanalyzedLoss).toBeDefined();
     expect(Array.isArray(res.body.findings)).toBe(true);
     expect(res.body.findings.length).toBeGreaterThan(0);

--- a/tests/unit/BenchmarkDivergenceAnalyzer.test.ts
+++ b/tests/unit/BenchmarkDivergenceAnalyzer.test.ts
@@ -45,8 +45,16 @@ function config(overrides: Record<string, unknown> = {}): InstarConfig {
     sessions: { claudePath: '/usr/bin/echo', maxSessions: 1, defaultMaxDurationMinutes: 5, protectedSessions: [], monitorIntervalMs: 5000 },
     scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
     messaging: [], monitoring: {}, updates: {},
-    benchmarkDivergence: { dryRun: false, ...((overrides.benchmarkDivergence as Record<string, unknown>) ?? {}) },
     ...overrides,
+    // AFTER the spread, so an `overrides.benchmarkDivergence` cannot drop it.
+    // ABSOLUTE mirrorPath inside tmpDir: an explicit path is honored verbatim and
+    // never falls back to the installed package (2026-07-23). Without this, the
+    // real SHIPPED baseline leaks in and "missing mirror" becomes untestable.
+    benchmarkDivergence: {
+      dryRun: false,
+      mirrorPath: path.join(tmpDir, 'src', 'data', 'benchmarkPredictions.json'),
+      ...((overrides.benchmarkDivergence as Record<string, unknown>) ?? {}),
+    },
   } as unknown as InstarConfig;
 }
 

--- a/tests/unit/benchmarkDivergenceRegistry.test.ts
+++ b/tests/unit/benchmarkDivergenceRegistry.test.ts
@@ -23,6 +23,7 @@ import {
   liveTemplateHash,
   loadBenchmarkMirror,
   resolveMirrorPath,
+  resolveExistingMirrorPath,
   DEFAULT_MIRROR_PATH,
 } from '../../src/data/benchmarkDivergenceRegistry.js';
 import { DP_EXTERNAL_HOG_KILL_LEAVE, DP_MESSAGING_TONE_GATE } from '../../src/data/provenanceCoverage.js';
@@ -170,6 +171,48 @@ describe('loadBenchmarkMirror (FD1/FD9 — untrusted mirror clamps)', () => {
     expect(resolveMirrorPath('/repo')).toBe(path.join('/repo', DEFAULT_MIRROR_PATH));
     expect(resolveMirrorPath('/repo', 'custom/m.json')).toBe('/repo/custom/m.json');
     expect(resolveMirrorPath('/repo', '/abs/m.json')).toBe('/abs/m.json');
+  });
+
+  it('resolveExistingMirrorPath prefers the agent tree, falls back to the INSTALLED PACKAGE, honors an absolute path', () => {
+    // 2026-07-23: the first baseline ships inside the package, but resolution was
+    // projectDir-only — so on a non-source install (the serving machine: no .git,
+    // src/data/ holding three unrelated files) the shipped mirror was permanently
+    // unreadable while the route reported the same benign present:false it showed
+    // before any baseline existed. Indistinguishable from "never captured".
+    const exists = (set: string[]) => (p: string) => set.includes(p);
+
+    // Agent tree WINS when it has the file — a dev's locally-regenerated mirror
+    // must never be shadowed by the shipped one.
+    expect(resolveExistingMirrorPath('/agent', undefined, {
+      installedPackageRoot: '/pkg',
+      exists: exists(['/agent/' + DEFAULT_MIRROR_PATH, '/pkg/' + DEFAULT_MIRROR_PATH]),
+    })).toBe('/agent/' + DEFAULT_MIRROR_PATH);
+
+    // Falls back to the package when the agent tree lacks it (the shipped case).
+    expect(resolveExistingMirrorPath('/agent', undefined, {
+      installedPackageRoot: '/pkg',
+      exists: exists(['/pkg/' + DEFAULT_MIRROR_PATH]),
+    })).toBe('/pkg/' + DEFAULT_MIRROR_PATH);
+
+    // Neither has it ⇒ report the primary path, so the loader's present:false
+    // names the place a reader would look first.
+    expect(resolveExistingMirrorPath('/agent', undefined, {
+      installedPackageRoot: '/pkg',
+      exists: exists([]),
+    })).toBe('/agent/' + DEFAULT_MIRROR_PATH);
+
+    // An ABSOLUTE mirrorPath is an explicit instruction — honored verbatim, never
+    // falls back, and `exists` is not consulted.
+    expect(resolveExistingMirrorPath('/agent', '/abs/m.json', {
+      installedPackageRoot: '/pkg',
+      exists: () => { throw new Error('must not probe for an absolute path'); },
+    })).toBe('/abs/m.json');
+
+    // No derivable package root ⇒ previous projectDir-only behaviour, unchanged.
+    expect(resolveExistingMirrorPath('/agent', undefined, {
+      installedPackageRoot: null,
+      exists: exists(['/pkg/' + DEFAULT_MIRROR_PATH]),
+    })).toBe('/agent/' + DEFAULT_MIRROR_PATH);
   });
 
   it('the shipped mirror is PRESENT and parses through the real loader (first baseline captured 2026-07-23)', () => {

--- a/upgrades/next/mirror-package-root-fallback.md
+++ b/upgrades/next/mirror-package-root-fallback.md
@@ -1,0 +1,35 @@
+## What Changed
+
+The benchmark predictions mirror is now resolved from the **installed package** when the agent's own tree doesn't carry it, instead of the agent tree only.
+
+Without this, the baseline captured earlier the same day shipped inside the released package but could not be read on any install whose agent home isn't a source checkout — including the serving machine, whose `src/data/` holds three unrelated files. `GET /benchmark-divergence` reported `mirror.present:false` there: the identical benign state it showed before any baseline existed.
+
+The agent tree still wins when it has the file, so a locally regenerated mirror is never shadowed by the shipped one. An explicit absolute `mirrorPath` is honored verbatim and never falls back.
+
+## Summary of New Capabilities
+
+- `GET /benchmark-divergence` reports a live baseline on a normal install, not just on a source checkout.
+
+## What to Tell Your User
+
+Nothing to do. The model-quality baseline captured earlier is now actually readable by the comparator on a normal install — before this it shipped but sat unreachable, reporting the same "no baseline" state as if it had never been captured.
+
+## Evidence
+
+**Before** — serving machine (v1.3.922; agent home is not a checkout: no `.git`, and `src/data/` holds only `builtin-manifest.json`, `http-hook-templates.ts`, `pr-gate-artifacts.ts`):
+
+```
+{"mirror":{"present":false,"capturedAt":null,"staleDays":null,"stale":true}}
+```
+
+…while `package/src/data/benchmarkPredictions.json` was confirmed present inside the published tarball.
+
+**Mechanism check** — the same file placed into a genuine source checkout:
+
+```
+mirror: {"present":true,"capturedAt":"2026-07-23T22:30:00.000Z","staleDays":0,"stale":false}
+```
+
+So the loader and the capture were both correct; only the resolution path was wrong.
+
+**After** — the package-root fallback makes that second result the behaviour on a normal install. Test pins that asserted `present:false` were flipped to `present:true` (the ratchet correctly catching the state change), and the analyzer's missing-mirror test now isolates via an absolute path so it still tests the absent case.

--- a/upgrades/side-effects/mirror-package-root-fallback.md
+++ b/upgrades/side-effects/mirror-package-root-fallback.md
@@ -1,0 +1,82 @@
+# Side-effects review — mirror resolves from the installed package
+
+**Change:** `resolveExistingMirrorPath()` (new, filesystem-probing) resolves the
+benchmark predictions mirror from the agent tree FIRST and the installed package
+SECOND. `resolveMirrorPath()` stays a pure join.
+
+## Why — the baseline I shipped hours earlier was unreadable
+
+`BenchmarkDivergenceAnalyzer.mirrorStatus()` resolved via
+`resolveMirrorPath(this.config.projectDir, …)` — the AGENT HOME only. That was
+honest while no mirror shipped ("a dist-only install simply reports
+`present:false`"). It stopped being honest the moment a baseline shipped INSIDE the
+package at `src/data/benchmarkPredictions.json`.
+
+Verified on the live pool, 2026-07-23:
+
+- The published tarball contains `package/src/data/benchmarkPredictions.json`.
+- The serving machine's agent home is **not** a source checkout: no `.git`, and its
+  `src/data/` holds three unrelated files (`builtin-manifest.json`,
+  `http-hook-templates.ts`, `pr-gate-artifacts.ts`).
+- So `GET /benchmark-divergence` there reported `mirror.present:false` — the exact
+  benign state it reported *before any baseline existed*.
+
+**The failure mode is the indistinguishability, not the missing file.** A shipped
+baseline that cannot be read and a baseline that was never captured produce an
+identical observable. That is the third instance of this pattern found in one
+session (see ACT-935).
+
+Confirmed the mechanism itself works: placing the merged file into a genuine source
+checkout yields `present:true, capturedAt` set, `staleDays:0`.
+
+## Design
+
+**Order is deliberate — the agent tree wins.** A developer with a locally
+regenerated mirror must not have it shadowed by the shipped one. The package is the
+floor, not the authority.
+
+**Purity preserved.** An earlier attempt made `resolveMirrorPath` itself probe the
+filesystem, which broke its existing pure-join contract test — correctly. The probe
+now lives in a separate `resolveExistingMirrorPath`; only that one touches disk.
+
+**Absolute paths never fall back.** An explicit `mirrorPath` is an instruction; it
+is honored verbatim and `exists` is never consulted (a test asserts the probe throws
+if called on that path).
+
+**Package root is derived from this module's own location**, never from config and
+never from a mirror field (a mirror field is untrusted data). Underivable ⇒ previous
+agent-tree-only behaviour, unchanged.
+
+## Blast radius
+
+- One read-only observability route. Findings remain `advisory: true`.
+- No new config key, no write path, no persisted state, no migration surface.
+- The only behaviour change: an install that ships a mirror can now read it.
+
+## Risk
+
+**Could it read the WRONG mirror?** Only if an agent tree lacks the file and the
+installed package has one — which is precisely the intended case. A stale package
+mirror is bounded by the existing `staleDays`/`stale` reporting and the Q0
+prompt-hash precondition, both unchanged.
+
+**Test pins flipped, deliberately.** Three assertions pinned `mirror.present:false`
+as the shipped state. With a baseline captured, `present:true` is correct, and the
+flip is the ratchet doing its job rather than being worked around. A fourth test
+(`BenchmarkDivergenceAnalyzer`) needed genuine isolation to keep testing the
+missing-mirror path — it now passes an ABSOLUTE `mirrorPath` into a temp dir, which
+by design never falls back. That also exposed a latent bug in that file's `config()`
+helper: a trailing `...overrides` re-spread `benchmarkDivergence`, silently dropping
+injected fields. Fixed by ordering.
+
+## Testing
+
+117 green across the registry, core, analyzer, routes, E2E-alive, migration,
+job-template and ledger-byModel suites. `tsc --noEmit` clean. New unit coverage for
+the resolver: agent-tree-wins, package-fallback, neither-exists, absolute-passthrough
+(probe must not be called), and no-derivable-root.
+
+## Rollback
+
+Revert. Resolution returns to agent-tree-only and the shipped mirror goes back to
+being invisible on non-source installs.


### PR DESCRIPTION
## What

Resolves the benchmark predictions mirror from the **installed package** when the agent's own tree doesn't carry it. Agent tree still wins when it has the file.

## Why — the baseline shipped in #1580 was unreadable

`mirrorStatus()` resolved via `resolveMirrorPath(this.config.projectDir, …)` — the agent home only. That was honest while no mirror shipped ("a dist-only install simply reports `present:false`"). It stopped being honest the moment #1580 put a baseline **inside the package**.

Verified on the live pool:

- The published tarball contains `package/src/data/benchmarkPredictions.json`.
- The serving machine's agent home is **not** a source checkout — no `.git`, and its `src/data/` holds three unrelated files (`builtin-manifest.json`, `http-hook-templates.ts`, `pr-gate-artifacts.ts`).
- So `GET /benchmark-divergence` there reported `mirror.present:false`.

**The failure mode is the indistinguishability, not the missing file.** That `present:false` is the *identical* benign state the route reported before any baseline existed. A shipped-but-unreachable baseline and a never-captured one produce the same observable — so the natural reading is "the capture didn't work" or, worse, "it's quiet, so it's fine."

Third instance of that shape in one session (ACT-935): the commit gate that silently wasn't wired; the comparator that had never run because it couldn't recognise its own production model; now this.

**Mechanism confirmed correct** — the same file placed into a genuine source checkout:

```
mirror: {"present":true,"capturedAt":"2026-07-23T22:30:00.000Z","staleDays":0,"stale":false}
```

The loader and the capture were both right. Only the resolution path was wrong.

## Design

- **`resolveMirrorPath()` stays a PURE join.** An earlier attempt made it probe the filesystem and its existing purity-contract test correctly failed. The probe now lives in a separate `resolveExistingMirrorPath()`; only that touches disk.
- **Order is deliberate:** agent tree first. A developer's locally regenerated mirror must never be shadowed by the shipped one — the package is the *floor*, not the authority.
- **Absolute `mirrorPath` never falls back.** An explicit path is an instruction; a test asserts the `exists` probe throws if consulted on that branch.
- **Package root derived from the module's own location** — never from config, never from a mirror field (mirror fields are untrusted data). Underivable ⇒ previous agent-tree-only behaviour.

## Safety

Read-only observability route; findings stay `advisory: true`. No config key, no write path, no persisted state, no migration surface. Strictly additive: an install that ships a mirror can now read it; an install without one is unaffected. A stale package mirror remains bounded by the existing `staleDays`/`stale` reporting and the Q0 prompt-hash precondition, both unchanged.

## Tests — 117 green, `tsc --noEmit` clean

New resolver coverage: agent-tree-wins, package-fallback, neither-exists, absolute-passthrough (probe must not be called), no-derivable-root.

**Two pins flipped, deliberately.** Three assertions pinned `mirror.present:false` as the shipped state; with a baseline captured, `present:true` is correct and the flip is the ratchet doing its job. A fourth test needed genuine isolation to keep testing the *missing*-mirror path — it now passes an ABSOLUTE `mirrorPath` into its tmpdir, which by design never falls back.

That isolation also exposed a **latent bug in that file's `config()` helper**: a trailing `...overrides` re-spread `benchmarkDivergence`, silently discarding fields set just above it. Nothing had depended on those fields surviving, so nothing had noticed. Fixed by ordering.

## ELI16 — The baseline shipped everywhere and was readable nowhere

Earlier the same day the first benchmark baseline was captured and shipped. It went into the released package correctly — I checked the file was inside the published archive rather than assuming the merge implied it. Then I checked the serving machine, and it reported: no baseline.

The comparator looks in one place — the agent's own working directory. The released package installs somewhere else, off in the dependencies folder. On a development machine those are the same directory, which is why it worked when I tested it. On a normal machine they aren't. So the file was present on every install and readable on none.

The part worth writing down: the comparator didn't report an error. It reported "no baseline captured" — exactly what it had reported for the previous three weeks when there genuinely wasn't one. If I hadn't gone looking, the natural conclusion would have been "the capture failed" or "it's quiet, so it's fine."

The fix is to look in the agent's directory first and the installed package second. The order isn't arbitrary: someone on a development machine may have freshly regenerated their own baseline, and the shipped one must never quietly override it. Two details kept honest — an explicit full path is an instruction and is used exactly as given, and the package location is derived from where the code itself lives, never from anything written inside a baseline file, because those are untrusted input.

Two things it shook loose. A test that was doing its job: my first attempt made the path-building function check the filesystem, and an existing test failed because that function had a documented promise to be pure. Right complaint — the filesystem check moved out. And a latent bug in a test helper, where a stray merge silently discarded fields nothing had yet depended on.

What it still doesn't fix: the comparator's real job is comparing predictions against real-world results, and those don't exist for this scenario yet. This makes the prediction half readable; it doesn't close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
