### PR TITLE
Fix automatic serving takeover cadence

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-24T18-30-09-909Z-automatic-serving-takeover.json
+++ b/.instar/instar-dev-decisions/2026-07-24T18-30-09-909Z-automatic-serving-takeover.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T18:30:09.909Z",
+  "slug": "automatic-serving-takeover",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 41,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T18-43-47-315Z-automatic-serving-takeover.json
+++ b/.instar/instar-dev-decisions/2026-07-24T18-43-47-315Z-automatic-serving-takeover.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T18:43:47.315Z",
+  "slug": "automatic-serving-takeover",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 35,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/core/LeaseCoordinator.ts
+++ b/src/core/LeaseCoordinator.ts
@@ -160,6 +160,15 @@ export class LeaseCoordinator {
   private lastObservedEpoch = 0;
   private suspended = false;
   /**
+   * Epoch acquired from a PEER through the normal fenced takeover authority.
+   * When this machine is the preferred captain, this is positive evidence that
+   * it may keep that exact epoch alive while the peer remains unreachable:
+   * acquisition already proved expired/dead/non-renewing and won the CAS.
+   * Process-local and epoch-bound by design; restart forgets it (fail-closed)
+   * and any higher observed epoch makes it inapplicable.
+   */
+  private peerTakeoverAuthorizedEpoch: number | null = null;
+  /**
    * The freshest lease THIS machine has signed (acquisition or renewal). It is
    * the authoritative low-latency copy of our own holding — we broadcast it
    * over the tunnel, but git is only updated coarsely (on epoch change), so a
@@ -260,6 +269,14 @@ export class LeaseCoordinator {
         }
       }
     }
+    // A higher accepted epoch permanently consumes any process-local solo-hold
+    // authorization for our older takeover. Do this BEFORE selfIssued folding:
+    // if the transport later forgets/removes that peer observation, the old
+    // epoch must never resurrect authority merely because it becomes the max
+    // visible record again.
+    if (this.peerTakeoverAuthorizedEpoch !== null && epoch > this.peerTakeoverAuthorizedEpoch) {
+      this.peerTakeoverAuthorizedEpoch = null;
+    }
     // Fold in our own freshest self-issued lease (a renewal's new expiry lives
     // here, not in coarse git). Only while not superseded by a higher epoch.
     if (this.selfIssued && this.selfIssued.holder === this.selfMachineId && this.selfIssued.epoch >= epoch) {
@@ -327,8 +344,8 @@ export class LeaseCoordinator {
    * ALL must hold (each is an EXISTING signal, never authority invented here):
    *  (1) the feature is enabled (DARK by default);
    *  (2) this machine is the F4-AGREED preferred-awake machine;
-   *  (3) EVERY peer is presumed-gone by liveness-silence (aged out, not merely
-   *      unreachable this tick) — the load-bearing "absent vs unreachable" gate;
+   *  (3) EVERY peer is presumed-gone by liveness-silence, OR this exact epoch
+   *      was acquired from a peer through the fenced takeover authority;
    *  (4) no higher epoch than ours is observed (a real takeover always wins).
    * Fail-closed: a missing dep ⇒ not eligible (today's self-suspend).
    */
@@ -336,7 +353,8 @@ export class LeaseCoordinator {
     const cfg = this.d.soloCaptainHold?.();
     if (!cfg?.enabled) return false;
     if (!this.d.isPreferredAwakeAgreed?.()) return false;
-    if (!this.d.allPeersPresumedGone?.()) return false;
+    const authorizedByPeerTakeover = this.peerTakeoverAuthorizedEpoch === ourEpoch;
+    if (!authorizedByPeerTakeover && !this.d.allPeersPresumedGone?.()) return false;
     // No higher epoch observed than the one we hold (a real takeover dominates).
     const view = this.effectiveView();
     if (view.epoch > ourEpoch) return false;
@@ -571,6 +589,25 @@ export class LeaseCoordinator {
   }
 
   /**
+   * Whether the current peer-held effective lease is takeable by the normal
+   * fenced acquisition rules right now. This is a scheduling hint only: callers
+   * still invoke acquireIfEligible(), which re-evaluates the same decision and
+   * owns the CAS. Exposing the hint lets the fast anti-blinding pull loop wake
+   * acquisition exactly when an expired/dead/non-renewing holder becomes
+   * eligible without turning every pull into a noisy acquisition attempt.
+   */
+  peerTakeoverEligible(): boolean {
+    const view = this.effectiveView();
+    if (!view.lease || view.lease.holder === this.selfMachineId) return false;
+    return this.fl.canAcquire(
+      view.lease,
+      this.d.presumedDeadHolders(),
+      this.now(),
+      this.staleHolderOpts(view.lease),
+    ).can;
+  }
+
+  /**
    * Attempt to acquire (or self-renew) the lease if eligible. Returns true if
    * THIS machine holds the lease afterward. Implements the bounded-retry CAS
    * with livelock backoff.
@@ -598,6 +635,17 @@ export class LeaseCoordinator {
       const res = this.d.store.casWrite(candidate);
       if (res.ok) {
         this.selfIssued = candidate;
+        if (
+          view.lease &&
+          view.lease.holder !== this.selfMachineId &&
+          (
+            decision.reason === 'current-lease-expired' ||
+            decision.reason.startsWith('holder-presumed-dead') ||
+            decision.reason.startsWith('holder-not-renewing')
+          )
+        ) {
+          this.peerTakeoverAuthorizedEpoch = candidate.epoch;
+        }
         await this.broadcast(candidate);
         this.markRenewOk();
         this.emitEpoch(candidate.epoch);

--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -1324,9 +1324,13 @@ export class MultiMachineCoordinator extends EventEmitter {
   /**
    * One pull tick: fan-out pull every peer, fold the freshest lease into our
    * view, reconcile role (a pulled HIGHER-epoch peer fences us → auto-demote),
-   * then surface a SAME-epoch contested split-brain Near-Silently. Pull is for
-   * LEARNING (anti-blinding); the heartbeat tickLease remains the only path that
-   * ACTS (acquire/renew). Re-arms via `arm` even on failure.
+   * then surface a SAME-epoch contested split-brain Near-Silently. A successful
+   * peer observation also nudges the normal fenced lease tick: this closes the
+   * phase gap where stale-holder eligibility becomes true just after the slow
+   * 2-minute heartbeat tick and takeover otherwise waits almost another full
+   * heartbeat period. The nudge does not add authority — tickLease still owns
+   * every acquire/renew decision and all its observe-only/preferred/fencing
+   * gates. Re-arms via `arm` even on failure.
    */
   private async tickLeasePull(arm: () => void): Promise<void> {
     if (this.leasePulling) { arm(); return; }
@@ -1368,6 +1372,18 @@ export class MultiMachineCoordinator extends EventEmitter {
         // §Problem A — ACT on a same-epoch contested tie (not just surface it):
         // deterministic tie-break → loser relinquishes / winner advances once.
         await this.resolveContestedSplitBrain();
+        // CMT-984/CMT-992 — automatic serving takeover must follow the existing
+        // 5s anti-blinding pull cadence, not the unrelated 2-minute heartbeat
+        // phase. Once F2's monotonic non-renewal window opens (or the observed
+        // lease expires), immediately re-run the ONE authoritative lease actor.
+        // tickLease's reentrancy guard makes this safe against a concurrent
+        // heartbeat tick; observe-only machines still refuse to acquire.
+        if (
+          !this.leaseCoordinator!.holdsLease() &&
+          this.leaseCoordinator!.peerTakeoverEligible()
+        ) {
+          await this.tickLease();
+        }
       }
     } catch {
       // @silent-fallback-ok — a pull failure (incl. a bounded-await timeout) is retried next tick

--- a/tests/unit/LeaseCoordinator-selfHeal.test.ts
+++ b/tests/unit/LeaseCoordinator-selfHeal.test.ts
@@ -95,8 +95,10 @@ describe('LeaseCoordinator self-heal wiring (F2 + F3)', () => {
     store.lease = bLease; store.epoch = 1; tunnel.peer = bLease;
     // First observation stamps B's freshness at mono=1000.
     expect(lc.currentHolder()).toBe('B');
+    expect(lc.peerTakeoverEligible()).toBe(false);
     // Time advances 7×TTL with NO new B nonce ⇒ B is non-renewing.
     mono = 1_000 + 7 * TTL;
+    expect(lc.peerTakeoverEligible()).toBe(true);
     expect(await lc.acquireIfEligible()).toBe(true); // A takes over
     expect(lc.currentEpoch()).toBe(2);
   });
@@ -189,6 +191,39 @@ describe('LeaseCoordinator Layer 3 — solo-captain hold', () => {
     const ok = await lc.renew();
     expect(ok).toBe(false);
     expect(getSuspend()).toMatch(/could not confirm/);
+  });
+
+  it('preferred fenced peer-takeover may hold that exact epoch solo before the 15m death threshold', async () => {
+    let mono = 1_000;
+    const { lc, store, tunnel, getSuspend } = mkHeldCoordinator({
+      soloEnabled: true,
+      preferred: true,
+      allGone: false,
+      mono: () => mono,
+    });
+    // B's expired signed lease is an existing fenced-acquisition grant. A wins
+    // epoch 2 even though B has not yet aged through the 15-minute registry
+    // death threshold.
+    store.lease = flB().signLease(1, new Date(0).toISOString(), new Date(500).toISOString(), 9);
+    store.epoch = 1;
+    expect(await lc.acquireIfEligible()).toBe(true);
+    expect(lc.currentEpoch()).toBe(2);
+
+    // No peer can confirm the next renewal. The takeover provenance authorizes
+    // preferred A to keep epoch 2 alive; it must not drop serving after one TTL.
+    mono += TTL + 1;
+    expect(await lc.renew()).toBe(true);
+    expect(lc.holdsLease()).toBe(true);
+    expect(getSuspend()).toBeNull();
+
+    // A higher peer epoch permanently burns the authorization. Even if that
+    // observation later disappears, epoch 2 must not resurrect solo authority.
+    tunnel.peer = flB().signLease(3, new Date(1_000).toISOString(), new Date(10_000_000).toISOString(), 10);
+    expect(lc.currentEpoch()).toBe(3);
+    tunnel.peer = null;
+    mono += TTL + 1;
+    expect(await lc.renew()).toBe(false);
+    expect(lc.holdsLease()).toBe(false);
   });
 
   it('NOT preferred ⇒ never holds solo (a traveler self-suspends as today)', async () => {

--- a/tests/unit/MultiMachineCoordinator-leasePull.test.ts
+++ b/tests/unit/MultiMachineCoordinator-leasePull.test.ts
@@ -164,6 +164,67 @@ describe('MultiMachineCoordinator — active lease-pull split-brain surface', ()
     coord.stop();
   });
 
+  it('CMT-984/CMT-992: a standby takes over a non-renewing observed holder on the pull cadence', async () => {
+    const machineId = `m_${crypto.randomBytes(8).toString('hex')}`;
+    const identity = seedIdentity(dir, machineId);
+    new MachineIdentityManager(dir).registerMachine(identity as any, 'standby');
+
+    let now = 2_000;
+    let mono = 2_000;
+    const bLease = fl('B').signLease(
+      1,
+      new Date(now).toISOString(),
+      new Date(now + 10 * TTL).toISOString(),
+      7,
+    );
+    const store = new LocalLeaseStore({ filePath: path.join(dir, 'lease-local.json') });
+    expect(store.casWrite(bLease).ok).toBe(true);
+
+    const tunnel: LeaseTransport = {
+      broadcast: async () => true,
+      observed: () => ({ lease: bLease, lastNonceByHolder: { B: bLease.nonce } }),
+      isReachable: () => true,
+      pullAllPeers: async () => { /* B is dark: its last signed lease remains unchanged */ },
+    };
+    const lc = new LeaseCoordinator({
+      lease: fl('A'),
+      store,
+      tunnel,
+      presumedDeadHolders: () => new Set(),
+      now: () => now,
+      monotonicNow: () => mono,
+      staleHolderTakeover: () => ({ enabled: true, nonRenewalMissedObservations: 2 }),
+    });
+
+    vi.useFakeTimers();
+    const state = new StateManager(dir);
+    const coord = new MultiMachineCoordinator(state, {
+      stateDir: dir,
+      multiMachine: { leasePullIntervalMs: 1_000 } as any,
+    });
+    coord.start();
+    coord.attachLeaseCoordinator(lc);
+    await coord.initializeLease();
+
+    expect(lc.currentHolder()).toBe('B');
+    expect(coord.isAwake).toBe(false);
+
+    // Reproduce the 2026-07-23 offline test: B stops renewing while its signed
+    // lease still looks live by wall clock. The F2 monotonic window opens at
+    // 2×TTL; the next pull tick must claim serving without waiting for the
+    // separate 2-minute heartbeat phase.
+    mono += 2 * TTL + 1;
+    now += 2 * TTL + 1;
+    await vi.advanceTimersByTimeAsync(1_300);
+
+    expect(lc.currentHolder()).toBe('A');
+    expect(lc.currentEpoch()).toBe(2);
+    expect(lc.holdsLease()).toBe(true);
+    expect(coord.isAwake).toBe(true);
+    expect(state.readOnly).toBe(false);
+    coord.stop();
+  });
+
   it('pull loop does not arm when the transport cannot pull (git-only mesh)', async () => {
     const machineId = `m_${crypto.randomBytes(8).toString('hex')}`;
     const identity = seedIdentity(dir, machineId);

--- a/upgrades/automatic-serving-takeover.eli16.md
+++ b/upgrades/automatic-serving-takeover.eli16.md
@@ -1,0 +1,32 @@
+# The standby now takes over as soon as the safety window opens
+
+In a two-machine setup, the standby already knew how to prove that the serving
+machine had stopped renewing its signed lease. The proof window is deliberately
+conservative: with the standard settings, the same signed lease must remain
+unchanged for about two minutes before a takeover is allowed.
+
+There was still a timing gap. The standby checked that proof while pulling the
+serving machine every few seconds, but only attempted the actual takeover on a
+separate two-minute timer. If the proof became sufficient just after that slow
+timer fired, the standby could wait almost another two minutes. This is why the
+2026-07-23 Codey laptop-offline test left the mesh naming the dark laptop while
+reporting no awake machine.
+
+The peer-pull loop now wakes the existing fenced lease actor as soon as the
+existing safety rules say takeover is eligible. It does not introduce a second
+way to claim serving: the same signed evidence, monotonic non-renewal window,
+preferred-machine rules, observe-only mode, and compare-and-swap fence all still
+apply. It only removes the unrelated timer-phase delay.
+
+The preferred Mini also remembers that the fenced authority granted this exact
+takeover epoch. That lets it keep the same epoch alive while the laptop remains
+offline, instead of dropping serving after one lease lifetime while waiting for
+the much slower registry-death threshold. This memory is process-local and
+epoch-bound: a restart forgets it, and any higher epoch immediately wins.
+
+A regression test recreates the offline-test shape: the laptop's lease remains
+valid by wall clock but its signed nonce stops advancing. After the two-minute
+evidence window, the next pull makes the Mini claim the next epoch, become awake,
+and restore writable serving without waiting for the slow heartbeat timer. A
+second ratchet proves that the preferred Mini keeps that exact takeover epoch
+alive when the laptop cannot confirm renewals.

--- a/upgrades/next/automatic-serving-takeover.md
+++ b/upgrades/next/automatic-serving-takeover.md
@@ -1,0 +1,33 @@
+---
+title: "Make standby serving takeover fire on time"
+---
+
+## What Changed
+
+When a serving machine stops renewing its signed lease, the standby now wakes
+the existing fenced takeover actor on the fast peer-observation cadence. This
+removes an unrelated timer-phase delay that could leave a two-machine mesh with
+no awake server for almost another two minutes after takeover was already safe.
+The preferred standby also keeps the exact fenced takeover epoch alive while the
+peer remains offline instead of self-suspending after one lease lifetime.
+
+## What to Tell Your User
+
+If your serving laptop goes offline, its standby can take over shortly after the
+configured safety window instead of waiting for a second slow timer. Existing
+split-brain fencing and automatic preferred-machine hand-back remain in place.
+
+## Summary of New Capabilities
+
+- Eligible serving failover runs on the roughly five-second lease-pull cadence.
+- A preferred standby may renew the exact epoch it acquired through the existing
+  expired/dead/non-renewing peer takeover authority.
+- The standby still uses the existing signed evidence, monotonic freshness, and
+  fenced compare-and-swap authority.
+- Returning preferred machines continue through claim-before-release hand-back.
+
+## Evidence
+
+The expanded focused gate passes 151 tests covering takeover, solo renewal, hand-back consent,
+zero-holder prevention, contested leases, and self-action convergence. TypeScript
+compile, repository lint, production build, and independent review also pass.

--- a/upgrades/side-effects/automatic-serving-takeover.md
+++ b/upgrades/side-effects/automatic-serving-takeover.md
@@ -1,0 +1,230 @@
+# Side-Effects Review — Automatic serving takeover cadence
+
+**Version / slug:** `automatic-serving-takeover`
+**Date:** `2026-07-24`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** `serving_takeover_review`
+
+## Summary of the change
+
+`LeaseCoordinator.peerTakeoverEligible()` exposes the existing fenced lease
+authority's current acquire verdict as a scheduling hint.
+`MultiMachineCoordinator.tickLeasePull()` uses that hint after a verified peer
+observation to wake the existing lease tick. This removes the unrelated
+two-minute heartbeat phase delay after stale-holder evidence becomes sufficient.
+When that authority grants the preferred machine a peer takeover,
+`LeaseCoordinator` records the won epoch process-locally so the existing
+solo-captain renewal path can keep that exact epoch alive before the slower
+registry-death threshold. No new acquisition authority or evidence type is
+introduced.
+
+## Decision-point inventory
+
+- `FencedLease.canAcquire` via `LeaseCoordinator.peerTakeoverEligible()` —
+  pass-through — reads the existing expired/dead/non-renewing-holder verdict
+  without writing state.
+- `MultiMachineCoordinator.tickLeasePull()` — modify — schedules the sole lease
+  actor when the existing authority says a peer takeover is eligible.
+- `LeaseCoordinator.acquireIfEligible()` — pass-through — remains the only
+  normal takeover authority and re-evaluates eligibility before its fenced CAS.
+- `LeaseCoordinator.soloCaptainHoldEligible()` — modify — accepts either the
+  existing all-peers-presumed-gone proof or an epoch-bound record that this
+  process already won a peer takeover through the same fenced authority.
+
+---
+
+## 1. Over-block
+
+No new rejection or block path is added. An observe-only machine continues to
+refuse acquisition inside `tickLease`; a preferred healthy peer continues to
+win through the existing lease rules. A healthy renewing peer produces
+`peerTakeoverEligible() === false`, so the new scheduling edge is inert.
+The solo-renew path cannot activate without first winning a fenced peer takeover
+and cannot apply to any other epoch.
+
+---
+
+## 2. Under-block
+
+The change cannot recover if the standby event loop or process is down, if no
+authenticated peer lease has ever been observed, or if the active pull loop is
+disabled/unavailable. Those cases retain the existing out-of-process watchdog,
+heartbeat tick, and fail-closed unknown-evidence behavior. A complete network
+partition can still delay takeover because absence of a verified observation is
+not treated as proof. A preferred captain that restarts while still isolated
+forgets the process-local takeover authorization and fails closed to the slower
+all-peers-presumed-gone path.
+
+---
+
+## 3. Level-of-abstraction fit
+
+This is at the coordinator scheduling layer. The fast peer-pull loop already
+owns authenticated observation cadence, while `LeaseCoordinator` and
+`FencedLease` own evidence evaluation and acquisition. The pull loop consumes
+the authority's hint and wakes the existing actor; it does not duplicate nonce,
+expiry, liveness, preference, or CAS logic.
+Solo renewal remains in `LeaseCoordinator`, where the acquisition provenance and
+current epoch can be checked together.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP. Reshape the design.
+
+`peerTakeoverEligible()` is a read-only scheduling signal produced by the
+existing deterministic lease authority. The constrained lease domain is fully
+enumerated by signed records, monotonic freshness, explicit liveness evidence,
+and CAS fencing. `acquireIfEligible()` remains the single authority and repeats
+the verdict at actuation time, preventing a stale scheduling hint from granting
+authority. The solo-renew latch is not a new takeover verdict; it records the
+epoch already granted by that authority and is invalid for every other epoch.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic is added at a competing-signals judgment point. The
+change reuses the converged lease policy's already-enumerated hard invariants and
+only alters when that authority is asked to run.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The hint calls the same `FencedLease.canAcquire` policy that
+  actuation calls, so it cannot shadow a different takeover check.
+- **Double-fire:** A heartbeat tick may race the pull-triggered tick, but
+  `leaseTicking` is the existing process-wide reentrancy guard and only one runs.
+- **Races:** Eligibility is re-evaluated inside `acquireIfEligible()` before CAS;
+  a peer renewal or competing claimant between hint and actuation safely wins.
+- **Feedback loops:** A successful takeover advances the epoch once. Subsequent
+  pulls see self holding and do not schedule another takeover. Failed eligibility
+  remains false until new evidence changes the authoritative view.
+- **Solo renewal:** The epoch-bound latch permits same-epoch renewal only. A
+  higher peer epoch immediately fails the equality check and fences Mini.
+- **Contested resolution:** Same-epoch tie resolution runs first. The new nudge
+  only follows when the post-resolution effective peer lease is actually
+  takeable, preventing ordinary contention from turning into lease churn.
+
+---
+
+## 6. External surfaces
+
+The visible change is timing and continuity: an eligible standby becomes awake and starts its
+existing Telegram/serving path on the next roughly five-second peer pull instead
+of waiting up to another two-minute heartbeat phase, then remains serving while
+the peer stays offline. No API schema, persistent
+record format, external credential, URL, or operator action is added. Runtime
+network timing remains outside full control, but the pull cadence is bounded and
+already validated to remain below the lease TTL.
+
+No operator-facing actions are added.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design with replicated authority:** the scheduling edge runs independently on every active
+lease participant, using authenticated lease observations propagated by
+`HttpLeaseTransport` and the existing shared/fenced epoch view. The behavior
+does not create durable state of its own. The won-takeover epoch latch is
+process-local because it is evidence about this incarnation's own CAS; a restart
+forgets it in the conservative direction.
+
+It emits no new user-facing notice, holds no topic-scoped durable state, and
+generates no URL. One-voice behavior comes from the existing fenced lease and
+poll-follows-lease path: only the CAS winner becomes awake and polls.
+
+---
+
+## 8. Rollback cost
+
+Pure code rollback: revert the scheduling edge and helper, then ship the next
+patch. No data migration or agent-state repair is required because no new state
+is written. During rollback propagation, worst-case behavior returns to the old
+timer-phase delay; fencing and split-brain safety remain unchanged.
+
+---
+
+## Conclusion
+
+The review found that directly attempting acquisition on every pull would have
+interfered with ordinary contested-lease resolution. The implementation was
+tightened to ask the existing authority for an eligibility hint first, and
+tests confirm the offline takeover, same-epoch solo renewal, and unchanged
+contested path. The change is clear to ship subject to a real two-machine test.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `serving_takeover_review`
+**Independent read of the artifact:** concur after concerns were resolved
+
+The reviewer confirmed the takeover edge is authority-safe and convergent, and
+independently reproduced the original 15/15 focused result. Three concerns were raised:
+
+1. A blocked, unrelated decision artifact generated by the first commit attempt
+   was staged. It was removed and is not part of this change.
+2. This artifact was not staged and still marked review pending. It is now
+   complete and staged with the change.
+3. The new regression covered takeover but not clean return. Return is already
+   owned by `LeaseHandbackReconciler`, not by this patch. Its claim-before-release
+   and failed-handback-never-leaves-zero-holders ratchets are in
+   `tests/unit/LeaseHandbackReconciler.test.ts` and
+   `tests/unit/LeaseCoordinator-handbackConsent.test.ts`; those tests are
+   included in the final focused gate. The requested real two-machine run will
+   additionally exercise the live hand-back after both machines run this build.
+
+After those corrections, the reviewer concurred that the staged set is scoped,
+the authority boundaries remain intact, races converge safely, and the artifact
+accurately distinguishes this takeover timing fix from the existing hand-back
+path. The reviewer independently reproduced the expanded 150/150 focused gate
+before the live test exposed the solo-renewal gap. Refreshed review of that
+correction is recorded below.
+
+The refreshed review independently reproduced the 151/151 gate and concurred
+after verifying the authorization-latch invalidation sequence: takeover
+authorizes epoch 2, a valid epoch 3 observation permanently clears that
+authority, and removing the observation cannot resurrect epoch-2 solo holding.
+No remaining blocker was found.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/MultiMachineCoordinator-leasePull.test.ts`
+- `tests/unit/LeaseCoordinator-selfHeal.test.ts`
+- Expanded takeover/solo-renewal/return result: 151 tests passed.
+- Existing return-path ratchets:
+  `tests/unit/LeaseHandbackReconciler.test.ts` and
+  `tests/unit/LeaseCoordinator-handbackConsent.test.ts`.
+- Repository lint, TypeScript compile, and production build passed.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: unbounded-self-action`, `closure: guard`,
+`guardEvidence: { enforcementType: ratchet, citation:
+tests/unit/MultiMachineCoordinator-leasePull.test.ts#CMT-984/CMT-992,
+howCaught: the controller's edge is level-triggered by a peer takeover verdict,
+re-enters the sole lease actor through its reentrancy guard, and settles after
+one fenced epoch advance because self-holding makes the trigger false; the
+regression ratchet proves the takeover and adjacent contested/solo cases prove
+the edge does not free-run. The repository-wide
+tests/unit/self-action-convergence.test.ts ratchet remains the controller-class
+backstop.}`


### PR DESCRIPTION
## What changed

- expose the existing fenced lease authority peer-takeover verdict as a read-only scheduling hint
- wake the sole lease actor from the fast authenticated peer-pull loop once takeover is eligible
- let the preferred Mini keep the exact fenced takeover epoch alive while the peer is unreachable
- permanently invalidate that process-local authority after any higher valid epoch is observed
- add regression coverage for the 2026-07-23 laptop-offline failure shape

## ELI16 — The Mini now notices and safely takes the baton

The two machines pass one signed “serving baton” between them. Before this change, the Mini could notice that the laptop had stopped renewing the baton but still wait for a slower timer before trying to take it. It could also drop the baton again if the laptop stayed unreachable. Now the fast observation loop wakes the existing fenced handoff logic, and a successful takeover authorizes the preferred Mini to keep only that exact baton epoch alive. A newer valid baton permanently cancels that temporary authority, preventing an old claim from returning.

## Root cause

The standby observed lease freshness every ~5 seconds, but actual acquisition only ran on a separate two-minute heartbeat tick. If the two-TTL non-renewal evidence window opened just after that tick, serving could remain unclaimed for almost another two minutes. Live deployment then exposed a second gap: an authorized takeover self-fenced at its next renewal while the peer was unreachable.

## Impact

Eligible takeover now happens on the next peer-pull tick and persists safely through the outage on the preferred Mini. Existing claim-before-release preferred-machine hand-back remains unchanged.

## Validation

- 151/151 focused takeover, solo-renewal, hand-back, consent, and convergence tests
- 274/274 affected pre-push smoke tests
- TypeScript compile, repository lint, and production build
- independent second-pass review concurred, including permanent higher-epoch invalidation
- Tier-2 instar-dev artifact and approved converged lease-self-heal spec
