### PR TITLE
Refresh AgentMD job bodies at trigger

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-31T22-48-25-828Z-agentmd-body-live-refresh.json
+++ b/.instar/instar-dev-decisions/2026-07-31T22-48-25-828Z-agentmd-body-live-refresh.json
@@ -1,0 +1,35 @@
+{
+  "ts": "2026-07-31T22:48:25.828Z",
+  "slug": "agentmd-body-live-refresh",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 49,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/scheduler/AgentMdJobLoader.ts",
+      "src/scheduler/JobRunHistory.ts",
+      "src/scheduler/JobScheduler.ts"
+    ],
+    "addedLines": 30,
+    "deletedLines": 19
+  },
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1804
+    ],
+    "notes": "PR #1804 made disk/body-hash drift visible but deliberately left execution on the boot-cached body, so a known edit continued to be inert until restart."
+  },
+  "classClosure": {
+    "defectClass": "generated-artifact-path-contract-drift",
+    "closure": "tests/unit/scheduler/JobScheduler.body-drift.test.ts",
+    "reason": "The consumer-seam test proves every validated edit reaches the next prompt and every invalid edit retains the last validated prompt.",
+    "component": "JobScheduler"
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/agentmd-body-live-refresh.eli16.md
+++ b/docs/eli16/agentmd-body-live-refresh.eli16.md
@@ -1,0 +1,13 @@
+# ELI16 — Edited job instructions run without a server restart
+
+AgentMD jobs store their instructions in readable markdown files. The scheduler
+used to load those instructions once at startup. It could detect when someone
+edited a file later, but it only warned that a restart was required and still
+ran the old instructions. That made a successful edit look live when it was not.
+
+The scheduler now re-reads the body at the moment a job is triggered. If the
+edited file is still a regular, size-bounded AgentMD file with valid frontmatter,
+the triggering run receives the new body and its run-history hash describes
+exactly those instructions. If the file is missing, malformed, symlinked, or too
+large, the scheduler safely keeps the last validated body and emits one warning
+for that bad disk state. Schedule and other manifest authority remain unchanged.

--- a/src/scheduler/AgentMdJobLoader.ts
+++ b/src/scheduler/AgentMdJobLoader.ts
@@ -1065,9 +1065,9 @@ function splitFrontmatter(text: string): { frontmatterText: string; body: string
  * reuses the loader's frontmatter split and body hash normalization without
  * reparsing YAML, rebuilding manifests, or changing the cached JobDefinition.
  */
-export function readAgentMdBodyHash(
+export function readAgentMdBody(
   resolvedPath: string,
-): { ok: true; bodyHash: string } | { ok: false; reason: string } {
+): { ok: true; body: string; bodyHash: string } | { ok: false; reason: string } {
   try {
     const stat = fs.lstatSync(resolvedPath);
     if (stat.isSymbolicLink()) {
@@ -1094,13 +1094,23 @@ export function readAgentMdBodyHash(
       };
     }
 
-    return { ok: true, bodyHash: hashBody(split.body) };
+    return { ok: true, body: split.body, bodyHash: hashBody(split.body) };
   } catch (err) {
     return {
       ok: false,
       reason: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+/** Backwards-compatible hash-only probe for observability consumers. */
+export function readAgentMdBodyHash(
+  resolvedPath: string,
+): { ok: true; bodyHash: string } | { ok: false; reason: string } {
+  const result = readAgentMdBody(resolvedPath);
+  return result.ok
+    ? { ok: true, bodyHash: result.bodyHash }
+    : result;
 }
 
 // ── Manifest → JobDefinition ───────────────────────────────────────────────

--- a/src/scheduler/JobRunHistory.ts
+++ b/src/scheduler/JobRunHistory.ts
@@ -75,7 +75,7 @@ export interface JobRun {
   origin?: 'instar' | 'user' | 'legacy';
   /** Absolute path the agentmd body was resolved from; null for non-agentmd. */
   resolvedPath?: string | null;
-  /** SHA-256 of the cached body. null for non-agentmd. */
+  /** SHA-256 of the body validated for this run. null for non-agentmd. */
   bodyHash?: string | null;
   /** SHA-256 of the canonicalized frontmatter object. null for non-agentmd. */
   frontmatterHash?: string | null;

--- a/src/scheduler/JobScheduler.ts
+++ b/src/scheduler/JobScheduler.ts
@@ -22,7 +22,7 @@ import { ExecutionJournal } from '../core/ExecutionJournal.js';
 import { IntegrationGate } from './IntegrationGate.js';
 import { JobReflector } from '../core/JobReflector.js';
 import { loadJobs } from './JobLoader.js';
-import { readAgentMdBodyHash } from './AgentMdJobLoader.js';
+import { readAgentMdBody } from './AgentMdJobLoader.js';
 import { hashBody } from './AgentMdLockFile.js';
 import { JobRunHistory } from './JobRunHistory.js';
 import { SkipLedger } from './SkipLedger.js';
@@ -373,7 +373,8 @@ export class JobScheduler {
     // Phase 1b: agentmd entries now flow through the dispatch path
     // alongside legacy entries. The Phase 1a defensive filter on
     // execute.type === 'agentmd' has been removed; buildPrompt's
-    // 'agentmd' case returns the cached body, and spawnJobSession
+    // 'agentmd' case returns the last validated body (refreshed from disk at
+    // each trigger boundary), and spawnJobSession
     // threads the per-job tool allowlist into the spawn call.
     const enabledJobs = this.jobs.filter(j => j.enabled);
 
@@ -498,7 +499,7 @@ export class JobScheduler {
       throw new Error(`Unknown job: ${slug}`);
     }
 
-    this.warnIfAgentMdBodyChanged(job);
+    this.refreshAgentMdBodyIfChanged(job);
 
     if (this.paused) {
       this.skipLedger.recordSkip(slug, 'paused');
@@ -968,11 +969,11 @@ export class JobScheduler {
   }
 
   /**
-   * Signal edits that cannot affect this process because agentmd bodies are
-   * intentionally cached at scheduler start. The warning is deduped by the
-   * observed disk state, while execution continues with the cached body.
+   * Re-read a validated agentmd body at the trigger boundary. Valid edits take
+   * effect on the run being triggered; unreadable or invalid edits fail safe
+   * to the last validated body and emit a warning deduped by disk state.
    */
-  private warnIfAgentMdBodyChanged(job: JobDefinition): void {
+  private refreshAgentMdBodyIfChanged(job: JobDefinition): void {
     if (
       job.execute.type !== 'agentmd' ||
       typeof job.body !== 'string' ||
@@ -981,14 +982,14 @@ export class JobScheduler {
       return;
     }
 
-    const disk = readAgentMdBodyHash(job.resolvedPath);
+    const disk = readAgentMdBody(job.resolvedPath);
     if (!disk.ok) {
       const fingerprint = `unreadable:${disk.reason}`;
       if (this.bodyDriftWarnings.get(job.slug) === fingerprint) return;
       this.bodyDriftWarnings.set(job.slug, fingerprint);
       console.warn(
         `[scheduler] Job "${job.slug}" body cannot be checked on disk (${disk.reason}); ` +
-        `continuing to use the body cached at scheduler start. Restart the server after repairing the file.`,
+        'continuing to use the last validated body until the file is repaired.',
       );
       return;
     }
@@ -999,11 +1000,11 @@ export class JobScheduler {
       return;
     }
 
-    if (this.bodyDriftWarnings.get(job.slug) === disk.bodyHash) return;
-    this.bodyDriftWarnings.set(job.slug, disk.bodyHash);
-    console.warn(
+    job.body = disk.body;
+    this.bodyDriftWarnings.delete(job.slug);
+    console.log(
       `[scheduler] Job "${job.slug}" body changed on disk after scheduler start; ` +
-      `continuing to use the cached body. Restart the server to apply the edit.`,
+      'reloaded the validated body for this run.',
     );
   }
 
@@ -1304,14 +1305,14 @@ export class JobScheduler {
         base = `Run this script: ${job.execute.value}${job.execute.args ? ' ' + job.execute.args : ''}`;
         break;
       case 'agentmd':
-        // Phase 1b dispatch: the cached markdown body IS the prompt. The
+        // Phase 1b dispatch: the last validated markdown body IS the prompt. The
         // loader (AgentMdJobLoader.loadAgentMdBody) guarantees `body` is
         // populated for any agentmd JobDefinition that survives validation;
         // if it is somehow missing here, surface that loud and refuse to
         // spawn an empty prompt rather than fail silently.
         if (typeof job.body !== 'string') {
           throw new Error(
-            `JobScheduler.buildPrompt: agentmd job "${job.slug}" has no cached body. ` +
+            `JobScheduler.buildPrompt: agentmd job "${job.slug}" has no validated body. ` +
             `This indicates a loader-hydration bug (see AgentMdJobLoader.isAgentMdJobHydrated). ` +
             `See docs/specs/INSTAR-JOBS-AS-AGENTMD-SPEC.md.`,
           );

--- a/tests/unit/scheduler/JobScheduler.agentmd-dispatch.test.ts
+++ b/tests/unit/scheduler/JobScheduler.agentmd-dispatch.test.ts
@@ -222,7 +222,7 @@ describe('JobScheduler agentmd dispatch (Phase 1b)', () => {
       await expect(async () => {
         // Directly invoke buildPrompt via a small reflection to surface the throw.
         (scheduler as unknown as { buildPrompt: (j: JobDefinition) => string }).buildPrompt(job);
-      }).rejects.toThrow(/no cached body/);
+      }).rejects.toThrow(/no validated body/);
     } finally {
       consoleSpy.mockRestore();
     }

--- a/tests/unit/scheduler/JobScheduler.body-drift.test.ts
+++ b/tests/unit/scheduler/JobScheduler.body-drift.test.ts
@@ -16,7 +16,7 @@ function agentMd(body: string): string {
   ].join('\n');
 }
 
-describe('JobScheduler agentmd body drift warning', () => {
+describe('JobScheduler agentmd body live refresh', () => {
   let project: TempProject;
   let sessionManager: MockSessionManager;
   let scheduler: JobScheduler;
@@ -48,7 +48,7 @@ describe('JobScheduler agentmd body drift warning', () => {
     scheduler = new JobScheduler({
       jobsFile: path.join(project.stateDir, 'jobs.json'),
       enabled: true,
-      maxParallelJobs: 2,
+      maxParallelJobs: 5,
       quotaThresholds: { normal: 50, elevated: 70, critical: 85, shutdown: 95 },
       startupGraceMs: 60_000,
     }, sessionManager as any, project.state, project.stateDir);
@@ -61,24 +61,28 @@ describe('JobScheduler agentmd body drift warning', () => {
     vi.restoreAllMocks();
   });
 
-  it('warns once per changed disk body while continuing with the cached prompt', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('reloads each validated disk edit for the run being triggered', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const reloadLogs = () => log.mock.calls.filter((call) =>
+      String(call[0] ?? '').includes('reloaded the validated body'),
+    );
     fs.writeFileSync(bodyPath, agentMd('First on-disk edit.\n'));
 
     await expect(scheduler.triggerJob('body-drift-probe', 'test')).resolves.toBe('triggered');
 
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0][0]).toContain('changed on disk after scheduler start');
-    expect(warn.mock.calls[0][0]).toContain('Restart the server to apply the edit');
-    expect(sessionManager._lastSpawnArgs?.prompt).toContain('Original cached instruction.');
-    expect(sessionManager._lastSpawnArgs?.prompt).not.toContain('First on-disk edit.');
+    expect(reloadLogs()).toHaveLength(1);
+    expect(reloadLogs()[0]?.[0]).toContain('changed on disk after scheduler start');
+    expect(sessionManager._lastSpawnArgs?.prompt).toContain('First on-disk edit.');
+    expect(sessionManager._lastSpawnArgs?.prompt).not.toContain('Original cached instruction.');
 
     await scheduler.triggerJob('body-drift-probe', 'test-again');
-    expect(warn).toHaveBeenCalledTimes(1);
+    expect(reloadLogs()).toHaveLength(1);
 
     fs.writeFileSync(bodyPath, agentMd('Second on-disk edit.\n'));
     await scheduler.triggerJob('body-drift-probe', 'test-after-second-edit');
-    expect(warn).toHaveBeenCalledTimes(2);
+    expect(reloadLogs()).toHaveLength(2);
+    const hydratedJobs = (scheduler as unknown as { jobs: Array<{ body?: string }> }).jobs;
+    expect(hydratedJobs[0]?.body).toContain('Second on-disk edit.');
   });
 
   it('warns without blocking when the body file becomes unreadable', async () => {
@@ -91,7 +95,19 @@ describe('JobScheduler agentmd body drift warning', () => {
 
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0][0]).toContain('body cannot be checked on disk');
-    expect(warn.mock.calls[0][0]).toContain('continuing to use the body cached');
+    expect(warn.mock.calls[0][0]).toContain('continuing to use the last validated body');
     expect(sessionManager._lastSpawnArgs?.prompt).toContain('Original cached instruction.');
+  });
+
+  it('retains the last validated body when an edit breaks frontmatter boundaries', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fs.writeFileSync(bodyPath, 'not valid agentmd anymore\nReplacement instruction.\n');
+
+    await expect(scheduler.triggerJob('body-drift-probe', 'test')).resolves.toBe('triggered');
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('valid frontmatter boundaries');
+    expect(sessionManager._lastSpawnArgs?.prompt).toContain('Original cached instruction.');
+    expect(sessionManager._lastSpawnArgs?.prompt).not.toContain('Replacement instruction.');
   });
 });

--- a/upgrades/next/agentmd-body-live-refresh.md
+++ b/upgrades/next/agentmd-body-live-refresh.md
@@ -1,0 +1,24 @@
+<!-- bump: patch -->
+
+## What Changed
+
+AgentMD job bodies are now revalidated and refreshed at each trigger boundary.
+Valid edits affect the triggering run without a server restart; invalid edits
+retain the last validated instructions.
+
+## What to Tell Your User
+
+- **Live job instruction edits**: "When I update a job's markdown instructions, the next run uses them without restarting the server."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|---|---|
+| Apply a job-body edit to the next run | Save a valid AgentMD markdown body; the scheduler refreshes it automatically |
+| Fail safely on broken edits | Repair the file after the scheduler warns; the last validated body remains active meanwhile |
+
+## Evidence
+
+Ninety-three focused scheduler and loader tests cover live first and subsequent
+edits, unchanged bodies, missing files, malformed frontmatter, prompt dispatch,
+run-history hashing, and loader validation.

--- a/upgrades/side-effects/agentmd-body-live-refresh.md
+++ b/upgrades/side-effects/agentmd-body-live-refresh.md
@@ -1,0 +1,32 @@
+# Side-effect review — AgentMD body live refresh
+
+## Changed boundary
+
+The existing trigger-time body drift probe now returns the validated body as
+well as its hash. `JobScheduler` replaces only `JobDefinition.body` before the
+trigger continues, so the prompt and run-history hash share one validated value.
+
+## Expected effects
+
+- A valid markdown body edit affects the next eligible invocation without a
+  server restart.
+- Repeated triggers with unchanged content do no mutation and emit no reload
+  message.
+- A later valid edit replaces the prior validated body.
+
+## Failure and safety behavior
+
+- Missing, non-regular, symbolic-link, oversized, or malformed files never
+  replace the last validated prompt.
+- Invalid disk states keep the existing deduplicated warning behavior.
+- Frontmatter and schedule metadata are not hot-reloaded; their existing
+  manifest authority and startup lifecycle are unchanged.
+- The synchronous read stays bounded by the existing AgentMD total/body byte
+  caps and occurs only at a job trigger boundary.
+
+## Class-closure declaration
+
+This is an instance of generated-artifact path/contract drift: the disk reader
+proved a new body existed while the execution consumer stayed on its boot copy.
+`tests/unit/scheduler/JobScheduler.body-drift.test.ts` closes the class at the
+consumer seam by proving valid edits reach prompts and invalid edits cannot.


### PR DESCRIPTION
## ELI16 — Edited job instructions reach the next run

AgentMD job bodies were loaded once when the scheduler started. The scheduler
could notice a later file edit, but it only warned and then deliberately ran the
old instructions. That made a successful edit and an ignored edit look nearly
the same from outside. At each trigger boundary, the scheduler now re-reads and
validates the body. A valid edit becomes the prompt for that run; an invalid,
missing, oversized, or symlinked file leaves the last validated prompt in place
and produces the existing deduplicated warning.

## What changed

- Extend the existing body-hash probe to return the validated body.
- Refresh only `JobDefinition.body` before the trigger continues.
- Keep schedule and frontmatter authority boot-loaded and unchanged.
- Align run-history wording and tests with the body actually used for the run.

## UX Impact

Saving a valid AgentMD instruction edit now affects the next eligible run without a server restart. Broken edits fail safe to the last known-good instructions and remain visible through a warning.

## Validation

- 93 focused scheduler and loader tests passed.
- Full TypeScript build passed.
- Full lint passed.
- Pre-push enumeration reached its guarded timeout and correctly deferred the authoritative full run to CI.

## Side effects

The synchronous trigger-time read is bounded by existing AgentMD file/body caps. It does not hot-reload schedules, enablement, tools, or any other frontmatter authority.
