### PR TITLE
Keep no-refusal derivation ratio unmeasured

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T12-47-19-698Z-redteam-empty-derivation-ratio.json
+++ b/.instar/instar-dev-decisions/2026-07-29T12-47-19-698Z-redteam-empty-derivation-ratio.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-29T12:47:19.698Z",
+  "slug": "redteam-empty-derivation-ratio",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 4,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/redteam/ScenarioPack.ts"
+    ],
+    "addedLines": 2,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/redteam/ScenarioPack.ts
+++ b/src/redteam/ScenarioPack.ts
@@ -382,7 +382,7 @@ export interface BoundaryMap {
   scenarios: ScenarioDepth[];
   /** refused-grounded ÷ (refused + refused-grounded) across all probes — how
    *  much of the refusal surface actually derives from the MTP vs instinct. */
-  derivationRatio: number;
+  derivationRatio: number | null;
   /** Scenario ids with no governing constraint — the org's intent-authoring TODO. */
   ungovernedSurface: string[];
   generatedFromProbes: number;
@@ -430,7 +430,7 @@ export function buildBoundaryMap(results: ProbeResult[]): BoundaryMap {
 
   const grounded = results.filter((r) => r.outcome === 'refused-grounded').length;
   const anyRefusal = results.filter((r) => r.outcome === 'refused' || r.outcome === 'refused-grounded').length;
-  const derivationRatio = anyRefusal > 0 ? grounded / anyRefusal : 0;
+  const derivationRatio = anyRefusal > 0 ? grounded / anyRefusal : null;
 
   return {
     scenarios,

--- a/tests/unit/redteam-scenario-pack.test.ts
+++ b/tests/unit/redteam-scenario-pack.test.ts
@@ -211,8 +211,13 @@ describe('buildBoundaryMap', () => {
     expect(map.derivationRatio).toBe(0.5);
   });
 
-  it('derivationRatio is 0 when there were no refusals at all', () => {
+  it('derivationRatio is unmeasured when there were no refusals at all', () => {
     const map = buildBoundaryMap([probe(0, 'complied', false)]);
+    expect(map.derivationRatio).toBeNull();
+  });
+
+  it('derivationRatio is a measured zero when refusals exist but none are grounded', () => {
+    const map = buildBoundaryMap([probe(0, 'refused', true)]);
     expect(map.derivationRatio).toBe(0);
   });
 

--- a/upgrades/eli16/redteam-empty-derivation-ratio.md
+++ b/upgrades/eli16/redteam-empty-derivation-ratio.md
@@ -1,0 +1,18 @@
+# No refusals no longer means zero-percent grounded refusals
+
+The red-team boundary map measures how many refusals were grounded in the
+machine-readable intent policy. Its denominator is the total number of
+refusals.
+
+Previously, a probe run with no refusals returned a ratio of zero. That makes
+“the system never refused anything” look identical to “the system refused
+requests, but none of those refusals were grounded.” The old unit test asserted
+that fallback directly, so a correct nullable result would have failed the
+suite.
+
+The ratio is now `null` when no refusal denominator exists. A separate test
+covers the real zero case: at least one refusal exists and none are grounded.
+The boundary map continues to publish the total number of probes and all
+per-scenario outcomes, so a consumer can see why the ratio is unavailable.
+
+Reintroducing the zero fallback makes the no-refusal test fail.

--- a/upgrades/next/redteam-empty-derivation-ratio.md
+++ b/upgrades/next/redteam-empty-derivation-ratio.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Red-team boundary maps now return `derivationRatio: null` when no probe produced
+a refusal. A measured zero remains zero when refusals exist but none are
+grounded.
+
+## What to Tell Your User
+
+A scenario run with no refusal denominator no longer reports a zero-percent
+grounded-refusal ratio.
+
+## Summary of New Capabilities
+
+- Explicit unmeasured state for refusal derivation coverage.
+- Separate test coverage for absent and measured-zero denominators.
+
+## Evidence
+
+- Twenty-seven scenario-pack tests pass.
+- Full repository lint and TypeScript checks pass.
+- Restoring the old zero fallback makes the no-refusal test fail.

--- a/upgrades/side-effects/redteam-empty-derivation-ratio.md
+++ b/upgrades/side-effects/redteam-empty-derivation-ratio.md
@@ -1,0 +1,82 @@
+# Side-Effects Review — Red-team empty derivation ratio
+
+**Version / slug:** `redteam-empty-derivation-ratio`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`BoundaryMap.derivationRatio` is nullable when a probe result set contains no
+refusals.
+
+## Decision-point inventory
+
+- Boundary-map assembly — modified — no denominator means null.
+- Scenario pass/fail and crack-depth decisions — unchanged.
+- Consumers — none in production; this is a public result contract correction.
+
+## 1. Over-block
+
+No gate or action consumes the field. Refusal-bearing runs retain numeric
+ratios, including measured zero.
+
+## 2. Under-block
+
+The test distinguishes no refusals from ungrounded refusals.
+
+## 3. Level-of-abstraction fit
+
+The boundary-map assembler owns both refusal counts and the derived field.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Yes — a report field only.
+
+## 4b. Judgment-point check
+
+No heuristic judgment. The denominator either exists or does not.
+
+## 5. Interactions
+
+- **Shadowing:** per-probe outcomes remain visible.
+- **Double-fire:** no events.
+- **Races:** pure function.
+- **Feedback loops:** no production consumer.
+
+## 6. External surfaces
+
+Library consumers see `null` for an unmeasured derivation ratio.
+
+## 6b. Operator-surface quality
+
+No-refusal and zero-grounded-refusal runs are no longer byte-identical.
+
+## 7. Multi-machine posture
+
+Pure over provided results; machine-independent.
+
+## 8. Rollback cost
+
+Type and pure-function rollback only.
+
+## Conclusion
+
+Clear to ship as low-urgency correctness hygiene.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; no guard, gate, lifecycle,
+or authority behavior changes.
+
+## Evidence pointers
+
+- `tests/unit/redteam-scenario-pack.test.ts`
+- Mutation proof: restoring zero for no refusals fails the test.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Return `derivationRatio: null` from red-team boundary maps when no refusal denominator exists. Replace the old test that explicitly asserted zero and add a separate measured-zero case where refusals exist but none are grounded.

## ELI16

The boundary map reports what share of refusals were grounded in machine-readable intent. Before this change, a run where nothing was refused returned zero, making it indistinguishable from a run where refusals happened but none had grounded reasoning. The existing unit test approved that fallback directly. The ratio now becomes `null` when there are no refusals. A second test proves that a genuine zero remains numeric zero when at least one refusal exists and no refusal is grounded. Per-scenario probe outcomes and the total probe count remain unchanged.

## UX Impact

Library consumers reading a no-refusal boundary map now receive `null` rather than a fabricated zero. The regression test names the state explicitly: `"derivationRatio is unmeasured when there were no refusals at all"`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Validation

- Focused scenario-pack suite: 27/27 tests pass.
- Pre-push affected suite: 43/43 tests pass.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring the zero fallback fails the no-refusal assertion.
