### PR TITLE
fix(git-sync): bare push could leave cross-machine sync silently dead

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-28T11-38-52-120Z-gitsync-push-upstream.json
+++ b/.instar/instar-dev-decisions/2026-07-28T11-38-52-120Z-gitsync-push-upstream.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-28T11:38:52.120Z",
+  "slug": "gitsync-push-upstream",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 18,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/core/GitSync.ts
+++ b/src/core/GitSync.ts
@@ -532,7 +532,23 @@ export class GitSyncManager {
       this.gitExec(['commit', '-m', message]);
 
       if (this.autoPush) {
-        this.gitExec(['push']);
+        try {
+          this.gitExec(['push']);
+        } catch (pushErr) {
+          // A branch with NO upstream cannot be pushed by a bare `git push` —
+          // git exits non-zero, the catch below returns `false`, and `false` is
+          // the SAME value this method returns for "no dirty paths" and
+          // "nothing staged". So the caller cannot tell a failed sync from
+          // having nothing to sync, and cross-machine state goes quiet with no
+          // signal: commits land locally and never reach origin.
+          //
+          // Retry ONCE with an explicit upstream. This is a no-op when tracking
+          // already exists, so the happy path is unchanged — the bare push is
+          // still attempted first and only a failure reaches here.
+          const branch = this.gitExec(['symbolic-ref', '--short', 'HEAD']).trim();
+          if (!branch) throw pushErr;
+          this.gitExec(['push', '-u', 'origin', branch]);
+        }
       }
 
       return true;

--- a/tests/unit/GitSync.test.ts
+++ b/tests/unit/GitSync.test.ts
@@ -150,6 +150,51 @@ describe('GitSyncManager', () => {
       expect(pushCalls.length).toBe(1);
     });
 
+    // A branch with NO upstream cannot be pushed by a bare `git push`. That
+    // failure returns the SAME `false` this method returns for "nothing to
+    // commit", so a dead sync is indistinguishable from an idle one.
+    it('does NOT add an explicit upstream when the bare push succeeds', () => {
+      const config = createConfig();
+      const manager = new GitSyncManager(config);
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('')                  // git status --porcelain -z
+        .mockReturnValueOnce('')                  // git add
+        .mockReturnValueOnce('some-file.json\n')  // git diff --cached --name-only
+        .mockReturnValueOnce('')                  // git commit
+        .mockReturnValueOnce('');                 // git push (succeeds)
+
+      manager.commitAndPush('test commit');
+
+      const upstreamPushes = vi.mocked(execFileSync).mock.calls.filter(
+        (call) => call[0] === 'git' && (call[1] as string[]).join(' ').includes('push -u origin'),
+      );
+      expect(upstreamPushes.length).toBe(0);
+    });
+
+    it('retries with an explicit upstream when the bare push fails', () => {
+      const config = createConfig();
+      const manager = new GitSyncManager(config);
+      vi.mocked(execFileSync)
+        .mockReturnValueOnce('')                  // git status --porcelain -z
+        .mockReturnValueOnce('')                  // git add
+        .mockReturnValueOnce('some-file.json\n')  // git diff --cached --name-only
+        .mockReturnValueOnce('')                  // git commit
+        .mockImplementationOnce(() => {           // git push -> no upstream
+          throw new Error('fatal: The current branch has no upstream branch');
+        })
+        .mockReturnValueOnce('main\n')            // git symbolic-ref --short HEAD
+        .mockReturnValueOnce('');                 // git push -u origin main
+
+      const ok = manager.commitAndPush('test commit');
+
+      const upstreamPushes = vi.mocked(execFileSync).mock.calls.filter(
+        (call) => call[0] === 'git' && (call[1] as string[]).join(' ') === 'push -u origin main',
+      );
+      expect(upstreamPushes.length).toBe(1);
+      // the retry SUCCEEDING must not be reported as a failed sync
+      expect(ok).toBe(true);
+    });
+
     it('respects autoPush=false', () => {
       const config = createConfig({ autoPush: false });
       const manager = new GitSyncManager(config);

--- a/upgrades/gitsync-push-upstream.eli16.md
+++ b/upgrades/gitsync-push-upstream.eli16.md
@@ -1,0 +1,27 @@
+# ELI16 — cross-machine sync could go silently dead
+
+When machines coordinate, they agree on who is in charge by committing a small record and pushing it
+to the shared repository. That push was written as a plain `git push` with no argument.
+
+A plain `git push` only works if the branch already knows where to push to. On a branch that does not,
+git refuses. The code caught that refusal and returned "false".
+
+The trouble is that "false" is what the same function returns when there was simply **nothing to
+send**. So a machine whose pushes were all failing looked exactly like a machine that had nothing to
+say. Its records piled up locally and never reached anyone, and nothing anywhere reported a problem.
+
+This was reported from real hardware back in May — one machine's coordination records committing
+locally and never reaching the shared repo, with no logs. Reading the code today, it is still there.
+
+**The fix is deliberately small.** The plain push is still tried first, exactly as before. Only if it
+fails does the code now ask git which branch it is on and try once more, saying explicitly where to
+push. If pushing already worked, nothing changes at all.
+
+I did not touch the "false means two different things" problem in the same change. It deserves its own
+fix, and the code that consumes it already handles the ambiguity defensively, so the urgent half is
+the push that never lands.
+
+**How I know it works rather than believing it.** Two tests: one proves the explicit push happens when
+the plain one fails, and one proves it does *not* happen when the plain one succeeds. With the fix
+removed, the first fails and the second still passes — which is what tells me the first is testing the
+fix and not something incidental.

--- a/upgrades/next/gitsync-push-upstream.md
+++ b/upgrades/next/gitsync-push-upstream.md
@@ -1,0 +1,35 @@
+<!-- bump: patch -->
+
+## What Changed
+
+`GitSync.commitAndPush` pushed with a bare `git push`. On a branch with no upstream that fails, and the
+catch returned `false` — the **same value** the method returns for "no dirty paths" and "nothing
+staged". So a machine whose pushes were all failing was indistinguishable from one with nothing to
+sync: commits landed locally, never reached origin, and nothing reported a problem.
+
+This is the cross-machine coordination path. PR #489 reported the consequence from real hardware in
+May — lease epochs committing locally and never reaching origin, with zero logs. Reading `main` today,
+there is no `set-upstream` anywhere in that file.
+
+The bare push is still attempted first. Only if it fails does the code resolve the branch and retry
+once as `push -u origin <branch>`, which is a no-op when tracking already exists.
+
+## What to Tell Your User
+
+Nothing to do. On a multi-machine setup this removes a way for machine-to-machine sync to stop working
+without saying so.
+
+## Summary of New Capabilities
+
+None. It makes an existing sync path report and recover instead of failing silently.
+
+## Evidence
+
+- Red → green with a control: without the fix the retry test fails (1 failed / 37 passed); with it,
+  38/38. The happy-path control — asserting NO extra push when the bare push succeeds — passes in both
+  directions, which is what shows the change is additive.
+- Verified on `origin/main` that `set-upstream` / `-u origin` / `branch --set` appear **zero** times in
+  `src/core/GitSync.ts`.
+- The `false`-means-three-things conflation is deliberately NOT fixed here: it is a semantic change to
+  a value `GitLeaseStore` and `RegistrySyncDebouncer` branch on, and `GitLeaseStore:80` already handles
+  it defensively. Tracked separately.

--- a/upgrades/side-effects/gitsync-push-upstream.md
+++ b/upgrades/side-effects/gitsync-push-upstream.md
@@ -1,0 +1,47 @@
+# Side-effects review — GitSync.commitAndPush upstream retry
+
+**Change:** `src/core/GitSync.ts` — the `autoPush` block gains a `try/catch`; on failure it resolves
+the branch via `symbolic-ref --short HEAD` and retries once as `push -u origin <branch>`. Two tests.
+
+## Direction of effect
+
+Strictly **additive on the failure path only**.
+
+| situation | before | after |
+|---|---|---|
+| bare `push` succeeds | pushed | **identical** — no extra git call (asserted by test) |
+| bare `push` fails, branch resolvable | `false` (looks like "nothing to do") | one retry with explicit upstream |
+| bare `push` fails, no branch (detached HEAD) | `false` | original error rethrown → same `false` |
+| `autoPush === false` | no push | unchanged |
+
+The happy path executes the same single git command it always did. That is asserted, not assumed —
+`does NOT add an explicit upstream when the bare push succeeds` fails if a second push ever appears.
+
+## Why the retry is safe
+
+`push -u origin <branch>` is a no-op with respect to tracking when tracking already exists, and it is
+only reached when the bare push has *already failed* — so it cannot turn a working sync into a broken
+one. The branch comes from `symbolic-ref --short HEAD`, which this file already uses in two other
+places, so no new failure mode is introduced; a detached HEAD yields an empty string and the original
+error is rethrown rather than pushing somewhere unintended.
+
+## What this deliberately does NOT fix
+
+`commitAndPush` returns `false` for three distinct situations: no dirty paths, nothing staged, and the
+push threw. A caller cannot tell "nothing to sync" from "sync failed".
+
+Not addressed here, for two reasons. It is a **semantic** change to a return value that `GitLeaseStore`
+and `RegistrySyncDebouncer` branch on — the lease mechanism that decides which machine serves — so it
+deserves its own change with its own review. And `GitLeaseStore:80` already handles the ambiguity
+defensively ("Push rejected (a peer advanced) or no-op" → re-read after a pull and retry), so the
+acute failure is the push that never lands, not the conflated return.
+
+Filed separately rather than bundled: bundling a behavioural change to the lease path into a push fix
+is how one review ends up covering two risks.
+
+## Verification
+
+- **Red → green with a control**: without the src change, `retries with an explicit upstream when the
+  bare push fails` FAILS (1 failed / 37 passed); with it, 38/38. The happy-path control passes in both
+  directions, which is what shows the change is additive rather than a behaviour swap.
+- `tsc --noEmit` clean.


### PR DESCRIPTION
## ELI16 — a machine could stop syncing and look exactly like a machine with nothing to say

Machines coordinate by committing a small record and pushing it to the shared repo. That push was a
bare `git push`.

A bare `git push` needs the branch to already know where it goes. On a branch that doesn't, git
refuses — and the catch returned `false`. But `false` is *also* what this method returns when there
was nothing to send:

```ts
if (filesToAdd.length === 0) return false;          // nothing to do
...
if (!diff.trim()) return false;                     // nothing to do
this.gitExec(['commit', '-m', message]);
if (this.autoPush) { this.gitExec(['push']); }      // ← bare push
return true;
} catch {
  // @silent-fallback-ok — push failure boolean return
  return false;                                     // ← push FAILED
}
```

So a machine whose pushes were all failing was indistinguishable from an idle one. Records piled up
locally, never reached anyone, and nothing reported a problem.

This isn't hypothetical. #489 reported it from real hardware in May: *"the awake machine's lease epochs
committed locally but never reached origin, with zero logs → entire cross-machine sync silently dead."*
Checked on `main` today — `set-upstream`, `-u origin` and `branch --set` appear **zero times** in that
file.

## The change is additive

The bare push is still attempted **first**, so a working setup executes exactly the same single git
command it always did. Only a failure reaches the new code, which resolves the branch via
`symbolic-ref --short HEAD` (already used twice elsewhere in this file) and retries once with an
explicit upstream — a no-op for tracking that already exists. A detached HEAD rethrows the original
error rather than pushing somewhere unintended.

## Verification — red → green, with a control

```
without the src change:  1 failed | 37 passed   ← the retry test fails
with it:                38 passed
```

The second test is the load-bearing one: **`does NOT add an explicit upstream when the bare push
succeeds`** passes in *both* directions. That is what demonstrates this is additive rather than a
behaviour swap — if the fix ever starts issuing a second push on the happy path, that test fails.

## What I deliberately did NOT fix

`false` meaning three different things.

That is a **semantic** change to a return value `GitLeaseStore` and `RegistrySyncDebouncer` branch on —
the lease mechanism that decides which machine serves. It deserves its own change and its own review.
And `GitLeaseStore:80` already handles the ambiguity defensively (*"Push rejected (a peer advanced) or
no-op"* → re-read after a pull and retry), so the acute failure is the push that never lands, not the
conflated return.

Bundling a behavioural change to the lease path into a push fix is how one review ends up silently
covering two risks. Tracked separately.

## Provenance

Found while triaging whether #489's six May defects are still real. Four of them I could classify; two
are already fixed on `main` by different routes, which is why #489 needs **splitting** rather than
merging or closing. This is the one that is still live and severe, extracted as its own change against
current `main`.