### PR TITLE
feat(memory): recall retrieves semantically — keyword becomes the fallback

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T18-31-25-617Z-recall-vector-primary.json
+++ b/.instar/instar-dev-decisions/2026-07-27T18-31-25-617Z-recall-vector-primary.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T18:31:25.617Z",
+  "slug": "recall-vector-primary",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 92,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/recall-vector-primary.eli16.md
+++ b/docs/specs/recall-vector-primary.eli16.md
@@ -1,0 +1,65 @@
+# ELI16 — the agent had a good memory and was using the bad one
+
+## The short version
+
+Your agent has two ways to search its own memory. One matches on meaning. One matches on
+words. The good one was built, fully switched on, and never called.
+
+## What was actually there
+
+Every one of the agent's 2,852 stored memories has an embedding — a mathematical
+representation of what it *means*, which is what lets a search find "the bot channel is
+one-directional" when you ask "why can't I reach the other agent". Coverage was complete:
+2,852 out of 2,852. The search function that uses them exists and works.
+
+The recall path called the other one. The word-matching one.
+
+## Why, and this is the annoying part
+
+Not a decision. Not a tradeoff anybody weighed. The word-matching search is *synchronous* —
+it returns immediately — and the meaning-based search is *asynchronous*, because computing
+what a sentence means takes a moment. The recall function was written synchronously, so only
+the synchronous search was reachable from it, so that's the one that got called.
+
+One ergonomic choice, made once, quietly decided how the entire system remembers things.
+
+And nothing reported it, because both searches hand back the same shape of answer. A
+word-match and a meaning-match are indistinguishable once they're results. There was no error,
+no warning, no slow query — just a worse answer than the one available, every single time,
+for as long as it had been running.
+
+## What changed
+
+Recall now asks the meaning-based search first. Word matching becomes what it should always
+have been: the fallback for when meaning-based search isn't available.
+
+Two supporting changes matter more than they sound.
+
+**The answer now says which search served it.** Meaning-based, or word-based, or word-based
+because meaning-based wasn't available. Without that, a system running on the fallback looks
+exactly like one running properly — which is the condition that let this last as long as it did.
+
+**The time limit is now real.** It used to be checked *after* the search came back, which is
+not a limit at all — a search taking thirty seconds would take thirty seconds and then be told
+it was too slow. It's now enforced while waiting, so a slow search gets cut off at the budget
+instead of holding up your reply.
+
+## The judgement call worth flagging
+
+There's a safety breaker that disables recall after repeated failures. I deliberately made
+timeouts *not* count toward it.
+
+The reasoning: the first search after a restart is slow, because the meaning-model has to load.
+That's a cold engine, not a broken one. If slowness tripped the breaker, every restart would
+disable the agent's memory for the whole cooldown — turning a two-second delay into a total
+outage. Real errors still trip it, and there's a test that proves the breaker still works, so
+the exception can't quietly blunt it.
+
+## What this doesn't fix
+
+The first recall after a restart will probably still time out while the model loads. That costs
+one missed lookup, silently, and everything after it is fast. Warming the model at startup is
+the obvious fix and is written down rather than bundled in here.
+
+And this only improves *finding* what was stored. Whether the right things get stored in the
+first place is a different problem.

--- a/src/core/PromptBuildRecall.ts
+++ b/src/core/PromptBuildRecall.ts
@@ -26,7 +26,7 @@
  */
 
 import crypto from 'node:crypto';
-import type { SemanticMemory } from '../memory/SemanticMemory.js';
+import type { SemanticMemory, SearchStrategy } from '../memory/SemanticMemory.js';
 
 export interface PromptBuildRecallConfig {
   enabled: boolean;
@@ -78,6 +78,12 @@ export interface PromptBuildRecallResult {
   elapsedMs: number;
   resultsCount: number;
   cacheKey: string;
+  /**
+   * Which retrieval strategy actually served this recall. Absent on the paths
+   * that never reached a search (disabled, cached, circuit-open, no-memory,
+   * error, timeout) — a strategy is only claimed when one genuinely ran.
+   */
+  strategy?: SearchStrategy;
 }
 
 interface CacheEntry {
@@ -105,12 +111,21 @@ export class PromptBuildRecall {
    * Run a recall pass for a user message. Returns the context-text to inject
    * into the system prompt (or empty string if nothing useful surfaces).
    *
-   * Synchronous because the caller (UserPromptSubmit hook) blocks on the
-   * response. The recall path itself uses sqlite-backed SemanticMemory which
-   * is fast and synchronous; the only "async" guard is the timeout, which is
-   * enforced by checking elapsed time after the search.
+   * ASYNC because recall now prefers `searchHybrid()` — the semantic path over
+   * the embedding index — rather than the keyword-only `search()`.
+   *
+   * It was synchronous, and that single choice decided the retrieval strategy for
+   * the whole system: `search()` is sync, `searchHybrid()` is not, so the sync one
+   * was called and the fully-populated vector index went unused. Nothing reported
+   * it, because a keyword answer and a semantic answer are the same shape.
+   *
+   * Executing server-side (the hook POSTs to `/internal/prompt-recall`) means the
+   * embedding model stays warm in a long-lived process, so the async cost is a
+   * cold-start on the first call after boot, not a per-call penalty. The timeout
+   * is now a real race rather than an after-the-fact elapsed check, so that
+   * cold start cannot exceed the budget the hook is entitled to.
    */
-  recall(opts: { userMessage: string; sessionId?: string }): PromptBuildRecallResult {
+  async recall(opts: { userMessage: string; sessionId?: string }): Promise<PromptBuildRecallResult> {
     const start = this.now();
     const cacheKey = this.makeCacheKey(opts);
 
@@ -133,12 +148,29 @@ export class PromptBuildRecall {
       return { contextText: '', source: 'no-memory', elapsedMs: 0, resultsCount: 0, cacheKey };
     }
 
+    const memory = this.deps.semanticMemory;
     let entries: Array<{ name: string; description?: string; confidence?: number }> = [];
+    let timedOut = false;
     try {
-      const raw = this.deps.semanticMemory.search(opts.userMessage, {
-        limit: this.config.maxRecallResults,
-        minConfidence: this.config.minConfidence,
-      });
+      // Semantic first, keyword as its fallback — searchHybrid degrades to
+      // search() internally when vectors are unavailable, and records which one
+      // actually served. The budget is enforced as a race: an embedding cold
+      // start must not hold the prompt path past recallTimeoutMs.
+      const raw = await Promise.race([
+        memory.searchHybrid(opts.userMessage, {
+          limit: this.config.maxRecallResults,
+          minConfidence: this.config.minConfidence,
+        }),
+        new Promise<null>((resolve) =>
+          setTimeout(() => { timedOut = true; resolve(null); }, this.config.recallTimeoutMs),
+        ),
+      ]);
+      if (timedOut || raw === null) {
+        // A timeout is not a circuit failure: the search may still be warming the
+        // model and succeeding. Counting it toward the breaker would open the
+        // circuit on a healthy-but-cold path and keep recall dark for the cooldown.
+        return { contextText: '', source: 'timeout', elapsedMs: this.now() - start, resultsCount: 0, cacheKey };
+      }
       entries = raw as typeof entries;
       this.circuit.consecutiveFailures = 0;
     } catch {
@@ -150,12 +182,19 @@ export class PromptBuildRecall {
     }
 
     const elapsed = this.now() - start;
+    // The race above already bounded the wait; this remains as a belt-and-braces
+    // check for a clock that jumped or a synchronous path that outran the timer.
     if (elapsed > this.config.recallTimeoutMs) {
       return { contextText: '', source: 'timeout', elapsedMs: elapsed, resultsCount: 0, cacheKey };
     }
 
+    // Which strategy served this recall — 'vector-hybrid' when embeddings ranked
+    // it, an 'fts-*' value when it fell back to lexical. Reported so a caller can
+    // tell a semantic answer from a keyword one.
+    const strategy = memory.lastSearchStrategy;
+
     if (entries.length === 0) {
-      const result: PromptBuildRecallResult = { contextText: '', source: 'empty', elapsedMs: elapsed, resultsCount: 0, cacheKey };
+      const result: PromptBuildRecallResult = { contextText: '', source: 'empty', elapsedMs: elapsed, resultsCount: 0, cacheKey, strategy };
       this.cache.set(cacheKey, { value: result, expiresAt: start + this.config.cacheTtlMs });
       return result;
     }
@@ -167,6 +206,7 @@ export class PromptBuildRecall {
       elapsedMs: elapsed,
       resultsCount: entries.length,
       cacheKey,
+      strategy,
     };
     this.cache.set(cacheKey, { value: result, expiresAt: start + this.config.cacheTtlMs });
     return result;

--- a/src/memory/SemanticMemory.ts
+++ b/src/memory/SemanticMemory.ts
@@ -165,6 +165,17 @@ export function buildFtsQueryVariants(
   };
 }
 
+/**
+ * Which retrieval strategy actually served a search.
+ *
+ * `vector-hybrid` means embeddings were used; the `fts-*` values mean lexical
+ * matching served it, either because the query was lexically satisfiable or
+ * because the vector path was unavailable. Exposed so a caller can tell a
+ * semantic answer from a keyword one — silently serving the cheap strategy is
+ * the degradation this reporting exists to make visible.
+ */
+export type SearchStrategy = 'vector-hybrid' | 'fts-strict' | 'fts-loose-fallback' | 'none';
+
 export class SemanticMemory {
   /**
    * W-4 / §A57 — process-wide registry of active SemanticMemory instances.
@@ -528,10 +539,10 @@ export class SemanticMemory {
    * That is not hypothetical here: recall ran on keyword-only search for its entire
    * life while a fully-populated vector index went uncalled, and nothing said so.
    */
-  private _lastSearchStrategy: 'fts-strict' | 'fts-loose-fallback' | 'none' = 'none';
+  private _lastSearchStrategy: SearchStrategy = 'none';
 
-  /** Which strategy served the last `search()` — see `_lastSearchStrategy`. */
-  get lastSearchStrategy(): 'fts-strict' | 'fts-loose-fallback' | 'none' {
+  /** Which strategy served the last search — see `_lastSearchStrategy`. */
+  get lastSearchStrategy(): SearchStrategy {
     return this._lastSearchStrategy;
   }
   private jsonlPath: string;
@@ -1712,7 +1723,10 @@ export class SemanticMemory {
    */
   async searchHybrid(query: string, options?: SemanticSearchOptions): Promise<ScoredEntity[]> {
     if (!this._vectorAvailable || !this.embeddingProvider || !this.vectorSearch) {
-      // Graceful degradation: fall back to FTS5-only
+      // Graceful degradation: fall back to FTS5-only. `search()` records the
+      // strategy it used, so the caller can still tell that the vector path did
+      // not run — a degradation that reports itself rather than one that looks
+      // identical to success.
       return this.search(query, options);
     }
 
@@ -1733,6 +1747,12 @@ export class SemanticMemory {
 
     // Run the combined search (which now picks up vector scores)
     const results = this.search(query, options);
+
+    // The inner search() just recorded a lexical strategy, which is true of the
+    // candidate selection but misleading as the answer to "did the semantic path
+    // run?" — embeddings genuinely participated in ranking here. Overwrite AFTER
+    // the call so the reported strategy matches what actually served.
+    this._lastSearchStrategy = 'vector-hybrid';
 
     // Clear cached scores
     this._lastVectorScores = null;

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -3802,7 +3802,7 @@ export function createRoutes(ctx: RouteContext): Router {
       res.json({ contextText: '', source: 'no-recall', elapsedMs: 0, resultsCount: 0, cacheKey: '' });
       return;
     }
-    const result = recall.recall({ userMessage, sessionId });
+    const result = await recall.recall({ userMessage, sessionId });
     res.json(result);
   });
 

--- a/tests/unit/PromptBuildRecall.test.ts
+++ b/tests/unit/PromptBuildRecall.test.ts
@@ -29,12 +29,17 @@ function makeStubMemory(
   options: { throws?: Error } = {},
 ): SemanticMemory {
   let calls = 0;
+  const run = () => {
+    calls++;
+    if (options.throws) throw options.throws;
+    return results;
+  };
   return {
-    search: () => {
-      calls++;
-      if (options.throws) throw options.throws;
-      return results;
-    },
+    search: run,
+    // recall() prefers the semantic path; searchHybrid degrades to search()
+    // internally in production, so the stub mirrors it.
+    searchHybrid: async () => run(),
+    lastSearchStrategy: 'vector-hybrid',
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     _callCount: () => calls,
   } as unknown as SemanticMemory;
@@ -59,28 +64,28 @@ function makeRecall(
 
 describe('PromptBuildRecall', () => {
   describe('gating', () => {
-    it('returns disabled when config.enabled is false', () => {
+    it('returns disabled when config.enabled is false', async () => {
       const { recall } = makeRecall([], { enabled: false });
-      const r = recall.recall({ userMessage: 'hello' });
+      const r = await recall.recall({ userMessage: 'hello' });
       expect(r.source).toBe('disabled');
       expect(r.contextText).toBe('');
     });
 
-    it('returns no-memory when semanticMemory is null', () => {
+    it('returns no-memory when semanticMemory is null', async () => {
       const { recall } = makeRecall([], {}, { semanticMemory: null });
-      const r = recall.recall({ userMessage: 'hello' });
+      const r = await recall.recall({ userMessage: 'hello' });
       expect(r.source).toBe('no-memory');
       expect(r.contextText).toBe('');
     });
   });
 
   describe('fresh recall', () => {
-    it('returns fresh + formatted block on a successful search', () => {
+    it('returns fresh + formatted block on a successful search', async () => {
       const { recall } = makeRecall([
         { name: 'echo-routing-pattern', description: 'use router.go() to navigate, never history.push' },
         { name: 'echo-prod-db-pool', description: 'max connections 20' },
       ]);
-      const r = recall.recall({ userMessage: 'how do I route?' });
+      const r = await recall.recall({ userMessage: 'how do I route?' });
       expect(r.source).toBe('fresh');
       expect(r.resultsCount).toBe(2);
       expect(r.contextText).toContain('<active_memory_recall>');
@@ -89,127 +94,137 @@ describe('PromptBuildRecall', () => {
       expect(r.contextText).toContain('</active_memory_recall>');
     });
 
-    it('returns empty when search returns []', () => {
+    it('returns empty when search returns []', async () => {
       const { recall } = makeRecall([]);
-      const r = recall.recall({ userMessage: 'unknown question' });
+      const r = await recall.recall({ userMessage: 'unknown question' });
       expect(r.source).toBe('empty');
       expect(r.contextText).toBe('');
       expect(r.resultsCount).toBe(0);
     });
 
-    it('uses entry name even when description is missing', () => {
+    it('uses entry name even when description is missing', async () => {
       const { recall } = makeRecall([{ name: 'name-only' }]);
-      const r = recall.recall({ userMessage: 'x' });
+      const r = await recall.recall({ userMessage: 'x' });
       expect(r.contextText).toContain('- name-only');
       expect(r.contextText).not.toContain('- name-only:');
     });
   });
 
   describe('cache', () => {
-    it('returns cached on identical second call within TTL', () => {
+    it('returns cached on identical second call within TTL', async () => {
       const { recall } = makeRecall([{ name: 'a', description: 'b' }]);
-      const r1 = recall.recall({ userMessage: 'hello world' });
-      const r2 = recall.recall({ userMessage: 'hello world' });
+      const r1 = await recall.recall({ userMessage: 'hello world' });
+      const r2 = await recall.recall({ userMessage: 'hello world' });
       expect(r1.source).toBe('fresh');
       expect(r2.source).toBe('cached');
       expect(r2.contextText).toBe(r1.contextText);
     });
 
-    it('normalizes case and whitespace in cache key', () => {
+    it('normalizes case and whitespace in cache key', async () => {
       const { recall } = makeRecall([{ name: 'a', description: 'b' }]);
-      const r1 = recall.recall({ userMessage: '   Hello World   ' });
-      const r2 = recall.recall({ userMessage: 'hello world' });
+      const r1 = await recall.recall({ userMessage: '   Hello World   ' });
+      const r2 = await recall.recall({ userMessage: 'hello world' });
       expect(r1.source).toBe('fresh');
       expect(r2.source).toBe('cached');
     });
 
-    it('re-runs after cache TTL elapses', () => {
+    it('re-runs after cache TTL elapses', async () => {
       const { recall, advance } = makeRecall([{ name: 'a', description: 'b' }], { cacheTtlMs: 1000 });
-      const r1 = recall.recall({ userMessage: 'q' });
+      const r1 = await recall.recall({ userMessage: 'q' });
       expect(r1.source).toBe('fresh');
       advance(1500);
-      const r2 = recall.recall({ userMessage: 'q' });
+      const r2 = await recall.recall({ userMessage: 'q' });
       expect(r2.source).toBe('fresh');
     });
 
-    it('caches the empty result too', () => {
+    it('caches the empty result too', async () => {
       const { recall } = makeRecall([]);
-      const r1 = recall.recall({ userMessage: 'q' });
-      const r2 = recall.recall({ userMessage: 'q' });
+      const r1 = await recall.recall({ userMessage: 'q' });
+      const r2 = await recall.recall({ userMessage: 'q' });
       expect(r1.source).toBe('empty');
       expect(r2.source).toBe('cached');
     });
   });
 
   describe('circuit breaker', () => {
-    it('opens after N consecutive failures', () => {
+    it('opens after N consecutive failures', async () => {
       const { recall } = makeRecall([], { circuitBreakerMaxFailures: 3 }, { throws: new Error('db down') });
       // Different user messages so cache doesn't hide the failures.
-      expect(recall.recall({ userMessage: 'q1' }).source).toBe('error');
-      expect(recall.recall({ userMessage: 'q2' }).source).toBe('error');
-      expect(recall.recall({ userMessage: 'q3' }).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q1' })).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q2' })).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q3' })).source).toBe('error');
       // Fourth call should short-circuit before hitting search.
-      expect(recall.recall({ userMessage: 'q4' }).source).toBe('circuit-open');
+      expect((await recall.recall({ userMessage: 'q4' })).source).toBe('circuit-open');
     });
 
-    it('reopens after cooldown elapses', () => {
+    it('reopens after cooldown elapses', async () => {
       const { recall, advance } = makeRecall(
         [],
         { circuitBreakerMaxFailures: 1, circuitBreakerCooldownMs: 10_000 },
         { throws: new Error('boom') },
       );
-      expect(recall.recall({ userMessage: 'q1' }).source).toBe('error');
-      expect(recall.recall({ userMessage: 'q2' }).source).toBe('circuit-open');
+      expect((await recall.recall({ userMessage: 'q1' })).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q2' })).source).toBe('circuit-open');
       advance(15_000);
       // After cooldown, breaker is willing to try again — search will fail again
       // since memory still throws, but the source is no longer 'circuit-open'.
-      expect(recall.recall({ userMessage: 'q3' }).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q3' })).source).toBe('error');
     });
 
-    it('resets failure count on a successful call', () => {
+    it('resets failure count on a successful call', async () => {
       // First, fail twice with a throwing memory, then swap in a working memory.
       // Easiest: stub a memory whose search behavior is configurable per call.
       let mode: 'throw' | 'ok' = 'throw';
+      const flaky = () => {
+        if (mode === 'throw') throw new Error('flaky');
+        return [{ name: 'a', description: 'b' }];
+      };
       const mem = {
-        search: () => {
-          if (mode === 'throw') throw new Error('flaky');
-          return [{ name: 'a', description: 'b' }];
-        },
+        search: flaky,
+        searchHybrid: async () => flaky(),
+        lastSearchStrategy: 'vector-hybrid',
       } as unknown as SemanticMemory;
       const config = { ...DEFAULT_PROMPT_BUILD_RECALL_CONFIG, enabled: true, circuitBreakerMaxFailures: 3 };
       const recall = new PromptBuildRecall({ semanticMemory: mem }, config);
-      expect(recall.recall({ userMessage: 'q1' }).source).toBe('error');
-      expect(recall.recall({ userMessage: 'q2' }).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q1' })).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q2' })).source).toBe('error');
       mode = 'ok';
-      const r = recall.recall({ userMessage: 'q3' });
+      const r = await recall.recall({ userMessage: 'q3' });
       expect(r.source).toBe('fresh');
       // After the success, failure count is 0; subsequent throws would need 3 more
       // before the breaker opens.
       mode = 'throw';
-      expect(recall.recall({ userMessage: 'q4' }).source).toBe('error');
-      expect(recall.recall({ userMessage: 'q5' }).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q4' })).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q5' })).source).toBe('error');
       // Two failures should NOT have opened the breaker.
-      expect(recall.recall({ userMessage: 'q6' }).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q6' })).source).toBe('error');
     });
   });
 
   describe('caps', () => {
-    it('respects maxRecallResults', () => {
+    it('respects maxRecallResults', async () => {
       const big = Array.from({ length: 20 }, (_, i) => ({ name: `e${i}`, description: `desc ${i}` }));
-      const mem = { search: (_q: string, opts?: { limit?: number }) => big.slice(0, opts?.limit ?? 20) } as unknown as SemanticMemory;
+      // Asserts the limit is passed THROUGH to the memory, so the stub honours it
+      // on the hybrid entry point recall now calls.
+      const slice = (opts?: { limit?: number }) => big.slice(0, opts?.limit ?? 20);
+      const mem = {
+        search: (_q: string, opts?: { limit?: number }) => slice(opts),
+        searchHybrid: async (_q: string, opts?: { limit?: number }) => slice(opts),
+        lastSearchStrategy: 'vector-hybrid',
+      } as unknown as SemanticMemory;
       const config = { ...DEFAULT_PROMPT_BUILD_RECALL_CONFIG, enabled: true, maxRecallResults: 3 };
       const recall = new PromptBuildRecall({ semanticMemory: mem }, config);
-      const r = recall.recall({ userMessage: 'x' });
+      const r = await recall.recall({ userMessage: 'x' });
       expect(r.resultsCount).toBe(3);
     });
 
-    it('respects maxRecallChars (drops later entries that would exceed the cap)', () => {
+    it('respects maxRecallChars (drops later entries that would exceed the cap)', async () => {
       const big = Array.from({ length: 10 }, (_, i) => ({
         name: `entry-${i}`,
         description: 'x'.repeat(150),
       }));
       const { recall } = makeRecall(big, { maxRecallChars: 400 });
-      const r = recall.recall({ userMessage: 'x' });
+      const r = await recall.recall({ userMessage: 'x' });
       expect(r.contextText.length).toBeLessThanOrEqual(400);
       // The header + footer + at least one entry should always fit.
       expect(r.contextText).toContain('<active_memory_recall>');
@@ -218,14 +233,111 @@ describe('PromptBuildRecall', () => {
   });
 
   describe('reset', () => {
-    it('clears cache and circuit', () => {
+    it('clears cache and circuit', async () => {
       const { recall } = makeRecall([{ name: 'a', description: 'b' }]);
-      recall.recall({ userMessage: 'q' });
+      await recall.recall({ userMessage: 'q' });
       expect(recall.getCacheSize()).toBe(1);
       recall.reset();
       expect(recall.getCacheSize()).toBe(0);
-      const fresh = recall.recall({ userMessage: 'q' });
+      const fresh = await recall.recall({ userMessage: 'q' });
       expect(fresh.source).toBe('fresh');
+    });
+  });
+
+
+  describe('semantic-first retrieval', () => {
+    // Recall ran on keyword-only search for its entire life while a fully
+    // populated vector index went uncalled, because recall() was synchronous and
+    // searchHybrid() is not. Nothing reported it: a keyword answer and a semantic
+    // answer are the same shape.
+    it('calls searchHybrid, not the keyword-only search', async () => {
+      const called: string[] = [];
+      const mem = {
+        search: () => { called.push('search'); return []; },
+        searchHybrid: async () => { called.push('searchHybrid'); return [{ name: 'a', description: 'b' }]; },
+        lastSearchStrategy: 'vector-hybrid',
+      } as unknown as SemanticMemory;
+      const recall = new PromptBuildRecall(
+        { semanticMemory: mem }, { ...DEFAULT_PROMPT_BUILD_RECALL_CONFIG, enabled: true },
+      );
+      await recall.recall({ userMessage: 'anything' });
+      expect(called).toContain('searchHybrid');
+      expect(called).not.toContain('search');
+    });
+
+    it('reports the strategy that actually served', async () => {
+      const mem = {
+        searchHybrid: async () => [{ name: 'a', description: 'b' }],
+        lastSearchStrategy: 'vector-hybrid',
+      } as unknown as SemanticMemory;
+      const recall = new PromptBuildRecall(
+        { semanticMemory: mem }, { ...DEFAULT_PROMPT_BUILD_RECALL_CONFIG, enabled: true },
+      );
+      expect((await recall.recall({ userMessage: 'x' })).strategy).toBe('vector-hybrid');
+    });
+
+    it('reports a lexical strategy honestly when vectors did not serve', async () => {
+      // searchHybrid degrades to search() internally when vectors are unavailable.
+      // The degradation must be visible, not silent.
+      const mem = {
+        searchHybrid: async () => [{ name: 'a', description: 'b' }],
+        lastSearchStrategy: 'fts-loose-fallback',
+      } as unknown as SemanticMemory;
+      const recall = new PromptBuildRecall(
+        { semanticMemory: mem }, { ...DEFAULT_PROMPT_BUILD_RECALL_CONFIG, enabled: true },
+      );
+      expect((await recall.recall({ userMessage: 'x' })).strategy).toBe('fts-loose-fallback');
+    });
+
+    it('claims no strategy on a path that never reached a search', async () => {
+      const recall = new PromptBuildRecall(
+        { semanticMemory: null }, { ...DEFAULT_PROMPT_BUILD_RECALL_CONFIG, enabled: true },
+      );
+      const r = await recall.recall({ userMessage: 'x' });
+      expect(r.source).toBe('no-memory');
+      expect(r.strategy).toBeUndefined();
+    });
+
+    it('bounds a slow search by the timeout instead of blocking the prompt path', async () => {
+      // Embedding cold-start is the realistic slow case. The budget must hold.
+      const mem = {
+        searchHybrid: () => new Promise((resolve) => setTimeout(() => resolve([{ name: 'a' }]), 5_000)),
+        lastSearchStrategy: 'vector-hybrid',
+      } as unknown as SemanticMemory;
+      const recall = new PromptBuildRecall(
+        { semanticMemory: mem }, { ...DEFAULT_PROMPT_BUILD_RECALL_CONFIG, enabled: true, recallTimeoutMs: 40 },
+      );
+      const r = await recall.recall({ userMessage: 'x' });
+      expect(r.source).toBe('timeout');
+    });
+
+    it('does NOT count a timeout as a circuit failure', async () => {
+      // A cold model that is still warming is not a broken provider. Counting it
+      // would open the breaker on a healthy path and keep recall dark for the
+      // whole cooldown — turning slowness into an outage.
+      const mem = {
+        searchHybrid: () => new Promise((resolve) => setTimeout(() => resolve([{ name: 'a' }]), 5_000)),
+        lastSearchStrategy: 'vector-hybrid',
+      } as unknown as SemanticMemory;
+      const config = { ...DEFAULT_PROMPT_BUILD_RECALL_CONFIG, enabled: true, recallTimeoutMs: 20, circuitBreakerMaxFailures: 2 };
+      const recall = new PromptBuildRecall({ semanticMemory: mem }, config);
+      expect((await recall.recall({ userMessage: 'q1' })).source).toBe('timeout');
+      expect((await recall.recall({ userMessage: 'q2' })).source).toBe('timeout');
+      // Third call must still attempt, not report circuit-open.
+      expect((await recall.recall({ userMessage: 'q3' })).source).toBe('timeout');
+    });
+
+    it('still opens the circuit on real errors', async () => {
+      // The timeout carve-out must not blunt the breaker for genuine failures.
+      const mem = {
+        searchHybrid: async () => { throw new Error('provider down'); },
+        lastSearchStrategy: 'none',
+      } as unknown as SemanticMemory;
+      const config = { ...DEFAULT_PROMPT_BUILD_RECALL_CONFIG, enabled: true, circuitBreakerMaxFailures: 2 };
+      const recall = new PromptBuildRecall({ semanticMemory: mem }, config);
+      expect((await recall.recall({ userMessage: 'q1' })).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q2' })).source).toBe('error');
+      expect((await recall.recall({ userMessage: 'q3' })).source).toBe('circuit-open');
     });
   });
 });

--- a/upgrades/next/recall-vector-primary.md
+++ b/upgrades/next/recall-vector-primary.md
@@ -1,0 +1,81 @@
+## What Changed
+
+Memory recall now retrieves semantically. Keyword matching becomes the fallback it was always
+meant to be.
+
+A fully-populated vector index already existed and went uncalled: `GET /semantic/stats` reports
+`vectorSearchAvailable: true` and `embeddingCount: 2852` against 2,852 entities — 100% coverage —
+while `PromptBuildRecall.ts:138` called the keyword-only `search()`.
+
+The cause was not a design decision. `recall()` was synchronous and `searchHybrid()` is async, so
+the synchronous one was reachable and got used. **One ergonomic choice silently set the retrieval
+strategy for the whole system**, and nothing reported it, because a keyword answer and a semantic
+answer are the same shape — a `ScoredEntity[]` either way.
+
+`recall()` is now async and calls `searchHybrid()`, which degrades to `search()` internally when
+vectors are unavailable, so an installation without a working embedding provider keeps exactly its
+previous behaviour — and now reports that it did.
+
+Two supporting changes:
+
+- **The result reports which strategy served it** (`vector-hybrid`, `fts-strict`,
+  `fts-loose-fallback`). `searchHybrid()` records `vector-hybrid` after its inner `search()` call,
+  so the reported strategy matches what actually ran rather than what the last lexical step did.
+- **The timeout is a real race.** It was previously checked *after* the search returned, so a slow
+  embedding cold-start would block the prompt path for its full duration and then report a
+  timeout. The budget now holds.
+
+A timeout deliberately does **not** count toward the circuit breaker: a model still warming is not
+a broken provider, and counting it would open the breaker on a healthy path and keep recall dark
+for the entire cooldown, converting slowness into an outage. Genuine errors still count, pinned by
+a test.
+
+This is the second defect in this path in one day. The first was that recall returned *nothing*
+for any natural-language query; fixing it made the lexical path work. This makes the lexical path
+the fallback.
+
+## Evidence
+
+New tests run against **unmodified source first**:
+
+| run | result |
+|---|---|
+| fix reverted | **5 failed / 17 passed** |
+| fix applied | **22 passed** |
+| semantic-memory regression (4 files) | **99 passed** |
+| `tsc --noEmit` | clean |
+
+Two new tests pass in *both* runs by design — "claims no strategy on a path that never reached a
+search" and "still opens the circuit on real errors". They are guards, not proofs.
+
+## What to Tell Your User
+
+Your agent has two ways to search its own memory: one that matches on meaning, and one that
+matches on words. The good one was built, fully switched on, and never called.
+
+All 2,852 of its stored memories already had the data needed for meaning-based search. The recall
+path used word-matching instead — not as a decision anyone weighed, but because the word-matching
+version returned instantly and the meaning-based one takes a moment, so only the instant one was
+reachable from the way recall was written. One small choice, made once, quietly decided how the
+whole system remembers.
+
+Nothing reported it, because both searches hand back the same shape of answer. A worse result and
+a better result look identical once they arrive.
+
+Recall now asks the meaning-based search first. It also says which search served each answer, so
+running on the fallback no longer looks the same as running properly — and the time limit is now
+enforced while waiting rather than checked afterwards, so a slow search can't hold up your reply.
+
+The first lookup after a restart may still be slow while the model loads. That costs one missed
+lookup, quietly, and everything after is fast.
+
+## Summary of New Capabilities
+
+- Memory recall retrieves by meaning rather than keyword, using the embedding index that was
+  already built and populated but never called.
+- Each recall reports which strategy served it, so running on the keyword fallback is
+  distinguishable from running semantically.
+- The recall timeout is enforced during the wait rather than checked afterwards, so a slow
+  embedding cold-start cannot block the prompt path.
+- A timeout no longer counts toward the recall circuit breaker, so a warming model cannot disable
+  memory for a full cooldown; genuine errors still trip it.

--- a/upgrades/side-effects/recall-vector-primary.md
+++ b/upgrades/side-effects/recall-vector-primary.md
@@ -1,0 +1,132 @@
+# Side-effects review — recall retrieves semantically, keyword becomes the fallback
+
+**Change:** `PromptBuildRecall.recall()` becomes async and calls `searchHybrid()` (the vector
+path) instead of the synchronous keyword-only `search()`. The timeout becomes a real race. The
+strategy that actually served is reported. `SemanticMemory.searchHybrid()` now records
+`vector-hybrid` so the reported strategy matches what ran.
+
+**Discovered:** 2026-07-27, diagnosing why a lesson stored on 2026-07-19 was re-derived from
+scratch. Operator directive the same day: *"Keyword searching should be supplementary, NOT the
+primary method."*
+
+## The condition
+
+A fully-populated vector index existed and went uncalled. `GET /semantic/stats`:
+`vectorSearchAvailable: true`, `embeddingCount: 2852` against 2,852 entities — 100% coverage.
+`searchHybrid()` performs real vector KNN. `PromptBuildRecall.ts:138` called `search()`.
+
+The cause was not a design decision. `recall()` was synchronous and `searchHybrid()` is async, so
+the synchronous one was reachable and got used. **One ergonomic choice silently set the retrieval
+strategy for the entire system**, and nothing reported it, because a keyword answer and a semantic
+answer are the same shape — a `ScoredEntity[]` either way.
+
+This is the second defect in the same path in one day. The first (#1680) was that recall returned
+*nothing* for any natural-language query. Fixing that made the lexical path work; this makes the
+lexical path the fallback it was always supposed to be.
+
+## 1. Over-block — what legitimate input does this reject?
+
+None. `searchHybrid()` degrades to `search()` internally whenever vectors are unavailable
+(`SemanticMemory.ts:1714`), so an installation without a working embedding provider gets exactly
+the previous behaviour — and now *reports* that it did, rather than being indistinguishable from
+the semantic path.
+
+The one input class treated differently is a **slow** search. Previously the timeout was checked
+after the search returned, so a 30-second embedding cold start would have blocked the prompt path
+for 30 seconds and then reported a timeout. It is now a race, so the budget actually holds.
+
+## 2. Under-block — what does this still miss?
+
+- **Cold start still costs one recall.** The first call after a server boot pays the ONNX model
+  load and will likely time out; subsequent calls are warm. The timeout path is silent and
+  cached-empty, so the cost is one missed recall, not an error. Pre-warming the model at boot is
+  the obvious follow-up and is deliberately not in this change. <!-- tracked: ACT-1395 -->
+- **It does not improve what is *in* the index.** Recall can only surface what was stored;
+  extraction quality is a separate problem.
+- **The strategy signal is per-call and in-memory**, not aggregated. Nothing yet reports "what
+  fraction of recalls were served semantically" — that would be the honest measure of whether
+  this change achieved its purpose, and it is not built here.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. `recall()` is the single funnel the prompt hook reaches through, and the strategy
+choice belongs at the point where the retrieval is requested, not inside `SemanticMemory` (which
+correctly offers both and lets the caller choose).
+
+The one-line addition inside `searchHybrid()` — recording `vector-hybrid` after the inner
+`search()` call — belongs in `SemanticMemory` because only it knows whether embeddings actually
+participated. Without it the strategy would report a lexical value even when vectors ranked the
+result, which would make the reporting actively misleading rather than merely absent.
+
+## 4. Signal vs authority compliance
+
+Recall is a **signal producer**: its output is injected as context and gates nothing. This change
+cannot block, delay, or redirect any action. The worst case is a less-relevant memory in context.
+
+The timeout carve-out deserves scrutiny, because it *weakens* a breaker: a timeout no longer
+counts toward the circuit. That is deliberate and argued — an embedding model that is still
+warming is not a broken provider, and counting it would open the breaker on a healthy path and
+keep recall dark for the whole cooldown, converting slowness into an outage. Genuine errors still
+count, and a test pins that the breaker still opens on real failures so the carve-out cannot
+quietly blunt it.
+
+## 5. Interactions
+
+- **Caller.** One call site (`routes.ts:3805`), already inside an async handler; it gains `await`.
+  The hook that reaches it is unchanged and still receives the same JSON.
+- **Circuit breaker.** Error path unchanged. Timeout path deliberately excluded — see §4.
+- **Cache.** Unchanged. A timeout is not cached (it may succeed warm); empty and fresh results are
+  cached as before.
+- **#1680's strategy field.** This extends the same union rather than introducing a parallel
+  signal, so `fts-strict` / `fts-loose-fallback` keep their meaning and `vector-hybrid` joins them.
+- **Cost.** Embedding is a local ONNX pipeline — no API call, no per-call spend, no new provider
+  dependency and nothing to route or budget.
+
+## 6. External surfaces
+
+`/internal/prompt-recall` gains an optional `strategy` field in its response. No field is removed
+or changed. The hook ignores unknown fields. No schema, migration, config, or persisted state.
+
+`recall()`'s signature changes from sync to async — a source-level breaking change with exactly
+one in-repo caller, updated here. It is exported, so an out-of-tree caller would break; there are
+none in this repo and the type change is compile-visible rather than silent.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design, and correctly so — no durable state is introduced.** The change picks
+which local query runs against the local `semantic.db`; the strategy signal is per-call and
+in-memory. Nothing here is replicated because nothing here is a durable fact about the agent —
+whether *this* machine's recall was served semantically is a property of this process's index and
+embedding provider, not a shared truth. Whether the semantic store itself replicates is a
+pre-existing, separate question this change neither introduces nor alters.
+
+## 8. Rollback cost
+
+Revert the commit. `recall()` returns to sync + keyword, the caller drops its `await`, and the
+strategy field disappears. No persisted state, no migration, no data to repair. The index remains
+populated either way — it was populated and unused before this change, and would be again.
+
+## Evidence
+
+New tests verified to fail against unmodified source before the fix:
+
+```
+# fix reverted
+Tests  5 failed | 17 passed (22)
+  ✗ calls searchHybrid, not the keyword-only search
+  ✗ reports the strategy that actually served
+  ✗ reports a lexical strategy honestly when vectors did not serve
+  ✗ bounds a slow search by the timeout instead of blocking the prompt path
+  ✗ does NOT count a timeout as a circuit failure
+
+# fix applied
+Tests  22 passed (22)
+
+# regression
+semantic-memory + recall-query + privacy + vec0-probe — 4 files, 99 passed
+tsc --noEmit — clean
+```
+
+The two new tests that pass in *both* runs are deliberate guards: "claims no strategy on a path
+that never reached a search" and "still opens the circuit on real errors". They should pass
+either way — that is what makes them guards rather than proofs.


### PR DESCRIPTION
## Summary

A fully-populated vector index existed and went uncalled.

| | |
|---|---|
| `GET /semantic/stats` | `vectorSearchAvailable: true`, `embeddingCount: 2852` / 2852 entities — **100% coverage** |
| `searchHybrid()` | performs real vector KNN |
| `PromptBuildRecall.ts:138` | called the **keyword-only** `search()` |

**The cause was not a design decision.** `recall()` was synchronous and `searchHybrid()` is async, so the synchronous one was reachable and got used. One ergonomic choice silently set the retrieval strategy for the entire system — and nothing reported it, because a keyword answer and a semantic answer are the same shape (`ScoredEntity[]` either way).

Operator directive, 2026-07-27: *"Keyword searching should be supplementary, NOT the primary method."*

## The change

`recall()` is async and calls `searchHybrid()`, which degrades to `search()` internally when vectors are unavailable — so a vector-less install keeps **exactly** its previous behaviour, and now reports that it did.

- **The result carries the strategy that served it** (`vector-hybrid` / `fts-strict` / `fts-loose-fallback`). `searchHybrid()` records `vector-hybrid` *after* its inner `search()` call, because the inner call records a lexical value that's true of candidate selection but misleading as the answer to "did the semantic path run?"
- **The timeout is now a race.** It was checked *after* the search returned — so a slow embedding cold-start would block the prompt path for its full duration and *then* report a timeout. The budget now holds.

## The judgement call worth reviewing

**A timeout deliberately does not count toward the circuit breaker.** A model still warming is not a broken provider; counting it would open the breaker on a healthy path and keep recall dark for the whole cooldown — converting slowness into an outage. Genuine errors still count, and a test pins that the breaker still opens on real failures so the carve-out can't quietly blunt it.

This is the one authority-adjacent element in the change and I'd rather flag it than have it found.

## Evidence

New tests run against **unmodified source first**:

| run | result |
|---|---|
| fix reverted | **5 failed / 17 passed** |
| fix applied | **22 passed** |
| semantic-memory + recall-query + privacy + vec0-probe | **4 files, 99 passed** |
| `tsc --noEmit` | clean |

Two new tests pass in **both** runs by design — "claims no strategy on a path that never reached a search" and "still opens the circuit on real errors". They're guards, not proofs.

## Context

Second defect in this path in one day. The first (#1680) was that recall returned **nothing** for any natural-language query — FTS5 implicit-AND over raw sentences, and no stored entity contains "why". Fixing that made the lexical path work. This makes the lexical path the *fallback*.

## Not in scope

The first recall after a restart will likely time out while the ONNX model loads — one silent missed lookup per boot, everything after warm. Pre-warming at startup is tracked as **ACT-1395** rather than bundled in.

## ELI16 — the agent had a good memory and was using the bad one

Your agent has two ways to search its own memory. One matches on meaning. One matches on words. The good one was built, fully switched on, and never called.

All 2,852 stored memories already had what meaning-based search needs. The recall path used word-matching instead — not as a tradeoff anyone weighed, but because the word-matching version returns instantly and the meaning-based one takes a moment, so only the instant one was reachable from the way recall was written. One small choice, made once, quietly decided how the whole system remembers.

Nothing reported it, because both searches hand back the same shape of answer. A worse result and a better result look identical once they've arrived. No error, no warning, no slow query — just a worse answer than the one available, every time, for as long as it had been running.

Recall now asks the meaning-based search first. Two supporting changes matter more than they sound. **The answer now says which search served it** — without that, a system running on the fallback looks exactly like one running properly, which is the condition that let this last. And **the time limit is now real**: it used to be checked *after* the search came back, which isn't a limit at all — a thirty-second search would take thirty seconds and then be told it was too slow.

The one judgement call: a safety breaker disables recall after repeated failures, and I made timeouts not count toward it. The first search after a restart is slow because the model has to load — a cold engine, not a broken one. If slowness tripped the breaker, every restart would disable memory for the whole cooldown. Real errors still trip it, and a test proves it.