### PR TITLE
fix(standards-audit): my own honesty field said "trustworthy" over the defect it exposed

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T02-51-13-410Z-assessment-confidence-unverified.json
+++ b/.instar/instar-dev-decisions/2026-07-26T02-51-13-410Z-assessment-confidence-unverified.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T02:51:13.410Z",
+  "slug": "assessment-confidence-unverified",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 115,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/assessment-confidence-unverified.eli16.md
+++ b/docs/specs/assessment-confidence-unverified.eli16.md
@@ -1,0 +1,83 @@
+# My own fix said "trustworthy" over exactly the defect it was built to expose
+
+## What happened
+
+This afternoon I shipped a change so our standards audit would stop reporting a confident number
+over a partial copy of our rules. I described it, in the pull request and to the operator, as making
+a stale read "no longer silent".
+
+Two hours later the server updated onto that release and I read the live endpoint for the first
+time. It said:
+
+**Twenty-two standards. Four and a half percent enforced. Marked trustworthy. Zero warnings.**
+
+The real document has eighty-one rules. So the number I had just shipped a fix for was still wrong,
+still confident, and now carried my own field actively vouching for it.
+
+## Why my checks all passed
+
+Because the stale copy is not broken. It is a **perfectly coherent document that happens to be a
+quarter of the real one.** Twenty-two headings, twenty-two of them parsed, nothing dropped, the
+anchor rules all present, comfortably above the minimum count.
+
+Every check I added looks *inside* the file: is it empty, does each heading carry a rule, do the
+known rules exist, is the count plausible. A stale-but-tidy document passes all of them by
+construction.
+
+And the review process had already told me this. Round two of the spec review said, in almost these
+words, that refusing only an empty registry would not catch the historical case because the real
+defect was twenty-two well-formed articles. I took that lesson into the **spec** and never applied
+it back to the **code I had already shipped**.
+
+## The thing that cannot be fixed by looking harder
+
+**Nothing inside a twenty-two-rule document says it should have eighty-one.** No amount of
+additional internal checking can discover that. Trustworthiness here requires an *outside*
+expectation — something shipped alongside the rules saying how many there should be and what they
+hash to. That mechanism is the separate piece of work currently waiting on an operator decision.
+
+So the deep fix genuinely waits. But that is not an excuse for the field to keep lying in the
+meantime.
+
+## What changes now
+
+My field said `trustworthy: true` when what it actually meant was **"my internal checks passed"**.
+Those are two different claims, and treating them as one is the precise failure this entire
+instrument was being fixed for. So the verdict now has three states instead of two:
+
+- **untrustworthy** — a check actively failed. Nothing parsed, or the parse objected.
+- **unverified** — the internal checks passed, but *there was nothing to check against*, so this
+  pass cannot tell whether it read the current rules or a tidy old copy of them.
+- **verified** — the internal checks passed **and** an outside expectation confirmed these are the
+  rules this build ships.
+
+Every verdict now carries a plain-English reason. And `unverified` is honest in a way that matters:
+it is neither reassuring nor alarming. It says *I do not know*, which is the truth.
+
+## Proved on the actual live case
+
+| input | before | now |
+|---|---|---|
+| the live 22-of-81 copy | **trustworthy** | `unverified`, with the reason |
+| the real 81-rule document | trustworthy | `unverified` — still correct, there is *still* nothing to check against |
+| a matching outside expectation | *(impossible)* | `verified` |
+| a mismatched expectation | *(impossible)* | `untrustworthy` |
+
+The second row is worth pausing on. Even reading the **complete, correct** document, the honest
+verdict is *unverified* — because the instrument cannot know it is complete. Reporting anything
+stronger would be the same overclaim in a nicer outfit.
+
+## The uncomfortable part
+
+This is the sixth time in one day that I reported a property of my own measurement as a property of
+the system — and the first time it was code I had shipped rather than something I inherited. Two
+hours from shipping to discovering it, and only because I stopped trusting my tests and read the
+live surface.
+
+The tests were green. All of them. They tested the cases I had thought of, which were the cases my
+fix handled. That is what a test suite does, and it is why a green suite is weaker evidence than it
+feels — a fourth test, in a fourth file, has now been found this evening encoding the behaviour it
+should have been challenging.
+
+The general lesson, which is becoming the theme: **a check that only looks inward cannot detect that
+it is looking at the wrong thing.**

--- a/src/core/StandardsEnforcementAuditor.ts
+++ b/src/core/StandardsEnforcementAuditor.ts
@@ -95,9 +95,45 @@ export interface CoverageSummary {
   /** Total dangling refs across all standards. */
   danglingCount: number;
   /**
-   * True only when the pass read a registry its own canary vouches for. False
-   * means every figure in this summary describes a fragment or a drifted parse
-   * — surface it beside the numbers rather than presenting them bare.
+   * How much this assessment has actually EARNED, in three states rather than a
+   * boolean that overclaims.
+   *
+   *   'untrustworthy' — a check actively failed (nothing parsed, or the canary
+   *                     objected). Every figure here describes a fragment or a
+   *                     drifted parse.
+   *   'unverified'    — the internal checks passed, but there was NO EXTERNAL
+   *                     EXPECTATION to check the registry against, so this pass
+   *                     cannot tell whether it read the CURRENT constitution or a
+   *                     coherent old copy of it. The figures are arithmetic over
+   *                     whatever was on disk.
+   *   'verified'      — internal checks passed AND an external expectation
+   *                     confirmed the registry is the one this build ships.
+   *
+   * WHY THE TRI-STATE EXISTS (found 2026-07-25, two hours after shipping the
+   * boolean): the live agent-home registry carries 22 articles where the source
+   * carries 81 — and it passes every internal check, because it is a perfectly
+   * self-consistent document that merely happens to be a quarter of the real one.
+   * 22 headings, 22 parsed, nothing dropped, anchors present, above the floor. So
+   * `assessmentTrustworthy: true` was asserting trust over exactly the defect the
+   * field was added to expose.
+   *
+   * The lesson, which the spec review had already given me and I applied only to
+   * the spec: nothing INSIDE a 22-rule document says it should have 81.
+   * Trustworthiness is not obtainable by looking harder at the file; it requires an
+   * outside expectation. Until one exists, the honest verdict is 'unverified' —
+   * NOT 'true', because "my internal checks passed" and "this assessment is
+   * trustworthy" are different claims, and conflating them is the failure this
+   * whole instrument was fixed to stop.
+   */
+  assessmentConfidence: 'verified' | 'unverified' | 'untrustworthy';
+  /** Plain-English reason for the confidence verdict — always populated. */
+  confidenceReason: string;
+  /**
+   * @deprecated Reads as a claim of trust the audit has not earned. Retained for
+   * one release so no consumer breaks; TRUE only when
+   * `assessmentConfidence === 'verified'`, which today means never — there is no
+   * expectation mechanism yet (it is the blocked
+   * `standards-registry-snapshot-refresh` spec). Prefer `assessmentConfidence`.
    */
   assessmentTrustworthy: boolean;
   /** Provenance of the registry this pass read. */
@@ -350,6 +386,66 @@ export function computeInputHash(opts: AuditorOptions): string {
 }
 
 /**
+ * Derive how much the assessment has EARNED. Extracted as a function on purpose:
+ * inline, TypeScript's flow analysis proved `'verified'` unreachable and rejected the
+ * comparison that derives the deprecated boolean — which is TRUE today and is exactly
+ * the point. Keeping the return type as the full union documents that `'verified'`
+ * becomes reachable the moment a same-build expectation ships beside the registry,
+ * without pretending it is reachable now.
+ *
+ * Order matters and mirrors how a reader asks it: did anything FAIL, and if not, did we
+ * have anything to CHECK AGAINST?
+ */
+export function deriveAssessmentConfidence(
+  total: number,
+  registry: RegistryProvenance,
+  /**
+   * A same-build expectation (article count + sha256) to check the registry against.
+   * Absent today — the mechanism is the `standards-registry-snapshot-refresh` spec.
+   * Passing one that MATCHES is the only route to `'verified'`.
+   */
+  expectation?: { articleCount: number; sha256: string; observedSha256: string },
+): { confidence: CoverageSummary['assessmentConfidence']; reason: string } {
+  if (total === 0) {
+    return {
+      confidence: 'untrustworthy',
+      reason: 'no standards parsed from the registry — nothing was measured',
+    };
+  }
+  if (!registry.canaryOk) {
+    return {
+      confidence: 'untrustworthy',
+      reason: `the registry-parse canary objected: ${registry.canaryFailures.join('; ')}`,
+    };
+  }
+  if (expectation) {
+    if (expectation.sha256 !== expectation.observedSha256) {
+      return {
+        confidence: 'untrustworthy',
+        reason:
+          `the registry does not match the expectation shipped beside it ` +
+          `(expected sha ${expectation.sha256.slice(0, 12)}, read ${expectation.observedSha256.slice(0, 12)})`,
+      };
+    }
+    return {
+      confidence: 'verified',
+      reason:
+        `${total} standards parsed from ${registry.path}, confirmed against the expectation ` +
+        `shipped in the same build (sha ${expectation.sha256.slice(0, 12)}, ` +
+        `${expectation.articleCount} articles)`,
+    };
+  }
+  return {
+    confidence: 'unverified',
+    reason:
+      `internal checks passed over ${total} standards parsed from ${registry.path} ` +
+      `(${registry.bytes} bytes), but NO external expectation exists to confirm this is the ` +
+      `CURRENT constitution rather than a coherent older copy — a stale registry passes every ` +
+      `internal check by construction`,
+  };
+}
+
+/**
  * Compute the full enforcement-coverage report. Deterministic: the per-standard order
  * follows the registry parse order; refs within a standard are sorted; the only
  * non-deterministic field is `generatedAt`/`classifiedAt` (a timestamp, excluded from
@@ -411,6 +507,9 @@ export function computeCoverage(
   const gaps = standards.filter((s) => s.enforcementKind === 'documented-only').map((s) => s.standard);
   const danglingCount = standards.reduce((n, s) => n + s.danglingRefs.length, 0);
 
+  const { confidence: assessmentConfidence, reason: confidenceReason } =
+    deriveAssessmentConfidence(total, registry);
+
   return {
     generatedAt: classifiedAt,
     inputHash,
@@ -421,7 +520,10 @@ export function computeCoverage(
       enforcedRatio,
       gaps,
       danglingCount,
-      assessmentTrustworthy: total > 0 && registry.canaryOk,
+      assessmentConfidence,
+      confidenceReason,
+      // Deprecated boolean: only a 'verified' verdict may present as trustworthy.
+      assessmentTrustworthy: assessmentConfidence === 'verified',
       registry,
     },
   };

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -7252,6 +7252,11 @@ export function createRoutes(ctx: RouteContext): Router {
       generatedAt: report.generatedAt,
       converged: true,
       convergedMeans: 'the deterministic pass is stable on unchanged inputs; NOT that standards are healthy',
+      // `assessmentConfidence` + `confidenceReason` arrive via the summary spread and are
+      // the fields to read. `assessmentTrustworthy` is retained (deprecated) for one
+      // release: it is TRUE only on a 'verified' verdict, which requires an external
+      // expectation that does not exist yet — so a stale-but-coherent registry now reads
+      // 'unverified' with the reason attached instead of asserting trust it never earned.
       ...report.summary,
     });
   });

--- a/tests/e2e/standards-coverage-lifecycle.test.ts
+++ b/tests/e2e/standards-coverage-lifecycle.test.ts
@@ -148,6 +148,8 @@ describe('Standards Enforcement-Coverage Audit — feature is alive (Tier 3 E2E)
     const res = await bearer(request(app()).get('/conformance/coverage/health')).set('X-Instar-Request', '1');
     expect(res.status).toBe(200);
     expect(res.body.assessmentTrustworthy).toBe(false);
+    expect(res.body.assessmentConfidence).toBe('untrustworthy');
+    expect(res.body.confidenceReason).toBeTruthy();
     expect(res.body.registry.canaryOk).toBe(false);
     expect(res.body.registry.canaryFailures.length).toBeGreaterThan(0);
     // The denominator is present so a reader can SEE it is a fragment.

--- a/tests/integration/conformance-dev-gate-route.test.ts
+++ b/tests/integration/conformance-dev-gate-route.test.ts
@@ -131,6 +131,7 @@ describe('GET /conformance/coverage/health — honest denominators (Tier 2 integ
     expect(res.body.total).toBe(0);
     expect(res.body.enforcedRatio).toBeNull();
     expect(res.body.assessmentTrustworthy).toBe(false);
+    expect(res.body.assessmentConfidence).toBe('untrustworthy');
   });
 
   it('carries the registry provenance the ratio was computed over', async () => {

--- a/tests/unit/standards-enforcement-auditor.test.ts
+++ b/tests/unit/standards-enforcement-auditor.test.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import os from 'node:os';
 import {
   computeCoverage,
+  deriveAssessmentConfidence,
   computeInputHash,
   stableView,
   type CoverageReport,
@@ -211,6 +212,8 @@ describe('StandardsEnforcementAuditor — real-registry canary', () => {
     expect(report.summary.total).toBe(0);
     expect(report.summary.enforcedRatio).toBeNull();
     expect(report.summary.assessmentTrustworthy).toBe(false);
+    expect(report.summary.assessmentConfidence).toBe('untrustworthy');
+    expect(report.summary.confidenceReason).toMatch(/nothing was measured/i);
     expect(report.summary.registry.articleHeadings).toBe(0);
     expect(report.summary.registry.parsed).toBe(0);
     expect(report.summary.registry.path).toBe(emptyRegistry);
@@ -222,7 +225,17 @@ describe('StandardsEnforcementAuditor — real-registry canary', () => {
     // while the source carried 81, and reported 0.0455 with nothing beside it saying
     // what it had divided by. Both figures are now inseparable from the ratio.
     const full = computeCoverage({ registryPath: REAL_REGISTRY, projectDir: process.cwd() });
-    expect(full.summary.assessmentTrustworthy).toBe(true);
+    // 2026-07-25, two hours after shipping the boolean: `true` here was the defect.
+    // The LIVE agent-home registry carries 22 of 81 articles and passes EVERY internal
+    // check — 22 headings, 22 parsed, nothing dropped, anchors present, above the floor —
+    // because it is a perfectly self-consistent document that is a quarter of the real
+    // one. So the boolean asserted trust over exactly what it was added to expose.
+    // Nothing INSIDE a 22-rule document says it should have 81: trustworthiness needs an
+    // outside expectation, and none exists yet. 'unverified' is the honest verdict even
+    // for the FULL registry, and the deprecated boolean is false until one ships.
+    expect(full.summary.assessmentConfidence).toBe('unverified');
+    expect(full.summary.assessmentTrustworthy).toBe(false);
+    expect(full.summary.confidenceReason).toMatch(/no external expectation/i);
     expect(full.summary.registry.parsed).toBe(full.summary.total);
     expect(full.summary.registry.articleHeadings).toBe(full.summary.total);
     expect(full.summary.registry.droppedHeadings).toEqual([]);
@@ -238,6 +251,7 @@ describe('StandardsEnforcementAuditor — real-registry canary', () => {
     expect(partial.summary.registry.parsed).toBe(partial.summary.total);
     // The canary's anchor + floor checks catch the truncation → not trustworthy.
     expect(partial.summary.assessmentTrustworthy).toBe(false);
+    expect(partial.summary.assessmentConfidence).toBe('untrustworthy');
     expect(partial.summary.registry.canaryFailures.length).toBeGreaterThan(0);
   });
 
@@ -246,5 +260,57 @@ describe('StandardsEnforcementAuditor — real-registry canary', () => {
     const blank = computeInputHash({ registryPath: path.join(repo, 'docs/BLANK.md'), projectDir: repo });
     const missing = computeInputHash({ registryPath: path.join(repo, 'docs/DOES-NOT-EXIST.md'), projectDir: repo });
     expect(missing).not.toBe(blank);
+  });
+
+  it('a COHERENT-BUT-STALE registry reads "unverified", never trustworthy (the live 22-of-81 case)', () => {
+    // The defect this tri-state exists for, found 2026-07-25 two hours after shipping the
+    // boolean. A stale registry is not malformed — it is a perfectly self-consistent
+    // document that happens to be a fraction of the real one, so it passes EVERY internal
+    // check: all headings parse, none dropped, anchors present, count above the floor.
+    // The old boolean therefore said `true` over exactly the defect it was added to expose.
+    const full = fs.readFileSync(REAL_REGISTRY, 'utf-8');
+    // Take a genuinely coherent SUBSET: whole families, every rule intact.
+    const cut = full.indexOf('## Building');
+    write('docs/STALE.md', full.slice(0, cut > 0 ? cut : 20000));
+    const report = computeCoverage({ registryPath: path.join(repo, 'docs/STALE.md'), projectDir: process.cwd() });
+
+    // Internally consistent: nothing dropped, so no internal check can object.
+    expect(report.summary.registry.droppedHeadings).toEqual([]);
+    expect(report.summary.registry.parsed).toBe(report.summary.registry.articleHeadings);
+    // And yet it is a fragment — so the verdict must NOT claim trust.
+    expect(report.summary.assessmentTrustworthy).toBe(false);
+    expect(report.summary.assessmentConfidence).not.toBe('verified');
+    expect(report.summary.confidenceReason).toBeTruthy();
+  });
+
+  it('deriveAssessmentConfidence: all four verdicts, in both directions', () => {
+    const okRegistry = computeCoverage({ registryPath: REAL_REGISTRY, projectDir: process.cwd() }).summary.registry;
+
+    // nothing measured
+    expect(deriveAssessmentConfidence(0, okRegistry).confidence).toBe('untrustworthy');
+
+    // an objecting canary
+    const badCanary = { ...okRegistry, canaryOk: false, canaryFailures: ['a heading lost its rule'] };
+    const bad = deriveAssessmentConfidence(81, badCanary);
+    expect(bad.confidence).toBe('untrustworthy');
+    expect(bad.reason).toMatch(/canary objected/i);
+
+    // internal checks pass, NO expectation → unverified (today's only non-failing state)
+    const un = deriveAssessmentConfidence(81, okRegistry);
+    expect(un.confidence).toBe('unverified');
+    expect(un.reason).toMatch(/no external expectation/i);
+    expect(un.reason).toMatch(/coherent older copy/i);
+
+    // a MATCHING expectation is the only route to verified
+    expect(deriveAssessmentConfidence(81, okRegistry, {
+      articleCount: 81, sha256: 'aaaaaaaaaaaa0000', observedSha256: 'aaaaaaaaaaaa0000',
+    }).confidence).toBe('verified');
+
+    // a MISMATCHED expectation is untrustworthy, not merely unverified
+    const mism = deriveAssessmentConfidence(22, okRegistry, {
+      articleCount: 81, sha256: 'aaaaaaaaaaaa0000', observedSha256: 'bbbbbbbbbbbb1111',
+    });
+    expect(mism.confidence).toBe('untrustworthy');
+    expect(mism.reason).toMatch(/does not match the expectation/i);
   });
 });

--- a/upgrades/next/assessment-confidence-unverified.md
+++ b/upgrades/next/assessment-confidence-unverified.md
@@ -1,0 +1,51 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**The standards audit's own honesty field was overclaiming, and reported `trustworthy: true` over the
+exact defect it was added to expose.**
+
+Verified on the LIVE endpoint two hours after v1.3.975 deployed: `total: 22`,
+`enforcedRatio: 0.0455`, **`assessmentTrustworthy: true`**, zero canary failures — while the source
+registry carries **81** articles. The stale agent-home copy is not malformed; it is a self-consistent
+document that is a quarter of the real one, so it passes every INTERNAL check by construction.
+
+`assessmentTrustworthy` was `total > 0 && canaryOk` — i.e. "my internal checks passed" — but it READ
+as "this assessment is trustworthy". Those are different claims.
+
+- **`assessmentConfidence`** (new): `'verified' | 'unverified' | 'untrustworthy'`.
+  - `untrustworthy` — a check actively failed (nothing parsed, or the canary objected).
+  - `unverified` — internal checks passed but NO external expectation existed to confirm this is the
+    CURRENT constitution rather than a coherent older copy.
+  - `verified` — internal checks passed AND a same-build expectation matched.
+- **`confidenceReason`** (new): always populated, plain English.
+- **`assessmentTrustworthy`** — deprecated, retained one release, TRUE only on `verified`.
+
+`'verified'` is **unreachable today**: the expectation mechanism is a separate, not-yet-approved
+change. So every passing read now reports `unverified` — including a complete, correct registry,
+because the instrument genuinely cannot verify completeness. Anything stronger would be the same
+overclaim in nicer clothes.
+
+## What to Tell Your User
+
+If you read a standards-enforcement figure, it now comes with a confidence verdict and a plain
+reason beside it. Most installs will see the verdict "unverified" — that is honest rather than a
+fault. It means the numbers are arithmetic over whatever copy of the rules was on disk, and nothing
+yet confirms that copy is the current one. A verdict of "untrustworthy" means a check actually
+failed and the figures describe only a fragment of your rules.
+
+## Known Gap (stated, not resolved)
+
+A coherent stale registry is still reported with real-looking figures; it is now LABELLED
+`unverified` with a reason naming that possibility, but the instrument cannot say which case it is
+in. Closing that needs an external expectation shipped beside the registry — the blocked
+`standards-registry-snapshot-refresh` spec. This change makes the uncertainty visible; it does not
+resolve it.
+
+## Evidence
+
+- `tests/unit/standards-enforcement-auditor.test.ts` — a coherent-but-stale registry passes every
+  internal check (zero dropped headings, `parsed === articleHeadings`) and still must not read
+  `verified`; plus all four `deriveAssessmentConfidence` verdicts in both directions.
+- `tests/integration/conformance-dev-gate-route.test.ts` — the HTTP body carries the verdict.
+- `tests/e2e/standards-coverage-lifecycle.test.ts` — the verdict + reason survive production init.

--- a/upgrades/side-effects/assessment-confidence-unverified.md
+++ b/upgrades/side-effects/assessment-confidence-unverified.md
@@ -1,0 +1,125 @@
+# Side-Effects Review — assessmentConfidence: my own honesty field was overclaiming
+
+## Summary of the change
+
+`CoverageSummary.assessmentTrustworthy` (shipped hours earlier in PR #1641) reported **`true` over
+the exact defect it was added to expose.** Verified on the LIVE endpoint after v1.3.975 deployed:
+
+```
+total: 22 | enforcedRatio: 0.0455 | assessmentTrustworthy: TRUE | canaryOk: true | canaryFailures: 0
+registry.parsed: 22 | articleHeadings: 22 | bytes: 46606 | families: [5 of the 6]
+```
+
+The source registry carries **81** articles. The stale agent-home copy is not malformed — it is a
+self-consistent document that is a quarter of the real one, so it passes every INTERNAL check by
+construction (all headings parse, none dropped, anchors present, count above the floor).
+
+`assessmentTrustworthy` was computed as `total > 0 && registry.canaryOk` — i.e. "my internal checks
+passed". It READ as "this assessment is trustworthy". Conflating those is the failure the whole
+instrument was being fixed for.
+
+Replaced by a tri-state `assessmentConfidence` (`'verified' | 'unverified' | 'untrustworthy'`) plus
+an always-populated `confidenceReason`. The boolean is retained, deprecated, TRUE only on
+`'verified'`.
+
+**Root insight:** nothing INSIDE a 22-rule document says it should have 81. Trustworthiness is not
+obtainable by looking harder at the file — it needs an EXTERNAL expectation. That mechanism is the
+blocked `standards-registry-snapshot-refresh` spec, so `'verified'` is unreachable today, and the
+honest verdict for every passing read is `'unverified'`.
+
+Proven against the real live registry (all four states):
+
+| input | before | after |
+|---|---|---|
+| the live 22-of-81 copy | `trustworthy: true` | `unverified` + reason |
+| the real 81-article registry | `true` | `unverified` — still correct; nothing to check against |
+| a MATCHING expectation | unreachable | `verified` |
+| a MISMATCHED expectation | unreachable | `untrustworthy` |
+
+## Decision-point inventory
+
+- `computeCoverage` / `GET /conformance/coverage{,/health}` — OBSERVE-ONLY. Gates nothing, blocks
+  nothing, no code path branches on the verdict. This changes what is REPORTED, never what anything
+  DOES.
+- `deriveAssessmentConfidence` — new, exported, pure. Extracted deliberately: inline, TypeScript's
+  flow analysis proved `'verified'` unreachable and REJECTED the comparison deriving the deprecated
+  boolean. That rejection is TRUE and is the point; a function keeps the union open for when an
+  expectation ships without pretending it is reachable now. (TS caught this, which is worth noting —
+  the compiler objected to a claim I could not yet honour.)
+- No gate, hook, sentinel, reaper, scheduler, migration or config surface touched.
+
+## 1. Over-block
+
+Nothing blocks. The adjacent risk is over-alarming: `assessmentTrustworthy` is now `false`
+EVERYWHERE, including for a complete and correct registry. That is intentional and argued in the
+ELI16: the instrument genuinely cannot verify completeness today, so anything stronger is the same
+overclaim in nicer clothes.
+
+The tri-state exists precisely so this is not alarming: `'unverified'` says *I do not know*, which is
+neither reassuring nor a red flag. A consumer reading only the deprecated boolean sees `false` and
+may over-read it — which is why the boolean is deprecated in its doc comment and the reason string is
+always populated.
+
+## 2. Under-block
+
+No detection is weakened: `'untrustworthy'` still fires on every case the boolean fired on (nothing
+parsed, canary objected), asserted in the updated tests. The change only ADDS a state between "fine"
+and "broken" where none existed.
+
+The residual gap, stated plainly: **a coherent stale registry is still reported with real-looking
+figures** (`total: 22, enforcedRatio: 0.0455`). It is now labelled `unverified` with a reason naming
+the possibility of "a coherent older copy", but the instrument cannot say *which* is the case. Only
+the blocked spec closes that. This change makes the uncertainty visible; it does not resolve it, and
+it must not be described as resolving it.
+
+## 3. Blast radius
+
+One field's semantics in `src/core/StandardsEnforcementAuditor.ts`; the route spreads the summary so
+the new fields flow automatically. Consumers checked with a full-text scan (`grep` silently returned
+nothing for a pattern present twice in this very file — python was used instead, and that tooling
+anomaly is recorded):
+
+- `assessmentTrustworthy` appears in exactly three test files (all updated) and nowhere in `src/`
+  outside its declaration and derivation. No runtime branch reads it.
+- The response is additive apart from the boolean's meaning narrowing; no field renamed or removed.
+
+## 4. Rollback plan
+
+Single-commit revert; no state, config, migration or persisted artifact. The audit recomputes per
+request.
+
+## 5. Test coverage (all three tiers)
+
+- **Unit** (`standards-enforcement-auditor.test.ts`, 16 pass): a coherent-but-stale registry (a real
+  whole-family subset of the live constitution) has zero dropped headings and `parsed ===
+  articleHeadings` — i.e. passes every internal check — and STILL must not read `verified`; plus
+  `deriveAssessmentConfidence`'s four verdicts in both directions, including that a mismatched
+  expectation is `untrustworthy` rather than merely `unverified`.
+- **Integration** (`conformance-dev-gate-route.test.ts`): the HTTP body carries
+  `assessmentConfidence: 'untrustworthy'` for an empty registry.
+- **E2E** (`standards-coverage-lifecycle.test.ts`): the verdict and its reason survive the production
+  initialization path.
+
+## 6. A fourth test found encoding the defect
+
+`standards-enforcement-auditor.test.ts` asserted `assessmentTrustworthy === true` for the full
+registry — pinning the overclaim as a specification. That is the FOURTH test found this evening
+asserting the behaviour it should have been challenging (the others: the standards parser's
+five-family allowlist, a fixture whose meaning changed with the wall clock, and the
+learning-velocity route's filed-items-count-as-learning fixtures).
+
+Four in one day is not a coincidence about those four tests. It is a property of how tests get
+written here: they pin what the code currently does. A green suite therefore attests to
+self-consistency, not correctness — which is the same shape as everything else this project has
+found, applied to our own verification. Recorded as a class; not fixed here, because the fix is a
+standard about how assertions are chosen, not a code change.
+
+## 7. How this was found, which is the transferable part
+
+Not by a test. By deploying and reading the live surface. The suite was fully green — it tested the
+cases I had thought of, which were exactly the cases my fix handled. The stale-but-coherent case was
+outside my imagination, and no amount of internal testing would have surfaced it.
+
+Two hours from shipping to discovery. The generalisable rule: **after shipping an honesty fix, read
+the live surface for the case you were fixing.** If the number you set out to correct still looks
+fine, you have not corrected it.


### PR DESCRIPTION
## ELI16 — my own fix reported "trustworthy" over exactly the defect it was built to expose

Hours after shipping #1641 — a change meant to stop the standards audit reporting a confident number over a partial copy of our rules — the server updated onto it and the live endpoint said: **22 standards, 4.5% enforced, marked trustworthy, zero warnings.** The real document has 81 rules. The stale copy is not malformed; it is a perfectly self-consistent document that happens to be a quarter of the real one, so it passes every *internal* check by construction. My field computed "my internal checks passed" and displayed it as "this assessment is trustworthy" — two different claims, and conflating them is the precise failure this instrument was being fixed for.

## Live evidence, after v1.3.975 deployed

```
total: 22 | enforcedRatio: 0.0455 | assessmentTrustworthy: TRUE
canaryOk: true | canaryFailures: 0 | parsed: 22 | articleHeadings: 22 | bytes: 46606
families: [5 of the 6]
```

Every internal check passes: all headings parse, none dropped, anchors present, count above the floor.

**Round 2 of the spec review had already told me this** — that refusing only an *empty* registry would not catch the historical case, because the real defect was 22 well-formed articles. I applied that lesson to the spec and never back to the code I had already shipped.

## The root insight

**Nothing inside a 22-rule document says it should have 81.** Trustworthiness cannot be obtained by looking harder at the file; it requires an *external* expectation. That mechanism is the blocked `standards-registry-snapshot-refresh` spec — so `'verified'` is unreachable today, and the honest verdict for every passing read is `'unverified'`.

## The change

| field | |
|---|---|
| `assessmentConfidence` | **new** — `'verified' \| 'unverified' \| 'untrustworthy'` |
| `confidenceReason` | **new** — always populated, plain English |
| `assessmentTrustworthy` | **deprecated**, retained one release; TRUE only on `'verified'` |

- **untrustworthy** — a check actively failed (nothing parsed, or the canary objected).
- **unverified** — internal checks passed, but there was nothing external to check against, so this pass cannot tell whether it read the current constitution or a coherent older copy.
- **verified** — internal checks passed *and* a same-build expectation matched.

## Proven on the real live registry — all four states

| input | before | after |
|---|---|---|
| the live 22-of-81 copy | `trustworthy: true` | `unverified` + reason |
| the real 81-article registry | `true` | `unverified` — **still correct**, nothing to check against |
| a MATCHING expectation | unreachable | `verified` |
| a MISMATCHED expectation | unreachable | `untrustworthy` |

Row two is the point: even reading the complete, correct document the honest verdict is `unverified`, because the instrument cannot know it is complete. Anything stronger is the same overclaim in nicer clothes.

## The compiler caught me

Inline, TypeScript's flow analysis proved `'verified'` unreachable and **rejected** the comparison deriving the deprecated boolean. That rejection is true and is the point — it objected to a claim I could not yet honour. `deriveAssessmentConfidence` is extracted as a pure exported function so the union stays open for when an expectation ships, without pretending it is reachable now.

## Residual gap, stated rather than papered over

A coherent stale registry is **still** reported with real-looking figures (`total: 22, enforcedRatio: 0.0455`). It is now *labelled* `unverified` with a reason naming "a coherent older copy", but the instrument cannot say which case it is in. Only the blocked spec closes that. This makes the uncertainty visible; it does not resolve it, and must not be described as resolving it.

## Tests (all three tiers)

- **Unit** (16 pass): a coherent-but-stale registry — a real whole-family subset of the live constitution — has zero dropped headings and `parsed === articleHeadings`, i.e. passes every internal check, and **still must not read `verified`**. Plus all four `deriveAssessmentConfidence` verdicts in both directions, including that a *mismatched* expectation is `untrustworthy` rather than merely `unverified`.
- **Integration**: the HTTP body carries the verdict.
- **E2E**: verdict + reason survive the production initialization path.

## A fourth test found encoding the defect

This file asserted `assessmentTrustworthy === true` for the full registry — pinning the overclaim as a specification. That is the **fourth** test found this evening asserting behaviour it should have been challenging (the others: the standards parser's five-family allowlist, a fixture whose meaning changed with the wall clock, and the learning-velocity route's filed-items-count-as-learning fixtures). Four in one day is a property of how tests get written here — they record what the code does — so a green suite attests to self-consistency, not correctness.

## How it was found, which is the transferable part

**Not by a test.** By deploying and reading the live surface. The suite was fully green: it tested the cases I had thought of, which were exactly the cases my fix handled. Two hours from shipping to discovery.

The rule worth keeping: **after shipping a fix to an honesty problem, read the live surface for the exact case you were fixing. If the number still looks fine, you have not fixed it.**

---

Project: `convergence-towards-coherence`, Tier 1 item 1 (self-correction). Tier 1 lane: ELI16 `docs/specs/assessment-confidence-unverified.eli16.md` + side-effects `upgrades/side-effects/assessment-confidence-unverified.md`.
