### PR TITLE
Warn when cached job bodies drift

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-31T17-54-56-000Z-job-manifest-body-drift-warning.json
+++ b/.instar/instar-dev-decisions/2026-07-31T17-54-56-000Z-job-manifest-body-drift-warning.json
@@ -1,0 +1,29 @@
+{
+  "ts": "2026-07-31T17:54:56.000Z",
+  "slug": "job-manifest-body-drift-warning",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "scheduler execution lifecycle: src/scheduler/JobScheduler.ts adds a live pre-trigger diagnostic",
+    "job prompt authority: src/scheduler/AgentMdJobLoader.ts reads the current on-disk body hash"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 96,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/scheduler/AgentMdJobLoader.ts",
+      "src/scheduler/JobScheduler.ts"
+    ],
+    "addedLines": 95,
+    "deletedLines": 1
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Agentmd prompt bodies are intentionally cached at scheduler startup, but no runtime check compared that cached authority with the named on-disk file. Run records continued to report the live resolvedPath while serving the stale cached prompt, making non-delivery indistinguishable from agent noncompliance until restart."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/scheduler/AgentMdJobLoader.ts
+++ b/src/scheduler/AgentMdJobLoader.ts
@@ -51,6 +51,7 @@ const READ_CONCURRENCY = 32;
 /** Spec §6: hard size caps to bound parser cost + adversarial payloads. */
 const MAX_FRONTMATTER_BYTES = 16 * 1024;
 const MAX_BODY_BYTES = 64 * 1024;
+const MAX_TOTAL_BYTES = MAX_FRONTMATTER_BYTES + MAX_BODY_BYTES + 1024;
 
 /** Spec §6: closed-set frontmatter key whitelist. Unknown keys → per-entry
  *  skip. Adding to this set is a deliberate change, never silent.
@@ -688,7 +689,6 @@ function loadAgentMdBody(
   // Size check on the raw file. Body cap = 64 KB; frontmatter cap = 16 KB.
   // We bound the total read to (16 + 64 + small framing) KB so an
   // adversarial 10 MB file cannot blow memory before parse.
-  const MAX_TOTAL_BYTES = MAX_FRONTMATTER_BYTES + MAX_BODY_BYTES + 1024;
   const stat = fs.statSync(resolved);
   if (stat.size > MAX_TOTAL_BYTES) {
     return {
@@ -1055,6 +1055,52 @@ function splitFrontmatter(text: string): { frontmatterText: string; body: string
   // rest may now be "" or start with "\n<body>".
   const body = rest.startsWith('\n') ? rest.slice(1) : rest;
   return { frontmatterText, body };
+}
+
+/**
+ * Read the current body hash for an already-resolved agentmd file.
+ *
+ * This is intentionally narrower than {@link loadAgentMdJobs}: runtime drift
+ * detection only needs to know whether the prompt body changed after boot. It
+ * reuses the loader's frontmatter split and body hash normalization without
+ * reparsing YAML, rebuilding manifests, or changing the cached JobDefinition.
+ */
+export function readAgentMdBodyHash(
+  resolvedPath: string,
+): { ok: true; bodyHash: string } | { ok: false; reason: string } {
+  try {
+    const stat = fs.lstatSync(resolvedPath);
+    if (stat.isSymbolicLink()) {
+      return { ok: false, reason: 'path became a symbolic link' };
+    }
+    if (!stat.isFile()) {
+      return { ok: false, reason: 'path is not a regular file' };
+    }
+    if (stat.size > MAX_TOTAL_BYTES) {
+      return {
+        ok: false,
+        reason: `file is ${stat.size} bytes — exceeds total cap of ${MAX_TOTAL_BYTES} bytes`,
+      };
+    }
+
+    const split = splitFrontmatter(fs.readFileSync(resolvedPath, 'utf-8'));
+    if (!split) {
+      return { ok: false, reason: 'file no longer has valid frontmatter boundaries' };
+    }
+    if (Buffer.byteLength(split.body, 'utf-8') > MAX_BODY_BYTES) {
+      return {
+        ok: false,
+        reason: `body exceeds cap of ${MAX_BODY_BYTES} bytes`,
+      };
+    }
+
+    return { ok: true, bodyHash: hashBody(split.body) };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
 }
 
 // ── Manifest → JobDefinition ───────────────────────────────────────────────

--- a/src/scheduler/JobScheduler.ts
+++ b/src/scheduler/JobScheduler.ts
@@ -22,6 +22,8 @@ import { ExecutionJournal } from '../core/ExecutionJournal.js';
 import { IntegrationGate } from './IntegrationGate.js';
 import { JobReflector } from '../core/JobReflector.js';
 import { loadJobs } from './JobLoader.js';
+import { readAgentMdBodyHash } from './AgentMdJobLoader.js';
+import { hashBody } from './AgentMdLockFile.js';
 import { JobRunHistory } from './JobRunHistory.js';
 import { SkipLedger } from './SkipLedger.js';
 import { classifySessionDeath } from '../monitoring/QuotaExhaustionDetector.js';
@@ -78,6 +80,9 @@ export class JobScheduler {
   private queue: QueuedJob[] = [];
   private running = false;
   private paused = false;
+
+  /** Last on-disk drift fingerprint warned for each agentmd job. */
+  private bodyDriftWarnings: Map<string, string> = new Map();
 
   /** Map session names to run IDs for completion tracking */
   private activeRunIds: Map<string, string> = new Map();
@@ -474,6 +479,7 @@ export class JobScheduler {
       if (state.timer) clearTimeout(state.timer);
     }
     this.retryState.clear();
+    this.bodyDriftWarnings.clear();
     this.running = false;
 
     this.state.appendEvent({
@@ -491,6 +497,8 @@ export class JobScheduler {
     if (!job) {
       throw new Error(`Unknown job: ${slug}`);
     }
+
+    this.warnIfAgentMdBodyChanged(job);
 
     if (this.paused) {
       this.skipLedger.recordSkip(slug, 'paused');
@@ -957,6 +965,46 @@ export class JobScheduler {
     }
 
     return result;
+  }
+
+  /**
+   * Signal edits that cannot affect this process because agentmd bodies are
+   * intentionally cached at scheduler start. The warning is deduped by the
+   * observed disk state, while execution continues with the cached body.
+   */
+  private warnIfAgentMdBodyChanged(job: JobDefinition): void {
+    if (
+      job.execute.type !== 'agentmd' ||
+      typeof job.body !== 'string' ||
+      typeof job.resolvedPath !== 'string'
+    ) {
+      return;
+    }
+
+    const disk = readAgentMdBodyHash(job.resolvedPath);
+    if (!disk.ok) {
+      const fingerprint = `unreadable:${disk.reason}`;
+      if (this.bodyDriftWarnings.get(job.slug) === fingerprint) return;
+      this.bodyDriftWarnings.set(job.slug, fingerprint);
+      console.warn(
+        `[scheduler] Job "${job.slug}" body cannot be checked on disk (${disk.reason}); ` +
+        `continuing to use the body cached at scheduler start. Restart the server after repairing the file.`,
+      );
+      return;
+    }
+
+    const cachedHash = hashBody(job.body);
+    if (disk.bodyHash === cachedHash) {
+      this.bodyDriftWarnings.delete(job.slug);
+      return;
+    }
+
+    if (this.bodyDriftWarnings.get(job.slug) === disk.bodyHash) return;
+    this.bodyDriftWarnings.set(job.slug, disk.bodyHash);
+    console.warn(
+      `[scheduler] Job "${job.slug}" body changed on disk after scheduler start; ` +
+      `continuing to use the cached body. Restart the server to apply the edit.`,
+    );
   }
 
   private enqueue(slug: string, reason: string): void {

--- a/tests/unit/scheduler/JobScheduler.body-drift.test.ts
+++ b/tests/unit/scheduler/JobScheduler.body-drift.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+import { JobScheduler } from '../../../src/scheduler/JobScheduler.js';
+import { createMockSessionManager, createTempProject } from '../../helpers/setup.js';
+import type { MockSessionManager, TempProject } from '../../helpers/setup.js';
+
+function agentMd(body: string): string {
+  return [
+    '---',
+    'name: "Body Drift Probe"',
+    'description: "Detects stale cached prompts."',
+    '---',
+    body,
+  ].join('\n');
+}
+
+describe('JobScheduler agentmd body drift warning', () => {
+  let project: TempProject;
+  let sessionManager: MockSessionManager;
+  let scheduler: JobScheduler;
+  let bodyPath: string;
+
+  beforeEach(() => {
+    project = createTempProject();
+    sessionManager = createMockSessionManager();
+
+    const jobsRoot = path.join(project.stateDir, 'jobs');
+    const scheduleDir = path.join(jobsRoot, 'schedule');
+    const userDir = path.join(jobsRoot, 'user');
+    fs.mkdirSync(scheduleDir, { recursive: true });
+    fs.mkdirSync(userDir, { recursive: true });
+    fs.writeFileSync(path.join(project.stateDir, 'jobs.json'), '[]');
+    fs.writeFileSync(path.join(scheduleDir, 'body-drift-probe.json'), JSON.stringify({
+      slug: 'body-drift-probe',
+      origin: 'user',
+      schedule: '0 0 1 1 *',
+      priority: 'low',
+      model: 'haiku',
+      expectedDurationMinutes: 1,
+      enabled: true,
+      execute: { type: 'agentmd' },
+    }));
+    bodyPath = path.join(userDir, 'body-drift-probe.md');
+    fs.writeFileSync(bodyPath, agentMd('Original cached instruction.\n'));
+
+    scheduler = new JobScheduler({
+      jobsFile: path.join(project.stateDir, 'jobs.json'),
+      enabled: true,
+      maxParallelJobs: 2,
+      quotaThresholds: { normal: 50, elevated: 70, critical: 85, shutdown: 95 },
+      startupGraceMs: 60_000,
+    }, sessionManager as any, project.state, project.stateDir);
+    scheduler.start();
+  });
+
+  afterEach(() => {
+    scheduler.stop();
+    project.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('warns once per changed disk body while continuing with the cached prompt', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fs.writeFileSync(bodyPath, agentMd('First on-disk edit.\n'));
+
+    await expect(scheduler.triggerJob('body-drift-probe', 'test')).resolves.toBe('triggered');
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('changed on disk after scheduler start');
+    expect(warn.mock.calls[0][0]).toContain('Restart the server to apply the edit');
+    expect(sessionManager._lastSpawnArgs?.prompt).toContain('Original cached instruction.');
+    expect(sessionManager._lastSpawnArgs?.prompt).not.toContain('First on-disk edit.');
+
+    await scheduler.triggerJob('body-drift-probe', 'test-again');
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    fs.writeFileSync(bodyPath, agentMd('Second on-disk edit.\n'));
+    await scheduler.triggerJob('body-drift-probe', 'test-after-second-edit');
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns without blocking when the body file becomes unreadable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    SafeFsExecutor.safeUnlinkSync(bodyPath, {
+      operation: 'tests/unit/scheduler/JobScheduler.body-drift.test.ts:remove-body',
+    });
+
+    await expect(scheduler.triggerJob('body-drift-probe', 'test')).resolves.toBe('triggered');
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('body cannot be checked on disk');
+    expect(warn.mock.calls[0][0]).toContain('continuing to use the body cached');
+    expect(sessionManager._lastSpawnArgs?.prompt).toContain('Original cached instruction.');
+  });
+});

--- a/upgrades/next/job-manifest-body-drift-warning.md
+++ b/upgrades/next/job-manifest-body-drift-warning.md
@@ -1,0 +1,26 @@
+# Job manifest body drift warning
+
+## What Changed
+
+The scheduler now detects when an agentmd job body changes on disk after the
+body was cached at startup. At the next trigger it emits a deduplicated warning
+that a restart is required, while continuing to run the cached body. This keeps
+the load-once design explicit instead of silently making prompt edits inert.
+
+## What to Tell Your User
+
+If recurring job instructions are edited while Instar is running, the next
+trigger now warns that a restart is required and that the cached instructions
+will still be used for that run.
+
+## Summary of New Capabilities
+
+- Detects agentmd prompt-body drift at trigger time.
+- Deduplicates warnings until the on-disk body changes again.
+- Keeps the load-once execution model and never blocks a job on drift.
+
+## Evidence
+
+- Scheduler tests prove the warning is deduplicated while the cached prompt is
+  still dispatched.
+- Tests prove an unreadable body file warns without blocking execution.


### PR DESCRIPTION
## What changed

- compare each agentmd job's cached prompt body hash with the current on-disk body at trigger time
- emit one warning per distinct drift state while continuing to execute the cached body
- warn without blocking when the body file becomes unreadable
- clear drift-warning state when the scheduler stops and reloads

## Why

Agentmd bodies are intentionally loaded once at scheduler startup, but edits made afterward were silently inert. Run records still named the live file path, which made “the agent ignored the instruction” indistinguishable from “the running scheduler never loaded the instruction.”

## ELI16 — make load-once behavior visible

Recurring job instructions are copied into memory when Instar starts. Editing the file later does not replace that in-memory copy until restart, but nothing previously told the operator that. Now, immediately before a job runs, Instar cheaply checks whether the file's prompt body still matches the cached version. If it differs, Instar says a restart is needed and clearly states that this run will keep using the older cached instructions. It warns once for each distinct edit instead of spamming every tick, and it never blocks the job or silently hot-reloads behavior.

## Validation

- 109 focused scheduler and loader tests pass
- build and TypeScript compilation pass
- full lint suite passes
- decision-audit and release-fragment gates pass