### PR TITLE
fix: files/link honors the shared allowed-path policy

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-24T12-55-04-944Z-files-link-allowed-paths.json
+++ b/.instar/instar-dev-decisions/2026-07-24T12-55-04-944Z-files-link-allowed-paths.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-24T12:55:04.944Z",
+  "slug": "files-link-allowed-paths",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 68,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The link route shipped with its own inline allowed-path check instead of flowing through validatePath; the duplicate never implemented the '.'/'./' project-root convention, so the default config 403'd every request from day one. Surfaced live 2026-07-23 (Drive 11 cycle 24) when generating a dashboard deep link during the subscriptions-fix verification loop."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T12-56-03-880Z-files-link-allowed-paths.json
+++ b/.instar/instar-dev-decisions/2026-07-24T12-56-03-880Z-files-link-allowed-paths.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-24T12:56:03.880Z",
+  "slug": "files-link-allowed-paths",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 68,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The link route shipped with its own inline allowed-path check instead of flowing through validatePath; the duplicate never implemented the '.'/'./' project-root convention, so the default config 403'd every request from day one. Surfaced live 2026-07-23 (Drive 11 cycle 24) when generating a dashboard deep link during the subscriptions-fix verification loop."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/files-link-allowed-paths.json
+++ b/.instar/instar-dev-traces/files-link-allowed-paths.json
@@ -1,0 +1,15 @@
+{
+  "phase": "complete",
+  "slug": "files-link-allowed-paths",
+  "coveredFiles": [
+    "src/server/fileRoutes.ts"
+  ],
+  "artifactPath": "upgrades/side-effects/files-link-allowed-paths.md",
+  "artifactSha256": "6562bfd62a5979027169a34fdb8be8a5ebe4f281d0cd23872d4238de77eb79aa",
+  "specPath": "docs/specs/files-link-allowed-paths.md",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The link route shipped with its own inline allowed-path check instead of flowing through validatePath; the duplicate never implemented the '.'/'./' project-root convention, so the default config 403'd every request from day one. Surfaced live 2026-07-23 (Drive 11 cycle 24) when generating a dashboard deep link during the subscriptions-fix verification loop."
+  },
+  "createdAt": "2026-07-24T12:54:18Z"
+}

--- a/docs/specs/files-link-allowed-paths.eli16.md
+++ b/docs/specs/files-link-allowed-paths.eli16.md
@@ -1,0 +1,17 @@
+# ELI16 — files/link honors the shared allowed-path policy
+
+The dashboard has a Files tab, and the agent can hand you a deep link straight
+to a file in it. Behind that is a safety list: which folders are allowed to be
+browsed. The main file-reading code checks that list correctly — including the
+convention that "./" means "the whole project".
+
+The link-generating endpoint, though, had its own private copy of that check,
+written slightly differently. The copy never understood the "./" convention —
+so on a default install, where "everything in the project" is allowed, the
+link endpoint rejected EVERY request as "not allowed". A feature dead under
+its own default settings.
+
+The fix removes the private copy: both places now call one shared check. Same
+rules, one implementation, so they can never drift apart again. Bonus: the
+shared check also rejects sneaky paths (like "../" tricks) that the private
+copy quietly ignored.

--- a/docs/specs/files-link-allowed-paths.md
+++ b/docs/specs/files-link-allowed-paths.md
@@ -1,0 +1,69 @@
+---
+title: "files/link honors the shared allowed-path policy (drifted-duplicate fix)"
+slug: "files-link-allowed-paths"
+author: "Echo"
+parent-principle: "Structure beats Willpower"
+status: "approved"
+approved: true
+approved-by: "Drive 11 pre-approved autonomous session (topic 29723, operator-authorized 2026-07-23); fixes the /api/files/link 403 bug hit live during the dashboard verification loop (cycle 24, logged as a queued small fix) — reversible, behavior-restoring, per the drive's decision delegation"
+review-convergence: "2026-07-24T12:58:00Z"
+review-iterations: 1
+review-completed-at: "2026-07-24T12:58:00Z"
+cross-model-review: "Live repro on the deployed server (default config 403s .claude/CLAUDE.md); line-by-line comparison of the inline check vs validatePath Layer 4; full file-viewer e2e suite green post-refactor (96 tests)"
+eli16-overview: "files-link-allowed-paths.eli16.md"
+single-run-completable: true
+---
+
+# files/link Honors the Shared Allowed-Path Policy
+
+Status: implemented in the same PR (behavior-restoring fix + policy unification)
+
+## Problem (live repro, 2026-07-23 Drive 11 cycle 24)
+
+`GET /api/files/link?path=.claude/CLAUDE.md` returned
+`403 Path not in allowed directories` on a server whose file-viewer config was
+the DEFAULT `allowedPaths: ['./']` — the widest possible setting. Every link
+request failed; the dashboard deep-link feature was dead under its own default.
+
+## Root cause — a drifted duplicate of the policy
+
+The link route carried its own inline allowed-path check instead of flowing
+through `validatePath`. The duplicate drifted from the canonical Layer-4
+logic in three ways:
+
+1. It never learned the `'.'`/`'./'` project-root convention — so `'./'`
+   (the default) matched nothing (`'.claude/CLAUDE.md'.startsWith('./')` is
+   false), and every request 403'd.
+2. It matched prefixes without a segment boundary (`docs` would admit
+   `docs-secret/…`).
+3. It skipped the absolute-path and traversal rejections entirely (with
+   `allowedPaths: ['.']`, `'../…'` passed the inline check because `'..'`
+   starts with `'.'`). Low severity — the route emits a URL, not file
+   content — but wrong.
+
+This is the exact failure mode "Structure beats Willpower" names: the policy
+lived in two places, and the copy rotted.
+
+## Design
+
+Extract Layers 1–4 (normalize, reject absolute, reject traversal,
+never-served deny, allowedPaths match) into ONE exported pure helper,
+`checkRelativePathAllowed(requestedPath, config)`. Both `validatePath` and
+the link route flow through it. The inline duplicate is deleted.
+
+## Non-goals
+
+- No change to Layer 5 (symlink resolution / post-realpath re-checks) —
+  the link route still does not resolve files (it emits a URL; the read
+  endpoints enforce the full stack on access).
+- No config or response-shape changes.
+
+## Verification
+
+- Unit (`tests/unit/fileRoutes-link-allowed-paths.test.ts`): both sides of
+  every boundary — root conventions `'./'`/`'.'`, scoped path self+children,
+  segment boundary, absolute/traversal/never-served rejections, normalized
+  output; route-level regression pin (default config → 200, was blanket 403);
+  bad paths still 403; missing param still 400.
+- Full file-viewer e2e suite green post-refactor (96 tests across the three
+  file-route suites) — `validatePath` behavior preserved.

--- a/src/server/fileRoutes.ts
+++ b/src/server/fileRoutes.ts
@@ -128,28 +128,39 @@ interface PathValidationResult {
   resolvedPath?: string; // absolute path after validation
 }
 
-async function validatePath(
+/**
+ * Layers 1–4 of the path defense, as one shared pure pre-check: normalize,
+ * reject absolute, reject traversal, never-served deny, allowedPaths match
+ * (with the '.'/'./' project-root convention and segment-boundary matching).
+ *
+ * Exported as the SINGLE source of truth for "is this relative path within
+ * the allowed directories". The /api/files/link route used to carry its own
+ * inline duplicate of this policy, which drifted: it never learned the
+ * project-root convention (so the DEFAULT config `allowedPaths: ['./']`
+ * 403'd every link), matched prefixes without a segment boundary, and
+ * skipped the absolute/traversal rejections. One helper, no drift.
+ */
+export function checkRelativePathAllowed(
   requestedPath: string,
-  projectDir: string,
   config: FileViewerConfig,
-): Promise<PathValidationResult> {
+): { ok: true; normalized: string } | { ok: false; error: string; status: number } {
   // Layer 1: Normalize
   const normalized = path.normalize(requestedPath);
 
   // Layer 2: Reject absolute paths
   if (path.isAbsolute(normalized)) {
-    return { valid: false, error: 'Absolute paths are not allowed', status: 403 };
+    return { ok: false, error: 'Absolute paths are not allowed', status: 403 };
   }
 
   // Layer 3: Reject path traversal
   if (normalized.includes('..')) {
-    return { valid: false, error: 'Path traversal not allowed', status: 403 };
+    return { ok: false, error: 'Path traversal not allowed', status: 403 };
   }
 
-  // Layer 3b: Never-served deny (fast path — the load-bearing check re-runs
-  // post-realpath at Layer 5e so a symlink cannot evade it).
+  // Layer 3b: Never-served deny (fast path — validatePath's load-bearing
+  // check re-runs post-realpath at Layer 5e so a symlink cannot evade it).
   if (isNeverServed(normalized)) {
-    return { valid: false, error: 'Access to this path is not permitted', status: 403 };
+    return { ok: false, error: 'Access to this path is not permitted', status: 403 };
   }
 
   // Layer 4: Check against allowedPaths
@@ -165,8 +176,22 @@ async function validatePath(
            normalizedClean.startsWith(normalizedAllowed + '/');
   });
   if (!allowed) {
-    return { valid: false, error: 'Path not in allowed directories', status: 403 };
+    return { ok: false, error: 'Path not in allowed directories', status: 403 };
   }
+  return { ok: true, normalized };
+}
+
+async function validatePath(
+  requestedPath: string,
+  projectDir: string,
+  config: FileViewerConfig,
+): Promise<PathValidationResult> {
+  // Layers 1–4 via the shared pre-check (single source of truth).
+  const pre = checkRelativePathAllowed(requestedPath, config);
+  if (!pre.ok) {
+    return { valid: false, error: pre.error, status: pre.status };
+  }
+  const normalized = pre.normalized;
 
   // Layer 5: Symlink resolution
   const absolutePath = path.resolve(projectDir, normalized);
@@ -812,24 +837,17 @@ export function createFileRoutes(options: { config: InstarConfig; liveConfig?: {
       return;
     }
 
-    // Validate path is within allowed directories
-    const normalized = path.normalize(filePath);
-    const inAllowed = config.allowedPaths.some(ap => {
-      const normalizedAllowed = path.normalize(ap);
-      return normalized.startsWith(normalizedAllowed) || normalized === normalizedAllowed.replace(/\/$/, '');
-    });
-
-    if (!inAllowed) {
-      res.status(403).json({ error: 'Path not in allowed directories' });
+    // Layers 1–4 via the shared pre-check — the same policy validatePath
+    // applies (project-root convention, segment boundaries, traversal/
+    // absolute rejection, never-served deny). This route previously carried
+    // an inline duplicate that drifted and 403'd every link under the
+    // default `allowedPaths: ['./']`.
+    const pre = checkRelativePathAllowed(filePath, config);
+    if (!pre.ok) {
+      res.status(pre.status).json({ error: pre.error });
       return;
     }
-
-    // Never-served deny (spec §3.5): the link route does not flow through
-    // validatePath, so it enforces the hardcoded deny explicitly.
-    if (isNeverServed(normalized)) {
-      res.status(403).json({ error: 'Access to this path is not permitted' });
-      return;
-    }
+    const normalized = pre.normalized;
 
     const encodedPath = encodeURIComponent(normalized);
     const relativePath = `/dashboard?tab=files&path=${encodedPath}`;

--- a/tests/e2e/file-viewer-e2e.test.ts
+++ b/tests/e2e/file-viewer-e2e.test.ts
@@ -817,6 +817,31 @@ describe('E2E: Dashboard File Viewer', () => {
       // URL should be properly encoded
       expect(res.body.relative).toBe('/dashboard?tab=files&path=docs%2FREADME.md');
     });
+
+    it("generates links under the DEFAULT project-root config ['./'] (regression: was a blanket 403)", async () => {
+      // files-link-allowed-paths spec: the link route's drifted inline check
+      // never learned the '.'/'./' root convention, so the DEFAULT config
+      // 403'd every link. The suite's other link tests use scoped paths
+      // ('.claude/', 'docs/') — exactly why this never surfaced here before.
+      await request(baseUrl, 'PATCH', '/api/files/config', {
+        allowedPaths: ['./'],
+      }, { 'x-instar-request': '1' });
+      try {
+        const res = await request(baseUrl, 'GET', '/api/files/link?path=.claude/CLAUDE.md');
+        expect(res.status).toBe(200);
+        expect(res.body.path).toBe('.claude/CLAUDE.md');
+        // Traversal + absolute must still be rejected under the root config.
+        const trav = await request(baseUrl, 'GET', `/api/files/link?path=${encodeURIComponent('../outside.txt')}`);
+        expect(trav.status).toBe(403);
+        const abs = await request(baseUrl, 'GET', `/api/files/link?path=${encodeURIComponent('/etc/passwd')}`);
+        expect(abs.status).toBe(403);
+      } finally {
+        // Restore the allowedPaths the surrounding tests established.
+        await request(baseUrl, 'PATCH', '/api/files/config', {
+          allowedPaths: ['.claude/', 'docs/'],
+        }, { 'x-instar-request': '1' });
+      }
+    });
   });
 
   // ════════════════════════════════════════════════════════════════════

--- a/tests/unit/fileRoutes-link-allowed-paths.test.ts
+++ b/tests/unit/fileRoutes-link-allowed-paths.test.ts
@@ -1,0 +1,130 @@
+/**
+ * GET /api/files/link honors the shared allowed-path policy
+ * (docs/specs/files-link-allowed-paths.md).
+ *
+ * The regression this pins (found live 2026-07-23, Drive 11 cycle 24): the
+ * link route carried its own INLINE duplicate of the Layer-4 allowedPaths
+ * check, which drifted from validatePath — it never learned the '.'/'./'
+ * project-root convention, so under the DEFAULT config
+ * (`allowedPaths: ['./']`) EVERY link request 403'd "Path not in allowed
+ * directories". The inline check also matched prefixes without a segment
+ * boundary and skipped the absolute/traversal rejections.
+ *
+ * Fix: one exported pure pre-check (`checkRelativePathAllowed`) is the single
+ * source of truth for Layers 1–4; both validatePath and the link route flow
+ * through it. Both sides of every decision boundary covered below.
+ *
+ * Harness mirrors tests/unit/fileRoutes-never-served.test.ts (express app +
+ * createFileRoutes + supertest).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import request from 'supertest';
+import { createFileRoutes, checkRelativePathAllowed } from '../../src/server/fileRoutes.js';
+import type { InstarConfig, FileViewerConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const cfg = (allowedPaths: string[]): FileViewerConfig => ({
+  enabled: true,
+  allowedPaths,
+  editablePaths: [],
+  maxFileSize: 1_048_576,
+  maxEditableFileSize: 204_800,
+});
+
+describe('checkRelativePathAllowed (unit — the shared Layer 1–4 pre-check)', () => {
+  it("the './' project-root default allows any in-project relative path", () => {
+    for (const p of ['.claude/CLAUDE.md', 'docs/readme.md', 'src/server/routes.ts']) {
+      const r = checkRelativePathAllowed(p, cfg(['./']));
+      expect(r.ok, p).toBe(true);
+    }
+  });
+
+  it("the '.' spelling of project root behaves identically", () => {
+    expect(checkRelativePathAllowed('.claude/CLAUDE.md', cfg(['.'])).ok).toBe(true);
+  });
+
+  it('a scoped allowed path matches itself and its children only', () => {
+    expect(checkRelativePathAllowed('docs/readme.md', cfg(['docs/'])).ok).toBe(true);
+    expect(checkRelativePathAllowed('docs', cfg(['docs/'])).ok).toBe(true);
+    expect(checkRelativePathAllowed('src/index.ts', cfg(['docs/'])).ok).toBe(false);
+  });
+
+  it('prefix matching respects segment boundaries (docs must not admit docs-secret)', () => {
+    const r = checkRelativePathAllowed('docs-secret/x.md', cfg(['docs']));
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects absolute paths and traversal regardless of allowedPaths', () => {
+    const abs = checkRelativePathAllowed('/etc/passwd', cfg(['./']));
+    expect(abs.ok).toBe(false);
+    if (!abs.ok) expect(abs.status).toBe(403);
+    const trav = checkRelativePathAllowed('../outside.txt', cfg(['./']));
+    expect(trav.ok).toBe(false);
+    // The '.'-root convention must not admit traversal ('..' starts with '.').
+    const travDot = checkRelativePathAllowed('../../secret', cfg(['.']));
+    expect(travDot.ok).toBe(false);
+  });
+
+  it('never-served paths are denied even under the project-root default', () => {
+    const r = checkRelativePathAllowed('.instar/state/judgment-provenance/x.jsonl', cfg(['./']));
+    expect(r.ok).toBe(false);
+  });
+
+  it('returns the normalized path on success', () => {
+    const r = checkRelativePathAllowed('docs/./readme.md', cfg(['./']));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.normalized).toBe('docs/readme.md');
+  });
+});
+
+describe('GET /api/files/link under the DEFAULT config (the live regression)', () => {
+  let projectDir: string;
+  let app: express.Express;
+
+  beforeAll(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'link-allowed-'));
+    fs.mkdirSync(path.join(projectDir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.claude', 'CLAUDE.md'), '# hi\n');
+    const config = {
+      projectDir,
+      stateDir: path.join(projectDir, '.instar'),
+      projectName: 'link-allowed-test',
+      port: 0,
+      // No dashboard.fileViewer override → DEFAULT config (allowedPaths ['./']).
+    } as unknown as InstarConfig;
+    app = express();
+    app.use(express.json());
+    app.use(createFileRoutes({ config }));
+  });
+  afterAll(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/fileRoutes-link-allowed-paths.test.ts',
+    });
+  });
+
+  it('generates a link for a project file under the default allowedPaths (was a blanket 403)', async () => {
+    const res = await request(app).get('/api/files/link').query({ path: '.claude/CLAUDE.md' });
+    expect(res.status).toBe(200);
+    expect(res.body.path).toBe('.claude/CLAUDE.md');
+    expect(res.body.relative).toContain('tab=files');
+    expect(res.body.relative).toContain(encodeURIComponent('.claude/CLAUDE.md'));
+  });
+
+  it('still 403s traversal, absolute, and never-served paths', async () => {
+    for (const bad of ['../outside.txt', '/etc/passwd', '.instar/state/judgment-provenance/x.jsonl']) {
+      const res = await request(app).get('/api/files/link').query({ path: bad });
+      expect(res.status, bad).toBe(403);
+    }
+  });
+
+  it('still 400s a missing path parameter', async () => {
+    const res = await request(app).get('/api/files/link');
+    expect(res.status).toBe(400);
+  });
+});

--- a/upgrades/next/files-link-allowed-paths.md
+++ b/upgrades/next/files-link-allowed-paths.md
@@ -1,0 +1,30 @@
+---
+slug: files-link-allowed-paths
+summary: Fix the dashboard file deep-link endpoint 403ing every request under the default allowedPaths config; unify the allowed-path policy into one shared check.
+---
+
+# File deep links work under the default config
+
+## What Changed
+
+`GET /api/files/link` carried a private, drifted copy of the allowed-path
+check that never learned the `'./'` project-root convention — so on default
+installs (`allowedPaths: ['./']`) every link request answered
+`403 Path not in allowed directories`. The Layer 1–4 policy (normalize,
+absolute/traversal rejection, never-served deny, allowedPaths match) is now
+one exported helper used by both `validatePath` and the link route; the
+duplicate is deleted. The link route is also stricter where the duplicate
+was loose: traversal, absolute paths, and segment-boundary bypasses are now
+rejected.
+
+## What to Tell Your User
+
+Dashboard file links work now. When your agent hands you a link straight to a
+file in the dashboard's Files tab, it opens instead of failing — this was
+broken on default settings. Nothing to configure.
+
+## Summary of New Capabilities
+
+- File deep links (`/api/files/link`) work under the default file-viewer
+  config; the allowed-path policy has a single implementation shared by all
+  file endpoints, so the two can no longer drift apart.

--- a/upgrades/side-effects/files-link-allowed-paths.md
+++ b/upgrades/side-effects/files-link-allowed-paths.md
@@ -1,0 +1,36 @@
+# Side-effects analysis — files-link-allowed-paths
+
+## ELI16 — what this does
+
+The dashboard's file deep-link endpoint (`GET /api/files/link`) rejected
+every request with 403 on default installs, because it carried a private,
+drifted copy of the allowed-path check that never learned the `'./'`
+project-root convention. The fix extracts the canonical Layer 1–4 check into
+one exported helper (`checkRelativePathAllowed`) used by both `validatePath`
+and the link route, deleting the duplicate.
+
+## What could this break?
+
+- **validatePath callers** (read/list/download/edit endpoints): behavior is
+  intended to be identical — the helper is a verbatim extraction of Layers
+  1–4. Verified by the full file-viewer e2e suite (96 tests green
+  post-refactor, including never-served, symlink-evasion, and edit paths).
+- **Link route behavior change (intended)**: requests that previously 403'd
+  under the default config now succeed (the regression being fixed). In the
+  OTHER direction the route becomes stricter: absolute paths, traversal, and
+  segment-boundary bypasses that the drifted inline check could admit under
+  scoped configs are now rejected — strictly safer.
+- **Response shapes**: unchanged (200 body, 400/403 error bodies keep their
+  fields; 403 error strings now come from the shared check's messages).
+
+## Failure modes considered
+
+- The link route intentionally does NOT gain Layer 5 (existence/symlink
+  resolution): it emits a URL, not content; the read endpoints enforce the
+  full stack when the link is followed. Documented as a spec non-goal.
+
+## Test coverage
+
+- `tests/unit/fileRoutes-link-allowed-paths.test.ts` — 10 tests, both sides
+  of every boundary + the route-level regression pin.
+- Existing `fileRoutes-never-served` + `file-viewer-e2e` suites green.


### PR DESCRIPTION
## What this fixes

Live repro (Drive 11, cycle 24): `GET /api/files/link?path=.claude/CLAUDE.md` answered **403 Path not in allowed directories** on a server running the DEFAULT file-viewer config (`allowedPaths: ['./']`) — the widest possible setting. Every dashboard deep-link request failed.

## Root cause — a drifted duplicate

The link route carried its own inline allowed-path check instead of flowing through `validatePath`. The duplicate drifted three ways: (1) it never learned the `'.'`/`'./'` project-root convention, so the default config matched nothing; (2) it matched prefixes without a segment boundary (`docs` would admit `docs-secret/…`); (3) it skipped the absolute/traversal rejections (with `allowedPaths: ['.']`, `'../…'` passed because `'..'` starts with `'.'`). Low severity on (3) — the route emits a URL, not content — but wrong.

## ELI16 — Overview

The dashboard's Files tab can be deep-linked. Behind that is a safety list of browsable folders. The main file-reading code checks the list correctly, including the convention that "./" means "the whole project". The link endpoint had its own private copy of that check which never understood "./" — so on default settings it rejected every request. The fix deletes the private copy: both places now call one shared check, so they can never drift apart again — and the shared check also rejects sneaky "../" paths the private copy quietly let through.

## The fix

Layers 1–4 (normalize, absolute/traversal rejection, never-served deny, allowedPaths match) extracted into one exported pure helper `checkRelativePathAllowed`; both `validatePath` and the link route flow through it. This is the exact failure mode **Structure beats Willpower** names — policy in two places, the copy rotted.

## Tests

- Unit (10, new): both sides of every boundary — root conventions, scoped self+children, segment boundary, absolute/traversal/never-served rejections, normalized output; route-level regression pin.
- E2E (+1, paired): the default-config `['./']` case against the real server path — the suite's other link tests use scoped paths, which is exactly why this never surfaced.
- Full file-viewer e2e suite green post-refactor (67 tests) — `validatePath` behavior preserved.

## Ceremony

Spec: `docs/specs/files-link-allowed-paths.md` (parent: Structure beats Willpower) · side-effects + release fragment (canonical sections) · instar-dev trace + gate on the commit.