### PR TITLE
docs(standards): strengthen the Migration Parity citation (gate → ratchet)

### DIFF
--- a/docs/STANDARDS-REGISTRY.md
+++ b/docs/STANDARDS-REGISTRY.md
@@ -417,7 +417,7 @@ The Root says *enforce behavior in structure, not willpower.* This family is **w
 
 ### Migration Parity
 **Rule.** Any change to agent-installed files (hooks, config defaults, CLAUDE.md template, built-in skills) must reach *existing* agents through the update path — not only new agents via `init`.
-**In practice.** Hook-template changes get a `migrateSettings()` patch (the migration surface is `src/core/PostUpdateMigrator.ts`); config defaults get existence-checked additions; built-in hooks are *always overwritten* on migration; every migration is idempotent.
+**In practice.** Hook-template changes get a `migrateSettings()` patch (the migration surface is `src/core/PostUpdateMigrator.ts`; the binding gate is `tests/integration/migration-guarantee.test.ts`, which runs eight committed pre-migration agent shapes through both code paths and asserts zero job loss and zero schedule drift, and which `scripts/protect-migration-guarantee.js` refuses to let a commit delete); config defaults get existence-checked additions; built-in hooks are *always overwritten* on migration; every migration is idempotent.
 **Earned from.** The zombie-cleanup-kills-active-sessions bug (deployed agents ran stale config that killed live sessions) and the hook-event-reporter ESM bug (install-if-missing left ESM-host agents stuck on a broken CJS hook). A feature that only works for new agents is a broken feature.
 **Traces to the goal.** Agents evolve *in place*. Evolution that doesn't reach the already-deployed self isn't evolution.
 


### PR DESCRIPTION
## ELI16 — I went back and attacked my own work, and one citation was weak

Today I closed nine constitutional rules by pointing them at guards that already existed. All nine were my own judgement with no second reader. So rather than move on, I re-read them **adversarially** — asking of each one *"what would make this wrong?"* instead of re-confirming it works.

One did not survive, and this fixes it.

**The rule:** any change to files installed on agents must reach *existing* agents, not only new ones. I had pointed it at the component that performs migrations. That is what the rule's own text names, so it is not false — but it is the **vehicle, not the enforcement**. Naming the thing that carries changes does not establish that anything *refuses* a change which forgot to bring one.

**The real guard exists and is much stronger.** There is a test suite that describes itself as "the binding gate": the release process refuses to advance unless it passes, and it runs eight recorded pre-upgrade agent states through both upgrade paths, asserting that no scheduled job is lost and no schedule silently drifts. And there is a second guard whose only job is to refuse any commit that deletes that test — a ratchet protecting the ratchet.

**Consequence:** the rule reclassifies from "has a guard" to **"has a ratchet"** — the strongest category, reserved for a guard backed by a test. The gap count and percentage do not move (this rule was already counted as covered); what changes is that the audit now records it at its **true strength** instead of understating it.

**Also considered and deliberately not cited:** the deletion-guard on its own. It protects the test; it does not enforce the rule. Citing it as the guard would have been a different overreach in exactly the shape this commit corrects.

## Why this matters beyond the one rule

The verification I did earlier confirmed every citation *resolves*. That is a different and much weaker question than whether each guard *enforces the rule it is now attached to*. Confirming is not reviewing. This pass took the second question seriously against my own work, and it found something in the first hour — which is roughly the rate I would expect if someone else audited it, and a reason to want that too.