### PR TITLE
docs: spec round 8 — derived scanStampSecs replaces producerless scanGeneration

### DIFF
--- a/docs/specs/cross-machine-door-capability-registry.md
+++ b/docs/specs/cross-machine-door-capability-registry.md
@@ -49,6 +49,21 @@ fix round must itself be verified, and a fix that adds a field or a fallback
 must be traced to every rule that consumes it (sort orders, counters, config
 key names) before the round is called clean.
 
+Round 8 came from the BUILD, not from a reviewer, and it exposed the blind
+spot that document-only convergence structurally cannot see: the spec named a
+`scanGeneration` counter "incremented on every completed doorway scan" — and
+no such field exists in production (absent from the scan-state writer's field
+allowlist and from `src/` entirely). Seven rounds of reading the document
+could not detect it, because the defect was not IN the document; it was in the
+document's relationship to the code it depends on. It surfaced within minutes
+of the first implementation attempt. The field is now `scanStampSecs`, derived
+from the `lastScanAt` that already exists and already changes on every
+completed scan. The rule this adds: a spec that names an EXTERNAL field, route,
+or store must cite where that thing exists in code — and a convergence round
+must include one grounding pass that checks those citations, not just internal
+consistency. Prose can only be verified against prose; a build verifies against
+reality.
+
 ## Glossary
 
 - **Doorway** — a way this machine reaches LLM providers (the Claude Code
@@ -140,7 +155,7 @@ and bounded.)
   "machineId": "mesh-machine-id",
   "machineEpoch": 1784958000,
   "projectionSeq": 172,
-  "scanGeneration": 41,
+  "scanStampSecs": 1784958000,
   "scanState": "observed|never-observed|source-unavailable",
   "truncated": false,
   "entries": [{
@@ -208,18 +223,30 @@ Field rules (all structurally enforced, not prose):
   backward clock, which is the named residual healed by watermark aging (the
   round-7 finding: this sentence previously asserted "re-mints a higher epoch
   anyway", contradicting the bound stated two rules up).
-- **`scanGeneration` exhaustion (normative — the round-7 finding).** The
-  counter increments on every completed scan and is width-clamped, so it must
-  have a defined transition at its ceiling or its own mechanism eventually
-  violates the clamp. At `9_999_999_999` the next completed scan WRAPS it to
-  `0` and re-mints the `machineEpoch` in the same write. Wrapping is safe
-  because `scanGeneration` is only ever compared for INEQUALITY inside the
-  pull-decision tuple (never ordered), and the epoch re-mint keeps the
-  receiver's `(machineEpoch, projectionSeq)` watermark strictly advancing
-  across the wrap. A receiver never needs to special-case it.
+- **`scanStampSecs` (round-8 finding — replaces the earlier
+  `scanGeneration` counter).** The observation-freshness component of the
+  digest tuple is DERIVED, never counted: it is
+  `floor(Date.parse(clamped lastScanAt) / 1000)`, or `0` when the machine has
+  never completed a scan. Why the change: rounds 6-7 specified a
+  `scanGeneration` counter "incremented on every completed doorway scan", but
+  NO SUCH FIELD EXISTS in production — it is absent from the scan-state
+  writer's field allowlist (`scripts/doorway-scan.mjs`) and from `src/`
+  entirely, so an implementer reading `scan.scanGeneration` gets `undefined`
+  forever and the propagation mechanism is silently dead (caught in review of
+  the Increment-0 build, PR #1615). `lastScanAt` is the field that already
+  exists, is already clamped by `DoorwayRegistryReader`, and already changes
+  on every completed scan — including a no-change one — which is exactly the
+  property the counter was invented to provide.
+  Consequences, all benign: it needs no producer change; it has no exhaustion
+  transition to define (a 10-digit epoch-seconds value is width-safe past year
+  2286); and a backward clock merely changes the tuple, which triggers ONE
+  bounded re-pull rather than corrupting anything, because the tuple is
+  compared for INEQUALITY only (never ordered). The receiver's
+  `(machineEpoch, projectionSeq)` watermark remains the sole ordering
+  authority.
 - **Envelope numeric width clamps (normative, so the digest bound holds by
   construction — the round-6 finding).** `schemaVersion` ≤ 3 decimal digits,
-  `machineEpoch` ≤ 11, `projectionSeq` ≤ 10, `scanGeneration` ≤ 10; all are
+  `machineEpoch` ≤ 11, `projectionSeq` ≤ 10, `scanStampSecs` ≤ 10; all are
   non-negative integers. A value exceeding its width is refused at write and
   rejects the projection on receive (`malformed`). A `projectionSeq` at its
   ceiling forces an epoch re-mint (which resets the sequence) rather than
@@ -234,7 +261,16 @@ Field rules (all structurally enforced, not prose):
   (`never-observed`), or the underlying doorway source could not be read
   (`source-unavailable`). A receiver renders a peer's empty projection using
   this field and NEVER as "no capabilities." It is envelope semantics, so it
-  joins `truncated` in the pull-decision tuple; a peer projection whose
+  joins `truncated` in the pull-decision tuple.
+  **Derivation (normative — the round-8 build finding):** `observed` requires
+  `lastScanAt !== null` in the scan-state, NOT mere existence of the
+  scan-state file. The canonical scan-state ships with `lastScanAt: null` on a
+  machine that has never completed a scan (`freshScanState()`), and main's
+  reader already encodes this rule (`DoorwayRegistryReader`:
+  `scanned = lastScanAt !== null`). Deriving `observed` from file existence
+  reports a never-scanned machine as observed — reintroducing exactly the
+  ambiguity this field exists to remove. An unreadable or corrupt scan-state
+  is `source-unavailable`, kept distinct from `never-observed`; a peer projection whose
   `scanState` is not `observed` produces that machine's named failure/empty
   row (`source-unavailable`, or the receiver-side `no-data-yet` before first
   ingest) instead of an inferred-empty capability list.
@@ -478,7 +514,7 @@ it:
 
 - Each machine's heartbeat carries a fixed-size capability digest, encoded
   as the compact string
-  `cap1:<schemaVersion>:<machineEpoch>:<projectionSeq>:<truncated 0|1>:<scanState 0|1|2>:<scanGeneration>:<entriesSha256-16hex>`
+  `cap1:<schemaVersion>:<machineEpoch>:<projectionSeq>:<truncated 0|1>:<scanState 0|1|2>:<scanStampSecs>:<entriesSha256-16hex>`
   — **≤ 64 bytes, and that bound is arithmetic, not aspirational**: the
   envelope width clamps above (3 + 11 + 10 + 10 decimal digits, one digit
   each for `truncated` and the `scanState` ordinal, a 16-hex truncated
@@ -498,20 +534,21 @@ it:
   sorted by `(doorwayId, capabilityId, sourceDetail)` — `sourceDetail` joins
   the sort key because it is part of the local row key, so two disagreeing
   local sources for one capability serialize deterministically instead of
-  colliding. JSON with sorted keys. `scanGeneration` is the origin's
-  completed-scan counter (increments on every completed doorway scan, even
-  a no-change one) — it propagates OBSERVATION freshness: a scan that
-  changes no facts still bumps the digest tuple, triggering one bounded
+  colliding. JSON with sorted keys. `scanStampSecs` is DERIVED from the
+  scan-state's clamped `lastScanAt` (see the field rules) — it propagates
+  OBSERVATION freshness: a scan that changes no facts still re-stamps
+  `lastScanAt` and therefore bumps the digest tuple, triggering one bounded
   re-pull per origin per scan (daily cadence, ≤200 rows) that refreshes
   receivers' stored `observedAt`, so stable healthy fleets never decay to
-  false observation-staleness (the round-5 non-propagation finding). Timestamps (`observedAt`,
+  false observation-staleness (the round-5 non-propagation finding, now
+  carried by a field that actually exists — the round-8 finding). Timestamps (`observedAt`,
   `doorwayScanAt`, `manifestVerifiedAt`) are EXCLUDED from the
   hash: a rebuild that merely re-stamps time does not churn the digest, so
   digest-compare stays a no-op for unchanged facts (the round-4
   volatile-timestamp finding). Two rebuilds of identical facts produce
   identical digests (fixture-tested in Increment 1).
 - The PULL DECISION keys on the tuple `(schemaVersion, truncated, scanState,
-  scanGeneration, entriesSha256)` — envelope semantics changes fetch too, so a
+  scanStampSecs, entriesSha256)` — envelope semantics changes fetch too, so a
   version bump or truncation change cannot hide behind identical entries
   (the round-4 envelope-fields finding). An epoch/seq bump with an
   unchanged tuple updates the watermark from the digest without fetching
@@ -721,7 +758,7 @@ presentation.
     exactly 2 keys, heartbeat digest ≤ 64 bytes — and that digest bound is
     made arithmetic by the envelope width clamps it depends on
     (`schemaVersion` ≤ 3 digits, `machineEpoch` ≤ 11, `projectionSeq` ≤ 10,
-    `scanGeneration` ≤ 10, `truncated`/`scanState` one digit each, 16-hex
+    `scanStampSecs` ≤ 10, `truncated`/`scanState` one digit each, 16-hex
     entries hash ⇒ 63 bytes worst case). The ingest section states the SAME
     64-byte number; the round-6 finding corrected an earlier 72-vs-64
     disagreement between the two sections. Cheap-tagged with one constraint:
@@ -832,7 +869,7 @@ machines): digest-compare per heartbeat IS our anti-entropy, at fixed cost.
 The nearest standard pattern is HTTP conditional caching, and v1 is
 deliberately isomorphic to it: the digest IS an ETag, the digest-change
 pull IS a conditional GET, `remoteTtlCeiling` IS the Cache-Control TTL,
-and `scanGeneration` IS a revision counter. What we add beyond ETag-style
+and `scanStampSecs` IS a Last-Modified stamp. What we add beyond ETag-style
 caching is exactly the part a mutually-authenticated-but-not-mutually-
 trusted mesh requires and a trusted HTTP origin does not: origin binding,
 the anti-replay watermark, and receiver-owned freshness. Everything else


### PR DESCRIPTION
## ELI16 — The spec asked for a counter that does not exist in the code; this swaps it for a field that does.

## What changed and why

Round 8 of the cross-machine capability registry convergence came from the **build**, not a reviewer. While reviewing Codey's Increment 0 (#1615) I checked the spec's claims against the code and found that `scanGeneration` — specified as "the origin's completed-scan counter, incremented on every completed doorway scan" — **does not exist in production**. It is absent from the scan-state writer's field allowlist in `scripts/doorway-scan.mjs` and from `src/` entirely. Any implementation reading `scan.scanGeneration` gets `undefined` forever, which silently disables the observation-freshness propagation the field was invented for (a no-change scan still bumping the digest tuple so receivers refresh `observedAt` instead of decaying to false staleness).

Seven document-only convergence rounds could not catch this, because the defect was not *in* the document — it was in the document's relationship to the code it depends on. The first implementation attempt surfaced it in minutes.

## The fix

- **`scanGeneration` to `scanStampSecs`**, derived as `floor(Date.parse(clamped lastScanAt)/1000)` (0 when never scanned). `lastScanAt` already exists, is already clamped by `DoorwayRegistryReader`, and already changes on every completed scan — including a no-change one. No producer change, no exhaustion transition to define, width-safe past 2286, and the pull tuple compares for inequality only so a backward clock costs at most one bounded re-pull.
- **`scanState` derivation made normative:** `observed` requires `lastScanAt !== null` (the rule `DoorwayRegistryReader` already encodes), never mere scan-state file existence — the canonical fresh scan-state ships `lastScanAt: null`, so file-existence reports a never-scanned machine as observed, the exact ambiguity `scanState` was added to remove. Corrupt or unreadable scan-state is `source-unavailable`, distinct from `never-observed`.
- **Standing rule recorded in the spec:** a spec naming an external field, route, or store must cite where it exists in code, and a convergence round must include one grounding pass over those citations. Prose can only be verified against prose; a build verifies against reality.

## Who sees this and what changes for them

Nobody user-facing: this is a spec-only change to an unshipped, dark feature (no routes, no config, no behavior change anywhere). The audience is the next implementer — it removes a field they would otherwise have to invent a producer for, and it prevents a never-scanned machine from being reported as scanned once the feature does ship.

## Scope

Spec text only. Unblocks the MF2 item in the #1615 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh2Eb2Yhn54obcsaGhm7kp
