### PR TITLE
fix(convergence-check): require a word boundary after "no" in the SETTLING rule

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-30T03-58-00-294Z-convergence-check-settling-word-boundary.json
+++ b/.instar/instar-dev-decisions/2026-07-30T03-58-00-294Z-convergence-check-settling-word-boundary.json
@@ -1,0 +1,27 @@
+{
+  "ts": "2026-07-30T03:58:00.294Z",
+  "slug": "convergence-check-settling-word-boundary",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 6,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/ConvergenceChecker.ts",
+      "src/core/PostUpdateMigrator.ts",
+      "src/templates/scripts/convergence-check.sh"
+    ],
+    "addedLines": 3,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/convergence-check-settling-word-boundary.eli16.md
+++ b/docs/specs/convergence-check-settling-word-boundary.eli16.md
@@ -1,0 +1,75 @@
+# ELI16 — Why your agent stopped getting blocked for saying "there is nothing"
+
+## The one-sentence version
+
+A safety check that reads your agent's messages before they send was mistaking the
+word "nothing" for the phrase "no", and blocking perfectly good messages because of it.
+
+## What already existed
+
+Before an instar agent sends you a message, that message passes a quality check. The
+check looks for a handful of known bad habits — claiming it can't do something without
+looking, promising things it won't remember, apologising too much, and one called
+**settling**: reporting "I found nothing" without actually digging.
+
+Settling is a real failure mode and the check is right to look for it. If an agent runs
+one search, gets an empty result, and tells you "there is no data", it has probably just
+been fooled by a bad query rather than discovered a fact about the world. The check
+catches that and makes the agent look again.
+
+## What was going wrong
+
+The check hunted for the phrase **"there is no"**. The problem is that "no" is the first
+two letters of a lot of ordinary words — *nothing*, *none*, *nobody*.
+
+So the check could not tell these two apart:
+
+- *"There is no data available."* — genuine settling. Should be caught.
+- *"There is nothing pathological required."* — ordinary English. Should not be.
+
+It blocked both. To the agent this looks like being refused permission to send a message
+it knows is fine, with an explanation that doesn't match what it wrote.
+
+This was found because a second session of this same agent, running on a different
+machine, got a correct message blocked twice and said so instead of quietly rewording
+until something got through.
+
+## What changed
+
+The check now requires "no" to be a **whole word**. "There is no data" still matches.
+"There is nothing" no longer does.
+
+The important part is what did *not* get lost. "There is nothing to report" **is** still
+caught — by a different part of the same rule that looks for "nothing to report"
+directly. So the check gave up a false alarm without giving up the thing it was built to
+find. There's a test that specifically proves this, because it was the main risk.
+
+## The part that was bigger than expected
+
+The same pattern turned out to be written in **three separate places** in the codebase:
+the script itself, a second copy translated into another programming language, and a
+third emergency copy used when the first one can't be read.
+
+Fixing only the obvious one would have left the bug alive in the other two — and the
+emergency copy is exactly the one that runs when something has already gone wrong, which
+is the worst time to hit a second bug.
+
+All three are fixed, and there is now an automatic guard that fails the build if they
+ever stop matching each other. That guard matters more than the fix: without it, the
+next person to touch this repeats the same mistake, because nothing tells them the other
+two copies exist.
+
+## What you need to decide
+
+Nothing. This is a bug fix with no options and no configuration. It makes an existing
+check slightly less trigger-happy in one specific way.
+
+## What could go wrong
+
+The realistic risk is that a genuine "settling" message now slips through because it
+happened to use the word "nothing". That is covered by the separate "nothing to report"
+branch and is tested, but heuristic text-matching is never perfect and this rule is a
+helpful nudge rather than a guarantee — it always was.
+
+Rolling back is one revert; the script is rewritten on every agent's next update either
+way, so nothing is left behind on disk.

--- a/src/core/ConvergenceChecker.ts
+++ b/src/core/ConvergenceChecker.ts
@@ -61,7 +61,7 @@ const CHECKS: Check[] = [
   },
   {
     category: 'settling',
-    pattern: /(no (data|results|information) (available|found|exists)|nothing (to report|happened|was found)|there (is|are) no|could(n.t| not) find (any|the)|appears to be empty|no (relevant|matching|applicable))/i,
+    pattern: /(no (data|results|information) (available|found|exists)|nothing (to report|happened|was found)|there (is|are) no([^a-zA-Z]|$)|could(n.t| not) find (any|the)|appears to be empty|no (relevant|matching|applicable))/i,
     detail: 'Reports nothing found without investigating multiple sources.',
   },
   {

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -12679,7 +12679,7 @@ fi
       'fi',
       '',
       '# 3. SETTLING — Accepting empty results without digging deeper',
-      'if echo "$CONTENT" | grep -qiE "(no (data|results|information) (available|found|exists)|nothing (to report|happened|was found)|there (is|are) no|could(n.t| not) find (any|the)|appears to be empty|no (relevant|matching|applicable))"; then',
+      'if echo "$CONTENT" | grep -qiE "(no (data|results|information) (available|found|exists)|nothing (to report|happened|was found)|there (is|are) no([^a-zA-Z]|$)|could(n.t| not) find (any|the)|appears to be empty|no (relevant|matching|applicable))"; then',
       '  ISSUES+=("SETTLING: You\'re reporting nothing found. Did you check multiple sources? Could the data source be stale or the search terms wrong? Empty results deserve investigation, not acceptance.")',
       '  ISSUE_COUNT=$((ISSUE_COUNT + 1))',
       'fi',

--- a/src/templates/scripts/convergence-check.sh
+++ b/src/templates/scripts/convergence-check.sh
@@ -39,7 +39,7 @@ if echo "$CONTENT" | grep -qiE "(^|[^a-zA-Z])i.ll (make sure|ensure|guarantee|al
 fi
 
 # 3. SETTLING — Accepting empty results without digging deeper
-if echo "$CONTENT" | grep -qiE "(no (data|results|information) (available|found|exists)|nothing (to report|happened|was found)|there (is|are) no|could(n.t| not) find (any|the)|appears to be empty|no (relevant|matching|applicable))"; then
+if echo "$CONTENT" | grep -qiE "(no (data|results|information) (available|found|exists)|nothing (to report|happened|was found)|there (is|are) no([^a-zA-Z]|$)|could(n.t| not) find (any|the)|appears to be empty|no (relevant|matching|applicable))"; then
   ISSUES+=("SETTLING: You're reporting nothing found. Did you check multiple sources? Could the data source be stale or the search terms wrong? Empty results deserve investigation, not acceptance.")
   ISSUE_COUNT=$((ISSUE_COUNT + 1))
 fi

--- a/tests/unit/convergence-check-settling-word-boundary.test.ts
+++ b/tests/unit/convergence-check-settling-word-boundary.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the SETTLING rule's word-boundary fix.
+ *
+ * THE BUG. The SETTLING alternation contained the fragment `there (is|are) no`
+ * with no trailing boundary, so it matched INSIDE longer words that merely begin
+ * with "no": "there is nothing", "there are none", "there is nobody". Those are
+ * ordinary descriptive English, not an agent settling for an empty result, so the
+ * gate blocked correct messages. Found 2026-07-30 when a second session of this
+ * agent had a message blocked twice on "there is nothing pathological required".
+ *
+ * THE REAL DEFECT was bigger than the one character: the identical regex lived in
+ * THREE places — the shell template, its TypeScript port, and an inline fallback
+ * in PostUpdateMigrator used when the template cannot be loaded. Fixing only the
+ * template would have left the port broken and shipped the bug to any agent whose
+ * template load failed. The drift guard at the bottom is the structural half of
+ * this fix; without it the three copies silently diverge again.
+ *
+ * TRUE POSITIVE PRESERVED BY A DIFFERENT BRANCH: "there is nothing to report" must
+ * still block. It does — via the separate `nothing (to report|...)` alternative,
+ * not via the fragment being removed. That is the assertion that proves the fix
+ * narrows the rule without deleting its purpose.
+ *
+ * Discrimination: every test below was run against the UNFIXED source first.
+ * Cases marked CONTROL pass either way and are NOT evidence for this change.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { checkConvergence } from '../../src/core/ConvergenceChecker.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'src/templates/scripts/convergence-check.sh');
+
+/** Run the shell gate. Exit 0 = allowed through, non-zero = blocked. */
+function shellBlocks(message: string): boolean {
+  try {
+    execFileSync('bash', [SCRIPT_PATH], {
+      input: message,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function tsSettles(message: string): boolean {
+  return checkConvergence(message).issues.some((i) => i.category === 'settling');
+}
+
+/** Sentences that are ordinary English, NOT a report of an empty search. */
+const FALSE_POSITIVES = [
+  'There is nothing pathological required.',
+  'I checked and there are none of those left.',
+  'There is nobody else on that machine.',
+];
+
+/** Genuine settling language that must keep blocking. */
+const TRUE_POSITIVES = [
+  'There is no data available for that window.',
+  'Nothing was found in the logs.',
+  'I could not find any matching row.',
+];
+
+describe('SETTLING rule — word boundary after "no" (shell template)', () => {
+  it.each(FALSE_POSITIVES)('allows %j (DISCRIMINATES: blocked before the fix)', (msg) => {
+    expect(shellBlocks(msg)).toBe(false);
+  });
+
+  it.each(TRUE_POSITIVES)('still blocks %j (CONTROL: blocks either way)', (msg) => {
+    expect(shellBlocks(msg)).toBe(true);
+  });
+
+  it('still blocks "there is nothing to report" via the OTHER alternative (CONTROL)', () => {
+    // The load-bearing check that the fix narrowed rather than gutted the rule:
+    // the fragment no longer matches "nothing", but `nothing (to report|...)` does.
+    expect(shellBlocks('There is nothing to report.')).toBe(true);
+  });
+
+  it('leaves an unrelated benign sentence alone (CONTROL)', () => {
+    expect(shellBlocks('The build completed and all tests passed.')).toBe(false);
+  });
+});
+
+describe('SETTLING rule — word boundary after "no" (TypeScript port)', () => {
+  it.each(FALSE_POSITIVES)('allows %j (DISCRIMINATES)', (msg) => {
+    expect(tsSettles(msg)).toBe(false);
+  });
+
+  it.each(TRUE_POSITIVES)('still flags %j (CONTROL)', (msg) => {
+    expect(tsSettles(msg)).toBe(true);
+  });
+
+  it('still flags "there is nothing to report" via the OTHER alternative (CONTROL)', () => {
+    expect(tsSettles('There is nothing to report.')).toBe(true);
+  });
+});
+
+describe('SETTLING rule — drift guard across all three copies', () => {
+  // One truth, three files. This guard is the reason the bug cannot come back in
+  // only two of them.
+  const COPIES = [
+    'src/templates/scripts/convergence-check.sh',
+    'src/core/ConvergenceChecker.ts',
+    'src/core/PostUpdateMigrator.ts',
+  ];
+  const ANCHORED = 'there (is|are) no([^a-zA-Z]|$)';
+  const UNANCHORED = 'there (is|are) no|';
+
+  it.each(COPIES)('%s carries the anchored form', (rel) => {
+    const src = fs.readFileSync(path.join(REPO_ROOT, rel), 'utf-8');
+    expect(src).toContain(ANCHORED);
+  });
+
+  it.each(COPIES)('%s no longer carries the unanchored form', (rel) => {
+    const src = fs.readFileSync(path.join(REPO_ROOT, rel), 'utf-8');
+    expect(src).not.toContain(UNANCHORED);
+  });
+
+  it('the copies are not silently reduced to fewer than three (guard integrity)', () => {
+    // Positive control for the guard itself: if someone deletes a copy, the
+    // per-file assertions above would vacuously stop covering it. This asserts
+    // the inventory is still what the fix reasoned about.
+    for (const rel of COPIES) {
+      expect(fs.existsSync(path.join(REPO_ROOT, rel))).toBe(true);
+    }
+    expect(COPIES).toHaveLength(3);
+  });
+});

--- a/upgrades/next/convergence-check-settling-word-boundary.md
+++ b/upgrades/next/convergence-check-settling-word-boundary.md
@@ -1,0 +1,58 @@
+# Pre-messaging check no longer blocks "there is nothing"
+
+## What Changed
+
+The pre-messaging quality gate (`convergence-check`) has a **settling** rule that
+catches an agent reporting an empty result without digging — "there is no data",
+"nothing was found". It searched for the phrase `there (is|are) no` with no trailing
+word boundary, so it also matched inside longer words that merely begin with "no":
+**nothing**, **none**, **nobody**.
+
+The result was that ordinary English got blocked. "There is nothing pathological
+required" was treated identically to "There is no data available."
+
+The rule now requires `no` to be a whole word, using the same guard idiom the adjacent
+commitment rule already applies to `promise` (`([^a-zA-Z]|$)`).
+
+**The same regex lived in three places** — the shell template, its TypeScript port
+(`ConvergenceChecker`), and an inline fallback in `PostUpdateMigrator` used when the
+template cannot be loaded. All three are corrected, and a new drift guard fails the
+build if they ever stop matching each other. Fixing only the template would have left
+the port broken and shipped the bug to any agent whose template load failed.
+
+The genuine catch is preserved by a **different** branch of the same rule: "there is
+nothing to report" still blocks, via `nothing (to report|happened|was found)`. That is
+asserted by an explicit test, because it was the main risk of narrowing the pattern.
+
+## Evidence
+
+- 22 new unit tests. Run against the **unfixed** source first: **12 failed / 10 passed**
+  there. So 12 assertions genuinely discriminate (6 false-positive cases across the
+  shell and TypeScript implementations, plus 6 drift-guard assertions); the other 10
+  pass either way and are labelled `CONTROL` in the test file rather than counted as
+  evidence.
+- Reproduced from a real incident: a second session of this agent, running on another
+  machine, had a correct message blocked twice on "there is nothing pathological
+  required" and reported it instead of rewording until something got through.
+- Migration parity verified rather than assumed: `PostUpdateMigrator` writes
+  `scripts/convergence-check.sh` unconditionally on every migration run, and the
+  template was confirmed byte-identical to the installed copy before editing.
+
+## What to Tell Your User
+
+Nothing is required of you, and nothing changes in how you talk to your agent.
+
+Your agent runs a quality check on its own messages before sending them, to catch
+habits like giving up after one empty search. That check was mis-firing on the word
+"nothing" — so an agent writing a perfectly good sentence like "there is nothing
+unusual here" could be stopped and made to rewrite it for no reason.
+
+That mis-fire is fixed. The check still catches the real thing it was built for; it
+just no longer trips over three common words. You may notice slightly fewer moments
+where your agent pauses and rephrases itself for no visible reason.
+
+## Summary of New Capabilities
+
+None — this is a correctness fix to an existing check. No new endpoints, config keys,
+commands, or agent-facing surfaces. The only addition is an internal drift guard that
+keeps the three copies of the rule in sync.

--- a/upgrades/side-effects/convergence-check-settling-word-boundary.md
+++ b/upgrades/side-effects/convergence-check-settling-word-boundary.md
@@ -1,0 +1,103 @@
+# Side-effects review — SETTLING rule word boundary
+
+**Change.** The pre-messaging quality gate's SETTLING rule contained the fragment
+`there (is|are) no` with no trailing boundary. It matched inside longer words that
+merely begin with "no" — `nothing`, `none`, `nobody` — so ordinary descriptive
+English was blocked as if the agent were settling for an empty search result. The
+fragment is now `there (is|are) no([^a-zA-Z]|$)`, using the same guard idiom the
+adjacent commitment rule already applied to `promise`.
+
+**How it was found.** A second session of this agent, running on the Laptop, had a
+correct message blocked twice on the phrase "there is nothing pathological
+required" and reported it rather than working around it.
+
+**The defect was larger than the one character.** The identical regex lives in
+THREE places: the shell template, its TypeScript port (`ConvergenceChecker.ts`),
+and an inline fallback in `PostUpdateMigrator` used when the template cannot be
+loaded. All three are fixed, and a drift guard now asserts they stay identical.
+Fixing only the template would have left the port broken and shipped the bug to
+any agent whose template load failed.
+
+---
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+This change **removes** over-blocking; it adds none. Three realistic sentences that
+were blocked now pass, each verified against the unfixed source first:
+"There is nothing pathological required." / "I checked and there are none of those
+left." / "There is nobody else on that machine."
+
+## 2. Under-block — what failure modes does this still miss?
+
+The rule now misses `there is no<word>` constructions where the longer word really
+is a settling claim. I could not construct a realistic one — "nothing", "none" and
+"nobody" are the only common continuations, and the genuinely-settling forms among
+them ("there is nothing to report") are caught by a **different** alternative in the
+same rule, `nothing (to report|happened|was found)`. That is asserted explicitly by
+test rather than assumed, because it is the whole reason this narrowing is safe.
+
+More broadly, the SETTLING rule remains a heuristic keyword matcher and always was.
+This change does not make it smarter, only less wrong on one fragment.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The bug is in the pattern itself, not in the hook that invokes it or
+the gate that consumes the verdict. No caller changes. The deeper question — whether
+a keyword matcher should hold blocking authority at all — is a real one but is out
+of scope here and is not made worse by this change.
+
+## 4. Signal vs authority compliance
+
+This gate **does** hold blocking authority with brittle logic, which is in tension
+with `docs/signal-vs-authority.md`. That tension pre-exists this change and is
+unchanged by it: the fix strictly narrows a false-positive branch, so it moves the
+brittle authority in the safer direction (fewer wrong blocks) without expanding what
+the check can block. No new authority is introduced, and no rule gains reach.
+
+## 5. Interactions
+
+None found. The fragment is one alternative inside one alternation in one rule. The
+other six rule categories are untouched. The one interaction that matters is
+intra-rule and is deliberate: `nothing (to report|...)` still catches the true
+positive the narrowed fragment gives up, so the two alternatives now divide the work
+cleanly instead of overlapping.
+
+## 6. External surfaces
+
+Agent-facing only. No end user sees this gate. Agents will see strictly fewer
+spurious "MESSAGE BLOCKED" refusals on outbound messaging. No API, config key, or
+schema changes. No timing or conversation-state dependence.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design, and correctly so** — no `machine-local-justification`
+marker is required because this introduces no new state or feature surface. The
+script is a per-machine installed file, already written to every machine by the
+existing always-overwrite migration path
+(`PostUpdateMigrator` writes `scripts/convergence-check.sh` unconditionally). Each
+machine therefore converges on the fixed copy independently at its next update;
+there is nothing to replicate, merge, or proxy. Migration parity was **verified, not
+assumed**: the write at `PostUpdateMigrator.ts:9943` is unconditional, and the
+template and the installed copy were confirmed byte-identical before editing.
+
+Note the asymmetry this creates in the interim: the Laptop, which reported the bug,
+keeps the broken copy until it updates. That is the normal update lag, not a
+coherence defect.
+
+## 8. Rollback cost
+
+Trivial. Revert one commit; the migration overwrites the script back to the previous
+content on the next update. No data migration, no state repair, no agent-side
+cleanup. The change is additive to a regex and carries no persisted footprint.
+
+---
+
+## Testing
+
+22 unit tests. Run against the **unfixed** source first: **12 failed / 10 passed**
+there, so 12 assertions genuinely discriminate (6 false-positive cases + 6 drift-guard
+assertions) and the other 10 are labelled CONTROL in the file because they pass either
+way and are not evidence for this change.
+
+The drift guard is the structural half: without it, the next person fixes one copy of
+three and the bug survives in the other two exactly as it did here.


### PR DESCRIPTION
Fixes a false positive in the pre-messaging quality gate that was blocking correct agent messages.

## ELI16 — what this is, in plain English

Before an instar agent sends you a message, that message passes a quality check. One rule catches **settling** — an agent reporting "I found nothing" after a single search, without digging. That rule is worth having: an empty result is usually a bad query, not a fact about the world.

The rule hunted for the phrase **"there is no"**. But "no" is the first two letters of a lot of ordinary words — *nothing*, *none*, *nobody*. So the check could not tell these apart:

- *"There is no data available."* — genuine settling. Should be caught.
- *"There is nothing pathological required."* — ordinary English. Should not be.

It blocked both. To an agent that looks like being refused permission to send a message it knows is fine, with a reason that doesn't match what it wrote.

The rule now requires `no` to be a **whole word**. The genuine catch is preserved by a *different* branch of the same rule — the "nothing to report" phrasing still blocks — and there's a test that proves it, because that was the main risk of narrowing the pattern.

**Nothing to decide here.** No options, no config. An existing check becomes slightly less trigger-happy in one specific way.

## How it was found

A second session of this agent, running on another machine, had a correct message blocked twice and reported it instead of rewording until something got through.

## The defect was bigger than one character

The identical regex lives in **three** places:

| # | file | role |
|---|---|---|
| 1 | `src/templates/scripts/convergence-check.sh` | the shipped script |
| 2 | `src/core/ConvergenceChecker.ts` | TypeScript port |
| 3 | `src/core/PostUpdateMigrator.ts` | inline fallback when the template can't load |

Fixing only #1 would have left the port broken and shipped the bug to any agent whose template load failed — and #3 is the copy that runs when something has *already* gone wrong.

All three are fixed, plus a **drift guard** that fails the build if they stop matching. The guard matters more than the fix: without it the next person repeats this exactly, because nothing tells them the other two copies exist.

## Evidence

- **22 unit tests.** Run against the **unfixed** source first: **12 failed / 10 passed** there. So 12 assertions genuinely discriminate (6 false-positive cases across both implementations + 6 drift-guard assertions). The other 10 pass either way and are labelled `CONTROL` in the file rather than counted as evidence.
- **Migration parity verified, not assumed:** `PostUpdateMigrator` writes `scripts/convergence-check.sh` unconditionally on every migration run, and the template was confirmed byte-identical to the installed copy before editing.
- Uses the same guard idiom the adjacent commitment rule already applies to `promise` (`([^a-zA-Z]|$)`) rather than introducing `\b`.

## Tier declaration — declared below the risk floor, deliberately

The gate signalled **risk floor 2**; I declared **Tier 1**, so this is recorded `belowFloor: true` in the decision audit.

The floor fired on **file identity** — `PostUpdateMigrator.ts` is fleet-migration machinery, which trips both the irreversibility and migration-surface signals. What I actually changed in that file is a **string literal inside an inline fallback copy of a regex**; no migration logic, control flow, or ordering is touched.

I did not re-run the trace to obtain a nicer record. Flagging the disagreement here instead so a human sees it, and it should surface at the next belowFloor-rate review.
