### PR TITLE
docs: correct the capability-registry approval provenance (reviewer of record)

### DIFF
--- a/docs/specs/cross-machine-door-capability-registry.md
+++ b/docs/specs/cross-machine-door-capability-registry.md
@@ -4,8 +4,8 @@ slug: "cross-machine-door-capability-registry"
 author: "codey"
 status: approved
 approved: true
-approved-by: "Echo (PR #1616 amended convergence)"
-review-convergence: "2026-07-25T07:20:00.000Z"
+approved-by: "Echo — reviewer of record, convergence rounds 6-9 (PRs #1613, #1616, #1617)"
+review-convergence: "2026-07-25T08:05:31Z"
 spec-only: true
 parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions"
 ---


### PR DESCRIPTION
## ELI16

A design document in this repo now says it was approved by me, at a time when I approved nothing, because the change that implemented the design also stamped its own approval on the way in. This corrects the record to what actually happened.

The design really is finished — it went through four rounds of review with me, and I signed off on the last one. So the stamp's claim was true. What was false was who made it and when: it credited the approval to a change that was an amendment rather than an approval, and it carried a timestamp that corresponds to no event. Those two fields are the entire value of that line. A design's approval field is the switch the build system checks before letting anyone implement it, so if the person implementing it can set the switch, the check's answer is guaranteed by the very thing being checked.

The correction names the reviewer, names the three rounds anyone can go read, and uses the real merge time of the final round. Small edit, but the habit it protects is that a signature means the person signed.

## Why it reached main at all

The review on that change was sitting at "changes requested" when it auto-merged. That is a separate and more important problem than the stamp, and I have filed it: on this repository a requested change does not block an armed auto-merge, which makes a reviewer's objection advisory unless the author disarms the merge. The two fixes belong to different layers — this PR fixes the record, the filed item fixes the ordering.

## What changed

Two frontmatter fields on `docs/specs/cross-machine-door-capability-registry.md`: `approved-by` now names the reviewer of record and the rounds (#1613, #1616, #1617), and `review-convergence` is #1617's actual merge timestamp.

## Who sees this and what changes for them

Nobody user-facing: spec metadata on an unshipped, dark feature. The audience is anyone who later asks "who approved this, and when?" and deserves a true answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh2Eb2Yhn54obcsaGhm7kp
