### PR TITLE
fix(ci): the rollout-evidence ratchet guarded active only — composed carries the same evaluable criteria

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T21-10-50-727Z-rollout-evidence-ratchet-composed.json
+++ b/.instar/instar-dev-decisions/2026-07-27T21-10-50-727Z-rollout-evidence-ratchet-composed.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T21:10:50.727Z",
+  "slug": "rollout-evidence-ratchet-composed",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 31,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/rollout-evidence-ratchet-composed.eli16.md
+++ b/docs/specs/rollout-evidence-ratchet-composed.eli16.md
@@ -1,0 +1,61 @@
+# ELI16 — the guard now covers the whole class it names
+
+## The thing being protected
+
+Some features in this codebase ship switched off and "graduate" to on once a stated
+condition is met — usually a number read from a specific web address inside the agent.
+The document describing the feature names that address.
+
+If the address does not exist, the condition can never be checked. The feature then sits
+switched off forever, and nothing anywhere says so. It looks careful. It is actually stuck,
+and the difference is invisible.
+
+A guard was built earlier today that refuses the build when a feature's document names an
+address that does not exist. That guard works.
+
+## What was wrong with it
+
+It only looked at features marked `active`.
+
+Feature documents also come marked `composed`, which means the feature graduates alongside
+a bigger parent feature rather than on its own. It is easy to read that as "somebody else's
+problem, skip it".
+
+That reading is wrong, and I checked the documents rather than assuming. A `composed`
+feature still states its own graduation condition, still names an address to read it from,
+and in one case still carries numeric thresholds to compare against. If its address is
+missing, the condition is exactly as uncheckable, and the feature parks for exactly the
+same reason. The word describes *who owns graduation*, not *whether the evidence matters*.
+
+So the guard's scope was narrower than the problem it was built for. Three feature documents
+sat outside it.
+
+## What changed
+
+The guard now covers both kinds, and its summary line reports the two counts separately —
+so if someone later narrows it again, a number visibly drops to zero instead of the change
+passing unnoticed.
+
+## Why widening it is safe
+
+This is the part worth understanding, because widening a guard normally means more work
+forced on people.
+
+It does not here. The guard already has an escape hatch: a list of accepted exceptions,
+each of which must carry a written reason, and each of which is automatically deleted the
+moment its address starts working again. So a `composed` feature whose parent was genuinely
+abandoned does not have to be fixed — it has to be *declared*, with a reason, in a list that
+cleans itself up.
+
+Getting in requires evidence. Getting out happens by itself. Nobody is forced to fix
+anything; they are forced to say what they decided.
+
+## Honest limits
+
+Nothing was broken when I checked — all eight addresses currently work. This closes a hole
+in the guard rather than repairing an outage.
+
+And this is a correction to my own work from a few hours ago. The guard I wrote said in its
+own header that it had swept every relevant document. That was true of the scope I gave it,
+and the scope was smaller than the class. Checking once is not the same as checking
+everything, which is the discipline this whole effort is about.

--- a/scripts/lint-rollout-evidence-resolvable.js
+++ b/scripts/lint-rollout-evidence-resolvable.js
@@ -115,18 +115,39 @@ for (const file of specFiles()) {
   try { text = fs.readFileSync(file, 'utf8'); } catch { continue; }
   const fm = frontmatter(text);
   if (!fm) continue;
-  if (field(fm, 'rollout-disposition') !== 'active') continue;
+  // GUARDED DISPOSITIONS — 'active' AND 'composed'.
+  //
+  // 'composed' does NOT mean exempt. It names WHO owns graduation (the rollout rides
+  // an owner feature via rollout-owner-feature) rather than WHETHER the evidence
+  // matters. A composed spec still carries a real rollout-criteria naming a
+  // measurement, and often rollout-metrics-json thresholds against it. If its ref
+  // 404s the criterion is exactly as unevaluable as an active one's, and the feature
+  // parks for exactly the same reason.
+  //
+  // Widening is safe BECAUSE of assertion C rather than in spite of it: a composed
+  // spec whose owner feature was genuinely abandoned may legitimately carry a stale
+  // ref, and the shrink-only baseline is where that goes — with a stated reason,
+  // deleted automatically the moment the ref starts resolving. So this does not force
+  // anyone to FIX anything; it forces them to DECLARE. Entry needs evidence.
+  //
+  // EARNED (2026-07-27): this lint shipped guarding 'active' only, and its own header
+  // said "a sweep of all 5 rollout-active specs" — accurate for its scope, and the
+  // scope was narrower than the class it names. A single-pass sweep is incomplete by
+  // definition (Iterative Audit to Convergence); this is that standard applied to the
+  // guard itself, one pass later.
+  const disposition = field(fm, 'rollout-disposition');
+  if (disposition !== 'active' && disposition !== 'composed') continue;
   if (field(fm, 'rollout-evidence-type') !== 'endpoint') continue;
   const ref = field(fm, 'rollout-evidence-ref');
   if (!ref || !ref.startsWith('/')) continue; // unparseable ⇒ skip, not fail
   const slug = field(fm, 'slug') || path.basename(file, '.md');
   const resolves = srcContains(ref);
-  seenActive.push({ slug, ref, resolves });
+  seenActive.push({ slug, ref, resolves, disposition });
 
   // A — every active endpoint ref resolves, unless explicitly accepted.
   if (!resolves && !allowed.has(slug)) {
     errors.push(
-      `${path.relative(ROOT, file)}: rollout-disposition:active names ` +
+      `${path.relative(ROOT, file)}: rollout-disposition:${disposition} names ` +
       `rollout-evidence-ref "${ref}" but no route with that path exists in src/. ` +
       `The graduation criterion can never be evaluated, so this rollout is parked ` +
       `indefinitely. Build the endpoint, correct the ref, or add an explicit ` +
@@ -157,6 +178,8 @@ if (errors.length) {
   process.exit(1);
 }
 console.log(
-  `lint-rollout-evidence-resolvable: clean — ${seenActive.length} rollout-active endpoint spec(s), ` +
+  `lint-rollout-evidence-resolvable: clean — ${seenActive.length} guarded endpoint spec(s) ` +
+  `(${seenActive.filter((s) => s.disposition === 'active').length} active, ` +
+  `${seenActive.filter((s) => s.disposition === 'composed').length} composed), ` +
   `${seenActive.filter((s) => s.resolves).length} resolving, ${allowed.size} accepted-unresolved.`,
 );

--- a/tests/unit/lint-rollout-evidence-resolvable.test.ts
+++ b/tests/unit/lint-rollout-evidence-resolvable.test.ts
@@ -38,15 +38,38 @@ describe('lint-rollout-evidence-resolvable — wiring', () => {
     const out = execFileSync('node', [LINT], { cwd: ROOT, encoding: 'utf8' });
     // It must report its denominator — a guard that says only "clean" cannot be
     // distinguished from a guard that scanned nothing.
-    expect(out).toMatch(/rollout-active endpoint spec\(s\)/);
+    expect(out).toMatch(/guarded endpoint spec\(s\)/);
     expect(out).toMatch(/resolving/);
   });
 
   it('reports a non-zero denominator — a scan of nothing is not a pass', () => {
     const out = execFileSync('node', [LINT], { cwd: ROOT, encoding: 'utf8' });
-    const m = /clean — (\d+) rollout-active endpoint spec\(s\)/.exec(out);
+    const m = /clean — (\d+) guarded endpoint spec\(s\)/.exec(out);
     expect(m).not.toBeNull();
     expect(Number(m![1])).toBeGreaterThan(0);
+  });
+
+  it('guards COMPOSED dispositions too, and reports each count separately', () => {
+    // The scope this lint shipped with was 'active' only, and the class is wider:
+    // a composed spec rides an owner feature for GRADUATION but still carries a real
+    // rollout-criteria naming a measurement. A 404 there parks the feature for
+    // exactly the same reason. Both counts are reported separately so a future
+    // narrowing shows up as a number going to zero rather than as silence.
+    const out = execFileSync('node', [LINT], { cwd: ROOT, encoding: 'utf8' });
+    const m = /\((\d+) active, (\d+) composed\)/.exec(out);
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBeGreaterThan(0);
+    expect(Number(m![2])).toBeGreaterThan(0);
+  });
+
+  it('the source actually admits composed — not just the message', () => {
+    // Guard against the shallow version of this change: editing the summary line to
+    // SAY composed while the filter still skips it. Asserts the predicate itself.
+    const src = fs.readFileSync(LINT, 'utf8');
+    expect(src).toMatch(/disposition !== 'active' && disposition !== 'composed'/);
+    // And that the refusal message names WHICH disposition fired, so a reader is not
+    // left inferring it — the scope error this whole widening is a correction for.
+    expect(src).toMatch(/rollout-disposition:\$\{disposition\}/);
   });
 });
 

--- a/upgrades/next/rollout-evidence-ratchet-composed.md
+++ b/upgrades/next/rollout-evidence-ratchet-composed.md
@@ -1,0 +1,36 @@
+## What Changed
+
+The build guard that stops a switched-off feature from claiming a graduation condition it can
+never check now covers a second kind of feature document it previously skipped.
+
+Some features graduate alongside a bigger parent feature rather than on their own. The guard
+treated those as out of scope. They are not: such a feature still states its own condition and
+still names an address to read it from, so a missing address parks it for exactly the same
+reason. Three feature documents sat outside the guard; all three are now covered.
+
+## Summary of New Capabilities
+
+None. No endpoint, config key, or behaviour is added. This widens the scope of an existing
+build-time check and reports its two counts separately, so a future narrowing shows up as a
+number dropping rather than as silence.
+
+Widening it forces no new work on anyone. The guard already carries an escape hatch — a list
+of accepted exceptions, each requiring a written reason, each deleted automatically once its
+address starts working. A feature whose parent was genuinely abandoned needs a declaration,
+not a fix.
+
+## Evidence
+
+Nothing was broken when this was written: all eight covered addresses currently work, and the
+accepted-exception list is empty. This closes a hole in the guard rather than repairing a
+fault.
+
+The guard was proved to actually bite by breaking one of the newly-covered documents on
+purpose — the check refused, and named which kind of document had failed — then restoring it
+byte-for-byte and confirming it passed again. The tests were proved the same way, by narrowing
+the check back and watching exactly the two new tests fail.
+
+## What to Tell Your User
+
+Nothing changes in how your agent behaves. A safety check that runs when the project is built
+now looks at a few more files than it used to.

--- a/upgrades/side-effects/rollout-evidence-ratchet-composed.md
+++ b/upgrades/side-effects/rollout-evidence-ratchet-composed.md
@@ -1,0 +1,54 @@
+# Side-effects review — rollout-evidence ratchet widened to `composed`
+
+## What this changes
+
+`scripts/lint-rollout-evidence-resolvable.js` guarded `rollout-disposition: active` only.
+It now guards `active` AND `composed`. Guarded endpoint specs go from 5 to 8.
+
+## Blast radius
+
+The lint runs in the `npm run lint` chain, so it gates every commit and every CI run.
+Widening it can, in principle, fail a build that previously passed.
+
+**Measured, not assumed: it cannot do so today.** All eight guarded refs resolve; the lint
+exits 0 with an EMPTY accepted-baseline. The three newly-covered specs are
+`self-heal-gate.md` (`/feedback-factory/drain/status`), `context-wedge-detection-completeness.md`
+(`/health`), and `slack-considered-acknowledgment-v1.md` (`/permissions/ambient-stats`).
+Two were already transitively covered — one shares its ref with an active spec, one names a
+path that trivially exists. Exactly one was genuinely unguarded.
+
+## The failure mode this could introduce, and why it does not
+
+The obvious risk of widening a guard is forcing unrelated work on whoever trips it next: a
+`composed` spec whose owner feature was abandoned may legitimately carry a stale ref, and
+such a person should not be conscripted into building a route they do not want.
+
+They are not. Assertion C's shrink-only baseline is the escape hatch, and it was designed
+before this change: an accepted entry requires a written reason and is auto-deleted the
+moment its ref starts resolving. So the widened guard forces a DECLARATION, never a fix.
+Entry needs evidence; exit happens by itself.
+
+## What is NOT weakened
+
+Assertions A (every guarded ref resolves unless accepted), B (baseline reasons must be
+substantive), and C (baseline shrinks only) are unchanged. No threshold moved. The
+refusal message now names which disposition fired, which is strictly more information.
+
+## Verification
+
+- Live run: `clean — 8 guarded endpoint spec(s) (5 active, 3 composed), 8 resolving, 0 accepted-unresolved`, exit 0.
+- Falsified against the real subject: breaking the COMPOSED spec's ref → exit 1 with a
+  refusal naming `rollout-disposition:composed`. Spec restored byte-identical; exit 0 again.
+- Falsified against the tests: narrowing the filter back to active-only → `2 failed | 7 passed`.
+  Restored → `9 passed`.
+- Two pre-existing tests asserted the OLD summary wording and correctly broke. Their
+  PROPERTY — that the guard must report its denominator, since "clean" alone cannot be told
+  from "scanned nothing" — is preserved, with the pattern updated rather than the assertion
+  dropped.
+
+## Reviewer's note
+
+This is a correction to my own work from earlier the same day. The lint's header claimed a
+sweep of "all 5 rollout-active specs" — accurate for its scope, and the scope was narrower
+than the class it names. Recorded in the source comment rather than quietly widened, because
+a guard that silently grew is indistinguishable from one that was always right.


### PR DESCRIPTION
## ELI16

Some features here ship switched off and turn on later once a stated condition is met — usually a number read from a specific address inside the agent. The document describing the feature names that address.

If the address does not exist, the condition can never be checked. The feature then sits switched off forever and nothing says so. It looks careful; it is actually stuck, and the difference is invisible from the outside.

A guard built earlier today refuses the build when a feature's document names an address that does not exist. That guard works. But it only looked at documents marked one particular way, and there is a second marking it skipped — used when a feature turns on alongside a bigger parent feature rather than on its own.

That word describes who owns the turning-on, not whether the evidence matters. Such a document still states its own condition, still names an address, and in one case still carries numeric thresholds to compare against. A missing address parks it for exactly the same reason. So the guard's reach was narrower than the problem it was built for, and three documents sat outside it. They are covered now.

Widening it forces no extra work on anyone, which is the part worth understanding. The guard already keeps a list of accepted exceptions, each needing a written reason, each removed automatically once its address starts working. A feature whose parent was genuinely abandoned needs a declaration, not a fix.

## What Changed

`scripts/lint-rollout-evidence-resolvable.js` guarded `rollout-disposition: active` only. It now guards `active` **and** `composed`. Guarded endpoint specs: 5 → 8.

The refusal message names which disposition fired, and the summary reports the two counts separately — so a future narrowing shows up as a number dropping to zero rather than as silence.

## Why `composed` is not exempt

Read from the specs rather than inferred from the word. `composed` means the rollout rides an owner feature (`rollout-owner-feature`) instead of graduating independently — it names **who owns graduation**, not **whether the evidence matters**. `slack-considered-acknowledgment-v1` still carries a real `rollout-criteria` requiring a measurement from its endpoint, plus `rollout-metrics-json` thresholds against it.

## Why widening is safe

Because of assertion C, not in spite of it. A composed spec whose owner feature was genuinely abandoned may legitimately carry a stale ref — and the shrink-only baseline is exactly where that goes: with a written reason, auto-deleted the moment the ref resolves. This forces a **declaration**, never a fix. Entry needs evidence; exit happens by itself.

## No live defect

All eight guarded refs resolve today and the baseline is empty. This closes a hole in the guard rather than repairing an outage. Two of the three newly-covered specs were already transitively covered; exactly one was genuinely unguarded.

## Falsification

Against the real subject, not a fixture:

- Broke the **composed** spec's ref → `exit 1`, refusal naming `rollout-disposition:composed`. Restored byte-identical → `exit 0`.
- Narrowed the filter back to active-only → exactly the two new tests fail (`2 failed | 7 passed`). Restored → `9 passed`. `tsc` exit 0.

Two pre-existing tests pinned the old summary wording and correctly broke. Their **property** — that the guard must report its denominator, since "clean" alone cannot be distinguished from "scanned nothing" — is preserved with the pattern updated rather than the assertion dropped. A third new test asserts the **filter** admits composed, not merely that the message says so, because the shallow version of this change is editing the summary line while the predicate still skips.

## Reviewer's note

This corrects my own work from a few hours ago. The lint's header claimed a sweep of "all 5 rollout-active specs" — accurate for its scope, and the scope was narrower than the class it names. Recorded in the source comment rather than quietly widened, because a guard that silently grew is indistinguishable from one that was always right.

Gate: `suggestedTier=1, riskFloor=1`, read before declaring.
