### PR TITLE
docs(test-config): the e2e skip justification had expired

### DIFF
--- a/docs/specs/e2e-config-stale-justification.eli16.md
+++ b/docs/specs/e2e-config-stale-justification.eli16.md
@@ -1,0 +1,50 @@
+# A note in the code that had quietly stopped being true
+
+## The situation
+
+There are two ways this project runs its tests. One of them compiles the program first; the
+other deliberately doesn't, because compiling takes time and it isn't needed there.
+
+Sitting next to that second setting was a note explaining the decision. It said, roughly:
+*don't add a compile step here, because it would wake up some sleeping tests — and one of
+them tries to use a tool the test machine doesn't have installed.*
+
+That was a good reason. It just isn't true any more, in two separate ways.
+
+## What changed underneath it
+
+**The missing tool is no longer a problem.** Earlier in the same working session, that exact
+tool dependency was fixed — the test now uses whichever package manager the machine
+actually has, and it finishes cleanly on a machine without the original one. So the
+obstacle the note warned about has been removed.
+
+**And the tests aren't sleeping.** The *other* test setup — the one that runs on every
+change — does compile the program, and it does include those tests. They run there, and
+they do real work: I ran one and watched it take about half a second per case rather than
+returning instantly.
+
+So the note was describing a world that no longer exists. Anyone reading it while deciding
+whether to change that setting would have been talked out of it for reasons that had
+expired.
+
+## What this changes
+
+Nothing that runs. This is a comment, and only a comment — the settings themselves are
+untouched, byte for byte. The tests still skip in the fast setup and still run in the
+thorough one, exactly as before.
+
+What changes is that the explanation now says the reason that actually still applies —
+compiling costs time and the coverage already exists elsewhere — instead of a reason that
+had quietly expired.
+
+## Why bother
+
+Because this is a small version of the thing that cost real time to find during this
+session: something that describes a state of the world, kept reporting confidently after
+the world moved. A stale note is a check on human judgement whose condition stopped holding
+without anyone noticing. It doesn't fail loudly — it just gives the next person a confident
+wrong answer.
+
+The person most likely to be misled by it was the next one to ask "should we compile in the
+fast setup too?" — a reasonable question, which the old note answered with a hazard that no
+longer exists.

--- a/upgrades/side-effects/e2e-config-stale-justification.md
+++ b/upgrades/side-effects/e2e-config-stale-justification.md
@@ -1,0 +1,66 @@
+# Side-effects review — e2e config's stale skip justification
+
+**Change.** Comment-only, in `vitest.e2e.config.ts`. **No executable change whatsoever** —
+`git diff` touches only comment lines; `include`, `globalSetup`, `testTimeout` and
+`environment` are byte-identical.
+
+The comment justified not compiling dist by stating that a build "would wake dormant
+dist-gated tests (e.g. dev-preflight-cli, which spawns `pnpm` — absent on the CI e2e
+runner)". Two things in that are no longer true:
+
+1. **The pnpm obstacle is gone.** PR #1712 made `dev:preflight` resolve its package manager
+   (pnpm, else `npm run lint`); it exits 0 under a pnpm-free PATH.
+2. **The tests are not dormant.** `vitest.config.ts` includes `tests/e2e/**` *and* wires
+   `build-dist.globalSetup` (added by #1709), so all three dist-gated tests run there.
+   Verified by executing `cli-unknown-command` under that config: 2 tests, 512ms + 387ms of
+   real work, not instant returns.
+
+The comment now states the reason that actually remains — build cost — and records that the
+tests are covered elsewhere.
+
+## 1. Over-block / 2. Under-block
+
+Not applicable: nothing is blocked or allowed. No predicate changed.
+
+## 3. Level-of-abstraction fit
+
+Correct. A config comment explaining *why* a globalSetup is absent belongs beside that
+globalSetup. Its accuracy is load-bearing precisely because it is the artifact a future
+reader consults before deciding whether to add a build step.
+
+## 4. Signal vs authority compliance
+
+No decision point touched. Worth noting the failure mode this repairs is the same class the
+run that found it was auditing: **a description that no longer matches what it describes.**
+A stale justification is a check on human reasoning whose passing condition (the pnpm
+obstacle) has silently stopped holding — it would have talked the next reader out of a
+change on grounds that expired.
+
+## 5. Interactions
+
+None. `vitest.config.ts`, `vitest.integration.config.ts` and `vitest.push.config.ts` all
+wire `build-dist.globalSetup` and are untouched. The e2e job's runtime behaviour is
+byte-identical: it still does not compile dist, and the three dist-gated tests still skip
+*there* while running in the unit shards.
+
+## 6. External surfaces
+
+None. Not shipped to agents, not a route, not config an operator sets, no persisted state.
+
+## 7. Multi-machine posture
+
+**Not applicable** — a build-time test config, evaluated per CI job. No runtime surface, no
+state, nothing to replicate, proxy, or strand on a topic transfer.
+
+## 8. Rollback cost
+
+Revert the commit. Comment-only; reverting restores an inaccurate comment, which is the
+reason not to.
+
+## Verification
+
+- `tsc --noEmit` clean.
+- `git diff` confirms only comment lines changed in the file.
+- The claims in the new comment are each checked rather than asserted: the pnpm-free run of
+  the built CLI exits 0 (from #1712's verification), and `cli-unknown-command` was executed
+  under `vitest.config.ts` and observed to run rather than skip.

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -8,10 +8,22 @@ export default defineConfig(withTestRunnerBound('e2e', {
     environment: 'node',
     testTimeout: 60000, // E2E tests may involve real sessions + cron waits
     // Asset-only: production registry resolution needs its gitignored generated
-    // data on a fresh checkout, but E2E still deliberately does NOT compile dist.
-    // A tsc/build globalSetup would wake dormant dist-gated tests (e.g.
-    // dev-preflight-cli, which spawns `pnpm` — absent on the CI e2e runner) that
-    // skip-by-design when dist is missing.
+    // data on a fresh checkout, but this config deliberately does NOT compile
+    // dist — a build here would cost every e2e run a full tsc.
+    //
+    // The dist-gated tests are NOT dormant. `vitest.config.ts` (what `npm test`
+    // and the CI unit shards run) includes `tests/e2e/**` AND wires
+    // build-dist.globalSetup, so all three run there — verified 2026-07-28 by
+    // executing cli-unknown-command under that config: 2 tests, 512ms + 387ms of
+    // real work, not instant returns. Skipping here is duplicate-coverage
+    // avoidance, not an excuse to leave them unrun.
+    //
+    // The previous note here justified the skip by saying dev-preflight-cli
+    // "spawns `pnpm` — absent on the CI e2e runner". That is no longer true:
+    // PR #1712 made the preflight resolve its package manager (pnpm, else
+    // `npm run lint`), and it exits 0 under a pnpm-free PATH. The obstacle the
+    // comment described is gone; the cost argument above is the reason that
+    // remains.
     globalSetup: ['tests/setup/ensure-registry-asset.globalSetup.ts'],
   },
 }));


### PR DESCRIPTION
## What Changed

**Comment-only.** `include`, `globalSetup`, `testTimeout` and `environment` in `vitest.e2e.config.ts` are byte-identical. No behaviour change.

The comment justified not compiling dist in the e2e config like this:

> A tsc/build globalSetup would wake dormant dist-gated tests (e.g. dev-preflight-cli, which spawns `pnpm` — absent on the CI e2e runner) that skip-by-design when dist is missing.

Neither half is true any more:

- **The pnpm obstacle is gone.** #1712 made `dev:preflight` resolve its package manager (pnpm, else `npm run lint`); it exits 0 under a pnpm-free PATH.
- **The tests are not dormant.** `vitest.config.ts` — what `npm test` and the CI unit shards run — includes `tests/e2e/**` *and* wires `build-dist.globalSetup` (added by #1709). All three dist-gated tests execute there. Verified by running `cli-unknown-command` under that config: 2 tests, **512ms and 387ms of real work**, not instant returns.

The comment now states the reason that actually remains — a build costs every e2e run a full `tsc` — and records that the coverage exists elsewhere, so skipping here is duplicate-coverage avoidance rather than tests going unrun.

## ELI16 — a note in the code that had quietly stopped being true

There are two ways this project runs its tests. One compiles the program first; the other deliberately doesn't, because compiling takes time and it wasn't needed there.

Next to that second setting sat a note explaining the decision: *don't add a compile step here, because it would wake up some sleeping tests — and one of them needs a tool the test machine doesn't have installed.*

That was a good reason. It just isn't true any more, in two separate ways. The missing tool was fixed earlier in this same working session, so that test now works on a machine without it. And the tests aren't sleeping: the other test setup does compile, does include them, and runs them for real — I ran one and watched it take about half a second per case rather than returning instantly.

So the note described a world that no longer exists. Anyone reading it while deciding whether to change that setting would have been talked out of it for reasons that had expired.

Nothing that runs changes here — this is a comment and only a comment. What changes is that the explanation now gives the reason that still applies instead of one that quietly lapsed.

That matters because it's a small version of what cost real time to find during this session: something describing the state of the world kept reporting confidently after the world moved. A stale note doesn't fail loudly; it just hands the next person a confident wrong answer.

## How this was found

Sweeping for **ACT-1514** (e2e tests passing by early return), now closed as converged:

- 60 raw `existsSync`-guard hits across `tests/`
- only **3** gate on a build artifact — the vacuous-in-CI shape (`dev-preflight-cli.test.ts:11`, `cli-unknown-command.test.ts:9,29`, all on `dist/cli.js`)
- the other 57 check files the test itself creates, or genuinely optional fixtures — not defects
- **all 3 already execute** in the unit shards, so #1709 itself closed that class

The residual was this stale note.

## Verification

- `tsc --noEmit` clean.
- `git diff` confirms only comment lines changed.
- Each claim in the new comment is checked rather than asserted: the pnpm-free run of the built CLI exits 0, and `cli-unknown-command` was executed under `vitest.config.ts` and observed to run rather than skip.

## Tier

Tier 1. Comment-only, zero executable delta, no runtime surface, route, persisted state, or migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDAgKAVJfGHgrFa7GJoSVn
