### PR TITLE
Reject invalid SDK credit totals

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T12-52-15-988Z-sdk-credit-zero-total.json
+++ b/.instar/instar-dev-decisions/2026-07-29T12-52-15-988Z-sdk-credit-zero-total.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-29T12:52:15.988Z",
+  "slug": "sdk-credit-zero-total",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 10,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/providers/costAwareRouting.ts"
+    ],
+    "addedLines": 7,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/providers/costAwareRouting.ts
+++ b/src/providers/costAwareRouting.ts
@@ -223,15 +223,19 @@ export class CostStateTracker {
     }
 
     const result: CostStateSnapshot = { capturedAt: new Date().toISOString() };
-    if (snapshot !== null) {
+    if (
+      snapshot !== null
+      && Number.isFinite(snapshot.totalUsd)
+      && snapshot.totalUsd > 0
+      && Number.isFinite(snapshot.remainingUsd)
+    ) {
       const safetyMarginUsd = this.safetyMarginFraction * snapshot.totalUsd;
       result.agentSdkCredit = {
         remainingUsd: snapshot.remainingUsd,
         totalUsd: snapshot.totalUsd,
         safetyMarginUsd,
         belowMargin: snapshot.remainingUsd <= safetyMarginUsd,
-        consumedFraction:
-          snapshot.totalUsd > 0 ? 1 - snapshot.remainingUsd / snapshot.totalUsd : 0,
+        consumedFraction: 1 - snapshot.remainingUsd / snapshot.totalUsd,
       };
     } else {
       result.agentSdkCredit = null;

--- a/tests/unit/providers/costAwareRouting.test.ts
+++ b/tests/unit/providers/costAwareRouting.test.ts
@@ -235,6 +235,25 @@ describe('CostStateTracker', () => {
       expect(snap.agentSdkCredit!.belowMargin).toBe(true);
     });
 
+    it('keeps a zero remaining balance measurable as fully consumed', async () => {
+      const tracker = new CostStateTracker({
+        readSdkCredit: async () => makeSnapshot(0, 200),
+      });
+      const snap = await tracker.snapshot();
+      expect(snap.agentSdkCredit).not.toBeNull();
+      expect(snap.agentSdkCredit!.remainingUsd).toBe(0);
+      expect(snap.agentSdkCredit!.consumedFraction).toBe(1);
+      expect(snap.agentSdkCredit!.belowMargin).toBe(true);
+    });
+
+    it('returns agentSdkCredit: null when total credit is zero', async () => {
+      const tracker = new CostStateTracker({
+        readSdkCredit: async () => makeSnapshot(0, 0),
+      });
+      const snap = await tracker.snapshot();
+      expect(snap.agentSdkCredit).toBeNull();
+    });
+
     it('returns agentSdkCredit: null when read returns null', async () => {
       const tracker = new CostStateTracker({
         readSdkCredit: async () => null,

--- a/upgrades/eli16/sdk-credit-zero-total.md
+++ b/upgrades/eli16/sdk-credit-zero-total.md
@@ -1,0 +1,17 @@
+# A zero-total credit pot is no longer treated as known
+
+The cost-state tracker records how much of an SDK credit pot has been consumed.
+That percentage needs a positive total credit amount.
+
+Previously, a provider snapshot with total credit equal to zero still produced
+a “known” object. Its consumed fraction became zero, which looked like a fresh,
+unused budget, while the same object also said the remaining amount was at or
+below its zero-dollar safety margin. The HTTP comparison route already treated
+a non-positive total as unknown, so two routes disagreed about the same input.
+
+The tracker now returns its existing unknown state when total credit is not a
+finite positive number or remaining credit is non-finite. A real zero remaining
+balance with a positive total stays valid and reports fully consumed.
+
+Tests cover both sides. Restoring the old object for a zero total makes the new
+boundary test fail.

--- a/upgrades/next/sdk-credit-zero-total.md
+++ b/upgrades/next/sdk-credit-zero-total.md
@@ -1,0 +1,24 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The cost-state tracker now treats SDK-credit snapshots with a non-positive or
+non-finite total as unknown. A zero remaining balance with a valid positive
+total remains measurable as fully consumed.
+
+## What to Tell Your User
+
+An invalid zero-total credit pot no longer looks like a known, zero-percent
+consumed budget.
+
+## Summary of New Capabilities
+
+- Validated SDK-credit denominator at the tracker boundary.
+- Consistent unknown-state behavior with the existing HTTP comparison route.
+
+## Evidence
+
+- Fifty focused cost-state and routing-cache tests pass.
+- Restoring the zero-total snapshot object makes the boundary test fail.

--- a/upgrades/side-effects/sdk-credit-zero-total.md
+++ b/upgrades/side-effects/sdk-credit-zero-total.md
@@ -1,0 +1,92 @@
+# Side-Effects Review — SDK-credit zero total
+
+**Version / slug:** `sdk-credit-zero-total`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`CostStateTracker.snapshot()` maps invalid total-credit denominators to its
+existing `agentSdkCredit: null` state.
+
+## Decision-point inventory
+
+- SDK-credit snapshot validation — modified.
+- Material-shift comparison — unchanged; it already handles known/unknown
+  transitions.
+- Routing policy — unchanged.
+
+## 1. Over-block
+
+Positive finite totals preserve prior behavior, including a zero remaining
+balance.
+
+## 2. Under-block
+
+Zero, negative, and non-finite totals cannot produce a known consumed fraction.
+Non-finite remaining values are rejected at the same boundary.
+
+## 3. Level-of-abstraction fit
+
+The tracker is the first shared layer that constructs the cached cost-state
+shape. The HTTP comparison route already uses the same denominator rule.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] Yes — the tracker supplies a signal to cache invalidation.
+
+Unknown state may invalidate a cached choice through the existing
+known-to-unknown reason; it does not select a provider by itself.
+
+## 4b. Judgment-point check
+
+No heuristic threshold change. Denominator validity is deterministic.
+
+## 5. Interactions
+
+- **Shadowing:** invalid totals use the established null state.
+- **Double-fire:** one material-shift reason at most.
+- **Races:** snapshot timing and TTL behavior are unchanged.
+- **Feedback loops:** valid provider snapshots are byte-for-byte equivalent.
+
+## 6. External surfaces
+
+Consumers see `agentSdkCredit: null` instead of a contradictory zero-total
+object.
+
+## 6b. Operator-surface quality
+
+Zero total can no longer look like zero consumption.
+
+## 7. Multi-machine posture
+
+Local provider state only; the same validation applies wherever the tracker is
+constructed.
+
+## 8. Rollback cost
+
+Pure validation rollback. No persistence.
+
+## Conclusion
+
+Clear to ship as a bounded cost-state consistency correction.
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** Not required; no provider-selection
+threshold or authority changes.
+
+## Evidence pointers
+
+- `tests/unit/providers/costAwareRouting.test.ts`
+- `tests/unit/providers/uxConfirm/TriggerGate.test.ts`
+- `tests/unit/providers/uxConfirm/FrameworkModelRouter.test.ts`
+- Mutation proof: restoring the zero-total object fails the boundary test.
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Description

Validate SDK-credit snapshots at the `CostStateTracker` boundary. Non-positive or non-finite totals and non-finite remaining values now use the existing unknown state; a zero remaining balance with a positive total stays valid and reports fully consumed.

## ELI16

The routing cache tracks how much of an SDK credit pot has been used. Before this change, a provider could report a total pot of zero and the tracker would still build a “known” credit object with zero-percent consumption. That object contradicted itself: it also said the remaining zero dollars were below the zero-dollar safety margin. The HTTP comparison route already rejects the same denominator. The tracker now returns its existing unknown state for an invalid total, while a genuine zero remaining balance against a positive total continues to mean 100% consumed. Provider-selection thresholds are unchanged.

## UX Impact

Routing-cache and diagnostic consumers now see `agentSdkCredit: null` for a zero-total pot instead of a misleading known object. The boundary test states the contract as `"returns agentSdkCredit: null when total credit is zero"`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Validation

- 50 focused cost-state and routing-cache tests pass.
- Full repository lint and TypeScript checks pass.
- Mutation proof: restoring the old zero-total object fails the boundary test.
- The local affected-test listing timed out inside the repository’s bounded runner and the pre-push gate explicitly deferred that listing to CI.
