### PR TITLE
fix(scheduler): a future-dated job fired at the next boot — the comment had the rule, the code didn't

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T11-06-57-741Z-scheduler-never-run-window.json
+++ b/.instar/instar-dev-decisions/2026-07-25T11-06-57-741Z-scheduler-never-run-window.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T11:06:57.741Z",
+  "slug": "scheduler-never-run-window",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 72,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/scheduler-never-run-window.eli16.md
+++ b/docs/specs/scheduler-never-run-window.eli16.md
@@ -1,0 +1,96 @@
+# The reminder that goes off the moment you set it — plain English
+
+## The one-sentence version
+
+Any newly created scheduled job fires immediately the next time the server
+restarts — even one set for months in the future — because the startup check
+that looks for jobs that missed their turn couldn't tell "brand new" apart from
+"long overdue," and guessed.
+
+## What the startup check is for
+
+When the server has been off for a while, some scheduled work will have been
+missed. The daily 4am job doesn't run if the machine was asleep at 4am. So at
+startup there's a sweep: look at everything scheduled, work out what should
+already have happened, and run those now rather than waiting another full day.
+
+Sensible. The problem is how it decides.
+
+## The mistake
+
+To know whether a job missed its turn, the check compares *now* against *the
+last time it ran*. Fine for a job with a history.
+
+But what about a job that has never run at all? There's no last-run time to
+compare against. The code hits that case and does this:
+
+> "No record of it running? Then it's overdue. Run it."
+
+Which is right for a job that was added while the machine was off and quietly
+slept through its window. And catastrophically wrong for a job created five
+minutes ago whose first scheduled moment is in December — because "has never
+run" describes both of those equally well.
+
+So: you set a reminder for December. The server restarts that evening. The
+reminder fires. It's now been delivered, months early, and it will never fire
+again, because it has run.
+
+## The part that bothers me most
+
+The comment directly above that code says what it's *supposed* to do:
+
+> *"Jobs that have never run: trigger on startup if their first expected run
+> time has already passed."*
+
+That's exactly the correct rule. Someone knew. It just isn't what the code does
+— the code skips the "if" entirely and triggers unconditionally. The intent was
+written down and never enforced, which is the whole difference between a
+comment and a check.
+
+There's a second tell. The scheduler's own test file starts every test by
+pretending each job has already run once, with the note *"so the startup check
+doesn't trigger jobs at startup."* The tests were built to step around this
+behaviour. It was known well enough to work around and never recognised as a
+bug.
+
+## Why it couldn't check its own rule
+
+To ask "has its first scheduled time already passed?" you need to know when the
+job started existing. Nothing recorded that. The system knew when each job last
+*ran*, and nothing else — so for a job that had never run, there was no fact to
+reason from, and the code fell back to a guess.
+
+## The fix
+
+Write down when each job is first registered. Then the rule the comment always
+described becomes checkable: a job that has never run counts as overdue only if
+it has existed longer than the gap between its own runs.
+
+- A reminder created today for December has existed for minutes. Its gap is a
+  year. Not overdue — it waits, correctly.
+- A job that was added a day ago, runs every four hours, and still hasn't run,
+  has genuinely slept through six windows. It catches up, exactly as before.
+
+When the information is missing entirely — a job whose record predates this
+change — it does nothing rather than guess. A skipped catch-up costs one delayed
+run. Guessing wrong costs a reminder that fires early and looks delivered, which
+is worse than one that never fires at all: you'd never go looking for it.
+
+## Why this came up now
+
+It's a prerequisite for something you asked for: when you tell me you'll check
+in on something by a date, that should become a real scheduled reminder rather
+than an intention I'm holding. That reminder rides this scheduler. Building it
+on a scheduler that fires future-dated jobs at boot would produce reminders that
+mark themselves delivered before the date arrives — worse than not having built
+it. This is the floor that had to be solid first.
+
+## What you'd notice
+
+Nothing changes for jobs that already run normally. What stops happening is the
+odd unexplained "why did that just run?" after a restart.
+
+One honest note: a job that's been sitting unrun for less than one of its own
+cycles will now wait for its next proper turn instead of firing at startup. That
+delay is the intended behaviour — it's the difference between "scheduled" and
+"whenever we happen to reboot."

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -661,6 +661,21 @@ export interface AgentMdExecute {
 
 export interface JobState {
   slug: string;
+  /**
+   * When this job was first REGISTERED with the scheduler (ISO). Distinct from
+   * `lastRun`: it answers "how long has this job existed?" for a job that has
+   * never run.
+   *
+   * WHY IT EXISTS: the startup missed-job sweep treated every job with no
+   * `lastRun` as overdue, so a brand-new job whose first window was months away
+   * fired immediately on the next boot (ACT-724 defect (a) — an annual reminder
+   * discharged itself the day it was created). The intended rule was already
+   * written in the comment above that branch — "trigger on startup if their
+   * first expected run time has already passed" — but nothing recorded when the
+   * job started existing, so the condition was uncheckable and the code simply
+   * fired everything. This is the missing fact.
+   */
+  firstSeenAt?: string;
   lastRun?: string;
   lastResult?: 'success' | 'failure' | 'timeout' | 'pending';
   /** Error message from the last failure (cleared on success) */

--- a/src/scheduler/JobScheduler.ts
+++ b/src/scheduler/JobScheduler.ts
@@ -399,6 +399,28 @@ export class JobScheduler {
           }
         });
         this.cronTasks.set(job.slug, task);
+
+        // Stamp when this job STARTED EXISTING, once. The startup missed-job
+        // sweep needs it to tell "brand-new, its window simply hasn't come yet"
+        // apart from "has been sitting here unrun through window after window".
+        // Without it the sweep could only see "no lastRun" and fired both alike
+        // (ACT-724 defect (a)). Never overwritten, so the age is real.
+        const existing = this.state.getJobState(job.slug);
+        if (!existing?.firstSeenAt) {
+          try {
+            this.state.saveJobState({
+              slug: job.slug,
+              consecutiveFailures: 0,
+              ...(existing ?? {}),
+              firstSeenAt: new Date().toISOString(),
+            });
+          } catch (err) {
+            // A bookkeeping write must never stop the scheduler from starting.
+            // Missing firstSeenAt degrades SAFE: the sweep declines to treat the
+            // job as missed (see checkMissedJobs) rather than firing it blind.
+            console.error(`[scheduler] Could not stamp firstSeenAt for "${job.slug}": ${err}`);
+          }
+        }
       } catch (err) {
         console.error(`[scheduler] Invalid cron expression for job "${job.slug}": ${job.schedule} — ${err instanceof Error ? err.message : err}`);
       }
@@ -1906,23 +1928,38 @@ export class JobScheduler {
       const task = this.cronTasks.get(job.slug);
       if (!task) continue;
 
-      // Jobs that have never run: trigger on startup if their first expected
-      // run time has already passed (i.e., the job was added while the server
-      // was down and missed its first scheduled window).
-      if (!jobState?.lastRun) {
-        // Use a large overdueRatio so never-run jobs sort below truly-overdue jobs
-        missedJobs.push({ job, overdueRatio: 1.5 });
-        continue;
-      }
-
-      const lastRun = new Date(jobState.lastRun).getTime();
-
       // Get expected interval from next two runs
       const nextRun = task.nextRun();
       const nextNextRun = task.nextRuns(2)[1];
       if (!nextRun || !nextNextRun) continue;
 
       const intervalMs = nextNextRun.getTime() - nextRun.getTime();
+
+      // Jobs that have never run: trigger on startup ONLY if their first
+      // expected run time has already passed — i.e. the job has existed for
+      // longer than one full interval without ever running, so a window really
+      // did go by. That was always the intended rule (it is stated in the
+      // comment this replaces), but nothing recorded when a job started
+      // existing, so the branch could not check it and fired EVERY never-run
+      // job instead. A reminder scheduled for December discharged itself on the
+      // next boot (ACT-724 defect (a)).
+      //
+      // Fails SAFE in both unknown cases: a job with no firstSeenAt (legacy
+      // state written before this field existed) is treated as not-missed. The
+      // cost is one skipped catch-up; the cost of guessing the other way is a
+      // future-dated job firing early, which is indistinguishable from the
+      // reminder having been delivered.
+      if (!jobState?.lastRun) {
+        const firstSeen = jobState?.firstSeenAt ? new Date(jobState.firstSeenAt).getTime() : null;
+        if (firstSeen === null || Number.isNaN(firstSeen)) continue;
+        const ageMs = now - firstSeen;
+        if (ageMs <= intervalMs) continue; // its window genuinely hasn't come yet
+        // Use a large overdueRatio so never-run jobs sort below truly-overdue jobs
+        missedJobs.push({ job, overdueRatio: 1.5 });
+        continue;
+      }
+
+      const lastRun = new Date(jobState.lastRun).getTime();
       const timeSinceLastRun = now - lastRun;
 
       // If overdue by more than 1.5x the interval, mark as missed

--- a/tests/unit/job-scheduler-edge.test.ts
+++ b/tests/unit/job-scheduler-edge.test.ts
@@ -239,16 +239,39 @@ describe('JobScheduler edge cases', () => {
   });
 
   describe('missed job detection', () => {
-    it('triggers jobs that have never run on startup', async () => {
-      // Jobs with no prior run history should be triggered at startup,
-      // not silently skipped because checkMissedJobs requires lastRun.
+    it('triggers a never-run job that has genuinely outlived its interval', async () => {
+      // The concern this test was written for is real: a job added while the
+      // server was down must not be silently skipped forever because
+      // checkMissedJobs keys on lastRun.
+      //
+      // It previously asserted that ANY never-run job fires at startup, which
+      // was the over-correction — a job whose first window is months away then
+      // discharges itself on the next boot (ACT-724 defect (a)). The intent is
+      // preserved here by representing the actual scenario: a job that has
+      // EXISTED for longer than its own interval without ever running. That
+      // one really did miss a window, and still catches up.
       createScheduler([makeJob('never-ran', { schedule: '0 */4 * * *' })], { startupGraceMs: 0 });
+      project.state.saveJobState({
+        slug: 'never-ran',
+        firstSeenAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // a day ago
+        consecutiveFailures: 0,
+      } as any);
       scheduler.start();
       await new Promise(r => setTimeout(r, 50));
 
       // The job should have been triggered as a "missed" job
       expect(mockSM._spawnCount).toBe(1);
       expect(mockSM._lastSpawnArgs?.name).toContain('never-ran');
+    });
+
+    it('does NOT trigger a never-run job whose first window has not arrived', async () => {
+      // The other side of the boundary, which nothing asserted before: a job
+      // registered moments ago waits for its schedule instead of firing now.
+      createScheduler([makeJob('brand-new', { schedule: '0 */4 * * *' })], { startupGraceMs: 0 });
+      scheduler.start();
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(mockSM._spawnCount).toBe(0);
     });
   });
 

--- a/tests/unit/job-scheduler-never-run-future-job.test.ts
+++ b/tests/unit/job-scheduler-never-run-future-job.test.ts
@@ -1,0 +1,135 @@
+/**
+ * A never-run job scheduled for the FUTURE must not fire at startup.
+ *
+ * THE DEFECT (ACT-724 motivating defect (a), observed 2026-07-17 on the
+ * hand-built benchmark-checkin-reminder): the startup missed-job sweep treats
+ * *every* job with no `lastRun` as missed —
+ *
+ *     if (!jobState?.lastRun) {
+ *       missedJobs.push({ job, overdueRatio: 1.5 });
+ *       continue;
+ *     }
+ *
+ * — so a brand-new job whose first scheduled window is months away is triggered
+ * immediately on the next boot. A reminder set for December fires today.
+ *
+ * The comment directly above that branch says the intended rule out loud:
+ * "trigger on startup IF THEIR FIRST EXPECTED RUN TIME HAS ALREADY PASSED."
+ * The code never checks that condition. The prose is right and the structure
+ * does not implement it.
+ *
+ * Corroboration that this is real and long-known: tests/unit/JobScheduler.test.ts
+ * pre-seeds `lastRun` in `beforeEach` with the comment "so checkMissedJobs
+ * doesn't trigger jobs at startup" — the suite works around the behaviour as a
+ * fixture quirk rather than reporting it as a bug.
+ *
+ * This matters beyond the annoyance: ACT-724 requires date-bearing commitments
+ * to materialize a one-shot reminder on the scheduler. A reminder that fires at
+ * boot instead of on its date is worse than no reminder, because it looks
+ * delivered.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { JobScheduler } from '../../src/scheduler/JobScheduler.js';
+import { createTempProject, createMockSessionManager, createSampleJobsFile } from '../helpers/setup.js';
+import type { TempProject, MockSessionManager } from '../helpers/setup.js';
+import type { JobSchedulerConfig } from '../../src/core/types.js';
+
+describe('startup missed-job sweep — never-run jobs', () => {
+  let project: TempProject;
+  let mockSM: MockSessionManager;
+  let scheduler: JobScheduler | undefined;
+  let jobsFile: string;
+
+  /** A jobs file with one job on the given cron, deliberately never run. */
+  function writeJobsFile(slug: string, schedule: string): string {
+    return createSampleJobsFile(project.stateDir, [
+      {
+        slug,
+        name: slug,
+        description: `test job ${slug}`,
+        schedule,
+        priority: 'medium',
+        expectedDurationMinutes: 1,
+        model: 'haiku',
+        enabled: true,
+        execute: { type: 'prompt', value: 'noop' },
+      },
+    ] as any);
+  }
+
+  beforeEach(() => {
+    project = createTempProject();
+    mockSM = createMockSessionManager();
+    // NOTE: deliberately NO lastRun pre-seeding — that workaround is what has
+    // been hiding this behaviour.
+  });
+
+  afterEach(() => {
+    scheduler?.stop();
+    scheduler = undefined;
+    project.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  function makeConfig(over?: Partial<JobSchedulerConfig>): JobSchedulerConfig {
+    return {
+      jobsFile,
+      enabled: true,
+      maxParallelJobs: 2,
+      quotaThresholds: { normal: 50, elevated: 70, critical: 85, shutdown: 95 },
+      startupGraceMs: 0,
+      ...over,
+    } as JobSchedulerConfig;
+  }
+
+  async function startAndSettle(): Promise<string[]> {
+    scheduler = new JobScheduler(makeConfig(), mockSM as any, project.state, project.stateDir);
+    const triggered: string[] = [];
+    const orig = (scheduler as any).triggerJob.bind(scheduler);
+    vi.spyOn(scheduler as any, 'triggerJob').mockImplementation(async (slug: string, reason: string) => {
+      triggered.push(`${slug}:${reason}`);
+      return undefined; // do not actually spawn anything
+    });
+    void orig;
+    await scheduler.start();
+    // The startup sweep is fired without await inside start(); let it drain.
+    await new Promise((r) => setTimeout(r, 250));
+    return triggered;
+  }
+
+  it('does NOT fire a never-run ANNUAL job whose next window is months away', async () => {
+    // 03:00 on 1 December — for most of the year this is far in the future.
+    jobsFile = writeJobsFile('year-away-reminder', '0 3 1 12 *');
+    const triggered = await startAndSettle();
+    expect(
+      triggered,
+      'a brand-new future-dated job must wait for its date, not fire at the next boot',
+    ).toEqual([]);
+  });
+
+  it('does NOT fire a never-run DAILY job that was only just registered', async () => {
+    jobsFile = writeJobsFile('fresh-daily', '0 4 * * *');
+    const triggered = await startAndSettle();
+    expect(triggered).toEqual([]);
+  });
+
+  it('DOES still fire a never-run job that has genuinely outlived a full interval', async () => {
+    // The catch-up behaviour the branch exists for must survive: a job that has
+    // been registered for longer than its own interval without ever running has
+    // really missed a window. Seed firstSeenAt far in the past to represent it.
+    jobsFile = writeJobsFile('long-overdue', '*/5 * * * *'); // every 5 minutes
+    project.state.saveJobState({
+      slug: 'long-overdue',
+      firstSeenAt: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(), // 6h ago
+      runCount: 0,
+      consecutiveFailures: 0,
+    } as any);
+    const triggered = await startAndSettle();
+    expect(
+      triggered.some((t) => t.startsWith('long-overdue:')),
+      'a job registered 6h ago on a 5-minute cron that has never run HAS missed windows',
+    ).toBe(true);
+  });
+});

--- a/upgrades/next/scheduler-never-run-window.md
+++ b/upgrades/next/scheduler-never-run-window.md
@@ -1,0 +1,65 @@
+## What Changed
+
+A newly created scheduled job fired immediately on the next server restart —
+including one scheduled months ahead.
+
+At startup the scheduler sweeps for work that was missed while the machine was
+off. To decide, it compares now against the job's last run. For a job that has
+**never** run there is no last run, and the code resolved that case by treating
+it as overdue and triggering it. That is right for a job added while the server
+was down that slept through its window, and wrong for a job created minutes ago
+whose first window is in December — "has never run" describes both identically.
+
+The comment directly above that branch stated the correct rule —
+
+> *"Jobs that have never run: trigger on startup if their first expected run
+> time has already passed"*
+
+— and the code never checked the condition. It couldn't: nothing recorded when a
+job started existing, so there was no fact to reason from.
+
+`JobState.firstSeenAt` is now stamped once at registration, and the sweep applies
+the intended rule: a never-run job is missed only if it has existed longer than
+one of its own intervals. A December reminder created today waits; a job that has
+sat unrun through six four-hour windows still catches up.
+
+Every unknown resolves to **not firing** — missing or unparseable `firstSeenAt`,
+uncomputable interval. That asymmetry is deliberate: a skipped catch-up costs one
+delayed run, while a future-dated job that fires early marks itself delivered and
+never fires again, so nobody goes looking for it.
+
+**Why now:** this is the prerequisite for dated commitments materializing real
+scheduled reminders (ACT-724). A reminder built on a scheduler that fires
+future-dated jobs at boot would discharge itself before its date — worse than
+never having built it. The standard itself is not in this change.
+
+## Evidence
+
+- `tests/unit/job-scheduler-never-run-future-job.test.ts` (3 cases): a never-run
+  annual job and a freshly-registered daily job both stay at zero triggers; a job
+  registered 6h ago on a 5-minute cron still catches up. Written failing first —
+  the two "must not fire" cases failed against the old code, the catch-up case
+  already passed.
+- `tests/unit/job-scheduler-edge.test.ts`: the existing test that asserted the
+  buggy behaviour was **updated, not deleted** — it now seeds `firstSeenAt` in the
+  past so it exercises the scenario it was written for (a job that genuinely
+  missed windows), plus a new sibling pinning the other side of the boundary.
+- Full scheduler suite: 76 tests across 8 files, green.
+
+## What to Tell Your User
+
+If you've ever seen a scheduled job run for no obvious reason shortly after a
+restart, this was probably it.
+
+The practical effect: reminders and scheduled work now happen when they're
+scheduled, not when the server next happens to reboot. A job that's been waiting
+less than one of its own cycles will now wait for its proper turn rather than
+firing at startup — that delay is the point.
+
+## Summary of New Capabilities
+
+- Scheduled jobs with a future first window are no longer discharged at server
+  startup.
+- Job state records when a job was first registered, so "brand new" and "long
+  overdue" are distinguishable facts rather than a guess.
+- The startup sweep fails toward not-running on every uncertainty.

--- a/upgrades/side-effects/scheduler-never-run-window.md
+++ b/upgrades/side-effects/scheduler-never-run-window.md
@@ -1,0 +1,156 @@
+# Side-effects review — scheduler-never-run-window
+
+**Change:** the startup missed-job sweep no longer treats every job with no
+`lastRun` as overdue. A new `JobState.firstSeenAt`, stamped once at
+registration, lets it apply the rule its own comment already described: a
+never-run job is missed only if it has existed longer than one of its own
+intervals.
+
+**Motivation:** ACT-724 defect (a) — a hand-built future-dated reminder job
+discharged itself on the next boot. This is the prerequisite for the ACT-724
+standard proper (dated commitments materializing one-shot reminders); that
+standard is NOT in this change.
+
+---
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+**One real, deliberate narrowing.** A never-run job that has existed for *less*
+than one interval is no longer triggered at startup. It waits for its next cron
+window instead.
+
+That is the intended behaviour — it is the difference between "scheduled" and
+"whenever we happen to reboot" — but it is a genuine behaviour change and the
+cost is honest: on a machine that restarts frequently, a newly-added job may now
+first run at its scheduled time rather than within seconds of being added.
+
+**Legacy state is also narrowed.** A job whose state predates `firstSeenAt` and
+has no `lastRun` is treated as not-missed rather than fired. This affects the
+first boot after upgrade only: registration stamps `firstSeenAt` for every job
+that lacks it, so from the second boot the rule applies normally. Chosen
+deliberately — see §4.
+
+## 2. Under-block — what failure modes does this still miss?
+
+- **A job added while the server was down still can't be dated precisely.**
+  `firstSeenAt` is stamped when the scheduler first *sees* the job, not when its
+  file was written. A job created during a three-day outage is stamped at boot
+  and so waits up to one interval before catching up. Using file mtime would be
+  more precise and less trustworthy (mtime changes on unrelated edits, syncs,
+  and checkouts). Named rather than silently accepted.
+- **Interval is inferred from the next two cron occurrences.** For irregular
+  crons (`0 3 1 12 *`, `0 9 * * 1-5`) the gap between the next two runs is not a
+  constant period. It is a sound *lower-ish bound* for the comparison here, but
+  it is an approximation, and it is the same approximation the pre-existing
+  `lastRun` branch already relies on. Not made worse; not fixed either.
+- **Nothing yet asserts one-shot semantics.** ACT-724 asks for first-class
+  one-shot jobs. This change makes cron-scheduled future jobs safe at boot; a
+  true one-shot type (fire once, then retire) is still absent, and the reminder
+  feature will need it.
+
+## 3. Level-of-abstraction fit
+
+Right layer. The missing thing was a *fact* ("when did this job start
+existing?"), so the fix adds the fact at the point that knows it — registration
+— and the decision stays where it was, in the sweep.
+
+The alternative considered and rejected: seeding `lastRun` at registration.
+That would have suppressed the symptom with less code, but it lies — it records
+a run that never happened, corrupting run history, `runCount` semantics, and any
+future "when did this last actually execute?" question. A separate field keeps
+"registered" and "ran" as the distinct facts they are. ACT-724's own sketch
+floated the `lastRun`-seeding option; this is a deliberate departure from it.
+
+## 4. Signal vs authority compliance
+
+`docs/signal-vs-authority.md`. The sweep holds real authority — it *triggers
+jobs* — and it is deterministic, which is appropriate: "has this job existed
+longer than its interval?" is arithmetic over two timestamps, not a judgment.
+There are no competing signals to weigh.
+
+**The direction of failure is the load-bearing property.** Every unknown case
+now resolves to *not firing*: missing `firstSeenAt`, unparseable `firstSeenAt`,
+uncomputable interval. That is the safe direction, and asymmetrically so — a
+skipped catch-up costs one delayed run, while a wrongly-fired future job marks
+itself delivered and will never fire again, so nobody goes looking for it. A
+missed reminder that looks delivered is worse than one that is merely late.
+
+The registration write is wrapped: a bookkeeping failure logs and continues
+rather than preventing the scheduler from starting, and the absent field then
+degrades to not-firing.
+
+## 5. Interactions
+
+- **The `lastRun` branch** — untouched. Jobs with run history take the identical
+  path (`timeSinceLastRun > intervalMs * 1.5`).
+- **Priority sorting and trigger limits** — untouched; a never-run job that does
+  qualify still enters with `overdueRatio: 1.5` exactly as before.
+- **`tests/unit/JobScheduler.test.ts`** — its `beforeEach` pre-seeds `lastRun`
+  "so checkMissedJobs doesn't trigger jobs at startup". That workaround is now
+  unnecessary but remains harmless and was left alone; removing it is unrelated
+  churn in a file this change does not otherwise touch.
+- **`tests/unit/job-scheduler-edge.test.ts`** — one existing test asserted the
+  buggy behaviour ("triggers jobs that have never run on startup"). It was
+  written for a real concern (never-run jobs being skipped forever) and had
+  over-corrected. **Updated, not deleted:** it now seeds `firstSeenAt` a day in
+  the past so it exercises the scenario it was actually written for, and a
+  sibling test pins the other side of the boundary. Called out explicitly
+  because editing a test to make a change pass is exactly the move that needs
+  scrutiny.
+- **StateManager** — `firstSeenAt` is additive and optional; older state loads
+  unchanged, and no migration is required.
+
+## 6. External surfaces
+
+- No route, config key, flag, env var, CLI surface, message, or notification.
+- `JobState` gains one optional field, persisted in existing job-state files.
+  Additive; nothing reads it but the sweep.
+- **User-visible behaviour:** the disappearance of unexplained job runs after a
+  restart. No new output.
+- No timing dependence beyond what the sweep already had.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN** — `machine-local-justification: hardware-bound-resource`.
+
+Job run state is per-machine because job *execution* is per-machine: each
+machine runs its own scheduler over its own scoped jobs, and "when did this
+machine first register this job?" is inherently a fact about that machine's
+scheduler, not a fleet fact. Replicating it would be actively wrong — machine B
+adopting machine A's `firstSeenAt` would make a job that B has never registered
+appear to have existed for days, re-creating the immediate-fire bug through the
+mesh.
+
+This is inherited, not introduced: `JobState` (`lastRun`, `runCount`,
+`consecutiveFailures`) is already machine-local for the same reason, and this
+field joins it. No new cross-machine surface, no notice, no durable shared
+state.
+
+## 8. Rollback cost
+
+**Revert the commit.** Reverting restores the fire-everything behaviour; the
+orphaned `firstSeenAt` values in job-state files are ignored by the old code and
+harmless. No migration, no data repair, no flag.
+
+## Second-pass review
+
+**Required** — this touches session/job lifecycle (it decides whether a job is
+triggered), which is on the Phase-5 trigger list.
+
+Self-review, recorded rather than skipped, with the two things I went looking
+for:
+
+1. **Did I make a test pass by weakening it?** One existing test was changed.
+   It asserted "any never-run job fires at startup" — the exact behaviour being
+   fixed — so it could not survive intact. I preserved its *intent* (a never-run
+   job must not be skipped forever) by giving it a past `firstSeenAt`, and added
+   the missing opposite-side assertion. The suite ends with strictly more
+   coverage of this boundary than it had: 2 tests where there was 1, plus 3 in a
+   dedicated file.
+2. **Is the new failure direction actually safe?** Every uncertain path leads to
+   "don't fire". The worst case is a delayed run; the previous worst case was a
+   reminder silently discharging itself early. Verified by test rather than
+   asserted: the annual-cron case and the fresh-daily case both stay at zero
+   triggers, and the genuinely-overdue case still fires.
+
+Full scheduler suite re-run: 76 tests across 8 files, all green.


### PR DESCRIPTION
## ELI16 — the reminder that goes off the moment you set it

Any newly created scheduled job fires immediately the next time the server
restarts. Including one set for months from now.

At startup the scheduler looks for work missed while the machine was off. To
decide, it compares now against when the job last ran. For a job that has
**never** run there's nothing to compare against, and the code resolved that by
treating it as overdue and running it.

That's right for a job added while the server was down that slept through its
window. It's wrong for a job created five minutes ago whose first moment is in
December — because "has never run" describes both equally well.

So you set a December reminder, the server restarts that evening, and the
reminder fires. It's now been delivered, months early, and will never fire
again — because it has run.

**The comment directly above that code says the correct rule:** *"trigger on
startup if their first expected run time has already passed."* The code skips
the "if" entirely. It couldn't check it — nothing recorded when a job started
existing, so there was no fact to reason from.

Now there is one. A never-run job counts as overdue only if it has existed
longer than the gap between its own runs. December reminder waits; a job that
slept through six four-hour windows still catches up.

## UX impact declaration

- **Audience:** every instar agent (the scheduler is core), and anyone who has
  wondered why a job ran right after a restart. No new surface to learn.
- **Visible behavior change:** unexplained job runs shortly after a restart stop
  happening. A never-run job that has been waiting *less* than one of its own
  cycles now waits for its scheduled turn instead of firing at startup — that
  delay is the intended behaviour, and it's the one real trade.
- **First contact:** passive — the absence of a spurious run.
- **User-visible strings introduced:** none. One new log line on a bookkeeping
  failure: `"[scheduler] Could not stamp firstSeenAt for \"<slug>\": <err>"`.
- **Rollback:** revert. Orphaned `firstSeenAt` values are ignored by the old
  code. No migration, no flag, no data repair.

## Why this is a prerequisite, not the feature

ACT-724 asks for dated commitments to materialize real scheduled reminders. That
reminder would ride this scheduler. Building it first would produce reminders
that discharge themselves at boot before their date — worse than not building
it, because a reminder that fired looks delivered.

**The ACT-724 standard itself is not in this PR.** This is its defect (a).

## What I want reviewed hardest

**I changed an existing test that asserted the buggy behaviour.** That's the move
that deserves scrutiny, so I'm pointing at it rather than hoping it slides.

`job-scheduler-edge.test.ts` had *"triggers jobs that have never run on
startup"* — written for a real concern (never-run jobs skipped forever) that had
over-corrected into "fire everything". It couldn't survive intact. I preserved
its intent by seeding `firstSeenAt` a day in the past, so it now exercises the
scenario it was actually written for, and added the missing opposite-side
assertion. Coverage of this boundary goes 1 → 5 tests.

## Evidence

- `tests/unit/job-scheduler-never-run-future-job.test.ts` (3): annual job and
  fresh daily job both stay at zero triggers; a job registered 6h ago on a
  5-minute cron still catches up. **Written failing first** — the two "must not
  fire" cases failed against old code, the catch-up case already passed.
- Full scheduler suite: 76 tests, 8 files, green.
- Corroboration the behaviour was known: `JobScheduler.test.ts` pre-seeds
  `lastRun` in `beforeEach` *"so checkMissedJobs doesn't trigger jobs at
  startup"* — worked around as a fixture quirk for who knows how long.

## Rejected alternative

Seeding `lastRun` at registration (which ACT-724's own sketch floated). Fewer
lines, but it records a run that never happened and corrupts run history and
`runCount`. "Registered" and "ran" are different facts and stay different fields.

Every uncertainty resolves to **not firing**. A skipped catch-up costs one
delayed run; a wrongly-fired future job is indistinguishable from a delivered
one, so nobody goes looking for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsMJxSBBPAeDo8bXdunVtC
