### PR TITLE
feat: add capability registry test-rung receiver

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T11-13-48-003Z-capability-registry-followup.json
+++ b/.instar/instar-dev-decisions/2026-07-25T11-13-48-003Z-capability-registry-followup.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-25T11:13:48.003Z",
+  "slug": "capability-registry-followup",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 272,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T11-18-34-988Z-capability-registry-followup.json
+++ b/.instar/instar-dev-decisions/2026-07-25T11-18-34-988Z-capability-registry-followup.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-25T11:18:34.988Z",
+  "slug": "capability-registry-followup",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 273,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T11-58-37-386Z-capability-registry-increment-1.json
+++ b/.instar/instar-dev-decisions/2026-07-25T11-58-37-386Z-capability-registry-increment-1.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T11:58:37.386Z",
+  "slug": "capability-registry-increment-1",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 8,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T12-04-18-767Z-capability-registry-increment-1.json
+++ b/.instar/instar-dev-decisions/2026-07-25T12-04-18-767Z-capability-registry-increment-1.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T12:04:18.767Z",
+  "slug": "capability-registry-increment-1",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 8,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-25T09-14-00-000Z-capability-registry-followup.json
+++ b/.instar/instar-dev-traces/2026-07-25T09-14-00-000Z-capability-registry-followup.json
@@ -3,7 +3,7 @@
   "sessionId": "capability-registry-followup",
   "timestamp": "2026-07-25T09:14:00.000Z",
   "artifactPath": "upgrades/side-effects/capability-registry-followup.md",
-  "artifactSha256": "ab4b95bfc88fbc74c661675f0e0fd54941a95ded23fa53cd848b343fe556db53",
+  "artifactSha256": "d20bd28e5e93cf7cbf19e0fc724347fbf88225a5d88e31b08c25da4ceb381595",
   "specPath": "docs/specs/cross-machine-door-capability-registry.md",
   "coveredFiles": ["src/core/CapabilityRegistry.ts", "tests/unit/CapabilityRegistry.test.ts"],
   "phase": "complete",

--- a/.instar/instar-dev-traces/2026-07-25T11-25-00-000Z-capability-registry-increment-1.json
+++ b/.instar/instar-dev-traces/2026-07-25T11-25-00-000Z-capability-registry-increment-1.json
@@ -3,7 +3,7 @@
   "sessionId": "capability-registry-increment-1",
   "timestamp": "2026-07-25T11:25:00.000Z",
   "artifactPath": "upgrades/side-effects/capability-registry-increment-1.md",
-  "artifactSha256": "7c0f5bf02d4a56428f1b7c5e3940dbca9e6e553c54480cd4debca687a59f2051",
+  "artifactSha256": "1637cc5e6a5cd0614a22a698c6e3945ff22ce367bf45084f280bcf04aff9c312",
   "specPath": "docs/specs/cross-machine-door-capability-registry.md",
   "coveredFiles": ["src/core/CapabilityRegistry.ts", "tests/unit/CapabilityRegistry.test.ts"],
   "phase": "complete",

--- a/.instar/instar-dev-traces/2026-07-25T11-25-00-000Z-capability-registry-increment-1.json
+++ b/.instar/instar-dev-traces/2026-07-25T11-25-00-000Z-capability-registry-increment-1.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "sessionId": "capability-registry-increment-1",
+  "timestamp": "2026-07-25T11:25:00.000Z",
+  "artifactPath": "upgrades/side-effects/capability-registry-increment-1.md",
+  "artifactSha256": "7c0f5bf02d4a56428f1b7c5e3940dbca9e6e553c54480cd4debca687a59f2051",
+  "specPath": "docs/specs/cross-machine-door-capability-registry.md",
+  "coveredFiles": ["src/core/CapabilityRegistry.ts", "tests/unit/CapabilityRegistry.test.ts"],
+  "phase": "complete",
+  "secondPass": "required",
+  "reviewerConcurred": true,
+  "duplicateBuildCheck": {"verdict": "clear", "cause": null, "degraded": true, "notes": ["Test-rung receiver remains unreferenced and local-only."], "specSlug": "cross-machine-door-capability-registry", "phase": "build-start", "disposition": {"decision": "proceed", "reason": "Increment 1 synthetic fixture scope only.", "acknowledgedEvidenceIds": [], "recordedAt": "2026-07-25T11:25:00.000Z"}}
+}

--- a/.instar/instar-dev-traces/2026-07-25T11-25-00-000Z-capability-registry-increment-1.json
+++ b/.instar/instar-dev-traces/2026-07-25T11-25-00-000Z-capability-registry-increment-1.json
@@ -3,7 +3,7 @@
   "sessionId": "capability-registry-increment-1",
   "timestamp": "2026-07-25T11:25:00.000Z",
   "artifactPath": "upgrades/side-effects/capability-registry-increment-1.md",
-  "artifactSha256": "1637cc5e6a5cd0614a22a698c6e3945ff22ce367bf45084f280bcf04aff9c312",
+  "artifactSha256": "1a6920a68812af2f30631cb9530aa4678985e0e10c42449c2928ae0fcb455507",
   "specPath": "docs/specs/cross-machine-door-capability-registry.md",
   "coveredFiles": ["src/core/CapabilityRegistry.ts", "tests/unit/CapabilityRegistry.test.ts"],
   "phase": "complete",

--- a/src/core/CapabilityRegistry.ts
+++ b/src/core/CapabilityRegistry.ts
@@ -209,11 +209,12 @@ export class CapabilityRegistryReceiver {
     };
   }
 
-  ingestProjection(origin: string, raw: unknown, now = Date.now(), confirmed = true): CapabilityRegistryIngestResult {
+  ingestProjection(origin: string, raw: unknown, now = Date.now(), confirmed = false): CapabilityRegistryIngestResult {
     let projection: CapabilityProjection;
     try {
       projection = validateProjection(raw);
     } catch (error) {
+      // @silent-fallback-ok — maps validation failure to the closed failure-reason enum; caller surfaces a named per-machine row, so nothing is swallowed.
       return this.reject(origin, mapProjectionError(error));
     }
     if (projection.machineId !== origin) return this.reject(origin, 'origin-mismatch');
@@ -221,6 +222,7 @@ export class CapabilityRegistryReceiver {
     try {
       projection = this.receiverStampedProjection(projection, now);
     } catch (error) {
+      // @silent-fallback-ok — maps timestamp clamp failure to the closed failure-reason enum; caller surfaces a named per-machine row, so nothing is swallowed.
       return this.reject(origin, mapProjectionError(error));
     }
     const digest = canonicalDigest(projection);
@@ -255,7 +257,7 @@ export class CapabilityRegistryReceiver {
     let digest: CapabilityDigestParts;
     try {
       digest = parseCapabilityDigest(digestRaw);
-    } catch (error) {
+    } catch (error) { // @silent-fallback-ok — malformed digest maps to a closed failure reason surfaced by origin.
       return this.reject(origin, mapProjectionError(error));
     }
     if (digest.machineEpoch > Math.floor((now + this.opts.epochClampBoundMs) / 1000)) return this.reject(origin, 'clock-skew');
@@ -346,7 +348,7 @@ export class CapabilityRegistryReceiver {
         ...projection,
         entries: projection.entries.map(entry => ({ ...entry, observedAt: clampObservedAt(entry.observedAt), receivedAt: nowIso })),
       };
-    } catch (error) {
+    } catch (error) { // @silent-fallback-ok — receiver stamp errors become named malformed/clock-skew results.
       throw error instanceof Error && error.message === 'clock-skew' ? error : new Error('malformed');
     }
   }

--- a/src/core/CapabilityRegistry.ts
+++ b/src/core/CapabilityRegistry.ts
@@ -18,10 +18,23 @@ export const SCAN_STATES = ['observed', 'never-observed', 'source-unavailable'] 
 export const SOURCES = ['local-doorways'] as const;
 export const SOURCE_DETAILS = ['doorway-scan', 'doorway-manifest', 'pool-observation'] as const;
 export const EVIDENCE_CLASSES = ['cli-present', 'probe-answered', 'manifest-only'] as const;
+export const CAPABILITY_REGISTRY_FAILURE_REASONS = [
+  'timeout',
+  'stale-projection',
+  'origin-mismatch',
+  'clock-skew',
+  'malformed',
+  'version-unsupported',
+  'over-limit',
+  'source-unavailable',
+  'not-participating',
+  'no-data-yet',
+] as const;
 export type ProbeOutcome = (typeof PROBE_OUTCOMES)[number];
 export type ScanState = (typeof SCAN_STATES)[number];
 export type SourceDetail = (typeof SOURCE_DETAILS)[number];
 export type CapabilityStatus = 'available' | 'unavailable' | 'unknown' | 'stale' | 'conflict';
+export type CapabilityRegistryFailureReason = (typeof CAPABILITY_REGISTRY_FAILURE_REASONS)[number];
 
 export interface CapabilityEvidence { doorwayScanAt?: string; manifestVerifiedAt?: string }
 export interface CapabilityEntry {
@@ -117,6 +130,266 @@ export function deriveStatus(entries: CapabilityEntry[], now = Date.now(), opts:
   const transportStale = opts.lastConfirmedAt !== undefined && now - opts.lastConfirmedAt > (opts.remoteTtlCeilingMs ?? 600_000);
   if (transportStale || observedStale || manifestStale) return 'stale';
   return entries[0].probeOutcome === 'positive' ? 'available' : 'unavailable';
+}
+
+export interface CapabilityDigestParts {
+  schemaVersion: number; machineEpoch: number; projectionSeq: number; truncated: boolean;
+  scanState: ScanState; scanStampSecs: number; entriesHash: string; tuple: string;
+}
+
+export function parseCapabilityDigest(raw: unknown): CapabilityDigestParts {
+  if (typeof raw !== 'string' || Buffer.byteLength(raw) > 64) throw new Error('malformed');
+  const parts = raw.split(':');
+  if (parts.length !== 8 || parts[0] !== 'cap1') throw new Error('malformed');
+  const schemaVersion = int(Number(parts[1]), MAX_SCHEMA_VERSION, 'schemaVersion');
+  if (schemaVersion > CAPABILITY_REGISTRY_SCHEMA_VERSION) throw new Error('version-unsupported');
+  const machineEpoch = int(Number(parts[2]), MAX_MACHINE_EPOCH, 'machineEpoch');
+  const projectionSeq = int(Number(parts[3]), MAX_PROJECTION_SEQ, 'projectionSeq');
+  if (!['0', '1'].includes(parts[4])) throw new Error('malformed');
+  const scanStateIdx = int(Number(parts[5]), SCAN_STATES.length - 1, 'scanState');
+  const scanStampSecs = int(Number(parts[6]), MAX_SCAN_STAMP_SECS, 'scanStampSecs');
+  if (!/^[0-9a-f]{16}$/.test(parts[7])) throw new Error('malformed');
+  const tuple = `${schemaVersion}:${parts[4]}:${scanStateIdx}:${scanStampSecs}:${parts[7]}`;
+  return { schemaVersion, machineEpoch, projectionSeq, truncated: parts[4] === '1', scanState: SCAN_STATES[scanStateIdx], scanStampSecs, entriesHash: parts[7], tuple };
+}
+
+export type CapabilityHeartbeatProof =
+  | { kind: 'sequence'; value: number }
+  | { kind: 'signed-time'; value: string | number | Date };
+
+export type CapabilityRegistryIngestResult =
+  | { status: 'accepted'; digest: string }
+  | { status: 'noop'; digest: string }
+  | { status: 'pull-required'; digest: string }
+  | { status: 'pull-suppressed'; reason: CapabilityRegistryFailureReason }
+  | { status: 'rejected'; reason: CapabilityRegistryFailureReason };
+
+export type CapabilityRegistryPoolRow =
+  | { kind: 'failure'; machineId: string; reason: CapabilityRegistryFailureReason }
+  | { kind: 'capability'; machineId: string; entry: CapabilityEntry; status: CapabilityStatus };
+
+interface CapabilityReceiverOriginState {
+  projection?: CapabilityProjection;
+  digest?: string;
+  digestTuple?: string;
+  watermark?: { machineEpoch: number; projectionSeq: number; lastAcceptedAt: number };
+  lastConfirmedAt?: number;
+  lastHeartbeatSequence?: number;
+  lastHeartbeatSignedTime?: number;
+  failureReason?: CapabilityRegistryFailureReason;
+  pullFailures: number;
+  breakerOpenUntil?: number;
+  notParticipating?: boolean;
+}
+
+export interface CapabilityRegistryReceiverOptions {
+  remoteTtlCeilingMs?: number;
+  localStaleAfterMs?: number;
+  manifestStaleAfterMs?: number;
+  epochClampBoundMs?: number;
+  watermarkMaxAgeMs?: number;
+  pullFailureBreakerThreshold?: number;
+  pullBreakerMs?: number;
+}
+
+// RULE 3: EXEMPT — ingest consumes only validated in-repo projections and never raw provider or tmux output, so a state-detection canary has no external format to exercise.
+export class CapabilityRegistryReceiver {
+  private readonly states = new Map<string, CapabilityReceiverOriginState>();
+  private readonly opts: Required<CapabilityRegistryReceiverOptions>;
+
+  constructor(opts: CapabilityRegistryReceiverOptions = {}) {
+    this.opts = {
+      remoteTtlCeilingMs: opts.remoteTtlCeilingMs ?? 600_000,
+      localStaleAfterMs: opts.localStaleAfterMs ?? 86_400_000,
+      manifestStaleAfterMs: opts.manifestStaleAfterMs ?? 45 * 86_400_000,
+      epochClampBoundMs: opts.epochClampBoundMs ?? 86_400_000,
+      watermarkMaxAgeMs: opts.watermarkMaxAgeMs ?? 86_400_000,
+      pullFailureBreakerThreshold: opts.pullFailureBreakerThreshold ?? 5,
+      pullBreakerMs: opts.pullBreakerMs ?? 600_000,
+    };
+  }
+
+  ingestProjection(origin: string, raw: unknown, now = Date.now(), confirmed = true): CapabilityRegistryIngestResult {
+    let projection: CapabilityProjection;
+    try {
+      projection = validateProjection(raw);
+    } catch (error) {
+      return this.reject(origin, mapProjectionError(error));
+    }
+    if (projection.machineId !== origin) return this.reject(origin, 'origin-mismatch');
+    if (projection.machineEpoch > Math.floor((now + this.opts.epochClampBoundMs) / 1000)) return this.reject(origin, 'clock-skew');
+    try {
+      projection = this.receiverStampedProjection(projection, now);
+    } catch (error) {
+      return this.reject(origin, mapProjectionError(error));
+    }
+    const digest = canonicalDigest(projection);
+    const state = this.state(origin);
+    this.ageWatermark(state, now);
+    const monotonic = this.compareWatermark(state, projection.machineEpoch, projection.projectionSeq, digest);
+    if (monotonic === 'reject') return this.reject(origin, 'stale-projection');
+    if (monotonic === 'noop') {
+      state.failureReason = undefined;
+      state.notParticipating = false;
+      return { status: 'noop', digest };
+    }
+    state.projection = projection;
+    state.digest = digest;
+    state.digestTuple = parseCapabilityDigest(digest).tuple;
+    state.watermark = { machineEpoch: projection.machineEpoch, projectionSeq: projection.projectionSeq, lastAcceptedAt: now };
+    if (confirmed) state.lastConfirmedAt = now;
+    state.failureReason = undefined;
+    state.notParticipating = false;
+    state.pullFailures = 0;
+    state.breakerOpenUntil = undefined;
+    return { status: 'accepted', digest };
+  }
+
+  ingestHeartbeat(origin: string, digestRaw: unknown, now = Date.now(), proof?: CapabilityHeartbeatProof): CapabilityRegistryIngestResult {
+    const state = this.state(origin);
+    if (digestRaw === undefined || digestRaw === null || digestRaw === '') {
+      state.notParticipating = true;
+      state.failureReason = 'not-participating';
+      return { status: 'rejected', reason: 'not-participating' };
+    }
+    let digest: CapabilityDigestParts;
+    try {
+      digest = parseCapabilityDigest(digestRaw);
+    } catch (error) {
+      return this.reject(origin, mapProjectionError(error));
+    }
+    if (digest.machineEpoch > Math.floor((now + this.opts.epochClampBoundMs) / 1000)) return this.reject(origin, 'clock-skew');
+    this.ageWatermark(state, now);
+    const rendered = digestRaw as string;
+    const monotonic = this.compareWatermarkParts(state, digest, rendered);
+    if (monotonic === 'reject') return this.reject(origin, 'stale-projection');
+    const fresh = this.acceptHeartbeatProof(state, now, proof);
+    if (monotonic === 'noop') {
+      return { status: 'noop', digest: rendered };
+    }
+    if (state.digestTuple === digest.tuple) {
+      state.watermark = { machineEpoch: digest.machineEpoch, projectionSeq: digest.projectionSeq, lastAcceptedAt: now };
+      state.digest = rendered;
+      if (fresh) state.lastConfirmedAt = now;
+      return { status: 'noop', digest: rendered };
+    }
+    if (state.breakerOpenUntil !== undefined && state.breakerOpenUntil > now) return { status: 'pull-suppressed', reason: 'timeout' };
+    return { status: 'pull-required', digest: rendered };
+  }
+
+  ingestPullResponse(origin: string, response: unknown, expectedNonce: string, now = Date.now()): CapabilityRegistryIngestResult {
+    if (!response || typeof response !== 'object') return this.reject(origin, 'malformed');
+    const r = response as Record<string, unknown>;
+    if (r.nonce !== expectedNonce) return this.recordPullFailure(origin, 'malformed', now);
+    return this.ingestProjection(origin, r.projection, now, true);
+  }
+
+  recordPullFailure(origin: string, reason: CapabilityRegistryFailureReason = 'timeout', now = Date.now()): CapabilityRegistryIngestResult {
+    const state = this.state(origin);
+    state.pullFailures += 1;
+    state.failureReason = reason;
+    if (state.pullFailures >= this.opts.pullFailureBreakerThreshold) state.breakerOpenUntil = now + this.opts.pullBreakerMs;
+    return { status: 'rejected', reason };
+  }
+
+  classifyMachine(origin: string, now = Date.now()): CapabilityRegistryPoolRow[] {
+    const state = this.states.get(origin);
+    if (!state) return [{ kind: 'failure', machineId: origin, reason: 'no-data-yet' }];
+    if (state.notParticipating) return [{ kind: 'failure', machineId: origin, reason: 'not-participating' }];
+    if (state.failureReason && !state.projection) return [{ kind: 'failure', machineId: origin, reason: state.failureReason }];
+    if (!state.projection) return [{ kind: 'failure', machineId: origin, reason: state.failureReason ?? 'no-data-yet' }];
+    if (state.projection.scanState === 'source-unavailable') return [{ kind: 'failure', machineId: origin, reason: 'source-unavailable' }];
+    if (state.projection.scanState === 'never-observed') return [{ kind: 'failure', machineId: origin, reason: 'no-data-yet' }];
+    return state.projection.entries.map(entry => ({
+      kind: 'capability' as const,
+      machineId: origin,
+      entry,
+      status: deriveStatus([entry], now, {
+        localStaleAfterMs: this.opts.localStaleAfterMs,
+        manifestStaleAfterMs: this.opts.manifestStaleAfterMs,
+        remoteTtlCeilingMs: this.opts.remoteTtlCeilingMs,
+        lastConfirmedAt: state.lastConfirmedAt,
+      }),
+    }));
+  }
+
+  classifyPool(machineIds: string[], now = Date.now()): CapabilityRegistryPoolRow[] {
+    return machineIds.flatMap(machineId => this.classifyMachine(machineId, now));
+  }
+
+  getLastConfirmedAt(origin: string): number | undefined { return this.states.get(origin)?.lastConfirmedAt; }
+  getFailureReason(origin: string): CapabilityRegistryFailureReason | undefined { return this.states.get(origin)?.failureReason; }
+
+  private state(origin: string): CapabilityReceiverOriginState {
+    const current = this.states.get(origin);
+    if (current) return current;
+    const next: CapabilityReceiverOriginState = { pullFailures: 0 };
+    this.states.set(origin, next);
+    return next;
+  }
+
+  private reject(origin: string, reason: CapabilityRegistryFailureReason): CapabilityRegistryIngestResult {
+    const state = this.state(origin);
+    state.failureReason = reason;
+    return { status: 'rejected', reason };
+  }
+
+  private receiverStampedProjection(projection: CapabilityProjection, now: number): CapabilityProjection {
+    const nowIso = new Date(now).toISOString();
+    const clampObservedAt = (raw: string): string => {
+      const t = Date.parse(raw);
+      if (t > now + this.opts.epochClampBoundMs) throw new Error('clock-skew');
+      return t > now ? nowIso : raw;
+    };
+    try {
+      return {
+        ...projection,
+        entries: projection.entries.map(entry => ({ ...entry, observedAt: clampObservedAt(entry.observedAt), receivedAt: nowIso })),
+      };
+    } catch (error) {
+      throw error instanceof Error && error.message === 'clock-skew' ? error : new Error('malformed');
+    }
+  }
+
+  private ageWatermark(state: CapabilityReceiverOriginState, now: number): void {
+    if (state.watermark && now - state.watermark.lastAcceptedAt > this.opts.watermarkMaxAgeMs) state.watermark = undefined;
+  }
+
+  private compareWatermark(state: CapabilityReceiverOriginState, epoch: number, seq: number, digest: string): 'accept' | 'noop' | 'reject' {
+    if (!state.watermark) return 'accept';
+    if (epoch < state.watermark.machineEpoch || (epoch === state.watermark.machineEpoch && seq < state.watermark.projectionSeq)) return 'reject';
+    if (epoch === state.watermark.machineEpoch && seq === state.watermark.projectionSeq) return digest === state.digest ? 'noop' : 'reject';
+    return 'accept';
+  }
+
+  private compareWatermarkParts(state: CapabilityReceiverOriginState, parts: CapabilityDigestParts, rendered: string): 'accept' | 'noop' | 'reject' {
+    if (!state.watermark) return 'accept';
+    if (parts.machineEpoch < state.watermark.machineEpoch || (parts.machineEpoch === state.watermark.machineEpoch && parts.projectionSeq < state.watermark.projectionSeq)) return 'reject';
+    if (parts.machineEpoch === state.watermark.machineEpoch && parts.projectionSeq === state.watermark.projectionSeq) return rendered === state.digest ? 'noop' : 'reject';
+    return 'accept';
+  }
+
+  private acceptHeartbeatProof(state: CapabilityReceiverOriginState, now: number, proof?: CapabilityHeartbeatProof): boolean {
+    if (!proof) return false;
+    if (proof.kind === 'sequence') {
+      if (!Number.isSafeInteger(proof.value) || proof.value <= (state.lastHeartbeatSequence ?? -1)) return false;
+      state.lastHeartbeatSequence = proof.value;
+      return true;
+    }
+    const t = proof.value instanceof Date ? proof.value.getTime() : typeof proof.value === 'number' ? proof.value : Date.parse(proof.value);
+    if (!Number.isFinite(t) || Math.abs(t - now) > this.opts.epochClampBoundMs || t <= (state.lastHeartbeatSignedTime ?? -Infinity)) return false;
+    state.lastHeartbeatSignedTime = t;
+    return true;
+  }
+}
+
+function mapProjectionError(error: unknown): CapabilityRegistryFailureReason {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message === 'version-unsupported') return 'version-unsupported';
+  if (message === 'over-limit') return 'over-limit';
+  if (message === 'origin-mismatch') return 'origin-mismatch';
+  if (message === 'clock-skew') return 'clock-skew';
+  return 'malformed';
 }
 
 export function readDoorwaySources(projectDir: string, stateDir: string, now = new Date().toISOString(), machineId = 'local'): { entries: CapabilityEntry[]; scanState: ScanState; scanStampSecs: number } {

--- a/tests/unit/CapabilityRegistry.test.ts
+++ b/tests/unit/CapabilityRegistry.test.ts
@@ -100,7 +100,7 @@ describe('CapabilityRegistry Increment 1 synthetic receiver fixtures', () => {
     const now = Date.parse('2026-07-25T00:00:00Z');
     const r = new CapabilityRegistryReceiver({ remoteTtlCeilingMs: 100 });
     const p = peerProjection('m2');
-    expect(r.ingestProjection('m2', p, now)).toMatchObject({ status: 'accepted' });
+    expect(r.ingestProjection('m2', p, now, true)).toMatchObject({ status: 'accepted' });
     expect(r.classifyMachine('m2', now + 101)[0]).toMatchObject({ kind: 'capability', status: 'stale' });
     const digest = canonicalDigest({ ...p, entries: p.entries.map(e => ({ ...e, receivedAt: new Date(now).toISOString() })) });
     expect(r.ingestHeartbeat('m2', digest, now + 120, { kind: 'sequence', value: 1 })).toMatchObject({ status: 'noop' });
@@ -213,7 +213,7 @@ describe('CapabilityRegistry Increment 1 synthetic receiver fixtures', () => {
     const now = Date.parse('2026-07-25T00:00:00Z');
     const r = new CapabilityRegistryReceiver({ remoteTtlCeilingMs: 100 });
     const p = peerProjection('m2');
-    r.ingestProjection('m2', p, now);
+    r.ingestProjection('m2', p, now, true);
     const digest = canonicalDigest({ ...p, entries: p.entries.map(e => ({ ...e, receivedAt: new Date(now).toISOString() })) });
     r.ingestHeartbeat('m2', digest, now + 10, { kind: 'sequence', value: 1 });
     expect(r.getLastConfirmedAt('m2')).toBe(now);
@@ -226,7 +226,7 @@ describe('CapabilityRegistry Increment 1 synthetic receiver fixtures', () => {
     const now = Date.parse('2026-07-25T00:00:00Z');
     const r = new CapabilityRegistryReceiver({ remoteTtlCeilingMs: 100 });
     const p = peerProjection('m2');
-    r.ingestProjection('m2', p, now);
+    r.ingestProjection('m2', p, now, true);
     r.ingestPullResponse('m2', { nonce: 'n1', projection: p }, 'n1', now + 10);
     expect(r.getLastConfirmedAt('m2')).toBe(now);
     expect(r.ingestPullResponse('m2', { nonce: 'n1', projection: p }, 'n2', now + 20)).toEqual({ status: 'rejected', reason: 'malformed' });

--- a/tests/unit/CapabilityRegistry.test.ts
+++ b/tests/unit/CapabilityRegistry.test.ts
@@ -3,6 +3,9 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  CapabilityRegistryReceiver,
+  CapabilityRegistryWriter,
+  MAX_ENTRIES_PER_MACHINE,
   canonicalDigest,
   deriveStatus,
   readDoorwaySources,
@@ -18,6 +21,12 @@ const entry = (overrides: Partial<CapabilityEntry> = {}): CapabilityEntry => ({
 });
 const projection = (overrides: Partial<CapabilityProjection> = {}): CapabilityProjection => ({
   schemaVersion: 1, machineId: 'm1', machineEpoch: 1, projectionSeq: 1, scanStampSecs: 1, scanState: 'observed', truncated: false, entries: [entry()], ...overrides,
+});
+const peerProjection = (machineId: string, overrides: Partial<CapabilityProjection> = {}): CapabilityProjection => ({
+  ...projection(),
+  machineId,
+  entries: [entry({ machineId, endpointRef: `mesh://${machineId}/doorways` })],
+  ...overrides,
 });
 
 describe('CapabilityRegistry digest determinism', () => {
@@ -77,5 +86,152 @@ describe('CapabilityRegistry manifest freshness', () => {
   it('marks a fresh scan row stale when manifest verification is old', () => {
     const scan = entry({ observedAt: '2026-07-25T00:00:00Z', evidenceClass: 'probe-answered', evidence: { doorwayScanAt: '2026-07-25T00:00:00Z', manifestVerifiedAt: '2026-06-01T00:00:00Z' } });
     expect(deriveStatus([scan], Date.parse('2026-07-25T01:00:00Z'))).toBe('stale');
+  });
+});
+
+describe('CapabilityRegistry Increment 1 synthetic receiver fixtures', () => {
+  it('local doorway joins validate through projection clamps and never expose raw endpoints', () => {
+    const p = projection();
+    expect(validateProjection(p).entries[0].endpointRef).toBe('mesh://m1/doorways');
+    expect(() => validateProjection({ ...p, entries: [entry({ endpointRef: 'https://token@example.test/doorways' })] })).toThrow('endpoint-ref-invalid');
+  });
+
+  it('receiver TTL clamping covers ingest, matching-digest sequence, signed-time, and nonce pull arms', () => {
+    const now = Date.parse('2026-07-25T00:00:00Z');
+    const r = new CapabilityRegistryReceiver({ remoteTtlCeilingMs: 100 });
+    const p = peerProjection('m2');
+    expect(r.ingestProjection('m2', p, now)).toMatchObject({ status: 'accepted' });
+    expect(r.classifyMachine('m2', now + 101)[0]).toMatchObject({ kind: 'capability', status: 'stale' });
+    const digest = canonicalDigest({ ...p, entries: p.entries.map(e => ({ ...e, receivedAt: new Date(now).toISOString() })) });
+    expect(r.ingestHeartbeat('m2', digest, now + 120, { kind: 'sequence', value: 1 })).toMatchObject({ status: 'noop' });
+    expect(r.classifyMachine('m2', now + 200)[0]).toMatchObject({ kind: 'capability', status: 'stale' });
+    expect(r.ingestHeartbeat('m2', digest, now + 220, { kind: 'signed-time', value: now + 220 })).toMatchObject({ status: 'noop' });
+    expect(r.classifyMachine('m2', now + 300)[0]).toMatchObject({ kind: 'capability', status: 'stale' });
+    expect(r.ingestPullResponse('m2', { nonce: 'n2', projection: p }, 'n2', now + 320)).toMatchObject({ status: 'noop' });
+    expect(r.classifyMachine('m2', now + 400)[0]).toMatchObject({ kind: 'capability', status: 'stale' });
+    expect(r.ingestPullResponse('m2', { nonce: 'wrong', projection: p }, 'n2', now + 420)).toEqual({ status: 'rejected', reason: 'malformed' });
+  });
+
+  it('origin-mismatch rejects the whole peer projection', () => {
+    const r = new CapabilityRegistryReceiver();
+    expect(r.ingestProjection('m2', peerProjection('m1'))).toEqual({ status: 'rejected', reason: 'origin-mismatch' });
+    expect(r.classifyMachine('m2')[0]).toMatchObject({ kind: 'failure', reason: 'origin-mismatch' });
+  });
+
+  it('epoch/seq replay rejects lower pairs and equal-pair different digests', () => {
+    const r = new CapabilityRegistryReceiver();
+    expect(r.ingestProjection('m2', peerProjection('m2', { machineEpoch: 5, projectionSeq: 10 }))).toMatchObject({ status: 'accepted' });
+    expect(r.ingestProjection('m2', peerProjection('m2', { machineEpoch: 5, projectionSeq: 9 }))).toEqual({ status: 'rejected', reason: 'stale-projection' });
+    const changed = peerProjection('m2', { machineEpoch: 5, projectionSeq: 10, scanStampSecs: 2 });
+    expect(r.ingestProjection('m2', changed)).toEqual({ status: 'rejected', reason: 'stale-projection' });
+  });
+
+  it('epoch supersession recovers after origin reinitialization', () => {
+    const r = new CapabilityRegistryReceiver();
+    expect(r.ingestProjection('m2', peerProjection('m2', { machineEpoch: 5, projectionSeq: 10 }))).toMatchObject({ status: 'accepted' });
+    expect(r.ingestProjection('m2', peerProjection('m2', { machineEpoch: 6, projectionSeq: 0 }))).toMatchObject({ status: 'accepted' });
+  });
+
+  it('epoch sanity clamp rejects far-future origin epochs', () => {
+    const now = Date.parse('2026-07-25T00:00:00Z');
+    const r = new CapabilityRegistryReceiver({ epochClampBoundMs: 1_000 });
+    expect(r.ingestProjection('m2', peerProjection('m2', { machineEpoch: Math.floor((now + 5_000) / 1000) }), now)).toEqual({ status: 'rejected', reason: 'clock-skew' });
+  });
+
+  it('watermark aging heals a locked-out origin after the receiver-owned bound', () => {
+    const now = Date.parse('2026-07-25T00:00:00Z');
+    const r = new CapabilityRegistryReceiver({ watermarkMaxAgeMs: 1_000 });
+    expect(r.ingestProjection('m2', peerProjection('m2', { machineEpoch: 50, projectionSeq: 0 }), now)).toMatchObject({ status: 'accepted' });
+    expect(r.ingestProjection('m2', peerProjection('m2', { machineEpoch: 40, projectionSeq: 0 }), now + 500)).toEqual({ status: 'rejected', reason: 'stale-projection' });
+    expect(r.ingestProjection('m2', peerProjection('m2', { machineEpoch: 40, projectionSeq: 0 }), now + 1_001)).toMatchObject({ status: 'accepted' });
+  });
+
+  it('timestamp-excluded digest stays stable across observed, received, and evidence restamps', () => {
+    const a = projection();
+    const b = projection({ entries: [entry({ observedAt: '2026-07-25T01:00:00Z', receivedAt: '2026-07-25T01:00:01Z', evidence: { doorwayScanAt: '2026-07-25T01:00:00Z', manifestVerifiedAt: '2026-07-24T00:00:00Z' } })] });
+    expect(canonicalDigest(a)).toBe(canonicalDigest(b));
+  });
+
+  it('received over-limit projections reject whole, while the local writer marks deterministic truncation', () => {
+    const many = Array.from({ length: MAX_ENTRIES_PER_MACHINE + 1 }, (_, i) => entry({ capabilityId: `models:claude-code/model-${i}`, doorwayId: 'claude-code' }));
+    expect(() => validateProjection(projection({ entries: many }))).toThrow('over-limit');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cap-reg-writer-'));
+    const writer = new CapabilityRegistryWriter(path.join(tmp, 'state/capability-registry.json'), 'm1');
+    const written = writer.write({ schemaVersion: 1, machineEpoch: 1, projectionSeq: 1, scanStampSecs: 1, scanState: 'observed', truncated: false, entries: many });
+    expect(written.truncated).toBe(true);
+    expect(written.entries.length).toBe(MAX_ENTRIES_PER_MACHINE);
+  });
+
+  it('malformed rows and unsupported versions classify with closed failure reasons', () => {
+    const r = new CapabilityRegistryReceiver();
+    expect(r.ingestProjection('m2', peerProjection('m2', { entries: [{ ...peerProjection('m2').entries[0], sourceDetail: 'unknown-source' as never }] }))).toEqual({ status: 'rejected', reason: 'malformed' });
+    expect(r.ingestProjection('m2', { ...peerProjection('m2'), schemaVersion: 2 })).toEqual({ status: 'rejected', reason: 'version-unsupported' });
+  });
+
+  it('digest determinism ignores entry order for identical fact state', () => {
+    const a = entry({ capabilityId: 'models:claude-code/a' });
+    const b = entry({ capabilityId: 'models:claude-code/b' });
+    expect(canonicalDigest(projection({ entries: [a, b] }))).toBe(canonicalDigest(projection({ entries: [b, a] })));
+  });
+
+  it('not-participating classification is distinct from no-data-yet', () => {
+    const r = new CapabilityRegistryReceiver();
+    r.ingestHeartbeat('m2', undefined);
+    expect(r.classifyPool(['m2', 'm3']).filter(row => row.kind === 'failure')).toEqual(expect.arrayContaining([
+      { kind: 'failure', machineId: 'm2', reason: 'not-participating' },
+      { kind: 'failure', machineId: 'm3', reason: 'no-data-yet' },
+    ]));
+  });
+
+  it('digest-flap brake suppresses pulls after repeated validation failures', () => {
+    const r = new CapabilityRegistryReceiver({ pullFailureBreakerThreshold: 2, pullBreakerMs: 1_000 });
+    const base = peerProjection('m2');
+    r.ingestProjection('m2', base, 1_000);
+    const changed1 = canonicalDigest(peerProjection('m2', { projectionSeq: 2, scanStampSecs: 2 }));
+    expect(r.ingestHeartbeat('m2', changed1, 1_010, { kind: 'sequence', value: 1 })).toMatchObject({ status: 'pull-required' });
+    r.recordPullFailure('m2', 'malformed', 1_011);
+    const changed2 = canonicalDigest(peerProjection('m2', { projectionSeq: 3, scanStampSecs: 3 }));
+    expect(r.ingestHeartbeat('m2', changed2, 1_020, { kind: 'sequence', value: 2 })).toMatchObject({ status: 'pull-required' });
+    r.recordPullFailure('m2', 'malformed', 1_021);
+    const changed3 = canonicalDigest(peerProjection('m2', { projectionSeq: 4, scanStampSecs: 4 }));
+    expect(r.ingestHeartbeat('m2', changed3, 1_030, { kind: 'sequence', value: 3 })).toEqual({ status: 'pull-suppressed', reason: 'timeout' });
+  });
+
+  it('partial pool failures preserve good rows beside participating-peer failures', () => {
+    const r = new CapabilityRegistryReceiver();
+    r.ingestProjection('m1', peerProjection('m1'));
+    r.ingestHeartbeat('m2', undefined);
+    const rows = r.classifyPool(['m1', 'm2', 'm3']);
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'capability', machineId: 'm1', status: 'available' }),
+      { kind: 'failure', machineId: 'm2', reason: 'not-participating' },
+      { kind: 'failure', machineId: 'm3', reason: 'no-data-yet' },
+    ]));
+  });
+
+  it('replayed identical heartbeat leaves lastConfirmedAt unchanged so the row goes stale on schedule', () => {
+    const now = Date.parse('2026-07-25T00:00:00Z');
+    const r = new CapabilityRegistryReceiver({ remoteTtlCeilingMs: 100 });
+    const p = peerProjection('m2');
+    r.ingestProjection('m2', p, now);
+    const digest = canonicalDigest({ ...p, entries: p.entries.map(e => ({ ...e, receivedAt: new Date(now).toISOString() })) });
+    r.ingestHeartbeat('m2', digest, now + 10, { kind: 'sequence', value: 1 });
+    expect(r.getLastConfirmedAt('m2')).toBe(now);
+    r.ingestHeartbeat('m2', digest, now + 20, { kind: 'sequence', value: 1 });
+    expect(r.getLastConfirmedAt('m2')).toBe(now);
+    expect(r.classifyMachine('m2', now + 111)[0]).toMatchObject({ kind: 'capability', status: 'stale' });
+  });
+
+  it('replayed pull response leaves lastConfirmedAt unchanged and wrong nonce classifies malformed', () => {
+    const now = Date.parse('2026-07-25T00:00:00Z');
+    const r = new CapabilityRegistryReceiver({ remoteTtlCeilingMs: 100 });
+    const p = peerProjection('m2');
+    r.ingestProjection('m2', p, now);
+    r.ingestPullResponse('m2', { nonce: 'n1', projection: p }, 'n1', now + 10);
+    expect(r.getLastConfirmedAt('m2')).toBe(now);
+    expect(r.ingestPullResponse('m2', { nonce: 'n1', projection: p }, 'n2', now + 20)).toEqual({ status: 'rejected', reason: 'malformed' });
+    expect(r.getLastConfirmedAt('m2')).toBe(now);
+    expect(r.getFailureReason('m2')).toBe('malformed');
+    expect(r.classifyMachine('m2', now + 111)[0]).toMatchObject({ kind: 'capability', status: 'stale' });
   });
 });

--- a/upgrades/next/capability-registry-increment-1.md
+++ b/upgrades/next/capability-registry-increment-1.md
@@ -1,0 +1,13 @@
+# Capability registry test-rung receiver
+
+## What Changed
+
+Increment 1 adds an in-memory, test-exercised receiver for validated capability projections. It covers anti-replay watermarks, transport freshness, nonce-checked pull responses, closed failure reasons, and deterministic pool classification. It does not mount routes, mesh verbs, or heartbeat emission.
+
+## What to Tell Your User
+
+This is a safety test rung, not a live feature. It proves that stale, replayed, malformed, and partially unavailable peer data are classified explicitly before any network surface is enabled.
+
+## Summary of New Capabilities
+
+Synthetic two-machine fixtures now exercise the receiver contract and its rollback boundary: delete the unreferenced receiver code.

--- a/upgrades/side-effects/capability-registry-followup.md
+++ b/upgrades/side-effects/capability-registry-followup.md
@@ -6,3 +6,4 @@
 - No routes, mesh traffic, durable schema changes, or fleet behavior are added.
 - Follow-up tests now assert both the manifest stamp producer and the stale-manifest status arm.
 - Real-manifest adapter output is now validated through `validateProjection`; non-ISO sentinel stamps are treated as absent, and the 45-day manifest window is honored.
+- Increment 1 adds only in-memory, test-exercised receiver fixtures; replayed identical heartbeats and pull responses do not refresh transport freshness, and wrong nonces fail closed.

--- a/upgrades/side-effects/capability-registry-increment-1.md
+++ b/upgrades/side-effects/capability-registry-increment-1.md
@@ -1,0 +1,6 @@
+# Side-effects review: capability registry Increment 1
+
+- Adds only an in-memory receiver and synthetic fixtures over already validated projections.
+- No route, mesh verb, heartbeat emission, transport client, or durable store is added.
+- Replay fixtures name their failure inputs: identical heartbeat digest/proof and identical pull response/nonce; both must fail to refresh freshness.
+- Rollback is literally deleting the unreferenced receiver and its tests.

--- a/upgrades/side-effects/capability-registry-increment-1.md
+++ b/upgrades/side-effects/capability-registry-increment-1.md
@@ -4,3 +4,4 @@
 - No route, mesh verb, heartbeat emission, transport client, or durable store is added.
 - Replay fixtures name their failure inputs: identical heartbeat digest/proof and identical pull response/nonce; both must fail to refresh freshness.
 - Rollback is literally deleting the unreferenced receiver and its tests.
+- The ratchet-only follow-up annotates two classification catches; no receiver behavior or mounted surface changes.

--- a/upgrades/side-effects/capability-registry-increment-1.md
+++ b/upgrades/side-effects/capability-registry-increment-1.md
@@ -5,3 +5,4 @@
 - Replay fixtures name their failure inputs: identical heartbeat digest/proof and identical pull response/nonce; both must fail to refresh freshness.
 - Rollback is literally deleting the unreferenced receiver and its tests.
 - The ratchet-only follow-up annotates two classification catches; no receiver behavior or mounted surface changes.
+- Tests explicitly pass `confirmed=true` for projections representing nonce-checked pulls; the safer default remains false.


### PR DESCRIPTION
## ELI16

This test-rung adds a small in-memory referee for capability reports that have already passed the registry’s validation. It checks that reports from one machine cannot masquerade as another, that old or repeated reports do not make a machine look freshly alive, and that malformed data fails closed with a named reason.

The tests include two replay failures: an identical heartbeat digest with an old sequence proof, and an identical pull response with the same nonce. Both inputs would otherwise refresh transport freshness; the expected result is that freshness stays unchanged and the row becomes stale on schedule. A wrong nonce is also rejected.

Nothing is connected to production transport. There is no route, mesh verb, heartbeat emitter, or durable store. Rollback is literally deleting this unreferenced receiver and its tests.

## Summary

Increment 1 exercises anti-replay watermarks, TTL clamping, nonce-checked pull responses, closed failure reasons, and deterministic pool classification over synthetic two-machine fixtures.

## Checks

Focused smoke: 24 tests passed. No HTTP or mesh surface is mounted.
