### PR TITLE
fix(claim-verification): the rollout evidence endpoint was never built

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T18-15-49-771Z-completion-claim-stats-route.json
+++ b/.instar/instar-dev-decisions/2026-07-27T18-15-49-771Z-completion-claim-stats-route.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-27T18:15:49.771Z",
+  "slug": "completion-claim-stats-route",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 27,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/claim-verification-sentinel.md
+++ b/docs/specs/claim-verification-sentinel.md
@@ -11,7 +11,7 @@ rollout-source-pr: 1534
 rollout-flag-path: monitoring.completionClaimVerification.enabled
 rollout-criteria: "The verifier admits at least one candidate claim and retains nonzero classification coverage in the evidence window without becoming an outbound authority."
 rollout-evidence-type: endpoint
-rollout-evidence-ref: /completion-claim-verification/stats
+rollout-evidence-ref: /completion-claim/stats
 rollout-metrics-json: '{"cadenceHours":6,"evidenceMaxAgeHours":12,"metrics":[{"id":"classified-completion-claims","source":"feature-summary","sourceRef":"claim-verification.classified-claims","direction":"at-least","threshold":1,"minSamples":1}]}'
 approved-by: "operator blanket pre-approval relayed 2026-07-20 — proceed immediately through build/merge"
 supervision: pre-approved-build-and-merge

--- a/docs/specs/completion-claim-stats-route.eli16.md
+++ b/docs/specs/completion-claim-stats-route.eli16.md
@@ -1,0 +1,59 @@
+# ELI16 — a safety check that could never be switched on
+
+## The short version
+
+There is a feature that watches the agent's own outgoing messages and flags factual claims it
+can't back up. It has been running for weeks in a "watch but don't act" mode. It was supposed to
+graduate to doing something real once it proved itself.
+
+It could never have graduated. The number that proves it works was impossible to read.
+
+## What was actually wrong
+
+The plan for this feature says, in writing: turn it on properly once it has classified at least
+one claim. Sensible — don't enable a checker until you've seen it check something.
+
+To read that number, the plan points at an address. That address was never built. Not "broken" —
+never built at all. Meanwhile the code that counts the number exists, works, and has been
+counting the whole time, with nothing anywhere calling it.
+
+So the feature sits in watch-only mode forever. Not because it's failing — the records show it
+observing and recording, dated today — but because the one number that would let anyone say
+"yes, it's working, switch it on" is unreachable.
+
+## Why nobody noticed
+
+Because a feature stuck in watch-only mode looks exactly like a feature that is being careful.
+
+There's no error. Nothing crashes. Nothing raises an alarm. Every day it does its watching, and
+every day nobody can check on it, and the absence of a complaint reads as "still soaking, still
+fine." It would have stayed there indefinitely.
+
+## What changed
+
+Two small things.
+
+The counters now have an address you can read them at. And the plan's pointer, which named an
+address that didn't exist, now names the one that does.
+
+That's all. The feature still doesn't do anything new — it still just watches. But now someone
+can look at it and decide whether it has earned the right to do more.
+
+## The detail worth keeping
+
+One of the tests checks that when the feature has counted **zero** claims, the answer is the
+number zero — not a missing field, not an empty response.
+
+That sounds pedantic and isn't. A missing number is indistinguishable from "this address doesn't
+work," which is the exact confusion that created this problem. If the answer to "how many claims
+has it classified?" can come back as nothing-at-all, then a genuinely idle feature and a broken
+endpoint look identical, and we're straight back where we started. Zero has to say zero.
+
+## What this doesn't fix
+
+This makes the feature *measurable*. It does not make it graduate — whether the evidence is good
+enough to switch it on is a separate decision for a person to make, on purpose.
+
+And there's a bigger question underneath, which is written down rather than answered: how many
+*other* features are parked in the same way, pointing at evidence that was never built? This
+found one. Nobody has checked the rest.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -23382,6 +23382,33 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       evidenceAvailable: !evidence.unavailable, canaryOk: evidence.canaryOk, reason: admission.reason });
   });
 
+  /**
+   * Read-only counters for the completion-claim verifier.
+   *
+   * `CompletionClaimVerifier.stats()` has existed since the verifier shipped and was
+   * called by no route, so the feature ran (and still runs) in dryRun with its own
+   * declared graduation evidence unobservable — `docs/specs/claim-verification-sentinel.md`
+   * names `rollout-evidence-type: endpoint` with a `classified-completion-claims >= 1`
+   * criterion, which nothing could evaluate. A dark feature whose rollout criterion
+   * cannot be read is a feature that stays dark forever, which is the failure this
+   * exposes rather than a new capability.
+   *
+   * Local-scope only and deliberately so: the audit route already owns the pool
+   * projection, and duplicating a fan-out here would add a second cross-machine
+   * surface for the same data. Gates nothing, mutates nothing.
+   */
+  router.get('/completion-claim/stats', (_req, res) => {
+    if (!ctx.completionClaimVerifier) { res.status(503).json({ error: 'completion-claim verification disabled' }); return; }
+    const stats = ctx.completionClaimVerifier.stats();
+    res.json({
+      stats,
+      // The spec's graduation metric, surfaced by the name the spec uses so the
+      // rollout check does not have to know the internal counter's field name.
+      'classified-completion-claims': stats.classifiedTurns,
+      scope: 'local',
+    });
+  });
+
   router.get('/completion-claim/audit', async (req, res) => {
     if (!ctx.completionClaimVerifier) { res.status(503).json({ error: 'completion-claim verification disabled' }); return; }
     const limit = Math.max(1, Math.min(Number(req.query.limit) || 100, 500));

--- a/tests/integration/completion-claim-stats-route.test.ts
+++ b/tests/integration/completion-claim-stats-route.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tier-2 integration tests for `GET /completion-claim/stats`.
+ *
+ * Why this route exists: `CompletionClaimVerifier.stats()` shipped with the verifier
+ * and was called by NO route. `docs/specs/claim-verification-sentinel.md` declares
+ * `rollout-disposition: active` with `rollout-evidence-type: endpoint` and a
+ * `classified-completion-claims >= 1` graduation criterion — and pointed at
+ * `/completion-claim-verification/stats`, a prefix that does not exist. So the
+ * feature ran in dryRun with its own graduation evidence unreadable, which means it
+ * could never graduate and nothing would have surfaced that.
+ *
+ * The audit route (`/completion-claim/audit`) was live and recording the whole time,
+ * so this is specifically the *counters* surface, not the feature.
+ *
+ * Covers:
+ *   - 503 when the verifier is absent (feature disabled) — matches the audit route
+ *   - 200 + the raw counters when present
+ *   - the spec's metric name is surfaced and mirrors the internal counter
+ *   - the route is read-only (it must not mutate counters)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { generateAgentToken, deleteAgentToken } from '../../src/messaging/AgentTokenManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const PROJECT_NAME = 'ccstats-test-' + Math.random().toString(36).slice(2, 8);
+let AUTH = '';
+let tmpDir = '';
+
+function statsFixture(classifiedTurns: number) {
+  return {
+    candidateTurns: classifiedTurns + 3,
+    classifiedTurns,
+    noClaimTurns: 2,
+    invalidOutputTurns: 0,
+    providerUnavailableTurns: 1,
+    flaggedTurns: 0,
+    duplicateTurns: 0,
+    falsePositiveDispositions: 0,
+    falseNegativeDispositions: 0,
+    canaryDriftSignals: 0,
+    generalAdmittedTurns: 4,
+    generalClaims: 6,
+    protectedCueGaps: 0,
+    coverageIncompleteTurns: 1,
+    corpusDrops: 0,
+    retentionFailures: 0,
+    verdicts: { 'uncorroborated-unknown': 3 },
+    generalVerdicts: { unverifiable: 5 },
+    refutedByCriticality: {},
+    unverifiableByCriticality: { high: 2 },
+    updatedAt: '2026-07-27T17:46:20.971Z',
+  };
+}
+
+function buildCtx(verifier: unknown): RouteContext {
+  return {
+    config: {
+      projectName: PROJECT_NAME,
+      projectDir: tmpDir,
+      stateDir: path.join(tmpDir, '.instar'),
+      port: 0,
+      authToken: AUTH,
+    } as never,
+    sessionManager: { listRunningSessions: () => [], isSessionAlive: () => false } as never,
+    state: { getJobState: () => null, getSession: () => null } as never,
+    scheduler: null, telegram: null, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, discoveryEvaluator: null, startTime: new Date(),
+    mentorRunner: null, currentInboundByTopic: new Map(),
+    completionClaimVerifier: verifier,
+  } as unknown as RouteContext;
+}
+
+function app(verifier: unknown) {
+  const a = express();
+  a.use(express.json());
+  a.use(createRoutes(buildCtx(verifier)));
+  return a;
+}
+
+describe('GET /completion-claim/stats', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccstats-'));
+    AUTH = generateAgentToken(PROJECT_NAME);
+  });
+
+  afterEach(() => {
+    deleteAgentToken(PROJECT_NAME);
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true, force: true,
+      operation: 'tests/integration/completion-claim-stats-route.test.ts',
+    });
+  });
+
+  it('503s when the verifier is absent, matching the audit route', async () => {
+    const res = await request(app(null))
+      .get('/completion-claim/stats')
+      .set('Authorization', `Bearer ${AUTH}`);
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/disabled/i);
+  });
+
+  it('returns the raw counters when the verifier is present', async () => {
+    const res = await request(app({ stats: () => statsFixture(7) }))
+      .get('/completion-claim/stats')
+      .set('Authorization', `Bearer ${AUTH}`);
+    expect(res.status).toBe(200);
+    expect(res.body.stats.classifiedTurns).toBe(7);
+    expect(res.body.stats.candidateTurns).toBe(10);
+    expect(res.body.scope).toBe('local');
+  });
+
+  it("surfaces the spec's graduation metric name, mirroring the internal counter", async () => {
+    // The spec's criterion is `classified-completion-claims >= 1`. A rollout check
+    // should not have to know that the internal field is `classifiedTurns`.
+    const res = await request(app({ stats: () => statsFixture(4) }))
+      .get('/completion-claim/stats')
+      .set('Authorization', `Bearer ${AUTH}`);
+    expect(res.body['classified-completion-claims']).toBe(4);
+    expect(res.body['classified-completion-claims']).toBe(res.body.stats.classifiedTurns);
+  });
+
+  it('reports zero honestly rather than omitting the metric', async () => {
+    // A dark feature that has classified nothing must read as 0, not as absent —
+    // absent is indistinguishable from "the endpoint does not work", which is the
+    // exact condition this route was added to end.
+    const res = await request(app({ stats: () => statsFixture(0) }))
+      .get('/completion-claim/stats')
+      .set('Authorization', `Bearer ${AUTH}`);
+    expect(res.status).toBe(200);
+    expect(res.body['classified-completion-claims']).toBe(0);
+  });
+
+  it('is read-only — reading stats must not mutate the verifier', async () => {
+    let calls = 0;
+    const verifier = {
+      stats: () => { calls += 1; return statsFixture(2); },
+      // Any mutation entry point being touched by a GET would be a defect.
+      recordDisposition: () => { throw new Error('stats route must not record dispositions'); },
+      recordCanaryDrift: () => { throw new Error('stats route must not record drift'); },
+    };
+    const res = await request(app(verifier))
+      .get('/completion-claim/stats')
+      .set('Authorization', `Bearer ${AUTH}`);
+    expect(res.status).toBe(200);
+    expect(calls).toBe(1);
+  });
+});

--- a/upgrades/next/completion-claim-stats-route.md
+++ b/upgrades/next/completion-claim-stats-route.md
@@ -1,0 +1,66 @@
+## What Changed
+
+Fixed a rollout-active feature that could never graduate because the evidence its own spec
+nominates was unreadable.
+
+`docs/specs/claim-verification-sentinel.md` is `status: approved`, `rollout-disposition: active`,
+`rollout-evidence-type: endpoint`, with the graduation criterion
+`classified-completion-claims >= 1`. On `main`, that criterion was unevaluable:
+
+- `CompletionClaimVerifier` exists and **is** constructed (`AgentServer.ts:2572`), with
+  `monitoring.completionClaimVerification` configured at `dryRun: true`.
+- `POST /completion-claim/observe` and `GET /completion-claim/audit` are live, and the audit
+  route was **actively recording** (records dated `2026-07-27T17:46Z`, verdicts such as
+  `uncorroborated-unknown`).
+- `CompletionClaimVerifier.stats()` is implemented and was **called by no route**.
+- `/completion-claim/stats` → 404, and the spec's `rollout-evidence-ref`
+  (`/completion-claim-verification/stats`) named a prefix that has never existed → 404.
+
+So the feature observed, recorded, and sat in dry-run indefinitely with nothing able to read the
+number that would let anyone graduate it — and no error, alarm, or degraded signal anywhere,
+because a feature stuck in watch-only mode is indistinguishable from a feature being careful.
+
+Adds `GET /completion-claim/stats` (read-only counters, 503 when the verifier is absent, matching
+the sibling audit route) and corrects the spec's `rollout-evidence-ref` to the path that exists.
+
+The response carries both `stats.classifiedTurns` and the spec's own metric name
+`classified-completion-claims`, so a rollout check does not need to know the internal field name.
+
+## Evidence
+
+Tests run against **unmodified source first**:
+
+| run | result |
+|---|---|
+| route reverted | **5 failed** |
+| route applied | **5 passed** |
+| `tsc --noEmit` | clean |
+
+The retained case worth naming: when the feature has classified nothing, the metric must read `0`
+and not be omitted. An absent number is indistinguishable from "the endpoint does not work" —
+exactly the confusion that produced this defect.
+
+## What to Tell Your User
+
+Your agent has a safety check that watches its own outgoing messages and flags factual claims it
+can't back up. It has been running in watch-only mode, which is correct — it was meant to prove
+itself before being allowed to do anything.
+
+It could never have finished proving itself. The plan said "switch it on once it has checked at
+least one claim", and pointed at an address for reading that number. The address was never built.
+The counting code existed and had been counting the whole time, with nothing able to read it.
+
+So it would have stayed in watch-only mode forever — not failing, just unmeasurable, and looking
+from the outside exactly like a feature being cautious.
+
+Nothing about what the check *does* has changed. It still only watches. What changed is that its
+progress can now be read, so a decision about switching it on can actually be made.
+
+## Summary of New Capabilities
+
+- Completion-claim verifier counters are readable at `GET /completion-claim/stats`, so a
+  rollout-active feature that was structurally unable to graduate now has evaluable evidence.
+- The spec's graduation metric is surfaced under its own name, so a rollout check does not depend
+  on internal field naming.
+- A feature that has classified nothing reports `0` rather than omitting the metric, so "idle" and
+  "broken endpoint" are distinguishable.

--- a/upgrades/side-effects/completion-claim-stats-route.md
+++ b/upgrades/side-effects/completion-claim-stats-route.md
@@ -1,0 +1,120 @@
+# Side-effects review — `GET /completion-claim/stats`
+
+**Change:** adds a read-only counters endpoint for the completion-claim verifier, and corrects
+the `rollout-evidence-ref` in `docs/specs/claim-verification-sentinel.md` from
+`/completion-claim-verification/stats` (a prefix that does not exist) to `/completion-claim/stats`.
+
+**Discovered:** 2026-07-27, while checking — before proposing a new feature — whether a
+claim-review capability already existed. It did, and it could not graduate.
+
+## The condition
+
+`docs/specs/claim-verification-sentinel.md` is `status: approved`, `rollout-disposition: active`,
+`rollout-evidence-type: endpoint`, with a graduation metric of
+`classified-completion-claims >= 1`. Verified on `main`:
+
+- `CompletionClaimVerifier` exists and **is** constructed (`src/server/AgentServer.ts:2572`).
+- `monitoring.completionClaimVerification` config is present with `dryRun: true`.
+- `POST /completion-claim/observe` and `GET /completion-claim/audit` are live —
+  `/completion-claim/audit` returns 200 and was **actively recording** (records dated
+  `2026-07-27T17:46:20.971Z`, `dryRun: true`, verdicts such as `uncorroborated-unknown`).
+- `CompletionClaimVerifier.stats()` is implemented (`src/monitoring/CompletionClaimVerifier.ts:231`)
+  and **called by no route**.
+- `/completion-claim/stats` → 404. `/completion-claim-verification/stats` (the spec's ref) → 404.
+
+So the feature runs, observes, and records — while the evidence its own spec nominates for
+graduation is unreadable. It cannot progress, and nothing surfaces that it is stuck.
+
+**Correction of record:** an earlier filing of this said "the route does not exist anywhere."
+That was wrong — the observe and audit routes exist under a different prefix. The accurate
+finding is narrower: no *stats* surface exists at any prefix, and the spec's ref points at a
+prefix that never did. Recorded rather than quietly amended.
+
+## 1. Over-block — what legitimate input does this reject?
+
+None. New read-only route; rejects nothing that previously worked. It 503s when the verifier is
+absent, which is the same contract the sibling audit route already uses — deliberately matched so
+"feature off" reads identically across both surfaces rather than one 404ing and one 503ing.
+
+## 2. Under-block — what does this still miss?
+
+- **It does not make the feature graduate.** It makes graduation *evaluable*. Whether the
+  criterion is met is a separate, later, evidence-driven decision that belongs to the operator.
+- **Local scope only.** The audit route already owns the pool projection; adding a second
+  cross-machine fan-out for the same underlying data would duplicate a surface rather than serve
+  one. A pool view of counters is a follow-up if it is ever wanted, not a gap this change creates.
+- **It does not audit the wider class.** This is one instance of "a spec nominates rollout
+  evidence that was never built". Whether other `rollout-evidence-ref` values resolve is an
+  open question this change does not answer. <!-- tracked: ACT-1394 -->
+
+## 3. Level-of-abstraction fit
+
+Correct layer, and deliberately the *thinnest* one. `stats()` already existed with the right
+shape; this exposes it and adds nothing else. The alternative — computing counters in the route —
+would have created a second source of truth for numbers the verifier already maintains.
+
+The spec-ref correction belongs in the same change because a stats route at a path the spec does
+not name would leave the rollout check just as unevaluable as before, only less obviously.
+
+## 4. Signal vs authority compliance
+
+Pure signal, and structurally incapable of being anything else: a GET that reads a counters
+snapshot. It gates nothing, blocks nothing, and mutates nothing. `stats()` returns a deep copy
+(`JSON.parse(JSON.stringify(...))`), so a caller cannot reach through the response into live
+counters. A test asserts the route touches no mutation entry point — `recordDisposition` and
+`recordCanaryDrift` throw if called during the request.
+
+## 5. Interactions
+
+- **Sibling route.** Shares the 503-when-absent contract with `/completion-claim/audit`; no
+  shared state, no ordering dependency, and reading stats does not disturb the audit ring.
+- **Rollout tracking.** The corrected `rollout-evidence-ref` is what the rollout machinery reads.
+  Before this change it pointed at a 404, so any automated evidence check would have failed or
+  silently found nothing; after it, the check resolves.
+- **Metric naming.** The response carries both `stats.classifiedTurns` (the internal field) and
+  `classified-completion-claims` (the spec's name) so a rollout check does not need to know the
+  internal field name. Duplication is deliberate and one-directional — the spec name mirrors the
+  counter, never the reverse.
+
+## 6. External surfaces
+
+One new authenticated GET. No wire-format change to any existing route, no schema, no migration,
+no config, no persisted state. The only non-route change is a single frontmatter line in a spec.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design, and correctly so — no durable state is introduced.** The counters
+describe what *this* server process has observed; they are in-memory, per-process, and reset on
+restart, which is a property of the existing verifier and not something this change alters. There
+is nothing here to replicate: a peer's counters are a different fact about a different process,
+not a stale copy of the same fact. `scope: 'local'` is stated explicitly in the response so a
+reader never mistakes it for a pool figure, and the pool projection continues to live on the audit
+route where the underlying records are durable.
+
+## 8. Rollback cost
+
+Delete the route and revert one frontmatter line. Nothing persists, nothing migrates, no consumer
+exists yet that could break. The feature returns to exactly its present state: running, observing,
+and unable to graduate.
+
+## Evidence
+
+Tests verified to fail against unmodified source before the fix was applied:
+
+```
+# route reverted
+Tests  5 failed (5)
+  ✗ 503s when the verifier is absent
+  ✗ returns the raw counters when present
+  ✗ surfaces the spec's graduation metric name
+  ✗ reports zero honestly rather than omitting the metric
+  ✗ is read-only
+
+# route applied
+Tests  5 passed (5)
+tsc --noEmit — clean
+```
+
+The "reports zero honestly" case is the one worth keeping: a dark feature that has classified
+nothing must read as `0`, never as an absent field, because absent is indistinguishable from
+"the endpoint does not work" — which is precisely the condition this route exists to end.


### PR DESCRIPTION
## Summary

`docs/specs/claim-verification-sentinel.md` is `status: approved`, `rollout-disposition: active`, `rollout-evidence-type: endpoint`, graduation criterion `classified-completion-claims >= 1`.

**That criterion was unevaluable.** Verified on `main`:

| | state |
|---|---|
| `CompletionClaimVerifier` | exists, **constructed** at `AgentServer.ts:2572` |
| `monitoring.completionClaimVerification` | configured, `dryRun: true` |
| `POST /completion-claim/observe`, `GET /completion-claim/audit` | live — audit **actively recording** (records `2026-07-27T17:46:20.971Z`, verdicts e.g. `uncorroborated-unknown`) |
| `CompletionClaimVerifier.stats()` | implemented at `CompletionClaimVerifier.ts:231`, **called by no route** |
| `/completion-claim/stats` | **404** |
| spec's `rollout-evidence-ref` → `/completion-claim-verification/stats` | **404 — prefix never existed** |

So the feature observed, recorded, and sat in dry-run indefinitely while the number that would let anyone graduate it was unreadable — with no error, no alarm, no degraded signal. **A feature stuck in watch-only mode is indistinguishable from a feature being careful.**

## The change

- `GET /completion-claim/stats` — read-only; 503 when the verifier is absent, matching the sibling audit route so "feature off" reads identically on both.
- Corrects the spec's `rollout-evidence-ref` to the path that exists. A stats route at a path the spec doesn't name leaves the rollout just as unevaluable, only less obviously.
- Response carries both `stats.classifiedTurns` and the spec's own metric name `classified-completion-claims`, so a rollout check needn't know the internal field name.

Pure signal: gates nothing, mutates nothing. `stats()` returns a deep copy, so a caller can't reach through into live counters — and a test asserts the route touches no mutation entry point.

## Evidence

Tests run against **unmodified source first**:

| run | result |
|---|---|
| route reverted | **5 failed** |
| route applied | **5 passed** |
| `tsc --noEmit` | clean |

The case worth keeping: a verifier that has classified nothing must report `0`, never omit the metric. An absent number is indistinguishable from "the endpoint does not work" — the exact confusion that produced this defect.

## Correction of record

An earlier filing of this said "the route does not exist anywhere." Wrong — observe and audit exist under a different prefix. The accurate finding is narrower: no *stats* surface at any prefix, and the spec pointed at a prefix that never existed. Stated in the artifact rather than quietly amended.

## Not in scope

How many *other* rollout-active specs name evidence that doesn't resolve? This found one; the class is unaudited. Tracked as **ACT-1394** with a lint ratchet proposed, rather than folded in.

## ELI16 — a safety check that could never be switched on

There's a feature that watches the agent's own outgoing messages and flags factual claims it can't back up. It's been running for weeks in watch-but-don't-act mode, meant to graduate once it proved itself.

It could never have graduated. The plan says "switch it on once it has classified at least one claim", and points at an address for reading that number. **The address was never built** — not broken, never built. Meanwhile the counting code exists, works, and has been counting the whole time with nothing calling it.

Nobody noticed because a feature stuck in watch-only mode looks exactly like a feature being careful. No error, no crash, no alarm. Every day it watches, every day nobody can check on it, and the absence of a complaint reads as "still soaking, still fine."

Two small things change: the counters now have an address you can read them at, and the plan points at the address that exists. The feature still only watches — but now someone can look at it and decide whether it's earned the right to do more.

One test checks that when it has counted **zero** claims, the answer is the number zero and not a missing field. That sounds pedantic and isn't: a missing number is indistinguishable from "this address doesn't work", which is the confusion that created this problem in the first place.