### PR TITLE
[HOLD: needs spec+ceremony] fix(relay): tone-advisory remediation prints a runnable command

### DIFF
--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -14302,6 +14302,14 @@ process.stdin.on('end', async () => {
    */
   // eslint-disable-next-line @typescript-eslint/naming-convention
   public static readonly TELEGRAM_REPLY_PRIOR_SHIPPED_SHAS: ReadonlySet<string> = new Set([
+    // Pre-advisory-flag-position version: the tone-advisory remediation named
+    // only the FLAGS, and the script's parse loop breaks at the first
+    // positional — so `telegram-reply.sh TOPIC --tone-complied RULE` swallowed
+    // the flags as MESSAGE TEXT (ignoring stdin) and drew a second, nonsensical
+    // advisory. Adding this SHA so the guard + full-command advisory reach
+    // already-deployed copies instead of producing a `.new` candidate.
+    // Shipped through 2026-07-25.
+    'a2cf02154a6023725f15480a575f54a5231278c70396cd12051b7d7055b72d98',
     // Tier-1 initial-init shipped version. Shipped at 362ff59d.
     '98f70b86856e37f2719c39ecec152adf07ec30ce73c8134ab831b35c5b1c25b3',
     // Rebrand to Instar (no behavioral change). Shipped at 686f5758.

--- a/src/templates/scripts/telegram-reply.sh
+++ b/src/templates/scripts/telegram-reply.sh
@@ -133,6 +133,22 @@ if [ -z "$TOPIC_ID" ]; then
   exit 1
 fi
 
+# Flags must PRECEDE the topic id (the parse loop above breaks at the first
+# positional). A flag appearing here would otherwise be swallowed as MESSAGE
+# TEXT — and stdin would be ignored — so an advisory remediation typed as
+# `telegram-reply.sh TOPIC --tone-complied RULE` silently sent the control text
+# as the message and drew a second, nonsensical advisory. Refuse loudly instead.
+for _arg in "$@"; do
+  case "$_arg" in
+    --tone-ack|--tone-reason|--tone-complied|--tone-decision-ref|--ack-advisory|--format|--format=*|--stdin-base64|--base64-stdin)
+      echo "Flag '$_arg' appeared AFTER the topic id, where it would be treated as message text." >&2
+      echo "Flags must come BEFORE the topic id. Correct form:" >&2
+      echo "  cat <<'EOF' | telegram-reply.sh $_arg [value] $TOPIC_ID" >&2
+      exit 2
+      ;;
+  esac
+done
+
 # Read message from args or stdin
 if [ $# -gt 0 ]; then
   MSG="$*"
@@ -500,8 +516,12 @@ elif [ "$HTTP_CODE" = "422" ]; then
     echo "  Issue: $ISSUE" >&2
     [ -n "$SUGGESTION" ] && echo "  Suggestion: $SUGGESTION" >&2
     [ -n "$TONE_REF" ] && echo "  decisionRef: $TONE_REF" >&2
-    echo "  AGREE  → revise, then re-run with: --tone-complied ${TONE_RULE:-RULE}${TONE_REF:+ --tone-decision-ref $TONE_REF}" >&2
-    echo "  DISAGREE → re-run unchanged with: --tone-ack ${TONE_RULE:-RULE} --tone-reason \"why the nudge is wrong here\"${TONE_REF:+ --tone-decision-ref $TONE_REF}" >&2
+    # Print the FULL command with the flags BEFORE the topic id. Naming only the
+    # flags invited them to be appended after it, where they become message text.
+    echo "  AGREE  → revise, then re-run (flags BEFORE the topic id):" >&2
+    echo "      cat <<'EOF' | $0 --tone-complied ${TONE_RULE:-RULE}${TONE_REF:+ --tone-decision-ref $TONE_REF} $TOPIC_ID" >&2
+    echo "  DISAGREE → re-run unchanged (flags BEFORE the topic id):" >&2
+    echo "      cat <<'EOF' | $0 --tone-ack ${TONE_RULE:-RULE} --tone-reason \"why the nudge is wrong here\"${TONE_REF:+ --tone-decision-ref $TONE_REF} $TOPIC_ID" >&2
     [ -n "$HOW_TO" ] && echo "  $HOW_TO" >&2
     # exit 1 (not 0): the message genuinely did NOT send, and a caller that
     # treats 0 as delivered would drop it silently. The wording above is what

--- a/tests/unit/telegram-reply-advisory-script.test.ts
+++ b/tests/unit/telegram-reply-advisory-script.test.ts
@@ -35,6 +35,7 @@ function writeFakeCurl(opts: {
   preflightBody?: string;
   preflightExit?: number;
   sendHttpCode?: string;
+  sendBody?: string;
   sendExit?: number;
 }) {
   const shimDir = path.join(dir, 'bin');
@@ -51,7 +52,7 @@ case "$url" in
     ${opts.preflightExit ? `exit ${opts.preflightExit}` : `printf '%s' '${(opts.preflightBody ?? '{"advisories":[]}').replace(/'/g, "'\\''")}'`}
     ;;
   */telegram/reply/*)
-    ${opts.sendExit ? `printf '\\n000'; exit ${opts.sendExit}` : `printf '{"ok":true,"messageId":7}\\n${opts.sendHttpCode ?? '200'}'`}
+    ${opts.sendExit ? `printf '\\n000'; exit ${opts.sendExit}` : `printf '%s' '${(opts.sendBody ?? '{"ok":true,"messageId":7}').replace(/'/g, "'\\''")}'; printf '\\n${opts.sendHttpCode ?? '200'}'`}
     ;;
   *)
     printf ''
@@ -357,5 +358,62 @@ describe('send failure outcome contract', () => {
     expect(stderr).toContain('AMBIGUOUS: Telegram relay transport ended without an HTTP outcome (curl 7).');
     const dbPath = path.join(dir, '.instar', 'state', 'pending-relay.echo.sqlite');
     expect(fs.existsSync(dbPath)).toBe(false);
+  });
+});
+
+describe('flag position (advisory remediation must not become the message)', () => {
+  it('a --tone-* flag AFTER the topic id is refused loudly, not swallowed as message text', async () => {
+    // The parse loop breaks at the first positional, so anything after the
+    // topic id would land in the message body (and stdin would be ignored).
+    // That silently sent control text as the reply and drew a SECOND advisory.
+    await expect(
+      execFileAsync('bash', [SCRIPT, '12476', '--tone-complied', 'B11_STYLE_MISMATCH'], {
+        cwd: dir,
+        env: { ...process.env, INSTAR_PORT: '4099', INSTAR_AUTH_TOKEN: 'tok' },
+      }),
+    ).rejects.toMatchObject({ code: 2 });
+  });
+
+  it('the refusal names the flag and shows the corrected order', async () => {
+    let stderr = '';
+    try {
+      await execFileAsync('bash', [SCRIPT, '12476', '--ack-advisory'], {
+        cwd: dir,
+        env: { ...process.env, INSTAR_PORT: '4099', INSTAR_AUTH_TOKEN: 'tok' },
+      });
+    } catch (err) {
+      stderr = (err as { stderr?: string }).stderr ?? '';
+    }
+    expect(stderr).toContain("Flag '--ack-advisory' appeared AFTER the topic id");
+    expect(stderr).toContain('Flags must come BEFORE the topic id');
+    expect(stderr).toContain('--ack-advisory');
+    expect(stderr).toContain('12476');
+  });
+
+  it('a tone advisory prints the FULL re-run command with flags before the topic id', async () => {
+    let stderr = '';
+    try {
+      await runScript({
+        env: AUTOMATED_ENV,
+        text: 'A dense stylized report with SHOUTY headers.',
+        curl: {
+          preflightBody: '{"advisories":[]}',
+          sendHttpCode: '422',
+          sendBody: JSON.stringify({
+            error: 'tone-gate-advisory',
+            rule: 'B11_STYLE_MISMATCH',
+            issue: 'too dense',
+            suggestion: 'plainer',
+            decisionRef: 'd-abc123',
+          }),
+        },
+      });
+    } catch (err) {
+      stderr = (err as { stderr?: string }).stderr ?? '';
+    }
+    // The remediation must be a runnable command whose flags PRECEDE 12476 —
+    // naming only the flags is what invited them to be appended after it.
+    expect(stderr).toMatch(/--tone-complied B11_STYLE_MISMATCH --tone-decision-ref d-abc123 12476/);
+    expect(stderr).toMatch(/--tone-ack B11_STYLE_MISMATCH[\s\S]*12476/);
   });
 });

--- a/upgrades/next/advisory-flag-position.md
+++ b/upgrades/next/advisory-flag-position.md
@@ -1,0 +1,25 @@
+## Tone-advisory remediation is now a runnable command (and a misplaced flag is refused, not sent)
+
+**Audience:** agent-only. **Maturity:** stable.
+
+When the outbound tone gate nudges a message, its advisory tells the sender how to
+re-run. It named only the FLAGS (`--tone-complied RULE --tone-decision-ref REF`)
+without saying where they go — and `telegram-reply.sh` parses flags only BEFORE the
+positional topic id, breaking its parse loop at the first positional.
+
+So the natural reading, `telegram-reply.sh TOPIC --tone-complied RULE`, silently
+treated the flags as the MESSAGE TEXT (stdin ignored) and sent control text to the
+user's conversation. The gate then reviewed that control text and issued a second,
+nonsensical advisory — which reads like the gate malfunctioning rather than a usage
+error.
+
+Two changes:
+
+1. **The advisory now prints the full runnable command**, flags before the topic id,
+   for both the AGREE and DISAGREE paths.
+2. **A known flag appearing after the topic id is refused** with exit 2, naming the
+   flag and showing the corrected order — instead of being swallowed as message text.
+
+Found by hitting it live on the first real advisory after the advisory migration
+shipped. Migration parity: the outgoing template SHA is recorded in the
+prior-shipped set, so deployed copies upgrade instead of producing a `.new` candidate.

--- a/upgrades/side-effects/advisory-flag-position.md
+++ b/upgrades/side-effects/advisory-flag-position.md
@@ -1,0 +1,18 @@
+# Side effects — advisory flag position
+
+- **Behavior change (agent-facing):** `telegram-reply.sh` now exits 2 when
+  `--tone-ack|--tone-reason|--tone-complied|--tone-decision-ref|--ack-advisory|--format|--stdin-base64`
+  appears AFTER the topic id. Previously such an argument became the message body.
+  A caller that RELIED on that accident (sending a literal `--tone-complied …`
+  string as a message) now fails loudly. No such caller exists in-tree.
+- **Output change:** the `tone-gate-advisory` and DISAGREE lines now print a full
+  command including the topic id. Anything parsing those two lines by exact prefix
+  would need to re-read them; they are human/agent-facing guidance, not a machine contract.
+- **Migration:** the outgoing shipped SHA (`a2cf0215…`) is added to
+  `TELEGRAM_REPLY_PRIOR_SHIPPED_SHAS`, so existing agents' copies are backed up and
+  overwritten on update rather than left behind with a `.new` candidate.
+- **Rollback:** revert the template + the SHA entry; deployed copies revert on the
+  next migration by the same SHA-history path.
+- **Test surface:** three new cases in `telegram-reply-advisory-script.test.ts`, plus
+  a `sendBody` option on the fake-curl shim — which is what makes the 422 advisory
+  branches testable at all (they were previously unreachable in that harness).


### PR DESCRIPTION
## ELI16

When one of my messages gets nudged for tone, the nudge tells me how to re-send it. It listed the two extra words to add to the command, but not where to put them — and the command only accepts them in one specific place, before the conversation number. Put them anywhere else and they stop being instructions and quietly become the message itself.

That is exactly what happened to me tonight, live: I followed the nudge, and my reply to the user turned into two lines of internal control text. The tone check then read THAT and complained, quite reasonably, that my message was just internal control text — which looks like the check malfunctioning when in fact it was doing its job on the wrong input. One round trip wasted, and on a worse night it would have sent gibberish to a person.

Two fixes. The nudge now prints the whole command, correctly ordered, so there is nothing to guess. And if one of those words does end up in the wrong place, the command now stops and says so, instead of silently mailing it to somebody.

The general rule worth keeping: an instruction that says what to add but not where to put it is incomplete, and a program that accepts a misplaced instruction as data turns a typo into a delivered mistake.

## What changed

- `tone-gate-advisory` (and the DISAGREE branch) print the full runnable command with flags BEFORE the topic id.
- A known flag (`--tone-*`, `--ack-advisory`, `--format`, `--stdin-base64`) appearing AFTER the topic id exits 2, naming the flag and showing the corrected order, instead of becoming message text.
- **Migration parity:** the outgoing template SHA joins `TELEGRAM_REPLY_PRIOR_SHIPPED_SHAS`, so deployed agents' copies are backed up and overwritten on update instead of being left behind with a `.new` candidate.
- **Tests:** three cases against the REAL shipped template, plus a `sendBody` option on the fake-curl shim — which is what makes the 422 advisory branches reachable in that harness at all. 18/18 in that file; the three sibling relay/migrator files are green.

## Who sees this and what changes for them

Agents, not end users. An agent that follows an advisory now gets a command that works the first time; an agent that misplaces a flag gets a clear refusal instead of accidentally sending control text to a person. Nothing changes for a message that was never flagged.

## Found how

By hitting it live on the first real advisory after the advisory migration shipped hours earlier — the argument for driving a new feature through its real surface immediately rather than trusting its tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh2Eb2Yhn54obcsaGhm7kp
