### PR TITLE
Pair PR template hints with their sections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,13 @@
 
 What does this PR do? Why is it needed?
 
-<!-- Gate: write at least 200 characters of plain-English explanation for a non-expert; comments do not count. -->
 ## ELI16
 
-<!-- Gate for user-facing paths: name who sees the change, describe the user-visible first contact, and quote an exact string from the diff. -->
+<!-- Gate: write at least 200 characters of plain-English explanation for a non-expert; comments do not count. -->
+
 ## UX Impact
+
+<!-- Gate for user-facing paths: name who sees the change, describe the user-visible first contact, and quote an exact string from the diff. -->
 
 ## Type of Change
 

--- a/tests/unit/pull-request-template-gates.test.ts
+++ b/tests/unit/pull-request-template-gates.test.ts
@@ -8,11 +8,16 @@ const templatePath = path.resolve(process.cwd(), '.github/PULL_REQUEST_TEMPLATE.
 
 describe('pull request template gate prompts', () => {
   const template = fs.readFileSync(templatePath, 'utf8');
+  const sectionOpening = (heading: string): string => {
+    const start = template.indexOf(`## ${heading}`);
+    const next = template.indexOf('\n## ', start + 1);
+    return template.slice(start, next === -1 ? undefined : next);
+  };
 
   it('prompts for the required ELI16 section and its minimum content', () => {
-    expect(template).toMatch(/^## ELI16\s*$/m);
-    expect(template).toMatch(/at least 200 characters/i);
-    expect(template).toMatch(/plain-English explanation for a non-expert/i);
+    const eli16 = sectionOpening('ELI16');
+    expect(eli16).toMatch(/^## ELI16\r?\n\r?\n<!-- Gate: write at least 200 characters/);
+    expect(eli16).toMatch(/plain-English explanation for a non-expert/i);
     expect(checkPrDescriptionEli16({ body: template })).toMatchObject({
       ok: false,
       reason: 'eli16-too-short',
@@ -20,9 +25,10 @@ describe('pull request template gate prompts', () => {
   });
 
   it('prompts for the required UX declaration and every gated detail', () => {
-    expect(template).toMatch(/^## UX Impact\s*$/m);
-    expect(template).toMatch(/who sees the change/i);
-    expect(template).toMatch(/user-visible first contact/i);
-    expect(template).toMatch(/quote an exact string from the diff/i);
+    const uxImpact = sectionOpening('UX Impact');
+    expect(uxImpact).toMatch(/^## UX Impact\r?\n\r?\n<!-- Gate for user-facing paths:/);
+    expect(uxImpact).toMatch(/who sees the change/i);
+    expect(uxImpact).toMatch(/user-visible first contact/i);
+    expect(uxImpact).toMatch(/quote an exact string from the diff/i);
   });
 });

--- a/upgrades/eli16/pr-template-hint-adjacency.md
+++ b/upgrades/eli16/pr-template-hint-adjacency.md
@@ -1,0 +1,16 @@
+# Pull-request hints now explain the right section
+
+The repository’s pull-request template recently gained two required sections:
+ELI16 and UX Impact. It also included a short comment explaining what each
+automated gate checks.
+
+The comments were placed one section too early. The ELI16 length hint sat above
+the ELI16 heading, while the UX hint sat above the UX heading. In the editor,
+that made the guidance look like it belonged to the preceding section. An
+author filling out UX Impact could miss the requirement to quote an exact string
+from the diff even though the template contained those words elsewhere.
+
+Each comment now sits directly below its own heading. The test no longer proves
+only that both headings and both hints exist; it extracts each section and
+asserts that the correct hint opens that section. Moving a hint back to the old
+position makes the test fail.

--- a/upgrades/next/pr-template-hint-adjacency.md
+++ b/upgrades/next/pr-template-hint-adjacency.md
@@ -1,0 +1,24 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The pull-request template now places each gate hint directly below the section
+it explains. Its unit test asserts that adjacency instead of merely checking
+that headings and guidance exist somewhere in the file.
+
+## What to Tell Your User
+
+Pull-request authors now see the ELI16 length guidance under ELI16 and the
+exact-diff-string guidance under UX Impact.
+
+## Summary of New Capabilities
+
+- Structurally paired PR-template headings and gate hints.
+- Regression coverage for both heading-to-hint relationships.
+
+## Evidence
+
+- The real template-gate test passes.
+- Moving a hint back above its heading makes the adjacency assertion fail.

--- a/upgrades/side-effects/pr-template-hint-adjacency.md
+++ b/upgrades/side-effects/pr-template-hint-adjacency.md
@@ -1,0 +1,88 @@
+# Side-Effects Review — Pull-request template hint adjacency
+
+**Version / slug:** `pr-template-hint-adjacency`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Two existing template comments move below their respective headings, and the
+template test now binds each hint to its section opening.
+
+## Decision-point inventory
+
+- PR author guidance — modified — each hint is locally scoped.
+- CI gate implementations — unchanged.
+- Pull-request description contents — unchanged until an author fills them.
+
+## 1. Over-block
+
+The test asserts only the two section openings. Authors remain free to write any
+content that satisfies the real gates.
+
+## 2. Under-block
+
+Both required headings are covered. A hint elsewhere in the template no longer
+satisfies the adjacency assertion.
+
+## 3. Level-of-abstraction fit
+
+The template owns author guidance, while the test imports the existing ELI16
+gate for behavioral coupling and adds a structural template assertion.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Yes — template comments are guidance; CI gates retain authority.
+
+## 4b. Judgment-point check
+
+No heuristic or authority changes.
+
+## 5. Interactions
+
+- **Shadowing:** correct local hints reduce confusion without replacing gates.
+- **Double-fire:** no runtime events.
+- **Races:** static repository files only.
+- **Feedback loops:** a future template rearrangement must update the paired
+  section test intentionally.
+
+## 6. External surfaces
+
+PR authors see the right gate guidance immediately beneath the section they are
+about to fill.
+
+## 6b. Operator-surface quality
+
+The UX hint now explicitly reaches the UX authoring location instead of being
+visually attached to ELI16.
+
+## 7. Multi-machine posture
+
+Repository-wide template behavior is identical for every contributor.
+
+## 8. Rollback cost
+
+Two comment moves and one test helper; no state.
+
+## Conclusion
+
+Clear to ship as a bounded process-surface correction.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; documentation and tests
+only, with no runtime or enforcement changes.
+
+## Evidence pointers
+
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `tests/unit/pull-request-template-gates.test.ts`
+- Mutation proof: placing the ELI16 hint above its heading fails the test.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Move the ELI16 and UX Impact gate hints directly below the headings they explain. Extend the existing template test so it extracts each section and verifies that the correct hint opens that section; merely having the right words somewhere else in the template no longer passes.

## ELI16

The pull-request template had both required headings and both pieces of guidance, but each guidance comment sat above its heading. That visually attached the ELI16 length rule to Description and the UX exact-string rule to ELI16, leaving UX Impact with no local help. This change moves each comment below its own heading. The test now checks the opening of each section, so a future edit cannot keep all the right words while putting them in the wrong place. Moving the ELI16 hint back above its heading was tested and makes the new assertion fail.

## UX Impact

Pull-request authors see the correct rule at first contact with each required section. Under UX Impact, the template now directly says to `"quote an exact string from the diff"` instead of placing that instruction above the heading.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Checklist

- [x] I have added tests for my changes
- [x] Targeted tests pass locally
- [x] Full lint and TypeScript checks pass locally
