### PR TITLE
Derive project round status from member evidence

### DIFF
--- a/.claude/skills/instar-project/SKILL.md
+++ b/.claude/skills/instar-project/SKILL.md
@@ -91,7 +91,10 @@ curl -sS -H "Authorization: Bearer $AUTH" \
 - `200 {action, params, skillCommand}` — `action` is one of
   `await-user-approval`, `ack-required`, `resolve-conflict`,
   `accept-partial`, `run-spec-converge`, `run-drift-check`,
-  `start-round`. `skillCommand` is a suggested `/project ...` (or
+  `repair-merge-evidence`, `start-round`. `repair-merge-evidence` means a
+  historical item says `merged` but lacks the PR/commit/check evidence needed
+  to support that conclusion; advance it to `merged` again with the PR artifact
+  to re-attest it without re-running the work. `skillCommand` is a suggested `/project ...` (or
   `/spec-converge`) invocation. `params.roundIndex`, `params.itemIds`,
   `params.status` are the round context.
 - `204` — every round is complete.
@@ -113,6 +116,11 @@ spec file at `docs/specs/`, `spec-converged → approved` requires
 `approved: true` in frontmatter, `approved → building` needs a
 TaskFlow record id, `building → merged` confirms the PR is MERGED
 and its `mergeCommit.oid` is reachable from `origin/main`.
+
+A same-stage `merged → merged` request is allowed only for a historical
+`merged` row whose evidence is incomplete. It runs the full merge validator
+again and atomically attaches the verified evidence; it does not redo the
+feature or fabricate missing fields.
 
 ```bash
 PROJECT_ID=...

--- a/.instar/instar-dev-decisions/2026-08-01T00-28-55-888Z-project-round-evidence-derivation.json
+++ b/.instar/instar-dev-decisions/2026-08-01T00-28-55-888Z-project-round-evidence-derivation.json
@@ -1,0 +1,34 @@
+{
+  "ts": "2026-08-01T00:28:55.888Z",
+  "slug": "project-round-evidence-derivation",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 278,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/ProjectRoundDerivation.ts",
+      "src/core/ProjectRoundExecution.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 228,
+    "deletedLines": 50
+  },
+  "causalAutopsy": {
+    "origin": "prior-pr",
+    "relatedPrs": [
+      1651
+    ],
+    "notes": "PR #1651 fixed evidence persistence for new merge transitions but left two adjacent consumers trusting cached conclusions: /next selected rounds by stored status, and the lazy integrity reader selected building rather than evidence-bearing merged rows. Historical pre-fix rows therefore still looked runnable while lacking proof."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "This change narrows an existing round runner's respawn behavior and adds no self-triggered action."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-01T00-47-30-819Z-project-round-evidence-derivation.json
+++ b/.instar/instar-dev-decisions/2026-08-01T00-47-30-819Z-project-round-evidence-derivation.json
@@ -1,0 +1,29 @@
+{
+  "ts": "2026-08-01T00:47:30.819Z",
+  "slug": "project-round-evidence-derivation",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 4,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/ProjectRoundExecution.ts"
+    ],
+    "addedLines": 4,
+    "deletedLines": 0
+  },
+  "causalAutopsy": {
+    "origin": "new-code",
+    "notes": "The first derivation patch let incomplete historical metadata outrank a definitive git regression and left older merged fixtures below the new three-field evidence floor. The amendment restores verdict precedence and makes the established fixtures express the full contract."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "This amendment narrows an existing runner refusal and adds no self-triggered action."
+  },
+  "verdict": "pass"
+}

--- a/docs/eli16/project-round-evidence-derivation.eli16.md
+++ b/docs/eli16/project-round-evidence-derivation.eli16.md
@@ -1,0 +1,33 @@
+# Project rounds now have to prove they are done
+
+The project tracker has two layers of state. Each individual work item says what
+stage it reached, while the containing round also stores a summary such as
+`pending` or `complete`. Those two layers could disagree. In particular, an old
+round could remain `pending` after every item merged, and the “what should I do
+next?” endpoint trusted that stale summary. It could therefore recommend
+starting the round again.
+
+There was a second, subtler problem in older data. Before the merge-evidence fix
+landed, some item rows were labeled `merged` but did not retain the PR number,
+merge commit, or the time at which the merge and CI were verified. Treating
+those labels as proof would make completion too easy; treating them as ordinary
+unfinished work would risk building an already-completed feature twice.
+
+This change makes item evidence the source of truth. A round is derived as
+complete only when every member is either explicitly skipped or is merged with
+all three evidence fields. The round’s stored status remains a cache for
+workflow details, but it cannot overrule the members. Project reads show the
+derived status, and the next-action endpoint skips rounds that have genuinely
+earned completion.
+
+If an old item says `merged` without its evidence, the tracker returns a
+specific repair action instead of `start-round`. Repair uses the existing
+advance endpoint: supplying the PR re-runs the full GitHub, canonical-main, and
+CI validation and attaches the resulting evidence atomically. Nothing is
+guessed and the feature is not rebuilt. The autonomous runner has the same
+defense, so directly invoking it cannot bypass the safer next-action result.
+
+The intended outcome is simple: cached summaries can no longer create work or
+erase proof. New merge transitions keep their evidence as before, old rows have
+an honest repair path, and a project round’s conclusion is always traceable to
+the records of its members.

--- a/docs/eli16/project-round-evidence-derivation.eli16.md
+++ b/docs/eli16/project-round-evidence-derivation.eli16.md
@@ -26,6 +26,9 @@ advance endpoint: supplying the PR re-runs the full GitHub, canonical-main, and
 CI validation and attaches the resulting evidence atomically. Nothing is
 guessed and the feature is not rebuilt. The autonomous runner has the same
 defense, so directly invoking it cannot bypass the safer next-action result.
+If git definitively proves a recorded commit is no longer on the main branch,
+that stronger negative verdict still permits repair work to run; missing old
+metadata never hides a real regression.
 
 The intended outcome is simple: cached summaries can no longer create work or
 erase proof. New merge transitions keep their evidence as before, old rows have

--- a/src/core/ProjectRoundDerivation.ts
+++ b/src/core/ProjectRoundDerivation.ts
@@ -1,0 +1,106 @@
+/**
+ * Derive a project's round state from its member records.
+ *
+ * `InitiativeRound.status` is a cached conclusion. The child initiatives are
+ * the evidence-bearing source of truth, so readers must not use that cache to
+ * decide whether work is complete (or whether it should be run again).
+ */
+
+import type {
+  Initiative,
+  InitiativeRound,
+  RoundStatus,
+} from './InitiativeTracker.js';
+
+export type MergedEvidenceField = 'prNumber' | 'mergeCommitOid' | 'ciCheckedAt';
+
+export interface ProjectRoundDerivation {
+  /** Status exposed to readers after reconciling the cached status with members. */
+  effectiveStatus: RoundStatus;
+  /** A terminal conclusion earned entirely from member state, when available. */
+  terminalStatus?: 'complete' | 'complete-with-skips';
+  /** Referenced child IDs absent from the tracker. */
+  missingMemberIds: string[];
+  /** Non-terminal members that still represent unfinished work. */
+  incompleteItemIds: string[];
+  /** `merged` claims whose record cannot identify what was verified. */
+  evidenceMissingByItem: Record<string, MergedEvidenceField[]>;
+}
+
+export function missingMergedEvidenceFields(
+  item: Pick<Initiative, 'prNumber' | 'mergeCommitOid' | 'ciCheckedAt'>,
+): MergedEvidenceField[] {
+  const missing: MergedEvidenceField[] = [];
+  if (!Number.isInteger(item.prNumber) || (item.prNumber ?? 0) <= 0) missing.push('prNumber');
+  if (
+    typeof item.mergeCommitOid !== 'string'
+    || !/^[0-9a-f]{7,64}$/i.test(item.mergeCommitOid.trim())
+  ) {
+    missing.push('mergeCommitOid');
+  }
+  if (
+    typeof item.ciCheckedAt !== 'string'
+    || !item.ciCheckedAt.trim()
+    || !Number.isFinite(Date.parse(item.ciCheckedAt))
+  ) {
+    missing.push('ciCheckedAt');
+  }
+  return missing;
+}
+
+export function hasCompleteMergedEvidence(
+  item: Pick<Initiative, 'prNumber' | 'mergeCommitOid' | 'ciCheckedAt'>,
+): boolean {
+  return missingMergedEvidenceFields(item).length === 0;
+}
+
+export function deriveProjectRound(
+  round: InitiativeRound,
+  childrenById: ReadonlyMap<string, Initiative>,
+): ProjectRoundDerivation {
+  const missingMemberIds: string[] = [];
+  const incompleteItemIds: string[] = [];
+  const evidenceMissingByItem: Record<string, MergedEvidenceField[]> = {};
+  let skippedCount = 0;
+
+  for (const itemId of round.itemIds ?? []) {
+    const item = childrenById.get(itemId);
+    if (!item) {
+      missingMemberIds.push(itemId);
+      continue;
+    }
+    if (item.pipelineStage === 'skipped') {
+      skippedCount += 1;
+      continue;
+    }
+    if (item.pipelineStage === 'merged') {
+      const missing = missingMergedEvidenceFields(item);
+      if (missing.length > 0) evidenceMissingByItem[itemId] = missing;
+      continue;
+    }
+    incompleteItemIds.push(itemId);
+  }
+
+  const hasMembers = (round.itemIds ?? []).length > 0;
+  const allMembersTerminal = hasMembers
+    && missingMemberIds.length === 0
+    && incompleteItemIds.length === 0
+    && Object.keys(evidenceMissingByItem).length === 0;
+  const terminalStatus = allMembersTerminal
+    ? (skippedCount > 0 ? 'complete-with-skips' : 'complete')
+    : undefined;
+
+  // A cached terminal conclusion whose members no longer support it has been
+  // invalidated. Other non-terminal workflow statuses remain useful hints.
+  const cachedWasTerminal = round.status === 'complete' || round.status === 'complete-with-skips';
+  const effectiveStatus: RoundStatus = terminalStatus
+    ?? (cachedWasTerminal ? 'regressed' : (round.status ?? 'pending'));
+
+  return {
+    effectiveStatus,
+    terminalStatus,
+    missingMemberIds,
+    incompleteItemIds,
+    evidenceMissingByItem,
+  };
+}

--- a/src/core/ProjectRoundExecution.ts
+++ b/src/core/ProjectRoundExecution.ts
@@ -179,6 +179,10 @@ export async function runRound(input: RunRoundInput, deps: RunRoundDeps): Promis
     ids.filter((id) => {
       const item = input.tracker.get(id);
       if (!item) return false;
+      // A real negative is a verdict, not an evidence gap. Git exit 1 proves
+      // the recorded commit is not on canonical main, so rerunning is allowed
+      // even when the stale row predates today's richer evidence fields.
+      if (v.regressed.has(id)) return false;
       // A plain pre-build item with no merge commit is ordinary unfinished
       // work. A row that already CLAIMS `merged` without the evidence behind
       // that claim is different: rerunning it could duplicate completed work.

--- a/src/core/ProjectRoundExecution.ts
+++ b/src/core/ProjectRoundExecution.ts
@@ -42,6 +42,7 @@ import { ProjectRoundWorktrees } from './ProjectRoundWorktrees.js';
 import { detectClaudePath } from './Config.js';
 import { SafeGitExecutor } from './SafeGitExecutor.js';
 import { withSyncOp } from './InFlightSyncOpMarker.js';
+import { hasCompleteMergedEvidence } from './ProjectRoundDerivation.js';
 
 /** Per-spec defaults. Tests dial both down to keep the suite fast. */
 export const DEFAULT_POLL_INTERVAL_MS = 60_000;
@@ -160,13 +161,14 @@ export async function runRound(input: RunRoundInput, deps: RunRoundDeps): Promis
   const maxResumeAttempts = input.maxResumeAttempts ?? DEFAULT_MAX_RESUME_ATTEMPTS;
   /**
    * The items that are GENUINELY uncheckable: absent from `verified` for a
-   * reason the runner could not establish, AND carrying a merge commit that
-   * says work may already have landed.
+   * reason the runner could not establish, AND whose structured state says
+   * work may already have landed (a merge commit, or a `merged` claim whose
+   * evidence is incomplete).
    *
-   * An item with no `mergeCommitOid` is also reported `unverifiable` by the
-   * git verifier, but that is not the same claim — it means nothing has landed
-   * yet, which is ordinary. Splitting on EVIDENCE rather than on the reason
-   * text keeps a reworded message from silently changing control flow.
+   * An ordinary pre-build item with no `mergeCommitOid` is also reported
+   * `unverifiable` by the git verifier, but that means nothing has landed yet.
+   * Splitting on structured state rather than the reason text keeps a reworded
+   * message from silently changing control flow.
    *
    * Defined once and used at BOTH decision points. The first draft of this
    * change inlined it at the pre-spawn check only, and the post-exit check
@@ -174,7 +176,15 @@ export async function runRound(input: RunRoundInput, deps: RunRoundDeps): Promis
    * still spawns.
    */
   const uncheckable = (ids: string[], v: MergedVerificationResult): string[] =>
-    ids.filter((id) => v.unverifiable.has(id) && Boolean(input.tracker.get(id)?.mergeCommitOid));
+    ids.filter((id) => {
+      const item = input.tracker.get(id);
+      if (!item) return false;
+      // A plain pre-build item with no merge commit is ordinary unfinished
+      // work. A row that already CLAIMS `merged` without the evidence behind
+      // that claim is different: rerunning it could duplicate completed work.
+      if (item.pipelineStage === 'merged' && !hasCompleteMergedEvidence(item)) return true;
+      return v.unverifiable.has(id) && Boolean(item.mergeCommitOid);
+    });
 
   const mergeBaseBranch = input.mergeBaseBranch ?? resolveCanonicalMainRef(input.targetRepoPath);
   const verifyMergedItems =
@@ -254,12 +264,6 @@ export async function runRound(input: RunRoundInput, deps: RunRoundDeps): Promis
 
       // Compute current stop condition: itemIds verified-merged.
       const verdict = await verifyMergedItems(lastItemIds);
-      if (lastItemIds.every((id) => verdict.verified.has(id))) {
-        outcome = 'complete';
-        mergedItemIds = [...lastItemIds];
-        break;
-      }
-
       // "I could not check" is not "not done" — but neither is it a reason to
       // stall a round that has simply not been worked yet.
       //
@@ -267,21 +271,26 @@ export async function runRound(input: RunRoundInput, deps: RunRoundDeps): Promis
       //   (a) the item records no mergeCommitOid at all — nothing has landed
       //       yet, which is the ordinary state of a fresh round. Spawning is
       //       exactly right here.
-      //   (b) the item DOES record a merge commit, but git could not answer
-      //       (guard refusal, missing binary, bad ref). Here the work may
-      //       already be done, and spawning would redo it.
+      //   (b) the item records a merge commit but git could not answer, OR the
+      //       item already claims `merged` while its evidence is incomplete.
+      //       Here the work may already be done, and spawning would redo it.
       //
-      // They are told apart by EVIDENCE — whether the item carries a
-      // mergeCommitOid — not by matching the reason text, which would make a
-      // reworded message silently change the control flow.
+      // They are told apart by STRUCTURED RECORD STATE, not by matching the
+      // reason text, which would make a reworded message silently change the
+      // control flow.
       const uncheckableWithEvidence = uncheckable(lastItemIds, verdict);
       if (uncheckableWithEvidence.length > 0) {
         outcome = 'unverifiable';
         unmergedItemIds = lastItemIds.filter((id) => !verdict.verified.has(id));
         reason =
-          `could not verify ${uncheckableWithEvidence.length} item(s) that DO record a merge commit ` +
-          `(${uncheckableWithEvidence.join(', ')}); refusing to respawn work that may already be done, ` +
-          'and recording no round verdict';
+          `could not verify ${uncheckableWithEvidence.length} item(s) whose records say work may ` +
+          `already be merged (${uncheckableWithEvidence.join(', ')}); refusing to respawn work that ` +
+          'may already be done, and recording no round verdict';
+        break;
+      }
+      if (lastItemIds.every((id) => verdict.verified.has(id))) {
+        outcome = 'complete';
+        mergedItemIds = [...lastItemIds];
         break;
       }
 
@@ -339,14 +348,15 @@ export async function runRound(input: RunRoundInput, deps: RunRoundDeps): Promis
       if (exit.kind === 'exited' && exit.code === 0) {
         // Step 6: verify per-item artifacts.
         const final = await verifyMergedItems(lastItemIds);
-        mergedItemIds = lastItemIds.filter((id) => final.verified.has(id));
-        unmergedItemIds = lastItemIds.filter((id) => !final.verified.has(id));
-        const finalUncheckable = uncheckable(unmergedItemIds, final);
-        if (unmergedItemIds.length === 0) {
-          outcome = 'complete';
-        } else if (finalUncheckable.length > 0) {
-          // At least one item RECORDS a merge commit the runner could not
-          // check. `partially-complete` asserts "this genuinely did not land",
+        const finalUncheckable = uncheckable(lastItemIds, final);
+        mergedItemIds = lastItemIds.filter(
+          (id) => final.verified.has(id) && !finalUncheckable.includes(id),
+        );
+        unmergedItemIds = lastItemIds.filter((id) => !mergedItemIds.includes(id));
+        if (finalUncheckable.length > 0) {
+          // At least one item records a merge commit the runner could not
+          // check, or claims merged without the full evidence contract.
+          // `partially-complete` asserts "this genuinely did not land",
           // which that item cannot support — so no verdict is recorded.
           //
           // An item with no merge commit at all, by contrast, genuinely did
@@ -354,8 +364,10 @@ export async function runRound(input: RunRoundInput, deps: RunRoundDeps): Promis
           // partially-complete below where it belongs.
           outcome = 'unverifiable';
           reason =
-            `child exited 0 but ${finalUncheckable.length} item(s) recording a merge commit ` +
-            `could not be checked (${finalUncheckable.join(', ')}); no round verdict recorded`;
+            `child exited 0 but ${finalUncheckable.length} item(s) lacked complete, ` +
+            `checkable merge evidence (${finalUncheckable.join(', ')}); no round verdict recorded`;
+        } else if (unmergedItemIds.length === 0) {
+          outcome = 'complete';
         } else {
           outcome = 'partially-complete';
         }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -178,6 +178,10 @@ import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
 import { validateStageTransition, type ValidationContext as StageValidationContext } from '../core/StageTransitionValidator.js';
 import type { PipelineStage, RoundStatus } from '../core/InitiativeTracker.js';
 import {
+  deriveProjectRound,
+  hasCompleteMergedEvidence,
+} from '../core/ProjectRoundDerivation.js';
+import {
   ATTENTION_PRIORITIES,
   ATTENTION_STATUSES,
   normalizeAttentionPriority,
@@ -1740,7 +1744,12 @@ function pickFields(
 
 /** Maps a /projects/:id/next action verb to the suggested skill invocation.
  *  Names are the canonical command set from PROJECT-SCOPE-SPEC § Phase 1.7. */
-function skillCommandForAction(action: string, projectId: string, roundIndex: number): string {
+function skillCommandForAction(
+  action: string,
+  projectId: string,
+  roundIndex: number,
+  itemId?: string,
+): string {
   switch (action) {
     case 'await-user-approval':
       return `/project ack ${projectId}`;
@@ -1754,6 +1763,8 @@ function skillCommandForAction(action: string, projectId: string, roundIndex: nu
       return `/spec-converge`;
     case 'run-drift-check':
       return `/project drift ${projectId} ${roundIndex}`;
+    case 'repair-merge-evidence':
+      return `/project advance ${projectId} ${itemId ?? '<itemId>'} merged`;
     case 'start-round':
     default:
       return `/project run-round ${projectId} ${roundIndex}`;
@@ -16464,7 +16475,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
 
     // Lazy merged-state reconciler — spec § Phase 1.4 lines 256-258.
     //
-    // GET /projects/:id is documented as "may mutate": when a 'building' child's
+    // GET /projects/:id is documented as "may mutate": when a 'merged' child's
     // mergeCommitOid is no longer ancestor of origin/main, we transition it to
     // 'regressed' and clear future autoAdvanceAt on its round.
     //
@@ -16487,7 +16498,7 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         return Number.MAX_SAFE_INTEGER;
       };
       const candidates = children
-        .filter((c) => c.pipelineStage === 'building' && typeof c.mergeCommitOid === 'string' && c.mergeCommitOid)
+        .filter((c) => c.pipelineStage === 'merged' && typeof c.mergeCommitOid === 'string' && c.mergeCommitOid)
         .filter((c) => {
           const t = c.ciCheckedAt ? Date.parse(c.ciCheckedAt) : 0;
           return !(Number.isFinite(t) && t > 0 && nowMs - t < debounceMs);
@@ -16583,6 +16594,26 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       }
     }
 
+    // Round status is a derived read model: child records carry the artifacts;
+    // the round's stored status is only a cache. Never render a stale `pending`
+    // after every member has earned completion, or a stale `complete` after its
+    // members stopped supporting that conclusion.
+    const childrenById = new Map(children.map((child) => [child.id, child]));
+    const projectForRead = {
+      ...project,
+      rounds: (project.rounds ?? []).map((round) => {
+        const derived = deriveProjectRound(round, childrenById);
+        return {
+          ...round,
+          status: derived.effectiveStatus,
+          ...(round.status !== derived.effectiveStatus ? { storedStatus: round.status } : {}),
+          evidenceMissingByItem: derived.evidenceMissingByItem,
+          missingMemberIds: derived.missingMemberIds,
+          incompleteItemIds: derived.incompleteItemIds,
+        };
+      }),
+    };
+
     // Optional field selector: `?fields=id,title,pipelineStage`. Used by
     // the dashboard projects selector (Phase 1.10). Always preserves `id`.
     const fieldsParam = typeof req.query.fields === 'string' ? req.query.fields : '';
@@ -16594,18 +16625,19 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
           .filter(Boolean)
       );
       fields.add('id');
-      const pickProj = pickFields(project as unknown as Record<string, unknown>, fields);
+      const pickProj = pickFields(projectForRead as unknown as Record<string, unknown>, fields);
       const pickKids = children.map((c) => pickFields(c as unknown as Record<string, unknown>, fields));
       res.json({ project: pickProj, children: pickKids });
       return;
     }
-    res.json({ project, children });
+    res.json({ project: projectForRead, children });
   });
 
   // GET /projects/:id/next — structured next-action payload.
   //
   // Spec § Phase 1.5 (line 268): returns `{ action, params, estimatedCost?,
-  // skillCommand? }` for the FIRST round whose status is not 'complete'.
+  // skillCommand? }` for the FIRST round whose MEMBERS have not earned a
+  // terminal status. Stored round status is a cache, never the authority.
   // Ordering: roundIndex ASC, then pipelineStage ASC, then itemId ASC.
   //
   // Action verbs the spec enumerates (a non-exhaustive contract):
@@ -16616,6 +16648,8 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   //   - 'run-spec-converge'    — at least one item is `spec-drafted`
   //   - 'run-drift-check'      — at least one item is `approved`, no fresh
   //                              drift verdict
+  //   - 'repair-merge-evidence'— item claims `merged` but cannot name the
+  //                              validated PR/commit/check timestamp
   //   - 'start-round'          — all preconditions met, ready to fire
   //
   // The endpoint does NOT run the runner's preflight — that's a heavier
@@ -16635,12 +16669,20 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       return;
     }
     const rounds = project.rounds ?? [];
-    const idx = rounds.findIndex((r) => (r.status ?? 'pending') !== 'complete');
+    const childrenById = new Map(
+      ctx.initiativeTracker
+        .list()
+        .filter((i) => i.parentProjectId === project.id)
+        .map((c) => [c.id, c])
+    );
+    const derivations = rounds.map((round) => deriveProjectRound(round, childrenById));
+    const idx = derivations.findIndex((derived) => derived.terminalStatus === undefined);
     if (idx === -1) {
       res.status(204).end();
       return;
     }
     const r = rounds[idx];
+    const derived = derivations[idx];
 
     // Determine the action verb from project + round state.
     type ActionVerb =
@@ -16650,18 +16692,15 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       | 'accept-partial'
       | 'run-spec-converge'
       | 'run-drift-check'
+      | 'repair-merge-evidence'
       | 'start-round';
     let action: ActionVerb = 'start-round';
-    const childrenById = new Map(
-      ctx.initiativeTracker
-        .list()
-        .filter((i) => i.parentProjectId === project.id)
-        .map((c) => [c.id, c])
-    );
     const itemsForRound = (r.itemIds ?? []).map((id) => childrenById.get(id)).filter(Boolean);
 
     if ((project.awaitingReconciliation ?? []).length > 0) {
       action = 'resolve-conflict';
+    } else if (Object.keys(derived.evidenceMissingByItem).length > 0) {
+      action = 'repair-merge-evidence';
     } else if ((r.status ?? 'pending') === 'partially-complete') {
       action = 'accept-partial';
     } else if (idx === 0 && !project.firstLaunchAckAt) {
@@ -16686,10 +16725,19 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
         roundIndex: idx,
         name: r.name,
         itemIds: r.itemIds,
-        status: r.status ?? 'pending',
+        status: derived.effectiveStatus,
+        storedStatus: r.status ?? 'pending',
+        evidenceMissingByItem: derived.evidenceMissingByItem,
+        missingMemberIds: derived.missingMemberIds,
+        incompleteItemIds: derived.incompleteItemIds,
         autoAdvanceAt: r.autoAdvanceAt,
       },
-      skillCommand: skillCommandForAction(action, project.id, idx),
+      skillCommand: skillCommandForAction(
+        action,
+        project.id,
+        idx,
+        Object.keys(derived.evidenceMissingByItem)[0],
+      ),
     });
   });
 
@@ -16872,12 +16920,24 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       mergeBaseBranch: resolveCanonicalMainRef(project.targetRepoPath),
     };
 
+    const actualStage = child.pipelineStage as PipelineStage | undefined;
     const fromStage =
       typeof body.fromStage === 'string'
         ? (body.fromStage as PipelineStage)
-        : (child.pipelineStage as PipelineStage | undefined);
+        : actualStage;
 
-    const result = await validateStageTransition(fromStage, targetStage, validationCtx);
+    // Historical rows may already claim `merged` while lacking the artifact
+    // fields that newer transitions persist. A same-stage request is an
+    // explicit re-attestation: run the full building→merged authority again
+    // and atomically attach its evidence without pretending the item regressed.
+    const repairingMergedEvidence =
+      actualStage === 'merged'
+      && targetStage === 'merged'
+      && (body.fromStage === undefined || body.fromStage === 'merged')
+      && !hasCompleteMergedEvidence(child);
+    const validationFromStage = repairingMergedEvidence ? 'building' : fromStage;
+
+    const result = await validateStageTransition(validationFromStage, targetStage, validationCtx);
     if (!result.ok) {
       res.status(409).json({ error: 'stage transition rejected', code: result.code, reason: result.reason });
       return;

--- a/tests/integration/projects-api.test.ts
+++ b/tests/integration/projects-api.test.ts
@@ -299,19 +299,79 @@ auto_advance: true
     expect(res.status).toBe(503);
   });
 
-  it('GET /projects/:id/next returns 204 when all rounds complete', async () => {
+  it('GET /projects/:id/next returns 204 when member evidence makes all rounds complete', async () => {
     await request(app)
       .post('/projects')
       .set('Authorization', `Bearer ${AUTH_TOKEN}`)
       .send({ planDocPath: goodPlan('all-done-project') });
     const proj = tracker.get('all-done-project');
     if (!proj) throw new Error('fixture project missing');
-    const rounds = (proj.rounds ?? []).map((r) => ({ ...r, status: 'complete' as const }));
-    await tracker.update(proj.id, { rounds, ifMatch: proj.version });
+    for (const itemId of (proj.rounds ?? []).flatMap((round) => round.itemIds)) {
+      const child = tracker.get(itemId)!;
+      await tracker.update(itemId, {
+        pipelineStage: 'merged',
+        prNumber: 1810,
+        mergeCommitOid: 'abcdef1234567890',
+        ciCheckedAt: '2026-07-31T00:00:00.000Z',
+        ifMatch: child.version,
+      });
+    }
     const res = await request(app)
       .get('/projects/all-done-project/next')
       .set('Authorization', `Bearer ${AUTH_TOKEN}`);
     expect(res.status).toBe(204);
+  });
+
+  it('GET /projects/:id/next surfaces historical merged rows for evidence repair instead of re-running them', async () => {
+    await request(app)
+      .post('/projects')
+      .set('Authorization', `Bearer ${AUTH_TOKEN}`)
+      .send({ planDocPath: goodPlan('repair-evidence-project') });
+    const proj = tracker.get('repair-evidence-project')!;
+    const firstRoundIds = proj.rounds![0].itemIds;
+    for (const itemId of firstRoundIds) {
+      const child = tracker.get(itemId)!;
+      await tracker.update(itemId, {
+        pipelineStage: 'merged',
+        ifMatch: child.version,
+      });
+    }
+
+    const res = await request(app)
+      .get('/projects/repair-evidence-project/next')
+      .set('Authorization', `Bearer ${AUTH_TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.body.action).toBe('repair-merge-evidence');
+    expect(res.body.action).not.toBe('start-round');
+    expect(Object.keys(res.body.params.evidenceMissingByItem)).toEqual(firstRoundIds);
+    expect(res.body.skillCommand).toBe(
+      `/project advance repair-evidence-project ${firstRoundIds[0]} merged`,
+    );
+  });
+
+  it('GET /projects/:id derives displayed round status from evidence-bearing members', async () => {
+    await request(app)
+      .post('/projects')
+      .set('Authorization', `Bearer ${AUTH_TOKEN}`)
+      .send({ planDocPath: goodPlan('derived-status-project') });
+    const proj = tracker.get('derived-status-project')!;
+    for (const itemId of proj.rounds![0].itemIds) {
+      const child = tracker.get(itemId)!;
+      await tracker.update(itemId, {
+        pipelineStage: 'merged',
+        prNumber: 1810,
+        mergeCommitOid: 'abcdef1234567890',
+        ciCheckedAt: '2026-07-31T00:00:00.000Z',
+        ifMatch: child.version,
+      });
+    }
+    const res = await request(app)
+      .get('/projects/derived-status-project?reconcile=false')
+      .set('Authorization', `Bearer ${AUTH_TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.body.project.rounds[0].status).toBe('complete');
+    expect(res.body.project.rounds[0].storedStatus).toBe('pending');
+    expect(tracker.get('derived-status-project')!.rounds![0].status).toBe('pending');
   });
 
   it('GET /projects/:id/next returns 404 for non-project initiative', async () => {
@@ -633,6 +693,27 @@ goal: try escape
     expect(res.status).toBe(409);
     expect(res.body.code).not.toBe('GH_PR_VIEW_UNAVAILABLE');
     expect(res.body.code).toBe('GH_PR_VIEW_FAILED');
+  });
+
+  it('POST /projects/:id/advance re-attests a historical merged row instead of rejecting merged → merged', async () => {
+    const { projectVersion, itemId } = await seedProject('adv-repair-evidence');
+    const child = tracker.get(itemId)!;
+    await tracker.update(itemId, {
+      pipelineStage: 'merged',
+      ifMatch: child.version,
+    });
+    const res = await request(app)
+      .post('/projects/adv-repair-evidence/advance')
+      .set('Authorization', `Bearer ${AUTH_TOKEN}`)
+      .set('If-Match', String(projectVersion))
+      .send({
+        itemId,
+        targetStage: 'merged',
+        artifact: { prNumber: 999999 },
+      });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('GH_PR_VIEW_FAILED');
+    expect(res.body.code).not.toBe('INVALID_TRANSITION');
   });
 
   it('POST /projects/:id/halt — halts the active round (idempotent)', async () => {

--- a/tests/unit/ProjectRoundDerivation.test.ts
+++ b/tests/unit/ProjectRoundDerivation.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type { Initiative, InitiativeRound } from '../../src/core/InitiativeTracker.js';
+import {
+  deriveProjectRound,
+  missingMergedEvidenceFields,
+} from '../../src/core/ProjectRoundDerivation.js';
+
+function item(id: string, overrides: Partial<Initiative> = {}): Initiative {
+  return {
+    id,
+    title: id,
+    description: 'fixture',
+    status: 'active',
+    phases: [{ id: 'p', name: 'p', status: 'pending' }],
+    currentPhaseIndex: 0,
+    lastTouchedAt: '2026-07-31T00:00:00.000Z',
+    needsUser: false,
+    blockers: [],
+    links: [],
+    createdAt: '2026-07-31T00:00:00.000Z',
+    updatedAt: '2026-07-31T00:00:00.000Z',
+    kind: 'task',
+    ...overrides,
+  };
+}
+
+function round(itemIds: string[], status: InitiativeRound['status'] = 'pending'): InitiativeRound {
+  return { name: 'round', itemIds, status };
+}
+
+const evidence = {
+  prNumber: 1810,
+  mergeCommitOid: 'abcdef1234567890',
+  ciCheckedAt: '2026-07-31T00:00:00.000Z',
+};
+
+describe('deriveProjectRound', () => {
+  it('earns complete from evidence-bearing merged members even when the cache says pending', () => {
+    const children = new Map([
+      ['a', item('a', { pipelineStage: 'merged', ...evidence })],
+      ['b', item('b', { pipelineStage: 'merged', ...evidence, prNumber: 1811 })],
+    ]);
+    const derived = deriveProjectRound(round(['a', 'b']), children);
+    expect(derived.terminalStatus).toBe('complete');
+    expect(derived.effectiveStatus).toBe('complete');
+  });
+
+  it('refuses to derive completion from a merged label without its evidence', () => {
+    const children = new Map([['a', item('a', { pipelineStage: 'merged' })]]);
+    const derived = deriveProjectRound(round(['a']), children);
+    expect(derived.terminalStatus).toBeUndefined();
+    expect(derived.evidenceMissingByItem).toEqual({
+      a: ['prNumber', 'mergeCommitOid', 'ciCheckedAt'],
+    });
+  });
+
+  it('invalidates a cached terminal conclusion when members do not support it', () => {
+    const children = new Map([['a', item('a', { pipelineStage: 'outline' })]]);
+    const derived = deriveProjectRound(round(['a'], 'complete'), children);
+    expect(derived.terminalStatus).toBeUndefined();
+    expect(derived.effectiveStatus).toBe('regressed');
+    expect(derived.incompleteItemIds).toEqual(['a']);
+  });
+
+  it('derives complete-with-skips from explicit terminal member states', () => {
+    const children = new Map([
+      ['a', item('a', { pipelineStage: 'merged', ...evidence })],
+      ['b', item('b', { pipelineStage: 'skipped' })],
+    ]);
+    expect(deriveProjectRound(round(['a', 'b']), children).terminalStatus)
+      .toBe('complete-with-skips');
+  });
+
+  it('does not let an empty round or a missing child vacuously complete', () => {
+    expect(deriveProjectRound(round([]), new Map()).terminalStatus).toBeUndefined();
+    const missing = deriveProjectRound(round(['gone']), new Map());
+    expect(missing.terminalStatus).toBeUndefined();
+    expect(missing.missingMemberIds).toEqual(['gone']);
+  });
+});
+
+describe('missingMergedEvidenceFields', () => {
+  it('requires a positive PR, a non-empty commit, and a real timestamp', () => {
+    expect(missingMergedEvidenceFields({
+      prNumber: 0,
+      mergeCommitOid: 'not-a-sha',
+      ciCheckedAt: 'not-a-date',
+    })).toEqual(['prNumber', 'mergeCommitOid', 'ciCheckedAt']);
+    expect(missingMergedEvidenceFields(evidence)).toEqual([]);
+  });
+});

--- a/tests/unit/ProjectRoundExecution.test.ts
+++ b/tests/unit/ProjectRoundExecution.test.ts
@@ -163,6 +163,35 @@ describe('ProjectRoundExecution.runRound', () => {
     expect(spawnedCalls).toBe(1);
   });
 
+  it('a historical merged claim without evidence is unverifiable and is never re-run', async () => {
+    await newProject(tracker, 'p-evidence-hole', ['i1'], targetRepo);
+    const child = tracker.get('i1')!;
+    await tracker.update('i1', { pipelineStage: 'merged', ifMatch: child.version });
+    let verifyCalls = 0;
+    const r = await runRound(
+      {
+        tracker,
+        projectId: 'p-evidence-hole',
+        roundIndex: 0,
+        targetRepoPath: targetRepo,
+        spawnCommand: 'bash',
+        spawnArgs: ['-c', 'exit 99'],
+        pollIntervalMs: 50,
+        sigtermGraceMs: 100,
+        verifyMergedItems: async (ids) => {
+          verifyCalls += 1;
+          // Even a positive git reachability result is not enough to launder
+          // the missing PR + CI evidence into a complete round.
+          return allVerified(ids);
+        },
+      },
+      { stateDir },
+    );
+    expect(r.outcome).toBe('unverifiable');
+    expect(r.reason).toMatch(/refusing to respawn/i);
+    expect(verifyCalls).toBe(1);
+  });
+
   it('natural exit + full verification → complete', async () => {
     await newProject(tracker, 'p-nat', ['i1'], targetRepo);
     // Step 1: pre-spawn check returns 0 → child spawns.

--- a/tests/unit/merged-record-carries-its-evidence.test.ts
+++ b/tests/unit/merged-record-carries-its-evidence.test.ts
@@ -221,6 +221,15 @@ describe('the advance route records the evidence it validated', () => {
 describe('the lazy merged-state reconciler does not invent a verdict', () => {
   const src = () => stripComments(fs.readFileSync(ROUTES, 'utf-8'));
 
+  it('selects evidence-bearing merged rows, not pre-merge building rows', () => {
+    const s = src();
+    const callIdx = s.indexOf('verifyMergedItemsViaGit(');
+    expect(callIdx, 'the reconciler callsite must exist').toBeGreaterThan(0);
+    const selection = s.slice(Math.max(0, callIdx - 2600), callIdx);
+    expect(selection).toMatch(/pipelineStage\s*===\s*['"]merged['"]/);
+    expect(selection).not.toMatch(/pipelineStage\s*===\s*['"]building['"]/);
+  });
+
   it('demotes to regressed ONLY on membership of the regressed set', () => {
     const s = src();
     const idx = s.indexOf('verifyMergedItemsViaGit(');

--- a/tests/unit/round-completion-verifies-merged.test.ts
+++ b/tests/unit/round-completion-verifies-merged.test.ts
@@ -91,7 +91,13 @@ describe('a round whose items are all merged can actually finish', () => {
         phases: [{ id: 'p', name: 'p' }],
         parentProjectId: id,
         pipelineStage: it.mergeCommitOid ? 'merged' : 'outline',
-        ...(it.mergeCommitOid ? { mergeCommitOid: it.mergeCommitOid } : {}),
+        ...(it.mergeCommitOid
+          ? {
+              prNumber: 1814,
+              mergeCommitOid: it.mergeCommitOid,
+              ciCheckedAt: '2026-08-01T00:00:00.000Z',
+            }
+          : {}),
       });
     }
   }
@@ -159,7 +165,13 @@ describe('REFUSAL: "I could not check" is not a verdict, in either direction', (
         id: it.id, title: `Item ${it.id}`, description: 'item',
         phases: [{ id: 'p', name: 'p' }], parentProjectId: id,
         pipelineStage: it.mergeCommitOid ? 'merged' : 'outline',
-        ...(it.mergeCommitOid ? { mergeCommitOid: it.mergeCommitOid } : {}),
+        ...(it.mergeCommitOid
+          ? {
+              prNumber: 1814,
+              mergeCommitOid: it.mergeCommitOid,
+              ciCheckedAt: '2026-08-01T00:00:00.000Z',
+            }
+          : {}),
       });
     }
   }

--- a/upgrades/next/project-round-evidence-derivation.md
+++ b/upgrades/next/project-round-evidence-derivation.md
@@ -1,0 +1,28 @@
+<!-- bump: patch -->
+
+## What Changed
+
+Project rounds now derive terminal status from their member records. A merged
+member counts only when it carries its validated PR number, merge commit, and
+verification time. Historical merged rows without that evidence produce a
+repair action and are never automatically rebuilt.
+The lazy integrity check also once again revalidates merged rows rather than
+selecting a stage that cannot yet carry merge evidence.
+
+## What to Tell Your User
+
+- **Project rounds no longer repeat completed work because of stale summaries:** “The tracker now checks the evidence on each item before deciding a round is complete or should run again.”
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|---|---|
+| See evidence-derived project round status | Read the project normally; displayed round status is derived from its members |
+| Repair a historical merged row without rebuilding it | Use the suggested `repair-merge-evidence` next action and supply the original PR to `/project advance` |
+
+## Evidence
+
+Focused unit and integration coverage proves pending caches derive complete,
+unsupported complete caches regress, evidence-empty merged rows request repair,
+same-stage re-attestation reaches the real validator, and direct runner calls
+refuse to redo possibly completed work. The TypeScript build passes.

--- a/upgrades/next/project-round-evidence-derivation.md
+++ b/upgrades/next/project-round-evidence-derivation.md
@@ -22,7 +22,7 @@ selecting a stage that cannot yet carry merge evidence.
 
 ## Evidence
 
-Focused unit and integration coverage proves pending caches derive complete,
+Eighty-nine focused unit and integration tests prove pending caches derive complete,
 unsupported complete caches regress, evidence-empty merged rows request repair,
 same-stage re-attestation reaches the real validator, and direct runner calls
 refuse to redo possibly completed work. The TypeScript build passes.

--- a/upgrades/side-effects/project-round-evidence-derivation.md
+++ b/upgrades/side-effects/project-round-evidence-derivation.md
@@ -31,6 +31,9 @@ timestamp no longer permits its round to complete or run. That is intentional:
 the row cannot distinguish completed work from a mistaken label. Legitimate
 fresh items at `outline`, `approved`, or `building` remain runnable because the
 runner distinguishes them from a row that already claims `merged`.
+A definitive git regression also remains runnable: exit status 1 proves the
+recorded commit is absent from canonical main, so the stale metadata gap cannot
+overrule that stronger negative verdict.
 
 ## 2. Under-block
 
@@ -119,6 +122,7 @@ outbound messaging, session lifecycle, dispatch, or a gate/watchdog surface.
 - `tests/unit/ProjectRoundDerivation.test.ts`
 - `tests/integration/projects-api.test.ts`
 - `tests/unit/ProjectRoundExecution.test.ts`
+- `tests/unit/round-completion-verifies-merged.test.ts`
 
 ## Class-Closure Declaration
 

--- a/upgrades/side-effects/project-round-evidence-derivation.md
+++ b/upgrades/side-effects/project-round-evidence-derivation.md
@@ -1,0 +1,127 @@
+# Side-Effects Review — Project round evidence derivation
+
+**Version / slug:** `project-round-evidence-derivation`
+**Date:** `2026-07-31`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`ProjectRoundDerivation.ts` makes evidence-bearing child initiatives the
+authority for terminal round status. `GET /projects/:id` renders that derived
+status, `/next` selects the first non-terminal derived round and emits
+`repair-merge-evidence` for historical evidence holes, `/advance` supports a
+validated same-stage re-attestation, and `ProjectRoundExecution` refuses to
+respawn work for an evidence-empty row that already claims `merged`. The lazy
+integrity read now selects those `merged` rows rather than the pre-merge
+`building` stage.
+
+## Decision-point inventory
+
+- `deriveProjectRound` — add — deterministically decides whether member state earns a terminal conclusion.
+- `GET /projects/:id/next` — modify — cached round status no longer authorizes a run; member derivation does.
+- `ProjectRoundExecution.runRound` — modify — historical merged claims without evidence are unverifiable, not runnable.
+- `POST /projects/:id/advance` — modify — a same-stage merged request can re-attest missing historical evidence through the existing validator.
+- `GET /projects/:id` lazy integrity selector — modify — revalidates the evidence-bearing terminal stage it is documented to protect.
+
+## 1. Over-block
+
+A deliberately hand-edited `merged` row with no PR, commit, or verification
+timestamp no longer permits its round to complete or run. That is intentional:
+the row cannot distinguish completed work from a mistaken label. Legitimate
+fresh items at `outline`, `approved`, or `building` remain runnable because the
+runner distinguishes them from a row that already claims `merged`.
+
+## 2. Under-block
+
+An explicit `skipped` stage counts as terminal without revalidating the skip
+reason fields. That preserves the existing skip contract and avoids turning
+this merged-evidence repair into a new skip migration. Merge evidence is
+structurally present but is not re-queried on every `/next`; the existing lazy
+and periodic integrity checks remain responsible for later regression.
+
+## 3. Level-of-abstraction fit
+
+The pure derivation sits between durable member records and all consumers of a
+round conclusion. It does not duplicate GitHub validation: the existing
+`StageTransitionValidator` remains the artifact authority. The HTTP routes
+consume derivation for read/next behavior, and the lower execution layer carries
+the independent no-redo safety floor so direct invocation cannot bypass it.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this is hard-invariant structural validation, not conversational judgment.
+
+The domain is enumerable: member missing, non-terminal, skipped, merged with
+three fields, or merged with one or more fields absent. The validator, not a
+brittle semantic detector, establishes the fields. No LLM judgment or message
+classification is added.
+
+## 4b. Judgment-point check
+
+No competing-signals heuristic is added. Terminal status is a deterministic
+invariant over typed member state; cached status is expressly a conclusion and
+therefore cannot outrank the records that support it.
+
+## 5. Interactions
+
+- **Shadowing:** derivation runs after the lazy project integrity read, so any real regression found there is visible to it.
+- **Double-fire:** the read path is pure and does not persist derived status; it cannot race another writer or fire work twice.
+- **Races:** `/advance` keeps the existing child OCC write and project version bump. Re-attestation persists evidence in the same child write as the stage.
+- **Feedback loops:** a repaired child causes the next read to derive completion; it does not enqueue work or recursively mutate the project.
+
+## 6. External surfaces
+
+Project API readers may see a round's displayed `status` differ from its stored
+cache; `storedStatus` is included only when they differ. `/next` adds one action
+verb and its evidence diagnostics. The existing `/project advance` skill is the
+phone/conversation-completable repair surface; no new operator-only form, raw
+shell workflow, external send, URL, or external-system write is introduced.
+
+## 6b. Operator-surface quality
+
+No dashboard or operator form is changed. The conversational skill presents a
+named repair action and a concrete item command, while raw evidence field names
+remain in the machine API for agent diagnosis.
+
+## 7. Multi-machine posture
+
+**Replicated:** project and child initiative records already use the Initiative
+Tracker's existing replication/coherence path. Every machine derives the same
+round result from the same replicated members; no new durable state exists.
+The change emits no user-facing notices, holds no additional state that can
+strand on topic transfer, and generates no URLs.
+
+## 8. Rollback cost
+
+Pure code and documentation change. Reverting it restores cached-status reads
+and removes same-stage re-attestation. It creates no migration or new persisted
+schema. Evidence attached through re-attestation uses existing fields and
+remains valid after rollback.
+
+## Conclusion
+
+The review moved status correction to a pure read derivation and kept artifact
+verification in the established validator. It also added a lower execution
+floor because fixing `/next` alone would leave a direct-run bypass. The change
+is bounded, reversible, and ready to ship with focused integration and unit
+coverage.
+
+## Second-pass review
+
+Not required: this changes a deterministic project-state invariant, not
+outbound messaging, session lifecycle, dispatch, or a gate/watchdog surface.
+
+## Evidence pointers
+
+- `tests/unit/ProjectRoundDerivation.test.ts`
+- `tests/integration/projects-api.test.ts`
+- `tests/unit/ProjectRoundExecution.test.ts`
+
+## Class-Closure Declaration
+
+No agent-authored-artifact defect — not applicable. The trace carries an
+explicit `unbounded-self-action` negative declaration because this change
+narrows an existing runner's respawn behavior and adds no self-triggered action.


### PR DESCRIPTION
## Summary
- derive terminal round status from evidence-bearing member records instead of cached round status
- surface historical merged rows without PR/commit/check evidence as a repair action and allow validated same-stage re-attestation
- refuse direct runner re-execution of possibly completed evidence-empty work and re-arm lazy integrity checks for merged rows

## ELI16 — A round is done only when its items can prove it
Projects keep both individual item records and a round summary. Those could disagree, so a stale summary could tell the agent to run work again even though every item had merged. The tracker now treats each item's retained PR, merge commit, and verification time as the source of truth. If an older row says merged but lacks that proof, the agent is told to repair the evidence from the original PR instead of rebuilding the feature. A definitive git regression remains runnable because that stronger negative verdict proves repair work is needed.

## UX Impact
Who sees this: agents and users reading project status or asking for the next project action. The user-visible behavior changes only when cached round state disagrees with member evidence: truly complete rounds display complete and are skipped, while historical evidence holes return the concrete action "repair-merge-evidence" rather than suggesting another run. First contact is the existing project status/next surface and its suggested project command; no new message or notification is emitted.

## Evidence
- 89 focused unit/integration tests pass
- TypeScript build passes
- full lint chain passes
- decision audit and side-effects review included

## Notes
The local pre-push affected-test listing timed out waiting on the shared test-runner lane; the focused suites passed locally, and CI remains authoritative.