### PR TITLE
fix(test): feedback-inbox e2e raced its own drain — polled one effect, asserted two

### DIFF
--- a/tests/e2e/feedback-inbox-lifecycle.test.ts
+++ b/tests/e2e/feedback-inbox-lifecycle.test.ts
@@ -131,12 +131,19 @@ describe('feedback-inbox E2E — alive when enabled (production init path + real
 
   it('WIRING INTEGRITY: the seeded blob lands as a durable row in the real on-disk store', async () => {
     // The priming drain runs at start(); poll briefly for it to complete.
+    //
+    // Poll for BOTH observable effects, not just the first. The drain writes the
+    // durable row and THEN clears the inbox, so waiting only on the row can exit
+    // between the two — the row is present, the inbox clear has not landed yet,
+    // and the assertion below reads a stale count of 1. That is a race in the
+    // test, not a defect in the drain: it fails only under load (observed on CI
+    // 2026-07-27, twice, and reproduced locally once in five runs).
     const storeFile = path.join(stateDir, 'state', 'feedback-factory', 'store', 'feedback.jsonl');
     let content = '';
     for (let i = 0; i < 50; i++) {
       if (fs.existsSync(storeFile)) {
         content = fs.readFileSync(storeFile, 'utf8');
-        if (content.includes('fb-e2e-1')) break;
+        if (content.includes('fb-e2e-1') && blob.count('inbox/') === 0) break;
       }
       await new Promise((r) => setTimeout(r, 100));
     }


### PR DESCRIPTION
## Summary

`tests/e2e/feedback-inbox-lifecycle.test.ts` → *"WIRING INTEGRITY: the seeded blob lands as a durable row in the real on-disk store"* fails intermittently with `AssertionError: expected 1 to be +0`.

**It is a race in the test, not a defect in the drain.** The drain writes the durable row and *then* clears the inbox. The test polled only for the row, so under load it could exit between the two effects — row present, inbox clear not yet landed — and `expect(blob.count('inbox/')).toBe(0)` reads a stale `1`.

## Why it matters now

It blocked **two** PRs today: #1682 (E2E Tests) and #1683 (Unit Tests node 22, shard 4/4). Reproduced locally once in five runs, which is why it reads as flaky rather than broken.

`safe-merge` correctly refused to merge on the red check both times — the gate did its job, which is why this needed fixing rather than re-running.

## The fix

The poll now waits for **both** observable effects before breaking:

```js
if (content.includes('fb-e2e-1') && blob.count('inbox/') === 0) break;
```

## Why this can't have made the test toothless

**No assertion is changed.** 8 insertions, 1 deletion, zero assertion lines touched. The fix only extends the *wait* — an inbox that genuinely never clears still fails, because the poll times out after 5s and the unchanged `expect(blob.count('inbox/')).toBe(0)` runs exactly as before.

That distinction is the whole point: a flaky test is usually "fixed" by loosening what it checks, which converts a real signal into a permanent pass. This waits longer for the same check.

## Evidence

- 4 consecutive passes post-fix (it also passed 4× pre-fix in isolation — the race needs load, which is why the CI shard surfaced it and a quiet local run does not).
- Diff confined to the poll condition and its explanatory comment.

## Not in scope

Codey independently reported contention-sensitive timing failures elsewhere in the same suite during a repository-wide run. The broader question — whether this suite has a systemic isolation problem — deserves a converging audit rather than one-off patches, and is tracked separately as **ACT-1397**. This fixes the instance that is blocking merges right now.

## ELI16 — a test that raced the thing it was testing

There is a step where the system takes a piece of feedback out of an inbox and writes it into
permanent storage. Two things happen, in order: the permanent copy gets written, and *then* the
inbox gets emptied.

The test watched for the first thing and then immediately checked the second. Most of the time
that's fine, because emptying the inbox takes almost no time. But when the machine is busy — which
is exactly what happens on CI — the gap between the two stretches, the test stops waiting as soon
as it sees the permanent copy, and then complains that the inbox still has something in it.

The inbox was going to be emptied a fraction of a second later. Nothing was broken. The test just
looked too early.

That's why it's intermittent, and intermittent is the worst kind: it blocked two separate pieces of
work today, and each time the honest question was "is this my change, or is this the test?" — which
takes real time to answer and can't be skipped, because sometimes the answer is "it's my change."

The fix is one line: wait for *both* things to have happened before checking either.

**The part I want reviewed:** the usual way to make a flaky test stop failing is to soften what it
checks, and that's a bad trade — you convert a real signal into a permanent pass and nobody notices
until something actually breaks. This does the opposite. Not a single assertion changed. The test
still demands the inbox be empty, and if it genuinely never empties, the wait times out and the
test fails exactly as it did before. The only thing that changed is how long it's willing to wait
for the thing it was already checking.
