### PR TITLE
docs(findings): retract the gemini OAuth-only detection finding — it is not a defect

### DIFF
--- a/docs/findings/2026-07-31-gemini-reviewer-detection-is-oauth-only.md
+++ b/docs/findings/2026-07-31-gemini-reviewer-detection-is-oauth-only.md
@@ -1,15 +1,87 @@
 ---
-title: "The gemini cross-model reviewer is detected by OAuth creds alone, so a host authed by API key is reported unavailable — the exact false-unavailable the module says it exists to prevent"
+title: "RETRACTED — the gemini reviewer's OAuth-only detection is correct, because Instar strips every non-OAuth credential before spawning gemini"
 date: 2026-07-31
 author: echo
 machine: Mac Mini
-severity: medium
-status: open
+severity: none
+status: retracted
 kind: finding
+retracted: 2026-07-31
 relates:
   - "src/core/crossModelReviewer.ts"
+  - "src/providers/adapters/gemini-cli/transport/geminiSpawn.ts"
+  - "src/providers/adapters/gemini-cli/config.ts"
   - "skills/spec-converge/SKILL.md"
 ---
+
+> # ⚠️ RETRACTED — the finding below is wrong
+>
+> **There is no defect.** OAuth-only detection is correct and deliberate. The original text is kept
+> intact beneath this notice because the reasoning error is worth more than the claim was.
+
+## Why it is wrong
+
+The finding reasoned entirely about **what the gemini CLI accepts when run by hand**. It never checked
+**how Instar actually spawns gemini** — and Instar removes every one of those credentials first.
+
+`src/providers/adapters/gemini-cli/transport/geminiSpawn.ts` builds the child environment as an
+**allowlist** ("anything not listed is dropped"), then hard-deletes the billing-capable vars:
+
+```ts
+/**
+ * The Google/Gemini billing-capable vars that are UNCONDITIONALLY deleted
+ * from the child env ... Any of these present would silently route Gemini onto
+ * a billed API path instead of the cached-OAuth/subscription path. A false-negative
+ * (silent billing) is asymmetrically costly, so the delete is unconditional and the
+ * geminiKeyLeakageCanary asserts none of these ever reaches the child.
+ */
+export const GEMINI_BILLING_ENV_VARS = [
+  'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'GOOGLE_APPLICATION_CREDENTIALS',
+  'GOOGLE_GENAI_USE_VERTEXAI', 'GOOGLE_CLOUD_PROJECT',
+] as const;
+```
+
+`GOOGLE_GENAI_USE_GCA` is not on the allowlist either, so it is dropped as well. Every gemini execution
+path goes through this — `GeminiCliIntelligenceProvider.ts:91`, the setup-wizard driver, and the loop
+production transport all call `buildGeminiChildEnv()`.
+
+`config.ts` states the policy outright: cached OAuth under `~/.gemini` is **"THE ALLOWED PATH"**; the
+API-key/Vertex route **"can route onto a BILLED API account"** and is stripped.
+
+**So on a host authed only by API key, Vertex, or Code Assist, gemini-as-Instar-spawns-it is genuinely
+not authed.** Reporting `gemini-not-authed` is a *true* unavailable. There is no false-unavailable and
+no open door.
+
+## The proposed fix would have been actively harmful
+
+Items 2–3 below ("treat a non-empty `GEMINI_API_KEY` as authed", "treat `GOOGLE_GENAI_USE_VERTEXAI` /
+`GOOGLE_GENAI_USE_GCA` as authed") would have made detection report *available* for a host that cannot
+run, and pushed toward honoring exactly the credentials a dedicated canary test
+(`geminiKeyLeakageCanary`) exists to keep out of the child. The "safe direction" argument in the
+original is inverted: admitting those methods is the unsafe direction.
+
+## The reasoning error, which is the part worth keeping
+
+**I verified the dependency's behaviour and never verified our invocation of it.** The CLI's own error
+text is real, quoted correctly, and irrelevant — the question was never "what can gemini accept?" but
+"what does Instar hand it?", and one `grep buildGeminiChildEnv` would have answered it.
+
+The mechanical slip: I grepped `GEMINI_API_KEY`, found it in `geminiSpawn.ts`, and **inferred
+acceptance from membership in a list.** The file, the line, and the variable were all exactly right;
+the list was a *deletion* list. I never read the ten lines of comment directly above it.
+
+**And the "Honest limits" section below is the sharpest lesson here.** It correctly flags that I never
+executed the API-key path end-to-end — a real limitation, honestly stated, and *not the load-bearing
+one*. The unchecked assumption was that Instar passes the environment through at all, and that never
+appeared as a caveat because it never occurred to me to doubt it. **Naming a limitation is not the same
+as naming the right limitation**; a well-caveated document can be more persuasive than an uncaveated
+one while resting on an assumption neither the author nor the reader ever surfaced.
+
+Issue #1789, filed from this finding, is closed as invalid.
+
+---
+
+*Original text follows, unaltered.*
 
 ## The claim
 


### PR DESCRIPTION
## ELI16 overview

Earlier tonight I wrote up a bug report saying one of our tools was broken. I was wrong, and this pull request takes it back.

The tool decides whether we can use Google's Gemini as a second opinion when reviewing our own work. It only says "yes" if you signed in with a Google account. I claimed that was too strict, because Gemini also accepts an API key — so anyone using a key would be wrongly told it was unavailable.

What I missed is that our own code deliberately throws that API key away before it ever starts Gemini. There is a deliberate rule here: an API key bills you per use, while signing in uses the subscription you already pay for. Someone before me decided we should never accidentally take the billed path, and wrote a test that fails if a key ever leaks through.

So the tool is right. On a machine with only an API key, Gemini genuinely cannot run the way we start it, and saying "unavailable" is honest rather than a mistake. Worse, the fix I proposed would have pointed us straight at the expensive path the safeguard exists to block.

This change marks the old write-up as retracted and explains the error, leaving the original text underneath so the reasoning is still visible. Nothing else changes — no code, no tests.

## What this retracts

PR #1779 landed a finding claiming the gemini cross-model reviewer's OAuth-only detection produces a **false-unavailable** on hosts authed by API key, Vertex, or Code Assist. **It does not. There is no defect**, and the fix that finding proposed would have been harmful.

## Why the finding was wrong

It reasoned entirely about what the gemini CLI accepts **when run by hand**, and never checked **how Instar spawns it**.

`geminiSpawn.ts` builds the child environment as an **allowlist** ("anything not listed is dropped"), then unconditionally hard-deletes the billing-capable vars — `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT`. `GOOGLE_GENAI_USE_GCA` is not allowlisted either, so it is dropped too. Every gemini execution path calls `buildGeminiChildEnv()`: `GeminiCliIntelligenceProvider.ts:91`, the setup-wizard driver, and the loop-production transport.

`config.ts` states the policy directly: cached OAuth under `~/.gemini` is **"THE ALLOWED PATH"**; the API-key/Vertex route **"can route onto a BILLED API account"** and is stripped.

**So on such a host, gemini as Instar spawns it is genuinely not authed.** `gemini-not-authed` is a *true* unavailable.

## The proposed fix would have been actively harmful

The original recommended treating a non-empty `GEMINI_API_KEY` (and `GOOGLE_GENAI_USE_VERTEXAI` / `GOOGLE_GENAI_USE_GCA`) as authed. That would report *available* for a host that cannot run, and push toward honoring precisely the credentials `geminiKeyLeakageCanary` exists to keep out of the child. The original's "safe direction" argument is inverted.

## What changed

Frontmatter → `status: retracted`, `severity: none`, retitled. A retraction header explains the error. **The original text is kept intact underneath** — the reasoning error is worth more than the claim was.

Issue #1789, filed from this finding, is closed as invalid.

## The lesson, recorded in the doc

I verified the dependency's behaviour and never verified our invocation of it. Mechanically: I grepped `GEMINI_API_KEY`, found it in `geminiSpawn.ts`, and **inferred acceptance from membership in a list** — the file, line, and variable were all right, and the list was a *deletion* list.

The original's "Honest limits" section is the sharpest part: it flags that I never executed the API-key path end-to-end — a real limitation, honestly stated, and **not the load-bearing one**. The unchecked assumption was that Instar passes the environment through at all. **Naming a limitation is not the same as naming the right limitation**, and a well-caveated document can read as more rigorous while resting on an assumption nobody surfaced.

Docs-only. No source or test changes.
