### PR TITLE
Route malformed Linux memory through fallback

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T12-14-57-507Z-linux-memory-unparseable-fallback.json
+++ b/.instar/instar-dev-decisions/2026-07-29T12-14-57-507Z-linux-memory-unparseable-fallback.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-29T12:14:57.507Z",
+  "slug": "linux-memory-unparseable-fallback",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 5,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/monitoring/hostMemoryPressure.ts"
+    ],
+    "addedLines": 4,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/monitoring/hostMemoryPressure.ts
+++ b/src/monitoring/hostMemoryPressure.ts
@@ -70,10 +70,13 @@ export function parseProcMeminfo(content: string): SystemMemoryReading {
     return match ? parseInt(match[1], 10) : 0;
   };
   const totalKB = parseKB('MemTotal');
+  if (totalKB === 0) {
+    throw new Error('/proc/meminfo contained no total memory');
+  }
   const availableKB = parseKB('MemAvailable') || (parseKB('MemFree') + parseKB('Buffers') + parseKB('Cached'));
   const totalGB = totalKB / (1024 * 1024);
   const freeGB = availableKB / (1024 * 1024);
-  const pressurePercent = totalKB > 0 ? ((totalKB - availableKB) / totalKB) * 100 : 0;
+  const pressurePercent = ((totalKB - availableKB) / totalKB) * 100;
   return { pressurePercent, freeGB, totalGB };
 }
 

--- a/tests/unit/host-memory-pressure.test.ts
+++ b/tests/unit/host-memory-pressure.test.ts
@@ -70,6 +70,11 @@ Cached:          2500000 kB
     const r = parseProcMeminfo(content);
     expect(100 - r.pressurePercent).toBeCloseTo(25, 0); // (1M+0.5M+2.5M)/16M
   });
+  it('rejects content with no parseable MemTotal', () => {
+    expect(() => parseProcMeminfo('procfs returned an unexpected format')).toThrow(
+      '/proc/meminfo contained no total memory',
+    );
+  });
 });
 
 describe('readSystemMemoryPressure — platform-aware, never throws', () => {
@@ -95,6 +100,18 @@ describe('readSystemMemoryPressure — platform-aware, never throws', () => {
     const r = readSystemMemoryPressure({
       platform: 'darwin',
       vmStat: () => 'vm_stat returned an unexpected format',
+      memoryUsage: () => ({ rss: 15 * 1024 ** 3 }),
+      totalmem: () => 16 * 1024 ** 3,
+    });
+
+    expect(r.pressurePercent).toBeCloseTo(93.75, 2);
+    expect(r.freeGB).toBeCloseTo(1, 2);
+    expect(r.totalGB).toBe(16);
+  });
+  it('linux: successful but unparseable proc-meminfo uses the RSS fallback', () => {
+    const r = readSystemMemoryPressure({
+      platform: 'linux',
+      procMeminfo: () => 'procfs returned an unexpected format',
       memoryUsage: () => ({ rss: 15 * 1024 ** 3 }),
       totalmem: () => 16 * 1024 ** 3,
     });

--- a/upgrades/eli16/linux-memory-unparseable-fallback.md
+++ b/upgrades/eli16/linux-memory-unparseable-fallback.md
@@ -1,0 +1,19 @@
+# Malformed Linux memory output no longer looks healthy
+
+Instar reads `/proc/meminfo` on Linux to calculate how much of the host's memory
+is under pressure. That calculation needs a total-memory value.
+
+Previously, a successful file read with unexpected or malformed text parsed the
+total as zero and returned zero-percent pressure. The pressure classifier then
+treated the host as normal, even though no memory measurement existed. Read
+errors already had a visible fallback that estimates pressure from process RSS,
+but the successful-yet-unparseable path never reached it.
+
+The Linux parser now rejects content that has no parseable `MemTotal`. The
+existing try/catch logs the degradation and invokes the existing RSS fallback,
+exactly as it does for a failed read. Valid `MemAvailable` and
+`MemFree+Buffers+Cached` calculations are unchanged.
+
+Tests cover the parser boundary and the full reader path. Restoring the old
+zero fallback makes the parser accept garbage and makes the end-to-end reading
+return zero instead of the injected high-pressure fallback.

--- a/upgrades/next/linux-memory-unparseable-fallback.md
+++ b/upgrades/next/linux-memory-unparseable-fallback.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Linux memory parsing now rejects `/proc/meminfo` content with no parseable
+`MemTotal`. The existing logged RSS fallback then supplies the reading instead
+of returning a fabricated zero-percent pressure measurement.
+
+## What to Tell Your User
+
+Malformed Linux memory output no longer makes the host look perfectly healthy;
+the same visible fallback already used for read failures now takes over.
+
+## Summary of New Capabilities
+
+- Parseability validation for Linux total-memory output.
+- Existing conservative fallback reused for successful-but-malformed reads.
+
+## Evidence
+
+- Tests cover direct parser rejection and the real reader-to-fallback path.
+- Restoring the zero fallback produces two direct failures.
+- Twenty-five focused tests and full repository lint pass.

--- a/upgrades/side-effects/linux-memory-unparseable-fallback.md
+++ b/upgrades/side-effects/linux-memory-unparseable-fallback.md
@@ -1,0 +1,96 @@
+# Side-Effects Review — Linux memory unparseable fallback
+
+**Version / slug:** `linux-memory-unparseable-fallback`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`parseProcMeminfo()` now throws when `MemTotal` cannot be parsed. The existing
+`readSystemMemoryPressure()` catch logs the failure and uses its existing RSS
+fallback.
+
+## Decision-point inventory
+
+- Linux memory parseability — modified — total memory is mandatory.
+- Platform reader fallback — reused unchanged.
+- Pressure classification and session reaping — passed through unchanged.
+
+## 1. Over-block
+
+Valid Linux memory output follows the same formulas. Only content that
+previously fabricated a zero denominator enters the existing fallback.
+
+## 2. Under-block
+
+Malformed successful reads no longer bypass fallback. The reader remains
+non-throwing at its public boundary.
+
+## 3. Level-of-abstraction fit
+
+The pure parser is the first layer that knows `MemTotal` is absent. The caller
+already owns logging and fallback, so the parser signals failure without
+duplicating recovery policy.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Yes — memory pressure informs real host-health decisions.
+
+This change replaces an invented normal reading with the author-owned fallback;
+it does not add a threshold or new authority path.
+
+## 4b. Judgment-point check
+
+No heuristic changes. Parseability is deterministic and the fallback formula is
+unchanged.
+
+## 5. Interactions
+
+- **Shadowing:** the malformed path now reaches the existing catch.
+- **Double-fire:** one logged fallback remains the only notice.
+- **Races:** synchronous read behavior is unchanged.
+- **Feedback loops:** downstream pressure consumers receive an existing reading
+  shape.
+
+## 6. External surfaces
+
+Malformed Linux input now logs the existing fallback message and returns the RSS
+estimate rather than `pressurePercent: 0, totalGB: 0`.
+
+## 6b. Operator-surface quality
+
+The fallback is explicitly logged with the parser reason, so the estimated
+reading is not silently presented as primary telemetry.
+
+## 7. Multi-machine posture
+
+Platform-local by design. Other machines and macOS parsing are unchanged.
+
+## 8. Rollback cost
+
+Pure code rollback. No state or schema changes.
+
+## Conclusion
+
+Clear to ship as a bounded parser correction that reuses existing recovery.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; downstream thresholds,
+actions, persistence, and lifecycle behavior are unchanged.
+
+## Evidence pointers
+
+- `tests/unit/host-memory-pressure.test.ts`
+- `tests/unit/session-reaper-pressure-audit.test.ts`
+- Twenty-five focused tests pass.
+- Mutation proof: restoring the zero fallback produces two direct failures.
+- Full repository lint, including TypeScript, passes.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Reject Linux `/proc/meminfo` content that has no parseable `MemTotal`, allowing the existing logged RSS fallback to handle a successful-but-unparseable read. Valid Linux memory calculations and the existing fallback policy are unchanged.

## Validation

- 25 focused memory-pressure and reaper tests pass.
- Pre-push affected smoke suite: 58/58 tests pass.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring the old zero fallback makes both the parser-boundary and end-to-end fallback tests fail.

## ELI16

Instar estimates host memory pressure from `/proc/meminfo` on Linux. Before this change, a file read could succeed while returning malformed text; the parser would then invent a total-memory value of zero and report zero-percent pressure. A downstream classifier treated that fabricated measurement as a healthy machine. The parser now says the input is unusable when total memory is missing, so the reader follows its existing, logged RSS-based fallback. This does not introduce a new policy or threshold. It makes malformed successful reads behave like read failures, while valid memory output keeps the same calculation.

## UX Impact

Operators whose Linux memory source is malformed will now see the existing fallback log with the precise reason `"/proc/meminfo contained no total memory"`, and host-health consumers receive the existing RSS estimate instead of a falsely healthy zero-percent reading.
