### PR TITLE
docs(standards): make Zero-Failure's guard citation resolvable (34 gaps → 33)

### DIFF
--- a/docs/STANDARDS-REGISTRY.md
+++ b/docs/STANDARDS-REGISTRY.md
@@ -368,7 +368,7 @@ The Root says *enforce behavior in structure, not willpower.* This family is **w
 
 ### Zero-Failure
 **Rule.** The test suite is green at all times. There is no such thing as a "pre-existing failure."
-**In practice.** If you see a failure, you own it — regardless of who caused it. Enforced structurally: Husky pre-push hook, CI branch protection, session-level test-health gate.
+**In practice.** If you see a failure, you own it — regardless of who caused it. Enforced structurally: the Husky pre-push suite gate (`scripts/pre-push-smoke.mjs`, which runs the affected tier and exits with Vitest's status, so a red suite blocks the push), CI branch protection, and a session-level test-health gate.
 **Earned from.** The classic responsibility gap — every developer assuming "someone else broke that," so failures accumulate unowned. The standard closes the gap by assigning ownership to whoever sees it.
 **Traces to the goal.** Coherence includes a coherent codebase; drift in the test suite is drift in the foundation.
 


### PR DESCRIPTION
## ELI16 — a rule we already enforce was being counted as unenforced

We keep a constitution of 82 standards, and an audit reads each one to check whether the guard it claims actually exists. This morning that audit reported only 30% enforced. Most of that turned out to be a bug in where it was looking, and with that corrected the real figure is 54% — with 34 standards genuinely naming no guard the audit can find.

**Zero-Failure was one of those 34, and it should not have been.** The rule is "the test suite is green at all times; there is no such thing as a pre-existing failure." Its own text already said it was enforced by "Husky pre-push hook, CI branch protection, session-level test-health gate" — but it said that in ordinary words. The audit only recognises a guard when the standard names a real file, route or symbol. So a guard that genuinely runs on every push was invisible, and the constitution looked weaker than it is.

This change names the file. Nothing about the enforcement changes — only whether the audit can see it.

**Verified rather than assumed.** I read the guard before citing it: the pre-push hook runs the affected test tier through that script, and the script exits with the test runner's own status, so a red suite blocks the push. I hit it myself three times today.

**Measured, using the audit's own code against this branch, changing only the constitution file:** 34 gaps → 33, ratio 0.5366 → 0.5488, and the Zero-Failure row flips from "documented only" to a real resolving guard. Dangling references stay at zero.

## Why only one, when 33 remain

Because matching a guard to a standard is judgment, and names lie. I nearly cited a file called `deferral-floor.ts` for the standard called "Deferral = Deletion" — the names line up almost perfectly. Reading it stopped me: that floor catches the agent handing an operational task back to the user, which is a *different* standard entirely.

Had I shipped it, the audit would report a standard as enforced by a guard that does not enforce it. **That is a false all-clear, and it is strictly worse than the gap it closes** — it is exactly the class of defect this whole effort exists to remove, committed inside the change meant to fix it.

So: one citation, read and verified. The remaining 33 each need the standard's text and the guard's behaviour read together, and that work is worth doing slowly.

## The caveat that should travel with the number

The ratio measures *"a guard of this shape exists and is named"*. It does **not** measure *"this guard enforces this standard"*. The audit says so itself in its own output. Anyone quoting the figure as a convergence metric should carry that limit with it — it is a real signal, and it is not a proof.