### PR TITLE
fix(instar-dev): a gate that could be silently absent now says so

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T09-24-09-510Z-gate-installation-selfcheck.json
+++ b/.instar/instar-dev-decisions/2026-07-27T09-24-09-510Z-gate-installation-selfcheck.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T09:24:09.510Z",
+  "slug": "gate-installation-selfcheck",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 106,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/gate-installation-selfcheck.eli16.md
+++ b/docs/specs/gate-installation-selfcheck.eli16.md
@@ -1,0 +1,52 @@
+# A gate that could be silently absent now says so
+
+## The problem
+
+Instar's development gate runs as a git pre-commit hook. Before any change to instar's own
+behaviour can be committed, the gate checks that the change carries its required paperwork — a
+plain-English overview, a side-effects review, and a trace recording that the change went through
+the proper process.
+
+That gate can be completely absent, and nothing tells you.
+
+A developer working on instar creates an isolated copy of the repo using `git worktree add`. That
+copy inherits the setting saying "look for hooks in this folder" from the main repo — but the folder
+itself does not exist until the dependencies are installed. In that state, committing runs no hook at
+all. It prints nothing, and it succeeds.
+
+So a working gate and a completely uninstalled gate look **identical on screen**: both are silent.
+
+This is not hypothetical. On 2026-07-27 an entire change was committed in the belief the gate had
+approved it. The gate had never executed. The silence was read as a pass.
+
+## Why the gate cannot fix this itself
+
+A hook that is not installed cannot run in order to announce that it is not installed. Absence
+cannot report itself. Any fix has to live somewhere that actually executes.
+
+## What changed
+
+The check was added to the step the developer runs by hand just before committing: writing the
+trace. That step is the one that *asserts* "this change went through the proper process" — and that
+assertion is false if the gate cannot run at all.
+
+So before writing a trace, the script now verifies the gate is genuinely installed: that the
+configured hooks folder exists and contains a pre-commit hook, or that a hook is installed the
+classic way. If it is not, the script refuses to write the trace and explains exactly what is wrong
+and how to fix it.
+
+## Being honest about what this can and cannot do
+
+This is a signal, not an enforcement. It cannot block a commit — the very situation it detects is the
+one where no commit hook runs. What it does is convert a silent absence into a loud one at the moment
+the developer would otherwise proceed believing everything was checked.
+
+There is an escape hatch for environments that genuinely have no hooks. Using it is recorded in the
+trace itself, so a trace written without a live gate can never later be mistaken for one the gate
+approved.
+
+And the check deliberately does not apply outside a git repository at all. Where there is no
+repository there is no commit, so there is nothing to gate and nothing to be misled about. That
+matters practically: several existing tests drive this script inside a bare temporary folder, and
+they keep working without every future test author having to remember a special setting — which
+would be exactly the kind of "remember to do it" burden this change exists to remove.

--- a/skills/instar-dev/scripts/write-trace.mjs
+++ b/skills/instar-dev/scripts/write-trace.mjs
@@ -46,6 +46,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 
 const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..', '..');
 
@@ -157,6 +158,107 @@ function buildToolchain() {
   }
 }
 
+/**
+ * Verify the commit gate is actually INSTALLED before writing a trace that implies it ran.
+ *
+ * THE FAILURE THIS EXISTS TO CATCH. A worktree created with `git worktree add` and a
+ * symlinked (or absent) node_modules has no husky shim, so `core.hooksPath` points at a
+ * directory that does not exist. `git commit` then runs NO hook: it prints nothing and
+ * succeeds. **A working gate and an uninstalled gate look identical on screen — silence.**
+ * That is not hypothetical; it happened on 2026-07-27 and a whole change was committed
+ * believing the gate had passed it, when the gate had never executed.
+ *
+ * The gate cannot report its own absence — an uninstalled hook cannot run to say it is
+ * uninstalled. So the check belongs at the nearest chokepoint the agent DOES invoke by
+ * hand, which is this script. Writing a trace is the step that asserts "this change came
+ * through the skill", and that assertion is false if the gate cannot execute.
+ *
+ * SCOPE HONESTY: this is a SIGNAL, not an authority. It refuses to write the trace and
+ * says why; it cannot block a commit, because the very condition it detects is the one
+ * where no commit hook runs. Without a trace an in-scope commit is refused ANYWAY once the
+ * hook IS installed — so the two layers compose rather than overlap. Its whole job is to
+ * turn a silent absence into a loud one at the moment the agent would otherwise proceed.
+ *
+ * Set INSTAR_DEV_ALLOW_UNINSTALLED_GATE=1 to proceed anyway (a genuinely hookless
+ * environment, e.g. a test harness). The override is recorded IN THE TRACE rather than
+ * merely permitted, so a trace written without a live gate can never later be mistaken for
+ * one the gate approved.
+ */
+function inspectGateInstallation() {
+  const result = { installed: false, reason: '', hooksPath: null };
+  let hooksPath;
+  try {
+    hooksPath = execFileSync('git', ['config', '--get', 'core.hooksPath'], {
+      cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    hooksPath = '';
+  }
+
+  if (!hooksPath) {
+    // No hooksPath set at all — git falls back to .git/hooks. Check there instead of
+    // assuming absence: a repo may legitimately install the hook the classic way.
+    let gitDir;
+    try {
+      gitDir = execFileSync('git', ['rev-parse', '--git-dir'], {
+        cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+    } catch {
+      // NOT A GIT REPOSITORY AT ALL — the check does not apply.
+      //
+      // This is not a loophole, it is the check's actual scope. The hazard being guarded
+      // is "a git repo whose commit hook will not run". Where there is no repo there is no
+      // commit, so there is nothing to gate and nothing to be misled about. Test harnesses
+      // that drive this script inside a bare temp directory land here.
+      //
+      // Deliberately NOT solved by making every such harness set the override env var:
+      // that would push the burden onto whoever writes the next test remembering to do it,
+      // which is the willpower-over-structure trade this whole change exists to remove.
+      // It is also not a meaningful bypass — an agent cannot make the instar repo stop
+      // being a git repository.
+      return { installed: true, reason: '', hooksPath: null, notApplicable: true };
+    }
+    const classic = path.resolve(ROOT, gitDir, 'hooks', 'pre-commit');
+    if (fs.existsSync(classic)) return { installed: true, reason: '', hooksPath: classic };
+    return { ...result, reason: 'core.hooksPath is unset and .git/hooks/pre-commit does not exist' };
+  }
+
+  result.hooksPath = hooksPath;
+  const resolved = path.resolve(ROOT, hooksPath);
+  if (!fs.existsSync(resolved)) {
+    return { ...result, reason: `core.hooksPath is "${hooksPath}" but that directory does not exist — husky is not installed in this worktree (run \`npm ci\` then \`npx husky\`)` };
+  }
+  const preCommit = path.join(resolved, 'pre-commit');
+  if (!fs.existsSync(preCommit)) {
+    return { ...result, reason: `core.hooksPath is "${hooksPath}" but it contains no pre-commit hook` };
+  }
+  return { installed: true, reason: '', hooksPath };
+}
+
+const gate = inspectGateInstallation();
+const gateOverridden = process.env.INSTAR_DEV_ALLOW_UNINSTALLED_GATE === '1';
+if (!gate.installed && !gateOverridden) {
+  console.error('');
+  console.error('  ╔════════════════════════════════════════════════════════════════════╗');
+  console.error('  ║  REFUSING to write a trace — the commit gate is NOT installed      ║');
+  console.error('  ╚════════════════════════════════════════════════════════════════════╝');
+  console.error('');
+  console.error(`  ${gate.reason}`);
+  console.error('');
+  console.error('  A trace asserts this change came through /instar-dev. With no hook');
+  console.error('  installed, `git commit` runs NOTHING and succeeds silently — a passing');
+  console.error('  gate and an absent gate look identical on screen. Writing the trace now');
+  console.error('  would record an approval that was never given.');
+  console.error('');
+  console.error('  Fix it in this worktree:   npm ci && npx husky');
+  console.error('  Then verify:               git config core.hooksPath && ls .husky/_');
+  console.error('');
+  console.error('  If this environment genuinely has no hooks (e.g. a test harness), set');
+  console.error('  INSTAR_DEV_ALLOW_UNINSTALLED_GATE=1 — the override is recorded in the trace.');
+  console.error('');
+  process.exit(1);
+}
+
 const artifactPath = path.resolve(ROOT, artifact);
 if (!fs.existsSync(artifactPath)) {
   console.error(`Artifact not found: ${artifact}`);
@@ -235,6 +337,10 @@ const trace = {
   // Duplicate-build guard §3.4 — omitted when no stub exists so pre-guard
   // traces round-trip byte-identically.
   ...(duplicateBuildCheck ? { duplicateBuildCheck } : {}),
+  // Recorded ONLY when the gate-installation check was overridden, so a trace written
+  // without a live commit gate can never later be mistaken for one the gate approved.
+  // Absent on every normal trace, so existing traces round-trip byte-identically.
+  ...(gate.installed ? {} : { gateInstallationOverridden: true, gateInstallationReason: gate.reason }),
 };
 
 fs.writeFileSync(traceFile, JSON.stringify(trace, null, 2) + '\n');

--- a/tests/unit/write-trace-gate-selfcheck.test.ts
+++ b/tests/unit/write-trace-gate-selfcheck.test.ts
@@ -1,0 +1,185 @@
+/**
+ * `write-trace.mjs` must refuse to write a trace when the commit gate is not installed.
+ *
+ * WHY. A worktree created with `git worktree add` inherits `core.hooksPath` from the shared
+ * repo config — typically `.husky/_` — while that directory does not exist until `npm ci`
+ * plus `npx husky` have run. In that state `git commit` executes NO hook: it prints nothing
+ * and succeeds. **A working gate and an uninstalled gate are indistinguishable on screen,
+ * because both are silent.** On 2026-07-27 a whole change was committed on the belief the
+ * gate had passed it, when the gate had never run.
+ *
+ * The gate cannot report its own absence — an uninstalled hook cannot execute to announce
+ * that it is uninstalled. So the check lives at the nearest chokepoint the agent invokes by
+ * hand: writing the trace, which is the step that ASSERTS the change came through the skill.
+ *
+ * These tests drive the real script as a subprocess against real temporary git repos,
+ * rather than reimplementing its logic — a test that reproduces the check it is verifying
+ * cannot fail when the check changes.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SCRIPT = path.join(REPO_ROOT, 'skills/instar-dev/scripts/write-trace.mjs');
+
+const tmpDirs: string[] = [];
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    try {
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true, force: true,
+        operation: 'tests/unit/write-trace-gate-selfcheck.test.ts:cleanup',
+      });
+    } catch { /* test cleanup only */ }
+  }
+});
+
+/**
+ * A minimal repo laid out the way write-trace.mjs expects, with the script copied to the
+ * path it resolves ROOT from (three levels up from skills/instar-dev/scripts/).
+ */
+function makeRepo(opts: { installGate: boolean }): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'write-trace-gate-'));
+  tmpDirs.push(root);
+
+  const op = 'tests/unit/write-trace-gate-selfcheck.test.ts';
+  SafeGitExecutor.execSync(['init', '-q'], { cwd: root, stdio: 'ignore', operation: `${op}:git-init` });
+  SafeGitExecutor.execSync(['config', 'user.email', 'test@example.com'], { cwd: root, stdio: 'ignore', operation: `${op}:git-config-email` });
+  SafeGitExecutor.execSync(['config', 'user.name', 'Test'], { cwd: root, stdio: 'ignore', operation: `${op}:git-config-name` });
+
+  fs.mkdirSync(path.join(root, 'skills/instar-dev/scripts'), { recursive: true });
+  fs.copyFileSync(SCRIPT, path.join(root, 'skills/instar-dev/scripts/write-trace.mjs'));
+
+  fs.mkdirSync(path.join(root, 'upgrades/side-effects'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'docs/specs'), { recursive: true });
+  // The script requires a non-stub artifact (>=200 chars), so this must be real text.
+  const body = 'Side-effects review body used purely to satisfy the artifact length floor. '.repeat(6);
+  fs.writeFileSync(path.join(root, 'upgrades/side-effects/demo.md'), body);
+  fs.writeFileSync(path.join(root, 'docs/specs/demo.eli16.md'), body);
+
+  // The failure condition: hooksPath points somewhere that does not exist. This is the
+  // DEFAULT state of a fresh worktree, not an exotic misconfiguration.
+  SafeGitExecutor.execSync(['config', 'core.hooksPath', '.husky/_'], { cwd: root, stdio: 'ignore', operation: `${op}:git-config-hookspath` });
+  if (opts.installGate) {
+    fs.mkdirSync(path.join(root, '.husky/_'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.husky/_/pre-commit'), '#!/bin/sh\nexit 0\n');
+  }
+  return root;
+}
+
+function runTrace(root: string, env: Record<string, string> = {}) {
+  return spawnSync(process.execPath, [
+    'skills/instar-dev/scripts/write-trace.mjs',
+    '--tier', '1',
+    '--tier-reasoning', 'test',
+    '--artifact', 'upgrades/side-effects/demo.md',
+    '--eli16-path', 'docs/specs/demo.eli16.md',
+    '--side-effects-path', 'upgrades/side-effects/demo.md',
+    '--files', 'src/demo.ts',
+  ], { cwd: root, encoding: 'utf8', env: { ...process.env, ...env } });
+}
+
+describe('write-trace gate-installation self-check', () => {
+  it('THE FIX: refuses to write a trace when hooksPath points at a missing directory', () => {
+    const root = makeRepo({ installGate: false });
+    const res = runTrace(root);
+
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain('the commit gate is NOT installed');
+    expect(res.stderr).toContain('core.hooksPath');
+
+    // The refusal must be total: no trace file may exist afterwards.
+    const dir = path.join(root, '.instar/instar-dev-traces');
+    const written = fs.existsSync(dir) ? fs.readdirSync(dir) : [];
+    expect(written, 'no trace may be written when the gate is absent').toEqual([]);
+  });
+
+  it('writes normally when the gate IS installed — the check does not block real work', () => {
+    // Dead-check for the test above: without this, an always-refusing script would pass it.
+    const root = makeRepo({ installGate: true });
+    const res = runTrace(root);
+
+    expect(res.status).toBe(0);
+    const dir = path.join(root, '.instar/instar-dev-traces');
+    expect(fs.readdirSync(dir).length).toBe(1);
+
+    const trace = JSON.parse(fs.readFileSync(path.join(dir, fs.readdirSync(dir)[0]), 'utf8'));
+    // A normal trace must NOT carry the override markers, so an overridden trace is
+    // distinguishable from an approved one by presence rather than by value.
+    expect(trace.gateInstallationOverridden).toBeUndefined();
+    expect(trace.gateInstallationReason).toBeUndefined();
+  });
+
+  it('the override proceeds but RECORDS itself in the trace', () => {
+    const root = makeRepo({ installGate: false });
+    const res = runTrace(root, { INSTAR_DEV_ALLOW_UNINSTALLED_GATE: '1' });
+
+    expect(res.status).toBe(0);
+    const dir = path.join(root, '.instar/instar-dev-traces');
+    const trace = JSON.parse(fs.readFileSync(path.join(dir, fs.readdirSync(dir)[0]), 'utf8'));
+
+    // The point of recording it: a trace written without a live gate can never later be
+    // mistaken for one the gate approved.
+    expect(trace.gateInstallationOverridden).toBe(true);
+    expect(trace.gateInstallationReason).toContain('core.hooksPath');
+  });
+
+  it('accepts a classic .git/hooks/pre-commit install (hooksPath unset)', () => {
+    // Not every repo uses husky. Refusing those would be an over-block.
+    const root = makeRepo({ installGate: false });
+    const op = 'tests/unit/write-trace-gate-selfcheck.test.ts';
+    SafeGitExecutor.execSync(['config', '--unset', 'core.hooksPath'], { cwd: root, stdio: 'ignore', operation: `${op}:git-unset-hookspath` });
+    const gitDir = SafeGitExecutor.readSync(['rev-parse', '--git-dir'], { cwd: root, encoding: 'utf8', operation: `${op}:git-dir` }).trim();
+    const hooks = path.resolve(root, gitDir, 'hooks');
+    fs.mkdirSync(hooks, { recursive: true });
+    fs.writeFileSync(path.join(hooks, 'pre-commit'), '#!/bin/sh\nexit 0\n');
+
+    const res = runTrace(root);
+    expect(res.status).toBe(0);
+  });
+
+  /**
+   * Scope boundary. The hazard is "a git repo whose commit hook will not run"; where there
+   * is no repo there is no commit, so the check does not apply. Existing harnesses
+   * (write-trace-tier, duplicate-build-guard-gates) drive this script inside a bare temp
+   * directory and must keep working WITHOUT each of them remembering an env var — pushing
+   * that burden onto the next test author is the willpower trade this change removes.
+   */
+  it('does NOT apply outside a git repository — bare directories still write a trace', () => {
+    const root = makeRepo({ installGate: false });
+    SafeFsExecutor.safeRmSync(path.join(root, '.git'), {
+      recursive: true, force: true,
+      operation: 'tests/unit/write-trace-gate-selfcheck.test.ts:degit',
+    });
+
+    const res = runTrace(root);
+    expect(res.status, res.stderr).toBe(0);
+
+    const dir = path.join(root, '.instar/instar-dev-traces');
+    const trace = JSON.parse(fs.readFileSync(path.join(dir, fs.readdirSync(dir)[0]), 'utf8'));
+    // Not-applicable is not an override: nothing was bypassed, so nothing is recorded.
+    expect(trace.gateInstallationOverridden).toBeUndefined();
+  });
+
+  it('refuses when hooksPath is unset AND no classic hook exists', () => {
+    const root = makeRepo({ installGate: false });
+    const op = 'tests/unit/write-trace-gate-selfcheck.test.ts';
+    SafeGitExecutor.execSync(['config', '--unset', 'core.hooksPath'], { cwd: root, stdio: 'ignore', operation: `${op}:git-unset-hookspath2` });
+    const gitDir = SafeGitExecutor.readSync(['rev-parse', '--git-dir'], { cwd: root, encoding: 'utf8', operation: `${op}:git-dir2` }).trim();
+    const preCommit = path.resolve(root, gitDir, 'hooks', 'pre-commit');
+    if (fs.existsSync(preCommit)) {
+      SafeFsExecutor.safeRmSync(preCommit, { force: true, operation: `${op}:rm-pre-commit` });
+    }
+
+    const res = runTrace(root);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain('unset');
+  });
+});

--- a/upgrades/next/gate-installation-selfcheck.md
+++ b/upgrades/next/gate-installation-selfcheck.md
@@ -1,0 +1,60 @@
+# Upgrade Guide — vNEXT
+
+<!-- internal-only -->
+<!-- bump: patch -->
+
+## What Changed
+
+`skills/instar-dev/scripts/write-trace.mjs` now verifies the instar-dev commit gate is actually
+installed before writing a trace, and refuses with an explanation when it is not.
+
+A worktree created with `git worktree add` inherits `core.hooksPath` (typically `.husky/_`) from the
+shared repo config, while that directory does not exist until `npm ci` plus `npx husky` have run. In
+that state `git commit` executes no hook: it prints nothing and succeeds. A working gate and an
+uninstalled gate are indistinguishable on screen, because both are silent — and on 2026-07-27 a
+change was committed on the belief the gate had passed it when the gate had never run.
+
+The gate cannot detect its own absence, since an uninstalled hook cannot execute to say so. The check
+therefore lives at the nearest chokepoint invoked by hand: writing the trace, which is the step that
+asserts the change came through the skill. `INSTAR_DEV_ALLOW_UNINSTALLED_GATE=1` overrides it, and
+the override is recorded in the trace so an unguarded trace can never be mistaken for an approved one.
+
+## Evidence
+
+Verified against a real hookless worktree before any test was written — `core.hooksPath` was already
+`.husky/_` in a freshly added worktree with no shim, confirming silently-no-gate is the default state
+rather than an exotic misconfiguration:
+
+```
+core.hooksPath is ".husky/_" but that directory does not exist — husky is not installed
+```
+
+Falsified by neutering the check in the script:
+
+```
+× THE FIX: refuses to write a trace when hooksPath points at a missing directory
+  → expected +0 to be 1
+× refuses when hooksPath is unset AND no classic hook exists
+  Tests  2 failed | 4 passed (6)
+```
+
+Restored byte-identical. The over-block was found by running the suites chosen from the diff rather
+than the files authored: the first implementation broke seven tests in `write-trace-tier` and
+`duplicate-build-guard-gates`, both of which drive the script inside bare temp directories. Scoping
+the check to git repositories only fixed it — a directory that is not a repo has no commit to gate.
+Final: `Test Files 3 passed (3) · Tests 23 passed (23)`.
+
+## Known limits
+
+The check verifies a pre-commit hook exists; it does not verify it is executable, non-empty, or that
+it is the instar-dev gate rather than another hook. A hook that exits 0 immediately would satisfy it
+while gating nothing. It also cannot help retroactively — a commit already made without the gate
+leaves no marker, because nothing ran to leave one.
+
+## What to Tell Your User
+
+None — internal change (no user-facing surface).
+
+## Summary of New Capabilities
+
+None — internal change (no user-facing surface).

--- a/upgrades/side-effects/gate-installation-selfcheck.md
+++ b/upgrades/side-effects/gate-installation-selfcheck.md
@@ -1,0 +1,83 @@
+# Side-effects review — write-trace gate-installation self-check
+
+**Change:** `skills/instar-dev/scripts/write-trace.mjs` refuses to write a trace when the instar-dev
+commit gate is not installed (hooksPath points at a missing directory, or no pre-commit hook exists).
+Overridable via `INSTAR_DEV_ALLOW_UNINSTALLED_GATE=1`, and the override is recorded in the trace.
+
+**Decision point touched?** Yes. This adds a refusal — the script now declines an operation it
+previously always performed. Per `docs/signal-vs-authority.md` the refusal is deliberately scoped as
+a SIGNAL: it cannot block a commit (the detected condition is precisely the one where no commit hook
+runs), it only refuses to emit an artifact that would assert an approval that never happened.
+
+---
+
+## 1. Over-block
+
+Real and found during the build, not theorised. The first implementation refused inside any directory
+whose hooks were absent, which broke seven existing tests in `write-trace-tier.test.ts` and
+`duplicate-build-guard-gates.test.ts` — both drive the script inside bare temp directories.
+
+Resolved by scoping the check to its actual hazard: a *git repository* whose hook will not run. A
+directory that is not a git repo has no commit to gate, so the check does not apply. Deliberately NOT
+resolved by setting the override env var in each harness — that would push the burden onto whoever
+writes the next test remembering to do it, which is the willpower-over-structure trade this change
+exists to remove.
+
+Remaining over-block risk: a repo that installs its pre-commit hook by some mechanism other than
+`core.hooksPath` or `.git/hooks/pre-commit` would be refused incorrectly. No such mechanism is used
+in this repo. The override exists for exactly that case and records itself.
+
+## 2. Under-block
+
+The check verifies a pre-commit hook *exists*; it does not verify it is executable, non-empty, or that
+it is actually the instar-dev gate rather than some other hook. A repo with a hook file that exits 0
+immediately would pass this check while gating nothing. Named rather than fixed: deeper verification
+would mean executing or parsing the hook, which is a larger change than the failure being closed.
+
+It also cannot help after the fact. A commit already made without the gate leaves no marker, because
+nothing ran to leave one.
+
+## 3. Level-of-abstraction fit
+
+Correct, and the placement is the substance of the change. The gate cannot detect its own absence —
+an uninstalled hook cannot execute to report that it is uninstalled — so the check must live in
+something that actually runs. Trace-writing is the nearest chokepoint the agent invokes by hand, and
+it is the step whose whole meaning is "this change came through the skill". Putting the check
+anywhere the agent might skip would reproduce the original problem one layer out.
+
+## 4. Signal vs authority compliance
+
+Compliant by construction. It holds no blocking authority over commits and could not acquire any:
+the condition it detects is defined by the absence of the mechanism that would do the blocking. It
+refuses to produce an artifact, which is the weakest possible action, and it fails loudly rather than
+silently. The escape hatch is recorded rather than merely permitted, so an overridden trace is
+distinguishable from an approved one by field presence.
+
+## 5. Interactions
+
+Composes with the pre-commit gate rather than duplicating it: without a trace an in-scope commit is
+refused anyway *once the hook is installed*, so the two layers cover different halves of the same
+failure. The trace gains two fields (`gateInstallationOverridden`, `gateInstallationReason`) emitted
+ONLY on override, so every normal trace round-trips byte-identically and existing readers are
+unaffected.
+
+Adds two `git config` / `git rev-parse` subprocess calls to a script that already shells out. No hot
+path; runs once per commit at most.
+
+## 6. External surfaces
+
+None. `write-trace.mjs` is a development-time script in the instar repo, not shipped behaviour, not
+an endpoint, not agent-visible at runtime. The only observers are instar developers and CI.
+
+## 7. Multi-machine posture
+
+Not applicable — this is a development-time script operating on the local checkout. It introduces no
+state, no persistence, and nothing to replicate, proxy, or reconcile. Every machine that develops
+instar runs its own copy against its own worktree, which is the correct and only sensible posture.
+
+## 8. Rollback cost
+
+Trivial. Remove the check function and its call site; the trace fields disappear with it (they are
+emitted only on override, so nothing else references them). No data migration, no persisted state, no
+agent state. The rollback re-creates the original silent-gate hazard, so it should be accompanied by
+a reason.


### PR DESCRIPTION
## ELI16 — a gate that could be silently absent now says so

Instar's development gate runs as a git pre-commit hook: before any change to instar's own behaviour
can be committed, it checks the change carries its required paperwork. **That gate can be completely
absent, and nothing tells you.**

A worktree created with `git worktree add` inherits `core.hooksPath` (typically `.husky/_`) from the
shared repo config, while that directory does not exist until `npm ci` plus `npx husky` have run. In
that state `git commit` executes **no hook at all**: it prints nothing, and it succeeds. So a working
gate and an uninstalled gate look identical on screen — both are silent.

That is not hypothetical. On 2026-07-27 an entire change was committed in the belief the gate had
approved it; the gate had never executed, and the silence was read as a pass. This PR closes that.

## Why the gate cannot fix this itself

A hook that is not installed cannot run in order to announce that it is not installed. Absence
cannot report itself. Any fix has to live somewhere that actually executes.

## What changed

The check was added to the step the developer runs by hand just before committing: writing the
trace. That step is the one that *asserts* "this change went through the proper process" — and that
assertion is false if the gate cannot run at all.

So before writing a trace, the script now verifies the gate is genuinely installed: that the
configured hooks folder exists and contains a pre-commit hook, or that a hook is installed the
classic way. If it is not, the script refuses to write the trace and explains exactly what is wrong
and how to fix it.

## Being honest about what this can and cannot do

This is a signal, not an enforcement. It cannot block a commit — the very situation it detects is the
one where no commit hook runs. What it does is convert a silent absence into a loud one at the moment
the developer would otherwise proceed believing everything was checked.

There is an escape hatch for environments that genuinely have no hooks. Using it is recorded in the
trace itself, so a trace written without a live gate can never later be mistaken for one the gate
approved.

And the check deliberately does not apply outside a git repository at all. Where there is no
repository there is no commit, so there is nothing to gate and nothing to be misled about. That
matters practically: several existing tests drive this script inside a bare temporary folder, and
they keep working without every future test author having to remember a special setting — which
would be exactly the kind of "remember to do it" burden this change exists to remove.

## Evidence

Verified against a real hookless worktree before any test was written — `core.hooksPath` was already
`.husky/_` in a freshly added worktree with no shim, confirming silently-no-gate is the default state
rather than an exotic misconfiguration:

```
core.hooksPath is ".husky/_" but that directory does not exist — husky is not installed
```

Falsified by neutering the check in the script:

```
× THE FIX: refuses to write a trace when hooksPath points at a missing directory
  → expected +0 to be 1
× refuses when hooksPath is unset AND no classic hook exists
  Tests  2 failed | 4 passed (6)
```

Restored byte-identical. The over-block was found by running the suites chosen from the diff rather
than the files authored: the first implementation broke seven tests in `write-trace-tier` and
`duplicate-build-guard-gates`, both of which drive the script inside bare temp directories. Scoping
the check to git repositories only fixed it — a directory that is not a repo has no commit to gate.
Final: `Test Files 3 passed (3) · Tests 23 passed (23)`.

## Known limits

The check verifies a pre-commit hook exists; it does not verify it is executable, non-empty, or that
it is the instar-dev gate rather than another hook. A hook that exits 0 immediately would satisfy it
while gating nothing. It also cannot help retroactively — a commit already made without the gate
leaves no marker, because nothing ran to leave one.

