### PR TITLE
fix(rule3-gate): registry lookup could never match a provider file

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-28T09-04-07-027Z-rule3-registry-lookup-provider-paths.json
+++ b/.instar/instar-dev-decisions/2026-07-28T09-04-07-027Z-rule3-registry-lookup-provider-paths.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-28T09:04:07.027Z",
+  "slug": "rule3-registry-lookup-provider-paths",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 19,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-28T09-04-41-932Z-rule3-registry-lookup-provider-paths.json
+++ b/.instar/instar-dev-decisions/2026-07-28T09-04-41-932Z-rule3-registry-lookup-provider-paths.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-28T09:04:41.932Z",
+  "slug": "rule3-registry-lookup-provider-paths",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 19,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/scripts/check-rule3-coverage.cjs
+++ b/scripts/check-rule3-coverage.cjs
@@ -149,9 +149,22 @@ function readRegistry() {
 }
 
 function isInRegistry(filepath, registryContent) {
-  // Strip src/ prefix; the registry uses paths relative to src/.
-  const stripped = filepath.replace(/^src\//, '');
-  return registryContent.includes(stripped);
+  // The registry's Location column is SECTION-relative, not uniformly relative
+  // to src/. Most sections write paths relative to src/, but the provider
+  // substrate section ("Provider substrate (`src/providers/`)") writes them
+  // relative to src/providers/ — 21 of its 23 rows, measured on main.
+  //
+  // Stripping only `src/` therefore looked for `providers/adapters/X.ts` while
+  // the row said `adapters/X.ts`, so no provider file could ever match. A file
+  // listed in three registry rows was still refused for a "missing registry
+  // entry", which told the author to add a row that already existed.
+  if (registryContent.includes(filepath.replace(/^src\//, ''))) return true;
+  // Only widen for genuine provider paths, so no other file gains a match it
+  // would not otherwise have had.
+  if (filepath.startsWith('src/providers/')) {
+    return registryContent.includes(filepath.replace(/^src\/providers\//, ''));
+  }
+  return false;
 }
 
 function hasMatchingCanary(stagedFiles, filepath) {

--- a/tests/unit/scripts/check-rule3-coverage.test.ts
+++ b/tests/unit/scripts/check-rule3-coverage.test.ts
@@ -30,9 +30,19 @@ delete childEnv.GIT_INDEX_FILE;
 delete childEnv.GIT_OBJECT_DIRECTORY;
 delete childEnv.GIT_COMMON_DIR;
 
+/**
+ * Run the COPY of the script inside the tmp repo, not the original.
+ *
+ * The script resolves the state-detector registry from `__dirname/../specs/`,
+ * so running the original made it read the real repo's registry while reading
+ * staged files from the tmp repo. `beforeEach` has always copied the script in
+ * — the copy was simply never executed, so every registry fixture was silently
+ * ignored and the "already in the registry" branch had no reachable coverage.
+ */
 function runCheck(cwd: string): { exitCode: number; stderr: string } {
+  const scriptInRepo = path.join(cwd, 'scripts', 'check-rule3-coverage.cjs');
   try {
-    execFileSync('node', [SCRIPT_PATH], { cwd, encoding: 'utf-8', stdio: 'pipe', env: childEnv });
+    execFileSync('node', [scriptInRepo], { cwd, encoding: 'utf-8', stdio: 'pipe', env: childEnv });
     return { exitCode: 0, stderr: '' };
   } catch (err) {
     const e = err as { status: number; stderr: Buffer | string };
@@ -45,6 +55,19 @@ function stage(cwd: string, filepath: string, content: string): void {
   fs.mkdirSync(path.dirname(full), { recursive: true });
   fs.writeFileSync(full, content, 'utf-8');
   execFileSync('git', ['add', filepath], { cwd, stdio: 'pipe', env: childEnv });
+}
+
+/**
+ * Overwrite the tmp repo's state-detector registry with the given table rows.
+ * The default fixture registry is empty, so the "already in the registry"
+ * branch of the gate was never exercised before these tests.
+ */
+function writeRegistry(cwd: string, ...rows: string[]): void {
+  fs.writeFileSync(
+    path.join(cwd, 'specs', 'provider-portability', '06-state-detector-registry.md'),
+    ['# Registry', '', '| Location | Status |', '|---|---|', ...rows, ''].join('\n'),
+    'utf-8',
+  );
 }
 
 describe('check-rule3-coverage.cjs', () => {
@@ -75,6 +98,39 @@ describe('check-rule3-coverage.cjs', () => {
     stage(repo, 'src/core/banal.ts', 'export const x = 1;');
     const result = runCheck(repo);
     expect(result.exitCode).toBe(0);
+  });
+
+  // A registry entry does NOT exempt on its own: the gate requires
+  // `inRegistry && (hasRationale || hasCanary)`. These two cases therefore
+  // stage a registered file that carries a rationale but no canary — the
+  // combination the registry branch exists to serve.
+  //
+  // The registry's Location column is section-relative. Most sections write
+  // paths relative to src/, but the provider-substrate section writes them
+  // relative to src/providers/ (21 of its 23 rows, measured on main).
+  const RATIONALE = '/** RULE 3.1 RATIONALE — advisory read; loud fallback. */';
+
+  it('accepts a registered file with a rationale when the registry path is relative to src/', () => {
+    writeRegistry(repo, '| `core/Widget.ts` — parses a subprocess result | 🔵 Exempt |');
+    stage(repo, 'src/core/Widget.ts', `${RATIONALE}\nexport const r = JSON.parse(stdout);`);
+    expect(runCheck(repo).exitCode).toBe(0);
+  });
+
+  it('accepts a registered provider file with a rationale when the registry path is relative to src/providers/', () => {
+    writeRegistry(
+      repo,
+      '| `adapters/openai-codex/observability/logTailer.ts` — parses a subprocess result | 🔵 Exempt |',
+    );
+    stage(
+      repo,
+      'src/providers/adapters/openai-codex/observability/logTailer.ts',
+      `${RATIONALE}\nexport const r = JSON.parse(stdout);`,
+    );
+    // Before the section-relative fix this failed: the gate stripped only
+    // `src/`, looked for `providers/adapters/...`, never matched the row that
+    // was right there, and refused the file for "registry entry or canary
+    // file" — telling the author to add a row that already existed.
+    expect(runCheck(repo).exitCode).toBe(0);
   });
 
   it('blocks when a staged source file fetches from Anthropic without canary or rationale', () => {

--- a/upgrades/next/rule3-registry-lookup-provider-paths.md
+++ b/upgrades/next/rule3-registry-lookup-provider-paths.md
@@ -1,0 +1,39 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The Rule 3 pre-commit gate's registry lookup could never match a file under `src/providers/`.
+
+`isInRegistry()` stripped only `src/`, so it searched the state-detector registry for
+`providers/adapters/foo/Bar.ts` — while the registry's provider section writes its Location column
+relative to `src/providers/`, i.e. `adapters/foo/Bar.ts`. 21 of that section's 23 rows use that
+form. The strings never met.
+
+A registered file was therefore still refused, with a message instructing the author to add a
+registry entry that already existed — in one case, one that appears in three separate rows.
+
+The lookup now also tries the `src/providers/`-relative form, guarded by
+`filepath.startsWith('src/providers/')` so no other file gains a match it did not already have.
+
+## What to Tell Your User
+
+Nothing. This is a contributor-facing pre-commit script — not shipped, not executed at runtime, no
+user-visible behaviour.
+
+## Summary of New Capabilities
+
+None. A registry entry still does not exempt a file on its own: `inRegistry && (hasRationale ||
+hasCanary)` is unchanged. This only stops the gate from ignoring a registry row that genuinely
+exists.
+
+## Evidence
+
+- Red → green, observed rather than predicted: the provider case failed and the `src/`-relative
+  control passed before the fix (1 failed / 23 passed); 24/24 after. The control is what isolates
+  the cause to the path form.
+- **Why the branch had no coverage:** `tests/unit/scripts/check-rule3-coverage.test.ts` copied the
+  script into its tmp repo but executed the *original*. Since the script resolves its registry from
+  `__dirname/../specs/`, it read the real repo's registry while reading staged files from the tmp
+  repo — so every registry fixture a test wrote was silently ignored. Fixed by running the copy;
+  all 22 pre-existing tests pass unchanged under the corrected harness.
+- Side-effects review: `upgrades/side-effects/rule3-registry-lookup-provider-paths.md`.

--- a/upgrades/rule3-registry-lookup-provider-paths.eli16.md
+++ b/upgrades/rule3-registry-lookup-provider-paths.eli16.md
@@ -1,0 +1,36 @@
+# ELI16 — the gate told authors to add a registry row that was already there
+
+There is a registry listing every place Instar reads state from something it doesn't control.
+A pre-commit gate uses it: if your file is in the registry *and* carries a rationale comment,
+the gate lets it through.
+
+For files under `src/providers/`, that lookup could never succeed.
+
+**Why.** The gate turned `src/providers/adapters/foo/Bar.ts` into
+`providers/adapters/foo/Bar.ts` and searched the registry for that string. But the registry's
+provider section writes its paths relative to `src/providers/`, so the row actually says
+`adapters/foo/Bar.ts`. The two never matched — 21 of the 23 provider rows are written that way.
+
+The result: a file listed in the registry — one of them appears in **three** rows — was still
+refused, with a message telling the author to add a registry entry. Adding the row again would
+not have helped. That is the worst kind of gate message: it is confidently wrong about what
+would fix it.
+
+**Why nobody noticed.** The test file for this gate builds a throwaway repo, copies the script
+into it, writes a registry fixture — and then runs the *original* script instead of the copy.
+The script finds its registry relative to its own folder, so it read the real repo's registry
+while reading the staged files from the throwaway one. Every registry fixture a test wrote was
+quietly ignored, so this whole branch had no working test coverage. That is fixed here too, by
+running the copy.
+
+**How I know the fix works rather than believing it.** I wrote two tests: the provider case, and
+a control using the ordinary path form that should already have worked. Before the fix the
+provider one failed and the control passed. After, both pass, and the 22 tests that were already
+there still pass.
+
+Worth saying: the control failed on my first attempt too, which meant my explanation was wrong.
+Chasing that disagreement is what turned up the harness defect. A control test that fails is
+telling you something.
+
+**Scope.** A registry entry still does not exempt a file on its own — a rationale or a canary is
+still required. This only stops the gate from ignoring a registry row that genuinely exists.

--- a/upgrades/side-effects/rule3-registry-lookup-provider-paths.md
+++ b/upgrades/side-effects/rule3-registry-lookup-provider-paths.md
@@ -1,0 +1,57 @@
+# Side-effects review — Rule 3 gate registry lookup (provider paths)
+
+**Change:** `isInRegistry()` in `scripts/check-rule3-coverage.cjs` gains a second, narrowly-scoped
+path form; `tests/unit/scripts/check-rule3-coverage.test.ts` runs the copied script instead of the
+original and gains 2 tests + a registry-fixture helper.
+
+## Direction of effect — the only question that matters for a gate
+
+This makes the gate **strictly more permissive**, so the risk to weigh is a false ACCEPT, never a
+false refusal.
+
+| Surface | Effect |
+|---|---|
+| Non-provider files | **None.** The widened form is behind `filepath.startsWith('src/providers/')`, so no other file can gain a match it did not already have. |
+| Provider files, registered, with rationale | Now correctly accepted (was refused). **This is the fix.** |
+| Provider files, registered, no rationale/canary | Still refused — `inRegistry && (hasRationale \|\| hasCanary)` is unchanged. |
+| Provider files, unregistered | Still refused. Containment against a row that does not exist still fails. |
+| Runtime / shipped product | **None.** A pre-commit script; not in `src/`, not bundled, not executed by the server. |
+
+## The false-accept surface, stated plainly
+
+Containment is a substring test, so a short row path could in principle match an unintended file.
+That property is **pre-existing** and unchanged in kind — this only adds a second candidate string
+for paths already under `src/providers/`. A file would need to be under `src/providers/` *and* have
+its `src/providers/`-relative path appear verbatim in the registry, which is precisely the
+condition the fix exists to honour.
+
+I considered resolving each row against its section heading instead, which would remove the
+guesswork entirely. It is the better long-term shape and a larger change; it is not done here.
+
+## Test-harness change — read this as a coverage change, not a cosmetic one
+
+`runCheck` now executes the copy inside the tmp repo. The script resolves the registry from
+`__dirname/../specs/`, so running the original read the **real** repo's registry while reading
+staged files from the tmp repo.
+
+Consequence: every registry fixture written by a test was silently ignored, and the
+"already in the registry" branch had **no reachable coverage at all**. `beforeEach` had always
+copied the script in — the copy was simply never run.
+
+All 22 pre-existing tests pass unchanged under the corrected harness, which is the evidence that
+this repaired coverage rather than altering what those tests assert.
+
+## Verification
+
+- **Red → green, observed:** before the fix, the provider test failed and the `src/`-relative
+  control passed (1 failed / 23 passed). After, 24/24.
+- The control is the load-bearing part: it fails if the cause is anything other than the provider
+  path form.
+- **A correction this produced:** on my first attempt the control failed *too*, which meant my
+  explanation was wrong — a registry entry alone never exempted anything. Following that
+  disagreement is what surfaced the harness defect. The earlier claim that 26 files on `main` were
+  affected is withdrawn: all 26 lack a rationale and would be refused regardless.
+
+## Rollback
+
+`git revert`. Restores the unreachable lookup; no state, no migration, no config.


### PR DESCRIPTION
## ELI16 — the gate told authors to add a registry row that was already there

A registry lists every place Instar reads state from something it doesn't control. The Rule 3
pre-commit gate uses it: if your file is in the registry **and** carries a rationale comment, it
passes.

For anything under `src/providers/`, that lookup could never succeed.

`isInRegistry()` stripped only `src/` and searched for `providers/adapters/foo/Bar.ts`. But the
registry's provider section writes its Location column relative to `src/providers/` — the row says
`adapters/foo/Bar.ts`. **21 of that section's 23 rows use that form.** The strings never met.

So a registered file was still refused, told to add a registry entry that already existed. One
affected file (`conversationLogReader.ts`) appears in **three** rows. That is the worst kind of
gate message — confidently wrong about what would fix it.

## Why it had no test coverage

`tests/unit/scripts/check-rule3-coverage.test.ts` builds a throwaway repo, copies the script in,
writes a registry fixture — then executes the **original** script via `SCRIPT_PATH`.

The script resolves its registry from `__dirname/../specs/`, so it read the **real** repo's
registry while reading staged files from the tmp repo. Every registry fixture a test wrote was
silently ignored, and the "already in the registry" branch was unreachable. `beforeEach` had always
copied the script in — the copy was simply never run.

Fixed here by running the copy. **All 22 pre-existing tests pass unchanged**, which is the evidence
this repaired coverage rather than changing what they assert.

## Direction of effect

Strictly **more permissive**, so the only risk worth weighing is a false accept.

| case | before | after |
|---|---|---|
| provider file, registered, with rationale | refused ❌ | accepted ✅ **(the fix)** |
| provider file, registered, no rationale/canary | refused | refused — `inRegistry && (hasRationale \|\| hasCanary)` unchanged |
| provider file, unregistered | refused | refused |
| any non-provider file | unchanged | unchanged — widening is behind a `startsWith('src/providers/')` guard |

## Verification — observed, not predicted

Red → green with a **control**:

```
before fix:  1 failed | 23 passed   ← provider case failed, src/-relative control passed
after fix:  24 passed
```

The control is the load-bearing part: it fails if the cause is anything other than the provider
path form.

**A correction this produced.** On my first attempt the control failed *too*, which meant my
explanation was wrong — a registry entry alone never exempted anything; the gate always also
required a rationale or canary. Chasing that disagreement is what surfaced the harness defect. I
have withdrawn an earlier claim that 26 files on `main` were affected: all 26 lack a rationale and
would be refused regardless.

## Not done here

Resolving each row against its section heading would remove the path guesswork entirely. It is the
better long-term shape and a larger change.

## Risk

Low. Not in `src/`, not shipped, not executed at runtime — a pre-commit script and its test.
`git revert` restores the unreachable lookup; no state, no migration, no config.