### PR TITLE
fix(insights): the panel said "Routing is healthy" over ZERO observations

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T04-31-40-896Z-dashboard-error-rate-unobserved.json
+++ b/.instar/instar-dev-decisions/2026-07-26T04-31-40-896Z-dashboard-error-rate-unobserved.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T04:31:40.896Z",
+  "slug": "dashboard-error-rate-unobserved",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 40,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/dashboard-error-rate-unobserved.eli16.md
+++ b/docs/specs/dashboard-error-rate-unobserved.eli16.md
@@ -1,0 +1,61 @@
+# The dashboard said "50% failing" and "healthy" at the same time — Plain-English Overview
+
+> The one-line version: a panel meant to tell you whether the routing layer is healthy would say it
+> was healthy when nothing had run at all — and, in one case, said "healthy" while displaying a fifty
+> percent failure rate two lines above.
+
+## The problem in one breath
+
+There is a dashboard panel summarising how the internal checks are doing. It shows an error rate and a
+sentence of plain-English verdict. If nothing had run in the last day, the panel showed "Error rate:
+0%" and wrote "Routing is healthy — 0 checks ran with no check failing." A sentence that tells you
+nothing ran and calls that healthy in the same breath.
+
+## What already exists
+
+- **A ledger of every internal check call** — how many ran, how many failed. That part is accurate.
+- **A per-check alarm** that flags any single check failing too often. This part was already careful:
+  it refuses to judge a check with fewer than five calls, because a rate over one or two calls means
+  nothing.
+- **A minimum-call threshold, written at the top of that very file**, with a comment explaining it
+  exists because an error rate below that volume is not statistically meaningful.
+
+## What this adds
+
+The panel now uses the threshold its own file already declares. With no calls at all, the error rate
+reads "no calls yet" rather than a zero you cannot distinguish from a measured one, and the verdict
+says there is nothing to judge yet. With a handful of calls it shows the real rate but declines to
+call anything healthy, saying plainly that the volume is too low to tell.
+
+**And the ordering now guarantees that a real failure is reported first, always.** Not enough evidence
+is a reason to withhold reassurance. It is never a reason to withhold a warning.
+
+## The worst case, which is what makes this more than tidiness
+
+Because the per-check alarm sensibly ignores checks with fewer than five calls, but the verdict
+sentence had no such condition, a window with two calls where one failed produced this:
+
+    Error rate: 50%
+    "Routing is healthy — 1 checks ran with no check failing a meaningful share of its calls."
+
+A fifty percent failure rate displayed directly above the word healthy. **The two halves of one panel
+contradicted each other**, and each half was individually defensible — the alarm was right to stay
+quiet on two calls, and the verdict was simply never told about the threshold the alarm was using.
+
+## The safeguards
+
+Nothing here can block, delay or change anything: it is a read-only panel. The genuinely-healthy case
+is untouched — ten clean calls still reads "Routing is healthy", word for word as before. And the
+failure case is untouched too: six calls with three errors still surfaces the failing check.
+
+A small grammar fix falls out of the same work: "1 checks are failing" now reads "1 check is failing".
+
+## A note on my own test
+
+My first test for this failed against correct output. It checked that the words "routing is healthy"
+were absent — but the new caveat legitimately contains them, in "too few to say whether routing is
+healthy". The test was wrong, not the code.
+
+Worth writing down because this project is about instruments that mis-measure, and a test is an
+instrument. I caught it by running it. Had I written it and trusted it, I would have "fixed" working
+code to satisfy a bad assertion.

--- a/src/monitoring/dashboardInsightCollectors.ts
+++ b/src/monitoring/dashboardInsightCollectors.ts
@@ -54,18 +54,48 @@ export function buildLlmActivityCollector(ledger: FeatureMetricsLedger): () => P
     }
     anomalies.sort((a, b) => (b.severity === 'alert' ? 1 : 0) - (a.severity === 'alert' ? 1 : 0));
 
-    const overallErrorRate = totalReal > 0 ? totalErrors / totalReal : 0;
+    // MIN_REAL_CALLS is declared at the top of this file as "minimum real calls
+    // before an error-rate is statistically meaningful" and the per-feature loop
+    // above honours it. The AGGREGATE did not: with zero calls it rendered
+    // `Error rate: 0%` and asserted "Routing is healthy — 0 checks ran", so an
+    // empty 24 hours was indistinguishable from a clean one. Same file, same
+    // constant, same reasoning — just applied to the aggregate too.
+    const overallErrorRate = totalReal > 0 ? totalErrors / totalReal : null;
     const metrics: InsightMetric[] = [
       { label: 'LLM calls (24h)', value: String(totalReal) },
       { label: 'Errors (24h)', value: String(totalErrors) },
-      { label: 'Error rate', value: `${Math.round(overallErrorRate * 100)}%` },
+      {
+        label: 'Error rate',
+        // A rate over zero calls is not a rate. Show why it is absent, not a "0%"
+        // a reader cannot tell from a measured zero.
+        value: overallErrorRate === null ? 'no calls yet' : `${Math.round(overallErrorRate * 100)}%`,
+      },
       { label: 'Checks active', value: String(features.length) },
     ];
     const facts: string[] = [];
-    if (anomalies.length === 0) {
-      facts.push(`Routing is healthy — ${features.length} checks ran with no check failing a meaningful share of its calls.`);
-    } else {
+    // Order matters, and BAD NEWS COMES FIRST unconditionally. Today an anomaly
+    // cannot occur below the floor (a feature needs >= MIN_REAL_CALLS to flag, so
+    // totalReal < MIN_REAL_CALLS implies none), but that is an arithmetic
+    // coincidence rather than a guarantee — if the constants ever diverge, a
+    // low-volume window must still surface a real failure. The floor gates only
+    // the reassuring conclusion, never a warning.
+    if (anomalies.length > 0) {
       facts.push(`${anomalies.length} check${anomalies.length === 1 ? '' : 's'} ${anomalies.length === 1 ? 'is' : 'are'} failing more than usual and worth a look.`);
+    } else if (totalReal === 0) {
+      // Nothing ran. Say so, rather than claiming health from an empty window.
+      facts.push(
+        features.length === 0
+          ? 'No checks have reported in the last 24 hours, so there is nothing to judge yet.'
+          : `${features.length} check${features.length === 1 ? '' : 's'} are configured but none made a call in the last 24 hours, so there is nothing to judge yet.`,
+      );
+    } else if (totalReal < MIN_REAL_CALLS) {
+      // The rate above is real data, but the volume is too low to call it healthy —
+      // the same asymmetry the per-feature loop already applies.
+      facts.push(
+        `Only ${totalReal} call${totalReal === 1 ? '' : 's'} in the last 24 hours — too few to say whether routing is healthy.`,
+      );
+    } else {
+      facts.push(`Routing is healthy — ${features.length} checks ran with no check failing a meaningful share of its calls.`);
     }
     if (busiest && busiest.realCalls > 0) facts.push(`The busiest check is ${busiest.feature} (${busiest.realCalls} calls in 24h).`);
 

--- a/tests/unit/dashboard-insight-collectors-unobserved.test.ts
+++ b/tests/unit/dashboard-insight-collectors-unobserved.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The LLM Activity collector must not report health it has not observed.
+ *
+ * Before this, with zero calls in the window the collector rendered
+ * `Error rate: 0%` and asserted "Routing is healthy — 0 checks ran with no check
+ * failing a meaningful share of its calls." — a sentence whose own denominator
+ * contradicts its claim. An empty 24 hours was indistinguishable from a clean one.
+ *
+ * The file already declared `MIN_REAL_CALLS = 5` ("minimum real calls before an
+ * error-rate is statistically meaningful") and the per-feature anomaly loop
+ * honoured it; only the aggregate ignored it. These tests pin the aggregate to the
+ * same discipline, and pin the asymmetry that matters: the floor withholds the
+ * REASSURING conclusion only, never a warning.
+ *
+ * Refs ACT-1243 (no ratio without a denominator); convergence-towards-coherence Tier 1.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildLlmActivityCollector } from '../../src/monitoring/dashboardInsightCollectors.js';
+import { FeatureMetricsLedger } from '../../src/monitoring/FeatureMetricsLedger.js';
+
+function collect(seed: (l: FeatureMetricsLedger) => void) {
+  const ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
+  seed(ledger);
+  return buildLlmActivityCollector(ledger)();
+}
+const metric = (snap: { metrics: readonly { label: string; value: string }[] }, label: string) =>
+  snap.metrics.find((m) => m.label === label)?.value;
+
+describe('LLM Activity collector — absence must not read as health', () => {
+  it('reports NO RATE and claims no health when nothing has run at all', () => {
+    const snap = collect(() => {});
+
+    // Was `0%` — indistinguishable from a measured zero.
+    expect(metric(snap, 'Error rate')).toBe('no calls yet');
+    expect(metric(snap, 'LLM calls (24h)')).toBe('0'); // the denominator is still shown
+    expect(metric(snap, 'Checks active')).toBe('0');
+
+    const facts = snap.facts.join(' ');
+    // The load-bearing assertion: it must NOT claim routing is healthy.
+    expect(facts).not.toMatch(/healthy/i);
+    expect(facts).toMatch(/nothing to judge yet/i);
+    expect(snap.anomalies).toEqual([]);
+  });
+
+  it('does not claim health on a volume too low to support it, but still shows the real rate', () => {
+    // 2 real calls, 1 an error. The 50% is honest data; the VERDICT is withheld
+    // because 2 calls cannot support "healthy" (MIN_REAL_CALLS is 5).
+    const snap = collect((l) => {
+      l.record({ feature: 'TopicIntentExtractor', kind: 'llm', outcome: 'error' });
+      l.record({ feature: 'TopicIntentExtractor', kind: 'llm', outcome: 'noop' });
+    });
+
+    expect(metric(snap, 'Error rate')).toBe('50%'); // the rate is reported honestly
+    expect(metric(snap, 'LLM calls (24h)')).toBe('2');
+
+    const facts = snap.facts.join(' ');
+    expect(facts).toMatch(/too few to say/i);
+    // Assert the absence of the AFFIRMATIVE claim, not of the words. The caveat
+    // itself legitimately reads "too few to say whether routing is healthy", so a
+    // loose /routing is healthy/i match fails on correct output — which is exactly
+    // what it did on the first run of this test.
+    expect(snap.facts.some((f) => /^Routing is healthy/.test(f))).toBe(false);
+  });
+
+  it('DOES claim health once enough calls support the claim (no false alarm)', () => {
+    const snap = collect((l) => {
+      for (let i = 0; i < 10; i++) l.record({ feature: 'MessageSentinel', kind: 'llm', outcome: 'noop' });
+    });
+
+    expect(metric(snap, 'Error rate')).toBe('0%'); // a MEASURED zero, over 10 calls
+    expect(metric(snap, 'LLM calls (24h)')).toBe('10');
+    expect(snap.facts.join(' ')).toMatch(/Routing is healthy/i);
+  });
+
+  it('a real failure is surfaced ahead of any evidence caveat — the floor never suppresses bad news', () => {
+    // 6 calls, 3 errors: above the floor, and a genuine 50% failure.
+    const snap = collect((l) => {
+      for (let i = 0; i < 3; i++) l.record({ feature: 'TopicIntentExtractor', kind: 'llm', outcome: 'error' });
+      for (let i = 0; i < 3; i++) l.record({ feature: 'TopicIntentExtractor', kind: 'llm', outcome: 'noop' });
+    });
+
+    expect(snap.anomalies.length).toBeGreaterThan(0);
+    const facts = snap.facts.join(' ');
+    expect(facts).toMatch(/failing more than usual/i);
+    // Neither the "nothing to judge" nor the "too few" caveat may displace a warning.
+    expect(facts).not.toMatch(/nothing to judge yet/i);
+    expect(facts).not.toMatch(/too few to say/i);
+    expect(snap.facts.some((f) => /^Routing is healthy/.test(f))).toBe(false);
+  });
+});

--- a/upgrades/next/dashboard-error-rate-unobserved.md
+++ b/upgrades/next/dashboard-error-rate-unobserved.md
@@ -1,0 +1,78 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**The LLM Activity dashboard panel claimed "Routing is healthy" when nothing had run — and in one
+case displayed `Error rate: 50%` directly above that claim.**
+
+`dashboardInsightCollectors.buildLlmActivityCollector` computed
+`overallErrorRate = totalReal > 0 ? totalErrors / totalReal : 0`, rendered it as `Error rate: 0%`, and
+pushed a health fact whenever the anomaly list was empty:
+
+    "Routing is healthy — 0 checks ran with no check failing a meaningful share of its calls."
+
+With an empty 24-hour window that sentence claimed health from no observations, its own denominator
+("0 checks ran") contradicting its claim. The sharper failure: the per-feature anomaly loop correctly
+requires `f.realCalls >= MIN_REAL_CALLS` before flagging a check, but the health sentence had no such
+condition — so a window with 2 calls where 1 errored rendered `Error rate: 50%` beside "Routing is
+healthy". Both halves were individually defensible; the verdict was simply never told about the
+threshold the alarm was already using.
+
+`MIN_REAL_CALLS = 5` is declared at the top of that same file, commented "minimum real calls before an
+error-rate is statistically meaningful". This applies it to the aggregate:
+
+- `overallErrorRate` is `null` at zero calls; the metric renders **`no calls yet`** rather than a `0%`
+  indistinguishable from a measured zero. The call count and check count still travel beside it.
+- Zero calls → a fact saying there is nothing to judge yet (distinguishing "no checks reported at all"
+  from "checks configured but idle").
+- Below the floor → the real rate is still shown, but the verdict is withheld: "Only N calls in the
+  last 24 hours — too few to say whether routing is healthy."
+- **Anomalies are evaluated FIRST and unconditionally**, so no evidence caveat can ever displace a
+  warning. Today an anomaly cannot occur below the floor, but that is an arithmetic coincidence
+  between two constants rather than a guarantee, and the ordering makes it structural.
+
+Verified before/after on the built collector: nothing-ran went from `0%` + "Routing is healthy" to
+`no calls yet` + "nothing to judge yet"; 2 calls with 1 error went from `50%` + "Routing is healthy" to
+`50%` + "too few to say"; 10 clean calls still reads "Routing is healthy" unchanged; 6 calls with 3
+errors still surfaces the failing check.
+
+A grammar fix falls out of the plural handling: "1 checks are failing" → "1 check is failing".
+
+## What to Tell Your User
+
+Nothing to do. On most installs this panel ships dark, so there is nothing visible.
+
+Where it runs, the panel is now honest about a quiet window: it says there is nothing to judge yet
+rather than reporting a flawless zero. Read that as "nothing is wrong and nothing is known" — it is
+deliberately not an alarm. Genuine failures are still reported exactly as promptly as before, and are
+now always reported ahead of any note about low call volume.
+
+## Summary of New Capabilities
+
+- The LLM Activity panel distinguishes "no calls observed" from "no errors observed": the error rate
+  reads `no calls yet` instead of `0%`, with the call count beside it.
+- A health verdict now requires enough calls to support it, reusing the file's own existing
+  `MIN_REAL_CALLS` threshold rather than a new one.
+- A real failure is surfaced ahead of any low-evidence caveat, by branch order rather than by luck.
+
+## Evidence
+
+**Reproduction (before):** build the collector over an empty ledger and read the snapshot. Observed:
+`Error rate: 0%` and the fact `"Routing is healthy — 0 checks ran with no check failing a meaningful
+share of its calls."` Then seed 2 calls with 1 error: observed `Error rate: 50%` together with
+`"Routing is healthy — 1 checks ran…"`.
+
+**Observed after,** same four scenarios against the built collector:
+
+| scenario | before | after |
+|---|---|---|
+| nothing ran (0 calls, 0 checks) | `0%` + "Routing is healthy — 0 checks ran…" | `no calls yet` + "No checks have reported in the last 24 hours, so there is nothing to judge yet." |
+| 2 calls, 1 error (below floor) | `50%` + "Routing is healthy — 1 checks ran…" | `50%` + "Only 2 calls in the last 24 hours — too few to say whether routing is healthy." |
+| 10 clean calls | `0%` + "Routing is healthy" | `0%` + "Routing is healthy" — unchanged |
+| 6 calls, 3 errors | `50%` + "1 checks are failing…" | `50%` + "1 check is failing more than usual and worth a look." |
+
+**Tests:** `tests/unit/dashboard-insight-collectors-unobserved.test.ts` — four cases covering
+no-rate-and-no-health-claim at zero calls, real-rate-with-verdict-withheld below the floor,
+health-claimed-once-supported, and a real failure surfacing ahead of any caveat. The existing
+`tests/e2e/insights-alive.test.ts` seeds 6 calls above the floor and passes unchanged. 7 tests pass
+across both files; `npx tsc --noEmit` clean.

--- a/upgrades/side-effects/dashboard-error-rate-unobserved.md
+++ b/upgrades/side-effects/dashboard-error-rate-unobserved.md
@@ -1,0 +1,141 @@
+# Side-Effects Review — the dashboard showed "Error rate: 50%" beside "Routing is healthy"
+
+**Version / slug:** `dashboard-error-rate-unobserved`
+**Date:** `2026-07-26`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `author-applied lenses — see Phase 5 (reduced independence, disclosed)`
+
+## Summary of the change
+
+The LLM Activity insight collector computed `overallErrorRate = totalReal > 0 ? totalErrors/totalReal : 0`
+and rendered it as `Error rate: 0%`, then asserted a health fact whenever no anomaly had been flagged:
+
+    "Routing is healthy — 0 checks ran with no check failing a meaningful share of its calls."
+
+Two failures fell out of that. With an empty 24-hour window the panel claimed health from no data —
+and the sentence's own denominator ("0 checks ran") contradicted its claim. Worse, with a genuine
+failure below the anomaly floor the panel showed **`Error rate: 50%` beside "Routing is healthy"**,
+because the per-feature loop correctly required `f.realCalls >= MIN_REAL_CALLS` before flagging while
+the health sentence had no such condition.
+
+`MIN_REAL_CALLS = 5` is declared at the top of this same file, commented "minimum real calls before
+an error-rate is statistically meaningful". The fix applies that existing, already-honoured constant
+to the aggregate: the rate is `null` (rendered "no calls yet") at zero calls, a sub-floor window says
+so plainly, and **a real failure is surfaced ahead of any evidence caveat**.
+
+## Decision-point inventory
+
+| point | classification | note |
+|---|---|---|
+| the `facts` branch order | `invariant` | Deterministic. Anomalies are checked FIRST and unconditionally, so no caveat can displace a warning. |
+| the sub-floor caveat | `invariant` | A comparison against the file's existing `MIN_REAL_CALLS`. Gates only the reassuring conclusion. |
+| `Error rate` rendering | `invariant` | `null` at zero calls → a string saying why, never a computed default. |
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+Nothing is blocked — this is a read-only dashboard collector with no gating authority. The analogue
+is **withholding a health claim from a genuinely healthy window**: a window with 1–4 clean calls now
+reads "too few to say" instead of "healthy". Bounded, and the real rate is still displayed beside the
+call count so the reader can judge for themselves. At 5+ calls the claim returns unchanged
+(demonstrated: 10 clean calls → "Routing is healthy", byte-identical to before).
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- The floor is a call count, not a confidence interval. 5 clean calls yields "healthy" though a real
+  interval would still be wide. Deliberate: this reuses the file's existing constant rather than
+  inventing a second, differently-tuned threshold in the same file.
+- `busiest` is still reported whenever `realCalls > 0`, which is honest (it is a count, not a rate).
+- The 24h window itself is not surfaced as a caveat when the process started minutes ago — a
+  short-uptime window looks the same as a genuinely quiet one. Out of scope here; noted rather than
+  silently skipped.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The defect is in how this collector renders its own aggregate, so the fix belongs in it. No
+shared helper was extracted: the sibling instance in `CoherenceGate` (PR #1648) has different types
+and a different output shape, and abstracting over two instances would be the premature-generalisation
+mistake this project's own spec review caught elsewhere.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+No. Pure presentation, zero authority: no branch blocks, delays or alters anything, and the collector
+is consumed only by the insights read surface. There is no misclassification path that can deny
+something, because nothing is denied. The change strictly reduces the panel's capacity to mislead.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No judgment point is introduced. Every branch is a deterministic comparison on counted calls against
+a constant already present in the file. The one asymmetry is deliberate and stated in a code comment:
+anomalies are evaluated first and unconditionally, so thin evidence can never suppress a warning —
+only the reassuring conclusion requires evidence behind it.
+
+## 5. Interactions
+
+- `overallErrorRate` is a local; verified by grep that nothing outside this file reads it.
+- `InsightMetric.value` is typed `string`, so "no calls yet" needs no type change and no consumer
+  performs arithmetic on it.
+- The existing E2E (`tests/e2e/insights-alive.test.ts`) seeds 6 calls with 3 errors — above the floor,
+  so it still routes to the anomaly branch and still asserts `/50%/`. Re-run: passes unchanged.
+- A visible grammar fix falls out of the plural handling: "1 checks are failing" → "1 check is failing".
+- No persistence, no config, no migration: every value is computed per call from the ledger.
+
+## 6. External surfaces
+
+The `/insights` payload for the `llm-activity` page changes in two places: `Error rate` may read
+"no calls yet" instead of "0%", and the first fact may be a caveat rather than a health claim. Both
+are display strings already typed as free text. The feature ships dark on the fleet (dev-agent gated,
+dryRun), so exposure is limited to development agents today.
+
+## 6b. Operator-surface quality
+
+This is the whole point of the change. An operator glancing at the panel during a quiet window
+previously read "Error rate: 0% · Routing is healthy" and would reasonably conclude the routing layer
+was fine. They now read "no calls yet" and "nothing to judge yet". And in the sub-floor case they no
+longer see a 50% error rate sitting next to the word "healthy" — the panel stops contradicting
+itself. None of the new wording is alarming: "nothing to judge yet" says nothing is wrong AND nothing
+is known.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: `unified` by construction — no new state.** The collector derives everything, per call,
+from the per-process metrics ledger that already existed. Each machine reports its own LLM activity,
+which is correct: a call was made by a specific process. No replication path is needed because nothing
+is stored, and no `machine-local-justification` marker is required because no new machine-local state
+is introduced.
+
+## 8. Rollback cost
+
+Trivial: revert one commit touching one source file plus its new test. No migration, no persisted
+state, no config key. A consumer written against the new strings sees the old ones again, and the old
+strings' failure mode is the one documented above.
+
+## Phase 5 — Second-pass review (independent reviewer subagent)
+
+**Disclosure, per Truthful Provenance:** no independent reviewer subagent was spawned — a standing
+instruction in this session prohibits spawning subagents unless the operator requests it. The review
+lenses were applied by the author. That is **reduced independence**, recorded as such rather than
+presented as a concurring second pass.
+
+What author-applied review actually caught and changed:
+
+1. **The first draft ordered the branches wrongly**, putting the sub-floor caveat ahead of the
+   anomaly message. Today no anomaly can occur below the floor (a feature needs `>= MIN_REAL_CALLS`
+   to flag, so `totalReal < MIN_REAL_CALLS` implies none) — but that is an arithmetic coincidence,
+   not a guarantee. Reordered so anomalies win unconditionally, and the reasoning is in a comment so
+   a future edit to either constant cannot silently reintroduce suppression.
+2. **My own first test asserted the wrong thing** and failed on correct output: it matched
+   `/routing is healthy/i`, which the caveat legitimately contains ("too few to say whether routing
+   is healthy"). Corrected to assert the absence of the AFFIRMATIVE claim. Worth recording because
+   this project's Tier 1 is about instruments that mis-measure — including my tests.
+3. The consumer check was run rather than assumed, establishing that `overallErrorRate` is local and
+   that `InsightMetric.value` is already a string.


### PR DESCRIPTION
## ELI16 — the dashboard said "50% failing" and "healthy" at the same time

There is a panel summarising how the internal checks are doing. If nothing had run in the last day it showed **"Error rate: 0%"** and wrote **"Routing is healthy — 0 checks ran with no check failing."** A sentence that tells you nothing ran and calls that healthy in the same breath.

The panel now uses a threshold its own file already declares. With no calls, the rate reads **"no calls yet"** instead of a zero you cannot tell from a measured one, and the verdict says there is nothing to judge yet. With a handful of calls it shows the real rate but declines to call anything healthy.

**And the ordering now guarantees a real failure is reported first, always.** Thin evidence is a reason to withhold reassurance. It is never a reason to withhold a warning.

## The worst case, which is what makes this more than tidiness

The per-check alarm sensibly ignores any check with fewer than five calls. The verdict sentence had no such condition. So a window with two calls where one failed produced:

```
Error rate: 50%
"Routing is healthy — 1 checks ran with no check failing a meaningful share of its calls."
```

A fifty percent failure rate displayed directly above the word healthy. **The two halves of one panel contradicted each other** — and each half was individually defensible. The alarm was right to stay quiet on two calls; the verdict was simply never told about the threshold the alarm was using.

`MIN_REAL_CALLS = 5` sits at the top of that same file, commented *"minimum real calls before an error-rate is statistically meaningful."* This applies the file's own constant to the aggregate. Not a new rule — the rule that was already there, reaching one line further.

## Refusal evidence (before → after, on the built collector)

| scenario | BEFORE | AFTER |
|---|---|---|
| nothing ran | `0%` + "Routing is healthy — 0 checks ran…" | `no calls yet` + "nothing to judge yet" |
| 2 calls, 1 error | `50%` + **"Routing is healthy"** | `50%` + "too few to say whether routing is healthy" |
| 10 clean calls | `0%` + "Routing is healthy" | **unchanged** — no false alarm |
| 6 calls, 3 errors | surfaces the failing check | **unchanged** — bad news never suppressed |

Anomalies are now evaluated **first and unconditionally**. Today an anomaly cannot occur below the floor (a feature needs `>= MIN_REAL_CALLS` to flag, so a sub-floor total implies none) — but that is an arithmetic coincidence between two constants, not a guarantee, so the ordering makes it structural.

## A note on my own test

My first version of the new test **failed against correct output.** It asserted the words "routing is healthy" were absent — but the new caveat legitimately contains them, in "too few to say whether routing is healthy". The test was wrong; the code was right.

Worth stating in a PR because this tier is about instruments that mis-measure, and a test is an instrument. I caught it by running it. Had I trusted it, I would have "fixed" working code to satisfy a bad assertion.

## Scope

- Read-only dashboard collector, **zero gating authority**. `overallErrorRate` is file-local (checked, not assumed) and `InsightMetric.value` is already typed `string`, so no consumer does arithmetic on it.
- Ships dark on the fleet (dev-agent gated), so exposure today is development agents only.
- Existing `tests/e2e/insights-alive.test.ts` seeds 6 calls above the floor and **passes unchanged**. 7 tests pass across both files; `npx tsc --noEmit` clean.
- Grammar fix falls out of the plural handling: "1 checks are failing" → "1 check is failing".
- Second-pass review was **author-applied, not independent** — disclosed in the artifact's Phase 5.

**This closes the ACT-1243 sweep.** 16 signature matches read individually → **2 real defects**: this one and #1648. Three of the sixteen were already correct and are named in the artifact as the exemplars the standard should point at, rather than a new rule being invented.

Refs ACT-1243; `convergence-towards-coherence` Tier 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsNuZUXXxnNKwA9mHs2TdQ
