### PR TITLE
fix(rule3-gate): judge the author's contribution, not everything a merge stages

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-28T09-29-01-994Z-rule3-gate-judges-author-contribution.json
+++ b/.instar/instar-dev-decisions/2026-07-28T09-29-01-994Z-rule3-gate-judges-author-contribution.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-28T09:29:01.994Z",
+  "slug": "rule3-gate-judges-author-contribution",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 43,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/scripts/check-rule3-coverage.cjs
+++ b/scripts/check-rule3-coverage.cjs
@@ -113,7 +113,50 @@ const STATE_DETECTION_PATTERNS = [
 const RULE3_EXEMPT_COMMENT_RE = /RULE\s*3\s*:\s*EXEMPT/i;
 const RULE3_RATIONALE_COMMENT_RE = /RULE\s*3\.1\s*RATIONALE/i;
 
+/**
+ * The incoming ref, if a merge is in progress. `MERGE_HEAD` exists only between
+ * `git merge` starting and the merge commit being written — exactly the window
+ * this hook runs in.
+ */
+function mergeHeadIfMerging() {
+  try {
+    const out = execSync('git rev-parse -q --verify MERGE_HEAD', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return out.trim() || null;
+  } catch {
+    return null; // not a merge — `rev-parse -q --verify` exits non-zero
+  }
+}
+
 function getStagedFiles() {
+  // During a MERGE the index holds every file that differs between the branch
+  // base and the incoming ref — i.e. effectively all of the incoming branch.
+  // Judging that as the committer's work makes anyone merging `main` into an
+  // older branch the author of all of `main`, so they are refused for
+  // pre-existing violations that are absent from their own diff and that they
+  // did not write. That refusal names a file they cannot see, so the natural
+  // responses are to edit someone else's code or reach for --no-verify.
+  //
+  // A committer's real contribution to a merge is what differs from the
+  // INCOMING ref: a file taken verbatim from MERGE_HEAD was not authored here.
+  // A conflict resolution DOES differ from MERGE_HEAD, so genuinely authored
+  // content is still evaluated — see the merge-semantics tests, which assert
+  // both directions.
+  const mergeHead = mergeHeadIfMerging();
+  if (mergeHead) {
+    try {
+      const out = execSync(
+        `git diff --cached --name-only --diff-filter=ACMR ${mergeHead}`,
+        { encoding: 'utf-8' },
+      );
+      return out.split('\n').filter((l) => l.trim().length > 0);
+    } catch {
+      // Fall through to the full staged list — the STRICTER reading, so a
+      // failure here can only over-report, never silently let code past.
+    }
+  }
   try {
     const out = execSync('git diff --cached --name-only --diff-filter=ACMR', {
       encoding: 'utf-8',

--- a/tests/unit/scripts/check-rule3-coverage.test.ts
+++ b/tests/unit/scripts/check-rule3-coverage.test.ts
@@ -415,3 +415,98 @@ export const _x = OpenAI;`,
     expect(result.exitCode).toBe(0);
   });
 });
+
+/**
+ * Merge semantics.
+ *
+ * A merge stages every file that differs between the branch base and the
+ * incoming ref. Judging that whole index as the committer's work makes anyone
+ * merging `main` into an older branch the author of all of `main` — so they are
+ * refused for pre-existing violations absent from their own diff, which they
+ * cannot see and did not write.
+ *
+ * The committer's real contribution to a merge is what differs from the
+ * INCOMING ref (`MERGE_HEAD`). A file taken verbatim from the incoming side was
+ * not authored here; a conflict resolution was.
+ */
+describe('check-rule3-coverage.cjs — merge semantics', () => {
+  let repo: string;
+  // `init.defaultBranch` varies by machine (main / master / anything). Capture
+  // the real name instead of hardcoding one — a hardcoded guess passes on the
+  // author's box and fails on everyone else's.
+  let baseBranch: string;
+
+  function git(cwd: string, ...args: string[]): string {
+    return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: 'pipe', env: childEnv });
+  }
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'rule3-merge-'));
+    git(repo, 'init', '-q');
+    git(repo, 'config', 'user.email', 'test@example.com');
+    git(repo, 'config', 'user.name', 'test');
+    fs.mkdirSync(path.join(repo, 'scripts'), { recursive: true });
+    fs.copyFileSync(SCRIPT_PATH, path.join(repo, 'scripts', 'check-rule3-coverage.cjs'));
+    fs.mkdirSync(path.join(repo, 'specs', 'provider-portability'), { recursive: true });
+    fs.writeFileSync(
+      path.join(repo, 'specs', 'provider-portability', '06-state-detector-registry.md'),
+      '# Registry\n\n(Empty for tests.)\n',
+    );
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-q', '-m', 'base');
+    baseBranch = git(repo, 'rev-parse', '--abbrev-ref', 'HEAD').trim();
+    git(repo, 'branch', 'incoming');
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('does NOT judge a violating file that came verbatim from the incoming ref', () => {
+    // The incoming branch introduces the violation — as `main` did with
+    // devClaimCheck.ts. The merging author never touched it.
+    git(repo, 'checkout', '-q', 'incoming');
+    stage(repo, 'src/core/TheirViolation.ts', 'export const r = JSON.parse(stdout);');
+    git(repo, 'commit', '-q', '-m', 'incoming adds a detector');
+
+    git(repo, 'checkout', '-q', baseBranch);
+    stage(repo, 'src/core/OurUnrelated.ts', 'export const x = 1;');
+    git(repo, 'commit', '-q', '-m', 'ours');
+
+    // --no-commit leaves MERGE_HEAD set, which is the state the hook runs in.
+    try {
+      git(repo, 'merge', '--no-commit', '--no-ff', 'incoming');
+    } catch {
+      /* a no-commit merge exits non-zero by design; the index is what matters */
+    }
+    // Sanity: the file IS staged (so a pass here is not vacuous — it means the
+    // gate looked at the index and correctly attributed the file elsewhere).
+    expect(git(repo, 'diff', '--cached', '--name-only')).toContain('src/core/TheirViolation.ts');
+
+    expect(runCheck(repo).exitCode).toBe(0);
+  });
+
+  it('DOES judge a file the author resolved differently from the incoming ref', () => {
+    // Both sides touch the same file; the author resolves it with violating
+    // content. That content exists on neither parent — it was authored here.
+    git(repo, 'checkout', '-q', 'incoming');
+    stage(repo, 'src/core/Contested.ts', 'export const a = 1;\n');
+    git(repo, 'commit', '-q', '-m', 'incoming version');
+
+    git(repo, 'checkout', '-q', baseBranch);
+    stage(repo, 'src/core/Contested.ts', 'export const b = 2;\n');
+    git(repo, 'commit', '-q', '-m', 'our version');
+
+    try {
+      git(repo, 'merge', '--no-commit', '--no-ff', 'incoming');
+    } catch {
+      /* conflict expected */
+    }
+    // The author's resolution introduces the detector.
+    stage(repo, 'src/core/Contested.ts', 'export const r = JSON.parse(stdout);\n');
+
+    const result = runCheck(repo);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('src/core/Contested.ts');
+  });
+});

--- a/upgrades/next/rule3-gate-judges-author-contribution.md
+++ b/upgrades/next/rule3-gate-judges-author-contribution.md
@@ -1,0 +1,39 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The Rule 3 pre-commit gate judged **everything a merge stages** as the committer's work.
+
+An ordinary commit's index is the author's change. A merge's index is every file that differs between
+the branch base and the incoming ref — so merging `main` into an older branch made the committer the
+author of all of `main`, and they were refused for pre-existing violations absent from their own diff.
+Measured on a branch based at 2026-06-01: 905 staged `src/*.ts`, refused on two files the merger never
+touched.
+
+While a merge is in progress the gate now diffs against `MERGE_HEAD`. A file taken verbatim from the
+incoming ref was not authored by the committer; a conflict resolution was, and is still evaluated.
+Outside a merge nothing changes. If the comparison fails, the gate falls back to the full index — the
+stricter reading, so a failure can only over-report.
+
+## What to Tell Your User
+
+Nothing. A contributor-facing pre-commit script — not shipped, not executed at runtime, no
+user-visible behaviour.
+
+## Summary of New Capabilities
+
+None. This narrows *who* a rule is enforced against, not what the rule requires. It removes a class of
+refusal that named a file the author could not see — the response to which was to edit someone else's
+code or skip the check.
+
+## Evidence
+
+- Red → green with a control: the verbatim-from-incoming test failed while the author-resolved control
+  passed (1 failed / 25 passed); 26/26 after. The control is what distinguishes scoping the gate from
+  weakening it — content matching neither parent is still judged.
+- The verbatim test asserts the offending file **is staged** before expecting a pass, so the pass
+  cannot come from an empty file list.
+- All 24 pre-existing tests pass unchanged.
+- Harness bug fixed en route: the new tests hardcoded `master` while `init.defaultBranch` is `main`
+  here; the branch name is now read from the repo rather than assumed.
+- Side-effects review: `upgrades/side-effects/rule3-gate-judges-author-contribution.md`.

--- a/upgrades/rule3-gate-judges-author-contribution.eli16.md
+++ b/upgrades/rule3-gate-judges-author-contribution.eli16.md
@@ -1,0 +1,34 @@
+# ELI16 — you were being judged as the author of everything you merged
+
+A pre-commit check looks at "the files you are committing" to decide whether new code that reads
+outside systems ships with its required justification. It gets that list from the git index.
+
+For an ordinary edit, the index *is* your change. **For a merge it is not.** Merging `main` into an
+older branch stages every file that differs between your branch and `main` — hundreds or thousands of
+them. The check then treats all of it as yours.
+
+So you get refused for a rule broken by a file you have never opened, which does not appear in your
+diff, in code somebody else wrote months ago. Measured on a branch based at 1 June: the merge stages
+905 TypeScript files and the check refuses on two of them, neither touched by the merger.
+
+That refusal is worse than annoying. It names a file you cannot see, so the two natural responses are
+to go and edit someone else's code, or to reach for the flag that skips the check. Neither is what
+anyone wanted.
+
+**The fix.** While a merge is in progress git records the incoming side as `MERGE_HEAD`. Your actual
+contribution to a merge is whatever differs from *that* — a file taken verbatim from the incoming
+branch was not written by you. So during a merge the check now compares against the incoming ref
+instead of the whole index.
+
+**It does not go soft.** If you resolve a conflict, your resolution matches neither parent, so it is
+still yours and still checked. There is a test for exactly that, and it fails if the fix is too
+permissive. Outside a merge nothing changes at all — same list, same behaviour, and the 24 existing
+tests pass untouched.
+
+If the comparison itself fails for any reason, the check falls back to the old full list. That is the
+stricter reading, so a failure can only ever over-report — it can never quietly let something past.
+
+**Why this is the right layer.** A sweep finds 26 files on `main` that would trip this rule. Which of
+them bites you depends on how old your branch is, because only files changed since your branch point
+get staged. Adding justifications one file at a time is chasing a moving target; making the check
+judge your own work fixes every version of the problem at once.

--- a/upgrades/side-effects/rule3-gate-judges-author-contribution.md
+++ b/upgrades/side-effects/rule3-gate-judges-author-contribution.md
@@ -1,0 +1,53 @@
+# Side-effects review — Rule 3 gate judges the author's contribution
+
+**Change:** `getStagedFiles()` in `scripts/check-rule3-coverage.cjs` diffs against `MERGE_HEAD` while
+a merge is in progress; a new `mergeHeadIfMerging()` helper detects that state. Two merge-semantics
+tests added.
+
+## Direction of effect — the only question that matters for a gate
+
+More permissive **during a merge only**, so the risk to weigh is a false ACCEPT.
+
+| situation | before | after |
+|---|---|---|
+| Ordinary commit (no merge) | full index | **identical** — `MERGE_HEAD` absent, original path taken |
+| Merge: file verbatim from incoming ref | judged as yours ❌ | not judged ✅ **(the fix)** |
+| Merge: file you resolved / authored | judged | **still judged** — differs from `MERGE_HEAD` |
+| Merge: unrelated file you also staged | judged | **still judged** — differs from `MERGE_HEAD` |
+| `git diff` against `MERGE_HEAD` fails | n/a | falls back to the full index — the **stricter** reading |
+
+The load-bearing claim is row 3, and it is asserted by a test that fails if the fix is too permissive.
+It is the reason this is scoping rather than weakening: content that exists on neither parent is
+authored content, and it is still evaluated.
+
+## What could go wrong, honestly
+
+**A file the author deliberately reverts to the incoming version.** If you resolve a conflict by
+taking the incoming side wholesale, that file no longer differs from `MERGE_HEAD` and is not judged.
+That is correct by the definition used here — you contributed no content — but it does mean a merge
+cannot be used to *re-introduce* an incoming violation under your name. Since the incoming ref already
+contains it, the rule was already not being enforced there; this changes who is asked to fix it, not
+whether it exists.
+
+**Octopus merges** (>1 `MERGE_HEAD`) — `rev-parse --verify MERGE_HEAD` returns the first only. Rare in
+this repo and it degrades toward the stricter side.
+
+**Not addressed:** the 26 latent violators on `main` remain. This stops them landing on whoever merges
+next; it does not add their missing justifications.
+
+## Blast radius
+
+Pre-commit script only. Not in `src/`, not bundled, not executed at runtime, no state, no migration,
+no config. `git revert` restores the previous behaviour exactly.
+
+## Verification
+
+- **Red → green with a control**: before the fix the verbatim-from-incoming test failed while the
+  author-resolved control passed (1 failed / 25 passed) — the control is what proves the fix targets
+  the right thing rather than disabling the check. 26/26 after.
+- The verbatim test asserts the file **is staged** before expecting a pass, so a pass cannot come from
+  an empty file list.
+- All 24 pre-existing tests pass unchanged.
+- A harness bug found and fixed en route: the tests hardcoded `master`, but `init.defaultBranch` is
+  `main` here. The branch name is now read from the repo, so the tests do not depend on the author's
+  git config.


### PR DESCRIPTION
## ELI16 — you were being judged as the author of everything you merged

The Rule 3 pre-commit gate asks git for "the files being committed" and gets the index.

For an ordinary edit the index **is** your change. **For a merge it is not.** Merging `main` into an
older branch stages every file that differs between your branch and `main`, and the gate treats all of
it as yours.

Measured on a branch based at 2026-06-01:

```
staged src/*.ts : 905
refused on      : src/commands/devCiFailures.ts
                  src/commands/devClaimCheck.ts     ← neither touched by the merger
```

That refusal is worse than noise: it names a file absent from your own diff, so the two natural
responses are to go edit somebody else's code, or reach for `--no-verify`.

## The fix

While a merge is in progress git records the incoming side as `MERGE_HEAD`. Your contribution to a
merge is whatever differs from **that** — a file taken verbatim from the incoming ref was not written
by you. During a merge the gate now diffs against `MERGE_HEAD`.

| situation | before | after |
|---|---|---|
| ordinary commit (no merge) | full index | **identical** — `MERGE_HEAD` absent, original path |
| merge: file verbatim from incoming | judged as yours ❌ | not judged ✅ **(the fix)** |
| merge: file you resolved / authored | judged | **still judged** |
| merge: unrelated file you staged | judged | **still judged** |
| the `MERGE_HEAD` diff itself fails | n/a | falls back to full index — the **stricter** reading |

Row 3 is the load-bearing one, and a test asserts it: content matching neither parent is authored
content and is still evaluated. That test fails if the fix is too permissive, which is what separates
*scoping* the gate from *weakening* it.

## Why this layer, and not 26 individual fixes

A read-only sweep finds **26** files on `main` matching a state-detection pattern with no marker.
Which of them bites you is `(latent violators) ∩ (files changed since your branch's base)` — so it is a
function of how old your branch is. Adding justifications one file at a time chases a moving target;
this fixes every version at once.

It does **not** add the 26 missing justifications. It stops them landing on whoever merges next.

## Verification — observed, with a control

```
before fix:  1 failed | 25 passed   ← verbatim-from-incoming failed, author-resolved control PASSED
after  fix: 26 passed
```

- The verbatim test asserts the offending file **is staged** before expecting a pass, so the pass
  cannot come from an empty file list. (I got burned by exactly that earlier today — a merge failed on
  an unfetched ref, nothing staged, and the checker exited 0 over an empty list. A vacuous pass is
  byte-identical to a real one.)
- All 24 pre-existing tests pass unchanged.
- **Harness bug found and fixed en route:** the new tests hardcoded `master` while `init.defaultBranch`
  is `main` here. The branch name is now read from the repo, so the tests do not depend on the author's
  git config.

## Two things I want a reviewer to look at

1. **The tier signal said 2, I declared 1.** `suggestedTier=2 (size=2, riskFloor=1, 43 LOC)`; the gate
   accepted Tier 1 and the signal is advisory. My reasoning: pre-commit script, not in `src/`, not
   shipped, not executed at runtime, byte-identical outside a merge. Flagging it rather than letting it
   pass unmentioned.
2. **Taking the incoming side wholesale.** Resolve a conflict by accepting the incoming version and
   that file no longer differs from `MERGE_HEAD`, so it is not judged. Correct by the definition used
   here — you contributed no content — but it means a merge cannot re-introduce an incoming violation
   under your name. The incoming ref already contains it, so this changes *who is asked to fix it*, not
   whether it exists.

## Risk

Low. Pre-commit script only — no state, no migration, no config, nothing shipped. `git revert` restores
the previous behaviour exactly.