### PR TITLE
fix(tests): stop the throughput fixture expiring on a calendar date

### DIFF
--- a/docs/specs/fix-expiring-throughput-fixture.eli16.md
+++ b/docs/specs/fix-expiring-throughput-fixture.eli16.md
@@ -1,0 +1,34 @@
+# Stop a test from expiring on a calendar date — Plain-English Overview
+
+> The one-line version: a test had two dates typed into it and quietly stopped passing when the calendar moved past them, turning every open pull request red for a reason unrelated to anyone's code.
+
+## The problem in one breath
+
+One test checks a dashboard route that answers "what merged in the last seven days?". To do that it feeds the route a fake merged pull request. The fake had two dates written into it as literal text. The route only keeps pull requests merged inside the last seven days — so the moment the calendar moved more than seven days past that typed-in date, the fake stopped counting, the route correctly returned nothing, and the test failed.
+
+It expired at midday today. Every open pull request went red within the hour, mine included, and none of them had touched that code.
+
+## Why this is worth more than the one-line fix
+
+This is a test that passes for a week and then fails for a reason that has nothing to do with what it is testing. That is worse than a test that simply breaks, because the failure arrives detached from any change — so whoever hits it reasonably assumes their own work caused it and goes looking in the wrong place. I did exactly that: I checked whether opening my pull request had changed the data the test reads, before noticing the test supplies its own data and the only moving part was the clock.
+
+It also blocks everyone at once. A shared pipeline that goes red on a date rather than on a change stops all delivery until somebody happens to investigate.
+
+## What already exists
+
+- **The route being tested** keeps a merged pull request only when its merge date sits between "seven days ago" and "now". That behaviour is correct and is not changed here.
+- **The test's own fake data** — the test does not read the real repository, it supplies a made-up pull request. So nothing about real activity affects it, which is what makes the diagnosis clean.
+
+## What this changes
+
+The two dates are now worked out relative to the moment the test runs — merged yesterday, opened the day before — instead of being typed in. They will always sit inside the seven-day window, so the test can no longer expire.
+
+One detail deliberately preserved: the gap between "opened" and "merged" stays exactly twenty-four hours. The route turns that gap into a speed score, and the test checks that score, so widening or narrowing the gap would have quietly changed the expected number and required editing an assertion that was never wrong.
+
+## The safeguards
+
+The comment left in the test names the exact failure, including the two literal dates that expired and the hour it happened. The next person to reach for a hardcoded date in a time-windowed test has the reason not to, written where they will be looking.
+
+## What you actually need to decide
+
+Nothing. This restores a test to testing the thing it was written to test. The only judgement call was keeping the twenty-four-hour gap rather than adjusting the expected score, and keeping it means no assertion changes at all.

--- a/tests/e2e/throughput-series-live.test.ts
+++ b/tests/e2e/throughput-series-live.test.ts
@@ -5,12 +5,24 @@ import { createThroughputRoutes } from '../../src/server/throughputRoutes.js';
 
 describe('Throughput series route is alive', () => {
   it('serves the real route contract through Express', async () => {
+    // Dates are RELATIVE to now on purpose. The route keeps only PRs with
+    // `cutoff <= mergedAt <= now` where `cutoff = now - days`, so hardcoded
+    // fixture dates silently expire: the previous literals
+    // (createdAt 2026-07-22T12:00:00Z, mergedAt 2026-07-23T12:00:00Z) fell out of
+    // the rolling 7-day window at 2026-07-30T12:00:00Z and turned CI red on every
+    // open PR — a test that passes for a week and then fails for a reason that has
+    // nothing to do with the code under test. Anchoring to now removes the clock
+    // from the assertion. The 24h created→merged gap is preserved deliberately:
+    // `team.index` is derived from median latency, so changing the gap would move
+    // the expected index below.
+    const mergedAt = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const createdAt = new Date(mergedAt.getTime() - 24 * 60 * 60 * 1000);
     const graphql = async () => ({
       search: {
         issueCount: 1,
         nodes: [{
             number: 42, title: 'Feature', author: { login: 'JKHeadley' },
-            createdAt: '2026-07-22T12:00:00Z', mergedAt: '2026-07-23T12:00:00Z',
+            createdAt: createdAt.toISOString(), mergedAt: mergedAt.toISOString(),
             additions: 70, deletions: 30,
             reviews: { nodes: [] }, commits: { totalCount: 2 },
           }],

--- a/upgrades/next/fix-expiring-throughput-fixture.md
+++ b/upgrades/next/fix-expiring-throughput-fixture.md
@@ -1,0 +1,19 @@
+# Upgrade Guide — vNEXT
+
+<!-- internal-only -->
+<!-- bump: patch -->
+
+## What Changed
+
+`tests/e2e/throughput-series-live.test.ts` stubbed a merged PR with literal dates (`createdAt: '2026-07-22T12:00:00Z'`, `mergedAt: '2026-07-23T12:00:00Z'`). The throughput route keeps only PRs where `cutoff <= mergedAt <= now` with `cutoff = now - days` (`src/server/throughputRoutes.ts:114-117`), so at `2026-07-30T12:00:00Z` the stub fell out of the rolling 7-day window, `rows` became `[]`, and the assertion failed. CI went red on every open PR within the hour, for a reason unrelated to any change in them.
+
+The stub's dates are now derived from `Date.now()` — merged 24h ago, created 48h ago — so the test cannot expire. The 24h created-to-merged gap is preserved deliberately: `team.index` is derived from median latency, so changing the gap would move the expected value and force an assertion edit that was never wrong.
+
+Diagnosis note worth keeping: a test that passes for a week then fails on a date is worse than one that simply breaks, because the failure arrives detached from any change, so the natural assumption is that your own work caused it. This fixture supplies its own data and reads no real repository state, which is what made the clock the only possible variable.
+
+## Evidence
+
+- Reproduced on a branch off freshly-fetched `origin/main`, confirming it is pre-existing and not caused by any in-flight PR: `rows: []` against expected `rows: [{ authors: { codey: { merges: 1 } }, team: { index: 80 } }]`.
+- Boundary identified precisely: the literal `mergedAt` sat exactly 7 days before `2026-07-30T12:00:00Z`, which is when the failures began.
+- After the fix: `npx vitest run tests/e2e/throughput-series-live.test.ts` gives 3/3 pass, with the `index: 80` assertion unchanged, proving the preserved 24h gap keeps the derived score identical.
+- `safe-merge` independently refused to merge PR #1753 while these checks were red, so the merge guard behaved correctly throughout.

--- a/upgrades/side-effects/fix-expiring-throughput-fixture.md
+++ b/upgrades/side-effects/fix-expiring-throughput-fixture.md
@@ -1,0 +1,76 @@
+# Side-Effects Review — Stop the throughput fixture expiring on a calendar date
+
+**Version / slug:** `fix-expiring-throughput-fixture`
+**Date:** `2026-07-30`
+**Author:** `echo (instar-dev agent)`
+**Second-pass reviewer:** `not required — test-only change, no decision-point surface`
+
+## Summary of the change
+
+`tests/e2e/throughput-series-live.test.ts` fed the throughput route a stub PR with literal dates (`createdAt: '2026-07-22T12:00:00Z'`, `mergedAt: '2026-07-23T12:00:00Z'`). The route keeps only PRs where `cutoff <= mergedAt <= now` with `cutoff = now - days` (`src/server/throughputRoutes.ts:114-117`), so at `2026-07-30T12:00:00Z` the stub fell out of the rolling 7-day window, `rows` became `[]`, and the assertion failed. Every open PR went red within the hour — reproduced locally on a branch off `origin/main`, so it is not caused by any in-flight change.
+
+The stub's dates are now derived from `Date.now()` (merged −24h, created −48h). Files touched: `tests/e2e/throughput-series-live.test.ts` only. No `src/` change.
+
+## Decision-point inventory
+
+No decision point. This is a test fixture; it gates nothing, blocks nothing, and constrains no agent behavior.
+
+- `tests/e2e/throughput-series-live.test.ts` — **modify** — stub dates made relative to now instead of literal.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface — over-block not applicable.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **Other hardcoded dates elsewhere.** This fixes the one fixture that expired. A repo-wide sweep for literal dates inside time-windowed assertions is not attempted here, so a sibling time bomb could exist and would surface the same way — red on a date, with no code change to blame. Recording this rather than silently scoping it out. <!-- tracked: ACT-1613 -->
+- **No structural guard against reintroduction.** Nothing prevents a future author typing a literal date into a windowed test. The mitigation is a comment naming the exact failure at the exact site, which is weaker than a lint. A lint would need to distinguish a date used as a window input from a date used as inert data, which is not obviously decidable — so a comment is the honest level of protection here rather than a guard I would be overstating. <!-- tracked: ACT-1613 -->
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The bug is in the test's own fixture data, and that is where it is fixed. The route's windowing behavior is right and is deliberately untouched — the test was wrong about time, not the code.
+
+The alternative was freezing the clock (`vi.setSystemTime`). Rejected: it would make this test's passing depend on fake-timer setup interacting with the route's real `Date.now()` calls, which is more machinery and more coupling than deriving two dates.
+
+---
+
+## 4. Signal vs authority compliance
+
+Not applicable — no authority and no signal. Per `docs/signal-vs-authority.md` the principle governs decision points; a test fixture is neither.
+
+---
+
+## 5. Interactions
+
+- **The 24h created→merged gap is preserved on purpose.** `metrics()` derives `medianLatencyH` from `mergedAt - createdAt`, and `team.index` is computed from latency alongside merges and LOC. Changing the gap would move the expected `index: 80` and force an assertion edit that was never wrong. Verified by running the file: 3/3 pass with the assertion untouched.
+- **Day bucketing** (`pacificDay`) now buckets to "yesterday in Pacific time" rather than a fixed calendar day. The test asserts on `rows[0]` and not on a specific date, so this is immaterial.
+- **No shadowing or double-firing** — nothing else consumes this fixture.
+- **Does not mask the Vercel check failure** also present on PR #1753; that is a separate, unrelated red and is not addressed here.
+
+---
+
+## 6. External surfaces
+
+None. Test-only: no route, hook, template, scaffold, migration, or runtime behavior changes. Nothing visible to any user, agent, or external system. The only externally-visible effect is that CI can go green again.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN** — and not meaningfully a posture question: this is a test file executed by whichever runner checks out the repo. There is no agent state, no replication path, no merged read, no user-facing notice, no durable state that could strand on topic transfer, and no generated URL. Stated explicitly rather than omitted, because the question exists to catch silent single-machine assumptions in features, and this is not a feature.
+
+---
+
+## 8. Rollback cost
+
+Zero. `git revert` restores the previous literals — which would immediately re-red CI, so the revert is only meaningful alongside a different fix. No migration, no state repair, no release coupling.


### PR DESCRIPTION
## ELI16 — a test had two dates typed into it and quietly stopped passing when the calendar moved past them

One test checks a dashboard route that answers "what merged in the last seven days?". To do that it feeds the route a fake merged pull request, and that fake had two dates written into it as literal text. The route only keeps pull requests merged inside the last seven days — so the moment the calendar moved more than seven days past that typed-in date, the fake stopped counting, the route correctly returned nothing, and the test failed.

It expired at midday today. Every open pull request went red within the hour, and none of them had touched that code.

This is worse than a test that simply breaks, because the failure arrives detached from any change — so whoever hits it reasonably assumes their own work caused it and goes looking in the wrong place. I did exactly that before noticing the test supplies its own data and the only moving part was the clock.

The two dates are now worked out relative to when the test runs — merged yesterday, opened the day before — so it can no longer expire. The twenty-four-hour gap between "opened" and "merged" is kept exactly as it was, because the route turns that gap into a speed score the test checks; widening it would have quietly changed the expected number and forced an edit to an assertion that was never wrong.

## The failure

`tests/e2e/throughput-series-live.test.ts` stubbed:

```
createdAt: '2026-07-22T12:00:00Z', mergedAt: '2026-07-23T12:00:00Z'
```

`src/server/throughputRoutes.ts:114-117` keeps only PRs where `cutoff <= mergedAt <= now`, with `cutoff = now - days`. At `2026-07-30T12:00:00Z` the stub fell out of the rolling 7-day window:

```
- "rows": Array [ { "authors": { "codey": { "merges": 1 } }, "team": { "index": 80 } } ]
+ "rows": Array []
```

## Evidence

- **Established as pre-existing before fixing**, by reproducing on a branch off freshly-fetched `origin/main` — this is what ruled out any in-flight PR as the cause.
- Boundary identified exactly: the literal `mergedAt` sat 7 days before `2026-07-30T12:00:00Z`, which is when the failures started.
- After the fix: `npx vitest run tests/e2e/throughput-series-live.test.ts` → **3/3 pass**, with the `index: 80` assertion **unchanged** — which is the proof that preserving the 24h gap keeps the derived score identical.
- `safe-merge` independently **refused** to merge PR #1753 while these checks were red. The merge guard behaved correctly throughout; this PR is what unblocks it.

## Scope

Test-only. No `src/` change, no decision point, no gate/sentinel/authority surface, no migration, no external surface. Deliberately kept separate from PR #1753 rather than bundled, so a misbehaving change is attributable.

Not attempted here, and recorded rather than silently dropped: a repo-wide sweep for other literal dates inside time-windowed assertions, and a lint to prevent reintroduction (distinguishing a date used as a window input from inert fixture data is not obviously decidable, so a comment at the site is the honest level of protection). Tracked as ACT-1613.

Tier 1. ELI16: `docs/specs/fix-expiring-throughput-fixture.eli16.md`. Side-effects review: `upgrades/side-effects/fix-expiring-throughput-fixture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)