### PR TITLE
fix(metrics): report empty rate denominators as unavailable

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T08-36-35-686Z-honest-empty-denominator-rates.json
+++ b/.instar/instar-dev-decisions/2026-07-29T08-36-35-686Z-honest-empty-denominator-rates.json
@@ -1,0 +1,14 @@
+{
+  "ts": "2026-07-29T08:36:35.686Z",
+  "slug": "honest-empty-denominator-rates",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 18,
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/reflect.ts
+++ b/src/commands/reflect.ts
@@ -208,7 +208,9 @@ function printPatternReport(report: PatternReport, showProposals?: boolean): voi
   const parts: string[] = [
     `${report.summary.uniqueSteps} unique steps`,
     `${report.summary.definedSteps} defined`,
-    `${Math.round(report.summary.successRate * 100)}% success`,
+    report.summary.successRate != null
+      ? `${Math.round(report.summary.successRate * 100)}% success`
+      : 'success unavailable',
   ];
   if (report.summary.avgDurationMinutes != null) {
     parts.push(`avg ${report.summary.avgDurationMinutes}min`);

--- a/src/core/DispatchDecisionJournal.ts
+++ b/src/core/DispatchDecisionJournal.ts
@@ -27,8 +27,8 @@ export interface DispatchDecisionStats {
   byDispatchType: Record<string, number>;
   /** Breakdown by evaluation method */
   byEvaluationMethod: Record<string, number>;
-  /** Acceptance rate (accept / total) */
-  acceptanceRate: number;
+  /** Acceptance rate (accept / total), or null when there are no decisions */
+  acceptanceRate: number | null;
   /** ISO timestamp of earliest entry */
   earliest: string | null;
   /** ISO timestamp of latest entry */
@@ -152,7 +152,7 @@ export class DispatchDecisionJournal {
         byDecision: {},
         byDispatchType: {},
         byEvaluationMethod: {},
-        acceptanceRate: 0,
+        acceptanceRate: null,
         earliest: null,
         latest: null,
       };
@@ -177,7 +177,7 @@ export class DispatchDecisionJournal {
       byDecision,
       byDispatchType,
       byEvaluationMethod,
-      acceptanceRate: entries.length > 0 ? acceptCount / entries.length : 0,
+      acceptanceRate: acceptCount / entries.length,
       earliest: sorted[0].timestamp,
       latest: sorted[sorted.length - 1].timestamp,
     };

--- a/src/core/PatternAnalyzer.ts
+++ b/src/core/PatternAnalyzer.ts
@@ -71,8 +71,8 @@ export interface PatternReport {
     avgDurationMinutes: number | null;
     /** Duration trend: 'increasing', 'decreasing', 'stable', 'insufficient-data' */
     durationTrend: 'increasing' | 'decreasing' | 'stable' | 'insufficient-data';
-    /** Overall success rate */
-    successRate: number;
+    /** Overall success rate, or null when there are no runs */
+    successRate: number | null;
   };
   /** ISO timestamp when this analysis was generated */
   analyzedAt: string;
@@ -198,7 +198,7 @@ export class PatternAnalyzer {
         durationTrend: this.computeDurationTrend(records),
         successRate: totalRuns > 0
           ? Math.round((records.filter(r => r.outcome === 'success').length / totalRuns) * 100) / 100
-          : 0,
+          : null,
       },
       analyzedAt: new Date().toISOString(),
     };

--- a/tests/unit/DispatchDecisionJournal.test.ts
+++ b/tests/unit/DispatchDecisionJournal.test.ts
@@ -371,13 +371,13 @@ describe('DispatchDecisionJournal', () => {
   // ── stats() ───────────────────────────────────────────────────────
 
   describe('stats()', () => {
-    it('returns zero stats for empty journal', () => {
+    it('returns null acceptance rate for empty journal', () => {
       const stats = journal.stats();
       expect(stats.total).toBe(0);
       expect(stats.byDecision).toEqual({});
       expect(stats.byDispatchType).toEqual({});
       expect(stats.byEvaluationMethod).toEqual({});
-      expect(stats.acceptanceRate).toBe(0);
+      expect(stats.acceptanceRate).toBeNull();
       expect(stats.earliest).toBeNull();
       expect(stats.latest).toBeNull();
     });

--- a/tests/unit/PatternAnalyzer.test.ts
+++ b/tests/unit/PatternAnalyzer.test.ts
@@ -79,7 +79,7 @@ describe('PatternAnalyzer', () => {
       expect(report.runsAnalyzed).toBe(0);
       expect(report.patterns).toEqual([]);
       expect(report.summary.uniqueSteps).toBe(0);
-      expect(report.summary.successRate).toBe(0);
+      expect(report.summary.successRate).toBeNull();
       expect(report.summary.durationTrend).toBe('insufficient-data');
     });
 

--- a/upgrades/honest-empty-denominator-rates.eli16.md
+++ b/upgrades/honest-empty-denominator-rates.eli16.md
@@ -1,0 +1,25 @@
+# Honest rates when there is nothing to measure
+
+Two internal reports were displaying `0%` when they had no observations at all.
+One summarizes how often dispatch decisions are accepted. The other summarizes
+how often recorded job runs succeed. In both cases, an empty history was being
+turned into the number zero.
+
+Zero is a real measurement: it says observations existed and none succeeded.
+An empty history is different. It means the system has no denominator and
+cannot calculate a rate yet. Treating those states as identical makes a new or
+unused component look confidently unsuccessful, just as treating an empty
+history as 100% would make it look confidently perfect.
+
+The reports now return `null` for those two rates when the corresponding count
+is zero. As soon as at least one decision or run exists, their calculations are
+unchanged. Existing non-empty values still range from zero to one.
+
+The command-line pattern summary also understands the nullable shape. It never
+performs arithmetic on an unavailable rate and labels that state as unavailable
+if it reaches the formatter. The ordinary no-records path still gives its
+existing plain-language message.
+
+Focused tests cover both empty histories and the existing non-empty
+calculations. This is a reporting correction only: it changes no dispatch
+decision, job outcome, scheduling behavior, stored record, or blocking gate.

--- a/upgrades/next/honest-empty-denominator-rates.md
+++ b/upgrades/next/honest-empty-denominator-rates.md
@@ -1,0 +1,21 @@
+# Empty aggregate histories no longer report a fabricated zero percent
+
+## What Changed
+
+Dispatch acceptance and job-pattern success reports now return an unavailable
+value when no decisions or runs exist, instead of reporting a measured zero.
+
+## Evidence
+
+- Focused unit tests cover both empty histories and non-empty calculations.
+- The repository typecheck confirms every arithmetic reader handles the
+  nullable contract.
+
+## What to Tell Your User
+
+Internal reliability summaries now distinguish “nothing measured yet” from a
+real zero-percent result.
+
+## Summary of New Capabilities
+
+- Honest empty-denominator handling for the final two ACT-1243 rate producers.

--- a/upgrades/side-effects/honest-empty-denominator-rates.md
+++ b/upgrades/side-effects/honest-empty-denominator-rates.md
@@ -1,0 +1,78 @@
+# Side-Effects Review — honest empty-denominator rates
+
+**Version / slug:** `honest-empty-denominator-rates`
+**Date:** 2026-07-29
+**Author:** Instar Agent (instar-codey)
+
+## Summary
+
+`DispatchDecisionJournal.stats()` and `PatternAnalyzer.analyze()` now return
+`null`, rather than a fabricated `0`, when their acceptance-rate or
+success-rate denominator is empty. Non-empty calculations are unchanged. The
+pattern-report formatter branches on the nullable value before doing
+arithmetic.
+
+## Decision-point inventory
+
+No decision point changes. These fields are read-only aggregate signals. They
+do not gate dispatch, scheduling, proposal generation, or any action. The
+change makes the signals distinguish “measured zero” from “not assessable.”
+
+## 1. Over-block
+
+No blocking authority is added or modified. The only compatibility cost is
+that readers typed against a guaranteed number must handle `null`; the
+repository typecheck identifies such readers, and the sole arithmetic caller
+now branches explicitly.
+
+## 2. Under-block
+
+This correction is deliberately bounded to the two remaining sites identified
+by the ACT-1243 audit. It does not claim that every rate in the system shares
+the same denominator semantics. Both targeted producers now represent empty
+evidence honestly, and focused tests pin that behavior. Re-injecting the old
+zero fallback made both assertions fail before the correct implementation was
+restored.
+
+## 3. Level-of-abstraction fit
+
+The producers own denominator knowledge, so they emit `null` at the source.
+Fixing only a formatter would leave API and programmatic consumers exposed to
+the fabricated value. The formatter change is a consumer adaptation, not a
+second interpretation layer.
+
+## 4. Signal vs authority compliance
+
+Compliant with `docs/signal-vs-authority.md`. These are observational signals
+with no blocking authority. The change removes an invented verdict from
+missing evidence and preserves all actual measurements.
+
+## 5. Interactions
+
+The dispatch stats object is exported publicly and serialized by existing
+callers without arithmetic. The pattern report feeds reflection and
+integration analysis; proposal generation depends on detected patterns, not
+the summary rate. The CLI is the only arithmetic reader and handles `null`
+explicitly.
+
+## 6. External surfaces
+
+Consumers may now see JSON `null` instead of `0` for an empty dispatch or job
+history. That is the intended contract correction. Histories with one or more
+records produce byte-equivalent numeric values.
+
+## 7. Multi-machine posture
+
+Machine-local by design. Each rate summarizes the journal read by that
+machine. No new state, replication path, URL, message, or one-voice concern is
+introduced.
+
+## 8. Rollback cost
+
+A direct revert restores the former numeric-only types and fabricated zeros.
+There is no data migration or state repair because no stored record changes.
+
+## Conclusion
+
+The change makes two aggregate signals honest at the empty-denominator
+boundary without altering authority or non-empty behavior.


### PR DESCRIPTION
## ELI16 — a rate over nothing is not a rate, so we now say "unavailable" instead of "0%"

Two internal health numbers used to answer `0` when there was nothing to measure — no dispatch
decisions recorded yet, or no job runs yet. A reader could not tell "we measured, and it really is
zero" apart from "we had nothing to divide by." Zero looks like a real, confident answer, so the
second case quietly read as bad news that had never actually been observed.

Now both report nothing at all when there is nothing to divide by, and the one place that printed
the number to a human says "success unavailable" rather than "0% success." No behaviour changes;
only the honesty of two figures and one line of output.

## What changed

- `DispatchDecisionJournal.stats()` now returns `acceptanceRate: null` when there are no dispatch decisions.
- `PatternAnalyzer.analyze()` now returns `successRate: null` when there are no runs.
- The pattern-summary formatter branches on the nullable rate before doing arithmetic.
- Non-empty calculations are unchanged.

## Why

These were the final two ACT-1243 producers that turned a missing denominator into a numeric `0`. That value reads as a measured zero-percent result even though no observation exists. The producer types now carry the honest unavailable state instead.

## Impact

This changes only read-only aggregate reporting. It does not alter dispatch decisions, scheduling, stored records, proposal generation, or any gate. API/programmatic consumers may now see JSON `null` for an empty history; histories with at least one observation retain the same numeric values.

## Validation

- 81 focused unit/integration tests pass.
- Full repository lint passes.
- TypeScript typecheck passes.
- Re-injecting the old zero fallbacks made both new empty-history assertions fail; restoring the fix made them pass.
- Pre-push affected set passed: 41 files / 450 tests.