### PR TITLE
Keep slowdown verification inconclusive without a baseline

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T11-13-55-265Z-burn-verifier-missing-baseline.json
+++ b/.instar/instar-dev-decisions/2026-07-29T11-13-55-265Z-burn-verifier-missing-baseline.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-29T11:13:55.265Z",
+  "slug": "burn-verifier-missing-baseline",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 34,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/monitoring/BurnVerifier.ts"
+    ],
+    "addedLines": 20,
+    "deletedLines": 14
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/BurnVerifier.ts
+++ b/src/monitoring/BurnVerifier.ts
@@ -30,8 +30,8 @@ export interface VerificationResult {
   attributionKey: string;
   preThrottleRate: number;
   postThrottleRate: number;
-  ratio: number;
-  successfullyThrottled: boolean;
+  ratio: number | null;
+  successfullyThrottled: boolean | null;
   verifiedAt: string;
 }
 
@@ -103,8 +103,10 @@ export class BurnVerifier {
     const row = rows.find((r) => r.attributionKey === attributionKey);
     const postThrottleTokens = row ? (row.freshTokens ?? row.totalTokens) : 0;
     const postThrottleRate = postThrottleTokens * (60 * 60 * 1000 / this.sampleWindowMs);
-    const ratio = preThrottleRate > 0 ? postThrottleRate / preThrottleRate : 0;
-    const successfullyThrottled = ratio < this.successRatio;
+    const ratio = Number.isFinite(preThrottleRate) && preThrottleRate > 0 && Number.isFinite(postThrottleRate)
+      ? postThrottleRate / preThrottleRate
+      : null;
+    const successfullyThrottled = ratio === null ? null : ratio < this.successRatio;
 
     const result: VerificationResult = {
       attributionKey,
@@ -120,16 +122,20 @@ export class BurnVerifier {
 
   private fireFollowUp(r: VerificationResult): void {
     const friendlyName = humanize(r.attributionKey);
-    const text = r.successfullyThrottled
-      ? `Caught and contained. ${friendlyName}: before the slowdown it was running at about ` +
-        `${formatRate(r.preThrottleRate)}; now it is running at about ${formatRate(r.postThrottleRate)} ` +
-        `— a ${formatReduction(r.ratio)} drop. The throttle will lift on its own at the configured time, ` +
-        `or you can release it sooner from the original alert.`
-      : `Slowdown did not take effect. I tried to slow ${friendlyName} down, but the rate did ` +
-        `not drop (was ${formatRate(r.preThrottleRate)}, still at ${formatRate(r.postThrottleRate)}). ` +
-        `This usually means one of two things: the attribution is pointing at the wrong code path ` +
-        `and the real offender is elsewhere, or the offending path does not honour the slowdown. ` +
-        `You may need to look at this one manually.`;
+    const text = r.ratio === null || r.successfullyThrottled === null
+      ? `Slowdown verification was inconclusive. I tried to verify ${friendlyName}, but the ` +
+        `before-slowdown rate was unavailable or zero. The current sample is ${formatRate(r.postThrottleRate)}, ` +
+        `but there is no measured baseline for a before-and-after comparison.`
+      : r.successfullyThrottled
+        ? `Caught and contained. ${friendlyName}: before the slowdown it was running at about ` +
+          `${formatRate(r.preThrottleRate)}; now it is running at about ${formatRate(r.postThrottleRate)} ` +
+          `— a ${formatReduction(r.ratio)} drop. The throttle will lift on its own at the configured time, ` +
+          `or you can release it sooner from the original alert.`
+        : `Slowdown did not take effect. I tried to slow ${friendlyName} down, but the rate did ` +
+          `not drop (was ${formatRate(r.preThrottleRate)}, still at ${formatRate(r.postThrottleRate)}). ` +
+          `This usually means one of two things: the attribution is pointing at the wrong code path ` +
+          `and the real offender is elsewhere, or the offending path does not honour the slowdown. ` +
+          `You may need to look at this one manually.`;
     this.fireTelegram(text);
   }
 

--- a/tests/unit/burn-detection-phase-6.test.ts
+++ b/tests/unit/burn-detection-phase-6.test.ts
@@ -184,4 +184,23 @@ describe('BurnVerifier — verification cycle', () => {
     expect(result.successfullyThrottled).toBe(true);
     expect(messages[0]).toMatch(/Caught and contained/i);
   });
+
+  it('does not claim success when the pre-throttle rate has no measured denominator', () => {
+    const verifier = new BurnVerifier({
+      ledger: fakeLedger([]) as any,
+      sendTelegram: (_, m) => messages.push(m),
+      now: () => now,
+    });
+
+    const result = verifier.runVerification('UnknownBaseline::aa', 0);
+
+    expect(result.preThrottleRate).toBe(0);
+    expect(result.postThrottleRate).toBe(0);
+    expect(result.ratio).toBeNull();
+    expect(result.successfullyThrottled).toBeNull();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/verification was inconclusive/i);
+    expect(messages[0]).toMatch(/no measured baseline/i);
+    expect(messages[0]).not.toMatch(/Caught and contained/i);
+  });
 });

--- a/upgrades/eli16/burn-verifier-missing-baseline.md
+++ b/upgrades/eli16/burn-verifier-missing-baseline.md
@@ -1,0 +1,26 @@
+# Slowdown verification now distinguishes success from missing evidence
+
+After Instar installs a token-use slowdown, it compares the rate from before the
+slowdown with a fresh rate several minutes later. A real reduction can support
+the “Caught and contained” follow-up, while a rate that did not fall triggers a
+warning that the slowdown may not be connected to the offending path.
+
+The old calculation had a third state that it forced into the success path. If
+the before-rate was missing or zero, there was no denominator for the
+comparison. The code substituted a ratio of zero, interpreted that as a
+one-hundred-percent reduction, and could send a reassuring message saying a
+component had been contained while both displayed rates were zero. No
+before-and-after claim was actually measurable.
+
+Verification results now represent that third state directly. Both the ratio
+and `successfullyThrottled` are null when the before-rate is unavailable, zero,
+or otherwise invalid. The follow-up says verification was inconclusive, gives
+the current sample, and explains that there is no measured baseline. Positive
+finite baselines continue through the existing success and failure paths
+unchanged.
+
+The regression enters the broken state with a zero before-rate and a zero
+current sample. It asserts the two null fields, the explanatory message, and
+the absence of “Caught and contained.” Restoring the old zero fallback makes
+the test fail. This changes no throttle, threshold, timer, or release behavior;
+it only prevents missing evidence from becoming false reassurance.

--- a/upgrades/next/burn-verifier-missing-baseline.md
+++ b/upgrades/next/burn-verifier-missing-baseline.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Post-throttle verification now reports a missing or zero pre-throttle rate as
+inconclusive. It returns nullable ratio and success fields instead of treating
+an empty denominator as a perfect reduction.
+
+## What to Tell Your User
+
+Instar no longer says a slowdown was successful when it has no measured
+before-rate to compare with the current sample.
+
+## Summary of New Capabilities
+
+- Explicit insufficient-evidence state for post-throttle verification.
+
+## Evidence
+
+- The regression enters the zero-before-rate state and asserts a null ratio, a
+  null success result, and an inconclusive follow-up message.
+- Restoring the fabricated zero ratio makes the regression fail.
+- Eleven focused tests and the full repository lint pass.

--- a/upgrades/side-effects/burn-verifier-missing-baseline.md
+++ b/upgrades/side-effects/burn-verifier-missing-baseline.md
@@ -1,0 +1,114 @@
+# Side-Effects Review — Burn-verifier missing baseline
+
+**Version / slug:** `burn-verifier-missing-baseline`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`BurnVerifier.runVerification()` now returns `ratio: null` and
+`successfullyThrottled: null` when no finite positive pre-throttle rate exists.
+Its Telegram follow-up names the result as inconclusive instead of routing the
+fabricated zero ratio through the successful “Caught and contained” message.
+
+## Decision-point inventory
+
+- Verification evidence sufficiency — modified — a finite positive before-rate
+  and a finite current rate are required for a ratio and success decision.
+- Throttle success threshold — passed through — measured ratios are still
+  compared with the existing configured `successRatio`.
+- Throttle installation and release — passed through — no actuation changes.
+
+## 1. Over-block
+
+No action is blocked. The new branch affects only a read-only verification
+result and its follow-up message. A real zero before-rate cannot support a
+percentage reduction because it has no usable denominator.
+
+## 2. Under-block
+
+The verifier still accepts every finite positive before-rate, including small
+values, and applies the configured threshold exactly as before. It does not
+attempt to infer a missing baseline from unrelated telemetry.
+
+## 3. Level-of-abstraction fit
+
+Evidence sufficiency belongs beside the ratio calculation that consumes the
+baseline. The follow-up renderer then maps the nullable result to a third,
+explicit message. This keeps the telemetry reader, throttle runbook, and
+delivery path unchanged.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The verifier is a post-action signal. It reports whether the observed rates
+support a success conclusion, but it does not install, retain, release, or
+override a throttle.
+
+## 4b. Judgment-point check
+
+No heuristic judgment is added. A ratio either has a finite positive
+denominator or it is not measurable. Existing measured results retain their
+configured threshold.
+
+## 5. Interactions
+
+- **Shadowing:** the inconclusive branch is checked before the existing success
+  and failure messages, so unknown evidence cannot masquerade as either.
+- **Double-fire:** one verification still produces exactly one follow-up.
+- **Races:** timers, ledger reads, and shared state are unchanged.
+- **Feedback loops:** the follow-up is informational and does not feed back into
+  throttle authority.
+
+## 6. External surfaces
+
+The result interface widens `ratio` and `successfullyThrottled` to nullable
+fields. Repository search finds no production consumer outside `BurnVerifier`;
+the live external effect is the Telegram follow-up. The new user-visible lead
+is “Slowdown verification was inconclusive.” Existing success and failure
+messages are unchanged for measurable inputs.
+
+## 6b. Operator-surface quality
+
+The new message states what could not be measured, includes the current sample,
+and avoids a recommendation or success claim. It is sent on the same topic and
+cadence as the existing verifier follow-up.
+
+## 7. Multi-machine posture
+
+**Machine-local by design.** Token-ledger telemetry and throttles belong to the
+agent host that observed the burn. No replicated state, URL, or cross-machine
+authority changes.
+
+## 8. Rollback cost
+
+Pure code rollback: restore the zero ratio and boolean-only result fields.
+There is no persistent-state migration. Rollback would reintroduce false
+success messages for missing baselines.
+
+## Conclusion
+
+Clear to ship as a small corrective PR. It adds the missing third outcome to a
+read-only verification signal and does not change throttle behavior.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; the implementation changes
+only a nullable metric result and its informational renderer. It does not alter
+an action, threshold, lifecycle controller, or authority boundary.
+
+## Evidence pointers
+
+- `tests/unit/burn-detection-phase-6.test.ts`
+- Eleven focused tests pass.
+- Mutation proof: restoring ratio zero makes the new null assertion fail.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Post-throttle verification previously substituted `ratio: 0` when the pre-throttle rate was zero or missing. Because zero is below the success threshold, that empty denominator became a confident success and could send “Caught and contained” while displaying zero before and after.

The result now uses `ratio: number | null` and `successfullyThrottled: boolean | null`. A non-finite or non-positive baseline produces the explicit insufficient-evidence outcome and an inconclusive follow-up. Measured positive baselines retain the existing success/failure threshold and messages.

Repository search finds no production consumer of `VerificationResult` outside this verifier; the live consumer is its Telegram renderer. No throttle, timer, release, or authority behavior changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Validation

- 11/11 focused verifier tests pass.
- Full lint and TypeScript checks pass.
- Mutation proof: restoring the zero fallback fails the null-ratio assertion (`expected 0 to be null`); restoring the correction passes.
- Empty-denominator candidate sweep falls from 57 sites on the branch base to 56.
- The pre-push affected-test listing hit its bounded local timeout; CI remains the full-suite authority.

## ELI16

After Instar slows a token-heavy component, it compares the rate before the slowdown with a fresh rate. The old code treated a missing before-rate as zero, then treated the resulting zero ratio as a perfect reduction. That could produce a reassuring “Caught and contained” message even when both displayed rates were zero and no comparison existed. The verifier now represents that third state honestly: the ratio and success result are null, and the follow-up says the check was inconclusive because no measured baseline exists. Real measured comparisons behave exactly as before.

## UX Impact

Who sees it: operators receiving the automatic post-throttle follow-up. At first contact, a missing or zero before-rate now produces the exact user-visible lead "Slowdown verification was inconclusive." The message includes the current sample and explains that no measured baseline exists instead of claiming successful containment.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added a regression test and proved it fails against the old behavior
- [x] New and existing focused tests pass locally
