### PR TITLE
fix(autonomy): fail loud on unparseable run state

### DIFF
--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -55,6 +55,8 @@ for _arg in "$@"; do [[ "$_arg" == "--codex" ]] && IS_CODEX=1; done
 # the same trusted Stop boundary when an explicit bounded task ledger is live.
 # hook-capability: DECISION_QUALITY_REALCHECK — run_end_call carries the real-check
 # pass|fail|configured:false observation to the existing decision-quality annotator.
+# hook-capability: STATE_PARSE_LOUD — a selected state file with missing/malformed
+# frontmatter is a visible hook failure, distinct from the clean no-state exit.
 # emit — human-facing approve/status text. In codex mode the Stop hook's STDOUT must be
 # ONLY valid decision-JSON (the `{"decision":"block",...}` case far below) or empty:
 # codex rejects ANY other stdout as "invalid stop hook JSON output" and reports the stop
@@ -221,6 +223,22 @@ if [[ "$IS_CODEX" == "1" ]] && [[ "$CODEX_LOOP_ENABLED" != "1" ]]; then
 fi
 
 # ── Read the selected state file ──────────────────────────────────────
+# STATE_FILE was selected only after an existence check. From this point on,
+# "no parseable state" is corruption, NOT the same outcome as "no autonomous
+# job". The API reader accepts plain key lines anywhere in the document, while
+# this hook intentionally consumes fenced frontmatter. A missing/partial fence
+# must therefore fail visibly instead of turning an active run into exit 0.
+state_parse_failure() {
+  printf 'ERROR: Autonomous mode: autonomous state exists but its frontmatter is unparseable: %s (expected a fenced block with active: true|false)\n' "$STATE_FILE" >&2
+  exit 1
+}
+
+FM_DELIMITER_COUNT=$(awk '$0 == "---" { count++ } END { print count + 0 }' "$STATE_FILE" 2>/dev/null)
+FM_DELIMITER_COUNT="${FM_DELIMITER_COUNT:-0}"
+if [[ "$FM_DELIMITER_COUNT" -lt 2 ]]; then
+  state_parse_failure
+fi
+
 FRONTMATTER=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$STATE_FILE")
 fm_get() {
   local key="$1"
@@ -252,6 +270,9 @@ iso8601_epoch() {
 }
 
 ACTIVE=$(fm_get active)
+if [[ "$ACTIVE" != "true" ]] && [[ "$ACTIVE" != "false" ]]; then
+  state_parse_failure
+fi
 if [[ "$ACTIVE" != "true" ]]; then
   exit 0
 fi

--- a/.instar/instar-dev-decisions/2026-07-29T01-12-30-546Z-autonomous-state-parse-loud.json
+++ b/.instar/instar-dev-decisions/2026-07-29T01-12-30-546Z-autonomous-state-parse-loud.json
@@ -1,0 +1,17 @@
+{
+  "ts": "2026-07-29T01:12:30.546Z",
+  "slug": "autonomous-state-parse-loud",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 154,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/autonomous-state-parse-loud.eli16.md
+++ b/docs/eli16/autonomous-state-parse-loud.eli16.md
@@ -1,0 +1,38 @@
+# When an autonomous run file is broken, say so
+
+An autonomous run is kept alive by a stop hook. Before a session is allowed to
+end, that hook reads the run’s state file and checks whether the run is still
+active. The server also reads the same file to report which runs are active.
+
+Those two readers did not agree on the file format. The server accepted plain
+`key: value` lines anywhere in the file. The hook accepted those fields only
+inside a fenced frontmatter block. If a state file existed and said
+`active: true` but had lost its fences, the server reported a healthy active run
+while the hook found no active value and quietly returned success. That success
+allowed every turn to stop. From the outside the run looked alive, but the part
+that continued it had gone inert.
+
+The fix preserves the existing format contract rather than changing every
+reader. A genuinely absent state file still means there is no autonomous job,
+so the hook exits cleanly and says nothing. Once the hook has selected an
+existing state file, however, missing fences or a missing/invalid `active` field
+are corruption. The hook now writes a clear error naming the state file and
+returns a failure status. It can no longer translate “I found the file but
+cannot read its control field” into “there is no active run.”
+
+The behavior is pinned with an executable test over the real production hook.
+On the same fence-less file, the server-side reader still reports
+`active: true`; before the fix the hook returned exit 0 with empty output, and
+after the fix it returns nonzero with the visible corruption message. Separate
+cases prove that no file remains a silent exit 0 and a valid fenced
+`active: false` file remains a silent exit 0.
+
+Existing installations receive the corrected hook through a new capability
+marker in the update migrator. Anchor-compatible recent hooks are patched at
+three exact anchors, so unrelated custom lines survive. Older canonical hooks
+are replaced only when their complete bytes match an exact SHA-256 recorded
+from repository history. A hook matching neither proof is left untouched. The
+change does not repair, rewrite, delete, pause, or resume any autonomous state
+file, and it does not change the API’s status reader. Its job is narrower:
+corrupt state may still require an operator or writer to repair it, but it must
+no longer impersonate the healthy no-job case.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -78,6 +78,37 @@ import { ITERATIVE_CONVERGING_AUDIT_SKILL_CONTENT } from '../data/builtinSkillCo
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
+ * Exact SHA-256 identities of every canonical autonomous stop-hook revision in
+ * repository history through the predecessor of STATE_PARSE_LOUD. These are a
+ * conservative migration escape hatch for agents that skipped several releases:
+ * exact historical stock bytes may be replaced by the current bundle; any
+ * customization changes the hash and is refused. Keep this list append-only.
+ */
+export const AUTONOMOUS_STOP_HOOK_STOCK_SHA256 = [
+  'af4b8a3666d10f3ea0e351798b045e04b1386aaf53e98eb966e96fade9ef6cbb',
+  'b8fc09c2294a62d74d015094c4e0161418a972d468383ee58601fc4f918f7a0a',
+  'e8b1502ef4b2f18e1e96f04bed3cb8625aefa8c82e9c280832177cdbdb487217',
+  'ed5c1914a3af5993cef5d0cc5da9ec7fff912a7aba0d16066460e96f6193acbe',
+  '92873086e199954f572bbbc46b4d7d9e3f2673dc6a532af7731e56cbadddbe50',
+  'c8a437ab16400b1ad164fc84ec4baec253064fa8f130eacc796bfea260e724f2',
+  '4e95364a4bd00d714bd2fd39895b73664e466c41212c51b4ee462a35d400248a',
+  'fc7532480019bcf87009be9a3df75d3042e9f7ace248e1c2090f901c1db5e2a8',
+  '044e292b8c60b9231c9517c58d6daa99b267874b5f9e80a2ca0ab22497a3554c',
+  '33973ac0dfa974957d65670eb834471729fa3ebdefe04f544671614d3eabce23',
+  '398545c4d6065ac3ef8f85894505167260ea663e8f4fd285a36cce67c35f4f70',
+  '0ee8e791108c44061209ee497bbda385ee654372cbdd50233812770d3cce757d',
+  'b79ba23293be29eb9c12265f482e183f2e82613abf416da6f905a12ee3d99fef',
+  '9dd3fdcef05e1a3e0b33245c7c0cf2f23c8a02d60e595f4b3bc0d3dd3a3b0b0d',
+  '396eccaa3eb44f277f4e8a68a89a1632c00a6a215a7e655a43f7331b99dd025a',
+  '86848a69a2122a9148fbcd68de3327d868ec6d33b81bdad0f6ba08c628c2c7b6',
+  '108a840b315b1b35059e1155671724a16bd4ce3ada7c0f3ca1b95839996fb6a1',
+  'a5e8373c99be1e38b1237f8cbc7a3d492031424b09e2786bf1a72a1097252e8e',
+  '972574c945ee1d43335970fab4512269d3e5e9f9afe92a13f94c99ebffba7391',
+  'ee403db081bc96043556c767b697df47dec89e3e03fe3de359681fb1c1d9aff9',
+  'fbb68b9d14465315653ebe597ec0f62d0846afbc3f59364a0fcc6657eeeddee1',
+] as const;
+
+/**
  * The "Playwright Profile Registry" CLAUDE.md awareness section. SHARED by
  * `generateClaudeMd` (new installs) and `migrateClaudeMd` (existing agents) so the
  * two can never drift (Agent Awareness + Migration Parity). Uses the `${port}`
@@ -3926,13 +3957,112 @@ export class PostUpdateMigrator {
    * these through init — a dedicated migration is the only path (Migration Parity
    * Standard, "updating existing skill content").
    *
-   * Idempotent + conservative per file: re-copy the bundled file only when the
-   * installed copy (a) lacks the current capability MARKER AND (b) still matches
-   * the stock FINGERPRINT. A customized file is left untouched. The marker is the
-   * multi-session signature so v1.2.55 topic-keyed installs (which lack it) still
-   * receive this upgrade.
+   * Idempotent + conservative per file: setup/SKILL migrations retain their
+   * established marker + fingerprint replacement. The stop-hook's latest
+   * state-parse bump is narrower: it patches exact unique recent-version anchors
+   * in place, preserving unrelated/custom bytes. Older canonical stock revisions
+   * are recognized by exact SHA-256; all unknown layouts are refused.
    */
   private migrateAutonomousStopHookTopicKeyed(result: MigrationResult): void {
+    const upgradeAutonomousHookStateParse = (): void => {
+      const relPath = '.claude/skills/autonomous/hooks/autonomous-stop-hook.sh';
+      const label = 'skills/autonomous/hooks/autonomous-stop-hook.sh (visible corrupt-state refusal instead of silent no-state exit)';
+      try {
+        const deployed = path.join(this.config.projectDir, ...relPath.split('/'));
+        if (!fs.existsSync(deployed)) return; // installAutonomousSkill handles fresh installs
+        const current = fs.readFileSync(deployed, 'utf8');
+        if (current.includes('STATE_PARSE_LOUD')) return; // already current — idempotent
+
+        // This marker bump must not use the generic "contains a stock-looking
+        // header" whole-file replacement below. A customized derivative can
+        // retain that header, and replacing it would silently erase operator
+        // changes. Patch only three exact, unique prior-version anchors and
+        // preserve every unrelated byte. Unknown/ambiguous layouts are left
+        // untouched so a future migration can handle them deliberately.
+        const markerAnchor = `# hook-capability: DECISION_QUALITY_REALCHECK — run_end_call carries the real-check
+# pass|fail|configured:false observation to the existing decision-quality annotator.
+# emit —`;
+        const markerReplacement = `# hook-capability: DECISION_QUALITY_REALCHECK — run_end_call carries the real-check
+# pass|fail|configured:false observation to the existing decision-quality annotator.
+# hook-capability: STATE_PARSE_LOUD — a selected state file with missing/malformed
+# frontmatter is a visible hook failure, distinct from the clean no-state exit.
+# emit —`;
+        const frontmatterAnchor = `FRONTMATTER=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$STATE_FILE")`;
+        const frontmatterReplacement = `# STATE_PARSE_LOUD: STATE_FILE was selected only after an existence check.
+# From this point on, an unreadable control block is corruption, not "no job".
+state_parse_failure() {
+  printf 'ERROR: Autonomous mode: autonomous state exists but its frontmatter is unparseable: %s (expected a fenced block with active: true|false)\\n' "$STATE_FILE" >&2
+  exit 1
+}
+
+FM_DELIMITER_COUNT=$(awk '$0 == "---" { count++ } END { print count + 0 }' "$STATE_FILE" 2>/dev/null)
+FM_DELIMITER_COUNT="\${FM_DELIMITER_COUNT:-0}"
+if [[ "$FM_DELIMITER_COUNT" -lt 2 ]]; then
+  state_parse_failure
+fi
+
+${frontmatterAnchor}`;
+        const activeAnchor = `ACTIVE=$(fm_get active)
+if [[ "$ACTIVE" != "true" ]]; then`;
+        const activeReplacement = `ACTIVE=$(fm_get active)
+if [[ "$ACTIVE" != "true" ]] && [[ "$ACTIVE" != "false" ]]; then
+  state_parse_failure
+fi
+if [[ "$ACTIVE" != "true" ]]; then`;
+
+        const anchors = [
+          [markerAnchor, markerReplacement],
+          [frontmatterAnchor, frontmatterReplacement],
+          [activeAnchor, activeReplacement],
+        ] as const;
+        let next = current;
+        let anchorsMatched = true;
+        for (const [anchor, replacement] of anchors) {
+          const first = next.indexOf(anchor);
+          const last = next.lastIndexOf(anchor);
+          if (first < 0 || first !== last) {
+            anchorsMatched = false;
+            break;
+          }
+          next = `${next.slice(0, first)}${replacement}${next.slice(first + anchor.length)}`;
+        }
+
+        if (!anchorsMatched) {
+          const currentSha256 = crypto.createHash('sha256').update(current).digest('hex');
+          if (!(AUTONOMOUS_STOP_HOOK_STOCK_SHA256 as readonly string[]).includes(currentSha256)) {
+            result.skipped.push(`${relPath}: customized or unknown layout — left untouched (no exact stock hash or unique state-parse anchors)`);
+            return;
+          }
+          const bundled = path.join(__dirname, '..', '..', ...relPath.split('/'));
+          if (!fs.existsSync(bundled)) {
+            result.errors.push(`${relPath} migration: bundled hook is missing`);
+            return;
+          }
+          next = fs.readFileSync(bundled, 'utf8');
+          if (!next.includes('STATE_PARSE_LOUD')) {
+            result.errors.push(`${relPath} migration: bundled hook lacks STATE_PARSE_LOUD`);
+            return;
+          }
+        }
+
+        const tempPath = `${deployed}.state-parse.${process.pid}.${randomUUID()}.tmp`;
+        try {
+          fs.writeFileSync(tempPath, next, { mode: 0o755 });
+          fs.renameSync(tempPath, deployed);
+        } finally {
+          if (fs.existsSync(tempPath)) {
+            SafeFsExecutor.safeRmSync(tempPath, {
+              force: true,
+              operation: 'PostUpdateMigrator:migrateAutonomousStopHookTopicKeyed:temp-cleanup',
+            });
+          }
+        }
+        result.upgraded.push(label);
+      } catch (err) {
+        result.errors.push(`${relPath} migration: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    };
+
     const upgrade = (
       relPath: string, marker: string, fingerprint: string, label: string,
     ): void => {
@@ -4027,12 +4157,14 @@ export class PostUpdateMigrator {
     // Marker bumped `TASK_CONTINUATION` → `DECISION_QUALITY_REALCHECK`: the
     // terminal run-end payload now carries the already-observed real-check
     // disposition into the existing decision-quality annotation chokepoint.
-    upgrade(
-      '.claude/skills/autonomous/hooks/autonomous-stop-hook.sh',
-      'DECISION_QUALITY_REALCHECK',
-      'Autonomous Mode Stop Hook',
-      'skills/autonomous/hooks/autonomous-stop-hook.sh (decision-quality real-check outcome transport at run-end)',
-    );
+    // Marker bumped `DECISION_QUALITY_REALCHECK` → `STATE_PARSE_LOUD`: the hook
+    // now distinguishes a genuinely absent autonomous state file (clean allow)
+    // from a selected file whose fenced frontmatter cannot be parsed (visible
+    // failure). Unlike earlier cumulative hook migrations, this bump is surgical
+    // for anchor-compatible recent revisions so stock-derived customizations survive.
+    // Older canonical stock bytes use the exact historical SHA-256 allowlist;
+    // every unknown layout is refused rather than overwritten.
+    upgradeAutonomousHookStateParse();
     // setup-autonomous.sh marker bumped `native-goal/set` → `IS_CODEX_AGENT`: the bundled
     // setup now ALSO auto-delegates to native /goal for CODEX agents (the prior native /goal
     // wiring was gated on `claude --version >= 2.1.139`, which is empty for a codex agent, so

--- a/tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts
+++ b/tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts
@@ -1,3 +1,4 @@
+// safe-git-allow: reads two immutable historical hook blobs to prove exact-hash migration.
 /**
  * Verifies PostUpdateMigrator upgrades an already-deployed autonomous stop hook
  * to the topic-keyed version on update.
@@ -13,7 +14,11 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { execFileSync } from 'node:child_process';
+import {
+  AUTONOMOUS_STOP_HOOK_STOCK_SHA256,
+  PostUpdateMigrator,
+} from '../../src/core/PostUpdateMigrator.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
@@ -45,27 +50,12 @@ function deploySkill(projectDir: string, content: string): string {
   return dst;
 }
 
-// A representative OLD (session-UUID-keyed) hook: carries the stock fingerprint
-// but lacks the topic-session-registry marker.
-const OLD_HOOK = `#!/bin/bash
-
+// A stock-looking but unknown hook layout. The old migration treated the
+// human-readable header as proof this was stock and overwrote the whole file.
+// It is deliberately unsafe to do that: customized derivatives retain headers.
+const STOCK_HEADER_UNKNOWN_LAYOUT = `#!/bin/bash
 # Autonomous Mode Stop Hook
-# Prevents session exit when autonomous mode is active.
-
-STATE_FILE=".instar/autonomous-state.local.md"
-STATE_SESSION=$(echo "$FRONTMATTER" | grep '^session_id:')
-if [[ "$STATE_SESSION" != "$HOOK_SESSION" ]]; then
-  exit 0
-fi
-rm "$STATE_FILE"
-`;
-
-// A v1.2.55 topic-keyed hook: has topic-session-registry but NOT the
-// multi-session marker — must still be upgraded.
-const TOPIC_KEYED_V1255_HOOK = `#!/bin/bash
-# Autonomous Mode Stop Hook
-# TOPIC-KEYED OWNERSHIP ...
-REGISTRY_FILE=".instar/topic-session-registry.json"
+# operator customization: do not erase
 exit 0
 `;
 
@@ -120,6 +110,60 @@ function deployHook(projectDir: string, content: string): string {
   return dst;
 }
 
+function priorStateParseHook(): string {
+  const bundled = fs.readFileSync(
+    path.join(process.cwd(), '.claude', 'skills', 'autonomous', 'hooks', 'autonomous-stop-hook.sh'),
+    'utf8',
+  );
+  return bundled
+    .replace(
+      `# hook-capability: STATE_PARSE_LOUD — a selected state file with missing/malformed
+# frontmatter is a visible hook failure, distinct from the clean no-state exit.
+`,
+      '',
+    )
+    .replace(
+      `# STATE_FILE was selected only after an existence check. From this point on,
+# "no parseable state" is corruption, NOT the same outcome as "no autonomous
+# job". The API reader accepts plain key lines anywhere in the document, while
+# this hook intentionally consumes fenced frontmatter. A missing/partial fence
+# must therefore fail visibly instead of turning an active run into exit 0.
+state_parse_failure() {
+  printf 'ERROR: Autonomous mode: autonomous state exists but its frontmatter is unparseable: %s (expected a fenced block with active: true|false)\\n' "$STATE_FILE" >&2
+  exit 1
+}
+
+FM_DELIMITER_COUNT=$(awk '$0 == "---" { count++ } END { print count + 0 }' "$STATE_FILE" 2>/dev/null)
+FM_DELIMITER_COUNT="\${FM_DELIMITER_COUNT:-0}"
+if [[ "$FM_DELIMITER_COUNT" -lt 2 ]]; then
+  state_parse_failure
+fi
+
+`,
+      '',
+    )
+    .replace(
+      `if [[ "$ACTIVE" != "true" ]] && [[ "$ACTIVE" != "false" ]]; then
+  state_parse_failure
+fi
+`,
+      '',
+    );
+}
+
+const HISTORICAL_STOCK_HOOKS = [
+  {
+    label: 'original session-keyed stock hook',
+    commit: 'f74b8086f6bb88b1b2aaa2c17d0ca39f70423fca',
+    sha256: 'fbb68b9d14465315653ebe597ec0f62d0846afbc3f59364a0fcc6657eeeddee1',
+  },
+  {
+    label: 'topic-keyed v1.2.55-era stock hook',
+    commit: 'c7f95344e7d7a43104cc2a37a0ab92bbd97eb78e',
+    sha256: '972574c945ee1d43335970fab4512269d3e5e9f9afe92a13f94c99ebffba7391',
+  },
+] as const;
+
 describe('PostUpdateMigrator — autonomous stop hook topic-keying', () => {
   let projectDir: string;
 
@@ -135,22 +179,23 @@ describe('PostUpdateMigrator — autonomous stop hook topic-keying', () => {
     });
   });
 
-  it('upgrades an old session-keyed hook to the topic-keyed version', () => {
-    const dst = deployHook(projectDir, OLD_HOOK);
-    expect(fs.readFileSync(dst, 'utf8')).not.toContain('topic-session-registry');
+  it('surgically upgrades the immediately prior stock hook to visible state-parse failure', () => {
+    const dst = deployHook(projectDir, priorStateParseHook());
+    expect(fs.readFileSync(dst, 'utf8')).not.toContain('STATE_PARSE_LOUD');
 
     const result = runMigration(newMigrator(projectDir));
 
     const updated = fs.readFileSync(dst, 'utf8');
-    expect(updated).toContain('topic-session-registry'); // now topic-keyed
-    expect(updated).toContain('TOPIC-KEYED OWNERSHIP');
+    expect(updated).toContain('STATE_PARSE_LOUD');
+    expect(updated).toContain('state_parse_failure');
+    expect(updated).toContain('FM_DELIMITER_COUNT');
     expect((fs.statSync(dst).mode & 0o111)).not.toBe(0); // executable
     expect(result.upgraded.some(u => u.includes('autonomous-stop-hook.sh'))).toBe(true);
     expect(result.errors).toEqual([]);
   });
 
   it('is idempotent — a second run makes no change and reports nothing', () => {
-    deployHook(projectDir, OLD_HOOK);
+    deployHook(projectDir, priorStateParseHook());
     runMigration(newMigrator(projectDir)); // first run upgrades
 
     const dst = path.join(projectDir, HOOK_REL);
@@ -162,7 +207,7 @@ describe('PostUpdateMigrator — autonomous stop hook topic-keying', () => {
     expect(second.errors).toEqual([]);
   });
 
-  it('leaves a customized hook untouched (no stock fingerprint)', () => {
+  it('leaves a customized hook untouched when the exact patch anchors are absent', () => {
     const custom = '#!/bin/bash\n# My heavily customized hook\nexit 0\n';
     const dst = deployHook(projectDir, custom);
 
@@ -173,22 +218,60 @@ describe('PostUpdateMigrator — autonomous stop hook topic-keying', () => {
     expect(result.errors).toEqual([]);
   });
 
+  it('refuses a customized hook that retains the stock header but lacks exact patch anchors', () => {
+    const dst = deployHook(projectDir, STOCK_HEADER_UNKNOWN_LAYOUT);
+
+    const result = runMigration(newMigrator(projectDir));
+
+    expect(fs.readFileSync(dst, 'utf8')).toBe(STOCK_HEADER_UNKNOWN_LAYOUT);
+    expect(result.skipped.some(s => s.includes('unknown layout'))).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('preserves stock-derived customization while surgically adding the validator', () => {
+    const customLine = '# operator customization: retain this exact line';
+    const priorCustomized = priorStateParseHook().replace(
+      'set -uo pipefail',
+      `${customLine}\nset -uo pipefail`,
+    );
+    const dst = deployHook(projectDir, priorCustomized);
+
+    const result = runMigration(newMigrator(projectDir));
+    const updated = fs.readFileSync(dst, 'utf8');
+
+    expect(updated).toContain(customLine);
+    expect(updated).toContain('STATE_PARSE_LOUD');
+    expect(updated).toContain('state_parse_failure');
+    expect(result.upgraded.some(u => u.includes('autonomous-stop-hook.sh'))).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  for (const historical of HISTORICAL_STOCK_HOOKS) {
+    it(`upgrades the exact ${historical.label} by canonical content hash`, () => {
+      expect(AUTONOMOUS_STOP_HOOK_STOCK_SHA256).toContain(historical.sha256);
+      const oldStock = execFileSync(
+        'git',
+        ['show', `${historical.commit}:.claude/skills/autonomous/hooks/autonomous-stop-hook.sh`],
+        { cwd: process.cwd(), encoding: 'utf8' },
+      );
+      const dst = deployHook(projectDir, oldStock);
+
+      const result = runMigration(newMigrator(projectDir));
+      const updated = fs.readFileSync(dst, 'utf8');
+
+      expect(updated).toContain('STATE_PARSE_LOUD');
+      expect(updated).toContain('state_parse_failure');
+      expect(updated).toContain('MULTI-SESSION (per-topic state)');
+      expect(() => execFileSync('bash', ['-n', dst])).not.toThrow();
+      expect(result.upgraded.some(u => u.includes('autonomous-stop-hook.sh'))).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+  }
+
   it('is a no-op when no hook is deployed (fresh installs handled by init)', () => {
     const result = runMigration(newMigrator(projectDir));
     expect(fs.existsSync(path.join(projectDir, HOOK_REL))).toBe(false);
     expect(result.upgraded).toEqual([]);
-    expect(result.errors).toEqual([]);
-  });
-
-  it('upgrades a v1.2.55 topic-keyed hook to multi-session (per-topic state)', () => {
-    const dst = deployHook(projectDir, TOPIC_KEYED_V1255_HOOK);
-    expect(fs.readFileSync(dst, 'utf8')).not.toContain('MULTI-SESSION (per-topic state)');
-
-    const result = runMigration(newMigrator(projectDir));
-
-    const updated = fs.readFileSync(dst, 'utf8');
-    expect(updated).toContain('MULTI-SESSION (per-topic state)'); // now multi-session
-    expect(result.upgraded.some(u => u.includes('autonomous-stop-hook.sh'))).toBe(true);
     expect(result.errors).toEqual([]);
   });
 

--- a/tests/unit/autonomous-stop-hook-idle-backoff.test.ts
+++ b/tests/unit/autonomous-stop-hook-idle-backoff.test.ts
@@ -262,20 +262,33 @@ describe('IDLE_BACKOFF — safety properties (static)', () => {
 });
 
 describe('IDLE_BACKOFF — existing agents receive the paced hook (migration)', () => {
-  it('upgrades a RESTART_NOTE_SILENT-era stock hook so it gains IDLE_BACKOFF', () => {
+  it('preserves IDLE_BACKOFF while surgically upgrading the immediately prior stock hook', () => {
     const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'backoff-mig-'));
     try {
       fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
       const dst = path.join(projectDir, HOOK_REL);
       fs.mkdirSync(path.dirname(dst), { recursive: true });
-      // Prior-era stock hook: carries the fingerprint + the previous marker, lacks IDLE_BACKOFF.
-      fs.writeFileSync(dst, [
-        '#!/bin/bash',
-        '# Autonomous Mode Stop Hook',
-        '# RESTART_NOTE_SILENT — self-lifecycle narration is housekeeping; default-silent.',
-        'exit 0',
-        '',
-      ].join('\n'));
+      const prior = fs.readFileSync(HOOK_PATH, 'utf8')
+        .replace(
+          `# hook-capability: STATE_PARSE_LOUD — a selected state file with missing/malformed
+# frontmatter is a visible hook failure, distinct from the clean no-state exit.
+`,
+          '',
+        )
+        .replace(
+          /# STATE_FILE was selected only after an existence check\.[\s\S]*?if \[\[ "\$FM_DELIMITER_COUNT" -lt 2 \]\]; then\n  state_parse_failure\nfi\n\n/,
+          '',
+        )
+        .replace(
+          `if [[ "$ACTIVE" != "true" ]] && [[ "$ACTIVE" != "false" ]]; then
+  state_parse_failure
+fi
+`,
+          '',
+        );
+      fs.writeFileSync(dst, prior);
+      expect(prior).toContain('IDLE_BACKOFF');
+      expect(prior).not.toContain('STATE_PARSE_LOUD');
 
       const migrator = new PostUpdateMigrator({
         projectDir, stateDir: path.join(projectDir, '.instar'), port: 4042, hasTelegram: false, projectName: 'test',
@@ -286,7 +299,8 @@ describe('IDLE_BACKOFF — existing agents receive the paced hook (migration)', 
 
       const upgraded = fs.readFileSync(dst, 'utf8');
       expect(upgraded).toContain('IDLE_BACKOFF');
-      expect(upgraded).toContain('RESTART_NOTE_SILENT'); // prior capability not lost
+      expect(upgraded).toContain('RESTART_NOTE_SILENT'); // older capability not lost
+      expect(upgraded).toContain('STATE_PARSE_LOUD');
       expect(result.errors).toEqual([]);
     } finally {
       fs.rmSync(projectDir, { recursive: true, force: true });

--- a/tests/unit/autonomous-stop-hook-notify.test.ts
+++ b/tests/unit/autonomous-stop-hook-notify.test.ts
@@ -143,16 +143,27 @@ describe('Layer A — notify_terminal_stop functional delivery (real extracted f
 describe('Layer A — existing agents receive the notify-enabled hook (migration)', () => {
   let projectDir: string;
 
-  // Old stock hook: carries the fingerprint, lacks the notify_terminal_stop marker.
-  const OLD_HOOK = [
-    '#!/bin/bash',
-    '# Autonomous Mode Stop Hook',
-    '# TOPIC-KEYED OWNERSHIP + MULTI-SESSION (per-topic state)',
-    '# Native /goal delegation',
-    'REGISTRY_FILE=".instar/topic-session-registry.json"',
-    'exit 0',
-    '',
-  ].join('\n');
+  // Immediately-prior stock hook: it already carries terminal notification,
+  // but lacks the STATE_PARSE_LOUD additions. The current migration patches
+  // this exact structure in place rather than replacing a stock-looking file.
+  const priorStateParseHook = (): string => fs.readFileSync(HOOK_PATH, 'utf8')
+    .replace(
+      `# hook-capability: STATE_PARSE_LOUD — a selected state file with missing/malformed
+# frontmatter is a visible hook failure, distinct from the clean no-state exit.
+`,
+      '',
+    )
+    .replace(
+      /# STATE_FILE was selected only after an existence check\.[\s\S]*?if \[\[ "\$FM_DELIMITER_COUNT" -lt 2 \]\]; then\n  state_parse_failure\nfi\n\n/,
+      '',
+    )
+    .replace(
+      `if [[ "$ACTIVE" != "true" ]] && [[ "$ACTIVE" != "false" ]]; then
+  state_parse_failure
+fi
+`,
+      '',
+    );
 
   beforeEach(() => {
     projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notify-stop-mig-'));
@@ -163,11 +174,12 @@ describe('Layer A — existing agents receive the notify-enabled hook (migration
     rmrf(projectDir);
   });
 
-  it('upgrades a pre-notify stock hook so it gains notify_terminal_stop', () => {
+  it('keeps notify_terminal_stop while surgically upgrading the prior stock hook', () => {
     const dst = path.join(projectDir, HOOK_REL);
     fs.mkdirSync(path.dirname(dst), { recursive: true });
-    fs.writeFileSync(dst, OLD_HOOK);
-    expect(fs.readFileSync(dst, 'utf8')).not.toContain('notify_terminal_stop');
+    fs.writeFileSync(dst, priorStateParseHook());
+    expect(fs.readFileSync(dst, 'utf8')).toContain('notify_terminal_stop');
+    expect(fs.readFileSync(dst, 'utf8')).not.toContain('STATE_PARSE_LOUD');
 
     const migrator = new PostUpdateMigrator({
       projectDir, stateDir: path.join(projectDir, '.instar'), port: 4042, hasTelegram: false, projectName: 'test',
@@ -177,6 +189,7 @@ describe('Layer A — existing agents receive the notify-enabled hook (migration
       .migrateAutonomousStopHookTopicKeyed(result);
 
     expect(fs.readFileSync(dst, 'utf8')).toContain('notify_terminal_stop');
+    expect(fs.readFileSync(dst, 'utf8')).toContain('STATE_PARSE_LOUD');
     expect(result.errors).toEqual([]);
   });
 
@@ -198,7 +211,8 @@ describe('Layer A — existing agents receive the notify-enabled hook (migration
     // The bundled hook still contains
     // notify_terminal_stop — asserted above — so that capability is not lost on upgrade.
     const src = fs.readFileSync(path.join(REPO_ROOT, 'src', 'core', 'PostUpdateMigrator.ts'), 'utf8');
-    expect(src).toMatch(/upgrade\(\s*'\.claude\/skills\/autonomous\/hooks\/autonomous-stop-hook\.sh',\s*'DECISION_QUALITY_REALCHECK'/);
+    expect(src).toContain("current.includes('STATE_PARSE_LOUD')");
+    expect(src).toContain('upgradeAutonomousHookStateParse();');
   });
 
   it('restart-resume note is SILENT to the user — audit + stderr only (RESTART_NOTE_SILENT)', () => {

--- a/tests/unit/autonomous-stop-hook-state-parse.test.ts
+++ b/tests/unit/autonomous-stop-hook-state-parse.test.ts
@@ -1,0 +1,144 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes only its mkdtempSync directory.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { listAutonomousJobs } from '../../src/core/AutonomousSessions.js';
+
+const HOOK_PATH = path.join(
+  process.cwd(),
+  '.claude',
+  'skills',
+  'autonomous',
+  'hooks',
+  'autonomous-stop-hook.sh',
+);
+
+let homeDir: string;
+
+function writeRegistry(): void {
+  fs.writeFileSync(
+    path.join(homeDir, '.instar', 'topic-session-registry.json'),
+    JSON.stringify({ topicToSession: { '458': 'echo-parse-test' } }),
+  );
+}
+
+function writeTopicState(content: string): void {
+  const dir = path.join(homeDir, '.instar', 'autonomous');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, '458.local.md'), content);
+}
+
+function runHook(codex = false): { exitCode: number; stdout: string; stderr: string } {
+  const result = spawnSync('bash', codex ? [HOOK_PATH, '--codex'] : [HOOK_PATH], {
+    cwd: homeDir,
+    input: JSON.stringify({ session_id: 'parse-test-session', transcript_path: '' }),
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: homeDir,
+      INSTAR_HOOK_TMUX_SESSION: 'echo-parse-test',
+      INSTAR_HOOK_BACKOFF_DISABLE: '1',
+    },
+    encoding: 'utf8',
+  });
+  return {
+    exitCode: result.status ?? 1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+beforeEach(() => {
+  homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-hook-state-parse-'));
+  fs.mkdirSync(path.join(homeDir, '.instar'), { recursive: true });
+  writeRegistry();
+});
+
+afterEach(() => {
+  fs.rmSync(homeDir, { recursive: true, force: true });
+});
+
+describe('autonomous stop hook state parsing', () => {
+  it('allows a genuinely absent autonomous state file without noise', () => {
+    const result = runHook();
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+  });
+
+  it('fails visibly when the selected state file exists but has no frontmatter fences', () => {
+    writeTopicState(`active: true
+iteration: 1
+session_id: "parse-test-session"
+report_topic: "458"
+duration_seconds: 79200
+started_at: "2026-07-28T00:00:00Z"
+
+Keep working.
+`);
+
+    const statusReader = listAutonomousJobs(path.join(homeDir, '.instar'));
+    expect(statusReader).toHaveLength(1);
+    expect(statusReader[0]).toMatchObject({ topic: '458', active: true });
+
+    const result = runHook();
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toMatch(/autonomous state exists but its frontmatter is unparseable/i);
+    expect(result.stderr).toMatch(/458\.local\.md/);
+  });
+
+  it('fails visibly when a fenced state omits the required active field', () => {
+    writeTopicState(`---
+iteration: 1
+session_id: "parse-test-session"
+report_topic: "458"
+---
+
+Keep working.
+`);
+
+    const result = runHook();
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toMatch(/autonomous state exists but its frontmatter is unparseable/i);
+  });
+
+  it('keeps Codex stdout protocol-clean while failing visibly on the same corrupt state', () => {
+    fs.writeFileSync(
+      path.join(homeDir, '.instar', 'config.json'),
+      JSON.stringify({ autonomousSessions: { codexLoopDriver: { enabled: true } } }),
+    );
+    writeTopicState(`active: true
+report_topic: "458"
+`);
+
+    const result = runHook(true);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toMatch(/autonomous state exists but its frontmatter is unparseable/i);
+  });
+
+  it('keeps a valid fenced inactive state as a clean allow', () => {
+    writeTopicState(`---
+active: false
+iteration: 1
+session_id: "parse-test-session"
+report_topic: "458"
+---
+
+Stopped.
+`);
+
+    const result = runHook();
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+  });
+});

--- a/upgrades/next/autonomous-state-parse-loud.md
+++ b/upgrades/next/autonomous-state-parse-loud.md
@@ -1,0 +1,57 @@
+# Upgrade Guide — vNEXT
+
+## What Changed
+
+The autonomous stop hook used a fenced-frontmatter parser while the server
+status reader accepted plain multiline fields. If a selected run-state file
+existed without `---` fences, the server could report `active: true` while the
+hook read an empty `active` value and silently exited 0 on every turn.
+
+The hook now separates three outcomes:
+
+- no state file: clean exit 0, unchanged;
+- valid fenced state with `active: false`: clean exit 0, unchanged;
+- selected state whose fences or required `active: true|false` field cannot be
+  parsed: a visible error and nonzero exit.
+
+The update migrator’s capability marker is bumped. Anchor-compatible recent
+hooks are patched at exact unique anchors, so unrelated customizations survive.
+Older canonical stock revisions are replaced only on an exact historical
+SHA-256 match. Unknown layouts are left untouched.
+
+## What to Tell Your User
+
+If an autonomous run’s state file becomes malformed, the agent now reports the
+corruption instead of quietly appearing to have no active run. No action is
+needed for valid existing runs.
+
+## Summary of New Capabilities
+
+- Autonomous status and continuation can no longer disagree silently when a
+  selected state file has lost its frontmatter fences.
+- Missing autonomous state remains normal and silent.
+- Existing stock installations receive the corrected hook during update.
+
+## Evidence
+
+- Refusal-first proof on the same fence-less active file: before, exit 0 with
+  empty stdout/stderr; after, exit 1 with an explicit unparseable-state error.
+- The test also proves the server-side reader reports that exact fence-less file
+  as `active: true`, reproducing the live split rather than testing a surrogate.
+- Absent-file and valid-inactive controls remain clean exit 0.
+- The complete autonomous stop-hook and migration unit surface passes: 154 tests across 13
+  files. The focused post-change test adds five passing behavioral cases,
+  including Codex stdout-protocol cleanliness on the corrupt-state failure.
+- Migration tests prove that a stock-derived customization survives the patch
+  and that a stock-looking customized hook with an unknown layout is refused
+  without modification.
+- Exact historical-stock tests prove both the original session-keyed hook and
+  the topic-keyed v1.2.55-era hook still receive the current valid shell hook.
+- Shell syntax validation and TypeScript typechecking pass.
+
+## Known Limits
+
+This change does not rewrite malformed state and does not make both readers
+share one parser. It makes the disagreement observable at the continuation
+chokepoint. An unknown customized hook layout is intentionally not modified by
+migration and therefore requires deliberate reconciliation.

--- a/upgrades/side-effects/autonomous-state-parse-loud.md
+++ b/upgrades/side-effects/autonomous-state-parse-loud.md
@@ -1,0 +1,226 @@
+# Side-Effects Review — Visible autonomous-state parse failure
+
+**Version / slug:** `autonomous-state-parse-loud`
+**Date:** `2026-07-28`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `Euler (independent Codex second pass)`
+
+## Summary of the change
+
+The bundled autonomous stop hook now distinguishes an absent state file from a
+selected state file whose fenced frontmatter cannot supply the required
+`active: true|false` control field. Absence remains a silent exit 0; corrupt
+selected state emits a specific error to stderr and exits nonzero. The
+PostUpdateMigrator capability marker is bumped with an exact-anchor in-place
+patch for anchor-compatible recent revisions and exact historical stock hashes
+for older canonical revisions. Behavioral tests execute the real hook while
+also checking the server-side reader on the same fence-less input.
+
+## Decision-point inventory
+
+- `.claude/skills/autonomous/hooks/autonomous-stop-hook.sh` state admission —
+  **modified** — after a file is selected, invalid control frontmatter changes
+  from permissive clean exit to visible structural failure.
+- Codex dark-launch gate — **pass-through** — it still runs before state parsing;
+  a disabled hook remains a no-op.
+- Existing `active: true|false` decision — **pass-through** — valid true and
+  false values retain their prior behavior.
+- `PostUpdateMigrator` hook deployment — **modified** — a new capability marker
+  patches three exact unique prior-version anchors in place. Older canonical
+  revisions are replaceable only by exact SHA-256 identity. Unrelated custom
+  bytes survive; unknown or ambiguous layouts are left untouched.
+
+---
+
+## 1. Over-block
+
+The new structural refusal rejects a selected fenced file that omits `active`,
+uses a value other than the writer contract’s literal `true` or `false`, or has
+fewer than two exact `---` delimiter lines. A hand-authored file using YAML
+synonyms such as `yes` would now fail visibly even though a general YAML parser
+might accept it. That is intentional: neither existing reader treats `yes` as
+active, and allowing it would recreate an ambiguous clean-exit state.
+
+Valid `active: false` files and the genuinely absent-file case are separately
+test-pinned as clean exit 0, so the refusal does not absorb the normal no-job
+surface.
+
+---
+
+## 2. Under-block
+
+The hook still uses its established line-oriented parser rather than a full YAML
+parser. A file with two delimiter lines and a literal `active: true|false` can
+pass this structural gate even if optional fields are malformed. Existing
+downstream validation and conservative defaults continue to own those fields.
+
+This change also does not make the server and shell share a parser. It closes
+the dangerous equivalence between “file absent” and “selected file cannot
+supply its required control field”; broader parser unification is not required
+to make this failure observable.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The check sits immediately after the hook has selected an existing state file
+and before the `active` allow/block decision. That is the narrowest layer with
+all required facts: selection already proved the file exists, and the hook owns
+the fenced-frontmatter contract it is about to consume. Moving the check to the
+server reader would leave the hook’s silent exit intact; moving it into every
+writer would not cover partial edits or corruption.
+
+This is a deterministic structural validator over an enumerable contract, not
+a semantic detector or a competing-signals judgment.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context
+  (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP. Reshape the design.
+
+None of the generic boxes exactly names this allowed exception. The change does
+hold failure authority, but only for the hard-invariant case explicitly exempted
+by `docs/signal-vs-authority.md`: after an existing file is selected, its
+control block must be fenced and `active` must be one of two enumerable literal
+values. No message meaning, intent, confidence score, or conversational context
+is evaluated. The same bytes always produce the same result and the error states
+which structural contract failed.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No static heuristic is added at a competing-signals decision point. File
+existence, delimiter count, and the two allowed `active` literals are an
+enumerable state-format invariant. Liveness, ownership, urgency, work evidence,
+and completion judgment remain with their existing downstream authorities.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the parse check runs after topic/legacy state selection and the
+  Codex feature gate, but before all state-derived lifecycle checks. It shadows
+  those checks only when their required control document is corrupt; running
+  them with fabricated empty values was the defect.
+- **Double-fire:** one hook invocation emits at most one parse error and exits.
+  It does not call Telegram, Attention, recovery audit, or run-end notification
+  paths.
+- **Races:** if the state file disappears between selection and read, the same
+  visible failure occurs. That is conservative and observable; the ordinary
+  no-state path still applies when removal wins before selection.
+- **Feedback loops:** no state is written and no retry is scheduled. The change
+  cannot repair or re-trigger itself.
+- **Migration:** the capability marker upgrade patches only three exact unique
+  anchors on compatible recent revisions and preserves every unrelated byte.
+  Older canonical stock revisions are recognized by a repository-history
+  SHA-256 allowlist and receive the bundled hook through a same-directory atomic
+  rename. A stock-derived customized hook is test-pinned to retain its custom
+  line; a stock-looking hook whose layout lacks both proofs is test-pinned to
+  remain byte-identical and report a skipped migration. Exact historical tests
+  cover the original session-keyed and topic-keyed v1.2.55-era hooks and run
+  `bash -n` on the deployed result.
+
+---
+
+## 6. External surfaces
+
+Other agents receive a visible hook failure instead of silence if their selected
+autonomous state is malformed. Valid runs and ordinary non-autonomous sessions
+have no output change. The error goes to stderr so Codex stdout remains empty or
+valid decision JSON, preserving its stop-hook protocol.
+
+No external API, Telegram/Slack message, dashboard surface, URL, database, or
+durable state shape changes. The hook does not mutate the malformed file.
+
+No operator-facing action is added; repair remains through existing state
+writers or operator controls.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design.** Each autonomous worker consumes the state file for
+the topic/session it owns on that machine. The structural parse result must
+therefore reflect the local file bytes; there is no meaningful merged verdict
+to replicate. The behavior itself ships to every stock installation through the
+normal update migrator.
+
+The change emits no user-facing notices, holds no new runtime state, and
+generates no URLs. Topic transfer remains governed by the existing autonomous
+state movement/ownership paths; this check neither copies nor deletes state.
+The class-closure process has one durable local action because the nearest
+defect class is still operator-unconfirmed; that action changes no run state.
+
+---
+
+## 8. Rollback cost
+
+Rollback is code-only and requires no data migration or state repair. Revert the
+validator and ship a patch. Because existing installs may already carry the new
+capability marker, an intentional rollback release must use a newer marker to
+re-deploy or patch the reverted behavior; simply restoring the old marker would
+not move already-updated installs backward. Unknown layouts remain unaffected
+in either direction.
+
+---
+
+## Conclusion
+
+The change is bounded to the structural ambiguity that caused the live failure:
+absent and unparseable are no longer byte-identical outcomes. The review added
+an explicit migration marker bump and kept Codex protocol output on stderr.
+Valid success/allow paths, state ownership, notification behavior, and state
+mutation are unchanged. The implementation is ready for independent second-pass
+re-review after resolving the reviewer’s two initial blockers.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `Euler`
+**Independent read of the artifact:** Initial review found two blocking issues:
+the generic header fingerprint could overwrite a customized stock-derived hook,
+and the proposed defect class was unconfirmed. The first re-review confirmed
+both corrections, then found one migration-parity regression: old canonical
+stock layouts were being skipped. Final re-review approved the exact historical
+SHA-256 fallback and restored session-keyed/v1.2.55 proofs. The reviewer also
+exhaustively migrated all 21 canonical revisions, ran `bash -n` on every result,
+and verified customized derivatives were preserved or refused safely.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/autonomous-stop-hook-state-parse.test.ts`
+- `tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts`
+- `tests/unit/autonomous-stop-hook-notify.test.ts`
+- `.claude/skills/autonomous/hooks/autonomous-stop-hook.sh`
+- `src/core/PostUpdateMigrator.ts`
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+- **`defectClass`** — `unknown-classification-fail-open`
+- **`closure`** — `gap`
+- **`guardEvidence`** — not applicable while the class remains unconfirmed
+- **`gap`** — `ACT-108` — operator confirmation is required before
+  `unknown-classification-fail-open` can supply class-level closure. The
+  instance-level regression test already prevents this exact hook defect from
+  returning.


### PR DESCRIPTION
## ELI16 — When a run file is broken, say so

An autonomous run stays alive because a stop hook reads its run file before allowing the session to end. Previously, if that file still said `active: true` but had lost its frontmatter fences, the status API said the run was active while the hook quietly behaved as if no run existed. The hook now treats a found-but-unreadable control block as a visible error. A genuinely absent file and a valid inactive run remain normal, silent exits.

## Outcome

A selected autonomous state file can no longer be mistaken for an absent job when its fenced control block is unparseable. The hook now emits a specific stderr error and exits nonzero; absent state and valid `active: false` remain clean exit 0.

## Failure-first proof

On the untouched base, the real hook received a fence-less file containing `active: true`, returned exit 0, and emitted no stdout or stderr. The server reader classified that same file as active. After this change, the same input returns exit 1 with the explicit unparseable-frontmatter error while keeping Codex stdout empty.

## Migration safety

- Anchor-compatible recent hooks are patched surgically at three unique anchors, preserving unrelated custom bytes.
- Older canonical stock hooks are recognized only by exact SHA-256 identities from repository history.
- Unknown or customized layouts are left byte-identical and reported skipped.
- Deployment uses a same-directory temporary file and atomic rename.
- Independent review exhaustively migrated all 21 canonical historical revisions and ran `bash -n` on every result.

## Verification

- 154 tests across the 13-file stop-hook and migration surface
- 30 focused parser/migration/notification tests
- TypeScript typecheck
- build
- lint
- shell syntax
- diff check

## Scope

Observability only. No state repair, deletion, pause/resume, notification change, API reader change, or new controller. The nearest defect class remains operator-unconfirmed, so class closure is recorded honestly as a tracked gap rather than claiming a class-level guard.