### PR TITLE
fix(mesh): ssh2 CJS named imports threw at load in five modules

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T19-41-29-895Z-ssh2-cjs-named-imports.json
+++ b/.instar/instar-dev-decisions/2026-07-26T19-41-29-895Z-ssh2-cjs-named-imports.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-26T19:41:29.895Z",
+  "slug": "ssh2-cjs-named-imports",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 27,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/ssh2-cjs-named-imports.eli16.md
+++ b/docs/specs/ssh2-cjs-named-imports.eli16.md
@@ -1,0 +1,94 @@
+# A channel that failed at every startup, in a way three different checks could not see — Plain-English Overview
+
+> The one-line version: one of the ways my machines talk to each other has been
+> broken at every single startup. The compiler passed it. The test runner passed it.
+> And the dashboard that lists broken systems did not list it, because the failure
+> happened before it could be listed.
+
+## What happened
+
+I went looking for why two agents could not reach each other, and found a second
+broken channel by accident. Every time my server starts, it prints this and carries on:
+
+```
+[mutual-ssh] initialization blocked: The requested module 'ssh2' does not
+  provide an export named 'Server'
+[peer-execution] disabled-grant cleanup blocked: Named export 'utils' not found.
+```
+
+Not an error. A warning, at startup, in a log nobody reads. Every boot. For as long
+as the code has been that way.
+
+## What was actually wrong
+
+JavaScript has two ways of packaging code — an older style and a newer one. My code
+is the newer style. The SSH library is the older style.
+
+When you take something from an older-style package, you have to take the whole box
+and then reach inside it. Five of my files tried to reach inside *while taking it* —
+naming the pieces they wanted at the door. The older-style box does not let you do
+that. The pieces are genuinely in there; the loader simply cannot see them from
+outside, so it refuses at the moment the file is loaded.
+
+Because it fails at *load* time, nothing in those files ever ran. The channel did not
+work badly. It never started.
+
+The fix is four words rearranged in five places: take the box, then reach inside.
+
+## The part that is more interesting than the bug
+
+I wrote a test to stop this coming back. The obvious test: load each of the five
+files, check none of them throws. It passed.
+
+Then I put the bug back on purpose to watch the test fail.
+
+**It passed again.** Against the broken code. All eight checks green.
+
+The test runner does not load files the way the real program does — it quietly
+rewrites the older-style packages so the shortcut works. So the test was not merely
+weak. It was **incapable** of ever seeing this bug, while looking exactly like proof
+that the bug could not return.
+
+The compiler is blind for a different reason: the pieces really do exist, so the
+types are correct. It is only the runtime lookup that fails.
+
+So three separate things all said fine: the compiler, the test runner, and my first
+test. The only thing that ever said otherwise was a warning line at startup.
+
+I rewrote the guard to read the source text instead. That is a cruder kind of check,
+and I would normally argue against it — text checks get fooled by text that merely
+*describes* the thing they are looking for. So it strips out comments and quoted text
+before it looks, and there is a test that proves this file's own description of the
+bug does not set it off. A cruder check that actually fires beats an elegant one that
+proves nothing.
+
+## The third place it was invisible
+
+There is a dashboard that lists every safety system and whether it is running. Its
+whole purpose is to make quiet failures loud.
+
+`mutual-ssh` is not on it. Not listed as broken — **not listed at all**, out of
+eighty-eight entries.
+
+The reason is small and worth knowing: a system adds itself to that list *during*
+startup. This one crashed a few lines earlier. So the failure removed itself from the
+one inventory designed to catch failures like it.
+
+That is the same shape as the other thing I fixed tonight, where a dropped connection
+left "connected" as the only note on record. In both cases the defect deletes its own
+evidence. I have written that down as its own problem rather than folding it into this
+change, because it is not really about SSH.
+
+## What this does and does not do
+
+**It does:** make all five files load. I built the real output and loaded it the way
+the real program does, and all five now load where all five previously threw.
+
+**It does not:** prove the channel works end to end. Loading is the first door, not
+the last one. Whether it then listens, finds its keys, and reaches another machine is
+untested here, and I am not going to claim it because I have not watched it happen.
+What I can say precisely is that it could not possibly have worked before, and that
+one specific reason is now gone.
+
+**Honest scope:** this takes the count of broken inter-agent channels from two down
+to one, and only in the sense that this one is no longer dead on arrival.

--- a/src/core/MachineSshEndpoint.ts
+++ b/src/core/MachineSshEndpoint.ts
@@ -1,7 +1,12 @@
 import fs from 'node:fs';
 import net from 'node:net';
 import { verify } from 'node:crypto';
-import { Server, utils, type Connection } from 'ssh2';
+import ssh2 from 'ssh2';
+import type { Connection, Server as SshServerType } from 'ssh2';
+// `ssh2` is CommonJS: a NAMED esm import throws at load
+// ("does not provide an export named 'Server'"). Types are erased at compile time
+// so `import type` is safe; VALUES must come off the default namespace.
+const { Server, utils } = ssh2;
 import type { SshPeerAdmission, SshPeerAdmissionStore } from './SshPeerAdmissionStore.js';
 
 export interface SshRpcChallenge {
@@ -32,7 +37,7 @@ export interface MachineSshEndpointOptions {
 
 /** Restricted SSH server: public-key auth plus the `instar-rpc` subsystem only. */
 export class MachineSshEndpoint {
-  private server: Server | null = null;
+  private server: SshServerType | null = null;
   private sockets = new Set<Connection>();
   private socketsByMachine = new Map<string, Set<Connection>>();
   private handshakesBySource = new Map<string, number>();

--- a/src/core/MutualSshVerifier.ts
+++ b/src/core/MutualSshVerifier.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import { createHash, randomBytes } from 'node:crypto';
-import { Client, utils } from 'ssh2';
+import ssh2 from 'ssh2';
+// `ssh2` is CommonJS — named esm imports throw at load. Destructure at runtime.
+const { Client, utils } = ssh2;
 import { canonicalSshResponse, type SshRpcChallenge, type SshRpcResponse } from './MachineSshEndpoint.js';
 
 export interface DirectionalSshProof {

--- a/src/core/PeerAuthorizedKeys.ts
+++ b/src/core/PeerAuthorizedKeys.ts
@@ -1,7 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { utils } from 'ssh2';
+import ssh2 from 'ssh2';
+// `ssh2` is CommonJS: a NAMED esm import throws at load
+// ("Named export 'utils' not found"). Default-import the namespace and destructure
+// at runtime. See ssh2-cjs-named-imports side-effects artifact.
+const { utils } = ssh2;
 import { SafeFsExecutor } from './SafeFsExecutor.js';
 
 const MARKER = 'instar-peer-access';

--- a/src/core/SshBootstrapAdvert.ts
+++ b/src/core/SshBootstrapAdvert.ts
@@ -1,5 +1,7 @@
 import net from 'node:net';
-import { utils } from 'ssh2';
+import ssh2 from 'ssh2';
+// `ssh2` is CommonJS — named esm imports throw at load. Destructure at runtime.
+const { utils } = ssh2;
 
 export interface SshBootstrapAdvert {
   machineId: string;

--- a/src/core/StandingSshVerifier.ts
+++ b/src/core/StandingSshVerifier.ts
@@ -1,5 +1,7 @@
 import fs from 'node:fs';
-import { Client, utils } from 'ssh2';
+import ssh2 from 'ssh2';
+// `ssh2` is CommonJS — named esm imports throw at load. Destructure at runtime.
+const { Client, utils } = ssh2;
 
 export interface StandingSshTarget {
   host: string;

--- a/tests/unit/ssh2-modules-load-under-esm.test.ts
+++ b/tests/unit/ssh2-modules-load-under-esm.test.ts
@@ -1,0 +1,159 @@
+/**
+ * The mutual-SSH / peer-execution modules must actually LOAD under Node's ESM loader.
+ *
+ * INCIDENT (2026-07-26). Two inter-agent channels were down. One was the relay
+ * (see relayConnectionObserver). The other was mutual-SSH, and it had been failing
+ * at EVERY server boot, warning-level only, surfaced nowhere:
+ *
+ *   [mutual-ssh] initialization blocked: The requested module 'ssh2' does not
+ *     provide an export named 'Server'
+ *   [peer-execution] disabled-grant cleanup blocked: Named export 'utils' not
+ *     found. The requested module 'ssh2' is a CommonJS module...
+ *
+ * `ssh2` is CommonJS. It genuinely has `Server`, `utils` and `Client` as runtime
+ * properties, but Node's ESM loader cannot statically detect them, so a NAMED value
+ * import throws at module-load time. Five files did exactly that, so five modules
+ * threw on import and the whole channel silently never initialised.
+ *
+ * ── WHY THIS IS A SOURCE SCAN AND NOT AN IMPORT TEST ────────────────────────────
+ *
+ * The obvious guard — import each module and assert it does not throw — was written
+ * first, passed, and was WRONG. Reverting a file to the broken named import left all
+ * eight assertions green:
+ *
+ *   $ npx vitest run tests/unit/ssh2-modules-load-under-esm.test.ts
+ *     ✓ tests/unit/ssh2-modules-load-under-esm.test.ts (8 tests)   # against BROKEN source
+ *
+ *   $ node --input-type=module -e "import { Server } from 'ssh2';"
+ *     SyntaxError: Named export 'Server' not found. The requested module 'ssh2' is
+ *     a CommonJS module, which may not support all module.exports as named exports.
+ *
+ * Vitest transforms modules through Vite, which rewrites CJS interop so a named
+ * import resolves. Production runs the compiled output under Node's own ESM loader,
+ * which does not. So an in-process import assertion is STRUCTURALLY INCAPABLE of
+ * observing this bug class — it does not merely miss it, it cannot see it. `tsc`
+ * is equally blind (exit 0 against the broken source), because the TYPES are real;
+ * only the runtime binding is not.
+ *
+ * That leaves a source scan. It is a text check, with a text check's known weakness
+ * — prose that *describes* a forbidden shape can trip it. That is mitigated by
+ * stripping comments and string literals before matching, and by asserting on
+ * import statements only. The trade is deliberate and is the honest one: a scan that
+ * really fires beats an import test that reads better and proves nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../src');
+
+/**
+ * Packages that are CommonJS at runtime, so a named VALUE import throws under Node
+ * ESM even though TypeScript accepts it. Add to this list when a new CJS dependency
+ * is introduced; the scan then covers every file at once.
+ */
+const CJS_ONLY_PACKAGES = ['ssh2'] as const;
+
+/** Remove comments and string literals so prose describing a bad import cannot trip the scan. */
+function stripNonCode(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[ \t]*\/\/.*$/gm, '')
+    .replace(/(['"`])(?:\\.|(?!\1)[^\\])*\1/g, (m) => {
+      // Preserve the module specifier itself — it is what we match on.
+      return CJS_ONLY_PACKAGES.some((p) => m === `'${p}'` || m === `"${p}"`) ? m : "''";
+    });
+}
+
+function walkTsFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkTsFiles(full, out);
+    else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) out.push(full);
+  }
+  return out;
+}
+
+interface Offence { file: string; statement: string; pkg: string; }
+
+function findNamedValueImports(): Offence[] {
+  const offences: Offence[] = [];
+  for (const file of walkTsFiles(SRC_DIR)) {
+    const code = stripNonCode(fs.readFileSync(file, 'utf-8'));
+    for (const pkg of CJS_ONLY_PACKAGES) {
+      // `import { X } from 'pkg'` / `import X, { Y } from 'pkg'` — but NOT `import type { X }`,
+      // which is erased at compile time and therefore safe.
+      const re = new RegExp(`import\\s+(?!type\\s)[^;]*?\\{[^}]*\\}[^;]*?from\\s*['"]${pkg}['"]`, 'g');
+      for (const match of code.matchAll(re)) {
+        if (/\{\s*type\s/.test(match[0]) && !/\{[^}]*[A-Za-z_$][^}]*\}/.test(match[0].replace(/type\s+\w+/g, ''))) {
+          continue; // inline `{ type Foo }` only — still type-erased
+        }
+        offences.push({ file: path.relative(SRC_DIR, file), statement: match[0].trim(), pkg });
+      }
+    }
+  }
+  return offences;
+}
+
+describe('CommonJS packages are never named-value-imported under ESM', () => {
+  it('REGRESSION: no source file takes a named value import from a CJS-only package', () => {
+    const offences = findNamedValueImports();
+    expect(
+      offences,
+      offences.length
+        ? `Named value import from a CommonJS package — this throws at load under Node ESM ` +
+          `(tsc and vitest both pass it). Use \`import pkg from '${offences[0].pkg}'\` then destructure.\n` +
+          offences.map((o) => `  ${o.file}: ${o.statement}`).join('\n')
+        : '',
+    ).toEqual([]);
+  });
+
+  it('the values ssh2 is used for are reachable the way the source now takes them', async () => {
+    const ssh2 = (await import('ssh2')).default;
+    expect(typeof ssh2.Server).toBe('function');
+    expect(typeof ssh2.Client).toBe('function');
+    expect(typeof ssh2.utils).toBe('object');
+    expect(typeof ssh2.utils.parseKey).toBe('function');
+  });
+
+  /**
+   * Dead-check guards. The assertion above passes trivially against a scanner that
+   * finds nothing because it is broken — an empty walk, a regex that matches
+   * nothing, or a strip step that deletes the whole file. Each is checked.
+   */
+  it('the scanner actually reads the tree it claims to scan', () => {
+    const files = walkTsFiles(SRC_DIR);
+    expect(files.length).toBeGreaterThan(100);
+    expect(files.some((f) => f.endsWith('MachineSshEndpoint.ts'))).toBe(true);
+  });
+
+  it('the scanner DETECTS the exact statement this incident shipped', () => {
+    // The pre-fix line from src/core/MachineSshEndpoint.ts, verbatim.
+    const bad = "import { Server, utils, type Connection } from 'ssh2';";
+    const re = new RegExp(`import\\s+(?!type\\s)[^;]*?\\{[^}]*\\}[^;]*?from\\s*['"]ssh2['"]`);
+    expect(re.test(stripNonCode(bad))).toBe(true);
+  });
+
+  it('the scanner ALLOWS the two safe forms — it is not a blanket ban on the word', () => {
+    const re = new RegExp(`import\\s+(?!type\\s)[^;]*?\\{[^}]*\\}[^;]*?from\\s*['"]ssh2['"]`);
+    // Default import: the fix.
+    expect(re.test(stripNonCode("import ssh2 from 'ssh2';"))).toBe(false);
+    // Type-only import: erased at compile time, cannot throw at runtime.
+    expect(re.test(stripNonCode("import type { Connection, Server } from 'ssh2';"))).toBe(false);
+  });
+
+  it('comments and strings describing a bad import do not trip the scan', () => {
+    // This file's own header contains the forbidden shape. If stripping regressed,
+    // the scan would flag innocent files for merely documenting the hazard.
+    const prose = `
+      // import { Server } from 'ssh2';
+      /* the old line was: import { Server, utils } from 'ssh2'; */
+      const doc = "import { Server } from 'ssh2';";
+      import ssh2 from 'ssh2';
+    `;
+    const re = new RegExp(`import\\s+(?!type\\s)[^;]*?\\{[^}]*\\}[^;]*?from\\s*['"]ssh2['"]`, 'g');
+    expect([...stripNonCode(prose).matchAll(re)]).toHaveLength(0);
+  });
+});

--- a/upgrades/next/ssh2-cjs-named-imports.md
+++ b/upgrades/next/ssh2-cjs-named-imports.md
@@ -1,0 +1,52 @@
+# Mutual-SSH modules no longer throw at load
+
+## What Changed
+
+Five `src/core/` modules took named value imports from `ssh2`, which is CommonJS.
+Node's ESM loader cannot statically detect CJS named exports, so each threw at load
+and `mutual-ssh` / `peer-execution` failed to initialise at every server boot —
+warning-level, surfaced nowhere. Fixed by default-importing the namespace and
+destructuring at runtime; type-only imports are unchanged.
+
+A regression guard scans `src/` for named value imports from a CJS allowlist. It is
+a source scan rather than an import assertion because an import assertion cannot
+observe this bug class: vitest transforms through Vite, which rewrites CJS interop,
+so the broken source passes in-process. `tsc` is likewise blind — the types are real.
+
+## Evidence
+
+- Built output loaded under Node's real ESM loader: all five modules load; all five
+  previously threw.
+- Guard refuses a reverted import, naming file and statement:
+  `× core/MutualSshVerifier.ts: import { Client, utils } from 'ssh2'`.
+- First-attempt import-assertion guard passed 8/8 against broken source; `tsc` exit 0.
+  Both recorded in the side-effects artifact.
+
+## Known limits
+
+Loading is not functioning: whether the runtime then binds, finds keys and reaches a
+peer is untested here and not claimed. `multiMachine.mutualSsh.enabled` registers with
+`guardRegistry` inside the failing try block, so the failure is absent from the guard
+inventory (88 rows, no mutualSsh row) — tracked, not fixed here. <!-- tracked: CMT-1044 -->
+
+## What to Tell Your User
+
+If you run instar on more than one machine, one of the ways those machines can talk
+to each other — the direct SSH channel — has been failing at every server start, in a
+way that only ever showed up as a warning line in a boot log. It could not have worked.
+That specific failure is now gone.
+
+Be honest about the size of this: the channel now *starts*. Whether it then connects
+to another machine end to end has not been demonstrated here, and should not be
+claimed. If you were relying on mutual-SSH and it was silently doing nothing, this
+removes the first reason why. If you run on a single machine, nothing changes for you.
+
+There is a related gap deliberately left open: this subsystem does not appear on the
+guard inventory at all when it fails, because it registers itself
+after the point where it was crashing. So "it's not listed" did not mean "it's fine".
+That is tracked separately.
+
+## Summary of New Capabilities
+
+None. This is a repair, not a new capability. Five modules that could never load now
+load; no route, config key, or user-visible surface is added or changed.

--- a/upgrades/side-effects/ssh2-cjs-named-imports.md
+++ b/upgrades/side-effects/ssh2-cjs-named-imports.md
@@ -1,0 +1,183 @@
+# Side-Effects Review — five modules that threw at load, and a guard that could not see it
+
+**Version / slug:** `ssh2-cjs-named-imports`
+**Date:** `2026-07-26`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `see Phase 5`
+
+## Summary of the change
+
+`ssh2` is CommonJS. Five files took named VALUE imports from it
+(`import { Server, utils } from 'ssh2'`). Node's ESM loader cannot statically detect
+CJS named exports, so each of those modules threw at load. Observed at every server
+boot, warning-level, surfaced nowhere:
+
+```
+[mutual-ssh] initialization blocked: The requested module 'ssh2' does not provide
+  an export named 'Server'                                    (server.ts:21596)
+[peer-execution] disabled-grant cleanup blocked: Named export 'utils' not found.
+                                                              (server.ts:21491)
+```
+
+Fix: default-import the namespace, destructure at runtime, keep the type import
+type-only (types are erased, so `import type { Connection }` is safe and unchanged).
+
+Verified against the built output under Node's real loader — all five previously
+threw, all five now load:
+
+```
+$ npm run build && node --input-type=module -e "…await import('./dist/core/'+m+'.js')…"
+  LOADS   PeerAuthorizedKeys / MachineSshEndpoint / MutualSshVerifier
+  LOADS   StandingSshVerifier / SshBootstrapAdvert
+```
+
+## The guard is a source scan, and that was not the first attempt
+
+The obvious regression guard — import each module, assert no throw — was written,
+passed, and was **wrong**. Reverting one file to the broken form left it fully green:
+
+```
+$ npx vitest run tests/unit/ssh2-modules-load-under-esm.test.ts   # BROKEN source
+  ✓ (8 tests) — Tests  8 passed (8)
+$ npx tsc --noEmit                                                # BROKEN source
+  tsc exit=0
+$ node --input-type=module -e "import { Server } from 'ssh2';"
+  SyntaxError: Named export 'Server' not found…
+```
+
+Vitest transforms through Vite, which rewrites CJS interop; production runs the
+compiled output under Node's loader, which does not. An in-process import assertion
+is **structurally incapable** of observing this class — it does not merely miss it.
+`tsc` is blind for a different reason: the types are genuinely correct.
+
+The replacement scans source text for named value imports from a CJS allowlist. It
+refuses correctly:
+
+```
+$ npx vitest run …   # after reverting src/core/MutualSshVerifier.ts
+  × REGRESSION: no source file takes a named value import from a CJS-only package
+    → core/MutualSshVerifier.ts: import { Client, utils } from 'ssh2'
+  Tests  1 failed | 5 passed (6)
+```
+
+## Decision-point inventory
+
+| point | classification | note |
+|---|---|---|
+| import form per file | `invariant` | Mechanical; no runtime branch introduced. |
+| scan allowlist (`CJS_ONLY_PACKAGES`) | `invariant` | Explicit list, currently `['ssh2']`. Deliberately not auto-derived — see §2. |
+| comment/string stripping before match | `invariant` | Asserted by a test using this file's own prose. |
+
+No judgment points. No model call. Nothing gates or blocks at runtime.
+
+## 1. Over-block
+
+The scan is the only thing that can refuse, and it refuses at test time, never at
+runtime. Its over-block risk is flagging an innocent file whose *prose* contains the
+forbidden shape — the known weakness of text checks, and one this codebase has been
+bitten by three times. Closed by stripping comments and string literals first, with a
+test that feeds it this very file's description of the bug and asserts zero matches.
+Both safe forms (`import ssh2 from 'ssh2'`, `import type { … }`) are asserted to pass.
+
+## 2. Under-block
+
+**The allowlist is manual.** A named value import from some *other* CJS package is
+not caught. Auto-deriving it (reading every dependency's `package.json` type field)
+was considered and rejected for this change: it turns a two-line list into a
+resolution problem with its own failure modes, and would have shipped untested. The
+list is the honest, visible limit. <!-- tracked: CMT-1044 -->
+
+**It scans `src/` only.** Scripts, hooks, and templates are not covered.
+
+**Loading is not working.** This proves five modules load. Whether `mutualSshRuntime.start()`
+then binds, finds keys, and reaches a peer is untested here and is NOT claimed. The
+precise claim: the channel could not have worked before, and one specific blocker is gone.
+
+**The guard cannot see the compiled reality.** A source scan infers the runtime
+failure from the source shape. The direct check — importing built output under Node —
+runs in this review but is not wired into CI, because it requires a build step the
+unit shard does not have.
+
+## 3. Level-of-abstraction fit
+
+The fix is at the only possible layer: the import statements themselves. The guard sits
+in the unit shard, which is where a cheap always-runs check belongs. A lint rule
+(`eslint-plugin-import`) would be the more conventional home; it is not adopted here
+because the repo has no such plugin configured and adding one is a larger change than
+the bug warrants.
+
+## 4. Signal vs authority compliance
+
+No runtime authority is introduced or moved. The change removes a load-time crash; it
+adds no gate, no branch, no decision. The test-time scan holds authority over CI only,
+which is the appropriate place for a brittle text check per `docs/signal-vs-authority.md`
+— brittleness is acceptable when the blast radius is a red build, not a blocked action.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+None introduced.
+
+## 5. Interactions
+
+- **`MutualSshRuntime` / mesh transport** — unchanged. This only lets its dependencies load.
+- **`guardRegistry`** — see §6b. Not modified here.
+- **Type imports** — `import type { Connection, Server as SshServerType }` retained in
+  `MachineSshEndpoint.ts`; `Server` needed splitting into a value binding and a type
+  alias because it is used as both. Caught by `tsc`, not by me.
+
+## 6. External surfaces
+
+None. No route, no config key, no log line, no user-visible message, no persisted state.
+
+## 6b. Operator-surface quality — the finding this change does NOT fix
+
+`multiMachine.mutualSsh.enabled` registers itself with `guardRegistry` **inside** the
+try block that threw. So the failure removed itself from the inventory built to catch
+exactly this. Confirmed against the live pre-fix server:
+
+```
+total guard rows: 88
+mutualSsh/peerExecution rows: 1   →  multiMachine.peerExecution.enabled
+```
+
+`mutualSsh` has no row at all — not "off", not "errored", absent. This is the same
+shape as tonight's relay defect (a dropped connection left "connected" as the only
+record): **the defect deletes its own evidence.** Registering guards before the
+fallible construction, so a crashed subsystem still appears as `errored`, is a real
+change to a shared registry and is deliberately not bundled here. <!-- tracked: CMT-1044 -->
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+Machine-local by design — a module either loads in this process or does not. No
+replication, no lease interaction, no shared state, no generated URL. The *feature*
+being repaired is cross-machine, but this change to it is not.
+
+## 8. Rollback cost
+
+Low. Five import statements and one test file. No migration, no persisted state, no
+config default, nothing installed into an agent home. Reverting restores the previous
+behaviour exactly — a warning at boot and a dead channel — and the guard would fail
+loudly on the way, which is the intended announcement.
+
+## Phase 5 — Second-pass review
+
+Touches no block/allow decision, no session lifecycle, no trust level, no gate or
+sentinel, so the high-risk trigger list is not engaged. Author-applied lenses, disclosed:
+
+**Adversarial — "how would I make this useless?"** By writing a guard that cannot
+observe the failure. I did exactly that on the first attempt, and only caught it
+because the refusal step is mandatory rather than optional. Recorded in §2 as the
+central lesson rather than quietly replaced.
+
+**"Did I fix the symptom or the cause?"** The cause, for the load failure. Not for the
+invisibility — §6b is the cause of *why nobody noticed for so long*, and it is left
+open and tracked rather than half-done.
+
+**"Would it have caught the incident?"** The guard would have failed the build the day
+the named import was introduced. It would not have surfaced the boot warning; nothing
+here changes observability.
+
+**Weakest point:** §2's last item. The scan infers a runtime property from source
+text. The direct check exists and passes, but runs by hand in this review rather than
+in CI — so the thing CI actually enforces is one inference removed from the thing that
+broke.


### PR DESCRIPTION
## What

`ssh2` is CommonJS. Node's ESM loader cannot statically detect its named exports, so `import { Server, utils } from 'ssh2'` throws at module load. Five `src/core` modules did this, so `mutual-ssh` and `peer-execution` failed to initialise at **every server boot** — warning-level, surfaced nowhere:

```
[mutual-ssh] initialization blocked: The requested module 'ssh2' does not provide an export named 'Server'
[peer-execution] disabled-grant cleanup blocked: Named export 'utils' not found.
```

Fix: default-import the namespace, destructure at runtime. Type-only imports unchanged (erased at compile time, cannot throw).

## The guard is a source scan, and that was not the first attempt

The obvious guard — import each module, assert no throw — was written, passed, and was **wrong**. Reverting a file to the broken form left it fully green:

```
$ npx vitest run tests/unit/ssh2-modules-load-under-esm.test.ts   # BROKEN source
  ✓ (8 tests) — Tests  8 passed (8)
$ npx tsc --noEmit                                                # BROKEN source
  tsc exit=0
$ node --input-type=module -e "import { Server } from 'ssh2';"
  SyntaxError: Named export 'Server' not found…
```

Vitest transforms through Vite, which rewrites CJS interop; production runs compiled output under Node's loader, which does not. An in-process import assertion is **structurally incapable** of observing this class. `tsc` is blind for a different reason — the types are genuinely correct.

The replacement scans source text (comments and string literals stripped first, with a test proving this PR's own prose does not trip it). It refuses correctly:

```
× REGRESSION: no source file takes a named value import from a CJS-only package
  → core/MutualSshVerifier.ts: import { Client, utils } from 'ssh2'
Tests  1 failed | 5 passed (6)
```

## Evidence

Built output loaded under Node's real ESM loader — all five previously threw:

```
LOADS  PeerAuthorizedKeys / MachineSshEndpoint / MutualSshVerifier
LOADS  StandingSshVerifier / SshBootstrapAdvert
```

## Honest scope

**Loading is not functioning.** Whether the runtime then binds, finds keys and reaches a peer is untested here and not claimed. The precise claim: the channel could not have worked before, and one specific blocker is gone.

**Left open and tracked:** `multiMachine.mutualSsh.enabled` registers with `guardRegistry` *inside* the try block that threw, so the failure is absent from the guard inventory — 88 rows, no mutualSsh row. Not "off", not "errored" — absent. The defect deleted its own evidence, same shape as #1656. Registering guards before fallible construction is a change to a shared registry and is deliberately not bundled.

**Origin:** #1539, the commit that created all five files. Wrong from birth; never worked once.

Tier 1. ELI16 + side-effects artifacts staged.

## ELI16 — a channel that failed at every startup, in a way three separate checks could not see

One of the ways my machines talk to each other has been broken at every single
startup, and nobody noticed for a simple reason: everything that was supposed to
notice said it was fine.

JavaScript has an older and a newer way of packaging code. Mine is newer; the SSH
library is older. With an older-style package you must take the whole box and then
reach inside. Five files tried to name the pieces they wanted *at the door*. The box
does not allow that — the pieces are genuinely in there, but the loader cannot see
them from outside, so it refuses the instant the file is loaded. Nothing in those
files ever ran. The channel did not work badly; it never started.

The fix is four words rearranged in five places: take the box, then reach inside.

The more interesting part is the guard I wrote to stop it returning. The obvious one —
load each file, check nothing throws — passed. Then I put the bug back on purpose to
watch it fail, and **it passed again**. The test runner quietly rewrites this exact
kind of import so the shortcut works; the real program does not. So the guard was not
weak, it was *incapable* — structurally unable to see the thing it was named after,
while looking like proof the bug could never return. The compiler is blind too, for a
different reason: the pieces really exist, so the types are correct and only the
runtime lookup fails.

Three independent things all reported fine on knowingly broken code. The replacement
reads the source text instead — a cruder check I would normally argue against, so it
strips comments and quoted text first, and a test proves this PR's own description of
the bug does not set it off.

There is a third place it was invisible: an inventory whose whole job is to list
broken systems does not list this one. Not as failing — absent, out of 88 entries. It
adds itself during startup and was crashing just before that point, so it removed
itself from the list designed to catch it. Left open and tracked rather than
half-fixed here.

**Honest scope:** this makes the five files load. Whether the channel then connects to
another machine end to end is untested and not claimed.
