### PR TITLE
Keep empty decision-quality ratios unmeasured

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T12-31-03-714Z-decision-quality-empty-ratios.json
+++ b/.instar/instar-dev-decisions/2026-07-29T12-31-03-714Z-decision-quality-empty-ratios.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-29T12:31:03.714Z",
+  "slug": "decision-quality-empty-ratios",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 6,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/server/routes.ts"
+    ],
+    "addedLines": 3,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -17309,14 +17309,14 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         contentClass: entry.contentClass,
         decisions,
         outcomesKnown,
-        outcomesKnownRatio: decisions > 0 ? outcomesKnown / decisions : 0,
+        outcomesKnownRatio: decisions > 0 ? outcomesKnown / decisions : null,
         /**
          * Settled (right|wrong) grades — the only ones that can support a rate.
          * `selfReportShare` below already divides by this same quantity.
          */
         settledGrades,
         /** Share of graded rows that are unsettled. 1.0 means nothing is known. */
-        unknownShare: outcomesKnown > 0 ? unknown / outcomesKnown : 0,
+        unknownShare: outcomesKnown > 0 ? unknown / outcomesKnown : null,
         // Below the minimum SETTLED-grade count an aggregate rate is not
         // actionable (§5.5 codex r5). Measured 2026-07-28: this counted
         // `unknown` toward the sample, so messaging-tone-gate (2075 decisions,
@@ -17345,7 +17345,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
           // much of it is self-report without having to know `byStrength`
           // exists. `selfReportOnly` is the loud case: every graded outcome
           // here is the interested party's word.
-          selfReportShare: right + wrong > 0 ? selfReportGraded / (right + wrong) : 0,
+          selfReportShare: right + wrong > 0 ? selfReportGraded / (right + wrong) : null,
           selfReportOnly: right + wrong > 0 && selfReportGraded === right + wrong,
         },
         // Strength FIRST (default aggregate) — proof-like and heuristic grades are never conflated.

--- a/tests/integration/decision-quality-routes.test.ts
+++ b/tests/integration/decision-quality-routes.test.ts
@@ -116,6 +116,9 @@ describe('GET /decision-quality (integration)', () => {
     expect(point).toBeTruthy();
     expect(point.decisions).toBe(1);
     expect(point.gradeDistribution.right).toBe(1);
+    expect(point.outcomesKnownRatio).toBe(1);
+    expect(point.unknownShare).toBe(0);
+    expect(point.gradeDistribution.selfReportShare).toBe(0);
     // Strength-first aggregate is present and segments proof-like vs heuristic.
     expect(point.byStrength['negative-evidence'].right).toBe(1);
     expect(point.byRule[HOG_SUSTAINED_RIGHT_RULE_ID].right).toBe(1);
@@ -125,6 +128,23 @@ describe('GET /decision-quality (integration)', () => {
     expect(res.body.rejections).toEqual({ enumInvalid: 0, rungMismatch: 0, ownerMismatch: 0, unknownDecisionPoint: 0 });
     // evidence_note is NEVER served by this route.
     expect(JSON.stringify(res.body)).not.toMatch(/evidence_note|evidenceNote/);
+  });
+
+  it('keeps empty per-point ratios unmeasured while preserving their denominators', async () => {
+    ledger = new FeatureMetricsLedger({ dbPath: ':memory:' });
+    const res = await request(appWith(ctxWith({ ledger, developmentAgent: true })))
+      .get('/decision-quality?sinceHours=24').set('Authorization', `Bearer ${AUTH}`);
+
+    expect(res.status).toBe(200);
+    const point = (res.body.points as Array<any>).find((p) => p.decisionPoint === DP_MESSAGING_TONE_GATE);
+    expect(point).toBeTruthy();
+    expect(point.decisions).toBe(0);
+    expect(point.outcomesKnown).toBe(0);
+    expect(point.settledGrades).toBe(0);
+    expect(point.outcomesKnownRatio).toBeNull();
+    expect(point.unknownShare).toBeNull();
+    expect(point.gradeDistribution.selfReportShare).toBeNull();
+    expect(point.insufficientEvidence).toBe(true);
   });
 
   it('a 100%-UNKNOWN stream is insufficientEvidence:true — unknown grades are not evidence', async () => {
@@ -161,6 +181,7 @@ describe('GET /decision-quality (integration)', () => {
     // The evidence count is zero, and the flag follows the evidence, not the rows.
     expect(point.settledGrades).toBe(0);
     expect(point.unknownShare).toBe(1);
+    expect(point.gradeDistribution.selfReportShare).toBeNull();
     expect(point.insufficientEvidence).toBe(true);
   });
 

--- a/upgrades/eli16/decision-quality-empty-ratios.md
+++ b/upgrades/eli16/decision-quality-empty-ratios.md
@@ -1,0 +1,20 @@
+# Empty decision-quality ratios are now honest
+
+The decision-quality route publishes several ratios for each decision point:
+how many decisions have an outcome row, what share of those outcomes are still
+unknown, and what share of settled grades came from self-report.
+
+Each ratio needs a different denominator. Previously, an empty point returned
+zero for all three. Those zeros read like real measurements: complete outcome
+coverage, no unknown results, and no self-reported evidence. The surrounding
+object did say evidence was insufficient, but consumers could still quote the
+individual ideal-looking fields.
+
+The route now returns `null` when the relevant denominator is zero. It still
+publishes decisions, outcome rows, settled grades, and the insufficiency flag,
+so the reason is visible. A populated point with a genuinely measured zero
+still returns zero.
+
+The integration test calls the real HTTP route with an empty ledger and checks
+all denominators and ratios together. Reintroducing the old fallbacks makes the
+test fail.

--- a/upgrades/next/decision-quality-empty-ratios.md
+++ b/upgrades/next/decision-quality-empty-ratios.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The per-decision-point quality view now returns `null` for outcomes-known,
+unknown-grade, and self-report ratios when their respective denominators are
+zero. The response continues to publish every denominator and its
+`insufficientEvidence` flag.
+
+## What to Tell Your User
+
+An empty decision-quality point no longer looks like it measured perfect
+outcome coverage, zero unknown grades, or zero self-reported evidence.
+
+## Summary of New Capabilities
+
+- Explicit unmeasured states for three per-point decision-quality ratios.
+- Positive-denominator zero values remain measurable and unchanged.
+
+## Evidence
+
+- The HTTP integration test exercises a real wired point with an empty ledger.
+- Tests separately preserve measured zero on a populated point.
+- Restoring all three zero fallbacks makes the empty-row assertions fail.

--- a/upgrades/side-effects/decision-quality-empty-ratios.md
+++ b/upgrades/side-effects/decision-quality-empty-ratios.md
@@ -1,0 +1,91 @@
+# Side-Effects Review — Decision-quality empty ratios
+
+**Version / slug:** `decision-quality-empty-ratios`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Three per-point decision-quality ratios return `null` instead of zero when
+their individual denominators are empty.
+
+## Decision-point inventory
+
+- HTTP response assembly — modified — zero denominators are explicit.
+- Insufficient-evidence decision — unchanged.
+- Pool field allowlist — unchanged; nullable values pass through the same keys.
+
+## 1. Over-block
+
+No gate or action reads these ratios in this change. The populated route retains
+numeric zero when the denominator exists.
+
+## 2. Under-block
+
+Every zero-denominator branch in this per-point response cluster is covered:
+decisions, outcome rows, and settled grades.
+
+## 3. Level-of-abstraction fit
+
+The response assembler owns both the counts and the derived ratios. It can
+express absence without changing the ledger.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Yes — this is an observability response only.
+
+No authority, threshold, or enforcement path changes.
+
+## 4b. Judgment-point check
+
+No heuristic judgment. A ratio without its denominator is mechanically
+unmeasurable.
+
+## 5. Interactions
+
+- **Shadowing:** `insufficientEvidence` remains true on empty rows.
+- **Double-fire:** no events or actions.
+- **Races:** read-only assembly over the existing ledger snapshot.
+- **Feedback loops:** pool responses preserve the same allowed fields.
+
+## 6. External surfaces
+
+API consumers see `null` rather than `0` for the three empty ratios. All
+denominator counts remain present.
+
+## 6b. Operator-surface quality
+
+The response can no longer contradict itself by pairing
+`insufficientEvidence: true` with ideal-looking zero ratios.
+
+## 7. Multi-machine posture
+
+Local and peer rows use the same field allowlist. No cross-machine state
+changes.
+
+## 8. Rollback cost
+
+Pure response-shape rollback. No persistence or migration.
+
+## Conclusion
+
+Clear to ship as a bounded observability correction.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; no guard, gate, lifecycle,
+or authority behavior changes.
+
+## Evidence pointers
+
+- `tests/integration/decision-quality-routes.test.ts`
+- Mutation proof: restoring the three zeros fails the empty-point and
+  unknown-only assertions.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Return `null` for three per-decision-point quality ratios when their own denominators are empty: outcomes-known ratio, unknown-grade share, and self-report share. Denominator counts and `insufficientEvidence` remain present, while populated points retain measured numeric zeros.

## Validation

- Real HTTP integration suite: 14/14 tests pass.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring the three zero fallbacks fails the empty-point and unknown-only cases.
- The local affected-test listing timed out under the repository’s bounded test-runner lane; the pre-push gate explicitly deferred that listing to CI and completed the push.

## ELI16

The decision-quality endpoint shows several percentages for every decision point. Each percentage needs a different count underneath it. Before this change, a decision point with no decisions or no settled grades returned zero for all three percentages. Those values looked ideal—complete coverage, no unknown outcomes, and no self-reported evidence—even though the same response admitted that evidence was insufficient. The endpoint now returns `null` when the relevant count is zero and keeps the count beside it, so clients can distinguish “measured zero” from “not measured.” A populated point that genuinely measures zero is unchanged.

## UX Impact

API users reading `"/decision-quality?sinceHours=24"` now see `null` for empty ratios instead of ideal-looking zeros; counts and the existing insufficiency flag explain why.

The concrete change behind that: `outcomesKnownRatio`, `unknownShare` and `selfReportShare` now return an unmeasured value instead of a confident zero when their denominator is empty, so a decision point that has produced no gradable outcomes no longer reads as fully-known.

*(Quoted-symbol sentence appended by Echo to satisfy the UX gate's quote-a-string-from-the-diff rule — the same gate the misplaced template hint keeps causing people to miss; #1741 fixes the hint placement.)*