### PR TITLE
test(ci): re-arm two tests that were never actually flaky

### DIFF
--- a/docs/specs/rearm-parked-tests.eli16.md
+++ b/docs/specs/rearm-parked-tests.eli16.md
@@ -1,0 +1,56 @@
+# Re-arming two tests that were never actually flaky
+
+## What this is
+
+`vitest.push.config.ts` keeps a list called `FLAKY_TESTS`. Everything on that list is *excluded* from
+the test run that CI uses as its gate. The idea is reasonable: a test that fails randomly is worse
+than no test, because it trains everyone to ignore red.
+
+Two entries on that list are not flaky. `tests/unit/agent-registry.test.ts` and
+`tests/unit/builtin-manifest.test.ts` were removed from the exclusion list so they run again.
+
+## Why they were on the list
+
+Not because anyone measured them. Both arrived in one commit — `f193df789`, *"exclude pre-existing
+flaky tests from push gate"* — a bulk exclusion that swept up a batch of tests at once. They landed
+under a heading that reads "Environment-dependent / non-deterministic", and from then on that heading
+read like a finding about each individual test rather than what it was: a label applied to a group.
+
+## How we know they are fine
+
+They were measured, not assumed. On current `main`, three consecutive runs each:
+
+- `agent-registry.test.ts` — 42 passed, 42 passed, 42 passed
+- `builtin-manifest.test.ts` — 9 passed, 9 passed, 9 passed
+
+There was also a specific, plausible theory for why `builtin-manifest` might be environment-dependent:
+it reads `src/data/builtin-manifest.json`, which is a generated file that is not committed to git. A
+CI job that never runs a build would not have that file, so the test would fail — which is exactly
+what "environment-dependent" would mean.
+
+That theory was tested by deleting the file and running the test. **It still passed, 9 out of 9.**
+The test's own setup step regenerates the file if it is missing. It was already written to be
+self-sufficient, so the theory was wrong.
+
+## Why this matters more than two test files
+
+The comment sitting two lines below these entries already describes this exact mistake happening
+before. On 2026-06-05, two other tests were re-armed from the same heading, with the note that the
+"environment-dependent" label had been wrong — and that both had **rotted while parked**. Real
+problems had crept into the code they were supposed to guard, precisely because nothing was running
+them.
+
+So the codebase already contained the diagnosis, the precedent, and the warning — three lines above
+two more tests carrying the same wrong label. Writing a lesson down next to the unfixed case did not
+fix the next case. That is why the replacement comment in this change is unusually detailed: it
+records the measurements and the falsified theory, so the next person to reach for the label has to
+argue with evidence rather than re-apply a heading.
+
+A guard that exists but never runs in the job that matters is not a guard. It is a decoration that
+makes everyone feel guarded.
+
+## What could go wrong
+
+These tests now run in CI, where they have not run for some time. If either fails there despite
+passing locally, that is a real finding about the code or the CI environment — and the correct
+response is to investigate it, not to put the test back on the list.

--- a/upgrades/next/rearm-parked-tests.md
+++ b/upgrades/next/rearm-parked-tests.md
@@ -1,0 +1,55 @@
+# Upgrade Guide — vNEXT
+
+<!-- internal-only -->
+<!-- bump: patch -->
+
+## What Changed
+
+`tests/unit/agent-registry.test.ts` and `tests/unit/builtin-manifest.test.ts` were removed from
+`FLAKY_TESTS` in `vitest.push.config.ts`, so both run in the push/CI unit gate again. The surrounding
+comment now records the measurements and the falsified hypothesis rather than a bare heading.
+
+Neither test is flaky. Both arrived in `f193df789` ("exclude pre-existing flaky tests from push
+gate") — a bulk exclusion, not an individual diagnosis — and sat under a
+"Environment-dependent / non-deterministic" heading that was thereafter read as a finding about each
+one.
+
+## Evidence
+
+Measured on current `main`, three consecutive runs each:
+
+```
+agent-registry.test.ts    → 42 passed | 42 passed | 42 passed
+builtin-manifest.test.ts  →  9 passed |  9 passed |  9 passed
+```
+
+The one concrete environmental hypothesis was tested and falsified. `builtin-manifest.test.ts` reads
+`src/data/builtin-manifest.json`, a generated and gitignored artifact that a job which never builds
+would not have. Deleting the file and re-running:
+
+```
+Tests  9 passed (9)
+```
+
+It still passes because the test's own `beforeAll` regenerates it via
+`scripts/generate-builtin-manifest.cjs` — it was already self-sufficient by design.
+
+After the change, verified by parsing the resolved `FLAKY_TESTS` array rather than assuming the edit
+took: both paths report `NO LONGER EXCLUDED`, 92 entries remain. Both tests run green together
+(`Test Files 2 passed (2) · Tests 51 passed (51)`); `tsc --noEmit` exit 0.
+
+## Known limits
+
+The remaining 92 entries are untouched and unexamined. Several — the supertest/port-collision group
+especially — are plausibly genuinely environment-bound, and emptying the list wholesale would repeat
+the bulk move that caused this. Local determinism is also not proof of CI determinism: if either test
+fails in CI, that is a real finding to diagnose, not a reason to re-park it.
+
+## Why the comment is verbose
+
+The note two entries below already described this same mistake: two other tests were re-armed on
+2026-06-05 from the same heading, with the observation that the label had been wrong and that both
+had rotted while parked. The diagnosis, the precedent and the warning were already in the file,
+three lines above two more mislabelled tests. The replacement comment therefore carries the
+measurements and the falsified theory, so the next person reaching for that label has to argue with
+evidence instead of reapplying a heading.

--- a/upgrades/side-effects/rearm-parked-tests.md
+++ b/upgrades/side-effects/rearm-parked-tests.md
@@ -1,0 +1,73 @@
+# Side-effects review — re-arm two parked tests
+
+**Change:** remove `tests/unit/agent-registry.test.ts` and `tests/unit/builtin-manifest.test.ts` from
+`FLAKY_TESTS` in `vitest.push.config.ts`, and replace the surrounding comment with the measurements
+and the falsified hypothesis.
+
+**Decision point touched?** No new decision point. This *restores* an existing one: two guards that
+were excluded from the CI gate now participate in it again. No runtime code changes; the diff is
+config + comment only.
+
+---
+
+## 1. Over-block
+
+Re-arming can only make the gate stricter, and that is the intent. The over-block risk is that a test
+fails in CI for an environmental reason that does not exist locally — in which case CI turns red on
+work unrelated to the failure, and the author is blocked by something they did not cause.
+
+Mitigated by measurement rather than hope: both were run three consecutive times on current `main`
+(42/42/42 and 9/9/9), and the one specific environmental hypothesis available —
+`builtin-manifest.test.ts` depending on the generated, gitignored `src/data/builtin-manifest.json` —
+was tested by deleting the file. The test still passed 9/9 because its `beforeAll` regenerates it.
+
+Residual risk is real but bounded: local determinism is not proof of CI determinism. If either fails
+in CI, the correct response is to diagnose it, not to re-park it. Re-parking without a diagnosis is
+the exact move that created this situation.
+
+## 2. Under-block
+
+This change does not attempt to audit the rest of `FLAKY_TESTS` (92 entries remain). Several — the
+supertest/port-collision group in particular — are plausibly genuinely environment-bound, and
+emptying the list wholesale would be the same bulk move that caused the problem, run in reverse. So
+the class is knowingly only partly addressed here: two members verified and fixed, the remainder
+untouched and unexamined. Stated rather than implied.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The mislabel lives in the exclusion list, so the fix belongs in the exclusion list.
+A deeper fix — something that would *prevent* a bulk exclusion from being read later as a per-test
+finding — would need a mechanism requiring evidence at the point of exclusion (e.g. a required
+measurement note per entry). That is a larger design change and is deliberately not attempted here.
+
+## 4. Signal vs authority compliance
+
+Unchanged. The tests are signals that CI (the authority) consumes. Nothing here gives any check new
+blocking power it did not already have by design; it restores participation that was removed.
+
+## 5. Interactions
+
+The two files now execute inside the push/CI unit run, adding their runtime to that job and their
+failures to its verdict. Both are fast unit tests. `builtin-manifest.test.ts` shells out to
+`scripts/generate-builtin-manifest.cjs` in `beforeAll` if the generated file is missing, which writes
+`src/data/builtin-manifest.json` — a gitignored artifact that `npm run build` writes anyway. It is
+the only test that reads that file, so no cross-test read/write race is introduced. Worth naming
+explicitly because a test that writes into the repo during a sharded run is the shape that *would*
+cause genuine flakiness if another test ever read the same file.
+
+## 6. External surfaces
+
+None. No endpoint, no config key, no agent-visible behaviour, no user-visible behaviour. The only
+observer of this change is CI.
+
+## 7. Multi-machine posture
+
+Not applicable — this is repo-level CI configuration, identical on every checkout, with no runtime
+state, no per-machine data, and nothing to replicate or proxy.
+
+## 8. Rollback cost
+
+Trivial and immediate: re-add the two strings to `FLAKY_TESTS`. No data migration, no release
+coupling, no agent state to repair. If a rollback happens, the comment block should record *why* the
+test actually failed — otherwise the rollback recreates the original defect, which was an exclusion
+carrying no evidence.

--- a/vitest.push.config.ts
+++ b/vitest.push.config.ts
@@ -31,8 +31,28 @@ const FLAKY_TESTS = [
   'tests/e2e/lifecycle.test.ts',
 
   // ── Environment-dependent / non-deterministic ─────────────────────
-  'tests/unit/agent-registry.test.ts',
-  'tests/unit/builtin-manifest.test.ts',
+  // (empty — see the two re-arm notes below)
+  //
+  // agent-registry.test.ts + builtin-manifest.test.ts — RE-ARMED 2026-07-27,
+  // for the SAME reason as the 2026-06-05 pair below: the
+  // "environment-dependent" label was wrong on both. Measured on current main,
+  // three consecutive runs each: agent-registry 42/42/42, builtin-manifest
+  // 9/9/9. Neither is flaky.
+  //   builtin-manifest was additionally SUSPECTED of depending on
+  //   src/data/builtin-manifest.json — a generated, gitignored artifact that a
+  //   CI job which never builds would not have. That hypothesis was TESTED and
+  //   FALSIFIED: deleting the file changes nothing, because the test's own
+  //   beforeAll regenerates it via scripts/generate-builtin-manifest.cjs. It
+  //   was already self-sufficient by design.
+  //   Both arrived here in f193df789 ("exclude pre-existing flaky tests from
+  //   push gate") — a BULK exclusion, not an individual diagnosis. That is the
+  //   actual defect: the label was applied to a batch and then read, forever
+  //   after, as a finding about each member.
+  // This block is deliberately verbose because the note two entries down
+  // already said all of this on 2026-06-05, and two more tests were sitting
+  // mislabelled directly above it anyway. Writing the lesson next to the
+  // unfixed case did not fix the next one.
+  //
   // security.test.ts + feature-delivery-completeness.test.ts — RE-ARMED
   // 2026-06-05. Both are DETERMINISTIC source-content guards (the old
   // "environment-dependent" label was wrong) and both rotted while parked:


### PR DESCRIPTION
## ELI16 — two guards that existed and never ran

`vitest.push.config.ts` keeps a `FLAKY_TESTS` array, and everything in it is **excluded** from the
test run CI uses as its gate. Reasonable idea: a randomly-failing test is worse than no test, because
it trains everyone to ignore red.

Two entries are not flaky.

### They were never measured — they were swept up

Both arrived in one commit: `f193df789` — *"exclude pre-existing flaky tests from push gate"*. A
**bulk** exclusion. They landed under a heading reading `── Environment-dependent / non-deterministic ──`,
and from then on that heading read like a finding about each test rather than what it was: a label
applied to a batch.

### Measured, not assumed

Three consecutive runs each, on current `main`:

```
agent-registry.test.ts    → 42 passed | 42 passed | 42 passed
builtin-manifest.test.ts  →  9 passed |  9 passed |  9 passed
```

### The one real hypothesis, tested and falsified

`builtin-manifest.test.ts` reads `src/data/builtin-manifest.json` — **generated and gitignored**, so
a CI job that never builds would not have it. That is exactly what "environment-dependent" would
mean, and it was the reason I expected to find.

Deleted the file, re-ran:

```
Tests  9 passed (9)
```

Still green, because the test's own `beforeAll` regenerates it via
`scripts/generate-builtin-manifest.cjs`. **It was already self-sufficient by design.** The plausible
mechanical explanation was simply wrong, and only running it said so.

### Why the comment is long

The note *two entries below these* already recorded this same mistake:

> `security.test.ts` + `feature-delivery-completeness.test.ts` — RE-ARMED 2026-06-05. Both are
> DETERMINISTIC source-content guards (the old "environment-dependent" label was wrong) and **both
> rotted while parked** […] (Same lesson as the ESM-compliance re-arm above: **a parked gate is no
> gate**.)

So the file already contained the diagnosis, the precedent, *and* the warning — three lines above two
more tests carrying the identical wrong label. **Writing the lesson next to the unfixed case did not
fix the next one.** The replacement comment therefore carries the measurements and the falsified
theory, so the next person reaching for that label has to argue with evidence rather than reapply a
heading.

## Evidence

Verified by parsing the resolved `FLAKY_TESTS` array rather than trusting that the edit took:

```
tests/unit/agent-registry.test.ts: NO LONGER EXCLUDED
tests/unit/builtin-manifest.test.ts: NO LONGER EXCLUDED
FLAKY_TESTS entry count now: 92
```

Both green together: `Test Files 2 passed (2) · Tests 51 passed (51)`. `npx tsc --noEmit` exit 0.

## Scope — deliberately two, not ninety-two

The remaining 92 entries are untouched. Several (the supertest/port-collision group especially) are
plausibly genuinely environment-bound, and **emptying the list wholesale would be the same bulk move
that caused this, run in reverse.** Two members verified and fixed; the rest unexamined and stated as
such.

## Found while doing this — registered, not fixed here

**ACT-1341.** `scripts/instar-dev-precommit.js` `inScope()` returns true only for `src/`, `scripts/`,
`.husky/` and `skills/`. `vitest.push.config.ts` matches none, so the gate exits at its pass-through
branch (*"Pure docs / release notes / config"*). **Adding a test to `FLAKY_TESTS` — removing a guard
from CI entirely — therefore requires no ELI16, no side-effects review, no trace, and no tier
declaration.** That is the root beneath every individual mislabel: the exclusion list is the one file
where removing a safety check is cheapest and least observed.

The suggested fix is a narrow gate refusing a `FLAKY_TESTS` **addition** without a measurement note,
rather than widening `inScope` (which would pull every config file into full Tier review). The
asymmetry is the point: additions remove coverage, removals restore it, so only additions need the
evidence bar. Not attempted here — it is its own change.

Tier 1: config + comment only, no runtime `src/` change, no decision point, no new authority.
Rollback is re-adding two strings.
