### PR TITLE
census: tracker refs are typed by kind, anchored to shipped source

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T09-22-43-549Z-census-tracker-ref-kinds.json
+++ b/.instar/instar-dev-decisions/2026-07-25T09-22-43-549Z-census-tracker-ref-kinds.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T09:22:43.549Z",
+  "slug": "census-tracker-ref-kinds",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 282,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/census-tracker-ref-kinds.eli16.md
+++ b/docs/specs/census-tracker-ref-kinds.eli16.md
@@ -1,0 +1,103 @@
+# Census tracker refs — the plain-English version
+
+## The one-sentence version
+
+A progress tracker that's supposed to tell us "are these 49 pending items still
+being tracked by something real?" can only ever answer "I have no idea" — because
+the thing it points at is a note that exists on exactly one computer, written
+into code that ships to all of them.
+
+## What's actually going on
+
+We have a list of about 60 places where I make judgment calls. Seven of them
+currently record what they decided so we can grade them later. The other 49 are
+a backlog — not yet wired up.
+
+To stop that backlog quietly rotting, there's a counter that asks a simple
+question of each pending item: *is the thing tracking this still alive?* If a
+tracker vanishes, the item has been abandoned and nobody would notice.
+
+Reasonable check. Except every one of those 49 items points at a to-do note whose
+ID only means something on the machine where I created it. That list of 49 lives
+in the shipped source code — identical on every machine. So on any machine but
+the one that minted the note, the ID refers to nothing at all.
+
+## Why this isn't just an untidy reference
+
+Someone already noticed half of this in July and fixed it properly. The check
+used to report those items as **dead** — as if the trackers had been deleted.
+They hadn't; the machine had simply never seen them. So the fix taught the check
+to say **"can't verify"** instead of **"deleted."**
+
+That was right, and it stopped a false alarm firing on every machine added to the
+fleet. But it left the counter permanently stuck on "can't verify," and a check
+that can only ever say *I don't know* isn't doing anything. It's honest noise.
+
+## What I'm changing
+
+The problem isn't that the ID is broken. It's that it's the **wrong kind of ID**
+for the job — a personal sticky note used where a permanent address was needed.
+
+So trackers get a kind. A to-do ID keeps working exactly as it does today, for
+the cases where it's genuinely a note-to-self on one machine. And a second kind
+points at an entry in a small **registry that lives in the code itself**.
+
+That second part is the whole trick, and I got it wrong the first time — worth
+saying plainly, because the wrong version was convincing.
+
+My first design pointed the 49 items at the **design document** that owns the
+backlog. Documents ship with the code, I reasoned, so every machine can check
+the file is there. An outside reviewer asked the one question I hadn't: *does
+that document actually ship?*
+
+It doesn't. Documentation is explicitly excluded from what gets published. So on
+every machine except this one, the check would look for a missing file and
+conclude the tracker had been **deleted** — 49 deletions that never happened.
+Today's "can't verify" is at least honest; my fix would have replaced it with a
+confident lie, and re-broken the very thing someone fixed in July.
+
+Code, unlike documentation, does ship. So the anchor is a short list written in
+code — a registry the check looks names up in. It's identical on every machine
+because it *is* the same shipped file, with no folder to be missing and no
+heading to be renamed out from under it.
+
+There's now a test that reads the packaging rules directly and fails if anyone
+tries the document approach again, so the reasoning can't quietly evaporate.
+
+Nicely, the general idea isn't new. The same file already has a category of
+entry that carries "a resolvable reference" and gets validated. The pending
+entries just never adopted the convention sitting next to them.
+
+## The thing I want to be explicit about
+
+The task I was given says: fix the reference *so the unverifiable count shrinks*.
+
+I could make that number zero in about a minute by swapping in a to-do ID that
+happens to be live on this machine. The counter would read clean. It would still
+be broken everywhere else, and now nobody would ever look again — because the
+warning light would be off.
+
+That's the trap, and I want it on the record that I'm not taking it. The point
+isn't a smaller number; it's a check that can actually answer. The number drops
+as a *consequence* of that, which is the only version worth having.
+
+## What you'd notice
+
+Honestly, nothing directly. This is instrumentation — a counter on an internal
+health page going from "49 unknown" to "0 unknown, 49 pending."
+
+What it buys is that the pending backlog becomes genuinely watchable. If one of
+those 49 ever loses its tracker for real, the check will say so, on every
+machine, instead of shrugging. Right now it would shrug, and we'd never know the
+difference between "fine" and "abandoned."
+
+One honest caveat about the new failure mode: because the registry ships with
+the code, a name that isn't in it reads as **deleted** rather than "unknown."
+That's deliberate — a shipped list's silence is a fact everywhere, not a local
+gap — but it does mean a typo would be loud rather than quiet. Two things stop
+that reaching you: the build refuses to publish a name that isn't in the
+registry, and undoing the change restores today's quieter behaviour.
+
+The second half of the task — actually wiring up the highest-traffic ones so they
+start recording — is where the backlog really shrinks. This comes first because
+wiring things up against a tracker nobody can verify is building on sand.

--- a/docs/specs/census-tracker-ref-kinds.md
+++ b/docs/specs/census-tracker-ref-kinds.md
@@ -1,0 +1,259 @@
+---
+title: "Census Tracker Refs Are Verifiable — a machine-local id in shipped source can never resolve"
+slug: "census-tracker-ref-kinds"
+author: "echo"
+status: "draft"
+created: 2026-07-25
+parent-principle: "Verify the State, Not Its Symbol"
+sibling-principles: "Observation Needs Structure; Close the Loop; No Silent Degradation to Brittle Fallback; An Instar Agent Is Always a Multi-Machine Entity; Testing Integrity; Structure beats Willpower"
+lessons-engaged: "the 2026-07-23 pending-tracker false-alarm fix (split `unverifiable` from `dead` — the correct FIRST half of this arc); llm-decision-quality-meter §5.6 (the retrofit backlog these trackers point at); tone-gate-advisory-migration 2026-07-25 (the sibling case: a metric that reads clean while being structurally incapable of meaning anything)"
+origin: "Autonomous run 2026-07-25, topic 33368 — task 2. Surfaced by GET /decision-quality reporting pendingRefUnverifiable: 49 on this machine, indefinitely."
+eli16-overview: "census-tracker-ref-kinds.eli16.md"
+review-convergence: "2026-07-25T09:14:34.440Z"
+review-iterations: 2
+review-completed-at: "2026-07-25T09:14:34.440Z"
+review-report: "docs/specs/reports/census-tracker-ref-kinds-convergence.md"
+approved: true
+approved-by: "Autonomous run 2026-07-25, topic 33368 — task 2 of the operator-authored run plan ('Census dead-reference fix. Resolve the dangling ACT-1193 reference blocking all 49 pending decision points'), under the run's standing instruction that decisions are reversible and dark-shipped: 'make the call, state it, keep going.'"
+approval-scope-note: "This is NOT a quoted per-change approval — the run plan authorized the TASK, and I chose the design. Two deviations from the literal instruction are on the record rather than assumed. (1) The task says fix the reference 'so pendingRefUnverifiable shrinks'; shrinking that number was achievable in a minute by swapping in a locally-live ACT id, which would have read clean here and stayed broken everywhere else. I built the verifiable version instead, and the count drops as a consequence — argued in section 1 under 'What this spec is NOT'. (2) The first design was INVERTED mid-flight after external review proved it would have been worse than shipping nothing; both the flaw and the correction were reported to Justin in topic 33368 on 2026-07-25 before the build continued, not disclosed after the fact. Reversible: revert restores today's behaviour, and no flag or durable state is introduced."
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 5
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# Census Tracker Refs Are Verifiable
+
+## 1. The problem
+
+`GET /decision-quality` reports census debt so the provenance-enrollment backlog
+cannot rot silently. On this machine it reports:
+
+    censusDebt: { wired: 7, pending: 49, exempt: 6, pendingRefUnverifiable: 49 }
+
+**All 49 pending decision points are unverifiable, and always will be.** Every
+one carries `status: 'pending:ACT-1193'` — an evolution-action id — and
+`PROVENANCE_COVERAGE` is a SHIPPED SOURCE CONSTANT, byte-identical on every
+install, while the evolution action queue is **machine-local and unreplicated**.
+
+A machine that never minted an id that high has not deleted the tracker; it has
+never seen it. The 2026-07-23 fix correctly recognised this and split
+`unverifiable` from `dead` so the check stopped reporting a deletion that never
+happened. That was the right first half.
+
+This is the second half. Not-false-alarming is not the same as verifying. The
+tracker still resolves on exactly one machine in the fleet — the one that minted
+`ACT-1193` — so for every other install the debt signal is permanently
+uninformative. A number that can only ever say "I don't know" is not a check.
+
+**What this spec is NOT.** The task as written says "resolve the dangling
+reference so `pendingRefUnverifiable` shrinks." Swapping in a locally-live ACT id
+would shrink it to zero on this machine and change nothing anywhere else — the
+metric would look fixed and remain broken. That is gaming, and it is explicitly
+rejected. The goal is a tracker that is **verifiable**, after which the count
+drops as a consequence.
+
+## 2. Design
+
+### 2.1 Tracker refs are typed by KIND
+
+`ACT-1193` is not a bad id; it is the wrong KIND of id for the job. A
+machine-local bookkeeping handle was written into a fleet-wide constant.
+
+Two ref kinds, distinguished by prefix:
+
+| kind | example | how it is adjudicated |
+|---|---|---|
+| `ACT-<n>` | `ACT-1193` | unchanged — the existing queue + high-water logic |
+| `backlog:<key>` | `backlog:decision-quality-enrolment` | exact-match lookup in `BACKLOG_TRACKERS`, a shipped source constant in `src/data/provenanceCoverage.ts` |
+
+`parseTrackerRef(ref)` returns a discriminated result; `adjudicatePendingTracker`
+branches on it. An unrecognised shape keeps today's strict `dead` reading — a
+malformed tracker must still surface rather than hide in a new bucket.
+
+**Frontloaded decision 1 — the anchor is a source CONSTANT, not a document.**
+The intuitive anchor is a spec file (`spec:llm-decision-quality-meter#5.6`),
+checked with `fs.existsSync`. It is wrong, and the reason is worth pinning
+because it inverts the whole change: **`docs/` is excluded from the published
+package** — `.npmignore` line 8, and absent from `package.json` `files[]`. A
+doc-path existence check therefore resolves FALSE on every fleet install,
+converting 49 honest `unverifiable` entries into 49 fleet-wide false `dead`
+ones. That is strictly worse than the status quo and re-runs the exact false
+alarm the 2026-07-23 fix removed.
+
+`src/data/` **is** published and compiles into `dist/`, so a constant declared
+there is byte-identical on every install *by construction* — no filesystem, no
+packaging assumption, and no sub-document anchor that can drift when a heading
+is renamed. `tests/unit/census-tracker-ref-kinds.test.ts` asserts both halves of
+that packaging fact directly against `package.json`, so the rejected design
+cannot be reintroduced silently.
+
+*(Credit where due: external cross-model review caught this. The first draft of
+this spec shipped the doc-path design.)*
+
+**Frontloaded decision 2 — the adjudicator is PURE, with no injected predicate.**
+Because the registry is a source constant, the function imports it and needs no
+filesystem and no `specExists`-style seam. That is strictly simpler than the
+rejected design *and* more verifiable: `unverifiable` is unreachable for the
+`backlog:` kind by construction, which the unit tier asserts.
+
+**Frontloaded decision 3 — `liveActs` becomes nullable.** A `backlog:` ref needs
+no evolution queue, but the route previously skipped adjudication entirely when
+`action-queue.json` was absent. Left alone, every fleet-stable ref would be
+silently *uncounted* on exactly the installs the kind exists to serve. The null
+case moves into the adjudicator: `backlog:` resolves normally, and an `ACT-<n>`
+ref with no readable queue reports `unverifiable` — never `dead`.
+
+**Frontloaded decision 4 — this is not a new invention.** `ProvenanceStatus`
+already carries `exempt:operator-ratified:<ref>`, documented as "a resolvable ref
+(PR / standards-registry anchor), also ratchet-validated." The resolvable-ref
+convention exists in this exact file; the pending kind simply never adopted it.
+
+### 2.2 The format ratchet moves with it
+
+The type doc states pending refs are "format-validated (`^ACT-\d+$`) and
+baseline-pinned by the ratchet." That ratchet is correct today and would
+correctly reject a `backlog:` ref, so it is extended in the same change —
+otherwise the build fails for the right reason at the wrong time.
+
+**Frontloaded decision 5 — the ratchet must still reject garbage.** Widening it
+to "anything" would remove the guard that makes a typo visible. It accepts
+exactly the two kinds (`^ACT-\d+$ | ^backlog:[a-z0-9][a-z0-9-]*$`) and nothing
+else — and it additionally resolves every `backlog:` ref against the registry at
+CI time, so a dangling key dies in the build rather than surfacing later as a
+runtime `dead` verdict.
+
+### 2.3 What actually shrinks the backlog
+
+Repointing refs makes the debt signal legible. It does not enrol anything. The
+second half of the task — enrolling the highest-volume unenrolled decision points
+so they genuinely record — is where the count drops for real, and it is
+sequenced after this because enrolment against an unverifiable tracker is
+building on sand.
+
+### 2.4 Alternatives considered
+
+Recorded because the chosen anchor is not the only stable one, and a reader
+should not have to infer why it wins here.
+
+| alternative | why not |
+|---|---|
+| **GitHub issue / PR id** (`gh:1618`) | Genuinely fleet-stable, and the honest runner-up. Rejected because resolving it needs network + auth to a repo most installs cannot read: a fleet agent would get `unverifiable` for a *different* reason, trading a local-state dependency for a network-and-permissions one. A check that fails closed on an outbound call is worse than one that cannot fail at all. |
+| **Commit / tree anchor** | Immutable and offline-checkable, but it names a point in history, not an obligation. It answers "did this commit exist?", never "is this work still tracked?". |
+| **A separate machine-readable manifest shipped in the package** | Works, and is what the registry effectively is — minus a second file, a second format, and a second thing that can drift from the entries it describes. Co-locating the registry with the entries in one source file is the same idea with fewer seams. |
+| **A replicated action log** (the evolution queue, made cross-machine) | The "right" long-term fix for machine-local trackers generally, and out of scope here: it changes a durable multi-machine store to repair a read-surface counter. Deliberately not attempted — this spec stops *depending* on that locality rather than changing it. |
+
+### 2.5 Two review findings adjudicated, not adopted
+
+Both raised by external cross-model review (2026-07-25, round 2) and both
+reasonable from outside the code. Recorded with the evidence that closes them.
+
+**"A mixed-version fleet breaks this — an old adjudicator reads `backlog:` as
+unknown and reports `dead`."** Not reachable. The refs and the parser are the
+*same shipped artifact*: `PROVENANCE_COVERAGE` (which holds the refs) and
+`adjudicatePendingTracker` (which parses them) both compile into `dist/` from
+one package version. An install therefore has old refs with an old parser, or
+new refs with a new parser — never a mix. The one path that could cross machines
+is the pool merge, and `censusDebt` is built at a single local callsite and is
+not among the pool-merged fields, so a peer's raw ref never reaches another
+machine's adjudicator. (Verified, not assumed.)
+
+**"`dead` for a malformed ref is semantically muddy — add an `invalid`
+verdict."** Correct as a matter of vocabulary, declined on reachability. The
+ratchet now format-validates every pending ref *and* resolves every `backlog:`
+key against the registry at CI time, so a malformed ref cannot reach a release;
+an `invalid` runtime verdict would be dead code guarding an impossible state.
+It would also widen the two-bucket contract the 2026-07-23 fix established
+(`dead` vs `unverifiable`) for no operational gain. The diagnosability concern
+is real but lands at build time, where the failure message names the entry.
+
+## Decision points touched
+
+| Decision point | Classification | Justification |
+|---|---|---|
+| `adjudicatePendingTracker` verdict (alive / dead / unverifiable) | `invariant` | A closed, enumerable domain: a ref either parses to a known kind and resolves, or it does not. No competing signals, no context to weigh — the failure mode this replaces was a *missing branch*, not a judgment call. |
+| Tracker-ref format validation (the ratchet) | `invariant` | A closed-world format check over a two-member enum at a dev-process chokepoint — the documented Signal-vs-Authority exemption class. It decides nothing about meaning. |
+
+## Multi-machine posture
+
+- **Tracker refs in `PROVENANCE_COVERAGE` — unified.** That is the entire point:
+  a `backlog:` ref resolves against a shipped source constant, so every machine
+  answers identically. The defect being fixed is precisely that today's ref is
+  machine-local while the constant carrying it is fleet-wide.
+- **`BACKLOG_TRACKERS` — unified.** A source constant in `src/data/`, which is
+  published (`package.json` `files[]`) and compiled into `dist/`. Uniformity is
+  structural, not conventional: there is no per-machine copy to diverge.
+- **`adjudicatePendingTracker` — unified.** A pure function over that constant.
+  It reads machine-local state ONLY for the `ACT-<n>` kind, which is
+  machine-local by design and already carries the high-water guard.
+- **The evolution-action queue — machine-local BY DESIGN** —
+  `machine-local-justification: operator-ratified-exception`. Inherited, not
+  introduced: the queue's locality is pre-existing and out of scope here. The
+  ratified artifact is the 2026-07-23 high-water adjudication already in
+  `src/server/routes.ts`, which exists specifically to keep that locality from
+  producing false deletions. This spec stops *depending* on that locality for
+  fleet-wide trackers rather than trying to change it.
+
+## Open questions
+
+*(none)*
+
+> Whether the remaining `ACT-` kind should eventually be retired entirely is a
+> real question, but not one that blocks this: some trackers legitimately are
+> machine-local work items, and the kind distinction is what lets both coexist
+> honestly.
+
+## Maturation plan
+
+- **test-agent-live:** n/a — a read-surface correctness fix with no agent-class staging surface.
+- **dev-agent-live:** this ship. The adjudicator change is always-on; it is a correctness fix to an observe-only debt counter, not a gated capability.
+- **dark-window:** none — the change cannot loosen a guard. It converts "permanently unknown" into a real verdict, and an unrecognised ref still reads `dead` exactly as today.
+- **graduation criterion:** THREE conditions, not one. On a machine that never
+  minted `ACT-1193`, `GET /decision-quality` reports (a) `pendingRefUnverifiable`
+  EMPTY, (b) `pendingRefDead` EMPTY, and (c) `pending` unchanged at 49. All three
+  are required together. (a) alone is gameable in the wrong direction — a
+  malformed or unregistered ref moves to `dead`, not `unverifiable`, so the
+  headline number can "improve" by reclassifying uncertainty into failure. (c)
+  is what stops the other gaming direction: quietly shrinking the backlog. All
+  three are asserted in the E2E tier on the real boot path, and the unit tier
+  additionally pins the exact ref DISTRIBUTION (all 49 on one deliberate key —
+  aggregate counts can look healthy while refs quietly drift apart) and the
+  absence of orphaned registry keys.
+- **fleet:** ships with the release; no flag, because there is no looser state to roll back to.
+
+## Testing
+
+- **Tier 1** (`tests/unit/census-tracker-ref-kinds.test.ts`, 21 cases) —
+  `parseTrackerRef` over both kinds and a garbage corpus (including the rejected
+  `spec:` shape, which must parse as `unknown`); `adjudicatePendingTracker` on
+  both sides of every branch, including an unregistered key (`dead` — a removed
+  registry entry IS a real deletion) and the null-queue case for both kinds; the
+  **packaging invariant** asserted directly against `package.json` (`src/data`
+  ships, `docs/` does not) so the rejected design cannot return silently;
+  prototype-key safety on the registry lookup (`constructor` / `__proto__` must
+  not resolve); and every pending census entry resolving on a queue-less install.
+- **Tier 2** (`tests/integration/census-tracker-ref-kinds-routes.test.ts`) —
+  `GET /decision-quality` through the real Express routes + authMiddleware
+  returns EMPTY `pendingRefUnverifiable` and `pendingRefDead` with `pending`
+  unchanged, on both a no-queue install and a populated queue that never saw
+  `ACT-1193`; auth still required.
+- **Tier 3** (`tests/e2e/decision-quality-alive.test.ts`) — the real `AgentServer`
+  boot asserts all three graduation conditions on the production init path,
+  which runs against a fresh stateDir with no evolution queue — i.e. exactly the
+  fleet install the old ref could not answer for.
+
+## Rollback
+
+Revert. There is no flag because there is no weakened state to return to: the
+change adds a ref kind and a branch.
+
+**Stated honestly, because the first draft got this wrong:** *before* a revert, a
+`backlog:` ref pointing at a key that is not in the registry reports **`dead`**,
+not `unverifiable` — that is the design, since a shipped registry's silence is a
+fact on every install rather than a local gap. So the failure mode of a bad ref
+is a loud false deletion, not a quiet unknown. Two things bound it: CI resolves
+every `backlog:` ref against the registry, so a dangling key cannot reach a
+release; and reverting restores today's `unverifiable` reading. The operational
+response to a `dead` verdict is to check the registry key, not to assume the
+tracked work vanished.

--- a/docs/specs/reports/census-tracker-ref-kinds-convergence.md
+++ b/docs/specs/reports/census-tracker-ref-kinds-convergence.md
@@ -1,0 +1,130 @@
+# Convergence report — census-tracker-ref-kinds
+
+**Spec:** `docs/specs/census-tracker-ref-kinds.md`
+**Author:** echo · **Rounds:** 2 · **Completed:** 2026-07-25
+
+---
+
+## Headline
+
+Round 1 returned **SERIOUS ISSUES** and **inverted the design**. The spec as
+first written would have been *worse than shipping nothing* — a detail worth
+leading with, because the flaw was invisible from inside the reasoning that
+produced it.
+
+Round 2 returned **MINOR ISSUES** against the corrected design: three adopted,
+two adjudicated and declined with recorded evidence.
+
+## Iteration summary
+
+| round | Standards-Conformance Gate | external cross-model | verdict |
+|---|---|---|---|
+| 1 | ran (0 flags) | `codex-cli:gpt-5.5` | **SERIOUS ISSUES** (5) |
+| 2 | ran (0 flags) | `codex-cli:gpt-5.5` | **MINOR ISSUES** (5) |
+
+*Caveat carried forward from the tone-gate convergence:* the conformance gate's
+"0 findings" is measured against the subset of the constitution it currently
+evaluates, not all ~80 standards (`ATT-conformance-partial-constitution`). It is
+a real signal, not a clean bill of health, and it is not treated as one here.
+
+Internal reviewers ran on the authoring session's model (opus). The clean-door
+Anthropic reviewer was not run; the cross-family pass was `codex-cli` only, so
+this is a **single-family** external read, disclosed rather than implied.
+
+## Round 1 — the finding that changed the design
+
+The first draft anchored the 49 pending census entries to a **spec document
+path** (`spec:llm-decision-quality-meter#5.6`), resolved with a filesystem
+existence check. The reasoning: documents ship with the source, so every install
+can verify them.
+
+The reviewer asked whether that was actually true.
+
+**It is not.** `docs/` is excluded from the published package — `.npmignore`
+line 8, and absent from `package.json` `files[]`. The existence check would
+therefore resolve FALSE on every fleet install, converting 49 honest
+`unverifiable` entries into **49 fleet-wide false `dead` ones**: a claim that
+49 trackers had been deleted when none had. That is strictly worse than the
+status quo, and it re-runs the exact false alarm the 2026-07-23 fix removed —
+while being labelled as the completion of that fix.
+
+Verified before accepting (`package.json` `files[]` + `.npmignore` read
+directly), then the design was rewritten around a **shipped source constant**
+(`BACKLOG_TRACKERS` in `src/data/provenanceCoverage.ts`), which is byte-identical
+on every install by construction: no filesystem, no packaging assumption, no
+sub-document anchor that drifts when a heading is renamed.
+
+The remaining round-1 findings were absorbed by that rewrite:
+
+| # | finding | disposition |
+|---|---|---|
+| 1 | `spec:<path>#<anchor>` verifies the document, never the anchor | **Moot** — no anchors exist; a registry key is the whole reference, exact-matched. |
+| 2 | Path grammar underspecified (directory? extension? traversal?) | **Moot** — no paths. Keys are `^[a-z0-9][a-z0-9-]*$`. |
+| 3 | Assumes docs ship everywhere | **Adopted — this is the inversion.** A packaging invariant is now asserted in CI against `package.json` so the rejected design cannot return silently. |
+| 4 | Graduation criterion passes while broken (uncertainty reclassified as failure) | **Adopted.** Now three conditions: `pendingRefUnverifiable` empty AND `pendingRefDead` empty AND `pending` unchanged at 49. |
+| 5 | Rollback description inaccurate | **Adopted.** The spec now states plainly that a bad ref reports `dead`, not `unverifiable`, *before* a revert — and what bounds it. |
+
+## Round 2 — three adopted, two declined
+
+**Adopted:**
+
+- **Registry existence risks becoming circular** — proving a symbol resolves is
+  not proving the obligation is real; a key nobody retires makes `alive` mean
+  "still listed". `BacklogTracker` now requires a **`closureCondition`** (what
+  must be true for the key to be deleted), CI enforces a minimum, and a second
+  test forbids **orphaned keys** (registered but referenced by nothing).
+- **Graduation could mask registry bloat** — aggregate counts can look healthy
+  while refs drift apart. CI now pins the exact ref **distribution**: all 49 on
+  one deliberate key, not a spray of near-misses.
+- **Alternatives under-acknowledged** — spec §2.4 now compares GitHub issue ids
+  (the honest runner-up; rejected because resolving it needs network + auth a
+  fleet install lacks), commit anchors, a separate shipped manifest, and a
+  replicated action log.
+
+**Declined, with evidence (spec §2.5):**
+
+- **"A mixed-version fleet breaks this."** Not reachable: the refs
+  (`PROVENANCE_COVERAGE`) and the parser (`adjudicatePendingTracker`) compile
+  into `dist/` from the *same package version*, so no install can hold new refs
+  with an old parser. The only cross-machine path is the pool merge, and
+  `censusDebt` is built at a single local callsite and is not pool-merged —
+  checked in source, not assumed.
+- **"`dead` for a malformed ref is semantically muddy; add `invalid`."**
+  Correct as vocabulary, declined on reachability: the ratchet format-validates
+  every pending ref *and* resolves every `backlog:` key at CI time, so a
+  malformed ref cannot reach a release. An `invalid` verdict would be dead code
+  guarding an impossible state, and would widen the two-bucket contract the
+  2026-07-23 fix established for no operational gain.
+
+## What the reviewer did not catch, and I did
+
+The route previously skipped tracker adjudication entirely when
+`action-queue.json` was absent (`if (liveActs !== null)`). A `backlog:` ref needs
+no queue — so left alone, every fleet-stable ref would have been silently
+*uncounted* on exactly the installs the new kind exists to serve. The feature
+would have reported a clean `[]` for the honest reason on the dev machine and
+the dishonest reason everywhere else. `liveActs` is now nullable and the null
+case is handled inside the adjudicator, with the Tier-1 and Tier-2 suites
+asserting the no-queue install directly.
+
+## Decision-point classification
+
+Both decision points classify as `invariant`, argued in the spec:
+`adjudicatePendingTracker`'s verdict (a closed enumerable domain — the failure
+being fixed was a *missing branch*, not a judgment call) and the tracker-ref
+format ratchet (a closed-world format check at a dev-process chokepoint — the
+documented Signal-vs-Authority exemption class).
+
+## Frontloaded decisions
+
+Five, all recorded in §2.1/§2.2: the source-constant anchor; the pure
+adjudicator with no injected predicate; nullable `liveActs`; the resolvable-ref
+convention already present in the file; and the ratchet accepting exactly two
+kinds. No decision is deferred to build time.
+
+## Standing caveat
+
+This spec's own first draft is the argument for running the external pass. Two
+consecutive specs in this run have come back SERIOUS ISSUES from the cross-model
+reviewer after reading clean internally. A single-family external read is a
+floor, not a ceiling.

--- a/scripts/generate-builtin-manifest.cjs
+++ b/scripts/generate-builtin-manifest.cjs
@@ -426,8 +426,18 @@ function main() {
     manifest.entries[entry.id] = entry;
   }
 
-  // Write to src/data/
-  const outputPath = path.join(ROOT, 'src/data/builtin-manifest.json');
+  // Write to src/data/ — or to an explicit override.
+  //
+  // WHY THE OVERRIDE EXISTS: the up-to-date CHECK in
+  // tests/unit/builtin-manifest.test.ts used to run this generator against the
+  // real path and diff the file before/after — i.e. a test that verifies the
+  // committed manifest is current by OVERWRITING the committed manifest. Under
+  // the parallel suite that races tests/unit/package-completeness.test.ts,
+  // whose full `npx tsc` build regenerates the same file, producing a random
+  // red on a green tree. A verifier must not mutate the artifact it verifies.
+  const outputPath = process.env.INSTAR_BUILTIN_MANIFEST_OUT
+    ? path.resolve(process.env.INSTAR_BUILTIN_MANIFEST_OUT)
+    : path.join(ROOT, 'src/data/builtin-manifest.json');
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, JSON.stringify(manifest, null, 2) + '\n');
 

--- a/src/data/provenanceCoverage.ts
+++ b/src/data/provenanceCoverage.ts
@@ -12,10 +12,12 @@
  *     runtime and counts unknowns). Wired entries declare their volumeClass —
  *     the PROVENANCE store's volume valve (§5.6; the ~250-byte decision_quality
  *     row is written for every enrolled settlement regardless of class).
- *   - status 'pending:<ACT-ref>'    — the retrofit backlog, format-validated +
+ *   - status 'pending:<ref>'        — the retrofit backlog, format-validated +
  *     PINNED shrink-only in tests/unit/provenance-coverage-ratchet.test.ts
- *     (count can only go down; re-pointing an entry to a different ACT is a
- *     reviewed baseline change — shrink-only covers count, not identity). The
+ *     (count can only go down; re-pointing an entry to a different tracker is a
+ *     reviewed baseline change — shrink-only covers count, not identity). A ref
+ *     is one of two KINDS: `ACT-<n>` (machine-local) or `backlog:<key>`
+ *     (fleet-stable, resolved against BACKLOG_TRACKERS below). The
  *     runtime half of the two-layer check (§5.6 pending-ref-dead) lives on
  *     GET /decision-quality, where the evolution queue exists.
  *   - status 'exempt:<taxonomy>'    — a CLOSED taxonomy (an exemption is a
@@ -58,8 +60,85 @@ export const EXEMPT_TAXONOMY_KEYS: ReadonlyArray<ExemptTaxonomyKey> = [
 ];
 
 /**
- * A decision point's provenance posture. `pending:<ACT-ref>` refs are
- * format-validated (^ACT-\d+$) and baseline-pinned by the ratchet;
+ * A BACKLOG TRACKER — a fleet-stable owner for a body of pending work.
+ *
+ * WHY THIS EXISTS (census-tracker-ref-kinds). A pending entry needs to name
+ * something a reader can resolve to answer "is this still tracked?". Two
+ * candidate anchors were rejected on evidence:
+ *
+ *  - An evolution-action id (`ACT-1193`) is a MACHINE-LOCAL handle. Written
+ *    into this constant — which is byte-identical on every install — it can
+ *    resolve on exactly one machine in the fleet.
+ *  - A spec DOCUMENT path was the obvious next reach, and is wrong for a
+ *    reason worth recording: `docs/` is excluded from the published package
+ *    (`.npmignore`; absent from package.json `files[]`). An existence check
+ *    against a doc path resolves FALSE on every fleet install, converting
+ *    "unverifiable" into a fleet-wide false "deleted" — strictly worse than
+ *    the status quo, and a re-run of the exact false alarm the 2026-07-23 fix
+ *    removed. (External cross-model review, 2026-07-25, caught this.)
+ *
+ * A source constant is the anchor that survives both objections: `src/data/`
+ * IS published, it compiles into `dist/`, and this record is therefore
+ * byte-identical everywhere BY CONSTRUCTION — no filesystem, no packaging
+ * assumption, no sub-document anchor that can silently drift.
+ *
+ * Removing a key while entries still point at it is a REAL deletion, and the
+ * adjudicator reports it as `dead` on every machine at once. That is the
+ * signal the debt check was built to raise.
+ */
+export interface BacklogTracker {
+  /** Stable key. Charset-clamped by the ratchet: ^[a-z0-9][a-z0-9-]*$ */
+  readonly key: string;
+  /** Where the work is specified. Documentation for a reader — NEVER resolved. */
+  readonly owner: string;
+  /** What the backlog is, in one line. */
+  readonly summary: string;
+  /**
+   * What must become TRUE for this backlog to be finished — the answer to
+   * "when does this key get deleted?".
+   *
+   * WHY IT IS REQUIRED (external review, 2026-07-25): without it, `alive` decays
+   * into "still listed". A key nobody ever retires makes the debt check pass
+   * forever while the work rots — the same class of empty-green the whole change
+   * exists to remove, just moved one level up. A closure condition makes the
+   * key's own staleness reviewable by a human reading the registry.
+   */
+  readonly closureCondition: string;
+}
+
+/**
+ * The backlog registry. Adding a key is a reviewed source change; removing one
+ * while referenced surfaces as `dead` fleet-wide, which is the intended alarm.
+ *
+ * `owner` is prose for a human reader. It is deliberately NOT resolved at
+ * runtime: resolving it would reintroduce the docs-do-not-ship defect above.
+ */
+export const BACKLOG_TRACKERS: Readonly<Record<string, BacklogTracker>> = {
+  'decision-quality-enrolment': {
+    key: 'decision-quality-enrolment',
+    owner: 'docs/specs/llm-decision-quality-meter.md §5.6 (Census + enrolment backlog)',
+    summary:
+      'Decision points enumerated in the census but not yet wired to record ' +
+      'provenance + outcomes. Each is retrofitted by enrolling its callsite ' +
+      'through the annotate chokepoint; the census debt counters track the drain.',
+    closureCondition:
+      'Every census entry is `wired` or carries a closed-taxonomy exemption — ' +
+      'i.e. NO entry carries this key. At that point the last reference is gone ' +
+      'and this key is deleted from the registry in the same change.',
+  },
+};
+
+/** Is this backlog key live? Pure lookup over a shipped constant. */
+export function backlogTrackerExists(key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(BACKLOG_TRACKERS, key);
+}
+
+/**
+ * A decision point's provenance posture. A `pending:<ref>` ref is
+ * format-validated and baseline-pinned by the ratchet, and carries one of two
+ * KINDS: `ACT-<n>` (a machine-local work item — legitimately local, resolved
+ * against the local queue with high-water adjudication) or
+ * `backlog:<key>` (fleet-stable, resolved against BACKLOG_TRACKERS above).
  * `exempt:operator-ratified:` carries a resolvable ref (PR / standards-registry
  * anchor), also ratchet-validated.
  */
@@ -263,7 +342,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'input-guard',
     component: 'InputGuard',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Input-coherence verdict over an inbound prompt; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -271,7 +350,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'session-activity-digest',
     component: 'SessionActivitySentinel',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Activity digest authored over session tmux output; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -279,7 +358,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'stall-triage-diagnosis',
     component: 'StallTriageNurse',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Stall-triage diagnosis over session output; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -287,7 +366,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'commitment-detect',
     component: 'CommitmentSentinel',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Commitment detection over conversation text; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -295,7 +374,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'presence-stall-judge',
     component: 'PresenceProxy',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Tier-3 stall judgment over session output; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -303,7 +382,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'message-sentinel-classify',
     component: 'MessageSentinel',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Pause/emergency/normal intent classification over an inbound user message (latency-critical); enrollment queued in the ACT-1193 retrofit backlog.',
@@ -311,7 +390,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'project-drift-check',
     component: 'ProjectDriftChecker',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Is-work-on-project coherence verdict over session work + files; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -319,7 +398,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'temporal-coherence-check',
     component: 'TemporalCoherenceChecker',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Temporal-coherence verdict over conversation content; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -327,7 +406,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'watchdog-stuck-judge',
     component: 'SessionWatchdog',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Stuck-session judgment over live session output; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -335,7 +414,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'resume-sanity-check',
     component: 'ResumeQueueDrainer',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Resume-sanity verdict before a queued mid-work revival; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -343,7 +422,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'topic-intent-arc-check',
     component: 'TopicIntentArcCheck',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Arc-check classification of a topic intent over conversation; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -351,7 +430,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'slack-stall-confirm',
     component: 'SlackAdapter',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Stall-confirm alert-suppression judgment over session output (Slack arm); enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -361,7 +440,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'prompt-injection-detect',
     component: 'PromptGate',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Prompt-injection detection over inbound content; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -369,7 +448,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'external-operation-gate',
     component: 'ExternalOperationGate',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Operation mutability/reversibility classification incl. in-content approval claims; enrollment queued in the ACT-1193 retrofit backlog.',
@@ -377,7 +456,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'warrants-reply-gate',
     component: 'WarrantsReplyGate',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Should-I-reply verdict over an inbound message; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -385,7 +464,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'unjustified-stop-gate',
     component: 'UnjustifiedStopGate',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Stop-justified verdict over session state; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -393,7 +472,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'coherence-review',
     component: 'CoherenceReviewer',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Outbound coherence review — THE measured high-volume point (3,641 of 4,098 llm calls/24h on the dev agent, spec §5.6); MUST declare sampled:<rate> or budget:<rows/day> at enrollment, never full.',
@@ -401,7 +480,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'move-intent-classify',
     component: 'MoveIntentClassifier',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Move/pin command-vs-discussion intent over an inbound message + context; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -409,7 +488,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'hub-intent-classify',
     component: 'HubIntentClassifier',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Hub open/tie bind-intent over an inbound hub message; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -417,7 +496,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'profile-intent-classify',
     component: 'ProfileIntentClassifier',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Topic-profile change intent (framework/model/thinking) over an inbound message; enrollment queued in the ACT-1193 retrofit backlog.',
@@ -425,7 +504,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'llm-sanitize',
     component: 'LLMSanitizer',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Sanitize verdict over untrusted inbound content (definitionally injection-exposed); enrollment queued in the ACT-1193 retrofit backlog.',
@@ -433,7 +512,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'override-detect',
     component: 'OverrideDetector',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Override-intent detection over a user turn (uxConfirm pre-routing); enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -441,7 +520,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'task-classify',
     component: 'TaskClassifier',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Task-type classification over a user task description; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -451,7 +530,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'job-reflect',
     component: 'JobReflector',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Job-outcome reflection over job output/transcript; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -459,7 +538,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'cross-model-review',
     component: 'crossModelReviewer',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Cross-model spec-document review over file content; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -467,7 +546,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'self-knowledge-extract',
     component: 'SelfKnowledgeTree',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Self-knowledge extraction over transcripts; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -475,7 +554,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'tree-triage',
     component: 'TreeTriage',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Knowledge-tree fragment triage over stored content; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -483,7 +562,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'topic-summarize',
     component: 'TopicSummarizer',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Topic summary authoring over conversation content; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -491,7 +570,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'contextual-evaluate',
     component: 'ContextualEvaluator',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Context-relevance evaluation over conversation/session content; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -499,7 +578,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'relationship-extract',
     component: 'RelationshipManager',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Relationship-fact extraction from conversation (PII-adjacent content); enrollment queued in the ACT-1193 retrofit backlog.',
@@ -507,7 +586,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'standards-conformance-review',
     component: 'StandardsConformanceReviewer',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Artifact-vs-standard conformance review over file content; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -515,7 +594,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'discovery-evaluate',
     component: 'DiscoveryEvaluator',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Serendipity-discovery evaluation over subagent output; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -523,7 +602,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'dashboard-insight',
     component: 'DashboardInsightEngine',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Awareness-only page-data insight authoring (degrades to a deterministic floor); enrollment queued in the ACT-1193 retrofit backlog.',
@@ -533,7 +612,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'pipe-session-spawn',
     component: 'PipeSessionSpawner',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Session authoring from (possibly user-authored) task descriptions; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -541,7 +620,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'cartographer-summary-author',
     component: 'CartographerSweep',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Doc-tree summary authoring over untrusted code; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -549,7 +628,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'standards-coverage-enrich',
     component: 'StandardsCoverageEnrichment',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Standards-coverage row enrichment over repo content (dark LLM path); enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -559,7 +638,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'input-classify',
     component: 'InputClassifier',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Auto-approve vs relay classification of inbound input; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -567,7 +646,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'session-summary-extract',
     component: 'SessionSummarySentinel',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Task/phase/files extraction over tmux output; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -575,7 +654,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'telegram-stall-confirm',
     component: 'TelegramAdapter',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Stall-confirm alert-suppression judgment over session output (Telegram arm); enrollment queued in the ACT-1193 retrofit backlog.',
@@ -583,7 +662,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'resume-uuid-validate',
     component: 'ResumeValidator',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Resume-UUID-vs-topic match verdict over session/resume state; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -591,7 +670,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'usher-topic-route',
     component: 'Usher',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Per-turn topic routing over an inbound user turn; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -599,7 +678,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'topic-intent-extract',
     component: 'TopicIntentExtractor',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Topic-intent extraction from a user turn; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -607,7 +686,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'pre-compaction-flush',
     component: 'PreCompactionFlush',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Durable-fact extraction over a transcript before compaction; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -615,7 +694,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'tree-synthesize',
     component: 'TreeSynthesis',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Knowledge-fragment synthesis into an answer; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -623,7 +702,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'llm-conflict-resolve',
     component: 'LLMConflictResolver',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Divergent multi-machine state resolution over untrusted peer data; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -631,7 +710,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'open-conversation-brief',
     component: 'openConversationBrief',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'A2A conversation-brief authoring over peer content; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -639,7 +718,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'a2a-checkin-summarize',
     component: 'a2a-checkin',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'A2A check-in thread summarization over peer-authored threads; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -647,7 +726,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'correction-distill',
     component: 'correction-learning',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Recurring-correction distillation into a durable preference; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
@@ -655,7 +734,7 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
   {
     decisionPoint: 'mentor-stage-b-classify',
     component: 'mentor-stage-b',
-    status: 'pending:ACT-1193',
+    status: 'pending:backlog:decision-quality-enrolment',
     contentClass: 'content-bearing',
     reason:
       'Mentor-signal classification over mentee output; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -123,7 +123,7 @@ import { decorateWithRopeCondition } from './poolRopeCondition.js';
 import { runDecisionGradingPass } from '../core/decisionGradingPass.js';
 import { annotateDecisionOutcome, decisionQualityRecordingLive, getDecisionAnnotationRejectionCounters } from '../core/DecisionQualityRecorderImpl.js';
 import { annotateCompletionRealcheck } from '../core/AutonomousRealCheckAnnotator.js';
-import { DP_COMPLETION_EVALUATE, DP_MESSAGING_TONE_GATE, PROVENANCE_COVERAGE, findWiredWithoutGraders } from '../data/provenanceCoverage.js';
+import { DP_COMPLETION_EVALUATE, DP_MESSAGING_TONE_GATE, PROVENANCE_COVERAGE, backlogTrackerExists, findWiredWithoutGraders } from '../data/provenanceCoverage.js';
 import { RemoteCloseAudit } from '../core/RemoteCloseAudit.js';
 import { RemoteAckStore } from '../core/RemoteAckStore.js';
 import { FailureLedger } from '../monitoring/FailureLedger.js';
@@ -1901,10 +1901,75 @@ export function parseActOrdinal(id: string): number | null {
  */
 export type PendingTrackerVerdict = 'alive' | 'dead' | 'unverifiable';
 
+/**
+ * A pending tracker reference, typed by KIND.
+ *
+ * WHY A KIND EXISTS (census-tracker-ref-kinds): `ACT-1193` was never a *broken*
+ * id — it is the wrong KIND of id for the job. An evolution-action id is a
+ * MACHINE-LOCAL bookkeeping handle, and `PROVENANCE_COVERAGE` is a shipped
+ * source constant that is byte-identical on every install. A per-machine handle
+ * written into a fleet-wide constant can only resolve on the one machine that
+ * minted it, so the debt check is structurally incapable of answering anywhere
+ * else. The 2026-07-23 fix stopped that reading as a DELETION (`unverifiable`
+ * instead of `dead`), which was correct — but a check that can only ever answer
+ * "I don't know" is not yet doing its job.
+ *
+ * A `backlog:` ref resolves against BACKLOG_TRACKERS — a SHIPPED SOURCE
+ * CONSTANT, byte-identical on every install. That is the whole difference.
+ *
+ * REJECTED ALTERNATIVE, recorded because it is the intuitive one and it is
+ * wrong: anchoring to a spec DOCUMENT path (`spec:<slug>`). `docs/` is excluded
+ * from the published package (`.npmignore`; absent from package.json `files[]`),
+ * so a file-existence check resolves FALSE on every fleet install — turning 49
+ * `unverifiable` entries into 49 fleet-wide false DELETIONS. That is strictly
+ * worse than the status quo and re-runs the exact false alarm the 2026-07-23 fix
+ * removed. Caught by external cross-model review, 2026-07-25.
+ */
+export type TrackerRef =
+  | { kind: 'act'; id: string }
+  | { kind: 'backlog'; key: string }
+  | { kind: 'unknown' };
+
+/**
+ * Classify a tracker ref. Shape-only — resolution is the adjudicator's job.
+ *
+ * `backlog:<key>` names an entry in BACKLOG_TRACKERS. The key is charset-clamped
+ * to the same shape the ratchet enforces, so a malformed ref parses as `unknown`
+ * (and reads `dead`) rather than silently becoming a lookup miss.
+ */
+export function parseTrackerRef(ref: string): TrackerRef {
+  const s = (ref ?? '').trim();
+  if (/^ACT-\d+$/.test(s)) return { kind: 'act', id: s };
+  const m = /^backlog:([a-z0-9][a-z0-9-]*)$/.exec(s);
+  if (m) return { kind: 'backlog', key: m[1] };
+  return { kind: 'unknown' };
+}
+
 export function adjudicatePendingTracker(
   act: string,
-  liveActs: LiveEvolutionActs,
+  // NULLABLE on purpose: a machine with no evolution queue on disk can still
+  // adjudicate a `backlog:` ref (it needs no queue). Before this, the CALLSITE
+  // skipped adjudication entirely when the queue was missing, which would have
+  // made every fleet-stable ref silently uncounted on exactly the installs the
+  // fleet-stable kind exists to serve.
+  liveActs: LiveEvolutionActs | null,
 ): PendingTrackerVerdict {
+  const ref = parseTrackerRef(act);
+
+  if (ref.kind === 'backlog') {
+    // Pure lookup over a shipped constant: the same answer on every machine,
+    // with no filesystem and no packaging assumption. A missing key IS a real
+    // deletion — the registry ships with the code, so its absence is a fact
+    // everywhere at once rather than a local gap. `unverifiable` is therefore
+    // unreachable for this kind BY CONSTRUCTION, which is the point.
+    return backlogTrackerExists(ref.key) ? 'alive' : 'dead';
+  }
+
+  // ── ACT kind: unchanged behaviour ──────────────────────────────────────
+  // No queue readable ⇒ this machine cannot resolve a machine-local id. Report
+  // `unverifiable`, never `dead`: not-knowing must not be reported as deletion,
+  // which is the false alarm the 2026-07-23 fix removed.
+  if (liveActs === null) return 'unverifiable';
   if (liveActs.alive.has(act)) return 'alive';
   const ord = parseActOrdinal(act);
   if (ord !== null && ord > liveActs.highWater) return 'unverifiable';
@@ -16576,12 +16641,12 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       if (entry.status === 'wired') wired++;
       else if (entry.status.startsWith('pending:')) {
         pending++;
-        if (liveActs !== null) {
-          const act = entry.status.slice('pending:'.length);
-          const verdict = adjudicatePendingTracker(act, liveActs);
-          if (verdict === 'dead') pendingRefDead.push(`${entry.decisionPoint}:${act}`);
-          else if (verdict === 'unverifiable') pendingRefUnverifiable.push(`${entry.decisionPoint}:${act}`);
-        }
+        const act = entry.status.slice('pending:'.length);
+        // No liveActs guard here: the adjudicator handles a missing queue itself
+        // (ACT ⇒ unverifiable, backlog ⇒ resolved against the shipped registry).
+        const verdict = adjudicatePendingTracker(act, liveActs);
+        if (verdict === 'dead') pendingRefDead.push(`${entry.decisionPoint}:${act}`);
+        else if (verdict === 'unverifiable') pendingRefUnverifiable.push(`${entry.decisionPoint}:${act}`);
       } else if (entry.status.startsWith('exempt:')) exempt++;
     }
 

--- a/tests/e2e/decision-quality-alive.test.ts
+++ b/tests/e2e/decision-quality-alive.test.ts
@@ -85,6 +85,15 @@ describe('Decision-Quality E2E lifecycle (feature is alive)', () => {
     // genuinely-deleted one, never collapsed into one false "dead" list).
     expect(Array.isArray(res.body.censusDebt.pendingRefDead)).toBe(true);
     expect(Array.isArray(res.body.censusDebt.pendingRefUnverifiable)).toBe(true);
+    // census-tracker-ref-kinds: and on the REAL production init path both are
+    // EMPTY. This harness boots a fresh stateDir with no evolution queue — i.e.
+    // exactly a fleet install that never minted the old machine-local ACT id.
+    // Before the fleet-stable `backlog:` kind, that machine could not resolve a
+    // single pending tracker; the debt signal was permanently uninformative.
+    // If a future change reintroduces a machine-local or doc-path anchor, these
+    // two lines are what catch it — on the boot path, not in a unit mock.
+    expect(res.body.censusDebt.pendingRefUnverifiable, 'pending trackers must resolve on a fleet install').toEqual([]);
+    expect(res.body.censusDebt.pendingRefDead, 'no pending tracker should read as deleted').toEqual([]);
     expect(res.body.rejections).toEqual({ enumInvalid: 0, rungMismatch: 0, ownerMismatch: 0, unknownDecisionPoint: 0 });
     // The three first-customer WIRED points are present in the census surface.
     const wiredPoints = (res.body.points as Array<any>).map((p) => p.decisionPoint);

--- a/tests/integration/census-tracker-ref-kinds-routes.test.ts
+++ b/tests/integration/census-tracker-ref-kinds-routes.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tier 2 — GET /decision-quality reports census debt correctly for the
+ * fleet-stable tracker kind, through the REAL Express routes + authMiddleware.
+ *
+ * Spec: docs/specs/census-tracker-ref-kinds.md
+ *
+ * The claim under test is exactly the one in the spec's graduation criterion,
+ * and it is asserted on the case that matters: an install with NO evolution
+ * queue on disk — i.e. every machine that did not mint the old ACT id.
+ * Before this change that machine reported all 49 as unverifiable (and, with
+ * the queue file absent, adjudicated nothing at all).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import request from 'supertest';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { authMiddleware } from '../../src/server/middleware.js';
+import { FeatureMetricsLedger } from '../../src/monitoring/FeatureMetricsLedger.js';
+import { PROVENANCE_COVERAGE } from '../../src/data/provenanceCoverage.js';
+
+const AUTH = 'test-census-tracker-refs';
+
+let tmpDir: string | null = null;
+let ledger: FeatureMetricsLedger | null = null;
+
+afterEach(() => {
+  try {
+    ledger?.close?.();
+  } catch {
+    /* ledger already closed — nothing to reclaim */
+  }
+  ledger = null;
+  if (tmpDir && fs.existsSync(tmpDir)) {
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true, force: true,
+      operation: 'tests/integration/census-tracker-ref-kinds-routes.test.ts',
+    });
+  }
+  tmpDir = null;
+});
+
+function freshStateDir(): string {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'census-refs-'));
+  return tmpDir;
+}
+
+/** Write a real evolution action-queue.json, the machine-local case. */
+function writeQueue(stateDir: string, actions: Array<{ id: string; status?: string }>): void {
+  const dir = path.join(stateDir, 'state', 'evolution');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'action-queue.json'),
+    JSON.stringify({ actions: actions.map((a) => ({ status: 'pending', ...a })) }),
+  );
+}
+
+function appFor(stateDir: string): express.Express {
+  ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
+  const ctx = {
+    config: {
+      projectName: 'test',
+      projectDir: '/tmp',
+      stateDir,
+      port: 0,
+      authToken: AUTH,
+      developmentAgent: true,
+      provenance: { uniformSeam: { dryRun: false } },
+      sessions: {} as any,
+      scheduler: {} as any,
+    } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    featureMetricsLedger: ledger,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+
+  const app = express();
+  app.use(express.json());
+  app.use(authMiddleware(() => AUTH, 'test'));
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+const PENDING_TOTAL = PROVENANCE_COVERAGE.filter((e) => e.status.startsWith('pending:')).length;
+
+describe('GET /decision-quality — census debt for fleet-stable tracker refs', () => {
+  it('reports ZERO unverifiable on an install with no evolution queue (the fleet case)', async () => {
+    const stateDir = freshStateDir(); // deliberately no action-queue.json
+    const res = await request(appFor(stateDir))
+      .get('/decision-quality?sinceHours=24')
+      .set('Authorization', `Bearer ${AUTH}`);
+
+    expect(res.status).toBe(200);
+    const debt = res.body.censusDebt;
+    expect(debt, 'censusDebt must be present').toBeTruthy();
+
+    // The whole claim of this change, on the machine it was broken for.
+    // Both surface as ARRAYS of "<decisionPoint>:<ref>" — the emptiness IS the claim.
+    expect(debt.pendingRefUnverifiable, JSON.stringify(debt.pendingRefUnverifiable)).toEqual([]);
+    expect(debt.pendingRefDead, JSON.stringify(debt.pendingRefDead)).toEqual([]);
+
+    // And the backlog itself did NOT shrink — the count is honest, not gamed.
+    expect(debt.pending).toBe(PENDING_TOTAL);
+  });
+
+  it('reports the same ZERO with a populated queue that has never seen ACT-1193', async () => {
+    // A peer machine whose own queue is real but low-numbered. Under the old
+    // ref this reported 49 unverifiable; the verdict must not depend on it.
+    const stateDir = freshStateDir();
+    writeQueue(stateDir, [{ id: 'ACT-1' }, { id: 'ACT-2' }, { id: 'ACT-3' }]);
+
+    const res = await request(appFor(stateDir))
+      .get('/decision-quality?sinceHours=24')
+      .set('Authorization', `Bearer ${AUTH}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.censusDebt.pendingRefUnverifiable).toEqual([]);
+    expect(res.body.censusDebt.pendingRefDead).toEqual([]);
+    expect(res.body.censusDebt.pending).toBe(PENDING_TOTAL);
+  });
+
+  it('the debt block still answers the other census questions (no collateral change)', async () => {
+    const stateDir = freshStateDir();
+    const res = await request(appFor(stateDir))
+      .get('/decision-quality?sinceHours=24')
+      .set('Authorization', `Bearer ${AUTH}`);
+
+    expect(res.status).toBe(200);
+    const debt = res.body.censusDebt;
+    expect(typeof debt.wired).toBe('number');
+    expect(typeof debt.exempt).toBe('number');
+    expect(debt.wired).toBeGreaterThan(0);
+    expect(debt.wired + debt.pending + debt.exempt).toBe(PROVENANCE_COVERAGE.length);
+  });
+
+  it('still requires Bearer auth (the census is not public)', async () => {
+    const stateDir = freshStateDir();
+    const res = await request(appFor(stateDir)).get('/decision-quality');
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/integration/decision-quality-act-tracker-routes.test.ts
+++ b/tests/integration/decision-quality-act-tracker-routes.test.ts
@@ -1,0 +1,162 @@
+/**
+ * §5.6 census debt — ACT-kind pending-tracker adjudication through the REAL route
+ * (the 2026-07-23 false-alarm fix's route-level guard).
+ *
+ * WHY THIS FILE EXISTS SEPARATELY (census-tracker-ref-kinds, 2026-07-25).
+ * These assertions used to live in decision-quality-routes.test.ts and drove the
+ * ACT semantics through whatever `PROVENANCE_COVERAGE` happened to contain — at
+ * the time, 49 entries all citing `ACT-1193`. That coupling was incidental, and
+ * repointing those entries to the fleet-stable `backlog:` kind broke three of
+ * them and — worse — made two others pass VACUOUSLY, asserting empty lists that
+ * nothing could populate any more.
+ *
+ * A test whose subject can silently evaporate is not guarding anything. So the
+ * census is now INJECTED here: the ACT semantics are exercised against a
+ * synthetic ACT-ref entry that cannot drift when the real backlog is repointed
+ * or drained. The guarantee is preserved permanently rather than accidentally.
+ *
+ * The module mock is file-scoped, which is exactly why this is its own file —
+ * the sibling suite must keep reading the real census.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import request from 'supertest';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const ACT_REF = 'ACT-1193';
+
+// One synthetic pending entry carrying an ACT ref, plus one wired entry so the
+// debt block is shaped like a real census. Everything else is irrelevant here.
+vi.mock('../../src/data/provenanceCoverage.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/data/provenanceCoverage.js')>();
+  return {
+    ...actual,
+    PROVENANCE_COVERAGE: [
+      {
+        decisionPoint: 'synthetic-act-point',
+        component: 'SyntheticActComponent',
+        category: 'gate',
+        status: `pending:${ACT_REF}`,
+        reason:
+          'Synthetic fixture pinning the ACT-kind adjudication path through the real route.',
+      },
+      ...actual.PROVENANCE_COVERAGE.filter((e) => e.status === 'wired').slice(0, 1),
+    ],
+  };
+});
+
+const { createRoutes } = await import('../../src/server/routes.js');
+const { authMiddleware } = await import('../../src/server/middleware.js');
+const { FeatureMetricsLedger } = await import('../../src/monitoring/FeatureMetricsLedger.js');
+
+const AUTH = 'test-act-tracker';
+let tmpDir: string | null = null;
+let ledger: InstanceType<typeof FeatureMetricsLedger> | null = null;
+
+afterEach(() => {
+  try {
+    ledger?.close?.();
+  } catch {
+    /* already closed — nothing to reclaim */
+  }
+  ledger = null;
+  if (tmpDir && fs.existsSync(tmpDir)) {
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/integration/decision-quality-act-tracker-routes.test.ts',
+    });
+  }
+  tmpDir = null;
+});
+
+function writeQueue(actions: Array<{ id: string; status: string }>): void {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dq-act-'));
+  const dir = path.join(tmpDir, 'state', 'evolution');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'action-queue.json'), JSON.stringify({ actions }));
+}
+
+async function censusDebt(): Promise<Record<string, any>> {
+  ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
+  const ctx = {
+    config: {
+      projectName: 'test', projectDir: '/tmp', stateDir: tmpDir ?? '/tmp/.instar', port: 0,
+      authToken: AUTH, developmentAgent: true,
+      provenance: { uniformSeam: { dryRun: false } },
+      sessions: {} as any, scheduler: {} as any,
+    } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    featureMetricsLedger: ledger,
+    startTime: new Date(),
+  } as any;
+
+  const app = express();
+  app.use(express.json());
+  app.use(authMiddleware(() => AUTH, 'test'));
+  app.use('/', createRoutes(ctx));
+
+  const res = await request(app).get('/decision-quality').set('Authorization', `Bearer ${AUTH}`);
+  expect(res.status).toBe(200);
+  return res.body.censusDebt;
+}
+
+describe('GET /decision-quality censusDebt — ACT-kind adjudication (injected census)', () => {
+  it('the fixture is real — exactly one pending ACT entry is under test', async () => {
+    // Guards the guard: if the mock ever stops injecting, every assertion below
+    // would go vacuously green. This is the check that makes that impossible.
+    writeQueue([{ id: 'ACT-1119', status: 'pending' }]);
+    const debt = await censusDebt();
+    expect(debt.pending).toBe(1);
+  });
+
+  it("a tracker ABOVE this machine's high-water reads unverifiable, never dead (the peer-minted case)", async () => {
+    // High-water 1119 < 1193 ⇒ this machine never minted that far: minted elsewhere.
+    writeQueue([{ id: 'ACT-1119', status: 'pending' }, { id: 'ACT-0004', status: 'completed' }]);
+    const debt = await censusDebt();
+    expect(debt.pendingRefDead).toEqual([]);
+    expect(debt.pendingRefUnverifiable.length).toBe(debt.pending);
+    expect(debt.pendingRefUnverifiable[0]).toContain(ACT_REF);
+  });
+
+  it('a tracker WITHIN high-water range but absent still reads dead (the genuine-deletion signal survives)', async () => {
+    // High-water 1211 > 1193 and 1193 is absent ⇒ genuinely deleted here.
+    writeQueue([{ id: 'ACT-1211', status: 'pending' }]);
+    const debt = await censusDebt();
+    expect(debt.pendingRefUnverifiable).toEqual([]);
+    expect(debt.pendingRefDead.length).toBe(debt.pending);
+    expect(debt.pendingRefDead[0]).toContain(ACT_REF);
+  });
+
+  it('a tracker that is alive locally is flagged by neither list', async () => {
+    writeQueue([{ id: ACT_REF, status: 'pending' }, { id: 'ACT-1211', status: 'completed' }]);
+    const debt = await censusDebt();
+    expect(debt.pending).toBe(1); // non-vacuous: there IS an entry that could have been flagged
+    expect(debt.pendingRefDead).toEqual([]);
+    expect(debt.pendingRefUnverifiable).toEqual([]);
+  });
+
+  it('a TERMINAL tracker within range reads dead (completed ≠ alive), and high-water still counts it', async () => {
+    writeQueue([{ id: ACT_REF, status: 'completed' }]);
+    const debt = await censusDebt();
+    // high-water is 1193 (terminal rows count toward high-water), 1193 is NOT > 1193 ⇒ dead.
+    expect(debt.pendingRefUnverifiable).toEqual([]);
+    expect(debt.pendingRefDead.length).toBe(debt.pending);
+  });
+
+  it('an absent queue reads unverifiable, never dead (a fresh agent is never false-flagged)', async () => {
+    // Behaviour CHANGE, deliberate: the route used to skip adjudication entirely
+    // when no queue existed, so both lists were empty. The null case now lives in
+    // the adjudicator, and for a machine-local ACT ref the honest answer to "is
+    // this alive?" with no queue to consult is `unverifiable` — never `dead`.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dq-act-noqueue-'));
+    const debt = await censusDebt();
+    expect(debt.pending).toBe(1);
+    expect(debt.pendingRefDead).toEqual([]);
+    expect(debt.pendingRefUnverifiable.length).toBe(1);
+  });
+});

--- a/tests/integration/decision-quality-routes.test.ts
+++ b/tests/integration/decision-quality-routes.test.ts
@@ -178,19 +178,17 @@ describe('GET /decision-quality (integration)', () => {
 });
 
 /**
- * §5.6 census debt — the pending-tracker adjudication (2026-07-23 false-alarm fix).
+ * §5.6 census debt — pending-tracker adjudication over the REAL census.
  *
- * PROVENANCE_COVERAGE declares its `pending:ACT-NNNN` trackers as SHIPPED SOURCE
- * CONSTANTS (identical on every install) but they are validated against the
- * MACHINE-LOCAL, unreplicated evolution action queue. A machine that never minted
- * an id that high has not DELETED the tracker — it has simply never seen it, and
- * reporting that as a dead tracker is a false alarm by construction (measured:
- * ACT-1193 pending on one machine at high-water 1211, absent on its peer at
- * high-water 1119 ⇒ the peer flagged all 49 entries).
+ * The real census now carries the fleet-stable `backlog:` kind, so this block
+ * asserts THAT kind against the live constant. The ACT-kind semantics from the
+ * 2026-07-23 false-alarm fix moved to
+ * tests/integration/decision-quality-act-tracker-routes.test.ts, where the
+ * census is INJECTED — those tests used to ride on the real census happening to
+ * cite ACT-1193, which made three of them break and two pass VACUOUSLY the
+ * moment the entries were repointed (census-tracker-ref-kinds, 2026-07-25).
  */
 describe('GET /decision-quality censusDebt — pending-tracker adjudication', () => {
-  const COVERAGE_TRACKER = 'ACT-1193'; // the id PROVENANCE_COVERAGE's pending entries cite
-
   function writeQueue(actions: Array<{ id: string; status: string }>): void {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dq-census-'));
     const dir = path.join(tmpDir, 'state', 'evolution');
@@ -206,42 +204,34 @@ describe('GET /decision-quality censusDebt — pending-tracker adjudication', ()
     return res.body.censusDebt;
   }
 
-  it('a tracker ABOVE this machine\'s high-water reads unverifiable, never dead (the peer-minted case)', async () => {
-    // High-water 1119 < 1193 ⇒ this machine never minted that far: minted elsewhere.
-    writeQueue([{ id: 'ACT-1119', status: 'pending' }, { id: 'ACT-0004', status: 'completed' }]);
+  it('the backlog is non-empty — every assertion below has a real subject', async () => {
+    // Guards against the vacuity that broke this block's predecessor: if the
+    // pending set ever empties, "no flags" would become trivially true.
+    writeQueue([{ id: 'ACT-1119', status: 'pending' }]);
     const debt = await censusDebt();
-    expect(debt.pendingRefDead).toEqual([]);
-    expect(debt.pendingRefUnverifiable.length).toBe(debt.pending);
-    expect(debt.pendingRefUnverifiable[0]).toContain(COVERAGE_TRACKER);
+    expect(debt.pending).toBeGreaterThan(0);
   });
 
-  it('a tracker WITHIN high-water range but absent still reads dead (the genuine-deletion signal survives)', async () => {
-    // High-water 1211 > 1193 and 1193 is absent ⇒ genuinely deleted here.
-    writeQueue([{ id: 'ACT-1211', status: 'pending' }]);
-    const debt = await censusDebt();
-    expect(debt.pendingRefUnverifiable).toEqual([]);
-    expect(debt.pendingRefDead.length).toBe(debt.pending);
-    expect(debt.pendingRefDead[0]).toContain(COVERAGE_TRACKER);
+  it('a fleet-stable ref resolves regardless of what the local action queue holds', async () => {
+    // The defect this replaced: the verdict depended on a MACHINE-LOCAL queue.
+    // Three very different queues, one answer.
+    for (const queue of [
+      [{ id: 'ACT-1119', status: 'pending' }],
+      [{ id: 'ACT-1211', status: 'pending' }],
+      [{ id: 'ACT-0001', status: 'completed' }],
+    ]) {
+      writeQueue(queue);
+      const debt = await censusDebt();
+      expect(debt.pendingRefDead, JSON.stringify(debt.pendingRefDead)).toEqual([]);
+      expect(debt.pendingRefUnverifiable, JSON.stringify(debt.pendingRefUnverifiable)).toEqual([]);
+      expect(debt.pending).toBeGreaterThan(0);
+    }
   });
 
-  it('a tracker that is alive locally is flagged by neither list', async () => {
-    writeQueue([{ id: COVERAGE_TRACKER, status: 'pending' }, { id: 'ACT-1211', status: 'completed' }]);
-    const debt = await censusDebt();
-    expect(debt.pendingRefDead).toEqual([]);
-    expect(debt.pendingRefUnverifiable).toEqual([]);
-  });
-
-  it('a TERMINAL tracker within range reads dead (completed ≠ alive), and high-water still counts it', async () => {
-    writeQueue([{ id: COVERAGE_TRACKER, status: 'completed' }]);
-    const debt = await censusDebt();
-    // high-water is 1193 (terminal rows count toward high-water), 1193 is NOT > 1193 ⇒ dead.
-    expect(debt.pendingRefUnverifiable).toEqual([]);
-    expect(debt.pendingRefDead.length).toBe(debt.pending);
-  });
-
-  it('an absent queue flags neither list (unchanged fail-safe — a fresh agent is never false-flagged)', async () => {
+  it('an ABSENT queue resolves identically — the fleet install, which could not answer before', async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dq-census-noqueue-'));
     const debt = await censusDebt();
+    expect(debt.pending).toBeGreaterThan(0);
     expect(debt.pendingRefDead).toEqual([]);
     expect(debt.pendingRefUnverifiable).toEqual([]);
   });

--- a/tests/unit/builtin-manifest.test.ts
+++ b/tests/unit/builtin-manifest.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../..');
@@ -56,15 +58,41 @@ describe('INSTAR_BUILTIN_MANIFEST', () => {
   });
 
   it('is up-to-date with current source', () => {
-    // Regenerate and compare
-    const before = fs.readFileSync(MANIFEST_PATH, 'utf-8');
-    execSync('node scripts/generate-builtin-manifest.cjs', { cwd: ROOT });
-    const after = fs.readFileSync(MANIFEST_PATH, 'utf-8');
+    // Generate to a TEMP path and diff against the committed file.
+    //
+    // This used to regenerate over MANIFEST_PATH itself and compare the file
+    // before/after — a verifier that mutates the artifact it verifies. Under the
+    // parallel suite it raced package-completeness.test.ts, whose full `npx tsc`
+    // build regenerates the same tracked file, so the comparison could read a
+    // half-written or foreign manifest and go red on a perfectly good tree.
+    // Generating elsewhere makes the check read-only and order-independent.
+    const tmpOut = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'builtin-manifest-check-')),
+      'builtin-manifest.json',
+    );
+    try {
+      execSync('node scripts/generate-builtin-manifest.cjs', {
+        cwd: ROOT,
+        env: { ...process.env, INSTAR_BUILTIN_MANIFEST_OUT: tmpOut },
+        stdio: 'pipe',
+      });
 
-    // Strip generatedAt timestamp for comparison (changes every run)
-    const normalize = (s: string) => s.replace(/"generatedAt":\s*"[^"]+"/, '"generatedAt": "NORMALIZED"');
+      const committed = fs.readFileSync(MANIFEST_PATH, 'utf-8');
+      const regenerated = fs.readFileSync(tmpOut, 'utf-8');
 
-    expect(normalize(after)).toBe(normalize(before));
+      // Strip generatedAt timestamp for comparison (changes every run)
+      const normalize = (s: string) => s.replace(/"generatedAt":\s*"[^"]+"/, '"generatedAt": "NORMALIZED"');
+
+      expect(
+        normalize(regenerated),
+        'src/data/builtin-manifest.json is stale — run `node scripts/generate-builtin-manifest.cjs` and commit the result',
+      ).toBe(normalize(committed));
+    } finally {
+      SafeFsExecutor.safeRmSync(path.dirname(tmpOut), {
+        recursive: true, force: true,
+        operation: 'tests/unit/builtin-manifest.test.ts',
+      });
+    }
   });
 
   it('covers all 14 built-in hooks', () => {

--- a/tests/unit/census-tracker-ref-kinds.test.ts
+++ b/tests/unit/census-tracker-ref-kinds.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tier 1 — census tracker refs are typed by KIND, and the fleet-stable kind
+ * resolves against a SHIPPED SOURCE CONSTANT.
+ *
+ * Spec: docs/specs/census-tracker-ref-kinds.md
+ *
+ * The defect: all 49 pending census entries carried `pending:ACT-1193`, an
+ * evolution-action id. That id is MACHINE-LOCAL; PROVENANCE_COVERAGE is a
+ * shipped constant identical on every install. So the debt check could only
+ * ever answer "I don't know" anywhere but the one machine that minted it.
+ *
+ * THE TRAP THIS FILE GUARDS (the reason the design changed mid-flight): the
+ * intuitive fix — anchor to a spec DOCUMENT path and check the file exists —
+ * is WORSE than the status quo, because `docs/` is excluded from the published
+ * package. It would have converted 49 honest `unverifiable` into 49 fleet-wide
+ * false `dead`. `packaging invariant` below is the test that makes that
+ * regression impossible to reintroduce silently.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseTrackerRef,
+  adjudicatePendingTracker,
+  type LiveEvolutionActs,
+} from '../../src/server/routes.js';
+import {
+  BACKLOG_TRACKERS,
+  backlogTrackerExists,
+  PROVENANCE_COVERAGE,
+} from '../../src/data/provenanceCoverage.js';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const acts = (alive: string[], highWater: number): LiveEvolutionActs => ({
+  alive: new Set(alive),
+  highWater,
+});
+
+describe('parseTrackerRef — kinds, and only these kinds', () => {
+  it('classifies a machine-local evolution-action id as the act kind', () => {
+    expect(parseTrackerRef('ACT-1193')).toEqual({ kind: 'act', id: 'ACT-1193' });
+    expect(parseTrackerRef('ACT-1')).toEqual({ kind: 'act', id: 'ACT-1' });
+  });
+
+  it('classifies a fleet-stable registry key as the backlog kind', () => {
+    expect(parseTrackerRef('backlog:decision-quality-enrolment')).toEqual({
+      kind: 'backlog',
+      key: 'decision-quality-enrolment',
+    });
+  });
+
+  it('tolerates surrounding whitespace without inventing a kind', () => {
+    expect(parseTrackerRef('  ACT-7  ')).toEqual({ kind: 'act', id: 'ACT-7' });
+    expect(parseTrackerRef(' backlog:a ')).toEqual({ kind: 'backlog', key: 'a' });
+  });
+
+  it('refuses garbage as unknown rather than guessing — a typo must stay visible', () => {
+    for (const bad of [
+      '',
+      '   ',
+      'ACT-',
+      'ACT-abc',
+      'act-1193', // case matters: the queue mints uppercase
+      'backlog:',
+      'backlog:Decision-Quality', // uppercase is not the key charset
+      'backlog:-leading-dash',
+      'backlog:has_underscore',
+      'backlog:a/b', // no separators — a key is not a path
+      'backlog:../escape',
+      'spec:llm-decision-quality-meter#5.6', // the REJECTED design; not a kind
+      'PR-1618',
+      'https://example.invalid/x',
+    ]) {
+      expect(parseTrackerRef(bad), `'${bad}' must not parse to a known kind`).toEqual({
+        kind: 'unknown',
+      });
+    }
+  });
+
+  it('is total over hostile input (null/undefined reach it as any in JS callers)', () => {
+    expect(parseTrackerRef(undefined as unknown as string)).toEqual({ kind: 'unknown' });
+    expect(parseTrackerRef(null as unknown as string)).toEqual({ kind: 'unknown' });
+  });
+});
+
+describe('adjudicatePendingTracker — backlog kind (the fleet-stable path)', () => {
+  it('a registered key is ALIVE', () => {
+    expect(adjudicatePendingTracker('backlog:decision-quality-enrolment', acts([], 0))).toBe('alive');
+  });
+
+  it('a key absent from the registry is DEAD — a removed tracker is a real deletion', () => {
+    expect(adjudicatePendingTracker('backlog:no-such-backlog', acts([], 0))).toBe('dead');
+  });
+
+  it('resolves identically with NO evolution queue at all — the whole point', () => {
+    // This is the fleet install: no action-queue.json on disk. The old callsite
+    // skipped adjudication entirely in this case; a fleet-stable ref must not
+    // depend on machine-local state to be answerable.
+    expect(adjudicatePendingTracker('backlog:decision-quality-enrolment', null)).toBe('alive');
+    expect(adjudicatePendingTracker('backlog:no-such-backlog', null)).toBe('dead');
+  });
+
+  it('NEVER answers unverifiable — unreachable for this kind by construction', () => {
+    for (const ref of ['backlog:decision-quality-enrolment', 'backlog:nope', 'backlog:x']) {
+      for (const live of [acts([], 0), acts(['ACT-1'], 99), null]) {
+        expect(adjudicatePendingTracker(ref, live)).not.toBe('unverifiable');
+      }
+    }
+  });
+
+  it('ignores the local evolution queue entirely (no cross-talk between kinds)', () => {
+    // A machine whose queue happens to contain a similarly-named entry must not
+    // change the verdict: the registry is the only authority for this kind.
+    const noisy = acts(['backlog:decision-quality-enrolment', 'ACT-1193'], 9999);
+    expect(adjudicatePendingTracker('backlog:no-such-backlog', noisy)).toBe('dead');
+  });
+});
+
+describe('adjudicatePendingTracker — act kind stays byte-for-byte as it was', () => {
+  it('a live id is ALIVE', () => {
+    expect(adjudicatePendingTracker('ACT-500', acts(['ACT-500'], 900))).toBe('alive');
+  });
+
+  it('an id below the high-water mark and not alive is DEAD (a real local deletion)', () => {
+    expect(adjudicatePendingTracker('ACT-500', acts(['ACT-501'], 900))).toBe('dead');
+  });
+
+  it('an id ABOVE the high-water mark is UNVERIFIABLE — minted on a peer, not deleted', () => {
+    expect(adjudicatePendingTracker('ACT-1193', acts(['ACT-1'], 900))).toBe('unverifiable');
+  });
+
+  it('an unreadable queue is UNVERIFIABLE, never dead', () => {
+    expect(adjudicatePendingTracker('ACT-500', null)).toBe('unverifiable');
+  });
+
+  it('a malformed ref is DEAD — it must surface, not hide in the unverifiable bucket', () => {
+    expect(adjudicatePendingTracker('nonsense', acts([], 0))).toBe('dead');
+    expect(adjudicatePendingTracker('spec:some-doc', acts([], 0))).toBe('dead');
+  });
+});
+
+describe('the packaging invariant — why the anchor is a constant and not a doc', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')) as {
+    files?: string[];
+  };
+
+  it('src/data IS published, so BACKLOG_TRACKERS reaches every install', () => {
+    // The registry lives in src/data/provenanceCoverage.ts and compiles to dist.
+    const published = pkg.files ?? [];
+    expect(
+      published.some((f) => f === 'dist' || f === 'src/data' || f.startsWith('src/data')),
+      'BACKLOG_TRACKERS must ship — otherwise a backlog ref cannot resolve on a fleet install',
+    ).toBe(true);
+  });
+
+  it('docs/ is NOT published — a doc-path anchor would be false-dead fleet-wide', () => {
+    // This is the finding that inverted the design (external review, 2026-07-25).
+    // If someone later adds docs/ to files[], THIS test is where the reasoning
+    // is recorded — re-read the spec before treating doc paths as resolvable.
+    const published = pkg.files ?? [];
+    expect(
+      published.some((f) => f === 'docs' || f.startsWith('docs/')),
+      'docs/ is excluded from the package; an existence check against a doc path resolves false on every fleet install',
+    ).toBe(false);
+  });
+
+  it('no census entry anchors to a doc path', () => {
+    for (const e of PROVENANCE_COVERAGE) {
+      if (!e.status.startsWith('pending:')) continue;
+      const ref = e.status.slice('pending:'.length);
+      expect(ref.startsWith('spec:'), `${e.decisionPoint}: doc-path anchors do not ship`).toBe(false);
+    }
+  });
+});
+
+describe('registry integrity', () => {
+  it('every key is self-consistent and charset-clean', () => {
+    for (const [k, v] of Object.entries(BACKLOG_TRACKERS)) {
+      expect(k).toMatch(/^[a-z0-9][a-z0-9-]*$/);
+      expect(v.key, 'the record key must match its map key').toBe(k);
+      expect(v.owner.length, 'owner must point a reader somewhere real').toBeGreaterThan(10);
+      expect(v.summary.length, 'summary must argue what the backlog is').toBeGreaterThanOrEqual(40);
+    }
+  });
+
+  it('backlogTrackerExists answers both sides, and is not fooled by prototype keys', () => {
+    expect(backlogTrackerExists('decision-quality-enrolment')).toBe(true);
+    expect(backlogTrackerExists('nope')).toBe(false);
+    // A plain `key in obj` / `obj[key]` check would answer true here.
+    expect(backlogTrackerExists('constructor')).toBe(false);
+    expect(backlogTrackerExists('toString')).toBe(false);
+    expect(backlogTrackerExists('__proto__')).toBe(false);
+  });
+
+  it('every record declares a CLOSURE CONDITION — "alive" must not decay into "still listed"', () => {
+    // External review, 2026-07-25: a registry key nobody ever retires makes the
+    // debt check pass forever while the work rots. The closure condition is what
+    // makes a stale key visible to a human reading the registry.
+    for (const [k, v] of Object.entries(BACKLOG_TRACKERS)) {
+      expect(v.closureCondition.length, `${k}: must state when this key is deleted`).toBeGreaterThanOrEqual(40);
+    }
+  });
+
+  it('has NO ORPHANED keys — every registered backlog is actually referenced', () => {
+    // The other direction of the same rot: a key whose last reference was wired
+    // away but which was never deleted. Its own closureCondition says the key
+    // goes when the last reference does; this is that rule, enforced.
+    const referenced = new Set(
+      PROVENANCE_COVERAGE.filter((e) => e.status.startsWith('pending:'))
+        .map((e) => e.status.slice('pending:'.length))
+        .filter((r) => r.startsWith('backlog:'))
+        .map((r) => r.slice('backlog:'.length)),
+    );
+    for (const k of Object.keys(BACKLOG_TRACKERS)) {
+      expect(
+        referenced.has(k),
+        `backlog key '${k}' is registered but referenced by no pending entry — delete it (its closure condition says so) or point the work at it`,
+      ).toBe(true);
+    }
+  });
+
+  it('the pending refs are exactly ONE deliberate key, not a spray of near-misses', () => {
+    // Aggregate counts can look healthy while refs drift apart (e.g. a typo'd
+    // second key that happens to be registered). Assert the distribution.
+    const dist = new Map<string, number>();
+    for (const e of PROVENANCE_COVERAGE) {
+      if (!e.status.startsWith('pending:')) continue;
+      const ref = e.status.slice('pending:'.length);
+      dist.set(ref, (dist.get(ref) ?? 0) + 1);
+    }
+    expect(
+      [...dist.keys()].sort(),
+      'the enrolment backlog is one body of work; a second ref here is either a real new backlog (register it deliberately) or a typo',
+    ).toEqual(['backlog:decision-quality-enrolment']);
+    expect(dist.get('backlog:decision-quality-enrolment')).toBe(
+      PROVENANCE_COVERAGE.filter((e) => e.status.startsWith('pending:')).length,
+    );
+  });
+
+  it('every pending census entry resolves against the registry RIGHT NOW', () => {
+    const pending = PROVENANCE_COVERAGE.filter((e) => e.status.startsWith('pending:'));
+    expect(pending.length, 'the backlog should not silently empty').toBeGreaterThan(0);
+    for (const e of pending) {
+      const verdict = adjudicatePendingTracker(e.status.slice('pending:'.length), null);
+      expect(verdict, `${e.decisionPoint}: pending ref must resolve on a queue-less install`).toBe(
+        'alive',
+      );
+    }
+  });
+});

--- a/tests/unit/provenance-coverage-ratchet.test.ts
+++ b/tests/unit/provenance-coverage-ratchet.test.ts
@@ -14,7 +14,7 @@
  *   3. PENDING + EXEMPT baselines are pinned SHRINK-ONLY, by IDENTITY
  *      (decisionPoint::component::ref) — re-pointing an entry to a different
  *      ACT, or re-classifying an exemption, is a reviewed baseline change.
- *   4. pending refs are format-valid (^ACT-\d+$); exemption taxonomy is CLOSED
+ *   4. pending refs are format-valid (^ACT-\d+$ | ^backlog:<key>$); exemption taxonomy is CLOSED
  *      (free text refused); pending/exempt reasons argue >= 40 chars.
  *   5. More than the seeded first-customer enrollment requires the grading
  *      pass's per-point sub-budget FIRST (LES r6 — the trigger is structural).
@@ -32,6 +32,7 @@ import { fileURLToPath } from 'node:url';
 import { COMPONENT_CATEGORY } from '../../src/core/componentCategories.js';
 import {
   PROVENANCE_COVERAGE,
+  backlogTrackerExists,
   RULE_REGISTRY,
   SUBBUDGET_IMPLEMENTED,
   EVIDENCE_RUNGS,
@@ -75,56 +76,56 @@ const baseOf = (component: string): string => component.split('/')[0].replace(/^
 // re-pointing a pending entry to a different ACT changes the line = reviewed. ──
 
 const PENDING_BASELINE = [
-  // decisionPoint::component::ACT-ref
-  'a2a-checkin-summarize::a2a-checkin::ACT-1193',
-  'cartographer-summary-author::CartographerSweep::ACT-1193',
-  'coherence-review::CoherenceReviewer::ACT-1193',
-  'commitment-detect::CommitmentSentinel::ACT-1193',
-  'contextual-evaluate::ContextualEvaluator::ACT-1193',
-  'correction-distill::correction-learning::ACT-1193',
-  'cross-model-review::crossModelReviewer::ACT-1193',
-  'dashboard-insight::DashboardInsightEngine::ACT-1193',
-  'discovery-evaluate::DiscoveryEvaluator::ACT-1193',
-  'external-operation-gate::ExternalOperationGate::ACT-1193',
-  'hub-intent-classify::HubIntentClassifier::ACT-1193',
-  'input-classify::InputClassifier::ACT-1193',
-  'input-guard::InputGuard::ACT-1193',
-  'job-reflect::JobReflector::ACT-1193',
-  'llm-conflict-resolve::LLMConflictResolver::ACT-1193',
-  'llm-sanitize::LLMSanitizer::ACT-1193',
-  'mentor-stage-b-classify::mentor-stage-b::ACT-1193',
-  'message-sentinel-classify::MessageSentinel::ACT-1193',
-  'move-intent-classify::MoveIntentClassifier::ACT-1193',
-  'open-conversation-brief::openConversationBrief::ACT-1193',
-  'override-detect::OverrideDetector::ACT-1193',
-  'pipe-session-spawn::PipeSessionSpawner::ACT-1193',
-  'pre-compaction-flush::PreCompactionFlush::ACT-1193',
-  'presence-stall-judge::PresenceProxy::ACT-1193',
-  'profile-intent-classify::ProfileIntentClassifier::ACT-1193',
-  'project-drift-check::ProjectDriftChecker::ACT-1193',
-  'prompt-injection-detect::PromptGate::ACT-1193',
-  'relationship-extract::RelationshipManager::ACT-1193',
-  'resume-sanity-check::ResumeQueueDrainer::ACT-1193',
-  'resume-uuid-validate::ResumeValidator::ACT-1193',
-  'self-knowledge-extract::SelfKnowledgeTree::ACT-1193',
-  'session-activity-digest::SessionActivitySentinel::ACT-1193',
-  'session-summary-extract::SessionSummarySentinel::ACT-1193',
-  'slack-stall-confirm::SlackAdapter::ACT-1193',
-  'stall-triage-diagnosis::StallTriageNurse::ACT-1193',
-  'standards-conformance-review::StandardsConformanceReviewer::ACT-1193',
-  'standards-coverage-enrich::StandardsCoverageEnrichment::ACT-1193',
-  'task-classify::TaskClassifier::ACT-1193',
-  'telegram-stall-confirm::TelegramAdapter::ACT-1193',
-  'temporal-coherence-check::TemporalCoherenceChecker::ACT-1193',
-  'topic-intent-arc-check::TopicIntentArcCheck::ACT-1193',
-  'topic-intent-extract::TopicIntentExtractor::ACT-1193',
-  'topic-summarize::TopicSummarizer::ACT-1193',
-  'tree-synthesize::TreeSynthesis::ACT-1193',
-  'tree-triage::TreeTriage::ACT-1193',
-  'unjustified-stop-gate::UnjustifiedStopGate::ACT-1193',
-  'usher-topic-route::Usher::ACT-1193',
-  'warrants-reply-gate::WarrantsReplyGate::ACT-1193',
-  'watchdog-stuck-judge::SessionWatchdog::ACT-1193',
+  // decisionPoint::component::tracker-ref
+  'a2a-checkin-summarize::a2a-checkin::backlog:decision-quality-enrolment',
+  'cartographer-summary-author::CartographerSweep::backlog:decision-quality-enrolment',
+  'coherence-review::CoherenceReviewer::backlog:decision-quality-enrolment',
+  'commitment-detect::CommitmentSentinel::backlog:decision-quality-enrolment',
+  'contextual-evaluate::ContextualEvaluator::backlog:decision-quality-enrolment',
+  'correction-distill::correction-learning::backlog:decision-quality-enrolment',
+  'cross-model-review::crossModelReviewer::backlog:decision-quality-enrolment',
+  'dashboard-insight::DashboardInsightEngine::backlog:decision-quality-enrolment',
+  'discovery-evaluate::DiscoveryEvaluator::backlog:decision-quality-enrolment',
+  'external-operation-gate::ExternalOperationGate::backlog:decision-quality-enrolment',
+  'hub-intent-classify::HubIntentClassifier::backlog:decision-quality-enrolment',
+  'input-classify::InputClassifier::backlog:decision-quality-enrolment',
+  'input-guard::InputGuard::backlog:decision-quality-enrolment',
+  'job-reflect::JobReflector::backlog:decision-quality-enrolment',
+  'llm-conflict-resolve::LLMConflictResolver::backlog:decision-quality-enrolment',
+  'llm-sanitize::LLMSanitizer::backlog:decision-quality-enrolment',
+  'mentor-stage-b-classify::mentor-stage-b::backlog:decision-quality-enrolment',
+  'message-sentinel-classify::MessageSentinel::backlog:decision-quality-enrolment',
+  'move-intent-classify::MoveIntentClassifier::backlog:decision-quality-enrolment',
+  'open-conversation-brief::openConversationBrief::backlog:decision-quality-enrolment',
+  'override-detect::OverrideDetector::backlog:decision-quality-enrolment',
+  'pipe-session-spawn::PipeSessionSpawner::backlog:decision-quality-enrolment',
+  'pre-compaction-flush::PreCompactionFlush::backlog:decision-quality-enrolment',
+  'presence-stall-judge::PresenceProxy::backlog:decision-quality-enrolment',
+  'profile-intent-classify::ProfileIntentClassifier::backlog:decision-quality-enrolment',
+  'project-drift-check::ProjectDriftChecker::backlog:decision-quality-enrolment',
+  'prompt-injection-detect::PromptGate::backlog:decision-quality-enrolment',
+  'relationship-extract::RelationshipManager::backlog:decision-quality-enrolment',
+  'resume-sanity-check::ResumeQueueDrainer::backlog:decision-quality-enrolment',
+  'resume-uuid-validate::ResumeValidator::backlog:decision-quality-enrolment',
+  'self-knowledge-extract::SelfKnowledgeTree::backlog:decision-quality-enrolment',
+  'session-activity-digest::SessionActivitySentinel::backlog:decision-quality-enrolment',
+  'session-summary-extract::SessionSummarySentinel::backlog:decision-quality-enrolment',
+  'slack-stall-confirm::SlackAdapter::backlog:decision-quality-enrolment',
+  'stall-triage-diagnosis::StallTriageNurse::backlog:decision-quality-enrolment',
+  'standards-conformance-review::StandardsConformanceReviewer::backlog:decision-quality-enrolment',
+  'standards-coverage-enrich::StandardsCoverageEnrichment::backlog:decision-quality-enrolment',
+  'task-classify::TaskClassifier::backlog:decision-quality-enrolment',
+  'telegram-stall-confirm::TelegramAdapter::backlog:decision-quality-enrolment',
+  'temporal-coherence-check::TemporalCoherenceChecker::backlog:decision-quality-enrolment',
+  'topic-intent-arc-check::TopicIntentArcCheck::backlog:decision-quality-enrolment',
+  'topic-intent-extract::TopicIntentExtractor::backlog:decision-quality-enrolment',
+  'topic-summarize::TopicSummarizer::backlog:decision-quality-enrolment',
+  'tree-synthesize::TreeSynthesis::backlog:decision-quality-enrolment',
+  'tree-triage::TreeTriage::backlog:decision-quality-enrolment',
+  'unjustified-stop-gate::UnjustifiedStopGate::backlog:decision-quality-enrolment',
+  'usher-topic-route::Usher::backlog:decision-quality-enrolment',
+  'warrants-reply-gate::WarrantsReplyGate::backlog:decision-quality-enrolment',
+  'watchdog-stuck-judge::SessionWatchdog::backlog:decision-quality-enrolment',
 ].sort();
 
 const EXEMPT_BASELINE = [
@@ -244,10 +245,25 @@ describe('provenance-coverage census ratchet (declare-or-fail)', () => {
 });
 
 describe('pending — the two-layer check, CI static half (§5.6)', () => {
-  it('pending refs are format-valid (^ACT-\\d+$) and every pending entry argues a real reason (>= 40 chars)', () => {
+  it('pending refs are format-valid (^ACT-\\d+$ | ^backlog:<key>$) and every pending entry argues a real reason (>= 40 chars)', () => {
     for (const e of pendingEntries) {
       const ref = e.status.slice('pending:'.length);
-      expect(ref, `${e.decisionPoint}: pending ref '${ref}' must be a bare evolution-queue id (ACT-<n>)`).toMatch(/^ACT-\d+$/);
+      // Exactly TWO kinds — deliberately NOT "anything". Widening this to a
+      // permissive pattern would remove the guard that makes a typo visible,
+      // which is most of this ratchet's value.
+      expect(
+        ref,
+        `${e.decisionPoint}: pending ref '${ref}' must be a machine-local evolution-queue id (ACT-<n>) or a fleet-stable backlog key (backlog:<key>)`,
+      ).toMatch(/^(?:ACT-\d+|backlog:[a-z0-9][a-z0-9-]*)$/);
+      // A backlog ref must resolve NOW — a pending entry pointing at a key that
+      // is not in the shipped registry is the dangling reference this whole
+      // change exists to make impossible, and CI is where it should die.
+      if (ref.startsWith('backlog:')) {
+        expect(
+          backlogTrackerExists(ref.slice('backlog:'.length)),
+          `${e.decisionPoint}: backlog ref '${ref}' is not in BACKLOG_TRACKERS`,
+        ).toBe(true);
+      }
       expect(
         (e.reason ?? '').length,
         `${e.decisionPoint}: pending reason must be a real argument (>= 40 chars)`,
@@ -496,7 +512,7 @@ describe('lookup helpers (the contracts later phases import)', () => {
     expect(getVolumeClass(DP_COMPLETION_STOP_RATIONALE)).toBe('full');
     // A pending point is declared but NOT enrolled — the seam writes nothing,
     // and a forward-declared volume class must not valve anything.
-    expect(getCensusEntry('coherence-review')?.status).toBe('pending:ACT-1193');
+    expect(getCensusEntry('coherence-review')?.status).toBe('pending:backlog:decision-quality-enrolment');
     expect(isEnrolled('coherence-review')).toBe(false);
     expect(getVolumeClass('coherence-review')).toBeUndefined();
     // Unknown decision points: undefined/false, never a throw (the settlement

--- a/upgrades/next/census-tracker-ref-kinds.md
+++ b/upgrades/next/census-tracker-ref-kinds.md
@@ -1,0 +1,89 @@
+## What Changed
+
+The census-debt counter on `GET /decision-quality` can now actually answer the
+question it was built to ask, on every machine rather than one.
+
+Each of the 49 not-yet-enrolled decision points carries a tracker reference, and
+the counter asks "is that tracker still alive?" — so an abandoned backlog item
+can't rot unnoticed. All 49 pointed at an evolution-action id (`ACT-1193`), which
+is **machine-local**, while the census constant carrying it ships identically to
+every install. Anywhere but the machine that minted that id, the counter could
+only ever answer "can't verify" — reporting `pendingRefUnverifiable: 49`
+indefinitely.
+
+A 2026-07-23 fix had already stopped this reading as a *deletion* (splitting
+`unverifiable` from `dead`), which was correct. This is the other half: not
+false-alarming isn't the same as verifying.
+
+Tracker refs are now typed by **kind**:
+
+- `ACT-<n>` — a machine-local work item. Behaviour unchanged, including the
+  high-water guard that keeps a peer-minted id from reading as deleted.
+- `backlog:<key>` — fleet-stable, resolved against `BACKLOG_TRACKERS`, a shipped
+  source constant. Byte-identical on every install by construction: no
+  filesystem, no packaging assumption, no anchor that drifts when a heading is
+  renamed.
+
+The 49 entries move to `backlog:decision-quality-enrolment`.
+
+**A rejected design worth recording.** The first version anchored to a spec
+*document* path and checked the file existed. `docs/` is excluded from the
+published package, so that check would have resolved false on every fleet
+install — turning 49 honest "can't verify" entries into **49 false "deleted"**
+ones, strictly worse than doing nothing and a re-run of the very false alarm the
+July fix removed. External cross-model review caught it. A CI test now asserts
+the packaging facts directly against `package.json`, so the mistake can't return
+silently.
+
+Also fixed: the route previously skipped tracker adjudication entirely when no
+evolution queue existed on disk, which would have left every fleet-stable ref
+silently *uncounted* on exactly the installs the new kind serves. The null case
+moved into the adjudicator.
+
+Guardrails: the ratchet accepts exactly the two kinds and resolves every
+`backlog:` key at build time (a dangling ref fails CI, not production); every
+registry entry must declare a **closure condition** (what makes the key
+deletable) so "alive" can't decay into "still listed"; orphaned keys and the
+exact ref distribution are both pinned.
+
+## Evidence
+
+- Tier 1 — `tests/unit/census-tracker-ref-kinds.test.ts` (24 cases): both kinds
+  and a garbage corpus; every adjudicator branch including the no-queue install;
+  the packaging invariant read from `package.json`; prototype-key safety on the
+  registry lookup; closure conditions; no orphaned keys; exact ref distribution.
+- Tier 1 — `tests/unit/provenance-coverage-ratchet.test.ts`: format ratchet
+  extended to exactly two kinds, plus live registry resolution of every
+  `backlog:` ref.
+- Tier 2 — `tests/integration/census-tracker-ref-kinds-routes.test.ts`: real
+  Express routes + auth; empty `pendingRefUnverifiable` and `pendingRefDead`
+  with `pending` unchanged, on both a queue-less install and a populated queue
+  that never saw `ACT-1193`.
+- Tier 3 — `tests/e2e/decision-quality-alive.test.ts`: all three graduation
+  conditions asserted on the real `AgentServer` boot path.
+- Spec `docs/specs/census-tracker-ref-kinds.md` (converged, 2 rounds) and
+  `docs/specs/reports/census-tracker-ref-kinds-convergence.md`.
+
+## What to Tell Your User
+
+Nothing you'd notice day to day — this is instrumentation.
+
+If you ever look at the decision-quality health read, the pending-backlog line
+now says something real. It used to report all 49 items as "can't verify" on
+every machine but one, which is a warning light that can only ever shrug. Now,
+if one of those items genuinely loses its tracker, it will say so — on every
+machine, not just the one where the note happened to be written.
+
+The backlog itself hasn't shrunk, and the count deliberately still reads 49.
+Making the number smaller was the easy version and the wrong one; making the
+check able to answer is what this does.
+
+## Summary of New Capabilities
+
+- Census tracker references are typed by kind, with a fleet-stable kind resolved
+  against a shipped source constant instead of machine-local state.
+- The pending-backlog debt signal on `GET /decision-quality` is meaningful on
+  every install rather than on a single machine.
+- Build-time guarantees that a tracker reference cannot dangle, that a backlog
+  key must declare how it gets retired, and that registered keys can't be
+  orphaned.

--- a/upgrades/side-effects/census-tracker-ref-kinds.md
+++ b/upgrades/side-effects/census-tracker-ref-kinds.md
@@ -1,0 +1,167 @@
+# Side-effects review — census-tracker-ref-kinds
+
+**Change:** pending census tracker refs are typed by KIND; the 49 enrolment-backlog
+entries move from a machine-local evolution-action id (`ACT-1193`) to a
+fleet-stable key resolved against a shipped source constant
+(`backlog:decision-quality-enrolment` → `BACKLOG_TRACKERS`).
+
+**Spec:** `docs/specs/census-tracker-ref-kinds.md` (converged, 2 rounds)
+
+---
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+**One, deliberately, at build time.** The format ratchet accepts exactly two ref
+kinds and additionally resolves every `backlog:` key against the registry. A
+census entry pointing at an unregistered key now fails CI rather than shipping.
+
+That is the intent — a dangling ref is the whole defect — but it is a real new
+way to redden a build, and the failure message names the entry and the missing
+key so the fix is mechanical.
+
+**Nothing at runtime.** The adjudicator's `ACT-<n>` path is behaviourally
+identical, with one exception that strictly *widens* what is accepted: a null
+(unreadable/absent) queue now yields `unverifiable` instead of the callsite
+skipping adjudication silently. No input that previously produced a verdict
+produces a different one.
+
+## 2. Under-block — what failure modes does this still miss?
+
+- **A registered key whose work is abandoned.** The check proves the tracker
+  *resolves*, never that anyone is doing the work. Round-2 review named this;
+  it is mitigated (a required `closureCondition`, and CI forbidding orphaned
+  keys) but not solved — a human still has to read the registry and notice a key
+  that should have been retired. Honest framing: this makes the debt *legible*,
+  not *worked*.
+- **The 49 are still not enrolled.** This change makes the counter meaningful; it
+  enrols nothing. The backlog is unchanged at 49 by design, and the graduation
+  criterion asserts that explicitly so "progress" cannot be faked by shrinking it.
+- **A second backlog added carelessly.** CI pins the current distribution to one
+  key, so a second key is a deliberate, reviewed act — but nothing judges whether
+  the second backlog is a *good* division of the work.
+
+## 3. Level-of-abstraction fit
+
+Right layer, and it moved *down* during review. The first design put resolution
+in the route (an injected `specExists` predicate over the filesystem); the final
+one puts it in a pure function over a constant imported directly. Fewer seams,
+no I/O, and `unverifiable` becomes unreachable for the new kind by construction
+rather than by care.
+
+The one deliberate cross-layer touch: `liveActs` became nullable so the *route*
+no longer decides whether adjudication is possible. That decision belongs with
+the kinds, which live in the adjudicator.
+
+## 4. Signal vs authority compliance
+
+`docs/signal-vs-authority.md`. Both decision points are `invariant`, argued in
+the spec:
+
+- **The adjudicator** holds no authority over agent behaviour. It computes a
+  verdict for a read-only observability counter — it gates nothing, blocks
+  nothing, and no code path branches on its output.
+- **The format ratchet** is a closed-world format check over a two-member enum
+  at a dev-process chokepoint — the documented exemption class ("the cost of a
+  false pass is catastrophic and the cost of a false block is merely 'try again
+  with the right arguments'"). Here even that overstates it: a false block is a
+  named CI failure with the offending entry printed.
+
+No brittle matcher gains blocking authority over a runtime path.
+
+## 5. Interactions
+
+- **The 2026-07-23 high-water fix** — preserved exactly, and the spec argues why
+  it must be (this change is its second half, not its replacement). The ACT path
+  keeps `unverifiable`-not-`dead` for a peer-minted id, and the new null-queue
+  case extends the same principle rather than contradicting it.
+- **The pending shrink-only ratchet** — identity-pinned, so repointing all 49
+  changes 49 baseline lines. That is the designed "reviewed baseline change"
+  behaviour, not a bypass: the diff is large and legible on purpose.
+- **`GET /decision-quality?scope=pool`** — unaffected. `censusDebt` is built at a
+  single local callsite and is not among the pool-merged fields (verified in
+  source while adjudicating the mixed-version finding), so no peer's raw ref
+  reaches another machine's adjudicator.
+- **No shadowing or double-fire.** One adjudicator, one callsite, one loop.
+
+## 6. External surfaces
+
+- `GET /decision-quality` → `censusDebt` — **field shapes unchanged**; the
+  `pendingRefUnverifiable` array simply becomes empty where it was 49 entries.
+  No consumer sees a new or renamed field.
+- No new route, config key, flag, env var, or CLI surface.
+- No user-visible behaviour on any agent. This is instrumentation.
+- **Timing/state dependence:** removed, not added. The new kind's verdict depends
+  on nothing outside the shipped artifact — no clock, no queue, no filesystem,
+  no network.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Unified**, and that is the entire point of the change.
+
+- `BACKLOG_TRACKERS` — unified by construction: a source constant in `src/data/`
+  (published in `package.json` `files[]`, compiled into `dist/`). There is no
+  per-machine copy that can diverge.
+- `adjudicatePendingTracker` — unified. Reads machine-local state *only* for the
+  `ACT-<n>` kind, which is machine-local by design and already guarded.
+- The evolution action queue stays **machine-local BY DESIGN**
+  (`machine-local-justification: operator-ratified-exception`, citing the
+  2026-07-23 high-water adjudication already in `src/server/routes.ts`).
+  Inherited, not introduced — this change stops *depending* on that locality for
+  a fleet-wide tracker rather than attempting to change it.
+- No notices, no durable state, no generated URLs — nothing to strand on a topic
+  transfer or to break across a machine boundary.
+
+## 8. Rollback cost
+
+**Revert the commit.** No flag, because there is no weakened state to return to;
+no migration, because no durable state is written; no agent-state repair.
+
+Stated plainly because the spec's first draft got it wrong: *before* a revert, a
+`backlog:` ref pointing at an unregistered key reports **`dead`**, not
+`unverifiable` — a loud false deletion rather than a quiet unknown. Two things
+bound that: CI resolves every `backlog:` ref against the registry, so a dangling
+key cannot reach a release; and reverting restores today's `unverifiable`.
+
+## Second-pass review
+
+**Not required** by the Phase-5 trigger list: no block/allow decision on
+messaging or dispatch, no session lifecycle, no compaction path, no coherence
+gate, trust level, or idempotency check, and nothing named sentinel/guard/gate/
+watchdog. The change is a read-only observability counter plus a CI ratchet.
+
+Substituting for it, and arguably stronger: the spec went through **two rounds of
+external cross-model review**, the first of which returned SERIOUS ISSUES and
+inverted the design (see the convergence report). The reviewer proved the
+original anchor would have produced 49 fleet-wide false deletions — a defect no
+internal pass caught.
+
+---
+
+## Addendum — an unrelated flake this change's own full-suite run surfaced
+
+Running the full unit suite against this branch produced one failure:
+`tests/unit/builtin-manifest.test.ts > is up-to-date with current source`. It
+passed in isolation, so it is not caused by this change — but the Zero-Failure
+Standard makes it mine on sight, so it is fixed in the same PR rather than
+re-run away.
+
+**The defect.** That test verified the committed manifest was current by
+*regenerating over it* and diffing the file before/after — a verifier that
+mutates the artifact it verifies. `tests/unit/package-completeness.test.ts` runs
+a full `npx tsc` build which (per its own comment) regenerates the same
+`src/data/builtin-manifest.json`. Under the parallel suite the two race, so a
+perfectly good tree goes red at random.
+
+**The fix.** `scripts/generate-builtin-manifest.cjs` honours an optional
+`INSTAR_BUILTIN_MANIFEST_OUT` override (default path unchanged); the test
+generates to a temp dir and diffs against the committed file, touching nothing
+shared. The check is now read-only and order-independent, and its failure
+message says how to fix a genuinely stale manifest.
+
+**Side effects of the fix:** none beyond the test. The override is opt-in and
+unset everywhere except this test, so the build and `prepublishOnly` paths are
+byte-identical. No runtime code, no shipped surface.
+
+This is the ninth instance in this run of the same shape — a check reporting a
+result it did not actually establish. Here it reported failure it hadn't earned,
+which is the less dangerous direction but the same root cause.


### PR DESCRIPTION
## ELI16 — a health check that could only ever say "I don't know" can now answer

There's a health counter that watches a backlog of 49 items and asks, for each
one, "is anybody still tracking this?" — so work can't quietly rot.

All 49 pointed at a to-do note whose ID only means something on the one machine
where it was written. But the list of 49 ships identically to every machine. So
everywhere else, the counter could only ever answer "I don't know." A warning
light that can only shrug isn't a warning light.

This gives tracker references a *kind*. A to-do ID keeps working as before, for
genuinely machine-local notes. A second kind points at a short registry that
lives in the code itself — so every machine can check it, because every machine
has the same copy.

**I got this wrong the first time, and it's the most useful thing in the PR.**
My original design pointed the items at the *design document* that owns the
backlog. Documents ship with the code, I reasoned. They don't — documentation is
excluded from the published package. So on every machine but this one, the check
would have found a missing file and concluded the tracker was **deleted**: 49
deletions that never happened. Today's honest "can't verify" would have become a
confident lie, re-breaking a bug someone fixed in July while claiming to finish
it. External cross-model review caught it. There's now a test that reads the
packaging rules directly and fails if anyone tries the document approach again.

The backlog itself deliberately still reads 49. Making the number smaller was the
easy version and the wrong one.

## UX impact declaration

- **Audience:** instar developers and maintainers. No end-user surface.
- **Visible behavior change:** none for any agent or user. No new route, config
  key, flag, env var, CLI command, message, or notification. The one externally
  observable difference is the *content* of an existing read: `censusDebt` in
  `GET /decision-quality` reports an empty `pendingRefUnverifiable` where it
  previously listed 49 entries. Field names and shapes are unchanged, so no
  consumer breaks.
- **First contact:** a maintainer reading `GET /decision-quality`, or a CI
  failure if a census entry gains a bad tracker ref.
- **User-visible strings introduced:** none. The strings this diff adds are
  developer-facing failure messages and code documentation:
  - `"src/data/builtin-manifest.json is stale — run \`node scripts/generate-builtin-manifest.cjs\` and commit the result"`
  - `"pending ref '${ref}' must be a machine-local evolution-queue id (ACT-<n>) or a fleet-stable backlog key (backlog:<key>)"`
  - `"backlog key '${k}' is registered but referenced by no pending entry — delete it (its closure condition says so) or point the work at it"`
  - `"docs/ is excluded from the package; an existence check against a doc path resolves false on every fleet install"`
- **Rollback:** revert. No flag, no migration, no durable state, no agent-state repair.

## What changed

| | |
|---|---|
| `src/data/provenanceCoverage.ts` | `BACKLOG_TRACKERS` registry + `backlogTrackerExists()`; 49 entries repointed to `backlog:decision-quality-enrolment` |
| `src/server/routes.ts` | `TrackerRef` kinds, `parseTrackerRef()`, kind-branching `adjudicatePendingTracker()`, nullable `liveActs`, callsite guard removed |
| `scripts/generate-builtin-manifest.cjs` | optional `INSTAR_BUILTIN_MANIFEST_OUT` (default path unchanged) |
| tests | 24 unit + 4 integration + 2 E2E assertions; ratchet extended; manifest flake fixed |
| docs | spec (converged, 2 rounds), ELI16, convergence report, side-effects, release fragment |

## Why `unverifiable` is now unreachable for the new kind

Not by care — by construction. A `backlog:` ref resolves by exact lookup in a
constant compiled into `dist/`. There is no filesystem call to fail, no queue to
be missing, and no network to time out. The unit tier asserts the verdict is
never `unverifiable` across every input and queue state.

## Two review findings adjudicated, not adopted

Both from round 2, both reasonable from outside the code, both closed with
evidence rather than opinion (spec §2.5):

- **"A mixed-version fleet breaks this."** Not reachable — the refs and the
  parser compile into `dist/` from the same package version, so no install holds
  new refs with an old parser. The only cross-machine path is the pool merge, and
  `censusDebt` isn't pool-merged (checked in source).
- **"`dead` for a malformed ref is muddy; add `invalid`."** Right as vocabulary,
  declined on reachability — CI format-validates and resolves every ref, so an
  `invalid` runtime verdict would guard an impossible state while widening the
  two-bucket contract the July fix established.

## Unrelated flake fixed here

The full-suite run on this branch went red on
`tests/unit/builtin-manifest.test.ts`, which passes in isolation. It verified the
committed manifest by **regenerating over it**, racing `package-completeness.test.ts`
whose full build regenerates the same file. A verifier that mutates the artifact
it verifies. Now generates to a temp dir and diffs read-only. Owned on sight per
the Zero-Failure Standard rather than re-run away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsMJxSBBPAeDo8bXdunVtC
