### PR TITLE
docs: spec round 10 — scanState and row presence are independent

### DIFF
--- a/docs/specs/cross-machine-door-capability-registry.md
+++ b/docs/specs/cross-machine-door-capability-registry.md
@@ -16,7 +16,7 @@ parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded 
 
 Spec-first deliverable for ACT-409. It proposes a cross-machine read model; it
 does not implement routes, storage, mesh verbs, or fleet rollout. Convergence
-rounds 1-7 (2026-07-25: six internal reviewer lanes + GPT-tier external passes
+rounds 1-10 (2026-07-25: six internal reviewer lanes + GPT-tier external passes
 + the standards-conformance gate each round) surfaced and resolved ~48
 material findings; the former ten open questions are resolved in
 `## Frontloaded Decisions`.
@@ -631,11 +631,28 @@ it:
 
 - `GET /capability-registry` — this machine's redacted projection. Serves the
   stored snapshot (validation once at ingest; read-time work is rule 4's
-  per-row timestamp comparison only). `200` with `scanState:
-  "never-observed"` and empty entries when no observation exists
-  (truthful-empty, mirroring `/doorways`' `never-run`); `503` ONLY when the
-  feature flag is dark. Disabled reads as disabled; empty reads as empty —
-  never interchangeable.
+  per-row timestamp comparison only). `503` ONLY when the feature flag is
+  dark. Disabled reads as disabled; empty reads as empty — never
+  interchangeable.
+  **`scanState` and row presence are INDEPENDENT (round-10 clarification —
+  the earlier wording "and empty entries when no observation exists" was
+  ambiguous and produced a real defect).** They answer different questions:
+  `scanState` reports whether a doorway SCAN has run; the rows report what
+  the catalog and any scan actually say. So a machine with a manifest and NO
+  scan-state returns `scanState: "never-observed"` **together with its
+  manifest-derived rows at status `unknown`** — never zero rows. Dropping
+  them loses real information ("the catalog lists these models and nothing
+  has probed them" is strictly more useful than "nothing here"), and it
+  collapses the three-way distinction `scanState` exists to preserve. Empty
+  `entries` is correct only when there is genuinely no manifest either
+  (`scanState` then still distinguishes never-scanned from
+  source-unavailable). Failing input for this rule: on a machine with a
+  manifest and no scan-state the route MUST return rows with status
+  `unknown`; a change that makes it return zero rows must fail a test.
+  Why it was ambiguous: manifest rows ARE observations — the record admits
+  them with `sourceDetail: doorway-manifest`, and the status matrix gives
+  `manifest-only` evidence the status `unknown` precisely so documented
+  existence is reportable without ever implying reachability.
 - `GET /capability-registry?scope=pool` — the local-serve merged view (see
   Ingest and transport). Per-machine failure rows with the closed reason
   enum; mixed failures return `200` with `pool.failed` rows — never a 500,

--- a/upgrades/next/spec-round10-manifest-rows.md
+++ b/upgrades/next/spec-round10-manifest-rows.md
@@ -1,0 +1,41 @@
+## What Changed
+
+Spec clarification for the (unshipped, dark) cross-machine capability registry: `scanState` and row
+presence are INDEPENDENT. A machine with a model manifest and no doorway scan-state now returns
+`scanState: "never-observed"` **together with** its manifest-derived rows at status `unknown`,
+instead of zero rows.
+
+The earlier wording ("`200` with `scanState: never-observed` and empty entries when no observation
+exists") was ambiguous, and the ambiguity produced a real defect: the Increment-2 route derived ten
+rows from the real manifest and served none of them, because "no observation" was read as "no scan".
+Manifest rows ARE observations — the record admits them with `sourceDetail: doorway-manifest`, and
+the status matrix gives `manifest-only` evidence the status `unknown` precisely so documented
+existence is reportable without ever implying reachability.
+
+The rule now carries its failing input: on a machine with a manifest and no scan-state the route
+MUST return rows with status `unknown`; a change that makes it return zero rows must fail a test.
+
+## Evidence
+
+Found by running the Increment-2 route's local-projection path against a real agent state dir rather
+than reading the diff: `durable projection ABSENT / fallback readDoorwaySources entries = 10 /
+scanState = never-observed`, and then observing that `classifyProjection` early-returned a single
+`no-data-yet` row, discarding all ten.
+
+## What to Tell Your User
+
+Nothing. This is a design-document correction for a feature that is switched off everywhere, so
+there is no user-visible change to announce. If a user asks why a capability list looked empty on a
+machine that had never run a scan, the honest answer is that it was a specification ambiguity: the
+catalog rows existed and were being discarded, and the corrected rule serves them marked as
+unverified rather than hiding them.
+
+## Summary of New Capabilities
+
+None. This amendment adds no capability — it removes an ambiguity that was silently costing one
+(the ability to see what a machine's catalog claims before anything has probed it).
+
+## Audience
+
+Agent-only, maturity experimental. No user-visible behavior: the feature is dark everywhere, no
+route ships enabled by this change, and the amendment is spec text only.

--- a/upgrades/side-effects/spec-round10-manifest-rows.md
+++ b/upgrades/side-effects/spec-round10-manifest-rows.md
@@ -1,0 +1,13 @@
+# Side effects — spec round 10 (scanState vs row presence)
+
+- **No code changes in this PR.** Spec text only; the feature is dark on every install.
+- **Downstream obligation created:** the Increment-2 route (merged behavior) currently returns zero
+  rows on a machine that has never scanned. Once this amendment lands, that behavior contradicts the
+  spec and must be fixed — tracked for Increment 3, with the failing input stated in the spec so the
+  fix is verifiable rather than asserted.
+- **Risk if NOT amended:** on any machine whose doorway-scan job is disabled (the shipped default),
+  the read surface would report nothing while holding a catalog it had already derived — the exact
+  "empty reads as unknown" conflation the three-way `scanState` exists to prevent.
+- **Rollback:** revert the spec paragraph; no deployed behavior changes either way.
+- **Provenance note:** this ambiguity was mine as the converging reviewer, not a build defect — the
+  implementation followed the spec as written. Recorded so the review history stays honest.


### PR DESCRIPTION
## ELI16

A machine keeps a catalogue of the models it could reach, and separately it can run a check to see whether they actually answer. The design said that if no check had ever run, the answer to "what can this machine do?" should be empty. That sounds careful, but it is wrong, and I only found out by running the code against a real machine instead of reading it: the code correctly worked out ten entries from the real catalogue and then threw all ten away, because no check had run.

Those two things answer different questions. "No check has run" is worth saying. "There is nothing here" is false when a catalogue lists ten models. The useful answer is both at once: here are the ten, marked as unverified, and no, nothing has probed them yet. Hiding them loses information a person or an agent would want, and it collapses a three-way distinction the design deliberately built — never checked, could not check, genuinely nothing.

So the rule now says the two are independent, and it carries the input that must break it: on a machine with a catalogue and no check, the answer must contain those entries marked unverified, and a change that empties it must fail a test.

Worth being clear about whose mistake this was. The implementation followed the specification exactly as written. The ambiguity was mine, as the person who converged that specification over nine review rounds — which is the third time tonight that using a mechanism, rather than reasoning about it, found what reading could not.

## What changed

Spec text only, in `## Surfaces and ownership`: `scanState` and row presence are independent; manifest-derived rows are served at status `unknown` alongside `scanState: "never-observed"`; empty `entries` is correct only when there is genuinely no manifest either. Plus the release fragment and the side-effects artifact recording the downstream obligation (the Increment-2 route must be corrected in Increment 3).

## Who sees this and what changes for them

Nobody user-facing — the feature is dark on every install and no behavior ships here. The audience is the next implementer, who now has an unambiguous rule with a stated failing input instead of a sentence that reads two ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh2Eb2Yhn54obcsaGhm7kp
