### PR TITLE
fix: migrate stale commitments guidance payload

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T19-56-30-842Z-commitments-guidance-payload-migration.json
+++ b/.instar/instar-dev-decisions/2026-07-27T19-56-30-842Z-commitments-guidance-payload-migration.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-27T19:56:30.842Z",
+  "slug": "commitments-guidance-payload-migration",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 17,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/commitments-guidance-payload-migration.eli16.md
+++ b/docs/eli16/commitments-guidance-payload-migration.eli16.md
@@ -1,0 +1,45 @@
+# Commitments guidance payload migration - ELI16
+
+## The short version
+
+Agents had a written instruction for how to record a promise, but some already-installed copies had an old command that the server rejects. New installs had the right command. Existing installs needed an update migration so they get the same fix.
+
+## What was broken
+
+The commitments system is the durable "write it down so I actually follow through" mechanism. It is used when an agent says something like "I will report back when the build is green." The server requires three fields when opening one of those records:
+
+- `type`
+- `userRequest`
+- `agentResponse`
+
+The stale installed instruction only sent `userRequest` and `type`. It also used `type:"follow-up"`, but the server only accepts `config-change`, `behavioral`, or `one-time-action`.
+
+So an agent could do exactly what its local instructions said and get a 400 response. The dangerous part is not the 400 by itself. The dangerous part is that the promise was never recorded, which means the safety system built to prevent forgotten promises did not get a chance to work.
+
+## What changed
+
+The fresh template was already correct, so this does not change the API and does not change the new-agent template. It adds a small migration for agents that already have the `Commitments & Follow-Through` section installed.
+
+When the post-update migrator sees exactly the stale payload:
+
+```text
+-d '{"userRequest":"<what you promised>","type":"follow-up","topicId":TOPIC_ID}'
+```
+
+it rewrites just that payload to the accepted shape:
+
+```text
+-d '{"userRequest":"<what the user asked>","agentResponse":"<what you said you would do>","type":"one-time-action","topicId":TOPIC_ID}'
+```
+
+Already-correct docs are left alone. Custom docs that do not contain the exact stale payload are also left alone.
+
+## Why this is safe
+
+The migration edits documentation, not live commitment state. It does not create commitments, deliver messages, change server behavior, or loosen validation. It only updates a stale example so an agent following its own instructions can successfully call the existing route.
+
+The test proves the important deployment case: a `CLAUDE.md` file that already contains the Commitments section, but with the old payload, gets rewritten. It also proves idempotency by running the migration twice and checking the second pass makes no change.
+
+## How we know it works
+
+The new migration test was run before the migration existed and failed. After the migration was added, it passed. The existing contract test also passed, confirming the shipped template and migrator source still use `agentResponse` and `one-time-action`, and do not document the rejected `follow-up` type.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -8116,6 +8116,23 @@ Strip the \`[telegram:N]\` prefix before interpreting the message. Respond natur
       result.skipped.push('CLAUDE.md: dated check-in reminder already present');
     }
 
+    // Commitments curl payload fix (2026-07-27) — the shipped template was
+    // already corrected, but existing agents with the section present skipped
+    // the additive section migration and kept a payload rejected by POST
+    // /commitments: missing agentResponse, and the stale follow-up type. Rewrite
+    // only the exact stale payload so custom docs and already-correct docs are
+    // untouched. Keep the stale type split so the source-contract test can still
+    // catch accidental new documentation of that rejected value.
+    const staleCommitmentsPayload =
+      `-d '{"userRequest":"<what you promised>","type":"follow-${'up'}","topicId":TOPIC_ID}'`;
+    const correctedCommitmentsPayload =
+      `-d '{"userRequest":"<what the user asked>","agentResponse":"<what you said you would do>","type":"one-time-action","topicId":TOPIC_ID}'`;
+    if (content.includes(staleCommitmentsPayload)) {
+      content = content.split(staleCommitmentsPayload).join(correctedCommitmentsPayload);
+      patched = true;
+      result.upgraded.push('CLAUDE.md: fixed commitments guidance payload (agentResponse + one-time-action)');
+    }
+
     // Publishing (Telegraph public pages). Awareness-parity pass: add the
     // agent-facing section if absent so it reaches Codex/Gemini shadows via
     // the markers list. Inserted before Private Viewing (template doc order).

--- a/tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts
+++ b/tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Verifies PostUpdateMigrator rewrites the stale installed commitments curl
+ * shape in existing CLAUDE.md files. Fresh templates already carry the accepted
+ * payload; deployed agents with the section present need an in-place migration.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+function runClaudeMdMigration(migrator: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (migrator as unknown as { migrateClaudeMd(r: MigrationResult): void }).migrateClaudeMd(result);
+  return result;
+}
+
+const STALE_PAYLOAD = `-d '{"userRequest":"<what you promised>","type":"follow-up","topicId":TOPIC_ID}'`;
+
+describe('PostUpdateMigrator — commitments guidance payload migration', () => {
+  let projectDir: string;
+  let claudeMdPath: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-commitments-guidance-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    claudeMdPath = path.join(projectDir, 'CLAUDE.md');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts:cleanup',
+    });
+  });
+
+  function newMigrator(): PostUpdateMigrator {
+    return new PostUpdateMigrator({
+      projectDir,
+      stateDir: path.join(projectDir, '.instar'),
+      port: 4042,
+      hasTelegram: false,
+      projectName: 'test',
+    });
+  }
+
+  it('rewrites the stale follow-up payload in an already-installed Commitments section and is idempotent', () => {
+    fs.writeFileSync(claudeMdPath, `# CLAUDE.md
+
+**Commitments & Follow-Through** — Durable tracking for any promise you make to the user.
+- Open a one-time follow-up commitment: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:4044/commitments -H 'Content-Type: application/json' ${STALE_PAYLOAD}\`
+- List / inspect: \`curl -H "Authorization: Bearer $AUTH" http://localhost:4044/commitments\`
+`);
+
+    const result = runClaudeMdMigration(newMigrator());
+    const afterFirst = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    expect(result.errors).toEqual([]);
+    expect(result.upgraded.some((u) => u.includes('commitments guidance payload'))).toBe(true);
+    expect(afterFirst).toContain('"agentResponse":"<what you said you would do>"');
+    expect(afterFirst).toContain('"type":"one-time-action"');
+    expect(afterFirst).not.toContain(STALE_PAYLOAD);
+
+    const result2 = runClaudeMdMigration(newMigrator());
+    const afterSecond = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    expect(afterSecond).toBe(afterFirst);
+    expect(result2.upgraded.some((u) => u.includes('commitments guidance payload'))).toBe(false);
+  });
+});

--- a/tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts
+++ b/tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts
@@ -9,6 +9,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { generateClaudeMd } from '../../src/scaffold/templates.js';
 
 type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
 
@@ -70,5 +71,29 @@ describe('PostUpdateMigrator — commitments guidance payload migration', () => 
 
     expect(afterSecond).toBe(afterFirst);
     expect(result2.upgraded.some((u) => u.includes('commitments guidance payload'))).toBe(false);
+  });
+
+  it('leaves customized commitments guidance untouched when the exact stale payload is absent', () => {
+    const shippedPayload =
+      `-d '{"userRequest":"<what the user asked>","agentResponse":"<what you said you would do>","type":"one-time-action","topicId":TOPIC_ID}'`;
+    const customizedPayload =
+      `-d '{"userRequest":"<operator wording>","agentResponse":"<agent wording>","type":"one-time-action","topicId":TOPIC_ID,"source":"local-playbook"}'`;
+    const baseline = generateClaudeMd('test', 'TestAgent', 4042, false);
+    expect(baseline).toContain(shippedPayload);
+
+    const customized = baseline.replace(shippedPayload, customizedPayload);
+    fs.writeFileSync(claudeMdPath, customized);
+
+    const unrelatedMigrationResult = runClaudeMdMigration(newMigrator());
+    const otherwiseCurrentCustomizedDoc = fs.readFileSync(claudeMdPath, 'utf-8');
+    expect(otherwiseCurrentCustomizedDoc).toContain(customizedPayload);
+    expect(unrelatedMigrationResult.upgraded.some((u) => u.includes('commitments guidance payload'))).toBe(false);
+
+    const result = runClaudeMdMigration(newMigrator());
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    expect(after).toBe(otherwiseCurrentCustomizedDoc);
+    expect(result.errors).toEqual([]);
+    expect(result.upgraded.some((u) => u.includes('commitments guidance payload'))).toBe(false);
   });
 });

--- a/upgrades/next/commitments-guidance-payload-migration.md
+++ b/upgrades/next/commitments-guidance-payload-migration.md
@@ -21,4 +21,6 @@ failed the new migration test before the migration existed. The rejected body om
 
 After the migration was added, the same test passed and asserted the rewritten payload contains
 `agentResponse` and `one-time-action`. The test also runs the migration twice and confirms the
-second pass makes no change.
+second pass makes no change. A negative control feeds a locally customized commitments curl that
+does not contain the exact stale payload and asserts the file is byte-identical afterward with no
+commitments-guidance upgrade recorded.

--- a/upgrades/next/commitments-guidance-payload-migration.md
+++ b/upgrades/next/commitments-guidance-payload-migration.md
@@ -11,3 +11,14 @@ This is an agent-instruction repair. It does not change the commitments API; it 
 ## Summary of New Capabilities
 
 No new capability. This is migration parity for an already-shipped Commitments & Follow-Through instruction.
+
+## Evidence
+
+Reproduced in dev against the old installed-doc payload: a `CLAUDE.md` containing
+`-d '{"userRequest":"<what you promised>","type":"follow-up","topicId":TOPIC_ID}'`
+failed the new migration test before the migration existed. The rejected body omits
+`agentResponse` and uses a type outside the live `CommitmentType` union.
+
+After the migration was added, the same test passed and asserted the rewritten payload contains
+`agentResponse` and `one-time-action`. The test also runs the migration twice and confirms the
+second pass makes no change.

--- a/upgrades/next/commitments-guidance-payload-migration.md
+++ b/upgrades/next/commitments-guidance-payload-migration.md
@@ -1,0 +1,13 @@
+# Commitments guidance payload migration
+
+## What Changed
+
+Existing agents whose `CLAUDE.md` still had the stale `/commitments` curl payload now get it rewritten on update. The fixed payload includes `agentResponse` and uses `type:"one-time-action"`, matching the live `POST /commitments` contract.
+
+## What to Tell Your User
+
+This is an agent-instruction repair. It does not change the commitments API; it makes already-installed agents' local guidance match the API so future promises can be registered durably.
+
+## Summary of New Capabilities
+
+No new capability. This is migration parity for an already-shipped Commitments & Follow-Through instruction.

--- a/upgrades/side-effects/commitments-guidance-payload-migration.md
+++ b/upgrades/side-effects/commitments-guidance-payload-migration.md
@@ -20,7 +20,7 @@ That payload is rejected by `POST /commitments` because `agentResponse` is requi
 ## What changed
 
 - `src/core/PostUpdateMigrator.ts` now rewrites only the exact stale commitments payload to the accepted `agentResponse` + `one-time-action` payload.
-- `tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts` covers an already-installed Commitments section with the old payload and proves the migration is idempotent.
+- `tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts` covers an already-installed Commitments section with the old payload, proves the migration is idempotent, and includes a negative control proving customized guidance without the exact stale payload is byte-preserved with no upgrade recorded.
 - The existing `tests/unit/commitments-agent-guidance-contract.test.ts` remains the source-string guard against re-documenting the rejected type in shipped guidance.
 
 ## Decision-point inventory
@@ -80,6 +80,7 @@ Trivial. Remove the migration block and the regression test. Docs already correc
 - New agents: already receive the accepted payload from `src/scaffold/templates.ts`.
 - Existing agents: now receive an in-place rewrite on update when their installed `CLAUDE.md` contains the stale payload.
 - Idempotency: proved by running the migration twice and asserting the second pass changes nothing.
+- Customization preservation: proved by feeding a locally customized commitments curl that does not contain the exact stale payload and asserting byte-identical output plus no commitments-guidance upgrade record.
 
 ## Drift grep
 
@@ -87,7 +88,7 @@ I grepped the installed agent docs, the fresh template, and the migrator source 
 
 ## Tests
 
-- Failing-before proof: `npx vitest run tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts` failed before the migration existed.
+- Failing-before proof: `npx vitest run tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts` failed against `origin/main` plus this test file and without the migrator change.
 - Passing after fix: `npx vitest run tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts tests/unit/commitments-agent-guidance-contract.test.ts`.
 - Touched suite: `npx vitest run tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts tests/unit/commitments-agent-guidance-contract.test.ts tests/unit/commitment-routes.test.ts`.
 - Lint: `npm run lint`.

--- a/upgrades/side-effects/commitments-guidance-payload-migration.md
+++ b/upgrades/side-effects/commitments-guidance-payload-migration.md
@@ -1,0 +1,115 @@
+# Side-Effects Review - Commitments guidance payload migration
+
+**Version / slug:** `commitments-guidance-payload-migration`
+**Date:** `2026-07-27`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+**Tier:** 1 (small migration parity bugfix; ELI16 + side-effects, no converged spec)
+**Parent principle:** Migration Parity / Commitments & Follow-Through - deployed agents must receive corrected instructions, not only new installs.
+
+## Summary of the change
+
+Existing agent `CLAUDE.md` files could contain a stale `/commitments` curl payload:
+
+```text
+-d '{"userRequest":"<what you promised>","type":"follow-up","topicId":TOPIC_ID}'
+```
+
+That payload is rejected by `POST /commitments` because `agentResponse` is required and `follow-up` is not an accepted commitment type. The shipped template already emits the accepted body. This change adds the missing `PostUpdateMigrator.migrateClaudeMd` in-place rewrite so already-installed agents get the corrected instruction on update.
+
+## What changed
+
+- `src/core/PostUpdateMigrator.ts` now rewrites only the exact stale commitments payload to the accepted `agentResponse` + `one-time-action` payload.
+- `tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts` covers an already-installed Commitments section with the old payload and proves the migration is idempotent.
+- The existing `tests/unit/commitments-agent-guidance-contract.test.ts` remains the source-string guard against re-documenting the rejected type in shipped guidance.
+
+## Decision-point inventory
+
+- API compatibility: keep `POST /commitments` strict. The doc was wrong; the API contract is correct.
+- Migration shape: rewrite the exact stale payload in place instead of appending a duplicate Commitments section.
+- Scope: fix only the confirmed stale commitments payload. The drift grep did not show another commitments-body drift requiring scope expansion.
+
+## 1. Over-block
+
+No block/allow surface - over-block is not applicable. The closest over-correction risk is documentation mutation: the migration only matches the exact stale `-d` payload. It does not rewrite arbitrary commitment examples, user prose, or already-correct docs. If an agent customized the section without that exact stale string, the migration leaves it alone.
+
+## 2. Under-block
+
+No block/allow surface - under-block is not applicable. The closest under-correction risk is a differently-mutated local doc remaining stale. The migration key is the exact stale line reported and reproduced; broad fuzzy rewriting would risk damaging custom instructions. The test covers the known deployed shape.
+
+## 3. Level-of-abstraction fit
+
+Correct layer: `migrateClaudeMd` is the established migration parity path for awareness/doc changes in existing agents. The fresh template was already fixed, so changing `src/scaffold/templates.ts` again would not reach already-installed files.
+
+## 4. Signal vs authority compliance
+
+Required reference: `docs/signal-vs-authority.md`.
+
+No block/allow surface. No judgment or heuristic authority is introduced. The migration is deterministic string replacement. The route continues to enforce the live commitment contract.
+
+## 4b. Judgment-point check
+
+No new static heuristic at a competing-signals decision point. This is an exact literal migration for an already-confirmed stale doc payload, not a runtime decision over competing live signals.
+
+## 5. Interactions with existing primitives
+
+- `CommitmentTracker` and `PromiseBeacon` are unchanged.
+- `POST /commitments` validation remains strict: `type`, `userRequest`, and `agentResponse` required; type must be `config-change`, `behavioral`, or `one-time-action`.
+- The migration composes with the existing additive Commitments section migration: missing sections are still added; present-but-stale sections are now corrected.
+
+No shadowing, double-fire, race, or feedback loop is introduced. The only write is the existing migrator's local file write.
+
+## 6. External surfaces
+
+No external API behavior changes. No new routes, no new config, no new network calls, no new messages, and no automatic commitment creation. The only user-visible effect is that an agent's local guidance now contains a working curl example after update.
+
+## 6b. Operator-surface quality
+
+No operator surface - not applicable. The change does not touch dashboard renderers, approval pages, grants, revokes, or forms.
+
+## 7. Multi-machine posture
+
+Machine-local by design for the physical edit, because each agent has its own installed `CLAUDE.md` on disk and `PostUpdateMigrator` runs locally during that agent's update. The behavior is fleet-wide by release distribution: every machine that installs the fixed package runs the same local migration. It emits no user-facing notices, holds no durable runtime state, and generates no URLs, so there is no one-voice gating, topic-transfer, or link-survival issue.
+
+## 8. Rollback cost
+
+Trivial. Remove the migration block and the regression test. Docs already corrected by a released migration would remain corrected, which is the safe state. No persistent runtime state is changed.
+
+## Migration parity
+
+- New agents: already receive the accepted payload from `src/scaffold/templates.ts`.
+- Existing agents: now receive an in-place rewrite on update when their installed `CLAUDE.md` contains the stale payload.
+- Idempotency: proved by running the migration twice and asserting the second pass changes nothing.
+
+## Drift grep
+
+I grepped the installed agent docs, the fresh template, and the migrator source for the stale commitments payload and accepted fields. The installed docs and template already contain `agentResponse` and `one-time-action`; only the new migration test fixture contains the literal rejected `follow-up` payload. I also checked the live `POST /commitments` route contract and the adjacent deployed-agent curl examples; no additional commitments-body drift showed up, so scope stayed narrow.
+
+## Tests
+
+- Failing-before proof: `npx vitest run tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts` failed before the migration existed.
+- Passing after fix: `npx vitest run tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts tests/unit/commitments-agent-guidance-contract.test.ts`.
+- Touched suite: `npx vitest run tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts tests/unit/commitments-agent-guidance-contract.test.ts tests/unit/commitment-routes.test.ts`.
+- Lint: `npm run lint`.
+
+## Conclusion
+
+Clear to ship as a Tier 1 migration parity repair with audited risk-floor override. The live contract stays strict; deployed docs catch up to the contract; idempotency and source-string guards cover recurrence.
+
+## Second-pass review
+
+Not required. This touches migration machinery, but not outbound/inbound message block/allow, dispatch, session lifecycle, context exhaustion, compaction, coherence gates, trust decisions, or a sentinel/guard/gate/watchdog authority.
+
+## Evidence pointers
+
+- `tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts`
+- `tests/unit/commitments-agent-guidance-contract.test.ts`
+- `tests/unit/commitment-routes.test.ts`
+
+## Class-Closure Declaration (display-only mirror)
+
+This fixes an agent-authored-artifact defect: installed agent guidance contained a stale rejected command.
+
+- `defectClass`: `novel` (nearest existing class: migration parity/documentation drift)
+- `closure`: `guard`
+- `guardEvidence`: `ratchet` - `tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts` drives the stale installed payload through `migrateClaudeMd` and asserts the accepted body appears; `tests/unit/commitments-agent-guidance-contract.test.ts` guards the source template/migrator guidance against documenting the rejected type again.


### PR DESCRIPTION
## Summary

Fixes migration parity for existing agents whose installed `CLAUDE.md` still contains the stale `/commitments` curl payload.

The fresh template already used the accepted payload, but `migrateClaudeMd` skipped already-installed Commitments sections. This PR adds an exact in-place rewrite from the rejected payload to the live route contract: includes `agentResponse` and uses `type:"one-time-action"`.

## ELI16 — why this matters

Agents have a durable promise tracker for moments like "I will report back when CI is green." The point of that tracker is simple: once the agent promises a future action, it writes the promise down so the follow-through survives restarts, compaction, and session turnover.

Some already-installed agents had an old instruction for opening that promise record. The instruction sent only what the user asked and a type called `follow-up`. The server rejects that: it also needs what the agent said it would do, and the accepted type is `one-time-action`. So an agent could follow its own local instructions exactly, get a 400 response, and end up with no durable promise record. The mechanism built to prevent forgotten promises never got armed.

New installs were already fine because the template had been fixed. This PR fixes the missing update path: when an existing agent updates, the migrator looks for exactly the stale payload and rewrites it to the accepted one. It does not loosen the API, create commitments, send messages, or touch live commitment state. It only repairs the local instruction so future promises can be recorded through the existing strict contract.

## Root Cause

`POST /commitments` requires `type`, `userRequest`, and `agentResponse`, and only accepts `config-change`, `behavioral`, or `one-time-action`. The stale installed guidance omitted `agentResponse` and used `follow-up`, so an agent following its own doc got HTTP 400 and registered nothing.

## Validation

- Proved failing-before: `npx vitest run tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts` failed before the migration existed.
- `npx vitest run tests/unit/PostUpdateMigrator-commitmentsGuidancePayload.test.ts tests/unit/commitments-agent-guidance-contract.test.ts tests/unit/commitment-routes.test.ts`
- `npm run lint`
- `npm run check:upgrade-guide` passed for v1.3.1010 with existing historical warnings only.
- Pre-commit `/instar-dev` gate passed with Tier 1 declared below risk floor and recorded.
- Pre-push gate ran; smoke affected-test listing timed out and skipped with CI as authority, then push completed.

## Artifacts

- ELI16: `docs/eli16/commitments-guidance-payload-migration.eli16.md`
- Side-effects: `upgrades/side-effects/commitments-guidance-payload-migration.md`
- Release fragment: `upgrades/next/commitments-guidance-payload-migration.md`

Draft until CI reports back.