### PR TITLE
feat(standards): a rule may no longer claim a guard it does not name

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-31T04-22-54-740Z-standards-false-claim-guard.json
+++ b/.instar/instar-dev-decisions/2026-07-31T04-22-54-740Z-standards-false-claim-guard.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-07-31T04:22:54.740Z",
+  "slug": "standards-false-claim-guard",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 93,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/standards-coverage.mjs"
+    ],
+    "addedLines": 88,
+    "deletedLines": 5
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/standards-false-claim-guard.eli16.md
+++ b/docs/specs/standards-false-claim-guard.eli16.md
@@ -1,0 +1,78 @@
+# Standards False-Claim Guard — Plain-English Overview
+
+> The one-line version: a rule in our constitution may no longer say "a scheduled check does this daily" unless it names the thing that actually does it.
+
+## The problem in one breath
+
+We have a build check that measures how many of our 81 constitutional rules are genuinely protected
+by something that runs. It works by asking whether a rule *points at* a real file. It cannot ask
+whether a rule *claims* to be protected. So a rule can describe machinery in the present tense —
+"a scheduled coherence audit walks the list on every machine daily" — while no such audit exists,
+and the check reports it as an ordinary unguarded rule, indistinguishable from one that never
+claimed anything. A human reading the constitution sees a protection that isn't there.
+
+Measured on 2026-07-31: of the 22 rules with no named guard, exactly three assert running
+machinery. Two were true and had simply never named their guard (both are now cited). The third —
+Cross-Store Coherence — is false. Of its three listed invariants, one has a per-message
+delivery-time fail-safe and two have no checker at all. It is the rule earned from the incident
+where two of our identity records disagreed for nineteen days with nothing noticing.
+
+## What already exists
+
+- **The coverage check** — reads every rule, extracts any file, route or symbol it names, verifies
+  those exist on disk, and classifies the rule by the strongest guard it names. Fails the build if
+  the protected share drops below a committed floor, or if a rule ever cites a guard that has been
+  deleted.
+- **The floors** — a protected-share floor that ratchets upward as gaps close, and a zero-tolerance
+  ceiling on citations that don't resolve.
+
+Both already work. This adds a third question to the same pass.
+
+## What this adds
+
+One new measurement and one new floor. For any rule the check has *already* concluded names no
+guard, it now also asks: **does this rule's own text assert that machinery is running?** If yes,
+that rule is counted as a *false claim* rather than an ordinary gap, named individually in the
+build output, and counted against a ceiling.
+
+- A per-rule line in the output naming the exact phrases that triggered it, so the finding is
+  actionable without re-reading the constitution.
+- A ceiling that starts at the currently measured value, so no existing build breaks.
+
+## The new pieces
+
+- **The claim detector** — a small set of patterns for assertions of a specific running mechanism
+  ("a scheduled audit", "walks the list", "fails the build", "checked on a cadence"). It is *not*
+  allowed to fire on a rule that names a guard, because it only ever sees rules already classified
+  as naming none. It is *not* allowed to fire on a requirement — "must be checked on a cadence" is
+  a rule being stated, not a claim being made, and prescriptive wording is excluded explicitly.
+
+## The safeguards
+
+**Precision comes from where it runs, not from tuning the patterns.** The detector only sees rules
+that name no guard at all. A rule that both claims machinery and cites it is never examined. So the
+only way to be flagged is to claim a mechanism and point at nothing — which is exactly the
+condition we want flagged, and there is no configuration that widens it.
+
+**It cannot break a build that is not already broken.** The ceiling defaults to the measured count
+(1), following the same "starts loose" approach the protected-share floor used. It is still doing
+real work at that value: a *new* rule that claims an unnamed guard fails immediately. The ceiling
+drops to zero once the one existing false claim is resolved — either by building the audit it
+describes, or by amending the sentence that describes it.
+
+**It is a build check, not a runtime gate.** It blocks nothing an agent does, delays no message,
+and touches no user-facing behaviour.
+
+## What it deliberately does not do
+
+It does not decide whether a guard is *sufficient* — only whether a rule that claims one has named
+one. A rule can name a real, resolvable, running guard that does its job badly, and this check will
+be satisfied. That is the same limit the existing coverage check has, and it is worth restating
+rather than quietly inheriting: this closes a bookkeeping gap, not a safety gap.
+
+## How you would know it was wrong
+
+If it fired on a rule that was merely *describing a requirement*, the ceiling would rise without a
+real false claim behind it. Four tests pin the boundary in both directions: a claim with no guard
+fails; the same claim with a resolvable guard passes; a prescriptive "must" passes; an ordinary
+unguarded rule passes.

--- a/scripts/standards-coverage.mjs
+++ b/scripts/standards-coverage.mjs
@@ -16,6 +16,9 @@
  *   - danglingCount = refs a standard names that are NOT on disk — fails the build if
  *     ABOVE ZERO (a guard file removed while a standard still cites it: a broken
  *     guarantee, the loudest signal).
+ *   - falseClaimCount = standards that name NO guard while their own prose asserts
+ *     running machinery ("a scheduled audit walks the list daily") — a false
+ *     all-clear in the constitution, read by humans as protection that exists.
  *
  * Self-contained (no dist import) so it runs in CI without a build step — it
  * re-implements the same deterministic parse → extract → verify the auditor does.
@@ -29,6 +32,10 @@
  *   STANDARDS_ENFORCED_RATIO_FLOOR  — min enforced ratio 0..1 (default 0 — starts
  *                                     loose, ratcheted up as gaps close)
  *   STANDARDS_DANGLING_CEILING      — max dangling refs (default 0 — zero tolerance)
+ *   STANDARDS_FALSE_CLAIM_CEILING   — max standards asserting an unnamed guard
+ *                                     (default 1 — the measured 2026-07-31 count;
+ *                                     ratchet to 0 once Cross-Store Coherence is
+ *                                     resolved)
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -71,6 +78,14 @@ const FLOORS = {
   enforcedRatio: numEnv('STANDARDS_ENFORCED_RATIO_FLOOR', 0.64),
   // Zero tolerance: a standard must NEVER cite a guard that doesn't exist.
   danglingCeiling: numEnv('STANDARDS_DANGLING_CEILING', 0),
+  // A gap that ASSERTS running machinery is a false all-clear, not an honest gap.
+  // Set to the measured count on 2026-07-31 (1 — Cross-Store Coherence) rather than
+  // 0, following the enforced-ratio precedent of "starts loose": a new check must
+  // not fail a build for a pre-existing condition it just became able to see. It
+  // already does the load-bearing job at 1 — a NEW standard that claims machinery
+  // without naming it fails immediately. RATCHET TO 0 once Cross-Store Coherence
+  // either gets its audit built or has the claim amended out of its prose.
+  falseClaimCeiling: numEnv('STANDARDS_FALSE_CLAIM_CEILING', 1),
 };
 
 // ── Deterministic parse → extract → verify (mirrors the auditor, self-contained) ──
@@ -121,6 +136,57 @@ function extractRefs(a) {
   for (const m of text.matchAll(MARKER_RE)) markers.push(m[1]);
   for (const m of text.matchAll(SYMBOL_RE)) markers.push(m[1].split('.')[0]);
   return { files: dedupe(files).sort(), routes: dedupe(routes).sort(), markers: dedupe(markers).sort() };
+}
+
+/**
+ * ── FALSE-CLAIM DETECTION ────────────────────────────────────────────────────
+ * A standard that says "this is how we behave" and names no guard is an HONEST
+ * gap. A standard that says "a scheduled audit walks the list daily" is making a
+ * claim of FACT — and if it names no resolvable guard, that claim is a false
+ * all-clear sitting in the constitution, read by humans as protection that exists.
+ *
+ * Earned 2026-07-31: of the 24 documented-only standards, exactly three asserted
+ * running machinery. Two were true and merely unnamed (now cited). The third —
+ * Cross-Store Coherence — claims "A scheduled coherence audit walks the list on
+ * every machine daily". No such audit exists; of its three enumerated invariants
+ * one has a per-message delivery-time fail-safe and two have no checker at all.
+ * It is the standard earned from two identity stores contradicting each other for
+ * 19 days with no tripwire — the reactive shield shipped, the tripwire did not.
+ *
+ * PRECISION OVER RECALL, deliberately, and it is structural rather than a matter
+ * of tuning: this runs ONLY over standards already classified `documented-only`.
+ * A standard that asserts machinery AND names a resolvable guard is never
+ * examined, so the only way to be flagged is to claim a mechanism and cite
+ * nothing. Patterns are assertions of a specific mechanism running, never
+ * prescriptions ("must refuse", "should block"), which is what the negative
+ * lookbehind excludes.
+ */
+const CLAIM_PATTERNS = [
+  /\ba scheduled\s+[a-z-]*\s*(?:audit|job|check|sweep|pass)\b/i,
+  /\bwalks the list\b/i,
+  /\b(?:checked|runs|fires|re-?runs)\s+on a cadence\b/i,
+  /\bfails the build\b/i,
+  /\benforcement is\b/i,
+  /\bis enforced by\b/i,
+  /\bon every machine\s+daily\b/i,
+  /\bdaily\b[^.]{0,40}\baudit\b/i,
+];
+// Prescriptive framing near a match means the standard is stating a requirement,
+// not asserting an existing mechanism. "must be checked on a cadence" is a rule;
+// "a scheduled audit walks the list" is a claim.
+const PRESCRIPTIVE_NEAR = /\b(?:must|should|shall|needs? to|ought to|is required to)\b[^.]{0,60}$/i;
+
+function detectEnforcementClaims(a) {
+  const text = `${a.rule ?? ''}\n${a.inPractice ?? ''}\n${a.appliedThrough ?? ''}`;
+  const hits = [];
+  for (const re of CLAIM_PATTERNS) {
+    const m = re.exec(text);
+    if (!m) continue;
+    const before = text.slice(Math.max(0, m.index - 60), m.index);
+    if (PRESCRIPTIVE_NEAR.test(before)) continue;
+    hits.push(m[0].trim());
+  }
+  return dedupe(hits).sort();
 }
 
 const KIND_RANK = { ratchet: 4, gate: 3, lint: 2, 'spec-only': 1 };
@@ -189,7 +255,8 @@ function compute() {
       generatedAt: new Date().toISOString(),
       registryFound: false,
       total: 0, byKind: { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 },
-      enforcedRatio: 1, gaps: [], danglingCount: 0, danglingByStandard: [],
+      enforcedRatio: 1, gaps: [], falseClaimCount: 0, falseClaims: [],
+      danglingCount: 0, danglingByStandard: [],
     };
   }
 
@@ -202,6 +269,7 @@ function compute() {
 
   const byKind = { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 };
   const gaps = [];
+  const falseClaims = [];
   const danglingByStandard = [];
   let danglingCount = 0;
 
@@ -224,7 +292,12 @@ function compute() {
     for (const g of guards) { if (best === null || KIND_RANK[g] > KIND_RANK[best]) best = g; }
     const kind = best ?? 'documented-only';
     byKind[kind] += 1;
-    if (kind === 'documented-only') gaps.push(a.name);
+    if (kind === 'documented-only') {
+      gaps.push(a.name);
+      // A gap that ASSERTS running machinery is a false claim, not an honest gap.
+      const claims = detectEnforcementClaims(a);
+      if (claims.length > 0) falseClaims.push({ standard: a.name, claims });
+    }
     if (dangling.length > 0) { danglingByStandard.push({ standard: a.name, refs: dangling.sort() }); danglingCount += dangling.length; }
   }
 
@@ -234,7 +307,9 @@ function compute() {
   return {
     generatedAt: new Date().toISOString(),
     registryFound: true,
-    total, byKind, enforcedRatio, gaps, danglingCount, danglingByStandard,
+    total, byKind, enforcedRatio, gaps,
+    falseClaimCount: falseClaims.length, falseClaims,
+    danglingCount, danglingByStandard,
   };
 }
 
@@ -258,8 +333,12 @@ function main() {
     console.error(`[standards-coverage] registry=${report.registryFound} total=${report.total} ` +
       `enforced-ratio=${report.enforcedRatio} (ratchet ${report.byKind.ratchet} / gate ${report.byKind.gate} / ` +
       `lint ${report.byKind.lint} / spec-only ${report.byKind['spec-only']} / gap ${report.byKind['documented-only']}) ` +
+      `false-claims=${report.falseClaimCount} ` +
       `dangling=${report.danglingCount}`);
-    console.error(`[standards-coverage] floors: enforced-ratio>=${FLOORS.enforcedRatio} dangling<=${FLOORS.danglingCeiling}`);
+    console.error(`[standards-coverage] floors: enforced-ratio>=${FLOORS.enforcedRatio} dangling<=${FLOORS.danglingCeiling} false-claims<=${FLOORS.falseClaimCeiling}`);
+    for (const fc of report.falseClaims) {
+      console.error(`[standards-coverage] FALSE CLAIM — "${fc.standard}" asserts running machinery (${fc.claims.map((c) => `"${c}"`).join(', ')}) but names no resolvable guard.`);
+    }
   }
 
   if (CHECK) {
@@ -273,10 +352,14 @@ function main() {
           ? ` — ${report.danglingByStandard.map((d) => `${d.standard}: [${d.refs.join(', ')}]`).join('; ')}`
           : ''));
     }
+    if (report.falseClaimCount > FLOORS.falseClaimCeiling) {
+      failures.push(`false claims ${report.falseClaimCount} > ceiling ${FLOORS.falseClaimCeiling}` +
+        ` — ${report.falseClaims.map((f) => `${f.standard}: asserts [${f.claims.join(', ')}] but names no resolvable guard`).join('; ')}`);
+    }
     if (failures.length > 0) {
       process.stderr.write('\n❌ standards-coverage check failed:\n');
       for (const f of failures) process.stderr.write(`  - ${f}\n`);
-      process.stderr.write('\nFix: build a guard for an unguarded standard (raise the ratio), or repair the dangling reference (the cited guard file was renamed/removed).\n');
+      process.stderr.write('\nFix: build a guard for an unguarded standard (raise the ratio), repair the dangling reference (the cited guard file was renamed/removed), or resolve a false claim — a standard whose prose asserts running machinery must either NAME the guard that runs it, or stop claiming it.\n');
       process.exit(1);
     }
     if (!QUIET) console.error('✅ standards-coverage check passed.');

--- a/tests/unit/standards-coverage-ratchet.test.ts
+++ b/tests/unit/standards-coverage-ratchet.test.ts
@@ -85,6 +85,51 @@ describe('standards-coverage ratchet script', () => {
     expect(r.out).toContain('removed.test.ts');
   });
 
+  // ── FALSE-CLAIM DETECTION (2026-07-31) ────────────────────────────────────
+  // A gap that ASSERTS running machinery is a false all-clear, not an honest gap.
+  // Both sides of the boundary are pinned: a prose CLAIM with no guard is caught;
+  // the same claim WITH a resolvable guard is not; and a prescriptive "must" is not
+  // a claim. Earned from Cross-Store Coherence, which asserts "a scheduled coherence
+  // audit walks the list on every machine daily" while no such audit exists.
+
+  it('FLAGS a gap whose prose asserts running machinery but names no guard', () => {
+    fs.appendFileSync(
+      path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'),
+      '\n### Claims An Audit\n**Rule.** r.\n**In practice.** A scheduled coherence audit walks the list on every machine daily.\n',
+    );
+    const r = runCheck({ STANDARDS_FALSE_CLAIM_CEILING: '0', STANDARDS_ENFORCED_RATIO_FLOOR: '0' });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('false claims');
+    expect(r.out).toContain('Claims An Audit');
+  });
+
+  it('does NOT flag the same claim when the standard names a guard that resolves', () => {
+    fs.appendFileSync(
+      path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'),
+      '\n### Claims And Cites\n**Rule.** r.\n**In practice.** A scheduled coherence audit walks the list on every machine daily, enforced by `tests/unit/widget.test.ts`.\n',
+    );
+    const r = runCheck({ STANDARDS_FALSE_CLAIM_CEILING: '0', STANDARDS_ENFORCED_RATIO_FLOOR: '0' });
+    expect(r.code).toBe(0);
+  });
+
+  it('does NOT flag a PRESCRIPTIVE requirement (a rule, not a claim of fact)', () => {
+    fs.appendFileSync(
+      path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'),
+      '\n### Prescribes Only\n**Rule.** Any two such stores must be checked on a cadence by machinery.\n**In practice.** declare the invariant when you add the store.\n',
+    );
+    const r = runCheck({ STANDARDS_FALSE_CLAIM_CEILING: '0', STANDARDS_ENFORCED_RATIO_FLOOR: '0' });
+    expect(r.code).toBe(0);
+  });
+
+  it('does NOT flag an ordinary unguarded standard that claims nothing', () => {
+    fs.appendFileSync(
+      path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'),
+      '\n### Honest Gap\n**Rule.** behave this way.\n**In practice.** use judgment.\n',
+    );
+    const r = runCheck({ STANDARDS_FALSE_CLAIM_CEILING: '0', STANDARDS_ENFORCED_RATIO_FLOOR: '0' });
+    expect(r.code).toBe(0);
+  });
+
   it('writes the output file but it is NOT the read baseline (the floor is the committed constant)', () => {
     runCheck();
     const outPath = path.join(repo, '.instar', 'standards-coverage.json');

--- a/upgrades/next/standards-false-claim-guard.md
+++ b/upgrades/next/standards-false-claim-guard.md
@@ -1,0 +1,78 @@
+## What Changed
+
+The CI standards-coverage check now distinguishes a standard that is **unguarded** from one that
+**claims a guard it does not name**. Both were previously counted the same way — as
+`documented-only` — which meant a rule could describe running machinery in the present tense while
+nothing existed, and the audit would report it identically to a rule that never claimed anything.
+
+`scripts/standards-coverage.mjs` gains `falseClaimCount` + `falseClaims[]`, a per-standard
+`FALSE CLAIM —` line on stderr naming the phrases that triggered it, and a
+`STANDARDS_FALSE_CLAIM_CEILING` floor checked under `--check`.
+
+The distinction matters because a human reads the constitution. An honest gap says "nobody is
+watching this." A false claim says "a scheduled audit walks the list on every machine daily" — and
+is read as protection that exists.
+
+## Why now
+
+Measured on 2026-07-31: of the 22 `documented-only` standards, exactly **three** assert running
+machinery. Two were true and had simply never named their guard — both now carry citations. The
+third, **Cross-Store Coherence Is an Invariant**, is false. Of its three enumerated invariants, one
+has a per-message delivery-time fail-safe (`senderValidationGate`), two have no checker at all, and
+the "scheduled coherence audit [that] walks the list on every machine daily" does not exist. It is
+the standard earned from two identity stores contradicting each other for nineteen days with no
+tripwire — the reactive shield shipped, the tripwire did not.
+
+## Precision is structural, not tuned
+
+The detector runs **only** over standards the script has already classified `documented-only`. A
+standard that asserts machinery *and* cites a resolvable guard is never examined, so the only way to
+be flagged is to claim a mechanism and point at nothing. Prescriptive framing is excluded — "must be
+checked on a cadence by machinery" is a requirement being stated, not a claim being made.
+
+Measured over the live registry: **1 flagged of 22 gaps across 81 standards, zero false positives on
+the other 21.**
+
+## What to Tell Your User
+
+Nothing changes in how the agent behaves. This is a build-time check on our own constitution: a
+rule may no longer say "a scheduled check does this daily" unless it names the thing that actually
+does it. One rule currently fails that test — the one written after two of our identity records
+disagreed for nineteen days without anything noticing — and it now says so out loud on every build
+instead of blending in with rules that never made a claim.
+
+## Summary of New Capabilities
+
+No new endpoint, route, or operator control. One new environment variable
+(`STANDARDS_FALSE_CLAIM_CEILING`, default `1`) and additional named lines in CI output.
+
+## Evidence
+
+- Live run: `total=81 … gap 22 false-claims=1 dangling=0`, with the flagged standard and its matched
+  phrases named on stderr.
+- The ceiling **bites** rather than only passing: default `1` → exit 0;
+  `STANDARDS_FALSE_CLAIM_CEILING=0` → exit 1 with the standard named in the failure text.
+- Four tests in `tests/unit/standards-coverage-ratchet.test.ts` pin both sides of the boundary —
+  a claim with no guard fails; the same claim with a resolvable guard passes; a prescriptive "must"
+  passes; an ordinary unguarded standard passes. Verified against the real script on temp fixtures
+  (exit 1 / 0 / 0 / 0).
+
+## Scope limit, stated plainly
+
+This closes a **bookkeeping** gap, not a safety gap. It checks that a standard claiming a guard has
+named one — never that the named guard is sufficient, or that it does its job. A rule can cite a
+real, resolvable, running guard that works badly and this check is satisfied. That is the same limit
+the existing coverage measure carries, restated rather than quietly inherited.
+
+## Default is deliberately loose
+
+The ceiling starts at **1**, the currently measured count, following the same "starts loose"
+approach the enforced-ratio floor used: a new check must not fail a build for a pre-existing
+condition it has only just become able to see. It is still load-bearing at that value — a **new**
+standard that claims an unnamed guard fails immediately. Ratchet it to `0` once Cross-Store
+Coherence either gets the audit it describes or has the claim amended out of its prose.
+
+## Rollback
+
+`STANDARDS_FALSE_CLAIM_CEILING=<n>` in the environment, with no code change. Reverting the commit
+leaves the two existing floors untouched.

--- a/upgrades/side-effects/standards-false-claim-guard.md
+++ b/upgrades/side-effects/standards-false-claim-guard.md
@@ -1,0 +1,156 @@
+# Side-Effects Review — Standards False-Claim Guard
+
+**Version / slug:** `standards-false-claim-guard`
+**Date:** `2026-07-31`
+**Author:** `echo`
+**Tier:** `1` (single build script + its unit tests; no runtime surface, no new authority)
+**Second-pass reviewer:** `not required at Tier 1 — the PR is the review surface`
+
+## Summary of the change
+
+`scripts/standards-coverage.mjs` already answers "does this standard NAME a resolvable guard?".
+It cannot answer "does this standard CLAIM one?". This adds that second question, scoped to
+standards the script has already classified `documented-only`.
+
+- **`detectEnforcementClaims(article)`** — matches assertions of a specific running mechanism
+  (`a scheduled <x> audit/job/check`, `walks the list`, `checked/runs/fires on a cadence`,
+  `fails the build`, `enforcement is`, `is enforced by`, `on every machine daily`) over the
+  Rule / In-practice / Applied-through fields. Prescriptive framing within 60 chars before a match
+  (`must`, `should`, `shall`, `needs to`, `ought to`, `is required to`) is excluded.
+- **`falseClaimCount` + `falseClaims[]`** on the report, and a per-standard `FALSE CLAIM —` line on
+  stderr naming the matched phrases.
+- **`STANDARDS_FALSE_CLAIM_CEILING`** floor (default **1**, the measured count) checked in
+  `--check`.
+- Four tests in `tests/unit/standards-coverage-ratchet.test.ts` pinning both sides of the boundary.
+
+Files: `scripts/standards-coverage.mjs`, `tests/unit/standards-coverage-ratchet.test.ts`.
+
+## Decision-point inventory
+
+- Claim detection over an article's prose — **add** — read-only classification of a markdown field;
+  decides a COUNT, never an action.
+- `falseClaimCeiling` comparison in `--check` — **add** — can fail a CI build. This is the only
+  authority the change carries.
+
+---
+
+## 1. Over-block
+
+The realistic over-block is a standard flagged for *describing a requirement* rather than asserting
+a fact. Two structural mitigations, neither of them threshold-tuning:
+
+- **Scope.** The detector runs ONLY over articles already classified `documented-only`. An article
+  that asserts machinery *and* cites a resolvable guard is never examined. There is no
+  configuration that widens this — it is a property of where the call sits in the loop.
+- **Prescriptive exclusion.** A negative lookbehind drops a match preceded by `must` / `should` /
+  `shall` / `needs to` / `ought to` / `is required to` within 60 characters, which is the shape a
+  requirement takes ("must be checked on a cadence by machinery").
+
+Measured over the live registry: **1 flagged of 22 gaps / 81 standards.** The one flagged is
+verified false by hand (Cross-Store Coherence — its named daily audit does not exist; of its three
+enumerated invariants, one has a per-message delivery-time fail-safe and two have no checker).
+Zero false positives across the other 21.
+
+Blast radius if it over-blocks anyway: a CI failure with a message naming the standard and the
+exact phrases. The fix is a one-word prose edit or a `STANDARDS_FALSE_CLAIM_CEILING` bump. No
+runtime behaviour, no agent action, no user-facing surface.
+
+## 2. Under-block
+
+Under-blocking is the expected and accepted state. The pattern list is deliberately narrow —
+precision over recall — so a standard asserting machinery in wording not covered (e.g. "this is
+policed continuously") is missed. That is the safe direction: a missed false claim leaves the
+status quo (an ordinary gap), while a false positive would fail a build for a rule that is honest.
+
+The ceiling starting at 1 rather than 0 is also deliberate under-blocking: it accepts the existing
+false claim rather than failing a build for a pre-existing condition the check has only just become
+able to see. It remains load-bearing at 1 — a *new* standard claiming an unnamed guard fails
+immediately.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The question "is this standard's self-description honest?" is a property of the
+standards registry, and the registry parser is the only component that already has each article's
+fields in memory and its guard-resolution verdict. Putting it anywhere else would mean re-parsing
+the constitution.
+
+It is deliberately NOT in `StandardsEnforcementAuditor` (the library the `/conformance` route
+serves): that surface is observe-only and non-gating by design, and this needs to fail a build.
+The two implementations already disagree by one article (81 vs 82), recorded rather than averaged;
+adding a gating check to the non-gating side would deepen that.
+
+## 4. Signal vs authority compliance
+
+This is a **brittle, low-context filter with build-failing authority**, which is exactly the shape
+*Signal vs. Authority* warns about. Justification for why it is acceptable here rather than a
+signal:
+
+- The domain is **not** agent behaviour or message content — it is a fixed, human-authored,
+  version-controlled document of 81 articles. The input is bounded and inspectable, not adversarial
+  or open-world.
+- The authority is **a CI failure on a docs file**, not a blocked action, message, or session. The
+  cost of a wrong verdict is one prose edit; nothing is lost and nothing is delayed for a user.
+- The same file already carries two comparable deterministic gates (the enforced-ratio floor and
+  the zero dangling ceiling) with the same shape and authority.
+
+Had this needed to judge *meaning* rather than *presence of an assertion pattern*, the correct
+implementation would be an LLM gate per *Intelligent Prompts*. It does not: it reports a phrase
+match to a human, who decides.
+
+## 4b. Judgment-point check (Judgment Within Floors)
+
+No judgment point is delegated. The check reports a count and the matched phrases; a human decides
+whether to build the guard or amend the prose. The ceiling is an operator-visible constant with an
+env override.
+
+## 5. Interactions
+
+- **Enforced-ratio floor** — independent. A false claim is also counted as a gap, so it already
+  depresses the ratio; this adds a *distinct* signal, it does not double-count into the ratio.
+- **Dangling-ref ceiling** — disjoint by construction: dangling means a citation that does not
+  resolve; false-claim means no citation at all.
+- **`/conformance/coverage`** — untouched. That route continues to report `documented-only` for the
+  same article; the two surfaces will now differ in *detail* (this one names it a false claim),
+  which is the intended asymmetry between a gating build check and an observe-only route.
+
+## 6. External surfaces
+
+None. No route, no config file, no user-visible message, no network call. The only new surface is
+one env var (`STANDARDS_FALSE_CLAIM_CEILING`) and additional stderr lines in CI output.
+
+## 6b. Operator-surface quality
+
+The failure message names the standard, the matched phrases, and the two acceptable resolutions
+("must either NAME the guard that runs it, or stop claiming it"). It teaches the required shape
+rather than only reporting a number, per the refusal-message convention used elsewhere in the file.
+
+## 7. Multi-machine posture
+
+Not applicable. A build-time script over a git-tracked file; no state, no per-machine posture, no
+replication, no lease interaction.
+
+## 8. Rollback cost
+
+Near zero, and there are three independent levers:
+
+1. `STANDARDS_FALSE_CLAIM_CEILING=<n>` in the environment — no code change.
+2. Revert the commit — the two prior floors are untouched by it.
+3. Delete the `CLAIM_PATTERNS` entries — the check degrades to reporting 0 and passes.
+
+No migration, no persisted state, nothing to un-write.
+
+## Conclusion
+
+Ship at Tier 1. The change is one build script and its tests; its only authority is a CI failure on
+a documentation file; its precision is structural rather than tuned; and its default ceiling cannot
+fail any build that passes today.
+
+## Evidence pointers
+
+- Finding that earned it: `docs/findings/2026-07-31-constitution-asserts-an-audit-that-does-not-exist.md`
+- Live measurement: `total=81 … gap 22 false-claims=1 dangling=0`, with
+  `FALSE CLAIM — "Cross-Store Coherence Is an Invariant" asserts running machinery ("A scheduled
+  coherence audit", "on every machine daily", "walks the list") but names no resolvable guard.`
+- Boundary verification against the real script on temp fixtures: claim-without-guard → exit 1;
+  claim WITH a resolvable guard → exit 0; prescriptive "must" → exit 0; ordinary unguarded standard
+  → exit 0.


### PR DESCRIPTION
## ELI16

A rule in our constitution may no longer say "a scheduled check does this daily" unless it names the thing that actually does it.

We have a build check that measures how many of our 81 constitutional rules are genuinely protected by something that runs. It works by asking whether a rule *points at* a real file. It could not ask whether a rule *claims* to be protected. So a rule could describe machinery in the present tense while nothing existed, and the check reported it exactly like a rule that never claimed anything — while a human reading the constitution sees a protection that isn't there.

Measured: of the 22 rules with no named guard, exactly **three** assert running machinery. Two were true and had simply never named their guard — both now carry citations (merged earlier). The third, **Cross-Store Coherence**, is false: of its three listed invariants one has a per-message delivery-time fail-safe and two have no checker, and the "scheduled coherence audit [that] walks the list on every machine daily" does not exist. It is the rule written after two of our identity records disagreed for nineteen days with nothing noticing.

### Precision is structural, not tuned

The detector runs **only** over standards already classified `documented-only`. A standard that asserts machinery *and* cites a resolvable guard is never examined — so the only way to be flagged is to claim a mechanism and point at nothing. Prescriptive framing ("must be checked on a cadence") is excluded: that is a requirement being stated, not a claim being made.

**1 flagged of 22 gaps across 81 standards. Zero false positives on the other 21.**

### Evidence

```
[standards-coverage] total=81 … gap 22 false-claims=1 dangling=0
[standards-coverage] floors: enforced-ratio>=0.64 dangling<=0 false-claims<=1
[standards-coverage] FALSE CLAIM — "Cross-Store Coherence Is an Invariant" asserts running
  machinery ("A scheduled coherence audit", "on every machine daily", "walks the list")
  but names no resolvable guard.
```

The ceiling **bites** rather than only passing: default `1` → exit 0; `STANDARDS_FALSE_CLAIM_CEILING=0` → exit 1 naming the standard. Four tests pin both sides — claim-without-guard fails; the same claim *with* a resolvable guard passes; a prescriptive "must" passes; an ordinary unguarded standard passes. Verified against the real script on temp fixtures (exit 1 / 0 / 0 / 0).

### Scope limit, stated rather than inherited

This closes a **bookkeeping** gap, not a safety gap. It checks that a rule claiming a guard has named one — never that the guard is sufficient or that it works. A rule can cite a real, running guard that does its job badly and this check is satisfied.

### Why the ceiling starts at 1

Following the enforced-ratio "starts loose" precedent: a new check must not fail a build for a pre-existing condition it has only just become able to see. It is still load-bearing at 1 — a **new** standard claiming an unnamed guard fails immediately. Ratchet to 0 once Cross-Store Coherence gets its audit or has the claim amended out.

### Process note

This is Tier 1 with a staged ELI16 + side-effects artifact + release-note fragment. An earlier attempt to land it rode a docs PR and was correctly refused by the `decision-audit` gate — the worktree had been created with raw `git worktree add` (because `instar worktree create` was broken by the credential-prefix bug documented in that same PR), so the husky shim was never wired and the local gate never ran. Rather than route around it, the code was parked, the ceremony done properly, and it is landing on its own.
