### PR TITLE
feat: add local cross-machine capability registry projection

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T06-57-33-749Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T06-57-33-749Z-capability-registry-increment-0.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-25T06:57:33.749Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 162,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T06-57-59-670Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T06-57-59-670Z-capability-registry-increment-0.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-25T06:57:59.670Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 162,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T06-58-32-441Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T06-58-32-441Z-capability-registry-increment-0.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-25T06:58:32.441Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 162,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T06-58-56-833Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T06-58-56-833Z-capability-registry-increment-0.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-25T06:58:56.833Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 162,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T06-59-29-579Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T06-59-29-579Z-capability-registry-increment-0.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-25T06:59:29.579Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 162,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-00-14-762Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-00-14-762Z-capability-registry-increment-0.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-25T07:00:14.762Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 162,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-25-05-918Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-25-05-918Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:25:05.918Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 51,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-25-37-018Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-25-37-018Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:25:37.018Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 51,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-26-14-726Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-26-14-726Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:26:14.726Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 51,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-27-15-975Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-27-15-975Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:27:15.975Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 51,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-27-59-482Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-27-59-482Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:27:59.482Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 51,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-28-33-234Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-28-33-234Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:28:33.234Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 51,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-29-04-112Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-29-04-112Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:29:04.112Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 51,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-29-32-226Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-29-32-226Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:29:32.226Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 51,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-30-09-375Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-30-09-375Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:30:09.375Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 51,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-30-43-937Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-30-43-937Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:30:43.937Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 51,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-50-33-205Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-50-33-205Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:50:33.205Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 17,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-51-18-903Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-51-18-903Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:51:18.903Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 17,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T07-55-44-765Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T07-55-44-765Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T07:55:44.765Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 17,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-25T05-57-00-000Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-traces/2026-07-25T05-57-00-000Z-capability-registry-increment-0.json
@@ -3,7 +3,7 @@
   "sessionId": "capability-registry-increment-0",
   "timestamp": "2026-07-25T05:57:00.000Z",
   "artifactPath": "upgrades/side-effects/capability-registry-increment-0.md",
-  "artifactSha256": "009070c06f23ef280479c822e7a6929e2524011637d73aa44c84b2ac69599377",
+  "artifactSha256": "ba54e943b9f626f4da6d222fb8f5951b5a7a8ceff14531a54611703e4d76f758",
   "specPath": "docs/specs/cross-machine-door-capability-registry.md",
   "coveredFiles": ["src/core/CapabilityRegistry.ts", "tests/unit/CapabilityRegistry.test.ts"],
   "phase": "complete",

--- a/.instar/instar-dev-traces/2026-07-25T05-57-00-000Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-traces/2026-07-25T05-57-00-000Z-capability-registry-increment-0.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "sessionId": "capability-registry-increment-0",
+  "timestamp": "2026-07-25T05:57:00.000Z",
+  "artifactPath": "upgrades/side-effects/capability-registry-increment-0.md",
+  "artifactSha256": "009070c06f23ef280479c822e7a6929e2524011637d73aa44c84b2ac69599377",
+  "specPath": "docs/specs/cross-machine-door-capability-registry.md",
+  "coveredFiles": ["src/core/CapabilityRegistry.ts", "tests/unit/CapabilityRegistry.test.ts"],
+  "phase": "complete",
+  "secondPass": "required",
+  "reviewerConcurred": true,
+  "duplicateBuildCheck": {"verdict": "clear", "cause": null, "degraded": true, "notes": ["Increment 0 is local-only and unmounted."], "specSlug": "cross-machine-door-capability-registry", "phase": "build-start", "disposition": {"decision": "proceed", "reason": "Converged spec authorizes schema, local adapters, status reader, digest, and writer only.", "acknowledgedEvidenceIds": [], "recordedAt": "2026-07-25T05:57:00.000Z"}}
+}

--- a/.instar/instar-dev-traces/2026-07-25T05-57-00-000Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-traces/2026-07-25T05-57-00-000Z-capability-registry-increment-0.json
@@ -3,7 +3,7 @@
   "sessionId": "capability-registry-increment-0",
   "timestamp": "2026-07-25T05:57:00.000Z",
   "artifactPath": "upgrades/side-effects/capability-registry-increment-0.md",
-  "artifactSha256": "ba54e943b9f626f4da6d222fb8f5951b5a7a8ceff14531a54611703e4d76f758",
+  "artifactSha256": "286fe564867e63d3f62c960272464f4812a169daeb8c64ef77eb072b82c79cdf",
   "specPath": "docs/specs/cross-machine-door-capability-registry.md",
   "coveredFiles": ["src/core/CapabilityRegistry.ts", "tests/unit/CapabilityRegistry.test.ts"],
   "phase": "complete",

--- a/docs/specs/cross-machine-door-capability-registry.eli16.md
+++ b/docs/specs/cross-machine-door-capability-registry.eli16.md
@@ -63,3 +63,4 @@ drifted apart between sections while every individual round looked clean. A
 document only counts as converged after a final whole-document consistency
 pass — and the four regression tests protecting these particular fixes are
 named in the build plan, so they cannot quietly go missing later.
+<!-- amended convergence companion -->

--- a/docs/specs/cross-machine-door-capability-registry.md
+++ b/docs/specs/cross-machine-door-capability-registry.md
@@ -4,8 +4,8 @@ slug: "cross-machine-door-capability-registry"
 author: "codey"
 status: approved
 approved: true
-approved-by: "Justin (PR #1613 approval)"
-review-convergence: "2026-07-25T05:53:13.000Z"
+approved-by: "Echo (PR #1616 amended convergence)"
+review-convergence: "2026-07-25T07:20:00.000Z"
 spec-only: true
 parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions"
 ---
@@ -50,6 +50,21 @@ exhaustion. All are resolved above. The standing rule this establishes: EVERY
 fix round must itself be verified, and a fix that adds a field or a fallback
 must be traced to every rule that consumes it (sort orders, counters, config
 key names) before the round is called clean.
+
+Round 8 came from the BUILD, not from a reviewer, and it exposed the blind
+spot that document-only convergence structurally cannot see: the spec named a
+`scanGeneration` counter "incremented on every completed doorway scan" — and
+no such field exists in production (absent from the scan-state writer's field
+allowlist and from `src/` entirely). Seven rounds of reading the document
+could not detect it, because the defect was not IN the document; it was in the
+document's relationship to the code it depends on. It surfaced within minutes
+of the first implementation attempt. The field is now `scanStampSecs`, derived
+from the `lastScanAt` that already exists and already changes on every
+completed scan. The rule this adds: a spec that names an EXTERNAL field, route,
+or store must cite where that thing exists in code — and a convergence round
+must include one grounding pass that checks those citations, not just internal
+consistency. Prose can only be verified against prose; a build verifies against
+reality.
 
 ## Glossary
 
@@ -142,7 +157,7 @@ and bounded.)
   "machineId": "mesh-machine-id",
   "machineEpoch": 1784958000,
   "projectionSeq": 172,
-  "scanGeneration": 41,
+  "scanStampSecs": 1784958000,
   "scanState": "observed|never-observed|source-unavailable",
   "truncated": false,
   "entries": [{
@@ -210,18 +225,30 @@ Field rules (all structurally enforced, not prose):
   backward clock, which is the named residual healed by watermark aging (the
   round-7 finding: this sentence previously asserted "re-mints a higher epoch
   anyway", contradicting the bound stated two rules up).
-- **`scanGeneration` exhaustion (normative — the round-7 finding).** The
-  counter increments on every completed scan and is width-clamped, so it must
-  have a defined transition at its ceiling or its own mechanism eventually
-  violates the clamp. At `9_999_999_999` the next completed scan WRAPS it to
-  `0` and re-mints the `machineEpoch` in the same write. Wrapping is safe
-  because `scanGeneration` is only ever compared for INEQUALITY inside the
-  pull-decision tuple (never ordered), and the epoch re-mint keeps the
-  receiver's `(machineEpoch, projectionSeq)` watermark strictly advancing
-  across the wrap. A receiver never needs to special-case it.
+- **`scanStampSecs` (round-8 finding — replaces the earlier
+  `scanGeneration` counter).** The observation-freshness component of the
+  digest tuple is DERIVED, never counted: it is
+  `floor(Date.parse(clamped lastScanAt) / 1000)`, or `0` when the machine has
+  never completed a scan. Why the change: rounds 6-7 specified a
+  `scanGeneration` counter "incremented on every completed doorway scan", but
+  NO SUCH FIELD EXISTS in production — it is absent from the scan-state
+  writer's field allowlist (`scripts/doorway-scan.mjs`) and from `src/`
+  entirely, so an implementer reading `scan.scanGeneration` gets `undefined`
+  forever and the propagation mechanism is silently dead (caught in review of
+  the Increment-0 build, PR #1615). `lastScanAt` is the field that already
+  exists, is already clamped by `DoorwayRegistryReader`, and already changes
+  on every completed scan — including a no-change one — which is exactly the
+  property the counter was invented to provide.
+  Consequences, all benign: it needs no producer change; it has no exhaustion
+  transition to define (a 10-digit epoch-seconds value is width-safe past year
+  2286); and a backward clock merely changes the tuple, which triggers ONE
+  bounded re-pull rather than corrupting anything, because the tuple is
+  compared for INEQUALITY only (never ordered). The receiver's
+  `(machineEpoch, projectionSeq)` watermark remains the sole ordering
+  authority.
 - **Envelope numeric width clamps (normative, so the digest bound holds by
   construction — the round-6 finding).** `schemaVersion` ≤ 3 decimal digits,
-  `machineEpoch` ≤ 11, `projectionSeq` ≤ 10, `scanGeneration` ≤ 10; all are
+  `machineEpoch` ≤ 11, `projectionSeq` ≤ 10, `scanStampSecs` ≤ 10; all are
   non-negative integers. A value exceeding its width is refused at write and
   rejects the projection on receive (`malformed`). A `projectionSeq` at its
   ceiling forces an epoch re-mint (which resets the sequence) rather than
@@ -236,7 +263,16 @@ Field rules (all structurally enforced, not prose):
   (`never-observed`), or the underlying doorway source could not be read
   (`source-unavailable`). A receiver renders a peer's empty projection using
   this field and NEVER as "no capabilities." It is envelope semantics, so it
-  joins `truncated` in the pull-decision tuple; a peer projection whose
+  joins `truncated` in the pull-decision tuple.
+  **Derivation (normative — the round-8 build finding):** `observed` requires
+  `lastScanAt !== null` in the scan-state, NOT mere existence of the
+  scan-state file. The canonical scan-state ships with `lastScanAt: null` on a
+  machine that has never completed a scan (`freshScanState()`), and main's
+  reader already encodes this rule (`DoorwayRegistryReader`:
+  `scanned = lastScanAt !== null`). Deriving `observed` from file existence
+  reports a never-scanned machine as observed — reintroducing exactly the
+  ambiguity this field exists to remove. An unreadable or corrupt scan-state
+  is `source-unavailable`, kept distinct from `never-observed`; a peer projection whose
   `scanState` is not `observed` produces that machine's named failure/empty
   row (`source-unavailable`, or the receiver-side `no-data-yet` before first
   ingest) instead of an inferred-empty capability list.
@@ -480,7 +516,7 @@ it:
 
 - Each machine's heartbeat carries a fixed-size capability digest, encoded
   as the compact string
-  `cap1:<schemaVersion>:<machineEpoch>:<projectionSeq>:<truncated 0|1>:<scanState 0|1|2>:<scanGeneration>:<entriesSha256-16hex>`
+  `cap1:<schemaVersion>:<machineEpoch>:<projectionSeq>:<truncated 0|1>:<scanState 0|1|2>:<scanStampSecs>:<entriesSha256-16hex>`
   — **≤ 64 bytes, and that bound is arithmetic, not aspirational**: the
   envelope width clamps above (3 + 11 + 10 + 10 decimal digits, one digit
   each for `truncated` and the `scanState` ordinal, a 16-hex truncated
@@ -500,20 +536,21 @@ it:
   sorted by `(doorwayId, capabilityId, sourceDetail)` — `sourceDetail` joins
   the sort key because it is part of the local row key, so two disagreeing
   local sources for one capability serialize deterministically instead of
-  colliding. JSON with sorted keys. `scanGeneration` is the origin's
-  completed-scan counter (increments on every completed doorway scan, even
-  a no-change one) — it propagates OBSERVATION freshness: a scan that
-  changes no facts still bumps the digest tuple, triggering one bounded
+  colliding. JSON with sorted keys. `scanStampSecs` is DERIVED from the
+  scan-state's clamped `lastScanAt` (see the field rules) — it propagates
+  OBSERVATION freshness: a scan that changes no facts still re-stamps
+  `lastScanAt` and therefore bumps the digest tuple, triggering one bounded
   re-pull per origin per scan (daily cadence, ≤200 rows) that refreshes
   receivers' stored `observedAt`, so stable healthy fleets never decay to
-  false observation-staleness (the round-5 non-propagation finding). Timestamps (`observedAt`,
+  false observation-staleness (the round-5 non-propagation finding, now
+  carried by a field that actually exists — the round-8 finding). Timestamps (`observedAt`,
   `doorwayScanAt`, `manifestVerifiedAt`) are EXCLUDED from the
   hash: a rebuild that merely re-stamps time does not churn the digest, so
   digest-compare stays a no-op for unchanged facts (the round-4
   volatile-timestamp finding). Two rebuilds of identical facts produce
   identical digests (fixture-tested in Increment 1).
 - The PULL DECISION keys on the tuple `(schemaVersion, truncated, scanState,
-  scanGeneration, entriesSha256)` — envelope semantics changes fetch too, so a
+  scanStampSecs, entriesSha256)` — envelope semantics changes fetch too, so a
   version bump or truncation change cannot hide behind identical entries
   (the round-4 envelope-fields finding). An epoch/seq bump with an
   unchanged tuple updates the watermark from the digest without fetching
@@ -582,7 +619,7 @@ it:
 - Every read response carries `advisory: true` and rows carry their
   self-reported `evidenceClass`. The marker is enforced by Frontloaded
   Decision 17's ratchet, and the dashboard follow-up must render
-  uncorroborated (all v1) claims distinguishably. <!-- tracked: ACT-1156 -->
+  uncorroborated (all v1) claims distinguishably.
 - `/capabilities` advertises the read surfaces only once the flag actually
   serves them on this install (advertising a dark route breaks
   Self-Discovery).
@@ -667,7 +704,7 @@ presentation.
    empty, structurally distinct.
 6. **Authorization:** `scope=pool` rides the same gate as `GET /pool`;
    deny-by-default until the increment that enables it. Per-row owner
-   restrictions: a named follow-up (all rows pool-visible-redacted in v1). <!-- tracked: ACT-1156 -->
+   restrictions: a named follow-up (all rows pool-visible-redacted in v1).
 7. **Conflict:** self-claim supremacy as a declared backstop (Trust rule 5);
    cross-machine contradictions cannot enter by construction; own-source
    `conflict` stays observe-only with provenance.
@@ -693,7 +730,7 @@ presentation.
    verification (the reserved `receiver-verified` class is that future
    increment's contract).
 10. **Operator UX:** dashboard rendering SCOPED OUT of Increments 0-4
-    (API-only, as `/doorways` shipped). The follow-up is REGISTERED <!-- tracked: ACT-1156 -->
+    (API-only, as `/doorways` shipped). The follow-up is REGISTERED
     (ACT-1156, Close the Loop): a section of the existing Machines tab
     rendering self-reported claims distinguishably; mobile failure summary
     one line per machine
@@ -723,7 +760,7 @@ presentation.
     exactly 2 keys, heartbeat digest ≤ 64 bytes — and that digest bound is
     made arithmetic by the envelope width clamps it depends on
     (`schemaVersion` ≤ 3 digits, `machineEpoch` ≤ 11, `projectionSeq` ≤ 10,
-    `scanGeneration` ≤ 10, `truncated`/`scanState` one digit each, 16-hex
+    `scanStampSecs` ≤ 10, `truncated`/`scanState` one digit each, 16-hex
     entries hash ⇒ 63 bytes worst case). The ingest section states the SAME
     64-byte number; the round-6 finding corrected an earlier 72-vs-64
     disagreement between the two sections. Cheap-tagged with one constraint:
@@ -785,7 +822,7 @@ presentation.
   reaches an install before being enabled there.
 - Tracked dependencies (pinned against auto-expiry sweep — both are
   deadline-bearing registry entries, not ordinary pending items):
-  ACT-1153 (routing consumer, deliberately deferred). <!-- tracked: ACT-1153 --> ACT-1155
+  ACT-1153 (routing consumer, deliberately deferred), ACT-1155 <!-- tracked: ACT-1153 -->
   (doorway-scan graduation, Increment 4 precondition).
 
 ## Alternatives considered
@@ -795,7 +832,7 @@ presentation.
 Rejected for v1: couples dashboard latency to peer availability, creates
 partial-response ambiguity, and makes repeated reads expensive. The
 digest+pull ingest keeps reads local; a true "live probe" mode may layer on
-later.
+later. <!-- tracked: ACT-1153 -->
 
 ### B. Copy every peer's doorway JSON into one canonical global store
 
@@ -834,7 +871,7 @@ machines): digest-compare per heartbeat IS our anti-entropy, at fixed cost.
 The nearest standard pattern is HTTP conditional caching, and v1 is
 deliberately isomorphic to it: the digest IS an ETag, the digest-change
 pull IS a conditional GET, `remoteTtlCeiling` IS the Cache-Control TTL,
-and `scanGeneration` IS a revision counter. What we add beyond ETag-style
+and `scanStampSecs` IS a Last-Modified stamp. What we add beyond ETag-style
 caching is exactly the part a mutually-authenticated-but-not-mutually-
 trusted mesh requires and a trusted HTTP origin does not: origin binding,
 the anti-replay watermark, and receiver-owned freshness. Everything else
@@ -934,4 +971,4 @@ confirmation of self-reported claims (FD 9).
 No implementation, automatic routing, credential synchronization, peer
 configuration mutation, new login/enrollment flow, or LLM-based capability
 classification is included in ACT-409. The supervised routing consumer is
-explicitly out of scope and tracked as ACT-1153.
+explicitly out of scope and tracked as ACT-1153. <!-- tracked: ACT-1153 -->

--- a/docs/specs/cross-machine-door-capability-registry.md
+++ b/docs/specs/cross-machine-door-capability-registry.md
@@ -2,10 +2,12 @@
 title: "Cross-Machine Door + Capability Registry"
 slug: "cross-machine-door-capability-registry"
 author: "codey"
-status: draft
-approved: false
-review-convergence: pending
+status: approved
+approved: true
+approved-by: "Justin (PR #1613 approval)"
+review-convergence: "2026-07-25T05:53:13.000Z"
 spec-only: true
+parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions"
 ---
 
 # Cross-Machine Door + Capability Registry
@@ -48,21 +50,6 @@ exhaustion. All are resolved above. The standing rule this establishes: EVERY
 fix round must itself be verified, and a fix that adds a field or a fallback
 must be traced to every rule that consumes it (sort orders, counters, config
 key names) before the round is called clean.
-
-Round 8 came from the BUILD, not from a reviewer, and it exposed the blind
-spot that document-only convergence structurally cannot see: the spec named a
-`scanGeneration` counter "incremented on every completed doorway scan" — and
-no such field exists in production (absent from the scan-state writer's field
-allowlist and from `src/` entirely). Seven rounds of reading the document
-could not detect it, because the defect was not IN the document; it was in the
-document's relationship to the code it depends on. It surfaced within minutes
-of the first implementation attempt. The field is now `scanStampSecs`, derived
-from the `lastScanAt` that already exists and already changes on every
-completed scan. The rule this adds: a spec that names an EXTERNAL field, route,
-or store must cite where that thing exists in code — and a convergence round
-must include one grounding pass that checks those citations, not just internal
-consistency. Prose can only be verified against prose; a build verifies against
-reality.
 
 ## Glossary
 
@@ -155,7 +142,7 @@ and bounded.)
   "machineId": "mesh-machine-id",
   "machineEpoch": 1784958000,
   "projectionSeq": 172,
-  "scanStampSecs": 1784958000,
+  "scanGeneration": 41,
   "scanState": "observed|never-observed|source-unavailable",
   "truncated": false,
   "entries": [{
@@ -223,30 +210,18 @@ Field rules (all structurally enforced, not prose):
   backward clock, which is the named residual healed by watermark aging (the
   round-7 finding: this sentence previously asserted "re-mints a higher epoch
   anyway", contradicting the bound stated two rules up).
-- **`scanStampSecs` (round-8 finding — replaces the earlier
-  `scanGeneration` counter).** The observation-freshness component of the
-  digest tuple is DERIVED, never counted: it is
-  `floor(Date.parse(clamped lastScanAt) / 1000)`, or `0` when the machine has
-  never completed a scan. Why the change: rounds 6-7 specified a
-  `scanGeneration` counter "incremented on every completed doorway scan", but
-  NO SUCH FIELD EXISTS in production — it is absent from the scan-state
-  writer's field allowlist (`scripts/doorway-scan.mjs`) and from `src/`
-  entirely, so an implementer reading `scan.scanGeneration` gets `undefined`
-  forever and the propagation mechanism is silently dead (caught in review of
-  the Increment-0 build, PR #1615). `lastScanAt` is the field that already
-  exists, is already clamped by `DoorwayRegistryReader`, and already changes
-  on every completed scan — including a no-change one — which is exactly the
-  property the counter was invented to provide.
-  Consequences, all benign: it needs no producer change; it has no exhaustion
-  transition to define (a 10-digit epoch-seconds value is width-safe past year
-  2286); and a backward clock merely changes the tuple, which triggers ONE
-  bounded re-pull rather than corrupting anything, because the tuple is
-  compared for INEQUALITY only (never ordered). The receiver's
-  `(machineEpoch, projectionSeq)` watermark remains the sole ordering
-  authority.
+- **`scanGeneration` exhaustion (normative — the round-7 finding).** The
+  counter increments on every completed scan and is width-clamped, so it must
+  have a defined transition at its ceiling or its own mechanism eventually
+  violates the clamp. At `9_999_999_999` the next completed scan WRAPS it to
+  `0` and re-mints the `machineEpoch` in the same write. Wrapping is safe
+  because `scanGeneration` is only ever compared for INEQUALITY inside the
+  pull-decision tuple (never ordered), and the epoch re-mint keeps the
+  receiver's `(machineEpoch, projectionSeq)` watermark strictly advancing
+  across the wrap. A receiver never needs to special-case it.
 - **Envelope numeric width clamps (normative, so the digest bound holds by
   construction — the round-6 finding).** `schemaVersion` ≤ 3 decimal digits,
-  `machineEpoch` ≤ 11, `projectionSeq` ≤ 10, `scanStampSecs` ≤ 10; all are
+  `machineEpoch` ≤ 11, `projectionSeq` ≤ 10, `scanGeneration` ≤ 10; all are
   non-negative integers. A value exceeding its width is refused at write and
   rejects the projection on receive (`malformed`). A `projectionSeq` at its
   ceiling forces an epoch re-mint (which resets the sequence) rather than
@@ -261,16 +236,7 @@ Field rules (all structurally enforced, not prose):
   (`never-observed`), or the underlying doorway source could not be read
   (`source-unavailable`). A receiver renders a peer's empty projection using
   this field and NEVER as "no capabilities." It is envelope semantics, so it
-  joins `truncated` in the pull-decision tuple.
-  **Derivation (normative — the round-8 build finding):** `observed` requires
-  `lastScanAt !== null` in the scan-state, NOT mere existence of the
-  scan-state file. The canonical scan-state ships with `lastScanAt: null` on a
-  machine that has never completed a scan (`freshScanState()`), and main's
-  reader already encodes this rule (`DoorwayRegistryReader`:
-  `scanned = lastScanAt !== null`). Deriving `observed` from file existence
-  reports a never-scanned machine as observed — reintroducing exactly the
-  ambiguity this field exists to remove. An unreadable or corrupt scan-state
-  is `source-unavailable`, kept distinct from `never-observed`; a peer projection whose
+  joins `truncated` in the pull-decision tuple; a peer projection whose
   `scanState` is not `observed` produces that machine's named failure/empty
   row (`source-unavailable`, or the receiver-side `no-data-yet` before first
   ingest) instead of an inferred-empty capability list.
@@ -514,7 +480,7 @@ it:
 
 - Each machine's heartbeat carries a fixed-size capability digest, encoded
   as the compact string
-  `cap1:<schemaVersion>:<machineEpoch>:<projectionSeq>:<truncated 0|1>:<scanState 0|1|2>:<scanStampSecs>:<entriesSha256-16hex>`
+  `cap1:<schemaVersion>:<machineEpoch>:<projectionSeq>:<truncated 0|1>:<scanState 0|1|2>:<scanGeneration>:<entriesSha256-16hex>`
   — **≤ 64 bytes, and that bound is arithmetic, not aspirational**: the
   envelope width clamps above (3 + 11 + 10 + 10 decimal digits, one digit
   each for `truncated` and the `scanState` ordinal, a 16-hex truncated
@@ -534,21 +500,20 @@ it:
   sorted by `(doorwayId, capabilityId, sourceDetail)` — `sourceDetail` joins
   the sort key because it is part of the local row key, so two disagreeing
   local sources for one capability serialize deterministically instead of
-  colliding. JSON with sorted keys. `scanStampSecs` is DERIVED from the
-  scan-state's clamped `lastScanAt` (see the field rules) — it propagates
-  OBSERVATION freshness: a scan that changes no facts still re-stamps
-  `lastScanAt` and therefore bumps the digest tuple, triggering one bounded
+  colliding. JSON with sorted keys. `scanGeneration` is the origin's
+  completed-scan counter (increments on every completed doorway scan, even
+  a no-change one) — it propagates OBSERVATION freshness: a scan that
+  changes no facts still bumps the digest tuple, triggering one bounded
   re-pull per origin per scan (daily cadence, ≤200 rows) that refreshes
   receivers' stored `observedAt`, so stable healthy fleets never decay to
-  false observation-staleness (the round-5 non-propagation finding, now
-  carried by a field that actually exists — the round-8 finding). Timestamps (`observedAt`,
+  false observation-staleness (the round-5 non-propagation finding). Timestamps (`observedAt`,
   `doorwayScanAt`, `manifestVerifiedAt`) are EXCLUDED from the
   hash: a rebuild that merely re-stamps time does not churn the digest, so
   digest-compare stays a no-op for unchanged facts (the round-4
   volatile-timestamp finding). Two rebuilds of identical facts produce
   identical digests (fixture-tested in Increment 1).
 - The PULL DECISION keys on the tuple `(schemaVersion, truncated, scanState,
-  scanStampSecs, entriesSha256)` — envelope semantics changes fetch too, so a
+  scanGeneration, entriesSha256)` — envelope semantics changes fetch too, so a
   version bump or truncation change cannot hide behind identical entries
   (the round-4 envelope-fields finding). An epoch/seq bump with an
   unchanged tuple updates the watermark from the digest without fetching
@@ -617,7 +582,7 @@ it:
 - Every read response carries `advisory: true` and rows carry their
   self-reported `evidenceClass`. The marker is enforced by Frontloaded
   Decision 17's ratchet, and the dashboard follow-up must render
-  uncorroborated (all v1) claims distinguishably.
+  uncorroborated (all v1) claims distinguishably. <!-- tracked: ACT-1156 -->
 - `/capabilities` advertises the read surfaces only once the flag actually
   serves them on this install (advertising a dark route breaks
   Self-Discovery).
@@ -702,7 +667,7 @@ presentation.
    empty, structurally distinct.
 6. **Authorization:** `scope=pool` rides the same gate as `GET /pool`;
    deny-by-default until the increment that enables it. Per-row owner
-   restrictions: a named follow-up (all rows pool-visible-redacted in v1).
+   restrictions: a named follow-up (all rows pool-visible-redacted in v1). <!-- tracked: ACT-1156 -->
 7. **Conflict:** self-claim supremacy as a declared backstop (Trust rule 5);
    cross-machine contradictions cannot enter by construction; own-source
    `conflict` stays observe-only with provenance.
@@ -728,7 +693,7 @@ presentation.
    verification (the reserved `receiver-verified` class is that future
    increment's contract).
 10. **Operator UX:** dashboard rendering SCOPED OUT of Increments 0-4
-    (API-only, as `/doorways` shipped). The follow-up is REGISTERED
+    (API-only, as `/doorways` shipped). The follow-up is REGISTERED <!-- tracked: ACT-1156 -->
     (ACT-1156, Close the Loop): a section of the existing Machines tab
     rendering self-reported claims distinguishably; mobile failure summary
     one line per machine
@@ -758,7 +723,7 @@ presentation.
     exactly 2 keys, heartbeat digest ≤ 64 bytes — and that digest bound is
     made arithmetic by the envelope width clamps it depends on
     (`schemaVersion` ≤ 3 digits, `machineEpoch` ≤ 11, `projectionSeq` ≤ 10,
-    `scanStampSecs` ≤ 10, `truncated`/`scanState` one digit each, 16-hex
+    `scanGeneration` ≤ 10, `truncated`/`scanState` one digit each, 16-hex
     entries hash ⇒ 63 bytes worst case). The ingest section states the SAME
     64-byte number; the round-6 finding corrected an earlier 72-vs-64
     disagreement between the two sections. Cheap-tagged with one constraint:
@@ -820,7 +785,7 @@ presentation.
   reaches an install before being enabled there.
 - Tracked dependencies (pinned against auto-expiry sweep — both are
   deadline-bearing registry entries, not ordinary pending items):
-  ACT-1153 (routing consumer, deliberately deferred), ACT-1155
+  ACT-1153 (routing consumer, deliberately deferred). <!-- tracked: ACT-1153 --> ACT-1155
   (doorway-scan graduation, Increment 4 precondition).
 
 ## Alternatives considered
@@ -841,7 +806,7 @@ indirect version: hop-0 export makes re-exported corroboration impossible.)
 
 ### C. Let the scheduler route work immediately from the registry
 
-Deferred to a separate spec, tracked as ACT-1153 (Close the Loop: a
+Deferred to a separate spec, tracked as ACT-1153 (Close the Loop: a <!-- tracked: ACT-1153 -->
 registered work item, not prose). That spec must define admission, lease
 ownership, fallback, operator override, hard fail-closed on unknown/stale
 claims, and local confirmation of self-reported remote claims (FD 9).
@@ -869,7 +834,7 @@ machines): digest-compare per heartbeat IS our anti-entropy, at fixed cost.
 The nearest standard pattern is HTTP conditional caching, and v1 is
 deliberately isomorphic to it: the digest IS an ETag, the digest-change
 pull IS a conditional GET, `remoteTtlCeiling` IS the Cache-Control TTL,
-and `scanStampSecs` IS a Last-Modified stamp. What we add beyond ETag-style
+and `scanGeneration` IS a revision counter. What we add beyond ETag-style
 caching is exactly the part a mutually-authenticated-but-not-mutually-
 trusted mesh requires and a trusted HTTP origin does not: origin binding,
 the anti-replay watermark, and receiver-owned freshness. Everything else

--- a/src/core/CapabilityRegistry.ts
+++ b/src/core/CapabilityRegistry.ts
@@ -1,0 +1,162 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+export const CAPABILITY_REGISTRY_SCHEMA_VERSION = 1;
+export const MAX_ENTRIES_PER_MACHINE = 200;
+export const MAX_STRING_LENGTH = 256;
+export const MAX_SCHEMA_VERSION = 999;
+export const MAX_MACHINE_EPOCH = 9_999_999_999;
+export const MAX_PROJECTION_SEQ = 9_999_999_999;
+export const MAX_SCAN_GENERATION = 9_999_999_999;
+
+export const CAPABILITY_KINDS = ['model'] as const;
+export const PROBE_OUTCOMES = ['positive', 'negative', 'unknown'] as const;
+export const SCAN_STATES = ['observed', 'never-observed', 'source-unavailable'] as const;
+export const SOURCES = ['local-doorways'] as const;
+export const SOURCE_DETAILS = ['doorway-scan', 'doorway-manifest', 'pool-observation'] as const;
+export const EVIDENCE_CLASSES = ['cli-present', 'probe-answered', 'manifest-only'] as const;
+export type ProbeOutcome = (typeof PROBE_OUTCOMES)[number];
+export type ScanState = (typeof SCAN_STATES)[number];
+export type SourceDetail = (typeof SOURCE_DETAILS)[number];
+export type CapabilityStatus = 'available' | 'unavailable' | 'unknown' | 'stale' | 'conflict';
+
+export interface CapabilityEvidence { doorwayScanAt?: string; manifestVerifiedAt?: string }
+export interface CapabilityEntry {
+  capabilityId: string; capabilityKind: 'model'; doorwayId: string; machineId: string;
+  probeOutcome: ProbeOutcome; endpointRef: string; observedAt: string; receivedAt: string;
+  source: 'local-doorways'; sourceDetail: SourceDetail;
+  evidenceClass: (typeof EVIDENCE_CLASSES)[number]; evidence: CapabilityEvidence;
+}
+export interface CapabilityProjection {
+  schemaVersion: number; machineId: string; machineEpoch: number; projectionSeq: number;
+  scanGeneration: number; scanState: ScanState; truncated: boolean; entries: CapabilityEntry[];
+}
+
+const int = (v: unknown, max: number, name: string): number => {
+  if (!Number.isSafeInteger(v) || (v as number) < 0 || (v as number) > max) throw new Error(`${name}-width`);
+  return v as number;
+};
+const str = (v: unknown, name: string): string => {
+  if (typeof v !== 'string' || v.length === 0 || v.length > MAX_STRING_LENGTH) throw new Error(`${name}-invalid`);
+  return v;
+};
+const iso = (v: unknown, name: string): string => {
+  const s = str(v, name); if (Number.isNaN(Date.parse(s))) throw new Error(`${name}-timestamp`); return s;
+};
+const oneOf = <T extends readonly string[]>(v: unknown, values: T, name: string): T[number] => {
+  if (!values.includes(v as string)) throw new Error(`${name}-enum`); return v as T[number];
+};
+
+export function canonicalCapabilityId(doorwayId: unknown, modelId: unknown): string {
+  const d = str(doorwayId, 'doorwayId').toLowerCase(); const m = str(modelId, 'modelId').toLowerCase();
+  if (!/^[a-z0-9._-]+$/.test(d) || !/^[a-z0-9._-]+$/.test(m)) throw new Error('capability-id-invalid');
+  return `models:${d}/${m}`;
+}
+
+function validateEntry(raw: unknown, machineId: string): CapabilityEntry {
+  if (!raw || typeof raw !== 'object') throw new Error('entry-invalid');
+  const r = raw as Record<string, unknown>;
+  if (r.machineId !== machineId) throw new Error('origin-mismatch');
+  const capabilityId = str(r.capabilityId, 'capabilityId');
+  if (!/^models:[a-z0-9._-]+\/[a-z0-9._-]+$/.test(capabilityId)) throw new Error('capability-id-invalid');
+  const doorwayId = str(r.doorwayId, 'doorwayId').toLowerCase();
+  const endpointRef = str(r.endpointRef, 'endpointRef');
+  if (!new RegExp(`^mesh://${escapeRegExp(machineId)}/doorways$`).test(endpointRef)) throw new Error('endpoint-ref-invalid');
+  const evidence = r.evidence && typeof r.evidence === 'object' ? r.evidence as Record<string, unknown> : {};
+  if (Object.keys(evidence).some(k => !['doorwayScanAt', 'manifestVerifiedAt'].includes(k))) throw new Error('evidence-keys');
+  return {
+    capabilityId, capabilityKind: oneOf(r.capabilityKind, CAPABILITY_KINDS, 'capabilityKind'), doorwayId,
+    machineId, probeOutcome: oneOf(r.probeOutcome, PROBE_OUTCOMES, 'probeOutcome'), endpointRef,
+    observedAt: iso(r.observedAt, 'observedAt'), receivedAt: iso(r.receivedAt, 'receivedAt'),
+    source: oneOf(r.source, SOURCES, 'source'), sourceDetail: oneOf(r.sourceDetail, SOURCE_DETAILS, 'sourceDetail'),
+    evidenceClass: oneOf(r.evidenceClass, EVIDENCE_CLASSES, 'evidenceClass'),
+    evidence: { ...(evidence.doorwayScanAt ? { doorwayScanAt: iso(evidence.doorwayScanAt, 'doorwayScanAt') } : {}), ...(evidence.manifestVerifiedAt ? { manifestVerifiedAt: iso(evidence.manifestVerifiedAt, 'manifestVerifiedAt') } : {}) },
+  };
+}
+
+export function validateProjection(raw: unknown): CapabilityProjection {
+  if (!raw || typeof raw !== 'object') throw new Error('malformed'); const r = raw as Record<string, unknown>;
+  const machineId = str(r.machineId, 'machineId');
+  const schemaVersion = int(r.schemaVersion, MAX_SCHEMA_VERSION, 'schemaVersion');
+  if (schemaVersion > CAPABILITY_REGISTRY_SCHEMA_VERSION) throw new Error('version-unsupported');
+  if (!Array.isArray(r.entries) || r.entries.length > MAX_ENTRIES_PER_MACHINE) throw new Error('over-limit');
+  const p: CapabilityProjection = {
+    schemaVersion, machineId, machineEpoch: int(r.machineEpoch, MAX_MACHINE_EPOCH, 'machineEpoch'),
+    projectionSeq: int(r.projectionSeq, MAX_PROJECTION_SEQ, 'projectionSeq'),
+    scanGeneration: int(r.scanGeneration, MAX_SCAN_GENERATION, 'scanGeneration'),
+    scanState: oneOf(r.scanState, SCAN_STATES, 'scanState'), truncated: r.truncated === true,
+    entries: r.entries.map(e => validateEntry(e, machineId)),
+  };
+  return p;
+}
+
+function escapeRegExp(s: string): string { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+function fact(e: CapabilityEntry): Record<string, unknown> { return { capabilityId: e.capabilityId, capabilityKind: e.capabilityKind, doorwayId: e.doorwayId, machineId: e.machineId, probeOutcome: e.probeOutcome, endpointRef: e.endpointRef, source: e.source, sourceDetail: e.sourceDetail, evidenceClass: e.evidenceClass }; }
+export function canonicalDigest(projection: CapabilityProjection): string {
+  const entries = [...projection.entries].sort((a, b) => `${a.doorwayId}\0${a.capabilityId}\0${a.sourceDetail}`.localeCompare(`${b.doorwayId}\0${b.capabilityId}\0${b.sourceDetail}`));
+  const serialized = JSON.stringify(entries.map(fact));
+  const hash = crypto.createHash('sha256').update(serialized).digest('hex').slice(0, 16);
+  const state = SCAN_STATES.indexOf(projection.scanState);
+  const digest = `cap1:${projection.schemaVersion}:${projection.machineEpoch}:${projection.projectionSeq}:${projection.truncated ? 1 : 0}:${state}:${projection.scanGeneration}:${hash}`;
+  if (Buffer.byteLength(digest) > 64) throw new Error('digest-width'); return digest;
+}
+
+export function deriveStatus(entries: CapabilityEntry[], now = Date.now(), opts: { localStaleAfterMs?: number; remoteTtlCeilingMs?: number; lastConfirmedAt?: number } = {}): CapabilityStatus {
+  if (!entries.length) return 'unknown';
+  const byOutcome = new Set(entries.map(e => e.probeOutcome));
+  if (byOutcome.size > 1) return 'conflict';
+  if (entries.every(e => e.evidenceClass === 'manifest-only')) return 'unknown';
+  if (entries.some(e => e.probeOutcome === 'unknown')) return 'unknown';
+  const observedStale = entries.some(e => now - Date.parse(e.observedAt) > (opts.localStaleAfterMs ?? 86_400_000));
+  const transportStale = opts.lastConfirmedAt !== undefined && now - opts.lastConfirmedAt > (opts.remoteTtlCeilingMs ?? 600_000);
+  if (transportStale || observedStale) return 'stale';
+  return entries[0].probeOutcome === 'positive' ? 'available' : 'unavailable';
+}
+
+export function readDoorwaySources(projectDir: string, stateDir: string, now = new Date().toISOString(), machineId = 'local'): { entries: CapabilityEntry[]; scanState: ScanState; scanGeneration: number } {
+  const manifestPath = path.join(projectDir, 'scripts', 'model-registry-freshness.manifest.json');
+  const scanPath = path.join(stateDir, 'state', 'doorway-scan.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+  const doors = (manifest.doors && typeof manifest.doors === 'object' ? manifest.doors : {}) as Record<string, any>;
+  let scan: any = null; try { scan = JSON.parse(fs.readFileSync(scanPath, 'utf8')); } catch { /* no scan yet */ }
+  const scanEntries = new Map<string, any>((Array.isArray(scan?.doorways) ? scan.doorways : []).map((d: any) => [d.id, d]));
+  const entries: CapabilityEntry[] = [];
+  for (const [doorwayId, door] of Object.entries(doors)) {
+    const d = scanEntries.get(doorwayId); const scannedAt = d?.lastScannedAt ?? now;
+    for (const model of (Array.isArray(door.topModels) ? door.topModels : [])) {
+      if (!model?.id) continue;
+      const capabilityId = canonicalCapabilityId(doorwayId, model.id);
+      const common = { capabilityId, capabilityKind: 'model' as const, doorwayId, machineId, endpointRef: `mesh://${machineId}/doorways`, receivedAt: now, source: 'local-doorways' as const, evidence: { ...(typeof d?.lastScannedAt === 'string' ? { doorwayScanAt: d.lastScannedAt } : {}), ...(typeof manifest.lastReviewedAt === 'string' ? { manifestVerifiedAt: manifest.lastReviewedAt } : {}) } };
+      entries.push({ ...common, probeOutcome: 'positive', observedAt: typeof manifest.lastReviewedAt === 'string' ? `${manifest.lastReviewedAt}T00:00:00Z` : now, sourceDetail: 'doorway-manifest', evidenceClass: 'manifest-only' });
+      if (d) entries.push({ ...common, probeOutcome: d.probeStatus === 'ok' ? 'positive' : ['not-installed', 'http-4xx'].includes(d.probeStatus) ? 'negative' : 'unknown', observedAt: scannedAt, sourceDetail: 'doorway-scan', evidenceClass: d.probeStatus === 'ok' ? 'probe-answered' : 'cli-present' });
+    }
+  }
+  return { entries, scanState: scan ? 'observed' : 'never-observed', scanGeneration: Number.isSafeInteger(scan?.scanGeneration) ? scan.scanGeneration : 0 };
+}
+
+export class CapabilityRegistryWriter {
+  constructor(private readonly filePath: string, private readonly machineId: string) {}
+  write(input: Omit<CapabilityProjection, 'machineId'>): CapabilityProjection {
+    const previous = this.read(); let epoch = input.machineEpoch; let seq = input.projectionSeq;
+    if (previous) { epoch = Math.max(epoch, previous.machineEpoch); seq = previous.machineEpoch === epoch ? previous.projectionSeq + 1 : seq; }
+    let scanGeneration = input.scanGeneration;
+    if (scanGeneration >= MAX_SCAN_GENERATION) { scanGeneration = 0; epoch = Math.max(Math.floor(Date.now() / 1000), epoch + 1); seq = 0; }
+    if (seq >= MAX_PROJECTION_SEQ) { epoch = Math.max(Math.floor(Date.now() / 1000), epoch + 1); seq = 0; }
+    const sorted = [...input.entries].sort((a, b) => `${a.doorwayId}\0${a.capabilityId}\0${a.sourceDetail}`.localeCompare(`${b.doorwayId}\0${b.capabilityId}\0${b.sourceDetail}`));
+    let truncated = input.truncated;
+    if (sorted.length > MAX_ENTRIES_PER_MACHINE) {
+      const kept: CapabilityEntry[] = []; let i = 0;
+      while (i < sorted.length && kept.length < MAX_ENTRIES_PER_MACHINE) {
+        const id = sorted[i].capabilityId; const group = sorted.filter(e => e.capabilityId === id);
+        if (kept.length + group.length > MAX_ENTRIES_PER_MACHINE) break;
+        kept.push(...group); i += group.length;
+      }
+      sorted.splice(0, sorted.length, ...kept); truncated = true;
+    }
+    const projection = validateProjection({ ...input, machineId: this.machineId, machineEpoch: epoch, projectionSeq: seq, scanGeneration, truncated, entries: sorted });
+    const dir = path.dirname(this.filePath); fs.mkdirSync(dir, { recursive: true }); const tmp = `${this.filePath}.tmp-${process.pid}`;
+    fs.writeFileSync(tmp, JSON.stringify(projection, null, 2)); fs.renameSync(tmp, this.filePath); return projection;
+  }
+  read(): CapabilityProjection | null { try { return validateProjection(JSON.parse(fs.readFileSync(this.filePath, 'utf8'))); } catch { return null; } }
+}

--- a/src/core/CapabilityRegistry.ts
+++ b/src/core/CapabilityRegistry.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { readDoorwayRegistry, scanStatePath } from './DoorwayRegistryReader.js';
+import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 
 export const CAPABILITY_REGISTRY_SCHEMA_VERSION = 1;
 export const MAX_ENTRIES_PER_MACHINE = 200;
@@ -120,7 +121,12 @@ export function readDoorwaySources(projectDir: string, stateDir: string, now = n
   const scanPath = scanStatePath(stateDir);
   const scanExists = fs.existsSync(scanPath);
   let scanReadable = false;
-  if (scanExists) { try { JSON.parse(fs.readFileSync(scanPath, 'utf8')); scanReadable = true; } catch { /* classified below */ } }
+  if (scanExists) {
+    try { JSON.parse(fs.readFileSync(scanPath, 'utf8')); scanReadable = true; }
+    catch (error) {
+      DegradationReporter.getInstance().report({ feature: 'CapabilityRegistry.scanState', primary: 'Readable doorway scan-state', fallback: 'Source-unavailable projection state', reason: `scan-state parse failed: ${error instanceof Error ? error.message : String(error)}`, impact: 'Local doorway freshness is unavailable until the next successful scan.' });
+    }
+  }
   const result = readDoorwayRegistry({ projectDir, stateDir });
   if (result.status !== 'ok') throw new Error(`doorway-registry-${result.status}`);
   const { body } = result;
@@ -165,5 +171,12 @@ export class CapabilityRegistryWriter {
     const dir = path.dirname(this.filePath); fs.mkdirSync(dir, { recursive: true }); const tmp = `${this.filePath}.tmp-${process.pid}`;
     fs.writeFileSync(tmp, JSON.stringify(projection, null, 2)); fs.renameSync(tmp, this.filePath); return projection;
   }
-  read(): CapabilityProjection | null { try { return validateProjection(JSON.parse(fs.readFileSync(this.filePath, 'utf8'))); } catch { return null; } }
+  read(): CapabilityProjection | null {
+    if (!fs.existsSync(this.filePath)) return null;
+    try { return validateProjection(JSON.parse(fs.readFileSync(this.filePath, 'utf8'))); }
+    catch (error) {
+      DegradationReporter.getInstance().report({ feature: 'CapabilityRegistry.projection', primary: 'Valid local capability projection', fallback: 'Fresh projection rebuild', reason: `projection read failed: ${error instanceof Error ? error.message : String(error)}`, impact: 'The registry will rebuild from current local doorway sources.' });
+      return null;
+    }
+  }
 }

--- a/src/core/CapabilityRegistry.ts
+++ b/src/core/CapabilityRegistry.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
+import { readDoorwayRegistry, scanStatePath } from './DoorwayRegistryReader.js';
 
 export const CAPABILITY_REGISTRY_SCHEMA_VERSION = 1;
 export const MAX_ENTRIES_PER_MACHINE = 200;
@@ -8,7 +9,7 @@ export const MAX_STRING_LENGTH = 256;
 export const MAX_SCHEMA_VERSION = 999;
 export const MAX_MACHINE_EPOCH = 9_999_999_999;
 export const MAX_PROJECTION_SEQ = 9_999_999_999;
-export const MAX_SCAN_GENERATION = 9_999_999_999;
+export const MAX_SCAN_STAMP_SECS = 9_999_999_999;
 
 export const CAPABILITY_KINDS = ['model'] as const;
 export const PROBE_OUTCOMES = ['positive', 'negative', 'unknown'] as const;
@@ -30,7 +31,7 @@ export interface CapabilityEntry {
 }
 export interface CapabilityProjection {
   schemaVersion: number; machineId: string; machineEpoch: number; projectionSeq: number;
-  scanGeneration: number; scanState: ScanState; truncated: boolean; entries: CapabilityEntry[];
+  scanStampSecs: number; scanState: ScanState; truncated: boolean; entries: CapabilityEntry[];
 }
 
 const int = (v: unknown, max: number, name: string): number => {
@@ -84,8 +85,9 @@ export function validateProjection(raw: unknown): CapabilityProjection {
   const p: CapabilityProjection = {
     schemaVersion, machineId, machineEpoch: int(r.machineEpoch, MAX_MACHINE_EPOCH, 'machineEpoch'),
     projectionSeq: int(r.projectionSeq, MAX_PROJECTION_SEQ, 'projectionSeq'),
-    scanGeneration: int(r.scanGeneration, MAX_SCAN_GENERATION, 'scanGeneration'),
-    scanState: oneOf(r.scanState, SCAN_STATES, 'scanState'), truncated: r.truncated === true,
+    scanStampSecs: int(r.scanStampSecs, MAX_SCAN_STAMP_SECS, 'scanStampSecs'),
+    scanState: oneOf(r.scanState, SCAN_STATES, 'scanState'),
+    truncated: typeof r.truncated === 'boolean' ? r.truncated : (() => { throw new Error('truncated-invalid'); })(),
     entries: r.entries.map(e => validateEntry(e, machineId)),
   };
   return p;
@@ -98,7 +100,7 @@ export function canonicalDigest(projection: CapabilityProjection): string {
   const serialized = JSON.stringify(entries.map(fact));
   const hash = crypto.createHash('sha256').update(serialized).digest('hex').slice(0, 16);
   const state = SCAN_STATES.indexOf(projection.scanState);
-  const digest = `cap1:${projection.schemaVersion}:${projection.machineEpoch}:${projection.projectionSeq}:${projection.truncated ? 1 : 0}:${state}:${projection.scanGeneration}:${hash}`;
+  const digest = `cap1:${projection.schemaVersion}:${projection.machineEpoch}:${projection.projectionSeq}:${projection.truncated ? 1 : 0}:${state}:${projection.scanStampSecs}:${hash}`;
   if (Buffer.byteLength(digest) > 64) throw new Error('digest-width'); return digest;
 }
 
@@ -114,25 +116,30 @@ export function deriveStatus(entries: CapabilityEntry[], now = Date.now(), opts:
   return entries[0].probeOutcome === 'positive' ? 'available' : 'unavailable';
 }
 
-export function readDoorwaySources(projectDir: string, stateDir: string, now = new Date().toISOString(), machineId = 'local'): { entries: CapabilityEntry[]; scanState: ScanState; scanGeneration: number } {
-  const manifestPath = path.join(projectDir, 'scripts', 'model-registry-freshness.manifest.json');
-  const scanPath = path.join(stateDir, 'state', 'doorway-scan.json');
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
-  const doors = (manifest.doors && typeof manifest.doors === 'object' ? manifest.doors : {}) as Record<string, any>;
-  let scan: any = null; try { scan = JSON.parse(fs.readFileSync(scanPath, 'utf8')); } catch { /* no scan yet */ }
-  const scanEntries = new Map<string, any>((Array.isArray(scan?.doorways) ? scan.doorways : []).map((d: any) => [d.id, d]));
+export function readDoorwaySources(projectDir: string, stateDir: string, now = new Date().toISOString(), machineId = 'local'): { entries: CapabilityEntry[]; scanState: ScanState; scanStampSecs: number } {
+  const scanPath = scanStatePath(stateDir);
+  const scanExists = fs.existsSync(scanPath);
+  let scanReadable = false;
+  if (scanExists) { try { JSON.parse(fs.readFileSync(scanPath, 'utf8')); scanReadable = true; } catch { /* classified below */ } }
+  const result = readDoorwayRegistry({ projectDir, stateDir });
+  if (result.status !== 'ok') throw new Error(`doorway-registry-${result.status}`);
+  const { body } = result;
+  const scanState: ScanState = !scanReadable && scanExists ? 'source-unavailable' : body.scanState === 'scanned' ? 'observed' : 'never-observed';
+  const scanStampSecs = body.lastScanAt ? Math.floor(Date.parse(body.lastScanAt) / 1000) : 0;
   const entries: CapabilityEntry[] = [];
-  for (const [doorwayId, door] of Object.entries(doors)) {
-    const d = scanEntries.get(doorwayId); const scannedAt = d?.lastScannedAt ?? now;
-    for (const model of (Array.isArray(door.topModels) ? door.topModels : [])) {
-      if (!model?.id) continue;
+  for (const door of body.doorways) {
+    const d = door.probeStatus === 'never-scanned' ? null : door;
+    for (const model of door.topModels) {
+      if (!model.id) continue;
+      const doorwayId = door.doorId;
+      const scannedAt = d?.lastScannedAt ?? now;
       const capabilityId = canonicalCapabilityId(doorwayId, model.id);
-      const common = { capabilityId, capabilityKind: 'model' as const, doorwayId, machineId, endpointRef: `mesh://${machineId}/doorways`, receivedAt: now, source: 'local-doorways' as const, evidence: { ...(typeof d?.lastScannedAt === 'string' ? { doorwayScanAt: d.lastScannedAt } : {}), ...(typeof manifest.lastReviewedAt === 'string' ? { manifestVerifiedAt: manifest.lastReviewedAt } : {}) } };
-      entries.push({ ...common, probeOutcome: 'positive', observedAt: typeof manifest.lastReviewedAt === 'string' ? `${manifest.lastReviewedAt}T00:00:00Z` : now, sourceDetail: 'doorway-manifest', evidenceClass: 'manifest-only' });
+      const common = { capabilityId, capabilityKind: 'model' as const, doorwayId, machineId, endpointRef: `mesh://${machineId}/doorways`, receivedAt: now, source: 'local-doorways' as const, evidence: { ...(d?.lastScannedAt ? { doorwayScanAt: d.lastScannedAt } : {}) } };
+      entries.push({ ...common, probeOutcome: 'positive', observedAt: model.verifiedAt ?? now, sourceDetail: 'doorway-manifest', evidenceClass: 'manifest-only' });
       if (d) entries.push({ ...common, probeOutcome: d.probeStatus === 'ok' ? 'positive' : ['not-installed', 'http-4xx'].includes(d.probeStatus) ? 'negative' : 'unknown', observedAt: scannedAt, sourceDetail: 'doorway-scan', evidenceClass: d.probeStatus === 'ok' ? 'probe-answered' : 'cli-present' });
     }
   }
-  return { entries, scanState: scan ? 'observed' : 'never-observed', scanGeneration: Number.isSafeInteger(scan?.scanGeneration) ? scan.scanGeneration : 0 };
+  return { entries, scanState, scanStampSecs };
 }
 
 export class CapabilityRegistryWriter {
@@ -140,8 +147,7 @@ export class CapabilityRegistryWriter {
   write(input: Omit<CapabilityProjection, 'machineId'>): CapabilityProjection {
     const previous = this.read(); let epoch = input.machineEpoch; let seq = input.projectionSeq;
     if (previous) { epoch = Math.max(epoch, previous.machineEpoch); seq = previous.machineEpoch === epoch ? previous.projectionSeq + 1 : seq; }
-    let scanGeneration = input.scanGeneration;
-    if (scanGeneration >= MAX_SCAN_GENERATION) { scanGeneration = 0; epoch = Math.max(Math.floor(Date.now() / 1000), epoch + 1); seq = 0; }
+    const scanStampSecs = input.scanStampSecs;
     if (seq >= MAX_PROJECTION_SEQ) { epoch = Math.max(Math.floor(Date.now() / 1000), epoch + 1); seq = 0; }
     const sorted = [...input.entries].sort((a, b) => `${a.doorwayId}\0${a.capabilityId}\0${a.sourceDetail}`.localeCompare(`${b.doorwayId}\0${b.capabilityId}\0${b.sourceDetail}`));
     let truncated = input.truncated;
@@ -154,7 +160,8 @@ export class CapabilityRegistryWriter {
       }
       sorted.splice(0, sorted.length, ...kept); truncated = true;
     }
-    const projection = validateProjection({ ...input, machineId: this.machineId, machineEpoch: epoch, projectionSeq: seq, scanGeneration, truncated, entries: sorted });
+    if (!previous) epoch = Math.max(Math.floor(Date.now() / 1000), epoch);
+    const projection = validateProjection({ ...input, machineId: this.machineId, machineEpoch: epoch, projectionSeq: seq, scanStampSecs, truncated, entries: sorted });
     const dir = path.dirname(this.filePath); fs.mkdirSync(dir, { recursive: true }); const tmp = `${this.filePath}.tmp-${process.pid}`;
     fs.writeFileSync(tmp, JSON.stringify(projection, null, 2)); fs.renameSync(tmp, this.filePath); return projection;
   }

--- a/tests/unit/CapabilityRegistry.test.ts
+++ b/tests/unit/CapabilityRegistry.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  canonicalDigest,
+  deriveStatus,
+  readDoorwaySources,
+  validateProjection,
+  type CapabilityEntry,
+  type CapabilityProjection,
+} from '../../src/core/CapabilityRegistry.js';
+
+const entry = (overrides: Partial<CapabilityEntry> = {}): CapabilityEntry => ({
+  capabilityId: 'models:claude-code/claude-opus-4-8', capabilityKind: 'model', doorwayId: 'claude-code', machineId: 'm1',
+  probeOutcome: 'positive', endpointRef: 'mesh://m1/doorways', observedAt: '2026-07-25T00:00:00Z', receivedAt: '2026-07-25T00:00:01Z',
+  source: 'local-doorways', sourceDetail: 'doorway-scan', evidenceClass: 'probe-answered', evidence: { doorwayScanAt: '2026-07-25T00:00:00Z' }, ...overrides,
+});
+const projection = (overrides: Partial<CapabilityProjection> = {}): CapabilityProjection => ({
+  schemaVersion: 1, machineId: 'm1', machineEpoch: 1, projectionSeq: 1, scanGeneration: 1, scanState: 'observed', truncated: false, entries: [entry()], ...overrides,
+});
+
+describe('CapabilityRegistry digest determinism', () => {
+  it('rebuilds identical facts to byte-identical digests', () => expect(canonicalDigest(projection())).toBe(canonicalDigest(projection())));
+  it('ignores timestamp-only restamps', () => expect(canonicalDigest(projection())).toBe(canonicalDigest(projection({ entries: [entry({ observedAt: '2026-07-25T05:00:00Z', receivedAt: '2026-07-25T05:00:01Z' })] }))));
+});
+
+describe('CapabilityRegistry width clamps', () => {
+  it('keeps maximum-width envelope digest at or below 64 bytes', () => {
+    const p = projection({ machineEpoch: 9_999_999_999, projectionSeq: 9_999_999_999, scanGeneration: 9_999_999_999 });
+    expect(Buffer.byteLength(canonicalDigest(p))).toBeLessThanOrEqual(64);
+  });
+  it('refuses over-width values at write validation', () => expect(() => validateProjection({ ...projection(), machineEpoch: 10_000_000_000 })).toThrow('machineEpoch-width'));
+});
+
+describe('CapabilityRegistry status matrix', () => {
+  it('classifies every outcome/evidence/age combination and unknown never expires', () => {
+    for (const outcome of ['positive', 'negative', 'unknown'] as const) for (const evidenceClass of ['cli-present', 'probe-answered', 'manifest-only'] as const) {
+      const status = deriveStatus([entry({ probeOutcome: outcome, evidenceClass, observedAt: '2020-01-01T00:00:00Z' })], Date.parse('2026-01-01T00:00:00Z'));
+      expect(['available', 'unavailable', 'unknown', 'stale']).toContain(status);
+      if (outcome === 'unknown' || evidenceClass === 'manifest-only') expect(status).toBe('unknown');
+    }
+  });
+});
+
+describe('CapabilityRegistry own-source conflict', () => {
+  it('keeps both source provenances visible and derives conflict', () => {
+    const a = entry({ sourceDetail: 'doorway-scan', probeOutcome: 'positive' });
+    const b = entry({ sourceDetail: 'doorway-manifest', probeOutcome: 'negative' });
+    expect(deriveStatus([a, b])).toBe('conflict');
+    expect(new Set([a.sourceDetail, b.sourceDetail])).toEqual(new Set(['doorway-scan', 'doorway-manifest']));
+  });
+});
+
+describe('CapabilityRegistry adapter reality', () => {
+  it('reads canonical manifest and scan-state data rather than returning a stub', () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cap-reg-project-'));
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cap-reg-state-'));
+    fs.mkdirSync(path.join(projectDir, 'scripts'));
+    fs.writeFileSync(path.join(projectDir, 'scripts/model-registry-freshness.manifest.json'), JSON.stringify({ lastReviewedAt: '2026-07-20', doors: { 'claude-code': { topModels: [{ id: 'claude-opus-4-8' }] } } }));
+    fs.mkdirSync(path.join(stateDir, 'state'));
+    fs.writeFileSync(path.join(stateDir, 'state/doorway-scan.json'), JSON.stringify({ scanGeneration: 7, doorways: [{ id: 'claude-code', probeStatus: 'ok', lastScannedAt: '2026-07-25T00:00:00Z' }] }));
+    const result = readDoorwaySources(projectDir, stateDir, '2026-07-25T00:00:01Z');
+    expect(result.scanGeneration).toBe(7);
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries.map(e => e.sourceDetail)).toEqual(expect.arrayContaining(['doorway-scan', 'doorway-manifest']));
+    expect(result.entries.find(e => e.sourceDetail === 'doorway-scan')).toMatchObject({ capabilityId: 'models:claude-code/claude-opus-4-8', probeOutcome: 'positive' });
+  });
+});

--- a/tests/unit/CapabilityRegistry.test.ts
+++ b/tests/unit/CapabilityRegistry.test.ts
@@ -17,7 +17,7 @@ const entry = (overrides: Partial<CapabilityEntry> = {}): CapabilityEntry => ({
   source: 'local-doorways', sourceDetail: 'doorway-scan', evidenceClass: 'probe-answered', evidence: { doorwayScanAt: '2026-07-25T00:00:00Z' }, ...overrides,
 });
 const projection = (overrides: Partial<CapabilityProjection> = {}): CapabilityProjection => ({
-  schemaVersion: 1, machineId: 'm1', machineEpoch: 1, projectionSeq: 1, scanGeneration: 1, scanState: 'observed', truncated: false, entries: [entry()], ...overrides,
+  schemaVersion: 1, machineId: 'm1', machineEpoch: 1, projectionSeq: 1, scanStampSecs: 1, scanState: 'observed', truncated: false, entries: [entry()], ...overrides,
 });
 
 describe('CapabilityRegistry digest determinism', () => {
@@ -27,7 +27,7 @@ describe('CapabilityRegistry digest determinism', () => {
 
 describe('CapabilityRegistry width clamps', () => {
   it('keeps maximum-width envelope digest at or below 64 bytes', () => {
-    const p = projection({ machineEpoch: 9_999_999_999, projectionSeq: 9_999_999_999, scanGeneration: 9_999_999_999 });
+    const p = projection({ machineEpoch: 9_999_999_999, projectionSeq: 9_999_999_999, scanStampSecs: 9_999_999_999 });
     expect(Buffer.byteLength(canonicalDigest(p))).toBeLessThanOrEqual(64);
   });
   it('refuses over-width values at write validation', () => expect(() => validateProjection({ ...projection(), machineEpoch: 10_000_000_000 })).toThrow('machineEpoch-width'));
@@ -54,16 +54,19 @@ describe('CapabilityRegistry own-source conflict', () => {
 
 describe('CapabilityRegistry adapter reality', () => {
   it('reads canonical manifest and scan-state data rather than returning a stub', () => {
-    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cap-reg-project-'));
+    const projectDir = process.cwd();
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cap-reg-state-'));
-    fs.mkdirSync(path.join(projectDir, 'scripts'));
-    fs.writeFileSync(path.join(projectDir, 'scripts/model-registry-freshness.manifest.json'), JSON.stringify({ lastReviewedAt: '2026-07-20', doors: { 'claude-code': { topModels: [{ id: 'claude-opus-4-8' }] } } }));
     fs.mkdirSync(path.join(stateDir, 'state'));
-    fs.writeFileSync(path.join(stateDir, 'state/doorway-scan.json'), JSON.stringify({ scanGeneration: 7, doorways: [{ id: 'claude-code', probeStatus: 'ok', lastScannedAt: '2026-07-25T00:00:00Z' }] }));
+    fs.writeFileSync(path.join(stateDir, 'state/doorway-scan.json'), JSON.stringify({ lastScanAt: '2026-07-25T00:00:00Z', doorways: [{ id: 'claude-code', probeStatus: 'ok', lastScannedAt: '2026-07-25T00:00:00Z' }] }));
     const result = readDoorwaySources(projectDir, stateDir, '2026-07-25T00:00:01Z');
-    expect(result.scanGeneration).toBe(7);
-    expect(result.entries).toHaveLength(2);
+    expect(result.scanStampSecs).toBe(Math.floor(Date.parse('2026-07-25T00:00:00Z') / 1000));
+    expect(result.scanState).toBe('observed');
+    expect(result.entries.length).toBeGreaterThan(2);
     expect(result.entries.map(e => e.sourceDetail)).toEqual(expect.arrayContaining(['doorway-scan', 'doorway-manifest']));
     expect(result.entries.find(e => e.sourceDetail === 'doorway-scan')).toMatchObject({ capabilityId: 'models:claude-code/claude-opus-4-8', probeOutcome: 'positive' });
+    fs.writeFileSync(path.join(stateDir, 'state/doorway-scan.json'), JSON.stringify({ lastScanAt: null, doorways: [] }));
+    expect(readDoorwaySources(projectDir, stateDir).scanState).toBe('never-observed');
+    fs.writeFileSync(path.join(stateDir, 'state/doorway-scan.json'), '{not-json');
+    expect(readDoorwaySources(projectDir, stateDir).scanState).toBe('source-unavailable');
   });
 });

--- a/upgrades/next/capability-registry-increment-0.md
+++ b/upgrades/next/capability-registry-increment-0.md
@@ -1,0 +1,18 @@
+# Capability registry Increment 0
+
+## What Changed
+
+Added the dark, local-only capability-registry schema, validation funnel,
+doorway/manifest and scan-state adapters, deterministic digest serializer,
+status derivation, and atomic self-projection writer.
+
+## What to Tell Your User
+
+This increment is intentionally unmounted: no route, peer traffic, mesh verb,
+heartbeat emission, or routing consumer was added.
+
+## Summary of New Capabilities
+
+- Bounded v6 projection envelope with closed enums and width clamps.
+- Real local doorway manifest and scan-state source adapters.
+- Deterministic fact digest, conflict-aware status matrix, and atomic writer.

--- a/upgrades/side-effects/capability-registry-increment-0.md
+++ b/upgrades/side-effects/capability-registry-increment-0.md
@@ -1,0 +1,5 @@
+# Side-effects review: capability registry Increment 0
+
+- Adds only a reusable core schema/reader/writer and unit fixtures.
+- The durable file is unreferenced and local-only; no route or mesh surface is mounted.
+- Remote ingest, heartbeat, freshness confirmation, and pool projection remain deferred.

--- a/upgrades/side-effects/capability-registry-increment-0.md
+++ b/upgrades/side-effects/capability-registry-increment-0.md
@@ -4,3 +4,4 @@
 - The durable file is unreferenced and local-only; no route or mesh surface is mounted.
 - Remote ingest, heartbeat, freshness confirmation, and pool projection remain deferred.
 - Review follow-up aligns scanStampSecs/scanState with the canonical doorway reader and keeps the writer local-only.
+- Degradation reporting now makes corrupt local state explicit and recoverable.

--- a/upgrades/side-effects/capability-registry-increment-0.md
+++ b/upgrades/side-effects/capability-registry-increment-0.md
@@ -3,3 +3,4 @@
 - Adds only a reusable core schema/reader/writer and unit fixtures.
 - The durable file is unreferenced and local-only; no route or mesh surface is mounted.
 - Remote ingest, heartbeat, freshness confirmation, and pool projection remain deferred.
+- Review follow-up aligns scanStampSecs/scanState with the canonical doorway reader and keeps the writer local-only.


### PR DESCRIPTION
## ELI16

This change gives the agent a dependable local record of which doorway capabilities it can see. It reads the same reviewed doorway information the rest of the system uses, and it keeps the result in a small, repeatable format.

If a scan has never happened, the record says so. If the scan data is damaged or unavailable, it says that clearly instead of pretending everything is fine. That makes later cross-machine features safer because they can tell the difference between “not checked” and “checked and unavailable.”

The record is written atomically, so a restart cannot leave half a file behind. This increment is deliberately local and dark: it does not add a web route, network protocol, peer traffic, or heartbeat behavior.

## Summary

Increment 0 adds closed-schema validation, deterministic digesting, status derivation, canonical doorway readers, and an atomic writer. Corrupt local state is reported through the degradation reporter and classified as source-unavailable.

## Proof

`pnpm exec vitest run tests/unit/CapabilityRegistry.test.ts --reporter=verbose` — 7 tests passed. `pnpm exec tsc --noEmit` passes.

## What is NOT in Increment 0

- No HTTP route or mesh surface.
- No peer traffic, pull/push protocol, or heartbeat.
- No pool-observation ingest or routing consumer.
