### PR TITLE
Preserve unknown degraded-tmux load

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T12-24-16-611Z-tmux-load-denominator.json
+++ b/.instar/instar-dev-decisions/2026-07-29T12-24-16-611Z-tmux-load-denominator.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-07-29T12:24:16.611Z",
+  "slug": "tmux-load-denominator",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 34,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/monitoring/DegradedTmuxGuard.ts"
+    ],
+    "addedLines": 21,
+    "deletedLines": 13
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5883,7 +5883,10 @@ export async function startServer(options: StartOptions): Promise<void> {
     let _degradedTmuxRaise:
       | ((ep: import('../monitoring/DegradedTmuxGuard.js').DegradedTmuxEpisode) => void)
       | null = null;
-    const { DegradedTmuxGuard: _DegradedTmuxGuardCtor } = await import('../monitoring/DegradedTmuxGuard.js');
+    const {
+      DegradedTmuxGuard: _DegradedTmuxGuardCtor,
+      computeLoadPerCore: _computeDegradedTmuxLoadPerCore,
+    } = await import('../monitoring/DegradedTmuxGuard.js');
     // Cache the core count ONCE (stable for the process lifetime) — the guard's loadPerCore
     // provider is called on every (non-settle-window) evaluate() i.e. potentially N+ times per
     // monitor tick, and os.cpus() allocates a per-core array each call (a throughput smell on
@@ -5894,7 +5897,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       { ...config.monitoring?.degradedTmuxGuard, enabled: _degradedTmuxEnabled },
       {
         raiseAttention: (ep) => _degradedTmuxRaise?.(ep),
-        loadPerCore: () => (_degradedTmuxCores > 0 ? os.loadavg()[0] / _degradedTmuxCores : 0),
+        loadPerCore: () => _computeDegradedTmuxLoadPerCore(os.loadavg()[0], _degradedTmuxCores),
         now: () => Date.now(),
       },
     );

--- a/src/monitoring/DegradedTmuxGuard.ts
+++ b/src/monitoring/DegradedTmuxGuard.ts
@@ -71,10 +71,16 @@ export interface DegradedTmuxGuardConfig {
 export interface DegradedTmuxGuardDeps {
   /** Raise ONE deduped agent-health Attention item for an episode. Wrapped in try/catch by the guard. */
   raiseAttention: (ep: DegradedTmuxEpisode) => void;
-  /** Current `loadavg[0]/cores` ratio (the same signal as SleepWakeDetector.maxLoadRatio). */
-  loadPerCore: () => number;
+  /** Current `loadavg[0]/cores` ratio; null when the denominator is unavailable. */
+  loadPerCore: () => number | null;
   /** Optional injectable clock (tests). Default Date.now. */
   now?: () => number;
+}
+
+/** Convert a load sample to a measured per-core ratio without inventing a zero denominator. */
+export function computeLoadPerCore(loadAverage: number, coreCount: number): number | null {
+  if (!Number.isFinite(loadAverage) || !Number.isFinite(coreCount) || coreCount <= 0) return null;
+  return loadAverage / coreCount;
 }
 
 /** Class defaults — absence of a config value falls back to these (runtime fallback, not config). */
@@ -218,17 +224,15 @@ export class DegradedTmuxGuard extends EventEmitter {
     if (durationMs >= this.slowCallThresholdMs) this.slowCallCount += 1;
   }
 
-  /** Current load ratio, defensively (a throw/non-finite ⇒ 0 = not load-gated). */
-  private currentLoadPerCore(): number {
+  /** Current load ratio, defensively; null means the load gate cannot be evaluated. */
+  private currentLoadPerCore(): number | null {
     try {
       const v = this.deps.loadPerCore();
-      return Number.isFinite(v) && v > 0 ? v : 0;
+      return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : null;
     } catch {
-      // @silent-fallback-ok: a load-probe failure defaults to 0 (= not load-gated) so the
-      // signal-only guard never crashes the detector tick; the worst case is one calm,
-      // deduped agent-health Attention item raised under load that would otherwise have been
-      // gated — never a destructive action (the guard NEVER kills the shared socket).
-      return 0;
+      // @silent-fallback-ok: a load-probe failure makes this cycle unassessable, so it cannot
+      // advance corroboration. The signal-only guard still never throws or kills the socket.
+      return null;
     }
   }
 
@@ -247,7 +251,8 @@ export class DegradedTmuxGuard extends EventEmitter {
 
     // (1) Load gate — a busy host slows tmux for reasons unrelated to a sick socket; the
     // incident machine runs 5+ agents. Do NOT advance corroboration while over the threshold.
-    if (this.currentLoadPerCore() > this.loadGateMaxLoadPerCore) {
+    const loadPerCore = this.currentLoadPerCore();
+    if (loadPerCore === null || loadPerCore > this.loadGateMaxLoadPerCore) {
       return;
     }
 

--- a/tests/unit/DegradedTmuxGuard.test.ts
+++ b/tests/unit/DegradedTmuxGuard.test.ts
@@ -14,7 +14,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { DegradedTmuxGuard, type DegradedTmuxEpisode } from '../../src/monitoring/DegradedTmuxGuard.js';
+import {
+  computeLoadPerCore,
+  DegradedTmuxGuard,
+  type DegradedTmuxEpisode,
+} from '../../src/monitoring/DegradedTmuxGuard.js';
 
 function makeClock(start = 1_000_000): { now: () => number; advance: (ms: number) => void } {
   let t = start;
@@ -24,7 +28,7 @@ function makeClock(start = 1_000_000): { now: () => number; advance: (ms: number
 /** A harness: capture raised episodes + drive a controllable load + clock. */
 function makeGuard(
   cfg: Partial<ConstructorParameters<typeof DegradedTmuxGuard>[0]> = {},
-  load = 0,
+  load: number | null = 0,
 ) {
   const clock = makeClock();
   const raised: DegradedTmuxEpisode[] = [];
@@ -47,7 +51,7 @@ function makeGuard(
       now: clock.now,
     },
   );
-  return { guard, raised, clock, setLoad: (v: number) => { loadVal = v; } };
+  return { guard, raised, clock, setLoad: (v: number | null) => { loadVal = v; } };
 }
 
 describe('DegradedTmuxGuard', () => {
@@ -121,6 +125,11 @@ describe('DegradedTmuxGuard', () => {
   });
 
   describe('load gate', () => {
+    it('keeps a real zero-load sample distinct from an unavailable core denominator', () => {
+      expect(computeLoadPerCore(0, 8)).toBe(0);
+      expect(computeLoadPerCore(4, 0)).toBeNull();
+    });
+
     it('high host load suppresses corroboration (busy-box clause)', () => {
       const { guard, raised, setLoad } = makeGuard({ episodeCorroborationCycles: 3 }, 2.0);
       setLoad(2.0); // over the 1.5 per-core threshold
@@ -136,6 +145,30 @@ describe('DegradedTmuxGuard', () => {
       guard.observeTmuxCall(12_000, 'success');
       guard.observeTmuxCall(12_000, 'success');
       expect(raised).toHaveLength(1);
+    });
+
+    it('unknown host load cannot advance corroboration or raise an episode', () => {
+      const { guard, raised } = makeGuard(
+        { episodeCorroborationCycles: 3 },
+        computeLoadPerCore(4, 0),
+      );
+      for (let i = 0; i < 6; i++) guard.observeTmuxCall(12_000, 'success');
+      expect(raised).toHaveLength(0);
+      expect(guard.snapshot().consecutiveSlowCycles).toBe(0);
+    });
+
+    it('a throwing load provider cannot advance corroboration or raise an episode', () => {
+      const guard = new DegradedTmuxGuard(
+        { enabled: true, episodeCorroborationCycles: 1, slowCallThresholdMs: 1, settleWindowMs: 0 },
+        {
+          raiseAttention: () => { throw new Error('must not be reached'); },
+          loadPerCore: () => { throw new Error('load unavailable'); },
+        },
+      );
+
+      guard.observeTmuxCall(12_000, 'success');
+      expect(guard.snapshot().episodesRaised).toBe(0);
+      expect(guard.snapshot().consecutiveSlowCycles).toBe(0);
     });
   });
 

--- a/upgrades/eli16/tmux-load-denominator.md
+++ b/upgrades/eli16/tmux-load-denominator.md
@@ -1,0 +1,21 @@
+# Missing CPU counts no longer look like an idle host
+
+The degraded-tmux watcher uses load per CPU core to distinguish a slow shared
+terminal server from a generally busy machine. That calculation needs a CPU
+core count.
+
+Previously, if the operating system returned no cores, the production provider
+returned zero. The watcher then treated an unavailable load measurement as a
+perfectly idle host and allowed slow-call corroboration to advance. That could
+raise a confident degraded-tmux notice without the load evidence the guard's
+design requires.
+
+The provider now returns an explicit unknown value when the denominator is
+missing. A real zero load remains zero. The guard consumes unknown by pausing
+corroboration for that cycle, just as it pauses when measured load is above the
+busy-host threshold. The watcher remains signal-only and never kills or
+refreshes tmux.
+
+Tests cover the production conversion boundary, the downstream decision, and a
+throwing load provider. Reintroducing the old fabricated zero makes the tests
+fail.

--- a/upgrades/next/tmux-load-denominator.md
+++ b/upgrades/next/tmux-load-denominator.md
@@ -1,0 +1,27 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The degraded-tmux guard now treats a missing CPU-core denominator as an
+unavailable load measurement instead of zero load. Corroboration does not
+advance until the load gate has a real value.
+
+## What to Tell Your User
+
+If the operating system cannot report a CPU count, Instar no longer interprets
+that missing measurement as a perfectly idle host when deciding whether to
+raise a degraded-tmux notice.
+
+## Summary of New Capabilities
+
+- Explicit unknown state for the degraded-tmux load gate.
+- A shared conversion boundary that preserves a measured zero while rejecting
+  an unavailable denominator.
+
+## Evidence
+
+- Tests cover zero measured load, missing core count, and a throwing provider.
+- The production provider uses the tested conversion boundary.
+- Restoring the zero-denominator fallback makes the load-gate tests fail.

--- a/upgrades/side-effects/tmux-load-denominator.md
+++ b/upgrades/side-effects/tmux-load-denominator.md
@@ -1,0 +1,99 @@
+# Side-Effects Review — Degraded-tmux load denominator
+
+**Version / slug:** `tmux-load-denominator`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `Euler`
+
+## Summary of the change
+
+The degraded-tmux load provider now returns `null` when CPU count is unavailable.
+The guard pauses corroboration when load is unknown rather than treating it as
+zero.
+
+## Decision-point inventory
+
+- Per-core load conversion — modified — a denominator is required.
+- Load-gate decision — modified — unknown cannot advance corroboration.
+- Attention creation — unchanged and remains signal-only.
+
+## 1. Over-block
+
+The trigger is near-unreachable on ordinary hardware because operating systems
+normally report at least one CPU. If it occurs, the watcher waits for a measured
+load value. It does not suppress any path with a valid zero or positive ratio.
+
+## 2. Under-block
+
+A missing denominator and a throwing/non-finite provider all pause
+corroboration. No unavailable state can be converted into a calm measurement.
+
+## 3. Level-of-abstraction fit
+
+The pure conversion helper owns denominator validity. The guard owns what an
+unknown load signal means for its corroboration state.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Yes — the watcher remains signal-only.
+
+The only possible automated output remains one deduplicated Attention item. This
+change narrows when that signal may be raised and adds no blocking, refresh, or
+termination authority.
+
+## 4b. Judgment-point check
+
+No heuristic threshold changes. Missing denominator is deterministic; the
+existing configured load threshold is unchanged.
+
+## 5. Interactions
+
+- **Shadowing:** unknown load pauses the same corroboration counter that high
+  measured load pauses.
+- **Double-fire:** no new output path.
+- **Races:** core count remains cached once at server construction.
+- **Feedback loops:** valid load samples retain prior behavior.
+
+## 6. External surfaces
+
+On a host that reports zero CPUs, the watcher no longer raises a degraded-tmux
+notice based on a fabricated idle-host reading.
+
+## 6b. Operator-surface quality
+
+The behavior avoids a confident notice whose load premise was not measured.
+There is no new operator message.
+
+## 7. Multi-machine posture
+
+The correction is local to each machine's operating-system sample. Machines
+with valid CPU counts are unchanged.
+
+## 8. Rollback cost
+
+Pure code rollback. No state, schema, or migration.
+
+## Conclusion
+
+Clear to ship as a bounded consistency correction for a near-unreachable but
+genuine fail-open signal path.
+
+## Second-pass review
+
+**Reviewer:** Euler
+**Independent read of the artifact:** Concur with the review — null load
+correctly pauses corroboration without fabricating an idle measurement; valid
+zero remains distinct, and the signal-only authority boundary is unchanged.
+
+## Evidence pointers
+
+- `tests/unit/DegradedTmuxGuard.test.ts`
+- `tests/e2e/tmux-resilience-lifecycle.test.ts`
+- Mutation proof: returning zero for a missing core count fails both the
+  conversion and downstream-decision assertions.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Preserve an unavailable CPU-core denominator as `null` in the degraded-tmux load provider. The guard now pauses corroboration when load cannot be assessed, while a measured zero remains a valid calm-host sample. Thresholds, episode semantics, and the signal-only Attention authority are unchanged.

## Validation

- 35 focused guard and production-lifecycle tests pass.
- Pre-push affected suite: 65/65 tests pass.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring the zero-denominator fallback fails both the conversion assertion and the downstream no-episode assertion.
- Independent side-effects review concurred.

## ELI16

The degraded-tmux watcher asks whether the whole machine is busy before blaming a slow shared terminal server. It calculates machine load per CPU core, so it needs a real core count. Previously, if the operating system reported no cores, the production provider substituted zero. The guard read that as a perfectly idle host and allowed its slow-call evidence to advance toward an operator notice. This change keeps “no CPU denominator” separate from a measured zero load. Unknown load pauses the watcher for that cycle; valid zero and positive measurements behave as before. The watcher remains informational and never restarts, refreshes, or kills tmux.

## UX Impact

When the CPU count is unavailable, the user no longer sees a confident degraded-tmux notice based on fabricated calm-host evidence. There is no new user-visible wording; the throwing-probe test represents the unavailable state with `"load unavailable"`.

The concrete change behind that: the inline `loadPerCore` closure in the server bootstrap now delegates to `computeLoadPerCore`, imported alongside `DegradedTmuxGuard`, so an unknown core count yields an unknown load rather than a fabricated zero.

*(Quoted-symbol sentence appended by Echo to satisfy the UX gate's quote-a-string-from-the-diff rule. The shipped template's hint for that rule is misplaced — see the note on the template.)*