### PR TITLE
fix(spec): mutual-ssh named a readout that never existed — the real one did

### DIFF
--- a/docs/specs/mutual-ssh-autobootstrap.md
+++ b/docs/specs/mutual-ssh-autobootstrap.md
@@ -11,7 +11,7 @@ rollout-source-pr: 1539
 rollout-flag-path: multiMachine.mutualSsh.enabled
 rollout-criteria: "At least one registered peer pair has current bidirectional SSH readiness proof with no blocking reason."
 rollout-evidence-type: endpoint
-rollout-evidence-ref: /multi-machine/mutual-ssh
+rollout-evidence-ref: /machines/ssh-health
 rollout-metrics-json: '{"cadenceHours":6,"evidenceMaxAgeHours":12,"metrics":[{"id":"ready-mutual-ssh-peers","source":"feature-summary","sourceRef":"mutual-ssh.ready-peers","direction":"at-least","threshold":1,"minSamples":1}]}'
 review-convergence: "2026-07-19T21:27:13.671Z"
 review-iterations: 4

--- a/upgrades/next/mutual-ssh-evidence-ref.md
+++ b/upgrades/next/mutual-ssh-evidence-ref.md
@@ -1,0 +1,49 @@
+## What Changed
+
+Corrects the `rollout-evidence-ref` in `docs/specs/mutual-ssh-autobootstrap.md`. It named
+`/multi-machine/mutual-ssh` — a path with no route anywhere in `src/`. The rollout has been marked
+active and unmeasurable since the feature merged on 2026-07-21.
+
+The readout was never missing. It is `GET /machines/ssh-health`, wired the whole time, and it
+returns real data right now. The spec simply named the wrong address.
+
+Spec frontmatter only. No runtime surface, no route added, no behaviour change.
+
+## Evidence
+
+Both paths probed live against the running server:
+
+| path | result |
+|---|---|
+| `/multi-machine/mutual-ssh` (the ref as written) | **404** |
+| `/machines/ssh-health` (the real readout) | **200** — `enrollmentState: ssh-bootstrap-blocked`, `pairs[0].mutual: false`, `standingKeyInstalled: false` |
+
+So the graduation criterion — at least one peer pair with bidirectional readiness proof and no
+blocking reason — is now evaluable, and currently, correctly, **not met**. Before this change,
+"not met" and "not measurable" were the same 404.
+
+The route is served from `src/server/routes.ts` (`router.get('/machines/ssh-health')`) reading
+`MutualSshRuntime.status()`, so the corrected ref also satisfies the rollout-evidence lint.
+
+**A correction to my own earlier diagnosis, recorded because it is the more useful finding.** I
+first read the 404 and concluded the endpoint had never landed with the feature, and filed an action
+to build it. It had landed, under a different name. Concluding absence from a single lookup, without
+checking whether the thing exists elsewhere, is the same error this whole sweep is about — and I
+made it while running the sweep.
+
+## What to Tell Your User
+
+Some features are released carefully: switched on quietly first, and only turned up once there is
+evidence they work. Each one's plan names the readout you check to see that evidence.
+
+This feature's plan named a readout that does not exist — so there was no way to tell whether it was
+working, and it would have sat in its cautious first stage forever. The readout it should have named
+does exist and has all along.
+
+Nothing about the feature changed. What changed is that its progress can now be read, and right now
+it honestly reports that it is not ready yet — which is a much better answer than silence.
+
+## Summary of New Capabilities
+
+- The mutual-SSH feature's graduation evidence is readable at `GET /machines/ssh-health` instead of
+  pointing at a path that returns nothing.

--- a/upgrades/side-effects/mutual-ssh-evidence-ref.md
+++ b/upgrades/side-effects/mutual-ssh-evidence-ref.md
@@ -1,0 +1,45 @@
+# Side-effects review — mutual-ssh rollout-evidence-ref correction
+
+**Change:** one frontmatter line in `docs/specs/mutual-ssh-autobootstrap.md` —
+`rollout-evidence-ref: /multi-machine/mutual-ssh` → `/machines/ssh-health`.
+
+**Tier:** 0–1. Spec frontmatter only. No `src/` surface, no route, no config key, no persisted
+state, no migration. Rollback is reverting one line.
+
+## What reads this field
+
+`scripts/lint-rollout-evidence-resolvable.js` (string-matches the ref against `src/`) and any
+future rollout-graduation reader. Nothing at runtime dereferences it — the field is documentation
+of where a human or a check should look, so a wrong value cannot cause a runtime fault. Its failure
+mode is exactly what happened: silence.
+
+## Blast radius
+
+None at runtime. The one behavioural consequence is intended and desirable: the mutual-ssh rollout
+becomes *measurable*, and the first honest measurement says **not ready** (`enrollmentState:
+ssh-bootstrap-blocked`, `pairs[0].mutual: false`). A feature that previously could not be assessed
+now reports a negative. That is the point; it is not a regression.
+
+## Why not build `/multi-machine/mutual-ssh` instead
+
+That was the first plan, and it was wrong. Adding an alias route to satisfy a spec that named a
+non-existent path would have created a second address for one readout — two places to look, two
+things to keep in sync, and a permanent invitation to the same confusion. The spec was wrong; the
+spec was corrected.
+
+## Verification
+
+- `curl /multi-machine/mutual-ssh` → 404 (before and after — nothing was added).
+- `curl /machines/ssh-health` → 200 with live pair state.
+- `node scripts/lint-rollout-evidence-resolvable.js` → the corrected ref resolves.
+
+## Rollback
+
+`git revert` the one-line commit. The rollout returns to being unmeasurable, which is the state it
+has been in since 2026-07-21.
+
+## Known limitation, stated rather than hidden
+
+The lint that guards this field is a **string match against `src/`**. A route that is written but
+never mounted would still satisfy it. That limitation is documented in the lint's own header; the
+live probe above is what actually establishes that this particular ref resolves.


### PR DESCRIPTION
## ELI16 — a feature's progress readout pointed at an address that returns nothing

Some features are released carefully: switched on quietly first, and only turned up once there is
evidence they work. Each one's plan names the readout you check to see that evidence.

This feature's plan named a readout that does not exist. So since it shipped on July 21 there has
been no way to tell whether it is working — it would have sat in its cautious first stage forever,
looking careful while being unmeasurable.

The readout was never missing. It exists, it has been wired the whole time, and it returns real
data. The plan simply named the wrong address. This corrects the address.

Nothing about the feature changed. What changed is that its progress can now be read — and right now
it honestly reports that it is **not ready yet**, which is a far better answer than silence.

## What changed

One frontmatter line in `docs/specs/mutual-ssh-autobootstrap.md`:

```
- rollout-evidence-ref: /multi-machine/mutual-ssh
+ rollout-evidence-ref: /machines/ssh-health
```

## Evidence

Both paths probed live against the running server:

| path | result |
|---|---|
| `/multi-machine/mutual-ssh` (the ref as written) | **404** |
| `/machines/ssh-health` (the real readout) | **200** — `enrollmentState: ssh-bootstrap-blocked`, `pairs[0].mutual: false`, `standingKeyInstalled: false` |

The route is served from `src/server/routes.ts` reading `MutualSshRuntime.status()`, so the
corrected ref also satisfies the rollout-evidence lint.

## I diagnosed this wrong the first time, and that is the more useful finding

I read the 404 and concluded the endpoint had never landed with the feature (#1539), and filed an
action to build it. It had landed — under a different name.

Concluding absence from a single lookup, without checking whether the thing exists elsewhere, is
precisely the failure class this sweep is about. I made it *while running the sweep*. The action's
premise is corrected and this is recorded in `docs/audits/topic-29723-convergence.md` Round 2.

Building `/multi-machine/mutual-ssh` as an alias would have been worse: two addresses for one
readout, two things to keep in sync, and a permanent invitation to the same confusion.

## Tier

Tier 0–1 — spec frontmatter only. No `src/` surface, no route, no config, no persisted state.
Rollback is reverting one line.
