### PR TITLE
docs: track the capability-registry spec's three deferral mentions

### DIFF
--- a/docs/specs/cross-machine-door-capability-registry.md
+++ b/docs/specs/cross-machine-door-capability-registry.md
@@ -650,7 +650,7 @@ it:
   `429`, jittered when fired on mesh-reconnect.
 - Every read response carries `advisory: true` and rows carry their
   self-reported `evidenceClass`. The marker is enforced by Frontloaded
-  Decision 17's ratchet, and the dashboard follow-up must render
+  Decision 17's ratchet, and the dashboard follow-up must render <!-- tracked: ACT-1156 -->
   uncorroborated (all v1) claims distinguishably.
 - `/capabilities` advertises the read surfaces only once the flag actually
   serves them on this install (advertising a dark route breaks
@@ -736,7 +736,7 @@ presentation.
    empty, structurally distinct.
 6. **Authorization:** `scope=pool` rides the same gate as `GET /pool`;
    deny-by-default until the increment that enables it. Per-row owner
-   restrictions: a named follow-up (all rows pool-visible-redacted in v1).
+   restrictions: a named follow-up (all rows pool-visible-redacted in v1). <!-- tracked: ACT-1156 -->
 7. **Conflict:** self-claim supremacy as a declared backstop (Trust rule 5);
    cross-machine contradictions cannot enter by construction; own-source
    `conflict` stays observe-only with provenance.
@@ -762,7 +762,7 @@ presentation.
    verification (the reserved `receiver-verified` class is that future
    increment's contract).
 10. **Operator UX:** dashboard rendering SCOPED OUT of Increments 0-4
-    (API-only, as `/doorways` shipped). The follow-up is REGISTERED
+    (API-only, as `/doorways` shipped). The follow-up is REGISTERED <!-- tracked: ACT-1156 -->
     (ACT-1156, Close the Loop): a section of the existing Machines tab
     rendering self-reported claims distinguishably; mobile failure summary
     one line per machine


### PR DESCRIPTION
## ELI16

A rule in this repository says: if a document mentions that something is being put off until later, the mention has to point at a tracked item, so that deferred work cannot quietly become forgotten work. Three sentences in the cross-machine capability design mention a follow-up without that pointer. All three refer to the same already-registered item, so this adds its marker to each.

The reason it is going in now is more interesting than the change. Those three sentences are mine, written during the review rounds. The rule that checks them is scoped to the FILE, not to whoever wrote the sentence — so the person it actually blocked was the builder trying to land an unrelated fix. He was right not to work around it, and it was my debt to pay, not his.

Small lesson worth keeping: writing "a named follow-up" without naming it is not a harmless bit of prose. It is a debt with someone else's name on it — specifically, the next person who touches the file.

## What changed

Three `<!-- tracked: ACT-1156 -->` markers in `docs/specs/cross-machine-door-capability-registry.md` (ACT-1156 is the registered follow-up covering the Machines-tab rendering and per-row owner restrictions). No prose, structure, or normative content altered.

## Who sees this and what changes for them

Nobody user-facing — comment markers in a spec for an unshipped, dark feature. Its practical effect is that the follow-up fix for the capability registry can be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh2Eb2Yhn54obcsaGhm7kp
