### PR TITLE
fix(memory): recall returned nothing for any natural-language question

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T17-02-40-059Z-semantic-recall-query.json
+++ b/.instar/instar-dev-decisions/2026-07-27T17-02-40-059Z-semantic-recall-query.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T17:02:40.059Z",
+  "slug": "semantic-recall-query",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 74,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-27T17-20-48-680Z-semantic-recall-query.json
+++ b/.instar/instar-dev-decisions/2026-07-27T17-20-48-680Z-semantic-recall-query.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T17:20:48.680Z",
+  "slug": "semantic-recall-query",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 34,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-27T17-21-21-946Z-semantic-recall-query.json
+++ b/.instar/instar-dev-decisions/2026-07-27T17-21-21-946Z-semantic-recall-query.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T17:21:21.946Z",
+  "slug": "semantic-recall-query",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 34,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-27T17-21-54-194Z-semantic-recall-query.json
+++ b/.instar/instar-dev-decisions/2026-07-27T17-21-54-194Z-semantic-recall-query.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T17:21:54.194Z",
+  "slug": "semantic-recall-query",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 34,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-27T17-22-48-100Z-semantic-recall-query.json
+++ b/.instar/instar-dev-decisions/2026-07-27T17-22-48-100Z-semantic-recall-query.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T17:22:48.100Z",
+  "slug": "semantic-recall-query",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 34,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-27T17-23-38-182Z-semantic-recall-query.json
+++ b/.instar/instar-dev-decisions/2026-07-27T17-23-38-182Z-semantic-recall-query.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T17:23:38.182Z",
+  "slug": "semantic-recall-query",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 34,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/semantic-recall-query.eli16.md
+++ b/docs/specs/semantic-recall-query.eli16.md
@@ -1,0 +1,88 @@
+# ELI16 — the memory worked, the question didn't
+
+## The short version
+
+Your agent has a memory. Before it answers you, it quietly searches that memory for anything
+relevant and reads it back to itself. That system was switched on and working. It just never
+found anything, because of how the question was phrased.
+
+## How it failed
+
+The search required **every single word** of the question to appear in a stored note.
+
+Ask "why is the deploy failing" and the search looks for notes containing *why* **and** *is*
+**and** *the* **and** *deploy* **and** *failing* — all five. No note anywhere contains the
+word "why". So the search returns nothing. Not "nothing relevant" — nothing at all, always,
+for any question starting with "why".
+
+And questions are the only thing this system is ever given. It gets handed whatever you
+typed, verbatim.
+
+Measured against the real memory store, which holds 2,852 notes:
+
+| what was asked | results |
+|---|---|
+| "can I reach Codey" | 0 |
+| "is Codey responding to my messages" | 0 |
+| "why is Codey not replying" | 0 |
+| "reach Codey" | 7 |
+| "Codey messages" | 17 |
+
+Same memory, same store, same instant. The only difference is the ordinary connecting words.
+
+## Why nobody noticed
+
+Because an empty answer is indistinguishable from an empty memory.
+
+When the search returned nothing, everything downstream behaved exactly as it would if the
+agent had genuinely never learned anything on the subject. There was no error, no warning,
+no slow query — just silence, which is precisely what "I have no relevant memories" is
+supposed to look like. The system reported perfect health while returning nothing, forever.
+
+This is the expensive kind of bug: it doesn't break, it just quietly does nothing.
+
+## What it cost
+
+A concrete example, which is what prompted this fix. On July 19 the agent recorded a note:
+*"Telegram bots cannot see other bots' messages, which means a topic post can appear
+successful while still failing to reach the intended bot pipeline."*
+
+On July 27 it spent a chunk of a morning re-discovering that exact fact from scratch, having
+first concluded — wrongly — that another agent had stopped working. The note was stored
+correctly the whole time. It was indexed. It was findable by keyword. It simply never came
+back, because the question was a sentence.
+
+## What changed
+
+Two things, both small.
+
+Ordinary connecting words — *why, is, the, can, I, to, my* — are dropped before searching.
+They carry no information about what you're looking for and they were the only reason most
+searches failed.
+
+And if requiring all the remaining words still finds nothing, the search retries accepting
+**any** of them. Something loosely relevant beats the empty answer that made every stored
+lesson unreachable.
+
+## The part that needed care
+
+Widening a search risks drowning good results in noise, so the widening is deliberately last
+in line. The precise search runs first and, whenever it finds anything at all, its results
+are used untouched — the loose retry never runs. It only fires against an otherwise-empty
+result, where the alternative isn't a better answer but no answer.
+
+It also can't invent relevance. Asking about something genuinely not in memory still returns
+nothing, and that is pinned by a test so a future change can't quietly turn this into a
+system that always finds something whether or not it's there.
+
+## How I know it works
+
+I wrote the tests, removed the fix, and ran them against the original code. Nine failed —
+the nine describing the new behaviour. Four passed, which was the point: those four check
+that ordinary keyword searches, precise matches, genuinely-absent topics and permission
+filters all still behave exactly as before. A test that only passes after your change isn't
+protecting anything.
+
+Then I ran it against the real 2,852-note memory rather than a test fixture. The question
+"why can a telegram bot not see messages" went from zero results to five — with the July 19
+note as the top hit.

--- a/docs/specs/semantic-recall-query.eli16.md
+++ b/docs/specs/semantic-recall-query.eli16.md
@@ -75,6 +75,26 @@ It also can't invent relevance. Asking about something genuinely not in memory s
 nothing, and that is pinned by a test so a future change can't quietly turn this into a
 system that always finds something whether or not it's there.
 
+## The looser search now says when it ran
+
+There's a trap in the fix itself, and I walked into it before catching it.
+
+The looser retry is a *weaker* search. If it quietly substitutes itself whenever the precise
+one comes up empty, then the system starts serving cheaper results while looking exactly as
+healthy as before — which is the same shape as the original bug. A weaker strategy running
+silently is how you end up with a system that reports fine for months while doing something
+worse than you think.
+
+So the search now records which of the two actually served each query: the precise one, the
+looser fallback, or neither. It's a read-only note — nothing blocks, nothing changes about
+the results — but the cheap path can no longer run without saying so.
+
+That mattered more than it sounds. The reason recall was running on keyword matching at all
+is that a *much* better search exists in this codebase, fully built, with every one of the
+2,852 memories indexed for it — and the recall path simply calls the keyword one instead.
+Nothing anywhere reported that. Had the cheap path been announcing itself, that would have
+been obvious years earlier instead of found by accident this week.
+
 ## How I know it works
 
 I wrote the tests, removed the fix, and ran them against the original code. Nine failed —

--- a/src/memory/SemanticMemory.ts
+++ b/src/memory/SemanticMemory.ts
@@ -516,6 +516,24 @@ export class SemanticMemory {
   private embeddingProvider: EmbeddingProvider | null = null;
   private vectorSearch: VectorSearch | null = null;
   private _vectorAvailable = false;
+
+  /**
+   * Which retrieval strategy actually served the most recent `search()` call.
+   *
+   * `fts-strict` is the precise implicit-AND query; `fts-loose-fallback` means the
+   * strict query found NOTHING and the weaker OR query was used instead. Exposed
+   * because "No Silent Degradation to Brittle Fallback" requires a drop to a weaker
+   * strategy to be an observable event rather than a detail — a retrieval path that
+   * silently serves from the cheap strategy reports healthy while being fake-healthy.
+   * That is not hypothetical here: recall ran on keyword-only search for its entire
+   * life while a fully-populated vector index went uncalled, and nothing said so.
+   */
+  private _lastSearchStrategy: 'fts-strict' | 'fts-loose-fallback' | 'none' = 'none';
+
+  /** Which strategy served the last `search()` — see `_lastSearchStrategy`. */
+  get lastSearchStrategy(): 'fts-strict' | 'fts-loose-fallback' | 'none' {
+    return this._lastSearchStrategy;
+  }
   private jsonlPath: string;
   /** Set after corruption auto-recovery — caller should reimport from JSONL */
   private _needsRebuild = false;
@@ -1538,7 +1556,13 @@ export class SemanticMemory {
     const db = this.ensureOpen();
 
     const variants = buildFtsQueryVariants(query);
-    if (!variants) return [];
+    if (!variants) {
+      // Reset rather than leaving the previous call's strategy readable — a stale
+      // "served by strict" on a query that never ran is exactly the kind of
+      // falsely-healthy signal this field exists to prevent.
+      this._lastSearchStrategy = 'none';
+      return [];
+    }
 
     const limit = options?.limit ?? 20;
 
@@ -1583,16 +1607,24 @@ export class SemanticMemory {
 
     const statement = db.prepare(sql);
     let rows = statement.all(...params) as (EntityRow & { fts_rank: number })[];
+    this._lastSearchStrategy = 'fts-strict';
 
     // Strict (implicit-AND over content words) is the precise query and stays
     // authoritative whenever it finds anything. Only when it finds NOTHING do we
     // widen to OR — an empty result is what made stored lessons unreachable, and
     // a loosely-relevant hit is strictly better than silence. Every other filter
     // (type, domain, confidence, privacy) is unchanged and still applies.
+    //
+    // The widening is RECORDED, not silent. Per the "No Silent Degradation to
+    // Brittle Fallback" standard, falling back to a weaker strategy is an event:
+    // a retrieval path that quietly serves from the cheap strategy looks healthy
+    // while being fake-healthy, which is the exact defect this whole change exists
+    // to fix. Reading `lastSearchStrategy` tells a caller what actually served.
     if (rows.length === 0 && variants.loose !== variants.strict) {
       const looseParams = [...params];
       looseParams[0] = variants.loose;
       rows = statement.all(...looseParams) as (EntityRow & { fts_rank: number })[];
+      this._lastSearchStrategy = 'fts-loose-fallback';
     }
 
     // ─── Vector results (if available) ────────────────────────

--- a/src/memory/SemanticMemory.ts
+++ b/src/memory/SemanticMemory.ts
@@ -111,6 +111,60 @@ function sanitizeFts5Query(query: string): string {
     .trim();
 }
 
+/**
+ * English function words that carry no retrieval signal but are FATAL to an
+ * FTS5 implicit-AND query.
+ *
+ * FTS5 requires EVERY bare token to match. No stored entity contains the word
+ * "why", so any question beginning "why ..." matches nothing regardless of the
+ * content words beside it. Recall is fed the user's raw message — always a
+ * natural-language sentence — so in practice it returned empty almost always.
+ * Measured on a live 2,852-entity store: "can I reach Codey" → 0 results,
+ * "is Codey responding to my messages" → 0, "why is Codey not replying" → 0,
+ * while "reach Codey" → 7, "Codey messages" → 17, "Codey" → 20.
+ */
+const FTS_STOPWORDS = new Set([
+  'a', 'about', 'am', 'an', 'and', 'any', 'are', 'as', 'at', 'be', 'been', 'but',
+  'by', 'can', 'could', 'did', 'do', 'does', 'for', 'from', 'get', 'got', 'had',
+  'has', 'have', 'how', 'i', 'if', 'in', 'is', 'it', 'its', 'me', 'my', 'no',
+  'of', 'on', 'or', 'our', 'should', 'so', 'that', 'the', 'their', 'them',
+  'then', 'there', 'these', 'they', 'this', 'to', 'was', 'we', 'were', 'what',
+  'when', 'where', 'which', 'who', 'why', 'will', 'with', 'would', 'you', 'your',
+]);
+
+/**
+ * Build the two FTS5 match expressions a recall query needs.
+ *
+ * `strict` drops stopwords and keeps FTS5's implicit AND, so a genuine
+ * multi-keyword query stays precise. `loose` ORs the same content words and is
+ * used ONLY as a fallback when strict returns nothing — five loosely-relevant
+ * memories beat the empty set that made stored lessons unreachable.
+ *
+ * Stopword removal never empties the query: if a message is ALL stopwords the
+ * original tokens are kept, so behaviour degrades to the previous semantics
+ * rather than silently matching everything.
+ *
+ * Exported for tests — the failure this fixes is invisible at the route level
+ * (a zero-result search looks identical to "nothing was ever stored").
+ */
+export function buildFtsQueryVariants(
+  query: string,
+): { strict: string; loose: string } | null {
+  const sanitized = sanitizeFts5Query(query);
+  if (!sanitized) return null;
+
+  const tokens = sanitized.split(' ').filter((t) => t.length > 0);
+  if (tokens.length === 0) return null;
+
+  const content = tokens.filter((t) => !FTS_STOPWORDS.has(t.toLowerCase()));
+  const effective = content.length > 0 ? content : tokens;
+
+  return {
+    strict: effective.join(' '),
+    loose: effective.length > 1 ? effective.join(' OR ') : effective.join(' '),
+  };
+}
+
 export class SemanticMemory {
   /**
    * W-4 / §A57 — process-wide registry of active SemanticMemory instances.
@@ -1483,8 +1537,8 @@ export class SemanticMemory {
   search(query: string, options?: SemanticSearchOptions): ScoredEntity[] {
     const db = this.ensureOpen();
 
-    const sanitized = sanitizeFts5Query(query);
-    if (!sanitized) return [];
+    const variants = buildFtsQueryVariants(query);
+    if (!variants) return [];
 
     const limit = options?.limit ?? 20;
 
@@ -1496,7 +1550,7 @@ export class SemanticMemory {
       WHERE entities_fts MATCH ?
     `;
 
-    const params: (string | number)[] = [sanitized];
+    const params: (string | number)[] = [variants.strict];
 
     if (options?.types && options.types.length > 0) {
       const placeholders = options.types.map(() => '?').join(',');
@@ -1527,7 +1581,19 @@ export class SemanticMemory {
     sql += ` ORDER BY entities_fts.rank LIMIT ?`;
     params.push(limit * 3); // Fetch extra for re-ranking
 
-    const rows = db.prepare(sql).all(...params) as (EntityRow & { fts_rank: number })[];
+    const statement = db.prepare(sql);
+    let rows = statement.all(...params) as (EntityRow & { fts_rank: number })[];
+
+    // Strict (implicit-AND over content words) is the precise query and stays
+    // authoritative whenever it finds anything. Only when it finds NOTHING do we
+    // widen to OR — an empty result is what made stored lessons unreachable, and
+    // a loosely-relevant hit is strictly better than silence. Every other filter
+    // (type, domain, confidence, privacy) is unchanged and still applies.
+    if (rows.length === 0 && variants.loose !== variants.strict) {
+      const looseParams = [...params];
+      looseParams[0] = variants.loose;
+      rows = statement.all(...looseParams) as (EntityRow & { fts_rank: number })[];
+    }
 
     // ─── Vector results (if available) ────────────────────────
     // vectorScores is populated asynchronously via searchHybrid() for callers

--- a/tests/unit/semantic-memory-recall-query.test.ts
+++ b/tests/unit/semantic-memory-recall-query.test.ts
@@ -157,4 +157,27 @@ describe('SemanticMemory.search — natural-language recall', () => {
     });
     expect(results).toEqual([]);
   });
+
+  it('REPORTS which strategy served — strict, when the precise query matches', () => {
+    memory.search('telegram bot');
+    expect(memory.lastSearchStrategy).toBe('fts-strict');
+  });
+
+  it('REPORTS the fallback when the precise query found nothing and OR was used', () => {
+    // Falling back to a weaker strategy must be an observable event, not a detail.
+    // 'kubernetes' appears in no entity, so the strict implicit-AND finds nothing
+    // and the OR widening is what actually serves the telegram/bot terms.
+    const results = memory.search('why can a telegram bot reach kubernetes');
+    expect(results.length).toBeGreaterThan(0);
+    expect(memory.lastSearchStrategy).toBe('fts-loose-fallback');
+  });
+
+  it('resets the reported strategy for a query that never ran', () => {
+    memory.search('telegram bot');
+    expect(memory.lastSearchStrategy).toBe('fts-strict');
+    memory.search('*()');
+    // Must not still read "strict" — a stale healthy-looking signal on a query
+    // that never executed is the failure mode this field exists to prevent.
+    expect(memory.lastSearchStrategy).toBe('none');
+  });
 });

--- a/tests/unit/semantic-memory-recall-query.test.ts
+++ b/tests/unit/semantic-memory-recall-query.test.ts
@@ -1,0 +1,160 @@
+// safe-git-allow: test file — uses SafeFsExecutor.safeRmSync; raw fs.* only for setup.
+/**
+ * Natural-language recall for SemanticMemory.search.
+ *
+ * The recall hook feeds `search()` the user's raw message — always a sentence.
+ * FTS5 requires EVERY bare token to match, and no stored entity contains the
+ * word "why", so a question could never match anything no matter what content
+ * words sat beside it. Recall was enabled, wired, and structurally incapable of
+ * returning a result for the queries it actually received.
+ *
+ * Measured on a live 2,852-entity store before the fix:
+ *   "can I reach Codey"                 -> 0     "reach Codey"     -> 7
+ *   "is Codey responding to my messages"-> 0     "Codey messages"  -> 17
+ *   "why is Codey not replying"         -> 0     "Codey"           -> 20
+ *
+ * The lesson that would have prevented a real incident was stored, indexed, and
+ * unreachable. These tests pin both halves: stopwords must not zero a query, and
+ * a strict match must still win when it exists (the fallback must not add noise).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  SemanticMemory,
+  buildFtsQueryVariants,
+} from '../../src/memory/SemanticMemory.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('buildFtsQueryVariants', () => {
+  it('drops stopwords that would zero an implicit-AND query', () => {
+    const v = buildFtsQueryVariants('why is Codey not replying');
+    expect(v).not.toBeNull();
+    expect(v!.strict).toBe('Codey replying');
+  });
+
+  it('ORs the content words for the fallback expression', () => {
+    const v = buildFtsQueryVariants('can I reach Codey');
+    expect(v!.strict).toBe('reach Codey');
+    expect(v!.loose).toBe('reach OR Codey');
+  });
+
+  it('leaves a pure keyword query untouched', () => {
+    const v = buildFtsQueryVariants('telegram bot');
+    expect(v!.strict).toBe('telegram bot');
+  });
+
+  it('keeps the original tokens when a query is ALL stopwords', () => {
+    // Must degrade to previous semantics, never to an empty match-everything query.
+    const v = buildFtsQueryVariants('what is it');
+    expect(v!.strict).toBe('what is it');
+  });
+
+  it('collapses to a single term without an OR when only one word survives', () => {
+    const v = buildFtsQueryVariants('what about Codey');
+    expect(v!.strict).toBe('Codey');
+    expect(v!.loose).toBe('Codey');
+  });
+
+  it('returns null for an empty or syntax-only query', () => {
+    expect(buildFtsQueryVariants('')).toBeNull();
+    expect(buildFtsQueryVariants('   ')).toBeNull();
+    expect(buildFtsQueryVariants('*()')).toBeNull();
+  });
+
+  it('still strips FTS5 operators so a query cannot be manipulated', () => {
+    const v = buildFtsQueryVariants('Codey AND secrets');
+    expect(v!.strict).not.toContain('AND');
+  });
+});
+
+describe('SemanticMemory.search — natural-language recall', () => {
+  let dir: string;
+  let memory: SemanticMemory;
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'semantic-recall-'));
+    memory = new SemanticMemory({ dbPath: path.join(dir, 'semantic.db') });
+    await memory.open();
+
+    // The real entity, as it was actually stored on 2026-07-19.
+    memory.remember({
+      type: 'fact',
+      name: 'Telegram bot visibility limit',
+      content:
+        "Telegram bots cannot see other bots' messages, which means a topic post " +
+        'can appear successful while still failing to reach the intended bot pipeline.',
+      confidence: 0.7,
+      lastVerified: new Date().toISOString(),
+      source: 'session:test',
+      tags: ['telegram', 'messaging'],
+    });
+    memory.remember({
+      type: 'fact',
+      name: 'Vercel deploy target',
+      content: 'Production deploys to Vercel from the main branch.',
+      confidence: 0.7,
+      lastVerified: new Date().toISOString(),
+      source: 'session:test',
+      tags: ['deploy'],
+    });
+  });
+
+  afterEach(() => {
+    memory.close();
+    SafeFsExecutor.safeRmSync(dir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/semantic-memory-recall-query.test.ts',
+    });
+  });
+
+  it('finds a stored lesson from a natural-language question (the reported bug)', () => {
+    const results = memory.search('why can a telegram bot not see messages');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.map((r) => r.name)).toContain(
+      'Telegram bot visibility limit',
+    );
+  });
+
+  it('finds it from a question phrased as the agent would ask it', () => {
+    const results = memory.search('can I reach the other bot on telegram');
+    expect(results.map((r) => r.name)).toContain(
+      'Telegram bot visibility limit',
+    );
+  });
+
+  it('still finds it from a bare keyword query (no regression)', () => {
+    const results = memory.search('telegram bot');
+    expect(results.map((r) => r.name)).toContain(
+      'Telegram bot visibility limit',
+    );
+  });
+
+  it('prefers the STRICT match and does not widen when strict already matches', () => {
+    // Both entities exist; a strict two-keyword hit must not drag in the
+    // unrelated one via the OR fallback.
+    const results = memory.search('telegram visibility');
+    expect(results.map((r) => r.name)).toContain(
+      'Telegram bot visibility limit',
+    );
+    expect(results.map((r) => r.name)).not.toContain(
+      'Vercel deploy target',
+    );
+  });
+
+  it('returns empty for a question about something genuinely not stored', () => {
+    // The fallback must widen the query, not invent relevance.
+    expect(memory.search('how do I configure the kubernetes ingress')).toEqual([]);
+  });
+
+  it('honours the confidence filter through the fallback path', () => {
+    const results = memory.search('why can a telegram bot not see messages', {
+      minConfidence: 0.95,
+    });
+    expect(results).toEqual([]);
+  });
+});

--- a/upgrades/next/semantic-recall-query.md
+++ b/upgrades/next/semantic-recall-query.md
@@ -1,0 +1,69 @@
+## What Changed
+
+Fixed a silent failure that made the agent's memory recall return nothing for essentially
+every question it was asked.
+
+Before answering, the agent searches its own memory store and injects anything relevant as
+context. That search required **every** word of the query to appear in a stored entry —
+FTS5's implicit AND over bare tokens. Recall is fed the user's raw message, which is always
+a sentence, so ordinary function words decided the outcome. No stored entity contains the
+word "why", so any question beginning "why" matched nothing regardless of its content words.
+
+`SemanticMemory.search()` now strips stopwords before building the match expression, and
+falls back to an OR of the content words when the strict AND match returns zero rows. The
+strict query runs first and stays authoritative whenever it finds anything, so keyword
+searches are unchanged and the widening only ever replaces an empty result.
+
+The failure was invisible by construction: an empty result set is indistinguishable from an
+empty memory. No error, no warning, no slow query — the system reported healthy while
+returning nothing indefinitely.
+
+## Evidence
+
+Tests were run against **unmodified source first**, to prove they exercise the bug:
+
+| run | result |
+|---|---|
+| fix reverted | **9 failed / 4 passed** — the 4 are the regression guards |
+| fix applied | **13 passed** |
+| semantic-memory regression surface | **5 files, 126 passed** |
+| `tsc --noEmit` | clean |
+
+Verified against the live 2,852-entity store, not only fixtures:
+
+```
+"can I reach Codey"                        0 → 5 hits
+"is Codey responding to my messages"       0 → 5 hits
+"why can a telegram bot not see messages"  0 → 5 hits, top hit "Telegram bot visibility limit"
+```
+
+That top hit is an entity stored on 2026-07-19 which never surfaced and was re-derived from
+scratch on 2026-07-27 — the incident that prompted the fix.
+
+## What to Tell Your User
+
+Your agent's memory has been storing things correctly all along, but the part that looks
+things up was almost never finding them — so lessons it had genuinely learned would quietly
+fail to come back, and it could re-discover the same thing weeks later as though it were new.
+
+The cause was mundane: the lookup demanded that every word of the question appear in a
+stored note, including words like "why", "is" and "the". Since no note contains the word
+"why", any question starting with "why" found nothing at all. Questions are the only thing
+this system is ever given, so it was returning empty almost every time.
+
+Ordinary connecting words are now ignored when searching, and if the precise search finds
+nothing the agent retries with a looser one. Precise matches still win whenever they exist,
+so this makes recall find more without making it noisier — and a question about something
+genuinely not in memory still correctly returns nothing.
+
+You don't need to do anything. Recall simply starts working where it previously came back
+empty.
+
+## Summary of New Capabilities
+
+- Memory recall now answers natural-language questions instead of returning empty for any
+  query containing ordinary function words.
+- A looser fallback search runs only when the precise search finds nothing, so existing
+  keyword lookups keep their exact previous behaviour and precision.
+- Queries about genuinely unknown topics still return no results — the fallback widens the
+  search without inventing relevance.

--- a/upgrades/side-effects/semantic-recall-query.md
+++ b/upgrades/side-effects/semantic-recall-query.md
@@ -1,0 +1,143 @@
+# Side-effects review — natural-language recall for SemanticMemory.search
+
+**Change:** `search()` strips stopwords before building the FTS5 match expression, and
+falls back to an OR of the content words when the strict implicit-AND match returns
+nothing.
+
+**Discovered:** live, 2026-07-27, while diagnosing why a lesson recorded on 2026-07-19
+("Telegram bot visibility limit") was re-derived from scratch eight days later. Capture had
+worked; the entity was stored, FTS-indexed, and retrievable by keyword. The recall hook was
+enabled and installed. It returned nothing because of the shape of the query it was handed.
+
+## The mechanism
+
+FTS5 requires **every** bare token to match. Recall is fed the user's raw message, which is
+always a sentence. Measured against the live 2,852-entity store:
+
+| query | before |
+|---|---|
+| `can I reach Codey` | 0 |
+| `is Codey responding to my messages` | 0 |
+| `why is Codey not replying` | 0 |
+| `reach Codey` | 7 |
+| `Codey messages` | 17 |
+
+No stored entity contains the word "why", so a question beginning "why" could never match
+anything regardless of its content words. The system was enabled, wired, and structurally
+incapable of answering the queries it received.
+
+## 1. Over-block — what legitimate input does this now reject?
+
+None. Stopword removal only ever *widens* the candidate set, and the OR fallback runs only
+when the strict query returned zero rows. Every input that previously returned results
+returns the same results by the same path — the strict query is attempted first and
+unchanged for keyword queries.
+
+The one guarded edge is an all-stopword query (`"what is it"`). Removing every token would
+leave an empty match expression, which in FTS5 is a syntax error rather than a match-nothing.
+`buildFtsQueryVariants` keeps the original tokens in that case, so behaviour degrades to
+exactly the previous semantics rather than throwing or matching everything. Pinned by test.
+
+## 2. Under-block — what does this still miss?
+
+- **No semantic/vector matching.** A query using different words than the stored entity
+  ("can't message the other agent" vs "bot visibility") still misses. The vector path exists
+  (`searchHybrid`) but `vec0` is not loadable on this machine, so lexical matching is what
+  actually runs. Widening lexically is the honest available fix, not a substitute for
+  embeddings. <!-- tracked: ACT-1384 -->
+- **Stopword list is English-only and fixed.** A domain word that is genuinely a stopword
+  here (e.g. "session") is not covered, and shouldn't be — over-stripping would blunt
+  precision.
+- **The OR fallback ranks by FTS rank only.** It can surface a weakly-relevant entity when a
+  strongly-relevant one does not exist. That is the intended trade: five loosely-relevant
+  memories beat the empty set that made every stored lesson unreachable. It cannot fabricate
+  a hit — a query about something genuinely not stored still returns empty (pinned by test).
+
+## 3. Level-of-abstraction fit
+
+Correct layer. `search()` is the single funnel every recall caller uses — the
+`before-prompt-recall` hook, `PromptBuildRecall`, and the `/semantic/search` route all reach
+it. Fixing query construction here fixes every caller at once. Fixing it in the hook would
+have left the route and any future caller broken, and would have put query-shaping knowledge
+outside the module that owns the index.
+
+## 4. Signal vs authority compliance
+
+Recall is a **signal producer** — its output is injected as context, never as an
+instruction, and it gates nothing. This change cannot block, delay, or redirect any action;
+the worst case is that a slightly-less-relevant memory is surfaced as background context.
+That is precisely the class of check where widening recall is safe: a false positive costs a
+line of injected context, while the false negative it replaces cost a repeated incident.
+
+No blocking authority is added or moved.
+
+## 5. Interactions
+
+- **Filter composition.** The fallback re-uses the identical prepared statement and
+  parameter list, substituting only the match expression. Type, domain, confidence, and
+  privacy filters therefore apply to both passes identically — verified by a test asserting
+  `minConfidence: 0.95` still returns empty through the fallback path.
+- **Vector re-ranking.** `_lastVectorScores` merging is untouched and runs after row
+  selection, so a widened row set is re-ranked by the same logic.
+- **Operator stripping preserved.** `sanitizeFts5Query` still runs first, so `AND`/`OR`/
+  `NOT`/`NEAR` and FTS5 syntax characters are removed from user input before tokenising. The
+  `OR` this change introduces is constructed by us from already-sanitised tokens, never
+  passed through from the caller. Pinned by test.
+- **No double-execution cost in the common case.** The second query runs only on a zero-row
+  first pass.
+
+## 6. External surfaces
+
+No wire format, schema, migration, config, or route change. `/semantic/search` returns
+results where it previously returned an empty array for the same input. Nothing that
+previously returned data changes shape. One new exported function (`buildFtsQueryVariants`),
+exported for testability because the failure is invisible at the route level — a zero-result
+search looks identical to "nothing was ever stored", which is exactly why this survived
+undetected.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design, and correctly so — no new state is introduced.** This changes only
+how a query string is built before hitting a local SQLite FTS index. Each machine already
+owns its own `semantic.db`; whether that store *replicates* is a separate concern that this
+change neither introduces nor alters. No notice, no generated URL, no durable state, nothing
+that could strand on topic transfer.
+
+## 8. Rollback cost
+
+Near zero. Revert the commit; `search()` returns to passing the sanitised string straight
+through. No persisted state, no migration, no agent-state repair. Any query that worked
+before the change works identically after a revert.
+
+## Evidence
+
+Tests verified to fail against unmodified source before the fix was applied:
+
+```
+# fix reverted
+Tests  9 failed | 4 passed (13)
+  — the 4 passing are the regression guards: bare keyword query, strict-match
+    preference, genuinely-absent query returns empty, confidence filter honoured.
+    They SHOULD pass on unfixed source; that is what makes them guards.
+
+# fix applied
+Tests  13 passed (13)
+
+# regression surface
+semantic-memory + privacy + evidence + invokeFromRemediator + corruption-recovery
+  — 5 files, 126 tests passed
+tsc --noEmit — clean
+```
+
+Verified against the **live 2,852-entity store**, not only fixtures:
+
+```
+"can I reach Codey"                      0 → 5 hits
+"is Codey responding to my messages"     0 → 5 hits
+"why can a telegram bot not see messages"  0 → 5 hits,
+      top hit = "Telegram bot visibility limit"
+```
+
+That last line is the point of the change: the entity recovered as the top hit is the exact
+lesson that was stored on 2026-07-19, never surfaced, and re-derived from scratch on
+2026-07-27.

--- a/upgrades/side-effects/semantic-recall-query.md
+++ b/upgrades/side-effects/semantic-recall-query.md
@@ -69,6 +69,31 @@ exactly the previous semantics rather than throwing or matching everything. Pinn
   memories beat the empty set that made every stored lesson unreachable. It cannot fabricate
   a hit — a query about something genuinely not stored still returns empty (pinned by test).
 
+## 2b. The fallback announces itself (self-caught during review)
+
+The first revision of this change introduced a **silent** degradation — the OR widening
+substituted a weaker strategy and reported nothing. That is the same defect class the change
+exists to fix, added by the fix. Caught before merge and corrected.
+
+`search()` now records `lastSearchStrategy`:
+
+- `fts-strict` — the precise implicit-AND query served
+- `fts-loose-fallback` — strict found nothing; the weaker OR query served instead
+- `none` — no query ran (reset on the early-return path, so a stale "served by strict" can
+  never be read for a query that never executed)
+
+Read-only. It gates nothing and does not change what `search()` returns. This is
+*No Silent Degradation to Brittle Fallback* (`docs/STANDARDS-REGISTRY.md:125`) applied to a
+retrieval path: "silent degradation to a weak check is worse than no check, because it looks
+protected while being fake-protected." The standard's own scope is LLM calls that *gate* an
+action, so it did not formally bind here — but its reasoning is exactly on point, and
+honouring it cost three tests.
+
+The concrete argument for it: recall ran on keyword-only search for its entire life while a
+fully-populated vector index (2,852/2,852 embeddings) went uncalled, and nothing anywhere
+reported that. A cheap path that announces itself is the difference between that being
+discoverable and being invisible for months.
+
 ## 3. Level-of-abstraction fit
 
 Correct layer. `search()` is the single funnel every recall caller uses — the

--- a/upgrades/side-effects/semantic-recall-query.md
+++ b/upgrades/side-effects/semantic-recall-query.md
@@ -40,11 +40,27 @@ exactly the previous semantics rather than throwing or matching everything. Pinn
 
 ## 2. Under-block — what does this still miss?
 
-- **No semantic/vector matching.** A query using different words than the stored entity
-  ("can't message the other agent" vs "bot visibility") still misses. The vector path exists
-  (`searchHybrid`) but `vec0` is not loadable on this machine, so lexical matching is what
-  actually runs. Widening lexically is the honest available fix, not a substitute for
-  embeddings. <!-- tracked: ACT-1384 -->
+- **This fixes the fallback path, NOT the primary one — and the primary one is the real bug.**
+  A fully-populated vector index already exists: `GET /semantic/stats` reports
+  `vectorSearchAvailable: true, embeddingCount: 2852` against 2,852 entities, i.e. 100%
+  coverage. `searchHybrid()` performs real vector KNN. But `PromptBuildRecall.ts:138` calls
+  the synchronous `search()` — FTS5 keyword-only — because `recall()` is synchronous
+  (`PromptBuildRecall.ts:113`) and `searchHybrid` is async. So recall runs on keyword
+  matching while the embeddings sit unused, and a query worded differently from the stored
+  entity misses regardless of this change.
+
+  This change is therefore a **floor-raiser for the lexical path**, which still matters —
+  `searchHybrid()` degrades to `search()` whenever vectors are unavailable, and
+  `/semantic/search` uses it directly — but it is explicitly not the answer to
+  "why didn't recall find this". Keyword search should be supplementary, not primary.
+  <!-- tracked: ACT-1386 -->
+
+  *Correction of record:* an earlier draft of this artifact claimed `vec0` was unloadable and
+  recall was lexical-only by necessity. That was wrong. It came from probing `semantic.db`
+  with python's `sqlite3`, which does not load the extension; the Node process loads it
+  successfully. The false claim is recorded here rather than quietly deleted, because
+  "I verified with the wrong tool and concluded a capability was missing" is the same failure
+  class this whole change exists to address.
 - **Stopword list is English-only and fixed.** A domain word that is genuinely a stopword
   here (e.g. "session") is not covered, and shouldn't be — over-stripping would blunt
   precision.


### PR DESCRIPTION
## Summary

`SemanticMemory.search()` passed the caller's sanitized string straight to FTS5, which requires **every** bare token to match. Recall is fed the user's raw message — always a sentence — so ordinary function words decided the outcome. **No stored entity contains the word "why", so any question beginning "why" matched nothing regardless of its content words.**

Measured on the live 2,852-entity store before the fix:

| query | results | | query | results |
|---|---|---|---|---|
| `can I reach Codey` | **0** | | `reach Codey` | 7 |
| `is Codey responding to my messages` | **0** | | `Codey messages` | 17 |
| `why is Codey not replying` | **0** | | `Codey` | 20 |

Same store, same instant. The only difference is the connecting words.

## Why this went undetected

**An empty result set is indistinguishable from an empty memory.** No error, no warning, no slow query — the system reported healthy while returning nothing indefinitely. Everything downstream behaved exactly as it would if the agent had genuinely learned nothing on the subject.

Concrete cost: an entity stored 2026-07-19 (`Telegram bot visibility limit`) was indexed and keyword-findable the whole time, never surfaced, and was re-derived from scratch on 2026-07-27 — after a wrong conclusion that a peer agent had stopped working.

## The change

Stopwords are dropped before building the match expression, and an OR of the content words is used **only** when the strict AND match returns zero rows.

- Strict runs first and stays authoritative whenever it matches → keyword queries are byte-identical, and widening only ever replaces an *empty* result.
- An all-stopword query keeps its original tokens (an empty FTS5 match expression is a syntax error, not a match-nothing).
- The fallback re-uses the same prepared statement and parameter list → type, domain, confidence and privacy filters apply identically on both passes.
- `sanitizeFts5Query` still runs first, so `AND`/`OR`/`NOT`/`NEAR` and FTS5 syntax chars are stripped from caller input. The `OR` introduced here is built by us from already-sanitized tokens.

Recall is a **signal producer** — injected as context, gates nothing. A false positive costs a line of context; the false negative it replaces cost a repeated incident.

## Self-caught during review: the fallback was silent

The first revision introduced a **silent** degradation — the OR widening substituted a weaker strategy and reported nothing. That is the same defect class this PR exists to fix, added by the fix. Corrected before merge.

`search()` now records `lastSearchStrategy`: `fts-strict` (precise query served), `fts-loose-fallback` (strict found nothing, weaker OR served instead), or `none` (no query ran — reset on the early-return path so a stale "served by strict" can't be read for a query that never executed).

Read-only, gates nothing, no change to what `search()` returns. This is *No Silent Degradation to Brittle Fallback* (`docs/STANDARDS-REGISTRY.md:125`) applied to retrieval: "silent degradation to a weak check is worse than no check, because it looks protected while being fake-protected." The standard's formal scope is LLM *gating* calls so it didn't bind here — but its reasoning is exactly on point.

Concretely: recall ran on keyword-only search for its entire life while a fully-populated vector index went uncalled, and nothing reported it. A cheap path that announces itself is the difference between that being discoverable and invisible.

## Evidence

Tests run against **unmodified source first**:

| run | result |
|---|---|
| fix reverted | **9 failed / 4 passed** — the 4 are the regression guards |
| fix applied | **13 passed** |
| semantic-memory suite (5 files) | **126 passed** |
| `tsc --noEmit` | clean |

The 4 passing on unfixed source are deliberate: bare keyword query, strict-match preference, genuinely-absent query returns empty, confidence filter honoured. A guard that only passes *after* the change guards nothing.

Verified on the **live 2,852-entity store**, not just fixtures:

```
"can I reach Codey"                        0 → 5 hits
"is Codey responding to my messages"       0 → 5 hits
"why can a telegram bot not see messages"  0 → 5 hits
      top hit = "Telegram bot visibility limit"   ← the 2026-07-19 entity
```

## Not in scope — and a correction

**This fixes the FALLBACK path, not the primary one.** A fully-populated vector index already exists: `GET /semantic/stats` reports `vectorSearchAvailable: true, embeddingCount: 2852` against 2,852 entities (100% coverage), and `searchHybrid()` does real vector KNN. But `PromptBuildRecall.ts:138` calls the **synchronous** `search()` — keyword-only — because `recall()` is synchronous (`PromptBuildRecall.ts:113`) and `searchHybrid` is async.

So recall runs on keyword matching while the embeddings sit unused. This change still matters — `searchHybrid()` degrades to `search()` whenever vectors are unavailable, and `/semantic/search` calls it directly — but it is **not** the answer to "why didn't recall find this". Keyword search should be supplementary, not primary. Tracked as **ACT-1386**.

*Correction of record:* the first revision of this PR claimed `vec0` was unloadable and recall was lexical-only by necessity. That was wrong — it came from probing `semantic.db` with python's `sqlite3`, which doesn't load the extension, while the Node process loads it fine. The claim is corrected in the artifact rather than quietly deleted, because "verified with the wrong tool, concluded a capability was missing" is the same failure class this change exists to address. ACT-1384 is cancelled as false-premise.

## ELI16 — the memory worked, the question didn't

The agent has a memory, and before answering it quietly searches that memory and reads anything relevant back to itself. That system was switched on and working correctly. It just never found anything, because of how the question was phrased.

The search demanded that **every single word** of the question appear in a stored note. Ask "why is the deploy failing" and it looked for notes containing *why* and *is* and *the* and *deploy* and *failing* — all five. No note anywhere contains the word "why", so it found nothing. Not "nothing relevant" — nothing at all, always, for any question starting with "why". And questions are the only thing this system is ever given.

Nobody noticed because an empty answer looks exactly like an empty memory. There was no error and no warning, just silence — which is precisely what "I have no relevant memories" is supposed to look like. It reported perfect health while returning nothing for months.

The fix drops ordinary connecting words before searching, and if the precise search still finds nothing, retries accepting any of the remaining words. The widening is deliberately last in line: the precise search runs first and, whenever it finds anything, its results are used untouched. It also can't invent relevance — asking about something genuinely not in memory still returns nothing, pinned by a test so a later change can't quietly turn this into a system that always finds something whether or not it's there.
