### PR TITLE
feat(tests): the exit path for FLAKY_TESTS — parked tests never came back

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T12-58-53-155Z-parked-test-recheck.json
+++ b/.instar/instar-dev-decisions/2026-07-27T12-58-53-155Z-parked-test-recheck.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-27T12:58:53.155Z",
+  "slug": "parked-test-recheck",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 185,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-27T13-00-44-928Z-parked-test-recheck.json
+++ b/.instar/instar-dev-decisions/2026-07-27T13-00-44-928Z-parked-test-recheck.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-27T13:00:44.928Z",
+  "slug": "parked-test-recheck",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 185,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/parked-test-recheck.eli16.md
+++ b/docs/specs/parked-test-recheck.eli16.md
@@ -1,0 +1,56 @@
+# A list you can get onto but never off
+
+## The situation
+
+Some tests are excluded from the automated checks that run before code ships. That is sometimes
+right: a test that fails randomly is worse than no test, because it trains everyone to ignore red.
+
+The list of excluded tests has a way in and no way out.
+
+Adding a test costs nothing — the file holding the list is treated as ordinary configuration, so
+removing a guard from the build needs no review, no explanation, no record. And nothing ever checks
+whether an excluded test could come back. The result is one-directional: the set of unchecked code
+can only grow.
+
+## This is measured, not theorised
+
+Three tests were run three times each. All three had been excluded for reasons like "the assertions
+don't match the current format" or "the detection is non-deterministic".
+
+All three now pass, every time. They were repaired at some point and nobody re-armed them.
+
+There is an earlier note in that same file about two other tests that had been excluded and **rotted**
+while nobody was running them. So it fails in both directions — things break while parked, and things
+get fixed while parked — and nobody notices either way, because nothing looks.
+
+A fourth entry excludes a file that does not exist at all.
+
+## What this adds
+
+A re-check that reports which excluded tests now pass consistently, and which entries point at files
+that are gone.
+
+Two decisions shape it:
+
+**It never re-arms anything.** Deciding a test can come back is a judgement about whether the original
+reason still holds. A third of the list is excluded because a database component fails to build "on
+this machine" — and the automated build runs on a different machine, where it may genuinely fail. A
+tool that switched tests back on because they passed locally would be exactly the confident-wrong
+answer this whole area keeps producing.
+
+**It is cheap enough that it will actually get run.** Scanning for missing files costs nothing at all.
+Only a small rotating handful of tests is actually executed per run, chosen so that repeated runs
+cover the whole list over time. A tool nobody runs is a decoration.
+
+## The bug this found in itself
+
+The first version read the list with a simple search for quoted text. The list is heavily commented —
+deliberately, because those comments are what stop the next person re-excluding a test on a wrong
+label — and one comment contains an apostrophe.
+
+That single apostrophe threw off the pairing of every quote after it. The tool invented entries that
+were fragments of prose, and silently lost dozens of real ones. It confidently reported forty-two
+missing files where there is one.
+
+It was caught by running it. The fix reads the list line by line and skips comments, and a test now
+feeds it a comment containing an apostrophe to make sure it stays fixed.

--- a/scripts/recheck-parked-tests.mjs
+++ b/scripts/recheck-parked-tests.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * recheck-parked-tests.mjs — the EXIT PATH for `FLAKY_TESTS`.
+ *
+ * THE DEFECT THIS CLOSES. `vitest.push.config.ts`'s `FLAKY_TESTS` array excludes tests from the
+ * push/CI gate. Adding an entry costs nothing — the file is classified as ordinary config, so
+ * removing a guard from CI needs no ELI16, no side-effects review, no trace. And NOTHING ever
+ * re-checks whether a parked test could come back. Entry is free; exit is impossible. The ungated
+ * surface can therefore only grow.
+ *
+ * That is not theoretical. Measured on 2026-07-27, three consecutive runs each:
+ *
+ *   notification-spam-prevention.test.ts  parked "assertion mismatch, emoji vs keyword"  15/15/15 PASS
+ *   message-formatter.test.ts             parked "expects /msg reply format"             17/17/17 PASS
+ *   ReflectionConsolidator.test.ts        parked "pattern detection non-deterministic"   16/16/16 PASS
+ *
+ * All three were repaired at some point and never re-armed. Note the INVERSE of the lesson already
+ * recorded in that same file: the 2026-06-05 pair ROTTED while parked; these were FIXED while parked.
+ * Nobody noticed either way, because nothing looks. A fourth entry,
+ * `tests/unit/slack-stall-active-gate.test.ts`, does not exist on disk at all — an exclusion that
+ * excludes nothing.
+ *
+ * ── WHAT THIS IS, AND WHAT IT DELIBERATELY IS NOT ────────────────────────────────────────────────
+ *
+ * It is a SIGNAL. It reports which parked entries now pass deterministically and which point at
+ * missing files. It NEVER re-arms anything and never edits the config.
+ *
+ * That restraint is the design, not timidity: re-arming is a JUDGEMENT about whether the reason for
+ * parking still holds. "Passes on this machine" does not establish "passes in CI" — a third of the
+ * list is parked for a native-binding failure whose stated scope is literally "on this machine", and
+ * CI is a different environment where it may genuinely fail. A tool that auto-re-armed on a local
+ * green would be exactly the confident-wrong-answer this whole area is about.
+ *
+ * ── WHY IT IS CHEAP ENOUGH TO ACTUALLY RUN ──────────────────────────────────────────────────────
+ *
+ * A tool nobody runs is a decoration, and running ~90 test files repeatedly is not something anyone
+ * will do. So the default is bounded: the missing-file scan is free (no test execution at all), and
+ * only a small ROTATING slice is executed per invocation, chosen from a stable hash of the day. Over
+ * successive runs the whole list is covered without any single run being expensive.
+ *
+ * Usage:
+ *   node scripts/recheck-parked-tests.mjs                # missing-file scan + rotating slice
+ *   node scripts/recheck-parked-tests.mjs --slice 20     # widen the slice
+ *   node scripts/recheck-parked-tests.mjs --missing-only # free: no test execution
+ *   node scripts/recheck-parked-tests.mjs --json         # machine-readable
+ *   node scripts/recheck-parked-tests.mjs --runs 3       # runs per file (default 2)
+ *
+ * Always exits 0. It reports; it does not gate. Making it a gate would recreate the original
+ * problem from the other side — a red build for a test somebody parked on purpose.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CONFIG = path.join(ROOT, 'vitest.push.config.ts');
+
+function parseArgs(argv) {
+  const out = { slice: 6, runs: 2, json: false, missingOnly: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') out.json = true;
+    else if (a === '--missing-only') out.missingOnly = true;
+    else if (a === '--slice') out.slice = Number(argv[++i]);
+    else if (a === '--runs') out.runs = Number(argv[++i]);
+  }
+  if (!Number.isFinite(out.slice) || out.slice < 0) out.slice = 6;
+  if (!Number.isFinite(out.runs) || out.runs < 1) out.runs = 2;
+  return out;
+}
+
+/**
+ * Read the parked entries out of the config.
+ *
+ * Deliberately a literal parse of the array rather than importing the config: importing would
+ * execute it, and this must be safe to run against a config that does not load.
+ */
+function readParkedEntries() {
+  const src = fs.readFileSync(CONFIG, 'utf-8');
+  const m = /const FLAKY_TESTS = \[(.*?)\n\];/s.exec(src);
+  if (!m) throw new Error(`could not locate FLAKY_TESTS in ${path.relative(ROOT, CONFIG)}`);
+
+  // Parse LINE BY LINE and skip comments. A naive /'([^']+)'/g over the whole block also matches
+  // apostrophes inside the prose — "the test's own beforeAll" yields a bogus entry `s own`. That is
+  // not hypothetical: the first version of this script reported 42 dangling entries, nearly all of
+  // them fragments of the explanatory comment added when two tests were re-armed. The array is
+  // heavily commented BY DESIGN (those comments are what stop the next person re-parking on a wrong
+  // label), so the parser has to tolerate prose rather than the prose having to stay terse.
+  const entries = [];
+  for (const raw of m[1].split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('//') || line.startsWith('*') || line.startsWith('/*')) continue;
+    const e = /^'([^']+)',?$/.exec(line);
+    if (e) entries.push(e[1]);
+  }
+  return entries;
+}
+
+/** Stable rotation so successive runs cover the whole list without any run being expensive. */
+function rotatingSlice(items, size, dayKey) {
+  if (size <= 0 || items.length === 0) return [];
+  let h = 0;
+  for (const c of dayKey) h = (h * 31 + c.charCodeAt(0)) >>> 0;
+  const start = h % items.length;
+  return Array.from({ length: Math.min(size, items.length) }, (_, i) => items[(start + i) % items.length]);
+}
+
+function runOnce(file) {
+  const res = spawnSync(
+    process.execPath,
+    ['./node_modules/.bin/vitest', 'run', file, '--reporter=basic'],
+    { cwd: ROOT, encoding: 'utf-8', timeout: 300_000, env: { ...process.env } },
+  );
+  const out = `${res.stdout ?? ''}${res.stderr ?? ''}`;
+  if (res.status === 0) return 'pass';
+  if (res.error || res.status === null) return 'errored';
+  return /Tests\s+\d+\s+failed/.test(out) ? 'fail' : 'errored';
+}
+
+const opts = parseArgs(process.argv);
+const entries = readParkedEntries();
+
+// Glob patterns cannot be resolved to a single file; report them rather than pretending.
+const isGlob = (e) => e.includes('*');
+const concrete = entries.filter((e) => !isGlob(e));
+const globs = entries.filter(isGlob);
+
+const missing = concrete.filter((e) => !fs.existsSync(path.join(ROOT, e)));
+const present = concrete.filter((e) => fs.existsSync(path.join(ROOT, e)));
+
+const results = [];
+if (!opts.missingOnly) {
+  const dayKey = new Date().toISOString().slice(0, 10);
+  for (const file of rotatingSlice(present, opts.slice, dayKey)) {
+    const runs = Array.from({ length: opts.runs }, () => runOnce(file));
+    const verdict = runs.every((r) => r === 'pass')
+      ? 'deterministic-pass'
+      : runs.every((r) => r === 'fail')
+        ? 'deterministic-fail'
+        : runs.includes('errored')
+          ? 'could-not-run'
+          : 'genuinely-flaky';
+    results.push({ file, runs, verdict });
+  }
+}
+
+const report = {
+  parkedTotal: entries.length,
+  concrete: concrete.length,
+  globPatterns: globs,
+  missingFiles: missing,
+  checked: results,
+  note:
+    'SIGNAL ONLY — nothing is re-armed. A local deterministic-pass does NOT establish that the ' +
+    'test passes in CI; a third of this list is parked for an environment reason whose stated ' +
+    'scope is "on this machine". Re-arming remains a judgement.',
+};
+
+if (opts.json) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  console.log(`\nParked tests: ${report.parkedTotal} entries (${concrete.length} concrete, ${globs.length} glob patterns)\n`);
+  if (missing.length) {
+    console.log(`  ENTRIES POINTING AT NOTHING (${missing.length}) — excluding a file that does not exist:`);
+    for (const f of missing) console.log(`    - ${f}`);
+    console.log('');
+  } else {
+    console.log('  No dangling entries.\n');
+  }
+  if (results.length) {
+    console.log(`  RE-CHECKED THIS RUN (rotating slice of ${results.length}, ${opts.runs} runs each):`);
+    for (const r of results) console.log(`    ${r.verdict.padEnd(20)} ${r.file}`);
+    const back = results.filter((r) => r.verdict === 'deterministic-pass');
+    if (back.length) {
+      console.log(`\n  ${back.length} entr${back.length === 1 ? 'y' : 'ies'} now pass deterministically HERE.`);
+      console.log('  That is a prompt to look, not a verdict: re-arming is a judgement about whether');
+      console.log('  the environment reason still holds, and CI is a different environment.');
+    }
+  }
+  console.log(`\n${report.note}\n`);
+}
+
+process.exit(0);

--- a/tests/unit/recheck-parked-tests.test.ts
+++ b/tests/unit/recheck-parked-tests.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The parked-test re-check must parse the exclusion list correctly — including its prose.
+ *
+ * WHY THIS TEST IS THE IMPORTANT ONE. The first version of the script used a naive
+ * `/'([^']+)'/g` over the whole `FLAKY_TESTS` block. That array is heavily commented BY DESIGN —
+ * the comments are what stop the next person re-parking a test on a wrong label — and one of those
+ * comments contains an apostrophe ("the test's own beforeAll").
+ *
+ * The damage was worse than a stray entry. A single unbalanced apostrophe shifts quote PAIRING for
+ * everything after it, so the naive parser both INVENTED entries (`s own`) and SILENTLY DROPPED
+ * dozens of real ones. It reported 42 dangling files where there is exactly one, and a count of 92
+ * against a true 91.
+ *
+ * That count was not only wrong here: it was published in a release note. A parser that fails by
+ * producing a plausible number is the exact failure this repository keeps finding — so the parser is
+ * pinned against prose, not just against a clean list.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SCRIPT = path.join(ROOT, 'scripts/recheck-parked-tests.mjs');
+
+function runAgainstRealRepo(): { parkedTotal: number; missingFiles: string[]; globPatterns: string[] } {
+  const res = spawnSync(process.execPath, [SCRIPT, '--missing-only', '--json'], {
+    cwd: ROOT, encoding: 'utf-8', timeout: 120_000,
+  });
+  expect(res.status, res.stderr).toBe(0);
+  return JSON.parse(res.stdout);
+}
+
+describe('parked-test re-check', () => {
+  it('always exits 0 — it reports, it does not gate', () => {
+    // Gating here would recreate the original problem from the other side: a red build for a test
+    // somebody parked deliberately.
+    const res = spawnSync(process.execPath, [SCRIPT, '--missing-only'], {
+      cwd: ROOT, encoding: 'utf-8', timeout: 120_000,
+    });
+    expect(res.status).toBe(0);
+  });
+
+  it('THE PARSER: prose in the array does not become an entry', () => {
+    const report = runAgainstRealRepo();
+    // Every entry must look like a test path. `s own` — the fragment the naive parser produced from
+    // an apostrophe in a comment — could never satisfy this.
+    for (const f of [...report.missingFiles, ...report.globPatterns]) {
+      expect(f, `${f} is not a test path`).toMatch(/^tests\//);
+    }
+    expect(report.parkedTotal).toBeGreaterThan(50);
+  });
+
+  it('finds the dangling entry that excludes a file which does not exist', () => {
+    const report = runAgainstRealRepo();
+    expect(report.missingFiles).toContain('tests/unit/slack-stall-active-gate.test.ts');
+    // Exactly one, not the 42 the naive parser hallucinated.
+    expect(report.missingFiles.length).toBeLessThan(5);
+  });
+
+  it('reports glob patterns separately rather than pretending they are files', () => {
+    const report = runAgainstRealRepo();
+    for (const g of report.globPatterns) expect(g).toContain('*');
+    // A glob must never be counted as a missing file — it resolves to many, or none.
+    for (const g of report.globPatterns) expect(report.missingFiles).not.toContain(g);
+  });
+
+  it('REGRESSION: an apostrophe in a comment cannot corrupt the parse', () => {
+    // Reproduces the exact failure in miniature, against a synthetic config.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'recheck-parse-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'vitest.push.config.ts'), [
+        'const FLAKY_TESTS = [',
+        "  // the test's own beforeAll regenerates it — an apostrophe, deliberately",
+        "  'tests/unit/alpha.test.ts',",
+        "  'tests/unit/beta.test.ts',",
+        '];',
+      ].join('\n'));
+      fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
+      fs.copyFileSync(SCRIPT, path.join(dir, 'scripts/recheck-parked-tests.mjs'));
+
+      const res = spawnSync(process.execPath, ['scripts/recheck-parked-tests.mjs', '--missing-only', '--json'], {
+        cwd: dir, encoding: 'utf-8', timeout: 60_000,
+      });
+      const out = JSON.parse(res.stdout);
+      expect(out.parkedTotal).toBe(2);
+      expect(out.missingFiles.sort()).toEqual(['tests/unit/alpha.test.ts', 'tests/unit/beta.test.ts']);
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true, force: true,
+        operation: 'tests/unit/recheck-parked-tests.test.ts:cleanup',
+      });
+    }
+  });
+});

--- a/upgrades/next/parked-test-recheck.md
+++ b/upgrades/next/parked-test-recheck.md
@@ -1,0 +1,54 @@
+# Upgrade Guide — vNEXT
+
+<!-- internal-only -->
+<!-- bump: patch -->
+
+## What Changed
+
+Adds `scripts/recheck-parked-tests.mjs` — the missing EXIT PATH for `vitest.push.config.ts`'s
+`FLAKY_TESTS`. Entry to that list costs nothing (the file is classified as ordinary config, so
+removing a guard from CI needs no artifact), and nothing ever re-checked whether a parked test could
+return. Entry free, exit impossible, ungated surface monotonically growing.
+
+The script reports which parked entries now pass deterministically and which point at files that no
+longer exist. It never re-arms and never edits config.
+
+## Evidence
+
+Measured on current main, three consecutive runs each: `notification-spam-prevention.test.ts`
+15/15/15, `message-formatter.test.ts` 17/17/17, `ReflectionConsolidator.test.ts` 16/16/16 — all parked
+as broken or non-deterministic, all repaired at some point and never re-armed. Note the inverse of the
+2026-06-05 note in that same file: those tests rotted while parked; these were fixed while parked.
+Nobody noticed either way. Plus one dangling entry: `tests/unit/slack-stall-active-gate.test.ts` is
+excluded and does not exist.
+
+Falsified by restoring the naive parser:
+
+```
+× THE PARSER: prose in the array does not become an entry        → s own
+× finds the dangling entry ...                                   → expected 42 to be less than 5
+× REGRESSION: an apostrophe in a comment cannot corrupt the parse
+  Tests  3 failed | 2 passed (5)
+```
+
+Restored byte-identical; 5 passed.
+
+## Known limits
+
+It never re-arms — a local deterministic-pass does not establish a CI pass, and a third of the list is
+parked for a native-binding reason whose stated scope is "on this machine". Glob entries are reported
+rather than resolved. Only a rotating slice runs per invocation, so a single run does not survey the
+whole list; the output says how many it checked.
+
+## Correction
+
+The first (naive) parser reported 92 parked entries; the true count is 91. That wrong number was
+published in the release note of the earlier re-arm change. Recorded rather than silently fixed.
+
+## What to Tell Your User
+
+None — internal change (no user-facing surface).
+
+## Summary of New Capabilities
+
+None — internal change (no user-facing surface).

--- a/upgrades/side-effects/parked-test-recheck.md
+++ b/upgrades/side-effects/parked-test-recheck.md
@@ -1,0 +1,71 @@
+# Side-effects review — parked-test re-check (the exit path for FLAKY_TESTS)
+
+**Change:** adds `scripts/recheck-parked-tests.mjs`, which reports which `FLAKY_TESTS` entries now
+pass deterministically and which point at files that no longer exist. Read-only; never edits config.
+
+**Decision point touched?** No gate is added or changed. It informs a human judgement (should this
+test be re-armed?) that currently has no prompt at all.
+
+---
+
+## 1. Over-block
+
+None possible: the script always exits 0 and modifies nothing. Making it a gate was considered and
+rejected — a red build for a test somebody parked deliberately would recreate the original problem
+from the other side.
+
+## 2. Under-block
+
+Deliberate and central: it does NOT re-arm. A local deterministic-pass does not establish a CI pass,
+and roughly a third of the list is parked for a native-binding failure whose stated scope is literally
+"on this machine" while CI is a different environment. Auto-re-arming on local green would be the
+confident-wrong-answer this area keeps producing.
+
+It also cannot evaluate glob entries (`tests/unit/threadline/**`) — those are reported separately
+rather than resolved, because a glob is not a file and pretending otherwise would put fake entries in
+the missing list.
+
+Bounded by default: only a rotating slice is executed per run. So a single run does NOT survey the
+whole list, and the output says how many were checked. Under-coverage that announces itself.
+
+## 3. Level-of-abstraction fit
+
+Correct. The gap is that the exclusion list has an entry path and no exit path; this is the exit
+path's reporting half. The complementary half — requiring evidence on ADDITIONS — is tracked
+separately (ACT-1341) and is a gate change, not a report.
+
+## 4. Signal vs authority compliance
+
+Pure signal, and deliberately so. Per `docs/signal-vs-authority.md` it produces information for an
+authority (a human) that already exists; it holds none itself.
+
+## 5. Interactions
+
+Reads `vitest.push.config.ts` by literal parse rather than importing it — importing would execute the
+config, and this must remain safe to run against a config that does not load. It executes vitest as a
+subprocess for the sampled files; those runs go through the normal host test-runner bound like any
+other.
+
+No production code touched. Nothing imports the script.
+
+## 6. External surfaces
+
+None. A developer-facing script; no endpoint, no config key, no agent-visible behaviour.
+
+## 7. Multi-machine posture
+
+Not applicable in the replication sense, and that is itself the point: the answer it produces is
+about THIS machine's environment, and the script says so in its own output note. A cross-machine
+merged view would be actively misleading, since the whole question is whether a local environment
+reason still holds.
+
+## 8. Rollback cost
+
+Trivial — delete the script and its test. No state, no schema, no consumers.
+
+## A correction this change surfaced
+
+The first implementation's naive parser produced a count of 92 parked entries. The true count is 91.
+That wrong number was published in the release note of the earlier re-arm change (`#1668`). It is
+recorded here rather than silently corrected, because a plausible-but-wrong number that reached an
+artifact is exactly the failure class this repository keeps finding.


### PR DESCRIPTION
vitest.push.config.ts's FLAKY_TESTS excludes tests from the CI gate. Adding an entry
costs nothing — the file is classified as ordinary config, so removing a guard from CI
needs no ELI16, no side-effects review, no trace (ACT-1341). And NOTHING ever
re-checked whether a parked test could return. Entry free, exit impossible, so the
ungated surface can only grow. Every individual mislabel found this week is a symptom
of that one asymmetry.

MEASURED, three consecutive runs each: notification-spam-prevention 15/15/15,
message-formatter 17/17/17, ReflectionConsolidator 16/16/16 — all parked as broken or
non-deterministic, all repaired at some point, none re-armed. Note the INVERSE of the
2026-06-05 note in that same file: those two ROTTED while parked; these three were
FIXED while parked. Nobody noticed either way, because nothing looks. Plus a dangling
entry: tests/unit/slack-stall-active-gate.test.ts is excluded and does not exist.

Two decisions shape the script. It NEVER re-arms: that is a judgement about whether the
original reason still holds, and a third of the list is parked for a native-binding
failure whose stated scope is literally "on this machine" while CI is a different
machine. Auto-re-arming on a local green would be precisely the confident-wrong-answer
this area keeps producing. And it is cheap enough to actually get run — the
missing-file scan executes no tests at all, and only a rotating slice runs per
invocation, so repeated runs cover the list without any run being expensive. A tool
nobody runs is a decoration.

THE BUG IT FOUND IN ITSELF. The first version parsed the list with a naive
/'([^']+)'/g. That array is heavily commented BY DESIGN — those comments are what stop
the next person re-parking on a wrong label — and one contains an apostrophe ("the
test's own beforeAll"). A single unbalanced apostrophe shifts quote PAIRING for
everything after it, so the parser both invented entries from prose AND silently
dropped dozens of real ones: it reported 42 dangling files where there is one. Caught
by running it. Now parsed line-by-line skipping comments, with a regression test that
feeds it an apostrophe-bearing comment.

CORRECTION carried in the artifacts: that naive parser produced the count "92 parked
entries", which was published in #1668's release note. The true count is 91. A
plausible-but-wrong number that reached a shipped artifact is the exact failure class
this repo keeps finding, so it is recorded rather than quietly fixed.

## ELI16 — feat(tests): the exit path for FLAKY_TESTS — parked tests never came back

When a test proves unreliable — passing and failing on identical code — it can be parked on a list
so it stops blocking everyone else's work. That was only ever meant to be temporary. In practice
there was no way off the list: nothing ever re-checked a parked test, so parking one was
effectively deleting it, quietly and permanently, while the list still implied the coverage existed.

This adds the missing exit. A script re-runs the parked tests against current code and reports
which ones now pass consistently, so a test that was parked because of a since-fixed race can be
returned to the suite on evidence rather than on someone's memory of why it was parked.

The change also fixes a subtler problem in reading that list. The first parser I wrote handled
quoting naively, and an apostrophe inside an ordinary comment was enough to throw off its
quote-pairing — it invented dozens of entries that did not exist while dropping real ones, and
reported a confident total either way. The replacement reads the file line by line and skips
comments explicitly, which is less clever and actually correct.
