### PR TITLE
fix(metrics): count completed correction learning

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-31T07-04-39-937Z-learning-velocity-corrections-count-finishing.json
+++ b/.instar/instar-dev-decisions/2026-07-31T07-04-39-937Z-learning-velocity-corrections-count-finishing.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-07-31T07:04:39.937Z",
+  "slug": "learning-velocity-corrections-count-finishing",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 72,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/LearningVelocityScorer.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 65,
+    "deletedLines": 7
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/learning-velocity-corrections-count-finishing.eli16.md
+++ b/docs/eli16/learning-velocity-corrections-count-finishing.eli16.md
@@ -1,0 +1,19 @@
+# Learning velocity counts absorbed corrections, not detected corrections
+
+## What was wrong
+
+The learning-velocity score is meant to answer “are we actually learning?” Its action-queue half already learned a hard lesson: writing down an action is not learning, so actions count only when they finish.
+
+The correction half still made the original mistake. It counted a correction the moment the system detected and stored it. The live ledger had 37 correction records and zero promoted preferences, yet all 37 were scored as learning events. That helped produce another flattering 88/100 “accelerating” score from work that had not completed.
+
+## What changes
+
+A correction now counts only after the correction loop reaches its successful `verified` state. That state means the routed preference still exists and the correction did not recur during its verification window. The event is dated at `updatedAt`, when verification completed, never at `detectedAt`, when the observation was filed.
+
+The just-shipped paraphrase clustering adds one more necessary rule. A cluster can retain several exact correction records while producing one preference. Learning velocity therefore counts one event per durable routed cluster, not one event per member. Older verified rows without a cluster identity still count individually.
+
+## What stays honest
+
+Open, acted-on, reopened, inconclusive, and timestamp-less verified rows do not count. The endpoint reports how many correction rows it considered, how many completed learning events it counted, how many member rows it coalesced, and why other rows were excluded. If the optional correction ledger cannot be read, the metric remains available but reports the source error instead of quietly presenting a partial denominator as complete.
+
+The score remains read-only and advisory. It controls nothing; this change repairs what the instrument reports.

--- a/src/core/LearningVelocityScorer.ts
+++ b/src/core/LearningVelocityScorer.ts
@@ -6,8 +6,8 @@
  * the existing model and suppress the weak signals where the future shows up.
  * EXO 3.0 says measure **learning velocity** instead — adaptability,
  * experimentation, capability creation. Instar already emits the raw learning
- * events (registered learnings, Playbook items added, corrections captured,
- * evolution actions); this scorer turns them into a velocity + trend + diversity
+ * events (registered learnings, Playbook items added, verified correction learning,
+ * completed evolution actions); this scorer turns them into a velocity + trend + diversity
  * signal so an org can watch how fast it's *learning*, not just how much it's
  * *producing*.
  *

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -10188,14 +10188,71 @@ export function createRoutes(ctx: RouteContext): Router {
           }
         }
       } catch { /* skip unreadable source */ }
-      // (3) Corrections — persisted in the SQLite CorrectionLedger, not a JSONL file.
-      // Guarded: correctionLearning ships off on many agents (ledger may be absent).
+      // (3) Corrections — COUNTED WHEN LEARNING IS VERIFIED, NOT WHEN DETECTED.
+      //
+      // A ledger row is an observation, not yet a learned preference. Counting it at
+      // detectedAt repeats the filing-rate inversion fixed above for actions: the live
+      // 37-row corpus scored 37 learning events even though it had produced zero
+      // preferences. `verified` is the correction loop's completed-success state: the
+      // routed preference still exists and the correction did not recur through its
+      // verification window. Its updatedAt is therefore the completion timestamp.
+      //
+      // Analyzer-time paraphrase clusters route as ONE preference while retaining
+      // their exact member records. Count one event per durable routeClusterId, using
+      // the latest member completion time; legacy verified rows without a cluster id
+      // remain one event each. Guarded: correctionLearning ships off on many agents
+      // (ledger may be absent).
+      const correctionAccounting = {
+        considered: 0,
+        counted: 0,
+        coalescedRecords: 0,
+        excluded: {} as Record<string, number>,
+        sourceError: false,
+      };
+      const excludeCorrection = (reason: string): void => {
+        correctionAccounting.excluded[reason] = (correctionAccounting.excluded[reason] ?? 0) + 1;
+      };
       if (ctx.correctionLedger) {
         try {
+          const completedClusters = new Map<string, string>();
           for (const r of ctx.correctionLedger.list({ limit: 1000 })) {
-            push((r as { detectedAt?: string; createdAt?: string }).detectedAt ?? (r as { createdAt?: string }).createdAt, 'correction');
+            correctionAccounting.considered += 1;
+            const rec = r as {
+              id?: string;
+              status?: string;
+              updatedAt?: string;
+              routeClusterId?: string;
+            };
+            const status = typeof rec.status === 'string' ? rec.status : 'unknown';
+            if (status !== 'verified') {
+              excludeCorrection(`not-verified:${status}`);
+              continue;
+            }
+            if (!rec.updatedAt) {
+              // Back-dating to detectedAt would turn the filing into the event again.
+              excludeCorrection('verified-without-timestamp');
+              continue;
+            }
+            const clusterKey = rec.routeClusterId ?? `record:${rec.id ?? correctionAccounting.considered}`;
+            const existing = completedClusters.get(clusterKey);
+            if (existing === undefined) {
+              completedClusters.set(clusterKey, rec.updatedAt);
+              continue;
+            }
+            correctionAccounting.coalescedRecords += 1;
+            if (Date.parse(rec.updatedAt) > Date.parse(existing)) {
+              completedClusters.set(clusterKey, rec.updatedAt);
+            }
           }
-        } catch { /* skip ledger error */ }
+          for (const completedAt of completedClusters.values()) {
+            push(completedAt, 'correction');
+            correctionAccounting.counted += 1;
+          }
+        } catch {
+          // @silent-fallback-ok: the ledger is an optional metric source; keep the
+          // read-only endpoint available but make the missing denominator explicit.
+          correctionAccounting.sourceError = true;
+        }
       }
       // The score never travels without what it was computed over (the
       // honest-denominator rule applied to this metric): `counting` states the rule in
@@ -10203,8 +10260,9 @@ export function createRoutes(ctx: RouteContext): Router {
       // reader can tell "we are not learning" from "almost nothing has finished yet".
       res.json({
         ...computeLearningVelocity(events, new Date().toISOString(), windowDays),
-        counting: 'evolution actions count on completion (completedAt), never on filing (createdAt)',
+        counting: 'evolution actions count on completion (completedAt), never on filing (createdAt); corrections count when verified (updatedAt), never on detection (detectedAt), with one event per routed cluster',
         evolutionActions: actionAccounting,
+        corrections: correctionAccounting,
       });
     } catch (err) {
       res.status(500).json({ error: err instanceof Error ? err.message : 'Failed to compute learning velocity' });

--- a/tests/e2e/learning-velocity-lifecycle.test.ts
+++ b/tests/e2e/learning-velocity-lifecycle.test.ts
@@ -67,9 +67,16 @@ describe('GET /metrics/learning-velocity — (E2E over HTTP)', () => {
     // actually reads it is the live endpoint.
     expect(body.counting).toMatch(/count on completion/i);
     expect(body.counting).toMatch(/never on filing/i);
+    expect(body.counting).toMatch(/corrections count when verified/i);
+    expect(body.counting).toMatch(/never on detection/i);
     expect(body.evolutionActions).toBeDefined();
     expect(typeof body.evolutionActions.considered).toBe('number');
     expect(typeof body.evolutionActions.counted).toBe('number');
     expect(body.evolutionActions.excluded).toBeDefined();
+    expect(body.corrections).toBeDefined();
+    expect(typeof body.corrections.considered).toBe('number');
+    expect(typeof body.corrections.counted).toBe('number');
+    expect(typeof body.corrections.coalescedRecords).toBe('number');
+    expect(body.corrections.excluded).toBeDefined();
   });
 });

--- a/tests/integration/learning-velocity-routes.test.ts
+++ b/tests/integration/learning-velocity-routes.test.ts
@@ -3,7 +3,7 @@
  * Tier-2: the route over the real HTTP pipeline, reading the REAL learning sources
  * from file-based state — the same paths/shapes the live agent writes:
  *   - registered learnings: state/evolution/learning-registry.json (ts at source.discoveredAt)
- *   - evolution actions:     state/evolution/action-queue.json  (.actions[].createdAt)
+ *   - evolution actions:     state/evolution/action-queue.json  (completedAt)
  *   - corrections:           the SQLite CorrectionLedger (ctx.correctionLedger.list())
  * Fixture timestamps are anchored to the actual "now" so they land inside the window.
  *
@@ -26,7 +26,16 @@ import type { RouteContext } from '../../src/server/routes.js';
 const DAY = 24 * 60 * 60 * 1000;
 const agoIso = (days: number) => new Date(Date.now() - days * DAY).toISOString();
 
-function ctxFor(stateDir: string, corrections: { detectedAt: string }[] = []): RouteContext {
+interface MetricCorrection {
+  id: string;
+  detectedAt: string;
+  status: 'open' | 'acted-on' | 'verified' | 'inconclusive' | 'reopened';
+  updatedAt?: string;
+  routeClusterId?: string;
+  routedVia?: string;
+}
+
+function ctxFor(stateDir: string, corrections: MetricCorrection[] = []): RouteContext {
   return {
     config: { projectName: 'echo', projectDir: path.dirname(stateDir), stateDir, port: 0 } as any,
     sessionManager: { listRunningSessions: () => [] } as any,
@@ -57,7 +66,7 @@ describe('GET /metrics/learning-velocity (integration)', () => {
 
   afterEach(() => { SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/learning-velocity-routes.test.ts' }); });
 
-  function appWith(corrections: { detectedAt: string }[] = []): express.Express {
+  function appWith(corrections: MetricCorrection[] = []): express.Express {
     const app = express();
     app.use(express.json());
     app.use('/', createRoutes(ctxFor(stateDir, corrections)));
@@ -91,8 +100,15 @@ describe('GET /metrics/learning-velocity (integration)', () => {
         { id: 'ACT-3', createdAt: agoIso(5), status: 'pending' },
       ],
     }));
-    // (3) corrections — from the SQLite ledger (mocked), detectedAt
-    const res = await request(appWith([{ detectedAt: agoIso(1) }])).get('/metrics/learning-velocity?windowDays=30');
+    // (3) corrections — a VERIFIED preference, dated when the learning completed.
+    const res = await request(appWith([{
+      id: 'CORR-1',
+      detectedAt: agoIso(12),
+      status: 'verified',
+      updatedAt: agoIso(1),
+      routeClusterId: 'cluster-1',
+      routedVia: 'recordPreference',
+    }])).get('/metrics/learning-velocity?windowDays=30');
 
     expect(res.status).toBe(200);
     expect(res.body.totalEvents).toBe(6); // 3 learnings + 2 COMPLETED actions + 1 correction
@@ -103,6 +119,9 @@ describe('GET /metrics/learning-velocity (integration)', () => {
     expect(res.body.evolutionActions.considered).toBe(3);
     expect(res.body.evolutionActions.counted).toBe(2);
     expect(res.body.evolutionActions.excluded['not-completed:pending']).toBe(1);
+    expect(res.body.corrections.considered).toBe(1);
+    expect(res.body.corrections.counted).toBe(1);
+    expect(res.body.corrections.coalescedRecords).toBe(0);
     expect(res.body.typeDiversity).toBe(3);
     expect(res.body.adaptabilityScore).toBeGreaterThan(0);
     expect(['accelerating', 'steady', 'declining']).toContain(res.body.trend);
@@ -196,5 +215,105 @@ describe('GET /metrics/learning-velocity (integration)', () => {
     // Both were COUNTED as candidates; the window did the excluding, and the
     // accounting reflects that honestly rather than hiding it.
     expect(res.body.evolutionActions.counted).toBe(2);
+  });
+
+  it('REFUSES to score detected corrections as learning before any preference is verified', async () => {
+    // Live-corpus shape from 2026-07-30: 37 ledger rows, zero promotions. The old
+    // metric scored all 37 at detectedAt and returned 88/100 "accelerating".
+    const filed = Array.from({ length: 37 }, (_, index): MetricCorrection => ({
+      id: `CORR-OPEN-${index}`,
+      detectedAt: agoIso(29 - (index % 28)),
+      status: 'open',
+    }));
+    filed.push({
+      id: 'CORR-ACTED-ON',
+      detectedAt: agoIso(4),
+      status: 'acted-on',
+      updatedAt: agoIso(1),
+      routedVia: 'recordPreference',
+    });
+
+    const res = await request(appWith(filed)).get('/metrics/learning-velocity?windowDays=30');
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalEvents).toBe(0);
+    expect(res.body.byType.correction).toBeUndefined();
+    expect(res.body.corrections.considered).toBe(38);
+    expect(res.body.corrections.counted).toBe(0);
+    expect(res.body.corrections.excluded['not-verified:open']).toBe(37);
+    expect(res.body.corrections.excluded['not-verified:acted-on']).toBe(1);
+    expect(res.body.counting).toMatch(/corrections count when verified/i);
+    expect(res.body.counting).toMatch(/never on detection/i);
+  });
+
+  it('counts one verified learning per routed cluster, not one per member record', async () => {
+    const res = await request(appWith([
+      {
+        id: 'CORR-A',
+        detectedAt: agoIso(20),
+        status: 'verified',
+        updatedAt: agoIso(3),
+        routeClusterId: 'cluster-shared',
+        routedVia: 'recordPreference',
+      },
+      {
+        id: 'CORR-B',
+        detectedAt: agoIso(18),
+        status: 'verified',
+        updatedAt: agoIso(2),
+        routeClusterId: 'cluster-shared',
+        routedVia: 'recordPreference',
+      },
+      {
+        id: 'CORR-C',
+        detectedAt: agoIso(16),
+        status: 'verified',
+        updatedAt: agoIso(1),
+        routeClusterId: 'cluster-shared',
+        routedVia: 'recordPreference',
+      },
+      {
+        id: 'CORR-LEGACY',
+        detectedAt: agoIso(14),
+        status: 'verified',
+        updatedAt: agoIso(4),
+        routedVia: 'recordPreference',
+      },
+    ])).get('/metrics/learning-velocity?windowDays=30');
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalEvents).toBe(2);
+    expect(res.body.byType.correction).toBe(2);
+    expect(res.body.corrections.considered).toBe(4);
+    expect(res.body.corrections.counted).toBe(2);
+    expect(res.body.corrections.coalescedRecords).toBe(2);
+  });
+
+  it('excludes a verified correction without a completion timestamp instead of back-dating detection', async () => {
+    const res = await request(appWith([{
+      id: 'CORR-NO-COMPLETION-TIME',
+      detectedAt: agoIso(1),
+      status: 'verified',
+      routedVia: 'recordPreference',
+    }])).get('/metrics/learning-velocity?windowDays=30');
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalEvents).toBe(0);
+    expect(res.body.corrections.counted).toBe(0);
+    expect(res.body.corrections.excluded['verified-without-timestamp']).toBe(1);
+  });
+
+  it('keeps the advisory route available but reports an unreadable correction source', async () => {
+    const app = express();
+    app.use(express.json());
+    const ctx = ctxFor(stateDir) as any;
+    ctx.correctionLedger = { list: () => { throw new Error('ledger unavailable'); } };
+    app.use('/', createRoutes(ctx));
+
+    const res = await request(app).get('/metrics/learning-velocity?windowDays=30');
+
+    expect(res.status).toBe(200);
+    expect(res.body.corrections.sourceError).toBe(true);
+    expect(res.body.corrections.counted).toBe(0);
   });
 });

--- a/upgrades/next/learning-velocity-corrections-count-finishing.md
+++ b/upgrades/next/learning-velocity-corrections-count-finishing.md
@@ -1,0 +1,28 @@
+# Learning velocity counts absorbed corrections
+
+## What Changed
+
+The learning-velocity endpoint no longer treats a detected correction as completed learning. Corrections count only when the correction loop reaches `verified`, dated at the lifecycle completion time. Several exact records routed as one paraphrase cluster contribute one event rather than one event per member.
+
+The response now includes correction accounting: rows considered, completed events counted, cluster members coalesced, exclusions by lifecycle state, and whether the optional ledger source could not be read.
+
+## What to Tell Your User
+
+The “are we actually learning?” score may drop. That is intentional: noticing a correction is not the same as absorbing it. The score now credits correction learning only after the preference survives verification.
+
+## Summary of New Capabilities
+
+No new action or control. `GET /metrics/learning-velocity` gains a `corrections` accounting object and a more complete counting-rule explanation.
+
+## Evidence
+
+- A 37-row detected-only ledger fixture now produces zero correction learning events.
+- An acted-on but unverified preference produces zero events.
+- Three verified records in one routed cluster produce one event; a verified legacy row without a cluster remains one event.
+- A verified row without a completion timestamp is excluded rather than back-dated to detection.
+- An unreadable correction source remains a 200 advisory response with `sourceError: true`.
+- Focused unit, integration, and end-to-end suites pass 18/18.
+
+## UX Impact
+
+Who sees it: users and agents reading the learning-velocity metric. On first contact after this update, the reported `adaptabilityScore` may be lower because unverified correction filings no longer count as learning. The concrete response now includes `corrections.counted` so the denominator is inspectable.

--- a/upgrades/side-effects/learning-velocity-corrections-count-finishing.md
+++ b/upgrades/side-effects/learning-velocity-corrections-count-finishing.md
@@ -1,0 +1,87 @@
+# Side-Effects Review — learning velocity counts absorbed corrections
+
+**Version / slug:** `learning-velocity-corrections-count-finishing`
+**Date:** `2026-07-31`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`GET /metrics/learning-velocity` previously turned every correction-ledger detection into a learning event at `detectedAt`. It now admits only `verified` correction learning at `updatedAt`, coalesces records sharing one durable `routeClusterId` into one event, and returns explicit correction accounting. The pure scorer is unchanged; only event gathering in `src/server/routes.ts`, one explanatory comment in `src/core/LearningVelocityScorer.ts`, and the route tests change.
+
+## Decision-point inventory
+
+- `GET /metrics/learning-velocity` event gathering — **modify** — changes which correction records are reported as completed learning events.
+- No block, allow, dispatch, lifecycle, or mutation decision is added. The metric remains read-only and advisory.
+
+## 1. Over-block
+
+No block/allow surface — over-block is not applicable.
+
+The analogous reporting risk is over-exclusion. A useful correction that has not reached `verified` does not count, even if a human believes it taught the agent something. That is intentional: detection, routing, and attempted application are intermediate states, not proof that learning completed. The response itemizes those states so the exclusion is visible rather than hidden.
+
+## 2. Under-block
+
+No block/allow surface — under-block is not applicable.
+
+A false `verified` lifecycle state would still count as learning because this metric consumes the correction loop’s durable success state rather than independently re-verifying preference contents. That is the correct abstraction boundary: the correction loop owns verification, while this route owns counting. Existing correction lifecycle tests guard the state transition.
+
+## 3. Level-of-abstraction fit
+
+The route is the existing event-gathering layer. `LearningVelocityScorer` remains a pure calculator over already-admitted events and does not gain ledger semantics. The correction loop remains the authority on whether correction learning verified. This avoids duplicating preference inspection or recurrence logic inside a reporting endpoint.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+Learning velocity is a signal. Nothing branches on its score, and this patch adds no authority. It consumes the correction loop’s existing verified lifecycle result and reports a stricter denominator.
+
+## 4b. Judgment-point check
+
+No new static heuristic at a competing-signals decision point. `status === "verified"` is the existing completed-success invariant owned by the correction loop, and `routeClusterId` is the existing identity for one routed external effect.
+
+## 5. Interactions
+
+- **Shadowing:** none. The route reads lifecycle results after the correction loop writes them.
+- **Double-fire:** cluster members are deliberately coalesced by `routeClusterId`, preventing one promoted preference from appearing as several learning events.
+- **Races:** the ledger read is a bounded snapshot. A cluster transitioning during the read can appear on the next request; the endpoint mutates nothing.
+- **Feedback loops:** none. No code consumes the metric to change correction state.
+- **Source failure:** an unreadable optional ledger leaves the endpoint alive and sets `corrections.sourceError: true`; the denominator is not silently presented as complete.
+
+## 6. External surfaces
+
+The JSON response gains a `corrections` accounting object and expands the human-readable `counting` rule. Existing score fields are unchanged. Users asking whether the agent is learning may see a lower, more honest score because detected-but-unabsorbed corrections no longer inflate it.
+
+No operator-facing action is added. No dashboard form, approval, secret, URL, or outbound notice changes.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+**Machine-local by design.** The endpoint already measures the learning sources available to the serving agent instance. This patch preserves that posture and reads the same local correction ledger as before. It emits no user-facing notices, holds no new durable state, and generates no URLs. There is no topic-transfer or one-voice concern because the route is request/response observability only.
+
+## 8. Rollback cost
+
+Pure code revert and patch release. No schema, config, migration, persisted data, or agent state repair is required. Reverting would immediately restore detection-time correction counting on the next request.
+
+## Conclusion
+
+The change closes the second half of the filing-versus-finishing inversion without moving the scorer or correction authority. Detected rows count zero; a verified legacy row counts once; several verified records from one routed cluster count once; and source degradation is explicit. The review found no blocking, actuation, or multi-machine side effect.
+
+## Second-pass review
+
+Not required. This is a Tier 1 read-only metric correction with no gate, sentinel, lifecycle, dispatch, or outbound surface.
+
+## Evidence pointers
+
+- `tests/integration/learning-velocity-routes.test.ts`
+- `tests/e2e/learning-velocity-lifecycle.test.ts`
+- `tests/unit/LearningVelocityScorer.test.ts`
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect and no self-triggered controller change — not applicable.


### PR DESCRIPTION
## ELI16

The learning-velocity metric was treating a correction as learned the moment it was filed. That made 37 still-open corrections look like 37 completed learning events and inflated the score. This change counts the correction only after its learning lifecycle reaches `verified`, using the verification update time.

## Root cause

The action half of the metric already counted completion. The correction half instead counted every ledger row at `detectedAt`, so detection and learning were conflated.

## What changed

- Count only `verified` correction records.
- Use `updatedAt` as the completion timestamp; do not backdate missing completion timestamps to detection.
- Coalesce paraphrase members by durable `routeClusterId`, so one verified learned cluster is one correction event.
- Preserve legacy verified rows without a cluster as one event each.
- Expose correction accounting (`considered`, `counted`, coalesced/excluded records, and source error) so zero is interpretable rather than silent.
- Keep the endpoint advisory and read-only; an unavailable optional correction ledger remains a 200 response but now reports `corrections.sourceError` explicitly.

## Validation

Fail-first coverage reproduced the defect before implementation:

- 37 open corrections plus one acted-on correction incorrectly produced 38 learning events.
- Four verified records spanning two learned outputs incorrectly counted as four.
- A verified row without a completion timestamp was incorrectly backdated to detection.

After the fix:

- focused integration: 11 passed
- focused e2e: 1 passed
- scorer unit suite: 6 passed
- lint: passed
- build: passed
- total focused tests: 18/18 passed

The pushed pre-push selector timed out while listing affected tests and explicitly deferred full-suite authority to CI. No ratchet baseline was changed.

## Honest result

A live-shaped fixture with 37 detected-but-unverified correction rows now contributes zero completed correction events. One acted-on but unverified row also contributes zero. A verified three-record cluster plus one legacy verified row contributes two completed correction events.

This corrects the same completion-vs-filing defect as the action half. It does not claim that the current live score is recomputed locally from Justin's ledger; CI and the route fixtures validate the behavior, while the previously reported live score of 88 is the motivating observation.

## UX Impact

Who sees it: users and agents reading the learning-velocity metric. On first contact after this update, the user-visible adaptability score may be lower because unverified correction filings no longer count as completed learning. The response now explains, `evolution actions count on completion (completedAt), never on filing (createdAt); corrections count when verified (updatedAt), never on detection (detectedAt), with one event per routed cluster`, and its accompanying correction accounting lets operators distinguish a truthful zero from unreadable or excluded correction data.
