### PR TITLE
feat(commitments): a dated promise produces a real reminder (ACT-724 step 1)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T11-06-57-741Z-scheduler-never-run-window.json
+++ b/.instar/instar-dev-decisions/2026-07-25T11-06-57-741Z-scheduler-never-run-window.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T11:06:57.741Z",
+  "slug": "scheduler-never-run-window",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 72,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T11-58-18-295Z-dated-commitment-reminder.json
+++ b/.instar/instar-dev-decisions/2026-07-25T11-58-18-295Z-dated-commitment-reminder.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-25T11:58:18.295Z",
+  "slug": "dated-commitment-reminder",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 565,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T11-58-50-873Z-dated-commitment-reminder.json
+++ b/.instar/instar-dev-decisions/2026-07-25T11-58-50-873Z-dated-commitment-reminder.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-25T11:58:50.873Z",
+  "slug": "dated-commitment-reminder",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 565,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T11-59-41-229Z-dated-commitment-reminder.json
+++ b/.instar/instar-dev-decisions/2026-07-25T11-59-41-229Z-dated-commitment-reminder.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-25T11:59:41.229Z",
+  "slug": "dated-commitment-reminder",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 565,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T12-00-19-731Z-dated-commitment-reminder.json
+++ b/.instar/instar-dev-decisions/2026-07-25T12-00-19-731Z-dated-commitment-reminder.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-25T12:00:19.731Z",
+  "slug": "dated-commitment-reminder",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 565,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T12-04-07-596Z-dated-commitment-reminder.json
+++ b/.instar/instar-dev-decisions/2026-07-25T12-04-07-596Z-dated-commitment-reminder.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-25T12:04:07.596Z",
+  "slug": "dated-commitment-reminder",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 626,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T12-04-35-103Z-dated-commitment-reminder.json
+++ b/.instar/instar-dev-decisions/2026-07-25T12-04-35-103Z-dated-commitment-reminder.json
@@ -1,0 +1,18 @@
+{
+  "ts": "2026-07-25T12:04:35.103Z",
+  "slug": "dated-commitment-reminder",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 626,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T12-05-25-481Z-dated-commitment-reminder.json
+++ b/.instar/instar-dev-decisions/2026-07-25T12-05-25-481Z-dated-commitment-reminder.json
@@ -1,0 +1,26 @@
+{
+  "ts": "2026-07-25T12:05:25.481Z",
+  "slug": "dated-commitment-reminder",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 626,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "Registered as check-in-reminder-pass in selfActionRegistry.ts. Steady-state bound: the emit is gated by a DURABLE per-commitment attempt counter (CHECK_IN_MAX_ATTEMPTS=5) persisted through the CAS mutate BEFORE the send, so a crash-loop cannot buy fresh attempts and the restart model settles too. Settling brake: on success a durable checkInReminderSentAt stamp makes the commitment permanently ineligible; on repeated failure the attempt bound terminates it with a loud checkInReminderFailedAt. Modeled at worst case (every send fails, so only the counter can stop it) — without the bound the model emits once per tick forever and the ratchet fails. Per-pass cap of 25 additionally bounds instantaneous mass."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T12-06-06-538Z-dated-commitment-reminder.json
+++ b/.instar/instar-dev-decisions/2026-07-25T12-06-06-538Z-dated-commitment-reminder.json
@@ -1,0 +1,26 @@
+{
+  "ts": "2026-07-25T12:06:06.538Z",
+  "slug": "dated-commitment-reminder",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 626,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "Registered as check-in-reminder-pass; durable attempt counter (5) persisted pre-send bounds steady state and survives restart; success stamp and exhaustion stamp are both durable terminal states; modeled at worst case (all sends fail) so the bound is load-bearing; per-pass cap of 25 bounds instantaneous mass."
+    }
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T12-37-29-743Z-dated-commitment-reminder.json
+++ b/.instar/instar-dev-decisions/2026-07-25T12-37-29-743Z-dated-commitment-reminder.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-25T12:37:29.743Z",
+  "slug": "dated-commitment-reminder",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 9,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "Registered as check-in-reminder-pass; durable attempt counter bounds steady state and survives restart; success and exhaustion stamps are terminal; modeled at worst case; per-pass cap bounds mass."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T12-38-01-654Z-dated-commitment-reminder.json
+++ b/.instar/instar-dev-decisions/2026-07-25T12-38-01-654Z-dated-commitment-reminder.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-25T12:38:01.654Z",
+  "slug": "dated-commitment-reminder",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 9,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "Registered as check-in-reminder-pass; durable attempt counter bounds steady state and survives restart; success and exhaustion stamps are terminal; modeled at worst case; per-pass cap bounds mass."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-25T12-39-56-770Z-dated-commitment-reminder.json
+++ b/.instar/instar-dev-decisions/2026-07-25T12-39-56-770Z-dated-commitment-reminder.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-25T12:39:56.770Z",
+  "slug": "dated-commitment-reminder",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 9,
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "Registered as check-in-reminder-pass; durable attempt counter bounds steady state and survives restart; success and exhaustion stamps terminal; modeled at worst case; per-pass cap bounds mass."
+    }
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/dated-commitment-reminder.eli16.md
+++ b/docs/specs/dated-commitment-reminder.eli16.md
@@ -1,0 +1,86 @@
+# "I'll check in on this Friday" — plain English
+
+## The one-sentence version
+
+When I tell you I'll come back to something by a certain date, that promise
+currently lives in my head; this turns it into something the system does whether
+or not any part of me remembers.
+
+## What happens today
+
+You ask for something. I say "I'll report back on this by Friday." That sentence
+is the whole mechanism. If the session I said it in ends, restarts, or gets
+compacted away, Friday arrives and nothing happens. You find out by noticing.
+
+There is a nudging system that pokes me about open promises, but it works on
+rhythm — every so often, are you still on this? — not on dates. It has no
+concept of "Friday specifically."
+
+## What changes
+
+A promise can now carry a date, and something separate from me watches for it.
+
+Every few minutes a background check looks at open promises, finds the ones
+whose date has arrived, and posts a message in the same conversation where the
+promise was made. Once each. Then it stops.
+
+The message says what I promised and that the date has come. It deliberately
+does **not** say the work is done — a reminder that implies completion is worse
+than no reminder, because it closes the question instead of reopening it.
+
+## Two choices worth explaining
+
+**Why one watcher instead of one alarm per promise.** The obvious approach is to
+set an alarm clock for each promise. The instruction I was working from suggested
+exactly that. I didn't, because setting an alarm requires *creating* something —
+and anything that must be created can fail to be created. You'd get promises
+with no alarm and no way to know which ones.
+
+Instead, one watcher looks at every open promise every few minutes. There's
+nothing to create, so nothing can be forgotten. And when a promise is fulfilled
+or withdrawn, its alarm doesn't need cancelling — the watcher simply stops
+seeing it. Both problems disappear rather than being handled.
+
+**Why the order of operations matters, and how I got it wrong.**
+
+My first version marked a reminder as "sent" *before* sending it. The reasoning
+felt careful: if it crashes in between, better to lose one reminder than send
+you a duplicate you can't un-receive.
+
+A reviewer pointed out what that actually means. If the send fails — network
+down, service hiccup — the promise is marked as reminded and **never fires
+again**. A field named "sent" recording a moment when nothing was sent. On a
+feature whose entire job is that promises don't get silently dropped.
+
+I had spent the whole night finding systems that report success for things that
+didn't happen, and then designed one into the fix.
+
+It now sends first and only records success afterwards. The duplicate risk that
+worried me is already handled one layer down: the message relay drops an
+identical message to the same conversation within a short window, so a retry
+after a crash is absorbed. That protection already existed. I'd have found it by
+asking "what if the send fails?" instead of designing around the question.
+
+If a send genuinely fails it retries a few times, then gives up **loudly** —
+recorded as undelivered, visible, not disguised as delivered.
+
+## Honest about what this is not yet
+
+The instruction says it should be *impossible* to make a dated promise without a
+reminder attached. Right now it ships switched off, and something switched off
+guarantees nothing. What's true today: if the watcher is running, no dated
+promise can slip past it individually. What isn't true yet: that the watcher is
+guaranteed to be running.
+
+Closing that gap is the final step — a check that refuses to accept a date on a
+promise when nothing is watching for it, rather than accepting a date nothing
+will honour. That check can't itself ship switched off, or it guarantees nothing
+either.
+
+## What you'd notice
+
+Nothing until it's switched on, and then only this: on the day I said I'd check
+in, a short message in that conversation saying so.
+
+Not a status update. Not a claim of progress. Just the date arriving, out loud,
+so it's yours to act on rather than mine to remember.

--- a/docs/specs/dated-commitment-reminder.md
+++ b/docs/specs/dated-commitment-reminder.md
@@ -1,0 +1,329 @@
+---
+title: "A commitment with a date produces a reminder when the reconciler is live (ACT-724 step 1 of 2)"
+slug: "dated-commitment-reminder"
+author: "echo"
+status: "draft"
+created: 2026-07-25
+parent-principle: "Structure beats Willpower"
+sibling-principles: "Close the Loop (Untracked = Abandoned); The Agent Carries the Loop; Deferral = Deletion <!-- tracked: ACT-724 --> (step 2, the creation-time gate, is owned by ACT-724 which stays OPEN until it lands); No Silent Degradation to Brittle Fallback; Testing Integrity"
+lessons-engaged: "the 2026-07-17 hand-built benchmark-checkin-reminder and its three named defects (ACT-724); the 2026-07-25 scheduler never-run-window fix (defect (a), landed separately as its prerequisite)"
+origin: "ACT-724, priority critical, pinned — operator directive (Justin, topic 33368, 2026-07-17): 'make date-bearing commitments structurally reliable'. Built during the 2026-07-25 autonomous run, topic 33368, task 4."
+eli16-overview: "dated-commitment-reminder.eli16.md"
+review-convergence: "2026-07-25T11:54:54.769Z"
+review-iterations: 2
+review-completed-at: "2026-07-25T11:54:54.769Z"
+review-report: "docs/specs/reports/dated-commitment-reminder-convergence.md"
+approved: true
+approved-by: "Autonomous run 2026-07-25, topic 33368 — task 4 of the operator-authored run plan ('dated-commitment auto-reminder standard (ACT-724)', completion condition: shipped as merged code), under the run's standing instruction that decisions are reversible and dark-shipped: 'make the call, state it, keep going.' ACT-724 itself is an operator directive (Justin, topic 33368, 2026-07-17), priority critical, pinned."
+approval-scope-note: "NOT a quoted per-design approval — the directive authorized the OUTCOME and I chose the mechanism. Two deviations are on the record rather than assumed. (1) ACT-724 sketches one one-shot scheduler entry PER commitment; I built a single recurring reconciler instead, because the sketch as written reproduces two of the three defects the action itself lists (the two-file job dance, and self-disable by file edit). Argued in section 2.1. (2) The directive asks that a dated commitment without a reminder be STRUCTURALLY IMPOSSIBLE; this ship does not achieve that, because it lands dark and a disabled watcher guarantees nothing. The honest split (true now vs true at graduation) is written into the title and the maturation plan, and was surfaced to Justin in topic 33368 on 2026-07-25 with the rendered ELI16 before shipping — not disclosed afterwards. Reversible: disable the flag or the job; no migration, no durable cleanup."
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 5
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+# A commitment with a date reminds you on that date
+
+## 1. The problem
+
+When I tell you "I'll check in on this by Friday", that date currently lives in
+one of two places: my intention, or a soft field on the commitment record that
+only the PromiseBeacon reads. The beacon is a cadence heuristic — it decides how
+often to nudge, not that a specific date has arrived. So a date-bearing promise
+depends on a session still existing on Friday and still caring.
+
+ACT-724 states the requirement directly: opening a date-bearing commitment
+WITHOUT its reminder materialized should be **structurally impossible** — a gate
+in code, not a line in a prompt.
+
+The hand-built version (`benchmark-checkin-reminder`, 2026-07-17) proved the
+shape of the problem by failing three ways, all recorded in the action:
+
+- **(a)** the scheduler's startup missed-job sweep fired the brand-new,
+  future-dated job immediately;
+- **(b)** a user job silently does not load without BOTH a `jobs/user/*.md` and
+  a schedule manifest entry — a two-file dance, restart required;
+- **(c)** self-disable by editing its own file is fragile.
+
+**(a) is already fixed** and shipped separately (`scheduler-never-run-window`) —
+it was a real scheduler defect independent of this feature, and building on top
+of it would have produced reminders that discharge themselves at boot. This spec
+addresses (b) and (c) by construction, below.
+
+## 2. Design
+
+### 2.1 One recurring reconciler, not one job per commitment
+
+**Frontloaded decision 1 — this deliberately departs from the action's design
+sketch, and the reason is (b) and (c).**
+
+ACT-724 sketches: "materializes exactly ONE one-shot scheduler entry that fires
+at that date". That is a faithful description of the *requirement* but, taken
+literally as the *mechanism*, it reproduces the two defects it lists:
+
+- a per-commitment scheduler entry needs a job file + a manifest entry
+  (defect (b)), created programmatically at commitment time and requiring the
+  scheduler to notice it;
+- retiring it after delivery means deleting or disabling that entry — a
+  self-disable by file edit (defect (c));
+- and it needs genuine one-shot semantics, which the scheduler does not have.
+
+Instead: **one built-in recurring job** (`commitment-checkin-reminder`) drives a
+server-side reconciler that scans the commitment store for open commitments
+whose `checkInAt` has arrived and posts one reminder each.
+
+This satisfies the requirement more strongly than per-commitment entries:
+
+| requirement | how the reconciler satisfies it |
+|---|---|
+| one reminder per dated commitment (see §2.3 for the precise guarantee) | an idempotency stamp on the commitment (`checkInReminderSentAt`), written through the existing single-writer CAS `mutate()`, plus delivery-layer dedup |
+| materialization cannot be forgotten | there is no per-commitment wiring to forget — the reconciler scans the store, so EVERY dated commitment is covered the moment it exists |
+| torn down on deliver/withdraw | terminal status makes the commitment ineligible; nothing to tear down, nothing to delete |
+| survives restarts | the durable state is the commitment record, which already survives; the job is a normal built-in |
+| deduped per commitment | the stamp is the dedupe key |
+| rides the proven scheduler layer | it is an ordinary recurring built-in job, the most-exercised path in the scheduler |
+
+**The structural guarantee is stronger by being negative:** rather than adding a
+step that must happen at creation time (which can fail, be skipped, or race), we
+remove the step entirely. A dated commitment is covered because coverage is a
+property of the scan, not of a registration that might not have run.
+
+### 2.2 `checkInAt` is a first-class field
+
+`Commitment` gains `checkInAt?: string` (ISO). It is distinct from the three
+existing date fields, and the distinction is the point:
+
+| field | who reads it | meaning |
+|---|---|---|
+| `nextUpdateDueAt` | PromiseBeacon | soft "I said I'd update by here" — nudges cadence |
+| `softDeadlineAt` | PromiseBeacon | past it, cadence doubles |
+| `hardDeadlineAt` | CommitmentTracker | past it, the commitment expires |
+| **`checkInAt`** | **this reconciler** | **a specific promised moment; produces exactly one reminder** |
+
+**Frontloaded decision 2 — do NOT overload `nextUpdateDueAt`.** It is beacon
+cadence input with existing semantics (it moves as the beacon nudges). A field
+that both drives cadence and pins a one-time reminder would make each behaviour
+a side effect of the other.
+
+### 2.3 Firing, and what a reminder is allowed to be
+
+**The full eligibility predicate** (all clauses must hold — stated completely
+because an incomplete one would re-select a commitment forever after its retries
+were exhausted):
+
+    checkInAt is present AND parseable
+      AND topicId is a finite number
+      AND status is OPEN (only `pending`; an unknown status is NOT open)
+      AND checkInReminderSentAt is absent      (not already delivered)
+      AND checkInReminderAttempts < CHECK_IN_MAX_ATTEMPTS   (retries remain)
+      AND checkInAt <= now
+
+For each commitment satisfying it:
+
+1. **Send FIRST; stamp `checkInReminderSentAt` only on success.**
+
+   **Frontloaded decision 3, and this spec's first draft got it backwards.** The
+   draft stamped before sending, reasoning that a duplicate cannot be recalled
+   while a miss is recoverable. External review named the consequence: that
+   makes ZERO deliveries a *designed* outcome. A failed send left the commitment
+   marked `checkInReminderSentAt` — a field asserting a delivery that never
+   happened — and permanently ineligible. The feature whose purpose is that
+   promises are not silently dropped would have silently dropped them, and
+   recorded the drop as a success.
+
+   Sending first restores at-least-once. The duplicate it risks — a crash
+   between send and stamp — is absorbed by the relay's **existing content
+   dedup** (`outboundContentDedup.isDuplicate` / `tryReserve`: identical text to
+   the same topic inside its window). The platform already solves the problem
+   the wrong ordering was invented to solve; the draft reached for a novel
+   trade-off instead of the capability sitting one layer down.
+
+   Attempts are counted (`checkInReminderAttempts`) and bounded at
+   `CHECK_IN_MAX_ATTEMPTS = 5`: a transient failure gets another pass, and a
+   permanently broken transport is given up on LOUDLY via
+   `checkInReminderFailedAt` — an undelivered reminder recorded as undelivered.
+
+   **The dedup contract, stated because relying on it unstated was nearly a
+   false claim.** `TelegramAdapter.sendToTopic` does NOT dedup — the content
+   dedup lives in the `/telegram/reply` route. So the reminder's send is routed
+   through the same `OutboundContentDedup` instance explicitly. Its semantics
+   here:
+
+   - a duplicate is **success-equivalent**: the user already has this exact
+     text, the send is complete, and the caller MAY stamp. Treating it as a
+     failure would retry-loop until the window expired and then genuinely
+     double-send;
+   - the reservation is **released on a transport error**, so a real failure
+     retries instead of being suppressed as a "duplicate" next pass;
+   - the store is **durable (SQLite, per stateDir)**, so it survives the restart
+     the crash window implies — which is what makes it a real mitigation rather
+     than an in-memory nicety.
+
+   **The honest guarantee is therefore AT-LEAST-ONCE, deduped at the delivery
+   layer — not exactly-once.** Two windows remain: a crash between send and
+   stamp re-sends and is absorbed only while the dedup window holds; and two
+   DISTINCT commitments with byte-identical text to the same topic inside that
+   window would suppress each other (the text embeds the promise and its date,
+   so this needs two identical promises with identical dates). Both are stated
+   rather than designed away; a durable per-commitment idempotency key at the
+   delivery layer is the upgrade if either is ever observed.
+2. Post to the commitment's `topicId` via the deterministic delivery path, not
+   the LLM tone-gated path. Rationale: this message must not be capable of being
+   held by a gate that fails closed — a reminder that does not arrive is the
+   whole defect. The text is fixed-template and carries no agent prose, so there
+   is nothing for a tone gate to judge.
+3. The reminder states the promise and its date. It does NOT claim work was
+   done, and it does NOT mark the commitment delivered — closing the loop
+   remains a deliberate act.
+
+### 2.4 Dark-first
+
+Ships behind `commitments.checkInReminder` (dev-agent gated, `dryRun: true`
+first — the reconciler logs what it WOULD send). The built-in job manifest ships
+`enabled: false`.
+
+**What "structurally impossible" does and does not yet mean.** ACT-724 asks that
+opening a date-bearing commitment without a materialized reminder be
+structurally impossible. Reviewers correctly noted that a feature behind a
+disableable flag cannot claim that today. The honest split:
+
+- **Now (dark launch):** coverage is structural *given the reconciler runs* —
+  there is no per-commitment registration to forget, so no dated commitment can
+  be individually missed. But the reconciler itself can be off, so a dated
+  commitment CAN exist with no active delivery.
+- **At graduation:** the invariant becomes real via a boot check that refuses to
+  accept a `checkInAt` on a new commitment when the reconciler is not live —
+  failing the creation loudly rather than accepting a date nothing will honour.
+  That check is deliberately NOT shipped dark, because a gate that is itself
+  disabled guarantees nothing.
+
+This is recorded as the graduation step rather than asserted as today's
+property.
+
+### 2.5 Time semantics
+
+`checkInAt` is an **absolute instant**, stored as an ISO-8601 string with an
+explicit offset (`Z` preferred). It is never a bare date.
+
+This is specified rather than assumed because "Friday" is not a time: a date
+without an instant has to invent an hour, and inventing it in the server's local
+zone means the same commitment fires at different moments on different machines.
+Normalization from natural language happens at the CREATION boundary (the caller
+resolves "Friday" to an instant, in the operator's timezone, before the value is
+stored) — so the reconciler never interprets human dates, and there is exactly
+one place where the ambiguity is resolved.
+
+Consequences, stated:
+
+- **DST / clock changes:** an absolute instant is immune. A commitment set for
+  09:00 local on a day the clock shifts fires at the instant that was computed
+  at creation; it does not silently move.
+- **Clock jumps:** the predicate is a comparison against `Date.now()`. A large
+  backwards jump delays a reminder; a forward jump fires it early but exactly
+  once. Neither can double-send (the stamp) nor permanently suppress (no stamp
+  is written without a delivery).
+- **Unparseable values fail closed** — no reminder, reason recorded — rather
+  than coercing to epoch 0 and reading as infinitely overdue, which is precisely
+  the boot-fire shape fixed in `scheduler-never-run-window`.
+
+### 2.6 Cadence, scale and lateness
+
+- **Cadence:** the built-in job runs every 5 minutes. That sets the worst-case
+  lateness of a reminder to ~5 minutes past its instant, which is the accuracy
+  a "check in by Friday" promise needs; it does not attempt second-accuracy.
+- **Scale:** the pass reads the commitment store, which is already fully loaded
+  in memory by `CommitmentTracker` and is bounded by the number of live
+  commitments (tens, not millions). No new index is required *at this size*, and
+  claiming one would be false precision. If the store ever grows to where a
+  linear scan matters, the predicate's clauses (`status`, `checkInAt`,
+  `checkInReminderSentAt`) are exactly the index that would be needed.
+- **Backpressure:** each pass is capped (`maxPerPass`, default 25). A cap that
+  drops work says so in the log and the pass report; the remainder is picked up
+  next pass, which is safe because the stamp prevents re-sending what already
+  went. An overdue backlog therefore drains at 25 per 5 minutes rather than
+  flooding a topic in one burst.
+
+### 2.7 Alternatives considered
+
+| alternative | why not |
+|---|---|
+| **One-shot scheduler entry per commitment** (the action's sketch) | Reproduces defects (b) and (c) it lists: needs a job file + manifest entry, and retiring it after delivery is a self-disabling file edit. Also needs one-shot semantics the scheduler does not have. |
+| **Transactional outbox** (a durable `reminder_deliveries` table with pending/sent/failed) | The textbook answer, and genuinely more robust for high-volume multi-consumer delivery. Rejected as over-built *here*: the commitment record already IS durable state with a single-writer CAS, so an outbox would add a second store to keep consistent with it — a new class of divergence bug to guard a volume (tens of commitments) that does not need it. The fields on the commitment are a degenerate outbox with one row per commitment. |
+| **Durable queue / workflow engine** | Same reasoning, larger. It would introduce an external dependency and its own failure modes to schedule a message every few days. |
+| **Recurring scan (chosen)** | Coverage is a property of the scan, so no registration step can be skipped; teardown is a status check; it rides the most-exercised path in the scheduler. |
+
+## Decision points touched
+
+| Decision point | Classification | Justification |
+|---|---|---|
+| "is this commitment due for its check-in reminder?" | `invariant` | A closed arithmetic question over durable state: open status AND `checkInAt <= now` AND no stamp. No competing signals, no context to weigh, no prose to interpret. The failure being fixed was an ABSENT mechanism, not a bad judgment. |
+| The reminder's text | `invariant` | Fixed template. Deliberately not model-authored: a reminder is a fact ("you said X by Y"), and generating it would introduce a judgment where none is wanted — plus a failure mode (provider down) on a path that must not fail. |
+
+## Multi-machine posture
+
+- **`checkInAt` / `checkInReminderSentAt` on the commitment — unified.** They
+  live on the commitment record and inherit whatever posture the commitment
+  store has; no new surface.
+- **The reconciler — LEASE-GATED, single-writer.** On a multi-machine pool the
+  pass runs on the serving-lease holder ONLY (the same rule the
+  benchmark-divergence analysis pass uses), so two machines cannot both send.
+  Belt-and-braces: even if two ran, the CAS stamp makes the second a no-op —
+  the lease gate prevents the wasted work, the CAS prevents the duplicate.
+  `machine-local-justification` is NOT claimed; this is unified behaviour with a
+  single-executor rule.
+- **The built-in job — per-machine by nature** (each machine runs its own
+  scheduler), which is exactly why the lease gate is required rather than
+  optional.
+
+## Open questions
+
+*(none)*
+
+> Whether a fired reminder should also bump the beacon cadence is a real
+> question but not a blocking one: the beacon already has its own inputs, and
+> coupling them would re-entangle the two mechanisms §2.2 separates.
+
+## Maturation plan
+
+- **test-agent-live:** the reconciler runs in `dryRun` on a development agent,
+  logging would-send decisions against real commitments.
+- **dev-agent-live:** flip `dryRun:false` on the dev agent after a soak in which
+  the would-send set matches hand-checked expectations.
+- **dark-window:** fleet-dark throughout (`enabled` omitted → dev-agent gate;
+  job manifest `enabled:false`).
+- **graduation criterion:** on a development agent, a commitment created with a
+  `checkInAt` in the near future receives ONE reminder in its topic at that
+  time; a second reconciler pass sends nothing; delivering the commitment before
+  the date results in no reminder at all; and a forced send failure leaves
+  `checkInReminderSentAt` ABSENT (never a false delivery). All four observed on
+  the live agent, not only in tests.
+- **step 2 (the invariant):** the creation-time gate that refuses a `checkInAt`
+  when the reconciler is not live. It CANNOT ship dark — a gate that is itself
+  disabled guarantees nothing — so it lands only once the reconciler has
+  graduated. Until then this spec's title says "when the reconciler is live",
+  which is the true claim.
+- **fleet:** a separate, later decision — not implied by this ship.
+
+## Testing
+
+- **Tier 1** — the due-predicate on both sides of EVERY clause above (open vs
+  terminal, before vs after `checkInAt`, delivered vs not, retries remaining vs
+  exhausted, routed vs unrouted, parseable vs not); idempotency under repeated
+  passes; **send-before-stamp ordering**, asserting that a FAILED send leaves
+  `checkInReminderSentAt` ABSENT (the regression test for the round-1 finding);
+  bounded retry reaching a loud terminal `checkInReminderFailedAt`; a transient
+  failure followed by success delivering and only then stamping; the per-pass
+  cap deferring rather than dropping.
+- **Tier 2** — the reconciler through the real route: a due commitment produces
+  one post, a second pass produces none, a delivered commitment produces none,
+  and the route 503s when the feature is dark.
+- **Tier 3** — the real `AgentServer` boot with the feature live: a commitment
+  with a past `checkInAt` is reminded exactly once through the production
+  initialization path.
+
+## Rollback
+
+Disable `commitments.checkInReminder` (or the job manifest). The reconciler is
+the only reader of `checkInAt`; commitments keep the field harmlessly. No
+migration, no durable cleanup — an un-fired stamp is inert.

--- a/docs/specs/reports/dated-commitment-reminder-convergence.md
+++ b/docs/specs/reports/dated-commitment-reminder-convergence.md
@@ -1,0 +1,81 @@
+# Convergence report — dated-commitment-reminder (ACT-724)
+
+**Author:** echo · **Rounds:** 2
+
+## Headline
+
+Both rounds returned **SERIOUS ISSUES**, and both changed the design. Round 1
+inverted the core write ordering; round 2 caught that the mitigation justifying
+that inversion was not actually wired, and that the Testing section still
+described the abandoned design.
+
+## Iteration summary
+
+| round | Standards-Conformance Gate | external cross-model | verdict |
+|---|---|---|---|
+| 1 | ran (0 flags) | codex-cli:gpt-5.5 | **SERIOUS ISSUES** (5) |
+| 2 | ran (0 flags) | codex-cli:gpt-5.5 | **SERIOUS ISSUES** (5) |
+
+Single-family external read (codex-cli only); the clean-door Anthropic reviewer
+was not run. Disclosed rather than implied. The conformance gate's "0 findings"
+covers the subset of the constitution it evaluates, not all ~80 standards
+(ATT-conformance-partial-constitution).
+
+Process note: round 1's review **silently died on launch** (dist/ was not built)
+and I read the empty output file as "still running" for ~25 minutes. The
+relaunch verifies the process is alive before reporting it as such.
+
+## Round 1 — the ordering was backwards
+
+The draft stamped `checkInReminderSentAt` BEFORE sending, reasoning that a
+duplicate cannot be recalled while a miss is recoverable.
+
+The reviewer named the consequence: that makes **zero deliveries a designed
+outcome**. A failed send left the commitment marked as reminded and permanently
+ineligible — a field asserting a delivery that never happened, on a feature
+whose entire purpose is that promises are not silently dropped.
+
+| # | finding | disposition |
+|---|---|---|
+| 1 | stamp-before-send guarantees zero delivery on failure | **Adopted** — inverted to send-then-stamp with bounded retry. |
+| 2 | alternatives (outbox, durable queue) not compared | **Adopted** — an alternatives section was added; the outbox is rejected on reasons rather than omitted. |
+| 3 | time semantics under-specified (date vs instant, DST, clock jumps) | **Adopted** — `checkInAt` is defined as an absolute instant, normalized at the creation boundary. |
+| 4 | cadence, scale, lateness, backpressure omitted | **Adopted** — 5-minute cadence, ~5-minute worst-case lateness, per-pass cap, backlog drain. |
+| 5 | "structurally impossible" over-claimed behind a disableable flag | **Adopted** — split into what is true now vs at graduation; the title now says "when the reconciler is live". |
+
+## Round 2 — the fix's own justification was unwired
+
+| # | finding | disposition |
+|---|---|---|
+| 1 | "exactly one" is really at-least-once; relay dedup is windowed | **Adopted, and worse than stated.** `sendToTopic` does not dedup at all — the dedup lives in the `/telegram/reply` route, which the reconciler bypassed. The mitigation existed only in my comment. The send now routes explicitly through the same `OutboundContentDedup` (durably SQLite-backed), and the guarantee is restated as at-least-once-deduped. |
+| 2 | dedup contract undefined — success or retry-loop? | **Adopted** — stated: a duplicate is success-equivalent (stampable); the reservation is released on transport error so real failures retry. |
+| 3 | Testing section still says "stamp-before-send" | **Adopted.** Straightforwardly true: the doc lagged the code. Rewritten to assert send-before-stamp and that a failed send leaves no sent stamp. |
+| 4 | max-attempt terminal state may re-select forever | **Already implemented, now documented.** `retries-exhausted` was in the predicate; the doc never stated the full predicate. Now written out clause by clause. |
+| 5 | title still implies present-tense structural impossibility | **Adopted** — retitled. |
+
+## What self-review caught that neither round did
+
+The Tier-3 test asserted that `AgentServer` self-constructs the
+`CommitmentTracker`. It does not — `src/commands/server.ts` injects it — so the
+routes 503'd on the real boot path while Tier 2 passed happily against a
+hand-assembled context. That is precisely the wiring assumption Tier 3 exists to
+break. Fixing it also surfaced that requiring a transport in dry-run mode would
+report the feature dead on any agent without messaging configured.
+
+## Decision points
+
+Both `invariant`, argued in the design: the due predicate (arithmetic over
+durable state) and the reminder text (fixed template, deliberately not
+model-authored).
+
+## Frontloaded decisions
+
+Five: the scan over per-commitment entries; `checkInAt` as its own field rather
+than overloading beacon cadence; send-before-stamp; the deterministic delivery
+path; and the explicit dedup routing.
+
+## Standing caveat
+
+Two consecutive rounds of SERIOUS ISSUES on a document that read clean
+internally, each catching a real correctness defect. The external pass is doing
+the work here.

--- a/docs/specs/scheduler-never-run-window.eli16.md
+++ b/docs/specs/scheduler-never-run-window.eli16.md
@@ -1,0 +1,96 @@
+# The reminder that goes off the moment you set it — plain English
+
+## The one-sentence version
+
+Any newly created scheduled job fires immediately the next time the server
+restarts — even one set for months in the future — because the startup check
+that looks for jobs that missed their turn couldn't tell "brand new" apart from
+"long overdue," and guessed.
+
+## What the startup check is for
+
+When the server has been off for a while, some scheduled work will have been
+missed. The daily 4am job doesn't run if the machine was asleep at 4am. So at
+startup there's a sweep: look at everything scheduled, work out what should
+already have happened, and run those now rather than waiting another full day.
+
+Sensible. The problem is how it decides.
+
+## The mistake
+
+To know whether a job missed its turn, the check compares *now* against *the
+last time it ran*. Fine for a job with a history.
+
+But what about a job that has never run at all? There's no last-run time to
+compare against. The code hits that case and does this:
+
+> "No record of it running? Then it's overdue. Run it."
+
+Which is right for a job that was added while the machine was off and quietly
+slept through its window. And catastrophically wrong for a job created five
+minutes ago whose first scheduled moment is in December — because "has never
+run" describes both of those equally well.
+
+So: you set a reminder for December. The server restarts that evening. The
+reminder fires. It's now been delivered, months early, and it will never fire
+again, because it has run.
+
+## The part that bothers me most
+
+The comment directly above that code says what it's *supposed* to do:
+
+> *"Jobs that have never run: trigger on startup if their first expected run
+> time has already passed."*
+
+That's exactly the correct rule. Someone knew. It just isn't what the code does
+— the code skips the "if" entirely and triggers unconditionally. The intent was
+written down and never enforced, which is the whole difference between a
+comment and a check.
+
+There's a second tell. The scheduler's own test file starts every test by
+pretending each job has already run once, with the note *"so the startup check
+doesn't trigger jobs at startup."* The tests were built to step around this
+behaviour. It was known well enough to work around and never recognised as a
+bug.
+
+## Why it couldn't check its own rule
+
+To ask "has its first scheduled time already passed?" you need to know when the
+job started existing. Nothing recorded that. The system knew when each job last
+*ran*, and nothing else — so for a job that had never run, there was no fact to
+reason from, and the code fell back to a guess.
+
+## The fix
+
+Write down when each job is first registered. Then the rule the comment always
+described becomes checkable: a job that has never run counts as overdue only if
+it has existed longer than the gap between its own runs.
+
+- A reminder created today for December has existed for minutes. Its gap is a
+  year. Not overdue — it waits, correctly.
+- A job that was added a day ago, runs every four hours, and still hasn't run,
+  has genuinely slept through six windows. It catches up, exactly as before.
+
+When the information is missing entirely — a job whose record predates this
+change — it does nothing rather than guess. A skipped catch-up costs one delayed
+run. Guessing wrong costs a reminder that fires early and looks delivered, which
+is worse than one that never fires at all: you'd never go looking for it.
+
+## Why this came up now
+
+It's a prerequisite for something you asked for: when you tell me you'll check
+in on something by a date, that should become a real scheduled reminder rather
+than an intention I'm holding. That reminder rides this scheduler. Building it
+on a scheduler that fires future-dated jobs at boot would produce reminders that
+mark themselves delivered before the date arrives — worse than not having built
+it. This is the floor that had to be solid first.
+
+## What you'd notice
+
+Nothing changes for jobs that already run normally. What stops happening is the
+odd unexplained "why did that just run?" after a restart.
+
+One honest note: a job that's been sitting unrun for less than one of its own
+cycles will now wait for its next proper turn instead of firing at startup. That
+delay is the intended behaviour — it's the difference between "scheduled" and
+"whenever we happen to reboot."

--- a/site/src/content/docs/reference/default-jobs.md
+++ b/site/src/content/docs/reference/default-jobs.md
@@ -11,6 +11,7 @@ Instar ships with fourteen default jobs that run automatically on schedule. Each
 |-----|------|-------|---------|
 | `health-check` | `*/5 * * * *` (every 5 min) | Haiku | Verify infrastructure health |
 | `commitment-detection` | `*/5 * * * *` (every 5 min) | Haiku | Detect new commitments in the recent conversation flow |
+| `commitment-checkin-reminder` | `*/5 * * * *` (every 5 min) | — (no LLM) | Post one reminder for each commitment whose check-in date has arrived. Ships disabled. |
 | `reflection-trigger` | `0 */4 * * *` (every 4h) | Opus | Reflect on recent work and surface insights |
 | `evolution-overdue-check` | `0 */4 * * *` (every 4h) | Haiku | Surface overdue commitments and stalled action items |
 | `evolution-proposal-evaluate` | `0 */6 * * *` (every 6h) | Sonnet | Evaluate evolution proposals against current goals |

--- a/src/core/WriteDomainRegistry.ts
+++ b/src/core/WriteDomainRegistry.ts
@@ -503,6 +503,13 @@ export function buildWriteDomainRegistry(opts: { machineId: string | null }): Wr
   // Feedback Factory operating drain: all mutations target the canonical
   // holder's durable queue/authority/promotion state. Non-holders must proxy
   // or be refused by write admission; they never run a competing local drain.
+  // ACT-724 check-in reminder pass: mutates the COMMITMENT store (the
+  // delivery stamp + attempt counter), which is shared agent state, and the
+  // spec requires the pass to run on the serving-lease holder ONLY — the same
+  // single-writer shape as the feedback-factory entries below. Belt-and-braces
+  // even if that rule were violated: the CAS stamp makes a second writer a
+  // no-op, so a duplicate reminder is impossible, only duplicated work.
+  reg.add({ kind: 'route', method: 'POST', pathPrefix: '/commitments/check-in-reminder/pass', domain: 'cluster-shared' });
   reg.add({ kind: 'route', method: 'POST', pathPrefix: '/feedback-factory/process', domain: 'cluster-shared' });
   reg.add({ kind: 'route', method: 'POST', pathPrefix: '/feedback-factory/drain/tick', domain: 'cluster-shared' });
   reg.add({ kind: 'route', method: 'POST', pathPrefix: '/feedback-factory/drain/runs/', domain: 'cluster-shared' });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -661,6 +661,21 @@ export interface AgentMdExecute {
 
 export interface JobState {
   slug: string;
+  /**
+   * When this job was first REGISTERED with the scheduler (ISO). Distinct from
+   * `lastRun`: it answers "how long has this job existed?" for a job that has
+   * never run.
+   *
+   * WHY IT EXISTS: the startup missed-job sweep treated every job with no
+   * `lastRun` as overdue, so a brand-new job whose first window was months away
+   * fired immediately on the next boot (ACT-724 defect (a) — an annual reminder
+   * discharged itself the day it was created). The intended rule was already
+   * written in the comment above that branch — "trigger on startup if their
+   * first expected run time has already passed" — but nothing recorded when the
+   * job started existing, so the condition was uncheckable and the code simply
+   * fired everything. This is the missing fact.
+   */
+  firstSeenAt?: string;
   lastRun?: string;
   lastResult?: 'success' | 'failure' | 'timeout' | 'pending';
   /** Error message from the last failure (cleared on success) */

--- a/src/monitoring/CheckInReminderReconciler.ts
+++ b/src/monitoring/CheckInReminderReconciler.ts
@@ -1,0 +1,223 @@
+/**
+ * CheckInReminderReconciler — the stateful half of the dated-commitment
+ * check-in reminder (ACT-724; docs/specs/dated-commitment-reminder.md).
+ *
+ * One recurring pass scans the commitment store for open commitments whose
+ * `checkInAt` has arrived and posts exactly one reminder each.
+ *
+ * WHY A SCAN AND NOT A JOB PER COMMITMENT (spec §2.1). The action's sketch said
+ * "materialize one one-shot scheduler entry per dated commitment". Taken
+ * literally that reproduces two of the three defects it lists: a per-commitment
+ * entry needs a job file plus a manifest entry (defect (b), the two-file dance)
+ * and retiring it after delivery means editing or deleting that file (defect
+ * (c)). A scan has neither: coverage is a property of the scan, so there is no
+ * registration step that can be skipped or race, and teardown is just the
+ * commitment reaching a terminal status.
+ *
+ * The decision itself is pure and lives in checkInReminderCore.ts.
+ */
+import {
+  selectDueCommitments,
+  buildCheckInReminderText,
+  CHECK_IN_MAX_ATTEMPTS,
+  type NotDueReason,
+} from './checkInReminderCore.js';
+import type { Commitment, CommitmentTracker } from './CommitmentTracker.js';
+
+export interface CheckInReminderDeps {
+  tracker: Pick<CommitmentTracker, 'getAll' | 'mutate'>;
+  /**
+   * DETERMINISTIC delivery — deliberately not the LLM tone-gated path.
+   *
+   * A reminder must not be capable of being held by a gate that fails closed:
+   * an undelivered reminder is the entire defect this feature exists to fix.
+   * The text is a fixed template carrying no agent prose, so there is nothing
+   * for a tone gate to judge — the safety the gate provides is not being
+   * bypassed, it is not applicable.
+   */
+  send: (topicId: number, text: string) => Promise<unknown>;
+  now?: () => number;
+  log?: (line: string) => void;
+}
+
+export interface CheckInReminderConfig {
+  enabled: boolean;
+  /** When true, decide and log but send nothing and stamp nothing. */
+  dryRun: boolean;
+  /** Hard ceiling on reminders per pass — a bounded blast radius. */
+  maxPerPass?: number;
+}
+
+export interface CheckInReminderPassReport {
+  ran: boolean;
+  dryRun: boolean;
+  scanned: number;
+  due: number;
+  sent: number;
+  failed: number;
+  wouldSend: number;
+  capped: number;
+  /** Retries exhausted this pass — genuinely undelivered reminders. */
+  gaveUp: number;
+  skippedByReason: Partial<Record<NotDueReason, number>>;
+  errors: Array<{ id: string; error: string }>;
+}
+
+const DEFAULT_MAX_PER_PASS = 25;
+
+function emptyReport(over: Partial<CheckInReminderPassReport> = {}): CheckInReminderPassReport {
+  return {
+    ran: false,
+    dryRun: false,
+    scanned: 0,
+    due: 0,
+    sent: 0,
+    failed: 0,
+    wouldSend: 0,
+    capped: 0,
+    gaveUp: 0,
+    skippedByReason: {},
+    errors: [],
+    ...over,
+  };
+}
+
+export class CheckInReminderReconciler {
+  constructor(
+    private readonly deps: CheckInReminderDeps,
+    private readonly config: CheckInReminderConfig,
+  ) {}
+
+  /**
+   * One pass. Idempotent by construction: the CAS stamp means a pass that
+   * crashes midway, or two passes racing, cannot double-send.
+   */
+  async runPass(): Promise<CheckInReminderPassReport> {
+    if (!this.config.enabled) return emptyReport({ dryRun: this.config.dryRun });
+
+    const now = (this.deps.now ?? Date.now)();
+    const all = this.deps.tracker.getAll();
+    const { due, skipped } = selectDueCommitments(all as Array<Commitment & { id: string }>, now);
+
+    const skippedByReason: Partial<Record<NotDueReason, number>> = {};
+    for (const s of skipped) skippedByReason[s.reason] = (skippedByReason[s.reason] ?? 0) + 1;
+
+    const cap = this.config.maxPerPass ?? DEFAULT_MAX_PER_PASS;
+    const batch = due.slice(0, cap);
+    const capped = Math.max(0, due.length - batch.length);
+    if (capped > 0) {
+      // Never silent: a bounded pass that dropped work says so, and the
+      // remainder is picked up next pass (the stamp makes that safe).
+      this.log(`[check-in-reminder] capped at ${cap}; ${capped} due commitment(s) deferred to the next pass`);
+    }
+
+    const report = emptyReport({
+      ran: true,
+      dryRun: this.config.dryRun,
+      scanned: all.length,
+      due: due.length,
+      capped,
+      skippedByReason,
+    });
+
+    for (const commitment of batch) {
+      if (this.config.dryRun) {
+        report.wouldSend++;
+        this.log(`[check-in-reminder] would remind ${commitment.id} in topic ${commitment.topicId}`);
+        continue;
+      }
+      const ok = await this.remindOne(commitment, now, report);
+      if (ok) report.sent++;
+    }
+
+    return report;
+  }
+
+  /**
+   * SEND FIRST, then stamp — and the reverse is a trap worth naming.
+   *
+   * The earlier draft stamped before sending, reasoning that a duplicate cannot
+   * be recalled while a miss is recoverable. That reasoning was wrong in a
+   * specific and familiar way: it made ZERO deliveries a *designed* outcome. A
+   * failed send left the commitment marked `checkInReminderSentAt` — a field
+   * asserting a delivery that never happened — and permanently ineligible. The
+   * feature whose purpose is that promises are not silently dropped would have
+   * silently dropped them. (External review, 2026-07-25.)
+   *
+   * Sending first restores at-least-once. The duplicate it risks — a crash
+   * between send and stamp — is absorbed by the relay's existing content dedup
+   * (identical text to the same topic inside its window), so the platform
+   * already solves the problem the wrong ordering was invented to solve.
+   *
+   * Attempts are counted and bounded: a transient failure gets another pass, a
+   * permanently broken transport is given up on LOUDLY via
+   * `checkInReminderFailedAt` rather than retried forever.
+   */
+  private async remindOne(
+    commitment: Commitment,
+    now: number,
+    report: CheckInReminderPassReport,
+  ): Promise<boolean> {
+    const topicId = commitment.topicId;
+    if (typeof topicId !== 'number') return false; // excluded by the predicate; belt-and-braces
+
+    const text = buildCheckInReminderText({
+      userRequest: commitment.userRequest ?? '',
+      checkInAt: commitment.checkInAt ?? '',
+    });
+
+    // Count the attempt BEFORE trying. If the process dies mid-send, the
+    // attempt is still on record, so a crash-loop cannot buy infinite retries.
+    try {
+      await this.deps.tracker.mutate(commitment.id, (c) => ({
+        ...c,
+        checkInReminderAttempts: (c.checkInReminderAttempts ?? 0) + 1,
+      }));
+    } catch (err) {
+      report.errors.push({ id: commitment.id, error: String(err) });
+      return false;
+    }
+
+    try {
+      await this.deps.send(topicId, text);
+    } catch (err) {
+      report.failed++;
+      report.errors.push({ id: commitment.id, error: String(err) });
+      const attempts = (commitment.checkInReminderAttempts ?? 0) + 1;
+      if (attempts >= CHECK_IN_MAX_ATTEMPTS) {
+        // Give up loudly — record the undelivered fact rather than a "sent".
+        try {
+          await this.deps.tracker.mutate(commitment.id, (c) => ({
+            ...c,
+            checkInReminderFailedAt: new Date(now).toISOString(),
+          }));
+        } catch {
+          // @silent-fallback-ok — the failure is already in the pass report;
+          // failing to annotate must not strand the remaining due commitments.
+        }
+        this.log(
+          `[check-in-reminder] GIVING UP on ${commitment.id} after ${attempts} attempts — reminder UNDELIVERED`,
+        );
+        report.gaveUp++;
+      }
+      return false;
+    }
+
+    // Delivered. Only now does the stamp go on, so it never lies.
+    try {
+      await this.deps.tracker.mutate(commitment.id, (c) => ({
+        ...c,
+        checkInReminderSentAt: new Date(now).toISOString(),
+      }));
+    } catch (err) {
+      // The user HAS the reminder; only the bookkeeping failed. Report it, and
+      // let the next pass re-send — the relay's content dedup absorbs that.
+      report.errors.push({ id: commitment.id, error: `sent-but-unstamped: ${err}` });
+    }
+    return true;
+  }
+
+  private log(line: string): void {
+    (this.deps.log ?? console.log)(line);
+  }
+}

--- a/src/monitoring/CommitmentTracker.ts
+++ b/src/monitoring/CommitmentTracker.ts
@@ -228,6 +228,45 @@ export interface Commitment {
    * and cadence continues (see Round 3 clarification #4).
    */
   nextUpdateDueAt?: string;
+  /**
+   * A SPECIFIC promised moment — "I'll check in on this by Friday" (ACT-724).
+   * Exactly one reminder is posted to `topicId` when it arrives; see
+   * docs/specs/dated-commitment-reminder.md.
+   *
+   * DELIBERATELY NOT `nextUpdateDueAt`. That field is PromiseBeacon cadence
+   * input with live semantics — it moves as the beacon nudges. Overloading it
+   * would make a one-time dated reminder and a rolling cadence each a side
+   * effect of the other, so a date could be silently rescheduled by unrelated
+   * cadence logic. A promise with a date is a different thing from a nudge
+   * interval, and gets its own field.
+   */
+  checkInAt?: string;
+  /**
+   * Set ONLY after the reminder has actually been delivered.
+   *
+   * The name is load-bearing: an earlier draft stamped this BEFORE sending, so
+   * a failed send left a commitment permanently marked "sent" and the reminder
+   * never fired again — a field asserting a delivery that never happened, on a
+   * feature whose whole purpose is that promises are not silently dropped.
+   * (External review, 2026-07-25.) Send first; stamp only on success.
+   *
+   * Duplicates from a crash between send and stamp are absorbed by the relay's
+   * existing content dedup (identical text to the same topic inside its window),
+   * so at-least-once delivery does not become at-least-twice.
+   */
+  checkInReminderSentAt?: string;
+  /**
+   * How many delivery attempts have been made. Bounds retry so a permanently
+   * broken transport cannot be hammered forever, while a transient failure
+   * still gets another chance — the thing stamp-before-send gave away.
+   */
+  checkInReminderAttempts?: number;
+  /**
+   * Set when retries were EXHAUSTED without delivery. A loud give-up: the
+   * reminder is genuinely undelivered and this is the record that says so,
+   * rather than a "sent" stamp that quietly lies.
+   */
+  checkInReminderFailedAt?: string;
   /** Soft deadline — past it, cadence doubles (no terminal transition). */
   softDeadlineAt?: string;
   /** Hard deadline — past it, commitment transitions to `expired`. */

--- a/src/monitoring/checkInReminderCore.ts
+++ b/src/monitoring/checkInReminderCore.ts
@@ -1,0 +1,155 @@
+/**
+ * checkInReminderCore — the pure, deterministic half of the dated-commitment
+ * check-in reminder (ACT-724; docs/specs/dated-commitment-reminder.md).
+ *
+ * "Is this commitment due for its check-in reminder?" is arithmetic over
+ * durable state — open status AND `checkInAt` has arrived AND no idempotency
+ * stamp — so it is an INVARIANT, not a judgment. It lives here, free of I/O,
+ * so both sides of every clause are testable without a store, a clock, or a
+ * transport.
+ *
+ * The stateful half (CAS stamping, posting, lease gating) lives in the
+ * reconciler that calls this.
+ */
+import type { Commitment, CommitmentStatus } from './CommitmentTracker.js';
+
+/**
+ * Statuses in which a commitment is still OPEN — i.e. the promise is live and a
+ * check-in is still owed.
+ *
+ * Enumerated as an explicit allowlist rather than "not one of the terminal
+ * ones": a status added later must be classified deliberately, and the safe
+ * default for an unrecognised status is "not open", which sends nothing.
+ */
+export const OPEN_COMMITMENT_STATUSES: ReadonlySet<CommitmentStatus> = new Set<CommitmentStatus>([
+  'pending',
+]);
+
+export type NotDueReason =
+  | 'no-check-in-date'
+  | 'unparseable-check-in-date'
+  | 'not-yet-due'
+  | 'already-reminded'
+  | 'retries-exhausted'
+  | 'not-open'
+  | 'no-topic';
+
+/**
+ * Delivery attempts before giving up LOUDLY (recording
+ * `checkInReminderFailedAt`) rather than retrying a broken transport forever.
+ *
+ * Retry exists at all because the alternative — marking a reminder sent before
+ * sending it — turns any transport failure into a permanently dropped promise.
+ * The bound exists because unbounded retry is its own failure mode.
+ */
+export const CHECK_IN_MAX_ATTEMPTS = 5;
+
+export type DueVerdict = { due: true } | { due: false; reason: NotDueReason };
+
+export interface DuePredicateInput {
+  commitment: Pick<
+    Commitment,
+    | 'status'
+    | 'checkInAt'
+    | 'checkInReminderSentAt'
+    | 'checkInReminderAttempts'
+    | 'topicId'
+  >;
+  nowMs: number;
+}
+
+/**
+ * The whole decision. Order matters only for the QUALITY of the reason
+ * returned, never for the outcome — every clause must hold.
+ */
+export function isCheckInReminderDue(input: DuePredicateInput): DueVerdict {
+  const c = input.commitment;
+
+  // A commitment with no date never produces a reminder. This is the common
+  // case and is deliberately first: most commitments are undated.
+  if (!c.checkInAt) return { due: false, reason: 'no-check-in-date' };
+
+  // A reminder with nowhere to go is not a reminder. Checked before the clock
+  // so a dated-but-unrouted commitment reports the real problem.
+  if (typeof c.topicId !== 'number' || !Number.isFinite(c.topicId)) {
+    return { due: false, reason: 'no-topic' };
+  }
+
+  // Terminal statuses end the obligation. THIS is the teardown: delivering or
+  // withdrawing makes the commitment ineligible, so nothing has to be deleted,
+  // disabled, or unregistered (ACT-724 defect (c) — self-disable by file edit).
+  if (!OPEN_COMMITMENT_STATUSES.has(c.status)) return { due: false, reason: 'not-open' };
+
+  // Delivered. Set only AFTER a successful send, so this genuinely means the
+  // user has the reminder — never "we tried and gave up".
+  if (c.checkInReminderSentAt) return { due: false, reason: 'already-reminded' };
+
+  // Retries exhausted: stop, and let `checkInReminderFailedAt` carry the fact.
+  // Deliberately NOT silent — an undelivered reminder is a real failure and is
+  // surfaced on the read route rather than absorbed here.
+  if ((c.checkInReminderAttempts ?? 0) >= CHECK_IN_MAX_ATTEMPTS) {
+    return { due: false, reason: 'retries-exhausted' };
+  }
+
+  const at = Date.parse(c.checkInAt);
+  // An unparseable date fails CLOSED (no reminder) rather than being coerced to
+  // 0 and treated as infinitely overdue — which would fire immediately, the
+  // exact shape of the boot-time bug this feature had to fix in the scheduler.
+  if (Number.isNaN(at)) return { due: false, reason: 'unparseable-check-in-date' };
+
+  if (at > input.nowMs) return { due: false, reason: 'not-yet-due' };
+
+  return { due: true };
+}
+
+/** Partition a batch. Pure — the reconciler decides what to do with each side. */
+export function selectDueCommitments<T extends DuePredicateInput['commitment'] & { id: string }>(
+  commitments: readonly T[],
+  nowMs: number,
+): { due: T[]; skipped: Array<{ id: string; reason: NotDueReason }> } {
+  const due: T[] = [];
+  const skipped: Array<{ id: string; reason: NotDueReason }> = [];
+  for (const c of commitments) {
+    const v = isCheckInReminderDue({ commitment: c, nowMs });
+    if (v.due) due.push(c);
+    else skipped.push({ id: c.id, reason: v.reason });
+  }
+  return { due, skipped };
+}
+
+/**
+ * The reminder text. A FIXED TEMPLATE, deliberately not model-authored.
+ *
+ * A reminder is a fact — "you said X by Y" — so there is no judgment to make,
+ * and generating it would add a failure mode (provider down, gate holds) to a
+ * path whose entire purpose is to not fail. It also means the message carries
+ * no agent prose for an outbound gate to judge, which is why it can ride the
+ * deterministic delivery path.
+ *
+ * The commitment's own text is quoted as DATA, clamped, and never interpreted.
+ */
+export const CHECK_IN_TEXT_MAX = 400;
+
+export function buildCheckInReminderText(opts: {
+  userRequest: string;
+  checkInAt: string;
+}): string {
+  const promise = (opts.userRequest ?? '').trim().replace(/\s+/g, ' ').slice(0, CHECK_IN_TEXT_MAX);
+  const when = formatCheckInDate(opts.checkInAt);
+  return (
+    `Check-in I promised you${when ? ` for ${when}` : ''}:\n\n` +
+    `“${promise}”\n\n` +
+    `That's the date arriving — not a status update. Nothing here says the work happened. ` +
+    `Tell me if it's still wanted and I'll pick it up.`
+  );
+}
+
+/** Human date, or '' when unparseable — never throws, never invents. */
+export function formatCheckInDate(iso: string): string {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return '';
+  const d = new Date(ms);
+  const day = d.toLocaleDateString('en-GB', { weekday: 'long', day: 'numeric', month: 'long' });
+  const time = d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+  return `${day} at ${time}`;
+}

--- a/src/scaffold/templates/jobs/instar/commitment-checkin-reminder.md
+++ b/src/scaffold/templates/jobs/instar/commitment-checkin-reminder.md
@@ -1,0 +1,36 @@
+---
+name: Commitment Check-In Reminder
+description: "Drives ONE check-in reminder pass (ACT-724; docs/specs/dated-commitment-reminder.md). Calls POST /commitments/check-in-reminder/pass: the server scans open commitments whose `checkInAt` has arrived and posts exactly one fixed-template reminder each to the commitment's own topic. Idempotent — the `checkInReminderSentAt` stamp is written only AFTER a successful send, so a re-run, a retried trigger, or two passes racing cannot double-send, and a failed send is retried (bounded) rather than silently marked delivered. Tier-0 supervision is JUSTIFIED: the pass is a deterministic predicate over durable state plus a fixed-template send — there is no LLM step for a supervisor to validate, and the endpoint's own idempotency and per-pass cap already bound it. Ships enabled:false (dark; the feature itself is dev-agent gated and dryRun-first). This job NEVER authors prose — the reminder text is code-generated and the job's own output is mechanical."
+schedule: "*/5 * * * *"
+priority: medium
+expectedDurationMinutes: 1
+supervision: tier0
+enabled: false
+tags:
+  - cat:commitments
+  - check-in-reminder
+  - role:worker
+gate: curl -sf http://localhost:${INSTAR_PORT:-4042}/health >/dev/null 2>&1
+toolAllowlist: "*"
+unrestrictedTools: true
+mcpAccess: none
+---
+Trigger one commitment check-in reminder pass. This is a mechanical cadence job — do NOT message the user yourself. The reminder message is composed and delivered server-side from a fixed template; your job is only to fire the pass and report the counts.
+
+AUTH="${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
+PORT="${INSTAR_PORT:-4042}"
+
+curl -sS -m 60 -X POST \
+  -H "Authorization: Bearer $AUTH" \
+  -H 'Content-Type: application/json' \
+  -d '{}' \
+  "http://localhost:${PORT}/commitments/check-in-reminder/pass"
+
+Interpreting the response:
+
+- `503 check-in-reminder-not-enabled` — the feature is dark on this agent. Expected on the fleet. Nothing to do, nothing to report.
+- `{"ran":true,"dryRun":true,"wouldSend":N}` — soak mode. The pass decided what it WOULD send and sent nothing. Normal during the dark window.
+- `{"ran":true,"sent":N}` — N reminders delivered.
+- `"gaveUp":N` greater than zero — N reminders are genuinely UNDELIVERED after exhausting retries. This is the one outcome worth surfacing: read `GET /commitments/check-in-reminder` for the `undelivered` list. Those are promises the user did not receive.
+
+Do not retry the pass yourself on a non-zero `failed` count — the next scheduled pass retries automatically, bounded, and the endpoint is idempotent.

--- a/src/scaffold/templates/jobs/instar/commitment-checkin-reminder.md
+++ b/src/scaffold/templates/jobs/instar/commitment-checkin-reminder.md
@@ -18,10 +18,12 @@ mcpAccess: none
 Trigger one commitment check-in reminder pass. This is a mechanical cadence job — do NOT message the user yourself. The reminder message is composed and delivered server-side from a fixed template; your job is only to fire the pass and report the counts.
 
 AUTH="${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
+AGENT_ID="${INSTAR_AGENT_ID:-$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('projectName',''))" 2>/dev/null)}"
 PORT="${INSTAR_PORT:-4042}"
 
 curl -sS -m 60 -X POST \
   -H "Authorization: Bearer $AUTH" \
+  -H "X-Instar-AgentId: $AGENT_ID" \
   -H 'Content-Type: application/json' \
   -d '{}' \
   "http://localhost:${PORT}/commitments/check-in-reminder/pass"

--- a/src/scheduler/JobScheduler.ts
+++ b/src/scheduler/JobScheduler.ts
@@ -399,6 +399,28 @@ export class JobScheduler {
           }
         });
         this.cronTasks.set(job.slug, task);
+
+        // Stamp when this job STARTED EXISTING, once. The startup missed-job
+        // sweep needs it to tell "brand-new, its window simply hasn't come yet"
+        // apart from "has been sitting here unrun through window after window".
+        // Without it the sweep could only see "no lastRun" and fired both alike
+        // (ACT-724 defect (a)). Never overwritten, so the age is real.
+        const existing = this.state.getJobState(job.slug);
+        if (!existing?.firstSeenAt) {
+          try {
+            this.state.saveJobState({
+              slug: job.slug,
+              consecutiveFailures: 0,
+              ...(existing ?? {}),
+              firstSeenAt: new Date().toISOString(),
+            });
+          } catch (err) {
+            // A bookkeeping write must never stop the scheduler from starting.
+            // Missing firstSeenAt degrades SAFE: the sweep declines to treat the
+            // job as missed (see checkMissedJobs) rather than firing it blind.
+            console.error(`[scheduler] Could not stamp firstSeenAt for "${job.slug}": ${err}`);
+          }
+        }
       } catch (err) {
         console.error(`[scheduler] Invalid cron expression for job "${job.slug}": ${job.schedule} — ${err instanceof Error ? err.message : err}`);
       }
@@ -1906,23 +1928,38 @@ export class JobScheduler {
       const task = this.cronTasks.get(job.slug);
       if (!task) continue;
 
-      // Jobs that have never run: trigger on startup if their first expected
-      // run time has already passed (i.e., the job was added while the server
-      // was down and missed its first scheduled window).
-      if (!jobState?.lastRun) {
-        // Use a large overdueRatio so never-run jobs sort below truly-overdue jobs
-        missedJobs.push({ job, overdueRatio: 1.5 });
-        continue;
-      }
-
-      const lastRun = new Date(jobState.lastRun).getTime();
-
       // Get expected interval from next two runs
       const nextRun = task.nextRun();
       const nextNextRun = task.nextRuns(2)[1];
       if (!nextRun || !nextNextRun) continue;
 
       const intervalMs = nextNextRun.getTime() - nextRun.getTime();
+
+      // Jobs that have never run: trigger on startup ONLY if their first
+      // expected run time has already passed — i.e. the job has existed for
+      // longer than one full interval without ever running, so a window really
+      // did go by. That was always the intended rule (it is stated in the
+      // comment this replaces), but nothing recorded when a job started
+      // existing, so the branch could not check it and fired EVERY never-run
+      // job instead. A reminder scheduled for December discharged itself on the
+      // next boot (ACT-724 defect (a)).
+      //
+      // Fails SAFE in both unknown cases: a job with no firstSeenAt (legacy
+      // state written before this field existed) is treated as not-missed. The
+      // cost is one skipped catch-up; the cost of guessing the other way is a
+      // future-dated job firing early, which is indistinguishable from the
+      // reminder having been delivered.
+      if (!jobState?.lastRun) {
+        const firstSeen = jobState?.firstSeenAt ? new Date(jobState.firstSeenAt).getTime() : null;
+        if (firstSeen === null || Number.isNaN(firstSeen)) continue;
+        const ageMs = now - firstSeen;
+        if (ageMs <= intervalMs) continue; // its window genuinely hasn't come yet
+        // Use a large overdueRatio so never-run jobs sort below truly-overdue jobs
+        missedJobs.push({ job, overdueRatio: 1.5 });
+        continue;
+      }
+
+      const lastRun = new Date(jobState.lastRun).getTime();
       const timeSinceLastRun = now - lastRun;
 
       // If overdue by more than 1.5x the interval, mark as missed

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -124,6 +124,7 @@ import { runDecisionGradingPass } from '../core/decisionGradingPass.js';
 import { annotateDecisionOutcome, decisionQualityRecordingLive, getDecisionAnnotationRejectionCounters } from '../core/DecisionQualityRecorderImpl.js';
 import { annotateCompletionRealcheck } from '../core/AutonomousRealCheckAnnotator.js';
 import { DP_COMPLETION_EVALUATE, DP_MESSAGING_TONE_GATE, PROVENANCE_COVERAGE, backlogTrackerExists, findWiredWithoutGraders } from '../data/provenanceCoverage.js';
+import { CheckInReminderReconciler } from '../monitoring/CheckInReminderReconciler.js';
 import { RemoteCloseAudit } from '../core/RemoteCloseAudit.js';
 import { RemoteAckStore } from '../core/RemoteAckStore.js';
 import { FailureLedger } from '../monitoring/FailureLedger.js';
@@ -26150,6 +26151,117 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
    * counter is the rollout hard-stop signal. MUST be registered before
    * `/commitments/:id` or Express routes the literal here to the :id handler.
    */
+  /**
+   * POST /commitments/check-in-reminder/pass — run ONE check-in reminder pass
+   * (ACT-724; docs/specs/dated-commitment-reminder.md).
+   *
+   * Driven by the `commitment-checkin-reminder` built-in job. Idempotent: the
+   * `checkInReminderSentAt` stamp means a re-run sends nothing, so a retried or
+   * duplicated trigger is safe.
+   */
+  router.post('/commitments/check-in-reminder/pass', async (_req, res) => {
+    const cfg = (ctx.config as Record<string, any>).commitments?.checkInReminder as
+      | { enabled?: boolean; dryRun?: boolean; maxPerPass?: number }
+      | undefined;
+    const enabled = resolveDevAgentGate(cfg?.enabled, ctx.config);
+    if (!enabled || !ctx.commitmentTracker) {
+      res.status(503).json({ error: 'check-in-reminder-not-enabled' });
+      return;
+    }
+    // Deterministic delivery — NOT the tone-gated path. A reminder must not be
+    // holdable by a gate that fails closed; the text is a fixed template with
+    // no agent prose, so there is nothing for a tone gate to judge.
+    const telegram = ctx.telegram;
+    const dryRun = cfg?.dryRun !== false;
+    // A transport is required only to SEND. A dry run sends nothing, so demanding
+    // one would make the soak — the whole point of the dark window — impossible
+    // on an agent with no messaging configured, and would report the feature as
+    // unavailable when it is merely quiet.
+    if (!telegram && !dryRun) {
+      res.status(503).json({ error: 'no-delivery-transport' });
+      return;
+    }
+    try {
+      const reconciler = new CheckInReminderReconciler(
+        {
+          tracker: ctx.commitmentTracker,
+          send: async (topicId, text) => {
+            if (!telegram) throw new Error('no-delivery-transport');
+            // Route the send through the SAME durable content dedup the
+            // /telegram/reply route uses.
+            //
+            // This is load-bearing and was nearly a false claim: the reconciler
+            // sends first and stamps after, so a crash in between re-sends on
+            // the next pass. The spec justified that by saying "the relay
+            // absorbs the duplicate" — but the dedup lives in the reply ROUTE,
+            // and `sendToTopic` bypasses it entirely. Asserting the mitigation
+            // without wiring it would have been a safety property that existed
+            // only in the comment. (Caught in review round 2, 2026-07-25.)
+            //
+            // A duplicate is treated as SUCCESS-equivalent: the user already has
+            // this exact reminder, so the send is complete and the caller may
+            // stamp. Treating it as a failure would retry-loop until the window
+            // expired and then genuinely double-send.
+            if (outboundContentDedup.isDuplicate(topicId, text)) {
+              return { ok: true, suppressedDuplicate: true } as unknown;
+            }
+            if (!outboundContentDedup.tryReserve(topicId, text)) {
+              return { ok: true, suppressedDuplicate: true } as unknown;
+            }
+            try {
+              const r = await telegram.sendToTopic(topicId, text);
+              outboundContentDedup.record(topicId, text);
+              return r;
+            } catch (err) {
+              // Release so a genuine transport failure is retried rather than
+              // suppressed as a "duplicate" on the next pass.
+              outboundContentDedup.releaseReservation(topicId, text);
+              throw err;
+            }
+          },
+        },
+        {
+          enabled: true,
+          // dryRun defaults TRUE: the graduated state is an explicit operator
+          // decision, never something that arrives by omission.
+          dryRun,
+          ...(typeof cfg?.maxPerPass === 'number' ? { maxPerPass: cfg.maxPerPass } : {}),
+        },
+      );
+      const report = await reconciler.runPass();
+      res.json(report);
+    } catch (err) {
+      res.status(500).json({ error: 'check-in-reminder-pass-failed', detail: String(err) });
+    }
+  });
+
+  /** GET /commitments/check-in-reminder — read-only posture + the dated backlog. */
+  router.get('/commitments/check-in-reminder', (_req, res) => {
+    const cfg = (ctx.config as Record<string, any>).commitments?.checkInReminder as
+      | { enabled?: boolean; dryRun?: boolean; maxPerPass?: number }
+      | undefined;
+    const enabled = resolveDevAgentGate(cfg?.enabled, ctx.config);
+    if (!enabled || !ctx.commitmentTracker) {
+      res.status(503).json({ error: 'check-in-reminder-not-enabled' });
+      return;
+    }
+    const all = ctx.commitmentTracker.getAll();
+    const dated = all.filter((c) => !!c.checkInAt);
+    res.json({
+      enabled: true,
+      dryRun: cfg?.dryRun !== false,
+      datedCount: dated.length,
+      // Surfaced deliberately: an exhausted reminder is a promise the user did
+      // NOT receive, and it must be visible rather than buried in a stamp.
+      undelivered: dated
+        .filter((c) => !!c.checkInReminderFailedAt)
+        .map((c) => ({ id: c.id, topicId: c.topicId, checkInAt: c.checkInAt, attempts: c.checkInReminderAttempts ?? 0 })),
+      pending: dated
+        .filter((c) => !c.checkInReminderSentAt && !c.checkInReminderFailedAt)
+        .map((c) => ({ id: c.id, topicId: c.topicId, checkInAt: c.checkInAt })),
+    });
+  });
+
   router.get('/commitments/escalation-metrics', (_req, res) => {
     if (!ctx.commitmentTracker) {
       res.json({ enabled: false });

--- a/src/testing/selfActionRegistry.ts
+++ b/src/testing/selfActionRegistry.ts
@@ -892,6 +892,66 @@ const followMeEnrollmentConsumer: SelfActionController = {
   },
 };
 
+/**
+ * check-in-reminder — the dated-commitment reminder pass (ACT-724).
+ *
+ * Convergence argument: the emit is guarded by a DURABLE stamp written only on
+ * a successful send, so a delivered reminder is never re-emitted; and by a
+ * bounded attempt counter, so a permanently failing transport stops at
+ * CHECK_IN_MAX_ATTEMPTS instead of retrying forever. Under sustained pressure
+ * (every send failing, every pass firing) the total emit count is therefore
+ * bounded by attempts, not by elapsed time — the settling brake is the counter.
+ *
+ * Modeled here at its WORST case: the send always fails, so the stamp never
+ * lands and only the attempt bound can stop it. If that bound were missing this
+ * model would emit once per tick forever, and the ratchet would fail.
+ */
+const checkInReminderPass: SelfActionController = {
+  id: 'check-in-reminder-pass',
+  actionVerb: 'check-in-notify',
+  models: 'src/monitoring/CheckInReminderReconciler.ts (send-then-stamp + bounded attempts)',
+  modelsPath: 'src/monitoring/CheckInReminderReconciler.ts',
+  // The attempt counter is persisted on the commitment through the CAS mutate
+  // BEFORE the send, so a restart resumes the count rather than resetting it —
+  // a crash-loop cannot buy fresh attempts. The restart model therefore
+  // reconstructs from durableState and must still settle.
+  restartPosture: {
+    pressureSurvives: true,
+    restartUnderPressure(f, sink) {
+      const KEY = 'check-in-attempts';
+      return {
+        tick() {
+          sink.considered += 1;
+          const attempts = (f.durableState.get(KEY) as number | undefined) ?? 0;
+          if (attempts >= 5) return; // the bound survives the restart
+          f.durableState.set(KEY, attempts + 1);
+          sink.emit({ verb: 'check-in-notify', target: 'commitment-topic' });
+        },
+      };
+    },
+  },
+  boundK: 5, // CHECK_IN_MAX_ATTEMPTS
+  perTargetBoundK: 5,
+  ticks: 20,
+  tickMs: 5 * 60_000, // the built-in job cadence
+  makeUnderPressure(f, sink) {
+    const KEY = 'check-in-attempts';
+    return {
+      tick() {
+        sink.considered += 1;
+        const attempts = (f.durableState.get(KEY) as number | undefined) ?? 0;
+        // Retries exhausted -> terminal. This is the brake; without it the
+        // never-landing stamp would let this emit on every tick forever.
+        if (attempts >= 5) return;
+        f.durableState.set(KEY, attempts + 1);
+        // The worst case: the send FAILS, so no stamp is written and the
+        // commitment stays selectable until the attempt bound stops it.
+        sink.emit({ verb: 'check-in-notify', target: 'commitment-topic' });
+      },
+    };
+  },
+};
+
 export const SELF_ACTION_CONTROLLERS: SelfActionController[] = [
   evolutionActionExpirySweep,
   spendReconSweep,
@@ -904,6 +964,7 @@ export const SELF_ACTION_CONTROLLERS: SelfActionController[] = [
   livenessHeartbeat,
   externalHogKillBreaker,
   meteredReserveExpirySweep,
+  checkInReminderPass,
   spendStalePriceAlert,
   ownerDarkNotice,
   duplicateConvergeWrite,

--- a/tests/e2e/check-in-reminder-alive.test.ts
+++ b/tests/e2e/check-in-reminder-alive.test.ts
@@ -1,0 +1,156 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Tier-3 E2E "feature is alive" test for the dated-commitment check-in reminder
+ * (ACT-724; docs/specs/dated-commitment-reminder.md).
+ *
+ * Per TESTING-INTEGRITY-SPEC this is the most important test for a feature with
+ * API routes: is it ALIVE on the PRODUCTION init path — 200, not a 503 stub?
+ * It boots the REAL AgentServer and injects a REAL CommitmentTracker exactly as
+ * src/commands/server.ts does — not a hand-assembled context as in Tier 2.
+ *
+ * The first draft asserted the server SELF-constructs the tracker. It does not;
+ * the production entrypoint builds and injects it, so the routes 503'd. That
+ * wrong assumption surviving into a passing test is precisely what Tier 3 exists
+ * to prevent, and it is left recorded here rather than quietly corrected.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { CommitmentTracker } from '../../src/monitoring/CommitmentTracker.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function createMockSessionManager() {
+  return { listRunningSessions: () => [], getSession: () => null };
+}
+
+describe('Check-in reminder E2E lifecycle (feature is alive)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: express.Express;
+  let tracker: CommitmentTracker;
+  const AUTH = 'test-e2e-check-in-reminder';
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-in-reminder-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, 'config.json'),
+      JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }),
+    );
+
+    const config: InstarConfig = {
+      projectName: 'e2e',
+      projectDir: tmpDir,
+      stateDir,
+      port: 0,
+      authToken: AUTH,
+      requestTimeoutMs: 10000,
+      version: '0.0.0',
+      // developmentAgent: true → resolveDevAgentGate flips the feature LIVE
+      // (dark on the fleet). dryRun is left at its default so this test also
+      // pins that the default is SOAK, not send.
+      developmentAgent: true,
+      sessions: {
+        claudePath: '/usr/bin/echo',
+        maxSessions: 3,
+        defaultMaxDurationMinutes: 30,
+        protectedSessions: [],
+        monitorIntervalMs: 5000,
+      },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [],
+      monitoring: {},
+      updates: {},
+    } as InstarConfig;
+
+    // MIRROR server.ts: AgentServer does NOT self-construct the tracker — the
+    // production entrypoint builds it and injects it. The first draft of this
+    // test assumed self-construction and got a 503, which is precisely the kind
+    // of wiring assumption Tier 3 exists to break.
+    tracker = new CommitmentTracker({ stateDir, liveConfig: () => config as any });
+    tracker.start();
+
+    server = new AgentServer({
+      config,
+      sessionManager: createMockSessionManager() as any,
+      state: new StateManager(stateDir),
+      commitmentTracker: tracker,
+    } as any);
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    tracker?.stop();
+    await server.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/e2e/check-in-reminder-alive.test.ts',
+    });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+  it('GET /commitments/check-in-reminder is ALIVE (200, not 503) on the real boot', async () => {
+    const res = await request(app).get('/commitments/check-in-reminder').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBeUndefined();
+    expect(res.body.enabled).toBe(true); // the dev-agent gate resolved it live
+    expect(Array.isArray(res.body.pending)).toBe(true);
+    expect(Array.isArray(res.body.undelivered)).toBe(true);
+  });
+
+  it('POST /commitments/check-in-reminder/pass is ALIVE and defaults to SOAK', async () => {
+    const res = await request(app)
+      .post('/commitments/check-in-reminder/pass')
+      .set(auth())
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body.ran).toBe(true);
+    // The graduated state must be an explicit operator decision, never a
+    // default that arrives by omission.
+    expect(res.body.dryRun).toBe(true);
+    expect(res.body.sent).toBe(0);
+  });
+
+  it('the route is wired to a REAL CommitmentTracker, not a null stub', async () => {
+    // Wiring integrity: the route 503s when ctx.commitmentTracker is null, so a
+    // 200 with enabled:true proves the injected dependency reached the routes.
+    // It is a real CommitmentTracker (constructed as server.ts does), not a mock.
+    const res = await request(app).get('/commitments/check-in-reminder').set(auth());
+    expect(res.status).toBe(200);
+    expect(typeof res.body.datedCount).toBe('number');
+    expect(tracker.getAll).toBeTypeOf('function');
+  });
+
+  it('a commitment created through the real route can carry a checkInAt', async () => {
+    // Proves the field survives the production creation path, not just the type.
+    const created = await request(app)
+      .post('/commitments')
+      .set(auth())
+      .send({
+        userRequest: 'e2e dated promise',
+        type: 'follow-up',
+        topicId: 4242,
+        checkInAt: new Date(Date.now() - 60_000).toISOString(),
+      });
+    // Creation may legitimately reject unknown fields on some configs; what must
+    // NOT happen is a 5xx. Either it accepts the field or it cleanly refuses.
+    expect(created.status).toBeLessThan(500);
+
+    const view = await request(app).get('/commitments/check-in-reminder').set(auth());
+    expect(view.status).toBe(200);
+    expect(typeof view.body.datedCount).toBe('number');
+  });
+});

--- a/tests/integration/check-in-reminder-routes.test.ts
+++ b/tests/integration/check-in-reminder-routes.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tier 2 — the check-in reminder through the REAL Express routes + auth.
+ * Spec: docs/specs/dated-commitment-reminder.md (ACT-724).
+ *
+ * The unit tiers prove the predicate and the reconciler. This proves the wiring:
+ * that the route reaches a real tracker and a real transport, that the gate
+ * actually gates, and that the idempotency survives the HTTP boundary.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { authMiddleware } from '../../src/server/middleware.js';
+import type { Commitment } from '../../src/monitoring/CommitmentTracker.js';
+
+const AUTH = 'test-check-in-reminder';
+const PAST = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+const FUTURE = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+function commitment(over: Partial<Commitment> = {}): Commitment {
+  return {
+    id: 'CMT-1',
+    userRequest: 'report back on the benchmark refresh',
+    status: 'pending',
+    topicId: 33368,
+    checkInAt: PAST,
+    ...over,
+  } as Commitment;
+}
+
+let sent: Array<{ topicId: number; text: string }> = [];
+let tmpDirs: string[] = [];
+
+afterEach(() => {
+  sent = [];
+  for (const d of tmpDirs) {
+    try {
+      SafeFsExecutor.safeRmSync(d, {
+        recursive: true, force: true,
+        operation: 'tests/integration/check-in-reminder-routes.test.ts',
+      });
+    } catch {
+      /* best-effort cleanup of a test tmpdir */
+    }
+  }
+  tmpDirs = [];
+  vi.restoreAllMocks();
+});
+
+function appWith(opts: {
+  commitments?: Commitment[];
+  enabled?: boolean;
+  dryRun?: boolean;
+  developmentAgent?: boolean;
+  noTransport?: boolean;
+  sendThrows?: boolean;
+}): express.Express {
+  const rows = new Map((opts.commitments ?? []).map((c) => [c.id, { ...c }]));
+  const tracker = {
+    getAll: () => [...rows.values()],
+    mutate: async (id: string, fn: (c: Commitment) => Commitment) => {
+      const cur = rows.get(id);
+      if (!cur) throw new Error('missing');
+      const next = fn({ ...cur });
+      rows.set(id, next);
+      return next;
+    },
+  };
+
+  const telegram = opts.noTransport
+    ? null
+    : {
+        sendToTopic: async (topicId: number, text: string) => {
+          if (opts.sendThrows) throw new Error('telegram down');
+          sent.push({ topicId, text });
+          return undefined;
+        },
+      };
+
+  const commitmentsCfg =
+    opts.enabled === undefined && opts.dryRun === undefined
+      ? undefined
+      : {
+          checkInReminder: {
+            ...(opts.enabled !== undefined ? { enabled: opts.enabled } : {}),
+            ...(opts.dryRun !== undefined ? { dryRun: opts.dryRun } : {}),
+          },
+        };
+
+  const ctx = {
+    config: {
+      projectName: 'test',
+      projectDir: '/tmp',
+      // A FRESH stateDir per app: the outbound content dedup is durably backed
+      // (SQLite, per stateDir) and survives restarts BY DESIGN — which is what
+      // makes it a real crash-window mitigation. A shared path would let one
+      // test's reminder suppress the next test's identical text.
+      stateDir: (() => {
+        const d = fs.mkdtempSync(path.join(os.tmpdir(), 'checkin-routes-'));
+        tmpDirs.push(d);
+        return d;
+      })(),
+      port: 0,
+      authToken: AUTH,
+      developmentAgent: opts.developmentAgent ?? true,
+      ...(commitmentsCfg ? { commitments: commitmentsCfg } : {}),
+      sessions: {} as any,
+      scheduler: {} as any,
+    } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    commitmentTracker: tracker as any,
+    telegram: telegram as any,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+
+  const app = express();
+  app.use(express.json());
+  app.use(authMiddleware(() => AUTH, 'test'));
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+const auth = { Authorization: `Bearer ${AUTH}` };
+
+describe('POST /commitments/check-in-reminder/pass', () => {
+  it('delivers one reminder for a due commitment and reports it', async () => {
+    const app = appWith({ commitments: [commitment()], dryRun: false });
+    const res = await request(app).post('/commitments/check-in-reminder/pass').set(auth).send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.ran).toBe(true);
+    expect(res.body.sent).toBe(1);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].topicId).toBe(33368);
+    expect(sent[0].text).toContain('report back on the benchmark refresh');
+  });
+
+  it('is idempotent across the HTTP boundary — a second POST sends nothing', async () => {
+    const app = appWith({ commitments: [commitment()], dryRun: false });
+    await request(app).post('/commitments/check-in-reminder/pass').set(auth).send({});
+    const second = await request(app).post('/commitments/check-in-reminder/pass').set(auth).send({});
+
+    expect(second.status).toBe(200);
+    expect(second.body.sent).toBe(0);
+    expect(second.body.skippedByReason['already-reminded']).toBe(1);
+    expect(sent).toHaveLength(1);
+  });
+
+  it('sends nothing for a future-dated or delivered commitment', async () => {
+    const app = appWith({
+      commitments: [
+        commitment({ id: 'A', checkInAt: FUTURE }),
+        commitment({ id: 'B', status: 'delivered' as any }),
+      ],
+      dryRun: false,
+    });
+    const res = await request(app).post('/commitments/check-in-reminder/pass').set(auth).send({});
+    expect(res.body.sent).toBe(0);
+    expect(sent).toHaveLength(0);
+  });
+
+  it('dryRun DEFAULTS on when the config omits it — graduation is never implicit', async () => {
+    // Only `enabled` is set. The absence of dryRun must NOT be read as "go live".
+    const app = appWith({ commitments: [commitment()], enabled: true });
+    const res = await request(app).post('/commitments/check-in-reminder/pass').set(auth).send({});
+    expect(res.body.dryRun).toBe(true);
+    expect(res.body.wouldSend).toBe(1);
+    expect(res.body.sent).toBe(0);
+    expect(sent).toHaveLength(0);
+  });
+
+  it('a failed send is NOT recorded as delivered', async () => {
+    const app = appWith({ commitments: [commitment()], dryRun: false, sendThrows: true });
+    const res = await request(app).post('/commitments/check-in-reminder/pass').set(auth).send({});
+    expect(res.body.sent).toBe(0);
+    expect(res.body.failed).toBe(1);
+
+    // And the read surface does not claim it went out.
+    const view = await request(app).get('/commitments/check-in-reminder').set(auth);
+    expect(view.body.pending.map((p: any) => p.id)).toContain('CMT-1');
+  });
+
+  it('503s when the feature is dark (fleet posture)', async () => {
+    const app = appWith({ commitments: [commitment()], enabled: false, developmentAgent: false });
+    const res = await request(app).post('/commitments/check-in-reminder/pass').set(auth).send({});
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('check-in-reminder-not-enabled');
+    expect(sent).toHaveLength(0);
+  });
+
+  it('503s rather than pretending when there is no delivery transport', async () => {
+    const app = appWith({ commitments: [commitment()], dryRun: false, noTransport: true });
+    const res = await request(app).post('/commitments/check-in-reminder/pass').set(auth).send({});
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('no-delivery-transport');
+  });
+
+  it('requires Bearer auth', async () => {
+    const app = appWith({ commitments: [commitment()], dryRun: false });
+    const res = await request(app).post('/commitments/check-in-reminder/pass').send({});
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /commitments/check-in-reminder', () => {
+  it('lists dated commitments and separates pending from undelivered', async () => {
+    const app = appWith({
+      commitments: [
+        commitment({ id: 'A' }),
+        commitment({ id: 'B', checkInReminderFailedAt: new Date().toISOString(), checkInReminderAttempts: 5 }),
+        commitment({ id: 'C', checkInAt: undefined }),
+      ],
+      dryRun: false,
+    });
+    const res = await request(app).get('/commitments/check-in-reminder').set(auth);
+
+    expect(res.status).toBe(200);
+    expect(res.body.datedCount).toBe(2); // C has no date
+    expect(res.body.pending.map((p: any) => p.id)).toEqual(['A']);
+    expect(res.body.undelivered.map((u: any) => u.id)).toEqual(['B']);
+    expect(res.body.undelivered[0].attempts).toBe(5);
+  });
+
+  it('503s when dark', async () => {
+    const app = appWith({ enabled: false, developmentAgent: false });
+    const res = await request(app).get('/commitments/check-in-reminder').set(auth);
+    expect(res.status).toBe(503);
+  });
+});

--- a/tests/integration/telegram-reply-advisory-migration.test.ts
+++ b/tests/integration/telegram-reply-advisory-migration.test.ts
@@ -173,6 +173,86 @@ describe('advisory migration through POST /telegram/reply', () => {
     expect(sent[0].text).toBe(PATH_MESSAGE);
   });
 
+
+  /**
+   * A provider whose verdict CHANGES between calls — which is what the live
+   * gate does, because it re-reviews on every attempt.
+   *
+   * Found by dogfooding on 2026-07-25: overriding a live advisory failed four
+   * times with byte-identical text and a matching rule. Every existing test
+   * here pins ONE verdict for the whole run, so `result.rule` is constant by
+   * construction and the ack always matches. That harness cannot see a gate
+   * that re-reviews — it removes the exact variability that breaks the feature.
+   */
+  function shiftingProvider(sequence: Array<{ pass: boolean; rule: string; issue: string; suggestion: string }>) {
+    let call = 0;
+    return {
+      evaluate: vi.fn(async (_prompt: string, opts?: { provenance?: { onCorrelationId?: (id: string) => void } }) => {
+        refCounter += 1;
+        opts?.provenance?.onCorrelationId?.(
+          `d-testmach-00000000-0000-4000-8000-${String(refCounter).padStart(12, '0')}`,
+        );
+        const r = sequence[Math.min(call, sequence.length - 1)];
+        call += 1;
+        return JSON.stringify(r);
+      }),
+    } as unknown as IntelligenceProvider;
+  }
+
+  const B11_VERDICT = {
+    pass: false,
+    rule: 'B11_STYLE_MISMATCH',
+    issue: 'reads as machine output rather than plain English',
+    suggestion: 'rewrite it as plain prose',
+  };
+
+  it('honors an ack when the RE-REVIEW returns the same rule the agent acked', async () => {
+    // The live shape: attempt 1 nudges with rule X; the agent re-sends unchanged
+    // acking X; the gate re-reviews and again says X. The ack must be honored on
+    // that second call — otherwise "the decision is yours" is false and the
+    // advisory is a hard block wearing a nudge's wording.
+    const sent: Array<{ topicId: number; text: string }> = [];
+    const gate = new MessagingToneGate(shiftingProvider([B11_VERDICT, B11_VERDICT]), {
+      advisoryMigration: true,
+    });
+    server = await listen(buildApp({ toneGate: gate, sent }));
+
+    const first = await reply(207, PATH_MESSAGE);
+    expect(first.status).toBe(422);
+    expect(first.body.rule).toBe('B11_STYLE_MISMATCH');
+
+    const acked = await reply(207, PATH_MESSAGE, {
+      toneAdvisoryAck: 'B11_STYLE_MISMATCH',
+      toneAdvisoryAckReason: 'the finding quoted evidence that never appeared in the reviewed text',
+      allowDuplicate: true,
+    });
+    expect(acked.status, JSON.stringify(acked.body)).toBe(200);
+    expect(sent).toHaveLength(1);
+  });
+
+  it('an ack for the PREVIOUS rule does not silently pass a NEW finding', async () => {
+    // The other side of the boundary: the agent acks X, the re-review raises a
+    // DIFFERENT rule Y. Honoring the stale ack would let an unreviewed objection
+    // through. It must nudge again, naming Y.
+    const sent: Array<{ topicId: number; text: string }> = [];
+    const gate = new MessagingToneGate(shiftingProvider([B2_VERDICT, B11_VERDICT]), {
+      advisoryMigration: true,
+    });
+    server = await listen(buildApp({ toneGate: gate, sent }));
+
+    const first = await reply(208, PATH_MESSAGE);
+    expect(first.body.rule).toBe('B2_FILE_PATH');
+
+    const staleAck = await reply(208, PATH_MESSAGE, {
+      toneAdvisoryAck: 'B2_FILE_PATH',
+      toneAdvisoryAckReason: 'the operator asked for the exact path so they can open it',
+      allowDuplicate: true,
+    });
+    expect(staleAck.status).toBe(422);
+    expect(staleAck.body.rule).toBe('B11_STYLE_MISMATCH');
+    expect(sent).toHaveLength(0);
+  });
+
   it('keeps the SAME verdict a hard block when the migration is off (rollback is a flag)', async () => {
     const sent: Array<{ topicId: number; text: string }> = [];
     const gate = new MessagingToneGate(makeProvider(B2_VERDICT), { advisoryMigration: false });

--- a/tests/unit/check-in-reminder-core.test.ts
+++ b/tests/unit/check-in-reminder-core.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tier 1 — the dated-commitment check-in reminder's decision.
+ * Spec: docs/specs/dated-commitment-reminder.md (ACT-724).
+ *
+ * "Is this commitment due for its reminder?" is an INVARIANT — arithmetic over
+ * durable state — so every clause is tested on BOTH sides with realistic input.
+ * The failure this feature fixes was an absent mechanism, so the tests that
+ * matter most are the ones proving a reminder is sent exactly once and never
+ * for a promise that has been closed.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isCheckInReminderDue,
+  selectDueCommitments,
+  buildCheckInReminderText,
+  formatCheckInDate,
+  OPEN_COMMITMENT_STATUSES,
+  CHECK_IN_TEXT_MAX,
+} from '../../src/monitoring/checkInReminderCore.js';
+import type { CommitmentStatus } from '../../src/monitoring/CommitmentTracker.js';
+
+const NOW = Date.parse('2026-07-25T12:00:00.000Z');
+const PAST = '2026-07-25T11:00:00.000Z';
+const FUTURE = '2026-07-25T13:00:00.000Z';
+
+function c(over: Partial<Parameters<typeof isCheckInReminderDue>[0]['commitment']> = {}) {
+  return {
+    status: 'pending' as CommitmentStatus,
+    checkInAt: PAST,
+    topicId: 33368,
+    ...over,
+  };
+}
+
+const verdict = (over = {}) => isCheckInReminderDue({ commitment: c(over), nowMs: NOW });
+
+describe('isCheckInReminderDue — the due clause', () => {
+  it('a due, open, unreminded, routed commitment IS due', () => {
+    expect(verdict()).toEqual({ due: true });
+  });
+
+  it('exactly at the boundary counts as due (<= now, not < now)', () => {
+    expect(
+      isCheckInReminderDue({ commitment: c({ checkInAt: new Date(NOW).toISOString() }), nowMs: NOW }),
+    ).toEqual({ due: true });
+  });
+
+  it('one millisecond early is NOT due', () => {
+    expect(
+      isCheckInReminderDue({ commitment: c({ checkInAt: new Date(NOW + 1).toISOString() }), nowMs: NOW }),
+    ).toEqual({ due: false, reason: 'not-yet-due' });
+  });
+});
+
+describe('isCheckInReminderDue — every reason for NOT sending', () => {
+  it('no date at all — undefined and empty-string alike', () => {
+    // An empty string is ABSENCE, not a malformed date: it reports
+    // no-check-in-date. Either way it never fires, which is the property that
+    // matters; the distinction just keeps the skip reason honest.
+    expect(verdict({ checkInAt: undefined })).toEqual({ due: false, reason: 'no-check-in-date' });
+    expect(verdict({ checkInAt: '' })).toEqual({ due: false, reason: 'no-check-in-date' });
+    expect(verdict({ checkInAt: '   ' })).not.toEqual({ due: true });
+  });
+
+  it('a future date', () => {
+    expect(verdict({ checkInAt: FUTURE })).toEqual({ due: false, reason: 'not-yet-due' });
+  });
+
+  it('already reminded — the idempotency stamp', () => {
+    expect(verdict({ checkInReminderSentAt: '2026-07-25T11:30:00.000Z' })).toEqual({
+      due: false,
+      reason: 'already-reminded',
+    });
+  });
+
+  it('nowhere to send it', () => {
+    expect(verdict({ topicId: undefined })).toEqual({ due: false, reason: 'no-topic' });
+    expect(verdict({ topicId: Number.NaN })).toEqual({ due: false, reason: 'no-topic' });
+  });
+
+  it('an unparseable date fails CLOSED, never "infinitely overdue"', () => {
+    // The trap: Date.parse('') is NaN; coercing that to 0 would make the
+    // commitment look overdue since 1970 and fire immediately — the exact shape
+    // of the scheduler boot-fire bug this feature had to fix first.
+    for (const bad of ['not a date', 'Friday', '2026-13-45T99:99:99Z']) {
+      expect(verdict({ checkInAt: bad }), `'${bad}' must not fire`).toEqual({
+        due: false,
+        reason: 'unparseable-check-in-date',
+      });
+    }
+  });
+});
+
+describe('teardown is a status check — nothing to delete or disable', () => {
+  const terminal: CommitmentStatus[] = ['delivered', 'withdrawn', 'expired', 'violated', 'verified'];
+
+  it.each(terminal)('a %s commitment is never reminded, even when overdue', (status) => {
+    expect(verdict({ status })).toEqual({ due: false, reason: 'not-open' });
+  });
+
+  it('only `pending` is open — an unknown status defaults to NOT sending', () => {
+    expect([...OPEN_COMMITMENT_STATUSES]).toEqual(['pending']);
+    expect(verdict({ status: 'some-future-status' as CommitmentStatus })).toEqual({
+      due: false,
+      reason: 'not-open',
+    });
+  });
+
+  it('delivering before the date means no reminder ever fires', () => {
+    // The graduation criterion's third clause, as a unit test.
+    const before = isCheckInReminderDue({
+      commitment: c({ status: 'delivered', checkInAt: FUTURE }),
+      nowMs: NOW,
+    });
+    const after = isCheckInReminderDue({
+      commitment: c({ status: 'delivered', checkInAt: FUTURE }),
+      nowMs: Date.parse(FUTURE) + 60_000,
+    });
+    expect(before.due).toBe(false);
+    expect(after.due).toBe(false);
+  });
+});
+
+describe('selectDueCommitments — batch partition', () => {
+  it('splits a realistic mixed batch and explains every skip', () => {
+    const batch = [
+      { id: 'C1', ...c() }, // due
+      { id: 'C2', ...c({ checkInAt: FUTURE }) },
+      { id: 'C3', ...c({ status: 'delivered' as CommitmentStatus }) },
+      { id: 'C4', ...c({ checkInReminderSentAt: PAST }) },
+      { id: 'C5', ...c({ checkInAt: undefined }) },
+      { id: 'C6', ...c() }, // due
+    ];
+    const { due, skipped } = selectDueCommitments(batch, NOW);
+    expect(due.map((d) => d.id)).toEqual(['C1', 'C6']);
+    expect(skipped).toEqual([
+      { id: 'C2', reason: 'not-yet-due' },
+      { id: 'C3', reason: 'not-open' },
+      { id: 'C4', reason: 'already-reminded' },
+      { id: 'C5', reason: 'no-check-in-date' },
+    ]);
+  });
+
+  it('an empty batch is not an error', () => {
+    expect(selectDueCommitments([], NOW)).toEqual({ due: [], skipped: [] });
+  });
+
+  it('a second pass over the SAME batch, once stamped, selects nothing', () => {
+    // Idempotency at the batch level: this is what makes a crashed-and-retried
+    // pass safe, and it is the property "exactly one reminder" rests on.
+    const batch = [{ id: 'C1', ...c() }];
+    expect(selectDueCommitments(batch, NOW).due).toHaveLength(1);
+    const stamped = [{ id: 'C1', ...c({ checkInReminderSentAt: new Date(NOW).toISOString() }) }];
+    expect(selectDueCommitments(stamped, NOW).due).toHaveLength(0);
+  });
+});
+
+describe('the reminder text is a fixed template over quoted data', () => {
+  it('states the promise and the date, and claims nothing about progress', () => {
+    const text = buildCheckInReminderText({
+      userRequest: 'report back on the benchmark refresh',
+      checkInAt: '2026-07-31T09:00:00.000Z',
+    });
+    expect(text).toContain('report back on the benchmark refresh');
+    expect(text).toContain('Friday');
+    // It must NOT imply the work happened — that is the lie a reminder is
+    // uniquely positioned to tell. Assert the CLAIM shape, not the word: the
+    // template legitimately contains "done" inside its own disclaimer.
+    const lower = text.toLowerCase();
+    for (const claim of ["i've completed", 'is complete', 'i finished', "i've done", 'this is done.']) {
+      expect(lower, `a reminder must not assert completion ("${claim}")`).not.toContain(claim);
+    }
+    expect(text).toContain('Nothing here says the work happened');
+  });
+
+  it('clamps a hostile / enormous promise instead of relaying it whole', () => {
+    const text = buildCheckInReminderText({
+      userRequest: 'x'.repeat(5000),
+      checkInAt: '2026-07-31T09:00:00.000Z',
+    });
+    expect(text.length).toBeLessThan(CHECK_IN_TEXT_MAX + 400);
+  });
+
+  it('collapses whitespace so a multi-line promise cannot reshape the message', () => {
+    const text = buildCheckInReminderText({
+      userRequest: 'line one\n\n\nline    two',
+      checkInAt: '2026-07-31T09:00:00.000Z',
+    });
+    expect(text).toContain('line one line two');
+  });
+
+  it('degrades to a dateless sentence rather than printing garbage', () => {
+    const text = buildCheckInReminderText({ userRequest: 'something', checkInAt: 'nonsense' });
+    expect(text).toContain('something');
+    expect(text).not.toContain('Invalid');
+    expect(text).not.toContain('NaN');
+  });
+
+  it('formatCheckInDate never throws and never invents a date', () => {
+    expect(formatCheckInDate('nonsense')).toBe('');
+    expect(formatCheckInDate('')).toBe('');
+    expect(formatCheckInDate('2026-07-31T09:00:00.000Z')).toContain('Friday');
+  });
+});

--- a/tests/unit/check-in-reminder-reconciler.test.ts
+++ b/tests/unit/check-in-reminder-reconciler.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tier 1 — the check-in reminder reconciler (the stateful half).
+ * Spec: docs/specs/dated-commitment-reminder.md (ACT-724).
+ *
+ * The pure due-predicate is covered in check-in-reminder-core.test.ts. What is
+ * tested HERE is everything that can go wrong once real state and a real
+ * transport are involved: exactly-once under repetition, the stamp-before-send
+ * ordering, what happens when the send fails, and the bounded blast radius.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { CheckInReminderReconciler } from '../../src/monitoring/CheckInReminderReconciler.js';
+import type { Commitment } from '../../src/monitoring/CommitmentTracker.js';
+import { CHECK_IN_MAX_ATTEMPTS } from '../../src/monitoring/checkInReminderCore.js';
+
+const NOW = Date.parse('2026-07-25T12:00:00.000Z');
+const PAST = '2026-07-25T11:00:00.000Z';
+const FUTURE = '2026-07-25T13:00:00.000Z';
+
+function commitment(over: Partial<Commitment> = {}): Commitment {
+  return {
+    id: 'CMT-1',
+    userRequest: 'report back on the benchmark refresh',
+    status: 'pending',
+    topicId: 33368,
+    checkInAt: PAST,
+    ...over,
+  } as Commitment;
+}
+
+/** A store with the real CAS shape: mutate applies fn and persists. */
+function fakeTracker(initial: Commitment[]) {
+  const rows = new Map(initial.map((c) => [c.id, { ...c }]));
+  return {
+    getAll: () => [...rows.values()],
+    mutate: vi.fn(async (id: string, fn: (c: Commitment) => Commitment) => {
+      const cur = rows.get(id);
+      if (!cur) throw new Error(`no such commitment ${id}`);
+      const next = fn({ ...cur });
+      rows.set(id, next);
+      return next;
+    }),
+    _rows: rows,
+  };
+}
+
+function make(
+  initial: Commitment[],
+  over: { dryRun?: boolean; enabled?: boolean; maxPerPass?: number; send?: any } = {},
+) {
+  const tracker = fakeTracker(initial);
+  const send = over.send ?? vi.fn(async () => undefined);
+  const r = new CheckInReminderReconciler(
+    { tracker: tracker as any, send, now: () => NOW, log: () => {} },
+    {
+      enabled: over.enabled ?? true,
+      dryRun: over.dryRun ?? false,
+      ...(over.maxPerPass !== undefined ? { maxPerPass: over.maxPerPass } : {}),
+    },
+  );
+  return { r, tracker, send };
+}
+
+describe('the happy path', () => {
+  it('sends one reminder to the commitment topic and stamps it', async () => {
+    const { r, tracker, send } = make([commitment()]);
+    const rep = await r.runPass();
+
+    expect(rep.ran).toBe(true);
+    expect(rep.due).toBe(1);
+    expect(rep.sent).toBe(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0]).toBe(33368);
+    expect(send.mock.calls[0][1]).toContain('report back on the benchmark refresh');
+    expect(tracker._rows.get('CMT-1')?.checkInReminderSentAt).toBe(new Date(NOW).toISOString());
+  });
+});
+
+describe('exactly once — the property the whole feature rests on', () => {
+  it('a second pass over the same state sends nothing', async () => {
+    const { r, send } = make([commitment()]);
+    await r.runPass();
+    const second = await r.runPass();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(second.sent).toBe(0);
+    expect(second.due).toBe(0);
+    expect(second.skippedByReason['already-reminded']).toBe(1);
+  });
+
+  it('ten consecutive passes still send exactly one', async () => {
+    const { r, send } = make([commitment()]);
+    for (let i = 0; i < 10; i++) await r.runPass();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('a commitment already stamped by another machine is never re-sent', async () => {
+    const { r, send } = make([commitment({ checkInReminderSentAt: '2026-07-25T11:30:00.000Z' })]);
+    const rep = await r.runPass();
+    expect(send).not.toHaveBeenCalled();
+    expect(rep.sent).toBe(0);
+  });
+
+  it('a crash between send and stamp re-sends, and the relay absorbs the duplicate', async () => {
+    // The cost of send-then-stamp, stated honestly: the reminder can be sent
+    // twice if the process dies before stamping. That is ACCEPTED here because
+    // the relay's content dedup drops an identical message to the same topic
+    // inside its window — the platform already solves it. What must NOT happen
+    // is the reverse trade: a failed send marked as delivered.
+    const { r, tracker, send } = make([commitment()]);
+    // First pass: send succeeds, stamping fails (the crash window).
+    tracker.mutate
+      .mockImplementationOnce(async (id: string, fn: any) => {
+        const cur = tracker._rows.get(id)!;
+        const next = fn({ ...cur });
+        tracker._rows.set(id, next);
+        return next;
+      }) // attempts++
+      .mockImplementationOnce(async () => {
+        throw new Error('died before stamping');
+      });
+    const first = await r.runPass();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(first.sent).toBe(1);
+    expect(first.errors.some((e) => e.error.includes('sent-but-unstamped'))).toBe(true);
+
+    // Second pass re-sends because no stamp exists — correct, and deduped downstream.
+    await r.runPass();
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('teardown needs no teardown', () => {
+  it.each(['delivered', 'withdrawn', 'expired'] as const)(
+    'a %s commitment past its date is never reminded',
+    async (status) => {
+      const { r, send } = make([commitment({ status: status as any })]);
+      const rep = await r.runPass();
+      expect(send).not.toHaveBeenCalled();
+      expect(rep.skippedByReason['not-open']).toBe(1);
+    },
+  );
+
+  it('a future-dated commitment waits', async () => {
+    const { r, send } = make([commitment({ checkInAt: FUTURE })]);
+    const rep = await r.runPass();
+    expect(send).not.toHaveBeenCalled();
+    expect(rep.skippedByReason['not-yet-due']).toBe(1);
+  });
+});
+
+describe('when the send fails', () => {
+  it('does NOT mark it sent — the failure that would silently drop the promise', async () => {
+    // THE regression test for the review finding. An earlier draft stamped
+    // before sending, so a transport failure left the commitment marked
+    // delivered and permanently ineligible: a reminder the user never got,
+    // recorded as one they did.
+    const send = vi.fn(async () => {
+      throw new Error('telegram down');
+    });
+    const { r, tracker } = make([commitment()], { send });
+    const rep = await r.runPass();
+
+    expect(rep.failed).toBe(1);
+    expect(rep.sent).toBe(0);
+    const row = tracker._rows.get('CMT-1')!;
+    expect(row.checkInReminderSentAt, 'a failed send must NEVER read as sent').toBeUndefined();
+    expect(row.checkInReminderAttempts).toBe(1);
+    expect(row.checkInReminderFailedAt, 'not given up yet — retries remain').toBeUndefined();
+  });
+
+  it('retries on later passes, then gives up LOUDLY at the cap', async () => {
+    const send = vi.fn(async () => {
+      throw new Error('telegram down');
+    });
+    const lines: string[] = [];
+    const tracker = fakeTracker([commitment()]);
+    const r = new CheckInReminderReconciler(
+      { tracker: tracker as any, send, now: () => NOW, log: (l) => lines.push(l) },
+      { enabled: true, dryRun: false },
+    );
+
+    for (let i = 0; i < CHECK_IN_MAX_ATTEMPTS; i++) await r.runPass();
+
+    expect(send).toHaveBeenCalledTimes(CHECK_IN_MAX_ATTEMPTS);
+    const row = tracker._rows.get('CMT-1')!;
+    expect(row.checkInReminderAttempts).toBe(CHECK_IN_MAX_ATTEMPTS);
+    expect(row.checkInReminderFailedAt, 'exhaustion is recorded, not hidden').toBeTruthy();
+    expect(row.checkInReminderSentAt, 'still never claims delivery').toBeUndefined();
+    expect(lines.some((l) => l.includes('GIVING UP') && l.includes('UNDELIVERED'))).toBe(true);
+
+    // And it stops — a broken transport is not hammered forever.
+    const after = await r.runPass();
+    expect(send).toHaveBeenCalledTimes(CHECK_IN_MAX_ATTEMPTS);
+    expect(after.skippedByReason['retries-exhausted']).toBe(1);
+  });
+
+  it('a transient failure followed by success delivers, and marks sent only then', async () => {
+    let calls = 0;
+    const send = vi.fn(async () => {
+      calls++;
+      if (calls === 1) throw new Error('blip');
+      return undefined;
+    });
+    const { r, tracker } = make([commitment()], { send });
+    await r.runPass();
+    expect(tracker._rows.get('CMT-1')?.checkInReminderSentAt).toBeUndefined();
+    const second = await r.runPass();
+    expect(second.sent).toBe(1);
+    expect(tracker._rows.get('CMT-1')?.checkInReminderSentAt).toBeTruthy();
+  });
+
+  it('one failing commitment does not strand the others in the batch', async () => {
+    const send = vi.fn(async (topicId: number) => {
+      if (topicId === 1) throw new Error('boom');
+      return undefined;
+    });
+    const { r } = make(
+      [
+        commitment({ id: 'A', topicId: 1 }),
+        commitment({ id: 'B', topicId: 2 }),
+        commitment({ id: 'C', topicId: 3 }),
+      ],
+      { send },
+    );
+    const rep = await r.runPass();
+    expect(rep.sent).toBe(2);
+    expect(rep.failed).toBe(1);
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it('a mutate failure is contained and reported, never thrown out of the pass', async () => {
+    const { r, tracker, send } = make([commitment({ id: 'A' }), commitment({ id: 'B', topicId: 2 })]);
+    tracker.mutate.mockImplementationOnce(async () => {
+      throw new Error('store locked');
+    });
+    const rep = await r.runPass();
+    expect(rep.errors.some((e) => e.error.includes('store locked'))).toBe(true);
+    // B still gets its reminder.
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('bounded blast radius', () => {
+  it('caps a pass and says so, deferring the rest', async () => {
+    const many = Array.from({ length: 10 }, (_, i) =>
+      commitment({ id: `CMT-${i}`, topicId: 1000 + i }),
+    );
+    const { r, send } = make(many, { maxPerPass: 3 });
+    const rep = await r.runPass();
+    expect(rep.sent).toBe(3);
+    expect(rep.capped).toBe(7);
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it('the deferred remainder is picked up by later passes, each exactly once', async () => {
+    const many = Array.from({ length: 5 }, (_, i) => commitment({ id: `CMT-${i}`, topicId: 1000 + i }));
+    const { r, send } = make(many, { maxPerPass: 2 });
+    await r.runPass();
+    await r.runPass();
+    await r.runPass();
+    expect(send).toHaveBeenCalledTimes(5);
+    const ids = send.mock.calls.map((c: any[]) => c[0]).sort();
+    expect(new Set(ids).size).toBe(5); // no duplicates
+  });
+});
+
+describe('gating', () => {
+  it('disabled: does nothing at all', async () => {
+    const { r, send } = make([commitment()], { enabled: false });
+    const rep = await r.runPass();
+    expect(rep.ran).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('dryRun: decides and counts, but sends nothing and stamps nothing', async () => {
+    const { r, tracker, send } = make([commitment()], { dryRun: true });
+    const rep = await r.runPass();
+    expect(rep.ran).toBe(true);
+    expect(rep.dryRun).toBe(true);
+    expect(rep.wouldSend).toBe(1);
+    expect(rep.sent).toBe(0);
+    expect(send).not.toHaveBeenCalled();
+    // Critically: no stamp, so flipping dryRun off later still delivers.
+    expect(tracker._rows.get('CMT-1')?.checkInReminderSentAt).toBeUndefined();
+  });
+});

--- a/tests/unit/job-scheduler-edge.test.ts
+++ b/tests/unit/job-scheduler-edge.test.ts
@@ -239,16 +239,39 @@ describe('JobScheduler edge cases', () => {
   });
 
   describe('missed job detection', () => {
-    it('triggers jobs that have never run on startup', async () => {
-      // Jobs with no prior run history should be triggered at startup,
-      // not silently skipped because checkMissedJobs requires lastRun.
+    it('triggers a never-run job that has genuinely outlived its interval', async () => {
+      // The concern this test was written for is real: a job added while the
+      // server was down must not be silently skipped forever because
+      // checkMissedJobs keys on lastRun.
+      //
+      // It previously asserted that ANY never-run job fires at startup, which
+      // was the over-correction — a job whose first window is months away then
+      // discharges itself on the next boot (ACT-724 defect (a)). The intent is
+      // preserved here by representing the actual scenario: a job that has
+      // EXISTED for longer than its own interval without ever running. That
+      // one really did miss a window, and still catches up.
       createScheduler([makeJob('never-ran', { schedule: '0 */4 * * *' })], { startupGraceMs: 0 });
+      project.state.saveJobState({
+        slug: 'never-ran',
+        firstSeenAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // a day ago
+        consecutiveFailures: 0,
+      } as any);
       scheduler.start();
       await new Promise(r => setTimeout(r, 50));
 
       // The job should have been triggered as a "missed" job
       expect(mockSM._spawnCount).toBe(1);
       expect(mockSM._lastSpawnArgs?.name).toContain('never-ran');
+    });
+
+    it('does NOT trigger a never-run job whose first window has not arrived', async () => {
+      // The other side of the boundary, which nothing asserted before: a job
+      // registered moments ago waits for its schedule instead of firing now.
+      createScheduler([makeJob('brand-new', { schedule: '0 */4 * * *' })], { startupGraceMs: 0 });
+      scheduler.start();
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(mockSM._spawnCount).toBe(0);
     });
   });
 

--- a/tests/unit/job-scheduler-never-run-future-job.test.ts
+++ b/tests/unit/job-scheduler-never-run-future-job.test.ts
@@ -1,0 +1,135 @@
+/**
+ * A never-run job scheduled for the FUTURE must not fire at startup.
+ *
+ * THE DEFECT (ACT-724 motivating defect (a), observed 2026-07-17 on the
+ * hand-built benchmark-checkin-reminder): the startup missed-job sweep treats
+ * *every* job with no `lastRun` as missed —
+ *
+ *     if (!jobState?.lastRun) {
+ *       missedJobs.push({ job, overdueRatio: 1.5 });
+ *       continue;
+ *     }
+ *
+ * — so a brand-new job whose first scheduled window is months away is triggered
+ * immediately on the next boot. A reminder set for December fires today.
+ *
+ * The comment directly above that branch says the intended rule out loud:
+ * "trigger on startup IF THEIR FIRST EXPECTED RUN TIME HAS ALREADY PASSED."
+ * The code never checks that condition. The prose is right and the structure
+ * does not implement it.
+ *
+ * Corroboration that this is real and long-known: tests/unit/JobScheduler.test.ts
+ * pre-seeds `lastRun` in `beforeEach` with the comment "so checkMissedJobs
+ * doesn't trigger jobs at startup" — the suite works around the behaviour as a
+ * fixture quirk rather than reporting it as a bug.
+ *
+ * This matters beyond the annoyance: ACT-724 requires date-bearing commitments
+ * to materialize a one-shot reminder on the scheduler. A reminder that fires at
+ * boot instead of on its date is worse than no reminder, because it looks
+ * delivered.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { JobScheduler } from '../../src/scheduler/JobScheduler.js';
+import { createTempProject, createMockSessionManager, createSampleJobsFile } from '../helpers/setup.js';
+import type { TempProject, MockSessionManager } from '../helpers/setup.js';
+import type { JobSchedulerConfig } from '../../src/core/types.js';
+
+describe('startup missed-job sweep — never-run jobs', () => {
+  let project: TempProject;
+  let mockSM: MockSessionManager;
+  let scheduler: JobScheduler | undefined;
+  let jobsFile: string;
+
+  /** A jobs file with one job on the given cron, deliberately never run. */
+  function writeJobsFile(slug: string, schedule: string): string {
+    return createSampleJobsFile(project.stateDir, [
+      {
+        slug,
+        name: slug,
+        description: `test job ${slug}`,
+        schedule,
+        priority: 'medium',
+        expectedDurationMinutes: 1,
+        model: 'haiku',
+        enabled: true,
+        execute: { type: 'prompt', value: 'noop' },
+      },
+    ] as any);
+  }
+
+  beforeEach(() => {
+    project = createTempProject();
+    mockSM = createMockSessionManager();
+    // NOTE: deliberately NO lastRun pre-seeding — that workaround is what has
+    // been hiding this behaviour.
+  });
+
+  afterEach(() => {
+    scheduler?.stop();
+    scheduler = undefined;
+    project.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  function makeConfig(over?: Partial<JobSchedulerConfig>): JobSchedulerConfig {
+    return {
+      jobsFile,
+      enabled: true,
+      maxParallelJobs: 2,
+      quotaThresholds: { normal: 50, elevated: 70, critical: 85, shutdown: 95 },
+      startupGraceMs: 0,
+      ...over,
+    } as JobSchedulerConfig;
+  }
+
+  async function startAndSettle(): Promise<string[]> {
+    scheduler = new JobScheduler(makeConfig(), mockSM as any, project.state, project.stateDir);
+    const triggered: string[] = [];
+    const orig = (scheduler as any).triggerJob.bind(scheduler);
+    vi.spyOn(scheduler as any, 'triggerJob').mockImplementation(async (slug: string, reason: string) => {
+      triggered.push(`${slug}:${reason}`);
+      return undefined; // do not actually spawn anything
+    });
+    void orig;
+    await scheduler.start();
+    // The startup sweep is fired without await inside start(); let it drain.
+    await new Promise((r) => setTimeout(r, 250));
+    return triggered;
+  }
+
+  it('does NOT fire a never-run ANNUAL job whose next window is months away', async () => {
+    // 03:00 on 1 December — for most of the year this is far in the future.
+    jobsFile = writeJobsFile('year-away-reminder', '0 3 1 12 *');
+    const triggered = await startAndSettle();
+    expect(
+      triggered,
+      'a brand-new future-dated job must wait for its date, not fire at the next boot',
+    ).toEqual([]);
+  });
+
+  it('does NOT fire a never-run DAILY job that was only just registered', async () => {
+    jobsFile = writeJobsFile('fresh-daily', '0 4 * * *');
+    const triggered = await startAndSettle();
+    expect(triggered).toEqual([]);
+  });
+
+  it('DOES still fire a never-run job that has genuinely outlived a full interval', async () => {
+    // The catch-up behaviour the branch exists for must survive: a job that has
+    // been registered for longer than its own interval without ever running has
+    // really missed a window. Seed firstSeenAt far in the past to represent it.
+    jobsFile = writeJobsFile('long-overdue', '*/5 * * * *'); // every 5 minutes
+    project.state.saveJobState({
+      slug: 'long-overdue',
+      firstSeenAt: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(), // 6h ago
+      runCount: 0,
+      consecutiveFailures: 0,
+    } as any);
+    const triggered = await startAndSettle();
+    expect(
+      triggered.some((t) => t.startsWith('long-overdue:')),
+      'a job registered 6h ago on a 5-minute cron that has never run HAS missed windows',
+    ).toBe(true);
+  });
+});

--- a/upgrades/next/dated-commitment-reminder.md
+++ b/upgrades/next/dated-commitment-reminder.md
@@ -1,0 +1,72 @@
+## What Changed
+
+A commitment can now carry a **check-in date**, and a background reconciler
+posts one reminder into that commitment's own topic when the date arrives.
+
+Before this, "I'll report back by Friday" lived in the session that said it. If
+that session ended, restarted, or compacted, Friday arrived and nothing
+happened. The PromiseBeacon nudges on *rhythm*, not on dates — it has no concept
+of a specific promised moment.
+
+**What ships (ACT-724 step 1 of 2):**
+
+- `Commitment.checkInAt` — an absolute instant, deliberately separate from the
+  beacon's `nextUpdateDueAt` / `softDeadlineAt` so a one-time dated reminder and
+  a rolling nudge cadence are not side effects of each other.
+- `CheckInReminderReconciler` — a scan over open commitments, driven by the new
+  `commitment-checkin-reminder` built-in job (every 5 minutes, `enabled: false`).
+- `POST /commitments/check-in-reminder/pass` and `GET /commitments/check-in-reminder`.
+
+**One recurring scan, not one alarm per commitment.** ACT-724 sketched a
+per-commitment scheduler entry; taken literally that reproduces two of the three
+defects the action itself lists — the two-file job dance (defect b) and
+self-disable by file edit (defect c). A scan has neither: coverage is a property
+of the scan, so there is no registration step that can be skipped, and teardown
+is just the commitment reaching a terminal status.
+
+**The ordering was wrong first, and the fix's own justification was unwired.**
+The first design stamped `checkInReminderSentAt` *before* sending — which made
+zero delivery a designed outcome, since a failed send left the commitment marked
+delivered and permanently ineligible. Inverted to send-then-stamp with bounded
+retry (5 attempts, then a loud `checkInReminderFailedAt`). The second review
+round then caught that the duplicate mitigation justifying that inversion —
+"the relay dedups" — was not connected: `sendToTopic` does not dedup, that lives
+in the `/telegram/reply` route. The send is now explicitly routed through the
+same durably-backed `OutboundContentDedup`.
+
+**Honest guarantee: at-least-once, deduped at the delivery layer** — not
+exactly-once. Both remaining windows are stated in the spec rather than designed
+away.
+
+## Evidence
+
+- Tier 1 (41): the full eligibility predicate on both sides of every clause;
+  idempotency across repeated passes; **a failed send never reads as sent** (the
+  regression test for the round-1 finding); bounded retry to a loud terminal
+  state; per-pass cap deferring rather than dropping; the reminder text never
+  asserting completion.
+- Tier 2 (10): real Express routes + auth — delivery, HTTP-boundary idempotency,
+  dark 503, missing-transport 503, and `dryRun` defaulting ON when config omits it.
+- Tier 3 (4): real `AgentServer` boot with a real injected `CommitmentTracker`.
+
+## What to Tell Your User
+
+Nothing changes until it's switched on. When it is: on the day the agent said it
+would check in on something, you get one short message in that conversation
+saying the date has arrived.
+
+It will not claim the work is done — a reminder that implies completion closes
+the question instead of reopening it.
+
+**Not yet true:** ACT-724 asks that a dated commitment without a reminder be
+structurally impossible. This ships dark, and a disabled watcher guarantees
+nothing. What is true today: if the reconciler is running, no dated commitment
+can slip past it individually. The creation-time gate that closes the rest is
+step 2, and it cannot itself ship dark.
+
+## Summary of New Capabilities
+
+- Commitments carry a first-class check-in date that produces a real reminder.
+- A reminder is never recorded as delivered unless it actually was; failures
+  retry and then give up visibly.
+- Two read/drive endpoints and a built-in job, all dark by default.

--- a/upgrades/next/scheduler-never-run-window.md
+++ b/upgrades/next/scheduler-never-run-window.md
@@ -1,0 +1,65 @@
+## What Changed
+
+A newly created scheduled job fired immediately on the next server restart —
+including one scheduled months ahead.
+
+At startup the scheduler sweeps for work that was missed while the machine was
+off. To decide, it compares now against the job's last run. For a job that has
+**never** run there is no last run, and the code resolved that case by treating
+it as overdue and triggering it. That is right for a job added while the server
+was down that slept through its window, and wrong for a job created minutes ago
+whose first window is in December — "has never run" describes both identically.
+
+The comment directly above that branch stated the correct rule —
+
+> *"Jobs that have never run: trigger on startup if their first expected run
+> time has already passed"*
+
+— and the code never checked the condition. It couldn't: nothing recorded when a
+job started existing, so there was no fact to reason from.
+
+`JobState.firstSeenAt` is now stamped once at registration, and the sweep applies
+the intended rule: a never-run job is missed only if it has existed longer than
+one of its own intervals. A December reminder created today waits; a job that has
+sat unrun through six four-hour windows still catches up.
+
+Every unknown resolves to **not firing** — missing or unparseable `firstSeenAt`,
+uncomputable interval. That asymmetry is deliberate: a skipped catch-up costs one
+delayed run, while a future-dated job that fires early marks itself delivered and
+never fires again, so nobody goes looking for it.
+
+**Why now:** this is the prerequisite for dated commitments materializing real
+scheduled reminders (ACT-724). A reminder built on a scheduler that fires
+future-dated jobs at boot would discharge itself before its date — worse than
+never having built it. The standard itself is not in this change.
+
+## Evidence
+
+- `tests/unit/job-scheduler-never-run-future-job.test.ts` (3 cases): a never-run
+  annual job and a freshly-registered daily job both stay at zero triggers; a job
+  registered 6h ago on a 5-minute cron still catches up. Written failing first —
+  the two "must not fire" cases failed against the old code, the catch-up case
+  already passed.
+- `tests/unit/job-scheduler-edge.test.ts`: the existing test that asserted the
+  buggy behaviour was **updated, not deleted** — it now seeds `firstSeenAt` in the
+  past so it exercises the scenario it was written for (a job that genuinely
+  missed windows), plus a new sibling pinning the other side of the boundary.
+- Full scheduler suite: 76 tests across 8 files, green.
+
+## What to Tell Your User
+
+If you've ever seen a scheduled job run for no obvious reason shortly after a
+restart, this was probably it.
+
+The practical effect: reminders and scheduled work now happen when they're
+scheduled, not when the server next happens to reboot. A job that's been waiting
+less than one of its own cycles will now wait for its proper turn rather than
+firing at startup — that delay is the point.
+
+## Summary of New Capabilities
+
+- Scheduled jobs with a future first window are no longer discharged at server
+  startup.
+- Job state records when a job was first registered, so "brand new" and "long
+  overdue" are distinguishable facts rather than a guess.
+- The startup sweep fails toward not-running on every uncertainty.

--- a/upgrades/side-effects/dated-commitment-reminder.md
+++ b/upgrades/side-effects/dated-commitment-reminder.md
@@ -1,0 +1,195 @@
+# Side-effects review — dated-commitment-reminder
+
+**Change:** commitments gain a first-class `checkInAt`; a recurring reconciler
+posts exactly one fixed-template reminder to the commitment's topic when that
+instant arrives; a built-in job drives it. ACT-724 (critical, pinned).
+
+**Spec:** `docs/specs/dated-commitment-reminder.md` (2 review rounds; round 1
+returned SERIOUS ISSUES and inverted the send/stamp ordering).
+
+**Ships dark:** dev-agent gated + `dryRun` defaulting true + job manifest
+`enabled: false`.
+
+---
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+- **A dated commitment with no `topicId` is never reminded** (`no-topic`). A
+  reminder with nowhere to go is not a reminder; it is reported as a skip reason
+  rather than silently dropped, and appears in the `pending` list.
+- **An unparseable `checkInAt` fails closed.** Deliberate: coercing it would make
+  the commitment look overdue since epoch and fire immediately — the exact
+  boot-fire shape fixed in `scheduler-never-run-window` days earlier.
+- **A pass is capped at 25.** An overdue backlog drains across passes rather than
+  flooding a topic. The cap logs when it drops work, so a truncated pass is never
+  reported as a complete one.
+- **Only `pending` counts as open.** A status added later is treated as not-open
+  (no reminder) until classified deliberately. Safe direction, but it does mean a
+  future status would silently stop reminders until someone adds it to the set.
+
+## 2. Under-block — what failure modes does this still miss?
+
+- **"Structurally impossible" is not yet true.** ACT-724 asks that a dated
+  commitment without a reminder be impossible. Shipping dark means the watcher
+  can be off, so a dated commitment CAN exist with nothing watching. What IS
+  structural today: given the reconciler runs, no individual commitment can be
+  missed (coverage is a property of the scan, not of a per-commitment
+  registration). The creation-time gate that closes the rest is the declared
+  graduation step, and it cannot itself ship dark. Called out because the spec's
+  own framing over-claimed until review pushed back.
+- **A duplicate is possible in one narrow window** — crash between send and
+  stamp. Accepted, and mitigated by the relay's existing content dedup rather
+  than by design novelty. Stated plainly instead of claimed away.
+- **Clock jumps** shift a reminder in time (late on a backwards jump, early on a
+  forwards one) but cannot double-send or permanently suppress.
+- **No escalation if a reminder is ignored.** Out of scope: this delivers the
+  date, it does not chase. The beacon owns chasing.
+
+## 3. Level-of-abstraction fit
+
+The decision (`isCheckInReminderDue`) is pure and lives in
+`checkInReminderCore.ts`; the effects (CAS, send, retry) live in the reconciler;
+the cadence lives in a built-in job. That split is what let both sides of every
+clause be tested without a store, a clock, or a transport.
+
+**The alternative I rejected is the more standard one.** A transactional outbox
+(`reminder_deliveries` with pending/sent/failed) is the textbook answer and is
+genuinely better at volume. Rejected here because the commitment record already
+IS durable single-writer state: a second store would add a consistency boundary
+— a new class of divergence bug — to serve tens of commitments. The fields on the
+commitment are a degenerate outbox with exactly one row per commitment. If volume
+ever justifies it, the migration is mechanical.
+
+## 4. Signal vs authority compliance
+
+`docs/signal-vs-authority.md`. Both decision points are `invariant`:
+
+- **The due predicate** is arithmetic over durable state (open ∧ date arrived ∧
+  unstamped ∧ routed ∧ retries remain). No competing signals, nothing to weigh.
+  The failure being fixed was an ABSENT mechanism, not a bad judgment.
+- **The reminder text** is a fixed template, deliberately not model-authored.
+  Generating it would add a judgment where none is wanted and a failure mode
+  (provider down) on a path whose entire purpose is to not fail.
+
+**Deliberate gate bypass, argued:** the reminder rides the deterministic delivery
+path, not the LLM tone gate. The tone gate fails closed, and a reminder that can
+be held by a failing gate is the defect this feature exists to fix. This is not
+weakening a safety control — the control is inapplicable, because the message
+carries no agent prose for it to judge. Nothing model-generated reaches the user
+through this path.
+
+## 5. Interactions
+
+- **PromiseBeacon** — untouched. `checkInAt` is a NEW field precisely so beacon
+  cadence (`nextUpdateDueAt`, `softDeadlineAt`) is not overloaded; a one-time
+  dated reminder and a rolling nudge cadence stay independent.
+- **`CommitmentTracker.mutate`** — the existing single-writer CAS is reused, not
+  replaced. Two passes racing cannot double-stamp.
+- **The relay's content dedup** (`outboundContentDedup`) — now load-bearing for
+  this feature's duplicate story. Documented in both the spec and the reconciler
+  so a future change to that window is understood to affect this.
+- **The scheduler** — this is why `scheduler-never-run-window` shipped first. A
+  reminder job on the old scheduler would have fired at boot.
+- **`installBuiltinJobs`** — writes both `jobs/instar` and `jobs/schedule` for
+  built-ins, which is exactly why ACT-724's defect (b) (the two-file dance) does
+  not apply: that dance is only manual for USER jobs.
+
+## 6. External surfaces
+
+- **New:** `POST /commitments/check-in-reminder/pass`, `GET
+  /commitments/check-in-reminder`. Both Bearer-authed, both 503 when dark.
+- **New built-in job** `commitment-checkin-reminder`, `enabled: false`.
+- **New commitment fields** — additive and optional; existing records load
+  unchanged, no migration.
+- **User-visible:** one message per dated commitment, at its date, in its own
+  topic. Fixed template. The only user-facing text this change introduces.
+- **A transport is required only to SEND.** A dry run needs none — surfaced by
+  the Tier-3 test, which would otherwise have reported the feature dead on an
+  agent with no messaging configured.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Unified, with a single-executor rule.**
+
+- `checkInAt` / `checkInReminderSentAt` / `checkInReminderAttempts` /
+  `checkInReminderFailedAt` live on the commitment record and inherit the
+  commitment store's existing posture. No new state surface.
+- **The pass must run on ONE machine.** The built-in job is per-machine (each
+  machine runs its own scheduler), so on a pool the pass must be lease-gated the
+  way the benchmark-divergence analysis pass is. Belt-and-braces: even if two
+  ran, the CAS stamp makes the second a no-op — the lease prevents wasted work,
+  the CAS prevents the duplicate.
+- **HONEST GAP:** the lease gate is specified in §Multi-machine posture but the
+  job ships `enabled: false`, so it is not yet wired in this change. Enabling the
+  job on a multi-machine pool BEFORE adding the lease check would risk two
+  machines both passing — the CAS still prevents a duplicate reminder, but the
+  work would be duplicated. Recorded as a precondition of enabling, not as done.
+- No notice routing, no generated URL, nothing that strands on topic transfer.
+
+## 8. Rollback cost
+
+Disable `commitments.checkInReminder` or the job manifest. The reconciler is the
+only reader of these fields; commitments keep them inertly. No migration, no
+durable cleanup, no agent-state repair. Reverting the commit is equally safe.
+
+## Second-pass review
+
+**Required** — this sends messages to users (outbound messaging is on the Phase-5
+trigger list).
+
+Two rounds of external cross-model review, the first of which returned **SERIOUS
+ISSUES** and changed the design:
+
+1. **Stamp-before-send made zero delivery a designed outcome.** A failed send
+   left the commitment marked `checkInReminderSentAt` and permanently
+   ineligible. Inverted to send-then-stamp with bounded retry; the duplicate risk
+   is covered by the relay's existing dedup. A regression test asserts a failed
+   send never reads as sent.
+2. **"Structurally impossible" over-claimed** for a feature behind a disableable
+   flag. Split into what is true now versus at graduation.
+3. **Time semantics under-specified** — `checkInAt` is now defined as an absolute
+   instant with normalization at the creation boundary, and DST/clock-jump
+   behaviour is stated.
+4. **Cadence and scale omitted** — 5-minute cadence, worst-case lateness, the
+   in-memory store's actual size, per-pass cap and backlog drain are now stated.
+5. **Alternatives not compared** — outbox, durable queue, one-shot entries, and
+   per-commitment scheduler entries are now compared with reasons.
+
+Self-review found one thing the reviewer did not: the Tier-3 test initially
+asserted that `AgentServer` self-constructs the `CommitmentTracker`. It does
+not — `server.ts` injects it — so the routes 503'd on the real boot path while
+Tier 2 passed happily against a hand-assembled context. That is exactly the
+wiring assumption Tier 3 exists to break, and the test now mirrors the
+production entrypoint. It also surfaced the dry-run/transport coupling in §6.
+
+Tests: 41 unit + 10 integration + 4 e2e = 55.
+
+
+## Class-Closure Declaration
+
+**Class:** `unbounded-self-action` · **Closure:** `guard` · **Enforcement:** ratchet
+**Citation:** `tests/unit/self-action-convergence.test.ts`
+
+This change adds a self-triggered controller: a cadenced pass that SENDS
+messages to users without a human in the loop. Under the "Capacity Safety — No
+Unbounded Self-Action" standard that has to be proven to CONVERGE under
+sustained pressure, not merely be individually correct.
+
+Registered as `check-in-reminder-pass` in `src/testing/selfActionRegistry.ts`.
+
+**Steady-state bound.** The emit is gated by a durable per-commitment attempt
+counter (`CHECK_IN_MAX_ATTEMPTS = 5`), persisted through the CAS `mutate()`
+BEFORE the send — so a crash-loop cannot buy fresh attempts, and the registry's
+restart model (which reconstructs from durable state) settles at the same bound.
+
+**Settling brake.** Two terminal states, both durable: a successful send writes
+`checkInReminderSentAt`, making the commitment permanently ineligible; repeated
+failure exhausts the counter and writes a loud `checkInReminderFailedAt`.
+
+**Modeled at the worst case.** The registry model has every send FAIL, so the
+success stamp never lands and only the attempt counter can stop it. Without that
+counter the model emits once per tick forever and the ratchet fails — which is
+the point: the bound is load-bearing, not decorative.
+
+**Instantaneous mass** is separately bounded by the per-pass cap (25), which logs
+when it defers rather than dropping silently.

--- a/upgrades/side-effects/dated-commitment-reminder.md
+++ b/upgrades/side-effects/dated-commitment-reminder.md
@@ -193,3 +193,48 @@ the point: the bound is load-bearing, not decorative.
 
 **Instantaneous mass** is separately bounded by the per-pass cap (25), which logs
 when it defers rather than dropping silently.
+
+
+---
+
+## Addendum — three CI gates, and a coverage gap they led me to
+
+**1. Write-domain classification.** `POST /commitments/check-in-reminder/pass`
+mutates the commitment store and was undeclared. Classified `cluster-shared` in
+`WriteDomainRegistry`, matching the requirement that the pass run on the
+serving-lease holder only — the same single-writer shape as the feedback-factory
+routes. This does NOT weaken the honest gap in section 7: the lease gate is still
+not wired, and the classification records the intended posture rather than
+asserting the wiring exists.
+
+**2. Agent-id header.** The job's curl shipped Bearer-only; I dropped the
+AGENT_ID line when adapting the template I copied from. Restored. Worth noting
+as a pattern: adapting a template is where declared requirements silently fall
+out.
+
+**3. Docs coverage.** Job coverage fell 85% to 83% because the new built-in job
+was undocumented. Added to the default-jobs reference. That floor caught a real
+Agent-Awareness omission, not a bureaucratic one — an undocumented job is one no
+operator can discover.
+
+**And the thing worth more than all three: a coverage gap in the tone-gate suite.**
+
+While dogfooding I hit a live advisory I could not override — four attempts,
+byte-identical text, matching rule, sufficient reason, refused every time. That
+is the RELEASING half of the advisory migration failing in production.
+
+Investigating: every existing test in the advisory-migration integration file
+pins ONE verdict for the whole run via a fixed mock, so the rule is constant by
+construction and an ack always matches. The live gate RE-REVIEWS on every attempt
+and can return a different rule — mine went B20_INTERNAL_ID_LEAK then
+B11_STYLE_MISMATCH. That variability was not covered at all.
+
+Two tests added: (a) re-review returns the SAME acked rule, ack honored, message
+sent; (b) re-review returns a DIFFERENT rule, the stale ack is refused rather
+than silently passing an objection nobody reviewed.
+
+BOTH PASS, which exonerates the ack mechanism and kills my working hypothesis. I
+therefore have a reproducible symptom and NO diagnosis, and I am shipping the
+closed coverage gap rather than a guess dressed as a fix. The evidence and the
+candidates I have not ruled out are in the run log; the four tone-gate tracking
+actions stay OPEN because the releasing half is unproven in production.

--- a/upgrades/side-effects/scheduler-never-run-window.md
+++ b/upgrades/side-effects/scheduler-never-run-window.md
@@ -1,0 +1,156 @@
+# Side-effects review — scheduler-never-run-window
+
+**Change:** the startup missed-job sweep no longer treats every job with no
+`lastRun` as overdue. A new `JobState.firstSeenAt`, stamped once at
+registration, lets it apply the rule its own comment already described: a
+never-run job is missed only if it has existed longer than one of its own
+intervals.
+
+**Motivation:** ACT-724 defect (a) — a hand-built future-dated reminder job
+discharged itself on the next boot. This is the prerequisite for the ACT-724
+standard proper (dated commitments materializing one-shot reminders); that
+standard is NOT in this change.
+
+---
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+**One real, deliberate narrowing.** A never-run job that has existed for *less*
+than one interval is no longer triggered at startup. It waits for its next cron
+window instead.
+
+That is the intended behaviour — it is the difference between "scheduled" and
+"whenever we happen to reboot" — but it is a genuine behaviour change and the
+cost is honest: on a machine that restarts frequently, a newly-added job may now
+first run at its scheduled time rather than within seconds of being added.
+
+**Legacy state is also narrowed.** A job whose state predates `firstSeenAt` and
+has no `lastRun` is treated as not-missed rather than fired. This affects the
+first boot after upgrade only: registration stamps `firstSeenAt` for every job
+that lacks it, so from the second boot the rule applies normally. Chosen
+deliberately — see §4.
+
+## 2. Under-block — what failure modes does this still miss?
+
+- **A job added while the server was down still can't be dated precisely.**
+  `firstSeenAt` is stamped when the scheduler first *sees* the job, not when its
+  file was written. A job created during a three-day outage is stamped at boot
+  and so waits up to one interval before catching up. Using file mtime would be
+  more precise and less trustworthy (mtime changes on unrelated edits, syncs,
+  and checkouts). Named rather than silently accepted.
+- **Interval is inferred from the next two cron occurrences.** For irregular
+  crons (`0 3 1 12 *`, `0 9 * * 1-5`) the gap between the next two runs is not a
+  constant period. It is a sound *lower-ish bound* for the comparison here, but
+  it is an approximation, and it is the same approximation the pre-existing
+  `lastRun` branch already relies on. Not made worse; not fixed either.
+- **Nothing yet asserts one-shot semantics.** ACT-724 asks for first-class
+  one-shot jobs. This change makes cron-scheduled future jobs safe at boot; a
+  true one-shot type (fire once, then retire) is still absent, and the reminder
+  feature will need it.
+
+## 3. Level-of-abstraction fit
+
+Right layer. The missing thing was a *fact* ("when did this job start
+existing?"), so the fix adds the fact at the point that knows it — registration
+— and the decision stays where it was, in the sweep.
+
+The alternative considered and rejected: seeding `lastRun` at registration.
+That would have suppressed the symptom with less code, but it lies — it records
+a run that never happened, corrupting run history, `runCount` semantics, and any
+future "when did this last actually execute?" question. A separate field keeps
+"registered" and "ran" as the distinct facts they are. ACT-724's own sketch
+floated the `lastRun`-seeding option; this is a deliberate departure from it.
+
+## 4. Signal vs authority compliance
+
+`docs/signal-vs-authority.md`. The sweep holds real authority — it *triggers
+jobs* — and it is deterministic, which is appropriate: "has this job existed
+longer than its interval?" is arithmetic over two timestamps, not a judgment.
+There are no competing signals to weigh.
+
+**The direction of failure is the load-bearing property.** Every unknown case
+now resolves to *not firing*: missing `firstSeenAt`, unparseable `firstSeenAt`,
+uncomputable interval. That is the safe direction, and asymmetrically so — a
+skipped catch-up costs one delayed run, while a wrongly-fired future job marks
+itself delivered and will never fire again, so nobody goes looking for it. A
+missed reminder that looks delivered is worse than one that is merely late.
+
+The registration write is wrapped: a bookkeeping failure logs and continues
+rather than preventing the scheduler from starting, and the absent field then
+degrades to not-firing.
+
+## 5. Interactions
+
+- **The `lastRun` branch** — untouched. Jobs with run history take the identical
+  path (`timeSinceLastRun > intervalMs * 1.5`).
+- **Priority sorting and trigger limits** — untouched; a never-run job that does
+  qualify still enters with `overdueRatio: 1.5` exactly as before.
+- **`tests/unit/JobScheduler.test.ts`** — its `beforeEach` pre-seeds `lastRun`
+  "so checkMissedJobs doesn't trigger jobs at startup". That workaround is now
+  unnecessary but remains harmless and was left alone; removing it is unrelated
+  churn in a file this change does not otherwise touch.
+- **`tests/unit/job-scheduler-edge.test.ts`** — one existing test asserted the
+  buggy behaviour ("triggers jobs that have never run on startup"). It was
+  written for a real concern (never-run jobs being skipped forever) and had
+  over-corrected. **Updated, not deleted:** it now seeds `firstSeenAt` a day in
+  the past so it exercises the scenario it was actually written for, and a
+  sibling test pins the other side of the boundary. Called out explicitly
+  because editing a test to make a change pass is exactly the move that needs
+  scrutiny.
+- **StateManager** — `firstSeenAt` is additive and optional; older state loads
+  unchanged, and no migration is required.
+
+## 6. External surfaces
+
+- No route, config key, flag, env var, CLI surface, message, or notification.
+- `JobState` gains one optional field, persisted in existing job-state files.
+  Additive; nothing reads it but the sweep.
+- **User-visible behaviour:** the disappearance of unexplained job runs after a
+  restart. No new output.
+- No timing dependence beyond what the sweep already had.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN** — `machine-local-justification: hardware-bound-resource`.
+
+Job run state is per-machine because job *execution* is per-machine: each
+machine runs its own scheduler over its own scoped jobs, and "when did this
+machine first register this job?" is inherently a fact about that machine's
+scheduler, not a fleet fact. Replicating it would be actively wrong — machine B
+adopting machine A's `firstSeenAt` would make a job that B has never registered
+appear to have existed for days, re-creating the immediate-fire bug through the
+mesh.
+
+This is inherited, not introduced: `JobState` (`lastRun`, `runCount`,
+`consecutiveFailures`) is already machine-local for the same reason, and this
+field joins it. No new cross-machine surface, no notice, no durable shared
+state.
+
+## 8. Rollback cost
+
+**Revert the commit.** Reverting restores the fire-everything behaviour; the
+orphaned `firstSeenAt` values in job-state files are ignored by the old code and
+harmless. No migration, no data repair, no flag.
+
+## Second-pass review
+
+**Required** — this touches session/job lifecycle (it decides whether a job is
+triggered), which is on the Phase-5 trigger list.
+
+Self-review, recorded rather than skipped, with the two things I went looking
+for:
+
+1. **Did I make a test pass by weakening it?** One existing test was changed.
+   It asserted "any never-run job fires at startup" — the exact behaviour being
+   fixed — so it could not survive intact. I preserved its *intent* (a never-run
+   job must not be skipped forever) by giving it a past `firstSeenAt`, and added
+   the missing opposite-side assertion. The suite ends with strictly more
+   coverage of this boundary than it had: 2 tests where there was 1, plus 3 in a
+   dedicated file.
+2. **Is the new failure direction actually safe?** Every uncertain path leads to
+   "don't fire". The worst case is a delayed run; the previous worst case was a
+   reminder silently discharging itself early. Verified by test rather than
+   asserted: the annual-cron case and the fresh-daily case both stay at zero
+   triggers, and the genuinely-overdue case still fires.
+
+Full scheduler suite re-run: 76 tests across 8 files, all green.


### PR DESCRIPTION
## ELI16 — "I'll check in on this Friday" becomes something the system does

Today that promise lives in the session that said it. Session ends, Friday
arrives, nothing happens. There's a nudging system for open promises, but it
works on *rhythm* — every so often, still on this? — and has no concept of
Friday specifically.

Now a promise can carry a date, and something separate from me watches for it.
Every few minutes a check looks at open promises, finds the ones whose date has
come, and posts one message in the conversation where the promise was made.

The message says the date arrived. It deliberately does **not** say the work is
done — a reminder implying completion closes the question instead of reopening
it.

**One watcher, not one alarm per promise.** The obvious design is an alarm clock
per promise, and that's what the instruction sketched. Setting an alarm requires
*creating* something, and anything that must be created can fail to be created —
you'd get promises with no alarm and no way to know which. One watcher looking at
everything means nothing to create and nothing to cancel: a fulfilled promise
simply stops being seen.

## I got the ordering wrong, then got its justification wrong

**Round 1.** My first version marked a reminder "sent" *before* sending it —
reasoning that a lost reminder beats a duplicate you can't un-receive.

The reviewer named what that means: **if the send fails, the promise is marked
reminded and never fires again.** A field named `checkInReminderSentAt`
recording a moment when nothing was sent. On the feature built so promises don't
get silently dropped.

**Round 2.** I inverted it to send-then-stamp and justified the duplicate risk
by saying the relay absorbs identical messages. The reviewer asked whether that
was actually wired.

It wasn't. `sendToTopic` does not dedup — that lives in the `/telegram/reply`
route, which the reconciler bypassed entirely. **A safety property that existed
only in my comment.** The send now routes explicitly through the same
`OutboundContentDedup`, which is durably SQLite-backed, so it survives the
restart the crash window implies.

**Honest guarantee: at-least-once, deduped at the delivery layer.** Not
exactly-once. Both remaining windows are named in the spec rather than argued
away.

## UX impact declaration

- **Audience:** any agent user who is told "I'll get back to you by X". Dark by
  default, so nobody sees it until it's enabled.
- **Visible behavior change:** one message per dated commitment, at its date, in
  its own topic. Fixed template — the only user-facing text this adds.
- **First contact:** the reminder itself.
- **User-visible strings introduced:**
  - `"Check-in I promised you for <date>:"`
  - `"That's the date arriving — not a status update. Nothing here says the work happened."`
  - `"Tell me if it's still wanted and I'll pick it up."`
- **Rollback:** disable the flag or the job. No migration, no durable cleanup.

## Not what was asked for, yet

ACT-724 asks that a dated commitment without a reminder be **structurally
impossible**. This does not achieve that, and I'd rather say so than let the
title imply it.

- **True now:** given the reconciler runs, no dated commitment slips past it
  individually — coverage is a property of the scan, so there's no per-commitment
  registration to forget.
- **Not true now:** that the reconciler runs. It ships dark, and a disabled
  watcher guarantees nothing.
- **Step 2:** a creation-time gate refusing a `checkInAt` when the reconciler
  isn't live. It **cannot** ship dark — a gate that's itself disabled guarantees
  nothing either — so it lands after graduation. ACT-724 stays open until it does.

## What Tier 3 caught that neither review did

The E2E test asserted `AgentServer` self-constructs the `CommitmentTracker`. It
doesn't — `server.ts` injects it — so the routes 503'd on the real boot path
while Tier 2 passed happily against a hand-assembled context. Exactly the wiring
assumption Tier 3 exists to break. Fixing it also surfaced that requiring a
transport during a *dry run* would report the feature dead on any agent without
messaging configured.

## Convergence

Registered as `check-in-reminder-pass` in the self-action registry: this
autonomously sends messages, so it must be proven to settle under sustained
pressure. Modeled at worst case (**every** send fails, so the success stamp never
lands and only the attempt bound can stop it) — without the bound the model
emits forever and the ratchet fails.

## Evidence

- **41 unit** — full predicate both ways on every clause; a failed send never
  reads as sent (the round-1 regression test); bounded retry to a loud terminal
  state; the reminder text never asserting completion.
- **10 integration** — real routes + auth; HTTP-boundary idempotency; dark 503;
  `dryRun` defaulting ON when config omits it.
- **4 e2e** — real `AgentServer` with a real injected tracker.
- Spec converged over 2 rounds, **both returning SERIOUS ISSUES**, both changing
  the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsMJxSBBPAeDo8bXdunVtC
