### PR TITLE
feat(provenance): enrol the conversation-intent extractor

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T17-49-57-111Z-enrol-topic-intent-extract.json
+++ b/.instar/instar-dev-decisions/2026-07-25T17-49-57-111Z-enrol-topic-intent-extract.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-25T17:49:57.111Z",
+  "slug": "enrol-topic-intent-extract",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 58,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/enrol-topic-intent-extract.eli16.md
+++ b/docs/specs/enrol-topic-intent-extract.eli16.md
@@ -1,0 +1,63 @@
+# Recording what the conversation-reader decides — plain English
+
+## The one-sentence version
+
+The thing that reads your messages to work out what a conversation is *about*
+makes that call several hundred times a week, and until now nothing recorded
+what it concluded.
+
+## What it does
+
+As we talk, something reads each substantive turn and asks: is there a new
+commitment here? Is this confirming something said earlier, or contradicting it?
+That's how a topic accumulates a sense of what it's for, rather than being a flat
+list of messages.
+
+It's a judgment call, made roughly seven hundred times a week — the busiest one
+left that wasn't being recorded, now that the stop-check is.
+
+## Why recording it matters
+
+There's a system meant to answer "are these judgments any good?" It can only
+answer for decisions that were written down. This one wasn't, so the question was
+unanswerable — not unanswered, unanswerable.
+
+## The careful part
+
+This reader sees more than most: your actual message, and a rolling summary of
+the whole conversation so far. Both are yours, both could contain anything.
+
+None of it gets stored. What's kept is the *shape* of the decision:
+
+- a fingerprint of the message — enough to tell two apart, not enough to read one
+- how long it was, whose turn it was, which turn number
+- how many existing threads it had to work with
+- whether a summary existed and how long it was — never a word of it
+
+The summary is the bigger risk, and it's why this is worth being deliberate
+about: leaking a message exposes one turn, leaking a summary exposes the whole
+conversation. The tests put a fake password in the message *and* a fake token in
+the summary, and check neither reaches storage.
+
+It's built as a list of specific things to keep, rather than a filter over
+everything — so if someone adds a new field to what this reader sees later, it
+won't quietly start being stored.
+
+## Two things I'm being explicit about
+
+**Recorded, not graded.** Same as the last one. Knowing whether an extraction was
+*right* means knowing what happened to it afterwards — was that signal later
+confirmed, contradicted, or quietly ignored? Those facts exist; connecting them
+to a specific decision is real work I haven't done. So it says "recorded, not
+graded" in its own entry, and the health check reports it that way.
+
+**It must never break a conversation.** This reader is designed to fail silently
+— if the model is unavailable, it returns nothing and the conversation continues
+undisturbed. Recording must not put a new way to fail in front of that. There are
+tests for exactly that: provider throwing, provider missing, both still degrade
+quietly.
+
+## What you'd notice
+
+Nothing. It's instrumentation on an internal judgment. What it buys is that a
+question about the quality of that judgment stops being impossible to ask.

--- a/src/core/TopicIntentExtractor.ts
+++ b/src/core/TopicIntentExtractor.ts
@@ -13,7 +13,8 @@
  * (e.g., trigger conflict-mark when two refs come into conflict).
  */
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
+import { DP_TOPIC_INTENT_EXTRACT } from '../data/provenanceCoverage.js';
 import {
   TopicIntentStore,
   buildEvent,
@@ -286,6 +287,32 @@ export function createLlmExtractFn(
         temperature: 0,
         maxTokens: 600,
         attribution: { component: 'TopicIntentExtractor' },
+        // LLM-Decision Quality Meter §5.1.4/§5.6 enrollment. Observability ONLY:
+        // the settlement seam consumes this block and records on its own path —
+        // it never reaches the model and never alters the extraction. A
+        // provenance write failure is contained by the recorder's fail-open
+        // contract, so it cannot break the degrade-safe [] guarantee above.
+        //
+        // IDENTITY ONLY. The input is a user TURN plus a rolling conversational
+        // summary — both untrusted and quotable. Neither enters the row; what
+        // does is an explicit allowlist of derived values, so a future field on
+        // ExtractorInput cannot appear here by default.
+        provenance: {
+          decisionPoint: DP_TOPIC_INTENT_EXTRACT,
+          context: {
+            topicId: input.topicId,
+            arcId: input.arcId,
+            messageId: input.message.id,
+            messageSha256: createHash('sha256').update(input.message.text ?? '').digest('hex'),
+            messageChars: (input.message.text ?? '').length,
+            fromUser: input.message.fromUser === true,
+            turn: input.message.turn,
+            existingRefCount: input.existingRefs.length,
+            hasRollingSummary: typeof input.rollingSummary === 'string' && input.rollingSummary.length > 0,
+            rollingSummaryChars: (input.rollingSummary ?? '').length,
+          },
+          optionsPresented: ['new-ref', 'reref', 'affirm', 'contradict'],
+        },
       });
     } catch {
       // network/timeout/provider failure / LlmQueue cap breach → degrade to no

--- a/src/data/provenanceCoverage.ts
+++ b/src/data/provenanceCoverage.ts
@@ -240,6 +240,9 @@ export const DP_FEEDBACK_READINESS = 'feedback-readiness';
 /** The stop-justified authority (src/core/UnjustifiedStopGate.ts). */
 export const DP_UNJUSTIFIED_STOP_GATE = 'unjustified-stop-gate';
 
+/** Topic-intent extraction from a conversational turn (src/core/TopicIntentExtractor.ts). */
+export const DP_TOPIC_INTENT_EXTRACT = 'topic-intent-extract';
+
 // ───────────────────────────────────────────────────────────────────────────
 // The census
 // ───────────────────────────────────────────────────────────────────────────
@@ -703,12 +706,32 @@ export const PROVENANCE_COVERAGE: ReadonlyArray<ProvenanceCoverageEntry> = [
       'Per-turn topic routing over an inbound user turn; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
   },
   {
-    decisionPoint: 'topic-intent-extract',
+    decisionPoint: DP_TOPIC_INTENT_EXTRACT,
     component: 'TopicIntentExtractor',
-    status: 'pending:backlog:decision-quality-enrolment',
+    status: 'wired',
+    // ~733 calls/7d (GET /metrics/features) — the highest-volume unenrolled
+    // point remaining after the stop gate. It fires on conversational turns, so
+    // a per-UTC-day COUNT budget rather than `full`: the decision_quality row is
+    // written for every settlement regardless, so counts stay complete while the
+    // provenance archive is capped.
+    volumeClass: 'budget:200',
+    // Content-bearing: the extractor reads a user TURN and a rolling
+    // conversational summary — both untrusted, both quotable. Entered as
+    // IDENTITY ONLY (hashes, counts, code-derived booleans); never the message
+    // text, never the summary.
     contentClass: 'content-bearing',
+    gradingPosture: 'measurement-only',
+    gradingReason:
+      'No outcome rule exists YET. Grading an extraction needs a downstream fact — ' +
+      'was the proposed signal later affirmed, contradicted, or silently dropped by ' +
+      'the arc it was attached to? Those transitions exist in the intent store but ' +
+      'joining them to a decision row is real plumbing, not a predicate. Enrolling ' +
+      'the DECISION side first is deliberate and is what this posture is for: rows ' +
+      'accumulate now so the grader has history when it lands. Declared rather than ' +
+      'left implicit so the census shows recorded-not-graded instead of implying ' +
+      'this point is measured when only half of it is.',
     reason:
-      'Topic-intent extraction from a user turn; enrollment queued in the ACT-1193 uniform-provenance retrofit backlog.',
+      'Topic-intent extraction from a conversational turn — the highest-volume unenrolled point after the stop gate.',
   },
   {
     decisionPoint: 'pre-compaction-flush',

--- a/tests/unit/provenance-coverage-ratchet.test.ts
+++ b/tests/unit/provenance-coverage-ratchet.test.ts
@@ -118,7 +118,6 @@ const PENDING_BASELINE = [
   'telegram-stall-confirm::TelegramAdapter::backlog:decision-quality-enrolment',
   'temporal-coherence-check::TemporalCoherenceChecker::backlog:decision-quality-enrolment',
   'topic-intent-arc-check::TopicIntentArcCheck::backlog:decision-quality-enrolment',
-  'topic-intent-extract::TopicIntentExtractor::backlog:decision-quality-enrolment',
   'topic-summarize::TopicSummarizer::backlog:decision-quality-enrolment',
   'tree-synthesize::TreeSynthesis::backlog:decision-quality-enrolment',
   'tree-triage::TreeTriage::backlog:decision-quality-enrolment',

--- a/tests/unit/topic-intent-extractor-provenance-enrollment.test.ts
+++ b/tests/unit/topic-intent-extractor-provenance-enrollment.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tier 1 — TopicIntentExtractor's provenance enrollment (§5.1.4/§5.6).
+ *
+ * ~733 calls/7d: the highest-volume unenrolled point remaining after the stop
+ * gate, and the second half of the census task's "enrol the highest-volume
+ * scenarios".
+ *
+ * The contract defended here is CONTENT-BEARING. This extractor reads a raw
+ * conversation turn AND a rolling conversational summary — both untrusted, both
+ * arbitrary user content. Neither may enter the provenance row. The context is
+ * an explicit allowlist of derived values rather than a filtered copy, so a
+ * future field on ExtractorInput cannot leak by default.
+ *
+ * Enrollment must also stay observability-only: it cannot alter the extraction,
+ * and it must not break the extractor's degrade-safe "return []" guarantee.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createLlmExtractFn } from '../../src/core/TopicIntentExtractor.js';
+import { DP_TOPIC_INTENT_EXTRACT, PROVENANCE_COVERAGE } from '../../src/data/provenanceCoverage.js';
+import type { IntelligenceProvider } from '../../src/core/types.js';
+
+const SECRET_MSG = 'deploy with the key sk-live-topicintent999 and my password is hunter2';
+const SECRET_SUMMARY = 'earlier the user pasted /Users/justin/private/keys.env and a token ghp_abc123';
+
+function capturing() {
+  const calls: any[] = [];
+  const provider = {
+    evaluate: vi.fn(async (_p: string, opts?: any) => {
+      calls.push(opts);
+      return JSON.stringify({ proposals: [] });
+    }),
+  } as unknown as IntelligenceProvider;
+  return { provider, calls };
+}
+
+const input = {
+  topicId: 33368,
+  arcId: 'arc-1',
+  message: {
+    id: 'msg-7',
+    text: SECRET_MSG,
+    fromUser: true,
+    turn: 12,
+    at: '2026-07-25T17:00:00.000Z',
+  },
+  existingRefs: [{ refId: 'r1' }, { refId: 'r2' }, { refId: 'r3' }],
+  rollingSummary: SECRET_SUMMARY,
+} as any;
+
+describe('the enrollment is present and typed', () => {
+  it('the census declares this point WIRED with a valve and content class', () => {
+    const e = PROVENANCE_COVERAGE.find((x) => x.decisionPoint === DP_TOPIC_INTENT_EXTRACT);
+    expect(e, 'the decision point must be in the census').toBeDefined();
+    expect(e!.status).toBe('wired');
+    expect(e!.volumeClass).toBe('budget:200');
+    expect(e!.contentClass).toBe('content-bearing');
+  });
+
+  it('declares measurement-only ON PURPOSE, with a real argument', () => {
+    const e = PROVENANCE_COVERAGE.find((x) => x.decisionPoint === DP_TOPIC_INTENT_EXTRACT)!;
+    expect(e.gradingPosture).toBe('measurement-only');
+    expect((e.gradingReason ?? '').length).toBeGreaterThanOrEqual(40);
+  });
+
+  it('passes a provenance block naming the typed decision point', async () => {
+    const { provider, calls } = capturing();
+    await createLlmExtractFn(provider)(input);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].provenance?.decisionPoint).toBe(DP_TOPIC_INTENT_EXTRACT);
+    expect(calls[0].provenance?.optionsPresented).toEqual([
+      'new-ref',
+      'reref',
+      'affirm',
+      'contradict',
+    ]);
+  });
+});
+
+describe('IDENTITY ONLY — the turn and the summary never enter the row', () => {
+  it('does not carry the message text, in whole or in fragment', async () => {
+    const { provider, calls } = capturing();
+    await createLlmExtractFn(provider)(input);
+    const ser = JSON.stringify(calls[0].provenance?.context ?? {});
+
+    expect(ser).not.toContain(SECRET_MSG);
+    expect(ser).not.toContain('sk-live-topicintent999');
+    expect(ser).not.toContain('hunter2');
+  });
+
+  it('does not carry the rolling summary — the bigger leak surface', async () => {
+    // The summary spans many turns, so leaking it would republish far more than
+    // the message that triggered the call.
+    const { provider, calls } = capturing();
+    await createLlmExtractFn(provider)(input);
+    const ser = JSON.stringify(calls[0].provenance?.context ?? {});
+
+    expect(ser).not.toContain(SECRET_SUMMARY);
+    expect(ser).not.toContain('/Users/justin/private/keys.env');
+    expect(ser).not.toContain('ghp_abc123');
+  });
+
+  it('carries the identity and shape a later reader needs', async () => {
+    const { provider, calls } = capturing();
+    await createLlmExtractFn(provider)(input);
+    const ctx = calls[0].provenance.context as Record<string, unknown>;
+
+    expect(String(ctx.messageSha256)).toMatch(/^[0-9a-f]{64}$/);
+    expect(ctx.messageChars).toBe(SECRET_MSG.length);
+    expect(ctx.topicId).toBe(33368);
+    expect(ctx.messageId).toBe('msg-7');
+    expect(ctx.fromUser).toBe(true);
+    expect(ctx.turn).toBe(12);
+    expect(ctx.existingRefCount).toBe(3);
+    // Presence and size of the summary, never its content.
+    expect(ctx.hasRollingSummary).toBe(true);
+    expect(ctx.rollingSummaryChars).toBe(SECRET_SUMMARY.length);
+  });
+
+  it('the hash distinguishes two different messages', async () => {
+    const a = capturing();
+    await createLlmExtractFn(a.provider)(input);
+    const b = capturing();
+    await createLlmExtractFn(b.provider)({
+      ...input,
+      message: { ...input.message, text: 'something else entirely' },
+    });
+    expect(a.calls[0].provenance.context.messageSha256).not.toBe(
+      b.calls[0].provenance.context.messageSha256,
+    );
+  });
+
+  it('handles an absent rolling summary without inventing one', async () => {
+    const { provider, calls } = capturing();
+    await createLlmExtractFn(provider)({ ...input, rollingSummary: undefined });
+    const ctx = calls[0].provenance.context as Record<string, unknown>;
+    expect(ctx.hasRollingSummary).toBe(false);
+    expect(ctx.rollingSummaryChars).toBe(0);
+  });
+});
+
+describe('observability only — degrade-safety is preserved', () => {
+  it('keeps attribution alongside the new block', async () => {
+    // Losing attribution would silently drop this component from the cost surface.
+    const { provider, calls } = capturing();
+    await createLlmExtractFn(provider)(input);
+    expect(calls[0].attribution?.component).toBe('TopicIntentExtractor');
+    expect(calls[0].provenance).toBeDefined();
+  });
+
+  it('a provider failure still degrades to [] rather than throwing', async () => {
+    // The extractor's core guarantee: it never breaks the conversation path it
+    // is attached to. Enrollment must not put a throw in front of that.
+    const provider = {
+      evaluate: vi.fn(async () => {
+        throw new Error('provider down');
+      }),
+    } as unknown as IntelligenceProvider;
+    const onDegrade = vi.fn();
+    const out = await createLlmExtractFn(provider, onDegrade)(input);
+    expect(out).toEqual([]);
+    expect(onDegrade).toHaveBeenCalledWith('error', 33368);
+  });
+
+  it('no provider at all still degrades to [] and never builds a row', async () => {
+    const onDegrade = vi.fn();
+    const out = await createLlmExtractFn(undefined, onDegrade)(input);
+    expect(out).toEqual([]);
+    expect(onDegrade).toHaveBeenCalledWith('no-intelligence', 33368);
+  });
+});

--- a/upgrades/next/enrol-topic-intent-extract.md
+++ b/upgrades/next/enrol-topic-intent-extract.md
@@ -1,0 +1,70 @@
+## What Changed
+
+`TopicIntentExtractor` — which reads each substantive conversation turn and
+decides whether it introduces, re-references, affirms or contradicts a topic
+signal — is now enrolled in the LLM-Decision Quality Meter.
+
+At ~733 calls / 7 days it was the highest-volume unenrolled decision point
+remaining after the stop gate, and nothing recorded what it concluded. The meter
+can only answer "is this judgment any good?" for points that record.
+
+**Identity only, and the leak surface here is unusually wide.** This extractor
+reads a raw user turn *and* a rolling conversational summary — both untrusted,
+and a summary leak republishes far more than one message. Neither is stored. The
+context is an explicit allowlist of derived values:
+
+- `messageSha256` + `messageChars` — distinguishes turns without reproducing one
+- `topicId`, `arcId`, `messageId`, `fromUser`, `turn`
+- `existingRefCount` — how many threads it had to anchor against
+- `hasRollingSummary` + `rollingSummaryChars` — presence and size, never content
+
+An allowlist rather than a filter, so a future field on the extractor's input
+cannot leak by default. Tests plant a fake API key and password in the message
+*and* a fake token and file path in the summary, asserting none of the four
+reach the row.
+
+**Declared `measurement-only`**, with an argued reason. Grading an extraction
+needs a downstream fact — was the signal later affirmed, contradicted, or
+silently dropped — and joining those transitions to a decision row is real
+plumbing. The census reports recorded-not-graded rather than implying
+measurement that doesn't exist.
+
+**Degrade-safety preserved.** The extractor's core guarantee is that it returns
+nothing rather than breaking the conversation it's attached to. Three tests cover
+provider-throws, provider-missing, and the degrade callback still firing.
+
+Volume valved at `budget:200`/day; the decision_quality row is written for every
+settlement regardless, so counts stay complete.
+
+## Evidence
+
+- `tests/unit/topic-intent-extractor-provenance-enrollment.test.ts` (11): census
+  posture; typed decision point and the four options presented; **planted
+  secrets in both the message and the summary never reach the context**; the
+  hash distinguishes different messages; absent summary handled without
+  invention; attribution survives; and all three degrade paths still return
+  empty.
+- Census ratchet: pending baseline shrinks by exactly one; typed-registration
+  check verifies the source imports `DP_TOPIC_INTENT_EXTRACT`.
+- 42 green across affected suites.
+
+## What to Tell Your User
+
+Nothing changes in behaviour. The part of the agent that works out what a
+conversation is *about* now records the calls it makes, so their quality can
+eventually be measured rather than assumed.
+
+None of your conversation is stored — only a fingerprint of each message and
+counts describing the decision's shape. The rolling summary in particular is
+recorded only as "present, this many characters," never its content.
+
+As with the previous one: recorded, not yet graded. Knowing whether a given call
+was right needs a later fact that isn't connected up yet, and the record says so
+rather than implying otherwise.
+
+## Summary of New Capabilities
+
+- The conversation-intent extractor records every decision it makes.
+- Recording is identity-only by construction and tested against planted secrets
+  in both of its untrusted inputs.
+- Enrollment cannot break the extractor's degrade-safe guarantee.

--- a/upgrades/side-effects/enrol-topic-intent-extract.md
+++ b/upgrades/side-effects/enrol-topic-intent-extract.md
@@ -1,0 +1,101 @@
+# Side-effects review — enrol-topic-intent-extract
+
+**Change:** enrol `TopicIntentExtractor` into the LLM-Decision Quality Meter
+(`pending:backlog:decision-quality-enrolment` → `wired`), identity-only context,
+declared `measurement-only`.
+
+**Why this point:** ~733 calls / 7 days — the highest-volume unenrolled decision
+point remaining after the stop gate (#1632). This continues the census task's
+"enrol the highest-volume scenarios", which is plural and where the backlog
+actually shrinks.
+
+**Tier:** 1 — one census entry, one inline context, no new module.
+
+---
+
+## 1. Over-block — what does this reject that it shouldn't?
+
+Nothing at runtime: enrollment adds an `options.provenance` block to an existing
+call. No predicate, no branch, no rejection path. At build time the census
+ratchet now requires this point to stay declared, which is the intent.
+
+## 2. Under-block — what does this still miss?
+
+- **Recorded, not graded**, and declared as such. Grading an extraction needs a
+  downstream fact — was the proposed signal later affirmed, contradicted, or
+  silently dropped? Those transitions exist in the intent store; joining them to
+  a decision row is real plumbing. The census shows the posture rather than
+  implying measurement that does not exist.
+- **`budget:200`/day caps the archive**, not the counts — the decision_quality
+  row is written for every settlement, and a truncation surfaces on the
+  droppedByBudget counter.
+- **The context is a fixed projection.** A field a future reader wants will not
+  exist retroactively. Chosen minimum reconstructs decision shape; widening is
+  additive but not backfillable.
+
+## 3. Level-of-abstraction fit
+
+The context is built inline at the callsite because that is the only place that
+knows which inputs are untrusted (the turn, the rolling summary) versus derived.
+Exporting that distinction so a downstream builder could guess is how a summary
+ends up in a provenance store.
+
+## 4. Signal vs authority compliance
+
+`docs/signal-vs-authority.md`. Enrollment holds **no authority**: the settlement
+seam consumes the block and records on its own path; it never reaches the model
+and never alters the extraction.
+
+**The safety property is the content-bearing contract**, enforced by test rather
+than by care. This extractor's leak surface is unusually wide — it reads a raw
+turn AND a rolling conversational summary, so a leak here republishes far more
+than one message. The fixtures plant a fake API key and password in the message
+and a fake token and file path in the summary; the tests assert none of the four
+reach the serialized context. A hash-distinctness test prevents a constant or
+empty hash from passing those tests while making the identity field useless.
+
+The context is an **allowlist of derived values**, not a filtered copy, so a new
+field on `ExtractorInput` cannot appear in a row by default.
+
+## 5. Interactions
+
+- **Degrade-safety** — the extractor's core guarantee is that it returns `[]`
+  rather than breaking the conversation path it is attached to. Enrollment must
+  not put a new throw in front of that; three tests cover provider-throws,
+  provider-missing, and the degrade callback still firing with the right reason.
+- **`/metrics/features`** — `attribution.component` preserved (explicitly
+  tested; losing it would silently drop this component from the cost surface).
+- **The census ratchet** — the pending baseline shrinks by exactly one line, the
+  direction it may move. The typed-registration check independently verifies the
+  source imports `DP_TOPIC_INTENT_EXTRACT` rather than restating the string.
+
+## 6. External surfaces
+
+- No route, config key, flag, env var, CLI, message, or notification.
+- `GET /decision-quality` shows one more `wired`, one fewer `pending`. Shapes
+  unchanged. No user-visible behaviour.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Unified.** The census is a shipped source constant, byte-identical on every
+install, so every machine enrolls the same point with the same valve and content
+class. The rows inherit the meter's existing posture; no new state surface, no
+notice, no generated URL.
+
+## 8. Rollback cost
+
+Revert. The census entry returns to `pending:` (restoring the baseline line), the
+provenance block disappears, previously-recorded rows remain inertly.
+
+## Second-pass review
+
+**Not required** by the Phase-5 trigger list — no block/allow decision, no
+session lifecycle, no gate. The component it observes is unchanged.
+
+Self-review, the thing I went looking for: **is the summary genuinely excluded,
+or only the message?** It would be easy to guard the obvious field and miss the
+larger one. The fixture plants distinct secrets in BOTH, and the assertions name
+both — because "we tested the leak path" is worth nothing if it tested the
+smaller of two.
+
+Tests: 11 new; 42 green across the affected suites.


### PR DESCRIPTION
## ELI16 — recording what the conversation-reader decides

As you talk, something reads each substantive turn and works out what the
conversation is *about*: is this a new commitment, is it confirming something
said earlier, is it contradicting it. That's how a topic accumulates meaning
instead of being a flat list of messages.

It makes that call about **700 times a week** — the busiest judgment left
unrecorded now that the stop-check is enrolled. Nothing wrote down what it
concluded, so "is that reader any good?" was unanswerable rather than unanswered.

## The careful part: this one sees more than most

The extractor reads your **raw turn** *and* a **rolling summary of the whole
conversation**. Both untrusted, both arbitrary content.

A message leak exposes one turn. A **summary leak republishes the conversation.**

So the row is an explicit **allowlist of derived values** — not a filter over the
input, which means a future field added to what this reader sees cannot start
being stored by accident:

| stored | not stored |
|---|---|
| `messageSha256`, `messageChars` | the message text |
| `topicId`, `arcId`, `messageId`, `fromUser`, `turn` | — |
| `existingRefCount` | the refs themselves |
| `hasRollingSummary`, `rollingSummaryChars` | **a single word of the summary** |

The tests plant a fake API key and password in the *message* **and** a fake token
and file path in the *summary*, asserting none of the four reach the context.
That pairing is deliberate: "we tested the leak path" is worth nothing if it
tested only the smaller of the two.

## Degrade-safety is the other contract

This extractor's core guarantee is that it returns nothing rather than breaking
the conversation it's attached to — provider down, it goes quiet. Enrollment must
not put a new way to fail in front of that. Three tests: provider throws,
provider missing, and the degrade callback still firing with the right reason.

## Recorded, not graded — declared, not implied

Grading an extraction needs a downstream fact: was that signal later affirmed,
contradicted, or silently dropped? Those transitions exist in the intent store;
joining them to a decision row is real plumbing. So the entry declares
`measurement-only` with an argued reason, and the census reports
recorded-not-graded rather than letting `wired` imply measurement that doesn't
exist.

## UX impact declaration

- **Audience:** maintainers reading the decision-quality surface. No end-user surface.
- **Visible behavior change:** none. No predicate, no branch, no new failure path;
  the extraction is provably unchanged. One more `wired`, one fewer `pending`.
- **First contact:** the census counts.
- **User-visible strings introduced:** none.
- **Rollback:** revert. Entry returns to `pending:`, block disappears, rows remain inertly.

## Evidence

- 11 new tests; 42 green across affected suites.
- Census ratchet: pending baseline shrinks by exactly one — the direction it may
  move; typed-registration check verifies the source *imports*
  `DP_TOPIC_INTENT_EXTRACT` rather than restating the string.
- `attribution.component` asserted to survive alongside the new block — losing it
  would silently drop this component from the cost surface.

Follows the pattern merged in #1632, second of the census task's "highest-volume
scenarios".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsMJxSBBPAeDo8bXdunVtC
