### PR TITLE
Keep empty self-knowledge coverage unmeasured

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T12-42-10-200Z-self-knowledge-empty-coverage.json
+++ b/.instar/instar-dev-decisions/2026-07-29T12-42-10-200Z-self-knowledge-empty-coverage.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-07-29T12:42:10.200Z",
+  "slug": "self-knowledge-empty-coverage",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 25,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/machine.ts",
+      "src/knowledge/CoverageAuditor.ts",
+      "src/knowledge/SelfKnowledgeTree.ts",
+      "src/knowledge/types.ts"
+    ],
+    "addedLines": 14,
+    "deletedLines": 11
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -949,7 +949,9 @@ export async function doctor(options: DoctorOptions): Promise<void> {
 
       const parts = [
         `${totalNodes} nodes`,
-        `${Math.round(validation.coverageScore * 100)}% coverage`,
+        validation.coverageScore === null
+          ? 'coverage n/a'
+          : `${Math.round(validation.coverageScore * 100)}% coverage`,
       ];
       if (health.searchCount > 0) {
         parts.push(health.cacheHitRate === null

--- a/src/knowledge/CoverageAuditor.ts
+++ b/src/knowledge/CoverageAuditor.ts
@@ -26,8 +26,8 @@ export interface CoverageGap {
 }
 
 export interface AuditResult {
-  /** Overall content coverage score (0-1) */
-  coverageScore: number;
+  /** Overall content coverage score (0-1), or null when the tree has no nodes. */
+  coverageScore: number | null;
   /** Total nodes in tree */
   totalNodes: number;
   /** Nodes with valid, non-empty sources */
@@ -40,7 +40,7 @@ export interface AuditResult {
 
 export interface HealthSummary {
   totalNodes: number;
-  coverageScore: number;
+  coverageScore: number | null;
   cacheHitRate: number | null;
   avgLatencyMs: number | null;
   errorRate: number | null;
@@ -97,10 +97,11 @@ export class CoverageAuditor {
       }
     }
 
+    const totalNodes = this.countNodes(config);
     return {
       coverageScore: validation.coverageScore,
-      totalNodes: this.countNodes(config),
-      validNodes: Math.round(validation.coverageScore * this.countNodes(config)),
+      totalNodes,
+      validNodes: validation.coverageScore === null ? 0 : Math.round(validation.coverageScore * totalNodes),
       gaps,
       validation,
     };
@@ -145,7 +146,7 @@ export class CoverageAuditor {
     const tracePath = path.join(this.stateDir, 'logs', 'tree-trace.jsonl');
     const defaultSummary: HealthSummary = {
       totalNodes: 0,
-      coverageScore: 0,
+      coverageScore: null,
       cacheHitRate: null,
       avgLatencyMs: null,
       errorRate: null,
@@ -187,7 +188,7 @@ export class CoverageAuditor {
 
       return {
         totalNodes: 0, // Caller fills this from config
-        coverageScore: 0, // Caller fills this from validation
+        coverageScore: null, // Caller fills this from validation
         cacheHitRate: totalCacheOps > 0 ? totalCacheHits / totalCacheOps : null,
         avgLatencyMs: totalLatency / entries.length,
         errorRate: totalErrors / entries.length,

--- a/src/knowledge/SelfKnowledgeTree.ts
+++ b/src/knowledge/SelfKnowledgeTree.ts
@@ -500,7 +500,7 @@ export class SelfKnowledgeTree {
         valid: false,
         warnings: [],
         errors: [{ nodeId: '', type: 'invalid_schema', message: 'Tree config file not found' }],
-        coverageScore: 0,
+        coverageScore: null,
       };
     }
 
@@ -566,7 +566,7 @@ export class SelfKnowledgeTree {
       }
     }
 
-    const coverageScore = totalNodes > 0 ? validNodes / totalNodes : 0;
+    const coverageScore = totalNodes > 0 ? validNodes / totalNodes : null;
 
     return {
       valid: errors.length === 0,

--- a/src/knowledge/types.ts
+++ b/src/knowledge/types.ts
@@ -188,7 +188,7 @@ export interface ValidationResult {
   valid: boolean;
   warnings: ValidationWarning[];
   errors: ValidationError[];
-  coverageScore: number;
+  coverageScore: number | null;
 }
 
 export interface ValidationWarning {

--- a/tests/unit/CoverageAudit.test.ts
+++ b/tests/unit/CoverageAudit.test.ts
@@ -172,6 +172,19 @@ describe('Coverage Audit + Evolution (Phase 4)', () => {
     expect(telegramGap).toBeUndefined();
   });
 
+  it('keeps an empty tree audit unmeasured instead of reporting zero-percent coverage', () => {
+    const tree = createTree();
+    const config = tree.getConfig()!;
+    for (const layer of config.layers) layer.children = [];
+    const validation = { valid: true, warnings: [], errors: [], coverageScore: null };
+    const auditor = new CoverageAuditor(projectDir, stateDir);
+
+    const audit = auditor.audit(config, validation);
+    expect(audit.totalNodes).toBe(0);
+    expect(audit.validNodes).toBe(0);
+    expect(audit.coverageScore).toBeNull();
+  });
+
   // Gate Test 4.3: coverage audit reports content coverage score
   it('4.3: coverage score reflects valid/total ratio', () => {
     const tree = createTree();

--- a/tests/unit/SelfKnowledgeTree.test.ts
+++ b/tests/unit/SelfKnowledgeTree.test.ts
@@ -342,6 +342,17 @@ Direct and technical. I don't waste words.
       expect(result.valid).toBe(true);
       expect(result.coverageScore).toBeGreaterThan(0);
     });
+
+    it('keeps coverage unmeasured when a valid tree contains no nodes', () => {
+      const config = makeConfig();
+      for (const layer of config.layers) layer.children = [];
+      writeTreeConfig(config);
+      const tree = createTree();
+
+      const result = tree.validate();
+      expect(result.valid).toBe(true);
+      expect(result.coverageScore).toBeNull();
+    });
   });
 
   // Grounding (Phase 2 preview)

--- a/upgrades/eli16/self-knowledge-empty-coverage.md
+++ b/upgrades/eli16/self-knowledge-empty-coverage.md
@@ -1,0 +1,19 @@
+# An empty knowledge tree no longer reports zero-percent coverage
+
+Self-knowledge coverage is the number of valid tree nodes divided by the total
+number of nodes. A tree can be syntactically valid while containing no nodes,
+so there is no denominator for that calculation.
+
+Previously, validation returned zero in that case. The HTTP health response
+published the zero, and the machine check displayed “0% coverage” beside “0
+nodes.” That sounds like a measured poor score even though no coverage
+population exists.
+
+Validation now returns an explicit unknown value for a zero-node tree. The
+coverage audit keeps totalNodes and validNodes at zero while preserving the
+unknown score. The HTTP response serializes it as `null`, and the machine check
+says `coverage n/a`. Trees with one or more nodes still return the same numeric
+ratio.
+
+Tests construct a valid empty tree and cover validation plus audit propagation.
+Reintroducing the old fallback makes the validation test fail.

--- a/upgrades/next/self-knowledge-empty-coverage.md
+++ b/upgrades/next/self-knowledge-empty-coverage.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Self-knowledge validation now reports `coverageScore: null` when a tree contains
+no nodes. The audit result and HTTP health response preserve that state, and
+the machine check renders `coverage n/a` instead of `0% coverage`.
+
+## What to Tell Your User
+
+An empty self-knowledge tree no longer looks like a measured zero-percent
+coverage result; the health surfaces say coverage is unavailable.
+
+## Summary of New Capabilities
+
+- Explicit unmeasured coverage for zero-node trees.
+- Consistent audit, API, and CLI presentation of the missing denominator.
+
+## Evidence
+
+- Validation and audit tests cover a valid zero-node tree.
+- Twenty-eight focused tests and full lint pass.
+- Restoring the old zero fallback makes the validation test fail.

--- a/upgrades/side-effects/self-knowledge-empty-coverage.md
+++ b/upgrades/side-effects/self-knowledge-empty-coverage.md
@@ -1,0 +1,88 @@
+# Side-Effects Review — Self-knowledge empty coverage
+
+**Version / slug:** `self-knowledge-empty-coverage`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Zero-node self-knowledge trees carry nullable coverage through validation,
+audit, HTTP, and machine-check output.
+
+## Decision-point inventory
+
+- Tree validation — modified — zero nodes means unmeasured.
+- Coverage audit — modified — nullable score, explicit zero counts.
+- Health/API/CLI presentation — modified — null or `coverage n/a`.
+
+## 1. Over-block
+
+No action or gate consumes the score. Trees with nodes keep numeric coverage.
+
+## 2. Under-block
+
+Both the primary validation result and the audit wrapper preserve the empty
+state. CLI formatting does not round null into zero.
+
+## 3. Level-of-abstraction fit
+
+Validation owns the denominator. Consumers propagate or render the resulting
+state without recalculating it.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Yes — these are observability surfaces only.
+
+No validation validity, routing, or enforcement behavior changes.
+
+## 4b. Judgment-point check
+
+No heuristic judgment. Zero-node division is mechanically unmeasurable.
+
+## 5. Interactions
+
+- **Shadowing:** node and valid-node counts remain visible.
+- **Double-fire:** no events.
+- **Races:** synchronous validation over the loaded configuration.
+- **Feedback loops:** coverage with a positive denominator is unchanged.
+
+## 6. External surfaces
+
+The health API returns `coverageScore: null`; the machine check prints
+`coverage n/a` for an empty tree.
+
+## 6b. Operator-surface quality
+
+The output no longer combines `0 nodes` with a claimed `0% coverage`
+measurement.
+
+## 7. Multi-machine posture
+
+Each machine validates its own tree with the same response contract.
+
+## 8. Rollback cost
+
+Pure type, calculation, and presentation rollback. No persistence.
+
+## Conclusion
+
+Clear to ship as a bounded observability correction.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; no gate, guard, authority,
+or lifecycle behavior changes.
+
+## Evidence pointers
+
+- `tests/unit/SelfKnowledgeTree.test.ts`
+- `tests/unit/CoverageAudit.test.ts`
+- Mutation proof: restoring zero on an empty tree fails validation.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Make self-knowledge coverage nullable when a valid tree contains zero nodes. Carry that unknown state through validation, coverage auditing, the health API, and the machine-check display while preserving numeric coverage for every positive-node tree.

## ELI16

Self-knowledge coverage divides valid tree nodes by total tree nodes. A syntactically valid tree is allowed to contain no nodes, but the old calculation returned zero in that case. The health API exposed that value and the machine check printed “0 nodes, 0% coverage,” which reads like a measured poor score even though no population exists. Validation now returns `null` when total nodes is zero. The audit still publishes both zero counts, the API preserves the null, and the machine check renders an explicit unavailable label. Trees containing nodes use the same numeric calculation as before.

## UX Impact

Operators running the machine health check on an empty self-knowledge tree now see `"coverage n/a"` beside the zero-node count; API consumers receive `coverageScore: null` with `totalNodes: 0`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Validation

- 28 focused validation and audit tests pass.
- Pre-push affected suite: 150 passed, 6 skipped, zero failures.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring the zero fallback makes the empty-tree validation test fail.
