### PR TITLE
fix(projects): a merged record that could not say what merged it

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T06-11-26-036Z-merged-record-carries-its-evidence.json
+++ b/.instar/instar-dev-decisions/2026-07-26T06-11-26-036Z-merged-record-carries-its-evidence.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T06:11:26.036Z",
+  "slug": "merged-record-carries-its-evidence",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 180,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-26T06-32-44-292Z-merged-record-carries-its-evidence.json
+++ b/.instar/instar-dev-decisions/2026-07-26T06-32-44-292Z-merged-record-carries-its-evidence.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T06:32:44.292Z",
+  "slug": "merged-record-carries-its-evidence",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 9,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-26T06-33-29-464Z-merged-record-carries-its-evidence.json
+++ b/.instar/instar-dev-decisions/2026-07-26T06-33-29-464Z-merged-record-carries-its-evidence.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T06:33:29.464Z",
+  "slug": "merged-record-carries-its-evidence",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 9,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-26T06-34-18-755Z-merged-record-carries-its-evidence.json
+++ b/.instar/instar-dev-decisions/2026-07-26T06-34-18-755Z-merged-record-carries-its-evidence.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T06:34:18.755Z",
+  "slug": "merged-record-carries-its-evidence",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 9,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-26T06-35-13-036Z-merged-record-carries-its-evidence.json
+++ b/.instar/instar-dev-decisions/2026-07-26T06-35-13-036Z-merged-record-carries-its-evidence.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T06:35:13.036Z",
+  "slug": "merged-record-carries-its-evidence",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 9,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-26T06-35-53-224Z-merged-record-carries-its-evidence.json
+++ b/.instar/instar-dev-decisions/2026-07-26T06-35-53-224Z-merged-record-carries-its-evidence.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T06:35:53.224Z",
+  "slug": "merged-record-carries-its-evidence",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 9,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/merged-record-carries-its-evidence.eli16.md
+++ b/docs/specs/merged-record-carries-its-evidence.eli16.md
@@ -1,0 +1,95 @@
+# A record that said "merged" but could not say what merged it — Plain-English Overview
+
+> The one-line version: the gate that decides whether a piece of work is really
+> finished demanded four kinds of proof, checked all four, and then threw the proof
+> away — so the record said "done" and could name nothing. Two safety checks that
+> read that proof were therefore looking at an empty table and reporting all clear.
+
+## How I found it
+
+I read my own project record to confirm the two finished items really were finished.
+Both said "merged". Neither carried a pull request number, a commit, or a timestamp —
+no trace of what made them merged. I had passed that evidence in myself when I marked
+them done.
+
+## What was happening
+
+To move an item to "merged", the gate proves four things: the pull request really is
+merged, it has a real commit attached, that commit is genuinely present on the main
+branch, and the tests were green. All four are real checks against the outside world.
+
+Then it saved a single word — "merged" — and dropped everything it had just proven.
+
+The reason turned out to be a matter of shape rather than carelessness. When the gate
+**refuses**, it hands back a reason and an error code, so it explains itself fully.
+When it **approves**, it hands back one bit: yes. So the caller had nothing to write
+down, because approval carried no information to write. The gate explained itself when
+it said no and said nothing when it said yes.
+
+## Why it mattered more than tidiness
+
+Two other pieces of the system watch for merged work that later gets undone —
+reverted, or force-pushed off the main branch. Both find the items to check by looking
+for that saved commit.
+
+Nothing ever saved it. So both of them examined an empty list, found nothing wrong,
+and said so — every time. One of them runs on every single read of the project.
+
+**A detector that inspects nothing and reports nothing looks exactly like a detector
+that inspects everything and finds nothing wrong.** That is this project's central
+finding, and here it sat on the question of whether finished work is still finished.
+
+## The part that nearly bit me
+
+I almost fixed only the first half — start saving the evidence — and stopped.
+
+Because that watching code had never actually run, three faults had been sitting in it
+untouched. It asked a question it lacked permission to ask, so a safety guard refused
+it outright. It looked for the commit on the wrong branch — on this machine the
+obvious branch is my personal copy, not where work actually lands. And worst, it
+treated *every* failure as proof the work had been reverted, including "I was refused"
+and "that branch does not exist."
+
+All three had already been found and fixed in the neighbouring piece of code weeks
+earlier. They survived here only because nobody could see them: the code never ran.
+
+So switching the evidence on, by itself, would have converted silent blindness into
+confident false accusations — healthy finished work marked as broken, and its schedule
+cleared. That is worse than the blindness. Both halves had to move together.
+
+## What changed
+
+An approval now carries what it proved: the pull request, the commit, the branch it
+was actually checked against, and when. That gets saved in the same single write that
+records the stage, so there is no window where the record says "merged" with nothing
+behind it.
+
+The watching code now asks its question properly, checks the branch it was *told* to
+check rather than assuming, and — the important part — has three possible answers
+instead of two:
+
+- **Still there.** Proven present on the main branch.
+- **Gone.** The one specific answer that genuinely means reverted.
+- **I could not tell.** Anything else at all.
+
+The third answer changes nothing about the item. It gets asked again later, rather
+than answered wrongly now.
+
+## What it does not do, said plainly
+
+This does not add any new checking of merged work. It makes the existing checks
+*possible*, by giving them the evidence they were always written to read, and safe, by
+stopping them from guessing. Whether they then catch a real regression is something
+only a real regression will show.
+
+## A note on the tests
+
+Nine new checks. All nine fail against the old code, with the failures naming the
+defect precisely — "expected undefined to be defined" for the evidence-free approval,
+and "expected false to be true" for the discarded pull request number.
+
+One of them failed the first time for the wrong reason: I had grabbed a fixed-size
+window of text around the code I wanted to inspect, and it ran past the end into the
+next block, so the check was reading the wrong lines. That is the same error this file
+is about — measuring something adjacent to what you meant and believing the answer.
+Found by running it, which is the cheapest possible place to find it.

--- a/docs/specs/merged-record-carries-its-evidence.eli16.md
+++ b/docs/specs/merged-record-carries-its-evidence.eli16.md
@@ -93,3 +93,22 @@ window of text around the code I wanted to inspect, and it ran past the end into
 next block, so the check was reading the wrong lines. That is the same error this file
 is about — measuring something adjacent to what you meant and believing the answer.
 Found by running it, which is the cheapest possible place to find it.
+
+## And one more, which is almost too neat
+
+The first attempt to land this change was **refused** by a rule that scans the whole
+codebase counting error-handlers which swallow failures silently. It reported that I
+had added one.
+
+I hadn't. It had found the phrase inside my own *comment* — the paragraph above, where
+I describe the forbidden pattern in order to explain why I removed it. The rule counts
+text, and text cannot tell an example from an instance.
+
+So a checker built to catch "errors turning into nothing" was fooled by a sentence
+about errors turning into nothing. That is the third time in one evening a checker has
+been tripped by a message *about* its own subject.
+
+I reworded the comment rather than change the rule. Weakening a safety check to
+unblock your own work is the wrong instinct even when the check is imprecise — and the
+rule is right far more often than it is wrong. The comment now names the shape in
+words and points at a sibling test that documents the same trap.

--- a/src/core/ProjectRoundExecution.ts
+++ b/src/core/ProjectRoundExecution.ts
@@ -473,25 +473,83 @@ function defaultVerifyMergedItems(targetRepoPath: string): (childIds: string[]) 
   };
 }
 
-/** Helper exported so callers can wire a SafeGit-backed verifier. */
+/**
+ * Three-state outcome. `unverifiable` is NOT a soft `regressed`: it means the
+ * check could not be run at all, and collapsing the two is how a refusal becomes
+ * a fabricated factual claim (the defect `/projects/:id/advance` had fixed for
+ * itself in #1643 while this sibling kept it).
+ */
+export interface MergedVerificationResult {
+  /** Proven reachable from the canonical-main ref. */
+  verified: Set<string>;
+  /** git exited 1 — the documented, genuine "not an ancestor". */
+  regressed: Set<string>;
+  /** The question could not be answered; the caller must NOT infer either way. */
+  unverifiable: Map<string, string>;
+}
+
+/**
+ * Helper exported so callers can wire a SafeGit-backed verifier.
+ *
+ * This function was dead code in practice until 2026-07-26: it selects on
+ * `child.mergeCommitOid`, and the only path that could have written that field
+ * (`/projects/:id/advance`) validated the merge commit and then discarded it. So
+ * every child hit the `continue` and the caller saw an empty set — a regression
+ * detector that scanned nothing and reported nothing, which reads exactly like a
+ * clean bill of health. Three defects therefore sat here unexercised, all three
+ * already fixed in the advance path a few hundred lines away:
+ *
+ *   1. no `sourceTreeReadOk`, so SourceTreeGuard REFUSES this read against an
+ *      instar source tree (the #1641 defect);
+ *   2. a hardcoded `origin/main`, which on a dev-agent home is the agent's FORK,
+ *      not where merges land — so the correct answer is "unreachable";
+ *   3. `catch {}` → not verified → the caller marks the item `regressed`, i.e.
+ *      "I could not check" rendered as "it was reverted".
+ *
+ * Any one of those would have turned healthy merged items into false regressions
+ * the moment the evidence started being written. Fixed together, because writing
+ * the evidence is what arms this code path.
+ */
 export async function verifyMergedItemsViaGit(
   targetRepoPath: string,
   childIds: string[],
-  tracker: InitiativeTracker
-): Promise<Set<string>> {
+  tracker: InitiativeTracker,
+  /** Canonical-main ref. Callers on a fork-origin install MUST resolve and pass
+   *  the real one; the default preserves behaviour for canonical-origin installs. */
+  mergeBaseBranch: string = 'origin/main'
+): Promise<MergedVerificationResult> {
   const verified = new Set<string>();
+  const regressed = new Set<string>();
+  const unverifiable = new Map<string, string>();
   for (const id of childIds) {
     const child = tracker.get(id);
-    if (!child || !child.mergeCommitOid) continue;
+    if (!child) continue;
+    if (!child.mergeCommitOid) {
+      // No evidence on the record — that is not a regression, it is an item we
+      // cannot speak about. Naming it keeps the gap visible instead of silently
+      // folding it into a clean result.
+      unverifiable.set(id, 'no mergeCommitOid recorded on the item');
+      continue;
+    }
     try {
-      SafeGitExecutor.run(
-        ['merge-base', '--is-ancestor', child.mergeCommitOid, 'origin/main'],
-        { cwd: targetRepoPath, operation: 'ProjectRoundExecution.verifyMergedItemsViaGit' }
+      SafeGitExecutor.readSync(
+        ['merge-base', '--is-ancestor', child.mergeCommitOid, mergeBaseBranch],
+        {
+          cwd: targetRepoPath,
+          operation: 'ProjectRoundExecution.verifyMergedItemsViaGit',
+          stdio: ['ignore', 'ignore', 'ignore'],
+          sourceTreeReadOk: true,
+        }
       );
       verified.add(id);
-    } catch {
-      // Not an ancestor of origin/main — not verified.
+    } catch (err) {
+      const status = (err as { status?: unknown }).status;
+      if (status === 1) {
+        regressed.add(id); // git's documented exit 1 — the ONLY genuine negative
+      } else {
+        unverifiable.set(id, err instanceof Error ? err.message : String(err));
+      }
     }
   }
-  return verified;
+  return { verified, regressed, unverifiable };
 }

--- a/src/core/ProjectRoundExecution.ts
+++ b/src/core/ProjectRoundExecution.ts
@@ -503,8 +503,13 @@ export interface MergedVerificationResult {
  *      instar source tree (the #1641 defect);
  *   2. a hardcoded `origin/main`, which on a dev-agent home is the agent's FORK,
  *      not where merges land — so the correct answer is "unreachable";
- *   3. `catch {}` → not verified → the caller marks the item `regressed`, i.e.
- *      "I could not check" rendered as "it was reverted".
+ *   3. a bodyless catch swallowing every error → not verified → the caller marks
+ *      the item `regressed`, i.e. "I could not check" rendered as "it was
+ *      reverted". (Described in words rather than shown as a literal: the
+ *      empty-catch ratchet counts occurrences in comments too, so quoting the
+ *      forbidden shape here fails the lint — a text matcher fooled by prose
+ *      describing the thing it forbids. Same trap is documented in
+ *      tests/unit/projects-advance-mergebase-wiring.test.ts.)
  *
  * Any one of those would have turned healthy merged items into false regressions
  * the moment the evidence started being written. Fixed together, because writing

--- a/src/core/StageTransitionValidator.ts
+++ b/src/core/StageTransitionValidator.ts
@@ -27,8 +27,34 @@ import path from 'node:path';
 import type { PipelineStage } from './InitiativeTracker.js';
 import { extractFrontmatter } from './SafeYaml.js';
 
+/**
+ * What a PASSING `building → merged` verdict established. The validator proves
+ * these four things (PR merged, a real merge-commit sha, that sha reachable from
+ * canonical main, CI rollup green) and until 2026-07-26 returned a bare
+ * `{ ok: true }` — one bit. So the caller could not persist what had just been
+ * checked, and the record ended up asserting `merged` while unable to say what
+ * merged it.
+ *
+ * The asymmetry is the point: a REFUSAL already carried `reason` + `code`, so the
+ * validator explained itself when it said no and said nothing when it said yes.
+ * Evidence on the success path restores the symmetry — and it is what the
+ * merged-state reconcilers consume, so without it they select nothing and their
+ * silence is indistinguishable from "no regressions found".
+ */
+export interface MergedEvidence {
+  prNumber: number;
+  /** GitHub-reported merge commit sha, format-validated above. */
+  mergeCommitOid: string;
+  /** The canonical-main ref the sha was proven reachable from — NOT assumed to
+   *  be `origin/main`, which is the agent's FORK on a dev-agent home. A later
+   *  re-check must use the SAME ref or it will contradict this verdict. */
+  mergeBaseBranch: string;
+  /** ISO instant this evidence was established. */
+  verifiedAt: string;
+}
+
 export type StageTransitionResult =
-  | { ok: true }
+  | { ok: true; evidence?: MergedEvidence }
   | { ok: false; reason: string; code: string };
 
 /**
@@ -322,7 +348,17 @@ export async function validateStageTransition(
     if (!ciIsGreen(view.statusCheckRollup)) {
       return { ok: false, reason: 'CI rollup is not green', code: 'CI_NOT_GREEN' };
     }
-    return { ok: true };
+    // Hand back WHAT was proven, not just THAT something was. The caller
+    // persists this onto the item so the record can name its own evidence.
+    return {
+      ok: true,
+      evidence: {
+        prNumber: ctx.prNumber,
+        mergeCommitOid: oid,
+        mergeBaseBranch,
+        verifiedAt: new Date().toISOString(),
+      },
+    };
   }
 
   // ── outline (creation default) ───────────────────────────────────

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -15908,17 +15908,46 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       const candidateIds = candidates.map((c) => c.id);
       if (candidateIds.length > 0) {
         let verified: Set<string> = new Set();
+        let regressedIds: Set<string> = new Set();
         try {
-          verified = await verifyMergedItemsViaGit(project.targetRepoPath, candidateIds, ctx.initiativeTracker);
+          const outcome = await verifyMergedItemsViaGit(
+            project.targetRepoPath,
+            candidateIds,
+            ctx.initiativeTracker,
+            // The fork-origin fix the advance path already applies. Without it a
+            // dev-agent home checks the agent's FORK, where the merge commit is
+            // genuinely absent, and every healthy item reads as regressed.
+            resolveCanonicalMainRef(project.targetRepoPath),
+          );
+          verified = outcome.verified;
+          regressedIds = outcome.regressed;
         } catch {
-          // git not available, no network, etc. — leave verified empty so we
-          // still update ciCheckedAt to back off; better than a hot loop.
+          // Whole-call failure — leave BOTH sets empty so every candidate falls
+          // into the unverifiable branch below. We still bump ciCheckedAt to back
+          // off rather than spin, but we do not invent a verdict.
         }
         let touched = false;
         for (const cand of candidates) {
           const child = ctx.initiativeTracker.get(cand.id);
           if (!child) continue;
           const isMerged = verified.has(cand.id);
+          const isRegressed = regressedIds.has(cand.id);
+          // "I could not check" is not a verdict. Previously anything not in
+          // `verified` was marked `regressed`, so a guard refusal, a missing
+          // binary or a bad ref demoted a healthy item and cleared its round's
+          // schedule. Only git's documented exit 1 demotes now; an unverifiable
+          // item keeps its stage and only takes the ciCheckedAt backoff, so the
+          // question is asked again later instead of being answered wrongly now.
+          if (!isMerged && !isRegressed) {
+            try {
+              await ctx.initiativeTracker.update(cand.id, {
+                ciCheckedAt: new Date(nowMs).toISOString(),
+                ifMatch: child.version,
+              });
+              touched = true;
+            } catch { /* @silent-fallback-ok — backoff only; stage untouched */ }
+            continue;
+          }
           try {
             await ctx.initiativeTracker.update(cand.id, {
               pipelineStage: isMerged ? 'merged' : 'regressed',
@@ -16258,8 +16287,23 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     }
 
     try {
+      // Persist the evidence the gate just established, in the SAME write that
+      // records the stage. Before 2026-07-26 the validated artifact built the
+      // validation context and was then discarded, so an item read `merged`
+      // while carrying no prNumber, no merge commit and no check timestamp —
+      // strictness at the gate, amnesia in the record. Two merged-state
+      // reconcilers select on `mergeCommitOid`, so nothing being written meant
+      // they matched nothing and reported nothing, which reads exactly like
+      // "no regressions found".
       const updated = await ctx.initiativeTracker.update(itemId, {
         pipelineStage: targetStage,
+        ...(result.evidence
+          ? {
+              prNumber: result.evidence.prNumber,
+              mergeCommitOid: result.evidence.mergeCommitOid,
+              ciCheckedAt: result.evidence.verifiedAt,
+            }
+          : {}),
         ifMatch: child.version,
       });
       // Bump the project version too so concurrent advance calls don't
@@ -16271,8 +16315,18 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         ifMatch: project.version,
       });
       res.json({
-        item: { id: updated.id, pipelineStage: updated.pipelineStage, version: updated.version },
+        item: {
+          id: updated.id,
+          pipelineStage: updated.pipelineStage,
+          version: updated.version,
+          // Echo back what the record now holds, so a caller can confirm the
+          // evidence landed instead of trusting that it did.
+          prNumber: updated.prNumber,
+          mergeCommitOid: updated.mergeCommitOid,
+          ciCheckedAt: updated.ciCheckedAt,
+        },
         project: { id: refreshed.id, version: refreshed.version },
+        ...(result.evidence ? { evidence: result.evidence } : {}),
       });
     } catch (err) {
       if (err instanceof Error && err.name === 'OccVersionMismatchError') {

--- a/tests/unit/StageTransitionValidator.test.ts
+++ b/tests/unit/StageTransitionValidator.test.ts
@@ -268,6 +268,53 @@ describe('StageTransitionValidator', () => {
     expect(r.ok).toBe(true);
   });
 
+  // A PASSING verdict must say what it proved. Until 2026-07-26 it returned a
+  // bare `{ ok: true }`, so the caller could not persist the evidence and the
+  // record asserted `merged` while unable to name what merged it. The refusal
+  // branches were richly informative the whole time — the asymmetry WAS the bug.
+  it('building → merged: a PASSING verdict carries the evidence it established', async () => {
+    const ctx: ValidationContext = {
+      targetRepoPath: tmpRepo,
+      prNumber: 1650,
+      ghPrView: async () => ({
+        state: 'MERGED',
+        mergeCommit: { oid: '5ff7559942d6aabbccdd' },
+        statusCheckRollup: [{ conclusion: 'SUCCESS' }],
+      }),
+      gitMergeBaseIsAncestor: () => true,
+      mergeBaseBranch: 'upstream/main',
+    };
+    const before = Date.now();
+    const r = await validateStageTransition('building', 'merged', ctx);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return; // narrow
+    expect(r.evidence).toBeDefined();
+    expect(r.evidence?.prNumber).toBe(1650);
+    expect(r.evidence?.mergeCommitOid).toBe('5ff7559942d6aabbccdd');
+    // The ref it was ACTUALLY proven against, not an assumed origin/main. A
+    // later re-check that used a different ref would contradict this verdict.
+    expect(r.evidence?.mergeBaseBranch).toBe('upstream/main');
+    const ts = Date.parse(String(r.evidence?.verifiedAt));
+    expect(Number.isFinite(ts)).toBe(true);
+    expect(ts).toBeGreaterThanOrEqual(before - 1000);
+  });
+
+  it('building → merged: a REFUSED verdict carries no evidence (nothing was established)', async () => {
+    const ctx: ValidationContext = {
+      targetRepoPath: tmpRepo,
+      prNumber: 42,
+      ghPrView: async () => ({
+        state: 'MERGED',
+        mergeCommit: { oid: 'aaaaaaa' },
+        statusCheckRollup: [{ conclusion: 'FAILURE' }],
+      }),
+      gitMergeBaseIsAncestor: () => true,
+    };
+    const r = await validateStageTransition('building', 'merged', ctx);
+    expect(r.ok).toBe(false);
+    expect((r as unknown as { evidence?: unknown }).evidence).toBeUndefined();
+  });
+
   it('building → merged: rejects when mergeCommit not reachable from origin/main', async () => {
     const ctx: ValidationContext = {
       targetRepoPath: tmpRepo,

--- a/tests/unit/merged-record-carries-its-evidence.test.ts
+++ b/tests/unit/merged-record-carries-its-evidence.test.ts
@@ -1,0 +1,260 @@
+/**
+ * The merged record must carry its own evidence, and the checker that reads that
+ * evidence must be able to say "I could not check".
+ *
+ * THE DEFECT (found 2026-07-26 auditing my own project tracker). Both Tier-1
+ * items of the `convergence-towards-coherence` project read
+ * `pipelineStage: "merged"` and carried NO artifact fields at all — no prNumber,
+ * no mergeCommitOid, no ciCheckedAt. `/projects/:id/advance` built a validation
+ * context from the submitted artifact, proved four things about it (PR MERGED, a
+ * format-valid merge sha, that sha reachable from canonical main, CI rollup
+ * green), and then wrote ONLY `pipelineStage`. Strictness at the gate, amnesia in
+ * the record. The root cause was a TYPE: `StageTransitionResult`'s success case
+ * was `{ ok: true }`, one bit, while every refusal carried `reason` + `code` — so
+ * the validator explained itself when it said no and said nothing when it said
+ * yes, and the caller had nothing to persist.
+ *
+ * WHY IT MATTERED BEYOND TIDINESS. Two merged-state reconcilers select on
+ * `mergeCommitOid`:
+ *   - `GET /projects/:id`'s lazy reconciler (documented "may mutate"), and
+ *   - `verifyMergedItemsViaGit`, which skips any child without one.
+ * Nothing ever wrote the field, so the candidate set was ALWAYS empty. A
+ * regression detector that scans nothing and reports nothing is indistinguishable
+ * from one that finds no regressions — merged work reverted or force-pushed off
+ * main would never have been noticed, and the silence read as health.
+ *
+ * WHY THE FIX HAD TO INCLUDE THE CONSUMER. Because the consumer had never run,
+ * three defects sat in it unexercised — all three ALREADY FIXED in the advance
+ * path a few hundred lines away:
+ *   1. `SafeGitExecutor.run` without `sourceTreeReadOk`, so SourceTreeGuard
+ *      refuses the read against an instar source tree (the #1641 defect);
+ *   2. a hardcoded `origin/main`, which on a dev-agent home is the agent's FORK,
+ *      where the merge commit is legitimately absent;
+ *   3. `catch {}` → not verified → the caller marked the item `regressed`, i.e.
+ *      "I could not check" rendered as "it was reverted".
+ * Writing the evidence is what ARMS that path, so writing it alone would have
+ * converted silent blindness into confident false regressions. This is the THIRD
+ * recorded instance of defect class 3 (2026-05-29 failure-learning, 2026-07-25
+ * projects/advance); each prior ratchet was scoped to its own subsystem.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { verifyMergedItemsViaGit } from '../../src/core/ProjectRoundExecution.js';
+import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { InitiativeTracker } from '../../src/core/InitiativeTracker.js';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const ROUTES = path.join(REPO_ROOT, 'src/server/routes.ts');
+const EXECUTION = path.join(REPO_ROOT, 'src/core/ProjectRoundExecution.ts');
+
+/** Extract each `SafeGitExecutor.readSync(...)` call's inner text, paren-balanced. */
+function readSyncCalls(file: string): string[] {
+  const src = fs.readFileSync(file, 'utf-8');
+  const needle = 'SafeGitExecutor.readSync(';
+  const out: string[] = [];
+  let i = 0;
+  while ((i = src.indexOf(needle, i)) !== -1) {
+    const start = i + needle.length;
+    let depth = 1;
+    let j = start;
+    while (j < src.length && depth > 0) {
+      const c = src[j];
+      if (c === '(') depth++;
+      else if (c === ')') depth--;
+      j++;
+    }
+    out.push(src.slice(start, j - 1));
+    i = j;
+  }
+  return out;
+}
+
+/** Strip comments so a text assertion cannot be satisfied (or fooled) by prose. */
+function stripComments(s: string): string {
+  return s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+describe('verifyMergedItemsViaGit: three states, and "could not check" is one of them', () => {
+  let stateDir: string;
+  let tracker: InitiativeTracker;
+
+  beforeEach(async () => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'merged-evidence-'));
+    fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
+    tracker = new InitiativeTracker(stateDir);
+    const child = (id: string) => ({
+      id,
+      title: `child ${id}`,
+      description: 'fixture child for merged-evidence verification',
+      phases: [{ id: 'build', name: 'Build' }],
+    });
+    await tracker.create(child('has-oid'));
+    await tracker.update('has-oid', { mergeCommitOid: 'a1b2c3d4e5f6' });
+    await tracker.create(child('no-oid'));
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    SafeFsExecutor.safeRmSync(stateDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/merged-record-carries-its-evidence.test.ts',
+    });
+  });
+
+  it('git exit 0 → verified', async () => {
+    vi.spyOn(SafeGitExecutor, 'readSync').mockReturnValue('');
+    const r = await verifyMergedItemsViaGit('/tmp/repo', ['has-oid'], tracker);
+    expect([...r.verified]).toEqual(['has-oid']);
+    expect(r.regressed.size).toBe(0);
+    expect(r.unverifiable.size).toBe(0);
+  });
+
+  it('git exit status 1 → regressed (the ONLY genuine negative)', async () => {
+    vi.spyOn(SafeGitExecutor, 'readSync').mockImplementation(() => {
+      const e = new Error('not an ancestor') as Error & { status?: number };
+      e.status = 1;
+      throw e;
+    });
+    const r = await verifyMergedItemsViaGit('/tmp/repo', ['has-oid'], tracker);
+    expect([...r.regressed]).toEqual(['has-oid']);
+    expect(r.verified.size).toBe(0);
+    expect(r.unverifiable.size).toBe(0);
+  });
+
+  it('any OTHER failure → unverifiable, never regressed', async () => {
+    // status 128 = bad revision (e.g. the wrong canonical-main ref); a
+    // SourceTreeGuardError carries no status at all. Both are the same class:
+    // the question was not answered. Collapsing them into `regressed` is how a
+    // refusal becomes a fabricated factual claim.
+    for (const status of [128, undefined]) {
+      vi.restoreAllMocks();
+      vi.spyOn(SafeGitExecutor, 'readSync').mockImplementation(() => {
+        const e = new Error('could not resolve ref') as Error & { status?: number };
+        if (status !== undefined) e.status = status;
+        throw e;
+      });
+      const r = await verifyMergedItemsViaGit('/tmp/repo', ['has-oid'], tracker);
+      expect(r.regressed.size, `status ${String(status)} must not demote an item`).toBe(0);
+      expect(r.verified.size).toBe(0);
+      expect(r.unverifiable.has('has-oid')).toBe(true);
+    }
+  });
+
+  it('a child with NO recorded evidence is unverifiable, not regressed', async () => {
+    vi.spyOn(SafeGitExecutor, 'readSync').mockReturnValue('');
+    const r = await verifyMergedItemsViaGit('/tmp/repo', ['no-oid'], tracker);
+    expect(r.regressed.size).toBe(0);
+    expect(r.verified.size).toBe(0);
+    expect(r.unverifiable.get('no-oid')).toMatch(/no mergeCommitOid/i);
+  });
+
+  it('checks the canonical-main ref it is GIVEN, not a hardcoded origin/main', async () => {
+    const seen: string[][] = [];
+    vi.spyOn(SafeGitExecutor, 'readSync').mockImplementation(((args: readonly string[]) => {
+      seen.push([...args]);
+      return '';
+    }) as typeof SafeGitExecutor.readSync);
+    await verifyMergedItemsViaGit('/tmp/repo', ['has-oid'], tracker, 'upstream/main');
+    expect(seen.length).toBe(1);
+    expect(seen[0]).toEqual(['merge-base', '--is-ancestor', 'a1b2c3d4e5f6', 'upstream/main']);
+  });
+
+  it('declares itself a source-tree READ (without it the guard refuses every call)', () => {
+    const calls = readSyncCalls(EXECUTION).filter(c =>
+      /operation\s*:\s*['"]ProjectRoundExecution\.verifyMergedItemsViaGit['"]/.test(c),
+    );
+    expect(calls.length, 'the verifier readSync must exist').toBe(1);
+    expect(
+      /\bsourceTreeReadOk\s*:\s*true\b/.test(calls[0]),
+      'a project targetRepoPath IS an instar source tree on every dogfooding agent',
+    ).toBe(true);
+    // And the ref must come from the parameter, not be baked into the call.
+    expect(
+      /['"]origin\/main['"]/.test(calls[0]),
+      'the canonical-main ref must be the caller-supplied parameter, not a literal',
+    ).toBe(false);
+  });
+});
+
+describe('the advance route records the evidence it validated', () => {
+  const src = () => fs.readFileSync(ROUTES, 'utf-8');
+
+  /** Body of the single `initiativeTracker.update(itemId, {...})` in /advance. */
+  function advanceUpdateBody(): string {
+    const s = src();
+    const idx = s.indexOf('ctx.initiativeTracker.update(itemId, {');
+    expect(idx, 'the /advance item update must exist').toBeGreaterThan(0);
+    const braceStart = s.indexOf('{', idx + 'ctx.initiativeTracker.update(itemId,'.length - 1);
+    let depth = 1;
+    let k = braceStart + 1;
+    while (k < s.length && depth > 0) {
+      const c = s[k];
+      if (c === '{') depth++;
+      else if (c === '}') depth--;
+      k++;
+    }
+    return stripComments(s.slice(braceStart, k));
+  }
+
+  it('persists prNumber, mergeCommitOid and ciCheckedAt in the SAME write as the stage', () => {
+    const body = advanceUpdateBody();
+    expect(body).toContain('pipelineStage');
+    // One write, not a follow-up: a second update could fail and leave a
+    // `merged` row with no evidence — the exact state being fixed.
+    for (const field of ['prNumber', 'mergeCommitOid', 'ciCheckedAt']) {
+      expect(
+        new RegExp(`\\b${field}\\b`).test(body),
+        `${field} must be persisted alongside the stage, not discarded after validation`,
+      ).toBe(true);
+    }
+    expect(
+      /\bresult\.evidence\b/.test(body),
+      'the persisted values must come from the validator verdict, not be re-derived by the caller',
+    ).toBe(true);
+  });
+});
+
+describe('the lazy merged-state reconciler does not invent a verdict', () => {
+  const src = () => stripComments(fs.readFileSync(ROUTES, 'utf-8'));
+
+  it('demotes to regressed ONLY on membership of the regressed set', () => {
+    const s = src();
+    const idx = s.indexOf('verifyMergedItemsViaGit(');
+    expect(idx, 'the reconciler callsite must exist').toBeGreaterThan(0);
+    const window = s.slice(idx, idx + 2600);
+    // The old shape: anything not in `verified` became `regressed`.
+    expect(
+      /\bregressedIds\.has\(/.test(window) || /\bisRegressed\b/.test(window),
+      'an item is demoted only when git said exit 1, never merely because it was absent from `verified`',
+    ).toBe(true);
+    // An unverifiable candidate must keep its stage — the update in that branch
+    // may touch ciCheckedAt (backoff) but must not set pipelineStage.
+    const guardIdx = window.indexOf('!isMerged && !isRegressed');
+    expect(guardIdx, 'the unverifiable branch must exist').toBeGreaterThan(0);
+    // Bound the branch at its own `continue`. A fixed character window ran past
+    // the closing brace into the verdict-recording block below and matched THAT
+    // block's `pipelineStage` — an assertion measuring the wrong text, which is
+    // the same mistake this test file exists to punish. Caught by running it.
+    const contIdx = window.indexOf('continue;', guardIdx);
+    expect(contIdx, 'the unverifiable branch must end in `continue`').toBeGreaterThan(guardIdx);
+    const branch = window.slice(guardIdx, contIdx);
+    expect(
+      /pipelineStage/.test(branch),
+      'the unverifiable branch must not change pipelineStage — it has no verdict to record',
+    ).toBe(false);
+  });
+
+  it('passes a resolved canonical-main ref instead of relying on the origin/main default', () => {
+    const s = src();
+    const idx = s.indexOf('verifyMergedItemsViaGit(');
+    const call = s.slice(idx, s.indexOf(')', s.indexOf('resolveCanonicalMainRef', idx)) + 1);
+    expect(
+      /resolveCanonicalMainRef\(/.test(call),
+      'on a fork-origin agent home origin/main does not contain the merge commit, so every healthy item would read as regressed',
+    ).toBe(true);
+  });
+});

--- a/upgrades/next/merged-record-carries-its-evidence.md
+++ b/upgrades/next/merged-record-carries-its-evidence.md
@@ -1,0 +1,105 @@
+<!-- bump: patch -->
+
+## What Changed
+
+**A project item could read `merged` while carrying no record of what merged it — and
+the two regression detectors that read that record were therefore selecting nothing and
+reporting all clear.**
+
+`/projects/:id/advance` proves four things before it will move an item to `merged`: the
+PR state is `MERGED`, it has a format-valid merge commit sha, that sha is reachable from
+canonical main, and the CI rollup is green. It then persisted **only** `pipelineStage`
+and discarded the evidence. Measured on the live store: both Tier-1 children of the
+`convergence-towards-coherence` project read `pipelineStage: "merged"` with no
+`prNumber`, no `mergeCommitOid` and no `ciCheckedAt`.
+
+The cause was a type, not carelessness. `StageTransitionResult`'s success case was
+`{ ok: true }` — one bit — while every refusal carried `reason` + `code`. The validator
+explained itself when it said no and said nothing when it said yes, so the caller had
+nothing to write down. A passing verdict now carries a `MergedEvidence` record (PR
+number, merge sha, the canonical-main ref it was actually proven against, and an ISO
+timestamp), persisted in the **same** `update()` as the stage — so no window exists in
+which an item reads `merged` with nothing behind it.
+
+**The half that mattered more.** Two merged-state reconcilers find their candidates by
+looking for `mergeCommitOid`: the lazy reconciler on `GET /projects/:id` (documented
+"may mutate", running on every read) and `verifyMergedItemsViaGit`. Nothing ever wrote
+that field, so the candidate set was always empty and the git verification never ran.
+A regression detector that scans nothing and reports nothing is indistinguishable from
+one that scans everything and finds nothing wrong — so merged work that was later
+reverted or force-pushed off main would never have been noticed.
+
+Because that path had never executed, three defects sat in it unexercised, **all three
+already fixed in the advance path a few hundred lines away**: it called
+`SafeGitExecutor.run` without `sourceTreeReadOk`, so SourceTreeGuard refuses the read
+against an instar source tree; it hardcoded `origin/main`, which on a dev-agent home is
+the agent's fork rather than where merges land; and its `catch {}` meant the caller
+marked the item `regressed`, turning "I could not check" into "it was reverted". Any one
+of those would have produced false demotions the moment evidence started being written,
+so both halves ship together. `verifyMergedItemsViaGit` now returns three states —
+`verified`, `regressed` (git's documented exit 1, the only genuine negative) and
+`unverifiable` (everything else, with its reason) — and the reconciler demotes only on
+`regressed`; an unverifiable item keeps its stage and takes only the `ciCheckedAt`
+backoff, so the question is asked again later instead of answered wrongly now.
+
+**What this does not do:** it adds no new regression checking. It makes the existing
+reconcilers *possible*, by giving them the evidence they were written to read, and
+*safe*, by stopping them guessing. Items merged before this change carry no evidence and
+report honestly as `unverifiable` with the reason "no mergeCommitOid recorded on the
+item" — no backfill is attempted, because reconstructing which PR merged a historical
+item would mean fabricating evidence.
+
+## What to Tell Your User
+
+If you use project tracking, a finished item now records the pull request, the commit
+and the time it was checked — so "merged" can name what merged it. Previously it could
+not.
+
+More usefully: the checks that watch for finished work being undone were, in practice,
+examining an empty list and reporting no problems. They now have something to examine.
+And when one of them cannot answer — no permission, wrong branch, missing commit — it
+says so instead of declaring the work reverted, which is what it used to do.
+
+## Summary of New Capabilities
+
+- A passing stage-transition verdict carries the evidence it established, instead of a
+  bare success flag.
+- A merged item records its PR number, merge commit and check timestamp in the same
+  write as its stage.
+- The merged-state verifier distinguishes "reverted" from "could not check", and the
+  reconciler demotes only on the former.
+- The reconciler checks the canonical-main ref resolved for the install rather than
+  assuming `origin/main`, so a fork-origin agent home no longer reads every healthy item
+  as regressed.
+- `POST /projects/:id/advance` echoes the recorded evidence back, so a caller can confirm
+  it landed rather than trusting that it did.
+
+## Evidence
+
+**Reproduction (before):** read any merged child of a project —
+`GET /projects/convergence-towards-coherence` returned both Tier-1 children with
+`pipelineStage: "merged"` and an object whose keys contained no `prNumber`,
+`mergeCommitOid` or `ciCheckedAt`. `grep` for writers of `mergeCommitOid` found none
+outside `InitiativeTracker`'s own accessors, while two consumers select on it.
+
+**Observed after,** same scenarios against the built code:
+
+| scenario | before | after |
+|---|---|---|
+| passing `building → merged` verdict | `{ ok: true }` | carries `prNumber`, `mergeCommitOid`, `mergeBaseBranch`, `verifiedAt` |
+| the item record after a merged advance | stage only | stage + PR number + merge sha + check timestamp, one write |
+| verifier, git exit 0 | verified | verified |
+| verifier, git exit 1 | not verified → caller demotes | `regressed` → caller demotes |
+| verifier, git exit 128 / guard refusal | not verified → **caller demotes** | `unverifiable` with reason → **stage unchanged** |
+| verifier, child with no recorded evidence | silently skipped | `unverifiable`, "no mergeCommitOid recorded" |
+| verifier's branch | hardcoded `origin/main` | the caller-resolved canonical-main ref |
+
+**Tests:** `tests/unit/merged-record-carries-its-evidence.test.ts` (9 new) plus 2 added
+to `tests/unit/StageTransitionValidator.test.ts`. All 9 fail against pre-fix source with
+failures that name the defect — "expected undefined to be defined" for the evidence-free
+approval, "prNumber must be persisted alongside the stage, not discarded after
+validation: expected false to be true", "the verifier readSync must exist: expected +0
+to be 1" (it used `.run`, proving the missing source-tree declaration), and "an item is
+demoted only when git said exit 1, never merely because it was absent from `verified`".
+The 48 pre-existing validator tests and the 8 `ProjectRoundExecution` tests pass
+unchanged. `npx tsc --noEmit` clean.

--- a/upgrades/side-effects/merged-record-carries-its-evidence.md
+++ b/upgrades/side-effects/merged-record-carries-its-evidence.md
@@ -198,3 +198,33 @@ What author-applied review caught and changed:
    ran past the branch it meant to inspect and matched the next block's
    `pipelineStage`. Now bounded at the branch's own `continue`. A test measuring
    adjacent text is the same defect class as the subject of this change.
+
+## Phase 6 — What CI refused, and why the fix went in the prose
+
+The first push was refused by the empty-catch ratchet
+(`tests/unit/no-empty-catch-blocks.test.ts`): count 1 against a baseline of 0. The
+offending occurrence was at `ProjectRoundExecution.ts:506` — **inside this change's own
+doc comment**, on the line quoting the forbidden bodyless-catch shape while explaining
+that it had been removed. The lint scans `src/` as text and does not strip comments, so
+it cannot distinguish an example from an instance.
+
+Noted rather than glossed, because it is the same failure mode this change is about,
+one layer out: a checker built to catch "errors turning into nothing" was tripped by a
+sentence *about* errors turning into nothing. It is also the third occurrence of that
+shape in a single session (twice in the outbound-message checker, once here), and the
+sibling test `tests/unit/projects-advance-mergebase-wiring.test.ts` already documents
+the identical trap for its own assertions — it strips comments before asserting,
+precisely because an earlier version of it matched the helper's own explanatory prose.
+
+**The prose was reworded; the lint was NOT touched.** Weakening a safety check to
+unblock one's own change is the wrong instinct even when the check is imprecise, and
+this lint's stated history (a bare catch in a 5-second loop causing a real cost
+incident) earns it the benefit of the doubt. Making the lint comment-aware is a
+legitimate improvement, but it belongs in its own change with its own review — not
+smuggled in as a side-effect of needing this PR to go green.
+
+**Re-verification scope, corrected.** The refusal proved my local scope was wrong: I
+had run the tests covering the changed module, but this failure came from a test that
+scans the whole source tree and whose subject my change never touched. The right scope
+for a source change is therefore *every tree-scanning test*, located by grep rather
+than guessed: 99 files, 8,370 tests, exit 0, `tsc --noEmit` clean.

--- a/upgrades/side-effects/merged-record-carries-its-evidence.md
+++ b/upgrades/side-effects/merged-record-carries-its-evidence.md
@@ -1,0 +1,200 @@
+# Side-Effects Review — a merged record that could not name what merged it
+
+**Version / slug:** `merged-record-carries-its-evidence`
+**Date:** `2026-07-26`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `author-applied lenses — see Phase 5 (reduced independence, disclosed)`
+
+## Summary of the change
+
+`/projects/:id/advance` validated a submitted artifact for `building → merged` — PR
+state `MERGED`, a format-valid merge sha, that sha reachable from canonical main, CI
+rollup green — and then wrote **only** `pipelineStage`. The validated evidence built
+the validation context and was discarded. Measured on the live store: both Tier-1
+children of `convergence-towards-coherence` read `pipelineStage: "merged"` with no
+`prNumber`, no `mergeCommitOid`, no `ciCheckedAt`.
+
+The root cause was a **type**. `StageTransitionResult`'s success case was `{ ok: true }`
+— one bit — while every refusal carried `reason` + `code`. The validator explained
+itself when it refused and said nothing when it approved, so the caller had nothing to
+persist. The fix widens the success case to carry a `MergedEvidence` record and
+persists it in the same `update()` as the stage.
+
+**The consequential half:** two merged-state reconcilers select on `mergeCommitOid` —
+`GET /projects/:id`'s lazy reconciler (documented "may mutate", runs on every read) and
+`verifyMergedItemsViaGit`. With the field never written, the candidate set was always
+empty, `verifyMergedItemsViaGit` was never called, and both reported nothing. A
+regression detector that scans nothing is indistinguishable from one that finds no
+regressions.
+
+Because that path had never executed, three defects sat in it unexercised — all three
+already fixed in the advance path a few hundred lines away: (1) `SafeGitExecutor.run`
+without `sourceTreeReadOk`, so SourceTreeGuard refuses the read against an instar
+source tree (the #1641 defect); (2) a hardcoded `origin/main`, which on a dev-agent
+home is the agent's FORK; (3) `catch {}` → not verified → caller marks `regressed`,
+i.e. a refusal rendered as "it was reverted". Writing the evidence is what ARMS that
+path, so the two halves ship together.
+
+## Decision-point inventory
+
+| point | classification | note |
+|---|---|---|
+| success-case evidence on `StageTransitionResult` | `invariant` | Pure data carriage. Adds no branch and cannot change a verdict — the same four checks decide `ok`. |
+| evidence persistence in `/advance` | `invariant` | Conditional on `result.evidence` presence only. Same single write as the stage, so no window exists where `merged` has no evidence. |
+| `verifyMergedItemsViaGit` three-state outcome | `invariant` | Deterministic on git's documented exit status: 1 ⇒ regressed, everything else ⇒ unverifiable. No judgment. |
+| reconciler unverifiable branch | `invariant` | Deterministic on set membership. Strictly *removes* an authority — the old code demoted on absence-from-`verified`. |
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+Nothing new is rejected. `/advance` accepts exactly what it accepted before — the four
+checks and their refusal codes are untouched; only the success return widened. No
+artifact field became required.
+
+The reconciler now demotes **strictly fewer** items: previously anything absent from
+`verified` became `regressed`; now only git exit 1 does. So the change cannot introduce
+a false demotion, only remove them.
+
+Real cost, stated plainly: an item that genuinely regressed but whose check cannot be
+run stays at `merged` rather than being demoted. That is a deliberate trade — the old
+behaviour "caught" it only by demoting everything it could not verify, which is not
+detection. The item keeps taking the `ciCheckedAt` backoff, so it is re-asked, and its
+unverifiable reason is returned to the caller rather than swallowed.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **No new regression detection is added.** This makes the existing reconcilers
+  *possible* (they now have evidence to select on) and *safe* (they can no longer guess).
+  Whether they catch a real revert is unproven until one occurs — recorded rather than
+  implied.
+- **Items merged BEFORE this change carry no evidence**, so they remain invisible to the
+  reconcilers. They surface as `unverifiable` with the reason "no mergeCommitOid
+  recorded on the item" rather than silently dropping out of the candidate set. No
+  backfill is attempted: reconstructing which PR merged a historical item would mean
+  guessing, and a fabricated evidence row is worse than an absent one.
+- The `GET /projects/:id` reconciler still selects only `pipelineStage === 'building'`
+  children, so an item that went straight to `merged` via `/advance` is not revalidated
+  by it. `verifyMergedItemsViaGit` is reachable for any child id the caller passes.
+  Widening that selection is a behavioural change to which items get demoted and is NOT
+  attempted here.
+- `defaultVerifyMergedItems` remains a deliberate no-op stub for the injected
+  `verifyMergedItems` seam (returns an empty Set). Its own comment says production
+  callers should pass a real verifier; the one production caller does.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The evidence originates in the validator (the only place that proves it), is
+carried on the validator's own result type, and is persisted by the route that owns the
+write. No new store, no new field on the wire, no new endpoint — `prNumber`,
+`mergeCommitOid` and `ciCheckedAt` are pre-existing declared `Initiative` fields, and
+`mergeCommitOid`'s own comment already said "recorded at building → merged". The fix
+makes the comment true rather than inventing a mechanism.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+It **reduces** brittle authority. The reconciler holds real authority (it demotes items
+to `regressed` and clears a round's future `autoAdvanceAt`), and it was exercising that
+authority on the brittle ground of "absent from a set that could be empty for any
+reason, including a permission refusal". Demotion now requires git's single documented
+negative exit status. Nothing in this change blocks, delays, or alters a message or an
+action.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No judgment point is introduced. Every new branch is a deterministic comparison (a
+`status === 1` test, a set-membership test, a presence test on `result.evidence`). The
+change *retires* a pseudo-judgment — treating an unanswerable question as a negative
+answer — and makes the asymmetry explicit in the type: `unverifiable` is a first-class
+outcome carrying its reason, never folded into either verdict.
+
+## 5. Interactions
+
+- **`GET /projects/:id` lazy reconciler** — the one production consumer. Now receives a
+  three-state result and a resolved canonical-main ref. An unverifiable candidate takes
+  the `ciCheckedAt` backoff and keeps its stage; only `regressed` membership triggers a
+  demotion and the round's `autoAdvanceAt` clearing (that downstream logic is unchanged).
+- **`verifyMergedItemsViaGit` signature** — return type widened
+  (`Set<string>` → `MergedVerificationResult`) and a fourth optional parameter added.
+  Grepped all callers: exactly one production callsite (`routes.ts`), updated. The
+  injected `verifyMergedItems` seam on `RunRoundInput` is a DIFFERENT type
+  (`Set<string>`) and is untouched, so `ProjectRoundExecution`'s own callers and its 8
+  unit tests are unaffected — verified by running them.
+- **`StageTransitionResult`** — the widened success case is an optional property, so
+  every existing `if (!result.ok)` caller and every `expect(r.ok).toBe(true)` assertion
+  keeps working. Confirmed: 48 pre-existing validator tests pass unchanged.
+- No persistence migration: the three fields already exist in the `Initiative` type,
+  the create/update allowlists, and the JSON store.
+
+## 6. External surfaces
+
+`POST /projects/:id/advance`'s 200 body gains `item.prNumber`, `item.mergeCommitOid`,
+`item.ciCheckedAt` and an `evidence` object on a merged transition. Additive only — no
+field removed, no shape changed, no status code changed. `GET /projects/:id` children
+now carry those fields once written. Refusal responses are byte-identical.
+
+## 6b. Operator-surface quality
+
+The operator previously read `merged` with no way to ask "merged by what?" — and got a
+silent all-clear from a regression detector that had never examined anything. They now
+see the PR, the merge commit and the check time on the record itself, and an
+unverifiable item names its reason instead of being demoted. Items merged before this
+change honestly report "no mergeCommitOid recorded" rather than appearing clean.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: `unified` by construction — no new state.** No new field, file, store, or
+surface is introduced; three already-declared fields on an existing per-machine store
+start being written. The evidence is a pure function of a PR's GitHub state plus the
+target repo's git history, both of which are machine-independent facts. The
+canonical-main ref is resolved per-machine from that machine's remotes, which is
+correct: it names the same upstream commit graph whatever the local remote is called —
+and resolving it (rather than assuming `origin/main`) is precisely what makes the check
+give the same answer on a fork-origin home as on a canonical one. No replication path
+is required and no `machine-local-justification` marker is needed.
+
+## 8. Rollback cost
+
+Three source files, one commit, no migration and no persisted-state change. Reverting
+restores a `merged` record that cannot name its evidence and two reconcilers that
+select nothing — and re-arms the "could not check ⇒ regressed" mistranslation the
+moment anything writes `mergeCommitOid`. Written-but-unread evidence fields are inert,
+so a revert leaves no corrupt data behind.
+
+## Phase 5 — Second-pass review (independent reviewer subagent)
+
+**Disclosure, per Truthful Provenance:** no independent reviewer subagent was spawned —
+a standing instruction in this session prohibits it unless the operator requests it.
+The review lenses were applied by the author. That is **reduced independence**, recorded
+as such rather than presented as a concurring second pass.
+
+What author-applied review caught and changed:
+
+1. **The first instinct was to persist the evidence and stop** — a two-line change that
+   would have armed a code path carrying three unexercised defects, turning silent
+   blindness into confident false regressions. The consumer had to be read before the
+   producer was fixed. This is the same "fix one site, leave its twin" mistake flagged
+   on #1647 and again on #1650 earlier the same night; third occurrence, caught before
+   shipping this time.
+2. **The hardcoded `origin/main` would have mis-fired specifically on this machine.**
+   The advance path had already resolved it via `resolveCanonicalMainRef` for exactly
+   this reason. Passing the resolved ref through was not optional — without it a
+   dev-agent home demotes every healthy item.
+3. **The unverifiable branch initially bumped nothing**, which would have re-asked an
+   unanswerable question on every read (a hot loop). It now takes the `ciCheckedAt`
+   backoff while explicitly leaving `pipelineStage` alone.
+4. **Consumers were grepped, not assumed** — establishing that the widened return type
+   has exactly one production caller and that the similarly-named injected
+   `verifyMergedItems` seam is a distinct type that must NOT change.
+5. **One new test passed for the wrong reason and was fixed:** a fixed-size text window
+   ran past the branch it meant to inspect and matched the next block's
+   `pipelineStage`. Now bounded at the branch's own `continue`. A test measuring
+   adjacent text is the same defect class as the subject of this change.


### PR DESCRIPTION
## ELI16 — Plain-English Overview

The gate that decides whether a piece of work is really finished demanded four kinds of proof,
checked all four, and then threw the proof away. So the record said "merged" and could name nothing —
no pull request, no commit, no time it was checked. I found it reading my own project record to
confirm two finished items really were finished. Both said "merged". Neither could say what merged it,
and I had supplied that evidence myself.

The cause was a matter of shape rather than carelessness. When the gate **refuses**, it hands back a
reason and an error code — it explains itself fully. When it **approves**, it hands back a single bit:
yes. So the caller had nothing to write down, because approval carried no information to write. The
gate explained itself when it said no and said nothing when it said yes.

**Why that mattered beyond tidiness.** Two other parts of the system watch for finished work that
later gets undone — reverted, or force-pushed off the main branch. Both find what to check by looking
for that saved commit. Nothing ever saved it. So both examined an empty list, found nothing wrong, and
said so. Every time. One of them runs on every single read of the project. A detector that inspects
nothing and reports nothing looks exactly like a detector that inspects everything and finds nothing
wrong.

**The part that nearly bit me.** I almost fixed only the first half — start saving the evidence — and
stopped. Because that watching code had never actually run, three faults had been sitting in it
untouched: it asked a question it lacked permission to ask, so a safety guard refused it outright; it
looked for the commit on the wrong branch, since on this machine the obvious branch is my own fork
rather than where work lands; and worst, it treated *every* failure as proof the work had been
reverted, including "I was refused" and "that branch does not exist". All three had already been found
and fixed in the neighbouring piece of code weeks earlier, and survived here only because nobody could
see them — the code never ran. Switching the evidence on by itself would have converted silent
blindness into confident false accusations: healthy finished work marked broken and its schedule
cleared. Worse than the blindness. Both halves move together.

**What changed.** An approval now carries what it proved — the pull request, the commit, the branch it
was actually checked against, and when — saved in the same single write that records the stage, so
there is no window where the record says "merged" with nothing behind it. The watching code now asks
its question properly, checks the branch it was *told* to check rather than assuming, and has three
possible answers instead of two: still there, gone (the one answer that genuinely means reverted), and
**I could not tell**. The third changes nothing about the item; it gets asked again later rather than
answered wrongly now.

**What this does not do:** it adds no new checking of finished work. It makes the existing checks
possible, by giving them the evidence they were written to read, and safe, by stopping them guessing.
Whether they catch a real regression is something only a real regression will show. Items merged before
this change carry no evidence and report honestly as "could not tell — no merge commit recorded", rather
than appearing clean; no backfill is attempted, because reconstructing which pull request merged a
historical item would mean fabricating evidence.

Full overview: `docs/specs/merged-record-carries-its-evidence.eli16.md`

## Refusal evidence

Nine new checks. All nine fail against pre-fix source (restored with `git show HEAD:` — no destructive
verb), each naming the defect rather than merely going red:

- `a PASSING verdict carries the evidence it established` → **expected undefined to be defined**
- `prNumber must be persisted alongside the stage, not discarded after validation` → **expected false to be true**
- `the verifier readSync must exist` → **expected +0 to be 1** (it used `.run`, proving the missing source-tree declaration)
- `an item is demoted only when git said exit 1, never merely because it was absent from verified` → **expected false to be true**

48 pre-existing validator tests and 8 `ProjectRoundExecution` tests pass unchanged. `npx tsc --noEmit`
clean. Full unit + integration suites run locally at CI scope.

One of the new tests passed the first time for the wrong reason: a fixed-size text window ran past the
branch it meant to inspect and matched the next block's `pipelineStage`. Now bounded at the branch's own
`continue`. A test measuring adjacent text is the same defect class as the subject of this change, and
recording it is cheaper than pretending it did not happen.

## Behaviour change

The reconciler now demotes **strictly fewer** items — only on git's documented exit 1, never on absence
from the verified set. It cannot introduce a false demotion, only remove them. `POST /projects/:id/advance`
gains additive response fields. No migration, no config key, no new state.

## Tier

Tier 1. ELI16 + side-effects artifact + green tests; three source files, no new surface, no converged
spec required. Side-effects review: `upgrades/side-effects/merged-record-carries-its-evidence.md`.

**Tier disagreement, recorded rather than pocketed:** the pre-commit classifier independently suggested
Tier 2 (`size=2, riskFloor=1, 180 LOC across 3 files`) while I declared Tier 1. The signal is advisory
and the gate passed, but it is a second opinion contradicting mine and this project is about not
quietly discarding those. My argument for Tier 1: no new surface, no new state, no config key, no
migration, and the only authority touched is *reduced* (strictly fewer demotions). The counter-argument
is the LOC count and that it touches `routes.ts`. If a reviewer prefers Tier 2 this needs a converged
spec, which it does not have — say so and I will route it that way.
