### PR TITLE
fix(projects): CI greenness must use the LATEST run per check, not every run

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T03-05-34-820Z-ci-green-latest-run.json
+++ b/.instar/instar-dev-decisions/2026-07-26T03-05-34-820Z-ci-green-latest-run.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T03:05:34.820Z",
+  "slug": "ci-green-latest-run",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 70,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/ci-green-latest-run.eli16.md
+++ b/docs/specs/ci-green-latest-run.eli16.md
@@ -1,0 +1,75 @@
+# A check that failed and was then fixed stayed failed forever, and blocked recording the work
+
+## What this actually is
+
+When our project tracker records a piece of work as finished, it verifies the pull request itself —
+including asking "were all the checks green?"
+
+It could never answer yes for a pull request whose checks had ever been red, even after they were
+fixed.
+
+## The concrete case
+
+Earlier tonight a pull request of mine failed one check: a gate requiring the description to carry a
+plain-English summary under a specific heading. I had written the summary and omitted the heading.
+I fixed the description, a fresh run of that check passed, and the pull request merged normally —
+because the merge gate looks at the *current* state of each check.
+
+The tracker does not. It asks the platform for the list of check runs and refuses if any of them
+failed. And the platform returns **every** run, including the superseded ones. So that pull request
+carries both entries, permanently:
+
+```
+eli16  FAILURE  01:43:52
+eli16  SUCCESS  01:45:32
+```
+
+Four different checks on that one pull request had two entries each. The tracker saw the older
+failure and refused to record work that had legitimately merged twenty minutes earlier.
+
+## Why this is the same bug as the others
+
+A superseded check run is a **stale symbol**. The check's actual current state is its latest run —
+which is precisely what the platform's own merge gate uses, and precisely what we were not using.
+
+So the recording path now has three separate instances of the same shape found in one evening:
+
+1. it could not find the tool it needed, and reported that as a fact about the merge;
+2. a safety guard refused a read, and that refusal was written down as "not on the main branch";
+3. an old check run was read as the check's present condition.
+
+Three independent defects, one code path, one underlying error each time: **reading a symbol instead
+of the state it stands for.** None of the three was visible from outside — they all presented
+identically, as a flat refusal.
+
+## What changes
+
+Before judging greenness, collapse the list to the **latest run of each check**, then evaluate those.
+
+## The two ways this must not become a loophole
+
+Deduplicating is dangerous if done carelessly — "keep the latest" could be used to launder a real
+failure. So:
+
+- **The latest run is authoritative in both directions.** A success followed by a later failure is
+  *not* green. If it were, this fix would be a way to hide a red by re-running until the ordering
+  suited you.
+- **Runs that cannot be ordered fail closed.** If two runs of the same check have equal or missing
+  timestamps, we cannot know which came last, so **the failing one wins.** An undatable success must
+  never mask a red.
+- **Unnamed entries are never merged together.** Some checks arrive as bare status entries with no
+  name at all; those are kept individually, so a failing one cannot be silently replaced by a
+  passing one.
+
+All three are tested, along with the case that was previously broken and the existing behaviour for
+a check still in flight.
+
+## How this was found
+
+Not by the failure happening again. I was about to tell the operator "the recording step will work
+once the server updates" — and instead of asserting it, I ran the check's own logic against the two
+real pull requests to see what it *would* say. It said no, twice, for two different reasons.
+
+That cost about two minutes and saved discovering both blockers later, one at a time, each looking
+like a fresh mystery. The habit worth keeping: **before claiming something will work after a
+dependency lands, run its logic now and watch what it actually returns.**

--- a/src/core/StageTransitionValidator.ts
+++ b/src/core/StageTransitionValidator.ts
@@ -68,7 +68,20 @@ export interface ValidationContext {
 export interface GhPrView {
   state: string;
   mergeCommit: { oid: string } | null;
-  statusCheckRollup: Array<{ conclusion?: string | null; status?: string | null; state?: string | null }>;
+  /**
+   * GitHub returns EVERY check run, including SUPERSEDED ones — a check that failed
+   * and was then re-run appears TWICE. `name`/`context` and the timestamps are needed
+   * to tell the current run from the stale one (see `ciIsGreen`).
+   */
+  statusCheckRollup: Array<{
+    conclusion?: string | null;
+    status?: string | null;
+    state?: string | null;
+    name?: string | null;
+    context?: string | null;
+    startedAt?: string | null;
+    completedAt?: string | null;
+  }>;
 }
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
@@ -425,13 +438,64 @@ async function loadFrontmatter(
   }
 }
 
-function ciIsGreen(rollup: GhPrView['statusCheckRollup']): boolean {
-  if (!Array.isArray(rollup) || rollup.length === 0) {
+type RollupEntry = GhPrView['statusCheckRollup'][number];
+
+/** Completion time of a check run, for ordering. 0 when unknown. */
+function runTime(c: RollupEntry): number {
+  const t = Date.parse(c.completedAt ?? c.startedAt ?? '');
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/**
+ * Collapse the rollup to the LATEST run per check name.
+ *
+ * GitHub's `statusCheckRollup` returns every run of every check, INCLUDING superseded
+ * ones. A check that failed and was then re-run to green appears twice, and the failed
+ * entry never goes away. Found 2026-07-25: PR #1641 merged legitimately (branch
+ * protection saw the passing `eli16` run) yet its rollup still carried
+ * `eli16: FAILURE` from 01:43:52 alongside `eli16: SUCCESS` from 01:45:22 — four check
+ * names were duplicated. The old `ciIsGreen` iterated every entry and refused on the
+ * stale failure, so the tracker could never record a correct merge whose CI had ever
+ * been red. A superseded check-run is a stale SYMBOL; the check's current state is the
+ * latest run, which is exactly what GitHub's own merge gate uses.
+ *
+ * Two deliberate safety choices, because a dedupe must never become a way to HIDE a
+ * real failure:
+ *  - Unnamed entries (bare status contexts with neither `name` nor `context`) are keyed
+ *    individually, so none is silently collapsed into another.
+ *  - When two runs of the same name cannot be ORDERED (equal or missing timestamps),
+ *    the FAILING one wins. Unorderable runs fail closed rather than letting an
+ *    undatable success mask a red.
+ */
+function latestRunPerCheck(rollup: GhPrView['statusCheckRollup']): RollupEntry[] {
+  const byKey = new Map<string, RollupEntry>();
+  let unnamed = 0;
+  const isBad = (c: RollupEntry): boolean => {
+    const concl = (c.conclusion ?? c.state ?? '').toUpperCase();
+    const status = (c.status ?? '').toUpperCase();
+    if (status && status !== 'COMPLETED' && status !== 'SUCCESS' && status !== 'NEUTRAL') return true;
+    return Boolean(concl) && concl !== 'SUCCESS' && concl !== 'SKIPPED' && concl !== 'NEUTRAL';
+  };
+  for (const c of rollup) {
+    const name = (c.name ?? c.context ?? '').trim();
+    const key = name || `\u0000unnamed-${unnamed++}`;
+    const prev = byKey.get(key);
+    if (!prev) { byKey.set(key, c); continue; }
+    const dt = runTime(c) - runTime(prev);
+    if (dt > 0) byKey.set(key, c);
+    else if (dt === 0 && isBad(c)) byKey.set(key, c); // unorderable → the failure wins
+  }
+  return [...byKey.values()];
+}
+
+function ciIsGreen(rollupRaw: GhPrView['statusCheckRollup']): boolean {
+  if (!Array.isArray(rollupRaw) || rollupRaw.length === 0) {
     // Empty rollup = no checks defined. Per spec we treat green as
     // "no failing checks" — an empty rollup is acceptable (small repos
     // without CI). This matches `gh pr merge --auto` semantics.
     return true;
   }
+  const rollup = latestRunPerCheck(rollupRaw);
   for (const check of rollup) {
     const concl = (check.conclusion ?? check.state ?? '').toUpperCase();
     const status = (check.status ?? '').toUpperCase();

--- a/tests/unit/StageTransitionValidator.test.ts
+++ b/tests/unit/StageTransitionValidator.test.ts
@@ -284,6 +284,81 @@ describe('StageTransitionValidator', () => {
     if (!r.ok) expect(r.code).toBe('MERGE_COMMIT_UNREACHABLE');
   });
 
+  describe('building → merged: CI greenness uses the LATEST run per check, not every run', () => {
+    // GitHub's statusCheckRollup returns EVERY run including superseded ones. Found
+    // 2026-07-25: PR #1641 merged legitimately (branch protection saw the passing run)
+    // yet its rollup still carried `eli16: FAILURE` from 01:43:52 beside
+    // `eli16: SUCCESS` from 01:45:22 — four names were duplicated. The old ciIsGreen
+    // refused on the stale failure, so the tracker could NEVER record a correct merge
+    // whose CI had ever been red. A superseded run is a stale symbol; the check's
+    // current state is its latest run.
+    const base = (rollup: unknown[]): ValidationContext => ({
+      targetRepoPath: tmpRepo,
+      prNumber: 1641,
+      ghPrView: async () => ({
+        state: 'MERGED',
+        mergeCommit: { oid: 'a1b2c3d4e5f60708' },
+        statusCheckRollup: rollup as never,
+      }),
+      gitMergeBaseIsAncestor: () => true,
+    });
+
+    it('a superseded FAILURE followed by a later SUCCESS is green (the live #1641 shape)', async () => {
+      const r = await validateStageTransition('building', 'merged', base([
+        { name: 'eli16', status: 'COMPLETED', conclusion: 'FAILURE', completedAt: '2026-07-26T01:44:01Z' },
+        { name: 'eli16', status: 'COMPLETED', conclusion: 'SUCCESS', completedAt: '2026-07-26T01:45:32Z' },
+      ]));
+      expect(r.ok).toBe(true);
+    });
+
+    it('a SUCCESS followed by a later FAILURE is NOT green — dedupe must never hide a real red', async () => {
+      // The other direction. If "keep the latest" were applied carelessly it would be a
+      // way to launder a genuine failure by ordering; the latest run is authoritative in
+      // BOTH directions.
+      const r = await validateStageTransition('building', 'merged', base([
+        { name: 'eli16', status: 'COMPLETED', conclusion: 'SUCCESS', completedAt: '2026-07-26T01:44:01Z' },
+        { name: 'eli16', status: 'COMPLETED', conclusion: 'FAILURE', completedAt: '2026-07-26T01:45:32Z' },
+      ]));
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.code).toBe('CI_NOT_GREEN');
+    });
+
+    it('UNORDERABLE runs of the same check fail closed — the failure wins', async () => {
+      // Equal or missing timestamps: we cannot know which ran last, so an undatable
+      // success must not mask a red.
+      for (const rollup of [
+        [ { name: 'x', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'x', status: 'COMPLETED', conclusion: 'FAILURE' } ],
+        [ { name: 'x', status: 'COMPLETED', conclusion: 'FAILURE' },
+          { name: 'x', status: 'COMPLETED', conclusion: 'SUCCESS' } ],
+        [ { name: 'x', status: 'COMPLETED', conclusion: 'SUCCESS', completedAt: '2026-07-26T01:44:01Z' },
+          { name: 'x', status: 'COMPLETED', conclusion: 'FAILURE', completedAt: '2026-07-26T01:44:01Z' } ],
+      ]) {
+        const r = await validateStageTransition('building', 'merged', base(rollup));
+        expect(r.ok, JSON.stringify(rollup)).toBe(false);
+      }
+    });
+
+    it('UNNAMED entries are never collapsed into one another', async () => {
+      // Bare status contexts with no name/context must be keyed individually, or a
+      // failing one could be silently replaced by a passing one.
+      const r = await validateStageTransition('building', 'merged', base([
+        { status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { status: 'COMPLETED', conclusion: 'FAILURE' },
+      ]));
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.code).toBe('CI_NOT_GREEN');
+    });
+
+    it('an IN-FLIGHT latest run is still not green (existing behaviour preserved)', async () => {
+      const r = await validateStageTransition('building', 'merged', base([
+        { name: 'eli16', status: 'COMPLETED', conclusion: 'FAILURE', completedAt: '2026-07-26T01:44:01Z' },
+        { name: 'eli16', status: 'IN_PROGRESS', completedAt: '2026-07-26T01:45:32Z' },
+      ]));
+      expect(r.ok).toBe(false);
+    });
+  });
+
   it('building → merged: a helper that CANNOT CHECK yields MERGE_BASE_UNVERIFIABLE, never a fabricated "not reachable"', async () => {
     // Live defect, 2026-07-25, recording PR #1641 as merged: the route's helper
     // swallowed a SourceTreeGuard REFUSAL in a bare `catch { return false }`, so a

--- a/upgrades/next/ci-green-latest-run.md
+++ b/upgrades/next/ci-green-latest-run.md
@@ -1,0 +1,41 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**A project item could never be recorded as merged if its pull request's CI had ever been red — even
+after it was fixed.**
+
+`StageTransitionValidator.ciIsGreen` evaluated EVERY entry in GitHub's `statusCheckRollup`. GitHub
+returns every run of every check, **including superseded ones**, so a check that failed and was
+re-run to green appears twice and the failure never disappears. Verified on the live PR #1641
+(merged legitimately): 31 rollup entries, four check names duplicated, including
+`eli16 FAILURE 01:44:01Z` beside `eli16 SUCCESS 01:45:32Z`. Branch protection merged the PR because it
+uses each check's CURRENT state; the tracker refused it with `CI_NOT_GREEN` because it also counted
+the stale run.
+
+The rollup is now collapsed to the **latest run per check name** (by `completedAt`, falling back to
+`startedAt`) before greenness is judged — which is what GitHub's own merge gate does.
+
+Three safeguards so the dedupe can never hide a genuine failure: the latest run is authoritative in
+BOTH directions (a success followed by a later failure is still not green); runs that cannot be
+ordered FAIL CLOSED (equal or missing timestamps ⇒ the failing run wins); and unnamed status entries
+are keyed individually so a failing one is never collapsed into a passing one.
+
+End-to-end, against the two real merged pull requests with the route's exact helper wiring: both went
+from refused to accepted.
+
+## What to Tell Your User
+
+If you track work in projects, marking an item as merged now succeeds for a pull request whose checks
+went red and were then fixed — which previously failed with a confusing "CI is not green" long after
+the pull request had merged.
+
+## Summary of New Capabilities
+
+- Greenness is evaluated per check against its latest run, matching branch-protection semantics.
+
+## Evidence
+
+- `tests/unit/StageTransitionValidator.test.ts` — five new cases: the live superseded-failure shape;
+  the reverse direction (later failure still refuses); unorderable runs fail closed across three
+  variants; unnamed entries never collapsed; an in-flight latest run still not green.

--- a/upgrades/side-effects/ci-green-latest-run.md
+++ b/upgrades/side-effects/ci-green-latest-run.md
@@ -1,0 +1,119 @@
+# Side-Effects Review — CI greenness must use the LATEST run per check
+
+## Summary of the change
+
+`StageTransitionValidator.ciIsGreen` iterated EVERY entry in GitHub's `statusCheckRollup` and refused
+on any non-success conclusion. GitHub returns every run of every check, **including superseded ones**,
+so a check that failed and was then re-run to green appears twice and the failed entry never
+disappears.
+
+Verified on the live PR #1641 (merged legitimately at 02:07:44Z):
+
+```
+rollup entries: 31 | names appearing more than once: eli16 (2), UX impact declaration (2),
+                                                     UX assertions (messaging E2E) (2), UX merge safety (2)
+eli16  COMPLETED  FAILURE  completedAt 2026-07-26T01:44:01Z
+eli16  COMPLETED  SUCCESS  completedAt 2026-07-26T01:45:32Z
+```
+
+Branch protection merged the PR because it evaluates each check's CURRENT state. The tracker refused
+it with `CI_NOT_GREEN` because it evaluated the stale run too — so **no correct merge whose CI had
+ever been red could ever be recorded.**
+
+Fix: `latestRunPerCheck` collapses the rollup to the newest run per check name (by `completedAt`,
+falling back to `startedAt`) before `ciIsGreen` evaluates it. `GhPrView.statusCheckRollup`'s type
+gains the `name`/`context`/`startedAt`/`completedAt` fields the dedupe needs; the route's existing
+`gh pr view --json …statusCheckRollup` already returns them, so no query change.
+
+## Decision-point inventory
+
+- `ciIsGreen` feeds the `building → merged` GATE. This change makes the gate ACCEPT a case it
+  previously refused, so it is the direction that needs the most scrutiny — see §1/§2.
+- No other decision point, hook, sentinel, reaper, scheduler, migration or config surface is touched.
+- `latestRunPerCheck` is a pure function over the rollup array.
+
+## 1. Over-block
+
+Strictly reduced, and that is the intent: a merged PR with a superseded failure is now recordable.
+Nothing that used to pass now fails.
+
+The one preserved refusal worth naming: a **latest** run that is still in flight (`status` not
+`COMPLETED`) is still not green, asserted in its own test, so the dedupe cannot be used to skip a
+pending check by pairing it with an older success.
+
+## 2. Under-block — the part that matters
+
+A dedupe is a potential laundering mechanism, so three properties are enforced and each is tested:
+
+1. **Latest is authoritative in BOTH directions.** SUCCESS followed by a later FAILURE is NOT green.
+   Without this, "keep the latest" would let anyone bury a red by arranging run order.
+2. **Unorderable runs FAIL CLOSED.** Equal or missing timestamps ⇒ the FAILING run wins. An undatable
+   success must never mask a red. (Three variants tested: no timestamps either way round, and equal
+   timestamps.)
+3. **Unnamed entries are keyed individually.** Bare status contexts with neither `name` nor `context`
+   are never collapsed into each other, so a failing one cannot be replaced by a passing one.
+
+Residual, stated: the dedupe trusts GitHub's timestamps. A platform that reported them wrongly could
+mis-order runs — but the fail-closed rule bounds the damage to the unorderable case, and the
+alternative (ignoring the rollup entirely, or trusting merge status alone) is strictly weaker.
+
+## 3. Blast radius
+
+One function plus one type widening in `src/core/StageTransitionValidator.ts`. `ciIsGreen` is private
+to that module (`grep` for callers: only the `to === 'merged'` branch). The route passes the rollup
+through unchanged. No response shape changes; no new code.
+
+## 4. Rollback plan
+
+Single-commit revert; no state, config, migration or artifact. Reverting restores the previous
+(over-refusing) behaviour immediately.
+
+## 5. Test coverage
+
+`tests/unit/StageTransitionValidator.test.ts` (46 pass), five new cases: the live #1641 shape
+(superseded FAILURE + later SUCCESS ⇒ green); the reverse (SUCCESS + later FAILURE ⇒ not green);
+unorderable-runs-fail-closed across three variants; unnamed entries not collapsed; and an in-flight
+latest run still not green.
+
+No integration/e2e tier added: this is a pure predicate inside an existing gate whose route path is
+already covered, and the decisive evidence is the end-to-end check below.
+
+## 6. End-to-end evidence, gathered BEFORE the fix and after
+
+The validator's real logic was run against the two real merged PRs with the route's exact helper
+wiring:
+
+```
+before:  item 1 (PR 1641) -> CI_NOT_GREEN
+         item 2 (PR 1644) -> MERGE_BASE_UNVERIFIABLE   (stale local ref; resolved by git fetch)
+after:   item 1 (PR 1641) -> WOULD SUCCEED
+         item 2 (PR 1644) -> WOULD SUCCEED
+```
+
+Note the second line: the `MERGE_BASE_UNVERIFIABLE` code shipped hours earlier in #1643 did its job
+here on a real case — an unknown local SHA reported as *unverifiable* rather than as a false "not an
+ancestor".
+
+## 7. Third instance in one code path, in one evening
+
+The completion-recording path has now yielded three independent defects tonight, each the same
+underlying error:
+
+| | defect | what it reported |
+|---|---|---|
+| #1640 | the `gh` binary was unreachable | a flat refusal |
+| #1643 | a SourceTreeGuard refusal was caught and returned as `false` | "the merge is not on main" |
+| this | a superseded check run read as the check's current state | "CI is not green" |
+
+All three presented identically from outside — an opaque refusal — and each masked the next. That is
+worth recording as a property of the path rather than three coincidences: **a code path whose failures
+all render as one indistinguishable refusal will hide its own defects in series.** The general fix is
+the one #1643 started: distinguish "could not determine" from "determined, and the answer is no".
+
+## 8. How it was found
+
+By refusing to assert. I was about to report that recording would work once the server updated, and
+instead ran the validator's own logic against the real PRs. It returned two different refusals. That
+cost two minutes and avoided discovering both blockers serially, each appearing to be a fresh
+mystery. Habit worth keeping: **before claiming something will work once a dependency lands, execute
+its logic now and read what it returns.**


### PR DESCRIPTION
## ELI16 — a check that failed and was then fixed stayed failed forever, and blocked recording the work

When the project tracker records work as finished it asks "were the pull request's checks green?" — and it could never answer yes for a pull request whose checks had *ever* been red, even after they were fixed and it merged normally. GitHub returns **every** check run when asked, including superseded ones, so a check that failed and was re-run to green appears twice and the failure never disappears. A superseded run is a stale symbol; the check's actual state is its latest run, which is exactly what GitHub's own merge gate uses and exactly what we were not using.

## The concrete case

PR #1641 merged legitimately at 02:07:44Z. Its rollup, permanently:

```
rollup entries: 31
names appearing more than once: eli16 (2), UX impact declaration (2),
                                UX assertions (messaging E2E) (2), UX merge safety (2)

eli16  COMPLETED  FAILURE  completedAt 2026-07-26T01:44:01Z
eli16  COMPLETED  SUCCESS  completedAt 2026-07-26T01:45:32Z
```

The failure at 01:44 was my own — I omitted the required heading from the description. I fixed it, a fresh run passed at 01:45, branch protection merged the PR. The tracker read both entries, saw the older failure, and refused with `CI_NOT_GREEN` twenty minutes after the merge.

## The fix

`latestRunPerCheck` collapses the rollup to the newest run per check name (`completedAt`, falling back to `startedAt`) before `ciIsGreen` evaluates it. `GhPrView.statusCheckRollup`'s type gains the `name`/`context`/`startedAt`/`completedAt` fields the dedupe needs — the route's existing `gh pr view --json …statusCheckRollup` already returns them, so no query change.

## Three safeguards, because a dedupe is a potential laundering mechanism

"Keep the latest" could trivially become a way to bury a genuine red. So:

1. **The latest run is authoritative in BOTH directions.** A SUCCESS followed by a later FAILURE is **not** green. Without this, run ordering becomes a way to hide a failure.
2. **Unorderable runs FAIL CLOSED.** Equal or missing timestamps ⇒ the **failing** run wins. An undatable success must never mask a red. (Three variants tested: missing timestamps in either order, and equal timestamps.)
3. **Unnamed entries are keyed individually.** Bare status contexts with neither `name` nor `context` are never collapsed into one another, so a failing one cannot be replaced by a passing one.

An in-flight latest run is still not green — existing behaviour, asserted so the dedupe can't be used to skip a pending check by pairing it with an older success.

## End-to-end evidence, before and after

The validator's real logic run against the two real merged PRs with the route's exact helper wiring:

```
before:  item 1 (PR 1641) -> CI_NOT_GREEN
         item 2 (PR 1644) -> MERGE_BASE_UNVERIFIABLE   (stale local ref; fixed by git fetch)
after:   item 1 (PR 1641) -> WOULD SUCCEED
         item 2 (PR 1644) -> WOULD SUCCEED
```

Note the second line: `MERGE_BASE_UNVERIFIABLE`, which shipped in #1643, did its job here on a real case — an unknown local SHA reported as *unverifiable* rather than as a false "not an ancestor".

## Third defect in this one code path, in one evening

| | defect | what it reported |
|---|---|---|
| #1640 | the `gh` binary was unreachable | a flat refusal |
| #1643 | a SourceTreeGuard refusal caught and returned as `false` | "the merge is not on main" |
| **this** | a superseded check run read as the check's current state | "CI is not green" |

All three presented identically from outside — an opaque refusal — and **each masked the next**, so fixing one only revealed the following one. Worth recording as a property of the path rather than three coincidences: **a code path whose failures all render as one indistinguishable refusal will hide its own defects in series.** The general remedy is the one #1643 began: distinguish "could not determine" from "determined, and the answer is no".

## How it was found

By refusing to assert. I was about to report that recording would work once the server updated; instead I ran the validator's own logic against the real PRs and watched what it returned. It refused twice, for two different reasons. Two minutes, versus discovering both blockers serially, each looking like a fresh mystery.

**Habit worth keeping: before claiming something will work once a dependency lands, execute its logic now and read what it actually returns.**

## Tests

`tests/unit/StageTransitionValidator.test.ts` — 46 pass, five new cases: the live superseded-failure shape; the reverse direction; unorderable-runs-fail-closed across three variants; unnamed entries never collapsed; an in-flight latest run still not green.

No integration/e2e tier: this is a pure predicate inside an existing gate whose route path is already covered, and the decisive evidence is the end-to-end run above.

---

Project: `convergence-towards-coherence` — unblocks Tier 1 item 3 (recording work as merged). Tier 1 lane: ELI16 `docs/specs/ci-green-latest-run.eli16.md` + side-effects `upgrades/side-effects/ci-green-latest-run.md`.
