### PR TITLE
fix(intent): the decision journal refuses a decision that does not say why

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-26T21-31-01-154Z-decision-journal-principle-required.json
+++ b/.instar/instar-dev-decisions/2026-07-26T21-31-01-154Z-decision-journal-principle-required.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-26T21:31:01.154Z",
+  "slug": "decision-journal-principle-required",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 4,
+  "loc": 151,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/decision-journal-principle-required.eli16.md
+++ b/docs/specs/decision-journal-principle-required.eli16.md
@@ -1,0 +1,91 @@
+# Making the decision log refuse a decision that does not say why — Plain-English Overview
+
+> The one-line version: I wrote down four decisions, believed I had recorded the reasoning behind
+> each one, and had not. The system accepted every word and stored it where nothing would ever read
+> it. Nothing told me. It could not have told me.
+
+## What happened
+
+My operator asked for something specific: stop escalating every choice to him, decide against our
+stated goals instead, and log the reasoning so he can review it later. He was explicit that this
+should be enforced by infrastructure rather than by me remembering.
+
+So I went to find out what would need building — and nearly told him we needed to build a decision
+recorder. That was wrong. One already exists. Its own description says it exists so that agents can
+log decisions when they face tradeoffs, and reflect later on whether those decisions matched what
+we said we cared about. It has a write endpoint, a read endpoint, statistics, and a separate
+component that reads it back to detect drift.
+
+It had recorded zero decisions. Ever.
+
+So I logged four, then a fifth. Then I looked at what I had actually stored.
+
+## The part I got wrong without being told
+
+Each time, I sent a field I called `reasoning`, and once a field I called `checkedAgainst`. Neither
+is a real field. The system has a real one for exactly this — it means "which principle or intent
+guided this choice" — and I never filled it, because nothing asked me to and nothing objected.
+
+My made-up fields were saved. They are sitting in the file right now. Nothing reads them. No
+statistic counts them, no drift detector consults them, no review surface shows them. I had written
+to a drawer nobody opens, and the system returned success.
+
+That is worse than losing the data outright, because I told my operator the reasoning was recorded.
+I believed it. The only reason I found out is that I went to read my own file.
+
+## The second half, which is the same bug wearing a different hat
+
+The statistics surface reports which principles have been referenced most. With five entries and
+nobody having filled that field, it reported an empty list.
+
+An empty journal also reports an empty list.
+
+So "nobody has made a decision yet" and "five decisions were recorded and not one of them said why"
+produced identical output. The instrument built to detect unreasoned decisions could not distinguish
+its own worst case from a clean slate.
+
+## What this builds
+
+Two refusals and one counter.
+
+**The log now rejects a decision that names no guiding principle.** Not a warning. It refuses to
+record it, and the rejection says why in words, naming the missing field.
+
+**It rejects invented field names too**, listing them back and pointing at where the content actually
+belongs. This is the one that would have caught me. Had it existed an hour ago, my very first attempt
+would have failed loudly instead of succeeding quietly, and I would have fixed it in seconds instead
+of discovering it by accident.
+
+**And the statistics now carry two counts side by side** — how many entries named a principle, and
+how many did not. Those two numbers are the entire difference between an empty journal and a journal
+full of unreasoned decisions.
+
+## What it does not do
+
+**It does not make me consult our goals.** It makes me unable to *claim* I did without saying which
+one. That is a real difference and I want to be honest about which side of it this lands on. The
+thing that fires at the moment of a decision and puts the goal hierarchy in front of me is a separate
+piece of work and is not in here.
+
+**It does not touch the automatic path.** Decisions the system generates on its own — routine,
+machine-applied ones — have no principle to cite and are deliberately left alone. Blocking those
+would break automatic dispatch to buy nothing. Only the path an agent writes to by hand is gated.
+
+**It does not repair the five entries already written.** They keep their unread fields. The counters
+will show them for what they are, which seems better than quietly rewriting my own history.
+
+## The part worth more than the feature
+
+I have a rule that nothing counts as done until I have broken it deliberately and watched the tests
+complain. I broke the checking logic four different ways and it complained properly each time.
+
+Then I broke the *connection* between the checking logic and the thing that receives submissions —
+so that nothing was ever actually checked. **All eleven tests still passed.**
+
+That is the second time tonight. The exact same shape, one feature apart: the logic thoroughly
+guarded, the wiring between the pieces not guarded at all, and a full green test run agreeing that a
+surface which checks nothing is fine. Last time I found it by luck. This time I went looking for it
+on purpose, because it had just happened, and it was there.
+
+The tests that catch it are in a separate file whose only job is to prove the receiving end actually
+asks. Break that wiring now and four of them fail immediately.

--- a/src/core/DecisionJournal.ts
+++ b/src/core/DecisionJournal.ts
@@ -42,8 +42,111 @@ export interface DecisionJournalStats {
   latest: string | null;
   /** Top principles referenced, sorted by frequency */
   topPrinciples: Array<{ principle: string; count: number }>;
+  /**
+   * Entries that DID name the principle/intent that guided the choice.
+   *
+   * Exists because `topPrinciples: []` is otherwise ambiguous between two
+   * very different journals: one with no entries at all, and one with many
+   * entries where nobody ever filled `principle`. The second is the failure
+   * this journal was built to detect (a decision kept, its reasoning
+   * discarded) and it previously rendered identically to a healthy empty
+   * journal — absence reading as presence.
+   */
+  principledCount: number;
+  /** Entries that did NOT name a guiding principle. */
+  unprincipledCount: number;
   /** Number of entries flagged as conflicting */
   conflictCount: number;
+}
+
+/** Fields a caller may submit over the agent-authored HTTP path. */
+export const DECISION_JOURNAL_WRITABLE_FIELDS = [
+  'sessionId',
+  'decision',
+  'principle',
+  'topicId',
+  'jobSlug',
+  'alternatives',
+  'confidence',
+  'context',
+  'conflict',
+  'tags',
+  'evidence',
+] as const;
+
+export interface DecisionSubmissionVerdict {
+  ok: boolean;
+  /** Machine-readable refusal reason; null when accepted. */
+  reason: 'missing-required' | 'unknown-fields' | null;
+  /** Human-facing explanation naming the offending fields. */
+  message: string | null;
+  /** Submitted keys that are not recorded by any reader. */
+  unknownFields: string[];
+  /** Required keys the submission omitted. */
+  missingFields: string[];
+}
+
+/**
+ * Validate an agent-authored decision submission BEFORE it is recorded.
+ *
+ * Two refusals, both earned from the same incident: an agent POSTed
+ * `reasoning` and `checkedAgainst`, believed it had recorded what the
+ * decision was checked against, and had not — neither key is read by
+ * anything. The write silently succeeded, so nothing could have caught it.
+ *
+ *  1. `principle` is REQUIRED. A decision recorded without naming what
+ *     guided it preserves THAT a choice was made and not WHY, which is the
+ *     one thing the journal exists to preserve.
+ *  2. Unknown fields are REFUSED rather than swallowed. Accepting a key no
+ *     reader consumes lets a caller believe it recorded something it did
+ *     not — the failure this function exists to make impossible.
+ *
+ * Pure: no I/O, no clock, no config. The machine-generated path
+ * (DispatchDecisionJournal → journal.log) deliberately does NOT run this —
+ * an auto-applied dispatch has no principle to cite and must not be blocked.
+ */
+export function validateDecisionSubmission(
+  body: Record<string, unknown> | null | undefined,
+): DecisionSubmissionVerdict {
+  const submitted = body && typeof body === 'object' ? body : {};
+  const allowed = new Set<string>(DECISION_JOURNAL_WRITABLE_FIELDS);
+
+  const unknownFields = Object.keys(submitted).filter(k => !allowed.has(k)).sort();
+
+  const missingFields = (['sessionId', 'decision', 'principle'] as const).filter(k => {
+    const v = (submitted as Record<string, unknown>)[k];
+    return typeof v !== 'string' || v.trim() === '';
+  });
+
+  if (missingFields.length > 0) {
+    return {
+      ok: false,
+      reason: 'missing-required',
+      message:
+        `Missing required field(s): ${missingFields.join(', ')}. ` +
+        `A decision must name the principle or intent that guided it — ` +
+        `recording the choice without the reasoning is what this journal exists to prevent.`,
+      unknownFields,
+      missingFields: [...missingFields],
+    };
+  }
+
+  if (unknownFields.length > 0) {
+    return {
+      ok: false,
+      reason: 'unknown-fields',
+      message:
+        `Unrecognised field(s): ${unknownFields.join(', ')}. ` +
+        `These would be stored but never read, so the submission would look ` +
+        `recorded without being recorded. Put the reasoning in 'context' and ` +
+        `the guiding intent in 'principle'. Writable fields: ` +
+        `${DECISION_JOURNAL_WRITABLE_FIELDS.join(', ')}.`,
+      unknownFields,
+      missingFields: [],
+    };
+  }
+
+  return { ok: true, reason: null, message: null, unknownFields: [], missingFields: [] };
 }
 
 export class DecisionJournal {
@@ -234,6 +337,8 @@ export class DecisionJournal {
         earliest: null,
         latest: null,
         topPrinciples: [],
+        principledCount: 0,
+        unprincipledCount: 0,
         conflictCount: 0,
       };
     }
@@ -244,10 +349,12 @@ export class DecisionJournal {
     // Count principles
     const principleCounts: Record<string, number> = {};
     let conflictCount = 0;
+    let principledCount = 0;
 
     for (const entry of entries) {
       if (entry.principle) {
         principleCounts[entry.principle] = (principleCounts[entry.principle] || 0) + 1;
+        principledCount++;
       }
       if (entry.conflict) {
         conflictCount++;
@@ -263,6 +370,8 @@ export class DecisionJournal {
       earliest: entries[0].timestamp,
       latest: entries[entries.length - 1].timestamp,
       topPrinciples,
+      principledCount,
+      unprincipledCount: entries.length - principledCount,
       conflictCount,
     };
   }

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -5287,6 +5287,12 @@ setTimeout(() => process.exit(0), 2000);
       result.upgraded.push('CLAUDE.md: added channel registry Registry First awareness');
     }
 
+    if (!content.includes('Decision journal — principle is required:')) {
+      content += '\n- **Decision journal — principle is required:** `POST /intent/journal` now REFUSES (400) a decision that names no guiding principle, and refuses invented field names by name rather than storing them. A field no reader consumes makes a submission look recorded without being recorded. Writable fields: `sessionId`, `decision`, `principle`, `topicId`, `jobSlug`, `alternatives`, `confidence`, `context`, `conflict`, `tags`, `evidence` — put reasoning in `context`, guiding intent in `principle`. `GET /intent/journal/stats` carries `principledCount`/`unprincipledCount`, because `topPrinciples: []` alone cannot distinguish "nothing decided yet" from "many decisions, none said why". The machine dispatch path is exempt.\n';
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added decision-journal principle requirement awareness');
+    }
+
     if (!content.includes('Codex quota is first-class in the pool:')) {
       content += '\n- **Codex quota is first-class in the pool:** Codex accounts read the real 5-hour + weekly windows from their latest rollout instead of appearing permanently empty. Placement and every reactive/proactive swap are framework-safe: a Codex session can use only Codex accounts, and a Claude session only Claude accounts.\n';
       patched = true;
@@ -9080,6 +9086,11 @@ Two layers keep my machine-to-machine \"ropes\" (Tailscale / LAN / Cloudflare) h
       // before reporting a peer unreachable, or it will improvise the same weaker
       // workaround I did — stop, and tell the operator the peer cannot be reached.
       '**Registry First — channel registry:',
+      // decision-journal: a Codex/Gemini agent that does not learn the new
+      // requirement will POST without `principle`, take a 400 it cannot explain,
+      // and fall back to recording decisions somewhere nothing reads — which is
+      // the exact failure this refusal exists to prevent.
+      '**Decision journal — principle is required:',
       '**Publishing**',
       '**Private Viewing**',
       '**Secret Drop**',

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -1584,6 +1584,16 @@ Your agent has intent engineering infrastructure for tracking how decisions alig
 
 **When to log a decision:** When you face a genuine tradeoff — speed vs. thoroughness, user request vs. stated boundary, cost vs. quality. Not every action, just the ones where intent guidance matters.
 
+**Decision journal — principle is required:** invented field names are REFUSED (400) too. A decision recorded without naming what guided it preserves THAT you chose and not WHY — the one thing this journal exists to preserve. Writable fields: \`sessionId\`, \`decision\`, \`principle\`, \`topicId\`, \`jobSlug\`, \`alternatives\`, \`confidence\`, \`context\`, \`conflict\`, \`tags\`, \`evidence\`. Anything else is rejected by name rather than stored, because a field no reader consumes makes a submission look recorded without being recorded. Put your reasoning in \`context\` and the guiding intent in \`principle\`:
+
+\`\`\`bash
+curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/intent/journal \\
+  -H 'Content-Type: application/json' \\
+  -d '{"sessionId":"<session>","decision":"<what you chose>","principle":"<what guided it>","context":"<why, and what you checked it against>"}'
+\`\`\`
+
+**Reading the stats honestly:** \`principledCount\` / \`unprincipledCount\` sit beside \`count\`. \`topPrinciples: []\` alone cannot tell you whether nobody has decided anything yet or whether many decisions were recorded and not one said why — these two counters are what separates those cases. The machine-generated dispatch path is deliberately exempt; an auto-applied dispatch has no principle to cite and is never blocked.
+
 ### Playbook — Adaptive Context Engineering
 
 The Playbook system gives you a living knowledge base that makes every session smarter than the last. Instead of loading the same static context every time, Playbook curates a manifest of context items — facts, lessons, patterns, safety rules — and selects exactly what's relevant for each session based on triggers, token budgets, and usefulness scores.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -22367,16 +22367,27 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
 
   router.post('/intent/journal', async (req, res) => {
     try {
-      const { DecisionJournal } = await import('../core/DecisionJournal.js');
+      const { DecisionJournal, validateDecisionSubmission } = await import(
+        '../core/DecisionJournal.js'
+      );
       const { EvidencePolicyError } = await import('../memory/SemanticMemory.js');
       const journal = new DecisionJournal(ctx.config.stateDir);
 
-      const { sessionId, decision, evidence, ...rest } = req.body || {};
-
-      if (!sessionId || !decision) {
-        res.status(400).json({ error: 'sessionId and decision are required' });
+      // Refuse before recording. A submission that names no guiding principle,
+      // or that carries a field no reader consumes, would otherwise succeed and
+      // look recorded without being recorded.
+      const verdict = validateDecisionSubmission(req.body);
+      if (!verdict.ok) {
+        res.status(400).json({
+          error: verdict.message,
+          reason: verdict.reason,
+          unknownFields: verdict.unknownFields,
+          missingFields: verdict.missingFields,
+        });
         return;
       }
+
+      const { sessionId, decision, evidence, ...rest } = req.body || {};
 
       // WikiClaim Phase 3 (spec § Producers line 258): every decision must
       // cite at least one evidence row. The route accepts an explicit

--- a/tests/integration/decision-journal-route.test.ts
+++ b/tests/integration/decision-journal-route.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tier-2 integration test for `POST /intent/journal` — the agent-authored
+ * decision write path.
+ *
+ * WHY THIS FILE EXISTS. The refusal that matters here lives at the ROUTE, not
+ * in the validator. The validator is a pure function; it can be perfect while
+ * the route never calls it, and the unit suite would still pass in full. That
+ * is precisely what happened one feature earlier tonight — a module thoroughly
+ * guarded, its wiring not, and nineteen green tests agreeing that a surface
+ * serving nothing was fine.
+ *
+ * So: the unit tests prove the validator refuses. These prove the route ASKS it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { generateAgentToken, deleteAgentToken } from '../../src/messaging/AgentTokenManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const PROJECT_NAME = 'decision-journal-route-' + Math.random().toString(36).slice(2, 8);
+const SESSION = 'sess-route-test';
+let AUTH = '';
+
+function buildCtx(tmpDir: string): RouteContext {
+  return {
+    config: {
+      projectName: PROJECT_NAME, projectDir: tmpDir,
+      stateDir: path.join(tmpDir, '.instar'), port: 0, authToken: AUTH,
+    } as never,
+    sessionManager: { listRunningSessions: () => [], isSessionAlive: () => false } as never,
+    state: { getJobState: () => null, getSession: () => null } as never,
+    scheduler: null, telegram: null, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, discoveryEvaluator: null, startTime: new Date(),
+    mentorRunner: null, currentInboundByTopic: new Map(),
+  } as unknown as RouteContext;
+}
+
+function mount(tmpDir: string): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(buildCtx(tmpDir)));
+  return app;
+}
+
+describe('POST /intent/journal (integration — the wiring, not just the validator)', () => {
+  let tmpDir: string;
+  let app: express.Express;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'decision-journal-route-'));
+    fs.mkdirSync(path.join(tmpDir, '.instar'), { recursive: true });
+    AUTH = generateAgentToken(PROJECT_NAME);
+    app = mount(tmpDir);
+  });
+  afterEach(() => {
+    try { deleteAgentToken(PROJECT_NAME); } catch { /* best-effort */ }
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true, force: true, operation: 'tests/integration/decision-journal-route.test.ts:cleanup',
+    });
+  });
+
+  const post = (body: unknown) =>
+    request(app).post('/intent/journal').set('Authorization', `Bearer ${AUTH}`).send(body as object);
+
+  it('REGRESSION: the ROUTE refuses a decision that names no principle', async () => {
+    // If the route stops calling the validator, this returns 201 and breaks.
+    const res = await post({ sessionId: SESSION, decision: 'Split the spec' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.reason).toBe('missing-required');
+    expect(res.body.missingFields).toContain('principle');
+  });
+
+  it('REGRESSION: the ROUTE refuses fields no reader consumes', async () => {
+    // The literal submission from the incident that produced this feature.
+    const res = await post({
+      sessionId: SESSION,
+      decision: 'Prune the run file at item-closure',
+      principle: 'Structure > Willpower',
+      reasoning: 'effort-based pruning measurably lost ground',
+      checkedAgainst: 'northstar; tier-1 topic goal',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.reason).toBe('unknown-fields');
+    expect(res.body.unknownFields).toEqual(['checkedAgainst', 'reasoning']);
+  });
+
+  it('REGRESSION: a refused submission writes NOTHING', async () => {
+    await post({ sessionId: SESSION, decision: 'no principle here' });
+    await post({ sessionId: SESSION, decision: 'x', principle: 'p', bogus: 1 });
+
+    const stats = await request(app)
+      .get('/intent/journal/stats').set('Authorization', `Bearer ${AUTH}`);
+
+    // A refusal that still recorded the row would be worse than no refusal:
+    // the journal would carry entries the caller was told were rejected.
+    expect(stats.body.count).toBe(0);
+  });
+
+  it('accepts a complete submission and records the principle', async () => {
+    const res = await post({
+      sessionId: SESSION,
+      decision: 'Prune the run file at item-closure',
+      principle: 'Structure > Willpower',
+      context: 'effort-based pruning lost ground five times; closure-triggered worked twice',
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.principle).toBe('Structure > Willpower');
+
+    const stats = await request(app)
+      .get('/intent/journal/stats').set('Authorization', `Bearer ${AUTH}`);
+    expect(stats.body.count).toBe(1);
+    expect(stats.body.principledCount).toBe(1);
+    expect(stats.body.unprincipledCount).toBe(0);
+  });
+
+  it('REGRESSION: /intent/journal/stats exposes the principled split', async () => {
+    // The read surface has to carry the new counters or the honesty fix is
+    // invisible to every consumer — a fixed module behind an unchanged surface.
+    const stats = await request(app)
+      .get('/intent/journal/stats').set('Authorization', `Bearer ${AUTH}`);
+
+    expect(stats.status).toBe(200);
+    expect(stats.body).toHaveProperty('principledCount');
+    expect(stats.body).toHaveProperty('unprincipledCount');
+  });
+
+  it('the refusal message tells the caller where the content belongs', async () => {
+    const res = await post({
+      sessionId: SESSION, decision: 'd', principle: 'p', reasoning: 'r',
+    });
+    // A refusal that does not name the correct field just relocates the failure.
+    expect(res.body.error).toMatch(/context/);
+    expect(res.body.error).toMatch(/never read/i);
+  });
+});

--- a/tests/integration/intent-routes.test.ts
+++ b/tests/integration/intent-routes.test.ts
@@ -158,15 +158,17 @@ describe('Intent Journal Routes (integration)', () => {
     });
 
     it('appends multiple entries without overwriting', async () => {
+      // `principle` is required — a decision recorded without naming what
+      // guided it is refused before it reaches the journal.
       await request(app)
         .post('/intent/journal')
-        .send({ sessionId: 's1', decision: 'First' });
+        .send({ sessionId: 's1', decision: 'First', principle: 'accuracy' });
       await request(app)
         .post('/intent/journal')
-        .send({ sessionId: 's2', decision: 'Second' });
+        .send({ sessionId: 's2', decision: 'Second', principle: 'accuracy' });
       await request(app)
         .post('/intent/journal')
-        .send({ sessionId: 's3', decision: 'Third' });
+        .send({ sessionId: 's3', decision: 'Third', principle: 'speed' });
 
       const journalFile = path.join(stateDir, 'decision-journal.jsonl');
       const lines = fs.readFileSync(journalFile, 'utf-8').trim().split('\n');
@@ -313,6 +315,10 @@ describe('Intent Journal Routes (integration)', () => {
         earliest: null,
         latest: null,
         topPrinciples: [],
+        // Zero on BOTH counters is what makes an empty journal distinguishable
+        // from a populated-but-unprincipled one (unprincipledCount > 0).
+        principledCount: 0,
+        unprincipledCount: 0,
         conflictCount: 0,
       });
     });

--- a/tests/unit/DecisionJournal.test.ts
+++ b/tests/unit/DecisionJournal.test.ts
@@ -286,6 +286,12 @@ describe('DecisionJournal', () => {
         earliest: null,
         latest: null,
         topPrinciples: [],
+        // An empty journal must report zero on BOTH counters, so that a
+        // populated-but-unprincipled journal (unprincipledCount > 0) is
+        // distinguishable from this one. See
+        // tests/unit/decision-journal-principle-honesty.test.ts.
+        principledCount: 0,
+        unprincipledCount: 0,
         conflictCount: 0,
       });
     });

--- a/tests/unit/decision-journal-principle-honesty.test.ts
+++ b/tests/unit/decision-journal-principle-honesty.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DecisionJournal,
+  validateDecisionSubmission,
+  DECISION_JOURNAL_WRITABLE_FIELDS,
+} from '../../src/core/DecisionJournal.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+/**
+ * The incident these tests encode:
+ *
+ * An agent POSTed a decision with `reasoning` and `checkedAgainst`, believed it
+ * had recorded what the decision was checked against, and had not — neither key
+ * is read by anything. The write succeeded (201). Separately, five entries sat
+ * in the journal with `principle` unset, and `stats()` reported
+ * `topPrinciples: []` — byte-identical to a journal with no entries at all.
+ *
+ * So the journal could not distinguish "nobody has decided anything yet" from
+ * "five decisions were recorded and not one said why". That is absence
+ * rendering as presence, on the surface built to detect exactly that.
+ */
+
+const SESSION = 'sess-decision-honesty';
+
+function evidence() {
+  return [
+    {
+      kind: 'session' as const,
+      sourceId: `session:${SESSION}`,
+      weight: 0.5,
+      confidence: 0.5,
+      privacyTier: 'private' as const,
+      updatedAt: new Date().toISOString(),
+    },
+  ];
+}
+
+describe('validateDecisionSubmission — refuses before recording', () => {
+  it('REGRESSION: a decision naming no guiding principle is REFUSED', () => {
+    const v = validateDecisionSubmission({
+      sessionId: SESSION,
+      decision: 'Split the spec rather than retry convergence',
+    });
+
+    expect(v.ok).toBe(false);
+    expect(v.reason).toBe('missing-required');
+    expect(v.missingFields).toContain('principle');
+    expect(v.message).toMatch(/principle or intent that guided it/i);
+  });
+
+  it('REGRESSION: a field no reader consumes is REFUSED, not swallowed', () => {
+    // The exact submission from the incident.
+    const v = validateDecisionSubmission({
+      sessionId: SESSION,
+      decision: 'Prune the run file at item-closure',
+      principle: 'Structure > Willpower',
+      reasoning: 'effort-based pruning measurably lost ground',
+      checkedAgainst: 'northstar; tier-1 topic goal',
+    });
+
+    expect(v.ok).toBe(false);
+    expect(v.reason).toBe('unknown-fields');
+    expect(v.unknownFields).toEqual(['checkedAgainst', 'reasoning']);
+    // The refusal must tell the caller where the content actually belongs,
+    // otherwise it just moves the failure rather than fixing it.
+    expect(v.message).toMatch(/context/);
+    expect(v.message).toMatch(/principle/);
+  });
+
+  it('accepts a complete submission', () => {
+    const v = validateDecisionSubmission({
+      sessionId: SESSION,
+      decision: 'Prune the run file at item-closure',
+      principle: 'Structure > Willpower',
+      context: 'effort-based pruning lost ground five times; closure-triggered worked twice',
+      tags: ['workspace'],
+    });
+
+    expect(v.ok).toBe(true);
+    expect(v.reason).toBeNull();
+    expect(v.unknownFields).toEqual([]);
+    expect(v.missingFields).toEqual([]);
+  });
+
+  it('a blank or whitespace principle does not satisfy the requirement', () => {
+    for (const principle of ['', '   ']) {
+      const v = validateDecisionSubmission({
+        sessionId: SESSION,
+        decision: 'something',
+        principle,
+      });
+      expect(v.ok).toBe(false);
+      expect(v.missingFields).toContain('principle');
+    }
+  });
+
+  it('missing-required outranks unknown-fields, and still reports both', () => {
+    const v = validateDecisionSubmission({
+      sessionId: SESSION,
+      decision: 'something',
+      bogus: 1,
+    });
+    expect(v.reason).toBe('missing-required');
+    expect(v.missingFields).toContain('principle');
+    // The caller learns about BOTH problems in one round trip rather than
+    // fixing one, resubmitting, and discovering the other.
+    expect(v.unknownFields).toEqual(['bogus']);
+  });
+
+  it('is total — null, undefined and non-objects refuse rather than throw', () => {
+    for (const input of [null, undefined, 'string' as unknown as null, 42 as unknown as null]) {
+      const v = validateDecisionSubmission(input as never);
+      expect(v.ok).toBe(false);
+      expect(v.reason).toBe('missing-required');
+    }
+  });
+
+  it('every writable field is accepted (the allowlist is not stricter than the type)', () => {
+    const full: Record<string, unknown> = {
+      sessionId: SESSION,
+      decision: 'd',
+      principle: 'p',
+      topicId: 29723,
+      jobSlug: 'job',
+      alternatives: ['a'],
+      confidence: 0.9,
+      context: 'c',
+      conflict: false,
+      tags: ['t'],
+      evidence: evidence(),
+    };
+    // Guards against the allowlist drifting away from the documented field set.
+    expect(Object.keys(full).sort()).toEqual([...DECISION_JOURNAL_WRITABLE_FIELDS].sort());
+    expect(validateDecisionSubmission(full).ok).toBe(true);
+  });
+});
+
+describe('stats() — an unprincipled journal cannot look like an empty one', () => {
+  let dir: string;
+  let journal: DecisionJournal;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'decision-journal-'));
+    journal = new DecisionJournal(dir);
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(dir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/decision-journal-principle-honesty.test.ts:cleanup',
+    });
+  });
+
+  it('REGRESSION: entries with no principle are COUNTED, not silently absent', () => {
+    journal.log({ sessionId: SESSION, decision: 'one' }, evidence());
+    journal.log({ sessionId: SESSION, decision: 'two' }, evidence());
+
+    const s = journal.stats();
+
+    expect(s.count).toBe(2);
+    expect(s.topPrinciples).toEqual([]); // unchanged, still honest
+    // The load-bearing assertion: this is what distinguishes the two journals.
+    expect(s.unprincipledCount).toBe(2);
+    expect(s.principledCount).toBe(0);
+  });
+
+  it('REGRESSION: an empty journal is DISTINGUISHABLE from an unprincipled one', () => {
+    const empty = journal.stats();
+    expect(empty.count).toBe(0);
+    expect(empty.unprincipledCount).toBe(0);
+
+    journal.log({ sessionId: SESSION, decision: 'one' }, evidence());
+    const populated = journal.stats();
+
+    // Before this change both objects agreed on every principle-related field.
+    expect(populated.unprincipledCount).not.toBe(empty.unprincipledCount);
+  });
+
+  it('counts principled and unprincipled entries separately in a mixed journal', () => {
+    journal.log({ sessionId: SESSION, decision: 'a', principle: 'Structure > Willpower' }, evidence());
+    journal.log({ sessionId: SESSION, decision: 'b', principle: 'Structure > Willpower' }, evidence());
+    journal.log({ sessionId: SESSION, decision: 'c', principle: 'Close the Loop' }, evidence());
+    journal.log({ sessionId: SESSION, decision: 'd' }, evidence());
+
+    const s = journal.stats();
+
+    expect(s.count).toBe(4);
+    expect(s.principledCount).toBe(3);
+    expect(s.unprincipledCount).toBe(1);
+    expect(s.principledCount + s.unprincipledCount).toBe(s.count);
+    expect(s.topPrinciples[0]).toEqual({ principle: 'Structure > Willpower', count: 2 });
+  });
+
+  it('the machine-generated path is NOT blocked — log() still accepts no principle', () => {
+    // DispatchDecisionJournal writes auto-applied dispatch decisions that have
+    // no principle to cite. The refusal is scoped to the agent-authored HTTP
+    // path; blocking here would break automatic dispatch.
+    expect(() =>
+      journal.log({ sessionId: SESSION, decision: 'auto-applied' }, evidence()),
+    ).not.toThrow();
+    expect(journal.stats().count).toBe(1);
+  });
+});

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -130,6 +130,7 @@ describe('Feature Delivery Completeness', () => {
       'Registry First — capability registry:',
       // channel-registry: which peer channels work right now (templates.ts + migrator parity).
       'Registry First — channel registry:',
+      'Decision journal — principle is required:',
       'Publishing',
       'Private Viewing',
       'Secret Drop',

--- a/upgrades/next/decision-journal-principle-required.md
+++ b/upgrades/next/decision-journal-principle-required.md
@@ -1,0 +1,60 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+`POST /intent/journal` now refuses two kinds of submission instead of accepting them silently: one
+that names no guiding `principle`, and one carrying field names no reader consumes. The route
+previously spread the request body straight through with no validation, so an invented key was
+persisted where nothing would ever read it and the write returned 201.
+
+`GET /intent/journal/stats` gains `principledCount` and `unprincipledCount`. Previously
+`topPrinciples: []` was byte-identical between an empty journal and a populated one where nobody had
+filled `principle` — so the surface built to detect unreasoned decisions could not distinguish its
+own worst case from a clean slate.
+
+The machine-generated dispatch path (`DispatchDecisionJournal` → `AutoDispatcher`) is deliberately
+exempt: an auto-applied dispatch has no principle to cite, and gating it would break automatic
+dispatch to buy nothing.
+
+## What to Tell Your User
+
+If you keep a decision log, it now refuses to record a decision that does not say what guided it,
+and tells you so instead of accepting it quietly. It also refuses field names it does not recognise,
+listing them back and pointing at where the content actually belongs.
+
+That second refusal is the one that matters, and it comes from a real mistake. An agent recorded
+several decisions using field names it had invented, believed the reasoning was saved, and reported
+as much. The values were stored somewhere nothing reads. The write succeeded, so nothing could have
+caught it. Now that submission fails immediately and says which fields are wrong.
+
+Be honest about the boundary: this makes it impossible to record a decision that claims no guiding
+intent. It does not make anyone actually weigh a choice against your stated goals before deciding.
+Any non-empty answer clears the gate. It closes the gap between deciding and recording, not the gap
+between deciding and thinking.
+
+If you already have entries with no principle, they are left alone rather than rewritten. The two new
+counters will report them for what they are.
+
+## Summary of New Capabilities
+
+No new endpoint. An existing write path gained a refusal, and an existing read surface gained two
+counters that separate "nothing decided yet" from "many decisions, none said why".
+
+## Evidence
+
+- Unwiring the validator from the route leaves the unit suite fully green (11/11) while four
+  integration tests fail — the module-guarded-but-unwired class, reproduced deliberately.
+- Swallowing unknown fields: 5 failed | 12 passed. Dropping the principle requirement: 5 failed |
+  12 passed. Reverting the counters: 4 failed | 13 passed.
+- Restored: 188 passed across the five affected files; `tsc --noEmit` exit 0.
+- A refused submission writes nothing — asserted against a live journal reporting `count: 0`.
+
+## Known limits
+
+The requirement is satisfied by any non-empty string; nothing distinguishes a genuinely-consulted
+principle from a plausible one typed to clear the gate. Nothing here fires at the moment of decision
+to put the goal hierarchy in front of the agent — that trigger is separate work and is not included.
+Existing unprincipled rows are not repaired. The journal is per-machine, so the counters answer "on
+this machine". <!-- tracked: CMT-1044 -->

--- a/upgrades/side-effects/decision-journal-principle-required.md
+++ b/upgrades/side-effects/decision-journal-principle-required.md
@@ -1,0 +1,212 @@
+# Side-Effects Review — a decision log that refuses a decision which does not say why
+
+**Version / slug:** `decision-journal-principle-required`
+**Date:** `2026-07-26`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `see Phase 5`
+
+## Summary of the change
+
+Operator directive (topic 29723, 20:4xZ): decide against the goal hierarchy instead of escalating,
+log the reasoning for later review, and **enforce it via infrastructure rather than by remembering**.
+
+Investigating what to build produced the finding that the machinery already exists — hierarchy
+(`GET /intent/org`, `/intent/tradeoff-resolve`), recorder (`DecisionJournal`, `POST /intent/journal`),
+and drift detector (`IntentDriftDetector`) — and had recorded **zero decisions, ever**. What is
+missing is not machinery; it is anything that forces its use or reveals its disuse.
+
+Then, using it, I produced the defect this PR fixes:
+
+- I POSTed `reasoning` and `checkedAgainst`. **Neither is a field.** The route spread `...rest`
+  straight through with no validation, so both were persisted where no reader consumes them. The
+  write returned 201. I then told my operator the reasoning was recorded — believing it.
+- `principle`, the typed field documented as *"Which AGENT.md principle or intent guided the choice"*,
+  was empty on all five entries.
+- `stats()` therefore reported `topPrinciples: []` — **byte-identical to an empty journal.** The
+  instrument built to detect unreasoned decisions could not distinguish its own worst case from a
+  clean slate.
+
+Adds `validateDecisionSubmission()` (pure) + `principledCount`/`unprincipledCount` on
+`DecisionJournalStats`, wires the validator into `POST /intent/journal`, and registers the behaviour
+change for new and existing agents.
+
+## Refusal evidence (constraint 2)
+
+```
+REFUSAL 1 — unwire the validator from the ROUTE (`if (false && !verdict.ok)`)
+  UNIT:        Tests  11 passed (11)      <-- the blindness, reproduced deliberately
+  INTEGRATION: × the ROUTE refuses a decision that names no principle
+               × the ROUTE refuses fields no reader consumes
+               × a refused submission writes NOTHING
+               × the refusal message tells the caller where the content belongs
+               Tests  4 failed | 2 passed (6)
+
+REFUSAL 2 — swallow unknown fields instead of refusing
+  × a field no reader consumes is REFUSED, not swallowed
+  × missing-required outranks unknown-fields, and still reports both
+  × (+3 integration)                       Tests  5 failed | 12 passed (17)
+
+REFUSAL 3 — drop `principle` from the required set
+  × a decision naming no guiding principle is REFUSED
+  × a blank or whitespace principle does not satisfy the requirement
+  × (+3)                                   Tests  5 failed | 12 passed (17)
+
+REFUSAL 4 — revert stats to the ambiguous shape
+  × entries with no principle are COUNTED, not silently absent   → expected +0 to be 2
+  × an empty journal is DISTINGUISHABLE from an unprincipled one → expected +0 not to be +0
+  × (+2)                                   Tests  4 failed | 13 passed (17)
+```
+
+Restored: **188 passed (188)** across the five affected files, `tsc --noEmit` exit 0.
+
+**REFUSAL 1 is the finding, and it is the second occurrence tonight of the same class.** One feature
+earlier (#1658) I emptied a route's registry and all 19 unit tests passed — module guarded, wiring
+not. So here I went looking for it deliberately: unwiring the validator leaves **11/11 unit tests
+green** while the route accepts everything it is supposed to refuse. The integration file exists for
+exactly this assertion and nothing else.
+
+## Decision-point inventory
+
+| point | classification | note |
+|---|---|---|
+| missing required field → refuse | `invariant` | Deterministic key/type check. No model call. |
+| unknown field → refuse | `invariant` | Allowlist comparison; allowlist asserted against the documented field set by test. |
+| missing-required outranks unknown-fields | `invariant` | Both are still reported, so one round trip surfaces both problems. |
+| machine dispatch path exempt | `invariant` | Scoped by callsite, not by inspecting content. |
+
+No judgment points. No LLM. Nothing is inferred about the *quality* of a cited principle — only that
+one was cited. Judging whether a decision genuinely followed the principle it names is the drift
+detector's job and is deliberately not attempted here.
+
+## 1. Over-block
+
+**This is the section that shaped the design.** A blanket requirement would have been wrong.
+
+`journal.log()` has two callers: the HTTP route (agent-authored) and `DispatchDecisionJournal
+.logDispatchDecision` via `AutoDispatcher`, which writes auto-applied dispatch decisions whose own
+documented shape is `{ dispatchDecision: 'accept', reasoning: 'auto-applied' }`. Those have no
+principle to cite. **Enforcing inside `log()` would have broken automatic dispatch to buy nothing**,
+so the refusal lives at the route and `log()` is untouched — asserted by a test that the module path
+still accepts an entry with no principle.
+
+Residual over-block risk on the agent path: a caller with a legitimate decision and genuinely no
+guiding principle now gets a 400. I accept this deliberately — under the operator directive, a
+decision made during operations without checking the stated goals is precisely what we are
+eliminating. The failure is loud, names the missing field, and is fixed by adding one string.
+
+Unknown-field rejection is a strict-schema change and could in principle break an existing caller.
+Measured evidence that it does not: **the journal had `count: 0` on this agent — no caller has ever
+successfully written to it.** The refusal also names the offending keys and the correct destination,
+so a broken caller is told exactly what to change rather than failing opaquely.
+
+## 2. Under-block
+
+**It does not force the check, only the citation.** Nothing here fires at the moment a decision is
+made and puts the hierarchy in front of the agent. An agent can still decide without consulting
+`GET /intent/org` and then name a principle after the fact. This PR makes it impossible to *record*
+a decision that claims no guiding intent; it does not make it impossible to *make* one. The
+consult-side trigger is genuinely separate work and is not bundled. <!-- tracked: CMT-1044 -->
+
+**It does not judge the principle.** Any non-empty string satisfies the requirement. A caller citing
+"because I felt like it" passes. Judging alignment is `IntentDriftDetector`'s job.
+
+**The five existing entries are not repaired.** They keep their unread `reasoning`/`checkedAgainst`
+keys. The new counters will report them as unprincipled, which is accurate. Rewriting my own history
+to look better than it was is the opposite of this tier's purpose.
+
+**`GET /intent/journal` (read) is unchanged** and will still return the legacy rows with their
+unread fields. Nothing marks those fields as unread on read.
+
+## 3. Level-of-abstraction fit
+
+The validator is pure — no `fs`, no clock, no config, no server import — so the refusal is unit
+testable without a server, and the route owns transport only. This mirrors the structure used one
+feature earlier and, more importantly, is what made REFUSAL 1 possible to demonstrate: a pure
+validator can be perfect while nothing calls it, which is precisely the failure mode being guarded.
+
+The counters live on `stats()` rather than in a new surface, because the ambiguity being fixed is a
+property of that existing return value. A new endpoint would have left the misleading one in place.
+
+## 4. Signal vs authority compliance
+
+This **is** an authority — it blocks a write — so `docs/signal-vs-authority.md` applies directly
+rather than trivially. It qualifies because the logic is deterministic and total: an allowlist
+comparison and a set of required-key checks, no heuristics, no model, no inference about content.
+That is the category the principle permits to hold blocking authority. Every uncertain input
+(`null`, `undefined`, a string, a number) resolves to a refusal with a named reason rather than a
+throw or a pass — asserted by test.
+
+The blocked path writes nothing: a refused submission leaves `count: 0`, asserted by integration
+test. A refusal that still recorded the row would be worse than no refusal, because the journal
+would carry entries the caller was told were rejected.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+None introduced. Every branch is a deterministic key or type comparison.
+
+## 5. Interactions
+
+- **`DispatchDecisionJournal` / `AutoDispatcher`** — deliberately NOT gated (see §1). Asserted.
+- **`IntentDriftDetector`** — reads the journal; gains higher-quality input (entries now carry
+  `principle`) and is otherwise untouched. Its 16 tests pass unchanged.
+- **`instar intent reflect` / `commands/intent.ts`** — calls `journal.log()` directly, module path,
+  unaffected by the route gate.
+- **`tests/unit/DecisionJournal.test.ts`** — one test pinned the exact empty-`stats()` object shape
+  and now asserts the two new counters. This is a shape assertion updated to a new shape, not a
+  behavioural assertion weakened; the comment records why the zero values matter.
+- **`CapabilityIndex`** — no change needed. `intent` is already classified under
+  `INTERNAL_PREFIXES` ("surfaced inside `evolution` subsystems"); this adds no new route prefix.
+
+## 6. External surfaces
+
+`POST /intent/journal` changes response behaviour: submissions that previously returned 201 may now
+return 400 with `{ error, reason, unknownFields, missingFields }`. `GET /intent/journal/stats` gains
+two fields (additive). No config key, no new route, no persisted-state migration, no message to any
+user. No credentials or content beyond what the caller submitted appear in any response.
+
+## 6b. Operator-surface quality
+
+The refusal message names the offending fields AND the correct destination (`context` for reasoning,
+`principle` for guiding intent) plus the full writable-field list. A refusal that only says "invalid"
+relocates the failure rather than fixing it; asserted by a test that the message mentions `context`.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** The journal is a per-machine JSONL under `stateDir`; the validator is
+pure and stateless, so the refusal is identical on every machine with no coordination required.
+There is no replication, no lease interaction, no generated URL, and no cross-machine read. Honest
+limitation: an agent running on two machines keeps two separate decision journals, so
+`principledCount` answers "on this machine". That predates this change and is not addressed here.
+<!-- tracked: CMT-1044 -->
+
+## 8. Rollback cost
+
+Low. One pure function, two counters, one route guard, plus doc/migration lines. No persisted-state
+change and no data migration — existing rows are read unchanged. Reverting restores the permissive
+route; already-written entries remain valid under both versions.
+
+## Phase 5 — Second-pass review
+
+This change **does** hold block/allow authority on a write path, so the high-risk trigger list is
+engaged. It does not touch session lifecycle, messaging, dispatch, trust levels, or recovery. Author
+lenses, disclosed:
+
+**Adversarial — "how would I make this useless?"** Three ways, all closed and asserted: let the
+route skip the validator (REFUSAL 1 — the real one); accept unknown keys silently (REFUSAL 2); drop
+the principle requirement (REFUSAL 3). A fourth — refuse but write the row anyway — is closed by the
+`a refused submission writes NOTHING` test.
+
+**"Would it have caught the incident?"** Yes, on the first attempt, which is the strongest thing I
+can say for it. My literal opening submission is now a test fixture and returns 400 naming
+`checkedAgainst` and `reasoning`. I would have lost seconds instead of finding out by reading my own
+file afterwards and having already told my operator otherwise.
+
+**"Symptom or cause?"** Partly cause, and I want this stated plainly rather than implied: it makes
+an unreasoned decision unrecordable, which is a real structural gate. It does not make an unreasoned
+decision unmakeable. The operator asked for decisions checked against the hierarchy; this delivers
+the enforcement half of "log the reasoning" and none of the consult half.
+
+**Weakest point:** the requirement is satisfiable by any non-empty string. Nothing distinguishes a
+genuinely-consulted principle from a plausible-sounding one typed to clear the gate — and the agent
+clearing it is the same one whose unreliability motivated the gate. That limit is inherent to a
+deterministic check and is the reason the consult-side trigger is not optional future work.

--- a/upgrades/side-effects/decision-journal-principle-required.md
+++ b/upgrades/side-effects/decision-journal-principle-required.md
@@ -95,9 +95,24 @@ decision made during operations without checking the stated goals is precisely w
 eliminating. The failure is loud, names the missing field, and is fixed by adding one string.
 
 Unknown-field rejection is a strict-schema change and could in principle break an existing caller.
-Measured evidence that it does not: **the journal had `count: 0` on this agent — no caller has ever
-successfully written to it.** The refusal also names the offending keys and the correct destination,
-so a broken caller is told exactly what to change rather than failing opaquely.
+The refusal names the offending keys and the correct destination, so a broken caller is told exactly
+what to change rather than failing opaquely.
+
+**CORRECTION — my first version of this section was too confident, and CI proved it.** I wrote that
+"the journal had `count: 0` on this agent, so no caller has ever successfully written to it" and
+treated that as evidence the back-compat risk was near-nil. That measurement was about the *live
+agent's data file*; it says nothing about *callers in the codebase*. There was one:
+`tests/integration/intent-routes.test.ts` POSTed three decisions with no `principle`, and my change
+refused all three, so the journal file was never created and a later read failed `ENOENT`.
+
+I did not catch it locally because I ran a targeted file set that did not include that test. CI did.
+Two failures, both mine, neither a flake. Resolution: the tests now supply a `principle` — which is
+the *correct* fix, since they were writing exactly the unreasoned decisions this gate exists to
+refuse, and their failure is the refusal working on a real caller rather than a synthetic one.
+
+The honest generalisation: "no rows in the data file" is not evidence of "no callers in the code".
+Those are different questions and I conflated them. A repo-wide sweep afterwards found three files
+POSTing to the route and six asserting on `stats()` shape; two needed changes, and both are fixed.
 
 ## 2. Under-block
 


### PR DESCRIPTION
## ELI16 — I recorded five decisions using field names I invented, believed the reasoning was saved, and it was stored where nothing reads it; the log now refuses that.

Full plain-English overview: `docs/specs/decision-journal-principle-required.eli16.md`

## What was wrong

`POST /intent/journal` destructured `{ sessionId, decision, evidence, ...rest }` and passed `...rest`
straight to `journal.log()` with no validation. So a caller could submit any key at all, have it
persisted where no reader consumes it, and receive `201`.

That is not hypothetical — it is how this PR was found. Under an operator directive to decide against
our goal hierarchy and log the reasoning, I POSTed five decisions carrying `reasoning` and
`checkedAgainst`. Neither is a field. Both were written to `.instar/decision-journal.jsonl` and are
read by nothing: no statistic counts them, no drift detector consults them, no surface displays them.
I then reported to the operator that the reasoning was recorded. I believed it. The only reason I
found out is that I went and read my own file.

Meanwhile `principle` — the typed field documented as *"Which AGENT.md principle or intent guided the
choice"* — was empty on every row. `stats()` therefore returned `topPrinciples: []`, which is
**byte-identical to the output for an empty journal**. The surface built to detect unreasoned
decisions could not distinguish its own worst case from a clean slate.

## What this changes

- **`validateDecisionSubmission()`** — pure, total, no I/O or clock. Refuses a missing/blank
  `principle`, and refuses unknown fields *by name* while pointing at the correct destination
  (`context` for reasoning, `principle` for guiding intent). `missing-required` outranks
  `unknown-fields` but both are reported, so one round trip surfaces both problems.
- **`principledCount` / `unprincipledCount`** on `DecisionJournalStats` — the two numbers that
  separate "nothing decided yet" from "many decisions, none said why".
- **The machine dispatch path is deliberately exempt.** `DispatchDecisionJournal` →
  `AutoDispatcher` writes auto-applied decisions whose documented shape is
  `{ dispatchDecision: 'accept', reasoning: 'auto-applied' }` — no principle to cite. Enforcing
  inside `journal.log()` would have broken automatic dispatch to buy nothing, so the gate lives at
  the route and `log()` is untouched (asserted by test).

## Refusal evidence

```
REFUSAL 1 — unwire the validator from the ROUTE (`if (false && !verdict.ok)`)
  UNIT:        Tests  11 passed (11)   <-- the blindness, reproduced deliberately
  INTEGRATION: Tests  4 failed | 2 passed (6)

REFUSAL 2 — swallow unknown fields          Tests  5 failed | 12 passed (17)
REFUSAL 3 — drop the principle requirement  Tests  5 failed | 12 passed (17)
REFUSAL 4 — revert the stats counters       Tests  4 failed | 13 passed (17)
```

Restored: **188 passed** across the five affected files, `tsc --noEmit` exit 0.

**REFUSAL 1 is the finding, and it is the second occurrence of this class one feature apart.** In
#1658 I emptied a route's registry and all 19 unit tests passed. So here I went looking for it on
purpose: disabling the route's call to the validator leaves **11/11 unit tests green** while the
route accepts everything it is meant to refuse. `tests/integration/decision-journal-route.test.ts`
exists for that assertion and nothing else.

## UX Impact

**Who sees this:** any agent that writes to its own decision log, plus the operator reading its
stats. A submission that previously returned `201` may now return `400` with `{ error, reason,
unknownFields, missingFields }`, and the message names both the offending fields and where the
content belongs — a refusal that only said "invalid" would relocate the failure rather than fix it.

**What the user notices:** the CLAUDE.md template now documents the requirement and ships a worked
example, so agents learn the shape rather than discovering it via a 400. The template's example body
includes `"<why, and what you checked it against>"` for the `context` field, and
`"<what guided it>"` for `principle`. `GET /intent/journal/stats` gains two counters (additive).

**Migration parity:** `PostUpdateMigrator` carries the same section for existing agents, and the
marker is registered in `featureSections` + the framework shadow-capability markers so Codex/Gemini
agents learn it too — without that, such an agent takes a 400 it cannot explain and falls back to
recording decisions somewhere nothing reads, which is the exact failure this refusal prevents.
No new route prefix, so `CapabilityIndex` is unchanged (`intent` is already an internal prefix).

## Honest scope

**This makes an unreasoned decision unrecordable, not unmakeable.** Any non-empty string clears the
gate; nothing distinguishes a genuinely-consulted principle from a plausible one typed to satisfy the
check — and the agent clearing it is the same one whose unreliability motivated it. The trigger that
puts the goal hierarchy in front of the agent *at decision time* is separate work and is not bundled.
It closes the gap between deciding and recording, not between deciding and thinking.

The five existing rows are not repaired; they keep their unread keys and will be reported as
unprincipled, which is accurate. Rewriting my own history to look better is the opposite of the
point. The journal is per-machine, so the counters answer "on this machine".

## Tier

**Tier 1 declared under a risk-floor-2 signal** (`PostUpdateMigrator` touch → irreversibility +
fleet-rollout). Recorded `belowFloor: true` with reasoning, per the audited-override path. The
migrator change is one idempotent doc-line append adjacent to an identical existing pattern — the
same shape accepted in #1658. The validator holds blocking authority, which I am not minimising, but
it is the category `docs/signal-vs-authority.md` explicitly permits to block: fully deterministic,
every uncertain input (`null`, non-object, blank string) resolving to a named refusal rather than a
throw or a pass. Measured blast radius: the journal had `count: 0` on this agent — no caller has ever
successfully written to it.
