### PR TITLE
docs(spec): re-surfacing the 98% — DRAFT, not converged (3 rounds)

### DIFF
--- a/docs/specs/undated-action-resurfacer.eli16.md
+++ b/docs/specs/undated-action-resurfacer.eli16.md
@@ -1,0 +1,72 @@
+# Re-surfacing the 98% — in plain English
+
+## The problem, in one paragraph
+
+Your agent keeps a to-do list of things it has noticed and should fix. It has a mechanism for bringing
+old items back to your attention so they don't rot — a job that runs every four hours and says "these
+are overdue."
+
+That job only looks at items that were given a **due date**. Almost nothing gets one, because nothing
+requires it. So of 912 open items, it can see **eighteen**. The other 894 are not being ignored —
+they are **invisible to it**, permanently, and 581 of those are marked high or critical. The oldest
+one nobody can reach is 24 days old.
+
+## Why that matters more than it sounds
+
+Two real cases found this week:
+
+- One item was written down, verified as real, and then **rediscovered five separate times over
+  fifteen days** by different pieces of work — each time from scratch, each time costing an
+  investigation. It had no due date, so it was never once brought back.
+- Another was marked *critical* and left alone for two days while the problem it described **got
+  worse** — the failure rate it measured climbed from 81% to 86.5% while it sat there.
+
+Neither was a case of bad prioritisation. Nobody looked at these and decided they could wait. They
+simply could not be seen by the only thing whose job is to bring things back.
+
+## What this adds
+
+One rule: **every run, bring back exactly one forgotten item — the oldest important one nobody has
+looked at.** Then leave it alone for two weeks. If it comes back three times and still hasn't moved,
+say so once and stop.
+
+That's the whole thing.
+
+## Why "exactly one" and not "all of them"
+
+Because there are 581 of these right now. A component that announced all of them — or even a daily
+digest of them — would bury the very surface it's supposed to help. Your agent already has a ceiling
+built specifically to stop that kind of flood, and it exists because that mistake has been made
+before.
+
+One at a time won't clear the backlog, and it isn't meant to. It means **no item can sit forever
+untouched**. Six a day, oldest first, and the worst case is bounded by arithmetic rather than by
+someone choosing a threshold correctly.
+
+## What it deliberately cannot do
+
+It never marks anything done, never cancels anything, never changes a priority, and never decides an
+item doesn't matter. It brings one thing back into view and says nothing else. Every judgment stays
+with you.
+
+## How you'd know it's working
+
+Not by a passing test — by watching it name a specific old item that genuinely could not have been
+raised before. It ships switched off, then in a mode where it only *logs* what it would have raised,
+so the choice can be checked against a real 581-item backlog before it says anything out loud.
+
+## The honest limits
+
+**It does not clear the pile.** 581 items, one per run, is not a drain — it's a guarantee that nothing
+sits forever. Clearing what has already accumulated is separate work and this doesn't pretend
+otherwise.
+
+**It only covers high and critical items to start.** Medium and low undated items are a bigger group,
+and adding them later is straightforward — but the measured damage is in the important ones, so that
+is where it starts.
+
+**One design question is genuinely open**, and it's written down as open rather than guessed: if you
+run your agent on more than one machine, both could bring back the same item unless they share a
+record of what's already been raised. There are two reasonable answers and the smaller one is probably
+right — but "probably right" is exactly how features get shipped machine-blind, so it gets decided
+before it gets built, not after.

--- a/docs/specs/undated-action-resurfacer.md
+++ b/docs/specs/undated-action-resurfacer.md
@@ -1,0 +1,350 @@
+---
+title: "Re-surfacing the 98%: what brings back an action nobody gave a date to"
+slug: "undated-action-resurfacer"
+author: "echo"
+status: "draft"
+created: 2026-07-28
+parent-principle: "Close the Loop"
+sibling-principles: "Deferral = Deletion; Bounded Blast Radius; Signal vs. Authority; Observability; No Unbounded Loops"
+origin: "Measured 2026-07-28 while working the standing 'give Close the Loop a mechanism' goal. The premise was wrong — a mechanism exists. Its reach is 2%."
+eli16-overview: "undated-action-resurfacer.eli16.md"
+---
+
+# Re-surfacing the 98%
+
+> **The rule.** An action that no one gave a due date to must still come back. Today it cannot: the
+> only re-surfacing path keys on `dueBy`, and 98% of the pending backlog has none.
+
+**How to read this document.** It states rules, not their history. Why each rule is shaped as it is
+lives in the convergence report.
+
+## 0. The measurement this exists for
+
+Taken on the live agent, 2026-07-28:
+
+| | count |
+|---|---|
+| pending actions | 912 |
+| carrying a `dueBy` | **18** |
+| carrying none | **894** |
+| of those, HIGH or CRITICAL | **581** |
+| oldest undated high-priority | **24 days** |
+| **reach of the existing mechanism** | **2.0%** |
+
+**The existing mechanism is not broken.** `evolution-overdue-check` runs every 4 hours, its gate
+passes, and it does exactly what it was built to do — surface actions past their due date. The gap is
+that nothing requires a due date at filing, so the overwhelming majority of the backlog is not
+*neglected* by it, it is **unreachable** by it.
+
+**Two confirming cases, traced independently before the measurement:**
+
+- An action verified 2026-07-13 was **rediscovered five times in fifteen days** by separate
+  investigations. No `dueBy`. It could never once have been raised.
+- A CRITICAL action filed 2026-07-26 sat while its underlying error rate climbed across three
+  measurements (81.0% → 84.8% → 86.5%). No `dueBy`. Same.
+
+Neither was a prioritisation failure. Both were reachability failures.
+
+## 1. What this is NOT
+
+**Not a second overdue checker.** Building one keyed on a different field reproduces the defect with a
+new blind spot. The existing checker keeps its job unchanged.
+
+**Not a notifier over a collection.** 581 high/critical undated actions exist right now. A component
+that surfaces per-element over that set is precisely the shape the notification-flood ceiling was
+built to stop — and it would poison the very surface it is meant to repair. **The bound is the
+feature**, not a safeguard bolted to it.
+
+**Not an authority.** It re-surfaces; it never completes, cancels, re-prioritises, or edits an action.
+
+## 2. The rule
+
+**Exactly ONE undated action is re-surfaced per run, or none.**
+
+| element | rule |
+|---|---|
+| eligible | `status: pending`, no `dueBy`, priority `high` or `critical` |
+| selection | **weighted lanes, not strict tiers**: 3 of every 4 runs draw the oldest eligible `critical`; the 4th draws the oldest eligible `high`. A lane with nothing eligible yields to the other. **Plus a max-age override**: any `high` older than 30 days enters the critical lane. Ties by action id. Excludes anything inside its cooldown. |
+| volume | **ONE per run. Never a digest, never a batch.** |
+| cooldown | an action re-surfaced is ineligible for 14 days, recorded durably |
+| destination | the attention queue, at the action's own priority — never a new topic |
+| effect | informational. It states the action id, age, priority, and title. It proposes nothing. |
+| terminal | after 3 re-surfacings with no status change, it stops and says so once |
+
+**Why ONE.** At six runs a day the 581-item backlog is not drained, and draining it is not the goal.
+One-per-run makes a flood **arithmetically impossible** — that part is unconditional, and it is the
+property the bound exists for. A bound that depends on a threshold being tuned correctly fails the
+first time the backlog grows; a bound of one does not.
+
+**What it guarantees, stated at the strength it actually has.** Eventual surfacing is NOT
+unconditional. It holds only while: the eligible set is finite and not growing faster than one per
+run; `createdAt` is stable (a backfill or import that stamps old rows with new dates reorders the
+queue); and the scheduler is actually running. **Under sustained inflow above six per day, oldest-first
+means the newest eligible rows are never reached** — the queue is not starved of attention, but the
+tail of it is. Saying "nothing can sit forever" without those conditions would be the overclaim this
+project keeps catching, so: **bounded flood unconditionally; eventual surfacing under the stated
+assumptions.** The `eligible` metric (§2.1) is what makes a violated assumption visible — if it climbs,
+the guarantee is not holding.
+
+**Why weighted lanes — and this rule was wrong TWICE before it was right.**
+
+Draft 1 said "oldest among high or critical". That lets a newly-filed CRITICAL wait behind hundreds
+of older HIGH rows — age outranking severity.
+
+Draft 2 said "all critical before any high". That fixes the first defect and **introduces its mirror
+image**: with non-trivial critical inflow, HIGH rows are never reached at all. And a HIGH row is the
+motivating failure of this entire spec — the 24-day-old one nothing had looked at. A rule that
+structurally starves the case you wrote the component for is worse than the rule it replaced.
+
+**Both drafts made the same mistake in opposite directions: letting one dimension dominate
+absolutely.** The fix is a fixed ratio, so neither lane can starve the other, plus an age override so
+a HIGH row cannot be indefinitely outranked no matter what the critical inflow does. Still fully
+deterministic, still no scoring model — a run's lane is a function of its index.
+
+**Why the terminal rung — and why "stop reminding" is NOT what it does.** An action re-surfaced three
+times without moving is not being ignored by accident; something is wrong with the row itself. But a
+rung that merely stops reminding would **replace silent rot with acknowledged rot** — the same
+abandonment, now with a receipt. That is a worse outcome than the problem, because it launders the
+failure as a handled state.
+
+**Rule: the terminal rung DEMANDS A DISPOSITION, it does not end the loop.** On the third raise the
+component records the row as `needs-disposition` and stops raising it — and that state is itself
+surfaced, in aggregate, as a standing count. Exactly one of four things then closes it: the action is
+**worked**, **cancelled with a reason**, **given a `dueBy`** (moving it to the existing overdue path),
+or **split** because it was too large to move. All four are human or agent decisions this component
+never makes.
+
+**The aggregate needs a CONSUMER, or it is rot at a higher altitude.** "Countable rot" is better than
+invisible rot and is not closure — an aggregate nobody reads is the same abandonment one level up, and
+saying so is the point of the standard this serves.
+
+So the count is not merely published: **when `needs-disposition` exceeds 10, that itself becomes a
+single attention item at HIGH, subject to the same one-per-run bound and its own 14-day cooldown.**
+That is the consumer. It is deliberately one threshold and one item — a second flood surface built to
+watch the first would be absurd.
+
+**Concurrency, designed rather than asserted.** Lease-holder-only (§4) prevents cross-machine
+duplication; it does not prevent two overlapping scheduler invocations on the SAME holder. The claim
+step is therefore a conditional write: the `pending-emit` append succeeds only if no unretired entry
+for that action id exists. A losing racer selects nothing and exits — it does not fall through to the
+next candidate, because a run that emits two rows is no longer one-per-run.
+
+## 2.1 What it meters — the whole loop, not the raise
+
+*Observability* is this spec's parent principle, and that standard is explicit that a **capture-only
+metering set is a half-measure**: it cannot tell you whether what you captured ever changed anything.
+A component that counted its own raises would be exactly that — it would prove it fired, and prove
+nothing about whether firing helped.
+
+**Recorded per run:**
+
+| metric | why it is not optional |
+|---|---|
+| `eligible` | the size of the undated high/critical pool. **This is the number the component exists to reduce.** If it does not fall over months, the component is decorative. |
+| `raised` | 0 or 1, and WHICH action id |
+| `skipped-cooldown` | how many eligible rows were held back. A large number beside a small pool means the cooldown is mis-set. |
+| `terminal` | actions that hit the 3-raise stop |
+
+**Recorded per raised action, which is the half that makes this a loop:**
+
+| metric | why |
+|---|---|
+| `statusAtRaise` → `statusAt+14d` | **did re-surfacing change anything?** The one question that decides whether this component earns its place. |
+| `raiseCount` | 1, 2, or 3 — the distribution says whether one raise is usually enough |
+| `ageAtFirstRaise` | how long a row waited before anything reached it. Should trend DOWN once running. |
+
+**The success test is stated in advance so it cannot be rationalised later:** if, after a soak, raised
+actions change status at no better a rate than unraised ones of comparable age and priority, this
+component is **not working** and its removal is the correct response — not a tuning pass. A
+re-surfacer that is ignored is a notifier, and this project has enough of those.
+
+**Where it lands:** the existing per-feature metrics surface. No new store — a component this small
+introducing its own observability substrate would be its own incoherence.
+
+## 2.2 The ledger — a state model, not "recorded durably"
+
+"Recorded durably" is not a specification. The cooldown and the raise-count live in one append-only
+ledger keyed by action id:
+
+| field | meaning |
+|---|---|
+| `actionId` | key |
+| `firstRaisedAt`, `lastRaisedAt` | timing |
+| `raiseCount` | 1-3 |
+| `observedStatus`, `observedPriority`, `observedDueBy` | the row's state AS SEEN at the last raise |
+| `disposition` | unset, or `needs-disposition` after the third |
+
+**What RESETS the count, and this is the part a naive ledger gets wrong:** "3 raises with no status
+change" must not ignore meaningful edits that are not status. If `priority`, `dueBy`, or the action's
+content changed since `lastRaisedAt`, **somebody engaged with the row** — the count resets and the
+cooldown restarts. Comparing only `status` would keep escalating a row that a human had actively
+worked on, which is the fastest way to make this component hated.
+
+**What RETIRES the entry:** the action leaving `pending`, or gaining a `dueBy` (it becomes the existing
+mechanism's problem, and two paths must never both own one row).
+
+**Append-only events, derived state — because the table above mixes them.** `raiseCount`,
+`disposition` and retirement are field-LIKE, which an append-only log cannot hold directly. The store
+is an event stream (`raised`, `emitted`, `reset`, `retired`, `disposition-set`); the table above is
+the PROJECTION derived by folding those events per action id. The projection may be cached, and it is
+always reconstructible from the events — so a corrupt cache is a rebuild rather than a data loss.
+
+**Atomicity — and an earlier draft had this exactly backwards.** It said "write the ledger before the
+raise" and claimed a crash would cost a duplicate. It would cost the opposite: the ledger records the
+raise, the cooldown then excludes the row for 14 days, and **the attention item is never emitted.** A
+silent miss — the precise failure this component exists to prevent, produced by its own bookkeeping.
+
+**Rule: two-phase, emit-then-confirm.**
+1. Append `{actionId, raisedAt, state: pending-emit}`.
+2. Emit the attention item.
+3. Atomically mark the entry `emitted`.
+
+A crash between 1 and 2, or 2 and 3, leaves a `pending-emit` row. **On start, any `pending-emit` older
+than one run interval is REPLAYED.** When the two failure directions are "says something twice" and
+"silently says nothing", a component about not-forgetting must choose the first — and must not confuse
+itself about which one it chose.
+
+**"A duplicate is harmless" is an assertion, so it is replaced by a mechanism.** Each raise carries a
+stable idempotency key — `resurface:{actionId}:{raiseCount}` — and the attention queue's existing
+dedupe consumes it, so a replay of an item the queue already accepted collapses rather than appearing
+twice. That matters because the destination is the surface this component exists to protect: an
+attention queue that amplifies duplicates is the flood failure arriving through the back door.
+**Replay is bounded**: three attempts, then the entry is marked `emit-failed` and counted in the §2.1
+metrics — a poison row must not retry forever, and it must not vanish either.
+
+## 2.3 Why not `nextReviewAt` on the action itself
+
+The industry-standard shape for this is a review-date field on the record — `nextReviewAt`, snooze-
+until, a workflow timer — rather than an external ledger and a second selection path. That would unify
+dated and undated review into one mechanism, which is genuinely more elegant.
+
+**It is rejected for one reason, and it is the reason this spec exists:** a review date is a field
+someone has to set. `dueBy` is already exactly that field, nothing requires it, and the measured
+result is 2% coverage. Adding a second optional date field would reproduce the defect under a new
+name — the 894 rows that have no `dueBy` today would have no `nextReviewAt` tomorrow, for the same
+reason.
+
+**The property that matters here is that eligibility requires NOTHING to have been filled in.** An
+external ledger over "everything pending, undated, important, oldest first" cannot be under-populated
+by an author who was in a hurry. That is worth the second path.
+
+**The strongest counter, which the rejection above does not answer.** Review raised it: the industry
+pattern is not an *optional human-entered* review date but a **system-assigned default** written at
+creation — every action gets a `nextReviewAt` automatically, so under-population is impossible by
+construction and dated and undated review collapse into one path. That is a better argument than the
+one this section originally rebutted, and it may well be the right long-term shape.
+
+**Why this component is still proposed, stated as a trade rather than a refutation:**
+
+| | system-default `nextReviewAt` | this component |
+|---|---|---|
+| covers new actions | yes, by construction | yes |
+| **covers the existing 894** | **only via a backfill that invents a review date for every one** | yes, immediately, without touching a single row |
+| changes the action schema | yes | no |
+| failure mode | a default that is wrong for a whole class is invisible until the class comes due | a bad selection is visible in the next run's output |
+
+**The deciding factor is the backfill.** Assigning a review date to 894 existing rows means choosing
+one for each, and the only information available to choose from is age and priority — which is exactly
+what this component reads directly, without writing anything. Where a migration would have to *invent*
+data to make the mechanism work, reading it live is the smaller move.
+
+**This is a preference under uncertainty, not a proof.** If a system-default review date is
+implemented, **this component becomes redundant and should be DELETED rather than kept** — recorded
+here so that outcome reads as success rather than as loss, and so nobody later defends this design out
+of ownership.
+
+## 3. Decision points touched
+
+| Decision point | classification |
+|---|---|
+| which actions are eligible | `invariant` — a field test over recorded values, no judgment |
+| which one is selected | `invariant` — oldest `createdAt`, deterministic tie-break by id |
+| how many per run | `invariant` — exactly one, not tunable |
+| when it stops | `invariant` — 3 re-surfacings, counted durably |
+
+None is a competing-signals point. Nothing here weighs, scores, or infers; every rule is a comparison
+over data already recorded. A judgment-candidate would be the wrong shape: the value of this component
+is that its behaviour is completely predictable, so a flood cannot arise from a misjudgement.
+
+## 4. Multi-machine posture
+
+**Posture: `machine-local`** — `machine-local-justification: operator-ratified-exception` pending, and
+**this is the spec's one genuinely open design question**, deliberately surfaced rather than answered
+by assertion.
+
+The action store is per-agent, and the re-surfacing cooldown is state about *what this agent has
+already raised*. Two machines re-surfacing from a shared backlog would double-raise unless the
+cooldown replicates.
+
+**DECIDED: option 1 — run on the serving-lease holder only.**
+
+1. **Lease-holder only** ← chosen. No replication, and it inherits an existing single-writer
+   guarantee rather than inventing one. A standby machine runs nothing, so double-raising is
+   impossible by construction rather than by reconciliation.
+2. Replicate the cooldown ledger — correct under partition, and more machinery than a
+   one-row-per-run component justifies.
+
+**The cost of option 1, stated:** if no machine holds the lease, nothing re-surfaces. That is
+acceptable because a pool with no lease-holder has larger problems than a stale backlog, and the
+`eligible` metric (§2.1) will show the gap rather than hide it.
+
+## 5. Frontloaded decisions
+
+| # | decision | resolution |
+|---|---|---|
+| 1 | Volume | **One per run.** Not configurable — a tunable bound is a bound that fails when the backlog grows. |
+| 2 | Eligibility | `high`/`critical` only for the first application. `medium`/`low` undated actions are the larger population and the smaller loss; widening later is additive. |
+| 3 | Destination | The existing attention queue at the action's own priority. No new topic, no new surface. |
+| 4 | Cooldown | 14 days, durable. Short enough that a genuinely stuck item returns; long enough that one run cannot chase the same row. |
+| 5 | Stop condition | 3 re-surfacings without a status change, then a single terminal note. |
+| 6 | Authority | None. It never mutates an action. |
+| 7 | Rollout | Ships **dark**, then dry-run (logs the row it WOULD raise), then live. The dry-run stage is the real test: it proves the selection is sane against a 581-row backlog before anything is raised. |
+
+## 6. Open questions
+
+*(none)*
+
+> §4's multi-machine choice was described in an earlier draft as "the spec's one genuinely open
+> question" while this section said none — a straight contradiction. It is now DECIDED in §4 (option 1,
+> lease-holder only), so neither section is parked on anyone.
+
+## 7. Deferred work
+
+- **Widening to `medium`/`low`** <!-- tracked: ACT-1510 --> — deliberately not in the first
+  application. The high/critical set is where the measured damage is.
+- **Draining the existing 581-row backlog** <!-- tracked: ACT-1510 --> — **this component is NOT
+  sufficient remediation for the measured harm, and must not be presented as such.** The live problem
+  IS that pile; at one per run, reaching all 581 takes roughly three months, by which time the oldest
+  rows are four months old. What this component guarantees is that the pile cannot grow *silently* and
+  that its oldest important rows are continuously surfaced — which is prevention, not a cure.
+  **Disposing of the existing 581 requires a bounded one-off review**, which is separate work with a
+  separate flood profile. Shipping this and declaring Close the Loop solved would be exactly the
+  overclaim this project keeps catching.
+
+## 8. What "done" means
+
+**BOTH are required. Neither substitutes for the other.**
+
+**1. All THREE test tiers, per the Testing Integrity Standard — not "some deterministic tests".**
+
+| tier | what it must cover here |
+|---|---|
+| **Unit** | the pure selection rule with real inputs: priority-tier-before-age, tie-break by id, cooldown exclusion, count-reset on a non-status edit, terminal transition at the third raise, retirement when a row gains a `dueBy`. |
+| **Integration** | the ledger + emit path end to end: two-phase `pending-emit` → emit → confirm, replay of a `pending-emit` left by a simulated crash, the conditional-write claim under two overlapping runs, and the `needs-disposition` threshold raising exactly one item. |
+| **E2E lifecycle** | the production initialization path — the component is CONSTRUCTED, wired to the real action store and the real attention queue, and a run selects and raises against them. **This is the tier that would have caught a reaper reporting "0 reclaimable" beside 39GB**, because it is the only one that proves the thing is reachable rather than merely correct. |
+
+**Wiring integrity is required explicitly**, per the same standard: assert the injected action-store
+reader and attention emitter are neither null nor no-ops and delegate to the real implementations. A
+component whose emitter is a stub passes every unit and integration test above while raising nothing —
+the exact shape this whole spec exists to prevent, reproduced inside its own test suite.
+
+**2. Live evidence** — a command and its output showing a specific, real, previously-invisible action
+raised. The two cases in §0 are the natural candidates: both undated, both old, both demonstrably
+unreachable before.
+
+**Why both, stated because picking one is the tempting shortcut:** a fixture test proves the logic is
+what I wrote down; it cannot prove the component is reachable, wired, and pointed at the real store —
+which is exactly the failure class that produced a reaper reporting "0 reclaimable" beside 39GB of
+worktrees. Conversely a live raise proves it is wired and cannot prove the cooldown or the terminal
+rung behave under conditions that will not occur during a demo. **Each covers the other's blind
+spot**, and this project has a long record of shipping one and calling it verified.


### PR DESCRIPTION
## ELI16 — the thing that brings forgotten work back can only see 2% of it

Your agent keeps a list of problems it has noticed. It has a mechanism for bringing old ones back so they don't rot — a job that runs every four hours saying "these are overdue."

**That job only looks at items someone gave a due date to. Of 912 open items, eighteen have one.**

So 894 are not being ignored — they are **invisible to it, permanently**. 581 of those are marked high or critical. The oldest one nothing can reach is 24 days old.

Two real cases found this week explain themselves once you know that: an item that was written down, verified, and then **rediscovered five separate times over fifteen days** by different work — and a *critical* one that sat for two days while the problem it described **got worse** (its failure rate climbed from 81% to 86.5%). Neither was neglected. Neither was reachable.

This spec proposes one rule: **bring back exactly one forgotten item per run** — never a batch, because 581 items through a per-element notifier is precisely the flood this project already built a ceiling to stop.

---

### Status: NOT CONVERGED

Three review rounds. The constitution checker is clean; the external reviewer still returns real design findings. Committed as a **reviewed draft** because the measurement belongs on the record regardless of where the design lands.

### What review corrected — the pattern is worth as much as the spec

- **The selection rule was wrong twice, in opposite directions.** First age dominated severity (a new critical waits behind hundreds of older highs). Fixed — and the fix let severity starve age, which structurally buries the *exact* case the spec was written for. Both drafts made the same mistake: letting one dimension dominate absolutely.
- **The atomicity was exactly backwards.** I wrote "record then emit, so a crash costs a duplicate." It costs the opposite — the ledger marks it raised, the cooldown hides it, and the item is **never emitted**. A silent miss, produced by the bookkeeping of a component whose entire purpose is not forgetting things.
- **The terminal rung would have replaced silent rot with acknowledged rot** — stopping the reminders and calling that a handled state.
- **"No action can sit forever" was an overclaim.** It holds only under assumptions that are now stated.
- **A system-assigned default review date is a genuinely better long-term shape**, and is now compared honestly instead of rebutted narrowly. If it ships, this component should be **deleted**, not defended.

### Honest limit

This prevents future rot. It does **not** drain the existing 581 — at one per run that is roughly three months — and the spec says so rather than letting the measurement imply otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDAgKAVJfGHgrFa7GJoSVn