### PR TITLE
Validate declared identity directory at boot

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-31T16-29-06-000Z-declared-identity-directory-boot-check.json
+++ b/.instar/instar-dev-decisions/2026-07-31T16-29-06-000Z-declared-identity-directory-boot-check.json
@@ -1,0 +1,29 @@
+{
+  "ts": "2026-07-31T16:29:06.000Z",
+  "slug": "declared-identity-directory-boot-check",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "server boot lifecycle surface: src/commands/server.ts adds an early boot diagnostic",
+    "agent identity context surface: src/core/ContextHierarchy.ts validates persisted self-knowledge"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 101,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/ContextHierarchy.ts"
+    ],
+    "addedLines": 100,
+    "deletedLines": 1
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Identity context is additive and retained an install-time absolute path after the agent moved. No boot check validated that persisted self-description before derived hooks, watchdogs, registries, and recovery paths consumed it. The stale path caused both a disabled revival queue and a failed compaction-recovery injection."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -190,7 +190,7 @@ import { ProjectMapper } from '../core/ProjectMapper.js';
 import { CartographerTree } from '../core/CartographerTree.js';
 import { CapabilityMapper } from '../core/CapabilityMapper.js';
 import { ScopeVerifier } from '../core/ScopeVerifier.js';
-import { ContextHierarchy } from '../core/ContextHierarchy.js';
+import { ContextHierarchy, checkDeclaredIdentityDirectory } from '../core/ContextHierarchy.js';
 import { CanonicalState } from '../core/CanonicalState.js';
 import { ExternalOperationGate, AUTONOMY_PROFILES } from '../core/ExternalOperationGate.js';
 import { MessageSentinel } from '../core/MessageSentinel.js';
@@ -3650,6 +3650,18 @@ function setupServerLog(stateDir: string): void {
 export async function startServer(options: StartOptions): Promise<void> {
   const config = loadConfig(options.dir);
   ensureStateDir(config.stateDir);
+
+  // Identity context is additive and survives agent moves. Validate its
+  // persisted directory before any subsystem can derive hooks, locks, or
+  // recovery paths from stale self-knowledge.
+  const declaredDirectoryCheck = checkDeclaredIdentityDirectory(config.stateDir, config.projectDir);
+  if (declaredDirectoryCheck.status === 'invalid') {
+    console.warn(pc.yellow(pc.bold('  ⚠ DECLARED AGENT DIRECTORY IS INVALID')));
+    console.warn(pc.yellow(`  ${declaredDirectoryCheck.identityPath}`));
+    console.warn(pc.yellow(`  Declares: ${declaredDirectoryCheck.declaredDirectory}`));
+    console.warn(pc.yellow(`  Problem: ${declaredDirectoryCheck.reason}`));
+    console.warn(pc.yellow('  Correct the identity directory before relying on generated hooks or recovery state.'));
+  }
 
   // ── Fork-bomb prevention P1 (forkbomb-prevention-simple §D-CAP) ──
   // Inject the operator-configured spawn-cap knobs into the host-wide spawn

--- a/src/core/ContextHierarchy.ts
+++ b/src/core/ContextHierarchy.ts
@@ -53,6 +53,93 @@ export interface ContextDispatchTable {
   reason: string;
 }
 
+export type DeclaredIdentityDirectoryCheck =
+  | {
+      status: 'not-declared';
+      identityPath: string;
+    }
+  | {
+      status: 'valid';
+      identityPath: string;
+      declaredDirectory: string;
+    }
+  | {
+      status: 'invalid';
+      identityPath: string;
+      declaredDirectory: string;
+      reason: string;
+    };
+
+/**
+ * Validate the project directory persisted in the agent's generated identity.
+ *
+ * Identity segments are additive: once written, initialize() intentionally does
+ * not overwrite operator customizations. That also means a moved agent can keep
+ * a stale absolute path indefinitely. Check the persisted claim against the live
+ * filesystem and the project directory that boot actually resolved.
+ */
+export function checkDeclaredIdentityDirectory(
+  stateDir: string,
+  projectDir: string,
+): DeclaredIdentityDirectoryCheck {
+  const identityPath = path.join(stateDir, 'context', 'identity.md');
+  let content: string;
+
+  try {
+    content = fs.readFileSync(identityPath, 'utf-8');
+  } catch {
+    return { status: 'not-declared', identityPath };
+  }
+
+  const match = content.match(/^- \*\*Directory\*\*:\s*(.+?)\s*$/m);
+  if (!match) return { status: 'not-declared', identityPath };
+
+  const declaredDirectory = match[1].replace(/^`(.+)`$/, '$1');
+  if (!path.isAbsolute(declaredDirectory)) {
+    return {
+      status: 'invalid',
+      identityPath,
+      declaredDirectory,
+      reason: 'the declared directory is not an absolute path',
+    };
+  }
+
+  try {
+    const declaredStat = fs.statSync(declaredDirectory);
+    if (!declaredStat.isDirectory()) {
+      return {
+        status: 'invalid',
+        identityPath,
+        declaredDirectory,
+        reason: 'the declared path is not a directory',
+      };
+    }
+
+    const declaredReal = fs.realpathSync(declaredDirectory);
+    const projectReal = fs.realpathSync(projectDir);
+    if (declaredReal !== projectReal) {
+      return {
+        status: 'invalid',
+        identityPath,
+        declaredDirectory,
+        reason: `the declared directory resolves to ${declaredReal}, but boot resolved this agent to ${projectReal}`,
+      };
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return {
+      status: 'invalid',
+      identityPath,
+      declaredDirectory,
+      reason: code === 'ENOENT'
+        ? 'the declared directory does not exist'
+        : `the declared directory cannot be resolved (${code ?? 'unknown filesystem error'})`,
+    };
+  }
+
+  return { status: 'valid', identityPath, declaredDirectory };
+}
+
 /** The canonical list of context segments every agent should have. */
 const DEFAULT_SEGMENTS: ContextSegment[] = [
   {

--- a/tests/unit/declared-identity-directory.test.ts
+++ b/tests/unit/declared-identity-directory.test.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { checkDeclaredIdentityDirectory } from '../../src/core/ContextHierarchy.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const roots: string[] = [];
+
+function fixture(): { projectDir: string; stateDir: string; identityPath: string } {
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'declared-identity-dir-'));
+  roots.push(projectDir);
+  const stateDir = path.join(projectDir, '.instar');
+  const identityPath = path.join(stateDir, 'context', 'identity.md');
+  fs.mkdirSync(path.dirname(identityPath), { recursive: true });
+  return { projectDir, stateDir, identityPath };
+}
+
+function writeIdentity(identityPath: string, directory: string): void {
+  fs.writeFileSync(identityPath, `# Identity & Scope\n\n- **Directory**: ${directory}\n`);
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    SafeFsExecutor.safeRmSync(root, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/declared-identity-directory.test.ts:cleanup',
+    });
+  }
+});
+
+describe('checkDeclaredIdentityDirectory', () => {
+  it('accepts a declared directory that resolves to the boot project', () => {
+    const fx = fixture();
+    writeIdentity(fx.identityPath, fx.projectDir);
+
+    expect(checkDeclaredIdentityDirectory(fx.stateDir, fx.projectDir)).toEqual({
+      status: 'valid',
+      identityPath: fx.identityPath,
+      declaredDirectory: fx.projectDir,
+    });
+  });
+
+  it('rejects a declared directory that does not exist', () => {
+    const fx = fixture();
+    const missing = path.join(fx.projectDir, 'moved-away');
+    writeIdentity(fx.identityPath, missing);
+
+    expect(checkDeclaredIdentityDirectory(fx.stateDir, fx.projectDir)).toMatchObject({
+      status: 'invalid',
+      declaredDirectory: missing,
+      reason: 'the declared directory does not exist',
+    });
+  });
+
+  it('rejects an existing directory that is not the boot project', () => {
+    const fx = fixture();
+    const different = fs.mkdtempSync(path.join(os.tmpdir(), 'other-agent-dir-'));
+    roots.push(different);
+    writeIdentity(fx.identityPath, different);
+
+    const result = checkDeclaredIdentityDirectory(fx.stateDir, fx.projectDir);
+    expect(result.status).toBe('invalid');
+    expect(result).toMatchObject({ declaredDirectory: different });
+    if (result.status === 'invalid') {
+      expect(result.reason).toContain('but boot resolved this agent to');
+    }
+  });
+
+  it('rejects a file and a relative directory declaration', () => {
+    const fx = fixture();
+    const file = path.join(fx.projectDir, 'not-a-directory');
+    fs.writeFileSync(file, 'x');
+
+    writeIdentity(fx.identityPath, file);
+    expect(checkDeclaredIdentityDirectory(fx.stateDir, fx.projectDir)).toMatchObject({
+      status: 'invalid',
+      reason: 'the declared path is not a directory',
+    });
+
+    writeIdentity(fx.identityPath, './relative-agent');
+    expect(checkDeclaredIdentityDirectory(fx.stateDir, fx.projectDir)).toMatchObject({
+      status: 'invalid',
+      reason: 'the declared directory is not an absolute path',
+    });
+  });
+
+  it('does not manufacture a declaration when identity context is absent', () => {
+    const fx = fixture();
+
+    expect(checkDeclaredIdentityDirectory(fx.stateDir, fx.projectDir)).toEqual({
+      status: 'not-declared',
+      identityPath: fx.identityPath,
+    });
+  });
+});
+
+describe('server boot wiring', () => {
+  it('warns without hard-failing before boot subsystems are configured', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src', 'commands', 'server.ts'), 'utf-8');
+    const start = source.indexOf('export async function startServer');
+    const check = source.indexOf('checkDeclaredIdentityDirectory(config.stateDir, config.projectDir)', start);
+    const spawnSemaphore = source.indexOf('configureHostSpawnSemaphore({', start);
+    const checkBlock = source.slice(check, spawnSemaphore);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(check).toBeGreaterThan(start);
+    expect(spawnSemaphore).toBeGreaterThan(check);
+    expect(checkBlock).toContain('console.warn');
+    expect(checkBlock).not.toMatch(/\bthrow\b|process\.exit\s*\(/);
+  });
+});

--- a/upgrades/next/declared-identity-directory-boot-check.md
+++ b/upgrades/next/declared-identity-directory-boot-check.md
@@ -1,0 +1,28 @@
+# Declared identity directories are checked at boot
+
+<!-- bump: patch -->
+
+## What Changed
+
+An agent can move while its additive identity context keeps the absolute directory written during the original installation. That stale self-description can then feed generated hooks, watchdogs, registries, and recovery paths even when the directory no longer exists.
+
+Server boot now reads the directory declared in the identity context before configuring other subsystems. The declaration must be absolute, resolve to a real directory, and resolve to the same project directory that boot selected. An invalid declaration produces a loud startup warning with the declared path and the reason it failed. The check is diagnostic: it does not rewrite operator-owned identity text or stop an otherwise recoverable server from starting.
+
+## What to Tell Your User
+
+Nothing changes when the agent's saved identity points at its current home. If the agent was moved and its identity still names the old location, startup now calls that out immediately instead of letting generated recovery machinery fail later.
+
+## Summary of New Capabilities
+
+Instar now performs an automatic boot-time filesystem check of the project directory stored in each agent's identity context. It detects missing paths, files presented as directories, relative declarations, and existing directories that belong to a different project.
+
+## Evidence
+
+- Twenty-eight focused tests pass across the new directory validator, its boot-order wiring, and the existing context hierarchy.
+- Negative cases exercise a missing directory, a regular file, a relative path, and a different existing project directory.
+- The TypeScript build and repository typecheck pass.
+- The compiled validator accepts the corrected live identity directory on the affected agent.
+
+## UX Impact
+
+Who sees it: operators watching server startup for an agent whose persisted identity directory is invalid. The first visible contact is the warning "DECLARED AGENT DIRECTORY IS INVALID", followed by the declaration and the filesystem reason. Agents with a valid declaration see no new output.


### PR DESCRIPTION
## Description

Validates the directory persisted in an agent's identity context at the start of every server boot. The declaration must be absolute, resolve to a real directory, and match the project directory boot selected. Invalid self-knowledge now produces a loud diagnostic before hooks, locks, watchdogs, or recovery machinery can quietly inherit it.

The check is diagnostic and non-destructive: it does not rewrite customized identity text and does not block the server from starting.

## ELI16

An agent writes down where it lives when it is installed. If the agent is moved later, that note can keep pointing at the old house. Several other parts of the system copy the address from the note, so one stale address can break recovery scripts and background safety work long after the move. This change makes the agent look up its saved address every time it starts. If the address is missing, is not a folder, or belongs to a different project, startup says so immediately instead of waiting for an unrelated recovery operation to fail.

## UX Impact

Who sees it: operators watching startup for an agent whose saved identity directory is invalid.

First contact: startup prints the exact warning `DECLARED AGENT DIRECTORY IS INVALID`, followed by the declaration and the filesystem reason. Agents whose declaration is valid see no new output.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My code follows the project's style (TypeScript strict mode)
- [x] I have added tests for my changes
- [x] Focused tests pass: 28/28
- [x] `npm run build` passes locally
- [x] `npm run lint` passes locally
- [x] I have added a release-note fragment

## Validation

- Missing, non-directory, relative, and wrong-existing-directory cases are covered.
- A wiring assertion pins the check before boot subsystem configuration.
- The compiled validator accepts the corrected identity directory on the affected live agent.
