### PR TITLE
Reconcile remediation evidence at boot

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-31T22-48-25-885Z-remediation-boot-reconciliation.json
+++ b/.instar/instar-dev-decisions/2026-07-31T22-48-25-885Z-remediation-boot-reconciliation.json
@@ -1,0 +1,33 @@
+{
+  "ts": "2026-07-31T22:48:25.885Z",
+  "slug": "remediation-boot-reconciliation",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 109,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/remediation/IntentAuditReconciler.ts",
+      "src/remediation/IntentJournal.ts",
+      "src/remediation/RemediatorBootstrap.ts",
+      "src/remediation/audit/AuditWriter.ts"
+    ],
+    "addedLines": 104,
+    "deletedLines": 5
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Durable intent and audit writers shipped with read APIs, but production bootstrap never constructed a comparison path and AuditWriter did not restore its hot tail after restart."
+  },
+  "classClosure": {
+    "defectClass": "unknown-classification-fail-open",
+    "closure": "tests/unit/IntentAuditReconciler.test.ts and tests/unit/RemediatorBootstrap.test.ts",
+    "reason": "The tests require both durable readers to participate in the live bootstrap path and distinguish matched evidence from an intent missing audit evidence.",
+    "component": "RemediatorBootstrap"
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/remediation-boot-reconciliation.eli16.md
+++ b/docs/eli16/remediation-boot-reconciliation.eli16.md
@@ -1,0 +1,15 @@
+# ELI16 — Remediation intent and audit records are checked after restart
+
+Before an automated remediation runs, Instar writes a durable intent record.
+It then writes audit rows showing that the attempt started and how it ended.
+Both files already had read APIs, but the live server never called them, so a
+crash in the small gap between those writes could leave evidence that nobody
+compared after restart.
+
+The remediation bootstrap now restores a bounded tail of accepted audit rows
+and compares it with recent durable intents. A matching attempt starts cleanly.
+An intent with no audit evidence becomes a loud boot warning instead of a
+silent forensic gap. The intent reader now streams its journal, avoiding a
+whole-file synchronous read when this dormant path becomes live. The audit hot
+index reads at most two megabytes and one thousand rows, so old logs cannot make
+startup memory grow without bound.

--- a/src/remediation/IntentAuditReconciler.ts
+++ b/src/remediation/IntentAuditReconciler.ts
@@ -1,0 +1,52 @@
+/**
+ * Boot-time reconciliation between durable remediation intents and the
+ * writer's bounded, hydrated audit tail.
+ *
+ * An intent is written before the first `started` audit row. If the process
+ * dies or audit persistence fails in that gap, the next process must make the
+ * mismatch visible instead of leaving both read APIs dormant.
+ */
+import type { IntentJournal } from './IntentJournal.js';
+import type { AuditWriter } from './audit/AuditWriter.js';
+
+export interface IntentAuditReconciliation {
+  intentsRead: number;
+  auditEntriesRead: number;
+  unmatchedIntentAttemptIds: string[];
+}
+
+// Intent persistence immediately precedes the first audit append. Include a
+// generous overlap before the oldest retained audit row so a missing `started`
+// row remains detectable even when key derivation or a busy host delayed the
+// append. Remediation dispatch is rate-bounded, so this cannot pull an
+// operationally large intent set into the comparison window.
+const INTENT_AUDIT_OVERLAP_MS = 5 * 60 * 1000;
+
+export async function reconcileIntentAudit(
+  intentJournal: IntentJournal,
+  auditWriter: AuditWriter,
+): Promise<IntentAuditReconciliation> {
+  const auditTail = auditWriter.recentTail();
+  const earliestAuditTimestamp = auditTail.reduce(
+    (earliest, entry) => Math.min(earliest, entry.timestamp),
+    Number.POSITIVE_INFINITY,
+  );
+  // The tail is a bounded window. Only compare intents inside that window so
+  // an old, valid intent is never called unmatched merely because its audit
+  // row has aged out of memory. With no audit rows, read all intents: a
+  // non-empty intent journal beside an empty projection is itself the signal.
+  const cursor = Number.isFinite(earliestAuditTimestamp)
+    ? Math.max(0, earliestAuditTimestamp - INTENT_AUDIT_OVERLAP_MS)
+    : 0;
+  const intents = await intentJournal.readSince(cursor);
+  const auditedAttemptIds = new Set(auditTail.map((entry) => entry.attemptId));
+  const unmatchedIntentAttemptIds = intents
+    .filter((intent) => !auditedAttemptIds.has(intent.attemptId))
+    .map((intent) => intent.attemptId);
+
+  return {
+    intentsRead: intents.length,
+    auditEntriesRead: auditTail.length,
+    unmatchedIntentAttemptIds,
+  };
+}

--- a/src/remediation/IntentJournal.ts
+++ b/src/remediation/IntentJournal.ts
@@ -25,6 +25,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import readline from 'node:readline';
 
 export type IntentBlastRadius = 'process' | 'machine' | 'fleet';
 export type IntentKind = 'dispatch' | 'verify' | 'rollback' | 'quarantine';
@@ -96,9 +97,10 @@ export class IntentJournal {
    */
   async readSince(cursor: number): Promise<IntentEntry[]> {
     if (!fs.existsSync(this.journalPath)) return [];
-    const raw = fs.readFileSync(this.journalPath, 'utf8');
     const out: IntentEntry[] = [];
-    for (const line of raw.split('\n')) {
+    const input = fs.createReadStream(this.journalPath, { encoding: 'utf8' });
+    const lines = readline.createInterface({ input, crlfDelay: Infinity });
+    for await (const line of lines) {
       if (!line) continue;
       let parsed: IntentEntry | undefined;
       try {

--- a/src/remediation/RemediatorBootstrap.ts
+++ b/src/remediation/RemediatorBootstrap.ts
@@ -50,6 +50,10 @@ import { MachineLock } from './MachineLock.js';
 import { IntentJournal } from './IntentJournal.js';
 import { AuditWriter } from './audit/AuditWriter.js';
 import {
+  reconcileIntentAudit,
+  type IntentAuditReconciliation,
+} from './IntentAuditReconciler.js';
+import {
   TrustElevationSource,
   type TrustedApprovalChannel,
 } from './TrustElevationSource.js';
@@ -100,6 +104,7 @@ export type BootstrapResult =
       remediator: Remediator;
       vault: RemediationKeyVault;
       registeredRunbookIds: string[];
+      intentAuditReconciliation: IntentAuditReconciliation;
     }
   | { disabled: true; reason: 'no-secret-backend' | 'config-flag-false' };
 
@@ -170,6 +175,16 @@ export async function bootstrapRemediator(
     // the rest of the integrity envelope.
     tokenVerifier: makeAuditTokenVerifier(vault),
   });
+  const intentAuditReconciliation = await reconcileIntentAudit(
+    intentJournal,
+    auditWriter,
+  );
+  if (intentAuditReconciliation.unmatchedIntentAttemptIds.length > 0) {
+    console.warn(
+      `[RemediatorBootstrap] ${intentAuditReconciliation.unmatchedIntentAttemptIds.length} ` +
+      'durable remediation intent(s) have no matching row in the hydrated audit window',
+    );
+  }
 
   // 3. F-5 TrustElevationSource. Default autonomy profile is 'supervised' —
   //    the minimum that gates upward transitions; matches the spec's stated
@@ -252,6 +267,7 @@ export async function bootstrapRemediator(
     remediator,
     vault,
     registeredRunbookIds,
+    intentAuditReconciliation,
   };
 }
 

--- a/src/remediation/audit/AuditWriter.ts
+++ b/src/remediation/audit/AuditWriter.ts
@@ -13,12 +13,13 @@
  *   - <stateDir>/remediation/audit-projection-<machineId>.jsonl  (accepted)
  *   - <stateDir>/remediation/audit-rejected.jsonl                (rejected)
  *
- * In-memory tail (A29): the writer keeps the last 1,000 accepted entries in
- * memory for hot-path reads by the churn detector and projection consumers.
+ * In-memory tail (A29): the writer hydrates and keeps the last 1,000 accepted
+ * entries for hot-path reads by boot reconciliation and projection consumers.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { readJsonlTailLastLines } from '../../utils/jsonl-tail.js';
 
 export type AuditOutcome =
   | 'started'
@@ -71,6 +72,7 @@ export interface AppendResult {
 }
 
 const DEFAULT_TAIL_SIZE = 1000;
+const AUDIT_TAIL_MAX_BYTES = 2 * 1024 * 1024;
 
 export class AuditWriter {
   private readonly projectionPath: string;
@@ -92,6 +94,7 @@ export class AuditWriter {
     this.rejectedPath = path.join(dir, 'audit-rejected.jsonl');
     this.tokenVerifier = options.tokenVerifier;
     this.tailSize = options.tailSize ?? DEFAULT_TAIL_SIZE;
+    this.hydrateTail();
   }
 
   /**
@@ -117,7 +120,7 @@ export class AuditWriter {
     return { accepted: true };
   }
 
-  /** In-memory tail of the last N accepted entries (A29). */
+  /** Hydrated in-memory tail of the last N accepted entries (A29). */
   recentTail(): AuditEntry[] {
     return [...this.tail];
   }
@@ -155,6 +158,32 @@ export class AuditWriter {
     this.tail.push(entry);
     if (this.tail.length > this.tailSize) {
       this.tail.splice(0, this.tail.length - this.tailSize);
+    }
+  }
+
+  /**
+   * Restore the hot read index from the durable projection at process boot.
+   * The tail is bounded by both entry count and bytes so a long-lived audit
+   * log never turns construction into a whole-file synchronous read.
+   */
+  private hydrateTail(): void {
+    const lines = readJsonlTailLastLines(
+      this.projectionPath,
+      this.tailSize,
+      AUDIT_TAIL_MAX_BYTES,
+    );
+    for (const line of lines) {
+      try {
+        const entry = deserializeAuditEntry(line);
+        this.pushTail(entry);
+        const key = `${entry.subsystem}:${entry.attemptId}`;
+        const previous = this.highWatermark.get(key) ?? 0;
+        this.highWatermark.set(key, Math.max(previous, entry.timestamp));
+      } catch {
+        // A malformed durable row is omitted from the hot read index. The
+        // append path remains available, and boot reconciliation will surface
+        // any intent whose matching audit evidence is consequently absent.
+      }
     }
   }
 }

--- a/tests/unit/AuditWriter.test.ts
+++ b/tests/unit/AuditWriter.test.ts
@@ -123,4 +123,27 @@ describe('AuditWriter', () => {
     expect(tail[0]?.attemptId).toBe('a-70');
     expect(tail[49]?.attemptId).toBe('a-119');
   });
+
+  it('hydrates the bounded recent tail when a new writer starts', async () => {
+    const firstWriter = new AuditWriter(tmpDir, {
+      machineId: 'm-test',
+      tokenVerifier: () => true,
+      tailSize: 2,
+    });
+    for (let i = 0; i < 3; i++) {
+      await firstWriter.append(
+        makeEntry({ attemptId: `persisted-${i}`, timestamp: 2_000_000 + i }),
+      );
+    }
+
+    const restartedWriter = new AuditWriter(tmpDir, {
+      machineId: 'm-test',
+      tokenVerifier: () => true,
+      tailSize: 2,
+    });
+    expect(restartedWriter.recentTail().map((entry) => entry.attemptId)).toEqual([
+      'persisted-1',
+      'persisted-2',
+    ]);
+  });
 });

--- a/tests/unit/IntentAuditReconciler.test.ts
+++ b/tests/unit/IntentAuditReconciler.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { reconcileIntentAudit } from '../../src/remediation/IntentAuditReconciler.js';
+import type { IntentEntry, IntentJournal } from '../../src/remediation/IntentJournal.js';
+import type { AuditEntry, AuditWriter } from '../../src/remediation/audit/AuditWriter.js';
+
+function intent(attemptId: string, declaredAt: number): IntentEntry {
+  return {
+    intentId: `intent-${attemptId}`,
+    attemptId,
+    runbookId: 'fixture',
+    signatureHash: 'sig',
+    blastRadius: 'process',
+    intent: 'dispatch',
+    declaredAt,
+    monotonicTs: BigInt(declaredAt),
+  };
+}
+
+function audit(attemptId: string, timestamp: number): AuditEntry {
+  return {
+    entryId: `audit-${attemptId}`,
+    attemptId,
+    outcome: 'started',
+    runbookId: 'fixture',
+    subsystem: 'fixture',
+    timestamp,
+    monotonicTs: BigInt(timestamp),
+    auditToken: Buffer.from('token'),
+  };
+}
+
+describe('reconcileIntentAudit', () => {
+  it('invokes both readers and reports an intent missing audit evidence', async () => {
+    let observedCursor = -1;
+    const intentJournal = {
+      readSince: async (cursor: number) => {
+        observedCursor = cursor;
+        return [intent('matched', 100), intent('missing', 101)];
+      },
+    } as IntentJournal;
+    const auditWriter = {
+      recentTail: () => [audit('matched', 100)],
+    } as AuditWriter;
+
+    const result = await reconcileIntentAudit(intentJournal, auditWriter);
+
+    expect(observedCursor).toBe(0);
+    expect(result).toEqual({
+      intentsRead: 2,
+      auditEntriesRead: 1,
+      unmatchedIntentAttemptIds: ['missing'],
+    });
+  });
+
+  it('reads from the beginning when the hydrated audit window is empty', async () => {
+    let observedCursor = -1;
+    const intentJournal = {
+      readSince: async (cursor: number) => {
+        observedCursor = cursor;
+        return [];
+      },
+    } as IntentJournal;
+    const auditWriter = { recentTail: () => [] } as unknown as AuditWriter;
+
+    await reconcileIntentAudit(intentJournal, auditWriter);
+    expect(observedCursor).toBe(0);
+  });
+});

--- a/tests/unit/RemediatorBootstrap.test.ts
+++ b/tests/unit/RemediatorBootstrap.test.ts
@@ -23,6 +23,8 @@ import {
 import { Remediator } from '../../src/remediation/Remediator.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { nodeAbiMismatchRunbook } from '../../src/remediation/runbooks/node-abi-mismatch.js';
+import { IntentJournal } from '../../src/remediation/IntentJournal.js';
+import { AuditWriter } from '../../src/remediation/audit/AuditWriter.js';
 
 // ── Fixture helpers ──────────────────────────────────────────────────────
 
@@ -183,6 +185,43 @@ describe('RemediatorBootstrap', () => {
       expect(result.vault).toBeDefined();
       expect(result.registeredRunbookIds).toContain('node-abi-mismatch');
       expect(result.registeredRunbookIds).toContain('messaging-delivery-failed');
+    });
+  });
+
+  it('reconciles persisted intents against the hydrated audit tail at boot', async () => {
+    await withEnvPassphrase(async () => {
+      const machineId = 'm-bootstrap-reconcile';
+      const intentJournal = new IntentJournal(tmpDir, { machineId });
+      await intentJournal.declareIntent({
+        attemptId: 'matched-attempt',
+        runbookId: 'node-abi-mismatch',
+        signatureHash: 'sig',
+        blastRadius: 'process',
+        intent: 'dispatch',
+      });
+      const auditWriter = new AuditWriter(tmpDir, {
+        machineId,
+        tokenVerifier: () => true,
+      });
+      await auditWriter.append({
+        entryId: 'entry-1',
+        attemptId: 'matched-attempt',
+        outcome: 'started',
+        runbookId: 'node-abi-mismatch',
+        subsystem: 'memory',
+        timestamp: Date.now(),
+        monotonicTs: process.hrtime.bigint(),
+        auditToken: Buffer.from('fixture'),
+      });
+
+      const result = await callBootstrapWithEnvBackend({ stateDir: tmpDir, machineId });
+      expect(result.disabled).toBe(false);
+      if (result.disabled) return;
+      expect(result.intentAuditReconciliation).toMatchObject({
+        intentsRead: 1,
+        auditEntriesRead: 1,
+        unmatchedIntentAttemptIds: [],
+      });
     });
   });
 

--- a/upgrades/next/remediation-boot-reconciliation.md
+++ b/upgrades/next/remediation-boot-reconciliation.md
@@ -1,0 +1,23 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Remediator startup now restores its bounded audit tail and compares recent
+durable intents with audit evidence. Missing evidence is surfaced during boot.
+
+## What to Tell Your User
+
+- **Restart-safe remediation evidence**: "After a restart, I now check that recent remediation intents have matching audit records instead of leaving the journals unread."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|---|---|
+| Detect an intent-to-audit persistence gap | Automatic whenever live remediation bootstraps |
+| Inspect reconciliation proof | Read the bootstrap reconciliation counts and boot warning |
+
+## Evidence
+
+Twenty-three focused tests cover audit-tail hydration and bounds, matching and
+missing intent evidence, real bootstrap reachability, corrupt intent rows, and
+existing token/watermark enforcement.

--- a/upgrades/side-effects/remediation-boot-reconciliation.md
+++ b/upgrades/side-effects/remediation-boot-reconciliation.md
@@ -1,0 +1,31 @@
+# Side-effect review — remediation boot reconciliation
+
+## Changed boundary
+
+`AuditWriter` hydrates its existing recent-tail read view from the durable
+projection during construction. `RemediatorBootstrap` invokes that view and
+`IntentJournal.readSince()` through a dedicated reconciler before it registers
+the live Remediator with the degradation path.
+
+## Expected effects
+
+- Restarted remediation processes retain a bounded hot audit window.
+- Recent intent-without-audit gaps produce one boot warning with a count.
+- The bootstrap result exposes reconciliation counts for diagnostics and tests.
+
+## Bounds and failure behavior
+
+- Audit hydration reads at most 1,000 rows and two megabytes from the file tail.
+- Intent scanning uses an asynchronous stream rather than blocking on a full
+  synchronous read; malformed individual lines retain the existing skip rule.
+- The comparison uses a five-minute overlap before the oldest retained audit
+  row so the intent that immediately preceded it remains visible.
+- Reconciliation is signal-only. It never retries, rolls back, or performs a
+  remediation, and an old intent outside the retained audit window is not
+  misclassified as a current mismatch.
+
+## Class-closure declaration
+
+This closes a dormant-reader wiring class at bootstrap. The dedicated unit test
+proves both readers are invoked, and the bootstrap test proves persisted rows
+survive construction and reach the reconciliation result.


### PR DESCRIPTION
## ELI16 — Reconcile remediation evidence after restart

Instar durably records an automated remediation's intent before it records the
audit trail for that attempt. Both files already had read APIs, but production
startup never invoked either one, so a crash in the gap between those writes
could leave evidence nobody compared. Startup now hydrates a bounded audit tail
and compares it with recent durable intents. Missing audit evidence produces a
loud warning; matching records remain silent. The readers are bounded or
streaming, and the reconciliation has no remediation authority.

## What changed

- Hydrate `AuditWriter.recentTail()` from at most 1,000 rows / 2 MiB of the durable projection.
- Stream `IntentJournal.readSince()` instead of reading the whole journal synchronously.
- Invoke both readers from `RemediatorBootstrap` through a dedicated reconciler.
- Expose reconciliation counts and warn on intent records with no matching audit row.

## UX Impact

No normal-flow UI changes. A restart that finds a recent intent/audit persistence gap now emits one count-based boot warning instead of leaving the gap silent.

## Validation

- 23 focused `AuditWriter`, `IntentJournal`, reconciler, and bootstrap tests passed.
- Full TypeScript build passed.
- Full lint passed.
- Pre-push affected suite passed: 16 files, 154 tests.

## Side effects

The comparison is signal-only. It cannot retry, roll back, dispatch, or mutate remediation state. Audit hydration is byte- and row-bounded; intent reading is asynchronous streaming.
