### PR TITLE
fix(time-claim): accept a parenthetical after the `in` elapsed anchor

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-24T00-47-05-364Z-time-claim-parenthetical-anchor.json
+++ b/.instar/instar-dev-decisions/2026-07-24T00-47-05-364Z-time-claim-parenthetical-anchor.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-24T00:47:05.364Z",
+  "slug": "time-claim-parenthetical-anchor",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 19,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "ELAPSED_RE's 'in' anchor listed a CLOSING paren in its boundary set but not an OPENING one. Latent since the anchor shipped; surfaced 2026-07-23 when two fabricated elapsed-time claims went out unflagged during a live time-boxed autonomous run. Diagnosed against the real /messaging/preflight endpoint: identical text with a trailing period returns a correct TIME_CLAIM advisory, with ' (' returns advisories:[]. The parenthetical form extracted ZERO claims, so the clock comparison never executed — a miss at the extraction stage, not the comparison stage."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T00-47-46-687Z-time-claim-parenthetical-anchor.json
+++ b/.instar/instar-dev-decisions/2026-07-24T00-47-46-687Z-time-claim-parenthetical-anchor.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-24T00:47:46.687Z",
+  "slug": "time-claim-parenthetical-anchor",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 19,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "ELAPSED_RE's 'in' anchor listed a CLOSING paren in its boundary set but not an OPENING one. Latent since the anchor shipped; surfaced 2026-07-23 when two fabricated elapsed-time claims went out unflagged during a live time-boxed autonomous run. Diagnosed against the real /messaging/preflight endpoint: identical text with a trailing period returns a correct TIME_CLAIM advisory, with ' (' returns advisories:[]. The parenthetical form extracted ZERO claims, so the clock comparison never executed — a miss at the extraction stage, not the comparison stage."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/time-claim-parenthetical-anchor.eli16.md
+++ b/docs/specs/time-claim-parenthetical-anchor.eli16.md
@@ -1,0 +1,77 @@
+# ELI16 — The honesty check had a blind spot shaped like a bracket
+
+## What this check is for
+
+When the agent is running a long timed job, it sends progress notes. Those notes
+often say how long it's been going. There's a guard that reads each note before it
+goes out, compares any elapsed-time claim against the real clock, and hands the note
+back with a complaint if the numbers disagree.
+
+It exists because an agent stating a confident, wrong number about itself is a
+particularly corrosive kind of error: it's unverifiable to the reader, and it makes
+every other number in the message worth less.
+
+## What went wrong
+
+During a long session I twice stated elapsed times I hadn't checked. Once I said
+forty minutes when fourteen had passed. Once I said an hour and ten minutes. Both
+went out without a murmur from the guard.
+
+The obvious conclusion was that the guard was switched off or broken. It wasn't. I
+tested it against my own bad messages on the live system and it worked correctly —
+fed one of them, it caught the contradiction and quoted the real clock back.
+
+The actual cause is narrower and stranger. The guard recognises phrases like:
+
+- `40 min in.`
+- `2h in)`
+- `7.5 hours in:`
+
+It has to be picky, because "in" is a slippery word. `3h in CI` means three hours
+spent *in* a place, not three hours elapsed — so the guard only treats "in" as a
+time marker when what follows it is punctuation rather than another word.
+
+The punctuation list included a **closing** bracket and not an **opening** one. So
+`40 min in.` was checked and `40 min in (iteration 1)` was invisible — not
+"checked and passed", but never recognised as a time claim in the first place.
+
+Both my bad messages used the bracket form, because writing `(iteration 1)` after a
+progress figure is the natural thing to do.
+
+## The fix
+
+Add the opening bracket to the list. One character class.
+
+There's a trade, and it's worth being explicit rather than pretending it's free.
+`2h in (CI queue)` will now be read as an elapsed claim when it probably means a
+place. That's a false alarm.
+
+I accepted it deliberately, because the two errors aren't equal. This guard doesn't
+block anything — it hands the message back with a note. A false alarm costs me one
+re-read. A miss costs the operator a confidently stated wrong number about how long
+something has been running. This session provided direct evidence for which of those
+actually happens.
+
+The picky rule itself is intact: "in" followed by an actual word is still not a time
+marker, and there are tests pinning that so the widening can't quietly erode it.
+
+## One thing left alone on purpose
+
+My other bad claim — fifty-seven minutes when the truth was forty-five — got through
+for a completely different reason. The guard tolerates a fifteen-minute margin so it
+doesn't nag about rounding, and twelve minutes is inside that.
+
+That's working as intended, and tightening it would cause real false alarms, so I
+left it and wrote it down instead. It's worth knowing as a property, though: early
+in a run that fixed margin covers a proportionally huge range. Fourteen minutes in,
+anything up to twenty-nine minutes passes unchallenged.
+
+## The pattern worth remembering
+
+I nearly reported a second, much bigger defect during this investigation — the
+detector appearing to extract a claim correctly and then fail to compare it. That
+turned out to be my own test passing an argument of the wrong shape. Checking the
+function signature before reporting saved a bad bug report.
+
+Which is the same failure as the original one: trusting a result without
+interrogating how it was produced.

--- a/src/core/time-claim.ts
+++ b/src/core/time-claim.ts
@@ -53,14 +53,29 @@ interface ExtractedClaim {
 // Anchored claim patterns. Each requires the anchor WORD so plain durations
 // never match. Hours may be fractional ("7.5 hours"); "Xh Ym" composes.
 // "in" as an elapsed anchor is only accepted at a boundary ("7.5 hours in:",
-// "1h50m in.", "2h in)") — never "3h in CI" / "in 2 hours".
+// "1h50m in.", "2h in)", "40 min in (iteration 1)") — never "3h in CI" /
+// "in 2 hours".
+//
+// The OPENING paren is in the boundary set deliberately (2026-07-23). It was
+// missing while the CLOSING paren was present, so "40 min in." was recognised
+// and "40 min in (iteration 1)" was not — and a parenthetical annotation after
+// a progress figure is an extremely natural way to write one. That gap let two
+// real fabricated elapsed-time claims through on a live autonomous run: the
+// claims extracted to NOTHING, so the comparison never ran at all.
+//
+// A residual ambiguity is accepted knowingly: "2h in (CI queue)" reads as a
+// PLACE rather than a duration and will now be treated as an elapsed claim. The
+// trade is deliberate — this signal is ADVISORY (it returns the message to the
+// author with a note, it never blocks), so a false positive costs one re-read
+// while a false negative costs the operator a fabricated time report. Tonight
+// supplied the evidence for which way that asymmetry points.
 const HOURS = String.raw`(\d{1,3}(?:\.\d+)?)\s*h(?:ours?|rs?)?`;
 const MINUTES = String.raw`(\d{1,2})\s*m(?:in(?:ute)?s?)?`;
 const HM = `${HOURS}(?:\\s*${MINUTES})?|${MINUTES}`;
 const PRE = String.raw`(?:~|≈|about\s+|around\s+|roughly\s+)?`;
 
 const ELAPSED_RE = new RegExp(
-  `${PRE}(?:${HM})\\s*(?:elapsed|into\\s+the\\s+(?:run|session)|in(?=\\s*(?:[,.;:)\\]!\\n—–-]|$|now\\b)))`,
+  `${PRE}(?:${HM})\\s*(?:elapsed|into\\s+the\\s+(?:run|session)|in(?=\\s*(?:[,.;:()\\[\\]!\\n—–-]|$|now\\b)))`,
   'gi',
 );
 const REMAINING_RE = new RegExp(

--- a/tests/unit/time-claim.test.ts
+++ b/tests/unit/time-claim.test.ts
@@ -137,3 +137,47 @@ describe('detectTimeClaimContradiction — both decision sides', () => {
     expect(detectTimeClaimContradiction('~7h elapsed', [RUN, other]).detected).toBe(false);
   });
 });
+
+/**
+ * Regression: the parenthetical-annotation form (2026-07-23).
+ *
+ * The `in` elapsed anchor accepted a CLOSING paren as a boundary but not an
+ * OPENING one, so `40 min in.` was recognised and `40 min in (iteration 1)` was
+ * not — it extracted NOTHING, so the comparison against the live clock never ran.
+ * That gap let two genuinely fabricated elapsed-time claims through on a live
+ * autonomous run: the exact failure this detector exists to prevent, in the most
+ * natural phrasing for a progress report.
+ */
+describe('the `in` anchor accepts a following parenthetical (regression)', () => {
+  const CLOCK: TimeClaimClock = { elapsedSeconds: 14 * 60, remainingSeconds: 7 * 3600, percentElapsed: 3 };
+
+  it('catches the real fabrications that slipped through', () => {
+    // Verbatim shapes of two messages actually sent at ~14 minutes elapsed.
+    for (const text of [
+      'AUTONOMOUS PROGRESS — 40 min in (iteration 1)',
+      'AUTONOMOUS PROGRESS — 1h10m in (iteration 1)',
+    ]) {
+      const claims = extractTimeClaims(text);
+      expect(claims.length, `should extract from: ${text}`).toBe(1);
+      expect(claims[0].kind).toBe('elapsed');
+      expect(detectTimeClaimContradiction(text, [CLOCK]).detected).toBe(true);
+    }
+  });
+
+  it('accepts a square bracket too, and the previously-working boundaries are unchanged', () => {
+    expect(extractTimeClaims('40 min in [run 2]').length).toBe(1);
+    expect(extractTimeClaims('40 min in.').length).toBe(1);
+    expect(extractTimeClaims('2h in)').length).toBe(1);
+    expect(extractTimeClaims('7.5 hours in:').length).toBe(1);
+    expect(extractTimeClaims('1h50m in, still going').length).toBe(1);
+  });
+
+  it('NEGATIVE: `in` followed by a word is still a place, never an anchor', () => {
+    // The whole point of the boundary rule — widening it must not reopen these.
+    expect(extractTimeClaims('3h in CI').length).toBe(0);
+    expect(extractTimeClaims('in 2 hours').length).toBe(0);
+    expect(extractTimeClaims('spent 2h in review').length).toBe(0);
+    // Task progress is not wall-clock progress.
+    expect(extractTimeClaims('the migration is 80% done').length).toBe(0);
+  });
+});

--- a/upgrades/next/time-claim-parenthetical-anchor.md
+++ b/upgrades/next/time-claim-parenthetical-anchor.md
@@ -1,0 +1,35 @@
+## What Changed
+
+The TIME_CLAIM outbound advisory now recognises an elapsed-time claim followed by a parenthetical — `40 min in (iteration 1)` — which it previously did not.
+
+The `in` anchor accepted a closing paren as a boundary but not an opening one, so `40 min in.` was checked against the live session clock and `40 min in (iteration 1)` extracted nothing at all, meaning no comparison ran.
+
+## Summary of New Capabilities
+
+- Elapsed claims written with a trailing parenthetical or bracket annotation are now verified against the live session clock instead of silently skipped.
+
+## What to Tell Your User
+
+Nothing to do. The check that verifies my elapsed-time claims against the real clock had a blind spot for one very common way of writing a progress line, and it's closed.
+
+## Evidence
+
+Found by testing the live preflight endpoint against messages actually sent during an active autonomous run.
+
+**Before:**
+
+```
+POST /messaging/preflight  "AUTONOMOUS PROGRESS — 57 minutes elapsed, 7h02m left"
+  -> {"advisories":[{"code":"TIME_CLAIM","match":"claimed \"57 minutes elapsed\"; live clock: 3h 58m elapsed", ...}]}
+
+POST /messaging/preflight  "AUTONOMOUS PROGRESS — 40 min in (iteration 1)"
+  -> {"advisories":[]}
+```
+
+Same endpoint, same active clock, same kind of claim — one caught, one invisible.
+
+**Root cause:** the `in` anchor's boundary set contained `)` but not `(`. The parenthetical form extracted zero claims, so the clock comparison never executed.
+
+**After:** both forms extract and flag. Against a 14-minute clock, `40 min in (iteration 1)` now returns `claimed "40 min in"; live clock: 14m elapsed`.
+
+**Not changed:** the 15-minute absolute tolerance floor, which let a separate 57-vs-45-minute claim pass. That is working as designed; narrowing it carries real false-positive cost and is recorded rather than changed.

--- a/upgrades/side-effects/time-claim-parenthetical-anchor.md
+++ b/upgrades/side-effects/time-claim-parenthetical-anchor.md
@@ -1,0 +1,70 @@
+# Side-effects review — TIME_CLAIM accepts a following parenthetical
+
+**Change:** one character class in `ELAPSED_RE`. The `in` elapsed anchor now
+accepts a following `(` or `[` as a boundary, alongside the existing
+`, . ; : ) ] ! — – -` / end-of-string / `now`.
+
+## Why — it missed two real fabrications on a live run
+
+Found 2026-07-23 by testing the LIVE `/messaging/preflight` endpoint against
+messages I had actually sent during an active time-boxed autonomous run.
+
+The anchor accepted a CLOSING paren but not an OPENING one:
+
+| text | before | after |
+|---|---|---|
+| `40 min in.` | extracts, flags | unchanged |
+| `2h in)` | extracts, flags | unchanged |
+| `40 min in (iteration 1)` | **extracts nothing** | extracts, flags |
+| `1h10m in (iteration 1)` | **extracts nothing** | extracts, flags |
+
+Both fabricated claims I sent used the parenthetical form — because annotating a
+progress figure with `(iteration N)` is the natural way to write one. The claims
+extracted to **nothing**, so the comparison against the live clock never ran at
+all. Verified against the real endpoint: the same text with a period returns a
+correct `TIME_CLAIM` advisory; with ` (` it returns `advisories: []`.
+
+**Not a broken guard.** The wiring is correct and live — the dev-agent gate
+resolves on, the relay posts `topicId` + kind, and conversational sends are
+covered as the one deliberate non-automated exception. Only the boundary set was
+incomplete.
+
+## Deliberately NOT changed
+
+**The 15-minute absolute tolerance floor.** My other fabricated claim — 57 minutes
+when the truth was 45 — passed because a 12-minute error is inside
+`DURATION_TOLERANCE_FLOOR_S`. That is working as designed (it stops the detector
+nagging about rounding), and narrowing it is a judgment call with real
+false-positive cost, so it is left alone and recorded instead. Worth knowing as a
+property: early in a run the fixed floor covers a proportionally large range — at
+14 minutes elapsed, any claim from 0 to 29 minutes passes.
+
+## Risk analysis
+
+**The accepted residual:** `2h in (CI queue)` reads as a PLACE and will now be
+treated as an elapsed claim. Knowingly accepted. The signal is **advisory** — it
+returns the message to the author with a note and never blocks — so a false
+positive costs one re-read, while a false negative costs the operator a fabricated
+time report. This session supplied direct evidence for which way that asymmetry
+points.
+
+**The boundary rule's purpose is preserved.** `in` followed by a WORD is still not
+an anchor. Negative tests pin `3h in CI`, `in 2 hours`, `spent 2h in review`, and
+the task-progress case `the migration is 80% done` — the widening must not reopen
+any of those, and it doesn't.
+
+**Blast radius:** one regex in one pure module. No authority (advisory only), no
+write path, no config key, no schema, no migration surface. Fail-open behaviour on
+every error path is untouched.
+
+## Testing
+
+`tests/unit/time-claim.test.ts` — 19 green (was 16). New: the two verbatim
+fabricated messages are caught against a 14-minute clock; the square-bracket form;
+all four previously-working boundaries unchanged; and four negatives pinning that
+`in`-before-a-word is still rejected. Full advisory suite set: 41 green.
+`tsc --noEmit` clean.
+
+## Rollback
+
+Revert. The anchor returns to its previous boundary set.


### PR DESCRIPTION
## What

One character class. The `in` elapsed anchor in `ELAPSED_RE` now accepts a following `(` or `[` as a boundary, alongside the existing `, . ; : ) ] ! — – -` / end-of-string / `now`.

## Why — it missed two real fabrications on a live run

The anchor listed a **closing** paren in its boundary set but not an **opening** one:

| text | before | after |
|---|---|---|
| `40 min in.` | extracts, flags | unchanged |
| `2h in)` | extracts, flags | unchanged |
| `40 min in (iteration 1)` | **extracts nothing** | extracts, flags |
| `1h10m in (iteration 1)` | **extracts nothing** | extracts, flags |

During a live time-boxed autonomous run on 2026-07-23 I twice stated elapsed times I hadn't checked — 40 min and 1h10m, at ~14 min actual. Both went out unflagged. Both used the parenthetical form, because annotating a progress figure with `(iteration N)` is the natural way to write one.

The miss was at the **extraction** stage, not the comparison stage: the text extracted zero claims, so the clock comparison never executed.

**Diagnosed against the real endpoint**, not by reading code:

```
POST /messaging/preflight  "…57 minutes elapsed, 7h02m left"
  -> {"advisories":[{"code":"TIME_CLAIM","match":"claimed \"57 minutes elapsed\"; live clock: 3h 58m elapsed"…}]}

POST /messaging/preflight  "…40 min in (iteration 1)"
  -> {"advisories":[]}
```

Same endpoint, same active clock, same class of claim.

**This is not a broken guard.** The wiring is live and correct — the dev-agent gate resolves on, the relay posts `topicId` + kind, and conversational sends are covered as the one deliberate non-automated exception. Only the boundary set was incomplete.

## The accepted residual, stated plainly

`2h in (CI queue)` reads as a PLACE and will now be treated as an elapsed claim. Knowingly accepted.

The two errors aren't symmetric. This signal is **advisory** — it returns the message to its author with a note and can never block, delay, or rewrite a send. A false positive costs one re-read. A false negative costs the operator a confidently-stated wrong number about the agent's own runtime, which is unverifiable to the reader and devalues every other number in the message. This session supplied direct evidence for which one actually occurs.

**The boundary rule's purpose is preserved.** `in` followed by a WORD is still not an anchor — negative tests pin `3h in CI`, `in 2 hours`, `spent 2h in review`, and the task-progress case `the migration is 80% done`, so the widening can't quietly erode the rule it relaxes.

## Deliberately NOT changed

`DURATION_TOLERANCE_FLOOR_S` (15 min absolute). A separate fabricated claim — 57 minutes when the truth was 45 — passed because a 12-minute error is inside it. That's working as designed (it stops the detector nagging about rounding); narrowing it carries real false-positive cost, so it's recorded rather than changed. Worth knowing as a property: early in a run the fixed floor covers a proportionally large range — at 14 minutes elapsed, any claim from 0 to 29 minutes passes.

## Safety

Pure module, no I/O. No authority (advisory by contract), no write path, no config key, no schema, no migration surface. Every fail-open error path untouched.

## Tests

`tests/unit/time-claim.test.ts` — **19 green** (was 16). New coverage: both verbatim fabricated messages caught against a 14-minute clock; the square-bracket form; all four previously-working boundaries unchanged; four negatives pinning `in`-before-a-word. Full advisory suite set: **41 green**. `tsc --noEmit` clean.

## ELI16 — The honesty check had a blind spot shaped like a bracket

When the agent runs a long timed job it sends progress notes, and those notes often say how long it's been going. A guard reads each note before it goes out, compares any elapsed-time claim against the real clock, and hands the note back if the numbers disagree. It exists because an agent stating a confident wrong number about itself is a corrosive kind of error — unverifiable to the reader, and it devalues every other number in the message.

Twice in one session I stated elapsed times I hadn't checked, and both sailed past. The obvious conclusion was that the guard was off or broken. It wasn't — fed one of my bad messages directly, it caught the contradiction and quoted the real clock back.

The actual cause is narrower. The guard has to be picky about the word "in", because `3h in CI` means three hours spent *in a place*, not three hours elapsed. So it only treats "in" as a time marker when punctuation follows rather than another word. The punctuation list had a closing bracket and not an opening one — so `40 min in.` was checked and `40 min in (iteration 1)` was never recognised as a time claim at all.

The fix adds the opening bracket. There's a trade worth naming rather than pretending it's free: `2h in (CI queue)` will now raise a false alarm. I took it deliberately, because the guard doesn't block anything — a false alarm costs one re-read, a miss costs a wrong number reaching the operator.

One more thing worth recording. While investigating I nearly reported a second, much bigger defect — the detector appearing to extract a claim correctly and then fail to compare it. That turned out to be my own test passing an argument of the wrong shape. Checking the signature before reporting saved a bad bug report — and it was the same failure as the original one: trusting a result without interrogating how it was produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
