### PR TITLE
chore(standards): ratchet the enforced-ratio floor 0 → 0.64

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-30T22-37-09-887Z-standards-enforced-ratio-floor.json
+++ b/.instar/instar-dev-decisions/2026-07-30T22-37-09-887Z-standards-enforced-ratio-floor.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-30T22:37:09.887Z",
+  "slug": "standards-enforced-ratio-floor",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 17,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/standards-coverage.mjs"
+    ],
+    "addedLines": 12,
+    "deletedLines": 5
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/standards-enforced-ratio-floor.eli16.md
+++ b/docs/eli16/standards-enforced-ratio-floor.eli16.md
@@ -1,0 +1,54 @@
+# ELI16 — locking in today's constitution gain so it can't quietly slide back
+
+We keep a constitution of 82 rules. An audit checks, for each one, whether the guard it claims actually
+exists — and a build check runs that audit every time anyone pushes.
+
+That check already had teeth in one place: if a rule points at a guard that isn't there, the build fails.
+Zero tolerance, and it works.
+
+**But the other number it measures — what fraction of rules are actually guarded — had its floor set to
+zero.** So the figure was calculated and printed on every build, and nothing happened no matter what it
+said. If it fell from today's level all the way back to where it started this morning, the build would still
+pass.
+
+Today that fraction moved from 53.7% to about 65%, because ten rules that were already being enforced
+finally got citations the audit could see. **This change sets the floor just below where we now are**, so
+that gain becomes a level every future build has to clear rather than a number someone can undo without
+noticing.
+
+## Why this can't break anyone's work
+
+The floor is set *below* today's measured value. Any build that doesn't make things worse passes exactly as
+it did before. The only thing it can newly stop is a change that lowers the fraction — someone adding a rule
+with no guard, or deleting a guard a rule depends on. That is precisely what it's for, and the failure
+message names both the floor and the measured value so the author can see what happened.
+
+There's roughly one rule's worth of headroom, so it won't trip on rounding.
+
+## The bit where I nearly got it wrong
+
+I first set the floor from a number I'd been quoting all day — about 65.9%. Then I ran the actual build
+script and it reported 65.4%, counting 81 rules where the other tool counts 82. **Two pieces of code
+measuring the same thing from the same file, disagreeing by one.**
+
+So I set the floor against the number the *build* uses, since the build is what enforces it, and left more
+headroom than I'd planned. I wrote the disagreement into the code comment rather than quietly picking the
+nicer figure — a future reader should know those two numbers don't match, because otherwise they'll trust
+both.
+
+## Undoing it
+
+There's already an environment setting that overrides the floor, so it can be switched off in the build
+config with no code change at all. Or revert one line. Nothing is stored, nothing migrates.
+
+## What I checked
+
+I proved it can actually fail, rather than only that it passes: set the floor artificially high and the
+check exits with an error; set it to the real value and it passes. A guard nobody has watched fail isn't a
+guard.
+
+## What this is not
+
+It doesn't make our rules better enforced. It measures whether each rule *names a guard that exists* — not
+whether that guard genuinely does the job. This locks in bookkeeping, not safety. The real work is still the
+24 rules that name no guard at all.

--- a/scripts/standards-coverage.mjs
+++ b/scripts/standards-coverage.mjs
@@ -57,11 +57,18 @@ const numEnv = (env, def) => {
   return v !== undefined && v !== '' && Number.isFinite(Number(v)) ? Number(v) : def;
 };
 const FLOORS = {
-  // Starts at 0 ("starts loose", the docs-coverage rationale) — the script's first
-  // job is to PREVENT regression (a new unguarded standard / a removed guard file)
-  // while the existing gap closes. Ratchet this upward (a visible PR diff) as the
-  // documented-only set shrinks.
-  enforcedRatio: numEnv('STANDARDS_ENFORCED_RATIO_FLOOR', 0),
+  // Started at 0 ("starts loose", the docs-coverage rationale) while the gap closed.
+  // Ratcheted to 0.64 on 2026-07-30: the documented-only set shrank 34 -> 24 that day
+  // (ten standards whose guards already existed gained resolvable citations). THIS
+  // script measures 0.6543; note the library (StandardsEnforcementAuditor, which the
+  // /conformance route serves) measures 0.6585 over 82 standards where this parser
+  // counts 81 — a known one-article discrepancy between two implementations of the
+  // same measure, recorded rather than averaged away. The floor is set against THIS
+  // script's number, since this script is what CI runs, with roughly one standard of
+  // headroom so a single unguarded addition surfaces as a real signal rather than
+  // tripping the build on rounding. It cannot fail a build that does not regress.
+  // Ratchet upward again (a visible PR diff) as the documented-only set shrinks.
+  enforcedRatio: numEnv('STANDARDS_ENFORCED_RATIO_FLOOR', 0.64),
   // Zero tolerance: a standard must NEVER cite a guard that doesn't exist.
   danglingCeiling: numEnv('STANDARDS_DANGLING_CEILING', 0),
 };

--- a/upgrades/next/standards-enforced-ratio-floor.md
+++ b/upgrades/next/standards-enforced-ratio-floor.md
@@ -1,0 +1,40 @@
+## What Changed
+
+The CI standards-coverage check now enforces a floor on the **enforced-ratio**, not only on dangling guard
+references. `FLOORS.enforcedRatio` moves from `0` to `0.64` in `scripts/standards-coverage.mjs`.
+
+Previously the ratio was computed and printed on every build with a floor of `0`, so a regression from the
+current level all the way back to the original one would still have passed. The dangling ceiling already had
+teeth at zero; the ratio did not.
+
+This is the maintenance action the script's own comment asks for — *"Ratchet this upward (a visible PR diff)
+as the documented-only set shrinks"* — taken after the documented-only set shrank from 34 standards to 24.
+
+## Evidence
+
+- The repository measures **0.6543** against the new **0.64** floor, so no build that does not regress can
+  fail. Verified by running `node scripts/standards-coverage.mjs --check` → exit 0.
+- Verified the ratchet **bites** rather than only passes: `STANDARDS_ENFORCED_RATIO_FLOOR=0.99` → exit 1,
+  `STANDARDS_ENFORCED_RATIO_FLOOR=0.64` → exit 0.
+- `tests/unit/standards-coverage-ratchet.test.ts` already covers the floor-regression and dangling-ceiling
+  failure paths and reads the committed constant, so it exercises this value rather than a copy.
+- Noted while choosing the value: this script measures **0.6543 over 81 standards** where
+  `StandardsEnforcementAuditor` measures **0.6585 over 82**, over the same registry file. The floor is set
+  against this script's number because this script is what CI runs; the discrepancy is recorded in the code
+  comment rather than averaged away.
+
+## What to Tell Your User
+
+Nothing — this is a CI-only maintenance change with no runtime, route, config or agent-visible surface. A
+deployed agent never executes this script.
+
+The one case where it becomes visible is a future pull request that adds a constitutional standard without a
+resolvable guard citation, or removes a guard file a standard cites: that build now fails with a message
+naming both the floor and the measured ratio. That failure is the intended signal.
+
+Rolling it back needs no code change: an environment setting that already exists can put the floor back to
+zero in the build configuration.
+
+## Summary of New Capabilities
+
+No new capability. An existing gate stops being toothless on one of the two measures it already reports.

--- a/upgrades/side-effects/standards-enforced-ratio-floor.md
+++ b/upgrades/side-effects/standards-enforced-ratio-floor.md
@@ -1,0 +1,89 @@
+# Side-Effects Review — ratchet the standards enforced-ratio floor 0 → 0.64
+
+**Parent standard:** Structure beats Willpower (the constitution's root) — a measurement nobody can regress
+is worth more than a measurement someone must remember to check.
+**Files:** `scripts/standards-coverage.mjs` (one constant + its comment).
+**Not a feature.** No flag, no route, no config key, no migration. A committed floor moves.
+
+## What changed
+
+`FLOORS.enforcedRatio` default: `0` → `0.64`. The surrounding comment is rewritten to record why, what the
+measured value was, and the cross-implementation discrepancy found while choosing it.
+
+This is the action the script's own comment asks the next person to take: *"Ratchet this upward (a visible
+PR diff) as the documented-only set shrinks."* It shrank **34 → 24** on 2026-07-30, as ten standards whose
+guards already existed gained resolvable citations (#1762–#1766, #1769, #1771–#1773).
+
+## Blast radius
+
+**Exactly one consumer.** `FLOORS` is read only by this script's own `--check`, which runs as the
+`standards-coverage` job in `ci.yml`. Nothing else imports it; no route, no runtime path, no agent behaviour
+reads it. A fleet agent never executes this file.
+
+**It cannot fail a build that does not regress.** The repository measures **0.6543** today against a
+**0.64** floor. Every build whose ratio is at or above today's level passes exactly as before. The only
+builds it can newly fail are those that *lower* the ratio — which is the entire purpose.
+
+**What it will newly fail, stated plainly so it is not a surprise:** a PR that adds a constitutional standard
+without a resolvable guard citation, or removes a guard file a standard cites, far enough to drop the ratio
+below 0.64. On today's 81-standard denominator that is roughly one standard of headroom. **That failure is
+the intended signal, not a false positive** — and the message names the floor and the measured value, so the
+author sees immediately what happened.
+
+**The dangling ceiling is untouched** (still zero, still enforced). This change adds teeth to the ratio only.
+
+## The margin, and the discrepancy that set it
+
+I first chose **0.65**, taken from `StandardsEnforcementAuditor.computeCoverage` reporting **0.6585 over 82
+standards**. Running the real script showed it reports **0.6543 over 81** — over the *same* registry file.
+Two implementations of the same measure disagree by one article.
+
+I did not average them or pick the flattering one. The floor is set against **this script's** number,
+because this script is what CI executes, with roughly one standard of headroom rather than the 0.0043
+(about a third of a standard) that 0.65 would have left. **The discrepancy is recorded in the code comment
+rather than resolved**, because resolving it is a separate piece of work and hiding it would make a future
+reader trust two numbers that do not agree.
+
+## Rollback
+
+Three levers, cheapest first:
+1. `STANDARDS_ENFORCED_RATIO_FLOOR=0` in the CI job — the env override already exists and needs no code
+   change.
+2. Revert the constant to `0`.
+3. Revert the commit.
+
+No state is written, no migration runs, nothing persists. Rollback is instantaneous and total.
+
+## Verification
+
+**Proven to fail, not merely to pass** — a guard nobody has watched fail is not a guard:
+
+```
+STANDARDS_ENFORCED_RATIO_FLOOR=0.99  node scripts/standards-coverage.mjs --check  → exit 1
+STANDARDS_ENFORCED_RATIO_FLOOR=0.64  node scripts/standards-coverage.mjs --check  → exit 0
+```
+
+The existing `tests/unit/standards-coverage-ratchet.test.ts` already covers the floor-regression and
+dangling-ceiling failure paths against a temp fixture, and it reads the floor from the committed constant —
+so it exercises this value rather than a hardcoded copy.
+
+## Multi-machine posture
+
+**Not applicable — machine-local by construction.** This is a CI script executed by GitHub Actions on a
+checkout. It reads no agent state, contacts no peer, and is never run by a deployed agent.
+
+## Signal vs. authority
+
+The script is **authority** by design: it fails a build. That authority already existed for the dangling
+ceiling; this change extends it to the ratio, where it was previously advisory-by-accident (floored at 0, so
+computed and reported but never binding). No new *kind* of authority is introduced — an existing gate stops
+being toothless on one of its two measures.
+
+## What this does NOT claim
+
+- **Not** that 0.64 is the right long-term floor. It is today's measured level minus headroom, and the
+  comment says to ratchet it again as the gap closes.
+- **Not** that the ratio measures enforcement quality. It measures that *a guard of the declared shape
+  exists and is named* — the auditor says so itself. This change locks in a bookkeeping level, not a safety
+  level.
+- **Not** a fix for the 81-vs-82 discrepancy, which is recorded and left open.


### PR DESCRIPTION
## ELI16 — locking in today's constitution gain so it can't quietly slide back

We keep a constitution of 82 rules, and a build check verifies that each one names a guard which really exists. That check already had teeth in one place: point a rule at a guard that isn't there and the build fails. Zero tolerance, and it works.

**The other number it measures — what fraction of rules are actually guarded — had its floor set to zero.** So the figure was calculated and printed on every build, and nothing happened whatever it said. If it fell from today's level all the way back to where it started this morning, the build would still pass.

Today that fraction moved from 53.7% to about 65%, because ten rules that were already being enforced finally got citations the check could see. **This sets the floor just below where we now are**, turning that gain into a level every future build must clear rather than a number someone can undo without noticing.

This is the maintenance action the script's own comment asks the next person to take: *"Ratchet this upward as the documented-only set shrinks."* It shrank from 34 to 24 today.

## Why this can't break anyone's work

The floor sits *below* today's measured value, so any build that doesn't make things worse passes exactly as before. The only thing it can newly stop is a change that lowers the fraction — someone adding a rule with no guard, or deleting a guard a rule depends on. That is precisely what it's for, and the failure message names both the floor and the measured value.

There's roughly one rule's worth of headroom, so it won't trip on rounding.

## The bit where I nearly got it wrong

I first set the floor from a number I'd been quoting all day — about 65.9%. Then I ran the actual build script and it reported **65.4%, counting 81 rules where the other tool counts 82.** Two pieces of code measuring the same thing from the same file, disagreeing by one.

So I set the floor against the number the *build* uses, since the build is what enforces it, and left more headroom than planned. The disagreement is written into the code comment rather than quietly resolved in favour of the nicer figure — a future reader should know those two numbers don't match, because otherwise they'll trust both.

## Verified it can fail

A guard nobody has watched fail isn't a guard. Set the floor artificially high and the check exits with an error; set it to the real value and it passes. The existing unit suite already covers the failure paths and reads the committed constant, so it exercises this value rather than a copy.

## What this is not

It does **not** make our rules better enforced. It measures whether each rule *names a guard that exists* — never whether that guard does the job. This locks in bookkeeping, not safety, and the artifact says so. The real work is still the 24 rules that name no guard at all.

Rolling it back needs no code change: an environment setting that already exists puts the floor back to zero.