### PR TITLE
Keep detector miss rate unknown before sampling

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T11-00-35-253Z-human-detector-empty-denominator.json
+++ b/.instar/instar-dev-decisions/2026-07-29T11-00-35-253Z-human-detector-empty-denominator.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-29T11:00:35.253Z",
+  "slug": "human-detector-empty-denominator",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 4,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/monitoring/HumanAsDetectorLog.ts"
+    ],
+    "addedLines": 2,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/HumanAsDetectorLog.ts
+++ b/src/monitoring/HumanAsDetectorLog.ts
@@ -285,11 +285,11 @@ export class HumanAsDetectorLog {
   }
 
   /** Drift-canary counters (sampled / mismatches / miss-rate). Read-only. */
-  getDriftCanary(): { sampled: number; mismatches: number; missRate: number } {
+  getDriftCanary(): { sampled: number; mismatches: number; missRate: number | null } {
     return {
       sampled: this.driftSampled,
       mismatches: this.driftMismatches,
-      missRate: this.driftSampled > 0 ? this.driftMismatches / this.driftSampled : 0,
+      missRate: this.driftSampled > 0 ? this.driftMismatches / this.driftSampled : null,
     };
   }
 

--- a/tests/unit/HumanAsDetectorLog-correction-learning.test.ts
+++ b/tests/unit/HumanAsDetectorLog-correction-learning.test.ts
@@ -128,8 +128,12 @@ describe('HumanAsDetectorLog — correction-learning Layer-0 extension', () => {
       expect(c.missRate).toBeCloseTo(1 / 3, 5);
     });
 
-    it('miss-rate is 0 with no samples', () => {
-      expect(log.getDriftCanary().missRate).toBe(0);
+    it('reports an unknown miss-rate rather than perfect recall with no samples', () => {
+      const canary = log.getDriftCanary();
+
+      expect(canary.sampled).toBe(0);
+      expect(canary.mismatches).toBe(0);
+      expect(canary.missRate).toBeNull();
     });
   });
 });

--- a/upgrades/eli16/human-detector-empty-denominator.md
+++ b/upgrades/eli16/human-detector-empty-denominator.md
@@ -1,0 +1,26 @@
+# Detector miss rate stays unknown until it has evidence
+
+The human-as-detector system has a small drift canary. It samples messages that
+the cheap first-pass rules did not classify and checks whether a more capable
+classifier recognizes a correction that those rules missed. Its summary
+contains three values: how many messages were sampled, how many were later
+judged to be misses, and the resulting miss rate.
+
+Before this change, a fresh process had zero samples and zero misses, but the
+summary still reported a numeric miss rate of zero. That number reads as
+perfect reliability: the detector appears to have missed zero percent of the
+messages it examined. In reality, it had examined nothing, so there was no
+evidence about its reliability at all.
+
+The correction keeps the two counts at zero and changes only the derived rate
+to `null` until at least one sample exists. Once samples exist, the calculation
+is unchanged. For example, one mismatch across three samples still reports a
+miss rate of one third, and a measured run with samples but no mismatches still
+reports a genuine numeric zero.
+
+This is an observability correction, not a new gate. It does not block
+messages, alter classification, change sampling, write persistent state, or
+trigger any action. It only prevents an empty denominator from being rendered
+as flattering evidence. The test deliberately begins with a fresh instance,
+asserts that its sample denominator is zero, and requires the rate to be
+unknown; that prevents a future fallback to a fabricated perfect score.

--- a/upgrades/next/human-detector-empty-denominator.md
+++ b/upgrades/next/human-detector-empty-denominator.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The human-as-detector drift canary now reports a null miss rate before it has
+sampled any messages, instead of presenting an unmeasured detector as having a
+perfect zero-percent miss rate. Sample and mismatch counts remain alongside the
+nullable rate.
+
+## What to Tell Your User
+
+Detector health no longer looks perfect before the detector has measured
+anything; an unmeasured miss rate is now shown as unknown.
+
+## Summary of New Capabilities
+
+- Honest empty-denominator reporting for the human-as-detector drift canary.
+
+## Evidence
+
+- The focused unit test enters the fresh-process state and requires zero samples
+  plus a null miss rate.
+- A measured one-in-three mismatch rate remains numeric.
+- The repository lint and TypeScript checks pass.

--- a/upgrades/side-effects/human-detector-empty-denominator.md
+++ b/upgrades/side-effects/human-detector-empty-denominator.md
@@ -1,0 +1,106 @@
+# Side-Effects Review — Human-detector empty denominator
+
+**Version / slug:** `human-detector-empty-denominator`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`HumanAsDetectorLog.getDriftCanary()` now returns `missRate: null` when
+`sampled` is zero. Its sample and mismatch counters are unchanged, and measured
+rates retain their existing calculation. The focused unit test pins both the
+fresh-process unknown state and the measured one-in-three state.
+
+## Decision-point inventory
+
+No decision point is added or modified. This is a read-only observability value;
+it neither classifies messages nor controls any action.
+
+## 1. Over-block
+
+No block/allow surface — over-block is not applicable.
+
+## 2. Under-block
+
+This bounded correction covers only the drift canary's miss-rate denominator.
+Other derived-rate sites are being evaluated separately so each defect has an
+isolated review and rollback surface. A consumer that ignores `sampled` and
+cannot represent `null` must update its display rather than coercing unknown
+back to zero; no repository consumer currently does so.
+
+## 3. Level-of-abstraction fit
+
+The correction belongs at the rate producer. Every caller then receives the
+same honest distinction between no evidence and measured zero, while the
+existing adjacent `sampled` field remains the denominator. Fixing a display
+would leave other consumers exposed.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The canary is an observability signal. Changing its empty value does not give it
+authority or change how any message is handled.
+
+## 4b. Judgment-point check
+
+No static heuristic or competing-signals judgment point is added. A zero
+denominator is structurally unmeasurable.
+
+## 5. Interactions
+
+- **Shadowing:** no parallel rate producer or display is bypassed.
+- **Double-fire:** no action fires from this return value.
+- **Races:** the existing in-memory counters and update order are unchanged.
+- **Feedback loops:** the value is read-only and is not fed back into sampling
+  or classification.
+
+## 6. External surfaces
+
+Code importing the public method now sees `number | null` rather than a numeric
+zero before the first sample. There are no current repository consumers beyond
+the unit tests. No external service, message, persistent record, timer, or
+operator action changes.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Machine-local by design.** The canary measures samples observed by one running
+process and stores only in-memory counters. This change adds no notices, durable
+state, topic-bound data, or URLs, so it cannot strand data or duplicate
+delivery across machines.
+
+## 8. Rollback cost
+
+Pure code rollback: restore the numeric fallback and the previous return type.
+No data migration or agent-state repair is required.
+
+## Conclusion
+
+Clear to ship as a small corrective PR. The producer now states that no sample
+means no measurement, while measured zero remains available after real samples.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; the change is a read-only
+metric correction and does not touch a gate, sentinel, watchdog, messaging, or
+session-lifecycle authority.
+
+## Evidence pointers
+
+- `tests/unit/HumanAsDetectorLog-correction-learning.test.ts`
+- 11 focused tests pass.
+- Mutation proof: restoring the numeric-zero fallback makes the fresh-process
+  assertion fail with `expected 0 to be null`; restoring the correction passes.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

A fresh human-as-detector drift canary had zero samples but reported a numeric zero miss rate, making no evidence look like perfect reliability. This changes the empty rate to null while retaining sampled and mismatch counts, and keeps measured rates unchanged.

## Validation

- 11 focused unit tests pass
- Full repository lint and TypeScript checks pass
- Mutation proof: restoring the zero fallback fails the fresh-process assertion
- The candidate sweep falls from 57 hits on current main to 56

## ELI16

The detector has a drift canary that counts how many messages it sampled and how many corrections it missed. Before this change, a brand-new process had sampled nothing but still reported a zero-percent miss rate. That reads as perfect reliability even though there was no evidence. The rate is now null until the first real sample. Once samples exist, a measured zero stays zero and one miss across three samples still reports one third. This changes only an observability value: it does not block messages, alter classification, persist data, or trigger any action. The regression begins with a truly fresh instance, asserts that its denominator is zero, and requires an unknown rate; restoring the old fallback makes that test fail.

## UX Impact

Who sees it: agents or operators reading detector health. What the user sees at first contact: an unmeasured "missRate" is null beside zero samples instead of a flattering zero. This makes the user-visible health statement internally consistent; measured values are unchanged.