### PR TITLE
feat(bench): capture the zombie-classify predictions-mirror baseline

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-24T02-17-27-270Z-zombie-classify-baseline-side-effects.json
+++ b/.instar/instar-dev-decisions/2026-07-24T02-17-27-270Z-zombie-classify-baseline-side-effects.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T02:17:27.270Z",
+  "slug": "zombie-classify-baseline.side-effects",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 26,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T02-18-28-775Z-zombie-classify-baseline-side-effects.json
+++ b/.instar/instar-dev-decisions/2026-07-24T02-18-28-775Z-zombie-classify-baseline-side-effects.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-24T02:18:28.775Z",
+  "slug": "zombie-classify-baseline.side-effects",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 26,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent from the moment the pair was enrolled as a decision point without ever being benched — a real analyze pass returned exactly one finding, byVerdict {precondition-failed: 1}, and had been doing so silently since enrollment. Half the enrolled surface measured nothing while the detector reported correctly and nobody read it. Back-filling from the prior battery was impossible: it had been scored against a prompt of a different shape (2029 chars vs 1373 live) and against a case set feeding the model an identity tuple the live prompt deliberately withholds."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T02-19-35-682Z-zombie-classify-baseline-side-effects.json
+++ b/.instar/instar-dev-decisions/2026-07-24T02-19-35-682Z-zombie-classify-baseline-side-effects.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-24T02:19:35.682Z",
+  "slug": "zombie-classify-baseline.side-effects",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 26,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent from the moment the pair was enrolled as a decision point without ever being benched — a real analyze pass returned exactly one finding, byVerdict {precondition-failed: 1}, and had been doing so silently since enrollment. Half the enrolled surface measured nothing while the detector reported correctly and nobody read it. Back-filling from the prior battery was impossible: it had been scored against a prompt of a different shape (2029 chars vs 1373 live) and against a case set feeding the model an identity tuple the live prompt deliberately withholds."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/zombie-classify-baseline.eli16.md
+++ b/docs/specs/zombie-classify-baseline.eli16.md
@@ -1,0 +1,98 @@
+# ELI16 — Measuring the thing you actually run
+
+## What this is for
+
+Some decisions in this system are made by asking a language model. One of them:
+a process is eating a lot of CPU and its parent application has quit — is it
+abandoned junk worth shutting down, or is it still doing something useful?
+
+We'd like to know how good the models are at that. So there's a test set: a batch
+of example situations, each with a known right answer, run against several models
+to see who gets what.
+
+There's also a watcher whose job is to notice when a model's real-world accuracy
+drifts away from its test-set score. That watcher had been quietly reporting
+"can't do my job" for this decision, because no test-set score had ever been
+recorded for it. This change records one.
+
+## Why it took the whole evening
+
+The test set existed. It just wasn't testing the real thing.
+
+**The questions had gone stale.** The wording the system actually sends had been
+rewritten since the test was written, and not just tweaked — restructured. The
+old test handed the model a process ID and a CPU percentage. The real one hands
+it seven yes/no facts and deliberately withholds the ID, on the reasoning that
+the model doesn't need it, and not naming a specific target is one less thing a
+malicious process can exploit. So the test was scoring a different, easier
+problem and reporting the result as if it were this one.
+
+**Half the examples described situations that never come up.** The system only
+consults a model about a narrow list of known process types. Four of the eight
+examples were about processes outside that list — a core operating-system
+service, our own server. Those never get a model asked about them at all.
+
+**And then I broke it myself.** Rebuilding the questions, I marked all eight as
+"on the known list", including the operating-system service. So the model was
+told something false and asked to judge accordingly. Three different models then
+failed the same examples in the same direction — which is almost never a story
+about the models. It was mine.
+
+## Two things the fixed test found
+
+**A question with no right answer.** Two examples are supposed to differ: in one
+we know the parent app has quit, in the other we *couldn't determine* whether it
+quit. Different situations, different correct answers. But the wording collapses
+"unknown" into "no", so both produce a character-for-character identical
+question. No model can do better than a coin flip. That's a flaw in the wording,
+not the models — logged separately to fix properly.
+
+It causes no harm today, because a separate mechanical check refuses outright
+when a fact is missing, so the model's answer there is never acted on. Which is
+exactly why nobody would ever have noticed: the wrong answer never has
+consequences, so nothing ever looks broken. You only see it by inspecting the
+decisions themselves.
+
+**Every model missed the same one.** One example states plainly that the process
+is *not* a sustained CPU hog. All three, across two different vendors, recommend
+shutting it down anyway. Also harmless — the mechanical check refuses on that
+exact fact — but all three talking past a fact stated in plain sight is worth
+knowing.
+
+## Where I was wrong and the models were right
+
+Two examples I wrote expected "leave it alone" for a process whose command line
+showed work in progress — a code-indexer mid-index. Every model said shut it
+down. They're right and I wasn't.
+
+Getting to this point requires the parent app to have already quit. A code
+indexer still working for an editor that closed is burning cores on results
+nobody will ever read. "Still working" and "abandoned" point in opposite
+directions here, and abandoned wins.
+
+Those two are withdrawn rather than scored. Marking them as failures would have
+published "the leading models fail to protect work in progress" — a memorable,
+quotable conclusion that happens to be false. A test case whose answer is
+genuinely arguable measures the answer key, not the model.
+
+## What guards this now
+
+The failure that cost the most was silent: I wrote the example data using a field
+name that doesn't exist, so it was ignored, and nine examples collapsed into
+identical copies of one. The file still listed twelve distinctly-named cases. It
+looked like broad coverage and was one question asked nine times.
+
+Nothing caught that. It surfaced from a hunch, after the scores looked strange.
+
+So the hunch is now machinery: the generator hashes every question it produces
+and refuses to write the file if two come out identical, naming the culprits.
+The one genuinely-unfixable duplicate is listed explicitly as a known exception,
+so it stays visible instead of being smoothed away.
+
+## What actually changed
+
+One data file, recording per-model scores for this decision, plus a note stating
+which examples were counted and which were set aside and why. One model's score
+is based on six examples rather than ten, because four of its calls errored —
+recorded as six rather than quietly rounded up, since the watcher weighs a thin
+sample differently from a solid one, and only if it's told the truth about it.

--- a/docs/specs/zombie-classify-baseline.side-effects.md
+++ b/docs/specs/zombie-classify-baseline.side-effects.md
@@ -1,0 +1,85 @@
+# Side effects — zombie-classify predictions-mirror baseline
+
+## The change
+
+One file: `src/data/benchmarkPredictions.json` gains a `zombie-classify` task
+entry (per-model `passes`/`deterministic` counts, `benchedPromptSource`,
+`benchedPromptHash`, `capturedAt`, plus `scoredPopulation` and `note` prose), and
+the top-level `capturedAt` is refreshed.
+
+No code paths change. No behaviour changes.
+
+## Who reads this file
+
+`BenchmarkDivergenceDetector` (observe-only, dev-gated, dark on the fleet). It
+compares a decision point's real settled grade-rate against this mirror's
+predicted pass-rate and emits `advisory: true` findings. It gates nothing, blocks
+nothing, and cannot alter a routing decision.
+
+Before this change the detector returned exactly one finding for this pair,
+`precondition-failed` — no mirror entry existed. After it, the pair has a
+prediction to compare against.
+
+## Blast radius
+
+**Bounded to advisory output.** The worst case from a wrong number here is a
+misleading finding on `GET /benchmark-divergence`. Nothing enacts on it.
+
+Specifically NOT affected:
+- The `ExternalHogSentinel` kill path. It reads the floor and the classifier
+  verdict; it has never read this file.
+- Model routing. `sessions.componentFrameworks` and the provider-fallback chain
+  are untouched.
+- The quality meter's own grading, which derives from settled decision rows.
+
+## The Q0 precondition
+
+The detector refuses to draw conclusions when the benched prompt hash no longer
+matches the live template — a stale benchmark must never blame or credit a model.
+`98b026db…` was verified equal to a sha256 of
+`EXTERNAL_HOG_CLASSIFIER_PROMPT_TEMPLATE`, compiled from this branch's source, at
+commit time.
+
+This is load-bearing in an unusual direction: if the hash were wrong, the
+detector would keep reporting `precondition-failed` — i.e. it fails toward
+saying nothing, not toward saying something false. That is the safe direction and
+it is intentional.
+
+**A future prompt change invalidates this baseline and must re-stamp it.** That
+includes fixing the unknown-vs-false flattening logged as ACT-1212, which will
+necessarily change the hash. The regeneration recipe is
+`research/llm-pathway-bench/instar-bench-v2/regen-zombie-classify.mjs`, which
+prints the hash to stamp. It refuses to run without being pointed at a compiled
+copy of the live builder, so the numbers cannot come from a prompt pasted into
+the script and left to rot.
+
+## What the numbers are, precisely
+
+Scored population is the 10 `production-candidate` cases — allowlist-matched, so
+a model genuinely is consulted about them. Excluded and retained in the task file
+as evidence:
+
+- **4 `floor-excluded`** — never allowlist-matched. `identityFor` returns null and
+  the scan tick surfaces them without classifying, so no model is ever asked.
+- **1 `invalid-unwinnable`** — renders byte-identical to another case carrying the
+  opposite expected answer (ACT-1212). Unpassable by construction.
+- **2 `contested-expectation`** — the models made the better argument; the
+  expectation was withdrawn rather than scored against them.
+
+`gemini-2.5-flash` is `n=6`, not 10: four calls errored during the run. Recorded
+as 6 because the detector's noise-awareness is only protective if the sample size
+it is given is true. Padding to 10 would manufacture a confident-looking
+prediction out of a thin one — the precise failure this whole mirror exists to
+prevent.
+
+## Multi-machine posture
+
+`unified` — a git-tracked source data file, identical on every machine by
+construction, replicated by the same mechanism as the rest of the source tree. No
+machine-local state, no per-machine divergence, nothing to reconcile.
+
+## Rollback
+
+Revert the commit. The detector returns to reporting `precondition-failed` for
+this pair, which is its honest state when no baseline exists. No migration, no
+persisted state, no cleanup.

--- a/src/data/benchmarkPredictions.json
+++ b/src/data/benchmarkPredictions.json
@@ -1,6 +1,6 @@
 {
  "_doc": "Content-free INSTAR-Bench predictions mirror (benchmark-divergence-detector FD1). Counts, not just rates, so the prediction carries its own sampling uncertainty. Regenerate by re-running the battery against the CURRENT prompt templates and re-stamping benchedPromptHash.",
- "capturedAt": "2026-07-23T22:30:00.000Z",
+ "capturedAt": "2026-07-24T01:20:00.000Z",
  "tasks": {
   "tone-gate": {
    "perModel": {
@@ -28,6 +28,30 @@
    "benchedPromptSource": "src/core/MessagingToneGate.ts:TONE_GATE_PROMPT_TEMPLATE",
    "benchedPromptHash": "4ae0cf6b02663c21a695393727bd05662334f0d8f1a9d3e45d8d9b2141208d54",
    "capturedAt": "2026-07-23T22:30:00.000Z"
+  },
+  "zombie-classify": {
+   "perModel": {
+    "gpt-5.5": {
+     "passRate": 0.9,
+     "passes": 9,
+     "deterministic": 10
+    },
+    "gpt-5.4-mini": {
+     "passRate": 0.9,
+     "passes": 9,
+     "deterministic": 10
+    },
+    "gemini-2.5-flash": {
+     "passRate": 0.8333,
+     "passes": 5,
+     "deterministic": 6
+    }
+   },
+   "benchedPromptSource": "src/monitoring/ExternalHogClassifierPrompt.ts:EXTERNAL_HOG_CLASSIFIER_PROMPT_TEMPLATE",
+   "benchedPromptHash": "98b026dbe3ee48cab1403ef24218e9e24f6ea2b3d598c23e383bed4e894cbb56",
+   "capturedAt": "2026-07-24T01:20:00.000Z",
+   "scoredPopulation": "production-candidate only (10 of 17 cases). Excluded by design: 4 floor-excluded (never allowlist-matched, so no model is ever consulted about them), 1 invalid-unwinnable (renders byte-identical to another case with the opposite expected answer — a prompt defect, see ACT-1212), 2 contested-expectation (the models made the better argument and the expectation was withdrawn). Excluded cases are retained in the task file as evidence, not deleted.",
+   "note": "gemini-2.5-flash n=6 not 10: four calls errored during the run, and the shortfall is recorded rather than papered over — the detector is noise-aware and should treat this prediction as correspondingly weak."
   }
  }
 }

--- a/upgrades/next/zombie-classify-baseline.md
+++ b/upgrades/next/zombie-classify-baseline.md
@@ -1,0 +1,33 @@
+## What Changed
+
+The benchmark predictions mirror now carries a `zombie-classify` entry, so the Benchmark-Divergence Detector has something to compare against for the second of its two enrolled decision points. It had been reporting `precondition-failed` for that pair since enrollment — correctly, since no baseline existed. Half the enrolled surface was measuring nothing.
+
+## Summary of New Capabilities
+
+- `GET /benchmark-divergence` can now produce a real verdict for the external-hog kill/leave classifier instead of a standing `precondition-failed`.
+
+## What to Tell Your User
+
+Nothing to do. This is internal measurement plumbing — the detector is observe-only, dev-gated, dark on the fleet, and gates nothing.
+
+## Evidence
+
+The baseline could not simply be re-run, because the existing case set was not testing the live decision.
+
+**Prompt drift, and a shape change.** The benched template was 2029 chars against a live prompt of 1373. The old cases fed the model `pid`, `parentPid`, `cpuPercent` and `elapsed`. The live prompt carries seven derived booleans plus the matched allowlist class, and deliberately withholds the identity tuple — the model does not need it, and omitting it denies an injection payload a concrete target to name in its logged reason.
+
+**Population mismatch.** Only an allowlist-matched candidate ever reaches a model: `identityFor` returns null otherwise and the scan tick surfaces the process without classifying it. Four of the eight original cases describe processes no model is ever consulted about.
+
+The boundary is the allowlist match **alone**, not the whole floor — an easy thing to get wrong, and it was gotten wrong once during this work. `evaluateKillFloor` runs separately, and a kill requires `floor.permitted && verdict === 'kill'`. A candidate the floor will veto is still a real question put to a real model, and its answer still worth grading. Reading floor-veto as "never asked" would have silently deleted three legitimate cases.
+
+**Two findings from the rebuilt set:**
+
+One case is unpassable by construction. `buildClassifierPrompt` renders every boolean with `=== true`, so an *unknown* owner state and a *known-false* owner state both print `owner_app_running: false`. Two cases carrying opposite expected answers render byte-for-byte identical prompts. That is a defect in the prompt, not the models — logged as ACT-1212. It is harmless today: the floor vetoes an unknown required field outright (`field-unknown:ownerAppRunning`), so the model's answer there is never enacted. Which is precisely why it would never surface from outcomes.
+
+All three models tested, across two families, recommend `kill` on a case whose fact block states plainly `sustained_high_cpu: false`. Also not enactable — the floor hard-vetoes on that exact fact. Also invisible from outcomes alone.
+
+**Scored population** is the 10 `production-candidate` cases. Excluded and retained in the task file as evidence rather than deleted: 4 `floor-excluded` (no model consulted), 1 `invalid-unwinnable` (above), and 2 `contested-expectation` — cases authored expecting `leave` for argv describing work in flight, where every model answered `kill` and had the better argument, since reaching a kill requires an orphaned owner and a language server indexing for a closed editor is burning cores on results nobody will collect. Those expectations were withdrawn rather than scored; encoding them would have published a confident and false claim about model behaviour.
+
+`gemini-2.5-flash` records `n=6` rather than 10 because four calls errored. Stamped as 6 rather than padded — the detector's noise-awareness only protects anything if the sample size it is given is true.
+
+**Not changed:** the classifier prompt itself. Fixing the unknown-vs-false flattening alters the prompt hash and invalidates this baseline, so it belongs in its own gated change with its own re-stamp, not bundled here.


### PR DESCRIPTION
## What this does

Adds a `zombie-classify` entry to `src/data/benchmarkPredictions.json`, so the Benchmark-Divergence Detector has a baseline to compare against for the second of its two enrolled decision points.

It had been returning `precondition-failed` for that pair since enrollment — correctly, because no baseline existed. Half the enrolled surface was measuring nothing, and the detector was reporting that honestly to nobody.

## Why it wasn't a re-run

The existing case set wasn't testing the live decision.

**The prompt had drifted, and changed shape.** Benched at 2029 chars against a live prompt of 1373. The old cases fed the model `pid`, `parentPid`, `cpuPercent`, `elapsed`. The live prompt carries seven derived booleans plus the matched allowlist class and deliberately withholds the identity tuple — the model doesn't need it, and omitting it denies an injection payload a concrete target to name in its logged reason.

**Half the cases described a population that never reaches a model.** Only an allowlist-matched candidate is classified; `identityFor` returns null otherwise and the scan tick surfaces the process without consulting anything.

The boundary is the allowlist match **alone**, not the whole floor. `evaluateKillFloor` runs separately and a kill needs `floor.permitted && verdict === 'kill'`, so a candidate the floor will veto is still a real question put to a real model. Reading floor-veto as "never asked" would have deleted three legitimate cases — I made that error mid-way and corrected it.

## Two findings

**A case no model can pass.** `buildClassifierPrompt` renders every boolean with `=== true`, so an *unknown* owner state and a *known-false* owner state both print `owner_app_running: false`. Two cases with opposite expected answers render byte-for-byte identical prompts.

That's a prompt defect, not a model failure (ACT-1212). Harmless today — the floor vetoes an unknown required field outright, so the answer is never enacted. Which is exactly why it would never surface from outcomes.

**All three models miss the same case.** Across two families, each recommends `kill` on a case whose fact block states `sustained_high_cpu: false` in plain sight. Also not enactable (hard floor veto on that fact). Also invisible from outcomes alone.

Both are the class of finding that only exists if you inspect decisions rather than results.

## Scored population

10 `production-candidate` cases. Excluded, and retained in the task file as evidence rather than deleted:

| axis | n | why |
|---|---|---|
| `floor-excluded` | 4 | never allowlist-matched — no model is consulted |
| `invalid-unwinnable` | 1 | renders identical to another case with the opposite answer |
| `contested-expectation` | 2 | the models had the better argument (below) |

The contested two were authored by me expecting `leave` for argv describing work in flight. Every model said `kill`, and they're right: reaching a kill requires an orphaned owner, and a language server indexing for a closed editor is burning cores on results nobody will collect. Withdrawn rather than scored — publishing them as failures would have produced a memorable, quotable claim that the leading models fail to protect live work, which is false.

`gemini-2.5-flash` is `n=6`, not 10, because four calls errored. Stamped as 6 rather than padded: the detector's noise-awareness only protects anything if the sample size is true.

## Guard added

The regeneration script now hashes every rendered case and hard-refuses to write the task file if two collide, naming the culprits, with the one genuine known-unfixable collision explicitly allowlisted.

That exists because nine cases silently collapsed into one during this work — authored with a `command:` key while `ExternalHogFacts` names the field `argv`, so the extra key was dropped and every vscode case rendered the identical prompt. The file still listed twelve distinctly-named cases. It looked like coverage and was one question asked nine times. Nothing caught it but an ad-hoc check run on a hunch.

## Risk

Data-only. Consumed by an observe-only, dev-gated, dark-on-fleet detector that gates nothing. Worst case is a misleading advisory line. If the stamped hash were wrong, the detector fails toward saying nothing (`precondition-failed`) rather than toward a false claim — the safe direction, by design.

Rollback is a plain revert; no migration, no persisted state.

## Verification

- `tsc --noEmit` clean
- `benchmarkDivergenceRegistry` (15 tests) + `external-hog-classifier-prompt` (6 tests) pass
- Stamped hash verified equal to a sha256 of `EXTERNAL_HOG_CLASSIFIER_PROMPT_TEMPLATE` compiled from this branch's source
- Battery run on subscription doors only; metered pre-flight confirmed 0 metered routes selected, and the run billed $0.0000

## ELI16 — Measuring the thing you actually run

Some decisions here are made by asking a language model: this process is eating CPU and its parent app has quit — abandoned junk, or still doing something useful? A test set checks how good the models are at that, and a watcher notices when real-world accuracy drifts from the test score. That watcher had been saying "can't do my job" for this decision, because no test score existed.

Recording one took the evening because the test wasn't testing the real thing. The questions had gone stale — the real wording had been restructured, handing the model seven yes/no facts instead of a process ID and a CPU percentage. Half the examples described situations that never come up. And rebuilding them, I marked all eight as "on the known list" including a core OS service, so three models then failed the same examples in the same direction. Almost never a story about the models. It was mine.

The fixed test found two things. One question has no right answer: two examples meant to differ — parent app *known* quit versus *couldn't determine* — collapse into identical text, so no model can beat a coin flip. And every model missed the same example, one stating plainly that the process isn't a sustained CPU hog, where all three recommend shutting it down anyway. Neither causes harm; a separate mechanical check catches both. Which is exactly why nobody would notice: the wrong answer never has consequences, so nothing ever looks broken.

Two examples I wrote, the models argued me out of — a code indexer mid-index whose editor has closed is working for nobody. Those are withdrawn, not scored against them. A test case whose answer is genuinely arguable measures the answer key, not the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
