### PR TITLE
docs(finding): accepts-and-ignores — three surfaces that take an argument they don't implement and answer success

### DIFF
--- a/docs/findings/2026-07-30-accepts-and-ignores.md
+++ b/docs/findings/2026-07-30-accepts-and-ignores.md
@@ -1,0 +1,100 @@
+---
+title: "Accepts-and-ignores: three surfaces that take an argument they do not implement and answer success"
+date: 2026-07-30
+author: echo
+machine: Mac Mini
+severity: medium
+status: open
+kind: finding
+relates:
+  - "docs/findings/2026-07-30-correction-loop-cannot-promote.md"
+  - "docs/findings/2026-07-30-conformance-audit-probes-a-stale-tree.md"
+---
+
+## The claim
+
+Three surfaces on the commitments API accept an argument they do not implement, discard it, and answer with
+a success-shaped response. **Rejection is safe. Silence would be safe. Plausible success is the dangerous
+third option**, and all three take it.
+
+I found each separately, hours apart, while doing unrelated work. Naming them as one class is the point —
+individually each reads as a small omission; together they are a pattern in how this API answers.
+
+## The three, each re-verified with a nonsense control
+
+**1. `GET /commitments?status=` is accepted and discarded.**
+
+| query | records returned |
+|---|---|
+| `?status=pending` | 1145 |
+| `?status=withdrawn` | 1145 |
+| `?status=zzznotarealstatus` | **1145** |
+
+A **nonsense** status returns the identical full set. So the response is unfiltered regardless of what is
+asked, while looking exactly like a filtered one.
+
+**2. `GET /commitments?limit=` is never read.**
+
+| query | records returned |
+|---|---|
+| `?limit=5` | 1145 |
+| `?limit=50` | 1145 |
+| `?limit=5000` | 1145 |
+
+**3. `POST /commitments/:id/transition` accepts a `to` naming a lifecycle status it does not implement.**
+
+```
+POST /commitments/CMT-1131/transition  {"to":"zzznotarealstatus"}
+→ {"transitioned": true, "id": "CMT-1131", "owner": "agent", "blockedOn": "external"}
+```
+
+Status afterwards: unchanged. The route transitions the **owner ⟂ blockedOn** pair — which is what it was
+built for — and never inspects a lifecycle status. A caller passing one gets the owner-pair no-op, and the
+no-op reports `true`. The real path is a separate `POST /commitments/:id/withdraw`.
+
+*(Control: a snapshot of CMT-1131 taken before the probe shows it was already `owner: agent /
+blockedOn: external / status: pending`, so the nonsense call mutated nothing — this was a genuine no-op, not
+a partial write.)*
+
+## What it actually cost
+
+**Instance 1 nearly produced two false alarms in one read.** Running a check with `?status=pending` returned
+withdrawn commitments alongside pending ones. A downstream filter then matched four items I had personally
+withdrawn hours earlier, and I was one step from reporting both a serious regression and a
+silent-withdrawal-failure bug that does not exist. What saved it was reading one record directly and finding
+it correctly `withdrawn` — the list was wrong, not the store.
+
+**Instance 3 silently failed five withdrawals.** Five stale commitments each returned `transitioned: true`
+and none changed. Only a read-back caught it; without that, five monuments would have sat in the ledger
+looking closed.
+
+## Why this shape is worse than an error
+
+A rejected argument teaches the caller the API in one round trip. An **ignored** argument returns something
+plausible, so the caller builds on it — and the wrongness surfaces later, somewhere else, as a conclusion
+rather than as an error. In instance 1 that meant a superset presented as a filtered set; in instance 3, a
+no-op presented as a state change.
+
+This is the same family as two other findings from the same day — a health surface reporting a status it
+never computed, and an audit reporting a confident ratio from a source tree it never verified. **The common
+shape: a response asserting more than the work behind it supports.**
+
+## Direction
+
+For each surface: **honour the argument, or reject it. Never accept and drop it.** For the transition route
+specifically, a `400` naming the correct route (`use POST /commitments/:id/withdraw`) is strictly better than
+either alternative — it costs the caller one read and teaches the API.
+
+The load-bearing test in every case is the same, and it is the one currently missing: **call the surface with
+an argument it does not implement and assert the response is NOT success-shaped.** A test that only exercises
+supported arguments cannot distinguish "handled" from "ignored".
+
+## What is NOT claimed
+
+- **Not** that any of these is a data-corruption risk. All three are read-path or no-op behaviours; instance
+  3 was verified against a pre-probe snapshot to have mutated nothing.
+- **Not** that the transition route is wrong to transition owner/blockedOn. That is its documented purpose
+  and it does it correctly. The defect is that it accepts an argument outside that purpose.
+- **Not** an exhaustive audit. I found three on one API **without looking for them** — which is what suggests
+  a pattern rather than three coincidences. Whether other routes do the same is untested, and worth a sweep.
+- **Not** measured on any other agent. One machine, one API.


### PR DESCRIPTION
## ELI16 — three places that take an instruction, throw it away, and say "done"

Found separately, hours apart, while doing other things. Individually each looks like a small omission. Together they are a pattern in how one part of our API answers, which is why they are written up as one thing.

**Asking for only the unfinished items returns everything.** Ask for "pending" — 1145 records. Ask for "withdrawn" — the same 1145. Ask for a **completely made-up word** — the same 1145 again. The filter is never applied, and the answer looks exactly like a filtered one.

**Asking for five records returns 1145.** So does asking for fifty, or five thousand.

**Telling a commitment to change state reports success and changes nothing.** I withdrew five stale items this way. All five came back "done". All five were still open. The route in question exists to change *who is waiting on what*, and it genuinely does that — it simply never looks at the kind of instruction I was giving it, so my instruction hit a no-op, and the no-op reported success. The correct route is a different one.

## What it actually cost today

The first one nearly made me report two serious bugs that don't exist. A check I ran asking for unfinished items came back including finished ones; a filter downstream then flagged four things I had personally closed hours earlier, and I was one step from telling the operator we had a serious regression *and* a silent-failure bug. What saved it was reading one record directly and finding it correctly closed — **the list was wrong, not the data.**

The third one silently failed five state changes. The only thing that caught it was reading each record back afterwards.

## Why this shape is worse than an error

**Rejecting an instruction is safe. Ignoring it silently is not.** A rejection teaches you the API in one round trip. An ignored instruction hands back something plausible that you then build on — and the wrongness surfaces much later, somewhere else, as a wrong conclusion rather than as an error message.

This is the same family as two other things found the same day: a health check reporting a status it never computed, and an audit reporting a confident figure from a copy of the code it never checked was current. **The common shape is a response claiming more than the work behind it supports.**

## What would fix it

Honour the instruction, or refuse it. Never accept and drop it. For the state-change route, refusing with "use the other route" is the best of the three — it costs one read and teaches the API.

The test that is missing in all three cases is the same: **give the surface an instruction it doesn't implement and check the answer is not success-shaped.** A test that only tries valid instructions cannot tell "handled" from "ignored".

## Honest limits

No data was corrupted — all three are read-path or no-op behaviours, and I verified the third against a snapshot taken before probing, so it changed nothing. The state-change route is not wrong to do its real job; it is wrong to accept work outside it. And this is not a sweep: I found three on one API **without looking for them**, which is what suggests a pattern rather than a coincidence. Whether others do the same is untested.