### PR TITLE
feat(quality-meter): opt-in candidate-body capture on the tone-gate provenance row

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-24T02-44-15-699Z-tone-candidate-body-capture-side-effects.json
+++ b/.instar/instar-dev-decisions/2026-07-24T02-44-15-699Z-tone-candidate-body-capture-side-effects.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-24T02:44:15.699Z",
+  "slug": "tone-candidate-body-capture.side-effects",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 113,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Latent from the meter's original content-bearing discipline, which was deliberate and documented but self-defeating: the gate inspects outbound text for leaks, so declining to store that text protected the store at the cost of making retrospective correctness review impossible. Surfaced when the operator reframed the programme around record-now/judge-later-in-bulk and the missing input became the blocking gap. The operator settled the retention question directly on 2026-07-23 (topic 33368): the text is already in the session transcript, so a second copy in an operator-and-agent-only store crosses no new line."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T15-48-00-394Z-tone-candidate-body-capture-side-effects.json
+++ b/.instar/instar-dev-decisions/2026-07-24T15-48-00-394Z-tone-candidate-body-capture-side-effects.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T15:48:00.394Z",
+  "slug": "tone-candidate-body-capture.side-effects",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 193,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/decision-input-capture.md
+++ b/docs/specs/decision-input-capture.md
@@ -1,0 +1,214 @@
+---
+title: "Decision-input capture: record richly, judge later in bulk"
+slug: "decision-input-capture"
+author: "echo"
+---
+
+# Decision-input capture: record richly, judge later in bulk
+
+## Problem statement
+
+The LLM-Decision Quality Meter enrolls decision points so their correctness can be
+measured. For the `messaging-tone-gate` point it records the verdict, the prompt
+version, latency, and an identity fingerprint of the candidate message.
+
+It cannot answer the question it exists to ask.
+
+"Was blocking this message correct?" is not decidable from a sha256. A hash cannot
+be re-read; a judge handed one has strictly nothing to judge. The meter today can
+measure how often the gate fired and how long it took, but never whether it was
+right — which is the entire point.
+
+The gap is structural, not an oversight. The identity-only discipline was
+deliberate and documented in code: the tone gate exists to inspect outbound text
+for leaks, so storing that text builds a pile of exactly the material the gate
+worries about. The reasoning is sound and the result is self-defeating — it
+protects the store by making the review impossible.
+
+### The operator's reframing (2026-07-23, topic 33368)
+
+The programme's shape changed. The operator's model, stated directly:
+
+1. For every LLM decision, record the INPUT, the PROMPT used, and the DECISION.
+2. Record whether the agent AGREED or DISAGREED, and when it disagreed, WHY — with
+   the context of why.
+3. Do **not** judge in real time. Judging happens later, in bulk, with an extremely
+   intelligent model, unhurried and not time-dependent.
+4. The results tune the prompt, become benchmark scenarios, and identify the best
+   model per scenario.
+
+This supersedes the direction of `tone-gate-contestation-evidence.md` — a design
+that computed a right/wrong verdict at decision time from thin deterministic
+signals. That design forced an unresolvable question (an override is a
+*disagreement*, not a *verdict*, and storing it as `wrong` misleads any downstream
+reader). Recording-then-judging dissolves that rather than managing it.
+
+It also revives a signal previously withdrawn as unsound. The earlier design needed
+to *prove* a rewrite came from the same author before it could count as evidence.
+Under bulk judging it does not: the recorded context goes to the judge and the judge
+decides. **Evidence need not be self-interpreting.**
+
+### Retention, settled
+
+The operator settled the retention question directly rather than leaving it open:
+the same text is already written to the session transcript on disk, so a second copy
+in a store only the operator and agent read crosses no line the transcript has not
+already crossed. Scoped explicitly to INTERNAL benchmarking of this install's own
+decisions.
+
+## Proposed design
+
+### Increment A (this spec, implemented)
+
+`buildToneDecisionContext()` takes an optional third parameter. When
+`recordCandidateBody: true`, the context carries the candidate body ALONGSIDE the
+existing sha256/bytes/chars identity. `ToneGateConfig` gains `recordCandidateBody`,
+read live at the callsite so it can be flipped without a restart.
+
+Absent or false ⇒ byte-identical to prior behaviour, asserted by a
+`JSON.stringify` equivalence test so the no-op property cannot drift silently.
+
+Properties, each load-bearing:
+
+| Property | Why it is where it is |
+|---|---|
+| **Clamp before scrub** | Scrub-then-truncate can bisect a `[REDACTED:…]` marker and leave the tail of a real secret past the cut — the exact failure being prevented, reintroduced by sequencing two safe steps wrongly. |
+| **Ceiling, not default** | `maxBodyChars` clamps DOWN to `TONE_CANDIDATE_BODY_MAX_CHARS` (4000) and never up, so no config value can make the store an unbounded archive of outbound prose. |
+| **Kinds, not offsets** | Redaction KINDS are recorded; offsets and matched text are not. Knowing a credential was present helps a judge; knowing where it sat helps nobody who should have it. |
+| **Withheld ≠ clean** | The scrubber replaces the whole field on error/oversize. Those set `bodyWithheld` explicitly rather than being conflated with "nothing sensitive found" — conflating them makes every clean-looking row untrustworthy. |
+| **Identity preserved** | sha256/bytes/chars still describe the WHOLE message even when the body is a fragment, so rows either side of a flag flip stay correlatable and dedupable. |
+
+### Increment B (specified, not built)
+
+**The disagreement reason.** Today the row records that an override occurred, not
+why. That "why" is the most valuable field on the record: it is the difference
+between "the gate and the agent disagreed" and "they disagreed, here is the
+reasoning, now judge who was right."
+
+The token-join work already built (a signed, stateless, cross-machine-safe decision
+token) is REUSABLE as the mechanism binding a disagreement record back to its
+decision. The grade-emitting half of that design falls away.
+
+### Increment C (specified, not built)
+
+**The bulk judging pass.** An offline, cadenced job that reads unjudged rows, hands
+each to a strong model with the full recorded context, and records a verdict plus
+reasoning. Explicitly NOT real-time; explicitly permitted to be slow.
+
+## Data lifecycle and storage (round-1 fold: codex-cli, gemini-cli)
+
+Both external reviewers noted the spec described *what* is captured without stating
+*where it lands or for how long*. Recorded plainly rather than left implied:
+
+- **Where.** The context object is written to the existing machine-local provenance
+  store (JSONL day-files under the agent home), the same store that already holds the
+  identity-only rows. No new store, table, or file is introduced.
+- **How long.** It inherits the store's existing retention, `provenance.retentionDays`
+  (default 14). A recorded body is deleted when its day-file ages out — there is no
+  separate, longer-lived copy.
+- **Who can read it.** The full context is machine-local and never served raw. The
+  read path applies redaction-by-field-omission, an existing invariant in code rather
+  than config. **The new `body` field must be confirmed to ride that omission rather
+  than defaulting through** — a content field added to an object whose serve
+  discipline was designed for identity-only data is precisely where a leak would hide.
+  Flagged for the security reviewer as the highest-value check in this round.
+- **Exports.** No export surface carries provenance context today. If one is added, it
+  must treat `body` as content, not metadata.
+
+### Redaction accounting is whole-message, not fragment (round-1 fold: codex-cli MINOR 2)
+
+Clamping precedes scrubbing for storage safety, which made the first implementation's
+`bodyRedactionKinds` mean "kinds found in the retained fragment". That is not the
+question a reader asks. "Did this message contain a credential?" is about the WHOLE
+message, and a credential sitting past the clamp would leave the row reading clean.
+
+Kinds are now computed over the full text (a second bounded scrub whose scrubbed
+output is discarded), and `bodyRedactionsBeyondClamp: true` marks a row whose stored
+fragment shows no marker because the credential lay past the cut. Nothing sensitive is
+stored either way; the accounting is simply now true of the message rather than of the
+excerpt.
+
+### Scrubber efficacy is a shared dependency, not a local guarantee (round-1 fold: gemini-cli MINOR 3)
+
+`scrubForStore` is pattern-based and boundary-anchored. It catches credential SHAPES;
+it does not catch personal information that is not credential-shaped, and a token run
+directly onto adjacent word characters does not match its boundaries. This spec
+deliberately depends on the shared scrubber rather than growing a second one, so its
+coverage — and its maintenance — is a project-level concern this feature inherits
+rather than solves. Stated so no reader mistakes "scrubbed" for "contains nothing
+sensitive".
+
+### Terminology (round-1 fold: both external reviewers)
+
+Both flagged in-house shorthand that is opaque from outside. Defined once:
+`uniformSeam` = the observe-only side-write point at the router where a decision row is
+minted; `contextFull` = the unredacted context retained machine-locally; `readRedacted`
+= the serve path that omits fields not cleared for reading; `OMIT-REQUIRED` = a config
+key deliberately never seeded, where absence is the intended state; **token-join** =
+the signed, stateless identifier binding a later record (e.g. an override) back to the
+decision it concerns.
+
+## Decision points touched
+
+| Decision point | Classification | Justification |
+|---|---|---|
+| `recordCandidateBody` on/off | **invariant** | A deterministic config read. There is no judgment: the operator's setting is the answer, and no signal competes with it. |
+| Clamp/scrub of a recorded body | **invariant** | Deterministic by design and must stay so. A model deciding what counts as a secret is strictly worse than a pattern scrubber with a hard length bound; the failure mode (a missed credential) is unrecoverable once written. |
+| The eventual bulk-judge verdict (Increment C) | **judgment-candidate** | Genuinely competing signals with no deterministic answer. Floor, when built: bounded action space (`right` / `wrong` / `unclear`), conservative default `unclear`, fallback ladder ending at "leave ungraded" — never a fabricated grade. Arbiter: the strong judging model. Deferred with the increment; NOT claimed as built. |
+
+Increment A itself introduces **no new judgment surface**. It changes what is
+recorded, not what is decided — the tone gate's verdict path, rule set, and
+fail-direction are untouched.
+
+## Multi-machine posture
+
+**`unified`.** No new state surface is introduced. The change adds a field to an
+existing context object; the provenance store's existing posture (machine-local
+`contextFull`, redaction-by-field-omission at `readRedacted`) is unchanged. No
+route, no replicated record, no per-machine divergence.
+
+The config key follows the existing `provenance.uniformSeam` precedent and is
+resolved per-machine from that machine's own config — an operator who enables
+capture on one machine and not another gets exactly that, which is the correct and
+expected behaviour for a retention setting, not a coherence defect.
+
+*(No `machine-local-justification` marker is required: nothing here is declared
+machine-local.)*
+
+## Frontloaded decisions
+
+Decisions made up front so no mid-build stop is needed:
+
+1. **Body stored alongside identity, never replacing it.** Rows either side of a
+   flag flip must stay correlatable.
+2. **4000-char ceiling.** Covers the overwhelming majority of real outbound messages
+   whole. A body cut mid-argument answers the judging question no better than a hash.
+3. **Off by default, OMIT-REQUIRED, no config seeding.** Seeding would write a
+   content-retention decision into every deployed agent's config on update.
+4. **Reuse `scrubForStore`.** The same scrubber every other content-bearing store
+   uses. A bespoke scrubber here would be a second thing to keep correct.
+5. **Pure function, config resolved by the caller.** Keeps the builder testable on
+   both sides of the boundary without touching global state.
+
+## Explicit non-authorization
+
+This flag authorizes recording THIS install's own decisions for internal
+benchmarking. It is **not** authorization for ingesting third-party scenarios, which
+the operator named as a future direction. That path needs an anonymisation layer
+that does not exist, for two independent reasons:
+
+- **Identifier-stripping is not anonymisation.** A conversation with every name
+  removed remains identifiable from its subject matter, and removing the subject
+  matter destroys its value as a scenario. The tension is real and must be designed
+  around, not asserted away.
+- **External scenarios are untrusted input.** A benchmark case is text a model will
+  later read. Anyone who can contribute one can attempt to shape how models behave
+  on it, or plant one that scores a favoured model well.
+
+Neither risk exists for locally-generated rows. Neither is solved here. Stated in
+the code comment so a future reader cannot mistake this flag for a green light.
+
+## Open questions
+
+None blocking Increment A. Increments B and C are specified above and tracked as
+separate work; neither is claimed as built by this spec.

--- a/docs/specs/tone-candidate-body-capture.eli16.md
+++ b/docs/specs/tone-candidate-body-capture.eli16.md
@@ -1,0 +1,98 @@
+# ELI16 — You can't re-read a fingerprint
+
+## The setup
+
+Before most messages go out, an AI checks them. Does this leak a password, does it
+quit on a task it could finish, does it dump jargon at someone who wanted plain
+English. Sometimes it holds a message back.
+
+We want to know how often it's right about that. Not by guessing — by going back
+later, reading the actual decisions, and marking them.
+
+## The problem
+
+Every one of those decisions is recorded. What the AI decided, which version of
+the instructions it was following, when, how long it took.
+
+Except the one thing that matters most: the message itself.
+
+That was stored as a fingerprint — a scrambled code, unique to that exact text,
+useless for anything but proving two messages were identical. It cannot be turned
+back into words. Nobody can read it.
+
+So the record says "the AI blocked a message" and offers no way to find out what
+the message said. You cannot judge that. Nobody could. The whole review plan was
+resting on a record that had been quietly hollowed out.
+
+## Why it was built that way
+
+Not carelessly — deliberately, and the reasoning was written down at the time.
+
+The gate exists to catch messages leaking things they shouldn't. Storing those
+messages means building a pile of exactly the text you were worried about. The
+fingerprint gave a way to track decisions without keeping a copy of everything the
+agent has ever said.
+
+Which is a real concern and a defensible call. It just makes the thing it's
+protecting impossible.
+
+## What changed
+
+Justin pointed out the part I'd missed: the messages are already saved. Every
+conversation gets written to a transcript on disk. Storing the same words a second
+time, somewhere only he and I can read, isn't a new exposure — it's a second copy
+of something already sitting there.
+
+So the message text is now recorded. But:
+
+**It's off unless switched on.** Nothing changes for anyone who doesn't turn it on,
+and the "off" behaviour is byte-for-byte what it was before — there's a test that
+asserts exactly that, so it can't drift.
+
+**Passwords still get stripped.** Same scrubber every other store here uses. If a
+message contained a token, the record shows that a credential was removed and what
+kind — never the value, never where it sat.
+
+**There's a hard ceiling on length.** Not a default someone can raise: a bigger
+number gets clamped back down. Anything cut short is flagged, so a reviewer knows
+it's reading a fragment rather than assuming it has the whole message.
+
+**The fingerprint stays.** It isn't replaced — it sits alongside. Records written
+before and after the switch flips can still be matched up.
+
+## One ordering detail that matters
+
+Cut the text first, then strip the passwords. Not the other way around.
+
+Do it backwards and you can slice a redaction marker in half, leaving the tail of a
+real secret sitting past the cut — the exact thing you were preventing, defeated by
+doing the two safe steps in the wrong order. Cutting first means the scrubber
+always sees the precise bytes that get stored.
+
+There's a test for this specifically: a password placed past the cut point, checked
+for absence in every form.
+
+## Where this does NOT apply
+
+Justin's next step is collecting decisions from other people's agents, to build a
+much larger set of examples. That needs something this doesn't have.
+
+Two reasons. Stripping names doesn't make a conversation anonymous — a support
+thread with every name removed is still recognisable from what it's about, and
+removing the substance destroys what made it a useful example. And examples from
+strangers are text a model will later read, contributed by people who might prefer
+their favoured model to score well.
+
+Neither problem exists for records generated here, by us, about our own decisions.
+Neither is solved by this change. The comment in the code says so directly, so
+nobody later mistakes this switch for permission to start ingesting outside data.
+
+## What's still missing
+
+When the AI blocks a message and I disagree and send it anyway, the record notes
+the override — but not why I disagreed.
+
+That "why" is the most valuable thing on the whole record. It's the difference
+between "the AI and the agent disagreed" and "the AI and the agent disagreed, and
+here's the reasoning, now you decide who was right." It isn't built yet, and it's
+the next piece.

--- a/docs/specs/tone-candidate-body-capture.side-effects.md
+++ b/docs/specs/tone-candidate-body-capture.side-effects.md
@@ -1,0 +1,117 @@
+# Side effects — opt-in candidate-body capture on the tone-gate provenance row
+
+## The change
+
+`buildToneDecisionContext()` gains an optional third parameter. When
+`recordCandidateBody: true`, the decision-quality provenance context carries the
+candidate message body — credential-scrubbed, length-clamped — alongside the
+sha256/bytes/chars identity it has always carried. A `recordCandidateBody` knob is
+added to `ToneGateConfig`, read live at the callsite via `getConfig()`.
+
+Absent or false, behaviour is byte-identical to today. There is a test asserting
+exactly that (`JSON.stringify` equality between omitted and explicitly-false), so
+the no-op property cannot drift silently.
+
+## Why this exists
+
+The quality meter's purpose is to answer "was this block correct?" retrospectively,
+in bulk, with a strong model. A sha256 cannot be re-read. An identity-only row hands
+that judge nothing to judge, so the meter could measure timing and volume but never
+correctness — the one thing it was built for.
+
+The prior identity-only discipline was deliberate and documented; the operator
+weighed the retention question directly (2026-07-23, topic 33368) and settled it:
+the same text is already written to the session transcript on disk, so a second copy
+in an operator-and-agent-only store crosses no new line.
+
+## Blast radius
+
+**Nil while the flag is off**, which is its shipped state — the key is OMIT-REQUIRED
+and never seeded.
+
+**When on**, the effect is bounded to what the provenance store holds. No gating
+behaviour changes: `buildToneDecisionContext` is a pure context builder feeding an
+observe-only side write. It cannot alter a block/allow verdict, cannot delay a send,
+and the tone gate's fail-closed semantics are untouched.
+
+Specifically NOT affected:
+- The gate's verdict path, rule set, and fail-direction config.
+- The served `decision` surface — context is machine-local, redaction-by-field-
+  omission at `readRedacted` (an existing invariant, not modified here).
+- Any other decision point's context builder.
+
+## Content-safety properties, and why each is where it is
+
+**Credential scrub.** Routed through `scrubForStore`, the same durable scrubber used
+by every other content-bearing store. Redaction KINDS are recorded (`bodyRedactionKinds`,
+deduped); offsets and matched text are not — knowing a credential was present helps a
+judge, knowing where it sat helps nobody who should have it.
+
+**Clamp before scrub, not after.** Load-bearing ordering. Scrubbing first and
+truncating second can bisect a `[REDACTED:…]` marker and leave the tail of a real
+secret past the cut — the failure mode being prevented, reintroduced by sequencing
+two safe operations wrongly. Covered by a dedicated test placing a credential beyond
+the clamp point and asserting its absence in every form.
+
+**Ceiling, not default.** `maxBodyChars` is clamped DOWN to
+`TONE_CANDIDATE_BODY_MAX_CHARS` (4000) and never up, so no config value can turn the
+store into an unbounded archive. Truncated rows carry `bodyTruncated: true`.
+
+**Withholding is distinguishable from cleanliness.** The scrubber replaces the whole
+field on its error and oversize paths. Those set `bodyWithheld: 'scrub-error' |
+'oversize'` rather than being conflated with "nothing sensitive found" — a judge must
+be able to tell "this message was clean" from "the scrub failed and the body was
+suppressed". Silently merging them would make every clean-looking row untrustworthy.
+
+**Identity preserved, not replaced.** sha256/bytes/chars describe the WHOLE message
+even when the stored body is a fragment, so rows written either side of a flag flip
+remain correlatable and dedupable.
+
+## Explicit non-authorization
+
+This flag authorizes recording THIS install's own decisions for internal
+benchmarking. It is not authorization for ingesting third-party scenarios, which the
+operator has named as a future direction. That path needs an anonymisation layer that
+does not exist:
+
+- Identifier-stripping is not anonymisation. A conversation with names removed stays
+  identifiable from its subject matter, and removing the subject matter destroys its
+  value as a scenario.
+- Externally-contributed scenarios are untrusted input — text a model will later
+  read, from contributors who may wish to influence how it scores.
+
+Neither risk applies to locally-generated rows. Both are stated in the code comment
+so a future reader cannot mistake this flag for a green light on external ingest.
+
+## Migration parity
+
+None required, deliberately. `recordCandidateBody` is OMIT-REQUIRED: absent means
+off, matching the `provenance.uniformSeam.enabled` precedent. It is NOT seeded by
+`ConfigDefaults`/`migrateConfig`, because seeding it would write a decision about
+content retention into every deployed agent's config file on update. Absence is the
+correct and safe state, and an existing agent that never sets it behaves exactly as
+it does today.
+
+## Multi-machine posture
+
+`unified` — no new state surface. The provenance store's existing posture
+(machine-local `contextFull`, redaction-by-field-omission on read) is unchanged; this
+adds a field to an existing context object rather than introducing a store, route, or
+replicated record.
+
+## Testing
+
+12 new unit tests (`tests/unit/tone-decision-context-body.test.ts`) covering both
+sides of the boundary: off-by-default (3, incl. byte-identical equivalence),
+on-behaviour (2), credential scrubbing (2), length bounds (4, incl. clamp-before-scrub
+ordering), and non-regression of the surrounding context (1).
+
+Existing suites re-run green: `MessagingToneGate` (55), `messaging-tone-gate-b15` (9),
+`messaging-tone-gate-b16` (9), `attention-route-tone-gate` (4) — 77 pre-existing plus
+12 new, 89 total. `tsc --noEmit` clean.
+
+## Rollback
+
+Set the flag false, or revert the commit. No persisted schema, no migration, no
+cleanup — rows already written keep their body and remain valid; rows written after
+carry identity only.

--- a/src/core/JudgmentProvenanceLog.ts
+++ b/src/core/JudgmentProvenanceLog.ts
@@ -44,6 +44,21 @@ export const PROVENANCE_ROW_BYTE_CLAMP = 64 * 1024;
 /** How large the precomputed redacted context view may grow (chars). */
 const REDACTED_CONTEXT_CLAMP = 2_000;
 
+/**
+ * Reserved top-level context key whose value is MACHINE-LOCAL BY CONSTRUCTION.
+ *
+ * Anything under this key is stripped before `contextRedacted` is built, so it lives
+ * only in `contextFull` — the field readRedacted() omits and the cross-machine
+ * allowlist excludes. This is the ONLY sanctioned way for a content-class envelope to
+ * retain a genuine body (e.g. an outbound message being judged for correctness later)
+ * without that body reaching a served surface.
+ *
+ * Deliberately a reserved KEY rather than a per-callsite path list: the provenance log
+ * must not need to know which decision points carry content, and a new enrolling
+ * callsite must not be able to leak by forgetting to register itself somewhere.
+ */
+export const CONTENT_FULL_KEY = '_contentFull';
+
 /** Flush the append buffer at this many rows or this many ms, whichever first. */
 const FLUSH_MAX_ROWS = 50;
 const FLUSH_INTERVAL_MS = 1_000;
@@ -295,7 +310,26 @@ export class JudgmentProvenanceLog {
     }
     let contextRedacted: string;
     try {
-      contextRedacted = JSON.stringify(scrub(input.context)).slice(0, REDACTED_CONTEXT_CLAMP);
+      // CONTENT-BEARING CONTAINMENT. `contextRedacted` is a SERVED field: it is
+      // returned by readRedacted() and is on the cross-machine allowlist
+      // (REDACTED_PROVENANCE_FIELDS), so whatever lands here is readable locally AND
+      // travels to peer machines on a pool merge. The scrubbers applied to it are
+      // CREDENTIAL-shape scrubbers, not PII scrubbing — they will not remove ordinary
+      // prose.
+      //
+      // That was safe while every envelope held identity + bounded code-derived
+      // features only. A decision point that must retain genuine content for later
+      // retrospective judging (decision-input-capture) breaks that assumption, and the
+      // failure is silent: the body simply appears in a served field nobody re-audited.
+      //
+      // So the reserved top-level key `_contentFull` is machine-local BY CONSTRUCTION —
+      // stripped here before the redacted projection is built, and therefore present
+      // only in `contextFull`, which readRedacted omits. A builder that needs to retain
+      // content puts it there and nowhere else. Non-content metadata ABOUT that content
+      // (redaction kinds, truncation flags) stays in the visible envelope, because those
+      // are exactly the fields a reader needs in order to trust the row.
+      const { [CONTENT_FULL_KEY]: _contentFull, ...redactable } = input.context;
+      contextRedacted = JSON.stringify(scrub(redactable)).slice(0, REDACTED_CONTEXT_CLAMP);
     } catch {
       contextRedacted = '[unserializable-context]';
     }

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -30,6 +30,21 @@ import { detectInternalIdLeak } from './internal-id-leak.js';
 import { detectSelfStopShape } from './self-stop-floor.js';
 import { detectDeferralShape } from './deferral-floor.js';
 import { DP_MESSAGING_TONE_GATE } from '../data/provenanceCoverage.js';
+import { scrubForStore } from './durableSecretScrub.js';
+import { CONTENT_FULL_KEY } from './JudgmentProvenanceLog.js';
+
+/**
+ * Hard ceiling on a recorded candidate body, in characters. A CEILING, not a default
+ * the caller can raise: `maxBodyChars` is clamped DOWN to it, never up, so no config
+ * value can turn the provenance store into an unbounded archive of outbound prose.
+ *
+ * 4000 covers the overwhelming majority of real outbound messages whole — the point
+ * of recording the body is that a later judge can read what was actually said, and a
+ * body cut off mid-argument answers "was blocking this correct?" no better than a
+ * hash does. Rows that do hit the ceiling are marked `bodyTruncated: true` so the
+ * judge knows it is reading a fragment rather than assuming it has the whole message.
+ */
+export const TONE_CANDIDATE_BODY_MAX_CHARS = 4000;
 
 /**
  * The prompt-version tag for the tone-gate judge, declared as the provenance
@@ -122,24 +137,125 @@ export function detectDeterministicLeak(
  * recent-message COUNT, the deterministic gate-signal KINDS). It NEVER stores the
  * message body or any plaintext slice of it.
  *
- * WHY NO plaintext head (mirrors the CompletionEvaluator content-bearing sibling,
- * §5.3): the candidate IS the very outbound text this gate exists to inspect for
- * leaks — a bounded head, even credential-scrubbed, would still archive
+ * WHY NO plaintext head BY DEFAULT (mirrors the CompletionEvaluator content-bearing
+ * sibling, §5.3): the candidate IS the very outbound text this gate exists to inspect
+ * for leaks — a bounded head, even credential-scrubbed, would still archive
  * non-credential PII / user-facing prose the store must not become a copy of. The
- * hash gives full identity (correlate/dedupe/replay-verify) with zero body
- * exposure.
+ * hash gives full identity (correlate/dedupe/replay-verify) with zero body exposure.
+ *
+ * WHY AN OPT-IN CANDIDATE BODY EXISTS ANYWAY (operator decision, 2026-07-23, topic
+ * 33368). The identity-only row cannot answer the question the meter exists to ask.
+ * "Was blocking this message correct?" is not decidable from a sha256: a hash cannot
+ * be re-read, and a later judge handed one has strictly nothing to judge. The
+ * operator's model is record richly now, judge later in bulk with a strong model —
+ * which requires the body to still be there at judging time.
+ *
+ * The operator weighed the retention question directly and settled it: the same text
+ * is ALREADY written to the session transcript on disk, so storing it a second time
+ * in a store only the operator and the agent read crosses no line the transcript has
+ * not already crossed. That reasoning is explicitly scoped to INTERNAL benchmarking
+ * of this install's own decisions.
+ *
+ * IT DOES NOT EXTEND to third-party data. The operator's stated next step —
+ * crowdsourcing scenarios from other installs' agents — needs an anonymisation layer
+ * that does not exist yet, and "scrub the identifiers" is not that layer: a support
+ * conversation with every name removed is still identifiable from what it is about,
+ * and stripping what makes it a scenario destroys its value as one. Incoming
+ * scenarios are also untrusted input — text a model will later read, contributed by
+ * someone who may wish to shape how it scores. Neither problem exists for
+ * locally-generated rows, and neither is solved here. A future ingest path for
+ * external scenarios MUST NOT reuse this flag as its authorization.
+ *
+ * The body is therefore: OFF unless explicitly enabled, credential-scrubbed through
+ * the same durable scrubber every other content-bearing store uses, hard length-
+ * clamped, and recorded ALONGSIDE the sha256 rather than replacing it — identity
+ * stays intact whether or not the body is present, so rows written before and after
+ * an operator flips this flag remain correlatable.
  */
 export function buildToneDecisionContext(
   text: string,
   context: ToneReviewContext,
+  /**
+   * Opt-in candidate-body capture. Absent/false ⇒ byte-identical behaviour to the
+   * identity-only row. Passed explicitly rather than read from config here so this
+   * stays a pure function (its callers own config resolution) and so a test can
+   * exercise both sides without touching global state.
+   */
+  opts?: { recordCandidateBody?: boolean; maxBodyChars?: number },
 ): Record<string, unknown> {
   const sha256 = (s: string): string => crypto.createHash('sha256').update(s, 'utf8').digest('hex');
+  const candidate: Record<string, unknown> = {
+    sha256: sha256(text),
+    bytes: Buffer.byteLength(text, 'utf8'),
+    chars: text.length,
+  };
+  // Machine-local by construction — see CONTENT_FULL_KEY. Attached to the envelope
+  // only when it actually holds something, so an identity-only row stays byte-identical
+  // to what it was before this feature existed.
+  const contentFull: Record<string, unknown> = {};
+  if (opts?.recordCandidateBody === true) {
+    // Clamp BEFORE scrubbing, never after: scrubbing first and truncating second can
+    // slice a `[REDACTED:...]` marker in half and leave the tail of a real secret
+    // sitting past the cut. Clamping first means the scrubber always sees the exact
+    // bytes that will be stored.
+    // Number.isFinite FIRST: Math.min(NaN, X) is NaN, and `text.length > NaN` is false,
+    // so a NaN bound would skip the clamp entirely AND report bodyTruncated:false — the
+    // ceiling bypassed by a row that claims to be complete. A non-finite bound falls back
+    // to the ceiling rather than being trusted.
+    const requested = opts.maxBodyChars;
+    const bound = typeof requested === 'number' && Number.isFinite(requested)
+      ? requested
+      : TONE_CANDIDATE_BODY_MAX_CHARS;
+    const limit = Math.max(0, Math.min(bound, TONE_CANDIDATE_BODY_MAX_CHARS));
+    const clamped = text.length > limit ? text.slice(0, limit) : text;
+    const scrubbed = scrubForStore(clamped);
+    // The body goes ONLY under the reserved machine-local key. `candidate` itself is
+    // part of the envelope that feeds `contextRedacted` — a SERVED field, on the
+    // cross-machine allowlist, scrubbed only for credential shapes. Putting the body
+    // there would publish outbound message text to the local read surface and to peer
+    // machines on a pool merge. This is not a hypothetical: the first implementation
+    // did exactly that, and it looked correct.
+    contentFull.candidateBody = scrubbed.text;
+    // Metadata ABOUT the body stays visible — a reader needs these to trust the row,
+    // and none of them carry content.
+    candidate.bodyTruncated = text.length > limit;
+    // Kinds are computed over the FULL text, not the stored fragment.
+    //
+    // Clamping first is required for storage safety (see above), but it makes the
+    // stored fragment's redaction list mean "kinds found in the first N chars" —
+    // which is NOT the question a reader asks. "Did this message contain a
+    // credential?" must be answerable for the WHOLE message, or a secret sitting
+    // past the cut makes the row read as clean. Two bounded scrubs: one over the
+    // full text for accurate metadata (its scrubbed output is discarded), one over
+    // the clamped text for the bytes actually stored.
+    // An oversize/errored full scan returns a MARKER span, not real findings. Using it
+    // would REPLACE the genuine kinds found in the stored fragment with ["oversize"] —
+    // a row whose body visibly redacted a token would report only that the scan failed.
+    // Fall back to the fragment's own findings and say plainly that whole-message
+    // accounting was unavailable.
+    const rawFullScan = text.length > limit ? scrubForStore(text) : scrubbed;
+    const fullScanUsable = rawFullScan.error !== true && rawFullScan.truncated !== true;
+    const fullScan = fullScanUsable ? rawFullScan : scrubbed;
+    if (!fullScanUsable) candidate.bodyRedactionScope = 'stored-fragment-only';
+    if (fullScan.redactions.length > 0) {
+      candidate.bodyRedactionKinds = [...new Set(fullScan.redactions.map((r) => r.kind))];
+      // True when the full message carried a credential that the clamp cut away, so
+      // the stored fragment shows no redaction marker despite the message having had
+      // one. Without this a truncated row looks cleaner than the message actually was.
+      if (fullScan.redactions.length > scrubbed.redactions.length) {
+        candidate.bodyRedactionsBeyondClamp = true;
+      }
+    }
+    // The scrubber replaces the whole field on its own error/oversize paths. Record
+    // that plainly so a judge reading this row can tell "nothing sensitive was found"
+    // from "the scrub failed and the body was withheld" — those are not the same
+    // fact, and silently conflating them would make the row quietly untrustworthy.
+    if (scrubbed.error === true) candidate.bodyWithheld = 'scrub-error';
+    else if (scrubbed.truncated === true) candidate.bodyWithheld = 'oversize';
+  }
   const ctx: Record<string, unknown> = {
-    candidate: {
-      sha256: sha256(text),
-      bytes: Buffer.byteLength(text, 'utf8'),
-      chars: text.length,
-    },
+    ...(Object.keys(contentFull).length > 0 ? { [CONTENT_FULL_KEY]: contentFull } : {}),
+    candidate,
     channel: String(context.channel ?? '').slice(0, 32),
     messageKind: context.messageKind ?? 'reply',
     recentMessageCount: Array.isArray(context.recentMessages) ? context.recentMessages.length : 0,
@@ -757,6 +873,21 @@ export interface ToneGateConfig {
    * classification before any real delivery). No effect outside 'tiered'.
    */
   toneTierDryRun?: boolean;
+  /**
+   * Record the candidate message BODY on the decision-quality provenance row, in
+   * addition to the sha256 identity that is always recorded (operator decision
+   * 2026-07-23, topic 33368 — see buildToneDecisionContext for the full reasoning
+   * and its limits).
+   *
+   * OFF unless explicitly set. Absent/false is byte-identical to the identity-only
+   * behaviour that shipped before this flag existed, so an agent that never sets it
+   * stores exactly what it stored yesterday.
+   *
+   * Scoped to INTERNAL benchmarking of this install's own decisions. It is NOT
+   * authorization for ingesting third-party scenarios, which need an anonymisation
+   * layer that does not exist yet.
+   */
+  recordCandidateBody?: boolean;
 }
 
 export class MessagingToneGate {
@@ -817,7 +948,11 @@ export class MessagingToneGate {
       // recorder's own total/fail-open contract).
       provenance: {
         decisionPoint: DP_MESSAGING_TONE_GATE,
-        context: buildToneDecisionContext(text, context),
+        context: buildToneDecisionContext(text, context, {
+          // Read live through getConfig() like every other tone-gate knob, so the
+          // operator can turn body capture on or off without a restart.
+          recordCandidateBody: this.getConfig().recordCandidateBody === true,
+        }),
         optionsPresented: [...TONE_OPTIONS_PRESENTED],
         promptId: TONE_GATE_PROMPT_ID,
       },

--- a/tests/unit/tone-decision-context-body.test.ts
+++ b/tests/unit/tone-decision-context-body.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Candidate-body capture on the tone gate's decision-quality provenance context.
+ *
+ * The meter exists to answer "was blocking this message correct?" retrospectively,
+ * in bulk, with a strong model. A sha256 cannot be re-read, so an identity-only row
+ * hands that judge nothing to judge. This covers the opt-in body capture that closes
+ * the gap — and, just as importantly, that it stays OFF unless asked for.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildToneDecisionContext,
+  TONE_CANDIDATE_BODY_MAX_CHARS,
+} from '../../src/core/MessagingToneGate.js';
+import { CONTENT_FULL_KEY } from '../../src/core/JudgmentProvenanceLog.js';
+
+const ctx = { channel: 'telegram', messageKind: 'reply' as const };
+
+const candidateOf = (c: Record<string, unknown>): Record<string, unknown> =>
+  c.candidate as Record<string, unknown>;
+
+const contentFullOf = (c: Record<string, unknown>): Record<string, unknown> =>
+  (c[CONTENT_FULL_KEY] ?? {}) as Record<string, unknown>;
+
+/**
+ * Mirrors how JudgmentProvenanceLog builds the SERVED `contextRedacted` field:
+ * strip the reserved machine-local key, then serialize. If a body can be found in
+ * here it is readable on GET /judgment-provenance and travels to peer machines on a
+ * pool merge.
+ */
+const servedProjection = (c: Record<string, unknown>): string => {
+  const { [CONTENT_FULL_KEY]: _omit, ...redactable } = c;
+  return JSON.stringify(redactable);
+};
+
+describe('buildToneDecisionContext — candidate body capture', () => {
+  describe('the default is unchanged', () => {
+    it('records no body when opts are omitted entirely', () => {
+      const c = candidateOf(buildToneDecisionContext('hello there', ctx));
+      expect(c.body).toBeUndefined();
+      expect(c.bodyTruncated).toBeUndefined();
+      expect(c.bodyRedactionKinds).toBeUndefined();
+    });
+
+    it('records no body when recordCandidateBody is explicitly false', () => {
+      const c = candidateOf(buildToneDecisionContext('hello there', ctx, { recordCandidateBody: false }));
+      expect(c.body).toBeUndefined();
+    });
+
+    it('produces a byte-identical context off vs. omitted — an agent that never sets the flag stores what it stored before', () => {
+      const omitted = buildToneDecisionContext('some outbound message', ctx);
+      const explicitOff = buildToneDecisionContext('some outbound message', ctx, { recordCandidateBody: false });
+      expect(JSON.stringify(explicitOff)).toBe(JSON.stringify(omitted));
+    });
+  });
+
+  describe('when enabled', () => {
+    it('records the body verbatim for ordinary prose', () => {
+      const text = 'I checked the scheduler and the job is queued behind two others.';
+      const full = buildToneDecisionContext(text, ctx, { recordCandidateBody: true });
+      expect(contentFullOf(full).candidateBody).toBe(text);
+      expect(candidateOf(full).bodyTruncated).toBe(false);
+    });
+
+    it('keeps the sha256 identity alongside the body, so rows written before and after the flag flips stay correlatable', () => {
+      const text = 'the same message';
+      const off = candidateOf(buildToneDecisionContext(text, ctx));
+      const on = candidateOf(buildToneDecisionContext(text, ctx, { recordCandidateBody: true }));
+      expect(on.sha256).toBe(off.sha256);
+      expect(on.bytes).toBe(off.bytes);
+      expect(on.chars).toBe(off.chars);
+    });
+  });
+
+  describe('credential scrubbing', () => {
+    it('redacts a credential in the body and reports the KIND without the offset or the matched text', () => {
+      const text = 'here is the token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 for the deploy';
+      const full = buildToneDecisionContext(text, ctx, { recordCandidateBody: true });
+      const c = candidateOf(full);
+      const body = String(contentFullOf(full).candidateBody);
+
+      expect(body).not.toContain('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789');
+      expect(body).toContain('[REDACTED:');
+      // Surrounding prose survives — a judge still sees what the message was about.
+      expect(body).toContain('for the deploy');
+
+      const kinds = c.bodyRedactionKinds as string[] | undefined;
+      expect(Array.isArray(kinds)).toBe(true);
+      expect(kinds!.length).toBeGreaterThan(0);
+      // Kinds only: no positional metadata that would help reconstruct the secret.
+      expect(JSON.stringify(c)).not.toMatch(/"(offset|start|index)"\s*:/);
+    });
+
+    it('omits bodyRedactionKinds entirely when nothing was redacted, rather than emitting an empty array', () => {
+      const c = candidateOf(buildToneDecisionContext('nothing sensitive here', ctx, { recordCandidateBody: true }));
+      expect(c.bodyRedactionKinds).toBeUndefined();
+    });
+
+    it('reports a credential that sits PAST the clamp, so a truncated row never reads cleaner than the message was', () => {
+      // The credential is cut away by the clamp — correctly, it must not be stored —
+      // but "did this message contain a credential?" is a question about the WHOLE
+      // message. Kinds are therefore computed over the full text.
+      const secret = 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+      // NOTE the space before the token: the scrubber's patterns are boundary-anchored,
+      // so a token run directly onto preceding word characters does not match. That is a
+      // property of the shared scrubber, not of this builder — but a fixture without the
+      // boundary silently tests nothing, which is how a passing test starts lying.
+      const text = `${'a'.repeat(300)} here is the token ${secret}`;
+      const full = buildToneDecisionContext(text, ctx, { recordCandidateBody: true, maxBodyChars: 100 });
+      const c = candidateOf(full);
+      const body = String(contentFullOf(full).candidateBody);
+
+      // The secret is absent from what is stored...
+      expect(body).not.toContain(secret);
+      expect(body).not.toContain('ghp_');
+      // ...but its presence in the message is still recorded.
+      const kinds = c.bodyRedactionKinds as string[] | undefined;
+      expect(Array.isArray(kinds)).toBe(true);
+      expect(kinds!.length).toBeGreaterThan(0);
+      // And the row says plainly that the redaction lay beyond the stored fragment.
+      expect(c.bodyRedactionsBeyondClamp).toBe(true);
+    });
+
+    it('does not set bodyRedactionsBeyondClamp when the credential is inside the stored fragment', () => {
+      const text = 'token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 here';
+      const c = candidateOf(buildToneDecisionContext(text, ctx, { recordCandidateBody: true }));
+      expect(c.bodyRedactionKinds).toBeDefined();
+      expect(c.bodyRedactionsBeyondClamp).toBeUndefined();
+    });
+  });
+
+  describe('length bound', () => {
+    it('clamps to the ceiling and flags the row as a fragment', () => {
+      const text = 'x'.repeat(TONE_CANDIDATE_BODY_MAX_CHARS + 500);
+      const full = buildToneDecisionContext(text, ctx, { recordCandidateBody: true });
+      const c = candidateOf(full);
+      expect(String(contentFullOf(full).candidateBody).length).toBeLessThanOrEqual(TONE_CANDIDATE_BODY_MAX_CHARS);
+      expect(c.bodyTruncated).toBe(true);
+      // The identity fields still describe the WHOLE message, not the fragment.
+      expect(c.chars).toBe(text.length);
+    });
+
+    it('clamps a caller-supplied maxBodyChars DOWN to the ceiling but never up', () => {
+      const text = 'y'.repeat(TONE_CANDIDATE_BODY_MAX_CHARS + 5000);
+      const full = buildToneDecisionContext(text, ctx, {
+        recordCandidateBody: true,
+        maxBodyChars: TONE_CANDIDATE_BODY_MAX_CHARS + 5000,
+      });
+      expect(String(contentFullOf(full).candidateBody).length).toBeLessThanOrEqual(TONE_CANDIDATE_BODY_MAX_CHARS);
+    });
+
+    it('honours a SMALLER caller-supplied bound', () => {
+      const full = buildToneDecisionContext('z'.repeat(500), ctx, { recordCandidateBody: true, maxBodyChars: 100 });
+      const c = candidateOf(full);
+      expect(String(contentFullOf(full).candidateBody).length).toBeLessThanOrEqual(100);
+      expect(c.bodyTruncated).toBe(true);
+    });
+
+    it('clamps BEFORE scrubbing, so truncation can never slice a redaction marker and leave secret bytes past the cut', () => {
+      // The credential sits beyond the clamp point: it must be cut away by the clamp,
+      // and must not appear in any form in the stored body.
+      const secret = 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+      const text = `${'a'.repeat(200)}${secret}`;
+      const full = buildToneDecisionContext(text, ctx, { recordCandidateBody: true, maxBodyChars: 100 });
+      const body = String(contentFullOf(full).candidateBody);
+      expect(body).not.toContain(secret);
+      expect(body).not.toContain('ghp_');
+      expect(body.length).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('the rest of the context is untouched', () => {
+    it('still carries the code-derived features when the body is recorded', () => {
+      const full = buildToneDecisionContext('a message', ctx, { recordCandidateBody: true });
+      expect(full.channel).toBe('telegram');
+      expect(full.messageKind).toBe('reply');
+      expect(Array.isArray(full.gateSignalKinds)).toBe(true);
+    });
+  });
+});
+
+/**
+ * CONTAINMENT — the highest-value property in this feature.
+ *
+ * `contextRedacted` is built from the context minus the reserved machine-local key,
+ * is returned by readRedacted(), and is on the cross-machine field allowlist. Anything
+ * reachable through it is readable on the served surface AND replicated to peers. The
+ * scrubbers applied there are credential-shape scrubbers; they do not remove prose.
+ *
+ * The first implementation of this feature put the body on `candidate`, which is inside
+ * that projection. It passed every other test in this file. These are the tests that
+ * would have caught it.
+ */
+describe('buildToneDecisionContext — content containment', () => {
+  const secretish = 'the quarterly figures are down and Dana is being let go';
+
+  it('keeps the body OUT of the served projection', () => {
+    const full = buildToneDecisionContext(secretish, ctx, { recordCandidateBody: true });
+    expect(servedProjection(full)).not.toContain(secretish);
+    expect(servedProjection(full)).not.toContain('Dana');
+  });
+
+  it('still carries the body in the machine-local key, so a later judge can read it', () => {
+    const full = buildToneDecisionContext(secretish, ctx, { recordCandidateBody: true });
+    expect(contentFullOf(full).candidateBody).toBe(secretish);
+  });
+
+  it('keeps trust-relevant metadata VISIBLE in the served projection', () => {
+    // A reader must be able to tell a truncated or credential-carrying row from a clean
+    // one without being handed the content itself.
+    const text = `${'a'.repeat(300)} here is the token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`;
+    const full = buildToneDecisionContext(text, ctx, { recordCandidateBody: true, maxBodyChars: 100 });
+    const served = servedProjection(full);
+    expect(served).toContain('bodyTruncated');
+    expect(served).toContain('bodyRedactionKinds');
+    expect(served).toContain('bodyRedactionsBeyondClamp');
+  });
+
+  it('attaches no machine-local key at all when body capture is off', () => {
+    const off = buildToneDecisionContext('hello', ctx);
+    expect(off[CONTENT_FULL_KEY]).toBeUndefined();
+  });
+});

--- a/upgrades/next/tone-candidate-body-capture.md
+++ b/upgrades/next/tone-candidate-body-capture.md
@@ -1,0 +1,31 @@
+## What Changed
+
+The tone gate's decision-quality provenance row can now record the candidate message BODY, alongside the sha256 identity it has always recorded. Off unless explicitly enabled (`recordCandidateBody` on the tone-gate config), and byte-identical to previous behaviour when absent.
+
+## Summary of New Capabilities
+
+- A later bulk judging pass can read what a held message actually said, instead of a hash it cannot re-read.
+- Recorded bodies are credential-scrubbed (kinds recorded, never offsets or matched text) and clamped to a hard 4000-char ceiling that config cannot raise.
+
+## What to Tell Your User
+
+Nothing changes unless you turn it on. When you do, held and allowed message text is stored in the local decision-quality record so its correctness can be reviewed later. The same text is already in the session transcript on disk; this is a second copy in a store only you and your agent read.
+
+## Evidence
+
+The quality meter exists to answer "was blocking this correct?" retrospectively. That question is not decidable from an identity-only row: a sha256 cannot be turned back into words, so a judge handed one has nothing to judge. The meter could measure latency and volume but never correctness — the thing it was built for.
+
+The prior no-plaintext discipline was deliberate and documented. It was also self-defeating: the gate inspects outbound text for leaks, so declining to store that text protects the store at the cost of making the review impossible.
+
+**Safety properties, and why each sits where it does:**
+
+- **Clamp BEFORE scrub.** Load-bearing ordering. Scrubbing first and truncating second can bisect a `[REDACTED:...]` marker and leave the tail of a real secret past the cut — the exact failure being prevented, reintroduced by sequencing two safe steps wrongly. A dedicated test places a credential beyond the clamp point and asserts its absence in every form.
+- **Ceiling, not default.** `maxBodyChars` clamps DOWN to `TONE_CANDIDATE_BODY_MAX_CHARS` and never up, so no config value can make the store an unbounded archive of outbound prose.
+- **Withheld is not the same as clean.** The scrubber replaces the whole field on its error/oversize paths; those set `bodyWithheld` to `scrub-error` or `oversize` rather than being conflated with "nothing sensitive found". A judge must be able to tell those apart, or every clean-looking row becomes untrustworthy.
+- **Identity preserved.** sha256/bytes/chars still describe the whole message even when the stored body is a fragment, so rows written either side of a flag flip stay correlatable.
+
+**Explicitly NOT authorized by this flag:** ingesting scenarios from other installs' agents. That needs an anonymisation layer that does not exist — identifier-stripping is not anonymisation (a conversation with names removed is still identifiable from its subject, and removing the subject destroys its value as a scenario), and external contributions are untrusted input a model will later read. Stated in the code comment so the flag cannot be mistaken for a green light on external ingest.
+
+**No config migration, deliberately.** The key is OMIT-REQUIRED: seeding it would write a content-retention decision into every deployed agent's config on update. Absence is the correct state.
+
+**Not changed:** the gate's verdict path, rule set, or fail-direction. This feeds an observe-only side write and cannot alter a block/allow decision.


### PR DESCRIPTION
## ELI16 — Give the quality-checker the actual message text to grade, not just a fingerprint

There's a safety check that decides whether each of my outgoing messages should be sent or held back. We want to grade, later and in bulk with a very smart model, whether those hold/send calls were *right*. Until now we only saved a **fingerprint** (a sha256 hash) of each message — and you can't read a fingerprint back, so the grader had literally nothing to look at. This change lets the system optionally save the **actual message text** next to the fingerprint, so a grader can later read what was really said and judge whether blocking it was correct.

It's careful about the obvious risk of keeping message text around: it's **off unless explicitly turned on**, credentials are **scrubbed out**, the text is **length-capped** at 4000 chars, and it's stored in a **machine-local-only** spot that never shows up on any shared or served surface. With the flag off, behaviour is byte-for-byte identical to before. It changes *nothing* about whether a message is actually sent — it only records more for later study.

## What this is

The LLM-Decision Quality Meter enrolls the `messaging-tone-gate` decision point so "was blocking this message correct?" can be judged retrospectively, in bulk, by a strong model. It couldn't: the provenance row carried only a **sha256 identity** of the candidate message, and a hash cannot be re-read — a judge handed one has nothing to judge.

## The change

`buildToneDecisionContext()` gains an opt-in `{ recordCandidateBody }`. When set, the decision-quality context records the candidate **body** alongside the sha256:

- **Credential-scrubbed** through the shared durable scrubber every content-bearing store uses.
- **Hard-clamped to a 4000-char CEILING** — clamped down, never up. Clamp happens *before* scrub (the other order could bisect a `[REDACTED:…]` marker and leave a secret tail past the cut).
- **Machine-local only** — written under the reserved content-full key, never on `candidate` (which feeds the served `contextRedacted` surface and travels on a pool merge). Containment tests assert the body stays out of the served projection.
- **Redaction KINDS, not offsets**, computed over the WHOLE message — a secret past the clamp still marks the row; a withheld body (`scrub-error` / `oversize`) is distinguishable from a genuinely clean one.
- **Identity preserved** — sha256/bytes/chars still describe the whole message, so rows written either side of a flag flip stay correlatable.

## Safety posture

- **OFF unless explicitly enabled.** Absent/false is byte-identical to the identity-only row that shipped before (asserted by a `JSON.stringify` equivalence test). OMIT-REQUIRED — never seeded by config defaults or migration.
- **No gating behaviour changes.** `buildToneDecisionContext` is a pure context builder feeding an observe-only side write. It cannot alter a block/allow verdict, cannot delay a send.
- **Scoped to INTERNAL benchmarking** of this install's own decisions. NOT authorization for third-party scenario ingest (needs an anonymisation layer that does not exist yet).

## Tier

Tier 1 — opt-in, off-by-default, observe-only, no block/allow authority. Staged ELI16 + side-effects artifact; instar-dev trace present. Operator decision 2026-07-23, topic 33368.

## Tests

18 unit tests (`tests/unit/tone-decision-context-body.test.ts`) covering off-by-default equivalence, on-behaviour, credential scrubbing, clamp-before-scrub ordering, length bounds, and content-containment (body out of served projection). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- eli16 payload refresh 2026-07-24T16:10Z -->