### PR TITLE
Keep unrun job rates unmeasured

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T11-22-42-058Z-job-history-unmeasured-rates.json
+++ b/.instar/instar-dev-decisions/2026-07-29T11-22-42-058Z-job-history-unmeasured-rates.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-07-29T11:22:42.058Z",
+  "slug": "job-history-unmeasured-rates",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 30,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/scheduler/JobRunHistory.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 22,
+    "deletedLines": 8
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/scheduler/JobRunHistory.ts
+++ b/src/scheduler/JobRunHistory.ts
@@ -100,14 +100,27 @@ export interface JobRunStats {
   totalRuns: number;
   successes: number;
   failures: number;
-  successRate: number;
-  avgDurationSeconds: number;
+  /** Percentage of completed runs that succeeded, or null when none completed. */
+  successRate: number | null;
+  /** Average duration of runs with a measured positive duration, or null when absent. */
+  avgDurationSeconds: number | null;
   lastRun?: JobRun;
   longestRun?: { durationSeconds: number; runId: string; startedAt: string };
   /** Runs per day over the stats window */
   runsPerDay: number;
   /** Completed rows that were intentionally condensed to the storage budget. */
   budgetCondensedRuns: number;
+}
+
+/** Average only measured per-job success rates; never turn an unrun job into 0% or 100%. */
+export function averageMeasuredJobSuccessRates(
+  stats: Array<Pick<JobRunStats, 'successRate'>>,
+): number | null {
+  const measured = stats
+    .map((row) => row.successRate)
+    .filter((rate): rate is number => rate !== null);
+  if (measured.length === 0) return null;
+  return measured.reduce((sum, rate) => sum + rate, 0) / measured.length;
 }
 
 /** Monotonic counter to ensure unique runIds even within the same millisecond */
@@ -379,8 +392,8 @@ export class JobRunHistory {
       totalRuns: completed.length,
       successes,
       failures,
-      successRate: completed.length > 0 ? Math.round((successes / completed.length) * 1000) / 10 : 0,
-      avgDurationSeconds: withDuration.length > 0 ? Math.round(totalDuration / withDuration.length) : 0,
+      successRate: completed.length > 0 ? Math.round((successes / completed.length) * 1000) / 10 : null,
+      avgDurationSeconds: withDuration.length > 0 ? Math.round(totalDuration / withDuration.length) : null,
       lastRun: runs[0],
       longestRun,
       runsPerDay,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -79,6 +79,7 @@ import { PROPOSABLE_FLOOR_ACTIONS, renderAuthorizationCard } from '../core/Autho
 import type { AuthorizationRequestStore, AuthorizationRequest } from '../core/AuthorizationRequestStore.js';
 import { planTransferByNickname } from '../core/TransferByNickname.js';
 import type { JobScheduler } from '../scheduler/JobScheduler.js';
+import { averageMeasuredJobSuccessRates } from '../scheduler/JobRunHistory.js';
 import type { InstarConfig, JobPriority } from '../core/types.js';
 import { IntelligenceRouter } from '../core/IntelligenceRouter.js';
 import { knownComponents } from '../core/componentCategories.js';
@@ -13211,9 +13212,9 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     const disabled = jobReports.filter(j => !j.enabled).length;
     const totalRuns = jobReports.reduce((sum, j) => sum + (j.stats?.totalRuns ?? 0), 0);
     const totalFailures = jobReports.reduce((sum, j) => sum + (j.stats?.failures ?? 0), 0);
-    const avgSuccessRate = jobReports.length > 0
-      ? jobReports.reduce((sum, j) => sum + (j.stats?.successRate ?? 100), 0) / jobReports.length
-      : 100;
+    const avgSuccessRate = averageMeasuredJobSuccessRates(
+      jobReports.flatMap((job) => job.stats ? [job.stats] : []),
+    );
 
     res.json({
       category,
@@ -13227,7 +13228,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         disabled,
         totalRuns,
         totalFailures,
-        avgSuccessRate: Math.round(avgSuccessRate * 10) / 10,
+        avgSuccessRate: avgSuccessRate === null ? null : Math.round(avgSuccessRate * 10) / 10,
       },
       jobs: jobReports,
     });

--- a/tests/unit/JobRunHistory.test.ts
+++ b/tests/unit/JobRunHistory.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { JobRunHistory } from '../../src/scheduler/JobRunHistory.js';
+import { JobRunHistory, averageMeasuredJobSuccessRates } from '../../src/scheduler/JobRunHistory.js';
 import type { JobRun, JobRunReflection } from '../../src/scheduler/JobRunHistory.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { DegradationReporter } from '../../src/monitoring/DegradationReporter.js';
@@ -464,12 +464,23 @@ describe('JobRunHistory unit tests', () => {
       expect(jobY!.totalRuns).toBe(2);
     });
 
-    it('returns zero stats for unknown job', () => {
+    it('returns unmeasured rates for an unknown job', () => {
       const history = new JobRunHistory(stateDir);
       const stats = history.stats('nonexistent');
       expect(stats.totalRuns).toBe(0);
-      expect(stats.successRate).toBe(0);
-      expect(stats.avgDurationSeconds).toBe(0);
+      expect(stats.successRate).toBeNull();
+      expect(stats.avgDurationSeconds).toBeNull();
+    });
+
+    it('excludes unrun jobs from the category success-rate average', () => {
+      expect(averageMeasuredJobSuccessRates([
+        { successRate: 75 },
+        { successRate: null },
+      ])).toBe(75);
+      expect(averageMeasuredJobSuccessRates([
+        { successRate: null },
+        { successRate: null },
+      ])).toBeNull();
     });
   });
 

--- a/upgrades/eli16/job-history-unmeasured-rates.md
+++ b/upgrades/eli16/job-history-unmeasured-rates.md
@@ -1,0 +1,24 @@
+# Jobs with no runs no longer look completely unsuccessful
+
+The job-history API reports how many completed runs succeeded and how long runs
+took. It also builds category reports so an overseer can see performance across
+several related jobs.
+
+Previously, a job with no completed runs reported a zero-percent success rate
+and a zero-second average duration. The category report then averaged that
+invented zero with real job rates. A category with one job at 75 percent and
+one job that had never run appeared to be at 37.5 percent, even though the
+second job provided no evidence at all.
+
+Per-job success rate and average duration are now null until a completed run
+supplies the relevant sample. Category reports exclude those null rates from
+the average, and return null when no job in the category has a measured rate.
+Counts such as total runs, successes, and failures remain zero because those
+are real counts, not ratios. Scheduler state, job execution, health decisions,
+and history storage are unchanged.
+
+The regression creates an unknown job and asserts zero completed runs alongside
+null rates. A second test proves that a measured 75-percent job remains 75
+percent when an unrun job is present, while two unrun jobs produce a null
+category average. Restoring the old zero fallback makes the test fail. This
+keeps “nothing happened” distinct from “everything failed.”

--- a/upgrades/next/job-history-unmeasured-rates.md
+++ b/upgrades/next/job-history-unmeasured-rates.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Job-history statistics now return null success and duration rates when no
+completed run supplies a denominator. Category reports average only measured
+job success rates instead of counting an unrun job as either 0% or 100%.
+
+## What to Tell Your User
+
+Jobs that have not run yet now show unknown performance rather than appearing
+to have failed every run.
+
+## Summary of New Capabilities
+
+- Explicit unmeasured state for per-job and category success statistics.
+
+## Evidence
+
+- The regression asserts null success and duration for an unrun job.
+- Aggregate tests prove an unrun job cannot dilute a measured 75% rate and an
+  all-unrun category remains null.
+- Restoring the zero fallback makes the regression fail.
+- Fifty-three focused unit and lifecycle tests and full repository lint pass.

--- a/upgrades/side-effects/job-history-unmeasured-rates.md
+++ b/upgrades/side-effects/job-history-unmeasured-rates.md
@@ -1,0 +1,101 @@
+# Side-Effects Review — Job-history unmeasured rates
+
+**Version / slug:** `job-history-unmeasured-rates`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`JobRunStats.successRate` and `avgDurationSeconds` are nullable when their sample
+sets are empty. The category-report route averages only measured success rates
+and returns null when every matching job is unmeasured.
+
+## Decision-point inventory
+
+- Metric evidence sufficiency — modified — empty completed-run or duration sets
+  no longer become numeric rates.
+- Scheduling, execution, and health classification — passed through unchanged.
+
+## 1. Over-block
+
+No action is blocked. Consumers must render nullable read-surface fields, but
+all measured rates retain their existing numeric values.
+
+## 2. Under-block
+
+Runs with recorded zero duration remain excluded by the existing duration
+contract, so an all-zero-duration sample is still unmeasured. This change does
+not validate whether an individual recorded outcome was labeled correctly.
+
+## 3. Level-of-abstraction fit
+
+Per-job nullability belongs where run samples are aggregated. Category
+nullability belongs at the route aggregation boundary, supported by a pure
+helper in the job-history module so the exclusion rule is directly tested.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+These fields are read-only observability. Scheduler admission, job execution,
+failure counters, and operator controls do not consume them as authority.
+
+## 4b. Judgment-point check
+
+No heuristic judgment is introduced. A percentage requires at least one
+completed run, and an average duration requires at least one measured duration.
+
+## 5. Interactions
+
+- **Shadowing:** null replaces only the two empty-sample fallbacks.
+- **Double-fire:** no events or notifications are emitted.
+- **Races:** history read and write behavior is unchanged.
+- **Feedback loops:** category reports remain observational.
+
+## 6. External surfaces
+
+Job-history and category-report JSON can now contain null for `successRate`,
+`avgDurationSeconds`, and `avgSuccessRate`. Counts remain numeric. Existing
+measured rates are byte-for-byte unchanged.
+
+## 6b. Operator-surface quality
+
+An unrun job no longer renders as zero-percent success, and an unmeasured job
+cannot dilute a category average. Clients can distinguish absence from failure
+using the null plus existing count fields.
+
+## 7. Multi-machine posture
+
+**Machine-local by design.** Each scheduler reports the history stored on its
+host. The change does not alter pool merging, topic placement, or replication.
+
+## 8. Rollback cost
+
+Pure code rollback: restore the zero fallbacks and simple category average. No
+stored history or agent state requires migration.
+
+## Conclusion
+
+Clear to ship as a small corrective PR. It changes only the truthfulness of
+empty-sample read surfaces.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; no action, lifecycle,
+authority, sentinel, guard, or gate behavior changes.
+
+## Evidence pointers
+
+- `tests/unit/JobRunHistory.test.ts`
+- `tests/e2e/job-run-history-lifecycle.test.ts`
+- Fifty-three focused tests pass.
+- Mutation proof: restoring the zero fallback fails the null assertion.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

A job with no completed runs previously reported `successRate: 0` and `avgDurationSeconds: 0`. The category report then averaged that fabricated zero with real job rates, so one measured 75% job plus one unrun job appeared as 37.5%.

The per-job rates are now nullable when their sample sets are empty. Category reports average only measured job rates and return null when every matching job is unmeasured. Counts remain numeric, and scheduling, execution, health state, and history persistence are unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Validation

- 40/40 focused JobRunHistory unit tests pass.
- 13/13 job-history lifecycle tests pass; 53/53 across the changed surface.
- Full lint and TypeScript checks pass.
- Mutation proof: restoring the zero fallback fails at `expected 0 to be null`.
- The raw denominator candidate sweep removes both per-job empty-rate sites, falling from 57 to 55 on this branch.
- The bounded pre-push affected-test listing timed out; CI remains the full-suite authority.

## ELI16

Job history tells operators how often a job succeeds and how long it takes. The old code assigned zero-percent success and zero seconds to a job that had never completed a run. A category report then mixed that invented zero with real results, making measured jobs look worse. Now an unrun job reports those rates as unknown, and category averages use only jobs that have actual completed-run evidence. If every job is unmeasured, the category average is also unknown. Run counts, scheduler behavior, and real measured rates do not change.

## UX Impact

Who sees it: operators and overseers reading per-job history or category reports. At first contact, an unrun job now carries the exact JSON field value "successRate": null rather than a false zero-percent result; `avgDurationSeconds` and an all-unmeasured category `avgSuccessRate` are likewise null.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove individual and aggregate empty-sample behavior
- [x] New and existing focused tests pass locally
