### PR TITLE
fix(standards-audit): the enforcement ratio carries its denominator, and the parser stops dropping a family

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T01-28-17-080Z-honest-denominators-standards.json
+++ b/.instar/instar-dev-decisions/2026-07-26T01-28-17-080Z-honest-denominators-standards.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T01:28:17.080Z",
+  "slug": "honest-denominators-standards",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 278,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/honest-denominators-standards.eli16.md
+++ b/docs/specs/honest-denominators-standards.eli16.md
@@ -1,0 +1,112 @@
+# Honest denominators, part two: the tool that grades our own rules was grading a quarter of them
+
+## What this actually is
+
+We keep a constitution — a document of standards the agent must hold to. We also have a tool that
+reads it and answers one question: *for each standard, does a real guard exist that enforces it?*
+It reports a single headline number.
+
+On 2026-07-25 that number read **4.55% enforced**, sitting next to the word **"converged: true"**.
+Both were misleading, in three separate ways, and the agent reading them quoted the alarming
+figure onward as fact.
+
+## Defect one: the ratio was computed over a quarter of the constitution
+
+The constitution has **81 articles**. The tool was reading a copy with **22**.
+
+Read in full, the real figure is **53.75% enforced** — 43 of 80 standards held by a test, a gate,
+or a linter. Not four percent. The arithmetic was never wrong; it was arithmetic over a
+denominator nobody could see, and the visible result was **twelve times more alarming than
+reality**.
+
+This change does not fix which copy gets read (that is a separate, tracked piece of work — see
+"What this does NOT fix" below). It fixes something more important: **the number can no longer
+appear without the denominator it was computed over.** Every response now carries how many
+article headings were found, how many parsed, which families were seen, how many bytes were read,
+and whether the audit's own canary vouches for any of it — plus an explicit
+`assessmentTrustworthy` flag. A fragment can still be measured. It can no longer pose as the
+whole.
+
+## Defect two: a whole family of standards was invisible by construction
+
+To find the articles, the parser held a list of five section names. The constitution has **six**
+sections of standards. Everything under the sixth — currently our self-hosting standard — was
+silently discarded. No warning, no count, nothing.
+
+A name list can only ever be as current as the last person who remembered to edit it. So the list
+is gone. A section now counts as a family of standards **because of its shape**: it is a family if
+at least one heading under it carries a rule. The prose sections (Genesis, Why this exists, The
+Stakes) carry no rules, so they are excluded automatically, and the next family someone adds is
+picked up with no code change at all.
+
+## Defect three: the guard against silent dropping could not detect a fourfold collapse
+
+There is a safety check meant to catch exactly the failure above — the parser quietly losing
+articles. It worked by comparing the parsed count against a floor of **15**, written when the real
+count was about 21.
+
+The constitution grew to 81. The floor never moved. So by now that check would have passed
+cheerfully while **65 of 81 articles vanished**. A guard whose threshold never grew with the thing
+it guards is not a guard.
+
+The floor stays as a coarse backstop for a total collapse, but the real check is now a
+**completeness comparison**: count the article headings actually present in the document, count
+how many parsed, and fail — naming each lost heading — if those two numbers disagree. That needs
+no maintenance as the document grows, because the document supplies its own denominator.
+
+## Defect four: a word that meant one thing and read as another
+
+`converged: true` has only ever meant "this deterministic pass is stable — re-running it on
+unchanged inputs gives the identical answer". It has never meant "the standards are healthy".
+
+Sitting bare next to a percentage, it read as the second thing. The meaning now travels with the
+field, so nobody has to know the history to read the response correctly.
+
+## And a fifth, smaller one
+
+A **missing** constitution used to hash identically to a **present but empty** one, so the two
+states shared a cache slot. Same shape as everything else here: absence and emptiness rendering
+as the same thing. They are now distinguishable.
+
+## What "nothing measured" now returns
+
+The rule from part one, applied here: **when there is nothing to divide by, there is no ratio.**
+
+The old code returned `0` in that case. That is not the flattering answer — it is the *alarming*
+one, which is arguably worse, because a frightening number is the one a reader is least likely to
+question. Either way it states a measurement that was never taken. The field is now `null`, and
+callers are told in the type not to coerce it back to a number.
+
+## What this does NOT fix
+
+The **stale copy** itself. The tool still reads the copy in the agent's own directory, and the
+updater that should keep that copy current classifies our drifted version as "customised — leave
+it alone", so it stays frozen. Fixing that is migration work with install-base reach, and it is
+tracked separately rather than bundled here.
+
+What changes today is that the stale copy can no longer be *silent*: the audit now reports a
+22-of-81 read as untrustworthy, with the counts visible, instead of as a confident 4.55%.
+
+## How you know it works rather than merely exists
+
+Three things were made to refuse something they previously waved through:
+
+1. Point the audit at a registry contributing no standards → it returns `null` and
+   `assessmentTrustworthy: false`, where it used to return `0`.
+2. Give the parser a family with one heading missing its rule → the canary **fails and names that
+   heading**, where the old floor passed it silently.
+3. Point the live endpoint at a truncated constitution → it comes back flagged untrustworthy with
+   the fragment's real denominator, where it used to answer with a bare, confident ratio.
+
+All three are covered at unit, integration, and end-to-end level.
+
+## The pattern this belongs to
+
+Sixth instance of one shape found on 2026-07-25: **the absence of information rendering
+identically to the presence of good information.** An empty map scoring 100% fresh. A commit
+banner that blocked nothing. A parse that dropped a family with no signal. A floor that could not
+detect a collapse. A ratio over a quarter of its subject.
+
+In every case the guard was present, wired, and mathematically incapable of reporting the failure
+it was written for. The fix is never "be more careful" — it is that a figure must carry what it
+was computed over, and must refuse to answer when it has nothing to answer with.

--- a/src/core/StandardsEnforcementAuditor.ts
+++ b/src/core/StandardsEnforcementAuditor.ts
@@ -25,7 +25,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
-import { loadStandardsRegistry, type StandardArticle } from './StandardsRegistryParser.js';
+import { parseStandardsRegistryDetailed, runRegistryCanary } from './StandardsRegistryParser.js';
 import { extractEnforcementRefs, flattenRefs, type EnforcementRef } from './StandardEnforcementExtractor.js';
 
 export type EnforcementKind = 'ratchet' | 'gate' | 'lint' | 'spec-only' | 'documented-only';
@@ -51,15 +51,57 @@ export interface StandardCoverage {
   classifiedAt: string;
 }
 
+/**
+ * What the audit's own inputs looked like, so a reader can tell an assessment
+ * over the WHOLE constitution apart from one over a fragment of it.
+ *
+ * Born from honest-denominators instance 4 (2026-07-25): this auditor reported
+ * `enforcedRatio: 0.0455` over 22 standards while the registry on disk carried
+ * 81. Reading the same registry in full gives 0.5375. The ratio was not wrong
+ * arithmetic — it was arithmetic over a denominator nobody could see, and the
+ * result was a figure 12× more alarming than reality, quoted onward as fact.
+ */
+export interface RegistryProvenance {
+  /** Absolute path of the registry file this pass actually read. */
+  path: string;
+  /** Bytes read — a 46KB copy where the source carries 248KB is a staleness tell. */
+  bytes: number;
+  /** Article headings found inside detected standards families — the parse denominator. */
+  articleHeadings: number;
+  /** Headings that parsed into an article. */
+  parsed: number;
+  /** Headings inside a family that carried no `**Rule.**` and were dropped. */
+  droppedHeadings: string[];
+  /** Families detected structurally. */
+  families: string[];
+  /** Registry-parse canary verdict — false means the numbers below are NOT trustworthy. */
+  canaryOk: boolean;
+  canaryFailures: string[];
+}
+
 export interface CoverageSummary {
   total: number;
   byKind: Record<EnforcementKind, number>;
-  /** (ratchet + gate + lint) / total — the fraction of standards with a verified structural guard. */
-  enforcedRatio: number;
+  /**
+   * (ratchet + gate + lint) / total — the fraction of standards with a verified
+   * structural guard. **`null` when `total` is 0**: with nothing to divide by
+   * there is no ratio, and reporting one (either the flattering 1 or the
+   * damning 0) states a measurement that was never taken. Callers must render
+   * null as "not assessed", never coerce it to a number.
+   */
+  enforcedRatio: number | null;
   /** Names of `documented-only` standards (the gaps). */
   gaps: string[];
   /** Total dangling refs across all standards. */
   danglingCount: number;
+  /**
+   * True only when the pass read a registry its own canary vouches for. False
+   * means every figure in this summary describes a fragment or a drifted parse
+   * — surface it beside the numbers rather than presenting them bare.
+   */
+  assessmentTrustworthy: boolean;
+  /** Provenance of the registry this pass read. */
+  registry: RegistryProvenance;
 }
 
 export interface CoverageReport {
@@ -292,9 +334,18 @@ function repoStructureSignal(projectDir: string): string {
 
 /** Compute the input hash that drives the recompute short-circuit. */
 export function computeInputHash(opts: AuditorOptions): string {
-  let registry = '';
-  try { registry = fs.readFileSync(opts.registryPath, 'utf-8'); } catch { registry = ''; }
-  const regHash = crypto.createHash('sha256').update(registry).digest('hex').slice(0, 16);
+  // An UNREADABLE registry must not hash identically to an empty-but-present one:
+  // that conflation is the honest-denominators shape at the cache layer, where a
+  // missing constitution would share a cache slot with a genuinely blank one.
+  // `computeCoverage` throws on an unreadable registry (the correct loud failure);
+  // this marker only keeps the short-circuit from confusing the two states.
+  let registryDigestInput: string;
+  try {
+    registryDigestInput = fs.readFileSync(opts.registryPath, 'utf-8');
+  } catch (err) {
+    registryDigestInput = ` unreadable:${opts.registryPath}:${err instanceof Error ? err.message : String(err)}`;
+  }
+  const regHash = crypto.createHash('sha256').update(registryDigestInput).digest('hex').slice(0, 16);
   return `${regHash}.${repoStructureSignal(opts.projectDir)}`;
 }
 
@@ -315,7 +366,21 @@ export function computeCoverage(
     return prior;
   }
 
-  const articles: StandardArticle[] = loadStandardsRegistry(opts.registryPath);
+  // Read ONCE and keep what the parse saw: the audit must be able to state the
+  // denominator it computed over (honest-denominators instance 4).
+  const registryMarkdown = fs.readFileSync(opts.registryPath, 'utf-8');
+  const { articles, diagnostics } = parseStandardsRegistryDetailed(registryMarkdown);
+  const canary = runRegistryCanary(articles, diagnostics);
+  const registry: RegistryProvenance = {
+    path: opts.registryPath,
+    bytes: Buffer.byteLength(registryMarkdown, 'utf-8'),
+    articleHeadings: diagnostics.articleHeadings,
+    parsed: diagnostics.parsed,
+    droppedHeadings: diagnostics.droppedHeadings,
+    families: diagnostics.families,
+    canaryOk: canary.ok,
+    canaryFailures: canary.failures,
+  };
   const routeTable = loadRouteTable(opts.projectDir);
 
   // Collect every wanted marker across all articles → ONE bounded src walk.
@@ -339,7 +404,10 @@ export function computeCoverage(
   for (const s of standards) byKind[s.enforcementKind] += 1;
   const total = standards.length;
   const enforced = byKind.ratchet + byKind.gate + byKind.lint;
-  const enforcedRatio = total === 0 ? 0 : Number((enforced / total).toFixed(4));
+  // No denominator → no ratio. Returning 0 here (the previous behaviour) reads on
+  // a dashboard as "0% of our standards are enforced" — a measurement, and an
+  // alarming one — when the truth is that nothing was measured at all.
+  const enforcedRatio = total === 0 ? null : Number((enforced / total).toFixed(4));
   const gaps = standards.filter((s) => s.enforcementKind === 'documented-only').map((s) => s.standard);
   const danglingCount = standards.reduce((n, s) => n + s.danglingRefs.length, 0);
 
@@ -347,7 +415,15 @@ export function computeCoverage(
     generatedAt: classifiedAt,
     inputHash,
     standards,
-    summary: { total, byKind, enforcedRatio, gaps, danglingCount },
+    summary: {
+      total,
+      byKind,
+      enforcedRatio,
+      gaps,
+      danglingCount,
+      assessmentTrustworthy: total > 0 && registry.canaryOk,
+      registry,
+    },
   };
 }
 

--- a/src/core/StandardsRegistryParser.ts
+++ b/src/core/StandardsRegistryParser.ts
@@ -37,14 +37,32 @@ export interface StandardArticle {
 }
 
 /**
- * The `##` families that contain standards ARTICLES. Other `##` sections (Why
- * this exists, Genesis, Two layers, How a standard joins, The Stakes) contain
- * `###` subheadings that are NOT articles and must be excluded.
+ * Standards families are detected STRUCTURALLY, not by name: a `##` section is a
+ * standards family iff it contains at least one `###` heading carrying a
+ * `**Rule.**` line. Other `##` sections (Why this exists, Genesis, Two layers,
+ * How a standard joins, The Stakes) carry `###` subheadings with no Rule line
+ * and are therefore excluded automatically.
+ *
+ * This replaced a hardcoded five-name allowlist (`The Root|The Substrate|
+ * Building|Shipping|Interaction`). That allowlist was a silent-drop generator:
+ * the registry grew a SIXTH family ("The Fractal — the framework that develops
+ * itself") and every article under it was discarded with no signal anywhere —
+ * found 2026-07-25 auditing this instrument (honest-denominators, instance 4).
+ * A name allowlist can only ever be as current as the last person who edited it;
+ * the structural rule needs no maintenance.
  */
-const STANDARDS_FAMILY_RE = /^##\s+(The Root|The Substrate|Building|Shipping|Interaction)\b/;
-/** Any `##` heading ends the current family's article-collection scope. */
+/** Any `##` heading opens a new section scope. */
 const ANY_H2_RE = /^##\s+/;
+const H2_NAME_RE = /^##\s+(.+?)\s*$/;
 const ARTICLE_RE = /^###\s+(.+?)\s*$/;
+/**
+ * Family display name: the heading text up to the first dash separator, so
+ * "The Substrate — the model-level truths …" stays "The Substrate" (the value
+ * the `?family=` filter and the coverage report have always carried).
+ */
+function familyName(heading: string): string {
+  return heading.split(/\s+[—–-]\s+/)[0].trim();
+}
 
 /** Extract the text after a `**Label.**` marker on a line (or '' if absent). */
 function fieldAfter(line: string, label: string): string | null {
@@ -53,41 +71,54 @@ function fieldAfter(line: string, label: string): string | null {
 }
 
 /**
- * Parse the registry markdown into standards articles. Pure function — no I/O —
- * so tests can feed fixture content and production feeds the real file.
+ * What the parse SAW, so a caller can tell "nothing was dropped" apart from
+ * "nothing could be seen" — the honest-denominator rule applied to the parse
+ * itself. `articleHeadings` is the denominator (`###` headings inside detected
+ * families); `parsed` is the numerator; `droppedHeadings` names the difference.
  */
-export function parseStandardsRegistry(markdown: string): StandardArticle[] {
-  const lines = markdown.split('\n');
-  const articles: StandardArticle[] = [];
+export interface RegistryParseDiagnostics {
+  /** Families detected structurally (a `##` section with ≥1 Rule-bearing `###`). */
+  families: string[];
+  /** `###` headings inside detected families — the denominator. */
+  articleHeadings: number;
+  /** Headings that parsed into an article (i.e. carried a `**Rule.**`). */
+  parsed: number;
+  /** Headings inside a detected family that carried NO Rule line — silently lost before. */
+  droppedHeadings: string[];
+  /** `##` sections skipped because no `###` under them carried a Rule (Genesis, Two layers, …). */
+  nonFamilySections: string[];
+}
 
-  let currentFamily: string | null = null;
+interface RawSection { heading: string; blocks: { name: string; article: StandardArticle }[] }
+
+/** Split the registry into `##` sections, each holding its `###` blocks. */
+function readSections(markdown: string): RawSection[] {
+  const sections: RawSection[] = [];
+  let section: RawSection | null = null;
   let cur: StandardArticle | null = null;
+  let curName = '';
 
   const flush = () => {
-    if (cur && cur.rule) articles.push(cur);
+    if (section && cur) section.blocks.push({ name: curName, article: cur });
     cur = null;
+    curName = '';
   };
 
-  for (const line of lines) {
-    const famMatch = line.match(STANDARDS_FAMILY_RE);
-    if (famMatch) {
+  for (const line of markdown.split('\n')) {
+    if (ANY_H2_RE.test(line)) {
       flush();
-      currentFamily = famMatch[1];
+      const h2 = line.match(H2_NAME_RE);
+      section = { heading: h2 ? h2[1].trim() : '', blocks: [] };
+      sections.push(section);
       continue;
     }
-    // A non-standards H2 closes the current family scope (so e.g. "## Two layers"
-    // stops us from collecting its ### subheadings as articles).
-    if (ANY_H2_RE.test(line) && !famMatch) {
-      flush();
-      currentFamily = null;
-      continue;
-    }
-    if (!currentFamily) continue;
+    if (!section) continue;
 
     const artMatch = line.match(ARTICLE_RE);
     if (artMatch) {
       flush();
-      cur = { family: currentFamily, name: artMatch[1].trim(), rule: '', inPractice: '' };
+      curName = artMatch[1].trim();
+      cur = { family: familyName(section.heading), name: curName, rule: '', inPractice: '' };
       continue;
     }
     if (!cur) continue;
@@ -102,7 +133,43 @@ export function parseStandardsRegistry(markdown: string): StandardArticle[] {
     if (appliedThrough !== null) { cur.appliedThrough = appliedThrough; continue; }
   }
   flush();
-  return articles;
+  return sections;
+}
+
+/**
+ * Parse the registry markdown into standards articles PLUS what the parse saw.
+ * Pure function — no I/O — so tests can feed fixture content and production
+ * feeds the real file.
+ */
+export function parseStandardsRegistryDetailed(
+  markdown: string,
+): { articles: StandardArticle[]; diagnostics: RegistryParseDiagnostics } {
+  const sections = readSections(markdown);
+  const articles: StandardArticle[] = [];
+  const diagnostics: RegistryParseDiagnostics = {
+    families: [], articleHeadings: 0, parsed: 0, droppedHeadings: [], nonFamilySections: [],
+  };
+
+  for (const section of sections) {
+    // Structural family test: at least one `###` block under this `##` carries a Rule.
+    const isFamily = section.blocks.some((b) => b.article.rule);
+    if (!isFamily) {
+      if (section.heading) diagnostics.nonFamilySections.push(section.heading);
+      continue;
+    }
+    diagnostics.families.push(familyName(section.heading));
+    for (const b of section.blocks) {
+      diagnostics.articleHeadings += 1;
+      if (b.article.rule) { articles.push(b.article); diagnostics.parsed += 1; }
+      else diagnostics.droppedHeadings.push(`${familyName(section.heading)} › ${b.name}`);
+    }
+  }
+  return { articles, diagnostics };
+}
+
+/** Parse the registry markdown into standards articles. */
+export function parseStandardsRegistry(markdown: string): StandardArticle[] {
+  return parseStandardsRegistryDetailed(markdown).articles;
 }
 
 /** Resolve + read + parse the on-disk registry. Throws if the file is missing. */
@@ -111,9 +178,27 @@ export function loadStandardsRegistry(registryPath: string): StandardArticle[] {
   return parseStandardsRegistry(content);
 }
 
+/** Read + parse the on-disk registry WITH parse diagnostics. Throws if missing. */
+export function loadStandardsRegistryDetailed(
+  registryPath: string,
+): { articles: StandardArticle[]; diagnostics: RegistryParseDiagnostics } {
+  return parseStandardsRegistryDetailed(fs.readFileSync(registryPath, 'utf-8'));
+}
+
 // ── Canary (state-detector drift guard) ───────────────────────────────────
 
-/** Minimum plausible article count — far below the real ~21, catches a parse collapse. */
+/**
+ * Coarse backstop only — catches a TOTAL parse collapse, nothing subtler.
+ *
+ * This constant used to be the canary's whole strength, with a comment reading
+ * "far below the real ~21". The registry grew to 81 articles and the constant
+ * never moved, so by 2026-07-25 it would have passed happily while 65 of 81
+ * articles vanished: a guard whose threshold never grew with the thing it
+ * guards. The real check is now `droppedHeadings` — a COMPLETENESS comparison
+ * against the count of article headings actually present, which needs no
+ * maintenance as the registry grows. Keep this floor as a backstop for callers
+ * that have no diagnostics to compare against; never treat it as sufficient.
+ */
 export const MIN_EXPECTED_ARTICLES = 15;
 
 /**
@@ -133,18 +218,47 @@ export interface RegistryCanaryResult {
   ok: boolean;
   articleCount: number;
   failures: string[];
+  /**
+   * The denominator the completeness check ran against — `###` headings found
+   * inside detected families. `null` when the caller supplied no diagnostics,
+   * which means completeness was NOT assessed (only the coarse floor ran).
+   */
+  articleHeadings: number | null;
+  /** False when no diagnostics were supplied — the canary could not check completeness. */
+  completenessAssessed: boolean;
 }
 
-/** Run the registry parse canary over a parsed article set. */
-export function runRegistryCanary(articles: StandardArticle[]): RegistryCanaryResult {
+/**
+ * Run the registry parse canary over a parsed article set.
+ *
+ * Pass `diagnostics` (from `parseStandardsRegistryDetailed`) to get the real
+ * check: every article heading present in a standards family must have parsed.
+ * Without it only the coarse floor + anchor checks run, and the result says so
+ * via `completenessAssessed: false` rather than implying a clean bill of health.
+ */
+export function runRegistryCanary(
+  articles: StandardArticle[],
+  diagnostics?: RegistryParseDiagnostics,
+): RegistryCanaryResult {
   const failures: string[] = [];
   if (articles.length < MIN_EXPECTED_ARTICLES) {
     failures.push(`only ${articles.length} articles parsed (expected ≥ ${MIN_EXPECTED_ARTICLES}) — registry format may have drifted`);
+  }
+  if (diagnostics && diagnostics.droppedHeadings.length > 0) {
+    failures.push(
+      `${diagnostics.droppedHeadings.length} of ${diagnostics.articleHeadings} article headings parsed with no **Rule.** line and were dropped: ${diagnostics.droppedHeadings.join('; ')}`,
+    );
   }
   for (const anchor of ANCHOR_ARTICLES) {
     const hit = articles.find(a => a.name.toLowerCase().includes(anchor.toLowerCase()));
     if (!hit) failures.push(`anchor article not found: "${anchor}"`);
     else if (!hit.rule) failures.push(`anchor article "${anchor}" parsed with an empty rule`);
   }
-  return { ok: failures.length === 0, articleCount: articles.length, failures };
+  return {
+    ok: failures.length === 0,
+    articleCount: articles.length,
+    failures,
+    articleHeadings: diagnostics ? diagnostics.articleHeadings : null,
+    completenessAssessed: Boolean(diagnostics),
+  };
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -7240,12 +7240,18 @@ export function createRoutes(ctx: RouteContext): Router {
     let report: StandardsCoverageReport;
     try { report = conformanceReport(); }
     catch (err) { res.status(500).json({ error: 'coverage compute failed', detail: err instanceof Error ? err.message : String(err) }); return; }
+    // `converged` means ONLY "the deterministic pass is stable" — re-running on
+    // unchanged inputs is byte-identical. It has never meant "the standards are
+    // healthy", but sitting bare beside `enforcedRatio` it read that way: on
+    // 2026-07-25 this response reported `converged: true` next to `0.0455` over a
+    // registry fragment, and the agent reading it drew the wrong conclusion twice
+    // in one day, then quoted it to the operator. The meaning now travels with the
+    // field, and the trustworthiness of the ratio travels beside it.
     res.json({
       enabled: true,
       generatedAt: report.generatedAt,
-      // The deterministic pass always converges — re-running on unchanged inputs is
-      // byte-identical, so `converged` is structurally true.
       converged: true,
+      convergedMeans: 'the deterministic pass is stable on unchanged inputs; NOT that standards are healthy',
       ...report.summary,
     });
   });

--- a/tests/e2e/standards-coverage-lifecycle.test.ts
+++ b/tests/e2e/standards-coverage-lifecycle.test.ts
@@ -20,6 +20,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { computeCoverage } from '../../src/core/StandardsEnforcementAuditor.js';
+import { parseStandardsRegistryDetailed } from '../../src/core/StandardsRegistryParser.js';
 import { createRoutes, type RouteContext } from '../../src/server/routes.js';
 import { authMiddleware } from '../../src/server/middleware.js';
 import { CartographerTree } from '../../src/core/CartographerTree.js';
@@ -118,5 +119,39 @@ describe('Standards Enforcement-Coverage Audit — feature is alive (Tier 3 E2E)
     expect(res.body.converged).toBe(true);
     expect(res.body.total).toBeGreaterThanOrEqual(15);
     expect(typeof res.body.enforcedRatio).toBe('number');
+  });
+
+  it('PART C: the live route assesses the WHOLE constitution and states its denominator', () => {
+    // honest-denominators instance 4 (2026-07-25): on the running server this route
+    // reported enforcedRatio 0.0455 over `total: 22` while the registry on disk
+    // carried 81 articles — a fragment posing as the whole, with nothing beside the
+    // number to reveal it. The fixture here mirrors the REAL registry, so the
+    // denominator the route reports must match the whole document.
+    const parsed = parseStandardsRegistryDetailed(fs.readFileSync(REAL_REGISTRY, 'utf-8'));
+    const report = computeCoverage({ registryPath: path.join(repo, 'docs/STANDARDS-REGISTRY.md'), projectDir: repo });
+
+    expect(report.summary.total).toBe(parsed.articles.length);
+    expect(report.summary.registry.articleHeadings).toBe(parsed.diagnostics.articleHeadings);
+    expect(report.summary.registry.droppedHeadings).toEqual([]);
+    // Every family in the document is assessed — including one no code names.
+    expect(report.summary.registry.families).toEqual(parsed.diagnostics.families);
+    expect(report.summary.registry.families).toContain('The Fractal');
+  });
+
+  it('PART C: a TRUNCATED registry cannot present itself as a trustworthy assessment', async () => {
+    // The live shape of the defect: the audit read a stale, much shorter copy. Any
+    // such fragment must come back flagged, with the denominator visible, rather
+    // than as a confident low ratio.
+    const full = fs.readFileSync(REAL_REGISTRY, 'utf-8');
+    fs.writeFileSync(path.join(repo, 'docs/STANDARDS-REGISTRY.md'), full.split('\n').slice(0, 300).join('\n'));
+
+    const res = await bearer(request(app()).get('/conformance/coverage/health')).set('X-Instar-Request', '1');
+    expect(res.status).toBe(200);
+    expect(res.body.assessmentTrustworthy).toBe(false);
+    expect(res.body.registry.canaryOk).toBe(false);
+    expect(res.body.registry.canaryFailures.length).toBeGreaterThan(0);
+    // The denominator is present so a reader can SEE it is a fragment.
+    expect(res.body.registry.parsed).toBe(res.body.total);
+    expect(res.body.convergedMeans).toMatch(/NOT that standards are healthy/i);
   });
 });

--- a/tests/integration/conformance-dev-gate-route.test.ts
+++ b/tests/integration/conformance-dev-gate-route.test.ts
@@ -113,3 +113,62 @@ describe('GET /conformance/coverage — dev-agent dark-gate (Tier 2 integration)
     expect(res.status).toBe(403);
   });
 });
+
+describe('GET /conformance/coverage/health — honest denominators (Tier 2 integration)', () => {
+  const health = (app: express.Express) =>
+    request(app).get('/conformance/coverage/health')
+      .set('Authorization', `Bearer ${AUTH}`)
+      .set('X-Instar-Request', '1');
+
+  const devApp = () => appWith({ developmentAgent: true, cartographer: { conformanceAudit: {} } });
+
+  it('reports enforcedRatio: null (not 0) over a registry that contributed no standards', async () => {
+    // The fixture registry has no articles. Before honest-denominators this route
+    // answered `enforcedRatio: 0` — read on a dashboard as "0% of our standards are
+    // enforced", a measurement that had never been taken. Nothing measured → null.
+    const res = await health(devApp());
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(0);
+    expect(res.body.enforcedRatio).toBeNull();
+    expect(res.body.assessmentTrustworthy).toBe(false);
+  });
+
+  it('carries the registry provenance the ratio was computed over', async () => {
+    const res = await health(devApp());
+    expect(res.status).toBe(200);
+    expect(res.body.registry).toBeDefined();
+    expect(res.body.registry.path).toBe(path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'));
+    expect(res.body.registry.articleHeadings).toBe(0);
+    expect(res.body.registry.parsed).toBe(0);
+    expect(res.body.registry.bytes).toBeGreaterThan(0);
+    expect(Array.isArray(res.body.registry.canaryFailures)).toBe(true);
+  });
+
+  it('never presents `converged` bare — the field carries what it actually means', async () => {
+    // `converged: true` sitting alone beside enforcedRatio was read as "standards are
+    // healthy" twice in one day (2026-07-25). It only ever meant "the pass is stable".
+    const res = await health(devApp());
+    expect(res.body.converged).toBe(true);
+    expect(res.body.convergedMeans).toMatch(/deterministic pass is stable/i);
+    expect(res.body.convergedMeans).toMatch(/NOT that standards are healthy/i);
+  });
+
+  it('a real (non-empty) registry yields a real ratio, marked trustworthy, over a visible denominator', async () => {
+    // Same route, populated registry → the ratio IS computed, and its denominator +
+    // trustworthiness travel with it so a fragment can never pose as the whole.
+    let md = '## Building — engineering discipline\n\n';
+    for (let i = 0; i < 20; i++) {
+      md += `### Standard ${i}\n**Rule.** r${i}.\n**Applied through.** src/index.ts\n\n`;
+    }
+    fs.writeFileSync(path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'), md);
+
+    const res = await health(devApp());
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(20);
+    expect(res.body.registry.articleHeadings).toBe(20);
+    expect(res.body.registry.parsed).toBe(20);
+    expect(res.body.registry.droppedHeadings).toEqual([]);
+    expect(res.body.registry.families).toEqual(['Building']);
+    expect(typeof res.body.enforcedRatio).toBe('number');
+  });
+});

--- a/tests/unit/CapabilityRegistry.test.ts
+++ b/tests/unit/CapabilityRegistry.test.ts
@@ -198,8 +198,25 @@ describe('CapabilityRegistry Increment 1 synthetic receiver fixtures', () => {
   });
 
   it('partial pool failures preserve good rows beside participating-peer failures', () => {
+    // The m1 row must be FRESH for this assertion to mean anything — the point is
+    // that a good row survives beside failing peers, not that a stale one does.
+    // The shared `entry()` fixture hardcodes observedAt 2026-07-25T00:00:00Z, and
+    // deriveStatus calls anything older than 24h `stale`, so this test passed on the
+    // day it was written and began failing at 2026-07-26T00:00Z purely because the
+    // wall clock moved. Stamp freshness explicitly rather than inheriting a literal
+    // whose meaning changes with the date.
+    const freshNow = new Date();
+    const fresh = peerProjection('m1', {
+      entries: [entry({
+        machineId: 'm1',
+        endpointRef: 'mesh://m1/doorways',
+        observedAt: freshNow.toISOString(),
+        receivedAt: freshNow.toISOString(),
+        evidence: { doorwayScanAt: freshNow.toISOString() },
+      })],
+    });
     const r = new CapabilityRegistryReceiver();
-    r.ingestProjection('m1', peerProjection('m1'));
+    r.ingestProjection('m1', fresh);
     r.ingestHeartbeat('m2', undefined);
     const rows = r.classifyPool(['m1', 'm2', 'm3']);
     expect(rows).toEqual(expect.arrayContaining([

--- a/tests/unit/standards-conformance-gate.test.ts
+++ b/tests/unit/standards-conformance-gate.test.ts
@@ -13,6 +13,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   parseStandardsRegistry,
+  parseStandardsRegistryDetailed,
   loadStandardsRegistry,
   runRegistryCanary,
   MIN_EXPECTED_ARTICLES,
@@ -48,10 +49,66 @@ describe('StandardsRegistryParser', () => {
   it('excludes non-standards ### subheadings (Genesis, How a standard joins, etc.)', () => {
     const articles = loadStandardsRegistry(REGISTRY_PATH);
     const families = new Set(articles.map(a => a.family));
-    // Only the five standards families — never "Genesis" / "Why this exists".
+    // Structural exclusion: a `##` section only counts as a family when at least
+    // one `###` under it carries a `**Rule.**`. The prose sections never do.
     for (const f of families) {
-      expect(['The Root', 'The Substrate', 'Building', 'Shipping', 'Interaction']).toContain(f);
+      expect(['Why this exists', 'Genesis', 'Two layers', 'How a new standard joins this registry', 'The Stakes'])
+        .not.toContain(f);
     }
+  });
+
+  it('does NOT silently drop a standards family the parser was never told about', () => {
+    // Regression guard for honest-denominators instance 4 (2026-07-25): family
+    // detection was a hardcoded five-name allowlist, so "The Fractal" — a real
+    // family in the registry — had every article under it discarded with no
+    // signal anywhere. Assert BOTH that it is present now and that detection is
+    // structural, so the next family added needs no code change to be seen.
+    const { articles, diagnostics } = parseStandardsRegistryDetailed(fs.readFileSync(REGISTRY_PATH, 'utf-8'));
+    expect(diagnostics.families).toContain('The Fractal');
+    expect(articles.some(a => a.family === 'The Fractal')).toBe(true);
+
+    const invented = `## An Entirely New Family — invented in this test\n\n### Some New Standard\n**Rule.** it holds.\n`;
+    const fresh = parseStandardsRegistryDetailed(invented);
+    expect(fresh.diagnostics.families).toEqual(['An Entirely New Family']);
+    expect(fresh.articles).toHaveLength(1);
+  });
+
+  it('canary reports the denominator it checked, and says so when it could not check', () => {
+    const md = fs.readFileSync(REGISTRY_PATH, 'utf-8');
+    const { articles, diagnostics } = parseStandardsRegistryDetailed(md);
+
+    const withDiag = runRegistryCanary(articles, diagnostics);
+    expect(withDiag.completenessAssessed).toBe(true);
+    expect(withDiag.articleHeadings).toBe(diagnostics.articleHeadings);
+    expect(withDiag.articleHeadings).toBeGreaterThan(MIN_EXPECTED_ARTICLES);
+    expect(withDiag.ok).toBe(true);
+
+    // Called WITHOUT diagnostics the canary cannot assess completeness, and must
+    // report that rather than implying a clean bill of health.
+    const withoutDiag = runRegistryCanary(articles);
+    expect(withoutDiag.completenessAssessed).toBe(false);
+    expect(withoutDiag.articleHeadings).toBeNull();
+  });
+
+  it('CANARY FAILS when an article heading inside a family parses with no rule (the silent drop)', () => {
+    // The old absolute floor could not see this: 20 healthy articles + one heading
+    // silently discarded still cleared "≥ 15 parsed". The completeness check names it.
+    let md = '## Building — engineering discipline\n\n';
+    for (let i = 0; i < 20; i++) md += `### Filler ${i}\n**Rule.** r${i}.\n\n`;
+    md += '### Dropped On The Floor\nprose but no rule line\n';
+    const { articles, diagnostics } = parseStandardsRegistryDetailed(md);
+
+    expect(articles).toHaveLength(20);
+    expect(diagnostics.articleHeadings).toBe(21);
+    expect(diagnostics.droppedHeadings).toEqual(['Building › Dropped On The Floor']);
+
+    // Floor-only: passes the count check (the blind spot).
+    expect(runRegistryCanary(articles).failures.join(' ')).not.toMatch(/Dropped On The Floor/);
+    // With diagnostics: fails and names the lost heading.
+    const canary = runRegistryCanary(articles, diagnostics);
+    expect(canary.ok).toBe(false);
+    expect(canary.failures.join(' ')).toMatch(/Dropped On The Floor/);
+    expect(canary.failures.join(' ')).toMatch(/of 21 article headings/);
   });
 
   it('CANARY FAILS on a drifted registry (too few articles)', () => {

--- a/tests/unit/standards-enforcement-auditor.test.ts
+++ b/tests/unit/standards-enforcement-auditor.test.ts
@@ -198,4 +198,53 @@ describe('StandardsEnforcementAuditor — real-registry canary', () => {
     expect(osq!.danglingRefs).toEqual([]); // every named guard resolves
     expect(osq!.guards.some((g) => g.ref === 'scripts/instar-dev-precommit.js' && g.verified)).toBe(true);
   });
+
+  it('refuses a ratio when there is nothing to divide by, and carries its denominator', () => {
+    // honest-denominators instance 4/6 (2026-07-25): `total === 0 ? 0 : ...` reported
+    // "0% of standards enforced" for a registry that contributed NO standards at all.
+    // Zero problems and zero data produced the same number, and the number was a
+    // measurement nobody had taken. Nothing-measured must read as null, not as 0.
+    write('docs/EMPTY-REGISTRY.md', '## Why this exists\n\nProse only. No articles.\n');
+    const emptyRegistry = path.join(repo, 'docs/EMPTY-REGISTRY.md');
+    const report = computeCoverage({ registryPath: emptyRegistry, projectDir: repo });
+
+    expect(report.summary.total).toBe(0);
+    expect(report.summary.enforcedRatio).toBeNull();
+    expect(report.summary.assessmentTrustworthy).toBe(false);
+    expect(report.summary.registry.articleHeadings).toBe(0);
+    expect(report.summary.registry.parsed).toBe(0);
+    expect(report.summary.registry.path).toBe(emptyRegistry);
+    expect(report.summary.registry.bytes).toBeGreaterThan(0);
+  });
+
+  it('states the denominator + trustworthiness on a REAL pass, so a fragment cannot pose as the whole', () => {
+    // The live defect this closes: the audit read a 22-article COPY of the registry
+    // while the source carried 81, and reported 0.0455 with nothing beside it saying
+    // what it had divided by. Both figures are now inseparable from the ratio.
+    const full = computeCoverage({ registryPath: REAL_REGISTRY, projectDir: process.cwd() });
+    expect(full.summary.assessmentTrustworthy).toBe(true);
+    expect(full.summary.registry.parsed).toBe(full.summary.total);
+    expect(full.summary.registry.articleHeadings).toBe(full.summary.total);
+    expect(full.summary.registry.droppedHeadings).toEqual([]);
+    expect(full.summary.registry.canaryOk).toBe(true);
+    expect(full.summary.registry.families.length).toBeGreaterThanOrEqual(6);
+
+    // A FRAGMENT of the same constitution: a ratio is still computed (it is real
+    // arithmetic over what was read) but the denominator makes the fragment visible.
+    const fragment = fs.readFileSync(REAL_REGISTRY, 'utf-8').split('\n').slice(0, 400).join('\n');
+    write('docs/FRAGMENT-REGISTRY.md', fragment);
+    const partial = computeCoverage({ registryPath: path.join(repo, 'docs/FRAGMENT-REGISTRY.md'), projectDir: process.cwd() });
+    expect(partial.summary.total).toBeLessThan(full.summary.total);
+    expect(partial.summary.registry.parsed).toBe(partial.summary.total);
+    // The canary's anchor + floor checks catch the truncation → not trustworthy.
+    expect(partial.summary.assessmentTrustworthy).toBe(false);
+    expect(partial.summary.registry.canaryFailures.length).toBeGreaterThan(0);
+  });
+
+  it('does not hash an unreadable registry identically to an empty one', () => {
+    write('docs/BLANK.md', '');
+    const blank = computeInputHash({ registryPath: path.join(repo, 'docs/BLANK.md'), projectDir: repo });
+    const missing = computeInputHash({ registryPath: path.join(repo, 'docs/DOES-NOT-EXIST.md'), projectDir: repo });
+    expect(missing).not.toBe(blank);
+  });
 });

--- a/upgrades/next/honest-denominators-standards.md
+++ b/upgrades/next/honest-denominators-standards.md
@@ -1,0 +1,71 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**The standards enforcement-coverage audit no longer reports a figure it cannot stand behind.**
+Five honesty defects in one instrument, found while auditing the tool that audits our constitution
+(2026-07-25). Live evidence on the dev machine: the audit reported `enforcedRatio: 0.0455` over
+`total: 22` while the source registry carries **81** article headings — re-run over the whole
+document the real figure is **0.5375**. The arithmetic was fine; the denominator was invisible, and
+the visible number was 12× more alarming than reality.
+
+- **`enforcedRatio` is now `number | null`.** With nothing to divide by it returns `null`, not `0`
+  ("0% enforced" is a measurement nobody took — and an *alarming* fabrication is worse than a
+  flattering one, because a frightening number is the least likely to be questioned).
+- **Family detection is structural, not a name allowlist.** A `##` section is a standards family
+  iff at least one `###` under it carries a `**Rule.**`. The old hardcoded five-name list silently
+  dropped every article under a sixth family (`## The Fractal`) — currently the Self-Hosting
+  standard. Prose sections are still excluded automatically, and the next family added needs no
+  code change to be seen.
+- **The parse canary compares against the document's own denominator.** `MIN_EXPECTED_ARTICLES = 15`
+  (written when the real count was ~21) never moved as the registry grew to 81, so it would have
+  passed while 65 of 81 articles vanished. It now fails — naming each lost heading — whenever a
+  heading inside a family parses with no rule. The floor is retained as a coarse backstop only.
+- **`converged` carries its meaning.** `GET /conformance/coverage/health` adds `convergedMeans`:
+  the field has only ever meant "the deterministic pass is stable", never "the standards are
+  healthy" — but sitting bare beside the ratio it read as the second thing.
+- **An unreadable registry no longer hashes identically to an empty one** in the recompute cache.
+
+`CoverageSummary` gains `assessmentTrustworthy` plus a `registry` provenance block (path, bytes,
+article headings found, parsed, dropped headings, families, canary verdict), so a fragment can be
+measured but can never pose as the whole.
+
+## What to Tell Your User
+
+Nothing to configure; this is an internal observability instrument (dev-agent-gated, read-only, and
+it gates nothing). If you had ever read a standards-enforcement percentage off this endpoint, read
+it again — the old figure may have been computed over a fraction of your constitution, and the
+response now tells you exactly what it counted.
+
+## Summary of New Capabilities
+
+- `parseStandardsRegistryDetailed` / `loadStandardsRegistryDetailed` return
+  `RegistryParseDiagnostics` (families, article headings, parsed, dropped headings, non-family
+  sections).
+- `runRegistryCanary(articles, diagnostics?)` reports `articleHeadings` + `completenessAssessed`,
+  and says so when it could NOT assess completeness rather than implying a clean bill of health.
+- `GET /conformance/coverage` + `/conformance/coverage/health` carry `assessmentTrustworthy`,
+  `registry`, and `convergedMeans`.
+
+## Known Gap (tracked, not deferred)
+
+This does **not** change which registry copy the server reads. The audit reads the agent-home
+snapshot, and `PostUpdateMigrator` classifies a drifted snapshot as "customized — left untouched",
+so it stays frozen. What changes today is that the stale read is no longer *silent*: it comes back
+`assessmentTrustworthy: false` with the counts attached instead of a confident low ratio. The
+migration is the next item on the same project tier. <!-- tracked: CMT-1035 -->
+
+## Evidence
+
+- `tests/unit/standards-conformance-gate.test.ts` — structural family detection (incl. an invented
+  family and `The Fractal`); the canary reports its denominator and admits when it could not check;
+  the silent-drop case the old floor passed and the completeness check now names.
+- `tests/unit/standards-enforcement-auditor.test.ts` — `enforcedRatio` null over an empty registry;
+  provenance + trustworthiness on a real pass vs a truncated fragment; unreadable ≠ empty in
+  `computeInputHash`.
+- `tests/integration/conformance-dev-gate-route.test.ts` — the HTTP response returns `null` not `0`,
+  carries provenance, never presents `converged` bare, and gives a real ratio over a visible
+  denominator when populated.
+- `tests/e2e/standards-coverage-lifecycle.test.ts` — the live route assesses the WHOLE constitution
+  (denominator equals the document's own heading count; families include `The Fractal`), and a
+  truncated registry cannot present itself as trustworthy.

--- a/upgrades/side-effects/honest-denominators-standards.md
+++ b/upgrades/side-effects/honest-denominators-standards.md
@@ -1,0 +1,147 @@
+# Side-Effects Review — honest denominators, part two: the standards-enforcement audit
+
+## Summary of the change
+
+Five honesty defects in ONE instrument — the standards enforcement-coverage audit — all found by
+the convergence-towards-coherence audit (2026-07-25) while measuring the instrument that measures
+our constitution. Live evidence: `GET /conformance/coverage/health` on this machine returned
+`{converged: true, total: 22, enforcedRatio: 0.0455}` while `docs/STANDARDS-REGISTRY.md` in the
+source repo carries **81** article headings. Re-run over the real registry: `total: 80`,
+`enforcedRatio: 0.5375`. The reported figure was 12× more alarming than reality and was quoted to
+the operator as fact.
+
+**A. `enforcedRatio` fabricated a ratio with no denominator.** `total === 0 ? 0 : …` returned `0`
+— "0% of standards enforced", a measurement nobody had taken. Now `number | null`, with the type
+telling callers not to coerce.
+
+**B. Family detection was a hardcoded five-name allowlist**
+(`The Root|The Substrate|Building|Shipping|Interaction`). The registry has SIX standards families;
+every article under `## The Fractal — the framework that develops itself` was silently dropped
+(currently the Self-Hosting standard). Replaced with structural detection: a `##` section is a
+family iff ≥1 `###` under it carries a `**Rule.**`. The prose sections (Why this exists, Genesis,
+Two layers, How a new standard joins, The Stakes) carry no rule lines and are excluded
+automatically — same exclusion the allowlist achieved, with no list to maintain.
+
+**C. The parse canary's floor could not detect a fourfold collapse.**
+`MIN_EXPECTED_ARTICLES = 15`, commented "far below the real ~21", never moved as the registry grew
+to 81 — so it would pass while 65 of 81 articles vanished. Added a completeness check:
+`droppedHeadings` (headings inside a detected family with no rule line) fails the canary and names
+each loss. The floor is retained, documented as a coarse backstop only.
+
+**D. `converged: true` sat bare beside the ratio.** It only ever meant "the deterministic pass is
+stable on unchanged inputs". Added `convergedMeans` so the meaning travels with the field.
+
+**E. An unreadable registry hashed identically to an empty one** in `computeInputHash`
+(`catch { registry = '' }`) — absence and emptiness sharing a cache slot, the same shape one layer
+down. Now distinguishable via an explicit marker.
+
+Supporting surface: `parseStandardsRegistryDetailed` / `loadStandardsRegistryDetailed` return
+`RegistryParseDiagnostics`; `runRegistryCanary(articles, diagnostics?)` reports `articleHeadings`
+and `completenessAssessed`; `CoverageSummary` gains `assessmentTrustworthy` + a `registry`
+provenance block.
+
+## Decision-point inventory
+
+- `computeCoverage` — an OBSERVE-ONLY reporter. Gates nothing, blocks nothing, has no authority
+  over any pipeline. The change alters what it *reports*, never what anything *does*.
+- `runRegistryCanary` — a state-detector whose verdict is returned as DATA. Both call sites
+  (`specReviewRoutes` HTTP handler and `runConformanceCheck` for the CLI) attach it to the
+  response; neither throws on it. A stricter canary therefore cannot newly block anything.
+- `parseStandardsRegistry` — pure function. Behaviour change: it now returns MORE articles
+  (the previously-dropped family).
+- `GET /conformance/coverage/health` — read-only, dev-agent-gated, `X-Instar-Request` gated.
+  Response gains fields; `enforcedRatio` changes type.
+
+No gate, hook, reaper, sentinel, or scheduler path is touched.
+
+## 1. Over-block
+
+The audit has no blocking authority, so it cannot over-block. The two adjacent risks:
+
+**The canary becoming stricter.** `runRegistryCanary` now fails when a heading inside a family
+carries no `**Rule.**`. Verified against the REAL registry: 80 headings, 80 parsed, zero dropped —
+so the live document passes. A future editor adding a non-article `###` inside a standards family
+WOULD trip it. That is intended (the failure names the heading and is trivially resolved by adding
+a rule or moving the subheading), and it is signal-only: the verdict rides in a response body,
+where no consumer treats it as a block. Checked all call sites for a throw-on-canary — none.
+
+**The conformance gate seeing more standards.** `StandardsConformanceReviewer` now receives the
+previously-dropped family, so a spec review may raise findings against Self-Hosting that it
+silently could not raise before. That is the defect being fixed, not a side effect to mitigate:
+the article was always in the constitution. The reviewer is signal-only per its own spec.
+
+## 2. Under-block
+
+**The stale-copy defect is NOT fixed here and is deliberately not bundled.** The running server
+reads `<projectDir>/docs/STANDARDS-REGISTRY.md` — the agent-home snapshot — and
+`PostUpdateMigrator.migrateFeatureMaturationGate` only overwrites that file when its hash is in a
+known `prior` set. Our copy has drifted out of that set, so it is classified "customized — left
+untouched" and stays frozen at 22 articles forever. Fixing it is install-base migration work with
+a real risk (overwriting a genuinely customised registry on someone's machine) and deserves its
+own review rather than riding along here.
+
+What this change buys in the meantime is that the stale read is no longer SILENT: the same
+22-article read now returns `assessmentTrustworthy: false` with `registry.parsed: 22` and the
+canary failures attached, instead of a bare confident `0.0455`.
+
+Tracked, not deferred-and-forgotten: <!-- tracked: CMT-1035 --> (tier-one closeout commitment,
+topic 29723) — the migration is the next item on the same tier and the completion condition of the
+registered autonomous run `run-ms13zzrz-78576404` requires the LIVE figure to be computed over ≥80
+standards, so this cannot be quietly dropped.
+
+## 3. Blast radius
+
+`enforcedRatio: number → number | null` is the one breaking-shaped change. Every consumer in the
+repo was checked:
+
+- `src/server/routes.ts` — spreads `report.summary` into the response; no arithmetic.
+- `tests/unit/standards-enforcement-auditor.test.ts`, `tests/e2e/standards-coverage-lifecycle.test.ts`
+  — assert on real (non-empty) registries where the value stays a number; both still pass.
+- `grep -rn "enforcedRatio"` across `src/`, `scripts/`, `tests/` — no other reader, no CI ratchet,
+  no dashboard tile consumes it.
+- `docs/`/CLAUDE.md prose mentions it descriptively only.
+
+`family` string values are unchanged for the five pre-existing families: the new
+`familyName()` truncates at the first dash separator, so `## The Substrate — the model-level
+truths …` still yields `The Substrate` (asserted in the updated unit test). `The Fractal` is
+additive.
+
+## 4. Rollback plan
+
+Single-commit revert; no state migration, no persisted artifact, no config key. The audit is
+recomputed from disk on every request behind an `inputHash` cache that lives in a route-local
+variable, so a revert takes effect on the next server start with nothing to clean up. No dark flag
+is needed: the change makes a read-only report more honest and cannot alter behaviour.
+
+## 5. Test coverage (all three tiers, per the Testing Integrity Standard)
+
+- **Unit** — `tests/unit/standards-conformance-gate.test.ts` (+4 cases): structural family
+  detection incl. an invented family and `The Fractal` present; canary reports its denominator and
+  says `completenessAssessed: false` when it cannot check; the silent-drop case that the old floor
+  passed and the completeness check now names.
+  `tests/unit/standards-enforcement-auditor.test.ts` (+3): `enforcedRatio` null over an empty
+  registry; provenance + trustworthiness on a real pass vs a truncated fragment; unreadable ≠
+  empty in `computeInputHash`.
+- **Integration** — `tests/integration/conformance-dev-gate-route.test.ts` (+4): the HTTP response
+  returns `null` not `0`, carries the registry provenance, never presents `converged` bare, and
+  yields a real ratio with a visible denominator on a populated registry.
+- **E2E** — `tests/e2e/standards-coverage-lifecycle.test.ts` (+2): the live route assesses the
+  WHOLE constitution (denominator equals the document's own heading count, families include
+  `The Fractal`), and a truncated registry cannot present itself as trustworthy.
+
+Every one of the three "has it refused something?" demonstrations in the ELI16 is an assertion in
+this set, not a manual check.
+
+## 6. Two mistakes made while building this, recorded rather than tidied away
+
+**The test that was protecting the bug.** `standards-conformance-gate.test.ts` asserted that every
+parsed family is one of exactly five names. It failed the moment `The Fractal` started parsing —
+the test existed to confirm the exclusion of prose sections, but it had frozen the bug in place as
+a specification. Rewritten to assert the prose sections are excluded (the real intent) plus a
+regression guard for the dropped family. This is the second time in one day a passing test was
+found protecting the defect it sat next to.
+
+**The alarming number was passed on unchecked.** Every other instrument found in this audit failed
+by *flattering* us; this one failed by *damning* us, and it was relayed to the operator without
+checking its denominator. A frightening figure is the one least likely to be questioned — which is
+why the denominator now travels with the number rather than being available on request.


### PR DESCRIPTION
## ELI16 — the tool that grades our own rules was grading a quarter of them, and reporting a number 12x more alarming than reality

We keep our standards in one document, and a tool grades whether each rule is actually enforced by a real test, gate or linter. The document has 81 rules. The tool was reading a copy with 22, so its headline figure (4.55% enforced) was arithmetic over a denominator nobody could see — the true figure is 54.3%. This change makes the number unable to appear without what it was computed over, stops the parser silently discarding an entire family of rules it was never told about, and replaces a stale hard-coded floor with a completeness check against the document's own count.

## What this is, in plain English

We keep our standards — the rules the agent holds itself to — in one document, and we have a tool that grades whether each rule is actually enforced by a real test, gate or linter. It reports one headline number.

On 2026-07-25 that number read **4.55% enforced**, next to the word **"converged: true"**. Both were misleading, and the agent reading them relayed the alarming figure to the operator as fact.

**The constitution has 81 articles. The tool was reading a copy with 22.** Read in full, the real figure is **54.3%** — 44 of 81 rules held by a test, gate or linter. The arithmetic was never wrong; it was arithmetic over a denominator nobody could see, and the visible result was twelve times more alarming than reality.

This change does not fix *which copy* gets read (that is separate, tracked work — see "Known gap"). It fixes something more important: **the number can no longer appear without what it was computed over.**

## The five defects

1. **A ratio with no denominator.** `total === 0 ? 0` reported "0% of standards enforced" for a registry that contributed none — a measurement nobody had taken. Now `number | null`, with the type telling callers not to coerce it back. An *alarming* fabrication is arguably worse than a flattering one, because a frightening number is the least likely to be questioned.

2. **A whole family of standards invisible by construction.** Family detection was a hardcoded list of five section names. The registry has **six**. Everything under the sixth — currently our Self-Hosting standard, which turns out to be **enforced by a gate** — was silently discarded. So the tool was not merely blind to a gap; it was blind to a rule we genuinely hold. Detection is now structural: a section is a family if at least one heading under it carries a rule. Prose sections still exclude themselves, and the next family added needs no code change.

3. **A guard that could not detect a fourfold collapse.** The canary meant to catch silent dropping compared against a floor of 15, written when the real count was ~21. The document grew to 81 and the floor never moved — it would have passed while 65 of 81 articles vanished. It now compares against the document's **own** heading count and fails naming each lost heading. The floor stays as a documented coarse backstop.

4. **A word that meant one thing and read as another.** `converged: true` has only ever meant "this deterministic pass is stable on unchanged inputs". Sitting bare beside a percentage it read as "the standards are healthy" — a conclusion drawn wrongly twice in one day. The meaning now travels with the field.

5. **Absence hashing identically to emptiness.** A missing registry shared a recompute-cache slot with a present-but-empty one. Same shape, one layer down.

`CoverageSummary` gains `assessmentTrustworthy` plus a `registry` provenance block (path, bytes, article headings found, parsed, dropped headings, families, canary verdict). A fragment can still be measured; it can no longer pose as the whole.

## Proof it works rather than merely exists

Three things now refuse what they previously waved through — each an assertion, not a manual check:

- an empty registry → `null` + `assessmentTrustworthy: false`, where it returned `0`
- a family heading with no rule → the canary **fails and names it**, where the old floor passed silently
- a truncated constitution on the live endpoint → flagged untrustworthy with its real denominator, where it answered with a bare confident ratio

Unit +7, integration +4, e2e +2. `tsc --noEmit` clean; full unit suite green (38,941 passing).

## Known gap — tracked, not deferred

This does **not** change which copy the server reads. `PostUpdateMigrator` classifies our drifted agent-home snapshot as "customized — left untouched", so it stays frozen at 22 articles. That is install-base migration work with real risk (it overwrites a file on every install) and gets its own reviewed spec rather than riding along here — the spec is written. What changes today is that the stale read is no longer **silent**. <!-- tracked: CMT-1035 -->

## Two mistakes made while building this, recorded rather than tidied away

**A test was protecting the bug.** `standards-conformance-gate.test.ts` asserted that every parsed family is one of exactly five names. It failed the moment the sixth family started parsing — the test existed to confirm prose sections are excluded, but it had frozen the bug in place as a specification. Rewritten to assert the real intent plus a regression guard. Second time in one day a passing test was found guarding the defect beside it.

**I relayed the alarming number without checking its denominator.** Every other instrument in this audit failed by flattering us; this one failed by damning us, and I passed it on. Same error, sign reversed.

## Second commit — an unrelated red test I found and own

`CapabilityRegistry.test.ts` had one failing case: a fixture hardcoded `observedAt: 2026-07-25T00:00:00Z`, and `deriveStatus` calls anything older than 24h `stale`. It passed on the day it was written and began failing at 2026-07-26T00:00Z from the wall clock alone. Freshness is now stamped explicitly. Zero-Failure Standard — I found it red, so it is mine.

---

Project: `convergence-towards-coherence`, Tier 1 item 1 (ACT-1243). Tier 1 lane: ELI16 `docs/specs/honest-denominators-standards.eli16.md` + side-effects `upgrades/side-effects/honest-denominators-standards.md`.

