### PR TITLE
fix: preserve manifest verification provenance

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T09-09-53-397Z-capability-registry-increment-0.json
+++ b/.instar/instar-dev-decisions/2026-07-25T09-09-53-397Z-capability-registry-increment-0.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T09:09:53.397Z",
+  "slug": "capability-registry-increment-0",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T09-14-53-324Z-capability-registry-followup.json
+++ b/.instar/instar-dev-decisions/2026-07-25T09-14-53-324Z-capability-registry-followup.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T09:14:53.324Z",
+  "slug": "capability-registry-followup",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T09-44-45-205Z-capability-registry-followup.json
+++ b/.instar/instar-dev-decisions/2026-07-25T09-44-45-205Z-capability-registry-followup.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T09:44:45.205Z",
+  "slug": "capability-registry-followup",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T10-08-00-846Z-capability-registry-followup.json
+++ b/.instar/instar-dev-decisions/2026-07-25T10-08-00-846Z-capability-registry-followup.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T10:08:00.846Z",
+  "slug": "capability-registry-followup",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 3,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T10-15-35-284Z-capability-registry-followup.json
+++ b/.instar/instar-dev-decisions/2026-07-25T10-15-35-284Z-capability-registry-followup.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T10:15:35.284Z",
+  "slug": "capability-registry-followup",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 12,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-25T09-14-00-000Z-capability-registry-followup.json
+++ b/.instar/instar-dev-traces/2026-07-25T09-14-00-000Z-capability-registry-followup.json
@@ -3,7 +3,7 @@
   "sessionId": "capability-registry-followup",
   "timestamp": "2026-07-25T09:14:00.000Z",
   "artifactPath": "upgrades/side-effects/capability-registry-followup.md",
-  "artifactSha256": "0abad49e51985b3af7dda94b81e0333a98b6f93fb474e25ab99897d052c1f25a",
+  "artifactSha256": "6225d0689a3590e85a9a7a2617a0fb0779fbd9bc84bd608f0e5df4eeb7406f74",
   "specPath": "docs/specs/cross-machine-door-capability-registry.md",
   "coveredFiles": ["src/core/CapabilityRegistry.ts", "tests/unit/CapabilityRegistry.test.ts"],
   "phase": "complete",

--- a/.instar/instar-dev-traces/2026-07-25T09-14-00-000Z-capability-registry-followup.json
+++ b/.instar/instar-dev-traces/2026-07-25T09-14-00-000Z-capability-registry-followup.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "sessionId": "capability-registry-followup",
+  "timestamp": "2026-07-25T09:14:00.000Z",
+  "artifactPath": "upgrades/side-effects/capability-registry-followup.md",
+  "artifactSha256": "0abad49e51985b3af7dda94b81e0333a98b6f93fb474e25ab99897d052c1f25a",
+  "specPath": "docs/specs/cross-machine-door-capability-registry.md",
+  "coveredFiles": ["src/core/CapabilityRegistry.ts", "tests/unit/CapabilityRegistry.test.ts"],
+  "phase": "complete",
+  "secondPass": "required",
+  "reviewerConcurred": true,
+  "duplicateBuildCheck": {"verdict": "clear", "cause": null, "degraded": true, "notes": ["Follow-up is limited to manifest evidence provenance and test resilience."], "specSlug": "cross-machine-door-capability-registry", "phase": "build-start", "disposition": {"decision": "proceed", "reason": "Reviewer-requested follow-up to activate manifest staleness evidence.", "acknowledgedEvidenceIds": [], "recordedAt": "2026-07-25T09:14:00.000Z"}}
+}

--- a/.instar/instar-dev-traces/2026-07-25T09-14-00-000Z-capability-registry-followup.json
+++ b/.instar/instar-dev-traces/2026-07-25T09-14-00-000Z-capability-registry-followup.json
@@ -3,7 +3,7 @@
   "sessionId": "capability-registry-followup",
   "timestamp": "2026-07-25T09:14:00.000Z",
   "artifactPath": "upgrades/side-effects/capability-registry-followup.md",
-  "artifactSha256": "6225d0689a3590e85a9a7a2617a0fb0779fbd9bc84bd608f0e5df4eeb7406f74",
+  "artifactSha256": "ab4b95bfc88fbc74c661675f0e0fd54941a95ded23fa53cd848b343fe556db53",
   "specPath": "docs/specs/cross-machine-door-capability-registry.md",
   "coveredFiles": ["src/core/CapabilityRegistry.ts", "tests/unit/CapabilityRegistry.test.ts"],
   "phase": "complete",

--- a/src/core/CapabilityRegistry.ts
+++ b/src/core/CapabilityRegistry.ts
@@ -140,7 +140,7 @@ export function readDoorwaySources(projectDir: string, stateDir: string, now = n
       const doorwayId = door.doorId;
       const scannedAt = d?.lastScannedAt ?? now;
       const capabilityId = canonicalCapabilityId(doorwayId, model.id);
-      const common = { capabilityId, capabilityKind: 'model' as const, doorwayId, machineId, endpointRef: `mesh://${machineId}/doorways`, receivedAt: now, source: 'local-doorways' as const, evidence: { ...(d?.lastScannedAt ? { doorwayScanAt: d.lastScannedAt } : {}) } };
+      const common = { capabilityId, capabilityKind: 'model' as const, doorwayId, machineId, endpointRef: `mesh://${machineId}/doorways`, receivedAt: now, source: 'local-doorways' as const, evidence: { ...(d?.lastScannedAt ? { doorwayScanAt: d.lastScannedAt } : {}), ...(model.verifiedAt ? { manifestVerifiedAt: model.verifiedAt } : {}) } };
       entries.push({ ...common, probeOutcome: 'positive', observedAt: model.verifiedAt ?? now, sourceDetail: 'doorway-manifest', evidenceClass: 'manifest-only' });
       if (d) entries.push({ ...common, probeOutcome: d.probeStatus === 'ok' ? 'positive' : ['not-installed', 'http-4xx'].includes(d.probeStatus) ? 'negative' : 'unknown', observedAt: scannedAt, sourceDetail: 'doorway-scan', evidenceClass: d.probeStatus === 'ok' ? 'probe-answered' : 'cli-present' });
     }

--- a/src/core/CapabilityRegistry.ts
+++ b/src/core/CapabilityRegistry.ts
@@ -112,8 +112,9 @@ export function deriveStatus(entries: CapabilityEntry[], now = Date.now(), opts:
   if (entries.every(e => e.evidenceClass === 'manifest-only')) return 'unknown';
   if (entries.some(e => e.probeOutcome === 'unknown')) return 'unknown';
   const observedStale = entries.some(e => now - Date.parse(e.observedAt) > (opts.localStaleAfterMs ?? 86_400_000));
+  const manifestStale = entries.some(e => e.evidence.manifestVerifiedAt !== undefined && now - Date.parse(e.evidence.manifestVerifiedAt) > (opts.localStaleAfterMs ?? 86_400_000));
   const transportStale = opts.lastConfirmedAt !== undefined && now - opts.lastConfirmedAt > (opts.remoteTtlCeilingMs ?? 600_000);
-  if (transportStale || observedStale) return 'stale';
+  if (transportStale || observedStale || manifestStale) return 'stale';
   return entries[0].probeOutcome === 'positive' ? 'available' : 'unavailable';
 }
 

--- a/src/core/CapabilityRegistry.ts
+++ b/src/core/CapabilityRegistry.ts
@@ -46,6 +46,7 @@ const str = (v: unknown, name: string): string => {
 const iso = (v: unknown, name: string): string => {
   const s = str(v, name); if (Number.isNaN(Date.parse(s))) throw new Error(`${name}-timestamp`); return s;
 };
+const isoOrAbsent = (v: unknown): string | undefined => typeof v === 'string' && !Number.isNaN(Date.parse(v)) ? v : undefined;
 const oneOf = <T extends readonly string[]>(v: unknown, values: T, name: string): T[number] => {
   if (!values.includes(v as string)) throw new Error(`${name}-enum`); return v as T[number];
 };
@@ -105,14 +106,14 @@ export function canonicalDigest(projection: CapabilityProjection): string {
   if (Buffer.byteLength(digest) > 64) throw new Error('digest-width'); return digest;
 }
 
-export function deriveStatus(entries: CapabilityEntry[], now = Date.now(), opts: { localStaleAfterMs?: number; remoteTtlCeilingMs?: number; lastConfirmedAt?: number } = {}): CapabilityStatus {
+export function deriveStatus(entries: CapabilityEntry[], now = Date.now(), opts: { localStaleAfterMs?: number; manifestStaleAfterMs?: number; remoteTtlCeilingMs?: number; lastConfirmedAt?: number } = {}): CapabilityStatus {
   if (!entries.length) return 'unknown';
   const byOutcome = new Set(entries.map(e => e.probeOutcome));
   if (byOutcome.size > 1) return 'conflict';
   if (entries.every(e => e.evidenceClass === 'manifest-only')) return 'unknown';
   if (entries.some(e => e.probeOutcome === 'unknown')) return 'unknown';
   const observedStale = entries.some(e => now - Date.parse(e.observedAt) > (opts.localStaleAfterMs ?? 86_400_000));
-  const manifestStale = entries.some(e => e.evidence.manifestVerifiedAt !== undefined && now - Date.parse(e.evidence.manifestVerifiedAt) > (opts.localStaleAfterMs ?? 86_400_000));
+  const manifestStale = entries.some(e => e.evidence.manifestVerifiedAt !== undefined && now - Date.parse(e.evidence.manifestVerifiedAt) > (opts.manifestStaleAfterMs ?? 45 * 86_400_000));
   const transportStale = opts.lastConfirmedAt !== undefined && now - opts.lastConfirmedAt > (opts.remoteTtlCeilingMs ?? 600_000);
   if (transportStale || observedStale || manifestStale) return 'stale';
   return entries[0].probeOutcome === 'positive' ? 'available' : 'unavailable';
@@ -133,6 +134,8 @@ export function readDoorwaySources(projectDir: string, stateDir: string, now = n
   const { body } = result;
   const scanState: ScanState = !scanReadable && scanExists ? 'source-unavailable' : body.scanState === 'scanned' ? 'observed' : 'never-observed';
   const scanStampSecs = body.lastScanAt ? Math.floor(Date.parse(body.lastScanAt) / 1000) : 0;
+  let manifestReviewedAt: string | undefined;
+  try { manifestReviewedAt = isoOrAbsent((JSON.parse(fs.readFileSync(path.join(projectDir, 'scripts/model-registry-freshness.manifest.json'), 'utf8')) as Record<string, unknown>).lastReviewedAt); } catch { /* canonical reader owns manifest failure classification */ }
   const entries: CapabilityEntry[] = [];
   for (const door of body.doorways) {
     const d = door.probeStatus === 'never-scanned' ? null : door;
@@ -141,8 +144,9 @@ export function readDoorwaySources(projectDir: string, stateDir: string, now = n
       const doorwayId = door.doorId;
       const scannedAt = d?.lastScannedAt ?? now;
       const capabilityId = canonicalCapabilityId(doorwayId, model.id);
-      const common = { capabilityId, capabilityKind: 'model' as const, doorwayId, machineId, endpointRef: `mesh://${machineId}/doorways`, receivedAt: now, source: 'local-doorways' as const, evidence: { ...(d?.lastScannedAt ? { doorwayScanAt: d.lastScannedAt } : {}), ...(model.verifiedAt ? { manifestVerifiedAt: model.verifiedAt } : {}) } };
-      entries.push({ ...common, probeOutcome: 'positive', observedAt: model.verifiedAt ?? now, sourceDetail: 'doorway-manifest', evidenceClass: 'manifest-only' });
+      const manifestVerifiedAt = isoOrAbsent(model.verifiedAt) ?? manifestReviewedAt;
+      const common = { capabilityId, capabilityKind: 'model' as const, doorwayId, machineId, endpointRef: `mesh://${machineId}/doorways`, receivedAt: now, source: 'local-doorways' as const, evidence: { ...(d?.lastScannedAt ? { doorwayScanAt: d.lastScannedAt } : {}), ...(manifestVerifiedAt ? { manifestVerifiedAt } : {}) } };
+      entries.push({ ...common, probeOutcome: 'positive', observedAt: manifestVerifiedAt ?? now, sourceDetail: 'doorway-manifest', evidenceClass: 'manifest-only' });
       if (d) entries.push({ ...common, probeOutcome: d.probeStatus === 'ok' ? 'positive' : ['not-installed', 'http-4xx'].includes(d.probeStatus) ? 'negative' : 'unknown', observedAt: scannedAt, sourceDetail: 'doorway-scan', evidenceClass: d.probeStatus === 'ok' ? 'probe-answered' : 'cli-present' });
     }
   }

--- a/tests/unit/CapabilityRegistry.test.ts
+++ b/tests/unit/CapabilityRegistry.test.ts
@@ -59,6 +59,7 @@ describe('CapabilityRegistry adapter reality', () => {
     fs.mkdirSync(path.join(stateDir, 'state'));
     fs.writeFileSync(path.join(stateDir, 'state/doorway-scan.json'), JSON.stringify({ lastScanAt: '2026-07-25T00:00:00Z', doorways: [{ id: 'claude-code', probeStatus: 'ok', lastScannedAt: '2026-07-25T00:00:00Z' }] }));
     const result = readDoorwaySources(projectDir, stateDir, '2026-07-25T00:00:01Z');
+    expect(() => validateProjection({ schemaVersion: 1, machineId: 'local', machineEpoch: 1, projectionSeq: 1, scanStampSecs: result.scanStampSecs, scanState: result.scanState, truncated: false, entries: result.entries })).not.toThrow();
     expect(result.scanStampSecs).toBe(Math.floor(Date.parse('2026-07-25T00:00:00Z') / 1000));
     expect(result.scanState).toBe('observed');
     expect(result.entries.length).toBeGreaterThan(2);

--- a/tests/unit/CapabilityRegistry.test.ts
+++ b/tests/unit/CapabilityRegistry.test.ts
@@ -63,7 +63,7 @@ describe('CapabilityRegistry adapter reality', () => {
     expect(result.scanState).toBe('observed');
     expect(result.entries.length).toBeGreaterThan(2);
     expect(result.entries.map(e => e.sourceDetail)).toEqual(expect.arrayContaining(['doorway-scan', 'doorway-manifest']));
-    expect(result.entries.find(e => e.sourceDetail === 'doorway-scan')).toMatchObject({ capabilityId: 'models:claude-code/claude-opus-4-8', probeOutcome: 'positive' });
+    expect(result.entries.find(e => e.sourceDetail === 'doorway-scan')).toMatchObject({ capabilityId: expect.stringMatching(/^models:claude-code\//), probeOutcome: 'positive' });
     fs.writeFileSync(path.join(stateDir, 'state/doorway-scan.json'), JSON.stringify({ lastScanAt: null, doorways: [] }));
     expect(readDoorwaySources(projectDir, stateDir).scanState).toBe('never-observed');
     fs.writeFileSync(path.join(stateDir, 'state/doorway-scan.json'), '{not-json');

--- a/tests/unit/CapabilityRegistry.test.ts
+++ b/tests/unit/CapabilityRegistry.test.ts
@@ -63,10 +63,18 @@ describe('CapabilityRegistry adapter reality', () => {
     expect(result.scanState).toBe('observed');
     expect(result.entries.length).toBeGreaterThan(2);
     expect(result.entries.map(e => e.sourceDetail)).toEqual(expect.arrayContaining(['doorway-scan', 'doorway-manifest']));
+    expect(result.entries.find(e => e.sourceDetail === 'doorway-manifest')?.evidence.manifestVerifiedAt).toBeTruthy();
     expect(result.entries.find(e => e.sourceDetail === 'doorway-scan')).toMatchObject({ capabilityId: expect.stringMatching(/^models:claude-code\//), probeOutcome: 'positive' });
     fs.writeFileSync(path.join(stateDir, 'state/doorway-scan.json'), JSON.stringify({ lastScanAt: null, doorways: [] }));
     expect(readDoorwaySources(projectDir, stateDir).scanState).toBe('never-observed');
     fs.writeFileSync(path.join(stateDir, 'state/doorway-scan.json'), '{not-json');
     expect(readDoorwaySources(projectDir, stateDir).scanState).toBe('source-unavailable');
+  });
+});
+
+describe('CapabilityRegistry manifest freshness', () => {
+  it('marks a fresh scan row stale when manifest verification is old', () => {
+    const scan = entry({ observedAt: '2026-07-25T00:00:00Z', evidenceClass: 'probe-answered', evidence: { doorwayScanAt: '2026-07-25T00:00:00Z', manifestVerifiedAt: '2026-06-01T00:00:00Z' } });
+    expect(deriveStatus([scan], Date.parse('2026-07-25T01:00:00Z'))).toBe('stale');
   });
 });

--- a/upgrades/next/capability-registry-followup.md
+++ b/upgrades/next/capability-registry-followup.md
@@ -1,0 +1,15 @@
+# Capability registry manifest provenance
+
+Manifest-derived capability rows now carry their manifest verification timestamp, activating the existing manifest-staleness status path. The adapter test no longer pins one model identifier.
+
+## What Changed
+
+The local registry now records when the reviewed doorway manifest was verified. That timestamp feeds the existing freshness calculation, allowing an old manifest to be classified as stale instead of appearing current. Tests remain resilient when the reviewed manifest rotates model names.
+
+## What to Tell Your User
+
+This is an internal reliability improvement. The agent can now tell when its local doorway catalog is old, while normal capability discovery and all user-facing routes remain unchanged.
+
+## Summary of New Capabilities
+
+Registry freshness can now detect stale canonical manifest evidence.

--- a/upgrades/side-effects/capability-registry-followup.md
+++ b/upgrades/side-effects/capability-registry-followup.md
@@ -1,0 +1,6 @@
+# Side-effects review: capability registry follow-up
+
+- This follow-up changes one behavior from Increment 0: manifest-derived capability rows now carry `evidence.manifestVerifiedAt` from the canonical manifest verification stamp.
+- That producer activates the status matrix's manifest-staleness arm; before this change, that arm could never fire because no adapter populated the field.
+- The adapter test now asserts the canonical doorway prefix without pinning one specific model id, so reviewed manifest model rotation does not create a false failure.
+- No routes, mesh traffic, durable schema changes, or fleet behavior are added.

--- a/upgrades/side-effects/capability-registry-followup.md
+++ b/upgrades/side-effects/capability-registry-followup.md
@@ -4,3 +4,4 @@
 - That producer activates the status matrix's manifest-staleness arm; before this change, that arm could never fire because no adapter populated the field.
 - The adapter test now asserts the canonical doorway prefix without pinning one specific model id, so reviewed manifest model rotation does not create a false failure.
 - No routes, mesh traffic, durable schema changes, or fleet behavior are added.
+- Follow-up tests now assert both the manifest stamp producer and the stale-manifest status arm.

--- a/upgrades/side-effects/capability-registry-followup.md
+++ b/upgrades/side-effects/capability-registry-followup.md
@@ -5,3 +5,4 @@
 - The adapter test now asserts the canonical doorway prefix without pinning one specific model id, so reviewed manifest model rotation does not create a false failure.
 - No routes, mesh traffic, durable schema changes, or fleet behavior are added.
 - Follow-up tests now assert both the manifest stamp producer and the stale-manifest status arm.
+- Real-manifest adapter output is now validated through `validateProjection`; non-ISO sentinel stamps are treated as absent, and the 45-day manifest window is honored.


### PR DESCRIPTION
## ELI16

This small follow-up makes the registry’s existing freshness rules useful for real manifest data. Each capability row now carries the timestamp showing when the reviewed manifest was verified, so an old manifest can become visibly stale instead of silently looking current.

The test also avoids hard-coding one model name. The reviewed manifest can rotate models without making the adapter test fail for the wrong reason. No routes, network traffic, or fleet behavior are changed.

## Summary

Adds `evidence.manifestVerifiedAt` to manifest-derived rows and removes a brittle literal model-id assertion.

## Checks

`pnpm exec tsc --noEmit`; focused CapabilityRegistry tests.
