### PR TITLE
fix(projects): a round that cannot start must fail the round, not the agent server

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-30T15-03-58-372Z-project-round-spawn-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-30T15-03-58-372Z-project-round-spawn-guard.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-30T15:03:58.372Z",
+  "slug": "project-round-spawn-guard",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 89,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/ProjectRoundExecution.ts"
+    ],
+    "addedLines": 85,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/project-round-spawn-guard.eli16.md
+++ b/docs/specs/project-round-spawn-guard.eli16.md
@@ -1,0 +1,88 @@
+# ELI16 — a project round that cannot start should fail the round, not the whole agent
+
+## What went wrong, in plain language
+
+Instar can run a "project round": it starts a fresh AI session in the background and lets
+it work through a list of items. Starting that session means launching a program called
+`claude`.
+
+Twice today, asking for a round to start **killed the entire agent server**. Not the round
+— the whole thing. It restarted itself about eleven seconds later, and the round was left
+sitting there marked "not started", with nothing written down anywhere explaining why.
+
+## Why launching a program can kill the server
+
+When a program cannot be launched at all — the file is not where we looked, or it is not
+executable — the operating system does not report that the way you would expect. It does
+not say "the program ran and failed". It reports a *separate* kind of event meaning "this
+never started."
+
+Nothing in the code was listening for that event. In Node.js, an event of that kind that
+nobody listens for is escalated into a crash of the whole process. So a missing file at
+launch became a dead server.
+
+There is a deliberate policy in this codebase about which crashes are survivable, and it
+crashes by default on anything it does not recognise. **That policy is correct and this
+change does not touch it.** The right fix is not to teach the crash-handler to shrug at
+this error; it is to stop leaving the launch unattended in the first place.
+
+## The second problem, which is quieter and worse
+
+Even if the crash had been prevented, the code that waits for the session to finish was
+listening *only* for "the session ended". A session that never started never ends. So the
+waiter would have sat there forever, waiting for something that could not happen.
+
+So one line carried two faults: it could kill the server, and if it did not, it could hang.
+
+## Why the program was missing
+
+The agent server is started by the operating system at login, and that gives it a much
+smaller list of places to look for programs than a normal terminal has. `claude` lives in
+a directory that list does not include.
+
+**This was already solved.** There is a helper in this codebase that knows how to find
+these programs — it checks the standard locations, the places version managers install
+things, and the search path. Five other parts of the system already use it. Its own notes
+record a session-spawn crash from this same cause two months ago, which is exactly why it
+learned to look in those extra places.
+
+The round-starting code, written later, simply did not use it. So this change is not a new
+mechanism — it is one call site finally reaching for the tool everyone else already uses.
+
+## What changes
+
+Two things.
+
+**First**, the launch now asks that helper where the program is, instead of hoping the
+operating system's short list happens to include it. If the helper genuinely cannot find
+it, behaviour is unchanged from before.
+
+**Second**, the launch now listens for "this never started". If that happens, the round is
+recorded as failed with a reason that says so, and the run stops there.
+
+That second half is the important one. Without it, the next launch failure for any other
+reason — a permissions problem, a corrupted install — would still take the agent down.
+
+## One deliberate decision worth flagging
+
+The code normally retries a failed session a few times before giving up. A launch failure
+deliberately does **not** consume one of those retries.
+
+Retrying a program that is not there cannot succeed, so spending the attempts only delays
+the answer — and worse, the round would then be recorded as "ran out of retries", which is
+true-sounding and wrong. The problem was never that retries ran out. It is that the thing
+never started.
+
+"Could not start" and "started and then failed" are different facts, and the record must
+not blur them.
+
+## How we know it works
+
+The tests launch a program that genuinely does not exist, so the failure is real rather
+than simulated.
+
+Run against the code *before* the fix, three of them fail — and the test run itself
+reports the same crash the server suffered today. Run against the fixed code, all twelve
+pass. A fourth test checks that an ordinary failed session still behaves exactly as it did
+before; that one passes either way, and is labelled as a control rather than counted as
+evidence.

--- a/src/core/ProjectRoundExecution.ts
+++ b/src/core/ProjectRoundExecution.ts
@@ -39,6 +39,7 @@ import { spawn, execFileSync, type ChildProcess } from 'node:child_process';
 import type { Initiative, InitiativeTracker, RoundStatus } from './InitiativeTracker.js';
 import { ProjectRoundLock } from './ProjectRoundLock.js';
 import { ProjectRoundWorktrees } from './ProjectRoundWorktrees.js';
+import { detectClaudePath } from './Config.js';
 import { SafeGitExecutor } from './SafeGitExecutor.js';
 import { withSyncOp } from './InFlightSyncOpMarker.js';
 
@@ -317,6 +318,23 @@ export async function runRound(input: RunRoundInput, deps: RunRoundDeps): Promis
         break;
       }
 
+      // The child never started. Record it as a round failure that NAMES the
+      // cause, and do NOT spend a resume attempt: a binary that cannot be
+      // resolved or executed will not resolve on a retry, so relaunching would
+      // burn the attempt budget and report the wrong reason ("attempts
+      // exhausted") for a condition that is not about attempts at all.
+      // "Could not start" and "started and failed" are different facts and the
+      // round record must not render them the same.
+      if (exit.kind === 'spawn-failed') {
+        outcome = 'failed';
+        // Node's spawn errors already name the binary ("spawn claude ENOENT"),
+        // so the message alone is enough to diagnose without plumbing the
+        // resolved path — which would risk leaking an absolute home path.
+        reason = `could not start the autonomous child: ${exit.spawnError ?? 'unknown spawn error'}`;
+        unmergedItemIds = [...lastItemIds];
+        break;
+      }
+
       // Natural exit.
       if (exit.kind === 'exited' && exit.code === 0) {
         // Step 6: verify per-item artifacts.
@@ -436,13 +454,44 @@ async function recordOutcome(
 }
 
 interface ExitResult {
-  kind: 'exited' | 'set-changed' | 'halted';
+  kind: 'exited' | 'set-changed' | 'halted' | 'spawn-failed';
   code?: number | null;
   signal?: NodeJS.Signals | null;
+  /** Sanitized reason, present only when kind === 'spawn-failed'. */
+  spawnError?: string;
 }
 
+/**
+ * Spawn errors captured at the spawn site.
+ *
+ * `child_process.spawn` reports a failure to START (ENOENT, EACCES) by
+ * emitting `'error'` — NOT by emitting `'exit'`. Two consequences, and the
+ * second is the one that bites:
+ *
+ *   1. An unhandled `'error'` becomes a process-level uncaught exception.
+ *      `uncaughtExceptionPolicy` crashes by default on anything it does not
+ *      recognise — correctly, since an unknown exception is not safe to
+ *      swallow. So an unstartable child took the WHOLE agent server down.
+ *   2. Even with the crash averted, `'exit'` never fires, so a waiter that
+ *      listens only for `'exit'` waits forever for an event that cannot come.
+ *
+ * Capturing here — at the spawn site, in the same tick as the spawn — means
+ * the "a spawn failure never crashes the process" property does not depend on
+ * any caller remembering to attach a listener. The waiter separately consumes
+ * the error to turn it into a recorded round failure.
+ */
+const spawnFailures = new WeakMap<ChildProcess, Error>();
+
 function spawnAutonomousChild(input: RunRoundInput, itemIds: string[]): ChildProcess {
-  const cmd = input.spawnCommand ?? 'claude';
+  // Resolve the binary rather than trusting the server's PATH. The server runs
+  // under launchd, whose PATH routinely excludes the nvm/asdf/npm-global bin dir
+  // that actually holds `claude` — so a bare 'claude' resolves in the operator's
+  // terminal and ENOENTs in the server. `detectFrameworkBinary` already scans
+  // exactly those locations (its own comment records the 2026-05-31 session-spawn
+  // crash from this same cause); this callsite simply was not using it.
+  // Falls back to the bare name so a host where detection legitimately finds
+  // nothing behaves as before rather than failing earlier than it used to.
+  const cmd = input.spawnCommand ?? detectClaudePath() ?? 'claude';
   const args = input.spawnArgs ?? ['--skill', 'autonomous'];
   const workdir =
     input.initialWorkdir ??
@@ -465,6 +514,13 @@ function spawnAutonomousChild(input: RunRoundInput, itemIds: string[]): ChildPro
       INSTAR_ROUND_ITEM_IDS: JSON.stringify(itemIds),
       INSTAR_STOP_CONDITION: 'all-items-merged-on-main',
     },
+  });
+  // Attach IMMEDIATELY — see spawnFailures above. Without a listener a failure
+  // to START is an unhandled 'error' event, which is a process-level uncaught
+  // exception, which kills the agent server. This listener exists so that
+  // property holds no matter what the caller does with the returned child.
+  child.on('error', (err: Error) => {
+    spawnFailures.set(child, err);
   });
   return child;
 }
@@ -490,9 +546,34 @@ async function waitForExitOrPollChange(
     });
   });
 
+  // A child that never STARTED emits 'error' and never emits 'exit', so the
+  // loop below would otherwise wait forever for an event that cannot arrive.
+  // Check the spawn-site capture first (the error may already have fired before
+  // this function attached anything), then listen for a later one.
+  // An error that ALREADY fired (captured at the spawn site) is answered before
+  // any waiting at all — read into its own local so the check below is not
+  // narrowed by this one.
+  const alreadyFailed = spawnFailures.get(child);
+  if (alreadyFailed) {
+    return { kind: 'spawn-failed', spawnError: alreadyFailed.message };
+  }
+  // Holder object rather than a bare `let`: the assignment happens inside a
+  // callback, which TypeScript's control-flow analysis cannot see.
+  const failure: { err?: Error } = {};
+  const spawnFailurePromise = new Promise<void>((resolve) => {
+    child.once('error', (err: Error) => {
+      failure.err = err;
+      resolve();
+    });
+  });
+
   while (!exited) {
-    // Wait either pollIntervalMs OR exit, whichever comes first.
-    await Promise.race([exitPromise, sleep(pollIntervalMs)]);
+    // Wait for exit, a spawn failure, OR the poll interval — whichever is first.
+    await Promise.race([exitPromise, spawnFailurePromise, sleep(pollIntervalMs)]);
+    const failedToStart = failure.err;
+    if (failedToStart) {
+      return { kind: 'spawn-failed', spawnError: failedToStart.message };
+    }
     if (exited) break;
 
     // Halt check.

--- a/tests/unit/ProjectRoundExecution.test.ts
+++ b/tests/unit/ProjectRoundExecution.test.ts
@@ -333,3 +333,125 @@ describe('ProjectRoundExecution.runRound', () => {
     expect(exclude).toContain('.worktrees/');
   });
 });
+
+/**
+ * A child that cannot START is a different fact from a child that started and
+ * failed, and the round record must not render them the same.
+ *
+ * `child_process.spawn` reports a failure to start by emitting `'error'`, NOT
+ * `'exit'`. Before this change nothing listened for it, so:
+ *   - the unhandled `'error'` became a process-level uncaught exception, which
+ *     `uncaughtExceptionPolicy` correctly crashes on (it cannot know an unknown
+ *     exception is safe to swallow) — taking the whole agent server down; and
+ *   - `'exit'` never fires, so a waiter listening only for `'exit'` waits for an
+ *     event that cannot arrive.
+ *
+ * These tests use a genuinely nonexistent binary, so the ENOENT is REAL rather
+ * than mocked — the same failure the server hit twice on 2026-07-30.
+ *
+ * DISCRIMINATION: tests 1-3 were run against the pre-change source and FAIL
+ * there. Test 4 is a CONTROL — it passes on both revisions and is included to
+ * prove the ordinary exit path is untouched, not as evidence for this change.
+ */
+describe('ProjectRoundExecution.runRound — child that cannot start', () => {
+  let stateDir: string;
+  let targetRepo: string;
+  let tracker: InitiativeTracker;
+
+  beforeEach(() => {
+    stateDir = makeStateDir();
+    targetRepo = makeGitRepo();
+    tracker = new InitiativeTracker(stateDir);
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/unit/ProjectRoundExecution.test.ts:state' }); } catch { /* ignore */ }
+    try { SafeFsExecutor.safeRmSync(targetRepo, { recursive: true, force: true, operation: 'tests/unit/ProjectRoundExecution.test.ts:repo' }); } catch { /* ignore */ }
+  });
+
+  const MISSING_BINARY = '/nonexistent/instar-test-definitely-not-a-real-binary';
+
+  it('DISCRIMINATING: an unstartable child resolves as a failed round instead of crashing the process', async () => {
+    await newProject(tracker, 'p-nospawn', ['i1'], targetRepo);
+    const r = await runRound(
+      {
+        tracker,
+        projectId: 'p-nospawn',
+        roundIndex: 0,
+        targetRepoPath: targetRepo,
+        spawnCommand: MISSING_BINARY,
+        spawnArgs: [],
+        pollIntervalMs: 50,
+        sigtermGraceMs: 100,
+        verifyMergedItems: async (ids) => notLanded(ids),
+      },
+      { stateDir }
+    );
+    expect(r.outcome).toBe('failed');
+  });
+
+  it('DISCRIMINATING: the reason NAMES the start failure rather than reporting exhausted attempts', async () => {
+    await newProject(tracker, 'p-reason', ['i1'], targetRepo);
+    const r = await runRound(
+      {
+        tracker,
+        projectId: 'p-reason',
+        roundIndex: 0,
+        targetRepoPath: targetRepo,
+        spawnCommand: MISSING_BINARY,
+        spawnArgs: [],
+        pollIntervalMs: 50,
+        sigtermGraceMs: 100,
+        verifyMergedItems: async (ids) => notLanded(ids),
+      },
+      { stateDir }
+    );
+    // The honest cause, not a proxy for it.
+    expect(r.reason).toMatch(/could not start/i);
+    expect(r.reason).toMatch(/ENOENT/);
+    // "attempts exhausted" would be a TRUE-sounding but WRONG reason: the
+    // problem is not that retries ran out, it is that the binary is not there.
+    expect(r.reason).not.toMatch(/attempts exhausted/i);
+  });
+
+  it('DISCRIMINATING: a start failure does not burn the resume-attempt budget', async () => {
+    await newProject(tracker, 'p-noresume', ['i1'], targetRepo);
+    const r = await runRound(
+      {
+        tracker,
+        projectId: 'p-noresume',
+        roundIndex: 0,
+        targetRepoPath: targetRepo,
+        spawnCommand: MISSING_BINARY,
+        spawnArgs: [],
+        pollIntervalMs: 50,
+        sigtermGraceMs: 100,
+        verifyMergedItems: async (ids) => notLanded(ids),
+      },
+      { stateDir }
+    );
+    // Relaunching a binary that does not exist cannot succeed, so spending the
+    // budget on it only delays the honest answer and mislabels the cause.
+    expect(r.resumeAttempts).toBe(0);
+  });
+
+  it('CONTROL (passes on both revisions): an ordinary non-zero exit still exhausts resumes and reports that', async () => {
+    await newProject(tracker, 'p-control-exit', ['i1'], targetRepo);
+    const r = await runRound(
+      {
+        tracker,
+        projectId: 'p-control-exit',
+        roundIndex: 0,
+        targetRepoPath: targetRepo,
+        spawnCommand: 'bash',
+        spawnArgs: ['-c', 'exit 3'],
+        pollIntervalMs: 50,
+        sigtermGraceMs: 100,
+        verifyMergedItems: async (ids) => notLanded(ids),
+      },
+      { stateDir }
+    );
+    expect(r.outcome).toBe('failed');
+    expect(r.reason).toMatch(/attempts exhausted/i);
+    expect(r.resumeAttempts).toBeGreaterThan(0);
+  });
+});

--- a/upgrades/next/project-round-spawn-guard.md
+++ b/upgrades/next/project-round-spawn-guard.md
@@ -1,0 +1,56 @@
+## What Changed
+
+Starting a project round could kill the whole agent server instead of failing the round.
+
+The round launches a background `claude` session. The agent server is started at login, so
+its search path excludes the directory where `claude` actually lives on nvm/asdf-managed
+hosts. A launch that cannot find the binary reports an `'error'` event — never `'exit'` —
+and nothing was listening, so Node escalated it to a process-level uncaught exception. The
+server died and auto-restarted, leaving the round marked "not started" with nothing recorded
+to explain it.
+
+Two fixes at the one call site:
+
+1. The binary is resolved via the existing `detectClaudePath()` / `detectFrameworkBinary`
+   helper, which already scans npm-global, Homebrew, nvm, asdf and PATH, and is already used
+   by five other files. This call site simply was not using it.
+2. A failure to start is now handled and recorded as a round failure whose reason names the
+   cause. It deliberately does not consume a resume attempt — retrying a binary that is not
+   there cannot succeed, and "attempts exhausted" would be a true-sounding but wrong reason.
+
+The process-level crash policy is unchanged and untouched. It is correct to crash on an
+unrecognised exception; the defect was an unattended launch, not the backstop.
+
+## Evidence
+
+Tests launch a genuinely nonexistent binary, so the ENOENT is real rather than mocked.
+
+- Against the pre-change source: **3 failed / 9 passed**, and the run reports three
+  `Uncaught Exception: spawn … ENOENT` — the same crash observed twice in production on
+  2026-07-30.
+- Against the fixed source: **12 passed / 12**.
+- A fourth test (ordinary non-zero exit still exhausts resumes) passes on both revisions and
+  is labelled CONTROL rather than counted as evidence.
+- Run duration fell 48s → 18s, because the unfixed version waited on exits that could never
+  arrive — the second, quieter half of the same defect.
+
+`tsc` clean on both changed files.
+
+## What to Tell Your User
+
+If a project round ever seemed to do nothing — the round stayed "not started" and your agent
+appeared to restart itself around the same moment — this is why. The round was trying to
+launch a background session, could not find the program, and that took the whole server down
+instead of failing the round.
+
+Two things are better now. The launch looks in the places the program is actually installed,
+rather than only the short list a login-started service inherits. And if a launch still
+cannot happen, you get a round marked failed with a reason that says so, instead of a silent
+restart and a round that looks untouched.
+
+Nothing is required of you and no setting changed.
+
+## Summary of New Capabilities
+
+No new capability. This removes a crash and replaces a silent non-event with a recorded,
+readable failure reason.

--- a/upgrades/side-effects/project-round-spawn-guard.md
+++ b/upgrades/side-effects/project-round-spawn-guard.md
@@ -1,0 +1,113 @@
+# Side-effects review — project round spawn guard
+
+Change: `ProjectRoundExecution` resolves the autonomous binary via the existing
+`detectClaudePath()` and handles the `'error'` event a failed spawn emits, recording a
+round failure instead of crashing the agent server.
+
+Related prior art: **ACT-1269** (2026-07-25, still pending) — same ENOENT class in the same
+subsystem, different binary (`gh`). **CMT-513** (delivered 2026-05-25) — an uncaught
+exception that crashed the whole server, i.e. the class has history.
+
+---
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+**None identified, and the risk direction is checked.** The new branch fires only on a
+`'error'` event from `spawn`, which is emitted exclusively when the child fails to START
+(ENOENT, EACCES, EPERM). It cannot fire for a child that started and exited non-zero — that
+path still runs the pre-existing resume logic, and a CONTROL test asserts it.
+
+The binary resolution is `input.spawnCommand ?? detectClaudePath() ?? 'claude'`. An injected
+`spawnCommand` (every test, and any future caller) is untouched, and the final fallback is
+the previous literal, so a host where detection legitimately finds nothing behaves exactly
+as before rather than failing earlier than it used to.
+
+## 2. Under-block — what failure modes does this still miss?
+
+**Named rather than glossed:**
+- A child that starts successfully and then hangs forever is NOT covered here. The existing
+  poll loop handles halt/set-change, but there is no wall-clock ceiling on a running child.
+  Out of scope; not introduced by this change.
+- A child that starts and immediately exits non-zero still consumes resume attempts, which
+  is correct — that IS a "started and failed" case.
+- ACT-1269's `gh` ENOENT is a DIFFERENT call site in a different layer and is **not** fixed
+  here. This change does not close that action, and I am not claiming it does.
+
+## 3. Level-of-abstraction fit
+
+**Right layer, and I checked whether a higher one should own it.**
+The obvious alternative was to add ENOENT to `uncaughtExceptionPolicy`'s survivable
+allowlist. **Rejected on the module's own stated reasoning**: it crashes by default because
+an unknown exception is not safe to swallow, keeps its list deliberately tight, and says in
+place that it is *"the crash backstop, NOT a license to skip the catch — the first-seen-stack
+logging still surfaces the un-guarded callsite so the real missing `.catch` gets fixed."*
+Widening that allowlist would have degraded a deliberately-tight safety boundary to quiet one
+callsite's bug. The policy is correct; the callsite was wrong.
+
+Binary resolution likewise belongs in `Config.detectFrameworkBinary`, where it already lives
+and is already used by five other files — not re-implemented here.
+
+## 4. Signal vs authority compliance
+
+Compliant. This adds no new blocking authority. It converts an unhandled process-level event
+into a **recorded round outcome** — strictly more information, strictly less destructive. The
+crash-vs-continue authority remains entirely with `uncaughtExceptionPolicy`, untouched.
+
+## 5. Interactions — shadowing, double-fire, races
+
+- **Two `'error'` listeners are attached deliberately** (one at the spawn site for the
+  never-crash guarantee, one in the waiter for control flow). Node invokes all listeners; the
+  first prevents the throw, the second drives the outcome. Not a double-fire: they have
+  different jobs and the outcome is produced once.
+- **An error that fires BEFORE the waiter attaches** is covered — the waiter checks the
+  spawn-site capture first and returns immediately. Without that check there is a real
+  ordering window.
+- **No interaction with the halt path**: a halted round returns before the spawn-failure
+  branch is reachable, and halt is checked first in the loop.
+- **`killProcessGroup` is not called** on a spawn failure — correct, since there is no process
+  group to kill; calling it would be a no-op at best.
+
+## 6. External surfaces
+
+**One, and it is operator-visible: the round's recorded `reason` string changes** for this
+failure mode, from (previously) nothing at all — because the server died before writing — to
+a sentence naming the spawn error.
+
+Node's spawn error text already embeds the binary name (`spawn claude ENOENT`), so the reason
+is diagnostic without plumbing the resolved absolute path through — which would risk leaking
+an absolute home directory into an operator-facing record. That was a deliberate choice, made
+after writing the interpolation and removing it.
+
+No API shape change, no new config key, no new route. No CLAUDE.md update proposed: this adds
+no capability an agent should newly reach for — it removes a crash.
+
+*(Explicitly checked, because my own 07-30 review of a different change answered this section
+"None. no external surface" and was wrong — a deploy path was an external surface. Here the
+question was asked as "what else consumes this?" rather than "does the other tool read it?")*
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN, and the reason is intrinsic rather than an omission.** Binary
+resolution answers "where is this program on THIS filesystem" — there is no coherent unified
+value across machines, and a replicated answer would be actively wrong (the Mini resolves
+`claude` under nvm; another host may use Homebrew or asdf). The existing
+`detectFrameworkBinary` memo is per-process for the same reason.
+
+The round outcome it produces is already per-project state written through
+`InitiativeTracker`, whose replication posture this change does not alter.
+
+## 8. Rollback cost
+
+**Low, and the lever is real rather than assumed.** The change is two edits in one file plus
+one import. Reverting the commit restores prior behaviour exactly; there is no migration, no
+persisted new field, and no config key to unset.
+
+A partial rollback is also available and safe: keeping the `'error'` handler while reverting
+the resolution (or vice versa) leaves a coherent system, because the two halves are
+independent — one prevents a crash, the other makes the launch more likely to succeed.
+
+**Confidence stated honestly:** the crash and the hang are both reproduced by tests that fail
+on the pre-change source, so the failure mode is verified rather than reasoned. What is NOT
+verified is production behaviour on a host where detection returns a path that exists but is
+not executable — the handler covers it by construction (EACCES is also an `'error'` event),
+but no test exercises that specific errno.


### PR DESCRIPTION
## ELI16 — a round that cannot start should fail the round, not the whole agent

Starting a project round launches a background `claude` session. **Twice today that killed the entire agent server** (13:14:56Z and 13:49:49Z), which auto-restarted ~11s later leaving the round marked "not started" with nothing recorded to explain it.

When a program cannot be launched at all, the OS does not report "it ran and failed" — it reports a *separate* event meaning "this never started." Nothing was listening for that event, and in Node an unheard event of that kind is escalated into a crash of the whole process. So a missing file at launch became a dead server.

The binary was missing because the server is started at login, which gives it a much shorter search path than a terminal. `claude` lives in a directory that path does not include.

**This was already solved.** A helper in this repo knows how to find these programs — it checks standard locations, version-manager installs, and PATH. Five other files already use it. Its own comment records a session-spawn crash from this same cause two months ago, which is *why* it learned to look in those places. The round-starting code, written later, simply did not use it.

Two changes, both at the one call site: resolve the binary through that helper, and listen for "this never started" so the round records a failure naming the cause instead of taking the process down.

A launch failure deliberately does **not** consume a resume attempt. Retrying a binary that is not there cannot succeed, and the round would then read "attempts exhausted" — true-sounding and wrong. "Could not start" and "started and failed" are different facts.

## What this does NOT do

- **Does NOT close ACT-1269** (2026-07-25, still pending) — the sibling `gh` ENOENT is a different call site in `Config.ts`. Fixing a cousin is not fixing the general case.
- **Does NOT touch `uncaughtExceptionPolicy`.** Adding ENOENT to its survivable allowlist was considered and **rejected on that module's own reasoning**: it crashes by default because an unknown exception is not safe to swallow, and it states in place that it is *"the crash backstop, NOT a license to skip the catch."* The policy is right; the callsite was wrong.

## Evidence (red-green, real ENOENT — not mocked)

| run | result |
|---|---|
| pre-change | **3 failed / 9 passed**, plus **3 × `Uncaught Exception: spawn … ENOENT`** — the production crash reproduced in a harness |
| post-change | **12 passed / 12** |

A fourth test (ordinary non-zero exit still exhausts resumes) passes on **both** revisions and is labelled CONTROL rather than counted as evidence. Suite duration also fell 48s → 18s, because the unfixed version waited on exits that could never arrive — the second, quieter half of the same defect.

`tsc` clean on both changed files.

## Tier declaration — the gate and I disagree, and that is deliberate

The gate signals **`suggestedTier=2` (size=2, riskFloor=1, 89 LOC across 1 file)**. I declared **Tier 1**. It accepted because 1 meets the risk *floor*, **not because it agreed**.

Recording that plainly: my first trace cited "suggestedTier 1" from my own pre-check, which was **wrong** — I fed the classifier all 5 staged files (468 LOC) instead of the in-scope file. Corrected and the commit amended rather than leaving a flattering number in the audit trail.

Why Tier 1 still stands: the suggestion is **size**-driven, while every *risk* signal that raises the floor — safety-invariant, irreversibility, migration, new capability — produced **no reasons**. The change removes a crash rather than adding authority; no decision point, config key, migration, persisted field or route; one call site plus one import.

If a reviewer thinks 89 lines in a crash-capable subsystem earns Tier 2 regardless, that is a reasonable disagreement — and it is now visible here rather than hidden behind a mis-cited signal.
