### PR TITLE
Keep empty Threadline trust rates unmeasured

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T11-43-52-834Z-threadline-trust-success-unmeasured.json
+++ b/.instar/instar-dev-decisions/2026-07-29T11-43-52-834Z-threadline-trust-success-unmeasured.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-07-29T11:43:52.834Z",
+  "slug": "threadline-trust-success-unmeasured",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 9,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/threadline/AgentTrustManager.ts",
+      "src/threadline/OpenClawBridge.ts"
+    ],
+    "addedLines": 6,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/threadline/AgentTrustManager.ts
+++ b/src/threadline/AgentTrustManager.ts
@@ -142,7 +142,7 @@ export interface InteractionStats {
   messagesResponded: number;
   successfulInteractions: number;
   failedInteractions: number;
-  successRate: number;
+  successRate: number | null;
   streakSinceIncident: number;
   lastInteraction: string | null;
 }
@@ -955,7 +955,7 @@ export class AgentTrustManager {
       messagesResponded: h.messagesResponded,
       successfulInteractions: h.successfulInteractions,
       failedInteractions: h.failedInteractions,
-      successRate: total > 0 ? h.successfulInteractions / total : 0,
+      successRate: total > 0 ? h.successfulInteractions / total : null,
       streakSinceIncident: h.streakSinceIncident,
       lastInteraction: h.lastInteraction || null,
     };

--- a/src/threadline/OpenClawBridge.ts
+++ b/src/threadline/OpenClawBridge.ts
@@ -379,7 +379,10 @@ export class OpenClawBridge {
           statusLines.push(`Trust level: ${profile?.level ?? 'unknown (defaults to untrusted)'}`);
           const stats = bridge.config.trustManager.getInteractionStats(agentIdentity);
           if (stats) {
-            statusLines.push(`Interactions: ${stats.successfulInteractions} successful, ${stats.failedInteractions} failed (${(stats.successRate * 100).toFixed(1)}% success rate)`);
+            const successRate = stats.successRate == null
+              ? 'success rate unknown'
+              : `${(stats.successRate * 100).toFixed(1)}% success rate`;
+            statusLines.push(`Interactions: ${stats.successfulInteractions} successful, ${stats.failedInteractions} failed (${successRate})`);
           }
         }
 

--- a/tests/unit/threadline/AgentTrustManager.test.ts
+++ b/tests/unit/threadline/AgentTrustManager.test.ts
@@ -183,11 +183,13 @@ describe('AgentTrustManager', () => {
       expect(stats.successRate).toBe(0.75);
     });
 
-    it('success rate is 0 when no interactions', () => {
+    it('keeps success rate unmeasured when there are no interactions', () => {
       const mgr = createManager();
       mgr.getOrCreateProfile('agent-a');
       const stats = mgr.getInteractionStats('agent-a')!;
-      expect(stats.successRate).toBe(0);
+      expect(stats.successfulInteractions).toBe(0);
+      expect(stats.failedInteractions).toBe(0);
+      expect(stats.successRate).toBeNull();
     });
   });
 

--- a/tests/unit/threadline/OpenClawBridge.test.ts
+++ b/tests/unit/threadline/OpenClawBridge.test.ts
@@ -462,6 +462,18 @@ describe('OpenClawBridge', () => {
       expect(result.text).toContain('Interactions:');
     });
 
+    it('names an unmeasured success rate for a profile with no interactions', async () => {
+      const trustManager = new AgentTrustManager({ stateDir: tmpDir });
+      trustManager.setTrustLevel('user-1', 'verified', 'user-granted');
+
+      const { bridge } = createBridge({ trustManager });
+      const action = bridge.getActions().find(a => a.name === 'THREADLINE_STATUS')!;
+      const result = await action.handler(createMockRuntime(), createMockMessage()) as { text: string };
+      expect(result.text).toContain('0 successful, 0 failed');
+      expect(result.text).toContain('success rate unknown');
+      expect(result.text).not.toContain('0.0% success rate');
+    });
+
     it('returns status with compute info when compute meter configured', async () => {
       const computeMeter = new ComputeMeter({ stateDir: tmpDir });
       const { bridge } = createBridge({ computeMeter });

--- a/upgrades/eli16/threadline-trust-success-unmeasured.md
+++ b/upgrades/eli16/threadline-trust-success-unmeasured.md
@@ -1,0 +1,20 @@
+# New trust profiles no longer start at zero-percent success
+
+Threadline keeps counts of successful and failed interactions for each known
+agent. Its status surfaces divide successes by all completed interactions to
+show a success rate.
+
+Previously, a newly created profile with zero successes and zero failures
+reported a zero-percent success rate. That looks like every interaction failed,
+even though no interaction had happened. The HTTP stats and OpenClaw status
+therefore turned missing history into a real-looking poor result.
+
+The success-rate field is now null until at least one success or failure is
+recorded. OpenClaw still shows both zero counts, but labels the rate “unknown.”
+Once an interaction exists, the existing numeric calculation is unchanged.
+Trust levels, permission checks, explicit allow and block lists, automatic
+downgrades, and interaction recording do not read this rate and are unchanged.
+
+The regression covers both the raw stats object and the text an operator sees.
+Restoring the old zero fallback produces failures in both tests, including the
+exact old “0.0% success rate” output.

--- a/upgrades/next/threadline-trust-success-unmeasured.md
+++ b/upgrades/next/threadline-trust-success-unmeasured.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Threadline interaction statistics now return a null success rate for a trust
+profile with no completed interactions. OpenClaw status names that state as
+unknown instead of formatting it as a measured zero-percent success rate.
+
+## What to Tell Your User
+
+A newly created Threadline trust profile no longer looks like it has failed
+every interaction before any interaction has occurred.
+
+## Summary of New Capabilities
+
+- Explicit unmeasured state for empty Threadline interaction history.
+- Plain-language OpenClaw status for an unknown success rate.
+
+## Evidence
+
+- Unit, integration, and end-to-end Threadline suites pass.
+- Restoring the zero fallback fails both the stats and formatted-status tests.
+- Full repository lint and TypeScript checks pass.

--- a/upgrades/side-effects/threadline-trust-success-unmeasured.md
+++ b/upgrades/side-effects/threadline-trust-success-unmeasured.md
@@ -1,0 +1,96 @@
+# Side-Effects Review — Threadline trust success unmeasured state
+
+**Version / slug:** `threadline-trust-success-unmeasured`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`AgentTrustManager.getInteractionStats()` now returns a null `successRate` when
+the profile has no successful or failed interactions. OpenClaw status renders
+that state as “success rate unknown.”
+
+## Decision-point inventory
+
+- Interaction-stat evidence sufficiency — modified — a rate requires at least
+  one completed interaction.
+- Trust levels and permission evaluation — passed through unchanged.
+- Safety-only auto-downgrade — passed through unchanged.
+
+## 1. Over-block
+
+No operation is blocked. Permission checks use trust level and explicit
+operation lists, not `successRate`.
+
+## 2. Under-block
+
+No permission or downgrade condition changes. A measured zero-percent rate
+after one or more failures remains numeric zero.
+
+## 3. Level-of-abstraction fit
+
+`AgentTrustManager` owns both interaction counts and the denominator, so it owns
+the nullable rate. OpenClaw owns the plain-language rendering. The HTTP route
+passes the field through.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — the changed field is read-only observability.
+
+The authority-bearing trust and permission methods do not consume this rate.
+
+## 4b. Judgment-point check
+
+No heuristic is added. Null applies only to an empty mathematical denominator.
+
+## 5. Interactions
+
+- **Shadowing:** null replaces only the new-profile zero fallback.
+- **Double-fire:** no events or notices are emitted.
+- **Races:** persistence and counter updates are unchanged.
+- **Feedback loops:** trust decisions do not read the rate.
+
+## 6. External surfaces
+
+The Threadline trust stats route can now return `successRate: null` for a known
+profile with no interactions. OpenClaw status says “success rate unknown.”
+Measured rates retain the same zero-to-one scale.
+
+## 6b. Operator-surface quality
+
+The status includes “0 successful, 0 failed” beside the unknown label, so the
+reason is visible without inference.
+
+## 7. Multi-machine posture
+
+Unchanged. Trust profiles and their interaction history retain the existing
+machine-local/replication behavior.
+
+## 8. Rollback cost
+
+Pure code rollback. No profile schema or stored history changes.
+
+## Conclusion
+
+Clear to ship as a bounded observability correction.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; permission, trust,
+authority, action, and lifecycle behavior are unchanged.
+
+## Evidence pointers
+
+- `tests/unit/threadline/AgentTrustManager.test.ts`
+- `tests/unit/threadline/OpenClawBridge.test.ts`
+- 286 focused unit, integration, and end-to-end tests pass.
+- Mutation proof: restoring the zero fallback produces two direct failures.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Threadline interaction statistics now return `successRate: null` for a known profile with zero successful and zero failed interactions. OpenClaw status renders that state as `success rate unknown` while retaining both counts. Measured rates remain unchanged.

The root cause was an empty-denominator fallback that made a newly created trust profile look like it had failed every interaction. That synthetic zero flowed through both the HTTP stats surface and the operator-facing OpenClaw status formatter. Trust levels, permission checks, operation lists, and auto-downgrades do not consume the rate.

## Validation

- 286 focused Threadline unit, integration, and end-to-end tests pass.
- Pre-push affected smoke tier: 19 files / 356 tests pass.
- Scoped Threadline e2e gate: 18 files / 333 tests pass.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring the zero fallback fails both the raw-stats assertion and the formatted-status assertion, reproducing the exact old `0.0% success rate` output.

## ELI16

Imagine creating a scorecard for a new teammate before they have done any tasks. Showing “0% successful” implies they failed, but there were no attempts to score. Threadline had the same problem for new trust profiles: zero successes divided by zero completed interactions was displayed as a real zero-percent rate. This change leaves the rate unknown until the first success or failure is recorded. The status still shows both zero counts, so the reason is visible. No trust or permission decision changes.

## UX Impact

Who sees it: operators reading Threadline trust stats or OpenClaw bridge status. What changes at first contact: a new profile says `"success rate unknown"` beside `0 successful, 0 failed`, instead of showing a fabricated zero-percent success rate. After any completed interaction, the existing numeric output remains unchanged.
