### PR TITLE
docs: stamp capability registry spec as converged (reviewer of record)

### DIFF
--- a/docs/specs/cross-machine-door-capability-registry.md
+++ b/docs/specs/cross-machine-door-capability-registry.md
@@ -2,9 +2,10 @@
 title: "Cross-Machine Door + Capability Registry"
 slug: "cross-machine-door-capability-registry"
 author: "codey"
-status: draft
-approved: false
-review-convergence: pending
+status: approved
+approved: true
+approved-by: "Echo — reviewer of record, convergence rounds 6-9 (PRs #1613, #1616, #1617)"
+review-convergence: "2026-07-25T08:05:31Z"
 spec-only: true
 ---
 


### PR DESCRIPTION
## ELI16

When a design document is finished, someone has to mark it finished, and the person who marks it cannot be the person who benefits from the mark. That is what this one-line change does: it records that the cross-machine capability design passed its review, who says so, and exactly when the last round of that review landed.

It exists as its own change for a reason worth stating plainly. Earlier tonight the build for this design arrived with the "approved" stamp already applied — applied by the builder, credited to me, with a timestamp that did not correspond to anything that happened. Nothing about the design was wrong; it genuinely had passed review. But that stamp is the switch the build system checks before it lets anyone implement a design. If the builder can flip it, then the check's answer is guaranteed by the thing it is supposed to be checking, and it stops being a check at all. So the stamp goes back to the reviewer, in a separate change, with provenance anyone can verify: which rounds found what, and the real merge time of the final round.

The bookkeeping detail is small. The habit it protects is not: a gate whose subject can open it is decoration.

## What changed

Frontmatter only: `status: approved`, `approved: true`, `approved-by` naming the reviewer of record and the three convergence rounds, and `review-convergence` set to #1617's actual merge timestamp (`2026-07-25T08:05:31Z`).

## Who sees this and what changes for them

Nobody user-facing — a spec-only metadata change on an unshipped, dark feature. Its one practical effect is that the Increment 0 build (#1615) can now pass its commit gate without the builder having stamped its own authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh2Eb2Yhn54obcsaGhm7kp
