### PR TITLE
fix(review-health): a reviewer that never ran reported a PERFECT pass rate

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T04-02-00-091Z-reviewer-health-unobserved.json
+++ b/.instar/instar-dev-decisions/2026-07-26T04-02-00-091Z-reviewer-health-unobserved.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T04:02:00.091Z",
+  "slug": "reviewer-health-unobserved",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 98,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/reviewer-health-unobserved.eli16.md
+++ b/docs/specs/reviewer-health-unobserved.eli16.md
@@ -1,0 +1,81 @@
+# A reviewer that never ran reported a perfect score — Plain-English Overview
+
+> The one-line version: the health check for the reviewers that vet my outgoing messages
+> gave a never-executed reviewer a flawless pass rate and a clean bill of health, so
+> "nothing has happened here" was impossible to tell apart from "everything is fine."
+
+## The problem in one breath
+
+Before a message of mine goes out, a set of reviewers can look at it. There is a health
+page for those reviewers. If a reviewer had never actually run — not once — that page
+reported it as scoring one hundred percent and being healthy. Not a blank, not a zero, but
+a perfect score, invented from no data at all. Anyone opening that page to ask "is this
+working?" got a confident yes from something that had never done anything.
+
+## What already exists
+
+- **The reviewers** — a set of checks that read a finished message and give an opinion.
+  On most installs, including this one, they are switched off entirely.
+- **The health page** — shows, per reviewer, how often it passed and whether it looks
+  healthy. This is what had the problem.
+- **A second, similar page** — the same numbers in a slightly different shape, for a
+  dashboard. It had the same problem, with a twist described below.
+- **A counter elsewhere in the same file** that already tracked "has this reviewer actually
+  run?" as a simple yes/no. The information needed to avoid the whole problem was already
+  being calculated a hundred lines away. The health pages just never looked at it.
+
+## What this adds
+
+A score is now reported as *nothing* when there is nothing to score, instead of as a number
+that reads like good news. The count of observations always travels beside the score, so a
+reader can see what it was calculated from. And a reviewer only gets called healthy once
+there is enough evidence to say so — five observations — with a new fourth state,
+"unobserved," for everything below that.
+
+The important asymmetry: the evidence requirement only holds back **good** news. A reviewer
+that failed on both of its only two attempts is still reported as failing. Requiring
+evidence before believing something is fine is prudent; requiring evidence before admitting
+something is broken would just be the same bug facing the other way.
+
+## The new pieces
+
+- **"Unobserved"** — a fourth answer alongside healthy, degraded and failing. It is
+  deliberately not an alarm. It means nothing is wrong and nothing is known yet, which is
+  a different and more useful thing to say than either "fine" or "broken."
+- **An evidence floor** — five observations before the word "healthy" is used. This is not
+  a new rule invented for this fix. Another part of the system computes the very same kind
+  of score and already refuses to act on it below a hundred observations. That guard is
+  precisely why the identical line of arithmetic is harmless there and was a bug here. So
+  this is one place being brought in line with a habit the codebase already keeps.
+
+## The safeguards
+
+The second page had the same defect pointing in **both** directions at once: the same
+quantity defaulted to zero in one place and to a perfect one in the other, about a hundred
+lines apart in a single file — and it also claimed flawless formatting from a reviewer that
+had never read a single response. Two opposite defaults for one number is the sign that
+neither was thought about, so both were fixed together rather than one being tidied while
+its twin was left.
+
+Nothing here can block, delay or change a message. These are read-only displays, and the
+only thing that consumes them is the page that shows them — checked, not assumed. An
+earlier claim that this surface controlled whether the reviewers get switched from watching
+to blocking was **wrong**, and was withdrawn once the connection was actually looked for.
+
+## Why the tests mattered more than the code
+
+Two existing tests were changed, and the reason is the more interesting half of this.
+
+One honestly said "reports healthy status when no reviews have run" — and asserted it. The
+bug was pinned in place as intended behaviour, so it could never be noticed by running the
+suite.
+
+The other was named "detects degraded status when error rate is high." Its own comment
+promised to simulate a high error rate by adjusting the numbers. **That simulation was
+never written.** The test created a fresh reviewer and asserted it was healthy. So the two
+paths it was named after had no coverage at all, while a green test carrying their name sat
+in the suite looking like proof they worked.
+
+That is the same shape as the original bug, one level up: a passing test named for a check
+is indistinguishable from that check actually being verified. The test now performs the
+simulation its comment described, and the previously untested paths are covered.

--- a/src/core/CoherenceGate.ts
+++ b/src/core/CoherenceGate.ts
@@ -263,6 +263,21 @@ interface ValueDocCache {
 
 const VALUE_DOC_CACHE_TTL_MS = 60 * 60 * 1000; // 60 minutes
 
+/**
+ * Observations a reviewer needs before its rates support a 'healthy' VERDICT.
+ *
+ * This is not a new discipline — it adopts a precedent this codebase already keeps.
+ * `SelfActionGovernor.checkObserveLimbo` computes the same shape of rate
+ * (`total > 0 ? wouldDeny / total : 0`) but gates its promotion criterion on
+ * `total >= 100`, so a zero-observation rate can never satisfy it. That guard is why
+ * the identical expression is harmless there and was a defect here.
+ *
+ * The floor is smaller (5, not 100) because this surface reports health continuously
+ * rather than gating a one-way promotion, so it has to become useful sooner. It gates
+ * ONLY the optimistic conclusion; a genuine failure on thin evidence is still reported.
+ */
+const REVIEWER_HEALTH_MIN_OBSERVATIONS = 5;
+
 // ── Main Class ───────────────────────────────────────────────────────
 
 /**
@@ -1645,13 +1660,21 @@ export class CoherenceGate {
     for (const [name, reviewer] of this.reviewers) {
       const m = reviewer.metrics;
       const total = m.passCount + m.failCount + m.errorCount;
+      // Every rate here is null on zero observations rather than a hardcoded default.
+      // Before this, the SAME quantity had OPPOSITE defaults in the two health surfaces
+      // of this one file: `passRate: 0` here (pessimistic) and `passRate: 1` in
+      // getReviewerHealth (optimistic) — and `jsonValidityRate: 1` claimed perfect JSON
+      // validity from a reviewer that had never parsed anything. Neither default was
+      // reasoned about; a reader could not tell "measured" from "not measured".
       perReviewer[name] = {
-        passRate: total > 0 ? m.passCount / total : 0,
-        flagRate: total > 0 ? m.failCount / total : 0,
-        errorRate: total > 0 ? m.errorCount / total : 0,
-        avgLatencyMs: total > 0 ? Math.round(m.totalLatencyMs / total) : 0,
-        jsonValidityRate: total > 0 ? 1 - (m.jsonParseErrors / total) : 1,
+        passRate: total > 0 ? m.passCount / total : null,
+        flagRate: total > 0 ? m.failCount / total : null,
+        errorRate: total > 0 ? m.errorCount / total : null,
+        avgLatencyMs: total > 0 ? Math.round(m.totalLatencyMs / total) : null,
+        jsonValidityRate: total > 0 ? 1 - (m.jsonParseErrors / total) : null,
         total,
+        insufficientEvidence: total < REVIEWER_HEALTH_MIN_OBSERVATIONS,
+        observationsRequired: REVIEWER_HEALTH_MIN_OBSERVATIONS,
       };
     }
 
@@ -1750,32 +1773,52 @@ export class CoherenceGate {
    * Get reviewer health — per-reviewer pass rate relative to baseline expectations.
    */
   getReviewerHealth(): ReviewerHealthReport {
-    const reviewerHealth: Record<string, {
-      passRate: number;
-      total: number;
-      status: 'healthy' | 'degraded' | 'failing';
-    }> = {};
+    const reviewerHealth: ReviewerHealthReport['reviewers'] = {};
 
     for (const [name, reviewer] of this.reviewers) {
       const m = reviewer.metrics;
       const total = m.passCount + m.failCount + m.errorCount;
-      const passRate = total > 0 ? m.passCount / total : 1;
-      const errorRate = total > 0 ? m.errorCount / total : 0;
 
-      let status: 'healthy' | 'degraded' | 'failing' = 'healthy';
-      if (errorRate > 0.5 || (total > 10 && passRate < 0.1)) {
+      // A rate over zero observations is not a rate. Report null rather than a
+      // number the reader cannot distinguish from a measured one.
+      const passRate = total > 0 ? m.passCount / total : null;
+      const errorRate = total > 0 ? m.errorCount / total : null;
+      const insufficientEvidence = total < REVIEWER_HEALTH_MIN_OBSERVATIONS;
+
+      // The floor gates only the OPTIMISTIC conclusion. A reviewer that errored on
+      // both of its two calls IS failing, and thin evidence must never suppress bad
+      // news — only the claim "this is healthy" needs a sample behind it.
+      let status: ReviewerHealthStatus;
+      if (errorRate !== null && (errorRate > 0.5 || (total > 10 && passRate !== null && passRate < 0.1))) {
         status = 'failing';
-      } else if (errorRate > 0.2 || m.jsonParseErrors > total * 0.3) {
+      } else if (errorRate !== null && (errorRate > 0.2 || m.jsonParseErrors > total * 0.3)) {
         status = 'degraded';
+      } else if (insufficientEvidence) {
+        // Includes total === 0 ("never ran"). Distinguishable from 'healthy' by the
+        // reader AND by any consumer switching on status.
+        status = 'unobserved';
+      } else {
+        status = 'healthy';
       }
 
-      reviewerHealth[name] = { passRate, total, status };
+      reviewerHealth[name] = {
+        passRate,
+        errorRate,
+        total,
+        observationsRequired: REVIEWER_HEALTH_MIN_OBSERVATIONS,
+        insufficientEvidence,
+        status,
+      };
     }
 
+    // Precedence: bad news outranks thin evidence, which outranks a healthy claim.
+    // 'unobserved' must never aggregate up as 'healthy' — that was the defect.
     const allStatuses = Object.values(reviewerHealth).map(r => r.status);
-    let overallStatus: 'healthy' | 'degraded' | 'failing' = 'healthy';
+    let overallStatus: ReviewerHealthStatus = 'healthy';
     if (allStatuses.includes('failing')) overallStatus = 'failing';
     else if (allStatuses.includes('degraded')) overallStatus = 'degraded';
+    else if (allStatuses.includes('unobserved')) overallStatus = 'unobserved';
+    else if (allStatuses.length === 0) overallStatus = 'unobserved'; // no reviewers at all
 
     return {
       overallStatus,
@@ -1988,12 +2031,27 @@ export interface CanaryTestResult {
   pass: boolean;
 }
 
+/**
+ * `unobserved` exists because the absence of observations previously rendered as the
+ * presence of good ones: a reviewer that had never run once reported `passRate: 1` and
+ * `status: 'healthy'`. Read a fourth state as "no verdict yet", never as a problem.
+ */
+export type ReviewerHealthStatus = 'healthy' | 'degraded' | 'failing' | 'unobserved';
+
 export interface ReviewerHealthReport {
-  overallStatus: 'healthy' | 'degraded' | 'failing';
+  overallStatus: ReviewerHealthStatus;
   reviewers: Record<string, {
-    passRate: number;
+    /** null when there are no observations — a rate over zero calls is not a rate. */
+    passRate: number | null;
+    /** Exposed because it DRIVES the verdict; a hidden input to a decision is unauditable. */
+    errorRate: number | null;
+    /** The denominator. Always present, so any rate above can be judged. */
     total: number;
-    status: 'healthy' | 'degraded' | 'failing';
+    /** Observations a 'healthy' verdict requires. */
+    observationsRequired: number;
+    /** true when `total < observationsRequired` (includes never-ran). */
+    insufficientEvidence: boolean;
+    status: ReviewerHealthStatus;
   }>;
   lastCanaryRun: CanaryTestResult[] | null;
 }

--- a/tests/unit/CoherenceGateCanary.test.ts
+++ b/tests/unit/CoherenceGateCanary.test.ts
@@ -133,13 +133,89 @@ describe('CoherenceGate — Canary & Health', () => {
   // ── Reviewer Health ────────────────────────────────────────────────
 
   describe('reviewer health', () => {
-    it('reports healthy status when no reviews have run', () => {
+    // REPLACES a test that asserted `overallStatus === 'healthy'` when no reviews had
+    // run. That assertion pinned the defect in place as correct behaviour: a reviewer
+    // that had never executed once reported `passRate: 1` (a PERFECT score) and
+    // `status: 'healthy'`, so the absence of observations was indistinguishable from
+    // the presence of good ones. The name of the old test — "reports healthy status
+    // when no reviews have run" — described the bug accurately; only the expectation
+    // that this was DESIRABLE was wrong.
+    it('refuses to call a reviewer that has NEVER RUN healthy, and reports no rate for it', () => {
       const gate = createGate();
       const health = gate.getReviewerHealth();
 
-      expect(health.overallStatus).toBe('healthy');
-      expect(health.reviewers).toBeDefined();
+      expect(health.overallStatus).toBe('unobserved');
+      expect(Object.keys(health.reviewers).length).toBeGreaterThan(0);
+
+      for (const [name, r] of Object.entries(health.reviewers)) {
+        expect(r.status, `${name} never ran`).toBe('unobserved');
+        // A rate over zero observations is not a rate.
+        expect(r.passRate, `${name} passRate`).toBeNull();
+        expect(r.errorRate, `${name} errorRate`).toBeNull();
+        // The denominator is always present so the reader can see WHY there is no rate.
+        expect(r.total).toBe(0);
+        expect(r.insufficientEvidence).toBe(true);
+        expect(r.observationsRequired).toBeGreaterThan(0);
+      }
+
       expect(health.lastCanaryRun).toBeNull();
+    });
+
+    it('does not let thin evidence read as a proven pass rate', () => {
+      const gate = createGate();
+      // ONE passing observation. The rate is a truthful 1.0 — but 1-of-1 is not a
+      // basis for the verdict "healthy", which is the only thing the floor gates.
+      const reviewers = (gate as unknown as { reviewers: Map<string, { metrics: Record<string, number> }> }).reviewers;
+      const first = [...reviewers.values()][0];
+      first.metrics.passCount = 1;
+
+      const r = gate.getReviewerHealth();
+      const entry = Object.values(r.reviewers).find(x => x.total === 1)!;
+      expect(entry.passRate).toBe(1);          // the rate is reported honestly
+      expect(entry.status).toBe('unobserved'); // the VERDICT is withheld
+      expect(entry.insufficientEvidence).toBe(true);
+    });
+
+    it('still reports FAILING on thin evidence — the floor gates optimism only, never bad news', () => {
+      const gate = createGate();
+      const reviewers = (gate as unknown as { reviewers: Map<string, { metrics: Record<string, number> }> }).reviewers;
+      const first = [...reviewers.values()][0];
+      // Errored on both of its only two calls. Below the observation floor, but a
+      // failure is a failure — suppressing it "for want of samples" would recreate
+      // the original defect pointing the other way.
+      first.metrics.errorCount = 2;
+
+      const r = gate.getReviewerHealth();
+      const entry = Object.values(r.reviewers).find(x => x.total === 2)!;
+      expect(entry.errorRate).toBe(1);
+      expect(entry.status).toBe('failing');
+      expect(r.overallStatus).toBe('failing');
+    });
+
+    it('reports HEALTHY once there is enough evidence to support the claim', () => {
+      const gate = createGate();
+      const reviewers = (gate as unknown as { reviewers: Map<string, { metrics: Record<string, number> }> }).reviewers;
+      for (const rv of reviewers.values()) rv.metrics.passCount = 20;
+
+      const r = gate.getReviewerHealth();
+      expect(r.overallStatus).toBe('healthy');
+      for (const entry of Object.values(r.reviewers)) {
+        expect(entry.status).toBe('healthy');
+        expect(entry.passRate).toBe(1);
+        expect(entry.insufficientEvidence).toBe(false);
+      }
+    });
+
+    it('overallStatus never aggregates an unobserved reviewer as healthy', () => {
+      const gate = createGate();
+      const reviewers = (gate as unknown as { reviewers: Map<string, { metrics: Record<string, number> }> }).reviewers;
+      const all = [...reviewers.values()];
+      // All but one well-observed and clean; one never ran.
+      for (const rv of all.slice(1)) rv.metrics.passCount = 20;
+
+      const r = gate.getReviewerHealth();
+      // The healthy majority must not drown out the one we know nothing about.
+      expect(r.overallStatus).toBe('unobserved');
     });
 
     it('reports per-reviewer health metrics', async () => {
@@ -163,18 +239,68 @@ describe('CoherenceGate — Canary & Health', () => {
         expect(reviewer).toHaveProperty('passRate');
         expect(reviewer).toHaveProperty('total');
         expect(reviewer).toHaveProperty('status');
-        expect(['healthy', 'degraded', 'failing']).toContain(reviewer.status);
+        // 'unobserved' included: a reviewer with no observations must be reportable as
+        // such rather than being forced into one of the three verdict states.
+        expect(['healthy', 'degraded', 'failing', 'unobserved']).toContain(reviewer.status);
       }
     });
 
+    // This test previously carried the comment "Simulate high error rate by directly
+    // manipulating metrics" — and then manipulated nothing. It created a fresh gate and
+    // asserted `overallStatus === 'healthy'`, so despite its name it exercised the
+    // never-ran path and left `degraded` and `failing` with ZERO coverage while sitting
+    // green in the suite. A passing test named for a check is indistinguishable from
+    // that check being verified. It now performs the simulation its own comment described.
     it('detects degraded status when error rate is high', () => {
       const gate = createGate();
-      // Simulate high error rate by directly manipulating metrics
-      // (In production, this would happen from real API failures)
-      const health = gate.getReviewerHealth();
+      const reviewers = (gate as unknown as { reviewers: Map<string, { metrics: Record<string, number> }> }).reviewers;
+      const first = [...reviewers.values()][0];
+      // 3 errors in 10 calls = 0.3 — above the 0.2 degraded threshold, below the 0.5
+      // failing one, and well past the observation floor so the verdict is supported.
+      first.metrics.passCount = 7;
+      first.metrics.errorCount = 3;
 
-      // Fresh reviewers should all be healthy
-      expect(health.overallStatus).toBe('healthy');
+      const health = gate.getReviewerHealth();
+      const entry = Object.values(health.reviewers).find(x => x.total === 10)!;
+      expect(entry.errorRate).toBeCloseTo(0.3, 5);
+      expect(entry.status).toBe('degraded');
+      expect(health.overallStatus).toBe('degraded');
+    });
+
+    it('detects failing status when the error rate is past the failing threshold', () => {
+      const gate = createGate();
+      const reviewers = (gate as unknown as { reviewers: Map<string, { metrics: Record<string, number> }> }).reviewers;
+      const first = [...reviewers.values()][0];
+      first.metrics.passCount = 2;
+      first.metrics.errorCount = 8; // 0.8 > 0.5
+
+      const health = gate.getReviewerHealth();
+      const entry = Object.values(health.reviewers).find(x => x.total === 10)!;
+      expect(entry.status).toBe('failing');
+      expect(health.overallStatus).toBe('failing');
+    });
+
+    it('getReviewerStats reports null rates — not zeros or a perfect score — when nothing ran', () => {
+      const gate = createGate();
+      const stats = gate.getReviewerStats() as Record<string, Record<string, {
+        passRate: number | null; flagRate: number | null; errorRate: number | null;
+        avgLatencyMs: number | null; jsonValidityRate: number | null;
+        total: number; insufficientEvidence: boolean;
+      }>>;
+      const perReviewer = stats.reviewers;
+      expect(Object.keys(perReviewer).length).toBeGreaterThan(0);
+      for (const [name, r] of Object.entries(perReviewer)) {
+        // Before: passRate 0 here but 1 in getReviewerHealth — the same quantity with
+        // opposite defaults in one file — and jsonValidityRate 1, claiming perfect JSON
+        // validity from a reviewer that had never parsed a single response.
+        expect(r.passRate, `${name} passRate`).toBeNull();
+        expect(r.flagRate, `${name} flagRate`).toBeNull();
+        expect(r.errorRate, `${name} errorRate`).toBeNull();
+        expect(r.avgLatencyMs, `${name} avgLatencyMs`).toBeNull();
+        expect(r.jsonValidityRate, `${name} jsonValidityRate`).toBeNull();
+        expect(r.total).toBe(0);
+        expect(r.insufficientEvidence).toBe(true);
+      }
     });
 
     it('includes canary results in health report after running canaries', async () => {

--- a/upgrades/next/reviewer-health-unobserved.md
+++ b/upgrades/next/reviewer-health-unobserved.md
@@ -1,0 +1,82 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**A response reviewer that had never run once reported a PERFECT pass rate and a status of
+`healthy` — so "this has never executed" was indistinguishable from "this is working perfectly."**
+
+`CoherenceGate.getReviewerHealth` computed `passRate = total > 0 ? passCount / total : 1` and
+defaulted `status` to `'healthy'`. With zero observations the absent case defaulted **optimistic**:
+a reviewer that had done nothing scored 100%, and `overallStatus` aggregated it as healthy.
+
+`getReviewerStats` carried the same defect pointing both directions at once — `passRate: 0`
+(pessimistic) for the SAME quantity about 110 lines away, plus `jsonValidityRate: 1`, claiming
+perfect JSON validity from a reviewer that had never parsed a response. Two opposite defaults for one
+quantity in one file is the tell that neither was reasoned about, so both sites are fixed together.
+
+Now: rates are `null` when there are no observations (a rate over zero calls is not a rate), the
+denominator always travels beside them, and a new `observationsRequired` / `insufficientEvidence`
+pair states what a verdict needs. `status` gains a fourth value, `'unobserved'`, and `overallStatus`
+uses the precedence `failing > degraded > unobserved > healthy` so an unknown reviewer can never
+aggregate up as healthy.
+
+**The floor gates only the optimistic conclusion.** A reviewer that errored on both of its only two
+calls is still reported `'failing'`; thin evidence must never suppress bad news, only good news.
+Verified before/after: never-ran went from `passRate 1, healthy` to `passRate null, unobserved`; one
+passing call reports its honest rate of 1 with the verdict withheld; two-of-two errors stays
+`failing`; twenty passes stays `healthy`.
+
+This adopts a precedent the codebase already keeps rather than inventing one.
+`SelfActionGovernor.checkObserveLimbo` computes the identical shape of rate and gates its criterion
+on `total >= 100`, which is exactly why that expression is harmless there and was a defect here.
+
+Two existing tests changed because they were holding the defect in place. One asserted
+`overallStatus === 'healthy'` when no reviews had run, pinning it as correct behaviour. The other,
+named `detects degraded status when error rate is high`, carried a comment promising to "simulate
+high error rate by directly manipulating metrics" and manipulated nothing — it created a fresh gate
+and asserted `'healthy'`, so despite its name it exercised the never-ran path and left the
+`degraded` and `failing` branches with zero coverage while sitting green in the suite. It now
+performs the simulation its own comment described, and both branches are covered.
+
+## What to Tell Your User
+
+Nothing to do, and on most installs nothing visible: the response-review pipeline is off by default,
+so its health endpoints already answer "not enabled."
+
+Where it does run, the health view is now honest about what it does not know. A reviewer that has not
+been exercised yet shows as **unobserved** with its observation count, rather than as a flawless
+100%. Read that as "nothing is wrong and nothing is known yet" — it is deliberately not an alarm.
+Genuine problems are still reported as promptly as before, including on very few observations.
+
+## Summary of New Capabilities
+
+- Reviewer health distinguishes "no observations yet" from "healthy": rates report `null` rather than
+  an invented default, the denominator travels beside every rate, and `unobserved` is a first-class
+  status that can never aggregate up as healthy.
+- The observation floor gates only the optimistic verdict, so a failing reviewer is still reported as
+  failing on as few as two observations.
+
+## Evidence
+
+**Reproduction (before):** construct the gate with reviewers registered and call
+`getReviewerHealth()` without running a single review. Observed: `passRate: 1`, `status: 'healthy'`,
+`overallStatus: 'healthy'` — a perfect score from zero observations. `getReviewerStats()` on the same
+gate: `passRate: 0`, `jsonValidityRate: 1` (the same quantity defaulting the opposite way, and
+perfect JSON validity from a reviewer that had never parsed a response).
+
+**Observed after,** same four scenarios run against the built code:
+
+| scenario | before | after |
+|---|---|---|
+| never ran (0 obs) | `passRate 1`, `healthy` | `passRate null`, `errorRate null`, `unobserved`, `insufficientEvidence true` |
+| one passing call | `passRate 1`, `healthy` | `passRate 1` (honest), verdict withheld → `unobserved` |
+| errored on both of 2 calls | `failing` | `failing` — unchanged, bad news not suppressed |
+| 20 passes | `healthy` | `healthy` — unchanged, no false alarm |
+| `getReviewerStats`, 0 obs | `passRate 0`, `jsonValidityRate 1` | every rate `null`, `insufficientEvidence true` |
+
+**Tests:** `tests/unit/CoherenceGateCanary.test.ts` — never-ran refused a healthy verdict and reports
+no rate; thin evidence reports its real rate but withholds the verdict; thin evidence still reports
+`failing`; sufficient evidence reports `healthy` unchanged; `overallStatus` never aggregates an
+unobserved reviewer as healthy; `degraded` and `failing` thresholds now genuinely exercised (they had
+**zero** coverage before — the test named for them manipulated no metrics); `getReviewerStats`
+reports null rates rather than zeros or a perfect score. 37 tests pass across the two affected files.

--- a/upgrades/side-effects/reviewer-health-unobserved.md
+++ b/upgrades/side-effects/reviewer-health-unobserved.md
@@ -1,0 +1,152 @@
+# Side-Effects Review — a reviewer that never ran reported a PERFECT pass rate
+
+**Version / slug:** `reviewer-health-unobserved`
+**Date:** `2026-07-26`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `author-applied lenses — see Phase 5 note (reduced independence, disclosed)`
+
+## Summary of the change
+
+`CoherenceGate.getReviewerHealth()` computed `passRate = total > 0 ? passCount/total : 1`
+and defaulted `status` to `'healthy'`. With zero observations a reviewer that had **never
+executed once** therefore reported a perfect pass rate and a healthy status, and
+`overallStatus` aggregated it as healthy. The absence of information rendered identically
+to the presence of good information.
+
+`getReviewerStats()` carried the same defect pointing both directions at once: `passRate: 0`
+(pessimistic) for the SAME quantity ~110 lines away, and `jsonValidityRate: 1` — claiming
+perfect JSON validity from a reviewer that had never parsed a response. Two opposite
+defaults for one quantity in one file is the tell that neither was reasoned about.
+
+After: rates are `null` at zero observations, the denominator is always present, `status`
+gains `'unobserved'`, and a minimum-observation floor (5) gates **only** the optimistic
+conclusion.
+
+## Decision-point inventory
+
+| point | classification | note |
+|---|---|---|
+| `status` per reviewer | `invariant` | Deterministic thresholds on measured rates. No competing signals; the only change is that the optimistic branch now requires evidence. |
+| `overallStatus` aggregation | `invariant` | Fixed precedence `failing > degraded > unobserved > healthy`. |
+| `REVIEWER_HEALTH_MIN_OBSERVATIONS` | `invariant` | A constant floor, not a judgment. Adopts the `total >= 100` precedent in `SelfActionGovernor.checkObserveLimbo`; smaller (5) because this surface reports continuously rather than gating a one-way promotion. |
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+Nothing is blocked — this is a read surface with no gating authority (verified: the only
+consumer of `getReviewerHealth` is `routes.ts` serving `GET /review/health`).
+
+The nearest analogue to over-blocking is **withholding a healthy verdict from a reviewer
+that deserves one**. Bounded: 1–4 observations report `status: 'unobserved'` with the real
+rate still visible, so a reader loses the label and keeps the data. At 5+ observations the
+verdict returns. Demonstrated: 20 passes → `'healthy'`, unchanged from before.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- The floor is a count, not a confidence interval. 5 passes out of 5 reports `'healthy'`
+  though a real interval would still be wide. Deliberate: this is a health display, and
+  the previous state was infinitely worse (0 observations → healthy).
+- `jsonParseErrors > total * 0.3` remains reachable at low `total`. Left as-is: it errs
+  toward *degraded*, which is the safe direction, and widening this change to re-derive
+  every threshold would exceed the finding.
+- Sibling sites in the same audit class are NOT fixed here and are recorded rather than
+  silently dropped: `dashboardInsightCollectors.ts:57` (`overallErrorRate → 0`, rendered
+  `Error rate: 0%`) is a real display-class instance; `OrgIntentDriftAnalyzer`,
+  `IntentDriftDetector`, `FeatureRegistry`, `ScenarioPack`, `GrowthMilestoneAnalyst` and
+  `escalation-resolution` are unexamined. The class is NOT closed.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The defect is in how these two methods report their own metrics, so the fix belongs in
+them. A shared "rate with provenance" helper was considered and rejected as premature: the
+sibling instances have not been read yet, and inventing an abstraction over one confirmed
+and one probable instance would be the "six mechanisms from one bad early choice" mistake
+the registry spec's own review caught.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+No. Pure reporting, zero authority: no branch of either method blocks, delays, or alters
+any message, and neither is consulted by any decision path. The change makes the surface
+*less* likely to mislead a human reading it. There is no new failure mode where a
+misclassification denies anything, because nothing is denied.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No judgment point is introduced. Every branch is a deterministic comparison on counted
+observations, and the new floor is a constant. The one asymmetry is deliberate and stated
+in code: the floor gates the optimistic conclusion only, so thin evidence can never
+suppress a genuine failure (errored on both of 2 calls → still `'failing'`).
+
+## 5. Interactions
+
+- `getHealthDashboard()` consumes `stats.summary`, **not** `stats.reviewers`, so the
+  nullable rates do not reach it. Verified by reading the method.
+- `getHealthDashboard()` already computed `reviewerCoverage` — "has this reviewer run?" —
+  as a separate boolean. The information needed to avoid this defect was already being
+  computed in the same class; the health surfaces just did not use it.
+- `routes.ts:31285` and `:31367` JSON-serialise the results. `null` serialises cleanly.
+  No consumer performs arithmetic or `toFixed` on these fields (checked).
+- No persistence, no migration, no config: these values are computed per call from
+  in-memory counters.
+
+## 6. External surfaces
+
+`GET /review/health` and `GET /review/stats` response shapes change: rates may be `null`,
+`status` may be `'unobserved'`, and three fields are added (`errorRate`,
+`observationsRequired`, `insufficientEvidence`). On installs where the response-review
+pipeline is disabled — including this one — both routes already return `501`, so the live
+blast radius here is nil. Any consumer must already handle `501`, and a `null` rate is
+strictly more honest than the `1` it replaces.
+
+## 6b. Operator-surface quality
+
+An operator asking "is my outbound review pipeline healthy?" previously received a
+confident yes from a pipeline that had never run. They now receive `unobserved` with the
+observation count beside it, which is answerable rather than misleading. `'unobserved'` is
+deliberately not an alarm word: nothing is wrong, nothing is known yet.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: `unified` by construction — no new state.** These are derived reads over
+per-process in-memory counters that already existed. Each machine reports its own
+reviewers' observations, which is correct: a reviewer's execution count is a property of
+the process that ran it. No replication path is needed because nothing is stored, and no
+`machine-local-justification` marker is required because no new machine-local state is
+introduced.
+
+## 8. Rollback cost
+
+Trivial and self-contained: revert one commit touching one source file and one test file.
+No migration, no persisted state, no config key, nothing to unwind. A consumer written
+against the new shape sees the old shape again, and the old shape's failure mode is the
+one documented above.
+
+## Phase 5 — Second-pass review (independent reviewer subagent)
+
+**Disclosure, per Truthful Provenance:** no independent reviewer subagent was spawned.
+A standing instruction in this session prohibits spawning subagents unless the operator
+requests it, so the review lenses (over-block, under-block, abstraction fit, signal-vs-
+authority, interactions, multi-machine) were applied by the author. That is **reduced
+independence** and is recorded as such rather than presented as a concurring second pass.
+
+What author-applied review actually caught and changed:
+
+1. An initial draft treated `total === 0` and `0 < total < 5` as one state. Splitting them
+   mattered: at `total > 0` the rate is real data worth showing, and only the *verdict*
+   needs withholding. Hence `passRate` is `null` only at zero, never at "few".
+2. The first design gated all three branches on the floor, which would have **suppressed a
+   genuine failure** on thin evidence — recreating the same defect pointing the other way.
+   Corrected so the floor gates optimism only.
+3. The consumer check was run rather than assumed, which is what established that
+   `getHealthDashboard` reads `stats.summary` and is unaffected. An earlier claim in this
+   session that this surface "gates the enforcement flip" was **disproven** by the same
+   check and withdrawn: `getReviewerHealth` has exactly one consumer, the route.


### PR DESCRIPTION
## ELI16 — the health check for my outbound reviewers gave a never-executed reviewer a perfect score

Before a message of mine goes out, a set of reviewers can look at it. There is a health page for those reviewers. If one had **never actually run — not once —** that page reported it as scoring one hundred percent and being healthy. Not a blank, not a zero, but a perfect score invented from no data. Anyone opening that page to ask "is this working?" got a confident yes from something that had never done anything.

A score is now reported as *nothing* when there is nothing to score, the observation count always travels beside it, and "healthy" requires five observations — with a new fourth answer, **unobserved**, below that. It is deliberately not an alarm: nothing is wrong, nothing is known yet.

The important asymmetry: the evidence requirement holds back **good** news only. A reviewer that failed both of its only two attempts is still reported as failing. Requiring evidence before believing something is fine is prudent; requiring it before admitting something is broken would be the same bug facing the other way.

This is not a new rule. `SelfActionGovernor.checkObserveLimbo` computes the identical kind of rate and already refuses to act on it below a hundred observations — that guard is exactly why the same line of arithmetic is harmless there and was a defect here. So this is one site being brought in line with a habit the codebase already keeps.

## The second site, and the tell

`getReviewerStats()` had the same defect pointing **both directions at once**: the same quantity defaulted to `0` in one place and to a perfect `1` about 110 lines away in the same file, and `jsonValidityRate` claimed flawless formatting from a reviewer that had never parsed a response. Two opposite defaults for one number is the sign that neither was reasoned about, so both were fixed together rather than one tidied while its twin was left.

Separately, `getHealthDashboard()` already computed `reviewerCoverage` — "has this reviewer run?" — as a boolean in the same class. The information needed to avoid this was already being calculated; the health surfaces just never looked at it.

## Why the tests are the more interesting half

Two existing tests changed, because they were what kept the defect alive.

One honestly said `'reports healthy status when no reviews have run'` — and asserted it. The bug was pinned as intended behaviour, so running the suite could never reveal it.

The other was named `'detects degraded status when error rate is high'`. Its own comment promised to "simulate high error rate by directly manipulating metrics." **That simulation was never written.** It created a fresh gate and asserted `'healthy'`. So despite its name it exercised the never-ran path, leaving `degraded` and `failing` with **zero coverage** while a green test carrying their name sat in the suite looking like proof. It now performs the simulation its comment described, and both paths are covered.

That is the same shape as the original defect one level up: a passing test named for a check is indistinguishable from that check actually being verified.

## Refusal evidence (before → after)

| case | BEFORE | AFTER |
|---|---|---|
| never ran | `passRate 1`, `healthy` | `passRate null`, **`unobserved`** |
| one passing call | `passRate 1`, `healthy` | rate honestly `1`, verdict **withheld** |
| errored on both of 2 calls | `failing` | **`failing`** — bad news never suppressed |
| 20 passes | `healthy` | **`healthy`** — no false alarm |
| `getReviewerStats`, 0 obs | `passRate 0`, `jsonValidityRate 1` | all rates **`null`** + `insufficientEvidence: true` |

## Scope, honestly

- Pure read surfaces with **zero gating authority**. `getReviewerHealth`'s only consumer is the route that serves it — checked, not assumed. An earlier claim of mine that this surface gates the reviewers' enforcement flip was **wrong and is withdrawn**; that wire does not exist.
- On installs where the pipeline is disabled, including this one, both routes already return `501`, so live blast radius is nil.
- Found by a **second** audit pass over every `*Rate|*Ratio|*Percent|*Share` symbol in `src/`, per Iterative Audit to Convergence — a single-pass audit is incomplete by definition. Of 16 signature matches, **one was already correct** (the governor) and one errs toward false suspicion, the safe direction. Both are recorded rather than "fixed". Sibling instances (`dashboardInsightCollectors.ts:57` and six unexamined sites) are named in the side-effects artifact — **the class is not closed.**
- Second-pass review was **author-applied, not independent** — disclosed in the artifact's Phase 5 rather than presented as a concurring review.

Refs ACT-1243; `convergence-towards-coherence` Tier 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsNuZUXXxnNKwA9mHs2TdQ
