### PR TITLE
fix(spec-review): refuse to claim delivery the relay never confirmed

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-28T18-14-24-855Z-publish-spec-review-honest-send.json
+++ b/.instar/instar-dev-decisions/2026-07-28T18-14-24-855Z-publish-spec-review-honest-send.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-28T18:14:24.855Z",
+  "slug": "publish-spec-review-honest-send",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 71,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/publish-spec-review-honest-send.eli16.md
+++ b/docs/specs/publish-spec-review-honest-send.eli16.md
@@ -1,0 +1,59 @@
+# The tool that hands you things to approve was dropping them
+
+## What happened
+
+When your agent needs your approval on a design, there is one sanctioned way to send it to
+you. It renders the plain-English summary as a web page, checks the link actually loads,
+and messages it to you. A safety hook *blocks* the agent from sending an approval request
+any other way — so this one tool is the only door.
+
+That tool sent the message by running a small script, and it looked for that script in
+whatever folder it happened to be running from. But agents are required to do their work
+in a separate checkout folder, and that folder does not contain the script. So the send
+failed with "file not found."
+
+Then the tool printed: **"published — verified and delivered."**
+
+Both lines, one after the other, in the same output. You received nothing. The agent was
+told you had received it.
+
+## Why this one is worse than it sounds
+
+Everything else in that tool is careful. It refuses to send a broken link. It refuses if
+the summary is missing or too short. It checks the page returns a real response before
+handing it over.
+
+And then it didn't check whether the message was sent.
+
+An approval request that vanishes doesn't look like an error to anybody. To you, nothing
+arrives — and nothing arriving is indistinguishable from the agent simply not asking yet.
+To the agent, it's done. So a design can sit "waiting for the operator" indefinitely while
+the operator was never actually asked.
+
+## How long it was there
+
+This exact problem was written down as a known bug **three separate times** — the 13th of
+July, the 27th of July, and again today — by different investigations that each found it
+fresh. Fifteen days. Nobody fixed it, because each time it was recorded as something to do
+later rather than done.
+
+It is fixed now.
+
+## What changed
+
+Two things, both small:
+
+- The tool now searches upward from wherever it is until it finds the script, so it works
+  from a working folder, from the agent's home, and from the older layout some installs
+  still use.
+- It only says "delivered" if the messaging script actually confirms it sent something. If
+  it can't confirm, it says **not delivered**, prints the message so the request isn't
+  lost, and exits with an error.
+
+The second part is the real fix. The first part just removes today's cause; the second
+means the next cause — whatever it is — announces itself instead of hiding.
+
+## What you'll notice
+
+Nothing, when it works. When it doesn't work you'll notice that your agent now says so,
+rather than both of you believing a message arrived that never did.

--- a/skills/spec-converge/scripts/publish-spec-review.mjs
+++ b/skills/spec-converge/scripts/publish-spec-review.mjs
@@ -33,6 +33,56 @@ import { checkEli16Overview } from '../../../scripts/eli16-overview-check.mjs';
 
 export const API_PORT = Number(process.env.INSTAR_PORT) || 4042;
 
+/** Relay locations, in resolution order (the second is the documented older-install path). */
+const RELAY_RELATIVE_PATHS = ['.instar/scripts/telegram-reply.sh', '.claude/scripts/telegram-reply.sh'];
+
+/**
+ * Locate telegram-reply.sh by walking UP from `startDir`.
+ *
+ * It used to be spawned as the bare relative path `.instar/scripts/telegram-reply.sh`,
+ * which only resolves when cwd IS the agent home. instar-dev work is REQUIRED to happen
+ * in a worktree (docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md), and a worktree has no
+ * `.instar/scripts/`, so every send from one failed with ENOENT. Walking up from a
+ * worktree at `<agent-home>/.worktrees/<slug>` reaches `<agent-home>`, which has it.
+ *
+ * Returns an absolute path, or null when no relay exists above `startDir`.
+ */
+export function resolveRelayScript(startDir = process.cwd(), existsSync = fs.existsSync) {
+  const envHome = process.env.INSTAR_AGENT_HOME;
+  const roots = [];
+  if (envHome) roots.push(path.resolve(envHome));
+  let dir = path.resolve(startDir);
+  for (;;) {
+    roots.push(dir);
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  for (const root of roots) {
+    for (const rel of RELAY_RELATIVE_PATHS) {
+      const candidate = path.join(root, rel);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Did the relay actually deliver?
+ *
+ * The relay prints `Sent <n> chars to topic <id>` on a real send. Requiring that
+ * marker — not merely a zero exit — is deliberate: this script's whole job is
+ * handing the operator something to approve, and it previously printed
+ * "[published] … delivered" straight after an ENOENT, so a dropped approval ask
+ * was indistinguishable from a delivered one. Filed three times in fifteen days
+ * (ACT-616 2026-07-13, ACT-1390 2026-07-27, ACT-1517 2026-07-28) before this fix.
+ */
+export function relayDelivered(result) {
+  if (!result || result.error) return false;
+  if (result.status !== 0) return false;
+  return /Sent\s+\d+\s+chars?\s+to\s+topic/i.test(`${result.stdout || ''}${result.stderr || ''}`);
+}
+
 /** Split a spec file into its frontmatter body and the rest. */
 export function extractFrontmatter(specText) {
   const m = specText.match(/^---\n([\s\S]*?)\n---/);
@@ -144,11 +194,30 @@ async function main() {
       console.error('--send requires --topic <id>');
       process.exit(2);
     }
-    const reply = spawnSync('bash', ['.instar/scripts/telegram-reply.sh', String(args.topic)], {
+    const relay = resolveRelayScript();
+    if (!relay) {
+      console.error(
+        'REFUSING to claim delivery: no telegram-reply.sh found at or above this directory ' +
+        `(looked for ${RELAY_RELATIVE_PATHS.join(' / ')}). The spec was NOT sent.`,
+      );
+      console.error('The composed message follows so the ask is not lost — send it yourself.');
+      console.log(message);
+      process.exit(1);
+    }
+    const reply = spawnSync('bash', [relay, String(args.topic)], {
       input: message, encoding: 'utf8',
     });
     process.stderr.write(reply.stdout || '');
     process.stderr.write(reply.stderr || '');
+    if (!relayDelivered(reply)) {
+      const why = reply.error
+        ? reply.error.message
+        : `relay exited ${reply.status} without a send confirmation`;
+      console.error(`\n[NOT DELIVERED] the spec was NOT sent to topic ${args.topic}: ${why}`);
+      console.error('The composed message follows so the ask is not lost — send it yourself.');
+      console.log(message);
+      process.exit(1);
+    }
     console.error(`\n[published] ELI16 link verified (HTTP 200) and delivered to topic ${args.topic}.`);
   } else {
     // Print the message + the verified link for the caller to send.

--- a/tests/unit/publish-spec-review-honest-send.test.ts
+++ b/tests/unit/publish-spec-review-honest-send.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import {
+  resolveRelayScript,
+  relayDelivered,
+} from '../../skills/spec-converge/scripts/publish-spec-review.mjs';
+
+/**
+ * publish-spec-review.mjs spawned `.instar/scripts/telegram-reply.sh` as a bare
+ * relative path and then printed "[published] … delivered" without inspecting the
+ * result. From a worktree — where instar-dev work is REQUIRED to happen — the spawn
+ * failed with ENOENT and the operator's approval ask was silently dropped while the
+ * agent was told it had been delivered.
+ *
+ * Filed three times before it was fixed: ACT-616 (2026-07-13), ACT-1390
+ * (2026-07-27), ACT-1517 (2026-07-28).
+ */
+describe('resolveRelayScript', () => {
+  const HOME = '/Users/x/.instar/agents/echo';
+  const RELAY = path.join(HOME, '.instar/scripts/telegram-reply.sh');
+
+  it('finds the relay when cwd IS the agent home', () => {
+    expect(resolveRelayScript(HOME, (p) => p === RELAY)).toBe(RELAY);
+  });
+
+  it('walks UP to the agent home from a worktree — the case that shipped broken', () => {
+    const worktree = path.join(HOME, '.worktrees/act1426-tautological');
+    expect(resolveRelayScript(worktree, (p) => p === RELAY)).toBe(RELAY);
+  });
+
+  it('falls back to the documented older-install .claude path', () => {
+    const legacy = path.join(HOME, '.claude/scripts/telegram-reply.sh');
+    expect(resolveRelayScript(HOME, (p) => p === legacy)).toBe(legacy);
+  });
+
+  it('prefers .instar over .claude when both exist', () => {
+    expect(resolveRelayScript(HOME, () => true)).toBe(RELAY);
+  });
+
+  it('returns null when no relay exists anywhere above — never a bogus path', () => {
+    expect(resolveRelayScript('/tmp/nowhere', () => false)).toBeNull();
+  });
+});
+
+describe('relayDelivered', () => {
+  const SENT = 'Sent 408 chars to topic 29723\n';
+
+  it('is true only when the relay confirms the send', () => {
+    expect(relayDelivered({ status: 0, stdout: SENT, stderr: '' })).toBe(true);
+  });
+
+  it('accepts the confirmation on stderr too', () => {
+    expect(relayDelivered({ status: 0, stdout: '', stderr: SENT })).toBe(true);
+  });
+
+  it('is FALSE on ENOENT — the exact production failure', () => {
+    expect(relayDelivered({
+      error: new Error('spawnSync bash ENOENT'),
+      status: null,
+      stdout: '',
+      stderr: 'bash: .instar/scripts/telegram-reply.sh: No such file or directory\n',
+    })).toBe(false);
+  });
+
+  it('is FALSE on a nonzero exit', () => {
+    expect(relayDelivered({ status: 1, stdout: '', stderr: 'boom' })).toBe(false);
+  });
+
+  it('is FALSE on exit 0 with NO confirmation — a silent no-op is not a delivery', () => {
+    expect(relayDelivered({ status: 0, stdout: '', stderr: '' })).toBe(false);
+  });
+
+  it('is FALSE for a null/undefined result', () => {
+    expect(relayDelivered(undefined)).toBe(false);
+    expect(relayDelivered(null)).toBe(false);
+  });
+});

--- a/upgrades/next/publish-spec-review-honest-send.md
+++ b/upgrades/next/publish-spec-review-honest-send.md
@@ -1,0 +1,44 @@
+# publish-spec-review honest send
+
+<!-- internal-only -->
+
+## What Changed
+
+`skills/spec-converge/scripts/publish-spec-review.mjs` spawned the relay script as a bare
+relative path (`.instar/scripts/telegram-reply.sh`) and then printed
+`[published] … delivered to topic N` without inspecting the spawn result.
+
+instar-dev work is required to happen in a worktree, and a worktree has no
+`.instar/scripts/`, so every send from one failed with ENOENT and was reported as
+delivered. Reproduced live: the ENOENT line and the "delivered" line printed one after the
+other, and the operator received nothing.
+
+This matters because the script sits on a hook-enforced path — `grounding-before-messaging`
+blocks a hand-written spec-review message and directs the agent here — so the one tool
+whose job is delivering approval asks could silently drop them, leaving work "awaiting
+operator approval" that the operator was never actually asked for.
+
+Two changes:
+
+- `resolveRelayScript()` walks up from cwd until it finds the relay, so a worktree reaches
+  the agent home. Honors `INSTAR_AGENT_HOME` first and falls back to the documented
+  `.claude/scripts/` path for older installs. Returns null rather than a guessed path.
+- `relayDelivered()` requires the relay's own `Sent <n> chars to topic <id>` confirmation,
+  not merely exit 0. On any failure the script prints `[NOT DELIVERED]` with the reason,
+  emits the composed message so the ask is not lost, and exits 1 — it fails closed instead
+  of failing silent.
+
+The script already refused a broken link, a missing overview, and a stub overview — and
+then did not check whether the message sent. Filed three times in fifteen days (ACT-616
+2026-07-13, ACT-1390 2026-07-27, ACT-1517 2026-07-28) before being fixed.
+
+## Evidence
+
+- 11 unit tests over both exported functions, including the exact production failure
+  (ENOENT → not delivered), the worktree walk-up that shipped broken, the `.claude`
+  fallback, precedence when both exist, and exit-0-with-no-confirmation.
+- Proven against the real filesystem from the actual worktree: `resolveRelayScript`
+  returns the agent home's relay and it exists on disk.
+- The fix direction was confirmed before the code was written — the unmodified script run
+  from the agent home printed `Sent 408 chars to topic 29723` and genuinely delivered,
+  while the same command from the worktree printed ENOENT followed by "delivered".

--- a/upgrades/side-effects/publish-spec-review-honest-send.md
+++ b/upgrades/side-effects/publish-spec-review-honest-send.md
@@ -1,0 +1,96 @@
+# Side-effects review — publish-spec-review honest send
+
+**Change.** `publish-spec-review.mjs` spawned `.instar/scripts/telegram-reply.sh` as a
+bare relative path and then printed `[published] … delivered to topic N` without
+inspecting the spawn result. Now the relay is resolved by walking up from cwd (with the
+documented `.claude/scripts/` fallback), and delivery is only claimed when the relay's own
+`Sent <n> chars to topic <id>` confirmation is present.
+
+**This bug was filed three times in fifteen days before being fixed:** ACT-616
+(2026-07-13, medium), ACT-1390 (2026-07-27, high), ACT-1517 (2026-07-28, high).
+Reproduced live at 18:09Z: the ENOENT line and the "delivered" line printed one after the
+other, and the operator received nothing.
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+The delivery check requires the relay's `Sent … chars to topic …` marker, so a future
+relay that succeeds *silently* would be reported as NOT delivered — a false negative.
+Accepted deliberately: this script's only job is handing the operator something to
+approve, so a false "didn't send" (which prints the composed message for manual sending
+and exits 1) is strictly safer than a false "sent". If the relay's output contract
+changes, this test fails loudly rather than the ask disappearing quietly.
+
+The path walk can in principle find a relay in an unrelated ancestor directory. In the
+agent-home/worktree layout the first match walking up is the agent's own relay, and
+`INSTAR_AGENT_HOME` takes precedence when set.
+
+## 2. Under-block — what failure modes does this still miss?
+
+- **The relay can confirm a send that Telegram later drops.** `Sent N chars` means the
+  relay accepted and posted it; downstream delivery failure is the relay's own retry
+  domain (PendingRelayStore / DeliveryFailureSentinel), not this script's.
+- **A wrong topic id still "delivers"** — to the wrong place. Not addressed here.
+- **Non-`--send` callers are unchanged**: they print the message and the verified link for
+  the caller to send, and can still drop it themselves. That path already exits 0
+  honestly because it never claims delivery.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. "Where does the relay live" is knowledge the spawning process must have,
+and "did the spawn work" is a question only the spawner can ask. Neither belongs to the
+relay or the caller. The walk-up specifically encodes the worktree convention
+(`docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md`), which is *why* cwd is reliably not the
+agent home.
+
+## 4. Signal vs authority compliance
+
+Compliant, and this is the crux. The script sits on a hook-ENFORCED path: the
+`grounding-before-messaging` hook BLOCKS a hand-written spec-review message and directs
+the agent here. So this script holds real authority over whether an operator ever sees an
+approval ask — and it was reporting success without checking. A brittle, unchecked step
+was granted the last word on a human decision point.
+
+The fix adds no new blocking authority. It makes an existing authority *honest*: it now
+fails closed (exit 1, message printed for manual sending) instead of failing silent.
+
+## 5. Interactions
+
+- **The grounding hook** is the upstream producer of traffic here; unchanged.
+- **telegram-reply.sh** is spawned identically, only via an absolute resolved path. Its
+  own duplicate-suppression and tone-gate behaviour are untouched.
+- **No double-send risk:** the delivery check is read-only on the result; it never retries.
+  A false negative prints the message for a human to send, which could produce a duplicate
+  if the relay *had* silently sent it — bounded by the relay's own exact-duplicate
+  suppression window.
+- No shadowing, no race: one synchronous spawn, one verdict.
+
+## 6. External surfaces
+
+Developer/agent tooling under `skills/`. No runtime agent behaviour, route, config, job,
+message schema, or persisted state changes. The only externally visible difference is that
+a failed send is now reported as failed — previously it was reported as success.
+
+## 7. Multi-machine posture
+
+**Machine-local BY DESIGN.** The question answered is "where on THIS disk is this agent's
+relay script" — a per-machine filesystem fact. Replicating or proxying it would be
+incorrect; a peer's relay path says nothing about this machine's. No durable state, no
+generated URL, no user-facing notice, so nothing strands on a topic transfer. The rendered
+private-view link the script produces is a separate concern and already tunnel-backed.
+
+## 8. Rollback cost
+
+Revert the commit. Two pure exported functions and one call site; no persisted state, no
+migration, no config. Reverting restores the false-success behaviour, which is the reason
+not to.
+
+## Verification
+
+- 11 unit tests over both exported functions, including the exact production failure
+  (ENOENT → `relayDelivered` false) and the worktree walk-up that shipped broken.
+- Proven against the real filesystem from the actual worktree: `resolveRelayScript`
+  returns the agent home's relay and `fs.existsSync` on it is true.
+- The end-to-end fix direction was confirmed before writing the code — running the
+  unmodified script from the agent home printed `Sent 408 chars to topic 29723` and
+  genuinely delivered, while running it from the worktree printed ENOENT followed by
+  "delivered".


### PR DESCRIPTION
## What Changed

`publish-spec-review.mjs` spawned the relay as a bare **relative** path (`.instar/scripts/telegram-reply.sh`) and then printed `[published] … delivered to topic N` **without inspecting the spawn result**.

instar-dev work is *required* to happen in a worktree, and a worktree has no `.instar/scripts/`. So every send from one failed with ENOENT and was reported as delivered. Reproduced live at 18:09Z today — these two lines printed one after the other:

```
bash: .instar/scripts/telegram-reply.sh: No such file or directory
[published] link verified (HTTP 200) and delivered to topic 29723.
```

The operator received nothing.

**Why this one matters more than its size.** The script sits on a hook-**enforced** path: `grounding-before-messaging` *blocks* a hand-written message of this kind and directs the agent here. So the single tool whose job is delivering approval asks could silently drop them — leaving work "awaiting operator approval" that the operator was never asked for. A vanished ask is indistinguishable, from the operator's side, from the agent simply not having asked yet.

The script already refused a broken link, a missing overview, and a stub overview. Then it did not check whether the message sent.

**Filed three times in fifteen days before this fix:** ACT-616 (2026-07-13), ACT-1390 (2026-07-27), ACT-1517 (2026-07-28) — three independent investigations, each recording it as a TODO. Dates verified against the ledger.

## The fix

- `resolveRelayScript()` walks **up** from cwd until it finds the relay, so a worktree reaches the agent home. Honors `INSTAR_AGENT_HOME` first, falls back to the documented `.claude/scripts/` path for older installs, and returns `null` rather than a guessed path.
- `relayDelivered()` requires the relay's own `Sent <n> chars to topic <id>` confirmation — not merely exit 0. A silent no-op is not a delivery.
- On any failure: `[NOT DELIVERED]` with the reason, the composed message printed so the ask is not lost, exit 1. **Fails closed instead of failing silent.**

The second part is the durable half. The first removes today's cause; the second means the next cause announces itself.

## ELI16 — the tool that hands you things to approve was dropping them

When your agent needs your approval on a design, there is one sanctioned way to send it to you: it renders the plain-English summary as a web page, checks the link actually loads, and messages it to you. A safety hook *blocks* the agent from asking any other way — so this one tool is the only door.

That tool sent the message by running a small script, and it looked for that script in whatever folder it happened to be running from. But agents are required to do their work in a separate checkout folder, which does not contain the script. So the send failed with "file not found." Then the tool printed: **"published — verified and delivered."** Both lines, one after the other, in the same output.

Everything else in that tool is careful. It refuses to send a broken link. It refuses if the summary is missing or too short. And then it didn't check whether the message was sent.

An approval request that vanishes doesn't look like an error to anyone. To you, nothing arrives — and nothing arriving is indistinguishable from the agent simply not having asked yet. To the agent, it's done. So a design can sit "waiting for the operator" indefinitely while the operator was never actually asked. This exact problem was written down three separate times over fifteen days before anyone fixed it.

Now it searches upward until it finds the script, and it only says "delivered" if the messaging script actually confirms it sent something. If it can't confirm, it says **not delivered**, prints the message so the request isn't lost, and exits with an error.

## Verification

- 11 unit tests over both exported functions: the exact production failure (ENOENT → not delivered), the worktree walk-up that shipped broken, the `.claude` fallback, precedence when both exist, exit-0-with-no-confirmation, and null-result.
- Proven against the real filesystem **from the actual worktree**: `resolveRelayScript` returns the agent home's relay and `fs.existsSync` on it is true.
- Fix direction confirmed before writing code: the unmodified script from the agent home printed `Sent 408 chars to topic 29723` and genuinely delivered; the same command from the worktree printed ENOENT then "delivered".

## Tier

Declared **Tier 1** against a size-driven signal of 2 (`size=2, riskFloor=1`, 71 LOC / 1 file). Risk floor is 1; **zero `src/` runtime files** — agent tooling under `skills/`, no route, config, persisted state, or migration. Most of the LOC is the doc comments recording why; trimming them to slip under the 40-LOC bar would be gaming the gate, so it is declared openly and recorded as `belowFloor`.

Release fragment is marked internal-only, which the push gate objectively verifies against the diff (it rejects that marker when any runtime `src/` file changed — zero here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDAgKAVJfGHgrFa7GJoSVn
