### PR TITLE
fix: record Telegram message provenance

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-31T21-50-38-037Z-message-store-provenance.json
+++ b/.instar/instar-dev-decisions/2026-07-31T21-50-38-037Z-message-store-provenance.json
@@ -1,0 +1,38 @@
+{
+  "ts": "2026-07-31T21:50:38.037Z",
+  "slug": "message-store-provenance",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/TelegramRelay.ts matches relay / delivery path",
+    "safety-invariant proximity: src/messaging/TelegramAdapter.ts matches Telegram adapter"
+  ],
+  "belowFloor": true,
+  "files": 9,
+  "loc": 119,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/TelegramRelay.ts",
+      "src/messaging/TelegramAdapter.ts",
+      "src/messaging/shared/MessageLogger.ts",
+      "src/messaging/shared/MessageProvenance.ts",
+      "src/messaging/shared/MessagingEventBus.ts",
+      "src/monitoring/CoherenceMonitor.ts",
+      "src/monitoring/CommitmentSentinel.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 95,
+    "deletedLines": 24
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "This change only labels inputs consumed by existing monitors; it adds no self-triggered action, cadence, retry, notification, steady-state edge, or settling behavior.",
+    "component": "MessageStoreProvenance"
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/message-store-provenance.eli16.md
+++ b/docs/eli16/message-store-provenance.eli16.md
@@ -1,0 +1,38 @@
+# Message-store provenance — Plain-English Overview
+
+> The one-line version: every new Telegram message record says whether it came from a user, an agent reply, or automation, so readers no longer guess from the message's wording.
+
+## The problem in one breath
+
+The Telegram history currently records only direction: user messages are `fromUser: true` and every outbound message is `fromUser: false`. That makes a deliberate conversational reply indistinguishable from a health alert, update broadcast, proxy heartbeat, or other server-generated text. Systems that need to count or react to the agent's actual replies have been forced to guess from emoji and text prefixes, and those guesses produce false counts and false state transitions.
+
+## What already exists
+
+- **The Telegram JSONL history** — durably records inbound and outbound messages and supports both a legacy writer and a shared message-logger writer.
+- **The reply route** — is the central send seam for conversational agent output, including replies relayed through the machine that owns Telegram.
+- **Direct adapter sends** — carry alerts, automated updates, proxy notices, command responses, and delivery fallbacks.
+- **History consumers** — use the log for presence cancellation, commitment detection, and output-coherence checks.
+
+## What this adds
+
+Every newly written Telegram row gets one closed, structural `provenance` value: `user`, `agent`, or `automation`. Inbound platform messages are stamped `user`; ordinary output through the reply route is stamped `agent`; direct adapter sends and explicitly automated reply traffic are stamped `automation`. This label is chosen from the code path at send or receive time, never by inspecting message prose.
+
+The same value is preserved through the shared logger, callback, event bus, and cross-machine relay. Existing rows remain readable with no rewrite: a missing field means legacy/unknown, and consumers keep their prior compatibility behavior for those rows. New consumers can count actual agent replies directly.
+
+## The safeguards
+
+**No historical guessing.** Old messages are not backfilled from text, emoji, session name, or `fromUser`; absence stays absence.
+
+**Outbound direction stays valid.** An outbound reply cannot be recorded as `user`, even if malformed relay metadata requests it.
+
+**Cross-machine parity.** A tokenless standby sends the structural value to the Telegram-owning machine, so both sides record the same origin instead of independently misclassifying a direct automated send as a reply.
+
+**Backward compatibility.** The field is additive. Legacy JSONL rows and non-migrated platform loggers may omit it, and existing readers continue to work.
+
+## What ships when
+
+This ships as one additive patch: the data contract, all Telegram write seams, relay transport, shared infrastructure propagation, selected consumers, and focused unit/integration coverage land together.
+
+## What you actually need to decide
+
+The operator already requested this behavior; the PR review decides whether these three structural categories and their compatibility rules correctly capture the intended distinction.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -12295,7 +12295,7 @@ export async function startServer(options: StartOptions): Promise<void> {
         const resp = await fetch(`http://localhost:${config.port}/telegram/reply/${topicId}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.authToken}` },
-          body: JSON.stringify({ text }),
+          body: JSON.stringify({ text, metadata: { provenance: 'automation' } }),
         });
         return resp.ok;
       },
@@ -12621,7 +12621,7 @@ export async function startServer(options: StartOptions): Promise<void> {
                 const resp = await fetch(`http://localhost:${config.port}/telegram/reply/${topicId}`, {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.authToken}` },
-                  body: JSON.stringify({ text }),
+                  body: JSON.stringify({ text, metadata: { provenance: 'automation' } }),
                 });
                 return resp.ok;
               } catch {
@@ -13987,9 +13987,9 @@ export async function startServer(options: StartOptions): Promise<void> {
         const slackMessagesLogPath = path.join(config.stateDir, 'slack-messages.jsonl');
 
         // Shared helper: check a messages log file for SUBSTANTIVE agent
-        // responses after a timestamp. Filters out system/proxy messages via
-        // isSystemOrProxyMessage AND brief acks via isBriefAck — both kinds
-        // of messages are non-cancelling from PresenceProxy's perspective.
+        // responses after a timestamp. New Telegram rows use structural
+        // provenance; legacy Telegram and Slack rows retain the text classifier
+        // until their writers have migrated. Brief acks remain non-cancelling.
         //
         // The brief-ack filter is what closes the gap from PR #128: that PR
         // taught the event path (recordAgentMessage) to ignore acks, but the
@@ -14011,10 +14011,12 @@ export async function startServer(options: StartOptions): Promise<void> {
                 const matchesTopic = msg.topicId === topicId
                   || (topicId < 0 && msg.channelId && slackChannelToSyntheticId(String(msg.channelId)) === topicId);
                 if (matchesTopic && !msg.fromUser && msg.timestamp > sinceIso) {
+                  if (msg.provenance === 'automation' || msg.provenance === 'user') continue;
                   // Non-cancelling agent message kinds: system/proxy
-                  // chrome, and brief acks ("On it"). Both leave tier
-                  // timers running.
-                  const isNonCancelling = isSystemOrProxyMessage(msg.text)
+                  // chrome on legacy rows, and brief acks ("On it"). Both
+                  // leave tier timers running. A structurally agent-authored
+                  // row is never reclassified from its text prefix.
+                  const isNonCancelling = (msg.provenance !== 'agent' && isSystemOrProxyMessage(msg.text))
                     || isBriefAck(msg.text);
                   if (isNonCancelling) continue;
                   return true;

--- a/src/core/TelegramRelay.ts
+++ b/src/core/TelegramRelay.ts
@@ -23,6 +23,8 @@
  * unit-testable without real network or wall-clock.
  */
 
+import type { MessageProvenance } from '../messaging/shared/MessageProvenance.js';
+
 export interface RelayResult {
   messageId: number;
   topicId: number;
@@ -87,7 +89,7 @@ export interface RelayDeps {
 export async function relayOutbound(
   topicId: number,
   text: string,
-  opts: { silent?: boolean; kindMetadata?: Record<string, unknown> } | undefined,
+  opts: { silent?: boolean; kindMetadata?: Record<string, unknown>; provenance?: Exclude<MessageProvenance, 'user'> } | undefined,
   deps: RelayDeps,
 ): Promise<RelayResult | RelayRefusal | null> {
   const log = deps.log ?? (() => {});
@@ -115,7 +117,9 @@ export async function relayOutbound(
       body: JSON.stringify({
         text,
         ...(opts?.silent ? { silent: true } : {}),
-        ...(opts?.kindMetadata ? { metadata: opts.kindMetadata } : {}),
+        ...(opts?.kindMetadata || opts?.provenance
+          ? { metadata: { ...opts?.kindMetadata, ...(opts?.provenance ? { provenance: opts.provenance } : {}) } }
+          : {}),
       }),
       signal: ac.signal,
     });

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -18,6 +18,7 @@ import type { ContentValidationConfig } from './TopicContentValidator.js';
 import { validateTopicContent, getTopicPurpose, classifyContent } from './TopicContentValidator.js';
 import { SHARED_INFRA_FLAGS } from './shared/FeatureFlags.js';
 import { MessageLogger, type LogEntry as SharedLogEntry } from './shared/MessageLogger.js';
+import type { MessageProvenance } from './shared/MessageProvenance.js';
 import { SessionChannelRegistry } from './shared/SessionChannelRegistry.js';
 import { StallDetector, type StallEvent } from './shared/StallDetector.js';
 import { CommandRouter } from './shared/CommandRouter.js';
@@ -254,6 +255,8 @@ interface LogEntry {
    * with no `forwarded` field is forwarded-UNKNOWN and does not count (fail-safe).
    */
   forwarded?: boolean;
+  /** Structural origin, stamped at the send/receive seam. */
+  provenance: MessageProvenance;
 }
 
 /**
@@ -594,7 +597,7 @@ export class TelegramAdapter implements MessagingAdapter {
   // Message log callback — fires on every message logged (inbound and outbound).
   // Used by TopicMemory to dual-write to SQLite for search and summarization.
   // Includes sender identity fields (Phase 1C/1D — User-Agent Topology Spec).
-  public onMessageLogged: ((entry: { messageId: number; topicId: number | null; text: string; fromUser: boolean; timestamp: string; sessionName: string | null; senderName?: string; senderUsername?: string; telegramUserId?: number; forwarded?: boolean }) => void) | null = null;
+  public onMessageLogged: ((entry: { messageId: number; topicId: number | null; text: string; fromUser: boolean; timestamp: string; sessionName: string | null; senderName?: string; senderUsername?: string; telegramUserId?: number; forwarded?: boolean; provenance?: MessageProvenance }) => void) | null = null;
 
   /**
    * Scope-accretion ratification observer (spec autonomous-scope-accretion-
@@ -624,7 +627,7 @@ export class TelegramAdapter implements MessagingAdapter {
    * invariant that avoids the 409-poller-conflict incident). Returns the sent
    * message's SendResult, or null if the relay could not deliver.
    */
-  public outboundRelay: ((topicId: number, text: string, options?: { silent?: boolean; kindMetadata?: Record<string, unknown> }) => Promise<SendResult | null>) | null = null;
+  public outboundRelay: ((topicId: number, text: string, options?: { silent?: boolean; kindMetadata?: Record<string, unknown>; provenance?: Exclude<MessageProvenance, 'user'> }) => Promise<SendResult | null>) | null = null;
 
   /**
    * True when a `sendToTopic` will RELAY through the lease holder rather than
@@ -1301,6 +1304,7 @@ export class TelegramAdapter implements MessagingAdapter {
       senderUsername: entry.senderUsername,
       telegramUserId: entry.telegramUserId,
       forwarded: entry.forwarded === true,
+      provenance: 'user',
     });
   }
 
@@ -1319,6 +1323,8 @@ export class TelegramAdapter implements MessagingAdapter {
        *  hop (spec outbound-jargon-filepath-gap §2.5). Direct sends ignore it
        *  — the local route already consumed it. */
       kindMetadata?: Record<string, unknown>;
+      /** Conversational agent reply vs server-generated outbound traffic. */
+      provenance?: Exclude<MessageProvenance, 'user'>;
       /** 'html' = the caller already produced ESCAPED Telegram HTML (e.g. the
        *  attention-hub post) — the send carries `parse_mode: 'HTML'` +
        *  `_formatMode: 'html'` so applyTelegramFormatter's markdown converter
@@ -1354,6 +1360,7 @@ export class TelegramAdapter implements MessagingAdapter {
       const relayed = await this.outboundRelay(topicId, text, {
         silent: options?.silent,
         kindMetadata: options?.kindMetadata,
+        provenance: options?.provenance ?? 'automation',
       });
       if (!relayed) {
         throw new Error('telegram outbound relay failed (tokenless standby, router unreachable)');
@@ -1384,6 +1391,7 @@ export class TelegramAdapter implements MessagingAdapter {
       fromUser: false,
       timestamp: new Date().toISOString(),
       sessionName: this.topicToSession.get(topicId) ?? null,
+      provenance: options?.provenance ?? 'automation',
     });
 
     // Clear stall tracking for this topic (agent responded)
@@ -2747,7 +2755,7 @@ export class TelegramAdapter implements MessagingAdapter {
   }
 
   /** Get recent message log entries for analysis */
-  getMessageLog(limit = 100): Array<{ topicId: number; text: string; fromUser: boolean; timestamp: string }> {
+  getMessageLog(limit = 100): Array<{ topicId: number; text: string; fromUser: boolean; timestamp: string; provenance?: MessageProvenance }> {
     try {
       if (!fs.existsSync(this.messageLogPath)) return [];
       // Bounded TAIL read — never the whole file. This only returns the last
@@ -2763,12 +2771,13 @@ export class TelegramAdapter implements MessagingAdapter {
             text: entry.text || '',
             fromUser: entry.fromUser ?? true,
             timestamp: entry.timestamp || new Date().toISOString(),
+            provenance: entry.provenance,
           };
         } catch {
           // @silent-fallback-ok — JSONL parse, skip corrupted
           return null;
         }
-      }).filter(Boolean) as Array<{ topicId: number; text: string; fromUser: boolean; timestamp: string }>;
+      }).filter(Boolean) as Array<{ topicId: number; text: string; fromUser: boolean; timestamp: string; provenance?: MessageProvenance }>;
     } catch {
       // @silent-fallback-ok — log read, empty array safe
       return [];
@@ -3766,6 +3775,7 @@ export class TelegramAdapter implements MessagingAdapter {
         platformUserId: entry.telegramUserId,
         platform: 'telegram',
         forwarded: entry.forwarded,
+        provenance: entry.provenance,
       });
       if (!persisted) return;
       this.rememberLoggedEntry(entry, dedupeKey);
@@ -3795,6 +3805,7 @@ export class TelegramAdapter implements MessagingAdapter {
           senderName: entry.senderName,
           senderUsername: entry.senderUsername,
           platformUserId: entry.telegramUserId?.toString(),
+          provenance: entry.provenance,
         }).catch(err => console.error(`[telegram] EventBus message:logged error: ${err}`));
       }
       return;
@@ -3843,6 +3854,7 @@ export class TelegramAdapter implements MessagingAdapter {
         senderName: entry.senderName,
         senderUsername: entry.senderUsername,
         platformUserId: entry.telegramUserId?.toString(),
+        provenance: entry.provenance,
       }).catch(err => console.error(`[telegram] EventBus message:logged error: ${err}`));
     }
   }
@@ -4846,6 +4858,7 @@ export class TelegramAdapter implements MessagingAdapter {
       senderUsername: msg.from.username,
       telegramUserId: msg.from.id,
       forwarded: isForwarded,
+      provenance: 'user',
     });
 
     // Scope-accretion ratification observer (R45) — the LIVE receive path.
@@ -5028,6 +5041,7 @@ export class TelegramAdapter implements MessagingAdapter {
         senderName: msg.from.first_name,
         senderUsername: msg.from.username,
         telegramUserId: msg.from.id,
+        provenance: 'user',
       });
 
       // Fire callbacks
@@ -5104,6 +5118,7 @@ export class TelegramAdapter implements MessagingAdapter {
         senderName: msg.from.first_name,
         senderUsername: msg.from.username,
         telegramUserId: msg.from.id,
+        provenance: 'user',
       });
 
       // Fire callbacks
@@ -5173,6 +5188,7 @@ export class TelegramAdapter implements MessagingAdapter {
         senderName: msg.from.first_name,
         senderUsername: msg.from.username,
         telegramUserId: msg.from.id,
+        provenance: 'user',
       });
 
       // Fire callbacks

--- a/src/messaging/shared/MessageLogger.ts
+++ b/src/messaging/shared/MessageLogger.ts
@@ -9,6 +9,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { SafeFsExecutor } from '../../core/SafeFsExecutor.js';
+import type { MessageProvenance } from './MessageProvenance.js';
 
 export interface LogEntry {
   messageId: number | string;
@@ -26,6 +27,8 @@ export interface LogEntry {
   platform?: string;
   /** Platform-authenticated forwarding provenance. Undefined means unknown. */
   forwarded?: boolean;
+  /** Structural message origin. Undefined only for legacy/non-migrated writers. */
+  provenance?: MessageProvenance;
 }
 
 /** Legacy Telegram-specific log entry shape for backward compatibility */
@@ -40,6 +43,7 @@ export interface TelegramLogEntry {
   senderUsername?: string;
   telegramUserId?: number;
   forwarded?: boolean;
+  provenance?: MessageProvenance;
 }
 
 export interface MessageLoggerConfig {

--- a/src/messaging/shared/MessageProvenance.ts
+++ b/src/messaging/shared/MessageProvenance.ts
@@ -1,0 +1,17 @@
+/**
+ * Structural origin of a persisted conversational message.
+ *
+ * `fromUser` describes direction; provenance distinguishes an agent's
+ * conversational reply from server-generated outbound traffic. Legacy rows
+ * omit this field and therefore remain unknown rather than being inferred from
+ * message text.
+ */
+export const MESSAGE_PROVENANCES = ['user', 'agent', 'automation'] as const;
+
+export type MessageProvenance = (typeof MESSAGE_PROVENANCES)[number];
+
+export function coerceMessageProvenance(value: unknown): MessageProvenance | undefined {
+  return typeof value === 'string' && (MESSAGE_PROVENANCES as readonly string[]).includes(value)
+    ? value as MessageProvenance
+    : undefined;
+}

--- a/src/messaging/shared/MessagingEventBus.ts
+++ b/src/messaging/shared/MessagingEventBus.ts
@@ -15,6 +15,8 @@
 
 // ── Event type definitions ──────────────────────────────────────────
 
+import type { MessageProvenance } from './MessageProvenance.js';
+
 export interface IncomingMessageEvent {
   channelId: string;
   userId: string;
@@ -34,6 +36,7 @@ export interface MessageLoggedEvent {
   senderName?: string;
   senderUsername?: string;
   platformUserId?: string;
+  provenance?: MessageProvenance;
 }
 
 export interface StallDetectedEvent {

--- a/src/monitoring/CoherenceMonitor.ts
+++ b/src/monitoring/CoherenceMonitor.ts
@@ -502,7 +502,9 @@ export class CoherenceMonitor extends EventEmitter {
       for (let i = lines.length - 1; i >= 0 && agentMessages.length < 50; i--) {
         try {
           const entry = JSON.parse(lines[i]);
-          if (!entry.fromUser && entry.text) {
+          // New automation rows are structurally excluded. Legacy rows have no
+          // provenance and retain the pre-migration behavior.
+          if (!entry.fromUser && entry.provenance !== 'automation' && entry.text) {
             agentMessages.push({ text: entry.text, timestamp: entry.timestamp });
           }
         } catch { /* skip malformed lines */ }

--- a/src/monitoring/CommitmentSentinel.ts
+++ b/src/monitoring/CommitmentSentinel.ts
@@ -48,6 +48,7 @@ interface TelegramMessage {
   fromUser: boolean;
   timestamp: string;
   sessionName?: string | null;
+  provenance?: 'user' | 'agent' | 'automation';
 }
 
 interface DetectedCommitment {
@@ -273,15 +274,24 @@ export class CommitmentSentinel {
     const pairs: Array<{ user: string; agent: string }> = [];
 
     for (let i = 0; i < messages.length - 1; i++) {
-      if (messages[i].fromUser && !messages[i + 1].fromUser) {
-        // Drop bare approval/continuation exchanges before the LLM sees them —
-        // the dominant false-positive source (#49). A message that asks for
-        // nothing durable cannot seed a commitment.
-        if (isBareContinuation(messages[i].text)) continue;
-        pairs.push({
-          user: messages[i].text,
-          agent: messages[i + 1].text,
-        });
+      const userMessage = messages[i];
+      if (!userMessage.fromUser) continue;
+      // Drop bare approval/continuation exchanges before the LLM sees them —
+      // the dominant false-positive source (#49). A message that asks for
+      // nothing durable cannot seed a commitment.
+      if (isBareContinuation(userMessage.text)) continue;
+
+      // Automation may legitimately appear between a user request and the
+      // conversational reply (health notice, proxy update, watcher status).
+      // Skip structurally automated rows, but stop at the next user message so
+      // a reply is never paired with the wrong request. Legacy outbound rows
+      // have no provenance and retain the old immediate-agent behavior.
+      for (let j = i + 1; j < messages.length; j++) {
+        const candidate = messages[j];
+        if (candidate.fromUser) break;
+        if (candidate.provenance === 'automation') continue;
+        pairs.push({ user: userMessage.text, agent: candidate.text });
+        break;
       }
     }
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -262,6 +262,7 @@ import { ReflectionMetrics } from '../monitoring/ReflectionMetrics.js';
 import { HomeostasisMonitor } from '../monitoring/HomeostasisMonitor.js';
 import { readReaperAudit } from '../monitoring/SessionReaper.js';
 import type { TelegramAdapter } from '../messaging/TelegramAdapter.js';
+import { coerceMessageProvenance, type MessageProvenance } from '../messaging/shared/MessageProvenance.js';
 import type { RelationshipManager } from '../core/RelationshipManager.js';
 import type { FeedbackManager } from '../core/FeedbackManager.js';
 import type { DispatchManager } from '../core/DispatchManager.js';
@@ -14449,6 +14450,17 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         ? metadata.toneAdvisoryAck.slice(0, 64)
         : undefined;
     const metadataJobSlug = typeof metadata?.jobSlug === 'string' ? metadata.jobSlug.slice(0, 128) : '';
+    // A relay hop carries the origin machine's structural classification. For
+    // a local call, derive it at this send seam: ordinary replies are agent
+    // prose; health/automated/proxy/system traffic is automation. Never infer
+    // from the message text. `user` is invalid on this outbound-only route.
+    const carriedProvenance = coerceMessageProvenance(metadata?.provenance);
+    const provenance: Exclude<MessageProvenance, 'user'> =
+      carriedProvenance === 'agent' || carriedProvenance === 'automation'
+        ? carriedProvenance
+        : !isProxy && !isSystemTemplate && (messageKind === undefined || messageKind === 'reply')
+          ? 'agent'
+          : 'automation';
 
     // ── Observability breadcrumbs (§2.1 — visibility on the named dodge
     // classes; sovereignty over the send is accepted, nothing is gated). ──
@@ -14562,6 +14574,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       // delivered (the false-success-under-load class).
       const sendResult = await ctx.telegram.sendToTopic(topicId, text, {
         skipStallClear: isProxy,
+        provenance,
         // Relay-hop forwarding (§2.5): when this standby relays through the
         // lease holder, the kind metadata must survive the hop so the
         // HOLDER's gate/audit see accurate context. Direct sends ignore it.

--- a/tests/integration/shared-infra-delegation.test.ts
+++ b/tests/integration/shared-infra-delegation.test.ts
@@ -91,6 +91,7 @@ describe('Shared Infrastructure Delegation', () => {
       const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
       expect(lines).toHaveLength(1);
       expect(JSON.parse(lines[0]).text).toBe('one real Telegram message');
+      expect(JSON.parse(lines[0]).provenance).toBe('user');
       expect(firstCallbacks).toHaveLength(1);
       expect(restartCallbacks).toHaveLength(0);
     });

--- a/tests/integration/telegram-message-provenance-route.test.ts
+++ b/tests/integration/telegram-message-provenance-route.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Message-store provenance through the real Telegram reply route.
+ *
+ * Proves the route classifies at the send seam instead of from message text,
+ * and that an authenticated relay can preserve an automation classification.
+ */
+
+import { afterAll, describe, expect, it } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import request from 'supertest';
+import { createRoutes } from '../../src/server/routes.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { MessageProvenance } from '../../src/messaging/shared/MessageProvenance.js';
+
+const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'telegram-message-provenance-'));
+
+interface CapturedSend {
+  topicId: number;
+  text: string;
+  provenance?: MessageProvenance;
+}
+
+function appWith(sent: CapturedSend[]): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(createRoutes({
+    config: { authToken: 'test', stateDir, port: 0, projectName: 'provenance-test' },
+    telegram: {
+      sendToTopic: async (topicId: number, text: string, options?: { provenance?: MessageProvenance }) => {
+        sent.push({ topicId, text, provenance: options?.provenance });
+        return { messageId: sent.length, timestamp: new Date().toISOString() };
+      },
+    },
+    sessionManager: { clearInjectionTracker: () => {} },
+  } as never));
+  return app;
+}
+
+afterAll(() => {
+  SafeFsExecutor.safeRmSync(stateDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/integration/telegram-message-provenance-route.test.ts',
+  });
+});
+
+describe('POST /telegram/reply — structural message provenance', () => {
+  it('classifies ordinary conversational output as agent-authored', async () => {
+    const sent: CapturedSend[] = [];
+    const res = await request(appWith(sent))
+      .post('/telegram/reply/71')
+      .send({ text: 'The work is complete.' });
+
+    expect(res.status).toBe(200);
+    expect(sent).toEqual([{ topicId: 71, text: 'The work is complete.', provenance: 'agent' }]);
+  });
+
+  it('classifies scheduled output as automation without inspecting its text', async () => {
+    const sent: CapturedSend[] = [];
+    const res = await request(appWith(sent))
+      .post('/telegram/reply/72')
+      .send({ text: 'This could look conversational.', metadata: { messageKind: 'automated' } });
+
+    expect(res.status).toBe(200);
+    expect(sent[0]?.provenance).toBe('automation');
+  });
+
+  it('preserves automation provenance carried by a cross-machine relay', async () => {
+    const sent: CapturedSend[] = [];
+    const res = await request(appWith(sent))
+      .post('/telegram/reply/73')
+      .send({ text: 'No kind metadata required.', metadata: { provenance: 'automation' } });
+
+    expect(res.status).toBe(200);
+    expect(sent[0]?.provenance).toBe('automation');
+  });
+
+  it('does not accept user provenance on an outbound row', async () => {
+    const sent: CapturedSend[] = [];
+    const res = await request(appWith(sent))
+      .post('/telegram/reply/74')
+      .send({ text: 'Outbound remains outbound.', metadata: { provenance: 'user' } });
+
+    expect(res.status).toBe(200);
+    expect(sent[0]?.provenance).toBe('agent');
+  });
+});

--- a/tests/unit/CoherenceMonitor-bounded-read.test.ts
+++ b/tests/unit/CoherenceMonitor-bounded-read.test.ts
@@ -72,4 +72,21 @@ describe('CoherenceMonitor output-sanity bounded read', () => {
     expect(sanity).toBeDefined();
     expect(sanity!.passed).toBe(false); // the recent localhost message was reachable
   });
+
+  it('does not attribute a structurally automated row to the conversational agent', () => {
+    const logPath = path.join(stateDir, 'telegram-messages.jsonl');
+    fs.writeFileSync(logPath, JSON.stringify({
+      messageId: 1,
+      topicId: 1,
+      text: 'Automated diagnostic at http://localhost:4040/dashboard',
+      fromUser: false,
+      provenance: 'automation',
+      timestamp: new Date().toISOString(),
+    }) + '\n');
+
+    const report = makeMonitor().runCheck();
+    const sanity = report.checks.find((c) => c.name === 'output-sanity');
+    expect(sanity).toBeDefined();
+    expect(sanity!.passed).toBe(true);
+  });
 });

--- a/tests/unit/CommitmentSentinel.test.ts
+++ b/tests/unit/CommitmentSentinel.test.ts
@@ -60,6 +60,7 @@ function writeMessages(stateDir: string, messages: Array<{
   text: string;
   fromUser: boolean;
   timestamp?: string;
+  provenance?: 'user' | 'agent' | 'automation';
 }>): void {
   const messagesPath = path.join(stateDir, 'telegram-messages.jsonl');
   const lines = messages.map(m => JSON.stringify({
@@ -68,6 +69,7 @@ function writeMessages(stateDir: string, messages: Array<{
     text: m.text,
     fromUser: m.fromUser,
     timestamp: m.timestamp ?? new Date().toISOString(),
+    ...(m.provenance ? { provenance: m.provenance } : {}),
   }));
   fs.writeFileSync(messagesPath, lines.join('\n') + '\n');
 }
@@ -127,6 +129,37 @@ describe('CommitmentSentinel', () => {
       const detected = await sentinel.scan();
       expect(detected).toBe(0);
       expect(intelligence.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('does not treat an automated outbound row as the agent reply in a commitment pair', async () => {
+      writeMessages(stateDir, [
+        { messageId: 1, topicId: 100, text: 'Can you investigate this?', fromUser: true, provenance: 'user' },
+        { messageId: 2, topicId: 100, text: 'System status: all checks running', fromUser: false, provenance: 'automation' },
+      ]);
+
+      const intelligence = createMockIntelligence('[]');
+      const { sentinel } = makeSentinel(stateDir, intelligence);
+
+      await expect(sentinel.scan()).resolves.toBe(0);
+      expect(intelligence.evaluate).not.toHaveBeenCalled();
+    });
+
+    it('pairs the user request with the later agent reply across intervening automation', async () => {
+      writeMessages(stateDir, [
+        { messageId: 1, topicId: 100, text: 'Please turn off auto-updates', fromUser: true, provenance: 'user' },
+        { messageId: 2, topicId: 100, text: 'System status: recovery running', fromUser: false, provenance: 'automation' },
+        { messageId: 3, topicId: 100, text: 'I will turn off auto-updates now', fromUser: false, provenance: 'agent' },
+      ]);
+
+      const intelligence = createMockIntelligence('[]');
+      const { sentinel } = makeSentinel(stateDir, intelligence);
+      await sentinel.scan();
+
+      expect(intelligence.evaluate).toHaveBeenCalledTimes(1);
+      const prompt = String((intelligence.evaluate as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+      expect(prompt).toContain('Please turn off auto-updates');
+      expect(prompt).toContain('I will turn off auto-updates now');
+      expect(prompt).not.toContain('System status: recovery running');
     });
 
     it('returns 0 for empty message file', async () => {

--- a/tests/unit/TelegramAdapter.test.ts
+++ b/tests/unit/TelegramAdapter.test.ts
@@ -304,13 +304,33 @@ describe('TelegramAdapter', () => {
       standby.outboundRelay = relay;
       try {
         const res = await standby.sendToTopic(42, 'reply from a moved session');
-        expect(relay).toHaveBeenCalledWith(42, 'reply from a moved session', { silent: undefined });
+        expect(relay).toHaveBeenCalledWith(42, 'reply from a moved session', {
+          silent: undefined,
+          kindMetadata: undefined,
+          provenance: 'automation',
+        });
         expect(res.messageId).toBe(999); // the relayed id, used for local bookkeeping
         expect(fetchSpy).not.toHaveBeenCalled(); // never hits the Telegram API directly
       } finally {
         vi.unstubAllGlobals();
         await standby.stop();
         SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/TelegramAdapter.test.ts:relay1' });
+      }
+    });
+
+    it('preserves explicit agent provenance through a tokenless relay', async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-tg-relay-provenance-'));
+      const standby = new TelegramAdapter({ token: '', chatId: '-100123456', pollIntervalMs: 100 }, tmp);
+      const relay = vi.fn(async (_topicId: number) => ({ messageId: 1000, topicId: _topicId }));
+      standby.outboundRelay = relay;
+      try {
+        await standby.sendToTopic(42, 'deliberate moved-session reply', { provenance: 'agent' });
+        expect(relay).toHaveBeenCalledWith(42, 'deliberate moved-session reply', expect.objectContaining({
+          provenance: 'agent',
+        }));
+      } finally {
+        await standby.stop();
+        SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/TelegramAdapter.test.ts:relay-provenance' });
       }
     });
 

--- a/tests/unit/relay-kind-forward.test.ts
+++ b/tests/unit/relay-kind-forward.test.ts
@@ -52,4 +52,15 @@ describe('relayOutbound — kind metadata survives the hop', () => {
     const body = JSON.parse((init as RequestInit).body as string);
     expect(body).toEqual({ text: 'plain reply' });
   });
+
+  it('carries structural provenance independently of message kind', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true, messageId: 4 }), { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    await relayOutbound(12476, 'direct adapter alert', { provenance: 'automation' }, deps(fetchImpl));
+    const [, init] = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.metadata).toEqual({ provenance: 'automation' });
+  });
 });

--- a/tests/unit/telegram-messaging.test.ts
+++ b/tests/unit/telegram-messaging.test.ts
@@ -130,8 +130,22 @@ describe('TelegramAdapter messaging', () => {
       expect(entry.topicId).toBe(42);
       expect(entry.text).toBe('Logged message');
       expect(entry.fromUser).toBe(false);
+      expect(entry.provenance).toBe('automation');
       expect(entry.messageId).toBe(1);
       expect(entry.timestamp).toBeTruthy();
+    });
+
+    it('records an explicit conversational reply as agent-authored', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true, result: { message_id: 2 } }),
+      });
+
+      await adapter.sendToTopic(42, 'A deliberate reply', { provenance: 'agent' });
+
+      const entry = JSON.parse(fs.readFileSync(path.join(tmpDir, 'telegram-messages.jsonl'), 'utf-8').trim());
+      expect(entry.provenance).toBe('agent');
+      expect(entry.fromUser).toBe(false);
     });
 
     it('includes session name in log when topic has registered session', async () => {
@@ -700,6 +714,7 @@ describe('TelegramAdapter messaging', () => {
       expect(entry.topicId).toBe(42);
       expect(entry.text).toBe('Log this message');
       expect(entry.fromUser).toBe(true);
+      expect(entry.provenance).toBe('user');
     });
   });
 });

--- a/upgrades/next/message-store-provenance.md
+++ b/upgrades/next/message-store-provenance.md
@@ -1,0 +1,27 @@
+<!-- bump: patch -->
+
+## What Changed
+
+New Telegram message-history rows now identify their structural origin as user input,
+an agent's conversational reply, or automation. The value is set at the receive/send
+boundary, survives the shared logger and cross-machine reply relay, and is never guessed
+from message wording. Existing rows remain readable with provenance left unknown.
+
+## What to Tell Your User
+
+- **Accurate message accounting**: "My message history can now distinguish what I deliberately said from automated alerts and status traffic."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|---|---|
+| Count conversational agent replies without prefix guessing | Read `provenance: "agent"` on new Telegram history rows |
+| Exclude automated notices structurally | Read `provenance: "automation"` instead of matching message text |
+| Preserve origin across machines | Automatic when a tokenless standby relays through the Telegram owner |
+
+## Evidence
+
+Focused unit and integration coverage exercises the real adapter, both JSONL writer modes,
+the production reply route, the cross-machine relay body, and provenance-aware monitor
+consumers. The final focused run passed 95 tests across seven files, including explicit proof
+for all three provenance values, legacy omission, and automation-interleaved commitment pairs.

--- a/upgrades/side-effects/message-store-provenance.md
+++ b/upgrades/side-effects/message-store-provenance.md
@@ -1,0 +1,115 @@
+# Side-Effects Review — Telegram message-store provenance
+
+**Version / slug:** `message-store-provenance`
+**Date:** `2026-07-31`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** `Codex independent reviewer — concurred after remediation`
+
+## Summary of the change
+
+This change adds an additive `provenance` field (`user | agent | automation`) to new Telegram message-log rows. `TelegramAdapter` stamps inbound and direct-send rows, the real `/telegram/reply` route stamps conversational versus automated output, `TelegramRelay` carries the value across a tokenless-standby hop, and the shared logger/event callback paths preserve it. Presence, coherence, and commitment consumers use structural automation provenance while retaining legacy behavior for rows with no field. Historical rows are left byte-for-byte unchanged.
+
+## Decision-point inventory
+
+- `POST /telegram/reply/:topicId` classification — **add** — derives an outbound row's structural origin from the trusted send path and validated message-kind/relay metadata; it does not block or alter delivery.
+- `PresenceProxy` log race guard — **modify** — automation rows cannot count as a substantive agent response; legacy rows retain the existing text-prefix fallback.
+- `CoherenceMonitor` output scan — **modify** — structurally automated rows are excluded from the agent-output sample; legacy outbound rows remain included.
+- `CommitmentSentinel` conversation pairing — **modify** — structurally automated rows are skipped between a user request and its conversational reply, while a new user row closes the candidate pair; legacy outbound rows retain the old behavior.
+
+---
+
+## 1. Over-block
+
+Message delivery has no new block/allow branch. A producer that incorrectly stamps genuine agent prose as `automation` could cause the three migrated observers to miss that row. The production classification is centralized at the reply route and the adapter defaults only non-route/direct sends to automation; route and relay integration tests cover the named boundaries.
+
+---
+
+## 2. Under-block
+
+Message delivery is unaffected. Legacy rows omit provenance, so readers deliberately retain their former heuristic or direction-only behavior for those rows; historical false counts are not retroactively repaired. Other platforms are not relabeled by this Telegram-specific change. A trusted internal caller that supplies incorrect relay metadata can still misclassify an outbound row, but cannot classify it as inbound `user`.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The writer seam is the right layer because it knows whether a message arrived from Telegram, passed through the conversational reply route, or originated as a direct server send. The cross-machine relay transports that already-made classification instead of reconstructing it from text on the holder. Consumers read the structural value and use compatibility logic only when the value is absent.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The closed provenance enum is structural metadata, not a judgment about message meaning. It neither blocks delivery nor overrides the outbound tone authority. Downstream monitors use it to avoid attributing automation to the conversational agent.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+This adds structural classification in an enumerable domain, rather than a static heuristic at a competing-signals judgment point. The three inputs are authenticated inbound platform traffic, ordinary conversational reply traffic, and server automation. Legacy unknowns remain unknown and use existing compatibility behavior rather than receiving a guessed label.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the reply route computes provenance after existing kind/proxy/system-template parsing and passes it alongside, not ahead of, tone-gate authority. It cannot shadow delivery checks.
+- **Double-fire:** a relayed send is logged on each participating machine's local history as before; the new field is carried so both records agree. No extra send or callback is introduced.
+- **Races:** provenance is immutable call data attached to the same append operation as the message. It adds no mutable shared state or asynchronous lookup.
+- **Feedback loops:** PresenceProxy stops treating automation as a reply, which prevents an automated notice from canceling its own waiting tier. Brief agent acknowledgments remain non-cancelling. Commitment pairing skips intervening automation but stops at the next user message, preventing cross-request pairing. Commitment and coherence changes are read-only observations and emit no new action loop.
+
+---
+
+## 6. External surfaces
+
+The persistent `telegram-messages.jsonl` schema gains one additive field on new rows. Internal callbacks and messaging events expose the same optional field. Existing rows, external readers, and non-Telegram loggers remain valid because the shared type treats omission as legacy/unknown. Telegram delivery bytes, timing, topic routing, and user-visible message text do not change. This patch adds no operator-facing action or mobile surface.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated in transit.** A tokenless standby passes provenance through `TelegramRelay` to the Telegram-owning holder, and both adapter logs persist the same value. The field rides the existing authenticated reply relay and requires no new replicated store. This change emits no new user-facing notice, holds no new independently mutable durable state, does not affect topic transfer, and generates no URLs.
+
+---
+
+## 8. Rollback cost
+
+Hot-fix rollback is a code revert and patch release. Data migration and agent-state repair are unnecessary: additive fields on rows written during the rollout remain harmless to old readers, and legacy-compatible readers already accept omission. Rolling back temporarily restores prefix-based ambiguity for new outbound rows but does not corrupt delivery or history.
+
+---
+
+## Conclusion
+
+The review found three material safeguards to make explicit: classify only at transport seams, default direct sends to automation, and transport the label across the multi-machine relay. The independent pass then found two gaps: metadata-less sentinel notices and commitment pairing across intervening automation. Both are now resolved with explicit sentinel provenance, bounded skip-to-reply pairing, and regression tests.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Codex independent reviewer
+**Independent read of the artifact:** Concur with the review — the two sentinel send seams now stamp automation explicitly, bounded pairing crosses automation without crossing a new user turn, and focused provenance/relay/legacy tests pass.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/telegram-messaging.test.ts` — direct-send automation, explicit agent reply, and inbound user rows.
+- `tests/integration/telegram-message-provenance-route.test.ts` — real reply-route classification and outbound-user rejection.
+- `tests/unit/relay-kind-forward.test.ts` — relay-hop provenance preservation.
+- `tests/integration/shared-infra-delegation.test.ts` — legacy/shared logger persistence parity.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: unbounded-self-action`, `closure: n/a`, reason: this changes only the structural input classification consumed by existing monitors; it adds no self-triggered action, cadence, retry, notification, steady-state edge, or settling behavior.


### PR DESCRIPTION
## Summary
- stamp new Telegram history rows with structural `user`, `agent`, or `automation` provenance at receive/send time
- preserve provenance through shared logging, callbacks, event bus, and cross-machine relay while leaving legacy rows unknown
- make presence, coherence, and commitment consumers ignore automation structurally; retain legacy compatibility

## ELI16 — Message histories now know who really spoke
Previously, Telegram history could tell whether a message arrived or was sent, but it could not tell whether a sent message was deliberately written by the agent or generated by an automated alert. Features that count or pair messages had to guess from the words in the message, and those guesses could be wrong. New history entries now carry one small label saying whether the speaker was the user, the agent, or automation. Older entries remain readable and keep their previous behavior. This changes accounting and safety decisions, not the words delivered in Telegram.

## UX Impact
Who sees it: Instar operators whose message accounting, presence detection, coherence checks, or commitment tracking reads Telegram history. What the user sees: Telegram conversation text and delivery are unchanged; the user-visible improvement is more accurate counts and fewer false decisions about whether the agent replied. First contact: the first Telegram send or receive after upgrading writes the exact new `provenance` field from the diff, while older history continues to work without it.

## Verification
- `npm run build`
- `npm run lint`
- 95 focused tests across adapter, relay, real reply route, shared logger, CommitmentSentinel, and CoherenceMonitor
- mandatory independent side-effects review concurred after two issues were fixed

## Compatibility
- additive JSONL field; no historical rewrite or database migration
- outbound rows cannot be classified as `user`
- legacy rows without provenance retain existing behavior