### PR TITLE
Surface green-PR namespace mismatch

### DIFF
--- a/.instar/instar-dev-decisions/2026-07-31T22-48-26-200Z-green-pr-namespace-visibility.json
+++ b/.instar/instar-dev-decisions/2026-07-31T22-48-26-200Z-green-pr-namespace-visibility.json
@@ -1,0 +1,35 @@
+{
+  "ts": "2026-07-31T22:48:26.200Z",
+  "slug": "green-pr-namespace-visibility",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 124,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/config/ConfigDefaults.ts",
+      "src/core/types.ts",
+      "src/monitoring/GreenPrAutoMerger.ts",
+      "src/monitoring/greenPrAutomergeWiring.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 118,
+    "deletedLines": 6
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The watcher conflated project identity with branch ownership and collapsed a populated but entirely out-of-namespace authored PR list into the same result as an empty repository."
+  },
+  "classClosure": {
+    "defectClass": "unknown-classification-fail-open",
+    "closure": "tests/unit/green-pr-automerger.test.ts and tests/integration/green-pr-automerge-routes.test.ts",
+    "reason": "Tests now distinguish idle from namespace mismatch, assert recovery, and expose both configuration and live mismatch state through the production status route.",
+    "component": "GreenPrAutoMerger"
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/green-pr-namespace-visibility.eli16.md
+++ b/docs/eli16/green-pr-namespace-visibility.eli16.md
@@ -1,0 +1,17 @@
+# ELI16 — The PR watcher explains when its branch prefix cannot match
+
+The green-PR watcher looks only at pull requests authored by the authenticated
+GitHub account, then narrows that list to branches owned by one agent prefix.
+Until now that prefix was silently borrowed from the project name. An agent
+named `instar-codey` that consistently creates `agent/...` branches would see
+open PRs, reject every one, and report the same result as an empty repository.
+An empty expected GitHub login made it inert for a second silent reason.
+
+The branch prefix is now an explicit optional setting, separate from project
+identity. Existing installations retain their project-name fallback. When an
+authored open-PR list is non-empty but every branch falls outside the configured
+prefix, the watcher records a mismatch episode, raises its existing aggregate
+attention signal, exposes examples in status, and a manual tick returns
+`namespace-mismatch`. Missing GitHub identity now refuses watcher startup with
+a named configuration issue. This change does not enable the watcher or grant
+merge authority; the existing PIN-gated enablement decision remains unchanged.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -19492,7 +19492,10 @@ export async function startServer(options: StartOptions): Promise<void> {
         const wiring = await import('../monitoring/greenPrAutomergeWiring.js');
         if (wiring.isAnalyzableGreenPrRepo(repoPath, safeMergePath)) {
           const gpMachineId = coordinator.identity?.machineId ?? `m_host_${os.hostname()}`;
-          const agentNamespace = config.projectName || 'agent';
+          const agentNamespace = wiring.resolveGreenPrAgentNamespace(
+            gpCfg.agentNamespace,
+            config.projectName,
+          );
           const wiringOpts = {
             repoPath, safeMergePath, stateDir: config.stateDir, machineId: gpMachineId,
             repo: 'JKHeadley/instar', agentNamespace,
@@ -19534,12 +19537,14 @@ export async function startServer(options: StartOptions): Promise<void> {
             // (the class deep-merges its defaults — enabled:true, redThresholdMs:2h).
             redPrWatchdog: (gpCfg as { redPrWatchdog?: { enabled?: boolean; redThresholdMs?: number } }).redPrWatchdog,
           } as never);
-          if (greenPrAutoMerger.invariantOk) {
+          if (greenPrAutoMerger.invariantOk && greenPrAutoMerger.configurationOk) {
             guardLatchStore.markPoolArmed(); // R7: this pool is deliberately armed
             greenPrAutoMerger.start();
             console.log(pc.green('  GreenPrAutoMerger enabled (auto-merges green self-authored PRs — Phase 7 machinery)'));
-          } else {
+          } else if (!greenPrAutoMerger.invariantOk) {
             console.log(pc.red(`  GreenPrAutoMerger NOT started — timeout invariant violated: ${greenPrAutoMerger.invariantReason}`));
+          } else {
+            console.log(pc.red(`  GreenPrAutoMerger NOT started — configuration invalid: ${greenPrAutoMerger.configurationIssues.join(', ')}`));
           }
         } else {
           console.log(pc.dim('  GreenPrAutoMerge enabled in config but no analyzable instar repo + safe-merge found — staying inert'));

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -768,6 +768,10 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       breakerCooldownMin: 60,
       mergeTimeoutMs: 1_500_000,
       mergeKillGraceMs: 60_000,
+      // Explicit branch prefix owned by the watcher. Empty preserves the
+      // historical projectName fallback; development agents should set this
+      // to the prefix their worktree workflow actually creates.
+      agentNamespace: '',
       expectedGhLogin: '',
       identityRecheckTicks: 6,
       holdReleaseTicks: 2,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6766,6 +6766,8 @@ export interface MonitoringConfig {
     breakerCooldownMin?: number;
     mergeTimeoutMs?: number;
     mergeKillGraceMs?: number;
+    /** Branch prefix owned by this watcher (for example "agent"). Defaults to projectName for compatibility. */
+    agentNamespace?: string;
     /** The agent's verified gh login (R4 identity contract). Unset → inert. */
     expectedGhLogin?: string;
     identityRecheckTicks?: number;

--- a/src/monitoring/GreenPrAutoMerger.ts
+++ b/src/monitoring/GreenPrAutoMerger.ts
@@ -169,6 +169,15 @@ export interface GreenPrState {
   identity?: { login: string | null; resolvedAt: number };
   /** Episodes that gave up (surfaced via attention), for the aggregate. */
   attentionLines?: string[];
+  /** Current episode where authored PRs exist but none use this watcher namespace. */
+  namespaceMismatch?: {
+    firstSeenAt: number;
+    lastSeenAt: number;
+    namespace: string;
+    openPrCount: number;
+    sampleBranches: string[];
+    fingerprint: string;
+  };
   /**
    * red-pr-watchdog per-PR "already-raised" memory. Keyed by PR number. Present
    * ⇔ we have surfaced this stuck-red PR; re-raised only when the elapsed-hours
@@ -270,6 +279,8 @@ export class GreenPrAutoMerger extends EventEmitter {
   /** Resolved at boot: does the timeout invariant hold? */
   readonly invariantOk: boolean;
   readonly invariantReason?: string;
+  readonly configurationOk: boolean;
+  readonly configurationIssues: string[];
 
   constructor(
     private readonly deps: GreenPrAutoMergerDeps,
@@ -302,6 +313,10 @@ export class GreenPrAutoMerger extends EventEmitter {
     );
     this.invariantOk = inv.ok;
     this.invariantReason = inv.reason;
+    this.configurationIssues = [];
+    if (!this.cfg.agentNamespace.trim()) this.configurationIssues.push('agentNamespace is empty');
+    if (!this.cfg.expectedGhLogin.trim()) this.configurationIssues.push('expectedGhLogin is empty');
+    this.configurationOk = this.configurationIssues.length === 0;
   }
 
   start(): void {
@@ -309,6 +324,14 @@ export class GreenPrAutoMerger extends EventEmitter {
     if (!this.invariantOk) {
       // Boot refusal must be LOUD (B24) — never start with an inverted invariant.
       this.deps.audit({ kind: 'green-pr-automerge', event: 'boot-refused-invariant', reason: this.invariantReason });
+      return;
+    }
+    if (!this.configurationOk) {
+      this.deps.audit({
+        kind: 'green-pr-automerge',
+        event: 'boot-refused-configuration',
+        issues: this.configurationIssues,
+      });
       return;
     }
     // Warm-up + orphan reap happens on the first acting tick.
@@ -321,6 +344,20 @@ export class GreenPrAutoMerger extends EventEmitter {
   }
 
   snapshot(): GreenPrState { return this.deps.loadState(); }
+
+  configurationView(): {
+    ok: boolean;
+    issues: string[];
+    agentNamespace: string;
+    identityConfigured: boolean;
+  } {
+    return {
+      ok: this.configurationOk,
+      issues: [...this.configurationIssues],
+      agentNamespace: this.cfg.agentNamespace,
+      identityConfigured: this.cfg.expectedGhLogin.length > 0,
+    };
+  }
 
   /**
    * The /hold route's handler (R3): validate the PR is open + in this agent's
@@ -425,6 +462,7 @@ export class GreenPrAutoMerger extends EventEmitter {
     // Build the candidate set (cheap fields) + the Layer-2 snapshot.
     const { eligible, snapshotEntries } = await this.gather(candidates, state);
     state.snapshot = { at: this.deps.now(), entries: snapshotEntries };
+    const namespaceMismatch = await this.observeNamespaceMismatch(candidates, state);
 
     // Red-PR watchdog (red-pr-watchdog): surface my own PRs stuck RED past the
     // threshold. Runs on every acting/warm-up tick that got a fresh PR list —
@@ -453,7 +491,7 @@ export class GreenPrAutoMerger extends EventEmitter {
     const target = selectOldest(eligible);
     if (!target) {
       this.deps.saveState(state);
-      return { acted: false, reason: 'no-candidate' };
+      return { acted: false, reason: namespaceMismatch ? 'namespace-mismatch' : 'no-candidate' };
     }
 
     // Act (Step 4 engine). dryRun observes only.
@@ -527,6 +565,56 @@ export class GreenPrAutoMerger extends EventEmitter {
       snapshotEntries.push({ pr: pr.number, headRefName: pr.headRefName, headRefOid: pr.headRefOid, kind: 'mergeable' });
     }
     return { eligible, snapshotEntries };
+  }
+
+  /**
+   * Make an authored-but-out-of-namespace list distinguishable from an idle
+   * repository. One audit/attention line is emitted per distinct mismatch
+   * episode; the live state clears as soon as the configured prefix matches.
+   */
+  private async observeNamespaceMismatch(
+    prs: PrSummary[],
+    state: GreenPrState,
+  ): Promise<boolean> {
+    const outside = prs.filter((pr) => !headInNamespace(pr.headRefName, this.cfg.agentNamespace));
+    const mismatched = prs.length > 0 && outside.length === prs.length;
+    if (!mismatched) {
+      if (state.namespaceMismatch) {
+        this.deps.audit({
+          kind: 'green-pr-automerge',
+          event: 'namespace-mismatch-recovered',
+          namespace: state.namespaceMismatch.namespace,
+        });
+        delete state.namespaceMismatch;
+      }
+      return false;
+    }
+
+    const sampleBranches = outside.map((pr) => pr.headRefName).sort().slice(0, 5);
+    const fingerprint = `${this.cfg.agentNamespace}\u0000${sampleBranches.join('\u0000')}`;
+    const prior = state.namespaceMismatch;
+    state.namespaceMismatch = {
+      firstSeenAt: prior?.firstSeenAt ?? this.deps.now(),
+      lastSeenAt: this.deps.now(),
+      namespace: this.cfg.agentNamespace,
+      openPrCount: prs.length,
+      sampleBranches,
+      fingerprint,
+    };
+    if (prior?.fingerprint !== fingerprint) {
+      this.deps.audit({
+        kind: 'green-pr-automerge',
+        event: 'namespace-mismatch',
+        namespace: this.cfg.agentNamespace,
+        openPrCount: prs.length,
+        sampleBranches,
+      });
+      await this.refreshAggregate(state, [
+        `configuration:branch-namespace-mismatch — saw ${prs.length} authored open PR(s), ` +
+        `but none starts with ${this.cfg.agentNamespace}/ (examples: ${sampleBranches.join(', ')})`,
+      ]);
+    }
+    return true;
   }
 
   // ---- act ----------------------------------------------------------------
@@ -862,8 +950,8 @@ export class GreenPrAutoMerger extends EventEmitter {
    * SET changes. A PR that recovers (no stuck-red checks) or leaves the open list
    * (merged/closed) has its memory cleared (Close the Loop).
    *
-   * "My own" is the branch-namespace filter (a pure proxy for author — listOpenPrs
-   * already passes `--author @me`, and PrSummary carries no author field).
+   * `listOpenPrs` establishes authorship with `--author @me`; the namespace
+   * filter is the separately configurable ownership scope for this watcher.
    */
   private redPrWatchdogPass(prs: PrSummary[], state: GreenPrState): void {
     const wd = this.cfg.redPrWatchdog;

--- a/src/monitoring/greenPrAutomergeWiring.ts
+++ b/src/monitoring/greenPrAutomergeWiring.ts
@@ -118,6 +118,16 @@ export interface GreenPrWiringOpts {
   githubRuntime?: () => AuthenticatedGitHubCliRuntime;
 }
 
+/** Resolve the watcher-owned branch prefix without conflating it with identity. */
+export function resolveGreenPrAgentNamespace(
+  configured: unknown,
+  projectName: unknown,
+): string {
+  if (typeof configured === 'string' && configured.trim()) return configured.trim();
+  if (typeof projectName === 'string' && projectName.trim()) return projectName.trim();
+  return 'agent';
+}
+
 /** Build the GuardLatchStore for this install. */
 export function buildGuardLatchStore(opts: GreenPrWiringOpts): GuardLatchStore {
   return new GuardLatchStore({

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -12355,6 +12355,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     // red-pr-watchdog: the stuck-red memory + config (answers "why did I get a
     // red-PR alert?"). NON-OPTIONAL — an EMPTY ARRAY when nothing is stuck red.
     const wd = ctx.greenPrAutoMerger.redPrWatchdogView();
+    const configuration = ctx.greenPrAutoMerger.configurationView();
     res.json({
       lastTickAt: state.lastTickAt ?? null,
       lastSuccessfulListAt: state.lastSuccessfulListAt ?? null,
@@ -12366,6 +12367,8 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       stuckRed: wd.stuckRed,
       redPrWatchdog: wd.config,
       snapshot: state.snapshot,
+      namespaceMismatch: state.namespaceMismatch ?? null,
+      configuration,
       gate: latch,
       invariantOk: ctx.greenPrAutoMerger.invariantOk,
     });

--- a/tests/integration/green-pr-automerge-routes.test.ts
+++ b/tests/integration/green-pr-automerge-routes.test.ts
@@ -99,6 +99,13 @@ describe('green-pr-automerge routes (integration)', () => {
     expect(res.body.gate).toBeTruthy();
     expect(res.body.gate.mergeAllowed).toBe(true);
     expect(res.body.invariantOk).toBe(true);
+    expect(res.body.configuration).toEqual({
+      ok: true,
+      issues: [],
+      agentNamespace: 'echo',
+      identityConfigured: true,
+    });
+    expect(res.body.namespaceMismatch).toBeNull();
   });
 
   it('rollback (Bearer) closes the gate; GET reflects it; PIN-gated enable re-arms', async () => {

--- a/tests/unit/green-pr-automerge-wiring.test.ts
+++ b/tests/unit/green-pr-automerge-wiring.test.ts
@@ -16,7 +16,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
-import { buildGreenPrDeps, buildGuardLatchStore, type GreenPrWiringOpts } from '../../src/monitoring/greenPrAutomergeWiring.js';
+import { buildGreenPrDeps, buildGuardLatchStore, resolveGreenPrAgentNamespace, type GreenPrWiringOpts } from '../../src/monitoring/greenPrAutomergeWiring.js';
 import { DefaultMergeRunner } from '../../src/monitoring/MergeRunner.js';
 
 let dir: string;
@@ -116,6 +116,17 @@ describe('buildGreenPrDeps — config-threading (M2)', () => {
     const runner = deps.runner as DefaultMergeRunner;
     expect(runner.resolvedStrategy).toBe('auto');
     expect(runner.resolvedArmTimeoutMs).toBe(60_000);
+  });
+});
+
+describe('resolveGreenPrAgentNamespace', () => {
+  it('prefers the explicit watcher prefix over project identity', () => {
+    expect(resolveGreenPrAgentNamespace('agent', 'instar-codey')).toBe('agent');
+  });
+
+  it('preserves the project-name fallback for existing installs', () => {
+    expect(resolveGreenPrAgentNamespace('', 'echo')).toBe('echo');
+    expect(resolveGreenPrAgentNamespace(undefined, undefined)).toBe('agent');
   });
 });
 

--- a/tests/unit/green-pr-automerger.test.ts
+++ b/tests/unit/green-pr-automerger.test.ts
@@ -149,6 +149,32 @@ describe('GreenPrAutoMerger — acting (post warm-up)', () => {
     expect(r.reason).toBe('no-candidate');
     expect(h.runCalls.length).toBe(0);
   });
+
+  it('surfaces authored PRs when none use the configured namespace', async () => {
+    const h = harness({ prs: [pr({ number: 100, headRefName: 'agent/one' }), pr({ number: 101, headRefName: 'fix/two' })] });
+    prime(h);
+    const r = await new GreenPrAutoMerger(h.deps, cfg).tick();
+    expect(r.reason).toBe('namespace-mismatch');
+    expect(h.state.namespaceMismatch).toMatchObject({ namespace: 'echo', openPrCount: 2 });
+    expect(h.audits.some((a) => a.event === 'namespace-mismatch')).toBe(true);
+    expect(h.attentionLines.flat().some((line) => /branch-namespace-mismatch/.test(line))).toBe(true);
+  });
+
+  it('clears the live mismatch when a namespaced PR appears', async () => {
+    const h = harness({ prs: [pr({ number: 100, headRefName: 'echo/one', labels: ['hold'] })] });
+    prime(h);
+    h.state.namespaceMismatch = {
+      firstSeenAt: 1,
+      lastSeenAt: 1,
+      namespace: 'echo',
+      openPrCount: 1,
+      sampleBranches: ['agent/old'],
+      fingerprint: 'old',
+    };
+    await new GreenPrAutoMerger(h.deps, cfg).tick();
+    expect(h.state.namespaceMismatch).toBeUndefined();
+    expect(h.audits.some((a) => a.event === 'namespace-mismatch-recovered')).toBe(true);
+  });
 });
 
 describe('GreenPrAutoMerger — identity contract (R4)', () => {
@@ -495,5 +521,17 @@ describe('GreenPrAutoMerger — boot invariant', () => {
     // armTimeoutMs(60k) + grace(60k) = 120k — well under budget → not inverted.
     const m = new GreenPrAutoMerger(h.deps, { ...cfg, busySkipBreakerThreshold: 2 });
     expect(m.invariantOk).toBe(true);
+  });
+
+  it('makes an empty expected GitHub login a loud configuration refusal', () => {
+    const h = harness();
+    const m = new GreenPrAutoMerger(h.deps, { ...cfg, expectedGhLogin: '' });
+    expect(m.configurationView()).toMatchObject({
+      ok: false,
+      identityConfigured: false,
+      agentNamespace: 'echo',
+    });
+    m.start();
+    expect(h.audits.some((a) => a.event === 'boot-refused-configuration')).toBe(true);
   });
 });

--- a/tests/unit/green-pr-red-watchdog.test.ts
+++ b/tests/unit/green-pr-red-watchdog.test.ts
@@ -223,11 +223,14 @@ describe('redPrWatchdogPass — orchestrator', () => {
     expect(h.state.redPrRaised?.[1399]).toBeUndefined();
   });
 
-  it('(f) a PR NOT authored by me (out of namespace) is skipped even if stuck red', async () => {
+  it('(f) an out-of-namespace PR is skipped by the red watchdog while the namespace mismatch stays visible', async () => {
     const h = harness([redPr({ headRefName: 'dawn/other' })]);
     await new GreenPrAutoMerger(h.deps, cfg).tick();
-    expect(h.attentionCalls).toHaveLength(0);
+    expect(h.attentionCalls).toHaveLength(1);
+    expect(h.attentionCalls[0].some((line) => /branch-namespace-mismatch/.test(line))).toBe(true);
+    expect(h.attentionCalls[0].some((line) => /PR #1399 red/.test(line))).toBe(false);
     expect(h.state.redPrRaised?.[1399]).toBeUndefined();
+    expect(h.audits.some((audit) => audit.event === 'red-pr-stuck')).toBe(false);
   });
 
   it('clears the raise memory when the PR recovers (goes green)', async () => {

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -426,16 +426,19 @@ describe('lint-dev-agent-dark-gate', () => {
       // line below it DOWN by +4. Path SET unchanged (still 25 entries, same dotted
       // paths); RE-VERIFIED via attributeEnabledFalsePaths on the edited
       // ConfigDefaults (uniform +4 shift, no new/removed entries).
-      '814': 'threadline.a2aCheckIn.enabled',
-      '945': 'mentor.enabled',
+      // greenPrAutoMerge.agentNamespace adds an explicit four-line namespace
+      // default/comment below that block's own dark `enabled` row. It adds no
+      // `enabled: false` literal, so every later attribution shifts by +4.
+      '818': 'threadline.a2aCheckIn.enabled',
+      '949': 'mentor.enabled',
       // mentor.visibleEcho is a fleet-on child setting under the existing dark
       // mentor gate. It adds no `enabled: false` row and shifts every later
       // attribution down by one; the hand-audited dotted-path set is unchanged.
-      '957': 'mentor.autonomousFix.enabled',
-      '972': 'mentee.enabled',
+      '961': 'mentor.autonomousFix.enabled',
+      '976': 'mentee.enabled',
       // evolutionActions.autoExpiry adds a 10-line fleet-on/dry-run-first block;
       // no dark row is added, and every later attribution shifts by +10.
-      '1042': 'prGate.classClosure.enabled',
+      '1046': 'prGate.classClosure.enabled',
       // +21 lines below: spec #3's multiMachine.seamlessOrchestrator dev-gated
       // sub-block (docs/specs/llm-seamlessness-orchestrator.md) was inserted at the
       // TOP of the multiMachine block; it OMITS `enabled` (rides resolveDevAgentGate),
@@ -444,17 +447,17 @@ describe('lint-dev-agent-dark-gate', () => {
       // multiMachine. It has no `enabled: false` literal and therefore shifts
       // every subsequent attribution without changing the audited path set.
       // ACT-897 peerExecution adds an 8-line dev-gated dry-run block.
-      '1146': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
-      '1150': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
-      '1157': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
-      '1167': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
-      '1404': 'multiMachine.sessionPool.enabled',
+      '1150': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
+      '1154': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
+      '1161': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
+      '1171': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
+      '1408': 'multiMachine.sessionPool.enabled',
       // #1367's moveIntent dev-gated sub-block was inserted under sessionPool
       // (docs/specs/nickname-move-intent-llm-rebuild.md); it OMITS `enabled` (rides
       // resolveDevAgentGate), adds no map row, and shifts the subsequent lines.
-      '1455': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
-      '1465': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '1494': 'multiMachine.sessionPool.holdForStability.enabled',
+      '1459': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
+      '1469': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '1498': 'multiMachine.sessionPool.holdForStability.enabled',
       // replicated-journal-compaction adds a 5-line compaction default block
       // above stateSync. It uses `run:false` (not an `enabled` gate), so the
       // attributed path set is unchanged and the four rows below shift by +5.
@@ -468,7 +471,7 @@ describe('lint-dev-agent-dark-gate', () => {
       // +32 lines, no `enabled:` literals) shift the cartographer rows below.
       // +15 below the #1561 baseline: this row is BELOW the failoverRunner insert,
       // so it carries both the +10 (missingLogin) and +15 (failoverRunner) shifts.
-      '1755': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1759': 'multiMachine.stateSync.threadlinePairing.enabled',
       // commitment-auto-expiry (2026-07-10): a 6-line `commitments.autoExpiry`
       // default sub-block was inserted above `promiseBeacon`/`cartographer`.
       // Its `enabled: true` literal is an explicit fleet-on default, not a dark
@@ -478,9 +481,9 @@ describe('lint-dev-agent-dark-gate', () => {
       // existing promiseBeacon block. It adds NO `enabled: false` dark-gate row,
       // so only the three cartographer rows below it shift DOWN by +1.
       // Below the failoverRunner insert → both +10 (missingLogin) and +15 shifts.
-      '1935': 'cartographer.freshnessSweep.enabled',
-      '1980': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '2005': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1939': 'cartographer.freshnessSweep.enabled',
+      '1984': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '2009': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/upgrades/next/green-pr-namespace-visibility.md
+++ b/upgrades/next/green-pr-namespace-visibility.md
@@ -1,0 +1,24 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The green-PR watcher now supports an explicit branch namespace and makes
+authored-but-out-of-namespace pull requests visible instead of reporting an
+ordinary empty candidate set. Missing GitHub identity is a loud startup refusal.
+
+## What to Tell Your User
+
+- **Honest auto-merge readiness**: "The PR watcher now tells me when its configured branch prefix cannot match my authored PRs, and it refuses loudly if GitHub identity is missing."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|---|---|
+| Align watcher ownership with branch conventions | Set the optional agentNamespace field under greenPrAutoMerge |
+| Diagnose an empty candidate set | Read configuration and namespaceMismatch from green-pr-automerge status |
+
+## Evidence
+
+Sixty-two focused unit and integration tests cover explicit and fallback
+namespace resolution, mismatch and recovery episodes, configuration refusal,
+tick results, attention/audit output, and the authenticated GitHub wiring.

--- a/upgrades/side-effects/green-pr-namespace-visibility.md
+++ b/upgrades/side-effects/green-pr-namespace-visibility.md
@@ -1,0 +1,35 @@
+# Side-effect review — green-PR namespace visibility
+
+## Changed boundary
+
+The watcher branch namespace is now resolved from
+`monitoring.greenPrAutoMerge.agentNamespace`, with the historical project-name
+and `agent` fallbacks preserved. Authorship remains established by the existing
+GitHub `--author @me` list query; the namespace is explicitly an ownership
+scope, not an identity proxy.
+
+## Expected effects
+
+- An enabled watcher with an empty expected GitHub login refuses startup and
+  records the exact configuration issue.
+- A non-empty authored PR list with zero namespace matches produces a live
+  `namespaceMismatch` status episode, a transition audit, one aggregate
+  attention line, and the `namespace-mismatch` tick result.
+- The episode clears as soon as the authored list is empty or any authored PR
+  uses the configured prefix; recovery is audited.
+
+## Authority and notification behavior
+
+- No configuration default enables auto-merge.
+- The PIN-gated re-arm path and all safe-merge, lease, latch, identity, hold,
+  protected-path, and CI gates are unchanged.
+- The mismatch path is signal-only and can never merge, close, label, or edit a
+  PR. Aggregate attention is deduplicated by mismatch fingerprint.
+- Existing installs with no explicit prefix keep their project-name behavior.
+
+## Class-closure declaration
+
+This is an unknown-classification/fail-open observability instance: a populated
+input set collapsed into the same `no-candidate` output as an empty input set.
+The watcher test now exercises both sides and the status route exposes the live
+configuration and mismatch state.


### PR DESCRIPTION
## ELI16 — The PR watcher explains a branch-prefix mismatch

The watcher already lists pull requests authored by the authenticated GitHub
account, then narrows them to one owned branch prefix. That prefix was silently
borrowed from the project name, so an `instar-codey` install creating `agent/*`
branches could see several authored PRs, reject all of them, and report exactly
the same result as an empty repository. The prefix is now separately
configurable, and a non-empty authored list with zero prefix matches becomes a
named, auditable mismatch episode with branch examples and status visibility.

## What changed

- Add optional `monitoring.greenPrAutoMerge.agentNamespace`, preserving the historical project-name fallback.
- Refuse watcher startup loudly when namespace or expected GitHub login is empty.
- Persist, audit, and surface authored-but-out-of-namespace episodes; clear the live episode on recovery.
- Correct the source comment: `--author @me` proves authorship, while namespace is a separate ownership scope.

## UX Impact

Who sees it: the operator of an enabled green-PR watcher. User-visible
behavior: status now exposes `namespaceMismatch` with the configured namespace,
count, and branch samples instead of looking idle. First contact: the existing
aggregate attention surface receives one deduplicated
`configuration:branch-namespace-mismatch` line when authored PRs exist but none
match the watcher prefix.

## Validation

- 62 focused unit and integration tests passed.
- Full TypeScript build passed.
- Full lint passed.
- Pre-push enumeration reached its guarded timeout and correctly deferred the authoritative full run to CI.

## Side effects

This does not enable auto-merge or weaken any merge gate. PIN-gated enablement, safe-merge, identity, lease, latch, hold, protected-path, and CI checks are unchanged; the new mismatch path is signal-only.
