### PR TITLE
Keep empty self-knowledge cache rates unmeasured

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T11-49-56-707Z-self-knowledge-cache-rate-unmeasured.json
+++ b/.instar/instar-dev-decisions/2026-07-29T11-49-56-707Z-self-knowledge-cache-rate-unmeasured.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-07-29T11:49:56.707Z",
+  "slug": "self-knowledge-cache-rate-unmeasured",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 8,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/knowledge/SelfKnowledgeTree.ts",
+      "src/knowledge/TreeTraversal.ts",
+      "src/knowledge/types.ts"
+    ],
+    "addedLines": 4,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/knowledge/SelfKnowledgeTree.ts
+++ b/src/knowledge/SelfKnowledgeTree.ts
@@ -629,7 +629,7 @@ export class SelfKnowledgeTree {
       synthesis: null,
       budgetUsed: 0,
       elapsedMs: Date.now() - startTime,
-      cacheHitRate: 0,
+      cacheHitRate: null,
       errors: [{ nodeId: '', sourceType: '', error, elapsedMs: 0 }],
     };
   }

--- a/src/knowledge/TreeTraversal.ts
+++ b/src/knowledge/TreeTraversal.ts
@@ -92,7 +92,7 @@ export class TreeTraversal {
       misses: this.stats.misses,
       evictions: this.stats.evictions,
       size: this.cache.size,
-      hitRate: total > 0 ? this.stats.hits / total : 0,
+      hitRate: total > 0 ? this.stats.hits / total : null,
     };
   }
 

--- a/src/knowledge/types.ts
+++ b/src/knowledge/types.ts
@@ -59,7 +59,7 @@ export interface SelfKnowledgeResult {
   synthesis: string | null;
   budgetUsed: number;
   elapsedMs: number;
-  cacheHitRate: number;
+  cacheHitRate: number | null;
   errors: SourceError[];
   triageMethod?: 'llm' | 'rule-based';
   confidence?: number;                     // Max node confidence (0.0-1.0)
@@ -142,7 +142,7 @@ export interface CacheStats {
   misses: number;
   evictions: number;
   size: number;
-  hitRate: number;
+  hitRate: number | null;
 }
 
 export const CACHE_TTL_MS: Record<CacheTier, number> = {

--- a/tests/unit/SelfKnowledgeTree.test.ts
+++ b/tests/unit/SelfKnowledgeTree.test.ts
@@ -377,6 +377,7 @@ Direct and technical. I don't waste words.
 
     expect(result.degraded).toBe(true);
     expect(result.fragments).toHaveLength(0);
+    expect(result.cacheHitRate).toBeNull();
     expect(result.errors.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/tests/unit/TreeTraversal.test.ts
+++ b/tests/unit/TreeTraversal.test.ts
@@ -131,6 +131,13 @@ describe('TreeTraversal', () => {
 
   // Gate Test 1.16/1.17: Caching behavior
   describe('caching', () => {
+    it('keeps hit rate unmeasured before the first cache lookup', () => {
+      const stats = traversal.cacheStats();
+      expect(stats.hits).toBe(0);
+      expect(stats.misses).toBe(0);
+      expect(stats.hitRate).toBeNull();
+    });
+
     it('returns cached content on second call', async () => {
       const node: SelfKnowledgeNode = {
         id: 'identity.core',
@@ -166,11 +173,13 @@ describe('TreeTraversal', () => {
       };
 
       await traversal.gather([node], { identity: 0.9 });
+      expect(traversal.cacheStats().hitRate).toBe(0);
       await traversal.gather([node], { identity: 0.9 });
 
       const stats = traversal.cacheStats();
       expect(stats.hits).toBe(1);
       expect(stats.misses).toBe(1);
+      expect(stats.hitRate).toBe(0.5);
     });
 
     it('invalidateTier clears tier-specific entries', async () => {

--- a/upgrades/eli16/self-knowledge-cache-rate-unmeasured.md
+++ b/upgrades/eli16/self-knowledge-cache-rate-unmeasured.md
@@ -1,0 +1,20 @@
+# Self-knowledge cache rates now require a cache lookup
+
+The self-knowledge tree caches source content so repeated searches can avoid
+reading the same source again. Its cache hit rate is the number of hits divided
+by all hits and misses.
+
+Previously, the cache reported zero percent before any lookup. A search that
+could not even load the tree returned the same value. Those states were
+indistinguishable from a real first lookup that missed the cache, even though
+only the real miss has a denominator.
+
+The cache rate is now null until a hit or miss occurs. A real first miss still
+reports numeric zero, and one hit plus one miss still reports one-half. A
+degraded search with no loaded tree also reports null. The validation route and
+search response pass that value through; caching, lookup, invalidation, and
+source gathering behavior are unchanged.
+
+The tests enter all three states. Restoring the old zero fallbacks makes the two
+no-evidence assertions fail directly, while the measured zero and one-half
+assertions remain numeric.

--- a/upgrades/next/self-knowledge-cache-rate-unmeasured.md
+++ b/upgrades/next/self-knowledge-cache-rate-unmeasured.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Self-knowledge traversal cache statistics now return a null hit rate before any
+cache lookup has occurred. A degraded search that cannot load a tree also
+returns a null cache hit rate, while a real first miss remains numeric zero.
+
+## What to Tell Your User
+
+A fresh or unavailable self-knowledge tree no longer looks like it measured a
+zero-percent cache hit rate.
+
+## Summary of New Capabilities
+
+- Explicit unmeasured state for traversal cache statistics.
+- Measured zero remains distinct for a real cache miss.
+
+## Evidence
+
+- Tests pin empty, first-miss, and mixed hit/miss states.
+- Restoring both zero fallbacks makes two empty-state regressions fail.
+- Twenty-seven focused tests and full repository lint pass.

--- a/upgrades/side-effects/self-knowledge-cache-rate-unmeasured.md
+++ b/upgrades/side-effects/self-knowledge-cache-rate-unmeasured.md
@@ -1,0 +1,92 @@
+# Side-Effects Review — Self-knowledge cache rate unmeasured state
+
+**Version / slug:** `self-knowledge-cache-rate-unmeasured`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`TreeTraversal.cacheStats()` now returns a null hit rate before any hit or miss,
+and `SelfKnowledgeTree` returns null when a search cannot load a tree. A real
+cache miss remains numeric zero.
+
+## Decision-point inventory
+
+- Cache-stat evidence sufficiency — modified — a rate requires a hit or miss.
+- Traversal, source gathering, and cache invalidation — passed through
+  unchanged.
+
+## 1. Over-block
+
+No operation is blocked. These values are returned by read surfaces.
+
+## 2. Under-block
+
+No error handling changes. A missing tree still returns the existing degraded
+result and source error; only its unmeasured rate changes.
+
+## 3. Level-of-abstraction fit
+
+`TreeTraversal` owns the hit and miss counters and therefore owns denominator
+sufficiency. `SelfKnowledgeTree` owns the pre-traversal failure result.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — the changed values are read-only observability.
+
+No search admission, cache policy, or validation decision reads the rate.
+
+## 4b. Judgment-point check
+
+No heuristic is added. Null applies only when both cache counters are zero.
+
+## 5. Interactions
+
+- **Shadowing:** null replaces only no-lookup zero fallbacks.
+- **Double-fire:** no events or notices are emitted.
+- **Races:** cache counters and map access are unchanged.
+- **Feedback loops:** the rate does not control cache behavior.
+
+## 6. External surfaces
+
+Self-knowledge search results and validation cache stats can now return null for
+their cache hit rate when no lookup occurred. Measured values retain the same
+zero-to-one scale.
+
+## 6b. Operator-surface quality
+
+The response carries hit and miss counts beside cache stats, and degraded search
+results retain their error, so null has an explicit reason.
+
+## 7. Multi-machine posture
+
+Unchanged. The traversal cache remains process-local.
+
+## 8. Rollback cost
+
+Pure code rollback. No cache or tree data migration is involved.
+
+## Conclusion
+
+Clear to ship as a bounded read-surface correction.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; no action, authority, gate,
+sentinel, lifecycle, or persistence behavior changes.
+
+## Evidence pointers
+
+- `tests/unit/TreeTraversal.test.ts`
+- `tests/unit/SelfKnowledgeTree.test.ts`
+- Twenty-seven focused tests pass.
+- Mutation proof: restoring both zero fallbacks produces two direct failures.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Self-knowledge traversal cache stats now return a null hit rate before the first cache lookup. A degraded search that cannot load a tree also returns null, while a real first cache miss remains measured zero and one hit plus one miss remains one-half.

The root cause was two zero fallbacks that collapsed “no cache lookup occurred” into “lookups occurred and none hit.” The value is exposed by both self-knowledge search results and the validation route.

## Validation

- 27 focused tree and traversal tests pass.
- Pre-push affected smoke tier: 147 tests pass, with 6 intentional skips.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring both zero fallbacks fails the fresh-cache and missing-tree regressions with `expected 0 to be null`.
- Tests separately pin a real first miss at numeric zero and one hit plus one miss at 0.5.

## ELI16

A cache hit rate asks, “Of all the lookups we tried, how many found an existing cached value?” Before the first lookup, there is nothing to divide by. Reporting zero percent makes that untouched cache look identical to a cache that was tried and missed. This change keeps the untouched state unknown. A real first miss still reports zero percent, and later hits change the measured rate normally. A failed search that never loaded a tree also stays unknown rather than pretending it tested the cache.

## UX Impact

Who sees it: operators reading self-knowledge search results or validation cache stats. What changes at first contact: before any lookup, `"hitRate": null` replaces a synthetic zero; a missing-tree search likewise returns an unknown cache hit rate beside its existing degraded error. Measured output is unchanged.
