### PR TITLE
docs(standards): cite the orphan-deferral guard for No Deferrals (25 gaps → 24)

### DIFF
--- a/docs/STANDARDS-REGISTRY.md
+++ b/docs/STANDARDS-REGISTRY.md
@@ -586,7 +586,7 @@ that reset-safe posture must be explicit and tested rather than assumed.
 
 ### No Deferrals
 **Rule.** Ship complete features and fixes. A deferral requires a same-PR tracked commitment with active follow-through — never an orphaned "later" note.
-**In practice.** "Tactical now + the rest later" without owned follow-through is how regressions recur. Default to comprehensive.
+**In practice.** "Tactical now + the rest later" without owned follow-through is how regressions recur. Default to comprehensive. Enforced by the orphan-deferral step in `scripts/instar-dev-precommit.js`: a spec carrying deferral language must track each instance with an explicit marker or a frontmatter field, and the commit is refused otherwise (the override is an env var and is logged).
 **Earned from.** A PR that deferred "lifeline auto-restart on server upgrade" — and that exact gap produced a regression two days later.
 **Traces to the goal.** Coherence over time means today's shortcut doesn't become next week's outage.
 


### PR DESCRIPTION
## ELI16 — the rule against half-finished work, and the check that already enforces it

Tenth rule closed in this series. Our constitution has 82; an audit checks whether each names a guard that really exists.

**"Ship complete work. If you must defer something, it needs a tracked commitment — never an orphaned 'later' note."**

That is genuinely enforced. A check runs before every commit: if a spec contains deferral language — *deferred*, *out of scope today*, *follow-up*, *not in this PR* — every instance must carry an explicit tracking marker, or **the commit is refused**. There is an override, and it is an environment variable that gets logged rather than a quiet exception.

**The guard and the rule share an origin**, which is the strongest evidence a mapping is real rather than plausible. The check's own comment records it: a pull request shipped four of five fixes for one failure class and deferred the fifth as out of scope. Two days later that exact deferral caused the same outage. The operator's response was that our work should focus on complete fixes with no deferrals — and someone turned that into a check instead of a paragraph.

**On citing the same file twice.** This file is now named by two different rules. That is correct rather than lazy: it is a gate that runs several independent checks, and the two rules point at two different ones. I verified this check blocks for the same reason I verified the other — the hook stops at the first failure, so a refusal isn't overwritten by a later passing check.

## Measured

**25 gaps → 24, 64.63% → 65.85%**, dangling references stay at zero.

## Where this series stands

Ten rules closed today: **34 gaps → 24, 53.66% → 65.85%**. Two citations strengthened after re-reading my own work adversarially — both times I had named the component that *computes* a verdict rather than the one that *acts* on it. And **five candidates examined and deliberately not cited**, including one whose machinery I proved broken earlier today: citing a guard I had just demonstrated does not work would be the worst possible version of this exercise.

The caveat that travels with the number: it measures *"a guard of this shape exists and is named"*, never *"this guard enforces this rule"*.