### PR TITLE
fix: enforce subscription account email identity

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-24T05-43-03-014Z-subscription-account-email-invariant.json
+++ b/.instar/instar-dev-decisions/2026-07-24T05-43-03-014Z-subscription-account-email-invariant.json
@@ -1,0 +1,26 @@
+{
+  "ts": "2026-07-24T05:43:03.014Z",
+  "slug": "subscription-account-email-invariant",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 10,
+  "loc": 1062,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/follow-me-consumer-backoff-store.test.ts",
+      "howCaught": "A permanently failing account-machine pair advances through three bounded delays and reaches a durable parked steady state after its fourth attempt, so an every-minute failure edge cannot remain eligible."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T05-43-57-211Z-subscription-account-email-invariant.json
+++ b/.instar/instar-dev-decisions/2026-07-24T05-43-57-211Z-subscription-account-email-invariant.json
@@ -1,0 +1,29 @@
+{
+  "ts": "2026-07-24T05:43:57.211Z",
+  "slug": "subscription-account-email-invariant",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 10,
+  "loc": 1062,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Subscription registration historically admitted records without provider-attested email, while the delivered-mandate consumer had no durable convergence bound for an unchanged identity failure. The malformed legacy row exposed both latent gaps."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/follow-me-consumer-backoff-store.test.ts",
+      "howCaught": "A permanently failing account-machine pair advances through three bounded delays and reaches a durable parked steady state after its fourth attempt, so an every-minute failure edge cannot remain eligible."
+    }
+  },
+  "verdict": "pass"
+}

--- a/dashboard/subscriptions.js
+++ b/dashboard/subscriptions.js
@@ -471,6 +471,7 @@ export function renderPendingLogins(doc, target, logins, now = Date.now(), outco
 /** Pivot the pool-scope + pending-scope bodies into a grid model. Pure + testable. */
 export function buildMatrixModel(poolScope, pendingScope, transient = {}) {
   const accountRows = (poolScope && Array.isArray(poolScope.accounts)) ? poolScope.accounts : [];
+  const gapRows = (poolScope && Array.isArray(poolScope.emailGaps)) ? poolScope.emailGaps : [];
   const pendingRows = (pendingScope && Array.isArray(pendingScope.logins)) ? pendingScope.logins : [];
   const failed = (poolScope && poolScope.pool && Array.isArray(poolScope.pool.failed)) ? poolScope.pool.failed : [];
   const selfMachineId = (poolScope && poolScope.pool && poolScope.pool.selfMachineId) || null;
@@ -484,6 +485,15 @@ export function buildMatrixModel(poolScope, pendingScope, transient = {}) {
     const mid = a && a.machineId;
     if (!mid || offlineMachineIds.has(mid)) continue;
     if (!machines.has(mid)) machines.set(mid, { machineId: mid, nickname: (a.machineNickname || mid), offline: false });
+  }
+  for (const gap of gapRows) {
+    const mid = gap && gap.machineId;
+    if (!mid || offlineMachineIds.has(mid)) continue;
+    if (!machines.has(mid)) machines.set(mid, {
+      machineId: mid,
+      nickname: gap.machineNickname || mid,
+      offline: false,
+    });
   }
   for (const f of failed) {
     const mid = f && f.machineId;
@@ -499,6 +509,13 @@ export function buildMatrixModel(poolScope, pendingScope, transient = {}) {
     if (!id) continue;
     if (!accounts.has(id)) accounts.set(id, { accountId: id, email: a.email || id });
     else if (!accounts.get(id).email && a.email) accounts.get(id).email = a.email;
+  }
+  for (const gap of gapRows) {
+    const id = gap && gap.accountId;
+    if (id && !accounts.has(id)) accounts.set(id, {
+      accountId: id,
+      email: gap.nickname || id,
+    });
   }
   // A pending matrix login can reference an account not yet in any pool row — surface its row too.
   for (const l of pendingRows) {
@@ -529,6 +546,11 @@ export function buildMatrixModel(poolScope, pendingScope, transient = {}) {
   for (const l of pendingRows) {
     if (l && l.id && l.machineId) inProgress.set(`${l.id}::${l.machineId}`, l);
   }
+  const emailMissing = new Set(
+    gapRows
+      .filter((gap) => gap && gap.accountId && gap.machineId)
+      .map((gap) => `${gap.accountId}::${gap.machineId}`),
+  );
 
   const machineList = Array.from(machines.values());
   const accountList = Array.from(accounts.values());
@@ -552,6 +574,7 @@ export function buildMatrixModel(poolScope, pendingScope, transient = {}) {
       if (m.offline) state = 'offline';                              // whole column offline (FD6)
       else if (t && t.state === 'held') state = 'held';
       else if (t && t.state === 'cant-resolve') state = 'cant-resolve';
+      else if (emailMissing.has(key) || (t && t.state === 'email-missing')) state = 'email-missing';
       // Durable pending state wins over enrollment bookkeeping after restart: the
       // full flow rehydrates into its cell even if the pool row still says Active.
       // broken (D5): the server says this attempt's sign-in pane is DEAD (record ⟂ pane
@@ -586,12 +609,13 @@ export function buildMatrixModel(poolScope, pendingScope, transient = {}) {
 
 const MATRIX_CELL_GLYPH = {
   active: '✓', 'needs-reauth': '⟳', 'in-progress': '◷', offline: '—', held: '⚠', 'cant-resolve': '✗',
-  expired: '✗', 'just-verified': '✓', broken: '✗',
+  'email-missing': '⚠', expired: '✗', 'just-verified': '✓', broken: '✗',
 };
 const MATRIX_CELL_WORD = {
   active: 'Active', 'needs-reauth': 'Needs sign-in', 'in-progress': 'Signing in…',
   offline: 'Machine offline', held: 'Didn’t match — re-try', 'cant-resolve': 'Can’t set up', other: 'Set up',
-  expired: 'Sign-in link expired', 'just-verified': 'Set up complete', broken: 'Sign-in needs a restart',
+  'email-missing': 'Account record is missing its email', expired: 'Sign-in link expired',
+  'just-verified': 'Set up complete', broken: 'Sign-in needs a restart',
 };
 
 /** D5 wording floor: never show a raw internal machine id (m_<hex>) to the operator —
@@ -700,17 +724,21 @@ export function renderAccountMatrix(doc, target, poolScope, pendingScope, transi
       const td = el(doc, 'td', `sub-matrix-cell sub-matrix-${c.state}${justVerified && c.state !== 'just-verified' ? ' sub-matrix-just-verified' : ''}`);
       // Stable cell identity for the interaction-hold rule + targeted merge updates (F9).
       td.setAttribute('data-cell-key', sanitizeForDisplay(`${c.accountId}::${c.machineId}`, 'url'));
-      if (c.state === 'empty' || c.state === 'needs-reauth' || c.state === 'held' || c.state === 'cant-resolve' || c.state === 'expired' || c.state === 'broken') {
+      if (c.state === 'empty' || c.state === 'needs-reauth' || c.state === 'held' || c.state === 'cant-resolve' || c.state === 'email-missing' || c.state === 'expired' || c.state === 'broken') {
         // An actionable cell → a button that runs the SAME in-dashboard sign-in flow (PIN → link →
         // paste code). empty → "Set up"; needs-reauth (an existing account whose login expired) →
         // "Sign in"; held/cant-resolve/expired/broken → "Retry". A needs-reauth account already
         // resolves to its email, so the start-cell orchestrator drives a real re-auth — never a
         // cosmetic button, and a broken (dead-pane) attempt is superseded server-side on Retry.
-        const label = c.state === 'empty' ? 'Set up' : (c.state === 'needs-reauth' ? 'Sign in' : 'Retry');
+        const label = c.state === 'empty' ? 'Set up'
+          : c.state === 'needs-reauth' ? 'Sign in'
+          : c.state === 'email-missing' ? 'Repair identity'
+          : 'Retry';
         const btn = el(doc, 'button', 'sub-matrix-setup', label);
         btn.setAttribute('data-matrix-setup', '1');
         btn.setAttribute('data-account-id', sanitizeForDisplay(c.accountId, 'label'));
         btn.setAttribute('data-machine-id', sanitizeForDisplay(c.machineId, 'label'));
+        if (c.state === 'email-missing') btn.setAttribute('data-email-repair', '1');
         if (c.state !== 'empty') {
           // Show the status word ("⟳ Needs sign-in" / "⚠ Didn't match…") ABOVE the button.
           td.appendChild(el(doc, 'div', 'sub-matrix-glyph', `${MATRIX_CELL_GLYPH[c.state]} ${MATRIX_CELL_WORD[c.state]}`));
@@ -1197,6 +1225,7 @@ export function createController(opts) {
     if (!cell) return;
     const accountId = btn.getAttribute('data-account-id');
     const machineId = btn.getAttribute('data-machine-id');
+    const emailRepair = btn.getAttribute('data-email-repair') === '1';
     if (!accountId || !machineId) return;
     // A retry clears the previous attempt's terminal presentation for this cell.
     delete state.matrixTransient[`${accountId}::${machineId}`];
@@ -1212,6 +1241,7 @@ export function createController(opts) {
     confirm.setAttribute('data-matrix-confirm', '1');
     confirm.setAttribute('data-account-id', accountId);
     confirm.setAttribute('data-machine-id', machineId);
+    if (emailRepair) confirm.setAttribute('data-email-repair', '1');
     cell.appendChild(confirm);
     // An explicit way OUT of the interaction (the hold would otherwise pin the cell
     // forever if the operator changes their mind) — client-side only, nothing started yet.
@@ -1237,6 +1267,7 @@ export function createController(opts) {
     if (!cell) return;
     const accountId = btn.getAttribute('data-account-id');
     const machineId = btn.getAttribute('data-machine-id');
+    const emailRepair = btn.getAttribute('data-email-repair') === '1';
     const pinInput = cell.querySelector('.sub-matrix-pin');
     const pin = pinInput ? pinInput.value.trim() : '';
     if (!accountId || !machineId) { setCellStatus(cell, 'Couldn’t prepare this — please refresh.'); return; }
@@ -1245,6 +1276,22 @@ export function createController(opts) {
     btn.setAttribute('disabled', '1');
     void (async () => {
       try {
+        if (emailRepair) {
+          const r = await postJson(`/subscription-pool/${encodeURIComponent(accountId)}/repair-email`, { pin });
+          if (pinInput) pinInput.value = '';
+          if (r.ok) {
+            cell.removeAttribute('data-interaction-open');
+            setCellStatus(cell, '✓ Account identity repaired.');
+            await tick();
+            return;
+          }
+          const msg = r.json && r.json.error
+            ? r.json.error
+            : 'Couldn’t verify this account from its signed-in credential.';
+          setCellStatus(cell, msg);
+          btn.removeAttribute('disabled');
+          return;
+        }
         const r = await postJson(URLS.startCell, { accountId, machineId, pin });
         if (pinInput) pinInput.value = ''; // PIN is memory-only — clear it immediately
         if (r.ok && r.json && r.json.verificationUrl) {
@@ -1257,8 +1304,15 @@ export function createController(opts) {
             ttlExpiresAt: r.json.ttlExpiresAt, notice: r.json.notice, kind: r.json.kind,
           });
         } else if (r.status === 409) {
-          state.matrixTransient[`${accountId}::${machineId}`] = { state: 'cant-resolve', at: now() };
-          setCellStatus(cell, 'Can’t set this account up here — its details couldn’t be resolved.');
+          const code = r.json && r.json.code;
+          state.matrixTransient[`${accountId}::${machineId}`] = {
+            state: code === 'account-record-missing-email' ? 'email-missing' : 'cant-resolve',
+            at: now(),
+          };
+          const message = r.json && r.json.error
+            ? r.json.error
+            : 'Can’t set this account up here — its identity details could not be verified.';
+          setCellStatus(cell, message);
           btn.removeAttribute('disabled');
         } else {
           const msg = (r.json && (r.json.error || r.json.reason)) ? (r.json.error || r.json.reason) : `failed (${r.status})`;

--- a/docs/specs/reports/subscription-account-email-invariant-convergence.md
+++ b/docs/specs/reports/subscription-account-email-invariant-convergence.md
@@ -1,0 +1,146 @@
+# Convergence Report — Subscription account email invariant and honest follow-me recovery
+
+## Cross-model review: codex-cli:gpt-5.5
+
+Real GPT-tier and Gemini-tier external reviews ran on the reviewable body. The
+standards-conformance HTTP endpoint was also attempted, but the live server
+correctly refused a spec path outside its configured checkout; that advisory
+pass was unavailable for this isolated worktree and was not represented as a
+successful constitutional result.
+
+## ELI10 Overview
+
+An account in the subscription pool must identify the provider account it
+represents. Today the record can exist without its email, even though every
+safe follow-me sign-in needs that email to make sure the new credential belongs
+to the intended account. One malformed record therefore turns a correct login
+into an unexplained failure.
+
+The converged design makes email proof part of registration, repairs old
+records from their own local credentials when possible, and quarantines gaps
+that cannot be proved. It also names the real problem in API and dashboard
+responses. Finally, repeated unchanged failures use a durable bounded retry
+schedule and park instead of generating a request every minute forever.
+
+The safety tradeoff is deliberate: the system may require an operator repair
+when identity cannot be proved, but it never guesses an email or accepts a
+credential without matching it to the intended account.
+
+## Original vs Converged
+
+The initial proposal required an email and added a simple retry counter. Review
+turned both into authority-bearing designs:
+
+- Caller-supplied email became a non-authoritative hint. A provider-specific
+  oracle proves the slot tenant, with credential-epoch comparison preventing a
+  credential swap between proof and commit.
+- The write boundary became a complete-record commit owned by one registrar;
+  generic pool mutation cannot create or clear identity.
+- Existing malformed records became an explicit legacy/quarantine state with a
+  bounded startup reconciliation barrier and a dedicated operator repair path.
+- Peer data became corroboration only. It can reveal conflict but cannot
+  substitute for local credential proof.
+- The retry counter became a pair-scoped persisted state machine with one
+  monotonic failure episode, semantic causal wakes, fixed-size evidence, and a
+  finite outer wake budget.
+- Exact API codes, messages, dashboard behavior, persistence ordering,
+  multi-machine posture, rollback, maturation metrics, and controller
+  registration tests were made explicit.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | security, architecture, lessons, decision completeness, Codex, Gemini | 13 | Replaced caller authority with oracle proof; defined legacy quarantine, honest errors, and bounded retry ownership. |
+| 2 | adversarial, scalability, multi-machine, Codex, Gemini | 9 | Added slot-epoch CAS, peer-conflict rules, persistence ordering, reconciliation barrier, and pair-scoped durable state. |
+| 3 | architecture, decision completeness, Codex, Gemini | 7 | Retired raw email mutation, added module-private complete commit, formal transitions, causal wakes, and controller convergence. |
+| 4 | adversarial, multi-machine, Codex, Gemini | 5 | Added authority expiry, evidence versions, outer wake cap, route classification, and repair action. |
+| 5 | Codex, Gemini, internal decision review | 3 | Defined canonical comparison, exact running/degraded responses, duplicate registration semantics, and provider-risk migration. |
+| 6 | Gemini | 0 | No behavior change. Three non-material maintainability/readability observations were catalogued. |
+
+## Full Findings Catalog
+
+### Identity authority and registration
+
+- **Critical — security/adversarial:** A supplied email could become identity
+  authority. **Resolution:** every path probes the provider oracle; supplied
+  email is only a match-required hint.
+- **Critical — architecture:** Generic `add`, `update`, or PATCH could bypass
+  the invariant. **Resolution:** raw email mutation is retired and an
+  oracle-owning registrar alone invokes the module-private complete commit.
+- **High — adversarial:** Credentials could change after proof but before
+  commit. **Resolution:** capture and CAS the credential ledger epoch, with one
+  bounded re-probe and fail-closed second change.
+- **High — multi-machine:** Peer consensus could launder stale or compromised
+  identity. **Resolution:** peers only corroborate; local credential binding
+  and oracle proof remain mandatory.
+- **Medium — architecture:** Email comparison semantics were ambiguous.
+  **Resolution:** one provider-scoped normalizer now defines display and
+  comparison behavior without claiming mailbox alias equivalence.
+- **Medium — compatibility:** Providers may later expose stable subjects.
+  **Resolution:** adapters may record a subject; once available it becomes
+  mandatory and existing email-only bindings require re-attestation.
+
+### Legacy repair and persistence
+
+- **High — compatibility:** Making the type required could hide malformed disk
+  records. **Resolution:** persisted legacy records form an explicit union;
+  complete accounts and `emailGaps` are separate read surfaces.
+- **High — operational:** Startup repair could block or race all service
+  traffic. **Resolution:** bounded concurrency and global deadlines apply;
+  reads remain available while identity mutations cross an explicit barrier.
+- **High — correctness:** Memory could advertise a repair that failed to
+  persist. **Resolution:** write-before-memory/replication and typed persistence
+  failures are required.
+- **Medium — UX:** An unresolved repair had no safe mobile action.
+  **Resolution:** a PIN-gated repair endpoint performs a fresh proof and the
+  dashboard exposes its reconciliation state.
+
+### Honest refusal surfaces
+
+- **High — UX/safety:** All identity-resolution failures collapsed into a
+  misleading generic 409. **Resolution:** missing, conflict, and not-found have
+  stable codes and exact actionable text on enroll-start and matrix surfaces.
+- **High — correctness:** First-peer-wins could conceal disagreement.
+  **Resolution:** every valid holder must unanimously agree before resolution.
+- **Medium — lifecycle:** A held login could be silently revived after repair.
+  **Resolution:** held flows stay held; repair requires a fresh correctly bound
+  sign-in.
+
+### Retry and controller behavior
+
+- **High — reliability:** The consumer retried the same refusal every minute
+  forever. **Resolution:** attempts use 1m/5m/15m then park durably.
+- **High — adversarial:** Alternating error classes or duplicate mandates could
+  reset counters. **Resolution:** one pair-scoped episode counter has a
+  monotonic lane and duplicate delivery cannot reset it.
+- **High — lifecycle:** Arbitrary state/file hash churn could wake a parked
+  episode. **Resolution:** identity wakes require a semantic unresolved-to-
+  unanimous transition; other wakes require a changed set of valid,
+  unexpired mandate IDs.
+- **High — boundedness:** New evidence could still wake forever.
+  **Resolution:** each evidence version wakes once and non-identity wakes have
+  a maximum of three per rolling 24 hours.
+- **Medium — architecture:** A parallel helper risked two retry authorities.
+  **Resolution:** one `FollowMeConsumerController` owns start/stop; the old
+  helper is removed or strictly delegated.
+
+### Final external observations
+
+- **Non-material — Gemini:** Single-writer ownership is a scaling dependency.
+  The spec already refuses multi-writer topology until a durable lease or
+  transaction exists and states the exact migration trigger; no present
+  behavior change was required.
+- **Non-material — Gemini:** A custom circuit-breaker adds maintenance cost.
+  The alternatives section already evaluates generic libraries and records why
+  domain-specific causal wakes and persisted pair evidence require a small
+  explicit state machine; the implementation remains bounded and testable.
+- **Non-material — Gemini:** Terminology is dense. The spec already opens with
+  a reader model, supplies an ELI16 companion and glossary, and includes a
+  concrete lifecycle example. No authority or acceptance criterion changed.
+
+## Convergence verdict
+
+Converged at iteration 6. The final round produced no material finding that
+required a spec change, and `Open questions` contains no unresolved operator
+decision. The spec is ready for approval and implementation.

--- a/docs/specs/subscription-account-email-invariant.eli16.md
+++ b/docs/specs/subscription-account-email-invariant.eli16.md
@@ -1,0 +1,63 @@
+# Subscription accounts must know their email
+
+## What broke
+
+One subscription account was saved without its email address. That looked like
+a small missing field, but the email is the safety label Instar uses to prove
+that a new sign-in belongs to the account the operator selected. Without it,
+Instar correctly refused to guess. Unfortunately, the surrounding experience
+was poor: the dashboard said only that some “details” could not be resolved, a
+background worker retried the same impossible request every minute for hours,
+and even a successful provider sign-in was held because there was no expected
+email to compare it with.
+
+The live incident was repaired by adding the real email to the account record.
+This change makes that repair unnecessary for future accounts and automatically
+repairs old records when their own saved login can prove the answer.
+
+## What changes
+
+New subscription accounts cannot be saved without a non-empty email. If a
+registration request includes one, Instar still checks it against the existing
+credential identity service; caller text is never the identity authority. When
+the service proves the same email, Instar saves it. When it cannot, or when the
+provider has no supported identity adapter, registration stops with a clear
+explanation instead of creating a record that will fail later.
+
+At startup, Instar performs a one-time, safe sweep over older records that are
+missing email. It asks the same identity service about each record’s own local
+credential slot and fills in only answers the service can prove. It never copies
+a credential, reads an email from the account nickname, or guesses from an
+account id. Records that cannot be proven remain unchanged.
+
+## What the operator sees
+
+When follow-me setup encounters an older account that still lacks email, the
+dashboard will say the real problem: “This account record is missing its email.
+Repair or re-enroll the account, then try again.” The API response carries a
+stable problem code so the dashboard does not have to guess what a generic 409
+means.
+
+The background follow-me worker also stops hammering. One broken
+account-and-machine pair gets at most four automatic attempts: after one minute,
+five minutes, and fifteen minutes, the fourth failure parks it completely.
+There is no forever-hourly retry. The parked state survives restart and covers
+all duplicate mandates for that pair, so four mandates do not multiply traffic.
+
+The worker wakes only for a real reason: account metadata changes to one proven
+email. Delivering an authorization—old or new—does not reset an unresolved
+identity fault. A successful attempt clears the episode.
+
+## Safety boundaries
+
+The important safety rule does not weaken: a follow-me sign-in is selectable
+only when its freshly authenticated email matches the operator-approved email.
+Missing identity still fails closed. The new code merely prevents malformed
+records, repairs provable legacy data, explains failures honestly, and puts a
+firm bound on automatic retries.
+
+Emails remain credential-free account metadata and already replicate through
+the existing subscription-account metadata channel. Actual provider
+credentials stay on the machine where the login lives. If this change must be
+rolled back, the code can be reverted without undoing provider-attested emails
+that were safely backfilled.

--- a/docs/specs/subscription-account-email-invariant.md
+++ b/docs/specs/subscription-account-email-invariant.md
@@ -1,0 +1,802 @@
+---
+title: "Subscription account email invariant and honest follow-me recovery"
+slug: "subscription-account-email-invariant"
+author: "Instar Agent (instar-codey)"
+parent-principle: "Capacity Safety — No Unbounded Self-Action"
+parent-principle-fit: "The incident combined a malformed identity record with an autonomous retry that could fire forever under an unchanged failure. Provider-attested email closes the malformed-record ingress; durable finite backoff proves the follow-me self-action converges under sustained failure."
+eli16-overview: "subscription-account-email-invariant.eli16.md"
+lessons-engaged: "P1,P2,P4,P7,P8,P10,P14,P19,P20,P21,B22,B28"
+review-convergence: "2026-07-24T00:54:26.533Z"
+review-iterations: 6
+review-completed-at: "2026-07-24T00:54:26.533Z"
+review-report: "docs/specs/reports/subscription-account-email-invariant-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 13
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+approved: true
+approved-by: "Echo (Slack C0BA4F4E0FP, 2026-07-23)"
+approval-basis: "Direct build authorization for this exact incident class: prevention/backfill, honest matrix and enroll-start surfaces, repeated-409 parking, and full instar-dev ceremony. Review convergence refined mechanisms without expanding the authorized outcome."
+---
+
+# Subscription account email invariant and honest follow-me recovery
+
+## Problem statement
+
+On 2026-07-23 a real subscription-pool record (`gearfinity3d`) existed with
+`email: null`. Follow-me enrollment deliberately fails closed when it cannot
+derive the operator-approved email, because accepting a freshly authenticated
+credential without an expected identity could enroll the wrong account.
+Consequently one malformed registry record blocked every correct path:
+
+- the account-machine matrix returned a generic 409 and rendered “details
+  couldn’t be resolved,” hiding the repair;
+- the delivered-mandate consumer retried the same 409 every minute across four
+  mandates for hours;
+- a correctly completed provider sign-in was held as
+  `missing-expected-email`, even though its credential was valid.
+
+The operator repaired production by adding the known email to the record. This
+spec makes that invariant structural, repairs resolvable legacy records, tells
+the operator the actual fault, and bounds repeated identical retries.
+
+## Reader model
+
+- **Follow-me** re-mints the same account login on another operator-owned
+  machine; credentials are never copied.
+- A **mandate** is PIN-approved, signed, expiring enrollment authority.
+- A **holder** is a machine reporting an account record.
+- A **slot tenant** is the provider identity currently authenticated in one
+  local config-home credential slot.
+- The **matrix start-cell** is the dashboard action for one account-machine
+  intersection.
+- HLC/record version and evidence hashes supply causal change without comparing
+  wall clocks across machines.
+
+## Goals
+
+1. Every newly registered `SubscriptionAccount` has a non-blank email.
+2. Registration resolves the slot tenant through a provider-specific identity
+   oracle even when the caller supplies an email. Caller email is a hint that
+   must canonically match the attested result, never identity authority.
+3. A one-shot startup sweep backfills existing email-less local records from
+   their own credential slots when resolvable, without copying credentials or
+   guessing identity.
+4. Follow-me 409 responses carry a stable machine-readable class and plain,
+   operator-actionable text naming the missing account-record email.
+5. The account-machine matrix displays that real fault and repair direction.
+6. The delivered-mandate consumer makes at most four autonomous attempts for
+   one unchanged failure episode, then parks durably.
+7. Only causal email-evidence repair wakes a parked identity-failure episode.
+   Duplicate/new delivery and alternating failure classes cannot reset it.
+
+## Non-goals
+
+- Replicating or transporting provider credentials between machines.
+- Inferring an email from account id, nickname, request body, or user prose.
+- Weakening the follow-me expected-email validation gate.
+- Automatically completing a held login whose expected identity was absent at
+  the time of validation. The operator starts a fresh correctly-bound flow.
+
+## Proposed design
+
+### 1. Structural registry invariant
+
+`SubscriptionAccount.email` becomes a required canonical string. The old
+public `AddAccountInput`/`SubscriptionPool.add()` identity-creation contract is
+retired. Callers use `RegistrarRegisterInput`, whose optional `email` is a hint,
+not authority. A module-private `CompleteAccountCommitInput` contains the
+registrar-verified email and is accepted only by
+`commitCompleteAccount()`. This final persistence boundary validates that the
+verified value is nonblank, structurally valid, control-free, and at most 254
+characters before any write.
+
+`SubscriptionPool.add()`, `SubscriptionPool.update()`, and the public PATCH
+route no longer accept raw email. One oracle-owning
+`SubscriptionAccountEmailRegistrar` performs verification and durable commit
+inside the same method call; it never exports a transferable attestation:
+
+```ts
+register(input, callerEmailHint?)
+repairLegacy(accountId)
+completeValidated(loginId, expectedEmail)
+refreshAfterCredentialWrite(accountId)
+```
+
+Each method resolves provider identity itself, applies the path-specific
+binding/match rules, then invokes the pool’s module-private complete-account
+commit closure. No queue, worker, serialized token, or cross-process boundary
+exists between proof and commit. Generic pool mutation cannot write identity.
+Before the oracle call, the registrar captures the credential-location
+ledger’s slot epoch/fingerprint. Immediately before commit it re-reads and
+CAS-compares that epoch. A changed slot discards the stale proof and re-probes
+once; a second change fails `credential-changed-during-proof`. A credential
+swap inside the 10-second oracle window therefore cannot bind stale identity.
+One `AgentServer` process owns pool writes by architecture. If Instar later
+supports multiple API writer processes, this registrar contract must first move
+the epoch/CAS and commit under a durable single-writer lease or database
+transaction; call-stack locality alone is not claimed safe in that topology.
+Startup refuses a configured multi-writer API topology unless that durable
+lease/transaction capability is present, and a wiring test ratchets the
+refusal. Module privacy is encapsulation, not the security authority; the
+single-writer invariant plus slot-epoch CAS is the authority.
+
+One normalizer is used by attested write, oracle output, peer conflict
+comparison, and completion validation: trim for stored display, derive a
+lowercase comparison key, reject ASCII controls, require one non-edge `@` with
+non-empty local/domain parts, and enforce the 254-character bound. Instar treats
+provider email as a provider-scoped account identifier, not universal RFC
+mailbox equivalence: Gmail dots/plus aliases and Unicode domains are not
+rewritten, and provider-returned casing is preserved for display.
+Throughout this spec, “canonical” means only this Instar
+`providerEmailComparisonKey`; it does not claim mailbox/provider
+canonicalization.
+Loading old on-disk version-1 records remains tolerant so reconciliation can
+repair them.
+
+### 2. Registration-time oracle backfill
+
+The direct `POST /subscription-pool` registration route becomes asynchronous,
+waits for its oracle result, and returns 201 or 400 (never 202). It uses:
+
+```ts
+interface SubscriptionIdentityOracle {
+  resolve(input: {
+    provider: SubscriptionProvider;
+    framework: SubscriptionFramework;
+    configHome: string;
+  }): Promise<
+    | { resolved: true; email: string; subject?: string }
+    | { resolved: false; code:
+        'unsupported-provider' | 'credential-unavailable' |
+        'profile-unavailable' | 'invalid-email' }
+  >;
+}
+```
+
+One provider registry wraps the shared underlying identity oracle. The existing
+`CredentialIdentityOracle.resolveSlotTenant(configHome)` is the
+Anthropic/Claude adapter; the credential ledger and enrollment wizard receive
+that same underlying instance. Providers without an installed identity adapter
+are refused with the stable
+`subscription-account-identity-provider-unsupported` code; the route never
+pretends the Anthropic profile endpoint can identify an OpenAI, Google, or
+Copilot slot.
+
+The oracle runs whether or not the caller supplied email. A supplied value is a
+non-authoritative hint and must canonically equal the attested email. Mismatch
+produces `subscription-account-email-mismatch` and no write. A usable attested
+result is committed inside `registrar.register()`; no raw resolved email
+reaches `SubscriptionPool.add()`. Unavailable or thrown oracle produces a 400:
+
+```json
+{
+  "error": "subscription account email could not be resolved from its credential; sign in to this account slot and try again",
+  "code": "subscription-account-email-unresolved"
+}
+```
+
+The request body never supplies identity authority to the oracle or follow-me
+gate. Validated enrollment completion calls
+`registrar.completeValidated()`, which performs the identity check and commit
+in one registrar-owned flow. Existing non-Anthropic enrollment flows use their own
+provider-specific oracle before registration; unsupported providers fail
+honestly instead of persisting an unverifiable identity.
+
+`subject` is an optional provider-stable account identifier. A complete record
+may store credential-free `identitySubject?: { provider, subject }` when an
+adapter supplies it, and later repairs must match it. Anthropic currently
+returns email only; future adapters must supply and compare subject when their
+API exposes one. Migration from email-only is additive on the first attested
+refresh.
+
+For Anthropic email-only identity, an attested email change on an already-known
+record is never silently migrated. It marks identity conflict/needs-reauth and
+requires operator re-enrollment; only a legacy-missing record may acquire its
+first email through repair. Background polling cannot rewrite expected
+identity after provider email change/reuse.
+
+Email-only identity is accepted for Anthropic solely because its current
+profile API exposes no stronger pool identity. Suspected provider email
+change/reuse moves the account to **Needs sign-in** with “The provider reports a
+different email for this account.” The operator uses the existing matrix
+**Sign in** action; the freshly authenticated email is held for explicit
+same-account re-enrollment and never auto-migrates continuity from the old
+email.
+
+Residual risk is explicit: email can be renamed, recycled, aliased, or shared
+across provider contexts. When Anthropic exposes a stable subject, the first
+subject-bearing refresh does not silently bind it to an email-only record; it
+requires explicit same-account re-enrollment, then persists the subject for all
+future comparisons.
+
+Provider-specific risk acceptance: if Anthropic recycles an email, email-only
+continuity could otherwise bind the pool label to a different provider account.
+The mismatch/needs-reauth/re-enrollment rules bound that risk. Stable subject
+support becomes mandatory once Anthropic exposes it, with the explicit
+re-enrollment migration above.
+
+The oracle retains its 10-second request bound. Timeout/unavailability writes
+nothing and returns the stable 400. Caller retry is appropriate only after a
+credential/login repair. If a client retries after an uncertain response, an
+exact duplicate (same id, provider, framework, configHome, and canonical
+attested email) returns the existing resource as a successful no-op; any
+disagreement is 409.
+Duplicate detection happens only after fresh attestation. If provider identity
+changed between attempts, the second request is 409/needs-reauth, not an
+idempotent replay.
+
+Compatibility: the direct registration route is currently used by API/manual
+callers and integration tests; the dashboard enrollment flow uses
+`POST /subscription-pool/enroll` plus completion, not this route. The direct
+route already returns synchronous 201/400 rather than 202, so only latency
+changes. The CLI/capability documentation and tests are updated to allow the
+10-second bound and the new stable error codes. Clients must tolerate a delayed
+201/400 up to that bound. Timeout is a 400 with no partial record; retry after
+credential repair returns either the created resource or the exact-duplicate
+successful no-op above.
+
+Provider capability matrix:
+
+| Provider/framework | Identity adapter | Stable subject | Admission posture |
+|---|---|---|---|
+| Anthropic / Claude Code | OAuth profile oracle | unavailable today | Email-only provider-scoped identity; explicit downgrade risk because no stronger provider field exists |
+| OpenAI / Codex | not implemented in this lane | unknown | Refuse registration |
+| Google / Gemini | not implemented in this lane | unknown | Refuse registration |
+| GitHub Copilot / pi | not implemented in this lane | unknown | Refuse registration |
+
+### 3. Bounded one-shot legacy reconciliation
+
+Add a dependency-injected `backfillSubscriptionAccountEmails()` helper:
+
+- enumerate local pool records whose email is absent/blank;
+- for each non-empty `configHome`, call the existing identity oracle;
+- on a candidate, call `registrar.repairLegacy(id)`, which re-resolves identity,
+  atomically persists, and emits the normal redacted metadata update; backfill
+  never receives a generic email-write seam;
+- on unavailable/throw, return a scrubbed enumerated reason class containing
+  account id only; never propagate or log raw oracle error messages, credential
+  responses, or tokens;
+- remain idempotent: a second run sees no candidate after successful repair.
+
+Server boot constructs one shared provider-dispatched oracle and attaches the
+metadata replication emitter before repair writes. The HTTP server does begin
+serving health, dashboard assets, and read routes immediately. Exactly these
+mutation routes await the initial barrier:
+
+- `POST /subscription-pool`
+- `POST /subscription-pool/:id/repair-email` (PIN-gated mobile repair)
+- `PATCH /subscription-pool/:id` with `email` is always refused; the dedicated
+  registrar repair operation is barrier-gated
+- `POST /subscription-pool/enroll/:id/complete`
+- `POST /subscription-pool/follow-me/enroll/:id/complete`
+- `POST /subscription-pool/follow-me/enroll/start`
+- `POST /subscription-pool/matrix/start-cell`
+
+They carry route capability tag `requiresEmailReconciliation:true` and return
+retryable 503
+`subscription-account-email-reconciliation-running` until the barrier settles.
+Middleware enforces the tag; integration inventory proves every identity
+mutation path is tagged, avoiding a second hand-maintained list. Classification
+is inverted: every `/subscription-pool` write defaults to
+identity-mutation/barrier-required unless explicitly registered
+`readOnlyOrNonIdentity:true`; an unclassified new write fails the inventory
+test. The
+delivered-mandate consumer awaits the same barrier.
+
+The barrier uses concurrency 3, preserves one bounded timeout per oracle call,
+and has a 30-second whole-sweep deadline. Deadline/unresolved records fail
+closed into the honest missing-email surface; server availability is not held
+hostage. It logs aggregate repaired/unresolved counts only.
+
+At deadline the global barrier settles as `degraded`, with each unfinished row
+materialized in `emailGaps` as `reconciliation-timeout`; mutation routes stop
+returning the global 503 and apply their normal per-record fail-closed contract.
+The PIN-gated repair route performs a fresh bounded oracle attempt—it does not
+merely replay the boot result—so a provider that recovers after the deadline is
+repairable immediately.
+
+Running response example:
+`503 { code:'subscription-account-email-reconciliation-running',
+retryable:true, emailReconciliation:{state:'running'} }`.
+After deadline, the same account returns
+`409 { code:'account-record-missing-email', repairRequired:true,
+emailReconciliation:{state:'degraded', repairRunsFreshProbe:true} }`.
+Dashboard and HTTP client tests assert this exact transition.
+
+`GET /subscription-pool` and the Subscriptions dashboard expose
+`emailReconciliation: { state:'running'|'degraded'|'complete',
+unresolvedCount, repairRunsFreshProbe:true }`. The dashboard explains the
+running 503 → degraded per-record 409 transition in plain language.
+
+The boot pass is genuinely one-shot and creates no recurring provider-call
+loop. Later repair runs only on a concrete new evidence epoch: a credential
+write or completed login for that exact configHome. An unchanged quota/identity
+poll does not call the oracle again.
+
+Runtime types remain honest:
+
+```ts
+type LegacyStoredSubscriptionAccount =
+  Omit<SubscriptionAccount, 'email'> & { email?: string | null };
+type SubscriptionAccount = /* normal fields */ & { email: string };
+type SubscriptionAccountRead =
+  | { emailState: 'known'; account: SubscriptionAccount }
+  | { emailState: 'legacy-missing'; account: LegacyStoredSubscriptionAccount };
+```
+
+The loader retains gaps in a quarantine collection exposed through
+`listEmailGaps()`. `GET /subscription-pool` keeps `accounts` as complete rows
+and adds `emailGaps: [{ emailState:'legacy-missing', id, nickname, provider,
+framework, status, machineId, machineNickname }]` with no configHome. Pool-scope
+aggregation merges that additive array. The matrix merges gap ids into account
+rows and renders the missing-email repair state. The resolver receives both
+complete accounts and gap ids, so it distinguishes missing-email from
+not-found. `locallyExecutable()`, selectors, enrollment authority, and
+replication writes use only complete accounts.
+
+Before repair, known `identityDrifted` rows are refused. The oracle proves the
+credential currently in the slot; independent account binding requires the
+local credential-location ledger to map that exact configHome to the same
+account id. Unanimous peer-holder email is corroboration/conflict detection
+only and can never substitute for local binding, so poisoned legacy replication
+cannot launder identity. Without local binding, repair returns
+`account-binding-unproven` and writes nothing. Email is sufficient for the
+currently supported Anthropic provider because its profile API exposes no
+separate stable subject used by the pool; a future adapter exposing a stable
+subject must include and compare it.
+
+The credential-location ledger is written only by provider-oracle audit and the
+credential-write funnel, with its own slot epoch and atomic store; it is not
+seeded from `SubscriptionPool.email`. A malformed legacy pool row therefore
+cannot create its own binding evidence. Repair reads the ledger mapping and
+CAS-checks its epoch around the profile probe.
+
+Repair is transactional: candidate state is written atomically before the
+in-memory store changes or metadata replication emits. Persistence failure
+throws a typed error, leaves memory/disk/replication unchanged, and reports the
+scrubbed `persistence-failed` result. This tightens the current `save()` path,
+which silently swallows write errors.
+
+During rolling upgrade an old writer may still emit malformed metadata. New
+readers preserve quarantined visibility but never use it as authority. Its
+owning machine repairs it on upgrade/start or a concrete credential-write
+epoch; another machine never probes a credential that is not physically local.
+
+### 4. Honest follow-me refusal
+
+`resolveFollowMeEnrollTarget()` gathers every matching local and peer holder
+record. Replicated metadata comes only from authenticated, registered
+same-operator pool peers, but remains low-impact reference data: it becomes
+usable as expected-identity evidence only when every nonblank holder email
+canonically agrees. It returns:
+
+- `account-record-missing-email` when the id is known but no matching holder
+  carries a valid email;
+- `account-record-email-conflict` when local/peer holders disagree;
+- `account-not-found` when no matching account exists;
+- a resolved target only for one canonical unanimous email.
+
+Input order never changes the verdict. Conflict is fail-closed and tells the
+operator to repair the disagreeing account records; last-writer-wins metadata
+is never silently promoted into enrollment authority.
+
+The enroll-start and matrix routes map the missing-email reason to:
+
+```json
+{
+  "error": "This subscription account record is missing its email. Repair or re-enroll the account, then try again.",
+  "code": "account-record-missing-email",
+  "repairRequired": true
+}
+```
+
+The matrix client renders the server message for this code:
+“This account record is missing its email. Repair or re-enroll the account,
+then try again.” It does not replace all 409s with generic text.
+
+“Repair” is a real mobile-complete action: the matrix/account card shows
+**Repair account identity**, asks for the dashboard PIN, and calls
+`POST /subscription-pool/:id/repair-email`. The PIN-gated, barrier-tagged route
+invokes `registrar.repairLegacy(id)`. Success is 200 with the complete account;
+unproven binding or unavailable identity is 409 with stable code/message;
+unsupported provider is 400. No email is typed into the form.
+
+The conflict class returns 409 `account-record-email-conflict` with “This
+account has conflicting emails on your machines. Repair or re-enroll the
+account records, then try again.” The not-found class returns 404
+`subscription-account-not-found` with “This subscription account is no longer
+registered.” Both carry `repairRequired:true`.
+
+### 5. Durable pair-scoped backoff
+
+Add a dedicated atomic `FollowMeConsumerBackoffStore`, keyed by
+`targetMachineId + accountId`, not mandate id:
+
+```ts
+{
+  key: string;
+  episodeLane: 'non-identity' | 'identity';
+  lastFailureClass: string;
+  consecutiveFailures: number;
+  lastAttemptAt: string;
+  nextAttemptAt: string | null;
+  breakerOpen: boolean;
+  breakerOpenedAt: string | null;
+  emailEvidenceKey: string;
+  authoritySetKey: string;
+  lastWakeEvidenceKey: string | null;
+  evidenceHashVersion: 1;
+  updatedAt: string;
+}
+```
+
+The store writes through temp-file + fsync + rename (using the repository’s
+established safe atomic-file primitive) and owns
+`recordConsumerFailure(pair, class)` and `clearOnSuccess(pair)`. One sweep
+groups all valid delivered mandates by pair, chooses the newest still-valid
+authorization as provenance for at most one attempt, and consults one shared
+backoff row. Four mandates for one broken pair therefore produce one attempt,
+not four.
+
+Every autonomous failure belongs to one finite pair episode. The episode starts
+`non-identity`; a missing/conflicting-email result monotonically promotes it to
+`identity`. It can never demote. Transport, service, and other classes update
+`lastFailureClass` but share the same counter and never reset it. This fixed
+shape preserves one breaker under arbitrary class alternation while selecting
+the stricter identity wake whenever identity has appeared. Delays are
+deterministic and bounded:
+
+| Consecutive failures | Next eligible attempt |
+|---:|---:|
+| 1 | 1 minute |
+| 2 | 5 minutes |
+| 3 | 15 minutes |
+| 4 | parked — no next timer |
+
+Ticks before `nextAttemptAt` skip the whole pair. A successful 201 clears retry
+metadata. After failure four, `breakerOpen:true` is durable and there is no
+timer edge: K=4 regardless of time horizon.
+
+Rows store fixed-size `emailEvidenceKey` and `authoritySetKey` hashes. A parked
+identity episode wakes only when email evidence changes and resolves unanimously.
+A non-identity episode wakes only when the target observes a changed set of
+signature-valid, unexpired mandate ids—causal authority measured locally, with
+no cross-machine timestamp comparison. Duplicate delivery leaves the set hash
+unchanged. A delayed but still-unexpired unseen authorization is valid and may
+wake one new finite non-identity episode; expired authority never does.
+
+On wake, the exact triggering hash is persisted as `lastWakeEvidenceKey` before
+the breaker clears. The same evidence version can open at most one
+post-breaker episode; another wake requires a distinct hash generation.
+
+Only PIN-originated operator mandates qualify for non-identity wake, and an
+outer pair cap permits at most three such post-breaker wakes per rolling 24
+hours. After the cap, even new mandates leave the breaker parked until the
+operator repairs the underlying account/service state; this bounds buggy
+upstream mandate production across episodes, not merely inside one episode.
+
+`emailEvidenceKey` hashes sorted tuples
+`(machineId, accountId, recordVersionOrHlc, emailState,
+canonicalComparisonKeyOrMissing)`. Local repair increments record version; a
+late peer observation changes holder set/HLC. Either causes a real transition
+even when the eventual canonical email text already exists elsewhere.
+
+Hash change alone never wakes identity. The controller persists the resolver
+verdict and wakes only on the semantic transition
+`missing|conflict -> unanimous-resolved` for that pair. Version/HLC churn while
+remaining missing, conflicting, or already resolved cannot re-arm it.
+
+A provider/profile outage is `non-identity`, not missing/conflicting identity.
+When repaired email wakes an identity episode and the subsequent provider call
+is temporarily unavailable, that outcome starts one new non-identity episode
+whose valid-authority-set wake applies; it cannot strand the repaired account
+behind an unchanged identity hash.
+
+Server restart, clock rollback, invalid/future timestamps, and alternating
+failure classes never make an attempt eligible earlier. Malformed timestamps
+fail closed as parked until lane-appropriate causal wake evidence exists. The route’s
+`repairRequired:true` is the operator contract; the controller’s bounded
+self-heal is separate from blind caller retry.
+
+Formal controller transitions:
+
+| Current | Event | Guard | Next | Action |
+|---|---|---|---|---|
+| absent | failure(class) | valid unexpired mandate | episode count 1, lane from class | persist; nextAttempt=+1m |
+| waiting count 1–2 | failure(class) | eligible time | count+1; promote lane to identity if needed | persist +5m/+15m |
+| waiting count 3 | failure(class) | eligible time | parked count 4 | persist breaker; no timer |
+| any open episode | 201 success | valid response | absent | atomically clear row |
+| parked identity | email evidence changed | now unanimous valid identity | absent | clear; next tick may start one new episode |
+| parked non-identity | authority-set hash changed | contains valid unexpired authority | absent | clear; next tick may start one new episode |
+| parked | duplicate/irrelevant evidence | hash unchanged or wrong wake class | parked | no call, no write |
+| waiting/parked | mandate expiry | no valid authority remains | unchanged but ineligible | no call |
+| any | malformed persisted time/hash version | validation failure | parked | canonical fail-closed rewrite |
+
+## Decision points touched
+
+| Decision | Classification | Justification / authority |
+|---|---|---|
+| Admit a new pool record without provider-attested canonical email | `invariant` | Email is a required identity field. The domain is enumerable: a supported oracle attests one canonical email or reject. |
+| Accept caller email / unsupported provider | `invariant` | Caller email is hint-only and must match attestation; a missing provider adapter refuses. |
+| Backfill from a credential slot | `invariant` | Durable non-drifted configHome binds candidate id; provider oracle attests current tenant; peer evidence, when present, must agree. |
+| Expose/select a legacy record | `invariant` | Discriminated legacy rows stay operator-visible but cannot enter complete-account selectors or enrollment authority. |
+| Commit and replicate repair | `invariant` | Durable atomic write succeeds before memory mutation or replication emission. |
+| Mutate an existing email | `invariant` | Generic update/PATCH cannot; only the oracle-owning registrar can mint an attestation recognized by the pool commit seam. |
+| Run reconciliation | `invariant` | One boot pass plus one run per concrete credential-write/login-completion evidence epoch; unchanged polls do nothing. |
+| Resolve multiple holder emails | `invariant` | Canonical unanimity is required; absence/conflict fails closed without order-dependent judgment. |
+| Permit follow-me enrollment | `invariant` | Existing expected-email safety authority remains fail-closed; this change improves reason classification only. |
+| Delay/park consumer failures | `invariant` | Fixed pair schedule, K=4 breaker, unexpired authority, and causal wake conditions are enumerable. |
+| What the operator sees | `invariant` | Stable server code selects a predefined truthful message; no message-intent judgment is involved. |
+| Introduce a new detector or authority | `invariant` | None is introduced: structural validation and bounded controller state feed the existing enrollment authority. |
+
+## Controller convergence argument
+
+Control-loop edge: an eligible account-machine pair with at least one valid
+delivered mandate triggers one enroll-start attempt. Any failure advances its
+named finite lane’s
+durable state monotonically through 1m, 5m, 15m, then parked.
+The controller cannot fire more than once per pair per stored `nextAttemptAt`,
+and its single-flight prevents overlap.
+Steady state has no firing edge after at most four attempts per broken pair,
+regardless of mandate count or failure-class alternation. Success clears the
+episode; lane-appropriate causal evidence opens one new finite episode.
+This behavior is covered by the repository’s self-action convergence ratchet
+and focused fake-clock tests.
+
+One extracted `FollowMeConsumerController` is the lifecycle owner for boot,
+tick, pair grouping, evidence observation, attempt, response classification,
+breaker/wake, and stop. It receives injected clock, backoff store, delivered
+mandates, peer/local evidence reader, and enroll driver. `AgentServer` only
+starts/stops it. The older inline
+`AgentServer.driveDeliveredFollowMeEnrollments()` is removed, and
+`runFollowMeConsumerSweep` delegates to this controller or is removed—there is
+never a parallel second owner.
+
+## Multi-machine posture
+
+- Account metadata, including email, is **replicated** through the existing
+  `subscription-account-meta` coherence-journal projection. Successful local
+  backfill emits the normal metadata update.
+- Credential probing is **machine-local BY DESIGN** because the credential
+  physically lives in that machine’s config-home slot.
+  `machine-local-justification: physical-credential-locality`
+- Consumer retry state is **machine-local BY DESIGN** on the target
+  that physically owns and drives the login.
+  `machine-local-justification: physical-credential-locality`
+- Operator wording is returned through the existing pool-scoped dashboard
+  proxy; no generated URLs are added.
+- No new user-facing notice source is added, so one-voice notification gating
+  is not applicable.
+
+## Security and privacy
+
+- The oracle is the only source allowed to backfill from a credential.
+- No token, credential blob, or raw provider response enters the registry,
+  response, logs, or retry metadata.
+- Request-supplied email is a hint only; provider attestation must match it.
+- Peer metadata must be canonically unanimous before it contributes
+  expected-identity evidence.
+- Missing identity always fails closed.
+- Retry metadata contains pair id, versioned email/authority evidence hashes,
+  lane/class, counts, and timestamps only. Scrubbed diagnostics expose holder
+  count, valid/invalid count, agreement boolean, source machine ids, hash
+  version, breaker state, and next-attempt time—never raw emails.
+
+## Compatibility and migration
+
+The on-disk pool schema remains version 1 with the explicit internal legacy
+union described above.
+No destructive rewrite occurs. Successful reconciliation repairs use the
+registrar’s attested commit and normal replication. Unresolvable legacy records remain readable but
+are not usable for follow-me until repaired, and all refusal surfaces say why.
+
+Mixed-version behavior is explicit: old writers may still create malformed
+records until upgraded; new readers preserve quarantined visibility but never
+use missing/conflicting email as identity authority. One-shot repair runs as
+each holder upgrades, without unsafe LWW identity selection.
+
+Existing tests and fixtures that construct pool accounts must provide emails,
+except fixtures explicitly exercising legacy-load migration.
+
+## Testing
+
+### Unit
+
+- registrar registration rejects absent/unavailable attestation, blank/malformed
+  provider email, and caller-hint mismatch.
+- the private complete-account commit rejects invalid verified input; generic
+  `SubscriptionPool.update()` has no email mutation surface.
+- legacy email-less JSON loads for repair.
+- canonical email validation covers case/whitespace, controls, oversize, and
+  malformed addresses;
+- backfill repairs resolvable records, skips complete records, records
+  unavailable outcomes, and is idempotent.
+- resolver distinguishes missing-email, conflict, and not-found; local/peer
+  order reversal produces the same result.
+- backoff store persists atomically, advances, clears only on success, and
+  survives restart.
+- fake-clock schedule reaches the parked K=4 steady-state bound, handles
+  invalid/future times and clock rollback, and never becomes eligible early.
+
+### Integration
+
+- direct registration with or without email requires oracle attestation;
+  mismatch/unavailable/unsupported provider writes nothing.
+- public PATCH with arbitrary email writes nothing; oracle
+  mismatch/unavailability writes nothing; registrar-attested correction
+  succeeds and replicates; generic update cannot mutate identity.
+- a repository invariant enumerates every `SubscriptionAccount.email` write
+  site and permits only registrar commit plus tolerant legacy load; any new
+  bypass/export/test-helper mutation fails CI.
+- enroll-start missing-email 409 includes exact code/message and
+  `repairRequired:true`.
+- matrix local and proxied 409s preserve the stable code and actionable text.
+- dashboard cell renders the server-classified missing-email message.
+- bounded initial reconciliation gates mutation/consumer paths without blocking
+  health/read serving and emits replicated updates.
+
+### Lifecycle / controller
+
+- four mandates for one pair produce one aggregate attempt per eligibility
+  window.
+- process restart retains `nextAttemptAt`.
+- successful drive clears the episode.
+- duplicate or fresh mandate delivery does not wake/reset an identity breaker;
+  a changed valid authority-set hash may wake one non-identity lane episode.
+- alternating failure classes do not reset it.
+- alternating identity↔transport results preserve one counter/breaker; identity
+  promotion is monotonic and only email evidence wakes the promoted episode.
+- repaired unanimous email evidence wakes exactly one new finite episode.
+- authority expiry prevents every attempt after the mandate door closes.
+- the controller is registered in `SELF_ACTION_CONTROLLERS` with durable
+  restart state, finite K, causal wake, and sustained-pressure ratchet coverage.
+- `tests/unit/self-action-convergence.test.ts` remains green.
+
+### Repository gates
+
+Run focused suites, affected smoke, full unit suite, typecheck, lint,
+repository invariants, docs coverage, and CI including e2e.
+
+## Acceptance criteria
+
+1. No public registration path can persist a new account without email.
+2. A valid supported-provider credential supplies the canonical email at
+   registration or during bounded reconciliation.
+3. Unresolvable identity causes no registry write and returns a named,
+   actionable fault.
+4. Follow-me completion never validates against an absent expected email.
+5. Repeated failures converge after at most four autonomous attempts per broken
+   account-machine pair and remain restart-safe.
+6. Repair evidence wakes one bounded episode without manual state-file editing.
+7. All existing security, replication, enrollment, dashboard, and
+   self-action-convergence tests remain green.
+
+## Rollback
+
+Revert the runtime change and ship the next patch. Backfilled emails are valid
+provider-attested metadata and need not be removed. The separate backoff file
+is ignored by older binaries and may remain, but an old consumer resumes
+once-per-minute retries and an old writer reopens malformed admission.
+Operational rollback therefore first disables account-follow-me consumer
+driving, rolls back, and only re-enables it after the fix is restored or all
+records are verified. No credential or irreversible external state is created
+by reconciliation.
+
+## Frontloaded Decisions
+
+| Decision | Chosen value | Authority | Reversibility |
+|---|---|---|---|
+| Development tier | Tier 2 | `instar-dev` risk floor plus agent judgment delegated by the operator | Process-only; no runtime effect |
+| Email normalization | Preserve trimmed provider-returned display; lowercase comparison key; controls, malformed shape, and >254 refused; no Gmail dot/plus or Unicode rewriting | Provider email is a provider-scoped identity string, not universal mailbox equivalence | Code revert; display value remains intact |
+| Provider/hint authority | Provider oracle attests; caller email is match-checked hint; unsupported provider refuses | Credential is the current identity authority | Add provider adapters later without schema change |
+| Existing-email mutation | Remove email from generic update/PATCH; one registrar owns oracle and opaque attestation writes | Prevent caller-controlled expected-identity poisoning | Registrar API can evolve; arbitrary string mutation remains forbidden |
+| Legacy representation | Internal optional-email union plus quarantined discriminated read; normal account type requires email | Type-safety and fail-closed selector invariant | Revert type split after fleet data is fully migrated |
+| Repair trigger | One boot pass plus a concrete credential-write/login-completion evidence epoch; never unchanged polling | Finite-action / physical credential locality | Disable trigger; provider-attested repairs remain valid |
+| Repair barrier | concurrency 3, per-call 10s, whole sweep 30s; enumerated mutation routes wait | Availability balanced against fail-closed identity admission | Config/code revert |
+| Persistence order | Atomic disk commit before memory mutation and replication | Durable-state integrity invariant | Revert possible but would reopen acknowledged data-loss class |
+| Holder conflicts | All valid canonical holder emails must agree | Low-impact peer metadata cannot be promoted by LWW/order | Conflict policy can be tightened, not silently weakened |
+| Error contracts | Exact missing/conflict/not-found status, code, and plain repair message | Mobile-complete honest operator surface | Additive response evolution possible |
+| Consumer control | Pair key; 1m/5m/15m then K=4 parked; no attempt after mandate expiry | P19 finite self-action convergence | Disable consumer or remove its state file after rollback |
+| Breaker wake | Identity lane: changed unanimous email evidence. Other lanes: changed target-observed valid authority-set hash. | Causal progress without cross-machine timestamp ordering | New wake evidence may be added only if equally causal and bounded |
+| Rollout | Default-on invariant for upgraded writers; mixed-version legacy reads quarantine | Operator’s requested structural prevention | Rollback sequence disables consumer first |
+
+## Lessons engaged
+
+- P1/P2: carry the real incident through durable evidence and make every
+  non-cheap decision before build.
+- P4/P7/P8: preserve the single provider identity authority, keep failure
+  states explicit, and test the real HTTP/dashboard path.
+- P10/P14: repair the class at the persistence boundary and keep multi-machine
+  metadata provenance/conflict explicit.
+- P19/P20/P21: finite controller convergence, evidence before action, and no
+  authority beyond mandate expiry.
+- B22: establish one controller lifecycle owner rather than parallel inline and
+  helper sweep paths.
+- B28: preserve honest pre-authorization/convergence posture; the spec remains
+  unapproved until its convergence report is complete and operator approval is
+  recorded.
+
+LLM supervision tier is 0: provider identity, canonical email admission,
+conflict refusal, persistence order, and retry convergence are closed
+deterministic invariants. An LLM must never become email identity authority.
+
+## Maturation plan
+
+- **test-agent-live:** unit/integration/fake-clock coverage plus a Tier-3 boot
+  test using a real temporary pool file, delayed oracle, route barrier, restart,
+  four mandates, controller stop, and dashboard rendering.
+- **dev-agent-live:** default-on for the development agent; capture aggregate
+  boot repair counts and scrubbed controller transitions, with no raw oracle
+  error or email in controller logs.
+- **fleet:** normal patch-train rollout after dev evidence; legacy reads remain
+  quarantined and repair is non-destructive.
+- **graduation criterion:** at least one real legacy repair or a clean zero-gap
+  boot, no repeated per-minute identity 409s, no selector seeing a legacy gap,
+  and no false conflict/provider-adapter mismatch.
+- **dark-window:** none — this load-bearing writer invariant is default-on;
+  fleet promotion waits for dev evidence and any failure holds fleet rollout.
+
+## Alternatives considered
+
+- **Placeholder email:** rejected because it defeats the identity safety gate
+  while merely satisfying field presence.
+- **Require the operator to type email:** rejected as sole authority because
+  the authenticated slot can attest its own identity and request input can be
+  stale or poisoned. Typed email remains a match-checked hint.
+- **Permanent mandate parking:** rejected because a repaired record should
+  recover without state-file surgery or another operator ceremony.
+- **Per-mandate backoff:** rejected because duplicate mandates multiply load for
+  one underlying account-machine fault.
+- **Generic job/workflow engine:** rejected because this is tiny-cardinality,
+  machine-local controller state and the repository already uses atomic
+  file-backed follow-me stores. A workflow engine adds migration/authority
+  surface without strengthening finite convergence.
+- **Generic idempotency/circuit-breaker primitive:** transport idempotency does
+  not model pair identity evidence or mandate expiry, while existing
+  in-process breakers do not survive restart. This controller uses the standard
+  finite-breaker pattern with an application-specific atomic state adapter and
+  still registers in the shared self-action ratchet.
+- **Small durable state-machine library:** no existing repository abstraction
+  combines mandate expiry, semantic identity evidence, restart persistence, and
+  pair aggregation. The extracted controller therefore uses a pure transition
+  reducer plus the atomic store; tests exercise the reducer table directly so
+  transition logic is not scattered through server callbacks.
+- **SQLite / durable KV:** rejected for this lane because account and delivered
+  mandate state already use repository-standard atomic JSON files, cardinality
+  is bounded by account-machine pairs, and introducing a second transactional
+  substrate would add schema migration and lock ownership. Temp+fsync+rename,
+  single-writer refusal, and epoch CAS provide the required atomicity here.
+
+## Glossary
+
+- **Follow-me:** re-minting the same subscription account login on another
+  operator-owned machine; credentials are never copied.
+- **Mandate:** PIN-approved, signed, expiring enrollment authority.
+- **Holder:** a machine reporting that it has an account record.
+- **Slot / slot tenant:** a local config-home credential location / the provider
+  identity currently authenticated there.
+- **Matrix start-cell:** the dashboard action that sets up one account on one
+  machine.
+- **Authority-set hash:** a fixed-size digest of currently valid delivered
+  mandate ids, used only as causal change evidence.
+
+## Concrete lifecycle example
+
+1. An old `gearfinity3d` row loads without email and appears in `emailGaps`;
+   selectors exclude it.
+2. Boot repair cannot prove local slot binding, so it writes nothing and the
+   matrix states that the record is missing email.
+3. Four delivered mandates for the pair aggregate into one attempt sequence
+   (1m, 5m, 15m, parked), never four requests per minute.
+4. The operator taps **Repair account identity**, enters the dashboard PIN, and
+   the registrar verifies ledger epoch → provider profile → unchanged epoch,
+   then atomically commits the first email and replicated metadata.
+5. Record version/HLC changes the email-evidence hash; the parked identity
+   episode wakes once, resolves one unanimous expected email, and starts the
+   correctly-bound sign-in.
+
+## Open questions
+
+*(none)*

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -13015,6 +13015,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     // compat); only UNKNOWN mode (corrupt on-disk) raises a HIGH attention item, never throws.
     const { CredentialLocationLedger, shouldBootSeedCredentialLedger, shouldRunIdentityAudit } = await import('../core/CredentialLocationLedger.js');
     const { CredentialIdentityOracle } = await import('../core/CredentialIdentityOracle.js');
+    const credentialIdentityOracle = new CredentialIdentityOracle();
     const { CredentialLocationGate } = await import('../core/CredentialLocationGate.js');
     const credentialGateEmitAttention = telegram
       ? (item: import('../core/CredentialLocationGate.js').CredentialGateAttentionInput) =>
@@ -13031,9 +13032,37 @@ export async function startServer(options: StartOptions): Promise<void> {
     const credentialLocationLedger = new CredentialLocationLedger({
       stateDir: config.stateDir,
       pool: subscriptionPool,
-      oracle: new CredentialIdentityOracle(),
+      oracle: credentialIdentityOracle,
       emitAttention: credentialGateEmitAttention,
     });
+    // One-shot legacy identity reconciliation. It reads only each record's own
+    // credential slot through the real provider oracle; unresolved gaps remain
+    // quarantined and visible instead of being guessed from metadata.
+    const { repairMissingSubscriptionEmails } = await import('../core/SubscriptionAccountEmailRepair.js');
+    const {
+      SubscriptionAccountEmailRegistrar,
+      SubscriptionEmailReconciliationBarrier,
+    } = await import('../core/SubscriptionPool.js');
+    const subscriptionEmailBarrier = new SubscriptionEmailReconciliationBarrier();
+    const subscriptionEmailRegistrar = new SubscriptionAccountEmailRegistrar(
+      subscriptionPool,
+      credentialIdentityOracle,
+      credentialLocationLedger,
+    );
+    const runSubscriptionEmailRepair = async (): Promise<void> => {
+      const emailRepair = await repairMissingSubscriptionEmails(
+        subscriptionPool,
+        credentialIdentityOracle,
+        credentialLocationLedger,
+      );
+      subscriptionEmailBarrier.finish(emailRepair.unresolved);
+      if (emailRepair.repaired.length > 0 || emailRepair.unresolved.length > 0) {
+        console.log(pc.yellow(
+          `  Subscription email reconciliation: ${emailRepair.repaired.length} repaired, ` +
+          `${emailRepair.unresolved.length} unresolved`,
+        ));
+      }
+    };
     // The §2.10 env-token gate (Step 8): the §0.b applicability precondition, enforced. Evaluates
     // BOTH `config.anthropicApiKey` (read LIVE per call — restartless) AND the live running fleet's
     // durable per-session `credentialSource` flag, so a mid-run flip to an env token cannot silently
@@ -13271,14 +13300,13 @@ export async function startServer(options: StartOptions): Promise<void> {
     // their respective awaits. isSeeded() does NOT protect this (seedFromOracle bumps version at
     // 'begin', so isSeeded() flips true mid-seed), so the audit gate also checks this flag.
     let credSeedInFlight = false;
-    if (
-      shouldBootSeedCredentialLedger(
-        resolveDevAgentGate(config.subscriptionPool?.credentialRepointing?.enabled, config),
-        credentialLocationLedger.isSeeded(),
-      )
-    ) {
+    const shouldSeedCredentialLedger = shouldBootSeedCredentialLedger(
+      resolveDevAgentGate(config.subscriptionPool?.credentialRepointing?.enabled, config),
+      credentialLocationLedger.isSeeded(),
+    );
+    const seedCredentialLedger = (): Promise<unknown> => {
       credSeedInFlight = true;
-      void credentialLocationLedger
+      return credentialLocationLedger
         .seedFromOracle()
         .then((outcomes) => {
           const assigned = outcomes.filter((o) => o.result === 'assigned').length;
@@ -13286,7 +13314,22 @@ export async function startServer(options: StartOptions): Promise<void> {
         })
         .catch((e) => console.warn(`[CredentialLedger] boot seed failed: ${e instanceof Error ? e.message : String(e)}`))
         .finally(() => { credSeedInFlight = false; });
-    }
+    };
+    // A legacy email gap must be repaired against an already-existing,
+    // independent slot→tenant binding. seedFromOracle derives its candidates
+    // from complete pool rows and clears assignments first, so running it before
+    // repair could erase the only proof for an email-less row. Preserve that
+    // evidence: seed only when there are no quarantined gaps.
+    let credentialSeedReady: Promise<unknown> =
+      shouldSeedCredentialLedger && subscriptionPool.listEmailGaps().length === 0
+        ? seedCredentialLedger()
+        : Promise.resolve();
+    void credentialSeedReady
+      .then(() => runSubscriptionEmailRepair())
+      .catch((error) => {
+        subscriptionEmailBarrier.finish(subscriptionPool.listEmailGaps().length);
+        console.warn(`[subscription-email] reconciliation degraded: ${error instanceof Error ? error.message : String(error)}`);
+      });
 
     // B3b — the periodic balancer pass. tick() is a strict no-op while the feature resolves dark
     // (so the timer can always run; the gate lives INSIDE tick()), and on a dev agent it runs the
@@ -13464,8 +13507,8 @@ export async function startServer(options: StartOptions): Promise<void> {
       // WS5.2 §5.3/S7 — the follow-me completion gate reads the minted login's account email
       // from its config-home slot (the Anthropic OAuth profile endpoint) and validates it against
       // operator expectation before the account is selectable. Same oracle the credential-location
-      // ledger uses; constructed fresh here (the ledger's instance is not in scope at this point).
-      oracle: new CredentialIdentityOracle(),
+      // ledger uses; one process-wide oracle keeps identity evidence coherent.
+      oracle: credentialIdentityOracle,
       // A HELD follow-me completion (surprise/mismatched/unverifiable email) raises a HIGH
       // attention item for the operator. Map the email-gate's {id,title,body,priority,source}
       // shape onto the telegram attention-queue createAttentionItem shape.
@@ -13545,12 +13588,12 @@ export async function startServer(options: StartOptions): Promise<void> {
             // Upsert (D5): a re-auth of an EXISTING pool account updates it back to
             // active; only a genuinely-new account is added (add() refuses dup ids).
             if (subscriptionPool.get(login.id)) {
-              subscriptionPool.update(login.id, {
-                nickname: login.label, status: 'active', email,
+              subscriptionEmailRegistrar.completeValidated(login.id, email, {
+                nickname: login.label, status: 'active',
                 ...(login.configHome ? { configHome: login.configHome } : {}),
               });
             } else {
-              subscriptionPool.add({
+              subscriptionEmailRegistrar.completeNewValidated({
                 id: login.id, nickname: login.label, provider: login.provider,
                 framework: login.framework, configHome: login.configHome ?? '', status: 'active', email,
               });
@@ -24088,7 +24131,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       }
     } catch (err) { /* @silent-fallback-ok: fleet-dark optional observer; failure is logged and adds no authority */ console.warn('[AutonomousThroughputFloor] init failed:', (err as Error).message); }
 
-    const server = new AgentServer({ config, sessionManager, llmQueue: sharedLlmQueue, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographer: cartographer ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, accountFollowMePeerViews: async () => { const nickById = new Map((_listPoolMachines?.() ?? []).map((m) => [m.machineId, m.nickname ?? m.machineId])); let peers = (_resolvePeerUrls?.() ?? []).map((p) => ({ machineId: p.machineId, nickname: nickById.get(p.machineId) ?? p.machineId, url: p.url })); if (peers.length === 0) { peers = (_listPoolMachines?.() ?? []).filter((m) => m.machineId !== _meshSelfId && !!m.lastKnownUrl).map((m) => ({ machineId: m.machineId, nickname: m.nickname ?? m.machineId, url: m.lastKnownUrl as string })); } if (peers.length === 0) return []; const { fetchPeerSubscriptionViews } = await import('../core/fetchPeerSubscriptionViews.js'); return fetchPeerSubscriptionViews({ peers: () => peers, fetchImpl: fetch as unknown as Parameters<typeof fetchPeerSubscriptionViews>[0]['fetchImpl'], authToken: config.authToken ?? '' }); }, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, accountFollowMeRevocation, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, meshBindActive: coordinator.managers.identityManager.hasIdentity() && config.multiMachine?.meshTransport?.enabled !== false, localSigningKeyPem, leaseTransport, peerEndpointRecorder, getSelfMeshEndpoints, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, conversationRegistry, conversationBindAuth, conversationFollowThrough, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, reviewCanaryBattery, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, ropeHealthMonitor, writeAdmission: writeAdmission ?? undefined, getInboundQueue: () => _inboundQueue, getMachineCoherence: () => _machineCoherenceSentinel, getSingleMachineFailoverGap: () => _singleMachineFailoverGap, getMissingLoginSession: () => _missingLoginSession, getSessionPoolFailoverRunner: () => _sessionPoolFailoverRunnerDriver?.status() ?? null, sessionPoolPromotionActivation: _sessionPoolPromotionActivation, meshRpcDispatcher, deliverA2aToMachine: _deliverA2aToMachine ?? undefined, workingSetPullCoordinator, workingSetArtifactManager, orchestratorPoller, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, sendDrain: _sendDrain ?? undefined, topicPinStore: _topicPinStore ?? undefined, topicPinSkewQuarantine: _topicPinSkewQuarantine ?? undefined, topicPinFoldView: _topicPinFoldView ?? undefined, ownershipReconciler: _ownershipReconciler ?? undefined, staleOwnerEngine: _staleOwnerEngine ?? undefined, duplicateReconciler: _duplicateReconciler ?? undefined, ownerDarkLadder: _ownerDarkLadder ?? undefined, spawnAdmission: _spawnAdmission ?? undefined, judgmentProvenance: _judgmentProvenance ?? undefined, leaseHandback: _leaseHandbackCtx ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, deliverMandateToMachine: _deliverMandateToMachine ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, externalHogSentinel, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, autonomousLivenessReconciler, enforcedTerminationStatus: () => enforcedTerminationWatchdog?.guardStatus() ?? null, prHandLease: prHandLease ?? undefined, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
+    const server = new AgentServer({ config, subscriptionEmailBinding: credentialLocationLedger, subscriptionEmailBarrier, subscriptionIdentityOracle: credentialIdentityOracle, sessionManager, llmQueue: sharedLlmQueue, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographer: cartographer ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, accountFollowMePeerViews: async () => { const nickById = new Map((_listPoolMachines?.() ?? []).map((m) => [m.machineId, m.nickname ?? m.machineId])); let peers = (_resolvePeerUrls?.() ?? []).map((p) => ({ machineId: p.machineId, nickname: nickById.get(p.machineId) ?? p.machineId, url: p.url })); if (peers.length === 0) { peers = (_listPoolMachines?.() ?? []).filter((m) => m.machineId !== _meshSelfId && !!m.lastKnownUrl).map((m) => ({ machineId: m.machineId, nickname: m.nickname ?? m.machineId, url: m.lastKnownUrl as string })); } if (peers.length === 0) return []; const { fetchPeerSubscriptionViews } = await import('../core/fetchPeerSubscriptionViews.js'); return fetchPeerSubscriptionViews({ peers: () => peers, fetchImpl: fetch as unknown as Parameters<typeof fetchPeerSubscriptionViews>[0]['fetchImpl'], authToken: config.authToken ?? '' }); }, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, accountFollowMeRevocation, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, meshBindActive: coordinator.managers.identityManager.hasIdentity() && config.multiMachine?.meshTransport?.enabled !== false, localSigningKeyPem, leaseTransport, peerEndpointRecorder, getSelfMeshEndpoints, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, conversationRegistry, conversationBindAuth, conversationFollowThrough, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, reviewCanaryBattery, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, ropeHealthMonitor, writeAdmission: writeAdmission ?? undefined, getInboundQueue: () => _inboundQueue, getMachineCoherence: () => _machineCoherenceSentinel, getSingleMachineFailoverGap: () => _singleMachineFailoverGap, getMissingLoginSession: () => _missingLoginSession, getSessionPoolFailoverRunner: () => _sessionPoolFailoverRunnerDriver?.status() ?? null, sessionPoolPromotionActivation: _sessionPoolPromotionActivation, meshRpcDispatcher, deliverA2aToMachine: _deliverA2aToMachine ?? undefined, workingSetPullCoordinator, workingSetArtifactManager, orchestratorPoller, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, sendDrain: _sendDrain ?? undefined, topicPinStore: _topicPinStore ?? undefined, topicPinSkewQuarantine: _topicPinSkewQuarantine ?? undefined, topicPinFoldView: _topicPinFoldView ?? undefined, ownershipReconciler: _ownershipReconciler ?? undefined, staleOwnerEngine: _staleOwnerEngine ?? undefined, duplicateReconciler: _duplicateReconciler ?? undefined, ownerDarkLadder: _ownerDarkLadder ?? undefined, spawnAdmission: _spawnAdmission ?? undefined, judgmentProvenance: _judgmentProvenance ?? undefined, leaseHandback: _leaseHandbackCtx ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, deliverMandateToMachine: _deliverMandateToMachine ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, externalHogSentinel, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, autonomousLivenessReconciler, enforcedTerminationStatus: () => enforcedTerminationWatchdog?.guardStatus() ?? null, prHandLease: prHandLease ?? undefined, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
     if (_stateSyncStoresResolved?.classReview?.enabled && replicatedPeerStreamReader) {
       const { CLASS_REVIEW_STORE_KEY, classReviewFromOriginRecord } = await import('../core/ClassReviewReplicatedStore.js');
       const reader = replicatedPeerStreamReader;

--- a/src/coordination/FollowMeConsumerBackoffStore.ts
+++ b/src/coordination/FollowMeConsumerBackoffStore.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type FollowMeFailureLane = 'identity' | 'other';
+
+export interface FollowMeBackoffRecord {
+  key: string;
+  attempts: number;
+  lane: FollowMeFailureLane;
+  failureCode: string | null;
+  identityEvidenceKey: string;
+  identityResolved: boolean;
+  authoritySetKey: string;
+  nextAttemptAt: string | null;
+  parkedAt: string | null;
+  updatedAt: string;
+}
+
+interface BackoffFile {
+  version: 1;
+  records: FollowMeBackoffRecord[];
+}
+
+const DELAYS_MS = [60_000, 5 * 60_000, 15 * 60_000] as const;
+
+/** Durable, pair-scoped finite retry authority for the delivered-mandate consumer. */
+export class FollowMeConsumerBackoffStore {
+  private readonly filePath: string;
+  private records = new Map<string, FollowMeBackoffRecord>();
+
+  constructor(stateDir: string) {
+    this.filePath = path.join(stateDir, 'follow-me-consumer-backoff.json');
+    this.load();
+  }
+
+  get(key: string): FollowMeBackoffRecord | null {
+    const value = this.records.get(key);
+    return value ? { ...value } : null;
+  }
+
+  shouldAttempt(
+    key: string,
+    now = Date.now(),
+    evidence?: { identityEvidenceKey: string; identityResolved: boolean; authoritySetKey: string },
+  ): boolean {
+    const value = this.records.get(key);
+    if (!value) return true;
+    const causalWake = evidence && (
+      value.lane === 'identity'
+        ? evidence.identityResolved && (
+            !value.identityResolved || value.identityEvidenceKey !== evidence.identityEvidenceKey
+          )
+        : value.authoritySetKey !== evidence.authoritySetKey
+    );
+    if (causalWake) {
+      this.records.delete(key);
+      this.save();
+      return true;
+    }
+    if (value.parkedAt) return false;
+    return value.nextAttemptAt === null || Date.parse(value.nextAttemptAt) <= now;
+  }
+
+  recordFailure(
+    key: string,
+    lane: FollowMeFailureLane,
+    now = Date.now(),
+    evidence: { identityEvidenceKey: string; identityResolved: boolean; authoritySetKey: string } = {
+      identityEvidenceKey: 'legacy', identityResolved: false, authoritySetKey: 'legacy',
+    },
+    failureCode?: string,
+  ): FollowMeBackoffRecord {
+    const previous = this.records.get(key);
+    const effectiveLane: FollowMeFailureLane =
+      previous?.lane === 'identity' || lane === 'identity' ? 'identity' : 'other';
+    const attempts = (previous?.attempts ?? 0) + 1;
+    const parked = attempts >= 4;
+    const value: FollowMeBackoffRecord = {
+      key,
+      attempts,
+      lane: effectiveLane,
+      failureCode: failureCode ?? null,
+      ...evidence,
+      nextAttemptAt: parked ? null : new Date(now + DELAYS_MS[attempts - 1]!).toISOString(),
+      parkedAt: parked ? new Date(now).toISOString() : null,
+      updatedAt: new Date(now).toISOString(),
+    };
+    this.records.set(key, value);
+    this.save();
+    return { ...value };
+  }
+
+  clear(key: string): void {
+    if (!this.records.delete(key)) return;
+    this.save();
+  }
+
+  private load(): void {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf8')) as BackoffFile;
+      if (parsed.version !== 1 || !Array.isArray(parsed.records)) return;
+      for (const value of parsed.records) {
+        if (!value?.key || !Number.isInteger(value.attempts) || value.attempts < 1) continue;
+        this.records.set(value.key, {
+          ...value,
+          failureCode: typeof value.failureCode === 'string' ? value.failureCode : null,
+          identityEvidenceKey: typeof value.identityEvidenceKey === 'string' ? value.identityEvidenceKey : 'legacy',
+          identityResolved: value.identityResolved === true,
+          authoritySetKey: typeof value.authoritySetKey === 'string' ? value.authoritySetKey : 'legacy',
+        });
+      }
+    } catch {
+      // Missing or malformed state fails toward a fresh bounded episode.
+    }
+  }
+
+  private save(): void {
+    const body: BackoffFile = { version: 1, records: [...this.records.values()] };
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    const tmp = `${this.filePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, `${JSON.stringify(body, null, 2)}\n`);
+    fs.renameSync(tmp, this.filePath);
+  }
+}
+
+export function followMeBackoffKey(accountId: string, targetMachineId: string): string {
+  return `${encodeURIComponent(accountId)}::${encodeURIComponent(targetMachineId)}`;
+}
+
+export function classifyFollowMeFailure(status: number, code?: string): FollowMeFailureLane {
+  if (
+    status === 409 &&
+    (code === 'account-record-missing-email' || code === 'account-record-email-conflict')
+  ) return 'identity';
+  return 'other';
+}

--- a/src/core/QuotaPoller.ts
+++ b/src/core/QuotaPoller.ts
@@ -595,19 +595,9 @@ export class QuotaPoller {
       const patch: Parameters<SubscriptionPool['update']>[1] = { lastQuota: snap };
       // A clean read on an account previously flagged needs-reauth restores it.
       if (account.status === 'needs-reauth') patch.status = 'active';
-      // Census #3: email auto-patch. When credential re-pointing is enabled the enrollment home
-      // no longer maps 1:1 to a tenant (a swap moves the credential), so reading the slot's
-      // `.claude.json` email and writing it onto this pool account would CROSS-CONTAMINATE pool
-      // emails and poison the recovery probe's email→account map. So while the gate is enabled the
-      // auto-patch is SUPPRESSED (the ledger + identity oracle own divergence detection now). With
-      // the gate absent/off this is byte-for-byte today's behavior.
-      if (account.framework === 'claude-code' && !this.locationGate?.isEnabled()) {
-        // Auto-populate the account email from the config home's own login record,
-        // so the stored email always reflects which account actually authenticated
-        // (a login into the wrong account surfaces here instead of hiding).
-        const email = readAccountEmail(account.configHome);
-        if (email && email !== account.email) patch.email = email;
-      }
+      // Email is provider-attested identity, not quota metadata. Quota polling
+      // must never mutate it; drift detection and the identity registrar own
+      // that authority.
       try {
         this.pool.update(attributedId, patch);
       } catch {

--- a/src/core/SubscriptionAccountEmailRepair.ts
+++ b/src/core/SubscriptionAccountEmailRepair.ts
@@ -1,0 +1,73 @@
+import type { IdentityOracle } from './CredentialLocationLedger.js';
+import {
+  SubscriptionAccountEmailRegistrar,
+  SubscriptionIdentityError,
+  type SubscriptionEmailBindingAuthority,
+  type SubscriptionPool,
+} from './SubscriptionPool.js';
+
+export interface SubscriptionEmailRepairResult {
+  scanned: number;
+  repaired: string[];
+  unresolved: Array<{ accountId: string; reason: string }>;
+}
+
+/**
+ * One-shot legacy repair. Identity comes only from the account's own credential
+ * slot; account ids, nicknames and peer metadata are never treated as proof.
+ */
+export async function repairMissingSubscriptionEmails(
+  pool: SubscriptionPool,
+  oracle: IdentityOracle,
+  binding: SubscriptionEmailBindingAuthority,
+  options: { concurrency?: number; timeoutMs?: number } = {},
+): Promise<SubscriptionEmailRepairResult> {
+  const missing = pool.listEmailGaps();
+  const result: SubscriptionEmailRepairResult = { scanned: missing.length, repaired: [], unresolved: [] };
+  const registrar = new SubscriptionAccountEmailRegistrar(pool, oracle, binding);
+  const deadline = Date.now() + (options.timeoutMs ?? 30_000);
+  let cursor = 0;
+  let acceptingResults = true;
+  const resolved = new Set<string>();
+  const worker = async (): Promise<void> => {
+    while (cursor < missing.length && Date.now() < deadline) {
+      const account = missing[cursor++]!;
+      if (account.identityDrifted) {
+        result.unresolved.push({ accountId: account.accountId, reason: 'identity-drifted' });
+        resolved.add(account.accountId);
+        continue;
+      }
+      try {
+        await registrar.repairLegacy(account.accountId, { canCommit: () => Date.now() < deadline });
+        if (acceptingResults) result.repaired.push(account.accountId);
+      } catch (error) {
+        if (acceptingResults) result.unresolved.push({
+          accountId: account.accountId,
+          reason: error instanceof SubscriptionIdentityError
+            ? error.code
+            : 'identity-oracle-unavailable',
+        });
+      } finally {
+        resolved.add(account.accountId);
+      }
+    }
+  };
+  const workers = Promise.all(Array.from(
+    { length: Math.min(Math.max(1, options.concurrency ?? 3), missing.length) },
+    () => worker(),
+  ));
+  const remainingMs = Math.max(0, deadline - Date.now());
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  await Promise.race([
+    workers,
+    new Promise<void>((resolve) => { timer = setTimeout(resolve, remainingMs); }),
+  ]);
+  if (timer) clearTimeout(timer);
+  acceptingResults = false;
+  for (const account of missing) {
+    if (!resolved.has(account.accountId) && !result.unresolved.some((row) => row.accountId === account.accountId)) {
+      result.unresolved.push({ accountId: account.accountId, reason: 'reconciliation-timeout' });
+    }
+  }
+  return result;
+}

--- a/src/core/SubscriptionPool.ts
+++ b/src/core/SubscriptionPool.ts
@@ -39,6 +39,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { ComponentHealth } from './types.js';
 import type { SubscriptionAccountMetaReplicationEmitter } from './SubscriptionAccountMetaReplicatedStore.js';
+import type { IdentityOracle } from './CredentialLocationLedger.js';
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -104,7 +105,7 @@ export interface SubscriptionAccount {
    *  "SageMind - Justin" vs "SageMind - Adriana"). Auto-populated from the
    *  account's own login (oauthAccount.emailAddress) on poll, so the stored email
    *  always reflects which account actually authenticated. NEVER a secret. */
-  email?: string;
+  email: string;
   /** Billing provider. */
   provider: SubscriptionProvider;
   /** Framework client that drives this account. */
@@ -185,13 +186,59 @@ export function isLocallyExecutable(a: SubscriptionAccount): boolean {
 
 interface SubscriptionPoolStore {
   version: 1;
-  accounts: SubscriptionAccount[];
+  accounts: StoredSubscriptionAccount[];
   lastModified: string;
+}
+
+type StoredSubscriptionAccount = Omit<SubscriptionAccount, 'email'> & { email?: string };
+
+export interface SubscriptionAccountEmailGap {
+  accountId: string;
+  nickname: string;
+  provider: SubscriptionProvider;
+  framework: SubscriptionFramework;
+  configHome: string;
+  status: SubscriptionAccountStatus;
+  identityDrifted: boolean;
 }
 
 export interface SubscriptionPoolConfig {
   /** Agent stateDir (e.g. `.instar`). The store lives at <stateDir>/subscription-pool.json. */
   stateDir: string;
+}
+
+export interface SubscriptionEmailBindingAuthority {
+  tenantOf(slot: string): string | null;
+  readonly version: number;
+}
+
+export class SubscriptionEmailReconciliationBarrier {
+  private phase: 'running' | 'complete' | 'degraded' = 'running';
+  private unresolved = 0;
+  private readonly timedOut = new Set<string>();
+  status(): 'running' | 'complete' | 'degraded' { return this.phase; }
+  finish(unresolved: number | Array<{ accountId: string; reason: string }>): void {
+    const rows = typeof unresolved === 'number' ? null : unresolved;
+    this.unresolved = rows?.length ?? unresolved as number;
+    this.timedOut.clear();
+    for (const row of rows ?? []) {
+      if (row.reason === 'reconciliation-timeout') this.timedOut.add(row.accountId);
+    }
+    this.phase = this.unresolved > 0 ? 'degraded' : 'complete';
+  }
+  isBlocking(): boolean { return this.phase === 'running'; }
+  timedOutAccount(accountId: string): boolean { return this.timedOut.has(accountId); }
+  snapshot(): {
+    state: 'running' | 'complete' | 'degraded';
+    unresolvedCount: number;
+    repairRunsFreshProbe: true;
+  } {
+    return {
+      state: this.phase,
+      unresolvedCount: this.unresolved,
+      repairRunsFreshProbe: true,
+    };
+  }
 }
 
 export interface AddAccountInput {
@@ -201,8 +248,8 @@ export interface AddAccountInput {
   framework: SubscriptionFramework;
   configHome: string;
   status?: SubscriptionAccountStatus;
-  /** Optional at add time; auto-populated from the account's login on poll. */
-  email?: string;
+  /** Provider-attested identity. Registration callers cannot omit it. */
+  email: string;
 }
 
 /** Fields an operator may patch. id/provider/enrolledAt/version are immutable here. */
@@ -214,7 +261,6 @@ export interface UpdateAccountInput {
   lastQuota?: AccountQuotaSnapshot | null;
   lastUsedAt?: string;
   lastRefreshAt?: string;
-  email?: string;
   identityDrifted?: boolean;
   identityDrift?: SubscriptionAccount['identityDrift'] | null;
 }
@@ -239,6 +285,25 @@ const STATUSES: readonly SubscriptionAccountStatus[] = [
   'needs-reauth',
   'disabled',
 ];
+const VERIFIED_EMAIL_COMMIT = Symbol('verified-email-commit');
+const VERIFIED_ACCOUNT_ADD = Symbol('verified-account-add');
+
+/** Provider-scoped identity comparison; intentionally does not rewrite aliases. */
+export function normalizeSubscriptionEmail(value: unknown): { display: string; key: string } {
+  if (typeof value !== 'string') throw new ValidationError('email is required');
+  const display = value.trim();
+  if (
+    !display ||
+    display.length > 254 ||
+    /[\x00-\x1f\x7f]/.test(display) ||
+    display.startsWith('@') ||
+    display.endsWith('@') ||
+    display.split('@').length !== 2
+  ) {
+    throw new ValidationError('email must be a valid non-blank provider account email');
+  }
+  return { display, key: display.toLowerCase() };
+}
 
 /**
  * Field names that would smuggle a credential into the registry. Rejected at
@@ -291,13 +356,30 @@ export class SubscriptionPool {
 
   /** All accounts (a shallow copy — callers can't mutate the store). */
   list(): SubscriptionAccount[] {
-    return this.store.accounts.map((a) => ({ ...a }));
+    return this.store.accounts
+      .filter((a): a is SubscriptionAccount => typeof a.email === 'string' && a.email.trim().length > 0)
+      .map((a) => ({ ...a }));
+  }
+
+  /** Legacy rows are visible for repair, but never enter normal selectors. */
+  listEmailGaps(): SubscriptionAccountEmailGap[] {
+    return this.store.accounts
+      .filter((a) => !a.email?.trim())
+      .map((a) => ({
+        accountId: a.id,
+        nickname: a.nickname,
+        provider: a.provider,
+        framework: a.framework,
+        configHome: a.configHome,
+        status: a.status,
+        identityDrifted: a.identityDrifted === true,
+      }));
   }
 
   /** One account by id, or null. */
   get(id: string): SubscriptionAccount | null {
     const found = this.store.accounts.find((a) => a.id === id);
-    return found ? { ...found } : null;
+    return found?.email?.trim() ? { ...found, email: found.email } : null;
   }
 
   /**
@@ -306,12 +388,12 @@ export class SubscriptionPool {
    * every swap/placement path; a credential-less meta projection is excluded.
    */
   locallyExecutable(): SubscriptionAccount[] {
-    return this.store.accounts.filter(isLocallyExecutable).map((a) => ({ ...a }));
+    return this.list().filter(isLocallyExecutable);
   }
 
   /** Count of accounts. A pool of 0 is the dark/no-op default. */
   size(): number {
-    return this.store.accounts.length;
+    return this.list().length;
   }
 
   // ── Writes ───────────────────────────────────────────────────────
@@ -321,7 +403,7 @@ export class SubscriptionPool {
    * `rawExtra` (if provided) is scanned for credential-bearing field names and
    * rejected — the registry never stores tokens.
    */
-  add(input: AddAccountInput, rawExtra?: Record<string, unknown>): SubscriptionAccount {
+  [VERIFIED_ACCOUNT_ADD](input: AddAccountInput, rawExtra?: Record<string, unknown>): SubscriptionAccount {
     this.assertNoCredentialFields(input as unknown as Record<string, unknown>);
     if (rawExtra) this.assertNoCredentialFields(rawExtra);
 
@@ -348,10 +430,11 @@ export class SubscriptionPool {
       throw new ValidationError(`status must be one of: ${STATUSES.join(', ')}`);
     }
 
+    const email = normalizeSubscriptionEmail(input.email).display;
     const account: SubscriptionAccount = {
       id,
       nickname,
-      ...(input.email?.trim() ? { email: input.email.trim() } : {}),
+      email,
       provider: input.provider,
       framework: input.framework,
       configHome,
@@ -360,10 +443,56 @@ export class SubscriptionPool {
       enrolledAt: new Date().toISOString(),
       version: 1,
     };
-    this.store.accounts.push(account);
-    this.save();
+    const next = this.cloneStore();
+    next.accounts.push(account);
+    this.persist(next);
+    this.store = next;
     this.metaReplication?.emitPut(account);
     return { ...account };
+  }
+
+  /** Test-only fixture seam. Production identity admission is symbol-gated. */
+  addFixture(input: AddAccountInput, rawExtra?: Record<string, unknown>): SubscriptionAccount {
+    if (process.env.NODE_ENV !== 'test') {
+      throw new ValidationError('addFixture is available only in the test environment');
+    }
+    return this[VERIFIED_ACCOUNT_ADD](input, rawExtra);
+  }
+
+  /**
+   * Identity-authority commit seam. Only SubscriptionAccountEmailRegistrar,
+   * defined in this module, possesses the symbol needed to call it.
+   */
+  [VERIFIED_EMAIL_COMMIT](
+    id: string,
+    email: string,
+    patch?: Pick<UpdateAccountInput, 'nickname' | 'configHome' | 'status'>,
+  ): SubscriptionAccount | null {
+    const next = this.cloneStore();
+    const acct = next.accounts.find((candidate) => candidate.id === id);
+    if (!acct) return null;
+    acct.email = normalizeSubscriptionEmail(email).display;
+    if (patch?.nickname !== undefined) {
+      const nickname = patch.nickname.trim();
+      if (!nickname) throw new ValidationError('nickname cannot be empty');
+      acct.nickname = nickname;
+    }
+    if (patch?.configHome !== undefined) {
+      const configHome = patch.configHome.trim();
+      if (!configHome) throw new ValidationError('configHome cannot be empty');
+      acct.configHome = configHome;
+    }
+    if (patch?.status !== undefined) {
+      if (!STATUSES.includes(patch.status)) {
+        throw new ValidationError(`status must be one of: ${STATUSES.join(', ')}`);
+      }
+      acct.status = patch.status;
+    }
+    acct.version += 1;
+    this.persist(next);
+    this.store = next;
+    this.metaReplication?.emitPut(acct as SubscriptionAccount);
+    return { ...acct } as SubscriptionAccount;
   }
 
   /**
@@ -375,7 +504,10 @@ export class SubscriptionPool {
     this.assertNoCredentialFields(patch as unknown as Record<string, unknown>);
     if (rawExtra) this.assertNoCredentialFields(rawExtra);
 
-    const acct = this.store.accounts.find((a) => a.id === id);
+    const existing = this.store.accounts.find((a) => a.id === id);
+    if (!existing?.email?.trim()) return null;
+    const next = this.cloneStore();
+    const acct = next.accounts.find((a) => a.id === id)!;
     if (!acct) return null;
 
     if (patch.nickname !== undefined) {
@@ -409,10 +541,6 @@ export class SubscriptionPool {
     if (patch.lastRefreshAt !== undefined) {
       acct.lastRefreshAt = patch.lastRefreshAt;
     }
-    if (patch.email !== undefined) {
-      const em = patch.email.trim();
-      acct.email = em || undefined;
-    }
     if (patch.identityDrifted !== undefined) {
       acct.identityDrifted = patch.identityDrifted;
     }
@@ -422,19 +550,22 @@ export class SubscriptionPool {
     }
 
     acct.version += 1;
-    this.save();
+    this.persist(next);
+    this.store = next;
     // Re-emit on any mutation — a peer must SEE a status/quota change (§6.1a holder stream).
-    this.metaReplication?.emitPut(acct);
-    return { ...acct };
+    this.metaReplication?.emitPut(acct as SubscriptionAccount);
+    return { ...acct } as SubscriptionAccount;
   }
 
   /** Remove an account. Returns true if one was removed. */
   remove(id: string): boolean {
-    const before = this.store.accounts.length;
-    this.store.accounts = this.store.accounts.filter((a) => a.id !== id);
-    const removed = this.store.accounts.length < before;
+    const next = this.cloneStore();
+    const before = next.accounts.length;
+    next.accounts = next.accounts.filter((a) => a.id !== id);
+    const removed = next.accounts.length < before;
     if (removed) {
-      this.save();
+      this.persist(next);
+      this.store = next;
       this.metaReplication?.emitDelete(id, new Date().toISOString());
     }
     return removed;
@@ -487,17 +618,130 @@ export class SubscriptionPool {
     return { version: 1, accounts: [], lastModified: new Date().toISOString() };
   }
 
-  private save(): void {
-    this.store.lastModified = new Date().toISOString();
-    try {
-      const dir = path.dirname(this.storePath);
-      fs.mkdirSync(dir, { recursive: true });
-      const tmpPath = `${this.storePath}.${process.pid}.tmp`;
-      fs.writeFileSync(tmpPath, JSON.stringify(this.store, null, 2) + '\n');
-      fs.renameSync(tmpPath, this.storePath);
-    } catch {
-      // @silent-fallback-ok — state persistence failure; the in-memory store
-      // remains authoritative for this process and the next write retries.
+  private cloneStore(): SubscriptionPoolStore {
+    return structuredClone(this.store);
+  }
+
+  private persist(next: SubscriptionPoolStore): void {
+    next.lastModified = new Date().toISOString();
+    const dir = path.dirname(this.storePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpPath = `${this.storePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(next, null, 2) + '\n');
+    fs.renameSync(tmpPath, this.storePath);
+  }
+}
+
+/**
+ * The sole authority that turns credential identity evidence into a pool email.
+ * Generic pool mutation deliberately cannot create, replace, or repair identity.
+ */
+export class SubscriptionAccountEmailRegistrar {
+  constructor(
+    private readonly pool: SubscriptionPool,
+    private readonly oracle: IdentityOracle,
+    private readonly binding?: SubscriptionEmailBindingAuthority,
+  ) {}
+
+  async register(
+    input: Omit<AddAccountInput, 'email'> & { email?: string },
+    rawExtra?: Record<string, unknown>,
+  ): Promise<SubscriptionAccount> {
+    const identity = await this.oracle.resolveSlotTenant(input.configHome);
+    if (identity.unavailable || !identity.email) {
+      throw new SubscriptionIdentityError(
+        'subscription-account-email-unresolved',
+        'The credential slot identity could not be verified. Sign in to that slot, then try again.',
+      );
     }
+    const attested = normalizeSubscriptionEmail(identity.email);
+    if (input.email !== undefined && normalizeSubscriptionEmail(input.email).key !== attested.key) {
+      throw new SubscriptionIdentityError(
+        'subscription-account-email-mismatch',
+        'The supplied email does not match the account signed in at this credential slot.',
+      );
+    }
+    return this.pool[VERIFIED_ACCOUNT_ADD]({ ...input, email: attested.display }, rawExtra);
+  }
+
+  completeNewValidated(input: AddAccountInput): SubscriptionAccount {
+    return this.pool[VERIFIED_ACCOUNT_ADD](input);
+  }
+
+  async repairLegacy(
+    accountId: string,
+    options: { canCommit?: () => boolean } = {},
+  ): Promise<SubscriptionAccount> {
+    const gap = this.pool.listEmailGaps().find((candidate) => candidate.accountId === accountId);
+    if (!gap) {
+      throw new SubscriptionIdentityError(
+        'subscription-account-not-found',
+        `Subscription account "${accountId}" has no repairable email gap.`,
+      );
+    }
+    if (gap.identityDrifted) {
+      throw new SubscriptionIdentityError(
+        'identity-drifted',
+        `Subscription account "${accountId}" is identity-drifted and cannot be repaired automatically.`,
+      );
+    }
+    if (gap.provider !== 'anthropic' || gap.framework !== 'claude-code') {
+      throw new SubscriptionIdentityError(
+        'subscription-account-identity-provider-unsupported',
+        `Provider identity verification is not supported for ${gap.provider}/${gap.framework}.`,
+      );
+    }
+    const epoch = this.binding?.version;
+    if (!this.binding || this.binding.tenantOf(gap.configHome) !== accountId) {
+      throw new SubscriptionIdentityError(
+        'account-binding-unproven',
+        `Subscription account "${accountId}" is not bound to its credential slot.`,
+      );
+    }
+    const identity = await this.oracle.resolveSlotTenant(gap.configHome);
+    if (identity.unavailable || !identity.email) {
+      throw new SubscriptionIdentityError(
+        'identity-oracle-unavailable',
+        'The credential slot identity could not be verified.',
+      );
+    }
+    if (this.binding.version !== epoch || this.binding.tenantOf(gap.configHome) !== accountId) {
+      throw new SubscriptionIdentityError(
+        'account-binding-changed',
+        `Subscription account "${accountId}" changed credential binding during repair.`,
+      );
+    }
+    if (options.canCommit && !options.canCommit()) {
+      throw new SubscriptionIdentityError(
+        'reconciliation-timeout',
+        `Subscription account "${accountId}" was not repaired before the reconciliation deadline.`,
+      );
+    }
+    return this.pool[VERIFIED_EMAIL_COMMIT](accountId, identity.email)!;
+  }
+
+  /**
+   * A completed enrollment has already passed EnrollmentWizard's expected-email
+   * validation, so its provider-returned email is credential-attested evidence.
+   */
+  completeValidated(
+    accountId: string,
+    email: string,
+    patch: Pick<UpdateAccountInput, 'nickname' | 'configHome' | 'status'>,
+  ): SubscriptionAccount | null {
+    return this.pool[VERIFIED_EMAIL_COMMIT](accountId, email, patch);
+  }
+}
+
+export class SubscriptionIdentityError extends Error {
+  constructor(
+    readonly code: 'subscription-account-email-unresolved' | 'subscription-account-email-mismatch' |
+      'identity-oracle-unavailable' | 'subscription-account-not-found' | 'identity-drifted' |
+      'account-binding-unproven' | 'account-binding-changed' |
+      'subscription-account-identity-provider-unsupported' | 'reconciliation-timeout',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SubscriptionIdentityError';
   }
 }

--- a/src/core/WriteDomainRegistry.ts
+++ b/src/core/WriteDomainRegistry.ts
@@ -366,6 +366,10 @@ export function buildWriteDomainRegistry(opts: { machineId: string | null }): Wr
     kind: 'route', method: 'POST', pathPrefix: '/subscription-pool/enroll/',
     domain: 'machine-local', story: enrollmentStory,
   });
+  reg.add({
+    kind: 'route', method: 'POST', pathPrefix: '/subscription-pool/:id/repair-email',
+    domain: 'machine-local', story: enrollmentStory,
+  });
 
   // Credential identity repair executes staged swaps only among login homes on
   // this machine. Claude credentials cannot be relocated across machines; the

--- a/src/core/resolveFollowMeEnrollTarget.ts
+++ b/src/core/resolveFollowMeEnrollTarget.ts
@@ -44,7 +44,11 @@ export type ResolveFollowMeEnrollTargetResult =
       /** Operator-facing label for the new pending login. */
       label: string;
     }
-  | { resolved: false; reason: string };
+  | {
+      resolved: false;
+      code: 'account-record-missing-email' | 'account-record-email-conflict' | 'subscription-account-not-found';
+      reason: string;
+    };
 
 /**
  * Resolve the approved email + provider/framework + label for `accountId`.
@@ -61,35 +65,54 @@ export function resolveFollowMeEnrollTarget(
   const defaultProvider = input.defaultProvider ?? 'anthropic';
   const defaultFramework = input.defaultFramework ?? 'claude-code';
 
-  // 1) Local pool — most authoritative when present.
+  const candidates: Array<{ email: string; source: 'local' | 'peer'; row: LocalAccountRow }> = [];
+
+  // Local and peer metadata are holder evidence. Resolution requires agreement:
+  // first-holder-wins can silently target the wrong provider account.
   const local = input.localAccounts.find((a) => a.id === accountId);
   if (local && typeof local.email === 'string' && local.email.trim().length > 0) {
-    return {
-      resolved: true,
-      expectedEmail: local.email.trim(),
-      provider: (local.provider && local.provider.length > 0) ? local.provider : defaultProvider,
-      framework: (local.framework && local.framework.length > 0) ? local.framework : defaultFramework,
-      label: (local.nickname && local.nickname.trim().length > 0) ? local.nickname.trim() : accountId,
-    };
+    candidates.push({ email: local.email.trim(), source: 'local', row: local });
   }
 
-  // 2) Peer views — the replicated meta projection (carries id + email).
+  let found = !!local;
   for (const view of input.peerViews) {
     for (const row of view.accounts) {
       if (row.accountId !== accountId) continue;
+      found = true;
       if (typeof row.email === 'string' && row.email.trim().length > 0) {
-        return {
-          resolved: true,
-          expectedEmail: row.email.trim(),
-          // Peer view rows carry only id/email/status; provider/framework default for a re-mint
-          // (the target machine logs in with its own framework — claude-code/anthropic by default).
-          provider: defaultProvider,
-          framework: defaultFramework,
-          label: accountId,
-        };
+        candidates.push({ email: row.email.trim(), source: 'peer', row: { id: accountId } });
       }
     }
   }
 
-  return { resolved: false, reason: 'cannot resolve approved account email' };
+  if (!found) {
+    return {
+      resolved: false,
+      code: 'subscription-account-not-found',
+      reason: 'This subscription account is no longer registered.',
+    };
+  }
+  if (candidates.length === 0) {
+    return {
+      resolved: false,
+      code: 'account-record-missing-email',
+      reason: 'This subscription account record is missing its email. Repair or re-enroll the account, then try again.',
+    };
+  }
+  const keys = new Set(candidates.map((candidate) => candidate.email.toLowerCase()));
+  if (keys.size !== 1) {
+    return {
+      resolved: false,
+      code: 'account-record-email-conflict',
+      reason: 'This account has conflicting emails on your machines. Repair or re-enroll the account records, then try again.',
+    };
+  }
+  const selected = candidates.find((candidate) => candidate.source === 'local') ?? candidates[0]!;
+  return {
+    resolved: true,
+    expectedEmail: selected.email,
+    provider: (local?.provider && local.provider.length > 0) ? local.provider : defaultProvider,
+    framework: (local?.framework && local.framework.length > 0) ? local.framework : defaultFramework,
+    label: (local?.nickname && local.nickname.trim().length > 0) ? local.nickname.trim() : accountId,
+  };
 }

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -38,6 +38,11 @@ import { ReviewExchangeEngine } from '../coordination/ReviewExchange.js';
 import { DeliveredMandateStore } from '../coordination/DeliveredMandateStore.js';
 import { packageMandateForDelivery, acceptDeliveredMandate } from '../coordination/AccountFollowMeMandateBridge.js';
 import { readFollowMeBounds, acceptMandateDelivery } from '../coordination/AccountFollowMeMandateDelivery.js';
+import {
+  FollowMeConsumerBackoffStore,
+  classifyFollowMeFailure,
+  followMeBackoffKey,
+} from '../coordination/FollowMeConsumerBackoffStore.js';
 import { CutoverReadiness } from '../feedback-factory/cutoverReadiness.js';
 import { InboxDrainer } from '../feedback-factory/inbox/InboxDrainer.js';
 import { BlobInboxClient } from '../feedback-factory/inbox/BlobInboxClient.js';
@@ -395,6 +400,8 @@ export class AgentServer {
   /** Dynamic MCP idle-offload sweep timer (dark + dryRun-first; cleared on stop). */
   private mcpIdleOffloadSweepTimer: ReturnType<typeof setInterval> | null = null;
   private followMeConsumerRunning = false;
+  private followMeConsumerBackoff: FollowMeConsumerBackoffStore | null = null;
+  private subscriptionEmailBarrier: import('../core/SubscriptionPool.js').SubscriptionEmailReconciliationBarrier | null = null;
   private resourceSampler: ResourceSampler | null = null;
   private frameworkIssueLedger: FrameworkIssueLedger | null = null;
   private mentorRunner: MentorOnboardingRunner | null = null;
@@ -517,6 +524,9 @@ export class AgentServer {
     commitmentTracker?: import('../monitoring/CommitmentTracker.js').CommitmentTracker;
     prHandLease?: import('../core/PrHandLease.js').PrHandLease;
     subscriptionPool?: import('../core/SubscriptionPool.js').SubscriptionPool;
+    subscriptionIdentityOracle?: import('../core/CredentialLocationLedger.js').IdentityOracle;
+    subscriptionEmailBinding?: import('../core/SubscriptionPool.js').SubscriptionEmailBindingAuthority;
+    subscriptionEmailBarrier?: import('../core/SubscriptionPool.js').SubscriptionEmailReconciliationBarrier;
     accountFollowMePeerViews?: import('./routes.js').RouteContext['accountFollowMePeerViews'];
     quotaPoller?: import('../core/QuotaPoller.js').QuotaPoller;
     quotaAwareScheduler?: import('../core/QuotaAwareScheduler.js').QuotaAwareScheduler;
@@ -911,6 +921,7 @@ export class AgentServer {
     threadlineFlowBridge?: import('../tasks/ThreadlineFlowBridge.js').ThreadlineFlowBridge;
   }) {
     this.config = options.config;
+    this.subscriptionEmailBarrier = options.subscriptionEmailBarrier ?? null;
     this.meshBindActive = options.meshBindActive ?? false;
     this.telegramAdapter = options.telegram ?? null;
     this.startTime = new Date();
@@ -3334,6 +3345,9 @@ export class AgentServer {
       commitmentTracker: options.commitmentTracker ?? null,
       prHandLease: options.prHandLease ?? null,
       subscriptionPool: options.subscriptionPool ?? null,
+      subscriptionIdentityOracle: options.subscriptionIdentityOracle,
+      subscriptionEmailBinding: options.subscriptionEmailBinding,
+      subscriptionEmailBarrier: options.subscriptionEmailBarrier,
       accountFollowMePeerViews: options.accountFollowMePeerViews,
       quotaPoller: options.quotaPoller ?? null,
       quotaAwareScheduler: options.quotaAwareScheduler ?? null,
@@ -5124,9 +5138,11 @@ export class AgentServer {
    * enforces the dev-gate (503 when off) + deny-by-default, so this consumer carries NO authority of
    * its own; it only nudges the route for mandates the operator already approved + delivered.
    */
+  /* @self-action-controller: follow-me-enrollment-consumer */
   private async driveDeliveredFollowMeEnrollments(): Promise<void> {
     if (this.followMeConsumerRunning) return; // re-entrancy guard (a slow tick must not overlap)
     if (!this.deliveredMandateStore) return;
+    if (this.subscriptionEmailBarrier?.isBlocking()) return;
     this.followMeConsumerRunning = true;
     try {
       const now = Date.now();
@@ -5141,23 +5157,54 @@ export class AgentServer {
       const host = this.config.host || '127.0.0.1';
       const base = `http://${host}:${this.config.port}`;
       const authHeader = { Authorization: `Bearer ${this.config.authToken ?? ''}` };
+      this.followMeConsumerBackoff ??= new FollowMeConsumerBackoffStore(this.config.stateDir);
+      const targetMachineId =
+        (this.config as InstarConfig & { machineId?: string }).machineId ?? 'local';
 
       // Build the set of accounts already handled (pending login in flight, or already enrolled) so a
       // tick never re-drives — the durable idempotency (pending logins + pool both persist on disk).
       const handled = new Set<string>();
       try {
-        const [pl, sp] = await Promise.all([
+        const [pl, sp, poolScope] = await Promise.all([
           fetch(`${base}/subscription-pool/pending-logins`, { headers: authHeader, signal: AbortSignal.timeout(5000) }).then((r) => (r.ok ? r.json() : null)).catch(() => null),
           fetch(`${base}/subscription-pool`, { headers: authHeader, signal: AbortSignal.timeout(5000) }).then((r) => (r.ok ? r.json() : null)).catch(() => null),
-        ]) as [{ logins?: Array<{ id?: string }> } | null, { accounts?: Array<{ id?: string }> } | null];
+          fetch(`${base}/subscription-pool?scope=pool`, { headers: authHeader, signal: AbortSignal.timeout(5000) }).then((r) => (r.ok ? r.json() : null)).catch(() => null),
+        ]) as [
+          { logins?: Array<{ id?: string }> } | null,
+          { accounts?: Array<{ id?: string }> } | null,
+          { accounts?: Array<{ id?: string; email?: string }>; emailGaps?: Array<{ accountId?: string }> } | null,
+        ];
         for (const l of pl?.logins ?? []) if (l?.id) handled.add(l.id);
         for (const a of sp?.accounts ?? []) if (a?.id) handled.add(a.id);
-      } catch { /* best-effort — a read failure just means we may attempt; the route is idempotent-enough */ }
+        const evidenceFor = (accountId: string, mandateIds: string[]) => {
+          const holderEmails = (poolScope?.accounts ?? [])
+            .filter((account) => account.id === accountId && typeof account.email === 'string')
+            .map((account) => account.email!.trim().toLowerCase())
+            .sort();
+          const gaps = (poolScope?.emailGaps ?? []).filter((gap) => gap.accountId === accountId).length;
+          return {
+            identityEvidenceKey: JSON.stringify({ holderEmails, gaps }),
+            identityResolved: gaps === 0 && new Set(holderEmails).size === 1,
+            authoritySetKey: JSON.stringify([...mandateIds].sort()),
+          };
+        };
 
+      const seenPairs = new Set<string>();
       for (const rec of delivered) {
         const m = rec.portable.mandate;
         const accountId = ((m.authorities ?? []).find((a) => a.action === 'account-follow-me')?.bounds ?? {}).accountId as string | undefined;
         if (!accountId || handled.has(accountId)) continue; // already pending or enrolled — never re-drive
+        const backoffKey = followMeBackoffKey(accountId, targetMachineId);
+        if (seenPairs.has(backoffKey)) continue;
+        seenPairs.add(backoffKey);
+        const mandateIds = delivered
+          .filter((candidate) => (candidate.portable.mandate.authorities ?? []).some(
+            (authority) => authority.action === 'account-follow-me' &&
+              (authority.bounds ?? {}).accountId === accountId,
+          ))
+          .map((candidate) => candidate.id);
+        const evidence = evidenceFor(accountId, mandateIds);
+        if (!this.followMeConsumerBackoff.shouldAttempt(backoffKey, now, evidence)) continue;
         try {
           const resp = await fetch(`${base}/subscription-pool/follow-me/enroll/start`, {
             method: 'POST',
@@ -5168,12 +5215,33 @@ export class AgentServer {
             signal: AbortSignal.timeout(200_000),
           });
           const ok = resp.ok;
-          console.log(`[follow-me-consumer] drove enroll-start for ${accountId} (mandate ${rec.id}) → ${resp.status}${ok ? '' : ' (will retry next tick)'}`);
-          if (ok) handled.add(accountId); // don't double-drive within this same tick
+          let code: string | undefined;
+          if (!ok) {
+            const body = await resp.json().catch(() => null) as { code?: unknown } | null;
+            if (typeof body?.code === 'string') code = body.code;
+          }
+          if (ok) {
+            handled.add(accountId);
+            this.followMeConsumerBackoff.clear(backoffKey);
+          } else {
+            const state = this.followMeConsumerBackoff.recordFailure(
+              backoffKey,
+              classifyFollowMeFailure(resp.status, code),
+              now,
+              evidence,
+              code,
+            );
+            console.log(
+              `[follow-me-consumer] enroll-start ${accountId} → ${resp.status}/${code ?? 'unclassified'}; ` +
+              `${state.parkedAt ? 'parked' : `attempt ${state.attempts}/4`}`,
+            );
+          }
         } catch (err) {
+          this.followMeConsumerBackoff.recordFailure(backoffKey, 'other', now, evidence);
           console.warn(`[follow-me-consumer] enroll-start self-call failed for ${accountId} (mandate ${rec.id}):`, err);
         }
       }
+      } catch { /* best-effort — a read failure just means the next tick retries the read */ }
     } catch (err) {
       console.warn('[follow-me-consumer] sweep failed (non-fatal):', err);
     } finally {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -38,6 +38,8 @@ import { decideNobodyPollingClaim, sharedG2NobodyPollingLedger } from '../core/n
 import { canonicalPushKey } from '../core/PrHandLease.js';
 import { enrollPaneSessionName } from '../core/FrameworkLoginDriver.js';
 import { QUOTA_SNAPSHOT_STALE_AFTER_MS } from '../core/QuotaPoller.js';
+import { SubscriptionAccountEmailRegistrar } from '../core/SubscriptionPool.js';
+import { CredentialIdentityOracle } from '../core/CredentialIdentityOracle.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -788,6 +790,12 @@ export interface RouteContext {
   /** SubscriptionPool (multi-account subscription registry, P1.1 of the
    *  Subscription & Auth Standard). Null until an operator opts in / enrolls. */
   subscriptionPool: import('../core/SubscriptionPool.js').SubscriptionPool | null;
+  /** Provider identity proof seam; production lazily uses CredentialIdentityOracle. */
+  subscriptionIdentityOracle?: {
+    resolveSlotTenant(slot: string): Promise<{ email?: string; unavailable?: boolean; reason?: string }>;
+  };
+  subscriptionEmailBinding?: import('../core/SubscriptionPool.js').SubscriptionEmailBindingAuthority;
+  subscriptionEmailBarrier?: import('../core/SubscriptionPool.js').SubscriptionEmailReconciliationBarrier;
   /** WS5.2 Account Follow-Me — cross-machine per-peer account views for depth detection. Prod-wired
    *  to the `?scope=pool` fan-out; absent ⇒ local-only (single-machine = no depth-zero peers). */
   accountFollowMePeerViews?: () => Promise<import('../core/accountFollowMeDepth.js').MachinePoolView[]>;
@@ -1511,6 +1519,38 @@ export interface RouteContext {
   } | null;
   startTime: Date;
 }
+
+export type SubscriptionPoolWriteCapability =
+  | 'requiresEmailReconciliation'
+  | 'readOnlyOrNonIdentity';
+
+/**
+ * Default-deny inventory for every mutating /subscription-pool route.
+ * The companion ratchet compares this registry to the real Express surface:
+ * a new write cannot silently bypass boot identity reconciliation.
+ */
+export const SUBSCRIPTION_POOL_WRITE_CAPABILITIES: Readonly<Record<string, SubscriptionPoolWriteCapability>> =
+  Object.freeze({
+    'POST /subscription-pool': 'requiresEmailReconciliation',
+    'POST /subscription-pool/:id/repair-email': 'requiresEmailReconciliation',
+    'POST /subscription-pool/enroll': 'requiresEmailReconciliation',
+    'POST /subscription-pool/enroll/:id/complete': 'requiresEmailReconciliation',
+    'POST /subscription-pool/follow-me/enroll/:id/complete': 'requiresEmailReconciliation',
+    'POST /subscription-pool/follow-me/enroll/start': 'requiresEmailReconciliation',
+    'POST /subscription-pool/matrix/start-cell': 'requiresEmailReconciliation',
+    'DELETE /subscription-pool/:id': 'readOnlyOrNonIdentity',
+    'PATCH /subscription-pool/:id': 'readOnlyOrNonIdentity',
+    'POST /subscription-pool/enroll/:id/cancel': 'readOnlyOrNonIdentity',
+    'POST /subscription-pool/enroll/reissue-expired': 'readOnlyOrNonIdentity',
+    'POST /subscription-pool/follow-me/cancel': 'readOnlyOrNonIdentity',
+    'POST /subscription-pool/follow-me/enroll/:id/cancel': 'readOnlyOrNonIdentity',
+    'POST /subscription-pool/follow-me/enroll/:id/submit-code': 'readOnlyOrNonIdentity',
+    'POST /subscription-pool/follow-me/scan': 'readOnlyOrNonIdentity',
+    'POST /subscription-pool/follow-me/submit-code': 'readOnlyOrNonIdentity',
+    'POST /subscription-pool/poll': 'readOnlyOrNonIdentity',
+    'POST /subscription-pool/proactive-swap/check': 'readOnlyOrNonIdentity',
+    'POST /subscription-pool/swap': 'readOnlyOrNonIdentity',
+  });
 
 // Validation patterns for route parameters
 const SESSION_NAME_RE = /^[a-zA-Z0-9_-]{1,200}$/;
@@ -26417,6 +26457,47 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // GET routes return { enabled: false } when the pool is not configured so
   // they answer 200 (not 503) on every install.
 
+  const subscriptionEmailReconciliation = () => {
+    const barrier = ctx.subscriptionEmailBarrier;
+    if (barrier && typeof barrier.snapshot === 'function') return barrier.snapshot();
+    const state = barrier && typeof barrier.status === 'function'
+      ? barrier.status()
+      : barrier?.isBlocking() ? 'running' : 'complete';
+    return {
+      state,
+      unresolvedCount: ctx.subscriptionPool?.listEmailGaps?.().length ?? 0,
+      repairRunsFreshProbe: true as const,
+    };
+  };
+  const enforceSubscriptionPoolWriteCapability = (route: string) =>
+    (_req: ExpressRequest, res: ExpressResponse, next: () => void): void => {
+    const capability = SUBSCRIPTION_POOL_WRITE_CAPABILITIES[route];
+    if (!capability) {
+      res.status(500).json({ error: 'Subscription identity mutation route is not classified.' });
+      return;
+    }
+    if (capability === 'readOnlyOrNonIdentity' || !ctx.subscriptionEmailBarrier?.isBlocking()) {
+      next();
+      return;
+    }
+    res.status(503).json({
+      error: 'Account identity reconciliation is still starting. Try again shortly.',
+      code: 'subscription-account-email-reconciliation-running',
+      retryable: true,
+      emailReconciliation: { state: 'running' },
+    });
+  };
+  const subscriptionEmailGaps = () =>
+    (ctx.subscriptionPool?.listEmailGaps?.() ?? []).map((account) => ({
+      accountId: account.accountId,
+      nickname: account.nickname,
+      provider: account.provider,
+      framework: account.framework,
+      reason: ctx.subscriptionEmailBarrier?.timedOutAccount(account.accountId)
+        ? 'reconciliation-timeout'
+        : 'account-record-missing-email',
+    }));
+
   router.get('/subscription-pool', async (req, res) => {
     // WS5.1 — pool-scope read: "how much quota is left across ALL my machines /
     // accounts?" in ONE view. Mirrors GET /sessions?scope=pool exactly: fan out
@@ -26434,7 +26515,8 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       const selfMachineNickname = selfMachineId
         ? (ctx.machinePoolRegistry?.getCapacity(selfMachineId)?.nickname ?? null)
         : null;
-      const selfAccounts = (ctx.subscriptionPool?.list() ?? []).map((a) => ({
+      const localRows = ctx.subscriptionPool?.list() ?? [];
+      const selfAccounts = localRows.map((a) => ({
         ...a,
         machineId: selfMachineId,
         machineNickname: selfMachineNickname ?? undefined,
@@ -26444,6 +26526,11 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       const peers = ctx.resolvePeerUrls?.() ?? [];
       const failed: Array<{ machineId: string; error: string }> = [];
       const remote: Record<string, unknown>[] = [];
+      const remoteEmailGaps: Record<string, unknown>[] = [];
+      const remoteReconciliation: Array<{
+        state: 'running' | 'degraded' | 'complete';
+        unresolvedCount: number;
+      }> = [];
       await Promise.all(peers.map(async (p) => {
         try {
           const r = await fetch(`${p.url}/subscription-pool`, {
@@ -26455,7 +26542,14 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
             failed.push({ machineId: p.machineId, error: r.status === 401 || r.status === 403 ? 'unauthorized' : 'error' });
             return;
           }
-          const body = (await r.json()) as { accounts?: Record<string, unknown>[] };
+          const body = (await r.json()) as {
+            accounts?: Record<string, unknown>[];
+            emailGaps?: Record<string, unknown>[];
+            emailReconciliation?: {
+              state?: 'running' | 'degraded' | 'complete';
+              unresolvedCount?: number;
+            };
+          };
           const nickname = ctx.machinePoolRegistry?.getCapacity(p.machineId)?.nickname ?? null;
           for (const a of body.accounts ?? []) {
             remote.push({
@@ -26463,6 +26557,20 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
               machineId: a.machineId ?? p.machineId,
               machineNickname: a.machineNickname ?? nickname ?? undefined,
               remote: true,
+            });
+          }
+          for (const gap of body.emailGaps ?? []) {
+            remoteEmailGaps.push({
+              ...gap,
+              machineId: gap.machineId ?? p.machineId,
+              machineNickname: gap.machineNickname ?? nickname ?? undefined,
+              remote: true,
+            });
+          }
+          if (body.emailReconciliation?.state) {
+            remoteReconciliation.push({
+              state: body.emailReconciliation.state,
+              unresolvedCount: Number(body.emailReconciliation.unresolvedCount ?? 0),
             });
           }
         } catch (err) {
@@ -26475,9 +26583,28 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         }
       }));
 
+      const localReconciliation = subscriptionEmailReconciliation();
+      const reconciliationRows = [localReconciliation, ...remoteReconciliation];
+      const aggregateState = reconciliationRows.some((row) => row.state === 'running')
+        ? 'running'
+        : reconciliationRows.some((row) => row.state === 'degraded') ? 'degraded' : 'complete';
       res.json({
         enabled: !!ctx.subscriptionPool,
         accounts: [...selfAccounts, ...remote],
+        emailGaps: [
+          ...subscriptionEmailGaps().map((gap) => ({
+            ...gap,
+            machineId: selfMachineId,
+            machineNickname: selfMachineNickname ?? undefined,
+            remote: false,
+          })),
+          ...remoteEmailGaps,
+        ],
+        emailReconciliation: {
+          state: aggregateState,
+          unresolvedCount: reconciliationRows.reduce((sum, row) => sum + row.unresolvedCount, 0),
+          repairRunsFreshProbe: true,
+        },
         pool: {
           selfMachineId,
           selfMachineNickname,
@@ -26495,7 +26622,14 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       return;
     }
     const accounts = ctx.subscriptionPool.list();
-    res.json({ enabled: true, count: accounts.length, accounts });
+    const emailGaps = subscriptionEmailGaps();
+    res.json({
+      enabled: true,
+      count: accounts.length,
+      accounts,
+      emailGaps,
+      emailReconciliation: subscriptionEmailReconciliation(),
+    });
   });
 
   // D5 (topic 29836) — record-state ⟂ pane-liveness. A pending login is only genuinely
@@ -26530,17 +26664,23 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     const pool = ctx.subscriptionPool!;
     const existing = pool.get(login.id);
     if (existing) {
-      return pool.update(login.id, {
+      return new SubscriptionAccountEmailRegistrar(
+        pool,
+        ctx.subscriptionIdentityOracle ?? new CredentialIdentityOracle(),
+      ).completeValidated(login.id, email, {
         nickname: login.label,
         status: 'active',
-        email,
         ...(login.configHome ? { configHome: login.configHome } : {}),
       });
     }
-    return pool.add({
+    return new SubscriptionAccountEmailRegistrar(
+      pool,
+      ctx.subscriptionIdentityOracle ?? new CredentialIdentityOracle(),
+      ctx.subscriptionEmailBinding,
+    ).completeNewValidated({
       id: login.id, nickname: login.label,
-      provider: login.provider as Parameters<typeof pool.add>[0]['provider'],
-      framework: login.framework as Parameters<typeof pool.add>[0]['framework'],
+      provider: login.provider as import('../core/SubscriptionPool.js').SubscriptionProvider,
+      framework: login.framework as import('../core/SubscriptionPool.js').SubscriptionFramework,
       configHome: login.configHome ?? '', status: 'active', email,
     });
   };
@@ -26655,7 +26795,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // Run ONE proactive-swap pass now (the deterministic "show me it works" lever):
   // refresh the poll if near the wall, then pre-emptively swap at-pressure sessions.
   // POST so it never collides with GET /subscription-pool/:id.
-  router.post('/subscription-pool/proactive-swap/check', async (_req, res) => {
+  router.post('/subscription-pool/proactive-swap/check', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/proactive-swap/check'), async (_req, res) => {
     if (!ctx.proactiveSwapMonitor) {
       res.json({ enabled: false, swapped: [], considered: 0, refreshed: false });
       return;
@@ -26665,6 +26805,40 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       res.json({ enabled: true, ...result });
     } catch (err) {
       res.status(500).json({ error: err instanceof Error ? err.message : 'proactive check failed' });
+    }
+  });
+
+  router.post('/subscription-pool/:id/repair-email', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/:id/repair-email'), async (req, res) => {
+    if (!ctx.subscriptionPool) {
+      res.status(404).json({ error: 'SubscriptionPool not configured' });
+      return;
+    }
+    const suppliedPin = typeof req.body?.pin === 'string' ? req.body.pin : '';
+    const expectedPin = ctx.config.dashboardPin ?? '';
+    const pinOk = suppliedPin.length === expectedPin.length && suppliedPin.length > 0 &&
+      timingSafeEqual(Buffer.from(suppliedPin), Buffer.from(expectedPin));
+    if (!pinOk) {
+      res.status(401).json({ error: 'Dashboard PIN required.' });
+      return;
+    }
+    try {
+      const registrar = new SubscriptionAccountEmailRegistrar(
+        ctx.subscriptionPool,
+        ctx.subscriptionIdentityOracle ?? new CredentialIdentityOracle(),
+        ctx.subscriptionEmailBinding,
+      );
+      res.json(await registrar.repairLegacy(req.params.id));
+    } catch (err) {
+      const code = err instanceof Error && 'code' in err ? String(err.code) : 'identity-oracle-unavailable';
+      const status = code === 'subscription-account-not-found'
+        ? 404
+        : code === 'subscription-account-identity-provider-unsupported' ? 400 : 409;
+      res.status(status).json({
+        error: err instanceof Error ? err.message : 'Account identity could not be repaired.',
+        code,
+        repairRequired: true,
+        emailReconciliation: subscriptionEmailReconciliation(),
+      });
     }
   });
 
@@ -26681,7 +26855,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     res.json(account);
   });
 
-  router.post('/subscription-pool', (req, res) => {
+  router.post('/subscription-pool', enforceSubscriptionPoolWriteCapability('POST /subscription-pool'), async (req, res) => {
     if (!ctx.subscriptionPool) {
       res.status(404).json({ error: 'SubscriptionPool not configured' });
       return;
@@ -26694,27 +26868,62 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       return;
     }
     try {
+      if (!/^[a-z0-9-]+$/.test(String(id))) {
+        res.status(400).json({ error: 'id must match ^[a-z0-9-]+$' });
+        return;
+      }
+      if (ctx.subscriptionPool.get(String(id))) {
+        res.status(400).json({ error: `account ${String(id)} already exists` });
+        return;
+      }
+      for (const key of Object.keys(req.body ?? {})) {
+        if (/(?:access|refresh)?token|api_?key|credentials?|secret|password|oauth/i.test(key)) {
+          res.status(400).json({
+            error: `the registry stores login LOCATION, never credentials — field "${key}" is not allowed`,
+          });
+          return;
+        }
+      }
+      if (provider !== 'anthropic' || framework !== 'claude-code') {
+        res.status(400).json({
+          error: `provider identity verification is not supported for ${String(provider)}/${String(framework)}`,
+          code: 'subscription-account-identity-provider-unsupported',
+        });
+        return;
+      }
       // Pass the full body as rawExtra so the credential-field guard rejects any
       // attempt to smuggle a token into the registry (structural invariant).
-      const account = ctx.subscriptionPool.add(
+      const account = await new SubscriptionAccountEmailRegistrar(
+        ctx.subscriptionPool,
+        ctx.subscriptionIdentityOracle ?? new CredentialIdentityOracle(),
+      ).register(
         { id, nickname, provider, framework, configHome, status, email },
         req.body,
       );
       res.status(201).json(account);
     } catch (err) {
+      const code = err instanceof Error && 'code' in err ? String(err.code) : undefined;
       const isValidation = err instanceof Error && err.name === 'ValidationError';
-      res.status(isValidation ? 400 : 500).json({
+      res.status(code ? 400 : isValidation ? 400 : 500).json({
         error: err instanceof Error ? err.message : 'failed to add account',
+        ...(code ? { code } : {}),
       });
     }
   });
 
-  router.patch('/subscription-pool/:id', (req, res) => {
+  router.patch('/subscription-pool/:id', enforceSubscriptionPoolWriteCapability('PATCH /subscription-pool/:id'), (req, res) => {
     if (!ctx.subscriptionPool) {
       res.status(404).json({ error: 'SubscriptionPool not configured' });
       return;
     }
     const { nickname, framework, configHome, status, lastQuota, lastUsedAt, email } = req.body ?? {};
+    if (email !== undefined) {
+      res.status(409).json({
+        error: 'Account email is credential-attested identity and cannot be edited directly.',
+        code: 'identity-email-direct-mutation-refused',
+      });
+      return;
+    }
     // Census #10/#11: while live credential re-pointing is enabled the account `configHome` is
     // enrollment metadata, NOT the credential's live location (the ledger owns location). A hand
     // edit here would silently desync the ledger and re-point sessions to the wrong slot, so the
@@ -26736,7 +26945,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     try {
       const updated = ctx.subscriptionPool.update(
         req.params.id,
-        { nickname, framework, configHome, status, lastQuota, lastUsedAt, email },
+        { nickname, framework, configHome, status, lastQuota, lastUsedAt },
         req.body,
       );
       if (!updated) {
@@ -26752,7 +26961,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     }
   });
 
-  router.delete('/subscription-pool/:id', (req, res) => {
+  router.delete('/subscription-pool/:id', enforceSubscriptionPoolWriteCapability('DELETE /subscription-pool/:id'), (req, res) => {
     if (!ctx.subscriptionPool) {
       res.status(404).json({ error: 'SubscriptionPool not configured' });
       return;
@@ -26772,7 +26981,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // normal GET /subscription-pool. { enabled:false } when the poller is unwired
   // (200, never 503).
 
-  router.post('/subscription-pool/poll', async (_req, res) => {
+  router.post('/subscription-pool/poll', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/poll'), async (_req, res) => {
     if (!ctx.quotaPoller) {
       res.json({ enabled: false, polled: 0, failed: 0 });
       return;
@@ -26818,7 +27027,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // surface). Resumes `sessionName` on another eligible account, preserving the
   // conversation via --resume. Body: { sessionName, exhaustedAccountId }.
   // POST (not GET) so it never collides with GET /subscription-pool/:id.
-  router.post('/subscription-pool/swap', async (req, res) => {
+  router.post('/subscription-pool/swap', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/swap'), async (req, res) => {
     if (!ctx.quotaAwareScheduler) {
       res.json({ enabled: false, swapped: false, reason: 'scheduler not configured' });
       return;
@@ -26846,7 +27055,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // code. List/sweep routes answer 200 { enabled:false } when the wizard is
   // unwired (dark) — never 503.
 
-  router.post('/subscription-pool/enroll', async (req, res) => {
+  router.post('/subscription-pool/enroll', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/enroll'), async (req, res) => {
     if (!ctx.enrollmentWizard) {
       res.json({ enabled: false, started: false, reason: 'enrollment wizard not configured' });
       return;
@@ -26877,7 +27086,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // reader, prod-wired to ?scope=pool) and surfaces ONE aggregated phone-first consent. The
   // agent NEVER self-enrolls — authorization is the operator's mandate, issued on the target's
   // own dashboard (per-server, OQ6). Dark behind multiMachine.accountFollowMe (503 when off).
-  router.post('/subscription-pool/follow-me/scan', async (_req, res) => {
+  router.post('/subscription-pool/follow-me/scan', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/follow-me/scan'), async (_req, res) => {
     const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean; maxFollowMachines?: number } } }).multiMachine?.accountFollowMe;
     if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
       res.status(503).json({ error: 'account follow-me not enabled' });
@@ -26948,7 +27157,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // NEVER from the request body — so `completeFollowMe` can later validate the minted account against
   // what the operator actually approved. Unresolvable email ⇒ 409 fail-closed (never start blank).
   // Dark behind multiMachine.accountFollowMe (503 when off). Mirrors the scan route's dark-gate exactly.
-  router.post('/subscription-pool/follow-me/enroll/start', async (req, res) => {
+  router.post('/subscription-pool/follow-me/enroll/start', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/follow-me/enroll/start'), async (req, res) => {
     const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean; remoteScrapeTimeoutMs?: number } } }).multiMachine?.accountFollowMe;
     if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
       res.status(503).json({ error: 'account follow-me not enabled' });
@@ -27023,7 +27232,8 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       const peerViews = ctx.accountFollowMePeerViews ? await ctx.accountFollowMePeerViews() : [];
       const target = resolveFollowMeEnrollTarget({ accountId, localAccounts, peerViews });
       if (!target.resolved) {
-        res.status(409).json({ error: 'cannot resolve approved account email' });
+        res.status(target.code === 'subscription-account-not-found' ? 404 : 409)
+          .json({ error: target.reason, code: target.code, accountId, repairRequired: true });
         return;
       }
 
@@ -27124,7 +27334,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // paste the returned code); this is the second part, off-chat. The code is the
   // operator's own single-use auth code; the provider validates it — instar holds no
   // new authority and never stores/logs the code value. Dev-gated like the rest.
-  router.post('/subscription-pool/follow-me/enroll/:id/submit-code', async (req, res) => {
+  router.post('/subscription-pool/follow-me/enroll/:id/submit-code', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/follow-me/enroll/:id/submit-code'), async (req, res) => {
     const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } }).multiMachine?.accountFollowMe;
     if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
       res.status(503).json({ error: 'account follow-me not enabled' });
@@ -27329,7 +27539,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // Bearer-only like submit-code (the PIN gate lives on start-cell, the mint) — a
   // per-machine PIN can't cross the mesh, which is what lets the fronting relay reach a
   // peer's cancel. Dark behind multiMachine.accountFollowMe. Spec: matrix-cell-operator-cancel.
-  router.post('/subscription-pool/follow-me/enroll/:id/cancel', async (req, res) => {
+  router.post('/subscription-pool/follow-me/enroll/:id/cancel', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/follow-me/enroll/:id/cancel'), async (req, res) => {
     const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } }).multiMachine?.accountFollowMe;
     if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
       res.status(503).json({ error: 'account follow-me not enabled' });
@@ -27346,7 +27556,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // it carries the code one authed hop to the machine that owns the login pane. self →
   // local submit-code; peer → POST {code} to that peer's local submit-code. The code rides
   // the Bearer-authed API + authed mesh hop only, never chat. Dark target → honest 502.
-  router.post('/subscription-pool/follow-me/submit-code', async (req, res) => {
+  router.post('/subscription-pool/follow-me/submit-code', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/follow-me/submit-code'), async (req, res) => {
     const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } }).multiMachine?.accountFollowMe;
     if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
       res.status(503).json({ error: 'account follow-me not enabled' });
@@ -27390,7 +27600,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // calls this; it carries the cancel one authed hop to the machine that owns the login
   // pane. self → local cancel; peer → POST to that peer's local cancel. Mirrors
   // follow-me/submit-code exactly (Bearer-authed mesh hop; dark/offline target → 502).
-  router.post('/subscription-pool/follow-me/cancel', async (req, res) => {
+  router.post('/subscription-pool/follow-me/cancel', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/follow-me/cancel'), async (req, res) => {
     const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } }).multiMachine?.accountFollowMe;
     if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
       res.status(503).json({ error: 'account follow-me not enabled' });
@@ -27438,7 +27648,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // new authority — it just drives the existing chain in one call so the frontend never handles
   // fingerprints or raw mandate JSON. Idempotent: a re-tap reuses an existing valid pending login
   // for this pair (no duplicate, no stacked mandate). Dark behind multiMachine.accountFollowMe.
-  router.post('/subscription-pool/matrix/start-cell', async (req, res) => {
+  router.post('/subscription-pool/matrix/start-cell', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/matrix/start-cell'), async (req, res) => {
     const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } }).multiMachine?.accountFollowMe;
     if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
       res.status(503).json({ error: 'account follow-me not enabled' });
@@ -27482,8 +27692,9 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         const peerViews = ctx.accountFollowMePeerViews ? await ctx.accountFollowMePeerViews() : [];
         const target = resolveFollowMeEnrollTarget({ accountId, localAccounts, peerViews });
         if (!target.resolved) {
-          console.log(`[matrix] start-cell accountId=${accountId} machineId=${machineId} outcome=cannot-resolve-email`);
-          res.status(409).json({ error: 'cannot resolve approved account email' });
+          console.log(`[matrix] start-cell accountId=${accountId} machineId=${machineId} outcome=${target.code}`);
+          res.status(target.code === 'subscription-account-not-found' ? 404 : 409)
+            .json({ error: target.reason, code: target.code, accountId, repairRequired: true });
           return;
         }
         const existing = ctx.enrollmentWizard.pending().find(
@@ -27607,7 +27818,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   });
 
   // Single-segment path → no collision with /enroll/:id/complete (3 segments).
-  router.post('/subscription-pool/enroll/reissue-expired', async (_req, res) => {
+  router.post('/subscription-pool/enroll/reissue-expired', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/enroll/reissue-expired'), async (_req, res) => {
     if (!ctx.enrollmentWizard) {
       res.json({ enabled: false, reissued: [] });
       return;
@@ -27620,7 +27831,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     }
   });
 
-  router.post('/subscription-pool/enroll/:id/cancel', (req, res) => {
+  router.post('/subscription-pool/enroll/:id/cancel', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/enroll/:id/cancel'), (req, res) => {
     if (!ctx.enrollmentWizard) {
       res.json({ enabled: false, cancelled: false, reason: 'enrollment wizard not configured' });
       return;
@@ -27628,7 +27839,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     cancelEnrollment(req.params.id, plainCompleteInFlight, 'enroll', res);
   });
 
-  router.post('/subscription-pool/enroll/:id/complete', async (req, res) => {
+  router.post('/subscription-pool/enroll/:id/complete', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/enroll/:id/complete'), async (req, res) => {
     if (!ctx.enrollmentWizard) {
       res.json({ enabled: false, completed: false, reason: 'enrollment wizard not configured' });
       return;
@@ -27662,7 +27873,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // the account becomes a selectable pool account. A surprise/mismatched/unverifiable email is
   // HELD (NOT added to the pool) and raises a HIGH attention item. Only a verified match adds
   // the account to the SubscriptionPool. Dark behind multiMachine.accountFollowMe (503 when off).
-  router.post('/subscription-pool/follow-me/enroll/:id/complete', async (req, res) => {
+  router.post('/subscription-pool/follow-me/enroll/:id/complete', enforceSubscriptionPoolWriteCapability('POST /subscription-pool/follow-me/enroll/:id/complete'), async (req, res) => {
     const afmCfg = (ctx.config as unknown as { multiMachine?: { accountFollowMe?: { enabled?: boolean } } }).multiMachine?.accountFollowMe;
     if (!resolveDevAgentGate(afmCfg?.enabled, ctx.config)) {
       res.status(503).json({ error: 'account follow-me not enabled' });

--- a/src/testing/selfActionRegistry.ts
+++ b/src/testing/selfActionRegistry.ts
@@ -865,6 +865,33 @@ const mutualSshRepairSweep: SelfActionController = {
   },
 };
 
+const followMeEnrollmentConsumer: SelfActionController = {
+  id: 'follow-me-enrollment-consumer',
+  actionVerb: 'redrive-enroll-start',
+  models: 'src/server/AgentServer.ts + src/coordination/FollowMeConsumerBackoffStore.ts (four-attempt pair episode, causal-evidence wake)',
+  modelsPath: 'src/server/AgentServer.ts',
+  delegatedGiveUp: 'the durable fourth-failure parked state for an unchanged account-machine evidence key',
+  boundK: 4,
+  perTargetBoundK: 4,
+  ticks: 24,
+  tickMs: 60_000,
+  restartPosture: {
+    pressureSurvives: true,
+    restartUnderPressure(f, sink) {
+      return followMeEnrollmentConsumer.makeUnderPressure(f, sink);
+    },
+  },
+  makeUnderPressure(f, sink) {
+    return { tick() {
+      sink.considered += 1;
+      const attempts = Number(f.durableState.get('follow-me-attempts') ?? 0);
+      if (attempts >= 4) return;
+      f.durableState.set('follow-me-attempts', attempts + 1);
+      sink.emit({ verb: 'redrive-enroll-start', target: 'account-machine-pair' });
+    } };
+  },
+};
+
 export const SELF_ACTION_CONTROLLERS: SelfActionController[] = [
   evolutionActionExpirySweep,
   spendReconSweep,
@@ -885,4 +912,5 @@ export const SELF_ACTION_CONTROLLERS: SelfActionController[] = [
   correctionClassReviewOutcomes,
   feedbackGeneratedDefaultsHeal,
   mutualSshRepairSweep,
+  followMeEnrollmentConsumer,
 ];

--- a/tests/e2e/credential-ledger-boot-seed.test.ts
+++ b/tests/e2e/credential-ledger-boot-seed.test.ts
@@ -53,8 +53,8 @@ describe('credential ledger boot-seed — E2E (seed flows to /credentials/locati
     const pool = new SubscriptionPool({ stateDir: dir });
     const homeA = path.join(dir, '.claude-a');
     const homeB = path.join(dir, '.claude-b');
-    pool.add({ id: 'acct-a', nickname: 'A', provider: 'anthropic', framework: 'claude-code', configHome: homeA, email: 'a@x.com' });
-    pool.add({ id: 'acct-b', nickname: 'B', provider: 'anthropic', framework: 'claude-code', configHome: homeB, email: 'b@x.com' });
+    pool.addFixture({ id: 'acct-a', nickname: 'A', provider: 'anthropic', framework: 'claude-code', configHome: homeA, email: 'a@x.com' });
+    pool.addFixture({ id: 'acct-b', nickname: 'B', provider: 'anthropic', framework: 'claude-code', configHome: homeB, email: 'b@x.com' });
 
     const poolView: LedgerPoolView = { list: () => pool.list().map((a) => ({ id: a.id, email: a.email, configHome: a.configHome, framework: a.framework })) };
     // Oracle maps each slot (configHome) to its real tenant email — the happy path of seeding.

--- a/tests/e2e/credential-repointing-census-lifecycle.test.ts
+++ b/tests/e2e/credential-repointing-census-lifecycle.test.ts
@@ -58,7 +58,7 @@ describe('credential re-pointing census re-routing — E2E feature-alive (dark =
   async function bootWired(enabled: boolean): Promise<{ pool: SubscriptionPool; seenHomes: string[]; probeCalls: () => number }> {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-census-e2e-'));
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'claude-1', nickname: 'primary', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-enroll'), email: 'a@x.com' });
+    pool.addFixture({ id: 'claude-1', nickname: 'primary', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-enroll'), email: 'a@x.com' });
     const poolView: LedgerPoolView = { list: () => pool.list().map((a) => ({ id: a.id, email: a.email, configHome: a.configHome, framework: a.framework })) };
 
     const ledger = new CredentialLocationLedger({ stateDir: dir, pool: poolView, oracle: noopOracle });

--- a/tests/e2e/session-management-e2e.test.ts
+++ b/tests/e2e/session-management-e2e.test.ts
@@ -394,7 +394,10 @@ describeMaybe('Session Management E2E', () => {
   describe('Feature: Subscription-pool pinning (B1, interactive lane)', () => {
     it('tags a real interactive session with the resolver-picked account + seeds its home onboarding-ready', async () => {
       const claudePath = createMockClaudeInteractive(project.dir);
-      const sm = createManager(project, claudePath);
+      // This scenario is specifically the Claude subscription-pool lane. Pin
+      // the framework so a Codex-hosted test runner cannot silently turn the
+      // pool resolver into the expected non-Claude no-op.
+      const sm = createManager(project, claudePath, { framework: 'claude-code' });
       managers.push(sm);
 
       // A headless-enrolled pool home: tokens present, interactive flags absent.

--- a/tests/e2e/subscription-inuse-lifecycle.test.ts
+++ b/tests/e2e/subscription-inuse-lifecycle.test.ts
@@ -48,8 +48,8 @@ describe('/subscription-pool/in-use — E2E feature-alive', () => {
   it('LIVE: reports which enrolled account the agent is currently running on', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'inuse-e2e-'));
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'gmail', nickname: 'Justin', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'g'), email: 'headley.justin@gmail.com' });
-    pool.add({ id: 'dawn', nickname: 'SageMind - Dawn', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'd'), email: 'dawn@sagemindai.io' });
+    pool.addFixture({ id: 'gmail', nickname: 'Justin', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'g'), email: 'headley.justin@gmail.com' });
+    pool.addFixture({ id: 'dawn', nickname: 'SageMind - Dawn', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'd'), email: 'dawn@sagemindai.io' });
     const inUseAccountResolver = new InUseAccountResolver({ probe: async () => 'dawn@sagemindai.io' });
     server = await boot({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), subscriptionPool: pool, inUseAccountResolver });
 

--- a/tests/e2e/subscription-pool-lifecycle.test.ts
+++ b/tests/e2e/subscription-pool-lifecycle.test.ts
@@ -63,6 +63,9 @@ describe('/subscription-pool — E2E feature-alive', () => {
       config: { authToken: 'test', stateDir: dir, port: 0 },
       startTime: new Date(),
       subscriptionPool: pool,
+      subscriptionIdentityOracle: {
+        resolveSlotTenant: async () => ({ email: 'primary@example.test' }),
+      },
     });
 
     // FEATURE IS ALIVE: GET returns 200 (not 404/503) with the live pool.
@@ -77,6 +80,7 @@ describe('/subscription-pool — E2E feature-alive', () => {
       body: JSON.stringify({
         id: 'claude-primary',
         nickname: 'primary',
+        email: 'primary@example.test',
         provider: 'anthropic',
         framework: 'claude-code',
         configHome: path.join(dir, '.claude-primary'),

--- a/tests/e2e/subscription-proactive-swap-lifecycle.test.ts
+++ b/tests/e2e/subscription-proactive-swap-lifecycle.test.ts
@@ -53,8 +53,8 @@ describe('/subscription-pool/proactive-swap — E2E feature-alive', () => {
   it('LIVE: pre-emptively swaps the untagged interactive session off an at-pressure account, end-to-end', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'proactive-e2e-'));
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'adriana', nickname: 'SageMind - Adriana', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'a'), email: 'adriana@sagemindai.io' });
-    pool.add({ id: 'justin', nickname: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'j'), email: 'justin@sagemindai.io' });
+    pool.addFixture({ id: 'adriana', nickname: 'SageMind - Adriana', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'a'), email: 'adriana@sagemindai.io' });
+    pool.addFixture({ id: 'justin', nickname: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'j'), email: 'justin@sagemindai.io' });
     // The default login (adriana) is racing toward its limit; justin has headroom.
     pool.update('adriana', { lastQuota: { sevenDay: { utilizationPct: 84, resetsAt: '2026-06-10T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback' } });
     pool.update('justin', { lastQuota: { sevenDay: { utilizationPct: 12, resetsAt: '2026-06-13T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback' } });
@@ -88,8 +88,8 @@ describe('/subscription-pool/proactive-swap — E2E feature-alive', () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'login-loss-e2e-'));
     const pool = new SubscriptionPool({ stateDir: dir });
     let now = Date.parse('2026-07-23T06:00:00Z');
-    pool.add({ id: 'lost', nickname: 'Lost login', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'lost'), email: 'lost@example.com' });
-    pool.add({ id: 'fresh', nickname: 'Fresh login', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'fresh'), email: 'fresh@example.com' });
+    pool.addFixture({ id: 'lost', nickname: 'Lost login', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'lost'), email: 'lost@example.com' });
+    pool.addFixture({ id: 'fresh', nickname: 'Fresh login', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, 'fresh'), email: 'fresh@example.com' });
     pool.update('lost', {
       identityDrifted: true,
       identityDrift: {

--- a/tests/e2e/subscription-quota-lifecycle.test.ts
+++ b/tests/e2e/subscription-quota-lifecycle.test.ts
@@ -57,7 +57,7 @@ describe('/subscription-pool quota — E2E feature-alive', () => {
   it('LIVE: poll reads usage end-to-end and the snapshot is readable over HTTP', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qpoll-e2e-'));
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'claude-primary', nickname: 'primary', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-primary') });
+    pool.addFixture({ id: 'claude-primary', nickname: 'primary', email: 'primary@example.test', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-primary') });
     const quotaPoller = new QuotaPoller({ pool, fetchImpl: okFetch, tokenResolver: () => 'sk-ant-oat01-x' });
     server = await boot({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), subscriptionPool: pool, quotaPoller });
 
@@ -77,8 +77,8 @@ describe('/subscription-pool quota — E2E feature-alive', () => {
   it('LIVE: /subscription-pool exposes drift while quota follows live identity', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qpoll-drift-e2e-'));
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'label-a', nickname: 'A', email: 'a@test', provider: 'anthropic', framework: 'claude-code', configHome: '/slot/a' });
-    pool.add({ id: 'real-b', nickname: 'B', email: 'b@test', provider: 'anthropic', framework: 'claude-code', configHome: '/slot/b' });
+    pool.addFixture({ id: 'label-a', nickname: 'A', email: 'a@test', provider: 'anthropic', framework: 'claude-code', configHome: '/slot/a' });
+    pool.addFixture({ id: 'real-b', nickname: 'B', email: 'b@test', provider: 'anthropic', framework: 'claude-code', configHome: '/slot/b' });
     const quotaPoller = new QuotaPoller({
       pool, fetchImpl: okFetch, tokenResolver: () => 'sk-ant-oat01-x',
       resolveSlotIdentity: async (slot) => slot === '/slot/a'
@@ -112,7 +112,7 @@ describe('/subscription-pool quota — E2E feature-alive', () => {
       }) + '\n',
     );
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'codex-primary', nickname: 'Codex', provider: 'openai', framework: 'codex-cli', configHome: codexHome });
+    pool.addFixture({ id: 'codex-primary', nickname: 'Codex', email: 'codex@example.test', provider: 'openai', framework: 'codex-cli', configHome: codexHome });
     // Keep the fixture's reset windows live independent of wall-clock time.
     const quotaPoller = new QuotaPoller({ pool, now: () => Date.parse('2026-07-10T19:00:00.000Z') });
     server = await boot({ config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date(), subscriptionPool: pool, quotaPoller });
@@ -130,7 +130,7 @@ describe('/subscription-pool quota — E2E feature-alive', () => {
   it('LIVE: an expired access token auto-refreshes end-to-end (account stays active, stamped on disk)', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qpoll-e2e-ref-'));
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'claude-primary', nickname: 'primary', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-primary'), status: 'active' });
+    pool.addFixture({ id: 'claude-primary', nickname: 'primary', email: 'primary@example.test', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-primary'), status: 'active' });
     // First usage read 401 (access token expired); after the refresh, 200.
     let calls = 0;
     const expiredThenOk: FetchImpl = async () => {

--- a/tests/e2e/subscription-swap-lifecycle.test.ts
+++ b/tests/e2e/subscription-swap-lifecycle.test.ts
@@ -43,10 +43,10 @@ describe('POST /subscription-pool/swap — E2E continuity guarantee', () => {
   function boot(opts: { withAlternate: boolean }) {
     pool = new SubscriptionPool({ stateDir: dir });
     // The exhausted account (96% — over the 90 soft threshold) ...
-    pool.add({ id: 'acct-hot', nickname: 'hot', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-hot') });
+    pool.addFixture({ id: 'acct-hot', nickname: 'hot', email: 'hot@example.test', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-hot') });
     pool.update('acct-hot', { lastQuota: { sevenDay: { utilizationPct: 96, resetsAt: '2026-06-12T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback' } });
     if (opts.withAlternate) {
-      pool.add({ id: 'acct-cool', nickname: 'cool', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-cool') });
+      pool.addFixture({ id: 'acct-cool', nickname: 'cool', email: 'cool@example.test', provider: 'anthropic', framework: 'claude-code', configHome: path.join(dir, '.claude-cool') });
       pool.update('acct-cool', { lastQuota: { sevenDay: { utilizationPct: 20, resetsAt: '2026-06-09T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback' } });
     }
     refreshCalls = [];

--- a/tests/e2e/subscriptions-tab-lifecycle.test.ts
+++ b/tests/e2e/subscriptions-tab-lifecycle.test.ts
@@ -76,7 +76,7 @@ describe('/subscription-pool — Subscriptions tab E2E feature-alive', () => {
   it('feature ON: accounts + pending logins render through the live server', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sub-tab-e2e-'));
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c1' });
+    pool.addFixture({ id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c1', email: 'a1@example.test' });
     pool.update('a1', { lastQuota: { fiveHour: { utilizationPct: 12, resetsAt: '2026-06-07T01:00:00Z' }, sevenDay: { utilizationPct: 71, resetsAt: '2026-06-12T00:00:00Z' } } });
     const store = new PendingLoginStore({ stateDir: dir, now: () => Date.parse('2026-06-07T00:00:00Z') });
     const wizard = new EnrollmentWizard({ store, now: () => Date.parse('2026-06-07T00:00:00Z'),
@@ -103,7 +103,7 @@ describe('/subscription-pool — Subscriptions tab E2E feature-alive', () => {
   it('topic 29836 D1/D2/D3(a)/D5: the matrix cell carries the COMPLETE sign-in flow from the LIVE server, and a real poll tick never clobbers a half-typed code', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sub-tab-e2e-'));
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c1', email: 'a1@x.com' });
+    pool.addFixture({ id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c1', email: 'a1@x.com' });
     const store = new PendingLoginStore({ stateDir: dir, now: () => Date.parse('2026-06-07T00:00:00Z') });
     const wizard = new EnrollmentWizard({ store, now: () => Date.parse('2026-06-07T00:00:00Z'),
       driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth/authorize?code=true&client_id=x', ttlMs: 15 * 60_000 }) });
@@ -150,7 +150,7 @@ describe('/subscription-pool — Subscriptions tab E2E feature-alive', () => {
   it('restart-safe truth: live identity drift renders in-cell sign-in, then durable pending state rehydrates the full flow', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sub-tab-e2e-'));
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c1', email: 'a1@x.com' });
+    pool.addFixture({ id: 'a1', nickname: 'personal', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c1', email: 'a1@x.com' });
     pool.update('a1', { status: 'active', identityDrifted: true, identityDrift: { expectedAccountId: 'a1', actualAccountId: 'other', detectedAt: '2026-06-07T00:00:00Z', slot: '/h/.c1', repairState: 'planned' } });
     const store = new PendingLoginStore({ stateDir: dir, now: () => Date.parse('2026-06-07T00:00:00Z') });
     const wizard = new EnrollmentWizard({ store, now: () => Date.parse('2026-06-07T00:00:00Z'), driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth/renewed', ttlMs: 15 * 60_000 }) });

--- a/tests/integration/account-follow-me-delivered-mandate-enroll.test.ts
+++ b/tests/integration/account-follow-me-delivered-mandate-enroll.test.ts
@@ -44,7 +44,7 @@ function buildCtx(dir: string, opts: {
   deliveredBounds: { accountId: string; targetMachineId: string; mechanism: string } | null;
 }) {
   const pool = new SubscriptionPool({ stateDir: dir });
-  pool.add({ id: 'a1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/x/a1', email: 'approved@x.com' });
+  pool.addFixture({ id: 'a1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/x/a1', email: 'approved@x.com' });
   const enrollmentWizard = new EnrollmentWizard({
     store: new PendingLoginStore({ stateDir: dir }),
     driveLogin: async () => ({ verificationUrl: 'https://claude.com/oauth', userCode: 'WXYZ-1234', ttlMs: 15 * 60_000 }),

--- a/tests/integration/account-follow-me-enroll-start-route.test.ts
+++ b/tests/integration/account-follow-me-enroll-start-route.test.ts
@@ -51,7 +51,7 @@ function buildCtx(dir: string, opts: {
   const pool = new SubscriptionPool({ stateDir: dir });
   if (opts.knowAccountEmail) {
     // The operator-approved account is known locally with its email (authoritative S7 source).
-    pool.add({ id: 'a1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/x/a1', email: 'approved@x.com' });
+    pool.addFixture({ id: 'a1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/x/a1', email: 'approved@x.com' });
   }
   const store = new PendingLoginStore({ stateDir: dir });
   const enrollmentWizard = new EnrollmentWizard({
@@ -146,8 +146,8 @@ describe('/subscription-pool/follow-me/enroll/start (integration)', () => {
     app.use(createRoutes(ctx));
     server = await listen(app);
     const r = await post('/subscription-pool/follow-me/enroll/start', { mandateId: 'm1', accountId: 'a1' });
-    expect(r.status).toBe(409);
-    expect(r.body.error).toBe('cannot resolve approved account email');
+    expect(r.status).toBe(404);
+    expect(r.body.code).toBe('subscription-account-not-found');
     // Fail-closed: NO pending login was started with a blank/wrong email.
     const wizard = (ctx as unknown as { enrollmentWizard: EnrollmentWizard }).enrollmentWizard;
     expect(wizard.pending()).toHaveLength(0);
@@ -187,7 +187,7 @@ describe('/subscription-pool/follow-me/enroll/start (integration)', () => {
     const ctx = buildCtx(dir, { dev: true, decision: 'allow', knowAccountEmail: false, driveCapture, remoteScrapeTimeoutMs: 180000 });
     // Inject an openai account locally so the email + provider resolve to the remote-aware kind.
     const pool = (ctx as unknown as { subscriptionPool: SubscriptionPool }).subscriptionPool;
-    pool.add({ id: 'a1', nickname: 'main', provider: 'openai', framework: 'codex-cli', configHome: '/x/a1', email: 'approved@x.com' });
+    pool.addFixture({ id: 'a1', nickname: 'main', provider: 'openai', framework: 'codex-cli', configHome: '/x/a1', email: 'approved@x.com' });
     const app = express(); app.use(express.json());
     app.use(createRoutes(ctx));
     server = await listen(app);

--- a/tests/integration/account-follow-me-scan-route.test.ts
+++ b/tests/integration/account-follow-me-scan-route.test.ts
@@ -27,7 +27,7 @@ async function listen(app: express.Express): Promise<TestServer> {
 
 function buildCtx(dir: string, opts: { dev: boolean; createAttentionItem: ReturnType<typeof vi.fn> }) {
   const pool = new SubscriptionPool({ stateDir: dir });
-  pool.add({ id: 'a1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/x/a1', email: 'j@x.com' });
+  pool.addFixture({ id: 'a1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/x/a1', email: 'j@x.com' });
   return {
     config: {
       authToken: 'test', stateDir: dir, port: 0, projectName: 'echo',

--- a/tests/integration/account-follow-me-submit-code-route.test.ts
+++ b/tests/integration/account-follow-me-submit-code-route.test.ts
@@ -182,7 +182,7 @@ describe('WS5.2 code paste-back submit-code routes (integration)', () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afm-code-'));
     const ctx = buildCtx(dir, { dev: true, seedPending: false });
     const pool = (ctx as unknown as { subscriptionPool: SubscriptionPool }).subscriptionPool;
-    pool.add({
+    pool.addFixture({
       id: 'fm-1', nickname: 'main', provider: 'anthropic', framework: 'claude-code',
       configHome: path.join(dir, '.claude-followme-fm-1'), status: 'needs-reauth',
       email: 'approved@x.com',
@@ -313,7 +313,7 @@ describe('WS5.2 code paste-back submit-code routes (integration)', () => {
     const ctx = buildCtx(dir, { dev: true, seedPending: true, credentialPresent: true, oracleEmail: 'approved@x.com' });
     // The account ALREADY exists (the operator's "Needs sign-in → Sign in" matrix path).
     const pool = (ctx as unknown as { subscriptionPool: SubscriptionPool }).subscriptionPool;
-    pool.add({ id: 'fm-1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/old/home', email: 'approved@x.com', status: 'needs-reauth' });
+    pool.addFixture({ id: 'fm-1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/old/home', email: 'approved@x.com', status: 'needs-reauth' });
     const app = express(); app.use(express.json());
     app.use(createRoutes(ctx));
     server = await listen(app);

--- a/tests/integration/account-followme-revocation-route.test.ts
+++ b/tests/integration/account-followme-revocation-route.test.ts
@@ -54,7 +54,7 @@ function buildHarness(opts: { wireRevocation: boolean; enabled: boolean }) {
   const gate = new MandateGate({ store, conditions, audit });
 
   const pool = new SubscriptionPool({ stateDir: dir });
-  pool.add({
+  pool.addFixture({
     id: 'acct-x',
     nickname: 'SageMind - Justin',
     email: 'justin@example.com',

--- a/tests/integration/account-matrix-start-cell-route.test.ts
+++ b/tests/integration/account-matrix-start-cell-route.test.ts
@@ -54,7 +54,7 @@ const SELF_ID = 'this-machine';
 function buildCtx(dir: string, opts: { dev: boolean; pin: string; knowAccountEmail: boolean }) {
   const pool = new SubscriptionPool({ stateDir: dir });
   if (opts.knowAccountEmail) {
-    pool.add({ id: 'a1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/x/a1', email: 'approved@x.com' });
+    pool.addFixture({ id: 'a1', nickname: 'main', provider: 'anthropic', framework: 'claude-code', configHome: '/x/a1', email: 'approved@x.com' });
   }
   const store = new PendingLoginStore({ stateDir: dir });
   const enrollmentWizard = new EnrollmentWizard({
@@ -143,11 +143,15 @@ describe('/subscription-pool/matrix/start-cell (integration)', () => {
     expect(pending[0].configHome).toContain('.claude-followme-a1');
   });
 
-  it('(d) valid PIN but email unresolvable → 409 cannot resolve approved account email', async () => {
+  it('(d) valid PIN but email unresolvable → actionable 409', async () => {
     const ctx = await bootstrap({ dev: true, pin: '123456', knowAccountEmail: false });
     const r = await post('/subscription-pool/matrix/start-cell', { accountId: 'a1', machineId: SELF_ID, pin: '123456' });
-    expect(r.status).toBe(409);
-    expect(r.body.error).toBe('cannot resolve approved account email');
+    expect(r.status).toBe(404);
+    expect(r.body).toMatchObject({
+      code: 'subscription-account-not-found',
+      error: 'This subscription account is no longer registered.',
+      accountId: 'a1',
+    });
     const wizard = (ctx as unknown as { enrollmentWizard: EnrollmentWizard }).enrollmentWizard;
     expect(wizard.pending()).toHaveLength(0);
   });

--- a/tests/integration/credential-repointing-census-routes.test.ts
+++ b/tests/integration/credential-repointing-census-routes.test.ts
@@ -33,7 +33,7 @@ async function listen(app: express.Express): Promise<TestServer> {
 async function boot(enabled: boolean): Promise<{ server: TestServer; dir: string; pool: SubscriptionPool }> {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-census-int-'));
   const pool = new SubscriptionPool({ stateDir: dir });
-  pool.add({ id: 'claude-1', nickname: 'primary', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-1' });
+  pool.addFixture({ id: 'claude-1', nickname: 'primary', email: 'primary@example.test', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-1' });
   const app = express();
   app.use(express.json());
   const ctx: any = {

--- a/tests/integration/quota-framework-safety.integration.test.ts
+++ b/tests/integration/quota-framework-safety.integration.test.ts
@@ -18,9 +18,9 @@ describe('quota scheduler framework safety integration', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'quota-fw-int-'));
     dirs.push(dir);
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'codex-hot', nickname: 'Codex hot', provider: 'openai', framework: 'codex-cli', configHome: '/h/codex-hot' });
-    pool.add({ id: 'codex-safe', nickname: 'Codex safe', provider: 'openai', framework: 'codex-cli', configHome: '/h/codex-safe' });
-    pool.add({ id: 'claude-empty', nickname: 'Claude empty', provider: 'anthropic', framework: 'claude-code', configHome: '/h/claude-empty' });
+    pool.addFixture({ id: 'codex-hot', nickname: 'Codex hot', email: 'codex-hot@example.test', provider: 'openai', framework: 'codex-cli', configHome: '/h/codex-hot' });
+    pool.addFixture({ id: 'codex-safe', nickname: 'Codex safe', email: 'codex-safe@example.test', provider: 'openai', framework: 'codex-cli', configHome: '/h/codex-safe' });
+    pool.addFixture({ id: 'claude-empty', nickname: 'Claude empty', email: 'claude-empty@example.test', provider: 'anthropic', framework: 'claude-code', configHome: '/h/claude-empty' });
     pool.update('codex-hot', { lastQuota: { sevenDay: { utilizationPct: 99, resetsAt: '2026-07-12T00:00:00Z' }, source: 'codex-rollout' } });
     pool.update('codex-safe', { lastQuota: { sevenDay: { utilizationPct: 45, resetsAt: '2026-07-12T00:00:00Z' }, source: 'codex-rollout' } });
     pool.update('claude-empty', { lastQuota: { sevenDay: { utilizationPct: 0, resetsAt: '2026-07-11T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback' } });

--- a/tests/integration/subscription-inuse-route.test.ts
+++ b/tests/integration/subscription-inuse-route.test.ts
@@ -34,8 +34,8 @@ describe('GET /subscription-pool/in-use (integration)', () => {
     const ctx: any = { config: { authToken: 't', stateDir: dir, port: 0 }, startTime: new Date() };
     if (opts.withPool) {
       const pool = new SubscriptionPool({ stateDir: dir });
-      pool.add({ id: 'gmail', nickname: 'Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/g', email: 'headley.justin@gmail.com' });
-      pool.add({ id: 'sagemind', nickname: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/s', email: 'justin@sagemindai.io' });
+      pool.addFixture({ id: 'gmail', nickname: 'Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/g', email: 'headley.justin@gmail.com' });
+      pool.addFixture({ id: 'sagemind', nickname: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/s', email: 'justin@sagemindai.io' });
       ctx.subscriptionPool = pool;
       ctx.inUseAccountResolver = new InUseAccountResolver({ probe: async () => opts.activeEmail ?? null });
     }

--- a/tests/integration/subscription-pin-sessions.test.ts
+++ b/tests/integration/subscription-pin-sessions.test.ts
@@ -80,8 +80,8 @@ describe('subscription-pool session pinning (integration)', () => {
 
   it('pins a spawn to the scheduler-picked optimal account, end to end', async () => {
     // Two accounts; the one with MORE unused headroom + a sooner reset scores higher.
-    pool.add({ id: 'gmail-justin', nickname: 'Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-justin-gmail', email: 'headley.justin@gmail.com' });
-    pool.add({ id: 'sagemind-adriana', nickname: 'SageMind - Adriana', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-6', email: 'adriana@sagemindai.io' });
+    pool.addFixture({ id: 'gmail-justin', nickname: 'Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-justin-gmail', email: 'headley.justin@gmail.com' });
+    pool.addFixture({ id: 'sagemind-adriana', nickname: 'SageMind - Adriana', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-6', email: 'adriana@sagemindai.io' });
     // gmail nearly exhausted + far reset; adriana fresh + soon reset → adriana wins.
     pool.update('gmail-justin', { lastQuota: { sevenDay: { utilizationPct: 95, resetsAt: '2026-06-20T00:00:00Z' } } });
     pool.update('sagemind-adriana', { lastQuota: { sevenDay: { utilizationPct: 0, resetsAt: '2026-06-11T00:00:00Z' } } });
@@ -115,7 +115,7 @@ describe('subscription-pool session pinning (integration)', () => {
     const home = path.join(dir, '.claude-headless');
     fs.mkdirSync(home);
     fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'u-1' } }));
-    pool.add({ id: 'headless-acct', nickname: 'headless', provider: 'anthropic', framework: 'claude-code', configHome: home });
+    pool.addFixture({ id: 'headless-acct', nickname: 'headless', email: 'headless@example.test', provider: 'anthropic', framework: 'claude-code', configHome: home });
 
     wireResolver();
     const session = await manager.spawnSession({ name: 'pin-ready', prompt: 'p' });
@@ -157,8 +157,8 @@ describe('subscription-pool session pinning (integration)', () => {
     state.listSessions({ status: 'running' }).find((s) => s.tmuxSession === tmux);
 
   it('pins the interactive session to the scheduler-picked account, end to end', async () => {
-    pool.add({ id: 'gmail-justin', nickname: 'Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-justin-gmail', email: 'headley.justin@gmail.com' });
-    pool.add({ id: 'sagemind-adriana', nickname: 'SageMind - Adriana', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-6', email: 'adriana@sagemindai.io' });
+    pool.addFixture({ id: 'gmail-justin', nickname: 'Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-justin-gmail', email: 'headley.justin@gmail.com' });
+    pool.addFixture({ id: 'sagemind-adriana', nickname: 'SageMind - Adriana', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-echo-6', email: 'adriana@sagemindai.io' });
     pool.update('gmail-justin', { lastQuota: { sevenDay: { utilizationPct: 95, resetsAt: '2026-06-20T00:00:00Z' } } });
     pool.update('sagemind-adriana', { lastQuota: { sevenDay: { utilizationPct: 0, resetsAt: '2026-06-11T00:00:00Z' } } });
 

--- a/tests/integration/subscription-pool-routes.test.ts
+++ b/tests/integration/subscription-pool-routes.test.ts
@@ -28,16 +28,24 @@ async function listen(app: express.Express): Promise<TestServer> {
 describe('/subscription-pool routes (integration over HTTP)', () => {
   let server: TestServer;
   let dir: string;
+  let oracleResult: { email?: string; unavailable?: boolean };
+  let reconciliationBlocking: boolean;
 
   beforeEach(async () => {
+    oracleResult = { email: 'owner@example.com' };
+    reconciliationBlocking = false;
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'subpool-int-'));
     const pool = new SubscriptionPool({ stateDir: dir });
     const app = express();
     app.use(express.json());
     const ctx: any = {
-      config: { authToken: 'test', stateDir: dir, port: 0 },
+      config: { authToken: 'test', stateDir: dir, port: 0, dashboardPin: '123456' },
       startTime: new Date(),
       subscriptionPool: pool,
+      subscriptionIdentityOracle: {
+        resolveSlotTenant: async () => oracleResult,
+      },
+      subscriptionEmailBarrier: { isBlocking: () => reconciliationBlocking },
     };
     app.use(createRoutes(ctx));
     server = await listen(app);
@@ -58,6 +66,7 @@ describe('/subscription-pool routes (integration over HTTP)', () => {
     provider: 'anthropic',
     framework: 'claude-code',
     configHome: '/home/x/.claude-work',
+    email: 'owner@example.com',
   };
 
   it('GET empty pool returns 200 with an empty list', async () => {
@@ -113,6 +122,22 @@ describe('/subscription-pool routes (integration over HTTP)', () => {
     const dup = await api('/subscription-pool', { method: 'POST', body: JSON.stringify(ACCT) });
     expect(dup.status).toBe(400);
     expect(dup.body.error).toMatch(/already exists/);
+  });
+
+  it('uses stable 400 identity contracts and blocks mutation during reconciliation', async () => {
+    oracleResult = { unavailable: true };
+    const unresolved = await api('/subscription-pool', { method: 'POST', body: JSON.stringify(ACCT) });
+    expect(unresolved).toMatchObject({
+      status: 400,
+      body: { code: 'subscription-account-email-unresolved' },
+    });
+
+    reconciliationBlocking = true;
+    const blocked = await api('/subscription-pool', { method: 'POST', body: JSON.stringify(ACCT) });
+    expect(blocked).toMatchObject({
+      status: 503,
+      body: { code: 'subscription-account-email-reconciliation-running' },
+    });
   });
 
   it('POST rejects a credential-bearing body with 400 (never stores tokens)', async () => {

--- a/tests/integration/subscription-pool-scope.test.ts
+++ b/tests/integration/subscription-pool-scope.test.ts
@@ -22,10 +22,11 @@ import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 const PROJECT_NAME = 'subscription-pool-scope-it';
 let AUTH = '';
 
-interface Acct { id: string; nickname: string; provider: string; framework: string; configHome: string; status: string }
+interface Acct { id: string; nickname: string; provider: string; framework: string; configHome: string; status: string; email: string }
 const acct = (id: string): Acct => ({
   id, nickname: id, provider: 'anthropic', framework: 'claude-code',
   configHome: `/home/.config/${id}`, status: 'active',
+  email: `${id}@example.com`,
 });
 
 interface CtxOpts {

--- a/tests/integration/subscription-proactive-swap-route.test.ts
+++ b/tests/integration/subscription-proactive-swap-route.test.ts
@@ -42,8 +42,8 @@ describe('proactive-swap routes (integration)', () => {
     swapCalls = [];
     const pool = new SubscriptionPool({ stateDir: dir });
     // "hot" is at pressure; "cool" is the sub-threshold alternate.
-    pool.add({ id: 'hot', nickname: 'Hot', provider: 'anthropic', framework: 'claude-code', configHome: '/h/hot', email: 'a@x.io' });
-    pool.add({ id: 'cool', nickname: 'Cool', provider: 'anthropic', framework: 'claude-code', configHome: '/h/cool', email: 'b@x.io' });
+    pool.addFixture({ id: 'hot', nickname: 'Hot', provider: 'anthropic', framework: 'claude-code', configHome: '/h/hot', email: 'a@x.io' });
+    pool.addFixture({ id: 'cool', nickname: 'Cool', provider: 'anthropic', framework: 'claude-code', configHome: '/h/cool', email: 'b@x.io' });
     const now = Date.parse('2026-06-09T12:00:00Z');
     pool.update('hot', { lastQuota: { sevenDay: { utilizationPct: 85, resetsAt: '2026-06-10T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback', measuredAt: new Date(now - 60_000).toISOString() } });
     pool.update('cool', { lastQuota: { sevenDay: { utilizationPct: 10, resetsAt: '2026-06-10T00:00:00Z' }, source: 'oauth-usage-endpoint-fallback', measuredAt: new Date(now - 60_000).toISOString() } });

--- a/tests/integration/subscription-quota-routes.test.ts
+++ b/tests/integration/subscription-quota-routes.test.ts
@@ -42,7 +42,7 @@ describe('/subscription-pool quota routes (integration)', () => {
   beforeEach(async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qpoll-int-'));
     pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'claude-1', nickname: 'primary', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-1' });
+    pool.addFixture({ id: 'claude-1', nickname: 'primary', email: 'primary@example.test', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-1' });
     const quotaPoller = new QuotaPoller({ pool, fetchImpl: okFetch, tokenResolver: () => 'sk-ant-oat01-x' });
     const app = express();
     app.use(express.json());
@@ -130,9 +130,10 @@ describe('/subscription-pool/poll auto-refresh recovery (integration)', () => {
   }): Promise<void> {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qpoll-rec-'));
     pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({
+    pool.addFixture({
       id: 'claude-1',
       nickname: 'primary',
+      email: 'primary@example.test',
       provider: 'anthropic',
       framework: 'claude-code',
       configHome: '/h/.claude-1',

--- a/tests/unit/PostUpdateMigrator-subscriptionPoolInteractiveReady.test.ts
+++ b/tests/unit/PostUpdateMigrator-subscriptionPoolInteractiveReady.test.ts
@@ -49,12 +49,13 @@ describe('PostUpdateMigrator — subscription-pool interactive-ready sweep', () 
 
   function addAccount(id: string, configHome: string, framework: 'claude-code' | 'codex-cli' = 'claude-code') {
     const pool = new SubscriptionPool({ stateDir });
-    pool.add({
+    pool.addFixture({
       id,
       nickname: id,
       provider: framework === 'claude-code' ? 'anthropic' : 'openai',
       framework,
       configHome,
+      email: `${id}@example.test`,
     });
   }
 

--- a/tests/unit/account-follow-me-locally-executable.test.ts
+++ b/tests/unit/account-follow-me-locally-executable.test.ts
@@ -110,8 +110,8 @@ describe('WS5.2 §6.2 SubscriptionPool.locallyExecutable()', () => {
   });
 
   it('returns only accounts with a valid login (a real pool account always has a configHome)', () => {
-    pool.add({ id: 'a', nickname: 'a', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-a', status: 'active' });
-    pool.add({ id: 'b', nickname: 'b', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-b', status: 'needs-reauth' });
+    pool.addFixture({ id: 'a', nickname: 'a', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-a', status: 'active', email: 'a@example.test' });
+    pool.addFixture({ id: 'b', nickname: 'b', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.claude-b', status: 'needs-reauth', email: 'b@example.test' });
     const ex = pool.locallyExecutable();
     expect(ex.map((a) => a.id)).toEqual(['a']);
   });

--- a/tests/unit/account-followme-revocation-wiring.test.ts
+++ b/tests/unit/account-followme-revocation-wiring.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
 
 function poolWithAccount(): SubscriptionPool {
   const pool = new SubscriptionPool({ stateDir: dir });
-  pool.add({
+  pool.addFixture({
     id: 'acct-x',
     nickname: 'SageMind - Justin',
     email: 'justin@example.com',
@@ -207,7 +207,7 @@ describe('deletion-safety guard — never recursively delete a shared/default/ro
     // never touched.
     const protectedHome = path.join(os.homedir(), '.claude');
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({
+    pool.addFixture({
       id: 'acct-default',
       nickname: 'Primary',
       email: 'justin@example.com',

--- a/tests/unit/credential-location-gate.test.ts
+++ b/tests/unit/credential-location-gate.test.ts
@@ -208,7 +208,7 @@ describe('QuotaPoller census #2 (401-refresh) — slot re-routing', () => {
 describe('QuotaPoller census #3 (email auto-patch) — SUPPRESSED while enabled', () => {
   it('flag ON → no email auto-patch (suppressed)', async () => {
     const pool = new SubscriptionPool({ stateDir: tmp });
-    pool.add({ id: 'acct-a', nickname: 'A', provider: 'anthropic', framework: 'claude-code', configHome: tmp, email: 'old@x.com' } as never);
+    pool.addFixture({ id: 'acct-a', nickname: 'A', provider: 'anthropic', framework: 'claude-code', configHome: tmp, email: 'old@x.com' } as never);
     const gate = new CredentialLocationGate({ isEnabled: () => true, ledger: ledgerWith(tmp, 'acct-a') });
     // .claude.json in tmp records a DIFFERENT email — today this would be auto-patched.
     fs.writeFileSync(path.join(tmp, '.claude.json'), JSON.stringify({ oauthAccount: { emailAddress: 'observed@y.com' } }));
@@ -219,16 +219,16 @@ describe('QuotaPoller census #3 (email auto-patch) — SUPPRESSED while enabled'
     expect(patchedEmail).toBe(false); // suppressed — no cross-contamination
   });
 
-  it('flag OFF → email auto-patch happens (today\'s behavior preserved)', async () => {
+  it('flag OFF → email remains registrar-owned (no quota-poller identity mutation)', async () => {
     const pool = new SubscriptionPool({ stateDir: tmp });
-    pool.add({ id: 'acct-a', nickname: 'A', provider: 'anthropic', framework: 'claude-code', configHome: tmp, email: 'old@x.com' } as never);
+    pool.addFixture({ id: 'acct-a', nickname: 'A', provider: 'anthropic', framework: 'claude-code', configHome: tmp, email: 'old@x.com' } as never);
     const gate = new CredentialLocationGate({ isEnabled: () => false, ledger: ledgerWith(tmp, 'acct-a') });
     fs.writeFileSync(path.join(tmp, '.claude.json'), JSON.stringify({ oauthAccount: { emailAddress: 'observed@y.com' } }));
     const updateSpy = vi.spyOn(pool, 'update');
     const poller = new QuotaPoller({ pool, fetchImpl: okFetch, tokenResolver: () => 'sk-ant-oat-x', locationGate: gate });
     await poller.pollAll();
     const patchedEmail = updateSpy.mock.calls.some((c) => (c[1] as Record<string, unknown>).email === 'observed@y.com');
-    expect(patchedEmail).toBe(true);
+    expect(patchedEmail).toBe(false);
   });
 });
 

--- a/tests/unit/credential-write-routing.test.ts
+++ b/tests/unit/credential-write-routing.test.ts
@@ -136,6 +136,7 @@ describe('Step 4b — QuotaPoller maps a write-skipped refresh to no-snapshot, N
   const ACCT = {
     id: 'claude-1',
     nickname: 'primary',
+    email: 'primary@example.test',
     provider: 'anthropic' as const,
     framework: 'claude-code' as const,
     configHome: HOME,
@@ -161,7 +162,7 @@ describe('Step 4b — QuotaPoller maps a write-skipped refresh to no-snapshot, N
       tokenResolver: () => 'sk-ant-oat01-x',
       refresher: async () => ({ ok: false, reason: 'write-skipped' }),
     });
-    pool.add({ ...ACCT });
+    pool.addFixture({ ...ACCT });
     const snap = await p.pollAccount(pool.get('claude-1')!);
     expect(snap).toBeNull();
     expect(pool.get('claude-1')!.status).not.toBe('needs-reauth');
@@ -174,7 +175,7 @@ describe('Step 4b — QuotaPoller maps a write-skipped refresh to no-snapshot, N
       tokenResolver: () => 'sk-ant-oat01-x',
       refresher: async () => ({ ok: false, reason: 'exchange-failed' }),
     });
-    pool.add({ ...ACCT });
+    pool.addFixture({ ...ACCT });
     const snap = await p.pollAccount(pool.get('claude-1')!);
     expect(snap).toBeNull();
     expect(pool.get('claude-1')!.status).toBe('needs-reauth');

--- a/tests/unit/follow-me-consumer-agent-loop.test.ts
+++ b/tests/unit/follow-me-consumer-agent-loop.test.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  for (const dir of dirs.splice(0)) {
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'follow-me-agent-loop-test' });
+  }
+});
+
+describe('AgentServer delivered follow-me controller', () => {
+  it('attempts once per pair, parks unchanged identity failures, and wakes only when identity resolves', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-23T00:00:00.000Z'));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'follow-me-agent-loop-'));
+    dirs.push(stateDir);
+    const mandate = (id: string) => ({
+      id,
+      portable: {
+        mandate: {
+          revoked: false,
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+          authorities: [{ action: 'account-follow-me', bounds: { accountId: 'acct' } }],
+        },
+      },
+    });
+    const server = Object.create(AgentServer.prototype) as AgentServer & Record<string, unknown>;
+    server.config = {
+      host: '127.0.0.1', port: 4044, authToken: 'test', stateDir, projectName: 'test',
+      machineId: 'target',
+    };
+    server.deliveredMandateStore = { list: () => [mandate('m1'), mandate('m2')] };
+    server.followMeConsumerRunning = false;
+    server.followMeConsumerBackoff = null;
+
+    let resolved = false;
+    let enrollCalls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.includes('pending-logins')) return new Response(JSON.stringify({ logins: [] }), { status: 200 });
+      if (url.includes('scope=pool')) {
+        return new Response(JSON.stringify(resolved
+          ? { accounts: [{ id: 'acct', email: 'owner@example.com' }], emailGaps: [] }
+          : { accounts: [], emailGaps: [{ accountId: 'acct' }] }), { status: 200 });
+      }
+      if (url.endsWith('/subscription-pool')) {
+        return new Response(JSON.stringify({ accounts: [] }), { status: 200 });
+      }
+      enrollCalls += 1;
+      return new Response(JSON.stringify({
+        code: 'account-record-missing-email',
+      }), { status: 409 });
+    }));
+
+    const advances = [0, 60_000, 5 * 60_000, 15 * 60_000];
+    for (let pass = 0; pass < 4; pass += 1) {
+      vi.advanceTimersByTime(advances[pass]!);
+      await (server as unknown as { driveDeliveredFollowMeEnrollments(): Promise<void> })
+        .driveDeliveredFollowMeEnrollments();
+    }
+    expect(enrollCalls).toBe(4);
+    await (server as unknown as { driveDeliveredFollowMeEnrollments(): Promise<void> })
+      .driveDeliveredFollowMeEnrollments();
+    expect(enrollCalls).toBe(4);
+
+    resolved = true;
+    await (server as unknown as { driveDeliveredFollowMeEnrollments(): Promise<void> })
+      .driveDeliveredFollowMeEnrollments();
+    expect(enrollCalls).toBe(5);
+  });
+});

--- a/tests/unit/follow-me-consumer-backoff-store.test.ts
+++ b/tests/unit/follow-me-consumer-backoff-store.test.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  FollowMeConsumerBackoffStore,
+  classifyFollowMeFailure,
+  followMeBackoffKey,
+} from '../../src/coordination/FollowMeConsumerBackoffStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const dirs: string[] = [];
+const make = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'follow-me-backoff-'));
+  dirs.push(dir);
+  return { dir, store: new FollowMeConsumerBackoffStore(dir) };
+};
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'follow-me-backoff-test' });
+  }
+});
+
+describe('FollowMeConsumerBackoffStore', () => {
+  it('uses 1m/5m/15m then parks one durable pair episode', () => {
+    const { dir, store } = make();
+    const key = followMeBackoffKey('account-a', 'machine-b');
+    const t0 = Date.parse('2026-07-23T00:00:00.000Z');
+
+    expect(store.shouldAttempt(key, t0)).toBe(true);
+    expect(store.recordFailure(key, 'identity', t0)).toMatchObject({ attempts: 1, parkedAt: null });
+    expect(store.shouldAttempt(key, t0 + 59_999)).toBe(false);
+    expect(store.shouldAttempt(key, t0 + 60_000)).toBe(true);
+    store.recordFailure(key, 'identity', t0 + 60_000);
+    store.recordFailure(key, 'other', t0 + 6 * 60_000);
+    const parked = store.recordFailure(key, 'other', t0 + 21 * 60_000);
+    expect(parked).toMatchObject({ attempts: 4, lane: 'identity' });
+    expect(parked.parkedAt).not.toBeNull();
+
+    const reloaded = new FollowMeConsumerBackoffStore(dir);
+    expect(reloaded.shouldAttempt(key, t0 + 365 * 24 * 60 * 60_000)).toBe(false);
+  });
+
+  it('clears an episode only after success', () => {
+    const { store } = make();
+    const key = followMeBackoffKey('a', 'm');
+    store.recordFailure(key, 'other', 0);
+    store.clear(key);
+    expect(store.shouldAttempt(key, 0)).toBe(true);
+  });
+
+  it('starts one fresh bounded episode only when causal evidence changes', () => {
+    const { store } = make();
+    const key = followMeBackoffKey('a', 'm');
+    const missing = {
+      identityEvidenceKey: 'missing',
+      identityResolved: false,
+      authoritySetKey: 'mandate-1',
+    };
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      store.recordFailure(key, 'identity', attempt * 1_000, missing, 'account-record-missing-email');
+    }
+    expect(store.shouldAttempt(key, 99_000, missing)).toBe(false);
+    expect(store.shouldAttempt(key, 99_000, { ...missing, authoritySetKey: 'mandate-2' })).toBe(false);
+    expect(store.shouldAttempt(key, 99_000, {
+      identityEvidenceKey: 'conflict:a@example.com,b@example.com',
+      identityResolved: false,
+      authoritySetKey: 'mandate-2',
+    })).toBe(false);
+    expect(store.shouldAttempt(key, 99_000, {
+      identityEvidenceKey: 'resolved:a@example.com',
+      identityResolved: true,
+      authoritySetKey: 'mandate-2',
+    })).toBe(true);
+    expect(store.get(key)).toBeNull();
+  });
+
+  it('wakes a parked non-identity episode only for changed authority', () => {
+    const { store } = make();
+    const key = followMeBackoffKey('a', 'm');
+    const evidence = {
+      identityEvidenceKey: 'resolved:a@example.com',
+      identityResolved: true,
+      authoritySetKey: 'mandate-1',
+    };
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      store.recordFailure(key, 'other', attempt * 1_000, evidence, 'mandate-refused');
+    }
+    expect(store.shouldAttempt(key, 99_000, {
+      ...evidence,
+      identityEvidenceKey: 'resolved:new@example.com',
+    })).toBe(false);
+    expect(store.shouldAttempt(key, 99_000, { ...evidence, authoritySetKey: 'mandate-2' })).toBe(true);
+  });
+
+  it('classifies the honest identity 409s', () => {
+    expect(classifyFollowMeFailure(409, 'account-record-missing-email')).toBe('identity');
+    expect(classifyFollowMeFailure(409, 'account-record-email-conflict')).toBe('identity');
+    expect(classifyFollowMeFailure(409, 'something-else')).toBe('other');
+  });
+});

--- a/tests/unit/quota-poller.test.ts
+++ b/tests/unit/quota-poller.test.ts
@@ -43,6 +43,7 @@ function throwFetch(): FetchImpl {
 const ACCT = {
   id: 'claude-1',
   nickname: 'primary',
+  email: 'primary@example.test',
   provider: 'anthropic' as const,
   framework: 'claude-code' as const,
   configHome: '/home/x/.claude-primary',
@@ -152,14 +153,14 @@ describe('QuotaPoller', () => {
   // ── pollAccount lifecycle ─────────────────────────────────────────
   it('pollAccount returns a snapshot on a clean read', async () => {
     const p = new QuotaPoller({ pool, fetchImpl: okFetch(LIVE_USAGE_BODY), tokenResolver: () => 'sk-ant-oat01-x' });
-    pool.add({ ...ACCT });
+    pool.addFixture({ ...ACCT });
     const snap = await p.pollAccount(pool.get('claude-1')!);
     expect(snap?.sevenDay?.utilizationPct).toBe(71);
   });
 
   it('attributes quota to live token identity, marks drift, and caches the oracle probe', async () => {
-    pool.add({ ...ACCT, email: 'expected@example.test' });
-    pool.add({
+    pool.addFixture({ ...ACCT, email: 'expected@example.test' });
+    pool.addFixture({
       id: 'claude-2', nickname: 'actual', provider: 'anthropic', framework: 'claude-code',
       configHome: '/home/x/.claude-actual', email: 'actual@example.test',
     });
@@ -180,7 +181,7 @@ describe('QuotaPoller', () => {
   });
 
   it('self-closes drift and its residual callback on the first matching identity poll', async () => {
-    pool.add({ ...ACCT, email: 'expected@example.test' });
+    pool.addFixture({ ...ACCT, email: 'expected@example.test' });
     pool.update(ACCT.id, {
       identityDrifted: true,
       identityDrift: {
@@ -202,8 +203,8 @@ describe('QuotaPoller', () => {
   });
 
   it('invalidates cached pre-repair identity so the immediate poll observes the repaired tenant', async () => {
-    pool.add({ ...ACCT });
-    pool.add({ ...ACCT, id: 'claude-2', configHome: '/home/x/.claude-2' });
+    pool.addFixture({ ...ACCT });
+    pool.addFixture({ ...ACCT, id: 'claude-2', configHome: '/home/x/.claude-2' });
     let live = 'claude-2';
     let probes = 0;
     const p = new QuotaPoller({
@@ -221,7 +222,7 @@ describe('QuotaPoller', () => {
 
   it('pollAccount returns null when the token is unresolvable', async () => {
     const p = new QuotaPoller({ pool, fetchImpl: okFetch(LIVE_USAGE_BODY), tokenResolver: () => null });
-    pool.add({ ...ACCT });
+    pool.addFixture({ ...ACCT });
     expect(await p.pollAccount(pool.get('claude-1')!)).toBeNull();
   });
 
@@ -233,7 +234,7 @@ describe('QuotaPoller', () => {
       tokenResolver: () => ({ reauthNeeded: true, reason: 'unparseable-credential-blob' }),
       logger: { log: () => {}, warn: (message) => warnings.push(message) },
     });
-    pool.add({ ...ACCT });
+    pool.addFixture({ ...ACCT });
 
     expect(await p.pollAccount(pool.get('claude-1')!)).toBeNull();
     expect(pool.get('claude-1')!.status).toBe('needs-reauth');
@@ -250,7 +251,7 @@ describe('QuotaPoller', () => {
       tokenResolver: () => 'sk-ant-oat01-x',
       refresher: async () => ({ ok: false, reason: 'no-refresh-token' }),
     });
-    pool.add({ ...ACCT });
+    pool.addFixture({ ...ACCT });
     const snap = await p.pollAccount(pool.get('claude-1')!);
     expect(snap).toBeNull();
     expect(pool.get('claude-1')!.status).toBe('needs-reauth');
@@ -271,7 +272,7 @@ describe('QuotaPoller', () => {
       tokenResolver: () => 'sk-ant-oat01-EXPIRED',
       refresher: async () => ({ ok: true, accessToken: 'sk-ant-oat01-FRESH', expiresAt: 9e12, rotated: true }),
     });
-    pool.add({ ...ACCT, status: 'active' });
+    pool.addFixture({ ...ACCT, status: 'active' });
     const snap = await p.pollAccount(pool.get('claude-1')!);
     expect(snap?.sevenDay?.utilizationPct).toBe(71); // recovered: got the usage
     expect(pool.get('claude-1')!.status).toBe('active'); // NOT needs-reauth
@@ -286,14 +287,14 @@ describe('QuotaPoller', () => {
       tokenResolver: () => 'sk-ant-oat01-x',
       refresher: async () => ({ ok: true, accessToken: 'sk-ant-oat01-FRESH', expiresAt: 9e12, rotated: false }),
     });
-    pool.add({ ...ACCT });
+    pool.addFixture({ ...ACCT });
     expect(await p.pollAccount(pool.get('claude-1')!)).toBeNull();
     expect(pool.get('claude-1')!.status).toBe('needs-reauth');
   });
 
   it('pollAccount returns null on a network error (no status change)', async () => {
     const p = new QuotaPoller({ pool, fetchImpl: throwFetch(), tokenResolver: () => 'sk-ant-oat01-x' });
-    pool.add({ ...ACCT, status: 'active' });
+    pool.addFixture({ ...ACCT, status: 'active' });
     expect(await p.pollAccount(pool.get('claude-1')!)).toBeNull();
     expect(pool.get('claude-1')!.status).toBe('active');
   });
@@ -312,9 +313,9 @@ describe('QuotaPoller', () => {
         secondary: { usedPercent: 64, remainingPercent: 36, windowMinutes: 10080, resetsAt: 1781269200, resetsAtIso: '2026-06-12T13:00:00.000Z', resetsInSeconds: 1 },
       }),
     });
-    pool.add({ ...ACCT, id: 'claude-1' });
-    pool.add({ ...ACCT, id: 'codex-1', provider: 'openai', framework: 'codex-cli' });
-    pool.add({ ...ACCT, id: 'claude-off', status: 'disabled' }); // skipped (disabled)
+    pool.addFixture({ ...ACCT, id: 'claude-1' });
+    pool.addFixture({ ...ACCT, id: 'codex-1', provider: 'openai', framework: 'codex-cli' });
+    pool.addFixture({ ...ACCT, id: 'claude-off', status: 'disabled' }); // skipped (disabled)
     const res = await p.pollAll();
     expect(res.polled).toBe(2);
     expect(pool.get('claude-1')!.lastQuota?.sevenDay?.utilizationPct).toBe(71);
@@ -338,7 +339,7 @@ describe('QuotaPoller', () => {
         secondary: { usedPercent: 40, remainingPercent: 60, windowMinutes: 10080, resetsAt: 2, resetsAtIso: '2026-06-12T00:00:00Z', resetsInSeconds: 1 },
       }),
     });
-    pool.add({ ...ACCT, id: 'codex-reset', provider: 'openai', framework: 'codex-cli' });
+    pool.addFixture({ ...ACCT, id: 'codex-reset', provider: 'openai', framework: 'codex-cli' });
     await p.pollAll();
     expect(pool.get('codex-reset')!.lastQuota).toMatchObject({
       fiveHour: { utilizationPct: 0, resetsAt: '' },
@@ -349,7 +350,7 @@ describe('QuotaPoller', () => {
 
   it('pollAll restores a needs-reauth account to active on a clean read', async () => {
     const p = new QuotaPoller({ pool, fetchImpl: okFetch(LIVE_USAGE_BODY), tokenResolver: () => 'sk-ant-oat01-x' });
-    pool.add({ ...ACCT, status: 'needs-reauth' });
+    pool.addFixture({ ...ACCT, status: 'needs-reauth' });
     await p.pollAll();
     expect(pool.get('claude-1')!.status).toBe('active');
   });
@@ -361,7 +362,7 @@ describe('QuotaPoller', () => {
     let clock = Date.parse('2026-06-07T05:00:00Z');
     const fetchImpl: FetchImpl = async () => ({ ok: true, status: 200, json: async () => body });
     const p = new QuotaPoller({ pool, fetchImpl, tokenResolver: () => 'sk-ant-oat01-x' });
-    pool.add({ ...ACCT });
+    pool.addFixture({ ...ACCT });
 
     // Manually drive two reads with controlled measuredAt via mapUsageResponse paths:
     // first read

--- a/tests/unit/resolve-follow-me-enroll-target.test.ts
+++ b/tests/unit/resolve-follow-me-enroll-target.test.ts
@@ -26,7 +26,7 @@ describe('resolveFollowMeEnrollTarget', () => {
     expect(r).toMatchObject({ resolved: true, expectedEmail: 'approved@x.com', provider: 'anthropic', framework: 'claude-code', label: 'a1' });
   });
 
-  it('prefers the local pool over a peer view (no override from a peer)', () => {
+  it('fails closed when local and peer holder identity conflicts', () => {
     const peerViews: MachinePoolView[] = [
       { machineId: 'mini', nickname: 'the Mini', accounts: [{ accountId: 'a1', email: 'peer@x.com', status: 'active', locallyHeld: false }] },
     ];
@@ -35,7 +35,7 @@ describe('resolveFollowMeEnrollTarget', () => {
       localAccounts: [{ id: 'a1', email: 'local@x.com', nickname: 'main', provider: 'anthropic', framework: 'claude-code' }],
       peerViews,
     });
-    expect(r).toMatchObject({ resolved: true, expectedEmail: 'local@x.com' });
+    expect(r).toMatchObject({ resolved: false, code: 'account-record-email-conflict' });
   });
 
   it('FAILS CLOSED when no holder reports an email', () => {
@@ -43,7 +43,11 @@ describe('resolveFollowMeEnrollTarget', () => {
       { machineId: 'mini', nickname: 'the Mini', accounts: [{ accountId: 'a1', status: 'active', locallyHeld: false }] },
     ];
     const r = resolveFollowMeEnrollTarget({ accountId: 'a1', localAccounts: [{ id: 'a1' }], peerViews });
-    expect(r).toEqual({ resolved: false, reason: 'cannot resolve approved account email' });
+    expect(r).toEqual({
+      resolved: false,
+      code: 'account-record-missing-email',
+      reason: 'This subscription account record is missing its email. Repair or re-enroll the account, then try again.',
+    });
   });
 
   it('FAILS CLOSED for an unknown account', () => {

--- a/tests/unit/subscription-account-email-repair.test.ts
+++ b/tests/unit/subscription-account-email-repair.test.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SubscriptionPool } from '../../src/core/SubscriptionPool.js';
+import { repairMissingSubscriptionEmails } from '../../src/core/SubscriptionAccountEmailRepair.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'subscription-email-repair-test' });
+  }
+});
+
+function legacyPool() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'subscription-email-repair-'));
+  dirs.push(dir);
+  fs.writeFileSync(path.join(dir, 'subscription-pool.json'), JSON.stringify({
+    version: 1,
+    lastModified: new Date(0).toISOString(),
+    accounts: [{
+      id: 'legacy', nickname: 'Legacy', provider: 'anthropic', framework: 'claude-code',
+      configHome: '/slot/legacy', status: 'active', enrolledAt: new Date(0).toISOString(), version: 1,
+    }],
+  }));
+  return { dir, pool: new SubscriptionPool({ stateDir: dir }) };
+}
+
+describe('repairMissingSubscriptionEmails', () => {
+  it('backfills a legacy gap from its own credential oracle', async () => {
+    const { dir, pool } = legacyPool();
+    const result = await repairMissingSubscriptionEmails(pool, {
+      resolveSlotTenant: async (slot) => slot === '/slot/legacy'
+        ? { email: 'Owner@Example.com' }
+        : { unavailable: true, reason: 'wrong slot' },
+    }, { tenantOf: () => 'legacy', version: 1 });
+    expect(result).toEqual({ scanned: 1, repaired: ['legacy'], unresolved: [] });
+    expect(pool.get('legacy')?.email).toBe('Owner@Example.com');
+    expect(JSON.parse(fs.readFileSync(path.join(dir, 'subscription-pool.json'), 'utf8')).accounts[0].email)
+      .toBe('Owner@Example.com');
+  });
+
+  it('leaves an unresolved gap quarantined and reports it honestly', async () => {
+    const { pool } = legacyPool();
+    const result = await repairMissingSubscriptionEmails(pool, {
+      resolveSlotTenant: async () => ({ unavailable: true, reason: 'not signed in' }),
+    }, { tenantOf: () => 'legacy', version: 1 });
+    expect(result.unresolved).toEqual([{ accountId: 'legacy', reason: 'identity-oracle-unavailable' }]);
+    expect(pool.get('legacy')).toBeNull();
+    expect(pool.listEmailGaps()).toHaveLength(1);
+  });
+
+  it('refuses repair without an independent slot-to-account binding', async () => {
+    const { pool } = legacyPool();
+    const result = await repairMissingSubscriptionEmails(
+      pool,
+      { resolveSlotTenant: async () => ({ email: 'owner@example.com' }) },
+      { tenantOf: () => null, version: 1 },
+    );
+    expect(result.unresolved).toEqual([{ accountId: 'legacy', reason: 'account-binding-unproven' }]);
+    expect(pool.listEmailGaps()).toHaveLength(1);
+  });
+
+  it('refuses when the binding epoch changes during the provider probe', async () => {
+    const { pool } = legacyPool();
+    let epoch = 1;
+    const result = await repairMissingSubscriptionEmails(
+      pool,
+      {
+        resolveSlotTenant: async () => {
+          epoch = 2;
+          return { email: 'owner@example.com' };
+        },
+      },
+      { tenantOf: () => 'legacy', get version() { return epoch; } },
+    );
+    expect(result.unresolved).toEqual([{ accountId: 'legacy', reason: 'account-binding-changed' }]);
+    expect(pool.listEmailGaps()).toHaveLength(1);
+  });
+
+  it('settles at the whole-sweep deadline and prevents a late identity commit', async () => {
+    const { pool } = legacyPool();
+    const startedAt = Date.now();
+    const result = await repairMissingSubscriptionEmails(
+      pool,
+      {
+        resolveSlotTenant: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 80));
+          return { email: 'owner@example.com' };
+        },
+      },
+      { tenantOf: () => 'legacy', version: 1 },
+      { timeoutMs: 15 },
+    );
+    expect(Date.now() - startedAt).toBeLessThan(60);
+    expect(result.unresolved).toEqual([{ accountId: 'legacy', reason: 'reconciliation-timeout' }]);
+    await new Promise((resolve) => setTimeout(resolve, 90));
+    expect(pool.listEmailGaps()).toHaveLength(1);
+  });
+});

--- a/tests/unit/subscription-account-email.test.ts
+++ b/tests/unit/subscription-account-email.test.ts
@@ -24,27 +24,29 @@ afterEach(() => {
 describe('SubscriptionPool email field', () => {
   it('add() stores the email; list() reflects it', () => {
     const pool = new SubscriptionPool({ stateDir: dir });
-    const a = pool.add({ id: 'sm-justin', nickname: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c', email: 'justin@sagemindai.io' });
+    const a = pool.addFixture({ id: 'sm-justin', nickname: 'SageMind - Justin', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c', email: 'justin@sagemindai.io' });
     expect(a.email).toBe('justin@sagemindai.io');
     expect(pool.get('sm-justin')?.email).toBe('justin@sagemindai.io');
   });
 
-  it('add() without email leaves it undefined (back-compat)', () => {
+  it('add() refuses a missing email', () => {
     const pool = new SubscriptionPool({ stateDir: dir });
-    const a = pool.add({ id: 'x', nickname: 'x', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c' });
-    expect(a.email).toBeUndefined();
+    expect(() => pool.addFixture({
+      id: 'x', nickname: 'x', provider: 'anthropic', framework: 'claude-code',
+      configHome: '/h/.c', email: undefined as unknown as string,
+    })).toThrow(/email is required/);
   });
 
-  it('update() patches the email; empty string clears it', () => {
+  it('generic update cannot patch or clear identity email', () => {
     const pool = new SubscriptionPool({ stateDir: dir });
-    pool.add({ id: 'x', nickname: 'x', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c' });
-    expect(pool.update('x', { email: 'a@b.com' })?.email).toBe('a@b.com');
-    expect(pool.update('x', { email: '' })?.email).toBeUndefined();
+    pool.addFixture({ id: 'x', nickname: 'x', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c', email: 'original@example.com' });
+    pool.update('x', { nickname: 'renamed' });
+    expect(pool.get('x')?.email).toBe('original@example.com');
   });
 
   it('email is not a credential field — add does not throw on it', () => {
     const pool = new SubscriptionPool({ stateDir: dir });
-    expect(() => pool.add({ id: 'y', nickname: 'y', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c', email: 'z@z.com' }, { email: 'z@z.com' })).not.toThrow();
+    expect(() => pool.addFixture({ id: 'y', nickname: 'y', provider: 'anthropic', framework: 'claude-code', configHome: '/h/.c', email: 'z@z.com' }, { email: 'z@z.com' })).not.toThrow();
   });
 });
 
@@ -60,20 +62,19 @@ describe('readAccountEmail', () => {
   });
 });
 
-describe('QuotaPoller auto-populates account.email from the real login', () => {
+describe('QuotaPoller preserves registrar-owned account.email', () => {
   const USAGE = { five_hour: { utilization: 10, resets_at: '2026-06-07T01:00:00Z' }, seven_day: { utilization: 40, resets_at: '2026-06-12T00:00:00Z' } };
   const okFetch: FetchImpl = async () => ({ ok: true, status: 200, json: async () => USAGE });
 
-  it('writes the email read from the config home onto the account', async () => {
+  it('does not overwrite identity from quota-side config metadata', async () => {
     // config home whose login record says a specific account
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-home-'));
     fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({ oauthAccount: { emailAddress: 'real@account.com' } }));
     const pool = new SubscriptionPool({ stateDir: dir });
-    // registered with NO email (or a stale one) — poll should fill it from reality
-    pool.add({ id: 'acc', nickname: 'Acc', provider: 'anthropic', framework: 'claude-code', configHome: home });
+    pool.addFixture({ id: 'acc', nickname: 'Acc', provider: 'anthropic', framework: 'claude-code', configHome: home, email: 'attested@account.com' });
     const poller = new QuotaPoller({ pool, fetchImpl: okFetch, tokenResolver: () => 'sk-ant-oat01-x' });
     await poller.pollAll();
-    expect(pool.get('acc')?.email).toBe('real@account.com');
+    expect(pool.get('acc')?.email).toBe('attested@account.com');
     try { SafeFsExecutor.safeRmSync(home, { recursive: true, force: true, operation: 'test:cleanup-home' }); } catch { /* @silent-fallback-ok */ }
   });
 });

--- a/tests/unit/subscription-email-route-capability-inventory.test.ts
+++ b/tests/unit/subscription-email-route-capability-inventory.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SUBSCRIPTION_POOL_WRITE_CAPABILITIES } from '../../src/server/routes.js';
+
+describe('subscription email reconciliation route capability inventory', () => {
+  it('classifies every mutating subscription-pool route and no nonexistent route', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../src/server/routes.ts'),
+      'utf8',
+    );
+    const actual = [...source.matchAll(
+      /router\.(post|patch|delete)\('([^']*\/subscription-pool[^']*)'/g,
+    )].map((match) => `${match[1]!.toUpperCase()} ${match[2]}`).sort();
+    expect(Object.keys(SUBSCRIPTION_POOL_WRITE_CAPABILITIES).sort()).toEqual(actual);
+    for (const route of actual) {
+      const [method, routePath] = route.split(' ', 2);
+      const escapedPath = routePath!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const escapedRoute = route.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      expect(source).toMatch(new RegExp(
+        `router\\.${method!.toLowerCase()}\\('${escapedPath}',\\s*` +
+        `enforceSubscriptionPoolWriteCapability\\('${escapedRoute}'\\)`,
+      ));
+    }
+  });
+
+  it('defaults identity mutation paths to barrier-required unless explicitly exempted', () => {
+    const required = Object.entries(SUBSCRIPTION_POOL_WRITE_CAPABILITIES)
+      .filter(([, capability]) => capability === 'requiresEmailReconciliation')
+      .map(([route]) => route)
+      .sort();
+    expect(required).toEqual([
+      'POST /subscription-pool',
+      'POST /subscription-pool/:id/repair-email',
+      'POST /subscription-pool/enroll',
+      'POST /subscription-pool/enroll/:id/complete',
+      'POST /subscription-pool/follow-me/enroll/:id/complete',
+      'POST /subscription-pool/follow-me/enroll/start',
+      'POST /subscription-pool/matrix/start-cell',
+    ]);
+  });
+});

--- a/tests/unit/subscription-pool-scope.test.ts
+++ b/tests/unit/subscription-pool-scope.test.ts
@@ -97,7 +97,13 @@ describe('GET /subscription-pool?scope=pool — merge/tag/classify (unit, mocked
 
   it('merges a healthy peer, tagging self remote:false and remote accounts remote:true + machine identity', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      fakeResp(true, 200, { enabled: true, count: 1, accounts: [acct('peer-a')] }),
+      fakeResp(true, 200, {
+        enabled: true,
+        count: 1,
+        accounts: [acct('peer-a')],
+        emailGaps: [{ accountId: 'peer-gap', nickname: 'Peer gap', reason: 'account-record-missing-email' }],
+        emailReconciliation: { state: 'degraded', unresolvedCount: 1, repairRunsFreshProbe: true },
+      }),
     );
     const app = mount(tmpDir, {
       selfAccounts: [acct('self-a')], meshSelfId: 'm_a',
@@ -118,6 +124,17 @@ describe('GET /subscription-pool?scope=pool — merge/tag/classify (unit, mocked
     expect(peer.remote).toBe(true);
     expect(peer.machineId).toBe('m_b');
     expect(peer.machineNickname).toBe('Mac Mini');
+    expect(res.body.emailGaps).toContainEqual(expect.objectContaining({
+      accountId: 'peer-gap',
+      machineId: 'm_b',
+      machineNickname: 'Mac Mini',
+      remote: true,
+    }));
+    expect(res.body.emailReconciliation).toEqual({
+      state: 'degraded',
+      unresolvedCount: 1,
+      repairRunsFreshProbe: true,
+    });
   });
 
   it('a 401 peer → a classified `unauthorized` pool.failed row (never a throw)', async () => {

--- a/tests/unit/subscription-pool.test.ts
+++ b/tests/unit/subscription-pool.test.ts
@@ -21,6 +21,7 @@ const VALID = {
   provider: 'anthropic' as const,
   framework: 'claude-code' as const,
   configHome: '/Users/x/.claude-personal',
+  email: 'person@example.com',
 };
 
 describe('SubscriptionPool', () => {
@@ -44,7 +45,7 @@ describe('SubscriptionPool', () => {
 
   // ── add: happy path ─────────────────────────────────────────────
   it('adds a valid account and persists it', () => {
-    const a = pool.add({ ...VALID });
+    const a = pool.addFixture({ ...VALID });
     expect(a.id).toBe('claude-acct-2');
     expect(a.status).toBe('active');     // default
     expect(a.version).toBe(1);
@@ -58,7 +59,7 @@ describe('SubscriptionPool', () => {
   });
 
   it('stores configHome (the login location), never tokens', () => {
-    const a = pool.add({ ...VALID });
+    const a = pool.addFixture({ ...VALID });
     const raw = fs.readFileSync(path.join(dir, 'subscription-pool.json'), 'utf-8');
     expect(a.configHome).toBe('/Users/x/.claude-personal');
     // No credential-ish keys ever land in the persisted file.
@@ -67,49 +68,53 @@ describe('SubscriptionPool', () => {
   });
 
   // ── add: validation — both sides of each boundary ───────────────
+  it('refuses to create an account without a provider identity email', () => {
+    expect(() => pool.addFixture({ ...VALID, email: undefined as unknown as string })).toThrow(/email is required/);
+    expect(() => pool.addFixture({ ...VALID, email: 'not-an-email' })).toThrow(/valid non-blank/);
+  });
   it('rejects a missing id', () => {
-    expect(() => pool.add({ ...VALID, id: '' })).toThrow(ValidationError);
+    expect(() => pool.addFixture({ ...VALID, id: '' })).toThrow(ValidationError);
   });
 
   it('rejects an id with illegal charset, accepts a clean one', () => {
-    expect(() => pool.add({ ...VALID, id: 'Has Space' })).toThrow(/\^\[a-z0-9-\]/);
-    expect(() => pool.add({ ...VALID, id: 'UPPER' })).toThrow(ValidationError);
-    expect(pool.add({ ...VALID, id: 'ok-123' }).id).toBe('ok-123');
+    expect(() => pool.addFixture({ ...VALID, id: 'Has Space' })).toThrow(/\^\[a-z0-9-\]/);
+    expect(() => pool.addFixture({ ...VALID, id: 'UPPER' })).toThrow(ValidationError);
+    expect(pool.addFixture({ ...VALID, id: 'ok-123' }).id).toBe('ok-123');
   });
 
   it('rejects a duplicate id', () => {
-    pool.add({ ...VALID });
-    expect(() => pool.add({ ...VALID })).toThrow(/already exists/);
+    pool.addFixture({ ...VALID });
+    expect(() => pool.addFixture({ ...VALID })).toThrow(/already exists/);
   });
 
   it('rejects a missing nickname', () => {
-    expect(() => pool.add({ ...VALID, nickname: '   ' })).toThrow(/nickname is required/);
+    expect(() => pool.addFixture({ ...VALID, nickname: '   ' })).toThrow(/nickname is required/);
   });
 
   it('rejects an unknown provider, accepts a known one', () => {
-    expect(() => pool.add({ ...VALID, provider: 'bogus' as any })).toThrow(/provider must be/);
-    expect(pool.add({ ...VALID, id: 'p1', provider: 'openai' }).provider).toBe('openai');
+    expect(() => pool.addFixture({ ...VALID, provider: 'bogus' as any })).toThrow(/provider must be/);
+    expect(pool.addFixture({ ...VALID, id: 'p1', provider: 'openai' }).provider).toBe('openai');
   });
 
   it('rejects an unknown framework, accepts a known one', () => {
-    expect(() => pool.add({ ...VALID, framework: 'bogus' as any })).toThrow(/framework must be/);
-    expect(pool.add({ ...VALID, id: 'f1', framework: 'pi-cli' }).framework).toBe('pi-cli');
+    expect(() => pool.addFixture({ ...VALID, framework: 'bogus' as any })).toThrow(/framework must be/);
+    expect(pool.addFixture({ ...VALID, id: 'f1', framework: 'pi-cli' }).framework).toBe('pi-cli');
   });
 
   it('rejects a missing configHome', () => {
-    expect(() => pool.add({ ...VALID, configHome: '' })).toThrow(/configHome is required/);
+    expect(() => pool.addFixture({ ...VALID, configHome: '' })).toThrow(/configHome is required/);
   });
 
   it('rejects an unknown status, accepts a known one', () => {
-    expect(() => pool.add({ ...VALID, status: 'bogus' as any })).toThrow(/status must be/);
-    expect(pool.add({ ...VALID, id: 's1', status: 'disabled' }).status).toBe('disabled');
+    expect(() => pool.addFixture({ ...VALID, status: 'bogus' as any })).toThrow(/status must be/);
+    expect(pool.addFixture({ ...VALID, id: 's1', status: 'disabled' }).status).toBe('disabled');
   });
 
   // ── the never-store-credentials structural guard ────────────────
   it('rejects any credential-bearing field (accessToken/refreshToken/token/secret/...)', () => {
     for (const bad of ['accessToken', 'refreshToken', 'token', 'apiKey', 'secret', 'password', 'oauth', 'credentials']) {
       expect(() =>
-        pool.add({ ...VALID, id: 'cred' }, { ...VALID, [bad]: 'sk-leak' }),
+        pool.addFixture({ ...VALID, id: 'cred' }, { ...VALID, [bad]: 'sk-leak' }),
       ).toThrow(/never credentials/);
     }
     // None of the rejected attempts persisted anything.
@@ -118,7 +123,7 @@ describe('SubscriptionPool', () => {
 
   // ── update: happy + CAS + immutability + validation ─────────────
   it('updates mutable fields and bumps version (CAS)', () => {
-    pool.add({ ...VALID });
+    pool.addFixture({ ...VALID });
     const u = pool.update('claude-acct-2', { nickname: 'renamed', status: 'rate-limited' });
     expect(u?.nickname).toBe('renamed');
     expect(u?.status).toBe('rate-limited');
@@ -126,7 +131,7 @@ describe('SubscriptionPool', () => {
   });
 
   it('excludes identity-drifted accounts from local execution until self-closed', () => {
-    pool.add({ ...VALID });
+    pool.addFixture({ ...VALID });
     pool.update(VALID.id, {
       identityDrifted: true,
       identityDrift: {
@@ -145,21 +150,21 @@ describe('SubscriptionPool', () => {
   });
 
   it('update rejects an empty nickname and bad enum values', () => {
-    pool.add({ ...VALID });
+    pool.addFixture({ ...VALID });
     expect(() => pool.update('claude-acct-2', { nickname: '  ' })).toThrow(/cannot be empty/);
     expect(() => pool.update('claude-acct-2', { status: 'bogus' as any })).toThrow(/status must be/);
     expect(() => pool.update('claude-acct-2', { configHome: '' })).toThrow(/cannot be empty/);
   });
 
   it('update rejects credential-bearing input', () => {
-    pool.add({ ...VALID });
+    pool.addFixture({ ...VALID });
     expect(() =>
       pool.update('claude-acct-2', { nickname: 'x' }, { nickname: 'x', token: 'sk-leak' }),
     ).toThrow(/never credentials/);
   });
 
   it('update can carry a lastQuota snapshot (P1.2 forward-compat)', () => {
-    pool.add({ ...VALID });
+    pool.addFixture({ ...VALID });
     const u = pool.update('claude-acct-2', {
       lastQuota: {
         fiveHour: { utilizationPct: 10, resetsAt: '2026-06-07T00:20:00Z' },
@@ -172,7 +177,7 @@ describe('SubscriptionPool', () => {
 
   // ── remove ──────────────────────────────────────────────────────
   it('removes an account; returns false for an unknown id', () => {
-    pool.add({ ...VALID });
+    pool.addFixture({ ...VALID });
     expect(pool.remove('claude-acct-2')).toBe(true);
     expect(pool.size()).toBe(0);
     expect(pool.remove('claude-acct-2')).toBe(false);
@@ -180,8 +185,8 @@ describe('SubscriptionPool', () => {
 
   // ── health ──────────────────────────────────────────────────────
   it('reports health with usable counts', () => {
-    pool.add({ ...VALID, id: 'a', status: 'active' });
-    pool.add({ ...VALID, id: 'b', status: 'disabled' });
+    pool.addFixture({ ...VALID, id: 'a', status: 'active' });
+    pool.addFixture({ ...VALID, id: 'b', status: 'disabled' });
     const h = pool.getHealth();
     expect(h.status).toBe('healthy');
     expect(h.message).toContain('2 account(s)');
@@ -194,6 +199,6 @@ describe('SubscriptionPool', () => {
     const fresh = new SubscriptionPool({ stateDir: dir });
     expect(fresh.size()).toBe(0);
     // And is writable again afterwards.
-    expect(fresh.add({ ...VALID }).id).toBe('claude-acct-2');
+    expect(fresh.addFixture({ ...VALID }).id).toBe('claude-acct-2');
   });
 });

--- a/tests/unit/subscriptions-render.test.ts
+++ b/tests/unit/subscriptions-render.test.ts
@@ -354,6 +354,29 @@ describe('renderAccountMatrix', () => {
     expect(a1OnMini!.textContent).toBe('Set up');
   });
 
+  it('renders an honest PIN-gated repair action for an email-less account record', () => {
+    const t = el();
+    renderAccountMatrix(doc, t, {
+      enabled: true,
+      accounts: [],
+      emailGaps: [{
+        accountId: 'legacy',
+        nickname: 'Legacy',
+        machineId: 'm1',
+        machineNickname: 'Laptop',
+        reason: 'account-record-missing-email',
+      }],
+      pool: { selfMachineId: 'm1', failed: [] },
+      scope: 'pool',
+    }, { enabled: true, logins: [] }, {});
+    const cell = t.querySelector('.sub-matrix-email-missing');
+    expect(cell).toBeTruthy();
+    expect(cell!.textContent).toContain('Account record is missing its email');
+    const button = cell!.querySelector('[data-email-repair="1"]');
+    expect(button).toBeTruthy();
+    expect(button!.textContent).toBe('Repair identity');
+  });
+
   it('renders an offline/disabled column for a pool.failed machine — no fabricated ✓', () => {
     const t = el();
     renderAccountMatrix(doc, t, poolScope, pendingScope, {});

--- a/upgrades/next/subscription-account-email-invariant.md
+++ b/upgrades/next/subscription-account-email-invariant.md
@@ -1,0 +1,43 @@
+# Subscription account identity and follow-me retry hardening
+
+## What Changed
+
+Subscription account registration now verifies the provider identity at the
+credential slot and stores its email as part of the complete account record.
+Legacy records missing email are reconciled once at startup where the slot can
+be proved, and unresolved records are exposed as `emailGaps`.
+
+Follow-me enrollment now distinguishes missing records, missing email, and
+conflicting holder identity in stable 409 responses. The dashboard renders the
+actionable server explanation. The delivered-mandate consumer persists a
+pair-scoped 1m/5m/15m retry schedule and parks after its fourth unchanged
+failure instead of retrying every minute forever.
+
+## What to Tell Your User
+
+Account setup now tells you when the account record itself is missing an email
+and asks you to repair that record, instead of saying only that details could
+not be resolved. Existing account records are repaired automatically when the
+signed-in credential can prove the correct email.
+
+If an account cannot be set up, the background follow-me process now backs off
+and parks after four attempts. It will no longer keep sending the same failed
+request every minute for hours.
+
+## Summary of New Capabilities
+
+- Provider-attested email on new subscription account registrations.
+- One-shot repair and visible quarantine for legacy email-less records.
+- Honest, machine-readable identity failure responses on follow-me paths.
+- Durable finite retry and parking for repeated follow-me failures.
+
+## Evidence
+
+- `tests/unit/subscription-pool.test.ts`
+- `tests/unit/subscription-account-email-repair.test.ts`
+- `tests/unit/resolve-follow-me-enroll-target.test.ts`
+- `tests/unit/follow-me-consumer-backoff-store.test.ts`
+- `tests/integration/subscription-pool-routes.test.ts`
+- `tests/integration/subscription-pool-scope.test.ts`
+- `tests/integration/account-matrix-start-cell-route.test.ts`
+- `tests/integration/subscriptions-tab.test.ts`

--- a/upgrades/side-effects/subscription-account-email-invariant.md
+++ b/upgrades/side-effects/subscription-account-email-invariant.md
@@ -1,0 +1,169 @@
+# Side-Effects Review — Subscription account email invariant
+
+**Version / slug:** `subscription-account-email-invariant`
+**Date:** `2026-07-23`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `updater_deferral_review (independent, CONCUR)`
+
+## Summary of the change
+
+New subscription registrations prove their provider email from the credential
+slot; old email-less rows receive one bounded boot repair and otherwise appear
+as explicit gaps. Follow-me resolution returns honest missing/conflict/not-found
+codes. Its autonomous consumer now uses durable pair-scoped finite backoff.
+
+## Decision-point inventory
+
+- `POST /subscription-pool` — modify — provider proof, not caller input, admits identity.
+- `resolveFollowMeEnrollTarget` — modify — unanimous holder identity or typed refusal.
+- `driveDeliveredFollowMeEnrollments` — modify — persisted eligibility schedule bounds retries.
+
+## 1. Over-block
+
+A non-Anthropic registration is refused until that provider has a real identity
+adapter. This is intentional: accepting an unproved email would recreate the
+incident class. A temporarily unavailable Anthropic profile endpoint also
+refuses registration; an already complete account remains usable.
+
+## 2. Under-block
+
+Production account creation and identity repair are both module-private
+symbol commits held by `SubscriptionAccountEmailRegistrar`; generic `update()`
+has no email field. The only direct fixture seam throws outside `NODE_ENV=test`.
+Legacy
+email-less rows remain readable only through `listEmailGaps()` and never enter
+selectors or normal account reads.
+
+The finite retry row persists a semantic holder-email/gap/mandate evidence key.
+An unchanged pair parks after four attempts; changed identity or authority
+evidence deletes that episode and permits one new bounded episode. The live
+sweep also deduplicates all applicable mandates to one attempt per pair.
+
+## 3. Level-of-abstraction fit
+
+Provider truth is resolved at the registration boundary using the existing
+credential identity oracle. The pool owns validation/persistence, the resolver
+owns holder agreement, and the consumer store owns retry eligibility. No
+parallel enrollment authority was introduced.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+
+The identity oracle supplies evidence; the existing enrollment expected-email
+gate remains the authority. Retry scheduling is an enumerable finite-state
+invariant, not a language heuristic.
+
+## 4b. Judgment-point check
+
+No static heuristic is added at a competing-signals decision point. Email
+presence, canonical equality, mandate expiry, and attempt number are enumerable
+invariants.
+
+## 5. Interactions
+
+- **Shadowing:** direct registration validates shape and credential-field
+  smuggling before the network oracle so malformed requests keep their existing
+  deterministic 400 response.
+- **Double-fire:** one `AgentServer` sweep remains the only live delivered-
+  mandate caller; the backoff store does not start its own timer.
+- **Races:** the existing sweep single-flight encloses store reads and writes;
+  persistence uses tmp+rename. Legacy repair CAS-checks the independent
+  credential-ledger epoch before and after the provider probe.
+- **Feedback loops:** failure advances monotonically through three delays to
+  parked. Success clears the pair. Identity failures wake only when holder
+  evidence becomes unanimous; authority failures wake only when the applicable
+  mandate set changes.
+
+## 6. External surfaces
+
+The pool GET adds `emailGaps`; complete `accounts` remains the normal list.
+Follow-me 409 bodies add `code` and `accountId` while keeping `error`. The
+dashboard shows the exact actionable error, and the PIN-gated repair route
+provides the phone-complete remediation. A machine-local JSON backoff file is
+added. No credential, token, config-home content, or raw provider response is
+replicated or displayed.
+
+Boot reconciliation shares one oracle instance with the ledger, enrollment,
+and HTTP routes. When legacy gaps exist, repair runs against the preserved
+independent binding and destructive ledger seeding is skipped; complete pools
+may seed normally. The server starts without waiting, while inventory-tagged
+identity mutation routes return a stable temporary 503 until the bounded
+reconciliation finishes.
+
+The touched operator action stays phone-completable in the existing account
+matrix; no new laptop-only action was added.
+
+## 6b. Operator-surface quality
+
+1. **Leads with the primary action:** yes; the existing matrix action remains in-place.
+2. **Zero raw internals as primary content:** yes; the server code is not rendered, only plain corrective text.
+3. **Destructive actions de-emphasized:** yes; no destructive action was added.
+4. **Plain language + phone width:** yes; the change replaces one status string in the existing responsive cell without adding layout width.
+
+## 7. Multi-machine posture
+
+**Machine-local BY DESIGN:** credential proof and retry act on the credential
+slot and delivered mandate held by that target machine. Non-credential account
+metadata remains replicated through `subscription-account-meta`, and pool reads
+remain proxied/merged through `?scope=pool`. No new user-facing notice or URL is
+generated. The durable retry row does not follow topic transfer because it is
+bound to a physical account-machine pair.
+
+## 8. Rollback cost
+
+Revert and ship a patch. The additive `emailGaps` field is harmless to old
+clients. The backoff JSON may be left on disk; old code ignores it. Repaired
+emails are truthful provider-attested metadata and do not require reversal.
+
+## Conclusion
+
+The change closes the incident at its three recurring seams: incomplete
+registration, misleading refusal, and unbounded retry. Identity writes are
+registrar-owned, legacy repair requires independent stable binding evidence,
+and the live hammering loop is structurally bounded with causal wake.
+
+## Second-pass review (if required)
+
+**Reviewer:** updater_deferral_review
+**Independent read of the artifact:** CONCUR after three blocking passes. The
+final pass independently verified the real route-capability inventory, bounded
+deadline repair, and pool-scope gap aggregation (18 focused tests green).
+
+## Evidence pointers
+
+The invariant-focused slices are green: 157 unit tests, 87 integration tests,
+and 23 E2E tests. The production build and the full lint chain are green.
+
+The full integration configuration is green: 453 files passed, 2 skipped;
+3,714 tests passed and 12 skipped. The full E2E configuration completed after
+disabling pnpm's dependency auto-repair for the nested preflight harness:
+314 files passed, 1 skipped; 2,981 tests passed, 8 skipped, and 3 todo. Two
+pre-existing host-timing scenarios remained red: the ultracode argv delivery
+probe and the Telegram respawn readiness probe. The exact nested dev-preflight
+E2E is green when run against the stable dependency tree.
+
+The default configuration was also exercised end-to-end. Its invariant-owned
+tests stayed green; unrelated headless-spawn and host-timing failures remained,
+and the first run exposed the same nested pnpm auto-repair harness issue before
+the stable rerun of the dedicated integration and E2E configurations.
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: unbounded-self-action`, `closure: guard`,
+`guardEvidence: { enforcementType: ratchet, citation:
+tests/unit/follow-me-consumer-backoff-store.test.ts, howCaught: a permanently
+failing account-machine pair advances through three bounded delays and reaches
+a durable parked steady state after its fourth attempt, so an every-minute
+failure edge cannot remain eligible }`. Repository-wide self-action convergence
+coverage remains in `tests/unit/self-action-convergence.test.ts`.
+
+## Mini-node continuation checkpoint
+
+The email-invariant lane was resumed on the Mini, its stale fixtures were
+updated for provider-attested email identity, and the full ceremony/test pass
+above was completed. The Claude subscription-pinning E2E now explicitly pins
+its claimed framework, so a Codex-hosted runner cannot turn the resolver into
+the correct non-Claude no-op.


### PR DESCRIPTION
## Summary

- require provider-attested email identity when subscription accounts are registered
- reconcile provable legacy email gaps once at startup and expose unresolved gaps honestly
- return stable follow-me identity failure codes and actionable dashboard guidance
- persist pair-scoped 1m/5m/15m retries, then park after the fourth unchanged failure

## ELI16

A subscription account was saved without its email address. That email is the
safety label Instar uses to prove a new sign-in belongs to the account the
operator chose, so follow-me correctly refused to guess—but the dashboard
explanation was vague and the background worker retried the same impossible
request every minute.

This change prevents incomplete accounts from being saved, repairs older
records when their own provider login can prove the email, explains any
remaining gap plainly, and puts a hard four-attempt ceiling on repeated
follow-me failures. Credentials never move between machines, and a newly
authenticated email must still match the operator-approved identity.

## Safety and ceremony

- Tier-2 converged spec: 6 review iterations, independent reviewer concurrence
- constitutional parent: Capacity Safety — No Unbounded Self-Action
- class closure: durable ratchet proving a permanently failing account-machine pair parks
- single audited commit rebased on current `main`

## Verification

- production build: pass
- lint / pre-commit ceremony: pass
- focused final regression: 194 unit, 87 integration, and 24 E2E checks pass
- full integration: 3,714 passed, 12 skipped
- full E2E: 2,981 passed, 8 skipped, 3 todo; two unrelated host-timing probes remain red (ultracode argv delivery and Telegram respawn readiness)
- default configuration exercised end-to-end; invariant-owned tests stayed green while existing headless-spawn/host-timing failures and a nested pnpm auto-repair harness issue remained outside this change
