### PR TITLE
fix(decision-quality): base insufficientEvidence on settled grades, not row count

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-28T18-00-00-252Z-decision-quality-settled-evidence.json
+++ b/.instar/instar-dev-decisions/2026-07-28T18-00-00-252Z-decision-quality-settled-evidence.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-28T18:00:00.252Z",
+  "slug": "decision-quality-settled-evidence",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 29,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/decision-quality-settled-evidence.eli16.md
+++ b/docs/specs/decision-quality-settled-evidence.eli16.md
@@ -1,0 +1,63 @@
+# "We have enough evidence" — about nothing at all
+
+## The one-paragraph version
+
+Your agent keeps score on its own judgment calls. Every time one of its internal checks
+makes a decision, that decision can later be graded: **right**, **wrong**, or **unknown**
+— unknown meaning nobody ever established which it was.
+
+Beside those counts it publishes a warning flag: *do we have enough evidence here for
+these numbers to mean anything?* The flag was calculated by adding up all three
+categories. But "unknown" is not evidence — it is the word for having none.
+
+So a check with 2,004 decisions, **zero** graded right, **zero** graded wrong, and 2,004
+graded unknown was reporting: **we have plenty of evidence.** About nothing.
+
+## Why that is worse than a wrong number
+
+A wrong number gets questioned. A confident "yes, this is reliable" gets *believed*.
+
+Two of your busiest internal checks were in exactly this state. Anyone reading their
+scoreboard would have seen "enough evidence" sitting next to "zero times wrong" and drawn
+the obvious conclusion: **this check has never made a mistake, so maybe it doesn't need
+the power to block things.**
+
+That conclusion would have been completely wrong. The check hadn't been proven right — it
+had never been graded at all. And this is not hypothetical: I was in the middle of writing
+exactly that kind of review earlier tonight. What stopped it being published was me
+noticing the underlying numbers were empty, not the flag whose entire job is to warn about
+empty numbers. The flag was actively giving the green light.
+
+## What changed
+
+Three small things:
+
+- The scoreboard now also shows **settled grades** — how many decisions were actually
+  established as right or wrong. That's the number that can support a percentage.
+- It shows **what share is unknown**. If that reads 100%, nothing is established.
+- The "enough evidence" flag now counts settled grades instead of counting rows.
+
+The old counts are still published, unchanged, because they answer a different and still
+useful question: *how many decisions got looked at at all?*
+
+## What you'll notice
+
+The two busy checks will flip from "enough evidence" to "not enough evidence." Nothing has
+got worse — that has been true the whole time and the display was wrong. This is a
+scoreboard, not a gate: it blocks nothing, delays nothing, and changes no behaviour.
+
+## The wider pattern, honestly
+
+This is the **seventh** recorded instance of one shape: a measurement that reports the
+ideal value when it actually has nothing to measure. An empty index scoring 100% fresh. A
+directory listing returning zero for a folder with files in it. Same mistake, different
+place, seven times.
+
+That was written up as a critical item three days ago, with a rule already stated for it:
+*every completeness measure must carry its denominator and say "nothing measured" rather
+than report a perfect score.* I found this instance without remembering that item existed,
+which is its own uncomfortable data point.
+
+That rule is precise enough to be enforced automatically rather than found by hand each
+time. Building that check is the real fix and it is bigger than this change; this one
+repairs the instance that was best placed to mislead a real decision.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1798,6 +1798,10 @@ function pickRedactedProvenanceFields(row: Record<string, unknown>): Record<stri
 const DECISION_QUALITY_POINT_FIELDS: readonly string[] = [
   'decisionPoint', 'component', 'status', 'volumeClass', 'contentClass',
   'decisions', 'outcomesKnown', 'outcomesKnownRatio', 'insufficientEvidence',
+  // settledGrades/unknownShare belong here too, or a pool-scope row silently
+  // loses the two fields that say whether its rates mean anything — leaving the
+  // merged view MORE misleading than the local one.
+  'settledGrades', 'unknownShare',
   'gradeDistribution', 'byStrength', 'byRule', 'byRung', 'attribution', 'counters', 'flags',
 ];
 function pickDecisionQualityPointFields(row: Record<string, unknown>): Record<string, unknown> {
@@ -16782,7 +16786,12 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         bump(byRung, r.rung, r.grade, r.n);
         bump(byStrength, r.evidenceStrength, r.grade, r.n);
       }
+      // `outcomesKnown` counts every decision carrying ANY grade row, including
+      // `unknown`. That is a ROW count, not an EVIDENCE count: an `unknown` grade
+      // is precisely the absence of a settled outcome. Both are published — they
+      // answer different questions — but only `settledGrades` can back a RATE.
       const outcomesKnown = right + wrong + unknown;
+      const settledGrades = right + wrong;
       points.push({
         decisionPoint: entry.decisionPoint,
         component: entry.component,
@@ -16792,8 +16801,24 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         decisions,
         outcomesKnown,
         outcomesKnownRatio: decisions > 0 ? outcomesKnown / decisions : 0,
-        // Below the minimum sample an aggregate rate is not actionable (§5.5 codex r5).
-        insufficientEvidence: outcomesKnown < minSample,
+        /**
+         * Settled (right|wrong) grades — the only ones that can support a rate.
+         * `selfReportShare` below already divides by this same quantity.
+         */
+        settledGrades,
+        /** Share of graded rows that are unsettled. 1.0 means nothing is known. */
+        unknownShare: outcomesKnown > 0 ? unknown / outcomesKnown : 0,
+        // Below the minimum SETTLED-grade count an aggregate rate is not
+        // actionable (§5.5 codex r5). Measured 2026-07-28: this counted
+        // `unknown` toward the sample, so messaging-tone-gate (2075 decisions,
+        // right=0 wrong=0 unknown=2004) served `insufficientEvidence: false` —
+        // "we have enough evidence" over a stream where NOTHING was settled.
+        // An audit trusting that flag would have read right=0/wrong=0 and
+        // concluded the gate is never wrong. The type contract already said
+        // "graded-decision count" (types.ts); the code counted rows.
+        // Instance 7 of ACT-1243: a metric must refuse a verdict when its
+        // denominator is unverifiable, never report the ideal value.
+        insufficientEvidence: settledGrades < minSample,
         gradeDistribution: {
           right,
           wrong,

--- a/tests/integration/decision-quality-routes.test.ts
+++ b/tests/integration/decision-quality-routes.test.ts
@@ -127,6 +127,69 @@ describe('GET /decision-quality (integration)', () => {
     expect(JSON.stringify(res.body)).not.toMatch(/evidence_note|evidenceNote/);
   });
 
+  it('a 100%-UNKNOWN stream is insufficientEvidence:true — unknown grades are not evidence', async () => {
+    ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
+    const now = Date.now();
+    // 25 decisions, every one graded `unknown`. 25 > minSampleForRates(20), so a
+    // row-counting flag would call this SUFFICIENT. Nothing here is settled.
+    for (let i = 0; i < 25; i += 1) {
+      const correlationId = `unk-${i}`;
+      ledger.recordDecision({
+        correlationId, decisionPoint: DP_EXTERNAL_HOG_KILL_LEAVE,
+        feature: 'ExternalHogClassifier', ts: now - 1000, model: 'gpt-5.5',
+        framework: 'codex-cli', promptId: 'hog-v1',
+      });
+      ledger.upsertOutcome({
+        correlationId, gradedBy: 'DecisionGrading', ruleId: HOG_SUSTAINED_RIGHT_RULE_ID,
+        rung: 'deterministic-ground-truth', evidenceStrength: 'negative-evidence',
+        grade: 'unknown', ts: now,
+      });
+    }
+
+    const res = await request(appWith(ctxWith({ ledger, developmentAgent: true })))
+      .get('/decision-quality?sinceHours=24').set('Authorization', `Bearer ${AUTH}`);
+
+    expect(res.status).toBe(200);
+    const point = (res.body.points as Array<any>).find((p) => p.decisionPoint === DP_EXTERNAL_HOG_KILL_LEAVE);
+    expect(point.decisions).toBe(25);
+    expect(point.gradeDistribution.unknown).toBe(25);
+    expect(point.gradeDistribution.right).toBe(0);
+    expect(point.gradeDistribution.wrong).toBe(0);
+
+    // The row count is still published and still 25 — it answers a different question.
+    expect(point.outcomesKnown).toBe(25);
+    // The evidence count is zero, and the flag follows the evidence, not the rows.
+    expect(point.settledGrades).toBe(0);
+    expect(point.unknownShare).toBe(1);
+    expect(point.insufficientEvidence).toBe(true);
+  });
+
+  it('settled grades above the floor DO clear insufficientEvidence (the flag is not stuck true)', async () => {
+    ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
+    const now = Date.now();
+    for (let i = 0; i < 25; i += 1) {
+      const correlationId = `set-${i}`;
+      ledger.recordDecision({
+        correlationId, decisionPoint: DP_EXTERNAL_HOG_KILL_LEAVE,
+        feature: 'ExternalHogClassifier', ts: now - 1000, model: 'gpt-5.5',
+        framework: 'codex-cli', promptId: 'hog-v1',
+      });
+      ledger.upsertOutcome({
+        correlationId, gradedBy: 'DecisionGrading', ruleId: HOG_SUSTAINED_RIGHT_RULE_ID,
+        rung: 'deterministic-ground-truth', evidenceStrength: 'negative-evidence',
+        grade: 'right', ts: now,
+      });
+    }
+
+    const res = await request(appWith(ctxWith({ ledger, developmentAgent: true })))
+      .get('/decision-quality?sinceHours=24').set('Authorization', `Bearer ${AUTH}`);
+
+    const point = (res.body.points as Array<any>).find((p) => p.decisionPoint === DP_EXTERNAL_HOG_KILL_LEAVE);
+    expect(point.settledGrades).toBe(25);
+    expect(point.unknownShare).toBe(0);
+    expect(point.insufficientEvidence).toBe(false);
+  });
+
   it('?scope=pool strips a hostile peer row down to the FIELD ALLOWLIST (contextFull + extras removed)', async () => {
     ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
     vi.stubGlobal('fetch', async () => ({

--- a/upgrades/next/decision-quality-settled-evidence.md
+++ b/upgrades/next/decision-quality-settled-evidence.md
@@ -1,0 +1,57 @@
+# decision-quality settled-evidence flag
+
+## What Changed
+
+`GET /decision-quality` computed `outcomesKnown = right + wrong + unknown` and served
+`insufficientEvidence: outcomesKnown < minSample`. An `unknown` grade is the *absence* of
+a settled outcome, so a decision point whose grades were 100% unknown reported that it had
+**sufficient** evidence. Measured live over 7 days: `messaging-tone-gate` at 2075
+decisions / 2004 unknown / 0 right / 0 wrong served `insufficientEvidence: false`;
+`completion-claim-verify` showed the same shape at 1929 / 1760.
+
+The route now also serves `settledGrades` (right + wrong) and `unknownShare`, and
+`insufficientEvidence` follows the settled count. `outcomesKnown` and `outcomesKnownRatio`
+are unchanged and still served — they answer a different question. Both new fields are
+added to the pool-merge field allowlist, so a `?scope=pool` row does not silently lose the
+two fields that say whether its rates mean anything.
+
+The type contract already described the intended behaviour ("below this **graded-decision**
+count"), and the same object literal already divided by `right + wrong` for
+`selfReportShare` — the correct denominator was present, one field simply did not use it.
+
+This is instance 7 of ACT-1243 (critical): a completeness metric must carry its denominator
+and refuse a verdict when that denominator is unverifiable, rather than report the ideal
+value.
+
+## Evidence
+
+- **Mutation-proved:** restoring the original `outcomesKnown < minSample` expression makes
+  the new test fail with exactly `expected false to be true` — the production symptom.
+  Restored; 13/13 green.
+- Both sides of the boundary are tested: 25 unknown grades (above the sample floor) must
+  give `insufficientEvidence: true`; 25 settled grades must give `false`. The second test
+  exists so the flag cannot be satisfied by being stuck true.
+- The pre-existing assertion (`1 < 20 → true`) is unchanged and still passes.
+- `tsc --noEmit` clean.
+
+## What to Tell Your User
+
+If you look at the panel showing how often your agent's internal checks get things right,
+two of the busiest ones will now say there is **not enough evidence** to judge them, where
+they previously said there was.
+
+Nothing has got worse. That was already true and the display was wrong: those checks had
+thousands of decisions recorded but none of them ever established as right or wrong, and
+the summary was counting "we never found out" as though it were evidence. It now counts
+only decisions that were actually settled, and separately shows you how much is still
+unknown.
+
+This panel only reports. It does not block anything, slow anything down, or change how
+your agent behaves.
+
+## Summary of New Capabilities
+
+Two new read-only figures on the decision-quality view: the number of decisions actually
+settled as right or wrong, and the share still unknown. The existing "enough evidence"
+indicator now follows the settled figure, so a stream where nothing has been established
+is reported as unproven rather than as proven.

--- a/upgrades/side-effects/decision-quality-settled-evidence.md
+++ b/upgrades/side-effects/decision-quality-settled-evidence.md
@@ -1,0 +1,108 @@
+# Side-effects review — decision-quality settled-evidence flag
+
+**Change.** `GET /decision-quality` computed `outcomesKnown = right + wrong + unknown` and
+served `insufficientEvidence: outcomesKnown < minSample`. An `unknown` grade is precisely
+the *absence* of a settled outcome, so a decision point with 100% unknown grades reported
+that it had **sufficient** evidence. Now: `settledGrades = right + wrong` is published,
+`unknownShare` is published, and `insufficientEvidence` follows the settled count.
+`outcomesKnown` and `outcomesKnownRatio` are unchanged and still served.
+
+**Measured before the fix** (live, 7-day window):
+
+| decision point | decisions | outcomesKnown | right | wrong | unknown | insufficientEvidence |
+|---|---|---|---|---|---|---|
+| messaging-tone-gate | 2075 | 2004 | 0 | 0 | 2004 | **false** |
+| completion-claim-verify | 1929 | 1760 | 0 | 0 | 1760 | **false** |
+
+Instance 7 of **ACT-1243** (critical, 2026-07-25): *a health/completeness metric must
+carry its denominator and refuse a ratio when it is zero or unverifiable.*
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+`insufficientEvidence` flips `false → true` for any point whose settled grades are below
+the floor but whose row count was above it. That is the intended correction, not
+over-blocking: those rows never supported a rate. Nothing is rejected, blocked, or
+withheld — this route gates nothing. The only effect is that a flag now says "don't trust
+these rates" where it previously said "do."
+
+Reader impact is real and worth stating plainly: any dashboard or reader currently seeing
+`insufficientEvidence: false` on the two high-volume points will now see `true`. That is
+the surface telling the truth for the first time, but it will look like a regression to
+anyone who assumed the old value meant something.
+
+## 2. Under-block — what failure modes does this still miss?
+
+- **`minSample` is a count, not a power calculation.** 20 settled grades is a floor, not
+  evidence that a rate is statistically meaningful. Unchanged by this fix.
+- **A settled grade can still be low-quality.** `selfReportShare` and `byStrength` exist
+  precisely because a `wrong` may be the interested party's own account (ACT-934). This
+  fix does not segment settled grades by strength — it only stops counting non-grades.
+- **`expired` is not counted anywhere in the flag.** An expired outcome is neither settled
+  nor unknown; a point that expires everything reads as zero settled → `true`, which is
+  correct, but the reason is not distinguishable from "never graded."
+- **The rates themselves are still served** when `insufficientEvidence` is true. A
+  consumer that ignores the flag reads `right: 0, wrong: 0` as before. The flag is a
+  signal, not an authority — deliberately, per Signal vs Authority.
+
+## 3. Level-of-abstraction fit
+
+Correct layer, and it moves the computation toward a quantity the same object already
+uses: `selfReportShare` on the very next lines divides by `right + wrong`. The settled
+count was already the right denominator here — one field simply did not use it.
+
+## 4. Signal vs authority compliance
+
+Compliant. `/decision-quality` is explicitly observe-only and gates nothing; this change
+adds no blocking authority and removes none. It repairs an **honesty** property of a
+signal: the flag's whole job is to tell a consumer when not to trust the numbers beside
+it, and it was answering the opposite of the truth in the two highest-volume cases.
+
+The failure mode this closes is a Signal-vs-Authority failure one level up: a *human or
+agent audit* reading `insufficientEvidence: false` alongside `right: 0, wrong: 0` would
+reasonably conclude "this gate has never been wrong" and argue to **remove its blocking
+authority**. A brittle input was positioned to drive a real authority decision.
+
+## 5. Interactions
+
+- **Pool merge:** `DECISION_QUALITY_POINT_FIELDS` is an explicit allowlist that strips
+  unknown fields from peer rows. `settledGrades` and `unknownShare` are added to it —
+  otherwise a `?scope=pool` row would silently lose exactly the two fields that say
+  whether its rates mean anything, leaving the merged view **more** misleading than the
+  local one. The allowlist's security property (a hostile peer cannot smuggle extra
+  fields) is unchanged; two known-good names were added.
+- **Benchmark-divergence detector:** already bounds unsettled streams independently via
+  `maxUnknownShare` and reads `gradedN` / `unknownShare` from its own computation. It does
+  not consume `insufficientEvidence`, so its verdicts do not change.
+- **CoherenceGate** has its own unrelated `insufficientEvidence` local
+  (`REVIEWER_HEALTH_MIN_OBSERVATIONS`); untouched, different symbol, no shared code.
+- **No double-fire, no race:** pure arithmetic inside an existing read path.
+
+## 6. External surfaces
+
+`GET /decision-quality` is dev-gated (503 on the fleet). Two additive fields plus one
+boolean whose *meaning* is corrected. No route, config key, message, job, or persisted
+state changes; nothing is written. The response schema only grows.
+
+## 7. Multi-machine posture
+
+**Proxied-on-read**, and handled: `?scope=pool` merges machine-tagged rows through
+`pickDecisionQualityPointFields`, which is updated so the new fields survive the merge.
+Per-machine rows stay individually visible (per-machine framework routing makes per-machine
+quality genuinely distinct data). No durable state, so nothing strands on a topic transfer.
+
+## 8. Rollback cost
+
+Revert the commit. Pure computation on a read route — no migration, no persisted state, no
+config, nothing to repair. The ledger rows are untouched; the change is entirely in how
+they are summarised on read.
+
+## Verification
+
+- **Mutation-proved:** restored the original `outcomesKnown < minSample` expression and the
+  new test failed with exactly `expected false to be true` — the production symptom. Fix
+  restored, 13/13 green.
+- Both sides of the boundary are covered: 25 unknown grades (above the sample floor) must
+  yield `insufficientEvidence: true`, and 25 settled grades must yield `false`. The second
+  test exists so the flag cannot be trivially satisfied by being stuck true.
+- The existing assertion (`1 < 20 → true`) is unchanged and still passes.
+- `tsc --noEmit` clean.


### PR DESCRIPTION
## What Changed

`GET /decision-quality` computed `outcomesKnown = right + wrong + unknown` and served `insufficientEvidence: outcomesKnown < minSample`. An `unknown` grade is the **absence** of a settled outcome, so a decision point whose grades were 100% unknown reported that it **had sufficient evidence**.

Measured live, 7-day window:

| decision point | decisions | outcomesKnown | right | wrong | unknown | insufficientEvidence |
|---|---|---|---|---|---|---|
| messaging-tone-gate | 2075 | 2004 | 0 | 0 | **2004** | **false** |
| completion-claim-verify | 1929 | 1760 | 0 | 0 | **1760** | **false** |

Now serves `settledGrades` (right + wrong) and `unknownShare`, and `insufficientEvidence` follows the settled count. `outcomesKnown` / `outcomesKnownRatio` are unchanged and still served — they answer a different question.

**The correct denominator was already in the same object literal.** `selfReportShare`, twenty lines below, already divides by `right + wrong`. The type contract already said "below this **graded-decision** count." One field simply did not use it.

Both new fields are added to `DECISION_QUALITY_POINT_FIELDS`, or a `?scope=pool` row would silently lose the two fields that say whether its rates mean anything — leaving the merged view **more** misleading than the local one.

## Why it matters beyond itself

This flag is why "0 of 5,293 decisions graded in 7 days" never announced itself: the meter's own evidence guard was answering *yes* the whole time. An audit reading `insufficientEvidence: false` beside `right: 0, wrong: 0` would reasonably conclude those gates are never wrong and argue to **remove their blocking authority**.

That is not hypothetical — a councilor track-record audit was being written against exactly these numbers earlier in this session. What stopped it was declining to publish on empty data, not this guard.

Instance 7 of **ACT-1243** (critical, filed 2026-07-25, six prior instances): *a completeness metric must carry its denominator and refuse a verdict when it is unverifiable.* Tracked as ACT-1515.

## ELI16 — a scoreboard that said "plenty of evidence" about nothing

Your agent keeps score on its own judgment calls. Each internal decision can later be graded right, wrong, or **unknown** — unknown meaning nobody ever established which it was. Beside those counts sits a warning flag: *is there enough evidence here for these numbers to mean anything?*

That flag was adding up all three categories. But "unknown" is not evidence — it is the word for having none. So a check with 2,004 decisions, zero graded right, zero graded wrong, and 2,004 unknown was reporting **we have plenty of evidence**. About nothing.

A wrong number gets questioned. A confident "this is reliable" gets believed. Anyone reading that scoreboard would have seen "enough evidence" next to "zero times wrong" and drawn the obvious conclusion: this check never makes mistakes, so perhaps it doesn't need the power to block things. It hadn't been proven right — it had never been graded at all.

The scoreboard now also shows how many decisions were actually settled, and what share is still unknown, and the flag follows the settled figure. It reports only; it blocks nothing.

## UX Impact

**Who sees it:** anyone reading the decision-quality view or a dashboard rendering it — and any agent or operator auditing how often an internal check is right.

**Visible behaviour:** the two highest-volume decision points flip from `insufficientEvidence: false` to `true`. Nothing has got worse; that was already true and the display was wrong. Two new read-only figures appear beside the existing ones: `settledGrades` and `unknownShare`. The previously published `outcomesKnown` is unchanged, so nothing reading it breaks.

**First contact:** the first time a reader opens the view after this ships, the busiest checks say there is not enough evidence to judge them where they previously claimed there was. No action is required of them — the change is that a reassurance they should never have been given is withdrawn.

## Verification

- **Mutation-proved:** restored the original `outcomesKnown < minSample` expression and the new test failed with exactly `expected false to be true` — the production symptom. Restored; 13/13 green.
- Both sides of the boundary tested: 25 unknown grades (above the sample floor) must yield `true`; 25 settled grades must yield `false`. The second test exists so the flag cannot be satisfied by being stuck true.
- The pre-existing assertion (`1 < 20 → true`) is unchanged and still passes.
- `tsc --noEmit` clean.

## Tier

Tier 1, matching the gate signal (`size=1, riskFloor=1`, 29 LOC / 1 file). Observe-only read route that gates nothing.

Side-effects: `upgrades/side-effects/decision-quality-settled-evidence.md` · ELI16 companion: `docs/specs/decision-quality-settled-evidence.eli16.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDAgKAVJfGHgrFa7GJoSVn
