### PR TITLE
feat(channels): whether I can reach you, not whether I'm configured to

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T05-57-42-647Z-user-channel-liveness.json
+++ b/.instar/instar-dev-decisions/2026-07-27T05-57-42-647Z-user-channel-liveness.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T05:57:42.647Z",
+  "slug": "user-channel-liveness",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 242,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/user-channel-liveness.eli16.md
+++ b/docs/specs/user-channel-liveness.eli16.md
@@ -1,0 +1,88 @@
+# I can now tell whether I can actually reach you — not just whether I'm set up to
+
+## The one-sentence version
+
+Asked "can you reach the operator right now?", the only answer available was a config file saying
+"yes, Telegram is set up" — which stays "yes" long after the connection has died.
+
+## What was already there
+
+A channel registry landed the night before this change. It answers "which ways of reaching another
+**agent** work right now?" with real probes, and it is good: it reports four peer channels, including
+one that is only half-built (it can receive but its send half has no caller), and one that refuses to
+overstate itself — *"confirms initialisation, not a completed round-trip to a peer."*
+
+Its own header states a deliberate scope: **peer-to-peer only**. That was the right call for a peer
+registry. It also meant the channels that carry messages to a *person* were not covered at all.
+
+## The gap
+
+For the user channels, the only thing that could be asked was `/capabilities`, which answers:
+
+```
+telegram: { configured: true, adapter: true, bidirectional: true }
+```
+
+Every one of those is read from configuration. None of them is a measurement. If Telegram's polling
+loop died on a rejected token four hours ago, all three are still `true`, because the config file
+still says the bot is set up.
+
+That is the same failure the peer registry was built to prevent — **a setting mistaken for a state** —
+relocated onto the channel that matters most, because it is the one carrying messages to a human.
+
+## What changed
+
+The two direct user channels, Telegram and Slack, now sit in the same registry, and their liveness
+comes from **live runtime state**:
+
+| Reads | Means |
+| --- | --- |
+| Telegram's `started` | is the poll loop running *right now* |
+| Telegram's `fatalReason` | *why* it stopped: rejected credential vs dropped network |
+| Slack's `isConnected()` | is the socket up *right now* |
+
+The verdicts distinguish things a yes/no cannot:
+
+- **rejected token** → "reachable, but holds no credential it will accept" — Telegram answered; it
+  said no. Restarting won't help; the token needs replacing.
+- **network death** → "broken" — a different problem with a different fix.
+- **stopped for no recorded reason** → **"unknown"**, explicitly *not* healthy and *not* a confident
+  "broken". Nothing here can tell a deliberate stop from a silent death, so it says so.
+- **no adapter at all** → "not configured". Off is not broken.
+
+## The trap that took the most care
+
+Slack's adapter has two flags that look interchangeable and are not. Its own source annotates one of
+them: `started` means **"ever connected."** The other, `_connected`, is cleared the moment the socket
+drops.
+
+A workspace that connected once at boot and died an hour later has `started === true` forever. Using
+it for liveness would report a dead channel as healthy — the exact bug being fixed, reintroduced
+inside the fix. The probe uses `isConnected()`, and a test fails if anyone changes it back.
+
+## Why both live in one registry instead of two
+
+"Which channel should I use?" is one question. Splitting the answer across two surfaces would mean a
+caller had to already know which list to consult — which is the arbitrariness the registry was built
+to remove. So the audience is recorded as a field on each channel rather than as two separate
+registries.
+
+It also matters that both are visible at once, because choosing between them is a real trade-off:
+reaching a peer costs latency, reaching the operator costs their attention. You cannot weigh that if
+you can only see one side.
+
+## The part that is a judgement, not a measurement
+
+Each channel records *when it is the right choice*. For the user channels that is not just "when the
+message is for the operator" — it is that a user channel is the **only surface that shows what the
+user genuinely experiences.** No internal log or proxy shows the real thing, so deliberately using it
+is a legitimate reason to choose it, not merely a cost to avoid.
+
+The cost is recorded just as plainly: operator attention is the scarcest resource here, and every
+automated message competes with the ones that matter.
+
+## What this does not do
+
+It does not send anything, change any routing, or make any channel more reliable. It reports. A
+channel reported `working` was polling when asked — that is a live reading, not a promise about the
+next second.

--- a/src/core/channelRegistry.ts
+++ b/src/core/channelRegistry.ts
@@ -58,8 +58,25 @@ export type ChannelState =
 /** Which direction(s) a channel can actually carry traffic — the half-built case made explicit. */
 export type ChannelDirection = 'bidirectional' | 'send-only' | 'receive-only' | 'none';
 
+/**
+ * Who is on the other end. This exists because "which channel should I use?" is ONE question with
+ * two very different answers, and splitting it across two surfaces recreates the arbitrariness this
+ * registry was built to remove — a caller would have to already know which list to consult.
+ *
+ * The distinction is kept as DATA rather than as two registries because the choice between them is
+ * itself a routing decision: reaching a peer costs latency, reaching the operator costs their
+ * attention. A caller cannot weigh that trade-off if it can only see one side of it.
+ */
+export type ChannelAudience =
+  /** Another agent. */
+  | 'peer'
+  /** A human operator, on the surface they actually read. */
+  | 'user';
+
 export interface ChannelDefinition {
   id: string;
+  /** Who is on the other end — see ChannelAudience for why this is data, not two registries. */
+  audience: ChannelAudience;
   /** What it is for, in the operator's terms. */
   purpose: string;
   /** When this channel is the right choice over the others. */
@@ -82,6 +99,7 @@ export interface ChannelProbeResult {
 
 export interface ChannelReport extends ChannelProbeResult {
   id: string;
+  audience: ChannelAudience;
   purpose: string;
   whenPreferred: string;
   cost: string;
@@ -125,7 +143,13 @@ export async function resolveChannels(
 ): Promise<ChannelRegistryReport> {
   const channels = await Promise.all(
     definitions.map(async (def): Promise<ChannelReport> => {
-      const base = { id: def.id, purpose: def.purpose, whenPreferred: def.whenPreferred, cost: def.cost };
+      const base = {
+        id: def.id,
+        audience: def.audience,
+        purpose: def.purpose,
+        whenPreferred: def.whenPreferred,
+        cost: def.cost,
+      };
       try {
         const result = await withTimeout(def.probe());
         // A probe returning a shape we do not recognise is a failed probe, not a healthy channel.

--- a/src/core/instarChannels.ts
+++ b/src/core/instarChannels.ts
@@ -39,6 +39,7 @@ export function buildChannelDefinitions(ctx: ChannelProbeContext): ChannelDefini
   return [
     {
       id: 'threadline-relay',
+      audience: 'peer',
       purpose: 'Direct agent-to-agent messaging over the shared relay.',
       whenPreferred: 'The default for peer work: fastest, and invisible to the operator, so it does not spend their attention.',
       cost: 'Requires the relay to be connected. Invisible when it fails, which is its main hazard.',
@@ -58,6 +59,7 @@ export function buildChannelDefinitions(ctx: ChannelProbeContext): ChannelDefini
     },
     {
       id: 'a2a-telegram',
+      audience: 'peer',
       purpose: 'Agent-to-agent messages carried over the operator-visible Telegram channel, with a marker and anti-loop machinery.',
       whenPreferred: 'When the exchange should be reviewable by the operator, or as a fallback the relay cannot provide — ONCE its sender is wired.',
       cost: 'Consumes operator attention; slower; the conversation is visible.',
@@ -67,6 +69,7 @@ export function buildChannelDefinitions(ctx: ChannelProbeContext): ChannelDefini
     },
     {
       id: 'mutual-ssh',
+      audience: 'peer',
       purpose: 'Machine-to-machine execution between paired hosts over a restricted SSH endpoint.',
       whenPreferred: 'Peer work that needs to run ON the other machine rather than be asked for.',
       cost: 'Requires paired keys and a listening endpoint; heaviest of the three to set up.',
@@ -89,6 +92,7 @@ export function buildChannelDefinitions(ctx: ChannelProbeContext): ChannelDefini
     },
     {
       id: 'peer-http',
+      audience: 'peer',
       purpose: "Direct HTTP to a peer agent's own server on this machine.",
       whenPreferred: 'Last resort when the relay is down and the peer is co-located.',
       cost: 'Needs a credential for the peer\'s authenticated routes; on-box only.',

--- a/src/core/userChannels.ts
+++ b/src/core/userChannels.ts
@@ -1,0 +1,185 @@
+/**
+ * The DIRECT USER channels — the surfaces a human operator actually reads — wired into the same
+ * channel registry as the peer channels.
+ *
+ * WHY THIS EXISTS (2026-07-27, topic 29723). The peer registry answered "which ways of reaching a
+ * PEER work right now?". Asked the same question about the operator, the only available answer was
+ * `/capabilities` reporting `telegram: { configured: true }`. That is a SETTING, not a STATE: a
+ * Telegram whose polling loop died on a 401 four hours ago still reports `configured: true`, because
+ * the config file still says so. Reaching for that number during an outage would produce exactly the
+ * false confidence the peer registry was built to prevent — one layer over, on the channel that
+ * matters most, because it is the one carrying messages to a person.
+ *
+ * So every probe here reads LIVE RUNTIME STATE and never configuration:
+ *
+ *   - Telegram exposes `getStatus()`, whose `started` field is `this.polling` — whether the loop is
+ *     running NOW — plus `fatalReason` distinguishing a rejected credential from a dropped network.
+ *     A comment on its `lastPollError` field says it is kept "so health probes can explain WHY
+ *     polling stopped". That consumer was never built. This is it.
+ *
+ *   - Slack exposes `isConnected()`, which returns `_connected` — cleared on disconnect. It
+ *     deliberately does NOT return `started`, which its own source annotates as "ever connected".
+ *     `started` is the trap: a workspace that connected once at boot and dropped an hour later
+ *     reports `started === true` forever. Liveness must come from the field that clears.
+ *
+ * ── THE ROUTING JUDGEMENT THIS ENCODES ─────────────────────────────────────────────────────────
+ *
+ * `whenPreferred` for a user channel is not merely "when the message is for the operator". A user
+ * channel is the ONLY surface that shows what the user genuinely experiences — a proxy cannot. That
+ * makes deliberately using it a legitimate REASON to choose it, not just a cost to be minimised.
+ * The constitution's "Live-User-Channel Proof Before Done" standard rests on exactly this, and the
+ * cost side is real and opposite: operator attention is finite and every automated message competes
+ * with the ones that matter. Both halves are recorded so a caller can weigh them.
+ */
+
+import type { ChannelDefinition, ChannelProbeResult } from './channelRegistry.js';
+
+/**
+ * Live Telegram adapter state. Mirrors the subset of `TelegramAdapter.getStatus()` this needs.
+ * `null` means the adapter was never constructed on this agent — which is `not-configured`, a
+ * distinct verdict from broken, and must never be an omitted row.
+ */
+export interface TelegramLiveStatus {
+  /** `this.polling` — whether the long-poll loop is running RIGHT NOW. Not "was ever started". */
+  started: boolean;
+  /** Why polling stopped, when it stopped for a reason the adapter could classify. */
+  fatalReason: '401' | 'network' | 'no-usable-bot-token' | null;
+  /** Consecutive poll errors. Non-zero while still polling is degraded-but-working, not broken. */
+  consecutivePollErrors: number;
+  /** Last poll error text, if any. */
+  lastError: string | null;
+  /** ISO instant polling stopped, when it has. */
+  stoppedAt: string | null;
+}
+
+export interface UserChannelProbeContext {
+  /** Live Telegram state, or null when the adapter was never constructed here. */
+  telegramStatus: () => TelegramLiveStatus | null;
+  /**
+   * Whether the Slack socket is up RIGHT NOW (`isConnected()`), or null when no Slack adapter was
+   * constructed. Deliberately not `started` — see the module docstring.
+   */
+  slackConnected: () => boolean | null;
+  /** Whether Slack is switched on for this agent at all. Off is not broken. */
+  slackEnabled: () => boolean;
+}
+
+/**
+ * Map live Telegram state onto the registry's vocabulary.
+ *
+ * Extracted and exported so the mapping is testable WITHOUT constructing an adapter — the mapping is
+ * where a wrong verdict would come from, so it is the part that must be pinned.
+ */
+export function telegramStateFrom(status: TelegramLiveStatus | null): ChannelProbeResult {
+  if (status === null) {
+    return {
+      state: 'not-configured',
+      direction: 'none',
+      detail: 'no Telegram adapter was constructed on this agent',
+    };
+  }
+
+  if (status.started) {
+    // Still polling. Transient errors do not make it unusable, but hiding them would overstate it.
+    const detail =
+      status.consecutivePollErrors > 0
+        ? `polling now, with ${status.consecutivePollErrors} consecutive poll error(s) — usable but degraded` +
+          (status.lastError ? `; last: ${status.lastError.slice(0, 120)}` : '')
+        : 'polling now with no consecutive errors';
+    return { state: 'working', direction: 'bidirectional', detail };
+  }
+
+  // Not polling. WHY it stopped changes what the operator should do about it, so it is not collapsed.
+  if (status.fatalReason === '401' || status.fatalReason === 'no-usable-bot-token') {
+    return {
+      state: 'reachable-no-credential',
+      direction: 'none',
+      detail:
+        status.fatalReason === '401'
+          ? 'Telegram answered and REJECTED the bot token (401); the endpoint is reachable but this ' +
+            'agent holds no credential it will accept'
+          : 'no usable bot token is available, so polling never started',
+    };
+  }
+  if (status.fatalReason === 'network') {
+    return {
+      state: 'broken',
+      direction: 'none',
+      detail:
+        'polling stopped on a network failure' +
+        (status.stoppedAt ? ` at ${status.stoppedAt}` : '') +
+        (status.lastError ? `; last: ${status.lastError.slice(0, 120)}` : ''),
+    };
+  }
+
+  // Stopped, with no reason the adapter could classify. That is genuinely undetermined: it may have
+  // been stopped deliberately or have died silently, and this cannot tell which. `unknown` is the
+  // honest verdict and is NEVER a synonym for healthy.
+  return {
+    state: 'unknown',
+    direction: 'none',
+    detail:
+      'the Telegram poll loop is not running and the adapter recorded no reason' +
+      (status.stoppedAt ? ` (stopped at ${status.stoppedAt})` : '') +
+      '; cannot tell a deliberate stop from a silent death',
+  };
+}
+
+/** Map live Slack state onto the registry's vocabulary. Exported for the same reason as above. */
+export function slackStateFrom(enabled: boolean, connected: boolean | null): ChannelProbeResult {
+  if (!enabled) {
+    return { state: 'not-configured', direction: 'none', detail: 'Slack is not enabled on this agent' };
+  }
+  if (connected === null) {
+    return {
+      state: 'unknown',
+      direction: 'none',
+      detail:
+        'Slack is enabled in config but no adapter was constructed, so its liveness cannot be read; ' +
+        'enabled-but-absent is not the same as working',
+    };
+  }
+  if (connected) {
+    return {
+      state: 'working',
+      direction: 'bidirectional',
+      detail: 'Socket Mode reports connected right now (this flag clears on disconnect)',
+    };
+  }
+  return {
+    state: 'broken',
+    direction: 'none',
+    detail: 'Slack is enabled but its Socket Mode connection is down right now',
+  };
+}
+
+export function buildUserChannelDefinitions(ctx: UserChannelProbeContext): ChannelDefinition[] {
+  return [
+    {
+      id: 'user-telegram',
+      audience: 'user',
+      purpose: "The operator's own Telegram — the surface they actually read.",
+      whenPreferred:
+        'When the message is FOR the operator. Also the deliberate choice when the point is to see ' +
+        'what the user genuinely experiences: no proxy or internal log shows the real thing, so ' +
+        'this is the only channel that can prove a user-facing change actually works.',
+      cost:
+        "Spends the operator's attention, which is the scarcest resource here — every automated " +
+        'message competes with the ones that matter. Visible and permanent.',
+      probe: async (): Promise<ChannelProbeResult> => telegramStateFrom(ctx.telegramStatus()),
+    },
+    {
+      id: 'user-slack',
+      audience: 'user',
+      purpose: 'A Slack workspace the operator reads, over Socket Mode.',
+      whenPreferred:
+        'When the operator works in Slack rather than Telegram, or when the exchange belongs where ' +
+        'their team can see it. Same user-experience-proof property as Telegram.',
+      cost:
+        "Spends the operator's attention, and is visible to anyone else in the channel — so it is " +
+        'the wrong surface for anything they would not want their workspace to see.',
+      probe: async (): Promise<ChannelProbeResult> =>
+        slackStateFrom(ctx.slackEnabled(), ctx.slackConnected()),
+    },
+  ];
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -337,6 +337,7 @@ import type { HandshakeManager } from '../threadline/HandshakeManager.js';
 import { createThreadlineRoutes } from '../threadline/ThreadlineEndpoints.js';
 import { resolveChannels } from '../core/channelRegistry.js';
 import { buildChannelDefinitions } from '../core/instarChannels.js';
+import { buildUserChannelDefinitions } from '../core/userChannels.js';
 import { evaluateSendGate, negotiatorLogDir } from '../threadline/NegotiatorGate.js';
 import { recordInboundAck } from '../threadline/recordInboundAck.js';
 import { recordThreadMessage } from '../threadline/recordThreadMessage.js';
@@ -30125,7 +30126,31 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
           detail: 'no peer HTTP endpoint configured for this agent',
         }),
       });
-      const report = await resolveChannels(defs);
+      // The DIRECT USER channels ride the same registry rather than a second surface: "which channel
+      // should I use?" is one question, and splitting the answer would force a caller to already know
+      // which list to consult. Every probe below reads LIVE adapter state — never config, because
+      // `configured: true` survives the connection dying (see src/core/userChannels.ts).
+      const telegramAdapter = ctx.telegram;
+      const slackAdapter = ctx.slack;
+      const userDefs = buildUserChannelDefinitions({
+        telegramStatus: () => {
+          if (!telegramAdapter || typeof telegramAdapter.getStatus !== 'function') return null;
+          const s = telegramAdapter.getStatus();
+          return {
+            started: s.started,
+            fatalReason: s.fatalReason,
+            consecutivePollErrors: s.consecutivePollErrors,
+            lastError: s.lastError,
+            stoppedAt: s.stoppedAt,
+          };
+        },
+        // `isConnected()` clears on disconnect; `started` means "ever connected" and would report a
+        // long-dead socket as healthy forever.
+        slackConnected: () =>
+          slackAdapter && typeof slackAdapter.isConnected === 'function' ? slackAdapter.isConnected() : null,
+        slackEnabled: () => Boolean(slackAdapter),
+      });
+      const report = await resolveChannels([...defs, ...userDefs]);
       return res.status(200).json({ advisory: true, ...report });
     } catch (error) {
       // A registry that 500s teaches nothing. Report the failure as the registry's own verdict.

--- a/tests/integration/channels-route.test.ts
+++ b/tests/integration/channels-route.test.ts
@@ -71,8 +71,29 @@ describe('GET /channels (integration — the wiring, not just the resolver)', ()
 
     expect(res.status).toBe(200);
     expect(res.body.channels.map((c: { id: string }) => c.id).sort())
-      .toEqual(['a2a-telegram', 'mutual-ssh', 'peer-http', 'threadline-relay']);
-    expect(res.body.summary.total).toBe(4);
+      .toEqual(['a2a-telegram', 'mutual-ssh', 'peer-http', 'threadline-relay', 'user-slack', 'user-telegram']);
+    expect(res.body.summary.total).toBe(6);
+  });
+
+  /**
+   * Pins the AUDIENCE PARTITION, not just the count.
+   *
+   * The test above is satisfied by any six ids. Without this one, a change that dropped the user
+   * channels would be "fixed" by editing the list back down to four — the same edit that hides the
+   * loss. Asserting BOTH audiences are present means removing a whole audience fails as a removal
+   * rather than as an arithmetic disagreement.
+   */
+  it('REGRESSION: both audiences are served — peer channels AND the operator-facing ones', async () => {
+    const res = await request(mount(tmpDir)).get('/channels').set('Authorization', `Bearer ${AUTH}`);
+
+    const byAudience = (a: string) =>
+      res.body.channels.filter((c: { audience: string }) => c.audience === a)
+        .map((c: { id: string }) => c.id).sort();
+
+    expect(byAudience('peer')).toEqual(['a2a-telegram', 'mutual-ssh', 'peer-http', 'threadline-relay']);
+    expect(byAudience('user')).toEqual(['user-slack', 'user-telegram']);
+    // Every row must declare one; an untagged channel is not a third state, it is a bug.
+    for (const c of res.body.channels) expect(['peer', 'user']).toContain(c.audience);
   });
 
   it('every row carries purpose, when-preferred, cost and evidence — the operator-facing columns', async () => {

--- a/tests/unit/user-channel-liveness.test.ts
+++ b/tests/unit/user-channel-liveness.test.ts
@@ -1,0 +1,190 @@
+/**
+ * The user channels report LIVENESS, not configuration.
+ *
+ * The defect these pin: `/capabilities` answers `telegram: { configured: true }` — which stays true
+ * after the poll loop dies, because the config file still says so. Every test below is written so
+ * that a probe which fell back to reading configuration would FAIL it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  buildUserChannelDefinitions,
+  telegramStateFrom,
+  slackStateFrom,
+  type TelegramLiveStatus,
+} from '../../src/core/userChannels.js';
+import { resolveChannels, type ChannelDefinition } from '../../src/core/channelRegistry.js';
+import { buildChannelDefinitions } from '../../src/core/instarChannels.js';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+
+/** A Telegram that is polling happily. */
+const healthy: TelegramLiveStatus = {
+  started: true,
+  fatalReason: null,
+  consecutivePollErrors: 0,
+  lastError: null,
+  stoppedAt: null,
+};
+
+describe('user channel liveness — the refusals', () => {
+  it('THE FIX: a configured-but-DEAD Telegram is never reported as working', () => {
+    // This is the whole point. Config still says the bot is set up; the loop is dead.
+    const dead: TelegramLiveStatus = {
+      started: false,
+      fatalReason: '401',
+      consecutivePollErrors: 7,
+      lastError: 'Unauthorized',
+      stoppedAt: '2026-07-27T05:00:00.000Z',
+    };
+    const r = telegramStateFrom(dead);
+    expect(r.state).not.toBe('working');
+    expect(r.direction).not.toBe('bidirectional');
+    // And it names WHY, because "broken" alone does not tell the operator what to do.
+    expect(r.state).toBe('reachable-no-credential');
+    expect(r.detail).toMatch(/401|reject/i);
+  });
+
+  it('a missing bot token is a credential verdict, not a network one', () => {
+    const r = telegramStateFrom({ ...healthy, started: false, fatalReason: 'no-usable-bot-token' });
+    expect(r.state).toBe('reachable-no-credential');
+  });
+
+  it('a network death is broken — distinct from a credential problem', () => {
+    const r = telegramStateFrom({
+      ...healthy,
+      started: false,
+      fatalReason: 'network',
+      lastError: 'ETIMEDOUT',
+      stoppedAt: '2026-07-27T05:00:00.000Z',
+    });
+    expect(r.state).toBe('broken');
+    expect(r.detail).toMatch(/network/i);
+  });
+
+  it('stopped for NO recorded reason is unknown — never working, never a confident broken', () => {
+    // The adapter cannot tell a deliberate stop from a silent death. Saying either would be a claim
+    // nothing established.
+    const r = telegramStateFrom({ ...healthy, started: false, fatalReason: null, stoppedAt: null });
+    expect(r.state).toBe('unknown');
+    expect(r.state).not.toBe('working');
+    expect(r.detail).toMatch(/cannot tell/i);
+  });
+
+  it('an absent adapter is not-configured — off is not broken', () => {
+    const r = telegramStateFrom(null);
+    expect(r.state).toBe('not-configured');
+  });
+
+  it('still polling WITH transient errors is working-but-degraded, and says so', () => {
+    const r = telegramStateFrom({ ...healthy, consecutivePollErrors: 3, lastError: 'ECONNRESET' });
+    expect(r.state).toBe('working');
+    expect(r.detail).toMatch(/degraded/i);
+    expect(r.detail).toMatch(/3/);
+  });
+
+  it('a clean poll loop is working', () => {
+    expect(telegramStateFrom(healthy).state).toBe('working');
+  });
+});
+
+describe('slack liveness uses the flag that CLEARS on disconnect', () => {
+  it('a live socket is working', () => {
+    expect(slackStateFrom(true, true).state).toBe('working');
+  });
+
+  it('THE TRAP: enabled with the socket DOWN is broken, not working', () => {
+    // `started` on the adapter means "ever connected" and would still be true here. Reading it
+    // instead of `isConnected()` would report a long-dead workspace as healthy forever.
+    const r = slackStateFrom(true, false);
+    expect(r.state).toBe('broken');
+    expect(r.direction).toBe('none');
+  });
+
+  it('enabled but no adapter constructed is unknown — enabled is not working', () => {
+    const r = slackStateFrom(true, null);
+    expect(r.state).toBe('unknown');
+    expect(r.detail).toMatch(/not the same as working/i);
+  });
+
+  it('not enabled is not-configured', () => {
+    expect(slackStateFrom(false, null).state).toBe('not-configured');
+  });
+});
+
+describe('registry integration — absence stays impossible', () => {
+  const ctx = {
+    telegramStatus: () => healthy,
+    slackConnected: () => true,
+    slackEnabled: () => true,
+  };
+
+  it('user channels are tagged user, peer channels stay tagged peer, in ONE report', async () => {
+    const peerDefs = buildChannelDefinitions({
+      relayStatus: () => null,
+      mutualSshConstructed: () => false,
+      mutualSshEnabled: () => false,
+      peerHttp: async () => ({ reachable: false, haveCredential: false, detail: 'none' }),
+    });
+    const report = await resolveChannels([...peerDefs, ...buildUserChannelDefinitions(ctx)]);
+
+    const audiences = new Map(report.channels.map((c) => [c.id, c.audience]));
+    expect(audiences.get('threadline-relay')).toBe('peer');
+    expect(audiences.get('user-telegram')).toBe('user');
+    expect(audiences.get('user-slack')).toBe('user');
+    // One question, one surface: both audiences present in the same report.
+    expect(new Set(report.channels.map((c) => c.audience))).toEqual(new Set(['peer', 'user']));
+  });
+
+  it('a THROWING user probe still yields a row, reported unknown — never an omission', async () => {
+    const exploding: ChannelDefinition = {
+      id: 'user-telegram',
+      audience: 'user',
+      purpose: 'p',
+      whenPreferred: 'w',
+      cost: 'c',
+      probe: async () => {
+        throw new Error('adapter exploded');
+      },
+    };
+    const report = await resolveChannels([exploding]);
+    expect(report.channels).toHaveLength(1);
+    expect(report.channels[0].state).toBe('unknown');
+    expect(report.channels[0].probeFailed).toBe(true);
+    // The invariant that makes the registry trustworthy: a failure cannot remove itself from view.
+    expect(report.summary.total).toBe(1);
+    expect(report.summary.working).toBe(0);
+  });
+
+  it('every user channel carries the user-experience rationale, not just a cost', () => {
+    // Justin's point: a user channel is the only surface that shows what the user actually sees.
+    // If someone rewrites these to be cost-only, the routing judgement is lost and this fails.
+    for (const def of buildUserChannelDefinitions(ctx)) {
+      expect(def.whenPreferred.length).toBeGreaterThan(40);
+      expect(def.cost).toMatch(/attention/i);
+    }
+    const tg = buildUserChannelDefinitions(ctx).find((d) => d.id === 'user-telegram')!;
+    expect(tg.whenPreferred).toMatch(/what the user genuinely experiences|proxy/i);
+  });
+});
+
+describe('source ratchet — the probes must not drift back to reading config', () => {
+  it('userChannels.ts never consults configuration for liveness', () => {
+    const src = readFileSync(join(REPO_ROOT, 'src', 'core', 'userChannels.ts'), 'utf-8');
+    // `configured` is the exact word whose truthiness caused the defect. It may appear in prose
+    // explaining the trap, but never as a property read.
+    expect(src).not.toMatch(/\.configured\b/);
+    expect(src).not.toMatch(/config\.\w/);
+  });
+
+  it('the route reads isConnected() for Slack, never started', () => {
+    const src = readFileSync(join(REPO_ROOT, 'src', 'server', 'routes.ts'), 'utf-8');
+    const wiring = src.slice(src.indexOf('buildUserChannelDefinitions({'));
+    const block = wiring.slice(0, wiring.indexOf('resolveChannels'));
+    expect(block).toMatch(/isConnected\(\)/);
+    // `slackAdapter.started` would be the "ever connected" trap.
+    expect(block).not.toMatch(/slackAdapter\.started/);
+  });
+});

--- a/upgrades/next/user-channel-liveness.md
+++ b/upgrades/next/user-channel-liveness.md
@@ -1,0 +1,74 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The channel registry answered "which ways of reaching a PEER work right now?" with real probes. Asked
+the same question about the *operator*, the only available answer was `/capabilities` reporting
+`telegram: { configured: true, adapter: true, bidirectional: true }` — three values read from
+configuration, none of them a measurement. A Telegram whose poll loop died on a rejected token hours
+ago still reports all three as `true`.
+
+The two direct user channels now sit in the same registry, with liveness read from live adapter
+state: Telegram's `started` (is the loop polling *now*) and `fatalReason` (rejected credential vs
+dropped network), and Slack's `isConnected()`. Every channel row gains an `audience` field of `peer`
+or `user`, so one surface answers the whole "which channel should I use?" question instead of two.
+
+## Evidence
+
+The verdicts distinguish cases a boolean cannot: a rejected token reports
+`reachable-no-credential` ("Telegram answered and REJECTED the bot token") rather than a generic
+failure; a network death reports `broken`; a loop stopped with no recorded reason reports `unknown`
+with "cannot tell a deliberate stop from a silent death" — explicitly not healthy and not a confident
+broken; and no adapter at all reports `not-configured`, because off is not broken.
+
+Refusals, by falsification. Making the Telegram probe read existence instead of liveness — precisely
+what the configuration reading does:
+
+```
+× THE FIX: a configured-but-DEAD Telegram is never reported as working
+× a missing bot token is a credential verdict, not a network one
+× a network death is broken — distinct from a credential problem
+× stopped for NO recorded reason is unknown — never working, never a confident broken
+  Tests  4 failed | 12 passed (16)
+```
+
+Giving Slack "ever connected" semantics — the trap its own source warns about, since `started` means
+"ever connected" while `isConnected()` clears on disconnect:
+
+```
+× THE TRAP: enabled with the socket DOWN is broken, not working
+```
+
+Restored: 35 passed across the three channel-registry suites; `tsc --noEmit` exit 0. Two source
+ratchets keep the probes from drifting back to configuration.
+
+## Known limits
+
+A live reading is not a promise — `working` means the loop was polling when asked, not that it will
+be a second later. Telegram `working` means the poll loop is up, not that a message to a particular
+topic would land. Slack is modelled as a single workspace. WhatsApp and iMessage adapters exist in
+the tree and are **not** covered here, so the registry makes no claim about them at all.
+
+## What to Tell Your User
+
+Your agent can now tell whether it can actually reach you, rather than only whether it was set up to.
+
+Before this, asking "are your channels working?" got an answer read from a settings file — which says
+yes just as confidently after the connection has died. Now it checks the live connection, and when
+something is wrong it says which kind of wrong: a rejected login is a different problem from a
+dropped network, and needs a different fix.
+
+It is also careful about what it does not know. If a channel stopped for a reason nothing recorded,
+it reports "unknown" rather than guessing — because a confident wrong answer during an outage is
+worse than an honest one.
+
+And each channel now records *when it is the right one to use*. For your own channels that includes
+something worth saying plainly: they cost your attention, and they are also the only place your agent
+can see what you actually see. Both of those are real, and they pull in opposite directions.
+
+## Summary of New Capabilities
+
+No new endpoint, command, or config key. `GET /channels` gains two rows for the direct user channels
+with live-state liveness, and every row gains an `audience` field marking it `peer` or `user`.

--- a/upgrades/side-effects/user-channel-liveness.md
+++ b/upgrades/side-effects/user-channel-liveness.md
@@ -1,0 +1,116 @@
+# Side-effects review — user-channel liveness in the channel registry
+
+**Change:** the two direct USER channels (Telegram, Slack) join the peer channel registry, with
+liveness probes that read live adapter state instead of configuration. `ChannelDefinition` and
+`ChannelReport` gain an `audience: 'peer' | 'user'` field.
+
+**Decision point touched:** none that blocks. This is a read surface — it informs a routing choice a
+caller makes, and holds no authority over it. `advisory: true` is already on the response.
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+Nothing is rejected; nothing is gated. The nearest analogue is reporting a *usable* channel as
+unusable, which would cause a caller to avoid a working path.
+
+One case deliberately risks that and should be named: a Telegram that is **not polling with no
+recorded reason** reports `unknown`, not `working`. If the adapter was stopped deliberately and could
+still send, this understates it. That direction is chosen on purpose — over-reporting liveness is the
+defect being fixed, and `unknown` carries its reason rather than pretending to a verdict.
+
+Transient errors do NOT downgrade a live channel: still-polling with a non-zero consecutive error
+count stays `working`, with the count named in the detail. Marking that broken would be the opposite
+over-block.
+
+## 2. Under-block — what does it still miss?
+
+- **A live reading is not a promise.** `working` means the loop was polling when asked. It can die a
+  second later. No probe can fix that; the response carries `generatedAt`.
+- **No round-trip is attempted.** Telegram `working` means the poll loop is up, not that a message to
+  a specific topic would land (a topic could be deleted, a user could have blocked the bot). The
+  peer registry's `mutual-ssh` entry already makes the same distinction in its own detail text, and
+  this follows that precedent rather than overstating.
+- **Slack is one workspace.** `isConnected()` is per-adapter; a multi-workspace setup is not modelled.
+- **Other user surfaces are absent** — WhatsApp and iMessage adapters exist in the tree. They are not
+  in this change, and the registry will therefore not claim anything about them. Under the registry's
+  own "absence is impossible" property this is a real limit: a channel with no row cannot report that
+  it is missing. Called out rather than quietly scoped away.
+
+## 3. Level-of-abstraction fit
+
+The user definitions live in a NEW file (`src/core/userChannels.ts`) rather than being added to
+`src/core/instarChannels.ts`, whose header declares an explicit "PEER-TO-PEER only" scope discipline
+and justifies two prior exclusions. Widening that file would have silently discarded a deliberate
+decision by its author.
+
+The two lists are composed at the route and resolved by the same `resolveChannels`, so the registry's
+invariants (one row per definition, bounded probes, `unknown` on failure) apply identically to both
+without being reimplemented.
+
+`audience` is data on the channel, not two registries, because the peer-vs-user choice is itself a
+routing decision a caller must be able to weigh. Two surfaces would require the caller to already
+know which to consult — the arbitrariness the registry exists to remove.
+
+## 4. Signal vs authority
+
+Pure signal. The registry reports; it never routes, blocks, or sends. The response is already flagged
+`advisory: true`. The mapping functions (`telegramStateFrom`, `slackStateFrom`) are exported and pure
+precisely so the verdict logic can be pinned by tests without constructing an adapter — the mapping
+is where a wrong verdict would originate.
+
+## 5. Interactions
+
+- **`/capabilities`** — unchanged. It keeps reporting `telegram: { configured: true }`, which remains
+  correct for what it measures (configuration). This adds the missing state reading; it does not
+  correct or replace the config reading, and the two answer different questions.
+- **Peer channels** — behaviour unchanged; they gain an `audience: 'peer'` tag. Because `audience` is
+  required on `ChannelDefinition`, a future channel cannot be added untagged: it is a compile error,
+  not a silent default.
+- **No double-fire / no races** — read-only, no writes, no timers of its own. Probes are bounded by
+  the registry's existing 3s timeout.
+
+## 6. External surfaces
+
+`GET /channels` gains two rows and every row gains an `audience` field. Additive: existing consumers
+reading `id`/`state`/`detail` are unaffected. No new route, no config key, no user-visible string.
+
+## 7. Multi-machine posture
+
+**Machine-local BY DESIGN**, `machine-local-justification: physical-credential-locality` — a Telegram
+bot token and its long-poll loop, and a Slack Socket Mode connection, live in one process on one
+machine. "Is my Telegram polling?" is only meaningful about the machine asked; replicating another
+machine's answer would assert liveness this process cannot observe. This matches the peer registry,
+which is machine-local for the same reason (its relay/SSH probes read local runtime state).
+
+## 8. Rollback cost
+
+Low. One new file, one required field on two interfaces, one route composing two lists. No data
+migration, no config, no persisted state. Reverting restores the prior behaviour exactly — including
+the gap.
+
+## Refusals demonstrated (command + output)
+
+Falsification 1 — make the Telegram probe read EXISTENCE instead of liveness (`if (status !== null)`
+in place of `if (status.started)`), i.e. exactly what `/capabilities` does:
+
+```
+× THE FIX: a configured-but-DEAD Telegram is never reported as working
+× a missing bot token is a credential verdict, not a network one
+× a network death is broken — distinct from a credential problem
+× stopped for NO recorded reason is unknown — never working, never a confident broken
+  Tests  4 failed | 12 passed (16)
+```
+
+Falsification 2 — give Slack "ever connected" semantics (`if (enabled)` in place of
+`if (connected)`), the exact trap its own source warns about:
+
+```
+× THE TRAP: enabled with the socket DOWN is broken, not working
+  Tests  1 failed | 15 passed (16)
+```
+
+Restored: `Tests 35 passed (35)` across `channel-registry`, `channel-registry-claims` and
+`user-channel-liveness`; `npx tsc --noEmit` exit 0.
+
+Two source ratchets are included so the probes cannot drift back: one asserts `userChannels.ts` never
+reads a `.configured` property or a `config.*` value, the other asserts the route wiring uses
+`isConnected()` and never `slackAdapter.started`.


### PR DESCRIPTION
## ELI16 — I can now tell whether I can actually reach you, not just whether I'm configured to

Asked "can you reach the operator right now?", the only answer available was a config file saying
"yes, Telegram is set up" — which stays "yes" long after the connection has died.

### What was already there

The channel registry (#1658) answers "which ways of reaching a **peer** work right now?" with real
probes, and it is good. Its header declares a deliberate scope: **peer-to-peer only**. That was the
right call for a peer registry, and it meant the channels carrying messages to a *person* were not
covered.

I went in suspicious of its `a2a-telegram` row — `state: half-built` reads like a claim typed once
that would rot the moment someone wired the sender. I was wrong: it is guarded by a source-scan test
that **fails if anyone wires it**, forcing the label to be updated. Verified rather than rebuilt.

### The gap

For the user channels the only askable surface was `/capabilities`:

```
telegram: { configured: true, adapter: true, bidirectional: true }
```

Three values read from configuration; none is a measurement. A Telegram whose poll loop died on a
rejected token four hours ago still reports all three as `true`.

That is the same **setting-mistaken-for-a-state** failure the peer registry exists to prevent,
relocated onto the channel that matters most — because it is the one carrying messages to a human.

### What changed

Telegram and Slack join the same registry, with liveness read from live adapter state:

| Reads | Means |
| --- | --- |
| Telegram `started` | is the poll loop running *now* |
| Telegram `fatalReason` | *why* it stopped — rejected credential vs dropped network |
| Slack `isConnected()` | is the socket up *now* |

Verdicts distinguish what a boolean cannot:

- **rejected token** → `reachable-no-credential` — Telegram answered and said no. Restarting won't
  help; the token needs replacing.
- **network death** → `broken` — different problem, different fix.
- **stopped with nothing recorded** → `unknown`, explicitly not healthy and not a confident broken:
  *"cannot tell a deliberate stop from a silent death."*
- **no adapter** → `not-configured`. Off is not broken.

### The trap, which was inside the fix

Slack's adapter has two flags that look interchangeable. Its own source annotates `started` as
**"ever connected"**; `_connected` clears on disconnect. A workspace that connected once at boot and
dropped an hour later has `started === true` forever — so using it would report a dead channel as
healthy: **the exact bug being fixed, rebuilt inside its own fix.** The probe uses `isConnected()`,
and a source ratchet fails if anyone swaps it back.

### Why one registry, not two

`audience: 'peer' | 'user'` is a required **field**, not a second registry. Splitting would force a
caller to already know which list to consult — which is the arbitrariness the registry was built to
remove. Required, so a future channel cannot be added untagged: a compile error, not a silent
default. Peer definitions stay in their own file, so `instarChannels.ts`'s deliberate scope
discipline is respected rather than overwritten.

### The judgement, encoded as data

`whenPreferred` on a user channel records that it is the **only surface that shows what the user
genuinely experiences** — no internal log or proxy does — so choosing it deliberately is a *reason*,
not merely a cost. `cost` names operator attention as the scarcest resource here. A test fails if
these are rewritten to be cost-only.

### Refusals proven by falsification

Probe reads existence instead of liveness (`if (status !== null)`) — precisely what the config
reading does:

```
× THE FIX: a configured-but-DEAD Telegram is never reported as working
× a missing bot token is a credential verdict, not a network one
× a network death is broken — distinct from a credential problem
× stopped for NO recorded reason is unknown — never working, never a confident broken
  Tests  4 failed | 12 passed (16)
```

Slack given "ever connected" semantics (`if (enabled)`):

```
× THE TRAP: enabled with the socket DOWN is broken, not working
  Tests  1 failed | 15 passed (16)
```

Restored: **35 passed** across `channel-registry`, `channel-registry-claims`,
`user-channel-liveness`; `tsc --noEmit` exit 0.

### Honest limits

A live reading is not a promise — `working` means the loop was polling when asked. Telegram
`working` means the loop is up, not that a message to a specific topic would land. Slack is modelled
as one workspace. **WhatsApp and iMessage adapters exist in the tree and are not covered** — under
the registry's own "absence is impossible" property that is a real gap, stated rather than scoped
away.

### Tier

Tier 1 on the merits: gate reported `suggestedTier=2 (size=2, riskFloor=1, 242 LOC across 4 files)`
→ `OK (Tier 1)`. Additive read-only observability on an existing `advisory: true` route; no decision
point, no authority, no config key, no persisted state, no migration.
