### PR TITLE
Fix truncated session context dispatch

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-31T22-24-57-394Z-session-dispatch-complete.json
+++ b/.instar/instar-dev-decisions/2026-07-31T22-24-57-394Z-session-dispatch-complete.json
@@ -1,0 +1,33 @@
+{
+  "ts": "2026-07-31T22:24:57.394Z",
+  "slug": "session-dispatch-complete",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)"
+  ],
+  "belowFloor": true,
+  "files": 1,
+  "loc": 4,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/PostUpdateMigrator.ts"
+    ],
+    "addedLines": 2,
+    "deletedLines": 2
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The producer grew beyond an undocumented twenty-line consumer cap; generator and deployed hook contract were never tested together."
+  },
+  "classClosure": {
+    "defectClass": "generated-artifact-path-contract-drift",
+    "closure": "tests/unit/PostUpdateMigrator-dispatchCompleteness.test.ts",
+    "reason": "The regression test enumerates both deployed hook generators and refuses any reintroduced twenty-line cap on DISPATCH.md.",
+    "component": "PostUpdateMigrator"
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/session-dispatch-complete.eli16.md
+++ b/docs/eli16/session-dispatch-complete.eli16.md
@@ -1,0 +1,15 @@
+# ELI16 — Session context no longer loses its last sections
+
+Instar generates a context dispatch file that tells an agent which deeper
+instructions to read for different kinds of work. The same file also ends with
+two important sections explaining which context is always loaded and which
+context is restored at session boundaries. The startup and compaction hooks
+used to print only the first twenty lines of this generated file. As the table
+grew beyond twenty lines, those final sections were guaranteed to disappear
+even though generation succeeded.
+
+Both deployed hook templates now print the complete generated dispatch file.
+The producer remains free to add or reorder routing rows without crossing a
+hidden consumer limit, and tests protect both the fresh-session and compaction
+paths from reintroducing that cap. The separate short excerpt of `AGENT.md`
+remains intentionally bounded and is not part of this change.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -12286,7 +12286,7 @@ except: pass
     if [ -f "\$DISPATCH_FILE" ]; then
       echo ""
       echo "--- CONTEXT DISPATCH (when X arises, read Y) ---"
-      cat "\$DISPATCH_FILE" | head -20
+      cat "\$DISPATCH_FILE"
       echo "--- END CONTEXT DISPATCH ---"
     fi
   else
@@ -13168,7 +13168,7 @@ except: pass
     if [ -f "\$DISPATCH_FILE" ]; then
       echo ""
       echo "--- CONTEXT DISPATCH (when X arises, read Y) ---"
-      cat "\$DISPATCH_FILE" | head -20
+      cat "\$DISPATCH_FILE"
       echo "--- END CONTEXT DISPATCH ---"
     fi
   else

--- a/tests/unit/PostUpdateMigrator-dispatchCompleteness.test.ts
+++ b/tests/unit/PostUpdateMigrator-dispatchCompleteness.test.ts
@@ -1,0 +1,33 @@
+/**
+ * The context hierarchy appends Tier 0 and Tier 1 guidance after the routing
+ * table. Both fresh-session and compaction hooks must therefore emit the whole
+ * generated DISPATCH.md file; a line cap silently drops structurally required
+ * sections as the table grows.
+ */
+import { describe, expect, it } from 'vitest';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+
+function migrator(): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir: '/tmp/instar-dispatch-completeness',
+    stateDir: '/tmp/instar-dispatch-completeness/.instar',
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test-agent',
+  });
+}
+
+describe('PostUpdateMigrator — complete context dispatch delivery', () => {
+  for (const hookName of ['session-start', 'compaction-recovery'] as const) {
+    it(`${hookName} emits the complete generated dispatch file`, () => {
+      const hook = migrator().getHookContent(hookName);
+      const dispatchBlock = hook.match(
+        /--- CONTEXT DISPATCH[^\n]*---[\s\S]*?--- END CONTEXT DISPATCH ---/,
+      )?.[0];
+
+      expect(dispatchBlock).toBeDefined();
+      expect(dispatchBlock).toContain('cat "$DISPATCH_FILE"');
+      expect(dispatchBlock).not.toMatch(/head\s+-20/);
+    });
+  }
+});

--- a/upgrades/next/session-dispatch-complete.md
+++ b/upgrades/next/session-dispatch-complete.md
@@ -1,0 +1,23 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Fresh sessions and compaction recovery now receive the complete generated
+context dispatch table, including the Tier 0 and Tier 1 sections appended at
+its end. The deliberate short identity excerpt remains unchanged.
+
+## What to Tell Your User
+
+- **Complete session guidance**: "Fresh sessions and resumed sessions now see every generated context-routing section."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|---|---|
+| Receive the full dispatch table at session boundaries | Automatic on fresh session start and compaction recovery |
+
+## Evidence
+
+Focused tests inspect both deployed hook generators and verify that neither
+applies the former twenty-line cap. The context hierarchy suite, full build,
+and repository lint also pass.

--- a/upgrades/side-effects/session-dispatch-complete.md
+++ b/upgrades/side-effects/session-dispatch-complete.md
@@ -1,0 +1,21 @@
+# Side-effect review — complete context dispatch delivery
+
+## Changed boundary
+
+`ContextHierarchy` writes an unbounded generated `DISPATCH.md`. The two
+deployed consumers in `PostUpdateMigrator` now preserve that producer contract
+by emitting the complete file on fresh-session and compaction-recovery paths.
+
+## Expected effects
+
+- Session-start hook output grows by the currently omitted tail of the dispatch
+  file (22 lines on the reporting installation).
+- Tier 0 and Tier 1 guidance is visible at the point where agents need it.
+- Future generator additions remain visible without coordinating a line cap.
+
+## Explicit non-effects
+
+- No context files are loaded eagerly because of this change; the dispatch file
+  is routing guidance, not the referenced file contents.
+- The intentional `AGENT.md` excerpt bounds are unchanged.
+- No persisted data or config migration is required.


### PR DESCRIPTION
## What changed

- Removed the twenty-line cap from both generated consumers of DISPATCH.md: fresh session start and compaction recovery.
- Added a regression test that enumerates both deployed hook generators.
- Left the deliberate short AGENT.md identity excerpts unchanged.

## Root cause

ContextHierarchy produces an unbounded routing table and appends the Tier 0 and Tier 1 guidance after the routing rows. PostUpdateMigrator independently capped both consumers at twenty lines, so the producer and consumers had incompatible contracts and the appended sections were structurally unreachable.

## ELI16 — Sessions now receive the whole context map

Instar creates a small map that tells an agent which deeper instructions to read when it starts particular kinds of work. That map also ends with important guidance about context that is always loaded and context restored at session boundaries. The startup machinery used to show only the first twenty lines, so as the map grew, the final guidance disappeared every time. Fresh starts and compaction recovery now print the complete generated map, and a test protects both copies of the deployed hook from silently adding the cap back.

## UX Impact

Audience: every agent starting or resuming an Instar session. Visible behavior: the CONTEXT DISPATCH block now includes every generated row plus its Tier 0 and Tier 1 sections. First contact: automatic at fresh session start and compaction recovery. The only cost is a small increase in startup guidance output; no referenced context file is loaded eagerly.

## Validation

- 24 focused tests passed across PostUpdateMigrator dispatch completeness and ContextHierarchy.
- Full TypeScript build passed.
- Repository lint passed.
- Pre-push affected-test gate passed.
