### PR TITLE
fix(fs): widen the recursive-delete retry budget from ~300ms to ~1s

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-28T12-29-32-346Z-rm-retry-budget.json
+++ b/.instar/instar-dev-decisions/2026-07-28T12-29-32-346Z-rm-retry-budget.json
@@ -1,0 +1,16 @@
+{
+  "ts": "2026-07-28T12:29:32.346Z",
+  "slug": "rm-retry-budget",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/SafeFsExecutor.ts matches SafeFsExecutor (destructive-fs funnel)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 21,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/core/SafeFsExecutor.ts
+++ b/src/core/SafeFsExecutor.ts
@@ -130,9 +130,28 @@ export class SafeFsExecutor {
    * loaded runner — a whole-class flake every tmpdir-cleanup test inherits.
    * Explicit caller-set values always win; non-recursive deletes unchanged.
    */
+  /**
+   * Retry budget for recursive+force removals.
+   *
+   * Raised from 3x100ms (~300ms) to 10x100ms (~1s) after a CI failure on main
+   * (2026-07-28): `ENOTEMPTY` on `rmdir` of a temp dir's `.git`, from a test whose
+   * setup runs real `git add` + `git commit`. The retries WERE in force — they
+   * simply ran out. A git child process (or its index.lock) can outlive a
+   * ~300ms window when the runner is loaded, so the teardown raced a process
+   * still writing into the directory.
+   *
+   * This widens the budget; it does not prove any budget is sufficient. A
+   * removal that is genuinely blocked now fails after ~1s instead of ~300ms,
+   * which costs nothing — the operation was going to fail either way. The
+   * deeper fix for the git case is ensuring the child has exited before
+   * teardown, which belongs with the tests rather than here.
+   *
+   * Only applied when the caller did not specify `maxRetries`, so an explicit
+   * choice always wins.
+   */
   private static withRmRetryDefaults<T extends fs.RmOptions>(rmOpts: T): T {
     if (rmOpts.recursive && rmOpts.force && rmOpts.maxRetries === undefined) {
-      return { ...rmOpts, maxRetries: 3, retryDelay: 100 };
+      return { ...rmOpts, maxRetries: 10, retryDelay: 100 };
     }
     return rmOpts;
   }

--- a/tests/unit/SafeFsExecutor.test.ts
+++ b/tests/unit/SafeFsExecutor.test.ts
@@ -1,5 +1,5 @@
 // safe-git-allow: this is the test file for SafeFsExecutor; direct fs usage is for fixture setup only.
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -330,5 +330,48 @@ describe('safeRm/safeRmSync — transient-error retry defaults (CI tmpdir-cleanu
     await SafeFsExecutor.safeRm(file, { force: true, operation: 'nonrecursive-test' });
     expect(fs.existsSync(file)).toBe(false);
     fs.rmdirSync(dir);
+  });
+});
+
+/**
+ * The rm retry budget had NO coverage before 2026-07-28, which is how a CI
+ * failure on main (`ENOTEMPTY` tearing down a temp dir holding a live git repo)
+ * reached a state where the retries were in force and simply too small.
+ *
+ * These assert the two BEHAVIOURS, deliberately not the numbers — pinning the
+ * constant would just restate it, and the budget is expected to be tuned.
+ */
+describe('SafeFsExecutor — rm retry budget', () => {
+  let sandbox: string;
+  beforeEach(() => { sandbox = mkSandbox('sfe-retry-'); });
+  afterEach(() => { rmrf(sandbox); });
+
+  it('applies a retry budget when recursive+force and the caller gave none', () => {
+    const target = path.join(sandbox, 'doomed');
+    fs.mkdirSync(target);
+    const spy = vi.spyOn(fs, 'rmSync').mockImplementation(() => undefined);
+    try {
+      SafeFsExecutor.safeRmSync(target, { recursive: true, force: true, operation: 'rm-retry-test' });
+      const opts = spy.mock.calls[0]?.[1] as fs.RmOptions;
+      expect(opts?.maxRetries).toBeGreaterThan(0);
+      expect(opts?.retryDelay).toBeGreaterThan(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('never overrides a maxRetries the caller chose explicitly', () => {
+    const target = path.join(sandbox, 'doomed2');
+    fs.mkdirSync(target);
+    const spy = vi.spyOn(fs, 'rmSync').mockImplementation(() => undefined);
+    try {
+      SafeFsExecutor.safeRmSync(target, {
+        recursive: true, force: true, maxRetries: 1, operation: 'rm-retry-explicit',
+      });
+      const opts = spy.mock.calls[0]?.[1] as fs.RmOptions;
+      expect(opts?.maxRetries).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/upgrades/next/rm-retry-budget.md
+++ b/upgrades/next/rm-retry-budget.md
@@ -1,0 +1,34 @@
+<!-- bump: patch -->
+
+## What Changed
+
+`SafeFsExecutor`'s recursive-delete retry budget goes from 3 attempts × 100ms (~300ms) to 10 × 100ms
+(~1s), for callers that pass `recursive` + `force` and do not choose their own `maxRetries`.
+
+Main went red twice on 2026-07-28 with filesystem races in test teardown — one `ENOTEMPTY` removing a
+temp dir holding a live git repo, one `EEXIST` in a performance worker — both while four CI runs
+competed for the same runners. In the first, the retries **were** in force and simply ran out: git's
+own child work can hold a directory longer than ~300ms on a loaded machine.
+
+## What to Tell Your User
+
+Nothing — internal robustness for filesystem cleanup.
+
+## Summary of New Capabilities
+
+None. A delete that would have succeeded still succeeds; one that never will now takes ~700ms longer
+to say so.
+
+## Evidence
+
+- `SafeFsExecutor.test.ts` 22/22, `SafeFsExecutor-atomicWrite.test.ts` 9/9, and `handoff-manager.test.ts`
+  (the suite that failed on main) 71/71.
+- Two tests added for behaviour that had **zero** coverage: a budget is applied when the caller gives
+  none, and an explicit `maxRetries` is never overridden. **They would pass on `main` too** — they guard
+  the mechanism, not the tuning, and are not evidence that ~1s is the right number.
+- **This does not prove the flake is closed.** No retry budget can be proven sufficient under arbitrary
+  load. The deeper fix for the git case is ensuring the child process has exited before teardown, which
+  belongs with the tests.
+- Prior art found while checking: `migrateWorktreeConvention.test.ts:110` already hand-rolls
+  `maxRetries: 5` with a comment about racing async cleanup — someone hit this class before and worked
+  around it locally rather than raising the shared default.

--- a/upgrades/rm-retry-budget.eli16.md
+++ b/upgrades/rm-retry-budget.eli16.md
@@ -1,0 +1,28 @@
+# ELI16 — a cleanup step gave up after a third of a second
+
+When a test finishes, it deletes its temporary folder. Deleting a folder can fail if something is
+still writing into it, so the delete is retried — three times, a tenth of a second apart. About a third
+of a second of patience in total.
+
+That is fine on an idle machine. It is not fine when the folder contains a real git repository and the
+machine is busy: git's own background work can hold the folder for longer than that, the retries run
+out, and the cleanup fails with "directory not empty". The test suite goes red for a reason that has
+nothing to do with the code being tested.
+
+That happened on main today, twice in one evening across two different tests — both while four builds
+were competing for the same machines.
+
+**What I changed:** the patience, from about a third of a second to about one second. Nothing else.
+
+**What I want to be honest about:** I cannot prove one second is enough. Nobody can — it depends on how
+loaded the machine is. This makes the failure much less likely; it does not make it impossible. A
+delete that was always going to fail now takes a second longer to say so, which costs nothing.
+
+The deeper fix for the git case is making sure git has actually finished before the cleanup starts, and
+that belongs with the tests rather than here.
+
+**Also added: two tests for behaviour that had none.** The retry logic had never been tested at all,
+which is how it reached a state where it was running and simply too small. They check that a retry
+budget is applied when the caller doesn't specify one, and that a caller who *does* specify one is never
+overridden. They deliberately don't assert the specific numbers — those are expected to be tuned, and a
+test that just repeats a constant tells you nothing.

--- a/upgrades/side-effects/rm-retry-budget.md
+++ b/upgrades/side-effects/rm-retry-budget.md
@@ -1,0 +1,48 @@
+# Side-effects review — recursive-delete retry budget
+
+**Change:** one constant in `SafeFsExecutor.withRmRetryDefaults` (`maxRetries: 3` → `10`, delay
+unchanged at 100ms), plus a doc block and two new tests.
+
+| Surface | Effect |
+|---|---|
+| Callers passing `recursive` + `force`, no `maxRetries` | Budget ~300ms → ~1s. **The only behavioural change.** |
+| Callers passing an explicit `maxRetries` | **Unchanged** — the default only applies when it is `undefined`. Asserted by a new test. |
+| Callers not passing `recursive` + `force` | **Unchanged** — the guard requires both. |
+| A delete that would have succeeded | Unchanged; retries only run after a failure. |
+| A delete that will never succeed | Fails after ~1s instead of ~300ms. |
+
+Node applies `retryDelay` only for `recursive` removals and retries on the transient errors this
+targets (`EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, `EPERM`), so a widened budget cannot mask a
+different class of failure — it retries exactly the races it was already retrying.
+
+## What this does NOT establish
+
+**It does not prove ~1s is sufficient.** No budget can be proven sufficient; it depends on machine
+load. This makes the race much less likely to be lost, not impossible. I would rather state that than
+imply the flake is closed.
+
+The deeper fix for the observed case is ensuring the git child process has exited before teardown,
+which belongs in the tests, not in a filesystem helper.
+
+## Blast radius
+
+`safeRm`/`safeRmSync` have **2,116 call sites**, so this is a wide change — but strictly in the
+direction of more patience, and only on a path that has already failed once. The worst case is a
+doomed delete taking 700ms longer to report.
+
+## About the new tests — read this before crediting them
+
+They cover behaviour that had **no coverage at all**: that a budget is applied when absent, and that an
+explicit caller value is never overridden. That gap is how the defaults reached a state where they were
+in force and simply too small.
+
+**They would also pass on `main`** — the property predates this change. They guard the mechanism, not
+the tuning. The tuning itself is a judgement no unit test can settle, and I am not going to present
+green tests as evidence for it.
+
+## Verification
+
+- `tests/unit/SafeFsExecutor.test.ts` 22/22 (20 before + 2 new); `SafeFsExecutor-atomicWrite` 9/9;
+  `handoff-manager` (the test that failed on main) 71/71.
+- `tsc --noEmit` clean — after fixing a self-inflicted break: the first draft of the doc block
+  contained a literal path with `*/` in it, which closed the comment early. The compiler caught it.


### PR DESCRIPTION
## ELI16 — a cleanup step gave up after a third of a second

When a test finishes it deletes its temp folder. Deleting can fail if something is still writing there,
so it retries — three times, 100ms apart. About a third of a second of patience.

Fine on an idle machine. Not fine when the folder holds a real git repo and the machine is busy: git's
own child work outlives that window, the retries run out, and cleanup fails with "directory not empty".
The suite goes red for a reason unrelated to the code under test.

**That happened on `main` today, twice in one evening, across two different tests** — both while four CI
runs competed for the same runners.

## The finding is that the retries were already there

My first theory was that `safeRmSync` didn't expose retry options at all. I checked, and it does:

```ts
if (rmOpts.recursive && rmOpts.force && rmOpts.maxRetries === undefined) {
  return { ...rmOpts, maxRetries: 3, retryDelay: 100 };   // ~300ms
}
```

The failing call passes `recursive` + `force`, so it **received** that budget. The retries ran and lost.
So this is a tuning problem, not a missing-feature problem — a different fix from the one I first filed.

Raised to `10 × 100ms`. An explicit caller `maxRetries` still wins, now asserted by a test.

## What this does NOT establish

**It does not prove ~1s is enough.** No budget can be proven sufficient — it depends on load. This makes
the race much less likely to be lost; it does not close it. I'd rather say that than present a green
suite as a fix.

The deeper fix for the git case is ensuring the child process has exited before teardown, which belongs
with the tests rather than in a filesystem helper.

## About the new tests — please don't over-credit them

The retry defaults had **zero** test coverage, which is how they reached a state where they were running
and simply too small. Two tests added: a budget is applied when the caller gives none, and an explicit
`maxRetries` is never overridden.

**They would pass on `main` too.** They guard the *mechanism*, not the *tuning*. They are not evidence
for the new number, and a test asserting `maxRetries === 10` would just restate the constant.

## Blast radius

`safeRm`/`safeRmSync` have **2,116 call sites** — wide, but strictly in the direction of more patience,
on a path only reached after a delete has already failed. Worst case: a doomed delete takes ~700ms
longer to report. Node applies `retryDelay` only for recursive removals and retries exactly the
transient errors this targets (`EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, `EPERM`), so a wider budget
can't mask a different failure class.

## Prior art found while checking

`tests/unit/migrateWorktreeConvention.test.ts:110` already hand-rolls `maxRetries: 5` with a comment
about racing async fire-and-forget cleanup. Someone hit this class before and worked around it locally
rather than raising the shared default — which is decent evidence that 3 was too low generally.

## Verification

`SafeFsExecutor` 22/22 · `SafeFsExecutor-atomicWrite` 9/9 · `handoff-manager` (the suite that failed on
main) 71/71 · `tsc --noEmit` clean.

One self-inflicted stumble worth recording: the first draft of the doc block contained a literal path
with `*/` in it, which closed the comment early and broke the build. The compiler caught it immediately.

## Provenance

Found by investigating a red `main` I caused — not through the merge's content (verified: #942 touches
zero handoff files) but through the load of merging four PRs in eleven minutes. Separately filed: the
merge-cadence lesson and the publish-ordering fragility that same burst exposed.