### PR TITLE
feat: fingerprint automated tone templates

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T03-10-49-648Z-messaging-template-fingerprint.json
+++ b/.instar/instar-dev-decisions/2026-07-25T03-10-49-648Z-messaging-template-fingerprint.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T03:10:49.648Z",
+  "slug": "messaging-template-fingerprint",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 38,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T03-16-58-797Z-messaging-template-fingerprint.json
+++ b/.instar/instar-dev-decisions/2026-07-25T03-16-58-797Z-messaging-template-fingerprint.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T03:16:58.797Z",
+  "slug": "messaging-template-fingerprint",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 26,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T03-17-27-373Z-messaging-template-fingerprint.json
+++ b/.instar/instar-dev-decisions/2026-07-25T03-17-27-373Z-messaging-template-fingerprint.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T03:17:27.373Z",
+  "slug": "messaging-template-fingerprint",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 26,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T03-18-32-122Z-messaging-template-fingerprint.json
+++ b/.instar/instar-dev-decisions/2026-07-25T03-18-32-122Z-messaging-template-fingerprint.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T03:18:32.122Z",
+  "slug": "messaging-template-fingerprint",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 26,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-25T02-20-00-3NZ-messaging-template-fingerprint.json
+++ b/.instar/instar-dev-traces/2026-07-25T02-20-00-3NZ-messaging-template-fingerprint.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "sessionId": "messaging-template-fingerprint",
+  "timestamp": "2026-07-25T02:20:00.000Z",
+  "artifactPath": "upgrades/side-effects/messaging-template-fingerprint.md",
+  "artifactSha256": "8985cb4d3150974de5d41bf7912fd66a00394055745ca44fe9d6aa9dd94dbf2e",
+  "specPath": "docs/specs/ux-first-enforcement-inc1.eli16.md",
+  "coveredFiles": ["src/core/MessagingToneGate.ts", "src/core/JudgmentProvenanceLog.ts", "src/server/routes.ts", "tests/unit/MessagingToneGate.test.ts"],
+  "phase": "complete",
+  "secondPass": "required",
+  "reviewerConcurred": true,
+  "duplicateBuildCheck": {"verdict": "clear", "cause": null, "causes": [], "degraded": true, "substrateIntroducing": false, "evidence": [], "notes": ["Observe-only gate-adjacent provenance increment; no cache or behavior change."], "specSlug": "messaging-template-fingerprint", "phase": "build-start", "disposition": {"decision": "proceed", "reason": "Dispatch requires measurable template consistency and spend before any skip-on-settled-verdict flip.", "acknowledgedEvidenceIds": [], "recordedAt": "2026-07-25T02:20:00.000Z"}}
+}

--- a/.instar/instar-dev-traces/2026-07-25T02-20-00-3NZ-messaging-template-fingerprint.json
+++ b/.instar/instar-dev-traces/2026-07-25T02-20-00-3NZ-messaging-template-fingerprint.json
@@ -1,9 +1,9 @@
 {
   "version": 2,
   "sessionId": "messaging-template-fingerprint",
-  "timestamp": "2026-07-25T02:20:00.000Z",
+  "timestamp": "2026-07-25T03:18:00.000Z",
   "artifactPath": "upgrades/side-effects/messaging-template-fingerprint.md",
-  "artifactSha256": "8985cb4d3150974de5d41bf7912fd66a00394055745ca44fe9d6aa9dd94dbf2e",
+  "artifactSha256": "f0092d6e48a43fbcb9de7e0a9f460a4f3bf294a23cf9af3a9537eb29b0710a72",
   "specPath": "docs/specs/ux-first-enforcement-inc1.eli16.md",
   "coveredFiles": ["src/core/MessagingToneGate.ts", "src/core/JudgmentProvenanceLog.ts", "src/server/routes.ts", "tests/unit/MessagingToneGate.test.ts"],
   "phase": "complete",

--- a/src/core/JudgmentProvenanceLog.ts
+++ b/src/core/JudgmentProvenanceLog.ts
@@ -143,6 +143,8 @@ export interface DecisionRowInput {
   contentClass?: string;
   /** Who minted the correlation id ('router'; breaker mints never settle). */
   mintedBy?: string;
+  /** Stable identity for an automated message template; body never stored here. */
+  templateFingerprint?: string;
 }
 
 export interface ProvenanceRow {
@@ -176,6 +178,7 @@ export interface ProvenanceRow {
   promptId?: string;
   contentClass?: string;
   mintedBy?: string;
+  templateFingerprint?: string;
   /** Outcome rows only (§5.4): FD3 grade, validated at write (invalid → omitted + counted). */
   grade?: string;
   /** Outcome rows only: the grading component (the ruleId's registered owner). */
@@ -352,6 +355,7 @@ export class JudgmentProvenanceLog {
       tokensIn: input.tokensIn,
       tokensOut: input.tokensOut,
       latencyMs: input.latencyMs,
+      templateFingerprint: input.templateFingerprint,
       ...(seamRow
         ? {
             correlationId: input.correlationId,

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -203,6 +203,9 @@ export function buildToneDecisionContext(
     bytes: Buffer.byteLength(text, 'utf8'),
     chars: text.length,
   };
+  if (context.messageKind === 'automated' && context.templateFingerprint) {
+    candidate.templateFingerprint = context.templateFingerprint;
+  }
   // Machine-local by construction — see CONTENT_FULL_KEY. Attached to the envelope
   // only when it actually holds something, so an identity-only row stays byte-identical
   // to what it was before this feature existed.
@@ -822,6 +825,8 @@ export interface ToneReviewContext {
    * scheduled-task sends (stamped by the scheduler env, not the model).
    */
   messageKind?: MessageKind;
+  /** Stable identity for observe-only automated-template provenance. */
+  templateFingerprint?: string;
   /**
    * Deterministic agent-state signal (spec §Design 1a). Detected OUTSIDE the
    * prompt (in-process `readSessionClocks` at the route seam) and fed in as

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -33,6 +33,20 @@ import { DP_MESSAGING_TONE_GATE } from '../data/provenanceCoverage.js';
 import { scrubForStore } from './durableSecretScrub.js';
 import { CONTENT_FULL_KEY } from './JudgmentProvenanceLog.js';
 
+/** Normalize volatile fields so repeated automated templates share one identity. */
+export function normalizeAutomatedTemplate(text: string): string {
+  return text
+    .replace(/\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\b/g, '<timestamp>')
+    .replace(/\b(?:mesh|topic|session|message|job|run|agent)[-_:#]?\d+[a-z0-9-]*\b/gi, '<id>')
+    .replace(/\b\d{6,}\b/g, '<number>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function fingerprintAutomatedTemplate(text: string): string {
+  return crypto.createHash('sha256').update(normalizeAutomatedTemplate(text), 'utf8').digest('hex');
+}
+
 /**
  * Hard ceiling on a recorded candidate body, in characters. A CEILING, not a default
  * the caller can raise: `maxBodyChars` is clamped DOWN to it, never up, so no config

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2455,6 +2455,8 @@ export function createRoutes(ctx: RouteContext): Router {
         budgetFailClosed && globalFailClosed !== true
           ? (latencyMs: number) => buildDegradedToneResult(text, latencyMs, 'budget-timeout')
           : undefined;
+      const templateFingerprint =
+        options.messageKind === 'automated' ? fingerprintAutomatedTemplate(text) : undefined;
       const result = await reviewWithinBudget(
         ctx.messagingToneGate.review(text, {
           channel,
@@ -2462,6 +2464,7 @@ export function createRoutes(ctx: RouteContext): Router {
           signals,
           targetStyle: ctx.config.messagingStyle,
           messageKind: options.messageKind,
+          templateFingerprint,
           agentState,
           recipientClass,
           // Undefined in observe-only mode (the default) and on every uncertainty,
@@ -2481,24 +2484,6 @@ export function createRoutes(ctx: RouteContext): Router {
         operatorTierDeliver,
         budgetDegrade,
       );
-
-      // Observe-only template census: every automated send is still judged;
-      // this adds a stable identity and verdict to the existing provenance row.
-      if (options.messageKind === 'automated' && ctx.judgmentProvenance) {
-        const templateFingerprint = fingerprintAutomatedTemplate(text);
-        ctx.judgmentProvenance.recordDecision({
-          component: 'MessagingToneGate',
-          decisionPoint: 'messaging-tone-gate',
-          context: { messageKind: 'automated', templateFingerprint },
-          optionsPresented: ['pass', 'block'],
-          decision: result.pass ? 'pass' : 'block',
-          reason: result.pass ? 'tone-gate-pass' : 'tone-gate-block',
-          floor: 'automated-template-observe-only',
-          fallbackRung: 'llm',
-          latencyMs: result.latencyMs,
-          templateFingerprint,
-        });
-      }
 
       // Structured observability: log every decision the authority made. This is
       // the "why I blocked" log — over-block audits read this. Invalid-rule

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -92,7 +92,7 @@ import { writeConfigAtomic, readSelfKnowledgeFlags } from '../core/BootSelfKnowl
 import { rateLimiter, signViewPath, OUTBOUND_GATE_REVIEW_BUDGET_MS } from './middleware.js';
 import { reviewWithinBudget } from './outboundGateBudget.js';
 import { resolveToneRecipientClass } from './toneRecipientClass.js';
-import { buildDegradedToneResult, resolveToneGateOperatorConfig } from '../core/MessagingToneGate.js';
+import { buildDegradedToneResult, resolveToneGateOperatorConfig, fingerprintAutomatedTemplate } from '../core/MessagingToneGate.js';
 import type { WriteOperation, WriteToken } from '../core/StateWriteAuthority.js';
 import { writeLifelineRestartSignal } from '../core/version-skew.js';
 import { readSessionClocks } from '../core/SessionClockReader.js';
@@ -2481,6 +2481,24 @@ export function createRoutes(ctx: RouteContext): Router {
         operatorTierDeliver,
         budgetDegrade,
       );
+
+      // Observe-only template census: every automated send is still judged;
+      // this adds a stable identity and verdict to the existing provenance row.
+      if (options.messageKind === 'automated' && ctx.judgmentProvenance) {
+        const templateFingerprint = fingerprintAutomatedTemplate(text);
+        ctx.judgmentProvenance.recordDecision({
+          component: 'MessagingToneGate',
+          decisionPoint: 'messaging-tone-gate',
+          context: { messageKind: 'automated', templateFingerprint },
+          optionsPresented: ['pass', 'block'],
+          decision: result.pass ? 'pass' : 'block',
+          reason: result.pass ? 'tone-gate-pass' : 'tone-gate-block',
+          floor: 'automated-template-observe-only',
+          fallbackRung: 'llm',
+          latencyMs: result.latencyMs,
+          templateFingerprint,
+        });
+      }
 
       // Structured observability: log every decision the authority made. This is
       // the "why I blocked" log — over-block audits read this. Invalid-rule

--- a/tests/unit/MessagingToneGate.test.ts
+++ b/tests/unit/MessagingToneGate.test.ts
@@ -8,6 +8,8 @@ import {
   MessagingToneGate,
   detectDeterministicLeak,
   scrubClickLinksForFloor,
+  normalizeAutomatedTemplate,
+  fingerprintAutomatedTemplate,
 } from '../../src/core/MessagingToneGate.js';
 import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
 
@@ -28,6 +30,17 @@ function errorProvider(err: Error): IntelligenceProvider {
 }
 
 describe('MessagingToneGate', () => {
+  it('normalizes volatile canary ids to one template fingerprint', () => {
+    const a = 'Delivery canary mesh-12345 reached topic-987654 at 2026-07-24T20:00:00Z';
+    const b = 'Delivery canary mesh-67890 reached topic-123456 at 2026-07-24T20:05:00Z';
+    expect(normalizeAutomatedTemplate(a)).toBe(normalizeAutomatedTemplate(b));
+    expect(fingerprintAutomatedTemplate(a)).toBe(fingerprintAutomatedTemplate(b));
+  });
+
+  it('keeps genuinely different automated templates distinct', () => {
+    expect(fingerprintAutomatedTemplate('Delivery canary succeeded for mesh-12345'))
+      .not.toBe(fingerprintAutomatedTemplate('Delivery canary failed for mesh-12345'));
+  });
   describe('pass case', () => {
     it('passes clean conversational messages', async () => {
       const provider = mockProvider(() =>

--- a/upgrades/next/messaging-template-fingerprint.md
+++ b/upgrades/next/messaging-template-fingerprint.md
@@ -1,0 +1,15 @@
+# Automated messaging template fingerprints
+
+## What Changed
+
+Automated tone-gate decisions now carry a stable template fingerprint and verdict in the existing provenance rows.
+
+## What to Tell Your User
+
+Repeated automated messages can now be measured as one template family, showing consistency and repeated LLM spend without changing delivery behavior.
+
+## Summary of New Capabilities
+
+- Volatile-span normalization for ids, numbers, and timestamps.
+- Deterministic SHA-256 template fingerprints.
+- Observe-only provenance fields for automated tone-gate verdicts.

--- a/upgrades/side-effects/messaging-template-fingerprint.md
+++ b/upgrades/side-effects/messaging-template-fingerprint.md
@@ -1,0 +1,5 @@
+# Side-effects review: automated messaging template fingerprint observe-only
+
+- Adds pure volatile-span normalization and SHA-256 fingerprinting for automated message templates.
+- Records the fingerprint and tone-gate verdict in existing JudgmentProvenanceLog rows; no body content, cache, skip, or behavior change is introduced.
+- Unit tests prove real canary-shaped ids collide and genuinely different templates remain distinct.

--- a/upgrades/side-effects/messaging-template-fingerprint.md
+++ b/upgrades/side-effects/messaging-template-fingerprint.md
@@ -3,3 +3,4 @@
 - Adds pure volatile-span normalization and SHA-256 fingerprinting for automated message templates.
 - Records the fingerprint and tone-gate verdict in existing JudgmentProvenanceLog rows; no body content, cache, skip, or behavior change is introduced.
 - Unit tests prove real canary-shaped ids collide and genuinely different templates remain distinct.
+- The fingerprint is now threaded into the gate's existing settlement provenance context, so each automated send still produces exactly one row.


### PR DESCRIPTION
## ELI16 — Automated messages now carry a stable fingerprint and pass/block verdict in existing provenance rows, without changing whether they are judged or delivered.

In plain English: repeated canary messages can be compared as one template family. Every send still pays the same tone-gate review; the new row only makes consistency and repeated spend measurable.

## UX Impact
- Who sees this: operators reviewing automated messaging quality and delivery.
- What they see: no changed user-facing text or behavior; operators get a scrubbed template identity and verdict for each automated send.
- First-contact test: synthetic canaries with different mesh/topic ids collide to one fingerprint while a changed sentence does not.
- Concrete diff string: `automated-template-observe-only`.

## What changed
- Normalize volatile ids, numbers, and timestamps, then hash the stable automated-template form.
- Record the fingerprint on the existing judgment-provenance row alongside the tone-gate pass/block verdict.
- Keep every automated send on the existing review path: no cache, skip, or behavior change.

## Provenance proof
Scrubbed row from the local install (fingerprint + verdict only; no body content):

```json
{"templateFingerprint":"7b75ae5041aad557218cf4104ea3a820fce87082e86d9630ccf226968f994e25","verdict":"pass"}
```

## Review notes
This is the observe-only first increment. The normalization and fingerprint helpers are pure and unit-tested against the real delivery-canary shape; a genuinely different template remains distinct. No new store or config is introduced.
