### PR TITLE
feat(channels): WhatsApp and iMessage join the registry, and the Telegram row names its subject

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T12-38-42-974Z-channels-wa-imessage.json
+++ b/.instar/instar-dev-decisions/2026-07-27T12-38-42-974Z-channels-wa-imessage.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T12:38:42.974Z",
+  "slug": "channels-wa-imessage",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 151,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-27T14-57-25-948Z-channels-wa-imessage.json
+++ b/.instar/instar-dev-decisions/2026-07-27T14-57-25-948Z-channels-wa-imessage.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T14:57:25.948Z",
+  "slug": "channels-wa-imessage",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 169,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/channels-wa-imessage.eli16.md
+++ b/docs/specs/channels-wa-imessage.eli16.md
@@ -1,0 +1,51 @@
+# Closing a gap I wrote down myself
+
+## What this is
+
+Your agent has a page that answers "which ways of reaching you actually work right now?" It checks
+each channel's live state rather than reading the settings file — because a settings file says
+"Telegram: on" just as confidently four hours after the connection died.
+
+When that page was built it covered Telegram and Slack, and the note shipped alongside it said
+plainly that WhatsApp and iMessage existed but were not covered. That was honest, but it was also a
+hole in the one promise the page makes: every channel gets a row, so a broken one can never simply be
+missing. A channel with no row cannot report that it is missing.
+
+This adds the two missing rows.
+
+## The state that a yes-or-no answer would have destroyed
+
+WhatsApp does not have a simple connected-or-not flag. It runs through real stages, and one of them
+matters a lot: **waiting for you to scan a pairing code**.
+
+In that state the connection is perfectly alive. It is simply not authenticated yet, and no amount of
+restarting will change that — a person has to pick up a phone and scan. If the page reported that as
+"broken", it would send someone off to debug a connection that is behaving exactly as designed.
+
+So it gets its own verdict: reachable, but no credential yet. The same distinction Telegram already
+makes when its token is rejected.
+
+The in-between stages — connecting, reconnecting — report "unknown" with the stage named, rather than
+being guessed either way. An answer that will be different in five seconds should not be frozen into
+a verdict.
+
+## The trap that was inside this fix
+
+iMessage reports a connection time alongside its state. It would have been the natural thing to show.
+
+It is fiction. The value is computed as "if we are started, the time right now" — so it reports the
+moment you asked, never the moment it connected. Ask three times, get three different connection
+times, all of them wrong.
+
+The rows are built on the state and deliberately not on that field, and a test now fails if anyone
+wires it in. A displayed timestamp looks more precise than a state name, which is exactly what makes
+it worse: it would have been confidently wrong instead of honestly vague.
+
+## Honest limits
+
+A live reading is not a promise. "Working" means the link was up when asked — not that a message to
+one particular chat or contact would arrive. Both rows say so in their own text rather than leaving
+the reader to assume.
+
+iMessage is also tied to one machine, because the thing it talks to runs there. That is recorded as a
+real cost of choosing it, not hidden.

--- a/src/core/userChannels.ts
+++ b/src/core/userChannels.ts
@@ -62,7 +62,33 @@ export interface UserChannelProbeContext {
   slackConnected: () => boolean | null;
   /** Whether Slack is switched on for this agent at all. Off is not broken. */
   slackEnabled: () => boolean;
+  /**
+   * WhatsApp's live connection state, or null when no adapter was constructed here.
+   *
+   * Read from `getStatus().state`, which is a real state machine
+   * (`disconnected | connecting | qr-pending | connected | reconnecting | closed`) rather
+   * than a boolean — so the row can distinguish "waiting for the operator to scan a QR"
+   * from "the link dropped", which a boolean would flatten into one indistinguishable
+   * "not working".
+   */
+  whatsappState: () => WhatsAppLiveState | null;
+  /**
+   * iMessage's live backend state, or null when no adapter was constructed here.
+   *
+   * Read from `getConnectionInfo().state`. Deliberately NOT `connectedAt` from the same
+   * object: that field is computed as `started ? new Date().toISOString() : undefined`, so
+   * it reports the moment you ASKED rather than the moment it connected. A row built on it
+   * would look precise and be fiction.
+   */
+  imessageState: () => IMessageLiveState | null;
 }
+
+/** The WhatsApp connection states this module distinguishes. Mirrors the adapter's own union. */
+export type WhatsAppLiveState =
+  | 'disconnected' | 'connecting' | 'qr-pending' | 'connected' | 'reconnecting' | 'closed';
+
+/** The iMessage backend states this module distinguishes. */
+export type IMessageLiveState = 'disconnected' | 'connecting' | 'connected' | string;
 
 /**
  * Map live Telegram state onto the registry's vocabulary.
@@ -115,13 +141,27 @@ export function telegramStateFrom(status: TelegramLiveStatus | null): ChannelPro
   // Stopped, with no reason the adapter could classify. That is genuinely undetermined: it may have
   // been stopped deliberately or have died silently, and this cannot tell which. `unknown` is the
   // honest verdict and is NEVER a synonym for healthy.
+  //
+  // THE SUBJECT MUST BE NAMED, and this row originally failed to name it. What is measured is the
+  // SERVER process's adapter. On a lifeline deployment inbound Telegram does not arrive through that
+  // adapter at all — a separate lifeline process polls and forwards to the server, which logs
+  // "Telegram relay wired (via lifeline callback forwarding)". There, a stopped server poll loop is
+  // NORMAL and says nothing about whether messages are arriving.
+  //
+  // Observed live on 2026-07-27: this row read `unknown` while inbound was perfectly healthy via the
+  // lifeline. That is the SAME scope error the threadline-relay row was fixed for hours earlier — a
+  // true statement whose subject is unstated, so the reader draws a conclusion about a path that was
+  // never measured. Naming the subject is the whole fix; the verdict itself stays `unknown`, because
+  // what this CAN see is genuinely undetermined.
   return {
     state: 'unknown',
     direction: 'none',
     detail:
-      'the Telegram poll loop is not running and the adapter recorded no reason' +
+      'the SERVER adapter\'s Telegram poll loop is not running and it recorded no reason' +
       (status.stoppedAt ? ` (stopped at ${status.stoppedAt})` : '') +
-      '; cannot tell a deliberate stop from a silent death',
+      '; cannot tell a deliberate stop from a silent death. NOTE this measures the server adapter only'
+      + ' — on a lifeline deployment inbound arrives via the lifeline process, so this alone does not'
+      + ' mean messages are not being received',
   };
 }
 
@@ -153,6 +193,94 @@ export function slackStateFrom(enabled: boolean, connected: boolean | null): Cha
   };
 }
 
+/**
+ * WhatsApp's state machine → an honest channel verdict.
+ *
+ * The interesting case is `qr-pending`: the link is alive and waiting for the operator to
+ * scan a code. That is neither working nor broken — it is *reachable, no credential yet*,
+ * and it needs a HUMAN action rather than a restart. Reporting it as `broken` would send
+ * someone to debug a connection that is behaving exactly as designed.
+ *
+ * `connecting` / `reconnecting` are genuinely in-flight, so they report `unknown` with the
+ * phase named rather than being guessed either way — an answer that will be different in
+ * five seconds must not be frozen into a verdict.
+ */
+export function whatsappStateFrom(state: WhatsAppLiveState | null): ChannelProbeResult {
+  if (state === null) {
+    return {
+      state: 'not-configured', direction: 'none',
+      detail: 'no WhatsApp adapter was constructed on this agent',
+    };
+  }
+  switch (state) {
+    case 'connected':
+      return {
+        state: 'working', direction: 'bidirectional',
+        detail: 'adapter reports connected; NOTE this is the link state, not proof a send to a particular chat would land',
+      };
+    case 'qr-pending':
+      return {
+        state: 'reachable-no-credential', direction: 'none',
+        detail: 'waiting for the operator to scan the pairing QR — the link is alive but unauthenticated; restarting will not help, a human must scan',
+      };
+    case 'connecting':
+    case 'reconnecting':
+      return {
+        state: 'unknown', direction: 'none',
+        detail: `link is ${state} — in flight, so neither working nor broken can be asserted yet`,
+      };
+    case 'disconnected':
+    case 'closed':
+      return {
+        state: 'broken', direction: 'none',
+        detail: `adapter reports ${state}; a send would be refused`,
+      };
+    default:
+      // An unrecognised state is NOT healthy and NOT a confident broken.
+      return {
+        state: 'unknown', direction: 'none',
+        detail: `adapter reported an unrecognised state (${String(state)})`,
+      };
+  }
+}
+
+/**
+ * iMessage's backend state → an honest channel verdict.
+ *
+ * Narrower than WhatsApp because the backend exposes less. Deliberately built on `state`
+ * and NOT on the sibling `connectedAt`, which is computed as
+ * `started ? new Date().toISOString() : undefined` — i.e. it always reports the moment you
+ * asked, never the moment it connected. A row built on that would look precise and be
+ * fiction, which is the exact failure this registry exists to prevent.
+ */
+export function imessageStateFrom(state: IMessageLiveState | null): ChannelProbeResult {
+  if (state === null) {
+    return {
+      state: 'not-configured', direction: 'none',
+      detail: 'no iMessage adapter was constructed on this agent',
+    };
+  }
+  if (state === 'connected') {
+    return {
+      state: 'working', direction: 'bidirectional',
+      detail: 'backend reports connected; NOTE this is the backend link, not proof a send to a particular contact would land',
+    };
+  }
+  if (state === 'connecting') {
+    return {
+      state: 'unknown', direction: 'none',
+      detail: 'backend is connecting — in flight, so neither working nor broken can be asserted yet',
+    };
+  }
+  if (state === 'disconnected') {
+    return { state: 'broken', direction: 'none', detail: 'backend reports disconnected; a send would be refused' };
+  }
+  return {
+    state: 'unknown', direction: 'none',
+    detail: `backend reported an unrecognised state (${String(state)})`,
+  };
+}
+
 export function buildUserChannelDefinitions(ctx: UserChannelProbeContext): ChannelDefinition[] {
   return [
     {
@@ -180,6 +308,30 @@ export function buildUserChannelDefinitions(ctx: UserChannelProbeContext): Chann
         'the wrong surface for anything they would not want their workspace to see.',
       probe: async (): Promise<ChannelProbeResult> =>
         slackStateFrom(ctx.slackEnabled(), ctx.slackConnected()),
+    },
+    {
+      id: 'user-whatsapp',
+      audience: 'user',
+      purpose: "A WhatsApp line the operator reads, paired to their own phone.",
+      whenPreferred:
+        'When the operator is away from a desk — it reaches a phone people actually carry. Same '
+        + 'user-experience-proof property as Telegram: it shows what they genuinely receive.',
+      cost:
+        "Spends the operator's attention on their most personal channel, so the bar for using it is "
+        + 'higher than for Telegram. Pairing is human-gated: a dropped link needs a QR scan, not a restart.',
+      probe: async (): Promise<ChannelProbeResult> => whatsappStateFrom(ctx.whatsappState()),
+    },
+    {
+      id: 'user-imessage',
+      audience: 'user',
+      purpose: "iMessage to the operator, through a backend on this machine.",
+      whenPreferred:
+        'When the operator is on Apple devices and wants messages where they already read them. '
+        + 'Like the others, it is a real user surface rather than a proxy for one.',
+      cost:
+        "Spends the operator's attention, and is machine-bound: it works only from the host holding "
+        + 'the backend, so it is the wrong choice for anything that must survive this machine going away.',
+      probe: async (): Promise<ChannelProbeResult> => imessageStateFrom(ctx.imessageState()),
     },
   ];
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -30176,6 +30176,19 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         slackConnected: () =>
           slackAdapter && typeof slackAdapter.isConnected === 'function' ? slackAdapter.isConnected() : null,
         slackEnabled: () => Boolean(slackAdapter),
+        // `getStatus().state` is a real state machine, so `qr-pending` (waiting on a human to
+        // scan) stays distinguishable from `disconnected` (the link dropped).
+        whatsappState: () =>
+          ctx.whatsapp && typeof ctx.whatsapp.getStatus === 'function'
+            ? ctx.whatsapp.getStatus().state
+            : null,
+        // `getConnectionInfo().state`, NOT the sibling `connectedAt` — that field is computed as
+        // `started ? new Date().toISOString() : undefined`, so it reports the moment you asked
+        // rather than the moment it connected.
+        imessageState: () =>
+          ctx.imessage && typeof ctx.imessage.getConnectionInfo === 'function'
+            ? ctx.imessage.getConnectionInfo().state
+            : null,
       });
       const report = await resolveChannels([...defs, ...userDefs]);
       return res.status(200).json({ advisory: true, ...report });

--- a/tests/integration/channels-route.test.ts
+++ b/tests/integration/channels-route.test.ts
@@ -71,8 +71,8 @@ describe('GET /channels (integration — the wiring, not just the resolver)', ()
 
     expect(res.status).toBe(200);
     expect(res.body.channels.map((c: { id: string }) => c.id).sort())
-      .toEqual(['a2a-telegram', 'mutual-ssh', 'peer-http', 'threadline-relay', 'user-slack', 'user-telegram']);
-    expect(res.body.summary.total).toBe(6);
+      .toEqual(['a2a-telegram', 'mutual-ssh', 'peer-http', 'threadline-relay', 'user-imessage', 'user-slack', 'user-telegram', 'user-whatsapp']);
+    expect(res.body.summary.total).toBe(8);
   });
 
   /**
@@ -91,7 +91,7 @@ describe('GET /channels (integration — the wiring, not just the resolver)', ()
         .map((c: { id: string }) => c.id).sort();
 
     expect(byAudience('peer')).toEqual(['a2a-telegram', 'mutual-ssh', 'peer-http', 'threadline-relay']);
-    expect(byAudience('user')).toEqual(['user-slack', 'user-telegram']);
+    expect(byAudience('user')).toEqual(['user-imessage', 'user-slack', 'user-telegram', 'user-whatsapp']);
     // Every row must declare one; an untagged channel is not a third state, it is a bug.
     for (const c of res.body.channels) expect(['peer', 'user']).toContain(c.audience);
   });

--- a/tests/unit/user-channel-liveness.test.ts
+++ b/tests/unit/user-channel-liveness.test.ts
@@ -29,6 +29,40 @@ const healthy: TelegramLiveStatus = {
   stoppedAt: null,
 };
 
+/**
+ * REGRESSION (2026-07-27, found by live-checking the shipped feature on the running agent).
+ *
+ * The `unknown` verdict said "the Telegram poll loop is not running" without naming WHOSE poll loop.
+ * What it measures is the SERVER process's adapter. On a lifeline deployment inbound Telegram never
+ * goes through that adapter — a separate lifeline process polls and forwards, and the server logs
+ * "Telegram relay wired (via lifeline callback forwarding)". There a stopped server poller is NORMAL.
+ *
+ * Observed live: this row read `unknown` while inbound was healthy. Same scope error the
+ * threadline-relay row was fixed for hours earlier — a true statement whose subject is unstated, so
+ * the reader concludes something about a path that was never measured.
+ */
+describe('the unknown verdict names its subject', () => {
+  it('says it measured the SERVER adapter, not inbound generally', () => {
+    const r = telegramStateFrom({
+      started: false, fatalReason: null, consecutivePollErrors: 0, lastError: null, stoppedAt: null,
+    });
+    expect(r.state).toBe('unknown');
+    expect(r.detail).toMatch(/server adapter/i);
+    // And it must say what that does NOT establish — the part a reader would otherwise infer.
+    expect(r.detail).toMatch(/lifeline/i);
+    expect(r.detail).toMatch(/does not|not mean/i);
+  });
+
+  it('still refuses to call it healthy — naming the subject must not soften the verdict', () => {
+    // The failure direction that matters: an unnamed subject was bad, but a reassuring one is worse.
+    const r = telegramStateFrom({
+      started: false, fatalReason: null, consecutivePollErrors: 0, lastError: null, stoppedAt: null,
+    });
+    expect(r.state).not.toBe('working');
+    expect(r.direction).toBe('none');
+  });
+});
+
 describe('user channel liveness — the refusals', () => {
   it('THE FIX: a configured-but-DEAD Telegram is never reported as working', () => {
     // This is the whole point. Config still says the bot is set up; the loop is dead.

--- a/tests/unit/user-channel-wa-imessage.test.ts
+++ b/tests/unit/user-channel-wa-imessage.test.ts
@@ -1,0 +1,113 @@
+/**
+ * WhatsApp and iMessage join the channel registry.
+ *
+ * WHY THIS EXISTS. When the direct user channels were added (PR #1665) the artifact recorded an
+ * explicit gap: "WhatsApp and iMessage adapters exist in the tree and are NOT covered — under the
+ * registry's own 'absence is impossible' property that is a real gap." A channel with no row cannot
+ * report that it is missing, so the honest limit was a hole in the very invariant the registry
+ * exists to hold. This closes it rather than leaving the note standing permanently.
+ *
+ * THE STATE THAT MATTERS. WhatsApp is not a boolean — its adapter runs a real state machine, and
+ * `qr-pending` means the link is alive and waiting for a HUMAN to scan a pairing code. A boolean
+ * would flatten that into "not working" and send someone to debug a connection behaving exactly as
+ * designed. It is `reachable-no-credential`: reachable, unauthenticated, and a restart will not help.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { whatsappStateFrom, imessageStateFrom } from '../../src/core/userChannels.js';
+
+describe('WhatsApp channel verdicts', () => {
+  it('THE STATE A BOOLEAN LOSES: qr-pending is reachable-no-credential, not broken', () => {
+    const r = whatsappStateFrom('qr-pending');
+    expect(r.state).toBe('reachable-no-credential');
+    // The operator must be told a restart is the wrong action here.
+    expect(r.detail).toMatch(/scan/i);
+  });
+
+  it('connected is working, and says what it does NOT prove', () => {
+    const r = whatsappStateFrom('connected');
+    expect(r.state).toBe('working');
+    expect(r.detail).toMatch(/not proof/i);
+  });
+
+  it.each(['disconnected', 'closed'] as const)('%s is broken', (s) => {
+    expect(whatsappStateFrom(s).state).toBe('broken');
+  });
+
+  it.each(['connecting', 'reconnecting'] as const)('%s is unknown — in flight, not guessed', (s) => {
+    const r = whatsappStateFrom(s);
+    expect(r.state).toBe('unknown');
+    expect(r.detail).toMatch(/in flight/i);
+  });
+
+  it('no adapter is not-configured — off is not broken', () => {
+    expect(whatsappStateFrom(null).state).toBe('not-configured');
+  });
+
+  it('an UNRECOGNISED state is unknown — never working, never a confident broken', () => {
+    // The failure direction that matters: a state this module has not seen must not read as healthy.
+    const r = whatsappStateFrom('some-future-state' as never);
+    expect(r.state).toBe('unknown');
+    expect(r.detail).toMatch(/unrecognised/i);
+  });
+});
+
+describe('iMessage channel verdicts', () => {
+  it('connected is working, and says what it does NOT prove', () => {
+    const r = imessageStateFrom('connected');
+    expect(r.state).toBe('working');
+    expect(r.detail).toMatch(/not proof/i);
+  });
+
+  it('disconnected is broken', () => {
+    expect(imessageStateFrom('disconnected').state).toBe('broken');
+  });
+
+  it('connecting is unknown — in flight', () => {
+    expect(imessageStateFrom('connecting').state).toBe('unknown');
+  });
+
+  it('no adapter is not-configured', () => {
+    expect(imessageStateFrom(null).state).toBe('not-configured');
+  });
+
+  it('an unrecognised backend state is unknown', () => {
+    expect(imessageStateFrom('weird').state).toBe('unknown');
+  });
+});
+
+describe('source ratchets — the verdicts must keep reading LIVE state', () => {
+  const src = fs.readFileSync(
+    path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../src/core/userChannels.ts'),
+    'utf-8',
+  );
+
+  it('never reads configuration to decide liveness', () => {
+    // The original defect this whole module exists to prevent: a setting read as a state.
+    expect(src).not.toMatch(/\.configured\b/);
+  });
+
+  /**
+   * The trap inside this fix. `getConnectionInfo()` also exposes `connectedAt`, computed as
+   * `started ? new Date().toISOString() : undefined` — it reports the moment you ASKED, never the
+   * moment it connected. A row built on it would look precise and be fiction, which is exactly the
+   * failure the registry exists to prevent, rebuilt inside its own extension.
+   */
+  it('RATCHET: the iMessage verdict is not built on the always-now connectedAt field', () => {
+    const fn = src.slice(src.indexOf('export function imessageStateFrom'));
+    const body = fn.slice(0, fn.indexOf('\n}'));
+    expect(body).not.toMatch(/connectedAt/);
+  });
+
+  it('RATCHET: the route wires WhatsApp from getStatus().state, not a boolean', () => {
+    const routes = fs.readFileSync(
+      path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../src/server/routes.ts'),
+      'utf-8',
+    );
+    expect(routes).toContain('ctx.whatsapp.getStatus().state');
+    expect(routes).toContain('ctx.imessage.getConnectionInfo().state');
+  });
+});

--- a/upgrades/next/channels-wa-imessage.md
+++ b/upgrades/next/channels-wa-imessage.md
@@ -1,0 +1,76 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+`GET /channels` covers WhatsApp and iMessage. Both adapters existed but had no registry row — a gap
+recorded explicitly when the direct user channels shipped, and a hole in the registry's own
+"absence is impossible" property, since a channel with no row cannot report that it is missing.
+
+WhatsApp is read from `getStatus().state`, a real state machine rather than a boolean, so
+`qr-pending` maps to `reachable-no-credential` — the link is alive and waiting for a human to scan a
+pairing code, and a restart will not help. `connecting`/`reconnecting` report `unknown` with the phase
+named rather than being guessed; `disconnected`/`closed` are `broken`; an unrecognised state is
+`unknown`, never `working`.
+
+iMessage is read from `getConnectionInfo().state`, deliberately NOT the sibling `connectedAt` — that
+field is computed as `started ? new Date().toISOString() : undefined`, so it reports the moment you
+asked rather than the moment it connected. A source ratchet fails if anyone wires it in.
+
+## Evidence
+
+Falsified by flattening `qr-pending` to `broken` in production:
+
+```
+× THE STATE A BOOLEAN LOSES: qr-pending is reachable-no-credential, not broken
+  → expected 'broken' to be 'reachable-no-credential'
+  Tests  1 failed | 15 passed (16)
+```
+
+Restored byte-identical. Green across every suite touching the change:
+`Test Files 5 passed (5) · Tests 59 passed (59)` (`user-channel-wa-imessage`,
+`user-channel-liveness`, `channel-registry`, `channel-registry-claims`, `channels-route`);
+`tsc --noEmit` exit 0. The integration test pinning the exact channel set and the audience partition
+was updated in this change rather than left for CI to catch.
+
+## Also in this change: the Telegram row now names its subject
+
+Found by checking the shipped feature on a running agent rather than only in tests. `/capabilities`
+reported `telegram: { configured: true, adapter: true, bidirectional: true }` while `/channels`
+reported `user-telegram: unknown — the Telegram poll loop is not running` — the config surface and the
+live surface disagreeing, which is exactly what this registry exists to expose.
+
+But the row was measuring the SERVER process's adapter and presenting it as the channel's state. On a
+lifeline deployment inbound never goes through that adapter: a separate lifeline process polls and
+forwards, and the server logs "Telegram relay wired (via lifeline callback forwarding)". Inbound was
+healthy; a stopped server poller is normal there.
+
+That is the same scope error the `threadline-relay` row was fixed for in #1667 — a true statement
+whose subject is unstated, so the reader concludes something about a path that was never measured.
+The verdict stays `unknown` (what it can see is genuinely undetermined); it now names the server
+adapter and says plainly that this alone does not mean messages are not arriving.
+
+## Known limits
+
+`working` means the link was up when probed — not that a message to a particular chat or contact
+would land. Neither row probes a round-trip, because a status read must not send. iMessage is bound to
+the host running its backend, recorded as a real cost of choosing it.
+
+## What to Tell Your User
+
+Your agent can now tell you whether WhatsApp and iMessage are actually working, alongside Telegram and
+Slack.
+
+The useful part is what it says when WhatsApp is waiting for you to scan a pairing code. That is not
+broken — the connection is fine, it just needs you for a moment — and restarting things would not fix
+it. It now says exactly that, instead of lumping it in with a dropped connection.
+
+It is also careful about what it does not know. If a link is mid-connection it says so rather than
+guessing, and a working link means the connection was up when it checked, not a promise that a message
+to one particular person will arrive.
+
+## Summary of New Capabilities
+
+No new endpoint, command, or config key. `GET /channels` gains `user-whatsapp` and `user-imessage`
+rows with live-state verdicts.

--- a/upgrades/side-effects/channels-wa-imessage.md
+++ b/upgrades/side-effects/channels-wa-imessage.md
@@ -1,0 +1,77 @@
+# Side-effects review — WhatsApp + iMessage join the channel registry
+
+**Change:** `buildUserChannelDefinitions` gains `user-whatsapp` and `user-imessage` rows, with
+exported `whatsappStateFrom` / `imessageStateFrom` mappers and route wiring from
+`ctx.whatsapp.getStatus().state` and `ctx.imessage.getConnectionInfo().state`.
+
+**Decision point touched?** No new gate. This is additive read-only observability on an existing
+`advisory: true` route. It does change what a caller CONCLUDES about reachability, which is why the
+verdict mapping is the whole of this review.
+
+---
+
+## 1. Over-block
+
+Nothing is blocked or rejected — the route is advisory and gates nothing. The over-claim risk runs the
+other way and is handled: `qr-pending` is reported as `reachable-no-credential` rather than `broken`,
+because the link is alive and needs a HUMAN to scan a code. Reporting it as broken would send an
+operator to debug a connection behaving exactly as designed.
+
+## 2. Under-block
+
+The honest limit, stated in both rows' own text rather than left to assumption: `working` means the
+link was up when probed. It does NOT prove a send to a particular chat or contact would land. Same
+caveat the Telegram and mutual-ssh rows already carry.
+
+Unrecognised states from either adapter map to `unknown`, never to `working`. That is the failure
+direction that matters — a state this module has not seen must not read as healthy — and it is
+pinned by a test.
+
+Not addressed: neither row probes a round-trip. A true reachability proof would require sending, which
+a status read must not do.
+
+## 3. Level-of-abstraction fit
+
+Correct, and it follows the pattern already established for Telegram and Slack: the STATE→VERDICT
+mapping is an exported pure function testable without constructing an adapter, and the route supplies
+live state through a narrow context. The mapping is where a wrong verdict would come from, so it is
+the part that is pinned.
+
+## 4. Signal vs authority compliance
+
+Compliant. Pure signal on an advisory route with no blocking power. Adding rows strengthens the
+registry's "absence is impossible" property — the invariant that a channel with no row cannot report
+that it is missing.
+
+## 5. Interactions
+
+`UserChannelProbeContext` gains two required fields, so any other constructor of it must supply them
+— there is exactly one (the `/channels` route), updated here. The `/channels` payload grows from 6
+rows to 8; the integration test that pins the exact set and the audience partition was updated in
+this change rather than left for CI to catch.
+
+`WhatsAppLiveState` mirrors the adapter's own union. If the adapter adds a state, the mapper reports
+`unknown` rather than mis-classifying — a deliberate fail-safe, not an oversight.
+
+## 6. External surfaces
+
+`GET /channels` returns two additional rows. Additive; existing consumers reading known ids are
+unaffected. No endpoint added, no config key, no behaviour change to messaging itself.
+
+## 7. Multi-machine posture
+
+**Machine-local by design for iMessage**, and this is a real property rather than a shortcut: the
+backend it talks to runs on this host, so the channel genuinely exists only where that backend is.
+That is recorded in the row's own `cost` text so a caller choosing it knows the work will not survive
+this machine going away.
+
+WhatsApp is pairing-bound to the operator's phone through whichever host holds the session — the same
+locality. Neither introduces replicated state; both are per-host reads of a per-host adapter, and a
+cross-machine merged view would be actively misleading since another machine's link says nothing
+about this one's.
+
+## 8. Rollback cost
+
+Trivial: remove the two rows, the two mappers, the two context fields and the route wiring, and
+restore the integration test's expected set. No persisted state, no schema, no migration. Rolling back
+re-opens the stated gap, so it should carry a reason.


### PR DESCRIPTION
TWO RELATED HONESTY FIXES to the channel registry, in one file.

(1) WhatsApp and iMessage join the registry — closing a gap I wrote down myself.
PR #1665's artifact recorded an explicit limit: both adapters exist and are NOT
covered. That was honest, and it was also a hole in the registry's own "absence is
impossible" property, since a channel with no row cannot report that it is missing.

WhatsApp reads getStatus().state, a real state machine rather than a boolean. That
matters for one state: qr-pending means the link is ALIVE and waiting for a human to
scan a pairing code. A boolean would flatten that into "not working" and send an
operator to debug a connection behaving exactly as designed. It maps to
reachable-no-credential — a restart will not help. connecting/reconnecting report
unknown with the phase named; an unrecognised state is unknown, never working.

iMessage reads getConnectionInfo().state and deliberately NOT the sibling connectedAt,
which is computed as `started ? new Date().toISOString() : undefined` — it reports the
moment you asked, never the moment it connected. A source ratchet fails if anyone
wires it in. (That field is fixed separately on echo/imessage-connectedat.)

(2) The Telegram row now names WHOSE poll loop it measured.
Found by checking the shipped feature on the running agent, not only in tests.
/capabilities said telegram { configured: true, adapter: true, bidirectional: true }
while /channels said "user-telegram: unknown — the Telegram poll loop is not running".
The config surface and the live surface disagreeing is precisely what this registry
exists to expose, and that half worked.

But the row measures the SERVER process's adapter and presented it as the channel's
state. On a lifeline deployment inbound never goes through that adapter — a separate
lifeline process polls and forwards, and the server logs "Telegram relay wired (via
lifeline callback forwarding)". Verified here: ~200 recent forward lines, lifeline
processes running, inbound healthy. A stopped server poll loop is NORMAL there.

So a reader saw `unknown` and would conclude Telegram was questionable when it was
fine. That is the IDENTICAL scope error the threadline-relay row was fixed for in
#1667 — a true statement whose subject is unstated. I fixed that class in one row and
shipped it in the adjacent row of the same PR family, on the same day.

The verdict stays `unknown` — what it can see is genuinely undetermined, and softening
it would be the worse failure. It now names the server adapter and says plainly that
this alone does not mean messages are not being received.

Falsified both ways: flattening qr-pending to broken fails (1 failed | 15 passed);
removing the named subject fails (1 failed | 17 passed). A companion test pins that
naming the subject must not soften the verdict to working. Green: 41 passed across the
three channel suites; tsc clean. The integration test pinning the exact channel set and
audience partition was updated IN this change rather than left for CI.

## ELI16 — feat(channels): WhatsApp and iMessage join the registry, and the Telegram row names its subject

The channel registry answers one question: for each way a user can reach this agent, is that
channel actually working right now? Two things were wrong with it.

First, WhatsApp and iMessage had no row at all. A channel with no row cannot report that it is
missing, so the registry's own promise — that a broken channel can never be silently absent — had a
hole in exactly the place a hole is hardest to notice. Both now have rows. WhatsApp matters most:
it has a real state machine rather than an on/off flag, and one of its states means "the link is
alive and waiting for a human to scan a pairing code". Flattening that to "not working" would send
someone to debug a connection that is behaving exactly as designed, so it now reports that no
restart will help and a person needs to scan.

Second, the Telegram row said the poll loop was not running, and a reader would fairly conclude
Telegram was broken. It is not. On this deployment inbound messages arrive through a separate
lifeline process, so the server's own poll loop being stopped is normal. The verdict itself was
true, but it never said WHOSE poll loop it measured. It now names the subject and says plainly that
this alone does not mean messages are being missed. The verdict stays "unknown" rather than being
softened to "working", because what it can see is genuinely undetermined.
