### PR TITLE
fix: expose uninspectable load-bearing guards

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T01-42-34-879Z-guard-uninspectable-summary.json
+++ b/.instar/instar-dev-decisions/2026-07-26T01-42-34-879Z-guard-uninspectable-summary.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T01:42:34.879Z",
+  "slug": "guard-uninspectable-summary",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 18,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/guardPostureView.ts
+++ b/src/monitoring/guardPostureView.ts
@@ -94,8 +94,12 @@ export interface GuardsSummary {
   missing: number;
   offRuntimeDivergent: number;
   runtimeEnriched: string; // "n/total"
-  // ── G3: load-bearing key-lists (the loud gap subset + the two quiet subsets) ──
+  // ── G3: load-bearing key-lists (gap, inspectability, and rollout posture) ──
   loadBearingGapKeys: string[];
+  /** Load-bearing guards whose posture cannot currently prove protection.
+   *  These retain their existing anomaly class; this list is read-surface
+   *  completeness, not a second probe alarm. */
+  loadBearingUninspectableKeys: string[];
   loadBearingSoakingKeys: string[];
   loadBearingAcceptedKeys: string[];
 }
@@ -116,6 +120,12 @@ const ROW_FIELD_ALLOWLIST: ReadonlySet<string> = new Set([
 ]);
 const RUNTIME_FIELD_ALLOWLIST: ReadonlySet<string> = new Set([
   'enabled', 'dryRun', 'lastTickAt', 'tickAgeMs', 'stale', 'jobCount', 'pausedJobCount',
+]);
+const LOAD_BEARING_UNINSPECTABLE_STATES: ReadonlySet<GuardEffectiveState> = new Set([
+  'missing',
+  'errored',
+  'on-stale',
+  'off-runtime-divergent',
 ]);
 export { ROW_FIELD_ALLOWLIST, RUNTIME_FIELD_ALLOWLIST };
 
@@ -390,12 +400,16 @@ export function buildGuardInventory(opts: {
     off: 0, offDeviant: 0, offDarkDefault: 0,
     divergedPendingRestart: 0, errored: 0, missing: 0, offRuntimeDivergent: 0,
     runtimeEnriched: '',
-    loadBearingGapKeys: [], loadBearingSoakingKeys: [], loadBearingAcceptedKeys: [],
+    loadBearingGapKeys: [], loadBearingUninspectableKeys: [],
+    loadBearingSoakingKeys: [], loadBearingAcceptedKeys: [],
   };
   let enriched = 0;
   for (const g of guards) {
     if (g.runtime) enriched++;
     if (g.loadBearingGap) summary.loadBearingGapKeys.push(g.key);
+    if (g.loadBearing && LOAD_BEARING_UNINSPECTABLE_STATES.has(g.effective)) {
+      summary.loadBearingUninspectableKeys.push(g.key);
+    }
     if (g.loadBearingSoaking) summary.loadBearingSoakingKeys.push(g.key);
     if (g.loadBearingAccepted) summary.loadBearingAcceptedKeys.push(g.key);
     switch (g.effective) {

--- a/tests/e2e/guards-loadbearing-lifecycle.test.ts
+++ b/tests/e2e/guards-loadbearing-lifecycle.test.ts
@@ -50,7 +50,7 @@ describe('GET /guards + accept-fallback — G3 E2E (feature alive over real HTTP
     SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/e2e/guards-loadbearing-lifecycle.test.ts:cleanup' });
   });
 
-  async function boot(): Promise<TestServer> {
+  async function boot(registry = new GuardRegistry()): Promise<TestServer> {
     const ctx = {
       config: {
         projectName: 'g3-e2e', projectDir: dir, stateDir, port: 0,
@@ -59,7 +59,7 @@ describe('GET /guards + accept-fallback — G3 E2E (feature alive over real HTTP
       sessionManager: { listRunningSessions: () => [] },
       state: { getJobState: () => null, getSession: () => null },
       startTime: new Date(),
-      guardRegistry: new GuardRegistry(),
+      guardRegistry: registry,
       meshSelfId: 'm-e2e',
     } as unknown as RouteContext;
     const app = express();
@@ -86,6 +86,30 @@ describe('GET /guards + accept-fallback — G3 E2E (feature alive over real HTTP
     // The summary carries the key-lists too.
     const summary = r.body.summary as Record<string, unknown>;
     expect(summary.loadBearingGapKeys as string[]).toContain(LB_KEY);
+  });
+
+  it('errored load-bearing posture remains distinct from a gap over the real GET /guards lifecycle', async () => {
+    fs.writeFileSync(
+      path.join(stateDir, 'config.json'),
+      JSON.stringify({
+        multiMachine: { sessionPool: { inboundQueue: { enabled: true } } },
+        scheduler: { enabled: true },
+      }),
+    );
+    const registry = new GuardRegistry();
+    registry.register(LB_KEY, () => {
+      throw new Error('status getter failed');
+    });
+    server = await boot(registry);
+
+    const r = await getGuards();
+
+    expect(r.status).toBe(200);
+    const row = (r.body.guards as Array<Record<string, unknown>>).find((guard) => guard.key === LB_KEY)!;
+    expect(row.effective).toBe('errored');
+    const summary = r.body.summary as Record<string, unknown>;
+    expect(summary.loadBearingGapKeys as string[]).not.toContain(LB_KEY);
+    expect(summary.loadBearingUninspectableKeys as string[]).toContain(LB_KEY);
   });
 
   it('the accept-fallback route is MOUNTED (not 404/503) and clears the gap end-to-end', async () => {

--- a/tests/integration/guards-route.test.ts
+++ b/tests/integration/guards-route.test.ts
@@ -123,6 +123,30 @@ describe('GET /guards (integration)', () => {
     expect(n).toBeGreaterThanOrEqual(2);
   });
 
+  it('surfaces an errored load-bearing guard as uninspectable without calling it a load-bearing gap', async () => {
+    fs.writeFileSync(
+      path.join(stateDir, 'config.json'),
+      JSON.stringify({
+        multiMachine: { sessionPool: { inboundQueue: { enabled: true } } },
+        scheduler: { enabled: true },
+      }),
+    );
+    const registry = new GuardRegistry();
+    registry.register('multiMachine.sessionPool.inboundQueue.enabled', () => {
+      throw new Error('status getter failed');
+    });
+
+    const res = await request(appWith(ctxFor({ guardRegistry: registry as never })))
+      .get('/guards')
+      .set(auth());
+
+    expect(res.status).toBe(200);
+    const key = 'multiMachine.sessionPool.inboundQueue.enabled';
+    expect(res.body.guards.find((guard: { key: string }) => guard.key === key).effective).toBe('errored');
+    expect(res.body.summary.loadBearingGapKeys).not.toContain(key);
+    expect(res.body.summary.loadBearingUninspectableKeys).toContain(key);
+  });
+
   it('config-read failure → top-level 500 error, never an empty-truthful inventory', async () => {
     fs.writeFileSync(path.join(stateDir, 'config.json'), '{corrupt');
     const res = await request(appWith(ctxFor())).get('/guards').set(auth());

--- a/tests/unit/monitoring/guard-posture-loadbearing.test.ts
+++ b/tests/unit/monitoring/guard-posture-loadbearing.test.ts
@@ -271,6 +271,60 @@ describe('buildGuardInventory + buildHeartbeatPostureBlock — load-bearing key-
     expect(inv.summary.loadBearingAcceptedKeys).toEqual([]);
   });
 
+  it('summary.loadBearingUninspectableKeys lists every loud-but-not-gap posture class', () => {
+    const peerExecutionKey = 'multiMachine.peerExecution.enabled';
+    const strandedKey = 'monitoring.strandedTopicSentinel.enabled';
+    const testRunnerCapKey = 'intelligence.testRunnerCap';
+    const snapshot: ResolvedGuardConfigSnapshot = {
+      resolved: {
+        multiMachine: {
+          peerExecution: { enabled: true },
+          sessionPool: { inboundQueue: { enabled: true } },
+        },
+        monitoring: { strandedTopicSentinel: { enabled: true } },
+        scheduler: { enabled: true },
+      },
+      defaults: {
+        multiMachine: {
+          peerExecution: { enabled: false },
+          sessionPool: { inboundQueue: { enabled: false } },
+        },
+        monitoring: { strandedTopicSentinel: { enabled: false } },
+        scheduler: { enabled: true },
+      },
+      fileAbsent: false,
+    };
+    const registry = new GuardRegistry();
+    registry.register(LB_KEY, () => {
+      throw new Error('status getter failed');
+    });
+    registry.register(strandedKey, () => ({ enabled: true, lastTickAt: 0 }));
+    registry.register(testRunnerCapKey, () => ({ enabled: false }));
+    const inv = buildGuardInventory({
+      snapshot,
+      bootSnapshot: {
+        ts: new Date(DECLARED).toISOString(),
+        posture: {
+          [peerExecutionKey]: true,
+          [LB_KEY]: true,
+          [strandedKey]: true,
+          [testRunnerCapKey]: true,
+        },
+      },
+      registry,
+      now: DECLARED,
+    });
+
+    expect(inv.guards.find((guard) => guard.key === peerExecutionKey)?.effective).toBe('missing');
+    expect(inv.guards.find((guard) => guard.key === LB_KEY)?.effective).toBe('errored');
+    expect(inv.guards.find((guard) => guard.key === strandedKey)?.effective).toBe('on-stale');
+    expect(inv.guards.find((guard) => guard.key === testRunnerCapKey)?.effective).toBe('off-runtime-divergent');
+    for (const key of [peerExecutionKey, LB_KEY, strandedKey, testRunnerCapKey]) {
+      expect(inv.summary.loadBearingGapKeys).not.toContain(key);
+      expect(inv.summary.loadBearingUninspectableKeys).toContain(key);
+    }
+  });
+
   it('an accepted guard moves from Gap-keys to Accepted-keys', () => {
     const inv = invWith({ [LB_KEY]: { reason: 'owned', owner: 'justin', acceptedAt: '2026-07-01T00:00:00.000Z' } });
     expect(inv.summary.loadBearingGapKeys).not.toContain(LB_KEY);

--- a/tests/unit/monitoring/guard-posture-probe-loadbearing.test.ts
+++ b/tests/unit/monitoring/guard-posture-probe-loadbearing.test.ts
@@ -17,7 +17,13 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { createGuardPostureProbes, type PeerPostureRead } from '../../../src/monitoring/probes/GuardPostureProbe.js';
-import type { GuardInventoryResult, GuardRow } from '../../../src/monitoring/guardPostureView.js';
+import {
+  buildGuardInventory,
+  type GuardInventoryResult,
+  type GuardRow,
+} from '../../../src/monitoring/guardPostureView.js';
+import { GuardRegistry } from '../../../src/monitoring/GuardRegistry.js';
+import type { ResolvedGuardConfigSnapshot } from '../../../src/monitoring/guardPosture.js';
 import type { GuardPostureSummary } from '../../../src/core/types.js';
 import { TelegramAdapter } from '../../../src/messaging/TelegramAdapter.js';
 import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
@@ -50,7 +56,8 @@ function inventory(guards: GuardRow[]): GuardInventoryResult {
       off: 0, offDeviant: 0, offDarkDefault: 0,
       divergedPendingRestart: 0, errored: 0, missing: 0, offRuntimeDivergent: 0,
       runtimeEnriched: `0/${guards.length}`,
-      loadBearingGapKeys: [], loadBearingSoakingKeys: [], loadBearingAcceptedKeys: [],
+      loadBearingGapKeys: [], loadBearingUninspectableKeys: [],
+      loadBearingSoakingKeys: [], loadBearingAcceptedKeys: [],
     },
   };
 }
@@ -162,6 +169,49 @@ describe('GuardPostureProbe — G3 separate episode track (real createAttentionI
     expect(acute).toBeDefined();
     expect(acute.summary).toContain('LOAD-BEARING critical path: operator inbound message delivery');
     // No double-alarm on the lb track for a loud class.
+    expect(adapter.getAttentionItem('guard-posture-loadbearing:ep-1')).toBeUndefined();
+  });
+
+  it('errored load-bearing guard is uninspectable without becoming a second load-bearing-gap anomaly', async () => {
+    const registry = new GuardRegistry();
+    registry.register(LB_KEY, () => {
+      throw new Error('status getter failed');
+    });
+    const snapshot: ResolvedGuardConfigSnapshot = {
+      resolved: {
+        multiMachine: { sessionPool: { inboundQueue: { enabled: true } } },
+      },
+      defaults: {
+        multiMachine: { sessionPool: { inboundQueue: { enabled: false } } },
+      },
+      fileAbsent: false,
+    };
+    const fullInventory = buildGuardInventory({
+      snapshot,
+      bootSnapshot: {
+        ts: new Date().toISOString(),
+        posture: { [LB_KEY]: true },
+      },
+      registry,
+    });
+    const erroredRow = fullInventory.guards.find((guard) => guard.key === LB_KEY)!;
+
+    expect(erroredRow.effective).toBe('errored');
+    expect(fullInventory.summary.loadBearingGapKeys).not.toContain(LB_KEY);
+    expect(fullInventory.summary.loadBearingUninspectableKeys).toContain(LB_KEY);
+
+    const probeInventory: GuardInventoryResult = {
+      ...fullInventory,
+      guards: [erroredRow],
+    };
+    const probe = makeProbe(() => probeInventory);
+    await probe.run();
+    await probe.run();
+
+    const attention = adapter.getAttentionItems().filter((item) => item.category === 'guard-posture');
+    expect(attention).toHaveLength(1);
+    expect(attention[0].id).toBe('guard-posture:ep-1');
+    expect(attention[0].summary).toContain('errored');
     expect(adapter.getAttentionItem('guard-posture-loadbearing:ep-1')).toBeUndefined();
   });
 

--- a/upgrades/eli16/guard-uninspectable-summary.md
+++ b/upgrades/eli16/guard-uninspectable-summary.md
@@ -1,0 +1,35 @@
+# Guard inspectability summary — Plain-English Overview
+
+> The one-line version: the guard-health readout now says when a critical protection cannot be inspected, instead of letting an empty gap list look like proof that every critical path is protected.
+
+## The problem in one breath
+
+The guard inventory has a list of load-bearing guards that are silently unguarded. That list is intentionally narrow: a missing, errored, stale, or runtime-contradicting guard is already alarming under its own posture class, so adding it to the gap class would produce two alarms for one problem. But the read surface did not explain that distinction. A reader could see an empty gap list and honestly conclude that no critical path was unguarded even though a load-bearing guard could not be inspected at all.
+
+## What already exists
+
+- **Guard posture rows** — classify each guard as confirmed, stale, missing, errored, off, dry-run, or runtime-divergent.
+- **Load-bearing gap list** — names critical guards that are silently off by default or stuck in dry-run past their soak window.
+- **Guard posture probe** — alarms missing, errored, stale, and runtime-divergent guards under their existing classes, without duplicating a load-bearing-gap alarm.
+
+## What this adds
+
+The summary returned by the guards read endpoint gains a separate list of load-bearing guards whose posture is uninspectable. The list contains only the four existing loud classes: missing, errored, stale while on, and enabled in configuration while reporting off at runtime.
+
+This is additive observability. It does not change a guard row's classification, enable or disable any guard, alter the load-bearing gap definition, or create another probe anomaly.
+
+## The safeguards
+
+**Prevents a false all-clear.** A clean gap list can now be read beside the uninspectable list, so absence from one class is not mistaken for proof of complete inspection.
+
+**Prevents double-alarming.** The probe remains unchanged. A load-bearing guard with an errored getter still produces one existing errored anomaly and no load-bearing-gap episode.
+
+**Refuses regression at every live seam.** Unit coverage proves all four allowed postures and the no-double-alarm rule. Integration and end-to-end coverage call the real authenticated guards route and require the new list to survive the response.
+
+## What ships when
+
+One additive summary field ships with the existing guards endpoint. Older consumers can ignore it; consumers that need an honest critical-path reading can use it immediately.
+
+## What you actually need to decide
+
+Does the PR preserve the existing classification and alarm behavior while making incomplete load-bearing inspection explicit?

--- a/upgrades/next/guard-uninspectable-summary.md
+++ b/upgrades/next/guard-uninspectable-summary.md
@@ -1,0 +1,19 @@
+# Upgrade Guide — vNEXT
+<!-- bump: patch -->
+
+## What Changed
+
+Fixed the guard-posture summary's false all-clear shape. `GET /guards` now returns `summary.loadBearingUninspectableKeys`, listing load-bearing guards whose existing posture is `missing`, `errored`, `on-stale`, or `off-runtime-divergent`. These guards remain excluded from `loadBearingGapKeys`, and `GuardPostureProbe` keeps emitting only their existing anomaly class, so the read surface becomes complete without changing classification or double-alarming.
+
+## What to Tell Your User
+
+The guard-health readout now distinguishes critical protections that are silently off from critical protections whose condition cannot currently be inspected. A clean critical-gap list no longer looks like proof that every critical protection was checked.
+
+## Summary of New Capabilities
+
+- Guard health now names load-bearing protections whose condition is missing, errored, stale, or contradicted by runtime state.
+
+## Evidence
+
+- Refusal-first unit coverage constructs an errored load-bearing guard and requires exclusion from the gap list, inclusion in the uninspectable list, and exactly one existing errored probe anomaly.
+- Unit coverage pins all four uninspectable posture classes. Integration and end-to-end lifecycle coverage require the new summary field to survive the real authenticated `GET /guards` route.

--- a/upgrades/side-effects/guard-uninspectable-summary.md
+++ b/upgrades/side-effects/guard-uninspectable-summary.md
@@ -1,0 +1,137 @@
+# Side-Effects Review — Guard load-bearing inspectability summary
+
+**Version / slug:** `guard-uninspectable-summary`
+**Date:** `2026-07-25`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `guard_uninspectable_review`
+
+## Summary of the change
+
+`src/monitoring/guardPostureView.ts` adds one field to `GuardsSummary`: `loadBearingUninspectableKeys`. `buildGuardInventory` fills it when a load-bearing row retains one of four existing effective postures: `missing`, `errored`, `on-stale`, or `off-runtime-divergent`. The existing row classification, `loadBearingGap` flag, `loadBearingGapKeys`, heartbeat projection, and `GuardPostureProbe` anomaly logic are unchanged. Because `GET /guards` returns `inventory.summary` directly, the additive field reaches the authenticated local and pool read surfaces without a route-specific copy step.
+
+## Decision-point inventory
+
+No block/allow or actuation decision point is added or modified. The change adds a read-only projection over already-derived guard rows. Existing guard classification and probe alert decisions are passed through unchanged.
+
+- `buildGuardInventory` summary assembly — **modify** — adds an orthogonal completeness list from the closed effective-state vocabulary.
+- `GuardPostureProbe` — **pass-through** — consumes guard rows exactly as before; it does not consume the new summary field.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface — over-block not applicable. Every existing request and guard posture remains accepted and classified as before.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+The requested `GET /guards` surface is complete for the named load-bearing inspectability classes. The compact heartbeat posture is a second rendering of the earlier shape: it carries `loadBearingGapKeys` and aggregate loud-class counts, but not keyed load-bearing inspectability. It remains unchanged by instruction; this finding was reported directly to Echo and was neither fixed nor filed.
+
+The new list also deliberately excludes `diverged-pending-restart`, `on-unverified`, and non-load-bearing rows because the requested closed set is exactly `missing`, `errored`, `on-stale`, and `off-runtime-divergent`.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. `buildGuardInventory` already owns the canonical `GuardsSummary` derived from the complete row inventory. Computing the list there avoids re-deriving state in `routes.ts`, keeps local and pool responses aligned, and leaves the probe's separate anomaly authority untouched. The membership check is a projection over a closed enum, not a new detector or competing classifier.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP. Reshape the design.
+
+The new field is an additive observation on a read surface. It cannot enable, disable, classify, alert, suppress, or authorize anything. `GuardPostureProbe` remains the anomaly consumer and sees the same rows it saw before.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic is added at a competing-signals decision point. The four-member set is the request's closed structural definition of "load-bearing but uninspectable"; it does not resolve conflicting evidence or make a behavioral decision. The normative effective-state precedence table remains unchanged.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** none. The field is assembled after each row has already been classified.
+- **Double-fire:** structurally prevented by leaving `GuardPostureProbe` unchanged. The required errored-row test produces one acute `errored` item and no `guard-posture-loadbearing` item.
+- **Races:** none. `buildGuardInventory` is pure over the caller's one-read snapshot and synchronous registry reads.
+- **Feedback loops:** none. `GET /guards` does not feed the field back into classification or actuation.
+- **Compatibility:** additive JSON field. Consumers that do not know it ignore it; consumers that need completeness can read it.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+Yes: authenticated callers of `GET /guards` and `GET /guards?scope=pool` see `summary.loadBearingUninspectableKeys`. No row fields, response status codes, authentication rules, persistent files, notices, or external-service calls change. The route's timing remains one linear pass over the existing guard rows.
+
+No operator-facing action is added. This is a read-only diagnostic field; there is no new grant, approval, destructive operation, or phone-only workflow.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No dashboard renderer, approval page, or operator action surface is changed — not applicable. The API field is machine-readable supporting data, not primary dashboard content.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: proxied-on-read.** Each machine derives its own guard truth from machine-local configuration and runtime getters. `GET /guards?scope=pool` already fetches each known peer's plain `GET /guards` response, so the new summary list travels with that peer's full response and remains attributed to the machine that observed it.
+
+The change emits no user-facing notices, holds no durable state, and generates no URLs. Topic transfer cannot strand it because it is recomputed on every read.
+
+The compact heartbeat posture does not gain this keyed list; that separate rendering was reported to Echo without alteration.
+
+---
+
+## 8. Rollback cost
+
+Pure additive code change. Revert the summary interface member, state set, initializer, and push line, then ship a patch. There is no data migration, persistent state cleanup, agent reset, or user-facing repair. During rollback, callers return to the earlier incomplete summary shape.
+
+---
+
+## Conclusion
+
+The change is narrow and correctly layered: it makes the read model honest without perturbing the classifications and alarms that already own these failure states. Refusal-first coverage pins the absent-field defect, all four exact uninspectable classes, no double-alarm behavior, the real authenticated route, and the live HTTP lifecycle. The heartbeat rendering remains an explicitly reported, unchanged finding under Echo's filing authority.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `guard_uninspectable_review`
+**Independent read of the artifact:** Concur with the review — the only runtime change is an additive summary projection over load-bearing rows in exactly `{missing, errored, on-stale, off-runtime-divergent}`; the precedence/classification and `GuardPostureProbe` code are untouched, the errored case yields one existing acute item and no load-bearing-gap item, and all 54 focused unit/integration/E2E tests pass with no threshold or authority changes.
+
+---
+
+## Evidence pointers
+
+- Refusal evidence: before implementation, `tests/unit/monitoring/guard-posture-probe-loadbearing.test.ts` failed because `loadBearingUninspectableKeys` was absent.
+- Unit: 32/32 across `guard-posture-loadbearing` and `guard-posture-probe-loadbearing`; the broader focused unit run was 62/62.
+- Integration: 18/18 in `tests/integration/guards-route.test.ts`.
+- E2E: 24/24 across `guards-loadbearing-lifecycle` and `guards-endpoint-lifecycle`.
+- Static/build: `npm run lint` and `npm run build` passed.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller change — not applicable.


### PR DESCRIPTION
## ELI16

The guard-health readout already distinguishes silently unguarded critical guards from ordinary dark guards, but its clean gap list was incomplete evidence: a load-bearing guard with a missing, errored, stale, or runtime-contradicting posture was intentionally excluded to avoid double-alarming, yet nothing in the summary said that critical protection could not be inspected. This adds a separate completeness list without changing any classification or alert behavior.

The existing posture classes still say which loud alarm fired; the new list separately says which load-bearing protections remain unproven. That is why `off-runtime-divergent` intentionally appears both in its existing loud class and in this read-surface completeness list.

## What changed

- Add `summary.loadBearingUninspectableKeys` to `GET /guards`.
- Populate it only for load-bearing rows in `missing`, `errored`, `on-stale`, or `off-runtime-divergent`.
- Preserve `loadBearingGapKeys` and `GuardPostureProbe` behavior exactly.

## UX Impact

**Who sees it:** Operators and agents reading the authenticated guard-health endpoint.

**User-visible behavior:** The summary now separates silently unguarded critical protections from critical protections whose condition cannot be inspected.

**First contact:** A caller reading `loadBearingUninspectableKeys` no longer mistakes an empty gap list for complete critical-path health.

## Proof

- Refusal-first: the unit test failed on the absent field before implementation.
- Unit: 62/62 focused green; exact four-state and no-double-alarm pins.
- Integration: 18/18 green on real `GET /guards`.
- E2E: 24/24 green over the real authenticated HTTP lifecycle.
- `npm run lint`, `npm run build`, repository invariants, and documentation coverage pass.