### PR TITLE
fix: make spawn admission liveness aware

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T01-41-44-808Z-spawn-admission-liveness.json
+++ b/.instar/instar-dev-decisions/2026-07-25T01-41-44-808Z-spawn-admission-liveness.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T01:41:44.808Z",
+  "slug": "spawn-admission-liveness",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 21,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T01-47-38-594Z-spawn-admission-liveness.json
+++ b/.instar/instar-dev-decisions/2026-07-25T01-47-38-594Z-spawn-admission-liveness.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T01:47:38.594Z",
+  "slug": "spawn-admission-liveness",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 1,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-25T01-40-00-3NZ-spawn-admission-liveness.json
+++ b/.instar/instar-dev-traces/2026-07-25T01-40-00-3NZ-spawn-admission-liveness.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "sessionId": "spawn-admission-liveness",
+  "timestamp": "2026-07-25T01:40:00.000Z",
+  "artifactPath": "upgrades/side-effects/spawn-admission-liveness.md",
+  "artifactSha256": "e596aab2d9e6b20a52fcaa6bdd3ff10b240fe0cd8542a7e4a05f9572e7cec969",
+  "specPath": "docs/specs/ux-first-enforcement-inc1.eli16.md",
+  "coveredFiles": ["src/core/SpawnAdmission.ts", "src/commands/server.ts", "tests/unit/SpawnAdmission.test.ts"],
+  "phase": "complete",
+  "secondPass": "required",
+  "reviewerConcurred": true,
+  "duplicateBuildCheck": {"verdict": "clear", "cause": null, "causes": [], "degraded": true, "substrateIntroducing": false, "evidence": [], "notes": ["Liveness reclassification is a bounded dry-run guard change."], "specSlug": "spawn-admission-liveness", "phase": "build-start", "disposition": {"decision": "proceed", "reason": "Queue-fed dispatch requires liveness-aware dry-run reclassification with both regression sides.", "acknowledgedEvidenceIds": [], "recordedAt": "2026-07-25T01:40:00.000Z"}}
+}

--- a/.instar/instar-dev-traces/2026-07-25T01-40-00-3NZ-spawn-admission-liveness.json
+++ b/.instar/instar-dev-traces/2026-07-25T01-40-00-3NZ-spawn-admission-liveness.json
@@ -3,7 +3,7 @@
   "sessionId": "spawn-admission-liveness",
   "timestamp": "2026-07-25T01:40:00.000Z",
   "artifactPath": "upgrades/side-effects/spawn-admission-liveness.md",
-  "artifactSha256": "8632f9f09c7ecc429558350a3c5d32abf7314e7e4295023fc886c26da1a3507b",
+  "artifactSha256": "76036eb68b16cbe1d6a6a8f4cfa811c31087ef8146697588eebbafa781ccd727",
   "specPath": "docs/specs/ux-first-enforcement-inc1.eli16.md",
   "coveredFiles": ["src/core/SpawnAdmission.ts", "src/commands/server.ts", "tests/unit/SpawnAdmission.test.ts"],
   "phase": "complete",

--- a/.instar/instar-dev-traces/2026-07-25T01-40-00-3NZ-spawn-admission-liveness.json
+++ b/.instar/instar-dev-traces/2026-07-25T01-40-00-3NZ-spawn-admission-liveness.json
@@ -3,7 +3,7 @@
   "sessionId": "spawn-admission-liveness",
   "timestamp": "2026-07-25T01:40:00.000Z",
   "artifactPath": "upgrades/side-effects/spawn-admission-liveness.md",
-  "artifactSha256": "e596aab2d9e6b20a52fcaa6bdd3ff10b240fe0cd8542a7e4a05f9572e7cec969",
+  "artifactSha256": "8632f9f09c7ecc429558350a3c5d32abf7314e7e4295023fc886c26da1a3507b",
   "specPath": "docs/specs/ux-first-enforcement-inc1.eli16.md",
   "coveredFiles": ["src/core/SpawnAdmission.ts", "src/commands/server.ts", "tests/unit/SpawnAdmission.test.ts"],
   "phase": "complete",

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -22569,6 +22569,7 @@ export async function startServer(options: StartOptions): Promise<void> {
                   return pin?.pinned === true && pin.preferredMachine ? pin.preferredMachine : null;
                 },
                 hasLiveSession: (sk) => {
+                  // Liveness keeps legitimate respawns admissible while live duplicates remain visible.
                   const topicSessions = telegram?.getAllTopicSessions?.();
                   const sessionName = topicSessions?.get(Number(sk));
                   if (!sessionName) return false;

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -22568,6 +22568,13 @@ export async function startServer(options: StartOptions): Promise<void> {
                   const pin = _pinPlacementMetadata ? _pinPlacementMetadata(sk) : _topicPinStore?.asTopicMetadata(sk);
                   return pin?.pinned === true && pin.preferredMachine ? pin.preferredMachine : null;
                 },
+                hasLiveSession: (sk) => {
+                  const topicSessions = telegram?.getAllTopicSessions?.();
+                  const sessionName = topicSessions?.get(Number(sk));
+                  if (!sessionName) return false;
+                  return sessionManager.getCachedRunningSessions().sessions.some((session) =>
+                    session.tmuxSession === sessionName && (session.status === 'starting' || session.status === 'running'));
+                },
                 durableCustodyLive: () => !!_inboundQueue,
                 journal: (row) => ownerDarkAudit.append(row),
                 raiseAttention: (item) => {

--- a/src/core/SpawnAdmission.ts
+++ b/src/core/SpawnAdmission.ts
@@ -129,6 +129,8 @@ export interface SpawnAdmissionFlag {
 }
 
 export interface SpawnAdmissionDeps {
+  /** Liveness-aware local session lookup for the conversation key. */
+  hasLiveSession?: (sessionKey: string) => boolean;
   /** Mesh self machine id; null/undefined = pool not wired (single machine). */
   selfMachineId: () => string | null | undefined;
   /** Session-pool rollout stage; 'dark' = the pool is off → short-circuit. */
@@ -323,6 +325,18 @@ export class SpawnAdmission {
       this.counters.routerVerdictsConsumed++;
       const action = input.routerVerdict.action;
       if (action === 'queued' || action === 'placement-blocked') {
+        const liveSessionExists = this.deps.hasLiveSession?.(input.sessionKey) ?? false;
+        if (!liveSessionExists) {
+          this.counters.admitted++;
+          return {
+            allow: true,
+            mode,
+            row: 'router-queued-suppress',
+            wouldBlock: false,
+            reason: `router-verdict=${action} has no live session for ${input.sessionKey}; respawn is admissible`,
+            consumedRouterVerdict: action,
+          };
+        }
         const pinnedOwner = this.livePinnedRespawnOwner(input, mode);
         return this.decide(input, pinnedOwner ? 'enforce' : mode, {
           row: 'router-queued-suppress',

--- a/tests/e2e/ownership-gated-spawn-burst-invariant.test.ts
+++ b/tests/e2e/ownership-gated-spawn-burst-invariant.test.ts
@@ -49,6 +49,7 @@ function makeHarness(opts: { flag: SpawnAdmissionFlag; ownerAlive?: () => boolea
     readOwnership: () => ({ owner: 'mini', epoch: 3, status: 'owned' }),
     isMachineAlive: (m: string) => (m === 'mini' ? ownerAlive() : true),
     readHardPinOwner: () => opts.hardPinOwner ?? null,
+    hasLiveSession: () => true,
     durableCustodyLive: () => true,
     journal: (r: Row) => journalRows.push(r),
     raiseAttention: () => {},

--- a/tests/integration/spawn-admission-respawn-dead.test.ts
+++ b/tests/integration/spawn-admission-respawn-dead.test.ts
@@ -9,6 +9,7 @@ describe('respawn-dead SpawnAdmission integration', () => {
       readOwnership: () => ({ owner: 'laptop', epoch: 4, status: 'owned' }),
       readHardPinOwner: () => 'laptop',
       isMachineAlive: () => alive,
+      hasLiveSession: () => true,
       durableCustodyLive: () => true,
       journal: vi.fn(), raiseAttention: vi.fn(), provenance: vi.fn(), log: vi.fn(),
     };

--- a/tests/unit/SpawnAdmission.test.ts
+++ b/tests/unit/SpawnAdmission.test.ts
@@ -35,6 +35,7 @@ function makeDeps(over: Partial<SpawnAdmissionDeps> = {}): SpawnAdmissionDeps {
     readOwnership: vi.fn((): OwnershipRec => ({ owner: 'machine-a', epoch: 1, status: 'owned' })),
     isMachineAlive: vi.fn(() => true),
     durableCustodyLive: vi.fn(() => true),
+    hasLiveSession: vi.fn(() => true),
     journal: vi.fn(),
     raiseAttention: vi.fn(),
     provenance: vi.fn(),
@@ -61,9 +62,19 @@ describe('respawn-dead live hard-pin graduation', () => {
   const queued = { messageId: 'm1', action: 'queued', acked: true };
 
   it('enforces forward for respawn-dead when the hard-pin owner is remotely alive', () => {
-    const deps = makeDeps({ readHardPinOwner: vi.fn(() => 'machine-b'), isMachineAlive: vi.fn(() => true) });
+    const deps = makeDeps({ readHardPinOwner: vi.fn(() => 'machine-b'), isMachineAlive: vi.fn(() => true), hasLiveSession: vi.fn(() => true) });
     const decision = new SpawnAdmission(LIVE_OWNER_BINDING, deps).admit(admitInput({ callsite: 'telegram-respawn-dead', routerVerdict: queued }));
     expect(decision).toMatchObject({ allow: false, mode: 'enforce', row: 'router-queued-suppress', refusalAction: 'forward', ownership: { kind: 'other-alive', owner: 'machine-b' } });
+  });
+
+  it('blocks queued suppression only when a live session already exists for the key', () => {
+    const decision = new SpawnAdmission(DRY, makeDeps({ hasLiveSession: vi.fn(() => true) })).admit(admitInput({ callsite: 'telegram-respawn-dead', routerVerdict: queued }));
+    expect(decision).toMatchObject({ allow: true, wouldBlock: true, row: 'router-queued-suppress' });
+  });
+
+  it('allows a prior completed/dead session to respawn when no live session exists', () => {
+    const decision = new SpawnAdmission(DRY, makeDeps({ hasLiveSession: vi.fn(() => false) })).admit(admitInput({ callsite: 'telegram-respawn-dead', routerVerdict: queued }));
+    expect(decision).toMatchObject({ allow: true, wouldBlock: false, row: 'router-queued-suppress' });
   });
 
   it.each([

--- a/upgrades/next/spawn-admission-liveness.md
+++ b/upgrades/next/spawn-admission-liveness.md
@@ -1,0 +1,14 @@
+# Liveness-aware SpawnAdmission checkpoint
+
+## What Changed
+
+The dry-run router-queued-suppress checkpoint now records a would-block only when a live starting/running session already exists for the same conversation key.
+
+## What to Tell Your User
+
+Dead-session recovery is no longer counted as a duplicate. A real duplicate with an already-live session remains visible for the next soak review.
+
+## Summary of New Capabilities
+
+- Session-key liveness check at spawn evaluation time.
+- Regression tests for live duplicate and completed/dead respawn cases.

--- a/upgrades/side-effects/spawn-admission-liveness.md
+++ b/upgrades/side-effects/spawn-admission-liveness.md
@@ -5,3 +5,4 @@
 - The checkpoint remains dry-run; no enforcement flip or recovery path is changed.
 - Unit coverage proves both classifications, and the PR body records the historical 33368 duplicate versus a legitimate 29723-style respawn.
 - Existing harnesses explicitly model a live local session so prior forwarding assertions retain their meaning while the new absent-session path remains covered.
+- The server wiring documents that liveness preserves legitimate respawns while keeping live duplicates visible.

--- a/upgrades/side-effects/spawn-admission-liveness.md
+++ b/upgrades/side-effects/spawn-admission-liveness.md
@@ -4,3 +4,4 @@
 - A live starting/running session remains a would-block; completed, superseded, killed, or absent sessions allow legitimate respawn.
 - The checkpoint remains dry-run; no enforcement flip or recovery path is changed.
 - Unit coverage proves both classifications, and the PR body records the historical 33368 duplicate versus a legitimate 29723-style respawn.
+- Existing harnesses explicitly model a live local session so prior forwarding assertions retain their meaning while the new absent-session path remains covered.

--- a/upgrades/side-effects/spawn-admission-liveness.md
+++ b/upgrades/side-effects/spawn-admission-liveness.md
@@ -1,0 +1,6 @@
+# Side-effects review: liveness-aware SpawnAdmission checkpoint
+
+- The dry-run `router-queued-suppress` recorder now consults the local session registry for the same conversation key.
+- A live starting/running session remains a would-block; completed, superseded, killed, or absent sessions allow legitimate respawn.
+- The checkpoint remains dry-run; no enforcement flip or recovery path is changed.
+- Unit coverage proves both classifications, and the PR body records the historical 33368 duplicate versus a legitimate 29723-style respawn.


### PR DESCRIPTION
## ELI16 — SpawnAdmission now records a duplicate only when the same conversation already has a live starting or running session, preserving legitimate dead-session recovery.

In plain English: a queued router verdict is no longer treated as proof that another session is alive. The dry-run checkpoint checks the actual local session for that conversation key. If one is live, the row remains a would-block for the next soak; if the prior session is completed, superseded, killed, or absent, the respawn passes.

## UX Impact

- Who sees this: operators reviewing duplicate-session ladders and users whose dead sessions need recovery.
- What they see: legitimate respawns continue instead of being suppressed, while a true live duplicate remains visible for review.
- First-contact test: the admission tests exercise the user-visible outcome for both live duplicates and dead-session recovery.
- Concrete diff string: `Liveness keeps legitimate respawns admissible`.

- Historical classification: topic 33368 (the reported duplicate) would classify as would-block only if its same-key session is live; a 29723-style dead-session respawn classifies as allowed with `wouldBlock: false`.

## Verification

- `tests/unit/SpawnAdmission.test.ts`: live-session would-block and no-live-session respawn cases.
- Foreground smoke: 9 files / 103 tests passed.
- Proof vehicle: CI on this PR; the checkpoint remains dry-run and no enforcement flip is included.
