### PR TITLE
fix orphan share honesty gate

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T14-47-03-721Z-orphanshare-null-honesty.json
+++ b/.instar/instar-dev-decisions/2026-07-29T14-47-03-721Z-orphanshare-null-honesty.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-07-29T14:47:03.721Z",
+  "slug": "orphanshare-null-honesty",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 64,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/benchmarkDivergenceCore.ts",
+      "src/monitoring/BenchmarkDivergenceAnalyzer.ts",
+      "src/monitoring/FeatureMetricsLedger.ts"
+    ],
+    "addedLines": 57,
+    "deletedLines": 7
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/orphanshare-null-honesty.eli16.md
+++ b/docs/eli16/orphanshare-null-honesty.eli16.md
@@ -1,0 +1,46 @@
+# Orphan Share Null Honesty — Plain-English Overview
+
+> The one-line version: the benchmark-divergence analyzer now treats a missing orphan-share denominator as unknown instead of silently pretending it is zero.
+
+## The problem in one breath
+
+The benchmark-divergence detector compares live graded decisions against a benchmark baseline and emits advisory findings such as aligned, divergent, partial, or insufficient evidence. One of its honesty checks asks whether too many outcomes are orphaned, which means the quality evidence cannot be trusted as a clean comparison. When the analyzer had enough settled grades but the recorded-decision denominator was zero, it produced an orphan share of zero, so the comparison could continue as if the orphan evidence was clean.
+
+That was not honest. A zero denominator means the orphan share is unavailable, not zero. In JavaScript, comparing `null > 0.05` would still behave like `0 > 0.05`, so the comparison site also has to branch on null before any numeric threshold check.
+
+## What already exists
+
+- **Benchmark-divergence analyzer** - reads matured decision-quality rollups and compares model performance against the mirrored benchmark predictions.
+- **Verdict ladder** - turns those inputs into advisory findings. It already has partial verdicts for cases where the comparison should not produce an aligned or divergent conclusion.
+- **Feature metrics ledger** - stores the latest benchmark findings and serves them through the benchmark-divergence API.
+- **Pool merge clamps** - accept only enumerated, content-free finding fields from peers so one machine cannot inject raw text into another machine's findings view.
+
+## What this adds
+
+This change makes the unavailable orphan-share case explicit. The analyzer now passes `null` when the orphan-share denominator is zero, and the verdict ladder returns `partial` with `partialReason: "orphan-share-unavailable"` before any numeric comparison runs. The existing over-threshold orphan-share path also gets `partialReason: "orphan-share-over-threshold"`, so tests can prove the specific reason surfaced rather than only proving that no actionable verdict was reached.
+
+The ledger gains an additive nullable `partial_reason` column for benchmark findings, with an idempotent open-time migration for existing SQLite databases. The API read surface and peer clamp allow only the closed partial-reason enum, preserving the existing content-free envelope.
+
+## The new pieces
+
+- **Partial reason enum** - names the two orphan-share partial cases without accepting free text.
+- **Null branch in the verdict ladder** - handles unavailable orphan share before JavaScript can coerce null during threshold comparison.
+- **Finding persistence field** - stores and returns the partial reason separately from the verdict, so downstream readers can tell "unknown denominator" from "too many orphans".
+
+## The safeguards
+
+**Prevents fabricated certainty.** A zero denominator no longer becomes a fabricated clean zero. The detector says the comparison is partial and names the reason.
+
+**Prevents weak test passes.** The regression tests assert the exact partial reason, not only the absence of an aligned or divergent verdict. A future bug that suppresses every verdict would not satisfy the new assertion.
+
+**Preserves the advisory boundary.** Benchmark-divergence findings remain advisory and content-free. This change does not add a block, allow, route, spawn, kill, or message-send authority.
+
+**Preserves peer safety.** Peer-provided partial reasons are clamped to the local enum and peer-authored free text is still dropped from the merged finding view.
+
+## What ships when
+
+This ships as one small Tier 1 fix: core verdict logic, analyzer producer behavior, ledger persistence, route allowlist, and focused tests in the same change.
+
+## What you actually need to decide
+
+Approve whether the benchmark-divergence detector should report the zero-denominator orphan-share path as `partial` with a distinct closed reason instead of treating it as clean evidence.

--- a/src/core/benchmarkDivergenceCore.ts
+++ b/src/core/benchmarkDivergenceCore.ts
@@ -35,6 +35,12 @@ export const PRECONDITION_REASONS = [
 ] as const;
 export type PreconditionReason = (typeof PRECONDITION_REASONS)[number];
 
+export const PARTIAL_REASONS = [
+  'orphan-share-unavailable',
+  'orphan-share-over-threshold',
+] as const;
+export type PartialReason = (typeof PARTIAL_REASONS)[number];
+
 /** FD8: the chronic streak RESETS only on an actionable verdict. */
 export const ACTIONABLE_VERDICTS: ReadonlySet<DivergenceVerdict> = new Set([
   'divergent-worse',
@@ -138,8 +144,8 @@ export interface VerdictInput {
   wrongN: number;
   /** ALL recorded decisions in the window (the correlation spine, FD2). */
   decidedTotal: number;
-  /** Pool-merged orphan share for the decision point (FD9). */
-  orphanShare: number;
+  /** Pool-merged orphan share for the decision point (FD9); null = denominator unavailable. */
+  orphanShare: number | null;
   /** FD8: every known machine reported for the window. */
   coverageComplete: boolean;
   thresholds: {
@@ -153,6 +159,7 @@ export interface VerdictInput {
 export interface VerdictResult {
   verdict: DivergenceVerdict;
   preconditionReason?: PreconditionReason;
+  partialReason?: PartialReason;
   unmapped?: boolean;
   orphanTainted: boolean;
   realGradeRate: number | null;
@@ -243,9 +250,17 @@ export function computeVerdict(input: VerdictInput): VerdictResult {
   }
 
   // 7. Coverage + orphan honesty gates (R2 applies to the honesty gates too).
+  // A missing denominator is its own partial reason. In JavaScript,
+  // `null > threshold` coerces to `0 > threshold`, so this must branch before
+  // the numeric comparison.
+  if (input.orphanShare === null) {
+    return { ...base, verdict: 'partial', partialReason: 'orphan-share-unavailable' };
+  }
   const orphanTainted = input.orphanShare > input.thresholds.maxOrphanShare;
   if (!input.coverageComplete) return { ...base, verdict: 'partial', orphanTainted };
-  if (orphanTainted) return { ...base, verdict: 'partial', orphanTainted: true };
+  if (orphanTainted) {
+    return { ...base, verdict: 'partial', partialReason: 'orphan-share-over-threshold', orphanTainted: true };
+  }
 
   // 8. Evidence floors (FD2): settled-grades denominator; the unsettled-stream
   //    gate reads decided_total (ALL decisions), so a point-day with a few
@@ -447,6 +462,7 @@ export interface FindingView {
   model: string;
   verdict: DivergenceVerdict;
   preconditionReason?: PreconditionReason;
+  partialReason?: PartialReason;
   realGradeRate: number | null;
   predictedRate: number | null;
   delta: number | null;
@@ -505,6 +521,10 @@ export function clampPeerFinding(raw: unknown, opts: { todayDay: string; maxAgeD
     typeof r.preconditionReason === 'string' && (PRECONDITION_REASONS as readonly string[]).includes(r.preconditionReason)
       ? (r.preconditionReason as PreconditionReason)
       : undefined;
+  const partialReason =
+    typeof r.partialReason === 'string' && (PARTIAL_REASONS as readonly string[]).includes(r.partialReason)
+      ? (r.partialReason as PartialReason)
+      : undefined;
 
   const win = r.analysisWindow && typeof r.analysisWindow === 'object' ? (r.analysisWindow as Record<string, unknown>) : {};
   const fromDay = typeof win.fromDay === 'string' && isValidAggregateDay(win.fromDay, opts.todayDay, opts.maxAgeDays) ? win.fromDay : '';
@@ -529,6 +549,7 @@ export function clampPeerFinding(raw: unknown, opts: { todayDay: string; maxAgeD
     model,
     verdict,
     ...(preconditionReason !== undefined ? { preconditionReason } : {}),
+    ...(partialReason !== undefined ? { partialReason } : {}),
     realGradeRate: clampNum(r.realGradeRate),
     predictedRate: clampNum(r.predictedRate),
     delta: clampNum(r.delta),

--- a/src/monitoring/BenchmarkDivergenceAnalyzer.ts
+++ b/src/monitoring/BenchmarkDivergenceAnalyzer.ts
@@ -35,6 +35,7 @@ import {
   type FindingView,
   type DivergenceVerdict,
   type PreconditionReason,
+  type PartialReason,
 } from '../core/benchmarkDivergenceCore.js';
 import {
   ENROLLED_PAIRS,
@@ -397,6 +398,7 @@ export class BenchmarkDivergenceAnalyzer {
         model: string;
         verdict: DivergenceVerdict;
         preconditionReason?: PreconditionReason;
+        partialReason?: PartialReason;
         unmapped?: boolean;
         orphanTainted: boolean;
         realGradeRate: number | null;
@@ -416,7 +418,7 @@ export class BenchmarkDivergenceAnalyzer {
 
       for (const [decisionPointId, taskId] of Object.entries(ENROLLED_PAIRS)) {
         const decided = decidedByPoint.get(decisionPointId) ?? 0;
-        const orphanShare = decided > 0 ? (orphansByPoint.get(decisionPointId) ?? 0) / decided : 0;
+        const orphanShare = decided > 0 ? (orphansByPoint.get(decisionPointId) ?? 0) / decided : null;
         const registryEntry = PROMPT_TEMPLATE_REGISTRY[taskId];
         const liveHash = liveTemplateHash(taskId);
         const task = mirror.tasks[taskId];
@@ -469,6 +471,7 @@ export class BenchmarkDivergenceAnalyzer {
             model,
             verdict: v.verdict,
             ...(v.preconditionReason !== undefined ? { preconditionReason: v.preconditionReason } : {}),
+            ...(v.partialReason !== undefined ? { partialReason: v.partialReason } : {}),
             ...(v.unmapped !== undefined ? { unmapped: v.unmapped } : {}),
             orphanTainted: v.orphanTainted,
             realGradeRate: v.realGradeRate,
@@ -571,6 +574,7 @@ export class BenchmarkDivergenceAnalyzer {
           model: c.model,
           verdict: c.verdict,
           preconditionReason: c.preconditionReason ?? null,
+          partialReason: c.partialReason ?? null,
           realGradeRate: c.realGradeRate,
           predictedRate: c.predictedRate,
           delta: c.delta,
@@ -741,6 +745,7 @@ export class BenchmarkDivergenceAnalyzer {
       model: row.model,
       verdict: row.verdict,
       preconditionReason: row.preconditionReason ?? undefined,
+      partialReason: row.partialReason ?? undefined,
       realGradeRate: row.realGradeRate,
       predictedRate: row.predictedRate,
       delta: row.delta,

--- a/src/monitoring/FeatureMetricsLedger.ts
+++ b/src/monitoring/FeatureMetricsLedger.ts
@@ -603,6 +603,7 @@ const SCHEMA = [
      model                  TEXT NOT NULL,
      verdict                TEXT NOT NULL,
      precondition_reason    TEXT,
+     partial_reason         TEXT,
      real_grade_rate        REAL,
      predicted_rate         REAL,
      delta                  REAL,
@@ -713,6 +714,10 @@ const ADDED_COLUMNS: Array<{ name: string; ddl: string }> = [
   { name: 'call_id', ddl: 'ALTER TABLE feature_metrics ADD COLUMN call_id TEXT' },
 ];
 
+const BENCHMARK_FINDING_ADDED_COLUMNS: Array<{ name: string; ddl: string }> = [
+  { name: 'partial_reason', ddl: 'ALTER TABLE benchmark_divergence_findings ADD COLUMN partial_reason TEXT' },
+];
+
 /** Batch ceiling for the retention prune (scal-F4): SQLite-portable bounded DELETE. */
 const PRUNE_BATCH = 5000;
 
@@ -800,6 +805,7 @@ export class FeatureMetricsLedger {
     this.db.pragma('synchronous = NORMAL');
     for (const ddl of SCHEMA) this.db.exec(ddl);
     this.ensureAddedColumns();
+    this.ensureBenchmarkFindingAddedColumns();
     this.migrateLegacyNoopOutcomes();
     // Partial index for the quality join (feature_metrics.verdict_id → correlation
     // id, §5.5). Guarded separately from the SCHEMA loop: verdict_id shipped in the
@@ -896,6 +902,21 @@ export class FeatureMetricsLedger {
       // @silent-fallback-ok: a failed column add leaves the DB on the old shape;
       // record() writes the new field as null and the rollup degrades to []
       // rather than throwing. Observability must never break its own open path.
+    }
+  }
+
+  /** Add post-ship columns to the benchmark findings table, idempotently. */
+  private ensureBenchmarkFindingAddedColumns(): void {
+    try {
+      const existing = new Set(
+        (this.db.prepare(`PRAGMA table_info(benchmark_divergence_findings)`).all() as Array<{ name: string }>).map((c) => c.name),
+      );
+      for (const col of BENCHMARK_FINDING_ADDED_COLUMNS) {
+        if (!existing.has(col.name)) this.db.exec(col.ddl);
+      }
+    } catch {
+      // @silent-fallback-ok: old finding rows remain readable; the analyzer can
+      // re-upsert the advisory row with the new field on a later pass.
     }
   }
 
@@ -2352,6 +2373,7 @@ export class FeatureMetricsLedger {
     model: string;
     verdict: string;
     preconditionReason?: string | null;
+    partialReason?: string | null;
     realGradeRate: number | null;
     predictedRate: number | null;
     delta: number | null;
@@ -2380,17 +2402,18 @@ export class FeatureMetricsLedger {
         this.db
           .prepare(
             `INSERT INTO benchmark_divergence_findings
-               (task_id, decision_point, model, verdict, precondition_reason, real_grade_rate, predicted_rate, delta,
+               (task_id, decision_point, model, verdict, precondition_reason, partial_reason, real_grade_rate, predicted_rate, delta,
                 graded_n, unknown_share, ci_half_width, bench_n, bench_ci_half_width, orphan_tainted, chronic,
                 chronic_streak, chronic_reason, coverage_json, dominant_machine_share, unmapped, benched_prompt_hash,
                 mirror_captured_at, window_from_day, window_to_day, first_seen_at, last_seen_at)
-             VALUES (@taskId, @decisionPointId, @model, @verdict, @preconditionReason, @realGradeRate, @predictedRate,
+             VALUES (@taskId, @decisionPointId, @model, @verdict, @preconditionReason, @partialReason, @realGradeRate, @predictedRate,
                 @delta, @gradedN, @unknownShare, @ciHalfWidth, @benchN, @benchCiHalfWidth, @orphanTainted, @chronic,
                 @chronicStreak, @chronicReason, @coverageJson, @dominantMachineShare, @unmapped, @benchedPromptHash,
                 @mirrorCapturedAt, @windowFromDay, @windowToDay, @ts, @ts)
              ON CONFLICT(task_id, decision_point, model) DO UPDATE SET
                verdict = excluded.verdict,
                precondition_reason = excluded.precondition_reason,
+               partial_reason = excluded.partial_reason,
                real_grade_rate = excluded.real_grade_rate,
                predicted_rate = excluded.predicted_rate,
                delta = excluded.delta,
@@ -2418,6 +2441,7 @@ export class FeatureMetricsLedger {
             model: f.model,
             verdict: f.verdict,
             preconditionReason: f.preconditionReason ?? null,
+            partialReason: f.partialReason ?? null,
             realGradeRate: f.realGradeRate,
             predictedRate: f.predictedRate,
             delta: f.delta,
@@ -2492,7 +2516,7 @@ export class FeatureMetricsLedger {
       return this.db
         .prepare(
           `SELECT task_id AS taskId, decision_point AS decisionPointId, model, verdict,
-                  precondition_reason AS preconditionReason, real_grade_rate AS realGradeRate,
+                  precondition_reason AS preconditionReason, partial_reason AS partialReason, real_grade_rate AS realGradeRate,
                   predicted_rate AS predictedRate, delta, graded_n AS gradedN, unknown_share AS unknownShare,
                   ci_half_width AS ciHalfWidth, bench_n AS benchN, bench_ci_half_width AS benchCiHalfWidth,
                   orphan_tainted AS orphanTainted, chronic, chronic_streak AS chronicStreak,

--- a/tests/integration/benchmark-divergence-routes.test.ts
+++ b/tests/integration/benchmark-divergence-routes.test.ts
@@ -111,7 +111,7 @@ function seedGradedDay(day = '2026-07-05', n = 5): void {
 
 /** The frozen FD10 FINDING envelope key set (content-free guarantee). */
 const FINDING_KEY_ALLOWLIST = new Set([
-  'taskId', 'decisionPointId', 'model', 'verdict', 'preconditionReason', 'realGradeRate', 'predictedRate',
+  'taskId', 'decisionPointId', 'model', 'verdict', 'preconditionReason', 'partialReason', 'realGradeRate', 'predictedRate',
   'delta', 'gradedN', 'unknownShare', 'ciHalfWidth', 'benchN', 'benchCiHalfWidth', 'orphanTainted',
   'chronic', 'chronicStreak', 'chronicReason', 'coverage', 'dominantMachineShare', 'unmapped',
   'benchedPromptHash', 'mirrorCapturedAt', 'analysisWindow', 'firstSeenAt', 'lastSeenAt', 'advisory',

--- a/tests/unit/BenchmarkDivergenceAnalyzer.test.ts
+++ b/tests/unit/BenchmarkDivergenceAnalyzer.test.ts
@@ -413,6 +413,20 @@ describe('R2 pool semantics (FD8/FD9)', () => {
     expect(f.orphanTainted).toBe(1); // holder-local share was 0 — only the pool merge catches it
   });
 
+  it('decided_total zero with enough settled grades surfaces orphan-share-unavailable, not fabricated zero', async () => {
+    writeMatchingMirror();
+    seedDecisions('2026-07-05', 30);
+    const rawDb = (ledger as unknown as { db: import('better-sqlite3').Database }).db;
+    rawDb.prepare(`UPDATE decision_quality_rollup_by_model SET decided_total = 0 WHERE decision_point = ?`)
+      .run(DP_MESSAGING_TONE_GATE);
+
+    await analyzer().analyze('manual');
+    const f = ledger.listBenchmarkFindings()[0];
+    expect(f.verdict).toBe('partial');
+    expect(f.partialReason).toBe('orphan-share-unavailable');
+    expect(f.gradedN).toBe(30);
+  });
+
   it('meter stores are BYTE-IDENTICAL with the detector dark, dryRun, and live (FD7 wiring integrity)', async () => {
     writeMatchingMirror();
     seedDecisions('2026-07-05', 30);

--- a/tests/unit/FeatureMetricsLedger-byModel.test.ts
+++ b/tests/unit/FeatureMetricsLedger-byModel.test.ts
@@ -354,6 +354,20 @@ describe('benchmark_divergence_findings — FD11 latest view + capped history', 
     expect(hist[0].verdict).toBe('divergent-worse');
   });
 
+  it('latest-view persists the partial reason separately from the verdict', () => {
+    const l = newLedger(() => T0);
+    l.upsertBenchmarkFinding(finding({
+      verdict: 'partial',
+      partialReason: 'orphan-share-unavailable',
+      orphanTainted: false,
+    }));
+    expect(l.listBenchmarkFindings()[0]).toMatchObject({
+      verdict: 'partial',
+      partialReason: 'orphan-share-unavailable',
+      orphanTainted: 0,
+    });
+  });
+
   it('history cap prunes oldest EXCEPT the first row per key (the first detection is never evicted)', () => {
     let nowMs = T0;
     const l = newLedger(() => nowMs);

--- a/tests/unit/benchmarkDivergenceCore.test.ts
+++ b/tests/unit/benchmarkDivergenceCore.test.ts
@@ -120,7 +120,20 @@ describe('computeVerdict — the FD4 precondition-first ladder', () => {
   it('pool-merged orphan share over the bound ⇒ partial + orphanTainted', () => {
     const v = computeVerdict(healthy({ orphanShare: 0.2 }));
     expect(v.verdict).toBe('partial');
+    expect(v.partialReason).toBe('orphan-share-over-threshold');
     expect(v.orphanTainted).toBe(true);
+  });
+
+  it('unavailable orphan share is a distinct partial reason before numeric comparison', () => {
+    const v = computeVerdict(healthy({
+      rightN: 20,
+      wrongN: 5,
+      decidedTotal: 0,
+      orphanShare: null,
+    }));
+    expect(v.verdict).toBe('partial');
+    expect(v.partialReason).toBe('orphan-share-unavailable');
+    expect(v.orphanTainted).toBe(false);
   });
 
   it('incomplete coverage ⇒ partial (offline machine — re-collected later)', () => {

--- a/upgrades/next/orphanshare-null-honesty.md
+++ b/upgrades/next/orphanshare-null-honesty.md
@@ -1,0 +1,23 @@
+# Upgrade Guide Fragment — Orphan Share Null Honesty
+
+## What Changed
+
+The benchmark-divergence detector no longer treats a zero decided-record denominator as a clean orphan share of zero. When settled grades are present but orphan-share cannot be measured, the advisory finding now becomes `partial` with `partialReason: "orphan-share-unavailable"` before any numeric threshold comparison runs.
+
+The over-threshold orphan path also names its reason as `partialReason: "orphan-share-over-threshold"`. The finding ledger stores the closed partial reason in a nullable additive column, and the benchmark-divergence API exposes it through the same content-free peer clamp used for the rest of the finding envelope.
+
+## What to Tell Your User
+
+The benchmark-divergence readout is more honest when its evidence is internally inconsistent: it now says the comparison is partial instead of presenting a model verdict from an unavailable orphan-share rate.
+
+## Summary of New Capabilities
+
+- Distinct partial reason for unavailable orphan-share evidence.
+- Closed partial-reason field on benchmark-divergence findings and pool reads.
+- Additive SQLite migration for existing benchmark finding ledgers.
+
+## Evidence
+
+- `./node_modules/.bin/vitest run tests/unit/benchmarkDivergenceCore.test.ts tests/unit/FeatureMetricsLedger-byModel.test.ts tests/unit/BenchmarkDivergenceAnalyzer.test.ts tests/integration/benchmark-divergence-routes.test.ts` passed: 4 files, 86 tests.
+- `./node_modules/.bin/tsc --noEmit` passed.
+- The pre-commit hook ran the full repository lint chain and accepted the Tier 1 instar-dev trace.

--- a/upgrades/side-effects/orphanshare-null-honesty.md
+++ b/upgrades/side-effects/orphanshare-null-honesty.md
@@ -1,0 +1,112 @@
+# Side-Effects Review — Orphan Share Null Honesty
+
+**Version / slug:** `orphanshare-null-honesty`
+**Date:** `2026-07-29`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+This change fixes the benchmark-divergence orphan-share honesty path. `src/monitoring/BenchmarkDivergenceAnalyzer.ts` now passes `null` when the orphan-share denominator is zero, `src/core/benchmarkDivergenceCore.ts` branches on that null before the numeric threshold comparison and returns `partialReason: "orphan-share-unavailable"`, and `src/monitoring/FeatureMetricsLedger.ts` persists the new closed reason on the advisory finding read surface. Tests cover the core null branch, the analyzer producer path, ledger persistence, and the route allowlist.
+
+## Decision-point inventory
+
+- `computeVerdict` in `src/core/benchmarkDivergenceCore.ts` - modify - advisory benchmark-divergence verdict classification now distinguishes unavailable orphan share from clean orphan share before threshold comparison.
+- `BenchmarkDivergenceAnalyzer` orphan-share producer - modify - zero decided denominator now produces `null` instead of fabricated `0`.
+- `benchmark_divergence_findings` read surface - modify - persists and serves a closed `partialReason` enum for advisory findings.
+
+---
+
+## 1. Over-block
+
+No block/allow surface - over-block not applicable. The changed verdict is advisory and does not block messages, actions, routing, retention, or execution. The concrete behavior change is that a benchmark finding which previously could be `aligned` or `divergent-*` with `decided_total = 0` and enough settled grades now becomes `partial` with `partialReason: "orphan-share-unavailable"`.
+
+---
+
+## 2. Under-block
+
+No block/allow surface - under-block not applicable. Remaining advisory limitations: the change only addresses the orphan-share denominator being unavailable. It does not reinterpret other inconsistent rollup shapes, and it does not attempt to repair the upstream rollup row. Those cases remain represented by the existing evidence fields such as `gradedN`, `unknownShare`, and the verdict ladder's other preconditions.
+
+---
+
+## 3. Level-of-abstraction fit
+
+This is at the right layer. The analyzer owns production of the pool-merged orphan-share input, while the pure verdict ladder owns the comparison and must therefore branch on null before numeric threshold logic. Persisting the closed reason in the ledger is also the right layer because the API can then surface the reason without recomputing or accepting peer-authored text.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No - this change has no block/allow surface.
+
+The verdict remains an advisory benchmark-divergence finding. It does not gate user messages, external operations, session lifecycle, dispatch, or retention. The only decision point changed is the detector's own content-free advisory classification.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. This is a structural denominator invariant: zero decided records cannot support an orphan-share rate. The closed partial reason reports that invariant instead of making a judgment over competing live signals.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The null branch runs before the existing orphan-share numeric comparison. That ordering is required because JavaScript would otherwise coerce null during comparison.
+- **Double-fire:** No second writer is added. The analyzer still writes one benchmark finding per `(task, decision point, model)` key through the existing upsert.
+- **Races:** The additive SQLite column is added at ledger open with `PRAGMA table_info` guarding. Existing rows default to null and are overwritten by the next idempotent analyzer upsert.
+- **Feedback loops:** The advisory finding can seed chronic-streak logic exactly like other `partial` verdicts. No new loop, cadence, or autonomous action is introduced.
+
+---
+
+## 6. External surfaces
+
+The benchmark-divergence API can now include `partialReason` on finding rows. This is a content-free closed enum and is accepted through the existing peer clamp only when it matches the local enum. Persistent state changes by adding nullable `partial_reason` to `benchmark_divergence_findings`; no destructive migration or data rewrite is required. No operator-facing actions are added.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface - not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Proxied-on-read.** Benchmark-divergence already merges peer findings through `GET /benchmark-divergence?scope=pool` and clamps peer finding fields locally. The new `partialReason` follows that same merged-read path and is a closed enum, not replicated free text. The feature emits no user-facing notices, holds only advisory ledger state, and generates no URLs.
+
+---
+
+## 8. Rollback cost
+
+Hot-fix release: revert the code and tests. The nullable `partial_reason` column can remain harmlessly in existing SQLite databases because older code ignores unknown columns and writes do not depend on it. No agent state repair is needed. During rollback propagation, users may temporarily see less specific benchmark-divergence partial findings or the prior fabricated-zero behavior on agents that have not updated.
+
+---
+
+## Conclusion
+
+Clear to ship as a Tier 1 fix. The review did not identify a new block/allow authority, multi-machine strand, operator surface, or destructive migration. The main risk is API shape expansion, controlled by a closed enum and covered by the route allowlist test.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required
+**Independent read of the artifact:** not required
+
+The change does not touch outbound or inbound messaging, dispatch, session lifecycle, context recovery, coherence gates, trust levels, or a sentinel/guard/watchdog component. It modifies an advisory detector verdict and its read surface only.
+
+---
+
+## Evidence pointers
+
+- `./node_modules/.bin/vitest run tests/unit/benchmarkDivergenceCore.test.ts tests/unit/FeatureMetricsLedger-byModel.test.ts tests/unit/BenchmarkDivergenceAnalyzer.test.ts tests/integration/benchmark-divergence-routes.test.ts` - 4 files passed, 86 tests passed.
+- `./node_modules/.bin/tsc --noEmit` - passed.
+- `rg -n "orphanShare" src tests -S` - only one numeric comparison site remains, in `computeVerdict`.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect - not applicable.


### PR DESCRIPTION
## What changed

- Treat the benchmark-divergence orphan-share denominator as unavailable (`null`) when `decided_total` is zero instead of fabricating a clean `0`.
- Branch on `null` in `computeVerdict` before the orphan-share threshold comparison, so JavaScript coercion cannot let the unavailable case pass as clean.
- Surface closed `partialReason` values for orphan-share partial findings:
  - `orphan-share-unavailable`
  - `orphan-share-over-threshold`
- Persist `partialReason` through the benchmark findings ledger with an additive nullable SQLite column and include it in the content-free API/peer-clamp allowlist.
- Added Tier 1 ELI16, side-effects review, and release-note fragment.

## Root cause

The analyzer produced `orphanShare = 0` when the decided denominator was zero. That allowed the exposed path where `gradedN` clears `minSample` but `decided_total` is zero to reach an aligned/divergent verdict as though orphan evidence was clean. Changing only the producer type would not be sufficient because `null > threshold` coerces through JavaScript numeric comparison; the comparison site now branches on `null` explicitly.

## Constraints addressed

- Confirmed the only numeric `orphanShare` comparison site is `src/core/benchmarkDivergenceCore.ts` in `computeVerdict` (`rg -n "orphanShare" src tests -S`). The analyzer only produces/passes the value.
- The regression tests assert the exact partial reason, not merely failure to reach an actionable verdict.
- I did not find an existing test pinning the fabricated zero behavior. Existing `orphanShare: 0` fixtures are healthy-input defaults, not zero-denominator assertions.

## Validation

- `./node_modules/.bin/vitest run tests/unit/benchmarkDivergenceCore.test.ts tests/unit/FeatureMetricsLedger-byModel.test.ts tests/unit/BenchmarkDivergenceAnalyzer.test.ts tests/integration/benchmark-divergence-routes.test.ts` passed: 4 files, 86 tests.
- `./node_modules/.bin/tsc --noEmit` passed.
- Pre-commit ran the full repository lint chain and accepted the Tier 1 instar-dev trace.
- Pre-push gate accepted the release fragment; affected-test listing timed out and skipped local smoke with CI as authority; branch push succeeded.
