### PR TITLE
Repeated spawn refusal must not be silent

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-30T12-39-36-116Z-spawn-drain-refusal-giveup.json
+++ b/.instar/instar-dev-decisions/2026-07-30T12-39-36-116Z-spawn-drain-refusal-giveup.json
@@ -1,0 +1,33 @@
+{
+  "ts": "2026-07-30T12:39:36.116Z",
+  "slug": "spawn-drain-refusal-giveup",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 346,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/types.ts",
+      "src/messaging/SpawnRequestManager.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 338,
+    "deletedLines": 8
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/spawn-request-manager.test.ts",
+      "howCaught": "SpawnRequestManager drain-loop tests cover target-scoped latching, independent targets, reason-drift collapse, re-arm hysteresis, default TTL-boundary queue preservation, and inline recovery after held payloads would otherwise expire."
+    }
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-30T12-39-45-091Z-spawn-drain-refusal-giveup.json
+++ b/.instar/instar-dev-decisions/2026-07-30T12-39-45-091Z-spawn-drain-refusal-giveup.json
@@ -1,0 +1,33 @@
+{
+  "ts": "2026-07-30T12:39:45.091Z",
+  "slug": "spawn-drain-refusal-giveup",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 346,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/types.ts",
+      "src/messaging/SpawnRequestManager.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 338,
+    "deletedLines": 8
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/spawn-request-manager.test.ts",
+      "howCaught": "SpawnRequestManager drain-loop tests cover target-scoped latching, independent targets, reason-drift collapse, re-arm hysteresis, default TTL-boundary queue preservation, and inline recovery after held payloads would otherwise expire."
+    }
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-31T07-47-01-367Z-spawn-drain-refusal-giveup.json
+++ b/.instar/instar-dev-decisions/2026-07-31T07-47-01-367Z-spawn-drain-refusal-giveup.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-07-31T07:47:01.367Z",
+  "slug": "spawn-drain-refusal-giveup",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 465,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/types.ts",
+      "src/messaging/SpawnRequestManager.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 454,
+    "deletedLines": 11
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-31T07-47-31-658Z-spawn-drain-refusal-giveup.json
+++ b/.instar/instar-dev-decisions/2026-07-31T07-47-31-658Z-spawn-drain-refusal-giveup.json
@@ -1,0 +1,33 @@
+{
+  "ts": "2026-07-31T07:47:31.658Z",
+  "slug": "spawn-drain-refusal-giveup",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 465,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/types.ts",
+      "src/messaging/SpawnRequestManager.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 454,
+    "deletedLines": 11
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/spawn-request-manager.test.ts",
+      "howCaught": "The regression drives sustained denied drain verdicts to the configured threshold, proves the target settles into a no-spawn latch, and proves visibility retries remain bounded to one attempt per 30 seconds without reactivating the drain loop."
+    }
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-31T07-56-08-448Z-spawn-drain-refusal-giveup.json
+++ b/.instar/instar-dev-decisions/2026-07-31T07-56-08-448Z-spawn-drain-refusal-giveup.json
@@ -1,0 +1,34 @@
+{
+  "ts": "2026-07-31T07:56:08.448Z",
+  "slug": "spawn-drain-refusal-giveup",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter"
+  ],
+  "belowFloor": true,
+  "files": 3,
+  "loc": 59,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/messaging/SpawnRequestManager.ts",
+      "src/messaging/TelegramAdapter.ts"
+    ],
+    "addedLines": 50,
+    "deletedLines": 9
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/spawn-request-manager.test.ts",
+      "howCaught": "Sustained denied drains settle at the latch threshold; operator visibility retries at a 30-second bound without reactivating the drain loop; the real adapter regression proves recurrence reopens one target-stable item instead of generating an unbounded item series."
+    }
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/spawn-drain-refusal-giveup.eli16.md
+++ b/docs/eli16/spawn-drain-refusal-giveup.eli16.md
@@ -1,0 +1,11 @@
+# Spawn Drain Refusal Give-Up — ELI16
+
+When one agent receives Threadline work and cannot start a new session, the refusal can be correct. A machine that is low on memory or deep into swap should not start more expensive sessions just to appear responsive. The bug was that the retry loop had no endpoint and no visible operator signal. One drain target could be refused thousands of times while the agent stopped producing work, and the only way to notice was to read a terminal pane.
+
+This change keeps the admission refusal intact. It does not loosen the memory threshold, session cap, or quota gate. Instead, the spawn request manager counts denied drain attempts per target. After a configurable threshold, it gives up on that target for a bounded cooldown, keeps the queued work held, and emits exactly one stable Attention item for that target. Further ticks do not keep spawning more notices or burning the same failed action. If the target genuinely recovers and later gives up again, the same durable item is refreshed and reopened so recurrence stays visible without creating a permanent pile of episode-keyed health items.
+
+The latch can re-arm only after the cooldown, and server wiring can require the refusal condition to clear first. For memory-pressure refusals, that means the memory monitor must report normal before the drain target can start trying again. The default re-arm interval is below the queued-message TTL, and the manager refreshes held queue timestamps when a latch re-arms so a message does not silently expire right at the recovery boundary.
+
+The important user-facing effect is simple: persistent spawn refusal becomes visible and bounded. Operators get one agent-health Attention item naming the drain target and refusal reason. Agents avoid an endless retry loop under real resource pressure. Held work is retried when the target re-arms or when a successful inline spawn proves the target is healthy again.
+
+The main remaining limit is durability. The held queue is still in process memory, so a server restart can lose pending drain messages. This fix closes the silent infinite retry defect; it does not turn the queue into a durable store or reinterpret whether a lower-level `spawnSession` throw happened before or after prompt delivery.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -16030,14 +16030,59 @@ export async function startServer(options: StartOptions): Promise<void> {
               reason: `Peer "${event.agent}" tripped the infra-failure soft limiter (${event.failureCount} non-attributable failures in 10min)`,
               impact: 'Peer\'s queue depth is capped; older messages are dropped. No blame attribution.',
             });
+          } else if (event.kind === 'spawn-drain-attention-failed') {
+            reporter.report({
+              feature: 'Threadline.SpawnDrainAttention',
+              primary: `Create Attention marker "${event.attentionId}" for peer "${event.agent}"`,
+              fallback: `Keep the drain target latched and retry the Attention write (attempt ${event.attempt})`,
+              reason: `Attention write failed: ${event.error}`,
+              impact: 'Queued work remains held and visible in spawn-manager status; the operator-facing marker is delayed.',
+            });
           }
         } catch (err) {
           console.warn(`[spawn-manager] degradation reporter failed: ${err instanceof Error ? err.message : String(err)}`);
         }
       },
+      onDrainGiveUp: async (event) => {
+        if (!telegram) {
+          throw new Error('Telegram Attention adapter is unavailable');
+        }
+        await telegram.createOrReopenAgentHealthAttentionItem({
+          id: event.attentionId,
+          title: `Spawn drain gave up for ${event.agent}`,
+          summary: `${event.refusalCount} consecutive drain re-attempts were refused; ${event.queuedMessagesHeld} queued message(s) are held.`,
+          description:
+            `The Threadline spawn drain latched queued messages from "${event.agent}" after repeated refusals. ` +
+            `Target: ${event.targetKey}. Refusal signature: ${event.refusalSignature}. ` +
+            `Last refusal: ${event.reason}. Refusal window: ${new Date(event.firstRefusedAt).toISOString()} to ${new Date(event.lastRefusedAt).toISOString()}. ` +
+            `The queued work is held until the refusal condition clears and the re-arm cooldown passes; the spawn guard threshold is unchanged.`,
+          category: 'agent-health',
+          priority: 'HIGH',
+          lane: 'agent-health',
+          healthKey: `spawn-drain-refusal:${event.targetKey}`,
+          sourceContext: `spawn-drain-refusal:${event.targetKey}`,
+        });
+      },
+      isDrainRefusalCleared: (marker) => {
+        // Only memory pressure has an authoritative live clear signal here.
+        // Other refusal classes still receive time hysteresis, then retry
+        // through the unchanged admission gate rather than remaining latched
+        // forever on a condition this layer cannot inspect.
+        if (!/memory pressure/i.test(marker.refusalSignature)) return true;
+        const state = memoryMonitor?.getState();
+        return !state || state.state === 'normal';
+      },
+      onDrainRearm: (event) => {
+        console.log(
+          `[spawn-manager] drain give-up latch re-armed for ${event.agent} ` +
+          `(target=${event.targetKey}, signature="${event.refusalSignature}", quiet=${event.rearmCooldownMs}ms)`,
+        );
+      },
       // §4.4: optional knobs from config.
       cooldownMs: spawnConfig?.cooldownMs,
       maxDrainsPerTick: spawnConfig?.maxDrainsPerTick,
+      drainRefusalGiveUpThreshold: spawnConfig?.drainRefusalGiveUpThreshold,
+      drainGiveUpRearmCooldownMs: spawnConfig?.drainGiveUpRearmCooldownMs,
       maxEnvelopeBytes: spawnConfig?.maxEnvelopeBytes,
       maxGlobalQueued: spawnConfig?.maxGlobalQueued,
       degradedMaxQueuedPerAgent: spawnConfig?.degradedMaxQueuedPerAgent,
@@ -16061,8 +16106,11 @@ export async function startServer(options: StartOptions): Promise<void> {
           if (!result.approved) {
             console.log(`[spawn-manager] drain re-attempt for ${agent} not approved: ${result.reason}`);
           }
+          return result;
         } catch (err) {
-          console.warn(`[spawn-manager] drain re-attempt for ${agent} threw: ${err instanceof Error ? err.message : String(err)}`);
+          const reason = err instanceof Error ? err.message : String(err);
+          console.warn(`[spawn-manager] drain re-attempt for ${agent} threw: ${reason}`);
+          return { approved: false, reason: `Drain callback threw: ${reason}`, retryAfterMs: 30_000 };
         }
       },
     });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5116,6 +5116,10 @@ export interface ThreadlineSpawnConfig {
   cooldownMs?: number;
   /** Max drains per tick. Default: 8. */
   maxDrainsPerTick?: number;
+  /** Max denied drain attempts per agent before give-up. Default: maxRetries or 3. */
+  drainRefusalGiveUpThreshold?: number;
+  /** Quiet-clear interval before a drain give-up latch can re-arm. Default: 480000 (8m). */
+  drainGiveUpRearmCooldownMs?: number;
   /** Max envelope context size in UTF-8 bytes. Default: 262144 (256 KiB). */
   maxEnvelopeBytes?: number;
   /** Max queued messages across ALL agents. Default: 1000. */

--- a/src/messaging/SpawnRequestManager.ts
+++ b/src/messaging/SpawnRequestManager.ts
@@ -154,7 +154,56 @@ export type SpawnFailureCause =
  */
 export type SpawnDegradationEvent =
   | { kind: 'spawn-penalty-tripped'; agent: string; consecutiveFailures: number; penaltyMs: number; at: number }
-  | { kind: 'spawn-infra-degraded'; agent: string; failureCount: number; degradationMs: number; at: number };
+  | { kind: 'spawn-infra-degraded'; agent: string; failureCount: number; degradationMs: number; at: number }
+  | {
+      kind: 'spawn-drain-attention-failed';
+      agent: string;
+      attentionId: string;
+      attempt: number;
+      error: string;
+      at: number;
+    };
+
+export interface SpawnDrainGiveUpEvent {
+  agent: string;
+  targetKey: string;
+  refusalSignature: string;
+  reason: string;
+  refusalCount: number;
+  queuedMessagesHeld: number;
+  firstRefusedAt: number;
+  lastRefusedAt: number;
+  at: number;
+  attentionId: string;
+}
+
+export interface SpawnDrainRearmEvent {
+  agent: string;
+  targetKey: string;
+  refusalSignature: string;
+  attentionId: string;
+  latchedAt: number;
+  lastRefusedAt: number;
+  rearmedAt: number;
+  rearmCooldownMs: number;
+}
+
+export interface SpawnDrainRefusalSnapshot {
+  agent: string;
+  targetKey: string;
+  refusalSignature: string;
+  count: number;
+  firstRefusedAt: number;
+  lastRefusedAt: number;
+  latchedAt: number;
+  attentionId: string;
+  attentionDelivered: boolean;
+  attentionAttempts: number;
+  lastAttentionAttemptAt: number;
+  attentionError?: string;
+}
+
+export type SpawnDrainReadyResult = void | Pick<SpawnResult, 'approved' | 'reason' | 'retryAfterMs'>;
 
 /** Error class callers throw from inside `spawnSession` to tag attributable failures. */
 export class SpawnFailureError extends Error {
@@ -248,9 +297,37 @@ export interface SpawnRequestManagerConfig {
    * `evaluate`. Optional: if unset, the drain loop is a no-op and queued
    * messages only drain on the next inline `evaluate` call (legacy behavior).
    */
-  onDrainReady?: (agent: string) => Promise<void>;
+  onDrainReady?: (agent: string) => Promise<SpawnDrainReadyResult>;
   /** §4.2: max drains per tick. Default 8. */
   maxDrainsPerTick?: number;
+  /**
+   * Max denied drain re-attempts for one agent before the manager holds that
+   * agent's queued payloads and emits one give-up event. Default: maxRetries
+   * (or 3). This bounds a correct-but-persistent refusal such as memory
+   * pressure so the drain loop cannot spin silently forever.
+   */
+  drainRefusalGiveUpThreshold?: number;
+  /**
+   * Called once when one drain target crosses the bounded-refusal threshold.
+   * Server wiring maps this to a stable Attention id; manager-level tracking
+   * still dedupes the event so a repeating tick cannot flood callers.
+   */
+  onDrainGiveUp?: (event: SpawnDrainGiveUpEvent) => void | Promise<void>;
+  /**
+   * Minimum quiet-clear interval before a give-up latch can re-arm. The timer
+   * is measured from the last denied drain result, not just from the first
+   * attention item, so near-threshold memory pressure cannot flap the latch.
+   * Default: 8 minutes, below queued-message TTL.
+   */
+  drainGiveUpRearmCooldownMs?: number;
+  /**
+   * Optional clear predicate for a latched refusal target. Re-arm requires the
+   * cooldown above AND this predicate returning true. Server wiring uses this
+   * for memory-pressure denials so a near-threshold host does not flap.
+   */
+  isDrainRefusalCleared?: (marker: SpawnDrainRefusalSnapshot) => boolean;
+  /** Called when a previously latched drain target has genuinely re-armed. */
+  onDrainRearm?: (event: SpawnDrainRearmEvent) => void | Promise<void>;
   /** §4.2: max queued messages per agent while in degraded admission. Default 1. */
   degradedMaxQueuedPerAgent?: number;
   /**
@@ -344,6 +421,8 @@ const DRAIN_MAX_PER_TICK_DEFAULT = 8;
 const DRR_QUANTUM = 1;
 const DRR_COST = 1;
 const DRR_AGE_BOOST_MULTIPLIER = 1.5;
+const DEFAULT_DRAIN_GIVE_UP_REARM_COOLDOWN_MS = 8 * 60_000;
+const DRAIN_GIVE_UP_ATTENTION_RETRY_MS = 30_000;
 
 const SPAWN_PROMPT_TEMPLATE = `You were spawned by an inter-agent message request.
 
@@ -412,6 +491,26 @@ export class SpawnRequestManager {
 
   /** §4.2: drain-attempt counter per agent. Reset on successful drain. */
   readonly #drainAttempts = new Map<string, number>();
+
+  /** Count denied drain re-attempts per agent so one target cannot spin forever. */
+  readonly #drainRefusals = new Map<string, {
+    count: number;
+    firstRefusedAt: number;
+    lastReason: string;
+  }>();
+
+  /** Stable per-target give-up latch. Re-armed only after hysteresis clears. */
+  readonly #drainGiveUpLatches = new Map<string, {
+    attentionId: string;
+    refusalSignature: string;
+    latchedAt: number;
+    lastRefusedAt: number;
+    attentionEvent: SpawnDrainGiveUpEvent;
+    attentionDelivered: boolean;
+    attentionAttempts: number;
+    lastAttentionAttemptAt: number;
+    attentionError?: string;
+  }>();
 
   /** §4.2: shared drain-tick timer. null when not started. */
   #drainTimer: ReturnType<typeof setInterval> | null = null;
@@ -609,6 +708,227 @@ export class SpawnRequestManager {
     } as PreservedTransientRefusal;
   }
 
+  #drainGiveUpThreshold(): number {
+    const configured = this.#config.drainRefusalGiveUpThreshold ?? this.#config.maxRetries ?? DEFAULT_MAX_RETRIES;
+    if (!Number.isFinite(configured)) return DEFAULT_MAX_RETRIES;
+    return Math.max(1, Math.floor(configured));
+  }
+
+  #drainGiveUpRearmCooldownMs(): number {
+    const configured = this.#config.drainGiveUpRearmCooldownMs ?? DEFAULT_DRAIN_GIVE_UP_REARM_COOLDOWN_MS;
+    if (!Number.isFinite(configured)) return DEFAULT_DRAIN_GIVE_UP_REARM_COOLDOWN_MS;
+    return Math.max(0, Math.floor(configured));
+  }
+
+  #drainTargetKey(agent: string): string {
+    return agent.replace(/[^a-zA-Z0-9._:-]/g, '_').slice(0, 80) || 'unknown';
+  }
+
+  #drainGiveUpAttentionId(targetKey: string): string {
+    // One durable item per target. Server wiring explicitly refreshes/reopens
+    // this item for later episodes, avoiding both silent recurrence and a
+    // permanent pile of date/episode-keyed health items.
+    return `spawn-drain-refusal-giveup:${targetKey}`;
+  }
+
+  #drainRefusalSignature(reason: string | undefined): string {
+    const raw = (reason ?? 'unknown').trim().replace(/\s+/g, ' ');
+    return raw.slice(0, 240) || 'unknown';
+  }
+
+  #refreshHeldQueueForRearm(agent: string, now: number): void {
+    const queue = this.#pendingMessages.get(agent);
+    if (!queue) return;
+    for (const entry of queue) {
+      entry.receivedAt = now;
+    }
+  }
+
+  async #maybeRearmDrainGiveUp(agent: string): Promise<void> {
+    const targetKey = this.#drainTargetKey(agent);
+    const latch = this.#drainGiveUpLatches.get(targetKey);
+    if (!latch) return;
+
+    const now = this.#nowFn();
+    const rearmCooldownMs = this.#drainGiveUpRearmCooldownMs();
+    if (now - latch.lastRefusedAt < rearmCooldownMs) return;
+
+    const refusal = this.#drainRefusals.get(agent);
+    const snapshot: SpawnDrainRefusalSnapshot = {
+      agent,
+      targetKey,
+      refusalSignature: latch.refusalSignature,
+      count: refusal?.count ?? 0,
+      firstRefusedAt: refusal?.firstRefusedAt ?? latch.latchedAt,
+      lastRefusedAt: latch.lastRefusedAt,
+      latchedAt: latch.latchedAt,
+      attentionId: latch.attentionId,
+      attentionDelivered: latch.attentionDelivered,
+      attentionAttempts: latch.attentionAttempts,
+      lastAttentionAttemptAt: latch.lastAttentionAttemptAt,
+      attentionError: latch.attentionError,
+    };
+    if (this.#config.isDrainRefusalCleared && !this.#config.isDrainRefusalCleared(snapshot)) return;
+
+    this.#refreshHeldQueueForRearm(agent, now);
+    this.#drainGiveUpLatches.delete(targetKey);
+    this.#clearDrainRefusal(agent);
+    try {
+      await this.#config.onDrainRearm?.({
+        agent,
+        targetKey,
+        refusalSignature: latch.refusalSignature,
+        attentionId: latch.attentionId,
+        latchedAt: latch.latchedAt,
+        lastRefusedAt: latch.lastRefusedAt,
+        rearmedAt: now,
+        rearmCooldownMs,
+      });
+    } catch {
+      // Observability failure must never keep the target latched forever.
+    }
+  }
+
+  async #forceRearmDrainGiveUp(agent: string): Promise<void> {
+    const targetKey = this.#drainTargetKey(agent);
+    const latch = this.#drainGiveUpLatches.get(targetKey);
+    if (!latch) return;
+
+    const now = this.#nowFn();
+    this.#refreshHeldQueueForRearm(agent, now);
+    this.#drainGiveUpLatches.delete(targetKey);
+    this.#clearDrainRefusal(agent);
+    try {
+      await this.#config.onDrainRearm?.({
+        agent,
+        targetKey,
+        refusalSignature: latch.refusalSignature,
+        attentionId: latch.attentionId,
+        latchedAt: latch.latchedAt,
+        lastRefusedAt: latch.lastRefusedAt,
+        rearmedAt: now,
+        rearmCooldownMs: 0,
+      });
+    } catch {
+      // Observability failure must never keep a proven-successful target latched.
+    }
+  }
+
+  #isDrainGiveUpLatched(agent: string): boolean {
+    return this.#drainGiveUpLatches.has(this.#drainTargetKey(agent));
+  }
+
+  async #deliverDrainGiveUpAttention(
+    latch: {
+      attentionId: string;
+      attentionEvent: SpawnDrainGiveUpEvent;
+      attentionDelivered: boolean;
+      attentionAttempts: number;
+      lastAttentionAttemptAt: number;
+      attentionError?: string;
+    },
+  ): Promise<void> {
+    if (latch.attentionDelivered) return;
+    const onDrainGiveUp = this.#config.onDrainGiveUp;
+    if (!onDrainGiveUp) {
+      latch.attentionDelivered = true;
+      return;
+    }
+
+    const at = this.#nowFn();
+    latch.attentionAttempts++;
+    latch.lastAttentionAttemptAt = at;
+    try {
+      await onDrainGiveUp(latch.attentionEvent);
+      latch.attentionDelivered = true;
+      latch.attentionError = undefined;
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      latch.attentionError = error;
+      try {
+        this.#config.onDegradation?.({
+          kind: 'spawn-drain-attention-failed',
+          agent: latch.attentionEvent.agent,
+          attentionId: latch.attentionId,
+          attempt: latch.attentionAttempts,
+          error,
+          at,
+        });
+      } catch {
+        // A secondary observability-sink failure cannot make queue admission
+        // or the bounded retry state depend on the reporter itself.
+      }
+    }
+  }
+
+  async #maybeRetryDrainGiveUpAttention(agent: string): Promise<void> {
+    const latch = this.#drainGiveUpLatches.get(this.#drainTargetKey(agent));
+    if (!latch || latch.attentionDelivered) return;
+    if (this.#nowFn() - latch.lastAttentionAttemptAt < DRAIN_GIVE_UP_ATTENTION_RETRY_MS) return;
+    await this.#deliverDrainGiveUpAttention(latch);
+  }
+
+  #isDeniedDrainResult(result: SpawnDrainReadyResult): result is Pick<SpawnResult, 'approved' | 'reason' | 'retryAfterMs'> {
+    return typeof result === 'object' && result !== null && result.approved === false;
+  }
+
+  async #recordDrainRefusal(agent: string, reason: string | undefined): Promise<void> {
+    const now = this.#nowFn();
+    const targetKey = this.#drainTargetKey(agent);
+    const refusalSignature = this.#drainRefusalSignature(reason);
+    const attentionId = this.#drainGiveUpAttentionId(targetKey);
+    const prior = this.#drainRefusals.get(agent);
+    const firstRefusedAt = prior?.firstRefusedAt ?? now;
+    const next = {
+      count: (prior?.count ?? 0) + 1,
+      firstRefusedAt,
+      lastReason: refusalSignature,
+    };
+    this.#drainRefusals.set(agent, next);
+
+    if (next.count < this.#drainGiveUpThreshold()) return;
+
+    this.#drrDeficit.delete(agent);
+    this.#drainAttempts.delete(agent);
+
+    const existingLatch = this.#drainGiveUpLatches.get(targetKey);
+    if (existingLatch) {
+      existingLatch.refusalSignature = refusalSignature;
+      existingLatch.lastRefusedAt = now;
+      return;
+    }
+
+    const attentionEvent: SpawnDrainGiveUpEvent = {
+      agent,
+      targetKey,
+      refusalSignature,
+      reason: next.lastReason,
+      refusalCount: next.count,
+      queuedMessagesHeld: this.getQueuedCount(agent),
+      firstRefusedAt: next.firstRefusedAt,
+      lastRefusedAt: now,
+      at: now,
+      attentionId,
+    };
+    const latch = {
+      attentionId,
+      refusalSignature,
+      latchedAt: now,
+      lastRefusedAt: now,
+      attentionEvent,
+      attentionDelivered: false,
+      attentionAttempts: 0,
+      lastAttentionAttemptAt: 0,
+      attentionError: undefined,
+    };
+    this.#drainGiveUpLatches.set(targetKey, latch);
+    await this.#deliverDrainGiveUpAttention(latch);
+  }
+
+  #clearDrainRefusal(agent: string): void {
+    this.#drainRefusals.delete(agent);
+  }
+
   // ── Public API ──────────────────────────────────────────────
 
   /**
@@ -723,7 +1043,10 @@ export class SpawnRequestManager {
 
     let queuedSnapshot: QueuedSpawnMessage[] = [];
     try {
-      queuedSnapshot = this.#snapshotQueue(agent);
+      // A latched target may still prove healthy through a new inline spawn.
+      // Keep the held backlog out of that probe; on success, force-rearm refreshes
+      // it and a later drain delivers it through the preservation funnel.
+      queuedSnapshot = this.#isDrainGiveUpLatched(agent) ? [] : this.#snapshotQueue(agent);
       const prompt = this.#buildSpawnPrompt(request, queuedSnapshot);
       const spawned = await this.#config.spawnSession(prompt, {
         model: request.suggestedModel,
@@ -752,6 +1075,7 @@ export class SpawnRequestManager {
 
       // Success — clear penalty state and pending retries.
       this.#clearFailureAttribution(agent);
+      await this.#forceRearmDrainGiveUp(agent);
       const retryKey = this.#getRetryKey(request);
       this.#pendingRetries.delete(retryKey);
 
@@ -876,6 +1200,10 @@ export class SpawnRequestManager {
       // remains refused as before.
       let newest: { agent: string; entry: QueuedSpawnMessage } | undefined;
       for (const [queuedAgent, queued] of this.#pendingMessages) {
+        // A give-up latch explicitly promises to hold its backlog until
+        // re-arm. Global chronological displacement may only consider work
+        // that is not protected by that promise.
+        if (this.#isDrainGiveUpLatched(queuedAgent)) continue;
         for (const entry of queued) {
           if (!newest || entry.sequence > newest.entry.sequence) {
             newest = { agent: queuedAgent, entry };
@@ -912,9 +1240,12 @@ export class SpawnRequestManager {
 
     const now = this.#nowFn();
     const maxAge = SpawnRequestManager.QUEUE_MAX_AGE_MS;
+    const heldByGiveUpLatch = this.#isDrainGiveUpLatched(agent);
     queue.sort((a, b) => a.sequence - b.sequence);
-    while (queue.length > 0 && now - queue[0].receivedAt > maxAge) {
-      queue.shift();
+    if (!heldByGiveUpLatch) {
+      while (queue.length > 0 && now - queue[0].receivedAt > maxAge) {
+        queue.shift();
+      }
     }
 
     // §4.2 infra soft limiter + §4.3 truncation marker.
@@ -923,6 +1254,12 @@ export class SpawnRequestManager {
     if (cap <= 0) {
       // Defensive backstop for future cap sources; effective config currently
       // floors degraded admission at one.
+      this.#truncated.add(agent);
+      return false;
+    }
+    if (heldByGiveUpLatch && queue.length >= cap) {
+      // Existing latched work is protected. Reject the new arrival instead
+      // of silently evicting a payload the give-up marker says is held.
       this.#truncated.add(agent);
       return false;
     }
@@ -1010,6 +1347,7 @@ export class SpawnRequestManager {
     pendingRetries: number;
     queuedMessages: Array<{ agent: string; count: number }>;
     penalties: Array<{ agent: string; untilMs: number; consecutiveFailures: number }>;
+    drainGiveUps: Array<SpawnDrainRefusalSnapshot & { rearmRemainingMs: number }>;
   } {
     const cooldowns: Array<{ agent: string; remainingMs: number }> = [];
     for (const agent of this.#lastSpawnByAgent.keys()) {
@@ -1038,11 +1376,33 @@ export class SpawnRequestManager {
       }
     }
 
+    const drainGiveUps: Array<SpawnDrainRefusalSnapshot & { rearmRemainingMs: number }> = [];
+    for (const [targetKey, latch] of this.#drainGiveUpLatches) {
+      const agent = [...this.#pendingMessages.keys()].find(a => this.#drainTargetKey(a) === targetKey) ?? targetKey;
+      const refusal = this.#drainRefusals.get(agent);
+      drainGiveUps.push({
+        agent,
+        targetKey,
+        refusalSignature: latch.refusalSignature,
+        count: refusal?.count ?? 0,
+        firstRefusedAt: refusal?.firstRefusedAt ?? latch.latchedAt,
+        lastRefusedAt: latch.lastRefusedAt,
+        latchedAt: latch.latchedAt,
+        attentionId: latch.attentionId,
+        attentionDelivered: latch.attentionDelivered,
+        attentionAttempts: latch.attentionAttempts,
+        lastAttentionAttemptAt: latch.lastAttentionAttemptAt,
+        attentionError: latch.attentionError,
+        rearmRemainingMs: Math.max(this.#drainGiveUpRearmCooldownMs() - (now - latch.lastRefusedAt), 0),
+      });
+    }
+
     return {
       cooldowns,
       pendingRetries: this.#pendingRetries.size,
       queuedMessages,
       penalties,
+      drainGiveUps,
     };
   }
 
@@ -1123,6 +1483,11 @@ export class SpawnRequestManager {
       const readyAgents: string[] = [];
       for (const [agent, queue] of this.#pendingMessages) {
         if (queue.length === 0) continue;
+        if (this.#isDrainGiveUpLatched(agent)) {
+          await this.#maybeRetryDrainGiveUpAttention(agent);
+          await this.#maybeRearmDrainGiveUp(agent);
+          if (this.#isDrainGiveUpLatched(agent)) continue;
+        }
         if (this.cooldownRemainingMs(agent) <= tickGraceMs) {
           readyAgents.push(agent);
         }
@@ -1159,10 +1524,18 @@ export class SpawnRequestManager {
 
       // Fire callbacks concurrently; one callback failure does not abort the batch.
       const results = await Promise.allSettled(
-        selected.map(agent => onDrainReady(agent).then(() => {
-          // Successful drain → reset attempt counter so next tick doesn't apply age-boost.
+        selected.map(async agent => {
+          const result = await onDrainReady(agent);
+          if (this.#isDeniedDrainResult(result)) {
+            await this.#recordDrainRefusal(agent, result.reason);
+            return;
+          }
+          // Successful drain → reset attempt/refusal counters so next tick
+          // doesn't apply age-boost or inherit a stale denial streak.
           this.#drainAttempts.delete(agent);
-        })),
+          this.#clearDrainRefusal(agent);
+          await this.#maybeRearmDrainGiveUp(agent);
+        }),
       );
       // Log but don't throw on individual callback failures.
       for (let i = 0; i < results.length; i++) {
@@ -1193,6 +1566,8 @@ export class SpawnRequestManager {
     maxEnvelopeBytes: number;
     maxGlobalQueued: number;
     degradedMaxQueuedPerAgent: number;
+    drainRefusalGiveUpThreshold: number;
+    drainGiveUpRearmCooldownMs: number;
     drainTickMs: number;
   } {
     return {
@@ -1204,6 +1579,8 @@ export class SpawnRequestManager {
         1,
         this.#config.degradedMaxQueuedPerAgent ?? DEGRADED_MAX_QUEUED_PER_AGENT_DEFAULT,
       ),
+      drainRefusalGiveUpThreshold: this.#drainGiveUpThreshold(),
+      drainGiveUpRearmCooldownMs: this.#drainGiveUpRearmCooldownMs(),
       drainTickMs: this.getDrainTickMs(),
     };
   }
@@ -1226,6 +1603,8 @@ export class SpawnRequestManager {
     maxEnvelopeBytes?: number;
     maxGlobalQueued?: number;
     degradedMaxQueuedPerAgent?: number;
+    drainRefusalGiveUpThreshold?: number;
+    drainGiveUpRearmCooldownMs?: number;
   }): { applied: true; tickIntervalChanged: boolean } | { applied: false; reason: string } {
     const validators: Array<[keyof typeof patch, (v: number) => boolean]> = [
       ['cooldownMs', v => v >= 0 && Number.isFinite(v)],
@@ -1233,6 +1612,8 @@ export class SpawnRequestManager {
       ['maxEnvelopeBytes', v => v >= 1 && Number.isFinite(v) && Number.isInteger(v)],
       ['maxGlobalQueued', v => v >= 0 && Number.isFinite(v) && Number.isInteger(v)],
       ['degradedMaxQueuedPerAgent', v => v >= 1 && Number.isFinite(v) && Number.isInteger(v)],
+      ['drainRefusalGiveUpThreshold', v => v >= 1 && Number.isFinite(v) && Number.isInteger(v)],
+      ['drainGiveUpRearmCooldownMs', v => v >= 0 && Number.isFinite(v) && Number.isInteger(v)],
     ];
     for (const [k, ok] of validators) {
       const v = patch[k];
@@ -1250,6 +1631,12 @@ export class SpawnRequestManager {
     if (patch.degradedMaxQueuedPerAgent !== undefined) {
       this.#config.degradedMaxQueuedPerAgent = patch.degradedMaxQueuedPerAgent;
     }
+    if (patch.drainRefusalGiveUpThreshold !== undefined) {
+      this.#config.drainRefusalGiveUpThreshold = patch.drainRefusalGiveUpThreshold;
+    }
+    if (patch.drainGiveUpRearmCooldownMs !== undefined) {
+      this.#config.drainGiveUpRearmCooldownMs = patch.drainGiveUpRearmCooldownMs;
+    }
     const newTickMs = this.getDrainTickMs();
     return { applied: true, tickIntervalChanged: oldTickMs !== newTickMs };
   }
@@ -1263,6 +1650,8 @@ export class SpawnRequestManager {
     this.#consecutiveSpawnFailures.clear();
     this.#drrDeficit.clear();
     this.#drainAttempts.clear();
+    this.#drainRefusals.clear();
+    this.#drainGiveUpLatches.clear();
     this.#infraFailureWindow.clear();
     this.#truncated.clear();
     this.#spawnInflightByAgent.clear();

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -4067,6 +4067,48 @@ export class TelegramAdapter implements MessagingAdapter {
   }
 
   /**
+   * Create the first Agent-Health item for an entity, or refresh and visibly
+   * reopen the same durable item when the condition returns after recovery.
+   *
+   * `createAttentionItem` intentionally dedupes on id and returns the existing
+   * row unchanged. That is right for retries inside one episode but would hide
+   * a later episode. Giving every episode a new id has the opposite failure:
+   * the Attention store grows forever for one persistent entity. This method
+   * keeps one target-stable row and makes recurrence explicit in the lane.
+   */
+  async createOrReopenAgentHealthAttentionItem(
+    item: Omit<AttentionItem, 'createdAt' | 'updatedAt' | 'status' | 'topicId'>,
+  ): Promise<AttentionItem> {
+    if (item.lane !== 'agent-health') {
+      throw new Error('createOrReopenAgentHealthAttentionItem requires lane=agent-health');
+    }
+
+    const existing = this.attentionItems.get(item.id);
+    if (!existing) return this.createAttentionItem(item);
+
+    Object.assign(existing, item, {
+      status: 'OPEN' as const,
+      updatedAt: new Date().toISOString(),
+    });
+    this.saveAttentionItems();
+
+    const topicId = await this.ensureAgentHealthLaneTopic();
+    if (topicId === null) {
+      throw new Error('Agent Health lane is unavailable');
+    }
+    const line = [
+      `<b>${this.escapeHtml(item.title)}</b>`,
+      this.escapeHtml(String(item.summary ?? '').slice(0, 400)),
+      '<i>This condition returned after recovery; the existing item was reopened.</i>',
+    ].join('\n');
+    await this.sendToTopic(topicId, line, { formatMode: 'html' });
+    existing.coalesced = true;
+    existing.topicId = topicId;
+    this.saveAttentionItems();
+    return existing;
+  }
+
+  /**
    * Build a calm, named, actionable self-health notice. Resolves a session's
    * topic id to its HUMAN topic name (never emits a bare `topic-<n>`), and ends
    * with a plain-language next step the user can just reply to. Used by the

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -30530,7 +30530,8 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   /**
    * §4.4 commit 3: update runtime-tunable spawn-manager fields atomically.
    * Body: any subset of { cooldownMs, maxDrainsPerTick, maxEnvelopeBytes,
-   * maxGlobalQueued, degradedMaxQueuedPerAgent }.
+   * maxGlobalQueued, degradedMaxQueuedPerAgent, drainRefusalGiveUpThreshold,
+   * drainGiveUpRearmCooldownMs }.
    *
    * Note: changing cooldownMs updates gate logic immediately, but the drain
    * tick interval is fixed at start(). The response indicates whether a
@@ -30545,7 +30546,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     }
     const body = (req.body ?? {}) as Record<string, unknown>;
     // Reject unknown fields to avoid silent typos.
-    const allowed = new Set(['cooldownMs', 'maxDrainsPerTick', 'maxEnvelopeBytes', 'maxGlobalQueued', 'degradedMaxQueuedPerAgent']);
+    const allowed = new Set(['cooldownMs', 'maxDrainsPerTick', 'maxEnvelopeBytes', 'maxGlobalQueued', 'degradedMaxQueuedPerAgent', 'drainRefusalGiveUpThreshold', 'drainGiveUpRearmCooldownMs']);
     const unknownKeys = Object.keys(body).filter(k => !allowed.has(k));
     if (unknownKeys.length > 0) {
       res.status(400).json({ error: `Unknown fields: ${unknownKeys.join(', ')}` });

--- a/tests/unit/attention-single-topic-routing.test.ts
+++ b/tests/unit/attention-single-topic-routing.test.ts
@@ -295,6 +295,40 @@ describe('Single-alerts-topic routing (default mode)', () => {
     expect(itemPost!._formatMode).toBe('html');
   });
 
+  it('refreshes and visibly reopens one target-stable Agent-Health item across episodes', async () => {
+    makeAdapter({ getAttentionHubTopicId: () => 782 });
+    const rec = installApiStub(adapter);
+    const base = {
+      id: 'spawn-drain-refusal-giveup:echo',
+      healthKey: 'spawn-drain-refusal:echo',
+      lane: 'agent-health' as const,
+      title: 'Spawn drain gave up for echo',
+      summary: 'first refusal episode',
+      description: 'first episode',
+      category: 'agent-health',
+      priority: 'HIGH' as const,
+      sourceContext: 'spawn-drain-refusal:echo',
+    };
+
+    const first = await adapter.createOrReopenAgentHealthAttentionItem(base);
+    await adapter.updateAttentionStatus(base.id, 'DONE');
+    const reopened = await adapter.createOrReopenAgentHealthAttentionItem({
+      ...base,
+      summary: 'second refusal episode',
+      description: 'second episode',
+    });
+
+    expect(adapter.getAttentionItems()).toHaveLength(1);
+    expect(reopened).toBe(first);
+    expect(reopened.status).toBe('OPEN');
+    expect(reopened.summary).toBe('second refusal episode');
+    expect(reopened.description).toBe('second episode');
+    expect(rec.forumTopicsCreated).toBe(1);
+    const sends = rec.messagesByThread.get(reopened.topicId!) ?? [];
+    expect(sends.some(text => text.includes('second refusal episode'))).toBe(true);
+    expect(sends.some(text => text.includes('returned after recovery'))).toBe(true);
+  });
+
   it("LEGACY 'per-item' mode preserves the pre-flip behavior: own topic, registered maps, /done closes it", async () => {
     makeAdapter({ attentionRouting: { mode: 'per-item' } });
     const rec = installApiStub(adapter);

--- a/tests/unit/spawn-request-manager.test.ts
+++ b/tests/unit/spawn-request-manager.test.ts
@@ -15,7 +15,14 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { SpawnRequestManager, computeEnvelopeHash, type SpawnRequest, type SpawnRequestManagerConfig } from '../../src/messaging/SpawnRequestManager.js';
+import {
+  SpawnRequestManager,
+  computeEnvelopeHash,
+  type SpawnDrainGiveUpEvent,
+  type SpawnDegradationEvent,
+  type SpawnRequest,
+  type SpawnRequestManagerConfig,
+} from '../../src/messaging/SpawnRequestManager.js';
 import type { Session } from '../../src/core/types.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -1137,6 +1144,447 @@ describe('SpawnRequestManager', () => {
       const drained = await mgr.runTick();
       expect(drained).toBe(3);
       expect(calls).toBe(3); // all callbacks invoked despite one failure
+    });
+
+    it('latches after repeated drain refusals and emits exactly one deduped attention event', async () => {
+      const attention: SpawnDrainGiveUpEvent[] = [];
+      const mgr = new SpawnRequestManager(makeDrainConfig({
+        cooldownMs: 0,
+        drainRefusalGiveUpThreshold: 3,
+        drainGiveUpRearmCooldownMs: 10_000,
+        isMemoryPressureHigh: () => true,
+        onDrainGiveUp: (event) => {
+          attention.push(event);
+        },
+        onDrainReady: async (agent: string) => {
+          drainCalls.push(agent);
+          return {
+            approved: false,
+            reason: 'Memory pressure too high for new session',
+            retryAfterMs: 120_000,
+          };
+        },
+      }));
+
+      await mgr.evaluate(makeRequest({
+        requester: { agent: 'echo', session: 'seed', machine: 'laptop' },
+        context: 'queued while memory pressure is high',
+      }));
+      await mgr.evaluate(makeRequest({
+        requester: { agent: 'echo', session: 'queued', machine: 'laptop' },
+        context: 'second queued message',
+      }));
+      expect(mgr.getQueuedCount('echo')).toBe(2);
+
+      fakeNow += 1;
+      expect(await mgr.runTick()).toBe(1);
+      fakeNow += 1;
+      expect(await mgr.runTick()).toBe(1);
+      expect(attention).toHaveLength(0);
+
+      fakeNow += 1;
+      expect(await mgr.runTick()).toBe(1);
+      expect(attention).toHaveLength(1);
+      expect(attention[0]).toMatchObject({
+        agent: 'echo',
+        targetKey: 'echo',
+        refusalSignature: 'Memory pressure too high for new session',
+        reason: 'Memory pressure too high for new session',
+        refusalCount: 3,
+        queuedMessagesHeld: 2,
+        attentionId: 'spawn-drain-refusal-giveup:echo',
+      });
+      expect(mgr.getQueuedCount('echo')).toBe(2);
+      expect(mgr.getStatus().drainGiveUps).toHaveLength(1);
+
+      fakeNow += 1;
+      expect(await mgr.runTick()).toBe(0);
+      expect(attention).toHaveLength(1);
+      expect(drainCalls).toEqual(['echo', 'echo', 'echo']);
+    });
+
+    it('keeps different drain targets independent when one target gives up', async () => {
+      const attention: SpawnDrainGiveUpEvent[] = [];
+      const mgr = new SpawnRequestManager(makeDrainConfig({
+        cooldownMs: 0,
+        drainRefusalGiveUpThreshold: 2,
+        drainGiveUpRearmCooldownMs: 10_000,
+        isMemoryPressureHigh: () => true,
+        onDrainGiveUp: (event) => attention.push(event),
+        onDrainReady: async (agent: string) => {
+          drainCalls.push(agent);
+          return { approved: false, reason: 'Memory pressure too high for new session' };
+        },
+      }));
+
+      await mgr.evaluate(makeRequest({ requester: { agent: 'echo', session: 'seed', machine: 'm' }, context: 'echo-1' }));
+      await mgr.evaluate(makeRequest({ requester: { agent: 'codey-mini', session: 'seed', machine: 'm' }, context: 'mini-1' }));
+
+      fakeNow += 1;
+      await mgr.runTick();
+      fakeNow += 1;
+      await mgr.runTick();
+
+      expect(attention.map(e => e.agent).sort()).toEqual(['codey-mini', 'echo']);
+      expect(new Set(attention.map(e => e.attentionId)).size).toBe(2);
+      expect(mgr.getQueuedCount('echo')).toBe(1);
+      expect(mgr.getQueuedCount('codey-mini')).toBe(1);
+    });
+
+    it('collapses same-target refusal reason drift into one latched episode', async () => {
+      const attention: SpawnDrainGiveUpEvent[] = [];
+      const reasons = [
+        'Memory pressure too high for new session',
+        'Memory pressure too high for new session (swap 23983MB)',
+        'Memory pressure too high for new session (swap 23984MB)',
+      ];
+      const mgr = new SpawnRequestManager(makeDrainConfig({
+        cooldownMs: 0,
+        drainRefusalGiveUpThreshold: 3,
+        drainGiveUpRearmCooldownMs: 10_000,
+        isMemoryPressureHigh: () => true,
+        onDrainGiveUp: (event) => attention.push(event),
+        onDrainReady: async (agent: string) => {
+          drainCalls.push(agent);
+          return { approved: false, reason: reasons[Math.min(drainCalls.length - 1, reasons.length - 1)] };
+        },
+      }));
+
+      await mgr.evaluate(makeRequest({ requester: { agent: 'echo', session: 'seed', machine: 'm' }, context: 'echo-1' }));
+
+      for (let i = 0; i < 3; i++) {
+        fakeNow += 1;
+        await mgr.runTick();
+      }
+      fakeNow += 1;
+      await mgr.runTick();
+
+      expect(attention).toHaveLength(1);
+      expect(attention[0]).toMatchObject({
+        agent: 'echo',
+        refusalCount: 3,
+        attentionId: 'spawn-drain-refusal-giveup:echo',
+      });
+      expect(attention[0].refusalSignature).toContain('swap 23984MB');
+      expect(drainCalls).toEqual(['echo', 'echo', 'echo']);
+    });
+
+    it('re-arms only after cooldown and the clear predicate agree', async () => {
+      const attention: SpawnDrainGiveUpEvent[] = [];
+      const rearmed: unknown[] = [];
+      let clear = false;
+      const mgr = new SpawnRequestManager(makeDrainConfig({
+        cooldownMs: 0,
+        drainRefusalGiveUpThreshold: 2,
+        drainGiveUpRearmCooldownMs: 5_000,
+        isMemoryPressureHigh: () => true,
+        isDrainRefusalCleared: () => clear,
+        onDrainGiveUp: (event) => attention.push(event),
+        onDrainRearm: (event) => rearmed.push(event),
+        onDrainReady: async (agent: string) => {
+          drainCalls.push(agent);
+          return drainCalls.length <= 2
+            ? { approved: false, reason: 'Memory pressure too high for new session' }
+            : { approved: true };
+        },
+      }));
+
+      await mgr.evaluate(makeRequest({ requester: { agent: 'echo', session: 'seed', machine: 'm' }, context: 'echo-1' }));
+      fakeNow += 1;
+      await mgr.runTick();
+      fakeNow += 1;
+      await mgr.runTick();
+      expect(attention).toHaveLength(1);
+
+      fakeNow += 4_999;
+      expect(await mgr.runTick()).toBe(0);
+      expect(drainCalls).toHaveLength(2);
+      expect(rearmed).toHaveLength(0);
+
+      fakeNow += 2;
+      expect(await mgr.runTick()).toBe(0);
+      expect(drainCalls).toHaveLength(2);
+      expect(rearmed).toHaveLength(0);
+
+      clear = true;
+      expect(await mgr.runTick()).toBe(1);
+      expect(drainCalls).toEqual(['echo', 'echo', 'echo']);
+      expect(rearmed).toHaveLength(1);
+      expect(mgr.getStatus().drainGiveUps).toHaveLength(0);
+    });
+
+    it('refreshes held queue age under the default give-up re-arm window', async () => {
+      let underPressure = true;
+      const spawnSession = vi.fn().mockResolvedValue('spawned-session-id');
+      let mgr: SpawnRequestManager;
+      mgr = new SpawnRequestManager(makeConfig({
+        cooldownMs: 0,
+        drainRefusalGiveUpThreshold: 3,
+        nowFn: () => fakeNow,
+        spawnSession,
+        isMemoryPressureHigh: () => underPressure,
+        isDrainRefusalCleared: () => !underPressure,
+        onDrainReady: async (agent: string) => {
+          drainCalls.push(agent);
+          return mgr.evaluate({
+            requester: { agent, session: 'drain', machine: 'drain' },
+            target: { agent: 'local', machine: 'local' },
+            reason: `Drain re-attempt for ${agent}`,
+            priority: 'medium',
+            triggeredBy: 'spawn-request-drain',
+          });
+        },
+      }));
+      expect(mgr.getRuntimeConfig().drainGiveUpRearmCooldownMs)
+        .toBeLessThan(SpawnRequestManager.QUEUE_MAX_AGE_MS);
+
+      await mgr.evaluate(makeRequest({
+        requester: { agent: 'echo', session: 'seed', machine: 'laptop' },
+        context: 'held payload must survive rearm',
+      }));
+      expect(mgr.getQueuedCount('echo')).toBe(1);
+
+      await mgr.runTick();
+      fakeNow += 1;
+      await mgr.runTick();
+      fakeNow += 1;
+      await mgr.runTick();
+      expect(mgr.getStatus().drainGiveUps).toHaveLength(1);
+
+      fakeNow += SpawnRequestManager.QUEUE_MAX_AGE_MS + 1;
+      underPressure = false;
+      const rearmed = await mgr.runTick();
+
+      expect(rearmed).toBe(1);
+      expect(spawnSession).toHaveBeenCalledTimes(1);
+      expect(spawnSession.mock.calls[0][0]).toContain('held payload must survive rearm');
+      expect(mgr.getQueuedCount('echo')).toBe(0);
+    });
+
+    it('does not TTL-prune held backlog when a new payload arrives while give-up is latched', async () => {
+      let underPressure = true;
+      const spawnSession = vi.fn().mockResolvedValue('spawned-session-id');
+      let mgr: SpawnRequestManager;
+      mgr = new SpawnRequestManager(makeConfig({
+        cooldownMs: 0,
+        drainRefusalGiveUpThreshold: 1,
+        drainGiveUpRearmCooldownMs: 30_000,
+        nowFn: () => fakeNow,
+        spawnSession,
+        isMemoryPressureHigh: () => underPressure,
+        isDrainRefusalCleared: () => !underPressure,
+        onDrainReady: async (agent: string) => mgr.evaluate({
+          requester: { agent, session: 'drain', machine: 'drain' },
+          target: { agent: 'local', machine: 'local' },
+          reason: `Drain re-attempt for ${agent}`,
+          priority: 'medium',
+          triggeredBy: 'spawn-request-drain',
+        }),
+      }));
+
+      await mgr.evaluate(makeRequest({
+        requester: { agent: 'echo', session: 'seed', machine: 'laptop' },
+        context: 'old held payload',
+      }));
+      await mgr.runTick();
+      expect(mgr.getStatus().drainGiveUps).toHaveLength(1);
+
+      fakeNow += SpawnRequestManager.QUEUE_MAX_AGE_MS + 1;
+      await mgr.evaluate(makeRequest({
+        requester: { agent: 'echo', session: 'new', machine: 'laptop' },
+        context: 'new payload during latch',
+      }));
+      expect(mgr.getQueuedCount('echo')).toBe(2);
+
+      underPressure = false;
+      await mgr.runTick();
+      expect(spawnSession).toHaveBeenCalledOnce();
+      const prompt = spawnSession.mock.calls[0][0] as string;
+      expect(prompt).toContain('old held payload');
+      expect(prompt).toContain('new payload during latch');
+      expect(mgr.getQueuedCount('echo')).toBe(0);
+    });
+
+    it('reports and retries a failed give-up attention write while keeping the target latched', async () => {
+      const degradation: SpawnDegradationEvent[] = [];
+      const onDrainGiveUp = vi.fn()
+        .mockRejectedValueOnce(new Error('attention store unavailable'))
+        .mockResolvedValueOnce(undefined);
+      const mgr = new SpawnRequestManager(makeDrainConfig({
+        cooldownMs: 0,
+        drainRefusalGiveUpThreshold: 1,
+        drainGiveUpRearmCooldownMs: 60_000,
+        isMemoryPressureHigh: () => true,
+        onDegradation: (event) => degradation.push(event),
+        onDrainGiveUp,
+        onDrainReady: async () => ({
+          approved: false,
+          reason: 'Memory pressure too high for new session',
+        }),
+      }));
+
+      await mgr.evaluate(makeRequest({
+        requester: { agent: 'echo', session: 'seed', machine: 'laptop' },
+        context: 'held while attention is unavailable',
+      }));
+      await mgr.runTick();
+
+      expect(onDrainGiveUp).toHaveBeenCalledOnce();
+      expect(degradation).toContainEqual(expect.objectContaining({
+        kind: 'spawn-drain-attention-failed',
+        agent: 'echo',
+        attempt: 1,
+        attentionId: 'spawn-drain-refusal-giveup:echo',
+      }));
+      expect(mgr.getStatus().drainGiveUps[0]).toMatchObject({
+        attentionDelivered: false,
+        attentionAttempts: 1,
+        attentionError: 'attention store unavailable',
+      });
+
+      fakeNow += 30_000;
+      expect(await mgr.runTick()).toBe(0);
+      expect(onDrainGiveUp).toHaveBeenCalledTimes(2);
+      expect(mgr.getStatus().drainGiveUps[0]).toMatchObject({
+        attentionDelivered: true,
+        attentionAttempts: 2,
+      });
+    });
+
+    it('clears a drain give-up latch after a successful inline spawn without dropping held queued work', async () => {
+      const attention: SpawnDrainGiveUpEvent[] = [];
+      const rearmed: unknown[] = [];
+      let pressureHigh = true;
+      const spawnSession = vi.fn().mockResolvedValue('spawned-session-id');
+      let mgr: SpawnRequestManager;
+      mgr = new SpawnRequestManager(makeDrainConfig({
+        cooldownMs: 0,
+        drainRefusalGiveUpThreshold: 2,
+        drainGiveUpRearmCooldownMs: 60_000,
+        spawnSession,
+        isMemoryPressureHigh: () => pressureHigh,
+        onDrainGiveUp: (event) => attention.push(event),
+        onDrainRearm: (event) => rearmed.push(event),
+        onDrainReady: async (agent: string) => {
+          drainCalls.push(agent);
+          return mgr.evaluate(makeRequest({
+            requester: { agent, session: 'drain', machine: 'm' },
+            context: undefined,
+            triggeredBy: 'spawn-request-drain',
+          }));
+        },
+      }));
+
+      await mgr.evaluate(makeRequest({ requester: { agent: 'echo', session: 'seed', machine: 'm' }, context: 'echo-1' }));
+      fakeNow += 1;
+      await mgr.runTick();
+      fakeNow += 1;
+      await mgr.runTick();
+      expect(attention).toHaveLength(1);
+      expect(mgr.getStatus().drainGiveUps).toHaveLength(1);
+
+      fakeNow += SpawnRequestManager.QUEUE_MAX_AGE_MS + 1;
+      pressureHigh = false;
+      const result = await mgr.evaluate(makeRequest({ requester: { agent: 'echo', session: 'inline', machine: 'm' }, context: 'new inline message' }));
+
+      expect(result.approved).toBe(true);
+      expect(mgr.getQueuedCount('echo')).toBe(1);
+      expect(rearmed).toHaveLength(1);
+      expect(mgr.getStatus().drainGiveUps).toHaveLength(0);
+      expect(spawnSession).toHaveBeenCalledOnce();
+      const prompt = spawnSession.mock.calls[0][0] as string;
+      expect(prompt).toContain('new inline message');
+      expect(prompt).not.toContain('echo-1');
+
+      await mgr.runTick();
+      expect(spawnSession).toHaveBeenCalledTimes(2);
+      const drainPrompt = spawnSession.mock.calls[1][0] as string;
+      expect(drainPrompt).toContain('echo-1');
+      expect(mgr.getQueuedCount('echo')).toBe(0);
+    });
+
+    it('starts a fresh refusal threshold after a latched target re-arms', async () => {
+      const attention: SpawnDrainGiveUpEvent[] = [];
+      let phase: 'deny' | 'approve' = 'deny';
+      const mgr = new SpawnRequestManager(makeDrainConfig({
+        cooldownMs: 0,
+        drainRefusalGiveUpThreshold: 2,
+        drainGiveUpRearmCooldownMs: 5_000,
+        isMemoryPressureHigh: () => true,
+        isDrainRefusalCleared: () => true,
+        onDrainGiveUp: (event) => attention.push(event),
+        onDrainReady: async (agent: string) => {
+          drainCalls.push(agent);
+          return phase === 'deny'
+            ? { approved: false, reason: 'Memory pressure too high for new session' }
+            : { approved: true };
+        },
+      }));
+
+      await mgr.evaluate(makeRequest({ requester: { agent: 'echo', session: 'seed', machine: 'm' }, context: 'echo-1' }));
+      fakeNow += 1;
+      await mgr.runTick();
+      fakeNow += 1;
+      await mgr.runTick();
+      expect(attention).toHaveLength(1);
+
+      phase = 'approve';
+      fakeNow += 5_001;
+      await mgr.runTick();
+      expect(mgr.getStatus().drainGiveUps).toHaveLength(0);
+
+      phase = 'deny';
+      await mgr.evaluate(makeRequest({ requester: { agent: 'echo', session: 'fresh', machine: 'm' }, context: 'echo-2' }));
+      fakeNow += 1;
+      await mgr.runTick();
+      expect(attention).toHaveLength(1);
+
+      fakeNow += 1;
+      await mgr.runTick();
+      expect(attention).toHaveLength(2);
+      expect(attention[1].attentionId).toBe(attention[0].attentionId);
+    });
+
+    it('does not refresh stale held queue entries before an inline spawn failure proves delivery', async () => {
+      const { SpawnFailureError } = await import('../../src/messaging/SpawnRequestManager.js');
+      const attention: SpawnDrainGiveUpEvent[] = [];
+      let memoryHigh = false;
+      const spawnSession = vi.fn()
+        .mockResolvedValueOnce('seed-session')
+        .mockRejectedValueOnce(new SpawnFailureError('provider failed before delivery', 'provider-5xx'))
+        .mockResolvedValueOnce('recovery-session');
+      const mgr = new SpawnRequestManager(makeDrainConfig({
+        cooldownMs: 0,
+        drainRefusalGiveUpThreshold: 1,
+        drainGiveUpRearmCooldownMs: 5_000,
+        spawnSession,
+        isMemoryPressureHigh: () => memoryHigh,
+        onDrainGiveUp: (event) => attention.push(event),
+        onDrainReady: async () => ({ approved: false, reason: 'Memory pressure too high for new session' }),
+      }));
+
+      await mgr.evaluate(makeRequest({ requester: { agent: 'echo', session: 'seed', machine: 'm' }, context: 'seed' }));
+      memoryHigh = true;
+      await mgr.evaluate(makeRequest({ requester: { agent: 'echo', session: 'held', machine: 'm' }, context: 'held-message' }));
+      await mgr.runTick();
+      expect(attention).toHaveLength(1);
+      expect(mgr.getQueuedCount('echo')).toBe(1);
+
+      memoryHigh = false;
+      fakeNow += SpawnRequestManager.QUEUE_MAX_AGE_MS + 1;
+      const failed = await mgr.evaluate(makeRequest({
+        requester: { agent: 'echo', session: 'inline-fail', machine: 'm' },
+        context: 'inline-trigger',
+      }));
+      expect(failed.approved).toBe(false);
+
+      const recovered = await mgr.evaluate(makeRequest({
+        requester: { agent: 'echo', session: 'inline-success', machine: 'm' },
+        context: 'recovery-trigger',
+      }));
+      expect(recovered.approved).toBe(true);
+      const recoveryPrompt = spawnSession.mock.calls[2][0] as string;
+      expect(recoveryPrompt).not.toContain('held-message');
     });
 
     it('infra-failure soft limiter triggers after 5 infra failures within window', async () => {

--- a/upgrades/next/spawn-drain-refusal-giveup.md
+++ b/upgrades/next/spawn-drain-refusal-giveup.md
@@ -1,0 +1,22 @@
+# Spawn Drain Refusal Give-Up
+
+## What Changed
+
+Repeated Threadline spawn-drain refusals are now bounded per drain target. After a target crosses the refusal threshold, the drain loop stops retrying that target for a re-arm window and emits one deduped agent-health Attention item instead of spinning silently.
+
+The existing memory-pressure and session-admission refusals are unchanged. This fix makes a correct sustained refusal visible and finite; it does not raise the memory threshold or hide resource pressure.
+
+## What to Tell Your User
+
+If an agent cannot start a new session because the host is under sustained pressure, it now surfaces one clear Attention item instead of retrying forever in the background. Held peer work remains queued for re-arm rather than being silently forgotten.
+
+## Summary of New Capabilities
+
+Operators can tune the drain refusal give-up threshold and re-arm cooldown through the existing spawn config surface. Spawn manager status now reports active drain give-up latches.
+
+## Evidence
+
+- `npx vitest run tests/unit/spawn-request-manager.test.ts tests/unit/attention-single-topic-routing.test.ts` — 115 tests passing, including current main's payload-preservation and ordering cases, latched-backlog TTL protection, Attention-write retry state, and target-stable Attention reopen behavior.
+- `npm run build` — passing; expected local no-signing-key transitional warning only.
+- `npm run lint` — passing; existing report-only notices only.
+- instar-dev pre-commit passed for the runtime fix and side-effects artifacts.

--- a/upgrades/side-effects/spawn-drain-refusal-giveup.md
+++ b/upgrades/side-effects/spawn-drain-refusal-giveup.md
@@ -1,0 +1,123 @@
+# Side-Effects Review — Spawn Drain Refusal Give-Up
+
+**Version / slug:** `spawn-drain-refusal-giveup`
+**Date:** `2026-07-30`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `Singer (subagent) — concern raised and resolved; Heisenberg (subagent) — re-review concurred`
+
+## Summary of the change
+
+This change makes repeated Threadline spawn-drain refusals bounded and visible. `src/messaging/SpawnRequestManager.ts` now lets the drain callback return a denial verdict, counts denials per drain target, latches the target after a configurable threshold, and exposes status/runtime config for the threshold and re-arm interval. `src/commands/server.ts` returns the drain verdict to the manager and emits one stable agent-health Attention item when give-up occurs. `src/server/routes.ts`, `src/core/types.ts`, and `tests/unit/spawn-request-manager.test.ts` cover the config and regression surface. A successful inline spawn clears the latch only after `spawnSession` resolves, then preserves held queued work for a later drain rather than mixing it into the inline prompt.
+
+## Decision-point inventory
+
+- `SpawnRequestManager.runTick()` — modify — a drain target with queued messages is no longer always eligible; a latched give-up target is skipped until re-arm.
+- `SpawnRequestManager.onDrainReady` result handling — modify — a denied spawn verdict now feeds refusal accounting instead of looking like successful callback completion.
+- `SpawnRequestManager.#recordDrainRefusal()` — add — deterministic bounded retry and latch decision for one drain target.
+- `server.ts onDrainGiveUp` — add — signal emission into the existing Attention queue with a target-stable id and explicit reopen/update behavior.
+- `/messages/spawn/config` route allowlist — modify — runtime tuning accepts the new threshold and re-arm interval.
+
+---
+
+## 1. Over-block
+
+The change can delay legitimate queued peer messages after the threshold if the refusal condition clears immediately after the latch is set. The re-arm interval defaults below the queued-message TTL, so a short-lived recovery just after the final refusal may wait for that interval before retrying. This is intentional pressure braking: the prior behavior retried indefinitely under sustained refusal, and the held queue plus attention item makes the delay visible rather than silent. While latched, existing backlog is protected from TTL pruning and capacity eviction; if its per-target capacity is already full, a newer arrival is refused and the existing truncation marker makes that loss explicit.
+
+---
+
+## 2. Under-block
+
+This does not make the queued-message store durable across process restart; held messages are still in-process state. It also does not prove whether a `spawnSession` throw means the prompt was already delivered, so the existing non-requeue behavior for spawn throws remains unchanged. Callback exceptions are counted as drain refusals by server wiring, but the fix does not classify every possible infrastructure failure into a richer cause taxonomy. Second-pass review found resolved under-blocks: held messages could age out at the same ten-minute TTL as the default re-arm interval, later arrivals could TTL-prune latched backlog, old refusal counters could survive re-arm, inline recovery could drain held messages too early, and a failed Attention write had no retry state. The implementation now defaults re-arm below the queue TTL, protects latched backlog from TTL/capacity eviction, refreshes held queue timestamps when the latch genuinely re-arms, clears refusal counters on both re-arm paths, avoids draining held queued payloads before inline spawn success is proven, and records/reports/retries failed Attention writes.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The manager is the right layer because it owns the drain target selection, DRR counters, queue visibility, and callback result semantics. Server wiring is the right layer for Attention because the manager should not import Telegram or operator surfaces. No parallel detector store is introduced; the change extends the existing spawn manager state and status path.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP. Reshape the design.
+
+This change is deterministic authority, but it falls under the hard-invariant / resource-safety carve-out rather than a conversational judgment point. It does not decide what a message means and does not weaken admission policy. It enforces a steady-state bound on a self-triggered retry loop after repeated explicit denial verdicts, then emits a signal to Attention.
+
+---
+
+## 4b. Judgment-point check
+
+No new static heuristic at a competing-signals judgment point. The bounded retry threshold is a capacity-safety invariant for a self-triggered loop: one target cannot be retried forever after repeated denied spawn verdicts. The memory-pressure clear predicate uses the existing memory monitor state only to prevent flapping; it does not overrule the spawn admission decision.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the latch runs after existing spawn admission returns a denial. It does not run before memory/session/quota checks and cannot hide a valid approval.
+- **Double-fire:** Attention uses one stable id and agent-health key per target, so delivery retries dedupe. A later episode after genuine re-arm updates and reopens that same item instead of either disappearing behind it or creating an unbounded series of episode-keyed items.
+- **Races:** `runTick()` already has an inflight guard; the new maps are mutated inside that serialized tick path. Current main's payload-preservation funnel snapshots queued backlog without removing it and commits only after `spawnSession` proves delivery. The rebase preserves that invariant: a latched target's inline recovery probe snapshots no held backlog, force-rearms only after proven delivery, and leaves the held entries for the next drain.
+- **Feedback loops:** the re-arm path has both time hysteresis and an optional clear predicate. For memory pressure, server wiring requires the memory monitor to report normal before re-arm.
+
+---
+
+## 6. External surfaces
+
+Other agents see no protocol change. The receiving agent's operator gets one Attention item when a drain target gives up. The existing GET and PATCH `/messages/spawn/config` responses include/accept two new numeric knobs. Persistent state is not added; held queue and latch state are process-local. No operator-facing dashboard or form is changed.
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. The only operator-visible change is an existing Attention queue item, not a new dashboard/form action.
+
+---
+
+## 7. Multi-machine posture
+
+**Machine-local BY DESIGN.** Spawn admission, memory pressure, active session count, and queued drain payloads are machine-specific truths. A Mac Mini under swap pressure should latch its own drain target even if another machine is healthy. The emitted notice is a local agent-health Attention item; it does not generate URLs and does not need topic-transfer durability. One-voice gating is handled by the target-stable Attention id on the machine that owns the failed drain.
+
+---
+
+## 8. Rollback cost
+
+Rollback is a code revert and patch release. No migration is needed because no durable schema is added. Held queue/latch state exists only in memory and disappears on process restart. During rollback, the old behavior returns: persistent refusals can again retry silently, but no user data migration or repair is required.
+
+---
+
+## Conclusion
+
+The review changed the implementation from dropping queued messages at give-up to holding them behind a latch, then changed the re-arm paths so held messages do not silently expire before their first post-rearm delivery attempt. That preserves work while still bounding the retry loop and surfacing the incident. The change is clear to ship as a spawn-lifecycle fix with second-pass review.
+
+---
+
+## Second-pass review
+
+**Reviewer:** Singer (subagent), then Heisenberg (subagent)
+**Independent read of the artifact:** concern raised, resolved, and re-reviewed cleanly
+
+Concern raised: held messages could still be silently lost because the give-up latch skipped drain attempts until the default ten-minute re-arm interval while queued entries also expired after ten minutes. A later review also checked stale refusal counters after re-arm and inline recovery draining held messages too early.
+
+Resolution: `SpawnRequestManager` now defaults the re-arm interval below the queue TTL, refreshes held queued entries' `receivedAt` timestamps immediately before scheduled re-arm, clears the old refusal counter on both re-arm paths, and no longer drains held payloads into an inline prompt before spawn success is proven. Heisenberg independently re-reviewed the amended diff and found no issues.
+
+**Current-main rebase review:** the only semantic conflict was with the later transient-refusal payload-preservation funnel. The resolution keeps both guarantees: no backlog removal before delivery, and no held-backlog injection into a latched inline probe. A successful probe force-rearms and refreshes the held entries; a failed probe leaves the latch and original backlog age/order untouched.
+
+The fresh independent reviewer raised four concrete gaps across three passes: later arrivals could TTL-prune latched backlog; an Attention write failure had neither visible state nor retry; an absent Telegram adapter falsely counted as successful delivery; and a permanent target-only Attention id could hide a later give-up episode behind an old resolved item. The implementation now protects latched backlog from TTL/capacity eviction, records and reports Attention failure state, retries every 30 seconds while latched, treats a missing adapter as failure, and explicitly refreshes/reopens the target-stable Attention item after genuine re-arm. This preserves the one-item-per-target invariant while making recurrence visible. The reviewer then audited that final target-stable/reopen design against the real-adapter regression and returned `APPROVE`; 115 focused tests and the build pass.
+
+---
+
+## Evidence pointers
+
+- `npx vitest run tests/unit/spawn-request-manager.test.ts tests/unit/attention-single-topic-routing.test.ts` — 115 tests passing, including current main's payload-preservation and ordering cases, latched-backlog TTL protection, Attention-write retry state, and target-stable Attention reopen behavior through the real adapter.
+- `npm run build` — passing; expected local no-signing-key transitional warning only.
+- `npm run lint` — completed during pre-commit; existing report-only notices only.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: unbounded-self-action`, `closure: guard`, `guardEvidence: { enforcementType: ratchet, citation: tests/unit/spawn-request-manager.test.ts, howCaught: the regression tests drive one drain target through repeated refused spawn verdicts, assert the loop settles by emitting exactly one give-up event and skipping subsequent ticks while messages remain held, and assert held messages survive re-arm rather than silently expiring }`.


### PR DESCRIPTION
## ELI16 — Stop endless silent spawn refusals

When a machine stays too full to start another agent session, the receiver can keep retrying the same queued handoff forever without making progress or telling anyone. This change gives that loop a firm stopping point, raises one stable health notice for the affected agent, and keeps the queued work visible instead of pretending it ran. If the machine later recovers far enough, the latch re-arms safely and refreshes the held item so it still has a fair chance to run. The admission limits themselves do not get weaker: real memory or session pressure is still refused.

## Summary

- Bounds repeated spawn-drain denial loops per target with a give-up latch.
- Emits one target-stable agent-health Attention item when a target crosses the refusal threshold.
- Refreshes and reopens that same durable item if the condition returns after genuine recovery; it does not create an item per episode.
- Protects latched backlog from TTL and capacity eviction while held.
- Makes Attention-write failure explicit in status and DegradationReporter, with a bounded 30-second visibility retry that does not reactivate the spawn loop.
- Preserves the existing memory/session admission refusals; this does not raise the memory threshold.
- Adds re-arm hysteresis, held-queue timestamp refresh, runtime config/status fields, ELI16/side-effects artifacts, and regression coverage.

## Root cause

A correct sustained spawn refusal, especially memory pressure, could keep the drain loop firing indefinitely with no operator-visible escalation or bounded give-up. The refusal itself was valid; the silence and unbounded retry were the defect.

## UX Impact

Who sees it: operators whose agent has queued Threadline work repeatedly refused by the spawn-drain path. On first contact after the refusal threshold, they see one Agent Health notice naming the affected target, refusal reason, refusal count, and held-message count. If the target genuinely recovers and later gives up again, that same durable item is refreshed and reopened with the concrete recurrence line: "This condition returned after recovery; the existing item was reopened." Other users and agents see no interface change, and the existing memory, session, and quota thresholds remain unchanged.

## Validation

- `npx vitest run tests/unit/spawn-request-manager.test.ts tests/unit/attention-single-topic-routing.test.ts` — 115 passed
- `npm run build`
- `npm run lint` via the structural pre-commit gate
- Independent session-lifecycle review — APPROVE after four passes
- Coherence gate checked before push/PR operations; topic 1 is unbound, repository/worktree identity was manually verified as `JKHeadley/instar`

## Review-driven corrections

Independent review caught and closed four silent-loss/silent-stop shapes: TTL pruning of latched backlog, Attention failure without visible state or retry, missing Telegram falsely counting as delivery, and later episodes disappearing behind an old resolved item. The final design preserves the deliberate one-item-per-target invariant by refreshing/reopening that item through the real Telegram adapter; a regression proves one stored item, reopened status, refreshed content, and a visible recurrence post.
