### PR TITLE
fix(jobs): canonical job source must authenticate too — plus the blind reflection digest (ACT-620)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-25T21-20-33-638Z-evo007-canonical-source-auth.json
+++ b/.instar/instar-dev-decisions/2026-07-25T21-20-33-638Z-evo007-canonical-source-auth.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-25T21:20:33.638Z",
+  "slug": "evo007-canonical-source-auth",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 2,
+  "loc": 60,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2182,7 +2182,7 @@ Verify that the agent's awareness infrastructure is healthy: topic bindings poin
 Read the auth token once:
 
 \\\`\\\`\\\`
-AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
 \\\`\\\`\\\`
 
 Check each area:
@@ -2254,7 +2254,7 @@ Review degradation events logged by the DegradationReporter, group repeated patt
 Read the auth token:
 
 \\\`\\\`\\\`
-AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
 \\\`\\\`\\\`
 
 ### 1. Read Events
@@ -2320,7 +2320,7 @@ Cross-validate agent state files for logical consistency. Detect orphaned refere
 Read the auth token:
 
 \\\`\\\`\\\`
-AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
 \\\`\\\`\\\`
 
 ### 1. Active Job Orphan
@@ -2393,7 +2393,7 @@ Review \\\`.instar/MEMORY.md\\\` for quality and hygiene. Memory is identity —
 Read the auth token:
 
 \\\`\\\`\\\`
-AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
 \\\`\\\`\\\`
 
 Read the full file: \\\`cat .instar/MEMORY.md\\\`
@@ -2468,7 +2468,7 @@ Check whether the guardians themselves are healthy. Monitors job execution, skip
 Read the auth token:
 
 \\\`\\\`\\\`
-AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
 \\\`\\\`\\\`
 
 ### 1. Job Health
@@ -2573,7 +2573,7 @@ Check whether recent sessions contributed to long-term knowledge. Detects contin
 Read the auth token:
 
 \\\`\\\`\\\`
-AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
 \\\`\\\`\\\`
 
 ### 1. Recent Sessions
@@ -3133,7 +3133,7 @@ export function getDefaultJobs(port: number): object[] {
       enabled: true,
       execute: {
         type: 'prompt',
-        value: `AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+        value: `AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
 
 # Read recent activity logs to understand what happened in last 4 hours
 RECENT_LOGS=$(ls -t .instar/logs/activity-*.jsonl 2>/dev/null | head -1)
@@ -3143,7 +3143,9 @@ fi
 
 # Extract recent session activity and key events (filter out noise, keep significant events)
 echo "=== RECENT ACTIVITY (Last 4 Hours) ==="
-tail -500 "$RECENT_LOGS" 2>/dev/null | jq -r 'select(.type != "job-start" and .type != "job-queued") | "\(.timestamp) [\(.type)] \(.message // .title // .session_name // .slug // "")"' 2>/dev/null | tail -100
+tail -500 "$RECENT_LOGS" 2>/dev/null | jq -r 'select(.type | IN("job_triggered","job_gate_skip","job_skipped") | not) | "\(.timestamp) [\(.type)] \(.summary // .metadata.slug // "")"' | tail -100
+echo "--- volume summary (noise types excluded above) ---"
+tail -500 "$RECENT_LOGS" 2>/dev/null | jq -r '.type' 2>/dev/null | sort | uniq -c | sort -rn
 
 echo ""
 echo "=== YOUR TASK ==="
@@ -3157,7 +3159,7 @@ echo ""
 echo "If you find genuine learnings:"
 echo "1. Update .instar/MEMORY.md with the insight (append to the file)"
 echo "2. Be specific: include what was learned, why it matters, and how it should guide future work"
-echo "3. Signal completion: curl -s -X POST http://localhost:\${INSTAR_PORT:-${port}}/reflection/record -H 'Content-Type: application/json' -d '{\"type\":\"quick\"}'"
+echo "3. Signal completion: curl -s -X POST -H \\"Authorization: Bearer \\$INSTAR_AUTH_TOKEN\\" -H \\"X-Instar-AgentId: \\$INSTAR_AGENT_ID\\" http://localhost:\${INSTAR_PORT:-${port}}/reflection/record -H 'Content-Type: application/json' -d '{\\"type\\":\\"quick\\"}'"
 echo ""
 echo "If nothing significant, do nothing. Silence means continuity is working as expected."`,
       },
@@ -3190,7 +3192,7 @@ echo "If nothing significant, do nothing. Silence means continuity is working as
       gate: `curl -sf http://localhost:\${INSTAR_PORT:-${port}}/health >/dev/null 2>&1`,
       execute: {
         type: 'script',
-        value: `RESULT=$(curl -s -X POST http://localhost:\${INSTAR_PORT:-${port}}/feedback/retry 2>/dev/null); COUNT=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('retried',0))" 2>/dev/null || echo 0); [ "$COUNT" -gt "0" ] && echo "Feedback retry: $COUNT item(s) forwarded." || echo "Feedback retry: nothing pending."`,
+        value: `AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"; RESULT=$(curl -s -X POST -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/feedback/retry 2>/dev/null); COUNT=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('retried',0))" 2>/dev/null || echo 0); [ "$COUNT" -gt "0" ] && echo "Feedback retry: $COUNT item(s) forwarded." || echo "Feedback retry: nothing pending."`,
       },
       tags: ['cat:infrastructure'],
     },
@@ -3206,7 +3208,11 @@ echo "If nothing significant, do nothing. Silence means continuity is working as
       gate: `curl -sf -H "Authorization: Bearer $INSTAR_AUTH_TOKEN" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/evolution/learnings?applied=false 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if len(d.get('learnings',[])) > 0 else 1)"`,
       execute: {
         type: 'prompt',
-        value: `Harvest and synthesize learnings: curl -s http://localhost:\${INSTAR_PORT:-${port}}/evolution/learnings?applied=false
+        value: `AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
+AGENT_ID="\${INSTAR_AGENT_ID:-$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('projectName',''))" 2>/dev/null)}"
+PORT="\${INSTAR_PORT:-${port}}"
+
+Harvest and synthesize learnings: curl -s -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $AGENT_ID" "http://localhost:$PORT/evolution/learnings?applied=false"
 
 Review unapplied learnings and look for:
 1. **Patterns**: Multiple learnings pointing to the same conclusion
@@ -3214,10 +3220,10 @@ Review unapplied learnings and look for:
 3. **Cross-domain connections**: Insights from one area that apply to another
 
 For each actionable pattern found, create an evolution proposal:
-curl -s -X POST http://localhost:\${INSTAR_PORT:-${port}}/evolution/proposals -H 'Content-Type: application/json' -d '{"title":"...","source":"insight-harvest from LRN-XXX","description":"...","type":"...","impact":"...","effort":"..."}'
+curl -s -X POST -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $AGENT_ID" http://localhost:$PORT/evolution/proposals -H 'Content-Type: application/json' -d '{"title":"...","source":"insight-harvest from LRN-XXX","description":"...","type":"...","impact":"...","effort":"..."}'
 
 Then mark the relevant learnings as applied:
-curl -s -X PATCH http://localhost:\${INSTAR_PORT:-${port}}/evolution/learnings/LRN-XXX/apply -H 'Content-Type: application/json' -d '{"appliedTo":"EVO-XXX"}'
+curl -s -X PATCH -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $AGENT_ID" http://localhost:$PORT/evolution/learnings/LRN-XXX/apply -H 'Content-Type: application/json' -d '{"appliedTo":"EVO-XXX"}'
 
 Also update MEMORY.md with any patterns worth preserving long-term.
 
@@ -3237,15 +3243,19 @@ If no actionable patterns found, exit silently.`,
       gate: `curl -sf -H "Authorization: Bearer $INSTAR_AUTH_TOKEN" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/evolution/actions/overdue 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if len(d.get('overdue',[])) > 0 else 1)"`,
       execute: {
         type: 'prompt',
-        value: `Check for overdue commitments: curl -s http://localhost:\${INSTAR_PORT:-${port}}/evolution/actions/overdue
+        value: `AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
+AGENT_ID="\${INSTAR_AGENT_ID:-$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('projectName',''))" 2>/dev/null)}"
+PORT="\${INSTAR_PORT:-${port}}"
+
+Check for overdue commitments: curl -s -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $AGENT_ID" http://localhost:$PORT/evolution/actions/overdue
 
 For each overdue action:
 1. Assess: Can this be completed now? Is it still relevant?
 2. If actionable, attempt to complete it or advance it
-3. If no longer relevant, cancel it: curl -s -X PATCH http://localhost:\${INSTAR_PORT:-${port}}/evolution/actions/ACT-XXX -H 'Content-Type: application/json' -d '{"status":"cancelled","resolution":"No longer relevant because..."}'
+3. If no longer relevant, cancel it: curl -s -X PATCH -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $AGENT_ID" http://localhost:$PORT/evolution/actions/ACT-XXX -H 'Content-Type: application/json' -d '{"status":"cancelled","resolution":"No longer relevant because..."}'
 4. If blocked, escalate to the user via Telegram (if configured)
 
-Also check pending actions (curl -s http://localhost:\${INSTAR_PORT:-${port}}/evolution/actions?status=pending) for items that have been pending more than 48 hours without a due date — these are forgotten commitments.
+Also check pending actions (curl -s -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $AGENT_ID" "http://localhost:$PORT/evolution/actions?status=pending") for items that have been pending more than 48 hours without a due date — these are forgotten commitments.
 
 If no overdue or stale items, exit silently.`,
       },
@@ -3395,10 +3405,10 @@ If no overdue or stale items, exit silently.`,
       expectedDurationMinutes: 1,
       model: 'haiku',
       enabled: true,
-      gate: `curl -sf http://localhost:\${INSTAR_PORT:-${port}}/health >/dev/null 2>&1 && AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null) && curl -sf -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/semantic/stats >/dev/null 2>&1`,
+      gate: `curl -sf http://localhost:\${INSTAR_PORT:-${port}}/health >/dev/null 2>&1 && AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}" && curl -sf -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/semantic/stats >/dev/null 2>&1`,
       execute: {
         type: 'script',
-        value: `AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null); AGENT=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('agentName','Agent'))" 2>/dev/null); RESULT=$(curl -s -X POST -H "Authorization: Bearer $AUTH" -H "Content-Type: application/json" -d "{\\"filePath\\":\\".instar/MEMORY.md\\",\\"agentName\\":\\"$AGENT\\"}" http://localhost:\${INSTAR_PORT:-${port}}/semantic/export-memory 2>/dev/null); COUNT=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('entityCount',0))" 2>/dev/null || echo 0); EXCLUDED=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('excludedCount',0))" 2>/dev/null || echo 0); [ "$COUNT" -gt "0" ] && echo "Memory export: $COUNT entities written to MEMORY.md ($EXCLUDED excluded below threshold)." || echo "Memory export: no entities to export."`,
+        value: `AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"; AGENT=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('agentName','Agent'))" 2>/dev/null); RESULT=$(curl -s -X POST -H "Authorization: Bearer $AUTH" -H "Content-Type: application/json" -d "{\\"filePath\\":\\".instar/MEMORY.md\\",\\"agentName\\":\\"$AGENT\\"}" http://localhost:\${INSTAR_PORT:-${port}}/semantic/export-memory 2>/dev/null); COUNT=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('entityCount',0))" 2>/dev/null || echo 0); EXCLUDED=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('excludedCount',0))" 2>/dev/null || echo 0); [ "$COUNT" -gt "0" ] && echo "Memory export: $COUNT entities written to MEMORY.md ($EXCLUDED excluded below threshold)." || echo "Memory export: no entities to export."`,
       },
       tags: ['cat:maintenance', 'role:worker', 'exec:script'],
     },
@@ -3431,7 +3441,7 @@ If no overdue or stale items, exit silently.`,
       gate: `curl -sf http://localhost:\${INSTAR_PORT:-${port}}/health >/dev/null 2>&1`,
       execute: {
         type: 'script',
-        value: `AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null); REFRESH=$(curl -s -X POST -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/capability-map/refresh 2>/dev/null); DRIFT=$(curl -s -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/capability-map/drift 2>/dev/null); ADDED=$(echo "$DRIFT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('added',[])))" 2>/dev/null || echo 0); REMOVED=$(echo "$DRIFT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('removed',[])))" 2>/dev/null || echo 0); CHANGED=$(echo "$DRIFT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('changed',[])))" 2>/dev/null || echo 0); UNMAPPED=$(echo "$DRIFT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('unmapped',[])))" 2>/dev/null || echo 0); if [ "$ADDED" -gt "0" ] || [ "$REMOVED" -gt "0" ] || [ "$CHANGED" -gt "0" ] || [ "$UNMAPPED" -gt "0" ]; then echo "Capability drift detected: +$ADDED -$REMOVED ~$CHANGED ?$UNMAPPED"; echo "$DRIFT" | python3 -c "import sys,json; d=json.load(sys.stdin); [print(f'  + {c[\"id\"]}') for c in d.get('added',[])]; [print(f'  - {r[\"id\"]}') for r in d.get('removed',[])]; [print(f'  ~ {c[\"id\"]} ({c[\"field\"]})') for c in d.get('changed',[])]" 2>/dev/null; else echo "Capability audit: no drift detected."; fi`,
+        value: `AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"; REFRESH=$(curl -s -X POST -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/capability-map/refresh 2>/dev/null); DRIFT=$(curl -s -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/capability-map/drift 2>/dev/null); ADDED=$(echo "$DRIFT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('added',[])))" 2>/dev/null || echo 0); REMOVED=$(echo "$DRIFT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('removed',[])))" 2>/dev/null || echo 0); CHANGED=$(echo "$DRIFT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('changed',[])))" 2>/dev/null || echo 0); UNMAPPED=$(echo "$DRIFT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('unmapped',[])))" 2>/dev/null || echo 0); if [ "$ADDED" -gt "0" ] || [ "$REMOVED" -gt "0" ] || [ "$CHANGED" -gt "0" ] || [ "$UNMAPPED" -gt "0" ]; then echo "Capability drift detected: +$ADDED -$REMOVED ~$CHANGED ?$UNMAPPED"; echo "$DRIFT" | python3 -c "import sys,json; d=json.load(sys.stdin); [print(f'  + {c[\"id\"]}') for c in d.get('added',[])]; [print(f'  - {r[\"id\"]}') for r in d.get('removed',[])]; [print(f'  ~ {c[\"id\"]} ({c[\"field\"]})') for c in d.get('changed',[])]" 2>/dev/null; else echo "Capability audit: no drift detected."; fi`,
       },
       grounding: {
         requiresIdentity: false,
@@ -3453,7 +3463,7 @@ If no overdue or stale items, exit silently.`,
         type: 'prompt',
         value: `Identity review — check your identity coherence and growth.
 
-AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"
 
 1. **Check soul.md drift**: curl -s -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/identity/soul/drift
    - If anyAboveThreshold is true, review the divergence. Is this healthy growth or unexpected drift?
@@ -3497,7 +3507,7 @@ If everything is coherent and no reflection is needed, exit silently. Only repor
       gate: `curl -sf -H "Authorization: Bearer $INSTAR_AUTH_TOKEN" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/evolution/proposals?status=proposed 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if len(d.get('proposals',[])) > 0 else 1)"`,
       execute: {
         type: 'prompt',
-        value: `Review pending evolution proposals: curl -s http://localhost:\${INSTAR_PORT:-${port}}/evolution/proposals?status=proposed\n\nFor each proposal:\n1. Read the title, description, type, and source\n2. Evaluate: Is this a genuine improvement? Is the effort worth the impact? Does it align with our goals?\n3. If approved, update status: curl -s -X PATCH http://localhost:\${INSTAR_PORT:-${port}}/evolution/proposals/EVO-XXX -H 'Content-Type: application/json' -d '{"status":"approved"}'\n4. If rejected or deferred, update with reason.\n\nDo NOT implement approved proposals — that's handled by the paired evolution-proposal-implement job.\n\nAlso check the dashboard: curl -s http://localhost:\${INSTAR_PORT:-${port}}/evolution — report any highlights to the user if they seem important.\n\nIf no proposals need attention, exit silently.`,
+        value: `AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"\nAGENT_ID="\${INSTAR_AGENT_ID:-$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('projectName',''))" 2>/dev/null)}"\nPORT="\${INSTAR_PORT:-${port}}"\n\nReview pending evolution proposals: curl -s -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $AGENT_ID" "http://localhost:$PORT/evolution/proposals?status=proposed"\n\nFor each proposal:\n1. Read the title, description, type, and source\n2. Evaluate: Is this a genuine improvement? Is the effort worth the impact? Does it align with our goals?\n3. If approved, update status: curl -s -X PATCH -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $AGENT_ID" http://localhost:$PORT/evolution/proposals/EVO-XXX -H 'Content-Type: application/json' -d '{"status":"approved"}'\n4. If rejected or deferred, update with reason.\n\nDo NOT implement approved proposals — that's handled by the paired evolution-proposal-implement job.\n\nAlso check the dashboard: curl -s -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $AGENT_ID" http://localhost:$PORT/evolution — report any highlights to the user if they seem important.\n\nIf no proposals need attention, exit silently.`,
       },
       tags: ['cat:learning', 'role:worker', 'exec:prompt', 'pair:evolution-proposal-implement'],
     },
@@ -3513,7 +3523,7 @@ If everything is coherent and no reflection is needed, exit silently. Only repor
       gate: `curl -sf -H "Authorization: Bearer $INSTAR_AUTH_TOKEN" -H "X-Instar-AgentId: $INSTAR_AGENT_ID" http://localhost:\${INSTAR_PORT:-${port}}/evolution/proposals?status=approved 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if len(d.get('proposals',[])) > 0 else 1)"`,
       execute: {
         type: 'prompt',
-        value: `Implement approved evolution proposals: curl -s http://localhost:\${INSTAR_PORT:-${port}}/evolution/proposals?status=approved\n\nFor each approved proposal:\n1. Read the full description and understand what needs to be built\n2. Implement it: create the skill/hook/job/config change described\n3. After implementation, mark complete: curl -s -X PATCH http://localhost:\${INSTAR_PORT:-${port}}/evolution/proposals/EVO-XXX -H 'Content-Type: application/json' -d '{"status":"implemented","resolution":"What was done"}'\n\nIf no approved proposals exist, exit silently.`,
+        value: `AUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"\nAGENT_ID="\${INSTAR_AGENT_ID:-$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('projectName',''))" 2>/dev/null)}"\nPORT="\${INSTAR_PORT:-${port}}"\n\nImplement approved evolution proposals: curl -s -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $AGENT_ID" "http://localhost:$PORT/evolution/proposals?status=approved"\n\nFor each approved proposal:\n1. Read the full description and understand what needs to be built\n2. Implement it: create the skill/hook/job/config change described\n3. After implementation, mark complete: curl -s -X PATCH -H "Authorization: Bearer $AUTH" -H "X-Instar-AgentId: $AGENT_ID" http://localhost:$PORT/evolution/proposals/EVO-XXX -H 'Content-Type: application/json' -d '{"status":"implemented","resolution":"What was done"}'\n\nIf no approved proposals exist, exit silently.`,
       },
       grounding: {
         requiresIdentity: true,
@@ -3533,7 +3543,7 @@ If everything is coherent and no reflection is needed, exit silently. Only repor
       gate: `curl -sf http://localhost:\${INSTAR_PORT:-${port}}/health >/dev/null 2>&1`,
       execute: {
         type: 'prompt',
-        value: `Scan recent messages for commitments and promises.\n\nAUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)\n\n1. Read your bookmark: cat .instar/state/commitment-detection-bookmark.json 2>/dev/null || echo '{"lastProcessedId": 0}'\n2. Fetch new messages since bookmark from Telegram message log: tail -100 .instar/telegram-messages.jsonl\n3. For each new message, check: does it contain a commitment, promise, or action item? Look for patterns like 'I will', 'let me', 'I\\'ll build', 'we should', 'TODO', 'action item', deadlines, etc.\n4. For each detected commitment, register it: curl -s -X POST http://localhost:\${INSTAR_PORT:-${port}}/evolution/actions -H "Authorization: Bearer $AUTH" -H 'Content-Type: application/json' -d '{"title":"...","source":"commitment-detection","description":"...","dueDate":"..."}'\n5. Update bookmark with the last processed message ID.\n\nOnly process NEW messages since last bookmark. Exit silently if no new commitments found.`,
+        value: `Scan recent messages for commitments and promises.\n\nAUTH="\${INSTAR_AUTH_TOKEN:-$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)}"\n\n1. Read your bookmark: cat .instar/state/commitment-detection-bookmark.json 2>/dev/null || echo '{"lastProcessedId": 0}'\n2. Fetch new messages since bookmark from Telegram message log: tail -100 .instar/telegram-messages.jsonl\n3. For each new message, check: does it contain a commitment, promise, or action item? Look for patterns like 'I will', 'let me', 'I\\'ll build', 'we should', 'TODO', 'action item', deadlines, etc.\n4. For each detected commitment, register it: curl -s -X POST http://localhost:\${INSTAR_PORT:-${port}}/evolution/actions -H "Authorization: Bearer $AUTH" -H 'Content-Type: application/json' -d '{"title":"...","source":"commitment-detection","description":"...","dueDate":"..."}'\n5. Update bookmark with the last processed message ID.\n\nOnly process NEW messages since last bookmark. Exit silently if no new commitments found.`,
       },
       tags: ['cat:evolution', 'role:worker', 'exec:prompt', 'pair:evolution-overdue-check'],
     },

--- a/src/scaffold/templates/jobs/instar/reflection-trigger.md
+++ b/src/scaffold/templates/jobs/instar/reflection-trigger.md
@@ -22,7 +22,9 @@ fi
 
 # Extract recent session activity and key events (filter out noise, keep significant events)
 echo "=== RECENT ACTIVITY (Last 4 Hours) ==="
-tail -500 "$RECENT_LOGS" 2>/dev/null | jq -r 'select(.type != "job-start" and .type != "job-queued") | "(.timestamp) [(.type)] (.message // .title // .session_name // .slug // "")"' 2>/dev/null | tail -100
+tail -500 "$RECENT_LOGS" 2>/dev/null | jq -r 'select(.type | IN("job_triggered","job_gate_skip","job_skipped") | not) | "\(.timestamp) [\(.type)] \(.summary // .metadata.slug // "")"' | tail -100
+echo "--- volume summary (noise types excluded above) ---"
+tail -500 "$RECENT_LOGS" 2>/dev/null | jq -r '.type' 2>/dev/null | sort | uniq -c | sort -rn
 
 echo ""
 echo "=== YOUR TASK ==="

--- a/tests/unit/job-template-auth-lint.test.ts
+++ b/tests/unit/job-template-auth-lint.test.ts
@@ -21,9 +21,18 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { getDefaultJobs } from '../../src/commands/init.js';
 
 const TEMPLATE_DIR = path.resolve(__dirname, '../../src/scaffold/templates/jobs/instar');
 const MIDDLEWARE_PATH = path.resolve(__dirname, '../../src/server/middleware.ts');
+/**
+ * The .md templates are GENERATED from getDefaultJobs() in init.ts by
+ * scripts/regen-default-job-templates.mjs. Linting only the generated output
+ * is not enough: a regen would happily reintroduce an unauthenticated body
+ * from the canonical source, silently reverting the fix. So init.ts is linted
+ * too — that is what actually closes the class.
+ */
+const INIT_PATH = path.resolve(__dirname, '../../src/commands/init.ts');
 
 /**
  * Endpoints the server serves WITHOUT the API bearer token.
@@ -187,6 +196,52 @@ describe('built-in job template auth lint', () => {
   it('still catches a genuine undefined $AUTH', () => {
     const bad = 'curl -s -H "Authorization: Bearer $AUTH" http://localhost:$PORT/evolution';
     expect(findUndefinedAuthVar(bad, 'bad.md')).toEqual(['bad.md']);
+  });
+
+  it('the canonical source (getDefaultJobs) authenticates its non-public API calls', () => {
+    // Lints the RESOLVED job objects, not the raw file. init.ts also contains
+    // the CLAUDE.md template prose, which carries illustrative curl examples
+    // that are documentation, not job bodies — regexing the whole file would
+    // flag those. Resolving getDefaultJobs(port) gives exactly the shipped
+    // gate + prompt bodies with ${port} already interpolated.
+    //
+    // This must lint the canonical SOURCE: the .md templates are generated
+    // from it, so a regen could otherwise reintroduce the 401 bug and
+    // silently revert the fix.
+    const jobs = getDefaultJobs(4042) as Array<{
+      slug?: string;
+      gate?: string;
+      execute?: { type?: string; value?: string };
+    }>;
+
+    expect(jobs.length, 'getDefaultJobs returned nothing — the lint would pass vacuously').toBeGreaterThan(10);
+
+    const violations: AuthViolation[] = [];
+    for (const job of jobs) {
+      const surfaces = [job.gate ?? '', job.execute?.value ?? ''];
+      for (const surface of surfaces) {
+        violations.push(...findUnauthenticatedCalls(surface, job.slug ?? '<unslugged>'));
+      }
+    }
+
+    const report = violations.map(v => `  ${v.file} → ${v.endpoint}\n    ${v.snippet}`).join('\n');
+    expect(violations, `Unauthenticated calls in canonical job definitions:\n${report}`).toEqual([]);
+  });
+
+  it('no job body in init.ts reads the auth token from config.json alone', () => {
+    // A config.json-only read is a live defect, not a style nit: on an agent
+    // whose stored token has drifted from the running server's token, that
+    // read returns a value the server rejects (observed 2026-07-25 — 16-char
+    // config value rejected, 36-char $INSTAR_AUTH_TOKEN accepted). The
+    // environment value must come first.
+    const content = fs.readFileSync(INIT_PATH, 'utf-8');
+    const configOnly = content
+      .split('\n')
+      .map((line, i) => ({ line, n: i + 1 }))
+      .filter(({ line }) => /AUTH=\$\(python3/.test(line) && !line.includes('INSTAR_AUTH_TOKEN'));
+
+    const report = configOnly.map(({ n }) => `  init.ts:${n}`).join('\n');
+    expect(configOnly, `Job bodies reading authToken from config.json only:\n${report}`).toEqual([]);
   });
 
   it('drift guard: every exempted path is still public in middleware.ts', () => {

--- a/upgrades/next/evo007-canonical-source-auth.md
+++ b/upgrades/next/evo007-canonical-source-auth.md
@@ -1,0 +1,28 @@
+## What Changed
+
+Follow-up to the built-in job-template auth fix. That change repaired the shipped `.md` templates; this repairs the **canonical source that generates them**. `src/scaffold/templates/jobs/instar/*.md` are produced from `getDefaultJobs()` in `src/commands/init.ts` via `scripts/regen-default-job-templates.mjs`, so the earlier fix was applied to generated output while the generator's input stayed broken — a regen would have silently reverted it (confirmed with the generator's `--dry-run`, which lists all five previously-fixed templates as regeneration targets).
+
+- **13 unauthenticated calls** in canonical job definitions now carry `Authorization: Bearer $AUTH` + `X-Instar-AgentId`. Twelve mirror the prior fix; the thirteenth — `feedback-retry` → `POST /feedback/retry` — was found by the new guard and confirmed live as a 401.
+- **12 config-only token reads** (`AUTH=$(python3 … config.json …)`) replaced with the env-first `${INSTAR_AUTH_TOKEN:-…}` form, across `reflection-trigger`, `memory-export`, `capability-audit`, `identity-review`, `commitment-detection`, and six CLAUDE.md-template instruction blocks. A config-only read is rejected outright on an agent whose stored token has drifted from the running server's.
+- **The reflection activity digest** (ACT-620) fixed in both callsites, and it was worse than reported: in the `.md` the jq program is a **compile error** (interpolation backslashes lost), silenced by `2>/dev/null`, so every reflection ran on an empty digest. The filter excluded `job-start`/`job-queued`, which never occur — real types are `job_triggered` / `job_gate_skip` / `job_skipped` — and the text slot read `.message`/`.title`/`.session_name`/`.slug`, none of which exist; the real keys are `.summary` and `.metadata.slug`. Now filters the real noise types, reads the real keys, and prints a type-count summary so job volume is visible without consuming the 100-line budget.
+- **The auth lint now covers the canonical source**, by resolving `getDefaultJobs(4042)` and linting the real `gate` + `execute.value` strings rather than regexing file text.
+
+## What to Tell Your User
+
+Reflection runs have been producing an empty activity digest — every reflection was working from a blank page, and the failure was silenced. Reflections will now see real recent activity. As with the prior fix, jobs that were quiet because they were failing will start producing output; that is the repair, not a new fault.
+
+## Summary of New Capabilities
+
+No new user-facing capability. Thirteen job bodies go from silently 401-ing to functional, reflection digests go from empty to populated, and the build-time guard now covers the source that generates the shipped templates.
+
+## Evidence
+
+- Guard proven to bite: with `init.ts` reverted to `origin/main`, the canonical-source test fails listing 13 unauthenticated calls (`reflection-trigger`, `feedback-retry`, `insight-harvest`, `evolution-overdue-check`, `evolution-proposal-evaluate`, `evolution-proposal-implement`); the config-only-token test fails with 12. Both pass on the fixed tree.
+- The guard's own first version passed **vacuously** — it regexed raw `init.ts`, whose bodies carry `localhost:\${INSTAR_PORT:-${port}}`, which its pattern never matched. Rewritten to lint resolved job objects, with a sample-size assertion so an empty resolution can never read as clean. The rewrite then found the `feedback-retry` defect.
+- Live: unauthenticated `POST /feedback/retry` returns `{"error":"Missing or invalid Authorization header"}`; authenticated returns `{"ok":true,"retried":0,"succeeded":0}`.
+- Shipped jq confirmed a compile error against a real activity log; corrected jq emits real `scheduler_start`/`scheduler_stop` rows with summaries plus `462 job_triggered / 33 job_gate_skip / 3 scheduler_start / 2 scheduler_stop`.
+- Real log census: keys are `type`, `timestamp`, `summary`, `metadata`, `sessionId`; types are `job_triggered`, `job_gate_skip`, `job_skipped`, `scheduler_start`, `scheduler_stop`.
+- Generated bash for the reflection echo extracted from the resolved job object and executed: renders `-d '{"type":"quick"}'` with `$INSTAR_AUTH_TOKEN` left unexpanded.
+- `tsc --noEmit` clean; auth lint (11 tests), `default-jobs-valid`, `refresh-jobs` green.
+
+Remaining general byte-parity between generated templates and their generator source is tracked as ACT-1263 <!-- tracked: ACT-1263 --> rather than folded in — reconciling all 14 generated templates is a distinct change with its own review surface.

--- a/upgrades/side-effects/evo007-canonical-source-auth.eli16.md
+++ b/upgrades/side-effects/evo007-canonical-source-auth.eli16.md
@@ -1,0 +1,47 @@
+# Fixing the thing that generates the job instructions — Plain-English Overview
+
+> The one-line version: last change fixed the printout; this one fixes the printer, because the printer would have re-printed the broken version.
+
+## The problem in one breath
+
+The previous fix repaired six job instruction files. It turns out those files are **generated** from a master list elsewhere in the code — and that master list was never fixed. Anyone regenerating the files would have quietly undone the repair, and everything would still *look* fine.
+
+That is the same trap this whole family of bugs keeps setting: a change that looks exactly like a real fix until something routine wipes it.
+
+## What already exists
+
+- **The master list** — one place in the code that defines every built-in scheduled job: when it runs, what it checks, and the instructions it follows.
+- **The generator** — a small script that turns that master list into the individual instruction files that ship to your agent.
+- **The build-time check from last time** — scans the *generated* files for jobs that call a locked door without a key.
+
+## What this adds
+
+**The check now also reads the master list**, not just the files it produces. That's the actual fix: the previous check guarded the output while the input stayed broken.
+
+Along with that:
+
+- **Thirteen jobs** in the master list now carry the key. Twelve were already known. The thirteenth — a job that retries failed feedback delivery — was found *by the new check*, not by me, and confirmed broken.
+- **Twelve places** were reading the key from a stored copy on disk instead of the live one. On a machine where the stored copy has gone out of date, that copy is rejected. They now prefer the live one.
+- **The reflection job's activity summary was completely empty** — and worse than reported. Its filter looked for two event types that never occur, and it read four field names that don't exist. On top of that, the version in the shipped file had lost some punctuation, which made it not just wrong but a **syntax error** — silenced, so it failed invisibly. Every reflection has been running on a blank page. Now it filters the event types that actually occur, reads the fields that actually exist, and adds a short count summary so the reflection can see how busy things were.
+
+## The safeguards
+
+**The check was caught lying, and fixed.** Its first version passed cleanly against the broken master list — not because the list was fine, but because its pattern didn't match the way text is written there. A check that passes for the wrong reason is worse than no check, because it hands you confidence you didn't earn. It now reads the *actual resolved jobs* rather than pattern-matching source text, and it refuses to report "clean" if it somehow finds no jobs to inspect.
+
+**It immediately proved itself.** The rewritten check found a broken job I didn't know about. That's the difference between a check that describes a fix and one that does work.
+
+**It was proven against the broken version first.** Turn the fix off, and the check reports all thirteen problems. Turn it on, and it reports none.
+
+**Documentation examples aren't punished.** The master list file also contains example commands written for humans to read. Those are deliberately not treated as real jobs, so the check doesn't flag prose.
+
+## What ships when
+
+All together — the master-list fixes, the reflection digest repair, and the widened check.
+
+## What's deliberately left for later
+
+The generated files and the master list have drifted apart over time in other, harmless-looking ways. The **key-and-lock** problem is now closed on both sides, but a full reconciliation of all fourteen generated files is a separate job with its own review. It's written down and tracked rather than quietly forgotten.
+
+## If it goes wrong
+
+Undo the change and ship a patch. Nothing is stored, nothing is migrated. Worst case is a return to quiet jobs that don't do anything — the same benign fallback as before.

--- a/upgrades/side-effects/evo007-canonical-source-auth.md
+++ b/upgrades/side-effects/evo007-canonical-source-auth.md
@@ -1,0 +1,147 @@
+# Side-Effects Review — Canonical job source must authenticate too (EVO-007 follow-up, ACT-620)
+
+**Version / slug:** `evo007-canonical-source-auth`
+**Date:** `2026-07-25`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+PR #1636 fixed the shipped `.md` job templates. This fixes the thing that **generates** them. `src/scaffold/templates/jobs/instar/*.md` are produced from `getDefaultJobs()` in `src/commands/init.ts` by `scripts/regen-default-job-templates.mjs`, so the previous fix was applied to generated output while the generator's input stayed broken — a regen would have silently reverted it. That is precisely the "fix that only looks like a fix" this family of defects keeps producing, and it was caught by reading the generator rather than trusting the previous PR's completeness.
+
+Changes:
+
+1. **13 unauthenticated calls** in canonical job definitions now carry `Authorization: Bearer $AUTH` + `X-Instar-AgentId`. Twelve mirror PR #1636; the thirteenth — `feedback-retry` → `POST /feedback/retry` — was **found by the new guard**, not by me, and confirmed live as a 401.
+2. **12 config-only token reads** (`AUTH=$(python3 … config.json …)`) replaced with the env-first `${INSTAR_AUTH_TOKEN:-…}` form across `reflection-trigger`, `memory-export`, `capability-audit`, `identity-review`, `commitment-detection`, and six CLAUDE.md-template instruction blocks. A config-only read is a live defect on any agent whose stored token has drifted from the running server's.
+3. **ACT-620's blind activity digest** fixed in both callsites. The shipped jq was worse than reported: in the `.md` it is a **jq compile error** (interpolation backslashes lost), silenced by `2>/dev/null`, so every reflection ran on an empty digest. The filter also excluded `job-start`/`job-queued`, which never occur — the real types are `job_triggered` / `job_gate_skip` / `job_skipped` — and the text slot read `.message`/`.title`/`.session_name`/`.slug`, none of which are keys; the real ones are `.summary` and `.metadata.slug`. Now filters the real noise types, reads the real keys, and adds a volume summary so the reflection sees job activity without it eating the 100-line budget.
+4. **The lint now covers the canonical source**, by resolving `getDefaultJobs(4042)` and linting the real `gate` + `execute.value` strings.
+
+## Decision-point inventory
+
+- `tests/unit/job-template-auth-lint.test.ts` — **modify** — extended to the canonical source. Still a CI lint: build-time only, zero runtime authority.
+- `getDefaultJobs()` job bodies — **modify** — LLM instruction text and shell one-liners. No block/allow logic.
+- No runtime module, route, gate, or sentinel is touched.
+
+---
+
+## 1. Over-block
+
+The only rejecting surface is the lint. Its over-block risk is a false CI failure.
+
+Notably, the **first version of the canonical-source guard was worse than a false positive — it was a false NEGATIVE**: it regexed the raw `init.ts` text, whose bodies contain `localhost:\${INSTAR_PORT:-${port}}`, which the detector's `\d+`/`$PORT` pattern never matched. It passed **vacuously** while the source was fully broken. Caught by running the detector against the pre-fix source and seeing it report nothing where an independent probe found violations. Fixed by linting the *resolved* job objects instead of the file text, plus an explicit `expect(jobs.length).toBeGreaterThan(10)` so an empty/failed resolution can never read as "clean".
+
+Scoping the lint to resolved job objects also removes a real over-block: `init.ts` embeds the CLAUDE.md template prose, which contains illustrative `curl` examples that are documentation, not job bodies. Linting the whole file flagged 52 of those.
+
+---
+
+## 2. Under-block
+
+- Same line-scoped-curl and non-curl-client limits as PR #1636.
+- The lint verifies a header is *present*, not that the token *resolves*; the config-only rule covers the known stale-token shape but a novel wrong-token expression would pass.
+- **The `.md` files and `init.ts` are still not byte-compared.** The auth/token class is now closed on both sides, but general drift is not — tracked as **ACT-1263** <!-- tracked: ACT-1263 -->.
+- The jq fix is verified against this machine's activity logs. A log containing event types not present here would still be filtered by name.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer, and this change *moves* the guard to the right layer: the previous lint sat on the generated artifact, one level below where the defect is authored. Linting the generator's resolved output is the level at which "a shipped job body must authenticate" is actually decidable.
+
+Resolving `getDefaultJobs()` rather than regexing the source is the same principle applied again — ask the system for its real answer instead of pattern-matching its text.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The lint can only fail a build. The job bodies are instructions and shell strings with no decision logic. Nothing here can refuse an agent action at runtime.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+**No new static heuristic at a competing-signals decision point.** "Does this resolved job body call a non-public endpoint without an auth header?" is an invariant over a finite, enumerable public-path set. No competing live signals.
+
+The jq event-type filter is a static list, but it is not a decision point either — it selects log lines for a human-readable digest, and a mis-filtered line degrades digest quality, never a decision.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** None. The lint file is independent.
+- **Double-fire:** None.
+- **Races:** None.
+- **Feedback loops:** `reflection-trigger`'s digest feeds an LLM reflection that may write MEMORY.md. Fixing the digest changes that input from *empty* to *real*, which is the intent; the digest is bounded (`tail -100` plus a type-count summary) so it cannot grow unbounded.
+- **Generator interaction (the important one):** `regen-default-job-templates.mjs` writes `.md` from these bodies. Because the canonical source is now fixed, a regen propagates the fix instead of reverting it. Verified via `--dry-run`, which lists all five previously-fixed templates as regeneration targets — the concrete proof the prior fix alone was revertible.
+
+---
+
+## 6. External surfaces
+
+- **Other users of the install base:** 13 job bodies that silently 401'd will start working, and reflection digests go from empty to populated. Same "quiet becomes active" note as PR #1636.
+- **External systems:** none; all calls are localhost.
+- **Persistent state:** none added.
+- **Secrets:** the reflection echo deliberately emits `$INSTAR_AUTH_TOKEN` **unexpanded**, so no token value enters a transcript. Verified by executing the generated line.
+- **Operator surface:** none added or touched.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+**No operator surface — not applicable.** No dashboard renderer, approval page, or grant/secret form is touched.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN**, same reason as PR #1636: templates are installed per machine by that machine's own `installBuiltinJobs()`, and the token each body resolves is necessarily machine-local (every install holds its own `authToken`; a shared token cannot work cross-machine). Identical shipped content resolved against per-machine credentials — not machine-local state that ought to be replicated.
+
+- **User-facing notices:** none emitted by this change.
+- **Durable state on topic transfer:** none held.
+- **Generated URLs:** none; all are localhost calls made by the job on its own machine.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the commit; agents pick it up on their next update.
+- **Data migration:** none.
+- **Agent state repair:** none.
+- **User visibility during rollback:** reverting restores quiet failure — no crash, no data loss. Same benign asymmetry as PR #1636.
+
+---
+
+## Conclusion
+
+This review's main product is the correction of my own guard. The canonical-source lint initially passed vacuously — the worst failure mode available to a check, because a vacuous pass is indistinguishable from a real one and would have shipped as false assurance. Testing the guard against the pre-fix source (rather than only against the fixed tree) exposed it, and the rewrite to lint resolved job objects then immediately earned its place by finding a 13th defect, `feedback-retry`, that I had not known about.
+
+The change is clear to ship. The remaining known gap — general byte-parity between generated templates and their source — is tracked as ACT-1263 rather than folded in, because reconciling all 14 generated templates is a distinct change with its own review surface.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required. No block/allow surface, no session lifecycle, no context/compaction, no coherence/trust surface, and no sentinel/guard/gate/watchdog runtime component. The only "gate"-adjacent text is the `gate:` frontmatter field, whose *content* is edited but whose evaluation semantics are untouched.
+
+---
+
+## Evidence pointers
+
+- Guard proven to bite: with `init.ts` reverted to `origin/main`, the canonical-source test fails listing 13 unauthenticated calls across `reflection-trigger`, `feedback-retry`, `insight-harvest`, `evolution-overdue-check`, `evolution-proposal-evaluate`, `evolution-proposal-implement`; the config-only-token test fails with 12. Both pass on the fixed tree.
+- Live 401 → 200 for the newly-found endpoint: unauthenticated `POST /feedback/retry` → `{"error":"Missing or invalid Authorization header"}`; authenticated → `{"ok":true,"retried":0,"succeeded":0}`.
+- Shipped jq proven to be a compile error against a real activity log; corrected jq emits real `scheduler_start`/`scheduler_stop` rows with summaries, and the volume summary reports `462 job_triggered / 33 job_gate_skip / 3 scheduler_start / 2 scheduler_stop`.
+- Real log key/type census: top-level keys are `type`, `timestamp`, `summary`, `metadata`, `sessionId` (never `message`/`title`/`session_name`/`slug`); types are `job_triggered`, `job_gate_skip`, `job_skipped`, `scheduler_start`, `scheduler_stop` (never `job-start`/`job-queued`).
+- Generated bash for the reflection echo extracted from the resolved job object and executed: renders `-d '{"type":"quick"}'` with `$INSTAR_AUTH_TOKEN` unexpanded.
+- `tsc --noEmit` clean; lint (11 tests), `default-jobs-valid`, `refresh-jobs` green.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+- **`defectClass`** — `proxy-signal-substitution` (the same class as PR #1636 and the EVO-004/005/006 family): the generated artifact was treated as the thing to fix, when the generator's input is what determines what ships.
+- **`closure`** — `guard`.
+- **`guardEvidence`** — `{enforcementType: lint, citation: tests/unit/job-template-auth-lint.test.ts#"the canonical source (getDefaultJobs) authenticates its non-public API calls", howCaught: it resolves getDefaultJobs(4042) and lints the real gate + prompt bodies, so an unauthenticated call cannot enter the canonical source that generates the shipped templates; run against the pre-fix source it reports all 13, and a sample-size assertion prevents a vacuous pass}`.
+- **`gap`** — `ACT-1263` for the remaining general byte-parity between generated templates and their generator source, which this change does not close.


### PR DESCRIPTION
## ELI16 — last change fixed the printout; this one fixes the printer, because the printer would have re-printed the broken version

The previous PR repaired six job instruction files. It turns out those files are **generated** from a master list elsewhere in the code — and that master list was never fixed. Anyone regenerating the files would have quietly undone the repair, and everything would still *look* fine. That's the same trap this family of bugs keeps setting: a change that looks exactly like a real fix until something routine wipes it.

**The check now also reads the master list**, not just the files it produces. Along with that:

- **Thirteen jobs** in the master list now carry the key. Twelve were already known. The thirteenth — a job that retries failed feedback delivery — was found *by the new check*, not by me, and confirmed broken.
- **Twelve places** were reading the key from a stored copy on disk instead of the live one. Where the stored copy has gone stale, it's rejected. They now prefer the live one.
- **The reflection job's activity summary was completely empty**, and worse than reported: its filter looked for two event types that never occur, it read four field names that don't exist, and the shipped copy had lost punctuation that made it an outright **syntax error** — silenced, so it failed invisibly. Every reflection has been running on a blank page.

### The safeguards

**The check was caught lying, and fixed.** Its first version passed cleanly against the broken master list — not because the list was fine, but because its pattern didn't match the way text is written there. A check that passes for the wrong reason is worse than no check, because it hands you confidence you didn't earn. It now reads the *actual resolved jobs* and refuses to report "clean" if it finds no jobs to inspect. **It immediately proved itself** by finding the thirteenth broken job.

**Proven against the broken version first:** turn the fix off and the check reports all thirteen; turn it on and it reports none.

**What you'll notice:** jobs that were quiet because they were failing will start producing output, and reflections will see real activity. That's the repair, not a new fault.

**If it goes wrong:** revert and ship a patch. Nothing stored, nothing migrated — worst case is a return to quiet jobs that do nothing.

---

## What Changed

`src/scaffold/templates/jobs/instar/*.md` are generated from `getDefaultJobs()` in `src/commands/init.ts` via `scripts/regen-default-job-templates.mjs`, so #1636 fixed generated output while the generator's input stayed broken. Confirmed with the generator's `--dry-run`, which lists all five previously-fixed templates as regeneration targets.

- **13 unauthenticated calls** in canonical job definitions now carry `Authorization: Bearer $AUTH` + `X-Instar-AgentId`. The thirteenth (`feedback-retry` → `POST /feedback/retry`) was found by the new guard and confirmed live as a 401.
- **12 config-only token reads** replaced with the env-first `${INSTAR_AUTH_TOKEN:-…}` form across `reflection-trigger`, `memory-export`, `capability-audit`, `identity-review`, `commitment-detection`, and six CLAUDE.md-template instruction blocks.
- **ACT-620 (blind reflection digest)** fixed in both callsites. In the `.md` the jq program is a **compile error** (interpolation backslashes lost) silenced by `2>/dev/null`. The filter excluded `job-start`/`job-queued`, which never occur — real types are `job_triggered` / `job_gate_skip` / `job_skipped` — and the text slot read `.message`/`.title`/`.session_name`/`.slug`, none of which are keys; real ones are `.summary` and `.metadata.slug`. Now filters real noise types, reads real keys, and prints a type-count summary.
- **The auth lint now covers the canonical source** by resolving `getDefaultJobs(4042)` and linting real `gate` + `execute.value` strings.

## Evidence

- With `init.ts` reverted to `origin/main`, the canonical-source test fails listing 13 unauthenticated calls; the config-only-token test fails with 12. Both pass on the fixed tree.
- The guard's first version passed **vacuously** — it regexed raw `init.ts`, whose bodies carry `localhost:\${INSTAR_PORT:-${port}}`, which its pattern never matched. Rewritten to lint resolved job objects with a sample-size assertion.
- Live: unauthenticated `POST /feedback/retry` → `{"error":"Missing or invalid Authorization header"}`; authenticated → `{"ok":true,"retried":0,"succeeded":0}`.
- Shipped jq confirmed a compile error against a real activity log; corrected jq emits real rows plus `462 job_triggered / 33 job_gate_skip / 3 scheduler_start / 2 scheduler_stop`.
- Generated bash for the reflection echo extracted from the resolved job object and executed: renders `-d '{"type":"quick"}'` with `$INSTAR_AUTH_TOKEN` unexpanded (no token in transcripts).
- `tsc --noEmit` clean; auth lint (11 tests), `default-jobs-valid`, `refresh-jobs` green.

## Notes for reviewers

- Declared **Tier 1 below the gate's riskFloor 2**, recorded as `belowFloor: true`. The floor came from "new config key added", a false positive: `CONFIG_SURFACE_HINT` matches the literal string `config.json` inside the python one-liner that *reads* the token, combined with JSON-shaped `-d` payloads. This change adds zero config surface — no key, no schema, no default.
- Remaining general byte-parity between generated templates and their generator source is tracked as **ACT-1263**, not folded in — reconciling all 14 generated templates is a distinct change with its own review surface.

Follow-up to #1636. Implements ACT-620.
