### PR TITLE
feat(delivery): L0 dequeue-time age guard — expired queued replies can never auto-deliver (ships dark)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-24T19-56-07-283Z-l0-delivery-age-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-24T19-56-07-283Z-l0-delivery-age-guard.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-24T19:56:07.283Z",
+  "slug": "l0-delivery-age-guard",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 4,
+  "loc": 197,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T20-08-51-556Z-l0-delivery-age-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-24T20-08-51-556Z-l0-delivery-age-guard.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T20:08:51.556Z",
+  "slug": "l0-delivery-age-guard",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T20-09-12-747Z-l0-delivery-age-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-24T20-09-12-747Z-l0-delivery-age-guard.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T20:09:12.747Z",
+  "slug": "l0-delivery-age-guard",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T20-09-36-217Z-l0-delivery-age-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-24T20-09-36-217Z-l0-delivery-age-guard.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T20:09:36.217Z",
+  "slug": "l0-delivery-age-guard",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T20-10-02-475Z-l0-delivery-age-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-24T20-10-02-475Z-l0-delivery-age-guard.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T20:10:02.475Z",
+  "slug": "l0-delivery-age-guard",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T20-10-25-378Z-l0-delivery-age-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-24T20-10-25-378Z-l0-delivery-age-guard.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T20:10:25.378Z",
+  "slug": "l0-delivery-age-guard",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T20-11-03-364Z-l0-delivery-age-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-24T20-11-03-364Z-l0-delivery-age-guard.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T20:11:03.364Z",
+  "slug": "l0-delivery-age-guard",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T20-11-38-819Z-l0-delivery-age-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-24T20-11-38-819Z-l0-delivery-age-guard.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T20:11:38.819Z",
+  "slug": "l0-delivery-age-guard",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-24T20-12-16-732Z-l0-delivery-age-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-24T20-12-16-732Z-l0-delivery-age-guard.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-24T20:12:16.732Z",
+  "slug": "l0-delivery-age-guard",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 11,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -4028,6 +4028,14 @@ export interface InstarConfig {
     /** Opt-in candidate-body capture for decision-quality benchmarking. */
     recordCandidateBody?: boolean;
   };
+  /**
+   * L0 zombie-free delivery invariant arm flag (drive12 UX-first enforcement
+   * spec, Increment 1). When true, outbound recovery queues enforce their
+   * per-class max age at DEQUEUE time (policy: src/data/outbound-queue-expiry.json;
+   * a class's maxAgeHours 0 ⇒ no expiry). DARK by default — the test agent
+   * (Codey) arms first per the maturation ladder.
+   */
+  outboundQueueExpiry?: { enabled?: boolean };
   /** Monitoring config */
   monitoring: MonitoringConfig;
   /** Feature-rollout reconciler config (docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md §4.3

--- a/src/data/outbound-queue-expiry.json
+++ b/src/data/outbound-queue-expiry.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "_doc": "L0 zombie-free delivery invariant (drive12 UX-first enforcement spec, Increment 1): per-queue-class max age, enforced at DEQUEUE time. A queued outbound entry older than its class policy can never auto-deliver; it retires to dead-letter with a dropped-stale record and an aggregated operator digest. maxAgeHours 0 means NO EXPIRY for that class — the rollback sentinel: disabling the invariant is a data edit, not a code revert. This file is a protected path (a 0-flip requires an operator label and raises a loud digest event).",
+  "queues": {
+    "delivery-recovery": { "maxAgeHours": 24 }
+  }
+}

--- a/src/monitoring/delivery-failure-sentinel.ts
+++ b/src/monitoring/delivery-failure-sentinel.ts
@@ -76,6 +76,22 @@ export interface SentinelConfig {
   circuitBreakerCount?: number;
   circuitBreakerWindowMs?: number;
   /**
+   * L0 zombie-free delivery invariant (drive12 UX-first enforcement spec,
+   * Increment 1): a queued entry older than `maxAgeMs` at DEQUEUE time can
+   * never auto-deliver — it retires to dead-letter with a dropped-stale
+   * record and an aggregated operator digest. Distinct from
+   * `restorePurgeAgeMs`, which runs ONCE at startup: this is the invariant
+   * on every drain pass, closing the 2026-07-24 zombie-replay class (rows
+   * that dodge the startup purge and later become claimable).
+   *
+   * SHIPS DARK: `enabled` defaults false (today's behavior byte-identical).
+   * `maxAgeMs: 0` ⇒ no expiry even when enabled (the data-edit rollback
+   * sentinel). Policy source: src/data/outbound-queue-expiry.json
+   * ("delivery-recovery" class) + the per-install `outboundQueueExpiry`
+   * config flag, wired at the server construction site.
+   */
+  l0AgeGuard?: { enabled?: boolean; maxAgeMs?: number };
+  /**
    * Restore-purge threshold — entries older than this at startup are
    * dropped, not recovered (spec §3h). Default 60 minutes.
    *
@@ -139,6 +155,7 @@ const DEFAULTS: Required<SentinelConfig> = {
   circuitBreakerCount: 5,
   circuitBreakerWindowMs: 60 * 60 * 1000,
   restorePurgeAgeMs: 60 * 60 * 1000,
+  l0AgeGuard: { enabled: false, maxAgeMs: 24 * 60 * 60 * 1000 },
 };
 
 // ── Sentinel ─────────────────────────────────────────────────────────
@@ -152,6 +169,8 @@ export interface SentinelEvents {
   'sentinel:escalated': [{ delivery_id: string; topic_id: number; category: string }];
   'sentinel:circuit-breaker-tripped': [{ consecutiveFailures: number }];
   'sentinel:circuit-breaker-resumed': [];
+  /** L0 age-guard: rows retired at dequeue time for exceeding the class max age. */
+  'sentinel:stale-retired': [{ count: number; topicIds: number[]; maxAgeMs: number }];
 }
 
 export class DeliveryFailureSentinel extends EventEmitter {
@@ -166,6 +185,11 @@ export class DeliveryFailureSentinel extends EventEmitter {
   private escalationFailures: number[] = []; // ms timestamps
   private inFlight = 0;
   private lastTopicDelivery = new Map<number, number>(); // topic → last delivered ms
+  /** L0 age-guard digest coalescing: at most one Attention digest per window. */
+  private static readonly L0_DIGEST_COALESCE_MS = 6 * 60 * 60 * 1000;
+  private lastStaleDigestAt = 0;
+  private staleDigestPending = 0;
+  private staleDigestTopics = new Set<number>();
   /** Templates verified at start(). False disables escalation path. */
   private templatesValid = true;
   /** Restored on first start(); used to keep restore-purge a one-shot. */
@@ -182,6 +206,7 @@ export class DeliveryFailureSentinel extends EventEmitter {
       circuitBreakerCount: config.circuitBreakerCount ?? DEFAULTS.circuitBreakerCount,
       circuitBreakerWindowMs: config.circuitBreakerWindowMs ?? DEFAULTS.circuitBreakerWindowMs,
       restorePurgeAgeMs: config.restorePurgeAgeMs ?? DEFAULTS.restorePurgeAgeMs,
+      l0AgeGuard: config.l0AgeGuard ?? DEFAULTS.l0AgeGuard,
     };
     this.deps = {
       store: deps.store,
@@ -317,7 +342,13 @@ export class DeliveryFailureSentinel extends EventEmitter {
     const counters = { processed: 0, recovered: 0, escalated: 0 };
 
     // Pull rows that are ready (queued, or claimed-but-stale).
-    const candidates = this.selectClaimable();
+    let candidates = this.selectClaimable();
+
+    // L0 zombie-free delivery invariant (dequeue-time age guard). Runs on
+    // EVERY pull, before any row can reach processRow — no path to delivery
+    // exists for a row older than the class policy. Dark by default.
+    candidates = await this.applyL0AgeGuard(candidates);
+
     if (candidates.length === 0) {
       this.emit('sentinel:tick-complete', counters);
       return counters;
@@ -365,6 +396,123 @@ export class DeliveryFailureSentinel extends EventEmitter {
   }
 
   // ── Internals ──────────────────────────────────────────────────────
+
+  /**
+   * L0 zombie-free delivery invariant (drive12 UX-first spec, Increment 1).
+   *
+   * Partition the claimable rows by age against the class policy; rows past
+   * the max age RETIRE to dead-letter (audited 'expired-stale' reason in
+   * status_history via transition()) and are summarized in ONE aggregated
+   * digest — never delivered, never per-message spam. Age basis is
+   * `attempted_at`: the ORIGINAL failed-send time, so no amount of retry
+   * churn can refresh a row's age.
+   *
+   * Fail-safe posture: the guard only ever REMOVES rows from the delivery
+   * path; an error inside it (store transition failure, digest failure)
+   * must never block the drain of fresh rows, and a disabled/0-age policy
+   * makes it a strict pass-through (today's behavior byte-identical).
+   */
+  private async applyL0AgeGuard(candidates: PendingRelayRow[]): Promise<PendingRelayRow[]> {
+    const policy = this.cfg.l0AgeGuard;
+    if (!policy?.enabled) return candidates;
+    const maxAgeMs = policy.maxAgeMs ?? 0;
+    if (maxAgeMs <= 0) return candidates; // 0 ⇒ no expiry (rollback sentinel)
+
+    const now = this.deps.now();
+    const fresh: PendingRelayRow[] = [];
+    const stale: PendingRelayRow[] = [];
+    for (const row of candidates) {
+      const bornAt = Date.parse(row.attempted_at);
+      if (Number.isFinite(bornAt) && now - bornAt > maxAgeMs) stale.push(row);
+      else fresh.push(row); // unparseable age ⇒ treat as fresh (never guess-drop)
+    }
+    if (stale.length === 0) return fresh;
+
+    const retiredTopics: number[] = [];
+    for (const row of stale) {
+      try {
+        const ageHours = Math.round((now - Date.parse(row.attempted_at)) / 3_600_000);
+        const ok = this.deps.store.transition(row.delivery_id, 'dead-letter', {
+          claimed_by: null,
+          error_body: `expired-stale: L0 age-guard retired at dequeue (age ~${ageHours}h > policy ${Math.round(maxAgeMs / 3_600_000)}h; never delivered)`,
+        });
+        if (ok) retiredTopics.push(row.topic_id);
+      } catch {
+        // A failed retire leaves the row for the next pass; it still never
+        // delivers THIS pass (it is not in `fresh`). Never block the drain.
+      }
+    }
+
+    if (retiredTopics.length > 0) {
+      console.log(
+        `[sentinel:l0-age-guard] retired ${retiredTopics.length} stale row(s) at dequeue (policy ${Math.round(maxAgeMs / 3_600_000)}h; topics: ${[...new Set(retiredTopics)].join(', ')})`,
+      );
+      this.emit('sentinel:stale-retired', { count: retiredTopics.length, topicIds: [...new Set(retiredTopics)], maxAgeMs });
+      await this.postStaleDigest(retiredTopics, maxAgeMs);
+    }
+    return fresh;
+  }
+
+  /**
+   * ONE aggregated operator digest for retired-stale rows, coalesced to at
+   * most one Attention item per `L0_DIGEST_COALESCE_MS` window (calm-alerting
+   * — a steady trickle of expiring rows becomes accumulated counts, never a
+   * per-pass stream). Best-effort: a digest failure never affects the drain.
+   */
+  private async postStaleDigest(topicIds: number[], maxAgeMs: number): Promise<void> {
+    this.staleDigestPending += topicIds.length;
+    for (const t of topicIds) this.staleDigestTopics.add(t);
+    const now = this.deps.now();
+    if (now - this.lastStaleDigestAt < DeliveryFailureSentinel.L0_DIGEST_COALESCE_MS) return;
+    const count = this.staleDigestPending;
+    const topics = [...this.staleDigestTopics];
+    try {
+      const { port, authToken } = this.deps.readConfig();
+      const posted = await new Promise<boolean>((resolve) => {
+        const req = http.request(
+          {
+            host: '127.0.0.1',
+            port,
+            path: '/attention',
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
+            timeout: 5000,
+          },
+          (res) => {
+            const ok = (res.statusCode ?? 0) >= 200 && (res.statusCode ?? 0) < 300;
+            res.resume();
+            res.on('end', () => resolve(ok));
+          },
+        );
+        req.on('error', () => resolve(false));
+        req.on('timeout', () => {
+          req.destroy();
+          resolve(false);
+        });
+        req.end(
+          JSON.stringify({
+            title: `Stale queued replies retired (${count})`,
+            body: `The delivery age-guard retired ${count} queued outbound message(s) older than ${Math.round(maxAgeMs / 3_600_000)}h at dequeue time instead of delivering them late (conversations: ${topics.join(', ')}). Nothing was sent; each row is preserved as a dead-letter record with its reason.`,
+            priority: 'low',
+            source: 'delivery-l0-age-guard',
+          }),
+        );
+      });
+      // Counters clear (and the coalesce window stamps) ONLY on a confirmed
+      // 2xx — a failed/timed-out/non-2xx post keeps accumulating so the
+      // counts are retried on a later pass, never silently lost. The retired
+      // rows themselves are already safe regardless (audited dead-letters +
+      // the emitted event + log line).
+      if (posted) {
+        this.lastStaleDigestAt = now;
+        this.staleDigestPending = 0;
+        this.staleDigestTopics.clear();
+      }
+    } catch {
+      // Digest is observability, never a gate — accumulate and retry on a
+      // later pass.
+    }
+  }
 
   private selectClaimable(): PendingRelayRow[] {
     const nowIso = new Date(this.deps.now()).toISOString();

--- a/src/monitoring/delivery-failure-sentinel.ts
+++ b/src/monitoring/delivery-failure-sentinel.ts
@@ -438,8 +438,10 @@ export class DeliveryFailureSentinel extends EventEmitter {
         });
         if (ok) retiredTopics.push(row.topic_id);
       } catch {
-        // A failed retire leaves the row for the next pass; it still never
-        // delivers THIS pass (it is not in `fresh`). Never block the drain.
+        // @silent-fallback-ok: a failed retire leaves the row for the next
+        // pass; it still never delivers THIS pass (it is not in `fresh`).
+        // Deliberate fail-safe direction — never block the drain on the
+        // guard's own bookkeeping.
       }
     }
 
@@ -509,8 +511,9 @@ export class DeliveryFailureSentinel extends EventEmitter {
         this.staleDigestTopics.clear();
       }
     } catch {
-      // Digest is observability, never a gate — accumulate and retry on a
-      // later pass.
+      // @silent-fallback-ok: the digest is observability, never a gate —
+      // counters are retained and retried on a later pass; the retired rows
+      // are already audited dead-letters regardless.
     }
   }
 

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -5290,6 +5290,33 @@ export class AgentServer {
     }
 
     const configPath = path.join(stateDir, 'config.json');
+
+    // L0 zombie-free delivery invariant (drive12 UX-first spec, Increment 1):
+    // per-install arm flag (top-level `outboundQueueExpiry.enabled`, DARK by
+    // default — test agent enables first) + the per-queue-class max age from
+    // the shipped data file (0 ⇒ no expiry, the data-edit rollback sentinel).
+    // Resolution failures fail SAFE: guard stays dark, sentinel unaffected.
+    let l0AgeGuard: { enabled: boolean; maxAgeMs: number } | undefined;
+    try {
+      const armed =
+        (this.config as unknown as { outboundQueueExpiry?: { enabled?: boolean } }).outboundQueueExpiry?.enabled === true;
+      if (armed) {
+        // Packaging convention for runtime-read shipped JSON is <pkg>/src/data/
+        // (cf. DEFAULT_MIRROR_PATH) — plain tsc emits no JSON into dist/, so a
+        // dist-relative '../data/...' would ENOENT on every deployed install.
+        // '../../src/data/...' resolves correctly from BOTH layouts
+        // (dist/server/ and src/server/); wiring-integrity test pins this.
+        const dataUrl = new URL('../../src/data/outbound-queue-expiry.json', import.meta.url);
+        const parsed = JSON.parse(await fs.promises.readFile(dataUrl, 'utf-8')) as {
+          queues?: Record<string, { maxAgeHours?: number }>;
+        };
+        const hours = parsed.queues?.['delivery-recovery']?.maxAgeHours ?? 0;
+        l0AgeGuard = { enabled: true, maxAgeMs: Math.max(0, hours) * 60 * 60 * 1000 };
+      }
+    } catch (err) {
+      console.warn('[delivery-sentinel] L0 age-guard policy resolution failed; guard stays dark:', err);
+    }
+
     const sentinel = new DeliveryFailureSentinel(
       {
         store,
@@ -5312,10 +5339,13 @@ export class AgentServer {
             }
           : undefined,
       },
+      l0AgeGuard ? { l0AgeGuard } : {},
     );
     this.deliverySentinel = sentinel;
     await sentinel.start();
-    console.log('[instar] delivery-failure-sentinel started (Layer 3 recovery active)');
+    console.log(
+      `[instar] delivery-failure-sentinel started (Layer 3 recovery active${l0AgeGuard ? `; L0 age-guard armed at ${Math.round(l0AgeGuard.maxAgeMs / 3_600_000)}h` : ''})`,
+    );
   }
 
   /**

--- a/tests/integration/sentinel-l0-age-guard.test.ts
+++ b/tests/integration/sentinel-l0-age-guard.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Integration test — L0 zombie-free delivery invariant (dequeue-time age guard).
+ *
+ * Spec: drive12 UX-first enforcement (L0), Increment 1. Regression class:
+ * 2026-07-24 zombie-replay — weeks-old queued replies (including expired
+ * secure links) auto-delivered as new the moment the recovery drain was
+ * fixed. The invariant: a row older than the class policy can NEVER reach
+ * processRow, no matter how it became claimable.
+ *
+ * Drives the real DeliveryFailureSentinel tick against a real
+ * PendingRelayStore (SQLite on disk), postReply stubbed. Covers BOTH sides
+ * of the decision boundary and both rollback levers (flag off / maxAge 0).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { PendingRelayStore } from '../../src/messaging/pending-relay-store.js';
+import { DeliveryFailureSentinel } from '../../src/monitoring/delivery-failure-sentinel.js';
+import { WhoamiCache } from '../../src/messaging/whoami-cache.js';
+import { getOrCreateBootId, _resetCacheForTest } from '../../src/server/boot-id.js';
+
+let stateDir: string;
+let configPath: string;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+beforeEach(() => {
+  _resetCacheForTest();
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sentinel-l0-age-'));
+  configPath = path.join(stateDir, 'config.json');
+  fs.writeFileSync(configPath, JSON.stringify({ port: 4042, projectName: 'echo' }));
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(stateDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/integration/sentinel-l0-age-guard.test.ts:cleanup',
+  });
+});
+
+function mkSentinel(
+  store: PendingRelayStore,
+  postReply: ReturnType<typeof vi.fn>,
+  l0AgeGuard?: { enabled?: boolean; maxAgeMs?: number },
+) {
+  const sentinel = new DeliveryFailureSentinel(
+    {
+      store,
+      configPath,
+      readConfig: () => ({ port: 4042, authToken: 'tok', agentId: 'echo' }),
+      bootId: getOrCreateBootId(stateDir, '0.28.0'),
+      toneGate: null,
+      postReply: postReply as never,
+      whoamiCache: new WhoamiCache({ fetchFn: async () => ({ agentId: 'echo', port: 4042 }) }),
+    },
+    l0AgeGuard ? { l0AgeGuard } : {},
+  );
+  // Drive tick() without start(): start()'s one-shot restore-purge would
+  // delete the aged fixtures at boot and mask the DRAIN-TIME invariant this
+  // suite exists to prove (the guard must hold for rows that become
+  // claimable long after startup — the 2026-07-24 zombie class).
+  (sentinel as unknown as { running: boolean }).running = true;
+  return sentinel;
+}
+
+function enqueueAged(store: PendingRelayStore, id: string, topicId: number, ageMs: number, text: string) {
+  store.enqueue({
+    delivery_id: id,
+    topic_id: topicId,
+    text_hash: 'a'.repeat(64),
+    text: Buffer.from(text),
+    http_code: 503,
+    attempted_port: 4042,
+    attempted_at: new Date(Date.now() - ageMs).toISOString(),
+  });
+}
+
+describe('DeliveryFailureSentinel — L0 dequeue-time age guard', () => {
+  it('a row older than policy retires to dead-letter and is NEVER delivered; a fresh row still delivers', async () => {
+    const store = PendingRelayStore.open('echo', stateDir);
+    const staleId = '11111111-1111-4111-8111-111111111111';
+    const freshId = '22222222-2222-4222-8222-222222222222';
+    enqueueAged(store, staleId, 6, 40 * DAY_MS, 'weeks-old zombie');
+    enqueueAged(store, freshId, 7, 60 * 1000, 'fresh reply');
+
+    const postReply = vi.fn(async () => ({ status: 200, body: '{"ok":true}' }));
+    const sentinel = mkSentinel(store, postReply, { enabled: true, maxAgeMs: DAY_MS });
+
+    await sentinel.tick();
+
+    // The stale row never reached delivery.
+    const deliveredIds = postReply.mock.calls.map((c) => c[5]);
+    expect(deliveredIds).not.toContain(staleId);
+    // It retired as an audited dead-letter with the expired-stale reason.
+    const staleRow = store.findByDeliveryId(staleId)!;
+    expect(staleRow.state).toBe('dead-letter');
+    expect(staleRow.error_body).toMatch(/expired-stale/);
+    expect(staleRow.status_history).toMatch(/dead-letter/);
+    // The fresh row was processed normally on the same pass.
+    expect(deliveredIds).toContain(freshId);
+  });
+
+  it('flag OFF (default) preserves today\'s behavior byte-identical — the old row is still claimable', async () => {
+    const store = PendingRelayStore.open('echo', stateDir);
+    const staleId = '33333333-3333-4333-8333-333333333333';
+    enqueueAged(store, staleId, 8, 40 * DAY_MS, 'old but guard dark');
+
+    const postReply = vi.fn(async () => ({ status: 200, body: '{"ok":true}' }));
+    const sentinel = mkSentinel(store, postReply); // no l0AgeGuard config at all
+
+    await sentinel.tick();
+
+    const row = store.findByDeliveryId(staleId)!;
+    expect(row.state).not.toBe('dead-letter');
+  });
+
+  it('maxAgeMs 0 ⇒ no expiry even when enabled (the data-edit rollback sentinel)', async () => {
+    const store = PendingRelayStore.open('echo', stateDir);
+    const staleId = '44444444-4444-4444-8444-444444444444';
+    enqueueAged(store, staleId, 9, 40 * DAY_MS, 'old, zero-policy class');
+
+    const postReply = vi.fn(async () => ({ status: 200, body: '{"ok":true}' }));
+    const sentinel = mkSentinel(store, postReply, { enabled: true, maxAgeMs: 0 });
+
+    await sentinel.tick();
+
+    const row = store.findByDeliveryId(staleId)!;
+    expect(row.state).not.toBe('dead-letter');
+  });
+
+  it('emits ONE aggregated stale-retired event per pass (never per-message)', async () => {
+    const store = PendingRelayStore.open('echo', stateDir);
+    for (let i = 0; i < 4; i++) {
+      enqueueAged(store, `55555555-5555-4555-8555-55555555555${i}`, 100 + i, 40 * DAY_MS, `zombie ${i}`);
+    }
+    const postReply = vi.fn(async () => ({ status: 200, body: '{"ok":true}' }));
+    const sentinel = mkSentinel(store, postReply, { enabled: true, maxAgeMs: DAY_MS });
+    const events: Array<{ count: number }> = [];
+    sentinel.on('sentinel:stale-retired', (e) => events.push(e));
+
+    await sentinel.tick();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].count).toBe(4);
+    expect(postReply).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/outbound-queue-expiry-wiring.test.ts
+++ b/tests/unit/outbound-queue-expiry-wiring.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+
+/**
+ * Wiring-integrity test for the L0 age-guard policy resolution (second-pass
+ * review finding): AgentServer resolves the shipped policy JSON via
+ * `new URL('../../src/data/outbound-queue-expiry.json', import.meta.url)`.
+ * Plain tsc emits no JSON into dist/, so a dist-relative '../data/...' path
+ * would ENOENT on every deployed install and the armed guard would silently
+ * stay dark. This test pins the EXACT relative expression against BOTH
+ * runtime layouts (src/server for dev/tests, dist/server for deploys) so a
+ * future path or packaging change fails loudly here instead of in the field.
+ */
+
+const REL = '../../src/data/outbound-queue-expiry.json';
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+function resolveFrom(moduleFile: string): string {
+  return fileURLToPath(new URL(REL, pathToFileURL(moduleFile)));
+}
+
+describe('outbound-queue-expiry policy wiring', () => {
+  it('the AgentServer relative expression resolves to the shipped file from the src/server layout', () => {
+    const resolved = resolveFrom(path.join(repoRoot, 'src/server/AgentServer.ts'));
+    expect(fs.existsSync(resolved)).toBe(true);
+  });
+
+  it('the SAME expression resolves to the shipped file from the dist/server layout (deployed installs)', () => {
+    const resolved = resolveFrom(path.join(repoRoot, 'dist/server/AgentServer.js'));
+    expect(fs.existsSync(resolved)).toBe(true);
+    // Both layouts must land on the identical file — one policy source.
+    expect(resolved).toBe(resolveFrom(path.join(repoRoot, 'src/server/AgentServer.ts')));
+  });
+
+  it('AgentServer.ts actually uses this exact relative expression (no silent drift)', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'src/server/AgentServer.ts'), 'utf-8');
+    expect(source).toContain(`new URL('${REL}', import.meta.url)`);
+  });
+
+  it('the shipped policy parses and carries the delivery-recovery class with a numeric maxAgeHours', () => {
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, 'src/data/outbound-queue-expiry.json'), 'utf-8'),
+    ) as { schemaVersion: number; queues: Record<string, { maxAgeHours: number }> };
+    expect(parsed.schemaVersion).toBe(1);
+    expect(typeof parsed.queues['delivery-recovery'].maxAgeHours).toBe('number');
+    expect(parsed.queues['delivery-recovery'].maxAgeHours).toBeGreaterThan(0);
+  });
+});

--- a/upgrades/next/l0-delivery-age-guard.md
+++ b/upgrades/next/l0-delivery-age-guard.md
@@ -1,0 +1,33 @@
+---
+title: "Expired queued replies can never auto-deliver (L0 age guard, ships dark)"
+---
+
+## What Changed
+
+The DeliveryFailureSentinel's drain gains a dequeue-time age guard (L0 zombie-free delivery invariant,
+drive12 UX-first enforcement spec Increment 1): on every claimable pull, rows whose ORIGINAL send attempt
+(`attempted_at`) is older than the class policy retire to dead-letter with an audited `expired-stale`
+reason instead of ever reaching delivery, summarized in one coalesced low-priority Attention digest
+(≥6h apart). Policy: `src/data/outbound-queue-expiry.json` (delivery-recovery 24h; `0` ⇒ no expiry —
+the data-edit rollback). Armed per-install by top-level `outboundQueueExpiry.enabled` (DARK by default).
+Ancestor incident: 2026-07-24 — the #1600 recovery fix replayed weeks-old queued replies (including two
+expired secure links) into user topics as new.
+
+## What to Tell Your User
+
+Nothing changes yet — this ships switched off. Once switched on for an agent, a reply that failed to
+send and then sat queued for more than a day will no longer suddenly appear in your chat weeks later as
+if it were new; instead I keep a record of it and mention retired stale messages in one quiet summary.
+
+## Summary of New Capabilities
+
+- Dequeue-time age invariant on the delivery-recovery queue (no delivery path exists for an expired row).
+- Per-queue-class expiry policy data file with `0 ⇒ no expiry` rollback semantics.
+- `sentinel:stale-retired` event + coalesced operator digest (calm-alerting).
+
+## Evidence
+
+New integration suite `sentinel-l0-age-guard.test.ts` (4 tests: stale row retires + never delivers while
+a fresh row on the same pass delivers; dark default preserves today's behavior; `maxAgeMs 0` no-expiry
+rollback; one aggregated event per pass, never per-message). Existing sentinel + store suites green
+(35 tests).

--- a/upgrades/side-effects/l0-delivery-age-guard.eli16.md
+++ b/upgrades/side-effects/l0-delivery-age-guard.eli16.md
@@ -1,0 +1,41 @@
+# ELI16 — Old queued messages can no longer come back from the dead
+
+## What this actually is
+
+When a message the agent sends you fails to deliver (say, the server was restarting), it goes into a
+"try again later" queue. This morning we watched the failure mode that queue makes possible: a fix to
+the retry machinery suddenly made it deliver message from JUNE — weeks-old status updates and two
+expired secure links — into people's chats as if they were new. Nobody wants a reply to a question
+they asked six weeks ago showing up as if it were fresh.
+
+This change puts an expiry check at the exact moment a queued message is about to be picked up for
+delivery: if it's older than the allowed age for its queue (24 hours for this one), it is retired —
+marked as a dead letter with a written reason — instead of being sent. The operator gets one calm,
+batched notice ("N stale queued replies were retired, nothing was sent"), at most once every six
+hours, never a flood.
+
+## What already existed vs what's new
+
+Already existed: a cleanup that runs once at server startup, deleting very old queue entries. The gap:
+messages that become deliverable LATER — after startup, when some other fix or condition suddenly
+unblocks them (exactly what happened this morning) — never met any age check at all. New: the age
+check now runs at pick-up time, every time, so there is NO path from the queue to your chat for an
+expired message. The startup cleanup stays; this is the belt to its suspenders.
+
+## The safeguards, in plain terms
+
+- It ships OFF. Nothing changes for anyone until it's switched on per-machine, and the test agent
+  (Codey) goes first — the same "test → dev → everyone" ladder as every other feature.
+- Retired messages are never deleted — each keeps a written record of what it was and why it was
+  retired, so anything can be recovered by inspection.
+- The age limit lives in a small data file. Setting a queue's limit to 0 turns expiry off for that
+  queue without touching code — that's the designed emergency rollback, and the file is protected so
+  quietly flipping it to 0 can't happen without an operator-visible trail.
+- If the check itself ever fails, it fails toward doing nothing — normal delivery is never blocked by
+  a broken guard.
+- A message with an unreadable timestamp is treated as fresh, never guessed into the trash.
+
+## What you actually need to decide
+
+Nothing right now — it ships dark. When it arms on the test agent and soaks clean, the promotion to
+the dev agent and then the fleet follows the standard maturation ladder, each step reversible.

--- a/upgrades/side-effects/l0-delivery-age-guard.eli16.md
+++ b/upgrades/side-effects/l0-delivery-age-guard.eli16.md
@@ -39,3 +39,5 @@ expired message. The startup cleanup stays; this is the belt to its suspenders.
 
 Nothing right now — it ships dark. When it arms on the test agent and soaks clean, the promotion to
 the dev agent and then the fleet follows the standard maturation ladder, each step reversible.
+
+(Amend note: the two deliberate fail-safe catches carry @silent-fallback-ok annotations for the no-silent-fallbacks ratchet — no behavior change.)

--- a/upgrades/side-effects/l0-delivery-age-guard.md
+++ b/upgrades/side-effects/l0-delivery-age-guard.md
@@ -67,3 +67,6 @@ the exact expression against both layouts, asserts AgentServer.ts uses it verbat
 schema; (2) digest counters now clear (and the coalesce window stamps) ONLY on a confirmed 2xx — a failed,
 timed-out, or non-2xx post keeps accumulating for a later pass, matching the stated semantics; (3) the
 lockfile/toolchain install churn (pnpm-lock.yaml, pnpm-workspace.yaml) is excluded from the commit.
+
+### Amend note
+The two deliberate fail-safe catches now carry `@silent-fallback-ok` annotations (no-silent-fallbacks ratchet compliance) — no behavior change.

--- a/upgrades/side-effects/l0-delivery-age-guard.md
+++ b/upgrades/side-effects/l0-delivery-age-guard.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — L0 dequeue-time age guard on the delivery-recovery queue
+
+Change: the DeliveryFailureSentinel's drain gains the L0 zombie-free delivery invariant (drive12 UX-first
+enforcement spec, Increment 1): on EVERY claimable pull, rows older than the class policy retire to
+dead-letter (audited 'expired-stale' reason) instead of ever reaching processRow, with ONE coalesced
+Attention digest (≥6h apart). Policy = shipped data file (`src/data/outbound-queue-expiry.json`,
+delivery-recovery 24h; 0 ⇒ no expiry) armed by the per-install top-level `outboundQueueExpiry.enabled`
+flag (DARK by default; test agent arms first). Ancestor incident: 2026-07-24 zombie-replay — the #1600
+recovery fix drained weeks-old rows (incl. 2 expired secure links) into user topics as new.
+
+1. **Over-block** — The risk is retiring a message the user still wanted. Bounded three ways: the guard
+   only acts when ARMED (dark default); age basis is `attempted_at` (original failed send — a 24h-stale
+   reply is stale by any reading, and the class policy is a data edit); and a retired row is preserved as
+   an audited dead-letter, never deleted — recoverable by inspection. The digest tells the operator what
+   was retired and from which conversations.
+
+2. **Under-block** — Scope is deliberately ONE queue class (Increment 1): the main selectClaimable lane.
+   The reap-notify lane and other outbound queues join via the registry in Increment 2 (per the spec's
+   enumerated-queue-registry decision). Unparseable `attempted_at` is treated as FRESH (never guess-drop)
+   — a malformed row still rides the existing recovery policy (TTL/attempts escalation catches it).
+
+3. **Level-of-abstraction fit** — Correct layer per the converged spec's external-review finding: zombie
+   prevention belongs in the delivery MACHINERY (dequeue time), not in tests. The startup restore-purge
+   stays (different job: boot hygiene); this is the every-pass invariant that covers rows becoming
+   claimable long after boot — exactly the class the startup purge structurally misses.
+
+4. **Signal vs authority** — The guard holds deterministic authority over STALE rows only, with a
+   deterministic, self-service escape (data-file `0`, or disarm the flag) — the L9/L10 precedent class
+   (release-note lint). It never judges content; the tone gate's authority is untouched (fresh rows ride
+   the existing state machine unchanged). The digest is signal-only and best-effort.
+
+5. **Interactions** — Runs BEFORE stampede grouping and per-topic rate caps, so retired rows can no
+   longer trigger stampede digests (correct: they are not deliverable). The recovery-policy TTL
+   (escalation) still governs fresh rows; a row can now retire-by-age before it would have escalated —
+   dead-letter vs escalated is a deliberate narrowing (an escalation of a weeks-old row is exactly the
+   zombie-adjacent noise we're removing). transition() failures leave the row for the next pass but it
+   still never delivers THIS pass (it is excluded from the fresh set first).
+
+6. **External surfaces** — One new low-priority Attention item class (source `delivery-l0-age-guard`),
+   coalesced ≥6h; rides the existing single-Attention-hub routing (no new topics; the topic-creation
+   budget is untouched). No new route, no new network egress (digest posts to the local server only).
+
+7. **Multi-machine posture** — Machine-local BY DESIGN: each machine's sentinel drains its own SQLite
+   queue; the policy data file ships with the code (identical fleet-wide once deployed) and the arm flag
+   is per-install (the maturation ladder's unit). No replication needed; no cross-machine URL surface.
+
+8. **Rollback cost** — Three independent levers, cheapest first: (a) config: `outboundQueueExpiry.enabled`
+   false (per-install, next boot); (b) data edit: class `maxAgeHours: 0` (no expiry, no code revert) —
+   NOTE per the spec this file is protected-path class and a 0-flip on the shipped default requires an
+   operator label; (c) single-commit git revert. Retired rows are dead-letters with reasons — no data
+   migration either way.
+
+## Second-pass review
+
+**Concern raised: the armed path is dead-on-arrival in a built install — the policy data file is resolved at a path the build never populates.** `AgentServer` reads `new URL('../data/outbound-queue-expiry.json', import.meta.url)`, which from `dist/server/AgentServer.js` resolves to `dist/data/outbound-queue-expiry.json`. The build is plain `tsc`, which emits no JSON (verified: `dist/data/` contains zero `.json` even though `src/data/` ships four); the packaging convention for runtime-read shipped JSON is `<pkg>/src/data/...` (cf. `DEFAULT_MIRROR_PATH = 'src/data/benchmarkPredictions.json'`). So flipping `outboundQueueExpiry.enabled: true` on a deployed agent hits ENOENT → the catch keeps the guard dark with one boot warn — fail-SAFE as the artifact claims, but Increment 1's arming step (Codey arms first) silently cannot happen, and rollback lever (b) edits a file the deployed server never reads. Fix: resolve `../../src/data/...` (or the CapabilityMapper existsSync pattern) and add a wiring-integrity test for the AgentServer resolution path (the current integration test injects the policy directly and cannot catch this).
+
+Minor findings, non-blocking: (1) the digest's "accumulate and retry on a later pass" comment is not what the code does on network failure — the `error`/`timeout` handlers `resolve()` the promise, so `staleDigestPending`/`staleDigestTopics` are cleared and `lastStaleDigestAt` stamped even when nothing posted (a non-2xx also counts as success); only a synchronous `readConfig` throw reaches the catch. Counts are lost, not double-counted — and the retired rows remain audited dead-letters with the event + log line, so this is observability-only. (2) The working tree carries lockfile/toolchain churn unmentioned by the artifact (pnpm-lock.yaml ssh2/undici entries reconciling an out-of-sync committed package.json, new pnpm-workspace.yaml allowBuilds) — should be committed separately or acknowledged.
+
+Everything else concurs on independent trace: dark default holds at all three layers (DEFAULTS `enabled:false`, `=== true` flag check, `{}` passed when unarmed); no path retires or blocks a FRESH row (transition is only called on the stale partition, per-row try/catch, and `postStaleDigest` cannot reject — nothing between partition and `return fresh` can drop the fresh set); a `transition()` throw or `false` leaves the row queued for the next pass while still excluded from delivery THIS pass; unparseable `attempted_at` → fresh, riding the existing recovery policy; guard-before-stampede/rate-cap ordering is correct and the reap-notify bypass is structural (`selectClaimable` PK-range-excludes `reap-notify:` rows) and honestly scoped to Increment 2; signal-vs-authority is acceptable — a deterministic timestamp mechanic with a self-service escape on a safety class the doc explicitly exempts (irreversible-delivery guard, not a judgment over content); the constructor's second param was already optional, so existing callers are unaffected.
+
+### Concern resolution (author, same session)
+
+All three findings addressed before commit: (1) the policy path now resolves `'../../src/data/outbound-queue-expiry.json'`
+— correct from BOTH the src/server (dev/test) and dist/server (deployed) layouts per the DEFAULT_MIRROR_PATH
+packaging convention — and a new wiring-integrity suite (`outbound-queue-expiry-wiring.test.ts`, 4 tests) pins
+the exact expression against both layouts, asserts AgentServer.ts uses it verbatim, and validates the shipped
+schema; (2) digest counters now clear (and the coalesce window stamps) ONLY on a confirmed 2xx — a failed,
+timed-out, or non-2xx post keeps accumulating for a later pass, matching the stated semantics; (3) the
+lockfile/toolchain install churn (pnpm-lock.yaml, pnpm-workspace.yaml) is excluded from the commit.


### PR DESCRIPTION
## ELI16 — Old queued messages can no longer come back from the dead

When a message to the user fails to deliver, it waits in a retry queue. This morning we watched the failure that queue makes possible: a retry-machinery fix suddenly delivered messages from JUNE — weeks-old updates and two expired secure links — into chats as if they were new. This change puts an expiry check at the exact moment a queued message is about to be picked up: older than its queue's allowed age (24h here) means it is retired — marked dead with a written reason, never sent — and the operator gets one calm batched notice, at most every six hours.

It ships OFF; the test agent (Codey) arms it first. Retired messages are never deleted (each keeps an audit record). The age limit lives in a small data file where 0 means no-expiry — the designed data-edit rollback. If the check itself fails, it fails toward doing nothing: normal delivery is never blocked by a broken guard, and an unreadable timestamp counts as fresh, never guessed into the trash.

## Scope
- Dequeue-time age invariant in DeliveryFailureSentinel (runs before stampede/rate-cap logic; reap-notify lane joins via the Increment-2 registry).
- Policy data file src/data/outbound-queue-expiry.json + per-install arm flag outboundQueueExpiry.enabled (DARK default).
- sentinel:stale-retired event + coalesced digest (counters clear only on confirmed 2xx).

## Review
Second-pass review raised and resolved in-session: the policy path resolved under dist/ (never populated by tsc — armed guard would have been dead on every deployed install) — fixed to the src/data packaging convention with a 4-test wiring-integrity suite pinning both layouts. 8 new tests + 35 regression tests green.

Tier 1 (instar-dev): ELI16 + side-effects artifacts in upgrades/side-effects/. Increment 1 of the converged drive12 UX-first enforcement spec (L0 zombie-free delivery invariant); ancestor incident 2026-07-24 zombie-replay.