### PR TITLE
Keep empty intent conflict rates unmeasured

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T12-08-21-802Z-intent-conflict-rate-unmeasured.json
+++ b/.instar/instar-dev-decisions/2026-07-29T12-08-21-802Z-intent-conflict-rate-unmeasured.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-07-29T12:08:21.802Z",
+  "slug": "intent-conflict-rate-unmeasured",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 13,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/intent.ts",
+      "src/core/IntentDriftDetector.ts"
+    ],
+    "addedLines": 7,
+    "deletedLines": 6
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/intent.ts
+++ b/src/commands/intent.ts
@@ -455,7 +455,8 @@ export async function intentDrift(options: IntentDriftOptions): Promise<void> {
   console.log();
 }
 
-function formatPercent(rate: number): string {
+function formatPercent(rate: number | null): string {
+  if (rate == null) return pc.dim('n/a');
   const pct = (rate * 100).toFixed(1) + '%';
   if (rate > 0.1) return pc.red(pct);
   if (rate > 0) return pc.yellow(pct);

--- a/src/core/IntentDriftDetector.ts
+++ b/src/core/IntentDriftDetector.ts
@@ -30,8 +30,8 @@ export interface DriftWindow {
   to: string;
   /** Number of decisions in this window */
   decisionCount: number;
-  /** Conflict rate (0-1) */
-  conflictRate: number;
+  /** Conflict rate (0-1), or null when the window has no decisions */
+  conflictRate: number | null;
   /** Top principles used */
   topPrinciples: Array<{ principle: string; count: number }>;
   /** Average numeric confidence, or null when the window cannot be measured completely. */
@@ -254,7 +254,7 @@ export class IntentDriftDetector {
     const decisionCount = entries.length;
 
     const conflictCount = entries.filter(e => e.conflict).length;
-    const conflictRate = decisionCount > 0 ? conflictCount / decisionCount : 0;
+    const conflictRate = decisionCount > 0 ? conflictCount / decisionCount : null;
 
     // Top principles
     const principleCounts: Record<string, number> = {};
@@ -325,7 +325,7 @@ export class IntentDriftDetector {
     const signals: DriftSignal[] = [];
 
     // 1. Conflict spike
-    if (previous.conflictRate > 0) {
+    if (current.conflictRate != null && previous.conflictRate != null && previous.conflictRate > 0) {
       const ratio = current.conflictRate / previous.conflictRate;
       if (ratio > 3) {
         signals.push({
@@ -342,7 +342,7 @@ export class IntentDriftDetector {
           delta: current.conflictRate - previous.conflictRate,
         });
       }
-    } else if (current.conflictRate > 0) {
+    } else if (current.conflictRate != null && previous.conflictRate === 0 && current.conflictRate > 0) {
       // Previous had zero conflicts, current has some — treat as a spike
       signals.push({
         type: 'conflict_spike',

--- a/tests/unit/IntentDriftDetector.test.ts
+++ b/tests/unit/IntentDriftDetector.test.ts
@@ -55,6 +55,7 @@ describe('IntentDriftDetector', () => {
       const result = detector.analyze();
 
       expect(result.current.decisionCount).toBe(0);
+      expect(result.current.conflictRate).toBeNull();
       expect(result.previous).toBeNull();
       expect(result.signals).toEqual([]);
       expect(result.driftScore).toBe(0);
@@ -77,6 +78,25 @@ describe('IntentDriftDetector', () => {
       expect(result.current.topPrinciples[0].principle).toBe('safety');
       expect(result.previous).toBeNull();
       expect(result.signals).toEqual([]);
+    });
+
+    it('does not compare conflicts when the current window has no decisions', () => {
+      writeJournal(stateDir, [
+        {
+          timestamp: daysAgo(20),
+          decision: 'Previous conflict',
+          conflict: true,
+          principle: 'safety',
+          confidence: 0.8,
+        },
+      ]);
+
+      const result = detector.analyze(14);
+      expect(result.current.decisionCount).toBe(0);
+      expect(result.current.conflictRate).toBeNull();
+      expect(result.previous?.decisionCount).toBe(1);
+      expect(result.previous?.conflictRate).toBe(1);
+      expect(result.signals.some(signal => signal.type === 'conflict_spike')).toBe(false);
     });
 
     it('detects conflict spike — warning threshold (>2x)', () => {

--- a/upgrades/eli16/intent-conflict-rate-unmeasured.md
+++ b/upgrades/eli16/intent-conflict-rate-unmeasured.md
@@ -1,0 +1,19 @@
+# Empty intent windows no longer look conflict-free
+
+Intent drift compares recent decisions with an earlier window. One metric is
+the share of decisions that recorded a conflict.
+
+Previously, a window with no decisions reported a zero-percent conflict rate.
+That looks like a measured conflict-free period even though there was nothing
+to inspect. A previous window could contain real decisions while the current
+window was empty, leaving a real rate beside a fabricated zero.
+
+The conflict rate is now null whenever the window's decision count is zero.
+Conflict-spike detection compares the two windows only when both rates are
+measured. The command-line formatter can render the absent rate as “n/a.” Real
+zero-percent windows—decisions exist and none record a conflict—remain numeric
+and continue to participate in spike detection exactly as before.
+
+Tests cover both a fully empty journal and a previous-only journal. The latter
+also asserts that no conflict-spike signal is invented from the missing current
+window. Restoring the old zero fallback fails both absence assertions.

--- a/upgrades/next/intent-conflict-rate-unmeasured.md
+++ b/upgrades/next/intent-conflict-rate-unmeasured.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Intent-drift windows now return a null conflict rate when they contain no
+decisions. Conflict-spike detection compares rates only when both windows are
+measured, and CLI formatting renders an unmeasured rate as unavailable.
+
+## What to Tell Your User
+
+An empty decision window no longer looks like it measured a perfect
+zero-percent conflict rate.
+
+## Summary of New Capabilities
+
+- Explicit unmeasured conflict rate for empty intent windows.
+- Pinned no-comparison behavior when either window lacks decisions.
+
+## Evidence
+
+- Tests cover fully empty and previous-only journal shapes.
+- Restoring the zero fallback produces two direct failures.
+- Twenty focused tests and full repository lint pass.

--- a/upgrades/side-effects/intent-conflict-rate-unmeasured.md
+++ b/upgrades/side-effects/intent-conflict-rate-unmeasured.md
@@ -1,0 +1,95 @@
+# Side-Effects Review — Intent conflict rate unmeasured state
+
+**Version / slug:** `intent-conflict-rate-unmeasured`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Intent-drift windows now use null conflict rates when they have no decisions.
+Conflict-spike detection requires both windows to have measured rates.
+
+## Decision-point inventory
+
+- Conflict-rate evidence sufficiency — modified — a rate requires a decision.
+- Conflict-spike signal — preserved — comparisons require two measured rates.
+- Confidence, principle, volume, and alignment signals — passed through
+  unchanged.
+
+## 1. Over-block
+
+No action is blocked. The detector emits advisory signals and the change
+suppresses only a comparison against an empty window.
+
+## 2. Under-block
+
+Real zero-conflict windows remain numeric zero. A current measured nonzero rate
+after a previous measured zero still emits the existing spike signal.
+
+## 3. Level-of-abstraction fit
+
+`IntentDriftDetector` owns window construction and signal comparison, so it can
+carry evidence sufficiency through both producer and consumer. The CLI owns
+formatting.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Yes — conflict spikes are advisory signals, not blocking authority.
+
+The change prevents a fabricated absence value from participating in signal
+generation.
+
+## 4b. Judgment-point check
+
+No thresholds or severity judgments change. Only denominator sufficiency is
+added.
+
+## 5. Interactions
+
+- **Shadowing:** null replaces only empty-window zeros.
+- **Double-fire:** previous-only windows are explicitly tested not to emit a
+  conflict spike.
+- **Races:** journal reads and time-window selection are unchanged.
+- **Feedback loops:** no action consumes the signal automatically.
+
+## 6. External surfaces
+
+Intent-drift analysis can now return `conflictRate: null` for an empty current
+window. Measured values retain the same zero-to-one scale.
+
+## 6b. Operator-surface quality
+
+`decisionCount: 0` appears beside the null rate, and CLI formatting supports
+“n/a.”
+
+## 7. Multi-machine posture
+
+Unchanged. The detector reads the same local journal and windows.
+
+## 8. Rollback cost
+
+Pure code rollback. No journal or schema changes.
+
+## Conclusion
+
+Clear to ship as a bounded signal-truthfulness correction.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; signal thresholds,
+authority, action, persistence, and lifecycle behavior are unchanged.
+
+## Evidence pointers
+
+- `tests/unit/IntentDriftDetector.test.ts`
+- Twenty focused tests pass.
+- Mutation proof: restoring the zero fallback produces two direct failures.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Intent-drift windows now return `conflictRate: null` when they contain zero decisions. Conflict-spike detection compares rates only when both windows are measured, and CLI formatting supports `n/a`.

The root cause was an empty-denominator fallback that made a decisionless period look perfectly conflict-free. A previous window could contain real decisions while the current window was empty, leaving a real rate beside a fabricated zero.

## Validation

- 20 focused intent-drift tests pass.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring the zero fallback fails both the fully-empty and previous-only regressions.
- The previous-only test also requires that no conflict-spike signal is invented from the unmeasured current window.
- Existing measured conflict-spike thresholds and tests remain unchanged.

## ELI16

Intent drift asks what share of decisions recorded a conflict. If a period has decisions and none conflict, zero percent is a real measurement. If the period has no decisions, there is nothing to divide by, so zero percent falsely makes the period look conflict-free. This change keeps the empty period unknown and only compares two conflict rates when both periods contain decisions. Real zero-percent periods and every existing spike threshold continue to work as before.

## UX Impact

Who sees it: operators reading intent-drift analysis or its CLI output. What changes at first contact: an empty window now carries `"conflictRate": null` beside `"decisionCount": 0`, and formatting renders that as `"n/a"` instead of an ideal-looking zero. Measured windows are unchanged.
