### PR TITLE
fix(memory): an apostrophe made every recall query throw

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T20-19-54-094Z-fts-apostrophe-strip.json
+++ b/.instar/instar-dev-decisions/2026-07-27T20-19-54-094Z-fts-apostrophe-strip.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T20:19:54.094Z",
+  "slug": "fts-apostrophe-strip",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 19,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/fts-apostrophe-strip.eli16.md
+++ b/docs/specs/fts-apostrophe-strip.eli16.md
@@ -1,0 +1,48 @@
+# An apostrophe made the agent's memory throw an error
+
+## What was broken
+
+The agent searches its own memory to check whether it already knows something. That search is fed
+the question exactly as it was asked — an ordinary English sentence.
+
+English sentences contain apostrophes. "the bot's messages", "what doesn't work", "that's the one".
+
+The search engine underneath treats an apostrophe as the character that opens a quoted string. So
+the moment a question contained one, the engine hit what looked to it like an unfinished quote and
+**threw a syntax error instead of searching**. Not a poor result — no result at all, and an error.
+
+Measured live against the running agent:
+
+- `why can a telegram bot not see another bot's messages` → **error**
+- the same question without the apostrophe → the correct memory, **ranked first**
+
+## Why it mattered more than it sounds
+
+This was fixed a day after two other memory-search repairs, and it undid part of them. Those
+repairs made the agent able to find a lesson from a natural-language question — which is the
+whole point, because the alternative is re-discovering things it already learned.
+
+But the meaning-based search runs the word-based search alongside it, so an error in the word-based
+half took the whole search down with it. **The character most likely to appear in a real question
+was the one that broke the search built to answer real questions.**
+
+## What changed
+
+One character added to the list of symbols already stripped out of a query before it reaches the
+search engine.
+
+The apostrophe now joins `* : " ^ { } ( ) . $ @ # ! ~ ? [ ]`, which were already removed for the
+same reason — they mean something to the engine and nothing to the person asking.
+
+**No search results are lost by removing it.** The engine already splits words at the apostrophe, so
+"bot's" and "bots" produce the same searchable words either way. Stripping it changes only whether
+the query is accepted at all.
+
+## How I know it works
+
+I broke it on purpose first. With the apostrophe left out of the strip list, the two new tests fail.
+With it in, all eighteen tests in that file pass, and seventy-six across the memory suites.
+
+The tests also assert something a stricter check might have missed: that the *word* survives. It
+would be easy to "fix" this by throwing away the whole term, which would stop the error and quietly
+lose the search. The tests require `bot` and `relay` to still be there afterwards.

--- a/src/memory/SemanticMemory.ts
+++ b/src/memory/SemanticMemory.ts
@@ -102,11 +102,28 @@ export interface SemanticMemoryCapabilityLeafKeyVault {
 /**
  * Strip FTS5 special syntax characters from a query.
  * Prevents query manipulation via AND, OR, NOT, NEAR, *, column filters.
+ *
+ * The apostrophe is in this set for a reason worth stating: FTS5 treats `'` as a
+ * STRING DELIMITER, so an ordinary English possessive or contraction — "bot's",
+ * "doesn't", "what's" — reaches the parser as an unterminated string and the whole
+ * query THROWS `fts5: syntax error near "'"`. Measured live against the running
+ * agent on 2026-07-27: `why can a telegram bot not see another bot's messages`
+ * errored on BOTH /semantic/search and /semantic/search/hybrid, while the identical
+ * query without the apostrophe returned the correct entity at rank 1.
+ *
+ * That throw is not confined to keyword search. `searchHybrid()` runs FTS5 alongside
+ * vector KNN, so the exception takes the whole hybrid call down with it — and
+ * PromptBuildRecall is fed the user's RAW message, where contractions are ordinary.
+ * So the character that breaks retrieval is one of the most common in the input.
+ *
+ * Stripping (rather than escaping) matches how every other special character here is
+ * handled, and costs nothing for retrieval: FTS5's unicode61 tokenizer already splits
+ * on the apostrophe, so `bot's` and `bots` produce the same tokens either way.
  */
 function sanitizeFts5Query(query: string): string {
   return query
     .replace(/\b(AND|OR|NOT|NEAR)\b/gi, '')
-    .replace(/[*:"^{}().$@#!~`?\\[\]]/g, '')
+    .replace(/['*:"^{}().$@#!~`?\\[\]]/g, '')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/tests/unit/semantic-memory-recall-query.test.ts
+++ b/tests/unit/semantic-memory-recall-query.test.ts
@@ -69,6 +69,28 @@ describe('buildFtsQueryVariants', () => {
     const v = buildFtsQueryVariants('Codey AND secrets');
     expect(v!.strict).not.toContain('AND');
   });
+
+  it('strips the apostrophe, which FTS5 reads as a string delimiter', () => {
+    // Measured live 2026-07-27 against the running agent: this exact query threw
+    // `fts5: syntax error near "'"` on BOTH /semantic/search and
+    // /semantic/search/hybrid, while the identical query without the apostrophe
+    // returned the correct entity at rank 1. Contractions and possessives are
+    // ordinary in the raw user message recall is fed, so the character that broke
+    // retrieval was one of the most common in the input.
+    const v = buildFtsQueryVariants("why can a telegram bot not see another bot's messages");
+    expect(v).not.toBeNull();
+    expect(v!.strict).not.toContain("'");
+    expect(v!.fallback ?? '').not.toContain("'");
+    // The word survives the strip — this must not silently drop the content term.
+    expect(v!.strict.toLowerCase()).toContain('bot');
+  });
+
+  it('strips apostrophes from contractions too, not only possessives', () => {
+    const v = buildFtsQueryVariants("what doesn't the relay deliver");
+    expect(v).not.toBeNull();
+    expect(v!.strict).not.toContain("'");
+    expect(v!.strict.toLowerCase()).toContain('relay');
+  });
 });
 
 describe('SemanticMemory.search — natural-language recall', () => {

--- a/upgrades/next/fts-apostrophe-strip.md
+++ b/upgrades/next/fts-apostrophe-strip.md
@@ -1,0 +1,43 @@
+## What Changed
+
+Fixes a crash in the agent's memory search: a question containing an apostrophe — an ordinary
+possessive or contraction — threw a syntax error instead of returning results.
+
+The search engine underneath reads `'` as the character that opens a quoted string, so
+"the bot's messages" or "what doesn't work" reached it as an unterminated quote. The apostrophe now
+joins the special characters already stripped from a query before it is run.
+
+This matters more than a stray character because the meaning-based search runs the word-based search
+alongside it, so the error took the whole search down — on the path the agent uses to check whether
+it already knows something.
+
+## Evidence
+
+Measured against the running agent (v1.3.1012, 2,930 stored entities):
+
+| query | result |
+|---|---|
+| `why can a telegram bot not see another bot's messages` | `fts5: syntax error near "'"` on both search routes |
+| the same query with the apostrophe removed | 20 results, the correct entity **ranked first** |
+
+Verified by reverting, because a passing test proves nothing: with the apostrophe left out of the
+strip list the two new tests FAIL (`2 failed | 16 passed`); with it in, **18 pass** in that file and
+**76** across five memory suites, with `tsc --noEmit` clean.
+
+No results are lost by stripping it — the engine already splits words at the apostrophe, so
+"bot's" and "bots" produce identical search terms. The tests assert the word itself SURVIVES, since
+the lazy way to stop the error would be to discard the whole term.
+
+## What to Tell Your User
+
+Your agent checks its own memory before answering, so it does not re-discover things it already
+worked out. That check was fed your question exactly as you asked it — and if your question happened
+to contain an apostrophe, which most natural questions do, the search failed outright instead of
+looking.
+
+It now handles those questions normally. Nothing about what it remembers has changed; it can simply
+reach it again.
+
+## Summary of New Capabilities
+
+- Memory search accepts questions containing apostrophes instead of failing on them.

--- a/upgrades/side-effects/fts-apostrophe-strip.md
+++ b/upgrades/side-effects/fts-apostrophe-strip.md
@@ -1,0 +1,63 @@
+# Side-effects review — strip the apostrophe from FTS5 queries
+
+**Change:** one character added to the existing strip class in `sanitizeFts5Query`
+(`src/memory/SemanticMemory.ts:106`): `'` joins `* : " ^ { } ( ) . $ @ # ! ~ ? \ [ ]`.
+
+**Tier:** 1. One character in one pure function. No route, no config, no persisted state, no
+migration, no schema. Rollback is removing the character.
+
+## The defect, measured live
+
+FTS5 reads `'` as a string delimiter, so an ordinary possessive or contraction reaches the parser as
+an unterminated string and the query THROWS. Against the running agent (v1.3.1012, 2,930 entities):
+
+| query | result |
+|---|---|
+| `why can a telegram bot not see another bot's messages` | `fts5: syntax error near "'"` on **both** `/semantic/search` and `/semantic/search/hybrid` |
+| the same query without the apostrophe | 20 hits, `Telegram Bot Visibility Limit` at **rank 1** |
+
+**The throw is not confined to keyword search.** `searchHybrid()` runs FTS5 alongside vector KNN, so
+the exception takes the hybrid call down with it — and `PromptBuildRecall` is fed the user's RAW
+message. PR #1683 had just made recall prefer the hybrid path; this defect could take that path out
+on any question containing a contraction.
+
+## Why STRIP rather than escape
+
+Consistency and cost. Every other special character here is stripped, not escaped, and FTS5's
+`unicode61` tokenizer already splits on the apostrophe — so `bot's` and `bots` produce identical
+tokens. Stripping changes only whether the query PARSES, never what it can match.
+
+Escaping (doubling the quote) would also work but introduces a second convention in a function whose
+whole contract is "remove characters that mean something to the engine and nothing to the asker".
+
+## Blast radius
+
+Queries that previously threw now return results. Queries that previously worked are unaffected —
+verified: 18 tests in the recall-query file and 76 across five memory suites pass unchanged, and the
+pre-existing operator-stripping and stopword tests are untouched.
+
+**Residual risk considered and rejected as immaterial:** a user searching for a literal apostrophe
+(e.g. an entity whose name contains one) loses that character from the query. Since the tokenizer
+already splits there, no stored entity is reachable *only* via a literal apostrophe, so nothing
+becomes unfindable.
+
+## Verification — by reverting, because a passing test proves nothing
+
+```
+apostrophe REMOVED from the strip class:  2 failed | 16 passed (18)
+  × strips the apostrophe, which FTS5 reads as a string delimiter
+  × strips apostrophes from contractions too, not only possessives
+apostrophe RESTORED:                      18 passed (18); 76 passed across 5 memory suites
+tsc --noEmit                              exit 0
+```
+
+The tests assert the word SURVIVES the strip (`bot`, `relay` still present), not merely that the
+apostrophe is gone. Without that, "fix" the error by dropping the whole term would pass.
+
+## A note on how this was found
+
+By reading the live surface after merging PR #1683, rather than by a test. I first ran the check
+against `/semantic/search` — the KEYWORD route — and was about to report that the vector fix
+under-delivered, because the correct entity did not appear. Reading the route showed
+`/semantic/search` calls `search()`, not `searchHybrid()`; the hybrid route ranks it **first**. The
+apostrophe error was the one real defect in that check, and it was on both.


### PR DESCRIPTION
## ELI16 — an apostrophe made the agent's memory throw an error instead of searching

The agent searches its own memory before answering, so it does not re-discover things it already
worked out. That search is fed the question exactly as it was asked — an ordinary English sentence.

English sentences contain apostrophes: "the bot's messages", "what doesn't work", "that's the one".

The search engine underneath treats an apostrophe as the character that opens a quoted string. So
the moment a question contained one, the engine saw an unfinished quote and **threw a syntax error
instead of searching**. Not a poor result — no result at all, and an error.

Measured live against the running agent (v1.3.1012, 2,930 stored entities):

- `why can a telegram bot not see another bot's messages` → **`fts5: syntax error near "'"`**
- the same question without the apostrophe → the correct memory, **ranked first**

This matters more than a stray character. The meaning-based search runs the word-based search
alongside it, so an error in the word-based half takes the whole search down — on the path recall
had *just* been switched to in #1683. The character most likely to appear in a real question was
the one that broke the search built to answer real questions.


## What was broken

The agent searches its own memory to check whether it already knows something. That search is fed
the question exactly as it was asked — an ordinary English sentence.

English sentences contain apostrophes. "the bot's messages", "what doesn't work", "that's the one".

The search engine underneath treats an apostrophe as the character that opens a quoted string. So
the moment a question contained one, the engine hit what looked to it like an unfinished quote and
**threw a syntax error instead of searching**. Not a poor result — no result at all, and an error.

Measured live against the running agent:

- `why can a telegram bot not see another bot's messages` → **error**
- the same question without the apostrophe → the correct memory, **ranked first**

## Why it mattered more than it sounds

This was fixed a day after two other memory-search repairs, and it undid part of them. Those
repairs made the agent able to find a lesson from a natural-language question — which is the
whole point, because the alternative is re-discovering things it already learned.

But the meaning-based search runs the word-based search alongside it, so an error in the word-based
half took the whole search down with it. **The character most likely to appear in a real question
was the one that broke the search built to answer real questions.**

## What changed

One character added to the list of symbols already stripped out of a query before it reaches the
search engine.

The apostrophe now joins `* : " ^ { } ( ) . $ @ # ! ~ ? [ ]`, which were already removed for the
same reason — they mean something to the engine and nothing to the person asking.

**No search results are lost by removing it.** The engine already splits words at the apostrophe, so
"bot's" and "bots" produce the same searchable words either way. Stripping it changes only whether
the query is accepted at all.

## How I know it works

I broke it on purpose first. With the apostrophe left out of the strip list, the two new tests fail.
With it in, all eighteen tests in that file pass, and seventy-six across the memory suites.

The tests also assert something a stricter check might have missed: that the *word* survives. It
would be easy to "fix" this by throwing away the whole term, which would stop the error and quietly
lose the search. The tests require `bot` and `relay` to still be there afterwards.
