### PR TITLE
Make recurring instruments semantically live

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-01T08-43-59-000Z-instrument-semantic-liveness.json
+++ b/.instar/instar-dev-decisions/2026-08-01T08-43-59-000Z-instrument-semantic-liveness.json
@@ -1,0 +1,41 @@
+{
+  "ts": "2026-08-01T08:43:59.000Z",
+  "slug": "instrument-semantic-liveness",
+  "suggestedTier": 2,
+  "declaredTier": 3,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "changes scheduler retry lifecycle",
+    "changes an externally consumed alignment metric denominator",
+    "adds a source-reported job-state contract"
+  ],
+  "belowFloor": false,
+  "files": 20,
+  "loc": 910,
+  "causalAutopsy": {
+    "deliveryCanary": "transport unavailability and measured typed-contract violations collapsed into one hard finding",
+    "alignment": "one legacy invalid confidence row made every valid new row unable to repair the 30-day grade",
+    "retry": "each retry trigger cleared its own episode counter before the failing script rescheduled, making the first delay repeat forever"
+  },
+  "classClosure": {
+    "defectClass": "novel",
+    "closure": "gap",
+    "gapItem": "ACT-378",
+    "component": "instrument-observability",
+    "novelClass": {
+      "nearestExistingClass": "aggregate-masks-subgroup-regression — both are denominator failures, but that class hides a subgroup loss inside a healthy aggregate while this class makes a relevant state unable to influence any verdict",
+      "includes": [
+        "unavailability and a measured contract violation collapse to one verdict",
+        "one legacy invalid row prevents all new valid input repairing a bounded metric",
+        "a verdict hides its measured cohort and exclusions"
+      ],
+      "excludes": [
+        "a constant surface that would react to relevant input",
+        "a young instrument that has simply not seen variety",
+        "an explicit unassessable run that future input can repair"
+      ],
+      "severity": "normal"
+    }
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-01T08-44-00-000Z-script-job-retry-convergence.json
+++ b/.instar/instar-dev-decisions/2026-08-01T08-44-00-000Z-script-job-retry-convergence.json
@@ -1,0 +1,30 @@
+{
+  "ts": "2026-08-01T08:44:00.000Z",
+  "slug": "script-job-retry-convergence",
+  "suggestedTier": 2,
+  "declaredTier": 3,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "changes scheduler retry lifecycle",
+    "fixes a live unbounded self-action episode"
+  ],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 142,
+  "causalAutopsy": {
+    "trigger": "a script subprocess exits nonzero",
+    "feedbackEdge": "the retry trigger cleared retryState before the same failure rescheduled itself",
+    "unboundedShape": "every retry re-entered attempt one and scheduled another one-minute retry"
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "component": "script-job-retry",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/job-retry.test.ts",
+      "howCaught": "The persistent-failure regression holds one cron episode under sustained pressure, proves the counter advances through all six widening delays, and proves steady-state settlement with no seventh self-action until a new cron window."
+    }
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-01T09-29-38-993Z-instrument-semantic-liveness.json
+++ b/.instar/instar-dev-decisions/2026-08-01T09-29-38-993Z-instrument-semantic-liveness.json
@@ -1,0 +1,36 @@
+{
+  "ts": "2026-08-01T09:29:38.993Z",
+  "slug": "instrument-semantic-liveness",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 6,
+  "loc": 253,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/intent.ts",
+      "src/core/InstrumentAssessment.ts",
+      "src/core/IntentDriftDetector.ts",
+      "src/core/types.ts",
+      "src/index.ts",
+      "src/scheduler/JobScheduler.ts"
+    ],
+    "addedLines": 227,
+    "deletedLines": 26
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "The script retry edge carries one episode counter through all six declared delays; the sixth retry exhausts the episode and leaves no timer, proving a steady-state bound and settling brake under sustained failure."
+    },
+    "component": "JobScheduler"
+  },
+  "verdict": "pass"
+}

--- a/docs/defect-classes.json
+++ b/docs/defect-classes.json
@@ -237,6 +237,33 @@
       "evidenceCountAtLastAck": 0,
       "proposalId": null,
       "nearestExistingClass": "unknown-classification-fail-open — both can let an unsafe state pass, but this class hides a known subgroup regression through aggregation rather than permissively classifying unknown input"
+    },
+    {
+      "id": "instrument-semantic-darkness",
+      "description": "An instrument runs and emits output, but its source contract structurally prevents the verdict from changing in response to a relevant world state: distinct states are collapsed into one verdict, or an old blocker makes new valid observations incapable of repairing assessability.",
+      "includes": [
+        "a delivery canary that classifies both an unavailable peer and a measured protocol violation as the same failure verdict",
+        "a composite metric where one legacy invalid row makes every future valid row unable to produce a grade for the whole bounded window",
+        "an instrument that reports a verdict without exposing the measured cohort, exclusions, and coverage needed to know which world states could affect it"
+      ],
+      "excludes": [
+        "a constant output whose source can change when its relevant input changes, such as an empty conflict register that would populate on a real conflict",
+        "a young instrument that has not yet observed varied input but does not structurally collapse distinct states",
+        "an honestly unassessable run with an explicit source-owned reason and a future observation path that can repair it"
+      ],
+      "canonicalExamples": [
+        "2026-08-01: Echo's delivery canary turned an intentionally offline peer into the same hard finding as a reachable peer violating the typed delivery contract",
+        "2026-08-01: alignment scoring stayed N/A over 10 valid rows because any one legacy qualitative confidence poisoned the entire 30-day population"
+      ],
+      "status": "unconfirmed",
+      "severity": "normal",
+      "closureStandard": null,
+      "closureStandardEnforcement": null,
+      "instanceCount": 0,
+      "escalatedAt": null,
+      "evidenceCountAtLastAck": 0,
+      "proposalId": null,
+      "nearestExistingClass": "aggregate-masks-subgroup-regression — both are denominator failures, but that class hides a regressing subgroup inside a healthy aggregate while this class prevents a relevant state or repairable observation from influencing any verdict at all"
     }
   ]
 }

--- a/docs/specs/instrument-semantic-liveness.eli16.md
+++ b/docs/specs/instrument-semantic-liveness.eli16.md
@@ -1,0 +1,38 @@
+# Instruments must be able to react to what they measure
+
+A monitor is not useful merely because it runs. It must be able to tell apart
+the world states its verdict claims to describe.
+
+Echo found a delivery check that called a sleeping laptop a delivery failure.
+The same red result also meant a reachable machine had violated the delivery
+protocol. Because ordinary unavailability and a real contract defect became the
+same verdict, the alert could never become quiet whenever that laptop was shut.
+People naturally learned to ignore it.
+
+The alignment grade had the opposite-looking version of the same problem. Ten
+new decisions contained valid numeric confidence, but fifteen older decisions
+contained words such as “high.” One old word forced the entire score to remain
+unavailable. New good data could not repair the instrument for almost a month.
+
+This change does not guess that an instrument is broken merely because its value
+stays constant. A conflict list may correctly stay empty for years; it would
+change as soon as a real conflict existed. Repetition cannot distinguish that
+healthy case from a broken mapping, so there is no arbitrary “after N equal
+runs, declare darkness” rule.
+
+Instead, each script instrument may report whether it really assessed anything,
+what verdict it reached, how many candidates it measured, and why it excluded
+the rest. The scheduler checks that the numbers agree and saves the report. An
+offline peer is now an explicit exclusion that lowers coverage, not a delivery
+failure. A reachable peer returning the wrong typed answer is still a measured
+failure and remains loud.
+
+Alignment now follows the same honesty rule. Only rows with measurable numeric
+confidence join the scored cohort, and that same cohort is used for every score
+component. The response says both “10 rows measured” and “40 rows existed,” plus
+the missing and invalid counts. This avoids mixing denominators while letting
+valid new entries affect the grade immediately.
+
+Finally, the scheduler retry counter now survives retry attempts. A script that
+keeps failing gets six widening retries and then waits for its next scheduled
+window. It can no longer reset itself to the first one-minute retry forever.

--- a/docs/specs/instrument-semantic-liveness.md
+++ b/docs/specs/instrument-semantic-liveness.md
@@ -1,0 +1,108 @@
+---
+title: "Instrument Semantic Liveness"
+slug: "instrument-semantic-liveness"
+author: "instar-codey"
+status: "implemented"
+approved: true
+origin: "Echo mentor-lane finding, 2026-08-01"
+---
+
+# Instrument Semantic Liveness
+
+## Problem
+
+An instrument can execute on schedule while being unable to respond honestly to
+the world. Two live mechanisms established the boundary:
+
+1. A delivery canary collapsed a peer being unavailable and a reachable peer
+   violating the typed delivery contract into the same hard failure.
+2. Alignment scoring allowed any one legacy qualitative confidence value to
+   poison the whole 30-day score, so new numeric rows could not repair the
+   verdict until the old row aged out.
+
+Repeated constancy is not sufficient evidence. An empty conflict register is a
+negative control: it can remain empty indefinitely and is still live because a
+real conflict would populate it. The predicate is semantic incapacity, not a
+history pattern.
+
+## Decisions
+
+### 1. Source reporting, not a central guesser
+
+Script instruments may emit one final line beginning with
+`INSTAR_INSTRUMENT_ASSESSMENT=` followed by JSON. The scheduler validates and
+preserves the report in job state. It never infers a verdict from repeated
+output, and it never treats process exit status as proof that a measurement was
+available.
+
+The report contains:
+
+- `status`: `assessed` or `unassessable`;
+- `verdict`: `pass`, `fail`, or `none` (only `none` is valid when unassessable);
+- a nonempty source-owned reason;
+- `populationSize`, `sampleSize`, and `excludedSampleSize`;
+- named exclusion counts and exact `sampleCoverage`.
+
+The parser rejects inconsistent totals, coverage, or status/verdict pairs. An
+ordinary script that emits no marker remains an ordinary script.
+
+### 2. No global N floor
+
+There is no run-count threshold. No value of N can prove semantic incapacity:
+the conflict register can correctly report the same outcome for a million runs,
+while a broken canary can collapse distinct states on its first run. History may
+support an advisory investigation, but authority comes from the source contract
+and its declared cohort.
+
+### 3. One cohort for a composite
+
+Alignment uses only decisions with measurable numeric confidence as one common
+cohort for all four components. Rows with missing or invalid confidence are
+excluded from conflict freedom, confidence, principle consistency, and journal
+health alike. This prevents a remedy from introducing mixed denominators.
+
+The API publishes both sides: `sampleSize` is the measured cohort;
+`populationSize` is every row in the period; exclusions are split into missing
+and invalid confidence; and `sampleCoverage` makes partial evidence explicit.
+If the common cohort is empty the response stays honestly unassessable. Once one
+valid row exists, valid new input can move the score immediately without
+rewriting legacy data or inventing a numeric meaning for qualitative labels.
+
+### 4. Availability is not conformance
+
+The live delivery canary classifies each peer arm as assessed or unavailable.
+A reachable, typed mesh response is assessed and may pass or fail. A transport
+error or an untyped edge/gateway HTTP response is excluded and lowers coverage;
+neither creates a delivery-contract finding or a retry-triggering nonzero exit.
+The local registry arm remains measured, so the suite can report a partial
+assessment without calling every peer reachable.
+
+### 5. Retry convergence is independent
+
+Script job retries retain their episode counter across `retry:*` triggers. A
+fresh cron or explicit trigger begins a new episode; successful subprocess
+completion clears it. Entering `pending` also preserves the durable consecutive-
+failure streak; only real success resets that counter. A persistent script
+failure therefore follows the six declared delays and stops until the next cron
+window instead of resetting to the one-minute delay forever.
+
+## Compatibility and rollback
+
+All fields are additive except the clarified alignment `sampleSize` meaning. It
+now means the cohort actually scored; consumers needing the old population
+count use `populationSize`. Existing journal rows remain untouched. Scripts that
+do not opt into the marker protocol behave exactly as before. Code rollback is
+safe; no persistent migration is required.
+
+## Verification
+
+- Parser tests accept assessed and unassessable reports, reject incoherent
+  source claims, and use repeated empty conflicts as the negative control.
+- Scheduler tests preserve source reports and prove a persistent script failure
+  stops after six escalating retries.
+- Alignment tests prove legacy invalid/missing rows cannot darken valid new
+  input and prove every component uses the same cohort.
+- The live Echo canary source was syntax-checked after adopting unavailable
+  exclusions and the source-reported field. Its real peer probe classified a
+  live HTTP 530 edge response as unavailable, reported 1/2 measured coverage,
+  emitted no finding, and exited zero.

--- a/src/commands/intent.ts
+++ b/src/commands/intent.ts
@@ -452,6 +452,16 @@ export async function intentDrift(options: IntentDriftOptions): Promise<void> {
   console.log(`    Confidence Level:       ${alignment.components.confidenceLevel}/100`);
   console.log(`    Principle Consistency:  ${alignment.components.principleConsistency}/100`);
   console.log(`    Journal Health:         ${alignment.components.journalHealth}/100`);
+  console.log(
+    `    Measured Cohort:        ${alignment.sampleSize}/${alignment.populationSize} ` +
+    `(${(alignment.sampleCoverage * 100).toFixed(1)}%; ${alignment.excludedSampleSize} excluded)`,
+  );
+  if (alignment.excludedSampleSize > 0) {
+    console.log(
+      `      Missing confidence: ${alignment.exclusions.missingConfidence}; ` +
+      `invalid confidence: ${alignment.exclusions.invalidConfidence}`,
+    );
+  }
   console.log();
 }
 

--- a/src/core/InstrumentAssessment.ts
+++ b/src/core/InstrumentAssessment.ts
@@ -1,0 +1,92 @@
+/**
+ * Source-reported measurement state for recurring instruments.
+ *
+ * This is deliberately not a generic "dark instrument detector". Repeatedly
+ * equal outcomes cannot distinguish a healthy empty-conflict register from a
+ * canary that maps every transport state to failure. The source owns that
+ * semantic distinction; the scheduler only validates and preserves its report.
+ */
+
+export const INSTRUMENT_ASSESSMENT_MARKER = 'INSTAR_INSTRUMENT_ASSESSMENT=';
+
+export interface InstrumentAssessment {
+  /** Whether this run produced any real measurement. */
+  status: 'assessed' | 'unassessable';
+  /** A verdict exists only when the run was assessed. */
+  verdict: 'pass' | 'fail' | 'none';
+  /** Stable source-owned explanation, suitable for operator surfaces. */
+  reason: string;
+  /** Full candidate population for this run. */
+  populationSize: number;
+  /** Common measured cohort used for the verdict. */
+  sampleSize: number;
+  /** Candidates that could not be measured. */
+  excludedSampleSize: number;
+  /** Source-owned exclusion categories whose counts sum to excludedSampleSize. */
+  exclusions: Record<string, number>;
+  /** sampleSize / populationSize, or 0 for an empty population. */
+  sampleCoverage: number;
+}
+
+export function parseInstrumentAssessment(output: string): InstrumentAssessment | null {
+  const line = output
+    .split(/\r?\n/)
+    .reverse()
+    .find(candidate => candidate.startsWith(INSTRUMENT_ASSESSMENT_MARKER));
+  if (!line) return null;
+
+  let value: unknown;
+  try {
+    value = JSON.parse(line.slice(INSTRUMENT_ASSESSMENT_MARKER.length));
+  } catch {
+    // @silent-fallback-ok — malformed source claims carry no authority and are
+    // deliberately treated exactly like an absent optional assessment marker.
+    return null;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  if (row.status !== 'assessed' && row.status !== 'unassessable') return null;
+  if (row.verdict !== 'pass' && row.verdict !== 'fail' && row.verdict !== 'none') return null;
+  if (row.status === 'assessed' && row.verdict === 'none') return null;
+  if (row.status === 'unassessable' && row.verdict !== 'none') return null;
+  if (typeof row.reason !== 'string' || row.reason.trim().length === 0) return null;
+
+  const populationSize = nonNegativeInteger(row.populationSize);
+  const sampleSize = nonNegativeInteger(row.sampleSize);
+  const excludedSampleSize = nonNegativeInteger(row.excludedSampleSize);
+  if (populationSize === null || sampleSize === null || excludedSampleSize === null) return null;
+  if (sampleSize + excludedSampleSize !== populationSize) return null;
+  if (row.status === 'assessed' && sampleSize === 0) return null;
+  if (row.status === 'unassessable' && sampleSize !== 0) return null;
+
+  if (!row.exclusions || typeof row.exclusions !== 'object' || Array.isArray(row.exclusions)) return null;
+  const exclusions: Record<string, number> = {};
+  for (const [key, count] of Object.entries(row.exclusions as Record<string, unknown>)) {
+    if (!key.trim()) return null;
+    const parsed = nonNegativeInteger(count);
+    if (parsed === null) return null;
+    exclusions[key] = parsed;
+  }
+  if (Object.values(exclusions).reduce((sum, count) => sum + count, 0) !== excludedSampleSize) return null;
+
+  const expectedCoverage = populationSize > 0 ? sampleSize / populationSize : 0;
+  if (typeof row.sampleCoverage !== 'number' || !Number.isFinite(row.sampleCoverage)) return null;
+  if (Math.abs(row.sampleCoverage - expectedCoverage) > Number.EPSILON * 8) return null;
+
+  return {
+    status: row.status,
+    verdict: row.verdict,
+    reason: row.reason,
+    populationSize,
+    sampleSize,
+    excludedSampleSize,
+    exclusions,
+    sampleCoverage: row.sampleCoverage,
+  };
+}
+
+function nonNegativeInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : null;
+}

--- a/src/core/IntentDriftDetector.ts
+++ b/src/core/IntentDriftDetector.ts
@@ -82,8 +82,19 @@ export interface AlignmentScore {
     /** Whether decisions are being logged regularly */
     journalHealth: number;
   };
-  /** Number of decisions analyzed */
+  /** Number of decisions in the common measurable cohort used by every component. */
   sampleSize: number;
+  /** Total decisions found in the requested period, before measurement exclusions. */
+  populationSize: number;
+  /** Decisions excluded from the common cohort. Always populationSize - sampleSize. */
+  excludedSampleSize: number;
+  /** Why decisions were excluded from the common cohort. */
+  exclusions: {
+    missingConfidence: number;
+    invalidConfidence: number;
+  };
+  /** Common-cohort coverage of the period population, from 0 to 1. */
+  sampleCoverage: number;
   /** Period analyzed */
   periodDays: number;
   /**
@@ -170,6 +181,35 @@ export class IntentDriftDetector {
    */
   alignmentScore(periodDays: number = 30): AlignmentScore {
     const entries = this.journal.read({ days: periodDays });
+    const confidenceClasses = entries.map(entry => ({
+      entry,
+      confidence: classifyDecisionConfidence(
+        (entry as { confidence?: unknown }).confidence,
+      ),
+    }));
+    const measurableEntries = confidenceClasses
+      .filter((row): row is {
+        entry: DecisionJournalEntry;
+        confidence: { status: 'valid'; value: number };
+      } => row.confidence.status === 'valid')
+      .map(row => row.entry);
+    const missingConfidence = confidenceClasses.filter(
+      row => row.confidence.status === 'missing',
+    ).length;
+    const invalidConfidence = confidenceClasses.filter(
+      row => row.confidence.status === 'invalid',
+    ).length;
+    const populationSize = entries.length;
+    const sampleSize = measurableEntries.length;
+    const excludedSampleSize = populationSize - sampleSize;
+    const sampleCoverage = populationSize > 0 ? sampleSize / populationSize : 0;
+    const measurement = {
+      sampleSize,
+      populationSize,
+      excludedSampleSize,
+      exclusions: { missingConfidence, invalidConfidence },
+      sampleCoverage,
+    };
 
     if (entries.length === 0) {
       return {
@@ -180,7 +220,7 @@ export class IntentDriftDetector {
           principleConsistency: 0,
           journalHealth: 0,
         },
-        sampleSize: 0,
+        ...measurement,
         periodDays,
         // NOT 'F'. Nothing was assessed, so there is no grade to report.
         grade: 'N/A',
@@ -189,10 +229,33 @@ export class IntentDriftDetector {
       };
     }
 
-    const conflictFreedom = this.computeConflictFreedom(entries);
-    const confidenceLevel = this.computeConfidenceLevel(entries);
-    const principleConsistency = this.computePrincipleConsistency(entries);
-    const journalHealth = this.computeJournalHealth(entries, periodDays);
+    if (measurableEntries.length === 0) {
+      return {
+        score: 0,
+        components: {
+          conflictFreedom: 0,
+          confidenceLevel: 0,
+          principleConsistency: 0,
+          journalHealth: 0,
+        },
+        ...measurement,
+        periodDays,
+        grade: 'N/A',
+        assessable: false,
+        summary:
+          `No decisions have measurable confidence — alignment cannot be assessed ` +
+          `(${missingConfidence} missing confidence, ${invalidConfidence} invalid confidence; ` +
+          `${populationSize} total).`,
+      };
+    }
+
+    // One denominator for the whole composite. A row excluded from confidence
+    // is excluded from every component; otherwise the weighted score would mix
+    // incompatible populations and conceal which decisions it actually grades.
+    const conflictFreedom = this.computeConflictFreedom(measurableEntries);
+    const confidenceLevel = this.computeConfidenceLevel(measurableEntries);
+    const principleConsistency = this.computePrincipleConsistency(measurableEntries);
+    const journalHealth = this.computeJournalHealth(measurableEntries, periodDays);
 
     // Weighted average: conflictFreedom(30%) + confidenceLevel(25%) + principleConsistency(25%) + journalHealth(20%)
     const rawScore =
@@ -204,14 +267,6 @@ export class IntentDriftDetector {
     const score = Math.round(rawScore);
     const grade = this.scoreToGrade(score);
     if (grade === 'N/A') {
-      const invalidConfidenceCount = entries.filter(
-        entry => classifyDecisionConfidence(
-          (entry as { confidence?: unknown }).confidence,
-        ).status === 'invalid',
-      ).length;
-      const reason = invalidConfidenceCount > 0
-        ? `${invalidConfidenceCount} decision(s) have invalid confidence values`
-        : 'A score component is non-finite';
       return {
         // Keep JSON honest. Returning NaN would serialize as null, recreating
         // the incident under a different grade.
@@ -222,15 +277,22 @@ export class IntentDriftDetector {
           principleConsistency: 0,
           journalHealth: 0,
         },
-        sampleSize: entries.length,
+        ...measurement,
         periodDays,
         grade: 'N/A',
         assessable: false,
-        summary: `${reason} — alignment cannot be assessed.`,
+        summary: 'A score component is non-finite — alignment cannot be assessed.',
       };
     }
 
-    const summary = this.buildAlignmentSummary(score, grade, entries.length, periodDays);
+    const summary = this.buildAlignmentSummary(
+      score,
+      grade,
+      sampleSize,
+      populationSize,
+      excludedSampleSize,
+      periodDays,
+    );
 
     return {
       score,
@@ -240,7 +302,7 @@ export class IntentDriftDetector {
         principleConsistency: Math.round(principleConsistency),
         journalHealth: Math.round(journalHealth),
       },
-      sampleSize: entries.length,
+      ...measurement,
       periodDays,
       grade,
       assessable: true,
@@ -553,7 +615,14 @@ export class IntentDriftDetector {
     return 'F';
   }
 
-  private buildAlignmentSummary(score: number, grade: string, sampleSize: number, periodDays: number): string {
+  private buildAlignmentSummary(
+    score: number,
+    grade: string,
+    sampleSize: number,
+    populationSize: number,
+    excludedSampleSize: number,
+    periodDays: number,
+  ): string {
     if (sampleSize === 0) return 'No decisions logged — alignment cannot be assessed.';
 
     const gradeDescriptions: Record<string, string> = {
@@ -564,6 +633,9 @@ export class IntentDriftDetector {
       F: 'Poor alignment — decisions are not tracking intent.',
     };
 
-    return `${gradeDescriptions[grade]} (${sampleSize} decisions over ${periodDays} days)`;
+    const coverage = populationSize > 0
+      ? `; ${sampleSize}/${populationSize} measurable, ${excludedSampleSize} excluded`
+      : '';
+    return `${gradeDescriptions[grade]} (${sampleSize} decisions over ${periodDays} days${coverage})`;
   }
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -682,6 +682,8 @@ export interface JobState {
   lastError?: string;
   /** Handoff notes from the last successful run — claims to verify, not facts */
   lastHandoff?: string;
+  /** Source-reported measurement state from the last script run, when present. */
+  lastAssessment?: import('./InstrumentAssessment.js').InstrumentAssessment;
   nextScheduled?: string;
   consecutiveFailures: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,11 @@ export type {
   JobReflectorConfig,
 } from './core/JobReflector.js';
 export { IntentDriftDetector } from './core/IntentDriftDetector.js';
+export {
+  INSTRUMENT_ASSESSMENT_MARKER,
+  parseInstrumentAssessment,
+} from './core/InstrumentAssessment.js';
+export type { InstrumentAssessment } from './core/InstrumentAssessment.js';
 export type { DriftWindow, DriftSignal, DriftAnalysis, AlignmentScore } from './core/IntentDriftDetector.js';
 export { OrgIntentManager } from './core/OrgIntentManager.js';
 export type { OrgConstraint, OrgGoal, ParsedOrgIntent, IntentConflict, IntentValidationResult } from './core/OrgIntentManager.js';

--- a/src/scheduler/JobScheduler.ts
+++ b/src/scheduler/JobScheduler.ts
@@ -15,6 +15,7 @@ import fs from 'node:fs';
 import crypto from 'node:crypto';
 import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+import { parseInstrumentAssessment } from '../core/InstrumentAssessment.js';
 
 const execFileAsync = promisify(execFile);
 import path from 'node:path';
@@ -663,7 +664,11 @@ export class JobScheduler {
     // "Run this script: ..." prompt and could hang for hours holding a live
     // session slot, leaving run-history stuck at `pending` (Codey gap-run F005).
     if (job.execute.type === 'script') {
-      this.clearRetryState(slug);
+      // A retry belongs to the current bounded retry episode. Clearing here on
+      // every trigger made each failing script retry look like attempt zero, so
+      // it could repeat the one-minute slot forever. Cron windows clear above;
+      // explicit/non-retry triggers begin a fresh episode here.
+      if (!reason.startsWith('retry:')) this.clearRetryState(slug);
       this.runScriptJob(job, reason);
       return 'triggered';
     }
@@ -1054,12 +1059,16 @@ export class JobScheduler {
       clampedAllowlist: observability.clampedAllowlist,
     });
 
+    const priorConsecutiveFailures = this.state.getJobState(job.slug)?.consecutiveFailures ?? 0;
     this.state.saveJobState({
       slug: job.slug,
       lastRun: new Date().toISOString(),
       lastResult: 'pending',
       lastError: undefined,
-      consecutiveFailures: 0,
+      // Starting another attempt is not recovery. Preserve the durable streak
+      // until the subprocess actually succeeds; resetting here made every
+      // persistent script failure appear to be failure #1 forever.
+      consecutiveFailures: priorConsecutiveFailures,
       nextScheduled: this.getNextRun(job.slug),
     });
 
@@ -1093,34 +1102,45 @@ export class JobScheduler {
       env,
       maxBuffer: 1024 * 1024,
     }).then(({ stdout, stderr }) => {
-      const output = [stdout, stderr].filter(Boolean).join('\n').slice(-1000);
+      // Successful completion (not merely successful trigger) closes the retry
+      // episode for script jobs.
+      this.clearRetryState(job.slug);
+      const rawOutput = [stdout, stderr].filter(Boolean).join('\n');
+      const output = rawOutput.slice(-1000);
+      const lastAssessment = parseInstrumentAssessment(rawOutput) ?? undefined;
       this.runHistory.recordCompletion({ runId, result: 'success', outputSummary: output || undefined });
       this.state.saveJobState({
         slug: job.slug,
         lastRun: new Date().toISOString(),
         lastResult: 'success',
         lastError: undefined,
+        lastAssessment,
         consecutiveFailures: 0,
         nextScheduled: this.getNextRun(job.slug),
       });
       this.releaseClaim(job.slug, 'success');
     }).catch((err: unknown) => {
       const errorMsg = err instanceof Error ? err.message : String(err);
-      const output = [
+      const rawOutput = [
         (err as { stdout?: string })?.stdout,
         (err as { stderr?: string })?.stderr,
-      ].filter(Boolean).join('\n').slice(-1000);
+      ].filter(Boolean).join('\n');
+      const output = rawOutput.slice(-1000);
+      const lastAssessment = parseInstrumentAssessment(rawOutput) ?? undefined;
       const result = errorMsg.includes('timed out') || errorMsg.includes('ETIMEDOUT') ? 'timeout' : 'failure';
       this.runHistory.recordCompletion({ runId, result, error: errorMsg, outputSummary: output || undefined });
       const previous = this.state.getJobState(job.slug);
+      const consecutiveFailures = (previous?.consecutiveFailures ?? 0) + 1;
       this.state.saveJobState({
         slug: job.slug,
         lastRun: new Date().toISOString(),
         lastResult: result,
         lastError: errorMsg,
-        consecutiveFailures: (previous?.consecutiveFailures ?? 0) + 1,
+        lastAssessment,
+        consecutiveFailures,
         nextScheduled: this.getNextRun(job.slug),
       });
+      this.alertOnConsecutiveFailures(job, consecutiveFailures, errorMsg);
       this.releaseClaim(job.slug, 'failure');
       this.scheduleRetry(job.slug, 'error');
     });

--- a/tests/integration/drift-routes.test.ts
+++ b/tests/integration/drift-routes.test.ts
@@ -207,6 +207,9 @@ describe('Drift & Alignment Routes (integration)', () => {
       expect(res.body.assessable).toBe(false);
       expect(res.body.summary).toMatch(/cannot be assessed/i);
       expect(res.body.sampleSize).toBe(0);
+      expect(res.body.populationSize).toBe(0);
+      expect(res.body.excludedSampleSize).toBe(0);
+      expect(res.body.sampleCoverage).toBe(0);
       expect(res.body.components).toBeTruthy();
       expect(res.body.components.conflictFreedom).toBe(0);
       expect(res.body.components.confidenceLevel).toBe(0);
@@ -235,6 +238,9 @@ describe('Drift & Alignment Routes (integration)', () => {
       expect(res.body.score).toBeGreaterThan(0);
       expect(['A', 'B', 'C', 'D', 'F']).toContain(res.body.grade);
       expect(res.body.sampleSize).toBe(20);
+      expect(res.body.populationSize).toBe(20);
+      expect(res.body.excludedSampleSize).toBe(0);
+      expect(res.body.sampleCoverage).toBe(1);
       expect(res.body.periodDays).toBe(30);
       expect(typeof res.body.components.conflictFreedom).toBe('number');
       expect(typeof res.body.components.confidenceLevel).toBe('number');
@@ -243,7 +249,7 @@ describe('Drift & Alignment Routes (integration)', () => {
       expect(typeof res.body.summary).toBe('string');
     });
 
-    it('does not serialize poisoned legacy confidence as null or grade it F', async () => {
+    it('reports an all-legacy population as excluded rather than grading it F', async () => {
       fs.writeFileSync(
         path.join(stateDir, 'decision-journal.jsonl'),
         JSON.stringify({
@@ -259,7 +265,11 @@ describe('Drift & Alignment Routes (integration)', () => {
       const res = await request(app).get('/intent/alignment');
 
       expect(res.status).toBe(200);
-      expect(res.body.sampleSize).toBe(1);
+      expect(res.body.sampleSize).toBe(0);
+      expect(res.body.populationSize).toBe(1);
+      expect(res.body.excludedSampleSize).toBe(1);
+      expect(res.body.exclusions).toEqual({ missingConfidence: 0, invalidConfidence: 1 });
+      expect(res.body.sampleCoverage).toBe(0);
       expect(res.body.score).toBe(0);
       expect(res.body.components.confidenceLevel).toBe(0);
       expect(res.body.grade).toBe('N/A');
@@ -304,6 +314,8 @@ describe('Drift & Alignment Routes (integration)', () => {
       const alignRes = await request(app).get('/intent/alignment');
       expect(alignRes.status).toBe(200);
       expect(alignRes.body.sampleSize).toBe(5);
+      expect(alignRes.body.populationSize).toBe(5);
+      expect(alignRes.body.sampleCoverage).toBe(1);
       expect(alignRes.body.score).toBeGreaterThan(0);
     });
   });

--- a/tests/unit/InstrumentAssessment.test.ts
+++ b/tests/unit/InstrumentAssessment.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  INSTRUMENT_ASSESSMENT_MARKER,
+  parseInstrumentAssessment,
+} from '../../src/core/InstrumentAssessment.js';
+
+describe('source-reported instrument assessment', () => {
+  it('accepts a coherent partial-coverage assessment', () => {
+    const value = {
+      status: 'assessed',
+      verdict: 'pass',
+      reason: 'one peer answered the typed contract; one was unavailable',
+      populationSize: 2,
+      sampleSize: 1,
+      excludedSampleSize: 1,
+      exclusions: { unavailable: 1 },
+      sampleCoverage: 0.5,
+    };
+
+    expect(parseInstrumentAssessment(
+      `diagnostic\n${INSTRUMENT_ASSESSMENT_MARKER}${JSON.stringify(value)}\n`,
+    )).toEqual(value);
+  });
+
+  it('accepts an explicitly unassessable run without fabricating a verdict', () => {
+    const value = {
+      status: 'unassessable',
+      verdict: 'none',
+      reason: 'all registered peers were unavailable',
+      populationSize: 2,
+      sampleSize: 0,
+      excludedSampleSize: 2,
+      exclusions: { unavailable: 2 },
+      sampleCoverage: 0,
+    };
+
+    expect(parseInstrumentAssessment(
+      `${INSTRUMENT_ASSESSMENT_MARKER}${JSON.stringify(value)}`,
+    )).toEqual(value);
+  });
+
+  it.each([
+    { status: 'assessed', verdict: 'none', populationSize: 1, sampleSize: 1, excludedSampleSize: 0, exclusions: {}, sampleCoverage: 1 },
+    { status: 'unassessable', verdict: 'pass', populationSize: 0, sampleSize: 0, excludedSampleSize: 0, exclusions: {}, sampleCoverage: 0 },
+    { status: 'assessed', verdict: 'pass', populationSize: 2, sampleSize: 1, excludedSampleSize: 0, exclusions: {}, sampleCoverage: 0.5 },
+    { status: 'assessed', verdict: 'pass', populationSize: 2, sampleSize: 1, excludedSampleSize: 1, exclusions: {}, sampleCoverage: 0.5 },
+  ])('rejects incoherent source claims %#', (partial) => {
+    const value = { reason: 'claim', ...partial };
+    expect(parseInstrumentAssessment(
+      `${INSTRUMENT_ASSESSMENT_MARKER}${JSON.stringify(value)}`,
+    )).toBeNull();
+  });
+
+  it('does not infer darkness from ordinary repeated output', () => {
+    expect(parseInstrumentAssessment('open conflicts: 0\nopen conflicts: 0')).toBeNull();
+  });
+});

--- a/tests/unit/IntentDriftDetector.test.ts
+++ b/tests/unit/IntentDriftDetector.test.ts
@@ -454,7 +454,7 @@ describe('IntentDriftDetector', () => {
       expect(score.summary).toContain('No decisions logged');
     });
 
-    it('treats a legacy qualitative confidence as poisoned input, not an F', () => {
+    it('excludes a legacy qualitative confidence and reports an unmeasurable population', () => {
       writeJournal(stateDir, [{
         timestamp: daysAgo(1),
         decision: 'Legacy decision',
@@ -465,7 +465,10 @@ describe('IntentDriftDetector', () => {
 
       const score = detector.alignmentScore(30);
 
-      expect(score.sampleSize).toBe(1);
+      expect(score.sampleSize).toBe(0);
+      expect(score.populationSize).toBe(1);
+      expect(score.excludedSampleSize).toBe(1);
+      expect(score.exclusions.invalidConfidence).toBe(1);
       expect(score.assessable).toBe(false);
       expect(score.grade).toBe('N/A');
       expect(score.score).toBe(0);

--- a/tests/unit/JobScheduler-script-job.test.ts
+++ b/tests/unit/JobScheduler-script-job.test.ts
@@ -141,4 +141,77 @@ describe('JobScheduler — script jobs run directly (no model session)', () => {
     await waitFor(() => fs.existsSync(markerPath));
     expect(fs.readFileSync(markerPath, 'utf-8')).toBe('token=script-token agent=script-agent');
   });
+
+  it('preserves a source-reported assessment without guessing from exit status', async () => {
+    project = createTempProject();
+    const mockSM = createMockSessionManager();
+    const assessment = {
+      status: 'unassessable',
+      verdict: 'none',
+      reason: 'the only peer was unavailable',
+      populationSize: 1,
+      sampleSize: 0,
+      excludedSampleSize: 1,
+      exclusions: { unavailable: 1 },
+      sampleCoverage: 0,
+    };
+    const jobs: JobDefinition[] = [{
+      slug: 'instrument-script',
+      name: 'Instrument Script',
+      description: 'reports its measurement state',
+      schedule: '0 0 * * *',
+      priority: 'low',
+      expectedDurationMinutes: 1,
+      model: 'haiku',
+      enabled: true,
+      execute: {
+        type: 'script',
+        value: `printf '%s\\n' 'INSTAR_INSTRUMENT_ASSESSMENT=${JSON.stringify(assessment)}'`,
+      },
+    }];
+    const jobsFile = path.join(project.stateDir, 'instrument-jobs.json');
+    fs.writeFileSync(jobsFile, JSON.stringify(jobs, null, 2));
+
+    scheduler = new JobScheduler(config(jobsFile), mockSM as any, project.state, project.stateDir);
+    scheduler.start();
+    expect(await scheduler.triggerJob('instrument-script', 'test')).toBe('triggered');
+
+    await waitFor(() => project!.state.getJobState('instrument-script')?.lastResult === 'success');
+    const state = project.state.getJobState('instrument-script');
+    expect(state?.lastResult).toBe('success');
+    expect(state?.lastAssessment).toEqual(assessment);
+    expect(state?.lastAssessment?.status).toBe('unassessable');
+  });
+
+  it('preserves the durable failure streak until a script actually succeeds', async () => {
+    project = createTempProject();
+    const mockSM = createMockSessionManager();
+    const jobs: JobDefinition[] = [{
+      slug: 'persistent-script-failure',
+      name: 'Persistent Script Failure',
+      description: 'fails repeatedly',
+      schedule: '0 0 1 1 *',
+      priority: 'low',
+      expectedDurationMinutes: 1,
+      model: 'haiku',
+      enabled: true,
+      execute: { type: 'script', value: 'exit 1' },
+    }];
+    const jobsFile = path.join(project.stateDir, 'persistent-script-jobs.json');
+    fs.writeFileSync(jobsFile, JSON.stringify(jobs, null, 2));
+
+    scheduler = new JobScheduler(config(jobsFile), mockSM as any, project.state, project.stateDir);
+    scheduler.start();
+
+    expect(await scheduler.triggerJob('persistent-script-failure', 'test')).toBe('triggered');
+    await waitFor(() => project!.state.getJobState('persistent-script-failure')?.lastResult === 'failure');
+    expect(project.state.getJobState('persistent-script-failure')?.consecutiveFailures).toBe(1);
+
+    expect(await scheduler.triggerJob('persistent-script-failure', 'test')).toBe('triggered');
+    await waitFor(() => (
+      project!.state.getJobState('persistent-script-failure')?.lastResult === 'failure' &&
+      project!.state.getJobState('persistent-script-failure')?.consecutiveFailures === 2
+    ));
+    expect(project.state.getJobState('persistent-script-failure')?.consecutiveFailures).toBe(2);
+  });
 });

--- a/tests/unit/alignment-score-not-assessed.test.ts
+++ b/tests/unit/alignment-score-not-assessed.test.ts
@@ -128,7 +128,7 @@ describe('alignmentScore — absence must not render as a bad grade', () => {
     expect(s.assessable).toBe(true);
   });
 
-  it('REGRESSION: a populated journal with string confidence is not graded F', () => {
+  it('REGRESSION: a population with no measurable confidence is not graded F', () => {
     fs.writeFileSync(
       path.join(dir, 'decision-journal.jsonl'),
       JSON.stringify({
@@ -142,7 +142,11 @@ describe('alignmentScore — absence must not render as a bad grade', () => {
 
     const s = detector.alignmentScore();
 
-    expect(s.sampleSize).toBe(1);
+    expect(s.sampleSize).toBe(0);
+    expect(s.populationSize).toBe(1);
+    expect(s.excludedSampleSize).toBe(1);
+    expect(s.exclusions).toEqual({ missingConfidence: 0, invalidConfidence: 1 });
+    expect(s.sampleCoverage).toBe(0);
     expect(s.assessable).toBe(false);
     expect(s.grade).toBe('N/A');
     expect(s.grade).not.toBe('F');
@@ -152,6 +156,54 @@ describe('alignmentScore — absence must not render as a bad grade', () => {
     expect(Number.isFinite(s.components.confidenceLevel)).toBe(true);
     expect(s.summary).toMatch(/invalid confidence/i);
     expect(JSON.stringify(s)).not.toContain('null');
+  });
+
+  it('REGRESSION: legacy bad rows cannot keep valid new input dark', () => {
+    const rows = [
+      {
+        timestamp: new Date().toISOString(),
+        sessionId: SESSION,
+        decision: 'legacy invalid row',
+        principle: 'speed',
+        confidence: 'high',
+        conflict: true,
+      },
+      {
+        timestamp: new Date().toISOString(),
+        sessionId: SESSION,
+        decision: 'legacy missing row',
+        principle: 'speed',
+        conflict: true,
+      },
+      {
+        timestamp: new Date().toISOString(),
+        sessionId: SESSION,
+        decision: 'measurable row',
+        principle: 'Structure > Willpower',
+        confidence: 0.9,
+        conflict: false,
+      },
+    ];
+    fs.writeFileSync(
+      path.join(dir, 'decision-journal.jsonl'),
+      rows.map(row => JSON.stringify(row)).join('\n') + '\n',
+    );
+
+    const s = detector.alignmentScore();
+
+    expect(s.assessable).toBe(true);
+    expect(s.grade).not.toBe('N/A');
+    expect(s.sampleSize).toBe(1);
+    expect(s.populationSize).toBe(3);
+    expect(s.excludedSampleSize).toBe(2);
+    expect(s.exclusions).toEqual({ missingConfidence: 1, invalidConfidence: 1 });
+    expect(s.sampleCoverage).toBeCloseTo(1 / 3);
+    // The common cohort applies to every component: excluded conflicts and
+    // principles cannot leak back into a differently-denominated component.
+    expect(s.components.conflictFreedom).toBe(100);
+    expect(s.components.confidenceLevel).toBe(90);
+    expect(s.components.principleConsistency).toBe(100);
+    expect(s.summary).toMatch(/1\/3 measurable, 2 excluded/);
   });
 
   it('legacy numeric strings retain their unambiguous numeric meaning', () => {
@@ -169,6 +221,10 @@ describe('alignmentScore — absence must not render as a bad grade', () => {
     const s = detector.alignmentScore();
 
     expect(s.assessable).toBe(true);
+    expect(s.sampleSize).toBe(1);
+    expect(s.populationSize).toBe(1);
+    expect(s.excludedSampleSize).toBe(0);
+    expect(s.sampleCoverage).toBe(1);
     expect(s.components.confidenceLevel).toBe(80);
     expect(s.grade).not.toBe('N/A');
   });

--- a/tests/unit/intent-drift.test.ts
+++ b/tests/unit/intent-drift.test.ts
@@ -108,6 +108,7 @@ describe('intent drift', () => {
     expect(output).toContain('Confidence Level');
     expect(output).toContain('Principle Consistency');
     expect(output).toContain('Journal Health');
+    expect(output).toContain('Measured Cohort');
   });
 
   it('respects --window option', async () => {

--- a/tests/unit/job-retry.test.ts
+++ b/tests/unit/job-retry.test.ts
@@ -161,6 +161,43 @@ describe('JobScheduler retry on skip', () => {
     expect(mockSM._spawnCount).toBe(0);
   });
 
+  it('bounds a persistently failing script job within one retry episode', async () => {
+    const jobs: JobDefinition[] = [{
+      slug: 'failing-script',
+      name: 'Failing Script',
+      description: 'Fails every direct execution',
+      // Keep a fresh cron window outside this test's ~8-hour fake-time span.
+      schedule: '0 0 1 1 *',
+      priority: 'medium',
+      model: 'haiku',
+      enabled: true,
+      execute: { type: 'script', value: 'exit 1' },
+    }];
+
+    const s = makeScheduler(jobs);
+    s.start();
+
+    // Keep the test deterministic: model a script completion failure at the
+    // runScriptJob seam. The production method reaches this same scheduleRetry
+    // call from its rejected subprocess promise.
+    (s as any).runScriptJob = vi.fn(() => {
+      (s as any).scheduleRetry('failing-script', 'error');
+    });
+
+    await s.triggerJob('failing-script', 'scheduled');
+    expect((s as any).retryState.get('failing-script').retries).toBe(1);
+
+    const delays = [61_000, 301_000, 901_000, 1_801_000, 3_601_000, 7_201_000];
+    for (let index = 0; index < delays.length; index++) {
+      await vi.advanceTimersByTimeAsync(delays[index]);
+      expect((s as any).retryState.get('failing-script').retries).toBe(index + 2 > 6 ? 6 : index + 2);
+    }
+
+    expect((s as any).runScriptJob).toHaveBeenCalledTimes(7); // initial + six retries
+    await vi.advanceTimersByTimeAsync(10_800_000);
+    expect((s as any).runScriptJob).toHaveBeenCalledTimes(7);
+  });
+
   it('clears retry state on stop', async () => {
     const jobs: JobDefinition[] = [{
       slug: 'cleanup-test',

--- a/upgrades/next/instrument-semantic-liveness.md
+++ b/upgrades/next/instrument-semantic-liveness.md
@@ -1,0 +1,43 @@
+# Instruments now report what they actually measured
+
+<!-- bump: patch -->
+
+## What Changed
+
+Recurring script instruments can now publish a validated assessed/unassessable
+report with their measured sample, full population, exclusions, and coverage.
+The scheduler preserves this report without guessing from repeated output or
+process exit status. Persistently failing scripts now exhaust six widening
+retries and settle until the next scheduled window.
+
+Alignment scoring now uses one common measurable cohort for every component.
+Legacy missing or qualitative confidence rows remain visible as exclusions but
+no longer prevent valid new decisions from producing a grade.
+
+## What to Tell Your User
+
+Monitoring can now distinguish “the check ran,” “the world was measurable,” and
+“the measured contract passed.” An offline peer no longer masquerades as a
+delivery-protocol failure, and old malformed journal rows no longer keep the
+alignment grade dark for a month. Coverage remains explicit, so partial evidence
+cannot look complete.
+
+## Summary of New Capabilities
+
+- Source-reported assessed/unassessable script-job state with validated counts.
+- Alignment sample/population/exclusion coverage on the API and CLI.
+- One common denominator across every alignment component.
+- Bounded script retries that stop after the declared six-step episode.
+- No generic constant-output detector and no false-positive N threshold.
+
+## Evidence
+
+- `tests/unit/InstrumentAssessment.test.ts`
+- `tests/unit/JobScheduler-script-job.test.ts`
+- `tests/unit/job-retry.test.ts`
+- `tests/unit/alignment-score-not-assessed.test.ts`
+- Live Echo alignment changed from N/A to an assessed C using 10 measurable
+  rows out of 40, with all 30 exclusions published.
+- Live Echo delivery probing classified an HTTP 530 gateway response as
+  unavailable, reported 50% coverage, emitted no contract finding, and exited
+  successfully.

--- a/upgrades/side-effects/instrument-semantic-liveness.md
+++ b/upgrades/side-effects/instrument-semantic-liveness.md
@@ -1,0 +1,234 @@
+# Side-Effects Review — Instrument semantic liveness
+
+**Version / slug:** `instrument-semantic-liveness`
+**Date:** `2026-08-01`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+This change adds a validated, opt-in assessment report for script instruments,
+preserves it in job state, repairs script retry convergence, and changes
+alignment scoring to use one measurable cohort with explicit population and
+exclusion counts. Echo's agent-local delivery canary now treats transport
+unavailability as an exclusion instead of a delivery-contract finding. The
+runtime files are `src/core/InstrumentAssessment.ts`,
+`src/scheduler/JobScheduler.ts`, `src/core/IntentDriftDetector.ts`,
+`src/core/types.ts`, `src/commands/intent.ts`, and `src/index.ts`.
+
+## Decision-point inventory
+
+- `parseInstrumentAssessment` — add — validates a source-owned observability
+  report as a hard structural invariant; it holds no operational authority.
+- `JobScheduler.runScriptJob` — modify — preserves a valid source report from
+  stdout or stderr without inferring one from process status.
+- `JobScheduler.triggerJob` — modify — preserves retry state on retry triggers
+  and clears it only for a new episode or successful completion.
+- `JobScheduler.runScriptJob` — modify — preserves the durable consecutive-
+  failure streak while an attempt is pending and resets it only after success.
+- `IntentDriftDetector.alignmentScore` — modify — builds one valid-confidence
+  cohort and publishes population, exclusions, and coverage.
+- `instar intent drift` — modify — renders cohort coverage for assessed grades.
+- Echo's `delivery-canary.mjs` — modify outside the product repository —
+  unavailable peers lower coverage, while only measured typed-contract
+  violations create findings and a nonzero exit.
+
+---
+
+## 1. Over-block
+
+The assessment parser is strict only for scripts that emit its exact marker.
+Ordinary output, including a constant zero-conflict result, is ignored. A
+source that opts in but emits impossible totals, mismatched coverage, an
+assessed `none`, or an unassessable pass/fail is rejected as malformed. This is
+structural validation of an explicit machine contract, not a judgment about
+the source's prose or meaning.
+
+Alignment does not reject input. Rows whose confidence is missing or cannot be
+interpreted numerically remain in the published population and exclusion
+counts, but are not used in the composite score.
+
+---
+
+## 2. Under-block
+
+The report contract cannot prove that a source's reason is semantically true;
+a buggy or dishonest source may still report internally consistent counts.
+That is intentionally outside the generic parser's authority. Per-source tests
+and negative controls remain responsible for proving that relevant world
+states can influence the source's report.
+
+A persistently unavailable peer no longer produces a delivery-contract alert
+from this canary. Peer reachability remains owned by the existing rope and
+health surfaces. A reachable typed but unexpected mesh response remains a hard
+canary finding.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The contract sits at the source/scheduler boundary: each source knows what it
+attempted to measure, while the scheduler owns generic validation and durable
+preservation. A central constancy detector would operate at the wrong layer
+because it could not distinguish a healthy stable negative-control surface
+from a collapsed instrument. Alignment cohort construction stays inside the
+alignment scorer, which owns the composite's denominator semantics. Retry
+episode convergence stays inside the scheduler, which owns timers and retry
+state.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change has no judgment-level block/allow surface.
+
+The parser may refuse a malformed opt-in report, which is hard-invariant
+validation explicitly permitted by the principle. It does not block script
+execution, infer semantic darkness, or convert repeated output into authority.
+The canary source retains authority only over its own typed protocol contract:
+unmeasured transport states are excluded, not called pass or fail.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic is added at a competing-signals decision point.
+Availability-versus-conformance is made enumerable by the typed response
+boundary: typed mesh responses are measured, while transport failures and
+untyped edge responses are explicitly unassessable. Alignment uses a structural
+numeric-cohort invariant rather than choosing among conflicting behavioral
+signals.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** `lastAssessment` is additive beside `lastResult`; it does not
+  replace process success/failure. Consumers must read the assessment when they
+  need measurement status rather than inferring a verdict from process status.
+- **Double-fire:** the canary no longer alerts for peer unavailability, avoiding
+  overlap with rope/peer availability owners. It still alerts once for measured
+  protocol violations.
+- **Races:** retry state is episode-scoped. A retry callback retains its count;
+  a fresh cron or explicit trigger starts a new bounded episode; success clears
+  the state. Existing active-job checks still prevent concurrent execution.
+- **Feedback loops:** a failed script reaches the existing six-delay ceiling and
+  settles until the next cron window. It can no longer reset itself to a one-
+  minute retry indefinitely. A cron arriving later starts one new bounded
+  episode as designed.
+
+---
+
+## 6. External surfaces
+
+`GET /intent/alignment` adds `populationSize`, `excludedSampleSize`,
+`exclusions`, and `sampleCoverage`. Its `sampleSize` is clarified from all rows
+to the common cohort actually scored. Job-state surfaces may add
+`lastAssessment`. Existing journal rows remain unchanged and scripts without
+the marker protocol retain their prior behavior. The live Echo canary is an
+agent-local consumer and has already been verified against an unavailable peer.
+
+No new operator action, external write authority, URL, configuration setting,
+or timer is introduced. The canary's existing Telegram alert path remains
+available for measured failures and now receives its vault-backed credential
+in scheduler execution.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No dashboard renderer, approval page, grant/revoke flow, secret form, or other
+operator surface is changed. No operator-facing action is added; not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design:** assessment state describes the machine that ran a
+particular scheduled job. The delivery canary measures its local registry arm
+and each registered peer arm separately, so a second machine changes the
+population and coverage instead of producing duplicate conformance claims.
+Peer availability is not promoted into protocol authority.
+
+This change emits a user-facing notice only for a measured delivery-contract
+violation through the existing canary alert path; it adds no new one-voice
+mechanism. It adds only optional job-state fields, creates no new durable store,
+does not strand topic-owned state on transfer, and generates no URLs.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the runtime changes and ship the next patch.
+- **Data migration:** none. Existing JSON readers tolerate the additive
+  `lastAssessment` field, and no journal rows are rewritten.
+- **Agent state repair:** none required. Old runtimes ignore the additive field.
+- **User visibility:** rollback would restore the old N/A alignment behavior
+  and the old noisy canary behavior while the patch propagates, but would not
+  corrupt state.
+
+---
+
+## Conclusion
+
+The review confirmed that semantic assessment must remain source-reported and
+that no run-count or constancy heuristic can hold authority. It also separated
+transport availability from typed protocol conformance and made retry
+settlement explicit. The change is reversible, migration-free, and clear to
+ship with the documented residual risk that a source can still make a
+semantically wrong but structurally valid claim.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required
+**Independent read of the artifact:** not required
+
+The change does not alter messaging block/allow decisions, dispatch authority,
+session spawn/restart/kill/recovery, compaction, trust, or a sentinel/guard/gate/
+watchdog. Its autonomous retry controller is covered by the existing
+self-action convergence ratchet and the machine-readable closure declaration.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/InstrumentAssessment.test.ts`
+- `tests/unit/JobScheduler-script-job.test.ts`
+- `tests/unit/job-retry.test.ts`
+- `tests/unit/alignment-score-not-assessed.test.ts`
+- `tests/unit/IntentDriftDetector.test.ts`
+- Focused verification after the annotation fix: 65 tests passed.
+- Repository-wide run: 47,242 tests passed; 18 unrelated environment-sensitive
+  failures in spawn, Gemini credential, and slow end-to-end lanes.
+- TypeScript check, full lint, production build, and diff checks passed.
+- Live Echo alignment: 10 of 40 rows measurable, 30 excluded, assessed grade C.
+- Live Echo delivery canary: HTTP 530 excluded as unavailable, one of two arms
+  measured, no finding, exit zero.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+For the instrument defect: `defectClass: novel`, `closure: gap`, `gapItem:
+ACT-378`, `component: instrument-observability`. The new registry class is
+`instrument-semantic-darkness`, nearest to
+`aggregate-masks-subgroup-regression`; it includes collapsed availability and
+conformance states, legacy invalid rows that prevent valid new input from
+repairing a bounded metric, and verdicts that hide their cohort. It excludes a
+constant surface that would react to relevant input, an instrument that simply
+has not seen variety, and an explicitly unassessable run that future input can
+repair. The candidate tests cannot claim guard closure until the operator
+confirms the novel class; ACT-378 tracks that gap.
+
+For the independent scheduler controller: `defectClass:
+unbounded-self-action`, `closure: guard`, `guardEvidence: { enforcementType:
+ratchet, citation: tests/unit/self-action-convergence.test.ts, howCaught: the
+retry edge carries its episode counter through all six delays; the sixth retry
+exhausts the episode and leaves no timer, which proves a steady-state bound and
+settling brake under sustained script failure }`.


### PR DESCRIPTION
## ELI16 — Instruments report what they actually measured

A monitor is useful only if the world can change its answer. This PR fixes two cases where that was impossible: an offline peer looked identical to a real delivery-protocol violation, and one old non-numeric journal row could keep every valid new alignment decision from producing a grade.

Recurring script checks can now say what they measured, what they could not measure, and how much of the population their verdict covers. Alignment uses the same measurable rows for every part of its score. A sleeping peer lowers coverage; a reachable peer that violates the typed contract still fails loudly.

It also fixes the scheduler loop that restarted a failing script at the first retry delay forever. Each failure episode now gets six widening retries and then settles until the next scheduled window.

## What changed

- Adds a source-reported, strictly validated assessment contract for recurring script instruments and persists the latest assessment in job state.
- Makes alignment use one common measurable cohort for every composite component, with explicit population, exclusions, and coverage.
- Bounds persistently failing script retries to the existing six-delay episode and preserves consecutive-failure state until real success.
- Updates Echo's agent-local delivery canary so transport unavailability lowers coverage instead of becoming a false delivery-contract finding.

## Root causes

The delivery canary collapsed peer unavailability and a typed protocol violation into one failure state. Alignment let any legacy missing or qualitative confidence value poison the entire 30-day score, so valid new evidence could not repair it. Script retry triggers also reset their own episode counter, making the documented backoff ceiling unreachable.

This deliberately does not add a generic constancy detector: stable output can be correct, as demonstrated by the zero-conflict negative control. Semantic assessment is source-owned.

## User impact

Alignment becomes responsive to valid new decisions without rewriting legacy rows, while making partial coverage visible. Offline peers stop creating false canary alerts. Persistently failing scripts settle after six retries instead of retrying every minute indefinitely.

## Evidence

- Focused suite: 65/65 passed.
- Repository-wide run: 47,242 passed; 18 unrelated environment-sensitive failures in the pre-existing spawn, Gemini credential, and slow end-to-end lanes.
- TypeScript, lint, build, whitespace checks, class-closure checks, and pre-commit governance passed.
- Live alignment: 10/40 measurable, 30 excluded, grade C.
- Live canary: HTTP 530 classified unavailable, 1/2 arms measured, no finding, exit 0.
- ACT-378 tracks operator confirmation of the new instrument-semantic-darkness defect class.

## Parser registry justification

`parseInstrumentAssessment` consumes an explicit machine marker with a closed, fully validated schema. It is not a scraper over unpredictable provider or real-world text, so it is intentionally outside `SCRAPE_PARSERS`.
