### PR TITLE
Enforce transient spawn-refusal payload preservation

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-30T17-01-26-213Z-spawn-transient-refusal-class-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-30T17-01-26-213Z-spawn-transient-refusal-class-guard.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-30T17:01:26.213Z",
+  "slug": "spawn-transient-refusal-class-guard",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 344,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/messaging/SpawnRequestManager.ts"
+    ],
+    "addedLines": 249,
+    "deletedLines": 95
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-30T17-02-08-399Z-spawn-transient-refusal-class-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-30T17-02-08-399Z-spawn-transient-refusal-class-guard.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-30T17:02:08.399Z",
+  "slug": "spawn-transient-refusal-class-guard",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 344,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/messaging/SpawnRequestManager.ts"
+    ],
+    "addedLines": 249,
+    "deletedLines": 95
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/spawn-transient-refusal-class-guard.eli16.md
+++ b/docs/specs/spawn-transient-refusal-class-guard.eli16.md
@@ -1,0 +1,44 @@
+# Transient Spawn Refusal Class Guard — Plain-English Overview
+
+> The one-line version: a temporary “not now” answer can no longer quietly become “message deleted,” and CI now rejects any new refusal branch that forgets this rule.
+
+## The problem in one breath
+
+When one agent asks another agent for help, the receiving machine may temporarily be unable to start a worker because it is cooling down, has too many sessions, is short on memory, has exhausted a quota window, or cannot launch the worker process. Those are retryable conditions. Historically, each branch decided for itself whether to park the message, and three of six branches got that decision wrong. Two were repaired individually, but nothing stopped a seventh branch from repeating the same mistake.
+
+## What already exists
+
+- **Admission checks** — decide whether a worker may start now. Their thresholds and authority remain unchanged.
+- **A bounded holding queue** — retains refused messages while a temporary condition clears.
+- **A drain loop** — revisits retained messages on a short cadence and tries delivery again.
+- **Truthful session launch** — the lower-level launcher now distinguishes a real pre-delivery launch failure from bookkeeping trouble after the prompt already reached a live worker.
+
+## What this adds
+
+Every retryable refusal is constructed through one preservation funnel. That funnel stores the current message before returning “try later.” The final launch path also treats the existing queue transactionally: it snapshots the backlog for the outgoing prompt but does not remove those entries until the launcher confirms delivery. If launch fails, the old entries keep their original age and order, and the current message joins them at the position and age it had when launch began—not when the failure finally came back.
+
+The compiler now enforces the class rule with a private branded result type: the guarded implementation cannot return a retryable result unless it came from the preservation funnel. A structural test pins the public method to that typed implementation, permits retryable call returns only from the funnel, and rejects casts elsewhere in the class that could evade it through a helper. That is the class-level protection the branch-by-branch repairs lacked. The same test checks the real server boot path constructs this class, starts its drain loop, hands that exact instance to the Threadline router and server, and disposes it at shutdown.
+
+## The safeguards
+
+**Admission stays authoritative.** This does not weaken memory, session, cooldown, or quota checks. Their predicates, reasons, and retry intervals are unchanged.
+
+**A failed launch cannot consume the backlog.** Queue entries remain reserved while launch is in flight. Only the exact snapshot included in a successfully delivered prompt is removed, so messages arriving concurrently remain queued.
+
+**The bounded queue keeps chronological priority.** If a later refusal fills the final global slot while an earlier launch is still awaiting its result, and that launch then fails, the earlier reserved payload displaces the globally newest later entry. The queue stays at the same bound and records truncation; the delayed failure cannot make the earlier message lose the capacity it had on arrival.
+
+**One agent cannot launch twice at once.** A per-agent in-flight reservation prevents overlapping attempts from both copying and delivering the same backlog, even when cooldown is configured to zero.
+
+**A successful launch remains exactly once.** Once the launcher confirms delivery, the snapshot is committed and cannot be drained into a second worker.
+
+**Bad legacy zero-cap configuration cannot hang the process.** Degraded admission is floored at one bounded slot, and runtime updates reject zero.
+
+**The test is wired to production, not a look-alike.** It verifies the actual boot source connects the guarded manager to the Threadline router and lifecycle calls.
+
+## What ships when
+
+The preservation funnel, transactional queue snapshot, in-flight serialization, runtime regressions, compiler/AST ratchet, and production-wiring proof ship together. There is no new configuration, migration, endpoint, or rollout switch.
+
+## What you actually need to decide
+
+Approve making “retryable refusal implies queue admission before return” a structurally enforced class invariant for every `SpawnRequestManager` branch.

--- a/src/messaging/SpawnRequestManager.ts
+++ b/src/messaging/SpawnRequestManager.ts
@@ -263,6 +263,34 @@ export interface SpawnRequestManagerConfig {
   maxGlobalQueued?: number;
 }
 
+interface QueuedSpawnMessage {
+  context: string;
+  threadId?: string;
+  receivedAt: number;
+  envelopeHash: string;
+  drainAttempts: number;
+  /** Monotonic arrival order, including payloads reserved during an in-flight spawn. */
+  sequence: number;
+}
+
+declare const TRANSIENT_REFUSAL_PRESERVED: unique symbol;
+
+/**
+ * A retryable refusal that can only be constructed by the preservation
+ * funnel. The private brand makes a new retryable return branch fail
+ * type-checking unless it first passes through `#refuseTransiently`.
+ */
+type PreservedTransientRefusal = SpawnResult & {
+  approved: false;
+  retryAfterMs: number;
+  readonly [TRANSIENT_REFUSAL_PRESERVED]: true;
+};
+
+type GuardedSpawnResult =
+  | (SpawnResult & { approved: true })
+  | (SpawnResult & { approved: false; retryAfterMs?: undefined })
+  | PreservedTransientRefusal;
+
 // ── Constants ───────────────────────────────────────────────────
 
 const DEFAULT_COOLDOWN_MS = 30_000; // 30 seconds (reduced from 5 min to allow multi-message agents)
@@ -359,13 +387,13 @@ export class SpawnRequestManager {
    *   process this entry. Bumped before each drain; reset on success.
    *   Used by DRR's age-boost.
    */
-  readonly #pendingMessages = new Map<string, {
-    context: string;
-    threadId?: string;
-    receivedAt: number;
-    envelopeHash: string;
-    drainAttempts: number;
-  }[]>();
+  readonly #pendingMessages = new Map<string, QueuedSpawnMessage[]>();
+
+  /** Serialize launch attempts per agent so one backlog cannot be delivered twice. */
+  readonly #spawnInflightByAgent = new Set<string>();
+
+  /** Arrival order shared by queued and in-flight-reserved payloads. */
+  #nextQueueSequence = 0;
 
   /** Max queued messages per agent before oldest are dropped */
   static readonly MAX_QUEUED_PER_AGENT = 10;
@@ -525,7 +553,13 @@ export class SpawnRequestManager {
   /** Effective per-agent queue cap, accounting for soft-limiter degradation. */
   effectiveMaxQueuedPerAgent(agent: string): number {
     if (this.isInfraDegraded(agent)) {
-      return this.#config.degradedMaxQueuedPerAgent ?? DEGRADED_MAX_QUEUED_PER_AGENT_DEFAULT;
+      // A zero cap makes `while (queue.length >= cap)` non-terminating. Keep
+      // degraded admission bounded but live, even for a stale constructor
+      // config written before updateConfig began rejecting zero.
+      return Math.max(
+        1,
+        this.#config.degradedMaxQueuedPerAgent ?? DEGRADED_MAX_QUEUED_PER_AGENT_DEFAULT,
+      );
     }
     return SpawnRequestManager.MAX_QUEUED_PER_AGENT;
   }
@@ -536,6 +570,37 @@ export class SpawnRequestManager {
     this.#penaltyUntil.delete(agent);
   }
 
+  /**
+   * The single construction path for a retryable refusal.
+   *
+   * `retryAfterMs` means "not now", so returning it without first preserving
+   * the refused payload is a data-loss bug. Keeping construction here makes
+   * that postcondition class-wide: the structural guard test rejects any
+   * retryable-result object created elsewhere in this class.
+   *
+   * Queued backlog is not handled here: evaluate snapshots it without removal
+   * and commits that exact snapshot only after spawnSession reports delivery.
+   * A rejection therefore leaves the backlog's age and ordering untouched.
+   */
+  #refuseTransiently(
+    request: SpawnRequest,
+    reason: string,
+    retryAfterMs: number,
+    reservedPayload?: QueuedSpawnMessage,
+  ): PreservedTransientRefusal {
+    const agent = request.requester.agent;
+    if (reservedPayload) {
+      this.#admitQueuedMessage(agent, reservedPayload);
+    } else if (request.context) {
+      this.#queueMessage(agent, request.context, request.pendingMessages?.[0]);
+    }
+    return {
+      approved: false,
+      reason,
+      retryAfterMs,
+    } as PreservedTransientRefusal;
+  }
+
   // ── Public API ──────────────────────────────────────────────
 
   /**
@@ -543,6 +608,17 @@ export class SpawnRequestManager {
    * Returns the result with approval status and session info if spawned.
    */
   async evaluate(request: SpawnRequest): Promise<SpawnResult> {
+    return this.#evaluateGuarded(request);
+  }
+
+  /**
+   * Typed implementation boundary for the class-level preservation invariant.
+   *
+   * A retryable result cannot satisfy this return type unless it came from
+   * `#refuseTransiently`, whose private brand certifies use of the preservation
+   * funnel.
+   */
+  async #evaluateGuarded(request: SpawnRequest): Promise<GuardedSpawnResult> {
     const agent = request.requester.agent;
 
     // §4.3: payload byte-size cap. Refuse oversized envelopes at admission so
@@ -562,14 +638,11 @@ export class SpawnRequestManager {
     // §4.2: single-source cooldown check (covers cooldown AND penalty).
     const remainingMs = this.cooldownRemainingMs(agent);
     if (remainingMs > 0) {
-      if (request.context) {
-        this.#queueMessage(agent, request.context, request.pendingMessages?.[0]);
-      }
-      return {
-        approved: false,
-        reason: `Cooldown: ${Math.ceil(remainingMs / 1000)}s remaining before next spawn for ${agent}`,
-        retryAfterMs: remainingMs,
-      };
+      return this.#refuseTransiently(
+        request,
+        `Cooldown: ${Math.ceil(remainingMs / 1000)}s remaining before next spawn for ${agent}`,
+        remainingMs,
+      );
     }
 
     // Check session limits — prefer the live accessor over the constructor
@@ -582,39 +655,22 @@ export class SpawnRequestManager {
       : this.#config.maxSessions;
     if (activeSessions.length >= liveMaxSessions) {
       if (request.priority !== 'critical' && request.priority !== 'high') {
-        // Queue the payload, like every other transient-pressure denial here: a
-        // session cap clears as running sessions finish — this branch sets
-        // retryAfterMs itself — so the content must survive the wait.
-        if (request.context) {
-          this.#queueMessage(agent, request.context, request.pendingMessages?.[0]);
-        }
-        return {
-          approved: false,
-          reason: `Session limit reached (${activeSessions.length}/${liveMaxSessions}). Priority ${request.priority} insufficient to override.`,
-          retryAfterMs: 60_000,
-        };
+        return this.#refuseTransiently(
+          request,
+          `Session limit reached (${activeSessions.length}/${liveMaxSessions}). Priority ${request.priority} insufficient to override.`,
+          60_000,
+        );
       }
     }
 
-    // Check memory pressure. Queue the message (like cooldown and the quota
-    // gate below) rather than dropping it: memory pressure is transient — this
-    // very branch sets retryAfterMs — and the content must survive it. Before
-    // this, memory pressure was the ONLY transient-pressure denial that
-    // destroyed the payload, so an A2A dispatch arriving during a pressure
-    // window was silently deleted while both the caller (`handled: true` from
-    // ThreadlineRouter) and the remote sender (`delivered: true`) recorded
-    // success. Observed live 2026-07-29: 40 such denials on one machine in a
-    // day, oscillating across the threshold every 30-80s, each one a lost
-    // inbound message.
+    // Check memory pressure. The refusal funnel preserves the payload while
+    // the transient pressure condition clears.
     if (this.#config.isMemoryPressureHigh?.()) {
-      if (request.context) {
-        this.#queueMessage(agent, request.context, request.pendingMessages?.[0]);
-      }
-      return {
-        approved: false,
-        reason: 'Memory pressure too high for new session',
-        retryAfterMs: 120_000,
-      };
+      return this.#refuseTransiently(
+        request,
+        'Memory pressure too high for new session',
+        120_000,
+      );
     }
 
     // Subscription-quota gate (S1) — only wired when the subscription-path
@@ -624,37 +680,43 @@ export class SpawnRequestManager {
     if (this.#config.shouldSpawnSession) {
       const quota = this.#config.shouldSpawnSession(request.priority);
       if (!quota.allowed) {
-        if (request.context) {
-          this.#queueMessage(agent, request.context, request.pendingMessages?.[0]);
-        }
-        return {
-          approved: false,
-          reason: `Subscription quota gate: ${quota.reason}`,
-          retryAfterMs: 120_000,
-        };
+        return this.#refuseTransiently(
+          request,
+          `Subscription quota gate: ${quota.reason}`,
+          120_000,
+        );
       }
     }
+
+    // Cooldown can legitimately be configured to zero, so it cannot serve as
+    // the concurrency lock. Serialize per agent explicitly: otherwise two
+    // overlapping launches can snapshot and deliver the same backlog.
+    if (this.#spawnInflightByAgent.has(agent)) {
+      return this.#refuseTransiently(
+        request,
+        `Spawn already in flight for ${agent}`,
+        1_000,
+      );
+    }
+
+    // Stamp the current payload before the first await, but do not enqueue it
+    // yet: it is already present in the launch prompt. If launch fails, the
+    // exact reserved object is inserted by sequence, preserving both its
+    // original TTL and its position ahead of later concurrent arrivals.
+    const currentReservation = request.context
+      ? this.#makeQueuedMessage(request.context, request.pendingMessages?.[0])
+      : undefined;
+    this.#spawnInflightByAgent.add(agent);
 
     // §4.2: failure-suppressive reservation. Stamp `lastSpawnByAgent` BEFORE
     // the async spawn, and do NOT roll back on failure. A peer that triggers
     // fast-failing spawns still pays the cooldown.
     this.#lastSpawnByAgent.set(agent, this.#nowFn());
 
-    // NOTE (deliberately NOT restoring these on failure — see below): #drainQueue
-    // empties the queue here because the prompt has to carry the payloads, so a
-    // spawn that throws destroys them. That is a real defect, but the obvious fix
-    // — put them back in the catch — is UNSAFE against the real `spawnSession`
-    // implementation: SessionManager.spawnSession creates the live tmux session
-    // WITH the prompt, and only afterwards calls state.saveSession() outside any
-    // try/catch. A throw from that bookkeeping step means the payloads were
-    // already DELIVERED, so re-queueing them would deliver the same instruction
-    // to a second live session. Restoring here would trade a rare lost message
-    // for a rare duplicated one, which is worse — a duplicate can act twice.
-    // The prerequisite is making spawnSession stop reporting failure once the
-    // session is live and holding the prompt. Tracked: CMT-1114.
+    let queuedSnapshot: QueuedSpawnMessage[] = [];
     try {
-      const queuedMessages = this.#drainQueue(agent);
-      const prompt = this.#buildSpawnPrompt(request, queuedMessages);
+      queuedSnapshot = this.#snapshotQueue(agent);
+      const prompt = this.#buildSpawnPrompt(request, queuedSnapshot);
       const spawned = await this.#config.spawnSession(prompt, {
         model: request.suggestedModel,
         maxDurationMinutes: request.suggestedMaxDuration,
@@ -669,6 +731,10 @@ export class SpawnRequestManager {
         // Undefined on every non-warm spawn → headless behavior unchanged.
         interactive: request.interactive,
       });
+      // spawnSession's contract is now delivery-truthful: resolution means the
+      // prompt reached a live session. Remove only the entries in this prompt;
+      // messages arriving while spawnSession was in flight remain queued.
+      this.#commitQueueSnapshot(agent, queuedSnapshot);
       // Accept both the legacy bare-id return and the {sessionId, tmuxSession}
       // object form. The tmuxSession (when provided) is forwarded so callers
       // (spawnNewThread) persist the REAL tmux name as the resume entry's
@@ -690,14 +756,14 @@ export class SpawnRequestManager {
     } catch (err) {
       const cause = this.#classifyFailure(err);
       this.#applyFailureAttribution(agent, cause);
-      // Deliberately NOT re-queueing here. A `spawnSession` rejection does not
-      // prove non-delivery (see the note above the try), so putting the payload
-      // back risks delivering the same instruction twice. Tracked: CMT-1114.
-      return {
-        approved: false,
-        reason: `Spawn failed (${cause}): ${err instanceof Error ? err.message : 'unknown error'}`,
-        retryAfterMs: 30_000,
-      };
+      return this.#refuseTransiently(
+        request,
+        `Spawn failed (${cause}): ${err instanceof Error ? err.message : 'unknown error'}`,
+        30_000,
+        currentReservation,
+      );
+    } finally {
+      this.#spawnInflightByAgent.delete(agent);
     }
   }
 
@@ -768,18 +834,64 @@ export class SpawnRequestManager {
    * global cap. (Per-agent truncation still queues the new entry.)
    */
   #queueMessage(agent: string, context: string, threadId?: string): boolean {
+    return this.#admitQueuedMessage(agent, this.#makeQueuedMessage(context, threadId));
+  }
+
+  /**
+   * Construct queue metadata at message arrival rather than eventual
+   * admission. In-flight payloads use this to retain their original TTL and
+   * order if the launch fails after later messages have arrived.
+   */
+  #makeQueuedMessage(context: string, threadId?: string): QueuedSpawnMessage {
+    return {
+      context,
+      threadId,
+      receivedAt: this.#nowFn(),
+      envelopeHash: computeEnvelopeHash({ context, threadId }),
+      drainAttempts: 0,
+      sequence: this.#nextQueueSequence++,
+    };
+  }
+
+  /** Admit a fully stamped payload while preserving monotonic arrival order. */
+  #admitQueuedMessage(agent: string, message: QueuedSpawnMessage): boolean {
     // §4.3 global cap: refuse new enqueues when total queued is at the
     // global limit. Computed before any local mutation.
     const maxGlobal = this.#config.maxGlobalQueued ?? DEFAULT_MAX_GLOBAL_QUEUED;
     let totalQueued = 0;
     for (const q of this.#pendingMessages.values()) totalQueued += q.length;
     if (totalQueued >= maxGlobal) {
-      // Mark the agent truncated before refusing. Callers discard this boolean
-      // (all five callsites are `if (request.context) { #queueMessage(...) }`),
-      // so without the marker a global-cap refusal was the one queue loss with
-      // NO trace at all — indistinguishable from a successful enqueue, which is
-      // the same silent-loss shape this whole area is being fixed for. The
-      // per-agent cap below already sets it; this makes the global cap match.
+      // A launch payload is stamped before its await and may be admitted only
+      // after a later in-flight refusal has filled the final slot. Preserve the
+      // bounded queue's chronological policy: an earlier reserved payload
+      // displaces the globally newest later arrival; an actually newer payload
+      // remains refused as before.
+      let newest: { agent: string; entry: QueuedSpawnMessage } | undefined;
+      for (const [queuedAgent, queued] of this.#pendingMessages) {
+        for (const entry of queued) {
+          if (!newest || entry.sequence > newest.entry.sequence) {
+            newest = { agent: queuedAgent, entry };
+          }
+        }
+      }
+      if (newest && message.sequence < newest.entry.sequence) {
+        const newestQueue = this.#pendingMessages.get(newest.agent);
+        const newestIndex = newestQueue?.indexOf(newest.entry) ?? -1;
+        if (newestQueue && newestIndex >= 0) {
+          newestQueue.splice(newestIndex, 1);
+          if (newestQueue.length === 0) {
+            this.#pendingMessages.delete(newest.agent);
+          }
+          this.#truncated.add(newest.agent);
+          totalQueued--;
+        }
+      }
+    }
+    if (totalQueued >= maxGlobal) {
+      // Mark the agent truncated before refusing. The preservation funnel does
+      // not surface this internal boolean, so without the marker a global-cap
+      // refusal would leave no trace. The per-agent cap below already sets it;
+      // this makes the global cap match.
       this.#truncated.add(agent);
       return false;
     }
@@ -792,6 +904,7 @@ export class SpawnRequestManager {
 
     const now = this.#nowFn();
     const maxAge = SpawnRequestManager.QUEUE_MAX_AGE_MS;
+    queue.sort((a, b) => a.sequence - b.sequence);
     while (queue.length > 0 && now - queue[0].receivedAt > maxAge) {
       queue.shift();
     }
@@ -799,6 +912,12 @@ export class SpawnRequestManager {
     // §4.2 infra soft limiter + §4.3 truncation marker.
     // Per-agent cap (degraded if soft-limited). Drop oldest on overflow.
     const cap = this.effectiveMaxQueuedPerAgent(agent);
+    if (cap <= 0) {
+      // Defensive backstop for future cap sources; effective config currently
+      // floors degraded admission at one.
+      this.#truncated.add(agent);
+      return false;
+    }
     let truncatedAny = false;
     while (queue.length >= cap) {
       queue.shift();
@@ -806,13 +925,8 @@ export class SpawnRequestManager {
     }
     if (truncatedAny) this.#truncated.add(agent);
 
-    queue.push({
-      context,
-      threadId,
-      receivedAt: now,
-      envelopeHash: computeEnvelopeHash({ context, threadId }),
-      drainAttempts: 0,
-    });
+    queue.push(message);
+    queue.sort((a, b) => a.sequence - b.sequence);
     return true;
   }
 
@@ -821,8 +935,14 @@ export class SpawnRequestManager {
     return this.#truncated.has(agent);
   }
 
-  /** Drain all queued messages for an agent */
-  #drainQueue(agent: string): { context: string; threadId?: string }[] {
+  /**
+   * Snapshot the currently valid queue without removing it.
+   *
+   * The snapshot stays reserved while spawnSession is in flight. This prevents
+   * another sender from consuming the temporarily freed global capacity and
+   * preserves each entry's original TTL/order if launch fails.
+   */
+  #snapshotQueue(agent: string): QueuedSpawnMessage[] {
     const queue = this.#pendingMessages.get(agent);
     if (!queue || queue.length === 0) {
       this.#truncated.delete(agent); // empty queue can't claim "truncated"
@@ -832,9 +952,38 @@ export class SpawnRequestManager {
     const now = this.#nowFn();
     const maxAge = SpawnRequestManager.QUEUE_MAX_AGE_MS;
     const valid = queue.filter(m => now - m.receivedAt < maxAge);
-    this.#pendingMessages.delete(agent);
-    this.#truncated.delete(agent); // §4.3: drain clears the marker
-    return valid;
+    if (valid.length === 0) {
+      this.#pendingMessages.delete(agent);
+      this.#truncated.delete(agent);
+      return [];
+    }
+    if (valid.length !== queue.length) {
+      this.#pendingMessages.set(agent, valid);
+    }
+    return [...valid];
+  }
+
+  /**
+   * Commit exactly the queue entries included in a delivered prompt.
+   *
+   * Object identity is deliberate: entries appended while spawnSession awaited
+   * may carry identical content/hash but represent separate inbound messages.
+   */
+  #commitQueueSnapshot(
+    agent: string,
+    delivered: QueuedSpawnMessage[],
+  ): void {
+    if (delivered.length === 0) return;
+    const queue = this.#pendingMessages.get(agent);
+    if (!queue || queue.length === 0) return;
+    const deliveredEntries = new Set(delivered);
+    const remaining = queue.filter((entry) => !deliveredEntries.has(entry));
+    if (remaining.length === 0) {
+      this.#pendingMessages.delete(agent);
+      this.#truncated.delete(agent);
+      return;
+    }
+    this.#pendingMessages.set(agent, remaining);
   }
 
   /** Get count of queued messages for an agent (for monitoring) */
@@ -1043,7 +1192,10 @@ export class SpawnRequestManager {
       maxDrainsPerTick: this.#config.maxDrainsPerTick ?? DRAIN_MAX_PER_TICK_DEFAULT,
       maxEnvelopeBytes: this.#config.maxEnvelopeBytes ?? DEFAULT_MAX_ENVELOPE_BYTES,
       maxGlobalQueued: this.#config.maxGlobalQueued ?? DEFAULT_MAX_GLOBAL_QUEUED,
-      degradedMaxQueuedPerAgent: this.#config.degradedMaxQueuedPerAgent ?? DEGRADED_MAX_QUEUED_PER_AGENT_DEFAULT,
+      degradedMaxQueuedPerAgent: Math.max(
+        1,
+        this.#config.degradedMaxQueuedPerAgent ?? DEGRADED_MAX_QUEUED_PER_AGENT_DEFAULT,
+      ),
       drainTickMs: this.getDrainTickMs(),
     };
   }
@@ -1072,7 +1224,7 @@ export class SpawnRequestManager {
       ['maxDrainsPerTick', v => v >= 1 && Number.isFinite(v) && Number.isInteger(v)],
       ['maxEnvelopeBytes', v => v >= 1 && Number.isFinite(v) && Number.isInteger(v)],
       ['maxGlobalQueued', v => v >= 0 && Number.isFinite(v) && Number.isInteger(v)],
-      ['degradedMaxQueuedPerAgent', v => v >= 0 && Number.isFinite(v) && Number.isInteger(v)],
+      ['degradedMaxQueuedPerAgent', v => v >= 1 && Number.isFinite(v) && Number.isInteger(v)],
     ];
     for (const [k, ok] of validators) {
       const v = patch[k];
@@ -1105,5 +1257,7 @@ export class SpawnRequestManager {
     this.#drainAttempts.clear();
     this.#infraFailureWindow.clear();
     this.#truncated.clear();
+    this.#spawnInflightByAgent.clear();
+    this.#nextQueueSequence = 0;
   }
 }

--- a/tests/unit/spawn-request-manager-class-guard.test.ts
+++ b/tests/unit/spawn-request-manager-class-guard.test.ts
@@ -1,0 +1,215 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const managerPath = path.join(repoRoot, 'src/messaging/SpawnRequestManager.ts');
+const serverPath = path.join(repoRoot, 'src/commands/server.ts');
+
+function propertyName(node: ts.ObjectLiteralElementLike): string | null {
+  if (!('name' in node) || !node.name) return null;
+  if (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name)) return node.name.text;
+  return node.name.getText();
+}
+
+function callTarget(node: ts.CallExpression, sourceFile: ts.SourceFile): string {
+  return node.expression.getText(sourceFile);
+}
+
+function guardedReturnViolations(
+  guardedEvaluate: ts.MethodDeclaration,
+  sourceFile: ts.SourceFile,
+): number[] {
+  const violations: number[] = [];
+  const inspect = (node: ts.Node): void => {
+    // A nested callback's return type is independent of #evaluateGuarded.
+    if (node !== guardedEvaluate && ts.isFunctionLike(node)) return;
+    if (ts.isReturnStatement(node)) {
+      const expression = node.expression;
+      const validFunnelCall = expression
+        && ts.isCallExpression(expression)
+        && callTarget(expression, sourceFile) === 'this.#refuseTransiently';
+      const validFinalObject = expression
+        && ts.isObjectLiteralExpression(expression)
+        && !expression.properties.some(ts.isSpreadAssignment)
+        && expression.properties.some((property) =>
+          ts.isPropertyAssignment(property)
+          && propertyName(property) === 'approved'
+          && (
+            property.initializer.kind === ts.SyntaxKind.TrueKeyword
+            || property.initializer.kind === ts.SyntaxKind.FalseKeyword
+          ));
+      if (!validFunnelCall && !validFinalObject) {
+        violations.push(sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1);
+      }
+    }
+    ts.forEachChild(node, inspect);
+  };
+  inspect(guardedEvaluate);
+  return violations;
+}
+
+describe('SpawnRequestManager transient-refusal class guard', () => {
+  it('funnels every retryable refusal through payload preservation and wires that guarded class in production', () => {
+    const managerSource = fs.readFileSync(managerPath, 'utf8');
+    const sourceFile = ts.createSourceFile(
+      managerPath,
+      managerSource,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+
+    const managerClass = sourceFile.statements.find(
+      (statement): statement is ts.ClassDeclaration =>
+        ts.isClassDeclaration(statement) && statement.name?.text === 'SpawnRequestManager',
+    );
+    expect(managerClass).toBeDefined();
+
+    const method = (name: string): ts.MethodDeclaration | undefined =>
+      managerClass!.members.find(
+        (member): member is ts.MethodDeclaration =>
+          ts.isMethodDeclaration(member) && member.name.getText(sourceFile) === name,
+      );
+    const publicEvaluate = method('evaluate');
+    const guardedEvaluate = method('#evaluateGuarded');
+    const preservationFunnel = method('#refuseTransiently');
+    expect(publicEvaluate).toBeDefined();
+    expect(guardedEvaluate).toBeDefined();
+    expect(preservationFunnel).toBeDefined();
+
+    const publicReturns: ts.ReturnStatement[] = [];
+    const collectPublicReturns = (node: ts.Node): void => {
+      if (ts.isReturnStatement(node)) publicReturns.push(node);
+      ts.forEachChild(node, collectPublicReturns);
+    };
+    collectPublicReturns(publicEvaluate!);
+    expect(publicReturns).toHaveLength(1);
+    expect(publicReturns[0].expression && ts.isCallExpression(publicReturns[0].expression)).toBe(true);
+    expect(callTarget(publicReturns[0].expression as ts.CallExpression, sourceFile)).toBe('this.#evaluateGuarded');
+
+    // TypeScript's private GuardedSpawnResult brand is the non-bypassable part:
+    // a computed key, Object.assign, imported helper, or prebuilt SpawnResult
+    // cannot satisfy #evaluateGuarded's return type. This AST assertion pins
+    // the public method to that typed funnel and forbids type assertions inside
+    // the guarded method that could cast around the compiler.
+    const unsafeAssertions: number[] = [];
+    const directRetryableObjects: number[] = [];
+    const inspectGuarded = (node: ts.Node): void => {
+      if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node)) {
+        unsafeAssertions.push(sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1);
+      }
+      if (
+        ts.isObjectLiteralExpression(node)
+        && node.properties.some((property) => propertyName(property) === 'retryAfterMs')
+      ) {
+        directRetryableObjects.push(sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1);
+      }
+      ts.forEachChild(node, inspectGuarded);
+    };
+    inspectGuarded(guardedEvaluate!);
+    expect(unsafeAssertions).toEqual([]);
+    expect(directRetryableObjects).toEqual([]);
+    expect(guardedReturnViolations(guardedEvaluate!, sourceFile)).toEqual([]);
+
+    // The only cast to either private guard type may be the factory's single
+    // brand construction. A helper elsewhere cannot cast or widen itself into
+    // a retryable result and then hide behind an indirect return call.
+    const brandedCasts: Array<{ method: string | undefined; type: string }> = [];
+    const inspectBrandedCasts = (node: ts.Node, method?: string): void => {
+      const currentMethod = ts.isMethodDeclaration(node)
+        ? node.name.getText(sourceFile)
+        : method;
+      if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node)) {
+        const type = node.type.getText(sourceFile);
+        if (type === 'PreservedTransientRefusal' || type === 'GuardedSpawnResult') {
+          brandedCasts.push({ method: currentMethod, type });
+        }
+      }
+      ts.forEachChild(node, (child) => inspectBrandedCasts(child, currentMethod));
+    };
+    inspectBrandedCasts(managerClass!);
+    expect(brandedCasts).toEqual([
+      { method: '#refuseTransiently', type: 'PreservedTransientRefusal' },
+    ]);
+
+    const serverSource = fs.readFileSync(serverPath, 'utf8');
+    const serverFile = ts.createSourceFile(
+      serverPath,
+      serverSource,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    let constructsManager = 0;
+    let routesManager = 0;
+    let startsManager = 0;
+    let disposesManager = 0;
+    let givesManagerToServer = 0;
+    const inspectServer = (node: ts.Node): void => {
+      if (
+        ts.isBinaryExpression(node)
+        && node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+        && node.left.getText(serverFile) === 'spawnManager'
+        && ts.isNewExpression(node.right)
+        && node.right.expression.getText(serverFile) === 'SpawnRequestManager'
+      ) constructsManager++;
+      if (
+        ts.isNewExpression(node)
+        && node.expression.getText(serverFile) === 'ThreadlineRouter'
+        && node.arguments?.some((argument) => argument.getText(serverFile) === 'spawnManager')
+      ) routesManager++;
+      if (ts.isCallExpression(node) && callTarget(node, serverFile) === 'spawnManager.start') startsManager++;
+      if (ts.isCallExpression(node) && callTarget(node, serverFile) === 'spawnManager.dispose') disposesManager++;
+      if (
+        ts.isNewExpression(node)
+        && node.expression.getText(serverFile) === 'AgentServer'
+        && node.arguments?.some((argument) =>
+          ts.isObjectLiteralExpression(argument)
+          && argument.properties.some((property) => propertyName(property) === 'spawnManager'))
+      ) givesManagerToServer++;
+      ts.forEachChild(node, inspectServer);
+    };
+    inspectServer(serverFile);
+    expect(constructsManager).toBe(1);
+    expect(routesManager).toBe(1);
+    expect(startsManager).toBe(1);
+    expect(disposesManager).toBe(1);
+    expect(givesManagerToServer).toBe(1);
+  });
+
+  it('rejects retryable helper indirection outside the guarded method', () => {
+    const managerSource = fs.readFileSync(managerPath, 'utf8');
+    const mutatedSource = managerSource
+      .replace(
+        '  // ── Public API',
+        `  #retryableBypass(): any {
+    return { approved: false, retryAfterMs: 1 };
+  }
+
+  // ── Public API`,
+      )
+      .replace(
+        'return this.#refuseTransiently(',
+        'return this.#retryableBypass(',
+      );
+    const sourceFile = ts.createSourceFile(
+      managerPath,
+      mutatedSource,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const managerClass = sourceFile.statements.find(
+      (statement): statement is ts.ClassDeclaration =>
+        ts.isClassDeclaration(statement) && statement.name?.text === 'SpawnRequestManager',
+    );
+    const guardedEvaluate = managerClass!.members.find(
+      (member): member is ts.MethodDeclaration =>
+        ts.isMethodDeclaration(member) && member.name.getText(sourceFile) === '#evaluateGuarded',
+    );
+
+    expect(guardedReturnViolations(guardedEvaluate!, sourceFile)).not.toEqual([]);
+  });
+});

--- a/tests/unit/spawn-request-manager.test.ts
+++ b/tests/unit/spawn-request-manager.test.ts
@@ -487,6 +487,196 @@ describe('SpawnRequestManager', () => {
       expect(result.reason).toContain('unknown error');
     });
 
+    it('preserves refused-payload ordering and original TTL after a true pre-delivery spawn failure', async () => {
+      let underPressure = true;
+      let now = 1_000_000;
+      let rejectLaunch: ((reason?: unknown) => void) | undefined;
+      const spawnSession = vi.fn()
+        .mockImplementationOnce(() => new Promise<string>((_resolve, reject) => {
+          rejectLaunch = reject;
+        }))
+        .mockResolvedValueOnce('spawned-session-id');
+      config = makeConfig({
+        cooldownMs: 1_000,
+        isMemoryPressureHigh: () => underPressure,
+        spawnSession,
+        nowFn: () => now,
+      });
+      manager = new SpawnRequestManager(config);
+
+      const initiallyRefused = await manager.evaluate(
+        makeRequest({ context: 'older payload already waiting' }),
+      );
+      expect(initiallyRefused.approved).toBe(false);
+      expect(manager.getQueuedCount('agent-a')).toBe(1);
+
+      underPressure = false;
+      now += 100;
+      const failedSpawnPromise = manager.evaluate(
+        makeRequest({ context: 'current payload refused by failed spawn' }),
+      );
+      expect(rejectLaunch).toBeTypeOf('function');
+
+      // This arrives while the launch is in flight. The pre-existing backlog
+      // must remain reserved rather than temporarily freeing queue capacity.
+      now += 100;
+      const concurrent = await manager.evaluate(
+        makeRequest({ context: 'payload arriving during launch' }),
+      );
+      expect(concurrent.approved).toBe(false);
+      expect(manager.getQueuedCount('agent-a')).toBe(2);
+
+      rejectLaunch!(new Error('tmux launch failed before delivery'));
+      const failedSpawn = await failedSpawnPromise;
+      expect(failedSpawn.approved).toBe(false);
+      expect(failedSpawn.retryAfterMs).toBe(30_000);
+      expect(manager.getQueuedCount('agent-a')).toBe(3);
+
+      now += 1_100;
+      const recovered = await manager.evaluate(makeRequest());
+      expect(recovered.approved).toBe(true);
+      expect(spawnSession).toHaveBeenCalledTimes(2);
+      const recoveredPrompt = spawnSession.mock.calls[1][0] as string;
+      const olderAt = recoveredPrompt.indexOf('older payload already waiting');
+      const currentAt = recoveredPrompt.indexOf('current payload refused by failed spawn');
+      const concurrentAt = recoveredPrompt.indexOf('payload arriving during launch');
+      expect(olderAt).toBeGreaterThanOrEqual(0);
+      expect(currentAt).toBeGreaterThan(olderAt);
+      expect(concurrentAt).toBeGreaterThan(currentAt);
+      expect(manager.getQueuedCount('agent-a')).toBe(0);
+
+      // The reservation's TTL starts when launch starts, not when its failure
+      // is eventually reported. A later message is still live in this narrow
+      // window, while the failed launch's current payload has expired.
+      let ttlNow = 2_000_000;
+      let rejectTtlLaunch: ((reason?: unknown) => void) | undefined;
+      const ttlSpawn = vi.fn()
+        .mockImplementationOnce(() => new Promise<string>((_resolve, reject) => {
+          rejectTtlLaunch = reject;
+        }))
+        .mockResolvedValueOnce('ttl-recovery');
+      const ttlManager = new SpawnRequestManager(makeConfig({
+        cooldownMs: 0,
+        nowFn: () => ttlNow,
+        spawnSession: ttlSpawn,
+      }));
+      const ttlLaunchStartedAt = ttlNow;
+      const ttlFailure = ttlManager.evaluate(
+        makeRequest({ context: 'failed launch payload with original age' }),
+      );
+      ttlNow += 100;
+      await ttlManager.evaluate(
+        makeRequest({ context: 'later payload still inside ttl' }),
+      );
+      ttlNow += 100;
+      rejectTtlLaunch!(new Error('failed before delivery'));
+      expect((await ttlFailure).approved).toBe(false);
+
+      ttlNow = ttlLaunchStartedAt + SpawnRequestManager.QUEUE_MAX_AGE_MS + 1;
+      expect((await ttlManager.evaluate(makeRequest())).approved).toBe(true);
+      const ttlPrompt = ttlSpawn.mock.calls[1][0] as string;
+      expect(ttlPrompt).not.toContain('failed launch payload with original age');
+      expect(ttlPrompt).toContain('later payload still inside ttl');
+    });
+
+    it('serializes same-agent launches so an overlapping success cannot deliver one backlog twice', async () => {
+      let underPressure = true;
+      let resolveFirstLaunch: ((sessionId: string) => void) | undefined;
+      const spawnSession = vi.fn()
+        .mockImplementationOnce(() => new Promise<string>((resolve) => {
+          resolveFirstLaunch = resolve;
+        }))
+        .mockResolvedValue('later-session');
+      const mgr = new SpawnRequestManager(makeConfig({
+        cooldownMs: 0,
+        isMemoryPressureHigh: () => underPressure,
+        spawnSession,
+      }));
+
+      await mgr.evaluate(makeRequest({ context: 'single backlog payload' }));
+      expect(mgr.getQueuedCount('agent-a')).toBe(1);
+
+      underPressure = false;
+      const firstLaunch = mgr.evaluate(makeRequest());
+      expect(resolveFirstLaunch).toBeTypeOf('function');
+
+      const overlapping = await mgr.evaluate(
+        makeRequest({ context: 'arrived during first launch' }),
+      );
+      expect(overlapping.approved).toBe(false);
+      expect(overlapping.reason).toContain('already in flight');
+      expect(spawnSession).toHaveBeenCalledTimes(1);
+
+      resolveFirstLaunch!('first-session');
+      expect((await firstLaunch).approved).toBe(true);
+      expect(spawnSession.mock.calls[0][0]).toContain('single backlog payload');
+      expect(mgr.getQueuedCount('agent-a')).toBe(1);
+
+      const later = await mgr.evaluate(makeRequest());
+      expect(later.approved).toBe(true);
+      expect(spawnSession).toHaveBeenCalledTimes(2);
+      expect(spawnSession.mock.calls[1][0]).toContain('arrived during first launch');
+      expect(spawnSession.mock.calls[1][0]).not.toContain('single backlog payload');
+      expect(mgr.getQueuedCount('agent-a')).toBe(0);
+    });
+
+    it('keeps the earlier failed-launch payload when a later overlap fills the global queue', async () => {
+      let rejectLaunch: ((reason?: unknown) => void) | undefined;
+      const spawnSession = vi.fn()
+        .mockImplementationOnce(() => new Promise<string>((_resolve, reject) => {
+          rejectLaunch = reject;
+        }))
+        .mockResolvedValueOnce('recovered-session');
+      const mgr = new SpawnRequestManager(makeConfig({
+        cooldownMs: 0,
+        maxGlobalQueued: 1,
+        spawnSession,
+      }));
+
+      const failedLaunch = mgr.evaluate(
+        makeRequest({ context: 'earlier payload reserved by launch' }),
+      );
+      expect(rejectLaunch).toBeTypeOf('function');
+
+      const overlap = await mgr.evaluate(
+        makeRequest({ context: 'later payload filling final queue slot' }),
+      );
+      expect(overlap.approved).toBe(false);
+      expect(mgr.getQueuedCount('agent-a')).toBe(1);
+
+      rejectLaunch!(new Error('failed before delivery'));
+      expect((await failedLaunch).approved).toBe(false);
+      expect(mgr.getQueuedCount('agent-a')).toBe(1);
+
+      expect((await mgr.evaluate(makeRequest())).approved).toBe(true);
+      const recoveredPrompt = spawnSession.mock.calls[1][0] as string;
+      expect(recoveredPrompt).toContain('earlier payload reserved by launch');
+      expect(recoveredPrompt).not.toContain('later payload filling final queue slot');
+    });
+
+    it('treats a zero degraded queue cap as a bounded one-slot floor instead of looping', async () => {
+      const spawnSession = vi.fn().mockRejectedValue(new Error('provider unavailable'));
+      const mgr = new SpawnRequestManager(makeConfig({
+        cooldownMs: 0,
+        degradedMaxQueuedPerAgent: 0,
+        spawnSession,
+      }));
+
+      // Five no-context failures trip degraded admission without touching the
+      // queue, so the unfixed zero-cap implementation fails safely at the next
+      // assertion instead of entering its synchronous infinite loop.
+      for (let i = 0; i < 5; i++) {
+        const result = await mgr.evaluate(makeRequest());
+        expect(result.approved).toBe(false);
+      }
+      expect(mgr.isInfraDegraded('agent-a')).toBe(true);
+      expect(mgr.effectiveMaxQueuedPerAgent('agent-a')).toBe(1);
+
+      const refused = await mgr.evaluate(makeRequest({ context: 'bounded payload' }));
+      expect(refused.approved).toBe(false);
+      expect(mgr.getQueuedCount('agent-a')).toBe(1);
+    });
+
 
     // Control on the queueing fix: a payload rescued from a pressure denial must
     // be delivered EXACTLY once — drained into the successful spawn's prompt and

--- a/upgrades/next/spawn-transient-refusal-class-guard.md
+++ b/upgrades/next/spawn-transient-refusal-class-guard.md
@@ -1,0 +1,31 @@
+# Transient spawn refusals now preserve their payload by construction
+
+## What Changed
+
+Every retryable refusal in `SpawnRequestManager` now passes through one preservation funnel before it returns. Cooldown, session-cap, memory-pressure, subscription-quota, and real pre-delivery launch failures keep their exact existing verdicts and retry intervals; the difference is that their inbound context is admitted to the existing retry queue rather than relying on branch authors to remember the same bookkeeping.
+
+The launch path is now transactional around queued messages. It snapshots the backlog for the outgoing prompt but leaves those entries in the queue until `spawnSession` confirms delivery. A launch rejection leaves the backlog's original timestamps and order untouched, and the current refused payload joins it using the timestamp and sequence reserved when launch began. If a later arrival filled the final global queue slot while launch awaited, chronological reconciliation evicts that globally newest arrival for the earlier reservation while keeping the configured bound. A successful launch removes only the exact snapshot it delivered, so messages arriving during launch remain queued.
+
+A per-agent in-flight reservation prevents two overlapping launches from delivering the same backlog when cooldown is zero. Degraded queue admission also floors legacy zero-cap configuration at one bounded slot, preventing the former non-terminating overflow loop.
+
+A private branded TypeScript result makes direct retryable returns fail compilation; an AST ratchet pins the public method to that typed implementation, permits retryable call returns only from `#refuseTransiently`, and forbids branded casts elsewhere in the class. A mutation regression proves an `any`-returning helper cannot bypass the rule. The same test verifies the production server constructs this guarded class, starts the drain loop, passes that exact instance to `ThreadlineRouter` and `AgentServer`, and disposes it at shutdown.
+
+## What to Tell Your User
+
+Temporary worker-start failures no longer eat agent-to-agent messages. A refused message waits for the next delivery attempt, and this is now enforced across the whole class rather than repaired one branch at a time.
+
+## Summary of New Capabilities
+
+No new user-facing capability, endpoint, flag, or configuration. This is a reliability invariant and CI regression guard for existing Threadline delivery.
+
+## Evidence
+
+- Every new regression ran on the unfixed source first and failed for the intended reasons:
+  - the real launch-failure regression found zero retained payloads where two were required;
+  - the class ratchet found five retryable returns bypassing a preservation funnel.
+  - reviewer-strengthened checks exposed reordered concurrent arrivals, duplicate overlapping launch admission, the zero-cap loop precondition, and the missing typed guard.
+  - re-review-strengthened checks exposed final-slot global-cap loss of the earlier reservation and an `any`-helper bypass of the first branded ratchet.
+- Fixed focused run: 89/89 tests.
+- Adjacent subscription-quota, Threadline, relay, admission, and messaging-route run: 166/166 tests.
+- `npm run lint`, including TypeScript typecheck and the full lint chain: pass.
+- Production wiring assertions cover constructor, router/server handoff, drain-loop start, and shutdown disposal.

--- a/upgrades/side-effects/spawn-transient-refusal-class-guard.md
+++ b/upgrades/side-effects/spawn-transient-refusal-class-guard.md
@@ -1,0 +1,157 @@
+# Side-Effects Review — transient spawn refusal class guard
+
+**Version / slug:** `spawn-transient-refusal-class-guard`
+**Date:** `2026-07-30`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `Locke (independent Codex review)`
+
+## Summary of the change
+
+`SpawnRequestManager.evaluate()` now delegates to a privately typed `#evaluateGuarded` implementation. Every retryable refusal in that implementation must satisfy a branded result type that only `#refuseTransiently` constructs; the funnel admits the current context to the existing bounded queue before returning the original denial. The spawn path snapshots queued entries without deleting them, passes that snapshot into the prompt, and commits only those exact object identities after `spawnSession` resolves. A real pre-delivery launch rejection therefore leaves the old backlog intact and queues the current request with its launch-start timestamp and sequence. If a later arrival occupied the final global slot during the await, global admission reconciles by sequence and displaces the globally newest later entry for the earlier reservation without exceeding the bound. A per-agent in-flight reservation prevents overlapping launches from delivering one snapshot twice. `tests/unit/spawn-request-manager-class-guard.test.ts` pins the public method to the typed implementation, permits call returns only from the preservation funnel, forbids branded casts elsewhere in the class, exercises an `any`-helper mutation, and checks the production server constructs, starts, routes, exposes, and disposes this exact manager.
+
+Files touched:
+
+- `src/messaging/SpawnRequestManager.ts` — typed preservation funnel, transactional queue snapshot/commit, sequence reservation, and per-agent in-flight serialization.
+- `tests/unit/spawn-request-manager.test.ts` — real pre-delivery failure, ordering/TTL, overlap, final-global-slot reconciliation, and zero-cap regressions.
+- `tests/unit/spawn-request-manager-class-guard.test.ts` — class-wide AST ratchet and production-wiring proof.
+- `docs/specs/spawn-transient-refusal-class-guard.eli16.md` — Tier-1 plain-English review surface.
+- `upgrades/next/spawn-transient-refusal-class-guard.md` — release fragment.
+
+## Decision-point inventory
+
+- `SpawnRequestManager.evaluate()` admission checks — **pass-through** — cooldown, session cap, memory pressure, subscription quota, and launch-failure predicates/verdicts are unchanged.
+- `#refuseTransiently()` — **add** — mechanical postcondition for an already-made retryable decision; it has no authority to classify a request or relax a gate.
+- `#spawnInflightByAgent` — **add** — a mechanical per-agent mutex after all admission decisions, preventing duplicate delivery without changing who may eventually spawn.
+- queue snapshot commit after `spawnSession` resolution — **modify** — removes only payloads whose prompt has been reported delivered.
+- degraded queue cap normalization — **modify** — stale constructor value zero is floored to one and new runtime updates reject zero, preventing a non-terminating overflow loop.
+
+---
+
+## 1. Over-block
+
+No admission authority changes. Every pre-existing refusal returns the same `approved`, `reason`, and `retryAfterMs` values as before. An overlapping same-agent launch is now serialized with a retryable refusal; without this mechanical lock, cooldown zero allowed both attempts to deliver the same queued instructions.
+
+The existing global/per-agent queue bounds still apply. Ordinary new arrivals at the global cap are refused and set the existing truncation marker. The only reconciliation case is a payload stamped earlier but admitted later because its launch was in flight: it displaces the globally newest later entry, marks that entry's agent truncated, and leaves total depth unchanged. This preserves chronological priority without weakening the ceiling.
+
+---
+
+## 2. Under-block
+
+This guard defines “retryable” mechanically as a `SpawnResult` carrying `retryAfterMs`. The private brand and guarded return union make a new retryable result fail type-checking unless it uses the funnel. The AST half constrains every guarded return to either a final literal result or a direct `this.#refuseTransiently` call, forbids assertions inside the guarded method, and permits branded casts across the class only at the funnel's single construction point. A mutation test injects an `any`-returning private helper and proves the ratchet rejects it. A future refusal that is conceptually temporary and omits `retryAfterMs` would still be treated as permanent; reviewers must ensure temporary decisions expose retry semantics.
+
+The queue remains process-local and a server restart can still lose admitted entries. That is tracked as `CMT-1112`; the current change closes branch drift, not persistence. <!-- tracked: CMT-1112 -->
+
+The remote sender is not yet given an end-to-end receipt distinguishing “spawned now” from “accepted into retry queue” or “queue cap refused admission.” That contract correction is tracked as `CMT-1111`. <!-- tracked: CMT-1111 -->
+
+---
+
+## 3. Level-of-abstraction fit
+
+The invariant belongs inside `SpawnRequestManager`, the one class that owns all five retryable outcomes and the queue they must feed. Putting it in `ThreadlineRouter` would require the router to reinterpret reason strings and duplicate admission knowledge. Putting it in each detector repeats the defect: another branch can forget.
+
+The compiler brand is intentionally class-scoped and is the non-bypassable enforcement. The AST ratchet pins the production method shape and blocks casts around that brand, while ordinary behavioral tests prove the funnel actually preserves and later drains content.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no new block/allow surface.
+
+Cooldown, session-count, memory-pressure, subscription-quota, and launch-result producers remain the existing authorities. `#refuseTransiently` consumes their already-final denial and performs deterministic storage bookkeeping. The AST test is a development-time structural validator, not a runtime message classifier and not a competing authority.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic appears at a competing-signals decision point. “A result containing `retryAfterMs` must use the preservation funnel” is an enumerable transport invariant, analogous to an idempotency-key requirement. It does not judge message meaning, urgency, or user intent.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the funnel runs only after an existing authority has denied. It cannot prevent later checks from running because those branches already returned at the same points.
+- **Double-fire:** pre-spawn branches queue the current payload once through the funnel. The launch branch snapshots existing entries without removing them; success commits the snapshot, while rejection queues only the current payload. The per-agent in-flight set prevents a second launch from snapshotting the same backlog before the first commits.
+- **Races:** `spawnSession` is awaited, so another inbound request can enqueue while launch is in flight. The old destructive drain temporarily freed capacity and could lose ordering. The new queue snapshot retains old entries in place; success removes snapshot entries by object identity, leaving concurrently appended entries even when their content/hash matches. On failure, the reserved current payload is inserted by its launch-start sequence, ahead of later arrivals.
+- **TTL:** failed launch does not recreate backlog entries. The current request receives its `receivedAt` timestamp before the launch await, so a slow failure cannot extend its ten-minute lifetime.
+- **Global capacity:** a reserved payload is not counted while already present in an in-flight launch prompt. If its launch fails after a later arrival fills the last slot, sequence reconciliation evicts only the globally newest later entry and admits the earlier reservation. This is bounded oldest-first retention, not extra capacity.
+- **Truncation:** a successful snapshot commit clears the truncation marker only if no entries remain. A concurrent remainder retains its marker.
+- **Drain loop:** `runTick` already prevents overlapping ticks with `#tickInflight`. The production `onDrainReady` callback calls the same guarded `evaluate()` method.
+- **Zero cap:** legacy `degradedMaxQueuedPerAgent: 0` previously made `while (queue.length >= cap)` infinite even for an empty queue. Effective admission now floors it to one, and live config updates reject zero.
+
+---
+
+## 6. External surfaces
+
+Other agents observe no new response fields and no changed denial copy. The visible improvement is behavioral: a message refused under a temporary condition remains available for retry, including when the worker process itself failed before delivery.
+
+No endpoint, configuration key, dashboard control, URL, database, or external service integration is added. Queue timing remains dependent on existing cooldown and drain cadence.
+
+No operator-facing actions are introduced.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** Spawn admission and the pending queue belong to the machine that received the inbound dispatch and is responsible for starting the local worker. This change neither creates nor changes topic placement, replicated records, or pool routing. The class guard applies identically in every installed copy.
+
+The process-local queue is not durable across restart; that separate persistence gap is tracked as `CMT-1112`. <!-- tracked: CMT-1112 -->
+
+This change emits no user-facing notices, creates no URLs, and adds no durable state that could strand during topic transfer.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the single code/test/docs commit and ship the next patch.
+- **Data migration:** none.
+- **Agent state repair:** none; the queue schema and persisted state are unchanged.
+- **User visibility:** rollback would reopen the pre-delivery spawn-failure loss and remove the structural CI ratchet.
+
+---
+
+## Conclusion
+
+The side-effects pass changed the initial implementation materially. Re-enqueueing drained messages would have reset their TTL and reordered them behind messages arriving during the launch await. The first independent pass then found four further gaps: overlapping same-agent launches could duplicate the snapshot; the current failed payload could sort behind a later arrival; a zero degraded cap could loop forever; and a raw AST text rule could be bypassed. The second independent pass found two more: the earlier reservation could still lose to a later arrival at the global cap, and an `any`-returning helper outside the guarded method could evade the branded boundary. The final design adds per-agent serialization, launch-start sequence/TTL reservation, chronological global-cap reconciliation, a one-slot degraded floor, and a compiler-enforced private brand with whole-class cast and guarded-return constraints. Existing admission authorities remain intact. Independent re-review concurs; this is clear to ship.
+
+---
+
+## Second-pass review
+
+**Reviewer:** Locke
+**First verdict:** CONCERN
+
+The first pass requested four concrete repairs: serialize same-agent launches; preserve the current payload's launch-start order and TTL across failure; make zero degraded capacity terminate safely; and replace the bypassable raw AST rule with a compiler-enforced return boundary plus stronger production wiring assertions. All four were reproduced with tests that failed against the then-current implementation before the fixes were written.
+
+**Second verdict:** CONCERN
+
+The re-review found a cap-one race where a later in-flight refusal could occupy the sole global slot before the earlier launch failed, causing the earlier reservation to be dropped. It also demonstrated that an `any`-returning helper outside `#evaluateGuarded` could evade the first AST rule. Both exact reproductions failed before their repairs: the recovered prompt contained only the later payload, and the mutation produced zero violations. The implementation now reconciles full global capacity by sequence and the ratchet constrains guarded return shapes plus branded casts across the class.
+
+**Final verdict:** CONCUR
+
+Locke re-read the final diff and this artifact, reran the focused 89-test suite, and confirmed both later concerns plus all four earlier concerns are closed. The production constructor, `ThreadlineRouter`/`AgentServer` handoffs, start, and dispose links are real and structurally pinned. No actionable correctness concern remains.
+
+---
+
+## Evidence pointers
+
+- Initial failing-before runtime result: expected queue depth `2`, received `0`.
+- Initial failing-before class ratchet: direct retryable result construction at five lines in the unfixed class.
+- Reviewer-strengthened failing-before result: four failures — ordering, overlapping admission, zero-cap effective value, and missing typed guard.
+- Re-review-strengthened failing-before result: two failures — final-slot loss of the earlier reservation and undetected `any`-helper indirection.
+- Fixed focused run: 89/89.
+- Adjacent quota/router/admission/integration run: 166/166.
+- Full TypeScript and 33-step lint chain: pass after reviewer repairs.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable. The defect is in hand-written TypeScript, not an LLM prompt, hook, config, skill, or standards text, and this change does not add a new self-triggered controller. The existing bounded drain controller is unchanged. Separately, this PR itself supplies the missing runtime/CI class guard: `#refuseTransiently` plus `tests/unit/spawn-request-manager-class-guard.test.ts` catch direct retryable returns, indirect helper returns, and branded casts outside the one construction point.


### PR DESCRIPTION
## ELI16

When a machine says “not now” to an agent message, that message must wait—not disappear. This change makes that a class-wide rule instead of relying on each refusal branch to remember queue bookkeeping. Failed launches retain their original message order and expiry, overlapping launches cannot deliver the same backlog twice, and CI now rejects direct or helper-hidden retryable returns that bypass preservation.

## What changed

- Route every retryable `SpawnRequestManager` result through a private preservation funnel enforced by a branded return type.
- Keep queued backlog entries in place until `spawnSession` truthfully confirms delivery, then commit only the exact delivered snapshot.
- Reserve launch-start sequence and timestamp for the current payload so a true pre-delivery failure preserves order and TTL.
- Serialize launches per agent, including when cooldown is zero.
- Reconcile a full global queue chronologically when an earlier in-flight reservation is admitted after a later arrival.
- Floor legacy degraded queue capacity at one and reject zero in runtime updates.
- Add a TypeScript-AST ratchet that pins the public method, rejects helper indirection/casts, and verifies the real production constructor, router/server handoffs, start, and dispose wiring.

## Root cause

Retryable refusals were assembled branch by branch. Three of six exits had destroyed payloads, and the first structural repair was itself bypassable. The launch path also removed backlog entries before delivery confirmation, had no same-agent in-flight lock, and admitted failed-launch payloads after later concurrent arrivals without preserving global capacity priority.

## UX Impact

Who sees this: agents sending Threadline messages and operators diagnosing delivery. The user-visible first-contact behavior under temporary cooldown, session, memory, quota, or launch pressure changes from silent loss to bounded retry; same-agent overlap is recorded as `Spawn already in flight for` while its payload waits. No admission authority is weakened, and there is no new endpoint, flag, migration, persistent schema, or UI.

## Validation

- Every new regression was run against its unfixed predecessor first and failed for the intended reason.
- Focused manager/class-guard suite: 89/89.
- Adjacent Threadline, relay, quota, and admission suites: 166/166.
- Pre-push affected smoke/integration set: 156/156.
- `npm run lint` (TypeScript plus 33 lint checks): pass.
- `npm run build`: pass.
- Independent side-effects review: CONCUR after three rounds; all six raised concerns were reproduced and repaired.

Tracks CMT-1113.
