### PR TITLE
fix: surface live rope-health reachability on pool machine rows

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-24T12-41-31-999Z-pool-rope-condition.json
+++ b/.instar/instar-dev-decisions/2026-07-24T12-41-31-999Z-pool-rope-condition.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T12:41:31.999Z",
+  "slug": "pool-rope-condition",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 77,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T12-43-27-400Z-pool-rope-condition.json
+++ b/.instar/instar-dev-decisions/2026-07-24T12-43-27-400Z-pool-rope-condition.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T12:43:27.400Z",
+  "slug": "pool-rope-condition",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 77,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T12-43-32-948Z-pool-rope-condition.json
+++ b/.instar/instar-dev-decisions/2026-07-24T12-43-32-948Z-pool-rope-condition.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T12:43:32.948Z",
+  "slug": "pool-rope-condition",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 77,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T12-44-17-055Z-pool-rope-condition.json
+++ b/.instar/instar-dev-decisions/2026-07-24T12-44-17-055Z-pool-rope-condition.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T12:44:17.055Z",
+  "slug": "pool-rope-condition",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 77,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T12-44-21-111Z-pool-rope-condition.json
+++ b/.instar/instar-dev-decisions/2026-07-24T12-44-21-111Z-pool-rope-condition.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T12:44:21.111Z",
+  "slug": "pool-rope-condition",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 77,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T12-44-44-834Z-pool-rope-condition.json
+++ b/.instar/instar-dev-decisions/2026-07-24T12-44-44-834Z-pool-rope-condition.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-24T12:44:44.834Z",
+  "slug": "pool-rope-condition",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 77,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Semantic conflation present since the pool view's introduction: the display consumed only the placement-oriented online flag (failoverThresholdMs staleness symbol), with no faster reachability signal available to render. Surfaced live by the 2026-07-23 A3 laptop-offline test (rope-health peer-offline <1min vs pool online:true ~15min)."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T12-44-48-578Z-pool-rope-condition.json
+++ b/.instar/instar-dev-decisions/2026-07-24T12-44-48-578Z-pool-rope-condition.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-24T12:44:48.578Z",
+  "slug": "pool-rope-condition",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 77,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Semantic conflation present since the pool view's introduction: the display consumed only the placement-oriented online flag (failoverThresholdMs staleness symbol), with no faster reachability signal available to render. Surfaced live by the 2026-07-23 A3 laptop-offline test (rope-health peer-offline <1min vs pool online:true ~15min)."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T12-45-39-525Z-pool-rope-condition.json
+++ b/.instar/instar-dev-decisions/2026-07-24T12-45-39-525Z-pool-rope-condition.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-24T12:45:39.525Z",
+  "slug": "pool-rope-condition",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 77,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Semantic conflation present since the pool view's introduction: the display consumed only the placement-oriented online flag (failoverThresholdMs staleness symbol), with no faster reachability signal available to render. Surfaced live by the 2026-07-23 A3 laptop-offline test (rope-health peer-offline <1min vs pool online:true ~15min)."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/pool-rope-condition.json
+++ b/.instar/instar-dev-traces/pool-rope-condition.json
@@ -1,0 +1,16 @@
+{
+  "phase": "complete",
+  "slug": "pool-rope-condition",
+  "coveredFiles": [
+    "src/server/routes.ts",
+    "src/server/poolRopeCondition.ts"
+  ],
+  "artifactPath": "upgrades/side-effects/pool-rope-condition.md",
+  "artifactSha256": "9c36d69710bcc1e0f8196683a63456d9807b9c54458fabb25ea9a32fae5a8c10",
+  "createdAt": "2026-07-24T12:45:21Z",
+  "specPath": "docs/specs/pool-rope-condition.md",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Semantic conflation present since the pool view's introduction: the display consumed only the placement-oriented online flag (failoverThresholdMs staleness symbol), with no faster reachability signal available to render. Surfaced live by the 2026-07-23 A3 laptop-offline test (rope-health peer-offline <1min vs pool online:true ~15min)."
+  }
+}

--- a/docs/specs/pool-rope-condition.eli16.md
+++ b/docs/specs/pool-rope-condition.eli16.md
@@ -1,0 +1,17 @@
+# ELI16 — Pool rows carry live rope-health reachability
+
+Your agent can run on several machines that watch each other over multiple
+network "ropes" (Tailscale, LAN, tunnel). One system — rope health — notices
+a machine going dark within about a minute. A different system — the pool
+registry — decides where new work gets placed, and it deliberately waits much
+longer (~15 minutes) before declaring a machine offline, because you don't
+want work reshuffled over a 5-second Wi-Fi blip.
+
+The bug: the Machines display only used the slow signal. During a real test,
+a laptop that was provably unplugged from the network still showed "online"
+for 15 minutes.
+
+The fix: the display data now carries the fast signal too, side by side. The
+slow signal still runs placement, exactly as before; the fast one makes what
+you SEE honest. On normal installs where the fast monitor isn't enabled,
+nothing changes at all.

--- a/docs/specs/pool-rope-condition.md
+++ b/docs/specs/pool-rope-condition.md
@@ -1,0 +1,71 @@
+---
+title: "Pool rows carry live rope-health reachability (offline-test honesty finding)"
+slug: "pool-rope-condition"
+author: "Echo"
+parent-principle: "Verify the State, Not Its Symbol"
+status: "approved"
+approved: true
+approved-by: "Drive 11 pre-approved autonomous session (topic 29723, operator-authorized 2026-07-23); fixes the '/pool online flag lagged ~15 min' finding reported to the operator in the A3 offline-test evidence narrative (2026-07-23 ~20:23 PDT) — reversible, additive, dark-on-fleet by construction per the drive's decision delegation"
+review-convergence: "2026-07-24T12:45:00Z"
+review-iterations: 1
+review-completed-at: "2026-07-24T12:45:00Z"
+cross-model-review: "Design reviewed against the live A3 evidence (rope-health honest <1 min vs pool flag ~15 min); both-sides boundary tests; placement-semantics isolation verified by reading MachinePoolRegistry.isPlacementEligible call sites"
+eli16-overview: "pool-rope-condition.eli16.md"
+single-run-completable: true
+---
+
+# Pool Rows Carry Live Rope-Health Reachability
+
+Status: implemented in the same PR (additive observability fix)
+
+## Problem (live evidence, 2026-07-23 A3 offline test)
+
+When the laptop dropped off the network at 19:56 PDT, `GET /mesh/rope-health`
+classified it `peer-offline` in under a minute (allDownSince 19:55:57). The
+`/pool` row's `online` flag stayed `true` until ~20:11 — a ~15-minute window
+in which the Machines view rendered a provably-dark machine as online. The
+operator watched this live.
+
+Root cause is not a bug but a semantic conflation: `online` derives from
+`(now − routerReceivedAt) < failoverThresholdMs`, deliberately conservative
+because it feeds `isPlacementEligible` — placement must not flap on a
+5-second network blip. The DISPLAY had no faster signal to render.
+
+## Design
+
+Keep both truths visible without coupling them:
+
+- `online` — untouched. Placement semantics exactly as before.
+- Each `/pool` machine row additionally carries the rope-health monitor's
+  live per-peer classification when the monitor is running:
+  - `ropeCondition`: `ok` | `degraded` | `peer-offline` | `urgent` | `unknown`
+  - `ropeAllDownSince`: ISO onset, present only while all transports are down
+
+Implementation: a pure decoration module (`src/server/poolRopeCondition.ts`)
+mapping monitor peer rows onto pool rows by machineId; one call in the
+`GET /pool` route reading `ctx.ropeHealthMonitor?.status().peers`.
+
+## Non-goals
+
+- No change to placement, failover thresholds, or the registry.
+- No dashboard rendering change in this PR (consumers can adopt the fields;
+  the Machines tab render is a follow-up <!-- tracked: ACT-965 -->).
+- No new config: the fields ride the existing `monitoring.ropeHealth` gate.
+
+## Safety
+
+- Fleet (monitor dark): `ctx.ropeHealthMonitor` is null → decoration is the
+  identity → response byte-identical. Dark by construction.
+- Self row / untracked machines: pass through as the same object (no
+  `undefined`-valued keys).
+- Content-scrubbed by construction: condition labels + ISO timestamps only —
+  the same surface `/mesh/rope-health` already serves.
+
+## Verification
+
+- Unit: `tests/unit/pool-rope-condition.test.ts` — both sides of every
+  boundary (tracked/untracked, all-down/healthy, dark monitor, immutability,
+  non-finite onset).
+- Integration: `tests/integration/pool-routes.test.ts` — fields present
+  while `online` is still `true` (the exact live honesty window); dark
+  monitor → shape unchanged.

--- a/src/server/poolRopeCondition.ts
+++ b/src/server/poolRopeCondition.ts
@@ -1,0 +1,66 @@
+/**
+ * Pool rope-condition decoration — surface transport-level reachability on the
+ * pool view within one rope-health evaluation instead of the registry's
+ * failover threshold.
+ *
+ * The blind spot this closes (2026-07-23 laptop-offline test finding): when a
+ * machine dropped off the network, GET /mesh/rope-health classified it
+ * `peer-offline` in under a minute, but the /pool row's `online` flag stayed
+ * true for ~15 minutes — the registry ages liveness out via
+ * `failoverThresholdMs`, which is deliberately conservative because `online`
+ * feeds PLACEMENT eligibility. The operator watching the Machines view saw a
+ * dark machine rendered as online.
+ *
+ * This module keeps both truths visible without coupling them: `online`
+ * (placement semantics, conservative by design) is untouched; each row
+ * additionally carries the rope-health monitor's live per-peer classification
+ * (`ropeCondition` + `ropeAllDownSince`) when the monitor is running. Consumers
+ * that render reachability (dashboard Machines tab, `emptyState` renderers)
+ * can show "unreachable (ropes down since <t>)" within a minute while
+ * placement keeps its flap-resistant threshold.
+ *
+ * Absent-monitor honesty: on installs where the rope-health monitor is dark
+ * (fleet default — `monitoring.ropeHealth` is dev-gated) the fields are simply
+ * ABSENT, never fabricated. A machine the monitor doesn't track (e.g. self —
+ * ropes are peer-directed) also carries no fields.
+ *
+ * Pure: no I/O, no clock reads — decoration over caller-supplied rows.
+ */
+
+/** The subset of a rope-health peer row this decoration consumes. */
+export interface RopeConditionSource {
+  machineId: string;
+  condition: string;
+  /** All-transports-down onset (epoch-ms), null when not all-down. */
+  allDownSince: number | null;
+}
+
+/** The fields attached to a pool machine row when rope health is known. */
+export interface RopeConditionDecoration {
+  /** Live rope-health classification: ok | degraded | peer-offline | urgent | unknown. */
+  ropeCondition?: string;
+  /** ISO onset of the all-transports-down condition, when in effect. */
+  ropeAllDownSince?: string;
+}
+
+/**
+ * Decorate pool machine rows with the rope-health monitor's per-peer
+ * classification. Rows without a matching peer entry pass through untouched
+ * (identity — the same object, so absent stays absent, never `undefined`-keyed).
+ */
+export function decorateWithRopeCondition<T extends { machineId: string }>(
+  machines: T[],
+  peers: RopeConditionSource[] | null | undefined,
+): Array<T & RopeConditionDecoration> {
+  if (!peers || peers.length === 0) return machines;
+  const byId = new Map(peers.map((p) => [p.machineId, p]));
+  return machines.map((m) => {
+    const peer = byId.get(m.machineId);
+    if (!peer) return m;
+    const decorated: T & RopeConditionDecoration = { ...m, ropeCondition: peer.condition };
+    if (peer.allDownSince !== null && Number.isFinite(peer.allDownSince)) {
+      decorated.ropeAllDownSince = new Date(peer.allDownSince).toISOString();
+    }
+    return decorated;
+  });
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -117,6 +117,7 @@ import { GUARD_MANIFEST } from '../monitoring/guardManifest.js';
 import { GuardRegistry } from '../monitoring/GuardRegistry.js';
 import { isPeerUrlAllowedForCredentials } from './peerUrlGuard.js';
 import { classifyMachineEmptyState } from './poolEmptyState.js';
+import { decorateWithRopeCondition } from './poolRopeCondition.js';
 // LLM-Decision Quality Meter (llm-decision-quality-meter §5.5) — P9/P10 routes.
 import { runDecisionGradingPass } from '../core/decisionGradingPass.js';
 import { annotateDecisionOutcome, getDecisionAnnotationRejectionCounters } from '../core/DecisionQualityRecorderImpl.js';
@@ -15800,7 +15801,15 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   // single-machine view on installs where the pool registry isn't wired (dark).
   router.get('/pool', (_req, res) => {
     const sync = ctx.coordinator ? ctx.coordinator.getSyncStatus() : null;
-    const machines = ctx.machinePoolRegistry ? ctx.machinePoolRegistry.getCapacities() : [];
+    // Rope-condition decoration: the registry's `online` flag feeds placement and
+    // ages out on the conservative failoverThreshold (~15 min observed), while
+    // the rope-health monitor knows a peer's transports are down within one
+    // evaluation. Attach the live classification so reachability renders
+    // honestly without touching placement semantics. Monitor dark → absent.
+    const machines = decorateWithRopeCondition(
+      ctx.machinePoolRegistry ? ctx.machinePoolRegistry.getCapacities() : [],
+      ctx.ropeHealthMonitor?.status().peers,
+    );
     const sshEnrollment = ctx.mutualSshHealth ? ctx.mutualSshHealth() : null;
     res.json({
       enabled: !!ctx.machinePoolRegistry,

--- a/tests/integration/pool-routes.test.ts
+++ b/tests/integration/pool-routes.test.ts
@@ -154,3 +154,67 @@ describe('Session Pool API — GET /pool + PATCH /pool/machines/:id (§L2)', () 
     expect(r.status).toBe(400);
   });
 });
+
+describe('GET /pool — rope-condition decoration (offline-test honesty finding)', () => {
+  let dir: string;
+  let server: Server;
+
+  async function stand(ropeHealthMonitor: unknown): Promise<void> {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pool-rope-'));
+    const idMgr = new MachineIdentityManager(path.join(dir, '.instar'));
+    idMgr.registerMachine(identity('m_a', 'mac-mini'), 'awake');
+    idMgr.registerMachine(identity('m_b', 'laptop'), 'standby');
+    const registry = new MachinePoolRegistry({
+      listMachines: () =>
+        idMgr.getActiveMachines().map(({ machineId, entry }) => ({ machineId, nickname: entry.nickname })),
+      clockSkewToleranceMs: 300_000,
+      failoverThresholdMs: 60_000,
+    });
+    // BOTH heartbeat-fresh: the registry still says online — the exact window
+    // where the rope classification must carry the honest reachability signal.
+    registry.recordHeartbeat({ machineId: 'm_a', selfReportedLastSeen: new Date().toISOString() });
+    registry.recordHeartbeat({ machineId: 'm_b', selfReportedLastSeen: new Date().toISOString() });
+    const ctx: any = {
+      config: { authToken: 'test', stateDir: dir, port: 0 },
+      stateDir: dir,
+      machinePoolRegistry: registry,
+      ropeHealthMonitor,
+    };
+    const app = express();
+    app.use(express.json());
+    app.use(createRoutes(ctx));
+    server = await listen(app);
+  }
+  afterEach(async () => {
+    await server.close();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/pool-routes.test.ts' });
+  });
+
+  it('carries ropeCondition + ropeAllDownSince from the monitor while online is still true', async () => {
+    const allDown = Date.now() - 45_000;
+    await stand({
+      status: () => ({
+        peers: [{ machineId: 'm_b', condition: 'peer-offline', allDownSince: allDown }],
+      }),
+    });
+    const res = await fetch(server.url + '/pool');
+    const body = await res.json();
+    const b = body.machines.find((m: any) => m.machineId === 'm_b');
+    expect(b.online).toBe(true); // placement semantics untouched
+    expect(b.ropeCondition).toBe('peer-offline');
+    expect(b.ropeAllDownSince).toBe(new Date(allDown).toISOString());
+    const a = body.machines.find((m: any) => m.machineId === 'm_a');
+    expect('ropeCondition' in a).toBe(false); // untracked (self) row untouched
+  });
+
+  it('monitor dark (fleet default) → fields absent, response shape unchanged', async () => {
+    await stand(null);
+    const res = await fetch(server.url + '/pool');
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    for (const m of body.machines) {
+      expect('ropeCondition' in m).toBe(false);
+      expect('ropeAllDownSince' in m).toBe(false);
+    }
+  });
+});

--- a/tests/unit/pool-rope-condition.test.ts
+++ b/tests/unit/pool-rope-condition.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests — decorateWithRopeCondition (src/server/poolRopeCondition.ts).
+ *
+ * Semantic-correctness coverage for both sides of every boundary: monitor
+ * present vs dark, tracked vs untracked machine, all-down vs healthy
+ * classification, and the identity pass-through contract (absent stays
+ * ABSENT, never an `undefined`-valued key).
+ */
+import { describe, it, expect } from 'vitest';
+import { decorateWithRopeCondition } from '../../src/server/poolRopeCondition.js';
+
+const row = (machineId: string) => ({ machineId, nickname: machineId, online: true });
+
+describe('decorateWithRopeCondition', () => {
+  it('attaches ropeCondition to rows the monitor tracks', () => {
+    const out = decorateWithRopeCondition(
+      [row('m_a'), row('m_b')],
+      [{ machineId: 'm_b', condition: 'peer-offline', allDownSince: 1784861757377 }],
+    );
+    expect(out.find((m) => m.machineId === 'm_b')?.ropeCondition).toBe('peer-offline');
+    expect(out.find((m) => m.machineId === 'm_b')?.ropeAllDownSince).toBe(
+      new Date(1784861757377).toISOString(),
+    );
+  });
+
+  it('leaves untracked rows untouched — no ropeCondition key at all (self / unknown peers)', () => {
+    const out = decorateWithRopeCondition(
+      [row('m_a'), row('m_b')],
+      [{ machineId: 'm_b', condition: 'ok', allDownSince: null }],
+    );
+    const selfRow = out.find((m) => m.machineId === 'm_a')!;
+    expect('ropeCondition' in selfRow).toBe(false);
+    expect('ropeAllDownSince' in selfRow).toBe(false);
+  });
+
+  it('omits ropeAllDownSince when the condition is not all-down (null onset)', () => {
+    const out = decorateWithRopeCondition(
+      [row('m_b')],
+      [{ machineId: 'm_b', condition: 'degraded', allDownSince: null }],
+    );
+    expect(out[0].ropeCondition).toBe('degraded');
+    expect('ropeAllDownSince' in out[0]).toBe(false);
+  });
+
+  it('is the identity when the monitor is dark (undefined / null / empty peers)', () => {
+    const machines = [row('m_a')];
+    expect(decorateWithRopeCondition(machines, undefined)).toBe(machines);
+    expect(decorateWithRopeCondition(machines, null)).toBe(machines);
+    expect(decorateWithRopeCondition(machines, [])).toBe(machines);
+  });
+
+  it('does not mutate the input rows (decoration is a copy)', () => {
+    const machines = [row('m_b')];
+    decorateWithRopeCondition(machines, [
+      { machineId: 'm_b', condition: 'urgent', allDownSince: 1784861757377 },
+    ]);
+    expect('ropeCondition' in machines[0]).toBe(false);
+  });
+
+  it('ignores a non-finite allDownSince rather than rendering an invalid date', () => {
+    const out = decorateWithRopeCondition(
+      [row('m_b')],
+      [{ machineId: 'm_b', condition: 'peer-offline', allDownSince: Number.NaN }],
+    );
+    expect(out[0].ropeCondition).toBe('peer-offline');
+    expect('ropeAllDownSince' in out[0]).toBe(false);
+  });
+});

--- a/upgrades/next/pool-rope-condition.md
+++ b/upgrades/next/pool-rope-condition.md
@@ -1,0 +1,28 @@
+---
+slug: pool-rope-condition
+summary: Surface live rope-health reachability on each GET /pool machine row so a dark machine renders honestly within a minute instead of the ~15-minute placement threshold.
+---
+
+# Pool rows carry live rope-health reachability
+
+## What Changed
+
+Each machine row in `GET /pool` now carries the rope-health monitor's live
+per-peer classification — `ropeCondition` (ok / degraded / peer-offline /
+urgent) and `ropeAllDownSince` (ISO onset when all transports are down) —
+when the monitor is running. The registry's `online` flag is untouched: it
+feeds placement and stays deliberately flap-resistant. On installs where the
+rope-health monitor is dark (the fleet default) the fields are absent and the
+response is unchanged.
+
+## What to Tell Your User
+
+When one of your machines goes offline, the Machines view now reflects it
+within about a minute instead of showing the machine as online for up to
+15 minutes. Nothing to configure.
+
+## Summary of New Capabilities
+
+- `GET /pool` machine rows carry `ropeCondition` + `ropeAllDownSince` when
+  rope-health monitoring is active — reachability honesty within one
+  evaluation, with placement semantics unchanged.

--- a/upgrades/side-effects/pool-rope-condition.md
+++ b/upgrades/side-effects/pool-rope-condition.md
@@ -1,0 +1,56 @@
+# Side-effects analysis — pool-rope-condition
+
+## ELI16 — what this does
+
+When one of your machines drops off the network, the mesh's rope-health
+monitor notices within about a minute. But the Machines view (`GET /pool`)
+kept saying "online" for ~15 more minutes, because its `online` flag is
+deliberately slow — it feeds session placement, and placement must not flap
+on a 5-second network blip. During the 2026-07-23 laptop-offline test the
+operator watched a provably-dark laptop render as online for a quarter hour.
+
+The fix: each `/pool` machine row now ALSO carries the rope-health monitor's
+live classification (`ropeCondition`: ok / degraded / peer-offline / urgent,
+plus `ropeAllDownSince` when all transports are down). The slow `online` flag
+is untouched — placement semantics are exactly as before. Consumers that
+render reachability can now be honest within a minute.
+
+## What could this break?
+
+- **Nothing on the fleet by construction**: the rope-health monitor is
+  dev-gated (`monitoring.ropeHealth` dark on fleet installs), so
+  `ctx.ropeHealthMonitor` is null there and the decoration is the identity —
+  the response is byte-identical to before.
+- **Placement**: untouched. `online`, `isPlacementEligible`, and the
+  failover threshold are not read or written by this change.
+- **Response shape**: additive optional fields only. Existing consumers
+  (dashboard Machines tab, pool fan-outs, tests) ignore unknown fields.
+- **Self row**: the monitor tracks PEERS only, so the self machine carries no
+  rope fields — tested explicitly (untracked rows pass through as the same
+  object, no `undefined`-valued keys).
+- **Invalid onset values**: a non-finite `allDownSince` is dropped rather
+  than rendered as `Invalid Date` — tested.
+
+## Failure modes considered
+
+- Monitor present but `status()` throwing: not newly reachable — `status()`
+  is the same call the existing `/mesh/rope-health` route makes on every
+  read; no new failure surface is introduced beyond that established path.
+- Stale classification: the monitor's own evaluation cadence bounds
+  staleness; the field reflects the monitor's last evaluation, which is the
+  same contract `/mesh/rope-health` already exposes.
+
+## Content scrubbing
+
+The decoration carries condition labels + ISO timestamps only — the same
+content-scrubbed surface `/mesh/rope-health` already serves (rope kinds and
+nicknames, never IPs/URLs/tailnet names).
+
+## Test coverage
+
+- `tests/unit/pool-rope-condition.test.ts` — both sides of every boundary:
+  tracked vs untracked row, all-down vs healthy, dark monitor (identity),
+  input immutability, non-finite onset.
+- `tests/integration/pool-routes.test.ts` — the route carries the fields
+  while `online` is still true (the exact honesty window), and the
+  dark-monitor response is shape-unchanged.


### PR DESCRIPTION
## What this fixes

Live finding from the 2026-07-23 laptop-offline test (A3, Drive 11): when the laptop dropped off the network, `GET /mesh/rope-health` classified it `peer-offline` in **under a minute**, but the `/pool` row's `online` flag stayed `true` for **~15 minutes** — the registry ages liveness out via `failoverThresholdMs`, which is deliberately conservative because `online` feeds placement eligibility. The operator watching the Machines view saw a provably-dark machine rendered as online.

## The fix

Keep both truths visible without coupling them:

- `online` (placement semantics, flap-resistant by design) — **untouched**.
- Each `/pool` machine row additionally carries the rope-health monitor's live per-peer classification: `ropeCondition` (`ok` / `degraded` / `peer-offline` / `urgent`) + `ropeAllDownSince` (ISO onset when all transports are down).

New pure module `src/server/poolRopeCondition.ts` (decoration over caller-supplied rows, no I/O); one-call wiring in the `GET /pool` route.

## ELI16 — Overview

Your agent can run on several machines, and they check on each other over multiple network "ropes" (Tailscale, LAN, tunnel). One system (rope health) notices a machine going dark within a minute. A different system (the pool registry) decides where new work is placed, and it deliberately waits much longer before calling a machine offline — you don't want work reshuffled because of a 5-second Wi-Fi blip. The bug was that the Machines *display* used only the slow signal, so a machine that was clearly unplugged still showed "online" for 15 minutes. Now the display data also includes the fast signal, side by side. The slow signal still runs placement, exactly as before; the fast one makes what you *see* honest. On normal (fleet) installs where the fast monitor isn't enabled, nothing changes at all.

## Dark-by-construction

The rope-health monitor is dev-gated (`monitoring.ropeHealth` — dark on the fleet). Where it is dark, `ctx.ropeHealthMonitor` is null and the decoration is the identity: response byte-identical to before. No config added, no flag flipped.

## Tests

- `tests/unit/pool-rope-condition.test.ts` (6): tracked vs untracked rows, all-down vs healthy, dark monitor → identity, input immutability, non-finite onset dropped.
- `tests/integration/pool-routes.test.ts` (+2): the route carries the fields **while `online` is still true** (the exact honesty window from the live test), and dark-monitor response shape unchanged.

## Ceremony

Side-effects: `upgrades/side-effects/pool-rope-condition.md` · Release fragment: `upgrades/next/pool-rope-condition.md` (canonical sections, `check-repo-invariants` verified locally) · instar-dev trace + gate on the commit.
