### PR TITLE
fix(tier-gate): a risk floor that tripped on a .config FILENAME

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T13-09-26-647Z-tier-config-hint-filename.json
+++ b/.instar/instar-dev-decisions/2026-07-27T13-09-26-647Z-tier-config-hint-filename.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T13:09:26.647Z",
+  "slug": "tier-config-hint-filename",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 16,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/tier-config-hint-filename.eli16.md
+++ b/docs/specs/tier-config-hint-filename.eli16.md
@@ -1,0 +1,47 @@
+# A safety bar that tripped on a filename
+
+## The setup
+
+Before any change to instar's own code is committed, a classifier suggests how much review the change
+needs, and separately sets a *floor* — a minimum level based on risk signals like "this adds a new
+capability" or "this touches something irreversible".
+
+The floor matters more than the suggestion. Declaring a change below its floor is allowed, but it is
+recorded as a deliberate override for someone to review later. That design only works if the floor is
+right, because the whole point is that going under it should feel like a decision.
+
+## What went wrong
+
+One of the risk signals is "a new configuration key was added". Detecting that from a diff is hard —
+almost every piece of code contains lines that look like `name: value` — so the check is gated: it
+only counts as a config key if the change also mentions something that looks like a configuration
+surface.
+
+One of those "looks like configuration" markers matched any text containing `.config`. That includes
+*filenames*.
+
+So a script that merely **reads** a file called `vitest.push.config.ts` matched the marker. Combined
+with an ordinary bit of code like `const options = { slice: 6, runs: 2 }`, the classifier concluded a
+new configuration key had been added and raised the floor — for a read-only helper script that adds
+no configuration at all.
+
+## Why this was worth fixing rather than working around
+
+I hit this myself and declared the change below the raised floor. The floor turned out to be wrong,
+so the outcome was fine — but that is luck, not judgement, and it points at the real damage.
+
+A bar that trips on a filename teaches whoever meets it that going under the bar is routine. Do that
+enough times and the override stops feeling like a decision. Then one day the bar is right, and it
+gets stepped over with the same shrug.
+
+A noisy guard does not merely annoy. It erodes the guard it belongs to.
+
+## What changed
+
+The filename marker is gone. The remaining markers all name genuine configuration surfaces — a config
+module, the config file itself, a config type. A change that really adds a configuration key will
+mention one of those.
+
+Two tests hold the line from both sides: one reproduces the exact case that misfired and requires the
+floor to stay low, and one runs through every remaining marker and requires the floor to still rise.
+Narrowing a check must not blind it, and the second test is what proves it did not.

--- a/scripts/lib/classify-tier.mjs
+++ b/scripts/lib/classify-tier.mjs
@@ -92,7 +92,21 @@ const NEW_CAPABILITY_PATTERNS = [
 // object literal). Without this guard the bare `key: value` pattern fires on
 // almost every TS change. We only treat a `key: value` addition as a new config
 // key when the diff also mentions a recognizable config anchor.
-const CONFIG_SURFACE_HINT = /(ConfigDefaults|config\.json|defaultConfig|InstarConfig|\.config\b|configSchema)/;
+// `\.config\b` used to be an alternative here, and it matched a FILENAME REFERENCE rather than a
+// config surface. A script that merely READS `vitest.push.config.ts` matched it; combined with any
+// ordinary object literal (`const out = { slice: 6, runs: 2 }`) it fired "new config key added" and
+// raised that change's risk floor to 2 — for a read-only developer script that adds no config key at
+// all.
+//
+// WHY THAT IS WORTH A FIX RATHER THAN A SHRUG. The floor is what makes a tier declaration mean
+// something, and declaring under it is treated here as a serious, audited act. A floor that fires on
+// a filename teaches authors that below-floor declarations are routine — which is exactly how a real
+// floor gets argued past later. A noisy guard degrades the guard it belongs to.
+//
+// The remaining anchors are all genuine config SURFACES: a config module, the config file itself by
+// name, or a config type. `foo.config.ts` as a mere mention is no longer one of them — a diff that
+// really adds a config key will name one of the others.
+const CONFIG_SURFACE_HINT = /(ConfigDefaults|config\.json|defaultConfig|InstarConfig|configSchema)/;
 
 /**
  * @param {object} input

--- a/tests/unit/classify-tier.test.ts
+++ b/tests/unit/classify-tier.test.ts
@@ -221,6 +221,44 @@ describe('classifyTier — risk floor: new capability (diff-text based)', () => 
     expect(r.suggestedTier).toBe(1);
   });
 
+  /**
+   * REGRESSION (2026-07-27). `\.config\b` used to be a CONFIG_SURFACE_HINT alternative, so a diff
+   * that merely READ a file named `*.config.ts` matched it. Combined with any ordinary object
+   * literal it fired "new config key added" and raised the risk floor to 2 — on a read-only
+   * developer script that adds no config key at all.
+   *
+   * This is not a cosmetic false positive. The floor is what makes a tier declaration mean
+   * something, and declaring under it is an audited act here. A floor that fires on a FILENAME
+   * teaches authors that below-floor declarations are routine, which is how a real floor gets
+   * argued past later. A noisy guard degrades the guard it belongs to.
+   */
+  it('does NOT fire on a mere .config FILENAME reference — the reproduction of the real case', () => {
+    const r = classifyTier({
+      inScopeFiles: ['scripts/recheck-parked-tests.mjs'],
+      addedLines: 40,
+      deletedLines: 0,
+      addedDiffText:
+        "const CONFIG = path.join(ROOT, 'vitest.push.config.ts');\n" +
+        'const out = {\n  slice: 6,\n  runs: 2,\n};',
+    });
+    expect(r.riskFloor, 'reading a .config filename is not adding a config key').toBe(1);
+    expect(r.reasons.join(' ')).not.toMatch(/config key/i);
+  });
+
+  it('STILL fires on a real config surface — the fix must not blind the check', () => {
+    // The other side of the boundary. Narrowing the hint must not stop it catching what it is for.
+    for (const anchor of ['ConfigDefaults', 'defaultConfig', 'InstarConfig', 'configSchema']) {
+      const r = classifyTier({
+        inScopeFiles: ['src/core/Thing.ts'],
+        addedLines: 2,
+        deletedLines: 0,
+        addedDiffText: `export const ${anchor} = {\n  newWidgetTimeout: 5000,\n};`,
+      });
+      expect(r.riskFloor, `${anchor} must still raise the floor`).toBe(2);
+      expect(r.reasons.join(' ')).toMatch(/config key/i);
+    }
+  });
+
   it('SKIPS the new-capability check entirely when addedDiffText is absent', () => {
     // The diff would have contained `export class` but we did not pass it →
     // the classifier must NOT guess. Only size governs.

--- a/upgrades/next/tier-config-hint-filename.md
+++ b/upgrades/next/tier-config-hint-filename.md
@@ -1,0 +1,48 @@
+# Upgrade Guide — vNEXT
+
+<!-- internal-only -->
+<!-- bump: patch -->
+
+## What Changed
+
+`scripts/lib/classify-tier.mjs` no longer treats a `.config` FILENAME reference as evidence of a
+config surface. The `\.config\b` alternative in `CONFIG_SURFACE_HINT` matched any text containing
+`.config`, including filenames — so a script that merely READ `vitest.push.config.ts`, combined with
+an ordinary object literal, fired "new capability: new config key added" and raised that change's risk
+floor to 2.
+
+## Evidence
+
+Falsified by restoring the alternative:
+
+```
+× does NOT fire on a mere .config FILENAME reference — the reproduction of the real case
+  → reading a .config filename is not adding a config key: expected 2 to be 1
+  Tests  1 failed | 48 passed (49)
+```
+
+Restored byte-identical; 49 passed, including all 47 pre-existing classifier tests unchanged. A second
+new test iterates every remaining anchor (`ConfigDefaults`, `defaultConfig`, `InstarConfig`,
+`configSchema`) and asserts the floor still rises — narrowing a check must not blind it.
+
+## Known limits
+
+If a genuine config-key addition mentions only a `*.config.ts` filename and none of the remaining
+anchors, its floor will no longer rise. The remaining anchors cover this repo's actual config
+surfaces, and the both-sides test guards against a future narrowing that blinds the check — but this
+is a heuristic over diff text and always was.
+
+## Why it mattered
+
+The floor is what makes a tier declaration meaningful: declaring under it is permitted but audited as
+a deliberate override. A floor that fires on a filename teaches authors that below-floor declarations
+are routine, which is how a real floor gets argued past later. A noisy guard degrades the guard it
+belongs to.
+
+## What to Tell Your User
+
+None — internal change (no user-facing surface).
+
+## Summary of New Capabilities
+
+None — internal change (no user-facing surface).

--- a/upgrades/side-effects/tier-config-hint-filename.md
+++ b/upgrades/side-effects/tier-config-hint-filename.md
@@ -1,0 +1,72 @@
+# Side-effects review — tier classifier no longer treats a .config FILENAME as a config surface
+
+**Change:** removes the `\.config\b` alternative from `CONFIG_SURFACE_HINT` in
+`scripts/lib/classify-tier.mjs`. That alternative matched a filename REFERENCE, so a diff that merely
+read `*.config.ts` satisfied the config-surface gate and, combined with any object literal, raised the
+risk floor for "new config key added".
+
+**Decision point touched?** Yes — the risk floor of the instar-dev tier gate. This LOWERS the floor in
+one specific false-positive case, so it is a loosening and reviewed as such.
+
+---
+
+## 1. Over-block
+
+This change exists to remove one. The over-block was concrete: a read-only developer script that adds
+no config key had its floor raised to 2 purely for naming `vitest.push.config.ts`.
+
+## 2. Under-block
+
+The real risk of the change, stated plainly: narrowing a heuristic can blind it. If a genuine
+config-key addition mentions ONLY a `*.config.ts` filename and none of the remaining anchors
+(`ConfigDefaults`, `config.json`, `defaultConfig`, `InstarConfig`, `configSchema`), its floor will no
+longer rise.
+
+Bounded two ways. The remaining anchors cover the actual config surfaces in this repo — a diff adding
+a real key names the module, the file, or the type. And a test now iterates EVERY remaining anchor and
+asserts the floor still rises, so a future narrowing that blinds the check fails.
+
+Residual: this is a heuristic over diff text and always was. It deters accidental omission; it is not
+a boundary against a determined author. Unchanged by this.
+
+## 3. Level-of-abstraction fit
+
+Correct — the defect is in the hint regex and the fix is in the hint regex. A broader alternative
+(requiring the anchor on the SAME line as the key) was considered and rejected as a larger behavioural
+change than the evidence supports: one bad alternative was identified precisely, so one alternative is
+removed.
+
+## 4. Signal vs authority compliance
+
+The classifier is a SIGNAL that informs a declared tier; the agent holds the authority and the
+declaration is audited. This change makes the signal more accurate without altering who decides. Per
+`docs/signal-vs-authority.md` that is the intended direction.
+
+## 5. Interactions
+
+`CONFIG_SURFACE_HINT` is used only to gate the `key: value` pattern inside the new-capability check.
+No other risk signal is affected; the `export class` and router patterns are untouched. All 47
+pre-existing classifier tests pass unchanged, plus 2 new ones.
+
+Changes to this file alter tier decisions for FUTURE commits only. Nothing recorded in past decision
+audits is rewritten.
+
+## 6. External surfaces
+
+None. Development-time classifier; no endpoint, no config key, no runtime behaviour, not user-facing.
+
+## 7. Multi-machine posture
+
+Not applicable: a pure function over diff text, identical on every checkout, with no state, no
+persistence, and nothing to replicate or reconcile.
+
+## 8. Rollback cost
+
+Trivial — restore the alternative. The regression test would then fail, which is the correct signal
+that the rollback reintroduces the false positive rather than a silent revert.
+
+## Disclosure
+
+I hit this false positive myself and declared Tier 1 under the raised floor without reading it first.
+That declaration and its deliberate re-declaration are both in the decision audit. This change fixes
+the classifier; it does not excuse the declaration.


### PR DESCRIPTION
CONFIG_SURFACE_HINT gated the noisy `key: value` new-config-key pattern behind a
recognisable config anchor. One of those anchors was `\.config\b`, which matches a
FILENAME REFERENCE. So a script that merely READ vitest.push.config.ts satisfied the
gate, and combined with an ordinary object literal (const out = { slice: 6, runs: 2 })
it fired "new capability: new config key added" and raised the risk floor to 2 — for a
read-only developer script that adds no config key at all.

WHY THIS IS WORTH FIXING RATHER THAN TOLERATING. The floor is what makes a tier
declaration mean something: declaring under it is permitted but recorded as a
deliberate, reviewable override. A floor that fires on a filename teaches authors that
below-floor declarations are routine — and that is exactly how a real floor gets
argued past later. A noisy guard degrades the guard it belongs to.

The filename alternative is removed. The remaining anchors (ConfigDefaults,
config.json, defaultConfig, InstarConfig, configSchema) all name genuine config
surfaces; a diff that really adds a key will mention one of them.

Both sides of the boundary are pinned. One test reproduces the exact misfire and
requires the floor to STAY low; another iterates every remaining anchor and requires
the floor to still RISE — narrowing a check must not blind it, and that second test is
what proves it did not. Falsified by restoring the alternative: 1 failed | 48 passed.
All 47 pre-existing classifier tests pass unchanged.

DISCLOSURE: I hit this false positive myself and declared Tier 1 under the raised floor
without reading it first — right by luck, not judgement. That declaration and its
deliberate re-declaration are both in the decision audit. This fixes the classifier; it
does not excuse the declaration. The floor on THIS change was read before declaring.

## ELI16 — fix(tier-gate): a risk floor that tripped on a .config FILENAME

Before a change to instar is committed, a gate estimates how risky it is and sets a floor on how
much process the change has to pay for. Declaring a change below that floor is allowed, but it is
recorded as a deliberate override for someone to review later.

One of the signals that raised the floor was meant to fire when a change adds a new configuration
key. It was matching the text ".config" anywhere in the diff — including a mere FILENAME. So a
read-only developer script that just happened to read a file called vitest.push.config.ts, and
contained any ordinary line that looked like "name: value", was flagged as adding configuration it
never touched, and its risk floor was raised for no reason.

That is worth fixing rather than shrugging at, because the floor is what makes a tier declaration
mean anything. A floor that fires on a filename teaches authors that declaring under it is routine
— and routine overrides are exactly how a real floor gets argued past when it matters. A noisy
guard degrades the guard it belongs to. The filename match is removed; the remaining anchors all
name genuine configuration surfaces. A second test checks the guard still fires for real config
changes, because narrowing a check must not blind it.
