### PR TITLE
fix(projects): a finished round can be recorded as finished

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T05-07-43-588Z-round-completion-verifies-merged.json
+++ b/.instar/instar-dev-decisions/2026-07-27T05-07-43-588Z-round-completion-verifies-merged.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T05:07:43.588Z",
+  "slug": "round-completion-verifies-merged",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 259,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/round-completion-verifies-merged.eli16.md
+++ b/docs/specs/round-completion-verifies-merged.eli16.md
@@ -1,0 +1,84 @@
+# A finished round can now be recorded as finished
+
+## The one-sentence version
+
+The part that checks "is this work actually merged?" was a placeholder that always answered
+"nothing is merged" — so a round could never be marked done, and asking it to run again would start
+a fresh session to redo work that was already finished.
+
+## What was actually there
+
+Projects here are organised into **rounds** — a batch of items worked together. When a round runs, a
+supervisor loops: *check whether every item has landed; if not, start a session to do the work; when
+that session exits, check again.*
+
+That check had a seam so tests could substitute a fake. Its default read, in full:
+
+> Best-effort no-op default — production callers should pass a real one.
+
+No production caller ever did. The one place that starts a round passes four things —
+tracker, project id, round index, repo path — and not the checker. So production ran the
+placeholder, which returns an empty answer every time.
+
+## Why an empty answer is worse than an error
+
+An empty answer means **"I verified nothing."** To the code receiving it, that is indistinguishable
+from **"nothing is merged."** Nothing crashes. Nothing logs. It just quietly always says no.
+
+Three things followed:
+
+1. The "everything has landed" condition could never be true, so a round whose items were all merged
+   **still started a session to redo them**.
+2. "Complete" became unreachable — not missing from the code, just never arrivable.
+3. Since the progress line counts only completed rounds, a project could honestly report
+   **"0 of 5 done"** while its items sat merged and verified. That is exactly what this project was
+   reporting when the defect was found.
+
+## What changed
+
+**The placeholder is deleted.** The seam now defaults to the real, git-backed checker, so a caller
+cannot forget to supply one. That is the whole fix in one line: the failure mode of forgetting is now
+"it works", instead of "it silently always says no".
+
+**And the answer got a third state.** The real checker already distinguishes three things, and the
+runner now respects all three:
+
+| The checker says | What it means | What the runner does |
+| --- | --- | --- |
+| verified | the work is on main | count it as landed |
+| regressed | git said, definitively, no | start a session to do the work |
+| unverifiable | the check could not run | see below |
+
+## The interesting part: two very different "I don't know"s
+
+"Could not check" arrives in two situations that look identical in the data and mean opposite things:
+
+- **The item records no merge commit at all.** Nothing has landed — which is the ordinary state of a
+  round nobody has worked yet. The right move is to start the session.
+- **The item records a merge commit, but git could not answer.** The work may already be done. Starting
+  a session would redo it.
+
+Telling these apart matters enough that getting it wrong breaks the system in opposite directions:
+treat the first as "unknown" and every fresh round stalls forever; treat the second as "not done" and
+you are back to redoing finished work.
+
+They are separated by **evidence** — does the item record a merge commit? — and deliberately *not* by
+reading the explanation text, because then rewording a message would silently change what the system
+does.
+
+When the second case happens, the runner **refuses in both directions**: it does not start a session,
+and it records no verdict at all. The round keeps the state it had and gets asked again later. Saying
+"failed" or "partly done" would state a conclusion nothing established.
+
+## What this does not do
+
+It does not make rounds run on a schedule, and it does not change what a session does once started.
+It makes a finished round recordable as finished, and makes an unanswerable check say so instead of
+guessing.
+
+## Honest note on how it was built
+
+The first draft applied the evidence rule at the pre-session check and missed the identical check
+after the session exits — so the old conflation survived in the second spot. A test written for the
+fresh-round case caught it. The rule is now defined once and used in both places, specifically so the
+two cannot drift apart again.

--- a/src/core/ProjectRoundExecution.ts
+++ b/src/core/ProjectRoundExecution.ts
@@ -34,12 +34,13 @@
  *   the runner.
  */
 
-import { spawn, type ChildProcess } from 'node:child_process';
+import { spawn, execFileSync, type ChildProcess } from 'node:child_process';
 
 import type { Initiative, InitiativeTracker, RoundStatus } from './InitiativeTracker.js';
 import { ProjectRoundLock } from './ProjectRoundLock.js';
 import { ProjectRoundWorktrees } from './ProjectRoundWorktrees.js';
 import { SafeGitExecutor } from './SafeGitExecutor.js';
+import { withSyncOp } from './InFlightSyncOpMarker.js';
 
 /** Per-spec defaults. Tests dial both down to keep the suite fast. */
 export const DEFAULT_POLL_INTERVAL_MS = 60_000;
@@ -85,15 +86,46 @@ export interface RunRoundInput {
   maxResumeAttempts?: number;
 
   /**
-   * Test hook: shell out to verify per-item artifacts. Defaults to a
-   * real `gh pr view` shell-out via SafeGitExecutor. Tests inject a
-   * stub. The function returns the set of itemIds whose artifact
-   * is verified merged-on-main-with-CI-green.
+   * Seam for verifying per-item artifacts. Defaults to the REAL git-backed
+   * `verifyMergedItemsViaGit`; tests inject a stub.
+   *
+   * It returns the three-state verdict deliberately — `verified` /
+   * `regressed` / `unverifiable`. A flat `Set<string>` cannot express "I
+   * could not check", so every item merely absent from it reads as
+   * not-merged, and this runner would respawn a child to redo work that may
+   * already be done. See the verdict handling in `runRound` below.
+   *
+   * HISTORY: this defaulted to a no-op that returned an EMPTY SET
+   * unconditionally, documented in place as "production callers should pass
+   * a real one". No production caller ever did. The consequence was that the
+   * all-items-merged stop condition could never fire, `outcome: 'complete'`
+   * was unreachable, and a round whose items were all merged still spawned a
+   * child to redo them. The default is now the real verifier precisely so a
+   * caller cannot forget: a seam whose default silently reports "nothing
+   * verified" is indistinguishable, to its caller, from "nothing is merged".
    */
-  verifyMergedItems?: (childIds: string[]) => Promise<Set<string>>;
+  verifyMergedItems?: (childIds: string[]) => Promise<MergedVerificationResult>;
+
+  /**
+   * Canonical-main ref for the merge-base check. Defaults to the resolved
+   * canonical ref (see `resolveCanonicalMainRef`), which matters on a
+   * fork-origin agent home where `origin/main` does not contain the merge
+   * commit and every healthy item would otherwise read as regressed.
+   */
+  mergeBaseBranch?: string;
 }
 
-export type RoundOutcome = 'complete' | 'partially-complete' | 'failed' | 'halted';
+/**
+ * `unverifiable` is NOT a soft `partially-complete`. It means the runner could
+ * not establish whether the round's work is done, so it has no verdict to
+ * record and no basis to redo the work either.
+ */
+export type RoundOutcome =
+  | 'complete'
+  | 'partially-complete'
+  | 'failed'
+  | 'halted'
+  | 'unverifiable';
 
 export interface RunRoundResult {
   outcome: RoundOutcome;
@@ -125,7 +157,29 @@ export async function runRound(input: RunRoundInput, deps: RunRoundDeps): Promis
   const pollIntervalMs = input.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const sigtermGraceMs = input.sigtermGraceMs ?? DEFAULT_SIGTERM_GRACE_MS;
   const maxResumeAttempts = input.maxResumeAttempts ?? DEFAULT_MAX_RESUME_ATTEMPTS;
-  const verifyMergedItems = input.verifyMergedItems ?? defaultVerifyMergedItems(input.targetRepoPath);
+  /**
+   * The items that are GENUINELY uncheckable: absent from `verified` for a
+   * reason the runner could not establish, AND carrying a merge commit that
+   * says work may already have landed.
+   *
+   * An item with no `mergeCommitOid` is also reported `unverifiable` by the
+   * git verifier, but that is not the same claim — it means nothing has landed
+   * yet, which is ordinary. Splitting on EVIDENCE rather than on the reason
+   * text keeps a reworded message from silently changing control flow.
+   *
+   * Defined once and used at BOTH decision points. The first draft of this
+   * change inlined it at the pre-spawn check only, and the post-exit check
+   * kept the old conflation — caught by the test that asserts a fresh round
+   * still spawns.
+   */
+  const uncheckable = (ids: string[], v: MergedVerificationResult): string[] =>
+    ids.filter((id) => v.unverifiable.has(id) && Boolean(input.tracker.get(id)?.mergeCommitOid));
+
+  const mergeBaseBranch = input.mergeBaseBranch ?? resolveCanonicalMainRef(input.targetRepoPath);
+  const verifyMergedItems =
+    input.verifyMergedItems ??
+    ((ids: string[]) =>
+      verifyMergedItemsViaGit(input.targetRepoPath, ids, input.tracker, mergeBaseBranch));
 
   const lock = new ProjectRoundLock({ stateDir: deps.stateDir });
 
@@ -198,10 +252,35 @@ export async function runRound(input: RunRoundInput, deps: RunRoundDeps): Promis
       }
 
       // Compute current stop condition: itemIds verified-merged.
-      const verified = await verifyMergedItems(lastItemIds);
-      if (lastItemIds.every((id) => verified.has(id))) {
+      const verdict = await verifyMergedItems(lastItemIds);
+      if (lastItemIds.every((id) => verdict.verified.has(id))) {
         outcome = 'complete';
         mergedItemIds = [...lastItemIds];
+        break;
+      }
+
+      // "I could not check" is not "not done" — but neither is it a reason to
+      // stall a round that has simply not been worked yet.
+      //
+      // `verifyMergedItemsViaGit` reports `unverifiable` for BOTH of these:
+      //   (a) the item records no mergeCommitOid at all — nothing has landed
+      //       yet, which is the ordinary state of a fresh round. Spawning is
+      //       exactly right here.
+      //   (b) the item DOES record a merge commit, but git could not answer
+      //       (guard refusal, missing binary, bad ref). Here the work may
+      //       already be done, and spawning would redo it.
+      //
+      // They are told apart by EVIDENCE — whether the item carries a
+      // mergeCommitOid — not by matching the reason text, which would make a
+      // reworded message silently change the control flow.
+      const uncheckableWithEvidence = uncheckable(lastItemIds, verdict);
+      if (uncheckableWithEvidence.length > 0) {
+        outcome = 'unverifiable';
+        unmergedItemIds = lastItemIds.filter((id) => !verdict.verified.has(id));
+        reason =
+          `could not verify ${uncheckableWithEvidence.length} item(s) that DO record a merge commit ` +
+          `(${uncheckableWithEvidence.join(', ')}); refusing to respawn work that may already be done, ` +
+          'and recording no round verdict';
         break;
       }
 
@@ -241,11 +320,27 @@ export async function runRound(input: RunRoundInput, deps: RunRoundDeps): Promis
       // Natural exit.
       if (exit.kind === 'exited' && exit.code === 0) {
         // Step 6: verify per-item artifacts.
-        const finalVerified = await verifyMergedItems(lastItemIds);
-        mergedItemIds = lastItemIds.filter((id) => finalVerified.has(id));
-        unmergedItemIds = lastItemIds.filter((id) => !finalVerified.has(id));
-        if (unmergedItemIds.length === 0) outcome = 'complete';
-        else outcome = 'partially-complete';
+        const final = await verifyMergedItems(lastItemIds);
+        mergedItemIds = lastItemIds.filter((id) => final.verified.has(id));
+        unmergedItemIds = lastItemIds.filter((id) => !final.verified.has(id));
+        const finalUncheckable = uncheckable(unmergedItemIds, final);
+        if (unmergedItemIds.length === 0) {
+          outcome = 'complete';
+        } else if (finalUncheckable.length > 0) {
+          // At least one item RECORDS a merge commit the runner could not
+          // check. `partially-complete` asserts "this genuinely did not land",
+          // which that item cannot support — so no verdict is recorded.
+          //
+          // An item with no merge commit at all, by contrast, genuinely did
+          // not land after a clean child exit, and falls through to
+          // partially-complete below where it belongs.
+          outcome = 'unverifiable';
+          reason =
+            `child exited 0 but ${finalUncheckable.length} item(s) recording a merge commit ` +
+            `could not be checked (${finalUncheckable.join(', ')}); no round verdict recorded`;
+        } else {
+          outcome = 'partially-complete';
+        }
         break;
       }
 
@@ -316,12 +411,18 @@ async function recordOutcome(
 ): Promise<void> {
   const proj = tracker.get(projectId);
   if (!proj) return;
-  const map: Record<RoundOutcome, RoundStatus> = {
+  // `unverifiable` has NO status. Every other outcome is a verdict the runner
+  // actually reached; this one is the absence of one, so the round keeps the
+  // status it had and gets asked again later. Mapping it onto `failed` or
+  // `partially-complete` would record a conclusion nothing established — the
+  // precise move that made a no-op verifier look like a healthy answer.
+  const map: Record<Exclude<RoundOutcome, 'unverifiable'>, RoundStatus> = {
     complete: 'complete',
     'partially-complete': 'partially-complete',
     failed: 'failed',
     halted: 'failed',
   };
+  if (outcome === 'unverifiable') return;
   const newStatus = map[outcome];
   const completedAt = new Date().toISOString();
   const rounds = (proj.rounds ?? []).map((r, i) =>
@@ -448,29 +549,64 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Real `gh pr view`-backed merged-state verifier. For each child id,
- * looks up the child's `prNumber` + `mergeCommitOid` from the tracker
- * and runs `git merge-base --is-ancestor <oid> origin/main` to confirm
- * the merge is reachable. Tests inject a stub instead.
+ * Resolve the ref that actually holds canonical `main` for this checkout.
  *
- * For PR 7's scope, this default is intentionally simple: it only
- * confirms reachability of `mergeCommitOid` if the child has one.
- * Real CI-green checks via `gh pr view` ship in a follow-up (the
- * StageTransitionValidator already performs them for /advance — when
- * the merged-state reconciler wires up in the next PR, it'll call
- * the validator here too).
+ * On a fork-origin agent home `origin/main` does NOT contain the canonical
+ * merge commit, so a merge-base check against it reports every healthy item
+ * as regressed. Falls back to the documented `origin/main` when `gh` or the
+ * remote mapping is unavailable (canonical-origin installs).
+ *
+ * Lives here rather than in the server layer because BOTH consumers — the
+ * lazy reconciler in `routes.ts` and this round runner — need the same
+ * resolution, and a core module must not import from `server/`.
+ *
+ * READ-ONLY: `gh repo view` + `git remote -v` (the latter via
+ * SafeGitExecutor.readSync — `remote` is a READONLY_GIT_VERB, shape-checked
+ * to list/get-url only).
  */
-function defaultVerifyMergedItems(targetRepoPath: string): (childIds: string[]) => Promise<Set<string>> {
-  return async (_childIds: string[]) => {
-    const verified = new Set<string>();
-    // Best-effort no-op default — production callers should pass a
-    // real verifyMergedItems that calls StageTransitionValidator.
-    // The point of this default is to avoid a spurious shell-out
-    // during tests that didn't override it (rare; tests should
-    // override).
-    void targetRepoPath;
-    return verified;
-  };
+export function resolveCanonicalMainRef(repoPath: string): string {
+  const FALLBACK = 'origin/main';
+  try {
+    // `gh repo view` is a BLOCKING spawn and this runs inside the server
+    // process (the auto-advance poller calls runRound). It funnels through
+    // withSyncOp so the in-flight marker sees the stall instead of it looking
+    // like an unexplained event-loop freeze.
+    //
+    // In `routes.ts` this callsite sat on the chokepoint lint's frozen
+    // baseline — grandfathered, not blessed. Moving it into core made it a NEW
+    // violation, and the lint refused it. That refusal is the useful part: it
+    // stopped a pre-existing blocking hazard from spreading into a module the
+    // round runner calls on every pass.
+    const GH_ARGS = ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'];
+    const GH_OPTS = {
+      cwd: repoPath,
+      encoding: 'utf-8' as const,
+      stdio: ['ignore', 'pipe', 'ignore'] as ('ignore' | 'pipe')[],
+    };
+    // The wrap must sit on the SAME LINE as the spawn: the chokepoint lint is a
+    // deliberately lexical, same-line matcher (it documents that it cannot prove
+    // runtime wrapping — that is the marker's own unit test's job). A cheap
+    // signal, not an authority, so it is satisfied literally.
+    const ghRepo = withSyncOp(() => execFileSync('gh', GH_ARGS, GH_OPTS)).trim();
+    if (!ghRepo) return FALLBACK;
+    const remotesOut = SafeGitExecutor.readSync(['remote', '-v'], {
+      cwd: repoPath,
+      operation: 'ProjectRoundExecution.resolveCanonicalMainRef',
+      encoding: 'utf-8',
+    });
+    for (const line of remotesOut.split('\n')) {
+      // format: "<name>\t<url> (fetch)"
+      const m = /^(\S+)\s+(\S+)\s+\(fetch\)/.exec(line.trim());
+      if (!m) continue;
+      const [, name, url] = m;
+      if (url.includes(ghRepo) || url.includes(`${ghRepo}.git`)) {
+        return `${name}/main`;
+      }
+    }
+    return FALLBACK;
+  } catch { /* @silent-fallback-ok: resolving the canonical-main ref is best-effort — gh missing / not-a-gh-repo / git error falls back to the documented `origin/main` default (the prior behavior), which the merge-base gate then re-validates. Not a degradation: it's the conservative default this resolver exists to refine, not replace. */
+    return FALLBACK;
+  }
 }
 
 /**

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -268,7 +268,7 @@ import type { TopicMemory } from '../memory/TopicMemory.js';
 import type { FeedbackAnomalyDetector } from '../monitoring/FeedbackAnomalyDetector.js';
 import type { ProjectMapper } from '../core/ProjectMapper.js';
 import type { CartographerTree } from '../core/CartographerTree.js';
-import { verifyMergedItemsViaGit } from '../core/ProjectRoundExecution.js';
+import { verifyMergedItemsViaGit, resolveCanonicalMainRef } from '../core/ProjectRoundExecution.js';
 import type { ProjectDriftChecker } from '../core/ProjectDriftChecker.js';
 import type { ScopeVerifier } from '../core/ScopeVerifier.js';
 import type { HighRiskAction } from '../core/ScopeVerifier.js';
@@ -1583,53 +1583,6 @@ function hashAuthHeader(header: unknown): string {
 }
 
 
-/**
- * Resolve the canonical-main ref a merged PR's commit must be reachable from,
- * for the projects `building → merged` gate (StageTransitionValidator).
- *
- * Default is `origin/main`. But on a dev-agent home `origin` is the agent's
- * FORK (e.g. instar-echo) while PRs merge on the UPSTREAM repo (JKHeadley/instar),
- * so origin/main never contains the merge commit → every advance failed
- * MERGE_COMMIT_UNREACHABLE. We ask gh which repo it resolves for this cwd
- * (the same repo `gh pr view` reads), then find the LOCAL remote whose URL
- * points at that repo and return `<remote>/main`. Falls back to `origin/main`
- * when gh or the remote mapping is unavailable (canonical-origin installs).
- *
- * READ-ONLY: `gh repo view` + `git remote -v` (the latter via
- * SafeGitExecutor.readSync — `remote` is a READONLY_GIT_VERB, shape-checked
- * to list/get-url only).
- */
-function resolveCanonicalMainRef(repoPath: string): string {
-  const FALLBACK = 'origin/main';
-  try {
-    const ghRepo = execFileSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], {
-      cwd: repoPath,
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-    if (!ghRepo) return FALLBACK;
-    // `git remote -v` is read-only (shape-checked by readSync). Find the remote
-    // whose fetch URL contains the gh-resolved "owner/repo".
-    const remotesOut = SafeGitExecutor.readSync(['remote', '-v'], {
-      cwd: repoPath,
-      operation: 'projects.advance.resolveCanonicalMainRef',
-      encoding: 'utf-8',
-    });
-    for (const line of remotesOut.split('\n')) {
-      // format: "<name>\t<url> (fetch)"
-      const m = /^(\S+)\s+(\S+)\s+\(fetch\)/.exec(line.trim());
-      if (!m) continue;
-      const [, name, url] = m;
-      // match owner/repo with or without a trailing .git
-      if (url.includes(ghRepo) || url.includes(`${ghRepo}.git`)) {
-        return `${name}/main`;
-      }
-    }
-    return FALLBACK;
-  } catch { /* @silent-fallback-ok: resolving the canonical-main ref is best-effort — gh missing / not-a-gh-repo / git error falls back to the documented `origin/main` default (the prior behavior), which the merge-base gate then re-validates. Not a degradation: it's the conservative default this resolver exists to refine, not replace. */
-    return FALLBACK; // gh missing / not a gh repo / git error → preserve default
-  }
-}
 
 /**
  * Read-check-increment for the per-token projects-creation counter.

--- a/tests/unit/ProjectRoundExecution.test.ts
+++ b/tests/unit/ProjectRoundExecution.test.ts
@@ -24,10 +24,30 @@ import os from 'node:os';
 import path from 'node:path';
 import { InitiativeTracker } from '../../src/core/InitiativeTracker.js';
 import { ProjectRoundLock } from '../../src/core/ProjectRoundLock.js';
-import { runRound } from '../../src/core/ProjectRoundExecution.js';
+import { runRound, type MergedVerificationResult } from '../../src/core/ProjectRoundExecution.js';
 import { ProjectRoundWorktrees } from '../../src/core/ProjectRoundWorktrees.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
+
+/**
+ * These stubs return the SAME three-state verdict the real verifier returns, so
+ * the tests exercise the contract production runs rather than a simpler one.
+ *
+ * `notLanded` uses the no-mergeCommitOid reason deliberately: that is exactly
+ * what `verifyMergedItemsViaGit` reports for work that has not landed yet, and
+ * the runner must read it as work-to-do — never as "could not check", which
+ * would stall every fresh round.
+ */
+const allVerified = (ids: string[]): MergedVerificationResult =>
+  ({ verified: new Set(ids), regressed: new Set(), unverifiable: new Map() });
+const notLanded = (ids: string[]): MergedVerificationResult =>
+  ({
+    verified: new Set(),
+    regressed: new Set(),
+    unverifiable: new Map(ids.map((i) => [i, 'no mergeCommitOid recorded on the item'])),
+  });
+const someVerified = (verifiedIds: string[], regressedIds: string[]): MergedVerificationResult =>
+  ({ verified: new Set(verifiedIds), regressed: new Set(regressedIds), unverifiable: new Map() });
 
 function makeStateDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'pre-state-'));
@@ -103,7 +123,7 @@ describe('ProjectRoundExecution.runRound', () => {
         spawnArgs: ['-c', 'exit 0'],
         pollIntervalMs: 50,
         sigtermGraceMs: 100,
-        verifyMergedItems: async () => { spawned++; return new Set<string>(); },
+        verifyMergedItems: async (ids) => { spawned++; return notLanded(ids); },
       },
       { stateDir }
     );
@@ -129,7 +149,7 @@ describe('ProjectRoundExecution.runRound', () => {
         sigtermGraceMs: 100,
         verifyMergedItems: async (ids) => {
           spawnedCalls++;
-          return new Set(ids);
+          return allVerified(ids);
         },
       },
       { stateDir }
@@ -148,10 +168,10 @@ describe('ProjectRoundExecution.runRound', () => {
     // Step 1: pre-spawn check returns 0 → child spawns.
     // Step 2 (post-spawn): we verify-merged on natural exit.
     let calls = 0;
-    const verify = async (ids: string[]): Promise<Set<string>> => {
+    const verify = async (ids: string[]): Promise<MergedVerificationResult> => {
       calls++;
-      // First call (pre-spawn): nothing verified. Second call (post-spawn): all verified.
-      return calls === 1 ? new Set<string>() : new Set(ids);
+      // First call (pre-spawn): nothing landed yet. Second (post-spawn): all verified.
+      return calls === 1 ? notLanded(ids) : allVerified(ids);
     };
     const r = await runRound(
       {
@@ -174,10 +194,13 @@ describe('ProjectRoundExecution.runRound', () => {
   it('natural exit + subset verified → partially-complete', async () => {
     await newProject(tracker, 'p-part', ['i1', 'i2', 'i3'], targetRepo);
     let calls = 0;
-    const verify = async (ids: string[]): Promise<Set<string>> => {
+    const verify = async (ids: string[]): Promise<MergedVerificationResult> => {
       calls++;
-      if (calls === 1) return new Set<string>();
-      return new Set([ids[0]]); // only first item verified
+      if (calls === 1) return notLanded(ids);
+      // Only the first landed; the rest are GENUINELY not merged (git exit 1).
+      // They must be `regressed`, not `unverifiable` — `partially-complete`
+      // asserts real non-landing, and an uncheckable item cannot support it.
+      return someVerified([ids[0]], ids.slice(1));
     };
     const r = await runRound(
       {
@@ -204,9 +227,9 @@ describe('ProjectRoundExecution.runRound', () => {
   it('halt mid-run: haltedAt set during child sleep → outcome=halted', async () => {
     await newProject(tracker, 'p-halt', ['i1'], targetRepo);
     let phase = 0;
-    const verify = async (): Promise<Set<string>> => {
+    const verify = async (ids: string[]): Promise<MergedVerificationResult> => {
       phase++;
-      return new Set<string>(); // never verified — child has to run
+      return notLanded(ids); // never landed — child has to run
     };
     // The child sleeps 10s but the runner halts mid-poll.
     const runPromise = runRound(
@@ -238,10 +261,10 @@ describe('ProjectRoundExecution.runRound', () => {
   it('dynamic stop revalidation: itemIds change → relaunch counter increments', async () => {
     await newProject(tracker, 'p-dyn', ['i1', 'i2'], targetRepo);
     let calls = 0;
-    const verify = async (ids: string[]): Promise<Set<string>> => {
+    const verify = async (ids: string[]): Promise<MergedVerificationResult> => {
       calls++;
-      // 1st pre-spawn: nothing. After relaunch: all verified (so we exit cleanly).
-      return calls >= 2 ? new Set(ids) : new Set<string>();
+      // 1st pre-spawn: nothing landed. After relaunch: all verified (clean exit).
+      return calls >= 2 ? allVerified(ids) : notLanded(ids);
     };
     // Long-running child, runner relaunches it on itemIds change.
     const runPromise = runRound(
@@ -282,7 +305,7 @@ describe('ProjectRoundExecution.runRound', () => {
         spawnArgs: ['-c', 'exit 0'],
         pollIntervalMs: 50,
         sigtermGraceMs: 100,
-        verifyMergedItems: async (ids) => new Set(ids), // instant complete
+        verifyMergedItems: async (ids) => allVerified(ids), // instant complete
       },
       { stateDir }
     );
@@ -302,7 +325,7 @@ describe('ProjectRoundExecution.runRound', () => {
         spawnArgs: ['-c', 'exit 0'],
         pollIntervalMs: 50,
         sigtermGraceMs: 100,
-        verifyMergedItems: async (ids) => new Set(ids),
+        verifyMergedItems: async (ids) => allVerified(ids),
       },
       { stateDir }
     );

--- a/tests/unit/round-completion-verifies-merged.test.ts
+++ b/tests/unit/round-completion-verifies-merged.test.ts
@@ -1,0 +1,337 @@
+/**
+ * A round must be able to finish — and must never claim a verdict it did not reach.
+ *
+ * `runRound`'s `verifyMergedItems` seam defaulted to a no-op returning an EMPTY
+ * SET unconditionally, documented in place as "production callers should pass a
+ * real one". No production caller ever did (`src/commands/server.ts` passes only
+ * tracker/projectId/roundIndex/targetRepoPath). The consequences, all verified
+ * from the code before this change:
+ *
+ *   - the all-items-merged stop condition could never be true, so a round whose
+ *     items were ALL merged still spawned a child to redo them;
+ *   - `outcome: 'complete'` was unreachable, so `RoundStatus 'complete'` was
+ *     never written by the poller path;
+ *   - and since the session-start digest counts only complete /
+ *     complete-with-skips, a project could show "0 of 5 done" with every item
+ *     merged and verified.
+ *
+ * The sting worth naming: a verifier that returns ∅ means "I verified nothing",
+ * which is indistinguishable to its caller from "nothing is merged". That is the
+ * same absence-reads-as-presence move the three-state `MergedVerificationResult`
+ * exists to prevent one layer down.
+ *
+ * So most of what follows tests what the runner declines to conclude.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { InitiativeTracker } from '../../src/core/InitiativeTracker.js';
+import { runRound, type MergedVerificationResult } from '../../src/core/ProjectRoundExecution.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
+
+const SRC = path.resolve(__dirname, '../../src/core/ProjectRoundExecution.ts');
+
+function makeStateDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'rcvm-state-'));
+}
+function makeGitRepo(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'rcvm-target-'));
+  SafeGitExecutor.run(['init', '-q'], { cwd: d, operation: 'tests/unit/round-completion-verifies-merged.test.ts:init' });
+  SafeGitExecutor.run(['config', 'user.email', 'test@test'], { cwd: d, operation: 'cfg' });
+  SafeGitExecutor.run(['config', 'user.name', 'test'], { cwd: d, operation: 'cfg' });
+  fs.writeFileSync(path.join(d, 'README'), 'x');
+  SafeGitExecutor.run(['add', '.'], { cwd: d, operation: 'cfg' });
+  SafeGitExecutor.run(['commit', '-m', 'init', '-q'], { cwd: d, operation: 'cfg' });
+  return d;
+}
+
+/** Build a three-state verdict without repeating the shape at every callsite. */
+const verdict = (o: {
+  verified?: string[];
+  regressed?: string[];
+  unverifiable?: [string, string][];
+}): MergedVerificationResult => ({
+  verified: new Set(o.verified ?? []),
+  regressed: new Set(o.regressed ?? []),
+  unverifiable: new Map(o.unverifiable ?? []),
+});
+
+describe('a round whose items are all merged can actually finish', () => {
+  let stateDir: string;
+  let targetRepo: string;
+  let tracker: InitiativeTracker;
+
+  beforeEach(() => {
+    stateDir = makeStateDir();
+    targetRepo = makeGitRepo();
+    tracker = new InitiativeTracker(stateDir);
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests:state' }); } catch { /* ignore */ }
+    try { SafeFsExecutor.safeRmSync(targetRepo, { recursive: true, force: true, operation: 'tests:repo' }); } catch { /* ignore */ }
+  });
+
+  async function project(id: string, items: { id: string; mergeCommitOid?: string }[]) {
+    await tracker.create({
+      id,
+      title: `Project ${id}`,
+      description: 'fixture',
+      phases: [{ id: 'overview', name: 'overview' }],
+      kind: 'project',
+      rounds: [{ name: 'r0', itemIds: items.map((i) => i.id) }],
+      targetRepoPath: targetRepo,
+    });
+    for (const it of items) {
+      await tracker.create({
+        id: it.id,
+        title: `Item ${it.id}`,
+        description: 'item',
+        phases: [{ id: 'p', name: 'p' }],
+        parentProjectId: id,
+        pipelineStage: it.mergeCommitOid ? 'merged' : 'outline',
+        ...(it.mergeCommitOid ? { mergeCommitOid: it.mergeCommitOid } : {}),
+      });
+    }
+  }
+
+  const base = (projectId: string) => ({
+    tracker,
+    projectId,
+    roundIndex: 0,
+    targetRepoPath: targetRepo,
+    // Would exit non-zero and be loudly visible if it were ever spawned.
+    spawnCommand: 'bash',
+    spawnArgs: ['-c', 'exit 99'],
+    pollIntervalMs: 50,
+    sigtermGraceMs: 100,
+  });
+
+  it('THE FIX: every item verified → complete, and no child is spawned to redo it', async () => {
+    // Before the change this was unreachable: the default verifier returned ∅,
+    // so `every(id => verified.has(id))` was false for any non-empty round and
+    // the runner spawned a child to redo already-merged work.
+    await project('p-done', [{ id: 'i1', mergeCommitOid: 'a'.repeat(40) }, { id: 'i2', mergeCommitOid: 'b'.repeat(40) }]);
+    let calls = 0;
+
+    const r = await runRound(
+      {
+        ...base('p-done'),
+        verifyMergedItems: async (ids) => { calls++; return verdict({ verified: ids }); },
+      },
+      { stateDir },
+    );
+
+    expect(r.outcome).toBe('complete');
+    expect(r.mergedItemIds).toEqual(['i1', 'i2']);
+    // Exactly one pre-spawn check, and no post-spawn check — because nothing spawned.
+    expect(calls).toBe(1);
+
+    const proj = tracker.get('p-done');
+    expect(proj?.rounds?.[0].status, 'a finished round must record its verdict').toBe('complete');
+  });
+});
+
+describe('REFUSAL: "I could not check" is not a verdict, in either direction', () => {
+  let stateDir: string;
+  let targetRepo: string;
+  let tracker: InitiativeTracker;
+
+  beforeEach(() => {
+    stateDir = makeStateDir();
+    targetRepo = makeGitRepo();
+    tracker = new InitiativeTracker(stateDir);
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests:state' }); } catch { /* ignore */ }
+    try { SafeFsExecutor.safeRmSync(targetRepo, { recursive: true, force: true, operation: 'tests:repo' }); } catch { /* ignore */ }
+  });
+
+  async function project(id: string, items: { id: string; mergeCommitOid?: string }[]) {
+    await tracker.create({
+      id, title: `Project ${id}`, description: 'fixture',
+      phases: [{ id: 'overview', name: 'overview' }], kind: 'project',
+      rounds: [{ name: 'r0', itemIds: items.map((i) => i.id) }], targetRepoPath: targetRepo,
+    });
+    for (const it of items) {
+      await tracker.create({
+        id: it.id, title: `Item ${it.id}`, description: 'item',
+        phases: [{ id: 'p', name: 'p' }], parentProjectId: id,
+        pipelineStage: it.mergeCommitOid ? 'merged' : 'outline',
+        ...(it.mergeCommitOid ? { mergeCommitOid: it.mergeCommitOid } : {}),
+      });
+    }
+  }
+
+  const base = (projectId: string, spawnScript: string) => ({
+    tracker, projectId, roundIndex: 0, targetRepoPath: targetRepo,
+    spawnCommand: 'bash', spawnArgs: ['-c', spawnScript],
+    pollIntervalMs: 50, sigtermGraceMs: 100,
+  });
+
+  it('an item that RECORDS a merge commit but cannot be checked → no respawn, and NO round verdict', async () => {
+    // THE test for this module. The work may already be done; redoing it is the
+    // duplicate-work failure, and recording `failed`/`partially-complete` would
+    // state a conclusion nothing established.
+    await project('p-unk', [{ id: 'i1', mergeCommitOid: 'c'.repeat(40) }]);
+    const marker = path.join(targetRepo, 'SPAWNED');
+
+    const r = await runRound(
+      {
+        ...base('p-unk', `touch ${JSON.stringify(marker)}; exit 0`),
+        verifyMergedItems: async () => verdict({ unverifiable: [['i1', 'git: bad ref']] }),
+      },
+      { stateDir },
+    );
+
+    expect(r.outcome).toBe('unverifiable');
+    expect(fs.existsSync(marker), 'a child was spawned to redo work that may already be done').toBe(false);
+    expect(r.reason).toMatch(/could not verify/i);
+
+    // No verdict recorded — the round keeps the status it had and gets asked again.
+    const proj = tracker.get('p-unk');
+    expect(proj?.rounds?.[0].status ?? 'pending').toBe('pending');
+  });
+
+  it('an item with NO merge commit recorded is NOT-DONE, not unknown — the child still spawns', async () => {
+    // The trap this test exists to hold shut. `verifyMergedItemsViaGit` reports
+    // `unverifiable` for an item carrying no mergeCommitOid, which is the
+    // ORDINARY state of a round nobody has worked yet. Treating that as "could
+    // not check" would refuse to spawn and deadlock every fresh round — turning
+    // a fix for redoing-finished-work into a total stall.
+    //
+    // The two are separated by EVIDENCE (does the item record a merge commit?),
+    // never by matching the reason text — a reworded message must not be able to
+    // change the control flow.
+    await project('p-fresh', [{ id: 'i1' }]); // deliberately no mergeCommitOid
+    const marker = path.join(targetRepo, 'SPAWNED');
+
+    const r = await runRound(
+      {
+        ...base('p-fresh', `touch ${JSON.stringify(marker)}; exit 0`),
+        verifyMergedItems: async () => verdict({ unverifiable: [['i1', 'no mergeCommitOid recorded on the item']] }),
+      },
+      { stateDir },
+    );
+
+    expect(fs.existsSync(marker), 'a fresh round must still spawn its child').toBe(true);
+    expect(r.outcome).not.toBe('unverifiable');
+  });
+
+  it('a genuinely regressed item still spawns — only git exit 1 means not-merged', async () => {
+    await project('p-reg', [{ id: 'i1', mergeCommitOid: 'd'.repeat(40) }]);
+    const marker = path.join(targetRepo, 'SPAWNED');
+
+    await runRound(
+      {
+        ...base('p-reg', `touch ${JSON.stringify(marker)}; exit 0`),
+        verifyMergedItems: async () => verdict({ regressed: ['i1'] }),
+      },
+      { stateDir },
+    );
+
+    expect(fs.existsSync(marker)).toBe(true);
+  });
+
+  it('child exits 0 but the shortfall is entirely uncheckable → unverifiable, NOT partially-complete', async () => {
+    // `partially-complete` asserts "some of this genuinely did not land". If the
+    // only reason an item is missing from `verified` is that the check could not
+    // run, that assertion is manufactured.
+    // i2 RECORDS a merge commit — that is what makes "could not check" a real
+    // gap rather than "did not land". Without the recorded commit the honest
+    // reading after a clean exit is partially-complete, which the next test
+    // pins.
+    await project('p-post', [{ id: 'i1' }, { id: 'i2', mergeCommitOid: 'e'.repeat(40) }]);
+    let call = 0;
+
+    const r = await runRound(
+      {
+        ...base('p-post', 'exit 0'),
+        verifyMergedItems: async () => {
+          call++;
+          // First (pre-spawn) call: both genuinely not landed → spawn.
+          // Second (post-exit) call: i1 landed, i2 uncheckable-with-evidence.
+          return call === 1
+            ? verdict({ regressed: ['i1', 'i2'] })
+            : verdict({ verified: ['i1'], unverifiable: [['i2', 'git: could not run']] });
+        },
+      },
+      { stateDir },
+    );
+
+    expect(r.outcome).toBe('unverifiable');
+    expect(r.mergedItemIds).toEqual(['i1']);
+    expect(r.unmergedItemIds).toEqual(['i2']);
+    const proj = tracker.get('p-post');
+    expect(proj?.rounds?.[0].status ?? 'pending', 'no verdict was reached, so none may be recorded').toBe('pending');
+  });
+
+  it('after a clean exit, an item that recorded NO merge commit is genuinely not-landed → partially-complete', async () => {
+    // The other side of the same boundary. Without this, "any unverifiable ⇒
+    // no verdict" would swallow the ordinary partial result and a round that
+    // really did half its work would never be recorded as such.
+    await project('p-partial', [{ id: 'i1' }, { id: 'i2' }]);
+    let call = 0;
+
+    const r = await runRound(
+      {
+        ...base('p-partial', 'exit 0'),
+        verifyMergedItems: async () => {
+          call++;
+          return call === 1
+            ? verdict({ regressed: ['i1', 'i2'] })
+            : verdict({ verified: ['i1'], unverifiable: [['i2', 'no mergeCommitOid recorded on the item']] });
+        },
+      },
+      { stateDir },
+    );
+
+    expect(r.outcome).toBe('partially-complete');
+    expect(r.mergedItemIds).toEqual(['i1']);
+    expect(tracker.get('p-partial')?.rounds?.[0].status).toBe('partially-complete');
+  });
+});
+
+describe('the seam cannot default to silence again', () => {
+  const src = () => fs.readFileSync(SRC, 'utf-8');
+
+  it('has no default verifier that returns an unconditional empty set', () => {
+    // The removed shape was a factory returning `async () => new Set<string>()`
+    // — a value indistinguishable from a real "nothing is merged" reading.
+    const s = src();
+    expect(
+      /defaultVerifyMergedItems/.test(s),
+      'the no-op default verifier must stay deleted; a caller must not be able to forget to pass a real one',
+    ).toBe(false);
+  });
+
+  it('defaults the seam to the real git-backed verifier', () => {
+    const s = src();
+    const idx = s.indexOf('input.verifyMergedItems ??');
+    expect(idx, 'the seam must have a default').toBeGreaterThan(0);
+    const window = s.slice(idx, idx + 400);
+    expect(
+      /verifyMergedItemsViaGit\(/.test(window),
+      'the default must be the real verifier, so production cannot silently run a stub',
+    ).toBe(true);
+  });
+
+  it('passes a resolved canonical-main ref rather than relying on the origin/main default', () => {
+    // On a fork-origin agent home origin/main does not contain the merge commit,
+    // so every healthy item would read as regressed and the round would respawn.
+    const s = src();
+    expect(/resolveCanonicalMainRef\(/.test(s)).toBe(true);
+  });
+
+  it('records NO round status for an unverifiable outcome', () => {
+    const s = src();
+    const idx = s.indexOf('const map: Record<');
+    expect(idx).toBeGreaterThan(0);
+    const window = s.slice(Math.max(0, idx - 600), idx + 600);
+    expect(
+      /outcome === 'unverifiable'\)\s*return/.test(window),
+      'an unverifiable round must return before writing a status — it has no verdict to record',
+    ).toBe(true);
+  });
+});

--- a/upgrades/next/round-completion-verifies-merged.md
+++ b/upgrades/next/round-completion-verifies-merged.md
@@ -1,0 +1,68 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+`runRound`'s `verifyMergedItems` seam defaulted to a no-op returning an empty set, documented in
+place as "production callers should pass a real one". No production caller ever did —
+`src/commands/server.ts` passes tracker, projectId, roundIndex and targetRepoPath, and nothing else.
+
+Consequences, all read from the code: the all-items-merged stop condition could never be true, so a
+round whose items were **all merged still spawned a child to redo them**; `outcome: 'complete'` was
+unreachable; and because the progress digest counts only completed rounds, a project could report
+`0 of 5 done` with its items merged and verified.
+
+The no-op default is deleted. The seam now defaults to the real `verifyMergedItemsViaGit`, carries
+the three-state `MergedVerificationResult`, and a new `unverifiable` outcome records **no** round
+status. `resolveCanonicalMainRef` moved from `src/server/routes.ts` into the core module both
+consumers share.
+
+## Evidence
+
+Live: project `convergence-towards-coherence` had items 1, 2 and 3 at `pipelineStage: merged`
+(item 3 verified against merge commit `3443efd1d`) while the session-start digest read `0 of 5 done`.
+
+Refusals, by falsification. Neutralising the evidence predicate:
+
+```
+× an item that RECORDS a merge commit but cannot be checked → no respawn, and NO round verdict
+× child exits 0 but the shortfall is entirely uncheckable → unverifiable, NOT partially-complete
+```
+
+Re-introducing a default that returns an unconditional empty verdict:
+
+```
+× the seam cannot default to silence again > has no default verifier that returns an unconditional empty set
+```
+
+Restored: 27/27 across the three affected files; `tsc --noEmit` exit 0.
+
+## Known limits
+
+Verification is still merge-base reachability of a recorded commit — an item merged with red CI
+verifies. Nothing here schedules rounds; it makes a run able to conclude. And
+`resolveCanonicalMainRef` remains best-effort: without `gh` it falls back to `origin/main`, which on
+a fork-origin home under-verifies toward spawning rather than toward a false complete.
+
+## What to Tell Your User
+
+A round of project work can now actually be recorded as finished.
+
+The piece that checks "has this work landed?" was a placeholder that always answered "nothing has
+landed". Nothing failed visibly — it just quietly always said no. So a round could never be marked
+complete, your progress line could read "0 of 5 done" while the work sat merged, and asking the round
+to run again would start a fresh session to redo work already finished.
+
+It now uses the real check. And when the check genuinely cannot run, it says so rather than guessing:
+it will not start a session to redo work that may already be done, and it records no verdict at all
+rather than claiming the round failed.
+
+The distinction that took the most care: "no merge recorded yet" and "there is a merge but I couldn't
+check it" look identical in the data and mean opposite things. Read the first as unknown and every
+new round stalls forever; read the second as not-done and you are back to redoing finished work.
+
+## Summary of New Capabilities
+
+No new endpoint, command, or config key. An existing round runner gained a working merged-state check
+and an honest "could not determine" outcome that records nothing instead of inventing a verdict.

--- a/upgrades/side-effects/round-completion-verifies-merged.md
+++ b/upgrades/side-effects/round-completion-verifies-merged.md
@@ -1,0 +1,137 @@
+# Side-effects review — round completion verifies merged state
+
+**Change:** `runRound`'s `verifyMergedItems` seam no longer defaults to a no-op that reports nothing
+verified. It defaults to the real git-backed `verifyMergedItemsViaGit`, the seam carries the
+three-state `MergedVerificationResult`, and a new `unverifiable` outcome records **no** round status.
+
+**Decision point touched:** yes — two of them. (a) whether a round is complete; (b) whether to spawn
+an autonomous child. Both previously ran on a verifier that could only ever say "nothing verified".
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+The one real risk is stalling a round that should proceed. `verifyMergedItemsViaGit` reports
+`unverifiable` for an item with **no `mergeCommitOid`**, which is the ordinary state of a round nobody
+has worked yet. A naive "any unverifiable ⇒ don't spawn" would deadlock **every fresh round** — a far
+worse defect than the one being fixed.
+
+Handled by splitting on **evidence**: only an item that *records* a merge commit and cannot be checked
+counts as genuinely uncheckable. An item with no recorded commit is not-done, and the child spawns.
+Pinned by `an item with NO merge commit recorded is NOT-DONE, not unknown — the child still spawns`.
+
+This test earned its place: the first draft applied the evidence rule at the pre-spawn check only,
+and the post-exit check kept the old conflation. The test failed, and the predicate is now defined
+once and used at both sites.
+
+## 2. Under-block — what does it still miss?
+
+- **CI-green is still not checked.** Verification remains merge-base reachability of a recorded
+  commit. An item merged with red CI verifies. Unchanged by this PR; `StageTransitionValidator`
+  performs the stronger check on the `/advance` path.
+- **No scheduling.** Nothing here makes rounds run; it makes a run able to conclude.
+- **`resolveCanonicalMainRef` is best-effort.** If `gh` is absent it falls back to `origin/main`,
+  which on a fork-origin home under-verifies (items read as regressed → a spawn, i.e. redoing work).
+  That is the pre-existing conservative default, now applied to this path too rather than left to a
+  caller to remember.
+
+## 3. Level-of-abstraction fit
+
+`resolveCanonicalMainRef` moved from `src/server/routes.ts` into `src/core/ProjectRoundExecution.ts`
+and is imported back. Both consumers — the lazy reconciler and this runner — need identical
+resolution, and a core module must not import from `server/`. Net: one definition, two callers,
+correct direction. The two source-grep tests in `merged-record-carries-its-evidence.test.ts` assert
+the *call* in `routes.ts`, not the definition, and still pass.
+
+## 4. Signal vs authority
+
+The verifier stays a **signal** — it reports three states and holds no blocking authority. `runRound`
+is the authority and now consumes all three rather than flattening them. The specific improvement:
+the authority can no longer be handed a value ("empty set") that is indistinguishable from a real
+negative reading. Per `docs/signal-vs-authority.md`, the failure was not a brittle check holding
+authority; it was an authority whose input could not express uncertainty.
+
+## 5. Interactions
+
+- **`/projects/:id/advance`** — untouched. Item-level stage transitions still go through
+  `StageTransitionValidator`; this only affects round-level outcome.
+- **`ProjectAutoAdvancePoller`** — unchanged; it clears `autoAdvanceAt` and counts unacked advances.
+  It now sees rounds that can actually reach `complete`.
+- **`ProjectDigestCache`** — unchanged, and this is the visible effect: the session-start
+  `N of M done` line can move off zero for the first time via the poller path.
+- **Double-fire / races** — none added. `unverifiable` performs strictly *fewer* writes than any
+  other outcome (it writes nothing), so it cannot race the tracker's OCC.
+
+## 6. External surfaces
+
+`RoundOutcome` gains `'unverifiable'` — a TypeScript-level addition on an exported union. In-repo
+consumers are `ProjectRoundExecution` itself and the tests; `recordOutcome` maps
+`Exclude<RoundOutcome,'unverifiable'>` so the compiler enforces the exhaustiveness rather than a
+runtime default swallowing it. No route, no config key, no user-visible string.
+
+## 7. Multi-machine posture
+
+**Machine-local BY DESIGN**, `machine-local-justification: hardware-bound-resource` — the check runs
+`git merge-base` against a working checkout on local disk, and the round runner already holds a
+host-local `ProjectRoundLock` (`.instar/local/round-runner.lock`). Round execution is bound to the
+machine holding the checkout; nothing here introduces state another machine would need to read. No
+notice, no durable cross-machine record, no generated URL.
+
+## 8. Rollback cost
+
+Low and local. One file's behavior plus a moved helper; no data migration, no config, no persisted
+schema. Reverting restores the prior behavior exactly — including the defect. A round left in
+`pending` by an `unverifiable` outcome is a normal pending round; nothing to repair.
+
+## Refusals demonstrated (command + output)
+
+Falsification 1 — neutralise the evidence predicate (`ids.filter(() => false && …)`):
+
+```
+× an item that RECORDS a merge commit but cannot be checked → no respawn, and NO round verdict
+× child exits 0 but the shortfall is entirely uncheckable → unverifiable, NOT partially-complete
+  Tests  2 failed | 8 passed (10)
+```
+
+Falsification 2 — re-introduce a default returning an unconditional empty verdict:
+
+```
+× the seam cannot default to silence again > has no default verifier that returns an unconditional empty set
+  Tests  1 failed | 9 passed (10)
+```
+
+Restored: `Tests 36 passed (36)` across the four affected files, `tsc --noEmit` exit 0.
+
+Falsification 3 — **a guard I did not anticipate, which changed the code.** The full suite failed on
+`lint-sync-subprocess-chokepoint`:
+
+```
+src/core/ProjectRoundExecution.ts:569 — raw sync spawn (execFileSync('gh', …)).
+A sync blocking op must funnel through withSyncOp() so the in-flight marker sees it.
+lint-sync-subprocess-chokepoint: 1 new violation(s).
+```
+
+In `routes.ts` that callsite sat on the lint's **frozen baseline** — grandfathered, not blessed.
+Moving it into core made it a NEW violation. The refusal is the useful part: `runRound` is called
+from the server's auto-advance poller, so a blocking `gh repo view` there stalls the event loop.
+Now funnelled through `withSyncOp` so the in-flight marker classes the stall instead of it
+presenting as an unexplained freeze. Lint after: `clean — 97 raw sync spawn(s), all grandfathered
+(142 baselined)`.
+
+Worth noting the lint is a deliberately **lexical, same-line** matcher (`/\bwithSyncOp\s*\(/`) and
+says so in its own header — it cannot prove runtime wrapping, which is the marker's unit test's job.
+My first wrap was semantically correct across three lines and still flagged. That is signal-vs-
+authority working as designed: a cheap check that names a hazard, not a proof.
+
+## Known-failing locally, verified NOT caused by this change
+
+`tests/e2e/dev-preflight-cli.test.ts` fails in this worktree. The cause is inside preflight's lint
+step, which shells out to `pnpm install`; reproduced standalone:
+
+```
+pnpm install → PNPM_EXIT=1
+[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: baileys, better-sqlite3, esbuild, sharp, …
+```
+
+That is a dependency build-script approval issue in a worktree installed with `npm ci`, naming only
+third-party packages and reading none of the changed files. Not run to completion deliberately —
+`pnpm install` would restructure the `node_modules` the 36 passing tests were validated against. CI
+installs the project its own way and is the arbiter; flagged here rather than quietly omitted.


### PR DESCRIPTION
## ELI16 — a finished round can now be recorded as finished

The part that checks "is this work actually merged?" was a placeholder that always answered
"nothing is merged" — so a round could never be marked done, and asking it to run again would
start a fresh session to redo work that was already finished.

**What was there.** Projects here are organised into *rounds* — a batch of items worked together.
A supervisor loops: check whether every item has landed; if not, start a session; when that
session exits, check again. That check had a seam so tests could substitute a fake, and its
default read, in full: *"Best-effort no-op default — production callers should pass a real one."*
No production caller ever did.

**Why an empty answer is worse than an error.** An empty answer means "I verified nothing." To the
code receiving it, that is indistinguishable from "nothing is merged." Nothing crashed. Nothing
logged. It just quietly always said no. So a round whose items were all merged still started a
session to redo them, "complete" became unreachable, and a project could honestly report
**"0 of 5 done"** while its items sat merged and verified. That is exactly what this project was
reporting when the defect was found.

**What changed.** The placeholder is deleted, and the seam now defaults to the real checker — so a
caller cannot forget. The failure mode of forgetting is now "it works", instead of "it silently
always says no". The answer also gained a third state: *verified* (it landed), *regressed* (git
said definitively no), *unverifiable* (the check could not run).

**The interesting part — two very different "I don't know"s.** "Could not check" arrives in two
situations that look identical in the data and mean opposite things. An item recording *no merge
commit at all* simply hasn't landed yet — ordinary on a fresh round, and the right move is to start
the session. An item that *records a merge commit* but which git couldn't confirm may already be
done, and starting a session would redo it. Read the first as unknown and every new round stalls
forever; read the second as not-done and you're back to redoing finished work. They're separated by
**evidence** — does the item record a merge commit? — and deliberately not by reading the
explanation text, because then rewording a message would silently change what the system does.

When the second case happens the runner **refuses in both directions**: it does not start a session,
and it records no verdict at all. Saying "failed" or "partly done" would state a conclusion nothing
established.

**What this does not do.** It does not make rounds run on a schedule, and it does not change what a
session does once started. It makes a finished round recordable as finished, and makes an
unanswerable check say so instead of guessing.

## What was broken

`runRound`'s `verifyMergedItems` seam defaulted to a no-op returning an **empty set**, documented in place as *"production callers should pass a real one"*. No production caller ever did — `src/commands/server.ts:17657` passes `{tracker, projectId, roundIndex, targetRepoPath}` and nothing else.

An empty answer means **"I verified nothing"**, which is indistinguishable to the caller from **"nothing is merged"**. Nothing crashed, nothing logged. Consequences, all read from the code:

- the all-items-merged stop condition could never be true, so a round whose items were **all merged still spawned a child to redo them**;
- `outcome: 'complete'` was unreachable, so `RoundStatus 'complete'` was never written by the poller path;
- and since the session-start digest counts only `complete`/`complete-with-skips`, a project could report **"0 of 5 done"** with its items merged and verified.

Observed live on `convergence-towards-coherence`: items 1, 2 and 3 at `pipelineStage: merged` (item 3 verified against merge commit `3443efd1d`) while the digest read `0 of 5 done`.

## What changed

**The no-op default is deleted**, not the call site patched. The seam now defaults to the real `verifyMergedItemsViaGit`, so a caller *cannot* forget — forgetting yields working behaviour instead of silent always-no. Verified first that the default protected nothing: 8 `runRound` calls in the only test file, 8 injections, zero real consumers.

The seam carries the three-state `MergedVerificationResult`, and a new `unverifiable` outcome records **no** round status.

## The distinction that carries the change

`verifyMergedItemsViaGit` reports `unverifiable` for two situations that look identical in the data and mean opposite things:

| Case | Meaning | Right move |
| --- | --- | --- |
| no `mergeCommitOid` recorded | nothing has landed yet — ordinary on a fresh round | spawn the child |
| records a merge commit, git could not answer | work may already be done | do **not** respawn, record no verdict |

Read the first as unknown and **every fresh round deadlocks forever** — strictly worse than the bug being fixed. Read the second as not-done and you are back to redoing finished work.

They are split on **evidence** (does the item record a merge commit?), never on the reason text, so rewording a message cannot change control flow. The predicate is defined once and used at *both* decision points — the first draft applied it at the pre-spawn check only and the post-exit check kept the old conflation, which the fresh-round test caught.

## Refusals proven (falsification)

Neutralising the evidence predicate:
```
× an item that RECORDS a merge commit but cannot be checked → no respawn, and NO round verdict
× child exits 0 but the shortfall is entirely uncheckable → unverifiable, NOT partially-complete
  Tests  2 failed | 8 passed (10)
```

Re-introducing a default that returns an unconditional empty verdict:
```
× the seam cannot default to silence again > has no default verifier returning an unconditional empty set
  Tests  1 failed | 9 passed (10)
```

Restored: **36/36** across the four affected files, `tsc --noEmit` exit 0.

## A guard bit and changed the code

Moving `resolveCanonicalMainRef` from `routes.ts` into core (both consumers need it; core must not import from `server/`) turned a **grandfathered** `execFileSync('gh', …)` into a **new** chokepoint violation. `runRound` is called from the server's auto-advance poller, so a blocking `gh repo view` there stalls the event loop — the lint stopped a pre-existing hazard from spreading. Now funnelled through `withSyncOp` (the `MachineSshIdentity` precedent): `clean — 97 raw sync spawn(s), all grandfathered (142 baselined)`.

## Known limits

Verification is still merge-base reachability of a recorded commit — an item merged with red CI verifies. Nothing here schedules rounds; it makes a run able to conclude. `resolveCanonicalMainRef` stays best-effort: without `gh` it falls back to `origin/main`, which on a fork-origin home under-verifies **toward spawning** rather than toward a false complete.

## Tier

Tier 1, riskFloor 1 — `suggestedTier=2 (size=2, riskFloor=1, 259 LOC across 2 files)` → `OK (Tier 1)`. Not an override.

Closes ACT-1319.
