### PR TITLE
fix(commitments): a promise was "kept" iff an optional text field was set

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T05-01-23-628Z-behavioural-promise-unverifiable.json
+++ b/.instar/instar-dev-decisions/2026-07-26T05-01-23-628Z-behavioural-promise-unverifiable.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T05:01:23.628Z",
+  "slug": "behavioural-promise-unverifiable",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 69,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/behavioural-promise-unverifiable.eli16.md
+++ b/docs/specs/behavioural-promise-unverifiable.eli16.md
@@ -1,0 +1,77 @@
+# A promise counted as kept because a text box was filled in — Plain-English Overview
+
+> The one-line version: the system that tracks whether I keep my promises to you was
+> deciding that question by checking whether one optional text field had been filled in
+> when the promise was created — ninety-eight cases out of ninety-eight, with no exceptions.
+
+## The problem in one breath
+
+When I promise you something about how I will behave, that promise gets recorded. There is
+a periodic check that marks each one either kept or broken. The check worked like this: it
+looked in a reminder file to see whether the promise's identifier appeared there. If yes,
+kept. If no, broken.
+
+But **that reminder file is written by the very same system, from its own list of
+promises.** And nothing else on the machine reads it. So the check was asking "did I
+successfully write my own note?" and reporting the answer as "did Echo keep her word?"
+
+## What the numbers looked like
+
+Seventy-four promises had that optional field filled in. **All seventy-four read "kept."**
+Twenty-four did not have it. **All twenty-four read "broken."** No exceptions in either
+direction.
+
+And because the check ran every minute or so, each one collected another tally mark every
+time. One promise from March had accumulated **a hundred and sixty-two thousand
+"violations."** Four created in the same minute all showed the identical number — which no
+amount of real behaviour could produce, and which is what gave the game away.
+
+The one holding *your* request — that I re-affirm the goals summary every few hours — was
+in the second group. It was **born permanently broken**, and would have read that way
+whether I sent you every summary or none of them.
+
+## What this changes
+
+A promise about behaviour is now left **open** rather than being declared kept or broken.
+Nothing here can watch what I actually do, so the honest answer is "not determined yet" —
+which is precisely what this same file already does for another kind of promise it cannot
+check, ten lines away, with a comment explaining why.
+
+Both wrong answers go, not just one:
+
+- **"Kept" was the more dangerous.** It offered reassurance nobody had earned.
+- **"Broken" was a false accusation.** A blank optional field is not a broken promise.
+
+The health readout changes too. It used to say "all verified" whenever nothing was marked
+broken — inferring compliance from the absence of complaints. It now says how many
+promises are actually verified and how many simply cannot be checked automatically.
+
+## What it does not fix, said plainly
+
+**Whether I actually keep behavioural promises is still not verified by anything.** This
+change stops the system claiming otherwise; it does not build real verification. Doing that
+would mean genuinely observing my conduct against each rule, which is a much bigger piece
+of work and is not attempted here.
+
+So this is a change from a confident wrong answer to an honest absence of one. That is an
+improvement, but it is worth being clear about which of the two it is.
+
+## The safeguards
+
+The reminder file still repairs itself if it goes missing — that was worth keeping. It just
+no longer counts as evidence about a promise.
+
+Nothing can be blocked, delayed or altered by any of this; it is a status calculation. And
+the change *removes* a false alarm: because twenty-four promises were wrongly marked broken,
+the commitment component reported itself permanently degraded. It no longer does.
+
+## A note on the old tests
+
+Three existing tests had to be rewritten, because all three asserted the behaviour being
+removed — including one that asserted a *missing* optional field should count as a broken
+promise.
+
+The middle one is worth quoting. It was named **"detects violation when rules file is
+deleted"** and its body asserted that nothing was detected, with a comment conceding "so it
+should still pass." A test whose name contradicts its own assertion records an intention
+that nobody implemented — and it sat green in the suite, looking like coverage.

--- a/src/monitoring/CommitmentTracker.ts
+++ b/src/monitoring/CommitmentTracker.ts
@@ -1426,14 +1426,39 @@ export class CommitmentTracker extends EventEmitter {
       return null;
     }
 
+    // A BEHAVIOURAL commitment is not automatically verifiable either, and it
+    // suffered the identical defect the block above was written to cure —
+    // measured live on 2026-07-26: CMT-068 at 162,344 violation ticks, and four
+    // commitments created in the same minute holding IDENTICAL counts (80,425),
+    // which individual behaviour cannot produce.
+    //
+    // The old check asked whether the commitment's ID appeared in the behavioural
+    // rules file. That file is written BY THIS CLASS from its own active list, and
+    // nothing else on the machine reads it (verified across the whole agent home),
+    // so the check verified that the system had written its own file. Its result
+    // was decided entirely by whether the optional `behavioralRule` field was
+    // populated: 74 commitments WITH the field all read `verified`; 24 WITHOUT it
+    // all read `violated`. 98 of 98, no exceptions. Not one observed behaviour.
+    //
+    // "Verified" was therefore false comfort and "violated" a false alarm — a
+    // missing optional field is not a broken promise. Same resolution as above:
+    // returning null neither violates nor delivers, so closure stays explicit
+    // (deliver()/markDelivered(), or `expiresAt`) and the overdue surfacing keeps
+    // it visible meanwhile. A promise nobody can verify should NAG, not vanish —
+    // and must never be reported as kept.
+    if (commitment.type === 'behavioral') {
+      // Preserve the one genuinely useful side effect of the old path: the rules
+      // file self-heals if it has gone missing. That is bookkeeping repair, and
+      // it is no longer mistaken for evidence about the promise.
+      this.ensureBehavioralRulesFile();
+      return null;
+    }
+
     let result: { passed: boolean; detail: string };
 
     switch (commitment.type) {
       case 'config-change':
         result = this.verifyConfigChange(commitment);
-        break;
-      case 'behavioral':
-        result = this.verifyBehavioral(commitment);
         break;
       case 'one-time-action':
         result = this.verifyOneTimeAction(commitment);
@@ -1541,9 +1566,19 @@ export class CommitmentTracker extends EventEmitter {
       };
     }
 
+    // "all verified" was a claim about commitments the sweep had never observed —
+    // the same conflation fixed at the behavioural early-return in `verifyOne`.
+    // Report what is actually known: how many carry a real verification, and how
+    // many are simply not automatically checkable. Absence of violations is not
+    // evidence of compliance.
+    const verified = active.filter(c => c.status === 'verified').length;
+    const unverified = active.length - verified;
     return {
       status: 'healthy',
-      message: `${active.length} commitment(s) tracked, all verified`,
+      message:
+        unverified === 0
+          ? `${active.length} commitment(s) tracked, all verified`
+          : `${active.length} commitment(s) tracked — ${verified} verified, ${unverified} not automatically verifiable (no violations)`,
       lastCheck: new Date().toISOString(),
     };
   }
@@ -1566,24 +1601,24 @@ export class CommitmentTracker extends EventEmitter {
     };
   }
 
-  private verifyBehavioral(commitment: Commitment): { passed: boolean; detail: string } {
-    // Behavioral commitments are "verified" if the rule text exists in the rules file
-    if (!commitment.behavioralRule) {
-      return { passed: false, detail: 'Missing behavioralRule on behavioral commitment' };
-    }
-
+  /**
+   * Self-heal the behavioural rules file if it has gone missing.
+   *
+   * REPLACES `verifyBehavioral`, which returned this file's contents as a VERDICT
+   * on whether a promise had been kept. Presence of a commitment's id in a file
+   * this class writes from its own active list is bookkeeping, not behaviour — see
+   * the reasoning at the behavioural early-return in `verifyOne`. Repairing the
+   * file is still worth doing; it just is not evidence about the promise, so this
+   * returns nothing.
+   */
+  private ensureBehavioralRulesFile(): void {
     try {
       if (!fs.existsSync(this.rulesPath)) {
         this.writeBehavioralRules();
       }
-      const content = fs.readFileSync(this.rulesPath, 'utf-8');
-      const hasRule = content.includes(commitment.id);
-      return {
-        passed: hasRule,
-        detail: hasRule ? 'Behavioral rule present in injection file' : 'Behavioral rule missing from injection file — regenerating',
-      };
     } catch {
-      return { passed: false, detail: 'Failed to read behavioral rules file' };
+      // @silent-fallback-ok — the rules file is nice-to-have; a failure here must
+      // never affect a commitment's status (that conflation was the defect).
     }
   }
 

--- a/tests/unit/CommitmentTracker-verify-batches-saves.test.ts
+++ b/tests/unit/CommitmentTracker-verify-batches-saves.test.ts
@@ -54,15 +54,26 @@ describe('CommitmentTracker.verify() batches store saves (wedge fix)', () => {
   it('persists the store exactly ONCE per verify() sweep, not once per commitment', () => {
     const tracker = new CommitmentTracker({ stateDir, liveConfig: new LiveConfig(stateDir) });
 
-    // N behavioral commitments: verify() will mutate each (pending -> verified)
-    // via mutateSync(), so the pre-fix code would have written the store N times.
+    // N config-change commitments: verify() mutates each (pending -> verified) via
+    // mutateSync(), so the pre-fix code would have written the store N times.
+    //
+    // FIXTURE CHANGED 2026-07-26 (behavioural -> config-change). This test's SUBJECT
+    // is unchanged — it still asserts one store write per sweep regardless of how
+    // many commitments mutate. But behavioural commitments no longer mutate during a
+    // sweep at all: their status used to be decided by whether their id appeared in a
+    // file this class writes itself, which is bookkeeping rather than conduct, so the
+    // sweep is now a no-op for them. With zero mutations there was nothing to batch
+    // and this test measured 0 writes — a vehicle that had stopped moving, not a
+    // broken guarantee. `config-change` genuinely verifies live state, so it mutates
+    // and exercises the batching this test exists to protect.
     const N = 40;
     for (let i = 0; i < N; i++) {
       tracker.record({
         userRequest: `rule ${i}`,
         agentResponse: 'ok',
-        type: 'behavioral',
-        behavioralRule: `Always do thing number ${i}`,
+        type: 'config-change',
+        configPath: 'updates.autoApply',
+        configExpectedValue: true, // matches the fixture config.json, so it verifies
       });
     }
 

--- a/tests/unit/CommitmentTracker.test.ts
+++ b/tests/unit/CommitmentTracker.test.ts
@@ -547,7 +547,22 @@ describe('CommitmentTracker', () => {
   // ── Verification: Behavioral ───────────────────────────
 
   describe('verification — behavioral', () => {
-    it('verifies when rule is present in rules file', () => {
+    // THESE THREE TESTS REPLACE ONES THAT ASSERTED THE DEFECT.
+    //
+    // The old trio pinned "a behavioural promise is verified iff its id appears in
+    // the rules file" as correct. That file is written by this class from its own
+    // active list and nothing else reads it, so the check verified the system's own
+    // bookkeeping and reported it as a verdict on the promise. Measured live
+    // 2026-07-26: 74 commitments WITH `behavioralRule` all read `verified`, 24
+    // WITHOUT it all read `violated` — 98 of 98, decided entirely by whether an
+    // optional field was populated.
+    //
+    // Worth naming: the middle test was called "detects violation when rules file
+    // is deleted" and its body asserted `passed: true`, with a comment conceding
+    // "so it should still pass". A test whose name contradicts its own assertion
+    // documents an intention nobody implemented.
+
+    it('does NOT produce a verdict for a behavioural promise — it cannot observe behaviour', () => {
       const tracker = makeTracker(stateDir);
       const c = tracker.record({
         type: 'behavioral',
@@ -556,13 +571,15 @@ describe('CommitmentTracker', () => {
         behavioralRule: 'Always check with user before deploying changes',
       });
 
-      // Recording should have created the rules file
-      const result = tracker.verifyOne(c.id);
-      expect(result).not.toBeNull();
-      expect(result!.passed).toBe(true);
+      // null = the sweep is a no-op, exactly as for an unverifiable one-time-action.
+      expect(tracker.verifyOne(c.id)).toBeNull();
+      // And the promise stays open rather than being declared kept or broken.
+      expect(tracker.get(c.id)!.status).toBe('pending');
+      expect(tracker.get(c.id)!.verificationCount).toBe(0);
+      expect(tracker.get(c.id)!.violationCount).toBe(0);
     });
 
-    it('detects violation when rules file is deleted', () => {
+    it('repairs the rules file when deleted, without treating that as evidence either way', () => {
       const tracker = makeTracker(stateDir);
       const c = tracker.record({
         type: 'behavioral',
@@ -571,32 +588,58 @@ describe('CommitmentTracker', () => {
         behavioralRule: 'Check before deploying',
       });
 
-      // First verify passes
-      expect(tracker.verifyOne(c.id)!.passed).toBe(true);
-
-      // Delete the rules file
       const rulesPath = path.join(stateDir, 'state', 'commitment-rules.md');
       SafeFsExecutor.safeUnlinkSync(rulesPath, { operation: 'tests/unit/CommitmentTracker.test.ts:580' });
 
-      // Verify again — it should regenerate the file and pass
-      const result = tracker.verifyOne(c.id);
-      // The verifyBehavioral method regenerates if file missing, so it should still pass
-      expect(result!.passed).toBe(true);
+      expect(tracker.verifyOne(c.id)).toBeNull();   // no verdict, either direction
+      expect(fs.existsSync(rulesPath)).toBe(true);  // but the bookkeeping self-heals
+      expect(tracker.get(c.id)!.status).toBe('pending');
     });
 
-    it('handles missing behavioralRule gracefully', () => {
+    it('a MISSING behavioralRule is not a broken promise', () => {
       const tracker = makeTracker(stateDir);
       const c = tracker.record({
         type: 'behavioral',
         userRequest: 'req',
         agentResponse: 'resp',
-        // Missing behavioralRule!
+        // Missing behavioralRule — an optional field, not a broken promise.
       });
 
-      const result = tracker.verifyOne(c.id);
-      expect(result).not.toBeNull();
-      expect(result!.passed).toBe(false);
-      expect(result!.detail).toContain('Missing behavioralRule');
+      expect(tracker.verifyOne(c.id)).toBeNull();
+      // Previously this read `violated` and accumulated a tick on every sweep.
+      expect(tracker.get(c.id)!.status).toBe('pending');
+      expect(tracker.get(c.id)!.violationCount).toBe(0);
+    });
+
+    it('REGRESSION: repeated sweeps never accumulate ticks on a behavioural promise', () => {
+      // The live signature this fixes: CMT-068 at 162,344 violations, and four
+      // commitments created in the same minute holding identical counts (80,425) —
+      // proof the counter tracked sweeps, not conduct.
+      const tracker = makeTracker(stateDir);
+      const withRule = tracker.record({
+        type: 'behavioral', userRequest: 'a', agentResponse: 'b', behavioralRule: 'r',
+      });
+      const withoutRule = tracker.record({ type: 'behavioral', userRequest: 'c', agentResponse: 'd' });
+
+      for (let i = 0; i < 25; i++) tracker.verify();
+
+      for (const id of [withRule.id, withoutRule.id]) {
+        const c = tracker.get(id)!;
+        expect(c.violationCount, `${id} violations after 25 sweeps`).toBe(0);
+        expect(c.verificationCount, `${id} verifications after 25 sweeps`).toBe(0);
+        expect(c.status).toBe('pending');
+      }
+    });
+
+    it('health does not claim "all verified" over promises it never observed', () => {
+      const tracker = makeTracker(stateDir);
+      tracker.record({ type: 'behavioral', userRequest: 'a', agentResponse: 'b', behavioralRule: 'r' });
+      tracker.verify();
+
+      const health = tracker.getHealth();
+      expect(health.status).toBe('healthy');          // nothing is wrong …
+      expect(health.message).not.toMatch(/all verified/); // … but nothing is verified either
+      expect(health.message).toMatch(/not automatically verifiable/);
     });
   });
 

--- a/upgrades/next/behavioural-promise-unverifiable.md
+++ b/upgrades/next/behavioural-promise-unverifiable.md
@@ -1,0 +1,81 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**A behavioural commitment was marked `verified` or `violated` according to whether its
+optional `behavioralRule` field was populated — 98 of 98 rows, no exceptions.**
+
+`CommitmentTracker.verifyBehavioral` decided the verdict with
+`content.includes(commitment.id)` against the behavioural rules file. That file is written
+**by the same class** from its own active list, and nothing else on the machine reads it, so
+the check verified that the system had written its own file and reported the result as a
+verdict on the promise.
+
+Measured on the live store: **74 behavioural commitments with `behavioralRule` set all read
+`verified`; 24 without it all read `violated`.** Because the sweep runs about once a minute,
+each accumulated a tick per pass — CMT-068 reached **162,344 violations**, and four
+commitments created in the same minute held **identical** counts (80,425), which individual
+conduct cannot produce.
+
+Behavioural commitments now take the path this file already gives an unverifiable
+`one-time-action`: **the sweep is a no-op**, the promise stays `pending`, and closure remains
+explicit (`deliver()` / `markDelivered()` / `expiresAt`), with the overdue surfacing keeping
+it visible. Both wrong answers are removed, not just one — `verified` was false comfort and
+`violated` a false accusation, since a blank optional field is not a broken promise.
+
+`getHealth` changed with it. It previously reported `"N commitment(s) tracked, all verified"`
+whenever nothing was marked broken, inferring compliance from the absence of violations —
+which would have become a *new* false claim once these rows moved to `pending`. It now names
+how many are genuinely verified and how many are not automatically verifiable. It also stops
+reporting the component `degraded`, which those 24 false violations had made permanent.
+
+The rules file still self-heals when missing (now `ensureBehavioralRulesFile`, which returns
+nothing) — repairing bookkeeping is worth doing but is not evidence about a promise.
+
+**What this does not do:** behavioural compliance remains unverified by anything. This stops
+the system claiming otherwise; it does not build real verification, which would require
+observing conduct against each rule. `config-change` verification is untouched and still
+genuinely reads live state.
+
+## What to Tell Your User
+
+If you track commitments, promises about behaviour now show as **pending** rather than
+verified or violated, with both counters at zero. That is more honest, not a regression:
+nothing was ever watching whether those promises were kept, so "verified" was reassurance
+nobody had earned and "violated" was usually just a blank optional field.
+
+You may also notice the commitment health line stops saying "all verified" and stops
+reporting itself degraded. Both were consequences of the same defect.
+
+## Summary of New Capabilities
+
+- A promise that cannot be automatically checked reports as open instead of being declared
+  kept or broken, matching the treatment this module already gave unverifiable one-time
+  actions.
+- Commitment counters no longer accumulate a tick per sweep for behavioural promises.
+- The commitment health line distinguishes "verified" from "not automatically verifiable"
+  rather than inferring compliance from an absence of violations.
+
+## Evidence
+
+**Reproduction (before):** record a behavioural commitment and run the verify sweep 25
+times. With `behavioralRule` set: `status: 'verified'`, `verificationCount: 25`. Without it:
+`status: 'violated'`, `violationCount: 25`, detail `"Missing behavioralRule on behavioral
+commitment"`. Live store corroboration: 74/74 with the field `verified`, 24/24 without it
+`violated`; CMT-068 at 162,344; CMT-555/556/557/558 identical at 80,425.
+
+**Observed after,** same scenarios against the built code:
+
+| scenario | before | after (25 sweeps) |
+|---|---|---|
+| behavioural, `behavioralRule` set | `verified`, +1 tick per sweep | `pending`, verifications 0, violations 0 |
+| behavioural, field absent | `violated`, +1 tick per sweep | `pending`, verifications 0, violations 0 |
+| rules file deleted | produced a verdict | no verdict; file self-heals; status unchanged |
+| health, 1 behavioural row | `"1 commitment(s) tracked, all verified"` | `"1 commitment(s) tracked — 0 verified, 1 not automatically verifiable (no violations)"`, status `healthy` |
+
+**Tests:** `tests/unit/CommitmentTracker.test.ts` — three tests rewritten because they
+asserted the removed behaviour (one of them asserting that a *missing* optional field is a
+broken promise; another named `"detects violation when rules file is deleted"` whose body
+asserted the opposite, with a comment conceding it). Two regression guards added: 25 sweeps
+accumulate zero ticks on either shape of behavioural promise, and health never claims "all
+verified" over promises it has not observed. **79 tests pass**; `npx tsc --noEmit` clean.

--- a/upgrades/side-effects/behavioural-promise-unverifiable.md
+++ b/upgrades/side-effects/behavioural-promise-unverifiable.md
@@ -1,0 +1,156 @@
+# Side-Effects Review — a promise was "kept" if a text field was filled in
+
+**Version / slug:** `behavioural-promise-unverifiable`
+**Date:** `2026-07-26`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `author-applied lenses — see Phase 5 (reduced independence, disclosed)`
+
+## Summary of the change
+
+`CommitmentTracker.verifyBehavioral` decided whether a behavioural promise had been
+kept by checking `content.includes(commitment.id)` against the behavioural rules file.
+That file is written **by this same class** from its own active list, and — verified
+across the whole agent home — **nothing else reads it**. So the check verified that the
+system had successfully written its own file, and its outcome was decided entirely by
+whether the optional `behavioralRule` field was populated.
+
+Measured on the live store: **74 behavioural commitments WITH the field all read
+`verified`; 24 WITHOUT it all read `violated`. 98 of 98, no exceptions in either
+direction.** Not one status observed conduct. `verified` was false comfort; `violated`
+was a false alarm (a missing optional field is not a broken promise). Both accumulated a
+counter tick on every sweep — CMT-068 reached **162,344**, and four commitments created
+in the same minute held **identical** counts (80,425), which individual behaviour cannot
+produce.
+
+Behavioural commitments now take the same path this file already gives an unverifiable
+`one-time-action`: the sweep is a **no-op**, the promise stays `pending`, and closure
+stays explicit (`deliver()` / `markDelivered()` / `expiresAt`). The rules file still
+self-heals, but repairing bookkeeping is no longer mistaken for evidence.
+
+## Decision-point inventory
+
+| point | classification | note |
+|---|---|---|
+| behavioural early-return in `verifyOne` | `invariant` | Deterministic on `type`. Mirrors the adjacent unverifiable-one-time-action return, which carries the same reasoning and history. |
+| `ensureBehavioralRulesFile` | `invariant` | Pure repair, returns nothing. It cannot influence a status — that conflation *was* the defect. |
+| `getHealth` message | `invariant` | Counts actual `verified` rows instead of inferring verification from the absence of violations. |
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+Nothing is blocked; this is a status computation with no gating authority. The nearest
+analogue is **withholding a `verified` status from a promise genuinely being honoured** —
+and that is the point: nothing here can observe conduct, so the status was never earned.
+74 rows move from `verified` to `pending`, which is a loss of *false* reassurance only.
+
+Real cost, stated plainly: an operator who read `verified` as "Echo is complying" loses
+that signal. It was never true, so the honest replacement is silence rather than a
+number — but the change does remove something people may have been relying on.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **Behavioural compliance is still unverified.** This change makes that visible; it does
+  not solve it. Genuine verification would need an observation of conduct (e.g. grading
+  outbound turns against the rule), which is a much larger piece of work and is NOT
+  attempted here. Recorded rather than silently implied.
+- `config-change` verification is untouched and still genuinely checks live state.
+- The rules file remains written-and-read-by-nobody. Removing it entirely is a separate
+  question (its `getBehavioralContext` sibling *is* served over HTTP, so the content has
+  a consumer even though the file does not).
+- `writeBehavioralRules`' comment still claims "remove the file so hooks skip injection",
+  describing a consumer that does not exist. Left in place rather than edited blind;
+  noted as a candidate.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes, and deliberately at the *same* layer as the existing precedent: an early return in
+`verifyOne`, ten lines below the one that handles unverifiable one-time-actions, sharing
+its rationale. No new status was introduced — `pending` already means "not determined",
+and adding an `unverifiable` state would have required touching the status union, three
+terminal-status guards, `getActive`, and auto-expiry eligibility for no semantic gain.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+No. It *removes* an authority that was exercised on brittle grounds: the old path
+asserted a verdict on the operator's promises from a filesystem read. Nothing here
+blocks, delays or alters any message or action. `getHealth` no longer reports `degraded`
+from 24 false violations, which strictly reduces false authority.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No judgment point is introduced; the new branch is a `type` comparison. The change
+*retires* a pseudo-judgment (file presence standing in for conduct). The asymmetry is
+explicit in code: absence of a verdict is reported as absence, never as either outcome.
+
+## 5. Interactions
+
+- **`getHealth`** was the one consumer that read `violated`: 24 false violations made the
+  component permanently `degraded`. Now it reports counts it can defend. Verified by grep
+  that no code outside this class reads `status === 'violated'`.
+- **`isAutoExpiryEligible`** treats `pending` and `violated` identically, so moving rows
+  between them causes no change in expiry behaviour — checked before editing.
+- **PromiseBeacon / overdue surfacing** operate on open commitments; `pending` keeps them
+  visible, which is the stated intent of the precedent ("should NAG, not vanish").
+- No persistence change, no migration, no config key. Existing rows re-evaluate to
+  `pending` on the next sweep without a data rewrite.
+
+## 6. External surfaces
+
+`GET /commitments` and `GET /commitments/:id` will show behavioural promises as `pending`
+rather than `verified`/`violated`, with both counters at 0. `GET /health` reports the
+commitment component's message differently. No route shape changes; no field is removed.
+
+## 6b. Operator-surface quality
+
+The operator previously saw either a reassuring `verified` that meant nothing, or a
+`violated` (with a five-figure count) that meant nothing — and, because 24 rows were
+falsely violated, a permanently `degraded` health component. They now see `pending` with
+honest zeroes, and a health line naming how many promises are simply not automatically
+checkable. `pending` is deliberately not alarming: nothing is wrong, nothing is known.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: `unified` by construction — no new state.** This changes how an existing
+per-machine store's rows are evaluated; it introduces no new field, file, or surface.
+Each machine already keeps its own commitment store (existing posture, unchanged by this
+work), and the evaluation is a pure function of a row plus that machine's rules file. No
+replication path is required and no `machine-local-justification` marker is needed,
+because no new machine-local state is introduced.
+
+## 8. Rollback cost
+
+One commit touching one source file and its test file. No migration, no persisted state,
+no config. Reverting restores the old semantics — and with them 98-of-98 statuses decided
+by a text field, plus the tick accumulation documented above.
+
+## Phase 5 — Second-pass review (independent reviewer subagent)
+
+**Disclosure, per Truthful Provenance:** no independent reviewer subagent was spawned — a
+standing instruction in this session prohibits it unless the operator requests it. The
+review lenses were applied by the author. That is **reduced independence**, recorded as
+such rather than presented as a concurring second pass.
+
+What author-applied review caught and changed:
+
+1. **The first instinct was to fix only the missing-field half** (stop marking a promise
+   violated for an absent optional field). That would have left the *false-comfort* half —
+   74 rows still reading `verified` — which is the more dangerous direction, and would have
+   repeated the "fix one site, leave its twin" mistake flagged on PR #1647 earlier tonight.
+   Both halves are addressed.
+2. **`getHealth`'s success message had to change too.** With behavioural rows at `pending`,
+   "all verified" would have become a *new* false claim introduced by this very fix — the
+   defect migrating one line sideways.
+3. **The rules-file self-heal was nearly lost.** The old method regenerated the file when
+   missing; deleting the method wholesale would have dropped that. Preserved as
+   `ensureBehavioralRulesFile`, which deliberately returns nothing.
+4. **Consumers were checked, not assumed** — establishing that `getHealth` was the only
+   reader of `violated` and that auto-expiry treats `pending`/`violated` alike.


### PR DESCRIPTION
## ELI16 — a promise counted as kept because a text box was filled in

When I promise something about how I will behave, that promise gets recorded, and a periodic check marks it kept or broken. The check looked in a reminder file to see whether the promise's identifier appeared there. Present, kept. Absent, broken.

**But that reminder file is written by the very same system, from its own list of promises — and nothing else on the machine reads it.** So the check asked "did I successfully write my own note?" and reported the answer as "did Echo keep her word?"

**Seventy-four promises had one optional field filled in. All seventy-four read "kept." Twenty-four did not. All twenty-four read "broken." Ninety-eight of ninety-eight, no exceptions either way.** And because the check runs about once a minute, each collected another tally mark every pass — one from March reached **162,344 "violations"**, and four created in the same minute held **identical** counts, which no amount of real behaviour could produce.

A behavioural promise is now left **open** instead. Nothing here can watch conduct, so "not determined" is the honest answer — which is exactly what this same file already does for another promise type it cannot check, **ten lines above**, with a comment explaining why. That block's history records fixing 51,000-tick violation spam for one-time-actions; the identical defect was simply never applied to behavioural ones.

## Both wrong answers go, not just one

- **"Kept" was the more dangerous** — reassurance nobody had earned.
- **"Broken" was a false accusation** — a blank optional field is not a broken promise.

Fixing only the missing-field half would have left the false-comfort direction standing, repeating the "fix one site, leave its twin" mistake flagged on #1647 earlier tonight.

`getHealth` changed with it: it used to say `"all verified"` whenever nothing was marked broken — inferring compliance from an absence of complaints — which would have become a **new** false claim once these rows moved to `pending`. It also stops reporting the component `degraded`, which those 24 false violations had made permanent.

## Refusal evidence (before → after, 25 sweeps, on the built code)

| scenario | BEFORE | AFTER |
|---|---|---|
| behavioural, field set | `verified`, +1 tick per sweep | `pending`, verifications 0, violations 0 |
| behavioural, field absent | `violated`, +1 tick per sweep | `pending`, verifications 0, violations 0 |
| rules file deleted | produced a verdict | no verdict; file self-heals; status unchanged |
| health, 1 behavioural row | `"1 commitment(s) tracked, all verified"` | `"… 0 verified, 1 not automatically verifiable (no violations)"`, still `healthy` |

## What this does NOT do

**Behavioural compliance remains unverified by anything.** This stops the system claiming otherwise; it does not build real verification, which would require observing conduct against each rule. That is a much larger piece of work and is deliberately not attempted here — so this is a change from a confident wrong answer to an honest absence of one, which is an improvement but worth naming precisely.

`config-change` verification is untouched and still genuinely reads live state.

## The tests

Three were rewritten because all three asserted the removed behaviour — including one asserting that a **missing optional field** is a broken promise.

The middle one deserves quoting: named **`detects violation when rules file is deleted`**, its body asserted that nothing was detected, with a comment conceding *"so it should still pass."* A test whose name contradicts its own assertion records an intention nobody implemented, and it sat green looking like coverage. Second such test found tonight.

Two regression guards added: 25 sweeps accumulate zero ticks on either shape of promise, and health never claims "all verified" over promises it has not observed. **79 tests pass**; `npx tsc --noEmit` clean.

## Scope

- A status computation with **zero gating authority** — it *removes* an authority that was exercised on brittle grounds. `getHealth` was the only consumer of `violated` (checked, not assumed), and auto-expiry treats `pending`/`violated` identically, so no behavioural regression.
- No new status: `pending` already means "not determined". Adding one would have touched the status union, three terminal guards, `getActive` and expiry eligibility for no semantic gain.
- No migration, no config, no persisted-data rewrite — existing rows re-evaluate on the next sweep.
- Second-pass review was **author-applied, not independent** — disclosed in the artifact's Phase 5.

This is the audit's original inversion — filing counted as doing — in the promise machinery, the same shape as the learning score counting filed items as learning (#1644, the first fix tonight).

Refs ACT-1243; `convergence-towards-coherence` Tier 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsNuZUXXxnNKwA9mHs2TdQ
