### PR TITLE
Prompt PR authors for the sections CI requires

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,12 @@
 
 What does this PR do? Why is it needed?
 
+<!-- Gate: write at least 200 characters of plain-English explanation for a non-expert; comments do not count. -->
+## ELI16
+
+<!-- Gate for user-facing paths: name who sees the change, describe the user-visible first contact, and quote an exact string from the diff. -->
+## UX Impact
+
 ## Type of Change
 
 - [ ] Bug fix (non-breaking change that fixes an issue)

--- a/tests/unit/pull-request-template-gates.test.ts
+++ b/tests/unit/pull-request-template-gates.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+// Import the real authority so a changed gate contract breaks this test instead of letting a copied regex drift.
 import { checkPrDescriptionEli16 } from '../../scripts/eli16-pr-description-check.mjs';
 
 const templatePath = path.resolve(process.cwd(), '.github/PULL_REQUEST_TEMPLATE.md');

--- a/tests/unit/pull-request-template-gates.test.ts
+++ b/tests/unit/pull-request-template-gates.test.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { checkPrDescriptionEli16 } from '../../scripts/eli16-pr-description-check.mjs';
+
+const templatePath = path.resolve(process.cwd(), '.github/PULL_REQUEST_TEMPLATE.md');
+
+describe('pull request template gate prompts', () => {
+  const template = fs.readFileSync(templatePath, 'utf8');
+
+  it('prompts for the required ELI16 section and its minimum content', () => {
+    expect(template).toMatch(/^## ELI16\s*$/m);
+    expect(template).toMatch(/at least 200 characters/i);
+    expect(template).toMatch(/plain-English explanation for a non-expert/i);
+    expect(checkPrDescriptionEli16({ body: template })).toMatchObject({
+      ok: false,
+      reason: 'eli16-too-short',
+    });
+  });
+
+  it('prompts for the required UX declaration and every gated detail', () => {
+    expect(template).toMatch(/^## UX Impact\s*$/m);
+    expect(template).toMatch(/who sees the change/i);
+    expect(template).toMatch(/user-visible first contact/i);
+    expect(template).toMatch(/quote an exact string from the diff/i);
+  });
+});


### PR DESCRIPTION
## ELI16

The repository checks every pull-request description for two pieces of
information that its own template never requested. Authors who followed the
template exactly still failed the plain-English explanation check, and changes
to user-facing paths also failed the user-impact check. This updates the
template so the required headings and their real acceptance rules are visible
before a PR is opened. The prompts are HTML comments, so they guide the author
without becoming fake content that satisfies either gate.

## Description

Add the two required description sections to the pull-request template:

- ELI16, with the 200-character plain-English minimum.
- UX Impact, with the audience, visible first-contact behavior, and exact
  diff-string requirements.

A regression test pins both headings and every required hint. It also runs the
real ELI16 checker against the untouched template and proves the comment remains
non-counting guidance rather than passing content.

## UX Impact

**Who sees this:** every contributor or agent opening a pull request from the
repository template.

**What the user sees:** the editor now includes `"## ELI16"` and
`"## UX Impact"` before the existing type/checklist sections, with one-line
instructions for satisfying each gate.

**First contact:** the requirements appear while the author is writing the
description, before CI has to reject the PR. Existing pull requests are
unchanged.

## Validation

- 12 focused template and ELI16-gate tests pass.
- Full repository lint passes.
- Final TypeScript typecheck passes.
- Diff validation passes.
