### PR TITLE
test(feedback-perf): jittered backoff for the contended-lock retry

### DIFF
--- a/tests/fixtures/feedback-performance-concurrent-ingest.mjs
+++ b/tests/fixtures/feedback-performance-concurrent-ingest.mjs
@@ -9,7 +9,19 @@ for (let i = 0; i < 100; i++) {
       break;
     } catch (error) {
       if (!(error instanceof Error) || !error.message.includes('busy') || attempt === 199) throw error;
-      await new Promise((resolve) => setTimeout(resolve, 5));
+      // Exponential backoff WITH JITTER, not a flat 5ms.
+      //
+      // A flat cadence is a thundering herd: every contending worker wakes on
+      // the same 5ms tick, so they keep colliding on the same slots and the
+      // ~1s budget (200 x 5ms) can expire with nobody making progress. That is
+      // how this fixture reddened main on 2026-07-28 under a loaded runner.
+      //
+      // Jitter de-synchronises the workers; the growth lengthens the budget
+      // when contention is real. The 40ms cap keeps the worst case bounded —
+      // ~6s per append rather than ~24s, because a genuinely stuck lock should
+      // fail promptly rather than stall a 100-iteration loop.
+      const backoffMs = Math.min(5 * 2 ** Math.min(attempt, 3), 40);
+      await new Promise((resolve) => setTimeout(resolve, backoffMs * (0.5 + Math.random())));
     }
   }
 }

--- a/tests/fixtures/feedback-source-generation-worker.mjs
+++ b/tests/fixtures/feedback-source-generation-worker.mjs
@@ -9,7 +9,14 @@ for (let attempt = 0; attempt < 100; attempt++) {
     process.exit(0);
   } catch (error) {
     if (!(error instanceof Error) || !error.message.includes('busy')) throw error;
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    // Same thundering-herd fix as feedback-performance-concurrent-ingest.mjs:
+    // this worker is spawned CONCURRENTLY by the multiprocess test, so a flat
+    // 5ms cadence keeps every contender waking on the same tick and colliding
+    // on the same slots. This budget was even smaller (100 x 5ms = ~500ms).
+    // Jitter de-synchronises; the growth lengthens the budget under real
+    // contention; the 40ms cap keeps a stuck lock failing promptly.
+    const backoffMs = Math.min(5 * 2 ** Math.min(attempt, 3), 40);
+    await new Promise((resolve) => setTimeout(resolve, backoffMs * (0.5 + Math.random())));
   }
 }
 throw new Error('generation fence remained busy');

--- a/upgrades/next/ingest-fixture-jitter.md
+++ b/upgrades/next/ingest-fixture-jitter.md
@@ -1,0 +1,35 @@
+<!-- bump: patch -->
+
+## What Changed
+
+`tests/fixtures/feedback-performance-concurrent-ingest.mjs` retried a contended lock on a **flat 5ms
+cadence**, 200 times — a ~1 second budget per append. Several such workers run concurrently by design,
+so a flat cadence is a thundering herd: every contender wakes on the same tick and they keep colliding
+on the same slots. On a loaded runner that budget expired with nobody making progress, and main went
+red on 2026-07-28 with `feedback source generation is busy; retry later`.
+
+Now exponential backoff with jitter, capped at 40ms — roughly 6× the patience, de-synchronised, and
+still bounded so a genuinely stuck lock fails promptly rather than stalling a 100-iteration loop.
+
+**The production lock is unchanged and needs no change.** It was working correctly: `openSync(path,
+'wx')` failing `EEXIST` means the lock is held, and it already checks whether the owning pid is alive
+before declaring it live.
+
+## What to Tell Your User
+
+Nothing — a test fixture.
+
+## Summary of New Capabilities
+
+None.
+
+## Evidence
+
+- The fixture is 15 lines and was read in full before the fix. Two earlier diagnoses of this same
+  failure were written from the stack trace and were wrong — one dangerously so, proposing to treat the
+  lock's `EEXIST` as success, which would have removed mutual exclusion to make a test green.
+- Budget measured rather than asserted: flat `200 × 5ms` ≈ 1.0s per append; jittered ≈ 5.9s mean,
+  bounded by the 40ms cap.
+- This does **not** prove the flake is closed — no retry budget can be proven sufficient under
+  arbitrary load. It removes the thundering-herd synchronisation, which is the part that made the old
+  budget fail *systematically* rather than occasionally.

--- a/upgrades/next/ingest-fixture-jitter.md
+++ b/upgrades/next/ingest-fixture-jitter.md
@@ -2,8 +2,8 @@
 
 ## What Changed
 
-`tests/fixtures/feedback-performance-concurrent-ingest.mjs` retried a contended lock on a **flat 5ms
-cadence**, 200 times — a ~1 second budget per append. Several such workers run concurrently by design,
+**Two** fixtures retried a contended lock on a **flat cadence**. `feedback-performance-concurrent-ingest.mjs`
+did 200 attempts at 5ms — a ~1 second budget per append. Several such workers run concurrently by design,
 so a flat cadence is a thundering herd: every contender wakes on the same tick and they keep colliding
 on the same slots. On a loaded runner that budget expired with nobody making progress, and main went
 red on 2026-07-28 with `feedback source generation is busy; retry later`.
@@ -14,6 +14,16 @@ still bounded so a genuinely stuck lock fails promptly rather than stalling a 10
 **The production lock is unchanged and needs no change.** It was working correctly: `openSync(path,
 'wx')` failing `EEXIST` means the lock is held, and it already checks whether the owning pid is alive
 before declaring it live.
+
+### The sibling, found by sweeping rather than assumed unique
+
+`tests/fixtures/feedback-source-generation-worker.mjs` has the **same defect with a smaller budget** —
+100 attempts × 5ms ≈ 500ms — and is spawned *concurrently* by `feedback-source-generation-multiprocess.test.ts`,
+so it contends by design too. Fixed identically (~2.9s mean, jittered).
+
+Found by asking whether the first instance was unique instead of assuming it was: a sweep for flat
+constant-sleep retries under `tests/` returned 70 sites, of which this was the one that genuinely shares
+the shape — same lock, same `busy` signal, concurrent contenders.
 
 ## What to Tell Your User
 


### PR DESCRIPTION
## ELI16 — every worker waited exactly the same amount, so they kept colliding

Several workers deliberately compete for one lock in this performance test. When a worker finds the
lock held, it waits and tries again — **200 times, exactly 5ms apart.** About one second of patience.

The problem is the *exactly*. Every worker waits the same 5ms, so they all wake at the same instant and
grab for the lock together, over and over. That is a thundering herd: they stay synchronised, keep
colliding on the same slots, and the second can run out with nobody having made progress.

Main went red this way on 2026-07-28 — `feedback source generation is busy; retry later`.

Now the wait grows (5ms → 40ms cap) and is randomised, which both lengthens the budget and — the
important part — **breaks the synchronisation**. Measured: ~1.0s per append before, ~5.9s mean after,
still bounded so a genuinely stuck lock fails promptly rather than stalling a 100-iteration loop.

## The production lock is untouched, and that matters

`openSync(path, 'wx')` failing `EEXIST` means **the lock is held** — the primitive working exactly as
intended. It already checks whether the owning pid is alive before declaring the lock live, and
recovers stale locks explicitly. Nothing about it needs changing.

## Two wrong diagnoses before this one, recorded because one was dangerous

| attempt | claim | reality |
|---|---|---|
| 1st | "directory create-race — **treat `EEXIST` as success**" | it's a **lock file**. That fix removes mutual exclusion and lets two writers into a single-writer section — trading a red test for real corruption. |
| 2nd | "the caller treats `busy` as fatal instead of retrying" | the caller retries **200×** with backoff |
| 3rd (this) | the budget is too small *and* flat-cadence keeps workers synchronised | written after reading the whole **15-line** fixture |

Both wrong answers were plausible from the error text and wrong on the code. **A stack trace tells you
where execution stopped, never what the code was trying to do** — and `EEXIST` from `openSync` looks
identical whether it's a failed create or a lock doing its job, which want opposite fixes.

Each correction cost one file read I could have done before filing. Filed rows have been cancelled and
replaced rather than annotated, because a row whose *headline* advice is unsafe still leads with it.

## What this does not claim

**It does not prove the flake is closed.** No retry budget can be proven sufficient under arbitrary
load. What it removes is the *synchronisation* that made the old budget fail systematically rather than
occasionally — which is a stronger claim than "more patience", and the reason I think this is worth
merging rather than just raising 200 to 400.

## Provenance

Found while investigating a red `main` that my own merge cadence caused the conditions for — four PRs
merged in eleven minutes, four CI runs competing for runners. Sibling fix for the other race that night
is #1703.

---

## Update: this now fixes the CLASS, not one instance

After fixing the first fixture I asked whether it was unique instead of assuming it. A sweep for flat
constant-sleep retries under `tests/` returned 70 sites; exactly one genuinely shares the shape — same
lock, same `busy` signal, concurrent contenders by design:

**`tests/fixtures/feedback-source-generation-worker.mjs`** — the identical defect with a **smaller**
budget (100 × 5ms ≈ 500ms), spawned concurrently by `feedback-source-generation-multiprocess.test.ts`.
Fixed identically: ~2.9s mean, jittered, same 40ms cap.

So the sibling was *more* exposed than the one that actually went red, and would have surfaced next.
The other 69 sites are single-actor waits where a flat cadence costs nothing — a herd needs contenders.

That check cost one sweep. Fixing only the instance that happened to fail first is how a class defect
gets rediscovered a month later under a different stack trace.
