### PR TITLE
feat(synthesis): decide and create — close the recurrence loop

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T03-24-21-564Z-recurrence-actuator.json
+++ b/.instar/instar-dev-decisions/2026-07-27T03-24-21-564Z-recurrence-actuator.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T03:24:21.564Z",
+  "slug": "recurrence-actuator",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 172,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-27T03-29-40-587Z-recurrence-loop.json
+++ b/.instar/instar-dev-decisions/2026-07-27T03-29-40-587Z-recurrence-loop.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T03:29:40.587Z",
+  "slug": "recurrence-loop",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 126,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/recurrence-actuator.eli16.md
+++ b/docs/specs/recurrence-actuator.eli16.md
@@ -1,0 +1,46 @@
+# Turning "noticed 278 times" into actual work — Plain-English Overview
+
+> The one-line version: the reader made repeated problems visible. This turns the worst of them into
+> real, tracked work — a few at a time, through the queue we already use, without asking you.
+
+## Why a reader wasn't enough
+
+The recurrence reader found that 2,068 unresolved items are really about 836 problems, and that 69 of
+those had been noticed 1,242 times between them without a single one ever being picked up.
+
+That's a good report. But a good report nobody acts on is the original problem with better
+typography — we already notice things beautifully and close almost nothing.
+
+## What this does
+
+For a problem that genuinely keeps recurring **and** that nobody has ever committed to, it creates a
+normal work item in the queue we already use. That's the whole loop: noticed repeatedly → becomes
+real work → sits where work is tracked → gets done, or gets explicitly dismissed.
+
+Dismissing is a perfectly good outcome, and the work item says so. An explicit "no, we're fine with
+this" beats the same thing being noticed another two hundred times.
+
+## The two ways this could make things worse
+
+**Creating work when it can't see the existing work list.** If the action queue can't be read, then
+"has someone already committed to this?" is unanswerable — everything looks untracked. It would
+cheerfully create duplicates of work that already exists, which is the exact redundancy it's meant to
+remove. So if that particular list is unreadable, it proposes **nothing** and says why.
+
+Notably it does *not* do that for the other two lists. If those are unreadable it has simply seen
+fewer examples, so anything still clearing the bar genuinely clears it. Treating all three the same
+would have been tidy-looking and wrong.
+
+**Turning 69 problems into 69 new tickets.** That's a fresh backlog wearing a different hat. So there
+is a hard cap per run — three — taking the biggest first. It converges over sessions instead of
+flooding. Right now it would create three items and hold back seventeen.
+
+## What it does not do
+
+It doesn't notify anyone, doesn't close anything, doesn't decide what's important. It queues work for
+a person or agent to judge. Its priority comes from volume alone, by a fixed rule — no model, no
+opinion.
+
+And it won't create the same item twice: each problem maps to a stable key, so running it again
+updates rather than duplicates. A tool meant to cure repeated noticing must not itself become a
+source of repeated noticing.

--- a/docs/specs/recurrence-loop.eli16.md
+++ b/docs/specs/recurrence-loop.eli16.md
@@ -1,0 +1,42 @@
+# Actually closing the loop — Plain-English Overview
+
+> The one-line version: the two earlier pieces could see repeated problems and decide which deserve
+> real work, but neither of them touched anything. This is the piece that joins them up and does it.
+
+## Why this exists separately
+
+The reader groups what we notice. The decider picks which groups deserve a work item. Both were
+written as pure calculations — they take information in and hand an answer back, touching nothing.
+
+That's good for testing, but it left an honest gap I flagged at the time: "the loop closes" was a
+property of the design, not something anyone had watched happen. This is the piece that makes it
+happen, and it's the only part of the feature that touches anything at all — so there is exactly one
+place a read can fail, and it can't be quietly swallowed somewhere in the middle.
+
+## What it does
+
+Reads the three lists, groups them, decides, and creates the work items. On live data it looks at 836
+problems, creates three, and holds back seventeen for later runs.
+
+## The distinction it protects
+
+There are two very different reasons nothing gets created, and they must never look the same:
+
+**A refusal** — it decided not to act. It couldn't see the existing work list, so it can't tell what's
+already owned, and creating anything would risk duplicating work that exists.
+
+**A failed write** — it decided to act, tried, and the store rejected it. That's an outage.
+
+If a broken store were reported as a refusal, a real failure would read as sound judgement. That is
+precisely the disease this whole project is about — something absent presenting as something fine —
+and it would be committed on the very last line of the thing built to cure it. So they're separate
+fields, and a write failure is never called a refusal.
+
+One failed write also doesn't abandon the rest; the others still go through, and the failures are
+listed.
+
+## What it still doesn't do
+
+Nothing calls it automatically yet. Running it is currently deliberate. The work items it creates are
+ordinary queue entries that a person or agent picks up, dismisses, or does — it has no opinion beyond
+"this recurred a lot and nobody owned it".

--- a/site/src/content/docs/architecture/recurrence-synthesis.md
+++ b/site/src/content/docs/architecture/recurrence-synthesis.md
@@ -1,0 +1,95 @@
+---
+title: Recurrence Synthesis
+description: One reader across the three places your agent notices problems, and the actuator that turns a repeated noticing into tracked work.
+---
+
+Your agent notices problems in three separate places — the **attention queue**, the **evolution
+action queue**, and the **sentinel log**. Until now nothing read across them. Each individual
+noticing was minor and each was true; nobody ever saw that the same underlying problem had been
+raised two hundred times.
+
+The measured consequence: roughly **thirty things started for every one finished**. Recurrence
+synthesis exists to close that gap, and it is deliberately built in three pieces so that seeing,
+deciding, and acting can each be wrong in isolation rather than silently together.
+
+## What it found on real data
+
+The first run against live stores, 2026-07-27:
+
+| Measure | Value |
+| --- | --- |
+| Open observations across the three stores | 2,068 |
+| Distinct underlying problems | 836 |
+| Problems noticed repeatedly but never tracked | 69 |
+| Noticings those 69 account for | 1,242 |
+
+The three largest, never before seen grouped: idle-timeout detection (278), escalation-suppressed
+(238 — a watcher recording its decision not to tell anyone, 238 times), and the credential
+rebalancer (177, which alone is 48% of the attention queue).
+
+## The three pieces
+
+### RecurrenceReader — seeing
+
+`RecurrenceReader` groups open observations from all three stores into recurrence clusters. It is
+pure and read-only: no route, no config, no authority. Every report carries a `coverage` block
+naming each store it could **not** read.
+
+That coverage block is the point. If a store is unreadable, the reader publishes the clusters it
+could see and leaves `verdict` **absent** rather than reporting `no-recurrence`. *Nothing there* and
+*could not look* are different answers, and a synthesiser that conflated them would be able to
+commit the exact failure it exists to detect.
+
+Keying is title-based, with digits and hex normalized away so that "3 topics stranded" and "17
+topics stranded" count as one problem. The trade is real: the blunt key occasionally over-merges,
+so each cluster carries an `exemplar` and its `sources` for a reader to spot it. Semantic matching
+would mean a model and a judgment point, deliberately avoided here.
+
+### RecurrenceActuator — deciding
+
+A report nobody acts on is the same 30:1 ratio with better typography. `RecurrenceActuator` turns a
+finding into a proposal for **one tracked action** on the action queue that already exists — no new
+store, no new notification channel. Creating a tracked action queues work for a human or agent to
+judge; it does not close, prioritise, escalate, or act on anything.
+
+It is pure: it returns a *plan*, so the write path and its gating stay exactly where they already
+are.
+
+Two refusals, deliberately **not** symmetric:
+
+- **The action queue is unreadable → propose nothing.** Whether anyone has already committed to a
+  problem is unanswerable, so every cluster would look unowned and the actuator would manufacture
+  duplicates of work that already exists — the exact redundancy it was built to remove, under the
+  banner of fixing it.
+- **Attention or sentinel unreadable → proceed.** Those only *understate* counts, so a cluster that
+  still clears the threshold genuinely clears it.
+
+Treating all three identically would have looked tidier and been wrong.
+
+Bounds keep the fix from becoming its own pile: a recurrence threshold (default 10 — a thing seen
+twice is not yet a pattern worth a work item), a hard per-run cap (default 3) so it converges across
+sessions densest-first rather than turning 69 clusters into 69 items, and a stable `externalKey` so
+a re-run updates one row instead of adding another. Priority is derived from volume alone —
+deterministic, no model.
+
+### The loop — acting
+
+`runRecurrenceLoop` reads the three stores, plans, and writes through a caller-supplied
+action-creation function. It is deliberately the only place in the feature that performs I/O, so a
+read failure has exactly one place to be reported from and cannot be swallowed mid-pipeline.
+
+Its load-bearing distinction is at the very end: a **failed write** is recorded separately from a
+**refusal**. One is an outage; the other is a decision not to act. Reporting an outage as a refusal
+would let real breakage present as sound judgment — this system's own disease, committed on the last
+line of the thing built to cure it. One failed write does not abandon the remaining ones.
+
+An unreadable store is data, not an exception: the loop never throws for one, it names the gap in
+coverage and lets the actuator's refusal read it.
+
+## Honest limits
+
+**Nothing schedules it.** The loop *can* close unattended; nothing yet calls it, so today it closes
+when something invokes it. That is stated rather than implied.
+
+Priority from volume alone means a rare-but-serious problem ranks below a frequent-but-trivial one.
+And the actuator inherits the reader's title-only keying, over-merges included.

--- a/src/core/RecurrenceActuator.ts
+++ b/src/core/RecurrenceActuator.ts
@@ -1,0 +1,172 @@
+/**
+ * RecurrenceActuator — turns a recurrence finding into tracked work, once.
+ *
+ * `RecurrenceReader` makes recurrence VISIBLE. Visibility is not the goal: the
+ * project's whole diagnosis is that instar notices constantly and closes almost
+ * nothing (filing-to-completion ≈ 30:1). A reader that produces a beautiful
+ * report which nobody acts on would be the 30:1 ratio with better typography.
+ *
+ * Operator directive, 2026-07-26 20:08Z: *"the synthesis itself must lead to
+ * ACTION and a fully closed loop"*, with as little user dependence as possible.
+ *
+ * So this proposes ONE thing, through a path that already exists: for a cluster
+ * that genuinely recurs and that nobody has ever turned into work, create a
+ * tracked action on the EXISTING evolution action queue. That closes the loop —
+ * noticed repeatedly → becomes real work → appears where work is tracked → gets
+ * done or explicitly cancelled.
+ *
+ * WHAT THIS IS NOT:
+ *  - Not a new notification channel. The single funniest way to fail at fixing
+ *    "we notice things and never close them" is to build a fourth place that
+ *    notices things. Nothing here notifies anybody.
+ *  - Not authority. Creating a tracked action QUEUES work for a human or agent to
+ *    judge. It does not close, prioritise, escalate, or act on anything.
+ *  - Not a bulk importer. See "the fix must not become its own pile" below.
+ */
+
+import type { RecurrenceCluster, RecurrenceReport } from './RecurrenceReader.js';
+
+/** A proposed piece of tracked work. The caller performs the actual write. */
+export interface ProposedAction {
+  title: string;
+  description: string;
+  priority: 'critical' | 'high' | 'medium' | 'low';
+  /**
+   * Stable key derived from the cluster, so a re-run UPDATES rather than
+   * duplicates. Without this the actuator would itself become a generator of
+   * repeated noticings — the precise disease it treats.
+   */
+  externalKey: string;
+  /** The cluster this came from, for the caller's audit trail. */
+  sourceKey: string;
+  observedCount: number;
+}
+
+export type ActuationRefusal =
+  | { reason: 'actions-store-unreadable'; detail: string }
+  | { reason: 'no-qualifying-clusters'; detail: string };
+
+export interface ActuationPlan {
+  /** Empty when `refused` is set. */
+  propose: ProposedAction[];
+  /** Set when the actuator declined to act at all, with why. */
+  refused?: ActuationRefusal;
+  /** Clusters that qualified but were held back by the per-run cap. */
+  deferredByCap: number;
+  /** Always present, so a caller can report honestly even on a refusal. */
+  consideredClusters: number;
+}
+
+export interface ActuationOptions {
+  /**
+   * A thing seen twice is not yet a pattern worth spending a work item on.
+   * Default 10: high enough that a proposal is obviously justified by volume.
+   */
+  minCount?: number;
+  /**
+   * Hard cap per run. 69 qualifying clusters turned into 69 action items would
+   * be a new backlog wearing a different hat — the fix becoming its own pile.
+   * A small cap converges across sessions instead, densest-first.
+   */
+  maxPerRun?: number;
+}
+
+/**
+ * Decide what work to propose from a recurrence report.
+ *
+ * Pure: it returns a PLAN. The caller writes it, so the write path (and its
+ * gating) stays exactly where it already is.
+ */
+export function planActuation(
+  report: RecurrenceReport,
+  opts: ActuationOptions = {},
+): ActuationPlan {
+  const minCount = opts.minCount ?? 10;
+  const maxPerRun = opts.maxPerRun ?? 3;
+
+  // THE REFUSAL, and it is sharper than the reader's.
+  //
+  // The reader withholds a VERDICT on any partial read. The actuator must
+  // withhold the ACTION — but only one missing store actually invalidates the
+  // decision, and conflating them would be lazy symmetry:
+  //
+  //   attention/sentinel unreadable → the reader saw FEWER observations. Counts
+  //     are understated, so a cluster that qualifies still genuinely qualifies.
+  //     Acting is conservative and safe.
+  //
+  //   ACTIONS unreadable → `tracked` is UNKNOWABLE for every cluster, because
+  //     `tracked` means "a member came from the action queue". Every cluster
+  //     would look untracked. Acting would duplicate work that may already
+  //     exist — the actuator would manufacture the exact redundancy it exists to
+  //     remove, and do it under the banner of fixing it.
+  //
+  // So: actions-store unreadable ⇒ propose NOTHING, and say why.
+  const actionsUnreadable = report.coverage.unreadable.find((u) => u.store === 'actions');
+  if (actionsUnreadable) {
+    return {
+      propose: [],
+      refused: {
+        reason: 'actions-store-unreadable',
+        detail:
+          `the action queue could not be read (${actionsUnreadable.reason}), so "has anyone already ` +
+          'committed to this?" is unanswerable for every cluster. Proposing work now would duplicate ' +
+          'whatever is already tracked. No actions proposed.',
+      },
+      deferredByCap: 0,
+      consideredClusters: report.clusters.length,
+    };
+  }
+
+  const qualifying = report.clusters.filter((c) => !c.tracked && c.count >= minCount);
+
+  if (qualifying.length === 0) {
+    return {
+      propose: [],
+      refused: {
+        reason: 'no-qualifying-clusters',
+        detail: `no untracked cluster reached the minCount=${minCount} threshold`,
+      },
+      deferredByCap: 0,
+      consideredClusters: report.clusters.length,
+    };
+  }
+
+  const selected = qualifying.slice(0, maxPerRun);
+  return {
+    propose: selected.map(toProposedAction),
+    deferredByCap: qualifying.length - selected.length,
+    consideredClusters: report.clusters.length,
+  };
+}
+
+/** Priority from volume alone — deterministic, no model, no judgment. */
+function priorityFor(count: number): ProposedAction['priority'] {
+  if (count >= 100) return 'high';
+  if (count >= 25) return 'medium';
+  return 'low';
+}
+
+function toProposedAction(c: RecurrenceCluster): ProposedAction {
+  const span = c.firstSeen && c.lastSeen && c.firstSeen !== c.lastSeen
+    ? ` between ${c.firstSeen} and ${c.lastSeen}`
+    : '';
+  return {
+    title: `Recurring, untracked: ${c.exemplar.slice(0, 90)}`,
+    description:
+      `Noticed ${c.count} times${span} across ${c.stores.join(', ')}` +
+      (c.sources.length ? ` (sources: ${c.sources.slice(0, 5).join(', ')})` : '') +
+      `, and never turned into tracked work.\n\n` +
+      'Surfaced by RecurrenceReader, which groups observations across the attention queue, the ' +
+      'action queue and the sentinel log. The individual noticings are each minor and each true; ' +
+      'the VOLUME is the finding.\n\n' +
+      'This action exists so the recurrence is either fixed or deliberately dismissed, rather than ' +
+      'noticed a further N times. Cancelling it IS a valid outcome — an explicit decision beats ' +
+      'silent accumulation.',
+    priority: priorityFor(c.count),
+    // Stable across runs: the same cluster always maps to the same key, so a
+    // second pass updates one row instead of adding another.
+    externalKey: `recurrence:${c.key}`,
+    sourceKey: c.key,
+    observedCount: c.count,
+  };
+}

--- a/src/core/recurrenceLoop.ts
+++ b/src/core/recurrenceLoop.ts
@@ -1,0 +1,126 @@
+/**
+ * recurrenceLoop — the caller that makes the loop actually close.
+ *
+ * `RecurrenceReader` sees. `RecurrenceActuator` decides. Neither touches a store,
+ * which is what keeps both pure and testable — but it also meant "the loop
+ * closes" was a DESIGNED property and not a demonstrated one. This is the piece
+ * that demonstrates it: it reads the three stores, plans, and writes the result
+ * through the caller-supplied action-creation function.
+ *
+ * It is deliberately the ONLY place in this feature that performs I/O, so every
+ * read failure has exactly one place to be reported from and cannot be swallowed
+ * somewhere in the middle.
+ *
+ * Operator directive 2026-07-26 20:08Z: synthesis must lead to ACTION, through
+ * paths that already exist, with the loop closed and minimal user dependence.
+ */
+
+import {
+  buildRecurrenceReport,
+  type Coverage,
+  type Observation,
+  type RecurrenceReport,
+} from './RecurrenceReader.js';
+import { planActuation, type ActuationOptions, type ProposedAction } from './RecurrenceActuator.js';
+
+/** Reads one store. Returning a rejected promise is how it reports "unreadable". */
+export type StoreReader = () => Promise<Observation[]>;
+
+export interface LoopDeps {
+  readAttention: StoreReader;
+  readActions: StoreReader;
+  readSentinel: StoreReader;
+  /**
+   * Creates ONE tracked action. The caller supplies this so the write goes
+   * through whatever path it already uses, with whatever gating that path
+   * already has. This module never constructs an HTTP call itself.
+   */
+  createAction: (a: ProposedAction) => Promise<{ id: string }>;
+}
+
+export interface LoopResult {
+  report: RecurrenceReport;
+  /** Actions actually created, with the ids the store returned. */
+  created: { id: string; title: string; observedCount: number }[];
+  /** Set when the actuator declined; `created` is then empty. */
+  refused?: { reason: string; detail: string };
+  /** Qualifying clusters held back by the per-run cap. */
+  deferredByCap: number;
+  /**
+   * Proposals whose WRITE failed. Distinct from `refused` (a decision not to
+   * act) — this is a decision to act that did not land, and conflating the two
+   * would hide real breakage behind a principled-looking refusal.
+   */
+  writeFailures: { title: string; error: string }[];
+}
+
+/** Read a store, converting failure into a named coverage gap rather than a throw. */
+async function readOrRecord(
+  store: Observation['store'],
+  read: StoreReader,
+  into: Observation[],
+  coverage: Coverage,
+): Promise<void> {
+  try {
+    into.push(...(await read()));
+    coverage.read.push(store);
+  } catch (err) {
+    coverage.unreadable.push({
+      store,
+      reason: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
+    });
+  }
+}
+
+/**
+ * Run one pass: read → group → plan → create.
+ *
+ * Never throws for an unreadable store — that is data, reported in
+ * `report.coverage`, and it is what the actuator's refusal reads.
+ */
+export async function runRecurrenceLoop(
+  deps: LoopDeps,
+  opts: ActuationOptions = {},
+): Promise<LoopResult> {
+  const observations: Observation[] = [];
+  const coverage: Coverage = { read: [], unreadable: [], completeness: 'complete' };
+
+  await readOrRecord('attention', deps.readAttention, observations, coverage);
+  await readOrRecord('actions', deps.readActions, observations, coverage);
+  await readOrRecord('sentinel', deps.readSentinel, observations, coverage);
+  coverage.completeness = coverage.unreadable.length === 0 ? 'complete' : 'partial';
+
+  const report = buildRecurrenceReport(observations, coverage);
+  const plan = planActuation(report, opts);
+
+  if (plan.refused) {
+    return {
+      report,
+      created: [],
+      refused: plan.refused,
+      deferredByCap: plan.deferredByCap,
+      writeFailures: [],
+    };
+  }
+
+  const created: LoopResult['created'] = [];
+  const writeFailures: LoopResult['writeFailures'] = [];
+
+  for (const proposal of plan.propose) {
+    try {
+      const { id } = await deps.createAction(proposal);
+      created.push({ id, title: proposal.title, observedCount: proposal.observedCount });
+    } catch (err) {
+      // A failed write is NOT a refusal. Recording it separately keeps a real
+      // outage from reading as a principled decision not to act — which would be
+      // this project's own failure mode (absence presenting as presence) at the
+      // very end of the loop it exists to close.
+      writeFailures.push({
+        title: proposal.title,
+        error: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
+      });
+    }
+  }
+
+  return { report, created, deferredByCap: plan.deferredByCap, writeFailures };
+}

--- a/tests/unit/recurrence-actuator.test.ts
+++ b/tests/unit/recurrence-actuator.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The actuator's refusals matter more than its proposals.
+ *
+ * It exists to close the loop: a problem noticed 177 times and never turned into
+ * work should become work. But two ways of doing that would make things worse
+ * than leaving it alone, and both are easy to write by accident:
+ *
+ *   1. Proposing when the ACTION QUEUE could not be read. Then "has anyone
+ *      already committed to this?" is unanswerable, every cluster looks
+ *      untracked, and the actuator manufactures duplicates of existing work —
+ *      the exact redundancy it exists to remove, under the banner of fixing it.
+ *
+ *   2. Proposing for all 69 qualifying clusters at once. That is a new backlog
+ *      wearing a different hat.
+ *
+ * So most of what follows tests what it declines to do.
+ */
+import { describe, it, expect } from 'vitest';
+import { planActuation } from '../../src/core/RecurrenceActuator.js';
+import { buildRecurrenceReport, type Observation, type Coverage } from '../../src/core/RecurrenceReader.js';
+
+const COMPLETE: Coverage = { read: ['attention', 'actions', 'sentinel'], unreadable: [], completeness: 'complete' };
+
+const obs = (p: Partial<Observation> & { title: string }): Observation => ({
+  store: 'attention', open: true, ...p,
+});
+
+/** n open observations sharing a title. */
+const cluster = (title: string, n: number, store: Observation['store'] = 'attention') =>
+  Array.from({ length: n }, () => obs({ title, store }));
+
+describe('REFUSAL: the action queue is the one store whose absence forbids acting', () => {
+  it('proposes NOTHING when the actions store is unreadable, and says why', () => {
+    // THE test. Every cluster would look untracked, so every proposal would risk
+    // duplicating work that already exists.
+    const report = buildRecurrenceReport(cluster('something loud', 200), {
+      read: ['attention', 'sentinel'],
+      unreadable: [{ store: 'actions', reason: 'ENOENT: evolution store unreadable' }],
+      completeness: 'partial',
+    });
+    const plan = planActuation(report);
+
+    expect(plan.propose).toHaveLength(0);
+    expect(plan.refused?.reason).toBe('actions-store-unreadable');
+    expect(plan.refused?.detail).toMatch(/ENOENT/);
+    // It still reports what it considered, so a caller can be honest about scope.
+    expect(plan.consideredClusters).toBe(1);
+  });
+
+  it('DOES act when attention or sentinel is unreadable — those only understate counts', () => {
+    // Deliberately NOT symmetric with the case above. A missing attention or
+    // sentinel store means the reader saw FEWER observations, so a cluster that
+    // still clears the threshold genuinely clears it. Treating all partial reads
+    // identically would be lazy symmetry that needlessly blocks safe action.
+    const report = buildRecurrenceReport(cluster('still loud', 40), {
+      read: ['actions'],
+      unreadable: [{ store: 'sentinel', reason: 'log absent' }],
+      completeness: 'partial',
+    });
+    const plan = planActuation(report);
+
+    expect(plan.refused).toBeUndefined();
+    expect(plan.propose).toHaveLength(1);
+  });
+});
+
+describe('REFUSAL: the fix must not become its own pile', () => {
+  it('caps proposals per run and reports what it held back', () => {
+    // 10 qualifying clusters must not become 10 action items in one pass.
+    //
+    // NOTE the titles are WORDS, not `problem 0..9`. My first version used digits
+    // and produced ONE cluster, not ten — the recurrence key normalizes digits to
+    // `N` by design, so `problem 0` and `problem 7` are the same key. The test was
+    // naive, not the code; recorded because it is a live demonstration of the
+    // over-merge trade the reader documents.
+    const names = ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'golf', 'hotel', 'india', 'juliet'];
+    const items = names.map((n) => cluster(`problem ${n}`, 50)).flat();
+    const plan = planActuation(buildRecurrenceReport(items, COMPLETE), { maxPerRun: 3 });
+
+    expect(plan.propose).toHaveLength(3);
+    expect(plan.deferredByCap).toBe(7);
+  });
+
+  it('takes the densest clusters first, so the cap converges on what matters', () => {
+    const items = [...cluster('minor', 12), ...cluster('enormous', 300), ...cluster('middling', 60)];
+    const plan = planActuation(buildRecurrenceReport(items, COMPLETE), { maxPerRun: 1 });
+
+    expect(plan.propose[0].observedCount).toBe(300);
+    expect(plan.propose[0].title).toContain('enormous');
+  });
+
+  it('ignores clusters below the recurrence threshold', () => {
+    // Seen three times is not yet a pattern worth spending a work item on.
+    const plan = planActuation(buildRecurrenceReport(cluster('twice-ish', 3), COMPLETE), { minCount: 10 });
+    expect(plan.propose).toHaveLength(0);
+    expect(plan.refused?.reason).toBe('no-qualifying-clusters');
+  });
+
+  it('never proposes for something already tracked', () => {
+    // A cluster with a member from the action queue means somebody already
+    // committed. Proposing again is the duplicate this whole design avoids.
+    const items = [...cluster('owned', 80), ...cluster('owned', 1, 'actions')];
+    const plan = planActuation(buildRecurrenceReport(items, COMPLETE));
+    expect(plan.propose).toHaveLength(0);
+  });
+});
+
+describe('idempotence — the actuator must not become a source of repeated noticings', () => {
+  it('derives a stable externalKey, so a re-run updates instead of duplicating', () => {
+    const items = cluster('the same problem, 40 times', 40);
+    const a = planActuation(buildRecurrenceReport(items, COMPLETE));
+    const b = planActuation(buildRecurrenceReport(items, COMPLETE));
+
+    expect(a.propose[0].externalKey).toBe(b.propose[0].externalKey);
+    expect(a.propose[0].externalKey).toMatch(/^recurrence:/);
+  });
+
+  it('different problems get different keys', () => {
+    const plan = planActuation(
+      buildRecurrenceReport([...cluster('problem one', 40), ...cluster('problem two', 40)], COMPLETE),
+      { maxPerRun: 2 },
+    );
+    expect(plan.propose[0].externalKey).not.toBe(plan.propose[1].externalKey);
+  });
+});
+
+describe('the proposal is work, not a notification', () => {
+  it('carries the evidence a reader needs to judge or dismiss it', () => {
+    const items = [
+      ...cluster('credential rebalancer', 177),
+      ...cluster('credential rebalancer', 3, 'sentinel'),
+    ];
+    const plan = planActuation(buildRecurrenceReport(items, COMPLETE));
+    const p = plan.propose[0];
+
+    expect(p.title).toContain('Recurring, untracked');
+    expect(p.description).toContain('180 times');
+    expect(p.description).toContain('attention, sentinel');
+    // Cancelling must be an explicitly blessed outcome — an explicit decision
+    // beats silent accumulation, and if dismissal feels illegitimate the queue
+    // just grows again.
+    expect(p.description).toMatch(/Cancelling it IS a valid outcome/);
+  });
+
+  it('priority comes from volume alone — deterministic, no model', () => {
+    const hi = planActuation(buildRecurrenceReport(cluster('huge', 150), COMPLETE));
+    const mid = planActuation(buildRecurrenceReport(cluster('medium', 30), COMPLETE));
+    const lo = planActuation(buildRecurrenceReport(cluster('small', 12), COMPLETE));
+
+    expect(hi.propose[0].priority).toBe('high');
+    expect(mid.propose[0].priority).toBe('medium');
+    expect(lo.propose[0].priority).toBe('low');
+  });
+});

--- a/tests/unit/recurrence-loop.test.ts
+++ b/tests/unit/recurrence-loop.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The loop must actually close — and must not lie about closing.
+ *
+ * The reader and the actuator are pure, which made them testable but left "the
+ * loop closes" a designed property rather than a demonstrated one. This is where
+ * it gets demonstrated: real reads in, real writes out.
+ *
+ * The failure mode to guard hardest is at the very END of the loop. A write that
+ * FAILS must not be reported the same way as a decision NOT to write. One is an
+ * outage; the other is a principled refusal. Conflating them would let real
+ * breakage present as sound judgment — this project's own disease, committed on
+ * the last line of the thing built to cure it.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { runRecurrenceLoop, type LoopDeps } from '../../src/core/recurrenceLoop.js';
+import type { Observation } from '../../src/core/RecurrenceReader.js';
+
+const obs = (title: string, store: Observation['store'] = 'attention'): Observation => ({
+  store, title, open: true,
+});
+
+const many = (title: string, n: number, store: Observation['store'] = 'attention') =>
+  Array.from({ length: n }, () => obs(title, store));
+
+const deps = (over: Partial<LoopDeps> = {}): LoopDeps => ({
+  readAttention: async () => many('a loud recurring thing', 40),
+  readActions: async () => [],
+  readSentinel: async () => [],
+  createAction: async () => ({ id: 'ACT-001' }),
+  ...over,
+});
+
+describe('the loop closes', () => {
+  it('reads, groups, plans and CREATES — end to end', () => {
+    const created: string[] = [];
+    return runRecurrenceLoop(deps({
+      createAction: async (a) => { created.push(a.title); return { id: `ACT-${created.length}` }; },
+    })).then((r) => {
+      expect(r.created).toHaveLength(1);
+      expect(r.created[0].id).toBe('ACT-1');
+      expect(r.created[0].observedCount).toBe(40);
+      expect(created[0]).toContain('a loud recurring thing');
+      expect(r.refused).toBeUndefined();
+      expect(r.writeFailures).toHaveLength(0);
+    });
+  });
+
+  it('passes the real store contents through to the report', async () => {
+    const r = await runRecurrenceLoop(deps({
+      readAttention: async () => many('x', 12),
+      readSentinel: async () => many('y', 5, 'sentinel'),
+    }));
+    expect(r.report.observationsConsidered).toBe(17);
+    expect(r.report.coverage.completeness).toBe('complete');
+    expect(r.report.verdict).toBe('recurrence-found');
+  });
+});
+
+describe('a failed WRITE is not a refusal', () => {
+  it('records write failures separately, and does not call them a refusal', async () => {
+    // THE test for this module. If the action store rejects the write, that is an
+    // OUTAGE. Reporting it as `refused` would dress a real failure as sound
+    // judgement — the exact absence-reads-as-presence move this whole project
+    // exists to remove, committed on the last line of the loop that cures it.
+    const r = await runRecurrenceLoop(deps({
+      createAction: async () => { throw new Error('503 action store unavailable'); },
+    }));
+
+    expect(r.created).toHaveLength(0);
+    expect(r.refused, 'a write outage was reported as a refusal').toBeUndefined();
+    expect(r.writeFailures).toHaveLength(1);
+    expect(r.writeFailures[0].error).toMatch(/503/);
+  });
+
+  it('one failed write does not abort the others', async () => {
+    let n = 0;
+    const r = await runRecurrenceLoop(deps({
+      readAttention: async () => [...many('alpha', 40), ...many('bravo', 40), ...many('charlie', 40)],
+      createAction: async (a) => {
+        n += 1;
+        if (n === 2) throw new Error('transient');
+        return { id: `ACT-${n}` };
+      },
+    }), { maxPerRun: 3 });
+
+    expect(r.created).toHaveLength(2);
+    expect(r.writeFailures).toHaveLength(1);
+  });
+});
+
+describe('an unreadable store is data, not an exception', () => {
+  it('does not throw, and names the gap in coverage', async () => {
+    const r = await runRecurrenceLoop(deps({
+      readSentinel: async () => { throw new Error('log absent'); },
+    }));
+    expect(r.report.coverage.unreadable).toEqual([{ store: 'sentinel', reason: 'log absent' }]);
+    expect(r.report.coverage.completeness).toBe('partial');
+    // Sentinel only understates counts, so acting is still correct.
+    expect(r.created).toHaveLength(1);
+  });
+
+  it('REFUSES to write when the ACTION store is unreadable, and creates nothing', async () => {
+    const create = vi.fn(async () => ({ id: 'should-never-happen' }));
+    const r = await runRecurrenceLoop(deps({
+      readActions: async () => { throw new Error('ENOENT evolution store'); },
+      createAction: create,
+    }));
+
+    expect(create).not.toHaveBeenCalled();
+    expect(r.created).toHaveLength(0);
+    expect(r.refused?.reason).toBe('actions-store-unreadable');
+    expect(r.writeFailures).toHaveLength(0);
+  });
+
+  it('every store unreadable → no verdict, no writes, no crash', async () => {
+    const r = await runRecurrenceLoop(deps({
+      readAttention: async () => { throw new Error('a'); },
+      readActions: async () => { throw new Error('b'); },
+      readSentinel: async () => { throw new Error('c'); },
+    }));
+    expect(r.report.coverage.unreadable).toHaveLength(3);
+    expect(r.report.verdict).toBeUndefined();
+    expect(r.created).toHaveLength(0);
+    expect(r.refused?.reason).toBe('actions-store-unreadable');
+  });
+});
+
+describe('bounded, and honest about what it held back', () => {
+  it('reports deferredByCap so the backlog is never silently truncated', async () => {
+    const r = await runRecurrenceLoop(deps({
+      readAttention: async () => [
+        ...many('alpha', 40), ...many('bravo', 40), ...many('charlie', 40),
+        ...many('delta', 40), ...many('echo', 40),
+      ],
+    }), { maxPerRun: 2 });
+
+    expect(r.created).toHaveLength(2);
+    expect(r.deferredByCap).toBe(3);
+  });
+
+  it('creates nothing when nothing qualifies', async () => {
+    const create = vi.fn(async () => ({ id: 'no' }));
+    const r = await runRecurrenceLoop(deps({
+      readAttention: async () => many('seen twice', 2),
+      createAction: create,
+    }));
+    expect(create).not.toHaveBeenCalled();
+    expect(r.refused?.reason).toBe('no-qualifying-clusters');
+  });
+});

--- a/upgrades/next/recurrence-actuator.md
+++ b/upgrades/next/recurrence-actuator.md
@@ -1,0 +1,72 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The recurrence reader (shipped in the previous fragment) makes recurrence visible. Visibility was
+never the goal: a report nobody acts on is the same filing-to-completion ratio with better
+typography. Two modules close the remaining half.
+
+`src/core/RecurrenceActuator.ts` turns a recurrence finding into a proposal for ONE tracked action on
+the EXISTING evolution action queue — no new store, no new notification channel, no new authority.
+Creating a tracked action queues work for a human or agent to judge; it does not close, prioritise,
+escalate, or act on anything.
+
+`src/core/recurrenceLoop.ts` is the caller that actually closes the loop: it reads the three stores,
+plans, and writes through a caller-supplied action-creation function. It is deliberately the only
+place in the feature that performs I/O, so a read failure has exactly one place to be reported from
+and cannot be swallowed mid-pipeline.
+
+## Evidence
+
+Full loop run against the three live stores with only the write intercepted: coverage complete, 836
+distinct problems, **would create 3, deferred 17 by the cap, zero write failures**. So "the loop
+closes" is demonstrated, not designed.
+
+Two refusals, deliberately **not** symmetric:
+
+- **Actions store unreadable ⇒ propose nothing.** `tracked` is unknowable for every cluster, so every
+  cluster looks unowned and the actuator would manufacture duplicates of work that already exists —
+  the exact redundancy it was built to remove, under the banner of fixing it.
+- **Attention or sentinel unreadable ⇒ proceed.** Those only understate counts, so a cluster still
+  clearing the threshold genuinely clears it. Treating all three identically would have looked
+  tidier and been wrong.
+
+A **failed write** is recorded separately from a **refusal**. One is an outage; the other is a
+decision not to act. Conflating them would let real breakage present as sound judgment. One failed
+write does not abandon the remaining ones.
+
+Bounds against the fix becoming its own pile: `minCount` (default 10), a hard per-run cap (default 3)
+so it converges across sessions densest-first rather than turning 69 clusters into 69 items, and a
+stable `externalKey` so a re-run updates instead of duplicating. Unit suite 30/30 across the feature;
+`tsc --noEmit` exit 0.
+
+## Known limits
+
+**Nothing schedules it.** The loop can close unattended; nothing yet calls it, so today it closes only
+when something invokes it. That is stated rather than implied. Priority is derived from volume alone
+— deterministic, no model, no judgment — so a rare-but-serious problem ranks below a frequent-but-
+trivial one. It inherits the reader's title-only keying, including its occasional over-merge.
+
+## What to Tell Your User
+
+Things you notice repeatedly can now become real work instead of being noticed again.
+
+The part shipped earlier counted how often the same underlying problem had been raised. This part
+takes the worst offenders and opens tracked items for them in the queue you already use — noticed
+repeatedly, never owned, becomes a job that gets done or explicitly dropped. Dropping it is a fine
+outcome, and the item says so: an explicit "no, we're fine with this" is worth far more than the same
+thing being raised another two hundred times.
+
+It is bounded on purpose. Out of 836 problems in a live dry run it would open three and hold back
+seventeen, working through the backlog over time rather than replacing one pile with another.
+
+The honest limit: nothing runs it on a schedule yet, so it closes the loop when something calls it,
+not on its own.
+
+## Summary of New Capabilities
+
+No new endpoint, command, or config key. Two internal modules: one that decides what recurring,
+untracked problem deserves a tracked action, and one that performs the read-plan-create pass through
+the action queue that already exists.

--- a/upgrades/side-effects/recurrence-actuator.md
+++ b/upgrades/side-effects/recurrence-actuator.md
@@ -1,0 +1,130 @@
+# Side-Effects Review — RecurrenceActuator (Tier 2 item 4, plan-only)
+
+**Version / slug:** `recurrence-actuator`
+**Date:** `2026-07-27`
+**Author:** `Echo (instar-dev agent)`
+
+## Summary
+
+`RecurrenceReader` makes recurrence visible. Visibility was never the goal — the project's diagnosis
+is that instar notices constantly and closes almost nothing (≈30:1). A reader nobody acts on is that
+ratio with better typography.
+
+Operator directive 2026-07-26 20:08Z: *"the synthesis itself must lead to ACTION and a fully closed
+loop"*, minimal user dependence.
+
+`planActuation()` returns a PLAN: for clusters that genuinely recur AND are untracked, propose work on
+the EXISTING evolution action queue. Pure — the caller performs the write, so the write path and its
+gating stay exactly where they already are.
+
+**Live dry-run, 2026-07-27:** 836 clusters considered → **3 proposed, 17 deferred by cap**
+(278x idle-timeout, 238x escalation-suppressed, 177x credential rebalancer — all `high`).
+
+## Refusal evidence (constraint 2)
+
+```
+REFUSAL 1 — actions store unreadable  ⇒  propose NOTHING
+  refused.reason : actions-store-unreadable
+  detail         : "…so 'has anyone already committed to this?' is unanswerable for every
+                    cluster. Proposing work now would duplicate whatever is already tracked."
+  propose        : []          consideredClusters: 1   ← still honest about scope
+
+DELIBERATELY NOT SYMMETRIC — attention/sentinel unreadable ⇒ it DOES act
+  Those only UNDERSTATE counts, so a cluster still clearing the bar genuinely clears it.
+  Treating all partial reads alike would be lazy symmetry that blocks safe action.
+
+REFUSAL 2 — per-run cap: 10 qualifying clusters ⇒ propose 3, deferredByCap 7
+REFUSAL 3 — below threshold: seen 3x with minCount 10 ⇒ no-qualifying-clusters
+REFUSAL 4 — already tracked: a member from the action queue ⇒ propose nothing
+```
+
+Tests **10 passed (10)**; combined with the reader **21 passed (21)**; `tsc --noEmit` exit 0.
+
+## A test caught the documented over-merge risk, live
+
+My first cap test built clusters titled `problem 0`…`problem 9` and asserted 3 proposals. It got 1:
+the recurrence key normalizes digits to `N`, so all ten collapsed to one cluster. **The fixture was
+naive, not the code** — and it is a live demonstration of the over-merge trade the reader's
+side-effects review names as its weakest point. Fixed with word-titles and the reason recorded in
+the test.
+
+## Decision-point inventory
+
+| point | classification |
+|---|---|
+| actions-unreadable ⇒ refuse | `invariant` — the load-bearing rule |
+| untracked + minCount filter | `invariant` — deterministic thresholds |
+| per-run cap, densest-first | `invariant` |
+| priority from volume | `invariant` — fixed bands, no model |
+| `externalKey` from cluster key | `invariant` — stable, idempotent |
+
+No judgment points, no LLM.
+
+## 1. Over-block
+
+Refuses entirely when the actions store is unreadable — deliberately, since acting blind creates
+duplicates. Cost: on a broken actions store, nothing is proposed until it is fixed. Correct trade.
+
+The `minCount` default of 10 will skip genuine problems seen 4–9 times. Accepted: a work item per
+seen-twice observation is how the queue got to 371 open in the first place.
+
+## 2. Under-block
+
+**Nothing prevents the CALLER from ignoring the plan or writing it badly.** This module returns data;
+the write is the caller's. That is the right seam (the write path keeps its own gating) but it means
+"the loop closes" is only true once a caller is wired. No caller ships here — that is the next step
+and is not claimed.
+
+**Cancelled actions are not re-proposed-proof.** If a human cancels a proposed action, the cluster
+remains untracked, so a later run could propose it again. The `externalKey` makes it the same row
+rather than a new one, but a "dismissed, stop asking" state belongs to the action store, not here.
+Named as a real gap. <!-- tracked: ACT-1311 -->
+
+## 3. Level-of-abstraction fit
+
+Plan-only, pure over the report. It cannot flood, cannot notify, cannot write. The one thing it
+must never become — a fourth place that notices things — is structurally impossible: it has no
+output channel.
+
+## 4. Signal vs authority compliance
+
+It proposes; it holds no authority. Creating a tracked action QUEUES work for a human or agent to
+judge — it does not close, prioritise beyond a fixed volume rule, escalate, or act.
+
+## 5. Interactions
+
+Consumes `RecurrenceReport` only. No writes, no schema change, no existing caller. Depends on
+`RecurrenceReader` (same branch, PR #1662) — this is stacked on it.
+
+## 6. External surfaces
+
+**None.** No route, no config, no persisted state, no user-visible behaviour in this increment.
+
+## 7. Multi-machine posture
+
+**Posture: `machine-local`.** `machine-local-justification: physical-credential-locality` — it plans
+over one machine's stores, whose observation titles carry that machine's ids, topics and account
+emails. Cross-machine synthesis would mean replicating those records; the correct route is the
+existing pool-scope fan-out, serving each machine's data from that machine.
+
+## 8. Rollback cost
+
+**Zero.** One module, one test file, no callers. Delete removes the feature.
+
+## Phase 5 — Second-pass review
+
+No gate/sentinel/watchdog, no block/allow authority, no session lifecycle, no LLM. Author lenses:
+
+**Adversarial — "how would I make this useless?"** Let it propose blind when the actions store is
+down (duplicates existing work), or let it propose for everything at once (new backlog). Both are
+asserted refusals.
+
+**"Would it have caught the incident?"** The incident is 69 untracked recurrers. It selects exactly
+that class and would open the top three today.
+
+**"Symptom or cause?"** Cause for the never-gets-picked-up half. NOT for the recurrence itself —
+proposing work does not fix the 278x idle-timeout; it makes someone decide about it. Claiming
+otherwise would be filing-as-progress.
+
+**Weakest point:** no caller is wired, so "the loop closes" is a designed property, not yet a
+demonstrated one. The dry-run shows what it WOULD propose; nothing has been written.

--- a/upgrades/side-effects/recurrence-loop.md
+++ b/upgrades/side-effects/recurrence-loop.md
@@ -1,0 +1,112 @@
+# Side-Effects Review — recurrenceLoop (the caller that closes the loop)
+
+**Version / slug:** `recurrence-loop` · **Date:** `2026-07-27` · **Author:** `Echo (instar-dev agent)`
+
+## Summary
+
+`RecurrenceReader` sees; `RecurrenceActuator` decides. Both are pure, which left **"the loop closes"
+a DESIGNED property, not a demonstrated one** — the weakest point named in the actuator's own review.
+This closes it: read three stores → group → plan → create, via a caller-supplied `createAction`.
+
+It is deliberately the ONLY I/O in the feature, so every read failure has exactly one reporting site
+and cannot be swallowed mid-pipeline.
+
+**Live run, writes intercepted, 2026-07-27:** coverage `complete` (attention, actions, sentinel);
+836 problems; **would create 3, deferred 17, 0 write failures, no refusal.**
+
+## Refusal evidence (constraint 2)
+
+```
+REFUSAL — action store unreadable ⇒ createAction NEVER CALLED
+  create spy      : not called          created: 0
+  refused.reason  : actions-store-unreadable      writeFailures: 0
+
+A FAILED WRITE IS NOT A REFUSAL  (the distinction this module exists to protect)
+  createAction throws '503 action store unavailable'
+    refused       : undefined      ← an outage must NOT present as judgement
+    writeFailures : [{ error: '503 …' }]
+    created       : 0
+
+  one failure among three ⇒ created 2, writeFailures 1 (others not abandoned)
+
+UNREADABLE STORE IS DATA, NOT AN EXCEPTION
+  sentinel throws ⇒ coverage.unreadable names it, completeness 'partial',
+    and it STILL creates 1 (sentinel only understates counts)
+  all three throw ⇒ verdict undefined, created 0, no crash
+```
+
+Tests **9 passed (9)**; whole feature **30 passed (30)**; `tsc --noEmit` exit 0.
+
+## Decision-point inventory
+
+| point | classification |
+|---|---|
+| read failure → coverage gap | `invariant` — try/catch → named entry, never a throw |
+| refusal vs write-failure separation | `invariant` — distinct fields, the load-bearing rule |
+| write loop continues past a failure | `invariant` |
+
+No judgment points, no LLM, no authority: `createAction` is supplied by the caller, so the write path
+keeps whatever gating it already has. This module never constructs an HTTP call.
+
+## 1. Over-block
+
+Refuses to write when the actions store is unreadable — inherited from the actuator and correct: it
+cannot tell what is already owned. Cost: a broken actions store stops proposals until fixed.
+
+## 2. Under-block
+
+**No scheduler/route calls it.** Running it is deliberate. So this demonstrates the loop CAN close,
+not that it closes *unattended*. Wiring a cadence is a separate increment with its own risk, and is
+not claimed here.
+
+**No dismissal memory.** A cancelled action leaves the cluster untracked, so a later run can propose
+it again (same `externalKey`, so one row, not many). A "dismissed, stop asking" state belongs to the
+action store. <!-- tracked: ACT-1311 -->
+
+**`createAction` failures are reported, not retried.** Deliberate: retry policy belongs to the write
+path, and a silent retry here would obscure the outage the separate field exists to surface.
+
+## 3. Level-of-abstraction fit
+
+All I/O in one place, everything else pure. The alternative — reads scattered through reader and
+actuator — is exactly how a failed read becomes an empty result that reads as "nothing found".
+
+## 4. Signal vs authority
+
+Holds none. It executes a plan produced by deterministic rules and writes through a function the
+caller owns.
+
+## 5. Interactions
+
+Consumes `RecurrenceReader` + `RecurrenceActuator` (same stack, PRs #1662 / actuator branch). Writes
+only via the injected function. No schema change.
+
+## 6. External surfaces
+
+**None.** No route, no config, no persisted state of its own.
+
+## 7. Multi-machine posture
+
+**Posture: `machine-local`.** `machine-local-justification: physical-credential-locality` — it reads
+one machine's stores, whose observation titles carry that machine's ids, topics and account emails,
+and writes to that machine's action queue. Cross-machine synthesis would mean replicating those
+records; the existing pool-scope fan-out is the correct route.
+
+## 8. Rollback cost
+
+**Zero.** One module, one test file, no callers.
+
+## Phase 5 — Second-pass review
+
+No gate/sentinel/watchdog, no block/allow authority, no LLM. Lenses:
+
+**Adversarial — "how would I make this useless?"** Report a write outage as a refusal, so breakage
+reads as judgement. Asserted against directly.
+
+**"Would it have caught the incident?"** It IS the incident's remedy: 69 untracked recurrers, top
+three actionable today.
+
+**"Symptom or cause?"** Cause for never-picked-up. Not for the recurrence itself — creating an item
+makes someone decide about the 278x idle-timeout; it does not fix it.
+
+**Weakest point:** nothing schedules it. "Closes unattended" remains unclaimed.


### PR DESCRIPTION
## ELI16 — turning "noticed 278 times" into actual work

Stacked on #1662. That PR built the piece that *sees* repeated problems — it found that 2,068 unresolved items are really 836 problems, and that 69 of them had been noticed 1,242 times between them without anyone ever picking one up.

A report nobody acts on is the original problem with better typography. So this adds the two pieces that *do* something: one decides which recurring problems deserve a real work item, and one actually creates them in the queue we already use.

Run against live data with only the final write intercepted: out of 836 problems it would open **three** and hold back **seventeen**. Not sixty-nine — it works through the backlog over sessions instead of replacing one pile with another.

---

## Two modules

**`RecurrenceActuator`** — pure planner. For clusters that genuinely recur *and* that nobody ever committed to, propose one work item on the existing action queue.

**`recurrenceLoop`** — the caller. Reads the three stores, plans, creates. Deliberately the **only** I/O in the feature, so a failed read has exactly one place to be reported and cannot be swallowed mid-pipeline.

## The refusals

**Deliberately asymmetric.** If the **actions** store is unreadable, it proposes nothing — "has anyone already committed to this?" is unanswerable, every cluster looks untracked, and it would manufacture duplicates of existing work. But if **attention** or **sentinel** is unreadable it proceeds, because those only *understate* counts, so a cluster still clearing the bar genuinely clears it. Treating all three alike would be tidy-looking and wrong.

```
actions unreadable   ⇒ createAction NEVER CALLED, refused: actions-store-unreadable
sentinel unreadable  ⇒ coverage names the gap, still creates (counts only understated)
all three unreadable ⇒ verdict undefined, created 0, no crash
below minCount       ⇒ no-qualifying-clusters
already tracked      ⇒ propose nothing
10 qualifying, cap 3 ⇒ created 3, deferredByCap 7
```

**A failed write is not a refusal.** Two very different things produce "nothing was created": a decision *not* to act, and a decision to act that the store rejected. If an outage were reported as a refusal, real breakage would read as sound judgement — this project's own disease, on the last line of the thing built to cure it. Separate fields; one failure doesn't abandon the rest.

```
createAction throws 503 ⇒ refused: undefined | writeFailures: [503 …] | created: 0
```

## Honest gaps

- **Nothing schedules it.** It *can* close the loop; it does not close it *unattended*. Separate increment, not claimed.
- **No dismissal memory.** A cancelled action leaves the cluster untracked, so a later run can propose it again — same `externalKey`, so one row rather than many. That state belongs to the action store.

## Notes

A test caught the documented over-merge risk live: clusters titled `problem 0`…`problem 9` collapsed to **one**, because the recurrence key normalizes digits by design (which is what lets "3 topics stranded" and "17 topics stranded" count as the same problem). The fixture was naive, not the code — recorded in the test.

Tests **30/30** across the feature; `tsc --noEmit` exit 0. Both commits gate-verified, `riskFloor=1`, Tier 1 accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
