### PR TITLE
fix: bound mentor onboarding retries

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T17-53-00-518Z-bounded-mentor-onboarding-retries.json
+++ b/.instar/instar-dev-decisions/2026-07-27T17-53-00-518Z-bounded-mentor-onboarding-retries.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-07-27T17:53:00.518Z",
+  "slug": "bounded-mentor-onboarding-retries",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 441,
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The correlation-scoped anti-ping-pong tracker intentionally deleted expired prompts and therefore forgot all retry history. Telegram's bot-to-bot receive blind spot turned that latent reset into roughly twenty-four identical visible sends over twelve hours: each correlation expired normally and the next tick treated identical content as new."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/scheduler/OutstandingPromptTracker.test.ts",
+      "howCaught": "The ratchet proves at most three attempts for one normalized unanswered content key, restart-surviving suppression and escalation, independence for new content, and a bounded 64-key ledger. The production lifecycle test separately drives three transport refusals and requires the fourth identical send to settle at refusal."
+    }
+  },
+  "verdict": "pass"
+}

--- a/src/scheduler/MentorOnboardingRunner.ts
+++ b/src/scheduler/MentorOnboardingRunner.ts
@@ -12,7 +12,13 @@
  *
  * Ships dormant: `mentor.enabled=false` / `mentor.mode='off'` by default (§16).
  */
-import { runMentorTick, type MentorTickResult, type MentorMode, type MentorCycleCapture } from './MentorOnboardingTick.js';
+import {
+  runMentorTick,
+  type MentorTickResult,
+  type MentorMode,
+  type MentorCycleCapture,
+  type MentorDeliveryOutcome,
+} from './MentorOnboardingTick.js';
 import { llmCircuitAvailable } from '../core/LlmCircuitBreaker.js';
 import {
   runAutonomousGuardian,
@@ -165,7 +171,14 @@ export interface MentorRunnerServices {
   /** Build the conversation surface (Stage A's only input). */
   getSurface: (framework: string) => ConversationSurface;
   /** Persist-only delivery to the mentee (live mode only; never spawns). */
-  deliverToMentee?: (framework: string, message: string) => void;
+  deliverToMentee?: (
+    framework: string,
+    message: string,
+  ) =>
+    | void
+    | boolean
+    | MentorDeliveryOutcome
+    | Promise<void | boolean | MentorDeliveryOutcome>;
   /** Called once when a tick actually RAN (ran=true) — lets the host advance the
    *  min-interval clock and the per-day run counter. */
   onTickRan?: () => void;

--- a/src/scheduler/MentorOnboardingTick.ts
+++ b/src/scheduler/MentorOnboardingTick.ts
@@ -88,7 +88,14 @@ export interface MentorTickDeps {
    * the structural fix for the cross-agent spawn loop. Omitted/undefined ⇒ no
    * delivery (the dormant + dry-run default).
    */
-  deliverToMentee?: (framework: string, message: string) => void;
+  deliverToMentee?: (
+    framework: string,
+    message: string,
+  ) =>
+    | void
+    | boolean
+    | MentorDeliveryOutcome
+    | Promise<void | boolean | MentorDeliveryOutcome>;
   /** Tick id for provenance/episode keying. */
   tickId?: string;
   now?: () => number;
@@ -104,12 +111,27 @@ export type MentorTickReason =
   | 'stage-a-failed'
   | 'ran';
 
+export type MentorDeliveryReason =
+  | 'prior-prompt-in-flight'
+  | 'identical-content-retry-exhausted'
+  | 'delivery-retry-ledger-full'
+  | 'delivery-state-unavailable'
+  | 'transport-unavailable'
+  | 'transport-failed';
+
+export interface MentorDeliveryOutcome {
+  delivered: boolean;
+  reason?: MentorDeliveryReason;
+}
+
 export interface MentorTickResult {
   ran: boolean;
   reason: MentorTickReason;
   mode?: MentorMode;
   /** True when the Stage-A message was delivered to the mentee (live mode only). */
   delivered?: boolean;
+  /** Distinct delivery-layer refusal/failure; never collapsed into "unanswered". */
+  deliveryReason?: MentorDeliveryReason;
   leakDetected?: boolean;
   observationsWritten?: number;
   findingsCount?: number;
@@ -221,9 +243,17 @@ export async function runMentorTick(deps: MentorTickDeps): Promise<MentorTickRes
   // 8. Deliver — ONLY in live mode, and ONLY via the host's persist-only path
   //    (§6). In dry-run we observe + capture but never contact the mentee.
   let delivered = false;
+  let deliveryReason: MentorDeliveryReason | undefined;
   if (deps.mode === 'live' && deps.deliverToMentee && transcript.trim()) {
-    deps.deliverToMentee(deps.framework, transcript);
-    delivered = true;
+    const outcome = await deps.deliverToMentee(deps.framework, transcript);
+    if (typeof outcome === 'object' && outcome !== null && 'delivered' in outcome) {
+      delivered = outcome.delivered;
+      deliveryReason = outcome.reason;
+    } else {
+      // Backward-compatible injected callbacks used by existing tests/plugins:
+      // explicit false means refused; void historically meant "accepted".
+      delivered = outcome !== false;
+    }
   }
 
   return {
@@ -231,14 +261,13 @@ export async function runMentorTick(deps: MentorTickDeps): Promise<MentorTickRes
     reason: 'ran',
     mode: deps.mode,
     delivered,
+    ...(deliveryReason ? { deliveryReason } : {}),
     leakDetected: leak.leaked,
     observationsWritten: captured.observationsWritten,
     findingsCount: findings.length,
-    // The tick SURFACES the Stage-A message it produced; it does NOT deliver it.
-    // No mentee-delivery path is wired yet — `live` mode is not reachable until
-    // the persist-only delivery (§6) is built + tested. Until then both dry-run
-    // and live only observe + capture. Delivery is a live-promotion blocker.
-    // <!-- tracked: topic-13435 -->
+    // The tick surfaces the exact Stage-A message for status/audit alongside
+    // the structured delivery outcome. Live delivery still occurs only through
+    // the injected host boundary above; dry-run never calls that boundary.
     stageAMessage: transcript,
   };
 }

--- a/src/scheduler/OutstandingPromptTracker.ts
+++ b/src/scheduler/OutstandingPromptTracker.ts
@@ -18,6 +18,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
 
 export interface OutstandingPromptTrackerOptions {
@@ -25,6 +26,10 @@ export interface OutstandingPromptTrackerOptions {
   filePath: string;
   /** A reply that doesn't arrive within this window is treated as orphaned. */
   replyTimeoutMs?: number;
+  /** Maximum sends of identical unanswered content before its breaker opens. */
+  maxIdenticalAttempts?: number;
+  /** Hard bound for distinct unresolved content keys retained in the ledger. */
+  maxTrackedContentKeys?: number;
   /** Injected for testability. */
   now?: () => number;
 }
@@ -34,33 +39,88 @@ interface OutstandingPrompt {
   sentAt: number;
   /** Mentee framework label (for the audit + future multi-mentee fan-out). */
   mentee: string;
+  /** Stable hash of the normalized mentor content reserved for this send. */
+  contentKey?: string;
 }
 
-interface PersistedFile {
+interface DeliveryRetryRecord {
+  mentee: string;
+  attempts: number;
+  firstAttemptAt: number;
+  lastAttemptAt: number;
+  /** Persisted one-shot latch for the retry-exhaustion escalation. */
+  escalatedAt?: number;
+}
+
+interface PersistedFileV1 {
   v: 1;
   /** corr → record. */
   entries: Record<string, OutstandingPrompt>;
 }
 
+interface PersistedFileV2 {
+  v: 2;
+  /** corr → record. */
+  entries: Record<string, OutstandingPrompt>;
+  /** content key → bounded retry record. Raw prompt text is never persisted. */
+  retries: Record<string, DeliveryRetryRecord>;
+}
+
 const DEFAULT_REPLY_TIMEOUT_MS = 20 * 60 * 1000; // 20 min — > the 15-min tick interval.
+const DEFAULT_MAX_IDENTICAL_ATTEMPTS = 3;
+const DEFAULT_MAX_TRACKED_CONTENT_KEYS = 64;
 
 export type CheckResult =
   | { ok: true }
   | { ok: false; reason: 'prior-prompt-in-flight'; outstandingCorr: string; sentAt: number };
 
+export type ReserveSendResult =
+  | { ok: true; contentKey: string; attempt: number; exhausted: boolean }
+  | {
+      ok: false;
+      reason: 'prior-prompt-in-flight';
+      outstandingCorr: string;
+      sentAt: number;
+    }
+  | {
+      ok: false;
+      reason: 'identical-content-retry-exhausted';
+      contentKey: string;
+      attempts: number;
+      firstAttemptAt: number;
+      lastAttemptAt: number;
+      escalated: boolean;
+    }
+  | {
+      ok: false;
+      reason: 'delivery-retry-ledger-full' | 'delivery-state-unavailable';
+    };
+
 export class OutstandingPromptTracker {
   private readonly filePath: string;
   private readonly replyTimeoutMs: number;
+  private readonly maxIdenticalAttempts: number;
+  private readonly maxTrackedContentKeys: number;
   private readonly now: () => number;
   private entries: Map<string, OutstandingPrompt>;
+  private retries: Map<string, DeliveryRetryRecord>;
   /** Per-(reason,day) dedup for the orphan-degradation notification. */
   private orphanedNotifiedFor: Set<string>;
 
   constructor(opts: OutstandingPromptTrackerOptions) {
     this.filePath = opts.filePath;
     this.replyTimeoutMs = opts.replyTimeoutMs ?? DEFAULT_REPLY_TIMEOUT_MS;
+    this.maxIdenticalAttempts = Math.max(
+      1,
+      Math.floor(opts.maxIdenticalAttempts ?? DEFAULT_MAX_IDENTICAL_ATTEMPTS),
+    );
+    this.maxTrackedContentKeys = Math.max(
+      1,
+      Math.floor(opts.maxTrackedContentKeys ?? DEFAULT_MAX_TRACKED_CONTENT_KEYS),
+    );
     this.now = opts.now ?? Date.now;
     this.entries = new Map();
+    this.retries = new Map();
     this.orphanedNotifiedFor = new Set();
     this.load();
   }
@@ -88,13 +148,86 @@ export class OutstandingPromptTracker {
   }
 
   /**
+   * Atomically reserve one outbound attempt BEFORE the transport is called.
+   *
+   * The reservation is the self-action boundary: the content-key attempt and
+   * outstanding correlation land in one durable file first. If that write
+   * fails, the send is refused rather than performed without a restart-proof
+   * brake. Identical unanswered content opens a durable breaker after the
+   * bounded attempt count; a different content key gets its own budget.
+   */
+  reserveSend(corr: string, mentee: string, content: string): ReserveSendResult {
+    this.sweepExpired();
+    for (const [outstandingCorr, prompt] of this.entries) {
+      if (prompt.mentee === mentee) {
+        return {
+          ok: false,
+          reason: 'prior-prompt-in-flight',
+          outstandingCorr,
+          sentAt: prompt.sentAt,
+        };
+      }
+    }
+
+    const contentKey = this.contentKey(mentee, content);
+    const prior = this.retries.get(contentKey);
+    if (prior && prior.attempts >= this.maxIdenticalAttempts) {
+      return {
+        ok: false,
+        reason: 'identical-content-retry-exhausted',
+        contentKey,
+        attempts: prior.attempts,
+        firstAttemptAt: prior.firstAttemptAt,
+        lastAttemptAt: prior.lastAttemptAt,
+        escalated: prior.escalatedAt != null,
+      };
+    }
+    if (!prior && this.retries.size >= this.maxTrackedContentKeys) {
+      return { ok: false, reason: 'delivery-retry-ledger-full' };
+    }
+
+    const now = this.now();
+    const next: DeliveryRetryRecord = prior
+      ? { ...prior, attempts: prior.attempts + 1, lastAttemptAt: now }
+      : { mentee, attempts: 1, firstAttemptAt: now, lastAttemptAt: now };
+    this.retries.set(contentKey, next);
+    this.entries.set(corr, { sentAt: now, mentee, contentKey });
+    if (!this.persist()) {
+      this.entries.delete(corr);
+      if (prior) this.retries.set(contentKey, prior);
+      else this.retries.delete(contentKey);
+      return { ok: false, reason: 'delivery-state-unavailable' };
+    }
+    return {
+      ok: true,
+      contentKey,
+      attempt: next.attempts,
+      exhausted: next.attempts >= this.maxIdenticalAttempts,
+    };
+  }
+
+  /**
+   * The transport refused or threw after a durable reservation. Remove only
+   * the in-flight correlation; retain the attempt so transport failures consume
+   * the same bounded budget as unacknowledged sends.
+   */
+  markDeliveryFailed(corr: string): void {
+    if (this.entries.delete(corr)) this.persist();
+  }
+
+  /**
    * Clear an outstanding prompt by `corr` (called when the matching reply arrives).
    * Returns true if an outstanding entry existed (legitimate reply); false if not
    * (a reply with no outstanding match — possibly a late reply after orphan-sweep,
    * or a spurious reply; the caller may want to log this).
    */
   clearByCorr(corr: string): boolean {
+    const prompt = this.entries.get(corr);
     const had = this.entries.delete(corr);
+    // A matching reply resolves the unanswered-content episode. Future use of
+    // the same words is a new conversation turn, not a continuation of this
+    // exhausted retry budget.
+    if (prompt?.contentKey) this.retries.delete(prompt.contentKey);
     if (had) this.persist();
     return had;
   }
@@ -124,6 +257,27 @@ export class OutstandingPromptTracker {
     return true;
   }
 
+  /**
+   * Durable one-shot latch for the distinct transport/delivery escalation.
+   * Returns true exactly once for an exhausted content key, including across a
+   * tracker reconstruction (server restart).
+   */
+  recordRetryExhaustionEscalated(contentKey: string): boolean {
+    const prior = this.retries.get(contentKey);
+    if (!prior || prior.attempts < this.maxIdenticalAttempts || prior.escalatedAt != null) {
+      return false;
+    }
+    this.retries.set(contentKey, { ...prior, escalatedAt: this.now() });
+    if (!this.persist()) {
+      // Refuse to emit an escalation whose one-shot latch is not durable. The
+      // next tick may retry the state write, but it cannot create a flood on a
+      // restart from an unrecorded notification.
+      this.retries.set(contentKey, prior);
+      return false;
+    }
+    return true;
+  }
+
   /** Test helper. */
   size(): number {
     return this.entries.size;
@@ -138,31 +292,64 @@ export class OutstandingPromptTracker {
     if (!fs.existsSync(this.filePath)) return;
     try {
       const raw = fs.readFileSync(this.filePath, 'utf-8');
-      const parsed = JSON.parse(raw) as PersistedFile;
-      if (parsed && parsed.v === 1 && parsed.entries && typeof parsed.entries === 'object') {
+      const parsed = JSON.parse(raw) as PersistedFileV1 | PersistedFileV2;
+      if (parsed && (parsed.v === 1 || parsed.v === 2) && parsed.entries && typeof parsed.entries === 'object') {
         for (const [corr, p] of Object.entries(parsed.entries)) {
           if (p && typeof p.sentAt === 'number' && typeof p.mentee === 'string') {
-            this.entries.set(corr, { sentAt: p.sentAt, mentee: p.mentee });
+            this.entries.set(corr, {
+              sentAt: p.sentAt,
+              mentee: p.mentee,
+              contentKey: typeof p.contentKey === 'string' ? p.contentKey : undefined,
+            });
+          }
+        }
+      }
+      if (parsed?.v === 2 && parsed.retries && typeof parsed.retries === 'object') {
+        for (const [contentKey, r] of Object.entries(parsed.retries)) {
+          if (
+            r &&
+            typeof r.mentee === 'string' &&
+            Number.isInteger(r.attempts) &&
+            r.attempts > 0 &&
+            typeof r.firstAttemptAt === 'number' &&
+            typeof r.lastAttemptAt === 'number'
+          ) {
+            this.retries.set(contentKey, {
+              mentee: r.mentee,
+              attempts: r.attempts,
+              firstAttemptAt: r.firstAttemptAt,
+              lastAttemptAt: r.lastAttemptAt,
+              escalatedAt: typeof r.escalatedAt === 'number' ? r.escalatedAt : undefined,
+            });
           }
         }
       }
     } catch {
       // Corrupted state → start fresh; better than crashing the mentor on a bad file.
       this.entries = new Map();
+      this.retries = new Map();
     }
   }
 
-  private persist(): void {
-    const file: PersistedFile = {
-      v: 1,
+  private contentKey(mentee: string, content: string): string {
+    const normalized = content.normalize('NFKC').trim().replace(/\s+/g, ' ');
+    return createHash('sha256').update(`${mentee}\0${normalized}`, 'utf8').digest('hex');
+  }
+
+  private persist(): boolean {
+    const file: PersistedFileV2 = {
+      v: 2,
       entries: Object.fromEntries(this.entries),
+      retries: Object.fromEntries(this.retries),
     };
     try {
       fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
       SafeFsExecutor.atomicWriteJsonSync(this.filePath, file, { operation: 'OutstandingPromptTracker.persist' });
+      return true;
     } catch (err) {
       // eslint-disable-next-line no-console
       console.warn(`[mentor] OutstandingPromptTracker persist failed (non-fatal) at ${this.filePath}:`, err instanceof Error ? err.message : String(err));
+      return false;
     }
   }
 }

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -4483,6 +4483,40 @@ export class AgentServer {
     const lastResultPath = options.config.stateDir
       ? path.join(options.config.stateDir, 'mentor-last-result.json')
       : null;
+    const sweepMentorOrphans = (): void => {
+      const outstanding = self.getOrCreateMentorOutstanding();
+      const orphans = outstanding.sweepExpired();
+      for (const orphan of orphans) {
+        if (!outstanding.recordOrphanNotified(orphan.corr)) continue;
+        console.warn(`[mentor] orphaned prompt — no reply within ${orphan.ageMs}ms (corr=${orphan.corr}, mentee=${orphan.mentee})`);
+        try {
+          DegradationReporter.getInstance().report({
+            feature: 'mentor.reply-orphaned',
+            primary: 'mentor receives a correlated mentee reply within replyTimeoutMs',
+            fallback: 'the content-key retry brake accounts for the attempt before any later send',
+            reason: `outstanding prompt corr=${orphan.corr} aged ${orphan.ageMs}ms without a mentor-reply`,
+            impact: 'the attempt is classified as unconfirmed delivery; identical content remains subject to its bounded retry budget',
+          });
+        } catch { /* best-effort */ }
+      }
+    };
+    const escalateMentorDeliveryExhaustion = (
+      contentKey: string,
+      attempts: number,
+      reason: string,
+    ): void => {
+      const outstanding = self.getOrCreateMentorOutstanding();
+      if (!outstanding.recordRetryExhaustionEscalated(contentKey)) return;
+      try {
+        DegradationReporter.getInstance().report({
+          feature: 'mentor.delivery-unconfirmed-retry-exhausted',
+          primary: 'a mentor prompt produces a correlated mentee reply',
+          fallback: 'the durable content-key breaker suppresses further identical sends',
+          reason,
+          impact: `that agenda item is paused as a transport/delivery failure after ${attempts} attempts; a genuinely new agenda item remains eligible`,
+        });
+      } catch { /* best-effort */ }
+    };
     return new MentorOnboardingRunner(
       {
         capture: (input) => ledger.captureRun(input),
@@ -4658,6 +4692,11 @@ export class AgentServer {
         isMenteeBusy: () => {
           const cfg = getConfig();
           const menteeAgent = cfg.menteeAgentName || `instar-${cfg.menteeFramework}`;
+          // Sweep + classify expired correlations BEFORE asking the busy gate.
+          // canSendTo also sweeps defensively, but doing it here preserves the
+          // orphan evidence instead of deleting it before the distinct delivery
+          // signal can be emitted.
+          sweepMentorOrphans();
           return !self.getOrCreateMentorOutstanding().canSendTo(menteeAgent).ok;
         },
         minIntervalElapsed: () => {
@@ -4702,29 +4741,28 @@ export class AgentServer {
           const menteeAgent = cfg.menteeAgentName || `instar-${framework}`;
           const corr = `mp-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 
-          // Anti-ping-pong (spec §Fix 2b item 4 + Justin's original concern). Same
-          // logic regardless of transport. Refuse to send a new prompt while a
-          // prior one is unanswered within replyTimeoutMs.
+          // Anti-ping-pong + content-key retry breaker. Reserve the attempt in
+          // durable state BEFORE calling any transport. A failed reservation is
+          // a hard refusal: acting without the restart-proof ledger would turn a
+          // storage problem back into an unbounded self-action loop.
           const outstanding = self.getOrCreateMentorOutstanding();
-          const orphans = outstanding.sweepExpired();
-          for (const orphan of orphans) {
-            if (outstanding.recordOrphanNotified(orphan.corr)) {
-              console.warn(`[mentor] orphaned prompt — no reply within ${orphan.ageMs}ms (corr=${orphan.corr}, mentee=${orphan.mentee})`);
-              try {
-                DegradationReporter.getInstance().report({
-                  feature: 'mentor.reply-orphaned',
-                  primary: 'mentor receives Codey reply within replyTimeoutMs',
-                  fallback: 'tick continues; no auto-resend; Stage-B sees the routed-sent row + no matching reply row',
-                  reason: `outstanding prompt corr=${orphan.corr} aged ${orphan.ageMs}ms without a mentor-reply`,
-                  impact: 'mentor cycle silently lost a reply; next tick allowed to retry',
-                });
-              } catch { /* best-effort */ }
+          const reservation = outstanding.reserveSend(corr, menteeAgent, message);
+          if (!reservation.ok) {
+            if (reservation.reason === 'prior-prompt-in-flight') {
+              console.warn(`[mentor] deliverToMentee deferred — prior-prompt-in-flight (corr=${reservation.outstandingCorr}, sentAt=${reservation.sentAt})`);
+              return { delivered: false, reason: reservation.reason };
             }
-          }
-          const check = outstanding.canSendTo(menteeAgent);
-          if (!check.ok) {
-            console.warn(`[mentor] deliverToMentee deferred — prior-prompt-in-flight (corr=${check.outstandingCorr}, sentAt=${check.sentAt})`);
-            return;
+            if (reservation.reason === 'identical-content-retry-exhausted') {
+              console.warn(`[mentor] deliverToMentee suppressed — identical-content-retry-exhausted (attempts=${reservation.attempts}, key=${reservation.contentKey.slice(0, 12)})`);
+              escalateMentorDeliveryExhaustion(
+                reservation.contentKey,
+                reservation.attempts,
+                `${reservation.attempts} attempts for the same normalized mentor content ended without a confirmed reply`,
+              );
+              return { delivered: false, reason: reservation.reason };
+            }
+            console.warn(`[mentor] deliverToMentee refused — ${reservation.reason}`);
+            return { delivered: false, reason: reservation.reason };
           }
 
           // Deliver via the unified a2a transport: same-machine /a2a/inbox
@@ -4735,47 +4773,55 @@ export class AgentServer {
             cfg.botToken && cfg.menteeChatId
               ? self.getOrCreateMentorBot(cfg.botToken, cfg.menteeChatId) ?? undefined
               : undefined;
-          const delivered = await self.deliverA2aMessage({
-            fromAgent: 'echo',
-            toAgent: menteeAgent,
-            role: 'mentor',
-            corr,
-            body: message,
-            allowedRoles: new Set(['mentor']),
-            // Route the mentor exchange to a DEDICATED mentor topic when one is
-            // configured, so the mentor's a2a check-ins don't interleave with
-            // the human↔mentee conversation topic (menteeTopicId). This one id
-            // drives both the /a2a/inbox body (where the mentee binds its
-            // session) and the Telegram fallback, so the whole exchange moves
-            // together. Falls back to menteeTopicId (backward-compatible).
-            telegramTopicId: resolveMentorDeliveryTopic(cfg),
-            targetMachineId: cfg.menteeMachineId,
-            // fromBotId = echo's mentor-bot id, so the mentee's allowlist
-            // (knownMentors[echo].botId === senderBotId) passes.
-            fromBotId: cfg.botToken ? cfg.botToken.split(':')[0] : undefined,
-            toBotId: cfg.menteeBotId,
-            telegramBot: telegramBot
-              ? { sendToTopic: (t, txt) => telegramBot.sendToTopic(t, txt) }
-              : undefined,
-            botToken: cfg.botToken,
-            visibleEcho: {
-              enabled: cfg.visibleEcho !== false,
-              bot: telegramBot
+          let delivered = false;
+          try {
+            delivered = await self.deliverA2aMessage({
+              fromAgent: 'echo',
+              toAgent: menteeAgent,
+              role: 'mentor',
+              corr,
+              body: message,
+              allowedRoles: new Set(['mentor']),
+              // Route the mentor exchange to a DEDICATED mentor topic when one is
+              // configured, so mentor a2a stays off the human conversation.
+              telegramTopicId: resolveMentorDeliveryTopic(cfg),
+              targetMachineId: cfg.menteeMachineId,
+              fromBotId: cfg.botToken ? cfg.botToken.split(':')[0] : undefined,
+              toBotId: cfg.menteeBotId,
+              telegramBot: telegramBot
                 ? { sendToTopic: (t, txt) => telegramBot.sendToTopic(t, txt) }
                 : undefined,
-              topicId: resolveMentorDeliveryTopic(cfg),
-              roleTag: '[mentor]',
-              reportFailure: (reason) => {
-                DegradationReporter.getInstance().report({
-                  feature: 'mentor.visible-echo',
-                  primary: 'successful inbox-local mentor delivery is mirrored visibly in Telegram',
-                  fallback: 'canonical /a2a/inbox delivery remains successful; operator may see a phantom prompt',
-                  reason,
-                  impact: 'mentor exchange was delivered but its visible chat mirror is partial or absent',
-                });
+              botToken: cfg.botToken,
+              visibleEcho: {
+                enabled: cfg.visibleEcho !== false,
+                bot: telegramBot
+                  ? { sendToTopic: (t, txt) => telegramBot.sendToTopic(t, txt) }
+                  : undefined,
+                topicId: resolveMentorDeliveryTopic(cfg),
+                roleTag: '[mentor]',
+                reportFailure: (reason) => {
+                  DegradationReporter.getInstance().report({
+                    feature: 'mentor.visible-echo',
+                    primary: 'successful inbox-local mentor delivery is mirrored visibly in Telegram',
+                    fallback: 'canonical /a2a/inbox delivery remains successful; operator may see a phantom prompt',
+                    reason,
+                    impact: 'mentor exchange was delivered but its visible chat mirror is partial or absent',
+                  });
+                },
               },
-            },
-          });
+            });
+          } catch (err) {
+            outstanding.markDeliveryFailed(corr);
+            console.warn(`[mentor] deliverToMentee transport failed (corr=${corr}, mentee=${menteeAgent}):`, err instanceof Error ? err.message : String(err));
+            if (reservation.exhausted) {
+              escalateMentorDeliveryExhaustion(
+                reservation.contentKey,
+                reservation.attempt,
+                `${reservation.attempt} transport attempts for the same normalized mentor content threw before delivery confirmation`,
+              );
+            }
+            return { delivered: false, reason: 'transport-failed' as const };
+          }
           if (delivered) {
             self.appendMentorSent(options.config.stateDir, {
               ts: Date.now(),
@@ -4785,9 +4831,21 @@ export class AgentServer {
               topicId: resolveMentorDeliveryTopic(cfg),
               message,
             });
-            outstanding.markSent(corr, menteeAgent);
+            return { delivered: true };
           } else {
+            outstanding.markDeliveryFailed(corr);
             console.warn(`[mentor] deliverToMentee did not deliver (corr=${corr}, mentee=${menteeAgent}) — no local peer + telegram fallback unavailable/blocked`);
+            // The attempt remains in the content ledger. On the final allowed
+            // attempt, emit the distinct delivery failure immediately instead
+            // of waiting for another tick merely to discover the open breaker.
+            if (reservation.exhausted) {
+              escalateMentorDeliveryExhaustion(
+                reservation.contentKey,
+                reservation.attempt,
+                `${reservation.attempt} transport attempts for the same normalized mentor content were refused`,
+              );
+            }
+            return { delivered: false, reason: 'transport-unavailable' as const };
           }
         },
         onTickRan: () => {

--- a/tests/e2e/mentor-onboarding-lifecycle.test.ts
+++ b/tests/e2e/mentor-onboarding-lifecycle.test.ts
@@ -122,6 +122,40 @@ describe('Mentor-onboarding E2E lifecycle (alive + dormant)', () => {
     const body = fs.readFileSync(jobPath, 'utf-8');
     expect(body).toMatch(/^enabled:\s*false\s*$/m);
   });
+
+  it('production delivery wiring durably breaks identical transport retries while allowing new content', async () => {
+    const runner = (server as any).mentorRunner;
+    const deliver = runner?.services?.deliverToMentee as
+      | ((framework: string, message: string) => Promise<{ delivered: boolean; reason?: string }>)
+      | undefined;
+    expect(deliver).toBeTypeOf('function');
+
+    const repeated = 'May I use the default permission rule?';
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      await expect(deliver!('codex-cli', repeated)).resolves.toMatchObject({
+        delivered: false,
+        reason: 'transport-unavailable',
+      });
+    }
+    await expect(deliver!('codex-cli', repeated)).resolves.toMatchObject({
+      delivered: false,
+      reason: 'identical-content-retry-exhausted',
+    });
+    await expect(deliver!('codex-cli', 'Please review the next bounded task.')).resolves.toMatchObject({
+      delivered: false,
+      reason: 'transport-unavailable',
+    });
+
+    const persisted = JSON.parse(
+      fs.readFileSync(path.join(stateDir, 'mentor-outstanding-prompts.json'), 'utf-8'),
+    ) as {
+      v: number;
+      retries: Record<string, { attempts: number; escalatedAt?: number }>;
+    };
+    expect(persisted.v).toBe(2);
+    expect(Object.values(persisted.retries).map((r) => r.attempts).sort()).toEqual([1, 3]);
+    expect(Object.values(persisted.retries).some((r) => typeof r.escalatedAt === 'number')).toBe(true);
+  });
 });
 
 describe('Mentor ledger survives a broken TokenLedger (regression: production cascade)', () => {

--- a/tests/integration/mentor-routes.test.ts
+++ b/tests/integration/mentor-routes.test.ts
@@ -93,6 +93,27 @@ describe('Mentor routes (integration)', () => {
     expect(status.body.lastResult?.mode).toBe('dry-run');
   });
 
+  it('GET /mentor/status preserves a delivery-breaker refusal as a distinct result', async () => {
+    const cfg: MentorConfig = { ...DEFAULT_MENTOR_CONFIG, enabled: true, mode: 'live' };
+    const svc: MentorRunnerServices = {
+      ...fakeServices(),
+      deliverToMentee: async () => ({
+        delivered: false,
+        reason: 'identical-content-retry-exhausted',
+      }),
+    };
+    const app = appWith(new MentorOnboardingRunner(svc, () => cfg));
+
+    expect((await request(app).post('/mentor/tick')).status).toBe(202);
+    await new Promise((r) => setTimeout(r, 10));
+    const status = await request(app).get('/mentor/status');
+    expect(status.body.lastResult).toMatchObject({
+      ran: true,
+      delivered: false,
+      deliveryReason: 'identical-content-retry-exhausted',
+    });
+  });
+
   it('POST /mentor/tick routes to the autonomous-fix guardian when enabled; spawns a loop session', async () => {
     const spawnLoopSession = vi.fn(async () => ({ sessionName: 'mentor-autoloop-int' }));
     const cfg: MentorConfig = {

--- a/tests/unit/MentorOnboardingTick.test.ts
+++ b/tests/unit/MentorOnboardingTick.test.ts
@@ -139,6 +139,30 @@ describe('runMentorTick — gate order + structural guarantees', () => {
     expect(deliver).toHaveBeenCalledWith('codex-cli', 'next task: ship the X primitive');
   });
 
+  it('awaits the delivery decision and surfaces a retry-breaker refusal distinctly', async () => {
+    let release!: () => void;
+    const wait = new Promise<void>((resolve) => { release = resolve; });
+    const deliver = vi.fn(async () => {
+      await wait;
+      return { delivered: false, reason: 'identical-content-retry-exhausted' as const };
+    });
+    const { deps } = makeDeps({
+      canaryCheck: () => true,
+      mode: 'live',
+      deliverToMentee: deliver,
+    });
+
+    const pending = runMentorTick(deps);
+    let settled = false;
+    void pending.then(() => { settled = true; });
+    await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
+    expect(settled).toBe(false);
+    release();
+    const r = await pending;
+    expect(r.delivered).toBe(false);
+    expect(r.deliveryReason).toBe('identical-content-retry-exhausted');
+  });
+
   it('does not deliver when there is no deliverToMentee wired (safe default)', async () => {
     const { deps } = makeDeps({ canaryCheck: () => true, mode: 'live', deliverToMentee: undefined });
     const r = await runMentorTick(deps);

--- a/tests/unit/scheduler/OutstandingPromptTracker.test.ts
+++ b/tests/unit/scheduler/OutstandingPromptTracker.test.ts
@@ -6,7 +6,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { OutstandingPromptTracker } from '../../../src/scheduler/OutstandingPromptTracker.js';
+import {
+  OutstandingPromptTracker,
+  type OutstandingPromptTrackerOptions,
+} from '../../../src/scheduler/OutstandingPromptTracker.js';
 import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
 
 const NOW = 1_779_900_000_000;
@@ -17,7 +20,7 @@ describe('OutstandingPromptTracker', () => {
   beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mentor-out-')); clock = NOW; });
   afterEach(() => { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'mentor-out test' }); });
 
-  function mk(over: { replyTimeoutMs?: number } = {}): OutstandingPromptTracker {
+  function mk(over: Partial<OutstandingPromptTrackerOptions> = {}): OutstandingPromptTracker {
     return new OutstandingPromptTracker({
       filePath: path.join(dir, 'out.json'),
       now: () => clock,
@@ -92,6 +95,99 @@ describe('OutstandingPromptTracker', () => {
     expect(t.recordOrphanNotified('corr-X')).toBe(true);
     expect(t.recordOrphanNotified('corr-X')).toBe(false);
     expect(t.recordOrphanNotified('corr-Y')).toBe(true);
+  });
+
+  it('DELIVERY BRAKE: allows the first attempt for new mentor content', () => {
+    const t = mk({ replyTimeoutMs: 5000 });
+    const r = t.reserveSend('corr-1', 'instar-codey', 'May I use the default permission rule?');
+    expect(r).toMatchObject({ ok: true, attempt: 1 });
+    expect(t.size()).toBe(1);
+  });
+
+  it('DELIVERY BRAKE: suppresses identical unanswered content after the bounded attempt cap', () => {
+    const t = mk({ replyTimeoutMs: 5000 });
+    const content = 'May I use the default permission rule?';
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      const r = t.reserveSend(`corr-${attempt}`, 'instar-codey', content);
+      expect(r).toMatchObject({ ok: true, attempt });
+      clock += 6000;
+      t.sweepExpired();
+    }
+
+    expect(t.reserveSend('corr-4', 'instar-codey', content)).toMatchObject({
+      ok: false,
+      reason: 'identical-content-retry-exhausted',
+      attempts: 3,
+    });
+  });
+
+  it('DELIVERY BRAKE: allows a genuinely new agenda item while old content is suppressed', () => {
+    const t = mk({ replyTimeoutMs: 5000 });
+    const oldContent = 'May I use the default permission rule?';
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      expect(t.reserveSend(`old-${attempt}`, 'instar-codey', oldContent).ok).toBe(true);
+      clock += 6000;
+      t.sweepExpired();
+    }
+
+    expect(t.reserveSend('old-4', 'instar-codey', oldContent).ok).toBe(false);
+    expect(t.reserveSend('new-1', 'instar-codey', 'Please review the next bounded task.')).toMatchObject({
+      ok: true,
+      attempt: 1,
+    });
+  });
+
+  it('DELIVERY BRAKE: survives a restart and escalates an exhausted content key once', () => {
+    const content = 'May I use the default permission rule?';
+    const t1 = mk({ replyTimeoutMs: 5000 });
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      expect(t1.reserveSend(`corr-${attempt}`, 'instar-codey', content).ok).toBe(true);
+      clock += 6000;
+      t1.sweepExpired();
+    }
+
+    const denied = t1.reserveSend('corr-4', 'instar-codey', content);
+    expect(denied).toMatchObject({
+      ok: false,
+      reason: 'identical-content-retry-exhausted',
+      attempts: 3,
+    });
+    if (denied.ok) throw new Error('expected exhausted delivery brake');
+    expect(t1.recordRetryExhaustionEscalated(denied.contentKey)).toBe(true);
+
+    const t2 = mk({ replyTimeoutMs: 5000 });
+    expect(t2.reserveSend('corr-after-restart', 'instar-codey', content)).toMatchObject({
+      ok: false,
+      reason: 'identical-content-retry-exhausted',
+      attempts: 3,
+    });
+    expect(t2.recordRetryExhaustionEscalated(denied.contentKey)).toBe(false);
+  });
+
+  it('DELIVERY BRAKE: normalizes whitespace, persists only hashes, and bounds distinct keys', () => {
+    const t = mk({ maxTrackedContentKeys: 2 });
+    const sensitive = 'May I use the default permission rule?';
+    const first = t.reserveSend('corr-a', 'instar-codey', sensitive);
+    expect(first).toMatchObject({ ok: true, attempt: 1 });
+    t.markDeliveryFailed('corr-a');
+
+    const normalizedRepeat = t.reserveSend(
+      'corr-b',
+      'instar-codey',
+      '  May I use the default   permission rule?  ',
+    );
+    expect(normalizedRepeat).toMatchObject({ ok: true, attempt: 2 });
+    t.markDeliveryFailed('corr-b');
+
+    expect(fs.readFileSync(path.join(dir, 'out.json'), 'utf-8')).not.toContain(sensitive);
+
+    expect(t.reserveSend('corr-c', 'instar-codey', 'A second agenda item.').ok).toBe(true);
+    t.markDeliveryFailed('corr-c');
+    expect(t.reserveSend('corr-d', 'instar-codey', 'A third agenda item.')).toEqual({
+      ok: false,
+      reason: 'delivery-retry-ledger-full',
+    });
   });
 
   it('CORRUPT FILE: starts fresh rather than crash the mentor', () => {

--- a/upgrades/eli16/bounded-mentor-onboarding-retries.md
+++ b/upgrades/eli16/bounded-mentor-onboarding-retries.md
@@ -1,0 +1,53 @@
+# Bounded mentor-onboarding retries — Plain-English Overview
+
+> The one-line version: an unanswered mentor prompt can now be sent at most three times, the limit survives a restart, and the system reports delivery trouble instead of posting the same question forever.
+
+## The problem
+
+The mentor loop already avoided sending a second prompt while the first one was waiting for a reply. That protection had a hole: after twenty minutes, the old correlation was declared expired and removed. The next tick then treated the same words as a brand-new prompt.
+
+That is how one permission question appeared about every thirty minutes for roughly twelve hours. Each individual send looked legal because the previous correlation had expired. Across the whole episode, however, there was no content-level limit, so the system could repeat its own action indefinitely.
+
+The visible Telegram post also did not prove that the mentee could receive it. Telegram can display a message from one bot while withholding that bot-authored message from another bot's update stream. The old loop interpreted the missing reply as an unanswered coaching question and retried. It needed to recognize the repeated lack of confirmation as a delivery problem.
+
+## What changes
+
+Before any live mentor send, the existing outstanding-prompt tracker now normalizes the message, combines it with the mentee identity, and hashes that pair into a content key. The tracker durably reserves the attempt before it calls the transport.
+
+Each content key gets three attempts:
+
+- Attempt one is allowed.
+- Attempts two and three are allowed after the earlier correlation expires or the transport refuses it.
+- A fourth attempt with the same unanswered content is refused.
+- Different content gets a different key and remains eligible.
+
+The state file is upgraded in place from version 1 to version 2. It keeps the existing outstanding correlations and adds a bounded retry ledger. Only hashes and timing/count metadata are stored; the prompt text is not copied into this state.
+
+## Why the ordering matters
+
+The reservation is written before the send. If the retry ledger cannot be persisted, the transport is not called. This prevents a disk or state failure from silently removing the very brake that makes the self-action bounded.
+
+A transport refusal still consumes an attempt. Otherwise an unreachable destination could be retried forever while the counter remained at zero. A confirmed correlated reply clears that content episode, because repeating the same words after an actual reply is a new conversation rather than an unanswered retry.
+
+## What the operator sees
+
+The normal first attempts remain unchanged. When the content budget is exhausted, the mentor tick reports a distinct delivery reason instead of claiming success or folding the event into a generic unanswered-question state.
+
+The first exhaustion also emits one degradation signal explaining that delivery could not be confirmed and that identical sends are now suppressed. A persisted `escalatedAt` latch prevents the escalation itself from becoming another flood, including across a restart.
+
+## Boundaries
+
+This change does not alter Threadline identity resolution, Telegram's bot-to-bot behavior, the process-wide LLM circuit breaker, the mentor agenda, the reply timeout, the tick cadence, or budget limits. It does not add a route or configuration switch.
+
+The retry ledger is capped at 64 unresolved content keys. Reaching that cap refuses new mentor sends rather than growing state without limit. Version-1 files remain readable and are rewritten as version 2 on the next state change.
+
+## Proof
+
+The four requested refusal-first tests were added before implementation and failed against the original source because `reserveSend` did not exist. After implementation they prove:
+
+- first content is allowed;
+- identical unanswered content is refused after three attempts;
+- a different agenda item remains allowed;
+- the breaker and its one-shot escalation survive a reconstructed tracker using the same state file.
+
+Additional coverage proves whitespace-normalized dedupe, raw prompt text exclusion, the 64-key state bound, asynchronous delivery outcome handling, HTTP status propagation, and the real production delivery closure over three transport failures plus a fourth-send refusal.

--- a/upgrades/next/bounded-mentor-onboarding-retries.md
+++ b/upgrades/next/bounded-mentor-onboarding-retries.md
@@ -1,0 +1,36 @@
+# Bound identical mentor-onboarding retries
+
+## What Changed
+
+The live mentor-onboarding delivery path now places a durable content-keyed retry brake in front of every outbound prompt.
+
+- Identical unanswered content is limited to three attempts.
+- The attempt is persisted before transport actuation.
+- A transport refusal consumes the same bounded budget as an unacknowledged send.
+- The fourth identical attempt is suppressed.
+- A different agenda item receives an independent budget.
+- Exhaustion emits one distinct delivery-degradation signal, protected by a restart-surviving latch.
+- The retry ledger stores hashes rather than prompt text and refuses growth beyond 64 unresolved keys.
+
+The mentor tick now awaits the delivery callback and records a specific `deliveryReason` when the delivery layer refuses or fails. It no longer marks an asynchronous send as delivered before the transport has answered.
+
+## What to Tell Your User
+
+Mentor onboarding will no longer keep reposting the same unanswered question forever. It makes at most three attempts for identical content, remembers that limit across restarts, and reports one distinct delivery failure when the limit is reached. A genuinely new agenda item can still proceed.
+
+The prior anti-ping-pong guard was correlation-scoped. Once an unanswered correlation aged past the reply timeout, the guard deleted it and the next tick could post the same generated question again. A bot-to-bot receive-path failure therefore produced about twenty-four visible copies over twelve hours.
+
+## Summary of New Capabilities
+
+- Durable, normalized-content deduplication bounds identical unanswered mentor prompts at three attempts.
+- Retry exhaustion and transport failures are visible as structured delivery outcomes with one restart-surviving escalation.
+- New agenda content remains independently eligible while an exhausted item stays suppressed.
+- Existing version-1 outstanding-prompt files load normally and upgrade on their next write.
+
+## Compatibility
+
+Existing version-1 outstanding-prompt files continue to load. The next write upgrades the file to version 2. No config, route, migration job, tick cadence, agenda rule, or reply timeout changes.
+
+## Validation
+
+Refusal-first unit tests failed on unmodified source, then passed with the implementation. Unit, integration, and end-to-end coverage pins the bounded attempts, novel-content independence, restart durability, one-shot escalation, production transport-failure behavior, and status visibility.

--- a/upgrades/side-effects/bounded-mentor-onboarding-retries.md
+++ b/upgrades/side-effects/bounded-mentor-onboarding-retries.md
@@ -1,0 +1,142 @@
+# Side-Effects Review — Bounded mentor-onboarding retries
+
+**Version / slug:** `bounded-mentor-onboarding-retries`
+**Date:** `2026-07-27`
+**Author:** `Instar Agent (instar-codey)`
+**Review tier:** Tier 1, user-directed
+
+## Summary of the change
+
+`OutstandingPromptTracker` extends its existing durable correlation ledger with a content-keyed retry ledger. Live mentor delivery reserves an attempt before transport, permits at most three attempts for the same unanswered normalized content, keeps new content independent, and persists a one-shot exhaustion escalation. `runMentorTick` now awaits the delivery callback and exposes the delivery layer's structured reason.
+
+The tracker persists only SHA-256 content keys plus mentee, attempt, timestamp, and escalation metadata. The ledger holds at most 64 unresolved content keys. Existing version-1 files load and upgrade on the next write.
+
+## Decision-point inventory
+
+- `OutstandingPromptTracker.reserveSend` — **new authority inside an existing authority** — permits or refuses one mentor send based on in-flight state, content-key attempts, storage availability, and the fixed ledger capacity.
+- `OutstandingPromptTracker.clearByCorr` — **modified** — a correlated reply now closes both the outstanding correlation and that content's retry episode.
+- `OutstandingPromptTracker.markDeliveryFailed` — **new transition** — removes the in-flight correlation while retaining the consumed attempt.
+- `AgentServer.deliverToMentee` — **modified actuation boundary** — durably reserves before transport and returns a structured delivery outcome.
+- `runMentorTick` — **modified observer** — awaits the delivery boundary and records its reason; it does not decide the retry policy.
+- `DegradationReporter.report` — **existing signal path** — emits one delivery-exhaustion event after the durable latch admits it.
+
+---
+
+## 1. Over-block
+
+The brake can suppress a prompt whose wording is identical even if the mentor intended a semantically separate repetition. That only happens after three sends without a correlated reply. A confirmed reply deletes the content episode, so later reuse after a real conversation is allowed. A genuinely different agenda item hashes separately and remains eligible.
+
+Whitespace is normalized before hashing. Cosmetic spacing cannot evade the brake, but punctuation or wording changes produce a new key. This is deliberate: the gate refuses exact normalized repetition, not semantic similarity judged by a brittle classifier.
+
+The 64-key ledger cap can refuse a novel prompt after 64 unresolved content episodes. That is a fail-closed capacity bound. It prefers pausing the autonomous mentor over allowing either unbounded state growth or eviction that would silently reopen old breakers.
+
+---
+
+## 2. Under-block
+
+An LLM can paraphrase the same intent and receive a new content key. This patch closes the observed identical-content loop, not semantic-repetition detection. Semantic dedupe would require judgment and risks suppressing legitimately revised questions; it is intentionally outside this Tier 1 correction.
+
+A corrupt version-2 file follows the tracker's existing corruption behavior and starts with fresh in-memory state. Normal restarts over valid state preserve the brake, which is the requested failure mode. Hardening corrupt-state recovery into a fail-closed operator repair state is a broader storage-policy change and is not smuggled into this patch.
+
+Version-1 outstanding entries have no historical content key. They preserve the existing in-flight refusal but cannot retroactively consume a content attempt. The first post-upgrade content reservation begins the new bounded history.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The retry authority belongs in `OutstandingPromptTracker`, which already owns the durable question “may this mentor send another prompt to this mentee?” Adding a second disconnected store would create competing truth for the same actuation boundary.
+
+Content normalization and hashing live beside the attempt state. `AgentServer` owns orchestration: reserve, call transport, mark immediate failure, append sent history, and emit degradation. `runMentorTick` only awaits and surfaces the structured outcome. No transport adapter is taught mentor-specific policy.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** `docs/signal-vs-authority.md`
+
+The static retry count is appropriate hard authority because “never perform identical autonomous sends without a bound” is a safety invariant, not a competing-signals judgment. The gate uses exact normalized content, explicit counters, and durable state. It does not guess user intent, message quality, or semantic equivalence.
+
+The degradation event is signal-only. It cannot reopen the breaker, alter the agenda, change transport routing, or authorize another send. The durable tracker remains the sole authority.
+
+---
+
+## 4b. Judgment-point check
+
+No LLM or heuristic decides whether the retry budget is exhausted. The decision inputs are a stable content key, integer attempt count, fixed maximum, outstanding correlation, and store health.
+
+The number three is a conservative structural ceiling for an existing retry loop that previously had no ceiling. It is not exposed as configuration in this patch, avoiding a migration surface and preventing an operator from accidentally configuring the invariant away.
+
+---
+
+## 5. Interactions
+
+- **Outstanding timeout:** an expired correlation is still swept, but its content attempt remains. Expiry permits evaluation of the next attempt; it no longer resets history.
+- **Immediate transport refusal:** the pre-send reservation remains counted while the outstanding correlation is removed, so a dead transport reaches the same breaker without waiting twenty minutes per attempt.
+- **Successful delivery:** the correlation stays outstanding until its matching reply or timeout.
+- **Matching reply:** clears the outstanding row and content retry episode.
+- **Late reply after timeout:** remains classified by the existing late/unknown-correlation behavior and does not silently reopen an exhausted content key.
+- **Restart:** entries, retry counts, and `escalatedAt` reload from one atomic JSON file.
+- **Concurrent tick:** the runner's existing single in-flight guard plus the tracker's per-mentee outstanding check prevents overlapping reservations in this process.
+- **Multi-machine:** state remains machine-local, matching the existing mentor runner's single active process. This patch adds no replicated authority.
+- **Escalation flood:** `recordRetryExhaustionEscalated` persists the latch before the degradation call. Repeated ticks see the open breaker and decline the signal.
+- **State growth:** 64 unresolved keys is a hard ceiling; raw message content is absent from this store.
+
+---
+
+## 6. External surfaces
+
+`GET /mentor/status.lastResult` can now include `deliveryReason` for a live tick. Existing fields and status codes remain unchanged; JSON omits the optional field when no delivery-layer reason exists.
+
+Operators may receive one existing-style degradation alert under the new feature name `mentor.delivery-unconfirmed-retry-exhausted`. Its content describes a delivery failure and the automatic suppression. It does not ask the operator to edit files, run commands, or diagnose raw internals.
+
+No Telegram API call shape, Threadline identity rule, bot token handling, topic selection, endpoint, config key, or dashboard surface changes.
+
+---
+
+## 6b. Operator-surface quality
+
+The only operator-facing addition is the existing degradation channel's plain-language event. It leads with the condition and effect: prompt delivery could not be confirmed, so identical sends stopped. It exposes no hash, correlation id, state path, token, or stack trace as primary content. There is no destructive action. The message is short enough for phone width and introduces no form or technical input.
+
+---
+
+## 7. Multi-machine posture
+
+**Posture: intentionally machine-local.** The mentor runner and its outstanding-prompt tracker already live on the machine executing Echo's mentor tick. A send is reserved and actuated by that same process. Replicating attempt authority without a cross-machine single-writer contract would create two counters that could each admit three sends.
+
+This patch preserves the existing one-process ownership boundary. If mentor execution becomes active-active in the future, the tracker must move behind a shared claim/lease before that rollout; this change does not claim cross-machine safety for a topology that is not currently enabled.
+
+---
+
+## 8. Rollback cost
+
+Reverting the code restores version-1 behavior. Older code reads the version-2 file as unsupported and starts fresh, so rollback removes the brake until the prior version is restored. No database migration or user-data conversion is required. The file contains only machine-local mentor retry metadata and can be regenerated.
+
+The additive `deliveryReason` field disappears on rollback. Existing consumers already tolerate its absence.
+
+---
+
+## Class-Closure Declaration
+
+**Defect class:** `unbounded-self-action`
+**Closure:** `guard`
+
+The guard is the durable pre-transport reservation plus the three-attempt content-key breaker. Unit tests prove the first send, cap, independent novel content, restart persistence, one-shot escalation, normalization, and capacity bound. The production-wiring E2E test drives three refused transport attempts, requires the fourth identical attempt to be suppressed, and requires a new message to retain an independent attempt.
+
+Steady state for one unanswered content key is therefore: at most three outbound attempts, one exhaustion signal, then permanent suppression in valid durable state. The escalation path cannot recursively send another mentor prompt.
+
+---
+
+## Evidence pointers
+
+- Refusal-first: four new tracker tests failed against unmodified source with `reserveSend is not a function`; ten pre-existing tracker tests remained green.
+- Focused proof after implementation: 77/77 across tracker, tick, runner, route integration, production lifecycle, and mentor config hot-read coverage.
+- Static validation: `npm run build` and `npm run lint` pass.
+- No route, config, transport identity, LLM breaker, cadence, budget, or agenda change.
+
+---
+
+## Causal autopsy
+
+**Origin:** latent.
+
+The correlation-scoped anti-ping-pong guard was correct within one reply window but treated timeout expiry as the end of all retry history. That latent reset became an unbounded loop when Telegram visibly accepted bot-authored posts that the mentee bot could not ingest. Every correlation expired normally, so the system repeatedly regenerated and resent identical content while believing each attempt was new.


### PR DESCRIPTION
## Summary

- persist a normalized-content retry reservation before mentor transport actuation
- cap identical unanswered mentor content at three attempts across restarts
- surface in-flight, exhaustion, ledger, unavailable-transport, and thrown-transport outcomes distinctly
- emit one durable exhaustion escalation while allowing genuinely new agenda content
- bound the retry ledger at 64 unresolved content keys and persist hashes rather than prompt text

## Root cause

The existing anti-ping-pong guard tracked only an outstanding correlation. Once that correlation reached its reply timeout, the tracker deleted it and forgot the retry episode. A bot-to-bot receive-path failure could therefore make every later tick treat identical generated content as a fresh prompt and repost it indefinitely.

## Proof

- Refusal-first: four new tracker tests failed against unmodified source because the durable reservation/breaker API did not exist; ten existing tests stayed green.
- Focused final: 77/77 mentor tracker, tick, runner, route, lifecycle, and config hot-read tests pass.
- Build: pass.
- Lint/typecheck: pass.
- Comprehensive repository run: 46,068 passed; 19 existing failures across 10 files. The changed mentor path was green. Reproduced outside this patch: two tmux/session timeout cases, one lifecycle wait timeout, and one session-routing assertion; dev preflight also reports the machine-global test-runner self-disable ledger and a non-TTY pnpm-install condition. CI is the authoritative full-suite gate.
- Capability discoverability: 171/171 pass.

## UX / compatibility

Existing v1 prompt state loads and upgrades to v2 on the next write. There is no config, route, cadence, agenda, identity, migration, or reply-timeout change. Exhausted exact normalized content stays paused; a new agenda item gets an independent budget.

## Risk and side effects

Tier 1, user-directed. The retry state is intentionally fail-closed when its pre-transport write cannot be made. Valid durable state never evicts exhausted content automatically, because eviction could silently reopen the flood. Corrupt legacy state retains the tracker’s existing fail-open recovery behavior. Semantic paraphrases are not deduplicated; the breaker keys exact NFKC/trimmed/whitespace-normalized content.

## Scope exclusions

This does not touch PR #1679’s Threadline identity-resolution shape or the process-wide LLM breaker work in ACT-1376.

## ELI16

The old safety check remembered only “a question is waiting right now.” After the waiting timer expired, it forgot that Echo had already asked the same thing, so a broken delivery path could make Echo ask forever. The new check writes down a fingerprint of the question before trying to send it. The same unanswered fingerprint gets three tries total, survives restarts, and then produces one delivery warning and stays stopped. A truly different question has a different fingerprint and can still be sent.
