### PR TITLE
fix: better-sqlite3 self-heal fails forever when npm is a version-manager wrapper script (mise/asdf)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3536,8 +3536,9 @@ async function ensureSqliteBindings(): Promise<boolean> {
           'The agent is running but its knowledge graph, conversation summaries, and ' +
           'related sqlite-backed subsystems are offline. The most common cause is a ' +
           'Node upgrade landed after the server started. Restart the agent to pick up ' +
-          'the rebuilt binding; if rebuild itself keeps failing, run `npx instar update` ' +
-          'or reinstall the agent.',
+          'the rebuilt binding; if rebuild itself keeps failing, run ' +
+          '`npm rebuild better-sqlite3` in the instar install directory with the ' +
+          "server's Node first on PATH, or reinstall the agent.",
       });
       return false;
     }

--- a/src/data/pr-gate-artifacts.ts
+++ b/src/data/pr-gate-artifacts.ts
@@ -307,7 +307,7 @@ ls -la .github/workflows/instar-pr-gate.yml
 \`\`\`
 
 The file should be present and owned by the repo (not a symlink). If
-missing, run \`npx instar update\` to re-run \`PostUpdateMigrator\`.
+missing, run \`instar migrate\` to re-run \`PostUpdateMigrator\`.
 
 ## Step 2 — Set up repo secrets
 

--- a/src/lifeline/ServerSupervisor.ts
+++ b/src/lifeline/ServerSupervisor.ts
@@ -28,6 +28,7 @@ import { SlowRetrySentinelEscalation } from './SlowRetrySentinelEscalation.js';
 import { SleepWakeDetector } from '../core/SleepWakeDetector.js';
 import { cpuLoadRatio, DEFAULT_MAX_LOAD_RATIO } from '../core/cpuStarvation.js';
 import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
+import { resolveNpmInvocation } from '../utils/npmInvocation.js';
 import { SafeGitExecutor } from '../core/SafeGitExecutor.js';
 // Cross-process reader for the in-flight-sync-op marker mirror file (amplifier #2,
 // spec §A.5). Dependency-light (fs+path only) so the lifeline process never loads
@@ -948,10 +949,23 @@ export class ServerSupervisor extends EventEmitter {
             ['install', installSpec, '--no-save', '--prefix', copy.prefixDir],
             ['rebuild', '--build-from-source', '--ignore-scripts', 'better-sqlite3', '--prefix', copy.prefixDir],
           ];
+          // npm on disk is not always a JS entry point: version managers
+          // (mise, asdf) ship `bin/npm` as a bash wrapper, and
+          // `spawnSync(checkNode, [npmPath, ...])` then parses bash as JS and
+          // dies with a SyntaxError before npm ever runs — so the heal could
+          // NEVER succeed on those installs and re-restored the wrong-ABI
+          // binary on every boot (observed on ln 2026-07-24, mise-managed
+          // node). Resolve the real npm-cli.js (or fall back to executing npm
+          // directly under the pinned PATH) instead.
+          const npmInvocation = resolveNpmInvocation(npmPath, checkNode);
+          if (!npmInvocation) {
+            console.error('[Supervisor] Preflight: could not resolve an npm invocation — cannot rebuild better-sqlite3');
+            continue;
+          }
           let rebuilt = false;
           let lastErr = '';
           for (const args of attempts) {
-            const r = spawnSync(checkNode, [npmPath, ...args], {
+            const r = spawnSync(npmInvocation.command, [...npmInvocation.argsPrefix, ...args], {
               encoding: 'utf-8', timeout: 120_000, cwd: this.projectDir, env: rebuildEnv,
             });
             if (r.status === 0 && verifyLoadable()) { rebuilt = true; break; }

--- a/src/memory/NativeModuleHealer.ts
+++ b/src/memory/NativeModuleHealer.ts
@@ -40,6 +40,7 @@ import child_process, {
   type SpawnSyncReturns,
 } from 'node:child_process';
 import { createRequire } from 'node:module';
+import { resolveNpmInvocation } from '../utils/npmInvocation.js';
 
 const require = createRequire(import.meta.url);
 
@@ -441,15 +442,27 @@ class NativeModuleHealerImpl {
     // `--ignore-scripts` on the from-source fallback keeps it scoped (no arbitrary
     // postinstalls). The prebuilt attempt MUST run scripts (that is how
     // prebuild-install fetches the binary), so it is a plain `npm install`.
+    //
+    // npm on disk is not always a JS entry point: version managers (mise,
+    // asdf) ship `bin/npm` as a bash wrapper — `node <bash-script>` dies with
+    // a SyntaxError before npm ever runs. Resolve the real npm-cli.js first.
+    const npmInvocation = resolveNpmInvocation(npmPath, process.execPath);
+    if (!npmInvocation) {
+      event.errorTail = 'could not resolve an npm invocation';
+      console.error(`[${component}] NativeModuleHealer: ${event.errorTail}`);
+      this.logHealEvent(event);
+      this.lastResult = event;
+      return false;
+    }
     const attempts: string[][] = [
-      [npmPath, 'install', installSpec, '--no-save', '--prefix', installPrefix],
-      [npmPath, 'rebuild', '--build-from-source', '--ignore-scripts', 'better-sqlite3', '--prefix', installPrefix],
+      ['install', installSpec, '--no-save', '--prefix', installPrefix],
+      ['rebuild', '--build-from-source', '--ignore-scripts', 'better-sqlite3', '--prefix', installPrefix],
     ];
     let result: SpawnSyncReturns<string> | null = null;
     for (const args of attempts) {
       try {
         // Namespace access so tests can monkey-patch child_process.spawnSync.
-        result = child_process.spawnSync(process.execPath, args, {
+        result = child_process.spawnSync(npmInvocation.command, [...npmInvocation.argsPrefix, ...args], {
           encoding: 'utf-8',
           timeout: 120_000,
           cwd: installPrefix,
@@ -759,9 +772,21 @@ class NativeModuleHealerImpl {
       ).version as string) || '';
     } catch { /* version optional */ }
     const installSpec = pkgVersion ? `better-sqlite3@${pkgVersion}` : 'better-sqlite3';
+    // See healBetterSqlite3: never run `node <npm-bin>` — the bin may be a
+    // version-manager bash wrapper (mise/asdf); resolve the real npm-cli.js.
+    const npmInvocation = resolveNpmInvocation(npmPath, process.execPath);
+    if (!npmInvocation) {
+      event.errorTail = 'could not resolve an npm invocation';
+      this.logHealEvent(event);
+      this.lastResult = event;
+      return {
+        outcome: 'failure',
+        details: { reason: event.errorTail, attemptId: ctx.attemptId },
+      };
+    }
     const attempts: string[][] = [
-      [npmPath, 'install', installSpec, '--no-save', '--prefix', installPrefix],
-      [npmPath, 'rebuild', '--build-from-source', '--ignore-scripts', 'better-sqlite3', '--prefix', installPrefix],
+      ['install', installSpec, '--no-save', '--prefix', installPrefix],
+      ['rebuild', '--build-from-source', '--ignore-scripts', 'better-sqlite3', '--prefix', installPrefix],
     ];
     let result: SpawnSyncReturns<string> | null = null;
     let lastSpawnErr = '';
@@ -769,7 +794,7 @@ class NativeModuleHealerImpl {
       if (ctx.abortSignal.aborted) break;
       try {
         // Use namespace access so tests can monkey-patch `child_process.spawnSync`.
-        result = child_process.spawnSync(process.execPath, args, {
+        result = child_process.spawnSync(npmInvocation.command, [...npmInvocation.argsPrefix, ...args], {
           encoding: 'utf-8',
           timeout: timeoutMs,
           cwd: installPrefix,

--- a/src/utils/npmInvocation.ts
+++ b/src/utils/npmInvocation.ts
@@ -1,0 +1,140 @@
+/**
+ * npmInvocation — build a spawn argv that runs npm under a SPECIFIC Node binary.
+ *
+ * Background:
+ *   The better-sqlite3 self-heal paths (ServerSupervisor preflight,
+ *   NativeModuleHealer) must run npm under the SERVER's Node so the rebuilt
+ *   native module targets the correct ABI. They did this by spawning
+ *   `spawnSync(targetNode, [npmPath, ...args])` — i.e. executing the npm *bin*
+ *   file as a Node script.
+ *
+ *   That works when `bin/npm` is the standard symlink to
+ *   `lib/node_modules/npm/bin/npm-cli.js` (official tarballs, nvm, Homebrew).
+ *   But Node version managers like mise and asdf ship `bin/npm` as a BASH
+ *   WRAPPER script (mise's wraps npm to run `mise reshim` after global
+ *   installs). Node strips the shebang and parses the bash body as
+ *   JavaScript, so every heal attempt dies instantly with a SyntaxError:
+ *
+ *     SyntaxError: Unexpected identifier 'pipefail'
+ *         ...
+ *         at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
+ *
+ *   Observed live on ln 2026-07-24: every boot logged
+ *   "better-sqlite3 version mismatch — rebuilding" followed by
+ *   "rebuild could not produce a loadable module ... restored prior binary",
+ *   with the truncated lastErr tail `oad (node:internal/modules/cjs/loader:255:19)`
+ *   — the wrapper-script SyntaxError. The self-heal could never succeed and
+ *   re-restored the wrong-ABI binary on every boot.
+ *
+ * Strategy (mirrors findNpmCli() in src/commands/server.ts, generalized):
+ *   1. npm-cli.js relative to the TARGET Node's dir
+ *      (<nodeDir>/../lib/node_modules/npm/bin/npm-cli.js) — the npm that
+ *      ships WITH that Node, guaranteed version-compatible.
+ *   2. If the given npm path resolves (through symlinks) to a JS entry,
+ *      run that file under the target Node — the pre-existing behavior.
+ *   3. npm-cli.js relative to the given npm path's REAL directory
+ *      (<npmDir>/../lib/node_modules/npm/bin/npm-cli.js) — this is exactly
+ *      the file mise's bash wrapper delegates to.
+ *   4. Known global npm-cli.js locations.
+ *   5. Last resort: execute the npm binary DIRECTLY (its own shebang runs
+ *      it — bash wrappers and `#!/usr/bin/env node` entries both work).
+ *      Callers pin PATH so `env node` resolves the target Node; this keeps
+ *      the ABI correct in the common case and, unlike `node <bash-script>`,
+ *      can actually succeed.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface NpmInvocation {
+  /** The executable to spawn. */
+  command: string;
+  /** Args to place BEFORE the npm subcommand args (empty for direct exec). */
+  argsPrefix: string[];
+  /** Which resolution strategy produced this invocation (for logging/tests). */
+  source:
+    | 'node-sibling-npm-cli'
+    | 'npm-path-js-entry'
+    | 'npm-relative-npm-cli'
+    | 'global-npm-cli'
+    | 'direct-exec';
+}
+
+const GLOBAL_NPM_CLI_CANDIDATES = [
+  '/opt/homebrew/lib/node_modules/npm/bin/npm-cli.js',
+  '/usr/local/lib/node_modules/npm/bin/npm-cli.js',
+  '/usr/lib/node_modules/npm/bin/npm-cli.js',
+];
+
+function isJsEntry(p: string): boolean {
+  return p.endsWith('.js') || p.endsWith('.cjs') || p.endsWith('.mjs');
+}
+
+function npmCliRelativeTo(dir: string): string {
+  return path.resolve(dir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js');
+}
+
+/**
+ * Resolve how to invoke npm so it runs under `nodeBin`.
+ *
+ * @param npmPath  Path to an npm executable as found on disk (may be a
+ *                 symlink to npm-cli.js OR a version-manager bash wrapper),
+ *                 or null when the caller could not find one.
+ * @param nodeBin  The Node binary the rebuild must target (ABI authority).
+ * @param opts     Test seam: override the global npm-cli.js candidate list.
+ * @returns        The invocation, or null when npmPath is null and no
+ *                 npm-cli.js could be located near nodeBin.
+ */
+export function resolveNpmInvocation(
+  npmPath: string | null,
+  nodeBin: string,
+  opts?: { globalCandidates?: string[] }
+): NpmInvocation | null {
+  const globalCandidates = opts?.globalCandidates ?? GLOBAL_NPM_CLI_CANDIDATES;
+  // 1. The npm that ships with the target Node itself.
+  const nodeSiblingCli = npmCliRelativeTo(path.dirname(nodeBin));
+  if (fs.existsSync(nodeSiblingCli)) {
+    return { command: nodeBin, argsPrefix: [nodeSiblingCli], source: 'node-sibling-npm-cli' };
+  }
+  // Also honor a symlinked nodeBin (e.g. <stateDir>/bin/node -> real install).
+  try {
+    const realNodeDir = path.dirname(fs.realpathSync(nodeBin));
+    const realSiblingCli = npmCliRelativeTo(realNodeDir);
+    if (fs.existsSync(realSiblingCli)) {
+      return { command: nodeBin, argsPrefix: [realSiblingCli], source: 'node-sibling-npm-cli' };
+    }
+  } catch { /* nodeBin may not exist in tests — fall through */ }
+
+  if (npmPath) {
+    let realNpm = npmPath;
+    try {
+      realNpm = fs.realpathSync(npmPath);
+    } catch { /* keep the given path */ }
+
+    // 2. Standard layout: bin/npm is a symlink to npm-cli.js.
+    if (isJsEntry(realNpm)) {
+      return { command: nodeBin, argsPrefix: [realNpm], source: 'npm-path-js-entry' };
+    }
+
+    // 3. Version-manager wrapper layout: bin/npm is a shell script sitting
+    //    beside lib/node_modules/npm/bin/npm-cli.js (mise, asdf plugins).
+    const wrapperSiblingCli = npmCliRelativeTo(path.dirname(realNpm));
+    if (fs.existsSync(wrapperSiblingCli)) {
+      return { command: nodeBin, argsPrefix: [wrapperSiblingCli], source: 'npm-relative-npm-cli' };
+    }
+  }
+
+  // 4. Known global npm-cli.js locations.
+  for (const candidate of globalCandidates) {
+    if (fs.existsSync(candidate)) {
+      return { command: nodeBin, argsPrefix: [candidate], source: 'global-npm-cli' };
+    }
+  }
+
+  // 5. Execute npm directly — NEVER `node <non-JS file>`. The caller's pinned
+  //    PATH steers any `env node` / internal `node` call to the target Node.
+  if (npmPath) {
+    return { command: npmPath, argsPrefix: [], source: 'direct-exec' };
+  }
+  return null;
+}

--- a/tests/unit/npm-invocation.test.ts
+++ b/tests/unit/npm-invocation.test.ts
@@ -1,0 +1,141 @@
+/**
+ * npmInvocation — regression tests for the version-manager npm wrapper bug.
+ *
+ * The better-sqlite3 self-heal paths ran `spawnSync(node, [npmPath, ...])`,
+ * executing the npm bin file as a Node script. mise/asdf ship `bin/npm` as a
+ * BASH wrapper, so Node parsed bash as JS and every heal attempt died with a
+ * SyntaxError — the preflight then restored the wrong-ABI binary on every
+ * boot, forever (observed live 2026-07-24 on a mise-managed Linux box).
+ *
+ * resolveNpmInvocation must never produce a `node <non-JS file>` invocation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveNpmInvocation } from '../../src/utils/npmInvocation.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const NO_GLOBALS = { globalCandidates: [] as string[] };
+
+describe('resolveNpmInvocation', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'npm-invocation-test-'));
+  });
+
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/npm-invocation.test.ts:cleanup' }); } catch { /* cleanup */ }
+  });
+
+  /** Build <root>/bin + <root>/lib/node_modules/npm/bin/npm-cli.js */
+  function makeNodeInstall(root: string, opts: { npmBin?: 'symlink' | 'bash-wrapper' | 'none' } = {}): {
+    nodeBin: string; npmBin: string; npmCli: string;
+  } {
+    const binDir = path.join(root, 'bin');
+    const cliDir = path.join(root, 'lib', 'node_modules', 'npm', 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(cliDir, { recursive: true });
+    const nodeBin = path.join(binDir, 'node');
+    fs.writeFileSync(nodeBin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const npmCli = path.join(cliDir, 'npm-cli.js');
+    fs.writeFileSync(npmCli, '// npm cli entry\n');
+    const npmBin = path.join(binDir, 'npm');
+    if (opts.npmBin === 'symlink') {
+      fs.symlinkSync(path.relative(binDir, npmCli), npmBin);
+    } else if (opts.npmBin === 'bash-wrapper') {
+      // Mirrors mise's real wrapper: a bash script that delegates to npm-cli.js.
+      fs.writeFileSync(npmBin, '#!/usr/bin/env bash\nset -euo pipefail\nexec node "$(dirname "$0")/../lib/node_modules/npm/bin/npm-cli.js" "$@"\n', { mode: 0o755 });
+    }
+    return { nodeBin, npmBin, npmCli };
+  }
+
+  it('prefers the npm-cli.js that ships with the target node', () => {
+    const install = makeNodeInstall(path.join(tmp, 'node-a'), { npmBin: 'bash-wrapper' });
+    const inv = resolveNpmInvocation(install.npmBin, install.nodeBin, NO_GLOBALS);
+    expect(inv).not.toBeNull();
+    expect(inv!.command).toBe(install.nodeBin);
+    expect(inv!.argsPrefix).toEqual([install.npmCli]);
+    expect(inv!.source).toBe('node-sibling-npm-cli');
+  });
+
+  it('resolves a symlinked bin/npm to its npm-cli.js target (standard layout)', () => {
+    // node has NO sibling npm-cli (bare node dir) — npm lives elsewhere.
+    const bareNodeDir = path.join(tmp, 'bare-node', 'bin');
+    fs.mkdirSync(bareNodeDir, { recursive: true });
+    const nodeBin = path.join(bareNodeDir, 'node');
+    fs.writeFileSync(nodeBin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+    const install = makeNodeInstall(path.join(tmp, 'npm-home'), { npmBin: 'symlink' });
+    const inv = resolveNpmInvocation(install.npmBin, nodeBin, NO_GLOBALS);
+    expect(inv).not.toBeNull();
+    expect(inv!.command).toBe(nodeBin);
+    // realpath of the symlink IS npm-cli.js
+    expect(inv!.argsPrefix).toEqual([fs.realpathSync(install.npmBin)]);
+    expect(inv!.source).toBe('npm-path-js-entry');
+  });
+
+  it('NEVER runs a bash-wrapper npm under node — resolves the sibling npm-cli.js instead (mise/asdf layout)', () => {
+    const bareNodeDir = path.join(tmp, 'bare-node', 'bin');
+    fs.mkdirSync(bareNodeDir, { recursive: true });
+    const nodeBin = path.join(bareNodeDir, 'node');
+    fs.writeFileSync(nodeBin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+    const install = makeNodeInstall(path.join(tmp, 'mise-node'), { npmBin: 'bash-wrapper' });
+    const inv = resolveNpmInvocation(install.npmBin, nodeBin, NO_GLOBALS);
+    expect(inv).not.toBeNull();
+    expect(inv!.command).toBe(nodeBin);
+    expect(inv!.argsPrefix).toEqual([install.npmCli]);
+    expect(inv!.source).toBe('npm-relative-npm-cli');
+  });
+
+  it('falls back to executing npm DIRECTLY when no npm-cli.js is locatable (never node <bash-script>)', () => {
+    const bareNodeDir = path.join(tmp, 'bare-node', 'bin');
+    fs.mkdirSync(bareNodeDir, { recursive: true });
+    const nodeBin = path.join(bareNodeDir, 'node');
+    fs.writeFileSync(nodeBin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+    // A lone shim with no lib/node_modules/npm anywhere near it (asdf shims dir).
+    const shimDir = path.join(tmp, 'shims');
+    fs.mkdirSync(shimDir, { recursive: true });
+    const shim = path.join(shimDir, 'npm');
+    fs.writeFileSync(shim, '#!/usr/bin/env bash\nexec asdf exec npm "$@"\n', { mode: 0o755 });
+
+    const inv = resolveNpmInvocation(shim, nodeBin, NO_GLOBALS);
+    expect(inv).not.toBeNull();
+    expect(inv!.source).toBe('direct-exec');
+    expect(inv!.command).toBe(shim);
+    expect(inv!.argsPrefix).toEqual([]);
+    // The load-bearing invariant: the command node executes must never be a
+    // non-JS file. Here node is not involved at all.
+    expect(inv!.command).not.toBe(nodeBin);
+  });
+
+  it('uses a provided global npm-cli.js candidate when nothing else resolves', () => {
+    const bareNodeDir = path.join(tmp, 'bare-node', 'bin');
+    fs.mkdirSync(bareNodeDir, { recursive: true });
+    const nodeBin = path.join(bareNodeDir, 'node');
+    fs.writeFileSync(nodeBin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+    const globalCli = path.join(tmp, 'global', 'npm-cli.js');
+    fs.mkdirSync(path.dirname(globalCli), { recursive: true });
+    fs.writeFileSync(globalCli, '// npm cli\n');
+
+    const inv = resolveNpmInvocation(null, nodeBin, { globalCandidates: [globalCli] });
+    expect(inv).not.toBeNull();
+    expect(inv!.command).toBe(nodeBin);
+    expect(inv!.argsPrefix).toEqual([globalCli]);
+    expect(inv!.source).toBe('global-npm-cli');
+  });
+
+  it('returns null when npmPath is null and nothing is locatable', () => {
+    const bareNodeDir = path.join(tmp, 'bare-node', 'bin');
+    fs.mkdirSync(bareNodeDir, { recursive: true });
+    const nodeBin = path.join(bareNodeDir, 'node');
+    fs.writeFileSync(nodeBin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+    expect(resolveNpmInvocation(null, nodeBin, NO_GLOBALS)).toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

The better-sqlite3 rebuild paths — the `ServerSupervisor` preflight and both `NativeModuleHealer` rebuild surfaces — run npm as:

```ts
spawnSync(targetNode, [npmPath, ...args])
```

i.e. they execute the npm **bin file as a Node script**. That works when `bin/npm` is the standard symlink to `npm-cli.js` (official tarballs, nvm, Homebrew). But **mise** and **asdf** ship `bin/npm` as a **bash wrapper** (mise's wraps npm to run `mise reshim` after global installs). Node strips the shebang, parses the bash body as JavaScript, and every heal attempt dies instantly:

```
SyntaxError: Unexpected identifier
    ...
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
```

## Observed live (2026-07-24, mise-managed Arch Linux box)

An auto-update landed a wrong-ABI `better_sqlite3.node` (ABI 141 vs the agent's node 24 / ABI 137). Every boot then logged:

```
[Supervisor] Preflight: better-sqlite3 version mismatch at .../shadow-install/node_modules/better-sqlite3 — rebuilding (server node: .../bin/node)
[Supervisor] Preflight: better-sqlite3 rebuild could not produce a loadable module at ... — restored prior binary (sqlite stays degraded, not bricked): oad (node:internal/modules/cjs/loader:255:19)
```

That clipped `lastErr` tail is the wrapper-script SyntaxError. Because **both** rebuild attempts fail the same way before npm even starts, the no-brick logic faithfully restores the wrong-ABI binary — on every boot, forever. SQLite subsystems (durable relay queue, knowledge graph, delivery sentinel, ApprenticeshipCycleStore) stay degraded until an operator runs `npm rebuild better-sqlite3` by hand. The degradation's own recovery hint made this worse — see below.

## The fix

New shared `resolveNpmInvocation()` in `src/utils/npmInvocation.ts` — the same idea as the existing `findNpmCli()` in `src/commands/server.ts` (which already got this right), generalized and applied to the three `node <npm-bin>` callsites:

1. `npm-cli.js` shipped **with the target node** (`<nodeDir>/../lib/node_modules/npm/bin/npm-cli.js`) — version-coherent with the ABI authority;
2. the given npm path when it (or its realpath) is a JS entry — pre-existing behavior, unchanged for standard layouts;
3. `npm-cli.js` **beside the wrapper** (`<npmDir>/../lib/node_modules/npm/bin/npm-cli.js`) — exactly the file mise's wrapper delegates to;
4. known global `npm-cli.js` locations;
5. last resort: execute npm **directly** (its own shebang runs it; callers already pin `PATH` so `env node` resolves the target node) — never `node <bash-script>`.

Verified against the real mise layout: the resolver returns `agent-node + .../lib/node_modules/npm/bin/npm-cli.js`, which is exactly the invocation that fixed the box manually.

## Also fixed: unactionable recovery guidance

Two places tell the operator to run `npx instar update`, which is not a command (`error: unknown command 'update'`):

- the sqlite-degradation impact message in `src/commands/server.ts` → now suggests `npm rebuild better-sqlite3` with the server's node first on PATH, or reinstalling the agent;
- the PR-gate runbook artifact in `src/data/pr-gate-artifacts.ts` → now says `instar migrate` (which actually re-runs `PostUpdateMigrator`).

## Tests

- New `tests/unit/npm-invocation.test.ts` (6 tests): standard symlink layout, mise-style bash-wrapper layout, bare-shim fallback (asdf shims dir), global-candidate path, and both null-input cases. The load-bearing invariant asserted throughout: **node is never handed a non-JS file**.
- Existing suites for the touched modules pass unchanged (`server-supervisor-preflight`, all three `NativeModuleHealer` suites — 50 tests; they mock `spawnSync`, so the invocation swap is transparent to them).
- `npm run lint` clean, `tsc --noEmit` clean.

## Follow-up observation (not in this PR)

The from-source fallback `npm rebuild --build-from-source --ignore-scripts better-sqlite3` is a no-op for better-sqlite3: its compile IS its `install` script (`prebuild-install || node-gyp rebuild`), so with `--ignore-scripts` npm rebuilds nothing and exits 0. The supervisor's `verifyLoadable()` catches this, but `NativeModuleHealer.healBetterSqlite3()` treats the exit-0 no-op as success. Left untouched here since `--ignore-scripts` is a documented supply-chain decision (SELF-HEALING-REMEDIATOR-V3 §A45) — flagging it in case you want a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)