### PR TITLE
fix(ux-gate): the UX-impact gate could not see the user-awareness surface

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-01T00-32-31-508Z-ux-first-enforcement-inc2.json
+++ b/.instar/instar-dev-decisions/2026-08-01T00-32-31-508Z-ux-first-enforcement-inc2.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-01T00:32:31.508Z",
+  "slug": "ux-first-enforcement-inc2",
+  "suggestedTier": 1,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 6,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/ux-impact-lint.mjs"
+    ],
+    "addedLines": 3,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-01T00-35-57-957Z-ux-gate-scaffold-scope.json
+++ b/.instar/instar-dev-decisions/2026-08-01T00-35-57-957Z-ux-gate-scaffold-scope.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-01T00:35:57.957Z",
+  "slug": "ux-gate-scaffold-scope",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 6,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/ux-impact-lint.mjs"
+    ],
+    "addedLines": 3,
+    "deletedLines": 3
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/ux-gate-scaffold-scope.eli16.md
+++ b/docs/eli16/ux-gate-scaffold-scope.eli16.md
@@ -1,0 +1,51 @@
+# The UX gate could not see the file that tells agents what they can do — ELI16
+
+Instar has a rule with real teeth: if your pull request touches anything a user
+will actually see, you must write a short "UX Impact" note explaining who sees
+it, what changes for them, and quote a real line from your own change to prove
+you are describing something that exists. A CI check called the UX-impact gate
+enforces this, and it decides whether your PR counts as "user-facing" by
+checking your changed files against a hard-coded list of paths.
+
+That list had a hole in it, and the hole was the most important file of all.
+
+Instar's Agent Awareness Standard says, in the project's own words: *"Every
+feature added to Instar MUST include a corresponding update to the CLAUDE.md
+template (`src/scaffold/templates.ts`). An agent that doesn't know about a
+capability effectively doesn't have it."* That one file generates the
+instructions every single agent reads at startup — it is how an agent learns
+what it is capable of and what to tell people. If anything in this codebase is
+user-facing, it is that.
+
+The gate's list did not contain it. It contained `src/templates/` — a
+different directory, holding hook and helper scripts — and stopped there. The
+two folder names differ by one word and by everything that matters.
+
+The consequence was quiet and precise. If a pull request changed *only* that
+file — adding a whole new capability description that every agent would start
+telling users about — the gate looked at the changed files, found nothing on
+its list, printed "UX lint: out of scope", and waved it through with no UX note
+required at all. The one change guaranteed to alter what users are told was the
+one change the user-facing gate ignored.
+
+This was not a hypothetical. Commit `e29259c49` in this repo touches
+`src/scaffold/templates.ts` and zero listed paths; running the shipping gate
+against it prints exactly that "out of scope" message and exits successfully.
+
+The fix adds that one file to the list. Deliberately one file, not the whole
+`src/scaffold/` folder: the standard names a specific file, and quietly
+widening a gate to cover more than anyone agreed to is its own kind of bug.
+
+Two smaller things came along with it. A change to agent-visible text can no
+longer claim the "this is just a refactor" exemption, because rewriting what
+every agent says is not a refactor. And the gate's error message was rewritten,
+because it had been lying by omission: it said your note must "quote a concrete
+string from the diff", while it was actually only searching the listed paths.
+An author who correctly quoted a real added line from an unlisted file was told
+their quote wasn't in the diff — which was, on its face, untrue. It now names
+the paths it actually searched, so the next person sees the real reason in
+seconds instead of concluding the check is broken.
+
+The honest limit: this closes one hole in one list. A list of paths standing in
+for the idea of "user-facing" is still a stand-in, and stand-ins drift. What
+this change does not do is give that list an owner or a reason to be re-read.

--- a/scripts/ux-impact-lint.mjs
+++ b/scripts/ux-impact-lint.mjs
@@ -22,12 +22,12 @@ try {
   const report = { version: 1, base, head, authorInScope, scope, allowlistedPaths: [], exempt: false, internalError: false };
   const writeReport = () => { if (reportPath) writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`); };
   if (!authorInScope) { report.outOfScopeAuthor = true; await writeReport(); console.log('UX lint: out-of-scope author'); process.exit(0); }
-  const allowlisted = names.filter((p) => p === 'src/server/routes.ts' || p === 'src/commands/server.ts' || p.startsWith('src/messaging/') || p.startsWith('src/dashboard/') || p.startsWith('src/templates/'));
+  const allowlisted = names.filter((p) => p === 'src/server/routes.ts' || p === 'src/commands/server.ts' || p === 'src/scaffold/templates.ts' || p.startsWith('src/messaging/') || p.startsWith('src/dashboard/') || p.startsWith('src/templates/'));
   report.allowlistedPaths = allowlisted;
   if (allowlisted.length === 0) { await writeReport(); console.log('UX lint: out of scope'); process.exit(0); }
   const diff = execFileSync('git', ['diff', '--unified=0', `${base}...${head}`, '--', ...allowlisted], { encoding: 'utf8' });
   const added = diff.split('\n').filter((line) => line.startsWith('+') && !line.startsWith('+++')).join('\n');
-  const refactorOnly = !allowlisted.some((p) => p.startsWith('src/templates/') || p === 'src/server/routes.ts' || p === 'src/commands/server.ts')
+  const refactorOnly = !allowlisted.some((p) => p.startsWith('src/templates/') || p === 'src/server/routes.ts' || p === 'src/commands/server.ts' || p === 'src/scaffold/templates.ts')
     && !/(?:^|\s)[`'\"](?:[^`'\"]+)[`'\"]/.test(added);
   const section = body.match(/^## UX Impact\s*\n([\s\S]*?)(?=^##\s|(?![\s\S]))/im)?.[1]?.trim() || '';
   if (/UX-Impact:\s*refactor-only/i.test(section) && refactorOnly) { report.exempt = true; report.exemption = 'refactor-only'; await writeReport(); console.log('UX lint PASS: deterministic refactor-only exemption'); process.exit(0); }
@@ -38,7 +38,7 @@ try {
   }
   const quoted = [...section.matchAll(/[`'"“]([^`'"”]+)[`'"”]/g)].map((m) => m[1]);
   if (!quoted.some((q) => q.length > 2 && diff.includes(q))) {
-    console.error('::error::UX Impact must quote a concrete string from the diff'); process.exit(1);
+    console.error(`::error::UX Impact must quote a concrete string from the USER-FACING paths this PR touches (${allowlisted.join(', ')}). Quotes from other changed files are not checked.`); process.exit(1);
   }
   await writeReport();
   console.log(`UX lint PASS: ${allowlisted.length} allowlisted path(s)`);

--- a/tests/unit/ux-impact-lint-scaffold-scope.test.ts
+++ b/tests/unit/ux-impact-lint-scaffold-scope.test.ts
@@ -1,0 +1,126 @@
+// safe-git-allow: test file — direct execFileSync builds a throwaway git
+//   fixture repo under a per-test tmpdir; the lint under test shells out to
+//   git itself and is exercised as a black box. fs.rmSync is tmpdir cleanup.
+
+/**
+ * Unit tests for scripts/ux-impact-lint.mjs — user-facing path scope.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The Agent Awareness Standard (CLAUDE.md) names `src/scaffold/templates.ts`
+ * as THE user-awareness surface: "Every feature added to Instar MUST include a
+ * corresponding update to the CLAUDE.md template (`src/scaffold/templates.ts`
+ * -> generateClaudeMd()). An agent that doesn't know about a capability
+ * effectively doesn't have it."
+ *
+ * The UX-impact gate's allowlist did not contain that path. A PR touching ONLY
+ * that file therefore hit `allowlisted.length === 0` and exited 0 — the gate
+ * skipped the change that alters what every agent tells its users.
+ *
+ * Verified against real commit e29259c49 before this fix: it touches
+ * src/scaffold/templates.ts and ZERO allowlisted paths, and the shipping lint
+ * answered "UX lint: out of scope" (exit 0).
+ *
+ * Covers BOTH sides of the decision boundary:
+ *   - scaffold/templates.ts alone -> gate ENGAGES (in scope)
+ *   - a genuinely internal path alone -> gate still SKIPS (no over-reach)
+ *   - a correct declaration quoting the scaffold diff -> PASSES
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const LINT = resolve(process.cwd(), 'scripts/ux-impact-lint.mjs');
+
+let repo: string;
+
+function git(...args: string[]): string {
+  return execFileSync('git', args, { cwd: repo, encoding: 'utf8' }).trim();
+}
+
+/** Write `file`, commit it, and return the new HEAD sha. */
+function commitFile(file: string, contents: string, message: string): string {
+  const full = join(repo, file);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, contents);
+  git('add', '-A');
+  git('-c', 'user.name=t', '-c', 'user.email=t@t', 'commit', '-m', message);
+  return git('rev-parse', 'HEAD');
+}
+
+/** Run the lint as CI does and return its exit code + combined output. */
+function runLint(base: string, head: string, body: string) {
+  const r = spawnSync(
+    process.execPath,
+    [LINT, '--base', base, '--head', head, '--scope', '', '--pusher', '', '--body', body],
+    { cwd: repo, encoding: 'utf8' },
+  );
+  return { code: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+const DECLARATION_NONE = '## UX Impact\n\nUX-Impact: none';
+
+beforeAll(() => {
+  repo = mkdtempSync(join(tmpdir(), 'ux-lint-scope-'));
+  git('init', '-q');
+  commitFile('README.md', 'seed\n', 'seed');
+});
+
+afterAll(() => {
+  if (repo) rmSync(repo, { recursive: true, force: true });
+});
+
+describe('ux-impact-lint: user-facing path scope', () => {
+  it('ENGAGES on a change touching only src/scaffold/templates.ts', () => {
+    const base = git('rev-parse', 'HEAD');
+    const head = commitFile(
+      'src/scaffold/templates.ts',
+      "export const generateClaudeMd = () => `\\n**Widgets are internal by default:** no user output.\\n`;\n",
+      'feat: agent-visible widgets guidance',
+    );
+
+    const { code, out } = runLint(base, head, DECLARATION_NONE);
+
+    // Must NOT be the skip path — this is the regression under test.
+    expect(out).not.toContain('out of scope');
+    expect(code).toBe(1);
+    expect(out).toContain('UX-Impact: none is not allowed');
+  });
+
+  it('PASSES when the declaration quotes a concrete string from the scaffold diff', () => {
+    const base = git('rev-parse', 'HEAD');
+    const head = commitFile(
+      'src/scaffold/templates.ts',
+      "export const generateClaudeMd = () => `\\n**Gadgets are internal by default:** no user output.\\n`;\n",
+      'feat: agent-visible gadgets guidance',
+    );
+
+    const body = [
+      '## UX Impact',
+      '',
+      'Who sees it: every new or upgraded agent. User-visible behavior: the',
+      'generated CLAUDE.md now states `Gadgets are internal by default:` so the',
+      'agent stops narrating gadget activity. First contact: none.',
+    ].join('\n');
+
+    const { code, out } = runLint(base, head, body);
+    expect(code).toBe(0);
+    expect(out).toContain('PASS');
+  });
+
+  it('still SKIPS a genuinely internal path (the allowlist did not over-reach)', () => {
+    const base = git('rev-parse', 'HEAD');
+    const head = commitFile(
+      'src/core/InternalWidget.ts',
+      'export const x = 1;\n',
+      'refactor: internal only',
+    );
+
+    const { code, out } = runLint(base, head, DECLARATION_NONE);
+    expect(code).toBe(0);
+    expect(out).toContain('out of scope');
+  });
+});

--- a/upgrades/next/ux-gate-scaffold-scope.md
+++ b/upgrades/next/ux-gate-scaffold-scope.md
@@ -1,0 +1,54 @@
+<!-- internal-only -->
+
+# UX-impact gate now sees the user-awareness surface
+
+## What Changed
+
+`scripts/ux-impact-lint.mjs` decides whether a PR counts as user-facing by matching
+changed files against a hard-coded allowlist. That allowlist omitted
+`src/scaffold/templates.ts` — the file the Agent Awareness Standard names as THE
+user-awareness surface ("An agent that doesn't know about a capability effectively
+doesn't have it"). A PR touching only that file matched nothing, hit
+`allowlisted.length === 0`, and exited 0. The change that alters what every agent tells
+its users required no UX declaration at all. `src/templates/` (hook and helper scripts)
+was allowlisted; `src/scaffold/` was not.
+
+Three edits, one defect:
+
+1. The `:25` allowlist gains `p === 'src/scaffold/templates.ts'` — the exact file the
+   standard names, in the exact exact-match style already used for two other files.
+   Deliberately **not** `startsWith('src/scaffold/')`: widening a gate beyond what a
+   standard names is a policy change nobody approved.
+2. The `:30` refactor-only exemption excludes that path too — rewriting agent-visible
+   text is never a pure refactor.
+3. The `:41` failure message now names the concept and lists the paths actually
+   searched. It previously read "UX Impact must quote a concrete string from the diff"
+   while searching only the allowlisted subset of the diff, so an author who correctly
+   quoted a real added line from an unlisted file was told something untrue about why
+   they failed.
+
+The gating predicate at `:40` is untouched. `scripts/` is CI-only, is not bundled into
+`dist/`, and is executed by no deployed agent, so no running agent's behaviour changes.
+
+## Evidence
+
+Verified against real commit `e29259c49`, which touches `src/scaffold/templates.ts` and
+zero allowlisted paths (both confirmed by control counts):
+
+| lint | result |
+|---|---|
+| shipping (`origin/main`) | `UX lint: out of scope`, exit 0 — gate skipped entirely |
+| patched | engages, exit 1 on `UX-Impact: none` |
+| patched, replaying PR #1813 | exit 0 — no regression on a real passing PR |
+
+The static contradiction, with a control: `CLAUDE.md` names `src/scaffold/templates.ts`
+as the user-awareness surface, while `ux-impact-lint.mjs` contained `scaffold` zero
+times (control: `templates` = 2, so the search works and this is a true negative).
+
+New test `tests/unit/ux-impact-lint-scaffold-scope.test.ts` covers both sides of the
+boundary and was trip-tested by reverting the lint to `origin/main`: 3/3 pass with the
+fix, 2 fail without it, and the internal-path control passes either way.
+
+Known residual, not claimed as fixed: the allowlist remains a proxy for "user-facing"
+and still omits `PostUpdateMigrator.ts`, skill bodies, and hook templates. This closes
+one hole in one list; the list still has no owner and no review trigger.

--- a/upgrades/side-effects/ux-gate-scaffold-scope.md
+++ b/upgrades/side-effects/ux-gate-scaffold-scope.md
@@ -1,0 +1,152 @@
+# Side-Effects Review — UX-impact gate: recognise `src/scaffold/templates.ts` as a user-facing path
+
+**Version / slug:** `ux-gate-scaffold-scope`
+**Date:** `2026-08-01`
+**Author:** `Echo (instar-dev)`
+**Second-pass reviewer:** `REQUIRED — this change modifies a gate` (see §Second pass)
+
+## Summary of the change
+
+`scripts/ux-impact-lint.mjs` decides whether a PR is "user-facing" by matching changed
+files against a hard-coded allowlist (`:25`). That allowlist omitted
+`src/scaffold/templates.ts` — the file the Agent Awareness Standard names as THE
+user-awareness surface ("An agent that doesn't know about a capability effectively
+doesn't have it"). A PR touching only that file therefore hit `allowlisted.length === 0`
+(`:27`) and exited 0, requiring no UX declaration for the change that alters what every
+agent tells its users. Three edits, one defect: the path joins the allowlist (`:25`), it
+also disqualifies the refactor-only exemption (`:30`), and the quote-check failure message
+(`:41`) now names the concept and lists the paths actually searched. Adds
+`tests/unit/ux-impact-lint-scaffold-scope.test.ts`.
+
+## Decision-point inventory
+
+- `ux-impact-lint.mjs:25` — **modify** — allowlist membership; adds one exact-match path.
+- `ux-impact-lint.mjs:27` — **pass-through** — the in-scope/out-of-scope exit. Unchanged
+  logic; a strictly smaller set of PRs now reaches the `exit(0)` skip.
+- `ux-impact-lint.mjs:30` — **modify** — refactor-only exemption eligibility.
+- `ux-impact-lint.mjs:41` — **modify** — failure MESSAGE only. The predicate at `:40` is
+  untouched.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+A PR that touches `src/scaffold/templates.ts` for a genuinely non-user-visible reason —
+e.g. renaming a local variable inside `generateClaudeMd()`, or reflowing a comment — now
+requires a UX Impact section where previously it required none. That is a real new cost
+imposed on a legitimate input.
+
+Two mitigations, both pre-existing: the `refactor-only` exemption still applies when the
+change adds no quoted strings (`:31`), and the author can satisfy the gate by quoting any
+concrete added string. It is a friction increase, not a wall. Concretely: a
+whitespace-only change to that file will now demand a declaration, which is mildly
+annoying and is the price of the file being in scope at all.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+Substantially more than it catches, and this must not be oversold:
+
+- The allowlist remains a **proxy** for "user-facing" and still omits every other path
+  that can reach a user — `src/core/PostUpdateMigrator.ts` (which writes agent-visible
+  guidance on upgrade), skill `SKILL.md` bodies, `src/data/http-hook-templates.ts`, and
+  any future file that renders text a human reads.
+- The gate only fires on **PR paths**, so a user-visible change delivered by a config
+  default or a runtime string has no coverage here at all.
+- A PR touching `src/scaffold/templates.ts` **and** an already-allowlisted file was
+  already in scope, so for that (common) shape this change alters nothing.
+- The quote check is satisfied by ANY quoted substring present in the allowlisted diff.
+  An author can still quote something trivially true and unrelated to the actual user
+  impact. This change does not make declarations honest; it makes them required.
+
+## 3. Level-of-abstraction fit
+
+The fix operates at the same level as the defect: a path missing from a path list is
+repaired by adding the path. No new abstraction, no new config surface, no new file.
+The alternative — deriving "user-facing" from something semantic rather than a path list
+— would be a genuinely better design and is deliberately NOT attempted here; it is a
+redesign, not a fix, and would ship as its own spec.
+
+## 4. Signal vs authority compliance
+
+The gate is an **authority** (it exits non-zero and blocks a PR), and it stays exactly as
+authoritative as it was — the change alters WHICH files it considers, never WHETHER it
+may block. No new authority is created. The message change at `:41` is pure signal
+improvement and carries no gating weight.
+
+Notably this change does not grant the gate any new power over anything outside the repo,
+and it cannot affect a running agent: `scripts/` is CI-only and ships in no runtime path.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No judgment point is added. Every predicate is deterministic string matching; there is no
+LLM call, no heuristic, and no scoring. The one judgment exercised was authorial and is
+recorded here: **exact-match `src/scaffold/templates.ts` rather than
+`startsWith('src/scaffold/')`**, because the standard names one file and widening a gate
+beyond what a standard names is a policy change no one approved.
+
+## 5. Interactions
+
+- **`.github/workflows/ux-impact-pr-gate.yml`** — unchanged. Its `paths:` trigger already
+  includes `scripts/ux-impact-lint.mjs`, so the workflow's own trigger set needs no edit.
+- **Agent Awareness Standard (CLAUDE.md)** — this change makes the gate agree with the
+  standard rather than contradict it. Nothing else consumes the allowlist.
+- **`report.allowlistedPaths`** (`:26`) — the emitted JSON report may now contain one more
+  path. Any downstream consumer reading that array sees a longer list; no consumer in this
+  repo branches on its contents.
+- **No interaction with the release pipeline, migrations, or PostUpdateMigrator.**
+
+## 6. External surfaces
+
+None. `scripts/ux-impact-lint.mjs` runs only in CI, is not bundled into `dist/`, is not
+served by any route, and is never executed by a deployed agent. No API, no dashboard, no
+Telegram surface, no config key. The only humans who observe a behaviour change are
+contributors opening PRs against this repo.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+The operator-visible surface is the CI failure message, and this change exists partly to
+improve it. Before: `UX Impact must quote a concrete string from the diff` — which is
+misleading, because the script searches only the allowlisted subset of the diff, so an
+author quoting a genuine added line from an unlisted file is told something false about
+why they failed. After: the message names the concept ("the USER-FACING paths this PR
+touches"), enumerates those paths, and states plainly that quotes from other changed files
+are not checked. An author can now self-diagnose in one read.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+Not applicable. CI-only script with no state, no lease interaction, no replication, and no
+per-machine behaviour. It executes once per workflow run on a GitHub runner.
+
+---
+
+## Risks accepted
+
+1. **Friction on incidental edits** to `src/scaffold/templates.ts` (§1). Accepted: the
+   file's whole purpose is agent-visible text, so incidental edits are rare and a
+   declaration is cheap.
+2. **The proxy remains a proxy** (§2). Accepted for this change and explicitly NOT claimed
+   as fixed. The allowlist still has no owner and no review trigger; that is a real
+   residual and is stated in the ELI16 rather than hidden.
+
+## Evidence
+
+Verified against real commit `e29259c49` (touches `src/scaffold/templates.ts`, zero
+allowlisted paths — both confirmed by control counts):
+
+| lint | result |
+|---|---|
+| shipping (`origin/main`) | `UX lint: out of scope`, **exit 0** — gate skipped |
+| patched | engages, **exit 1** on `UX-Impact: none` |
+| patched, replaying PR #1813 | **exit 0** — no regression on a real passing PR |
+
+Tests trip-tested in both directions: **3/3 pass** with the fix; **2 fail** without it;
+the internal-path control passes either way (as a control must).
+
+## Second pass
+
+This change modifies a **gate**, which mandates second-pass review. Requested from Codey
+on the PR. Not self-certified: the reviewer's response will be appended here.


### PR DESCRIPTION
## Summary

`scripts/ux-impact-lint.mjs` decides whether a PR is user-facing by matching changed files against a hard-coded allowlist (`:25`). That allowlist omitted `src/scaffold/templates.ts` — the file the **Agent Awareness Standard** names as THE user-awareness surface: *"Every feature added to Instar MUST include a corresponding update to the CLAUDE.md template (`src/scaffold/templates.ts`). An agent that doesn't know about a capability effectively doesn't have it."*

A PR touching **only** that file matched nothing, hit `allowlisted.length === 0` (`:27`), and exited 0. The change that alters what every agent tells its users required no UX declaration at all. `src/templates/` (hook/helper scripts) was allowlisted; `src/scaffold/` was not — the two directories differ by one word and by everything that matters.

## ELI16 — the gate could not see the file that tells agents what they can do

Instar has a rule with teeth: if your PR touches anything a user sees, you must write a UX Impact note and quote a real line from your own change. A CI check enforces it by comparing your changed files to a hard-coded list. The list had a hole, and the hole was the single most user-facing file in the repo — the one that generates the instructions every agent reads at startup. Change only that file, and the gate printed "out of scope" and waved it through. Full version: `docs/eli16/ux-gate-scaffold-scope.eli16.md`.

## Three edits, one defect

1. **`:25`** — allowlist gains `p === 'src/scaffold/templates.ts'`. Deliberately **not** `startsWith('src/scaffold/')`: the standard names one file, and widening a gate beyond what a standard names is a policy change nobody approved.
2. **`:30`** — the refactor-only exemption excludes that path too; rewriting agent-visible text is never a pure refactor.
3. **`:41`** — the failure message now names the concept and lists the paths actually searched. It previously read *"UX Impact must quote a concrete string from the diff"* while searching only the allowlisted **subset** of the diff — so an author who correctly quoted a real added line from an unlisted file was told something untrue about why they failed.

The gating predicate at `:40` is **untouched**.

## UX Impact

UX-Impact: refactor-only does not apply — but the user-facing surface here is the **CI failure message**, and improving it is part of the change. Who sees it: contributors opening PRs against this repo. What changes: an author whose quote is not in the allowlisted subset now reads which paths were actually searched, instead of a message stating `must quote a concrete string from the diff` that is untrue on its face. First contact: the existing CI check output; no new surface. `scripts/` is CI-only, is not bundled into `dist/`, and is executed by no deployed agent — **no running agent's behaviour changes**.

## Evidence

Verified against real commit `e29259c49` (touches `src/scaffold/templates.ts`, **zero** allowlisted paths — both confirmed by control counts):

| lint | result |
|---|---|
| shipping (`origin/main`) | `UX lint: out of scope`, **exit 0** — gate skipped entirely |
| patched | engages, **exit 1** on `UX-Impact: none` |
| patched, replaying PR #1813 | **exit 0** — no regression on a real passing PR |

Static contradiction, with a control: `CLAUDE.md` names the file; `ux-impact-lint.mjs` contained `scaffold` **0** times (control: `templates` = 2 — a true negative, not a failed lookup).

Test trip-tested by reverting the lint to `origin/main`: **3/3 pass with the fix, 2 fail without it**, and the internal-path control passes either way.

## Known residual — not claimed as fixed

The allowlist is still a **proxy** for "user-facing". It still omits `src/core/PostUpdateMigrator.ts`, skill `SKILL.md` bodies, and `http-hook-templates.ts`, and it still has **no owner and no review trigger**. This closes one hole in one list. The over-block / under-block sections of `upgrades/side-effects/ux-gate-scaffold-scope.md` state that plainly rather than burying it.

## Second pass — requested

@instar-codey this modifies a **gate**, so second-pass review is mandatory and I have not self-certified it. Two things I would most like you to attack:

1. **Is exact-match right, or should it be `startsWith('src/scaffold/')`?** I chose narrow because the standard names one file. You may think the whole directory belongs in scope.
2. **Over-block (§1 of the artifact):** a whitespace-only edit to that file now demands a UX declaration. I judged that acceptable. Push back if you disagree.

## Provenance — how this was found, including a wrong turn

I found this while chasing a **false** finding, and the false one is worth recording. I read two `UX impact declaration` FAILURE rows on #1813 and concluded the gate had cried wolf and been overridden. It had not: all three runs are on the same head sha — fail 23:49:34Z, fail 23:51:25Z, **success 23:54:03Z** — twenty minutes before the merge. Those were **superseded rows**. Your PR was correct and the gate was correct.

I caught it only because I trip-tested before shipping: "the old lint must FAIL on #1813" came back PASS, and that contradiction unravelled the story. The defect in this PR is a *different* one, re-verified from scratch against `e29259c49` rather than inherited from the retracted claim.

