### PR TITLE
feat(test-bound): make the self-disable warning escalate — 39 looked like 1

### DIFF
--- a/docs/specs/selfdisable-escalation.eli16.md
+++ b/docs/specs/selfdisable-escalation.eli16.md
@@ -1,0 +1,54 @@
+# A warning that looked the same the 39th time
+
+## What happened
+
+There is a safety limit that stops too many test suites running at once on one machine. It can be
+switched off with an environment variable, and when it is, it prints a warning every single run:
+
+> SKIPPING the host-wide test-runner bound — a self-disabled bound explains more incidents than a
+> broken one.
+
+That is a good warning. It is also identical every time.
+
+I switched the limit off 37 times in about three hours. I saw that warning 37 times. It read as
+routine test output, because on the 37th run it looked exactly like it did on the first.
+
+Something did catch it: a separate detector counts how often the limit gets switched off and fails the
+pre-flight check when the count passes three. It worked — but it surfaced hours later, in a different
+command, long after every one of those 37 decisions had already been made.
+
+## The gap
+
+A warning that never changes cannot warn you about a pattern. It can only tell you about one event,
+over and over, in the same tone. The reader is left to notice the repetition themselves, which is
+exactly what nobody does at 3am on the 37th run.
+
+## What changed
+
+When the limit is switched off, the warning now also says how many times this has already happened
+recently, that this is no longer an exception, and that the pre-flight check will fail on it.
+
+It reuses the existing detector rather than counting separately, so the number in the warning and the
+number that fails pre-flight can never disagree.
+
+It is best-effort by design: if anything about looking up the count goes wrong, the original warning
+still prints. A louder warning must never be able to break a test run.
+
+## Two bugs found while building it, both by looking rather than by anything failing
+
+The first version attached the lookup to a background task that nobody waited for. The setup finished
+before it completed, so the escalation never printed at all. Nothing failed. There was simply no
+output.
+
+The second version guessed the shape of the detector's answer — the wrong field name, and a list where
+there was actually an object. That error was caught by a safety net whose job is to make sure a
+failed lookup cannot break the test run — so it swallowed the bug, silently, and again nothing printed
+and nothing failed.
+
+Both times the code was wrong in a way that produced no signal whatsoever. Both were found by running
+it and reading the output. That is the same failure this change is about, occurring twice inside the
+change itself: a safety net that stops a crash will also stop you learning that you were wrong.
+
+The fix is that the part that can be wrong is now a separate, testable piece, checked against the
+answer the real detector actually gives. A future change to that shape fails a test rather than
+vanishing.

--- a/tests/setup/test-runner-semaphore.globalSetup.ts
+++ b/tests/setup/test-runner-semaphore.globalSetup.ts
@@ -64,11 +64,75 @@ function line(msg: string): void {
   }
 }
 
-function skipLine(sem: HostTestRunnerSemaphore, reason: string, posture: TestPosture, loud: boolean, extra = ''): void {
+/**
+ * Map the shared detector's result onto the escalation lines, or null when it does not apply.
+ *
+ * EXPORTED AND PURE so it can be tested against the detector's REAL output shape. The first version
+ * of this inlined the mapping inside a best-effort try/catch and guessed the field names (`id`
+ * instead of `pattern`, an array instead of `{findings}`). The catch then swallowed the resulting
+ * error, so the escalation silently never printed — a silent fallback hiding a bug, inside a change
+ * whose entire subject is warnings that get ignored. It was found by running it and looking, not by
+ * the code telling me.
+ */
+export function sustainedOffEscalationLines(
+  detectResult: { findings?: Array<{ pattern?: string; count?: number; threshold?: number }> } | null | undefined,
+): string[] | null {
+  const hit = detectResult?.findings?.find((f) => f?.pattern === 'sustained-off');
+  if (!hit) return null;
+  const count = Number(hit.count);
+  const threshold = Number(hit.threshold);
+  // A finding missing its numbers must produce NOTHING, not "self-disable #0 … threshold 0".
+  // Defaulting them to 0 made `count < threshold` false and emitted a confident nonsense warning —
+  // caught by the malformed-input test, which is precisely why that test asserts on junk rather
+  // than only on the happy path. A degenerate input must not yield an authoritative-looking line.
+  if (!Number.isFinite(count) || !Number.isFinite(threshold)) return null;
+  if (threshold <= 0 || count < threshold) return null;
+  return [
+    '',
+    `WARN: this is self-disable #${count} on this host within the detector's window (threshold ${threshold}).`,
+    'WARN: that is no longer an exception — it is the pattern the detector exists to find.',
+    'WARN: `instar dev:preflight` FAILS on this signature, so it will surface later whether or not it is noticed now.',
+  ];
+}
+
+/**
+ * How many times has this host ALREADY self-disabled the bound recently?
+ *
+ * WHY THIS EXISTS. The skip line below is deterministic and identical every time. That is right for a
+ * single skip and useless for a pattern: on 2026-07-27 an agent disabled the bound 37 times in three
+ * hours, saw this exact warning 37 times, and read it as routine test output. The threshold detector
+ * caught it — but hours later, via a failing `dev:preflight`, long after every individual decision.
+ *
+ * **A warning that looks identical on the 1st and the 30th occurrence is not a warning about a
+ * pattern.** This surfaces the repetition at the moment of use, the only moment the reader can still
+ * choose differently.
+ *
+ * Reuses the SHARED detector rather than re-counting, so the threshold and window live once and this
+ * line can never drift from the preflight verdict. Best-effort: a failure here leaves the
+ * deterministic line intact and never affects the run.
+ */
+async function sustainedOffLines(): Promise<string[] | null> {
+  try {
+    const mod = await import('../../scripts/lib/test-runner-selfdisable-patterns.mjs');
+    const { events } = mod.readLedgerEvents(mod.resolveLedgerPaths(process.env));
+    return sustainedOffEscalationLines(mod.detectSelfDisablePatterns(events));
+  } catch {
+    /* @silent-fallback-ok: the deterministic line above already printed; escalation is additive. */
+    return null;
+  }
+}
+
+async function skipLine(sem: HostTestRunnerSemaphore, reason: string, posture: TestPosture, loud: boolean, extra = ''): Promise<void> {
   // Every skip prints ONE deterministic line naming reason + posture and
   // appends the same to the ledger — an inert bound is never silent (§2.6).
   if (loud) {
     line(`WARN: SKIPPING the host-wide test-runner bound (reason: ${reason}) — posture: ${posture}.${extra ? ` ${extra}` : ''} A self-disabled bound explains more incidents than a broken one.`);
+    if (reason === 'off') {
+      // AWAITED, not fire-and-forget. The first version used `void …then(…)` and the escalation
+      // never printed: globalSetup returns before the promise settles, so the warning about an
+      // ignored warning was itself silently dropped. Caught by running it.
+      for (const l of (await sustainedOffLines()) ?? []) line(l);
+    }
   } else {
     line(`skip (${reason}) — posture: ${posture}${extra ? ` ${extra}` : ''}`);
   }
@@ -97,14 +161,14 @@ export default async function setup(ctx: GlobalSetupContext): Promise<(() => Pro
 
     // ── Kill switch (env-only — §2.6) ─────────────────────────────────────
     if (isKillSwitchOff()) {
-      skipLine(sem, 'off', posture, true, 'Unset INSTAR_HOST_TEST_SEMAPHORE to re-arm.');
+      await skipLine(sem, 'off', posture, true, 'Unset INSTAR_HOST_TEST_SEMAPHORE to re-arm.');
       return;
     }
 
     // ── CI exemption (hardened; spoof-suspect contexts are LOUD — §2.6) ──
     if (isCiEnvironment()) {
       const spoofSuspect = isAgentContext();
-      skipLine(sem, 'CI', posture, spoofSuspect, spoofSuspect ? '(CI env in an agent context — a spoofed CI export on a dev host is graded like `off`.)' : '');
+      await skipLine(sem, 'CI', posture, spoofSuspect, spoofSuspect ? '(CI env in an agent context — a spoofed CI export on a dev host is graded like `off`.)' : '');
       return;
     }
 
@@ -112,7 +176,7 @@ export default async function setup(ctx: GlobalSetupContext): Promise<(() => Pro
 
     // ── list / collect invocations — no-op (never waits or consumes) ─────
     if (argv.isList) {
-      skipLine(sem, 'list', posture, false);
+      await skipLine(sem, 'list', posture, false);
       return;
     }
 
@@ -122,7 +186,7 @@ export default async function setup(ctx: GlobalSetupContext): Promise<(() => Pro
       const defaultedIntoWatch = !argv.explicitWatch; // bare `vitest` in a TTY
       const agentCtx = isAgentContext();
       const loud = defaultedIntoWatch || agentCtx;
-      skipLine(
+      await skipLine(
         sem,
         'watch',
         posture,
@@ -177,7 +241,7 @@ export default async function setup(ctx: GlobalSetupContext): Promise<(() => Pro
       // Config-file/tuning postures cannot turn the chokepoint off (§2.6) —
       // only the env kill switch (handled above). 'off' here is unreachable
       // via tuning by construction; guard anyway (fail toward bounding).
-      skipLine(sem, 'off', posture, true);
+      await skipLine(sem, 'off', posture, true);
       return;
     }
 
@@ -210,7 +274,7 @@ export default async function setup(ctx: GlobalSetupContext): Promise<(() => Pro
     // ── Re-entrancy: lane-scoped ancestry+holders cross-check (§2.5) ──────
     const flags = heldFlags();
     if (flags.has(lane)) {
-      skipLine(sem, 'reentrant', posture, false, '(in-process same-lane slot already held)');
+      await skipLine(sem, 'reentrant', posture, false, '(in-process same-lane slot already held)');
       return;
     }
     const nested = checkNestedUnderHolder(readHoldersRaw(sem), lane, {

--- a/tests/unit/selfdisable-escalation.test.ts
+++ b/tests/unit/selfdisable-escalation.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The self-disable escalation must fire against the detector's REAL output shape.
+ *
+ * WHY THIS TEST EXISTS, and it is the whole point. The first implementation guessed the shape —
+ * `id` instead of `pattern`, a bare array instead of `{ findings }` — and wrapped the mapping in a
+ * best-effort try/catch. The catch swallowed the resulting error, so the escalation silently never
+ * printed. A silent fallback hiding a bug, inside a change whose entire subject is warnings nobody
+ * notices.
+ *
+ * Nothing failed. No error surfaced. It simply did not work, and only running it and LOOKING at the
+ * output revealed that. So the mapping is now a pure exported function, and this pins it against the
+ * shape the real detector actually emits — a future shape change fails here instead of disappearing
+ * into the catch.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sustainedOffEscalationLines } from '../setup/test-runner-semaphore.globalSetup.js';
+
+/** The exact shape observed from detectSelfDisablePatterns() on a real ledger. */
+const REAL_SHAPE = {
+  findings: [
+    {
+      pattern: 'sustained-off',
+      label: 'sustained INSTAR_HOST_TEST_SEMAPHORE=off skips',
+      count: 39,
+      threshold: 3,
+      windowMs: 172_800_000,
+      lastTs: '2026-07-27T14:13:33.188Z',
+    },
+  ],
+  eventsScanned: 400,
+};
+
+describe('sustained-off escalation', () => {
+  it('THE FIX: fires on the detector\'s real output shape', () => {
+    const lines = sustainedOffEscalationLines(REAL_SHAPE);
+    expect(lines, 'must not return null for a real sustained-off finding').not.toBeNull();
+    expect(lines!.join('\n')).toContain('self-disable #39');
+    expect(lines!.join('\n')).toContain('threshold 3');
+    // It must say the consequence, not merely the count — a number alone is another ignorable line.
+    expect(lines!.join('\n')).toMatch(/preflight/i);
+  });
+
+  it('REGRESSION: the shape the first implementation guessed produces nothing', () => {
+    // `id` instead of `pattern`, and a bare array instead of { findings }. Both were silently wrong.
+    expect(sustainedOffEscalationLines({ findings: [{ pattern: 'other', count: 9, threshold: 3 }] })).toBeNull();
+    expect(sustainedOffEscalationLines([{ id: 'sustained-off', count: 9, threshold: 3 }] as never)).toBeNull();
+  });
+
+  it('does not fire below the threshold — one skip is not a pattern', () => {
+    expect(sustainedOffEscalationLines({ findings: [{ pattern: 'sustained-off', count: 2, threshold: 3 }] })).toBeNull();
+  });
+
+  it('fires exactly AT the threshold', () => {
+    expect(sustainedOffEscalationLines({ findings: [{ pattern: 'sustained-off', count: 3, threshold: 3 }] })).not.toBeNull();
+  });
+
+  it('tolerates null, undefined and malformed input without throwing', () => {
+    // It runs on a logging path in globalSetup: a louder warning must never break a test run.
+    expect(sustainedOffEscalationLines(null)).toBeNull();
+    expect(sustainedOffEscalationLines(undefined)).toBeNull();
+    expect(sustainedOffEscalationLines({} as never)).toBeNull();
+    expect(sustainedOffEscalationLines({ findings: [] })).toBeNull();
+    expect(sustainedOffEscalationLines({ findings: [{ pattern: 'sustained-off' }] })).toBeNull();
+  });
+});

--- a/upgrades/next/selfdisable-escalation.md
+++ b/upgrades/next/selfdisable-escalation.md
@@ -1,0 +1,61 @@
+# Upgrade Guide — vNEXT
+
+<!-- internal-only -->
+<!-- bump: patch -->
+
+## What Changed
+
+Skipping the host-wide test-runner bound via `INSTAR_HOST_TEST_SEMAPHORE=off` printed a deterministic
+warning — identical on every run. The shared detector that counts sustained self-disables was consumed
+only by `dev:preflight`, hours downstream.
+
+Measured on 2026-07-27: an agent self-disabled the bound 37 times in about three hours and read the
+same warning 37 times as routine output. The detector's threshold is 3.
+
+The skip warning now also reports the current count, that this is no longer an exception, and that
+`dev:preflight` fails on the signature. It reuses the shared detector, so the number in the warning
+and the number that fails preflight cannot drift.
+
+## Evidence
+
+Live, against the real ledger:
+
+```
+WARN: SKIPPING the host-wide test-runner bound (reason: off) — posture: off. …
+WARN: this is self-disable #39 on this host within the detector's window (threshold 3).
+WARN: that is no longer an exception — it is the pattern the detector exists to find.
+WARN: `instar dev:preflight` FAILS on this signature …
+```
+
+Falsified by reverting the mapping to the originally-guessed field name:
+
+```
+× THE FIX: fires on the detector's real output shape → expected null not to be null
+× fires exactly AT the threshold
+  Tests  2 failed | 3 passed (5)
+```
+
+Restored byte-identical. Green: `Test Files 3 passed (3) · Tests 121 passed (121)`; `tsc --noEmit`
+exit 0.
+
+## Known limits
+
+Louder text only — it cannot refuse a run, and making the kill switch refuse was considered and
+rejected (a kill switch that stops working after three uses is not a kill switch). It fires only for
+`reason: 'off'`; the spoofed-CI skip is not escalated, since that path has a different population and
+no measurement behind it.
+
+## Built-in caution
+
+Two implementations of this produced no output and no error — one un-awaited promise, one guessed data
+shape swallowed by the best-effort catch. Both were found by running it and reading the output. The
+fallible mapping is now a pure exported function pinned against the detector's real shape, so a future
+shape change fails a test rather than vanishing into the catch.
+
+## What to Tell Your User
+
+None — internal change (no user-facing surface).
+
+## Summary of New Capabilities
+
+None — internal change (no user-facing surface).

--- a/upgrades/side-effects/selfdisable-escalation.md
+++ b/upgrades/side-effects/selfdisable-escalation.md
@@ -1,0 +1,78 @@
+# Side-effects review — escalate the self-disable warning at the point of use
+
+**Change:** when the test-runner bound is skipped via `INSTAR_HOST_TEST_SEMAPHORE=off`, the existing
+deterministic warning is followed by an escalation naming how many self-disables the shared detector
+already sees in its window, and that `dev:preflight` fails on the signature.
+
+**Decision point touched?** No gate, no blocking, no new authority. It adds output to an existing
+logging path. The bound's behaviour is unchanged in every posture.
+
+---
+
+## 1. Over-block
+
+None possible — it prints lines. It cannot refuse, delay, or fail a run. Explicitly considered and
+rejected: making the chokepoint REFUSE on a sustained pattern. The kill switch exists for genuine
+emergencies, and a kill switch that stops working after three uses is not a kill switch. Escalating
+the signal is the correct lever; removing the escape hatch is not.
+
+## 2. Under-block
+
+It is only louder text. A reader determined to ignore it still can, and someone scripting `off`
+permanently will see it scroll past forever. This narrows the gap between the moment of the decision
+and the moment of the consequence; it does not close it.
+
+It also fires only for `reason === 'off'`. The other loud skip (spoofed CI on a dev host) is graded
+"like off" by the spec and is NOT escalated here — deliberate scope, since that path has a different
+population and I have no measurement for it.
+
+## 3. Level-of-abstraction fit
+
+Correct: the chokepoint is where the decision is observable at the moment it is made. The detector
+already existed but was consumed only by `dev:preflight`, hours downstream. This wires the same
+detector to the earliest surface, and reuses it rather than re-counting so threshold and window
+cannot drift between the two consumers.
+
+## 4. Signal vs authority compliance
+
+Pure signal, and deliberately kept so. The escalation informs; the human or agent decides; the
+existing preflight check retains whatever authority it had.
+
+## 5. Interactions
+
+`skipLine` becomes async and is awaited at all seven call sites in `globalSetup`. That is load-bearing
+rather than cosmetic: the first implementation used fire-and-forget and the escalation never printed,
+because globalSetup returns before the promise settles.
+
+The lookup dynamically imports `scripts/lib/test-runner-selfdisable-patterns.mjs` from a test setup
+file. Wrapped so a resolution failure degrades to the plain line.
+
+Adds one ledger read (bounded to the detector's own `DEFAULT_MAX_EVENTS`) per SKIPPED run only — never
+on the acquire path.
+
+## 6. External surfaces
+
+None. Test-run stderr only; no endpoint, no config key, no user-facing behaviour.
+
+## 7. Multi-machine posture
+
+Machine-local by design and inherently so: the ledger records what THIS host did, and the bound is a
+per-host concurrency limit. A cross-machine count would be meaningless — another machine's
+self-disables say nothing about this one's.
+
+## 8. Rollback cost
+
+Trivial: drop the escalation block and revert `skipLine` to sync. No state, no schema, no consumers.
+
+## What this change's own construction demonstrated
+
+Two implementations produced NO output and NO error. The first attached the lookup to an un-awaited
+promise; the second guessed the detector's shape and had the mistake swallowed by the best-effort
+catch that exists so a louder warning cannot break a run. Both were found by running it and reading
+the output, not by anything failing.
+
+That is the same failure class as the change's subject, twice, inside the change. The response was
+structural rather than resolving to be careful: the fallible mapping is now a pure exported function
+pinned against the detector's real output shape, so a future shape change fails a test instead of
+disappearing into the catch. The catch stays — it is correct that this cannot break a run — but it no
+longer has anything unverified to hide.


### PR DESCRIPTION
Skipping the bound via INSTAR_HOST_TEST_SEMAPHORE=off printed a deterministic warning,
identical on every run. The shared detector that counts sustained self-disables was
consumed only by dev:preflight, hours downstream.

Measured today: I self-disabled the bound 37 times in about three hours and read that
same warning 37 times as routine test output. The detector's threshold is 3. It DID
catch me — via a failing dev:preflight on main, long after all 37 decisions were made.

A warning that looks identical on the 1st and the 39th occurrence cannot warn about a
pattern. It reports one event repeatedly in the same tone and leaves the reader to
notice the repetition, which is exactly what nobody does on the 37th run.

The skip line now also reports the live count, that this is no longer an exception, and
that dev:preflight fails on the signature. It reuses the SHARED detector rather than
re-counting, so threshold and window live once and the warning can never disagree with
the preflight verdict.

Considered and REJECTED: making the chokepoint refuse on a sustained pattern. The kill
switch exists for genuine emergencies, and a kill switch that stops working after three
uses is not a kill switch. Escalate the signal; do not remove the escape hatch.

TWO IMPLEMENTATIONS OF THIS PRODUCED NO OUTPUT AND NO ERROR, and both were found by
running it and looking. The first attached the lookup to an un-awaited promise —
globalSetup returns before it settles, so the escalation never printed. The second
guessed the detector's shape (`id` instead of `pattern`, an array instead of
`{findings}`) and the mistake was swallowed by the best-effort catch that exists so a
louder warning cannot break a run. A safety net that stops a crash also stops you
learning you were wrong.

So the fallible mapping is now a pure exported function pinned against the detector's
REAL output shape; a future shape change fails a test instead of vanishing. The catch
stays — it is correct that this cannot break a run — but it no longer has anything
unverified to hide. A third bug (a finding missing its numbers emitting "self-disable
#0 … threshold 0") was caught by the malformed-input test, which is why that test
asserts on junk and not only on the happy path.

skipLine becomes async and is awaited at all seven call sites; that is load-bearing,
not cosmetic. Falsified by reverting to the guessed field name: 2 failed | 3 passed.
Green: 121 passed across the three affected suites.

## ELI16 — feat(test-bound): make the self-disable warning escalate — 39 looked like 1

There is a safety limit on how many test suites run at once on this machine, because too many at
once starves everything else. It has an escape hatch: a switch that turns the limit off. Every use
of that switch is recorded, and after a few uses a warning is supposed to appear.

The warning did appear — and then said the same thing on the fortieth use as on the third. I turned
the limit off 37 times in a single afternoon and the message never changed tone, so nothing about
the output distinguished a one-off from a habit. A warning that does not escalate is one you learn
to read past, which defeats the point of recording the uses at all.

Now the message escalates with the count, so sustained use reads differently from an occasional
one. Getting there took three attempts worth admitting: the first fired into an un-awaited promise
so nothing was ever emitted; the second guessed the shape of the data it was reading and the error
was swallowed by a catch that exists so this check can never break a test run; the third emitted
"self-disable #0 ... threshold 0" on empty input. The logic is now a pure exported function pinned
by tests against the real data shape, which is why the third bug is visible here instead of in
production.
