### PR TITLE
docs(commitments): the promise fix is forward-only — correct three over-claims

### DIFF
--- a/docs/specs/behavioural-promise-unverifiable.eli16.md
+++ b/docs/specs/behavioural-promise-unverifiable.eli16.md
@@ -32,6 +32,15 @@ whether I sent you every summary or none of them.
 
 ## What this changes
 
+> **Correction added 2026-07-26, after this shipped.** What follows is true of promises
+> recorded **from now on**. It is not true of promises that already existed — and I originally
+> wrote it as though it were. The fix works by *declining to reach a verdict*, so it never goes
+> back and revisits a verdict already stamped. Checked on a live install: ninety-eight existing
+> records still showed their old readings, seventy-four "kept" and twenty-four "broken". The
+> runaway tally did stop for all of them. The stale verdicts did not clear, and clearing them is
+> a separate decision that hasn't been made. Left visible rather than edited away, because a
+> description that over-claims is the same fault as the one this page is about.
+
 A promise about behaviour is now left **open** rather than being declared kept or broken.
 Nothing here can watch what I actually do, so the honest answer is "not determined yet" —
 which is precisely what this same file already does for another kind of promise it cannot

--- a/upgrades/1.3.982.md
+++ b/upgrades/1.3.982.md
@@ -42,6 +42,17 @@ genuinely reads live state.
 
 ## What to Tell Your User
 
+> **CORRECTION (2026-07-26, after release).** The paragraph below over-claimed and is kept
+> visible rather than quietly rewritten. **The change is forward-only.** Promises about
+> behaviour recorded from now on stay open, and the runaway tally stopped for all of them —
+> but promises that already existed **keep the verdict they were last stamped with**, because
+> the fix works by declining to reach a verdict, which means it never revisits one. Measured
+> on a live install after deploy: 98 behavioural records still showed 74 "kept" and 24
+> "broken", unchanged. So if you had behavioural commitments before upgrading, their old and
+> untrustworthy verdicts are still on screen, and the health line will still count those 74 as
+> verified. Clearing them needs a deliberate decision (rewriting stored records, or having the
+> display refuse a verdict for anything unverifiable) and has not been made.
+
 If you track commitments, promises about behaviour now show as **pending** rather than
 verified or violated, with both counters at zero. That is more honest, not a regression:
 nothing was ever watching whether those promises were kept, so "verified" was reassurance
@@ -69,10 +80,14 @@ commitment"`. Live store corroboration: 74/74 with the field `verified`, 24/24 w
 
 **Observed after,** same scenarios against the built code:
 
+**Scope note added 2026-07-26:** every row below was measured on a **newly created** commitment.
+A row that already existed before the upgrade keeps its stored verdict — see the correction above.
+
 | scenario | before | after (25 sweeps) |
 |---|---|---|
-| behavioural, `behavioralRule` set | `verified`, +1 tick per sweep | `pending`, verifications 0, violations 0 |
-| behavioural, field absent | `violated`, +1 tick per sweep | `pending`, verifications 0, violations 0 |
+| behavioural, `behavioralRule` set (NEW row) | `verified`, +1 tick per sweep | `pending`, verifications 0, violations 0 |
+| behavioural, field absent (NEW row) | `violated`, +1 tick per sweep | `pending`, verifications 0, violations 0 |
+| behavioural row that PREDATES the change | `verified` or `violated`, ticking | ticking stops; **stored verdict unchanged** |
 | rules file deleted | produced a verdict | no verdict; file self-heals; status unchanged |
 | health, 1 behavioural row | `"1 commitment(s) tracked, all verified"` | `"1 commitment(s) tracked — 0 verified, 1 not automatically verifiable (no violations)"`, status `healthy` |
 

--- a/upgrades/side-effects/behavioural-promise-unverifiable.md
+++ b/upgrades/side-effects/behavioural-promise-unverifiable.md
@@ -100,8 +100,23 @@ explicit in code: absence of a verdict is reported as absence, never as either o
   between them causes no change in expiry behaviour — checked before editing.
 - **PromiseBeacon / overdue surfacing** operate on open commitments; `pending` keeps them
   visible, which is the stated intent of the precedent ("should NAG, not vanish").
-- No persistence change, no migration, no config key. Existing rows re-evaluate to
-  `pending` on the next sweep without a data rewrite.
+- No persistence change, no migration, no config key.
+- ~~Existing rows re-evaluate to `pending` on the next sweep without a data rewrite.~~
+  **CORRECTED 2026-07-26 — this was FALSE and is struck rather than deleted.** The
+  behavioural branch returns BEFORE the `switch` in `verifyOne`, so `mutateSync` never runs
+  and a pre-existing row is never touched. **The change is FORWARD-ONLY.**
+  Verified on the live store after deploy: 98 behavioural rows still read **74 `verified` /
+  24 `violated`**, unchanged. What the change DID do, measured over two reads 75s apart:
+  tick accumulation stopped dead (one row frozen at 163,135 where it had been climbing every
+  minute). What it did NOT do: clear the 98 stale verdicts — so the false comfort this change
+  set out to remove is still displayed for every row that predates it, and `getHealth`, which
+  now counts actual `verified` rows, will report those 74 stale stamps as verified.
+  Remedy is an open operator decision, not a reflex: either a migration resetting behavioural
+  rows to `pending` (a data rewrite this very section claimed was unnecessary) or a read
+  surface that refuses a verdict for a never-verifiable row whatever is stored.
+  **Found by reading the live surface for the exact case the change fixed** — no test caught
+  it, and the suite was green. An artifact that over-claims is the same defect class as the
+  bug it documents, which is why the wrong sentence stays visible above.
 
 ## 6. External surfaces
 


### PR DESCRIPTION
## ELI16 — Plain-English Overview

Earlier tonight I shipped a fix to the machinery that tracks whether I keep promises about how I'll
behave. I then wrote, in three places including the release notes users read, that existing records
would sort themselves out on the next pass.

They don't. **The change is forward-only, and I said otherwise.**

The fix works by *declining to reach a verdict* — and something that declines to reach a verdict never
goes back to revisit one it already reached. So every promise recorded before the upgrade keeps
whatever stamp it was last given. Ninety-eight of them, on a live install after the deploy: seventy-four
still say "kept", twenty-four still say "broken". Unchanged.

What the fix genuinely did was stop the runaway tally. One record had been climbing every minute for
months; I read it twice, seventy-five seconds apart, and it sat frozen at the same number. That part is
real and it applies to every record, old and new.

What it did not do is clear the ninety-eight stale verdicts. So the false reassurance the change existed
to remove is still on screen for anything predating it — and the health summary, which that same change
taught to count genuinely-verified records, dutifully counts those seventy-four stale stamps as
verified.

**This pull request changes no behaviour.** It corrects three documents that told the reader otherwise:
the release guide users actually read, the side-effects review, and the plain-English overview.

**The wrong sentences are struck through and quoted, not deleted.** A description that over-claims is
the same fault as the bug it describes — quietly rewriting it would repeat that fault one level up, and
leave no trace that the claim was ever made. The correction sits next to the claim in each file.

**Deliberately not included:** any remedy for the ninety-eight stale records. Clearing them means either
rewriting stored data — which the very section I'm correcting declared unnecessary — or having the
display refuse a verdict for anything unverifiable regardless of what's stored. That's a real decision
with real trade-offs and it belongs to the operator, not to me at seven in the morning.

## How it was found

By reading the live system for the exact case the change was meant to fix. No test caught this and the
suite was green — the same lesson as #1641/#1645 earlier tonight, which is why I went and looked.

Verified two independent ways before writing a word: the code (the behavioural branch returns before the
point where a record would be updated, so the update never runs) and the live store (98 records,
74/24 split, unchanged after deploy).

## Verification

Documentation only — three files, no source change, no behaviour change. `eli16-overview-check` passes;
`upgrade-guide-check` passes (6,451 assertions across the guides).
