### PR TITLE
Keep empty self-knowledge health metrics unmeasured

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T11-29-28-566Z-self-knowledge-health-unmeasured.json
+++ b/.instar/instar-dev-decisions/2026-07-29T11-29-28-566Z-self-knowledge-health-unmeasured.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-07-29T11:29:28.566Z",
+  "slug": "self-knowledge-health-unmeasured",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 30,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/machine.ts",
+      "src/knowledge/CoverageAuditor.ts"
+    ],
+    "addedLines": 18,
+    "deletedLines": 12
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -952,11 +952,17 @@ export async function doctor(options: DoctorOptions): Promise<void> {
         `${Math.round(validation.coverageScore * 100)}% coverage`,
       ];
       if (health.searchCount > 0) {
-        parts.push(`${Math.round(health.cacheHitRate * 100)}% cache hit`);
-        parts.push(`${Math.round(health.avgLatencyMs)}ms avg`);
-        if (health.errorRate > 0) {
+        parts.push(health.cacheHitRate === null
+          ? 'cache hit n/a'
+          : `${Math.round(health.cacheHitRate * 100)}% cache hit`);
+        if (health.avgLatencyMs !== null) {
+          parts.push(`${Math.round(health.avgLatencyMs)}ms avg`);
+        }
+        if (health.errorRate !== null && health.errorRate > 0) {
           parts.push(`${(health.errorRate * 100).toFixed(1)}% error rate`);
         }
+      } else {
+        parts.push('no search samples');
       }
 
       const hasErrors = validation.errors.length > 0;

--- a/src/knowledge/CoverageAuditor.ts
+++ b/src/knowledge/CoverageAuditor.ts
@@ -41,9 +41,9 @@ export interface AuditResult {
 export interface HealthSummary {
   totalNodes: number;
   coverageScore: number;
-  cacheHitRate: number;
-  avgLatencyMs: number;
-  errorRate: number;
+  cacheHitRate: number | null;
+  avgLatencyMs: number | null;
+  errorRate: number | null;
   searchCount: number;
   degradedSearches: number;
 }
@@ -146,9 +146,9 @@ export class CoverageAuditor {
     const defaultSummary: HealthSummary = {
       totalNodes: 0,
       coverageScore: 0,
-      cacheHitRate: 0,
-      avgLatencyMs: 0,
-      errorRate: 0,
+      cacheHitRate: null,
+      avgLatencyMs: null,
+      errorRate: null,
       searchCount: 0,
       degradedSearches: 0,
     };
@@ -188,9 +188,9 @@ export class CoverageAuditor {
       return {
         totalNodes: 0, // Caller fills this from config
         coverageScore: 0, // Caller fills this from validation
-        cacheHitRate: totalCacheOps > 0 ? totalCacheHits / totalCacheOps : 0,
-        avgLatencyMs: entries.length > 0 ? totalLatency / entries.length : 0,
-        errorRate: entries.length > 0 ? totalErrors / entries.length : 0,
+        cacheHitRate: totalCacheOps > 0 ? totalCacheHits / totalCacheOps : null,
+        avgLatencyMs: totalLatency / entries.length,
+        errorRate: totalErrors / entries.length,
         searchCount: entries.length,
         degradedSearches: degradedCount,
       };

--- a/tests/unit/CoverageAudit.test.ts
+++ b/tests/unit/CoverageAudit.test.ts
@@ -55,6 +55,34 @@ describe('Coverage Audit + Evolution (Phase 4)', () => {
     fs.writeFileSync(path.join(stateDir, 'logs', 'tree-trace.jsonl'), lines);
   }
 
+  it('reports unmeasured health rates when no trace sample exists', () => {
+    const health = new CoverageAuditor(projectDir, stateDir).healthSummary();
+
+    expect(health.searchCount).toBe(0);
+    expect(health.cacheHitRate).toBeNull();
+    expect(health.avgLatencyMs).toBeNull();
+    expect(health.errorRate).toBeNull();
+  });
+
+  it('keeps cache hit rate unmeasured when searches recorded no cache operations', () => {
+    writeTraceEntries([{
+      timestamp: '2026-03-12T15:00:00Z',
+      query: 'uncached probe',
+      cacheHits: [],
+      cacheMisses: [],
+      errors: [],
+      elapsedMs: 25,
+      degraded: false,
+    }]);
+
+    const health = new CoverageAuditor(projectDir, stateDir).healthSummary();
+
+    expect(health.searchCount).toBe(1);
+    expect(health.cacheHitRate).toBeNull();
+    expect(health.avgLatencyMs).toBe(25);
+    expect(health.errorRate).toBe(0);
+  });
+
   // Gate Test 4.1: doctor reports tree health summary
   it('4.1: health summary includes total nodes, coverage, cache rate, latency, errors', () => {
     const tree = createTree();

--- a/upgrades/eli16/self-knowledge-health-unmeasured.md
+++ b/upgrades/eli16/self-knowledge-health-unmeasured.md
@@ -1,0 +1,23 @@
+# Self-knowledge health no longer invents perfect performance
+
+Instar records a trace whenever the self-knowledge tree answers a search. Its
+health surface summarizes cache hit rate, average latency, and errors so an
+operator can see whether that search path is useful and reliable.
+
+Previously, a missing trace file, an empty file, a fully unreadable file, and a
+real set of zero measurements all produced the same three numbers: zero cache
+hits, zero milliseconds, and zero errors. Two of those numbers look ideal even
+though the system had measured nothing. A search that performed no cache
+operation also reported a zero-percent hit rate instead of saying the rate had
+no denominator.
+
+The three trace-derived health fields are now null when no valid search sample
+exists. When searches exist but none touched the cache, only the cache hit rate
+is null; latency and error rate remain measured from the search count. The HTTP
+health response passes those values through. The machine diagnostic prints “no
+search samples” or “cache hit n/a” rather than formatting an invented zero.
+
+The regressions cover both absence shapes and assert the sample counts beside
+the null fields. Restoring the old fallback produces two direct failures. Tree
+search, caching, validation, coverage scoring, and error handling are unchanged;
+only the read surface now distinguishes evidence from absence.

--- a/upgrades/next/self-knowledge-health-unmeasured.md
+++ b/upgrades/next/self-knowledge-health-unmeasured.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Self-knowledge health now returns null cache, latency, and error metrics when no
+search trace exists. A search with no cache operations also reports a null cache
+hit rate, and machine diagnostics name the absence instead of formatting zero.
+
+## What to Tell Your User
+
+An unused or unreadable self-knowledge trace no longer looks like perfect
+zero-millisecond, zero-error performance.
+
+## Summary of New Capabilities
+
+- Explicit unmeasured state for self-knowledge health metrics.
+- Plain-language machine diagnostics for missing search samples.
+
+## Evidence
+
+- Tests cover both a missing trace and a real search with no cache operations.
+- Restoring the zero fallbacks makes both regressions fail.
+- Eleven focused tests and full repository lint pass.

--- a/upgrades/side-effects/self-knowledge-health-unmeasured.md
+++ b/upgrades/side-effects/self-knowledge-health-unmeasured.md
@@ -1,0 +1,100 @@
+# Side-Effects Review — Self-knowledge health unmeasured state
+
+**Version / slug:** `self-knowledge-health-unmeasured`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`CoverageAuditor.healthSummary()` now makes its three trace-derived rates
+nullable when no valid samples exist, and makes cache hit rate nullable when a
+search performed no cache operation. Machine diagnostics render those states
+as “no search samples” or “cache hit n/a.”
+
+## Decision-point inventory
+
+- Trace evidence sufficiency — modified — rates require their actual sample
+  denominators.
+- Tree validation and health status — passed through unchanged.
+
+## 1. Over-block
+
+No action is blocked. Existing consumers receive null instead of zero only when
+the underlying trace or cache-operation denominator is empty.
+
+## 2. Under-block
+
+The trace reader still skips corrupt individual lines and summarizes remaining
+valid entries. It does not expose a corrupt-line count, so partial trace
+corruption remains outside these rate fields.
+
+## 3. Level-of-abstraction fit
+
+Nullability belongs in `CoverageAuditor`, which owns trace parsing and knows the
+denominators. HTTP passes the fields through, while the machine command owns
+plain-language formatting of the nullable result.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+Self-knowledge health is read-only observability. The machine command's status
+continues to depend on tree validation errors and warnings, not these rates.
+
+## 4b. Judgment-point check
+
+No heuristic is added. The change applies only mathematical denominator
+requirements and explicit absence rendering.
+
+## 5. Interactions
+
+- **Shadowing:** null replaces the prior all-zero default; measured paths remain
+  unchanged.
+- **Double-fire:** no events or notices are emitted.
+- **Races:** trace file reading remains synchronous and unchanged.
+- **Feedback loops:** the metrics do not control search or cache behavior.
+
+## 6. External surfaces
+
+`GET /self-knowledge/health` can now return null for `cacheHitRate`,
+`avgLatencyMs`, and `errorRate`. Machine diagnostics add “no search samples” and
+“cache hit n/a.” Measured numeric values retain the same units and formulas.
+
+## 6b. Operator-surface quality
+
+The diagnostic names why a percentage is absent and keeps the existing search
+count in the HTTP response, so null is explainable rather than ambiguous.
+
+## 7. Multi-machine posture
+
+**Machine-local by design.** Search traces and cache behavior belong to the host
+that served the self-knowledge query. No replicated state or URL changes.
+
+## 8. Rollback cost
+
+Pure code rollback: restore the numeric defaults and CLI formatting. No trace or
+tree data requires migration.
+
+## Conclusion
+
+Clear to ship as a small corrective PR. It changes only read-surface truthfulness.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; no lifecycle, action,
+authority, sentinel, guard, or gate behavior changes.
+
+## Evidence pointers
+
+- `tests/unit/CoverageAudit.test.ts`
+- Eleven focused tests pass.
+- Mutation proof: restoring both zero fallbacks produces two direct failures.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Self-knowledge health no longer reports fabricated ideal values when the trace is absent or contains no relevant measurements. `cacheHitRate`, `avgLatencyMs`, and `errorRate` are now nullable, and the machine-doctor output renders explicit unknown states instead of `0%` / `0ms` measurements that never occurred.

The root cause was three empty-denominator fallbacks in `CoverageAuditor`: missing or unreadable trace data returned an all-zero summary, and a search with no cache operations reported a perfect zero-percent cache-hit rate. The CLI then formatted those synthetic values exactly like real measurements.

## Validation

- 11 focused unit tests pass.
- Full repository lint and TypeScript checks pass.
- Pre-push affected smoke tier: 10 files / 96 tests pass.
- Mutation proof: restoring the old zero fallbacks makes the new fresh-state and no-cache-operation assertions fail (`expected 0 to be null`); restoring the correction returns the focused suite to green.
- The raw empty-denominator candidate grep falls from 56 sites on the base to 53 on this branch.

## ELI16

Imagine a dashboard for a search system that has not recorded any searches yet. Saying “0 milliseconds, 0% errors, and 0% cache hits” looks like three measurements, but nothing was measured. That can make an empty or broken telemetry source look healthy. This change keeps those fields unknown until the trace contains evidence, while preserving numeric values once searches actually occur. A search with no cache operation can still report its measured latency and error status, but its cache-hit rate remains unknown because there was no cache attempt to divide by.

## UX Impact

Who sees it: operators running machine doctor or reading self-knowledge health. What changes at first contact: an empty trace now says `"no search samples"`, and a measured search with no cache operation says `"cache hit n/a"`, rather than presenting synthetic zero values. Existing measured output remains unchanged.
