### PR TITLE
fix(gate): the pre-push gate demanded a file the release flow never creates

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T19-37-19-357Z-prepush-gate-frozen-guide.json
+++ b/.instar/instar-dev-decisions/2026-07-27T19-37-19-357Z-prepush-gate-frozen-guide.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T19:37:19.357Z",
+  "slug": "prepush-gate-frozen-guide",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 59,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/prepush-gate-frozen-guide.eli16.md
+++ b/docs/specs/prepush-gate-frozen-guide.eli16.md
@@ -1,0 +1,56 @@
+# A gate refused every push, and told everyone to fix it the wrong way
+
+## What was broken
+
+There is a check that runs before code is pushed. Its job is: *if the release notes say this ships a
+fix, make sure someone wrote a review of what that fix might break.*
+
+Sensible. But when there were no release notes in flight — the normal state right after a release
+goes out — it fell back to checking the notes for the release that had **already shipped**. And it
+demanded a review file named after that version number.
+
+That file never exists. Review files are named after the change, not after the version, and the
+release process has never created a version-named one. So the check asked for something that cannot
+be produced, on a release that had already shipped and already been reviewed, and it did this on
+**every push from a clean tree**.
+
+## Why this is worse than a false alarm
+
+A false alarm you can ignore. This one came with instructions.
+
+The message said "no matching side-effects review artifact found" — so three separate times, someone
+did the obvious thing and hand-wrote the missing file. Those files are still in the repo, and two of
+them openly say what they are: *"This file exists so the repo state matches the gate's documented
+post-release expectation."*
+
+That is a gate teaching people to write junk to satisfy it. The junk then looks like evidence of
+review, when it is evidence of a workaround.
+
+Both of those files also claim the underlying problem "remains logged" in an issue ledger, under a
+specific tracking key. It is not there. The ledger holds 163 issues and none of them is this one. So
+the problem was declared tracked, was not tracked, and recurred a third time today — which is exactly
+how a thing recurs.
+
+## What changed
+
+The check now only runs against release notes **this push is actually shipping**. If there are no
+notes in flight, there is nothing for it to check, and it says nothing.
+
+Nothing was weakened, and this is the part worth checking rather than taking on trust:
+
+- The per-change requirement still lives where it always did — the check that runs when you
+  **commit**, which refuses any in-scope file without its plain-English summary and its
+  side-effects review. That one is untouched.
+- A separate check still refuses a push that changes shipping code without adding release notes at
+  all, and it names the actual fix.
+- And with notes in flight, the review requirement still fires. There is a test for exactly that,
+  because the easy mistake here would be to trade a false alarm for a missed one.
+
+The message it prints when it does fire now names the right remedy — a review file named after the
+change — and says explicitly not to create a version-named file.
+
+## How I know it works
+
+By breaking it on purpose. The three new tests were run against the **old** code first, and all
+three failed. Then against the new code, where all nineteen pass. A test that has never failed is a
+test that has never proved anything.

--- a/scripts/pre-push-gate.js
+++ b/scripts/pre-push-gate.js
@@ -345,44 +345,57 @@ if (!process.env.CI) {
   // isn't what this PR is changing. Falls back to the versioned guide when no
   // fragment / NEXT.md is staged (post-release-cut state).
   const inFlight = assembledContent !== null;
-  const guideContent = inFlight
-    ? assembledContent
-    : (versionedGuideExists ? fs.readFileSync(versionedGuidePath, 'utf-8') : null);
-  if (guideContent !== null) {
+
+  // This check is a RELEASE-LEVEL re-check on the notes THIS PUSH is shipping —
+  // which means it only has a subject when in-flight notes exist. It deliberately
+  // does NOT fall back to the versioned guide.
+  //
+  // Why (three recurrences, 2026: v1.3.492, v1.3.802, v1.3.1009): the release cut
+  // renames upgrades/next/*.md into upgrades/<version>.md and bumps package.json,
+  // but side-effects artifacts are named per CHANGE SLUG, never per version — so
+  // upgrades/side-effects/<version>.md is a file the release flow never creates.
+  // Falling back to the frozen guide therefore demanded a filename that cannot
+  // exist, on EVERY push from a clean post-release tree, for a release that had
+  // already shipped and already been reviewed.
+  //
+  // The damage was not the refusal, it was the REMEDY the message named: three
+  // separate times someone hand-wrote a placeholder upgrades/side-effects/<version>.md
+  // to get past it (see 1.3.492.md and 1.3.802.md, both of which say so in their
+  // own text). A gate whose advice is unfollowable teaches people to write junk
+  // that satisfies it.
+  //
+  // Nothing is weakened. Per-change enforcement lives in the pre-COMMIT gate
+  // (scripts/instar-dev-precommit.js — refuses in-scope staged files without an
+  // ELI16 + side-effects artifact), and check 3b above already refuses a
+  // release-relevant push that ships no fragment, with an actionable remedy.
+  if (inFlight) {
     // Extract "## What Changed" section
-    const whatChangedMatch = guideContent.match(/## What Changed\s*([\s\S]*?)(?=\n##\s|$)/);
+    const whatChangedMatch = assembledContent.match(/## What Changed\s*([\s\S]*?)(?=\n##\s|$)/);
     const whatChanged = whatChangedMatch ? whatChangedMatch[1] : '';
 
     const qualifies = FIX_PATTERNS.some((p) => p.test(whatChanged));
 
     if (qualifies) {
       const sideEffectsDir = path.join(ROOT, 'upgrades', 'side-effects');
-      // When in-flight notes (fragments/NEXT.md) drive the push, any fresh
-      // artifact (last 24h) counts — the versioned-filename requirement only
-      // applies when a versioned guide is being validated without in-flight notes.
-      const artifactName = (!inFlight && versionedGuideExists) ? `${version}.md` : null;
       let artifactFound = false;
 
       if (fs.existsSync(sideEffectsDir)) {
         const files = fs.readdirSync(sideEffectsDir).filter((f) => f.endsWith('.md'));
-        if (artifactName) {
-          artifactFound = files.includes(artifactName);
-        } else {
-          // For in-flight notes (fragments/NEXT.md), any fresh artifact from the
-          // last 24h counts. The expectation is that during release cut, the
-          // fragment/NEXT.md -> <version>.md rename pairs with an artifact rename.
-          const recent = files.filter((f) => {
-            const stat = fs.statSync(path.join(sideEffectsDir, f));
-            return Date.now() - stat.mtimeMs < 24 * 60 * 60 * 1000;
-          });
-          artifactFound = recent.length > 0;
-        }
+        // Any fresh artifact from the last 24h counts — the in-flight notes name
+        // the change, the artifact reviews it, and the two are paired by the PR
+        // rather than by filename.
+        const recent = files.filter((f) => {
+          const stat = fs.statSync(path.join(sideEffectsDir, f));
+          return Date.now() - stat.mtimeMs < 24 * 60 * 60 * 1000;
+        });
+        artifactFound = recent.length > 0;
       }
 
       if (!artifactFound) {
         errors.push(
-          `Upgrade notes claim a fix/feature but no matching side-effects review artifact found in upgrades/side-effects/. ` +
-          `Every change qualifying for review must ship with an artifact produced via the /instar-dev skill. ` +
+          `Your release-note fragment claims a fix/feature but no side-effects review artifact was written in the last 24h. ` +
+          `Add upgrades/side-effects/<slug>.md for this change (produced via the /instar-dev skill) — ` +
+          `do NOT create a version-named file to satisfy this check. ` +
           `See skills/instar-dev/SKILL.md and docs/signal-vs-authority.md.`
         );
       }

--- a/tests/unit/pre-push-gate.test.ts
+++ b/tests/unit/pre-push-gate.test.ts
@@ -409,4 +409,114 @@ describe('Pre-push gate integration — release-note fragments', () => {
     expect(status).not.toBe(0);
     expect(stdout).toContain('Release-note fragments are malformed');
   });
+
+  // ── post-release-cut state (the three-time recurrence) ────────────────────
+  //
+  // After a release cut the tree has: upgrades/<version>.md (the frozen guide for
+  // the version that just shipped), no fragments, and NO
+  // upgrades/side-effects/<version>.md — because side-effects artifacts are named
+  // per change slug and the release flow never creates a version-named one.
+  //
+  // The gate used to fall back to that frozen guide and demand exactly that
+  // impossible filename, refusing EVERY push from a clean post-release tree. The
+  // recurrence is documented in the repo itself: upgrades/side-effects/1.3.492.md
+  // and 1.3.802.md are hand-written placeholders whose own text says they exist
+  // only to satisfy this check.
+
+  function writeFrozenGuideClaimingAFix(version: string) {
+    fs.writeFileSync(
+      path.join(scratch, 'upgrades', `${version}.md`),
+      [
+        `# Upgrade Guide — v${version}`,
+        '',
+        '## What Changed',
+        '',
+        'Fixes a bug in the scheduler.',
+        '',
+        '## Evidence',
+        '',
+        'Reproduced first: with the old code the scheduler skipped every job whose cron',
+        'expression contained a step value, so a job set to every 15 minutes never ran at',
+        'all. Observed 0 runs across a 2 hour window. After the fix the same job ran 8',
+        'times in the same window. Reverting the one-line change reproduced the failure',
+        'again, which is how the cause was confirmed rather than assumed.',
+        '',
+        '## What to Tell Your User',
+        '',
+        'Your agent picked up a small repair. Nothing changes about how it talks to you.',
+        '',
+        '## Summary of New Capabilities',
+        '',
+        '| Capability | How to Use |',
+        '|-----------|-----------|',
+        '| Repair | automatic |',
+        '',
+      ].join('\n'),
+    );
+  }
+
+  it('ACCEPTS a post-release-cut tree with no fragment and no version-named artifact', () => {
+    // package.json is pinned to 0.28.999 by beforeEach; the frozen guide for THAT
+    // version is what the cut leaves behind.
+    writeFrozenGuideClaimingAFix('0.28.999');
+    // Deliberately NO upgrades/next/*.md and NO upgrades/side-effects/0.28.999.md.
+    expect(fs.existsSync(path.join(scratch, 'upgrades', 'side-effects', '0.28.999.md'))).toBe(false);
+
+    const { status, stdout } = runGate();
+    expect(status).toBe(0);
+    expect(stdout).not.toContain('side-effects review artifact');
+  });
+
+  it('does not demand a version-named side-effects artifact even when one has never existed', () => {
+    writeFrozenGuideClaimingAFix('0.28.999');
+
+    const { stdout } = runGate();
+    // The old message named upgrades/side-effects/<version>.md as the remedy,
+    // which is what taught three placeholder files into the repo. Assert the
+    // gate never asks for a version-named artifact again. (The frozen guide's own
+    // FILENAME may still appear in unrelated content-validation messages — what
+    // must not appear is the side-effects artifact demand.)
+    expect(stdout).not.toContain('side-effects review artifact');
+    expect(stdout).not.toContain('side-effects/0.28.999.md');
+  });
+
+  it('STILL refuses an in-flight fix-claiming fragment with no fresh side-effects artifact', () => {
+    // The check is not removed — it is scoped to the notes this push is actually
+    // shipping. With a fragment present and no artifact, it must still refuse,
+    // otherwise this fix would have traded a false positive for a false negative.
+    fs.writeFileSync(
+      path.join(scratch, 'upgrades', 'next', 'a-real-fix.md'),
+      [
+        '# Upgrade Guide — vNEXT',
+        '',
+        '<!-- bump: patch -->',
+        '',
+        '## What Changed',
+        '',
+        'Fixes a crash in the relay.',
+        '',
+        '## Evidence',
+        '',
+        'Reproduced the crash, applied the fix, confirmed it no longer reproduces.',
+        '',
+        '## What to Tell Your User',
+        '',
+        'Your agent no longer drops messages when the relay restarts.',
+        '',
+        '## Summary of New Capabilities',
+        '',
+        '| Capability | How to Use |',
+        '|-----------|-----------|',
+        '| Repair | automatic |',
+        '',
+      ].join('\n'),
+    );
+    // side-effects dir exists but is empty — no fresh artifact.
+
+    const { status, stdout } = runGate();
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('side-effects review artifact was written in the last 24h');
+    // And the remedy it names must be the slug form, never a version-named file.
+    expect(stdout).toContain('upgrades/side-effects/<slug>.md');
+  });
 });

--- a/upgrades/next/prepush-gate-frozen-guide.md
+++ b/upgrades/next/prepush-gate-frozen-guide.md
@@ -1,0 +1,52 @@
+<!-- internal-only -->
+
+## What Changed
+
+Fixes the pre-push gate's side-effects-artifact check, which refused **every push from a clean
+post-release tree** and named an impossible remedy when it did.
+
+After a release cut there are no in-flight release-note fragments, so the check fell back to
+`upgrades/<version>.md` — the guide for the version that already shipped — and demanded
+`upgrades/side-effects/<version>.md`. Side-effects artifacts are named per change slug; the release
+flow has never produced a version-named one, so the demand could not be satisfied.
+
+The check is now scoped to the notes the push is actually shipping. With no notes in flight there is
+nothing to check and it stays silent. With notes in flight it fires exactly as before.
+
+## Evidence
+
+**Three observed recurrences, self-documented in the repo.** `upgrades/side-effects/1.3.492.md` and
+`1.3.802.md` are hand-written placeholders whose own text says they exist only to satisfy this
+check; the second calls itself "its second observed recurrence". Today (v1.3.1009) was the third,
+and it refused a sibling branch before diagnosis.
+
+Both placeholders claim the gap "remains logged in the framework-issues ledger under dedupKey
+`pre-push-gate-versioned-artifact-fallback`". It is not. Queried four ways — unfiltered,
+`?status=fixed`, `?bucket=instar-integration-gap`, `?framework=instar` — the ledger holds 163 issues
+and zero matches, with no dedupKey containing `release`, `artifact`, or `push`. Declared tracked,
+never tracked, recurred. It is registered for real with this change.
+
+**Verified by reverting, because a passing test proves nothing:**
+
+| gate | result |
+|---|---|
+| OLD code, new tests | **3 failed** \| 16 passed (19) |
+| NEW code | **19 passed** (19) |
+
+Plus a live run against the real repo in its actual post-cut state: errors before, warnings only
+after.
+
+**Nothing is weakened, and this was the load-bearing question.** Per-change enforcement still lives
+in the pre-COMMIT gate (which refuses in-scope staged files lacking an ELI16 + side-effects artifact,
+and blocked this very change twice while it was being written); check 3b still refuses a
+release-relevant push with no fragment; and check 5 still fires when in-flight notes claim a fix with
+no fresh artifact — asserted by a dedicated negative-control test, since the easy mistake here is
+trading a false positive for a false negative.
+
+## What to Tell Your User
+
+None — internal change (no user-facing surface).
+
+## Summary of New Capabilities
+
+None — internal change (no user-facing surface).

--- a/upgrades/side-effects/prepush-gate-frozen-guide.md
+++ b/upgrades/side-effects/prepush-gate-frozen-guide.md
@@ -1,0 +1,78 @@
+# Side-effects review — pre-push gate stops validating the frozen versioned guide
+
+**Change:** `scripts/pre-push-gate.js` check 5 (side-effects-artifact requirement) is scoped to
+in-flight release notes. It no longer falls back to `upgrades/<version>.md` — the guide for the
+version that already shipped.
+
+**Tier:** 1. One local developer gate. No `src/` surface, no route, no config, no persisted state,
+no migration. Not run in CI (`if (!process.env.CI)`), so it cannot change what merges — only what a
+developer can push from their own machine.
+
+## The defect, with its recurrence record
+
+Post-release-cut the tree has `upgrades/<version>.md` (frozen), no fragments, and no
+`upgrades/side-effects/<version>.md`. That last file is one the release flow never creates: artifacts
+are named per change slug. The fallback demanded it anyway, so **every push from a clean
+post-release tree was refused**.
+
+Three observed recurrences, all self-documented in the repo:
+
+| version | evidence |
+|---|---|
+| v1.3.492 | `upgrades/side-effects/1.3.492.md` — a hand-written placeholder that says so |
+| v1.3.802 | `upgrades/side-effects/1.3.802.md` — same, and calls itself "its second observed recurrence" |
+| v1.3.1009 | today; refused this branch's sibling PR before diagnosis |
+
+Both placeholders state the gap "remains logged in the framework-issues ledger under dedupKey
+`pre-push-gate-versioned-artifact-fallback`". **It is not.** Queried four ways
+(`GET /framework-issues` unfiltered, `?status=fixed`, `?bucket=instar-integration-gap`,
+`?framework=instar`): 163 issues, zero matches, and no dedupKey in the store containing `release`,
+`artifact`, or `push`. The tracking claim was hollow, which is why it recurred a third time. The
+issue is registered for real as part of this change.
+
+## What is NOT weakened — the load-bearing question
+
+Removing a check is the risky half of this. Three separate enforcement points remain:
+
+1. **`scripts/instar-dev-precommit.js` — untouched.** This is the real per-change enforcement: it
+   refuses a COMMIT whose in-scope staged files lack an ELI16 doc and a side-effects artifact, and
+   it verifies the artifact's sha against the decision trace. It blocked this very change twice
+   while it was being written.
+2. **Check 3b — untouched.** A push with release-relevant files and no fragment is still refused,
+   with an actionable remedy (`add upgrades/next/<slug>.md`).
+3. **Check 5 itself — still fires, scoped.** With in-flight notes claiming a fix and no fresh
+   artifact, it refuses exactly as before. Test:
+   `STILL refuses an in-flight fix-claiming fragment with no fresh side-effects artifact`.
+
+The narrowed case — "no in-flight notes, frozen guide claims a fix, no version-named artifact" — was
+never a real signal. It fired on a release that had already shipped and already been reviewed.
+
+## Blast radius
+
+A developer can now push from a clean post-release tree without hand-writing a placeholder. That is
+the entire behavioural change. Nothing in CI, publishing, or runtime reads this script.
+
+**Residual risk:** if the release process ever DID start producing version-named artifacts and
+someone relied on this check to enforce that, this would silently stop enforcing it. Judged
+acceptable: no such producer exists, and the 37 version-named artifacts already in the repo are
+release rollups and placeholders, not a maintained convention.
+
+## Verification
+
+Verified by REVERTING, because a passing test proves nothing:
+
+```
+against the OLD gate:  3 failed | 16 passed (19)
+  × ACCEPTS a post-release-cut tree with no fragment and no version-named artifact
+  × does not demand a version-named side-effects artifact even when one has never existed
+  × STILL refuses an in-flight fix-claiming fragment with no fresh side-effects artifact
+against the NEW gate:  19 passed (19)
+```
+
+Plus a live run against the real repo in its actual post-cut state (v1.3.1009, no fragments): errors
+before, warnings only after.
+
+## Rollback
+
+`git revert`. The gate returns to refusing every clean post-release push, and the next person writes
+`upgrades/side-effects/<version>.md` by hand for the fourth time.


### PR DESCRIPTION
## ELI16 — a gate refused every push, and told everyone to fix it the wrong way

There is a check that runs before code is pushed. Its job is: if the release notes say this ships a
fix, make sure someone wrote a review of what that fix might break. Sensible.

But when there were no release notes in flight — the normal state right after a release goes out —
it fell back to checking the notes for the release that had **already shipped**, and demanded a
review file named after that version number. That file never exists: review files are named after
the change, not the version, and the release process has never created a version-named one.

So it asked for something that cannot be produced, on a release already shipped and already
reviewed, on **every push from a clean tree**. And because the message named that impossible file as
the remedy, three separate times someone hand-wrote it. Those placeholder files are still in the
repo, and two of them say in their own text that they exist only to satisfy this check.


## What was broken

There is a check that runs before code is pushed. Its job is: *if the release notes say this ships a
fix, make sure someone wrote a review of what that fix might break.*

Sensible. But when there were no release notes in flight — the normal state right after a release
goes out — it fell back to checking the notes for the release that had **already shipped**. And it
demanded a review file named after that version number.

That file never exists. Review files are named after the change, not after the version, and the
release process has never created a version-named one. So the check asked for something that cannot
be produced, on a release that had already shipped and already been reviewed, and it did this on
**every push from a clean tree**.

## Why this is worse than a false alarm

A false alarm you can ignore. This one came with instructions.

The message said "no matching side-effects review artifact found" — so three separate times, someone
did the obvious thing and hand-wrote the missing file. Those files are still in the repo, and two of
them openly say what they are: *"This file exists so the repo state matches the gate's documented
post-release expectation."*

That is a gate teaching people to write junk to satisfy it. The junk then looks like evidence of
review, when it is evidence of a workaround.

Both of those files also claim the underlying problem "remains logged" in an issue ledger, under a
specific tracking key. It is not there. The ledger holds 163 issues and none of them is this one. So
the problem was declared tracked, was not tracked, and recurred a third time today — which is exactly
how a thing recurs.

## What changed

The check now only runs against release notes **this push is actually shipping**. If there are no
notes in flight, there is nothing for it to check, and it says nothing.

Nothing was weakened, and this is the part worth checking rather than taking on trust:

- The per-change requirement still lives where it always did — the check that runs when you
  **commit**, which refuses any in-scope file without its plain-English summary and its
  side-effects review. That one is untouched.
- A separate check still refuses a push that changes shipping code without adding release notes at
  all, and it names the actual fix.
- And with notes in flight, the review requirement still fires. There is a test for exactly that,
  because the easy mistake here would be to trade a false alarm for a missed one.

The message it prints when it does fire now names the right remedy — a review file named after the
change — and says explicitly not to create a version-named file.

## How I know it works

By breaking it on purpose. The three new tests were run against the **old** code first, and all
three failed. Then against the new code, where all nineteen pass. A test that has never failed is a
test that has never proved anything.
