### PR TITLE
fix(metrics): learning velocity counts finishing, not filing (ACT-1244)

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T02-31-48-402Z-learning-velocity-counts-finishing.json
+++ b/.instar/instar-dev-decisions/2026-07-26T02-31-48-402Z-learning-velocity-counts-finishing.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T02:31:48.402Z",
+  "slug": "learning-velocity-counts-finishing",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 65,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/learning-velocity-counts-finishing.eli16.md
+++ b/docs/specs/learning-velocity-counts-finishing.eli16.md
@@ -1,0 +1,76 @@
+# The metric that told us we were learning was measuring how fast we abandon things
+
+## What this actually is
+
+We have one number meant to answer a question no throughput metric can: **are we actually
+learning and adapting, or just producing output?**
+
+On the morning of 2026-07-25 it read **88 out of 100, trend accelerating** — at the exact moment
+the operator halted all work because the opposite was visibly true.
+
+So I looked at what it counts. Of 771 "learning events", **739 were items *filed*** — entries
+added to our action queue. Not lessons learned. Not work finished. Things written down.
+
+And filing is precisely what we do *instead* of finishing. Measured the same day on the real
+queue: 1,288 actions, of which 743 still pending, 523 cancelled — **494 of those carrying the
+sweep's own words, "Abandoned without active tracking since creation date"** — and 20 completed.
+
+Which means the metric had inverted. **The faster we abandoned work, the higher our adaptability
+score climbed.** Every night of heavy filing pushed it up. Nothing anywhere pointed the other way,
+because the instrument built to be that signal was counting the wrong events.
+
+## What changes
+
+A learning event is now a piece of work that **finished**.
+
+An action counts only when it reached `completed`, and it is stamped at the moment it *completed* —
+not at the moment it was *filed*. Pending, in-progress, cancelled and auto-abandoned items count
+for nothing.
+
+## The real before and after
+
+Same queue, same 30-day window, only the rule changed:
+
+| | events |
+|---|---|
+| old rule — every action, dated when filed | **784** |
+| new rule — completions, dated when completed | **18** |
+
+The old number overstated by a factor of **forty-three**, and 494 of those events were items with
+the word *abandoned* written on them by an automatic sweep.
+
+## The number now carries what it was computed over
+
+Two additions, because a low score has two very different meanings and they must be
+distinguishable:
+
+- **The rule travels with the answer** — one line stating that actions count on completion, never
+  on filing. A reader does not have to know the history.
+- **The exclusions are itemised** — how many were considered, how many counted, and how many were
+  set aside for each reason, with *auto-abandoned* named specifically since it is the largest
+  bucket and the one the old metric scored as learning.
+
+So "18 events" now reads as *"almost nothing has finished yet"* rather than being mistaken for
+*"we have stopped learning"*. Those call for opposite responses.
+
+## Two doors deliberately left shut
+
+- **A completion with no completion timestamp is excluded, not back-dated to when it was filed.**
+  That would have re-imported the whole filing bias through the one remaining gap.
+- **The window still excludes old completions.** "Counts completions" must not quietly become
+  "counts every completion ever" — both sides of that boundary are tested.
+
+## How you know it works rather than merely exists
+
+The route's own tests previously used fixtures with only a filing date, and asserted they counted
+as learning. Those tests encoded the inversion as a specification — the **third** time in one day
+a passing test was found protecting the defect beside it. They are rewritten, and the new cases
+include the real queue in miniature: five filed-or-abandoned items and one genuine completion, with
+the assertion that exactly **one** event is counted and the abandoned pair is named as such.
+
+## Why this one came first
+
+The operator's plan puts "make the instruments honest" ahead of everything else, and this is why:
+every report on whether the rest of the plan is working — including mine — would otherwise be
+graded by a number that rises when we abandon work. You cannot measure a project about finishing
+things with an instrument that rewards filing them.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -9922,13 +9922,62 @@ export function createRoutes(ctx: RouteContext): Router {
           }
         }
       } catch { /* skip unreadable source */ }
-      // (2) Evolution actions — a JSON array under .actions (each with top-level
-      // createdAt), NOT a logs/*.jsonl stream.
+      // (2) Evolution actions — COUNTED ON COMPLETION, NOT ON FILING.
+      //
+      // The metric's own inversion (ACT-1244, verified 2026-07-25). The old line
+      // counted EVERY action at its `createdAt`, so 739 of 771 "learning events" —
+      // 96% — were items merely FILED. Measured the same day on this agent's real
+      // queue: of 1,285 actions, 740 were still pending, 523 cancelled (494 of those
+      // carrying the resolution "Abandoned without active tracking since creation
+      // date"), 20 completed, 2 in progress.
+      //
+      // So the metric answering "are we learning?" was almost purely a measure of
+      // filing RATE — and filing is precisely what we do INSTEAD of finishing: the
+      // faster work was abandoned, the higher the adaptability score climbed. It read
+      // 88/100 "accelerating" on the morning the operator halted all work because the
+      // opposite was visibly true.
+      //
+      // A learning event is a piece of work that FINISHED. An action contributes one
+      // only when it reached `completed`, stamped at `completedAt` (when the learning
+      // actually happened) rather than `createdAt` (when the intention was recorded).
+      // Pending, in_progress, cancelled and auto-abandoned contribute nothing and are
+      // accounted for by exclusion reason, so a low score is legible as "little has
+      // finished" rather than mistaken for "we stopped learning".
+      const actionAccounting = {
+        considered: 0,
+        counted: 0,
+        excluded: {} as Record<string, number>,
+      };
+      const excludeAction = (reason: string): void => {
+        actionAccounting.excluded[reason] = (actionAccounting.excluded[reason] ?? 0) + 1;
+      };
       try {
         const p = path.join(ctx.config.stateDir, 'state', 'evolution', 'action-queue.json');
         if (fs.existsSync(p)) {
           const aq = JSON.parse(fs.readFileSync(p, 'utf-8'));
-          for (const a of (aq.actions ?? [])) push(tsField(a), 'evolution');
+          for (const a of (aq.actions ?? [])) {
+            actionAccounting.considered += 1;
+            const rec = (a ?? {}) as Record<string, unknown>;
+            const status = typeof rec.status === 'string' ? rec.status : 'unknown';
+            if (status !== 'completed') {
+              // Name the auto-abandoned class specifically: it is the single largest
+              // bucket and the one the old metric scored as learning.
+              const resolution = typeof rec.resolution === 'string' ? rec.resolution : '';
+              excludeAction(status === 'cancelled' && /abandoned without active tracking/i.test(resolution)
+                ? 'auto-abandoned'
+                : `not-completed:${status}`);
+              continue;
+            }
+            // A completion with no completion timestamp cannot be placed in the
+            // window; counting it at createdAt would re-import the filing bias.
+            const completedAt = rec.completedAt ?? rec.updatedAt;
+            if (completedAt === undefined || completedAt === null || completedAt === '') {
+              excludeAction('completed-without-timestamp');
+              continue;
+            }
+            push(completedAt, 'evolution');
+            actionAccounting.counted += 1;
+          }
         }
       } catch { /* skip unreadable source */ }
       // (3) Corrections — persisted in the SQLite CorrectionLedger, not a JSONL file.
@@ -9940,7 +9989,15 @@ export function createRoutes(ctx: RouteContext): Router {
           }
         } catch { /* skip ledger error */ }
       }
-      res.json(computeLearningVelocity(events, new Date().toISOString(), windowDays));
+      // The score never travels without what it was computed over (the
+      // honest-denominator rule applied to this metric): `counting` states the rule in
+      // one line, and `evolutionActions` shows how much was excluded and why — so a
+      // reader can tell "we are not learning" from "almost nothing has finished yet".
+      res.json({
+        ...computeLearningVelocity(events, new Date().toISOString(), windowDays),
+        counting: 'evolution actions count on completion (completedAt), never on filing (createdAt)',
+        evolutionActions: actionAccounting,
+      });
     } catch (err) {
       res.status(500).json({ error: err instanceof Error ? err.message : 'Failed to compute learning velocity' });
     }

--- a/tests/e2e/learning-velocity-lifecycle.test.ts
+++ b/tests/e2e/learning-velocity-lifecycle.test.ts
@@ -61,5 +61,15 @@ describe('GET /metrics/learning-velocity — (E2E over HTTP)', () => {
     expect(body.byType.learning).toBe(4);
     expect(typeof body.adaptabilityScore).toBe('number');
     expect(body.windowDays).toBe(30);
+    // ACT-1244: the counting rule and its accounting must survive the PRODUCTION
+    // initialization path, not just the route-level test — a score whose denominator
+    // is invisible is the failure this change removes, and the place a reader
+    // actually reads it is the live endpoint.
+    expect(body.counting).toMatch(/count on completion/i);
+    expect(body.counting).toMatch(/never on filing/i);
+    expect(body.evolutionActions).toBeDefined();
+    expect(typeof body.evolutionActions.considered).toBe('number');
+    expect(typeof body.evolutionActions.counted).toBe('number');
+    expect(body.evolutionActions.excluded).toBeDefined();
   });
 });

--- a/tests/integration/learning-velocity-routes.test.ts
+++ b/tests/integration/learning-velocity-routes.test.ts
@@ -80,21 +80,29 @@ describe('GET /metrics/learning-velocity (integration)', () => {
         { id: 'LRN-3', source: { discoveredAt: agoIso(8) } },
       ],
     }));
-    // (2) evolution actions — JSON array under .actions, top-level createdAt
+    // (2) evolution actions — counted ON COMPLETION (ACT-1244). These fixtures
+    // previously carried only `createdAt` and were counted as learning, which is the
+    // inversion being fixed: they now count only when `completed` with a
+    // `completedAt`. The third filed-but-unfinished action must NOT count.
     fs.writeFileSync(path.join(evoDir(stateDir), 'action-queue.json'), JSON.stringify({
       actions: [
-        { id: 'ACT-1', createdAt: agoIso(10) },
-        { id: 'ACT-2', createdAt: agoIso(2) },
+        { id: 'ACT-1', createdAt: agoIso(20), status: 'completed', completedAt: agoIso(10) },
+        { id: 'ACT-2', createdAt: agoIso(9), status: 'completed', completedAt: agoIso(2) },
+        { id: 'ACT-3', createdAt: agoIso(5), status: 'pending' },
       ],
     }));
     // (3) corrections — from the SQLite ledger (mocked), detectedAt
     const res = await request(appWith([{ detectedAt: agoIso(1) }])).get('/metrics/learning-velocity?windowDays=30');
 
     expect(res.status).toBe(200);
-    expect(res.body.totalEvents).toBe(6);
+    expect(res.body.totalEvents).toBe(6); // 3 learnings + 2 COMPLETED actions + 1 correction
     expect(res.body.byType.learning).toBe(3);
     expect(res.body.byType.evolution).toBe(2);
     expect(res.body.byType.correction).toBe(1);
+    // The filed-but-unfinished action is visible as an exclusion, not silently dropped.
+    expect(res.body.evolutionActions.considered).toBe(3);
+    expect(res.body.evolutionActions.counted).toBe(2);
+    expect(res.body.evolutionActions.excluded['not-completed:pending']).toBe(1);
     expect(res.body.typeDiversity).toBe(3);
     expect(res.body.adaptabilityScore).toBeGreaterThan(0);
     expect(['accelerating', 'steady', 'declining']).toContain(res.body.trend);
@@ -113,11 +121,80 @@ describe('GET /metrics/learning-velocity (integration)', () => {
 
   it('survives a missing correctionLedger (correctionLearning off)', async () => {
     fs.writeFileSync(path.join(evoDir(stateDir), 'action-queue.json'), JSON.stringify({
-      actions: [{ id: 'ACT-1', createdAt: agoIso(3) }],
+      actions: [{ id: 'ACT-1', createdAt: agoIso(9), status: 'completed', completedAt: agoIso(3) }],
     }));
     const res = await request(appWith()).get('/metrics/learning-velocity?windowDays=30');
     expect(res.status).toBe(200);
     expect(res.body.totalEvents).toBe(1);
     expect(res.body.byType.evolution).toBe(1);
+  });
+
+  it('REFUSES to score filing as learning: the real-shaped queue counts only completions', async () => {
+    // The live inversion (ACT-1244, measured on this agent 2026-07-25): 739 of 771
+    // "learning events" were items FILED, 494 of them explicitly auto-abandoned. So
+    // the faster work was abandoned, the higher the adaptability score climbed. This
+    // fixture is that queue in miniature.
+    fs.writeFileSync(path.join(evoDir(stateDir), 'action-queue.json'), JSON.stringify({
+      actions: [
+        // the abandonment sweep's own wording — the single largest real bucket
+        { id: 'ACT-A', createdAt: agoIso(25), status: 'cancelled',
+          resolution: 'Abandoned without active tracking since creation date (3+ weeks); commitment closed' },
+        { id: 'ACT-B', createdAt: agoIso(24), status: 'cancelled',
+          resolution: 'Abandoned without active tracking since creation date (3+ weeks)' },
+        // cancelled for a real, considered reason — still not learning
+        { id: 'ACT-C', createdAt: agoIso(20), status: 'cancelled', resolution: 'Superseded by later work' },
+        { id: 'ACT-D', createdAt: agoIso(15), status: 'pending' },
+        { id: 'ACT-E', createdAt: agoIso(12), status: 'in_progress' },
+        // the ONLY thing that finished
+        { id: 'ACT-F', createdAt: agoIso(20), status: 'completed', completedAt: agoIso(4) },
+      ],
+    }));
+    const res = await request(appWith()).get('/metrics/learning-velocity?windowDays=30');
+
+    expect(res.status).toBe(200);
+    // Under the OLD rule all six counted (every action at its createdAt). Now: one.
+    expect(res.body.byType.evolution).toBe(1);
+    expect(res.body.totalEvents).toBe(1);
+
+    const acct = res.body.evolutionActions;
+    expect(acct.considered).toBe(6);
+    expect(acct.counted).toBe(1);
+    // The abandoned class is named specifically — it is the bucket the old metric
+    // scored as learning, so it must be legible rather than lumped in with the rest.
+    expect(acct.excluded['auto-abandoned']).toBe(2);
+    expect(acct.excluded['not-completed:cancelled']).toBe(1);
+    expect(acct.excluded['not-completed:pending']).toBe(1);
+    expect(acct.excluded['not-completed:in_progress']).toBe(1);
+    // The rule travels with the number.
+    expect(res.body.counting).toMatch(/count on completion/i);
+    expect(res.body.counting).toMatch(/never on filing/i);
+  });
+
+  it('a completed action with NO completedAt is excluded, not back-dated to createdAt', async () => {
+    // Counting it at createdAt would re-import the filing bias through the one door
+    // left open — a completion whose timestamp is missing is unplaceable, not free.
+    fs.writeFileSync(path.join(evoDir(stateDir), 'action-queue.json'), JSON.stringify({
+      actions: [{ id: 'ACT-1', createdAt: agoIso(3), status: 'completed' }],
+    }));
+    const res = await request(appWith()).get('/metrics/learning-velocity?windowDays=30');
+    expect(res.status).toBe(200);
+    expect(res.body.totalEvents).toBe(0);
+    expect(res.body.evolutionActions.excluded['completed-without-timestamp']).toBe(1);
+  });
+
+  it('a completion OUTSIDE the window is excluded by date, not by status', async () => {
+    // Both sides of the window boundary, so "counts completions" cannot quietly
+    // become "counts all completions ever".
+    fs.writeFileSync(path.join(evoDir(stateDir), 'action-queue.json'), JSON.stringify({
+      actions: [
+        { id: 'OLD', createdAt: agoIso(120), status: 'completed', completedAt: agoIso(90) },
+        { id: 'NEW', createdAt: agoIso(40), status: 'completed', completedAt: agoIso(5) },
+      ],
+    }));
+    const res = await request(appWith()).get('/metrics/learning-velocity?windowDays=30');
+    expect(res.body.byType.evolution).toBe(1);
+    // Both were COUNTED as candidates; the window did the excluding, and the
+    // accounting reflects that honestly rather than hiding it.
+    expect(res.body.evolutionActions.counted).toBe(2);
   });
 });

--- a/upgrades/next/learning-velocity-counts-finishing.md
+++ b/upgrades/next/learning-velocity-counts-finishing.md
@@ -1,0 +1,50 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**`GET /metrics/learning-velocity` now counts work that FINISHED, not work that was filed.**
+
+The metric answering "are we actually learning and adapting?" counted every evolution action at its
+`createdAt`. Verified 2026-07-25: 739 of 771 "learning events" (96%) were items merely FILED, and on
+the real queue 494 of those carry the abandonment sweep's own resolution text. So the metric had
+inverted — **the faster work was abandoned, the higher the adaptability score climbed.** It read
+88/100 "accelerating" on the morning the operator halted all work because the opposite was visibly
+true.
+
+An action now contributes a learning event only when `status === 'completed'`, stamped at
+`completedAt` (falling back to `updatedAt`). Pending, in-progress, cancelled and auto-abandoned
+actions contribute nothing.
+
+Measured before/after on a real queue, 30-day window, rule change only: **784 events → 18** (of
+1,288 considered: 743 pending, 494 auto-abandoned, 29 cancelled, 2 in progress).
+
+Two doors deliberately shut: a `completed` action with no completion timestamp is EXCLUDED rather
+than back-dated to `createdAt` (which would re-import the filing bias), and the window still
+excludes old completions.
+
+`computeLearningVelocity` itself is untouched — only the route's event gathering changed.
+
+## What to Tell Your User
+
+Your adaptability score will drop, in most cases sharply, and the new number is the honest one. The
+old one was largely a count of how fast items were being filed. The response now states the counting
+rule and itemises what was excluded and why, so a low score reads as "little has finished recently"
+rather than "we have stopped learning" — those call for opposite responses.
+
+## Summary of New Capabilities
+
+- `counting` — the rule in one line, travelling with the number.
+- `evolutionActions` — `{ considered, counted, excluded }` by reason, with `auto-abandoned` named
+  specifically (the largest bucket, and the one the old metric scored as learning).
+
+## Evidence
+
+- `tests/integration/learning-velocity-routes.test.ts` — 7 tests. Three existing cases rewritten
+  (they asserted filed items count as learning — a specification of the inversion), three added:
+  the real queue in miniature (5 filed-or-abandoned + 1 completion → exactly 1 event); a completion
+  with no timestamp excluded rather than back-dated; a completion outside the window excluded by
+  date while still visible in `counted`.
+- `tests/e2e/learning-velocity-lifecycle.test.ts` — the counting rule and accounting survive the
+  production initialization path.
+- `tests/unit/LearningVelocityScorer.test.ts` — unchanged and passing: the pure scorer's contract
+  did not move.

--- a/upgrades/side-effects/learning-velocity-counts-finishing.md
+++ b/upgrades/side-effects/learning-velocity-counts-finishing.md
@@ -1,0 +1,102 @@
+# Side-Effects Review — learning velocity counts finishing, not filing (ACT-1244)
+
+## Summary of the change
+
+`GET /metrics/learning-velocity` counted EVERY evolution action at its `createdAt`, so the metric
+answering "are we learning?" was almost purely a measure of FILING RATE. Verified 2026-07-25: 739 of
+771 events (96%) were filed items; on the real queue 494 of those carry the sweep's resolution
+"Abandoned without active tracking since creation date". The metric read 88/100 "accelerating" on
+the morning the operator halted work because the opposite was visibly true — **the faster work was
+abandoned, the higher the score climbed.**
+
+An action now contributes a learning event ONLY when `status === 'completed'`, stamped at
+`completedAt` (falling back to `updatedAt`). Everything else is excluded and ACCOUNTED FOR by
+reason. The response gains `counting` (the rule, in one line) and `evolutionActions`
+(`considered` / `counted` / `excluded` by reason, with `auto-abandoned` named specifically).
+
+Measured before/after on this agent's live queue, 30-day window, rule change only:
+**784 events → 18.** Considered 1,288; excluded 743 `not-completed:pending`, 494 `auto-abandoned`,
+29 `not-completed:cancelled`, 2 `not-completed:in_progress`.
+
+## Decision-point inventory
+
+- `GET /metrics/learning-velocity` — a READ-ONLY observability route. It gates nothing, blocks
+  nothing, and no code path branches on its output. The change alters what it REPORTS, never what
+  anything DOES.
+- `computeLearningVelocity` (`src/core/LearningVelocityScorer.ts`) — **untouched.** It remains a
+  pure function over an event list; only the route's event GATHERING changed. Its 6 unit tests pass
+  unmodified, which is the evidence that the scorer's contract is unchanged.
+- No gate, hook, reaper, sentinel, scheduler, migration or config surface is touched.
+
+## 1. Over-block
+
+Not applicable — nothing here blocks. The adjacent risk is over-EXCLUSION: an action that genuinely
+represents learning but is not marked `completed` no longer counts. That is the intended semantics
+(the whole finding is that filing ≠ learning), and it is not silent: every exclusion is itemised by
+reason in the response, so a reader can see exactly what was set aside and disagree with the rule if
+they wish.
+
+Two exclusions were chosen deliberately and could be argued:
+
+- **`completed` with no `completedAt`/`updatedAt` → excluded, not back-dated to `createdAt`.**
+  Back-dating would re-import the entire filing bias through the one remaining gap. On the live
+  queue this bucket is EMPTY (all 20 completions carry `completedAt`), so the strict choice costs
+  nothing today and closes the door for later.
+- **`cancelled` for a considered reason → still excluded.** A deliberate cancellation may well
+  embody a lesson, but it is not a completion, and admitting it would reopen the "closing a row
+  counts as learning" path that produced the inversion.
+
+## 2. Under-block
+
+The score can now READ LOWER than reality if completions are recorded without status/timestamp
+hygiene. That is a reporting risk, not a safety one, and it is bounded by the accounting block: a
+low score with `counted: 1, excluded: {not-completed:pending: 743}` is legible as "almost nothing
+has finished", which is the true statement. The previous behaviour had the opposite failure — a high
+score that was structurally unfalsifiable — and an honest low number is strictly better than a
+flattering unfalsifiable one.
+
+`byType.learning` (registered learnings) and `byType.correction` (the correction ledger) are
+unchanged: both are genuine learning artifacts rather than filings, so neither was touched.
+
+## 3. Blast radius
+
+One route handler in `src/server/routes.ts`. Consumers checked:
+
+- `grep -rn "learning-velocity"` across `src/`, `scripts/`, `tests/` — the route is read by the
+  CLAUDE.md template docs and the dashboard's plain-language surface; no code branches on
+  `adaptabilityScore` or `byType.evolution`.
+- The response is ADDITIVE (`counting`, `evolutionActions`); no existing field was renamed or
+  removed, so a consumer reading `totalEvents`/`byType`/`adaptabilityScore` still parses.
+- `tests/unit/LearningVelocityScorer.test.ts` — 6 tests, unmodified, pass. The scorer is untouched.
+
+## 4. Rollback plan
+
+Single-commit revert. No state, no config key, no migration, no persisted artifact; the metric is
+recomputed from disk on every request. Reverting restores the old counting immediately.
+
+## 5. Test coverage (all three tiers)
+
+- **Unit** — `LearningVelocityScorer.test.ts` unchanged and passing (proves the pure scorer's
+  contract did not move).
+- **Integration** — `tests/integration/learning-velocity-routes.test.ts`, 7 tests. Three existing
+  cases UPDATED (see §6) and three added: the real queue in miniature (5 filed-or-abandoned + 1
+  completion → exactly 1 event, `auto-abandoned` counted as 2 and named); a `completed` action with
+  no timestamp excluded rather than back-dated; and a completion outside the window excluded by
+  DATE while still appearing in `counted`, so "counts completions" cannot become "counts every
+  completion ever".
+- **E2E** — `tests/e2e/learning-velocity-lifecycle.test.ts`: the `counting` rule and the
+  `evolutionActions` accounting must survive the PRODUCTION initialization path, because the live
+  endpoint is where a reader actually reads the number.
+
+## 6. Three existing tests were encoding the defect
+
+`learning-velocity-routes.test.ts` used action fixtures carrying only `createdAt` and asserted they
+counted as learning events. Those assertions were a specification of the inversion: they would have
+failed any correct implementation. Rewritten to use completions, with the filed-but-unfinished case
+retained and asserted as an EXCLUSION rather than deleted.
+
+This is the **third** time in one day a passing test was found protecting the defect beside it (the
+others: the standards parser's five-family allowlist, and a fixture whose meaning changed with the
+wall clock). Recorded rather than tidied away, because three instances in a day is a pattern about
+how our tests get written — they pin current behaviour, and current behaviour is what the audit
+found wanting. The class is worth a standard; it is not fixed here.


### PR DESCRIPTION
## ELI16 — the metric that told us we were learning was measuring how fast we abandon things

One number is meant to answer what no throughput metric can: are we actually learning, or just producing output? It read **88/100, accelerating** on the exact morning the operator halted all work because the opposite was visibly true. It counted every action in our queue **at the moment it was filed** — 739 of 771 "learning events" were items merely written down, and 494 of those carry the abandonment sweep's own words. So the metric had inverted: **the faster we abandoned work, the higher the adaptability score climbed.** An action now counts only when it actually `completed`, stamped when it completed.

## Measured before and after, on a real queue

Same 30-day window, only the rule changed:

| | events |
|---|---|
| old rule — every action, dated when filed | **784** |
| new rule — completions, dated when completed | **18** |

A 43× overstatement. Of 1,288 considered: 743 `not-completed:pending`, **494 `auto-abandoned`**, 29 `not-completed:cancelled`, 2 `not-completed:in_progress`.

## The number now carries what it was computed over

`18` has two possible readings — "we stopped learning" and "almost nothing has finished yet" — and they call for opposite responses. So the response gains:

- **`counting`** — the rule in one line, travelling with the answer.
- **`evolutionActions`** — `{ considered, counted, excluded }` by reason, with `auto-abandoned` named specifically since it is the largest bucket and the one the old metric scored as learning.

## Two doors deliberately shut

- **A `completed` action with no completion timestamp is excluded, not back-dated to `createdAt`.** Back-dating would re-import the entire filing bias through the one remaining gap. On the live queue this bucket is empty (all 20 completions carry `completedAt`), so the strict choice costs nothing today and closes the door for later.
- **The window still excludes old completions.** "Counts completions" must not quietly become "counts every completion ever". Both sides asserted.

## `computeLearningVelocity` is untouched

Only the route's event *gathering* changed. The pure scorer's 6 unit tests pass **unmodified** — that is the evidence for the claim, not a promise.

## Three existing tests were encoding the defect

`learning-velocity-routes.test.ts` used action fixtures carrying only `createdAt` and asserted they counted as learning events. That is the inversion written down as a specification: those assertions would fail any correct implementation. Rewritten, with the filed-but-unfinished case **retained and asserted as an exclusion** rather than deleted.

This is the **third time in one day** a passing test was found protecting the defect beside it — the others being the standards parser's five-family allowlist and a fixture whose meaning changed with the wall clock. Three in a day is a pattern about how our tests get written: they pin current behaviour, and current behaviour is exactly what this audit found wanting. So "the tests pass" is weaker evidence than it looks. The class is recorded rather than fixed here.

## Tests

- **Integration** (`learning-velocity-routes.test.ts`, 7 pass): three cases rewritten, three added — the real queue in miniature (5 filed-or-abandoned + 1 completion → exactly **1** event, `auto-abandoned` counted as 2 and named); a completion with no timestamp excluded rather than back-dated; a completion outside the window excluded by date while still visible in `counted`.
- **E2E** (`learning-velocity-lifecycle.test.ts`): the counting rule and the accounting survive the **production initialization path** — the live endpoint is where a reader actually reads the number.
- **Unit** (`LearningVelocityScorer.test.ts`): unchanged, passing.

## Why this one is early in the plan

The operator's plan puts "make the instruments honest" before everything else, and this is the reason: every report on whether the rest of the plan is working — including mine — would otherwise be graded by a number that rises when we abandon work. You cannot measure a project about finishing things with an instrument that rewards filing them.

---

Project: `convergence-towards-coherence`, Tier 1 item 2 (ACT-1244). Tier 1 lane: ELI16 `docs/specs/learning-velocity-counts-finishing.eli16.md` + side-effects `upgrades/side-effects/learning-velocity-counts-finishing.md`.
