### PR TITLE
fix: surface unproven load-bearing guards fleet-wide

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T03-10-35-280Z-guard-heartbeat-unproven-summary.json
+++ b/.instar/instar-dev-decisions/2026-07-26T03-10-35-280Z-guard-heartbeat-unproven-summary.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T03:10:35.280Z",
+  "slug": "guard-heartbeat-unproven-summary",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 30,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/dashboard/glance.js
+++ b/dashboard/glance.js
@@ -967,6 +967,22 @@ export function machineRecordNode(doc, m, opts = {}) {
     rows.push(['Safety checks on', String(on)]);
     const problems = guardPostureProblems(p);
     if (problems > 0) rows.push(['Safety checks needing a look', String(problems)]);
+    const uninspectableKeys = Array.isArray(p.loadBearingUninspectableKeys)
+      ? p.loadBearingUninspectableKeys.filter((key) => typeof key === 'string')
+      : [];
+    const uninspectableCount = Number.isFinite(p.loadBearingUninspectable)
+      ? Math.max(uninspectableKeys.length, Math.floor(p.loadBearingUninspectable))
+      : uninspectableKeys.length;
+    if (uninspectableCount > 0 || uninspectableKeys.length > 0) {
+      const shown = uninspectableKeys.join(', ');
+      const truncated = uninspectableCount > uninspectableKeys.length
+        ? ` (${uninspectableKeys.length} shown)`
+        : '';
+      rows.push([
+        'Load-bearing protection unproven',
+        `${uninspectableCount}${shown ? ` — ${shown}${truncated}` : ''}`,
+      ]);
+    }
   } else {
     rows.push(['Safety checks', 'not reported yet']);
   }

--- a/src/core/GuardPostureStore.ts
+++ b/src/core/GuardPostureStore.ts
@@ -30,6 +30,10 @@ interface StoreFileShape {
   machines: Record<string, StoredGuardPosture>;
 }
 
+function optionalStringArraysEqual(a: string[] | undefined, b: string[] | undefined): boolean {
+  if (a === undefined || b === undefined) return a === b;
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
 
 /** Field-wise posture equality EXCLUDING generatedAt (which changes every
  *  beat by construction and must not defeat write-on-change). */
@@ -44,6 +48,8 @@ export function postureSemanticsEqual(a: GuardPostureSummary, b: GuardPostureSum
     a.divergedPendingRestart === b.divergedPendingRestart &&
     a.errored === b.errored &&
     a.missing === b.missing &&
+    a.loadBearingUninspectable === b.loadBearingUninspectable &&
+    optionalStringArraysEqual(a.loadBearingUninspectableKeys, b.loadBearingUninspectableKeys) &&
     a.offDeviantKeys.length === b.offDeviantKeys.length &&
     a.offDeviantKeys.every((k, i) => k === b.offDeviantKeys[i]) &&
     a.offRuntimeDivergentKeys.length === b.offRuntimeDivergentKeys.length &&

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2298,9 +2298,8 @@ export interface MachineCapacity {
 }
 
 /** The compact posture block that rides the capacity heartbeat
- *  (GUARD-POSTURE-ENDPOINT-SPEC §2.3). Counts plus per-key detail for ONLY
- *  the two sharpest signals (offDeviantKeys, offRuntimeDivergentKeys) —
- *  bounded by the manifest size. */
+ *  (GUARD-POSTURE-ENDPOINT-SPEC §2.3). Counts plus bounded per-key detail for
+ *  the read surfaces that must not collapse an absent class into all-clear. */
 export interface GuardPostureSummary {
   onConfirmed: number;
   onUnverified: number;
@@ -2317,6 +2316,11 @@ export interface GuardPostureSummary {
    *  heartbeat so a peer gap is visible fleet-wide. Optional for wire back-compat —
    *  an un-upgraded peer omits them and the probe Array.isArray-guards the read. */
   loadBearingGapKeys?: string[];
+  /** Full count plus at most 16 deterministic keys. Read-surface context only:
+   *  probes and pool notifications deliberately ignore these fields because
+   *  the underlying missing/errored/stale/divergent classes already alarm. */
+  loadBearingUninspectable?: number;
+  loadBearingUninspectableKeys?: string[];
   loadBearingSoakingKeys?: string[];
   loadBearingAcceptedKeys?: string[];
   generatedAt: string;

--- a/src/monitoring/guardPostureView.ts
+++ b/src/monitoring/guardPostureView.ts
@@ -42,6 +42,12 @@ export type GuardDivergence = 'none' | 'diverged' | 'not-applicable' | 'snapshot
 /** Staleness multiplier over a guard's self-declared cadence (spec §2.2, N=5). */
 export const STALE_TICK_MULTIPLIER = 5;
 
+/** Per-heartbeat wire bound for load-bearing keys whose protection cannot
+ * currently be proved. The full count travels separately, so truncation can
+ * never turn into an all-clear. Sixteen covers today's 13 load-bearing guards
+ * while placing a fixed ceiling on this 30-second payload. */
+export const HEARTBEAT_LOAD_BEARING_UNINSPECTABLE_KEY_CAP = 16;
+
 /** The CLOSED projection — every field a /guards row may carry. Anything not
  *  named here never leaves the server (Tier-1 allowlist test). */
 export interface GuardRuntimeProjection {
@@ -462,11 +468,15 @@ export function buildHeartbeatPostureBlock(
     divergedPendingRestart: s.divergedPendingRestart,
     errored: s.errored,
     missing: s.missing,
-    // G3 (§2.6): the three load-bearing key-lists ride the heartbeat so a peer
-    // gap is visible fleet-wide. The heartbeat compute (server.ts site 3) threads
+    // G3 (§2.6): the load-bearing key-lists ride the heartbeat so peer posture is
+    // visible fleet-wide. The heartbeat compute (server.ts site 3) threads
     // the local accept map + `now`, so these are already correctly derived here —
     // this block just filters (an accepted guard never ships as a loadBearingGap).
     loadBearingGapKeys: [...s.loadBearingGapKeys],
+    loadBearingUninspectable: s.loadBearingUninspectableKeys.length,
+    loadBearingUninspectableKeys: [...s.loadBearingUninspectableKeys]
+      .sort((a, b) => a.localeCompare(b))
+      .slice(0, HEARTBEAT_LOAD_BEARING_UNINSPECTABLE_KEY_CAP),
     loadBearingSoakingKeys: [...s.loadBearingSoakingKeys],
     loadBearingAcceptedKeys: [...s.loadBearingAcceptedKeys],
     generatedAt,

--- a/tests/e2e/glance-jargon-belt-lifecycle.test.ts
+++ b/tests/e2e/glance-jargon-belt-lifecycle.test.ts
@@ -63,7 +63,11 @@ describe('Jargon-belt glance tabs — E2E feature-alive', () => {
   it('Machines: /pool 200, the glance renders end-to-end, an XSS nickname is inert', async () => {
     const machines = [
       { machineId: 'm_1', nickname: 'Laptop', online: true, clockSkewStatus: 'ok', activeSessionCount: 1, maxSessions: 6,
-        hardware: { cpuModel: 'Apple M2', cpuCores: 8, totalMemBytes: 17179869184 }, guardPosture: { onConfirmed: 16 } },
+        hardware: { cpuModel: 'Apple M2', cpuCores: 8, totalMemBytes: 17179869184 },
+        guardPosture: {
+          onConfirmed: 16, errored: 1, loadBearingUninspectable: 1,
+          loadBearingUninspectableKeys: ['multiMachine.sessionPool.inboundQueue.enabled'],
+        } },
       { machineId: 'm_2', nickname: '<img src=x onerror=alert(1)> Mini', online: true, clockSkewStatus: 'ok' },
     ];
     server = await bootApp({ ...BASE, machinePoolRegistry: { getCapacities: () => machines } });
@@ -80,6 +84,12 @@ describe('Jargon-belt glance tabs — E2E feature-alive', () => {
     expect(handle.drilldown.querySelector('img')).toBeNull();
     expect(handle.drilldown.querySelector('script')).toBeNull();
     expect(handle.drilldown.textContent).toContain('onerror'); // literal text, harmless
+    const laptopRow = Array.from(handle.drilldown.querySelectorAll('.glance-list-row'))
+      .find((row: any) => row.textContent.includes('Laptop'));
+    laptopRow.dispatchEvent(new (dom.window as any).Event('click'));
+    const recordText = handle.drilldown.querySelector('[data-glance-record]').textContent;
+    expect(recordText).toContain('Load-bearing protection unproven');
+    expect(recordText).toContain('multiMachine.sessionPool.inboundQueue.enabled');
   });
 
   it('Health: /systems/status 200, the full glance renders end-to-end from live subsystems', async () => {

--- a/tests/integration/glance-jargon-belt-tabs.test.ts
+++ b/tests/integration/glance-jargon-belt-tabs.test.ts
@@ -77,7 +77,11 @@ describe('Machines glance (integration — real /pool)', () => {
   it('feature ON: /pool 200, glance renders from live machines + drills to a record', async () => {
     const machines = [
       { machineId: 'm_1', nickname: 'Laptop', online: true, clockSkewStatus: 'ok', activeSessionCount: 2, maxSessions: 6,
-        hardware: { cpuModel: 'Apple M2', cpuCores: 8, totalMemBytes: 17179869184 }, guardPosture: { onConfirmed: 16, offDeviant: 6 } },
+        hardware: { cpuModel: 'Apple M2', cpuCores: 8, totalMemBytes: 17179869184 },
+        guardPosture: {
+          onConfirmed: 16, errored: 1, loadBearingUninspectable: 1,
+          loadBearingUninspectableKeys: ['multiMachine.sessionPool.inboundQueue.enabled'],
+        } },
       { machineId: 'm_2', nickname: 'Mini', online: false, clockSkewStatus: 'ok' },
     ];
     server = await bootApp({
@@ -105,7 +109,10 @@ describe('Machines glance (integration — real /pool)', () => {
     onlineBtn.dispatchEvent(new (dom.window as any).Event('click'));
     const row = handle.drilldown.querySelector('.glance-list-row');
     row.dispatchEvent(new (dom.window as any).Event('click'));
-    expect(handle.drilldown.querySelector('[data-glance-record]')!.textContent).toMatch(/Specs|Status/);
+    const recordText = handle.drilldown.querySelector('[data-glance-record]')!.textContent;
+    expect(recordText).toMatch(/Specs|Status/);
+    expect(recordText).toContain('Load-bearing protection unproven');
+    expect(recordText).toContain('multiMachine.sessionPool.inboundQueue.enabled');
   });
 
   it('dark: /pool enabled:false → the tab builds a friendly single-machine glance', async () => {

--- a/tests/integration/guards-route.test.ts
+++ b/tests/integration/guards-route.test.ts
@@ -290,6 +290,8 @@ describe('heartbeat posture ingestion (MachinePoolRegistry + GuardPostureStore)'
     offDeviant: 1, offDeviantKeys: ['monitoring.sessionReaper.enabled'],
     offRuntimeDivergent: 0, offRuntimeDivergentKeys: [],
     divergedPendingRestart: 0, errored: 0, missing: 0,
+    loadBearingUninspectable: 1,
+    loadBearingUninspectableKeys: ['multiMachine.sessionPool.inboundQueue.enabled'],
     generatedAt: '2026-06-12T00:00:00.000Z',
   };
 
@@ -310,6 +312,8 @@ describe('heartbeat posture ingestion (MachinePoolRegistry + GuardPostureStore)'
     });
     const cap = pool.getCapacity('m-peer')!;
     expect(cap.guardPosture?.offDeviantKeys).toEqual(['monitoring.sessionReaper.enabled']);
+    expect(cap.guardPosture?.loadBearingUninspectable).toBe(1);
+    expect(cap.guardPosture?.loadBearingUninspectableKeys).toEqual(['multiMachine.sessionPool.inboundQueue.enabled']);
     expect(cap.guardPostureReceivedAt).toBe(new Date(now).toISOString());
 
     // "Restart": a FRESH registry + fresh store reload the durable last-known
@@ -325,7 +329,39 @@ describe('heartbeat posture ingestion (MachinePoolRegistry + GuardPostureStore)'
     const cap2 = pool2.getCapacity('m-peer')!;
     expect(cap2.online).toBe(false); // dark — but posture still renders
     expect(cap2.guardPosture?.onConfirmed).toBe(3);
+    expect(cap2.guardPosture?.loadBearingUninspectableKeys).toEqual(['multiMachine.sessionPool.inboundQueue.enabled']);
     expect(cap2.guardPostureReceivedAt).toBe(new Date(now).toISOString());
+  });
+
+  it('persists a changed uninspectable key list even when every existing posture count stays equal', () => {
+    let now = 1_781_300_000_000;
+    const store = new GuardPostureStore(stateDir);
+    const pool = new MachinePoolRegistry({
+      listMachines: () => [{ machineId: 'm-peer', nickname: 'mini' }],
+      clockSkewToleranceMs: 300_000,
+      failoverThresholdMs: 60_000,
+      now: () => now,
+      postureStore: store,
+    });
+    pool.recordHeartbeat({
+      machineId: 'm-peer',
+      selfReportedLastSeen: new Date(now).toISOString(),
+      guardPosture: POSTURE,
+    });
+    now += 30_000;
+    pool.recordHeartbeat({
+      machineId: 'm-peer',
+      selfReportedLastSeen: new Date(now).toISOString(),
+      guardPosture: {
+        ...POSTURE,
+        loadBearingUninspectableKeys: ['monitoring.strandedTopicSentinel.enabled'],
+        generatedAt: new Date(now).toISOString(),
+      },
+    });
+
+    const reloaded = new GuardPostureStore(stateDir);
+    expect(reloaded.get('m-peer')?.posture.loadBearingUninspectableKeys)
+      .toEqual(['monitoring.strandedTopicSentinel.enabled']);
   });
 
   it('a posture-less beat carries the previous block forward WITHOUT refreshing its age', () => {

--- a/tests/unit/dashboard-glance-drilldown.test.ts
+++ b/tests/unit/dashboard-glance-drilldown.test.ts
@@ -389,6 +389,25 @@ describe('F11 walk-every-tile — the Machines glance (Phase 3) + issue #1429', 
     expect(handle.drilldown.querySelector('[data-glance-record]')!.textContent).toMatch(/In plain words/);
   });
 
+  it('a machine record displays unproven load-bearing protection without making that read-only field a health classifier', () => {
+    const unprovenPool = { enabled: true, machines: [
+      mkMachine({
+        guardPosture: {
+          onConfirmed: 16,
+          loadBearingUninspectable: 1,
+          loadBearingUninspectableKeys: ['multiMachine.sessionPool.inboundQueue.enabled'],
+        },
+      }),
+    ] };
+    const handle = renderGlance(doc, root, machinesGlanceSpec(doc, unprovenPool, null, {}));
+    expect(handle.headline.textContent).toContain('online and healthy');
+    activate(handle, 'online');
+    handle.drilldown.querySelector('.glance-list-row')!.dispatchEvent(new dom.window.Event('click'));
+    const recordText = handle.drilldown.querySelector('[data-glance-record]')!.textContent!;
+    expect(recordText).toContain('Load-bearing protection unproven');
+    expect(recordText).toContain('multiMachine.sessionPool.inboundQueue.enabled');
+  });
+
   it('#1429: the nickname edits commit ONLY on Enter/blur, with optimistic echo', () => {
     let saved: any = null;
     const handle = renderGlance(doc, root, machinesGlanceSpec(doc, pool, guards, {

--- a/tests/unit/monitoring/guard-posture-loadbearing.test.ts
+++ b/tests/unit/monitoring/guard-posture-loadbearing.test.ts
@@ -12,6 +12,7 @@ import {
   buildGuardInventory,
   buildHeartbeatPostureBlock,
   deriveGuardRow,
+  HEARTBEAT_LOAD_BEARING_UNINSPECTABLE_KEY_CAP,
   ROW_FIELD_ALLOWLIST,
 } from '../../../src/monitoring/guardPostureView.js';
 import { GuardRegistry } from '../../../src/monitoring/GuardRegistry.js';
@@ -331,11 +332,47 @@ describe('buildGuardInventory + buildHeartbeatPostureBlock — load-bearing key-
     expect(inv.summary.loadBearingAcceptedKeys).toContain(LB_KEY);
   });
 
-  it('the heartbeat block carries the three key-lists', () => {
+  it('the heartbeat block carries a counted, capped uninspectable list alongside the existing three lists', () => {
     const hb = buildHeartbeatPostureBlock(invWith(), '2026-07-01T00:00:00.000Z');
     expect(hb.loadBearingGapKeys).toContain(LB_KEY);
+    expect(hb.loadBearingUninspectable).toBe(invWith().summary.loadBearingUninspectableKeys.length);
+    expect(hb.loadBearingUninspectableKeys).toEqual(
+      [...invWith().summary.loadBearingUninspectableKeys].sort((a, b) => a.localeCompare(b)),
+    );
     expect(hb.loadBearingSoakingKeys).toEqual([]);
     expect(hb.loadBearingAcceptedKeys).toEqual([]);
+  });
+
+  it('refuses the heartbeat false all-clear for an errored load-bearing guard and caps per-tick keys', () => {
+    const registry = new GuardRegistry();
+    registry.register(LB_KEY, () => {
+      throw new Error('status getter failed');
+    });
+    const snapshot: ResolvedGuardConfigSnapshot = {
+      resolved: { multiMachine: { sessionPool: { inboundQueue: { enabled: true } } } },
+      defaults: { multiMachine: { sessionPool: { inboundQueue: { enabled: false } } } },
+      fileAbsent: false,
+    };
+    const inv = buildGuardInventory({
+      snapshot,
+      bootSnapshot: {
+        ts: new Date(DECLARED).toISOString(),
+        posture: { [LB_KEY]: true },
+      },
+      registry,
+      now: DECLARED,
+    });
+    const extraKeys = Array.from(
+      { length: HEARTBEAT_LOAD_BEARING_UNINSPECTABLE_KEY_CAP + 3 },
+      (_, i) => `synthetic.loadBearing.${String(i).padStart(2, '0')}`,
+    );
+    inv.summary.loadBearingUninspectableKeys = [LB_KEY, ...extraKeys];
+
+    const hb = buildHeartbeatPostureBlock(inv, '2026-07-01T00:00:00.000Z');
+    expect(hb.loadBearingGapKeys).not.toContain(LB_KEY);
+    expect(hb.loadBearingUninspectable).toBe(1 + extraKeys.length);
+    expect(hb.loadBearingUninspectableKeys).toContain(LB_KEY);
+    expect(hb.loadBearingUninspectableKeys).toHaveLength(HEARTBEAT_LOAD_BEARING_UNINSPECTABLE_KEY_CAP);
   });
 });
 

--- a/tests/unit/monitoring/guard-posture-probe-loadbearing.test.ts
+++ b/tests/unit/monitoring/guard-posture-probe-loadbearing.test.ts
@@ -261,6 +261,34 @@ describe('GuardPostureProbe — G3 separate episode track (real createAttentionI
     expect(adapter.getAttentionItems().filter((i) => i.category === 'guard-posture')).toEqual([]);
   });
 
+  it('a peer uninspectable list is read-only context: errored still emits exactly one existing anomaly and no notification track', async () => {
+    const peerPosture: GuardPostureSummary = {
+      onConfirmed: 0, onUnverified: 0, onStale: 0, onDryRun: 0,
+      offDeviant: 0, offDeviantKeys: [], offRuntimeDivergent: 0, offRuntimeDivergentKeys: [],
+      divergedPendingRestart: 0, errored: 1, missing: 0,
+      loadBearingGapKeys: [],
+      loadBearingUninspectable: 1,
+      loadBearingUninspectableKeys: [LB_KEY],
+      generatedAt: new Date().toISOString(),
+    };
+    const peers: PeerPostureRead[] = [{
+      machineId: 'm-peer',
+      nickname: 'peer',
+      online: true,
+      posture: peerPosture,
+      postureAgeMs: 1_000,
+    }];
+    const probe = makeProbe(() => inventory([]), peers);
+    await probe.run();
+    await probe.run();
+
+    const attention = adapter.getAttentionItems().filter((item) => item.category === 'guard-posture');
+    expect(attention).toHaveLength(1);
+    expect(attention[0].id).toBe('guard-posture:ep-1');
+    expect(attention[0].summary).toContain('errored');
+    expect(adapter.getAttentionItem('guard-posture-loadbearing:ep-1')).toBeUndefined();
+  });
+
   it('operator-accept on THIS machine does NOT silence a peer gap (per-machine independence)', async () => {
     // Local guard is ACCEPTED (loadBearingAccepted, no gap) — but the peer's
     // heartbeat still reports it as a gap → the peer gap surfaces.

--- a/upgrades/eli16/guard-heartbeat-unproven-summary.md
+++ b/upgrades/eli16/guard-heartbeat-unproven-summary.md
@@ -1,0 +1,44 @@
+# Fleet guard-posture completeness — Plain-English Overview
+
+> The one-line version: every machine now carries a bounded list of load-bearing protections it cannot currently prove, and the fleet view displays that list without creating another alarm.
+
+## The problem in one breath
+
+The local guard readout already distinguishes two different questions: which critical protections are silently unguarded, and which critical protections are loudly unproven because their posture is missing, errored, stale, or contradicted by runtime state. The compact heartbeat omitted the second answer. That meant the cross-machine view could still show an empty critical-gap list and be mistaken for a complete all-clear even though the sending machine had explicitly found a load-bearing protection it could not prove.
+
+## What already exists
+
+- **Local guard inventory** — names load-bearing guards in the four existing unproven posture classes while leaving them out of the silent-gap class.
+- **Guard posture alarms** — raise the existing missing, errored, stale, or runtime-divergent anomaly. They deliberately do not raise a second load-bearing-gap alarm for the same guard.
+- **Machine heartbeat and pool view** — carry a compact guard-posture block from each machine and retain its last known value for a dark peer.
+- **Machines dashboard** — reads the pool response and opens a per-machine detail record.
+
+## What this adds
+
+The heartbeat gains a full count and a bounded key sample for load-bearing protections whose existing posture cannot currently prove protection. The producer sorts the keys and sends at most 16 of them. Sixteen covers all 13 load-bearing guards in today’s manifest, and the uncapped count remains present if the manifest later grows past the key ceiling, so truncation is visible rather than becoming another false all-clear.
+
+The machine detail record displays the count and the keys received from that machine. If the count is larger than the key sample, it says how many keys are shown. This is the actual reader for the new wire field; it prevents the fix from stopping at a decorative payload that no operator surface consumes.
+
+## The new pieces
+
+- **Bounded heartbeat projection** — copies the already-derived unproven list into a count plus at most 16 deterministic keys. It cannot classify a guard, change a gap, or trigger an action.
+- **Fleet detail rendering** — displays “Load-bearing protection unproven” inside the existing machine record. It does not change the machine headline, attention tile, warning tone, or notification path.
+- **Durable semantic comparison** — treats the new count and key sample as meaningful heartbeat state, so a changed sample persists even when the older aggregate posture counts happen to remain equal.
+
+## The safeguards
+
+**Prevents double-alarming.** The peer probe continues to ignore the new fields. A load-bearing errored guard still produces exactly one existing errored anomaly and no load-bearing-gap episode or fleet notification.
+
+**Prevents classification drift.** The local effective-state precedence, `loadBearingGap` membership, gap keys, and machine-health calculation are unchanged. The new fields are a read-only projection of an existing list.
+
+**Prevents heartbeat growth from becoming open-ended.** At most 16 key strings ride each 30-second heartbeat. The full count travels independently, so a future seventeenth key is omitted from the sample but not from the truth.
+
+**Refuses a decorative wire field.** Unit coverage pins the producer, bound, and no-second-alarm rule. Integration coverage carries the fields through durable pool state and the real `/pool` route. End-to-end coverage opens the shipped Machines glance and requires the remote key to appear in the machine record.
+
+## What ships when
+
+This is one additive patch completing the same guard-read-surface item as the local summary. Older peers and consumers remain compatible because the two wire members are optional on read; upgraded senders always emit both.
+
+## What you actually need to decide
+
+Does this patch complete the cross-machine read without changing any existing guard classification, anomaly, notification, or fleet-health decision?

--- a/upgrades/next/guard-heartbeat-unproven-summary.md
+++ b/upgrades/next/guard-heartbeat-unproven-summary.md
@@ -1,0 +1,24 @@
+# Upgrade Guide — vNEXT
+<!-- bump: patch -->
+
+## What Changed
+
+Completed the guard-posture false-all-clear fix across machines. Capacity heartbeats now carry the full count and at most 16 sorted keys for load-bearing protections whose existing posture is `missing`, `errored`, `on-stale`, or `off-runtime-divergent`. The Machines dashboard displays that read-only result in each machine’s detail record. Existing guard classification, critical-gap membership, machine health, probe anomalies, and notifications are unchanged.
+
+The key ceiling is explicit: today’s 13 load-bearing guards all fit, while a future larger set keeps its full count and marks a truncated sample instead of growing every 30-second heartbeat without bound.
+
+## What to Tell Your User
+
+The cross-machine safety-check view now says when a machine cannot prove a critical protection, instead of letting an empty critical-gap list look like a complete all-clear. This adds detail only; it does not create another alert.
+
+## Summary of New Capabilities
+
+- Machine details now show load-bearing protections that are loudly unproven.
+- The frequent heartbeat carries a bounded key sample plus the complete count.
+
+## Evidence
+
+- Refusal-first unit coverage failed before implementation because the heartbeat dropped the list and the fleet record did not display it.
+- Unit coverage constructs an errored load-bearing guard and proves it stays out of the gap list, enters the new bounded heartbeat list, and produces exactly one existing anomaly with no second notification track.
+- Integration coverage proves the fields survive heartbeat persistence and the real authenticated `/pool` route.
+- End-to-end coverage opens the shipped Machines glance and requires the remote guard key in the machine record.

--- a/upgrades/side-effects/guard-heartbeat-unproven-summary.md
+++ b/upgrades/side-effects/guard-heartbeat-unproven-summary.md
@@ -1,0 +1,137 @@
+# Side-Effects Review — Fleet guard-posture completeness
+
+**Version / slug:** `guard-heartbeat-unproven-summary`
+**Date:** `2026-07-25`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `heartbeat_guard_review`
+
+## Summary of the change
+
+`src/monitoring/guardPostureView.ts` projects the existing `loadBearingUninspectableKeys` summary into the capacity heartbeat as a full `loadBearingUninspectable` count plus at most 16 sorted keys. `src/core/types.ts` adds the optional wire members, and `src/core/GuardPostureStore.ts` includes them in write-on-change semantic equality. `dashboard/glance.js` displays the received count and keys in the existing per-machine Layer-3 record. No guard row, gap membership, anomaly, attention item, notification, machine-health calculation, or placement decision changes.
+
+## Decision-point inventory
+
+No block/allow or actuation decision point is added or modified.
+
+- `buildHeartbeatPostureBlock` — **modify** — adds a bounded read-only projection of an existing summary list.
+- `GuardPostureStore.postureSemanticsEqual` — **modify** — recognizes changes to the new wire fields for persistence; it does not decide posture or liveness.
+- `machineRecordNode` — **modify** — displays received data at Layer 3 only.
+- `GuardPostureProbe` — **pass-through** — deliberately unchanged; it continues to alarm only the pre-existing posture and gap classes.
+- `guardPostureProblems` / `machineNeedsAttention` — **pass-through** — deliberately unchanged; the new field cannot alter fleet health or attention classification.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The producer accepts every existing inventory, and older heartbeat payloads without the optional fields remain valid.
+
+---
+
+## 2. Under-block
+
+The 16-key sample can omit individual keys if the load-bearing manifest grows beyond 16, but the full count makes that truncation explicit and the dashboard says how many keys are shown. Today’s manifest contains 13 load-bearing guards, so every current key fits.
+
+One adjacent persistence limitation was observed and left unchanged: `GuardPostureStore.postureSemanticsEqual` does not compare the three older `loadBearingGapKeys`, `loadBearingSoakingKeys`, or `loadBearingAcceptedKeys` lists. Live in-memory posture still updates before the equality check, but a keys-only change to one of those older lists may not be written for restart recovery when every compared count stays equal. This PR compares only the two new fields required for its own durable wiring. The adjacent finding is reported to Echo and is neither fixed nor filed here.
+
+By instruction, the field name retains the earlier `Uninspectable` wording even though `off-runtime-divergent` is more precisely “inspected but unproven.” The code comment and operator label use “cannot prove protection” / “unproven,” preserving wire compatibility without a behavior-free rename.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The projection belongs in `buildHeartbeatPostureBlock`, which already translates the complete local inventory into the compact wire shape. It reuses the canonical list instead of re-deriving posture in the heartbeat or dashboard. The 16-key clamp is a transport bound, not a posture heuristic. Display belongs in the existing machine record because `/pool` is the fleet heartbeat consumer and that record already renders the machine’s guard counts.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP. Reshape the design.
+
+The new heartbeat members can only describe already-derived state. Neither the store nor the dashboard can enable, disable, suppress, alarm, notify, place, or authorize anything from them. Existing authorities receive byte-for-byte equivalent inputs because the probe does not read the new members.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic is added at a competing-signals decision point. Membership comes from the existing closed list. The number 16 is an explicit transport ceiling over a deterministic sample, paired with an uncapped count; it does not decide whether protection is healthy.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none. Posture classification and summary assembly complete before heartbeat projection. The dashboard reads the result after pool ingestion.
+- **Double-fire:** structurally prevented. No new call to `emitAttention`, `createAttentionItem`, notification code, or probe evaluator exists. The peer refusal test presents `errored: 1` together with the new key and obtains exactly one existing acute episode and no load-bearing episode.
+- **Races:** no new concurrent state is introduced. `MachinePoolRegistry` already replaces its in-memory posture on each beat; the store’s existing synchronous write-on-change path receives two more compared fields.
+- **Feedback loops:** none. `/pool` and the Machines glance are read surfaces. The displayed value is never fed into guard evaluation, machine health, routing, placement, or messaging.
+- **Compatibility:** the wire fields are optional for old persisted records and old peers. The renderer falls back to the key-array length when a transitional payload has keys but no count and refuses to display a count smaller than the keys actually present.
+- **Payload:** the new list is sorted and sliced to 16. The full count is one number; there is no unbounded free text.
+
+---
+
+## 6. External surfaces
+
+Authenticated `/pool` callers receive two additive optional members inside each machine’s existing `guardPosture` block. The Machines dashboard displays them in the existing machine detail record. No response status, authentication rule, peer URL, external-service call, Telegram/Slack message, attention item, or notification changes.
+
+The persisted `guard-posture-peers.json` may contain the two additive fields after an upgraded heartbeat. Old records deserialize because the fields are optional; rollback ignores the extra JSON members.
+
+No operator-facing action is added. The surface is diagnostic only: there is no grant, approval, destructive operation, or laptop-only workflow.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+1. **Leads with the primary action?** There is no action. The new answer appears directly in the already-open machine record beside its other safety-check facts; it is not hidden behind another toggle.
+2. **Zero raw internals as primary content?** The plain label is “Load-bearing protection unproven.” Guard keys are supporting identifiers after the human-readable count, not headline or tile content.
+3. **Destructive actions de-emphasized?** No destructive or constructive control is added.
+4. **Plain language + phone width?** The label is plain language and the existing record value style uses `overflow-wrap: anywhere`, so long guard keys wrap instead of forcing horizontal scroll. The change adds no table or fixed-width element. Unit, integration, and end-to-end DOM tests open the real Layer-3 record and require the count/key text; the existing phone-width record layout and tap targets are unchanged.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: replicated via heartbeat.** Each machine derives its own machine-local guard truth and includes the bounded projection in its normal capacity heartbeat. `MachinePoolRegistry` receives it, `GuardPostureStore` retains the last known value for a dark peer, `GET /pool` returns it, and the Machines glance displays it with that machine’s identity.
+
+It emits no user-facing notice, so one-voice gating is not needed. It adds no new store or topic-bound state; it extends the existing per-machine posture record. It generates no URLs. The peer probe deliberately ignores the field, preventing a per-machine multiplication of notices.
+
+---
+
+## 8. Rollback cost
+
+Revert the two wire members, producer projection, semantic comparison, dashboard row, and tests, then ship a patch. Existing persisted JSON may retain unknown additive members, which older code ignores. There is no schema migration, database cleanup, agent reset, user notification, or classification repair.
+
+---
+
+## Conclusion
+
+The change completes the second read surface without creating a second behavioral system. The heartbeat is explicitly bounded, the count preserves truth under truncation, the fleet reader displays the field, and all existing authority paths remain unchanged. Refusal-first tests pin the errored guard’s exclusion from `loadBearingGapKeys`, inclusion in the new list, exactly one existing anomaly with no notification track, the 16-key ceiling, persistence, real `/pool` exposure, and end-to-end display.
+
+---
+
+## Second-pass review (required: guard-related change)
+
+**Reviewer:** `heartbeat_guard_review`
+
+**Independent read of the artifact:** Concur with the review: the errored load-bearing guard remains outside `loadBearingGapKeys`; the heartbeat adds only an honest full count plus a deterministic 16-key sorted sample; probe, notification, and machine-health decision paths do not consume the new fields; persistence and the real `/pool` → Machines record path are wired; and the focused unit/integration/e2e suite passes 98/98 with direct refusal assertions for field omission, count dishonesty, cap removal, persistence loss, and display loss. I found no inaccurate artifact claim or adjacent scope drift requiring rework.
+
+---
+
+## Evidence pointers
+
+- Before implementation, the focused unit suite failed three assertions: the heartbeat count/list were absent and the machine record omitted the load-bearing-unproven row.
+- Unit: 67/67 across producer, probe refusal, and dashboard drill-down suites.
+- Integration: 26/26 across heartbeat persistence, real `/pool`, and Machines glance wiring.
+- E2E: 5/5 in the shipped jargon-belt Machines lifecycle.
+- Static/build: `npm run lint` and `npm run build` pass without threshold changes.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller change — not applicable.


### PR DESCRIPTION
## Description

Completes the same guard read-surface defect fixed locally in #1642 on the cross-machine heartbeat and fleet reader.

The root cause was a projection gap: `buildHeartbeatPostureBlock` carried the silent load-bearing gap, soaking, and accepted lists, but dropped `loadBearingUninspectableKeys`. A reader of the pool view could therefore mistake absence of that class for a complete all-clear.

This PR:

- carries the full `loadBearingUninspectable` count plus at most 16 sorted `loadBearingUninspectableKeys` on the 30-second heartbeat;
- preserves those fields in durable peer posture state;
- displays the count and bounded keys in the existing Machines detail record;
- leaves guard classification, `loadBearingGapKeys`, machine health, `GuardPostureProbe`, attention items, and notifications unchanged.

The 16-key cap covers all 13 load-bearing guards in the current manifest. If that set grows, the full count remains honest and the fleet record says how many keys are shown.

## ELI16 — Cross-machine guard health no longer hides missing proof

A machine already knew the difference between a critical safety check that was quietly switched off and one it tried to inspect but could not prove healthy. The short status message sent to other machines only carried the first answer, so the fleet view could look clean while important evidence was missing. This change sends the second answer too, with a strict size limit: the message carries the complete number and at most 16 check names. The machine details page shows that information, but it does not create another alert or change whether the machine is called healthy. Existing alarms still speak once under their original reason.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## UX Impact

Who sees it: operators opening a machine in the Machines dashboard.

User-visible behavior: the Layer-3 record now shows `Load-bearing protection unproven` followed by the full count and the bounded key sample. The front-page headline, Attention needed tile, warning tone, and all notifications remain exactly as before.

First contact: an operator diagnosing a peer now sees the missing critical-path evidence in the same machine record as its existing safety-check counts; no new prompt or action is introduced.

## Safety / refusal evidence

- An errored load-bearing guard remains absent from `loadBearingGapKeys`.
- The new heartbeat list contains it and is capped at 16 deterministic keys while retaining the full count.
- The peer probe produces exactly one existing errored anomaly, no load-bearing-gap episode, and no additional notification track.
- A payload containing only the new fields does not change machine health classification.
- The field is required through durable pool state, the real `/pool` route, and the shipped Machines record.

## Validation

- 67 unit assertions passed.
- 26 integration assertions passed.
- 5 end-to-end assertions passed.
- Independent guard review passed all 98 focused assertions and concurred with the side-effects artifact.
- `npm run lint` passed.
- `npm run build` passed.
- Repository invariants passed.
- No budget, threshold, classification, or notification rule was raised or relaxed.

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My code follows the project's style (TypeScript strict mode)
- [x] I have added tests for my changes
- [x] Focused unit, integration, and e2e tests pass locally
- [x] `npm run build` passes locally
- [x] I have updated documentation
