### PR TITLE
fix(test-bound): stop charging a 60s poll budget for a permanent permission error

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T11-32-02-592Z-rendezvous-unwritable-fastfail.json
+++ b/.instar/instar-dev-decisions/2026-07-27T11-32-02-592Z-rendezvous-unwritable-fastfail.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T11:32:02.592Z",
+  "slug": "rendezvous-unwritable-fastfail",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 107,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/rendezvous-unwritable-fastfail.eli16.md
+++ b/docs/specs/rendezvous-unwritable-fastfail.eli16.md
@@ -1,0 +1,62 @@
+# A guard that took a minute to admit it couldn't run
+
+## What this is about
+
+Instar has a safety bound that stops too many test suites running at once on one machine. Test
+runners coordinate through a small set of files in a shared folder — a rendezvous point. Whoever
+holds the lock file runs; everyone else waits their turn.
+
+Waiting is the right behaviour when someone else genuinely holds the lock, because they will finish
+and release it.
+
+## The problem
+
+The waiting logic could not tell "someone else is using this" apart from "I am not allowed to write
+here at all".
+
+When a test run happens somewhere that cannot write to the shared folder — a sandboxed agent, a
+locked-down CI box, a read-only mount — the lock attempt fails with a permission error. The code
+treated that exactly like contention: it waited, retried every five seconds, and kept going for the
+full budget. Sixty seconds for a small run, two minutes for a full suite. Then it gave up, printed a
+clear warning, and let the run proceed anyway.
+
+The decision to let the run proceed was always correct. The problem was that it took a minute to
+reach it — because a folder you are not permitted to write to does not become writable by asking it
+twelve more times.
+
+## Why this is a correctness problem, not a speed one
+
+Sixty seconds is longer than anyone waits before concluding something is broken.
+
+That is not a guess. An agent running in a sandbox tried to test this very repository, saw no output
+for thirty seconds, concluded the tests could not run there, and reported them as unrunnable. Four
+separate sessions were written off as mysterious stalls. The warning explaining exactly what was
+happening did eventually print — after everybody had stopped looking.
+
+A warning that arrives after everyone has given up is, in practice, indistinguishable from silence.
+That is the same failure this guard exists to prevent, happening inside the guard itself.
+
+## What changed
+
+The lock attempt now reports which kind of failure occurred. A permission-class error means the
+rendezvous is structurally unusable, so the run is admitted immediately with a distinct reason
+recorded, instead of being polled against a budget that cannot help.
+
+Genuine contention is untouched: a lock held by another run still waits the full budget, because
+there waiting is exactly right.
+
+## Measured
+
+Same test file, same unwritable folder, one tree with the fix and one without:
+
+- Before: 66.23 seconds
+- After: 794 milliseconds
+
+The tests pass in both cases. Only the delay is gone.
+
+## An honest limitation
+
+When the shared folder cannot be written, the mechanism that limits how many runs may proceed at once
+cannot work either — it is itself made of files in that folder. That was already true before this
+change; the old path reached the same unbounded outcome, just a minute later. Saying so plainly is
+better than implying a protection that is not there.

--- a/src/core/hostSemaphoreCore.ts
+++ b/src/core/hostSemaphoreCore.ts
@@ -118,7 +118,21 @@ export function atomicWriteFileSync(
 
 export type LockTakeResult =
   | { ok: true; fd: number }
-  | { ok: false; reason: 'held' | 'error' };
+  | {
+      ok: false;
+      reason: 'held' | 'error';
+      /**
+       * The errno of the failure, surfaced ONLY on `reason: 'error'`.
+       *
+       * WHY: callers need to distinguish a TRANSIENT failure (worth polling) from a
+       * PERMANENT one (never worth polling). An unwritable rendezvous directory reports
+       * EACCES/EPERM and will not become writable by being asked twelve more times, but
+       * without the code every error looked alike and was waited out on the contention
+       * path. Purely additive — `reason` is unchanged, so existing callers behave exactly
+       * as before.
+       */
+      code?: string;
+    };
 
 /**
  * ONE attempt to take the exclusive lock at `lockPath` (O_CREAT|O_EXCL) and
@@ -142,7 +156,7 @@ export function tryTakeLockOnce(lockPath: string, record: string): LockTakeResul
       }
     }
     if (e.code === 'EEXIST') return { ok: false, reason: 'held' };
-    return { ok: false, reason: 'error' };
+    return { ok: false, reason: 'error', ...(e.code ? { code: e.code } : {}) };
   }
 }
 

--- a/src/core/hostTestRunnerSemaphore.ts
+++ b/src/core/hostTestRunnerSemaphore.ts
@@ -869,6 +869,13 @@ export class HostTestRunnerSemaphore {
   private readonly bootTimeMs: () => number | null;
   private readonly ttlMsOverride?: number;
   private readonly sleep: (ms: number) => Promise<void>;
+  /**
+   * Errno of a PERMANENT rendezvous failure observed by the last lock attempt, or null.
+   * Cleared on any successful lock take, so a transient permission blip that later
+   * resolves cannot leave the semaphore stuck in fast-fail. See
+   * `isPermanentRendezvousError`.
+   */
+  private rendezvousUnwritable: string | null = null;
   private readonly pollIntervalMs: number;
   private readonly genId: () => string;
 
@@ -1474,13 +1481,23 @@ export class HostTestRunnerSemaphore {
         this.paths.lock,
         JSON.stringify({ pid: process.pid, hostname: this.host, at: this.now() }),
       );
-      if (res.ok) return res.fd;
+      if (res.ok) {
+        this.rendezvousUnwritable = null;
+        return res.fd;
+      }
       if (res.reason === 'error') {
         // Could be a missing base dir — create and retry once.
         try {
           ensureBaseDir(this.paths);
-        } catch {
-          /* @silent-fallback-ok: the outer loop treats persistent errors as lock-unavailable */
+          if (isPermanentRendezvousError(res.code)) this.rendezvousUnwritable = res.code ?? 'EACCES';
+        } catch (err) {
+          // ensureBaseDir ITSELF failed. If it failed for a permission reason the
+          // rendezvous is structurally unwritable — record it so the outer loop can
+          // fail open at once instead of polling a directory that will never appear.
+          const code = (err as NodeJS.ErrnoException).code;
+          if (isPermanentRendezvousError(code)) this.rendezvousUnwritable = code ?? 'EACCES';
+          /* @silent-fallback-ok: a NON-permanent mkdir failure stays on the contention
+             path exactly as before — the outer loop treats it as lock-unavailable. */
         }
       }
       if (this.now() >= deadline) return null;
@@ -1621,6 +1638,46 @@ export class HostTestRunnerSemaphore {
         continue;
       }
       // Lock unavailable within the attempt deadline.
+      //
+      // FAST-FAIL on a structurally unwritable rendezvous. The budget below exists for
+      // CONTENTION — another run holds the lock and will release it. A permission failure
+      // will not resolve by waiting, so polling it merely charges the full budget (60s
+      // targeted / 120s suite) before reaching the SAME admit. The admission decision is
+      // unchanged; only its latency is. Distinct cause so the two are never conflated in
+      // the ledger.
+      if (this.rendezvousUnwritable !== null) {
+        // The storm ceiling, the witness and the ledger ALL live in the same directory we
+        // just proved unwritable, so each is best-effort here and none may prevent the
+        // admit. This is not a weakening: the pre-existing path reached the SAME admit
+        // via `claimStormSlot()` throwing EACCES into the outer handler — 60s later. The
+        // outcome is identical; only the delay is removed.
+        //
+        // Stated plainly because it matters: when the rendezvous cannot be written, the
+        // storm ceiling CANNOT bound fail-open admits — it is implemented as files in
+        // that directory. That limitation is inherent to an unwritable rendezvous, not
+        // introduced here, and pretending otherwise would be the dishonest option.
+        let stormSlot: number | null = null;
+        let witnessFile: string | null = null;
+        try {
+          stormSlot = this.claimStormSlot();
+          witnessFile = this.writeWitness();
+        } catch (err) {
+          if (err instanceof TestRunnerStormCeilingError) throw err; // a real ceiling still refuses
+          /* @silent-fallback-ok: bookkeeping in an unwritable rendezvous cannot succeed;
+             the admit below is the honest outcome and is recorded on stderr regardless. */
+        }
+        try {
+          this.ledger('fail-open-admit', {
+            cause: 'rendezvous-unwritable',
+            lane: req.lane,
+            stormSlot,
+            errno: this.rendezvousUnwritable,
+          });
+        } catch {
+          /* @silent-fallback-ok: the ledger file is inside the unwritable rendezvous. */
+        }
+        return { kind: 'fail-open-admit', cause: 'rendezvous-unwritable', witnessFile };
+      }
       const age = this.lockFileAgeMs();
       if (age !== null && age > LOCK_WEDGE_AGE_MS) {
         // Provably wedged (critical section is sub-ms) — race-safe age-reclaim.
@@ -1906,6 +1963,32 @@ export class HostTestRunnerSemaphore {
 
 function ensureBaseDir(paths: TestRunnerPaths): void {
   if (!fs.existsSync(paths.baseDir)) fs.mkdirSync(paths.baseDir, { recursive: true, mode: 0o700 });
+}
+
+/**
+ * Is this errno a PERMANENT rendezvous failure — one that polling cannot fix?
+ *
+ * The acquisition loop's wait budget exists for CONTENTION: another run holds the lock
+ * and will release it, so waiting is correct. A permission failure is categorically
+ * different — an unwritable rendezvous directory does not become writable because it was
+ * asked twelve more times at five-second intervals.
+ *
+ * MEASURED before this existed: with the rendezvous unwritable, a targeted run took
+ * 61.82s versus a 932ms control (66x) — the full 60s targeted budget burned, and only
+ * THEN the fail-open admit. The admit was always correct; its latency was not.
+ *
+ * Why that mattered beyond slowness: 60s exceeds any observer's patience window. A
+ * sandboxed agent investigating its own runs gave up at 30s and reported the tests as
+ * un-runnable. **A degradation that is loud but arrives after everyone has stopped
+ * looking is indistinguishable from a silent one** — which is the exact failure class
+ * this guard exists to prevent, occurring inside the guard.
+ *
+ * Deliberately NARROW: only EACCES/EPERM/EROFS. ENOENT is excluded — a missing directory
+ * IS fixable, and `ensureBaseDir` fixes it on the very next line. Anything unrecognised
+ * stays on the contention path, so an unfamiliar errno can never shorten the budget.
+ */
+function isPermanentRendezvousError(code: string | undefined): boolean {
+  return code === 'EACCES' || code === 'EPERM' || code === 'EROFS';
 }
 
 /** Sub-millisecond spin — permitted ONLY inside the lock critical section (§2.2). */

--- a/tests/unit/host-test-runner-rendezvous-unwritable.test.ts
+++ b/tests/unit/host-test-runner-rendezvous-unwritable.test.ts
@@ -1,0 +1,165 @@
+/**
+ * A PERMANENT rendezvous failure must fail open at once, not be waited out.
+ *
+ * MEASURED before this existed, with the rendezvous dir mode 500 and everything else
+ * identical (same test file, same directory, one tree with the fix and one without):
+ *
+ *     BEFORE  Duration 66.23s   Tests 5 passed
+ *     AFTER   Duration  794ms   Tests 5 passed
+ *
+ * The admit was always correct — the tests pass either way. What was wrong is that
+ * `takeLockBounded` reported EACCES as an undifferentiated error, so the acquisition loop
+ * treated a permanently unwritable directory as transient lock contention and polled it at
+ * 5s intervals for the whole 60s targeted budget before reaching the SAME conclusion.
+ *
+ * Why that is a correctness problem and not a performance one: 60s exceeds any observer's
+ * patience. A sandboxed agent investigating its own runs interrupted at 30s and reported
+ * the suite as un-runnable; four delegate sessions were written off as mysterious stalls.
+ * **A degradation that is loud but arrives after everyone has stopped looking is
+ * indistinguishable from a silent one** — the precise failure class this guard exists to
+ * prevent, happening inside the guard.
+ *
+ * These tests assert on the recorded SLEEP LIST rather than wall-clock duration:
+ * "did it poll at all?" is the actual claim, and it is deterministic.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  HostTestRunnerSemaphore,
+  resolveTestRunnerPaths,
+  type TestRunnerPaths,
+  type HostTestRunnerSemaphoreDeps,
+} from '../../src/core/hostTestRunnerSemaphore.js';
+import { tryTakeLockOnce } from '../../src/core/hostSemaphoreCore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const HOST = 'test-host';
+const madeDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of madeDirs.splice(0)) {
+    try {
+      fs.chmodSync(dir, 0o700);
+    } catch { /* may already be writable */ }
+    try {
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true, force: true,
+        operation: 'tests/unit/host-test-runner-rendezvous-unwritable.test.ts:cleanup',
+      });
+    } catch { /* best-effort */ }
+  }
+});
+
+/** A rendezvous whose base dir exists but cannot be written into. */
+function unwritablePaths(): TestRunnerPaths {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rendezvous-ro-'));
+  madeDirs.push(dir);
+  fs.chmodSync(dir, 0o500); // r-x — present, not writable
+  return resolveTestRunnerPaths({ INSTAR_HOST_TEST_BASE_DIR: dir });
+}
+
+/** A normal, writable rendezvous. */
+function writablePaths(): TestRunnerPaths {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rendezvous-rw-'));
+  madeDirs.push(dir);
+  return resolveTestRunnerPaths({ INSTAR_HOST_TEST_BASE_DIR: dir });
+}
+
+/**
+ * REAL clock for `now`, injected `sleep` that only RECORDS.
+ *
+ * A fully fake clock cannot be used here: `takeLockBounded` bounds its attempt with a
+ * sub-millisecond busy-wait against `now()`, so a clock that only advances inside `sleep`
+ * never reaches the 250ms deadline and the loop spins forever. (My first version of this
+ * harness did exactly that and hung — the test caught its own defect before it could be
+ * mistaken for one in the code.)
+ *
+ * The claim under test is "did it POLL?", and the recorded sleep list answers that
+ * precisely without needing a fake clock at all.
+ */
+function clockSem(paths: TestRunnerPaths, over: Partial<HostTestRunnerSemaphoreDeps> = {}) {
+  const sleeps: number[] = [];
+  const sem = new HostTestRunnerSemaphore({
+    paths,
+    env: {},
+    hostname: () => HOST,
+    dfProbe: () => ({ status: 'local' }),
+    pidAlive: () => true,
+    gatherEvidence: () => ({ startMs: new Map(), pgid: new Map() }),
+    signal: () => {},
+    bootTimeMs: () => null,
+    pollIntervalMs: 5000,
+    now: () => Date.now(),
+    sleep: async (ms: number) => { sleeps.push(ms); },
+    ...over,
+  } as HostTestRunnerSemaphoreDeps);
+  return { sem, sleeps };
+}
+
+// chmod does not restrain root. Running as root would silently turn the central test into
+// a no-op that still passes — exactly the "green but establishing nothing" shape this
+// project is about — so it is skipped loudly instead.
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+
+describe('rendezvous unwritable → fail open immediately', () => {
+  it.skipIf(isRoot)('THE FIX: admits at once with cause rendezvous-unwritable, without polling', async () => {
+    const { sem, sleeps } = clockSem(unwritablePaths());
+
+    const res = await sem.acquire({ lane: 'targeted', runClass: 'background', budgetMs: 60_000 });
+
+    expect(res.kind).toBe('fail-open-admit');
+    if (res.kind === 'fail-open-admit') {
+      // A distinct cause: never conflated with genuine contention in the ledger.
+      expect(res.cause).toBe('rendezvous-unwritable');
+    }
+    // The whole point. Previously this polled the full budget first.
+    expect(sleeps, 'must not poll a directory that cannot become writable').toEqual([]);
+  });
+
+  it.skipIf(isRoot)('the admit still happens — the decision is unchanged, only its latency', async () => {
+    // Dead-check for the test above: if the change had turned a fail-open into a refusal,
+    // the assertion on `cause` alone would not have caught it.
+    const { sem } = clockSem(unwritablePaths());
+    const res = await sem.acquire({ lane: 'suite', runClass: 'background', budgetMs: 120_000 });
+    expect(res.kind).toBe('fail-open-admit');
+  });
+
+  it('a WRITABLE rendezvous is unaffected — it acquires normally', async () => {
+    // The other side of the boundary: the fast-fail must not fire on a healthy path.
+    const { sem, sleeps } = clockSem(writablePaths());
+    const res = await sem.acquire({ lane: 'targeted', runClass: 'background', budgetMs: 60_000 });
+    expect(res.kind).toBe('acquired');
+    expect(sleeps).toEqual([]);
+  });
+});
+
+describe('tryTakeLockOnce errno surfacing', () => {
+  it('surfaces the errno on a permission failure', () => {
+    if (isRoot) return;
+    const paths = unwritablePaths();
+    const res = tryTakeLockOnce(paths.lock, 'record');
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.reason).toBe('error');
+      expect(res.code).toBe('EACCES');
+    }
+  });
+
+  it('a HELD lock reports contention and carries no errno — the distinction the fix rests on', () => {
+    const paths = writablePaths();
+    const first = tryTakeLockOnce(paths.lock, 'first');
+    expect(first.ok).toBe(true);
+
+    const second = tryTakeLockOnce(paths.lock, 'second');
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      // `held` is genuine contention: it WILL clear when the holder releases, so waiting
+      // is correct and this path must never be fast-failed.
+      expect(second.reason).toBe('held');
+      expect(second.code).toBeUndefined();
+    }
+  });
+});

--- a/upgrades/next/rendezvous-unwritable-fastfail.md
+++ b/upgrades/next/rendezvous-unwritable-fastfail.md
@@ -1,0 +1,78 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The host test-runner bound coordinates through lock and witness files under `~/.instar`. Its
+acquisition loop could not distinguish a lock HELD by another run (transient — waiting is correct)
+from a rendezvous it is not permitted to write to at all (permanent — waiting cannot help), because
+`tryTakeLockOnce` collapsed every non-EEXIST failure into an undifferentiated `error`.
+
+So in any environment that cannot write there — a sandboxed agent, a locked-down box, a read-only
+mount — a permission failure was polled at 5s intervals for the entire lane budget (60s targeted,
+120s suite) before reaching a fail-open admit.
+
+`tryTakeLockOnce` now surfaces the errno, and EACCES/EPERM/EROFS are classified as a permanent
+rendezvous failure that admits immediately with a distinct ledger cause `rendezvous-unwritable`.
+Genuine contention is untouched and still waits the full budget.
+
+## Evidence
+
+Same test file, same mode-500 rendezvous, one tree with the fix and one without:
+
+```
+BEFORE   Duration 66.23s    Tests 5 passed
+AFTER    Duration   794ms   Tests 5 passed
+```
+
+Falsified by disabling the fast-fail branch in production, which reproduces the old behaviour exactly
+— the durations are precisely the two lane budgets:
+
+```
+× THE FIX: admits at once with cause rendezvous-unwritable, without polling      60013ms
+  → EACCES: permission denied, mkdir '…/host-test-runner-witness'
+× the admit still happens — the decision is unchanged, only its latency         120020ms
+  Tests  2 failed | 3 passed (5)
+```
+
+Restored byte-identical. Green across every suite touching the changed files:
+`Test Files 5 passed (5) · Tests 150 passed (150)`; `tsc --noEmit` exit 0.
+
+The new tests assert on the recorded sleep list — "did it poll at all?" — rather than wall-clock
+duration, so the claim is deterministic.
+
+## Known limits
+
+When the rendezvous cannot be written, the storm ceiling cannot bound fail-open admits: it is made of
+files in that same directory. That was already true — the previous path called `claimStormSlot()`,
+which threw on its first `mkdirSync`, and admitted via the outer handler regardless. This change
+reaches the identical outcome in under a second instead of a minute; it does not create a protection
+that was never there.
+
+The classifier is deliberately narrow (EACCES/EPERM/EROFS). An unrecognised permanent errno still
+burns the full budget, because a wrong fast-fail is worse than a slow correct one.
+
+## What to Tell Your User
+
+Your agent's safety limit on running too many test suites at once used to take a full minute to
+notice when it could not operate at all.
+
+The limit works by having test runs check in with each other through a shared folder. If your agent
+is running somewhere it is not allowed to write to that folder, checking in fails immediately and
+permanently — but the code treated that the same as someone else being mid-run, and waited its turn
+for up to two minutes before giving up and continuing anyway.
+
+Continuing was the right call. Taking a minute to get there was not, because a minute is longer than
+anyone waits before assuming something is broken. That is not hypothetical: it caused several pieces
+of work to be abandoned as mysterious freezes when the explanation was printed all along, just far
+too late.
+
+It now recognises a permissions problem for what it is and carries on straight away, saying clearly
+that the limit is not in force in that environment rather than quietly implying it is.
+
+## Summary of New Capabilities
+
+No new endpoint, command, or config key. Lock failures now carry their errno, and the test-runner
+bound admits immediately on a permanently unwritable rendezvous with a distinct
+`rendezvous-unwritable` ledger cause.

--- a/upgrades/side-effects/rendezvous-unwritable-fastfail.md
+++ b/upgrades/side-effects/rendezvous-unwritable-fastfail.md
@@ -1,0 +1,81 @@
+# Side-effects review — fast-fail a permanently unwritable test-runner rendezvous
+
+**Change:** `tryTakeLockOnce` now surfaces the errno on its error branch; the test-runner semaphore
+classifies EACCES/EPERM/EROFS as a permanent rendezvous failure and fail-open-admits immediately with
+cause `rendezvous-unwritable`, instead of polling the full lane budget (60s targeted / 120s suite)
+and reaching the same admit.
+
+**Decision point touched?** Yes — the admission path of a safety bound. The DECISION is unchanged
+(both before and after, an unwritable rendezvous ends in a fail-open admit); only its LATENCY changes.
+That distinction is the whole review.
+
+---
+
+## 1. Over-block
+
+None. The change only ever shortens a wait that already ended in admission; nothing that previously
+proceeded is now refused. The one refusal path preserved deliberately: a genuine
+`TestRunnerStormCeilingError` is re-thrown rather than swallowed, so the storm ceiling still refuses
+when it is able to function.
+
+## 2. Under-block
+
+Real and worth stating precisely. When the rendezvous is unwritable the storm ceiling **cannot bound
+fail-open admits** — it is implemented as witness files in that same directory. So N concurrent runs
+in that environment all admit.
+
+This is NOT introduced here: the previous path called `claimStormSlot()`, which threw EACCES on its
+first `mkdirSync`, and the outer handler admitted anyway. The unbounded outcome is identical; this
+change reaches it in 800ms instead of 60s. The honest framing is that an unwritable rendezvous means
+the bound is not in force at all — and the ELI16 and the code comment both say so rather than implying
+protection that is absent.
+
+Also under-blocked: the classifier is narrow by design (EACCES/EPERM/EROFS). An exotic permanent
+errno not on that list still burns the full budget. Chosen deliberately — a wrong fast-fail is worse
+than a slow correct one, so anything unrecognised stays on the contention path.
+
+## 3. Level-of-abstraction fit
+
+Correct. The information needed (which errno) is produced at the syscall boundary in
+`hostSemaphoreCore.tryTakeLockOnce` and consumed by the loop that decides whether waiting can help.
+Surfacing it is additive — `reason` is unchanged, so the spawn-lane callers of the same primitive are
+untouched.
+
+## 4. Signal vs authority compliance
+
+Compliant. The semaphore keeps exactly the authority it had. No new blocking power is introduced; a
+detector (errno classification) feeds an existing decision. Per `docs/signal-vs-authority.md` this is
+the good direction: a cheap deterministic signal informing an authority that already existed.
+
+## 5. Interactions
+
+`LockTakeResult` gains an optional `code` field on the error branch — additive, consumed only by the
+test-runner semaphore. The spawn semaphore and its priority variant use the same primitive and are
+unaffected (verified: 150 tests green across all five semaphore suites).
+
+New ledger cause `rendezvous-unwritable`, distinct from the existing
+`lock-unavailable-full-budget`, so the two are never conflated when reading the event log — an
+environment that cannot host the bound looks different from a genuinely contended one.
+
+`rendezvousUnwritable` is cleared on any successful lock take, so a transient permission blip that
+later resolves cannot leave the semaphore latched into fast-fail.
+
+## 6. External surfaces
+
+None. No endpoint, no config key, no user-visible behaviour. The observable difference is that a run
+in an unwritable-rendezvous environment starts ~60s sooner and its ledger row names a different
+cause.
+
+## 7. Multi-machine posture
+
+**Machine-local by design, and inherently so.** The rendezvous is a host-wide coordination point
+under `~/.instar` — its entire purpose is bounding concurrency on ONE machine's CPU. There is nothing
+to replicate: another machine's test concurrency is not this machine's concern, and a shared
+rendezvous across machines would be actively wrong. No new state surface is introduced; this changes
+the latency of an existing per-host read/write path.
+
+## 8. Rollback cost
+
+Trivial. Remove the fast-fail branch and the errno field; behaviour returns to polling the full
+budget. No persisted state, no schema, no migration — the only durable trace is ledger rows carrying
+the new cause string, which readers already tolerate as free-form.


### PR DESCRIPTION
## ELI16 — a guard that took a full minute to admit it couldn't run

Instar has a safety bound that stops too many test suites running at once on one machine. Runs
coordinate through lock files in a shared folder: whoever holds the lock runs, everyone else waits.
**Waiting is correct when someone else genuinely holds it** — they will finish and release it.

The waiting logic could not tell *"someone else is using this"* apart from *"I am not allowed to write
here at all."* Both arrived as an undifferentiated error, because `tryTakeLockOnce` collapsed every
non-`EEXIST` failure into one bucket and threw the errno away.

So anywhere that folder is unwritable — a sandboxed agent, a locked-down box, a read-only mount — a
permission failure was polled every 5 seconds for the **entire** lane budget (60s targeted, 120s
suite), then admitted anyway. **A folder you lack permission to write does not become writable by
asking it twelve more times.**

Letting the run proceed was always the right call. Taking a minute to get there was not.

## Evidence

Same test file, same mode-500 rendezvous, one tree with the fix and one without:

```
BEFORE   Duration 66.23s    Tests 5 passed
AFTER    Duration   794ms   Tests 5 passed
```

Falsified by disabling the fast-fail branch in production, which reproduces the old behaviour exactly
— the durations are precisely the two lane budgets:

```
× THE FIX: admits at once with cause rendezvous-unwritable, without polling      60013ms
  → EACCES: permission denied, mkdir '…/host-test-runner-witness'
× the admit still happens — the decision is unchanged, only its latency         120020ms
  Tests  2 failed | 3 passed (5)
```

Restored byte-identical. Green across every suite touching the changed files:
`Test Files 5 passed (5) · Tests 150 passed (150)`; `tsc --noEmit` exit 0.

The new tests assert on the recorded sleep list — "did it poll at all?" — rather than wall-clock
duration, so the claim is deterministic.

## Known limits

When the rendezvous cannot be written, the storm ceiling cannot bound fail-open admits: it is made of
files in that same directory. That was already true — the previous path called `claimStormSlot()`,
which threw on its first `mkdirSync`, and admitted via the outer handler regardless. This change
reaches the identical outcome in under a second instead of a minute; it does not create a protection
that was never there.

The classifier is deliberately narrow (EACCES/EPERM/EROFS). An unrecognised permanent errno still
burns the full budget, because a wrong fast-fail is worse than a slow correct one.

## What to Tell Your User

Your agent's safety limit on running too many test suites at once used to take a full minute to
notice when it could not operate at all.

The limit works by having test runs check in with each other through a shared folder. If your agent
is running somewhere it is not allowed to write to that folder, checking in fails immediately and
permanently — but the code treated that the same as someone else being mid-run, and waited its turn
for up to two minutes before giving up and continuing anyway.

Continuing was the right call. Taking a minute to get there was not, because a minute is longer than
anyone waits before assuming something is broken. That is not hypothetical: it caused several pieces
of work to be abandoned as mysterious freezes when the explanation was printed all along, just far
too late.

It now recognises a permissions problem for what it is and carries on straight away, saying clearly
that the limit is not in force in that environment rather than quietly implying it is.

## Summary of New Capabilities

No new endpoint, command, or config key. Lock failures now carry their errno, and the test-runner
bound admits immediately on a permanently unwritable rendezvous with a distinct
`rendezvous-unwritable` ledger cause.

## Why this is a correctness problem, not a speed one

Sixty seconds is longer than anyone waits before concluding something is broken. That is not
hypothetical — it is what this session actually did: a sandboxed agent testing this repo saw no
output for 30s, concluded the suite was un-runnable, and **four delegate sessions were written off as
mysterious stalls** while the warning explaining it printed all along, just far too late.

**A degradation that is loud but arrives after everyone has stopped looking is indistinguishable from
a silent one** — the exact failure class this guard exists to prevent, occurring inside the guard.
