### PR TITLE
fix: retire the two-codes sign-in disclaimer

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-24T00-04-45-117Z-ws52-account-follow-me-email-gate.json
+++ b/.instar/instar-dev-decisions/2026-07-24T00-04-45-117Z-ws52-account-follow-me-email-gate.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T00:04:45.117Z",
+  "slug": "ws52-account-follow-me-email-gate",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 26,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T00-05-55-412Z-ws52-account-follow-me-email-gate.json
+++ b/.instar/instar-dev-decisions/2026-07-24T00-05-55-412Z-ws52-account-follow-me-email-gate.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T00:05:55.412Z",
+  "slug": "ws52-account-follow-me-email-gate",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 26,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T00-09-07-893Z-remove-two-codes-notice.json
+++ b/.instar/instar-dev-decisions/2026-07-24T00-09-07-893Z-remove-two-codes-notice.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T00:09:07.893Z",
+  "slug": "remove-two-codes-notice",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 26,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/remove-two-codes-notice.eli16.md
+++ b/docs/specs/remove-two-codes-notice.eli16.md
@@ -1,0 +1,53 @@
+# Removing the "two codes" sign-in disclaimer — plain-English overview
+
+## What this change actually is
+
+When you set up a new Claude account on an Instar agent, the sign-in flow used
+to attach a warning to every pending login: "Heads up: a brand-new Claude login
+often asks for TWO codes in order — first an email-verification code Anthropic
+sends you, then the sign-in code shown after that." That warning appeared in the
+dashboard's pending-login panel, in the account-grid sign-in cells, and in
+Telegram messages that relayed the login link.
+
+The warning was written in early live testing (topic 20905), when Anthropic's
+sign-in page really did ask for two codes on most brand-new logins. That
+behavior has since become rare — the operator reports not having seen it in a
+long time — so the disclaimer had turned into noise: repeated on every single
+enrollment, describing a step that almost never happens, and making the flow
+look more complicated than it is. The operator asked for it to be removed
+outright rather than reworded.
+
+This change deletes the notice at its source. `EnrollmentWizard.flowNotice()` —
+the one and only function that produced the text — is removed, along with the
+line in `EnrollmentWizard.start()` that attached it to each pending login.
+
+## What stays
+
+The *plumbing* for notices stays: the pending-login store still has an optional
+`notice` field, the API still passes it through, and the dashboard still renders
+a notice if one is present. That machinery is generic and harmless — it simply
+has nothing to say right now. If a future flow genuinely needs a heads-up, the
+field is there. The tests that cover the render path now use neutral fixture
+text ("this provider may show an extra verification step") so the coverage
+survives without shipping the stale advice anywhere in the codebase.
+
+The engineering comments explaining why remote enrollments get a *larger
+timeout budget* (the sign-in can still occasionally involve an extra
+verification step, especially on mobile) also stay — that rationale is about
+timeouts, not user-facing messaging, and it is still true.
+
+## What you actually need to decide
+
+Whether removing the disclaimer entirely (rather than showing it conditionally)
+is right. The operator made this call explicitly on 2026-07-23: the extra step
+"MIGHT still happen when going through the flow on mobile," but it is rare
+enough that a permanent warning on every enrollment is the wrong trade. If the
+two-code window returns in force, the correct fix is a conditional notice driven
+by observed provider behavior — not restoring a blanket disclaimer.
+
+## Risk, in plain terms
+
+Near zero. No decision logic, no gate, no authority changes — only static text
+removal. The worst case is a user hitting the rare two-code sequence without a
+warning, which costs them a moment of confusion on the provider's own page; the
+flow itself works identically either way.

--- a/src/core/EnrollmentWizard.ts
+++ b/src/core/EnrollmentWizard.ts
@@ -174,27 +174,6 @@ export class EnrollmentWizard {
   }
 
   /**
-   * Operator-facing heads-up about a flow's quirks, surfaced on the pending login.
-   * The url-code-paste (Claude) flow on a brand-new account slot frequently issues
-   * TWO codes in sequence: Anthropic first emails an email-VERIFICATION code, then
-   * (after that's accepted) the page shows the sign-in code to paste back. Enrolling
-   * is always a new slot, so the operator should expect — and not be confused by —
-   * the two-step sequence (this confusion was flagged in live testing, topic 20905).
-   * device-code (Codex) is a single code, so no notice. Returns undefined when there
-   * is nothing to warn about.
-   */
-  static flowNotice(kind: LoginFlowKind): string | undefined {
-    if (kind === 'url-code-paste') {
-      return (
-        'Heads up: a brand-new Claude login often asks for TWO codes in order — ' +
-        'first an email-verification code Anthropic sends you, then the sign-in code ' +
-        'shown after that. Enter the email code first; the sign-in code comes next.'
-      );
-    }
-    return undefined;
-  }
-
-  /**
    * Start an enrollment: drive the login, capture the public code/URL, store it
    * as a pending login (TTL visible). Returns the stored PendingLogin — the
    * surface the operator's phone shows.
@@ -240,7 +219,6 @@ export class EnrollmentWizard {
       configHome: input.configHome,
       verificationUrl: artifact.verificationUrl,
       userCode: artifact.userCode,
-      notice: EnrollmentWizard.flowNotice(kind),
       expectedEmail: input.expectedEmail,
       ttlMs: artifact.ttlMs,
     });

--- a/src/core/PendingLoginStore.ts
+++ b/src/core/PendingLoginStore.ts
@@ -94,7 +94,7 @@ export interface IssueLoginInput {
   configHome?: string;
   verificationUrl: string;
   userCode?: string;
-  /** Operator-facing flow heads-up (e.g. the Claude two-code sequence). */
+  /** Operator-facing flow heads-up (optional; no built-in flow populates it today). */
   notice?: string;
   /** WS5.2 §5.3/S7 — the operator-expected account email (a follow-me login carries it
    *  so completion can validate the minted account against operator expectation). */

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -27499,7 +27499,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         if (existing) {
           console.log(`[matrix] start-cell accountId=${accountId} machineId=${machineId} outcome=reused-pending`);
           // Flow-detail passthrough (topic 29836 D2/D3): expectedEmail (which account the OAuth
-          // page MUST show), ttlExpiresAt (link-expiry countdown), notice (the two-codes heads-up)
+          // page MUST show), ttlExpiresAt (link-expiry countdown), notice (optional flow heads-up)
           // and kind ride along so the matrix CELL can carry the complete flow end-to-end instead
           // of stranding those steps in the bottom Pending-logins panel. All operator-facing,
           // never secrets (same fields the pending-logins surface already serves).

--- a/tests/integration/subscriptions-tab.test.ts
+++ b/tests/integration/subscriptions-tab.test.ts
@@ -198,7 +198,7 @@ describe('Subscriptions tab controller (integration)', () => {
       loginId: 'a1', machineId: 'm2', kind: 'url-code-paste',
       expectedEmail: 'headley.justin@gmail.com',
       ttlExpiresAt: new Date(Date.parse('2026-06-07T00:00:00Z') + 12 * 60_000).toISOString(),
-      notice: 'Heads up: a brand-new Claude login often asks for TWO codes in order.',
+      notice: 'Heads up: this provider may show an extra verification step.',
     },
   };
 
@@ -280,7 +280,7 @@ describe('Subscriptions tab controller (integration)', () => {
     const cell = await openCellToSignIn(c);
     expect(cell.querySelector('.sub-matrix-expected').textContent).toContain('must show headley.justin@gmail.com');
     expect(cell.querySelector('a.sub-matrix-signin').getAttribute('href')).toContain('code=true');
-    expect(cell.querySelector('.sub-matrix-notice').textContent).toContain('TWO codes');
+    expect(cell.querySelector('.sub-matrix-notice').textContent).toContain('extra verification step');
     expect(cell.querySelector('[data-matrix-cancel]')).toBeTruthy();
     const code = cell.querySelector('.sub-matrix-code-input');
     code.value = 'ABC'; // mid-paste…

--- a/tests/unit/enrollment-wizard.test.ts
+++ b/tests/unit/enrollment-wizard.test.ts
@@ -47,28 +47,17 @@ describe('EnrollmentWizard', () => {
     expect(EnrollmentWizard.defaultKind('github-copilot')).toBe('url-code-paste');
   });
 
-  it('flowNotice: url-code-paste (Claude) warns about the two-code sequence; device-code does not', () => {
-    const claude = EnrollmentWizard.flowNotice('url-code-paste');
-    expect(claude).toBeTruthy();
-    expect(claude).toMatch(/two codes/i);
-    expect(claude).toMatch(/email/i);
-    expect(EnrollmentWizard.flowNotice('device-code')).toBeUndefined();
-  });
+  it('start attaches NO flow notice on any enrollment (the two-codes disclaimer is retired)', async () => {
+    const claude = wizard([{ verificationUrl: 'https://claude.com/oauth/authorize?code=abc', ttlMs: 15 * 60_000 }]);
+    const cl = await claude.start({ id: 'sagemind-1', label: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code' });
+    expect(cl.kind).toBe('url-code-paste');
+    expect(cl.notice).toBeUndefined();
+    expect(claude.pending()[0].notice).toBeUndefined();
 
-  it('start attaches the two-code notice on a Claude (url-code-paste) enrollment', async () => {
-    const w = wizard([{ verificationUrl: 'https://claude.com/oauth/authorize?code=abc', ttlMs: 15 * 60_000 }]);
-    const l = await w.start({ id: 'sagemind-1', label: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code' });
-    expect(l.kind).toBe('url-code-paste');
-    expect(l.notice).toMatch(/two codes/i);
-    // it survives the store round-trip onto the phone surface
-    expect(w.pending()[0].notice).toMatch(/two codes/i);
-  });
-
-  it('start attaches NO notice on a device-code (Codex) enrollment', async () => {
-    const w = wizard([{ verificationUrl: 'https://auth.openai.com/codex/device', userCode: '7DAU-W4XJA', ttlMs: 15 * 60_000 }]);
-    const l = await w.start({ id: 'codex-1', label: 'codex', provider: 'openai', framework: 'codex-cli' });
-    expect(l.kind).toBe('device-code');
-    expect(l.notice).toBeUndefined();
+    const codex = wizard([{ verificationUrl: 'https://auth.openai.com/codex/device', userCode: '7DAU-W4XJA', ttlMs: 15 * 60_000 }]);
+    const cx = await codex.start({ id: 'codex-1', label: 'codex', provider: 'openai', framework: 'codex-cli' });
+    expect(cx.kind).toBe('device-code');
+    expect(cx.notice).toBeUndefined();
   });
 
   it('start drives the login + stores the public code/URL with TTL', async () => {
@@ -485,7 +474,7 @@ describe('EnrollmentWizard', () => {
       expect(l.kind).toBe('device-code');
     });
 
-    it('a remote Claude start stays url-code-paste (no single-code flow) + keeps the two-code notice', async () => {
+    it('a remote Claude start stays url-code-paste (no single-code flow), with no flow notice', async () => {
       let seenKind: string | undefined;
       const drive: LoginDriver = async (req) => {
         seenKind = req.kind;
@@ -494,7 +483,7 @@ describe('EnrollmentWizard', () => {
       const w = new EnrollmentWizard({ store, driveLogin: drive, now: () => clock });
       const l = await w.start({ id: 'claude-r', label: 'main', provider: 'anthropic', framework: 'claude-code', remote: true });
       expect(seenKind).toBe('url-code-paste');
-      expect(l.notice).toMatch(/two codes/i);
+      expect(l.notice).toBeUndefined();
     });
 
     it('an explicit kind always wins over the remote preference', async () => {

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -271,10 +271,10 @@ describe('renderPendingLogins', () => {
     renderPendingLogins(doc, t, [{
       id: 'sagemind-1', label: 'SageMind - Justin', kind: 'url-code-paste',
       verificationUrl: 'https://claude.com/oauth/authorize?code=abc',
-      notice: 'Heads up: a brand-new Claude login often asks for TWO codes in order — first an email-verification code, then the sign-in code.',
+      notice: 'Heads up: this provider may show an extra verification step.',
       ttlExpiresAt: '2026-06-07T00:12:00Z', reissueCount: 0,
     }], NOW);
-    expect(t.querySelector('.sub-pending-notice')!.textContent).toContain('TWO codes');
+    expect(t.querySelector('.sub-pending-notice')!.textContent).toContain('extra verification step');
   });
   it('omits the notice element when there is none', () => {
     const t = el();
@@ -475,7 +475,7 @@ describe('renderAccountMatrix', () => {
         id: 'a2', machineId: 'm1', kind: 'url-code-paste', paneAlive: true,
         verificationUrl: 'https://claude.com/oauth/authorize?code=true&client_id=x',
         expectedEmail: 'headley.justin@gmail.com',
-        notice: 'Heads up: a brand-new Claude login often asks for TWO codes in order.',
+        notice: 'Heads up: this provider may show an extra verification step.',
         ttlExpiresAt: '2026-06-07T00:12:00Z',
       }],
     };
@@ -490,7 +490,7 @@ describe('renderAccountMatrix', () => {
     const submit = cell.querySelector('[data-matrix-code-submit]')!;
     expect(submit.getAttribute('data-login-id')).toBe('a2');
     expect(submit.getAttribute('data-machine-id')).toBe('m1');
-    expect(cell.querySelector('.sub-matrix-notice')!.textContent).toContain('TWO codes');
+    expect(cell.querySelector('.sub-matrix-notice')!.textContent).toContain('extra verification step');
     const ttl = cell.querySelector('.sub-matrix-ttl')!;
     expect(ttl.getAttribute('data-ttl-expires')).toBe('2026-06-07T00:12:00Z');
     expect(cell.querySelector('[data-matrix-cancel]')).toBeTruthy();

--- a/upgrades/next/remove-two-codes-notice.md
+++ b/upgrades/next/remove-two-codes-notice.md
@@ -1,0 +1,29 @@
+# The "two codes" sign-in disclaimer is retired
+
+## What Changed
+
+New-account sign-in flows no longer attach the "a brand-new Claude login often
+asks for TWO codes" warning to every pending login. The only producer of that
+text (`EnrollmentWizard.flowNotice()`) is removed; the optional notice plumbing
+remains for future flows that genuinely need a heads-up.
+
+## Evidence
+
+- `tests/unit/enrollment-wizard.test.ts` — starts for Claude (local and
+  remote) and Codex all assert `notice` is undefined.
+- `tests/unit/subscriptions-render.test.ts` /
+  `tests/integration/subscriptions-tab.test.ts` — the generic notice render
+  path stays covered with neutral fixture text.
+
+## What to Tell Your User
+
+Sign-in links for adding a new account no longer carry the repeated "you may
+be asked for two codes" warning. The sign-in flow itself is unchanged — in the
+rare case the provider does ask for an email-verification code first, its own
+page walks you through it.
+
+## Summary of New Capabilities
+
+- Cleaner account sign-in surfaces: the stale two-codes disclaimer no longer
+  appears in the dashboard pending-login panel, account-grid cells, or
+  relayed sign-in messages.

--- a/upgrades/side-effects/remove-two-codes-notice.md
+++ b/upgrades/side-effects/remove-two-codes-notice.md
@@ -1,0 +1,72 @@
+# Side-Effects Review — Retire the Two-Codes Sign-In Disclaimer
+
+**Version / slug:** `remove-two-codes-notice`
+**Date:** `2026-07-23`
+**Author:** `Instar Agent (echo)`
+**Second-pass reviewer:** not required (no decision-point surface)
+
+## Summary of the change
+
+`EnrollmentWizard.flowNotice()` — the only producer of the "a brand-new Claude
+login often asks for TWO codes" disclaimer — is deleted, along with the
+`notice:` population in `EnrollmentWizard.start()`. No built-in flow populates
+the pending-login `notice` field anymore. The generic optional-notice plumbing
+(store field, API passthrough, dashboard if-present rendering) is retained;
+its test fixtures now use neutral text so the render path stays covered
+without re-shipping the stale advice. Operator directive 2026-07-23 (topic
+29723): stop surfacing this disclaimer everywhere.
+
+## Decision-point inventory
+
+None touched. The notice was static informational text attached to pending
+logins; it gated nothing, blocked nothing, and fed no classifier. The S7
+email-identity gate, enrollment TTL/reissue machinery, and mandate
+authorization paths are untouched.
+
+## 1. Over-block
+
+Not applicable — no block/allow surface exists in this change.
+
+## 2. Under-block
+
+Not applicable — nothing was previously blocked by the notice. The residual
+risk is informational only: in the rare case Anthropic's sign-in still asks
+for an email-verification code before the sign-in code (occasionally seen on
+mobile), the operator sees that step without a prior warning. The provider's
+own page walks them through it.
+
+## 3. Level-of-abstraction fit
+
+The removal is at the producer (wizard) layer, not the render layer — the
+right place: render sites stay generic and any future notice-producing flow
+gets them for free. Deleting the render plumbing instead would have coupled
+this text decision to three UI surfaces.
+
+## 4. Signal vs authority compliance
+
+Required reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no new block/allow surface and removes none.
+
+## 4b. Judgment-point check
+
+No heuristic added or removed at any decision point. Static text deletion.
+
+## 5. Interactions
+
+- **Shadowing:** none — no other component produced or keyed on the notice
+  text. A repo-wide sweep for the disclaimer text and `flowNotice` references
+  confirmed the producer was singular.
+- **Double-fire:** none — nothing fires.
+- **Races:** none — the `notice` field simply stays undefined; every consumer
+  already handles absence (`?? null` / if-present rendering).
+- **Feedback loops:** none.
+
+## 6. External surfaces
+
+Pending-login API responses now carry `notice: null`/absent where they carried
+the disclaimer string; every consumer (dashboard subscriptions tab, matrix
+cells, Telegram relay of login links) already renders nothing for an absent
+notice. No schema change — the optional field remains in the type. Existing
+persisted pending logins that carry the old notice string still render it
+until they expire; no migration is needed for ephemeral TTL-bounded records.


### PR DESCRIPTION
## ELI16 — the repeated "you may be asked for two codes" warning is removed from account sign-in

Every time you added a Claude account, Instar attached a warning saying a brand-new login "often asks for TWO codes" — first an email-verification code, then the sign-in code. That was true in early testing, but the extra step has become rare, so the warning turned into noise repeated on every enrollment (dashboard panel, account cells, and relayed sign-in messages). The operator asked for it to be gone. This change deletes the one function that produced the text. The machinery that *could* show a notice stays (it's generic and harmless — it just has nothing to say now), and the timeout budgets that account for the occasional extra verification step are untouched. Sign-in itself works exactly the same; in the rare case the provider does ask for an extra code, its own page walks you through it. Full overview: docs/specs/remove-two-codes-notice.eli16.md.

## What

Removes the "a brand-new Claude login often asks for TWO codes" disclaimer from every enrollment surface, per operator directive (2026-07-23, topic 29723): the two-code window is rare now and the repeated warning reads as noise.

## How

- Delete `EnrollmentWizard.flowNotice()` — the sole producer — and the `notice:` population in `start()`.
- Keep the generic optional-notice plumbing (store field, API passthrough, dashboard if-present rendering); test fixtures for the render path now use neutral text so the stale advice ships nowhere.
- Retire the two stale comments that described the removed notice; scrape-timeout rationale comments stay (still true, and about budgets not messaging).

## Verification

- `npx tsc --noEmit` clean.
- `tests/unit/enrollment-wizard.test.ts` (37), `tests/unit/subscriptions-render.test.ts` (56), `tests/integration/subscriptions-tab.test.ts` (19) all green.
- Tier 1 instar-dev ceremony: ELI16 + side-effects artifact + release fragment + trace staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- eli16 gate: body carries the ELI16 section; comment added to refresh the check after a stale-payload rerun -->
