### PR TITLE
fix(standards): classify enforcement headings

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-01T02-39-07-279Z-standards-enforcement-heading-scope.json
+++ b/.instar/instar-dev-decisions/2026-08-01T02-39-07-279Z-standards-enforcement-heading-scope.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-08-01T02:39:07.279Z",
+  "slug": "standards-enforcement-heading-scope",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 411,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/standards-coverage.mjs",
+      "src/core/StandardEnforcementExtractor.ts",
+      "src/core/StandardsEnforcementAuditor.ts",
+      "src/core/StandardsRegistryParser.ts"
+    ],
+    "addedLines": 351,
+    "deletedLines": 60
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/STANDARDS-REGISTRY.md
+++ b/docs/STANDARDS-REGISTRY.md
@@ -647,7 +647,7 @@ that reset-safe posture must be explicit and tested rather than assumed.
 **In practice.** No "remember to log it" or "remember to run X" step survives into a design — for anyone. If a behavior depends on someone remembering, it isn't built yet. All user interaction goes through channels; the agent never asks the user to go edit a file.
 **Earned from.** The methodology-drift incident (2026-05-23): the agent had the Playbook tool available the whole session and never used it to capture "Telegram is the test surface." Agent-manual is the same willpower failure as user-manual.
 **Traces to the goal.** A coherent agent carries its own context and reaches for its own tools — the human shouldn't have to be its memory or its operator's manual.
-**Full spec.** `docs/specs/UX-AND-AGENT-AGENCY-STANDARD.md` (also `docs/UX-AND-AGENT-AGENCY-STANDARD.md`).
+**Full spec.** `docs/UX-AND-AGENT-AGENCY-STANDARD.md`.
 
 ### Mobile-Complete Operator Actions
 **Rule.** Every action that needs the operator — an approval, a grant, a credential submission, a decision, any PIN-gated authority — must be completable from a phone, via the dashboard or a link the agent sends. A terminal command, a file edit, or any laptop-only step in an operator loop is a defect, not a workaround.

--- a/docs/specs/CARTOGRAPHER-CONFORMANCE-AUDIT.md
+++ b/docs/specs/CARTOGRAPHER-CONFORMANCE-AUDIT.md
@@ -65,7 +65,7 @@ Authority": a coverage gap is a signal to build a guard, never an automatic bloc
 
 | Primitive | Source (verified) | Use |
 |---|---|---|
-| registry parse | `StandardsRegistryParser` (`src/core/StandardsRegistryParser.ts`) | parses `docs/STANDARDS-REGISTRY.md` `### ` articles → `{ family, name, rule, inPractice }[]` deterministically, ~30+ articles. v3 extends parsing to ALSO capture the `**Applied through.**` line (and scan `inPractice` + `appliedThrough` text for enforcement references). |
+| registry parse | `StandardsRegistryParser` (`src/core/StandardsRegistryParser.ts`) | parses `docs/STANDARDS-REGISTRY.md` `### ` articles deterministically. Enforcement prose is captured as complete blocks through a closed heading enum (`Applied through`, `Enforced by (structure, not willpower)`, `Enforcement`, `Full spec`, `Full specs`); provenance headings are explicitly excluded, and every unrecognized bold article heading is reported in parse diagnostics. |
 | repo file existence | `fs` | verify a referenced path (`scripts/lint-*.js`, `tests/**/*.test.ts`, `docs/specs/*.md`, `src/**`) exists. |
 | route existence | `src/server/routes.ts` scan | verify a referenced `GET/POST /…` route is registered (regex over the routes source, the `docs-coverage.mjs` pattern). |
 | gate/symbol existence | repo grep | verify a referenced gate/marker symbol (`B16_UNVERIFIED_WALL`, `MessagingToneGate`, `failureSwap`) is present in source. |
@@ -78,10 +78,13 @@ This spec touches **no merged spec #2 code**. It reuses `StandardsRegistryParser
 
 ### Part A — Reference extraction (deterministic)
 
-Extend `StandardsRegistryParser` to capture, per article, the `**Applied through.**`
-line in addition to `rule`/`inPractice` (an additive field `appliedThrough?: string`;
-the existing canary stays green). A new pure `StandardEnforcementExtractor` then pulls
-**enforcement references** from `inPractice` + `appliedThrough`:
+`StandardsRegistryParser` captures `rule` and `inPractice` as complete blocks rather
+than only the text on their label line. It also preserves enforcement blocks under a
+closed enum of guard-naming headings: `Applied through`, `Enforced by (structure, not
+willpower)`, `Enforcement`, `Full spec`, and `Full specs`. The legacy additive
+`appliedThrough?: string` field remains for compatibility; the complete, heading-tagged
+blocks live in `enforcementSections`. A pure `StandardEnforcementExtractor` pulls
+**enforcement references** from `inPractice` plus those allowlisted blocks:
 
 - **File paths** — `` `scripts/lint-*.js` ``, `` `tests/**/*.test.ts` ``,
   `` `docs/specs/*.md` ``, `` `src/**/*.ts` `` (backtick-fenced or bare path tokens).
@@ -94,6 +97,16 @@ the existing canary stays green). A new pure `StandardEnforcementExtractor` then
 Extraction is conservative: a reference is only counted if it matches a known
 enforcement shape. Unmatched prose contributes no reference (→ the standard reads as
 having no *named* guard, which is itself the signal).
+
+The allowlist is deliberately not “all bold headings.” `Earned from`, `Traces to the
+goal`, `Derives from`, `Ratified by`, and `Source documents` are a closed provenance
+denylist: their paths explain origin and must never be promoted into live guards. Any
+other bold article heading is excluded and named under
+`summary.registry.enforcementScope.unrecognizedSections`. Known explanatory headings
+have their own explicit non-enforcement enum, which keeps the real registry's
+unrecognized baseline at zero. The same object publishes the accepted heading enum,
+both exclusion enums, and the number of captured blocks, so “no guard named” is
+distinguishable from “this section was not classified.”
 
 ### Part B — Verification + classification (deterministic)
 
@@ -139,7 +152,9 @@ never-guarded one.
   - `GET /conformance/coverage/health` — counts by `enforcementKind`, the enforced
     ratio (`ratchet+gate+lint` / total), the gap list (`documented-only`), the
     dangling-ref count, last-computed time, `converged` (always true for the
-    deterministic pass). Mirrors `/cartographer/health`.
+    deterministic pass), plus `registry.enforcementScope` stating which section
+    headings were read, deliberately excluded, or left unrecognized. Mirrors
+    `/cartographer/health`.
 - **Store.** The latest report is written to `state/standards-coverage.json` (a single
   compacted current-state document — bounded by the standards count, ~30 rows; no
   unbounded growth, no rotation needed). Output-only; never the read baseline for the
@@ -154,12 +169,14 @@ never-guarded one.
 ### Part E — CI ratchet (the standing guard, observe-only at the repo level)
 
 A `scripts/standards-coverage.mjs --check` (parity with `docs-coverage.mjs`): a
-hardcoded committed floor on the enforced ratio + a hard zero ceiling on **dangling
-refs** (a standard must never reference a guard that doesn't exist). Fails the build
-on regression — a new standard shipped with no guard, or a guard file removed while
-a standard still cites it. The floor starts at the current measured ratio and
-ratchets up as gaps are closed (the docs-coverage "starts loose" rationale). The
-written `state/standards-coverage.json` is measurement-only, never the floor.
+hardcoded committed floor on the enforced ratio + hard zero ceilings on **dangling
+refs** and **unrecognized article headings**. Fails the build on regression — a new
+standard shipped with no guard, a guard file removed while a standard still cites it,
+or a new bold article field whose role was never classified. Its self-contained parser
+is classification-parity-tested against `StandardsRegistryParser` over the real
+registry. The ratio floor is 0.70 against the measured 0.7073, so one new unguarded
+standard (58/83 = 0.6988) trips it. The written `state/standards-coverage.json` is
+measurement-only, never the floor.
 
 ## Security & data-egress
 
@@ -220,10 +237,14 @@ written `state/standards-coverage.json` is measurement-only, never the floor.
   - **the real registry**: a canary asserts the audit parses the LIVE
     `docs/STANDARDS-REGISTRY.md` and classifies a KNOWN-enforced standard ("No Silent
     Degradation" → its `no-silent-llm-fallback.test.ts` ratchet verifies) and that the
-    enforced ratio is within a sane band (catches a parser break).
+    enforced ratio is within a sane band (catches a parser break). The alternate-heading
+    regression proves Framework-Agnostic reads as a ratchet, the three `Full spec(s)`
+    articles read as spec-only, provenance refs stay excluded, and unknown headings
+    remain visible in the scope diagnostics.
   - **CI ratchet script**: enforced-ratio floor fails on a synthetic regression; a
-    synthetic dangling ref fails the zero-dangling ceiling; the floor is the committed
-    constant; output file is never the floor.
+    synthetic dangling ref and a synthetic unknown heading fail their zero ceilings;
+    the self-contained parser matches the library's real classifications; the floor is
+    the committed constant; output file is never the floor.
 - **Tier 2 (integration/HTTP):** `GET /conformance/coverage` + `/coverage/health` →
   200 with the documented shape + filters when enabled; 503 disabled; 401 no bearer;
   the intent-header gate enforced.

--- a/docs/specs/cartographer-conformance-audit.eli16.md
+++ b/docs/specs/cartographer-conformance-audit.eli16.md
@@ -62,3 +62,20 @@ to users too," this same audit becomes a capability a user's own agent inherits:
   file-existence checks are the authority.
 - **Surface, don't fix.** It points at the gaps; it never auto-builds a guard and
   never blocks anything. A gap is information for a human (or the agent) to act on.
+
+## July 2026 update — reading the right sections
+
+The registry uses more than one label for enforcement. Framework-Agnostic says
+“Enforced by (structure, not willpower),” while several articles say “Full spec”
+or “Full specs.” The old parser copied only `In practice` and `Applied through`,
+and only the text carried on those exact label lines. A real ratchet under another
+heading could therefore disappear before the enforcement extractor saw it.
+
+Scanning every bold section would be worse: “Earned from” and “Traces to the goal”
+contain postmortems and historical files, not live guards. The parser now reads
+complete blocks under a short enforcement-heading allowlist, excludes separate
+provenance and explanatory lists, and reports every other heading as unrecognized.
+The real registry has zero unrecognized headings, and CI refuses a new one until its
+role is deliberately classified. On the real
+registry this corrects four false gaps (one ratchet and three spec-only articles),
+moves the named-reference ratio from 0.6951 to 0.7073, and keeps zero dangling refs.

--- a/scripts/standards-coverage.mjs
+++ b/scripts/standards-coverage.mjs
@@ -29,13 +29,15 @@
  *   node scripts/standards-coverage.mjs --json     # JSON to stdout
  *
  * Floors (env override):
- *   STANDARDS_ENFORCED_RATIO_FLOOR  — min enforced ratio 0..1 (default 0 — starts
- *                                     loose, ratcheted up as gaps close)
+ *   STANDARDS_ENFORCED_RATIO_FLOOR  — min enforced ratio 0..1 (default 0.70,
+ *                                     ratcheted up as gaps close)
  *   STANDARDS_DANGLING_CEILING      — max dangling refs (default 0 — zero tolerance)
  *   STANDARDS_FALSE_CLAIM_CEILING   — max standards asserting an unnamed guard
  *                                     (default 1 — the measured 2026-07-31 count;
  *                                     ratchet to 0 once Cross-Store Coherence is
  *                                     resolved)
+ *   STANDARDS_UNRECOGNIZED_SECTION_CEILING — max unclassified article headings
+ *                                     (default 0 — every heading declares a role)
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -65,17 +67,13 @@ const numEnv = (env, def) => {
 };
 const FLOORS = {
   // Started at 0 ("starts loose", the docs-coverage rationale) while the gap closed.
-  // Ratcheted to 0.64 on 2026-07-30: the documented-only set shrank 34 -> 24 that day
-  // (ten standards whose guards already existed gained resolvable citations). THIS
-  // script measures 0.6543; note the library (StandardsEnforcementAuditor, which the
-  // /conformance route serves) measures 0.6585 over 82 standards where this parser
-  // counts 81 — a known one-article discrepancy between two implementations of the
-  // same measure, recorded rather than averaged away. The floor is set against THIS
-  // script's number, since this script is what CI runs, with roughly one standard of
-  // headroom so a single unguarded addition surfaces as a real signal rather than
-  // tripping the build on rounding. It cannot fail a build that does not regress.
-  // Ratchet upward again (a visible PR diff) as the documented-only set shrinks.
-  enforcedRatio: numEnv('STANDARDS_ENFORCED_RATIO_FLOOR', 0.64),
+  // Ratcheted to 0.70 on 2026-07-31 after the self-contained parser was brought
+  // into parity with StandardsRegistryParser: 82 standards, 58 with a named
+  // ratchet/gate/lint ref, ratio 0.7073. The old parser silently ignored alternate
+  // enforcement headings and one whole structurally-detected family, reporting a
+  // different denominator from the API. 0.70 keeps headroom for rounding while a
+  // single new unguarded standard (58/83 = 0.6988) trips the ratchet.
+  enforcedRatio: numEnv('STANDARDS_ENFORCED_RATIO_FLOOR', 0.70),
   // Zero tolerance: a standard must NEVER cite a guard that doesn't exist.
   danglingCeiling: numEnv('STANDARDS_DANGLING_CEILING', 0),
   // A gap that ASSERTS running machinery is a false all-clear, not an honest gap.
@@ -86,36 +84,145 @@ const FLOORS = {
   // without naming it fails immediately. RATCHET TO 0 once Cross-Store Coherence
   // either gets its audit built or has the claim amended out of its prose.
   falseClaimCeiling: numEnv('STANDARDS_FALSE_CLAIM_CEILING', 1),
+  // Zero tolerance: a new bold article section must be explicitly classified as
+  // core, enforcement, provenance, or explanatory narrative.
+  unrecognizedSectionCeiling: numEnv('STANDARDS_UNRECOGNIZED_SECTION_CEILING', 0),
 };
 
 // ── Deterministic parse → extract → verify (mirrors the auditor, self-contained) ──
 
-const STANDARDS_FAMILY_RE = /^##\s+(The Root|The Substrate|Building|Shipping|Interaction)\b/;
 const ANY_H2_RE = /^##\s+/;
+const H2_NAME_RE = /^##\s+(.+?)\s*$/;
 const ARTICLE_RE = /^###\s+(.+?)\s*$/;
-function fieldAfter(line, label) {
-  const m = line.match(new RegExp(`^\\*\\*${label}\\.\\*\\*\\s*(.*)$`));
-  return m ? m[1].trim() : null;
-}
+const FIELD_HEADING_RE = /^\*\*(.+?)\.\*\*\s*(.*)$/;
+const ENFORCEMENT_SECTION_HEADINGS = [
+  'Applied through',
+  'Enforced by (structure, not willpower)',
+  'Enforcement',
+  'Full spec',
+  'Full specs',
+];
+const EXCLUDED_PROVENANCE_SECTION_HEADINGS = [
+  'Derives from',
+  'Earned from',
+  'Ratified by',
+  'Source documents',
+  'Traces to the goal',
+];
+const EXCLUDED_NARRATIVE_SECTION_HEADINGS = [
+  'Applied at the shipping layer',
+  'Balanced by — Responsible Resource',
+  'Benchmarks earn a real job',
+  'Composition with No Silent Degradation',
+  'Constrain the model\'s output with structure, never by matching its prose',
+  'Distinct from Cross-Machine Coherence',
+  'Distinct from Deferral = Deletion',
+  'Distinct from the OnboardingGate',
+  'Neither is whole alone',
+  'Notice and fight the reflex (the load-bearing awareness)',
+  'Per-feature posture (2026-06-12 widening)',
+  'Restart-survival corollary',
+  'The Eternal Sentinel exemption (ratified with the standard)',
+  'The moving threshold (mastery)',
+  'The near-total ban',
+  'Three obligations, in increasing blast radius',
+  'Three postures, in increasing order of ambition',
+];
+const CORE_SECTION_HEADINGS = ['Rule', 'In practice'];
+const ENFORCEMENT_SECTION_HEADING_SET = new Set(ENFORCEMENT_SECTION_HEADINGS);
+const EXCLUDED_PROVENANCE_SECTION_HEADING_SET = new Set(EXCLUDED_PROVENANCE_SECTION_HEADINGS);
+const EXCLUDED_NARRATIVE_SECTION_HEADING_SET = new Set(EXCLUDED_NARRATIVE_SECTION_HEADINGS);
+const CORE_SECTION_HEADING_SET = new Set(CORE_SECTION_HEADINGS);
+const familyName = (heading) => heading.split(/\s+[—–-]\s+/)[0].trim();
+
 function parseRegistry(markdown) {
-  const lines = markdown.split('\n');
-  const articles = [];
-  let fam = null, cur = null;
-  const flush = () => { if (cur && cur.rule) articles.push(cur); cur = null; };
-  for (const line of lines) {
-    const fm = line.match(STANDARDS_FAMILY_RE);
-    if (fm) { flush(); fam = fm[1]; continue; }
-    if (ANY_H2_RE.test(line) && !fm) { flush(); fam = null; continue; }
-    if (!fam) continue;
-    const am = line.match(ARTICLE_RE);
-    if (am) { flush(); cur = { family: fam, name: am[1].trim(), rule: '', inPractice: '', appliedThrough: '' }; continue; }
+  const sections = [];
+  let section = null;
+  let cur = null;
+  let curName = '';
+  let observedSections = [];
+  let field = null;
+
+  const flushField = () => {
+    if (!cur || !field) return;
+    const heading = field.heading;
+    const text = field.lines.join('\n').trim();
+    observedSections.push(heading);
+    if (heading === 'Rule') cur.rule = text;
+    else if (heading === 'In practice') cur.inPractice = text;
+    else if (ENFORCEMENT_SECTION_HEADING_SET.has(heading)) {
+      cur.enforcementSections.push({ heading, text });
+      if (heading === 'Applied through') cur.appliedThrough = text;
+    }
+    field = null;
+  };
+
+  const flush = () => {
+    flushField();
+    if (section && cur) section.blocks.push({ name: curName, article: cur, observedSections });
+    cur = null;
+    curName = '';
+    observedSections = [];
+  };
+
+  for (const line of markdown.split('\n')) {
+    if (ANY_H2_RE.test(line)) {
+      flush();
+      const h2 = line.match(H2_NAME_RE);
+      section = { heading: h2 ? h2[1].trim() : '', blocks: [] };
+      sections.push(section);
+      continue;
+    }
+    if (!section) continue;
+    const articleMatch = line.match(ARTICLE_RE);
+    if (articleMatch) {
+      flush();
+      curName = articleMatch[1].trim();
+      cur = {
+        family: familyName(section.heading), name: curName,
+        rule: '', inPractice: '', appliedThrough: '', enforcementSections: [],
+      };
+      continue;
+    }
     if (!cur) continue;
-    const r = fieldAfter(line, 'Rule'); if (r !== null) { cur.rule = r; continue; }
-    const ip = fieldAfter(line, 'In practice'); if (ip !== null) { cur.inPractice = ip; continue; }
-    const at = fieldAfter(line, 'Applied through'); if (at !== null) { cur.appliedThrough = at; continue; }
+    const fieldMatch = line.match(FIELD_HEADING_RE);
+    if (fieldMatch) {
+      flushField();
+      field = { heading: fieldMatch[1].trim(), lines: [fieldMatch[2]] };
+      continue;
+    }
+    if (field) field.lines.push(line);
   }
   flush();
-  return articles;
+
+  const articles = [];
+  const enforcementScope = {
+    recognizedHeadings: [...ENFORCEMENT_SECTION_HEADINGS],
+    excludedProvenanceHeadings: [...EXCLUDED_PROVENANCE_SECTION_HEADINGS],
+    excludedNarrativeHeadings: [...EXCLUDED_NARRATIVE_SECTION_HEADINGS],
+    capturedSections: 0,
+    unrecognizedSections: [],
+  };
+  for (const candidate of sections) {
+    if (!candidate.blocks.some((block) => block.article.rule)) continue;
+    for (const block of candidate.blocks) {
+      if (!block.article.rule) continue;
+      articles.push(block.article);
+      enforcementScope.capturedSections += block.article.enforcementSections.length;
+      for (const heading of block.observedSections) {
+        if (
+          CORE_SECTION_HEADING_SET.has(heading) ||
+          ENFORCEMENT_SECTION_HEADING_SET.has(heading) ||
+          EXCLUDED_PROVENANCE_SECTION_HEADING_SET.has(heading) ||
+          EXCLUDED_NARRATIVE_SECTION_HEADING_SET.has(heading)
+        ) continue;
+        enforcementScope.unrecognizedSections.push(
+          `${familyName(candidate.heading)} › ${block.name} › ${heading}`,
+        );
+      }
+    }
+  }
+  return { articles, enforcementScope };
 }
 
 const FILE_RE = /`([a-zA-Z0-9_./-]+\.(?:ts|js|mjs|cjs|md|json|sh))`/g;
@@ -127,7 +234,11 @@ const isEnforcementPath = (p) => ENFORCEMENT_PATH_PREFIXES.some((pre) => p.start
 const dedupe = (xs) => [...new Set(xs)];
 
 function extractRefs(a) {
-  const text = `${a.inPractice ?? ''}\n${a.appliedThrough ?? ''}`;
+  const text = [
+    a.inPractice ?? '',
+    a.appliedThrough ?? '',
+    ...(a.enforcementSections ?? []).map((section) => section.text),
+  ].join('\n');
   const files = [];
   for (const m of text.matchAll(FILE_RE)) { if (isEnforcementPath(m[1])) files.push(m[1]); }
   const routes = [];
@@ -177,7 +288,12 @@ const CLAIM_PATTERNS = [
 const PRESCRIPTIVE_NEAR = /\b(?:must|should|shall|needs? to|ought to|is required to)\b[^.]{0,60}$/i;
 
 function detectEnforcementClaims(a) {
-  const text = `${a.rule ?? ''}\n${a.inPractice ?? ''}\n${a.appliedThrough ?? ''}`;
+  const text = [
+    a.rule ?? '',
+    a.inPractice ?? '',
+    a.appliedThrough ?? '',
+    ...(a.enforcementSections ?? []).map((section) => section.text),
+  ].join('\n');
   const hits = [];
   for (const re of CLAIM_PATTERNS) {
     const m = re.exec(text);
@@ -257,10 +373,17 @@ function compute() {
       total: 0, byKind: { ratchet: 0, gate: 0, lint: 0, 'spec-only': 0, 'documented-only': 0 },
       enforcedRatio: 1, gaps: [], falseClaimCount: 0, falseClaims: [],
       danglingCount: 0, danglingByStandard: [],
+      enforcementScope: {
+        recognizedHeadings: [...ENFORCEMENT_SECTION_HEADINGS],
+        excludedProvenanceHeadings: [...EXCLUDED_PROVENANCE_SECTION_HEADINGS],
+        excludedNarrativeHeadings: [...EXCLUDED_NARRATIVE_SECTION_HEADINGS],
+        capturedSections: 0,
+        unrecognizedSections: [],
+      },
     };
   }
 
-  const articles = parseRegistry(markdown);
+  const { articles, enforcementScope } = parseRegistry(markdown);
   const routeTable = loadRouteTable();
   const extracted = articles.map((a) => ({ a, refs: extractRefs(a) }));
   const wanted = new Set();
@@ -307,7 +430,7 @@ function compute() {
   return {
     generatedAt: new Date().toISOString(),
     registryFound: true,
-    total, byKind, enforcedRatio, gaps,
+    total, byKind, enforcedRatio, gaps, enforcementScope,
     falseClaimCount: falseClaims.length, falseClaims,
     danglingCount, danglingByStandard,
   };
@@ -334,8 +457,9 @@ function main() {
       `enforced-ratio=${report.enforcedRatio} (ratchet ${report.byKind.ratchet} / gate ${report.byKind.gate} / ` +
       `lint ${report.byKind.lint} / spec-only ${report.byKind['spec-only']} / gap ${report.byKind['documented-only']}) ` +
       `false-claims=${report.falseClaimCount} ` +
-      `dangling=${report.danglingCount}`);
-    console.error(`[standards-coverage] floors: enforced-ratio>=${FLOORS.enforcedRatio} dangling<=${FLOORS.danglingCeiling} false-claims<=${FLOORS.falseClaimCeiling}`);
+      `dangling=${report.danglingCount} ` +
+      `unrecognized-sections=${report.enforcementScope.unrecognizedSections.length}`);
+    console.error(`[standards-coverage] floors: enforced-ratio>=${FLOORS.enforcedRatio} dangling<=${FLOORS.danglingCeiling} false-claims<=${FLOORS.falseClaimCeiling} unrecognized-sections<=${FLOORS.unrecognizedSectionCeiling}`);
     for (const fc of report.falseClaims) {
       console.error(`[standards-coverage] FALSE CLAIM — "${fc.standard}" asserts running machinery (${fc.claims.map((c) => `"${c}"`).join(', ')}) but names no resolvable guard.`);
     }
@@ -356,10 +480,16 @@ function main() {
       failures.push(`false claims ${report.falseClaimCount} > ceiling ${FLOORS.falseClaimCeiling}` +
         ` — ${report.falseClaims.map((f) => `${f.standard}: asserts [${f.claims.join(', ')}] but names no resolvable guard`).join('; ')}`);
     }
+    if (report.enforcementScope.unrecognizedSections.length > FLOORS.unrecognizedSectionCeiling) {
+      failures.push(
+        `unrecognized article sections ${report.enforcementScope.unrecognizedSections.length} > ceiling ${FLOORS.unrecognizedSectionCeiling}` +
+        ` — ${report.enforcementScope.unrecognizedSections.join('; ')}`,
+      );
+    }
     if (failures.length > 0) {
       process.stderr.write('\n❌ standards-coverage check failed:\n');
       for (const f of failures) process.stderr.write(`  - ${f}\n`);
-      process.stderr.write('\nFix: build a guard for an unguarded standard (raise the ratio), repair the dangling reference (the cited guard file was renamed/removed), or resolve a false claim — a standard whose prose asserts running machinery must either NAME the guard that runs it, or stop claiming it.\n');
+      process.stderr.write('\nFix: build a guard for an unguarded standard (raise the ratio), repair a dangling reference, classify each unknown article heading, or resolve a false claim whose prose asserts unnamed machinery.\n');
       process.exit(1);
     }
     if (!QUIET) console.error('✅ standards-coverage check passed.');

--- a/site/src/content/docs/features/cartographer.md
+++ b/site/src/content/docs/features/cartographer.md
@@ -62,6 +62,14 @@ ratchet beats a gate beats a lint beats a design doc beats nothing). It surfaces
 standard citing a guard that no longer exists). It is "Structure beats Willpower" made
 measurable.
 
+The parser reads complete article blocks through a closed enforcement-heading list,
+not every bold section indiscriminately. Guard headings such as **Applied through**,
+**Enforced by (structure, not willpower)**, and **Full spec(s)** are included;
+provenance such as **Earned from** and **Traces to the goal** is deliberately excluded,
+as are explicitly enumerated explanatory headings. The report's
+`registry.enforcementScope` names those boundaries and lists any unrecognized article
+headings, so an unread section cannot masquerade as an article with no guard.
+
 The core is fully deterministic — local file reads only, zero token cost, zero egress,
 identical output every run. An optional language-model enrichment pass for fuzzy cases
 is a structural stub, off by default; the deterministic coverage is always the
@@ -70,7 +78,7 @@ authority. Read surfaces (owner-gated):
 - `GET /conformance/coverage` — the full per-standard coverage map (filters by
   `family`, `kind`, `status`).
 - `GET /conformance/coverage/health` — counts by enforcement kind, the enforced ratio,
-  the gap list, and the dangling-ref count.
+  the gap list, the dangling-ref count, and the parser's enforcement-heading scope.
 
 A CI ratchet (`scripts/standards-coverage.mjs`) holds an enforced-ratio floor and a
 hard zero ceiling on dangling references.

--- a/src/core/StandardEnforcementExtractor.ts
+++ b/src/core/StandardEnforcementExtractor.ts
@@ -110,11 +110,15 @@ function dedupe(xs: string[]): string[] {
 
 /**
  * Extract enforcement references from a single article. Scans both `inPractice` and
- * `appliedThrough` (the two prose lines that name enforcement). Pure + deterministic:
+ * `appliedThrough` / allowlisted `enforcementSections` (the prose blocks that name enforcement). Pure + deterministic:
  * same article in → same refs out, in stable (sorted) order.
  */
 export function extractEnforcementRefs(article: StandardArticle): ExtractedRefs {
-  const text = `${article.inPractice ?? ''}\n${article.appliedThrough ?? ''}`;
+  const text = [
+    article.inPractice ?? '',
+    article.appliedThrough ?? '',
+    ...(article.enforcementSections ?? []).map((section) => section.text),
+  ].join('\n');
 
   const files: string[] = [];
   for (const m of text.matchAll(FILE_RE)) {

--- a/src/core/StandardsEnforcementAuditor.ts
+++ b/src/core/StandardsEnforcementAuditor.ts
@@ -26,7 +26,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
-import { parseStandardsRegistryDetailed, runRegistryCanary } from './StandardsRegistryParser.js';
+import {
+  ENFORCEMENT_SECTION_HEADINGS,
+  EXCLUDED_NARRATIVE_SECTION_HEADINGS,
+  EXCLUDED_PROVENANCE_SECTION_HEADINGS,
+  parseStandardsRegistryDetailed,
+  runRegistryCanary,
+  type RegistryEnforcementParseScope,
+} from './StandardsRegistryParser.js';
 import { extractEnforcementRefs, flattenRefs, type EnforcementRef } from './StandardEnforcementExtractor.js';
 import { earnsVerified, readAuthoredConstitution, type RegistryIntegrity } from './standardsRegistryPath.js';
 
@@ -106,6 +113,8 @@ export interface RegistryProvenance {
   /** Registry-parse canary verdict — false means the numbers below are NOT trustworthy. */
   canaryOk: boolean;
   canaryFailures: string[];
+  /** What article sections the enforcement parser admitted, excluded, or could not classify. */
+  enforcementScope: RegistryEnforcementParseScope;
 }
 
 export interface CoverageSummary {
@@ -1281,6 +1290,7 @@ export function computeCoverage(
     families: diagnostics.families,
     canaryOk: canary.ok,
     canaryFailures: canary.failures,
+    enforcementScope: diagnostics.enforcementScope,
   };
   const guards = guardResolution.provenance;
   const liveProjectDir = guards.projectDir;
@@ -1393,6 +1403,13 @@ export function unusableCoverageReport(
     families: [],
     canaryOk: false,
     canaryFailures: [`${resolution.reason}: ${resolution.detail}`],
+    enforcementScope: {
+      recognizedHeadings: [...ENFORCEMENT_SECTION_HEADINGS],
+      excludedProvenanceHeadings: [...EXCLUDED_PROVENANCE_SECTION_HEADINGS],
+      excludedNarrativeHeadings: [...EXCLUDED_NARRATIVE_SECTION_HEADINGS],
+      capturedSections: 0,
+      unrecognizedSections: [],
+    },
   };
   return {
     generatedAt: new Date().toISOString(),

--- a/src/core/StandardsRegistryParser.ts
+++ b/src/core/StandardsRegistryParser.ts
@@ -34,7 +34,74 @@ export interface StandardArticle {
    * scans `inPractice` + `appliedThrough` for verifiable enforcement references.
    */
   appliedThrough?: string;
+  /**
+   * Complete blocks whose headings are explicitly allowed to name enforcement.
+   * Unlike the legacy `appliedThrough` field, these retain continuation lines
+   * (including bullet lists) and preserve which closed-enum heading admitted the
+   * text. Provenance/narrative blocks never enter this collection.
+   */
+  enforcementSections?: StandardEnforcementSection[];
 }
+
+/** Headings whose content the enforcement auditor is allowed to inspect. */
+export const ENFORCEMENT_SECTION_HEADINGS = [
+  'Applied through',
+  'Enforced by (structure, not willpower)',
+  'Enforcement',
+  'Full spec',
+  'Full specs',
+] as const;
+
+export type EnforcementSectionHeading = typeof ENFORCEMENT_SECTION_HEADINGS[number];
+
+export interface StandardEnforcementSection {
+  heading: EnforcementSectionHeading;
+  text: string;
+}
+
+/**
+ * Sections that may contain paths but are evidence of origin, not live guards.
+ * Keep this closed and explicit: widening enforcement extraction to arbitrary
+ * bold headings would turn postmortems and design provenance into enforcement.
+ */
+export const EXCLUDED_PROVENANCE_SECTION_HEADINGS = [
+  'Derives from',
+  'Earned from',
+  'Ratified by',
+  'Source documents',
+  'Traces to the goal',
+] as const;
+
+/**
+ * Known explanatory article blocks that are neither core fields, provenance, nor
+ * enforcement. Enumerating them keeps the real registry's unrecognized baseline
+ * at zero: a newly-authored bold heading must be deliberately classified.
+ */
+export const EXCLUDED_NARRATIVE_SECTION_HEADINGS = [
+  'Applied at the shipping layer',
+  'Balanced by — Responsible Resource',
+  'Benchmarks earn a real job',
+  'Composition with No Silent Degradation',
+  'Constrain the model\'s output with structure, never by matching its prose',
+  'Distinct from Cross-Machine Coherence',
+  'Distinct from Deferral = Deletion',
+  'Distinct from the OnboardingGate',
+  'Neither is whole alone',
+  'Notice and fight the reflex (the load-bearing awareness)',
+  'Per-feature posture (2026-06-12 widening)',
+  'Restart-survival corollary',
+  'The Eternal Sentinel exemption (ratified with the standard)',
+  'The moving threshold (mastery)',
+  'The near-total ban',
+  'Three obligations, in increasing blast radius',
+  'Three postures, in increasing order of ambition',
+] as const;
+
+const CORE_SECTION_HEADINGS = ['Rule', 'In practice'] as const;
+const ENFORCEMENT_SECTION_HEADING_SET = new Set<string>(ENFORCEMENT_SECTION_HEADINGS);
+const EXCLUDED_PROVENANCE_SECTION_HEADING_SET = new Set<string>(EXCLUDED_PROVENANCE_SECTION_HEADINGS);
+const EXCLUDED_NARRATIVE_SECTION_HEADING_SET = new Set<string>(EXCLUDED_NARRATIVE_SECTION_HEADINGS);
+const CORE_SECTION_HEADING_SET = new Set<string>(CORE_SECTION_HEADINGS);
 
 /**
  * Standards families are detected STRUCTURALLY, not by name: a `##` section is a
@@ -64,11 +131,8 @@ function familyName(heading: string): string {
   return heading.split(/\s+[—–-]\s+/)[0].trim();
 }
 
-/** Extract the text after a `**Label.**` marker on a line (or '' if absent). */
-function fieldAfter(line: string, label: string): string | null {
-  const m = line.match(new RegExp(`^\\*\\*${label}\\.\\*\\*\\s*(.*)$`));
-  return m ? m[1].trim() : null;
-}
+/** A bold article-field heading plus any text carried on the same line. */
+const FIELD_HEADING_RE = /^\*\*(.+?)\.\*\*\s*(.*)$/;
 
 /**
  * What the parse SAW, so a caller can tell "nothing was dropped" apart from
@@ -87,9 +151,35 @@ export interface RegistryParseDiagnostics {
   droppedHeadings: string[];
   /** `##` sections skipped because no `###` under them carried a Rule (Genesis, Two layers, …). */
   nonFamilySections: string[];
+  /** The exact enforcement-section scope used by this parse. */
+  enforcementScope: RegistryEnforcementParseScope;
 }
 
-interface RawSection { heading: string; blocks: { name: string; article: StandardArticle }[] }
+/**
+ * Makes the parser's trust boundary inspectable at the API surface. A reader can
+ * distinguish "the article named no guard" from "the parser did not classify
+ * this section heading" without widening extraction to provenance by accident.
+ */
+export interface RegistryEnforcementParseScope {
+  /** Closed enum whose blocks may contribute enforcement references. */
+  recognizedHeadings: string[];
+  /** Closed enum deliberately excluded even when its prose contains path-shaped refs. */
+  excludedProvenanceHeadings: string[];
+  /** Closed enum of explanatory blocks deliberately excluded from enforcement. */
+  excludedNarrativeHeadings: string[];
+  /** Number of allowlisted blocks captured across parsed standards. */
+  capturedSections: number;
+  /** Article-qualified bold headings outside the core, allowlist, and provenance denylist. */
+  unrecognizedSections: string[];
+}
+
+interface RawArticleBlock {
+  name: string;
+  article: StandardArticle;
+  observedSections: string[];
+}
+
+interface RawSection { heading: string; blocks: RawArticleBlock[] }
 
 /** Split the registry into `##` sections, each holding its `###` blocks. */
 function readSections(markdown: string): RawSection[] {
@@ -97,11 +187,32 @@ function readSections(markdown: string): RawSection[] {
   let section: RawSection | null = null;
   let cur: StandardArticle | null = null;
   let curName = '';
+  let observedSections: string[] = [];
+  let field: { heading: string; lines: string[] } | null = null;
+
+  const flushField = () => {
+    if (!cur || !field) return;
+    const heading = field.heading;
+    const text = field.lines.join('\n').trim();
+    observedSections.push(heading);
+
+    if (heading === 'Rule') cur.rule = text;
+    else if (heading === 'In practice') cur.inPractice = text;
+    else if (ENFORCEMENT_SECTION_HEADING_SET.has(heading)) {
+      const typedHeading = heading as EnforcementSectionHeading;
+      (cur.enforcementSections ??= []).push({ heading: typedHeading, text });
+      // Backward-compatible field retained for existing consumers.
+      if (typedHeading === 'Applied through') cur.appliedThrough = text;
+    }
+    field = null;
+  };
 
   const flush = () => {
-    if (section && cur) section.blocks.push({ name: curName, article: cur });
+    flushField();
+    if (section && cur) section.blocks.push({ name: curName, article: cur, observedSections });
     cur = null;
     curName = '';
+    observedSections = [];
   };
 
   for (const line of markdown.split('\n')) {
@@ -123,14 +234,15 @@ function readSections(markdown: string): RawSection[] {
     }
     if (!cur) continue;
 
-    const rule = fieldAfter(line, 'Rule');
-    if (rule !== null) { cur.rule = rule; continue; }
-    const inPractice = fieldAfter(line, 'In practice');
-    if (inPractice !== null) { cur.inPractice = inPractice; continue; }
-    // Additive (spec #3): capture the `**Applied through.**` line if present. Same
-    // `fieldAfter` extraction as Rule/In practice; absent on articles without one.
-    const appliedThrough = fieldAfter(line, 'Applied through');
-    if (appliedThrough !== null) { cur.appliedThrough = appliedThrough; continue; }
+    const fieldMatch = line.match(FIELD_HEADING_RE);
+    if (fieldMatch) {
+      flushField();
+      field = { heading: fieldMatch[1].trim(), lines: [fieldMatch[2]] };
+      continue;
+    }
+    // A field is a BLOCK, not only its label line. This is load-bearing for
+    // headings such as `**Enforced by ...**` whose actual refs live in bullets.
+    if (field) field.lines.push(line);
   }
   flush();
   return sections;
@@ -148,6 +260,13 @@ export function parseStandardsRegistryDetailed(
   const articles: StandardArticle[] = [];
   const diagnostics: RegistryParseDiagnostics = {
     families: [], articleHeadings: 0, parsed: 0, droppedHeadings: [], nonFamilySections: [],
+    enforcementScope: {
+      recognizedHeadings: [...ENFORCEMENT_SECTION_HEADINGS],
+      excludedProvenanceHeadings: [...EXCLUDED_PROVENANCE_SECTION_HEADINGS],
+      excludedNarrativeHeadings: [...EXCLUDED_NARRATIVE_SECTION_HEADINGS],
+      capturedSections: 0,
+      unrecognizedSections: [],
+    },
   };
 
   for (const section of sections) {
@@ -160,7 +279,22 @@ export function parseStandardsRegistryDetailed(
     diagnostics.families.push(familyName(section.heading));
     for (const b of section.blocks) {
       diagnostics.articleHeadings += 1;
-      if (b.article.rule) { articles.push(b.article); diagnostics.parsed += 1; }
+      if (b.article.rule) {
+        articles.push(b.article);
+        diagnostics.parsed += 1;
+        diagnostics.enforcementScope.capturedSections += b.article.enforcementSections?.length ?? 0;
+        for (const heading of b.observedSections) {
+          if (
+            CORE_SECTION_HEADING_SET.has(heading) ||
+            ENFORCEMENT_SECTION_HEADING_SET.has(heading) ||
+            EXCLUDED_PROVENANCE_SECTION_HEADING_SET.has(heading) ||
+            EXCLUDED_NARRATIVE_SECTION_HEADING_SET.has(heading)
+          ) continue;
+          diagnostics.enforcementScope.unrecognizedSections.push(
+            `${familyName(section.heading)} › ${b.name} › ${heading}`,
+          );
+        }
+      }
       else diagnostics.droppedHeadings.push(`${familyName(section.heading)} › ${b.name}`);
     }
   }
@@ -232,7 +366,8 @@ export interface RegistryCanaryResult {
  * Run the registry parse canary over a parsed article set.
  *
  * Pass `diagnostics` (from `parseStandardsRegistryDetailed`) to get the real
- * check: every article heading present in a standards family must have parsed.
+ * check: every article heading present in a standards family must have parsed,
+ * and every bold article field must have an explicitly classified role.
  * Without it only the coarse floor + anchor checks run, and the result says so
  * via `completenessAssessed: false` rather than implying a clean bill of health.
  */
@@ -247,6 +382,11 @@ export function runRegistryCanary(
   if (diagnostics && diagnostics.droppedHeadings.length > 0) {
     failures.push(
       `${diagnostics.droppedHeadings.length} of ${diagnostics.articleHeadings} article headings parsed with no **Rule.** line and were dropped: ${diagnostics.droppedHeadings.join('; ')}`,
+    );
+  }
+  if (diagnostics && diagnostics.enforcementScope.unrecognizedSections.length > 0) {
+    failures.push(
+      `${diagnostics.enforcementScope.unrecognizedSections.length} article sections have an unrecognized role and were excluded from enforcement extraction: ${diagnostics.enforcementScope.unrecognizedSections.join('; ')}`,
     );
   }
   for (const anchor of ANCHOR_ARTICLES) {

--- a/tests/e2e/standards-coverage-lifecycle.test.ts
+++ b/tests/e2e/standards-coverage-lifecycle.test.ts
@@ -174,9 +174,39 @@ describe('Standards Enforcement-Coverage Audit — feature is alive (Tier 3 E2E)
     expect(report.summary.total).toBe(parsed.articles.length);
     expect(report.summary.registry.articleHeadings).toBe(parsed.diagnostics.articleHeadings);
     expect(report.summary.registry.droppedHeadings).toEqual([]);
+    expect(report.summary.registry.enforcementScope.recognizedHeadings).toContain(
+      'Enforced by (structure, not willpower)',
+    );
+    expect(report.summary.registry.enforcementScope.excludedProvenanceHeadings).toContain('Earned from');
+    expect(report.summary.registry.enforcementScope.excludedNarrativeHeadings).toContain(
+      'Three postures, in increasing order of ambition',
+    );
+    expect(report.summary.registry.enforcementScope.capturedSections).toBeGreaterThan(0);
+    expect(report.summary.registry.enforcementScope.unrecognizedSections).toEqual([]);
     // Every family in the document is assessed — including one no code names.
     expect(report.summary.registry.families).toEqual(parsed.diagnostics.families);
     expect(report.summary.registry.families).toContain('The Fractal');
+  });
+
+  it('PART A: alternate enforcement headings correct the four known false gaps', () => {
+    const report = computeCoverage({ registryPath: REAL_REGISTRY, projectDir: process.cwd() });
+    const byName = (name: string) => report.standards.find((standard) => standard.standard.startsWith(name));
+
+    const framework = byName('Framework-Agnostic');
+    expect(framework?.enforcementKind).toBe('ratchet');
+    expect(framework?.danglingRefs).toEqual([]);
+    expect(framework?.guards).toEqual(expect.arrayContaining([
+      expect.objectContaining({ ref: 'src/core/frameworkSessionLaunch.ts', refResolves: true }),
+      expect.objectContaining({ ref: 'src/core/frameworkInjectionProcesses.ts', refResolves: true }),
+      expect.objectContaining({ ref: 'tests/unit/framework-agnosticism.test.ts', refResolves: true }),
+    ]));
+
+    expect(byName('Testing Integrity')?.enforcementKind).toBe('spec-only');
+    expect(byName('No Manual Work')?.enforcementKind).toBe('spec-only');
+    expect(byName('Signal vs. Authority')?.enforcementKind).toBe('spec-only');
+    for (const name of ['Framework-Agnostic', 'Testing Integrity', 'No Manual Work', 'Signal vs. Authority']) {
+      expect(report.summary.gaps.some((gap) => gap.startsWith(name))).toBe(false);
+    }
   });
 
   it('PART C: a TRUNCATED registry cannot present itself as a trustworthy assessment', async () => {

--- a/tests/integration/standards-coverage-route.test.ts
+++ b/tests/integration/standards-coverage-route.test.ts
@@ -129,6 +129,13 @@ describe('GET /conformance/coverage (Tier 2 integration)', () => {
     expect(typeof res.body.summary.enforcedRatio).toBe('number');
     expect(Array.isArray(res.body.standards)).toBe(true);
     expect(res.body.count).toBe(3);
+    expect(res.body.summary.registry.enforcementScope).toEqual(expect.objectContaining({
+      recognizedHeadings: expect.arrayContaining(['Applied through', 'Enforced by (structure, not willpower)']),
+      excludedProvenanceHeadings: expect.arrayContaining(['Earned from', 'Traces to the goal']),
+      excludedNarrativeHeadings: expect.arrayContaining(['Three postures, in increasing order of ambition']),
+      capturedSections: 2,
+      unrecognizedSections: [],
+    }));
     const kinds = res.body.standards.map((s: { enforcementKind: string }) => s.enforcementKind);
     expect(kinds).toContain('ratchet');
     expect(kinds).toContain('gate');
@@ -217,6 +224,7 @@ describe('GET /conformance/coverage/health (Tier 2 integration)', () => {
     expect(Array.isArray(res.body.gaps)).toBe(true);
     expect(res.body.gaps).toContain('Gap One');
     expect(res.body.danglingCount).toBe(0);
+    expect(res.body.registry.enforcementScope.recognizedHeadings).toContain('Full specs');
   });
 });
 

--- a/tests/unit/standard-enforcement-extractor.test.ts
+++ b/tests/unit/standard-enforcement-extractor.test.ts
@@ -31,6 +31,19 @@ describe('StandardEnforcementExtractor', () => {
     expect(refs.markers).toContain('MessagingToneGate');
   });
 
+  it('scans an allowlisted enforcement section retained by the parser', () => {
+    const refs = extractEnforcementRefs(article({
+      enforcementSections: [{
+        heading: 'Enforced by (structure, not willpower)',
+        text: 'Compiler `src/core/frameworkSessionLaunch.ts`; ratchet `tests/unit/framework-agnosticism.test.ts`.',
+      }],
+    }));
+    expect(refs.files).toEqual([
+      'src/core/frameworkSessionLaunch.ts',
+      'tests/unit/framework-agnosticism.test.ts',
+    ]);
+  });
+
   it('returns zero refs for bare prose with no enforcement shape', () => {
     const a = article({ inPractice: 'Deferral feels harmless because it still remembers; the cost lands on a successor.' });
     const refs = extractEnforcementRefs(a);

--- a/tests/unit/standards-conformance-gate.test.ts
+++ b/tests/unit/standards-conformance-gate.test.ts
@@ -111,6 +111,24 @@ describe('StandardsRegistryParser', () => {
     expect(canary.failures.join(' ')).toMatch(/of 21 article headings/);
   });
 
+  it('CANARY FAILS when a bold article field has no classified parser role', () => {
+    const md = [
+      '## Building',
+      '### Mystery Standard',
+      '**Rule.** r.',
+      '**A brand-new mystery field.** hidden content',
+    ].join('\n');
+    const { articles, diagnostics } = parseStandardsRegistryDetailed(md);
+    const canary = runRegistryCanary(articles, diagnostics);
+
+    expect(diagnostics.enforcementScope.unrecognizedSections).toEqual([
+      expect.stringContaining('A brand-new mystery field'),
+    ]);
+    expect(canary.ok).toBe(false);
+    expect(canary.failures.join(' ')).toMatch(/unrecognized role/i);
+    expect(canary.failures.join(' ')).toMatch(/A brand-new mystery field/);
+  });
+
   it('CANARY FAILS on a drifted registry (too few articles)', () => {
     const tiny = `## Building\n\n### Only One\n**Rule.** something.\n`;
     const canary = runRegistryCanary(parseStandardsRegistry(tiny));

--- a/tests/unit/standards-coverage-ratchet.test.ts
+++ b/tests/unit/standards-coverage-ratchet.test.ts
@@ -13,6 +13,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
+import { computeCoverage } from '../../src/core/StandardsEnforcementAuditor.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT = path.resolve(__dirname, '../../scripts/standards-coverage.mjs');
@@ -85,6 +86,59 @@ describe('standards-coverage ratchet script', () => {
     expect(r.out).toContain('removed.test.ts');
   });
 
+  it('reads alternate enforcement blocks but excludes provenance headings', () => {
+    write('docs/STANDARDS-REGISTRY.md', [
+      '## Building',
+      '### Alternate Heading',
+      '**Rule.** r.',
+      '**Enforced by (structure, not willpower).** Layers:',
+      '- `tests/unit/widget.test.ts`.',
+      '**Earned from.** `tests/unit/missing-provenance.test.ts`.',
+    ].join('\n'));
+    expect(runCheck({ STANDARDS_ENFORCED_RATIO_FLOOR: '1' }).code).toBe(0);
+
+    write('docs/STANDARDS-REGISTRY.md', [
+      '## Building',
+      '### Provenance Only',
+      '**Rule.** r.',
+      '**Earned from.** `tests/unit/widget.test.ts`.',
+    ].join('\n'));
+    const provenanceOnly = runCheck({ STANDARDS_ENFORCED_RATIO_FLOOR: '1' });
+    expect(provenanceOnly.code).toBe(1);
+    expect(provenanceOnly.out).toContain('enforced ratio');
+  });
+
+  it('FAILS when a bold article section has not been deliberately classified', () => {
+    fs.appendFileSync(
+      path.join(repo, 'docs', 'STANDARDS-REGISTRY.md'),
+      '\n### Unknown Section\n**Rule.** r.\n**Mystery evidence.** `tests/unit/widget.test.ts`.\n',
+    );
+    const r = runCheck({ STANDARDS_ENFORCED_RATIO_FLOOR: '0' });
+    expect(r.code).toBe(1);
+    expect(r.out).toContain('unrecognized article sections');
+    expect(r.out).toContain('Mystery evidence');
+  });
+
+  it('the self-contained CI parser stays classification-compatible with the library parser', () => {
+    const realRoot = path.resolve(__dirname, '../..');
+    const cli = JSON.parse(execFileSync('node', [SCRIPT, '--json'], {
+      cwd: realRoot,
+      encoding: 'utf8',
+      env: { ...process.env, STANDARDS_COVERAGE_ROOT: realRoot },
+    }));
+    const library = computeCoverage({
+      registryPath: path.join(realRoot, 'docs', 'STANDARDS-REGISTRY.md'),
+      projectDir: realRoot,
+    });
+
+    expect(cli.total).toBe(library.summary.total);
+    expect(cli.byKind).toEqual(library.summary.byKind);
+    expect(cli.enforcedRatio).toBe(library.summary.enforcedRatio);
+    expect(cli.gaps).toEqual(library.summary.gaps);
+    expect(cli.danglingCount).toBe(library.summary.danglingCount);
+    expect(cli.enforcementScope).toEqual(library.summary.registry.enforcementScope);
+  });
+
   // ── FALSE-CLAIM DETECTION (2026-07-31) ────────────────────────────────────
   // A gap that ASSERTS running machinery is a false all-clear, not an honest gap.
   // Both sides of the boundary are pinned: a prose CLAIM with no guard is caught;
@@ -137,7 +191,9 @@ describe('standards-coverage ratchet script', () => {
     const report = JSON.parse(fs.readFileSync(outPath, 'utf-8'));
     // The output records the floors but they come from the script constant/env, never
     // from a previously-written output file — corrupting the output cannot lower the bar.
+    expect(report.floors.enforcedRatio).toBe(0.7);
     expect(report.floors.danglingCeiling).toBe(0);
+    expect(report.floors.unrecognizedSectionCeiling).toBe(0);
     fs.writeFileSync(outPath, JSON.stringify({ enforcedRatio: -999, danglingCount: 999, floors: { enforcedRatio: -1, danglingCeiling: 999 } }));
     // The next check ignores the poisoned output entirely and still passes on the real state.
     expect(runCheck().code).toBe(0);

--- a/tests/unit/standards-registry-applied-through.test.ts
+++ b/tests/unit/standards-registry-applied-through.test.ts
@@ -9,9 +9,11 @@ import { describe, it, expect } from 'vitest';
 import path from 'node:path';
 import {
   parseStandardsRegistry,
+  parseStandardsRegistryDetailed,
   loadStandardsRegistry,
   runRegistryCanary,
 } from '../../src/core/StandardsRegistryParser.js';
+import { extractEnforcementRefs } from '../../src/core/StandardEnforcementExtractor.js';
 
 const REGISTRY_PATH = path.join(process.cwd(), 'docs/STANDARDS-REGISTRY.md');
 
@@ -45,6 +47,62 @@ describe('StandardsRegistryParser — appliedThrough field (spec #3)', () => {
     expect(a.name).toBe('Bare Standard');
     expect(a.rule).toBe('Just a rule.');
     expect(a.appliedThrough).toBeUndefined();
+  });
+
+  it('captures allowlisted enforcement BLOCKS without importing provenance or unknown sections', () => {
+    const md = [
+      '## Building',
+      '',
+      '### Framework Floor',
+      '**Rule.** Work everywhere.',
+      '**In practice.** The rule has a continuation:',
+      '- runtime paths stay portable.',
+      '**Enforced by (structure, not willpower).** Three layers:',
+      '- compiler `src/core/frameworkSessionLaunch.ts`.',
+      '- ratchet `tests/unit/framework-agnosticism.test.ts`.',
+      '**Earned from.** Incident `docs/postmortems/not-a-guard.md`.',
+      '**Mystery evidence.** `tests/unit/must-not-be-imported.test.ts`.',
+      '',
+    ].join('\n');
+
+    const { articles, diagnostics } = parseStandardsRegistryDetailed(md);
+    const [article] = articles;
+    expect(article.inPractice).toContain('runtime paths stay portable');
+    expect(article.enforcementSections).toEqual([{
+      heading: 'Enforced by (structure, not willpower)',
+      text: expect.stringContaining('tests/unit/framework-agnosticism.test.ts'),
+    }]);
+
+    const refs = extractEnforcementRefs(article);
+    expect(refs.files).toEqual([
+      'src/core/frameworkSessionLaunch.ts',
+      'tests/unit/framework-agnosticism.test.ts',
+    ]);
+    expect(refs.files).not.toContain('docs/postmortems/not-a-guard.md');
+    expect(refs.files).not.toContain('tests/unit/must-not-be-imported.test.ts');
+
+    expect(diagnostics.enforcementScope.recognizedHeadings).toContain('Enforced by (structure, not willpower)');
+    expect(diagnostics.enforcementScope.excludedProvenanceHeadings).toContain('Earned from');
+    expect(diagnostics.enforcementScope.capturedSections).toBe(1);
+    expect(diagnostics.enforcementScope.unrecognizedSections).toEqual([
+      'Building › Framework Floor › Mystery evidence',
+    ]);
+  });
+
+  it('captures singular and plural Full spec aliases as spec-only enforcement inputs', () => {
+    const md = [
+      '## Building',
+      '### Singular',
+      '**Rule.** r.',
+      '**Full spec.** `docs/specs/singular.md`.',
+      '### Plural',
+      '**Rule.** r.',
+      '**Full specs.** `docs/specs/a.md`, `docs/specs/b.md`.',
+    ].join('\n');
+    const articles = parseStandardsRegistry(md);
+
+    expect(extractEnforcementRefs(articles[0]).files).toEqual(['docs/specs/singular.md']);
+    expect(extractEnforcementRefs(articles[1]).files).toEqual(['docs/specs/a.md', 'docs/specs/b.md']);
   });
 
   it('the real registry has SOME articles carrying an appliedThrough line', () => {

--- a/upgrades/next/standards-enforcement-heading-scope.md
+++ b/upgrades/next/standards-enforcement-heading-scope.md
@@ -1,0 +1,31 @@
+<!-- bump: patch -->
+
+## What Changed
+
+The standards enforcement auditor now reads complete blocks under a closed set of
+guard-naming headings, including `Enforced by (structure, not willpower)` and
+`Full spec(s)`. It explicitly excludes provenance headings and publishes every
+unrecognized article heading in `registry.enforcementScope` instead of silently
+treating unread content as an absent guard. CI now holds that unknown-heading count at
+zero and holds the improved named-reference ratio at a 0.70 floor.
+
+## What to Tell Your User
+
+- **The standards gap list is more accurate:** “The auditor can now see guards named under the registry’s alternate enforcement headings without counting postmortems as protection.”
+- **Its reading boundary is visible:** “The coverage response says which headings it accepts, excludes, and did not recognize.”
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|---|---|
+| Inspect the parser trust boundary | Read `summary.registry.enforcementScope` from the conformance coverage report |
+| Find unclassified registry sections | Review `enforcementScope.unrecognizedSections` |
+| Audit alternate enforcement headings | Use `Enforced by (structure, not willpower)`, `Enforcement`, or `Full spec(s)` in a standards article |
+| Prevent parser drift | The CI parser/library parity test and zero-unknown ceiling run automatically |
+
+## Evidence
+
+Parser-to-extractor tests prove multiline enforcement blocks are retained while
+guard-shaped paths in provenance and unknown sections stay excluded. Real-registry
+tests prove the four corrected classifications, zero dangling refs, and the exact
+82-standard result: 17 gaps and a 0.7073 named-reference resolution ratio.

--- a/upgrades/side-effects/standards-enforcement-heading-scope.md
+++ b/upgrades/side-effects/standards-enforcement-heading-scope.md
@@ -1,0 +1,222 @@
+# Side-Effects Review — Standards Enforcement Heading Scope
+
+**Version / slug:** `standards-enforcement-heading-scope`
+**Date:** `2026-07-31`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** `Hume`
+
+## Summary of the change
+
+This change makes standards enforcement classification follow the registry's actual
+article structure. `StandardsRegistryParser.ts` captures complete multiline fields and
+admits guard references only from an explicit enforcement-heading enum;
+`StandardEnforcementExtractor.ts` consumes those sections;
+`StandardsEnforcementAuditor.ts` exposes parse-scope diagnostics; and the self-contained
+CI parser in `scripts/standards-coverage.mjs` mirrors the runtime behavior with an exact
+parity test. Known provenance and narrative headings remain excluded, while a genuinely
+unknown heading is visible and rejected by both the runtime canary and CI ratchet.
+
+## Build context
+
+- **Canonical remote:** `https://github.com/JKHeadley/instar.git`
+- **Isolated worktree:** `.worktrees/agent-standards-enforcement-heading-scope`
+- **Branch:** `agent/standards-enforcement-heading-scope`
+- **Base:** `7e677149b` (`v1.3.1096`)
+- **Rollback unit:** one source commit plus its release fragment; no state migration
+
+## Decision-point inventory
+
+- `StandardsRegistryParser.parse()` heading classification — **modify** — deterministically
+  classifies each bold registry heading as enforcement, provenance, narrative, or unknown.
+- `StandardEnforcementExtractor.extract()` evidence discovery — **modify** — scans complete
+  allowlisted enforcement sections in addition to the legacy `Applied through` field.
+- `StandardsEnforcementAuditor.audit()` runtime canary — **modify** — reports unclassified
+  headings and treats their presence as an untrustworthy audit input.
+- `scripts/standards-coverage.mjs --check` — **modify** — refuses unknown headings, keeps
+  dangling references at a zero ceiling, and raises the measured enforcement floor from
+  0.64 to 0.70.
+
+---
+
+## 1. Over-block
+
+The new zero-unknown rule will reject a legitimate new registry heading until that
+heading is explicitly assigned to enforcement, provenance, or narrative scope. For
+example, adding `**Verification hooks.**` to an article without updating the parser enum
+will fail the runtime canary and CI. That is intentional: the parser cannot silently
+guess whether paths in a new section are guards. Exact spelling, punctuation, and case
+are part of the structured registry contract, and the failure includes the article and
+heading so the enum can be updated deliberately.
+
+The 0.70 coverage floor leaves 0.0073 measured headroom. One additional unguarded
+standard would reduce the ratio to 58/83 = 0.6988 and fail. This is the intended ratchet
+behavior, not a general runtime block; it prevents the registry from adding an
+enforcement claim without naming a real guard.
+
+---
+
+## 2. Under-block
+
+An allowlisted enforcement section can still make an inaccurate semantic claim about
+what a real path enforces. The existing claim-verification pass detects some such
+overclaims but remains deliberately conservative. A referenced test that is skipped or
+weak still resolves as a live artifact; this change verifies citation existence and
+classification provenance, not test quality. The pre-existing Cross-Store Coherence
+false-claim finding therefore remains visible rather than being hidden by this parser
+change.
+
+A future author can also place prose in an allowlisted section with no paths. That does
+not create enforcement evidence: the extractor still requires a resolvable guard
+reference, so the article stays documented-only.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Heading classification belongs in `StandardsRegistryParser`, which owns the registry
+grammar. Guard-reference recognition remains in `StandardEnforcementExtractor`, and
+artifact existence/classification remains in `StandardsEnforcementAuditor`. This keeps
+the parser from deciding whether a cited file is a real guard.
+
+The CI script must remain self-contained because it runs before the TypeScript build is
+available. Re-implementing the small parser there is therefore necessary, but an exact
+classification-parity test compares its complete article map with the library parser so
+the two implementations cannot drift silently.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [x] Deterministic hard-invariant authority — the input domain is an explicitly enumerated structured registry grammar, not natural-language intent.
+- [ ] ⚠️ Yes, with brittle logic — STOP. Reshape the design.
+
+This is a constrained exception described by the principle itself. The check validates
+the classification of authored Markdown field labels; it does not infer what arbitrary
+prose means or decide a user action. Every current label is enumerated, and an unknown
+label has no safe implicit interpretation because treating provenance as enforcement
+creates false confidence while ignoring enforcement creates a false gap. The runtime
+parser emits the structured unknown-heading signal; the standards audit canary and CI
+policy are the single authorities for their respective decision points and log the
+article/heading evidence behind the failure.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic is added at a competing-signals decision point. Heading
+membership is a closed grammar invariant: there are no live signals such as liveness,
+urgency, ownership, or recency to arbitrate. The system refuses an unknown grammar token
+until an author explicitly classifies it rather than making a contextual judgment from
+the section body.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** parser scope runs before reference extraction by design. Provenance,
+  narrative, and unknown sections never reach path extraction; tests plant guard-shaped
+  paths in those sections and prove they remain excluded.
+- **Double-fire:** the runtime canary and CI ratchet can both report the same unknown
+  heading. They act in different environments and share no mutable state; duplicate
+  detection is useful defense in depth and produces no duplicate external action.
+- **Races:** parsing is synchronous and derived only from immutable file contents. There
+  is no shared state, retry, cleanup, or lifecycle race.
+- **Feedback loops:** registry/source hashes invalidate cached audit reports after a
+  change, but reports never modify the registry. The coverage result cannot feed itself.
+- **Existing checks:** the zero-dangling ceiling and false-claim detector remain active.
+  The corrected No Manual Work citation removes the one newly exposed stale alias
+  without weakening the dangling-reference ratchet.
+
+---
+
+## 6. External surfaces
+
+The owner-gated standards coverage response gains additive
+`registry.enforcementScope` diagnostics and several standards move from
+documented-only to their evidence-backed classifications. The measured registry is now
+82 articles, 17 documented-only gaps, and an enforced ratio of 0.7073. Existing route
+names, filters, legacy `appliedThrough`, and `enforcementBasis` semantics remain
+compatible. The CI floor changes from 0.64 to 0.70 and unknown headings gain a zero
+ceiling.
+
+There are no new external calls, credentials, write endpoints, persistent records,
+notifications, URLs, or operator-facing actions. No Telegram, GitHub, Cloudflare, or
+other integration behavior changes.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Replicated through source control:** every machine running the same code and registry
+bytes derives the same heading scope, guard references, classifications, and coverage
+ratio. No separate runtime replication mechanism is needed because the feature has no
+mutable state. It emits no user-facing notices, holds no durable state that could strand
+on topic transfer, and generates no URLs.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the parser, extractor, auditor, and CI changes and ship the
+  next patch. The independently correct registry citation may remain.
+- **Data migration:** none; all output is derived from source files.
+- **Agent state repair:** none; cached reports invalidate from source hashes.
+- **User visibility:** the additive diagnostics and corrected classifications disappear
+  while rollback propagates, but no user data or workflow state is lost.
+
+---
+
+## Conclusion
+
+The review tightened the initial design from a broad “report excluded headings” model
+to a four-way closed grammar: enforcement, provenance, narrative, or unknown. Unknown
+headings now fail visibly instead of silently entering the documented-only bucket, and
+provenance paths can never masquerade as guards. Focused parser/extractor/auditor tests,
+the exact CI/runtime parity test, the live registry ratchet, lint, and build are green.
+The independent second pass concurred; the change is clear to ship.
+
+---
+
+## Second-pass review (required)
+
+**Reviewer:** Hume
+**Independent read of the artifact:** concur
+
+The closed heading grammar correctly admits only enforcement sections, excludes both
+`Earned from` and `Traces to the goal`, rejects unknown headings as a deterministic
+structural invariant, preserves runtime/CI parity and additive API compatibility, fixes
+the stale No Manual Work citation, and has a clean code-only rollback. The reviewer
+independently confirmed the live ratchet/build and 76 focused tests pass.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/standards-registry-applied-through.test.ts`
+- `tests/unit/standard-enforcement-extractor.test.ts`
+- `tests/unit/standards-conformance-gate.test.ts`
+- `tests/unit/standards-coverage-ratchet.test.ts`
+- `tests/e2e/standards-coverage-lifecycle.test.ts`
+- `node scripts/standards-coverage.mjs --check`
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable. The primary defect is a product
+parser bug over the standards registry; `prompt-parser-contract-drift` explicitly
+excludes genuine parser bugs in non-prompt code. The incidental stale citation was
+corrected, while the zero-dangling ratchet already guards that artifact class.


### PR DESCRIPTION
## Summary

Correct the standards auditor's registry parser so enforcement evidence is discovered from the headings the registry actually uses, without admitting provenance or narrative citations as guards.

The parser now captures complete multiline blocks and classifies headings through a closed enum. `Applied through`, `Enforced by (structure, not willpower)`, `Enforcement`, `Full spec`, and `Full specs` are enforcement-bearing. Provenance headings including `Earned from` and `Traces to the goal` remain excluded. Any genuinely unknown heading is reported and fails both the runtime canary and CI until explicitly classified.

## ELI16 — Read the labels before judging the evidence

Think of each standard as a school report with labeled boxes. Some boxes say how the rule is actually checked; other boxes explain where the idea came from. The auditor used to read only one label, so it missed real checks written under labels such as “Full spec” and wrongly called those standards documentation-only. It now recognizes every approved enforcement label, reads the whole box even when it spans several lines, and deliberately ignores history/provenance boxes. If someone invents a new label later, the auditor stops and names it instead of silently guessing. That keeps both false gaps and false enforcement claims visible.

## Measured impact

- 82 standards total
- documented-only gaps: 21 → 17
- enforced ratio: 0.6951 → 0.7073
- Framework-Agnostic: ratchet
- Testing Integrity, No Manual Work, and Signal vs Authority: spec-only
- dangling references: 0
- unclassified headings: 0

The stale No Manual Work spec alias is corrected to the existing canonical document. Runtime and self-contained CI parser classifications are pinned by an exact parity test.

## Compatibility and safety

The existing `appliedThrough` field remains intact. New enforcement-section and scope-diagnostic fields are additive. The CI floor rises to 0.70, so one new unguarded standard fails the ratchet. A Tier 2 side-effects review and independent reviewer concurrence cover over/under-blocking, signal-vs-authority, interactions, external surfaces, multi-machine behavior, and rollback.

## Verification

- 106 focused tests passed in the final local run
- independent reviewer reran 76 focused tests
- `npm run lint`
- `npm run build`
- `node scripts/standards-coverage.mjs --check`
