### PR TITLE
fix: keep delivered spawns truthful after state-write failure

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-30T01-58-29-659Z-spawn-postdelivery-bookkeeping-truth.json
+++ b/.instar/instar-dev-decisions/2026-07-30T01-58-29-659Z-spawn-postdelivery-bookkeeping-truth.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-30T01:58:29.659Z",
+  "slug": "spawn-postdelivery-bookkeeping-truth",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 26,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SessionManager.ts"
+    ],
+    "addedLines": 25,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/spawn-postdelivery-bookkeeping-truth.eli16.md
+++ b/docs/specs/spawn-postdelivery-bookkeeping-truth.eli16.md
@@ -1,0 +1,40 @@
+# A Delivered Spawn Must Not Report Failure — Plain-English Overview
+
+> The one-line version: once a new agent session is alive and already has its instruction, a failure to save the monitoring record must be reported as degraded bookkeeping, not as a failed delivery that invites the same instruction to run twice.
+
+## The problem in one breath
+
+Starting a headless agent session happens in two distinct moments. First, the system creates the live terminal process and puts the full instruction into its launch command. Then it writes a small session record so dashboards, limits, and cleanup logic can track that process. The second step can fail even though the first one already succeeded. Until now, that bookkeeping error escaped as a generic spawn failure, so a caller could reasonably retry work that was already running.
+
+That ambiguity blocked the safe completion of the adjacent message-loss repair. Putting a supposedly failed message back into the retry queue is safe only when it truly was not delivered. If the session was already alive, retrying can create two agents acting on the same instruction.
+
+## What already exists
+
+- **A truthful launch boundary** — failure while creating the terminal session already throws and remains a real spawn failure.
+- **A session-state record** — after launch, the system stores the session identity and monitoring metadata.
+- **Visible degradation reporting** — operational failures can be surfaced without pretending the primary action failed.
+- **A retrying message queue** — transiently refused agent-to-agent work can wait for another attempt, but it must never requeue work that was already delivered.
+
+## What this adds
+
+The post-launch state write is now explicitly treated as bookkeeping. If it fails, the system logs and reports that degradation, returns the already-live session to the caller, and does not emit a false failure signal. The launch path itself is unchanged: if the terminal session cannot be created, the method still throws.
+
+A regression test proves the exact boundary. It forces the state write to fail after capturing one successful terminal launch, then verifies that the prompt appears in that single launch, the session remains live, and the method resolves instead of rejecting. The test was run before the implementation change and failed on the escaped state-write error; it passes after the fix.
+
+## The safeguards
+
+**No delivery retry is invented.** The change does not queue, resend, or recreate anything. It only prevents successful delivery from masquerading as failure.
+
+**Real launch failures remain loud.** The existing terminal-creation error boundary is untouched. A failure before the process exists still rejects exactly as before.
+
+**The degraded state remains visible and actionable.** The bookkeeping exception is not swallowed silently. It produces both a direct error log and the existing structured degradation report with the exact session id and terminal-session name. That report states the full consequence: the live process is outside normal monitoring and automatic reaping and can survive a restart until it is cleaned up manually.
+
+**The interactive reroute path is unchanged.** That path saves state before it injects the prompt, so its state-write failure does not prove delivery. Applying the same rule there would be dishonest.
+
+## What ships when
+
+This is one narrow runtime fix with one discriminating regression test and no configuration, migration, endpoint, or rollout flag. It can be reverted as a single code change and leaves no new durable state.
+
+## What you actually need to decide
+
+Nothing: this closes a false-failure defect by making the return value match the delivery event that has already happened.

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -2617,7 +2617,31 @@ rm()  { "${shimRunner}" rm  "$@"; }
       completionMode: 'exit',
     };
 
-    this.state.saveSession(session);
+    try {
+      this.state.saveSession(session);
+    } catch (err) {
+      // The headless launch argv already carried the prompt into a successfully
+      // created tmux session. A persistence failure here is therefore
+      // post-delivery bookkeeping, not a spawn failure. Rejecting would invite
+      // the caller to redrive the same payload into a second live session.
+      const reason = err instanceof Error ? err.message : String(err);
+      const identifiedReason =
+        `Session "${tmuxSession}" (${sessionId}) state persistence failed: ${reason}`;
+      console.error(
+        `[SessionManager] Session "${tmuxSession}" is live and the prompt was delivered, ` +
+        `but session bookkeeping failed: ${reason}`,
+      );
+      DegradationReporter.getInstance().report({
+        feature: 'SessionManager.spawnSession.persistDeliveredSession',
+        primary: 'Persist the already-delivered headless session record',
+        fallback: 'Return the live session without converting delivery into a false spawn failure',
+        reason: identifiedReason,
+        impact:
+          `The caller will not duplicate the delivered prompt, but untracked tmux session ` +
+          `"${tmuxSession}" (${sessionId}) is outside normal monitoring and automatic reaping ` +
+          `and may survive restart until manually cleaned up`,
+      });
+    }
     return session;
   }
 

--- a/tests/unit/headless-spawn-reroute.test.ts
+++ b/tests/unit/headless-spawn-reroute.test.ts
@@ -76,6 +76,7 @@ vi.mock('node:child_process', () => {
 
 import { SessionManager } from '../../src/core/SessionManager.js';
 import { StateManager } from '../../src/core/StateManager.js';
+import { DegradationReporter } from '../../src/monitoring/DegradationReporter.js';
 import type { SessionManagerConfig } from '../../src/core/types.js';
 
 /** Helper: the newest captured new-session argv. */
@@ -168,6 +169,42 @@ describe('headless-spawn reroute', () => {
     // headless tmux block does NOT set the wide interactive pane geometry.
     expect(argv).not.toContain('200');
     expect(argv).not.toContain('50');
+  });
+
+  it('delivery truth: post-launch session bookkeeping failure does not report the delivered prompt as failed', async () => {
+    const { manager, state } = makeManager({ framework: 'claude-code' }, tmpDir);
+    const saveSpy = vi.spyOn(state, 'saveSession')
+      .mockImplementationOnce(() => { throw new Error('simulated session-state write failure'); });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const reportSpy = vi.spyOn(DegradationReporter.getInstance(), 'report')
+      .mockImplementation(() => {});
+
+    try {
+      const session = await manager.spawnSession({
+        name: 'job-bookkeeping-fail',
+        prompt: 'deliver this exactly once',
+      });
+
+      expect(newSessionArgvs).toHaveLength(1);
+      expect(launchArgvFrom(lastNewSessionArgv(), CLAUDE)).toContain('deliver this exactly once');
+      expect(mockTmuxSessions.has(session.tmuxSession)).toBe(true);
+      expect(saveSpy).toHaveBeenCalledWith(expect.objectContaining({
+        id: session.id,
+        tmuxSession: session.tmuxSession,
+        status: 'running',
+      }));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(
+        `Session "${session.tmuxSession}" is live and the prompt was delivered`,
+      ));
+      expect(reportSpy).toHaveBeenCalledWith(expect.objectContaining({
+        feature: 'SessionManager.spawnSession.persistDeliveredSession',
+        reason: expect.stringContaining(`"${session.tmuxSession}" (${session.id})`),
+        impact: expect.stringContaining('outside normal monitoring and automatic reaping'),
+      }));
+    } finally {
+      reportSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 
   // ── V2: force + claude-code → interactive lane, no -p ──

--- a/upgrades/next/spawn-postdelivery-bookkeeping-truth.md
+++ b/upgrades/next/spawn-postdelivery-bookkeeping-truth.md
@@ -1,0 +1,23 @@
+# A delivered agent session no longer reports a false launch failure
+
+## What Changed
+
+A headless session launch creates the live terminal process with its full instruction first, then writes a session record for monitoring. If that record write failed, the launch method used to reject even though the new agent was already running the instruction. Callers could then retry the same work into a second live session.
+
+The post-launch record write is now classified as degraded bookkeeping: it is logged and structurally reported with the exact session identity, but the already-live session is returned as success. Real failures before the terminal session exists still reject exactly as before. The interactive reroute path is unchanged because it injects its instruction only after persistence, so a write failure there does not prove delivery.
+
+The tradeoff is explicit: if the first record write fails, the live terminal session is outside normal monitoring and automatic reaping and may survive restart until manually cleaned up. Reporting the launch as failed would not fix that orphan; it would additionally invite a second agent to run the same instruction. The identified orphan is the safer and observable outcome.
+
+## Evidence
+
+The new regression forces the session-state write to throw after one successful captured tmux launch. Against the unfixed source, the suite produced 25 passes and one failure: the simulated bookkeeping exception escaped. With the fix, all 26 tests pass, and the regression proves one launch, the exact prompt in that launch, a live session, and a resolved result.
+
+Adjacent verification passed 131/131 assertions across headless spawn behavior, spawn-request queue behavior, framework portability, interactive session caps, and silent-fallback enforcement. `npm run lint` also passed, including TypeScript checking and the complete repository lint chain.
+
+## What to Tell Your User
+
+If one agent starts work handed to it by another agent, it will no longer claim the start failed merely because the monitoring record could not be saved afterward. That prevents the sender from launching the same instruction twice while keeping the bookkeeping problem visible for diagnosis.
+
+## Summary of New Capabilities
+
+No new capability, endpoint, setting, or operator action. This corrects the success/failure boundary of existing headless session launches. Rollback is a single revert with no state migration.

--- a/upgrades/side-effects/spawn-postdelivery-bookkeeping-truth.md
+++ b/upgrades/side-effects/spawn-postdelivery-bookkeeping-truth.md
@@ -1,0 +1,135 @@
+# Side-Effects Review — a delivered headless spawn must not report failure
+
+**Version / slug:** `spawn-postdelivery-bookkeeping-truth`
+**Date:** `2026-07-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `spawn-truth-review (independent Codex reviewer)`
+
+## Summary of the change
+
+`SessionManager.spawnSession()` creates a headless tmux session with the full prompt in its launch argv, then persists the session record. The persistence call was outside the launch `try/catch`, so a state-write exception rejected the method after delivery had already occurred. This change catches only that post-delivery bookkeeping exception, reports the degradation, and returns the live `Session`. The real tmux-creation failure boundary is unchanged. The runtime change is in `src/core/SessionManager.ts`; the discriminating regression is in `tests/unit/headless-spawn-reroute.test.ts`.
+
+Build location was re-grounded before editing: the branch starts at current `upstream/main` `30189100f` (`v1.3.1068`), with `upstream` resolving to `https://github.com/JKHeadley/instar.git` and `package.json` version `1.3.1068`. The worktree helper refused because this running legacy project-bound agent is absent from the new global registry, so an existing clean Instar-owned worktree under this agent's home was switched to a fresh branch at that exact upstream head; no stale branch content or unrelated changes were carried forward.
+
+## Decision-point inventory
+
+- `SessionManager.spawnSession()` post-launch persistence result — **modified** — a state-write exception after successful headless launch now reports degraded bookkeeping and resolves with the already-live session.
+- `SessionManager.spawnSession()` tmux launch result — **pass-through** — failure before the terminal session exists still rejects through the existing launch `try/catch`.
+- `SpawnRequestManager` spawn-failure retry decision — **interaction only** — it no longer receives a false rejection for an already-delivered headless prompt, preventing an unsafe redrive.
+
+---
+
+## 1. Over-block
+
+**No new rejection surface.** The change removes one false rejection after delivery. Legitimate launch failures, session-cap refusals, worktree-lock failures, and tmux-name collisions remain byte-for-byte on their existing rejecting paths.
+
+---
+
+## 2. Under-block
+
+Framed as under-fix because this change does not block:
+
+1. A live headless session whose first state write fails is absent from persisted monitoring, session counts, dashboard reads, kill-by-id, and normal cleanup. `OrphanProcessReaper` classifies the unknown tmux name as external rather than adopting it, so there is no later automatic reconciliation: it can survive restart indefinitely until manually cleaned up. The structured degradation report includes the exact tmux name and session id and states this consequence. Returning failure would not repair the missing state; it would add duplicate-delivery risk, so this orphan posture is the explicitly accepted lower-risk outcome.
+2. The rerouted-interactive path is intentionally unchanged. It creates a live REPL, saves state, and only then injects the prompt asynchronously. A state-write failure there does **not** prove prompt delivery, so the headless truth rule cannot honestly be copied to that path.
+3. `StateManager.saveSession()` can mutate older duplicate-name records through best-effort stale-record supersession before the new record's atomic write fails. It does not publish a partially written new record: the new file is written through a temp-file rename, lifecycle-journal emission is non-throwing, and cache invalidation follows only after the atomic write returns. The accepted degraded shape is therefore an untracked live process, potentially alongside already-superseded older records.
+
+---
+
+## 3. Level-of-abstraction fit
+
+This is the correct layer. `SessionManager.spawnSession()` is the only function that knows the ordering of the two events: successful tmux creation with the prompt, then state persistence. `SpawnRequestManager` cannot safely reconstruct that truth from a generic exception or from persisted state, because persisted state is the operation that failed. Fixing the return contract at the source lets every caller distinguish actual launch failure from post-delivery bookkeeping failure without new error-string matching, probing, or duplicate recovery machinery.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change has no block/allow surface.
+
+The boundary is an enumerable ordering invariant, not a judgment about message meaning: after `execFileSync(tmux new-session …prompt)` returns successfully, delivery has occurred; before it returns, delivery is not claimed. No detector, heuristic, threshold, or conversational authority is added. The existing structured degradation reporter receives the bookkeeping failure as an observation.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+**No new static heuristic at a competing-signals decision point.** The choice depends on a single causal boundary in one synchronous function: whether the tmux creation call already returned successfully. There are no competing liveness, ownership, urgency, or conversation signals to arbitrate.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the new catch surrounds only `state.saveSession(session)` after the headless launch block. It cannot shadow tmux creation errors, worktree resolution errors, reroute admission refusals, or pre-launch validation.
+- **Double-fire:** this closes a double-fire hazard. A caller that receives success does not enter its spawn-failure retry path, so one delivered prompt stays one delivery.
+- **Races:** no shared state, timer, or asynchronous step is added. The tmux launch and state write remain synchronous and ordered.
+- **Adjacent retry path:** `SpawnRequestManager` still treats genuine `spawnSession` rejection as non-delivery. This fix makes that assumption true for the headless post-launch state-write case that previously violated it.
+- **Monitoring:** a failed first state write leaves an untracked live process outside caps, dashboard reads, kill-by-id, `SessionManager` monitoring, and `OrphanProcessReaper` reconciliation. It may survive restart indefinitely. The change does not conceal that; it emits a direct error plus `DegradationReporter` containing the exact tmux name and session id. No blind retry is attempted because the original failure may be a durable write guard or filesystem failure, while stale-record supersession may already have changed older records.
+- **Interactive reroute:** deliberately not covered. That path has not injected the prompt at its save boundary, so preserving its current rejection avoids falsely claiming delivery.
+
+---
+
+## 6. External surfaces
+
+- **Other agents and callers:** they now receive a successful spawn result when their headless prompt is already running, instead of an exception that encourages unsafe retry.
+- **Install base:** every updated agent receives the corrected return semantics. There is no config flag because reporting an already-delivered operation as failed is never a desirable mode.
+- **External systems:** no API, Telegram, Slack, GitHub, Cloudflare, or protocol shape changes.
+- **Persistent state:** no new schema or store. The handled failure is specifically a failure to write the existing session record.
+- **Timing/runtime conditions:** no new timing dependency. The boundary is the synchronous return of tmux session creation.
+- **Operator surface:** no operator-facing action is added or changed.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+**No operator surface — not applicable.**
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** A tmux session and its state file are facts about the machine that launched the process. The corrected result applies independently on whichever pool machine owns and executes the spawn; it does not create replicated state or authorize another machine to retry the same prompt.
+
+- **User-facing notices:** none; only existing machine-local logs and degradation reporting, so no one-voice user notice is added.
+- **Durable state/topic transfer:** no new durable state. A failed first session-state write leaves the process machine-local, untracked, and not automatically reconciled even after restart; the identified degradation event is the only action surface. This change prevents that condition from also producing a cross-machine duplicate delivery.
+- **Generated URLs:** none.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the catch/report block and the regression test, then ship the next patch.
+- **Data migration:** none.
+- **Agent state repair:** none introduced. Any session record that failed before or after this fix follows the existing machine-local recovery/cleanup posture.
+- **User visibility:** rollback would restore the rare false-failure/duplicate-redrive risk during the propagation window.
+
+---
+
+## Conclusion
+
+The change is narrow and matches the actual delivery boundary: successful headless tmux creation means the prompt is already running, while earlier failures remain failures. Review preserved two explicit tradeoffs: the interactive reroute path cannot use the same rule because its prompt injection happens after persistence, and a first-write failure leaves an indefinitely untracked machine-local process. The latter is now identified by session id and tmux name in the degradation report and is accepted as less dangerous than duplicating an already-running instruction.
+
+---
+
+## Second-pass review (required)
+
+**Reviewer:** spawn-truth-review (independent Codex reviewer)
+**Independent read of the artifact:** concur
+
+The reviewer confirmed the synchronous headless delivery boundary, unchanged pre-delivery rejection path, duplicate-redrive prevention, and deliberate exclusion of rerouted-interactive. Its first read raised the indefinite-orphan and actionability gaps; after the artifact and degradation event were corrected to name the session and accept the true cleanup posture, the reviewer concurred.
+
+---
+
+## Evidence pointers
+
+- Pre-fix focused run: 25 passed, 1 failed; the new regression alone failed on the escaped simulated state-write exception.
+- Post-fix focused run: 26/26 passed.
+- Adjacent verification: 131/131 passed across headless spawn, spawn request management, framework portability, interactive cap, and no-silent-fallback suites.
+- `npm run lint`: passed, including `tsc --noEmit` and the complete lint chain.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller added or modified — not applicable.


### PR DESCRIPTION
## ELI16

Starting a headless agent session has two separate moments. First, tmux creates the live process with the full instruction already present in the launch command. Second, Instar saves a small record so dashboards, limits, monitoring, and cleanup can find that process. If the second step failed, `spawnSession` used to reject even though the instruction was already running. A caller could then treat that rejection as non-delivery and start a second agent on the same instruction.

This change makes the result match reality. A real failure before tmux creates the process still rejects exactly as before. A state-write failure after the headless process is live is reported as degraded bookkeeping with the exact session id and tmux name, but the already-live session is returned as success so callers do not duplicate the work. The interactive reroute path is deliberately unchanged because it injects its prompt only after persistence; a write failure there does not prove delivery.

The tradeoff is explicit: when the first record write fails, that live tmux process is outside normal monitoring and automatic reaping and may survive restart until manually cleaned up. That identified orphan is safer than both the orphan and a duplicated instruction.

## What changed

- Catch only the post-delivery headless session-state write.
- Emit actionable structured degradation with the session identity and indefinite-orphan consequence.
- Add a regression that proves one live prompt delivery resolves despite the simulated bookkeeping failure.
- Document the delivery boundary, scope limit, rollback, and independent side-effects review.

## Validation

- Regression failed before the source fix: 25 passed, 1 failed on the escaped state-write exception.
- Focused headless suite after fix: 26/26 passed.
- Adjacent spawn/framework/fallback suites: 131/131 passed.
- TypeScript and the complete lint chain passed.
- Independent session-lifecycle second pass initially raised the orphan-observability gap, then concurred after the code, test, and artifacts were corrected.
