### PR TITLE
Keep empty semantic confidence unmeasured

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T11-55-34-499Z-semantic-confidence-unmeasured.json
+++ b/.instar/instar-dev-decisions/2026-07-29T11-55-34-499Z-semantic-confidence-unmeasured.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-07-29T11:55:34.499Z",
+  "slug": "semantic-confidence-unmeasured",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 24,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/semantic.ts",
+      "src/core/types.ts",
+      "src/memory/SemanticMemory.ts"
+    ],
+    "addedLines": 13,
+    "deletedLines": 11
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/semantic.ts
+++ b/src/commands/semantic.ts
@@ -154,7 +154,7 @@ export async function semanticStats(opts: SemanticOptions): Promise<void> {
     console.log(pc.bold('\n  Semantic Memory\n'));
     console.log(`  Entities:     ${stats.totalEntities}`);
     console.log(`  Edges:        ${stats.totalEdges}`);
-    console.log(`  Avg conf:     ${(stats.avgConfidence * 100).toFixed(1)}%`);
+    console.log(`  Avg conf:     ${stats.avgConfidence == null ? pc.dim('n/a') : `${(stats.avgConfidence * 100).toFixed(1)}%`}`);
     console.log(`  Stale:        ${stats.staleCount > 0 ? pc.yellow(String(stats.staleCount)) : pc.dim('0')}`);
     console.log(`  DB size:      ${formatBytes(stats.dbSizeBytes)}`);
 
@@ -210,9 +210,11 @@ export async function semanticDecay(opts: SemanticOptions): Promise<void> {
     console.log(`  Processed:  ${report.entitiesProcessed}`);
     console.log(`  Decayed:    ${report.entitiesDecayed}`);
     console.log(`  Expired:    ${report.entitiesExpired}`);
-    if (report.entitiesProcessed > 0) {
+    if (report.avgConfidence != null && report.minConfidence != null && report.maxConfidence != null) {
       console.log(`  Confidence: ${(report.minConfidence * 100).toFixed(1)}% - ${(report.maxConfidence * 100).toFixed(1)}%`);
       console.log(`  Average:    ${(report.avgConfidence * 100).toFixed(1)}%`);
+    } else if (report.entitiesProcessed > 0) {
+      console.log(`  Confidence: ${pc.dim('n/a (no active entities)')}`);
     }
     console.log();
   } catch (err) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7566,9 +7566,9 @@ export interface DecayReport {
   entitiesProcessed: number;
   entitiesDecayed: number;
   entitiesExpired: number;
-  minConfidence: number;
-  maxConfidence: number;
-  avgConfidence: number;
+  minConfidence: number | null;
+  maxConfidence: number | null;
+  avgConfidence: number | null;
 }
 
 /**
@@ -7588,7 +7588,7 @@ export interface SemanticMemoryStats {
   totalEntities: number;
   totalEdges: number;
   entityCountsByType: Record<EntityType, number>;
-  avgConfidence: number;
+  avgConfidence: number | null;
   staleCount: number;
   dbSizeBytes: number;
   /** Whether vector search (sqlite-vec) is active */

--- a/src/memory/SemanticMemory.ts
+++ b/src/memory/SemanticMemory.ts
@@ -1895,9 +1895,9 @@ export class SemanticMemory {
       entitiesProcessed: rows.length,
       entitiesDecayed: decayed,
       entitiesExpired: expired,
-      minConfidence: activeCount > 0 ? minConf : 0,
-      maxConfidence: activeCount > 0 ? maxConf : 0,
-      avgConfidence: activeCount > 0 ? sumConf / activeCount : 0,
+      minConfidence: activeCount > 0 ? minConf : null,
+      maxConfidence: activeCount > 0 ? maxConf : null,
+      avgConfidence: activeCount > 0 ? sumConf / activeCount : null,
     };
   }
 
@@ -2319,7 +2319,7 @@ export class SemanticMemory {
 
     // Avg confidence
     const avgRow = db.prepare('SELECT AVG(confidence) as avg FROM entities').get() as { avg: number | null };
-    const avgConfidence = avgRow.avg ?? 0;
+    const avgConfidence = avgRow.avg;
 
     // Stale count
     const staleCount = (db.prepare('SELECT COUNT(*) as cnt FROM entities WHERE confidence < ?').get(this.config.staleThreshold) as { cnt: number }).cnt;
@@ -2345,7 +2345,7 @@ export class SemanticMemory {
       totalEntities: entityCount,
       totalEdges: edgeCount,
       entityCountsByType: entityCountsByType as Record<EntityType, number>,
-      avgConfidence: Math.round(avgConfidence * 100) / 100, // Round to 2 decimal places
+      avgConfidence: avgConfidence == null ? null : Math.round(avgConfidence * 100) / 100, // Round to 2 decimal places
       staleCount,
       dbSizeBytes,
       vectorSearchAvailable: this._vectorAvailable,

--- a/tests/unit/semantic-memory.test.ts
+++ b/tests/unit/semantic-memory.test.ts
@@ -479,6 +479,35 @@ describe('SemanticMemory', () => {
   // ─── Confidence Decay ──────────────────────────────────────────
 
   describe('confidence decay', () => {
+    it('keeps confidence statistics unmeasured with no active entities', () => {
+      const report = setup.memory.decayAll();
+      expect(report.entitiesProcessed).toBe(0);
+      expect(report.entitiesExpired).toBe(0);
+      expect(report.minConfidence).toBeNull();
+      expect(report.maxConfidence).toBeNull();
+      expect(report.avgConfidence).toBeNull();
+    });
+
+    it('keeps confidence statistics unmeasured when every processed entity expires', () => {
+      setup.memory.remember({
+        type: 'fact',
+        name: 'Expired fact',
+        content: 'No longer active',
+        confidence: 0.9,
+        lastVerified: new Date().toISOString(),
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        source: 'test',
+        tags: [],
+      });
+
+      const report = setup.memory.decayAll();
+      expect(report.entitiesProcessed).toBe(1);
+      expect(report.entitiesExpired).toBe(1);
+      expect(report.minConfidence).toBeNull();
+      expect(report.maxConfidence).toBeNull();
+      expect(report.avgConfidence).toBeNull();
+    });
+
     it('reduces confidence of unverified entities', () => {
       const id = setup.memory.remember({
         type: 'fact',
@@ -912,11 +941,11 @@ describe('SemanticMemory', () => {
       expect(stats.dbSizeBytes).toBeGreaterThan(0);
     });
 
-    it('returns zeroes for empty database', () => {
+    it('keeps average confidence unmeasured for an empty database', () => {
       const stats = setup.memory.stats();
       expect(stats.totalEntities).toBe(0);
       expect(stats.totalEdges).toBe(0);
-      expect(stats.avgConfidence).toBe(0);
+      expect(stats.avgConfidence).toBeNull();
     });
   });
 

--- a/upgrades/eli16/semantic-confidence-unmeasured.md
+++ b/upgrades/eli16/semantic-confidence-unmeasured.md
@@ -1,0 +1,19 @@
+# Empty semantic memory no longer has a zero-percent confidence
+
+Semantic memory stores facts, lessons, and other entities with confidence
+scores. Its statistics show the average confidence, while the decay command
+shows the minimum, maximum, and average after aging or expiring entries.
+
+Previously, an empty store reported a zero-percent average. A decay run that
+processed entries but expired all of them reported zero for all three
+confidence values. Those numbers look like measurements of very low-quality
+knowledge, even though no active entity remained to measure.
+
+The statistics now return null when the store is empty. Decay reports return
+null confidence values when their active-entity denominator is empty, whether
+the run started empty or removed every expired entry. The CLI prints “n/a” and,
+for the all-expired case, names that no active entities remain. Counts, expiry,
+decay, search, and storage behavior are unchanged.
+
+The tests deliberately enter both empty shapes and retain the existing measured
+average case. Restoring the zero fallbacks makes all three new assertions fail.

--- a/upgrades/next/semantic-confidence-unmeasured.md
+++ b/upgrades/next/semantic-confidence-unmeasured.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Semantic-memory statistics now return a null average confidence for an empty
+store. Confidence-decay reports also return null minimum, maximum, and average
+values when no active entities remain, including after every processed entity
+expires. CLI output renders those states as unavailable.
+
+## What to Tell Your User
+
+An empty semantic-memory store no longer looks like its knowledge has a measured
+zero-percent confidence.
+
+## Summary of New Capabilities
+
+- Explicit unmeasured confidence statistics for empty memory.
+- Honest decay reporting when a run leaves no active entities.
+
+## Evidence
+
+- Tests cover empty stores, all-expired runs, and measured confidence.
+- Restoring the zero fallbacks produces three direct failures.
+- Fifty-one focused tests and full repository lint pass.

--- a/upgrades/side-effects/semantic-confidence-unmeasured.md
+++ b/upgrades/side-effects/semantic-confidence-unmeasured.md
@@ -1,0 +1,93 @@
+# Side-Effects Review — Semantic confidence unmeasured state
+
+**Version / slug:** `semantic-confidence-unmeasured`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Semantic-memory store statistics and confidence-decay reports now use null
+confidence values when no active entity supplies a denominator. CLI output
+renders those states as “n/a.”
+
+## Decision-point inventory
+
+- Aggregate-confidence evidence sufficiency — modified — confidence summaries
+  require at least one active entity.
+- Decay and hard expiry — passed through unchanged.
+- Search, recall, and persistence — passed through unchanged.
+
+## 1. Over-block
+
+No operation is blocked. The changed values are statistics and command output.
+
+## 2. Under-block
+
+Expiry and decay still run exactly as before. An all-expired report retains its
+processed and expired counts while declining to fabricate confidence values.
+
+## 3. Level-of-abstraction fit
+
+`SemanticMemory` owns both the SQL aggregate and active-entity count, so it owns
+the nullable values. The semantic command owns plain-language formatting.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — the changed values are read-only observability.
+
+No admission, expiry, search, or retention decision consumes these aggregates.
+
+## 4b. Judgment-point check
+
+No heuristic is added. Null applies only when the aggregate has no active row.
+
+## 5. Interactions
+
+- **Shadowing:** null replaces only empty/all-expired zero defaults.
+- **Double-fire:** no events or notices are emitted.
+- **Races:** transactions and SQL reads are unchanged.
+- **Feedback loops:** the aggregates do not control confidence updates.
+
+## 6. External surfaces
+
+`GET /semantic/stats` can now return `avgConfidence: null` for an empty store.
+`semantic stats` prints “Avg conf: n/a.” An all-expired decay run prints
+“Confidence: n/a (no active entities).” Measured numeric values are unchanged.
+
+## 6b. Operator-surface quality
+
+Entity and expiry counts remain beside the nullable values, so the absence is
+explainable from the same output.
+
+## 7. Multi-machine posture
+
+Unchanged. Semantic-memory database ownership and synchronization behavior are
+not modified.
+
+## 8. Rollback cost
+
+Pure code rollback. No database schema or stored entity changes.
+
+## Conclusion
+
+Clear to ship as a bounded observability correction.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; no action, authority, gate,
+sentinel, lifecycle, or persistence behavior changes.
+
+## Evidence pointers
+
+- `tests/unit/semantic-memory.test.ts`
+- Fifty-one focused tests pass.
+- Mutation proof: restoring the zero fallbacks produces three direct failures.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Semantic-memory statistics now return `avgConfidence: null` for an empty store. Confidence-decay reports also return null minimum, maximum, and average confidence when no active entities remain, including when every processed entity expires. CLI output renders those states as `n/a`.

The root cause appeared in two forms: the decay report used explicit zero fallbacks, while SQL `AVG(...)` was followed by `?? 0`, so the latter escaped the original ternary grep despite producing the same fabricated measurement. Entity counts, expiry, decay, search, and persistence behavior are unchanged.

## Validation

- 51 focused semantic-memory tests pass.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring the zero fallbacks fails three regressions—empty store stats, empty decay, and an all-expired decay run.
- The existing measured two-entity average remains numeric at 0.7.
- The ternary sweep loses the decay candidate, and the related nullish-coalescing instance is closed with it.

## ELI16

Semantic memory assigns confidence scores to active facts and lessons. An average only makes sense when at least one active item exists. Previously, an empty store printed a zero-percent average, which looks like the system measured very poor knowledge. A decay run that expired every item did the same for its minimum, maximum, and average. This change reports those values as unknown and keeps the counts that explain why. Once active items exist, the same numeric calculations are used as before.

## UX Impact

Who sees it: operators reading semantic-memory stats or running the semantic CLI. What changes at first contact: an empty store prints `"Avg conf:     n/a"`, and an all-expired decay report prints `"Confidence: n/a (no active entities)"`, instead of synthetic zero-percent values. Measured stores are unchanged.
