### PR TITLE
fix(claim-verification): gap events recorded that a cue was missed, never why

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-28T02-28-47-800Z-extraction-gap-signal-reason.json
+++ b/.instar/instar-dev-decisions/2026-07-28T02-28-47-800Z-extraction-gap-signal-reason.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-28T02:28:47.800Z",
+  "slug": "extraction-gap-signal-reason",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 129,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/ClaimObservation.ts
+++ b/src/monitoring/ClaimObservation.ts
@@ -86,6 +86,39 @@ const PROTECTED: Record<string, RegExp> = {
   injection: /(?:ignore previous|ignore above|system prompt|developer message|<system|do not extract)/i,
 };
 
+/**
+ * Why a protected-cue span was booked as an extraction gap (spec §2.1).
+ * `no-overlapping-claim` — the model extracted nothing over this span.
+ * `unendorsed-overlap`   — a claim DID overlap, but only quoted/hedged/non-endorsed, so the
+ *                          deterministic lane still books a gap. Distinguishing this from
+ *                          `no-overlapping-claim` is the whole point of the reason field: the
+ *                          extractor is being charged for a span it classified correctly.
+ * `invalid-envelope`     — the model envelope failed validation, so extraction is unknowable.
+ */
+export type ExtractionGapReason = 'no-overlapping-claim' | 'unendorsed-overlap' | 'invalid-envelope';
+
+/** Deterministic non-LLM recall floor (spec §2.1). Never a factual claim, never a verdict. */
+export interface ExtractionGapSignal {
+  kind: string;
+  minimumCriticality: ClaimCriticality;
+  reason: ExtractionGapReason;
+  span: { startByte: number; endByte: number };
+}
+
+/**
+ * Spec §2.1: `high` for protected approval/capacity/completion/credential cues, and
+ * `irreversible-precondition` when a consequential-action premise may be present.
+ * Anything else falls to the §2.3 `medium` default. Uncertainty rounds UP, never down (§2.3).
+ */
+const CUE_MINIMUM_CRITICALITY: Record<string, ClaimCriticality> = {
+  capacity: 'high',
+  completion: 'high',
+  attribution: 'high',
+  injection: 'high',
+  action: 'irreversible-precondition',
+  state: 'medium',
+};
+
 export function buildClaimCandidates(message: string): PreparedClaimObservation['candidates'] {
   const out: PreparedClaimObservation['candidates'] = [];
   const bytes = Buffer.from(message, 'utf8');
@@ -312,19 +345,46 @@ function compare(actual: number | string, expected: number | string, comparator:
   }
 }
 
-export function protectedCueGaps(message: string, claims: ExtractedClaim[]): string[] {
-  const ranges = claims.filter((claim) => claim.endorsed && !claim.quoted && !claim.hedged)
-    .map((claim) => [claim.sourceStartByte, claim.sourceEndByte] as const);
+/**
+ * Spec §2.1: emit one `ExtractionGapSignal` per protected-cue SPAN with no endorsed overlap —
+ * "every protected-cue span is placed in a deterministic shadow stratum". This is the coarse
+ * non-LLM recall floor: a high-criticality observation, NOT a normalized factual claim, so it
+ * can neither support nor refute anything and holds no blocking authority.
+ *
+ * Scans every candidate for every cue family. The prior implementation stopped at the first
+ * candidate matching each family and collapsed the result to a bare family name, which both
+ * under-counted (a later unmatched span was never examined) and erased the reason a span was
+ * booked — making the resulting gap totals uninterpretable.
+ */
+export function extractionGapSignals(
+  message: string,
+  claims: ExtractedClaim[],
+  opts: { envelopeValid?: boolean } = {},
+): ExtractionGapSignal[] {
   const candidates = buildClaimCandidates(message);
-  const gaps: string[] = [];
+  const signals: ExtractionGapSignal[] = [];
   for (const [name, pattern] of Object.entries(PROTECTED)) {
+    const minimumCriticality = CUE_MINIMUM_CRITICALITY[name] ?? 'medium';
     for (const candidate of candidates) {
       if (!pattern.test(candidate.text)) continue;
-      if (!ranges.some(([start, end]) => start < candidate.sourceEndByte && end > candidate.sourceStartByte)) gaps.push(name);
-      break;
+      const span = { startByte: candidate.sourceStartByte, endByte: candidate.sourceEndByte };
+      if (opts.envelopeValid === false) {
+        signals.push({ kind: name, minimumCriticality, reason: 'invalid-envelope', span });
+        continue;
+      }
+      const overlapping = claims.filter((claim) => claim.sourceStartByte < span.endByte
+        && claim.sourceEndByte > span.startByte);
+      if (overlapping.some((claim) => claim.endorsed && !claim.quoted && !claim.hedged)) continue;
+      signals.push({ kind: name, minimumCriticality,
+        reason: overlapping.length > 0 ? 'unendorsed-overlap' : 'no-overlapping-claim', span });
     }
   }
-  return [...new Set(gaps)];
+  return signals;
+}
+
+/** Deduped cue-family names, retained for existing counters and the audit row's `gapKinds`. */
+export function protectedCueGaps(message: string, claims: ExtractedClaim[]): string[] {
+  return [...new Set(extractionGapSignals(message, claims).map((signal) => signal.kind))];
 }
 
 export function newMessageAttemptId(): string { return randomUUID(); }
@@ -424,13 +484,58 @@ export class ClaimObservationRecorder {
     } catch { /* @silent-fallback-ok: failed settlement remains pending and reports false */ return false; }
   }
   recordEvent(input: Record<string, unknown>): boolean {
-    const allowed: Record<string, unknown> = { schemaVersion: 1, eventUuid: randomUUID() };
+    // schemaVersion 2 == this row may carry gapSignals. Rows written before the ExtractionGapSignal
+    // conformance fix are schemaVersion 1 and carry only a bare gapKinds list, so gap-rate figures
+    // must NOT be compared across the boundary: v1 rows undercount (the old scan stopped at the
+    // first matching candidate per family) and record no reason. Split on this, not on key-absence.
+    const allowed: Record<string, unknown> = { schemaVersion: 2, eventUuid: randomUUID() };
     for (const key of ['ts', 'evaluated', 'flagged', 'dryRun', 'event', 'verdict', 'actionKind', 'hadToolCalls', 'reason'] as const) {
       const value = input[key];
       if (typeof value === 'string') allowed[key] = value.slice(0, 128);
       else if (typeof value === 'boolean') allowed[key] = value;
     }
     if (Array.isArray(input.gapKinds)) allowed.gapKinds = input.gapKinds.filter((v): v is string => typeof v === 'string').slice(0, 8);
+    // Structural only: cue family, reason enum, criticality enum, and integer byte offsets.
+    // No message text, and these rows carry no messagePseudonym/topicPseudonym/claimId, so the
+    // offsets have no join key back to a message or topic.
+    //
+    // The cap is PER FAMILY, not a flat head-slice. extractionGapSignals emits family-outer
+    // (capacity, completion, attribution, action, state, injection), so a flat slice would drop
+    // whole trailing families — completion first, which is the family the gap-reason statistic is
+    // actually about, and injection (the adversarial family) entirely. That would bias the sample
+    // in the exact direction that makes it useless, and do it invisibly.
+    if (Array.isArray(input.gapSignals)) {
+      const perFamily = new Map<string, Array<Record<string, unknown>>>();
+      let dropped = false;
+      for (const raw of input.gapSignals) {
+        if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+        const signal = raw as Record<string, unknown>;
+        const span = (signal.span && typeof signal.span === 'object' ? signal.span : {}) as Record<string, unknown>;
+        const offset = (value: unknown): number => (typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : 0);
+        const kind = typeof signal.kind === 'string' ? signal.kind.slice(0, 32) : 'unknown';
+        const bucket = perFamily.get(kind) ?? [];
+        if (bucket.length >= 8) { dropped = true; continue; }
+        bucket.push({
+          kind,
+          reason: typeof signal.reason === 'string' ? signal.reason.slice(0, 32) : 'unknown',
+          minimumCriticality: CRITICALITIES.has(signal.minimumCriticality as ClaimCriticality)
+            ? signal.minimumCriticality as ClaimCriticality : 'medium',
+          span: { startByte: offset(span.startByte), endByte: offset(span.endByte) },
+        });
+        perFamily.set(kind, bucket);
+      }
+      // The per-family cap alone bounds the array at 8 x DISTINCT KINDS, and `kind` is
+      // caller-supplied. The in-tree producer only ever emits the 6 PROTECTED families (<=48), but
+      // recordEvent is an untrusted-input boundary, and appendBounded rotates-then-writes rather
+      // than rejecting an oversized row — so an unbounded row would cost audit history, not just
+      // space. Keep an unconditional ceiling too, and mark it when it bites.
+      const flattened = [...perFamily.values()].flat();
+      const signals = flattened.slice(0, 48);
+      if (signals.length < flattened.length) dropped = true;
+      if (signals.length > 0) allowed.gapSignals = signals;
+      // Loss is never silent: an analyst must be able to see that a cap trimmed a row.
+      if (dropped) allowed.gapSignalsTruncated = true;
+    }
     return this.appendBounded(this.auditPath, allowed, this.opts.maxAuditBytes ?? 50 * 1024 * 1024, true);
   }
   readPoolAggregates(limit = 100): Array<Record<string, unknown>> {

--- a/src/monitoring/CompletionClaimVerifier.ts
+++ b/src/monitoring/CompletionClaimVerifier.ts
@@ -8,7 +8,7 @@ import type { EvidenceActionKind, TurnEvidence } from './TurnEvidence.js';
 import { ClaimClauseArbiter, type ClaimClauseArbitration } from './ClaimClauseArbiter.js';
 import { ClaimObservationAdmissionQueue } from './ClaimObservationAdmissionQueue.js';
 import {
-  applyClaimCriticalityFloor, assessClaim, prepareClaimObservation, protectedCueGaps,
+  applyClaimCriticalityFloor, assessClaim, extractionGapSignals, prepareClaimObservation,
   ClaimObservationRecorder, newMessageAttemptId, type ClaimAssessment, type ClaimCriticality,
 } from './ClaimObservation.js';
 
@@ -172,7 +172,9 @@ export class CompletionClaimVerifier {
       if (arbitration.authoritative) this.bump('classifiedTurns');
       if (this.opts.generalObservation) {
         const claims = arbitration.general?.claims ?? [];
-        const gaps = protectedCueGaps(prepared.message, claims);
+        const gapSignals = extractionGapSignals(prepared.message, claims,
+          { envelopeValid: !!arbitration.general });
+        const gaps = [...new Set(gapSignals.map((signal) => signal.kind))];
         for (const _claim of claims) this.bump('generalClaims');
         for (const _gap of gaps) this.bump('protectedCueGaps');
         if (arbitration.general?.saturated || gaps.length > 0) this.bump('coverageIncompleteTurns');
@@ -189,7 +191,7 @@ export class CompletionClaimVerifier {
             outputTokens: arbitration.generalModel?.outputTokens })) this.bump('corpusDrops');
         }
         if (gaps.length > 0) this.appendAudit({ ts: new Date().toISOString(), evaluated: true,
-          event: 'protected-cue-unextracted', gapKinds: gaps, dryRun: this.opts.dryRun });
+          event: 'protected-cue-unextracted', gapKinds: gaps, gapSignals, dryRun: this.opts.dryRun });
       }
       if (!arbitration.authoritative) {
         this.bump('invalidOutputTurns');

--- a/tests/unit/extraction-gap-signal.test.ts
+++ b/tests/unit/extraction-gap-signal.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  extractionGapSignals,
+  protectedCueGaps,
+  ClaimObservationRecorder,
+  type ExtractedClaim,
+} from '../../src/monitoring/ClaimObservation.js';
+
+/**
+ * Spec claim-verification-sentinel.md §2.1 — the deterministic protected-predicate lane emits
+ * ExtractionGapSignal {minimumCriticality, reason, span}. Before this, the lane collapsed every
+ * gap to a bare cue-family name, so a gap booked because NOTHING overlapped was indistinguishable
+ * from a gap booked despite an overlapping claim the extractor CORRECTLY marked hedged/quoted.
+ * That ambiguity is what made the observed gap rate uninterpretable.
+ */
+
+const claimOver = (startByte: number, endByte: number, overrides: Partial<ExtractedClaim> = {}): ExtractedClaim => ({
+  clauseId: 0,
+  kind: 'completion',
+  subjectKind: 'tool-action',
+  predicate: 'tool-action.completed',
+  operand: { type: 'state-enum', value: 'done', enumVersion: 'action-v1' },
+  comparator: 'eq',
+  subjectSelector: { type: 'unresolved' },
+  consequence: { relation: 'none', actionClass: 'none' },
+  sourceStartByte: startByte,
+  sourceEndByte: endByte,
+  referencedEntityHints: [],
+  endorsed: true,
+  negated: false,
+  hedged: false,
+  quoted: false,
+  suggestedCriticality: 'low',
+  confidence: 0.9,
+  tenseScope: 'past',
+  ...overrides,
+});
+
+describe('ExtractionGapSignal — reason (spec §2.1)', () => {
+  const message = 'The migration is done.';
+
+  it('books no-overlapping-claim when the model extracted nothing over the span', () => {
+    const signals = extractionGapSignals(message, []).filter((s) => s.kind === 'completion');
+    expect(signals).toHaveLength(1);
+    expect(signals[0].reason).toBe('no-overlapping-claim');
+  });
+
+  it('books unendorsed-overlap when a hedged claim DID overlap — the extractor was not silent', () => {
+    const signals = extractionGapSignals(message, [claimOver(0, message.length, { hedged: true })])
+      .filter((s) => s.kind === 'completion');
+    expect(signals).toHaveLength(1);
+    // The distinction this whole change exists to make: a hedged overlap is the extractor
+    // classifying correctly, not the extractor missing a claim.
+    expect(signals[0].reason).toBe('unendorsed-overlap');
+  });
+
+  it.each([
+    ['quoted', { quoted: true }],
+    ['non-endorsed', { endorsed: false }],
+  ])('books unendorsed-overlap for a %s overlap too', (_label, overrides) => {
+    const signals = extractionGapSignals(message, [claimOver(0, message.length, overrides)])
+      .filter((s) => s.kind === 'completion');
+    expect(signals[0]?.reason).toBe('unendorsed-overlap');
+  });
+
+  it('books NO gap at all when an endorsed, unquoted, unhedged claim overlaps (the other side)', () => {
+    const signals = extractionGapSignals(message, [claimOver(0, message.length)])
+      .filter((s) => s.kind === 'completion');
+    expect(signals).toHaveLength(0);
+  });
+
+  it('books invalid-envelope when the model envelope failed validation', () => {
+    const signals = extractionGapSignals(message, [], { envelopeValid: false })
+      .filter((s) => s.kind === 'completion');
+    expect(signals[0]?.reason).toBe('invalid-envelope');
+  });
+});
+
+describe('ExtractionGapSignal — span and criticality floor', () => {
+  it('carries the byte span of the cue candidate, not the whole message', () => {
+    const message = 'Nothing here. The deploy is done.';
+    const [signal] = extractionGapSignals(message, []).filter((s) => s.kind === 'completion');
+    expect(signal.span.startByte).toBeGreaterThan(0);
+    expect(signal.span.endByte).toBeGreaterThan(signal.span.startByte);
+    expect(message.slice(signal.span.startByte, signal.span.endByte)).toContain('deploy');
+  });
+
+  it.each([
+    ['The deploy is done.', 'completion', 'high'],
+    ['We are capped at four lanes.', 'capacity', 'high'],
+    ['Justin approved it.', 'attribution', 'high'],
+    ['I will delete the branch.', 'action', 'irreversible-precondition'],
+    ['The job is running.', 'state', 'medium'],
+  ])('%s -> %s floors at %s (uncertainty rounds up)', (message, kind, expected) => {
+    const signal = extractionGapSignals(message, []).find((s) => s.kind === kind);
+    expect(signal?.minimumCriticality).toBe(expected);
+  });
+});
+
+describe('ExtractionGapSignal — every span, not just the first', () => {
+  it('catches a later unmatched span even when an earlier one was covered', () => {
+    // Two completion-cue sentences. The FIRST is covered by an endorsed claim; the second is not.
+    // The prior implementation stopped at the first matching candidate per cue family and would
+    // have reported no completion gap at all here.
+    const message = 'The merge is done. The deploy is finished.';
+    const firstEnd = message.indexOf('.') + 1;
+    const signals = extractionGapSignals(message, [claimOver(0, firstEnd)])
+      .filter((s) => s.kind === 'completion');
+    expect(signals).toHaveLength(1);
+    expect(signals[0].reason).toBe('no-overlapping-claim');
+    expect(signals[0].span.startByte).toBeGreaterThanOrEqual(firstEnd);
+  });
+
+  it('protectedCueGaps still returns deduped family names for existing counters', () => {
+    const gaps = protectedCueGaps('The merge is done. The deploy is finished.', []);
+    expect(gaps).toEqual([...new Set(gaps)]);
+    expect(gaps).toContain('completion');
+  });
+});
+
+describe('ExtractionGapSignal — audit persistence stays within the privacy boundary', () => {
+  const withRecorder = (fn: (recorder: ClaimObservationRecorder, dir: string) => void): void => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claim-gap-'));
+    try {
+      fn(new ClaimObservationRecorder({ stateDir: dir, pseudonymKey: Buffer.alloc(32, 9) }), dir);
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'claim-gap-test' });
+    }
+  };
+
+  const readAudit = (dir: string): Record<string, unknown> => JSON.parse(
+    fs.readFileSync(path.join(dir, 'state', 'claim-verification', 'claim-observation-audit-v2.jsonl'), 'utf8')
+      .trim().split('\n')[0],
+  );
+
+  it('persists structural gap signals and never the message text', () => {
+    withRecorder((recorder, dir) => {
+      const message = 'The migration is done.';
+      expect(recorder.recordEvent({ ts: new Date().toISOString(), evaluated: true,
+        event: 'protected-cue-unextracted', gapKinds: ['completion'],
+        gapSignals: extractionGapSignals(message, []).filter((s) => s.kind === 'completion'),
+        dryRun: true })).toBe(true);
+      const raw = fs.readFileSync(path.join(dir, 'state', 'claim-verification', 'claim-observation-audit-v2.jsonl'), 'utf8');
+      expect(raw).not.toContain('migration');
+      const row = readAudit(dir);
+      expect(row.gapSignals).toMatchObject([
+        { kind: 'completion', reason: 'no-overlapping-claim', minimumCriticality: 'high' },
+      ]);
+      expect((row.gapSignals as Array<{ span: unknown }>)[0].span)
+        .toMatchObject({ startByte: expect.any(Number), endByte: expect.any(Number) });
+    });
+  });
+
+  it('clamps a malformed signal rather than writing arbitrary caller data through', () => {
+    withRecorder((recorder, dir) => {
+      expect(recorder.recordEvent({ ts: new Date().toISOString(), evaluated: true,
+        event: 'protected-cue-unextracted',
+        gapSignals: [{ kind: 'x'.repeat(200), reason: 42, minimumCriticality: 'not-a-tier',
+          span: { startByte: -5, endByte: 'nope' }, secretField: 'gh-token-value' }],
+        dryRun: true })).toBe(true);
+      const raw = fs.readFileSync(path.join(dir, 'state', 'claim-verification', 'claim-observation-audit-v2.jsonl'), 'utf8');
+      expect(raw).not.toContain('gh-token-value');
+      expect(raw).not.toContain('secretField');
+      const signal = (readAudit(dir).gapSignals as Array<Record<string, unknown>>)[0];
+      expect((signal.kind as string).length).toBe(32);
+      expect(signal.reason).toBe('unknown');
+      expect(signal.minimumCriticality).toBe('medium');
+      expect(signal.span).toMatchObject({ startByte: 0, endByte: 0 });
+    });
+  });
+
+  it('caps PER FAMILY so a busy message cannot drop the completion family wholesale', () => {
+    withRecorder((recorder, dir) => {
+      // Family-outer emission means a flat head-slice would keep only `capacity` here and silently
+      // discard `completion` — the family the gap-reason statistic is actually about.
+      const message = Array.from({ length: 24 },
+        (_, i) => `Lane ${i} is capped and the deploy is done and running.`).join(' ');
+      const gapSignals = extractionGapSignals(message, []);
+      expect(gapSignals.length).toBeGreaterThan(24);
+      expect(recorder.recordEvent({ ts: new Date().toISOString(), evaluated: true,
+        event: 'protected-cue-unextracted', gapSignals, dryRun: true })).toBe(true);
+      const row = readAudit(dir);
+      const persisted = row.gapSignals as Array<{ kind: string }>;
+      const families = [...new Set(persisted.map((s) => s.kind))].sort();
+      expect(families).toEqual(['capacity', 'completion', 'state']);
+      for (const family of families) {
+        expect(persisted.filter((s) => s.kind === family).length).toBeLessThanOrEqual(8);
+      }
+      // Loss is recorded, never silent.
+      expect(row.gapSignalsTruncated).toBe(true);
+    });
+  });
+
+  it('bounds the array unconditionally against a hostile caller inventing kinds', () => {
+    withRecorder((recorder, dir) => {
+      // recordEvent is an untrusted-input boundary. A per-family cap alone bounds the array at
+      // 8 x DISTINCT KINDS, so 5000 invented kinds would each get their own bucket and land a
+      // ~500KB row — and appendBounded rotates-then-writes rather than rejecting, so an oversized
+      // row costs audit history.
+      expect(recorder.recordEvent({ ts: new Date().toISOString(), evaluated: true,
+        event: 'protected-cue-unextracted',
+        gapSignals: Array.from({ length: 5000 }, (_, i) => ({ kind: `invented-${i}`,
+          reason: 'no-overlapping-claim', minimumCriticality: 'high', span: { startByte: 0, endByte: 1 } })),
+        dryRun: true })).toBe(true);
+      const row = readAudit(dir);
+      expect((row.gapSignals as unknown[]).length).toBe(48);
+      expect(row.gapSignalsTruncated).toBe(true);
+    });
+  });
+
+  it('does not mark truncation when everything fit', () => {
+    withRecorder((recorder, dir) => {
+      expect(recorder.recordEvent({ ts: new Date().toISOString(), evaluated: true,
+        event: 'protected-cue-unextracted',
+        gapSignals: extractionGapSignals('The migration is done.', []),
+        dryRun: true })).toBe(true);
+      expect(readAudit(dir)).not.toHaveProperty('gapSignalsTruncated');
+    });
+  });
+
+  it('stamps schemaVersion 2 so gap rates are never compared across the conformance fix', () => {
+    withRecorder((recorder, dir) => {
+      recorder.recordEvent({ ts: new Date().toISOString(), evaluated: true,
+        event: 'protected-cue-unextracted', gapKinds: ['completion'], dryRun: true });
+      expect(readAudit(dir).schemaVersion).toBe(2);
+    });
+  });
+
+  it('omits gapSignals entirely when none are supplied, leaving legacy rows unchanged', () => {
+    withRecorder((recorder, dir) => {
+      expect(recorder.recordEvent({ ts: new Date().toISOString(), evaluated: true,
+        event: 'protected-cue-unextracted', gapKinds: ['completion'], dryRun: true })).toBe(true);
+      const row = readAudit(dir);
+      expect(row.gapKinds).toEqual(['completion']);
+      expect(row).not.toHaveProperty('gapSignals');
+    });
+  });
+});

--- a/upgrades/next/extraction-gap-signal-reason.md
+++ b/upgrades/next/extraction-gap-signal-reason.md
@@ -1,0 +1,55 @@
+## What Changed
+
+The claim-verification observer now records **why** a protected-cue span was booked as an extraction
+gap, instead of only recording that one was. Per `docs/specs/claim-verification-sentinel.md` §2.1,
+the deterministic protected-predicate lane is specified to emit
+`ExtractionGapSignal {minimumCriticality, reason, span}`. That signal had never been built — the
+shipped code returned a deduped list of bare cue-family names, so all three spec-distinguished causes
+rendered as the same string.
+
+Each gapped span now carries one of three reasons: `no-overlapping-claim` (the model extracted
+nothing there), `unendorsed-overlap` (a claim *did* overlap, but only quoted/hedged/non-endorsed —
+the extractor classified it correctly and was charged for a gap anyway), or `invalid-envelope`.
+
+Two correctness fixes came with it:
+
+- The cue scan stopped at the first matching candidate per family, so a later uncovered span was
+  never examined. It now scans every span, as §2.1 requires. Gap counts rise as a result — this is
+  a measurement fix, not an extractor regression.
+- Audit rows written by this path are stamped `schemaVersion: 2`. **Gap rates must not be compared
+  across that boundary**: version-1 rows undercount and carry no reason.
+
+## What to Tell Your User
+
+Nothing — there is no user-visible change, no new command, and no behavior difference in any
+conversation. This is internal measurement plumbing for a feature that ships dark and runs in
+dry-run: it observes and records, and holds no authority to block, delay, or alter any message.
+
+If a user asks why it was worth doing: the observer had been running for days producing a number
+nobody could interpret. About 89% of recorded gaps were the completion family, but with only a
+family name stored there was no way to distinguish the observer genuinely missing a claim from the
+observer being penalised for correctly marking something as hedged or quoted. The reason field
+separates those two, which is what the accumulated data was missing.
+
+## Summary of New Capabilities
+
+None for users. Internally, the claim observer's gap events now carry a reason, a byte span, and a
+criticality floor per gapped span instead of a bare family name, and the audit rows that record them
+are capped per family with an explicit marker whenever trimming occurs, so a trimmed sample can
+never be mistaken for a complete one.
+
+## Evidence
+
+- `tests/unit/extraction-gap-signal.test.ts` — 20 tests covering all three reasons, the no-gap case
+  (endorsed overlap), the criticality floor per cue family, span correctness, the every-span fix,
+  `gapKinds` back-compat, per-family truncation, and rejection of malformed caller payloads.
+- Old-vs-new demonstrated directly: on `"The migration is done."` the previous algorithm emits
+  `["completion"]` for a hedged overlap **and** for a true no-overlap — identical output, different
+  cause. On `"The merge is done. The deploy is finished."` with the first sentence covered, it emits
+  `[]` and misses the genuine gap.
+- Per-family truncation bug caught in second-pass review and reproduced before fixing: 72 signals on
+  a 24-candidate message, of which a flat head-slice kept only `capacity` and dropped `completion`
+  and `state` entirely.
+- 36/36 green (20 new, 11 pre-existing `claim-observation-v1` untouched, 5 integration
+  `completion-claim-stats-route`).
+- Side-effects review with second-pass: `upgrades/side-effects/extraction-gap-signal-reason.md`.

--- a/upgrades/side-effects/extraction-gap-signal-reason.md
+++ b/upgrades/side-effects/extraction-gap-signal-reason.md
@@ -1,0 +1,254 @@
+# Side-Effects Review — ExtractionGapSignal reason + span (spec §2.1 conformance)
+
+**Version / slug:** `extraction-gap-signal-reason`
+**Date:** `2026-07-27`
+**Author:** `echo`
+**Second-pass reviewer:** `required — sentinel/observability surface (see Phase 5 section)`
+
+## Summary of the change
+
+`docs/specs/claim-verification-sentinel.md` §2.1 specifies that the deterministic
+protected-predicate lane emits `ExtractionGapSignal {minimumCriticality, reason, span}` when a
+protected cue "has no overlapping endorsed claim, has only quoted/hedged/non-endorsed overlap, or
+the envelope is invalid." That signal was never built: `git grep ExtractionGapSignal` returned zero
+hits across `src/` and `tests/`. The shipped `protectedCueGaps()` returned a deduped list of bare
+cue-family names, so all three spec-distinguished causes rendered as the same string.
+
+This change implements the signal. `extractionGapSignals()` (in `src/monitoring/ClaimObservation.ts`)
+scans every candidate span for every cue family and returns one signal per gapped span carrying the
+reason, the byte span, and the §2.5 criticality floor. `protectedCueGaps()` is retained, now derived
+from those signals, so existing counters and the `gapKinds` audit field are unchanged.
+`CompletionClaimVerifier.observe()` writes the new `gapSignals` array alongside `gapKinds`, and
+`ClaimObservationRecorder.recordEvent()` gains a strictly-clamped, per-family-capped allowlist
+branch for it, stamping `schemaVersion: 2`.
+
+`gapKinds` keeps its shape and its consumers, but its *values* are monotone-increasing — see §5.
+
+Files touched: `src/monitoring/ClaimObservation.ts`, `src/monitoring/CompletionClaimVerifier.ts`,
+`tests/unit/extraction-gap-signal.test.ts` (new).
+
+**Why now:** the missing `reason` is the measurement blocker that held EVO-005 across eleven review
+cycles. 89.1% of gap events (295/331 in the live audit) are the `completion` family, and with only a
+family name recorded there is no way to tell a real extractor miss from the extractor being charged
+for a span it correctly marked hedged or quoted. Demonstrated concretely: under the old algorithm a
+hedged overlap and a true no-overlap both emit exactly `["completion"]`.
+
+## Decision-point inventory
+
+- `protectedCueGaps` / `extractionGapSignals` (`src/monitoring/ClaimObservation.ts`) — **modify** —
+  deterministic cue detector. Produces observations only. Holds no blocking authority before or
+  after this change.
+- `CompletionClaimVerifier.observe` audit emission — **modify** — adds a field to an existing
+  dark, dry-run audit row. No change to any return value that a caller branches on.
+- `ClaimObservationRecorder.recordEvent` allowlist — **modify** — adds one clamped structural field.
+
+---
+
+## 1. Over-block
+
+**No block/allow surface — over-block not applicable.** The signal never gates a message. The
+feature is dark (`dryRun: true` in production today) and §2.1 states the shadow signal "never
+creates a factual claim or verdict." `observe()`'s return contract is untouched.
+
+The nearest analogue to an over-block is over-*counting*: the fixed scan now books gaps the old
+first-match-then-break loop skipped, so gap counts rise. That is the correct count per §2.1 ("every
+protected-cue span"), but see §5 for the baseline discontinuity it creates.
+
+## 2. Under-block
+
+**No block/allow surface — under-block not applicable.**
+
+What the change still does *not* measure, stated plainly:
+
+- **Cue over-breadth is untouched.** The `completion` regex fires on the noun "fix" (983 occurrences
+  in the local message corpus, the single dominant token) and on instar's own term of art "ships
+  dark", which means deliberately DISABLED — the opposite of a completion claim. Those produce
+  `no-overlapping-claim` signals indistinguishable from genuine extractor misses. Separating them
+  requires recording the matched cue token, which is **out of scope here and deliberately so**: §2.6
+  fixes a closed audit field list and forbids raw claim text and plain content hashes, so a cue-token
+  field is a spec change needing its own convergence and approval.
+  <!-- tracked: ACT-1433 -->
+- `reason` therefore quantifies the endorsement-filter share of the gap rate exactly, and leaves the
+  cue-over-breadth share unresolved. It narrows the ambiguity; it does not eliminate it.
+- The `injection` family is assigned a `high` floor rather than its own tier. §2.1 names only
+  approval/capacity/completion/credential for `high` and consequential-action premises for
+  `irreversible-precondition`; injection markers are conservatively floored at `high` because
+  uncertainty rounds up per §2.3.
+- **Per-family truncation.** A single turn emitting more than 8 gapped spans in one family keeps the
+  first 8 of that family and sets `gapSignalsTruncated: true`. Within-family reason shares are
+  therefore biased toward earlier spans on those (rare) rows. The truncation is recorded, so such
+  rows can be excluded from a reason-share computation rather than silently skewing it.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The detector already lives in `ClaimObservation.ts` and already computed the overlap
+relation this change reports — the information was being discarded one line after being derived, not
+gathered somewhere new. No higher layer could reconstruct it, because only this function sees both
+the cue span and the claim's endorsed/quoted/hedged flags at the same time.
+
+This feeds the existing audit lane rather than creating a parallel one, per §2.6's "one bounded
+origin-local append/read/rotation path."
+
+## 4. Signal vs authority compliance
+
+**Compliant.** Reference: `docs/signal-vs-authority.md`.
+
+This is a detector producing a strictly richer structured signal. It gains no blocking power, adds
+no new code path that can refuse or alter a message, and does not become an input to any authority
+in this change. Per §2.1 the gap signal "is the coarse non-LLM recall floor: a high-criticality
+observation, not a normalized factual claim, and therefore cannot support/refute."
+
+The `minimumCriticality` field is worth calling out specifically: it is a *label carried on an
+observation*, not a threshold anything acts on. Nothing in this change reads it back.
+
+## 5. Interactions
+
+- **`gapKinds` shape preserved; values monotone-increasing.** `protectedCueGaps()` keeps returning
+  deduped family names and still populates `gapKinds`. But old ⊆ new strictly: the old loop pushed a
+  family iff the *first* pattern-matching candidate was uncovered, the new one iff *any* is, so
+  `gapKinds` can gain a family and can never lose one. The existing `toContain('capacity')` assertion
+  is safe and all 11 pre-existing tests pass unmodified — but "unchanged" would be wrong, and callers
+  comparing counts across the boundary must not treat the two as the same measurement.
+- **`coverageIncompleteTurns` shifts too.** `CompletionClaimVerifier` bumps it on `gaps.length > 0`,
+  and `gaps` can now be non-empty on turns where it previously was not. That counter moves in the
+  same direction and for the same reason, and is not a regression.
+- **Baseline discontinuity — the real interaction risk.** Anyone comparing gap rates across this
+  deploy sees a step change that is a measurement fix, not an extractor regression. **Split on
+  `schemaVersion`**: pre-change rows are `1`, post-change rows are `2`. Key-absence was the first
+  proposed marker and is wrong — it only works via a coupling (the verifier happens to write the row
+  only when signals exist), and `recordEvent` will legitimately write a `gapSignals`-free row, which
+  a dedicated test asserts. The version stamp is the durable marker.
+- **`schemaVersion` is per-row-TYPE, not per-file.** `recordEvent` rows are now `2`, while
+  `record()` and `recordAuthoritativeOutcome` keep writing `1` into the same
+  `claim-observation-audit-v2.jsonl`. Splitting gap rows on `schemaVersion >= 2` is correct because
+  gap rows are event rows; an analyst splitting the *whole file* will find claim-observation rows
+  stay `1` forever, which is expected and not a bug.
+- **Truncation cannot silently bias the sample.** The per-family cap replaced a flat head-slice that
+  would have dropped whole trailing families. Because emission is family-outer, that slice kept only
+  `capacity` on a busy message and discarded `completion` (the family the statistic is about) and
+  `injection` (the adversarial family) entirely — reproduced at 72 signals → 1 surviving family
+  before the fix, and covered by a regression test now.
+- **No double-fire.** The audit row is emitted once per turn under the existing `gaps.length > 0`
+  guard, which is unchanged.
+- **Shared metric untouched.** `this.bump('protectedCueGaps')` still iterates deduped kinds, so the
+  `/metrics/features` magnitude is not redefined by the richer signal list.
+
+## 6. External surfaces
+
+No route, no schema served to another agent, no user-visible surface. The audit file is local and
+already exists. `/completion-claim/stats` is unaffected — its integration test passes unmodified.
+
+Privacy: the new field carries a cue-family name, a reason enum, a criticality enum, and two integer
+byte offsets. No message text.
+
+**On whether byte offsets sit inside the §2.6 boundary — the honest argument.** An earlier draft of
+this artifact claimed the offsets are "the same class already carried by
+`sourceStartByte`/`sourceEndByte` throughout §2.6." That is false and has been removed: in §2.6 those
+offsets appear only as HMAC inputs to `claimId`, never as a persisted plaintext field, so this is the
+first plaintext persistence of that value. The real basis is threefold:
+
+1. The §2.6 closed field list is already pervasively exceeded by shipped code — `recordEvent` today
+   writes `ts, evaluated, flagged, event, verdict, actionKind, hadToolCalls, reason, gapKinds`, none
+   of which are in the list, and `record()` persists `actualLatencyMs`, a plaintext un-bucketed
+   numeric of exactly the class at issue. `gapSignals` introduces no *new* class of deviation.
+2. The forbidden categories are enumerated — raw text, paths, URLs, identities, secrets, credentials,
+   commands/results, free-form rationale, plain content hashes. A byte offset is none of them.
+3. The §2.6 re-identification concern is about *joining* shape/model/timing/pseudonym. These
+   `protected-cue-unextracted` rows carry no join key at all — no `messagePseudonym`,
+   `topicPseudonym`, or `claimId` — so the offsets are not joinable to a message or topic.
+
+Residual disclosure is real and worth naming: an offset pair is a coarse sentence-length/position
+fingerprint in mode-0600 local operational data. It sits strictly below the existing
+`actualLatencyMs` bar. If a reviewer disagrees that (1) is acceptable, the correct response is a
+spec-level cleanup of the closed list, not a carve-out for this field.
+
+Clamping: `recordEvent` clamps every field, drops unknown keys, and caps per family — covered by a
+test asserting a planted `secretField` never reaches disk. **This guarantee is conditional on
+`opts.recorder` being set.** `CompletionClaimVerifier.appendAudit` has a fallback path that writes
+the raw row to `logs/completion-claim-audit.jsonl` with no clamping. That is pre-existing (`gapKinds`
+has identical exposure) and carries no live risk here because `gapSignals` is internally produced,
+never caller-supplied — but the guarantee is not unconditional and should not be stated as such.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN**, and strictly more so than the pooled-rows posture would require.
+
+`gapSignals` never enters the pool projection at all: `readPoolAggregates`/`readPoolPage` read the
+corpus path, not the audit path, and the peer merge in `routes.ts` is an explicit field allowlist
+(`day, claimShapeId, modelDoor, verifierVersion, count, verdicts`). So there is no pool-side surface
+to leak — a reviewer should not go looking for one. (An earlier draft said the field "inherits the
+pooled untrusted-display posture," which invited exactly that wasted search.)
+
+The consequence for measurement: a gap-reason figure is per-machine and cannot be assembled across
+the pool through any existing read. No user-facing notice, no durable state that strands on topic
+transfer, no generated URL.
+
+## 8. Rollback cost
+
+**Low.** The change is additive and observation-only. Reverting the commit restores the prior
+function body; no migration, no agent state repair, no data cleanup. Existing audit rows remain
+readable either way because `gapSignals` is an optional key that consumers must already tolerate the
+absence of (every historical row lacks it). No release is gated on it and nothing reads the field
+back yet.
+
+---
+
+## Phase 5 — second-pass review
+
+Required: the change touches a sentinel/observability surface in the claim-verification family.
+
+**Reviewer verdict: "Concern raised" — one blocking finding, since resolved; several should-fixes,
+all folded into the sections above.**
+
+**Blocking (fixed).** The persisted `gapSignals` array used a flat `.slice(0, 24)`. Because
+`extractionGapSignals` emits family-outer, that silently dropped whole trailing families —
+reproduced on a 24-candidate message at 72 signals where only `capacity` survived and `completion`
+and `state` were discarded entirely. The bias ran precisely against the change's purpose: the
+motivating figure is that ~89% of gaps are the `completion` family, and `completion` was the first
+thing dropped. Resolved with a per-family cap of 8 plus a `gapSignalsTruncated` marker, and a
+regression test. **This is the finding that justifies the phase** — the change would otherwise have
+shipped a measurement instrument biased in the one direction guaranteed to make it useless, and the
+bias would not have shown up in any of the tests written before the review.
+
+**Should-fixes, all applied:** the §2.6 span justification was factually wrong and has been rewritten
+with the real argument (§6); `gapKinds` was described as "unchanged" when it is monotone-increasing
+(§5, summary); the `coverageIncompleteTurns` shift was unlisted (§5); `schemaVersion` was not bumped
+and the proposed key-absence split marker rested on a coupling (§5, now `schemaVersion: 2`); the
+multi-machine section overstated exposure (§7); the clamping guarantee is conditional on
+`opts.recorder` (§6); and two `§2.5` citations were actually `§2.3` (fixed in both the artifact and
+the code comment).
+
+**Second round — reviewer verdict: "Concur."** The blocking finding was independently re-verified
+against the staged code (72 signals produced → 24 persisted as 8/8/8 across all three families,
+`gapSignalsTruncated: true`, `schemaVersion: 2`). The reviewer agreed with capping per-family at 8
+rather than raising to 144, on the grounds that the statistic is a per-family reason *share*, so
+preserving the family distribution is the property that matters, and that the residual within-family
+position bias is *recoverable* because truncated rows are marked and can be excluded.
+
+**One new finding, introduced by the blocking fix, since resolved.** Replacing the flat
+`.slice(0, 24)` removed the *unconditional* array bound: the per-family cap alone bounds the array
+at 8 × distinct kinds, and `kind` is caller-supplied. Probed at 5,000 invented kinds → 5,000
+persisted objects in a ~559KB row, with `gapSignalsTruncated` correctly false because nothing was
+dropped per family. Not reachable from the in-tree producer (6 families, ≤48 objects), but
+`recordEvent` is deliberately an untrusted-input boundary and `appendBounded` rotates-then-writes
+instead of rejecting an oversized row, so an unbounded row would cost audit *history*. Resolved with
+an unconditional `.slice(0, 48)` that also sets the truncation marker, plus a hostile-input test.
+
+**Reviewer answers to the two questions posed:**
+- **(a) Span inside the privacy boundary:** yes, but not for the reason originally given. Basis
+  rewritten in §6.
+- **(b) Raising counts mid-soak:** correct; do not flag-preserve the old behavior. The old scan is a
+  recall bug, not a baseline — §2.7 sets deterministic protected-gap recall at 1.0 on closed cue
+  fixtures, which the broken scan structurally cannot meet. Preserving it would keep accumulating a
+  measurement known to be false in a known direction. Old ⊆ new is provable, so the discontinuity is
+  monotone and interpretable.
+
+**Open question the review surfaced, not resolved here:** whether the §2.7 readiness clock (≥1,000
+admitted messages / 200 settled T0 claims over 14 days) restarts for gap-rate metrics, given that
+this changes the definition of the measured quantity mid-window. It plausibly should. That is a
+judgment about the soak's validity, not about this code, and belongs to whoever reads the re-soak.
+<!-- tracked: ACT-1433 -->
+
+**Confirmed clean by the reviewer:** no blocking authority (nothing reads `gapSignals` or
+`minimumCriticality` back — the sole consumer maps to `kind` and discards the rest);
+level-of-abstraction fit; rollback cost; no double-fire; and the §2 cue-over-breadth disclosure.


### PR DESCRIPTION
## ELI16 — the observer wrote down that it missed something, but never why

A background watcher reads what I say and checks whether I'm making factual claims — "the deploy is
done", "we're capped at four lanes". It runs dark and in dry-run: it only watches and records, and
cannot block or change a single message.

It has a cheap safety net underneath the smart part. The safety net just looks for trigger words. If
a trigger word shows up in a sentence and the smart part didn't pull a claim out of that sentence,
the net writes down "possible miss here" so a human can check whether the smart part is any good.

The problem: it wrote down *that* it happened, never *why*. There are three quite different reasons,
and all three were being recorded as the same one word. Reason one, the smart part genuinely saw
nothing. Reason two, the smart part DID see something and correctly decided it wasn't a real claim —
someone was hedging ("this should be fixed"), or quoting someone else. Reason three, the smart part
crashed and we know nothing.

Reason two is the killer. The smart part did its job *right*, and got a black mark for it. Since all
three looked identical in the log, nobody could tell whether the watcher was actually bad at its job
or was being blamed for being good at it. About 89% of the recorded misses were one category, and
that number was uninterpretable — which is why this sat unfixed for eleven review cycles.

This change writes the reason down. It also fixes two real bugs found on the way: the net gave up
after the first trigger word in each category, so a miss later in the same message was never looked
at; and when there were too many findings to store, it threw away whole categories starting with the
exact one everybody cares about — silently. Now it keeps a fair sample from every category and flags
when it had to trim.

What it does NOT do: tell you *which* trigger word fired. That matters, because "fix" is usually just
a noun ("the next fix"), and this project says "ships dark" constantly to mean a feature is turned
OFF — the opposite of finished — and both trip the net. Recording the actual word touches a privacy
rule about what may be stored, so it needs its own approval and is deliberately not in here.

Nothing user-visible changes. This is a measuring instrument being made readable before anyone tries
to draw a conclusion from it.

## What this fixes

`docs/specs/claim-verification-sentinel.md` §2.1 specifies the deterministic protected-predicate lane emit `ExtractionGapSignal {minimumCriticality, reason, span}`. **It was never built** — `git grep ExtractionGapSignal` returns zero hits across `src/` and `tests/`. The shipped `protectedCueGaps()` returned deduped bare cue-family names, so all three spec-distinguished causes rendered as the same string.

This is the measurement blocker behind **EVO-005**, which has sat "not implemented" across eleven review cycles. 89.1% of live gap events (295/331) are the `completion` family, but with only a family name stored there is no way to separate a genuine extractor miss from the extractor being *charged* for a span it correctly marked hedged or quoted.

Demonstrated on the old code — identical output, different cause:

| input | old output |
|---|---|
| `"The migration is done."` + hedged overlapping claim | `["completion"]` |
| `"The migration is done."` + no claims at all | `["completion"]` |
| `"The merge is done. The deploy is finished."`, first sentence covered | `[]` ← misses a real gap |

## What changed

- **`reason`** per gapped span: `no-overlapping-claim` / `unendorsed-overlap` / `invalid-envelope`. The middle one is the case that was invisible.
- **Every span scanned**, per §2.1. The old scan stopped at the first matching candidate per family, so a later uncovered span was never examined. Gap counts rise — a measurement fix, not an extractor regression. Old ⊆ new, so the discontinuity is monotone.
- **`schemaVersion: 2`** on event rows. Gap rates must not be compared across that boundary: v1 rows undercount and carry no reason.
- `gapKinds` shape and its counters are preserved (values are monotone-increasing, documented).

## Scope boundary — deliberate

Recording the matched **cue token** is *not* here. That would separate cue over-breadth (the bare noun "fix" at 983 occurrences; instar's own "ships dark", which means *disabled*, fires the completion cue). §2.6 fixes a closed audit field list and forbids raw claim text, so a cue-token field is a spec change needing its own convergence and approval. `reason` quantifies the endorsement-filter share exactly and leaves the cue-over-breadth share open.

## Review

Second-pass review caught a **blocking** defect in the first cut: the persisted array used a flat `.slice(0, 24)` while emission is family-outer, so a busy message kept only `capacity` and dropped `completion` (the family the statistic is about) and `injection` entirely — biased precisely against the change's purpose, and invisibly. Reproduced at 72 signals → 1 surviving family. Now capped per family at 8 with a `gapSignalsTruncated` marker, plus an unconditional 48 ceiling because `recordEvent` is an untrusted-input boundary and `appendBounded` rotates-then-writes rather than rejecting an oversized row.

Reviewer re-verified against the staged code and returned **Concur**.

## Verification

- 37 tests green locally (20 new, 11 pre-existing untouched, 5 integration), `tsc --noEmit` clean.
- **The local smoke tier self-skipped** (`affected-test listing timed out`) because the host test-runner slot was saturated by a concurrent drive — CI is the authority for the full suite here, not my machine.
- Side-effects artifact with the full second-pass exchange: `upgrades/side-effects/extraction-gap-signal-reason.md`.

Spec: `docs/specs/claim-verification-sentinel.md` (approved, converged 2026-07-21)
Refs: ACT-1433, EVO-005

🤖 Generated with [Claude Code](https://claude.com/claude-code)
