### PR TITLE
Keep empty trust-elevation rates unmeasured

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T12-02-21-656Z-trust-elevation-rates-unmeasured.json
+++ b/.instar/instar-dev-decisions/2026-07-29T12-02-21-656Z-trust-elevation-rates-unmeasured.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-29T12:02:21.656Z",
+  "slug": "trust-elevation-rates-unmeasured",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 19,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/TrustElevationTracker.ts"
+    ],
+    "addedLines": 11,
+    "deletedLines": 8
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/core/TrustElevationTracker.ts
+++ b/src/core/TrustElevationTracker.ts
@@ -58,10 +58,10 @@ export interface EvolutionAcceptanceStats {
   rejected: number;
   /** Number approved without modification */
   approvedUnmodified: number;
-  /** Acceptance rate (0-1) */
-  acceptanceRate: number;
-  /** Rolling window (last N proposals) acceptance rate */
-  recentAcceptanceRate: number;
+  /** Acceptance rate (0-1), or null before any proposal is decided */
+  acceptanceRate: number | null;
+  /** Rolling window (last N proposals) acceptance rate, or null when empty */
+  recentAcceptanceRate: number | null;
   /** Rolling window size */
   recentWindowSize: number;
 }
@@ -179,8 +179,8 @@ export class TrustElevationTracker {
       approved: approved.length,
       rejected: rejected.length,
       approvedUnmodified: approvedUnmodified.length,
-      acceptanceRate: events.length > 0 ? approved.length / events.length : 0,
-      recentAcceptanceRate: recentEvents.length > 0 ? recentApproved.length / recentEvents.length : 0,
+      acceptanceRate: events.length > 0 ? approved.length / events.length : null,
+      recentAcceptanceRate: recentEvents.length > 0 ? recentApproved.length / recentEvents.length : null,
       recentWindowSize: windowSize,
     };
   }
@@ -247,6 +247,7 @@ export class TrustElevationTracker {
     const threshold = this.config.acceptanceRateThreshold ?? 0.85;
 
     if (stats.totalDecided < minProposals) return null;
+    if (stats.recentAcceptanceRate == null) return null;
     if (stats.recentAcceptanceRate < threshold) return null;
 
     // Check if this opportunity already exists and is dismissed
@@ -279,7 +280,9 @@ export class TrustElevationTracker {
     if (currentProfile === 'autonomous') return null;
 
     const stats = this.getAcceptanceStats();
-    const hasGoodAcceptance = stats.totalDecided >= 10 && stats.recentAcceptanceRate >= 0.8;
+    const hasGoodAcceptance = stats.totalDecided >= 10
+      && stats.recentAcceptanceRate != null
+      && stats.recentAcceptanceRate >= 0.8;
     const hasOperationTrust = operationElevations.length >= 2;
 
     if (!hasGoodAcceptance && !hasOperationTrust) return null;
@@ -296,7 +299,7 @@ export class TrustElevationTracker {
     }
 
     const reasons: string[] = [];
-    if (hasGoodAcceptance) {
+    if (hasGoodAcceptance && stats.recentAcceptanceRate != null) {
       reasons.push(`${(stats.recentAcceptanceRate * 100).toFixed(0)}% evolution acceptance rate`);
     }
     if (hasOperationTrust) {

--- a/tests/unit/TrustElevationTracker.test.ts
+++ b/tests/unit/TrustElevationTracker.test.ts
@@ -42,7 +42,10 @@ describe('TrustElevationTracker', () => {
       const stats = tracker.getAcceptanceStats();
       expect(stats.totalDecided).toBe(0);
       expect(stats.approved).toBe(0);
-      expect(stats.acceptanceRate).toBe(0);
+      expect(stats.acceptanceRate).toBeNull();
+      expect(stats.recentAcceptanceRate).toBeNull();
+      expect(tracker.checkEvolutionGovernanceElevation('ai-assisted')).toBeNull();
+      expect(tracker.checkProfileElevation('supervised', [])).toBeNull();
     });
 
     it('loads persisted state', () => {

--- a/upgrades/eli16/trust-elevation-rates-unmeasured.md
+++ b/upgrades/eli16/trust-elevation-rates-unmeasured.md
@@ -1,0 +1,21 @@
+# Empty evolution history no longer reports zero-percent acceptance
+
+The trust-elevation system tracks how often evolution proposals are approved.
+It may suggest more autonomy only after enough decisions and a high recent
+acceptance rate.
+
+Previously, a fresh history with no approved or rejected proposals reported
+zero-percent acceptance. That number looked like every proposal was rejected,
+even though no decision existed. The minimum-count gate already prevented this
+empty value from granting authority, but the API still presented it as a real
+measurement.
+
+The overall and recent rates are now null until at least one non-deferred
+proposal is decided. The elevation paths explicitly return no opportunity when
+the recent rate is unmeasured, in addition to retaining their existing minimum
+decision requirements. Once decisions exist, the same ratios and thresholds
+apply.
+
+The regression asserts both halves together: empty rates are null, and neither
+governance nor profile elevation is suggested. Restoring the old zero fallback
+fails the metric assertion without changing the no-elevation proof.

--- a/upgrades/next/trust-elevation-rates-unmeasured.md
+++ b/upgrades/next/trust-elevation-rates-unmeasured.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Trust-elevation acceptance statistics now return null overall and recent rates
+before any proposal is decided. The existing minimum-decision gates remain in
+place and explicitly reject the unmeasured state before suggesting an autonomy
+or profile elevation.
+
+## What to Tell Your User
+
+A fresh evolution history no longer looks like it has a measured zero-percent
+acceptance rate, and it still cannot authorize any trust elevation.
+
+## Summary of New Capabilities
+
+- Explicit unmeasured state for empty evolution acceptance history.
+- Pinned no-elevation behavior for that state.
+
+## Evidence
+
+- Unit, integration, and end-to-end trust-elevation tests pass.
+- Restoring the zero fallback fails the empty-history regression.
+- Seventy-four focused tests and full repository lint pass.

--- a/upgrades/side-effects/trust-elevation-rates-unmeasured.md
+++ b/upgrades/side-effects/trust-elevation-rates-unmeasured.md
@@ -1,0 +1,98 @@
+# Side-Effects Review — Trust-elevation rates unmeasured state
+
+**Version / slug:** `trust-elevation-rates-unmeasured`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`TrustElevationTracker.getAcceptanceStats()` now returns null rates when no
+non-deferred proposal has been decided. Elevation checks explicitly reject a
+null recent rate and retain their existing minimum-count requirements.
+
+## Decision-point inventory
+
+- Acceptance-stat evidence sufficiency — modified — a rate requires a decided
+  proposal.
+- Evolution-governance elevation — preserved — minimum count plus measured
+  threshold remains required.
+- Profile elevation — preserved — either measured count-gated acceptance or
+  independent operation-trust evidence remains required.
+
+## 1. Over-block
+
+No previously eligible measured history is blocked. The new null guard is
+reachable only when the decision denominator is empty, which was already below
+the minimum count.
+
+## 2. Under-block
+
+An empty history still produces no elevation opportunity. Tests pin both
+governance and profile paths in the same state as the nullable rates.
+
+## 3. Level-of-abstraction fit
+
+`TrustElevationTracker` owns the decision history, statistics, and count-gated
+consumers, so it can change the contract without leaving an unsafe downstream
+interpretation.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Yes — the rates inform an authority suggestion, but only after a
+  deterministic minimum-count gate and a measured threshold.
+
+This change makes the signal less authoritative in the absence state. It does
+not grant or broaden any operation.
+
+## 4b. Judgment-point check
+
+No heuristic changes. Existing thresholds and decision floors are unchanged.
+
+## 5. Interactions
+
+- **Shadowing:** null replaces only empty-history zeros.
+- **Double-fire:** no opportunities are created from the empty state.
+- **Races:** state persistence and event recording are unchanged.
+- **Feedback loops:** measured acceptance still follows the existing evaluator.
+
+## 6. External surfaces
+
+The acceptance API and status payload can now return null overall and recent
+rates when `totalDecided` is zero. Measured values retain the same scale.
+
+## 6b. Operator-surface quality
+
+`totalDecided: 0` remains beside both null rates, so their reason is explicit.
+
+## 7. Multi-machine posture
+
+Unchanged. State ownership and synchronization are not modified.
+
+## 8. Rollback cost
+
+Pure code rollback. No stored events or schemas change.
+
+## Conclusion
+
+Clear to ship as a bounded observability correction with authority preservation
+proved in the same regression.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; the change reduces the
+authority signal in an already count-blocked state and adds an explicit refusal.
+
+## Evidence pointers
+
+- `tests/unit/TrustElevationTracker.test.ts`
+- Seventy-four focused unit, integration, and end-to-end tests pass.
+- Mutation proof: restoring the zero fallback produces a direct failure.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Trust-elevation acceptance stats now return null overall and recent rates when no non-deferred proposal has been decided. The existing minimum-decision gates remain intact, and elevation consumers explicitly reject an unmeasured recent rate.

The root cause was two empty-denominator fallbacks that made a fresh evolution history look like it had a measured zero-percent acceptance rate. The authority path was already count-gated; this change pins that safety property in the same regression rather than relying on ordering by inspection.

## Validation

- 74 focused unit, integration, and end-to-end tests pass.
- Pre-push affected smoke tier: 12 files / 153 tests pass.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring the zero fallbacks fails the empty-history rate assertion.
- The empty-state test also requires both governance and profile elevation checks to return no opportunity.

## ELI16

An acceptance rate asks how many decided proposals were approved. Before any proposal is approved or rejected, zero percent falsely suggests every proposal failed. The API now reports that rate as unknown. More importantly, this statistic can help suggest additional autonomy, so the test also proves an empty history still cannot produce either kind of elevation. Once enough decisions exist, the same ratios, minimum counts, and thresholds are used as before.

## UX Impact

Who sees it: operators reading evolution acceptance or autonomy status. What changes at first contact: with `"totalDecided": 0`, both `"acceptanceRate": null` and `"recentAcceptanceRate": null` replace synthetic zeros. No trust elevation is suggested from that state; measured histories are unchanged.
