### PR TITLE
fix(threadline): accept the bare fingerprint prefix that discover emits

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T16-33-46-482Z-threadline-prefix-resolve.json
+++ b/.instar/instar-dev-decisions/2026-07-27T16-33-46-482Z-threadline-prefix-resolve.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T16:33:46.482Z",
+  "slug": "threadline-prefix-resolve",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 58,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/threadline-prefix-resolve.eli16.md
+++ b/docs/specs/threadline-prefix-resolve.eli16.md
@@ -1,0 +1,96 @@
+# ELI16 — Two agents couldn't talk because one tool's answer was the other tool's error
+
+## The short version
+
+Agents have a way to find each other and a way to message each other. The finder handed
+out an address in a form the messenger refused to accept. So two perfectly healthy agents
+could look each other up, try to send, and fail — every time, forever, with an error that
+said the other agent didn't exist.
+
+## What it looked like from the outside
+
+For weeks it looked like the other agent was broken or ignoring me. It wasn't. Both agents
+were running, connected, and correctly configured. Every message got back:
+
+```
+Agent not found: "7970149e"
+```
+
+The truly diagnostic moment came when the other agent tried to reply and got the exact
+mirror image of my error — `Agent not found: "63b1dbb2"` — pointing back at *me*. Two
+agents, both alive, both holding the other's address, neither able to deliver. When both
+ends fail symmetrically, the problem isn't at either end. It's in the thing between them.
+
+## What was actually wrong
+
+An agent's identity is a long string of hex characters — 32 of them. Think of it as a
+phone number.
+
+The **finder** tool, when it lists nearby agents, shortens each one to the first 8
+characters so the output is readable. Sensible on its own.
+
+The **messenger** tool accepts an agent's name, or a full 32-character identity, or the
+combined form `name:shortcode`. What it did *not* accept was a bare shortcode on its own.
+
+So a bare 8-character identity — exactly what the finder returns, and exactly what the
+messenger's own documentation shows as an example — fell through every branch. The
+messenger assumed anything that wasn't a full identity must be a *name*, looked for an
+agent literally named "7970149e", found none, and reported that no such agent existed.
+
+The error message was true and completely misleading. There was no agent by that name.
+There was very much an agent at that address.
+
+## Why it went unnoticed
+
+Because each half was defensible in isolation. Shortening a long identity for display is
+reasonable. Requiring a complete identity for delivery is reasonable. Nobody wrote a bug;
+two reasonable local decisions disagreed about what an address is, and no test covered the
+handoff between them. The documentation even described the workflow — discover, then send —
+that the code could not perform.
+
+That is the general shape worth remembering: the defect lived in the seam, not in either
+component, and every component's own tests passed.
+
+## What changed
+
+The messenger now accepts a bare shortcode. It compares it against every identity it knows
+and, if exactly one starts with those characters, that's the recipient.
+
+## The part that needed care
+
+The obvious version of this fix is "find the first identity that starts with those
+characters and use it." That would have worked today and been wrong.
+
+When I ran the finder, it returned **two** entries with the same agent name and different
+identities — one live, one a leftover registration. Taking the first match would have
+picked whichever came out of the list first and delivered the message there. The send would
+have reported success. The message would have gone to the wrong recipient, and nobody would
+have known.
+
+A failed send is visible and annoying. A silent wrong delivery is invisible and much worse.
+So the rule is stricter:
+
+- Exactly one identity matches → send.
+- Several match but only one is actually online → send to the live one. A stale leftover
+  shouldn't make a working address ambiguous.
+- Otherwise → refuse, and list every candidate with its full identity so the caller can say
+  precisely which one they meant.
+
+Ambiguity is handed back as a decision. It is never resolved by guessing.
+
+## How I know it works
+
+I wrote the tests, then removed the fix and ran them against the original code. Five failed —
+the five describing the new behaviour. Twenty-one passed, which was the point: those are the
+guards proving ordinary name lookup, full identities, and hex-like agent names still behave
+exactly as before. A guard that only passes *after* your change isn't guarding anything.
+
+With the fix restored, all 26 pass, along with the surrounding 1,581 tests in the messaging
+area.
+
+## What this doesn't fix
+
+The finder still shortens identities to 8 characters while a comment beside it claims 32.
+This change makes the short form *work* rather than making the two halves agree, because
+changing what the finder outputs would affect everything already consuming it. That
+inconsistency is written down and tracked, not quietly patched over.

--- a/src/threadline/client/ThreadlineClient.ts
+++ b/src/threadline/client/ThreadlineClient.ts
@@ -404,6 +404,11 @@ export class ThreadlineClient extends EventEmitter {
       return nameOrId as AgentFingerprint;
     }
 
+    // 1b. Bare fingerprint-prefix match — see findAgentByFingerprintPrefix. This is
+    // the address `threadline_discover` actually hands callers, so it must resolve.
+    const byPrefix = this.findAgentByFingerprintPrefix(nameOrId);
+    if (byPrefix) return byPrefix.agentId;
+
     // 2. Parse disambiguation syntax: "name:fingerprintPrefix"
     const { name, fingerprintPrefix } = this.parseAgentAddress(nameOrId);
 
@@ -425,14 +430,65 @@ export class ThreadlineClient extends EventEmitter {
       return byName.agentId;
     }
 
-    // 4. Cache miss — re-discover and try again
+    // 4. Cache miss — re-discover and try again. The prefix retry matters as much as
+    // the name retry: on a cold cache the first prefix attempt has nothing to match.
     if (this.relayClient) {
       await this.autoDiscover();
+      const byPrefixRetry = this.findAgentByFingerprintPrefix(nameOrId);
+      if (byPrefixRetry) return byPrefixRetry.agentId;
       const byNameRetry = this.findAgentByName(name, fingerprintPrefix);
       if (byNameRetry) return byNameRetry.agentId;
     }
 
     return null;
+  }
+
+  /**
+   * Match a BARE fingerprint prefix (no "name:" syntax) against known agents.
+   *
+   * `threadline_discover` emits each agent's fingerprint TRUNCATED to 8 hex chars,
+   * and the send tool's own parameter docs advertise exactly that form
+   * ("fd9268c2..."), so a bare prefix is the address callers actually hold. Before
+   * this branch existed such an input fell through to name matching, matched no agent
+   * NAMED "7970149e", and resolved to null — so the documented discover-then-send
+   * workflow could not work at all. Two healthy, correctly-configured agents would
+   * simply never connect, because the address one tool returns was an address the
+   * other tool refused.
+   *
+   * Requires a UNIQUE match. This is an addressing function: silently picking one of
+   * several candidates would deliver the message to the WRONG agent, which is worse
+   * than not delivering it. Ambiguity is an explicit error naming the candidates,
+   * matching the convention in findAgentByName.
+   *
+   * Returns undefined — never throws — when the input is not a bare hex string or
+   * matches nothing, so ordinary name resolution still runs unchanged. An agent whose
+   * NAME happens to be hex-like is therefore unaffected: with no fingerprint match
+   * this falls through and the name path resolves it as before.
+   */
+  private findAgentByFingerprintPrefix(input: string): KnownAgent | undefined {
+    // 4 hex chars is the same floor parseAgentAddress already accepts for the
+    // "name:prefix" form — enough entropy to read as a deliberate address.
+    if (!/^[0-9a-f]{4,64}$/i.test(input)) return undefined;
+    const prefix = input.toLowerCase();
+
+    const matches: KnownAgent[] = [];
+    for (const agent of this.knownAgents.values()) {
+      if (agent.agentId.toLowerCase().startsWith(prefix)) matches.push(agent);
+    }
+
+    if (matches.length === 0) return undefined;
+    if (matches.length === 1) return matches[0];
+
+    // Same live-vs-dead twin allowance as name resolution: if exactly one matching
+    // row is live, the stale duplicate does not make the address ambiguous.
+    const onlinePick = this.pickSingleOnline(matches);
+    if (onlinePick) return onlinePick;
+
+    const options = matches.map(a => `  ${a.name} (${a.agentId})`).join('\n');
+    throw new Error(
+      `Ambiguous fingerprint prefix "${input}" — ${matches.length} agents match. ` +
+      `Use the full fingerprint to disambiguate:\n${options}`,
+    );
   }
 
   /**

--- a/tests/unit/threadline/ThreadlineClient-resolve.test.ts
+++ b/tests/unit/threadline/ThreadlineClient-resolve.test.ts
@@ -179,3 +179,72 @@ describe('ThreadlineClient — duplicate-identity name resolution (§A/§B/§C)'
     expect(await pr).toEqual([]);
   });
 });
+
+// ── Bare fingerprint-prefix addressing ───────────────────────────────────────
+//
+// `threadline_discover` returns each agent's fingerprint truncated to 8 hex chars,
+// and threadline_send's own parameter docs advertise that form ("fd9268c2..."). The
+// resolver had no bare-prefix branch, so that address fell through to name matching
+// and resolved to null: the documented discover-then-send workflow could not work.
+// Observed live 2026-07-27 — echo→instar-codey, both agents healthy, every send
+// answered `Agent not found: "7970149e"`.
+
+describe('ThreadlineClient — bare fingerprint-prefix addressing', () => {
+  let client: ThreadlineClient;
+  let p: Priv & { resolveAgent(x: string): Promise<string | null> };
+
+  beforeEach(() => {
+    client = new ThreadlineClient({ name: 'Tester', stateDir: '/tmp/resolve-prefix-test' }, () => 1_000_000);
+    p = client as unknown as Priv & { resolveAgent(x: string): Promise<string | null> };
+  });
+
+  it('resolves the 8-char prefix that discover emits (the reported bug)', async () => {
+    seed(client, '7970149e92589e0e6f173754df4d5cd0', 'instar-codey', true);
+    await expect(p.resolveAgent('7970149e')).resolves.toBe('7970149e92589e0e6f173754df4d5cd0');
+  });
+
+  it('still resolves a full fingerprint exactly (no regression)', async () => {
+    seed(client, '63b1dbb21646e2f5f860441f6c6443ad', 'echo', true);
+    await expect(p.resolveAgent('63b1dbb21646e2f5f860441f6c6443ad'))
+      .resolves.toBe('63b1dbb21646e2f5f860441f6c6443ad');
+  });
+
+  it('is case-insensitive on the prefix', async () => {
+    seed(client, '7970149e92589e0e6f173754df4d5cd0', 'instar-codey', true);
+    await expect(p.resolveAgent('7970149E')).resolves.toBe('7970149e92589e0e6f173754df4d5cd0');
+  });
+
+  it('THROWS on an ambiguous prefix rather than delivering to the wrong agent', async () => {
+    seed(client, 'abcd1111111111111111111111111111', 'one', true);
+    seed(client, 'abcd2222222222222222222222222222', 'two', true);
+    await expect(p.resolveAgent('abcd')).rejects.toThrow(/Ambiguous fingerprint prefix/);
+  });
+
+  it('names every candidate in the ambiguity error so the caller can disambiguate', async () => {
+    seed(client, 'abcd1111111111111111111111111111', 'one', true);
+    seed(client, 'abcd2222222222222222222222222222', 'two', true);
+    await expect(p.resolveAgent('abcd')).rejects.toThrow(/abcd1111111111111111111111111111/);
+  });
+
+  it('prefers the single LIVE row when a stale twin shares the prefix', async () => {
+    seed(client, 'abcd1111111111111111111111111111', 'one', true);
+    seed(client, 'abcd2222222222222222222222222222', 'one-dead', false);
+    await expect(p.resolveAgent('abcd')).resolves.toBe('abcd1111111111111111111111111111');
+  });
+
+  it('returns null for a prefix matching nothing', async () => {
+    seed(client, '7970149e92589e0e6f173754df4d5cd0', 'instar-codey', true);
+    await expect(p.resolveAgent('deadbeef')).resolves.toBeNull();
+  });
+
+  it('still resolves a hex-LIKE agent name when no fingerprint matches it', async () => {
+    // Guards the fall-through: prefix matching must not shadow name resolution.
+    seed(client, '7970149e92589e0e6f173754df4d5cd0', 'abcdef', true);
+    await expect(p.resolveAgent('abcdef')).resolves.toBe('7970149e92589e0e6f173754df4d5cd0');
+  });
+
+  it('leaves ordinary name resolution untouched', async () => {
+    seed(client, '7970149e92589e0e6f173754df4d5cd0', 'instar-codey', true);
+    await expect(p.resolveAgent('instar-codey')).resolves.toBe('7970149e92589e0e6f173754df4d5cd0');
+  });
+});

--- a/upgrades/next/threadline-prefix-resolve.md
+++ b/upgrades/next/threadline-prefix-resolve.md
@@ -1,0 +1,64 @@
+## What Changed
+
+Fixed an addressing bug that could prevent two healthy agents from ever exchanging a
+Threadline message.
+
+`threadline_discover` returns each agent's fingerprint truncated to 8 hex characters, and
+`threadline_send`'s own parameter documentation advertises that short form
+(`"fd9268c2..."`). But `ThreadlineClient.resolveAgent` had no branch for a bare prefix: it
+fell through to name matching, found no agent *named* `7970149e`, and returned null. The
+send then failed with `Agent not found: "7970149e"`. The documented discover-then-send
+workflow could not complete.
+
+`resolveAgent` now accepts a bare fingerprint prefix, and **requires a unique match**. This
+matters: `resolveAgent` decides which peer receives a message, and discovery can legitimately
+return two rows for the same agent (a live registration and a stale one). Resolving a prefix
+to "whichever matched first" would have silently delivered to the wrong agent while reporting
+success — worse than not delivering at all. When several agents share a prefix and exactly
+one is online, the live one wins (the same allowance name resolution already makes for
+live-vs-stale twins). Otherwise the send is refused with every candidate and its full
+fingerprint listed, so the caller can say precisely which they meant.
+
+Non-hex input, and any prefix matching no known fingerprint, fall through untouched — name
+resolution, including for agents with hex-like names, behaves exactly as before.
+
+## Evidence
+
+The tests were run against unmodified source *before* the fix was applied, to prove they
+exercise the bug rather than merely accompany it:
+
+- Fix reverted: **5 failed / 21 passed** — the 5 failures are precisely the new behaviours
+  (8-char prefix resolves, case-insensitivity, ambiguity throws, candidates named in the
+  error, live-row preference). The 21 that pass are the deliberate regression guards.
+- Fix applied: **26 passed**.
+- Regression surface: `tests/unit/threadline/` — **65 files, 1581 tests, all passing**.
+- `tsc --noEmit` clean.
+
+Observed live on 2026-07-27 between two running, relay-connected agents on the same machine.
+Both ends failed symmetrically — each reported the other as "not found" while holding the
+other's address — which is what identified the seam between the two tools, rather than either
+agent, as the defect.
+
+## What to Tell Your User
+
+If you have ever tried to connect two of your agents over Threadline and been told the other
+agent could not be found — while both were plainly running and correctly configured — this is
+very likely why, and it is fixed.
+
+The short agent ID your agent sees when it looks up its peers is now an address it can
+actually send to. Nothing changes about how you ask for it; "message my other agent" simply
+works where it may previously have failed with a confusing not-found error.
+
+One deliberate behaviour worth knowing: if a short ID is ambiguous because two agents share
+those opening characters, your agent will now stop and list them rather than pick one. That
+is intentional. A message delivered to the wrong agent looks like success and is much harder
+to notice than a message that refuses to send.
+
+## Summary of New Capabilities
+
+- Agent-to-agent messaging accepts the short (8-character) agent fingerprint that agent
+  discovery returns, closing a gap where the discover-then-send workflow could not complete.
+- Ambiguous short IDs are reported with the full candidate list instead of resolving to an
+  arbitrary agent, so a message can never be silently delivered to the wrong peer.
+- A stale duplicate registration no longer makes a working address ambiguous when exactly one
+  matching agent is online.

--- a/upgrades/side-effects/threadline-prefix-resolve.md
+++ b/upgrades/side-effects/threadline-prefix-resolve.md
@@ -1,0 +1,136 @@
+# Side-effects review — bare fingerprint-prefix addressing in `resolveAgent`
+
+**Change:** `ThreadlineClient.resolveAgent` gains a bare fingerprint-prefix branch
+(`findAgentByFingerprintPrefix`), so the 8-char fingerprint `threadline_discover`
+emits is an address `threadline_send` will actually accept.
+
+**Discovered:** live, 2026-07-27. Echo → instar-codey. Both agents healthy, both
+relay-connected, correct chat, correct topic. Every send answered
+`Agent not found: "7970149e"`. Codey's own reply to Echo failed with the mirror-image
+error `Agent not found: "63b1dbb2"`. Neither agent was misconfigured — the address one
+tool handed out was an address the other tool refused.
+
+## 1. Over-block — what legitimate input does this reject that it shouldn't?
+
+None. The new branch only ever *adds* resolutions; it returns `undefined` for any input
+that is not a bare hex string of 4–64 chars, and for any hex string that matches no
+known fingerprint. In both cases control falls through to the pre-existing name path
+unchanged.
+
+The one input class that now behaves differently in a *rejecting* direction is an
+**ambiguous** prefix — two known agents sharing it. That previously resolved to `null`
+("not found"); it now throws a named-candidates error. This is strictly more informative
+than the old outcome, and the alternative (silently picking) is the failure this review
+most wants to prevent. See §4.
+
+## 2. Under-block — what does this still miss?
+
+- **Discover still emits 8 chars while its neighbouring comment says 32.**
+  `ThreadlineMCPServer.ts` sets `entry.fingerprint = a.publicKey.substring(0, 8)` at two
+  sites (lines 510, 870 on main) beside a comment reading "fingerprint = first 32 hex
+  chars". This change makes the 8-char form *work* rather than making the two halves
+  agree. Deliberate: changing discover's output is a contract change to every existing
+  consumer, whereas widening the resolver is backward-compatible and fixes all current
+  callers at once. The inconsistency is recorded here rather than silently fixed.
+  <!-- tracked: ACT-1380 -->
+- **A 4-char prefix is permitted.** With a large enough agent population, 4 hex chars
+  will collide. Collisions surface as the ambiguity error rather than a wrong delivery,
+  so the failure mode is safe, but it is a usability cliff at scale rather than a
+  correctness one.
+- This does not address unreachability caused by anything other than addressing — a dark
+  relay, an unpaired peer, or a trust refusal are all untouched.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. `resolveAgent` is the single funnel every send path already goes through
+(`routes.ts:12841` calls `relayClient.resolveAgent(targetAgent)` and 404s on null). Fixing
+it here fixes the MCP tool, the HTTP route, and any future caller at once. Fixing it in
+the MCP tool would have left the HTTP route broken; fixing it in discover would have
+changed a published output shape without helping callers who already hold a short
+fingerprint from an older message or a log line.
+
+## 4. Signal vs authority compliance
+
+`resolveAgent` is an *authority* — its return value directly determines which peer
+receives a message. That is precisely why the new branch **requires a unique match**.
+
+The tempting implementation is "match the prefix, take the first hit." That would have
+made my own send succeed today, because discover returned **two** `instar-codey` rows
+(`092c1cac…` and `7970149e…`) and only one is live. Taking the first would have delivered
+to whichever the map happened to yield first — a silent wrong-recipient delivery, which is
+categorically worse than a failed send, because the sender believes it succeeded.
+
+So the branch reuses the existing convention exactly:
+- exactly one match → resolve
+- several matches, exactly one online → resolve to the live one (`pickSingleOnline`, the
+  same live-vs-dead twin allowance `findAgentByName` already makes)
+- otherwise → throw, naming every candidate and its full fingerprint
+
+Ambiguity is surfaced to the caller as a decision, never absorbed as a guess.
+
+## 5. Interactions
+
+- **Ordering.** The prefix branch runs after exact-match (1) and before name parsing (2).
+  It cannot shadow name resolution, because a zero-match prefix returns `undefined` and
+  falls through. An agent whose *name* is hex-like resolves as before — covered by an
+  explicit regression test.
+- **`name:prefix` syntax.** Untouched. `parseAgentAddress` only engages on a colon, and a
+  bare prefix has none. The 4-char floor is deliberately the same one `parseAgentAddress`
+  already uses for its suffix, so the two addressing forms agree on what counts as a
+  prefix.
+- **Cold cache.** The retry after `autoDiscover()` in step 4 now re-tries the prefix as
+  well as the name. Without this the fix would work only when the cache was already warm —
+  which is the very condition that is false on a first send after boot.
+- **Rediscovery cooldown.** Unchanged; the prefix branch performs no discovery of its own.
+
+## 6. External surfaces
+
+No wire-format, protocol, or persisted-state change. No new config, route, or dependency.
+The observable difference is that an address which previously 404'd now resolves, plus one
+new error message string on the ambiguous path. Nothing depends on timing or conversation
+state.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design, and correctly so — no justification marker needed because no
+durable state is introduced.** `knownAgents` is a process-local in-memory cache rebuilt
+from relay discovery on every connect. Two machines running this agent each resolve
+against their own live view of the relay, which is the correct behaviour: reachability is
+a property of *this* process's relay connection, not a fact to replicate. Replicating a
+resolution cache would actively harm — a peer that machine A can reach may be unreachable
+from machine B, and a shared cache would assert otherwise.
+
+No user-facing notice, no generated URL, no state that could strand on topic transfer.
+
+## 8. Rollback cost
+
+Near zero. Revert the commit; the added method becomes unreferenced and the resolver
+returns to exact-match-plus-name. No migration, no persisted state, no agent-state repair.
+Any address that worked before still works after a revert — the change is purely additive
+to the set of inputs that resolve.
+
+## Evidence
+
+Tests were verified to fail against unmodified source before the fix was applied, so they
+demonstrably exercise the bug rather than merely accompanying it:
+
+```
+# fix reverted, tests only
+Tests  5 failed | 21 passed (26)
+  ✗ resolves the 8-char prefix that discover emits (the reported bug) → null
+  ✗ is case-insensitive on the prefix                                 → null
+  ✗ THROWS on an ambiguous prefix rather than delivering to the wrong agent → resolved null
+  ✗ names every candidate in the ambiguity error                      → resolved null
+  ✗ prefers the single LIVE row when a stale twin shares the prefix    → null
+
+# fix applied
+Tests  26 passed (26)
+
+# regression surface
+tests/unit/threadline/ — 65 files, 1581 passed
+tsc --noEmit — clean
+```
+
+The 21 that pass in both runs are the deliberate regression guards (full fingerprint,
+ordinary name, hex-like name, unknown prefix → null); they *should* pass either way, and
+their passing on unfixed source is what makes them meaningful as guards.


### PR DESCRIPTION
## Summary

`threadline_discover` returns each agent's fingerprint truncated to 8 hex chars, and `threadline_send`'s own parameter docs advertise that form (`"fd9268c2..."`). But `resolveAgent` had no bare-prefix branch — a bare `7970149e` fell through to name matching, matched no agent *named* that, and resolved to `null`. **The documented discover-then-send workflow could not complete.**

Observed live 2026-07-27 between two healthy, relay-connected agents. Every send answered `Agent not found: "7970149e"`; the peer's reply failed with the mirror-image error naming this agent. Symmetric failure at both ends is what identified the seam between the two tools — rather than either agent — as the defect.

## The care point: unique match required

`resolveAgent` is an authority — its return value decides which peer receives a message. Discovery returned **two** rows for the same peer name (one live, one stale), so "take the first prefix hit" would have silently delivered to the **wrong agent while reporting success**. That is worse than not delivering.

- exactly one match → resolve
- several matches, exactly one online → resolve to the live one (`pickSingleOnline`, the same allowance `findAgentByName` already makes)
- otherwise → throw, naming every candidate and its full fingerprint

Non-hex input and zero-match prefixes fall through untouched, so name resolution — including for hex-like agent names — is unchanged.

## Evidence

Tests were run against **unmodified source first**, to prove they exercise the bug rather than merely accompany it:

| run | result |
|---|---|
| fix reverted | **5 failed / 21 passed** — the 5 are exactly the new behaviours |
| fix applied | **26 passed** |
| `tests/unit/threadline/` | **65 files, 1581 passed** |
| `tsc --noEmit` | clean |
| scoped e2e | 18 files / 333 passed |

The 21 passing in both runs are the deliberate regression guards (full fingerprint, ordinary name, hex-like name, unknown prefix → null). Their passing on unfixed source is what makes them meaningful as guards.

## Tier

Tier 1. Gate signal was `suggestedTier=2, riskFloor=1`; declared at the risk floor, not below it. ELI16 + side-effects artifacts staged.

## Not in scope

`ThreadlineMCPServer` still emits `substring(0, 8)` beside a comment reading "fingerprint = first 32 hex chars". Widening the resolver is backward-compatible and fixes every existing caller at once; changing discover's output is a contract change to every consumer. Tracked as ACT-1380.

## ELI16 — two tools disagreed about what an address is

Agents have a way to find each other and a way to message each other. The finder hands out an address in a shortened form, and the messenger refused to accept that form. So two perfectly healthy agents could look each other up, attempt to send, and fail every single time with an error saying the other agent did not exist. The error was true and completely misleading — there was no agent by that *name*, but there was very much an agent at that *address*.

Each half was defensible alone. Shortening a long identity for display is reasonable. Requiring a complete identity for delivery is reasonable. Nobody wrote a bug; two reasonable local decisions disagreed about what counts as an address, no test covered the handoff, and the documentation described a workflow the code could not perform.

The messenger now accepts the short form. The part that needed care: the obvious fix is "use the first identity that starts with those characters", which would have worked in testing and been wrong — discovery returned two entries for the same agent, one live and one stale, so picking the first would have delivered to the wrong recipient while reporting success. A failed send is visible and annoying; a silent wrong delivery is invisible and much worse. So a match must be unique, a lone live entry wins over stale duplicates, and anything genuinely ambiguous is refused with the candidates listed.
