### PR TITLE
fix(throughput): require explicit GitHub runtime identity

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-24T14-56-33-744Z-throughput-github-runtime-repair.json
+++ b/.instar/instar-dev-decisions/2026-07-24T14-56-33-744Z-throughput-github-runtime-repair.json
@@ -1,0 +1,26 @@
+{
+  "ts": "2026-07-24T14:56:33.744Z",
+  "slug": "throughput-github-runtime-repair",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 521,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "The touched CI and Green-PR controllers retain lease and cadence admission with no new trigger edge; missing explicit identity converges each tick to a bounded no-action refusal, while the cited ratchet detects any steady-state action path lacking a settling brake."
+    },
+    "component": "github-runtime-consumers"
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T14-57-21-512Z-throughput-github-runtime-repair.json
+++ b/.instar/instar-dev-decisions/2026-07-24T14-57-21-512Z-throughput-github-runtime-repair.json
@@ -1,0 +1,26 @@
+{
+  "ts": "2026-07-24T14:57:21.512Z",
+  "slug": "throughput-github-runtime-repair",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 521,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "The touched CI and Green-PR controllers retain lease and cadence admission with no new trigger edge; missing explicit identity converges each tick to a bounded no-action refusal, while the cited ratchet detects any steady-state action path lacking a settling brake."
+    },
+    "component": "github-runtime-consumers"
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T14-58-42-198Z-throughput-github-runtime-repair.json
+++ b/.instar/instar-dev-decisions/2026-07-24T14-58-42-198Z-throughput-github-runtime-repair.json
@@ -1,0 +1,29 @@
+{
+  "ts": "2026-07-24T14:58:42.198Z",
+  "slug": "throughput-github-runtime-repair",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 521,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The Throughput implementation was validated from an interactive shell, but its production launchd environment lacked Homebrew PATH; the same code also inherited gh's machine-global keychain principal because no explicit server identity boundary existed."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "The touched CI and Green-PR controllers retain lease and cadence admission with no new trigger edge; missing explicit identity converges each tick to a bounded no-action refusal, while the cited ratchet detects any steady-state action path lacking a settling brake."
+    },
+    "component": "github-runtime-consumers"
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/throughput-github-runtime-repair.eli16.md
+++ b/docs/specs/throughput-github-runtime-repair.eli16.md
@@ -1,0 +1,38 @@
+# Throughput GitHub Runtime Repair — Plain-English Overview
+
+> The one-line version: the Throughput chart and its neighboring GitHub jobs now use an explicit agent-owned GitHub identity and no longer depend on the Mac's login shell or somebody else's GitHub session.
+
+## The problem in one breath
+
+The Throughput tab was present, but its server request failed every time in production. The server starts in the background with a smaller command search path than an interactive terminal, so it could not find the Homebrew-installed GitHub program. Worse, if it did find the program, it could silently act as whichever person last signed into GitHub on that Mac.
+
+## What already exists
+
+- **The Throughput chart** — shows merged work, speed, quality, output, and a composite score.
+- **The agent secret vault** — can hold a `github_token` without placing it in source code.
+- **The Green-PR safety ladder** — checks eligibility and delegates the final operation to the guarded merge script.
+- **The CI failure poller** — reads failed GitHub runs for the failure-learning loop.
+
+## What this adds
+
+Throughput now talks directly to GitHub's structured API. It uses only a token explicitly supplied to the server or stored in the agent's vault. If neither exists, the route says that GitHub authentication is unavailable and stops; it does not borrow the Mac owner's login.
+
+The two jobs that still need the GitHub command-line program share one resolver. That resolver finds the Homebrew binary by absolute path, attaches the explicit agent token, and passes the same identity into the guarded merge child. It briefly caches the answer so periodic jobs do not repeatedly unlock the vault.
+
+## The safeguards
+
+**Prevents the wrong identity from being used.** There is no lookup of the GitHub CLI's global login and no unauthenticated fallback. Both token variables are set explicitly for every remaining child process.
+
+**Prevents plausible but incomplete charts.** GitHub Search reports how many matches exist. The server verifies that number, refuses windows beyond the provider's 1,000-result ceiling, and refuses if pagination returns fewer rows than promised.
+
+**Keeps calendar days honest.** Daily buckets use the real Los Angeles timezone, including daylight-saving changes, instead of assuming the coast is always seven hours behind UTC.
+
+**Keeps autonomous merge authority unchanged.** The repair supplies a trustworthy runtime identity; it does not weaken protected-path checks, CI checks, head pinning, leases, or the final guarded merge script.
+
+## What ships when
+
+This is one repair release because partial shipment would leave a known identity hole. Code, tests, review artifacts, and release notes land together. The merge is not the final done claim: after deployment, Echo must load the real Throughput chart at desktop and phone widths and confirm live chart data.
+
+## What you actually need to decide
+
+The approved shape is: direct authenticated GraphQL for Throughput, one explicit authenticated CLI runtime for the two unavoidable CLI consumers, and fail-closed behavior whenever identity or data completeness cannot be proven.

--- a/docs/specs/throughput-github-runtime-repair.md
+++ b/docs/specs/throughput-github-runtime-repair.md
@@ -1,0 +1,104 @@
+---
+slug: throughput-github-runtime-repair
+title: "Throughput GitHub runtime repair and explicit server identity"
+date: 2026-07-24
+author: instar-codey
+review-convergence: "three-lens-security-integration-throughput-2026-07-24"
+review-iterations: 2
+approved: true
+approved-by: User
+approved-via: "Interactive Mini session, 2026-07-24: urgent fix direction explicitly authorized, including direct GraphQL preference, explicit identity, class closure across all three bare-gh call paths, full ceremony, and auto-merge."
+eli16-overview: throughput-github-runtime-repair.eli16.md
+parent-principle: "Know Your Principal — An Unverified Identity Is a Guess"
+---
+
+# Throughput GitHub runtime repair and explicit server identity
+
+## Problem
+
+The production Throughput route executes the GitHub CLI by its bare name. Instar
+servers launched by launchd do not normally inherit Homebrew's binary directory,
+so the process fails with `ENOENT` and the route returns HTTP 503 on every request.
+Even when the executable is discoverable, an unqualified server-side CLI call may
+use the machine-global GitHub keychain seat. That identity can belong to someone
+other than the agent and is not an acceptable identity source for shipped server
+behavior.
+
+Two adjacent server components share the same class: the CI failure poller invokes
+the CLI directly, and the Green-PR merge watcher invokes it for reads while its
+`safe-merge` child invokes it again for actuation.
+
+## Design
+
+1. Throughput no longer starts a CLI process. It calls GitHub GraphQL directly with
+   a token resolved from `GITHUB_TOKEN`, then the agent vault's `github_token`.
+   Absence of explicit identity returns the distinct `github-auth-unavailable`
+   HTTP 503. Transport, schema, pagination, and count failures retain the generic
+   fail-closed 503.
+2. A shared server GitHub runtime resolves the two remaining CLI consumers. It
+   selects an absolute executable from the two Homebrew locations or absolute PATH
+   entries and constructs a child environment containing explicit `GH_TOKEN` and
+   `GITHUB_TOKEN`. It never consults `gh auth` or a machine-global config.
+3. Runtime resolution is cached for five minutes, including missing-token results.
+   This avoids repeated vault/keychain reads from periodic pollers while bounding
+   how long a token rotation takes to appear.
+4. The Green-PR watcher shares one resolved runtime between read calls and the
+   `safe-merge` child. The child PATH begins with the already-resolved executable
+   directory, so the script's internal `gh` calls select that binary and inherit
+   the same explicit identity. Missing runtime makes both contract probing and
+   actuation refuse.
+5. GitHub Search's `issueCount` is treated as a cardinality invariant. Counts over
+   GitHub's 1,000-result Search ceiling, count changes during pagination, or a final
+   fetched-count mismatch make the Throughput read fail closed rather than render
+   silently incomplete metrics.
+6. Throughput day buckets use the `America/Los_Angeles` timezone instead of a fixed
+   UTC offset, covering both PST and PDT.
+
+## Decision points touched
+
+- **Throughput identity availability** — deterministic safety invariant. No token
+  means a distinct unavailable response; there is no fallback identity.
+- **GitHub CLI runtime availability** — deterministic safety invariant. Both an
+  explicit token and executable must resolve before a remaining CLI operation.
+- **Search completeness** — deterministic data-integrity invariant. Reported and
+  fetched counts must agree and remain within the provider ceiling.
+- **Green-PR actuation** — existing `safe-merge` authority is unchanged. This repair
+  supplies its process identity and fails before it when identity is unavailable.
+
+These are enumerable boundary checks, not contextual judgment points. Existing
+lease, protected-path, check-state, head-pin, and `safe-merge` authorities remain
+in place.
+
+## Acceptance criteria
+
+- The Throughput route succeeds with launchd-like PATH when an explicit token is
+  available, without starting `gh`.
+- Missing explicit identity returns HTTP 503 with
+  `github-auth-unavailable`.
+- Environment identity takes precedence over the vault; no code invokes `gh auth`.
+- CI polling and both Green-PR read and act paths use the shared explicit runtime.
+- Relative PATH entries, non-files, and non-executable candidates are rejected.
+- Runtime successes and failures are cached only for a bounded interval.
+- Search truncation and cardinality drift fail closed.
+- Pacific day boundaries are correct in summer and winter.
+- Focused tests, TypeScript, lint, repository invariants, and the complete test
+  ceremony pass or any unrelated baseline failure is independently reproduced and
+  documented.
+
+## Rollback
+
+This is a code-only change with no schema or durable-state migration. Reverting the
+commit restores the prior behavior. During rollback propagation, Throughput may
+return the original 503 and the two remaining CLI consumers may again depend on the
+ambient machine, so rollback is operationally safe but knowingly restores the
+incident.
+
+## Convergence record
+
+The first implementation removed the Throughput subprocess and added the shared
+runtime. Independent security, integration, and throughput-correctness reviews
+then challenged the design. The converged revision additionally threads explicit
+identity through the real `safe-merge` act path, validates Search cardinality,
+uses timezone-aware day boundaries, rejects relative PATH entries, caches vault
+resolution, and adds consumer-level behavioral tests. With those findings folded
+in, all three review lenses returned no unresolved design objection.

--- a/src/core/githubRuntime.ts
+++ b/src/core/githubRuntime.ts
@@ -1,0 +1,279 @@
+/**
+ * Server-safe GitHub runtime.
+ *
+ * Long-lived agent servers run under launchd, where PATH commonly omits
+ * Homebrew, and must never inherit the active identity from a machine-global
+ * `gh` keychain seat. This module is the single runtime boundary for:
+ *
+ *  - resolving an explicit per-agent token (`GITHUB_TOKEN`, then vault);
+ *  - calling GitHub GraphQL directly; and
+ *  - running the few remaining gh-dependent server adapters with an absolute
+ *    executable and explicit token environment.
+ *
+ * Missing auth/executable always fails before a GitHub operation. No caller
+ * falls through to `~/.config/gh/hosts.yml`.
+ */
+import { execFile, execFileSync } from 'node:child_process';
+import { constants as fsConstants, accessSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { resolveGhTokenFromVault, type ResolveGhTokenOptions } from './ghToken.js';
+
+export class GitHubAuthUnavailableError extends Error {
+  readonly code = 'github-auth-unavailable';
+
+  constructor() {
+    super('github-auth-unavailable');
+    this.name = 'GitHubAuthUnavailableError';
+  }
+}
+
+export class GitHubCliUnavailableError extends Error {
+  readonly code = 'github-cli-unavailable';
+
+  constructor() {
+    super('github-cli-unavailable');
+    this.name = 'GitHubCliUnavailableError';
+  }
+}
+
+export interface ResolveGitHubTokenOptions extends ResolveGhTokenOptions {
+  stateDir?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+/** Resolve only explicit server identity: environment first, then agent vault. */
+export function resolveGitHubToken(options: ResolveGitHubTokenOptions = {}): string | null {
+  const env = options.env ?? process.env;
+  const token = env.GITHUB_TOKEN;
+  if (typeof token === 'string' && token.trim()) return token.trim();
+  return options.stateDir
+    ? resolveGhTokenFromVault(options.stateDir, { forceFileKey: options.forceFileKey })
+    : null;
+}
+
+/** Cache token presence or absence for a bounded interval. */
+export function createGitHubTokenResolver(options: ResolveGitHubTokenOptions & {
+  cacheTtlMs?: number;
+  now?: () => number;
+}): () => string | null {
+  const now = options.now ?? (() => Date.now());
+  const cacheTtlMs = options.cacheTtlMs ?? 5 * 60_000;
+  let cached: { expiresAt: number; token: string | null } | null = null;
+  return () => {
+    const timestamp = now();
+    if (cached && timestamp < cached.expiresAt) return cached.token;
+    const token = resolveGitHubToken(options);
+    cached = { expiresAt: timestamp + cacheTtlMs, token };
+    return token;
+  };
+}
+
+export interface ResolveGhExecutableOptions {
+  env?: NodeJS.ProcessEnv;
+  isExecutable?: (candidate: string) => boolean;
+}
+
+/**
+ * Resolve gh without relying on launchd's truncated PATH. Candidate order is
+ * deterministic: Apple Silicon Homebrew, Intel Homebrew, then explicit PATH.
+ */
+export function resolveGhExecutable(options: ResolveGhExecutableOptions = {}): string | null {
+  const env = options.env ?? process.env;
+  const isExecutable = options.isExecutable ?? ((candidate: string) => {
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      return statSync(candidate).isFile();
+    } catch { /* @silent-fallback-ok — a missing/non-executable gh candidate is expected while resolving the next explicit candidate */
+      return false;
+    }
+  });
+  const candidates = [
+    '/opt/homebrew/bin/gh',
+    '/usr/local/bin/gh',
+    ...(env.PATH ?? '')
+      .split(path.delimiter)
+      .filter((dir) => path.isAbsolute(dir))
+      .map((dir) => path.join(dir, 'gh')),
+  ];
+  for (const candidate of [...new Set(candidates)]) {
+    if (isExecutable(candidate)) return candidate;
+  }
+  return null;
+}
+
+function explicitGitHubEnv(env: NodeJS.ProcessEnv, token: string, executable: string): NodeJS.ProcessEnv {
+  const executableDir = path.dirname(executable);
+  const pathEntries = (env.PATH ?? '')
+    .split(path.delimiter)
+    .filter((entry) => path.isAbsolute(entry) && entry !== executableDir);
+  return {
+    ...env,
+    GH_TOKEN: token,
+    GITHUB_TOKEN: token,
+    // safe-merge still invokes `gh` internally. Put the already-resolved,
+    // absolute executable directory first so that child cannot select a
+    // different binary or depend on launchd's truncated PATH.
+    PATH: [executableDir, ...pathEntries].join(path.delimiter),
+  };
+}
+
+export type AuthenticatedGhResult = { code: number; stdout: string; stderr: string };
+export type AuthenticatedGhExec = (args: string[]) => Promise<AuthenticatedGhResult>;
+
+export interface AuthenticatedGitHubCliRuntime {
+  executable: string;
+  env: NodeJS.ProcessEnv;
+}
+
+interface AuthenticatedGitHubRuntimeOptions extends ResolveGitHubTokenOptions {
+  resolveToken?: () => string | null;
+  resolveExecutable?: () => string | null;
+  cacheTtlMs?: number;
+  now?: () => number;
+}
+
+/**
+ * Resolve and briefly cache the explicit GitHub CLI runtime. Long-lived
+ * pollers call this repeatedly, so caching both success and typed failure
+ * avoids a vault/keychain read on every GitHub command while still allowing
+ * token rotation to take effect within the bounded TTL.
+ */
+export function createAuthenticatedGitHubCliRuntimeResolver(
+  options: AuthenticatedGitHubRuntimeOptions,
+): () => AuthenticatedGitHubCliRuntime {
+  const env = options.env ?? process.env;
+  const now = options.now ?? (() => Date.now());
+  const cacheTtlMs = options.cacheTtlMs ?? 5 * 60_000;
+  let cached:
+    | { expiresAt: number; value: AuthenticatedGitHubCliRuntime }
+    | { expiresAt: number; error: GitHubAuthUnavailableError | GitHubCliUnavailableError }
+    | null = null;
+
+  return () => {
+    const timestamp = now();
+    if (cached && timestamp < cached.expiresAt) {
+      if ('error' in cached) throw cached.error;
+      return cached.value;
+    }
+    const expiresAt = timestamp + cacheTtlMs;
+    const token = options.resolveToken ? options.resolveToken() : resolveGitHubToken(options);
+    if (!token) {
+      const error = new GitHubAuthUnavailableError();
+      cached = { expiresAt, error };
+      throw error;
+    }
+    const executable = options.resolveExecutable ? options.resolveExecutable() : resolveGhExecutable({ env });
+    if (!executable) {
+      const error = new GitHubCliUnavailableError();
+      cached = { expiresAt, error };
+      throw error;
+    }
+    const value = { executable, env: explicitGitHubEnv(env, token, executable) };
+    cached = { expiresAt, value };
+    return value;
+  };
+}
+
+interface AuthenticatedGhOptions extends AuthenticatedGitHubRuntimeOptions {
+  resolveRuntime?: () => AuthenticatedGitHubCliRuntime;
+  execFileImpl?: typeof execFile;
+}
+
+/** Build the async arg-array gh runner used by long-lived server adapters. */
+export function createAuthenticatedGhExec(options: AuthenticatedGhOptions): AuthenticatedGhExec {
+  const run = options.execFileImpl ?? execFile;
+  const resolveRuntime = options.resolveRuntime
+    ?? createAuthenticatedGitHubCliRuntimeResolver(options);
+  return async (args: string[]) => {
+    let runtime: AuthenticatedGitHubCliRuntime;
+    try {
+      runtime = resolveRuntime();
+    } catch (error) {
+      if (error instanceof GitHubAuthUnavailableError || error instanceof GitHubCliUnavailableError) {
+        return { code: 1, stdout: '', stderr: error.code };
+      }
+      throw error;
+    }
+    return new Promise((resolve) => {
+      run(
+        runtime.executable,
+        args,
+        {
+          env: runtime.env,
+          timeout: 30_000,
+          maxBuffer: 32 * 1024 * 1024,
+        },
+        (err, stdout, stderr) => resolve({
+          code: err ? (typeof (err as NodeJS.ErrnoException & { code?: unknown }).code === 'number'
+            ? (err as NodeJS.ErrnoException & { code: number }).code
+            : 1) : 0,
+          stdout: stdout ?? '',
+          stderr: stderr ?? '',
+        }),
+      );
+    });
+  };
+}
+
+interface AuthenticatedGhSyncOptions extends AuthenticatedGitHubRuntimeOptions {
+  resolveRuntime?: () => AuthenticatedGitHubCliRuntime;
+  resolveToken?: () => string | null;
+  resolveExecutable?: () => string | null;
+  execFileSyncImpl?: typeof execFileSync;
+  timeoutMs?: number;
+}
+
+/** Build a cached synchronous runner for legacy polling code. */
+export function createAuthenticatedGhSyncExec(
+  options: AuthenticatedGhSyncOptions,
+): (args: string[]) => string {
+  const run = options.execFileSyncImpl ?? execFileSync;
+  const resolveRuntime = options.resolveRuntime
+    ?? createAuthenticatedGitHubCliRuntimeResolver(options);
+  return (args: string[]) => {
+    const runtime = resolveRuntime();
+    return run(runtime.executable, args, {
+      encoding: 'utf-8',
+      timeout: options.timeoutMs ?? 15_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: runtime.env,
+    });
+  };
+}
+
+/** Run one synchronous command with explicit identity. */
+export function execAuthenticatedGhSync(args: string[], options: AuthenticatedGhSyncOptions): string {
+  return createAuthenticatedGhSyncExec(options)(args);
+}
+
+export interface FetchGitHubGraphqlOptions {
+  token: string;
+  query: string;
+  variables?: Record<string, unknown>;
+  fetchImpl?: typeof globalThis.fetch;
+  timeoutMs?: number;
+}
+
+/** Direct GitHub GraphQL call with a bounded, non-secret error surface. */
+export async function fetchGitHubGraphql<T>(options: FetchGitHubGraphqlOptions): Promise<T> {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const response = await fetchImpl('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${options.token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'instar-agent-server',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({ query: options.query, variables: options.variables ?? {} }),
+    signal: AbortSignal.timeout(options.timeoutMs ?? 30_000),
+  });
+  if (!response.ok) throw new Error(`github-graphql-http-${response.status}`);
+  const payload = await response.json() as { data?: T; errors?: unknown[] };
+  if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+    throw new Error(`github-graphql-errors-${payload.errors.length}`);
+  }
+  if (payload.data == null) throw new Error('github-graphql-invalid-response');
+  return payload.data;
+}

--- a/src/monitoring/CiFailurePoller.ts
+++ b/src/monitoring/CiFailurePoller.ts
@@ -22,7 +22,10 @@
  * filedBy is the constant `source:ci` (§5) so CI failures share one analyzer
  * "session" identity → they can never alone satisfy the diversity gate.
  */
-import { execFileSync } from 'node:child_process';
+import {
+  createAuthenticatedGhSyncExec,
+  type AuthenticatedGitHubCliRuntime,
+} from '../core/githubRuntime.js';
 import type { FailureLedger, FailureCategory } from './FailureLedger.js';
 // scrubSecrets moved to a shared module (spec §3.3 — the Correction & Preference
 // Learning Sentinel applies the SAME pass on both sides of its LLM hop). Still
@@ -44,8 +47,12 @@ export interface CiFailurePollerOptions {
   resolveByMergeCommit: (oid: string) => CiInitiativeRef | undefined;
   /** Resolve the `owner/name` repo (validated by the poller). Return null if none. */
   resolveRepo: () => string | null;
-  /** Injectable gh runner (args array). Default: execFileSync('gh', args). */
+  /** Per-agent state root containing the encrypted GitHub token vault. */
+  stateDir?: string;
+  /** Injectable gh runner (args array). Default: shared explicit-auth helper. */
   runGh?: (args: string[]) => string;
+  /** Test seam: shared explicit GitHub runtime resolver. */
+  githubRuntime?: () => AuthenticatedGitHubCliRuntime;
   /** Only poll when this returns true (fenced-lease holder). Default: always. */
   isLeaseHolder?: () => boolean;
   /** Poll interval (ms). Default 6h. */
@@ -112,7 +119,10 @@ export class CiFailurePoller {
     this.resolveRepo = opts.resolveRepo;
     this.runGh =
       opts.runGh ??
-      ((args) => execFileSync('gh', args, { encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] }));
+      createAuthenticatedGhSyncExec({
+        stateDir: opts.stateDir,
+        resolveRuntime: opts.githubRuntime,
+      });
     this.isLeaseHolder = opts.isLeaseHolder ?? (() => true);
     this.intervalMs = opts.intervalMs && opts.intervalMs > 0 ? opts.intervalMs : 6 * 60 * 60 * 1000;
     this.maxRunsPerTick = opts.maxRunsPerTick && opts.maxRunsPerTick > 0 ? opts.maxRunsPerTick : 50;
@@ -188,4 +198,3 @@ export class CiFailurePoller {
     return filed;
   }
 }
-

--- a/src/monitoring/MergeRunner.ts
+++ b/src/monitoring/MergeRunner.ts
@@ -77,6 +77,11 @@ export interface MergeRunnerConfig {
   mergeKillGraceMs: number;
   expectedContractVersion: number;
   /**
+   * Explicit per-agent GitHub child environment. Null means the act path is
+   * unavailable; the runner must not fall back to the machine-global gh seat.
+   */
+  resolveGitHubEnv: () => NodeJS.ProcessEnv | null;
+  /**
    * Merge strategy (mergerunner-auto-arm-handoff). `auto` (default) arms GitHub
    * native auto-merge via `safe-merge … --auto` and returns in seconds; `admin`
    * is the legacy synchronous poll+merge via `--admin`. Absent → 'auto'.
@@ -146,10 +151,12 @@ export class DefaultMergeRunner implements MergeRunner {
 
   async probeContract(): Promise<{ ok: boolean; version?: number }> {
     try {
+      const githubEnv = this.cfg.resolveGitHubEnv();
+      if (!githubEnv) return { ok: false };
       const out = await this.spawn({
         command: this.cfg.nodePath ?? process.execPath,
         args: [this.cfg.safeMergePath, '--capabilities'],
-        env: process.env,
+        env: githubEnv,
         deadlineMs: 30_000,
       });
       if (out.status !== 0) return { ok: false };
@@ -183,6 +190,11 @@ export class DefaultMergeRunner implements MergeRunner {
       this.log(`safe-merge hash changed between probe and exec — refusing (${attempt.pr})`);
       return { outcome: 'skipped:safe-merge-contract', confirmedMerged: false };
     }
+    const githubEnv = this.cfg.resolveGitHubEnv();
+    if (!githubEnv) {
+      this.log(`explicit GitHub runtime unavailable — refusing (${attempt.pr})`);
+      return { outcome: 'skipped:github-runtime-unavailable', confirmedMerged: false };
+    }
 
     const attemptToken = crypto.randomBytes(8).toString('hex');
     // Phase 1: durable intent record BEFORE the spawn.
@@ -212,7 +224,7 @@ export class DefaultMergeRunner implements MergeRunner {
           '--match-head-commit', attempt.headRefOid,
           '--deadline-ms', String(pathTimeoutMs),
         ],
-        env: { ...process.env, GREEN_PR_ATTEMPT_TOKEN: attemptToken },
+        env: { ...githubEnv, GREEN_PR_ATTEMPT_TOKEN: attemptToken },
         deadlineMs: pathTimeoutMs + this.cfg.mergeKillGraceMs,
         onPid: (pid) => {
           // Phase 2: patch pid/pgid (the child's pid IS its pgid when detached).

--- a/src/monitoring/greenPrAutomergeWiring.ts
+++ b/src/monitoring/greenPrAutomergeWiring.ts
@@ -28,8 +28,12 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { execFile } from 'node:child_process';
 
+import {
+  createAuthenticatedGhExec,
+  createAuthenticatedGitHubCliRuntimeResolver,
+  type AuthenticatedGitHubCliRuntime,
+} from '../core/githubRuntime.js';
 import { GuardLatchStore, type GuardLatchEntry } from './GuardLatchStore.js';
 import { DefaultMergeRunner } from './MergeRunner.js';
 import {
@@ -110,14 +114,8 @@ export interface GreenPrWiringOpts {
   logger?: (msg: string) => void;
   /** Test seam: override the gh exec. */
   ghExec?: (args: string[]) => Promise<{ stdout: string; stderr: string; code: number }>;
-}
-
-function gh(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
-  return new Promise((resolve) => {
-    execFile('gh', args, { maxBuffer: 16 * 1024 * 1024 }, (err, stdout, stderr) => {
-      resolve({ stdout: stdout ?? '', stderr: stderr ?? '', code: err ? (err as NodeJS.ErrnoException & { code?: number }).code ?? 1 : 0 });
-    });
-  });
+  /** Test seam: explicit GitHub runtime shared by reads and safe-merge. */
+  githubRuntime?: () => AuthenticatedGitHubCliRuntime;
 }
 
 /** Build the GuardLatchStore for this install. */
@@ -135,7 +133,12 @@ export function buildGuardLatchStore(opts: GreenPrWiringOpts): GuardLatchStore {
 
 /** Build the full GreenPrAutoMerger deps (real gh adapters). */
 export function buildGreenPrDeps(opts: GreenPrWiringOpts, latches: GuardLatchStore): GreenPrAutoMergerDeps {
-  const exec = opts.ghExec ?? gh;
+  const githubRuntime = opts.githubRuntime
+    ?? createAuthenticatedGitHubCliRuntimeResolver({ stateDir: opts.stateDir });
+  const exec = opts.ghExec ?? createAuthenticatedGhExec({
+    stateDir: opts.stateDir,
+    resolveRuntime: githubRuntime,
+  });
   const now = opts.now ?? (() => Date.now());
 
   const runner = new DefaultMergeRunner(
@@ -146,6 +149,13 @@ export function buildGreenPrDeps(opts: GreenPrWiringOpts, latches: GuardLatchSto
       mergeTimeoutMs: opts.mergeTimeoutMs,
       mergeKillGraceMs: opts.mergeKillGraceMs,
       expectedContractVersion: 2,
+      resolveGitHubEnv: () => {
+        try {
+          return githubRuntime().env;
+        } catch { /* @silent-fallback-ok: missing explicit GitHub identity makes the autonomous act path refuse */
+          return null;
+        }
+      },
       // mergerunner-auto-arm-handoff M2: the runner selects --auto vs --admin and
       // the auto-path deadline from these (config → GreenPrAutoMergerConfig →
       // buildGreenPrDeps → MergeRunnerConfig). Defaults keep the arm path.

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -2351,6 +2351,7 @@ export class AgentServer {
         if (sources?.ci === true && this.failureLedger) {
           this.ciFailurePoller = new CiFailurePoller({
             ledger: this.failureLedger,
+            stateDir: options.config.stateDir,
             resolveByMergeCommit: (oid) => {
               const i = tracker?.findByMergeCommit(oid);
               // `origin` (loop self-exclusion, §4.3) lands with slice 2's origin
@@ -3694,7 +3695,7 @@ export class AgentServer {
     }
     const routes = createRoutes(routeCtx);
     this.app.use(routes);
-    this.app.use(createThroughputRoutes());
+    this.app.use(createThroughputRoutes({ stateDir: options.config.stateDir }));
 
     // File viewer routes (after auth middleware)
     const fileRoutes = createFileRoutes({ config: options.config, liveConfig: options.liveConfig });

--- a/src/server/throughputRoutes.ts
+++ b/src/server/throughputRoutes.ts
@@ -1,35 +1,84 @@
-import { execFile } from 'node:child_process';
 import { Router, type Request, type Response } from 'express';
+import {
+  createGitHubTokenResolver,
+  fetchGitHubGraphql,
+  GitHubAuthUnavailableError,
+  resolveGitHubToken,
+} from '../core/githubRuntime.js';
 
 // RULE 3.1 RATIONALE
 // Criticality: low — this is a read-only dashboard signal with no actuation authority.
 // Frequency: on-demand, browser-selected, with a private one-minute response cache.
-// Stability: `gh --json` and GraphQL are versioned structured interfaces; no human text is parsed.
-// Fallback: command, schema, or JSON failure returns explicit HTTP 503, never plausible zero metrics.
+// Stability: GitHub GraphQL is a versioned structured interface; no human text is parsed.
+// Fallback: auth, transport, schema, or JSON failure returns explicit HTTP 503, never plausible zero metrics.
 // Verdict: deterministic aggregation over bounded inputs; contract tests pin author and index semantics.
 // RULE 3: EXEMPT — this parses typed, structured GitHub JSON and fails the read closed; it does not infer provider state from presentation text.
 
 type Author = 'codey' | 'echo' | 'other';
 type Weights = { velocity: number; speed: number; quality: number; output: number };
-type GhExec = (args: string[]) => Promise<{ code: number; stdout: string; stderr: string }>;
-type Pr = { number: number; title: string; author?: { login?: string }; mergedAt: string; createdAt: string; additions: number; deletions: number };
+export type ThroughputGraphql = (query: string, variables: Record<string, unknown>) => Promise<unknown>;
+type Pr = {
+  number: number;
+  title: string;
+  author?: { login?: string } | null;
+  mergedAt: string;
+  createdAt: string;
+  additions: number;
+  deletions: number;
+  reviews?: { nodes?: Array<{ state?: string }> };
+  commits?: { totalCount?: number };
+};
 type Detail = { reworkLoops: number; commits: number };
+type SearchPage = {
+  search?: {
+    issueCount?: number;
+    nodes?: Pr[];
+    pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+  };
+};
 
 export const DEFAULT_THROUGHPUT_WEIGHTS: Weights = { velocity: .40, speed: .20, quality: .25, output: .15 };
 const WINDOWS = [7, 14, 30] as const;
+const MAX_SEARCH_PAGES = 10;
+const THROUGHPUT_QUERY = `
+  query ThroughputPullRequests($query: String!, $cursor: String) {
+    search(query: $query, type: ISSUE, first: 100, after: $cursor) {
+      issueCount
+      nodes {
+        ... on PullRequest {
+          number
+          title
+          author { login }
+          mergedAt
+          createdAt
+          additions
+          deletions
+          reviews(first: 30) { nodes { state } }
+          commits { totalCount }
+        }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`;
 const ZERO = () => ({ merges: 0, medianLatencyH: 0, reworkLoops: 0, reverts: 0, medianPushIters: 0, medianLoc: 0 });
 
-function gh(args: string[]): ReturnType<GhExec> {
-  return new Promise(resolve => execFile('gh', args, { timeout: 30_000, maxBuffer: 32 * 1024 * 1024 }, (err, stdout, stderr) =>
-    resolve({ code: err ? 1 : 0, stdout: stdout ?? '', stderr: stderr ?? '' })));
-}
 function median(values: number[]): number {
   if (!values.length) return 0;
   const a = [...values].sort((x, y) => x - y); const m = Math.floor(a.length / 2);
   return Math.round((a.length % 2 ? a[m] : (a[m - 1] + a[m]) / 2) * 10) / 10;
 }
 function authorOf(login?: string): Author { return login === 'JKHeadley' ? 'codey' : login === 'EchoOfDawn' ? 'echo' : 'other'; }
-function pdtDay(iso: string): string { return new Date(Date.parse(iso) - 7 * 3_600_000).toISOString().slice(0, 10); }
+const PACIFIC_DAY = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/Los_Angeles',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+export function pacificDay(iso: string): string {
+  const parts = Object.fromEntries(PACIFIC_DAY.formatToParts(new Date(iso)).map((part) => [part.type, part.value]));
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
 function metrics(prs: Pr[], details: Map<number, Detail>) {
   return {
     merges: prs.length,
@@ -40,32 +89,77 @@ function metrics(prs: Pr[], details: Map<number, Detail>) {
     medianLoc: median(prs.map(p => p.additions + p.deletions)),
   };
 }
-async function detailMap(numbers: number[], run: GhExec): Promise<Map<number, Detail>> {
-  const out = new Map<number, Detail>();
-  for (let offset = 0; offset < numbers.length; offset += 50) {
-    const batch = numbers.slice(offset, offset + 50);
-    const fields = batch.map(n => `p${n}:pullRequest(number:${n}){number reviews(first:30){nodes{state}} commits{totalCount}}`).join(' ');
-    const r = await run(['api', 'graphql', '-f', `query=query{repository(owner:"JKHeadley",name:"instar"){${fields}}}`]);
-    if (r.code) throw new Error(`github-details-unavailable: ${r.stderr.slice(0, 120)}`);
-    const repo = JSON.parse(r.stdout)?.data?.repository ?? {};
-    for (const n of batch) {
-      const p = repo[`p${n}`]; if (!p) continue;
-      out.set(n, { reworkLoops: (p.reviews?.nodes ?? []).filter((x: { state?: string }) => x.state === 'CHANGES_REQUESTED').length, commits: Number(p.commits?.totalCount ?? 0) });
+
+async function listMergedPullRequests(
+  graphql: ThroughputGraphql,
+  cutoff: number,
+  now: number,
+): Promise<Pr[]> {
+  const searchQuery = `repo:JKHeadley/instar is:pr is:merged merged:>=${new Date(cutoff).toISOString().slice(0, 10)} sort:updated-desc`;
+  const prs: Pr[] = [];
+  let expectedCount: number | null = null;
+  let fetchedCount = 0;
+  let cursor: string | null = null;
+  for (let page = 0; page < MAX_SEARCH_PAGES; page += 1) {
+    const data = await graphql(THROUGHPUT_QUERY, { query: searchQuery, cursor }) as SearchPage;
+    const search = data.search;
+    if (!search || !Number.isSafeInteger(search.issueCount) || search.issueCount! < 0
+      || !Array.isArray(search.nodes) || !search.pageInfo) {
+      throw new Error('github-throughput-invalid-response');
     }
+    if (search.issueCount! > 1_000) throw new Error('github-throughput-result-cap-exceeded');
+    if (expectedCount === null) expectedCount = search.issueCount!;
+    if (search.issueCount !== expectedCount) throw new Error('github-throughput-count-changed');
+    fetchedCount += search.nodes.length;
+    prs.push(...search.nodes.filter((pr) =>
+      typeof pr?.mergedAt === 'string'
+      && Date.parse(pr.mergedAt) >= cutoff
+      && Date.parse(pr.mergedAt) <= now));
+    if (!search.pageInfo.hasNextPage) {
+      if (fetchedCount !== expectedCount) throw new Error('github-throughput-result-truncated');
+      return prs;
+    }
+    if (typeof search.pageInfo.endCursor !== 'string' || !search.pageInfo.endCursor) {
+      throw new Error('github-throughput-invalid-cursor');
+    }
+    cursor = search.pageInfo.endCursor;
   }
-  return out;
+  throw new Error('github-throughput-page-cap-exceeded');
 }
 
 /** Canonical server-owned implementation of Echo's throughput-metrics.mjs contract. */
-export async function buildThroughputSeries(opts: { days: 7 | 14 | 30; now?: Date; run?: GhExec; weights?: Weights }) {
-  const now = opts.now ?? new Date(); const run = opts.run ?? gh; const weights = opts.weights ?? DEFAULT_THROUGHPUT_WEIGHTS;
+export async function buildThroughputSeries(opts: {
+  days: 7 | 14 | 30;
+  now?: Date;
+  graphql?: ThroughputGraphql;
+  stateDir?: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof globalThis.fetch;
+  resolveToken?: () => string | null;
+  weights?: Weights;
+}) {
+  const now = opts.now ?? new Date(); const weights = opts.weights ?? DEFAULT_THROUGHPUT_WEIGHTS;
   const cutoff = now.getTime() - opts.days * 86_400_000;
-  const listed = await run(['pr', 'list', '--repo', 'JKHeadley/instar', '--state', 'merged', '--limit', '400', '--json', 'number,title,author,mergedAt,createdAt,additions,deletions']);
-  if (listed.code) throw new Error(`github-list-unavailable: ${listed.stderr.slice(0, 120)}`);
-  const prs = (JSON.parse(listed.stdout) as Pr[]).filter(p => Date.parse(p.mergedAt) >= cutoff && Date.parse(p.mergedAt) <= now.getTime());
-  const details = await detailMap(prs.map(p => p.number), run);
+  let graphql = opts.graphql;
+  if (!graphql) {
+    const token = opts.resolveToken
+      ? opts.resolveToken()
+      : resolveGitHubToken({ stateDir: opts.stateDir, env: opts.env });
+    if (!token) throw new GitHubAuthUnavailableError();
+    graphql = (query, variables) => fetchGitHubGraphql({
+      token,
+      query,
+      variables,
+      fetchImpl: opts.fetchImpl,
+    });
+  }
+  const prs = await listMergedPullRequests(graphql, cutoff, now.getTime());
+  const details = new Map<number, Detail>(prs.map((pr) => [pr.number, {
+    reworkLoops: (pr.reviews?.nodes ?? []).filter((review) => review.state === 'CHANGES_REQUESTED').length,
+    commits: Number(pr.commits?.totalCount ?? 0),
+  }]));
   const days = new Map<string, Pr[]>();
-  for (const p of prs) days.set(pdtDay(p.mergedAt), [...(days.get(pdtDay(p.mergedAt)) ?? []), p]);
+  for (const p of prs) days.set(pacificDay(p.mergedAt), [...(days.get(pacificDay(p.mergedAt)) ?? []), p]);
   const rows = [...days].sort(([a], [b]) => a.localeCompare(b)).map(([day, all]) => {
     const authors: Partial<Record<Author, ReturnType<typeof ZERO>>> = {};
     for (const a of ['codey', 'echo', 'other'] as const) {
@@ -83,14 +177,32 @@ export async function buildThroughputSeries(opts: { days: 7 | 14 | 30; now?: Dat
   return { repo: 'JKHeadley/instar', windowDays: opts.days, generatedAt: now.toISOString(), weights, rows };
 }
 
-export function createThroughputRoutes(options: { run?: GhExec; weights?: Weights } = {}): Router {
+export function createThroughputRoutes(options: {
+  graphql?: ThroughputGraphql;
+  stateDir?: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof globalThis.fetch;
+  weights?: Weights;
+} = {}): Router {
   const router = Router();
+  const resolveToken = createGitHubTokenResolver({
+    stateDir: options.stateDir,
+    env: options.env,
+  });
   router.get('/throughput/series', async (req: Request, res: Response) => {
     const days = Number(req.query.days ?? 14);
     if (!WINDOWS.includes(days as 7 | 14 | 30)) { res.status(400).json({ error: 'invalid-throughput-window', allowed: WINDOWS }); return; }
     try {
-      res.set('Cache-Control', 'private, max-age=60').json(await buildThroughputSeries({ days: days as 7 | 14 | 30, ...options }));
-    } catch {
+      res.set('Cache-Control', 'private, max-age=60').json(await buildThroughputSeries({
+        days: days as 7 | 14 | 30,
+        ...options,
+        resolveToken,
+      }));
+    } catch (error) {
+      if (error instanceof GitHubAuthUnavailableError) {
+        res.status(503).json({ error: 'github-auth-unavailable' });
+        return;
+      }
       res.status(503).json({ error: 'throughput-series-unavailable' });
     }
   });

--- a/tests/e2e/throughput-series-live.test.ts
+++ b/tests/e2e/throughput-series-live.test.ts
@@ -5,20 +5,19 @@ import { createThroughputRoutes } from '../../src/server/throughputRoutes.js';
 
 describe('Throughput series route is alive', () => {
   it('serves the real route contract through Express', async () => {
-    const run = async (args: string[]) => args[0] === 'pr'
-      ? {
-          code: 0, stderr: '', stdout: JSON.stringify([{
+    const graphql = async () => ({
+      search: {
+        issueCount: 1,
+        nodes: [{
             number: 42, title: 'Feature', author: { login: 'JKHeadley' },
             createdAt: '2026-07-22T12:00:00Z', mergedAt: '2026-07-23T12:00:00Z',
             additions: 70, deletions: 30,
-          }]),
-        }
-      : {
-          code: 0, stderr: '', stdout: JSON.stringify({ data: { repository: {
-            p42: { reviews: { nodes: [] }, commits: { totalCount: 2 } },
-          } } }),
-        };
-    const app = express().use(createThroughputRoutes({ run }));
+            reviews: { nodes: [] }, commits: { totalCount: 2 },
+          }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+    const app = express().use(createThroughputRoutes({ graphql }));
     const response = await request(app).get('/throughput/series?days=7');
     expect(response.status).toBe(200);
     expect(response.body).toMatchObject({
@@ -33,5 +32,15 @@ describe('Throughput series route is alive', () => {
     const response = await request(app).get('/throughput/series?days=90');
     expect(response.status).toBe(400);
     expect(response.body.allowed).toEqual([7, 14, 30]);
+  });
+
+  it('fails closed with a distinct error when no explicit GitHub identity exists', async () => {
+    const app = express().use(createThroughputRoutes({
+      stateDir: '/definitely/missing',
+      env: {},
+    }));
+    const response = await request(app).get('/throughput/series?days=7');
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({ error: 'github-auth-unavailable' });
   });
 });

--- a/tests/integration/throughput-github-auth.test.ts
+++ b/tests/integration/throughput-github-auth.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SecretStore } from '../../src/core/SecretStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { createThroughputRoutes } from '../../src/server/throughputRoutes.js';
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'throughput-auth-integration-'));
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(stateDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/integration/throughput-github-auth.test.ts',
+  });
+});
+
+describe('Throughput explicit GitHub identity integration', () => {
+  it('reads github_token from the agent vault and sends it to direct GraphQL', async () => {
+    new SecretStore({ stateDir, forceFileKey: true }).set('github_token', 'vault-agent-token');
+    let authorization: string | null = null;
+    const fetchImpl = (async (_url: string | URL | Request, init?: RequestInit) => {
+      authorization = new Headers(init?.headers).get('authorization');
+      return new Response(JSON.stringify({
+        data: {
+          search: {
+            issueCount: 1,
+            nodes: [{
+              number: 77,
+              title: 'Fix',
+              author: { login: 'EchoOfDawn' },
+              createdAt: new Date(Date.now() - 3_600_000).toISOString(),
+              mergedAt: new Date(Date.now() - 1_000).toISOString(),
+              additions: 4,
+              deletions: 1,
+              reviews: { nodes: [] },
+              commits: { totalCount: 1 },
+            }],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof globalThis.fetch;
+    const app = express().use(createThroughputRoutes({
+      stateDir,
+      env: {},
+      fetchImpl,
+    }));
+
+    const response = await request(app).get('/throughput/series?days=7');
+    expect(response.status).toBe(200);
+    expect(response.body.rows[0].authors.echo.merges).toBe(1);
+    expect(authorization).toBe('Bearer vault-agent-token');
+  });
+});

--- a/tests/unit/CiFailurePoller.test.ts
+++ b/tests/unit/CiFailurePoller.test.ts
@@ -5,6 +5,10 @@
  * exercised deterministically (no network, no real gh).
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { FailureLedger } from '../../src/monitoring/FailureLedger.js';
 import {
   CiFailurePoller, ciCategoryFromName, currentFailures, scrubSecrets,
@@ -127,5 +131,37 @@ describe('CiFailurePoller.tick (the §3.1 source behavior)', () => {
   it('only polls on the fenced-lease holder', () => {
     const p = poller({ isLeaseHolder: () => false, runGh: ghJson([{ headSha: 's', conclusion: 'failure', name: 'test', createdAt: 'z' }]) });
     expect(p.tick()).toBe(0);
+  });
+
+  it('uses the shared authenticated runtime on the default gh path', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-gh-runtime-'));
+    try {
+      const marker = path.join(dir, 'ci-gh-env.txt');
+      const executable = path.join(dir, 'gh');
+      fs.writeFileSync(executable, `#!/bin/sh\nprintf '%s|%s' "$GH_TOKEN" "$GITHUB_TOKEN" > "${marker}"\nprintf '[]'\n`, { mode: 0o700 });
+      const p = new CiFailurePoller({
+        ledger,
+        resolveByMergeCommit: () => undefined,
+        resolveRepo: () => 'JKHeadley/instar',
+        githubRuntime: () => ({
+          executable,
+          env: {
+            ...process.env,
+            PATH: dir,
+            GH_TOKEN: 'agent-token',
+            GITHUB_TOKEN: 'agent-token',
+          },
+        }),
+        onError: () => {},
+      });
+      expect(p.tick()).toBe(0);
+      expect(fs.readFileSync(marker, 'utf8')).toBe('agent-token|agent-token');
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/CiFailurePoller.test.ts',
+      });
+    }
   });
 });

--- a/tests/unit/github-runtime-wiring.test.ts
+++ b/tests/unit/github-runtime-wiring.test.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const read = (relative: string) => fs.readFileSync(path.join(ROOT, relative), 'utf8');
+
+describe('server-side GitHub runtime wiring', () => {
+  it('keeps Throughput CLI-free and on direct authenticated GraphQL', () => {
+    const source = read('src/server/throughputRoutes.ts');
+    expect(source).toContain('fetchGitHubGraphql');
+    expect(source).toContain('resolveGitHubToken');
+    expect(source).not.toContain("from 'node:child_process'");
+    expect(source).not.toMatch(/execFile\s*\(\s*['"]gh['"]/);
+  });
+
+  it('routes the Green-PR watcher and CI poller through the shared helper', () => {
+    const green = read('src/monitoring/greenPrAutomergeWiring.ts');
+    const ci = read('src/monitoring/CiFailurePoller.ts');
+    expect(green).toContain('createAuthenticatedGitHubCliRuntimeResolver({ stateDir: opts.stateDir })');
+    expect(green).toContain('resolveRuntime: githubRuntime');
+    expect(green).toContain('resolveGitHubEnv: () =>');
+    expect(ci).toContain('createAuthenticatedGhSyncExec({');
+    expect(ci).toContain('resolveRuntime: opts.githubRuntime');
+    expect(green).not.toContain("execFile('gh'");
+    expect(ci).not.toContain("execFileSync('gh'");
+  });
+
+  it('threads the per-agent state directory into both server constructors', () => {
+    const server = read('src/server/AgentServer.ts');
+    expect(server).toContain('createThroughputRoutes({ stateDir: options.config.stateDir })');
+    expect(server).toMatch(/new CiFailurePoller\(\{\s*ledger: this\.failureLedger,\s*stateDir: options\.config\.stateDir,/);
+  });
+});

--- a/tests/unit/github-runtime.test.ts
+++ b/tests/unit/github-runtime.test.ts
@@ -1,0 +1,217 @@
+import { execFile, execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SecretStore } from '../../src/core/SecretStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  createAuthenticatedGhExec,
+  createAuthenticatedGitHubCliRuntimeResolver,
+  execAuthenticatedGhSync,
+  fetchGitHubGraphql,
+  GitHubAuthUnavailableError,
+  resolveGhExecutable,
+  resolveGitHubToken,
+} from '../../src/core/githubRuntime.js';
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'github-runtime-'));
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(stateDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/github-runtime.test.ts',
+  });
+});
+
+describe('resolveGitHubToken', () => {
+  it('prefers the explicit server environment over the vault', () => {
+    new SecretStore({ stateDir, forceFileKey: true }).set('github_token', 'vault-token');
+    expect(resolveGitHubToken({
+      stateDir,
+      env: { GITHUB_TOKEN: '  env-token  ' },
+      forceFileKey: true,
+    })).toBe('env-token');
+  });
+
+  it('falls back to the per-agent encrypted vault', () => {
+    new SecretStore({ stateDir, forceFileKey: true }).set('github_token', 'vault-token');
+    expect(resolveGitHubToken({ stateDir, env: {}, forceFileKey: true })).toBe('vault-token');
+  });
+
+  it('returns null instead of consulting a machine-global gh seat', () => {
+    expect(resolveGitHubToken({ stateDir, env: {}, forceFileKey: true })).toBeNull();
+  });
+});
+
+describe('resolveGhExecutable', () => {
+  it('checks Homebrew locations before launchd PATH entries', () => {
+    const checked: string[] = [];
+    const found = resolveGhExecutable({
+      env: { PATH: '/usr/bin:/bin' },
+      isExecutable: (candidate) => {
+        checked.push(candidate);
+        return candidate === '/opt/homebrew/bin/gh';
+      },
+    });
+    expect(found).toBe('/opt/homebrew/bin/gh');
+    expect(checked[0]).toBe('/opt/homebrew/bin/gh');
+  });
+
+  it('falls back to an executable found on the supplied PATH', () => {
+    expect(resolveGhExecutable({
+      env: { PATH: '/custom/bin:/usr/bin' },
+      isExecutable: (candidate) => candidate === '/custom/bin/gh',
+    })).toBe('/custom/bin/gh');
+  });
+
+  it('ignores relative PATH entries', () => {
+    const checked: string[] = [];
+    resolveGhExecutable({
+      env: { PATH: 'relative/bin:/usr/bin' },
+      isExecutable: (candidate) => {
+        checked.push(candidate);
+        return false;
+      },
+    });
+    expect(checked).not.toContain(path.join('relative/bin', 'gh'));
+    expect(checked).toContain('/usr/bin/gh');
+  });
+});
+
+describe('authenticated gh execution', () => {
+  it('caches both successful and unavailable runtimes for the bounded TTL', () => {
+    let now = 1_000;
+    let tokenCalls = 0;
+    const resolveRuntime = createAuthenticatedGitHubCliRuntimeResolver({
+      env: { PATH: '/usr/bin:/bin' },
+      now: () => now,
+      cacheTtlMs: 100,
+      resolveToken: () => {
+        tokenCalls += 1;
+        return tokenCalls === 1 ? null : 'rotated-token';
+      },
+      resolveExecutable: () => '/opt/homebrew/bin/gh',
+    });
+    expect(() => resolveRuntime()).toThrow(GitHubAuthUnavailableError);
+    expect(() => resolveRuntime()).toThrow(GitHubAuthUnavailableError);
+    expect(tokenCalls).toBe(1);
+    now += 101;
+    expect(resolveRuntime().env.GH_TOKEN).toBe('rotated-token');
+    expect(resolveRuntime().env.PATH?.split(path.delimiter)[0]).toBe('/opt/homebrew/bin');
+    expect(resolveRuntime().env.GH_TOKEN).toBe('rotated-token');
+    expect(tokenCalls).toBe(2);
+  });
+
+  it('does not start the async child when no explicit token exists', async () => {
+    const execFileImpl = vi.fn() as unknown as typeof execFile;
+    const run = createAuthenticatedGhExec({
+      stateDir,
+      env: {},
+      resolveToken: () => null,
+      resolveExecutable: () => '/opt/homebrew/bin/gh',
+      execFileImpl,
+    });
+    await expect(run(['api', 'user'])).resolves.toEqual({
+      code: 1,
+      stdout: '',
+      stderr: 'github-auth-unavailable',
+    });
+    expect(execFileImpl).not.toHaveBeenCalled();
+  });
+
+  it('uses an absolute executable and forces the explicit token into the async child', async () => {
+    let captured: { file?: string; env?: NodeJS.ProcessEnv } = {};
+    const execFileImpl = ((file: string, _args: string[], options: { env?: NodeJS.ProcessEnv }, callback: (err: Error | null, stdout: string, stderr: string) => void) => {
+      captured = { file, env: options.env };
+      callback(null, 'ok', '');
+      return {} as ReturnType<typeof execFile>;
+    }) as typeof execFile;
+    const run = createAuthenticatedGhExec({
+      stateDir,
+      env: { PATH: '/usr/bin:/bin' },
+      resolveToken: () => 'agent-token',
+      resolveExecutable: () => '/opt/homebrew/bin/gh',
+      execFileImpl,
+    });
+
+    await expect(run(['api', 'user'])).resolves.toMatchObject({ code: 0, stdout: 'ok' });
+    expect(captured.file).toBe('/opt/homebrew/bin/gh');
+    expect(captured.env?.GH_TOKEN).toBe('agent-token');
+    expect(captured.env?.GITHUB_TOKEN).toBe('agent-token');
+    expect(captured.env?.PATH?.split(path.delimiter)[0]).toBe('/opt/homebrew/bin');
+  });
+
+  it('throws the distinct auth error before sync execution when no token exists', () => {
+    const execFileSyncImpl = vi.fn() as unknown as typeof execFileSync;
+    expect(() => execAuthenticatedGhSync(['run', 'list'], {
+      stateDir,
+      env: {},
+      resolveToken: () => null,
+      resolveExecutable: () => '/opt/homebrew/bin/gh',
+      execFileSyncImpl,
+    })).toThrow(GitHubAuthUnavailableError);
+    expect(execFileSyncImpl).not.toHaveBeenCalled();
+  });
+
+  it('forces the explicit token into the sync child environment', () => {
+    let capturedEnv: NodeJS.ProcessEnv | undefined;
+    const execFileSyncImpl = ((_file: string, _args: readonly string[], options: { env?: NodeJS.ProcessEnv }) => {
+      capturedEnv = options.env;
+      return '[]';
+    }) as typeof execFileSync;
+    expect(execAuthenticatedGhSync(['run', 'list'], {
+      stateDir,
+      env: { PATH: '/usr/bin:/bin' },
+      resolveToken: () => 'agent-token',
+      resolveExecutable: () => '/usr/local/bin/gh',
+      execFileSyncImpl,
+    })).toBe('[]');
+    expect(capturedEnv?.GH_TOKEN).toBe('agent-token');
+    expect(capturedEnv?.GITHUB_TOKEN).toBe('agent-token');
+    expect(capturedEnv?.PATH?.split(path.delimiter)[0]).toBe('/usr/local/bin');
+  });
+});
+
+describe('fetchGitHubGraphql', () => {
+  it('sends the explicit token directly to api.github.com', async () => {
+    let request: { url?: string; authorization?: string; body?: string } = {};
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      request = {
+        url: String(url),
+        authorization: headers.get('authorization') ?? undefined,
+        body: String(init?.body),
+      };
+      return new Response(JSON.stringify({ data: { viewer: { login: 'EchoOfDawn' } } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof globalThis.fetch;
+
+    await expect(fetchGitHubGraphql<{ viewer: { login: string } }>({
+      token: 'agent-token',
+      query: 'query { viewer { login } }',
+      fetchImpl,
+    })).resolves.toEqual({ viewer: { login: 'EchoOfDawn' } });
+    expect(request.url).toBe('https://api.github.com/graphql');
+    expect(request.authorization).toBe('Bearer agent-token');
+    expect(request.body).not.toContain('machine-global');
+  });
+
+  it('surfaces only bounded status metadata on HTTP failure', async () => {
+    const fetchImpl = (async () => new Response('sensitive upstream body', {
+      status: 401,
+    })) as typeof globalThis.fetch;
+    await expect(fetchGitHubGraphql({
+      token: 'bad-token',
+      query: 'query { viewer { login } }',
+      fetchImpl,
+    })).rejects.toThrow('github-graphql-http-401');
+  });
+});

--- a/tests/unit/green-pr-automerge-wiring.test.ts
+++ b/tests/unit/green-pr-automerge-wiring.test.ts
@@ -59,11 +59,40 @@ function baseOpts(over: Partial<GreenPrWiringOpts> = {}): GreenPrWiringOpts {
     leaseEpoch: () => 0,
     postAttentionAggregate: async () => {},
     auditPath: path.join(dir, 'audit.jsonl'),
+    githubRuntime: () => ({
+      executable: '/opt/homebrew/bin/gh',
+      env: {
+        PATH: '/opt/homebrew/bin:/usr/bin:/bin',
+        GH_TOKEN: 'agent-token',
+        GITHUB_TOKEN: 'agent-token',
+      },
+    }),
     ...over,
   };
 }
 
 describe('buildGreenPrDeps — config-threading (M2)', () => {
+  it('uses the shared authenticated runtime on the default gh read path', async () => {
+    const marker = path.join(dir, 'green-gh-env.txt');
+    const fakeExecutable = path.join(dir, 'gh');
+    fs.writeFileSync(fakeExecutable, `#!/bin/sh\nprintf '%s|%s' "$GH_TOKEN" "$GITHUB_TOKEN" > "${marker}"\nprintf '[]'\n`, { mode: 0o700 });
+    const opts = baseOpts({
+      ghExec: undefined,
+      githubRuntime: () => ({
+        executable: fakeExecutable,
+        env: {
+          ...process.env,
+          PATH: dir,
+          GH_TOKEN: 'agent-token',
+          GITHUB_TOKEN: 'agent-token',
+        },
+      }),
+    });
+    const deps = buildGreenPrDeps(opts, buildGuardLatchStore(opts));
+    await expect(deps.listOpenPrs()).resolves.toEqual([]);
+    expect(fs.readFileSync(marker, 'utf8')).toBe('agent-token|agent-token');
+  });
+
   it('threads mergeStrategy:auto + armTimeoutMs into the CONSTRUCTED MergeRunner', () => {
     const { ghExec } = fakeGh({});
     const latches = buildGuardLatchStore(baseOpts({ ghExec }));

--- a/tests/unit/merge-runner.test.ts
+++ b/tests/unit/merge-runner.test.ts
@@ -36,6 +36,12 @@ const baseCfg = () => ({
   mergeTimeoutMs: 1000,
   mergeKillGraceMs: 100,
   expectedContractVersion: 2,
+  resolveGitHubEnv: () => ({
+    ...process.env,
+    PATH: '/opt/homebrew/bin:/usr/bin:/bin',
+    GH_TOKEN: 'agent-token',
+    GITHUB_TOKEN: 'agent-token',
+  }),
 });
 
 function fakeSpawn(map: { capabilities?: SpawnOutcome; merge?: SpawnOutcome }) {
@@ -58,6 +64,23 @@ describe('parseResultLine', () => {
 });
 
 describe('DefaultMergeRunner — contract probe + hash pin', () => {
+  it('fails closed before spawning when explicit GitHub identity is unavailable', async () => {
+    let spawned = false;
+    const r = new DefaultMergeRunner(
+      { ...baseCfg(), resolveGitHubEnv: () => null },
+      {
+        spawn: async (args) => {
+          spawned = true;
+          return fakeSpawn({})(args);
+        },
+        confirmMerged: async () => true,
+        prState: async () => 'OPEN',
+      },
+    );
+    expect(await r.probeContract()).toEqual({ ok: false });
+    expect(spawned).toBe(false);
+  });
+
   it('probes the contract and pins the script hash', async () => {
     const r = new DefaultMergeRunner(baseCfg(), { spawn: fakeSpawn({}), confirmMerged: async () => true, prState: async () => 'OPEN' });
     const p = await r.probeContract();
@@ -83,6 +106,28 @@ describe('DefaultMergeRunner — contract probe + hash pin', () => {
 });
 
 describe('DefaultMergeRunner — run', () => {
+  it('threads the same explicit identity into capabilities and safe-merge', async () => {
+    const environments: NodeJS.ProcessEnv[] = [];
+    const spawn = async (a: SpawnArgs): Promise<SpawnOutcome> => {
+      environments.push(a.env);
+      return fakeSpawn({})(a);
+    };
+    const r = new DefaultMergeRunner(baseCfg(), {
+      spawn,
+      confirmMerged: async () => true,
+      prState: async () => 'OPEN',
+    });
+    await r.probeContract();
+    await r.run({ pr: 5, headRefOid: 'sha', repo: 'JKHeadley/instar' });
+    expect(environments).toHaveLength(2);
+    for (const env of environments) {
+      expect(env.GH_TOKEN).toBe('agent-token');
+      expect(env.GITHUB_TOKEN).toBe('agent-token');
+      expect(env.PATH?.split(path.delimiter)[0]).toBe('/opt/homebrew/bin');
+    }
+    expect(environments[1].GREEN_PR_ATTEMPT_TOKEN).toBeTruthy();
+  });
+
   it('writes a two-phase in-flight record and clears it after', async () => {
     let pidAtPhase2: number | null = null;
     const spawn = async (a: SpawnArgs): Promise<SpawnOutcome> => {

--- a/tests/unit/throughput-routes.test.ts
+++ b/tests/unit/throughput-routes.test.ts
@@ -1,22 +1,111 @@
 import { describe, expect, it } from 'vitest';
-import { buildThroughputSeries } from '../../src/server/throughputRoutes.js';
+import { buildThroughputSeries, pacificDay } from '../../src/server/throughputRoutes.js';
 
 describe('throughput series contract', () => {
   it('computes prototype-compatible author metrics and index', async () => {
-    const prs = [
-      { number: 1, title: 'Feature', author: { login: 'JKHeadley' }, createdAt: '2026-07-20T12:00:00Z', mergedAt: '2026-07-21T12:00:00Z', additions: 80, deletions: 20 },
-      { number: 2, title: 'Revert fix', author: { login: 'EchoOfDawn' }, createdAt: '2026-07-22T00:00:00Z', mergedAt: '2026-07-22T12:00:00Z', additions: 10, deletions: 10 },
-    ];
-    const run = async (args: string[]) => args[0] === 'pr'
-      ? { code: 0, stderr: '', stdout: JSON.stringify(prs) }
-      : { code: 0, stderr: '', stdout: JSON.stringify({ data: { repository: {
-          p1: { reviews: { nodes: [{ state: 'CHANGES_REQUESTED' }] }, commits: { totalCount: 3 } },
-          p2: { reviews: { nodes: [] }, commits: { totalCount: 1 } },
-        } } }) };
-    const result = await buildThroughputSeries({ days: 7, now: new Date('2026-07-24T00:00:00Z'), run });
+    const graphql = async () => ({
+      search: {
+        issueCount: 2,
+        nodes: [
+          {
+            number: 1, title: 'Feature', author: { login: 'JKHeadley' },
+            createdAt: '2026-07-20T12:00:00Z', mergedAt: '2026-07-21T12:00:00Z',
+            additions: 80, deletions: 20,
+            reviews: { nodes: [{ state: 'CHANGES_REQUESTED' }] },
+            commits: { totalCount: 3 },
+          },
+          {
+            number: 2, title: 'Revert fix', author: { login: 'EchoOfDawn' },
+            createdAt: '2026-07-22T00:00:00Z', mergedAt: '2026-07-22T12:00:00Z',
+            additions: 10, deletions: 10,
+            reviews: { nodes: [] },
+            commits: { totalCount: 1 },
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+    const result = await buildThroughputSeries({
+      days: 7,
+      now: new Date('2026-07-24T00:00:00Z'),
+      graphql,
+    });
     expect(result.rows[0].authors.codey).toMatchObject({ merges: 1, medianLatencyH: 24, reworkLoops: 1, medianPushIters: 3, medianLoc: 100 });
     expect(result.rows[1].authors.echo).toMatchObject({ merges: 1, medianLatencyH: 12, reverts: 1 });
     expect(result.rows.map(r => r.team.index)).toEqual([55, 59.9]);
     expect(result.weights).toEqual({ velocity: .4, speed: .2, quality: .25, output: .15 });
+  });
+
+  it('paginates the direct GraphQL search without a gh subprocess', async () => {
+    const cursors: Array<string | null> = [];
+    const graphql = async (_query: string, variables: Record<string, unknown>) => {
+      cursors.push((variables.cursor as string | null) ?? null);
+      return variables.cursor == null
+        ? {
+            search: {
+              issueCount: 1,
+              nodes: [],
+              pageInfo: { hasNextPage: true, endCursor: 'page-2' },
+            },
+          }
+        : {
+            search: {
+              issueCount: 1,
+              nodes: [{
+                number: 3, title: 'Feature', author: { login: 'JKHeadley' },
+                createdAt: '2026-07-22T00:00:00Z', mergedAt: '2026-07-23T00:00:00Z',
+                additions: 1, deletions: 1, reviews: { nodes: [] }, commits: { totalCount: 1 },
+              }],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          };
+    };
+    const result = await buildThroughputSeries({
+      days: 7,
+      now: new Date('2026-07-24T00:00:00Z'),
+      graphql,
+    });
+    expect(cursors).toEqual([null, 'page-2']);
+    expect(result.rows).toHaveLength(1);
+  });
+
+  it('fails closed when GitHub Search reports more than its 1,000-result API cap', async () => {
+    await expect(buildThroughputSeries({
+      days: 30,
+      now: new Date('2026-07-24T00:00:00Z'),
+      graphql: async () => ({
+        search: {
+          issueCount: 1_001,
+          nodes: [],
+          pageInfo: { hasNextPage: true, endCursor: 'opaque' },
+        },
+      }),
+    })).rejects.toThrow('github-throughput-result-cap-exceeded');
+  });
+
+  it('fails closed when the fetched node count does not match issueCount', async () => {
+    await expect(buildThroughputSeries({
+      days: 7,
+      now: new Date('2026-07-24T00:00:00Z'),
+      graphql: async () => ({
+        search: {
+          issueCount: 1,
+          nodes: [],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      }),
+    })).rejects.toThrow('github-throughput-result-truncated');
+  });
+});
+
+describe('Pacific throughput day', () => {
+  it('uses PDT around the summer UTC boundary', () => {
+    expect(pacificDay('2026-07-01T06:59:59Z')).toBe('2026-06-30');
+    expect(pacificDay('2026-07-01T07:00:00Z')).toBe('2026-07-01');
+  });
+
+  it('uses PST around the winter UTC boundary', () => {
+    expect(pacificDay('2026-01-01T07:59:59Z')).toBe('2025-12-31');
+    expect(pacificDay('2026-01-01T08:00:00Z')).toBe('2026-01-01');
   });
 });

--- a/upgrades/next/throughput-github-runtime-repair.md
+++ b/upgrades/next/throughput-github-runtime-repair.md
@@ -1,0 +1,30 @@
+# Throughput GitHub runtime repair
+
+## What Changed
+
+The Throughput server now calls GitHub GraphQL directly with an explicit
+agent-owned token instead of starting a bare `gh` subprocess. The remaining
+server-side CLI consumers share one absolute-executable, explicit-token runtime,
+including the guarded Green-PR merge child.
+
+## What to Tell Your User
+
+The Throughput tab can load real chart data when the agent has `GITHUB_TOKEN` or a
+vault `github_token`, even when the server runs in the background with launchd's
+restricted PATH. It will report authentication unavailable instead of silently
+using another person's GitHub login.
+
+## Summary of New Capabilities
+
+- Uses direct authenticated GraphQL for Throughput.
+- Fails closed on missing identity, incomplete Search pagination, or provider
+  result ceilings.
+- Uses real Pacific timezone boundaries in both standard and daylight time.
+- Gives CI polling and Green-PR reads/actuation one shared explicit GitHub runtime.
+
+## Evidence
+
+The focused runtime, route, pagination, timezone, CI, and Green-PR suites pass 68
+tests. TypeScript and repository lint pass. Independent security, integration, and
+throughput reviews were folded into the converged design. Final release evidence
+also requires post-deployment desktop and phone verification with real chart data.

--- a/upgrades/next/throughput-github-runtime-repair.md
+++ b/upgrades/next/throughput-github-runtime-repair.md
@@ -9,8 +9,8 @@ including the guarded Green-PR merge child.
 
 ## What to Tell Your User
 
-The Throughput tab can load real chart data when the agent has `GITHUB_TOKEN` or a
-vault `github_token`, even when the server runs in the background with launchd's
+The Throughput tab can load real chart data when the agent has a GitHub token in
+its environment or vault, even when the server runs in the background with launchd's
 restricted PATH. It will report authentication unavailable instead of silently
 using another person's GitHub login.
 
@@ -24,7 +24,7 @@ using another person's GitHub login.
 
 ## Evidence
 
-The focused runtime, route, pagination, timezone, CI, and Green-PR suites pass 68
+The focused runtime, route, pagination, timezone, CI, and Green-PR suites pass 73
 tests. TypeScript and repository lint pass. Independent security, integration, and
 throughput reviews were folded into the converged design. Final release evidence
 also requires post-deployment desktop and phone verification with real chart data.

--- a/upgrades/side-effects/throughput-github-runtime-repair.md
+++ b/upgrades/side-effects/throughput-github-runtime-repair.md
@@ -1,0 +1,155 @@
+# Side-Effects Review — Throughput GitHub runtime repair
+
+**Version / slug:** `throughput-github-runtime-repair`
+**Date:** `2026-07-24`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `Aquinas (review_security_identity)`
+
+## Summary of the change
+
+The Throughput route moves from a bare GitHub CLI subprocess to authenticated
+GraphQL, while `src/core/githubRuntime.ts` becomes the shared explicit-token,
+absolute-executable boundary for the CI poller and Green-PR watcher. The same
+runtime environment is threaded through the real `safe-merge` child. Search
+cardinality and Pacific timezone correctness are made explicit invariants.
+
+## Decision-point inventory
+
+- `buildThroughputSeries` identity resolution — **modify** — only environment or
+  agent-vault identity is accepted.
+- Throughput Search pagination — **modify** — reported and fetched counts must agree
+  and remain at or below the provider ceiling.
+- `resolveGhExecutable` — **add** — only known absolute, executable files qualify.
+- `DefaultMergeRunner` process admission — **modify** — explicit GitHub runtime is
+  required before contract probing or actuation.
+- `CiFailurePoller` GitHub read — **modify** — uses the shared cached runtime.
+
+---
+
+## 1. Over-block
+
+A legitimate install with a working machine-global `gh auth login` but no
+`GITHUB_TOKEN` and no vault `github_token` is now refused. This is intentional:
+the ambient login cannot prove agent identity. A 30-day window with more than 1,000
+merged PRs is also refused rather than partially charted; a different data source
+would be needed to support that volume honestly.
+
+## 2. Under-block
+
+An explicit token can still belong to the wrong GitHub principal if the operator
+stores the wrong value. This layer proves explicit selection, not semantic
+ownership. GitHub may also change its GraphQL schema or Search ceiling; those
+changes fail the route closed through schema/count validation rather than render
+incorrect data.
+
+## 3. Level-of-abstraction fit
+
+Identity and executable selection are centralized at the server process boundary,
+below all three consumers. Throughput uses the higher-level GraphQL interface
+because it needs structured read data, while the two legacy CLI consumers reuse the
+lower-level runtime primitive. The existing `safe-merge` authority continues to own
+merge judgment and execution; this change does not create a parallel merge gate.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [x] Yes, with deterministic structural invariants — explicit identity,
+  executable-file status, and complete provider cardinality are enumerable safety
+  floors, not brittle proxies for intent.
+
+The new refusals answer structural questions with exact evidence. They do not infer
+user intent or choose among competing live signals. Green-PR judgment remains with
+the existing eligibility ladder and `safe-merge`.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic is added at a competing-signals decision point. Token
+presence, executable path shape, HTTP/schema validity, Search cardinality, and
+timezone conversion are hard invariants with enumerable outcomes.
+
+## 5. Interactions
+
+- **Shadowing:** explicit-runtime admission runs before GitHub reads or merge
+  contract probing. It intentionally shadows ambient CLI identity; later safety
+  checks run unchanged once admission succeeds.
+- **Double-fire:** no new scheduler or action is added. The Green-PR watcher and CI
+  poller retain their existing cadence and lease gates.
+- **Races:** the five-minute cache is process-local. A token rotation can coexist
+  with the old value until the TTL expires; GitHub rejects a revoked value, and no
+  caller falls back to ambient auth.
+- **Feedback loops:** Throughput is read-only. CI writes the existing failure ledger
+  and Green-PR retains the existing act path; this change adds no feedback edge.
+
+## 6. External surfaces
+
+GitHub receives direct GraphQL requests from Throughput with an explicit bearer
+identity. The route's unauthenticated failure is now specifically
+`github-auth-unavailable`; other failures retain the generic unavailable response.
+No secret value is logged or returned. There is no new database, file format, URL,
+notification, or operator action. Existing installs must supply `GITHUB_TOKEN` or
+the vault secret for live data.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No dashboard renderer, form, or operator action is changed. The existing Throughput
+tab is verified separately after deployment at desktop and phone widths.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN:** executable location and server environment are
+machine-specific security truths. Each fleet server independently requires its
+agent-scoped explicit identity and resolves its own executable. The output contract
+is identical across machines; a misconfigured peer fails closed rather than
+borrowing that host's global GitHub seat. No user-facing notices are emitted, no new
+durable state can strand during topic transfer, and no URLs are generated.
+
+## 8. Rollback cost
+
+Pure code rollback: revert and ship a patch. No migration, state cleanup, or agent
+reset is required. The rollback window restores the known Throughput 503 and ambient
+CLI-identity hazard on affected machines, but does not corrupt data.
+
+## Conclusion
+
+The first review found that fixing only Throughput left the actual `safe-merge`
+child outside the identity boundary. It also found Search truncation, repeated vault
+resolution, relative-PATH acceptance, and fixed-offset day bucketing. All were
+folded into this change with behavioral tests. The design is clear to ship subject
+to the independent second-pass reread and green ceremony.
+
+## Second-pass review (if required)
+
+**Reviewer:** Aquinas (`review_security_identity`)
+**Independent read of the artifact: concur**
+
+Concur with the review: the shared runtime closes the prior identity and PATH
+gaps through the real `safe-merge` act path, all three consumers fail safely, and
+the cadence, lease, rollback, multi-machine, and self-action conclusions match the
+final code and behavioral tests.
+
+## Evidence pointers
+
+- `tests/unit/github-runtime.test.ts`
+- `tests/integration/throughput-github-auth.test.ts`
+- `tests/unit/throughput-routes.test.ts`
+- `tests/unit/green-pr-automerge-wiring.test.ts`
+- `tests/unit/merge-runner.test.ts`
+- `tests/unit/CiFailurePoller.test.ts`
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: unbounded-self-action`, `closure: guard`,
+`guardEvidence: { enforcementType: ratchet, citation:
+tests/unit/self-action-convergence.test.ts, howCaught: the touched CI and Green-PR
+controllers retain lease/cadence admission and no new trigger edge; missing identity
+settles each tick to a bounded no-action refusal, while the existing convergence
+ratchet detects a controller whose steady-state action can grow without a settling
+brake }`.
+
+The production incident is an ordinary runtime identity defect, not an
+agent-authored prompt/config/skill defect. The declaration is present because this
+repair modifies existing self-triggered controllers.


### PR DESCRIPTION
## Summary

- replace the Throughput route's bare `gh` subprocess with direct GitHub GraphQL over `fetch`
- resolve GitHub identity only from `GITHUB_TOKEN` or the agent vault's `github_token`, returning `github-auth-unavailable` with the existing fail-closed 503 shape when neither exists
- route CI polling and Green-PR reads **and merge actuation** through one shared runtime that requires an absolute executable plus explicit token environment
- harden Throughput pagination against GitHub Search's 1,000-result ceiling and unstable result counts
- bucket chart data with real `America/Los_Angeles` calendar boundaries, including DST

## ELI16 — The chart now uses the agent's own GitHub key

The Throughput chart was like a dashboard whose engine could only start when somebody happened to leave the right tool in the server's tiny background search path. In production that tool was not there, so the chart failed every time. Worse, if the tool was found, it could silently use whichever person's GitHub account was logged into that Mac.

This repair makes the agent carry its own identity. The chart talks directly to GitHub using a token explicitly supplied to the server or kept in the agent's vault. If no agent-owned token exists, it stops with a clear authentication-unavailable response instead of borrowing somebody else's login. The two background jobs that still need GitHub's command-line tool now share a resolver that finds the program by an absolute path and gives every child process that same explicit token, including the final guarded merge child.

The chart also refuses incomplete search results rather than drawing a convincing but partial picture, and it groups days using the real Los Angeles timezone so daylight-saving changes do not move work into the wrong day. Existing merge safety checks remain unchanged. After deployment, Echo will still verify the live chart at desktop and phone widths before calling the lane done.

## Production failure repaired

The deployed agent server runs under launchd with a restricted PATH. On Homebrew machines, the previous `execFile("gh", ...)` therefore failed with `ENOENT`, so every Throughput request returned 503.

The same subprocess also inherited whichever GitHub identity was logged into the machine keychain. That is unsafe on shared or repurposed Minis: a shipped feature must identify its GitHub principal explicitly.

## Class closure

This PR closes the same hazard in all three known server-side bare-`gh` consumers:

- Throughput: direct authenticated GraphQL; no CLI dependency
- CI failure polling: shared absolute-path, explicit-token CLI runtime
- Green-PR automation: shared runtime for both reads and the actual safe-merge child

The runtime checks Homebrew locations before absolute PATH entries, never delegates authentication to `gh auth`, and caches bounded token/executable resolution to avoid repeated vault reads.

## Ceremony and review

Tier 2 spec and ELI16 overview are included. Independent security, integration, and throughput-correctness reviews challenged the design; their findings were folded in and the security reviewer concurred on the second pass.

## Verification

- focused runtime, route, pagination, timezone, CI, merge, wiring, and no-silent-fallback tests: **73/73**
- full TypeScript and repository lint: **green**
- build: **green**
- pre-commit Tier-2 trace/artifact gate: **green**
- pre-push affected-test classification: 180 files / 1,171 tests, correctly deferred to the required CI matrix because it exceeds the local smoke cap

The local exhaustive matrix also exposed pre-existing harness failures unrelated to this patch: the nested dev-preflight runner invalidates the outer npm-installed Vitest tree through pnpm, and the isolated headless-spawn-reroute suite has baseline environment failures. Focused coverage was rerun after restoring dependencies and remained 73/73.

## Done gate

Merge is not the final done claim. After merge and deployment, Echo will re-run the deployed-dashboard verification at 2560px and 390px with real chart data.
