### PR TITLE
feat(provenance): enrol the stop gate — the busiest unrecorded judgment call

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T13-39-12-006Z-enrol-unjustified-stop-gate.json
+++ b/.instar/instar-dev-decisions/2026-07-25T13-39-12-006Z-enrol-unjustified-stop-gate.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-25T13:39:12.006Z",
+  "slug": "enrol-unjustified-stop-gate",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 88,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/enrol-unjustified-stop-gate.eli16.md
+++ b/docs/specs/enrol-unjustified-stop-gate.eli16.md
@@ -1,0 +1,82 @@
+# Starting to keep records on the busiest judgment call — plain English
+
+## The one-sentence version
+
+There's a system that decides whether I'm allowed to stop working, it makes that
+call about two hundred times a day, and until now nothing recorded what it
+decided or why.
+
+## Background: the thing that keeps me working
+
+When I try to end a session, something checks whether stopping is legitimate.
+Finished the work, hit a real error, need a decision only you can make — those
+are fine. "This is getting long, let's pick it up fresh" is not, and it gets
+refused.
+
+It's one of the busiest judgment calls in the system: roughly 1,300 times a
+week, second only to the check on my outgoing messages.
+
+## The problem
+
+There's a separate system whose job is to answer "are these judgment calls
+actually any good?" — worth knowing, since a check that's wrong half the time is
+worse than no check.
+
+It can only answer for decisions that were **recorded**. About sixty judgment
+points exist; seven were recorded. The stop check was not one of them, despite
+being the busiest. Nobody could say whether it was right, wrong, too strict, or
+too lenient, because nothing was written down.
+
+This starts writing it down.
+
+## What gets recorded, and what deliberately doesn't
+
+The stop check reads two things: evidence gathered by the system (which files
+changed, which commits exist) and **untrusted content** — my stated reason for
+stopping, plus the last ten turns of conversation.
+
+That conversation is the sensitive part. It's whatever we happened to be
+discussing, which could be anything.
+
+So none of it is recorded. What gets stored is the *shape* of the decision:
+
+- a fingerprint of my stated reason — enough to tell two different reasons
+  apart, not enough to read either
+- how long it was, how many turns there were, how long they were
+- which pieces of evidence existed, and of what kind
+- which warning signs fired (those are computed by code, not written by anyone)
+
+Enough to reconstruct what the decision looked like. Not enough to reconstruct
+the conversation. The tests check this by putting a fake password and a fake API
+key into the input and asserting neither appears anywhere in what gets stored.
+
+## The half I'm not pretending to have done
+
+Recording a decision is not the same as knowing whether it was **right**.
+
+To grade this one you'd need a fact that comes later: after the check allowed a
+stop, did the work turn out to be unfinished? After it refused one, did I
+actually go on to do something useful? Those facts exist elsewhere in the system,
+but connecting them to a specific decision is real work, not a small addition.
+
+So this records decisions without grading them, and **says so explicitly** in the
+record itself, using a category that exists for exactly this situation. The
+system's own health check reads that category and reports this point as
+measured-but-not-graded rather than counting it as fully done.
+
+That distinction matters more than it sounds. The easy version of this change
+would move a number from "not covered" to "covered" and leave anyone reading it
+believing the busiest judgment call in the system was being evaluated. It
+wouldn't be. Saying which half is missing is the difference between a smaller
+number and a truer one.
+
+The reason it's still worth doing now: records only accumulate going forward. If
+the grading arrives in a month and nothing was recorded, it starts from zero.
+This way there's history waiting for it.
+
+## What you'd notice
+
+Nothing. This is instrumentation on an internal judgment — no new behaviour, no
+messages, nothing user-facing. What it buys is that the question "is that check
+any good?" stops being unanswerable in principle and becomes merely unanswered
+for now.

--- a/src/core/UnjustifiedStopGate.ts
+++ b/src/core/UnjustifiedStopGate.ts
@@ -35,6 +35,7 @@
 
 import { createHash } from 'node:crypto';
 import type { IntelligenceProvider } from './types.js';
+import { DP_UNJUSTIFIED_STOP_GATE } from '../data/provenanceCoverage.js';
 import type { StopGateBreakerState, StopGateBreakerStateStore } from './StopGateBreakerState.js';
 import { emptyStopGateBreakerState, normalizeStopGateBreakerState } from './StopGateBreakerState.js';
 
@@ -611,7 +612,7 @@ export class UnjustifiedStopGate {
 
     let responseText: string;
     try {
-      responseText = await this.callWithTimeout(prompt);
+      responseText = await this.callWithTimeout(prompt, input);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       const latencyMs = this.config.now() - start;
@@ -687,7 +688,42 @@ export class UnjustifiedStopGate {
     return { ok: true, result: { ...validation.result, latencyMs, promptHash: this.systemPromptHash } };
   }
 
-  private async callWithTimeout(prompt: string): Promise<string> {
+  /**
+   * The §5.6 provenance context for one stop decision — IDENTITY ONLY.
+   *
+   * The gate judges a session's stop rationale, which means the input is
+   * content-bearing and largely UNTRUSTED (the stop reason and recent turns are
+   * session-provided). None of it enters the row. What goes in is what a later
+   * reader needs to reconstruct the SHAPE of the decision without republishing
+   * the conversation: hashes, counts, bounds, and code-derived booleans.
+   *
+   * Recording the rationale text would turn the provenance store into a
+   * transcript archive, which is exactly the failure the content-bearing class
+   * exists to prevent.
+   */
+  private buildStopDecisionContext(input: EvaluateInput): Record<string, unknown> {
+    const reason = input.untrustedContent?.stopReason ?? '';
+    const turns = input.untrustedContent?.recentTurns ?? [];
+    const artifacts = input.evidenceMetadata?.artifacts ?? [];
+    return {
+      // Identity of the judged text, never the text.
+      stopReasonSha256: createHash('sha256').update(reason).digest('hex'),
+      stopReasonChars: reason.length,
+      // Shape of the evidence the authority was allowed to cite.
+      artifactCount: artifacts.length,
+      artifactKinds: [...new Set(artifacts.map((a) => (a as { kind?: string }).kind ?? 'unknown'))].sort(),
+      // Which detector signals fired — code-derived booleans, safe verbatim.
+      signals: input.evidenceMetadata?.signals ?? {},
+      sessionStartTs: input.evidenceMetadata?.sessionStartTs ?? null,
+      metaSelfReferenceHint: input.evidenceMetadata?.metaSelfReferenceHint === true,
+      // Conversation shape only.
+      recentTurnCount: turns.length,
+      recentTurnChars: turns.reduce((n, t) => n + (t?.text?.length ?? 0), 0),
+      selfDeferralGuardEnabled: this.config.selfDeferralGuardEnabled === true,
+    };
+  }
+
+  private async callWithTimeout(prompt: string, input?: EvaluateInput): Promise<string> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.config.clientTimeoutMs);
     try {
@@ -700,6 +736,21 @@ export class UnjustifiedStopGate {
         temperature: 0,
         rateLimitWaitMs: RATE_LIMIT_WAIT_MS,
         attribution: { component: 'UnjustifiedStopGate' }, // attribution for /metrics/features
+        // LLM-Decision Quality Meter §5.1.4/§5.6 enrollment. Observability
+        // ONLY: the settlement seam consumes this block and records the row on
+        // its own path — it never reaches the model and never alters the
+        // continue/allow/escalate verdict. A provenance write failure is
+        // contained by the recorder's own fail-open contract.
+        ...(input
+          ? {
+              provenance: {
+                decisionPoint: DP_UNJUSTIFIED_STOP_GATE,
+                context: this.buildStopDecisionContext(input),
+                optionsPresented: ['continue', 'allow', 'escalate'],
+                promptId: this.systemPromptHash,
+              },
+            }
+          : {}),
       });
       return await Promise.race([call, abortRace]);
     } finally {

--- a/src/data/provenanceCoverage.ts
+++ b/src/data/provenanceCoverage.ts
@@ -237,6 +237,9 @@ export const DP_COMPLETION_CLAIM_VERIFY = 'completion-claim-verify';
 /** Feedback cluster evidence → owned-work readiness judgment. */
 export const DP_FEEDBACK_READINESS = 'feedback-readiness';
 
+/** The stop-justified authority (src/core/UnjustifiedStopGate.ts). */
+export const DP_UNJUSTIFIED_STOP_GATE = 'unjustified-stop-gate';
+
 // ───────────────────────────────────────────────────────────────────────────
 // The census
 // ───────────────────────────────────────────────────────────────────────────
@@ -462,12 +465,36 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
       'Should-I-reply verdict over an inbound message; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
   },
   {
-    decisionPoint: 'unjustified-stop-gate',
+    decisionPoint: DP_UNJUSTIFIED_STOP_GATE,
     component: 'UnjustifiedStopGate',
-    status: 'pending:backlog:decision-quality-enrolment',
+    status: 'wired',
+    // The highest-volume UNENROLLED decision point in the census: ~1343 calls
+    // in the last 7 days (GET /metrics/features), second only to the tone gate
+    // among gates. A per-UTC-day COUNT budget rather than `full`: this fires on
+    // every stop attempt across every session, and an always-on gate must not
+    // grow the provenance archive without a hard ceiling. The ~250-byte
+    // decision_quality row is written for every settlement regardless, so the
+    // COUNTS stay complete even when the archive is valved.
+    volumeClass: 'budget:300',
+    // Content-bearing: the gate judges a session's stop rationale. It enters the
+    // row as IDENTITY ONLY — hashes, bounds, and code-derived features — never
+    // the rationale text or any transcript slice.
     contentClass: 'content-bearing',
+    // ── Grading posture ──────────────────────────────────────────────────
+    // MEASUREMENT-ONLY, declared rather than left as a silent gap.
+    gradingPosture: 'measurement-only',
+    gradingReason:
+      'No honest outcome rule exists YET. Grading "was this stop justified?" needs a ' +
+      'downstream fact — did the run resume and do real work after the gate allowed a ' +
+      'stop, or did the agent genuinely have nothing left after the gate held one? Those ' +
+      'signals exist (the resume queue, the autonomous liveness reconciler) but joining ' +
+      'them to a decision row is real plumbing, not a predicate. Enrolling the DECISION ' +
+      'side first is deliberate and is what this posture is for: the rows accumulate now, ' +
+      'so when the outcome join lands there is history to grade instead of a cold start. ' +
+      'Recording without grading is stated here so the census shows it rather than ' +
+      'implying this point is measured when only half of it is.',
     reason:
-      'Stop-justified verdict over session state; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
+      'The stop-justified authority — the highest-volume unenrolled point in the census.',
   },
   {
     decisionPoint: 'coherence-review',

--- a/tests/unit/provenance-coverage-ratchet.test.ts
+++ b/tests/unit/provenance-coverage-ratchet.test.ts
@@ -122,7 +122,6 @@ const PENDING_BASELINE = [
   'topic-summarize::TopicSummarizer::backlog:decision-quality-enrolment',
   'tree-synthesize::TreeSynthesis::backlog:decision-quality-enrolment',
   'tree-triage::TreeTriage::backlog:decision-quality-enrolment',
-  'unjustified-stop-gate::UnjustifiedStopGate::backlog:decision-quality-enrolment',
   'usher-topic-route::Usher::backlog:decision-quality-enrolment',
   'warrants-reply-gate::WarrantsReplyGate::backlog:decision-quality-enrolment',
   'watchdog-stuck-judge::SessionWatchdog::backlog:decision-quality-enrolment',

--- a/tests/unit/unjustified-stop-gate-provenance-enrollment.test.ts
+++ b/tests/unit/unjustified-stop-gate-provenance-enrollment.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tier 1 — UnjustifiedStopGate's provenance enrollment (llm-decision-quality-meter
+ * §5.1.4/§5.6). The gate is the highest-volume UNENROLLED decision point in the
+ * census (~1343 calls/7d), and enrolling it is the second half of the census task.
+ *
+ * The contract these tests defend is the CONTENT-BEARING one. This gate judges a
+ * session's stop rationale, so its inputs are largely untrusted and quotable:
+ * the stop reason and up to ten recent conversation turns. None of that may enter
+ * the provenance row. If it did, the store would quietly become a transcript
+ * archive — the exact failure the content-bearing class exists to prevent, and
+ * the kind that is invisible until someone reads the archive.
+ *
+ * Enrollment must also be OBSERVABILITY-ONLY: it cannot change what the gate
+ * decides, and a provenance problem cannot break a stop decision.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { UnjustifiedStopGate } from '../../src/core/UnjustifiedStopGate.js';
+import { DP_UNJUSTIFIED_STOP_GATE, PROVENANCE_COVERAGE } from '../../src/data/provenanceCoverage.js';
+import type { IntelligenceProvider } from '../../src/core/types.js';
+
+const SECRET_REASON = 'I am stopping because the API key sk-live-abcdef123456 rotated and I got confused';
+const SECRET_TURN = 'the user said: my password is hunter2 and the deploy path is /Users/justin/secret/deploy.sh';
+
+/** Captures the options the gate hands the provider. */
+function capturingProvider(): { provider: IntelligenceProvider; calls: any[] } {
+  const calls: any[] = [];
+  const provider = {
+    evaluate: vi.fn(async (_prompt: string, opts?: any) => {
+      calls.push(opts);
+      // A SCHEMA-VALID response: the gate rejects anything without an
+      // enumerated rule, so a lazy mock would exercise the failure path and
+      // quietly prove nothing about the success path.
+      return JSON.stringify({
+        decision: 'continue',
+        rule: 'U2_PLAN_FILE_NEXT_STEP_EXPLICIT',
+        rationale: 'plan file still has open steps',
+        // A `continue` verdict must cite a plan file from the enumerated
+        // artifact set — the gate's own coherence rule. Satisfying it means
+        // this test exercises the SUCCESS path rather than a validation reject.
+        evidence_pointer: { plan_file: 'docs/plan.md' },
+        cited_evidence: ['docs/plan.md'],
+      });
+    }),
+  } as unknown as IntelligenceProvider;
+  return { provider, calls };
+}
+
+function makeGate(provider: IntelligenceProvider) {
+  return new UnjustifiedStopGate({
+    intelligence: provider,
+    clientTimeoutMs: 5_000,
+    maxTokens: 512,
+    now: () => 1_700_000_000_000,
+    selfDeferralGuardEnabled: true,
+  } as any);
+}
+
+const input = {
+  evidenceMetadata: {
+    artifacts: [
+      { kind: 'plan-file', path: 'docs/plan.md' },
+      { kind: 'commit', sha: 'abc123' },
+    ],
+    signals: { contextDeath: true, fatigue: false },
+    sessionStartTs: 1_699_999_000_000,
+    metaSelfReferenceHint: false,
+  },
+  untrustedContent: {
+    stopReason: SECRET_REASON,
+    recentTurns: [
+      { source: 'user' as const, text: SECRET_TURN },
+      { source: 'agent' as const, text: 'understood, continuing' },
+    ],
+  },
+};
+
+describe('the enrollment is present and typed', () => {
+  it('the census declares this point WIRED', () => {
+    const entry = PROVENANCE_COVERAGE.find((e) => e.decisionPoint === DP_UNJUSTIFIED_STOP_GATE);
+    expect(entry, 'the decision point must be in the census').toBeDefined();
+    expect(entry!.status).toBe('wired');
+    expect(entry!.component).toBe('UnjustifiedStopGate');
+  });
+
+  it('declares a volume valve and the content class, as a wired entry must', () => {
+    const entry = PROVENANCE_COVERAGE.find((e) => e.decisionPoint === DP_UNJUSTIFIED_STOP_GATE)!;
+    expect(entry.volumeClass).toBe('budget:300');
+    expect(entry.contentClass).toBe('content-bearing');
+  });
+
+  it('declares measurement-only ON PURPOSE, with a real argument', () => {
+    // The honest half of this enrollment: decisions are recorded, outcomes are
+    // not gradeable yet. Declaring it keeps the census truthful instead of
+    // implying this point is measured when only half of it is.
+    const entry = PROVENANCE_COVERAGE.find((e) => e.decisionPoint === DP_UNJUSTIFIED_STOP_GATE)!;
+    expect(entry.gradingPosture).toBe('measurement-only');
+    expect((entry.gradingReason ?? '').length).toBeGreaterThanOrEqual(40);
+  });
+
+  it('passes a provenance block naming the typed decision point', async () => {
+    const { provider, calls } = capturingProvider();
+    await makeGate(provider).evaluate(input as any);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].provenance?.decisionPoint).toBe(DP_UNJUSTIFIED_STOP_GATE);
+    expect(calls[0].provenance?.optionsPresented).toEqual(['continue', 'allow', 'escalate']);
+    expect(calls[0].provenance?.promptId, 'the prompt hash pins WHICH prompt decided').toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('IDENTITY ONLY — the untrusted text never enters the row', () => {
+  it('does not carry the stop reason, in whole or in part', async () => {
+    const { provider, calls } = capturingProvider();
+    await makeGate(provider).evaluate(input as any);
+    const serialized = JSON.stringify(calls[0].provenance?.context ?? {});
+
+    expect(serialized).not.toContain(SECRET_REASON);
+    expect(serialized, 'not even a fragment').not.toContain('sk-live-abcdef123456');
+    expect(serialized).not.toContain('rotated and I got confused');
+  });
+
+  it('does not carry conversation turns — no transcript archive by accident', async () => {
+    const { provider, calls } = capturingProvider();
+    await makeGate(provider).evaluate(input as any);
+    const serialized = JSON.stringify(calls[0].provenance?.context ?? {});
+
+    expect(serialized).not.toContain(SECRET_TURN);
+    expect(serialized).not.toContain('hunter2');
+    expect(serialized).not.toContain('/Users/justin/secret/deploy.sh');
+    expect(serialized).not.toContain('understood, continuing');
+  });
+
+  it('carries the IDENTITY and SHAPE a later reader actually needs', async () => {
+    const { provider, calls } = capturingProvider();
+    await makeGate(provider).evaluate(input as any);
+    const ctx = calls[0].provenance?.context as Record<string, unknown>;
+
+    // A hash pins WHICH rationale was judged without republishing it.
+    expect(String(ctx.stopReasonSha256)).toMatch(/^[0-9a-f]{64}$/);
+    expect(ctx.stopReasonChars).toBe(SECRET_REASON.length);
+    // The evidence the authority was allowed to cite, by shape.
+    expect(ctx.artifactCount).toBe(2);
+    expect(ctx.artifactKinds).toEqual(['commit', 'plan-file']);
+    // Code-derived booleans are safe verbatim — they are not user text.
+    expect(ctx.signals).toEqual({ contextDeath: true, fatigue: false });
+    expect(ctx.recentTurnCount).toBe(2);
+    expect(ctx.recentTurnChars).toBe(SECRET_TURN.length + 'understood, continuing'.length);
+  });
+
+  it('the hash actually distinguishes two different rationales', async () => {
+    // Guards against a constant/empty hash making the identity field useless.
+    const a = capturingProvider();
+    await makeGate(a.provider).evaluate(input as any);
+    const b = capturingProvider();
+    await makeGate(b.provider).evaluate({
+      ...input,
+      untrustedContent: { ...input.untrustedContent, stopReason: 'a completely different reason' },
+    } as any);
+
+    expect(a.calls[0].provenance.context.stopReasonSha256).not.toBe(
+      b.calls[0].provenance.context.stopReasonSha256,
+    );
+  });
+
+  it('survives empty and missing untrusted content without throwing', async () => {
+    const { provider, calls } = capturingProvider();
+    await makeGate(provider).evaluate({
+      evidenceMetadata: { artifacts: [], signals: {}, sessionStartTs: null },
+      untrustedContent: { stopReason: '', recentTurns: [] },
+    } as any);
+    const ctx = calls[0].provenance.context as Record<string, unknown>;
+    expect(ctx.stopReasonChars).toBe(0);
+    expect(ctx.artifactCount).toBe(0);
+    expect(ctx.recentTurnCount).toBe(0);
+  });
+});
+
+describe('observability only — enrollment cannot change the verdict', () => {
+  it('returns the same decision it would have without provenance', async () => {
+    const { provider } = capturingProvider();
+    const out = await makeGate(provider).evaluate(input as any) as any;
+    // The verdict comes from the model response, untouched by enrollment.
+    expect(out.ok, JSON.stringify(out)).toBe(true);
+    expect(out.result.decision).toBe('continue');
+    expect(out.result.rule).toBe('U2_PLAN_FILE_NEXT_STEP_EXPLICIT');
+  });
+
+  it('the provenance block is passed alongside attribution, not instead of it', async () => {
+    const { provider, calls } = capturingProvider();
+    await makeGate(provider).evaluate(input as any);
+    // Losing attribution would silently drop this component from the cost
+    // surface — enrollment must ADD a signal, never displace one.
+    expect(calls[0].attribution?.component).toBe('UnjustifiedStopGate');
+    expect(calls[0].provenance).toBeDefined();
+  });
+});

--- a/upgrades/next/enrol-unjustified-stop-gate.md
+++ b/upgrades/next/enrol-unjustified-stop-gate.md
@@ -1,0 +1,84 @@
+## What Changed
+
+`UnjustifiedStopGate` — the authority that decides whether an agent may stop
+working — is now enrolled in the LLM-Decision Quality Meter.
+
+At ~1343 calls / 7 days it was the **highest-volume unenrolled decision point in
+the census** and the second-busiest gate overall, yet nothing recorded what it
+decided or on what basis. The meter can only answer "is this judgment any good?"
+for points that record; this one didn't, so the question was unanswerable in
+principle.
+
+**What the row carries — identity only.** The gate reads untrusted session
+content (the stop rationale and up to ten recent conversation turns). None of it
+is recorded. The context is an explicit allowlist of derived values:
+
+- `stopReasonSha256` + `stopReasonChars` — distinguishes two rationales without
+  reproducing either
+- `artifactCount` / `artifactKinds` — the evidence the authority could cite
+- `signals` — code-derived booleans (not user text)
+- `recentTurnCount` / `recentTurnChars` — conversation shape only
+
+An allowlist rather than a filtered copy, so a future input field cannot appear
+in the row by default. Tests plant a fake API key and password in the input and
+assert neither reaches the serialized context.
+
+**Declared `measurement-only`, on purpose.** Recording a decision is not grading
+it. Grading this point needs a downstream fact — did work resume after an allowed
+stop; did the agent genuinely continue after a refused one — and joining those
+signals to a decision row is real plumbing. Rather than let `wired` imply more
+than exists, the entry declares `gradingPosture: 'measurement-only'` with an
+argued reason, so `findWiredWithoutGraders` reports it as an explicit posture
+instead of a silent contradiction.
+
+That distinction is the point: the easy version of this change moves a census
+number and leaves a reader believing the busiest judgment call is being
+evaluated. It isn't yet. Rows accumulate now so the grader has history when it
+lands, rather than starting cold.
+
+Volume is valved at `budget:300`/day (an always-on gate must not grow the archive
+unbounded); the `decision_quality` row is written for every settlement regardless,
+so counts stay complete.
+
+## Evidence
+
+- `tests/unit/unjustified-stop-gate-provenance-enrollment.test.ts` (11): the
+  census declares it wired with a volume valve and content class; the
+  measurement-only posture carries a real argument; the provenance block names
+  the typed constant with the prompt hash; **planted secrets never reach the
+  context**; the hash distinguishes different rationales (so it isn't a constant);
+  empty input doesn't throw; the verdict is unchanged and `attribution` survives
+  alongside the new block.
+- Census ratchet: pending baseline shrinks by exactly one; typed-registration
+  check independently verifies the source imports `DP_UNJUSTIFIED_STOP_GATE`.
+- 72 green across the affected suites.
+
+## What to Tell Your User
+
+Nothing changes in how the agent behaves. This is instrumentation on an internal
+judgment — no new messages, no new settings, nothing you interact with.
+
+What it buys: the check that decides whether the agent may stop working is the
+busiest judgment call in the system, and until now nothing recorded what it
+decided. Now it does. So the question "is that check actually any good — too
+strict, too lenient, wrong half the time?" stops being unanswerable and becomes
+answerable once enough history accumulates.
+
+Worth being precise about what is NOT true yet: the decisions are recorded, not
+graded. Knowing whether a given call was *right* needs a later fact (did work
+resume after a stop was allowed?) that isn't connected up yet. The record says so
+explicitly rather than implying the check is being evaluated when only half of
+that is in place.
+
+None of the conversation is stored — only a fingerprint of the stop reason and
+counts describing the decision's shape.
+
+## Summary of New Capabilities
+
+- The stop-justification authority now records every decision it makes, so its
+  quality can be evaluated rather than assumed.
+- Recording is identity-only by construction: an explicit allowlist of derived
+  values, tested against planted secrets, so session content cannot leak into the
+  provenance store.
+- The census now distinguishes "recorded and gradeable" from "recorded but not
+  yet gradeable", so the coverage number reflects what actually exists.

--- a/upgrades/side-effects/enrol-unjustified-stop-gate.md
+++ b/upgrades/side-effects/enrol-unjustified-stop-gate.md
@@ -1,0 +1,126 @@
+# Side-effects review — enrol-unjustified-stop-gate
+
+**Change:** enrol `UnjustifiedStopGate` into the LLM-Decision Quality Meter
+(`pending:backlog:decision-quality-enrolment` → `wired`), with an identity-only
+provenance context and an explicitly declared `measurement-only` grading posture.
+
+**Why this point:** at ~1343 calls / 7 days (`GET /metrics/features`) it is the
+highest-volume UNENROLLED decision point in the census, and the second-busiest
+gate overall. This is the second half of the run's census task — the half where
+the backlog actually shrinks rather than merely becoming legible.
+
+**Tier:** 1 — one census entry, one context builder, one provenance block. No new
+route, config key, flag, or durable store.
+
+---
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+**Nothing.** Enrollment adds an `options.provenance` block to an existing
+provider call. It introduces no predicate, no branch, and no rejection path. The
+gate's continue/allow/escalate verdict is computed exactly as before — asserted
+directly by a test rather than argued.
+
+The one build-time narrowing: the census ratchet now requires this point to stay
+declared. Removing the enrollment without updating the census fails CI, which is
+the intent.
+
+## 2. Under-block — what failure modes does this still miss?
+
+- **It records decisions; it does not grade them.** This is the honest half and
+  is declared as `gradingPosture: 'measurement-only'` with a ≥40-char argument,
+  so `findWiredWithoutGraders` reports it as an explicit posture rather than a
+  silent contradiction. **The census number improves and the point is still not
+  measured end-to-end** — anyone reading "wired" without reading the posture will
+  overestimate what exists. That is why the posture is declared, tested, and
+  stated in the release note.
+- **Volume is capped at `budget:300`/day.** A day with more than 300 stop
+  decisions archives the first 300; the `decision_quality` row is still written
+  for every settlement, so counts stay complete while the archive is valved. A
+  loud `droppedByBudget` counter surfaces the truncation.
+- **The context is a fixed projection.** If a future reader needs a field I did
+  not include, the history will not have it retroactively. I chose the minimum
+  that reconstructs decision shape; widening later is additive but not backfillable.
+
+## 3. Level-of-abstraction fit
+
+The context builder is a private method on the gate, because only the gate knows
+which of its inputs are trusted evidence and which are untrusted session text.
+Building it anywhere else would require exporting that distinction — and a
+downstream builder that guesses wrong is precisely how a transcript ends up in
+a provenance store.
+
+The provenance block rides the existing `options` argument alongside
+`attribution`, so enrollment adds a signal rather than displacing one (tested).
+
+## 4. Signal vs authority compliance
+
+`docs/signal-vs-authority.md`. Enrollment holds **no authority at all** — it is
+pure observability. The settlement seam consumes the block and records on its own
+path; it never reaches the model and never alters the verdict.
+
+The gate itself remains what it was: an LLM authority with a deterministic
+fail-open contract. This change deliberately does not touch that.
+
+**The content-bearing contract is the safety property here**, and it is enforced
+by test rather than by care: the fixtures plant a fake API key and a fake
+password in the untrusted input, and the tests assert neither appears anywhere in
+the serialized context. A hash-distinctness test prevents a constant or empty
+hash from making the identity field useless while still passing the leak tests.
+
+## 5. Interactions
+
+- **`/metrics/features`** — unchanged; `attribution.component` is preserved
+  (explicitly tested, because losing it would silently drop this component from
+  the cost surface).
+- **The census ratchet** — the pending baseline shrinks by exactly one line, which
+  is the direction it is allowed to move. The typed-registration check
+  independently verifies the enrolling source imports `DP_UNJUSTIFIED_STOP_GATE`
+  rather than restating the string.
+- **The breaker / fail-open path** — untouched. A provenance write failure is
+  contained by the recorder's own fail-open contract, so it cannot convert into a
+  stop-decision failure.
+- **The prompt hash** — reused as `promptId`, so a row records WHICH prompt
+  decided. The gate already computed it; nothing new is derived.
+
+## 6. External surfaces
+
+- No route, config key, flag, env var, CLI, message, or notification.
+- `GET /decision-quality` will show one more `wired` point and one fewer
+  `pending`. Field shapes unchanged.
+- No user-visible behaviour whatsoever.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Unified.** The census is a shipped source constant, byte-identical on every
+install, so every machine enrolls the same point with the same volume valve and
+content class. The provenance rows themselves inherit the meter's existing
+posture — this change adds no new state surface, no notice, and no generated URL.
+
+## 8. Rollback cost
+
+Revert. The census entry returns to `pending:` (restoring the baseline line), the
+provenance block disappears, and previously-recorded rows remain inertly in the
+store — harmless, and still readable if the enrollment returns.
+
+## Second-pass review
+
+**Not required** by the Phase-5 trigger list: enrollment makes no block/allow
+decision, touches no session lifecycle, and adds no gate. The gate it observes is
+unchanged.
+
+Self-review, recorded rather than skipped:
+
+1. **Is this the honest version or the number-improving version?** The
+   temptation was real: flipping `pending` → `wired` shrinks census debt whether
+   or not anything can be graded. I took the declared `measurement-only` path
+   because the census distinguishes it and `findWiredWithoutGraders` surfaces it
+   — the gap stays visible instead of being absorbed into a better-looking
+   number. If that posture did not exist I would not have shipped this as-is.
+2. **Could the untrusted text leak by a route I did not consider?** The context is
+   an explicit allowlist of derived values, not a filtered copy of the input, so
+   a new input field cannot appear in the row by default. The leak tests assert
+   absence of planted secrets rather than presence of expected keys, which is the
+   direction that catches accidental widening.
+
+Tests: 11 new unit tests; 72 green across the affected suites.


### PR DESCRIPTION
## ELI16 — starting to keep records on the busiest judgment call

Something decides whether I'm allowed to stop working. Finished the job, hit a
real error, need a decision only you can make — fine. "This is getting long,
let's pick it up fresh" — refused.

It makes that call about **1,300 times a week**. Second-busiest judgment in the
system. And nothing recorded what it decided or why.

There's a separate system whose whole job is answering "are these judgment calls
any good?" — worth knowing, since a check that's wrong half the time is worse
than no check. It can only answer for decisions that were *recorded*. Sixty-odd
judgment points exist; seven recorded. The busiest one wasn't among them, so the
question was unanswerable in principle.

This records it.

## The two halves, and I'm only doing one

**Recording a decision is not grading it.** To grade this one you need a fact
that arrives later: after it allowed a stop, was the work actually unfinished?
After it refused one, did I go on to do something real? Those facts exist
elsewhere; connecting them to a specific decision is genuine plumbing.

So this declares `gradingPosture: 'measurement-only'` with an argued reason, and
the health check reports it as *measured-but-not-graded* rather than counting it
as done.

**That distinction is the entire reason this PR is written the way it is.** The
easy version flips `pending` → `wired`, the census number improves, and anyone
reading it believes the busiest judgment call is being evaluated. It isn't.
Saying which half is missing is the difference between a smaller number and a
truer one.

Worth doing now anyway: records only accumulate forward. If the grader lands in a
month against zero history, it starts cold.

## The safety property: identity only

The gate reads **untrusted** session content — my stop rationale plus up to ten
recent conversation turns, which could be anything we were discussing.

None of it is stored. The context is an explicit **allowlist of derived values**,
not a filtered copy of the input — so a future input field cannot appear in a row
by default:

| stored | not stored |
|---|---|
| `stopReasonSha256`, `stopReasonChars` | the rationale text |
| `artifactCount`, `artifactKinds` | artifact contents |
| `signals` (code-derived booleans) | anything user-written |
| `recentTurnCount`, `recentTurnChars` | the turns |

Tests plant a fake API key (`sk-live-…`) and a fake password in the input and
assert neither appears anywhere in the serialized context. A separate test proves
the hash actually distinguishes two rationales — otherwise a constant or empty
hash would sail through the leak tests while making the identity field useless.

## UX impact declaration

- **Audience:** maintainers reading `GET /decision-quality`. No end-user surface.
- **Visible behavior change:** none. No predicate, no branch, no new rejection
  path. The gate's continue/allow/escalate verdict is provably unchanged (tested
  directly, not argued). One more `wired` point and one fewer `pending`.
- **First contact:** the census counts on the decision-quality read.
- **User-visible strings introduced:** none.
- **Rollback:** revert. The census entry returns to `pending:`, the block
  disappears, and recorded rows remain inertly.

## Tier declaration — I declared BELOW the signaled floor

The gate signaled Tier 2 (`riskFloor: 2`) and I declared **Tier 1**. Recorded as
`belowFloor: true` in the decision audit, and flagged here rather than left in
the log.

The floor's stated reason is *"new capability: new config key added"* — **I added
no config key.** The heuristic appears to have matched a census field name
(`gradingPosture:` / `volumeClass:`) in the diff. On substance this is one census
entry, one private context builder, and one `options.provenance` block on an
existing call: no route, no config, no flag, no durable store, no decision logic.

If a reviewer reads the floor as correct, the fix is a converged spec and I'll
write one — but I'd rather state the disagreement than quietly take the higher
tier and imply the heuristic was right.

## Evidence

- 11 new unit tests; 72 green across the affected suites.
- Census ratchet: pending baseline shrinks by exactly one — the direction it is
  permitted to move. The typed-registration check independently verifies the
  source *imports* `DP_UNJUSTIFIED_STOP_GATE` rather than restating the string.
- `attribution.component` explicitly asserted to survive alongside the new block:
  losing it would silently drop this component from the cost surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsMJxSBBPAeDo8bXdunVtC
