### PR TITLE
docs(spec): worktree read-path event-loop safety — NOT converged, for review

### DIFF
--- a/docs/findings/2026-07-30-armed-deleter-with-no-evidence-trail.md
+++ b/docs/findings/2026-07-30-armed-deleter-with-no-evidence-trail.md
@@ -1,0 +1,124 @@
+---
+title: "An armed deleter has run for seven weeks and nothing records what it deleted"
+date: 2026-07-30
+author: echo
+machine: Laptop (mac.lan)
+severity: high
+status: open
+kind: finding
+relates:
+  - "docs/specs/agent-worktree-reaper.md"
+  - "docs/specs/worktree-read-path-eventloop-safety.md"
+  - "docs/STANDARDS-REGISTRY.md"
+---
+
+# An armed deleter has run for seven weeks and nothing records what it deleted
+
+**Deliberately not folded into the event-loop change.** That change is about a frozen
+event loop. This is about an irreversible action with no evidence trail. Folding the
+second into the first buries it, and it is the more serious of the two.
+
+## The finding
+
+`AgentWorktreeReaper` emits a `reaped` event when it removes a worktree:
+
+```ts
+this.deps.removeWorktree(info.path);
+reaped.push(info.path);
+this.emit('reaped', info);
+```
+
+**Nothing listens to it.** The construction site in `src/commands/server.ts` builds the
+reaper, calls `start()`, logs one line if it is enabled, and registers no handler. There
+is no `.on('reaped', …)` anywhere in the tree. There is no audit file, no log line, no
+attention item, and no entry in the reap-log (that log is for *sessions*, a different
+subsystem).
+
+So the reaper can delete a worktree and leave **no record that it did**.
+
+## Why this is the headline and not a footnote
+
+It sat alongside two fail-open gates found the same day. It is worse than both, for a
+structural reason rather than a severity-scoring one:
+
+- A fail-open gate is a **bounded risk**. You can reason about its trigger, measure
+  whether the trigger occurs, and calculate what it could cost.
+- No evidence trail is **an unanswerable question**. It does not raise the probability
+  of harm; it removes the ability to determine whether harm occurred.
+
+This was demonstrated rather than argued. A peer asked a reasonable question — *has this
+reaper actually removed anything on that machine?* — and the honest answer is that the
+system structurally cannot answer it. Everything below is the best evidence obtainable,
+and it is not sufficient.
+
+It is also the purest instance of a defect class we hit repeatedly on 2026-07-29/30: **a
+claim with no mechanism behind it.** A health endpoint reporting `ok` it never computed;
+an exemption comment asserting a safety property that had silently stopped being true; a
+test certifying a property the shipped code violated. This is the same shape with an
+irreversible consequence instead of a merely misleading one.
+
+## Evidence gathered (2026-07-30, Laptop)
+
+**Armed, and for longer than assumed.** `GET /worktrees/agent-reaper` reports
+`enabled: true, dryRun: false`. `logs/guard-posture.jsonl`:
+
+| When | Transition |
+| --- | --- |
+| 2026-06-06T07:17:03Z | `monitoring.agentWorktreeReaper.enabled` → **enabled** |
+| 2026-06-07T16:49:22Z | disabled, in the batch load-shed (9 guards at once) |
+| 2026-06-07T18:12:42Z | **re-enabled** |
+
+≈7.5 weeks armed with a 24h cadence, plus a 15-minute post-boot initial pass.
+
+**Enumeration works here.** 49 worktrees evaluated on the live snapshot — so the reaper
+has had real candidates to consider on every pass, unlike a machine where enumeration
+fails and the reaper is inert by accident.
+
+**No partial-removal signature.** 50 registered worktrees, 59 directories on disk, and
+**zero** registered-but-missing directories. A `git worktree remove` takes both the
+directory and the registration, so an interrupted removal would show as a registered
+worktree with no directory. None exists. The nine extra directories are the opposite
+shape — untracked leftovers, not deletion residue.
+
+**Nothing is currently eligible.** 35 `uncommitted-changes`, 14 `unmerged`, **0
+reclaimable**. Both of those gates fail closed correctly.
+
+**The most recent pass removed nothing.** `lastPassAt` 2026-07-30 05:48 local,
+`reapedLastPass: 0`.
+
+## The honest limit
+
+**Absence of a signature is not proof of absence of deletions.** Every item above is
+consistent with "it never deleted anything" and equally consistent with "it deleted
+things cleanly and left no trace" — which is precisely what a successful
+`git worktree remove` does. The only artefact that would distinguish them is the record
+that does not exist.
+
+What can be said with confidence: the most recent pass removed nothing, nothing is
+eligible right now, and there is no evidence of a deletion. What cannot be said: that
+none occurred in the preceding seven weeks.
+
+## Recommendation
+
+1. **Add a listener and a durable record before anything else.** Every `reaped` event
+   should append to an audit file with the worktree path, branch, head SHA, the verdict
+   reasons that authorised it, and the timestamp. This is small, and until it exists
+   every future question of this kind has the same non-answer.
+2. **Treat the record as a precondition for arming, not a nice-to-have.** A guard that
+   performs irreversible actions should not be armable without one. That is the
+   *Structure beats Willpower* form of this finding: the record should not depend on
+   whoever wires it remembering to.
+3. **Register the reaper as a self-triggered destructive controller.** It is absent from
+   the self-action registry despite firing on a timer and deleting on a heuristic. Its
+   `maxReapsPerPass` cap bounds one pass, never the loop — the exact distinction the
+   *Capacity Safety — No Unbounded Self-Action* standard draws. Today produced three
+   independent arguments for this: the heuristic delete with a per-pass-only cap; seven
+   weeks armed on one machine while the guard manifest classified it differently on
+   another; and no instrumentation and no deletion record at all.
+
+## Scope note
+
+Items 1 and 2 are not in the event-loop PR and should not be. That change is confined to
+execution strategy; this is a foundation gap. Smuggling a foundation change into a
+performance fix is how a change stops being reviewable — and it would land in the same PR
+where a delete-unsafe path was just found.

--- a/docs/findings/2026-07-30-armed-deleter-with-no-evidence-trail.md
+++ b/docs/findings/2026-07-30-armed-deleter-with-no-evidence-trail.md
@@ -5,6 +5,8 @@ author: echo
 machine: Laptop (mac.lan)
 severity: high
 status: open
+tracked-by: ACT-1225
+follow-through-due: 2026-08-06
 kind: finding
 relates:
   - "docs/specs/agent-worktree-reaper.md"
@@ -100,21 +102,47 @@ none occurred in the preceding seven weeks.
 
 ## Recommendation
 
-1. **Add a listener and a durable record before anything else.** Every `reaped` event
-   should append to an audit file with the worktree path, branch, head SHA, the verdict
-   reasons that authorised it, and the timestamp. This is small, and until it exists
-   every future question of this kind has the same non-answer.
+1. **Register a listener for `reaped` AND `error`, with a durable record.** Every
+   `reaped` event should append to an audit file with the worktree path, branch, head
+   SHA, the verdict reasons that authorised it, and the timestamp. Until it exists every
+   future question of this kind has the same non-answer.
+
+   **`error` is not a documentation gap — it is a live crash path.** The reaper extends
+   `EventEmitter` and emits `'error'` on both the listing-failure and removal-failure
+   paths, and **Node throws when `'error'` is emitted with zero listeners**. Both emit
+   sites are on the timer path invoked as `void this.reap()`, so on an armed machine a
+   `git worktree remove` failure becomes an unhandled promise rejection. An earlier
+   version of this recommendation scoped the listener work to `reaped` alone and missed
+   this. Worth noting the irony: the event-loop change added a last-resort `catch` to the
+   route handlers for exactly this failure class while the timer path kept it.
 2. **Treat the record as a precondition for arming, not a nice-to-have.** A guard that
    performs irreversible actions should not be armable without one. That is the
    *Structure beats Willpower* form of this finding: the record should not depend on
    whoever wires it remembering to.
-3. **Register the reaper as a self-triggered destructive controller.** It is absent from
-   the self-action registry despite firing on a timer and deleting on a heuristic. Its
-   `maxReapsPerPass` cap bounds one pass, never the loop — the exact distinction the
-   *Capacity Safety — No Unbounded Self-Action* standard draws. Today produced three
+3. **Drive the EXISTING lint out of report-only — do not ask anyone to remember.** An
+   earlier version of this recommendation said the reaper "should be registered" as a
+   self-triggered destructive controller, which is the willpower-shaped remedy this
+   document's own thesis rejects. The loop-closer is already built and already pointed at
+   the right file: `scripts/lint-no-unregistered-self-action.js` reports
+   `src/monitoring/AgentWorktreeReaper.ts` as an unregistered self-action controller
+   today — one of **21** — and exits 0 because it is report-only, gated on
+   `prGate.classClosure.dryRun: false`. The remediation is the flip and the backlog, not
+   a reminder. The reaper's `maxReapsPerPass` cap bounds one pass, never the loop — the
+   exact distinction the *Capacity Safety — No Unbounded Self-Action* standard draws. Today produced three
    independent arguments for this: the heuristic delete with a per-pass-only cap; seven
    weeks armed on one machine while the guard manifest classified it differently on
    another; and no instrumentation and no deletion record at all.
+
+## Cadence — how this finding avoids being its own subject
+
+Registered as **ACT-1225**, due 2026-08-06, so it re-surfaces rather than resting in a
+directory nothing reads.
+
+This is not bookkeeping. An earlier version of this document was filed `status: open` in a
+new directory with no consumer, no tracker id and no re-surfacing cadence — which the
+*Close the Loop* standard names exactly: *untracked = abandoned*. A high-severity finding
+about **an irreversible action with no mechanism behind the claim** was itself a claim
+with no mechanism behind it. Caught in review, not by the author.
 
 ## Scope note
 

--- a/docs/findings/2026-07-30-shared-signal-opposite-polarity.md
+++ b/docs/findings/2026-07-30-shared-signal-opposite-polarity.md
@@ -1,0 +1,87 @@
+---
+title: "A shared signal read by two consumers with opposite polarity cannot be made safe for one without checking the other"
+date: 2026-07-30
+author: echo
+severity: medium
+status: open
+kind: lesson
+tracked-by: ACT-1225
+relates:
+  - "docs/specs/worktree-read-path-eventloop-safety.md"
+  - "docs/findings/2026-07-30-armed-deleter-with-no-evidence-trail.md"
+  - "docs/STANDARDS-REGISTRY.md"
+---
+
+# A shared signal with opposite polarity
+
+## The rule
+
+**When a signal feeds two consumers that read it in opposite directions, "make it fail
+safe" is not a well-defined instruction until you say *safe for which one*.** Hardening it
+for one consumer will, by construction, weaken it for the other.
+
+## The instance
+
+`isInUse(path)` answers "is something using this worktree?" Two consumers:
+
+| Consumer | `true` means | Its safe direction |
+| --- | --- | --- |
+| `AgentWorktreeReaper` (a **deleter**) | KEEP — do not delete | `true` |
+| `OrphanedWorkSentinel` (a **detector**) | SKIP — do not flag as abandoned | `false` |
+
+Review found the deleter's version failing *open*: a failed process scan returned an
+empty set, indistinguishable from "nothing is using it", clearing a gate on the path to an
+irreversible delete. The fix collapsed a failed scan to `true` — correct for the deleter.
+
+It silently blinded the detector. Every worktree became `skip('owner-alive')` whenever the
+scan failed, and the route reported `orphanedCount: 0` — "nothing stranded" — on the
+surface whose entire purpose is not losing stranded work.
+
+**Note what was false.** Not the skip; skipping on uncertainty is defensible for a
+detector too, because a false abandonment claim is also harmful. The false part was the
+**reason**: `owner-alive` asserts a live owner that was never observed. The truth was
+"liveness could not be determined", and those are different facts that had been collapsed
+into one word.
+
+## Why it slipped through
+
+The change that introduced it was made *by the author of the artifact whose closing lesson
+reads*: "an interface was widened and its consumers were never audited."
+
+That lesson was written about widening a **type** (`boolean` → `Awaitable<boolean>`) and
+missing a consumer. The regression widened a **value** (`boolean` → `boolean | 'unknown'`)
+and missed a consumer. Same defect, one layer up, committed within hours of naming it.
+
+The generalisable part is not the carelessness. It is that **naming a failure mode does
+not protect you from it — only a check does.** The author had the words and still made the
+mistake; a reviewer executing the code found it.
+
+## The fix, and the shape worth copying
+
+Do **not** collapse the third state at the source and hope each consumer wants the same
+collapse. Expose the uncollapsed answer and let each consumer collapse it for its own
+polarity, with its own vocabulary:
+
+- The signal now exposes `isInUseTriState` → `true` / `false` / `'unknown'`.
+- The deleter keeps a boolean `isInUse` that collapses `'unknown'` → `true` (KEEP), with a
+  comment at the definition naming the polarity hazard.
+- The detector reads the tri-state and emits a distinct `owner-liveness-unknown`, so
+  "could not tell" never renders as "nothing here".
+- The detector's snapshot carries `undeterminedCount`, so a zero orphan count cannot be
+  read as an all-clear when the real answer is that nothing could be determined.
+
+That last point is the same principle as the sibling armed-deleter finding: **an
+unanswerable question must be visibly unanswerable, not silently rendered as a negative
+answer.**
+
+## The check to build
+
+Type-level collapse of a multi-state answer into a boolean at the *source* is the smell.
+Where a signal has more than two states and more than one consumer, the collapse belongs at
+each call site, not at the definition.
+
+There is no lint for this today, and the related class — truthiness on an `Awaitable`
+union, which recurred once in this same change — has no lint either. Both are currently
+guarded by a code comment saying "never do this here", which is the willpower-shaped
+remedy that *Structure beats Willpower* rejects. Tracked under ACT-1225 alongside the
+reaper's other structural gaps.

--- a/docs/specs/worktree-read-path-eventloop-safety.eli16.md
+++ b/docs/specs/worktree-read-path-eventloop-safety.eli16.md
@@ -94,9 +94,18 @@ time limit, for a reason worth explaining below.
 
 ## The safeguards, in plain terms
 
-- **Nothing about the decisions changed.** Which leftovers are safe to clean up, and
-  which are kept, is exactly as before. Two tests exist purely to prove that, and
-  they are labelled honestly as *not* being proof the freezing is fixed.
+- **Some decisions DID change, and earlier versions of this page said otherwise.**
+  This is the correction that matters most, because this is the page written for
+  the person approving the work. The gate ORDER is unchanged, and two tests pin
+  that. But in four places the answer itself changed, every one of them toward
+  keeping rather than deleting: the last check before a deletion was silently
+  broken and now works; a failed scan for "is anything using this?" used to mean
+  "nothing is" and now means "keep"; an unreadable lock file used to read as absent
+  and now reads as present; and a job abandoned on a time limit is a new outcome
+  that did not exist before. The technical documents retracted the "nothing
+  changed" claim this morning and this page kept asserting it — a reviewer caught
+  that, and it is the fourth time on this change that a correction landed in the
+  technical write-up and missed the one a human actually reads.
 - **When in doubt, keep.** If any check fails or times out, the answer is "cannot
   tell", which always means keep the copy. A half-finished answer is thrown away
   rather than treated as a success — because a half-answer could look like "this is
@@ -108,8 +117,10 @@ time limit, for a reason worth explaining below.
 - **Not a cache.** Sharing only happens between requests arriving at the same
   moment; nothing is stored. The page still tells you what is true right now,
   which was a firm requirement.
-- **Nothing can get stuck forever.** This one came out of the same review and is
-  less obvious than it sounds. The "several people share one answer" trick works by
+- **Nothing can get stuck forever — now on BOTH status pages.** This one came out
+  of the same review and is less obvious than it sounds. (The time limits were
+  originally added to only one of the two pages while the paperwork claimed both;
+  every reviewer in the next round caught it, and the second page has them now.) The "several people share one answer" trick works by
   putting up a sign saying *a job is already running*, and taking the sign down when
   the job finishes. If a job never finishes at all, the sign never comes down — and
   then everyone who asks afterwards waits forever, and the automatic cleanup helper
@@ -155,15 +166,20 @@ Whether to approve this so it can be committed.
 Things worth weighing:
 
 - **Risk of doing it:** it changes how a helper that *deletes things* reads
-  version-control state. That is why it is filed at the highest care level, even
-  though the automated check thought a lower one was warranted. No decision logic
-  changed, and all three layers of the test suite pass.
+  version-control state, and it now also adds a piece to the safety checkpoint all
+  version-control commands pass through. That is why it is filed at the highest
+  care level, even though the automated check thought a lower one was warranted.
+  The decision RULES are unchanged; four of the answers changed, all of them toward
+  keeping rather than deleting (see above). All three layers of the test suite pass.
 - **Risk of not doing it:** every visit to either status page freezes the agent for
   several seconds, including its heartbeat to your other machine. The status page is
   about to be given a *more* important role, so it will be visited more.
-- **Backing it out:** one setting makes the checks run strictly one at a time, and a
-  full reversal is just undoing the code. Nothing is stored, nothing is migrated,
-  and there is no data to repair.
+- **Backing it out:** one setting makes the checks run strictly one at a time. A
+  full reversal is undoing the code AND three things that are easy to forget: the
+  new automatic check has to come out of the check list in two places or the test
+  suite goes red; a frozen tracking file has to be put back; and a short note this
+  change adds to already-updated agents stays behind, because a code reversal
+  cannot un-write it. Nothing else is stored and there is no data to repair.
 - **One thing that is now caught automatically.** Two mistakes on this branch came
   from the same slip — asking a question the new way but reading the answer the old
   way, which quietly always gives the same reply no matter what is true. An

--- a/docs/specs/worktree-read-path-eventloop-safety.eli16.md
+++ b/docs/specs/worktree-read-path-eventloop-safety.eli16.md
@@ -130,7 +130,11 @@ time limit, for a reason worth explaining below.
   while something it started keeps the line open. So every step now has its own time
   limit and gives up honestly rather than hanging.
 - **Giving up says so.** When a check is abandoned this way, the automatic cleanup
-  simply does nothing that round — safe. But the status page **refuses to answer**
+  REPORTS that it did nothing that round. Being precise, because an earlier version
+  of this line was not: the abandoned job is not actually stopped, so it may still
+  finish its own deletions. What it can no longer do — since the latest round — is
+  be joined by a SECOND cleanup running at the same time, which is what made the
+  "how much may be deleted at once" limit stop meaning anything. But the status page **refuses to answer**
   rather than showing an empty list, because an empty list would read as "nothing to
   clean up here", which is a made-up answer on the page that reports what the
   deleting helper sees.

--- a/docs/specs/worktree-read-path-eventloop-safety.eli16.md
+++ b/docs/specs/worktree-read-path-eventloop-safety.eli16.md
@@ -1,0 +1,121 @@
+---
+title: "Plain-English overview — a status page that froze the whole server"
+slug: "worktree-read-path-eventloop-safety-eli16"
+covers: "docs/specs/worktree-read-path-eventloop-safety.md"
+---
+
+# A status page that froze the whole server
+
+## The short version
+
+Your agent has a housekeeping helper that looks after leftover copies of the
+codebase — scratch copies made when work gets done in isolation. There is a status
+page that answers "which of these leftovers can be cleaned up, and why is each one
+being kept?"
+
+Asking that question froze the entire agent for over ten seconds. Not the status
+page — **everything**. Every other page, every scheduled check, the heartbeat that
+tells your other machine this one is still alive. One click, ten seconds of a
+completely unresponsive agent.
+
+This change makes asking that question stop freezing everything.
+
+## Why it happened
+
+The agent does one thing at a time, very fast. That is normally fine, because each
+thing takes a few thousandths of a second.
+
+To answer the status question, the agent has to ask the version-control tool
+several questions about **each** leftover copy: has anything been edited here? Is
+this work already saved into the main line? Is somebody using it right now? On this
+machine there are forty-eight leftover copies, so that is well over a hundred
+separate little programs it has to run.
+
+The bug is that it ran them in a way that meant "wait right here until this
+finishes, and do nothing else at all." Do that a hundred-odd times in a row and the
+agent is simply gone for ten seconds.
+
+## How we know, rather than assume
+
+We measured it on the real running agent. A trivial health check normally answers in
+about 17 thousandths of a second. While the status question was being answered, the
+same health check took **10.6 seconds**. A second status page had the same flaw and
+froze things for 3.7 seconds.
+
+And that ten seconds is the *good* case. The agent gives up early on any leftover
+copy that obviously has unsaved edits, and most of them did — so most of them
+skipped the expensive checks. A tidier machine would be frozen for longer.
+
+## The part that is a lesson rather than a bug
+
+There was a note in the code explicitly permitting this, on the grounds that the
+cleanup helper ships switched off, so nothing was really running it.
+
+That note was wrong in a way nobody noticed. It was true of the *automatic
+background cleanup*, but the *status page* runs the same expensive work every time
+somebody asks — switched on or not. And on this machine the helper is not switched
+off at all: it is switched on. Checking both machines showed them reporting
+different states for the same setting.
+
+So a safety claim written in a comment quietly stopped being true when the settings
+changed, and nothing re-checked it. That is the real story here, and it is why this
+got fixed rather than added to a list.
+
+## What already existed, and what is new
+
+**Already existed:** a way to ask version-control questions *without* freezing
+everything, sitting inside the same safety checkpoint that all version-control
+commands go through. Another part of the agent already uses it for exactly this
+reason. This was genuinely useful to discover — it meant no new hole had to be cut
+in a safety checkpoint. The fix rides on something already built and reviewed.
+
+**New:** the status pages now use that non-freezing method; the checks run a few at
+a time instead of all at once; one repeated lookup that was being redone for every
+single copy is now done once; and if several people ask at the same moment they
+share one answer instead of each triggering the whole job again.
+
+## The safeguards, in plain terms
+
+- **Nothing about the decisions changed.** Which leftovers are safe to clean up, and
+  which are kept, is exactly as before. Two tests exist purely to prove that, and
+  they are labelled honestly as *not* being proof the freezing is fixed.
+- **When in doubt, keep.** If any check fails or times out, the answer is "cannot
+  tell", which always means keep the copy. A half-finished answer is thrown away
+  rather than treated as a success — because a half-answer could look like "this is
+  safe to delete" when it is not.
+- **One set of rules, not two.** The easier fix would have been a separate fast path
+  just for the status page. That was deliberately rejected: the rules that decide
+  whether something gets **deleted** must not be able to drift apart from the rules
+  the status page shows you.
+- **Not a cache.** Sharing only happens between requests arriving at the same
+  moment; nothing is stored. The page still tells you what is true right now,
+  which was a firm requirement.
+
+## An honest note about the testing
+
+The first version of the test that was supposed to prove this was fixed **passed
+against the broken code**. That made it worthless — a test that cannot tell broken
+from fixed proves nothing.
+
+The cause was subtle: the measurement stopped a fraction too early and never
+actually observed the freeze it was looking for. Once corrected, it fails against
+the broken code with 758 thousandths of a second of freeze against a 250 limit, and
+passes against the fix. Every test here was run against the broken code first, on
+purpose, for exactly this reason.
+
+## What you actually need to decide
+
+Whether to approve this so it can be committed.
+
+Things worth weighing:
+
+- **Risk of doing it:** it changes how a helper that *deletes things* reads
+  version-control state. That is why it is filed at the highest care level, even
+  though the automated check thought a lower one was warranted. No decision logic
+  changed, and all three layers of the test suite pass.
+- **Risk of not doing it:** every visit to either status page freezes the agent for
+  several seconds, including its heartbeat to your other machine. The status page is
+  about to be given a *more* important role, so it will be visited more.
+- **Backing it out:** one setting makes the checks run strictly one at a time, and a
+  full reversal is just undoing the code. Nothing is stored, nothing is migrated,
+  and there is no data to repair.

--- a/docs/specs/worktree-read-path-eventloop-safety.eli16.md
+++ b/docs/specs/worktree-read-path-eventloop-safety.eli16.md
@@ -65,14 +65,32 @@ got fixed rather than added to a list.
 
 **Already existed:** a way to ask version-control questions *without* freezing
 everything, sitting inside the same safety checkpoint that all version-control
-commands go through. Another part of the agent already uses it for exactly this
-reason. This was genuinely useful to discover — it meant no new hole had to be cut
-in a safety checkpoint. The fix rides on something already built and reviewed.
+commands go through.
 
-**New:** the status pages now use that non-freezing method; the checks run a few at
-a time instead of all at once; one repeated lookup that was being redone for every
-single copy is now done once; and if several people ask at the same moment they
-share one answer instead of each triggering the whole job again.
+**And this is where the plan changed, so it is worth being straight about it.** The
+original plan was to use that existing method and add nothing to the safety
+checkpoint — which sounded better, because touching a safety checkpoint is the
+scariest part of this work. A later review showed the plan did not hold. That
+existing method hands back a job that is still running, so the checkpoint writes
+down "this was allowed to start" and never learns whether it *succeeded*. A check
+that FAILED — the kind of check that decides whether something gets deleted — was
+being recorded as though it had gone fine, with no record of the failure at all.
+The slower, blocking method records failures properly.
+
+So the choice was: leave the mismatch and describe it honestly in the paperwork, or
+close it. It got closed — which means this change **does** add something to the
+safety checkpoint after all: a proper non-freezing way to ask a question that
+records the answer the same way the old one did. The rules about what is allowed are
+untouched and are now written in one shared place instead of copied three times, so
+they cannot quietly drift apart.
+
+That reversal is the reason this is still filed at the highest care level.
+
+**New:** the status pages use the non-freezing method; the checks run a few at a
+time instead of all at once; one repeated lookup that was being redone for every
+single copy is now done once; several people asking at the same moment share one
+answer instead of each triggering the whole job again; and every step now has a
+time limit, for a reason worth explaining below.
 
 ## The safeguards, in plain terms
 
@@ -90,6 +108,21 @@ share one answer instead of each triggering the whole job again.
 - **Not a cache.** Sharing only happens between requests arriving at the same
   moment; nothing is stored. The page still tells you what is true right now,
   which was a firm requirement.
+- **Nothing can get stuck forever.** This one came out of the same review and is
+  less obvious than it sounds. The "several people share one answer" trick works by
+  putting up a sign saying *a job is already running*, and taking the sign down when
+  the job finishes. If a job never finishes at all, the sign never comes down — and
+  then everyone who asks afterwards waits forever, and the automatic cleanup helper
+  quietly stops running altogether. It would look perfectly healthy and simply never
+  find anything, which is the exact problem this helper exists to prevent. Killing
+  the underlying command is *not* enough to rule this out, because a command can die
+  while something it started keeps the line open. So every step now has its own time
+  limit and gives up honestly rather than hanging.
+- **Giving up says so.** When a check is abandoned this way, the automatic cleanup
+  simply does nothing that round — safe. But the status page **refuses to answer**
+  rather than showing an empty list, because an empty list would read as "nothing to
+  clean up here", which is a made-up answer on the page that reports what the
+  deleting helper sees.
 
 ## An honest note about the testing
 
@@ -102,6 +135,18 @@ actually observed the freeze it was looking for. Once corrected, it fails agains
 the broken code with 758 thousandths of a second of freeze against a 250 limit, and
 passes against the fix. Every test here was run against the broken code first, on
 purpose, for exactly this reason.
+
+**It happened a second time, in the latest round, and is worth recording rather than
+smoothing over.** A test written to prove the new "nothing gets stuck forever"
+safeguard also passed against the broken version — so it, too, proved nothing. The
+reason is instructive: it tested the safeguard at the layer where the code was
+written, and the problem it was hunting only appears one layer up. That test was
+deleted rather than kept for appearances, and replaced with three that genuinely
+fail when the safeguard is removed.
+
+The habit underneath both is the same one this whole change keeps running into:
+claiming something is true, testing the half where it is true, and letting the green
+result stand for the whole claim.
 
 ## What you actually need to decide
 
@@ -119,3 +164,11 @@ Things worth weighing:
 - **Backing it out:** one setting makes the checks run strictly one at a time, and a
   full reversal is just undoing the code. Nothing is stored, nothing is migrated,
   and there is no data to repair.
+- **One thing that is now caught automatically.** Two mistakes on this branch came
+  from the same slip — asking a question the new way but reading the answer the old
+  way, which quietly always gives the same reply no matter what is true. An
+  automatic check now refuses that pattern outright, and was tested by putting the
+  original mistake back to confirm it catches it. A related mistake — changing a
+  shared answer without checking everyone who reads it — has **no** automatic check;
+  it is written down as a lesson only. That distinction is deliberate, because
+  "written down" and "prevented" are not the same thing.

--- a/docs/specs/worktree-read-path-eventloop-safety.md
+++ b/docs/specs/worktree-read-path-eventloop-safety.md
@@ -216,8 +216,8 @@ blocking shape, so they get the identical protections:
 | Property | `/worktrees/agent-reaper` | `/orphaned-work` |
 | --- | --- | --- |
 | async handler + last-resort 500 | yes | yes |
-| non-blocking git reads | yes (shared deps) | yes (shared deps — it builds on the reaper's) |
-| non-blocking `lsof` / `gh` | yes | yes (same shared deps) |
+| non-blocking git reads | yes | yes (same factory, separate instance — see below) |
+| non-blocking `lsof` / `gh` | yes | yes (same CODE, separate instance — see below) |
 | bounded fan-out | yes (`snapshotConcurrency`) | yes (bounded, not `Promise.all`) |
 | base ref memoized per pass | yes | **separate deps INSTANCE — see below** |
 | single-flight in-flight sharing | yes | yes |
@@ -253,7 +253,10 @@ the expensive part and incomplete for the stampede part.
 Round two found a hole underneath the single-flight design. Every marker that says
 "a pass is already running" — the two memo in-flight slots, the base-ref slot,
 `pendingSnapshot`, and the reaper's own `running` flag — is cleared in a `finally`
-block. **A `finally` never runs on a promise that never settles.** So one
+block. (Round five moved `running` specifically: it now clears from the LATCH arm
+rather than the caller's, for the overlap reason below — so the caller path has no
+`finally` at all. The hazard argument is unchanged: a `finally` that never runs is
+still the problem.) **A `finally` never runs on a promise that never settles.** So one
 non-settling read would not merely be slow: it would pin those markers for the life
 of the process, and every later caller would join a promise that never resolves.
 The background reaper would stop running passes altogether — a guard that looks
@@ -281,7 +284,8 @@ Three ceilings, at the three layers where the hazard is reachable:
 **A deliberate asymmetry between the two pass surfaces.** An abandoned `reap`
 returns an EMPTY result; an abandoned `snapshot` REJECTS (the route renders it as a
 500). They differ because an empty result means different things: an empty pass
-simply does nothing, the safe direction, whereas an empty snapshot would ASSERT
+REPORTS nothing — while the abandoned pass may still complete its own deletions, so
+    "does nothing" was too strong and is retracted below — whereas an empty snapshot would ASSERT
 "nothing reclaimable" on the read surface that reports what the deleter sees — a
 fabricated answer, the same class as the NaN-concurrency hole this branch already
 closed.
@@ -295,7 +299,7 @@ re-validating, and keeps calling `removeWorktree` — irreversible deletes — w
 `reap()` has already returned `{reaped: []}`. So the abandoned pass does not "do
 nothing"; it does work the caller has been told did not happen, which is the same
 fabricated-answer class this section rejects for `snapshot`. And because the
-`finally` releases the single-pass latch, a second pass can start while the first
+`finally` released the single-pass latch (pre-round-five), a second pass could start while the first
 is still deleting, so N overlapping passes can delete up to N × `maxReapsPerPass` —
 the aggregate blast-radius bound is weaker than the config key's name promises.
 
@@ -305,11 +309,32 @@ something that should have been kept. The weakening is to the RATE bound, not to
 correctness. Stated this way rather than the reassuring way, because the reassuring
 way was false.
 
-**Not fixed here, deliberately.** Bounding the number of live passes (rather than
-the work within one) is a change to the reaper's control loop, not to its read path.
-It belongs with the outstanding work to register this component as a self-triggered
-destructive controller, where the per-pass-versus-per-loop distinction is the whole
-point — tracked with that item rather than smuggled in here.
+**FIXED in round five — the round-four deferral was wrong.** Round four recorded the
+above honestly and deferred the fix to the separate destructive-controller work. Two
+independent reviewers (round-four scalability, round-five external) said deferring is
+weak *precisely because this component deletes*, and they were right: an honest
+record of a delete-rate hole is still a delete-rate hole.
+
+The external reviewer also supplied the design the deferral was hiding behind — that
+freeing the caller and holding the bound looked like the same act, and they are not.
+They are now two clocks:
+
+- **Caller clock** (`PASS_DEADLINE_MS`, 10 min) frees the REQUEST. The caller gets an
+  honest empty pass and moves on, exactly as before.
+- **Controller clock** — the latch is released when the underlying work actually
+  SETTLES, however long that takes. While an abandoned pass is still alive, a second
+  `reap()` takes the already-running short-circuit and does nothing, so two passes
+  can never delete at once and `maxReapsPerPass` is a real rate bound again.
+- `LATCH_CEILING_MS` (60 min) is a last-resort backstop so a pass that NEVER settles
+  cannot hold the latch for the process lifetime — without it, fixing the overlap
+  would reintroduce the wedge the caller clock was added to break.
+
+Pinned by a test that drives a real overlap: with the round-three single-clock
+behaviour restored, the second pass reaps a worktree while the first is still alive;
+with the fix, it reaps nothing, and a CONTROL confirms back-to-back healthy passes
+still work. The residue that remains is honest and unchanged: an abandoned pass is
+still not *cancelled*, so it may still complete its own deletions — but it can no
+longer be joined by a second pass doing the same.
 <!-- tracked: topic 37155 -->
 
 ### The pass ceiling is not the cliff an operator meets first
@@ -327,7 +352,7 @@ its full subprocess cost for an answer nobody receives.
 Arithmetic for the scale this spec itself calls supported-if-slow: at ~200ms per
 worktree and `snapshotConcurrency: 4`, 500 worktrees is ~25s — inside the 30s budget
 with 17% margin, and `git cherry` cost is O(commits ahead), not constant, so a repo
-with long-lived branches crosses it easily. **500 worktrees is already a 408 regime**,
+with long-lived branches crosses it easily. **500 worktrees is therefore a 408 regime in practice rather than in principle**,
 and the failure mode this spec documents for that regime is the wrong one.
 
 Not fixed here: adding a route-timeout override is a server-config change with
@@ -348,10 +373,19 @@ therefore `(W + 1)` per instance — at the default `snapshotConcurrency: 4`, **
 concurrent children**, of which up to **two are simultaneous full-system process
 scans**. At the documented rollback lever (`1`) it is 4; at a hand-set 16 it is 34.
 
-**And that bound is per un-settled pass, not absolute.** Nothing bounds the NUMBER
-of live passes, so under a persistent wedge each ceiling expiry can leave another
-abandoned pass alive: `live children ≈ (W + 1) × k`, with `k` unbounded. The honest
-statement is "10 per un-settled pass, and passes are unbounded" — not "10".
+**And that bound is per un-settled pass — for the surfaces that still allow more than
+one.** Round five bounded live REAP passes to one (the latch is held until the work
+settles; `LATCH_CEILING_MS` is the 60-minute backstop, not a per-expiry release), so
+the reaper's background path is now genuinely capped. `snapshot()` on both classes,
+and the sentinel's `scan()`, are still single-clock: their in-flight markers release
+at the caller ceiling, so under a persistent wedge each expiry can leave another
+abandoned pass alive — `live children ≈ (W + 1) × k`, with `k` unbounded there.
+
+So the honest statement is now per-surface rather than global, and an earlier version
+of this paragraph said "passes are unbounded" flatly after round five had already
+bounded one of them. Applying the latch fix to the remaining surfaces is the obvious
+next step and is NOT done here — named rather than implied.
+<!-- tracked: topic 37155 -->
 
 **These subprocesses ride no host-wide cap.** The spec cites the 2026-06-20
 fork-bomb and the host-wide spawn cap as the reason `mapBounded` exists, which
@@ -411,14 +445,22 @@ table below, because the two contradicting each other is how the false claim sur
   untouched. Widening the signals to awaitable left it reading them synchronously,
   which made the in-use check refuse every delete and the negated checks vacuous.
   See the table entry for the full account.
-- In **three** places this work **restores** a fail-closed property the shipped code
-  did not actually have: the process scan's failure direction; the output bound; and
-  the lock/marker existence gates, whose documented fail-closed catch was
-  unreachable. (An earlier version said "two" while describing the third elsewhere
-  in this same document.)
+- In **two** places this work restores a fail-closed property the SHIPPED code did
+  not have: the process scan's failure direction, and the lock/marker existence
+  gates whose documented fail-closed catch was unreachable.
+
+  The count has now been wrong in both directions, which is worth recording rather
+  than quietly settling on the right number. It first said "two" while describing a
+  third case elsewhere; round four "corrected" it to three; round five showed the
+  third element was never a shipped defect at all — the output bound was dropped by
+  this branch's own earlier draft and then restored, so it is a self-inflicted
+  regression repaired, not a latent hazard found. A correction can be more precise
+  and less true, and this one advertised its own precision in a parenthetical.
 - Round three adds a wall-clock ceiling, which introduces a new outcome that did
-  not exist before: an abandoned pass. `reap` degrades to an empty pass (does
-  nothing — safe); `snapshot` REJECTS rather than reporting an empty list, because
+  not exist before: an abandoned pass. `reap` degrades to an empty REPORT
+  (the abandoned pass is not cancelled and may still complete its own deletions —
+  what it can no longer do is be joined by a second pass); `snapshot` REJECTS rather
+  than reporting an empty list, because
   an empty list on the surface that reports what the deleter sees would assert
   "nothing reclaimable".
 
@@ -565,10 +607,13 @@ reverting anything.
 **A full back-out is NOT just reverting the source files, and three earlier
 descriptions of it disagreed with each other in three different ways.** It is:
 
-1. The touched source files: the two monitoring modules, the git funnel, types, the
-   construction site, the update migration and the route.
-2. **The new lint, removed from BOTH places** — the chain in `package.json` AND its
-   entry in the `REQUIRED_LINTS` ratchet. Removing it from only the chain leaves the
+1. The touched source files: FOUR under `src/monitoring/` (the reaper, the sentinel,
+   and both git-signal modules), the git funnel, types, the construction site, the
+   update migration and the route. ("The two monitoring modules" undercounted.)
+2. **The new lint, removed from FOUR places** — the `lint` chain in `package.json`,
+   the two `lint:no-unawaited-awaitable*` scripts beside it, AND its entry in the
+   `REQUIRED_LINTS` ratchet. ("BOTH places" was itself wrong: a back-out following it
+   leaves two npm scripts invoking a deleted file.) Removing it from only the chain leaves the
    ratchet asserting a lint that no longer runs, so the documented back-out would
    leave the test suite RED. Also delete the script and its allowlist entry in the
    destructive-op lint.
@@ -580,6 +625,11 @@ descriptions of it disagreed with each other in three different ways.** It is:
    every agent on update; a source revert cannot un-write it. So "nothing is stored"
    was false — deployed agents would retain documentation for a config key that no
    longer exists.
+
+5. **The unrelated test fixes STAY.** The gemini auth-skip helper and the expiring
+   throughput fixture were repaired under the Zero-Failure Standard and have nothing
+   to do with this change; reverting them re-reds the suite for reasons the back-out
+   is not trying to undo.
 
 No config DEFAULT changes and there is no data to repair; the runtime change is
 confined to execution strategy.
@@ -608,8 +658,12 @@ in a Tier-3 delete-path change is a review cost whether or not it is benign:
 
 ## Decision points touched
 
-This change touches decision points **only in how they execute**, never in what they
-decide. Each is classified below.
+This change touches most decision points only in how they EXECUTE — but not all, and
+an earlier version of this sentence said "never in what they decide" while the table
+directly below it contains a row stating the opposite. See the Signal-vs-authority
+section for the full account: the reclaim race guard's behaviour changed, two gates
+gained a fail-closed property the shipped code lacked, and the abandoned-pass
+disposition is an outcome that did not previously exist. Each is classified below.
 
 | Decision point | Classification | Justification |
 | --- | --- | --- |
@@ -658,6 +712,33 @@ Every decision this build required is settled here; none is parked on the user.
    have detected the remainder, and "the read path does not block" would have been
    *nearly* true. Both are converted.
 7. **Tier 3 declared** above the gate's signalled floor of 2.
+
+### Decisions taken after round three (this list was stale until round five)
+
+The seven items above were the round-three set, under a heading claiming the list is
+complete. Four rounds have since taken decisions that belong in it:
+
+8. **Two clocks for a pass, not one** (round five). The caller is freed at
+   `PASS_DEADLINE_MS`; the latch is held until the work SETTLES, with
+   `LATCH_CEILING_MS` (60 min) as a last-resort backstop. Chosen over the
+   single-clock version, which let a second pass start while an abandoned one was
+   still deleting.
+9. **Record, don't swallow, and don't crash** (round four). The reaper carries a
+   constructor-level `error` listener writing to a bounded ring surfaced on the read
+   route. Chosen over a silent default listener (which trades a crash for an
+   invisible failure) and over leaving it (which killed the process).
+10. **Honest flags where rejecting is impossible; reject where an empty answer would
+    lie.** An abandoned SNAPSHOT rejects; an abandoned REAP reports empty; an
+    ENUMERATION failure sets `enumerationFailed` on both read surfaces rather than
+    rendering a fabricated zero.
+11. **The failure audit carries the underlying tool's own reason** (a bounded stderr
+    slice), not just an exit code — on a path whose result gates a delete.
+12. **The sentinel inherits `agentWorktreeReaper.snapshotConcurrency`** unless it
+    declares its own, so the documented rollback lever covers both routes.
+13. **No route-timeout override, and no threaded cancellation.** Both are real
+    decisions with consequences named elsewhere in this spec (an operator meets a
+    408 before the pass ceiling; an abandoned pass completes its own work). Recorded
+    here so the completeness claim above is true rather than aspirational.
 
 ## Open questions
 

--- a/docs/specs/worktree-read-path-eventloop-safety.md
+++ b/docs/specs/worktree-read-path-eventloop-safety.md
@@ -107,19 +107,39 @@ request's ten seconds. Necessary at best, nowhere near sufficient.
 
 Four parts, each load-bearing:
 
-1. **`defaultReadGitAsync`** — a non-blocking read built on
-   `SafeGitExecutor.readStream`, which **already** applies the identical verb
-   classification, destructive-shape refusal, SourceTreeGuard checks, environment
-   scrubbing and audit-trail emission as `readSync`. **No new privilege and no new
-   bypass is added to the git funnel**; only the moment the calling thread is
-   released changes. Precedent: `src/core/cartographerDetect.ts` consumes the same
-   primitive for the same reason (fix instar#1069).
+1. **`SafeGitExecutor.readAsync`** — a non-blocking whole-output read, added to
+   the git funnel as the async twin of `readSync`. It applies the identical verb
+   classification, destructive-shape refusal, SourceTreeGuard checks and
+   environment scrubbing, via a preamble now **shared by all three read entry
+   points** rather than hand-copied into each. **No new privilege and no new
+   bypass**; only the moment the calling thread is released changes.
+
+   **This replaced an earlier design that consumed `readStream` with caller-side
+   accumulation, and the correction matters.** Round two found that `readStream`
+   hands back a live child and returns, so the funnel emits its `allowed` row at
+   SPAWN time and never learns how the read ENDED. A failed read — the kind that
+   gates an irreversible delete — was recorded as `allowed` with **no failure
+   row**, while `readSync` records `denied: subprocess-error`. An earlier version
+   of this spec claimed the two paths audit identically. That claim was false, and
+   it was false on the delete path, in the same branch that filed a finding titled
+   "an armed deleter has run with no record of what it deleted". Moving
+   accumulation inside the funnel is what makes the parity real.
+
+   **Emission contract, stated exactly rather than claimed as identity.** A
+   refusal or guard failure emits the same single `denied` row as `readSync` and
+   throws before any spawn. A completed read emits exactly ONE terminal row:
+   `allowed` on a clean exit, `denied: subprocess-error: …` on every failure
+   shape. No spawn-time row is emitted, so a caller sees one row per read — the
+   same shape as `readSync`, though the reason strings name `readAsync`.
 
    It resolves **only on a clean exit**. Partial stdout is discarded on every
-   failure shape — non-zero exit, spawn error, or the executor's own SIGKILL
-   timeout — so a truncated read can never be mistaken for a successful one. Every
-   caller treats a rejection as "cannot determine", which routes to KEEP. The
-   deletion-safe direction is preserved bit for bit.
+   failure shape — non-zero exit, spawn error, oversized output, torn-down pipe,
+   or either timeout — so a truncated read can never be mistaken for a successful
+   one. Every caller treats a rejection as "cannot determine", which routes to
+   KEEP. The deletion-safe direction is preserved bit for bit.
+
+   `readStream` is unchanged and remains the right primitive for a genuinely
+   incremental consumer (`src/core/cartographerDetect.ts`, fix instar#1069).
 
 2. **Bounded fan-out (`mapBounded`, `snapshotConcurrency`, default 4).** Freeing
    the loop without bounding the work would replace one freeze with a burst of
@@ -198,6 +218,50 @@ The sentinel's single-flight was added specifically in response to this finding;
 first draft gave it bounded fan-out but not in-flight sharing, so parity was real for
 the expensive part and incomplete for the stampede part.
 
+### Wall-clock bounds — why every await on this path has a ceiling
+
+Round two found a hole underneath the single-flight design. Every marker that says
+"a pass is already running" — the two memo in-flight slots, the base-ref slot,
+`pendingSnapshot`, and the reaper's own `running` flag — is cleared in a `finally`
+block. **A `finally` never runs on a promise that never settles.** So one
+non-settling read would not merely be slow: it would pin those markers for the life
+of the process, and every later caller would join a promise that never resolves.
+The background reaper would stop running passes altogether — a guard that looks
+healthy and simply never finds anything, which is the exact failure shape the reaper
+exists to prevent.
+
+A subprocess timeout is **not** sufficient to rule this out. It kills the child, but
+`close` fires only once every stdio pipe is closed, so a git that spawned a helper
+holding stdout can leave the promise pending after the kill. (Verified: reproducible
+under plain node.)
+
+Three ceilings, at the three layers where the hazard is reachable:
+
+- **`readAsync`** enforces the child's `timeout` AND an independent timer on the
+  promise (`timeout + 5s`). The child-level kill stays the preferred exit — it
+  produces the precise exit-code message — and the timer only fires when that
+  mechanism failed to settle at all.
+- **Each single-flight memo** wraps its callee in a 60s ceiling. This is not
+  redundant with the above: `cwdRoots`, `mergedPrMap` and the base-ref reader are all
+  **injectable**, so the bound inside the read primitive does not cover a wiring
+  that supplies its own.
+- **Each pass** (`reap`, `snapshot`) carries a 10-minute ceiling, for the same
+  reason one layer up: every `deps.*` signal is injected.
+
+**A deliberate asymmetry between the two pass surfaces.** An abandoned `reap`
+returns an EMPTY result; an abandoned `snapshot` REJECTS (the route renders it as a
+500). They differ because an empty result means different things: an empty pass
+simply does nothing, the safe direction, whereas an empty snapshot would ASSERT
+"nothing reclaimable" on the read surface that reports what the deleter sees — a
+fabricated answer, the same class as the NaN-concurrency hole this branch already
+closed.
+
+**Honest limit.** An abandoned pass cannot be cancelled, so it may still be alive
+and could overlap the next one. That is accepted: every delete re-validates against
+live state immediately before acting, so an overlap can only produce FEWER reaps,
+whereas staying wedged forever produces a reaper that never runs again.
+<!-- tracked: topic 37155 -->
+
 ### Request cancellation — deliberate, not overlooked
 
 An abandoned HTTP client does **not** cancel an in-flight pass. This is a conscious
@@ -235,15 +299,35 @@ problem, and conflating them would have widened this change substantially.
 
 ## Signal vs authority
 
-This change holds **no** decision authority. It does not alter a single verdict:
-the gates, their order, their fail-closed directions and the reclaim race guard are
-untouched. It changes *when the calling thread is released* and *how many reads run
-at once*. The two CONTROL tests exist to pin exactly that — verdicts before and
-after are identical.
+This change holds **no** decision authority: it adds no gate, removes none, and
+reorders none. What it changes is *when the calling thread is released* and *how
+many reads run at once*.
 
-The one behavioural surface is the route contract: both handlers are now async and
-carry a last-resort `catch` so a rejected promise becomes a 500 rather than an
-unhandled rejection that could take the server down.
+**But "it does not alter a single verdict" is NOT true, and an earlier version of
+this section said it was.** Correcting it here rather than only in the decision-point
+table below, because the two contradicting each other is how the false claim survived:
+
+- The **reclaim race guard** — the TOCTOU re-check immediately before an
+  irreversible delete — was changed by this work and was wrongly listed as
+  untouched. Widening the signals to awaitable left it reading them synchronously,
+  which made the in-use check refuse every delete and the negated checks vacuous.
+  See the table entry for the full account.
+- In two places this work **restores** a fail-closed property the shipped code did
+  not actually have (the process scan's failure direction; the output bound).
+- Round three adds a wall-clock ceiling, which introduces a new outcome that did
+  not exist before: an abandoned pass. `reap` degrades to an empty pass (does
+  nothing — safe); `snapshot` REJECTS rather than reporting an empty list, because
+  an empty list on the surface that reports what the deleter sees would assert
+  "nothing reclaimable".
+
+That reads worse than the original claim and it is the accurate version. The two
+CONTROL tests pin what genuinely did not change: the gate ORDER and their verdicts
+on unambiguous inputs.
+
+Route contract: both handlers are async and carry a last-resort `catch`, so a
+rejected promise becomes a 500 rather than an unhandled rejection that could take
+the server down. With the ceiling, that 500 is now reachable in a new way — a
+wedged pass — and it is the honest surface for "I could not answer".
 
 ## Test plan
 
@@ -255,6 +339,25 @@ replaces, multi-line porcelain intact, **rejects** on non-zero exit, **rejects
 rather than resolving empty** on an invalid path (resolving `''` would read as
 clean/merged and could authorise a delete). Plus `mapBounded`: order preservation,
 concurrency never exceeded, empty input, limit clamping.
+
+**Tier 1 — unit** (`tests/unit/SafeGitExecutor.test.ts`, `readAsync` block): the
+funnel's own contract — clean read, refusal audited identically to `readSync`
+before any spawn, **a failed read audited as `denied: subprocess-error`** (the row
+`readStream` structurally could not emit), and an oversized read rejecting rather
+than truncating.
+
+**Tier 1 — unit** (`tests/unit/agent-worktree-git-wiring-nonblocking.test.ts`):
+production wiring makes **zero** blocking reads, for BOTH routes, with no reader
+injected — the construction production actually uses.
+
+**Tier 1 — unit** (`tests/unit/agent-worktree-reaper.test.ts`, wall-clock block):
+the pass and in-flight markers self-clear when an injected signal never settles,
+and the abandoned pass emits an error rather than failing silently.
+
+**Tier 1 — unit** (`tests/unit/lint-no-unawaited-awaitable-test.test.ts`): the lint
+that pins the un-awaited-`Awaitable` class fires on both halves of the historical
+defect, stays clean on every awaited form and on the optional-dep false positive,
+and honours its escape hatch.
 
 **Tier 2 — integration** (`tests/integration/agent-worktree-reaper-eventloop.test.ts`):
 sampled event-loop drift across a real fan-out over 12 real worktrees, wired
@@ -280,11 +383,69 @@ Every test was run against **unfixed** source first.
 - Tests that pass either way are labelled **CONTROL** in the file, with a comment
   stating they pin the classification contract and are **not** evidence the hazard
   is gone. They are not counted as proof.
+- **Round three, each fix reverted and re-run.** The audit-parity fix: reverted,
+  its test fails. The pass and in-flight ceilings: reverted, all three of their
+  tests time out instead of passing, while the CONTROL still passes. The lint:
+  the historical defect reintroduced verbatim into `AgentWorktreeReaper`, and it
+  fires on both lines.
+- **One round-three test did NOT discriminate and was removed rather than kept.**
+  The first attempt to prove the `readAsync` wall-clock bound used a fake git whose
+  grandchild holds stdout open. That reproduces the non-settling wedge under plain
+  node but NOT under the test runner, where `close` still fires — so it passed with
+  the deadline reverted and was evidence of nothing. Worse, its assertion accepted
+  two different rejection reasons, which is what let it look green. It is replaced
+  by an explicitly-labelled CONTROL, and the discriminating coverage lives where the
+  hazard is reachable and deterministic: injected never-settling signals at the memo
+  and pass layers. Recorded because "I verified it discriminates" was claimed for
+  this fix before it was true.
+
+### A fourth round-two finding, closed in round three: the unreachable fail-closed catch
+
+Three gates — the two lock checks and the build-marker check — wrapped
+`fs.existsSync` in a `try/catch` documented as fail-closed. **That catch is
+unreachable.** `existsSync` swallows every error internally and returns `false`, so
+a lock file that EXISTS but cannot be read (EACCES, IO error) was reported as
+ABSENT — "no in-flight work here" — which CLEARS a delete gate. The fail-closed
+comment described a branch that could never run.
+
+This is the same defect class as the false exemption comment that started this whole
+change: a safety property asserted in prose that the code does not implement. Two
+instances of that class in one file is the reason the spec now treats a prose safety
+claim as a defect until a test pins it.
+
+Replaced by `existsFailClosed`, built on `statSync`, which throws and therefore
+allows the distinction: `ENOENT` is a genuine absence; anything else is "cannot
+tell" and answers PRESENT — the KEEP direction for every caller. Pinned by two tests
+that fail against `existsSync` and two CONTROLs that pin that fail-closed did not
+become always-closed (which would disable the reaper rather than protect it).
+<!-- tracked: topic 37155 -->
+
+### Defect classes now pinned by a lint — and the one that is not
+
+Two classes recurred on this branch after being named in writing, which is the
+argument that naming a failure mode does not protect you from it; only a check does.
+
+- **An `Awaitable<T>` signal tested as a boolean without `await`** — now pinned by
+  `scripts/lint-no-unawaited-awaitable-test.js`, wired into `npm run lint`. The
+  type system cannot catch it (a promise in a boolean test is legal TypeScript) and
+  no existing test could (every fake was synchronous, so the async shape production
+  uses never appeared). Verified against the historical defect reintroduced verbatim.
+  Deliberately narrow — same-file declarations, direct call syntax — because a lint
+  that is mostly false positives gets disabled, which protects nothing.
+- **A shared signal widened without auditing its other consumers** — NOT pinned, and
+  I do not have a lint for it. This is the polarity regression: a third state was
+  added to a signal read by two consumers with OPPOSITE polarity, and only one was
+  updated. A lint would have to know which consumers exist and what each one's safe
+  direction is, which is semantic rather than syntactic. It is recorded in
+  `docs/findings/2026-07-30-shared-signal-opposite-polarity.md` and remains a
+  convention, not a guarantee. Stated plainly rather than implied closed.
 
 ## Rollback
 
 `snapshotConcurrency: 1` makes the fan-out fully serial (slowest, gentlest) without
-reverting anything. A full back-out is a revert of the five source files; no
+reverting anything. A full back-out is a revert of the touched source files (the two
+monitoring modules, the git funnel, types, the construction site, the update
+migration and the route); no
 migration, no persisted state, no config default change, and no data to repair —
 the change is confined to execution strategy.
 
@@ -316,9 +477,16 @@ Every decision this build required is settled here; none is parked on the user.
    in-flight sharing. Chosen over a cache (cannot fix the first request, and breaks
    the parent spec's freshness rule) and over a concurrency bound alone (does
    nothing about a single request's ten seconds).
-2. **No new funnel primitive.** Build on the existing `readStream` rather than
-   adding an async read to `SafeGitExecutor`, because it already carries identical
-   guard and audit semantics.
+2. **A new funnel primitive after all — `SafeGitExecutor.readAsync`.** REVERSED in
+   round three, and the reversal is the honest record rather than a tidy one. The
+   original decision was to build on `readStream` and add nothing to the funnel,
+   "because it already carries identical guard and audit semantics". The guard half
+   was true; the AUDIT half was not. `readStream` returns a live child, so the
+   funnel emits `allowed` at spawn and never learns the outcome — a failed read
+   gating a delete was audited as allowed with no failure row. Rather than restate
+   the spec's parity claim as a caveat, the accumulation moved INTO the funnel so
+   the parity is real. The classification, guard and env-scrubbing preamble is now
+   shared by all three read entry points, so they cannot drift apart.
 3. **One classification path**, via `Awaitable<T>`, rather than a second async-only
    route path — so delete-authorising classification cannot drift from displayed
    classification.

--- a/docs/specs/worktree-read-path-eventloop-safety.md
+++ b/docs/specs/worktree-read-path-eventloop-safety.md
@@ -1,0 +1,382 @@
+---
+title: "Worktree read-path event-loop safety — a status route must not freeze the server"
+slug: "worktree-read-path-eventloop-safety"
+author: "echo"
+parent-principle: "Structure beats Willpower"
+status: "draft"
+tier: 3
+origin: "2026-07-29 topic 37155 — blocking finding on the guard-enumeration spec (PR #1748), raised in five separate convergence rounds across two failed 10-round attempts"
+relates:
+  - "docs/specs/agent-worktree-reaper.md"
+  - "docs/specs/ORPHANED-WORK-SENTINEL-SPEC.md"
+  - "docs/specs/CARTOGRAPHER-SWEEP-EVENTLOOP-SAFETY.md"
+  - "docs/specs/tmux-event-loop-resilience.md"
+  - "docs/postmortems/2026-06-07-server-temporarily-down.md"
+---
+
+# Worktree read-path event-loop safety
+
+## Problem
+
+`GET /worktrees/agent-reaper` was a non-async Express handler calling
+`AgentWorktreeReaper.snapshot()` directly. `snapshot()` fans `evaluate()` out over
+every worktree, and each gate shells out **synchronously** through
+`SafeGitExecutor.readSync` (`execFileSync`). A synchronous spawn cannot be
+preempted, so the whole Node event loop — every route, every timer, the serving
+lease heartbeat, the mesh rope probes — stalls for the full duration of the
+fan-out. `GET /orphaned-work` had the identical shape.
+
+### Measured, not theorised
+
+On a live agent (Laptop, 2026-07-29, 48 registered worktrees):
+
+| Probe | Latency |
+| --- | --- |
+| `GET /health`, loop idle | ~17 ms |
+| `GET /health`, during one `GET /worktrees/agent-reaper` | **10.6 s** |
+| `GET /worktrees/agent-reaper` itself | 10.9 s |
+| `GET /health`, during one `GET /orphaned-work` | **3.7 s** |
+
+One request, ~620× degradation, no hang and nothing pathological required.
+
+### Why the measured number is a floor, not a ceiling
+
+1. **Gates short-circuit cheapest-first.** 34 of the 48 worktrees stopped at the
+   dirty check and never paid for the expensive `git cherry` comparison. A tidier
+   agent whose worktrees are mostly clean pays the full price on all of them.
+2. **The default branch was re-resolved per worktree, un-memoized.**
+   `isMerged` called `resolveBaseRef()` for *every* worktree; that walks up to four
+   candidate ref names probing each two ways. On an agent whose first candidate
+   remote exists it is one extra spawn per worktree; on a fleet agent lacking it,
+   five before one succeeds. So per-worktree cost is nearer **seven** spawns than
+   the "up to three" the parent spec assumed.
+3. **Two non-git commands sat on the same blocking path.** `isMerged` may consult
+   `gh pr list` (30 s bound, a *network round trip*) to catch multi-commit
+   squash-merges, and `isInUse` shells out to a full-system `lsof` (15 s bound).
+   Both are memoized (60 s / 10 s), so each costs one call per request rather than
+   one per worktree — but a **cold cache still froze the loop**, and on a busy host
+   the process scan is the single most expensive call on the path. Both are
+   converted here (see Design); leaving them would have meant the hazard was
+   *reduced*, not removed.
+
+### Why the existing exemption did not cover it
+
+`agentWorktreeGit.ts` carries a `lint-allow-blocking-scan` comment justifying the
+blocking scan on the grounds that the reaper "ships dark + dry-run + reviewed (off
+by default), so this is not on any live agent's hot path."
+
+That reasoning only ever covered the **background timer**. The reaper is
+constructed *unconditionally* and passed into the server context regardless of the
+enabled flag, so the **read route runs the full pass whether or not reaping is
+armed**. Independently corroborated across two machines via
+`GET /guards?scope=pool`: the same manifest key classifies as `on-dry-run` on one
+machine and `on-unverified` on the other, and the live snapshot on the Laptop
+returned `enabled: true, dryRun: false`.
+
+So the exemption is not merely stale — it is a **documented safety claim that
+nobody re-checked after the config diverged**, being relied upon on an agent where
+the guard is armed. That is what puts this hazard in scope rather than tracked.
+
+### Why this could not be left as prose
+
+The shipped mitigation was documentation telling readers to poll `/guards`
+instead. A reviewer correctly called that a violation of *Structure beats
+Willpower*: a written instruction is not a guardrail. The parent spec also makes
+this route **more authoritative**, so adoption pressure rises while the hazard
+stays.
+
+## Design
+
+### Rejected: a cache on the existing route
+
+Explicitly rejected, for two independent reasons:
+
+1. It contradicts the parent spec's own freshness rule. `/guards` is deliberately
+   pass-based and lags; this route answers "what do you see **right now**". Making
+   its answer depend on who polled it last recreates a defect that took ten
+   convergence rounds to remove.
+2. **A cache cannot fix the first request** — and the first request is the one
+   that froze the loop.
+
+### Rejected: a route-level concurrency bound alone
+
+It prevents concurrent hits from stacking, but does nothing about a single
+request's ten seconds. Necessary at best, nowhere near sufficient.
+
+### Adopted: non-blocking end to end, bounded, single-flighted
+
+Four parts, each load-bearing:
+
+1. **`defaultReadGitAsync`** — a non-blocking read built on
+   `SafeGitExecutor.readStream`, which **already** applies the identical verb
+   classification, destructive-shape refusal, SourceTreeGuard checks, environment
+   scrubbing and audit-trail emission as `readSync`. **No new privilege and no new
+   bypass is added to the git funnel**; only the moment the calling thread is
+   released changes. Precedent: `src/core/cartographerDetect.ts` consumes the same
+   primitive for the same reason (fix instar#1069).
+
+   It resolves **only on a clean exit**. Partial stdout is discarded on every
+   failure shape — non-zero exit, spawn error, or the executor's own SIGKILL
+   timeout — so a truncated read can never be mistaken for a successful one. Every
+   caller treats a rejection as "cannot determine", which routes to KEEP. The
+   deletion-safe direction is preserved bit for bit.
+
+2. **Bounded fan-out (`mapBounded`, `snapshotConcurrency`, default 4).** Freeing
+   the loop without bounding the work would replace one freeze with a burst of
+   ~150 concurrent git subprocesses on a 48-worktree agent — a different hazard, in
+   the direction of the 2026-06-20 fork-bomb. The bound keeps both civil.
+
+3. **Base ref resolved once per pass**, memoized — removing defect (2) above.
+
+4. **Single-flight**, not a cache. Precisely: **no settled result is ever reused —
+   a caller may join an already-running pass.** Nothing is retained after a pass
+   settles, so the next request always starts fresh work. The honest consequence,
+   which the cross-model reviewer was right to make explicit: a caller who joins an
+   in-flight pass receives results from work that began marginally before its own
+   request. That is bounded by one pass duration and is categorically different from
+   a cache, which would serve a *completed* result to a later request. The parent
+   spec's freshness rule — never serve an answer whose age depends on who polled
+   last — holds.
+
+5. **The two non-git commands are non-blocking too.** `gh pr list` and the
+   full-system `lsof` now run through an async runner with the same
+   clean-exit-or-reject contract, and each memo gained its own **single-flight**
+   latch — without which a bounded fan-out of N evaluations racing a cold cache
+   would each launch its own full-system scan (the async form of the stampede the
+   memo exists to prevent).
+
+   The `lint-allow-blocking-scan` exemption was **removed along with its
+   justification**, not merely annotated. Keeping an exemption whose stated reason
+   is false is how the original defect survived review, so the fix is to stop
+   blocking rather than to re-word the permission. This removes ONE INSTANCE of the hazard class named in root cause #4 of
+   `docs/postmortems/2026-06-07-server-temporarily-down.md`. It does NOT close that
+   root cause: its two named follow-ups (OrphanProcessReaper, mcpProcessReaper) still
+   use blocking process scans and are untouched here. An earlier draft claimed the
+   closure outright, which was wrong. <!-- tracked: topic 37155 -->
+
+   The `withSyncOp` in-flight marker around the `gh` call was removed with it. That
+   marker existed so a *blocking* spawn would not read as a stuck event loop to the
+   watchdogs — i.e. it made this freeze **invisible to the watchdog rather than
+   absent**. An async spawn never stalls the loop, so there is nothing left to mask;
+   removing the mask together with its cause is deliberate.
+
+### One classification path, deliberately
+
+Signals are typed `Awaitable<T>` and `evaluate()` awaits each. The reap timer and
+the read route therefore share **one** classifier. A second async-only path would
+be the obvious smaller change and is rejected: the classification that authorises
+an irreversible `git worktree remove` must not be able to drift from the one the
+observability route displays. Awaiting a non-promise is a no-op, so injected sync
+fakes behave exactly as before.
+
+### Injection contract preserved
+
+Callers supplying only the blocking `readGit` (every existing unit test) must still
+control what the async path reads. The deps factory **derives** the async reader
+from an injected sync one rather than ignoring it. Without this, those tests
+silently assert against real git instead of their fixture — a caught near-miss,
+recorded here because it is the exact shape of a test that looks green and proves
+nothing.
+
+### Both routes, explicitly
+
+The reviewer correctly noted the design read as if it covered only the reaper. It
+covers both, and the two are held at parity deliberately — they had the identical
+blocking shape, so they get the identical protections:
+
+| Property | `/worktrees/agent-reaper` | `/orphaned-work` |
+| --- | --- | --- |
+| async handler + last-resort 500 | yes | yes |
+| non-blocking git reads | yes (shared deps) | yes (shared deps — it builds on the reaper's) |
+| non-blocking `lsof` / `gh` | yes | yes (same shared deps) |
+| bounded fan-out | yes (`snapshotConcurrency`) | yes (bounded, not `Promise.all`) |
+| base ref memoized per pass | yes | inherited (same deps instance) |
+| single-flight in-flight sharing | yes | yes |
+| tests | unit + integration + e2e | unit + integration + e2e |
+
+The sentinel's single-flight was added specifically in response to this finding; the
+first draft gave it bounded fan-out but not in-flight sharing, so parity was real for
+the expensive part and incomplete for the stampede part.
+
+### Request cancellation — deliberate, not overlooked
+
+An abandoned HTTP client does **not** cancel an in-flight pass. This is a conscious
+choice: no `AbortSignal` is threaded through the fan-out. The reasoning is that
+single-flight already bounds the damage — repeated aborts by the same or several
+clients coalesce onto **one** running pass rather than accumulating passes, so the
+abandoned-client cost is capped at one pass in flight, not N. Threading cancellation
+through the reads, the process scan and the network call would add a failure surface
+(partial reads, half-cancelled subprocesses) to a path whose whole purpose is
+delete-safety, for a bounded gain. Named as a decision rather than left silent.
+<!-- tracked: topic 37155 -->
+
+### What is still bounded only by memoization
+
+Honest residue, stated rather than implied: total work is still unbounded in the
+number of worktrees. `snapshotConcurrency` bounds *concurrency*, not the total, so an
+agent with 500 worktrees performs ~1500 reads per request — politely, without
+starving the loop, but the response gets slower with scale. No per-request ceiling
+or pagination is introduced. This is a latency property, not an event-loop property —
+but at large worktree counts latency becomes availability pressure (long-held request
+slots, subprocess churn), so the alternatives are named rather than ignored:
+
+- **Pagination / a max-worktrees-per-request cap** — rejected here because a partial
+  answer to "which worktrees can be reclaimed, and why is each kept?" invites exactly
+  the misreading the parent spec fought: a truncated list read as a complete one.
+- **Streaming the response** — plausible, and a larger change to the route contract
+  than a safety fix should carry.
+- **A background pass with a generation id served on read** — this is the cache the
+  parent spec's freshness rule forbids, wearing a different name.
+
+All three are deferred as separate work, not dismissed. The measured problem was a
+frozen event loop; that is fixed. Scale-shaped latency is a real but different
+problem, and conflating them would have widened this change substantially.
+<!-- tracked: topic 37155 -->
+
+## Signal vs authority
+
+This change holds **no** decision authority. It does not alter a single verdict:
+the gates, their order, their fail-closed directions and the reclaim race guard are
+untouched. It changes *when the calling thread is released* and *how many reads run
+at once*. The two CONTROL tests exist to pin exactly that — verdicts before and
+after are identical.
+
+The one behavioural surface is the route contract: both handlers are now async and
+carry a last-resort `catch` so a rejected promise becomes a 500 rather than an
+unhandled rejection that could take the server down.
+
+## Test plan
+
+Three tiers, per the Testing Integrity Standard.
+
+**Tier 1 — unit** (`tests/unit/agent-worktree-git-async-read.test.ts`): the async
+read against real git — clean read, byte-identical to the blocking read it
+replaces, multi-line porcelain intact, **rejects** on non-zero exit, **rejects
+rather than resolving empty** on an invalid path (resolving `''` would read as
+clean/merged and could authorise a delete). Plus `mapBounded`: order preservation,
+concurrency never exceeded, empty input, limit clamping.
+
+**Tier 2 — integration** (`tests/integration/agent-worktree-reaper-eventloop.test.ts`):
+sampled event-loop drift across a real fan-out over 12 real worktrees, wired
+through the **production deps factory**. Budget 250 ms.
+
+**Tier 3 — e2e**: the existing reaper and orphaned-work lifecycle suites, which
+drive the production initialisation path.
+
+### Discrimination discipline
+
+Every test was run against **unfixed** source first.
+
+- The event-loop test **passed against unfixed source on its first run** — and was
+  therefore worthless. Cause: `await` on a *synchronous* body resolves through the
+  microtask queue, which runs before timers, so `clearInterval` fired before the
+  sampler could observe the stall; a genuine multi-second freeze measured as ~0 ms.
+  The cartographer precedent does not hit this because the work it measures is
+  already async and its sampler runs *during* the work. One missing macrotask yield
+  made the measurement structurally blind.
+- Corrected, it fails against unfixed source at **758 ms against a 250 ms budget**
+  (12 worktrees, with `lsof` and the network call excluded for determinism — so
+  even that is an under-estimate), and passes after.
+- Tests that pass either way are labelled **CONTROL** in the file, with a comment
+  stating they pin the classification contract and are **not** evidence the hazard
+  is gone. They are not counted as proof.
+
+## Rollback
+
+`snapshotConcurrency: 1` makes the fan-out fully serial (slowest, gentlest) without
+reverting anything. A full back-out is a revert of the five source files; no
+migration, no persisted state, no config default change, and no data to repair —
+the change is confined to execution strategy.
+
+## Decision points touched
+
+This change touches decision points **only in how they execute**, never in what they
+decide. Each is classified below.
+
+| Decision point | Classification | Justification |
+| --- | --- | --- |
+| `evaluate()` reap-eligibility gates (`isInUse` → branch → `isClean` → `isMerged`) | **invariant** | Deterministic by design and must stay so: this gate authorises an irreversible `git worktree remove`. Every gate fails CLOSED to KEEP, and "any ambiguity → KEEP" is the parent spec's hard requirement. NOTE: this was NOT true of `isInUse` before this change — a failed process scan returned an empty set, indistinguishable from "nothing is using it", which CLEARED a delete gate. It now returns an explicit `unknown` and `isInUse` answers KEEP. The universal claim is true as of this change, and was not before it. No competing signals are weighed: each gate is a monotone conjunction over conservative positive-evidence sources, and any missing or failed source yields KEEP. |
+| Read-failure disposition (a git read rejects → treat as "cannot determine") | **invariant** | Deliberately one-directional: unknown always resolves to KEEP. Making this a judgment call would mean sometimes deleting on an unproven read, which is the one outcome the design forbids. |
+| Fan-out width (`snapshotConcurrency`) | **invariant** | A resource bound, not a behavioural decision — it cannot change any verdict, only how many reads are in flight. Operator-tunable; `1` is the gentlest setting. |
+| `reclaimRaceGuard` — the TOCTOU re-check immediately before an irreversible delete | **invariant** | Same fail-closed rationale as the gates above; it exists because `info.branch` is captured at enumeration and may be stale by reclaim time. **This spec CHANGED its behaviour and an earlier draft wrongly listed it as untouched.** When the signals became awaitable the guard still read them synchronously: an un-awaited Promise is always truthy, so the in-use check refused every delete (an inert reaper) while the negated dirty/unmerged checks became vacuous — meaning a worktree that went dirty between evaluation and reclaim would have been DELETED. It now awaits every signal, and three tests driven by promise-returning fakes (the production shape) pin both directions. |
+| Single-flight sharing (concurrent callers share the in-flight pass) | **invariant** | Deterministic latch on presence of an in-flight pass. No signal is weighed and no verdict is affected — the shared result is the same result each caller would have computed. |
+
+No decision point in this change is a **judgment-candidate**: none of them weighs
+competing or ambiguous signals. This is asserted rather than assumed — the failure
+class judgment-candidates exist for is a static rule arbitrating between signals
+that genuinely conflict, and there is no such arbitration here. If a future change
+introduced one (for example, deciding *staleness* rather than reading objective
+facts) that would need reclassifying.
+
+## Frontloaded Decisions
+
+Every decision this build required is settled here; none is parked on the user.
+
+1. **Shape.** Non-blocking end to end + bounded fan-out + once-per-pass base ref +
+   in-flight sharing. Chosen over a cache (cannot fix the first request, and breaks
+   the parent spec's freshness rule) and over a concurrency bound alone (does
+   nothing about a single request's ten seconds).
+2. **No new funnel primitive.** Build on the existing `readStream` rather than
+   adding an async read to `SafeGitExecutor`, because it already carries identical
+   guard and audit semantics.
+3. **One classification path**, via `Awaitable<T>`, rather than a second async-only
+   route path — so delete-authorising classification cannot drift from displayed
+   classification.
+4. **Injected sync `readGit` derives the async reader** rather than being ignored,
+   preserving the existing test injection contract.
+5. **Default `snapshotConcurrency: 4`**, inline-defaulted so absent config preserves
+   shipped behaviour and no config migration is required.
+6. **No blocking call is left on the read path.** An earlier draft memoized
+   `gh pr list` and `lsof` and deferred their conversion. The
+   Standards-Conformance Gate flagged that as a No-Deferrals violation and was
+   right: the event-loop test excludes both for determinism, so the test could not
+   have detected the remainder, and "the read path does not block" would have been
+   *nearly* true. Both are converted.
+7. **Tier 3 declared** above the gate's signalled floor of 2.
+
+## Open questions
+
+*(none)*
+
+## Multi-machine posture
+
+**Posture: machine-local.**
+
+`machine-local-justification: hardware-bound-resource`
+
+Both routes report on worktree checkouts that physically exist on the serving
+machine's own disk, and the event loop being starved is that machine's own. A
+worktree is a directory on one filesystem; it cannot be read from another machine
+without that machine's filesystem, so the *subject* of these routes is bound to
+specific physical hardware. Nothing replicates, nothing is proxied on read, no
+generated URL crosses a machine boundary, and no durable state is written.
+
+**Why the resource is genuinely hardware-bound, distinct from the view over it.**
+The Standards-Conformance Gate flagged an earlier draft for defending machine-local
+with *scope control* rather than a concrete impossibility. That objection was
+correct about the draft's reasoning, and the corrected argument separates two things
+the draft conflated:
+
+- **The resource is hardware-bound and cannot be unified.** A worktree is a
+  directory on one physical filesystem. Reading it requires that machine; there is no
+  representation of another machine's worktree that this machine could serve. The
+  same is true of both signals the routes depend on — the running-process table and
+  the on-disk locks are properties of one kernel and one disk. This is the
+  `hardware-bound-resource` key in its literal sense, not a convenience label.
+- **A pool-scoped *view* over those local resources is feasible, and is a separate
+  feature.** `GET /guards?scope=pool` demonstrates the pattern: each machine reads
+  its own local state and a fronting machine merges the answers. Such a view would
+  not make any worktree non-local — it aggregates per-machine local reads, and it
+  brings its own obligations (peer fan-out, dark-peer tolerance, staleness tagging).
+
+So `unified` is **infeasible for the resource** and **feasible for a view that does
+not yet exist**. This spec introduces no view and does not change the routes' scope;
+it changes execution strategy only. A reviewer may still argue the routes *should*
+grow a pool-scoped mode — that is a real position, and it is a separate spec rather
+than a silent assumption here. <!-- tracked: topic 37155 -->
+
+The cross-machine relevance runs in the opposite direction and is the point of the
+fix: a frozen loop stalls *this* machine's serving-lease heartbeat and rope probes,
+which is exactly how a purely local blocking read presents as mesh instability.
+Corroborated across both machines via `GET /guards?scope=pool`, which reports
+divergent classifications for the same manifest key.

--- a/docs/specs/worktree-read-path-eventloop-safety.md
+++ b/docs/specs/worktree-read-path-eventloop-safety.md
@@ -146,7 +146,16 @@ Four parts, each load-bearing:
    ~150 concurrent git subprocesses on a 48-worktree agent — a different hazard, in
    the direction of the 2026-06-20 fork-bomb. The bound keeps both civil.
 
-3. **Base ref resolved once per pass**, memoized — removing defect (2) above.
+3. **Base ref resolved once per pass WHEN ONE RESOLVES**, memoized — removing defect
+   (2) above. The qualifier is load-bearing and was missing until round four: a
+   `null` result is deliberately NOT cached (a transient failure would otherwise pin
+   every worktree to "unmerged" for the full TTL), and single-flight only coalesces
+   CONCURRENT callers. So on a repo where none of the candidate names resolves — a
+   default branch called something else, or any non-instar checkout — resolution
+   repeats, bounded below by roughly one per fan-out batch and above by one per
+   worktree: exactly the un-memoized defect this item claims to remove. The claim is
+   true on the repos this ships against and false in general, so it is stated with
+   its condition rather than flatly.
 
 4. **Single-flight**, not a cache. Precisely: **no settled result is ever reused —
    a caller may join an already-running pass.** Nothing is retained after a pass
@@ -210,9 +219,30 @@ blocking shape, so they get the identical protections:
 | non-blocking git reads | yes (shared deps) | yes (shared deps — it builds on the reaper's) |
 | non-blocking `lsof` / `gh` | yes | yes (same shared deps) |
 | bounded fan-out | yes (`snapshotConcurrency`) | yes (bounded, not `Promise.all`) |
-| base ref memoized per pass | yes | inherited (same deps instance) |
+| base ref memoized per pass | yes | **separate deps INSTANCE — see below** |
 | single-flight in-flight sharing | yes | yes |
-| tests | unit + integration + e2e | unit + integration + e2e |
+| **wall-clock pass ceiling** | yes | **yes (added round four — it was MISSING)** |
+| tests | unit + integration + e2e | unit + integration + e2e (the Tier-2 event-loop measurement covers the reaper route only) |
+
+**Two corrections to this table, both found in round four, both of which it was
+built to prevent.**
+
+**It had no wall-clock row.** Round three added the ceilings to the reaper and not
+to the sentinel, and the table — which exists to demonstrate parity — simply had no
+row for the one dimension where parity failed. All five internal reviewers found it
+independently. The sentinel's `pendingSnapshot` and `running` clear in `finally`
+blocks over equally-injectable deps, so the identical wedge applied; and the
+consequence there was WORSE, because `snapshot()` never rejected, so the route's
+last-resort `catch` never fired and the request would hang with no response at all
+while every later caller joined the same dead promise. Fixed, with tests that
+time out when either ceiling is removed.
+
+**"Same deps instance" was false.** `makeOrphanedWorkSentinelDeps` constructs its
+OWN `makeAgentWorktreeReaperDeps`, separate from the server's. They share the
+FACTORY, not the instance — so the memo closures are separate and the full-system
+process scan, which this spec itself calls the most expensive call on the path, can
+run TWICE rather than once when both routes are exercised inside the memo window.
+That error is what made the composed-concurrency number in the next section wrong.
 
 The sentinel's single-flight was added specifically in response to this finding; the
 first draft gave it bounded fan-out but not in-flight sharing, so parity was real for
@@ -256,11 +286,80 @@ simply does nothing, the safe direction, whereas an empty snapshot would ASSERT
 fabricated answer, the same class as the NaN-concurrency hole this branch already
 closed.
 
-**Honest limit.** An abandoned pass cannot be cancelled, so it may still be alive
-and could overlap the next one. That is accepted: every delete re-validates against
-live state immediately before acting, so an overlap can only produce FEWER reaps,
-whereas staying wedged forever produces a reaper that never runs again.
+**Honest limit — restated in round four, because the earlier version was wrong on
+two counts.** It read: "an empty pass simply does nothing, the safe direction …
+an overlap can only produce FEWER reaps."
+
+Neither holds. An abandoned pass is NOT cancelled: it keeps iterating, keeps
+re-validating, and keeps calling `removeWorktree` — irreversible deletes — while
+`reap()` has already returned `{reaped: []}`. So the abandoned pass does not "do
+nothing"; it does work the caller has been told did not happen, which is the same
+fabricated-answer class this section rejects for `snapshot`. And because the
+`finally` releases the single-pass latch, a second pass can start while the first
+is still deleting, so N overlapping passes can delete up to N × `maxReapsPerPass` —
+the aggregate blast-radius bound is weaker than the config key's name promises.
+
+What IS still true, and is the reason the asymmetry stands: every INDIVIDUAL delete
+re-validates against live state immediately before acting, so no overlap can delete
+something that should have been kept. The weakening is to the RATE bound, not to
+correctness. Stated this way rather than the reassuring way, because the reassuring
+way was false.
+
+**Not fixed here, deliberately.** Bounding the number of live passes (rather than
+the work within one) is a change to the reaper's control loop, not to its read path.
+It belongs with the outstanding work to register this component as a self-triggered
+destructive controller, where the per-pass-versus-per-loop distinction is the whole
+point — tracked with that item rather than smuggled in here.
 <!-- tracked: topic 37155 -->
+
+### The pass ceiling is not the cliff an operator meets first
+
+`PASS_DEADLINE_MS` is 10 minutes; the server's request-timeout middleware defaults
+to **30 seconds** and neither of these routes carries an override. So in shipped
+configuration a pass exceeding ~30s returns the client a **408**, not the 500 this
+spec's asymmetry argument describes — the abandoned-snapshot-rejects-with-500 path
+is observable only if that timeout is raised above the ceiling.
+
+Worse, the middleware sends the 408 but does not abort the handler, and no
+cancellation is threaded (a deliberate choice, below), so the pass runs on and pays
+its full subprocess cost for an answer nobody receives.
+
+Arithmetic for the scale this spec itself calls supported-if-slow: at ~200ms per
+worktree and `snapshotConcurrency: 4`, 500 worktrees is ~25s — inside the 30s budget
+with 17% margin, and `git cherry` cost is O(commits ahead), not constant, so a repo
+with long-lived branches crosses it easily. **500 worktrees is already a 408 regime**,
+and the failure mode this spec documents for that regime is the wrong one.
+
+Not fixed here: adding a route-timeout override is a server-config change with
+consequences beyond this path. Named so the next reader is not misled about which
+mechanism they will actually meet.
+<!-- tracked: topic 37155 -->
+
+### The composed concurrency ceiling, stated
+
+A round-two finding asked for this and round three did not deliver it. Four surfaces
+can be in flight at once, not the three originally framed — both read routes, the
+reaper's background timer, AND the sentinel's background timer (which is live on a
+development agent, the exact class where the freeze was measured).
+
+Because the two routes hold SEPARATE deps instances (see the parity-table
+correction), their memo latches do not cross. Peak concurrent child processes is
+therefore `(W + 1)` per instance — at the default `snapshotConcurrency: 4`, **10
+concurrent children**, of which up to **two are simultaneous full-system process
+scans**. At the documented rollback lever (`1`) it is 4; at a hand-set 16 it is 34.
+
+**And that bound is per un-settled pass, not absolute.** Nothing bounds the NUMBER
+of live passes, so under a persistent wedge each ceiling expiry can leave another
+abandoned pass alive: `live children ≈ (W + 1) × k`, with `k` unbounded. The honest
+statement is "10 per un-settled pass, and passes are unbounded" — not "10".
+
+**These subprocesses ride no host-wide cap.** The spec cites the 2026-06-20
+fork-bomb and the host-wide spawn cap as the reason `mapBounded` exists, which
+invites the inference that this path is covered by it. It is not: that semaphore
+funnels LLM spawns (`claude -p` / `codex exec`) only. `snapshotConcurrency` is a
+PER-PROCESS bound, so N co-resident agents multiply it. Borrowing the authority of a
+control this path sits outside is precisely the false-exemption shape this change
+exists to remove, so it is disclosed rather than implied.
 
 ### Request cancellation — deliberate, not overlooked
 
@@ -312,8 +411,11 @@ table below, because the two contradicting each other is how the false claim sur
   untouched. Widening the signals to awaitable left it reading them synchronously,
   which made the in-use check refuse every delete and the negated checks vacuous.
   See the table entry for the full account.
-- In two places this work **restores** a fail-closed property the shipped code did
-  not actually have (the process scan's failure direction; the output bound).
+- In **three** places this work **restores** a fail-closed property the shipped code
+  did not actually have: the process scan's failure direction; the output bound; and
+  the lock/marker existence gates, whose documented fail-closed catch was
+  unreachable. (An earlier version said "two" while describing the third elsewhere
+  in this same document.)
 - Round three adds a wall-clock ceiling, which introduces a new outcome that did
   not exist before: an abandoned pass. `reap` degrades to an empty pass (does
   nothing — safe); `snapshot` REJECTS rather than reporting an empty list, because
@@ -388,16 +490,31 @@ Every test was run against **unfixed** source first.
   tests time out instead of passing, while the CONTROL still passes. The lint:
   the historical defect reintroduced verbatim into `AgentWorktreeReaper`, and it
   fires on both lines.
-- **One round-three test did NOT discriminate and was removed rather than kept.**
-  The first attempt to prove the `readAsync` wall-clock bound used a fake git whose
-  grandchild holds stdout open. That reproduces the non-settling wedge under plain
-  node but NOT under the test runner, where `close` still fires — so it passed with
-  the deadline reverted and was evidence of nothing. Worse, its assertion accepted
-  two different rejection reasons, which is what let it look green. It is replaced
-  by an explicitly-labelled CONTROL, and the discriminating coverage lives where the
-  hazard is reachable and deterministic: injected never-settling signals at the memo
-  and pass layers. Recorded because "I verified it discriminates" was claimed for
-  this fix before it was true.
+- **A round-three test did not discriminate, was deleted, and the stated reason for
+  deleting it was WRONG — corrected in round four.** The first attempt to prove the
+  `readAsync` wall-clock bound used a fake git whose grandchild holds stdout open.
+  It was removed on the recorded grounds that the wedge "does not reproduce under
+  the test runner, where `close` still fires". The adversarial reviewer rebuilt that
+  exact shape and showed it settles at `timeout + grace` — i.e. the deadline firing,
+  proving `close` did NOT fire. The wedge reproduces perfectly well under the runner.
+  The real defect was the deleted test's own LOOSE assertion, which accepted either
+  rejection reason and therefore passed on both branches.
+
+  This matters more than a wrong test. A loose-assertion problem was misdiagnosed as
+  an environment problem, and the misdiagnosis was written into this spec as durable
+  methodology — where it would have told the next person that coverage which is
+  demonstrably writable cannot be written. The test is restored with an assertion
+  naming ONLY the deadline, and the sibling CONTROL's disjunction was tightened for
+  the same reason.
+
+- **Round three claimed "each fix reverted and re-run" while enumerating only three
+  of seven — and the two it omitted were exactly the two that were pinned by
+  nothing.** The `readAsync` deadline and the memo deadlines could both be reverted
+  with the entire suite green. Both now have discriminating tests (the restored
+  grandchild test, and an injected never-settling memo callee), verified by
+  reverting each and watching them time out. Recorded rather than quietly fixed,
+  because the sentence "each fix reverted" appeared in the very section whose
+  purpose is to stop unverified pinning claims.
 
 ### A fourth round-two finding, closed in round three: the unreachable fail-closed catch
 
@@ -443,11 +560,51 @@ argument that naming a failure mode does not protect you from it; only a check d
 ## Rollback
 
 `snapshotConcurrency: 1` makes the fan-out fully serial (slowest, gentlest) without
-reverting anything. A full back-out is a revert of the touched source files (the two
-monitoring modules, the git funnel, types, the construction site, the update
-migration and the route); no
-migration, no persisted state, no config default change, and no data to repair —
-the change is confined to execution strategy.
+reverting anything.
+
+**A full back-out is NOT just reverting the source files, and three earlier
+descriptions of it disagreed with each other in three different ways.** It is:
+
+1. The touched source files: the two monitoring modules, the git funnel, types, the
+   construction site, the update migration and the route.
+2. **The new lint, removed from BOTH places** — the chain in `package.json` AND its
+   entry in the `REQUIRED_LINTS` ratchet. Removing it from only the chain leaves the
+   ratchet asserting a lint that no longer runs, so the documented back-out would
+   leave the test suite RED. Also delete the script and its allowlist entry in the
+   destructive-op lint.
+3. **The chokepoint baseline key must be RE-ADDED**, because reverting the source
+   reintroduces the blocking process scan it recorded. That file's own contract says
+   it may only shrink, so this is the one step that needs a deliberate exception
+   rather than a mechanical revert.
+4. **The note already written to deployed agents STAYS.** The migration writes it to
+   every agent on update; a source revert cannot un-write it. So "nothing is stored"
+   was false — deployed agents would retain documentation for a config key that no
+   longer exists.
+
+No config DEFAULT changes and there is no data to repair; the runtime change is
+confined to execution strategy.
+
+### Files in this change that are NOT about event-loop safety
+
+Named because three reviewers flagged them as undocumented, and an unexplained file
+in a Tier-3 delete-path change is a review cost whether or not it is benign:
+
+- **`tests/helpers/gemini-usable.ts` and the two gemini live-CLI suites.** Those
+  suites gated on "is the binary installed" while the account on this machine cannot
+  authenticate, so they admitted a run that could never succeed and failed for a
+  reason unrelated to any code. They now distinguish not-installed from
+  cannot-authenticate and skip LOUDLY on the second. Included because the
+  Zero-Failure Standard makes a red suite this change's problem regardless of cause
+  — and because it is the same presence-standing-in-for-usability defect this change
+  is about. It changes what a green run MEANS on an unauthenticated machine, which
+  is why it is disclosed rather than left as a quiet test edit.
+- **`tests/e2e/throughput-series-live.test.ts`.** A fixture with hardcoded dates that
+  sat inside a 7-day window when written and fell out of it on 2026-07-30. Made
+  relative. Wholly unrelated; fixed under the same standard.
+- **`scripts/sync-subprocess-chokepoint-baseline.json`.** One legitimate removal (the
+  now-async process scan). The file was regenerated rather than edited, which
+  re-encoded two unrelated characters and dropped the trailing newline — churn in a
+  frozen artifact, flagged by two reviewers.
 
 ## Decision points touched
 

--- a/upgrades/side-effects/worktree-read-path-eventloop-safety.md
+++ b/upgrades/side-effects/worktree-read-path-eventloop-safety.md
@@ -301,6 +301,40 @@ to be. Had any required editing, the refactor would have changed what the funnel
 ADMITS, not just where the code lives — which is the one outcome that would make
 this change unsafe.
 
+**Round four: NOT converged, and the reason is worth stating precisely.** Six
+internal reviewers plus the external pass produced roughly forty findings, about a
+dozen design-class. The severe ones were all introduced by round three's own fixes:
+
+1. **The pass ceiling could terminate the process.** It reports through an event
+   channel with no listener in production — verified across the source tree AND the
+   deployed build. In this runtime that throws, the drivers do not await, and the
+   unhandled rejection meets a fatal policy. A fix for a hung guard became a crashed
+   server. Closed by recording errors on a bounded ring surfaced on the read route,
+   so the emission is structurally safe AND observable rather than swallowed.
+2. **The sibling route had none of the ceilings** while the parity table claimed
+   identical protections — and had no row for the ceiling, so the one dimension
+   where parity failed was the one it did not mention. All five internal reviewers
+   found it. Closed.
+3. **The new lint was keyed on a type-alias SPELLING**, so the sibling module —
+   widened by this same change using an inline union — was skipped entirely.
+   Re-keyed on the shape; verified by reintroducing the defect there.
+4. **Two of the seven round-three fixes were pinned by nothing**, while this
+   artifact's discrimination section said "each fix reverted and re-run". Both now
+   have tests verified to fail when the fix is removed.
+5. **The stated reason for deleting a round-three test was wrong.** It was recorded
+   as un-reproducible under the test runner; the adversarial reviewer rebuilt it and
+   showed it reproduces exactly. The real defect was its own loose assertion. That
+   misdiagnosis had been written in as durable methodology, which would have told
+   the next person that writable coverage could not be written.
+
+A process failure of the author's also belongs here: the code-executing reviewer ran
+concurrently with five read-only ones on one tree, and three of them reported the
+tree mutating under them. Separately, a shell working-directory change made for an
+unrelated purpose silently rescoped a sequence of recovery commands onto a different
+checkout — no work was lost, but ten files in that checkout were overwritten and had
+to be restored. Both are the same shape as the defects under review: a measurement
+taken through a changed environment, attributed to the thing being measured.
+
 **Scope limit on that review, stated because it is a gate item.** It was performed
 against the branch as it stood before round three. Its verification that the safety
 checkpoint was left untouched no longer describes the current code: round three adds

--- a/upgrades/side-effects/worktree-read-path-eventloop-safety.md
+++ b/upgrades/side-effects/worktree-read-path-eventloop-safety.md
@@ -143,7 +143,12 @@ not be able to drift from the one displayed for observability.
   `keep / uncommitted-changes`. Harmless for delete-safety (it errs toward keeping) but
   it IS a verdict produced by the execution change, so the blanket "no verdict changed"
   claim does not survive here either. <!-- tracked: topic 37155 -->
-- **No double-fire, no shadowing.** No new timer, listener or scheduled work.
+- **No double-fire, no shadowing.** No new timer and no new scheduled work. There IS
+  one new listener — a permanent constructor-level `error` listener on the reaper,
+  added in round four because emitting `error` with none was killing the process. It
+  RECORDS to a bounded ring rather than swallowing, and a consumer attaching its own
+  listener still receives everything. An earlier version of this line said "no new
+  listener" and survived the change that added one.
 - **`withSyncOp` marker REMOVED from this path.** It previously wrapped the `gh`
   call so a blocking spawn would not read as a stuck event loop to the watchdogs —
   i.e. it made this freeze *invisible* rather than absent. With the spawn now async
@@ -153,9 +158,22 @@ not be able to drift from the one displayed for observability.
 
 ## 6. External surfaces
 
-- **Route contract.** Both handlers are async. Response bodies are byte-identical;
-  status codes gain a last-resort `500` so a rejected promise can never become an
-  unhandled rejection that takes the server down. `503`-when-unwired is unchanged.
+- **Route contract.** Both handlers are async, and status codes gain a last-resort
+  `500` so a rejected promise can never become an unhandled rejection that takes the
+  server down. `503`-when-unwired is unchanged.
+
+  **Response bodies are NO LONGER byte-identical** — corrected in round five, which
+  found that sentence still standing. The reaper's read gained `enumerationFailed`
+  and `recentErrors`; the sentinel's gained `undeterminedCount` and
+  `enumerationFailed`. All are ADDITIVE and no consumer asserts whole-body equality
+  (checked: no schema, no contract test, no snapshot test), so nothing breaks — but
+  "byte-identical" was this artifact's only claim about the external contract, and it
+  was wrong. `recentErrors` carries error MESSAGES; every command on this path is
+  local (`worktree list`, `status`, `rev-parse`, `cherry`, `worktree remove`), so no
+  remote URL and therefore no embedded-credential class exists. Git's
+  `worktree remove` stderr can name files INSIDE a worktree whose absolute path is
+  already in the same Bearer-authed body — an incremental widening, stated rather
+  than scrubbed.
 - **Latency profile changes shape.** A bounded fan-out (default 4) is wall-clock
   slower than an unbounded one would be, but the route was never fast — and the whole
   server is no longer hostage to it. `snapshotConcurrency: 1` is the gentlest setting.
@@ -208,12 +226,17 @@ armed.
 **Low, and the lever is now discoverable** (it was not when this section was first
 written — see §6). `snapshotConcurrency: 1` serialises the fan-out with no code change,
 on BOTH routes: the sentinel's width was a hardcoded 4 until review caught it, and it
-now reads the same key. A full
-back-out is a revert of the touched source files (the two monitoring modules, the git
-funnel, types, the construction site, the update migration and the route), plus
-removing the new lint from the lint chain. No migration, no persisted state, no
-config default that must be unwound, no agent-state repair, and no data to fix — the
-change is confined to execution strategy. The test migrations revert with it.
+now reads the same key. A full back-out is NOT a plain revert, and this paragraph previously said it was —
+making it the FOURTH disagreeing description across three documents. **The
+authoritative list is the four numbered steps in the spec's Rollback section**, and
+it is deliberately not restated here so the two cannot drift apart again. Its
+load-bearing points: the new lint must come out of THREE places in `package.json`
+plus the `REQUIRED_LINTS` ratchet, or the documented back-out leaves the suite RED;
+the frozen chokepoint baseline key must be re-ADDED, against that file's
+may-only-shrink contract; and the note this change writes into already-deployed
+agents STAYS, because a source revert cannot un-write it — so "no migration, no
+persisted state" was false, as §6 of this same artifact already said. The unrelated
+test fixes kept green under the Zero-Failure Standard should NOT be reverted with it.
 
 ---
 

--- a/upgrades/side-effects/worktree-read-path-eventloop-safety.md
+++ b/upgrades/side-effects/worktree-read-path-eventloop-safety.md
@@ -1,0 +1,252 @@
+# Side-effects review — worktree read-path event-loop safety
+
+**Spec:** `docs/specs/worktree-read-path-eventloop-safety.md`
+**Declared tier:** 3 (gate signalled `suggestedTier=2`, `riskFloor=2` — declared **above** the floor, not below)
+**Files:** `src/monitoring/AgentWorktreeReaper.ts`, `src/monitoring/agentWorktreeGit.ts`,
+`src/monitoring/OrphanedWorkSentinel.ts`, `src/monitoring/orphanedWorkGit.ts`, `src/server/routes.ts`
+(+ 3 new test files, 3 migrated test files)
+**Test status:** 97 tests green across 10 files — unit, integration and e2e.
+**Review status:** six internal reviewers + the conformance gate + one external family
+have all reported. Their blocking findings are fixed; see the Review record below.
+
+---
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+**No new rejection is introduced at the classifier.** Not one gate, gate order, or
+fail-closed direction changed; the two CONTROL tests pin identical verdicts before
+and after.
+
+One genuine over-block risk exists and is deliberate. `defaultReadGitAsync` resolves
+**only** on a clean exit, so a read that previously "succeeded" with partial output
+under an edge case now rejects. Rejection routes to KEEP, i.e. the safe direction —
+it can cause a worktree to be *retained* that might have been reclaimable, never the
+reverse. Retaining a reclaimable worktree costs disk; deleting an unreclaimable one
+costs work. This trade is intentional.
+
+Second, narrower: `readStream` refuses destructive verbs/shapes. Every call here is a
+genuine read (`worktree list`, `status`, `rev-parse`, `cherry`), all already
+permitted by the identical classifier `readSync` uses. A future contributor adding a
+non-read verb to this path gets a hard refusal rather than silent execution — correct.
+
+## 2. Under-block — what failure modes does this still miss?
+
+Named honestly; none is a regression, all pre-exist:
+
+- **RESOLVED after review.** An earlier draft left `gh pr list` and `lsof`
+  synchronous-but-memoized and tracked their conversion. The Standards-Conformance
+  Gate flagged that as a No-Deferrals violation and was right: the event-loop test
+  excludes both for determinism, so no test could have caught the remainder, and the
+  claim "the read path does not block" would have been merely nearly true. Both are
+  now non-blocking, each memo gained its own single-flight latch, and the
+  `lint-allow-blocking-scan` exemption was deleted along with its false
+  justification. The `withSyncOp` marker went with it — it existed to hide a
+  blocking spawn from the watchdogs, i.e. to make this freeze invisible rather than
+  absent.
+- **Request cancellation is not threaded.** An abandoned client does not cancel an
+  in-flight pass. Bounded by single-flight to one running pass rather than N; named
+  as a decision in the spec. <!-- tracked: topic 37155 -->
+- **`currentBranch` and `hasActiveBuildMarker` remain synchronous.** Both are on the
+  *reclaim* path, not the read path, and are single cheap calls — but they are
+  blocking, and `reap()` is now async around them. The wiring-integrity test asserts
+  zero blocking reads on the READ path specifically, so this residue is scoped and
+  visible rather than assumed away. <!-- tracked: topic 37155 -->
+- **Unbounded total work.** `snapshotConcurrency` bounds concurrency, not the total.
+  An agent with 500 worktrees still performs ~1500 reads per request, just politely,
+  without starving the loop. Pagination, streaming and a background-pass-with-
+  generation-id were each considered and are named in the spec with reasons for
+  deferral. This is a latency property, not an event-loop property.
+  <!-- tracked: topic 37155 -->
+
+## 3. Level-of-abstraction fit
+
+Right layer, and deliberately not lower. The obvious alternative — extend
+`SafeGitExecutor` with a new async primitive — was **avoided** once `readStream` was
+found to already exist there with identical guard semantics. So the safety
+checkpoint is untouched and this change sits entirely in its consumers.
+
+Not higher either: an Express-level timeout or a worker thread would mask the
+symptom while leaving a synchronous fan-out inside a status handler. The cartographer
+precedent (instar#1069) used a worker because it parses a large index in-process;
+here the cost is subprocess spawns, which async I/O addresses directly without a
+worker's setup cost per request.
+
+`mapBounded` is a local 15-line helper rather than a dependency, and is co-located
+with its only two consumers.
+
+## 4. Signal vs authority compliance
+
+**Compliant — but an earlier version of this answer was FALSE and is corrected here.**
+Reference: `docs/signal-vs-authority.md`.
+
+The reaper is an authority (it deletes). This change does not touch that authority's
+DECISION LOGIC — the gate set, their order, the blast-radius cap and the per-path
+failure breaker are unchanged. But the earlier claim that it "does not alter a single
+verdict" and that "the reclaim race guard is untouched" was wrong on two counts, both
+found by review and both now fixed:
+
+1. **`reclaimRaceGuard` changed behaviour**, because its inputs changed type and it was
+   not updated. Reading an un-awaited Promise in a boolean test made the in-use check
+   refuse every delete and made the dirty/unmerged re-checks vacuous — the latter being
+   a path where a worktree that went dirty between evaluation and reclaim would have
+   been deleted. Fixed; pinned by tests driven with promise-returning signals.
+2. **`isInUse` did not fail closed.** A failed process scan returned an empty set,
+   which reads as "nothing is using this worktree" and clears a delete gate. That is a
+   success-shaped rejection on a delete-authorising signal. It now returns an explicit
+   `unknown` and the answer is KEEP.
+
+The honest statement is therefore: this change alters execution strategy and, in two
+places, RESTORES a fail-closed property the code did not actually have. It adds no new
+authority.
+
+The structural decision that IS about authority: signals are `Awaitable<T>` and
+`evaluate()` awaits them, so the reap timer and the read route share ONE classifier. A
+separate async-only route path was rejected precisely because the classification
+authorising an irreversible delete must not drift from the one displayed.
+
+The one structural decision that *is* about authority: signals are `Awaitable<T>` and
+`evaluate()` awaits them, so the reap timer and the read route share **one**
+classifier. A separate async-only route path would have been simpler and was
+rejected precisely because the classification authorising an irreversible delete must
+not be able to drift from the one displayed for observability.
+
+## 5. Interactions
+
+- **Shared deps between two consumers.** `makeOrphanedWorkSentinelDeps` builds on
+  `makeAgentWorktreeReaperDeps`, so converting one forced the other. Both are
+  converted; typecheck confirms no third consumer exists.
+- **Caught near-miss — injection contract.** Tests inject a sync `readGit` to control
+  `isClean`. After the conversion that injection no longer reached the async path, so
+  those tests would have silently asserted against **real git** instead of their
+  fixture. The factory now derives the async reader from an injected sync one. This is
+  the highest-value finding in this review: an existing green test that had quietly
+  stopped testing anything.
+- **Single-flight vs the reap timer.** They share `evaluate()` but not the
+  single-flight latch (`pendingSnapshot` guards `snapshot()` only; `reap()` keeps its
+  own `running` flag). A snapshot and a reap pass can therefore run concurrently, as
+  before. Both are read-only up to the reclaim step, and the reclaim step is
+  unchanged and still race-guarded.
+- **No double-fire, no shadowing.** No new timer, listener or scheduled work.
+- **`withSyncOp` marker REMOVED from this path.** It previously wrapped the `gh`
+  call so a blocking spawn would not read as a stuck event loop to the watchdogs —
+  i.e. it made this freeze *invisible* rather than absent. With the spawn now async
+  there is nothing to mask, so the marker went with its cause. Worth flagging as an
+  interaction: any watchdog tuned on seeing in-flight-sync markers from this path
+  will now see none, which is correct rather than a signal loss.
+
+## 6. External surfaces
+
+- **Route contract.** Both handlers are async. Response bodies are byte-identical;
+  status codes gain a last-resort `500` so a rejected promise can never become an
+  unhandled rejection that takes the server down. `503`-when-unwired is unchanged.
+- **Latency profile changes shape.** A bounded fan-out (default 4) is wall-clock
+  slower than an unbounded one would be, but the route was never fast — and the whole
+  server is no longer hostage to it. `snapshotConcurrency: 1` is the gentlest setting.
+- **New config key** `snapshotConcurrency` with an inline default of 4. Absent config
+  preserves shipped behaviour, so no `migrateConfig` entry is required.
+- **No timing or conversation-state dependence**; no user-visible messaging; no
+  dashboard surface change.
+- **Agent Awareness:** no CLAUDE.md template change proposed. The route, its purpose
+  and its triggers are already documented; nothing an agent should newly *do* was
+  added — this is a correctness fix behind an existing documented surface.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Posture: machine-local.** `machine-local-justification: hardware-bound-resource`.
+Both routes report on worktree checkouts that physically exist on the serving
+machine's own disk, and the starved event loop is that machine's own. Nothing
+replicates, nothing is proxied on read, no durable state is written, no generated URL
+crosses a machine boundary, and there is no notice requiring one-voice gating.
+
+The conformance gate flagged an earlier draft here for defending locality with *scope
+control* instead of a real impossibility. The corrected argument separates the
+**resource** (a directory on one filesystem, plus a process table and on-disk locks
+from one kernel — genuinely not unifiable) from a **pool-scoped view over those local
+reads** (feasible, the `/guards?scope=pool` pattern, and a separate feature this spec
+does not introduce). A reviewer may legitimately argue the routes should grow such a
+view; that is a different spec.
+
+The cross-machine consequence runs the other way and is the point: a frozen loop
+stalls this machine's serving-lease heartbeat and rope probes, so a purely local
+blocking read presents as mesh instability. Fixing it locally removes a
+mesh-visible failure mode. Corroborated across both machines via
+`GET /guards?scope=pool`, which reports divergent classifications for the same
+manifest key — evidence the exemption comment was being relied on where the guard is
+armed.
+
+## 8. Rollback cost
+
+**Low.** `snapshotConcurrency: 1` serialises the fan-out with no code change. A full
+back-out is a revert of five source files. No migration, no persisted state, no
+config default that must be unwound, no agent-state repair, and no data to fix — the
+change is confined to execution strategy. The test migrations revert with it.
+
+---
+
+## Review record
+
+**Standards-Conformance Gate (code-backed, reads the living constitution).**
+Round 1: 82 standards checked, **2 possible violations** — (a) *No Deferrals*, for
+leaving the `gh`/`lsof` conversion tracked-but-undone while claiming read-path
+event-loop safety; (b) *An Instar Agent Is Always a Multi-Machine Entity*, for
+defending machine-local with scope control rather than a concrete impossibility.
+**Both accepted.** (a) was fixed in code; (b) was rewritten to separate the
+hardware-bound *resource* from a feasible-but-nonexistent pool-scoped *view*.
+Round 2 (after both fixes): **0 findings**, fit verdict `fit`.
+
+**Cross-model external review — `codex-cli:gpt-5.5`, verdict MINOR ISSUES.**
+Five findings, all folded:
+1. *Injection-contract escape hatch* (design) — the sync-derived async reader means a
+   future production wiring could reintroduce blocking behind an `await`. **Fixed
+   structurally**: a new wiring-integrity suite asserts production deps make **zero**
+   `readSync` calls across `listWorktrees` / `isClean` / `isMerged` and a full
+   snapshot pass, and documents the shim as test-only.
+2. *Route coverage* (design) — parity between the two routes was not demonstrated.
+   **Real gap found**: the sentinel had bounded fan-out but **not** single-flight.
+   Added, plus an explicit per-route parity table.
+3. *Cancellation* (design) — abandoned clients leave the pass running. Now a named
+   decision with its rationale rather than an omission.
+4. *Scalability alternatives* (precision) — pagination / streaming / background-pass
+   alternatives now named with reasons for deferral.
+5. *"Single-flight, not a cache"* (precision) — tightened to "no settled result is
+   reused; a caller may join an already-running pass," including the honest
+   consequence.
+
+**Second external family — `gemini-cli:gemini-3.1-pro-preview`: ATTEMPTED, DEGRADED
+(timeout).** Detected as available and invoked; the call timed out and returned no
+findings. Recorded as a degraded per-round result, not a clean pass and not a skip.
+(Consistent with this framework's behaviour on other recent specs in this repo, where
+it timed out across rounds 6-9.) Because the codex family succeeded, the aggregate
+external posture is a genuine RAN — but only ONE of two available families actually
+produced an opinion, which is less assurance than two.
+
+**Six internal reviewers (security, scalability, adversarial, integration,
+decision-completeness, lessons-aware): REPORTED.** Roughly thirty findings. Two were
+CRITICAL and both falsified the author's central claim:
+- `reclaimRaceGuard` reading awaitable signals in boolean context (inert reaper in one
+  configuration; **deleting a dirtied worktree** in a nearby one). Found independently
+  by four reviewers, two of which proved it by executing the code rather than reading
+  it. FIXED + discriminating tests added.
+- `/orphaned-work` still fully blocking, because its deps builder defaulted its own
+  reader and passed the defaulted one down, so the compatibility shim always took its
+  sync branch. Found independently by five reviewers. FIXED, plus two reads on that
+  route that had never been converted at all.
+
+Also fixed: the dropped output bound (a truncated `status` reads as CLEAN), missing
+stream-error handling (a partial read exiting 0 read as complete), `isInUse` failing
+open toward deletion, the third memo missing its single-flight latch, a cached null
+base ref pinning the whole agent to "unmerged", detached fan-out workers after a
+rejection, a NaN concurrency silently producing an empty answer, and a rollback lever
+that reached only one of the two routes.
+
+**Independent second-pass review (Phase 5): OUTSTANDING.** Required because this change
+touches a reaper. Owned by the peer agent (topic 37155), who accepted it. Deliberately
+NOT self-signed. **This artifact is incomplete until that concurrence is recorded
+here.**
+
+**The lesson worth carrying out of this review** (recorded because it generalises): every
+one of the critical findings had the same shape — an interface was widened to allow
+promises, and its consumers were never audited for it. TypeScript permits truthiness on
+`boolean | Promise<boolean>`, this repo has no lint that rejects it, and every existing
+test injected synchronous fakes so production's shape never appeared in the suite. The
+defect class is not specific to this change.

--- a/upgrades/side-effects/worktree-read-path-eventloop-safety.md
+++ b/upgrades/side-effects/worktree-read-path-eventloop-safety.md
@@ -60,10 +60,22 @@ Named honestly; none is a regression, all pre-exist:
 
 ## 3. Level-of-abstraction fit
 
-Right layer, and deliberately not lower. The obvious alternative — extend
-`SafeGitExecutor` with a new async primitive — was **avoided** once `readStream` was
-found to already exist there with identical guard semantics. So the safety
-checkpoint is untouched and this change sits entirely in its consumers.
+Right layer — and round three moved it DOWN one, deliberately, against my earlier
+answer here. This section previously said extending `SafeGitExecutor` with a new
+async primitive was **avoided** because `readStream` already existed "with identical
+guard semantics". The guard semantics were identical; the AUDIT semantics were not.
+`readStream` hands back a live child, so the funnel records `allowed` at spawn and
+never sees how the read ended — a failed read that gates an irreversible delete was
+recorded as allowed with no failure row, while the blocking path records
+`denied: subprocess-error`.
+
+So the change now DOES add a primitive to the safety checkpoint: `readAsync`, the
+async twin of `readSync`, with the classification/guard/env preamble extracted and
+shared by all three read entry points so they cannot drift. That is a larger
+footprint in the funnel than this section originally claimed, and it is the reason
+the declared risk tier is right. The alternative was keeping a spec claim that was
+false on the delete path, in the same branch that filed a finding about an armed
+deleter leaving no record of what it deleted.
 
 Not higher either: an Express-level timeout or a worker thread would mask the
 symptom while leaving a synchronous fan-out inside a status handler. The cartographer
@@ -197,7 +209,9 @@ armed.
 written — see §6). `snapshotConcurrency: 1` serialises the fan-out with no code change,
 on BOTH routes: the sentinel's width was a hardcoded 4 until review caught it, and it
 now reads the same key. A full
-back-out is a revert of five source files. No migration, no persisted state, no
+back-out is a revert of the touched source files (the two monitoring modules, the git
+funnel, types, the construction site, the update migration and the route), plus
+removing the new lint from the lint chain. No migration, no persisted state, no
 config default that must be unwound, no agent-state repair, and no data to fix — the
 change is confined to execution strategy. The test migrations revert with it.
 
@@ -265,10 +279,16 @@ PR #1757). Not self-signed.
 
 The reviewer independently verified two load-bearing claims against source rather than
 accepting them, and both held: that `SafeGitExecutor.readStream` genuinely pre-exists
-carrying the same destructive-verb and destructive-shape denials (so leaving the safety
-checkpoint untouched is sound rather than convenient), and that the false exemption was
-real and shipped — the comment asserting "ships dark + dry-run + reviewed" sat on a guard
+carrying the same destructive-verb and destructive-shape denials, and that the false
+exemption was real and shipped — the comment asserting "ships dark + dry-run + reviewed" sat on a guard
 that is armed on this machine.
+
+**Scope limit on that review, stated because it is a gate item.** It was performed
+against the branch as it stood before round three. Its verification that the safety
+checkpoint was left untouched no longer describes the current code: round three adds
+`readAsync` to `SafeGitExecutor`. The reviewer's three findings are fixed and its
+concurrence stands for what it read; it is NOT a review of the funnel change, and
+nothing here should be read as though it were.
 
 Its three findings, all now fixed in this artifact:
 1. **§6 and §8 contradicted each other.** §8 rated rollback LOW *because*

--- a/upgrades/side-effects/worktree-read-path-eventloop-safety.md
+++ b/upgrades/side-effects/worktree-read-path-eventloop-safety.md
@@ -283,6 +283,24 @@ carrying the same destructive-verb and destructive-shape denials, and that the f
 exemption was real and shipped — the comment asserting "ships dark + dry-run + reviewed" sat on a guard
 that is armed on this machine.
 
+**The reviewer's follow-up question, answered with the measurement rather than a
+recollection.** They asked whether the existing `SafeGitExecutor` suite ran
+UNCHANGED against the de-duplicated read preamble — the point being that if any of
+it needed editing, that is the most important line in the change.
+
+It ran unchanged. The diff against the branch base is **110 insertions and zero
+deletions or modifications**: the 31 pre-existing tests (execSync source-tree
+guard, readSync classification and bypass, readStream refusal and timeout) are
+byte-identical, and the 5 additions are the new `readAsync` block. All 36 pass.
+
+That is the evidence that extracting `prepareReadOnlySpawn` preserved the admission
+decision rather than merely appearing to: the tests that pin destructive-verb
+refusal, destructive-shape refusal, the `-C <dir>` target extraction, the
+source-tree guard and the sourceTreeReadOk bypass were not touched and did not need
+to be. Had any required editing, the refactor would have changed what the funnel
+ADMITS, not just where the code lives — which is the one outcome that would make
+this change unsafe.
+
 **Scope limit on that review, stated because it is a gate item.** It was performed
 against the branch as it stood before round three. Its verification that the safety
 checkpoint was left untouched no longer describes the current code: round three adds

--- a/upgrades/side-effects/worktree-read-path-eventloop-safety.md
+++ b/upgrades/side-effects/worktree-read-path-eventloop-safety.md
@@ -99,11 +99,6 @@ The honest statement is therefore: this change alters execution strategy and, in
 places, RESTORES a fail-closed property the code did not actually have. It adds no new
 authority.
 
-The structural decision that IS about authority: signals are `Awaitable<T>` and
-`evaluate()` awaits them, so the reap timer and the read route share ONE classifier. A
-separate async-only route path was rejected precisely because the classification
-authorising an irreversible delete must not drift from the one displayed.
-
 The one structural decision that *is* about authority: signals are `Awaitable<T>` and
 `evaluate()` awaits them, so the reap timer and the read route share **one**
 classifier. A separate async-only route path would have been simpler and was
@@ -121,11 +116,21 @@ not be able to drift from the one displayed for observability.
   fixture. The factory now derives the async reader from an injected sync one. This is
   the highest-value finding in this review: an existing green test that had quietly
   stopped testing anything.
-- **Single-flight vs the reap timer.** They share `evaluate()` but not the
-  single-flight latch (`pendingSnapshot` guards `snapshot()` only; `reap()` keeps its
-  own `running` flag). A snapshot and a reap pass can therefore run concurrently, as
-  before. Both are read-only up to the reclaim step, and the reclaim step is
-  unchanged and still race-guarded.
+- **Single-flight vs the reap timer — READ §4 FIRST.** They share `evaluate()` but not
+  the single-flight latch (`pendingSnapshot` guards `snapshot()` only; `reap()` keeps
+  its own `running` flag), so a snapshot and a reap pass can run concurrently.
+  **Correction to an earlier version of this bullet, which said the reclaim step was
+  "unchanged and still race-guarded":** that was reassurance, and it was wrong. The
+  reclaim guard's BEHAVIOUR changed (§4 finding 1) — it read awaitable signals in
+  boolean context, which made two of its three re-checks vacuous. It is fixed and
+  pinned by tests, but a reviewer checking concurrency safety must not read this bullet
+  as "nothing changed here".
+  A second, genuinely new interleaving: `snapshot()` now yields between gates while
+  `reap()` can call the blocking `removeWorktree`. An in-flight `isClean` against a path
+  the reaper just removed rejects → KEEP → the route can report a *deleted* worktree as
+  `keep / uncommitted-changes`. Harmless for delete-safety (it errs toward keeping) but
+  it IS a verdict produced by the execution change, so the blanket "no verdict changed"
+  claim does not survive here either. <!-- tracked: topic 37155 -->
 - **No double-fire, no shadowing.** No new timer, listener or scheduled work.
 - **`withSyncOp` marker REMOVED from this path.** It previously wrapped the `gh`
   call so a blocking spawn would not read as a stuck event loop to the watchdogs —
@@ -146,9 +151,21 @@ not be able to drift from the one displayed for observability.
   preserves shipped behaviour, so no `migrateConfig` entry is required.
 - **No timing or conversation-state dependence**; no user-visible messaging; no
   dashboard surface change.
-- **Agent Awareness:** no CLAUDE.md template change proposed. The route, its purpose
-  and its triggers are already documented; nothing an agent should newly *do* was
-  added — this is a correctness fix behind an existing documented surface.
+- **Agent Awareness — CORRECTED after independent review.** An earlier version said no
+  CLAUDE.md template change was needed. That was right about the ROUTE and wrong about
+  the KNOB, and it contradicted §8: §8 rates rollback LOW *because* `snapshotConcurrency`
+  exists, while §6 left that key undocumented on every agent-facing surface. A lever
+  nothing surfaces is not a lever anyone finds under pressure — the two sections could
+  not both stand.
+  Resolved in favour of documenting it: `snapshotConcurrency` is declared in the config
+  type alongside its siblings, and a `PostUpdateMigrator` CLAUDE.md addendum bullet
+  carries it to already-deployed agents (the same treatment `initialPassDelayMs` and
+  `githubMergeCheck` received — both inline-defaulted and behaviour-preserving-when-
+  absent, and both still got a bullet, for exactly this reason). Tuning the fan-out
+  when that route is slow IS something an agent should newly do.
+  No `migrateConfig` entry is required: the key is inline-defaulted, so its absence
+  yields the shipped behaviour and writing `4` into every agent's config would freeze
+  today's default.
 
 ## 7. Multi-machine posture (Cross-Machine Coherence)
 
@@ -176,7 +193,10 @@ armed.
 
 ## 8. Rollback cost
 
-**Low.** `snapshotConcurrency: 1` serialises the fan-out with no code change. A full
+**Low, and the lever is now discoverable** (it was not when this section was first
+written — see §6). `snapshotConcurrency: 1` serialises the fan-out with no code change,
+on BOTH routes: the sentinel's width was a hardcoded 4 until review caught it, and it
+now reads the same key. A full
 back-out is a revert of five source files. No migration, no persisted state, no
 config default that must be unwound, no agent-state repair, and no data to fix — the
 change is confined to execution strategy. The test migrations revert with it.
@@ -239,10 +259,41 @@ base ref pinning the whole agent to "unmerged", detached fan-out workers after a
 rejection, a NaN concurrency silently producing an empty answer, and a rollback lever
 that reached only one of the two routes.
 
-**Independent second-pass review (Phase 5): OUTSTANDING.** Required because this change
-touches a reaper. Owned by the peer agent (topic 37155), who accepted it. Deliberately
-NOT self-signed. **This artifact is incomplete until that concurrence is recorded
-here.**
+**Independent second-pass review (Phase 5): COMPLETE — CONCUR, with three findings, none
+blocking.** Performed by the peer agent from a different machine (topic 37155, posted on
+PR #1757). Not self-signed.
+
+The reviewer independently verified two load-bearing claims against source rather than
+accepting them, and both held: that `SafeGitExecutor.readStream` genuinely pre-exists
+carrying the same destructive-verb and destructive-shape denials (so leaving the safety
+checkpoint untouched is sound rather than convenient), and that the false exemption was
+real and shipped — the comment asserting "ships dark + dry-run + reviewed" sat on a guard
+that is armed on this machine.
+
+Its three findings, all now fixed in this artifact:
+1. **§6 and §8 contradicted each other.** §8 rated rollback LOW *because*
+   `snapshotConcurrency` exists, while §6 proposed no agent-facing documentation for it —
+   so the entire rollback lever was an undocumented config key. "A lever nothing surfaces
+   is not a lever anyone finds under pressure." Resolved by documenting it (config type +
+   a `PostUpdateMigrator` CLAUDE.md addendum), not by weakening §8. Acting on this also
+   exposed that the two routes read *different* keys, so the "one lever, both routes"
+   claim was false until the sentinel was wired to inherit the reaper's.
+2. **§4 carried the same paragraph twice, reworded** — a corrected paragraph added
+   without removing the one it replaced. Worse in the authority section than elsewhere,
+   because a reader cannot tell whether it describes one decision or two. Duplicate
+   removed.
+3. **§5 read as reassurance where §4 read as caveat.** §5 said the reclaim step was
+   "unchanged and still race-guarded" while §4 said its behaviour changed. §5 is where a
+   reviewer checks concurrency safety, so it now carries the correction and points at §4.
+
+The reviewer deliberately did NOT re-run the adversarial pass on the central claim or the
+foundation question, on the grounds that duplicating passes the author had already
+directed produces agreement rather than independence. That is recorded as a scope choice,
+not an omission.
+
+**Convergence is still owed a genuinely quiet round; this review does not substitute for
+one.** The round that produced these fixes contained many design-class findings, and the
+rule is two consecutive rounds without them. The convergence tag is NOT written.
 
 **The lesson worth carrying out of this review** (recorded because it generalises): every
 one of the critical findings had the same shape — an interface was widened to allow


### PR DESCRIPTION
**Draft. Docs only. Not converged, not ready to merge.**

The implementation is deliberately **not** in this PR — the instar-dev commit gate correctly refuses it until the spec converges, and the reviewer round is still open. This lands the review artifacts so they are durable and readable off one machine.

## What is here
- the spec
- its plain-English (ELI16) companion
- the side-effects review

## The defect being fixed (measured, not theorised)
On a live agent with 48 worktrees: baseline `/health` ~17ms; during **one** request to `GET /worktrees/agent-reaper`, `/health` took **10.6s**. `GET /orphaned-work` froze the loop for 3.7s. Both handlers were synchronous and fanned `execFileSync` git reads out per worktree.

## Why it is not converged
A six-reviewer round produced two CRITICAL findings against the implementation, both since fixed on the working tree but not in this PR:

1. **`reclaimRaceGuard` read now-awaitable signals without awaiting.** An un-awaited Promise is always truthy, so the in-use check refused every delete (inert reaper); and because `!Promise` is always false, the dirty and unmerged re-checks became vacuous — a nearby configuration would have **deleted a worktree that went dirty between evaluation and reclaim**. Found independently by four reviewers, two of which proved it by executing the code.
2. **`/orphaned-work` was never actually converted.** Its deps builder defaulted its own reader and passed the *defaulted* one down, so the compatibility shim always took its synchronous branch. Found by five reviewers. The wiring test written to close that hatch only covered the construction that cannot exhibit it.

Also fixed: a dropped output bound (a truncated `git status` reads as CLEAN), missing stream-error handling, and a process scan that failed *toward* deletion.

## Corrections to earlier claims in this spec
- It does **not** close root cause #4 of the 2026-06-07 postmortem; it removes one instance of that hazard class while the two follow-ups that postmortem names are untouched.
- "Every gate fails closed" was **false** for one signal until this change; the spec now states the before and after rather than implying it always held.
- The signal-vs-authority answer was rewritten: "no verdict changed" was wrong on two counts.

## Outstanding
- independent second-pass review (owner: peer agent, not the author)
- at least one more full convergence round — the rule is two consecutive rounds with no design-level findings, and this round produced many
- convergence tag (not written, deliberately)
- operator approval

Related finding, deliberately **not** folded in: the reaper emits a `reaped` event and **no listener exists**, so an armed deleter has run daily for ~7.5 weeks with no record of what it removed. Being written up separately.