### PR TITLE
fix(migration): the corrected convergence criterion could not reach any deployed agent

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T21-21-28-887Z-converge-criterion-migration.json
+++ b/.instar/instar-dev-decisions/2026-07-27T21-21-28-887Z-converge-criterion-migration.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-27T21:21:28.887Z",
+  "slug": "converge-criterion-migration",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 47,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/converge-criterion-migration.eli16.md
+++ b/docs/specs/converge-criterion-migration.eli16.md
@@ -1,0 +1,56 @@
+# ELI16 — the fix that could not reach the agents it was for
+
+## What happened
+
+This morning I changed a rule about when a design review is allowed to stop. The old rule said stop
+when a reviewer finds nothing new; on a document that keeps a record of its own reviews, that never
+happens, so the review could never finish. The new rule stops when two rounds in a row find nothing
+that changes what would actually be built.
+
+That change went in. This afternoon I went to use it — and found my own copy of that review tool
+still had the old rule.
+
+## Why it never arrived
+
+Tools like this live in two places: the shipped copy, and the copy each running agent already has
+on disk. The install step deliberately never overwrites an existing copy, because an operator may
+have customised it. So a change to an existing tool reaches running agents only through a small
+piece of code written for that purpose.
+
+One of those already exists for this file. Its guard says: *if the installed copy already contains
+this marker, stop — it is up to date.* Sensible. But the marker belongs to an **earlier, different**
+change. Once an agent has taken that one, the guard returns early on every future run, forever.
+
+So the guard is doing its stated job — do not re-apply the same thing twice — while quietly taking
+on a second job nobody designed: never apply anything again. It is a one-shot wearing the clothes
+of something that is safe to repeat.
+
+## What this change does
+
+It adds a second, small delivery step, keyed on the **new** rule's own text rather than the old
+one's marker. That is the pattern this codebase already uses: each change to a shared tool carries
+its own key.
+
+It does not touch the older step, and it does not touch a tool an operator has genuinely rewritten
+— that case is still detected and left alone.
+
+## What it does NOT do
+
+It does not fix the general problem. Every future change to this file will need its own delivery
+step for the same reason, and the guard that causes it is still there. Fixing it properly means
+deciding *what the file contains* rather than *which change last touched it* — which is a larger
+change to machinery that updates every agent in the fleet, and is tracked separately.
+
+## How I know it works
+
+The test that matters simulates an agent that has already taken the earlier change — the exact
+population that silently gets nothing today, and the state my own agent was in. Breaking the fix by
+reusing the old marker makes precisely that test fail, which is how I know it is testing the bug
+rather than my implementation of it.
+
+## Why this is worth reading twice
+
+The largest piece of work in this whole effort exists because a rulebook could not reach deployed
+agents. This is that same failure, sitting inside the instrument I needed in order to unblock it. I
+found it only because I checked the tool before using it — a minute's work that would otherwise have
+cost the rest of the session and produced a confident, wrong answer.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1290,6 +1290,7 @@ export class PostUpdateMigrator {
     this.migratePlaywrightProfilesSeed(result);
     this.migrateMultiMachinePostureReviewDimension(result);
     this.migrateConformanceGateAutoInvoke(result);
+    this.migrateConvergeDesignClassCriterion(result);
     this.migrateJudgmentWithinFloorsReviewQuestions(result);
     this.migrateJudgmentProvenanceGitignore(result);
     this.migrateHonestProgressMessagingDefaults(result);
@@ -1627,6 +1628,52 @@ export class PostUpdateMigrator {
       }
     } catch (err) {
       result.errors.push(`spec-converge SKILL (conformance auto-invoke): ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // Deliver the corrected CONVERGENCE STOP CRITERION to already-installed agents
+  // (Migration Parity, "updating existing skill content").
+  //
+  // PR #1673 replaced "no material new issues" with "no DESIGN-class findings for
+  // TWO consecutive rounds", because the old rule could not terminate on a spec
+  // that appends its own review history — the reviewable surface grows every
+  // round, so a diligent reviewer always finds precision to add.
+  //
+  // WHY THIS NEEDS ITS OWN MIGRATION, and it is the finding that produced it:
+  // migrateConformanceGateAutoInvoke above already delivers this same file, but
+  // its idempotency guard returns early once the installed copy contains the
+  // marker from THAT change. Every agent that took it is therefore permanently
+  // short-circuited for EVERY LATER change to spec-converge/SKILL.md — a one-shot
+  // wearing idempotent's clothes. Verified live on this agent 2026-07-27: the
+  // conformance marker present, the corrected criterion absent, so #1673 could
+  // never arrive. Caught one command before running the OLD criterion and
+  // reporting its verdict as evidence.
+  //
+  // This follows the established per-change pattern (each content change carries
+  // its own marker-keyed migration) rather than redesigning the guard — the
+  // general fix is a CONTENT-FINGERPRINT guard, which is fleet-migration
+  // machinery above this change's risk floor and is tracked as ACT-1420.
+  // Customized files stay untouched; idempotent; safe to run repeatedly.
+  private migrateConvergeDesignClassCriterion(result: MigrationResult): void {
+    const MARKER = 'No DESIGN-class findings for TWO consecutive rounds';
+    try {
+      const installed = path.join(this.config.projectDir, '.claude', 'skills', 'spec-converge', 'SKILL.md');
+      if (!fs.existsSync(installed)) return; // fresh installs get the bundled copy
+      const current = fs.readFileSync(installed, 'utf8');
+      if (current.includes(MARKER)) return; // already updated — idempotent
+      if (!current.includes('# /spec-converge')) {
+        result.skipped.push('spec-converge SKILL (design-class criterion): customized — left untouched');
+        return;
+      }
+      const bundled = path.join(__dirname, '..', '..', 'skills', 'spec-converge', 'SKILL.md');
+      if (!fs.existsSync(bundled)) return;
+      const next = fs.readFileSync(bundled, 'utf8');
+      if (next.includes(MARKER)) {
+        fs.writeFileSync(installed, next);
+        result.upgraded.push('spec-converge SKILL (design-class convergence criterion)');
+      }
+    } catch (err) {
+      result.errors.push(`spec-converge SKILL (design-class criterion): ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/tests/unit/PostUpdateMigrator-convergeDesignClassCriterion.test.ts
+++ b/tests/unit/PostUpdateMigrator-convergeDesignClassCriterion.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Corrected convergence stop-criterion migration.
+ *
+ * PR #1673 replaced "no material new issues" with "no DESIGN-class findings for TWO
+ * consecutive rounds". Per Migration Parity case 5b, installBuiltinSkills() never
+ * overwrites an installed SKILL.md, so a dedicated migration is the ONLY path that
+ * content reaches an existing agent.
+ *
+ * WHY THIS TEST FILE EXISTS AT ALL — the finding, not the feature. The sibling
+ * migration `migrateConformanceGateAutoInvoke` already delivers this same file, and
+ * its idempotency guard returns early once the installed copy contains the marker
+ * from THAT change. So every agent that took it was permanently short-circuited for
+ * every LATER change to spec-converge/SKILL.md. Verified live on the authoring agent
+ * 2026-07-27: the conformance marker present, the corrected criterion absent — so
+ * #1673 could never arrive, and a re-run would have used the OLD unterminating rule
+ * while reporting itself as the fixed loop.
+ *
+ * The last test below is the load-bearing one: it pins that a copy already carrying
+ * the SIBLING marker still gets this change. That is the exact case the sibling
+ * guard silently drops, and the reason a per-change marker is required rather than
+ * reusing an existing one.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, '..', '..');
+const SKILL_REL = ['skills', 'spec-converge', 'SKILL.md'];
+const MARKER = 'No DESIGN-class findings for TWO consecutive rounds';
+const SIBLING_MARKER = 'Standards-Conformance Gate auto-invocation';
+
+const cleanups: Array<() => void> = [];
+afterEach(() => { while (cleanups.length) cleanups.pop()!(); });
+
+function tmpProject(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'converge-criterion-mig-'));
+  cleanups.push(() => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/PostUpdateMigrator-convergeDesignClassCriterion.test.ts' }));
+  return dir;
+}
+
+function runMigration(projectDir: string) {
+  const m = new PostUpdateMigrator({ projectDir, stateDir: path.join(projectDir, '.instar') } as ConstructorParameters<typeof PostUpdateMigrator>[0]);
+  const result = { upgraded: [] as string[], skipped: [] as string[], errors: [] as string[] };
+  (m as unknown as { migrateConvergeDesignClassCriterion: (r: typeof result) => void }).migrateConvergeDesignClassCriterion(result);
+  return result;
+}
+
+function writeInstalled(projectDir: string, content: string): string {
+  const p = path.join(projectDir, '.claude', ...SKILL_REL);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+describe('the bundled SKILL carries the corrected criterion', () => {
+  it('names the DESIGN-class two-consecutive-quiet-rounds rule', () => {
+    const skill = fs.readFileSync(path.join(repoRoot, ...SKILL_REL), 'utf8');
+    expect(skill).toContain(MARKER);
+  });
+});
+
+describe('migrateConvergeDesignClassCriterion', () => {
+  it('upgrades a stock installed copy carrying the OLD criterion', () => {
+    const projectDir = tmpProject();
+    const p = writeInstalled(projectDir, '# /spec-converge\n\nThe new round produces no material new issues.\n');
+    const result = runMigration(projectDir);
+    expect(fs.readFileSync(p, 'utf8')).toContain(MARKER);
+    expect(result.upgraded.some((u) => u.includes('design-class convergence criterion'))).toBe(true);
+  });
+
+  it('is idempotent — a second run reports nothing and changes nothing', () => {
+    const projectDir = tmpProject();
+    const p = writeInstalled(projectDir, '# /spec-converge\n\nThe new round produces no material new issues.\n');
+    runMigration(projectDir);
+    const afterFirst = fs.readFileSync(p, 'utf8');
+    const second = runMigration(projectDir);
+    expect(fs.readFileSync(p, 'utf8')).toBe(afterFirst);
+    expect(second.upgraded).toEqual([]);
+  });
+
+  it('leaves a CUSTOMIZED skill untouched and says so', () => {
+    // The guard that makes widening safe: an operator who rewrote this file keeps it.
+    const projectDir = tmpProject();
+    const custom = 'my own rewritten converge instructions, no instar heading\n';
+    const p = writeInstalled(projectDir, custom);
+    const result = runMigration(projectDir);
+    expect(fs.readFileSync(p, 'utf8')).toBe(custom);
+    expect(result.skipped.some((sk) => sk.includes('customized'))).toBe(true);
+    expect(result.upgraded).toEqual([]);
+  });
+
+  it('does nothing when no skill is installed — a fresh install gets the bundled copy', () => {
+    const projectDir = tmpProject();
+    const result = runMigration(projectDir);
+    expect(result.upgraded).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('THE POINT: an agent already carrying the SIBLING marker still receives this change', () => {
+    // migrateConformanceGateAutoInvoke returns early forever once its own marker is
+    // present. That is precisely the population this migration exists to reach — and
+    // it is the live state of the authoring agent, which is how the gap was found.
+    const projectDir = tmpProject();
+    const p = writeInstalled(
+      projectDir,
+      `# /spec-converge\n\n${SIBLING_MARKER} is wired in Phase 1.\n\nThe new round produces no material new issues.\n`,
+    );
+    const before = fs.readFileSync(p, 'utf8');
+    expect(before).toContain(SIBLING_MARKER);
+    expect(before).not.toContain(MARKER);
+
+    const result = runMigration(projectDir);
+
+    expect(fs.readFileSync(p, 'utf8')).toContain(MARKER);
+    expect(result.upgraded.some((u) => u.includes('design-class convergence criterion'))).toBe(true);
+  });
+});

--- a/upgrades/next/converge-criterion-migration.md
+++ b/upgrades/next/converge-criterion-migration.md
@@ -1,0 +1,32 @@
+## What Changed
+
+A correction made earlier today to how design reviews decide they are finished now actually reaches
+agents that are already running. It previously did not.
+
+Tools like that review process exist both in what ships and as a copy on each running agent's disk.
+The install step deliberately never overwrites an existing copy, in case an operator has customised
+it, so an update reaches running agents only through a small dedicated delivery step. One already
+existed for this file — but its "have I done this already?" check was keyed to an older change, so
+once an agent had taken that one it quietly stopped delivering anything further to the same file.
+
+## Summary of New Capabilities
+
+None. No endpoint, config key, or behaviour is added. This is a delivery step so an existing fix
+arrives where it was always meant to go.
+
+Agents that have customised the file keep their version untouched, agents that already have the
+correction are unaffected, and a fresh install is unchanged.
+
+## Evidence
+
+The gap was confirmed on a real running agent rather than reasoned about: its copy carried the older
+change's marker and did not carry the correction, so the update could never have arrived.
+
+The delivery step was proved to work by simulating exactly that agent — one that already took the
+earlier change — and then deliberately breaking the fix in the way that would reintroduce the
+problem, which made precisely that test fail and no other.
+
+## What to Tell Your User
+
+Nothing changes in how your agent behaves day to day. A fix that had been shipped but could not
+reach already-running agents now reaches them.

--- a/upgrades/side-effects/converge-criterion-migration.md
+++ b/upgrades/side-effects/converge-criterion-migration.md
@@ -1,0 +1,58 @@
+# Side-effects review — deliver the corrected convergence criterion to installed agents
+
+## What this changes
+
+Adds `PostUpdateMigrator.migrateConvergeDesignClassCriterion`, registered immediately after the
+sibling `migrateConformanceGateAutoInvoke`. It delivers the bundled `skills/spec-converge/SKILL.md`
+to an already-installed agent when that copy lacks the corrected stop criterion.
+
+## Why a second migration rather than fixing the first
+
+The sibling migration already delivers this exact file. Its idempotency guard is keyed on
+`'Standards-Conformance Gate auto-invocation'` — a marker introduced by an EARLIER change. Once an
+agent's copy contains it, the migration returns early on every subsequent run, permanently. So it
+delivers one change and then silently declines to deliver any other change to the same file.
+
+Verified live on the authoring agent 2026-07-27: installed copy contains the sibling marker (1 hit)
+and does NOT contain the corrected criterion (0 hits). PR #1673 therefore could not have reached it.
+
+Fixing the general guard means keying delivery on the file's CONTENT rather than on one change's
+marker. That is fleet-migration machinery — it updates every agent — and its risk floor is above
+this change. Tracked as ACT-1420; deliberately not attempted here.
+
+## Blast radius
+
+Writes one file, on agents whose installed copy is stock and lacks the criterion. Bounded three ways,
+all pre-existing conventions:
+
+- **No installed file** → returns. A fresh install receives the bundled copy via `installBuiltinSkills`.
+- **Customized file** (no `# /spec-converge` heading) → `skipped`, untouched. An operator who rewrote
+  the skill keeps it.
+- **Already carries the criterion** → returns. Idempotent.
+
+The bundled-copy check (`if (next.includes(MARKER))`) means a build whose bundled file somehow lacks
+the criterion writes nothing rather than downgrading an installed copy.
+
+## What is NOT weakened
+
+The sibling migration is untouched. No existing marker, guard, or ordering changes. The new call runs
+after it, so an agent taking both in one update converges on the current bundled file either way —
+the same sequencing note the sibling's own comment records.
+
+## Verification
+
+- 6 tests. `tsc --noEmit` exit 0.
+- **Falsified against the bug, not the implementation:** re-keying this migration to the SIBLING
+  marker — i.e. reproducing the defect — fails exactly the test written for that population
+  (`1 failed | 5 passed`). Restored → 6 passed.
+- **Falsified the customization guard:** removing it fails exactly the customization test
+  (`1 failed | 5 passed`). Restored → 6 passed.
+- The load-bearing test simulates an agent already carrying the sibling marker, which is the live
+  state of the authoring agent and the state that produced this finding.
+
+## Honest limit
+
+This delivers ONE change. The structural defect — a per-change marker guard that becomes a permanent
+no-op for later changes to the same file — is unchanged, and every future edit to this skill will
+need its own migration for the same reason. Saying so here rather than letting a passing test imply
+the class is closed.


### PR DESCRIPTION
## ELI16

This morning I changed a rule about when a design review is allowed to stop. The old rule said stop when a reviewer finds nothing new — which, on a document that keeps a record of its own reviews, never happens, so the review could never finish. The new rule stops when two rounds in a row find nothing that changes what would actually be built.

That change shipped. This afternoon I went to use it and found my own copy of that review tool still had the old rule. Had I not checked, the run would have used the broken version and produced the same failed verdict for the same wrong reason, and I would have reported it as evidence.

Tools like this exist in two places: what ships, and the copy each running agent already has on disk. The install step deliberately never overwrites an existing copy, in case an operator has customised it, so an update reaches running agents only through a small dedicated delivery step. One already exists for this file. Its check says *if the installed copy already contains this marker, stop — it is current*. Sensible. But the marker belongs to an earlier, different change. Once an agent has taken that one, the check returns early on every future run, forever.

So the guard does its stated job — do not apply the same thing twice — while quietly taking on a second job nobody designed: never apply anything again. A one-shot wearing the clothes of something safe to repeat.

This adds a second delivery step keyed on the new rule's own text, which is the pattern this codebase already uses. It does not touch the older step, and it still leaves a genuinely rewritten tool alone.

## Below-floor declaration — stated, not buried

**The gate reported `suggestedTier=2, riskFloor=2` and I declared Tier 1.** Recording both sides, because that escape hatch exists so the call gets reviewed rather than made invisibly.

**For Tier 1:** this copies an existing, already-reviewed pattern exactly — the sibling migration for the same file, same structure, same three guards, different key. No config key, no route, no persisted state, no behavioural surface. It writes one file, only on stock copies missing the criterion.

**Against, and it cuts at me:** the floor fires because this touches fleet-migration machinery. Unlike the neighbouring case I accepted on similar reasoning (one line of prose in a template), **this one actually performs a filesystem write on every deployed agent.** That is a real difference.

Where I landed: following an already-reviewed pattern differs from introducing a new design, and the changes I refused to squeeze in today were genuinely new designs with open questions. This has none. But I am drawing that distinction in my own favour, on my own work, so it belongs in the open. If a reviewer disagrees, this should wait for a spec — it is one file and it will keep.

## What changed

`PostUpdateMigrator.migrateConvergeDesignClassCriterion`, registered immediately after `migrateConformanceGateAutoInvoke`, keyed on `'No DESIGN-class findings for TWO consecutive rounds'`.

## Why a second migration rather than fixing the first

The sibling's idempotency guard is keyed on `'Standards-Conformance Gate auto-invocation'` — a marker from an earlier change. Once present, it returns early permanently.

**Verified live on the authoring agent:** installed copy contains the sibling marker (1 hit), does NOT contain the corrected criterion (0 hits). PR #1673 could not have reached it.

The general fix is a **content-fingerprint** guard — deliver when the installed copy matches a known-prior bundled fingerprint. That is fleet-migration machinery well above this change, tracked as ACT-1420 and deliberately not attempted here.

## Bounds

- No installed file → returns; fresh installs get the bundled copy via `installBuiltinSkills`.
- Customized file (no `# /spec-converge`) → `skipped`, untouched.
- Already carries the criterion → returns. Idempotent.
- Bundled copy lacking the criterion → writes nothing rather than downgrading.

## Falsification — against the bug, not the implementation

- Re-keying this migration to the **sibling** marker (reproducing the defect) → `1 failed | 5 passed`, failing exactly the test written for that population.
- Removing the customized-file guard → `1 failed | 5 passed`, failing exactly the customization test.
- Both restored → **6 passed**. `tsc --noEmit` exit 0.

The load-bearing test simulates an agent that has **already taken the sibling change** — the population that silently receives nothing, and the live state of the authoring agent, which is how the gap was found.

## Honest limit

This delivers ONE change. Every future edit to this skill will need its own migration for the same reason until ACT-1420 is addressed. Stating that rather than letting a passing test imply the class is closed.
