### PR TITLE
feat: fleet default-ON for the L0 outbound-queue age guard

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T05-35-09-192Z-session-pool-track-d-wiring.json
+++ b/.instar/instar-dev-decisions/2026-07-25T05-35-09-192Z-session-pool-track-d-wiring.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T05:35:09.192Z",
+  "slug": "session-pool-track-d-wiring",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 12,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T05-37-39-909Z-fleet-l0-default-on.json
+++ b/.instar/instar-dev-decisions/2026-07-25T05-37-39-909Z-fleet-l0-default-on.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T05:37:39.909Z",
+  "slug": "fleet-l0-default-on",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 12,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/fleet-l0-default-on.eli16.md
+++ b/docs/specs/fleet-l0-default-on.eli16.md
@@ -1,0 +1,29 @@
+# Fleet default-ON for the zombie-message guard — plain-English overview
+
+Every Instar agent keeps a queue of messages it tried to send but could not deliver yet.
+Until today, if that queue held very old messages (from a crash weeks ago, say), a recovery
+could "helpfully" deliver them — so users received ancient messages as if they were new.
+On 2026-07-24 this hit every agent in the fleet at once.
+
+The guard that fixes it already exists and is already proven: at the moment a queued message
+is about to be delivered, its age is checked against the queue's shelf life (24 hours for the
+recovery queue). Anything older is retired to a dead-letter record with a written reason —
+never delivered. It ran all day on the test agent (where it retired a real 35-day-old message
+on its first check) and on the development agent, with zero false retirements through six
+deploys and restarts.
+
+This change flips the guard from "off unless an install turns it on" to "on unless an install
+turns it off." Concretely: the code that reads the setting changes from requiring an explicit
+"enabled: true" to treating anything except an explicit "enabled: false" as armed. Every agent
+gets the protection at its next auto-update with no setup. Any install that deliberately set
+"enabled: false" stays dark — an explicit choice is always respected.
+
+Two instant rollback levers exist independently: an install can set the flag to false, and any
+queue's shelf life can be set to zero (meaning "no expiry") in the shipped policy file. The
+worst failure direction of a bug here is a message retired too eagerly — recorded with a named
+reason, auditable, never silent — and fresh messages cannot be touched because the 24-hour bar
+is roughly a hundred times the normal retry horizon.
+
+What you need to decide: nothing further — the operator approved fleet rollout ("go fleet",
+2026-07-24 22:30 PDT) after reviewing the soak evidence. This document exists so any reader
+can understand the change without archaeology.

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -5302,14 +5302,16 @@ export class AgentServer {
     const configPath = path.join(stateDir, 'config.json');
 
     // L0 zombie-free delivery invariant (drive12 UX-first spec, Increment 1):
-    // per-install arm flag (top-level `outboundQueueExpiry.enabled`, DARK by
-    // default — test agent enables first) + the per-queue-class max age from
-    // the shipped data file (0 ⇒ no expiry, the data-edit rollback sentinel).
-    // Resolution failures fail SAFE: guard stays dark, sentinel unaffected.
+    // fleet DEFAULT-ON since v1.3.953 (operator go-fleet 2026-07-24 after
+    // test+dev soak) — absence of the top-level `outboundQueueExpiry` block
+    // arms the guard; an explicit `enabled: false` keeps an install dark.
+    // Per-queue-class max age comes from the shipped data file (0 ⇒ no expiry,
+    // the data-edit rollback sentinel). Resolution failures fail SAFE: guard
+    // stays dark, sentinel unaffected.
     let l0AgeGuard: { enabled: boolean; maxAgeMs: number } | undefined;
     try {
       const armed =
-        (this.config as unknown as { outboundQueueExpiry?: { enabled?: boolean } }).outboundQueueExpiry?.enabled === true;
+        (this.config as unknown as { outboundQueueExpiry?: { enabled?: boolean } }).outboundQueueExpiry?.enabled !== false;
       if (armed) {
         // Packaging convention for runtime-read shipped JSON is <pkg>/src/data/
         // (cf. DEFAULT_MIRROR_PATH) — plain tsc emits no JSON into dist/, so a

--- a/tests/unit/outbound-queue-expiry-wiring.test.ts
+++ b/tests/unit/outbound-queue-expiry-wiring.test.ts
@@ -39,6 +39,14 @@ describe('outbound-queue-expiry policy wiring', () => {
     expect(source).toContain(`new URL('${REL}', import.meta.url)`);
   });
 
+  it('the arm gate is fleet default-ON: absence arms, only an explicit false keeps an install dark', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'src/server/AgentServer.ts'), 'utf-8');
+    // Default-ON semantics (operator go-fleet 2026-07-24): the gate must read
+    // `enabled !== false`, never `enabled === true` (which made absence dark).
+    expect(source).toContain('outboundQueueExpiry?.enabled !== false');
+    expect(source).not.toContain('outboundQueueExpiry?.enabled === true');
+  });
+
   it('the shipped policy parses and carries the delivery-recovery class with a numeric maxAgeHours', () => {
     const parsed = JSON.parse(
       fs.readFileSync(path.join(repoRoot, 'src/data/outbound-queue-expiry.json'), 'utf-8'),

--- a/upgrades/next/fleet-l0-default-on.md
+++ b/upgrades/next/fleet-l0-default-on.md
@@ -1,0 +1,24 @@
+# Fleet default-ON: zombie-message age guard
+
+## What Changed
+The L0 delivery age-guard (merged dark in #1603, soaked on test+dev 2026-07-24) is now ON by
+default fleet-wide: queued outbound messages older than their queue's shelf life (24h for
+delivery-recovery) are retired to dead-letter with a named reason at the moment of delivery,
+instead of being replayed to users. An explicit `outboundQueueExpiry.enabled: false` keeps an
+install dark; `maxAgeHours: 0` disables expiry per queue.
+
+## Evidence
+- Test rung: retired a real 35-day stale row at first dequeue (audited reason), zero false
+  retirements all day. Dev rung: armed + boot-confirmed across restarts, zero retirements
+  (clean queue). Six deploys crossed with no misfire. Operator approval: "go fleet"
+  (2026-07-24 ~22:30 PDT, topic 29723) after the evidence proposal.
+- New wiring test pins the default-ON gate semantics (absence arms; only explicit false darkens).
+
+## What to Tell Your User
+Your agent will no longer replay days-old queued messages as if they were new. If a message
+could not be delivered for more than a day, it is set aside with a written reason instead of
+being sent late; nothing fresh is affected. If you ever want the old behavior back, one setting
+turns this off for your install.
+
+## Summary of New Capabilities
+Stale-message replay protection is now on for every agent by default.

--- a/upgrades/side-effects/fleet-l0-default-on.md
+++ b/upgrades/side-effects/fleet-l0-default-on.md
@@ -1,0 +1,39 @@
+# Side-Effects Review — fleet-l0-default-on
+
+**Change:** the L0 age-guard arm gate in AgentServer flips from `enabled === true` (default dark)
+to `enabled !== false` (default ON). One expression + comment; one new wiring test pinning the
+semantics.
+
+1. **Over-block:** none identified at the gate level. Downstream, the guard can now retire stale
+   rows on installs that never opted in. The retirement policy itself is unchanged and soaked
+   (24h bar ≈ 100x retry horizon; test-rung retired only a genuine 35-day row; zero false
+   retirements across both soak installs). Residual risk: an install with a legitimately paused
+   >24h delivery backlog would see those rows retired with named reasons — judged acceptable
+   and intended (that backlog IS the zombie-replay hazard).
+2. **Under-block:** unchanged — the guard still covers only queues named in the shipped policy
+   file (delivery-recovery at 24h). Other queues remain future policy additions.
+3. **Level-of-abstraction fit:** correct — the arm decision stays at the single construction
+   site that already owns policy resolution; no new layer.
+4. **Signal vs authority:** the guard holds narrow, deterministic authority (retire-at-dequeue
+   by age) that was deliberately granted via the converged UX-first spec and now fleet-approved
+   by the operator. Not a brittle heuristic; behavior fails SAFE (resolution failure ⇒ dark).
+5. **Interactions:** none new — DeliveryFailureSentinel behavior is untouched except rows it
+   would have replayed past the age bar; the stale-digest coalescer already handles notice flow.
+6. **External surfaces:** fleet-wide behavior change (the point). Users stop receiving stale
+   replays; operators see dead-letter records with named reasons instead. Announced via the
+   release note's user-facing sections.
+7. **Multi-machine posture:** machine-local BY DESIGN — each install's guard governs its own
+   delivery queue; no replication needed; a topic moving machines meets the destination's guard,
+   which enforces the same shipped policy.
+8. **Rollback cost:** two instant levers, no release needed — per-install `enabled: false`, or
+   per-queue `maxAgeHours: 0` in the policy file. Full revert is this one-line gate flip back.
+
+**Conclusion:** minimal-surface flip of an already-soaked guard, operator-approved for fleet.
+
+**Second-pass review (independent reviewer subagent, 2026-07-24):** Concur with the review —
+verified in code: a resolution failure leaves `l0AgeGuard` undefined and the sentinel's
+constructor default (`enabled: false`) keeps the guard dark; a missing/zero/negative/NaN
+`maxAgeHours` degrades to strict pass-through (fails toward under-block, never over-block);
+the flag has exactly one reader and the guard one callsite at dequeue (no double-fire or
+shadowing); the retire-by-age policy is deterministic transport-layer mechanics with
+named-reason audit, consistent with signal-vs-authority's deterministic-policy carve-out.


### PR DESCRIPTION
## ELI16 — the anti-stale-message guard now protects everyone by default

Every Instar agent keeps a queue of messages it tried to send but could not deliver yet. Before today's incident fix, a recovery could deliver very old queued messages as if they were new — users got weeks-old texts out of nowhere. The guard that stops this already exists and was proven all day on two installs: at the moment a queued message is about to go out, its age is checked; anything past its shelf life (24 hours for the recovery queue) is set aside with a written reason instead of sent. This change simply flips that guard from "off unless you turn it on" to "on unless you turn it off." Any install that explicitly turned it off stays off, and one setting turns it back off at any time. Nothing is ever deleted — a set-aside message always keeps its full record.

## What

Flips the L0 delivery age-guard (merged dark in #1603) to fleet default-ON: absence of the top-level `outboundQueueExpiry` block arms the guard; an explicit `enabled: false` keeps an install dark; `maxAgeHours: 0` disables expiry per queue class. One-expression gate change (`enabled === true` → `enabled !== false`) plus a wiring test pinning the semantics.

## Who sees this and what changes for them

Every Instar user whose agent previously could replay stale queued messages. After their agent's next auto-update, any queued outbound message older than its queue's shelf life (24h for delivery-recovery) is retired to a dead-letter record with a written reason — e.g. `expired — retired at delivery time` — instead of being delivered late. Users stop receiving days-old messages presented as new; nothing about fresh-message delivery changes. Operators who explicitly set `outboundQueueExpiry.enabled: false` see no change (their choice is respected).

## Evidence

- Test rung (Codey): armed 14:02 PDT 2026-07-24, retired a genuine 35-day stale row at first dequeue with audited reason; zero false retirements all day.
- Dev rung (Echo): armed 14:09, boot-confirmed across natural restarts (incl. v1.3.945 at 16:11); zero retirements (clean queue).
- Six deploys/restarts crossed on both installs with no misfire.
- Operator approval: "go fleet" — 2026-07-24, topic 29723, following the evidence proposal (report #22).

## Rollback

Two instant levers, no release needed: per-install `outboundQueueExpiry.enabled: false`, or per-queue `maxAgeHours: 0`. Full revert is this one-line gate flip back. Failure direction is safe: a defect could only retire too eagerly — always recorded with a named reason, never silent — and cannot touch fresh messages (24h bar ≈ 100× the retry horizon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)