### PR TITLE
Fix compaction recovery hook path

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-31T12-54-26-588Z-compaction-recovery-path-reachability.json
+++ b/.instar/instar-dev-decisions/2026-07-31T12-54-26-588Z-compaction-recovery-path-reachability.json
@@ -1,0 +1,42 @@
+{
+  "ts": "2026-07-31T12:54:26.588Z",
+  "slug": "compaction-recovery-path-reachability",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 4,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/PostUpdateMigrator.ts"
+    ],
+    "addedLines": 2,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "novel",
+    "closure": "gap",
+    "gapItem": "ACT-245",
+    "component": "PostUpdateMigrator.getSessionStartHook",
+    "novelClass": {
+      "nearestExistingClass": "prompt-parser-contract-drift — both are producer/consumer contract drift in agent-authored text, but generated-artifact-path-contract-drift concerns filesystem reachability rather than prompt-output schemas",
+      "includes": [
+        "an installer writes a generated hook or helper at one path while a generated caller checks or executes a different path",
+        "two templates independently spell a shared generated-artifact location and drift without an integration assertion"
+      ],
+      "excludes": [
+        "a runtime file missing because an otherwise-correct installation was interrupted or manually deleted",
+        "a user-customized path intentionally resolved through configuration"
+      ],
+      "severity": "critical"
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-31T12-55-13-781Z-compaction-recovery-path-reachability.json
+++ b/.instar/instar-dev-decisions/2026-07-31T12-55-13-781Z-compaction-recovery-path-reachability.json
@@ -1,0 +1,42 @@
+{
+  "ts": "2026-07-31T12:55:13.781Z",
+  "slug": "compaction-recovery-path-reachability",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 4,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/PostUpdateMigrator.ts"
+    ],
+    "addedLines": 2,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "novel",
+    "closure": "gap",
+    "gapItem": "ACT-245",
+    "component": "PostUpdateMigrator.getSessionStartHook",
+    "novelClass": {
+      "nearestExistingClass": "prompt-parser-contract-drift — both are producer/consumer contract drift in agent-authored text, but generated-artifact-path-contract-drift concerns filesystem reachability rather than prompt-output schemas",
+      "includes": [
+        "an installer writes a generated hook or helper at one path while a generated caller checks or executes a different path",
+        "two templates independently spell a shared generated-artifact location and drift without an integration assertion"
+      ],
+      "excludes": [
+        "a runtime file missing because an otherwise-correct installation was interrupted or manually deleted",
+        "a user-customized path intentionally resolved through configuration"
+      ],
+      "severity": "critical"
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-07-31T12-55-58-858Z-compaction-recovery-path-reachability.json
+++ b/.instar/instar-dev-decisions/2026-07-31T12-55-58-858Z-compaction-recovery-path-reachability.json
@@ -21,22 +21,11 @@
   },
   "causalAutopsy": null,
   "classClosure": {
-    "defectClass": "novel",
+    "defectClass": "generated-artifact-path-contract-drift",
     "closure": "gap",
     "gapItem": "ACT-245",
-    "component": "PostUpdateMigrator.getSessionStartHook",
-    "novelClass": {
-      "nearestExistingClass": "prompt-parser-contract-drift — both are producer/consumer contract drift in agent-authored text, but generated-artifact-path-contract-drift concerns filesystem reachability rather than prompt-output schemas",
-      "includes": [
-        "an installer writes a generated hook or helper at one path while a generated caller checks or executes a different path",
-        "two templates independently spell a shared generated-artifact location and drift without an integration assertion"
-      ],
-      "excludes": [
-        "a runtime file missing because an otherwise-correct installation was interrupted or manually deleted",
-        "a user-customized path intentionally resolved through configuration"
-      ],
-      "severity": "critical"
-    }
+    "prNumber": 1799,
+    "component": "PostUpdateMigrator.getSessionStartHook"
   },
   "verdict": "pass"
 }

--- a/.instar/instar-dev-decisions/2026-07-31T12-55-58-858Z-compaction-recovery-path-reachability.json
+++ b/.instar/instar-dev-decisions/2026-07-31T12-55-58-858Z-compaction-recovery-path-reachability.json
@@ -1,0 +1,42 @@
+{
+  "ts": "2026-07-31T12:55:58.858Z",
+  "slug": "compaction-recovery-path-reachability",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 4,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/PostUpdateMigrator.ts"
+    ],
+    "addedLines": 2,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "novel",
+    "closure": "gap",
+    "gapItem": "ACT-245",
+    "component": "PostUpdateMigrator.getSessionStartHook",
+    "novelClass": {
+      "nearestExistingClass": "prompt-parser-contract-drift — both are producer/consumer contract drift in agent-authored text, but generated-artifact-path-contract-drift concerns filesystem reachability rather than prompt-output schemas",
+      "includes": [
+        "an installer writes a generated hook or helper at one path while a generated caller checks or executes a different path",
+        "two templates independently spell a shared generated-artifact location and drift without an integration assertion"
+      ],
+      "excludes": [
+        "a runtime file missing because an otherwise-correct installation was interrupted or manually deleted",
+        "a user-customized path intentionally resolved through configuration"
+      ],
+      "severity": "critical"
+    }
+  },
+  "verdict": "pass"
+}

--- a/docs/defect-classes.json
+++ b/docs/defect-classes.json
@@ -185,6 +185,32 @@
       "evidenceCountAtLastAck": 0,
       "proposalId": null,
       "nearestExistingClass": "unknown-classification-fail-open — both concern classifier authority, but this class over-classifies known vocabulary in the wrong context while the neighbor permissively defaults unknown input"
+    },
+    {
+      "id": "generated-artifact-path-contract-drift",
+      "description": "Two agent-authored generated artifacts that must compose name different canonical filesystem locations for the same installed dependency, so each artifact is locally valid while the end-to-end runtime path is unreachable.",
+      "includes": [
+        "an installer writes a generated hook or helper at one path while a generated caller checks or executes a different path",
+        "two templates independently spell a shared generated-artifact location and drift without an integration assertion",
+        "an always-overwrite migration consistently installs both sides of a broken path contract"
+      ],
+      "excludes": [
+        "a runtime file missing because an otherwise-correct installation was interrupted or manually deleted",
+        "a user-customized path that is intentionally resolved through configuration",
+        "an ordinary product-code call to a nonexistent module that is already caught by the compiler or linker"
+      ],
+      "canonicalExamples": [
+        "Issue #1798: PostUpdateMigrator installed compaction-recovery.sh under hooks/instar while the generated session-start hook checked and executed hooks/compaction-recovery.sh"
+      ],
+      "status": "unconfirmed",
+      "severity": "critical",
+      "closureStandard": null,
+      "closureStandardEnforcement": null,
+      "instanceCount": 0,
+      "escalatedAt": null,
+      "evidenceCountAtLastAck": 0,
+      "proposalId": null,
+      "nearestExistingClass": "prompt-parser-contract-drift — both are producer/consumer contract drift in agent-authored text, but this class concerns generated filesystem reachability rather than an LLM prompt's output schema"
     }
   ]
 }

--- a/docs/specs/context-death-pitfall-prevention.eli16.md
+++ b/docs/specs/context-death-pitfall-prevention.eli16.md
@@ -1,5 +1,8 @@
 # Context-Death Pitfall Prevention — Plain English
 
+> Constitutional anchor: **Structure beats Willpower** — continuation must be
+> restored by installed machinery, not by hoping a compressed session remembers.
+
 ## What This Is
 
 Sometimes an agent stops in the middle of real work and explains the stop by saying the session is getting long, the context window might run out, or a fresh session would be cleaner. That sounds responsible, but in this system it is usually the wrong move. Instar already has recovery machinery that reloads identity, recent memory, and conversation context when a session compacts or restarts. If the work has a durable plan, committed code, a ledger entry, or another concrete artifact, the agent should continue from that artifact instead of making the user ask again.

--- a/docs/specs/context-death-pitfall-prevention.md
+++ b/docs/specs/context-death-pitfall-prevention.md
@@ -8,6 +8,7 @@ approved-at: "2026-04-17T06:24:43-04:00"
 date: 2026-04-17
 author: Echo
 cluster: cluster-autonomous-execution-robustness
+parent-principle: "Structure beats Willpower"
 review-iterations: 4
 review-convergence: "2026-04-17T18:10:00-04:00"
 review-completed-at: "2026-04-17T18:10:00-04:00"

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -11839,8 +11839,8 @@ echo ""
 
 # On compaction, delegate to the dedicated recovery hook
 if [ "\$EVENT" = "compact" ]; then
-  if [ -x "$INSTAR_DIR/hooks/compaction-recovery.sh" ]; then
-    exec bash "$INSTAR_DIR/hooks/compaction-recovery.sh"
+  if [ -x "$INSTAR_DIR/hooks/instar/compaction-recovery.sh" ]; then
+    exec bash "$INSTAR_DIR/hooks/instar/compaction-recovery.sh"
   fi
 fi
 

--- a/tests/unit/PostUpdateMigrator-loadAssess.test.ts
+++ b/tests/unit/PostUpdateMigrator-loadAssess.test.ts
@@ -34,6 +34,11 @@ function runMigrateScripts(m: PostUpdateMigrator): MigrationResult {
   (m as unknown as { migrateScripts(r: MigrationResult): void }).migrateScripts(result);
   return result;
 }
+function runMigrateHooks(m: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (m as unknown as { migrateHooks(r: MigrationResult): void }).migrateHooks(result);
+  return result;
+}
 function runMigrateClaudeMd(m: PostUpdateMigrator): MigrationResult {
   const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
   (m as unknown as { migrateClaudeMd(r: MigrationResult): void }).migrateClaudeMd(result);
@@ -83,7 +88,7 @@ describe('getSessionStartHook — MACHINE LOAD block survives compaction', () =>
     expect(hook).toContain('--- MACHINE LOAD ---');
     expect(hook).toContain('load-assess.sh');
     const blockIdx = hook.indexOf('--- MACHINE LOAD ---');
-    const execIdx = hook.indexOf('exec bash "$INSTAR_DIR/hooks/compaction-recovery.sh"');
+    const execIdx = hook.indexOf('exec bash "$INSTAR_DIR/hooks/instar/compaction-recovery.sh"');
     expect(blockIdx).toBeGreaterThan(-1);
     expect(execIdx).toBeGreaterThan(-1);
     // The load-bearing property: the block prints BEFORE the process-replacing exec,
@@ -96,6 +101,38 @@ describe('getSessionStartHook — MACHINE LOAD block survives compaction', () =>
     const hook = (m as unknown as { getSessionStartHook(): string }).getSessionStartHook();
     expect(hook.toLowerCase()).toContain('load average');
     expect(hook.toLowerCase()).toContain('never');
+  });
+});
+
+describe('PostUpdateMigrator — compaction recovery hook reachability', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-compaction-hook-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/unit/PostUpdateMigrator-loadAssess.test.ts' });
+  });
+
+  it('writes the recovery hook at the exact path checked and executed by session-start', () => {
+    const result = runMigrateHooks(createMigrator(projectDir));
+    expect(result.errors).toEqual([]);
+
+    const sessionStartPath = path.join(projectDir, '.instar', 'hooks', 'instar', 'session-start.sh');
+    const sessionStart = fs.readFileSync(sessionStartPath, 'utf8');
+    const referencedRecoveryPaths = Array.from(
+      sessionStart.matchAll(/"\$INSTAR_DIR\/([^"]*compaction-recovery\.sh)"/g),
+      (match) => match[1],
+    );
+
+    expect(referencedRecoveryPaths).toHaveLength(2);
+    expect(new Set(referencedRecoveryPaths)).toEqual(new Set(['hooks/instar/compaction-recovery.sh']));
+
+    const installedRecoveryPath = path.join(projectDir, '.instar', referencedRecoveryPaths[0]);
+    expect(fs.existsSync(installedRecoveryPath)).toBe(true);
+    expect(fs.statSync(installedRecoveryPath).mode & 0o100).toBe(0o100);
   });
 });
 

--- a/upgrades/next/compaction-recovery-path-reachability.md
+++ b/upgrades/next/compaction-recovery-path-reachability.md
@@ -1,0 +1,23 @@
+# Compaction recovery path reachability
+
+## What Changed
+
+The generated session-start hook now checks and executes compaction recovery at
+the same canonical built-in-hook path used by the update migrator. A regression
+test runs the hook migration and proves both generated references resolve to the
+executable recovery file that was actually installed.
+
+## What to Tell Your User
+
+After an update, your agent can once again restore its identity and conversation context when a long session is compacted.
+
+## Summary of New Capabilities
+
+No new capability was added; this restores the existing post-compaction recovery path.
+
+## Evidence
+
+- `tests/unit/PostUpdateMigrator-loadAssess.test.ts`: 7 tests pass, including the
+  new installed-path consistency regression.
+- The regression failed on the previous source with the exact observed mismatch
+  before passing after both session-start references were corrected.

--- a/upgrades/side-effects/compaction-recovery-path-reachability.md
+++ b/upgrades/side-effects/compaction-recovery-path-reachability.md
@@ -1,0 +1,197 @@
+# Side-Effects Review — compaction recovery path reachability
+
+**Version / slug:** `compaction-recovery-path-reachability`
+**Date:** `2026-07-31`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `Codex subagent 1798_second_pass — concurred`
+
+## Summary of the change
+
+`PostUpdateMigrator` already installs both built-in hooks under
+`.instar/hooks/instar/`, but the generated session-start hook checked and
+executed compaction recovery at the obsolete flat path
+`.instar/hooks/compaction-recovery.sh`. The compact branch therefore skipped
+identity and conversation recovery even after a successful migration. This
+change aligns the session-start executable check and `exec` with the canonical
+installer path and adds a migration-level regression that reads the generated
+hook, extracts both references, and proves they resolve to the executable file
+the same migration wrote. It also registers the broader generated-artifact
+path-contract defect class and tracks its class-level lint as ACT-245.
+
+## Decision-point inventory
+
+- `getSessionStartHook()` compact-event branch — **modified** — its existing
+  deterministic executable-presence check now names the canonical built-in-hook
+  directory. The branch's allow/skip semantics are unchanged.
+- `migrateHooks()` built-in installation location — **passed through** — remains
+  the authoritative writer at `hooks/instar/compaction-recovery.sh`.
+- Compaction recovery content and all recovery judgments — **passed through** —
+  no detection, retry, restart, or recovery policy changes.
+
+---
+
+## 1. Over-block
+
+The change rejects no user input and adds no new refusal. A manually maintained
+legacy recovery hook that exists only at `.instar/hooks/compaction-recovery.sh`
+is no longer considered by the generated session-start hook, but that flat path
+was already non-authoritative: every current migration writes and overwrites the
+built-in hook under `.instar/hooks/instar/`. Custom hooks belong under
+`.instar/hooks/custom/`, so preserving the stale flat lookup would reintroduce
+layout ambiguity rather than legitimate compatibility.
+
+---
+
+## 2. Under-block
+
+The regression closes this exact producer/consumer path mismatch for compaction
+recovery. It does not yet scan every generated hook-to-helper reference in the
+repository; that broader class guard is tracked as ACT-245, due 2026-09-14. A
+file may still be absent after external deletion or an interrupted migration;
+the existing executable check intentionally skips in that condition rather than
+making session startup fail.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The fix sits at the generated caller that contained the wrong literal, while
+the regression spans the actual migration boundary. Testing only the template
+string would prove spelling but not installation reachability; testing only the
+installed file would miss whether both the check and `exec` use the same path.
+The migration-level test is therefore the smallest layer that proves the
+end-to-end contract without introducing a second path resolver into shell.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no new block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] Yes, with brittle logic.
+
+The pre-existing `-x` check is a deterministic filesystem invariant, not a
+judgment over ambiguous evidence. This change corrects the invariant's operand;
+it does not promote a detector into authority or alter the fail-soft startup
+policy when the helper is truly missing.
+
+---
+
+## 4b. Judgment-point check
+
+No new static heuristic or competing-signals decision point is added. “Does the
+canonical executable installed by this migrator exist?” is an enumerable
+structural invariant.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** on compact events, the dedicated recovery script still replaces
+  the session-start process before ordinary startup output. The corrected path
+  makes the already-designed branch reachable.
+- **Double-fire:** there remains exactly one compact delegate and one `exec`; the
+  path correction cannot invoke both legacy and canonical copies.
+- **Races:** migration writes both files synchronously before returning. The test
+  exercises the completed migration state; no shared mutable runtime state is
+  introduced.
+- **Feedback loops:** none. The helper runs once per compact lifecycle event and
+  this change adds no trigger, retry, or re-entry edge.
+- **Adjacent migration behavior:** built-in hooks remain always-overwrite, so an
+  existing installation receives both corrected session-start content and the
+  canonical recovery helper on its next update.
+
+---
+
+## 6. External surfaces
+
+Existing agents regain the intended post-compaction identity and conversation
+context after update. There is no HTTP/API/schema change, no new message, no
+database or ledger write, and no dependency on Telegram, Slack, GitHub, or
+Cloudflare. The only timing dependency is the existing compact lifecycle event.
+No operator-facing action is added.
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture
+
+**machine-local BY DESIGN** — session hooks and compaction events belong to the
+specific process and checkout on each machine. The source fix replicates through
+the normal software update path, after which each machine's migrator installs its
+own canonical hook pair. The change emits no user-facing notice, holds no durable
+state, strands nothing on topic transfer, and generates no URL.
+
+---
+
+## 8. Rollback cost
+
+Pure generated-hook source change plus test and governance artifacts. A hot-fix
+can revert the two corrected literals; no data migration or agent-state repair is
+required. Reverting would restore the silent post-compaction context loss on
+agents after their next migration, which is why rollback is safe mechanically
+but undesirable behaviorally.
+
+---
+
+## Conclusion
+
+The implementation is narrow and complete for #1798: both authoritative source
+references now match the authoritative writer, and a fail-first integration
+regression proves the contract at migration output. Because compaction is a
+session-lifecycle surface, an independent second-pass review checked the
+migration, compact-event execution, authority posture, and release claim and
+concurred. The broader defect-class guard is honestly tracked as ACT-245 rather
+than overstating this one regression as repository-wide closure.
+
+---
+
+## Second-pass review
+
+**Reviewer:** Codex subagent `1798_second_pass`
+**Independent read of the artifact:** concur
+
+The reviewer independently verified that both generated references match the
+canonical writer, ran the focused 7-test suite, and executed a compact event
+against migrated hooks to prove recovery replaces ordinary session-start flow.
+They found no added authority, persistent-state mutation, security-boundary
+change, or migration hazard, and agreed that the unconfirmed novel class is
+honestly recorded as a gap under ACT-245.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/PostUpdateMigrator-loadAssess.test.ts` — fail-first result captured:
+  expected `hooks/instar/compaction-recovery.sh`, received
+  `hooks/compaction-recovery.sh`; then 7/7 tests passed after the source fix.
+- `src/core/PostUpdateMigrator.ts#getSessionStartHook` — both the executable check
+  and `exec` now use the installed built-in-hook path.
+- `src/core/PostUpdateMigrator.ts#migrateHooks` — authoritative writer remains
+  `hooks/instar/compaction-recovery.sh`.
+- Independent compact-event execution reached the installed recovery hook and
+  replaced ordinary session-start flow.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+- **`defectClass`** — `generated-artifact-path-contract-drift`, a novel class:
+  independently generated producer and consumer artifacts can each be locally
+  valid while naming different canonical paths for the same dependency. Its
+  nearest existing class is `prompt-parser-contract-drift`; both are contract
+  drift, but that class is restricted to prompt-output schemas rather than
+  generated filesystem reachability.
+- **`closure`** — `gap`. The class enters unconfirmed, so this instance test
+  cannot honestly claim class-wide closure.
+- **`guardEvidence`** — not applicable for gap closure.
+- **`gap`** — ACT-245, “Add generated-artifact path-contract lint,” due
+  2026-09-14. The regression in this change still guards the exact #1798 pair.


### PR DESCRIPTION
## What changed

- Corrected both generated session-start references to use the canonical hooks/instar/compaction-recovery.sh path written by PostUpdateMigrator.
- Added a fail-first migration regression that proves the check and exec references resolve to the installed executable.
- Registered the broader generated-artifact path-contract drift class and tracked its repository-wide lint as ACT-245.

## ELI16 — Fix a broken address between two installed hooks

When a long session is compressed, one small script is supposed to hand control to a second script that reloads the agent identity and recent conversation. The updater installed that second script in the built-in hooks folder, but the first script looked for it one folder higher, so the handoff quietly never happened.

This change makes both sides use the same address and adds a test that installs the real pair, reads both references, and proves they point to the executable that was actually written. It restores existing recovery behavior; it does not add a new decision-maker or new user workflow.

The repaired address is the canonical built-in hooks location used by both generated artifacts.

## Root cause

The migrator wrote the recovery helper in the built-in hooks directory, while the generated session-start hook still checked and executed the retired flat location. Both artifacts installed successfully, but the compact branch could never reach the helper.

## Impact

Existing agents regain identity and conversation-context recovery after compaction on their next update. No new authority, persistent state, or operator action is introduced.

## Validation

- Fail-first regression reproduced the old path mismatch, then passed after both source references were corrected.
- 25 focused compaction and migration tests pass.
- 49 class-closure registry and lint tests pass.
- npm run build passes.
- npm run lint passes.
- Independent lifecycle second-pass review concurred and executed the compact path end to end.

Closes #1798