### PR TITLE
fix(conformance): verify source-tree freshness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ src/redteam/packs/*/payloads/L3.md
 # the TS-source (vitest) and compiled (production) layouts. Build output, never committed.
 src/data/standards-registry.md
 src/data/standards-registry.meta.json
+src/data/standards-guard-index.json
+src/data/standards-guard-index.meta.json

--- a/.instar/instar-dev-decisions/2026-07-31T04-24-11-175Z-conformance-source-freshness.json
+++ b/.instar/instar-dev-decisions/2026-07-31T04-24-11-175Z-conformance-source-freshness.json
@@ -1,0 +1,34 @@
+{
+  "ts": "2026-07-31T04:24:11.175Z",
+  "slug": "conformance-source-freshness",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 490,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/generate-standards-registry-asset.mjs",
+      "src/core/StandardsEnforcementAuditor.ts"
+    ],
+    "addedLines": 448,
+    "deletedLines": 42
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The guard-tree probe established capability from two landmarks but never established identity or freshness. Agent homes legitimately retained old source copies, so a coherent stale tree passed every internal check. The registry side already carried a same-build integrity basis; this change applies the same structure to audit-relevant source evidence."
+  },
+  "classClosure": {
+    "defectClass": "stale-source-accepted-by-landmarks",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/standards-enforcement-auditor.test.ts",
+      "howCaught": "A landmark-complete stale fixture is rejected unless its complete audit-evidence index exactly matches the same-build packed index; the matching checkout is selected and the no-match boundary returns null."
+    }
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-07-31T04-25-28-135Z-conformance-source-freshness.json
+++ b/.instar/instar-dev-decisions/2026-07-31T04-25-28-135Z-conformance-source-freshness.json
@@ -1,0 +1,34 @@
+{
+  "ts": "2026-07-31T04:25:28.135Z",
+  "slug": "conformance-source-freshness",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 490,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/generate-standards-registry-asset.mjs",
+      "src/core/StandardsEnforcementAuditor.ts"
+    ],
+    "addedLines": 448,
+    "deletedLines": 42
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The guard-tree probe established capability from two landmarks but never established identity or freshness. Agent homes legitimately retained old source copies, so a coherent stale tree passed every internal check. The registry side already carried a same-build integrity basis; this change applies the same structure to audit-relevant source evidence."
+  },
+  "classClosure": {
+    "defectClass": "stale-source-accepted-by-landmarks",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/standards-enforcement-auditor.test.ts",
+      "howCaught": "A landmark-complete stale fixture is rejected unless its complete audit-evidence index exactly matches the same-build packed index; the matching checkout is selected and the no-match boundary returns null."
+    }
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-07-31T04-21-37-000Z-conformance-source-freshness.json
+++ b/.instar/instar-dev-traces/2026-07-31T04-21-37-000Z-conformance-source-freshness.json
@@ -1,0 +1,40 @@
+{
+  "version": 3,
+  "slug": "conformance-source-freshness",
+  "sessionId": "conformance-source-freshness",
+  "timestamp": "2026-07-31T04:21:37.000Z",
+  "artifactPath": "upgrades/side-effects/conformance-source-freshness.md",
+  "artifactSha256": "d585b2d5bd8a45ac6016c265dafa1d620ae520a0def562f8688a45065ddc962d",
+  "coveredFiles": [
+    ".gitignore",
+    "scripts/generate-standards-registry-asset.mjs",
+    "src/core/StandardsEnforcementAuditor.ts",
+    "tests/integration/standards-coverage-route.test.ts",
+    "tests/setup/build-dist.globalSetup.ts",
+    "tests/setup/ensure-registry-asset.globalSetup.ts",
+    "tests/unit/standards-enforcement-auditor.test.ts",
+    "tests/unit/standards-registry-asset.test.ts",
+    "docs/eli16/conformance-source-freshness.eli16.md",
+    "upgrades/side-effects/conformance-source-freshness.md"
+  ],
+  "phase": "complete",
+  "tier": 1,
+  "tierReasoning": "Tier 1: read-only conformance-source selection and generated build evidence. No mutation of runtime state, config, database, messaging, or route wiring. The HTTP payload is additive inside the existing summary.guards object. Unit tests cover both sides of source identity; the existing route integration test proves production exposure.",
+  "eli16Path": "docs/eli16/conformance-source-freshness.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/conformance-source-freshness.md",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The guard-tree probe established capability from two landmarks but never established identity or freshness. Agent homes legitimately retained old source copies, so a coherent stale tree passed every internal check. The registry side already carried a same-build integrity basis; this change applies the same structure to audit-relevant source evidence."
+  },
+  "classClosure": {
+    "defectClass": "stale-source-accepted-by-landmarks",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/standards-enforcement-auditor.test.ts",
+      "howCaught": "A landmark-complete stale fixture is rejected unless its complete audit-evidence index exactly matches the same-build packed index; the matching checkout is selected and the no-match boundary returns null."
+    }
+  },
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/eli16/conformance-source-freshness.eli16.md
+++ b/docs/eli16/conformance-source-freshness.eli16.md
@@ -1,0 +1,49 @@
+# Conformance source freshness
+
+## The problem
+
+The standards audit checks whether every guard named by the constitution exists. It used
+the agent's configured project directory. An agent home can contain an old copy of
+`src/` with all the expected landmarks, so the audit confidently counted missing guards
+that exist in current code.
+
+Landmarks answer “could this be source code?” They do not answer “is this the source code
+that belongs to the constitution and package I am auditing?”
+
+## The repair
+
+The build now creates a deterministic index of every audit-relevant file, route, and
+symbol from the real source checkout. It stamps that index with:
+
+- its own SHA-256;
+- the constitution SHA-256; and
+- the package version.
+
+At runtime the audit checks a small, bounded set of plausible checkouts. A checkout wins
+only if recomputing its complete guard index exactly matches the packed same-build index.
+The configured agent home, `repo/` convention, current working directory, executing
+package root, and sibling development-agent `repo/` directories are candidates; there is
+no broad home-directory crawl.
+
+If a matching checkout exists, the audit reads that live tree and reports its real path.
+If an install has no checkout, it can still use the verified packed evidence rather than
+deleting the capability. If neither basis verifies, landmark-only results are explicitly
+untrustworthy.
+
+## Why this catches the real failure
+
+A stale tree may still contain `src/server/routes.ts` and `src/core`, so it passes the old
+probe. It cannot reproduce an index containing current guard files, routes, and symbols.
+The semantic test creates exactly that state: the stale tree passes both landmarks but is
+rejected, while the matching checkout is selected.
+
+On the measured machine, resolving with Echo's stale home configured selects the current
+Codey worktree, reports zero dangling references, and exposes the selected path, basis,
+index SHA, registry SHA, and package version in `summary.guards`.
+
+## Limits
+
+The index proves equality for the evidence this audit consumes, not byte-for-byte identity
+of every source file. That is the correct boundary: this audit measures named-reference
+existence, not source equivalence or guard execution. The SHA stamps are build consistency
+checks, not adversarial signatures.

--- a/scripts/generate-standards-registry-asset.mjs
+++ b/scripts/generate-standards-registry-asset.mjs
@@ -2,10 +2,12 @@
 /**
  * generate-standards-registry-asset — ship the constitution with the code that reads it.
  *
- * Reads the authored `docs/STANDARDS-REGISTRY.md` and writes two build artifacts:
+ * Reads the authored registry and the real source checkout, then writes four artifacts:
  *
  *   dist/data/standards-registry.md        — a VERBATIM byte copy
  *   dist/data/standards-registry.meta.json — { sha256, articleCount, generatedFrom }
+ *   dist/data/standards-guard-index.json    — deterministic guard evidence from ROOT
+ *   dist/data/standards-guard-index.meta.json — same-build sha/registry/version stamp
  *
  * Deterministic, no network. Runs AFTER `tsc` in the build chain: after compile
  * (so `dist/` and the shared parser exist) and before packaging. A clean step
@@ -193,13 +195,34 @@ if (typeof packageVersion !== 'string' || packageVersion.length === 0) {
 }
 
 const meta = `${JSON.stringify({ sha256, articleCount, generatedFrom: SOURCE_REL, packageVersion }, null, 2)}\n`;
+let guardIndex;
+try {
+  const auditorUrl = pathToFileURL(path.join(ROOT, 'dist', 'core', 'StandardsEnforcementAuditor.js')).href;
+  const { buildGuardTreeIndex } = await import(auditorUrl);
+  guardIndex = buildGuardTreeIndex(ROOT, bytes.toString('utf-8'), packageVersion);
+} catch (err) {
+  die(
+    `could not build the guard evidence index from the real source tree — ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+  );
+}
+const guardIndexBytes = Buffer.from(`${JSON.stringify(guardIndex, null, 2)}\n`, 'utf-8');
+const guardIndexSha256 = crypto.createHash('sha256').update(guardIndexBytes).digest('hex');
+const guardIndexMeta = `${JSON.stringify({
+  sha256: guardIndexSha256,
+  registrySha256: sha256,
+  packageVersion,
+}, null, 2)}\n`;
 for (const dir of OUT_DIRS) {
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, 'standards-registry.md'), bytes);
   fs.writeFileSync(path.join(dir, 'standards-registry.meta.json'), meta);
+  fs.writeFileSync(path.join(dir, 'standards-guard-index.json'), guardIndexBytes);
+  fs.writeFileSync(path.join(dir, 'standards-guard-index.meta.json'), guardIndexMeta);
 }
 
 console.log(
-  `✓ standards registry asset: ${articleCount} articles, sha256 ${sha256.slice(0, 12)}… → ` +
+  `✓ standards registry asset: ${articleCount} articles, registry ${sha256.slice(0, 12)}…, ` +
+    `guards ${guardIndexSha256.slice(0, 12)}… → ` +
     OUT_DIRS.map((d) => path.relative(ROOT, d)).join(' + '),
 );

--- a/src/core/StandardsEnforcementAuditor.ts
+++ b/src/core/StandardsEnforcementAuditor.ts
@@ -25,6 +25,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 import { parseStandardsRegistryDetailed, runRegistryCanary } from './StandardsRegistryParser.js';
 import { extractEnforcementRefs, flattenRefs, type EnforcementRef } from './StandardEnforcementExtractor.js';
 import { earnsVerified, readAuthoredConstitution, type RegistryIntegrity } from './standardsRegistryPath.js';
@@ -251,12 +252,51 @@ export interface CoverageReport {
  * a confident zero.
  */
 export interface GuardTreeProvenance {
-  /** The directory refs were resolved against. */
+  /** The directory refs were resolved against, or the packed-index sentinel. */
   projectDir: string;
+  /** The configured directory, retained when a packed index supersedes a stale local tree. */
+  configuredProjectDir: string;
   /** Whether that directory actually contains an analyzable instar source tree. */
   analyzable: boolean;
   /** The markers probed, so a reader can see WHY it was judged (un)analyzable. */
   markersFound: string[];
+  /** The independently checkable basis used to select this guard evidence. */
+  basis:
+    | 'executing-source-tree'
+    | 'source-tree-index-match'
+    | 'packed-source-index-match'
+    | 'configured-tree-unverified'
+    | 'not-probed';
+  /** True only when the tree/index is tied to the code and constitution being read. */
+  freshnessVerified: boolean;
+  /** Plain-English explanation of what established (or failed to establish) freshness. */
+  freshnessReason: string;
+  /** sha256 of the packed source index, when that is the basis. */
+  sourceIndexSha256: string | null;
+  /** Registry sha the packed index was generated against. */
+  registrySha256: string | null;
+  /** Package version the packed index was generated for. */
+  packageVersion: string | null;
+}
+
+export interface GuardTreeIndex {
+  schemaVersion: 1;
+  generatedFrom: 'source-tree';
+  registrySha256: string;
+  packageVersion: string;
+  guards: VerifiedGuard[];
+}
+
+interface GuardTreeIndexMeta {
+  sha256: string;
+  registrySha256: string;
+  packageVersion: string;
+}
+
+interface GuardEvidenceResolution {
+  provenance: GuardTreeProvenance;
+  indexedGuards: Map<string, VerifiedGuard> | null;
+  packedIndex?: GuardTreeIndex;
 }
 
 export interface AuditorOptions {
@@ -530,6 +570,294 @@ function verifyRefs(
   });
 }
 
+function guardKey(guard: Pick<VerifiedGuard, 'kind' | 'ref'>): string {
+  return `${guard.kind}\u0000${guard.ref}`;
+}
+
+/**
+ * Build the deterministic evidence index shipped beside the packed constitution.
+ *
+ * This runs in the real source checkout during `npm run build`, where the source tree
+ * is unambiguous. Runtime installs need not guess which old checkout happens to sit in
+ * `projectDir`; they verify and consume this same-build index instead.
+ */
+export function buildGuardTreeIndex(
+  projectDir: string,
+  registryMarkdown: string,
+  packageVersion: string,
+): GuardTreeIndex {
+  const { articles } = parseStandardsRegistryDetailed(registryMarkdown);
+  const extracted = articles.map((article) => extractEnforcementRefs(article));
+  const refsByKey = new Map<string, EnforcementRef>();
+  const wantedMarkers = new Set<string>();
+  for (const refs of extracted) {
+    for (const ref of flattenRefs(refs)) {
+      refsByKey.set(`${ref.kind}\u0000${ref.ref}`, ref);
+      if (ref.kind === 'marker') wantedMarkers.add(ref.ref);
+    }
+  }
+  const routeTable = loadRouteTable(projectDir);
+  const symbolIndex = buildSymbolIndex(projectDir, wantedMarkers);
+  const guards = verifyRefs(
+    [...refsByKey.values()].sort((a, b) => guardKey(a).localeCompare(guardKey(b))),
+    projectDir,
+    routeTable,
+    symbolIndex,
+  );
+  return {
+    schemaVersion: 1,
+    generatedFrom: 'source-tree',
+    registrySha256: crypto.createHash('sha256').update(registryMarkdown).digest('hex'),
+    packageVersion,
+    guards,
+  };
+}
+
+function executingPackageRoot(): string | null {
+  try {
+    return fileURLToPath(new URL('../../', import.meta.url));
+  } catch {
+    // @silent-fallback-ok: this is one candidate identity only. The packed-index
+    // resolver below remains authoritative for published installs and returns a
+    // surfaced, untrustworthy provenance when it cannot verify its own artifacts.
+    return null;
+  }
+}
+
+function sameDirectory(a: string, b: string): boolean {
+  try {
+    return fs.realpathSync(a) === fs.realpathSync(b);
+  } catch {
+    // @silent-fallback-ok: inability to prove path identity is a negative result,
+    // never permission to label a configured tree as current.
+    return false;
+  }
+}
+
+function sameGuardIndex(left: GuardTreeIndex, right: GuardTreeIndex): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+/**
+ * Select a real checkout only when its audit-relevant evidence exactly matches the
+ * same-build packed index. Landmark presence alone is deliberately insufficient.
+ */
+export function findMatchingGuardTree(
+  candidates: string[],
+  expected: GuardTreeIndex,
+  registryMarkdown: string,
+  packageVersion: string,
+): string | null {
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    let canonical: string;
+    try {
+      canonical = fs.realpathSync(candidate);
+    } catch {
+      // @silent-fallback-ok: a missing candidate is not a degraded audit result; it
+      // simply cannot prove identity and the next bounded candidate is evaluated.
+      continue;
+    }
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+    if (!probeGuardTree(canonical).analyzable) continue;
+    let observed: GuardTreeIndex;
+    try {
+      observed = buildGuardTreeIndex(canonical, registryMarkdown, packageVersion);
+    } catch {
+      // @silent-fallback-ok: one optional candidate that cannot be fully indexed
+      // has not established identity. Continue to the next bounded candidate; the
+      // packed fallback retains analysis and exposes its own basis.
+      continue;
+    }
+    if (sameGuardIndex(observed, expected)) return canonical;
+  }
+  return null;
+}
+
+function guardTreeCandidates(configuredProjectDir: string): string[] {
+  const candidates = [
+    configuredProjectDir,
+    path.join(configuredProjectDir, 'repo'),
+    process.cwd(),
+  ];
+  const packageRoot = executingPackageRoot();
+  if (packageRoot) candidates.push(packageRoot);
+
+  // Agent deployments keep a bounded fleet at `<agents>/<name>` and development
+  // agents keep their checkout at `<agent>/repo`. Search only that one known level:
+  // no home-directory crawl, no arbitrary project discovery.
+  const agentsDir = path.dirname(configuredProjectDir);
+  if (path.basename(agentsDir) === 'agents') {
+    try {
+      for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true }).slice(0, 100)) {
+        if (entry.isDirectory()) candidates.push(path.join(agentsDir, entry.name, 'repo'));
+      }
+    } catch {
+      // @silent-fallback-ok: fleet-layout discovery is an optional bounded candidate
+      // source. Package-local evidence below retains the capability and reports its basis.
+    }
+  }
+  return candidates;
+}
+
+function readPackedGuardIndex(
+  registrySha256: string,
+  runningPackageVersion: string | null,
+  configuredProjectDir: string,
+): GuardEvidenceResolution | null {
+  let indexPath: string;
+  let metaPath: string;
+  try {
+    indexPath = fileURLToPath(new URL('../data/standards-guard-index.json', import.meta.url));
+    metaPath = fileURLToPath(new URL('../data/standards-guard-index.meta.json', import.meta.url));
+  } catch {
+    // @silent-fallback-ok: malformed module URL means this candidate is unavailable;
+    // the caller returns configured-tree-unverified with the failed freshness claim
+    // visible in the report.
+    return null;
+  }
+
+  let bytes: Buffer;
+  let parsed: unknown;
+  let meta: unknown;
+  try {
+    bytes = fs.readFileSync(indexPath);
+    parsed = JSON.parse(bytes.toString('utf-8'));
+    meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+  } catch {
+    // @silent-fallback-ok: a missing/unreadable index is not substituted or trusted.
+    // The caller exposes the absence as an unverified guard-tree basis.
+    return null;
+  }
+  const index = parsed as Partial<GuardTreeIndex>;
+  const stamp = meta as Partial<GuardTreeIndexMeta>;
+  const observedSha256 = crypto.createHash('sha256').update(bytes).digest('hex');
+  const structurallyValid =
+    index.schemaVersion === 1
+    && index.generatedFrom === 'source-tree'
+    && typeof index.registrySha256 === 'string'
+    && typeof index.packageVersion === 'string'
+    && Array.isArray(index.guards)
+    && index.guards.every((guard) =>
+      guard !== null
+      && typeof guard === 'object'
+      && typeof (guard as VerifiedGuard).ref === 'string'
+      && ['file', 'route', 'marker'].includes((guard as VerifiedGuard).kind)
+      && typeof (guard as VerifiedGuard).refResolves === 'boolean');
+  const stampMatches =
+    stamp.sha256 === observedSha256
+    && stamp.registrySha256 === registrySha256
+    && stamp.packageVersion === runningPackageVersion
+    && index.registrySha256 === registrySha256
+    && index.packageVersion === runningPackageVersion;
+  if (!structurallyValid || !stampMatches) return null;
+
+  const indexedGuards = new Map<string, VerifiedGuard>();
+  for (const guard of index.guards as VerifiedGuard[]) {
+    indexedGuards.set(guardKey(guard), { ...guard });
+  }
+  return {
+    provenance: {
+      projectDir: '(packed same-build source index)',
+      configuredProjectDir,
+      analyzable: true,
+      markersFound: ['packed guard evidence'],
+      basis: 'packed-source-index-match',
+      freshnessVerified: true,
+      freshnessReason:
+        `the source evidence index sha256 ${observedSha256} matches its build meta, registry ` +
+        `sha256 ${registrySha256}, and running package version ${runningPackageVersion}`,
+      sourceIndexSha256: observedSha256,
+      registrySha256,
+      packageVersion: runningPackageVersion,
+    },
+    indexedGuards,
+    packedIndex: index as GuardTreeIndex,
+  };
+}
+
+function resolveGuardEvidence(
+  opts: AuditorOptions,
+  registryMarkdown: string,
+): GuardEvidenceResolution {
+  const registrySha256 = crypto.createHash('sha256').update(registryMarkdown).digest('hex');
+  const configuredProbe = probeGuardTree(opts.projectDir);
+
+  if (opts.integrity?.basis === 'packed-meta-match') {
+    const packed = readPackedGuardIndex(
+      registrySha256,
+      opts.integrity.runningPackageVersion,
+      opts.projectDir,
+    );
+    if (packed && packed.packedIndex && opts.integrity.runningPackageVersion) {
+      const matched = findMatchingGuardTree(
+        guardTreeCandidates(opts.projectDir),
+        packed.packedIndex,
+        registryMarkdown,
+        opts.integrity.runningPackageVersion,
+      );
+      if (matched) {
+        const probe = probeGuardTree(matched);
+        const packageRoot = executingPackageRoot();
+        const executing = packageRoot !== null && sameDirectory(packageRoot, matched);
+        return {
+          provenance: {
+            ...probe,
+            configuredProjectDir: opts.projectDir,
+            basis: executing ? 'executing-source-tree' : 'source-tree-index-match',
+            freshnessVerified: true,
+            freshnessReason:
+              `the live tree's complete audit-evidence index exactly matches packed source index ` +
+              `${packed.provenance.sourceIndexSha256}; landmark-only candidates were rejected`,
+            sourceIndexSha256: packed.provenance.sourceIndexSha256,
+            registrySha256,
+            packageVersion: opts.integrity.runningPackageVersion,
+          },
+          indexedGuards: null,
+        };
+      }
+    }
+    if (packed) return packed;
+  }
+
+  return {
+    provenance: {
+      ...configuredProbe,
+      configuredProjectDir: opts.projectDir,
+      basis: 'configured-tree-unverified',
+      freshnessVerified: false,
+      freshnessReason:
+        configuredProbe.analyzable
+          ? 'the configured tree has the audit landmarks, but no same-build identity ties it to the packed constitution; a coherent stale tree passes landmark probes by construction'
+          : 'the configured tree lacks the complete source landmarks and no valid same-build source index was available',
+      sourceIndexSha256: null,
+      registrySha256,
+      packageVersion:
+        opts.integrity?.basis === 'packed-meta-match'
+          ? opts.integrity.runningPackageVersion
+          : null,
+    },
+    indexedGuards: null,
+  };
+}
+
+function verifyRefsFromResolution(
+  refs: EnforcementRef[],
+  resolution: GuardEvidenceResolution,
+  projectDir: string,
+  routeTable: Set<string>,
+  symbolIndex: Set<string>,
+): VerifiedGuard[] {
+  if (resolution.indexedGuards === null) {
+    return verifyRefs(refs, projectDir, routeTable, symbolIndex);
+  }
+  return refs.map((ref) => {
+    const indexed = resolution.indexedGuards!.get(`${ref.kind}\u0000${ref.ref}`);
+    return indexed ? { ...indexed } : { ref: ref.ref, kind: ref.kind, refResolves: false };
+  });
+}
+
 /** Classify a standard by its strongest VERIFIED guard. */
 function classifyStandard(guards: VerifiedGuard[]): EnforcementKind {
   let best: Exclude<EnforcementKind, 'documented-only'> | null = null;
@@ -601,7 +929,10 @@ function guardStateSignal(projectDir: string, prior?: CoverageReport | null): st
   return h.digest('hex').slice(0, 16);
 }
 
-export function computeInputHash(opts: AuditorOptions): string {
+function computeInputHashForResolution(
+  opts: AuditorOptions,
+  guardResolution?: GuardEvidenceResolution,
+): string {
   // An UNREADABLE registry must not hash identically to an empty-but-present one:
   // that conflation is the honest-denominators shape at the cache layer, where a
   // missing constitution would share a cache slot with a genuinely blank one.
@@ -671,7 +1002,16 @@ export function computeInputHash(opts: AuditorOptions): string {
   const authoredSignal = authored === null
     ? 'no-authored-source'
     : crypto.createHash('sha256').update(authored).digest('hex').slice(0, 16);
-  return `${regHash}.${auxHash}.${authoredSignal}.${repoStructureSignal(opts.projectDir)}`;
+  const guardBasisSignal = guardResolution
+    ? `${guardResolution.provenance.basis}:${guardResolution.provenance.sourceIndexSha256 ?? 'live'}:` +
+      `${guardResolution.provenance.projectDir}`
+    : 'guard-basis-not-resolved';
+  return `${regHash}.${auxHash}.${authoredSignal}.${repoStructureSignal(opts.projectDir)}.` +
+    crypto.createHash('sha256').update(guardBasisSignal).digest('hex').slice(0, 16);
+}
+
+export function computeInputHash(opts: AuditorOptions): string {
+  return computeInputHashForResolution(opts);
 }
 
 /**
@@ -753,36 +1093,31 @@ export function deriveAssessmentConfidence(
     };
   }
   const verdict = earnsVerified(integrity);
-  if (verdict.verified) {
+  if (!verdict.verified) {
     return {
-      confidence: 'verified',
+      confidence: 'unverified',
       reason:
-        `${total} standards parsed from ${registry.path}, and ${verdict.reason}. ` +
-        // The honest scope limit, stated IN the verdict rather than left to be inferred.
-        //
-        // The REGISTRY half now carries three currency operands. The GUARD half carries
-        // none: refs resolve against whatever src/ sits in projectDir, and on a deployed
-        // agent that is a copy which can be months older than the constitution being
-        // graded (measured: an agent home's routes.ts dated May 28 against a current
-        // registry). So `verified` speaks for the constitution's currency, NOT for the
-        // currency of the tree its guards were looked up in.
-        //
-        // Naming the limit rather than silently widening the word is the same repair this
-        // change already made twice. Establishing guard-tree currency is a separate job
-        // and is recorded as one, not quietly folded in here.
-        `SCOPE NOTE: this verdict covers the CONSTITUTION's currency only. The enforcement ` +
-        `refs were resolved against ${guards?.projectDir ?? 'the configured project dir'}, ` +
-        `whose currency is not established by anything here — on a deployed agent that tree ` +
-        `can be older than the constitution being graded`,
+        `internal checks passed over ${total} standards parsed from ${registry.path} ` +
+        `(${registry.bytes} bytes), but ${verdict.reason} — so nothing establishes this is the CURRENT ` +
+        `constitution rather than a coherent older copy; a stale registry passes every internal check ` +
+        `by construction`,
+    };
+  }
+  if (guards && !guards.freshnessVerified) {
+    return {
+      confidence: 'untrustworthy',
+      reason:
+        `the constitution is package-stamped, but guard-tree freshness was not established: ` +
+        `${guards.freshnessReason}. The coverage counts remain observable for diagnosis, but a stale ` +
+        `tree passes capability landmarks by construction and cannot support a trustworthy ratio`,
     };
   }
   return {
-    confidence: 'unverified',
+    confidence: 'verified',
     reason:
-      `internal checks passed over ${total} standards parsed from ${registry.path} ` +
-      `(${registry.bytes} bytes), but ${verdict.reason} — so nothing establishes this is the CURRENT ` +
-      `constitution rather than a coherent older copy; a stale registry passes every internal check ` +
-      `by construction`,
+      `${total} standards parsed from ${registry.path}, and ${verdict.reason}. ` +
+      `The guard evidence is also current: ${guards?.freshnessReason ?? 'the caller supplied no guard provenance'}. ` +
+      `This is package/build currency, not a runtime execution check and not tamper-resistant`,
   };
 }
 
@@ -824,7 +1159,18 @@ export function probeGuardTree(projectDir: string): GuardTreeProvenance {
   // `analyzable` permanently false the moment anyone adds a third `check()` — which is
   // exactly the failure this probe was just repaired from, encoded so it can recur.
   const analyzable = markersFound.includes('src/server/routes.ts') && markersFound.includes('src/core');
-  return { projectDir, analyzable, markersFound };
+  return {
+    projectDir,
+    configuredProjectDir: projectDir,
+    analyzable,
+    markersFound,
+    basis: 'configured-tree-unverified',
+    freshnessVerified: false,
+    freshnessReason: 'landmark presence proves analyzability, not source-tree identity or freshness',
+    sourceIndexSha256: null,
+    registrySha256: null,
+    packageVersion: null,
+  };
 }
 
 /**
@@ -891,7 +1237,15 @@ export function computeCoverage(
   opts: AuditorOptions,
   prior?: CoverageReport | null,
 ): CoverageReport {
-  const inputHash = computeInputHash(opts);
+  // Read once before source resolution: the guard index is tied to these exact
+  // registry bytes, and candidate checkouts are selected by reproducing that index.
+  const registryMarkdown = opts.registryMarkdown ?? fs.readFileSync(opts.registryPath, 'utf-8');
+  assertResolutionCoherent(opts, registryMarkdown);
+  const guardResolution = resolveGuardEvidence(opts, registryMarkdown);
+  const inputHash = computeInputHashForResolution(opts, guardResolution);
+  const currentGuardSignal = guardResolution.provenance.sourceIndexSha256 !== null
+    ? `source-index:${guardResolution.provenance.sourceIndexSha256}`
+    : guardStateSignal(guardResolution.provenance.projectDir, prior);
   // TWO conditions, not one.
   //
   // `inputHash` covers the registry bytes, the basis, the paths and a coarse repo
@@ -907,7 +1261,7 @@ export function computeCoverage(
   // prior-derived value into the key makes the first computation (no prior) and the
   // second (with prior) disagree by construction, so the short-circuit would never fire
   // — which is how the first attempt at this failed, caught by an existing test.
-  if (prior && prior.inputHash === inputHash && prior.guardSignal === guardStateSignal(opts.projectDir, prior)) {
+  if (prior && prior.inputHash === inputHash && prior.guardSignal === currentGuardSignal) {
     // Inputs unchanged → the deterministic report is byte-identical to the prior;
     // return it (only its timestamp would differ on recompute). The short-circuit.
     return prior;
@@ -915,7 +1269,6 @@ export function computeCoverage(
 
   // Read ONCE and keep what the parse saw: the audit must be able to state the
   // denominator it computed over (honest-denominators instance 4).
-  const registryMarkdown = opts.registryMarkdown ?? fs.readFileSync(opts.registryPath, 'utf-8');
   const { articles, diagnostics } = parseStandardsRegistryDetailed(registryMarkdown);
   const canary = runRegistryCanary(articles, diagnostics);
   const registry: RegistryProvenance = {
@@ -929,20 +1282,30 @@ export function computeCoverage(
     canaryOk: canary.ok,
     canaryFailures: canary.failures,
   };
-  assertResolutionCoherent(opts, registryMarkdown);
-  const guards = probeGuardTree(opts.projectDir);
-  const routeTable = loadRouteTable(opts.projectDir);
+  const guards = guardResolution.provenance;
+  const liveProjectDir = guards.projectDir;
+  const routeTable = guardResolution.indexedGuards === null
+    ? loadRouteTable(liveProjectDir)
+    : new Set<string>();
 
   // Collect every wanted marker across all articles → ONE bounded src walk.
   const extracted = articles.map((a) => ({ a, refs: extractEnforcementRefs(a) }));
   const wantedMarkers = new Set<string>();
   for (const { refs } of extracted) for (const m of refs.markers) wantedMarkers.add(m);
-  const symbolIndex = buildSymbolIndex(opts.projectDir, wantedMarkers);
+  const symbolIndex = guardResolution.indexedGuards === null
+    ? buildSymbolIndex(liveProjectDir, wantedMarkers)
+    : new Set<string>();
 
   const classifiedAt = new Date().toISOString();
   const standards: StandardCoverage[] = extracted.map(({ a, refs }) => {
     const flat = flattenRefs(refs);
-    const guards = verifyRefs(flat, opts.projectDir, routeTable, symbolIndex);
+    const guards = verifyRefsFromResolution(
+      flat,
+      guardResolution,
+      liveProjectDir,
+      routeTable,
+      symbolIndex,
+    );
     const enforcementKind = classifyStandard(guards);
     const danglingRefs = guards.filter((g) => !g.refResolves).map((g) => g.ref).sort();
     return { standard: a.name, family: a.family, enforcementKind, guards, danglingRefs, classifiedAt };
@@ -962,8 +1325,15 @@ export function computeCoverage(
   const danglingCount = standards.reduce((n, s) => n + s.danglingRefs.length, 0);
 
   const { confidence: assessmentConfidence, reason: confidenceReason } =
-    deriveAssessmentConfidence(total, registry, opts.integrity, guards,
-      compareAgainstAuthoredSource(opts.projectDir, registryMarkdown));
+    deriveAssessmentConfidence(
+      total,
+      registry,
+      opts.integrity,
+      guards,
+      guards.basis === 'executing-source-tree' || guards.basis === 'source-tree-index-match'
+        ? compareAgainstAuthoredSource(liveProjectDir, registryMarkdown)
+        : { answerable: false, matches: false },
+    );
 
   const report: CoverageReport = {
     generatedAt: classifiedAt,
@@ -990,7 +1360,9 @@ export function computeCoverage(
     },
   };
   // Computed AFTER the standards exist, because it digests the refs this pass resolved.
-  report.guardSignal = guardStateSignal(opts.projectDir, report);
+  report.guardSignal = guardResolution.provenance.sourceIndexSha256 !== null
+    ? `source-index:${guardResolution.provenance.sourceIndexSha256}`
+    : guardStateSignal(liveProjectDir, report);
   return report;
 }
 
@@ -1045,7 +1417,18 @@ export function unusableCoverageReport(
       registry,
       // No pass ran, so the guard tree was never probed. Reporting `analyzable:
       // false` here would assert a fact about the repo that this path never checked.
-      guards: { projectDir: '(not probed — the registry was unusable)', analyzable: false, markersFound: [] },
+      guards: {
+        projectDir: '(not probed — the registry was unusable)',
+        configuredProjectDir: '(unknown)',
+        analyzable: false,
+        markersFound: [],
+        basis: 'not-probed',
+        freshnessVerified: false,
+        freshnessReason: 'the registry was unusable, so no guard source was selected',
+        sourceIndexSha256: null,
+        registrySha256: registry.sha256,
+        packageVersion: null,
+      },
     },
   };
 }

--- a/tests/integration/standards-coverage-route.test.ts
+++ b/tests/integration/standards-coverage-route.test.ts
@@ -273,6 +273,10 @@ describe('GET /conformance/coverage — the PRODUCTION resolution path (no overr
     expect(res.body.registryCurrent).toBe(true);
     expect(res.body.usable).toBe(true);
     expect(res.body.guardsAnalyzable).toBe(true);
+    expect(res.body.summary.guards.freshnessVerified).toBe(true);
+    expect(res.body.summary.guards.sourceIndexSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(res.body.summary.guards.projectDir).toBe(fs.realpathSync(REPO_ROOT));
+    expect(res.body.summary.guards.configuredProjectDir).toBe(REPO_ROOT);
     // Graded over the WHOLE constitution — the point of the change.
     expect(res.body.summary.total).toBeGreaterThanOrEqual(60);
     // And the fleet key the spec names as its rollout discriminator is actually present.
@@ -346,7 +350,9 @@ describe('GET /conformance/coverage — the PRODUCTION resolution path (no overr
           },
         },
         {
-          name: 'unanalyzable guard tree', projectDir: empty, useFixture: false,
+          // Caller-supplied registry deliberately bypasses the production packed-index
+          // fallback so this row still exercises the genuinely missing-guards state.
+          name: 'unanalyzable guard tree', projectDir: empty, useFixture: true,
           expected: {
             usable: false, registryUsable: true, guardsAnalyzable: false,
             registryCurrent: false, verifiedKind: null,

--- a/tests/setup/build-dist.globalSetup.ts
+++ b/tests/setup/build-dist.globalSetup.ts
@@ -103,8 +103,12 @@ function ensureRegistryAsset(): void {
   const needed = [
     path.join(ROOT, 'src', 'data', 'standards-registry.md'),
     path.join(ROOT, 'src', 'data', 'standards-registry.meta.json'),
+    path.join(ROOT, 'src', 'data', 'standards-guard-index.json'),
+    path.join(ROOT, 'src', 'data', 'standards-guard-index.meta.json'),
     path.join(ROOT, 'dist', 'data', 'standards-registry.md'),
     path.join(ROOT, 'dist', 'data', 'standards-registry.meta.json'),
+    path.join(ROOT, 'dist', 'data', 'standards-guard-index.json'),
+    path.join(ROOT, 'dist', 'data', 'standards-guard-index.meta.json'),
   ];
   if (needed.every((p) => fs.existsSync(p))) return;
   execSync('node scripts/generate-standards-registry-asset.mjs', { cwd: ROOT, stdio: 'inherit' });

--- a/tests/setup/ensure-registry-asset.globalSetup.ts
+++ b/tests/setup/ensure-registry-asset.globalSetup.ts
@@ -14,6 +14,7 @@ import {
   parseStandardsRegistryDetailed,
   runRegistryCanary,
 } from '../../src/core/StandardsRegistryParser.js';
+import { buildGuardTreeIndex } from '../../src/core/StandardsEnforcementAuditor.js';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -27,6 +28,8 @@ export function ensureRegistryAsset(root: string): void {
   const outputs = outputDirs.flatMap(dir => [
     path.join(dir, 'standards-registry.md'),
     path.join(dir, 'standards-registry.meta.json'),
+    path.join(dir, 'standards-guard-index.json'),
+    path.join(dir, 'standards-guard-index.meta.json'),
   ]);
   if (outputs.every(output => fs.existsSync(output))) return;
 
@@ -64,10 +67,20 @@ export function ensureRegistryAsset(root: string): void {
     generatedFrom: sourceRelative,
     packageVersion,
   }, null, 2)}\n`;
+  const registrySha256 = crypto.createHash('sha256').update(bytes).digest('hex');
+  const guardIndex = buildGuardTreeIndex(root, bytes.toString('utf-8'), packageVersion);
+  const guardIndexBytes = Buffer.from(`${JSON.stringify(guardIndex, null, 2)}\n`, 'utf-8');
+  const guardIndexMeta = `${JSON.stringify({
+    sha256: crypto.createHash('sha256').update(guardIndexBytes).digest('hex'),
+    registrySha256,
+    packageVersion,
+  }, null, 2)}\n`;
 
   for (const dir of outputDirs) {
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(path.join(dir, 'standards-registry.md'), bytes);
     fs.writeFileSync(path.join(dir, 'standards-registry.meta.json'), meta);
+    fs.writeFileSync(path.join(dir, 'standards-guard-index.json'), guardIndexBytes);
+    fs.writeFileSync(path.join(dir, 'standards-guard-index.meta.json'), guardIndexMeta);
   }
 }

--- a/tests/unit/standards-enforcement-auditor.test.ts
+++ b/tests/unit/standards-enforcement-auditor.test.ts
@@ -14,11 +14,14 @@ import {
   computeCoverage,
   deriveAssessmentConfidence,
   computeInputHash,
+  buildGuardTreeIndex,
+  findMatchingGuardTree,
   probeGuardTree,
   stableView,
   type CoverageReport,
   containedRefPath,
 } from '../../src/core/StandardsEnforcementAuditor.js';
+import { resolveStandardsRegistry } from '../../src/core/standardsRegistryPath.js';
 
 const REAL_REGISTRY = path.join(process.cwd(), 'docs/STANDARDS-REGISTRY.md');
 
@@ -426,7 +429,16 @@ describe('StandardsEnforcementAuditor — real-registry canary', () => {
     // An UNANALYZABLE guard tree is untrustworthy, not verified — the registry may be
     // perfectly sound while every enforcement figure describes a missing repository.
     const noTree = deriveAssessmentConfidence(81, okRegistry, full, {
-      projectDir: '/tmp/not-instar', analyzable: false, markersFound: [],
+      projectDir: '/tmp/not-instar',
+      configuredProjectDir: '/tmp/not-instar',
+      analyzable: false,
+      markersFound: [],
+      basis: 'configured-tree-unverified',
+      freshnessVerified: false,
+      freshnessReason: 'no matching source evidence',
+      sourceIndexSha256: null,
+      registrySha256: null,
+      packageVersion: null,
     });
     expect(noTree.confidence).toBe('untrustworthy');
     expect(noTree.reason).toMatch(/not an analyzable instar source tree/i);
@@ -539,6 +551,52 @@ describe('StandardsEnforcementAuditor — real-registry canary', () => {
       `These files branch on the integrity basis without going through earnsVerified, so the ` +
         `version-skew and count-mismatch downgrades do not apply to them: ${offenders.join(', ')}`,
     ).toEqual([]);
+  });
+});
+
+describe('StandardsEnforcementAuditor — source freshness resolution', () => {
+  beforeEach(buildFixture);
+
+  it('rejects a landmark-complete stale tree and selects the checkout whose evidence matches', () => {
+    const markdown = fs.readFileSync(registryPath, 'utf-8');
+    const expected = buildGuardTreeIndex(repo, markdown, '9.9.9');
+    const stale = fs.mkdtempSync(path.join(os.tmpdir(), 'std-audit-stale-'));
+    try {
+      fs.cpSync(repo, stale, { recursive: true });
+      fs.rmSync(path.join(stale, 'tests/unit/no-silent-llm-fallback.test.ts'));
+
+      expect(probeGuardTree(stale).analyzable, 'the stale tree must pass the old landmark probe').toBe(true);
+      expect(findMatchingGuardTree([stale, repo], expected, markdown, '9.9.9')).toBe(fs.realpathSync(repo));
+    } finally {
+      fs.rmSync(stale, { recursive: true, force: true });
+    }
+  });
+
+  it('returns no checkout when every candidate is stale instead of blessing landmarks', () => {
+    const markdown = fs.readFileSync(registryPath, 'utf-8');
+    const expected = buildGuardTreeIndex(repo, markdown, '9.9.9');
+    fs.rmSync(path.join(repo, 'tests/unit/no-silent-llm-fallback.test.ts'));
+
+    expect(probeGuardTree(repo).analyzable).toBe(true);
+    expect(findMatchingGuardTree([repo], expected, markdown, '9.9.9')).toBeNull();
+  });
+
+  it('the packed-source basis makes freshness independently checkable in the real report', () => {
+    const resolution = resolveStandardsRegistry();
+    expect(resolution.usable).toBe(true);
+    if (!resolution.usable) return;
+
+    const report = computeCoverage({
+      registryPath: resolution.path,
+      registryMarkdown: resolution.markdown,
+      integrity: resolution.integrity,
+      projectDir: process.cwd(),
+    });
+    expect(report.summary.guards.freshnessVerified).toBe(true);
+    expect(report.summary.guards.sourceIndexSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(['executing-source-tree', 'source-tree-index-match']).toContain(report.summary.guards.basis);
+    expect(report.summary.guards.projectDir).toBe(fs.realpathSync(process.cwd()));
+    expect(report.summary.danglingCount).toBe(0);
   });
 });
 

--- a/tests/unit/standards-registry-asset.test.ts
+++ b/tests/unit/standards-registry-asset.test.ts
@@ -31,6 +31,8 @@ const ROOT = path.resolve(__dirname, '../..');
 const AUTHORED = path.join(ROOT, 'docs', 'STANDARDS-REGISTRY.md');
 const ASSET = path.join(ROOT, 'dist', 'data', 'standards-registry.md');
 const META = path.join(ROOT, 'dist', 'data', 'standards-registry.meta.json');
+const GUARD_INDEX = path.join(ROOT, 'dist', 'data', 'standards-guard-index.json');
+const GUARD_INDEX_META = path.join(ROOT, 'dist', 'data', 'standards-guard-index.meta.json');
 
 /**
  * The asset is a BUILD artifact, and CI's unit job runs `npm ci` + tests with NO
@@ -48,7 +50,12 @@ beforeAll(() => {
     // Full build: the generator imports the SHARED parser from dist/, so a bare
     // generator run cannot bootstrap itself.
     execFileSync('npm', ['run', 'build'], { cwd: ROOT, stdio: 'pipe' });
-  } else if (!fs.existsSync(ASSET) || !fs.existsSync(META)) {
+  } else if (
+    !fs.existsSync(ASSET)
+    || !fs.existsSync(META)
+    || !fs.existsSync(GUARD_INDEX)
+    || !fs.existsSync(GUARD_INDEX_META)
+  ) {
     execFileSync('node', ['scripts/generate-standards-registry-asset.mjs'], { cwd: ROOT, stdio: 'pipe' });
   }
 }, 600_000);
@@ -100,10 +107,17 @@ describe('standards registry ships as a build artifact', () => {
         path.join(ROOT, 'scripts', 'generate-standards-registry-asset.mjs'),
         path.join(generatorRoot, 'scripts', 'generate-standards-registry-asset.mjs'),
       );
-      fs.copyFileSync(
-        path.join(ROOT, 'dist', 'core', 'StandardsRegistryParser.js'),
-        path.join(generatorRoot, 'dist', 'core', 'StandardsRegistryParser.js'),
-      );
+      for (const compiled of [
+        'StandardsRegistryParser.js',
+        'StandardEnforcementExtractor.js',
+        'standardsRegistryPath.js',
+        'StandardsEnforcementAuditor.js',
+      ]) {
+        fs.copyFileSync(
+          path.join(ROOT, 'dist', 'core', compiled),
+          path.join(generatorRoot, 'dist', 'core', compiled),
+        );
+      }
       execFileSync('node', ['scripts/generate-standards-registry-asset.mjs'], {
         cwd: generatorRoot,
         stdio: 'pipe',
@@ -112,8 +126,12 @@ describe('standards registry ships as a build artifact', () => {
       for (const rel of [
         'src/data/standards-registry.md',
         'src/data/standards-registry.meta.json',
+        'src/data/standards-guard-index.json',
+        'src/data/standards-guard-index.meta.json',
         'dist/data/standards-registry.md',
         'dist/data/standards-registry.meta.json',
+        'dist/data/standards-guard-index.json',
+        'dist/data/standards-guard-index.meta.json',
       ]) {
         expect(
           fs.readFileSync(path.join(sourceRoot, rel)),
@@ -157,7 +175,12 @@ describe('standards registry ships as a build artifact', () => {
         // guards, so it gets the clearest message, not the worst one.
         const members = execFileSync('tar', ['-tzf', tarball], { encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 })
           .split('\n');
-        for (const member of ['package/dist/data/standards-registry.md', 'package/dist/data/standards-registry.meta.json']) {
+        for (const member of [
+          'package/dist/data/standards-registry.md',
+          'package/dist/data/standards-registry.meta.json',
+          'package/dist/data/standards-guard-index.json',
+          'package/dist/data/standards-guard-index.meta.json',
+        ]) {
           expect(
             members.includes(member),
             `${member} is MISSING from a real npm tarball — the packaging regression this ratchet ` +
@@ -172,7 +195,9 @@ describe('standards registry ships as a build artifact', () => {
           'tar',
           ['-xzf', tarball, '-C', tmp,
            'package/dist/data/standards-registry.md',
-           'package/dist/data/standards-registry.meta.json'],
+           'package/dist/data/standards-registry.meta.json',
+           'package/dist/data/standards-guard-index.json',
+           'package/dist/data/standards-guard-index.meta.json'],
           { stdio: 'pipe' },
         );
 
@@ -190,6 +215,12 @@ describe('standards registry ships as a build artifact', () => {
             'no later step cleans dist/.',
         ).toBe(sha256(fs.readFileSync(AUTHORED)));
         expect(packedMeta.sha256).toBe(sha256(packed));
+        const packedGuardIndex = fs.readFileSync(path.join(tmp, 'package/dist/data/standards-guard-index.json'));
+        const packedGuardMeta = JSON.parse(
+          fs.readFileSync(path.join(tmp, 'package/dist/data/standards-guard-index.meta.json'), 'utf-8'),
+        );
+        expect(packedGuardMeta.sha256).toBe(sha256(packedGuardIndex));
+        expect(packedGuardMeta.registrySha256).toBe(sha256(packed));
       } finally {
         SafeFsExecutor.safeRmSync(tmp, {
           recursive: true, force: true,
@@ -762,7 +793,7 @@ describe('a REAL resolution earns verified end-to-end — no hand-built literals
     })).toThrow(/incoherent auditor options/);
   });
 
-  it('REFUSAL: an unanalyzable guard tree is untrustworthy however sound the registry is', () => {
+  it('a missing configured tree resolves to the real checkout by same-build evidence', () => {
     const res = resolveStandardsRegistry();
     if (!res.usable) throw new Error(`resolver unusable: ${res.detail}`);
     const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'no-instar-'));
@@ -770,10 +801,15 @@ describe('a REAL resolution earns verified end-to-end — no hand-built literals
       const report = computeCoverage({
         registryPath: res.path, projectDir: empty, registryMarkdown: res.markdown, integrity: res.integrity,
       });
-      expect(report.summary.guards.analyzable).toBe(false);
-      expect(report.summary.assessmentConfidence).toBe('untrustworthy');
-      expect(report.summary.assessmentTrustworthy).toBe(false);
-      expect(report.summary.confidenceReason).toMatch(/not an analyzable instar source tree/i);
+      expect(report.summary.guards.analyzable).toBe(true);
+      expect(['executing-source-tree', 'source-tree-index-match']).toContain(report.summary.guards.basis);
+      expect(report.summary.guards.freshnessVerified).toBe(true);
+      expect(report.summary.guards.configuredProjectDir).toBe(empty);
+      expect(report.summary.guards.sourceIndexSha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(report.summary.guards.projectDir).toBe(fs.realpathSync(ROOT));
+      expect(report.summary.assessmentConfidence).toBe('verified');
+      expect(report.summary.assessmentTrustworthy).toBe(true);
+      expect(report.summary.danglingCount).toBe(0);
     } finally {
       SafeFsExecutor.safeRmSync(empty, { recursive: true, force: true, operation: 'test.cleanup' });
     }

--- a/upgrades/next/conformance-source-freshness.md
+++ b/upgrades/next/conformance-source-freshness.md
@@ -1,0 +1,36 @@
+## What Changed
+
+The standards conformance audit no longer treats an arbitrary source-shaped
+directory as current. The build now records deterministic guard evidence from
+the real source checkout and stamps it with the registry identity and package
+version. At runtime, the auditor resolves a checkout only when recomputing that
+evidence produces an exact match.
+
+A stale tree that merely contains the expected landmarks is rejected. When a
+matching checkout exists, the report names that real directory. An installed
+package without a checkout can still use the verified same-build evidence, so
+the repair preserves the audit instead of turning every packaged install into
+an unanalysable result.
+
+## Evidence
+
+- A fixture whose stale tree passes both legacy landmark probes now resolves to
+  a separate matching checkout.
+- The inverse boundary returns unverified provenance when neither a matching
+  checkout nor valid packed evidence exists.
+- A live replay with Echo's stale agent-home tree resolved the current source
+  checkout, reported zero dangling references, and earned verified confidence.
+- Focused unit, integration, packaging, and broader standards checks passed,
+  along with the TypeScript build and repository lint suite.
+
+## What to Tell Your User
+
+Conformance coverage now identifies the source it actually audited and explains
+why that source is current. Old code copies can no longer produce confident,
+misleading coverage numbers simply because they have familiar filenames.
+
+## Summary of New Capabilities
+
+The conformance report now exposes checkable source freshness and provenance,
+including the configured and resolved locations, the selection basis, and the
+matching build identities.

--- a/upgrades/side-effects/conformance-source-freshness.md
+++ b/upgrades/side-effects/conformance-source-freshness.md
@@ -1,0 +1,48 @@
+# Side effects: conformance source freshness
+
+## Scope
+
+- `npm run build` emits two additional generated files in both `src/data/` and
+  `dist/data/`: `standards-guard-index.json` and its meta file.
+- `GET /conformance/coverage` and `/conformance/coverage/health` keep their existing
+  routes and top-level compatibility fields. `summary.guards` adds checkable freshness
+  provenance: configured and resolved paths, basis, freshness verdict/reason, index SHA,
+  registry SHA, and package version.
+- No config, database, migration, network call, notification, or write to an agent's
+  project tree is added.
+
+## Runtime behavior
+
+The read-only audit performs a bounded candidate lookup when first requested. For each
+landmark-complete candidate it computes only the evidence the audit already consumes.
+The existing route cache avoids repeating the work on unchanged inputs.
+
+When a live checkout exactly matches the packed evidence, refs are evaluated against that
+real path. With no checkout, verified packed evidence preserves analysis. A marker-only
+tree with no matching index is never allowed to earn a trustworthy ratio.
+
+## Compatibility and rollback
+
+The change is additive on the HTTP payload and generated package data. Existing clients
+that read `summary.guards.projectDir`, `analyzable`, or `markersFound` continue to work.
+Rollback is code-only: older versions ignore the extra packed files. Removing the new
+resolver restores configured-tree probing but also restores the stale-tree defect.
+
+## Failure and observability
+
+Missing, malformed, hash-mismatched, registry-mismatched, or version-mismatched index
+artifacts do not get guessed around. The report carries
+`basis: configured-tree-unverified`, `freshnessVerified: false`, and a reason; with a
+package-stamped registry that state is `assessmentConfidence: untrustworthy`.
+
+All new best-effort catches are narrow candidate failures and include inline
+`@silent-fallback-ok` justifications. They never convert absence into freshness.
+
+## Verification
+
+- Unit: stale landmark-complete tree rejected; exact matching tree selected; no-match
+  boundary returns null; real report carries a 64-hex index SHA and zero dangling refs.
+- Integration: production `/conformance/coverage` exposes the resolved real checkout and
+  freshness provenance.
+- Packaging: source-only setup and real generator remain byte-identical; a real npm
+  tarball contains the index and matching meta.


### PR DESCRIPTION
## ELI16

The conformance audit used to ask only whether a directory looked like an
Instar source tree. An old copy with the expected files passed that test, so the
audit confidently graded code from May against today's standards. This change
gives the source evidence an identity: the build records the complete
guard-resolution result from the real source tree and stamps it with the
registry and package version. At runtime, a checkout is accepted only when
recomputing that evidence matches exactly. A stale landmark-complete copy is
rejected; a current checkout is reported by its real path. Packaged installs
without a checkout retain the capability through verified same-build evidence.

## Root cause

The audit verified source-tree capability (landmarks exist), not source-tree
identity (this is the tree described by the registry). A coherent stale copy
passes capability checks by construction.

## What changed

- Generate a deterministic guard-evidence index and integrity metadata during
  the registry asset build.
- Bounded-search configured, conventional agent, working-directory, and
  package-root checkout candidates.
- Select a real checkout only on a complete evidence match.
- Fall back to verified packed evidence when an install has no checkout.
- Expose configured/resolved paths, basis, freshness verdict/reason, and build
  identities in the report.
- Add unit, integration, packaging, ELI16, side-effects, and release-note
  coverage.

## User impact

Conformance coverage no longer reports confident ratios from a stale source
copy. Operators can see exactly what source was audited and why it is considered
current.

## Validation

- Production build.
- TypeScript no-emit check and full repository lint.
- Focused auditor, route, and packaging tests: 77/77.
- Broader standards unit, integration, and end-to-end tests: 57/57.
- Live stale-home replay: resolved the current checkout, verified confidence,
  zero dangling references, and ratio 0.6829.
- Rebased focused rerun: 77/77.
- Local pre-push path gate passed; changed-test smoke listing timed out and
  explicitly deferred that smoke subset to CI.
