### PR TITLE
docs: draft cross-machine door capability registry

### DIFF
--- a/.instar/instar-dev-traces/2026-07-25T05-11-19-000Z-cross-machine-door-capability-spec.json
+++ b/.instar/instar-dev-traces/2026-07-25T05-11-19-000Z-cross-machine-door-capability-spec.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "sessionId": "cross-machine-door-capability-spec",
+  "timestamp": "2026-07-25T05:11:19.000Z",
+  "artifactPath": "upgrades/side-effects/cross-machine-door-capability-registry.md",
+  "artifactSha256": "740865f7d6c2b26b96a798f14050108ad2d7963e57efb1415bce673451f6267c",
+  "specPath": "docs/specs/cross-machine-door-capability-registry.md",
+  "coveredFiles": [
+    "docs/specs/cross-machine-door-capability-registry.md",
+    "docs/specs/cross-machine-door-capability-registry.eli16.md",
+    "upgrades/next/cross-machine-door-capability-registry.md"
+  ],
+  "phase": "spec-draft",
+  "secondPass": "required",
+  "reviewerConcurred": false,
+  "duplicateBuildCheck": {
+    "verdict": "clear",
+    "cause": null,
+    "degraded": true,
+    "notes": ["Spec-only draft; implementation explicitly deferred."],
+    "specSlug": "cross-machine-door-capability-registry",
+    "phase": "build-start",
+    "disposition": {
+      "decision": "proceed",
+      "reason": "ACT-409 requires convergence before implementation; open questions are intentionally recorded.",
+      "acknowledgedEvidenceIds": [],
+      "recordedAt": "2026-07-25T05:11:19.000Z"
+    }
+  }
+}

--- a/docs/specs/cross-machine-door-capability-registry.eli16.md
+++ b/docs/specs/cross-machine-door-capability-registry.eli16.md
@@ -9,17 +9,57 @@ approved: false
 
 Instar can already ask one machine which model doorways it knows about, and it
 can already ask the mesh which machines exist. It cannot yet answer the useful
-combined question: “Which machine can do this job right now, through which
-doorway, and how fresh is that information?”
+combined question: "Which machine can do this job right now, through which
+doorway, and how fresh is that information?"
 
 This proposal adds a read-only joining layer. Each machine keeps its own
 doorway facts. The mesh can show a redacted, machine-labeled view of those
 facts, including when a peer is stale, unknown, or disagreeing. It never copies
-secrets and it does not start routing work.
+secrets and it does not start routing work — every answer it gives is labeled
+advisory, a report card rather than a steering wheel.
 
-The first steps are deliberately cautious: define the data shape, test bad and
-stale peer data, run it on the development agent, then observe it on a small
-fleet cohort. Every step has a dark switch and rollback. The open questions in
-the main spec—freshness, transport, authorization, vocabulary, and operator
-display—must be answered in convergence before any implementation or routing
-decision is approved.
+The convergence review hardened the trust rules into structure rather than
+promises. Each machine may only speak for itself: a peer cannot claim
+capabilities on another machine's behalf, and it cannot re-tell things it
+heard from others as if they were its own. Freshness is judged by the machine
+RECEIVING the data, not the one sending it — so a misbehaving peer cannot
+stamp itself "fresh forever," and an old recording of a machine's earlier
+report is rejected rather than replayed as new. Every row also says HOW it
+was verified (the tool merely exists, versus the model actually answered),
+and how fresh the underlying model catalog itself is — so a stale catalog
+can't masquerade as live truth.
+
+The rollout is deliberately cautious: define the data shape, test bad and
+stale peer data (including replays and floods), run it on the development
+agent, then observe it on a small fleet cohort. Every step has a dark switch
+and a real rollback, honestly distinguished from "empty" — a switched-off
+registry says it is off; an empty one says it is empty. One honest caveat is
+written into the plan: most fleet machines don't run the doorway scan yet, so
+the fleet stage ships knowingly quiet until that scan graduates — that
+dependency is named rather than discovered later. All ten of the draft's open
+questions were settled during convergence and recorded in the spec as
+frontloaded decisions, so a builder can implement it start to finish without
+stopping to ask anyone anything.
+
+One more round happened after the spec already looked finished, and it is the
+part worth remembering. Five review rounds had passed and the document read as
+converged, so a sixth adversarial pass was run purely to test that belief — and
+it found eight real defects. The most serious was a security hole: because a
+peer's "still alive" ping was accepted purely on being authentic, a captured
+ping could be replayed forever to keep a dead machine looking permanently
+healthy, quietly defeating the whole freshness idea. The fix requires proof
+that a ping is NEW, not merely genuine, and if the underlying channel cannot
+prove that, the system deliberately reports peers as stale rather than
+pretending they are fresh. Others were quieter but real: two different
+published limits for the same field size, two different clock-tolerance
+numbers, a rule that promised to show WHICH source disagreed while having no
+field able to say so, an empty answer that could mean three different things
+(never checked / could not check / genuinely nothing), and a claim about
+recovery that was stronger than the mechanism behind it.
+
+The lesson is now written into the spec itself: rounds of review are not
+evidence of convergence. Each round fixed wording in one place, so the numbers
+drifted apart between sections while every individual round looked clean. A
+document only counts as converged after a final whole-document consistency
+pass — and the four regression tests protecting these particular fixes are
+named in the build plan, so they cannot quietly go missing later.

--- a/docs/specs/cross-machine-door-capability-registry.eli16.md
+++ b/docs/specs/cross-machine-door-capability-registry.eli16.md
@@ -1,0 +1,25 @@
+---
+title: "ELI16 — Cross-Machine Door + Capability Registry"
+slug: "cross-machine-door-capability-registry-eli16"
+status: draft
+approved: false
+---
+
+# ELI16 — Cross-Machine Door + Capability Registry
+
+Instar can already ask one machine which model doorways it knows about, and it
+can already ask the mesh which machines exist. It cannot yet answer the useful
+combined question: “Which machine can do this job right now, through which
+doorway, and how fresh is that information?”
+
+This proposal adds a read-only joining layer. Each machine keeps its own
+doorway facts. The mesh can show a redacted, machine-labeled view of those
+facts, including when a peer is stale, unknown, or disagreeing. It never copies
+secrets and it does not start routing work.
+
+The first steps are deliberately cautious: define the data shape, test bad and
+stale peer data, run it on the development agent, then observe it on a small
+fleet cohort. Every step has a dark switch and rollback. The open questions in
+the main spec—freshness, transport, authorization, vocabulary, and operator
+display—must be answered in convergence before any implementation or routing
+decision is approved.

--- a/docs/specs/cross-machine-door-capability-registry.md
+++ b/docs/specs/cross-machine-door-capability-registry.md
@@ -12,10 +12,58 @@ spec-only: true
 
 ## Scope and status
 
-This is a deliberately incomplete, spec-first draft for ACT-409. It proposes a
-cross-machine read model; it does not implement routes, storage, mesh verbs, or
-fleet rollout. Open questions are recorded instead of guessed. Justin's
-convergence review and the reviewer lanes are expected to settle them.
+Spec-first deliverable for ACT-409. It proposes a cross-machine read model; it
+does not implement routes, storage, mesh verbs, or fleet rollout. Convergence
+rounds 1-7 (2026-07-25: six internal reviewer lanes + GPT-tier external passes
++ the standards-conformance gate each round) surfaced and resolved ~48
+material findings; the former ten open questions are resolved in
+`## Frontloaded Decisions`.
+
+Round 6 (an adversarial external pass run specifically to test whether the
+spec was actually converged) found eight material defects that five prior
+rounds had missed, and they share ONE cause worth recording: every round
+patched prose locally, so NUMBERS and INVARIANTS drifted apart between
+sections — a 72-vs-64 byte digest bound, a ±2-min-vs-24h skew tolerance, an
+epoch-monotonicity claim stronger than its own mechanism, a status matrix
+whose ordering contradicted the sentence beneath it, a `conflict` rule with
+no field able to express provenance, an `entries: []` with three
+indistinguishable meanings, a replayable heartbeat that could hold a dead
+peer "fresh" forever, and a row bound that collided with a
+never-drop invariant. All eight are resolved above/below with the fix
+named inline. The process lesson (filed to the drive's coherence gap log):
+multi-round spec editing REQUIRES a final cross-section consistency pass —
+per-round local edits cannot detect number drift, and "five rounds" is not
+evidence of convergence.
+
+Round 7 then VERIFIED those eight fixes independently (six confirmed
+resolved) and demonstrated the same lesson one level up: two of the round-6
+fixes had left a contradicting sentence elsewhere in the document, and three
+of the fixes introduced NEW defects of their own — a fix can carry its own
+bug. Specifically: the fallback that closed the heartbeat replay hole
+reproduced it on the pull path (closed here by a receiver-nonce echo); the new
+compound row key `(capabilityId, sourceDetail)` was not propagated into either
+truncation sort order, so truncation could silently drop half of a
+`conflict`; and the new `scanGeneration` width clamp had no defined behavior at
+exhaustion. All are resolved above. The standing rule this establishes: EVERY
+fix round must itself be verified, and a fix that adds a field or a fallback
+must be traced to every rule that consumes it (sort orders, counters, config
+key names) before the round is called clean.
+
+## Glossary
+
+- **Doorway** — a way this machine reaches LLM providers (the Claude Code
+  CLI, Codex CLI, an API key); inventoried by `GET /doorways`.
+- **Pool / mesh** — this agent's set of machines and their authenticated
+  machine-to-machine transport.
+- **Projection** — a machine's own derived, rebuildable summary of its
+  capabilities; never an authority, always reconstructible from sources.
+- **Heartbeat digest** — a tiny fixed-size summary riding the existing
+  authenticated capacity/presence heartbeat, used only to detect "something
+  changed, pull the full projection."
+- **Dark** — shipped in code but disabled by config; a dark route answers
+  `503` with a named code, never fabricated data.
+- **Ratchet** — a repo-level lint/CI check that fails the build when a rule
+  regresses, so the rule is enforced by machinery rather than review memory.
 
 ## Problem
 
@@ -27,9 +75,9 @@ Instar already has two useful but separate truths:
   endpoint propagation, leases, placement, and capability advertisements)
   describe machines and some operational reachability.
 
-Neither is a durable, queryable answer to: “Which machine can serve this
+Neither is a durable, queryable answer to: "Which machine can serve this
 capability, through which doorway, with what freshness and authorization
-posture?” Operators must join local `/doorways` data to pool data manually.
+posture?" Operators must join local `/doorways` data to pool data manually.
 That creates stale routing, ambiguous failures, and multi-machine friction: a
 capability can be present in a peer's config but unavailable at runtime, or a
 door can be reachable locally while its advertised peer endpoint is stale.
@@ -42,178 +90,846 @@ local doorway truth and authenticated machine/mesh state remain the sources.
 ## Design principles
 
 1. **Read model, not control plane.** v1 discovers and reports; it does not
-   migrate sessions, mint credentials, or automatically route work.
-2. **Source-linked freshness.** Every row names its source (`doorways` or pool /
-   mesh observation), observed-at time, and freshness class. Missing or stale
-   data is represented explicitly, never omitted or converted to “available.”
-3. **Machine-qualified identity.** Keys include stable machine id and capability
-   id. Nicknames and URLs are display fields, not identity.
-4. **Authenticated, untrusted remote data.** Peer snapshots are accepted only
-   through existing machine-authenticated mesh paths, then schema-clamped as
-   untrusted data. Remote descriptions never become instructions or executable
-   commands.
-5. **Least disclosure.** Store endpoint references and capability metadata, not
-   tokens, private model prompts, or raw credential locations. Pool scope obeys
-   existing operator authorization.
-6. **Deterministic conflict handling.** A local live observation outranks an
-   older peer claim; contradictory claims remain visible with provenance rather
-   than being silently merged.
+   migrate sessions, mint credentials, or automatically route work. Every read
+   response carries `advisory: true`, and that marker is backed by a
+   structural guard, not culture (see Frontloaded Decision 17).
+2. **Source-linked freshness, receiver-owned.** Every row names its source,
+   observed-at time, and freshness class. Missing or stale data is represented
+   explicitly, never omitted or converted to "available." Freshness authority
+   belongs to the RECEIVER: peer-declared timestamps are claims, clamped to
+   receiver-owned ceilings (see Trust and merge rules).
+3. **Machine-qualified identity.** Keys include stable machine id and
+   capability id. Nicknames are display fields, not identity. URLs are never
+   display fields.
+4. **Authenticated, untrusted, self-reported remote data.** Peer snapshots are
+   accepted only through existing machine-authenticated mesh paths, then
+   schema-clamped as untrusted data. Every remote field — including
+   `probeOutcome` and `evidenceClass` — is SELF-REPORTED by the peer: authentication proves
+   who spoke, never that the claim is true. Remote descriptions never become
+   instructions; rows rendered into agent context ride the established
+   `<replicated-untrusted-data>` envelope, and display strings are
+   HTML-escaped at the render funnel.
+5. **Least disclosure.** Store endpoint references and capability metadata,
+   not tokens, private model prompts, or raw credential locations. Pool scope
+   obeys existing operator authorization.
+6. **Deterministic conflict handling with self-claim supremacy.** A machine is
+   the SOLE authority for rows about itself. Contradictory cross-machine
+   claims cannot enter (Trust rule 1); a machine's own-source contradictions
+   remain visible with provenance rather than being silently merged.
+7. **Origin-bound projections.** A machine's exported projection contains ONLY
+   rows it originated about itself (hop count 0). Peer-learned rows are never
+   re-exported — no claim laundering, no manufactured corroboration.
 
-## Proposed record (v1)
+## Proposed record (v6)
 
-The registry is a durable, machine-local projection with a pool read assembled
-from authenticated peer projections:
+Each machine keeps ONE durable artifact — its own self-projection — and ONE
+in-memory, TTL-bounded map of validated peer projections. Peer rows are
+deliberately NOT durable: their TTL ceiling (10 min) is far below any
+restart-recovery horizon, and the digest+pull path repopulates them within a
+heartbeat cycle, so durability would buy nothing and would create a durable
+PII-free-but-peer-owned state surface with no clean posture. (Restart
+consequence, stated honestly: for up to one heartbeat cycle after a server
+restart, pool reads show peers as `unknown` with reason `no-data-yet` — the
+receiver-side "no ingest yet this process lifetime" state, deliberately
+distinct from the peer-side `source-unavailable` — truthful, self-healing,
+and bounded.)
 
 ```json
 {
   "schemaVersion": 1,
   "machineId": "mesh-machine-id",
+  "machineEpoch": 1784958000,
+  "projectionSeq": 172,
+  "scanGeneration": 41,
+  "scanState": "observed|never-observed|source-unavailable",
+  "truncated": false,
   "entries": [{
-    "capabilityId": "models:anthropic/claude-opus-4-8",
-    "capabilityKind": "model|route|service",
+    "capabilityId": "models:claude-code/claude-opus-5",
+    "capabilityKind": "model",
     "doorwayId": "claude-code",
     "machineId": "mesh-machine-id",
-    "status": "available|unavailable|unknown|stale|conflict",
-    "endpointRef": "mesh://machine/doorways",
+    "probeOutcome": "positive|negative|unknown",
+    "endpointRef": "mesh://mesh-machine-id/doorways",
     "observedAt": "2026-07-25T00:00:00Z",
-    "expiresAt": "2026-07-25T00:10:00Z",
+    "receivedAt": "2026-07-25T00:00:03Z",
     "source": "local-doorways|peer-pool|mesh-heartbeat",
-    "evidence": { "doorwayScanAt": "...", "machineEpoch": 42 }
+    "sourceDetail": "doorway-scan|doorway-manifest|pool-observation",
+    "evidenceClass": "cli-present|probe-answered|manifest-only",
+    "evidence": {
+      "doorwayScanAt": "2026-07-25T00:00:00Z",
+      "manifestVerifiedAt": "2026-07-20T00:00:00Z"
+    }
   }]
 }
 ```
 
-`endpointRef` is an opaque route reference, never a bearer URL. `expiresAt` is
-required for remotely derived rows. A row without a fresh observation cannot
-be selected as available by a future routing consumer.
+Field rules (all structurally enforced, not prose):
 
-## Surfaces and ownership (proposed)
+- **`machineEpoch` (envelope-level, first-class).** ONE total-ordered minting
+  rule (no source mixing): whenever the origin initializes fresh projection
+  state it mints `epoch = max(wall-clock-now-seconds,
+  previously-highest-emitted + 1)` — the previously-highest value read from
+  the durable self-projection when present, else 0. Honest bound on that
+  rule (the round-6 finding; the earlier text over-claimed): the `prev + 1`
+  arm makes minting monotonic across wall-clock rollback and across any
+  re-init that can still READ the durable projection. It CANNOT be monotonic
+  across *total state loss combined with a backward clock* — with the
+  previous value unreadable and the clock behind it, the only inputs
+  available are both lower, so a regressed epoch is possible. That residual
+  is not a permanent lockout and needs no extra mechanism: the receiver's
+  watermark aging (below) accepts the origin fresh after
+  `watermarkMaxAge`, so the worst case is bounded staleness for an origin
+  that lost state while its clock ran backwards — a diagnosable state
+  visible in `/capability-registry/health` per-origin rejection counters.
+  Minting never references the mesh machine-epoch (whose small-counter
+  domain is incomparable with wall-clock values — the round-3 inversion
+  finding). It
+  appears ONCE per projection — never per entry — so the merge precondition
+  is well-defined. Receive-side sanity clamp (anti-poisoning): an epoch
+  greater than the receiver's wall-clock-now + `epochClampBound` (default
+  24h — wide enough that ordinary clock drift, including the observed
+  80-minute production case, never rejects an honest origin) is rejected
+  with reason `clock-skew` (a skewed honest origin must not read as
+  corrupt). **Watermark aging — the universal lockout healer:** a
+  receiver's per-origin watermark EXPIRES after `watermarkMaxAge` (default
+  24h) without an accepted projection; the next authenticated projection is
+  then accepted fresh. This bounds EVERY lockout class — a poisoned
+  watermark (one-time origin compromise minting ≤ now+24h of headroom), a
+  forward-clock-glitch epoch preserved by the `prev + 1` arm, a reinstall,
+  a crash-loop of fresh-init mints — to ≤ `watermarkMaxAge` worst case,
+  with the reopened replay window bounded as in rule 2 (≤ 10 min of stale
+  advisory rows). Sustained per-origin rejections are visible in
+  `/capability-registry/health` counters, so a locked-out origin is a
+  diagnosable state, never a silent one.
+- **`projectionSeq`** — per-epoch monotonic counter, incremented on every
+  projection write; persisted in the durable self-projection so a
+  same-epoch rebuild continues the sequence. State loss re-mints an epoch
+  under the rule above — higher in every case EXCEPT total state loss with a
+  backward clock, which is the named residual healed by watermark aging (the
+  round-7 finding: this sentence previously asserted "re-mints a higher epoch
+  anyway", contradicting the bound stated two rules up).
+- **`scanGeneration` exhaustion (normative — the round-7 finding).** The
+  counter increments on every completed scan and is width-clamped, so it must
+  have a defined transition at its ceiling or its own mechanism eventually
+  violates the clamp. At `9_999_999_999` the next completed scan WRAPS it to
+  `0` and re-mints the `machineEpoch` in the same write. Wrapping is safe
+  because `scanGeneration` is only ever compared for INEQUALITY inside the
+  pull-decision tuple (never ordered), and the epoch re-mint keeps the
+  receiver's `(machineEpoch, projectionSeq)` watermark strictly advancing
+  across the wrap. A receiver never needs to special-case it.
+- **Envelope numeric width clamps (normative, so the digest bound holds by
+  construction — the round-6 finding).** `schemaVersion` ≤ 3 decimal digits,
+  `machineEpoch` ≤ 11, `projectionSeq` ≤ 10, `scanGeneration` ≤ 10; all are
+  non-negative integers. A value exceeding its width is refused at write and
+  rejects the projection on receive (`malformed`). A `projectionSeq` at its
+  ceiling forces an epoch re-mint (which resets the sequence) rather than
+  overflowing. These four widths are what make the digest's single size bound
+  arithmetic rather than aspirational.
+- **`truncated`** — envelope boolean (clamped), present on the wire so a
+  receiver renders a truncated projection as truncated, never as complete.
+- **`scanState`** — envelope closed enum (`observed | never-observed |
+  source-unavailable`), on the wire because an EMPTY `entries` array is
+  otherwise three different truths (the round-6 finding): a scan ran and
+  genuinely found nothing (`observed`), no scan has ever run on that machine
+  (`never-observed`), or the underlying doorway source could not be read
+  (`source-unavailable`). A receiver renders a peer's empty projection using
+  this field and NEVER as "no capabilities." It is envelope semantics, so it
+  joins `truncated` in the pull-decision tuple; a peer projection whose
+  `scanState` is not `observed` produces that machine's named failure/empty
+  row (`source-unavailable`, or the receiver-side `no-data-yet` before first
+  ingest) instead of an inferred-empty capability list.
+- **`probeOutcome`** — closed enum (`positive|negative|unknown`): the RAW
+  observed fact ("the probe answered" / "the probe failed" / "no probe").
+  Derived STATUS (`available|unavailable|unknown|stale|conflict`) is NEVER
+  on the wire — it is computed by whichever machine SERVES a read, from
+  probeOutcome + freshness via the status matrix. A peer therefore cannot
+  even express "I am available" as a claim; it can only report what its
+  probe did. (This also removes the round-5 ambiguity of a derived field
+  inside the fact hash.)
+- **`capabilityKind`** — v1 admits `model` ONLY. `route` and `service` are
+  reserved enum values REJECTED on write (kind-specific status/evidence
+  contracts are a future schema bump).
+- **`capabilityId`** — format-clamped (`models:<doorwayId>/<modelId>`, charset
+  + length bounded), NOT membership-clamped against a second hand-maintained
+  list (the doorway manifest's Opus-5 release-day staleness is the recorded
+  failure mode of closed membership lists). The `models:` namespace is
+  derivable only from doorway-scan output; unparseable ids are rejected.
+  Canonicalization: `doorwayId` and `modelId` are lowercased, charset
+  `[a-z0-9._-]` only (a delimiter or escape character in a source id rejects
+  the row — no escaping games), and two ids are the same capability iff
+  their canonical forms are byte-equal.
+- **`endpointRef`** — a closed grammar, not a free string: MUST parse as
+  `mesh://<machineId>/<enumerated-route>` where the machineId component
+  MUST EQUAL the projection envelope's `machineId` (origin-bound — a lying
+  origin cannot point a future consumer at another machine's routes; v1
+  enumerated-route set: `doorways` only). `http(s)://` schemes, userinfo,
+  query strings, and secret-shaped substrings are refused at write AND at
+  receive. A sink test asserts the field never round-trips raw input.
+- **`evidence`** — a CLOSED schema (exactly the two keys shown, ISO-8601
+  type-clamped). Unknown keys are dropped on receive. `manifestVerifiedAt`
+  carries the canonical doorway manifest's own freshness so catalog staleness
+  is visible per row (source-stale distinguishable from observation-stale).
+- **`evidenceClass`** — closed enum declaring probe depth: `cli-present`
+  (binary/version check only), `probe-answered` (the door actually answered),
+  `manifest-only` (no live probe). All values are SELF-reported;
+  `receiver-verified` is deliberately reserved (absent in v1) for a future
+  active-verification increment, so no v1 row can claim independent
+  corroboration.
+- **`receivedAt`** — stamped by the RECEIVER, never accepted from the wire.
+- **`source`** — hop-0 is FIELD-ENFORCED, not asserted: the durable
+  self-projection writer and the export path accept only
+  `source: "local-doorways"` rows; a `peer-pool`/`mesh-heartbeat` source in
+  an exported projection rejects it (`malformed`). Those two values exist
+  only in the receiver's in-memory peer map, stamped by the receiver.
+- **`sourceDetail`** — closed enum naming WHICH local source produced the
+  row (`doorway-scan` = live scan-state, `doorway-manifest` = the canonical
+  model manifest, `pool-observation` = the machine's own pool/mesh
+  observation of its doorways). This field is what makes own-source
+  `conflict` representable at all (the round-6 finding: `source` is pinned to
+  the single value `local-doorways` on every exported row, so it cannot
+  distinguish two disagreeing local sources). The local row key is therefore
+  `(capabilityId, sourceDetail)`, not `capabilityId` alone: two local sources
+  that disagree about the same capability both persist, and the read surface
+  renders `conflict` for that `capabilityId` WITH the disagreeing
+  `sourceDetail` values and their per-row `probeOutcome`/`observedAt` — which
+  is what "visible with provenance" requires. `sourceDetail` is
+  fact-bearing (it participates in the digest tuple) and is clamped on
+  receive like every other enum; an unknown value rejects the projection
+  (`malformed`).
 
-- `GET /capability-registry` — this machine's redacted projection; always
-  returns a truthful empty/unknown state when no observations exist.
-- `GET /capability-registry?scope=pool` — operator-authorized merge of peer
-  projections, with per-machine failure rows and age/freshness preserved.
-- `POST /capability-registry/refresh` — bounded, read-only refresh trigger;
-  no automatic routing or credential use.
-- `/capabilities` advertises the read surfaces once implemented.
+**Status derivation matrix (normative).** Status is a pure function of
+evidence and effective expiry — never stored authority:
 
-The existing `/doorways` registry remains authoritative for doorway/model facts
-on each machine. Existing pool and mesh endpoint routes remain authoritative for
-machine identity and transport reachability. The new registry owns only the
-join, freshness classification, and conflict presentation.
+The rows are evaluated STRICTLY in the order listed; the first matching row
+wins and no later row can override it. The unknown-producing rows deliberately
+sit ABOVE the expiry rows, which is what makes "`unknown` does not expire"
+a structural property rather than a second competing rule (the round-6
+ordering finding: with expiry evaluated first, an unknown row would have
+classified `stale`, contradicting the sentence below the table).
+
+| # | Condition (first match wins) | Status |
+|---|---|---|
+| 1 | No observation for the key exists | `unknown` |
+| 2 | Own-source contradiction (same `capabilityId`, disagreeing `probeOutcome` across distinct `sourceDetail` values) | `conflict` |
+| 3 | `evidenceClass: manifest-only` (regardless of claimed positivity) | `unknown` |
+| 4 | `probeOutcome: unknown` (no probe outcome, at any `evidenceClass` or age) | `unknown` |
+| 5 | Transport expiry passed (Trust rule 3 formula) | `stale` |
+| 6 | Source observation aged out (`observedAt`/`doorwayScanAt` > localStaleAfter, or a stale `manifestVerifiedAt`) | `stale` |
+| 7 | Fresh observation, `probeOutcome: negative` (door probe failed / model absent) | `unavailable` |
+| 8 | Fresh observation, `probeOutcome: positive` | `available` |
+
+Rows 1-4 are total over the "no usable outcome" space, so rows 5-8 are only
+ever reached by a row carrying a `positive` or `negative` outcome — the
+expiry arms therefore govern exactly the two statuses that can decay.
+`unavailable` and `available` both decay to `stale` (never to each other) as
+their evidence ages; `unknown` is the floor and does not expire, by the
+ordering above. `manifest-only` evidence can never yield `available` — the
+strongest it supports is `unknown` (a catalog entry proves existence in a
+document, not reachability).
+
+## Trust and merge rules (normative)
+
+Each rule is a structural property of the registry, not guidance for a future
+consumer:
+
+1. **Origin binding.** A peer projection is accepted ONLY for the machine
+   whose authenticated channel identity matches BOTH the envelope `machineId`
+   and every entry's `machineId`; any mismatch rejects the WHOLE projection
+   with failure reason `origin-mismatch`. A peer therefore cannot assert
+   capabilities as — or about — another machine. (Rule 6's whole-projection
+   rejection semantics apply to every receive-side rule.)
+2. **Per-origin monotonicity (anti-replay).** The receiver keeps, per origin,
+   the highest accepted `(machineEpoch, projectionSeq)` pair (in-memory,
+   beside the peer map). A projection with a lower pair is rejected with
+   failure reason `stale-projection`; an EQUAL pair with a DIFFERENT digest
+   is also rejected `stale-projection` (one sequence number cannot name two
+   states), while an equal pair with an equal digest is a no-op. A
+   captured, validly-authenticated older snapshot cannot regress state or
+   resurrect a retracted claim.
+   Honest bound: after a receiver restart the watermark is empty, so a
+   replayed old projection could be accepted once — where receiver TTL
+   clamping (rule 3) caps the damage at ≤ 10 min of stale advisory rows.
+   Epoch supersession (see field rules) keeps origin reinstalls recoverable.
+3. **Receiver-owned freshness — transport and observation aged SEPARATELY.**
+   The two freshness dimensions have different clocks and are never mixed
+   (the round-4 domain-mixing finding):
+   - **Transport freshness** (is the origin still standing behind this
+     projection?): a single receiver-owned expression — `lastConfirmedAt +
+     remoteTtlCeiling` (default ceiling 10 min; heartbeat-cadence domain),
+     where `lastConfirmedAt` is a per-origin scalar set at ingest and
+     refreshed by each authenticated MATCHING-digest heartbeat from that
+     origin (O(1) per origin, not per row) **that is itself proven NEW**
+     (see the freshness precondition below). There is NO peer-declared
+     expiry anywhere in the design — the round-5 review showed any
+     peer-stamped arm inevitably reintroduces steady-state-stale, and
+     receiver-owned freshness makes a peer expiry claim dead weight. A
+     healthy-but-unchanged peer stays transport-fresh WITHOUT full pulls;
+     transport-stale means the heartbeat stopped.
+     **Freshness precondition (normative — closes the round-6 replay hole).**
+     "Authenticated" is not "new": a captured matching-digest heartbeat
+     replayed on a loop would otherwise reset `lastConfirmedAt` forever and
+     keep a dead peer permanently fresh, defeating the TTL (the epoch/seq
+     watermark does not reject an equal pair with an equal digest — that is
+     defined as a no-op). A heartbeat may therefore advance
+     `lastConfirmedAt` ONLY when the receiver can prove it is new, by one of
+     exactly two admitted proofs: (a) the mesh heartbeat carries a
+     per-origin strictly-increasing sequence/nonce and this one is strictly
+     greater than the last seen from that origin, or (b) the mesh heartbeat
+     carries an origin-signed send time within the receiver's
+     `epochClampBound` skew window AND strictly newer than the last accepted
+     one. If the underlying heartbeat provides NEITHER proof, the registry
+     MUST NOT treat heartbeats as confirmation at all: it falls back to
+     advancing `lastConfirmedAt` only on a successful authenticated PULL
+     **whose response echoes the receiver's per-request nonce** (see the
+     pull-freshness rule in `## Ingest and transport` — the round-7 finding:
+     without that echo the fallback inherits the very replay gap it was
+     introduced to close, since an equal-pair/equal-digest response is a
+     defined no-op rather than a rejection), and the affected peers simply go
+     transport-stale between pulls. That fallback is the fail-closed
+     direction — a peer reads stale rather than falsely fresh — and which
+     mode is in force is reported by `/capability-registry/health`
+     (`confirmationMode: heartbeat-sequence | heartbeat-signed-time |
+     pull-only`) so the posture is never a silent assumption. Increment 1
+     MUST assert the fallback in a fixture test (replayed identical
+     heartbeat ⇒ `lastConfirmedAt` unchanged ⇒ row goes `stale` on
+     schedule).
+   - **Observation freshness** (how old is the underlying fact?):
+     `observedAt` denotes when the SOURCE observation was made (for local
+     rows, == `doorwayScanAt`) — NOT projection-emission time — and ages on
+     the SOURCE cadence via the status matrix (`localStaleAfter`, default
+     24h; scan-cadence domain). It takes no part in the 10-min expiry
+     formula.
+   Anti-laundering needs no `observedAt` arm: a replayed OLDER projection
+   is rejected by rule 2's watermark before freshness is ever computed, and
+   a NEW projection honestly carrying an old observation classifies `stale`
+   through the matrix's source-age row. An `observedAt` up to 24h
+   future-dated (`epochClampBound` — the same drift tolerance the epoch
+   clamp uses, covering the observed 80-minute production drift) is CLAMPED
+   to `receivedAt` (an observation "from the future" is treated as
+   observed-now, receiver-owned honesty); beyond 24h it is rejected
+   (`clock-skew`). The two skew tolerances are deliberately ONE number —
+   a drift that passes the epoch clamp can never be locked out by the
+   observation bound. Consumers and UI must render observation age alongside
+   status — "fresh" never asserts a recent re-check beyond what
+   `evidenceClass` + `observedAt` actually say.
+4. **Status derives at read time — cheaply.** `GET /capability-registry`
+   serves the stored/ingested snapshot; the ONLY read-time computation is
+   the status matrix applied per row (probeOutcome + two freshness
+   comparisons — no join recompute, O(rows served)). Status NEVER exists as
+   stored state or wire data, so "a row without a fresh observation cannot
+   be selected as available" is a property of the read surface itself,
+   everywhere, with no stored-status staleness class even possible.
+5. **Self-claim supremacy (backstop).** A machine's own authenticated live
+   observation about itself always outranks any peer claim about it. Under
+   rule 1 such peer claims cannot even be ingested, so this rule is the
+   DECLARED DEPENDENT BACKSTOP: it exists so that any future relaxation of
+   origin binding must consciously confront it, not so it fires today.
+   `conflict` status covers contradictions among a machine's OWN sources
+   only, shown with provenance, observe-only.
+6. **Cardinality ceilings.** Per-origin entry cap (default 200 rows). An
+   over-limit RECEIVED projection is rejected WHOLE with failure reason
+   `over-limit` (no truncation-order gaming). The LOCAL writer never
+   silently truncates its own honest derivation: if local derivation exceeds
+   the cap it writes the first N rows in deterministic
+   `(doorwayId, capabilityId, sourceDetail)` sort order — `sourceDetail` is
+   part of the sort key because it is part of the row key, and without it two
+   rows that differ ONLY in provenance TIE, making truncation nondeterministic
+   and able to drop one half of a contradiction (the round-7 finding: a
+   silently half-erased `conflict` would violate the visible-with-provenance
+   invariant). Rows sharing a `capabilityId` are therefore adjacent and are
+   retained or dropped as a GROUP: the writer never splits a
+   `capabilityId`'s provenance set across the cap boundary — it stops at the
+   last complete group that fits — marks the projection `truncated: true`
+   (visible in every read), and logs loudly — truthful, bounded, and
+   impossible to hit silently. Pool responses carry `total` +
+   `truncated: true` beyond a response bound, with deterministic retention
+   order: per-machine failure rows always retained, then capability rows by
+   `(machineId, capabilityId, sourceDetail)` sort, with the same
+   never-split-a-capability's-provenance-group rule as the local writer. The bound governs CAPABILITY rows only
+   (`maxPoolResponseCapabilityRows`, default 2000) and failure rows are
+   counted separately — otherwise the two rules collide whenever failures
+   alone reach the bound, forcing an implementer to violate one of them (the
+   round-6 finding). Failure rows need no bound of their own: there is at
+   most ONE per machine, and the machine set is already bounded by the
+   authenticated pool registry, so the response stays bounded by
+   construction while "every machine's failure is visible" stays absolute.
+7. **Closed failure vocabulary.** Every per-machine failure row's `reason` is
+   a fixed enum (`timeout`, `stale-projection`, `origin-mismatch`,
+   `clock-skew`, `malformed`, `version-unsupported`, `over-limit`,
+   `source-unavailable`, `not-participating`, `no-data-yet`) — never verbatim
+   peer/transport error text (the doorway registry's probeStatus lesson;
+   also closes a prompt-injection and disclosure channel).
+   `not-participating` is the mixed-enablement answer: a pool-registered,
+   heartbeat-fresh machine whose heartbeats carry NO capability digest has
+   the feature dark — honestly distinguishable from a broken
+   (`timeout`/`malformed`) or source-empty (`source-unavailable`) peer.
+8. **Bounded lifetimes, no GC machinery.** Remote rows are in-memory and
+   expire under their receiver-clamped TTLs; a machine absent from the
+   authenticated pool registry drops from the peer map immediately on
+   registry removal. The durable self-projection is fully re-derived on
+   every rebuild, so a frozen projection cannot present dead local
+   capabilities after re-enable — the projection rebuilds before it serves
+   (`snapshotStale` flagged until the first rebuild completes).
+
+## Ingest and transport (ONE chokepoint)
+
+There is exactly ONE peer-data ingest path, and every Trust rule runs inside
+it:
+
+- Each machine's heartbeat carries a fixed-size capability digest, encoded
+  as the compact string
+  `cap1:<schemaVersion>:<machineEpoch>:<projectionSeq>:<truncated 0|1>:<scanState 0|1|2>:<scanGeneration>:<entriesSha256-16hex>`
+  — **≤ 64 bytes, and that bound is arithmetic, not aspirational**: the
+  envelope width clamps above (3 + 11 + 10 + 10 decimal digits, one digit
+  each for `truncated` and the `scanState` ordinal, a 16-hex truncated
+  entries hash, the 4-byte `cap1` tag and 7 separators) sum to 63 bytes
+  worst case. A value that would exceed its clamp is refused at write, so an
+  over-long digest cannot be emitted. (Round-6 finding: this bound and
+  Frontloaded Decision 14 previously disagreed — 72 vs 64 — and neither
+  followed "by construction" without the width clamps; both now read 64.)
+  `scanState` is encoded as an ordinal (`0 = observed`, `1 = never-observed`,
+  `2 = source-unavailable`) so envelope semantics, not just entry content,
+  drive the pull decision. A machine with the feature dark emits NO digest
+  (see failure reason `not-participating`).
+- **Digest determinism (normative):** `entriesSha256` is computed over a
+  CANONICAL serialization of the FACT-BEARING fields ONLY —
+  `(capabilityId, capabilityKind, doorwayId, machineId, probeOutcome,
+  endpointRef, source, sourceDetail, evidenceClass)` per entry, entries
+  sorted by `(doorwayId, capabilityId, sourceDetail)` — `sourceDetail` joins
+  the sort key because it is part of the local row key, so two disagreeing
+  local sources for one capability serialize deterministically instead of
+  colliding. JSON with sorted keys. `scanGeneration` is the origin's
+  completed-scan counter (increments on every completed doorway scan, even
+  a no-change one) — it propagates OBSERVATION freshness: a scan that
+  changes no facts still bumps the digest tuple, triggering one bounded
+  re-pull per origin per scan (daily cadence, ≤200 rows) that refreshes
+  receivers' stored `observedAt`, so stable healthy fleets never decay to
+  false observation-staleness (the round-5 non-propagation finding). Timestamps (`observedAt`,
+  `doorwayScanAt`, `manifestVerifiedAt`) are EXCLUDED from the
+  hash: a rebuild that merely re-stamps time does not churn the digest, so
+  digest-compare stays a no-op for unchanged facts (the round-4
+  volatile-timestamp finding). Two rebuilds of identical facts produce
+  identical digests (fixture-tested in Increment 1).
+- The PULL DECISION keys on the tuple `(schemaVersion, truncated, scanState,
+  scanGeneration, entriesSha256)` — envelope semantics changes fetch too, so a
+  version bump or truncation change cannot hide behind identical entries
+  (the round-4 envelope-fields finding). An epoch/seq bump with an
+  unchanged tuple updates the watermark from the digest without fetching
+  identical content. Watermark advance and the `lastConfirmedAt` re-clamp
+  apply ONLY to digests authenticated directly as the origin — an
+  indirectly-propagated digest can trigger a pull, never advance trust
+  state. When the entries hash differs from the last
+  ingested state, the receiver fetches the full projection via the EXISTING
+  authenticated pull verb (the pull re-authenticates the origin — an
+  indirectly-propagated digest can trigger a pull but can never bypass rule
+  1's channel-identity check) and runs it through the validation funnel
+  (rules 1-3, 6, schema clamps). A validation REJECTION counts as a pull
+  failure for the brakes below — a stale-locked or misbehaving origin is
+  backed off, not re-pulled every heartbeat.
+- Per-origin pull brakes (P19, declared): exponential backoff on pull
+  failure, a per-origin breaker after 5 consecutive failures (half-open
+  retry each 10 min), and full pulls jittered on mesh-reconnect AND on
+  receiver process restart (neither a partition heal nor a reboot
+  synchronizes N simultaneous pulls). A peer whose entries hash genuinely
+  flips every heartbeat is bounded to one 200-row pull per heartbeat cycle
+  per origin — sustained-but-bounded, and visible in ingest counters.
+- **Pull freshness (normative — the round-7 finding).** Because the RECEIVER
+  initiates a pull, it needs no assumption about the transport to obtain a
+  liveness proof: every pull request carries a receiver-generated single-use
+  nonce, and the response MUST echo it. `lastConfirmedAt` advances ONLY on a
+  nonce-echoing response. A captured older response cannot carry the current
+  nonce, so it can neither refresh transport freshness nor extend a dead
+  peer's TTL — and this holds in `pull-only` confirmation mode, which is
+  exactly the mode chosen when the heartbeat cannot prove newness. A
+  missing-or-wrong-nonce response is a named failure row (`malformed`) and
+  counts as a pull failure for the brakes.
+- Transport replay posture, stated honestly: the pull verb re-authenticates
+  per request, and the nonce echo above makes RESPONSE replay ineffective for
+  FRESHNESS; rules 2-3 (epoch/seq watermark + TTL clamps) remain the
+  defense-in-depth against a replayed response's CONTENT. What is deliberately
+  NOT claimed: that the underlying mesh transport is nonce-replay-proof — the
+  design stops depending on that property rather than assuming it.
+- `GET /capability-registry?scope=pool` performs NO fan-out of any kind: it
+  serves the union of the durable self-projection and the in-memory
+  validated peer map. Peer failure rows come from the ingest state (last
+  attempt outcome per origin). This deliberately does NOT depend on the
+  WS4.4(f) shared pool poll-cache (dark on the fleet) or any other read-time
+  carrier — the read is O(serve-local) by construction.
+
+## Surfaces and ownership
+
+- `GET /capability-registry` — this machine's redacted projection. Serves the
+  stored snapshot (validation once at ingest; read-time work is rule 4's
+  per-row timestamp comparison only). `200` with `scanState:
+  "never-observed"` and empty entries when no observation exists
+  (truthful-empty, mirroring `/doorways`' `never-run`); `503` ONLY when the
+  feature flag is dark. Disabled reads as disabled; empty reads as empty —
+  never interchangeable.
+- `GET /capability-registry?scope=pool` — the local-serve merged view (see
+  Ingest and transport). Per-machine failure rows with the closed reason
+  enum; mixed failures return `200` with `pool.failed` rows — never a 500,
+  never an omitted machine. Authorization: the same operator-Bearer +
+  pool-visibility gate as `GET /pool` / `GET /sessions?scope=pool`; pool
+  scope is DENY-BY-DEFAULT (route refuses) until its increment enables it.
+- `POST /capability-registry/refresh` — Bearer-auth, LOCAL-projection rebuild
+  ONLY: re-reads existing doorway scan-state and pool observations. It NEVER
+  invokes doorway probes (nothing metered — metered probes stay human-manual
+  per the doorway spec) and NEVER triggers transitive peer refreshes.
+  Single-flight (concurrent calls coalesce), rate-limited 1 per 5 min with
+  `429`, jittered when fired on mesh-reconnect.
+- Every read response carries `advisory: true` and rows carry their
+  self-reported `evidenceClass`. The marker is enforced by Frontloaded
+  Decision 17's ratchet, and the dashboard follow-up must render
+  uncorroborated (all v1) claims distinguishably.
+- `/capabilities` advertises the read surfaces only once the flag actually
+  serves them on this install (advertising a dark route breaks
+  Self-Discovery).
+
+The existing `/doorways` registry remains authoritative for doorway/model
+facts on each machine. Existing pool and mesh endpoint routes remain
+authoritative for machine identity and transport reachability. The new
+registry owns only the join, freshness classification, and conflict
+presentation.
+
+## Multi-machine posture
+
+- **Durable self-projection** (`state/capability-registry.json`, hop-0 rows
+  about this machine only): machine-local BY DESIGN.
+  machine-local-justification: physical-credential-locality — a machine's
+  doorway reachability is a function of the CLI logins and credentials that
+  physically live on that machine's disk; its self-projection cannot be
+  authored anywhere else. (Peer-learned rows are NOT in this file — they are
+  in-memory only, so the durable surface is exactly the credential-local
+  part.)
+- **In-memory peer map + anti-replay watermark**: transient receiver state,
+  not a durable surface; posture question does not arise (nothing on disk,
+  rebuilt within one heartbeat cycle, loss consequences stated in Trust
+  rule 2).
+- **Pool view**: proxied-on-read from local ingest state — nothing
+  replicates as authority (replicating projections would recreate rejected
+  Alternative B; reach is not authority).
+- **User-facing notices** (the Increment 4 attention item): raised by the
+  serving-lease holder ONLY (elected-raiser precedent) — one voice. The
+  hysteresis/episode state is holder-local; a lease move mid-episode resets
+  the 3-tick counter (honest reset semantics — worst case one delayed item,
+  never a duplicate).
+- **Generated URLs**: none — `endpointRef` is an opaque mesh route reference
+  by closed grammar; no URLs cross machine boundaries.
+- The refresh job runs per-machine over its own projection.
+
+## Decision points touched
+
+| Decision point | Class | Rationale / floor |
+|---|---|---|
+| Truthful-empty reads (missing never becomes `available`) | invariant | Constitutional honesty; enforced at the read surface. |
+| Peer data authenticated-then-untrusted, schema-clamped, never instructions | invariant | WS2.x envelope convention; closed schemas above. |
+| No tokens / credential paths / URLs in any row | invariant | Least disclosure; endpointRef closed grammar + sink test. |
+| Read-model-not-control-plane (no v1 consumer routes work from this) | invariant | Signal vs. authority; `advisory: true` + the FD-17 ratchet; consumer requires the separate tracked spec (ACT-1153). |
+| Every peer failure is a named closed-enum row, never an omitted machine | invariant | No Silent Degradation. |
+| Origin binding + monotonicity + self-claim backstop | invariant | Deterministic trust rules; no judgment involved. |
+| Freshness/status classifier (TTL, skew, stale thresholds) | judgment-candidate | Floor: a row past effective expiry may NEVER classify `available`; conservative default `unknown`. Arbiter: config-tunable ceilings with spec-named defaults (FD 2). |
+| Conflict presentation (own-source contradictions) | judgment-candidate | Floor: contradictions are never silently merged; observe-only in v1. Arbiter: spec-fixed rule now; operator-resolution flow only via a future spec. |
+| Refresh/pull budget & brakes | judgment-candidate | Floor: single-flight + rate-limit + per-origin backoff/breaker + zero LLM spend + no metered probes. Arbiter: config knobs with named defaults. |
+| Increment 4 attention thresholds | judgment-candidate | Floor: ONE aggregated deduped item (Bounded Notification Surface); hysteresis required. Arbiter: config with named defaults (FD 8). |
+
+## Frontloaded Decisions
+
+1. **Vocabulary:** v1 admits only `models:<doorwayId>/<modelId>` rows whose id
+   parses under the format clamp and whose doorway id is a registered
+   doorway. `route`/`service` kinds: reserved, rejected on write. The
+   `models:` namespace is derivable only from doorway-scan output — format
+   is clamped in code; membership is NOT a second hand-maintained list.
+2. **Freshness defaults:** transport TTL ceiling 10 min (≥ 2× the 30s-5min
+   transport cadences, anti-flap), applied via Trust rule 3's
+   transport-only formula with the per-origin `lastConfirmedAt` re-clamp;
+   observation freshness ages separately on the source cadence
+   (`localStaleAfter` 24h). Future-dating skew is ONE number, not two:
+   `epochClampBound` (24h) bounds BOTH the epoch sanity clamp and the
+   `observedAt` future-clamp, and `watermarkMaxAge` is also 24h. The
+   round-6 finding removed a third, contradictory "±2 min" tolerance and its
+   `skewToleranceMs` key — two different published numbers for one bound is
+   exactly the drift a converged spec must not ship. Config-tunable
+   (`capabilityRegistry.freshness.*`) — numbers cheap-to-change-after
+   behind the dark flag; the classifier floor is invariant.
+3. **Transport:** the digest+pull design in `## Ingest and transport` — one
+   chokepoint, no new mesh RPC, no new trust path, no read-time fan-out.
+4. **Persistence:** durable atomic-write JSON at
+   `state/capability-registry.json` for the SELF-projection only
+   (single-writer funnel, temp-file+rename — the torn-state lesson; all
+   source adapters feed one writer). Peer rows in-memory only. Explicitly
+   NOT the replicated-store foundation. Container choice
+   cheap-to-change-after (drop-and-rebuild; the anti-replay watermark is
+   deliberately NOT stored in it — see Trust rule 2).
+5. **HTTP contract:** `200` truthful-empty with `scanState`, `503`
+   only-when-dark, pool partial failures as named rows in a `200`. Dark ≠
+   empty, structurally distinct.
+6. **Authorization:** `scope=pool` rides the same gate as `GET /pool`;
+   deny-by-default until the increment that enables it. Per-row owner
+   restrictions: a named follow-up (all rows pool-visible-redacted in v1).
+7. **Conflict:** self-claim supremacy as a declared backstop (Trust rule 5);
+   cross-machine contradictions cannot enter by construction; own-source
+   `conflict` stays observe-only with provenance.
+8. **Refresh cadence/budget:** the `capability-registry-refresh` job (ships
+   `enabled: false`) is THE local-rebuild driver; a completed doorway-scan
+   run ALSO triggers a rebuild (event, not cadence), so the two jobs
+   compose without a second schedule. Peer ingest rides the heartbeat
+   digest. Attention: ONE deduped aggregated item after 3 consecutive
+   all-stale ticks counted over PARTICIPATING peers only —
+   `not-participating` (feature-dark) machines are excluded from the
+   hysteresis, and a tick with ZERO participating peers counts as nothing
+   (never toward the alarm — vacuous all-stale must not fire it). A cohort
+   machine in a mostly-dark fleet therefore never alarms about healthy
+   non-participants, while dark peers stay VISIBLE as `not-participating`
+   rows (excluded from alarms, never from the view). Priority medium,
+   episode-keyed. Numbers config-tunable, cheap-tagged.
+9. **Granularity:** v1 contract is exactly the v6 record's field set. Quotas
+   / prompt-support / channel-compat are ADDITIVE optional fields behind a
+   `schemaVersion` bump. The routing-consumer minimum contract belongs to
+   the future routing spec (ACT-1153), which MUST treat every remote claim
+   as an unverified hint requiring local confirmation before commitment —
+   self-reported `evidenceClass` never substitutes for receiver
+   verification (the reserved `receiver-verified` class is that future
+   increment's contract).
+10. **Operator UX:** dashboard rendering SCOPED OUT of Increments 0-4
+    (API-only, as `/doorways` shipped). The follow-up is REGISTERED
+    (ACT-1156, Close the Loop): a section of the existing Machines tab
+    rendering self-reported claims distinguishably; mobile failure summary
+    one line per machine
+    ("<nickname> — N capabilities, M stale, K failed (as of <age>; oldest
+    observation <age>)").
+11. **Config keys (named):** `capabilityRegistry.enabled` (Increment 2+;
+    omitted ⇒ resolveDevAgentGate — live on a development agent, dark on
+    the fleet), `capabilityRegistry.poolScope.enabled` (Increment 4 cohort),
+    `capabilityRegistry.freshness.{remoteTtlCeilingMs,localStaleAfterMs,epochClampBoundMs,watermarkMaxAgeMs}`
+    (there is deliberately NO `skewToleranceMs` — `epochClampBoundMs` is the
+    single future-dating bound),
+    `capabilityRegistry.limits.{maxEntriesPerMachine,maxPoolResponseCapabilityRows}`
+    (the pool bound governs CAPABILITY rows only — per-machine failure rows are
+    counted separately and never dropped; see Trust rule 6).
+    Job manifest: `capability-registry-refresh`, ships `enabled: false`.
+    Config defaults ride `migrateConfig()`; the CLAUDE.md template entry
+    (FD 16) rides `migrateClaudeMd()` — both per Migration Parity.
+12. **Dark-route semantics:** dark = `503` with `code:
+    "capability-registry-dark"`, NEVER the truthful-empty `200` (the round-1
+    draft's rollback text pre-decided the dishonest direction; corrected).
+13. **Schema forward-compat:** a peer projection with unknown/higher
+    `schemaVersion` is a named failure row (`version-unsupported`), never a
+    silent drop and never a partial parse — specified BEFORE Increment 3
+    (mixed versions are the NORMAL state during a rolling update).
+14. **Validation clamp numbers:** maxEntriesPerMachine 200,
+    maxPoolResponseCapabilityRows 2000, string fields ≤ 256 chars, evidence
+    exactly 2 keys, heartbeat digest ≤ 64 bytes — and that digest bound is
+    made arithmetic by the envelope width clamps it depends on
+    (`schemaVersion` ≤ 3 digits, `machineEpoch` ≤ 11, `projectionSeq` ≤ 10,
+    `scanGeneration` ≤ 10, `truncated`/`scanState` one digit each, 16-hex
+    entries hash ⇒ 63 bytes worst case). The ingest section states the SAME
+    64-byte number; the round-6 finding corrected an earlier 72-vs-64
+    disagreement between the two sections. Cheap-tagged with one constraint:
+    `limits.*` must be changed fleet-uniformly (or receiver limit ≥ any
+    origin's cap) — a receiver with a lower cap than an origin's honest
+    projection rejects it loudly (`over-limit`), which is visible but
+    avoidable drift.
+15. **Testing:** Increment 1 fixture tests as listed — INCLUDING the four
+    round-6/7 regression fixtures: (a) a replayed identical heartbeat AND a
+    replayed pull response each leave `lastConfirmedAt` unchanged so the row
+    goes `stale` on schedule (the pull case covers `pull-only` mode; a
+    wrong-nonce response classifies `malformed`),
+    (b) the status matrix is TOTAL (every `(probeOutcome, evidenceClass,
+    age)` combination classifies, with `probeOutcome: unknown` never
+    reaching an expiry arm), (c) two disagreeing `sourceDetail` rows for one
+    `capabilityId` render `conflict` WITH both provenances, and (d) a
+    maximum-width envelope serializes to a digest ≤ 64 bytes while an
+    over-width value is refused at write — PLUS Tier 2 integration
+    tests over the full HTTP pipeline (`/capability-registry`,
+    `/capability-registry/health`, and `scope=pool` including
+    partial-failure rows) PLUS the Tier 3 E2E feature-alive lifecycle test
+    (production init path; route answers `200` truthful-empty, not `503`)
+    — all three tiers, from the increment that mounts each surface
+    (Testing Integrity Standard).
+16. **Agent awareness:** the CLAUDE.md template gains the Registry First
+    entry ("which machine can serve capability X?" → `GET
+    /capability-registry`) in the SAME PR that mounts the route, delivered
+    to existing agents via `migrateClaudeMd()` (FD 11).
+17. **The advisory marker is ratcheted, not cultural:** the SAME PR that
+    mounts the route ships a named lint/ratchet — "no non-test code consumes
+    `/capability-registry` responses for admission, placement, or routing
+    decisions" — registered against the read-model invariant in the
+    Standards Enforcement Coverage inventory, so a future in-repo consumer
+    cannot quietly promote this surface to authority. (Round-2 finding: an
+    unchecked `advisory: true` is decorative; this is the structural guard.)
+
+## Maturation plan
+
+- **test-agent-live:** Increment 1's synthetic two-machine fixtures run in CI
+  from the first PR; the test agent (Codey's install) arms the route the
+  moment Increment 2's release reaches it, via an EXPLICIT
+  `capabilityRegistry.enabled: true` (never an assumption about how the
+  dev-agent gate resolves on his install).
+- **dev-agent-live:** Increment 2 — route live on the development agent
+  (Echo), observe-only, refresh job armed manually.
+- **fleet:** Increment 3 ships dark fleet-wide; Increment 4 enables a
+  bounded cohort whose doorway-scan job is enabled (tracked precondition:
+  ACT-1155).
+- **graduation criterion:** 7 days of Increment-4 cohort soak with zero
+  false `available` classifications (spot-audited against live doorway
+  state), zero unbounded-growth events, and the attention item firing only
+  on genuine sustained staleness. The measurement surface is
+  `GET /capability-registry/health` (mounted with Increment 2): ingest
+  counts, rejections by closed reason PER ORIGIN (a locked-out or skewed
+  origin is diagnosable, never silent), pulls, breaker states, watermark
+  ages, and per-status row counts — Increment 4's "publish metrics" refers
+  to THIS surface, so the criterion is measurable, not aspirational.
+- **dark-window:** each increment's flag stays dark ≥ 48h after its release
+  reaches an install before being enabled there.
+- Tracked dependencies (pinned against auto-expiry sweep — both are
+  deadline-bearing registry entries, not ordinary pending items):
+  ACT-1153 (routing consumer, deliberately deferred), ACT-1155
+  (doorway-scan graduation, Increment 4 precondition).
 
 ## Alternatives considered
 
 ### A. Proxy `/doorways` from every peer on each request
 
-Rejected for v1: it couples dashboard latency to peer availability, creates
-partial-response ambiguity, and makes repeated reads expensive. It may be a
-later “live probe” mode layered over the durable projection.
+Rejected for v1: couples dashboard latency to peer availability, creates
+partial-response ambiguity, and makes repeated reads expensive. The
+digest+pull ingest keeps reads local; a true "live probe" mode may layer on
+later.
 
 ### B. Copy every peer's doorway JSON into one canonical global store
 
-Rejected: it creates a second authority, loses machine-local posture, and makes
-conflicts look like consensus. Keep projections machine-local and merge only at
-the read surface.
+Rejected: creates a second authority, loses machine-local posture, and makes
+conflicts look like consensus. Keep projections machine-local and merge only
+at the read surface. (Origin binding — Trust rule 1 — also closes the
+indirect version: hop-0 export makes re-exported corroboration impossible.)
 
 ### C. Let the scheduler route work immediately from the registry
 
-Deferred: stale or conflicting capability data must first soak. v1 is
-observe-only; a later routing proposal must define admission, lease ownership,
-fallback, and operator override separately.
+Deferred to a separate spec, tracked as ACT-1153 (Close the Loop: a
+registered work item, not prose). That spec must define admission, lease
+ownership, fallback, operator override, hard fail-closed on unknown/stale
+claims, and local confirmation of self-reported remote claims (FD 9).
 
-### D. Use one generic “online” boolean
+### D. Use one generic "online" boolean
 
 Rejected: online transport does not prove a doorway or capability is usable.
-Rows retain independent doorway, mesh, and freshness evidence.
+Rows retain independent doorway, mesh, and freshness evidence — plus
+`evidenceClass`, so probe depth is honest per row.
+
+### E. Industry patterns (service discovery / gossip / CRDT)
+
+What we borrow and what we deliberately avoid: from Consul/Kubernetes-style
+discovery we borrow TTL-bounded health rows and explicit
+readiness-vs-liveness separation (`evidenceClass` is our readiness-depth
+analog), but reject the trusted central catalog (recreates Alternative B in
+a mesh whose machines are mutually authenticated, not mutually trusted).
+From gossip (SWIM-style) we reject transitive claims outright — origin
+binding forbids exactly what gossip optimizes — and our convergence-speed
+need is met by the existing heartbeat cadence. From CRDT/LWW registers we
+reject silent last-writer-wins conflict resolution ("conflicts look like
+consensus"); we keep contradictions visible with provenance instead.
+Watch/anti-entropy semantics are unnecessary at pool scale (≤ tens of
+machines): digest-compare per heartbeat IS our anti-entropy, at fixed cost.
+The nearest standard pattern is HTTP conditional caching, and v1 is
+deliberately isomorphic to it: the digest IS an ETag, the digest-change
+pull IS a conditional GET, `remoteTtlCeiling` IS the Cache-Control TTL,
+and `scanGeneration` IS a revision counter. What we add beyond ETag-style
+caching is exactly the part a mutually-authenticated-but-not-mutually-
+trusted mesh requires and a trusted HTTP origin does not: origin binding,
+the anti-replay watermark, and receiver-owned freshness. Everything else
+reuses existing primitives (heartbeat, pull verb, breakers, attention
+aggregation) rather than new machinery.
 
 ## Rollout ladder and rollback
 
 ### Increment 0 — schema and read-only local projection (dark)
 
-Define the schema, validation limits, source adapters, and a local status
-reader. No route is mounted and no peer traffic is added. Rollback is deleting
-the unreferenced schema/reader; no user state is authoritative.
+Define the schema, validation limits, closed enums, source adapters behind
+the single-writer funnel, and a local status reader. No route mounted, no
+peer traffic. Rollback: delete the unreferenced schema/reader.
 
 ### Increment 1 — test rung
 
-Fixture tests cover local `/doorways` joins, stale expiry, conflicting peer
-claims, malformed remote rows, and partial pool failures. A synthetic two-machine
-mesh proves machine identity and no-token disclosure. Rollback is disabling the
-test-only adapter; no production behavior changes.
+Fixture tests cover local `/doorways` joins, stale expiry, receiver TTL
+clamping (all three formula arms + the matching-digest re-clamp),
+origin-mismatch rejection, epoch/seq replay rejection (including epoch
+supersession recovery, the epoch sanity clamp, and watermark aging healing
+a locked-out origin), timestamp-excluded digest stability (a re-stamped
+rebuild does not churn the digest), over-limit
+whole-rejection AND the local truncated-flag path, malformed rows,
+version-unsupported rows, digest determinism (two rebuilds of identical
+state → identical digests), `not-participating` classification, digest-flap
+brake behavior, and partial pool failures. A synthetic two-machine mesh
+proves machine identity binding and no-token disclosure (endpointRef sink
+test). Rollback: disable the test-only adapter.
 
 ### Increment 2 — development agent (observe-only)
 
-Mount `GET /capability-registry` locally and populate from this agent's actual
-doorway scan plus authenticated pool observations. Add a bounded refresh job
-disabled by default. Rollback is an explicit dark flag that makes routes return
-the documented unavailable/unknown state and stops refresh; retain no routing
-decisions.
+Mount `GET /capability-registry` locally (dev-agent gate resolution),
+populated from this agent's actual doorway scan plus authenticated pool
+observations; ship the Tier 2 + Tier 3 tests with it. The refresh job ships
+`enabled: false`. Rollback: `capabilityRegistry.enabled: false` — routes
+answer the documented dark `503`, refresh stops.
 
 ### Increment 3 — fleet dark read surface
 
-Ship the route and schema to fleet agents, but keep peer scope and refresh dark
-unless the fleet flag is enabled. Monitor freshness, conflict, payload size,
-peer failure rates, and disclosure audits. Rollback is the fleet flag off and
-versioned schema reader retained for forward compatibility.
+Ship route + schema fleet-wide, dark by default. Peer scope and refresh stay
+dark. The `version-unsupported` forward-compat contract (FD 13) is REQUIRED
+here. **Population dependency, stated honestly:** the local source is the
+doorway-scan job, which ships `enabled: false` fleet-wide — a fleet machine
+that never runs it projects `scanState: "never-observed"` truthfully and
+permanently. Increment 3 therefore ships KNOWINGLY INERT on the fleet, and
+graduating the scan job is a NAMED, TRACKED precondition of Increment 4
+(ACT-1155) — without it, Increment 4's cohort would observe nothing and its
+attention item would be permanently meaningless (the dark-but-load-bearing
+lesson; the surface itself is advisory-only, so `dark-default` is its honest
+class, not a G3 load-bearing gap).
 
 ### Increment 4 — fleet observe-only
 
-Enable pool read/refresh for a bounded cohort. Publish metrics and one
-aggregated attention item for sustained stale/conflict conditions. No consumer
-may make routing or admission decisions from this surface yet. Rollback is
-cohort disable plus refresh stop; stale rows expire naturally.
+Enable pool read/refresh for a bounded cohort whose scan job is enabled
+(ACT-1155 delivered). Publish metrics and ONE aggregated attention item
+(lease-holder raiser, 3-tick hysteresis) for sustained stale/conflict. No
+consumer may make routing or admission decisions from this surface (FD 17's
+ratchet). Rollback: cohort disable + refresh stop; remote rows expire from
+memory under receiver TTLs; local rows rebuild on next scan.
 
 ### Future increment — supervised routing (not in this spec)
 
-Only after convergence and soak evidence may a separate spec authorize a
-consumer. It must define lease ownership, fallback, operator override, and a
-hard fail-closed rule for unknown/stale capability claims.
+Tracked as ACT-1153. Only after convergence and soak evidence may a separate
+spec authorize a consumer; it must define lease ownership, fallback, operator
+override, hard fail-closed on unknown/stale claims, and receiver-side
+confirmation of self-reported claims (FD 9).
 
 ## Security, privacy, and multi-machine failure posture
 
-- Peer reads require existing machine authentication and authorization; no new
-  trust path is implied by this registry.
-- Clamp counts, strings, arrays, timestamps, and enum values on write and read.
-- Never return tokens, credential paths, raw model prompts, or private tunnel
-  URLs. Pool rows are machine-qualified and redacted.
-- A peer timeout, stale epoch, malformed payload, or clock-skew rejection yields
-  a named failure row, not an omitted machine.
-- Local and remote evidence are labeled separately. “Unknown” is not “down,”
-  and “reachable” is not “capable.”
+- Peer reads require existing machine authentication and authorization; no
+  new trust path is implied. Pool scope is deny-by-default until its
+  increment enables it.
+- All clamps are enumerated with numbers (FD 14); enums are closed;
+  `evidence` is a closed schema; unknown keys drop on receive.
+- Never return tokens, credential paths, raw model prompts, or tunnel URLs.
+  `endpointRef` is grammar-enforced opaque; display fields carry no URLs;
+  pool rows are machine-qualified and redacted.
+- A peer timeout, stale/replayed projection, origin mismatch, clock-skew
+  rejection, malformed payload, unsupported schema version, or over-limit
+  projection yields a NAMED closed-enum failure row, not an omitted machine
+  and not verbatim error text.
+- Local and remote evidence are labeled separately, with self-reported probe
+  depth (`evidenceClass`). "Unknown" is not "down," "reachable" is not
+  "capable," "CLI present" is not "model answered," and — the residual
+  accepted risk, named honestly — an authenticated peer CAN lie about
+  itself in v1; nothing downstream may treat such claims as verified
+  (FD 9 / FD 17).
+- Rows rendered into agent context ride the untrusted-data envelope; rows
+  rendered into HTML are escaped at the funnel.
 
 ## Open questions for convergence
 
-1. **Canonical capability vocabulary:** Should v1 limit `capabilityId` to the
-   existing `/capabilities` keys and doorway `topModels`, or also admit route
-   and service capabilities from pool advertisements? Who owns the enum?
-2. **Freshness bounds:** What default TTL and maximum clock-skew tolerance are
-   acceptable for peer rows? Should TTL vary by capability kind or doorway?
-3. **Transport:** Should pool scope use an existing authenticated pull verb,
-   piggyback on heartbeat, or add a dedicated mesh RPC? Which choice best avoids
-   fan-out and thundering herds?
-4. **Persistence:** Is a machine-local JSON/SQLite projection sufficient, or
-   must the registry reuse an existing pool store and replication semantics?
-5. **Failure HTTP contract:** Should unavailable local state be `200` with
-   explicit unknown entries (recommended for a read model) or `503` when its
-   source is absent? What should mixed pool failures return?
-6. **Authorization:** Which existing capability/operation gate authorizes
-   `scope=pool`, and should machine owners be able to restrict individual
-   capability rows beyond the current pool visibility policy?
-7. **Conflict policy:** Should contradictory claims remain `conflict` until an
-   operator resolves them, or may a newer local observation automatically win?
-8. **Refresh cadence and budget:** What cadence, concurrency cap, and alert
-   threshold fit the current mesh without creating a new background-spend or
-   attention-flood risk?
-9. **Doorway-to-capability granularity:** Is model identity enough, or must the
-   row include prompt/tool support, quotas, and channel compatibility? What is
-   the minimum useful contract for a later routing consumer?
-10. **Operator UX:** Which existing dashboard surface should render the pool
-    view, and what is the smallest mobile-friendly failure summary?
+*(none — all resolved into Frontloaded Decisions above)*
 
 ## Non-goals
 
 No implementation, automatic routing, credential synchronization, peer
 configuration mutation, new login/enrollment flow, or LLM-based capability
-classification is included in ACT-409.
-
+classification is included in ACT-409. The supervised routing consumer is
+explicitly out of scope and tracked as ACT-1153.

--- a/docs/specs/cross-machine-door-capability-registry.md
+++ b/docs/specs/cross-machine-door-capability-registry.md
@@ -1,0 +1,219 @@
+---
+title: "Cross-Machine Door + Capability Registry"
+slug: "cross-machine-door-capability-registry"
+author: "codey"
+status: draft
+approved: false
+review-convergence: pending
+spec-only: true
+---
+
+# Cross-Machine Door + Capability Registry
+
+## Scope and status
+
+This is a deliberately incomplete, spec-first draft for ACT-409. It proposes a
+cross-machine read model; it does not implement routes, storage, mesh verbs, or
+fleet rollout. Open questions are recorded instead of guessed. Justin's
+convergence review and the reviewer lanes are expected to settle them.
+
+## Problem
+
+Instar already has two useful but separate truths:
+
+- `GET /doorways` is the doorway/model knowledge registry. It describes how a
+  machine can reach model providers and overlays machine-local probe state.
+- The multi-machine pool surfaces (`GET /pool`, pool machine records, mesh
+  endpoint propagation, leases, placement, and capability advertisements)
+  describe machines and some operational reachability.
+
+Neither is a durable, queryable answer to: “Which machine can serve this
+capability, through which doorway, with what freshness and authorization
+posture?” Operators must join local `/doorways` data to pool data manually.
+That creates stale routing, ambiguous failures, and multi-machine friction: a
+capability can be present in a peer's config but unavailable at runtime, or a
+door can be reachable locally while its advertised peer endpoint is stale.
+
+The cross-machine registry adds a bounded, machine-qualified read model that
+links a capability to its serving machine(s), doorway, endpoint reference,
+verification time, and honest status. It is a projection, not a new authority:
+local doorway truth and authenticated machine/mesh state remain the sources.
+
+## Design principles
+
+1. **Read model, not control plane.** v1 discovers and reports; it does not
+   migrate sessions, mint credentials, or automatically route work.
+2. **Source-linked freshness.** Every row names its source (`doorways` or pool /
+   mesh observation), observed-at time, and freshness class. Missing or stale
+   data is represented explicitly, never omitted or converted to “available.”
+3. **Machine-qualified identity.** Keys include stable machine id and capability
+   id. Nicknames and URLs are display fields, not identity.
+4. **Authenticated, untrusted remote data.** Peer snapshots are accepted only
+   through existing machine-authenticated mesh paths, then schema-clamped as
+   untrusted data. Remote descriptions never become instructions or executable
+   commands.
+5. **Least disclosure.** Store endpoint references and capability metadata, not
+   tokens, private model prompts, or raw credential locations. Pool scope obeys
+   existing operator authorization.
+6. **Deterministic conflict handling.** A local live observation outranks an
+   older peer claim; contradictory claims remain visible with provenance rather
+   than being silently merged.
+
+## Proposed record (v1)
+
+The registry is a durable, machine-local projection with a pool read assembled
+from authenticated peer projections:
+
+```json
+{
+  "schemaVersion": 1,
+  "machineId": "mesh-machine-id",
+  "entries": [{
+    "capabilityId": "models:anthropic/claude-opus-4-8",
+    "capabilityKind": "model|route|service",
+    "doorwayId": "claude-code",
+    "machineId": "mesh-machine-id",
+    "status": "available|unavailable|unknown|stale|conflict",
+    "endpointRef": "mesh://machine/doorways",
+    "observedAt": "2026-07-25T00:00:00Z",
+    "expiresAt": "2026-07-25T00:10:00Z",
+    "source": "local-doorways|peer-pool|mesh-heartbeat",
+    "evidence": { "doorwayScanAt": "...", "machineEpoch": 42 }
+  }]
+}
+```
+
+`endpointRef` is an opaque route reference, never a bearer URL. `expiresAt` is
+required for remotely derived rows. A row without a fresh observation cannot
+be selected as available by a future routing consumer.
+
+## Surfaces and ownership (proposed)
+
+- `GET /capability-registry` — this machine's redacted projection; always
+  returns a truthful empty/unknown state when no observations exist.
+- `GET /capability-registry?scope=pool` — operator-authorized merge of peer
+  projections, with per-machine failure rows and age/freshness preserved.
+- `POST /capability-registry/refresh` — bounded, read-only refresh trigger;
+  no automatic routing or credential use.
+- `/capabilities` advertises the read surfaces once implemented.
+
+The existing `/doorways` registry remains authoritative for doorway/model facts
+on each machine. Existing pool and mesh endpoint routes remain authoritative for
+machine identity and transport reachability. The new registry owns only the
+join, freshness classification, and conflict presentation.
+
+## Alternatives considered
+
+### A. Proxy `/doorways` from every peer on each request
+
+Rejected for v1: it couples dashboard latency to peer availability, creates
+partial-response ambiguity, and makes repeated reads expensive. It may be a
+later “live probe” mode layered over the durable projection.
+
+### B. Copy every peer's doorway JSON into one canonical global store
+
+Rejected: it creates a second authority, loses machine-local posture, and makes
+conflicts look like consensus. Keep projections machine-local and merge only at
+the read surface.
+
+### C. Let the scheduler route work immediately from the registry
+
+Deferred: stale or conflicting capability data must first soak. v1 is
+observe-only; a later routing proposal must define admission, lease ownership,
+fallback, and operator override separately.
+
+### D. Use one generic “online” boolean
+
+Rejected: online transport does not prove a doorway or capability is usable.
+Rows retain independent doorway, mesh, and freshness evidence.
+
+## Rollout ladder and rollback
+
+### Increment 0 — schema and read-only local projection (dark)
+
+Define the schema, validation limits, source adapters, and a local status
+reader. No route is mounted and no peer traffic is added. Rollback is deleting
+the unreferenced schema/reader; no user state is authoritative.
+
+### Increment 1 — test rung
+
+Fixture tests cover local `/doorways` joins, stale expiry, conflicting peer
+claims, malformed remote rows, and partial pool failures. A synthetic two-machine
+mesh proves machine identity and no-token disclosure. Rollback is disabling the
+test-only adapter; no production behavior changes.
+
+### Increment 2 — development agent (observe-only)
+
+Mount `GET /capability-registry` locally and populate from this agent's actual
+doorway scan plus authenticated pool observations. Add a bounded refresh job
+disabled by default. Rollback is an explicit dark flag that makes routes return
+the documented unavailable/unknown state and stops refresh; retain no routing
+decisions.
+
+### Increment 3 — fleet dark read surface
+
+Ship the route and schema to fleet agents, but keep peer scope and refresh dark
+unless the fleet flag is enabled. Monitor freshness, conflict, payload size,
+peer failure rates, and disclosure audits. Rollback is the fleet flag off and
+versioned schema reader retained for forward compatibility.
+
+### Increment 4 — fleet observe-only
+
+Enable pool read/refresh for a bounded cohort. Publish metrics and one
+aggregated attention item for sustained stale/conflict conditions. No consumer
+may make routing or admission decisions from this surface yet. Rollback is
+cohort disable plus refresh stop; stale rows expire naturally.
+
+### Future increment — supervised routing (not in this spec)
+
+Only after convergence and soak evidence may a separate spec authorize a
+consumer. It must define lease ownership, fallback, operator override, and a
+hard fail-closed rule for unknown/stale capability claims.
+
+## Security, privacy, and multi-machine failure posture
+
+- Peer reads require existing machine authentication and authorization; no new
+  trust path is implied by this registry.
+- Clamp counts, strings, arrays, timestamps, and enum values on write and read.
+- Never return tokens, credential paths, raw model prompts, or private tunnel
+  URLs. Pool rows are machine-qualified and redacted.
+- A peer timeout, stale epoch, malformed payload, or clock-skew rejection yields
+  a named failure row, not an omitted machine.
+- Local and remote evidence are labeled separately. “Unknown” is not “down,”
+  and “reachable” is not “capable.”
+
+## Open questions for convergence
+
+1. **Canonical capability vocabulary:** Should v1 limit `capabilityId` to the
+   existing `/capabilities` keys and doorway `topModels`, or also admit route
+   and service capabilities from pool advertisements? Who owns the enum?
+2. **Freshness bounds:** What default TTL and maximum clock-skew tolerance are
+   acceptable for peer rows? Should TTL vary by capability kind or doorway?
+3. **Transport:** Should pool scope use an existing authenticated pull verb,
+   piggyback on heartbeat, or add a dedicated mesh RPC? Which choice best avoids
+   fan-out and thundering herds?
+4. **Persistence:** Is a machine-local JSON/SQLite projection sufficient, or
+   must the registry reuse an existing pool store and replication semantics?
+5. **Failure HTTP contract:** Should unavailable local state be `200` with
+   explicit unknown entries (recommended for a read model) or `503` when its
+   source is absent? What should mixed pool failures return?
+6. **Authorization:** Which existing capability/operation gate authorizes
+   `scope=pool`, and should machine owners be able to restrict individual
+   capability rows beyond the current pool visibility policy?
+7. **Conflict policy:** Should contradictory claims remain `conflict` until an
+   operator resolves them, or may a newer local observation automatically win?
+8. **Refresh cadence and budget:** What cadence, concurrency cap, and alert
+   threshold fit the current mesh without creating a new background-spend or
+   attention-flood risk?
+9. **Doorway-to-capability granularity:** Is model identity enough, or must the
+   row include prompt/tool support, quotas, and channel compatibility? What is
+   the minimum useful contract for a later routing consumer?
+10. **Operator UX:** Which existing dashboard surface should render the pool
+    view, and what is the smallest mobile-friendly failure summary?
+
+## Non-goals
+
+No implementation, automatic routing, credential synchronization, peer
+configuration mutation, new login/enrollment flow, or LLM-based capability
+classification is included in ACT-409.
+

--- a/upgrades/next/cross-machine-door-capability-registry.md
+++ b/upgrades/next/cross-machine-door-capability-registry.md
@@ -1,0 +1,13 @@
+# Cross-machine door + capability registry (spec draft)
+
+## What Changed
+
+Added the ACT-409 spec-only draft and ELI16 companion for a cross-machine,
+read-only join of doorway/model knowledge with authenticated pool capability
+observations.
+
+## What to Tell Your User
+
+This PR defines the problem, boundaries, rollout ladder, rollback posture, and
+open convergence questions. It intentionally ships no implementation or routing
+behavior.

--- a/upgrades/next/cross-machine-door-capability-registry.md
+++ b/upgrades/next/cross-machine-door-capability-registry.md
@@ -11,3 +11,9 @@ observations.
 This PR defines the problem, boundaries, rollout ladder, rollback posture, and
 open convergence questions. It intentionally ships no implementation or routing
 behavior.
+
+## Summary of New Capabilities
+
+- A convergible design for joining local doorway facts with authenticated
+  machine capability observations.
+- Explicit freshness, conflict, privacy, rollout, and rollback contracts.

--- a/upgrades/side-effects/cross-machine-door-capability-registry.md
+++ b/upgrades/side-effects/cross-machine-door-capability-registry.md
@@ -1,0 +1,6 @@
+# Side-effects review: cross-machine door + capability registry spec
+
+- Documentation only: no runtime, route, mesh, or persistence changes.
+- The draft explicitly keeps the registry read-only and observe-only until a
+  later converged spec authorizes a routing consumer.
+- Open questions are named rather than guessed; convergence must settle them.


### PR DESCRIPTION
## ELI16 — This draft defines how Instar could show which machine can provide which doorway or capability, how fresh that claim is, and what happens when peers disagree, without implementing routing yet.

## Spec-only

ACT-409 is intentionally a convergence draft. There are no runtime, route,
mesh, persistence, or routing changes in this PR. The main spec names the
problem, joins the existing `/doorways` registry with authenticated pool and
mesh observations, defines a bounded machine-qualified read model, considers
alternatives, and lays out dark → test rung → dev → fleet rollout and rollback.

The ELI16 companion is `docs/specs/cross-machine-door-capability-registry.eli16.md`.

## Open questions

The draft explicitly leaves vocabulary, freshness TTL, transport, persistence,
HTTP failure semantics, pool authorization, conflict policy, cadence/budget,
capability granularity, and operator UX for Justin's convergence review. No
implementation should begin until those questions are settled.

## Proof vehicle

This lane's proof is the spec review and labeled draft PR, not a live server or
CI feature evaluation. The pre-push gate passed with zero affected tests.
