### PR TITLE
fix(benchmark): the divergence detector has never produced a verdict — one character

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T10-28-49-807Z-benchmark-source-match.json
+++ b/.instar/instar-dev-decisions/2026-07-25T10-28-49-807Z-benchmark-source-match.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T10:28:49.807Z",
+  "slug": "benchmark-source-match",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 4,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/benchmark-source-match.eli16.md
+++ b/docs/specs/benchmark-source-match.eli16.md
@@ -1,0 +1,103 @@
+# The benchmark checker that never checked anything — plain English
+
+## The one-sentence version
+
+A system built to tell us when a model performs worse in real life than it did
+on its test has never once given an answer, because two labels it compares
+differ by a single character — and its way of saying "I can't tell" looks
+exactly like it working properly.
+
+## What the thing is for
+
+We benchmark the models that make judgment calls — is this message safe to send,
+is this process a runaway. The benchmark says "this model should get about 96% of
+these right."
+
+Then reality happens. The interesting question is whether reality agrees. If a
+model scores 96% on the test and gets 70% right in production, something is
+wrong: maybe the test is too easy, maybe production is harder than we thought,
+maybe we picked the wrong model. That gap is worth knowing about.
+
+So there's a checker whose whole job is to compare those two numbers and flag
+disagreements.
+
+## The safety check in front of it
+
+Before comparing, it makes sure the benchmark it's holding actually corresponds
+to what's running now. Prompts change. If someone rewrote the instructions since
+the benchmark was taken, the old score describes something that no longer
+exists, and comparing against it would be worse than not comparing at all — it
+would blame a model for a test it never sat.
+
+So the checker verifies the benchmark matches the live version. If it can't
+confirm that, it refuses to judge and says so. **That refusal is correct
+behaviour**, and remembering that is the key to the whole story.
+
+## What was actually wrong
+
+Part of that verification compares two labels describing where the tested text
+lives.
+
+One says `...MessagingToneGate.ts:TONE_GATE_PROMPT_TEMPLATE`.
+The other says `...MessagingToneGate.ts#TONE_GATE_PROMPT_TEMPLATE`.
+
+A colon in one, a hash in the other. Everything else identical. They're compared
+character by character, so they never match, so the checker always concludes it
+can't confirm what it's holding, so it always declines to judge.
+
+Every task. Every run. Since the day it shipped.
+
+## Why this went unnoticed, which is the real point
+
+Because refusing to judge is a legitimate answer.
+
+The checker runs on schedule. It completes without error. It emits a valid,
+designed verdict: "precondition failed — can't verify the benchmark." Nothing
+crashes. Nothing goes red. No alarm fires, because from the outside, a checker
+that is permanently blindfolded produces exactly the same output as a checker
+that is being appropriately careful about a stale benchmark.
+
+The only way to notice is to ask "why has it never said anything else?" — and
+then refuse to accept the reasonable-sounding answer.
+
+## What I changed
+
+Two things, and the second matters more.
+
+**The character.** The labels now match, and the checker can get past its own
+front door.
+
+**Something that compares them.** A build check now verifies those two labels
+are identical, and fails the build if they drift apart. It also checks the
+benchmark still matches the live prompt, that every benchmarked task is one the
+system knows about, and that none of them are empty.
+
+The one-character typo was the bug. **The absence of anything comparing the two
+labels was the defect.** A single character was allowed to silently disable an
+entire subsystem, and nothing anywhere would have told us.
+
+## What I deliberately did not do
+
+The obvious "fix" is to make the comparison more forgiving — treat a colon and a
+hash as the same thing. I didn't, and wouldn't.
+
+That comparison is a safety check. Making it lenient would mean it stops
+catching cases where the benchmark genuinely doesn't match what's running — and
+then the checker would confidently blame models based on tests they never took.
+That's a worse failure than saying nothing, because it produces confident
+garbage instead of honest silence.
+
+The strict comparison is right. What was missing was anything ensuring the two
+sides stay in step. So the mismatch is now impossible to ship, rather than
+tolerated at runtime.
+
+## What you'd notice
+
+Right now, nothing — until this ships and the checker starts producing real
+verdicts for the first time.
+
+When it does, expect its first answers to be unglamorous: mostly "not enough
+evidence yet," because it needs a decent number of graded decisions before it
+will commit to a claim. That's the system being careful, and this time it'll be
+careful for the right reason rather than because it tripped over a punctuation
+mark.

--- a/src/data/benchmarkPredictions.json
+++ b/src/data/benchmarkPredictions.json
@@ -25,7 +25,7 @@
      "deterministic": 14
     }
    },
-   "benchedPromptSource": "src/core/MessagingToneGate.ts:TONE_GATE_PROMPT_TEMPLATE",
+   "benchedPromptSource": "src/core/MessagingToneGate.ts#TONE_GATE_PROMPT_TEMPLATE",
    "benchedPromptHash": "4ae0cf6b02663c21a695393727bd05662334f0d8f1a9d3e45d8d9b2141208d54",
    "capturedAt": "2026-07-23T22:30:00.000Z"
   },
@@ -47,7 +47,7 @@
      "deterministic": 6
     }
    },
-   "benchedPromptSource": "src/monitoring/ExternalHogClassifierPrompt.ts:EXTERNAL_HOG_CLASSIFIER_PROMPT_TEMPLATE",
+   "benchedPromptSource": "src/monitoring/ExternalHogClassifierPrompt.ts#EXTERNAL_HOG_CLASSIFIER_PROMPT_TEMPLATE",
    "benchedPromptHash": "98b026dbe3ee48cab1403ef24218e9e24f6ea2b3d598c23e383bed4e894cbb56",
    "capturedAt": "2026-07-24T01:20:00.000Z",
    "scoredPopulation": "production-candidate only (10 of 17 cases). Excluded by design: 4 floor-excluded (never allowlist-matched, so no model is ever consulted about them), 1 invalid-unwinnable (renders byte-identical to another case with the opposite expected answer — a prompt defect, see ACT-1212), 2 contested-expectation (the models made the better argument and the expectation was withdrawn). Excluded cases are retained in the task file as evidence, not deleted.",

--- a/tests/unit/benchmark-mirror-registry-agreement.test.ts
+++ b/tests/unit/benchmark-mirror-registry-agreement.test.ts
@@ -1,0 +1,178 @@
+/**
+ * The Benchmark-Divergence Detector's Q0 precondition compares two strings for
+ * EXACT equality (BenchmarkDivergenceAnalyzer.ts):
+ *
+ *     registrySourceMatches =
+ *       task.benchedPromptSource === registryEntry.source
+ *
+ * A mismatch means `precondition-failed / hash-unverifiable` — the detector
+ * declines to judge, which is the correct behaviour for a benchmark it cannot
+ * tie to the live prompt.
+ *
+ * WHAT HAPPENED (2026-07-25). The mirror wrote those sources with a COLON
+ * separator (`MessagingToneGate.ts:TONE_GATE_PROMPT_TEMPLATE`) while the
+ * registry declared them with a HASH (`...ts#TONE_GATE_PROMPT_TEMPLATE`). One
+ * character. So `registrySourceMatches` was false for EVERY task on EVERY run,
+ * and the detector returned `precondition-failed` for its entire shipped life.
+ *
+ * It never looked broken. `precondition-failed` is a legitimate, designed
+ * verdict — the responsible answer when a benchmark is genuinely stale. The
+ * analysis pass completed cleanly, emitted a valid verdict, and errored never.
+ * A permanently blindfolded detector is output-identical to a correctly
+ * cautious one, which is exactly why this survived.
+ *
+ * The one-character typo was the bug. The absence of anything comparing the two
+ * strings at build time was the DEFECT — that is what this file fixes. The
+ * exact-match comparison in the analyzer is deliberately NOT loosened: it is the
+ * guard. Loosening it would trade a visible failure for a silent one. Instead a
+ * mismatch is made unshippable.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  PROMPT_TEMPLATE_REGISTRY,
+  liveTemplateHash,
+} from '../../src/data/benchmarkDivergenceRegistry.js';
+import { computeVerdict, type VerdictInput } from '../../src/core/benchmarkDivergenceCore.js';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const MIRROR_PATH = path.join(ROOT, 'src/data/benchmarkPredictions.json');
+
+interface MirrorTask {
+  benchedPromptSource?: unknown;
+  benchedPromptHash?: unknown;
+  perModel?: Record<string, unknown>;
+}
+
+function readMirror(): { tasks: Record<string, MirrorTask> } {
+  return JSON.parse(fs.readFileSync(MIRROR_PATH, 'utf-8'));
+}
+
+describe('benchmark mirror ↔ prompt registry agreement (Q0 precondition)', () => {
+  const mirror = readMirror();
+
+  it('the fixture is real — the mirror carries tasks and the registry is populated', () => {
+    // Guards the guard: every assertion below iterates one of these, so an
+    // empty collection would make this whole file vacuously green.
+    expect(Object.keys(mirror.tasks).length).toBeGreaterThan(0);
+    expect(Object.keys(PROMPT_TEMPLATE_REGISTRY).length).toBeGreaterThan(0);
+  });
+
+  it('every mirror task names a task the registry knows', () => {
+    for (const taskId of Object.keys(mirror.tasks)) {
+      expect(
+        PROMPT_TEMPLATE_REGISTRY[taskId],
+        `mirror task '${taskId}' has no PROMPT_TEMPLATE_REGISTRY entry — the analyzer cannot resolve a live prompt for it`,
+      ).toBeDefined();
+    }
+  });
+
+  it('benchedPromptSource EXACTLY equals the registry source — the string the analyzer compares', () => {
+    // THE regression test. This is the comparison the analyzer performs; if it
+    // fails here, the detector is blind in production and says nothing about it.
+    for (const [taskId, entry] of Object.entries(PROMPT_TEMPLATE_REGISTRY)) {
+      const task = mirror.tasks[taskId];
+      if (!task) continue; // covered by the coverage test below
+      expect(
+        task.benchedPromptSource,
+        `task '${taskId}': the mirror's benchedPromptSource must be byte-identical to the registry source, or ` +
+          `registrySourceMatches is false and every verdict becomes precondition-failed/hash-unverifiable. ` +
+          `Note the separator: the registry uses '#', not ':'.`,
+      ).toBe(entry.source);
+    }
+  });
+
+  it('benchedPromptHash matches the live template hash', () => {
+    // The sibling precondition. A drifted hash is a legitimate stale-benchmark
+    // signal (re-capture the mirror), unlike the source mismatch above which is
+    // always a bug — but both silently disable the detector, so both are pinned.
+    for (const taskId of Object.keys(PROMPT_TEMPLATE_REGISTRY)) {
+      const task = mirror.tasks[taskId];
+      if (!task) continue;
+      const live = liveTemplateHash(taskId);
+      expect(live, `task '${taskId}': live template hash is uncomputable`).not.toBeNull();
+      expect(
+        task.benchedPromptHash,
+        `task '${taskId}': the benched prompt hash no longer matches the live template — the prompt changed ` +
+          `since the benchmark was captured. Re-capture the mirror; do NOT edit the hash by hand.`,
+      ).toBe(live);
+    }
+  });
+
+  it('every registry task has a mirror entry (no silently unbenchable decision point)', () => {
+    for (const taskId of Object.keys(PROMPT_TEMPLATE_REGISTRY)) {
+      expect(
+        mirror.tasks[taskId],
+        `registry task '${taskId}' has no mirror entry — it can never be compared against a benched baseline`,
+      ).toBeDefined();
+    }
+  });
+
+  it('every mirror task carries at least one per-model baseline', () => {
+    for (const [taskId, task] of Object.entries(mirror.tasks)) {
+      const models = Object.keys(task.perModel ?? {});
+      expect(models.length, `mirror task '${taskId}' has no perModel baselines`).toBeGreaterThan(0);
+    }
+  });
+});
+
+/**
+ * The BEHAVIOURAL claim. String equality above is the mechanism; this is the
+ * consequence — with the sources agreeing the ladder gets PAST step 2 and can
+ * reach a real verdict, and with them disagreeing it cannot, no matter how good
+ * the evidence is.
+ */
+describe('the source match is what lets the ladder reach a real verdict', () => {
+  const HASH = 'a'.repeat(64);
+
+  function input(registrySourceMatches: boolean): VerdictInput {
+    return {
+      normalizedModel: 'gpt-5.5',
+      mirrorPresent: true,
+      mirrorStaleDays: 1,
+      mirrorStalenessMaxDays: 30,
+      bench: { passRate: 0.96, passes: 27, deterministic: 28 },
+      benchedPromptHash: HASH,
+      liveHash: HASH,
+      registrySourceMatches,
+      windowPromptIds: ['p1'],
+      // Deliberately generous evidence: plenty of settled grades, no unknowns,
+      // no orphans, full coverage. Nothing but the source flag differs.
+      rightN: 180,
+      wrongN: 20,
+      decidedTotal: 200,
+      orphanShare: 0,
+      coverageComplete: true,
+      thresholds: {
+        divergenceThreshold: 0.1,
+        minSample: 20,
+        maxUnknownShare: 0.5,
+        maxOrphanShare: 0.2,
+      },
+    };
+  }
+
+  it('sources DISAGREE → precondition-failed/hash-unverifiable, however strong the evidence', () => {
+    const r = computeVerdict(input(false));
+    expect(r.verdict).toBe('precondition-failed');
+    expect(r.preconditionReason).toBe('hash-unverifiable');
+    // This was production for the detector's entire shipped life.
+  });
+
+  it('sources AGREE → a real, actionable verdict on the same evidence', () => {
+    const r = computeVerdict(input(true));
+    expect(r.verdict).not.toBe('precondition-failed');
+    expect(r.preconditionReason).toBeUndefined();
+    // 0.90 real vs 0.96 benched = 0.06 delta, inside the 0.10 threshold.
+    expect(r.verdict).toBe('aligned');
+    expect(r.realGradeRate).toBeCloseTo(0.9, 5);
+    expect(r.predictedRate).toBeCloseTo(0.96, 5);
+  });
+
+  it('and a genuinely worse real rate now surfaces as divergent-worse', () => {
+    const r = computeVerdict({ ...input(true), rightN: 120, wrongN: 80 });
+    expect(r.verdict).toBe('divergent-worse');
+  });
+});

--- a/upgrades/next/benchmark-source-match.md
+++ b/upgrades/next/benchmark-source-match.md
@@ -1,0 +1,70 @@
+## What Changed
+
+The Benchmark-Divergence Detector — which compares how a model performs in
+production against how it scored on its benchmark — has never produced a single
+actionable verdict since it shipped. It does now.
+
+Before comparing, the detector verifies that the benchmark it holds actually
+corresponds to the live prompt; if it can't confirm that, it declines to judge
+rather than blame a model for a test it never sat. That verification compares two
+strings for exact equality:
+
+- the mirror's `benchedPromptSource`: `src/core/MessagingToneGate.ts:TONE_GATE_PROMPT_TEMPLATE`
+- the registry's `source`: `src/core/MessagingToneGate.ts#TONE_GATE_PROMPT_TEMPLATE`
+
+A colon against a hash. One character, on both benchmarked tasks. So
+`registrySourceMatches` was `false` on every run, step 2 of the verdict ladder
+fired, and every comparison returned `precondition-failed / hash-unverifiable` —
+permanently.
+
+**It never looked broken.** `precondition-failed` is a legitimate, designed
+verdict: the correct answer when a benchmark is genuinely stale. The analysis
+pass completed cleanly, emitted a valid verdict, and never errored. A
+permanently blindfolded detector is output-identical to a correctly cautious one.
+
+Fixed: the mirror's two source strings now match the registry, and a CI ratchet
+(`tests/unit/benchmark-mirror-registry-agreement.test.ts`) asserts they stay
+identical — plus that the benched prompt hash still matches the live template,
+that every benchmarked task is registry-known, and that no task has empty
+baselines.
+
+**The comparison itself was deliberately not loosened.** Making `:` and `#`
+interchangeable would have hidden the symptom while weakening a real safety
+check — letting genuine benchmark/prompt mismatches through so the detector
+could confidently blame models for tests they never sat. The strict comparison is
+the guard. What was missing was anything keeping the two sides in step, and that
+absence — not the typo — was the defect.
+
+## Evidence
+
+- `tests/unit/benchmark-mirror-registry-agreement.test.ts` (9 cases): source
+  equality, hash-vs-live-template, registry↔mirror task coverage both ways,
+  non-empty baselines, a fixture-is-real guard against vacuity, and a
+  behavioural pair proving the ladder's outcome flips on `registrySourceMatches`
+  alone (identical evidence → `precondition-failed` vs `aligned`, plus
+  `divergent-worse` on a genuinely worse rate).
+- Mutation-tested: restoring the original `:` turns the ratchet red with a
+  message naming the separator.
+- Live hashes computed and compared against the mirror before changing anything
+  — they match, ruling out prompt drift as the cause.
+
+## What to Tell Your User
+
+If you've ever looked at the benchmark-divergence read and seen nothing useful,
+this is why: it wasn't quiet because everything agreed, it was quiet because it
+couldn't get past its own front door.
+
+Expect its first real answers to be modest — mostly "not enough evidence yet"
+until enough graded decisions accumulate. That's the system being careful, and
+this time for the right reason rather than because of a punctuation mismatch.
+
+Note this fix makes the detector *able* to answer; it doesn't turn it on. Whether
+findings get recorded is still governed by its dry-run setting.
+
+## Summary of New Capabilities
+
+- The Benchmark-Divergence Detector can reach a real verdict for the first time.
+- A build-time invariant keeps the benchmark mirror and the prompt registry in
+  step, so a one-character drift can never again silently disable the subsystem.
+- A drifted prompt hash now fails the build instead of quietly suppressing every
+  verdict.

--- a/upgrades/side-effects/benchmark-source-match.md
+++ b/upgrades/side-effects/benchmark-source-match.md
@@ -1,0 +1,144 @@
+# Side-effects review — benchmark-source-match
+
+**Change:** correct the two `benchedPromptSource` values in
+`src/data/benchmarkPredictions.json` (`:` → `#`) so they match the
+`PROMPT_TEMPLATE_REGISTRY` sources the analyzer compares them against, and add a
+CI ratchet that makes the mismatch unshippable.
+
+**Tier:** 1 (ELI16 + side-effects; a data correction plus a test — no new
+runtime code path).
+
+---
+
+## The defect in one paragraph
+
+`BenchmarkDivergenceAnalyzer.ts:423` computes
+`registrySourceMatches = task.benchedPromptSource === registryEntry.source`.
+The mirror wrote `src/core/MessagingToneGate.ts:TONE_GATE_PROMPT_TEMPLATE`; the
+registry declares `src/core/MessagingToneGate.ts#TONE_GATE_PROMPT_TEMPLATE`. So
+the flag was `false` for every task on every run, step 2 of the verdict ladder
+fired, and the Benchmark-Divergence Detector returned
+`precondition-failed / hash-unverifiable` for its entire shipped life. It has
+never produced a single actionable verdict. Verified directly against the live
+constants before changing anything.
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+**At build time: one new way to fail, deliberately.** A mirror whose
+`benchedPromptSource` or `benchedPromptHash` disagrees with the registry now
+fails CI. That is the entire point, and both failure messages say exactly what to
+do (`the registry uses '#', not ':'` / `re-capture the mirror; do NOT edit the
+hash by hand`).
+
+**At runtime: nothing.** This *unblocks* — it removes a precondition failure that
+was firing on every comparison. No input that previously produced a verdict now
+produces a different one; inputs that produced `precondition-failed` may now
+produce a real verdict, which is the intent.
+
+## 2. Under-block — what failure modes does this still miss?
+
+- **The detector may now say very little for a while.** Getting past the
+  precondition does not manufacture evidence: most comparisons will land on
+  `insufficient-evidence` until enough graded decisions accumulate. Correct
+  behaviour, and worth stating so "it's still not saying much" isn't read as
+  this fix having failed.
+- **The mirror's per-model baselines are still whatever was last captured.** This
+  change does not re-capture them, and deliberately does not invent numbers for
+  models that were never benchmarked (see §6).
+- **Other silent-precondition classes remain possible.** `stale-mirror` and
+  `prompt-drifted` are real, legitimate states. The new hash test converts one of
+  them (drift) into a loud build failure, but a mirror that ages past its
+  staleness bound will still quietly suppress verdicts — the same shape of
+  problem, one layer out. Not fixed here; named honestly.
+
+## 3. Level-of-abstraction fit
+
+The fix is at the data layer because the data was wrong: the registry is
+documented as authoritative (`benchedPromptSource must match this string or Q0
+is hash-unverifiable`), so the mirror is what needed correcting.
+
+The *guard* is at the build layer, which is the right place for an invariant
+between two static files. It could not sensibly live at runtime — at runtime the
+mismatch is already indistinguishable from a legitimately stale benchmark, which
+is precisely why it survived.
+
+## 4. Signal vs authority compliance
+
+`docs/signal-vs-authority.md`. Unchanged, and deliberately so.
+
+The exact-match comparison in the analyzer is a **brittle check with real
+authority** — it suppresses verdicts. That is the documented exemption class: a
+false pass (comparing against a benchmark that does not describe the live
+prompt) produces confident wrong claims about a model, while a false block
+produces silence. Silence is the safe direction.
+
+**I explicitly rejected the tempting fix.** Normalising the comparison so `:` and
+`#` both match would have made the symptom disappear while weakening the guard —
+trading a visible failure for a silent one, and letting genuine
+benchmark/prompt mismatches through. The strict comparison stays; the mismatch
+becomes unshippable instead.
+
+The new test holds no runtime authority: it is a build-time assertion over two
+static files.
+
+## 5. Interactions
+
+- **The verdict ladder** — untouched. The change moves inputs past step 2; steps
+  3–9 behave exactly as before. Both branches are pinned by the new behavioural
+  tests (same evidence, `registrySourceMatches` false vs true →
+  `precondition-failed` vs `aligned`).
+- **`benchmarkDivergence.dryRun`** — orthogonal. This is why the detector never
+  *persisted* findings; the source mismatch is why it never *had* one worth
+  persisting. Fixing one without the other leaves the feature dark, and the
+  dryRun flip is the operator's, not this PR's.
+- **The tone-gate prompt** — I suspected my own 2026-07-25 tone-gate change had
+  drifted the prompt hash and caused this. It had not: both hashes match live.
+  The new hash test now makes that class of drift a build failure rather than a
+  silent suppression, so a future prompt edit cannot repeat the worry.
+- **No shadowing, no double-fire.** One comparison, one callsite.
+
+## 6. External surfaces
+
+- `GET /benchmark-divergence` — no shape change. `summary.byVerdict` and
+  `findings` may become non-empty for the first time; every finding remains
+  `advisory: true` and gates nothing.
+- No new route, config key, flag, env var, CLI surface, or message.
+- **No fabricated data.** The mirror's per-model numbers are untouched. Adding
+  `claude-opus-5` / `claude-fable-5` baselines requires actually running the
+  benchmark against those models; inventing plausible pass rates would poison
+  the exact comparison this change exists to enable. Out of scope here and
+  called out rather than quietly skipped.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Unified.** Both files are shipped source constants
+(`src/data/`, published in `package.json` `files[]`, compiled into `dist/`), so
+every machine holds byte-identical copies and computes the same
+`registrySourceMatches`. There is no per-machine state, no durable write, no
+notice, and no generated URL. The pool-merged read path is unaffected — peers
+merge computed findings, not raw sources.
+
+Before this fix the detector was uniformly blind across the fleet; after it, it
+is uniformly able to compare. The posture does not change, only the verdict.
+
+## 8. Rollback cost
+
+**Revert the commit.** No flag, no migration, no durable state, no agent-state
+repair. Reverting restores the permanent `precondition-failed` behaviour — i.e.
+the detector goes back to being silently blind, which is worth stating plainly
+because that state is indistinguishable from healthy caution from the outside.
+
+## Second-pass review
+
+**Not required** by the Phase-5 trigger list: no messaging/dispatch block-allow
+decision, no session lifecycle, no compaction path, no coherence gate, trust
+level, or idempotency check, and nothing named sentinel/guard/gate/watchdog. The
+change is a two-character data correction plus a build-time assertion, and every
+finding the affected subsystem emits is advisory by construction.
+
+The claim that matters was verified empirically rather than argued: the live
+hashes were computed and compared against the mirror (they match — my first
+hypothesis was wrong), the two source strings were printed and diffed, the
+ratchet was mutation-tested by restoring the original typo (it fails, naming the
+separator), and the behavioural pair proves the ladder's outcome flips on that
+flag alone.


### PR DESCRIPTION
## ELI16 — the benchmark checker that has never once checked anything

There's a system whose job is to tell us when a model does worse in real life
than it did on its benchmark. It has never given an answer. Not "gives bad
answers" — has never, since it shipped, produced a single real verdict.

Before it compares anything, it makes sure the benchmark it's holding actually
corresponds to what's running now. Prompts change; comparing against a benchmark
for a prompt that no longer exists would blame a model for a test it never sat.
So if it can't confirm the match, it refuses to judge. **That refusal is correct
behaviour** — which is the whole reason this went unnoticed.

Part of that confirmation compares two labels saying where the tested text
lives. One says `...MessagingToneGate.ts:TONE_GATE_PROMPT_TEMPLATE`. The other
says `...MessagingToneGate.ts#TONE_GATE_PROMPT_TEMPLATE`. A colon against a
hash. They're compared character by character, so they never match, so the
checker always concludes it can't verify what it's holding, so it always
declines. Every task, every run, forever.

Nothing errored. Nothing went red. The scheduled pass completed cleanly and
emitted a valid, designed verdict every time. A permanently blindfolded checker
produces exactly the same output as a correctly cautious one.

Fixed the character — and added a build check comparing those two labels, so
they can't silently drift apart again. **The typo was the bug; the absence of
anything comparing them was the defect.**

## UX impact declaration

- **Audience:** instar maintainers. No end-user surface.
- **Visible behavior change:** none in shape. `GET /benchmark-divergence` keeps
  its exact response contract; `summary.byVerdict` and `findings` may become
  non-empty for the first time. Every finding stays `advisory: true` and gates
  nothing. This makes the detector *able* to answer — it does not turn it on
  (persistence is still governed by its dry-run setting).
- **First contact:** a maintainer reading `GET /benchmark-divergence`, or a CI
  failure if the mirror and registry drift apart.
- **User-visible strings introduced:** none. The strings added are developer-facing
  test failure messages:
  - `"the mirror's benchedPromptSource must be byte-identical to the registry source... Note the separator: the registry uses '#', not ':'."`
  - `"the benched prompt hash no longer matches the live template — the prompt changed since the benchmark was captured. Re-capture the mirror; do NOT edit the hash by hand."`
  - `"registry task '...' has no mirror entry — it can never be compared against a benched baseline"`
- **Rollback:** revert. No flag, no migration, no durable state. Worth saying
  plainly: reverting returns the detector to being *silently* blind, a state
  indistinguishable from healthy caution.

## The fix I deliberately did not make

Normalising the comparison so `:` and `#` both match. That hides the symptom and
weakens a real guard — genuine benchmark/prompt mismatches would then pass, and
the detector would confidently blame models for tests they never sat. Confident
garbage is worse than honest silence. The strict comparison is the guard; the
mismatch is now unshippable instead.

## Evidence

- 9 cases in `tests/unit/benchmark-mirror-registry-agreement.test.ts`: source
  equality, benched-hash vs live template, registry↔mirror coverage in both
  directions, non-empty baselines, and a fixture-is-real guard so the file can't
  go vacuously green.
- **Behavioural proof, not just string equality:** identical evidence with
  `registrySourceMatches` false vs true yields `precondition-failed` vs
  `aligned`; a genuinely worse real rate yields `divergent-worse`. The claim
  under test is the outcome.
- Mutation-tested: restoring the original `:` turns the ratchet red with a
  message naming the separator.
- I suspected my own tone-gate prompt change had drifted the hash and checked
  first — it hadn't. Live hashes match the mirror. Computed before concluding.

## Not done, deliberately

The mirror's per-model baselines are untouched. Adding `claude-opus-5` /
`claude-fable-5` requires actually running the benchmark against them; inventing
plausible pass rates would poison the very comparison this enables. Called out
rather than quietly skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsMJxSBBPAeDo8bXdunVtC
