### PR TITLE
fix(threadline): report delivery receipts honestly

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-30T18-57-51-182Z-threadline-honest-delivery-receipts.json
+++ b/.instar/instar-dev-decisions/2026-07-30T18-57-51-182Z-threadline-honest-delivery-receipts.json
@@ -1,0 +1,32 @@
+{
+  "ts": "2026-07-30T18:57:51.182Z",
+  "slug": "threadline-honest-delivery-receipts",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/relayContentDedup.ts matches relay / delivery path"
+  ],
+  "belowFloor": false,
+  "files": 9,
+  "loc": 297,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/messaging/SpawnRequestManager.ts",
+      "src/messaging/relayContentDedup.ts",
+      "src/server/routes.ts",
+      "src/threadline/A2ADeliveryTracker.ts",
+      "src/threadline/ThreadlineEndpoints.ts",
+      "src/threadline/ThreadlineMCPServer.ts",
+      "src/threadline/ThreadlineRouter.ts",
+      "src/threadline/mcp-http-client.ts"
+    ],
+    "addedLines": 248,
+    "deletedLines": 49
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-30T18-58-55-316Z-threadline-honest-delivery-receipts.json
+++ b/.instar/instar-dev-decisions/2026-07-30T18-58-55-316Z-threadline-honest-delivery-receipts.json
@@ -1,0 +1,32 @@
+{
+  "ts": "2026-07-30T18:58:55.316Z",
+  "slug": "threadline-honest-delivery-receipts",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/messaging/relayContentDedup.ts matches relay / delivery path"
+  ],
+  "belowFloor": false,
+  "files": 9,
+  "loc": 297,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/messaging/SpawnRequestManager.ts",
+      "src/messaging/relayContentDedup.ts",
+      "src/server/routes.ts",
+      "src/threadline/A2ADeliveryTracker.ts",
+      "src/threadline/ThreadlineEndpoints.ts",
+      "src/threadline/ThreadlineMCPServer.ts",
+      "src/threadline/ThreadlineRouter.ts",
+      "src/threadline/mcp-http-client.ts"
+    ],
+    "addedLines": 248,
+    "deletedLines": 49
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/threadline-honest-delivery-receipts.eli16.md
+++ b/docs/eli16/threadline-honest-delivery-receipts.eli16.md
@@ -1,0 +1,51 @@
+# Honest Threadline delivery receipts — Plain-English Overview
+
+> The one-line version: sending a message now distinguishes “someone accepted responsibility for it” from “the receiving agent actually processed it.”
+
+## The problem in one breath
+
+Threadline used one success-shaped result for several very different events: a relay accepted bytes, a receiver queued work, a live session received the message, or a spawn was refused. The final sender-facing tool then turned almost every successful HTTP request into `delivered: true`, so a message that never reached a live agent could look fully delivered.
+
+## What already exists
+
+- **Fast receiver acceptance** — receiving servers acknowledge authenticated messages before a potentially slow session spawn, preventing sender timeouts from creating duplicate retries.
+- **Retryable spawn admission** — temporary memory, cooldown, quota, and session-cap refusals can retain a payload for a later drain attempt.
+- **Reply waiting** — callers can optionally wait for a reply on the same conversation thread.
+- **Delivery tracking** — the separate agent-to-agent tracker records sends and later acknowledgements, but the immediate send result did not respect that distinction.
+
+## What this adds
+
+Every relevant layer now carries two separate facts. `accepted` means the next layer retained responsibility for processing; `delivered` means there is concrete evidence of processing, such as live-session injection, a completed spawn/resume, explicit processing, or a reply. A verified receiver's asynchronous HTTP acknowledgement is therefore `accepted: true, delivered: false`. Sending bytes into the relay socket without waiting for its acknowledgement is only a submission, so it remains `accepted: false, delivered: false` unless a reply later proves processing. A spawn refusal is not handled or delivered; it is accepted only when the current payload really entered the bounded retry queue.
+
+The sender-facing tool no longer upgrades transport success into delivery. If an older compatible response omits the new fields, the fallback can infer acceptance from successful transport, but it infers delivery only from concrete evidence such as a reply.
+
+## The new pieces
+
+- **Explicit router outcomes** — every router exit identifies whether the message was accepted, delivered, or queued. Autonomy blocks and errors are neither accepted nor delivered; approval queues are accepted but not delivered.
+- **Honest accept boundaries** — both authenticated receiver endpoints say explicitly that asynchronous work is accepted but not yet delivered. A duplicate retry is suppressed conservatively and does not claim acceptance because the earlier attempt's current state may be unknown.
+- **Honest sender mapping** — local, relay, HTTP-helper, and MCP responses preserve those facts instead of collapsing them into a generic success.
+- **Queue-admission evidence** — a retryable spawn refusal reports whether this particular payload actually entered the queue, including bounded-cap rejection.
+
+## The safeguards
+
+**Prevents submission from masquerading as acceptance or delivery.** Relay socket submission and duplicate suppression can return a successful operation result while both receipt facts remain false. Asynchronous receiver acknowledgement and approval queueing are accepted but cannot silently become proof that a live agent processed the content.
+
+**Prevents refusal from masquerading as handling.** A real spawn denial returns an unhandled result, and its acceptance flag is tied to actual queue admission rather than the presence of a retry interval.
+
+**Prevents the honesty fix from duplicating work.** The production relay listener previously retried any threadless message when `handled` was false. It now retries only when the router also failed to resolve a thread; a refused payload with a resolved thread cannot be handed to the router twice.
+
+The warm-worker path also stops after a transient refusal that already queued the payload. It no longer falls through to a cold-worker evaluation and queues the same inbound a second time.
+
+**Preserves fast acknowledgement.** The receiver still responds before the slow spawn. This change does not reintroduce the timeout-and-duplicate failure that the asynchronous accept boundary fixed.
+
+## What ships when
+
+This is one source-compatible patch: the exported result fields remain optional for older fixtures while the built-in router always supplies them. Runtime rollout is directionally conservative. An updated sender interpreting an older receiver will not promote missing delivery evidence. An older sender can still apply its historical `delivered:true` default to an updated receiver until that sender upgrades, so the false-positive is fully removed only after the sending machine carries this patch.
+
+## What you actually need to decide
+
+No operator decision or feature toggle is required; this corrects the meaning of the existing delivery result.
+
+## Verification
+
+Every new behavioral assertion was first shown failing against the unfixed revision. After the final hardening change, all 341 assertions across the 15 changed receipt, wiring, integration, and end-to-end test files pass. The silent-fallback ratchet remains exactly at its existing 495-item baseline, and the full lint/typecheck and production build gates pass. The broad local sweep also exposed unrelated session-launch fixture/config leakage and tmux timing failures in untouched files, so the authoritative sharded CI run remains the final merge gate rather than being papered over as locally green.

--- a/docs/specs/A2A-DURABLE-DELIVERY-SPEC.eli16.md
+++ b/docs/specs/A2A-DURABLE-DELIVERY-SPEC.eli16.md
@@ -53,3 +53,21 @@ no message text is ever logged. Nothing about routing changes — it just stops 
 gate from failing in silence, so the next test from Dawn will say in plain words
 whether the gate rejected her (and exactly why) or her message never arrived at
 all. That answer points straight at the real fix.
+
+## Honest immediate receipts (added 2026-07-30)
+
+The durable tracker above is later proof, but the immediate send result also
+needed to stop overstating what happened. The sender now gets two separate
+facts: **accepted** means the next layer retained responsibility, while
+**delivered** means a live handler actually processed the message or a reply
+proved processing. A fast receiver acknowledgement can therefore be accepted
+without pretending the agent already saw it; a temporary refusal is accepted
+only when that exact payload really entered the retry queue. Relay submission,
+duplicate suppression, errors, and unqueued refusals do not fabricate either
+fact.
+
+The production recovery path and content deduplication were hardened alongside
+the new wording: an honestly refused message cannot be handed to the router
+twice, and a rejected first admission cannot poison a legitimate retry. These
+behaviors are pinned through the real server/router/MCP wiring, not only through
+injected test doubles.

--- a/docs/specs/A2A-DURABLE-DELIVERY-SPEC.md
+++ b/docs/specs/A2A-DURABLE-DELIVERY-SPEC.md
@@ -18,10 +18,12 @@ commitment: CMT-1143
 
 ## Problem
 
-Agent-to-agent (Threadline + file-relay) messaging is **fire-and-forget at every
-hop**. A `threadline_send` that returns `delivered:true / accepted` means only
-that the TRANSPORT accepted the bytes — it says nothing about whether the peer
-ever PROCESSED the message. And there is no record on the SENDER side that "this
+Agent-to-agent (Threadline + file-relay) messaging was **fire-and-forget at every
+hop**. Older `threadline_send` results collapsed local submission, transport
+acceptance, and peer processing into `delivered:true`; current results separate
+`accepted` from proven `delivered`, and an unacknowledged relay submission is
+neither. There is still no immediate guarantee that the peer processed the
+message. And there is no record on the SENDER side that "this
 message is still waiting for the peer to acknowledge it," so a peer going dark is
 invisible until a human notices the silence.
 
@@ -30,8 +32,8 @@ paths:
 1. **Dawn→Echo over Threadline**: not landing (zero relay-accept entries). An
    addressing/discovery gap on the sender's side; the sender gets no signal the
    message was lost.
-2. **Echo→Dawn over Threadline**: `delivered:true/accepted` ≠ read — a kickoff
-   was accepted by the relay but Dawn never saw it.
+2. **Echo→Dawn over Threadline**: the historical `delivered:true/accepted` result
+   did not mean read — a kickoff was submitted to the relay but Dawn never saw it.
 3. **Dawn→Echo over the file relay**: lands but rots — a check-in sat 10h unread
    because nothing on the receiving side watched the channel.
 

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -16919,8 +16919,11 @@ export async function startServer(options: StartOptions): Promise<void> {
           };
           let result = await threadlineRouter.handleInboundMessage(envelope, relayContext);
 
-          // Fallback for threadId-less messages
-          if (!result.handled && !msg.threadId) {
+          // Fallback only when a threadless message could not be associated
+          // with any thread. A refusal can be unhandled while still carrying
+          // the router-resolved threadId; retrying that payload would hand the
+          // same refused message to the router twice.
+          if (!result.handled && !result.threadId && !msg.threadId) {
             (envelope.message as { threadId?: string }).threadId = getSyntheticThreadId(senderFingerprint);
             result = await threadlineRouter.handleInboundMessage(envelope, relayContext);
           }

--- a/src/messaging/SpawnRequestManager.ts
+++ b/src/messaging/SpawnRequestManager.ts
@@ -115,6 +115,12 @@ export interface SpawnResult {
   tmuxSession?: string;
   reason?: string;
   retryAfterMs?: number;
+  /**
+   * For a refused spawn, whether the current payload was admitted to the
+   * bounded retry queue. False means the caller must not describe the payload
+   * as accepted merely because the refusal is retryable.
+   */
+  queued?: boolean;
 }
 
 /**
@@ -589,15 +595,17 @@ export class SpawnRequestManager {
     reservedPayload?: QueuedSpawnMessage,
   ): PreservedTransientRefusal {
     const agent = request.requester.agent;
+    let queued = false;
     if (reservedPayload) {
-      this.#admitQueuedMessage(agent, reservedPayload);
+      queued = this.#admitQueuedMessage(agent, reservedPayload);
     } else if (request.context) {
-      this.#queueMessage(agent, request.context, request.pendingMessages?.[0]);
+      queued = this.#queueMessage(agent, request.context, request.pendingMessages?.[0]);
     }
     return {
       approved: false,
       reason,
       retryAfterMs,
+      queued,
     } as PreservedTransientRefusal;
   }
 

--- a/src/messaging/relayContentDedup.ts
+++ b/src/messaging/relayContentDedup.ts
@@ -77,6 +77,15 @@ export class RelayContentDedup {
     return true;
   }
 
+  /**
+   * Release a fresh-key reservation when downstream inbox admission fails.
+   * Otherwise the rejected attempt would poison an identical valid retry for
+   * the full dedup window.
+   */
+  forget(senderAgent: string, threadId: string, content: string): void {
+    this.seen.delete(RelayContentDedup.keyFor(senderAgent, threadId, content));
+  }
+
   /** Number of retained keys (test/observability aid). */
   size(): number {
     return this.seen.size;

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -29862,6 +29862,8 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       await ctx.messageRouter.acknowledge(messageId, sessionId);
       res.json({ ok: true });
     } catch (err) {
+      // @silent-fallback-ok: the acknowledgement fails closed as HTTP 500;
+      // no degraded/default execution continues after this catch.
       res.status(500).json({ error: err instanceof Error ? err.message : 'Ack failed' });
     }
   });
@@ -29871,6 +29873,11 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       res.status(503).json({ error: 'Messaging not available' });
       return;
     }
+    let dedupReservation: {
+      senderAgent: string;
+      threadId: string;
+      content: string;
+    } | null = null;
     try {
       // Verify bearer token — the sender must present our agent's token
       const authHeader = req.headers.authorization;
@@ -29903,13 +29910,30 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
               : '');
         if (dThread && dText && !relayContentDedup.shouldProcess(dSender, dThread, dText)) {
           console.log(`[relay-agent] Deduped retried message from ${dSender} (thread: ${dThread.slice(0, 8)}, id: ${envelope.message?.id ?? 'none'}) — identical content within window`);
-          res.json({ ok: true, deduped: true });
+          res.json({
+            ok: true,
+            deduped: true,
+            accepted: false,
+            delivered: false,
+            deliveryOutcome: 'duplicate suppressed; prior attempt state unknown',
+            threadline: { accepted: false, delivered: false, async: false },
+          });
           return;
+        }
+        if (dThread && dText) {
+          dedupReservation = {
+            senderAgent: dSender,
+            threadId: dThread,
+            content: dText,
+          };
         }
       }
 
       const accepted = await ctx.messageRouter.relay(envelope, 'agent');
       if (accepted) {
+        // MessageRouter has now admitted the envelope to its inbox. Keep the
+        // dedup record and clear only the rollback handle.
+        dedupReservation = null;
         const senderAgent = envelope.message?.from?.agent;
         console.log(`[relay-agent] Accepted message from ${senderAgent ?? 'unknown'} (thread: ${envelope.message?.threadId ?? 'none'}, id: ${envelope.message?.id ?? 'none'})`);
 
@@ -30035,7 +30059,20 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
               });
               if (decision.suppress) {
                 console.log(`[relay-agent] warrants-reply gate suppressed reply (${decision.verdict.signal}) from ${senderAgentName} thread ${gThreadId.slice(0, 8)}`);
-                res.json({ ok: true, threadline: { handled: true, threadId: gThreadId, spawned: false, suppressed: true, signal: decision.verdict.signal } });
+                res.json({
+                  ok: true,
+                  accepted: true,
+                  delivered: true,
+                  threadline: {
+                    handled: true,
+                    accepted: true,
+                    delivered: true,
+                    threadId: gThreadId,
+                    spawned: false,
+                    suppressed: true,
+                    signal: decision.verdict.signal,
+                  },
+                });
                 return;
               }
               // CMT-509 §2: warranted + parentless (no bound topic) → surface to
@@ -30072,7 +30109,12 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         // The actual reply still flows back via the reply-waiter mechanism
         // (resolved above), decoupled from this HTTP response.
         if (ctx.threadlineRouter) {
-          res.json({ ok: true, accepted: true, threadline: { accepted: true, async: true } });
+          res.json({
+            ok: true,
+            accepted: true,
+            delivered: false,
+            threadline: { accepted: true, delivered: false, async: true },
+          });
           // Process asynchronously — the response is already sent.
           // handleInboundMessage is NOT dropped: it runs to completion in the
           // background; its outcome is logged (never surfaced to the closed
@@ -30095,14 +30137,41 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
             })
             .catch((err) => {
               console.error('[routes] ThreadlineRouter async handling error:', err);
+              DegradationReporter.getInstance().report({
+                feature: 'routes.relayAgentAsyncHandling',
+                primary: 'Process an accepted agent relay message through ThreadlineRouter',
+                fallback: 'Keep the already-recorded inbox admission for recovery and surface the processing failure',
+                reason: `Async Threadline handling failed: ${err instanceof Error ? err.message : String(err)}`,
+                impact: 'The sender received acceptance, but this attempt did not reach a live agent session.',
+              });
             });
           return;
         }
-        res.json({ ok: true });
+        res.json({
+          ok: true,
+          accepted: true,
+          delivered: false,
+          threadline: { accepted: true, delivered: false, async: false },
+        });
       } else {
+        if (dedupReservation) {
+          relayContentDedup.forget(
+            dedupReservation.senderAgent,
+            dedupReservation.threadId,
+            dedupReservation.content,
+          );
+          dedupReservation = null;
+        }
         res.status(409).json({ error: 'Relay rejected (loop or duplicate)' });
       }
     } catch (err) {
+      if (dedupReservation) {
+        relayContentDedup.forget(
+          dedupReservation.senderAgent,
+          dedupReservation.threadId,
+          dedupReservation.content,
+        );
+      }
       res.status(500).json({ error: err instanceof Error ? err.message : 'Relay failed' });
     }
   });
@@ -31335,6 +31404,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         }
         res.json({
           success: true,
+          accepted: false,
           threadId: effectiveThreadId,
           messageId: '',
           delivered: false,
@@ -31536,19 +31606,38 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
                 });
 
                 if (localResp.ok) {
-                  let localRespBody: { ok?: boolean; threadline?: {
-                    handled?: boolean; spawned?: boolean; resumed?: boolean; injected?: boolean;
-                    threadId?: string; sessionName?: string; error?: string; gateDecision?: string;
-                  } } = {};
+                  let localRespBody: {
+                    ok?: boolean;
+                    accepted?: boolean;
+                    delivered?: boolean;
+                    deduped?: boolean;
+                    threadline?: {
+                      accepted?: boolean; delivered?: boolean; async?: boolean;
+                      handled?: boolean; spawned?: boolean; resumed?: boolean; injected?: boolean;
+                      suppressed?: boolean; threadId?: string; sessionName?: string;
+                      error?: string; gateDecision?: string;
+                    };
+                  } = {};
                   try { localRespBody = await localResp.json() as typeof localRespBody; } catch { /* no body */ }
                   const tl = localRespBody.threadline;
-                  const outcome = tl?.injected ? 'injected into live session'
+                  const delivered = localRespBody.delivered
+                    ?? tl?.delivered
+                    ?? Boolean(tl?.injected || tl?.spawned || tl?.resumed || tl?.suppressed);
+                  const accepted = localRespBody.accepted
+                    ?? tl?.accepted
+                    ?? localRespBody.deduped
+                    ?? (delivered || (tl?.handled === true && !tl?.error));
+                  const outcome = localRespBody.deduped ? 'duplicate suppressed; prior attempt state unknown'
+                    : tl?.injected ? 'injected into live session'
                     : tl?.spawned ? 'spawned new session'
                     : tl?.resumed ? 'resumed existing thread'
+                    : tl?.suppressed ? 'processed; no reply warranted'
                     : tl?.gateDecision === 'queue-for-approval' ? 'queued for approval'
                     : tl?.error ? `error: ${tl.error}`
                     : tl?.handled === false ? 'queued (no live session)'
-                    : 'accepted';
+                    : accepted && tl?.async ? 'accepted for async processing'
+                    : accepted ? 'accepted'
+                    : 'refused';
                   console.log(`[relay-send] Local delivery to ${localTarget.name}:${localTarget.port} (thread: ${effectiveThreadId}) — ${outcome}`);
 
                   // Persist our OWN outbound leg into the thread history so
@@ -31619,18 +31708,20 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
                     });
                   } catch (err) {
                     // @silent-fallback-ok: recording-only — A2A delivery tracking must never
-                    // break the send (the message was already delivered above). Logged.
+                    // break the send (the message was already admitted/submitted above). Logged.
                     console.warn(`[relay-send] A2A delivery record failed (non-fatal): ${err instanceof Error ? err.message : err}`);
                   }
                   if (waitForReply) {
                     const reply = await waitForThreadlineReply(ctx, localTarget.name, effectiveThreadId, timeoutSeconds);
                     res.json({
                       success: true,
+                      accepted,
+                      delivered: reply !== null ? true : delivered,
                       messageId: msgId,
                       threadId: effectiveThreadId,
                       resolvedAgent: localTarget.name,
                       deliveryPath: 'local',
-                      deliveryOutcome: outcome,
+                      deliveryOutcome: reply !== null ? 'reply received' : outcome,
                       threadline: tl,
                       reply,
                       topicLinkageStamped: resolvedOriginTopicId !== undefined,
@@ -31638,6 +31729,8 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
                   } else {
                     res.json({
                       success: true,
+                      accepted,
+                      delivered,
                       messageId: msgId,
                       threadId: effectiveThreadId,
                       resolvedAgent: localTarget.name,
@@ -31734,7 +31827,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
           if (typeof inReplyTo === 'string') ctx.listenerManager.retainReplyClaimFailure(inReplyTo, replyClaimOwner);
         }
       }
-      // Robustness Phase 2 (D-B): append the relay-delivered outbound leg to the
+      // Robustness Phase 2 (D-B): append the relay-submitted outbound leg to the
       // canonical log through the funnel. The wire createdAt is stamped inside the
       // relay client, so this end's createdAt is best-effort (symmetry on the relay
       // path degrades to unverified, advisory-only); F3 holds unconditionally — the
@@ -31783,27 +31876,33 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         });
       } catch (err) {
         // @silent-fallback-ok: recording-only — A2A delivery tracking must never break
-        // the send (the message was already delivered above). Logged.
+        // the send (the message was already submitted above). Logged.
         console.warn(`[relay-send] A2A delivery record failed (non-fatal): ${err instanceof Error ? err.message : err}`);
       }
       if (waitForReply) {
         const reply = await waitForThreadlineReply(ctx, resolvedId, effectiveRelayThreadId, timeoutSeconds);
         res.json({
           success: true,
+          accepted: reply !== null,
+          delivered: reply !== null,
           messageId: relayMsgId,
           threadId: effectiveRelayThreadId,
           resolvedAgent: resolvedId,
           deliveryPath: 'relay',
+          deliveryOutcome: reply !== null ? 'reply received' : 'submitted to relay; acceptance unconfirmed',
           reply,
           topicLinkageStamped: resolvedOriginTopicId !== undefined,
         });
       } else {
         res.json({
           success: true,
+          accepted: false,
+          delivered: false,
           messageId: relayMsgId,
           threadId: effectiveRelayThreadId,
           resolvedAgent: resolvedId,
           deliveryPath: 'relay',
+          deliveryOutcome: 'submitted to relay; acceptance unconfirmed',
           topicLinkageStamped: resolvedOriginTopicId !== undefined,
         });
       }

--- a/src/threadline/A2ADeliveryTracker.ts
+++ b/src/threadline/A2ADeliveryTracker.ts
@@ -3,12 +3,13 @@
  * agent-to-agent (Threadline / file-relay) messaging.
  *
  * The problem this closes (operator directive, 2026-06-06): every A2A hop was
- * fire-and-forget. A `threadline_send` that returns `delivered:true` only means
- * the TRANSPORT accepted it — it says nothing about whether the peer ever
- * PROCESSED it. And there was no record on the SENDER side of "this message is
+ * fire-and-forget. Older `threadline_send` results collapsed local submission,
+ * transport acceptance, and peer processing into `delivered:true`; current
+ * results separate `accepted` from proven `delivered`. There was also no record
+ * on the SENDER side of "this message is
  * still waiting for the peer to acknowledge it", so a peer going dark was
  * invisible until a human noticed silence (Dawn's check-in sat 10h unread; my
- * hosting kickoff was accepted by the relay but never seen).
+ * hosting kickoff was submitted to the relay but never seen).
  *
  * This is the durable spine of the fix:
  *   - recordSent()      — every outbound A2A message is written here BEFORE/with

--- a/src/threadline/ThreadlineEndpoints.ts
+++ b/src/threadline/ThreadlineEndpoints.ts
@@ -571,7 +571,12 @@ export function createThreadlineRoutes(
       // background failure is logged (it cannot 500 a response that already
       // returned). The former 422-retryable path was already unreachable — the
       // sender aborts at ~10s, long before the 9-30s spawn produced it.
-      res.json({ accepted: true, async: true, threadId: body.message?.threadId });
+      res.json({
+        accepted: true,
+        delivered: false,
+        async: true,
+        threadId: body.message?.threadId,
+      });
 
       // Robustness Phase 1 (D-E / closes F4): record the implicit delivery ack on
       // the VERIFIED E2E relay inbound path — the path that previously lacked it,

--- a/src/threadline/ThreadlineMCPServer.ts
+++ b/src/threadline/ThreadlineMCPServer.ts
@@ -141,7 +141,9 @@ export interface SendMessageResult {
   deliveryOutcome?: string;
   /** How the message was delivered (local, relay) */
   deliveryPath?: string;
-  /** Whether the content was actually delivered (false when withheld by the negotiator lease). */
+  /** Whether a receiver or relay accepted responsibility for the content. */
+  accepted?: boolean;
+  /** Whether processing is proven, rather than merely transport-accepted. */
   delivered?: boolean;
   /** True when the single-negotiator lease withheld this content send (G1 holding). */
   held?: boolean;
@@ -653,17 +655,17 @@ export class ThreadlineMCPServer {
           // process. Single hook for both local-delivery and relay-delivery
           // outbound paths. (See server/routes.ts /threadline/relay-send.)
 
+          const accepted = result.accepted
+            ?? (!result.held && !result.deliveryOutcome?.startsWith('error'));
+          // A reply is direct evidence that the peer processed this message.
+          // Without a reply or an explicit receipt, success means only that the
+          // transport accepted responsibility — never silently promote it to
+          // delivery.
+          const delivered = result.delivered ?? Boolean(result.reply);
           const response: Record<string, unknown> = {
-            // `delivered` reflects whether the recipient actually accepted
-            // the message. It's true unless the recipient reported an
-            // error outcome. When no outcome info is available we default
-            // to true (success path) — result.success is already checked above.
-            // The single-negotiator lease can explicitly set delivered:false when
-            // it WITHHELD this non-owner content send (G1 holding) — honor it.
-            delivered: result.delivered !== undefined
-              ? result.delivered
-              : !(result.deliveryOutcome?.startsWith('error')),
-            outcome: result.deliveryOutcome ?? 'accepted',
+            accepted,
+            delivered,
+            outcome: result.deliveryOutcome ?? (delivered ? 'delivered' : 'accepted'),
             deliveryPath: result.deliveryPath,
             threadId: result.threadId,
             messageId: result.messageId,

--- a/src/threadline/ThreadlineRouter.ts
+++ b/src/threadline/ThreadlineRouter.ts
@@ -104,8 +104,25 @@ export interface RelayMessageContext {
 
 /** Result of handling an inbound threaded message */
 export interface ThreadlineHandleResult {
-  /** Whether this message was handled as a threadline message */
+  /**
+   * Whether a Threadline delivery handler took responsibility for the message.
+   * A spawn refusal or internal error is false even though the envelope was
+   * recognized as Threadline traffic.
+   */
   handled: boolean;
+  /**
+   * Whether this layer retained responsibility for eventual processing.
+   * Optional for source compatibility with result fixtures from older Instar
+   * versions; ThreadlineRouter itself always returns it.
+   */
+  accepted?: boolean;
+  /**
+   * Whether the message reached a live handler or was conclusively processed.
+   * Optional for source compatibility; ThreadlineRouter itself always returns it.
+   */
+  delivered?: boolean;
+  /** Whether accepted work is waiting in a retry or approval queue. */
+  queued?: boolean;
   /** The thread ID (existing or newly created) */
   threadId?: string;
   /** Whether a new session was spawned (vs. resumed) */
@@ -125,6 +142,11 @@ export interface ThreadlineHandleResult {
   /** Approval ID (if message was queued for approval) */
   approvalId?: string;
 }
+
+type CompleteThreadlineHandleResult = ThreadlineHandleResult & {
+  accepted: boolean;
+  delivered: boolean;
+};
 
 // ── Constants ───────────────────────────────────────────────────
 
@@ -519,12 +541,12 @@ export class ThreadlineRouter {
        */
       inboundSenderFingerprint?: string;
     },
-  ): Promise<ThreadlineHandleResult> {
+  ): Promise<CompleteThreadlineHandleResult> {
     const { message } = envelope;
 
     // Only handle messages from other agents (not self-delivery)
     if (message.from.agent === this.config.localAgent) {
-      return { handled: false };
+      return { handled: false, accepted: false, delivered: false };
     }
 
     // First-contact: if the sender didn't provide a threadId, try to reuse
@@ -580,7 +602,9 @@ export class ThreadlineRouter {
     // Prevent concurrent spawns for the same thread
     if (this.pendingSpawns.has(threadId)) {
       return {
-        handled: true,
+        handled: false,
+        accepted: false,
+        delivered: false,
         threadId,
         error: 'Spawn already in progress for this thread',
       };
@@ -596,7 +620,9 @@ export class ThreadlineRouter {
         switch (gateResult.decision) {
           case 'block':
             return {
-              handled: true,
+              handled: false,
+              accepted: false,
+              delivered: false,
               threadId,
               gateDecision: 'block',
               error: `Blocked by autonomy gate: ${gateResult.reason}`,
@@ -605,6 +631,9 @@ export class ThreadlineRouter {
           case 'queue-for-approval':
             return {
               handled: true,
+              accepted: true,
+              delivered: false,
+              queued: true,
               threadId,
               gateDecision: 'queue-for-approval',
               approvalId: gateResult.approvalId,
@@ -639,10 +668,14 @@ export class ThreadlineRouter {
             },
           });
           if (outcome.kind === 'routed') {
+            const delivered = outcome.deliveryMode === 'live-inject';
             return {
               handled: true,
+              accepted: true,
+              delivered,
+              queued: delivered ? undefined : true,
               threadId,
-              injected: outcome.deliveryMode === 'live-inject',
+              injected: delivered,
               resumed: outcome.deliveryMode === 'resume-pending',
             };
           }
@@ -681,7 +714,9 @@ export class ThreadlineRouter {
     } catch (err) {
       console.error(`[ThreadlineRouter] Error handling inbound message for thread ${threadId}:`, err);
       return {
-        handled: true,
+        handled: false,
+        accepted: false,
+        delivered: false,
         threadId,
         error: err instanceof Error ? err.message : 'Unknown error',
       };
@@ -786,7 +821,7 @@ export class ThreadlineRouter {
     entry: ThreadResumeEntry,
     envelope: MessageEnvelope,
     relayContext?: RelayMessageContext,
-  ): Promise<ThreadlineHandleResult> {
+  ): Promise<CompleteThreadlineHandleResult> {
     const { message } = envelope;
 
     // Threadline A2A continuity: this thread already has a claude-code
@@ -830,7 +865,10 @@ export class ThreadlineRouter {
       );
 
       return {
-        handled: true,
+        handled: false,
+        accepted: spawnResult.queued === true,
+        delivered: false,
+        queued: spawnResult.queued === true,
         threadId,
         error: `Spawn denied: ${spawnResult.reason}`,
       };
@@ -847,6 +885,8 @@ export class ThreadlineRouter {
 
     return {
       handled: true,
+      accepted: true,
+      delivered: true,
       threadId,
       resumed: true,
       sessionName: spawnResult.tmuxSession || entry.sessionName,
@@ -859,7 +899,7 @@ export class ThreadlineRouter {
     threadId: string,
     envelope: MessageEnvelope,
     relayContext?: RelayMessageContext,
-  ): Promise<ThreadlineHandleResult> {
+  ): Promise<CompleteThreadlineHandleResult> {
     const { message } = envelope;
 
     // Build history context (may be empty for brand new threads)
@@ -913,7 +953,10 @@ export class ThreadlineRouter {
       );
 
       return {
-        handled: true,
+        handled: false,
+        accepted: spawnResult.queued === true,
+        delivered: false,
+        queued: spawnResult.queued === true,
         threadId,
         error: `Spawn denied: ${spawnResult.reason}`,
       };
@@ -949,6 +992,8 @@ export class ThreadlineRouter {
 
     return {
       handled: true,
+      accepted: true,
+      delivered: true,
       threadId,
       spawned: true,
       sessionName: newEntry.sessionName,
@@ -974,7 +1019,7 @@ export class ThreadlineRouter {
     threadId: string,
     envelope: MessageEnvelope,
     relayContext: RelayMessageContext,
-  ): Promise<ThreadlineHandleResult | null> {
+  ): Promise<CompleteThreadlineHandleResult | null> {
     if (!this.warmSessionPool) return null;
     const { message } = envelope;
 
@@ -1033,8 +1078,29 @@ export class ThreadlineRouter {
     }
 
     if (!spawnResult.approved) {
-      // Don't escalate here; just fall back to the cold-spawn path which has its
-      // own denial handling. (Avoids double-counting denials.)
+      // A transient refusal may already have retained THIS payload in the
+      // shared retry queue. Do not evaluate the cold path and enqueue it a
+      // second time. Unqueued warm failures can still use the proven cold
+      // fallback (for example, a warm-only conflict or permanent refusal).
+      if (spawnResult.queued === true) {
+        this.spawnManager.handleDenial(
+          {
+            requester: message.from,
+            target: { agent: this.config.localAgent, machine: this.config.localMachine },
+            reason: `Warm thread ${threadId}`,
+            priority: message.priority === 'critical' ? 'critical' : 'medium',
+          },
+          spawnResult,
+        );
+        return {
+          handled: false,
+          accepted: true,
+          delivered: false,
+          queued: true,
+          threadId,
+          error: `Spawn denied: ${spawnResult.reason}`,
+        };
+      }
       console.log(`[ThreadlineRouter] Warm spawn not approved for thread ${threadId}: ${spawnResult.reason}. Falling back to cold-spawn.`);
       return null;
     }
@@ -1091,6 +1157,8 @@ export class ThreadlineRouter {
     console.log(`[ThreadlineRouter] Warm (keep-alive) session ${sessionName} admitted for thread ${threadId} (peer ${peerId.slice(0, 16)})`);
     return {
       handled: true,
+      accepted: true,
+      delivered: true,
       threadId,
       spawned: true,
       sessionName,
@@ -1110,7 +1178,7 @@ export class ThreadlineRouter {
     entry: ThreadResumeEntry,
     envelope: MessageEnvelope,
     relayContext?: RelayMessageContext,
-  ): Promise<ThreadlineHandleResult | null> {
+  ): Promise<CompleteThreadlineHandleResult | null> {
     if (!this.messageDelivery) return null;
     if (!entry.sessionName) return null;
 
@@ -1146,6 +1214,8 @@ export class ThreadlineRouter {
       console.log(`[ThreadlineRouter] Injected message into live session ${entry.sessionName} for thread ${threadId}`);
       return {
         handled: true,
+        accepted: true,
+        delivered: true,
         threadId,
         injected: true,
         sessionName: entry.sessionName,

--- a/src/threadline/mcp-http-client.ts
+++ b/src/threadline/mcp-http-client.ts
@@ -82,6 +82,7 @@ export async function sendMessageViaHttp(
       error?: string;
       deliveryOutcome?: string;
       deliveryPath?: string;
+      accepted?: boolean;
       delivered?: boolean;
       held?: boolean;
       note?: string;
@@ -104,6 +105,7 @@ export async function sendMessageViaHttp(
         replyFrom: parsed.replyFrom,
         deliveryOutcome: parsed.deliveryOutcome,
         deliveryPath: parsed.deliveryPath,
+        accepted: parsed.accepted,
         // Negotiator lease (Robustness Phase 1): surface withheld/held + the
         // holding note + the commitment-class advisory back to the session.
         delivered: parsed.delivered,

--- a/tests/e2e/threadline/ThreadlineMCPE2E.test.ts
+++ b/tests/e2e/threadline/ThreadlineMCPE2E.test.ts
@@ -374,7 +374,8 @@ describe('ThreadlineMCP E2E', () => {
         arguments: { agentId: 'flaky', message: 'Try 2' },
       });
       const d2 = JSON.parse((r2.content as any)[0].text);
-      expect(d2.delivered).toBe(true);
+      expect(d2.accepted).toBe(true);
+      expect(d2.delivered).toBe(false);
     });
 
     it('handles tool call with missing thread gracefully', async () => {

--- a/tests/integration/threadline-relay-agent-dedup.test.ts
+++ b/tests/integration/threadline-relay-agent-dedup.test.ts
@@ -94,6 +94,8 @@ describe('/messages/relay-agent — content-hash dedup (duplicate-reply fix)', (
 
     handleInboundMessage = vi.fn(async (): Promise<ThreadlineHandleResult> => ({
       handled: true,
+      accepted: true,
+      delivered: true,
       spawned: true,
       threadId: 'thread-abc',
       sessionName: 'session-xyz',
@@ -189,8 +191,51 @@ describe('/messages/relay-agent — content-hash dedup (duplicate-reply fix)', (
     const r2 = await post(envelope({ id: `retry-${crypto.randomUUID()}`, threadId, body }));
     expect(r2.status).toBe(200);
     expect(r2.body.deduped).toBe(true);
+    expect(r2.body.accepted).toBe(false);
+    expect(r2.body.delivered).toBe(false);
+    expect(r2.body.threadline).toEqual({
+      accepted: false,
+      delivered: false,
+      async: false,
+    });
 
     // The receiver must have been handed the message exactly ONCE.
+    expect(handleInboundMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the content reservation when relay admission rejects so a retry can be accepted', async () => {
+    handleInboundMessage.mockClear();
+    const threadId = crypto.randomUUID();
+    const body = 'retry after the first admission failed';
+    const relay = vi.spyOn(messageRouter, 'relay');
+    relay.mockResolvedValueOnce(false);
+
+    const rejected = await post(envelope({ id: `reject-${crypto.randomUUID()}`, threadId, body }));
+    expect(rejected.status).toBe(409);
+
+    relay.mockRestore();
+    const retry = await post(envelope({ id: `retry-${crypto.randomUUID()}`, threadId, body }));
+    expect(retry.status).toBe(200);
+    expect(retry.body.deduped).toBeUndefined();
+    expect(retry.body.accepted).toBe(true);
+    expect(handleInboundMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the content reservation when relay admission throws so a retry can be accepted', async () => {
+    handleInboundMessage.mockClear();
+    const threadId = crypto.randomUUID();
+    const body = 'retry after the first admission threw';
+    const relay = vi.spyOn(messageRouter, 'relay');
+    relay.mockRejectedValueOnce(new Error('inbox unavailable'));
+
+    const rejected = await post(envelope({ id: `throw-${crypto.randomUUID()}`, threadId, body }));
+    expect(rejected.status).toBe(500);
+
+    relay.mockRestore();
+    const retry = await post(envelope({ id: `retry-${crypto.randomUUID()}`, threadId, body }));
+    expect(retry.status).toBe(200);
+    expect(retry.body.deduped).toBeUndefined();
+    expect(retry.body.accepted).toBe(true);
     expect(handleInboundMessage).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/integration/threadline-relay-agent-result.test.ts
+++ b/tests/integration/threadline-relay-agent-result.test.ts
@@ -29,6 +29,8 @@ import { MessageRouter } from '../../src/messaging/MessageRouter.js';
 import { SessionSummarySentinel } from '../../src/messaging/SessionSummarySentinel.js';
 import { SpawnRequestManager } from '../../src/messaging/SpawnRequestManager.js';
 import { generateAgentToken, deleteAgentToken } from '../../src/messaging/AgentTokenManager.js';
+import { ConversationStore } from '../../src/threadline/ConversationStore.js';
+import { WarrantsReplyGate } from '../../src/threadline/WarrantsReplyGate.js';
 import { createTempProject, createMockSessionManager } from '../helpers/setup.js';
 import type { TempProject, MockSessionManager } from '../helpers/setup.js';
 import type { InstarConfig } from '../../src/core/types.js';
@@ -109,7 +111,14 @@ describe('/messages/relay-agent — accept-boundary response (duplicate-reply ro
         await new Promise<void>((r) => { releaseHandler = r; });
       }
       handlerOrder.push('router-end');
-      return { handled: true, spawned: true, threadId: 'thread-abc', sessionName: 'session-xyz' };
+      return {
+        handled: true,
+        accepted: true,
+        delivered: true,
+        spawned: true,
+        threadId: 'thread-abc',
+        sessionName: 'session-xyz',
+      };
     });
 
     const fakeRouter = { handleInboundMessage } as any;
@@ -131,6 +140,8 @@ describe('/messages/relay-agent — accept-boundary response (duplicate-reply ro
         cooldownMs: 1000,
       }),
       threadlineRouter: fakeRouter,
+      conversationStore: new ConversationStore(project.stateDir),
+      warrantsReplyGate: new WarrantsReplyGate(),
     });
 
     await server.start();
@@ -181,7 +192,12 @@ describe('/messages/relay-agent — accept-boundary response (duplicate-reply ro
 
     expect(res.body.ok).toBe(true);
     expect(res.body.accepted).toBe(true);
-    expect(res.body.threadline).toEqual({ accepted: true, async: true });
+    expect(res.body.delivered).toBe(false);
+    expect(res.body.threadline).toEqual({
+      accepted: true,
+      delivered: false,
+      async: true,
+    });
     // The synchronous spawn result is intentionally NOT in the response.
     expect(res.body.threadline.spawned).toBeUndefined();
     expect(res.body.threadline.sessionName).toBeUndefined();
@@ -225,6 +241,68 @@ describe('/messages/relay-agent — accept-boundary response (duplicate-reply ro
     expect(res.body.ok).toBe(true);
     expect(res.body.accepted).toBe(true);
     // The rejection is logged async; it cannot 500 a response that already returned.
+  });
+
+  it('reports durable inbox acceptance explicitly when no Threadline router is wired', async () => {
+    const routeCtx = (server as any).routeContext as { threadlineRouter: unknown };
+    const router = routeCtx.threadlineRouter;
+    routeCtx.threadlineRouter = null;
+    try {
+      const res = await request(app)
+        .post('/messages/relay-agent')
+        .set('Authorization', `Bearer ${relayAgentToken}`)
+        .send(validEnvelope())
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        ok: true,
+        accepted: true,
+        delivered: false,
+        threadline: { accepted: true, delivered: false, async: false },
+      });
+    } finally {
+      routeCtx.threadlineRouter = router;
+    }
+  });
+
+  it('reports warrants-reply suppression as conclusively processed', async () => {
+    handlerOrder.length = 0;
+    releaseHandler = null;
+    const threadId = crypto.randomUUID();
+    const first = validEnvelope();
+    first.message.threadId = threadId;
+    first.message.body = 'thanks for the update';
+    await request(app)
+      .post('/messages/relay-agent')
+      .set('Authorization', `Bearer ${relayAgentToken}`)
+      .send(first)
+      .expect(200);
+    await vi.waitFor(() => expect(releaseHandler).not.toBeNull());
+    releaseHandler!();
+    await vi.waitFor(() => expect(handlerOrder).toContain('router-end'));
+
+    handleInboundMessage.mockClear();
+    const second = validEnvelope();
+    second.message.threadId = threadId;
+    second.message.body = 'got it, thank you';
+    const res = await request(app)
+      .post('/messages/relay-agent')
+      .set('Authorization', `Bearer ${relayAgentToken}`)
+      .send(second)
+      .expect(200);
+
+    expect(res.body).toMatchObject({
+      ok: true,
+      accepted: true,
+      delivered: true,
+      threadline: {
+        handled: true,
+        accepted: true,
+        delivered: true,
+        suppressed: true,
+      },
+    });
+    expect(handleInboundMessage).not.toHaveBeenCalled();
   });
 
   // ── PR-3: waiters re-keyed by threadId (resolved BEFORE the response — unchanged) ──

--- a/tests/integration/threadline/ThreadlineIntegration.test.ts
+++ b/tests/integration/threadline/ThreadlineIntegration.test.ts
@@ -505,6 +505,8 @@ describe('Threadline Integration Tests', () => {
       const result = await router.handleInboundMessage(envelope);
 
       expect(result.handled).toBe(true);
+      expect(result.accepted).toBe(true);
+      expect(result.delivered).toBe(true);
       expect(result.spawned).toBe(true);
       expect(result.error).toBeUndefined();
     });
@@ -534,6 +536,9 @@ describe('Threadline Integration Tests', () => {
       const result = await router.handleInboundMessage(envelope);
 
       expect(result.handled).toBe(true);
+      expect(result.accepted).toBe(true);
+      expect(result.delivered).toBe(false);
+      expect(result.queued).toBe(true);
       expect(result.gateDecision).toBe('queue-for-approval');
       expect(result.approvalId).toBeDefined();
       expect(result.spawned).toBeUndefined();
@@ -574,7 +579,9 @@ describe('Threadline Integration Tests', () => {
       const envelope = makeEnvelope({ threadId: crypto.randomUUID(), fromAgent: 'evil-agent' });
       const result = await router.handleInboundMessage(envelope);
 
-      expect(result.handled).toBe(true);
+      expect(result.handled).toBe(false);
+      expect(result.accepted).toBe(false);
+      expect(result.delivered).toBe(false);
       expect(result.gateDecision).toBe('block');
       expect(result.error).toContain('Blocked');
       expect(spawnManager.evaluate).not.toHaveBeenCalled();
@@ -604,6 +611,8 @@ describe('Threadline Integration Tests', () => {
       const result = await router.handleInboundMessage(envelope);
 
       expect(result.handled).toBe(true);
+      expect(result.accepted).toBe(true);
+      expect(result.delivered).toBe(true);
       expect(result.spawned).toBe(true);
       expect(notifier.notifyUser).toHaveBeenCalled();
     });
@@ -761,7 +770,9 @@ describe('Threadline Integration Tests', () => {
       const envelope = makeEnvelope({ threadId: crypto.randomUUID(), fromAgent: 'remote-agent' });
       const result = await router.handleInboundMessage(envelope);
 
-      expect(result.handled).toBe(true);
+      expect(result.handled).toBe(false);
+      expect(result.accepted).toBe(false);
+      expect(result.delivered).toBe(false);
       expect(result.error).toContain('Spawn denied');
       expect(spawnManager.handleDenial).toHaveBeenCalled();
     });

--- a/tests/integration/threadline/ThreadlineMCP.test.ts
+++ b/tests/integration/threadline/ThreadlineMCP.test.ts
@@ -536,7 +536,8 @@ describe('ThreadlineMCP Integration', () => {
       });
 
       const data = JSON.parse((result.content as any)[0].text);
-      expect(data.delivered).toBe(true);
+      expect(data.accepted).toBe(true);
+      expect(data.delivered).toBe(false);
       expect(data.reply).toBeUndefined();
     });
 
@@ -578,7 +579,8 @@ describe('ThreadlineMCP Integration', () => {
         arguments: { agentId: 'doomed', threadId, message: 'After deletion' },
       });
       const data2 = JSON.parse((sendResult2.content as any)[0].text);
-      expect(data2.delivered).toBe(true);
+      expect(data2.accepted).toBe(true);
+      expect(data2.delivered).toBe(false);
     });
   });
 

--- a/tests/integration/threadline/honest-delivery-wiring.test.ts
+++ b/tests/integration/threadline/honest-delivery-wiring.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Production-wiring regression for honest Threadline delivery receipts.
+ *
+ * A router refusal is now `handled:false`, but it can still carry a resolved
+ * threadId. The relay-ingest fallback must only synthesize and retry when the
+ * router could not resolve a thread at all; otherwise a real refused payload
+ * would be handed to the router twice.
+ */
+
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(root, rel), 'utf-8');
+}
+
+describe('Threadline honest-delivery production wiring', () => {
+  it('does not retry a threadless inbound message when the router already resolved its thread', () => {
+    const server = read('src/commands/server.ts');
+
+    expect(server).toContain('if (!result.handled && !result.threadId && !msg.threadId)');
+  });
+
+  it('passes the configured router through AgentServer into the real route context', () => {
+    const agentServer = read('src/server/AgentServer.ts');
+    const server = read('src/commands/server.ts');
+
+    expect(agentServer).toContain('threadlineRouter: options.threadlineRouter ?? null');
+    expect(server).toMatch(/new AgentServer\(\{[\s\S]*?\bthreadlineRouter,[\s\S]*?\}\);/);
+  });
+
+  it('marks both receiver accept boundaries as accepted but not delivered', () => {
+    const routes = read('src/server/routes.ts');
+    const endpoints = read('src/threadline/ThreadlineEndpoints.ts');
+    const localStart = routes.indexOf("router.post('/messages/relay-agent'");
+    const localEnd = routes.indexOf("router.get('/messages/inbox'", localStart);
+    const localReceiver = routes.slice(localStart, localEnd);
+    const signedStart = endpoints.indexOf("router.post('/threadline/messages/receive'");
+    const signedEnd = endpoints.indexOf("router.post('/threadline/threads/backfill'", signedStart);
+    const signedReceiver = endpoints.slice(signedStart, signedEnd);
+
+    expect(localReceiver).toMatch(/if \(ctx\.threadlineRouter\)[\s\S]*accepted:\s*true,\s*\n\s*delivered:\s*false,\s*\n\s*threadline:/);
+    expect(signedReceiver).toMatch(/accepted:\s*true,\s*\n\s*delivered:\s*false,\s*\n\s*async:/);
+  });
+});

--- a/tests/integration/threadline/negotiator-send-gate.test.ts
+++ b/tests/integration/threadline/negotiator-send-gate.test.ts
@@ -117,6 +117,7 @@ describe('Threadline negotiator send-gate (integration)', () => {
     // Content was WITHHELD.
     expect(json.success).toBe(true);
     expect(json.held).toBe(true);
+    expect(json.accepted).toBe(false);
     expect(json.delivered).toBe(false);
     expect(json.deliveryOutcome).toBe('holding');
     // Only the fixed holding notice reached the peer — NOT the warm session's content.
@@ -127,7 +128,7 @@ describe('Threadline negotiator send-gate (integration)', () => {
     expect(a2aDeliveryTracker.pending().length).toBe(0);
   });
 
-  it('OWNER: the lease-holding session is the voice — content is delivered', async () => {
+  it('OWNER: the lease-holding session is the voice — content is submitted to the relay', async () => {
     await listen(buildApp({ enabled: true, dryRun: false }));
     await conversationStore.acquireOrRenewLease('thread-1', { ownerSessionName: OWNER_SESSION, ownerMachineId: 'machine-a' }, { ttlMs: 90000 });
 
@@ -137,9 +138,12 @@ describe('Threadline negotiator send-gate (integration)', () => {
     });
 
     expect(json.success).toBe(true);
+    expect(json.accepted).toBe(false);
+    expect(json.delivered).toBe(false);
     expect(json.deliveryPath).toBe('relay');
+    expect(json.deliveryOutcome).toBe('submitted to relay; acceptance unconfirmed');
     expect(sentAuto.length).toBe(1);
-    expect(sentAuto[0].text).toBe('real owner content'); // the real content, not a notice
+    expect(sentAuto[0].text).toBe('real owner content'); // real content was submitted, not a notice
   });
 
   it('DRY-RUN: a foreign lease is observed but the content still sends', async () => {

--- a/tests/integration/threadline/relay-send-local-roundtrip.test.ts
+++ b/tests/integration/threadline/relay-send-local-roundtrip.test.ts
@@ -46,7 +46,12 @@ describe('Threadline send — full-stack local delivery round-trip', () => {
     targetApp.get('/threadline/health', (_req, res) => res.json({ ok: true }));
     targetApp.post('/messages/relay-agent', (req, res) => {
       capturedEnvelopes.push(req.body);
-      res.json({ ok: true, threadline: { handled: true, spawned: true, sessionName: 'thread-x', gateDecision: 'allow' } });
+      res.json({
+        ok: true,
+        accepted: true,
+        delivered: false,
+        threadline: { accepted: true, delivered: false, async: true },
+      });
     });
     await new Promise<void>((resolve) => {
       fakeTarget = targetApp.listen(0, '127.0.0.1', () => {
@@ -99,7 +104,7 @@ describe('Threadline send — full-stack local delivery round-trip', () => {
     SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'relay-send-local-roundtrip:cleanup' });
   });
 
-  it('delivers locally and maps deliveryPath="local" success back through the helper', async () => {
+  it('maps the real local accept boundary without claiming asynchronous processing is delivered', async () => {
     const result = await sendMessageViaHttp(
       { targetAgent: TARGET, message: 'roundtrip hello', waitForReply: false, timeoutSeconds: 120 },
       port,
@@ -107,6 +112,9 @@ describe('Threadline send — full-stack local delivery round-trip', () => {
     );
 
     expect(result.success).toBe(true);
+    expect(result.accepted).toBe(true);
+    expect(result.delivered).toBe(false);
+    expect(result.deliveryOutcome).toBe('accepted for async processing');
     expect(result.deliveryPath).toBe('local');
     expect(result.messageId).toBeTruthy();
     expect(result.threadId).toBeTruthy();

--- a/tests/integration/threadline/warm-session-a2a.test.ts
+++ b/tests/integration/threadline/warm-session-a2a.test.ts
@@ -228,4 +228,53 @@ describe('Warm-Session A2A — integration (router + pool + spawn manager)', () 
     expect(pool.get('shared-thread')?.peerId).toBe('fp-owner'); // untouched
     expect(pool.get('shared-thread')?.sessionName).toBe('echo-owner');
   });
+
+  it('a queued warm refusal does not evaluate and queue the same inbound again on the cold path', async () => {
+    const pool = new WarmSessionPool({ globalCap: 3, perPeerCap: 1, ttlMs: 600_000 });
+    let evaluateCalls = 0;
+    let denialCalls = 0;
+    const queuedSpawnManager = {
+      evaluate: async () => {
+        evaluateCalls += 1;
+        return {
+          approved: false,
+          queued: true,
+          reason: 'Memory pressure too high for new session',
+          retryAfterMs: 60_000,
+        };
+      },
+      handleDenial: () => {
+        denialCalls += 1;
+      },
+    };
+    const router = new ThreadlineRouter(
+      { getThread: async () => null } as any,
+      queuedSpawnManager as any,
+      resumeMap,
+      {} as any,
+      { localAgent: 'LocalAgent', localMachine: 'local' },
+      null,
+      messageDelivery as any,
+      undefined,
+      undefined,
+      pool,
+      true,
+      'verified',
+      null,
+    );
+
+    const result = await router.handleInboundMessage(
+      makeEnvelope(crypto.randomUUID(), 'fp-dawn'),
+      relayCtx('fp-dawn', true),
+    );
+
+    expect(evaluateCalls).toBe(1);
+    expect(denialCalls).toBe(1);
+    expect(result).toMatchObject({
+      handled: false,
+      accepted: true,
+      delivered: false,
+      queued: true,
+    });
+  });
 });

--- a/tests/unit/relayContentDedup.test.ts
+++ b/tests/unit/relayContentDedup.test.ts
@@ -26,6 +26,13 @@ describe('RelayContentDedup', () => {
     expect(d.shouldProcess('codey', 'thread-1', 'fix the bug')).toBe(false);
   });
 
+  it('forgets a reservation that failed admission so an identical retry can proceed', () => {
+    const d = new RelayContentDedup({ now: () => 1000 });
+    expect(d.shouldProcess('codey', 'thread-1', 'fix the bug')).toBe(true);
+    d.forget('codey', 'thread-1', 'fix the bug');
+    expect(d.shouldProcess('codey', 'thread-1', 'fix the bug')).toBe(true);
+  });
+
   it('processes again once the window has elapsed (plausibly a real re-send)', () => {
     const clock = mkClock();
     const d = new RelayContentDedup({ ttlMs: 60_000, now: clock.now });

--- a/tests/unit/spawn-request-manager.test.ts
+++ b/tests/unit/spawn-request-manager.test.ts
@@ -367,6 +367,7 @@ describe('SpawnRequestManager', () => {
       // payload, it does not weaken the guard.
       expect(result.reason).toContain('Memory pressure');
       expect(result.retryAfterMs).toBe(120_000);
+      expect(result.queued).toBe(true);
 
       expect(manager.getStatus().queuedMessages).toEqual([
         { agent: 'agent-a', count: 1 },
@@ -413,6 +414,7 @@ describe('SpawnRequestManager', () => {
 
       expect(result.approved).toBe(false);
       expect(result.reason).toContain('Memory pressure');
+      expect(result.queued).toBe(false);
       // An empty payload must not create a phantom queue row.
       expect(manager.getStatus().queuedMessages).toEqual([]);
     });
@@ -454,6 +456,7 @@ describe('SpawnRequestManager', () => {
       }));
 
       expect(refused.approved).toBe(false);
+      expect(refused.queued).toBe(false);
       expect(manager.getQueuedCount('agent-z')).toBe(0); // genuinely not queued
       // The loss is now accounted rather than silent.
       expect(manager.isTruncated('agent-z')).toBe(true);

--- a/tests/unit/threadline-mcp-send-path.test.ts
+++ b/tests/unit/threadline-mcp-send-path.test.ts
@@ -79,7 +79,9 @@ describe('sendMessageViaHttp — honest error surfacing', () => {
         messageId: 'msg-1',
         threadId: 'thread-1',
         deliveryPath: 'relay',
-        deliveryOutcome: 'spawned new session',
+        deliveryOutcome: 'reply received',
+        accepted: true,
+        delivered: true,
         reply: 'hi back',
         replyFrom: 'dawn',
       }),
@@ -91,10 +93,33 @@ describe('sendMessageViaHttp — honest error surfacing', () => {
     expect(result.messageId).toBe('msg-1');
     expect(result.threadId).toBe('thread-1');
     expect(result.deliveryPath).toBe('relay');
-    expect(result.deliveryOutcome).toBe('spawned new session');
+    expect(result.deliveryOutcome).toBe('reply received');
+    expect(result.accepted).toBe(true);
+    expect(result.delivered).toBe(true);
     expect(result.reply).toBe('hi back');
     expect(result.replyFrom).toBe('dawn');
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves an accepted-but-not-delivered receipt instead of upgrading it to delivery', async () => {
+    fetchMock.mockResolvedValueOnce(
+      fakeResponse(200, {
+        success: true,
+        messageId: 'msg-accepted',
+        threadId: 'thread-accepted',
+        deliveryPath: 'local',
+        deliveryOutcome: 'accepted for async processing',
+        accepted: true,
+        delivered: false,
+      }),
+    );
+
+    const result = await sendMessageViaHttp(baseParams(), PORT, TOKEN);
+
+    expect(result.success).toBe(true);
+    expect(result.accepted).toBe(true);
+    expect(result.delivered).toBe(false);
+    expect(result.deliveryOutcome).toBe('accepted for async processing');
   });
 
   it('surfaces a 404 agent-not-found error without an envelope fallback', async () => {

--- a/tests/unit/threadline/ThreadlineEndpoints.test.ts
+++ b/tests/unit/threadline/ThreadlineEndpoints.test.ts
@@ -417,7 +417,12 @@ describe('ThreadlineEndpoints', () => {
 
       // Accepted immediately, async flagged, no spawn-outcome fields.
       expect(res.status).toBe(200);
-      expect(res.body).toMatchObject({ accepted: true, async: true, threadId: 't-1' });
+      expect(res.body).toMatchObject({
+        accepted: true,
+        delivered: false,
+        async: true,
+        threadId: 't-1',
+      });
       expect(res.body.spawned).toBeUndefined();
       expect(res.body.resumed).toBeUndefined();
       // The handler STARTED but the response did NOT await it (still pending).

--- a/tests/unit/threadline/ThreadlineMCPServer.test.ts
+++ b/tests/unit/threadline/ThreadlineMCPServer.test.ts
@@ -490,6 +490,7 @@ describe('ThreadlineMCPServer', () => {
         });
 
         const data = JSON.parse((result.content as any)[0].text);
+        expect(data.accepted).toBe(true);
         expect(data.delivered).toBe(true);
         expect(data.threadId).toBe('thread-new-123');
         expect(data.reply).toBe('Hello back!');
@@ -548,7 +549,8 @@ describe('ThreadlineMCPServer', () => {
           }),
         );
         const data = JSON.parse((result.content as any)[0].text);
-        expect(data.delivered).toBe(true);
+        expect(data.accepted).toBe(true);
+        expect(data.delivered).toBe(false);
         expect(data.reply).toBeUndefined();
         expect(data.note).toBeUndefined();
       } finally {
@@ -575,8 +577,36 @@ describe('ThreadlineMCPServer', () => {
         });
 
         const data = JSON.parse((result.content as any)[0].text);
-        expect(data.delivered).toBe(true);
+        expect(data.accepted).toBe(true);
+        expect(data.delivered).toBe(false);
         expect(data.reply).toBeUndefined();
+      } finally {
+        await close();
+      }
+    });
+
+    it('does not infer acceptance from a legacy success response with an error outcome', async () => {
+      (deps.sendMessage as any).mockResolvedValue({
+        success: true,
+        threadId: 'thread-legacy-error',
+        messageId: '',
+        deliveryOutcome: 'error: Spawn denied: memory pressure',
+      });
+
+      const { client, close } = await connectClientServer({}, deps);
+      try {
+        const result = await client.callTool({
+          name: 'threadline_send',
+          arguments: {
+            agentId: 'remote-agent',
+            message: 'Legacy refusal',
+          },
+        });
+
+        const data = JSON.parse((result.content as any)[0].text);
+        expect(data.accepted).toBe(false);
+        expect(data.delivered).toBe(false);
+        expect(data.outcome).toContain('Spawn denied');
       } finally {
         await close();
       }
@@ -602,7 +632,8 @@ describe('ThreadlineMCPServer', () => {
         });
 
         const data = JSON.parse((result.content as any)[0].text);
-        expect(data.delivered).toBe(true);
+        expect(data.accepted).toBe(true);
+        expect(data.delivered).toBe(false);
         expect(data.reply).toBeNull();
         expect(data.note).toContain('No reply received');
       } finally {

--- a/tests/unit/threadline/ThreadlineRouter.test.ts
+++ b/tests/unit/threadline/ThreadlineRouter.test.ts
@@ -602,6 +602,7 @@ describe('ThreadlineRouter', () => {
         approved: false,
         reason: 'Session limit reached',
         retryAfterMs: 60_000,
+        queued: true,
       } as SpawnResult);
 
       const threadId = crypto.randomUUID();
@@ -609,7 +610,10 @@ describe('ThreadlineRouter', () => {
 
       const result = await router.handleInboundMessage(envelope);
 
-      expect(result.handled).toBe(true);
+      expect(result.handled).toBe(false);
+      expect(result.accepted).toBe(true);
+      expect(result.delivered).toBe(false);
+      expect(result.queued).toBe(true);
       expect(result.error).toContain('Session limit reached');
       expect(result.spawned).toBeUndefined();
       expect(result.resumed).toBeUndefined();
@@ -652,7 +656,9 @@ describe('ThreadlineRouter', () => {
 
       const result = await router.handleInboundMessage(envelope);
 
-      expect(result.handled).toBe(true);
+      expect(result.handled).toBe(false);
+      expect(result.accepted).toBe(false);
+      expect(result.delivered).toBe(false);
       expect(result.error).toContain('Spawn system crashed');
     });
   });

--- a/upgrades/next/threadline-honest-delivery-receipts.md
+++ b/upgrades/next/threadline-honest-delivery-receipts.md
@@ -1,0 +1,35 @@
+# Threadline now reports acceptance and delivery separately
+
+## What Changed
+
+Threadline send results now distinguish two facts that were previously collapsed:
+
+- `accepted` means the receiver, relay, or queue retained responsibility for the message.
+- `delivered` means there is concrete evidence that a live handler processed it, or a reply proves processing.
+
+Temporary spawn refusals are accepted only when the current payload actually entered the bounded retry queue. Autonomy blocks, internal errors, and unqueued refusals are neither accepted nor delivered. Approval queues and asynchronous receiver acknowledgement can be accepted without being delivered. Relay socket submission and duplicate suppression remain unaccepted until stronger evidence arrives; a reply proves both acceptance and processing.
+
+The sender-facing MCP tool no longer defaults a successful HTTP request to `delivered:true`. Local and relay send routes preserve the explicit result, replies upgrade delivery evidence, and an explicit legacy error cannot be inferred as accepted. An updated sender is conservative with an older receiver. An older sender still has its historical default and must upgrade before it interprets the new fields correctly.
+
+A production-wiring review found that the existing threadless relay fallback could call the router twice after an honestly unhandled refusal. It now synthesizes and retries only when the router also failed to resolve a thread.
+
+The same review found that content deduplication reserved a key before inbox admission. A rejected or thrown first attempt could therefore poison the valid retry. Failed admission now releases that reservation, while a genuinely duplicated request is suppressed without claiming that its earlier twin was accepted.
+
+Warm-session admission had a related double-fire: a transient refusal could queue the payload and then immediately re-evaluate it on the cold path. A queued warm refusal now stops after the first admission and reports queued/not-delivered.
+
+## What to Tell Your User
+
+When one agent sends work to another, “the transport took it” no longer appears as “the other agent processed it.” You can now tell the difference between accepted work, queued work, proven delivery, and refusal. This removes the false success that made a genuinely refused message look delivered.
+
+## Summary of New Capabilities
+
+No new endpoint, flag, or operator control. Existing Threadline responses gain honest acceptance/delivery semantics, and the sender-facing tool exposes both facts.
+
+## Evidence
+
+- Every new behavioral regression was exercised against the unfixed source first and failed on the intended false claim or missing field.
+- The production-wiring regression failed on the old threadless fallback before the source fix, proving the test covers the real constructor/listener path rather than an injected substitute.
+- Pre-hardening affected and adjacent run: 364/364 unit/integration assertions plus 66/66 E2E assertions.
+- Final post-hardening run: 341/341 assertions across the 15 changed receipt/wiring test files, plus 5/5 no-silent-fallback ratchet assertions at the exact 495 baseline.
+- Full lint, TypeScript typecheck, production build, `git diff --check`, and three independent re-reviews: pass.
+- The broad local sweep also surfaced unrelated session-launch fixture/config leakage and tmux timing failures in untouched files; those are not represented as patch failures, and authoritative sharded CI remains required before merge.

--- a/upgrades/side-effects/threadline-honest-delivery-receipts.md
+++ b/upgrades/side-effects/threadline-honest-delivery-receipts.md
@@ -1,0 +1,131 @@
+# Side-Effects Review — Honest Threadline delivery receipts
+
+**Version / slug:** `threadline-honest-delivery-receipts`
+**Date:** `2026-07-30`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `three independent reviewers — all concur`
+
+## Summary of the change
+
+This change separates local submission, receiver acceptance, and proven processing across `SpawnRequestManager`, `ThreadlineRouter`, the two receiver accept boundaries, the local/relay send route, the MCP HTTP client, and the MCP result. It narrows the production threadless fallback so a newly honest `handled:false` refusal cannot cause a second router invocation. Second-pass review also made content dedup admission transactional: a rejected or thrown inbox admission releases its reservation, while a duplicate is suppressed without claiming acceptance. Pressure, autonomy, trust, quota, and spawn-admission verdicts remain unchanged.
+
+## Decision-point inventory
+
+- `SpawnRequestManager.#refuseTransiently` — modify — reports whether this exact refused payload entered the bounded retry queue.
+- `ThreadlineRouter.handleInboundMessage` result exits — modify — separates handled, accepted, delivered, and queued without changing the underlying gate verdict.
+- `/messages/relay-agent` and `/threadline/messages/receive` accept boundaries — modify — explicitly report accepted but not delivered before background processing.
+- `/threadline/relay-send` result mapping — modify — preserves explicit receipt facts and uses concrete legacy completion signals only.
+- `ThreadlineMCPServer` send result — modify — stops defaulting successful transport to delivered.
+- Relay-ingest threadless fallback — modify — retries only when no thread was resolved, preventing double handling after a refusal.
+- Relay content dedup — modify — reserves before inbox admission, rolls back on rejection/throw, and reports suppressed duplicates conservatively.
+
+---
+
+## 1. Over-block
+
+The change touches two deterministic block/allow surfaces. The threadless fallback no longer retries an unhandled result when the router already resolved a thread; the legitimate excluded input is precisely a refusal that would otherwise be double-fired. Content dedup still suppresses an identical sender/thread/content triple within 60 seconds, so a deliberate verbatim resend inside that window remains an accepted pre-existing tradeoff. This patch makes that suppression explicit and prevents a failed first admission from poisoning the retry.
+
+---
+
+## 2. Under-block
+
+This patch cannot prove eventual processing after an asynchronous accept boundary unless a later reply or existing receipt path supplies evidence. A receiver can accept work and then restart before in-memory queued work is drained; that durability gap is tracked separately by CMT-1112. A first request that was durably admitted but failed during later processing can cause an equivalent retry to be suppressed for the bounded 60-second dedup window. Mixed-version receivers can omit `accepted`; an updated sender treats successful non-held, non-error legacy responses as accepted but never infers delivery without concrete evidence.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The queue-admission boolean is a low-level fact produced by the component that owns the queue. The router composes that fact with its actual processing outcome, and the MCP surface reports the composed facts. `handled` also drives deterministic retry/recovery structure, so the production fallback was reviewed and narrowed at that consumer rather than treated as display-only. Dedup remains an enumerable idempotency invariant, not conversational judgment.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP. Reshape the design. Brittle detectors must not own block authority. Either promote the logic to smart-gate level (with proper context) or demote it to a signal that feeds an existing smart gate.
+
+**Applicable posture:** deterministic structural authority over enumerable invariants, which the template's four conversational-gate choices do not name. The fallback may retry only when no thread was resolved, and dedup may suppress only the existing exact normalized triple within its fixed window. Neither interprets intent or competing conversational signals, so an LLM-backed smart gate would be the wrong abstraction.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic exists at a competing-signals decision point. “A live handler processed this message,” “the receiver accepted it,” “the relay socket was merely submitted to,” and “this payload entered the queue” are enumerable state facts. The compatibility fallback is deliberately one-way: absent explicit proof may imply acceptance only after successful non-error legacy transport, but never delivery.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** Reporting happens after existing trust, autonomy, lease, quota, and pressure checks. Dedup still runs before inbox admission to reserve against concurrent duplicates, but now rolls that reservation back if admission rejects or throws.
+- **Double-fire:** Changing a refusal to `handled:false` exposed the production threadless fallback as a possible second invocation. The fallback now also requires no resolved thread, and a fail-first wiring regression pins that condition.
+- **Races:** The local `/messages/relay-agent` endpoint acknowledges after durable `MessageRouter` inbox admission but before background spawn. The signed `/threadline/messages/receive` endpoint acknowledges authenticated in-process responsibility before its optional canonical write and background handoff; its pre-existing crash-before-handoff window remains and is not mislabeled durable custody. Both say only `accepted:true, delivered:false`, avoiding the historical timeout/retry race. A concurrent duplicate sees a conservative unaccepted suppression result rather than fabricated acceptance.
+- **Feedback loops:** The immediate MCP result does not feed the router. Existing later reply and acknowledgement systems may strengthen delivery evidence, but no new retry loop is introduced.
+
+---
+
+## 6. External surfaces
+
+Other agents now see separate `accepted` and `delivered` fields. Existing success, thread, reply, held, note, and path fields remain. Relay socket submission is explicitly unconfirmed (`accepted:false, delivered:false`); asynchronous receiver acceptance is `accepted:true, delivered:false`. Suppression is conclusively processed, while duplicate suppression claims neither fact. The exported result fields remain optional for source compatibility with older external fixtures, while the built-in router returns both. No external service, persistent schema, URL, credential, or operator action changes.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated behavior** — the semantics travel with the installed Instar package on each machine, while the wire format is additive for mixed-version peers. An updated sender treats an older receiver conservatively. The reverse direction is limited: an old sender ignores the new fields and can retain its historical false `delivered:true` default until that sending machine upgrades. There is no new durable state to replicate or proxy. This change emits no user-facing notices, generates no URLs, and holds no new state that can strand during topic transfer.
+
+---
+
+## 8. Rollback cost
+
+Pure code and response-semantics change: revert and ship a patch. There is no data migration, state repair, or cleanup. Rollback would restore the false-positive `delivered:true` behavior while propagation completes, which is the only user-visible regression.
+
+---
+
+## Conclusion
+
+The reviews found and changed six interactions: the threadless double-fire fallback, queued warm-refusal double admission, unacknowledged relay submission, poisoned dedup reservations, legacy error acceptance, and receipt omissions on suppression/no-router success branches. Each behavioral correction has a fail-first regression. Fast receiver acknowledgement remains intact, the exported type stays source-compatible, and authoritative A2A documentation now uses the new meanings. All three independent reviewers concur after re-review.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** correctness, production-wiring, and side-effects reviewers
+**Independent read of the artifact: concur**
+
+- Relay socket submission was falsely called accepted; it is now unconfirmed until reply evidence.
+- Dedup could retain a rejected/throwing reservation; both failure modes now release it.
+- Legacy explicit error outcomes could infer acceptance; the fallback now excludes them.
+- Suppression and no-router success branches omitted receipt fields; both are explicit.
+- A queued warm refusal fell through and queued the same inbound again on the cold path; it now returns after one admission.
+- Mixed-version directionality, deterministic retry/dedup authority, type compatibility, and A2A documentation were corrected.
+
+All reviewers independently verified the corrections and concurred.
+
+---
+
+## Evidence pointers
+
+- New receipt and wiring regressions were run against the unfixed source first; the focused unfixed run exposed missing queue admission, false handled/delivered results, lost HTTP fields, the unsafe threadless fallback, and the omitted held-path acceptance result.
+- Reviewer-added regressions failed before their fixes for unconfirmed relay acceptance, rejected and thrown dedup admission, legacy error acceptance, and omitted receiver-branch fields.
+- Pre-hardening affected and adjacent verification: 364/364 unit/integration assertions plus 66/66 E2E assertions.
+- Final post-hardening affected verification: 341/341 assertions across all 15 changed receipt, wiring, integration, and E2E files; the no-silent-fallback ratchet is also at its exact 495 baseline (5/5 assertions).
+- Full lint chain, TypeScript typecheck, production build, and `git diff --check`: pass.
+- A broad local sweep was interrupted after it exposed unrelated session-launch fixture/config leakage and tmux timing failures in untouched files. Those signals are recorded rather than mislabeled green; authoritative sharded CI remains the merge gate.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no added or modified self-triggered controller — not applicable.


### PR DESCRIPTION
## ELI16

When one agent sends work to another, there are two different moments that matter: someone takes responsibility for the message, and a live agent actually processes it. The old result blurred those moments together. A relay accepting bytes, a receiver starting asynchronous work, or a temporary spawn refusal could all appear to the sender as `delivered: true`, even when no live agent had seen the message.

This patch gives those moments separate names. `accepted` means the next layer retained responsibility; `delivered` means there is concrete processing evidence, such as a successful live-session injection, completed spawn or resume, explicit suppression that conclusively processed the request, or a reply. A receiver can now acknowledge quickly as `accepted: true, delivered: false` without reintroducing timeout-driven duplicate sends. A temporary refusal is accepted only when that exact payload actually entered the retry queue.

The change also closes the production interactions exposed by honest refusals. The threadless recovery path no longer hands a resolved-but-refused message to the router twice. Warm-session admission stops after one queued refusal rather than falling through and queueing the payload again. Relay content dedup releases its reservation when inbox admission rejects or throws, so a failed first attempt cannot poison a valid retry. Unacknowledged relay socket submission and duplicate suppression no longer fabricate acceptance or delivery.

## Root cause

The sender-facing MCP path treated successful transport as proof of delivery, while receiver endpoints intentionally respond before slow session work completes. `ThreadlineRouter` also returned `handled: true` for spawn refusals, and the queue API did not report whether the exact refused payload had actually been retained. Those mismatched meanings propagated across receiver routes, local and relay send mapping, the HTTP helper, and the MCP result.

## What changed

- Added explicit acceptance and delivery facts to router outcomes and sender-visible results.
- Bound transient-refusal acceptance to exact queue admission.
- Preserved fast asynchronous receiver acknowledgements without claiming processing.
- Propagated receipts through local, relay, HTTP-helper, and MCP paths.
- Kept legacy compatibility conservative: successful legacy transport may imply acceptance, but delivery requires concrete evidence.
- Narrowed production fallback and warm-session paths to prevent double handling.
- Made relay dedup reservations transactional on admission failure.
- Updated the durable-delivery spec, plain-English overview, upgrade guide, and side-effects analysis.

## UX Impact

Who sees this: agents and operators reading the immediate `threadline_send` result. The user-visible behavior changes at first contact with a receiver: a fast asynchronous acknowledgement now says `accepted for async processing` and reports accepted-but-not-delivered, instead of presenting transport success as proof that the receiving agent processed the message. A reply or concrete live-session result still upgrades the receipt to delivered. Existing endpoint names, controls, and send flow are unchanged; the visible change is more precise status, not an added interaction.

## Validation

Every new behavioral regression was first run against unfixed commit `707dacbe` and failed on the intended false claim, missing field, duplicate path, or poisoned reservation. After the final hardening change:

- 341/341 affected assertions passed across all 15 changed receipt, wiring, integration, and E2E files.
- 333/333 path-scoped Threadline E2E assertions passed in the pre-push gate.
- The no-silent-fallback ratchet passed 5/5 at its exact existing 495-item baseline.
- Full TypeScript typecheck and lint passed.
- Production build passed.
- `git diff --check` and deletion review passed.
- Three independent review passes (correctness, production wiring, side effects) concurred after fixes.

A broad local sweep also surfaced unrelated session-launch fixture/config leakage and tmux timing failures in untouched files; this PR does not label that sweep green. The authoritative sharded CI rollup remains the merge gate: zero failures, zero pending real checks, E2E passed, and clean mergeability are required before safe merge.