### PR TITLE
docs(spec): the Decision Replayability standard, shipped out of a blocked worktree

### DIFF
--- a/docs/specs/decision-replayability-standard.eli16.md
+++ b/docs/specs/decision-replayability-standard.eli16.md
@@ -1,0 +1,71 @@
+# When the agent decides for you, you should be able to see the decision — Plain-English Overview
+
+> The one-line version: parts of this system make choices on your behalf, and some of them were
+> recording almost nothing about it. You could see *that* a decision happened, but not what the
+> options were, what was picked, or why. That's a receipt, not a record.
+
+## The problem
+
+There's a component that answers approval prompts for you. When your agent is running somewhere you
+can't see — driven from your phone, say — and the terminal stops to ask "do you want to proceed?",
+nobody is sitting there to press a key. So this component presses it.
+
+That's the right behaviour. The problem is what it wrote down afterwards: only the name of the
+pattern that matched. Nothing about what was on the screen, what the options were, which one it took,
+or why.
+
+That can't be reviewed. If you came back later and asked "should it have pressed that?", the record
+can't tell you. You'd know something happened, and nothing more.
+
+The reason it was built that way was privacy — the reasoning being that terminal contents might be
+sensitive, so better to store none of it. That reasoning gets the trade backwards. A choice made on
+your behalf that can't be reconstructed is a choice nobody can hold to account. That's a safety
+problem wearing a privacy costume.
+
+## What changes
+
+From now on, when something decides for you, the record has to be good enough to *replay* the
+decision: what was offered, what was chosen, the reasoning that produced it, and enough of the
+surrounding situation to judge whether it was right.
+
+The test is simple — if someone reading the record can't reconstruct the situation well enough to
+*disagree* with the choice, the record isn't good enough.
+
+## The screenshot question
+
+The obvious next question is whether we should just save a picture of the screen. That was asked, and
+the answer is interesting, because the question hides an assumption: that the choice is between a
+picture and nothing.
+
+For a terminal, it isn't. Saving a picture of the terminal and saving the terminal's *text* capture
+exactly the same information. But the text can be automatically checked for passwords and keys before
+it's saved, it can be searched later, and it can be compared between incidents. A picture can do none
+of those things.
+
+So the rule is: **save the text wherever text exists.** That's not being squeamish about the picture —
+it's that the picture is a *worse* record which also happens to be one we can't clean. Where there
+genuinely is no text version, like a browser page or a graphical dialog, then a picture it is, with
+limits on how much and how long.
+
+## Two limits worth knowing
+
+**We capture the prompt and its surroundings, not the whole scrolled-back terminal.** Everything
+further up is unrelated output from other work, which might contain sensitive things and answers no
+question the prompt doesn't already answer. Capturing more would be less safe and no more useful.
+
+**Nothing gets saved without being checked for credentials first.** And — this is the part that
+matters most — if that check strips out so much that the record no longer explains the decision, the
+record says so explicitly. It doesn't quietly leave behind something that looks complete but isn't.
+
+That last rule exists because a log that silently became useless is the exact trap this whole line of
+work keeps running into: something that's present, reports no problem, and guards nothing.
+
+## What this does not do yet
+
+**The standard is written. The code does not follow it yet.** The component described above still
+records only the pattern name. Changing it is real work, and it's been registered as a tracked item
+rather than quietly assumed.
+
+Saying "we have a standard for that" while the code ignores it would be the same failure this
+standard is about — so it's worth being blunt: right now this is a rule we've agreed to, not a rule
+the system enforces.

--- a/docs/specs/decision-replayability-standard.md
+++ b/docs/specs/decision-replayability-standard.md
@@ -1,0 +1,121 @@
+---
+title: "Decision Replayability — an unreplayable decision is an unaccountable one"
+slug: "decision-replayability-standard"
+author: "echo"
+status: "draft"
+created: 2026-07-27
+parent-principle: "Observability — you can't tune what you can't see"
+sibling-principles: "Documentation IS Being; Never-Waste Feedback; Signal vs. Authority; Know Your Principal"
+origin: "Operator directive, 2026-07-26 18:32Z: 'we tend to not record data for the sake of privacy. However, this is against the EXO 3.0 fundamentals which requires everything to be fully auditable. This is not a privacy issue. It's a safety and coherence issue and all the data needs to be recoverable so that the situation could be fully replayed and reevaluated.' Plus his 19:34Z follow-up asking me to decide the screenshot question."
+eli16-overview: "decision-replayability-standard.eli16.md"
+---
+
+# Decision Replayability
+
+> **The rule.** When an autonomous component makes a choice on the operator's behalf, the record
+> must be sufficient to REPLAY that choice: what was on offer, what was picked, why, and enough
+> surrounding state to re-evaluate it later. Recording only that a decision happened is not an audit
+> trail — it is a receipt.
+
+## 1. The failure this closes
+
+Instar components have repeatedly narrowed what they record, citing privacy. The clearest example is
+the permission-prompt auto-resolver, documented as recording **"matched-pattern names only, never raw
+pane text."** It presses a key on the operator's behalf and records only which regex matched.
+
+That cannot be replayed. It cannot answer *what was I choosing between?*, *what else was offered?*, or
+*would that choice still be right?* An operator reviewing it learns that something happened.
+
+**The operator's correction is the governing one:** this is not a privacy question. It is a safety and
+coherence question. A decision that cannot be reconstructed cannot be audited, and an unauditable
+autonomous decision is an unaccountable one.
+
+## 2. What must be recorded
+
+For every decision an autonomous component makes on the operator's behalf:
+
+| Field | Why |
+|---|---|
+| `optionsOffered` | The choice set. Without it "chose option 1" is meaningless. |
+| `optionChosen` | The action taken. |
+| `rationale` | Which rule/pattern/heuristic fired, and its inputs. Not just its NAME. |
+| `context` | The surrounding state needed to re-evaluate: the prompt region, session, framework, timestamp. |
+| `outcome` | What happened after — did it clear, did it recur. |
+
+"Enough to replay" is the bar. If a reviewer cannot reconstruct the situation well enough to disagree
+with the choice, the record is insufficient.
+
+## 3. The medium question — and why "screenshot" was the wrong frame
+
+The operator asked whether storing a screenshot is acceptable. The question contains an assumption
+worth challenging: that the choice is between an image and nothing.
+
+**For a terminal prompt it is not.** A tmux pane capture and a screenshot of that pane carry
+IDENTICAL information. But:
+
+| | scrubable | greppable | diffable | size |
+|---|---|---|---|---|
+| pane TEXT | ✅ passes the credential-scrubbing chokepoint | ✅ | ✅ | bytes |
+| IMAGE | ❌ cannot be scrubbed without OCR heuristics | ❌ | ❌ | KB–MB |
+
+**So the rule is: capture text wherever text exists.** This is not privacy-squeamishness dressed up —
+it is choosing the *more* auditable medium. An image is a worse audit artifact that also happens to be
+unscrubbable.
+
+**Images are required, and therefore permitted, where no text equivalent exists** — a GUI dialog, a
+browser page, a rendered chart. There, bounded region + bounded retention + sensitive-at-rest
+handling apply.
+
+## 4. The bound: prompt region, not unbounded scrollback
+
+Capture the decision's own context — the prompt and its immediate surroundings — **not** the entire
+scrollback buffer.
+
+This is a real bound, not a hedge. The audit question is *what was this component choosing between*,
+which the prompt region answers completely. Unbounded scrollback adds arbitrary preceding output —
+other tasks, other files, whatever was echoed — which is pure secret-exposure surface with **zero**
+additional audit value. A bigger capture would be less safe and no more replayable.
+
+## 5. The one hard floor
+
+Captured context passes the existing credential-scrubbing chokepoint before it is written. This is
+NOT a licence to record less: it is what makes recording MORE possible. The constitution makes
+credential exposure a non-overridable wall, and a standard that wrote unscrubbable secrets to disk by
+default would put those two rules in genuine conflict. Text capture removes the conflict entirely.
+
+**Scrubbing must never silently empty the record.** If scrubbing removes so much that the decision is
+no longer replayable, the record says so explicitly (`replayability: degraded` + reason) rather than
+storing a hollow entry that looks complete. An audit trail that quietly became useless is the exact
+absence-reads-as-presence failure this project exists to remove.
+
+## 6. Decision points touched
+
+| point | classification |
+|---|---|
+| what to record | `invariant` — the field set above is fixed, not per-component judgment |
+| text vs image | `invariant` — text where a text form exists; image only where it does not |
+| capture bound | `invariant` — prompt region, deterministic |
+| scrub-before-write | `invariant` — existing chokepoint, no new judgment |
+
+No judgment points, no LLM, nothing gated.
+
+## 7. Multi-machine posture
+
+**Posture: `machine-local`.** `machine-local-justification: physical-credential-locality` — a
+decision record is evidence of what happened on ONE machine's session, and the captured context can
+contain that machine's credentials-in-flight. Replicating it would multiply the at-rest exposure of
+scrubbed-but-sensitive context across every machine for zero audit gain: the reviewer wants the record
+where the decision happened. Cross-machine reads use the existing pool-scope fan-out, which serves
+from the owning machine rather than copying.
+
+## 8. Open questions
+
+*(none)* — the screenshot question is resolved in §3 by the operator's delegation (2026-07-26 19:34Z),
+recorded in the decision journal with its reasoning.
+
+## 9. Scope and status
+
+This standard is **written but NOT yet applied**. Applying it means changing at least
+`PermissionPromptAutoResolver` (today: matched-pattern names only) and auditing other components for
+the same narrowing. That work is tracked, not assumed — see the registered action. Writing the
+standard and claiming the components comply would be precisely the gap this project keeps finding.

--- a/upgrades/next/decision-replayability-standard.md
+++ b/upgrades/next/decision-replayability-standard.md
@@ -1,0 +1,48 @@
+# Upgrade Guide — vNEXT
+
+<!-- internal-only -->
+<!-- bump: patch -->
+
+## What Changed
+
+Adds `docs/specs/decision-replayability-standard.md` (plus its ELI16 companion) — the written
+standard for what must be recorded so a decision can be replayed and re-evaluated later, rather than
+merely asserted to have happened.
+
+It answers the question the operator asked directly: **is a screenshot an acceptable thing to store?**
+For a TERMINAL prompt the answer is no, and not for privacy reasons — the scrubbed pane TEXT of the
+prompt region carries identical information to an image of it, but only text is scrubbable,
+greppable, and diffable. Text is therefore *more* auditable, not less. Images remain the right medium
+only where no text form exists, such as a GUI or a browser.
+
+The standard carries three bounds so the rule cannot quietly become unbounded surveillance: capture
+the prompt REGION rather than full scrollback; scrub before write, never after; and mark a record
+`replayability: degraded` when scrubbing has hollowed it out, so a log can never silently become
+useless while still looking complete.
+
+## Evidence
+
+Docs-only: no runtime surface, no endpoint, no config key, no behaviour change. The standard's own
+`## Decision points touched` and `## Multi-machine posture` sections are present as the spec format
+requires.
+
+Shipped as its own change deliberately. The document was written and staged inside an unrelated
+worktree that is blocked awaiting operator approval — so a finished deliverable was sitting
+uncommitted behind a blocker it has no dependency on, one worktree removal away from being lost.
+Extracting it is the concrete application of the project's own rule that deferral is deletion.
+
+## Known limits
+
+This ships the standard, not its enforcement. Applying it to the first runtime consumer
+(`PermissionPromptAutoResolver`, which today records matched-pattern names and a one-way fingerprint
+but no replayable prompt region) is tracked separately as ACT-1312 and is deliberately NOT bundled
+here. Until that lands, the standard is a written rule with no mechanical guard behind it — which by
+this project's own measure means it is not yet enforced.
+
+## What to Tell Your User
+
+None — internal change (no user-facing surface).
+
+## Summary of New Capabilities
+
+None — internal change (no user-facing surface).


### PR DESCRIPTION
## ELI16 — the standard for recording a decision so it can be replayed

Justin asked a direct question on 2026-07-26: **is a screenshot an acceptable thing to store?**

The answer, for a TERMINAL prompt, is no — and the interesting part is that it is not a privacy
argument. The scrubbed pane TEXT of the prompt region carries **identical information** to a picture
of that same region. But text can be scrubbed of secrets, grepped, and diffed against the next
occurrence; an image can do none of those. So text is **more** auditable, not less. Storing the
picture would be choosing the medium that is harder to audit while feeling more complete.

Images remain the right answer exactly where no text form exists — a GUI, a browser.

The standard carries three bounds so "record everything" cannot quietly become unbounded capture:
capture the prompt **region**, not full scrollback; **scrub before write**, never after; and mark a
record `replayability: degraded` when scrubbing has hollowed it out — so a log can never silently
become useless while still looking complete.

## What Changed

Adds `docs/specs/decision-replayability-standard.md` (plus its ELI16 companion) — the written
standard for what must be recorded so a decision can be replayed and re-evaluated later, rather than
merely asserted to have happened.

It answers the question the operator asked directly: **is a screenshot an acceptable thing to store?**
For a TERMINAL prompt the answer is no, and not for privacy reasons — the scrubbed pane TEXT of the
prompt region carries identical information to an image of it, but only text is scrubbable,
greppable, and diffable. Text is therefore *more* auditable, not less. Images remain the right medium
only where no text form exists, such as a GUI or a browser.

The standard carries three bounds so the rule cannot quietly become unbounded surveillance: capture
the prompt REGION rather than full scrollback; scrub before write, never after; and mark a record
`replayability: degraded` when scrubbing has hollowed it out, so a log can never silently become
useless while still looking complete.

## Evidence

Docs-only: no runtime surface, no endpoint, no config key, no behaviour change. The standard's own
`## Decision points touched` and `## Multi-machine posture` sections are present as the spec format
requires.

Shipped as its own change deliberately. The document was written and staged inside an unrelated
worktree that is blocked awaiting operator approval — so a finished deliverable was sitting
uncommitted behind a blocker it has no dependency on, one worktree removal away from being lost.
Extracting it is the concrete application of the project's own rule that deferral is deletion.

## Known limits

This ships the standard, not its enforcement. Applying it to the first runtime consumer
(`PermissionPromptAutoResolver`, which today records matched-pattern names and a one-way fingerprint
but no replayable prompt region) is tracked separately as ACT-1312 and is deliberately NOT bundled
here. Until that lands, the standard is a written rule with no mechanical guard behind it — which by
this project's own measure means it is not yet enforced.

## What to Tell Your User

None — internal change (no user-facing surface).

## Summary of New Capabilities

None — internal change (no user-facing surface).
