### PR TITLE
Fall back when macOS memory output is unparseable

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T11-07-16-863Z-host-memory-unparseable-fallback.json
+++ b/.instar/instar-dev-decisions/2026-07-29T11-07-16-863Z-host-memory-unparseable-fallback.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-29T11:07:16.863Z",
+  "slug": "host-memory-unparseable-fallback",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 5,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/monitoring/hostMemoryPressure.ts"
+    ],
+    "addedLines": 4,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/hostMemoryPressure.ts
+++ b/src/monitoring/hostMemoryPressure.ts
@@ -52,11 +52,14 @@ export function parseVmStat(output: string): SystemMemoryReading {
   const purgeablePages = parsePages('Pages purgeable');
 
   const totalPages = freePages + activePages + inactivePages + wiredPages + compressorPages;
+  if (totalPages === 0) {
+    throw new Error('vm_stat output contained no total memory pages');
+  }
   const totalGB = (totalPages * pageSize) / (1024 ** 3);
   const availablePages = freePages + inactivePages + purgeablePages;
   const freeGB = (availablePages * pageSize) / (1024 ** 3);
   const usedPages = totalPages - availablePages;
-  const pressurePercent = totalPages > 0 ? (usedPages / totalPages) * 100 : 0;
+  const pressurePercent = (usedPages / totalPages) * 100;
   return { pressurePercent, freeGB, totalGB };
 }
 

--- a/tests/unit/host-memory-pressure.test.ts
+++ b/tests/unit/host-memory-pressure.test.ts
@@ -43,9 +43,10 @@ Pages occupied by compressor:            500000.
     const freePct = 100 - parseVmStat(critical).pressurePercent;
     expect(freePct).toBeLessThan(5); // genuinely critical → low available
   });
-  it('empty/garbage output does not throw and yields a finite reading', () => {
-    const r = parseVmStat('');
-    expect(Number.isFinite(r.pressurePercent)).toBe(true);
+  it('empty/garbage output is rejected as unparseable', () => {
+    expect(() => parseVmStat('vm_stat returned an unexpected format')).toThrow(
+      'vm_stat output contained no total memory pages',
+    );
   });
 });
 
@@ -89,6 +90,18 @@ describe('readSystemMemoryPressure — platform-aware, never throws', () => {
     });
     expect(Number.isFinite(r.pressurePercent)).toBe(true);
     expect(r.pressurePercent).toBeCloseTo(25, 0); // 4GB rss / 16GB
+  });
+  it('darwin: successful but unparseable vm_stat output uses the RSS fallback', () => {
+    const r = readSystemMemoryPressure({
+      platform: 'darwin',
+      vmStat: () => 'vm_stat returned an unexpected format',
+      memoryUsage: () => ({ rss: 15 * 1024 ** 3 }),
+      totalmem: () => 16 * 1024 ** 3,
+    });
+
+    expect(r.pressurePercent).toBeCloseTo(93.75, 2);
+    expect(r.freeGB).toBeCloseTo(1, 2);
+    expect(r.totalGB).toBe(16);
   });
   it('an unknown platform uses the fallback', () => {
     const r = readSystemMemoryPressure({ platform: 'sunos', memoryUsage: () => ({ rss: 2 * 1024 ** 3 }), totalmem: () => 8 * 1024 ** 3 });

--- a/upgrades/eli16/host-memory-unparseable-fallback.md
+++ b/upgrades/eli16/host-memory-unparseable-fallback.md
@@ -1,0 +1,27 @@
+# Malformed memory output no longer looks like a healthy machine
+
+Instar measures memory pressure differently on macOS because the ordinary
+free-memory number does not include memory the operating system can reclaim.
+It runs the native `vm_stat` command, reads several page counters, and combines
+them into total and available memory.
+
+The reader already handled a command that throws or cannot run: it logs the
+failure and falls back to a rough estimate based on the Instar process memory
+and the machine total. But there was a second failure shape. The command could
+succeed and return non-empty text that contained none of the expected page
+counters. Every missing counter became zero, the total denominator became zero,
+and the code returned zero-percent pressure. The machine then looked perfectly
+healthy even though nothing had been measured.
+
+The parser now rejects output whose total page count is zero. That rejection is
+caught by the existing read-failure handler, so it uses the same logged RSS
+fallback the original author already built. The throw path, fallback formula,
+logging, thresholds, and real valid parser behavior are unchanged.
+
+The regression deliberately supplies a non-empty string so it cannot pass
+through the existing empty-output branch. With a simulated machine using
+fifteen of sixteen gigabytes, malformed native output must produce the fallback
+reading of 93.75-percent pressure, one gigabyte free, and sixteen gigabytes
+total. Restoring the old parser makes that test report zero and fail. This keeps
+unknown input from becoming a flattering health measurement without inventing
+a new pressure policy.

--- a/upgrades/next/host-memory-unparseable-fallback.md
+++ b/upgrades/next/host-memory-unparseable-fallback.md
@@ -1,0 +1,27 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The macOS memory reader now treats a successful `vm_stat` command with no
+parseable total-page counters as a read failure. It uses the existing logged RSS
+fallback instead of publishing zero-percent pressure from an empty denominator.
+
+## What to Tell Your User
+
+Malformed macOS memory output can no longer make a machine look perfectly
+healthy; Instar now says the native reading failed and uses its conservative
+fallback.
+
+## Summary of New Capabilities
+
+- Parse-validity detection for successful macOS memory-stat reads.
+
+## Evidence
+
+- The focused test feeds non-empty but unparseable output and proves the RSS
+  fallback reports 93.75% pressure rather than zero.
+- The existing thrown-reader fallback test remains unchanged and green.
+- Removing the parse-validity check makes both new assertions fail.
+- Fourteen focused tests and the full repository lint pass.

--- a/upgrades/side-effects/host-memory-unparseable-fallback.md
+++ b/upgrades/side-effects/host-memory-unparseable-fallback.md
@@ -1,0 +1,115 @@
+# Side-Effects Review — Host-memory unparseable fallback
+
+**Version / slug:** `host-memory-unparseable-fallback`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`parseVmStat()` now rejects a zero total-page count as unparseable.
+`readSystemMemoryPressure()` already catches parser errors, logs the failed
+native read, and returns its existing RSS-based fallback. The new test enters
+the previously uncovered successful-but-unparseable path; the existing
+thrown-reader test and fallback implementation are unchanged.
+
+## Decision-point inventory
+
+- `parseVmStat` parse-validity invariant — modified — a non-empty native command
+  result must contain at least one total-memory page counter before it can
+  become a pressure measurement.
+- Memory-pressure policy — passed through — the existing fallback and all
+  downstream pressure thresholds remain unchanged.
+
+## 1. Over-block
+
+No user or agent action is blocked. A syntactically unusual `vm_stat` output
+that contains none of the five total-memory counters is rejected rather than
+graded; that is appropriate because no total-memory denominator can be derived.
+
+## 2. Under-block
+
+The parser can still accept partially populated output when at least one
+total-memory counter is present. That preserves its existing tolerant parsing
+contract. This change does not claim to validate the semantic relationship
+between every page category; it closes the specific state where no measurement
+exists at all.
+
+## 3. Level-of-abstraction fit
+
+The validity check belongs in the pure parser, immediately after the denominator
+is assembled. The reader already owns fallback selection, logging, and
+never-throw behavior. Reusing that path avoids a second fallback policy and
+keeps consumers unaware of parser details.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The zero-page check is a hard structural invariant: pressure cannot be computed
+without total pages. It does not decide whether an operation may proceed.
+Downstream pressure policy continues to consume the resulting measurement.
+
+## 4b. Judgment-point check
+
+No competing-signals judgment point or new policy heuristic is added. A
+zero-denominator parse cannot yield a measurement.
+
+## 5. Interactions
+
+- **Shadowing:** the new parser rejection feeds the existing catch-and-fallback
+  path; it does not bypass or duplicate it.
+- **Double-fire:** only one reading is returned. The rejected native parse does
+  not also publish a zero reading.
+- **Races:** all reads remain synchronous and local; shared state is unchanged.
+- **Feedback loops:** downstream reaping and revival continue to see the same
+  fallback shape already used when the native command throws.
+
+## 6. External surfaces
+
+On malformed non-empty macOS output, logs now name the parse failure and the
+returned reading comes from the RSS fallback. Valid macOS output, Linux input,
+other platforms, external services, persistent state, and message formats are
+unchanged. No operator-facing action is added.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Machine-local by design.** Memory pressure is a physical property of each
+host and must differ across machines. The correction emits no user notice,
+stores no durable or topic-bound state, and generates no URL.
+
+## 8. Rollback cost
+
+Pure code rollback: remove the zero-page rejection and restore the guarded
+division. No data migration or agent repair is required. Rollback would
+reintroduce the false-healthy reading for malformed native output.
+
+## Conclusion
+
+Clear to ship as a small corrective PR. The change reuses the existing visible,
+never-throw fallback and leaves its already-correct thrown-reader path intact.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; the implementation changes
+only parser validity and routes through an existing tested fallback. It does not
+modify a lifecycle controller, authority, threshold, or action.
+
+## Evidence pointers
+
+- `tests/unit/host-memory-pressure.test.ts`
+- Fourteen focused tests pass.
+- Mutation proof: removing the validity check makes the parser fail to throw and
+  makes the reader return zero instead of the asserted 93.75-percent fallback.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

A successful, non-empty `vm_stat` response with no parseable page counters previously produced a zero-page denominator. That became `pressurePercent: 0`, and the host was classified as healthy even though no memory measurement existed.

The parser now rejects that specific successful-but-unparseable result. The existing `readSystemMemoryPressure()` catch path then logs the native read failure and uses its conservative RSS estimate. The already-correct thrown-reader path is unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Validation

- 14 focused host-memory tests pass.
- Full lint and TypeScript checks pass.
- Pre-push affected suite: 56/56 pass.
- Mutation proof: restoring the fabricated-zero fallback makes both the parser contract and end-to-end fallback tests fail; restoring this fix makes them pass.
- Empty-denominator candidate sweep falls from 57 sites on the branch base to 56.

## ELI16

macOS reports memory using page counters. The code used to assume that any non-empty response contained those counters. If the command returned text we could not understand, every parsed counter became zero, division used a zero fallback, and the machine looked perfectly healthy at 0% pressure. Now unreadable output is treated like a failed measurement, so the existing conservative backup estimate is used instead of publishing a flattering number invented from no data. The normal parser and the existing exception fallback behave exactly as before.

## UX Impact

Who sees it: agents and operators reading host-memory health when macOS returns malformed or unexpected native output. At first contact, they now receive the existing logged RSS fallback rather than a false healthy `pressurePercent: 0` measurement. The diagnostic includes the exact user-visible string "vm_stat output contained no total memory pages".

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix, including a deliberate regression mutation
- [x] New and existing unit tests pass locally
