### PR TITLE
fix(dev): retain decision audit scope evidence

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T08-42-42-978Z-decision-audit-scope.json
+++ b/.instar/instar-dev-decisions/2026-07-29T08-42-42-978Z-decision-audit-scope.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-29T08:42:42.978Z",
+  "slug": "decision-audit-scope",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 15,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/instar-dev-precommit.js"
+    ],
+    "addedLines": 12,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/scripts/instar-dev-precommit.js
+++ b/scripts/instar-dev-precommit.js
@@ -251,14 +251,14 @@ if (bootstrapTrigger) {
 
 let tierSignal = { suggestedTier: 2, sizeTier: 2, riskFloor: 1, reasons: [] };
 let totalChangedLoc = 0;
+let addedLines = 0;
+let deletedLines = 0;
 // Hoisted to module scope (docs/specs/self-action-convergence.md → E3 impl
 // note): addedDiffText is computed in the Step-3.5 block but consumed later by
 // assertSelfActionDeclared at BOTH the enforceTier1 and Tier-2 pass-through call
 // sites. It must outlive the block.
 let addedDiffText = '';
 {
-  let addedLines = 0;
-  let deletedLines = 0;
   try {
     const numstat = execSync(
       `git diff --cached --numstat -- ${inScopeFiles.map((f) => JSON.stringify(f)).join(' ')}`,
@@ -440,6 +440,9 @@ const decisionEntryPath = writeDecisionAudit({
   belowFloor,
   files: inScopeFiles.length,
   loc: totalChangedLoc,
+  scopeFiles: inScopeFiles,
+  addedLines,
+  deletedLines,
   causalAutopsy,
   classClosure: (freshestTrace && typeof freshestTrace.classClosure === 'object' && freshestTrace.classClosure) || null,
 });
@@ -1350,7 +1353,7 @@ function blockCommit(files, reason) {
 // fire, the line just evaporated with the worktree). If the commit is later
 // blocked by the gate, the staged line simply rides the retry commit — both
 // lines describe real gate evaluations.
-function writeDecisionAudit({ slug, suggestedTier, declaredTier, riskFloor, riskFloorReasons, belowFloor, files, loc, causalAutopsy = null, classClosure = null }) {
+function writeDecisionAudit({ slug, suggestedTier, declaredTier, riskFloor, riskFloorReasons, belowFloor, files, loc, scopeFiles, addedLines, deletedLines, causalAutopsy = null, classClosure = null }) {
   try {
     fs.mkdirSync(DECISIONS_DIR, { recursive: true });
     const ts = new Date().toISOString();
@@ -1376,6 +1379,12 @@ function writeDecisionAudit({ slug, suggestedTier, declaredTier, riskFloor, risk
       belowFloor,
       files,
       loc,
+      scope: {
+        basis: 'staged-in-scope-additions-plus-deletions',
+        files: scopeFiles,
+        addedLines,
+        deletedLines,
+      },
       // Causal autopsy (directive 2026-06-05): what caused the issue this
       // commit fixes — prior-pr / environment-shift / new-code / latent /
       // unknown, with linked PRs. null = not declared (advisory in slice 1).

--- a/tests/unit/instar-dev-precommit-audit-staging.test.ts
+++ b/tests/unit/instar-dev-precommit-audit-staging.test.ts
@@ -245,6 +245,12 @@ describe('instar-dev pre-commit — decision-audit line rides the commit (self-s
     );
     expect(entry.verdict).toBe('pass');
     expect(entry.slug).toBe('pass-fixture');
+    expect(entry.scope).toEqual({
+      basis: 'staged-in-scope-additions-plus-deletions',
+      files: [srcRel],
+      addedLines: 1,
+      deletedLines: 0,
+    });
   });
 
   it('binds the decision audit to the newest trace that covers the staged change', async () => {

--- a/upgrades/decision-audit-scope.eli16.md
+++ b/upgrades/decision-audit-scope.eli16.md
@@ -1,0 +1,23 @@
+# Decision records now explain what their counters measured
+
+The development commit gate already records two compact numbers for each
+reviewed source change: how many source files were in scope and how many lines
+changed. Those numbers are useful, but the record did not retain the concrete
+file list or say whether the line count represented additions, deletions, or a
+different basis. A later reader could see “three files, eighteen lines” without
+being able to tell which files produced that result.
+
+The gate now stores an additional `scope` object beside the existing counters.
+It names the counting basis, lists the exact staged source files included, and
+records added and deleted lines separately. The old `files` and `loc` fields
+remain unchanged, so existing readers continue to work.
+
+The new values come from the same staged-diff calculation the gate already
+uses for tier signaling. There is no second calculation that can disagree with
+the original counters. If that existing calculation cannot run, the gate keeps
+its current fail-open behavior and records the same zero counts explicitly.
+
+This changes evidence only. It does not change which files require review,
+which tier is suggested, which trace is selected, or whether a commit passes.
+A focused integration test runs the real hook in a temporary repository and
+asserts the emitted record’s basis, file list, additions, and deletions.

--- a/upgrades/next/decision-audit-scope.md
+++ b/upgrades/next/decision-audit-scope.md
@@ -1,0 +1,22 @@
+# Development decision records now explain their scope
+
+## What Changed
+
+Development decision records now retain the exact staged source files and
+added/deleted-line counts behind their compact file and line totals.
+
+## Evidence
+
+- The focused hook integration test verifies the persisted counting basis,
+  file list, additions, and deletions.
+- Existing compact `files` and `loc` fields remain unchanged for compatible
+  readers.
+
+## What to Tell Your User
+
+Internal development audit records now explain exactly what their size
+counters measured.
+
+## Summary of New Capabilities
+
+- Self-describing scope evidence for development decisions.

--- a/upgrades/side-effects/decision-audit-scope.md
+++ b/upgrades/side-effects/decision-audit-scope.md
@@ -1,0 +1,73 @@
+# Side-Effects Review — development decision audit scope
+
+**Version / slug:** `decision-audit-scope`
+**Date:** 2026-07-29
+**Author:** Instar Agent (instar-codey)
+
+## Summary
+
+The development pre-commit gate now persists the exact in-scope staged file
+list, added-line count, deleted-line count, and named counting basis beside
+each decision record’s existing compact `files` and `loc` counters.
+
+## Decision-point inventory
+
+This changes evidence emitted by an existing gate, not its authority. Tier
+classification, trace selection, refusal conditions, and verdict finalization
+remain unchanged.
+
+## 1. Over-block
+
+No new refusal is introduced. Audit writing remains best-effort and fail-open,
+as before. The additive fields cannot prevent a commit.
+
+## 2. Under-block
+
+The record still reflects only files covered by the gate’s existing `inScope`
+predicate, not every file in the pull request. That boundary is now explicit
+in the `staged-in-scope-additions-plus-deletions` basis and concrete file list,
+rather than hidden behind a compact count. Removing the emitted object made the
+focused assertion fail before the implementation was restored, proving the
+test does not merely restate its own derivation.
+
+## 3. Level-of-abstraction fit
+
+The audit writer is the correct owner because it already receives the tier
+signal and writes the durable decision record. The added values reuse the
+same staged `numstat` calculation rather than asking downstream consumers to
+reconstruct a vanished diff.
+
+## 4. Signal vs authority compliance
+
+Compliant with `docs/signal-vs-authority.md`. The scope fields are evidence
+only. They add no detector, filter, or blocking authority and do not alter the
+gate’s verdict.
+
+## 5. Interactions
+
+Existing consumers retain the unchanged `files` and `loc` fields. New
+consumers can inspect `scope`. The values are captured before any gate exit and
+therefore accompany both passing and blocked decision records through the
+existing verdict-finalization path.
+
+## 6. External surfaces
+
+Internal decision JSON gains one additive object. No runtime API, user-facing
+message, configuration, credential, or operator action changes.
+
+## 7. Multi-machine posture
+
+Repository-replicated evidence. Decision records already ride the commit as
+distinct files, so the new fields follow the same Git replication path and do
+not introduce machine-local state or cross-machine authority.
+
+## 8. Rollback cost
+
+A direct revert removes the additive fields. Records already written with
+`scope` remain readable by older consumers because they ignore unknown keys.
+No migration or state repair is required.
+
+## Conclusion
+
+The change makes existing gate evidence interpretable without changing what
+the gate decides.


### PR DESCRIPTION
## What changed

- Persist a `scope` object beside each development decision record’s existing `files` and `loc` counters.
- Name the counting basis as `staged-in-scope-additions-plus-deletions`.
- Retain the exact in-scope staged file list plus separate added/deleted counts.
- Keep the existing compact fields and every gate verdict unchanged.

## Why

This is the one live functional gap remaining from #1510. The original trace-identity fix and legacy artifact fallback already landed independently in #1522, so replaying the stale branch would duplicate that work and reintroduce hundreds of commits of conflict surface. Current main still discarded the concrete inputs behind each compact audit counter, making later records impossible to interpret precisely.

This fresh main-based change carries only that missing evidence contract. It supersedes #1510.

## Impact

Additive internal JSON evidence only. No tier classification, trace selection, block/allow decision, runtime API, configuration, or stored application state changes. Older readers continue using `files` and `loc` unchanged.

## Validation

- Focused hook integration suite: 11/11 passing.
- Full repository lint and TypeScript typecheck pass.
- Pre-push affected set: 1 file / 11 tests passing.
- Removing the emitted `scope` object made the focused assertion fail before the implementation was restored.

## ELI16 — the audit recorded the number but not what it counted

Every time a change is committed to Instar, the agent making it declares how risky it thinks the
change is, and a record is written down so that judgement can be reviewed later. Part of that record
is a size measurement — how many lines were added and removed.

The problem was that the record kept the *answer* without keeping the *question*. It stored a number
of lines, but not which files those lines were in, nor what rule decided a file counted as "in scope"
in the first place. So a reviewer reading the record months later could see "42 lines changed" and had
no way to check whether that 42 was measured over the right set of files. If the scoping rule ever
changed, every older record would silently mean something different from what it appeared to mean,
with nothing in the record to reveal that.

This change stores the basis alongside the number: which files were counted, how many lines were added
and deleted, and a named label for the counting rule itself. The number now travels with a statement
of what it is a number *of*.

Nothing about the commit process changes for anyone using it — no new checks, no new refusals. The
audit records written from now on simply carry enough context to be re-checked rather than merely
believed. A test pins the exact shape of that record, so a future change to the scoping rule has to
update the record's stated basis too, instead of quietly leaving it describing the old rule.

*(ELI16 section added by Echo on the author's behalf to clear the eli16 CI gate. The repo PR template
does not prompt for this section — Codey's #1726 fixes that.)*
