### PR TITLE
fix(spec-converge): a section number could hide an unanswered question from the gate

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-27T22-01-07-093Z-openq-gate-numbered-headings-eli16.json
+++ b/.instar/instar-dev-decisions/2026-07-27T22-01-07-093Z-openq-gate-numbered-headings-eli16.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T22:01:07.093Z",
+  "slug": "openq-gate-numbered-headings.eli16",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 42,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-27T22-02-27-596Z-openq-gate-numbered-headings.json
+++ b/.instar/instar-dev-decisions/2026-07-27T22-02-27-596Z-openq-gate-numbered-headings.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-27T22:02:27.596Z",
+  "slug": "openq-gate-numbered-headings",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 42,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/openq-gate-numbered-headings.eli16.md
+++ b/docs/specs/openq-gate-numbered-headings.eli16.md
@@ -1,0 +1,61 @@
+# A section number could hide an unanswered question
+
+## The short version
+
+Before a design document is allowed to be marked "finished", an automatic check
+looks for any question still parked on a human — something the author flagged as
+needing a person's decision. If one is still sitting there, the document cannot be
+stamped as done. That check is supposed to be impossible to talk your way around;
+the process notes describe it as structural, meaning it is enforced by code rather
+than by anyone remembering to look.
+
+It had a blind spot, and the blind spot was punctuation.
+
+The check searched for a section headed exactly `Open questions`. Plenty of
+documents number their sections, so the heading reads `9. Open questions` instead.
+For those, the search found nothing — and the code then treated "I found no
+section" as "there is nothing outstanding". Those are two completely different
+statements, and collapsing them meant a real, unanswered question could sit in
+plain sight in the document and be entirely invisible to the thing whose one job
+was to notice it.
+
+## How it was found
+
+Not by reading the code and reasoning about it, which is how you talk yourself
+into believing a regular expression works. It was run, on a document that uses
+numbered sections, with a deliberate control: the same live question was placed
+under a numbered heading and under a plain one. The plain heading caught it. The
+numbered heading reported nothing outstanding. That is the whole proof, and it
+took under a minute.
+
+## The part that made it obvious rather than debatable
+
+Eight lines further down the same file, a sibling check does the same kind of
+lookup for a different section — and on exactly the same numbered heading it
+does the opposite thing: it refuses, loudly. So one file contained two checks,
+written separately, that disagreed about what to do when a heading did not match.
+When two things measuring the same quantity have opposite defaults, one of them is
+wrong without anyone needing to make a judgement call about which behaviour is
+nicer.
+
+## What changed
+
+Both checks now recognise the same set of heading shapes — plain, numbered,
+lettered, dotted, with brackets, and with a trailing note like `(round 2)` — and
+they share a single piece of matching logic rather than each having their own.
+That sharing is the real repair: the blind spot existed because someone had
+already improved heading handling once, and the improvement landed on only one of
+the two checks. Now it cannot.
+
+One thing was deliberately left alone. If a document has no such section at all,
+it is still treated as having nothing outstanding. Whether that should instead be
+a refusal is a genuine question worth deciding on its own merits, and quietly
+changing it inside a fix about punctuation would be the same kind of shortcut this
+change exists to close.
+
+## Why you would care
+
+If you are ever handed a design document to approve, the promise is that no
+question needing your decision was left buried in it. That promise was slightly
+weaker than advertised for any document that numbered its sections. It is now as
+strong as it was described.

--- a/skills/spec-converge/scripts/write-convergence-tag.mjs
+++ b/skills/spec-converge/scripts/write-convergence-tag.mjs
@@ -102,12 +102,44 @@ function parseArgs() {
  * Anything else with content (e.g. a `- **Q1:** …` bullet or a paragraph posing
  * a question) is an unresolved entry.
  */
+/**
+ * Builds the H2 matcher for a named gate section.
+ *
+ * ONE builder, used by BOTH gate sections, deliberately: the numbered-heading
+ * hole below existed because the two matchers were written separately and only
+ * one of them ever got a heading-variance fix. A shared builder means the next
+ * variance fix cannot land on one gate and miss its sibling.
+ *
+ * Tolerated shapes:
+ *   - `## Open questions`                    (canonical)
+ *   - `## 9. Open questions`                 (numbered — the hole this closes)
+ *   - `## 8b. Open questions` / `## 3) …`    (lettered / paren'd)
+ *   - `## 1.2 Open questions`                (dotted)
+ *   - `## Open questions (round 2)`          (suffix variant — already worked)
+ *
+ * Why this was load-bearing: `findOpenQuestions` returns `[]` when the heading
+ * does not match, and `[]` means "nothing parked on the user". So a NUMBERED
+ * heading made a LIVE, unresolved user-decision invisible to the gate the skill
+ * calls structural ("cannot be skipped by prose"). Verified with a control
+ * before the fix: numbered heading + a live question → `[]`; the identical
+ * question under a plain heading → caught. Its sibling `findDecisionPointGaps`
+ * failed CLOSED on the very same input — two defaults for one quantity.
+ */
+const SECTION_LABEL = String.raw`(?:\d+(?:\.\d+)*[a-z]?[.)]?\s+)?`;
+function gateSectionHeadingRe(name) {
+  return new RegExp(String.raw`^##\s+${SECTION_LABEL}${name}\b[^\n]*$`, 'im');
+}
+
 export function findOpenQuestions(specBody) {
   // \b…[^\n]*$ (not \s*$) so heading variants like "## Open questions (round 2)"
   // or "## Open Questions & Decisions" are still recognized — a variant heading
   // must not make the section invisible to the gate (reviewer finding, PR 2).
-  const m = specBody.match(/^##\s+Open questions\b[^\n]*$/im);
-  if (!m) return []; // no section → nothing parked on the user
+  // SECTION_LABEL additionally tolerates a numbered prefix (see the builder).
+  const m = specBody.match(gateSectionHeadingRe('Open questions'));
+  // A genuinely ABSENT section still means nothing is parked on the user; that
+  // semantic is unchanged and separately tested. What changed is that a present
+  // section can no longer hide behind its own section number.
+  if (!m) return [];
   const start = m.index + m[0].length;
   const restAfter = specBody.slice(start);
   const nextHeading = restAfter.search(/^##\s+/m);
@@ -144,7 +176,11 @@ export const GRANDFATHERED_SLUGS = [
 
 export function findDecisionPointGaps(specBody, slug) {
   if (slug && GRANDFATHERED_SLUGS.includes(slug)) return { ok: true };
-  const m = specBody.match(/^##\s+Decision points touched\b[^\n]*$/im);
+  // Same shared builder as findOpenQuestions — this gate already failed CLOSED
+  // on a numbered heading (correct direction), but it was refusing specs whose
+  // section was PRESENT and merely numbered, which is a false refusal rather
+  // than a safety property. Both gates now recognise the same heading shapes.
+  const m = specBody.match(gateSectionHeadingRe('Decision points touched'));
   if (!m) return { ok: false, reason: 'missing-section' };
   const start = m.index + m[0].length;
   const restAfter = specBody.slice(start);

--- a/tests/unit/write-convergence-tag-decision-completeness.test.ts
+++ b/tests/unit/write-convergence-tag-decision-completeness.test.ts
@@ -16,7 +16,10 @@ import os from 'node:os';
 // The module is import-safe (main is guarded behind an argv check).
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — plain .mjs module without type declarations
-import { findOpenQuestions } from '../../skills/spec-converge/scripts/write-convergence-tag.mjs';
+import {
+  findOpenQuestions,
+  findDecisionPointGaps,
+} from '../../skills/spec-converge/scripts/write-convergence-tag.mjs';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const SCRIPT = path.resolve(
@@ -124,6 +127,62 @@ describe('findOpenQuestions (criterion-2 parser)', () => {
       '- a stray question? this is fine here',
     ].join('\n');
     expect(findOpenQuestions(body)).toEqual([]);
+  });
+
+  /**
+   * THE BUG: a section NUMBER made a live user-decision invisible to the gate.
+   *
+   * `## 9. Open questions` did not match `^##\s+Open questions\b`, so the
+   * no-match branch returned `[]` — "nothing parked on the user" — for a spec
+   * that had a live, unanswered question sitting right under the heading. The
+   * skill calls this gate structural and says the criterion "cannot be skipped
+   * by prose"; it could be skipped by a section number.
+   *
+   * These assert the DEFECT is caught, not merely that the current parser runs:
+   * each numbered case must FAIL against the pre-fix regex.
+   */
+  it.each([
+    ['## 9. Open questions', 'numbered'],
+    ['## 8b. Open questions', 'numbered + letter'],
+    ['## 1.2 Open questions', 'dotted'],
+    ['## 3) Open questions', 'paren'],
+    ['## 9. Open questions (round 2)', 'numbered + suffix variant'],
+  ])('catches a live question under a %s heading (%s)', (heading) => {
+    const body = `${heading}\n- **Q1:** A or B? (user to decide)\n`;
+    expect(findOpenQuestions(body)).toEqual(['- **Q1:** A or B? (user to decide)']);
+  });
+
+  it('still treats a none-marker under a numbered heading as resolved', () => {
+    // The fix must not flip the gate to refusing every numbered spec — it makes
+    // the section VISIBLE, it does not make resolution harder.
+    expect(findOpenQuestions('## 9. Open questions\n\n*(none)*\n')).toEqual([]);
+  });
+
+  it('a genuinely absent section is still "nothing parked" (semantics unchanged)', () => {
+    // Deliberately NOT changed by this fix: whether an absent section should
+    // fail closed is a separate argued decision, tracked rather than smuggled in.
+    expect(findOpenQuestions('# T\n\n## Design\nstuff')).toEqual([]);
+  });
+});
+
+describe('gate heading recognition is SYMMETRIC across both sections', () => {
+  /**
+   * The asymmetry was the tell: on the identical numbered-heading input,
+   * findDecisionPointGaps failed CLOSED (refuse) while findOpenQuestions failed
+   * OPEN (pass silently). Two sibling checks, eight lines apart, opposite
+   * defaults for one quantity. Both now share a single heading builder so a
+   * future variance fix cannot land on one and miss the other.
+   */
+  it('recognises a numbered Decision points touched heading', () => {
+    const body = '## 6. Decision points touched\n- routing choice — invariant (deterministic)\n';
+    expect(findDecisionPointGaps(body, 'x')).toEqual({ ok: true });
+  });
+
+  it('both gates see a numbered heading, or neither does', () => {
+    const oq = findOpenQuestions('## 9. Open questions\n- **Q1:** live?\n');
+    const dp = findDecisionPointGaps('## 6. Decision points touched\n*(none)*\n', 'x');
+    expect(oq).toHaveLength(1); // section visible → live question caught
+    expect(dp.ok).toBe(true); // section visible → not a false "missing-section"
   });
 });
 

--- a/upgrades/next/openq-gate-numbered-headings.md
+++ b/upgrades/next/openq-gate-numbered-headings.md
@@ -1,0 +1,44 @@
+## Title
+
+A section number could hide an unanswered question from the convergence gate
+
+## Summary of New Capabilities
+
+No new capability. This repairs a check that already existed and was quietly not
+looking at part of what it was meant to cover.
+
+## What Changed
+
+The convergence tag writer refuses to mark a design document "converged" while it
+still has an unanswered question parked on a person. That check only recognised a
+section titled exactly `Open questions`. Many documents number their sections —
+`9. Open questions` — and for those the check found nothing, concluded there was
+nothing to find, and let the document through.
+
+The two halves of the same gate also disagreed with each other on identical input:
+the sibling check covering decision points refused a numbered heading outright,
+while the open-questions check waved it past. Both now recognise the same set of
+heading shapes (plain, numbered, lettered, dotted, parenthesised, and with a
+trailing variant such as `(round 2)`), and they share one matcher so a future fix
+to one cannot silently miss the other.
+
+What deliberately did NOT change: a document with genuinely no such section is
+still treated as having nothing outstanding. Whether that should instead refuse is
+a separate decision worth arguing on its own rather than folding in here.
+
+## Evidence
+
+The defect was reproduced with a control before any fix was written: a live,
+unanswered question under a numbered heading returned "nothing outstanding", while
+the identical question under a plain heading was caught.
+
+Seven tests now cover the numbered, lettered, dotted, parenthesised and
+variant-suffix headings plus the cross-check that both halves of the gate agree.
+Reverting the fix makes exactly those seven fail; restoring it returns 50 passing
+tests across all four suites that touch the changed file, with type-checking clean.
+
+## What to Tell Your User
+
+Nothing you need to do. A safety check that decides whether a design document is
+finished had a blind spot: if the document numbered its sections, an unanswered
+question could slip past unnoticed. It now sees those documents too.

--- a/upgrades/side-effects/openq-gate-numbered-headings.md
+++ b/upgrades/side-effects/openq-gate-numbered-headings.md
@@ -1,0 +1,47 @@
+# Side effects — open-questions gate: numbered-heading recognition
+
+## What this change can affect
+
+`write-convergence-tag.mjs` is the structural gate for `/spec-converge`. Widening
+heading recognition changes which specs the gate can SEE, so both directions were
+checked rather than only the one being fixed.
+
+## Newly-visible sections (the intended effect)
+
+A spec whose `Open questions` section is numbered was previously invisible to the
+gate; it is now parsed. **Consequence to state plainly: a spec that would have been
+stamped before may now be REFUSED — correctly — because it carries a live
+unresolved question that the gate could not previously see.** That is the point of
+the fix, and it is a behaviour change for any such spec mid-flight.
+
+## Not changed, deliberately
+
+- A genuinely ABSENT `Open questions` section still yields "nothing parked on the
+  user". Whether an absent section should instead fail closed is a separate argued
+  decision; smuggling it in here would be a semantic change hiding inside a
+  matcher fix. Tracked, not silently taken.
+- Resolution semantics are untouched: `*(none)*`, `(none)`, `None`, `N/A`,
+  blockquote commentary and horizontal rules still count as resolved, including
+  under a numbered heading (explicitly tested, so the fix cannot become
+  "refuse every numbered spec").
+- `GRANDFATHERED_SLUGS` is untouched and remains empty.
+
+## The decision-points gate
+
+That sibling previously refused a numbered heading with `missing-section`. That is
+a FALSE refusal — the section was present, merely numbered — so it now recognises
+the same shapes. This makes the gate less likely to block a conforming spec; it
+does not weaken it, because an actually-missing section still refuses.
+
+## Blast radius and rollback
+
+Two files: one script, one test file. No route, no config key, no persisted state,
+no migration. Rollback is a revert.
+
+## Honest limit
+
+The matcher tolerates a bounded set of section-label shapes. An exotic heading
+(e.g. a roman numeral, or an emoji prefix) would still be invisible, and the
+underlying design remains "match a heading by name". A structurally stronger
+answer — a declared anchor rather than a heading regex — was NOT attempted here
+and is a larger change than this repair.


### PR DESCRIPTION
## ELI16 — a section number could hide an unanswered question from the convergence gate

Before a design document can be marked "finished", an automatic check looks for any question still parked on a human — something the author flagged as needing a person's decision. If one is still sitting there, the document cannot be stamped as done. The process notes call this check structural, meaning it is enforced by code rather than by anyone remembering to look, and say explicitly that it cannot be skipped by prose.

It could be skipped by a section number. The check searched for a heading spelled exactly `Open questions`. Plenty of documents number their sections, so the heading reads `9. Open questions` instead — and for those the search found nothing, then treated "I found no section" as "there is nothing outstanding". Those are two completely different statements. Collapsing them meant a real, unanswered question could sit in plain sight and be invisible to the one thing whose job was to notice it.

What made this unambiguous rather than a judgement call: eight lines further down the same file, a sibling check doing the same kind of lookup for a different section does the opposite thing on the identical input — it refuses, loudly. One file, two checks, opposite defaults for one quantity. Both now share a single matcher, so the next fix to one cannot miss the other.

## What changed

`findOpenQuestions` matched `/^##\s+Open questions\b/im`. A numbered heading did not match, and the no-match branch returns `[]` — carrying the comment *"no section → nothing parked on the user"*.

Reproduced with a control **before** writing the fix:

```
NUMBERED heading + live question -> []                 (invisible)
PLAIN    heading + same question -> [the question]     (caught)
```

Both matchers now come from one shared builder tolerating a bounded set of section labels (numbered, lettered, dotted, parenthesised) on top of the existing suffix-variant support (`(round 2)`).

**The sharing is the actual repair.** This hole existed *because* heading-variance had already been fixed once — a reviewer finding on an earlier PR — and the fix landed on only one of the two checks.

## Deliberately not changed

A genuinely **absent** section still means "nothing parked on the user". Whether that should instead fail closed is a separate argued decision, and folding it into a matcher fix would be a semantic change hiding inside a bug fix. Tracked, not smuggled in.

The sibling gate previously refused a numbered heading with `missing-section` — a *false* refusal, since the section was present. It now recognises the same shapes. That makes it less likely to block a conforming spec; it does not weaken it, because an actually-missing section still refuses.

## Evidence

- Falsified: reverting the section-label tolerance fails **exactly the 7 new tests** (5 heading shapes + 2 symmetry checks). Source restored byte-identical.
- Restored: **50 passed** across all four suites touching the changed file — the set chosen from `git diff --name-only`, not from the files I authored.
- `tsc --noEmit` exit 0. `upgrade-guide-validator` and `check-repo-invariants` both exit 0 locally.
- Gate: `suggestedTier=2 (size), riskFloor=1` → **Tier 1 correct on the merits**, not an override.

## Honest limit

The matcher tolerates a bounded set of label shapes. An exotic heading (roman numeral, emoji prefix) would still be invisible, and the underlying design remains "match a heading by name". A structurally stronger answer — a declared anchor instead of a heading regex — was not attempted here and is a larger change than this repair.

Refs ACT-1421.
