### PR TITLE
Keep empty benchmark attribution unmeasured

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T11-37-39-953Z-benchmark-missing-model-share-unmeasured.json
+++ b/.instar/instar-dev-decisions/2026-07-29T11-37-39-953Z-benchmark-missing-model-share-unmeasured.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-29T11:37:39.953Z",
+  "slug": "benchmark-missing-model-share-unmeasured",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 4,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/monitoring/BenchmarkDivergenceAnalyzer.ts"
+    ],
+    "addedLines": 2,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/BenchmarkDivergenceAnalyzer.ts
+++ b/src/monitoring/BenchmarkDivergenceAnalyzer.ts
@@ -769,7 +769,7 @@ export class BenchmarkDivergenceAnalyzer {
   summary(): {
     byVerdict: Record<string, number>;
     unmappedModels: string[];
-    missingModelShare: number;
+    missingModelShare: number | null;
     unanalyzedLoss: { byMachine: Record<string, number> };
   } {
     const s = this.settings();
@@ -799,7 +799,7 @@ export class BenchmarkDivergenceAnalyzer {
     return {
       byVerdict,
       unmappedModels: Array.from(unmapped).sort(),
-      missingModelShare: total > 0 ? missing / total : 0,
+      missingModelShare: total > 0 ? missing / total : null,
       unanalyzedLoss: { byMachine },
     };
   }

--- a/tests/unit/BenchmarkDivergenceAnalyzer.test.ts
+++ b/tests/unit/BenchmarkDivergenceAnalyzer.test.ts
@@ -482,4 +482,11 @@ describe('status surfaces (FD10)', () => {
     const a = analyzer();
     expect(a.summary().missingModelShare).toBeCloseTo(0.5);
   });
+
+  it('keeps missingModelShare unmeasured when the matured window has no decisions', () => {
+    const a = analyzer();
+    const summary = a.summary();
+    expect(summary.byVerdict).toEqual({});
+    expect(summary.missingModelShare).toBeNull();
+  });
 });

--- a/upgrades/eli16/benchmark-missing-model-share-unmeasured.md
+++ b/upgrades/eli16/benchmark-missing-model-share-unmeasured.md
@@ -1,0 +1,19 @@
+# Empty benchmark windows no longer look perfectly attributed
+
+The benchmark-divergence summary reports what share of recorded decisions did
+not identify the model that made them. That share is useful only when the
+matured analysis window actually contains decisions.
+
+Previously, an empty window returned zero. A reader could reasonably interpret
+that as “zero percent of decisions are missing model attribution,” even though
+there were no decisions to inspect. The same value therefore represented both
+perfect attribution and no evidence.
+
+The summary now returns null when its decision denominator is empty. Once any
+decisions exist, it keeps the existing calculation: missing decisions divided
+by all decisions. Verdict counts and unanalyzed-loss reporting are unchanged.
+
+The regression enters a genuinely empty matured window and asserts both the
+empty verdict map and the null share. Restoring the old zero fallback makes that
+test fail directly, while the existing half-missing measured case remains
+numeric at one-half.

--- a/upgrades/next/benchmark-missing-model-share-unmeasured.md
+++ b/upgrades/next/benchmark-missing-model-share-unmeasured.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The benchmark-divergence summary now returns a null missing-model share when its
+matured analysis window contains no decisions, instead of presenting an
+unmeasured window as a measured zero-percent share.
+
+## What to Tell Your User
+
+An empty benchmark-divergence window no longer looks like every recorded
+decision had valid model attribution.
+
+## Summary of New Capabilities
+
+- Explicit unmeasured state for benchmark missing-model attribution.
+- Numeric missing-model shares remain unchanged once decisions exist.
+
+## Evidence
+
+- The focused suite covers empty and measured matured windows.
+- Restoring the zero fallback makes the empty-window regression fail.
+- Twenty-four focused tests and full repository lint pass.

--- a/upgrades/side-effects/benchmark-missing-model-share-unmeasured.md
+++ b/upgrades/side-effects/benchmark-missing-model-share-unmeasured.md
@@ -1,0 +1,96 @@
+# Side-Effects Review — Benchmark missing-model share unmeasured state
+
+**Version / slug:** `benchmark-missing-model-share-unmeasured`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`BenchmarkDivergenceAnalyzer.summary()` now returns null for
+`missingModelShare` when the matured window contains zero decisions. Measured
+windows retain the existing ratio.
+
+## Decision-point inventory
+
+- Benchmark summary evidence sufficiency — modified — a share requires at
+  least one recorded decision.
+- Divergence verdict computation — passed through unchanged.
+
+## 1. Over-block
+
+No action is blocked. The summary is a read-only operator surface.
+
+## 2. Under-block
+
+No detector condition changes. Null distinguishes an empty matured window from
+a measured zero-percent missing-model share.
+
+## 3. Level-of-abstraction fit
+
+The analyzer owns the matured-window aggregation and is the first layer that
+knows whether the ratio has a denominator. The HTTP route passes its summary
+through without reconstructing that evidence.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The benchmark-divergence endpoint remains advisory observability. Verdict
+generation and preconditions are untouched.
+
+## 4b. Judgment-point check
+
+No heuristic is added. The change applies the mathematical requirement that a
+share needs a non-empty denominator.
+
+## 5. Interactions
+
+- **Shadowing:** null replaces only the empty-window zero fallback.
+- **Double-fire:** no events or notices are emitted.
+- **Races:** ledger reads and window selection are unchanged.
+- **Feedback loops:** the summary does not control analysis or routing.
+
+## 6. External surfaces
+
+`GET /benchmark-divergence` can now return
+`summary.missingModelShare: null` when the matured window has no decisions.
+Measured numeric values retain the same range and formula.
+
+## 6b. Operator-surface quality
+
+The neighboring empty `byVerdict` map makes the reason for null visible in the
+same summary. No ideal-looking value is fabricated.
+
+## 7. Multi-machine posture
+
+Unchanged. Plain scope still summarizes the local ledger and pool collection
+still follows its existing aggregation path.
+
+## 8. Rollback cost
+
+Pure code rollback: restore the numeric fallback. No ledger data or schema
+migration is involved.
+
+## Conclusion
+
+Clear to ship as a small read-surface truthfulness correction.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; no lifecycle, action,
+authority, sentinel, guard, or gate behavior changes.
+
+## Evidence pointers
+
+- `tests/unit/BenchmarkDivergenceAnalyzer.test.ts`
+- Twenty-four focused tests pass.
+- Mutation proof: restoring the zero fallback produces one direct failure.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

The benchmark-divergence summary now reports `missingModelShare: null` when its matured analysis window contains zero decisions. Once decisions exist, the existing missing-model / total-decision calculation remains unchanged.

The root cause was an empty-denominator fallback that returned zero for both “every decision has model attribution” and “there are no decisions to inspect.” The result is operator-facing JSON, so a fresh or empty window looked perfectly attributed despite having no evidence.

## Validation

- 24 focused benchmark-divergence tests pass.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring the zero fallback fails the new empty-window assertion with `expected 0 to be null`; restoring the correction returns all focused tests to green.
- The existing measured case still reports one-half when 10 of 20 decisions are missing a model.
- The raw empty-denominator candidate grep falls by one on this branch.

## ELI16

Suppose a report asks, “What percentage of these decisions forgot to record which model made them?” If there are twenty decisions and ten are missing a model, the answer is fifty percent. But if there are no decisions at all, zero percent is not an answer—it makes an empty report look perfect. This change uses `null` for that no-evidence state. As soon as decisions exist, the same numeric percentage is calculated as before. No divergence verdicts, thresholds, storage, or analysis behavior change.

## UX Impact

Who sees it: operators reading the benchmark-divergence endpoint. What changes at first contact: an empty matured window now returns `"missingModelShare": null` beside its empty verdict summary, instead of an ideal-looking zero. Measured windows keep their existing numeric output.
