### PR TITLE
fix(spawn): a transient-pressure refusal must not destroy the payload it refused

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-29T23-58-52-850Z-spawn-denial-preserves-payload.json
+++ b/.instar/instar-dev-decisions/2026-07-29T23-58-52-850Z-spawn-denial-preserves-payload.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-29T23:58:52.850Z",
+  "slug": "spawn-denial-preserves-payload",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 46,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/messaging/SpawnRequestManager.ts"
+    ],
+    "addedLines": 44,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/spawn-denial-preserves-payload.eli16.md
+++ b/docs/specs/spawn-denial-preserves-payload.eli16.md
@@ -1,0 +1,109 @@
+# A refused message must not be a deleted message — Plain-English Overview
+
+> The one-line version: when one agent sends another agent work and the receiving machine is too busy to
+> start a session for it, the message was being **thrown away** while both sides reported success — this
+> makes it wait and get retried instead.
+
+## The problem in one breath
+
+Agents hand each other work over a direct channel. When a message arrives, the receiving agent has to
+start up a session to read it. If the machine is short on memory at that exact moment, it refuses to
+start one — which is correct and sensible. What was not correct is that the refusal **deleted the
+message**, and then reported the whole thing as handled. The sending agent was told "delivered." The
+receiving agent's log said "handled." Nobody was told anything had been lost.
+
+I found this because Codey, the agent I hand implementation work to, produced 25 merged changes yesterday
+morning and then nothing at all for the next eight hours. He was not idle and he was not stuck. He was
+unreachable, and the pipe between us was reporting success. His machine logged **40** of these refusals in
+a single day — each one a message that no longer exists.
+
+## What already exists
+
+- **The admission check** — the piece that decides whether a session can be started right now. It looks
+  at four things: has this sender spawned too recently, are we at the session cap, is memory tight, is the
+  subscription quota exhausted. Any of those can refuse. All four are temporary conditions that clear on
+  their own.
+- **A holding queue** — a place to park a message when a session can't be started yet. It already
+  existed, and two of the four refusal paths already used it.
+- **A retry loop** — already running, on every agent, every five seconds. It looks for messages sitting
+  in the holding queue and tries again to start a session for them. This is the part that made the fix
+  small: the delivery machinery was already there and already trying. The messages just weren't being put
+  where it could find them.
+
+## What this adds
+
+There were six exits from the admission check that don't start a session. Three parked the message; three
+destroyed it. This fixes the two where non-delivery is *certain*, and deliberately leaves the third alone.
+
+**Fixed — memory tight.** The one that cost eight hours of Codey's day, and every one of the forty
+observed losses.
+
+**Fixed — at the session cap.** Same defect, same shape, three lines away. Session caps clear as sessions
+finish, so it is temporary in exactly the same way.
+
+**Deliberately NOT fixed — the session failed to start.** I did fix this one, and then removed the fix,
+which is the most useful thing that happened during this change. To build the startup instructions the
+code empties the whole holding queue first, so a failed start destroys everything it took out. The obvious
+repair is to put them back. But starting a session happens in two steps: the session is created and handed
+the message, and *then* it gets recorded — and the recording step can fail on its own, outside any error
+handling. So "starting failed" does not mean "nothing arrived." Putting the message back would have
+delivered the same instruction to a second live session. That trades a rare lost message for a rare
+duplicated one, and a duplicate can act twice. The real prerequisite is upstream: once a session is alive
+and holding the work, it should stop reporting failure just because the paperwork afterwards failed.
+
+**Still drops, correctly — a message over the hard size limit.** That is a permanent rejection, not a
+temporary one, so parking it would just re-refuse it forever.
+
+**One extra line.** There are two limits on how much can wait in the holding area. Going over the
+per-sender limit already left a mark; going over the overall limit left none at all — the one kind of loss
+with no trace whatsoever. It leaves a mark now.
+
+## The safeguards
+
+**A refusal is still a refusal.** Nothing about *whether* to start a session changed — not a threshold,
+not a priority rule, not a single reason message. I checked whether the memory limit was simply set too
+low, because loosening it would have been the easy answer. It isn't set too low: the machine's overflow
+space was 94% full, so the guard was right to fire every time it fired. The fix is that firing no longer
+destroys anything.
+
+**A retry can't turn one message into two.** The retry loop's own attempt carries no message, so a refused
+retry can't re-file a copy of what it was trying to deliver. And a message that *is* delivered is taken out
+of the holding area in the same instant, with no pause in between, so two things happening at once can't
+both pick it up. Two tests pin this, including one confirming a delivered message is not left behind for a
+second send.
+
+**The tests were checked against the old code first.** Every new test was run against the unfixed version
+to confirm it actually fails there. A test that passes either way proves nothing, and I have shipped that
+mistake before.
+
+## What this does not fix
+
+Four things, stated plainly because they are easy to gloss over:
+
+- **The sender is still told "delivered."** After this change that's roughly true — the message is parked
+  for imminent retry rather than deleted — but if it later ages out or gets pushed out by newer messages,
+  the sender still won't know. Fixing that properly means changing what the receiving side reports back,
+  which touches more callers than this change should.
+- **The queue doesn't survive a restart.** It lives in memory. If the server restarts between a message
+  being parked and being delivered, it's gone.
+- **A machine wedged for more than ten minutes still drops.** Messages expire from the queue after ten
+  minutes. On the machine where I found this, the memory pressure cleared every 30–80 seconds against a
+  five-second retry, so this wasn't the operating case — but a genuinely stuck machine will still lose
+  messages.
+- **A failed session start still loses its messages**, for the reason above.
+
+All four are tracked as real follow-through items rather than left as good intentions.
+
+## What ships when
+
+One change, one pull request. There's no phasing, no flag, and no rollout stage, because there is no
+configuration under which silently deleting an accepted message is the behavior anyone wants. Rolling it
+back is a single revert with no state to clean up.
+
+## What you actually need to decide
+
+Nothing — this is a defect fix with no policy question in it, and no decision is being handed to you.
+
+The judgment worth flagging: I widened the scope to all three broken paths after finding the same defect
+twice more, then narrowed it back to two when review proved the third repair would have introduced a worse
+bug than the one it fixed. What ships is the part where non-delivery is certain rather than assumed.

--- a/src/messaging/SpawnRequestManager.ts
+++ b/src/messaging/SpawnRequestManager.ts
@@ -582,6 +582,12 @@ export class SpawnRequestManager {
       : this.#config.maxSessions;
     if (activeSessions.length >= liveMaxSessions) {
       if (request.priority !== 'critical' && request.priority !== 'high') {
+        // Queue the payload, like every other transient-pressure denial here: a
+        // session cap clears as running sessions finish — this branch sets
+        // retryAfterMs itself — so the content must survive the wait.
+        if (request.context) {
+          this.#queueMessage(agent, request.context, request.pendingMessages?.[0]);
+        }
         return {
           approved: false,
           reason: `Session limit reached (${activeSessions.length}/${liveMaxSessions}). Priority ${request.priority} insufficient to override.`,
@@ -590,8 +596,20 @@ export class SpawnRequestManager {
       }
     }
 
-    // Check memory pressure
+    // Check memory pressure. Queue the message (like cooldown and the quota
+    // gate below) rather than dropping it: memory pressure is transient — this
+    // very branch sets retryAfterMs — and the content must survive it. Before
+    // this, memory pressure was the ONLY transient-pressure denial that
+    // destroyed the payload, so an A2A dispatch arriving during a pressure
+    // window was silently deleted while both the caller (`handled: true` from
+    // ThreadlineRouter) and the remote sender (`delivered: true`) recorded
+    // success. Observed live 2026-07-29: 40 such denials on one machine in a
+    // day, oscillating across the threshold every 30-80s, each one a lost
+    // inbound message.
     if (this.#config.isMemoryPressureHigh?.()) {
+      if (request.context) {
+        this.#queueMessage(agent, request.context, request.pendingMessages?.[0]);
+      }
       return {
         approved: false,
         reason: 'Memory pressure too high for new session',
@@ -622,6 +640,18 @@ export class SpawnRequestManager {
     // fast-failing spawns still pays the cooldown.
     this.#lastSpawnByAgent.set(agent, this.#nowFn());
 
+    // NOTE (deliberately NOT restoring these on failure — see below): #drainQueue
+    // empties the queue here because the prompt has to carry the payloads, so a
+    // spawn that throws destroys them. That is a real defect, but the obvious fix
+    // — put them back in the catch — is UNSAFE against the real `spawnSession`
+    // implementation: SessionManager.spawnSession creates the live tmux session
+    // WITH the prompt, and only afterwards calls state.saveSession() outside any
+    // try/catch. A throw from that bookkeeping step means the payloads were
+    // already DELIVERED, so re-queueing them would deliver the same instruction
+    // to a second live session. Restoring here would trade a rare lost message
+    // for a rare duplicated one, which is worse — a duplicate can act twice.
+    // The prerequisite is making spawnSession stop reporting failure once the
+    // session is live and holding the prompt. Tracked: CMT-1114.
     try {
       const queuedMessages = this.#drainQueue(agent);
       const prompt = this.#buildSpawnPrompt(request, queuedMessages);
@@ -660,6 +690,9 @@ export class SpawnRequestManager {
     } catch (err) {
       const cause = this.#classifyFailure(err);
       this.#applyFailureAttribution(agent, cause);
+      // Deliberately NOT re-queueing here. A `spawnSession` rejection does not
+      // prove non-delivery (see the note above the try), so putting the payload
+      // back risks delivering the same instruction twice. Tracked: CMT-1114.
       return {
         approved: false,
         reason: `Spawn failed (${cause}): ${err instanceof Error ? err.message : 'unknown error'}`,
@@ -740,7 +773,16 @@ export class SpawnRequestManager {
     const maxGlobal = this.#config.maxGlobalQueued ?? DEFAULT_MAX_GLOBAL_QUEUED;
     let totalQueued = 0;
     for (const q of this.#pendingMessages.values()) totalQueued += q.length;
-    if (totalQueued >= maxGlobal) return false;
+    if (totalQueued >= maxGlobal) {
+      // Mark the agent truncated before refusing. Callers discard this boolean
+      // (all five callsites are `if (request.context) { #queueMessage(...) }`),
+      // so without the marker a global-cap refusal was the one queue loss with
+      // NO trace at all — indistinguishable from a successful enqueue, which is
+      // the same silent-loss shape this whole area is being fixed for. The
+      // per-agent cap below already sets it; this makes the global cap match.
+      this.#truncated.add(agent);
+      return false;
+    }
 
     let queue = this.#pendingMessages.get(agent);
     if (!queue) {

--- a/tests/unit/spawn-request-manager.test.ts
+++ b/tests/unit/spawn-request-manager.test.ts
@@ -189,6 +189,54 @@ describe('SpawnRequestManager', () => {
       expect(result.approved).toBe(true);
     });
 
+    // ── Payload preservation at the session cap ─────────────────
+    //
+    // A session cap is transient — it clears as running sessions finish, and the
+    // branch sets retryAfterMs itself — so a denial here must not destroy the
+    // payload. This branch used to drop it, like the memory-pressure branch did.
+
+    it('queues the message content when denied at the session limit', async () => {
+      let atLimit = true;
+      config = makeConfig({
+        cooldownMs: 0,
+        maxSessions: 2,
+        getActiveSessions: () => (atLimit ? [makeSession('s1'), makeSession('s2')] : []),
+      });
+      manager = new SpawnRequestManager(config);
+
+      const denied = await manager.evaluate(
+        makeRequest({ priority: 'medium', context: 'queued-at-session-cap' }),
+      );
+      expect(denied.approved).toBe(false);
+      // The verdict is unchanged — this preserves the payload, it does not
+      // weaken the cap.
+      expect(denied.reason).toContain('Session limit reached');
+      expect(denied.retryAfterMs).toBe(60_000);
+      expect(manager.getQueuedCount('agent-a')).toBe(1);
+
+      // A session finishes; the next attempt carries the queued payload.
+      atLimit = false;
+      const approved = await manager.evaluate(
+        makeRequest({ priority: 'medium', context: 'second message' }),
+      );
+      expect(approved.approved).toBe(true);
+      const prompt = (config.spawnSession as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(prompt).toContain('queued-at-session-cap');
+      expect(manager.getQueuedCount('agent-a')).toBe(0);
+    });
+
+    it('control — session-limit denial with NO context queues nothing', async () => {
+      config = makeConfig({
+        maxSessions: 2,
+        getActiveSessions: () => [makeSession('s1'), makeSession('s2')],
+      });
+      manager = new SpawnRequestManager(config);
+
+      const result = await manager.evaluate(makeRequest({ priority: 'medium' }));
+      expect(result.approved).toBe(false);
+      expect(manager.getQueuedCount('agent-a')).toBe(0);
+    });
+
     // ── Live cap accessor (codex-instar audit Item 2) ─────────
     //
     // Regression: the manager used to read `maxSessions` from the
@@ -293,6 +341,123 @@ describe('SpawnRequestManager', () => {
       const result = await manager.evaluate(makeRequest());
       expect(result.approved).toBe(true);
     });
+
+    // ── Payload preservation under memory pressure ──────────────
+    //
+    // Memory pressure used to be the ONLY transient-pressure denial that
+    // destroyed the request payload (cooldown and the subscription-quota gate
+    // both queue it). An A2A dispatch arriving in a pressure window was
+    // silently deleted while ThreadlineRouter reported `handled: true` and the
+    // remote sender reported `delivered: true`. Observed live 2026-07-29: one
+    // machine oscillated across the threshold every 30-80s and logged 40 such
+    // denials in a day, each a lost inbound message.
+
+    it('queues the message content under memory-pressure denial (content survives the pressure)', async () => {
+      config = makeConfig({
+        isMemoryPressureHigh: () => true,
+      });
+      manager = new SpawnRequestManager(config);
+
+      const result = await manager.evaluate(
+        makeRequest({ context: 'important peer message' }),
+      );
+
+      expect(result.approved).toBe(false);
+      // The denial verdict itself is unchanged — this fix preserves the
+      // payload, it does not weaken the guard.
+      expect(result.reason).toContain('Memory pressure');
+      expect(result.retryAfterMs).toBe(120_000);
+
+      expect(manager.getStatus().queuedMessages).toEqual([
+        { agent: 'agent-a', count: 1 },
+      ]);
+    });
+
+    it('delivers the queued payload to the next approved spawn once pressure clears', async () => {
+      let underPressure = true;
+      const spawnSession = vi.fn().mockResolvedValue('spawned-session-id');
+      config = makeConfig({
+        cooldownMs: 0, // isolate the pressure gate from the cooldown gate
+        isMemoryPressureHigh: () => underPressure,
+        spawnSession,
+      });
+      manager = new SpawnRequestManager(config);
+
+      const denied = await manager.evaluate(
+        makeRequest({ context: 'queued-under-memory-pressure' }),
+      );
+      expect(denied.approved).toBe(false);
+      expect(spawnSession).not.toHaveBeenCalled();
+
+      underPressure = false;
+      const approved = await manager.evaluate(
+        makeRequest({ context: 'second message' }),
+      );
+
+      expect(approved.approved).toBe(true);
+      expect(spawnSession).toHaveBeenCalledTimes(1);
+      const prompt = spawnSession.mock.calls[0][0] as string;
+      expect(prompt).toContain('queued-under-memory-pressure');
+      expect(prompt).toContain('second message');
+      // Drained, not duplicated.
+      expect(manager.getStatus().queuedMessages).toEqual([]);
+    });
+
+    it('control — memory-pressure denial with NO context queues nothing', async () => {
+      config = makeConfig({
+        isMemoryPressureHigh: () => true,
+      });
+      manager = new SpawnRequestManager(config);
+
+      const result = await manager.evaluate(makeRequest()); // no `context`
+
+      expect(result.approved).toBe(false);
+      expect(result.reason).toContain('Memory pressure');
+      // An empty payload must not create a phantom queue row.
+      expect(manager.getStatus().queuedMessages).toEqual([]);
+    });
+
+    // ── Global-cap refusal must leave a trace ───────────────────
+    //
+    // Every callsite discards `#queueMessage`'s boolean return
+    // (`if (request.context) { #queueMessage(...) }`), so a global-cap refusal
+    // used to be the ONE queue loss with no trace at all — indistinguishable
+    // from a successful enqueue. That is the same silent-loss shape this area is
+    // being fixed for, so the global cap now sets the truncation marker the
+    // per-agent cap already set. Found by second-pass review, 2026-07-29.
+
+    it('marks the agent truncated when the GLOBAL queue cap refuses the payload', async () => {
+      config = makeConfig({
+        cooldownMs: 0,
+        maxGlobalQueued: 2,
+        isMemoryPressureHigh: () => true,
+      });
+      manager = new SpawnRequestManager(config);
+
+      // Fill the global queue to its cap with two other agents' payloads.
+      await manager.evaluate(makeRequest({
+        requester: { agent: 'agent-x', session: 's', machine: 'm' },
+        context: 'first',
+      }));
+      await manager.evaluate(makeRequest({
+        requester: { agent: 'agent-y', session: 's', machine: 'm' },
+        context: 'second',
+      }));
+      expect(manager.getQueuedCount('agent-x')).toBe(1);
+      expect(manager.getQueuedCount('agent-y')).toBe(1);
+      expect(manager.isTruncated('agent-z')).toBe(false); // control: clean before
+
+      // Third agent's payload cannot be admitted — global cap is reached.
+      const refused = await manager.evaluate(makeRequest({
+        requester: { agent: 'agent-z', session: 's', machine: 'm' },
+        context: 'lost-to-global-cap',
+      }));
+
+      expect(refused.approved).toBe(false);
+      expect(manager.getQueuedCount('agent-z')).toBe(0); // genuinely not queued
+      // The loss is now accounted rather than silent.
+      expect(manager.isTruncated('agent-z')).toBe(true);
+    });
   });
 
   // ── Spawn Failure ───────────────────────────────────────────
@@ -320,6 +485,30 @@ describe('SpawnRequestManager', () => {
       const result = await manager.evaluate(makeRequest());
       expect(result.approved).toBe(false);
       expect(result.reason).toContain('unknown error');
+    });
+
+
+    // Control on the queueing fix: a payload rescued from a pressure denial must
+    // be delivered EXACTLY once — drained into the successful spawn's prompt and
+    // NOT left sitting in the queue for the drain loop to send again.
+    it('control — a queued payload is delivered exactly once, not re-queued', async () => {
+      let underPressure = true;
+      const spawnSession = vi.fn().mockResolvedValue('spawned-session-id');
+      config = makeConfig({
+        cooldownMs: 0,
+        isMemoryPressureHigh: () => underPressure,
+        spawnSession,
+      });
+      manager = new SpawnRequestManager(config);
+
+      await manager.evaluate(makeRequest({ context: 'delivered-once' }));
+      underPressure = false;
+      const ok = await manager.evaluate(makeRequest());
+
+      expect(ok.approved).toBe(true);
+      expect(spawnSession.mock.calls[0][0]).toContain('delivered-once');
+      // Drained and delivered — must NOT be sitting in the queue for a re-send.
+      expect(manager.getQueuedCount('agent-a')).toBe(0);
     });
   });
 

--- a/upgrades/next/spawn-denial-preserves-payload.md
+++ b/upgrades/next/spawn-denial-preserves-payload.md
@@ -1,0 +1,79 @@
+# A refused agent-to-agent message is no longer a deleted one
+
+## What Changed
+
+`SpawnRequestManager.evaluate()` — the admission funnel every inbound agent-to-agent dispatch passes
+through before a session is spawned for it — had six exits that do not spawn. Three preserved the
+inbound payload by queueing it; three destroyed it. All transient-pressure exits now preserve it:
+
+- **Memory pressure** — now queues the payload (was: dropped it).
+- **Session limit** — now queues the payload (was: dropped it).
+- **Spawn threw** — deliberately UNCHANGED. This branch also destroys payloads, and an earlier revision
+  of this change restored them — but second-pass review proved that unsafe and it was removed.
+  `SessionManager.spawnSession` creates the live tmux session *with the prompt* and only afterwards calls
+  `state.saveSession()` outside any `try/catch`, so a rejection does NOT prove non-delivery. Restoring
+  would risk delivering the same instruction to a second live session — trading a rare lost message for a
+  rare duplicated one. The prerequisite is upstream: `spawnSession` must stop reporting failure once the
+  session is live and holding the prompt. <!-- tracked: CMT-1114 -->
+- **`envelope-too-large`** — still drops, deliberately: it is a permanent size rejection, not transient,
+  so queueing it would re-refuse the same oversized payload on every drain tick.
+
+Every denial verdict is byte-for-byte unchanged — same predicate, same `reason`, same `retryAfterMs`. No
+threshold, priority rule, or gate was touched. Queued payloads join the drain loop
+(`runTick` / `onDrainReady`) that was already running on a 5-second tick, so delivery lands at the next
+window instead of never.
+
+One further line: a GLOBAL-cap refusal in `#queueMessage` now sets the existing `#truncated` marker. It
+returns `false` before any marker logic and every callsite discards that boolean, so this was the one
+queue loss that left no trace at all — the same silent-loss shape being fixed here.
+
+## Evidence
+
+Found live on a two-agent machine, 2026-07-29:
+
+- **40** `Spawn denied: Memory pressure too high for new session` entries in one agent's server log in a
+  single day. Each one destroyed its payload.
+- Three dispatches confirmed lost at `19:45:23.541Z`, `23:18:33.406Z`, `23:20:35.503Z` — each logged
+  `handled: true` alongside the spawn-denied error, while the sending agent's `threadline_send` returned
+  `{"delivered":true,"outcome":"accepted"}`. Both ends recorded success.
+- Impact: the receiving agent merged 25 PRs up to `15:01Z` then produced nothing for 8 hours. Not idle —
+  unreachable, with the transport reporting success.
+- Pressure was genuine, not a miscalibrated threshold (checked, because loosening it would have been the
+  cheap answer): swap 16361 MB used of 17408 MB (94%), compressor holding ~7.3 GB, total RSS 7.9 GB on
+  16 GB of RAM.
+- The retry driver was already live and already trying: `[spawn-manager] drain re-attempt for echo not
+  approved: …` at `09:32:28.013Z` and `09:32:33.021Z`, 5 seconds apart, `tick=5000ms`.
+
+Tests: 5 added to `tests/unit/spawn-request-manager.test.ts` (3 positive, 2 pure controls) plus one
+renamed exactly-once control. **Every new test was run against the unfixed source first** — 5 failed / 78
+passed on original code; the two no-context controls passed on both old and new, proving they
+discriminate. With the fix: 83/83. Wider run across `spawn-request-manager`, `subscription-quota-gates`,
+`threadline/ThreadlineRouter`, `SpawnAdmission` and `threadline-fixes`: 197 passed. `tsc --noEmit` exits
+0 and the 33-lint chain passes.
+
+The running copy provably carries the defect: both agents' installed
+`dist/messaging/SpawnRequestManager.js` shows the memory-pressure branch returning with no enqueue.
+
+Known limits, tracked rather than papered over: the sender is still told `delivered: true` (CMT-1111),
+the queue does not survive a server restart (CMT-1112), no class-level guard exists yet (CMT-1113), and
+the spawn-failure branch still loses payloads pending the upstream truthfulness fix (CMT-1114).
+
+## What to Tell Your User
+
+If two of your agents hand each other work, a message could previously be **deleted** when the receiving
+machine was briefly short on memory or at its session cap — and both sides reported success, so neither
+you nor the agents had any way to know. That is fixed: a refused message now waits and is retried
+automatically, usually within a minute.
+
+The symptom this explains: an agent that looks idle for hours despite being handed work, with no error
+anywhere. It was not idle — it was unreachable behind a transport that reported delivery.
+
+Two honest limits. If a machine stays under pressure for more than ten minutes, messages can still
+expire; and if the agent's server restarts while a message is waiting, that message is lost. Neither is
+left as a good intention — both are tracked. <!-- tracked: CMT-1111 --> <!-- tracked: CMT-1112 -->
+
+## Summary of New Capabilities
+
+No new capability, endpoint, config key, or flag — this is a defect fix in existing behavior. Rollback is
+a single revert with no state to clean up. The pre-existing kill switch for the retry machinery
+(`threadline.spawn.drainEnabled: false`) is unchanged.

--- a/upgrades/side-effects/spawn-denial-preserves-payload.md
+++ b/upgrades/side-effects/spawn-denial-preserves-payload.md
@@ -1,0 +1,421 @@
+# Side-Effects Review — a transient-pressure spawn refusal must not destroy the payload it refused
+
+**Version / slug:** `spawn-denial-preserves-payload`
+**Date:** `2026-07-29`
+**Author:** `echo`
+**Second-pass reviewer:** `required (session-lifecycle / spawn surface)`
+
+## Summary of the change
+
+`SpawnRequestManager.evaluate()` is the admission funnel every inbound agent-to-agent dispatch passes
+through before a session is spawned to handle it. It has six exits that do not spawn. Three of them
+destroyed the inbound payload; three did not. This change makes the whole set consistent, so a refusal
+never means data loss.
+
+Before → after, all six exits:
+
+| Exit | Transient? | Before | After |
+|---|---|---|---|
+| `envelope-too-large` | no — permanent rejection | drops | **drops (correct, unchanged)** |
+| cooldown | yes | queues | queues |
+| session limit | yes (`retryAfterMs: 60_000`) | **drops** | **queues** |
+| memory pressure | yes (`retryAfterMs: 120_000`) | **drops** | **queues** |
+| subscription quota | yes | queues | queues |
+| spawn threw | yes (`retryAfterMs: 30_000`) | drains queue, then destroys all of it | **UNCHANGED — restoring is unsafe, see §1a. Tracked: CMT-1114** |
+
+Files touched:
+
+- `src/messaging/SpawnRequestManager.ts` — the two missing
+  `if (request.context) { #queueMessage(...) }` guards, plus one line making a GLOBAL-cap refusal set
+  the truncation marker (§1a finding 2). **Every denial verdict — predicate, `reason` string, and
+  `retryAfterMs` — is byte-for-byte unchanged.**
+- `tests/unit/spawn-request-manager.test.ts` — 5 tests added (3 positive, 2 pure controls) plus one
+  renamed exactly-once control.
+
+**Scope was CUT after second-pass review.** An earlier revision of this change also restored the drained
+queue when `spawnSession` threw. Review proved that unsafe and it was removed — §1a below.
+
+Live evidence (this machine, 2026-07-29):
+
+- Codey's `logs/server.log` carries **40** `Spawn denied: Memory pressure too high for new session`
+  entries in one day.
+- Three of my own dispatches to him were destroyed this way, at `19:45:23.541Z`, `23:18:33.406Z`,
+  `23:20:35.503Z`. Each logged `async handleInboundMessage complete: {"handled":true,...,"error":"Spawn
+  denied: Memory pressure too high for new session"}` and each returned
+  `{"delivered":true,"outcome":"accepted"}` to me.
+- Consequence: Codey merged 25 PRs up to `15:01Z` and then produced nothing for eight hours. He was not
+  idle — he was **unreachable, and the transport reported success to both ends.**
+- His `MemoryPressureMonitor` oscillates 70–78% against the default `elevated: 75` threshold, flipping
+  every 30–80 seconds, so roughly half of all inbound A2A dispatches were coin-flipped into deletion.
+
+I explicitly considered and **rejected** raising the pressure threshold, which would have been the
+cheap answer. The pressure is genuine, not miscalibrated: swap 16.4 GB used of 17.4 GB (94%), total RSS
+7.9 GB plus 7.3 GB held by the compressor on a 16 GB machine, and only ~67 MB safely reclaimable. The
+guard is right to fire. The defect is that firing destroyed data.
+
+**Scope grew, then was cut back.** I opened this to fix memory pressure. Auditing the function's other
+exits for this artifact found the same defect twice more, so I fixed all three — the third being the worst,
+since `#drainQueue` empties the queue *before* the spawn and a throw destroyed everything it had taken,
+including payloads the cooldown and quota branches had just rescued. Second-pass review then proved the
+third fix UNSAFE (§1a) and it was removed. The remaining two are the ones with the live evidence behind
+them: every one of the 40 observed losses was a memory-pressure denial, which happens *before* any spawn
+is attempted, so nothing could have been delivered.
+
+## Decision-point inventory
+
+- `SpawnRequestManager.evaluate()` — session-limit gate — **pass-through** — verdict identical in every
+  input case; payload retained on the already-denied path.
+- `SpawnRequestManager.evaluate()` — memory-pressure gate — **pass-through** — same.
+- `SpawnRequestManager.evaluate()` — spawn-failure catch — **untouched** (an earlier revision changed it;
+  reverted after review, see §1a).
+- `#queueMessage()` global-cap refusal — **modified, non-decision** — still refuses exactly the same
+  payloads; now sets the existing `#truncated` marker so the refusal leaves a trace.
+
+No decision point is added, modified, or removed. No threshold, predicate, or priority rule is touched.
+
+---
+
+## 1. Over-block
+
+**No block/allow surface change — over-block not applicable.** Nothing new can be refused. Every
+predicate and reason string is unchanged, and pinned tests assert the unchanged verdict (`reason`
+contains, `retryAfterMs` exact) *alongside* each new queue assertion, specifically so a later edit
+cannot quietly turn one of these into a threshold change.
+
+The nearest real concern is queue *capacity*, in §2 and §5.
+
+---
+
+## 1a. What second-pass review changed (the scope cut)
+
+Review ran BEFORE this shipped and produced one blocking finding and one accuracy finding. Both are
+recorded here rather than quietly absorbed, because the first one means an earlier revision of this
+change would have made things worse.
+
+**Finding 1 — BLOCKING. Restoring the drained queue on a failed spawn can DUPLICATE delivery.**
+The removed code assumed a `spawnSession` rejection proves nothing was delivered. I verified that
+assumption against the real implementation and it is false. `SessionManager.spawnSession`:
+
+1. calls `execFileSync(tmux, ['new-session', '-d', …headlessSpec.argv])` — this creates a LIVE process
+   already running the framework CLI **with the full prompt**, which is the moment of delivery;
+2. that call sits in a `try/catch` that rethrows only tmux-creation failures;
+3. **after** that block, it builds the `Session` object and calls `this.state.saveSession(session)`
+   — outside any `try/catch` — and only then returns.
+
+So a throw from `saveSession` (disk I/O, a `guardWrite` refusal, a serialization edge) means the payload
+was **already delivered** while `spawnSession` reports failure. The restore would have put that payload
+back, and the drain loop — 5 seconds later — would have delivered the same instruction to a second live
+session. Two real agent processes acting on one instruction.
+
+That is strictly worse than the bug being fixed: a lost message is recoverable by re-sending, a duplicated
+instruction can act twice. And the failure modes are *correlated* — `saveSession` I/O failures are more
+likely under exactly the memory pressure this change targets, not less.
+
+I considered three ways to keep the restore safely and rejected all three:
+- **Gate on `#classifyFailure`'s cause.** The real `spawnSession` never throws `SpawnFailureError`, so
+  every production failure classifies as `ambiguous` — the restore would either never fire (useless) or
+  fire on the unsafe case (the bug).
+- **String-match the tmux-creation error message.** Brittle, and prohibited by the project's own rule
+  against matching on text where structure is required.
+- **Ask whether the session exists before restoring.** `SpawnRequestManager` has no such accessor;
+  `getActiveSessions()` reads persisted state, which is precisely what failed to write.
+
+So the restore was **removed**, not weakened. The prerequisite is upstream: `spawnSession` must stop
+reporting failure once the session is live and holding the prompt — a bookkeeping failure after delivery
+should be reported without rejecting. That is the same defect class this whole change is about, wearing
+the opposite mask: **an operation that succeeded and reported failure.** Tracked: CMT-1114.
+
+What ships is the part with the live evidence: all 40 observed losses were memory-pressure denials, which
+occur *before* any spawn is attempted, so non-delivery there is structural rather than assumed.
+
+**Finding 2 — accuracy. My own §2.1 claim was false for the global cap.**
+I had written that queue loss now "goes through an accounted, marked, capped path instead of an unrecorded
+`return`." True for the per-agent cap. False for the global cap: `#queueMessage` returns `false` as its
+first statement, before any marker logic, and **every callsite discards the boolean**. So a global-cap
+refusal was the one queue loss with no trace whatsoever. I fixed the code to make the sentence true
+(the global-cap path now sets `#truncated`) rather than softening the sentence to match the code.
+
+**Findings the review cleared:** TTL preservation was correct; no ordering bug from moving the drain; and
+the three specific claims it checked (verdicts byte-for-byte unchanged, the drain request carries no
+`context`, a successful spawn does not restore) were all accurate as stated.
+
+**Reviewer's non-blocking note, now moot:** it observed that restore-at-the-front combined with
+front-first truncation could re-discard the very entries being rescued. Removing the restore removes that
+question entirely.
+
+---
+
+## 2. Under-block
+
+Framed as under-*fix*, since there is no block surface:
+
+1. **Sustained pressure can still lose content, but no longer silently — and this claim is now true for
+   BOTH caps.** `#queueMessage` enforces a per-agent cap (drops oldest, sets `#truncated`) and a global
+   cap. Review caught that my first draft of this sentence was FALSE for the global cap: it returns
+   `false` as its very first statement, before any marker logic, and **every callsite discards that
+   boolean** (`if (request.context) { #queueMessage(...) }`), so a global-cap refusal was the one queue
+   loss with no trace at all — exactly the silent-loss shape this change exists to remove. Rather than
+   soften the sentence I made the code match it: the global-cap path now sets `#truncated` too. Content
+   can still be lost under sustained pressure; it can no longer be lost invisibly.
+2. **The 10-minute TTL still applies.** `QUEUE_MAX_AGE_MS` is 10 minutes, and `#drainQueue` filters
+   expired entries. A machine wedged above the threshold for longer than that will still drop. On the
+   machine where the loss was observed, windows open every 30–80 seconds against a 5-second drain tick,
+   so this is not the operating case.
+3. **The sender is still told `delivered: true`.** `ThreadlineRouter`'s `handled: true` on denial is
+   deliberately untouched here. After this change that report is *approximately* true — the payload is
+   accepted for imminent retry rather than deleted — but a cap-drop or TTL expiry remains invisible to
+   the remote peer. Fixing it means changing the router's return contract and its callers, a wider blast
+   radius than this change should carry. <!-- tracked: CMT-1111 -->
+4. **The queue does not survive a restart.** It is in-process memory, so a server restart between
+   enqueue and drain loses queued entries. This is the pre-existing behavior of the two branches that
+   already queued; this change matches them rather than diverging. <!-- tracked: CMT-1112 -->
+5. **`envelope-too-large` still drops, and should.** It is not transient — the payload is over a hard
+   byte cap, so queueing it would store the oversized content and re-refuse it every drain tick. Its
+   sender deserves an honest rejection, which is a different fix (see §2.3), not a queue slot.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Right layer, and deliberately the smallest one that closes the class.
+
+The loss happened inside `evaluate()`, so `evaluate()` is where it is fixed. Two alternatives were
+considered and rejected:
+
+- **Fix it in `ThreadlineRouter`** (have the router queue on denial): wrong layer. The router is one of
+  several `evaluate()` callers, so the loss would remain for all the others. Fixing the property at the
+  admission funnel covers every caller at once — which is the same argument the constitution's
+  fix-the-property-not-the-instance rule makes.
+- **Add a retry driver**: unnecessary, and would have been a duplicate. One already exists and is
+  already running: `runTick()` plus the `onDrainReady` callback wired in `src/commands/server.ts`
+  re-attempt a spawn for any agent holding queued messages, on a **5-second** tick, enabled by default
+  (`spawnManager.start()` unless `threadline.spawn.drainEnabled === false`). Codey's log proves it live
+  — `09:32:28.013Z` and `09:32:33.021Z` both read `[spawn-manager] drain re-attempt for echo not
+  approved: Memory pressure too high for new session`, five seconds apart, for this exact agent.
+
+So this change builds no new machinery. It connects a dropped payload to the retry driver that was
+already there and already trying, using the `#queueMessage` primitive that was already being called
+twice in the same function.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change has no block/allow surface.
+
+Each gate remains exactly the authority it already was, with the same threshold, predicate, and verdict.
+No detector is added and no blocking logic is introduced. The change makes existing authorities'
+denials **non-destructive**, which strengthens the principle rather than bending it: today a guard's
+action is externally indistinguishable from a message-eating bug, so an operator cannot tell a working
+guard from a broken one by observing it. After this change, a denial means "not now" instead of
+"deleted" — the guard becomes legible.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+**No new static heuristic at a competing-signals decision point.** No heuristic is added at all. The
+two conditionals introduced are `if (request.context)` — a structural presence check on a field, copied
+verbatim from the two sibling branches precisely so the four cases cannot drift apart — and the
+global-cap marker, which fires on an already-existing comparison rather than introducing a threshold. No
+signal is weighed against another.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** branch order in `evaluate()` is unchanged. Each new `#queueMessage` call runs
+  immediately *before* an existing `return`, so nothing that previously ran is now skipped.
+- **Double-fire:** no, and this was the sharpest thing to verify. Three independent reasons, in order of
+  how load-bearing they are:
+  1. **`#drainQueue` is fully synchronous and deletes the map key before returning** (`this.#pendingMessages.delete(agent)`),
+     and there is no `await` between the drain and that delete. So two concurrent `evaluate()` calls for
+     the same agent — say an inline inbound and the drain loop's own re-attempt interleaving — cannot both
+     receive the same entries: the first takes them all, the second sees an empty queue. This is the
+     property that makes the restore safe to add at all.
+  2. **The cooldown stamp serializes the common case.** `#lastSpawnByAgent.set` happens *before* the spawn
+     and is never rolled back, so a second request for the same agent while one is in flight hits the
+     cooldown branch and queues rather than racing.
+  3. **Restore only runs when the spawn threw**, meaning nothing in that prompt reached a session, so
+     putting the payloads back cannot re-deliver work that already arrived.
+  `#drainQueue(agent)` is also called on the spawn path only, after every denial branch — so a denial can
+  never drain the queue it just wrote to.
+  The drain loop's re-attempt is a synthetic request carrying **no** `context` (verified by reading
+  `onDrainReady` in `src/commands/server.ts`), so a re-attempt that is itself refused cannot enqueue a
+  duplicate of the payload it is trying to deliver — the two no-context control tests pin exactly this.
+  And the restore path only runs when `spawnSession` **threw**, meaning nothing in that prompt reached a
+  session, so restoring cannot cause a double delivery. A dedicated control test asserts a *successful*
+  spawn drains and does **not** restore.
+- **Races:** `#pendingMessages` is a plain `Map` mutated from the single-threaded event loop; `runTick`
+  guards re-entry with `#tickInflight`. No new shared state and no new mutation ordering: the queueing
+  calls happen on paths that already returned without touching anything else.
+- **Feedback loops:** none. Queueing cannot affect the pressure reading, the pressure monitor, the
+  session count, or the cooldown/penalty state, so no new call can influence its own gate.
+- **Failure-attribution and escalation:** `#applyFailureAttribution` still runs first in the catch, and
+  `handleDenial`'s escalation is untouched. The restore is additive to the existing failure path.
+- **Global cap: bound preserved, and its refusal is no longer silent.** With the restore removed, nothing
+  in this change can exceed `DEFAULT_MAX_GLOBAL_QUEUED` (1000) — `#queueMessage` is the only enqueue path
+  and it checks the global total first. The change here is that the refusal now sets `#truncated` (see
+  §2.1). Per-agent growth stays bounded by `MAX_QUEUED_PER_AGENT` (10), or
+  `DEGRADED_MAX_QUEUED_PER_AGENT_DEFAULT` (1) once `isInfraDegraded()` trips after
+  `INFRA_FAILURE_THRESHOLD` (5) infra failures in 10 minutes — so a peer that repeatedly fails spawns has
+  its queue footprint reduced, not expanded.
+- **One consequence of the marker worth naming:** `isTruncated(agent)` will now report true in a case it
+  did not before (global-cap refusal). Its only consumer treats it as an advisory "this agent's queue lost
+  something" signal, and `#drainQueue` still clears it on the next successful drain, so the new true is
+  more accurate rather than newly load-bearing.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** yes, positively and by design — this is the transport that
+  carries work between agents. No interface change: `SpawnResult` fields are identical.
+- **Install base:** every agent receives it on update. The behavioral delta is strictly "a payload that
+  was previously destroyed is now retried," which is why it ships without a flag — there is no
+  configuration under which silently deleting an accepted message is the desired behavior.
+- **External systems:** none. No Telegram, Slack, GitHub, or network surface.
+- **Persistent state:** none. The queue is in-process memory; nothing is written to disk.
+- **Timing / runtime conditions:** delivery timing depends on when pressure clears and on the 5-second
+  drain tick — outside our control, honestly bounded by the 10-minute TTL (§2.2). No *new* timing
+  dependency: the change joins a path that was already scheduled.
+- **Operator surface (Mobile-Complete Operator Actions):** **no operator-facing action** is added or
+  touched. Queue depth is already observable via `getStatus().queuedMessages` and `getQueuedCount()`,
+  and the existing `threadline.spawn.drainEnabled` kill switch is unchanged.
+
+---
+
+## 6b. Operator-surface quality
+
+**No operator surface — not applicable.** No dashboard renderer, approval page, or grant/secret-drop
+form is staged in this change.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN**, with the reason: this queue holds transient inbound payloads for sessions
+that will run **in this machine's own process**, gated by **this machine's own** memory reading and
+session count. A payload queued on machine A must be delivered by A, because the session that consumes
+it is A's. Replicating it would be actively wrong — it would let machine B spawn a session for a message
+A accepted, which is exactly the duplicate-session class the pool's ownership rules exist to prevent.
+
+- **User-facing notices:** none — this path emits no user-facing message, so no one-voice gating is
+  needed. (The absence of *any* notice on loss is the honest gap recorded in §2.3, tracked as CMT-1111.)
+- **Durable state / topic transfer:** none, so nothing can strand on a transfer. A queued payload dies
+  with the process — pre-existing behavior, tracked as CMT-1112.
+- **Generated URLs:** none.
+
+The pool-wide question ("did a peer's dispatch reach me?") is already answered by a separate
+proxied-on-read surface: `GET /threadline/peers/health`, whose `pendingCount` / `stale` fields are how I
+first noticed 126 unacked messages to this peer.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert this commit and ship as the next patch. Behavior returns exactly to
+  dropping payloads on those three exits.
+- **Data migration:** none. No schema, file, ledger, or config key is introduced.
+- **Agent state repair:** none. Nothing to notify or reset; queued entries are in-memory and expire on
+  their own within 10 minutes.
+- **User visibility:** none during the rollback window. Rolling back restores the previous silent-loss
+  behavior; it cannot corrupt state or leave a half-applied condition.
+- **Pre-existing kill switch:** an operator who wants the drain machinery off entirely already has
+  `threadline.spawn.drainEnabled: false`, unchanged by this work.
+
+Close to the cheapest possible rollback: one revert, no state.
+
+---
+
+## Conclusion
+
+The review did real work three times, and the most valuable pass was the one that took work away.
+
+First it grew the scope correctly: auditing the function's other exits for the decision-point inventory
+found the same defect in two more branches.
+
+Then it corrected a claim I would otherwise have shipped. I had planned to describe the fix as "the
+payload survives until the peer sends again," because I assumed no retry driver existed. Reading for §3
+found `runTick` / `onDrainReady` already wired and started by default, and Codey's own log showed it
+re-attempting for this exact agent every five seconds.
+
+Then second-pass review cut the scope back, and this is the part that matters most. My third fix would
+have turned a rare lost message into a rare duplicated instruction, because I asserted "the spawn threw
+so nothing was delivered" from the shape of `evaluate()` without reading what the injected `spawnSession`
+actually does. It creates the live session with the prompt and *then* does work that can throw. I could
+not have found that by re-reading my own diff — I had read it several times and thought it was sound —
+which is the whole argument for the gate existing.
+
+What ships is smaller than what I built and better evidenced: the two branches that refuse *before* any
+spawn is attempted, where non-delivery is structural rather than assumed, plus one line making the last
+silent queue-loss path leave a trace. Four honest limits remain, each with a real tracked commitment
+(CMT-1111, CMT-1112, CMT-1113, CMT-1114) rather than a good intention.
+
+Clear to ship.
+
+---
+
+## Second-pass review
+
+**Reviewer:** independent reviewer (fresh context, no prior involvement in the change)
+**Independent read of the artifact: CONCERN RAISED — resolved by cutting scope.**
+
+- **Duplicate delivery via partial-success-then-throw** — CONFIRMED by my own reading of
+  `SessionManager.spawnSession` (tmux `new-session` delivers the prompt; `state.saveSession()` runs
+  afterwards outside any `try/catch`). The offending code was **removed**, not softened. §1a finding 1;
+  tracked CMT-1114.
+- **Global-cap refusal is silent, so §2.1's "accounted, marked, capped" was inaccurate** — CONFIRMED
+  (`return false` precedes all marker logic; all callsites discard the boolean). **Code changed so the
+  claim is true**, rather than the claim changed to match the code. §1a finding 2.
+- **Restored-entries-truncated-first** — non-blocking, now moot with the restore removed.
+- Categories the reviewer cleared: TTL preservation, drain-move ordering, and three specific artifact
+  claims it checked independently.
+
+I verified both findings against the source myself before accepting them rather than taking the review on
+trust; the blocking one reproduces in the code as described.
+
+## Evidence pointers
+
+- **Live repro, three destroyed dispatches:** `instar-codey/logs/server.log` at `19:45:23.541Z`,
+  `23:18:33.406Z`, `23:20:35.503Z` — each `handled:true` carrying
+  `error: "Spawn denied: Memory pressure too high for new session"`, each returning
+  `{"delivered":true,"outcome":"accepted"}` to the sender.
+- **Denial volume:** 40 matches for `Spawn denied: Memory pressure` in that log for 2026-07-29.
+- **Retry driver proven live:** same log, `09:32:28.013Z` and `09:32:33.021Z` —
+  `[spawn-manager] drain re-attempt for echo not approved: …`, five seconds apart. Tick confirmed
+  `tick=5000ms` at `[spawn-manager] drain loop started`.
+- **Pressure genuinely high (threshold not miscalibrated):** `vm.swapusage` 16385 MB used of 17408 MB
+  (94%); `Pages occupied by compressor` 467843 × 16 KB ≈ 7.3 GB; total RSS across 427 processes 7.9 GB
+  on 16 GB of RAM; ~67 MB safely reclaimable.
+- **Negative control run BEFORE trusting the tests, and re-run after the scope cut:** with
+  `src/messaging/SpawnRequestManager.ts` stashed to original, **5 of the new tests FAIL (5 failed / 78
+  passed)**; the two pure no-context controls PASS on both old and new code, proving they discriminate
+  rather than merely agreeing with whatever is in front of them. With the fix restored: **83/83 pass**.
+- **Wider runs, all green:** `spawn-request-manager` + `subscription-quota-gates` +
+  `threadline/ThreadlineRouter` + `SpawnAdmission`; `threadline-fixes` + `NovelFailureReviewer`.
+- `npx tsc --noEmit` exits 0; `npm run lint` (33-lint chain) passes.
+- **The running copy provably has the defect:** both agents' installed
+  `dist/messaging/SpawnRequestManager.js` shows the memory-pressure branch returning with no enqueue —
+  so this is a live defect in deployed code, not a source-only observation.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+**No agent-authored-artifact defect — not applicable.** This is a defect in hand-written TypeScript, not
+in an LLM prompt, hook, config, skill, or standards text. It also adds no self-triggered controller: the
+retry driver it feeds (`runTick` / `onDrainReady`) already exists, is already bounded by DRR quantum,
+`maxDrainsPerTick`, per-agent and global queue caps, and a 10-minute entry TTL, and is not modified here.
+No new firing edge is added: the two queueing calls sit on paths that already returned a denial, and
+neither can extend an entry's lifetime.
+
+For the record, the defect's *shape* is the one this project has spent the week cataloguing — an
+operation that fails and reports success. The guard that would generalize it does not exist: a rule that
+a transient-pressure refusal must never destroy the payload it refused. Three of six branches in one
+function had it wrong, and nothing in the repo would have caught any of them. That standards gap is
+tracked, not closed here. <!-- tracked: CMT-1113 -->


### PR DESCRIPTION
## ELI16 — a message one agent sends another was being deleted when the receiving machine was busy, while both sides reported success

Agents hand each other work over a direct channel. When a message arrives, the receiving agent has to start a session to read it. If the machine is short on memory at that moment it refuses to start one — which is correct. What was **not** correct is that the refusal **threw the message away**, and then reported the whole thing as handled. The sender was told "delivered." The receiver's log said "handled." Nobody was told anything was lost.

That is how Codey went eight hours producing nothing after merging 25 changes. He was not idle and not stuck — he was **unreachable**, and the pipe between us was reporting success. His machine logged 40 of these in one day.

**What already existed:** a holding queue for messages that can't be started yet, and a retry loop already running on every agent every five seconds, looking for queued messages and trying again. The delivery machinery was there and already trying. The messages just weren't being put where it could find them.

**What this changes:** the two refusal paths where it is *certain* nothing was delivered — memory tight, and at the session cap — now park the message instead of deleting it, so the existing retry picks it up, usually within a minute. Plus one line so that hitting the overall queue limit leaves a trace; it was previously the one kind of loss with no record at all.

**What it deliberately does not change, and this is the interesting part:** there is a third path that loses messages, I fixed it too, and then I **removed** that fix. Starting a session happens in two steps — the session is created and handed the message, and *then* it gets recorded — and the recording step can fail on its own, outside any error handling. So "starting failed" does not mean "nothing arrived." Putting the message back would have delivered the same instruction to a *second* live session. That trades a rare lost message for a rare duplicated one, and a duplicate can act twice. The real prerequisite is upstream: once a session is alive and holding the work, it should stop reporting failure just because the paperwork afterwards failed.

**I also checked the lazy answer first.** The memory limit could simply have been set too low — loosening it would have been a one-line change. It isn't too low: the machine's overflow space was 94% full. The guard was right to fire every single time. The defect was that firing destroyed data.

**Nothing to decide.** No new capability, endpoint, config key or flag; rolling it back is one revert with no state to clean up.

---

## The defect

`SpawnRequestManager.evaluate()` is the admission funnel every inbound agent-to-agent dispatch passes through before a session is spawned for it. It has **six exits that do not spawn**. Three preserved the inbound payload by queueing it; **three destroyed it** — and the destruction was reported as success at both ends.

Found live, not theorised. Codey merged 25 PRs up to `15:01Z` on 2026-07-29 and then produced nothing for eight hours. He was **not idle — he was unreachable, behind a transport reporting delivery**:

- **40** `Spawn denied: Memory pressure too high for new session` entries in his log in one day, each destroying its payload.
- Three of my dispatches confirmed destroyed at `19:45:23.541Z`, `23:18:33.406Z`, `23:20:35.503Z`. Each logged `handled: true` alongside the spawn-denied error; each returned `{"delivered":true,"outcome":"accepted"}` to me.
- His `MemoryPressureMonitor` oscillates 70–78% against the default `elevated: 75`, flipping every 30–80s — so roughly **half** of all inbound A2A dispatches were coin-flipped into deletion.
- The running copy provably carries it: both agents' installed `dist/messaging/SpawnRequestManager.js` shows the memory-pressure branch returning with no enqueue.

I considered and **rejected** the cheap fix of raising the threshold. The pressure is genuine: swap **16.4 GB used of 17.4 GB (94%)**, compressor holding ~7.3 GB, RSS 7.9 GB on 16 GB, only ~67 MB safely reclaimable. The guard is right to fire. The defect is that firing deleted data.

## The change

| Exit | Transient? | Before | After |
|---|---|---|---|
| `envelope-too-large` | no — permanent | drops | drops (correct) |
| cooldown | yes | queues | queues |
| **session limit** | yes (`retryAfterMs: 60_000`) | **drops** | **queues** |
| **memory pressure** | yes (`retryAfterMs: 120_000`) | **drops** | **queues** |
| subscription quota | yes | queues | queues |
| spawn threw | yes | drains then destroys | **UNCHANGED — see below** |

Plus one line: a **GLOBAL-cap refusal** in `#queueMessage` now sets the existing `#truncated` marker. It returns `false` before any marker logic and every callsite discards that boolean, so it was the one queue loss leaving *no trace at all*.

**Every denial verdict is byte-for-byte unchanged** — same predicate, same `reason`, same `retryAfterMs`. No threshold, priority rule, config key, flag, endpoint or persistent state is touched. Queued payloads join the drain loop (`runTick` / `onDrainReady`) that was **already running on a 5-second tick** — proven live in the affected machine's own log (`[spawn-manager] drain re-attempt for echo not approved: …` at `09:32:28.013Z` and `09:32:33.021Z`). This change builds no new machinery; it connects a dropped payload to the retry driver that was already there and already trying.

## Why the third broken branch is deliberately NOT fixed

I did fix it, then **removed the fix** after independent second-pass review — the most useful thing that happened here.

`#drainQueue` empties the queue *before* the spawn because the prompt has to carry the payloads, so a spawn that throws destroys them. The obvious repair is to restore them in the `catch`. That is **unsafe** against the real implementation: `SessionManager.spawnSession` calls `execFileSync(tmux, ['new-session', '-d', …])` — creating a **live process already holding the full prompt**, which is the moment of delivery — and only *afterwards* calls `state.saveSession()` **outside any `try/catch`**. So a throw from that bookkeeping step means the payload was **already delivered** while `spawnSession` reports failure. Restoring would have re-delivered the same instruction to a second live session ~5s later.

That trades a rare lost message for a rare **duplicated instruction**, which is worse — a duplicate can act twice. And the failure modes are *correlated*: `saveSession` I/O failures are more likely under exactly the memory pressure this change targets.

Three ways to keep it safely were considered and rejected (gate on `#classifyFailure` — every production failure is `ambiguous`, so it would never fire or fire on the unsafe case; string-match the tmux error — brittle and against project rules; ask whether the session exists — no accessor, and `getActiveSessions()` reads the state that just failed to write). The prerequisite is upstream: `spawnSession` must stop reporting failure once the session is live and holding the prompt. Tracked **CMT-1114**.

What ships is the part where non-delivery is **structural rather than assumed** — and all 40 observed losses were memory-pressure denials, which occur before any spawn is attempted.

## Verification

- **Every new test run against the unfixed source FIRST**: 5 failed / 78 passed there. The two pure no-context controls **pass on both old and new code**, proving they discriminate rather than agreeing with whatever is in front of them. With the fix: **83/83**.
- Wider run across `spawn-request-manager`, `subscription-quota-gates`, `threadline/ThreadlineRouter`, `SpawnAdmission`, `threadline-fixes`: **197 passed**.
- `tsc --noEmit` clean; the 33-lint chain clean.

## Honest limits, each with a real tracker

- **CMT-1111** — the sender is still told `delivered: true`; a later cap-drop or TTL expiry stays invisible to the peer.
- **CMT-1112** — the queue is in-process memory and does not survive a server restart.
- **CMT-1113** — no class-level guard exists for "a transient-pressure refusal must never destroy the payload it refused". Three of six branches had it wrong and nothing in the repo would have caught any of them.
- **CMT-1114** — the spawn-failure branch, above.

## Process

Tier 1 declared at the gate's own `riskFloor=1` (the `suggestedTier=2` came from the size component, 46 LOC in 1 file, not from risk). Zero decision-point change; rollback is one revert with no state to clean up. Second-pass review was performed and was load-bearing — it **blocked** the original three-branch version, and I verified its finding against `SessionManager` myself before accepting it rather than taking it on trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTwDm67w3D11kLCWP3VDRR
