### PR TITLE
Read project stage evidence from canonical ref

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-01T11-08-01-948Z-stage-validator-ref-evidence.json
+++ b/.instar/instar-dev-decisions/2026-08-01T11-08-01-948Z-stage-validator-ref-evidence.json
@@ -1,0 +1,32 @@
+{
+  "ts": "2026-08-01T11:08:01.948Z",
+  "slug": "stage-validator-ref-evidence",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/SafeGitExecutor.ts matches SafeGitExecutor (destructive-git funnel)",
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 569,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SafeGitExecutor.ts",
+      "src/core/StageTransitionContext.ts",
+      "src/core/StageTransitionValidator.ts",
+      "src/server/AgentServer.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 430,
+    "deletedLines": 139
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Production assembled validator dependencies ad hoc, so isolated logic could receive a stale or incomplete evidence world while returning a plausible domain refusal. Central lazy assembly plus immutable live-ref evidence closes the recurring wiring class."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-01T11-08-43-411Z-stage-validator-ref-evidence.json
+++ b/.instar/instar-dev-decisions/2026-08-01T11-08-43-411Z-stage-validator-ref-evidence.json
@@ -1,0 +1,32 @@
+{
+  "ts": "2026-08-01T11:08:43.411Z",
+  "slug": "stage-validator-ref-evidence",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/SafeGitExecutor.ts matches SafeGitExecutor (destructive-git funnel)",
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 569,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SafeGitExecutor.ts",
+      "src/core/StageTransitionContext.ts",
+      "src/core/StageTransitionValidator.ts",
+      "src/server/AgentServer.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 430,
+    "deletedLines": 139
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Production assembled validator dependencies ad hoc, so isolated logic could receive a stale or incomplete evidence world while returning a plausible domain refusal. Central lazy assembly plus immutable live-ref evidence closes the recurring wiring class."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-01T11-10-12-755Z-stage-validator-ref-evidence.json
+++ b/.instar/instar-dev-decisions/2026-08-01T11-10-12-755Z-stage-validator-ref-evidence.json
@@ -1,0 +1,32 @@
+{
+  "ts": "2026-08-01T11:10:12.755Z",
+  "slug": "stage-validator-ref-evidence",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/SafeGitExecutor.ts matches SafeGitExecutor (destructive-git funnel)",
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 569,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SafeGitExecutor.ts",
+      "src/core/StageTransitionContext.ts",
+      "src/core/StageTransitionValidator.ts",
+      "src/server/AgentServer.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 430,
+    "deletedLines": 139
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Production assembled validator dependencies ad hoc, so isolated logic could receive a stale or incomplete evidence world while returning a plausible domain refusal. Central lazy assembly plus immutable live-ref evidence closes the recurring wiring class."
+  },
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-01T11-10-44-771Z-stage-validator-ref-evidence.json
+++ b/.instar/instar-dev-decisions/2026-08-01T11-10-44-771Z-stage-validator-ref-evidence.json
@@ -1,0 +1,32 @@
+{
+  "ts": "2026-08-01T11:10:44.771Z",
+  "slug": "stage-validator-ref-evidence",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/core/SafeGitExecutor.ts matches SafeGitExecutor (destructive-git funnel)",
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 569,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SafeGitExecutor.ts",
+      "src/core/StageTransitionContext.ts",
+      "src/core/StageTransitionValidator.ts",
+      "src/server/AgentServer.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 430,
+    "deletedLines": 139
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "Production assembled validator dependencies ad hoc, so isolated logic could receive a stale or incomplete evidence world while returning a plausible domain refusal. Central lazy assembly plus immutable live-ref evidence closes the recurring wiring class."
+  },
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/PROJECT-SCOPE-SPEC.eli16.md
+++ b/docs/specs/PROJECT-SCOPE-SPEC.eli16.md
@@ -1,0 +1,35 @@
+# Project Scope, in plain language
+
+Project Scope keeps a long plan from quietly losing its unfinished pieces. It
+groups related initiatives into rounds and gives every item a visible journey:
+outline, drafted spec, converged spec, approval, build, and merge. The server is
+responsible for checking the evidence behind each step, so an item cannot move
+forward merely because a caller says that the work exists.
+
+This repair changes where the server looks for spec evidence. A project points
+at a local checkout so the server has access to the repository, but that
+checkout may be days old or may intentionally be on an unrelated branch. It is
+therefore a poor source of truth for whether a spec has landed. The server now
+reads the live canonical repository identity and main-branch head, freezes that
+head to one immutable commit, and reads the spec and its convergence report from
+that snapshot. The checkout supplies the Git object database; the checked-out
+branch and a stale local remote-tracking ref no longer decide the answer.
+
+The important safeguard is honesty about uncertainty. An exact absence on the
+canonical snapshot is still a normal stage refusal: the required artifact is
+not there. If Git cannot resolve the reference or read the object, the server
+reports that the evidence could not be verified. It does not turn an
+infrastructure failure into the confident but false claim that the spec is
+missing.
+
+All production dependencies for stage validation are now assembled in one
+typed factory. That includes canonical repository/snapshot resolution, the repository-artifact
+reader, the pull-request reader, and the merge-ancestry check. A missing helper
+is a loud wiring error. This closes the recurring class in which one forgotten
+dependency made an entire pipeline stage unreachable while returning a
+plausible project-level rejection.
+
+Nothing here creates a new database, changes project records, or verifies the
+TaskFlow identifier used by the later build stage. The repair is deliberately
+limited to giving the existing spec, convergence, and merge gates one coherent
+repository world and one complete production assembly point.

--- a/docs/specs/PROJECT-SCOPE-SPEC.md
+++ b/docs/specs/PROJECT-SCOPE-SPEC.md
@@ -1,6 +1,8 @@
 ---
 title: "Project Scope — Keep Multi-Spec Plans From Falling Off The Radar"
 slug: "project-scope"
+parent-principle: "Verify the State, Not Its Symbol"
+eli16-overview: PROJECT-SCOPE-SPEC.eli16.md
 author: "echo"
 review-convergence: true
 review-iterations: 5
@@ -239,19 +241,19 @@ A new module `src/core/StageTransitionValidator.ts` defines per-edge preconditio
 
 | From | To | Required artifact |
 |------|----|-------------------|
-| outline | spec-drafted | `specPath` exists; file is valid markdown; YAML frontmatter parses with safe-loader |
-| spec-drafted | spec-converged | spec frontmatter has `review-convergence: true`; convergence report file exists at `docs/specs/reports/<slug>-convergence.md` where `<slug>` matches `^[a-z0-9][a-z0-9-]{0,63}$` |
-| spec-converged | approved | spec frontmatter has `approved: true` AND `approved-by` AND `approved-date` |
+| outline | spec-drafted | `specPath` exists as a regular blob on one immutable snapshot of the live canonical-main head; file is valid markdown; YAML frontmatter parses with safe-loader |
+| spec-drafted | spec-converged | canonical-main spec frontmatter has a non-empty `review-convergence` tag; convergence report is a regular blob at `docs/specs/reports/<slug>-convergence.md` on the same snapshot, where `<slug>` matches `^[a-z0-9][a-z0-9-]{0,63}$` |
+| spec-converged | approved | the same canonical-main snapshot's spec frontmatter has `approved: true` AND `approved-by` AND `approved-date` |
 | approved | building | TaskFlow record id provided; record exists with `status: running` |
-| building | merged | `prNumber` provided; `gh pr view <num> --json state,mergeCommit,statusCheckRollup` reports `state == "MERGED"` AND `mergeCommit.oid` reachable from `origin/main` AND CI rollup green |
+| building | merged | `prNumber` provided; `gh pr view <num> --json state,mergeCommit,statusCheckRollup` reports `state == "MERGED"` AND `mergeCommit.oid` reachable from the same resolved canonical-main ref AND CI rollup green |
 | building | regressed | merged-state check failed; auto-applied by the reconciler |
 | merged | regressed | same; auto-applied; **also rolls back round status if applicable (see Phase 1.5)** |
 | any | skipped | `skippedReason` non-empty AND `skippedBy` populated |
 | skipped | outline | `unskippedAt` recorded; reason logged in notes |
 
-**Slug regex constraint:** spec frontmatter `slug` MUST match `^[a-z0-9][a-z0-9-]{0,63}$` (same regex as project `id`). Convergence report path is constructed via `path.join(repoRoot, 'docs/specs/reports', slug + '-convergence.md')` and `realpath`-checked to remain under `docs/specs/reports/`. Slugs that fail this check reject the transition.
+**Slug regex constraint:** spec frontmatter `slug` MUST match `^[a-z0-9][a-z0-9-]{0,63}$` (same regex as project `id`). Convergence report paths are lexically jailed under `docs/specs/reports/`, then read from the canonical git tree. Symlink, tree, and submodule entries are not valid evidence. Slugs that fail this check reject the transition.
 
-**Target repo:** `mergeCommit.oid` reachability is checked in the project's `targetRepoPath` (see Phase 1.1), NOT the agent's cwd. The reconciler `cd`s into `targetRepoPath` (or uses `git -C`) before running `git merge-base --is-ancestor`. Default for new projects: read `targetRepoPath` from plan-doc frontmatter; missing → reject project creation.
+**Target repo and evidence world:** `targetRepoPath` supplies the local git object store, not the truth of whichever branch is checked out there. The server resolves the live canonical repository (a fork's parent), reads its current `main` head without mutating local refs, and freezes that head to one commit OID per request. Spec files, convergence reports, and `mergeCommit.oid` reachability all use that snapshot. The reconciler uses `targetRepoPath` (never the agent cwd) for read-only git operations. Default for new projects: read `targetRepoPath` from plan-doc frontmatter; missing → reject project creation. Unavailable identity, remote head, or object data is unverifiable evidence, not a claim that an artifact is absent.
 
 `POST /projects/:id/advance` calls the validator and rejects with 409 on artifact-check failure. A new `merged-state reconciler` runs on `GET /projects/:id` (**lazy**, debounced per-child: skip if `ciCheckedAt < 6h ago`, AND capped at ≤3 child-revalidations per GET to bound `gh pr view` shell-out cost; selection order is oldest `ciCheckedAt` first, ties broken by `roundIndex` ASC then `itemId` ASC, so no child can starve) and as a periodic job (every 6 hours, no per-call cap). On miss → transition to `regressed`, roll back round status, clear future `autoAdvanceAt`, surface via `awaitingUser`.
 
@@ -352,7 +354,7 @@ cacheKey = sha256(promptTemplateVersion + modelId + specBodySha + sortedReferenc
 
 **Failure modes:** timeout = 30 seconds, fail-closed (round halts with `manual-review-required`). One retry on timeout. Repeated failure (3 in a row across resumes within the same round) → round status `failed`.
 
-**Cost ceiling (corrected from iter 2):** total drift-check spend per agent ≤ $1/day. Tracked via daily-rotated append-only ledger at `.instar/drift-spend-YYYY-MM-DD.jsonl` (one file per UTC day; old files retained ≤30 days then archived to a monthly tarball). Each row: `{recordId, projectId, estimatedCost, actualCost?, timestamp}`. Each call pre-reserves estimated cost via this read-check-append sequence under an **advisory file lock** on `.instar/local/drift-spend.lock` (POSIX `fcntl` flock; lock file lives under machine-local `.instar/local/` to avoid git-sync deltas on a 0-byte file) — protects against concurrent drift-checks across different projects on the same machine. After the call, an `actualCost` row reconciles. Cap check uses `sum(estimatedCost where actualCost is null) + sum(actualCost where present)` for the current UTC day, O(day-rows-only). Boundary: `spent + estimated > $1.00` → reject (strict greater-than). Per-machine ledger; on multi-machine, total is sum of machines' ledgers in git-sync — documented as "per-agent ceiling, up to N machines × $1/day in worst case" (not a true cross-machine atomic cap; deferred as same-PR-registered child `drift-spend-cross-machine`).
+**Cost ceiling (corrected from iter 2):** total drift-check spend per agent ≤ $1/day. Tracked via daily-rotated append-only ledger at `.instar/drift-spend-YYYY-MM-DD.jsonl` (one file per UTC day; old files retained ≤30 days then archived to a monthly tarball). Each row: `{recordId, projectId, estimatedCost, actualCost?, timestamp}`. Each call pre-reserves estimated cost via this read-check-append sequence under an **advisory file lock** on `.instar/local/drift-spend.lock` (POSIX `fcntl` flock; lock file lives under machine-local `.instar/local/` to avoid git-sync deltas on a 0-byte file) — protects against concurrent drift-checks across different projects on the same machine. After the call, an `actualCost` row reconciles. Cap check uses `sum(estimatedCost where actualCost is null) + sum(actualCost where present)` for the current UTC day, O(day-rows-only). Boundary: `spent + estimated > $1.00` → reject (strict greater-than). Per-machine ledger; on multi-machine, total is sum of machines' ledgers in git-sync — documented as "per-agent ceiling, up to N machines × $1/day in worst case" (not a true cross-machine atomic cap; deferred as same-PR-registered child `drift-spend-cross-machine`). <!-- tracked: drift-spend-cross-machine -->
 
 **Path jail for file reads:** all paths in `specPath`, `sourceDocs`, and the file references inside specs must (a) be relative to `targetRepoPath`, (b) resolve via `path.realpath` to a location inside `targetRepoPath`, (c) not traverse symlinks that escape. YAML frontmatter parsed with `js-yaml` safe-load. Tests cover `../`, absolute paths, symlink escape.
 
@@ -387,7 +389,7 @@ cacheKey = sha256(promptTemplateVersion + modelId + specBodySha + sortedReferenc
 10. **On `partially-complete`:** do NOT auto-advance. Surface as `awaitingUser: 'round N partially complete; accept partial (M-of-K items skipped) or resolve missing items'`. User runs `POST /projects/:id/accept-partial` or `/project advance` per item.
 11. **On `failed` (after 3 resume attempts):** round.status = `failed`, project.status = `awaiting-user`. Auto-advance poller skips. Only `/project resume --force` or `/project abandon` accepted.
 
-**Halt switch:** `POST /projects/:id/halt` writes `haltedAt` to the active round, project.status → `halted`, signals the autonomous process via SIGTERM (5s grace, then SIGKILL). Lock released. Worktrees retained for inspection (cleanup deferred to user `/project resume` or `/project abandon`).
+**Halt switch:** `POST /projects/:id/halt` writes `haltedAt` to the active round, project.status → `halted`, signals the autonomous process via SIGTERM (5s grace, then SIGKILL). Lock released. Worktrees remain available for inspection and are cleaned up by an explicit user `/project resume` or `/project abandon` action.
 
 **Sentinel integration:** the existing MessageSentinel emergency-stop handler also halts any active round-runner-managed autonomous session via the same path.
 
@@ -563,14 +565,14 @@ Initiatives tab filter:
 
 ### Phase 1.14: Out of scope for Phase 1 (tracked as same-PR child initiatives)
 
-Each deferred item below is registered as a CHILD INITIATIVE of the project-scope project itself in the same commit that ships Phase 1, at `pipelineStage: 'outline'`. The `defers:` list in this spec's frontmatter names each slug; the new `scripts/check-defers.sh` pre-commit hook (Phase 1.6) enforces that each slug exists as a registered initiative at HEAD.
+Each deferred item below is registered as a CHILD INITIATIVE of the project-scope project itself in the same commit that ships Phase 1, at `pipelineStage: 'outline'`. <!-- tracked: project-scope --> The `defers:` list in this spec's frontmatter names each slug; the new `scripts/check-defers.sh` pre-commit hook (Phase 1.6) enforces that each slug exists as a registered initiative at HEAD.
 
-| Item | Why deferred |
+| Item | Why deferred | <!-- tracked: project-scope -->
 |------|--------------|
-| Project-level daily digest job (`project-daily-digest`) | Reuses initiative-digest infra; small follow-up |
-| Cross-project drift / scope overlap (`cross-project-drift`) | Needs separate primitive; deferred. Phase 1 logs file-path overlap into a deferred-review queue (no blocking) |
+| Project-level daily digest job (`project-daily-digest`) | Reuses initiative-digest infra; small follow-up <!-- tracked: project-daily-digest --> |
+| Cross-project drift / scope overlap (`cross-project-drift`) | Needs separate primitive; deferred. <!-- tracked: cross-project-drift --> Phase 1 logs file-path overlap into a deferred-review queue (no blocking) <!-- tracked: cross-project-drift --> |
 | Auto-seeding projects from PR labels (`project-pr-label-autoseed`) | Detection logic non-trivial; Phase 2 |
-| True cross-machine atomic drift-spend cap (`drift-spend-cross-machine`) | Phase 1 uses per-machine ledger summed via sync; atomic cap deferred |
+| True cross-machine atomic drift-spend cap (`drift-spend-cross-machine`) | Phase 1 uses per-machine ledger summed via sync; atomic cap deferred <!-- tracked: drift-spend-cross-machine --> |
 
 ## Surface
 
@@ -578,6 +580,7 @@ Each deferred item below is registered as a CHILD INITIATIVE of the project-scop
 |------|--------|
 | `src/core/InitiativeTracker.ts` | Add new optional fields; serialization rule; `kind` immutability; backfill on first load (batched, single-write, idempotent); digest-cache invalidation in write path |
 | `src/core/StageTransitionValidator.ts` | NEW. Per-edge artifact preconditions; uses `gh pr view` for merge state |
+| `src/core/StageTransitionContext.ts` | Single production dependency assembly; canonical-ref repository artifact reads and merge helpers |
 | `src/core/ProjectDriftChecker.ts` | NEW. Signal-only verdict with path jail, file hashing + mtime fast-path, JSON-schema output, cost ledger, citation verification |
 | `src/core/ProjectRoundRunner.ts` | NEW. Single-entry-point round lifecycle with halt switch, lazy worktree allocation, SIGTERM, dynamic stop revalidation, per-step halt checkpoints |
 | `src/core/PlanDocParser.ts` | NEW. Frontmatter schema + roster-table parser; safe YAML; path jail; dry-run mode |
@@ -610,9 +613,9 @@ Each deferred item below is registered as a CHILD INITIATIVE of the project-scop
 - Not a ticket system. No assignees other than the agent. No priority fields outside round groupings.
 - Not modifying TaskFlow. Each per-item build IS a TaskFlow record, but the round itself is not.
 - Not replacing `/build` or `/instar-dev`. The round runner *delegates* to these for per-item builds.
-- Not implementing cross-project drift detection in Phase 1 (deferred as a same-PR tracked child).
-- Not implementing PR-label auto-seeding (deferred as a same-PR tracked child).
-- Not implementing true cross-machine atomic drift-spend cap in Phase 1 (deferred as a same-PR tracked child).
+- Not implementing cross-project drift detection in Phase 1 (deferred as a same-PR tracked child). <!-- tracked: cross-project-drift -->
+- Not implementing PR-label auto-seeding (deferred as a same-PR tracked child). <!-- tracked: project-pr-label-autoseed -->
+- Not implementing true cross-machine atomic drift-spend cap in Phase 1 (deferred as a same-PR tracked child). <!-- tracked: drift-spend-cross-machine -->
 - Not multi-user. Single owner per project; single agent per project.
 
 ## Rollback cost
@@ -707,7 +710,7 @@ Each deferred item below is registered as a CHILD INITIATIVE of the project-scop
 19. Plan-doc with `source_docs: ["/etc/passwd"]` or `slug: "../etc/foo"` → rejected by parser.
 20. Session-start hook reads cache file in ≤50ms; with missing cache, falls back to one-line "state unavailable" message.
 21. Dashboard Projects tab renders correctly; Initiatives tab default-hides project-kind and parented items via server-side filter.
-22. All deferred follow-ups (digest job, cross-project drift, PR-label auto-seeding, cross-machine drift-spend cap) exist as registered child initiatives in the same commit; `scripts/check-defers.sh` pre-commit hook rejects the commit if not.
+22. All deferred follow-ups <!-- tracked: project-scope --> (digest job, cross-project drift, PR-label auto-seeding, cross-machine drift-spend cap) exist as registered child initiatives in the same commit; `scripts/check-defers.sh` pre-commit hook rejects the commit if not.
 23. Round-complete message via Telegram includes whatLanded, concreteNextStep, brakeHandlePhrase; absence → send rejected by tone gate. Pre-flight halt message includes empty-default whatLanded; presence enforced, not non-emptiness.
 24. Stale-PID lock removed without server restart on next preflight.
 25. Skipped item can transition back to `outline` via `/project advance <id> outline` with `unskippedAt`.
@@ -740,7 +743,7 @@ The following are now normative (resolved in convergence):
 - **Drift check model**: cheapest configured intelligence provider; consistent with other gates.
 - **Round runner failure recovery**: in-progress + resume up to 3 attempts; `failed` thereafter; only `--force` resume or `abandon`.
 - **Drift-check input size**: hard 5-file cap; over-budget → `manual-review-required`.
-- **Cross-project drift**: deferred to Phase 2 as a same-PR-registered child; Phase 1 logs file-path overlap into a deferred-review queue (no blocking).
+- **Cross-project drift**: deferred to Phase 2 as a same-PR-registered child; Phase 1 logs file-path overlap into a deferred-review queue (no blocking). <!-- tracked: cross-project-drift -->
 - **Drift check authority**: SIGNAL only; deterministic gate combines drift + artifact + ownership + brake state.
 - **First-launch approval**: required at runner pre-flight (single chokepoint).
 - **Auto-advance window persistence**: persisted ISO timestamp polled by existing tick.

--- a/src/core/SafeGitExecutor.ts
+++ b/src/core/SafeGitExecutor.ts
@@ -140,9 +140,8 @@ export const READONLY_GIT_VERBS: ReadonlySet<string> = new Set([
  * standpoint they are read-tier. Permitted on the instar source tree ONLY
  * when the caller opts in via `SafeGitOptions.sourceTreeReadOk: true`.
  *
- * Currently: `fetch` only. (`ls-remote` is pure-read and already in
- * READONLY_GIT_VERBS — it goes through readSync which never trips the
- * source-tree guard.)
+ * `ls-remote` is pure-read but still passes through readSync's defense-in-depth
+ * source-tree check, so it is named here as an explicit opt-in read-tier verb.
  */
 export const SOURCE_TREE_READ_TIER_VERBS: ReadonlySet<string> = new Set([
   // data-pull verbs (execSync path)
@@ -157,6 +156,7 @@ export const SOURCE_TREE_READ_TIER_VERBS: ReadonlySet<string> = new Set([
   'diff',
   'cat-file',
   'merge-base',
+  'ls-remote',
   'remote', // shape-checked to list/get-url only; needed by resolveCanonicalRemote
   // read-tier verbs the AgentWorktreeReaper needs against the source tree to
   // decide whether a worktree is reclaimable. Both are pure reads (no mutation

--- a/src/core/StageTransitionContext.ts
+++ b/src/core/StageTransitionContext.ts
@@ -1,0 +1,228 @@
+/**
+ * The single production assembly point for StageTransitionValidator evidence.
+ *
+ * Keeping all dependencies here prevents a route from remembering one helper
+ * while silently omitting the next. Spec files, convergence reports, and merge
+ * commits all resolve against `canonicalMainRef`; the working checkout is only
+ * the local git object store and may be on any branch.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { SafeGitExecutor } from './SafeGitExecutor.js';
+import { withSyncOp } from './InFlightSyncOpMarker.js';
+import { resolveGhBinary } from './resolveGhBinary.js';
+import {
+  StageTransitionWiringError,
+  type GhPrView,
+  type ValidationContext,
+} from './StageTransitionValidator.js';
+
+export interface StageTransitionArtifactInput {
+  specPath?: unknown;
+  prNumber?: unknown;
+  taskFlowRecordId?: unknown;
+  skippedReason?: unknown;
+  skippedBy?: unknown;
+  unskippedAt?: unknown;
+}
+
+export interface ProductionStageTransitionContextInput {
+  targetRepoPath: string;
+  artifact: StageTransitionArtifactInput;
+}
+
+export interface ProductionStageTransitionContextDependencies {
+  /** Test seam. Production resolves one live canonical-main snapshot lazily. */
+  resolveCanonicalMainSnapshot?: (repoPath: string) => string;
+}
+
+export function createProductionStageTransitionContext(
+  input: ProductionStageTransitionContextInput,
+  dependencies: ProductionStageTransitionContextDependencies = {},
+): ValidationContext {
+  if (!input.targetRepoPath) {
+    throw new StageTransitionWiringError('targetRepoPath is required');
+  }
+
+  const { artifact } = input;
+  let canonicalMainSnapshot: string | undefined;
+  const context: ValidationContext = {
+    targetRepoPath: input.targetRepoPath,
+    resolveCanonicalMainRef: () => {
+      if (canonicalMainSnapshot) return canonicalMainSnapshot;
+      canonicalMainSnapshot = (
+        dependencies.resolveCanonicalMainSnapshot ?? resolveCanonicalMainSnapshot
+      )(input.targetRepoPath);
+      return canonicalMainSnapshot;
+    },
+    specPath: typeof artifact.specPath === 'string' ? artifact.specPath : undefined,
+    prNumber: typeof artifact.prNumber === 'number' ? artifact.prNumber : undefined,
+    taskFlowRecordId: typeof artifact.taskFlowRecordId === 'string' ? artifact.taskFlowRecordId : undefined,
+    skippedReason: typeof artifact.skippedReason === 'string' ? artifact.skippedReason : undefined,
+    skippedBy: typeof artifact.skippedBy === 'string' ? artifact.skippedBy : undefined,
+    unskippedAt: typeof artifact.unskippedAt === 'string' ? artifact.unskippedAt : undefined,
+    readRepositoryArtifact: async (ref, repoRelativePath) =>
+      readRegularFileAtRef(input.targetRepoPath, ref, repoRelativePath),
+    ghPrView: async (prNumber) => {
+      const ghBin = resolveGhBinary();
+      if (!ghBin) {
+        throw new Error(
+          'the GitHub CLI (gh) could not be found. The server may be running with a ' +
+          'minimal PATH; set INSTAR_GH_PATH to its absolute path. The merge cannot be ' +
+          'verified without it, so this transition is refused rather than assumed.',
+        );
+      }
+      const out = withSyncOp(() => execFileSync(
+        ghBin,
+        ['pr', 'view', String(prNumber), '--json', 'state,mergeCommit,statusCheckRollup'],
+        { cwd: input.targetRepoPath, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+      ));
+      return JSON.parse(out) as GhPrView;
+    },
+    gitMergeBaseIsAncestor: (sha, branch) => {
+      try {
+        SafeGitExecutor.readSync(['merge-base', '--is-ancestor', sha, branch], {
+          cwd: input.targetRepoPath,
+          operation: 'projects.advance.mergeBaseIsAncestor',
+          stdio: ['ignore', 'ignore', 'ignore'],
+          sourceTreeReadOk: true,
+        });
+        return true;
+      } catch (err) {
+        const status = (err as { status?: unknown }).status;
+        if (status === 1) return false;
+        throw new Error(
+          `merge-base --is-ancestor could not be verified (${err instanceof Error ? err.message : String(err)})`,
+        );
+      }
+    },
+  };
+
+  assertCompleteStageTransitionContext(context);
+  return context;
+}
+
+export function assertCompleteStageTransitionContext(ctx: ValidationContext): void {
+  const missing: string[] = [];
+  if (!ctx.canonicalMainRef?.trim() && typeof ctx.resolveCanonicalMainRef !== 'function') {
+    missing.push('canonicalMainRef/resolveCanonicalMainRef');
+  }
+  if (typeof ctx.readRepositoryArtifact !== 'function') missing.push('readRepositoryArtifact');
+  if (typeof ctx.ghPrView !== 'function') missing.push('ghPrView');
+  if (typeof ctx.gitMergeBaseIsAncestor !== 'function') missing.push('gitMergeBaseIsAncestor');
+  if (missing.length > 0) {
+    throw new StageTransitionWiringError(`incomplete validator context: ${missing.join(', ')}`);
+  }
+}
+
+/**
+ * Resolve the live canonical main branch to one immutable commit OID.
+ *
+ * The remote identity comes from GitHub (using the absolute-path resolver that
+ * works under launchd). Forks resolve to their parent repository. `ls-remote`
+ * then establishes the current remote head without mutating local refs. The
+ * returned OID is immutable, so spec and report reads within one request cannot
+ * straddle two moving snapshots. Any failure throws and becomes an
+ * unverifiable-evidence verdict at the validator boundary.
+ */
+function resolveCanonicalMainSnapshot(repoPath: string): string {
+  const ghBin = resolveGhBinary();
+  if (!ghBin) {
+    throw new Error(
+      'the GitHub CLI (gh) could not be found; canonical repository identity cannot be verified',
+    );
+  }
+
+  const raw = withSyncOp(() => execFileSync(
+    ghBin,
+    ['repo', 'view', '--json', 'nameWithOwner,parent'],
+    { cwd: repoPath, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+  ));
+  const repoView = JSON.parse(raw) as {
+    nameWithOwner?: unknown;
+    parent?: { nameWithOwner?: unknown } | null;
+  };
+  const canonicalRepo = typeof repoView.parent?.nameWithOwner === 'string'
+    ? repoView.parent.nameWithOwner
+    : repoView.nameWithOwner;
+  if (typeof canonicalRepo !== 'string' || !canonicalRepo.trim()) {
+    throw new Error('GitHub did not return a canonical repository identity');
+  }
+
+  const remotes = SafeGitExecutor.readSync(['remote', '-v'], {
+    cwd: repoPath,
+    operation: 'projects.advance.resolveCanonicalRemote',
+    sourceTreeReadOk: true,
+  });
+  const candidates: string[] = [];
+  for (const line of remotes.split('\n')) {
+    const match = /^(\S+)\s+(\S+)\s+\(fetch\)$/.exec(line.trim());
+    if (!match) continue;
+    const [, name, url] = match;
+    if (githubRepositoryFromRemote(url) === canonicalRepo.toLowerCase()) candidates.push(name);
+  }
+  if (candidates.length === 0) {
+    throw new Error(`no git remote matches canonical repository ${canonicalRepo}`);
+  }
+  const remote = candidates.includes('upstream')
+    ? 'upstream'
+    : candidates.includes('origin')
+      ? 'origin'
+      : candidates[0];
+
+  const remoteHead = SafeGitExecutor.readSync(
+    ['ls-remote', '--exit-code', remote, 'refs/heads/main'],
+    {
+      cwd: repoPath,
+      operation: 'projects.advance.resolveCanonicalMainSnapshot',
+      sourceTreeReadOk: true,
+      maxBuffer: 1024 * 1024,
+    },
+  ).trim();
+  const headMatch = /^([0-9a-f]{40,64})\s+refs\/heads\/main$/i.exec(remoteHead);
+  if (!headMatch) {
+    throw new Error(`canonical repository ${canonicalRepo} has no unambiguous refs/heads/main`);
+  }
+  return headMatch[1];
+}
+
+function githubRepositoryFromRemote(remoteUrl: string): string | null {
+  const match = /github\.com(?::|\/)([^/\s]+)\/([^/\s]+?)(?:\.git)?$/i.exec(remoteUrl);
+  return match ? `${match[1]}/${match[2]}`.toLowerCase() : null;
+}
+
+/** Read exactly one regular blob without consulting the working tree. */
+function readRegularFileAtRef(repoPath: string, ref: string, repoRelativePath: string): string | null {
+  const literalPathspec = `:(literal)${repoRelativePath}`;
+  const tree = SafeGitExecutor.readSync(
+    ['ls-tree', '-z', '--full-tree', ref, '--', literalPathspec],
+    {
+      cwd: repoPath,
+      operation: 'projects.advance.repositoryArtifactTree',
+      sourceTreeReadOk: true,
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  if (!tree) return null;
+
+  const records = tree.split('\0').filter(Boolean);
+  if (records.length !== 1) {
+    throw new Error(`expected one exact tree entry, got ${records.length}`);
+  }
+  const match = /^(\d+) ([^ ]+) ([0-9a-f]+)\t([\s\S]+)$/.exec(records[0]);
+  if (!match) throw new Error('git ls-tree returned an unparseable entry');
+  const [, mode, type, oid, returnedPath] = match;
+  if (returnedPath !== repoRelativePath) {
+    throw new Error(`git ls-tree returned unexpected path "${returnedPath}"`);
+  }
+  if (type !== 'blob' || (mode !== '100644' && mode !== '100755')) {
+    throw new Error(`repository artifact is not a regular file (mode ${mode}, type ${type})`);
+  }
+
+  return SafeGitExecutor.readSync(['cat-file', 'blob', oid], {
+    cwd: repoPath,
+    operation: 'projects.advance.repositoryArtifactBlob',
+    sourceTreeReadOk: true,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}

--- a/src/core/StageTransitionValidator.ts
+++ b/src/core/StageTransitionValidator.ts
@@ -11,11 +11,11 @@
  *   reachability). No LLM-mediated judgment lives here. The drift checker
  *   (Phase 1.4) emits a *signal* but does NOT call into this validator.
  *
- * Path safety:
- *   All filesystem references (specPath, convergence-report path) are
- *   realpath-resolved and must stay under `targetRepoPath` (or under
- *   `docs/specs/reports/` for the convergence report). Symlinks that
- *   escape are rejected.
+ * Evidence world:
+ *   Spec and convergence-report evidence is read from one explicit canonical
+ *   git ref, never from whichever branch happens to be checked out at
+ *   `targetRepoPath`. The working tree supplies the repository/object store;
+ *   it is not evidence about what canonical main contains.
  *
  * Reconciler-only transitions (`*-> regressed`) require
  * `ctx.bypassMode === 'reconciler'` to succeed; user-initiated requests
@@ -78,17 +78,31 @@ export interface ValidationContext {
   unskippedAt?: string;
   /** Special-cased reconciler bypass for `*-> regressed` edges. */
   bypassMode?: 'reconciler';
+  /** The one canonical ref used by BOTH spec and merge evidence. */
+  canonicalMainRef?: string;
+  /** Resolve and memoize one immutable canonical-main snapshot for this request. */
+  resolveCanonicalMainRef?: () => string;
+  /**
+   * Read a regular repository file from `canonicalMainRef`.
+   *
+   * `null` means the path is authoritatively absent from that ref. Throwing
+   * means the evidence source could not be checked and MUST NOT be translated
+   * into a domain claim that the file is absent.
+   */
+  readRepositoryArtifact?: (ref: string, repoRelativePath: string) => Promise<string | null>;
   // Helpers (overridable for tests):
-  readSpecFrontmatter?: (absPath: string) => Promise<unknown>;
   ghPrView?: (prNumber: number) => Promise<GhPrView>;
   gitMergeBaseIsAncestor?: (sha: string, branch: string) => boolean;
-  /**
-   * The canonical-main ref the merge commit must be reachable from. Defaults to
-   * `origin/main`. On a fork-origin checkout (dev-agent home: origin = the
-   * fork, merges on the upstream remote) the route resolves the upstream
-   * remote and passes `<remote>/main` here. (#866 sibling fix.)
-   */
-  mergeBaseBranch?: string;
+}
+
+/** A caller omitted infrastructure, rather than a project failing a gate. */
+export class StageTransitionWiringError extends Error {
+  readonly code = 'STAGE_VALIDATOR_WIRING_ERROR';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'StageTransitionWiringError';
+  }
 }
 
 export interface GhPrView {
@@ -188,15 +202,19 @@ export async function validateStageTransition(
     if (!ctx.specPath || !ctx.specPath.trim()) {
       return { ok: false, reason: 'specPath required', code: 'SPEC_PATH_MISSING' };
     }
-    const jailed = jailPath(ctx.targetRepoPath, ctx.specPath);
+    const jailed = jailRepositoryPath(ctx.targetRepoPath, ctx.specPath);
     if (!jailed.ok) return { ok: false, reason: jailed.reason, code: 'SPEC_PATH_ESCAPE' };
-    if (!fs.existsSync(jailed.absPath)) {
+    const spec = await readRepositoryEvidence(ctx, jailed.repoRelativePath, 'spec');
+    if (!spec.ok) {
+      return { ok: false, reason: spec.error, code: 'SPEC_EVIDENCE_UNVERIFIABLE' };
+    }
+    if (spec.text === null) {
       return { ok: false, reason: `spec file does not exist: ${ctx.specPath}`, code: 'SPEC_FILE_MISSING' };
     }
-    if (!jailed.absPath.toLowerCase().endsWith('.md')) {
+    if (!jailed.repoRelativePath.toLowerCase().endsWith('.md')) {
       return { ok: false, reason: 'spec must be a markdown (.md) file', code: 'SPEC_NOT_MARKDOWN' };
     }
-    const fm = await loadFrontmatter(jailed.absPath, ctx.readSpecFrontmatter);
+    const fm = loadFrontmatter(spec.text);
     if (!fm.ok) return { ok: false, reason: fm.error, code: 'SPEC_FRONTMATTER_INVALID' };
     return { ok: true };
   }
@@ -206,9 +224,16 @@ export async function validateStageTransition(
     if (!ctx.specPath) {
       return { ok: false, reason: 'specPath required for convergence', code: 'SPEC_PATH_MISSING' };
     }
-    const jailed = jailPath(ctx.targetRepoPath, ctx.specPath);
+    const jailed = jailRepositoryPath(ctx.targetRepoPath, ctx.specPath);
     if (!jailed.ok) return { ok: false, reason: jailed.reason, code: 'SPEC_PATH_ESCAPE' };
-    const fm = await loadFrontmatter(jailed.absPath, ctx.readSpecFrontmatter);
+    const spec = await readRepositoryEvidence(ctx, jailed.repoRelativePath, 'spec');
+    if (!spec.ok) {
+      return { ok: false, reason: spec.error, code: 'SPEC_EVIDENCE_UNVERIFIABLE' };
+    }
+    if (spec.text === null) {
+      return { ok: false, reason: `spec file does not exist: ${ctx.specPath}`, code: 'SPEC_FILE_MISSING' };
+    }
+    const fm = loadFrontmatter(spec.text);
     if (!fm.ok) return { ok: false, reason: fm.error, code: 'SPEC_FRONTMATTER_INVALID' };
     const data = fm.data;
     if (!isConvergenceTagPresent(data['review-convergence'])) {
@@ -228,11 +253,15 @@ export async function validateStageTransition(
       };
     }
     const reportRel = path.join('docs/specs/reports', `${slug}-convergence.md`);
-    const reportJailed = jailPathUnderSubdir(ctx.targetRepoPath, 'docs/specs/reports', reportRel);
+    const reportJailed = jailRepositoryPathUnderSubdir(ctx.targetRepoPath, 'docs/specs/reports', reportRel);
     if (!reportJailed.ok) {
       return { ok: false, reason: reportJailed.reason, code: 'CONVERGENCE_REPORT_ESCAPE' };
     }
-    if (!fs.existsSync(reportJailed.absPath)) {
+    const report = await readRepositoryEvidence(ctx, reportJailed.repoRelativePath, 'convergence report');
+    if (!report.ok) {
+      return { ok: false, reason: report.error, code: 'CONVERGENCE_REPORT_UNVERIFIABLE' };
+    }
+    if (report.text === null) {
       return {
         ok: false,
         reason: `convergence report missing: ${reportRel}`,
@@ -247,9 +276,16 @@ export async function validateStageTransition(
     if (!ctx.specPath) {
       return { ok: false, reason: 'specPath required for approval', code: 'SPEC_PATH_MISSING' };
     }
-    const jailed = jailPath(ctx.targetRepoPath, ctx.specPath);
+    const jailed = jailRepositoryPath(ctx.targetRepoPath, ctx.specPath);
     if (!jailed.ok) return { ok: false, reason: jailed.reason, code: 'SPEC_PATH_ESCAPE' };
-    const fm = await loadFrontmatter(jailed.absPath, ctx.readSpecFrontmatter);
+    const spec = await readRepositoryEvidence(ctx, jailed.repoRelativePath, 'spec');
+    if (!spec.ok) {
+      return { ok: false, reason: spec.error, code: 'SPEC_EVIDENCE_UNVERIFIABLE' };
+    }
+    if (spec.text === null) {
+      return { ok: false, reason: `spec file does not exist: ${ctx.specPath}`, code: 'SPEC_FILE_MISSING' };
+    }
+    const fm = loadFrontmatter(spec.text);
     if (!fm.ok) return { ok: false, reason: fm.error, code: 'SPEC_FRONTMATTER_INVALID' };
     const data = fm.data;
     if (data.approved !== true) {
@@ -285,9 +321,7 @@ export async function validateStageTransition(
     if (typeof ctx.prNumber !== 'number' || !Number.isInteger(ctx.prNumber) || ctx.prNumber <= 0) {
       return { ok: false, reason: 'prNumber required for building → merged', code: 'PR_NUMBER_MISSING' };
     }
-    if (!ctx.ghPrView) {
-      return { ok: false, reason: 'ghPrView helper not provided', code: 'GH_PR_VIEW_UNAVAILABLE' };
-    }
+    if (!ctx.ghPrView) throw new StageTransitionWiringError('ghPrView dependency was not assembled');
     let view: GhPrView;
     try {
       view = await ctx.ghPrView(ctx.prNumber);
@@ -309,20 +343,22 @@ export async function validateStageTransition(
       return { ok: false, reason: 'mergeCommit.oid is not a sha', code: 'MERGE_COMMIT_INVALID' };
     }
     if (!ctx.gitMergeBaseIsAncestor) {
+      throw new StageTransitionWiringError('gitMergeBaseIsAncestor dependency was not assembled');
+    }
+    // Use the SAME immutable canonical-main snapshot as the spec/report gates.
+    // A fork remote, stale remote-tracking ref, missing gh binary, or unavailable
+    // network is unverifiable — never silently collapsed to origin/main.
+    let mergeBaseBranch: string;
+    try {
+      mergeBaseBranch = resolveContextCanonicalMainRef(ctx);
+    } catch (err) {
+      if (err instanceof StageTransitionWiringError) throw err;
       return {
         ok: false,
-        reason: 'gitMergeBaseIsAncestor helper not provided',
-        code: 'MERGE_BASE_HELPER_UNAVAILABLE',
+        reason: `could not resolve canonical main: ${err instanceof Error ? err.message : String(err)}`,
+        code: 'MERGE_BASE_UNVERIFIABLE',
       };
     }
-    // The canonical-main ref defaults to `origin/main`, but on a dev-agent
-    // home `origin` is the agent's FORK (instar-echo) while merges land on the
-    // upstream remote (JKHeadley/instar) — so origin/main never contains the
-    // merge commit and every advance failed MERGE_COMMIT_UNREACHABLE. The
-    // route now resolves the remote whose URL matches the gh-resolved PR repo
-    // and passes it as `mergeBaseBranch`; this default preserves prior behavior
-    // for canonical-origin installs.
-    const mergeBaseBranch = ctx.mergeBaseBranch ?? 'origin/main';
     // "I could not check" is NOT "it is not there" (found 2026-07-25: the route's
     // helper swallowed a SourceTreeGuard REFUSAL and returned false, so a merge that
     // was demonstrably on main reported as unreachable — a refusal rendered as a
@@ -377,6 +413,11 @@ export async function validateStageTransition(
 interface JailResult {
   ok: true;
   absPath: string;
+}
+
+interface RepositoryJailResult {
+  ok: true;
+  repoRelativePath: string;
 }
 
 interface JailFail {
@@ -434,6 +475,50 @@ function jailPathUnderSubdir(root: string, subdir: string, rel: string): JailRes
   return outer;
 }
 
+/**
+ * Lexically confine a path to the repository for git-tree reads.
+ *
+ * This deliberately does not inspect working-tree descendants: doing so would
+ * let a stale checkout decide whether a path on the canonical ref is safe or
+ * present. Git-tree reads never follow filesystem symlinks, and the production
+ * reader separately rejects symlink/tree/submodule entries at the ref.
+ */
+export function jailRepositoryPath(root: string, requested: string): RepositoryJailResult | JailFail {
+  if (!root || !path.isAbsolute(root)) {
+    return { ok: false, reason: `targetRepoPath must be absolute, got "${root}"` };
+  }
+  if (requested.includes('\0')) return { ok: false, reason: 'repository path contains NUL' };
+  try {
+    fs.realpathSync(root);
+  } catch {
+    return { ok: false, reason: `targetRepoPath does not exist: ${root}` };
+  }
+
+  const lexicalRoot = path.resolve(root);
+  const absolute = path.isAbsolute(requested)
+    ? path.resolve(requested)
+    : path.resolve(lexicalRoot, requested);
+  const relative = path.relative(lexicalRoot, absolute);
+  if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    return { ok: false, reason: `path "${requested}" escapes targetRepoPath` };
+  }
+  return { ok: true, repoRelativePath: relative.split(path.sep).join('/') };
+}
+
+function jailRepositoryPathUnderSubdir(
+  root: string,
+  subdir: string,
+  requested: string,
+): RepositoryJailResult | JailFail {
+  const outer = jailRepositoryPath(root, requested);
+  if (!outer.ok) return outer;
+  const normalizedSubdir = path.posix.normalize(subdir.split(path.sep).join('/')).replace(/\/$/, '');
+  if (!outer.repoRelativePath.startsWith(`${normalizedSubdir}/`)) {
+    return { ok: false, reason: `path "${requested}" is not under ${subdir}` };
+  }
+  return outer;
+}
+
 function realpathToNearestExisting(p: string): string {
   let cur = p;
   // Walk up until a path exists, realpath it, then re-join the tail.
@@ -451,27 +536,56 @@ function realpathToNearestExisting(p: string): string {
   return p;
 }
 
-async function loadFrontmatter(
-  absPath: string,
-  injected?: (absPath: string) => Promise<unknown>
-): Promise<{ ok: true; data: Record<string, unknown> } | { ok: false; error: string }> {
-  try {
-    let raw: unknown;
-    if (injected) {
-      raw = await injected(absPath);
-    } else {
-      const text = fs.readFileSync(absPath, 'utf-8');
-      const fm = extractFrontmatter(text);
-      if (fm.error) return { ok: false, error: fm.error };
-      raw = fm.frontmatter ?? {};
-    }
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-      return { ok: false, error: 'frontmatter is not a mapping' };
-    }
-    return { ok: true, data: raw as Record<string, unknown> };
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+async function readRepositoryEvidence(
+  ctx: ValidationContext,
+  repoRelativePath: string,
+  label: string,
+): Promise<{ ok: true; text: string | null } | { ok: false; error: string }> {
+  if (!ctx.readRepositoryArtifact) {
+    throw new StageTransitionWiringError('readRepositoryArtifact dependency was not assembled');
   }
+  let canonicalMainRef: string;
+  try {
+    canonicalMainRef = resolveContextCanonicalMainRef(ctx);
+  } catch (err) {
+    if (err instanceof StageTransitionWiringError) throw err;
+    return {
+      ok: false,
+      error: `could not resolve canonical main: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  try {
+    return { ok: true, text: await ctx.readRepositoryArtifact(canonicalMainRef, repoRelativePath) };
+  } catch (err) {
+    return {
+      ok: false,
+      error: `could not read ${label} "${repoRelativePath}" from ${canonicalMainRef}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+function resolveContextCanonicalMainRef(ctx: ValidationContext): string {
+  if (ctx.canonicalMainRef?.trim()) return ctx.canonicalMainRef;
+  if (!ctx.resolveCanonicalMainRef) {
+    throw new StageTransitionWiringError('canonicalMainRef dependency was not assembled');
+  }
+  const resolved = ctx.resolveCanonicalMainRef();
+  if (!resolved?.trim()) {
+    throw new Error('canonical-main resolver returned an empty ref');
+  }
+  return resolved;
+}
+
+function loadFrontmatter(
+  text: string,
+): { ok: true; data: Record<string, unknown> } | { ok: false; error: string } {
+  const fm = extractFrontmatter(text);
+  if (fm.error) return { ok: false, error: fm.error };
+  const raw = fm.frontmatter ?? {};
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'frontmatter is not a mapping' };
+  }
+  return { ok: true, data: raw as Record<string, unknown> };
 }
 
 type RollupEntry = GhPrView['statusCheckRollup'][number];

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -876,6 +876,8 @@ export class AgentServer {
     initiativeTracker?: import('../core/InitiativeTracker.js').InitiativeTracker;
     /** Project-scope round runner (Phase 1b PR 3). */
     projectRoundRunner?: import('../core/ProjectRoundRunner.js').ProjectRoundRunner;
+    /** Test seam for canonical stage-evidence resolution; production leaves undefined. */
+    stageTransitionContextDependencies?: import('../core/StageTransitionContext.js').ProductionStageTransitionContextDependencies;
     /** Project drift checker (Phase 1b connect-the-dots). Optional —
      *  when omitted, POST /projects/:id/drift-check returns 503. */
     projectDriftChecker?: import('../core/ProjectDriftChecker.js').ProjectDriftChecker;
@@ -3499,6 +3501,7 @@ export class AgentServer {
       stopNotifier: options.stopNotifier ?? null,
       initiativeTracker: options.initiativeTracker ?? null,
       projectRoundRunner: options.projectRoundRunner ?? null,
+      stageTransitionContextDependencies: options.stageTransitionContextDependencies,
       projectDriftChecker: options.projectDriftChecker ?? null,
       machineHeartbeat: options.machineHeartbeat ?? null,
       tokenLedger: this.tokenLedger,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -173,9 +173,9 @@ import { randomUUID as cryptoRandomUUID } from 'node:crypto';
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import { SafeGitExecutor } from '../core/SafeGitExecutor.js';
-import { resolveGhBinary } from '../core/resolveGhBinary.js';
 import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
-import { validateStageTransition, type ValidationContext as StageValidationContext } from '../core/StageTransitionValidator.js';
+import { StageTransitionWiringError, validateStageTransition } from '../core/StageTransitionValidator.js';
+import { createProductionStageTransitionContext } from '../core/StageTransitionContext.js';
 import type { PipelineStage, RoundStatus } from '../core/InitiativeTracker.js';
 import {
   deriveProjectRound,
@@ -1053,6 +1053,8 @@ export interface RouteContext {
    *  /advance, /halt, /ack, /accept-partial. Null when initiativeTracker
    *  is also null. */
   projectRoundRunner: import('../core/ProjectRoundRunner.js').ProjectRoundRunner | null;
+  /** Test seam only; production leaves this undefined so the factory resolves live canonical evidence. */
+  stageTransitionContextDependencies?: import('../core/StageTransitionContext.js').ProductionStageTransitionContextDependencies;
   /** Project drift checker (Phase 1b connect-the-dots). Null when no
    *  IntelligenceProvider is configured (then POST /projects/:id/drift-check
    *  returns 503). */
@@ -16841,85 +16843,12 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
     }
 
     const artifact = body.artifact ?? {};
-    const validationCtx: StageValidationContext = {
-      targetRepoPath: project.targetRepoPath,
-      specPath: typeof artifact.specPath === 'string' ? artifact.specPath : undefined,
-      prNumber: typeof artifact.prNumber === 'number' ? artifact.prNumber : undefined,
-      taskFlowRecordId: typeof artifact.taskFlowRecordId === 'string' ? artifact.taskFlowRecordId : undefined,
-      skippedReason: typeof artifact.skippedReason === 'string' ? artifact.skippedReason : undefined,
-      skippedBy: typeof artifact.skippedBy === 'string' ? artifact.skippedBy : undefined,
-      unskippedAt: typeof artifact.unskippedAt === 'string' ? artifact.unskippedAt : undefined,
-      // #866: `building → merged` requires ghPrView + gitMergeBaseIsAncestor, but
-      // the validator has NO internal default for these (unlike readSpecFrontmatter,
-      // which loadFrontmatter defaults). Without injecting them here EVERY
-      // building→merged transition fails GH_PR_VIEW_UNAVAILABLE — i.e. no project
-      // item can ever reach `merged` through the live API (found 2026-06-06 closing
-      // out multimachine-coherence P0). Both helpers are READ-ONLY git/gh against
-      // the project's target repo.
-      ghPrView: async (prNumber: number) => {
-        // Resolve gh by absolute path: the server is launched by launchd with a
-        // minimal PATH that omits /opt/homebrew/bin, so bare 'gh' died with a raw
-        // `spawnSync gh ENOENT` and NO project item could reach `merged`
-        // (found 2026-07-25). A missing binary is now a NAMED diagnostic rather
-        // than an opaque spawn error — the gate still refuses, but says why.
-        const ghBin = resolveGhBinary();
-        if (!ghBin) {
-          throw new Error(
-            'the GitHub CLI (gh) could not be found. The server may be running with a ' +
-            'minimal PATH; set INSTAR_GH_PATH to its absolute path. The merge cannot be ' +
-            'verified without it, so this transition is refused rather than assumed.',
-          );
-        }
-        const out = execFileSync(
-          ghBin,
-          ['pr', 'view', String(prNumber), '--json', 'state,mergeCommit,statusCheckRollup'],
-          { cwd: project.targetRepoPath, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
-        );
-        return JSON.parse(out) as import('../core/StageTransitionValidator.js').GhPrView;
-      },
-      gitMergeBaseIsAncestor: (sha: string, branch: string) => {
-        // `merge-base --is-ancestor` is a READ-ONLY verb — routed through readSync
-        // (the sanctioned read path), not raw execFileSync, per the destructive-tool
-        // funnel. It exits 0 (ancestor) or 1 (not an ancestor).
-        //
-        // `sourceTreeReadOk` is REQUIRED here and its absence was a live defect
-        // (found 2026-07-25 recording PR #1641 as merged). readSync runs the
-        // SourceTreeGuard unless the caller declares a read, and a project's
-        // targetRepoPath IS an instar source tree — so the guard refused this query
-        // every time. `merge-base` is already in SOURCE_TREE_READ_TIER_VERBS, i.e.
-        // the permission for exactly this read exists; it simply was never asked for.
-        //
-        // The far worse half was below: the old `catch { return false }` converted
-        // that REFUSAL into "the merge commit is not on main" — a fabricated factual
-        // claim, and the reason this step's failure was indistinguishable from a real
-        // negative for as long as it existed. A refusal is not an answer. Only git's
-        // documented exit status 1 means "not an ancestor"; every other failure
-        // (guard refusal, missing binary, bad revision → 128, timeout) is UNVERIFIABLE
-        // and is rethrown so the validator can say so instead of guessing.
-        try {
-          SafeGitExecutor.readSync(['merge-base', '--is-ancestor', sha, branch], {
-            cwd: project.targetRepoPath,
-            operation: 'projects.advance.mergeBaseIsAncestor',
-            stdio: ['ignore', 'ignore', 'ignore'],
-            sourceTreeReadOk: true,
-          });
-          return true; // exit 0 = sha IS an ancestor of branch
-        } catch (err) {
-          const status = (err as { status?: unknown }).status;
-          if (status === 1) return false; // the ONLY genuine "not an ancestor"
-          throw new Error(
-            `merge-base --is-ancestor could not be verified (${err instanceof Error ? err.message : String(err)})`,
-          );
-        }
-      },
-      // Resolve the canonical-main ref the merge commit must be reachable from.
-      // The validator defaults to `origin/main`, but on a dev-agent home `origin`
-      // is the agent's FORK while merges land on the upstream remote — so we map
-      // the gh-resolved PR repo (e.g. JKHeadley/instar) to the LOCAL remote whose
-      // URL points at it and use `<remote>/main`. Falls back to `origin/main`.
-      mergeBaseBranch: resolveCanonicalMainRef(project.targetRepoPath),
-    };
-
+    // One assembly point owns EVERY validator dependency. Three live defects
+    // each made an entire stage unreachable because this route hand-built the
+    // context and remembered dependencies one at a time (#866: gh helpers
+    // absent; 2026-07-25: launchd could not resolve bare gh; 2026-08-01: spec
+    // gates read a stale working checkout). The factory makes omissions wiring
+    // errors and gives spec + merge gates the same canonical-main world.
     const actualStage = child.pipelineStage as PipelineStage | undefined;
     const fromStage =
       typeof body.fromStage === 'string'
@@ -16937,7 +16866,24 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
       && !hasCompleteMergedEvidence(child);
     const validationFromStage = repairingMergedEvidence ? 'building' : fromStage;
 
-    const result = await validateStageTransition(validationFromStage, targetStage, validationCtx);
+    let result;
+    try {
+      const validationCtx = createProductionStageTransitionContext({
+        targetRepoPath: project.targetRepoPath,
+        artifact,
+      }, ctx.stageTransitionContextDependencies);
+      result = await validateStageTransition(validationFromStage, targetStage, validationCtx);
+    } catch (err) {
+      if (err instanceof StageTransitionWiringError) {
+        res.status(500).json({
+          error: 'stage validator wiring failure',
+          code: err.code,
+          reason: err.message,
+        });
+        return;
+      }
+      throw err;
+    }
     if (!result.ok) {
       res.status(409).json({ error: 'stage transition rejected', code: result.code, reason: result.reason });
       return;

--- a/tests/integration/projects-api.test.ts
+++ b/tests/integration/projects-api.test.ts
@@ -70,6 +70,28 @@ describe('/projects routes (integration)', () => {
     } as InstarConfig;
   }
 
+  function publishTargetRepoState(message: string): void {
+    SafeGitExecutor.run(['add', '-A'], {
+      cwd: targetRepo,
+      operation: 'tests/integration/projects-api.test.ts:publish-target-add',
+    });
+    SafeGitExecutor.run(['commit', '-q', '-m', message], {
+      cwd: targetRepo,
+      operation: 'tests/integration/projects-api.test.ts:publish-target-commit',
+    });
+    const head = SafeGitExecutor.readSync(['rev-parse', 'HEAD'], {
+      cwd: targetRepo,
+      operation: 'tests/integration/projects-api.test.ts:publish-target-head',
+    }).trim();
+    // resolveCanonicalMainRef conservatively falls back to origin/main in this
+    // local-only fixture. Keep that remote-tracking ref as the authoritative
+    // world while individual tests freely make the working checkout disagree.
+    SafeGitExecutor.run(['update-ref', 'refs/remotes/origin/main', head], {
+      cwd: targetRepo,
+      operation: 'tests/integration/projects-api.test.ts:publish-target-ref',
+    });
+  }
+
   function writePlan(name: string, body: string): string {
     const p = path.join(plansDir, name);
     fs.writeFileSync(p, body);
@@ -117,6 +139,9 @@ auto_advance: true
     // target repo to be a real git repository for ProjectRoundRunner
     // preflight step 8 to pass.
     SafeGitExecutor.run(['init', '-q'], { cwd: targetRepo, operation: 'tests/integration/projects-api.test.ts:beforeAll-git-init' });
+    SafeGitExecutor.run(['config', 'user.name', 'Projects API Test'], { cwd: targetRepo, operation: 'tests/integration/projects-api.test.ts:beforeAll-git-name' });
+    SafeGitExecutor.run(['config', 'user.email', 'projects-api@test.invalid'], { cwd: targetRepo, operation: 'tests/integration/projects-api.test.ts:beforeAll-git-email' });
+    publishTargetRepoState('initial canonical spec');
     plansDir = fs.mkdtempSync(path.join(os.tmpdir(), 'projects-api-plans-'));
 
     tracker = new InitiativeTracker(project.stateDir);
@@ -146,6 +171,9 @@ auto_advance: true
       state: project.state,
       initiativeTracker: tracker,
       projectRoundRunner,
+      stageTransitionContextDependencies: {
+        resolveCanonicalMainSnapshot: () => 'refs/remotes/origin/main',
+      },
       machineHeartbeat,
     });
     app = server.getApp();
@@ -535,8 +563,11 @@ goal: try escape
 
   it('POST /projects/:id/advance — outline → spec-drafted with a real spec file', async () => {
     const { projectVersion, itemId } = await seedProject('adv-1');
-    // Materialize the spec file the validator will look for.
+    // Publish the spec, then deliberately remove it ONLY from the checkout.
+    // The gate must read canonical main, not the stale/unrelated branch state.
     fs.writeFileSync(path.join(targetRepo, 'docs/specs/a.md'), '# spec');
+    publishTargetRepoState('publish adv-1 spec');
+    SafeFsExecutor.safeUnlinkSync(path.join(targetRepo, 'docs/specs/a.md'), { operation: 'tests/integration/projects-api.test.ts:adv-1-stale-checkout' });
     const res = await request(app)
       .post('/projects/adv-1/advance')
       .set('Authorization', `Bearer ${AUTH_TOKEN}`)
@@ -549,6 +580,7 @@ goal: try escape
     expect(res.status).toBe(200);
     expect(res.body.item.pipelineStage).toBe('spec-drafted');
     expect(tracker.get(itemId)?.pipelineStage).toBe('spec-drafted');
+    fs.writeFileSync(path.join(targetRepo, 'docs/specs/a.md'), '# spec');
   });
 
   it('POST /projects/:id/advance — spec-drafted → spec-converged accepts the canonical TIMESTAMP tag + report (Part A bug-fix through the real route)', async () => {
@@ -562,6 +594,7 @@ goal: try escape
     );
     fs.mkdirSync(path.join(targetRepo, 'docs/specs/reports'), { recursive: true });
     fs.writeFileSync(path.join(targetRepo, 'docs/specs/reports/a-convergence.md'), '# convergence report\n');
+    publishTargetRepoState('publish converged spec and report');
 
     // Step 1: outline → spec-drafted.
     const drafted = await request(app)
@@ -582,8 +615,10 @@ goal: try escape
     expect(converged.body.item.pipelineStage).toBe('spec-converged');
     expect(tracker.get(itemId)?.pipelineStage).toBe('spec-converged');
 
-    // Restore the empty spec for subsequent tests.
+    // Restore canonical main for subsequent tests.
     fs.writeFileSync(path.join(targetRepo, 'docs/specs/a.md'), '');
+    SafeFsExecutor.safeRmSync(path.join(targetRepo, 'docs/specs/reports/a-convergence.md'), { force: true, operation: 'tests/integration/projects-api.test.ts:restore-convergence-report' });
+    publishTargetRepoState('restore empty canonical spec');
   });
 
   it('POST /projects/:id/advance — spec-drafted → spec-converged with timestamp tag but MISSING report returns 409 (report check stays unconditional)', async () => {
@@ -596,6 +631,7 @@ goal: try escape
     // not → CONVERGENCE_REPORT_MISSING (not ESCAPE, which is the dir-absent case).
     fs.mkdirSync(path.join(targetRepo, 'docs/specs/reports'), { recursive: true });
     SafeFsExecutor.safeRmSync(path.join(targetRepo, 'docs/specs/reports/a-convergence.md'), { force: true, operation: 'tests/integration/projects-api.test.ts:advance-converge-noreport' });
+    publishTargetRepoState('publish converged spec without report');
 
     const drafted = await request(app)
       .post('/projects/adv-converge-noreport/advance')
@@ -613,8 +649,9 @@ goal: try escape
     expect(converged.status).toBe(409);
     expect(converged.body.code).toBe('CONVERGENCE_REPORT_MISSING');
 
-    // Restore the empty spec for subsequent tests.
+    // Restore canonical main for subsequent tests.
     fs.writeFileSync(path.join(targetRepo, 'docs/specs/a.md'), '');
+    publishTargetRepoState('restore empty canonical spec again');
   });
 
   it('POST /projects/:id/advance — missing If-Match returns 428', async () => {
@@ -638,10 +675,10 @@ goal: try escape
 
   it('POST /projects/:id/advance — artifact-fail (missing specPath file) returns 409', async () => {
     const { projectVersion, itemId } = await seedProject('adv-4');
-    // Spec path the plan lists doesn't exist on disk → validator rejects.
+    // Spec path is absent from canonical main → validator rejects, regardless
+    // of what a checkout happens to contain.
     SafeFsExecutor.safeUnlinkSync(path.join(targetRepo, 'docs/specs/a.md'), { operation: 'tests/integration/projects-api.test.ts:advance-no-spec' });
-    fs.writeFileSync(path.join(targetRepo, 'docs/specs/a.md'), ''); // re-create empty for other tests
-    SafeFsExecutor.safeUnlinkSync(path.join(targetRepo, 'docs/specs/a.md'), { operation: 'tests/integration/projects-api.test.ts:advance-no-spec-2' });
+    publishTargetRepoState('remove canonical spec');
     const res = await request(app)
       .post('/projects/adv-4/advance')
       .set('Authorization', `Bearer ${AUTH_TOKEN}`)
@@ -653,8 +690,9 @@ goal: try escape
       });
     expect(res.status).toBe(409);
     expect(res.body.code).toBe('SPEC_FILE_MISSING');
-    // Restore the spec file for subsequent tests.
+    // Restore canonical main for subsequent tests.
     fs.writeFileSync(path.join(targetRepo, 'docs/specs/a.md'), '');
+    publishTargetRepoState('restore canonical spec after missing test');
   });
 
   it('POST /projects/:id/advance — unknown child returns 404', async () => {
@@ -667,12 +705,10 @@ goal: try escape
     expect(res.status).toBe(404);
   });
 
-  it('POST /projects/:id/advance — building → merged WIRES ghPrView (never GH_PR_VIEW_UNAVAILABLE) [#866]', async () => {
-    // Wiring-integrity (#866): the validator has no internal default for
-    // ghPrView, so building→merged was structurally impossible on every
-    // install (always GH_PR_VIEW_UNAVAILABLE) until the route injects it.
-    // After the fix the helper is provided, so ANY failure of the now-wired
-    // helper surfaces as GH_PR_VIEW_FAILED — never UNAVAILABLE — regardless of
+  it('POST /projects/:id/advance — building → merged has a complete production context [#866]', async () => {
+    // Wiring-integrity (#866): ghPrView used to be omitted, making this edge
+    // structurally impossible. The production factory must now supply it, so
+    // any operational failure is GH_PR_VIEW_FAILED — never a wiring error — regardless of
     // whether `gh` is installed/authed in CI (a missing gh binary or a fake PR
     // both throw inside the injected helper, which the validator maps to
     // GH_PR_VIEW_FAILED). The ONLY way to get UNAVAILABLE is the helper being
@@ -692,6 +728,7 @@ goal: try escape
     // helper-missing reason — the helper is now wired.
     expect(res.status).toBe(409);
     expect(res.body.code).not.toBe('GH_PR_VIEW_UNAVAILABLE');
+    expect(res.body.code).not.toBe('STAGE_VALIDATOR_WIRING_ERROR');
     expect(res.body.code).toBe('GH_PR_VIEW_FAILED');
   });
 

--- a/tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts
+++ b/tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts
@@ -115,6 +115,7 @@ describe('SafeGitExecutor.sourceTreeReadOk', () => {
     expect(SOURCE_TREE_READ_TIER_VERBS.has('log')).toBe(true);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('diff')).toBe(true);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('merge-base')).toBe(true);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('ls-remote')).toBe(true);
     // Must NEVER include verbs that modify the working tree or committed refs:
     expect(SOURCE_TREE_READ_TIER_VERBS.has('commit')).toBe(false);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('push')).toBe(false);
@@ -130,7 +131,7 @@ describe('SafeGitExecutor.sourceTreeReadOk', () => {
     expect(SOURCE_TREE_READ_TIER_VERBS.has('status')).toBe(true);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('cherry')).toBe(true);
     // Bounded — adding to this set requires a spec edit + side-effects review.
-    expect(SOURCE_TREE_READ_TIER_VERBS.size).toBeLessThanOrEqual(11);
+    expect(SOURCE_TREE_READ_TIER_VERBS.size).toBeLessThanOrEqual(12);
   });
 
   it('readSync path honors sourceTreeReadOk — diff on a source tree passes', () => {

--- a/tests/unit/SafeGitExecutor.test.ts
+++ b/tests/unit/SafeGitExecutor.test.ts
@@ -9,6 +9,7 @@ import {
   SafeGitExecutorError,
   DESTRUCTIVE_GIT_VERBS,
   READONLY_GIT_VERBS,
+  SOURCE_TREE_READ_TIER_VERBS,
   _internal,
 } from '../../src/core/SafeGitExecutor.js';
 import { SourceTreeGuardError } from '../../src/core/SourceTreeGuard.js';
@@ -448,6 +449,10 @@ describe('verb classification sets', () => {
     expect(overlap.sort()).toEqual(
       ['branch', 'config', 'format-patch', 'remote', 'stash', 'worktree'].sort(),
     );
+  });
+
+  it('permits an explicitly opted-in ls-remote read against an instar source tree', () => {
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('ls-remote')).toBe(true);
   });
 });
 

--- a/tests/unit/StageTransitionContext.test.ts
+++ b/tests/unit/StageTransitionContext.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  assertCompleteStageTransitionContext,
+  createProductionStageTransitionContext,
+} from '../../src/core/StageTransitionContext.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
+
+describe('production StageTransition context', () => {
+  let repo: string;
+
+  function createContext(artifact: Record<string, unknown> = {}) {
+    return createProductionStageTransitionContext(
+      { targetRepoPath: repo, artifact },
+      { resolveCanonicalMainSnapshot: () => 'HEAD' },
+    );
+  }
+
+  beforeAll(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'stage-context-'));
+    fs.mkdirSync(path.join(repo, 'docs/specs'), { recursive: true });
+    fs.writeFileSync(path.join(repo, 'docs/specs/on-main.md'), '# canonical\n');
+    fs.symlinkSync('on-main.md', path.join(repo, 'docs/specs/link.md'));
+    SafeGitExecutor.run(['init', '-q'], { cwd: repo, operation: 'tests/unit/StageTransitionContext.test.ts:init' });
+    SafeGitExecutor.run(['config', 'user.name', 'Stage Context Test'], { cwd: repo, operation: 'tests/unit/StageTransitionContext.test.ts:name' });
+    SafeGitExecutor.run(['config', 'user.email', 'stage-context@test.invalid'], { cwd: repo, operation: 'tests/unit/StageTransitionContext.test.ts:email' });
+    SafeGitExecutor.run(['add', '-A'], { cwd: repo, operation: 'tests/unit/StageTransitionContext.test.ts:add' });
+    SafeGitExecutor.run(['commit', '-q', '-m', 'canonical artifacts'], { cwd: repo, operation: 'tests/unit/StageTransitionContext.test.ts:commit' });
+  });
+
+  afterAll(() => {
+    SafeFsExecutor.safeRmSync(repo, { recursive: true, force: true, operation: 'tests/unit/StageTransitionContext.test.ts:cleanup' });
+  });
+
+  it('reads a canonical blob even when the working checkout no longer has it', async () => {
+    const ctx = createContext({ specPath: 'docs/specs/on-main.md' });
+    SafeFsExecutor.safeUnlinkSync(path.join(repo, 'docs/specs/on-main.md'), { operation: 'tests/unit/StageTransitionContext.test.ts:stale-checkout' });
+    await expect(ctx.readRepositoryArtifact?.('HEAD', 'docs/specs/on-main.md')).resolves.toBe('# canonical\n');
+    fs.writeFileSync(path.join(repo, 'docs/specs/on-main.md'), '# canonical\n');
+  });
+
+  it('returns null only for an authoritatively absent ref path', async () => {
+    const ctx = createContext();
+    await expect(ctx.readRepositoryArtifact?.('HEAD', 'docs/specs/absent.md')).resolves.toBeNull();
+  });
+
+  it('rejects symlink blobs rather than treating them as regular evidence', async () => {
+    const ctx = createContext();
+    await expect(ctx.readRepositoryArtifact?.('HEAD', 'docs/specs/link.md')).rejects.toThrow(/not a regular file/);
+  });
+
+  it('assembles every production dependency and reports incomplete contexts loudly', () => {
+    const ctx = createContext();
+    expect(() => assertCompleteStageTransitionContext(ctx)).not.toThrow();
+    expect(() => assertCompleteStageTransitionContext({ targetRepoPath: repo })).toThrow(/incomplete validator context/);
+  });
+
+  it('resolves one immutable canonical snapshot lazily and memoizes it for the request', () => {
+    let resolutions = 0;
+    const ctx = createProductionStageTransitionContext(
+      { targetRepoPath: repo, artifact: {} },
+      { resolveCanonicalMainSnapshot: () => {
+        resolutions += 1;
+        return '0123456789012345678901234567890123456789';
+      } },
+    );
+    expect(resolutions).toBe(0);
+    expect(ctx.resolveCanonicalMainRef?.()).toBe('0123456789012345678901234567890123456789');
+    expect(ctx.resolveCanonicalMainRef?.()).toBe('0123456789012345678901234567890123456789');
+    expect(resolutions).toBe(1);
+  });
+});

--- a/tests/unit/StageTransitionValidator.test.ts
+++ b/tests/unit/StageTransitionValidator.test.ts
@@ -35,6 +35,23 @@ describe('StageTransitionValidator', () => {
   // CONVERGENCE_REPORT_MISSING check.
   let timestampNoReportSpecRel: string;
 
+  function specContext(overrides: Partial<ValidationContext> = {}): ValidationContext {
+    const repo = overrides.targetRepoPath ?? tmpRepo;
+    return {
+      targetRepoPath: repo,
+      canonicalMainRef: 'refs/heads/main',
+      readRepositoryArtifact: async (_ref, repoRelativePath) => {
+        try {
+          return fs.readFileSync(path.join(repo, repoRelativePath), 'utf-8');
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+          throw err;
+        }
+      },
+      ...overrides,
+    };
+  }
+
   beforeAll(() => {
     tmpRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'stage-validator-'));
     fs.mkdirSync(path.join(tmpRepo, 'docs/specs/reports'), { recursive: true });
@@ -83,35 +100,88 @@ describe('StageTransitionValidator', () => {
   // ── outline → spec-drafted ────────────────────────────────────────
 
   it('outline → spec-drafted: accepts when spec file exists and frontmatter parses', async () => {
-    const r = await validateStageTransition('outline', 'spec-drafted', {
+    const r = await validateStageTransition('outline', 'spec-drafted', specContext({
       targetRepoPath: tmpRepo,
       specPath: goodSpecRel,
-    });
+    }));
     expect(r.ok).toBe(true);
   });
 
   it('outline → spec-drafted: rejects when specPath missing', async () => {
-    const r = await validateStageTransition('outline', 'spec-drafted', {
+    const r = await validateStageTransition('outline', 'spec-drafted', specContext({
       targetRepoPath: tmpRepo,
-    });
+    }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('SPEC_PATH_MISSING');
   });
 
   it('outline → spec-drafted: rejects when spec file does not exist', async () => {
-    const r = await validateStageTransition('outline', 'spec-drafted', {
+    const r = await validateStageTransition('outline', 'spec-drafted', specContext({
       targetRepoPath: tmpRepo,
       specPath: 'docs/specs/nonexistent.md',
-    });
+    }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('SPEC_FILE_MISSING');
   });
 
-  it('outline → spec-drafted: rejects path traversal in specPath', async () => {
+  it('outline → spec-drafted: an unreadable evidence source is not fabricated as a missing spec', async () => {
+    const r = await validateStageTransition('outline', 'spec-drafted', specContext({
+      specPath: goodSpecRel,
+      readRepositoryArtifact: async () => {
+        throw new Error('canonical ref unavailable');
+      },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('SPEC_EVIDENCE_UNVERIFIABLE');
+      expect(r.code).not.toBe('SPEC_FILE_MISSING');
+      expect(r.reason).toContain('canonical ref unavailable');
+    }
+  });
+
+  it('outline → spec-drafted: canonical identity/freshness failure is unverifiable, never absent', async () => {
     const r = await validateStageTransition('outline', 'spec-drafted', {
       targetRepoPath: tmpRepo,
-      specPath: '../../etc/passwd',
+      specPath: goodSpecRel,
+      resolveCanonicalMainRef: () => {
+        throw new Error('live remote head unavailable');
+      },
+      readRepositoryArtifact: async () => null,
     });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('SPEC_EVIDENCE_UNVERIFIABLE');
+      expect(r.reason).toContain('live remote head unavailable');
+    }
+  });
+
+  it('outline → spec-drafted: a missing reader is a wiring error, not a project refusal', async () => {
+    await expect(validateStageTransition('outline', 'spec-drafted', {
+      targetRepoPath: tmpRepo,
+      canonicalMainRef: 'origin/main',
+      specPath: goodSpecRel,
+    })).rejects.toMatchObject({ code: 'STAGE_VALIDATOR_WIRING_ERROR' });
+  });
+
+  it('outline → spec-drafted: reads the explicitly named canonical ref', async () => {
+    let seenRef = '';
+    const r = await validateStageTransition('outline', 'spec-drafted', specContext({
+      canonicalMainRef: 'upstream/main',
+      specPath: goodSpecRel,
+      readRepositoryArtifact: async (ref, repoRelativePath) => {
+        seenRef = ref;
+        return fs.readFileSync(path.join(tmpRepo, repoRelativePath), 'utf-8');
+      },
+    }));
+    expect(r.ok).toBe(true);
+    expect(seenRef).toBe('upstream/main');
+  });
+
+  it('outline → spec-drafted: rejects path traversal in specPath', async () => {
+    const r = await validateStageTransition('outline', 'spec-drafted', specContext({
+      targetRepoPath: tmpRepo,
+      specPath: '../../etc/passwd',
+    }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('SPEC_PATH_ESCAPE');
   });
@@ -119,10 +189,10 @@ describe('StageTransitionValidator', () => {
   it('outline → spec-drafted: rejects non-markdown extensions', async () => {
     const txtPath = path.join(tmpRepo, 'docs/specs/spec.txt');
     fs.writeFileSync(txtPath, '---\ntitle: not md\n---\n');
-    const r = await validateStageTransition('outline', 'spec-drafted', {
+    const r = await validateStageTransition('outline', 'spec-drafted', specContext({
       targetRepoPath: tmpRepo,
       specPath: 'docs/specs/spec.txt',
-    });
+    }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('SPEC_NOT_MARKDOWN');
   });
@@ -130,28 +200,28 @@ describe('StageTransitionValidator', () => {
   // ── spec-drafted → spec-converged ────────────────────────────────
 
   it('spec-drafted → spec-converged: accepts when review-convergence:true + report exists', async () => {
-    const r = await validateStageTransition('spec-drafted', 'spec-converged', {
+    const r = await validateStageTransition('spec-drafted', 'spec-converged', specContext({
       targetRepoPath: tmpRepo,
       specPath: convergedSpecRel,
-    });
+    }));
     expect(r.ok).toBe(true);
   });
 
   it('spec-drafted → spec-converged: accepts the canonical ISO-TIMESTAMP tag + report (Part A bug-fix)', async () => {
     // Previously REJECTED because `"<ts>" !== true`. The tooling writes the
     // timestamp string, so this is the real-world converged spec.
-    const r = await validateStageTransition('spec-drafted', 'spec-converged', {
+    const r = await validateStageTransition('spec-drafted', 'spec-converged', specContext({
       targetRepoPath: tmpRepo,
       specPath: timestampConvergedSpecRel,
-    });
+    }));
     expect(r.ok).toBe(true);
   });
 
   it('spec-drafted → spec-converged: timestamp tag but MISSING report still fails (report check stays unconditional)', async () => {
-    const r = await validateStageTransition('spec-drafted', 'spec-converged', {
+    const r = await validateStageTransition('spec-drafted', 'spec-converged', specContext({
       targetRepoPath: tmpRepo,
       specPath: timestampNoReportSpecRel,
-    });
+    }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('CONVERGENCE_REPORT_MISSING');
   });
@@ -162,19 +232,19 @@ describe('StageTransitionValidator', () => {
       path.join(tmpRepo, emptyTagSpec),
       `---\ntitle: empty\nslug: empty-convergence-tag\nreview-convergence: ""\n---\n# body\n`
     );
-    const r = await validateStageTransition('spec-drafted', 'spec-converged', {
+    const r = await validateStageTransition('spec-drafted', 'spec-converged', specContext({
       targetRepoPath: tmpRepo,
       specPath: emptyTagSpec,
-    });
+    }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('CONVERGENCE_TAG_MISSING');
   });
 
   it('spec-drafted → spec-converged: rejects when review-convergence missing', async () => {
-    const r = await validateStageTransition('spec-drafted', 'spec-converged', {
+    const r = await validateStageTransition('spec-drafted', 'spec-converged', specContext({
       targetRepoPath: tmpRepo,
       specPath: goodSpecRel,
-    });
+    }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('CONVERGENCE_TAG_MISSING');
   });
@@ -186,10 +256,10 @@ describe('StageTransitionValidator', () => {
       path.join(tmpRepo, badSpec),
       `---\ntitle: bad\nslug: "../../../etc/passwd"\nreview-convergence: true\n---\n# body\n`
     );
-    const r = await validateStageTransition('spec-drafted', 'spec-converged', {
+    const r = await validateStageTransition('spec-drafted', 'spec-converged', specContext({
       targetRepoPath: tmpRepo,
       specPath: badSpec,
-    });
+    }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('SLUG_INVALID');
   });
@@ -201,10 +271,10 @@ describe('StageTransitionValidator', () => {
       path.join(tmpRepo, orphanSpec),
       `---\ntitle: orphan\nslug: orphan-spec\nreview-convergence: true\n---\n# body\n`
     );
-    const r = await validateStageTransition('spec-drafted', 'spec-converged', {
+    const r = await validateStageTransition('spec-drafted', 'spec-converged', specContext({
       targetRepoPath: tmpRepo,
       specPath: orphanSpec,
-    });
+    }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('CONVERGENCE_REPORT_MISSING');
   });
@@ -212,10 +282,10 @@ describe('StageTransitionValidator', () => {
   // ── spec-converged → approved ────────────────────────────────────
 
   it('spec-converged → approved: accepts with all three approved fields', async () => {
-    const r = await validateStageTransition('spec-converged', 'approved', {
+    const r = await validateStageTransition('spec-converged', 'approved', specContext({
       targetRepoPath: tmpRepo,
       specPath: approvedSpecRel,
-    });
+    }));
     expect(r.ok).toBe(true);
   });
 
@@ -225,10 +295,10 @@ describe('StageTransitionValidator', () => {
       path.join(tmpRepo, partialSpec),
       `---\ntitle: partial\nslug: partial-approved\napproved: true\napproved-date: 2026-05-11\n---\n# body\n`
     );
-    const r = await validateStageTransition('spec-converged', 'approved', {
+    const r = await validateStageTransition('spec-converged', 'approved', specContext({
       targetRepoPath: tmpRepo,
       specPath: partialSpec,
-    });
+    }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('APPROVED_BY_MISSING');
   });
@@ -254,6 +324,7 @@ describe('StageTransitionValidator', () => {
   it('building → merged: accepts squash-merged PR via mocked ghPrView', async () => {
     const ctx: ValidationContext = {
       targetRepoPath: tmpRepo,
+      canonicalMainRef: 'origin/main',
       prNumber: 42,
       ghPrView: async () => ({
         state: 'MERGED',
@@ -282,7 +353,7 @@ describe('StageTransitionValidator', () => {
         statusCheckRollup: [{ conclusion: 'SUCCESS' }],
       }),
       gitMergeBaseIsAncestor: () => true,
-      mergeBaseBranch: 'upstream/main',
+      canonicalMainRef: 'upstream/main',
     };
     const before = Date.now();
     const r = await validateStageTransition('building', 'merged', ctx);
@@ -302,6 +373,7 @@ describe('StageTransitionValidator', () => {
   it('building → merged: a REFUSED verdict carries no evidence (nothing was established)', async () => {
     const ctx: ValidationContext = {
       targetRepoPath: tmpRepo,
+      canonicalMainRef: 'origin/main',
       prNumber: 42,
       ghPrView: async () => ({
         state: 'MERGED',
@@ -318,6 +390,7 @@ describe('StageTransitionValidator', () => {
   it('building → merged: rejects when mergeCommit not reachable from origin/main', async () => {
     const ctx: ValidationContext = {
       targetRepoPath: tmpRepo,
+      canonicalMainRef: 'origin/main',
       prNumber: 42,
       ghPrView: async () => ({
         state: 'MERGED',
@@ -341,6 +414,7 @@ describe('StageTransitionValidator', () => {
     // current state is its latest run.
     const base = (rollup: unknown[]): ValidationContext => ({
       targetRepoPath: tmpRepo,
+      canonicalMainRef: 'origin/main',
       prNumber: 1641,
       ghPrView: async () => ({
         state: 'MERGED',
@@ -414,6 +488,7 @@ describe('StageTransitionValidator', () => {
     // "it is not there" must be distinguishable, because they call for opposite actions.
     const ctx: ValidationContext = {
       targetRepoPath: tmpRepo,
+      canonicalMainRef: 'origin/main',
       prNumber: 42,
       ghPrView: async () => ({
         state: 'MERGED',
@@ -435,11 +510,34 @@ describe('StageTransitionValidator', () => {
     }
   });
 
+  it('building → merged: an unresolved live canonical snapshot is unverifiable', async () => {
+    const ctx: ValidationContext = {
+      targetRepoPath: tmpRepo,
+      prNumber: 42,
+      resolveCanonicalMainRef: () => {
+        throw new Error('remote main freshness unknown');
+      },
+      ghPrView: async () => ({
+        state: 'MERGED',
+        mergeCommit: { oid: 'a1b2c3d4e5f60708' },
+        statusCheckRollup: [{ conclusion: 'SUCCESS' }],
+      }),
+      gitMergeBaseIsAncestor: () => true,
+    };
+    const r = await validateStageTransition('building', 'merged', ctx);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('MERGE_BASE_UNVERIFIABLE');
+      expect(r.reason).toContain('remote main freshness unknown');
+    }
+  });
+
   it('building → merged: a GENUINE negative is still MERGE_COMMIT_UNREACHABLE (the boundary is not blurred)', async () => {
     // The other side of the same boundary: making refusals honest must NOT turn a real
     // "not an ancestor" into an unverifiable, or the check would stop refusing anything.
     const ctx: ValidationContext = {
       targetRepoPath: tmpRepo,
+      canonicalMainRef: 'origin/main',
       prNumber: 42,
       ghPrView: async () => ({
         state: 'MERGED',
@@ -453,15 +551,15 @@ describe('StageTransitionValidator', () => {
     if (!r.ok) expect(r.code).toBe('MERGE_COMMIT_UNREACHABLE');
   });
 
-  it('building → merged: uses ctx.mergeBaseBranch when provided (fork-origin agent home) [#866 sibling]', async () => {
+  it('building → merged: uses ctx.canonicalMainRef when provided (fork-origin agent home) [#866 sibling]', async () => {
     // On a dev-agent home, origin = the fork; merges land on upstream. The
-    // route resolves the upstream remote and passes mergeBaseBranch; the
+    // route resolves the upstream remote and passes canonicalMainRef; the
     // helper must be called with THAT ref, not the hardcoded origin/main.
     let seenBranch = '';
     const ctx: ValidationContext = {
       targetRepoPath: tmpRepo,
       prNumber: 42,
-      mergeBaseBranch: 'upstream/main',
+      canonicalMainRef: 'upstream/main',
       ghPrView: async () => ({
         state: 'MERGED',
         mergeCommit: { oid: 'a1b2c3d4e5f60708' },
@@ -481,7 +579,7 @@ describe('StageTransitionValidator', () => {
     const ctx: ValidationContext = {
       targetRepoPath: tmpRepo,
       prNumber: 42,
-      mergeBaseBranch: 'upstream/main',
+      canonicalMainRef: 'upstream/main',
       ghPrView: async () => ({
         state: 'MERGED',
         mergeCommit: { oid: 'aaaaaaa' },
@@ -516,6 +614,7 @@ describe('StageTransitionValidator', () => {
   it('building → merged: rejects when CI rollup has a failure', async () => {
     const ctx: ValidationContext = {
       targetRepoPath: tmpRepo,
+      canonicalMainRef: 'origin/main',
       prNumber: 42,
       ghPrView: async () => ({
         state: 'MERGED',

--- a/tests/unit/projects-advance-mergebase-wiring.test.ts
+++ b/tests/unit/projects-advance-mergebase-wiring.test.ts
@@ -32,6 +32,7 @@ import { describe, it, expect } from 'vitest';
 
 const REPO_ROOT = path.resolve(__dirname, '../..');
 const ROUTES = path.join(REPO_ROOT, 'src/server/routes.ts');
+const CONTEXT = path.join(REPO_ROOT, 'src/core/StageTransitionContext.ts');
 const VALIDATOR = path.join(REPO_ROOT, 'src/core/StageTransitionValidator.ts');
 
 /** Extract each `SafeGitExecutor.readSync(...)` call's inner text, paren-balanced. */
@@ -57,8 +58,24 @@ function readSyncCalls(file: string): string[] {
 }
 
 describe('projects /advance merge-base check: source-tree wiring + honest refusal', () => {
+  it('the route delegates all validator dependency assembly to the production factory', () => {
+    const src = fs.readFileSync(ROUTES, 'utf-8');
+    expect(src).toContain('createProductionStageTransitionContext({');
+    expect(src).not.toContain('const validationCtx: StageValidationContext = {');
+    expect(src).toMatch(/try \{\s+const validationCtx = createProductionStageTransitionContext\(\{/);
+    expect(src).not.toMatch(/createProductionStageTransitionContext\(\{[\s\S]{0,300}canonicalMainRef:/);
+  });
+
+  it('the factory owns live canonical identity/freshness resolution without bare gh or origin/main fallback', () => {
+    const src = fs.readFileSync(CONTEXT, 'utf-8');
+    expect(src).toContain('resolveGhBinary()');
+    expect(src).toContain("['ls-remote', '--exit-code', remote, 'refs/heads/main']");
+    expect(src).not.toContain("execFileSync('gh'");
+    expect(src).not.toContain("return 'origin/main'");
+  });
+
   it('the mergeBaseIsAncestor readSync declares sourceTreeReadOk: true', () => {
-    const calls = readSyncCalls(ROUTES).filter(c =>
+    const calls = readSyncCalls(CONTEXT).filter(c =>
       /operation\s*:\s*['"]projects\.advance\.mergeBaseIsAncestor['"]/.test(c),
     );
     expect(calls.length, 'expected the projects.advance.mergeBaseIsAncestor readSync to exist').toBe(1);
@@ -71,7 +88,7 @@ describe('projects /advance merge-base check: source-tree wiring + honest refusa
   it('the helper distinguishes git exit status 1 from every other failure', () => {
     // The load-bearing half. Fixing only the permission would make THIS case work
     // while leaving the mistranslation in place for the next one.
-    const src = fs.readFileSync(ROUTES, 'utf-8');
+    const src = fs.readFileSync(CONTEXT, 'utf-8');
     // Bound the helper body exactly — a generous character window around the
     // callsite swept in neighbouring functions and made this assertion meaningless
     // (it matched an unrelated `catch { return false }` next door). Brace-balance

--- a/upgrades/next/stage-validator-ref-evidence.md
+++ b/upgrades/next/stage-validator-ref-evidence.md
@@ -1,0 +1,64 @@
+# Project stage validation now reads canonical repository evidence
+
+<!-- bump: patch -->
+
+## What Changed
+
+Project stage transitions now validate specs and convergence reports against one
+immutable snapshot of the live canonical-main head. The branch currently checked
+out in `targetRepoPath`, and a stale local remote-tracking ref, no longer determines
+whether a project artifact exists.
+
+All production dependencies for `StageTransitionValidator` are assembled in one
+typed factory. Missing infrastructure is reported as a validator wiring failure;
+an unavailable git evidence source is reported as unverifiable; only an exact
+absence on the canonical ref becomes `SPEC_FILE_MISSING` or
+`CONVERGENCE_REPORT_MISSING`.
+
+## What to Tell Your User
+
+A project item can leave the outline stage when its spec is on canonical main even if the
+server's local checkout is stale or on an unrelated branch. Stage gates now look
+at the same repository world as the merge gate.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|------------|
+| Ref-backed project-stage evidence | Automatic for project stage transitions |
+| Explicit unverifiable-evidence refusal | Returned automatically when canonical repository evidence cannot be read |
+
+## Design Decisions
+
+- One text reader returns a blob or `null`; it replaces separate filesystem
+  existence and frontmatter reads, avoiding split-world and time-of-check drift.
+- Git `ls-tree` establishes exact absence and entry mode, then `cat-file` reads
+  the content-addressed blob. Symlinks, trees, and submodules are refused.
+- Canonical repository identity uses the launchd-safe GitHub CLI resolver; a
+  read-only remote-head query freezes spec, report, and merge evidence to one OID.
+- The TaskFlow-id gate is unchanged; this repair does not invent a TaskFlow store
+  or claim caller-supplied text names a verified record.
+
+## Causal Autopsy
+
+This was a latent production-wiring defect. The validator's isolated logic was
+correct for the filesystem it received, but the live route supplied a checkout
+as the evidence world. Two earlier stage-wide failures in the same route came
+from missing merge helpers and a launchd-invisible `gh` binary. Point fixes made
+those dependencies work without preventing the next omission. Centralizing the
+context is the class-level repair.
+
+## Multi-machine Posture
+
+No new cross-machine state or write path is introduced. Each machine confirms the
+live remote head, then reads its local object store at that immutable OID. If the
+remote identity, head, or local object is unavailable,
+the result is explicitly unverifiable rather than a fabricated missing-file
+claim.
+
+## Evidence
+
+- `tests/unit/StageTransitionContext.test.ts`
+- `tests/unit/StageTransitionValidator.test.ts`
+- `tests/unit/projects-advance-mergebase-wiring.test.ts`
+- `tests/integration/projects-api.test.ts`

--- a/upgrades/side-effects/stage-validator-ref-evidence.md
+++ b/upgrades/side-effects/stage-validator-ref-evidence.md
@@ -1,0 +1,206 @@
+# Side-Effects Review — Canonical repository evidence for project stage validation
+
+**Version / slug:** `stage-validator-ref-evidence`
+**Date:** `2026-08-01`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `Codex independent reviewer (stage_validator_review)`
+
+## Summary of the change
+
+Project stage transitions now read specs and convergence reports from one
+immutable snapshot of the live canonical-main head instead of the branch checked out at
+`targetRepoPath`. `src/core/StageTransitionContext.ts` becomes the single
+production assembly point for canonical repository identity/freshness resolution, the repository-blob reader,
+GitHub PR reader, and merge-ancestry helper. `StageTransitionValidator` retains
+the stage authority but distinguishes exact absence from unverifiable evidence
+and loud wiring failure. The Projects API route delegates context assembly to
+that factory. Tests cover stale-checkout reads, exact absence, non-regular Git
+entries, incomplete wiring, and the real route.
+
+## Decision-point inventory
+
+- **Spec existence and frontmatter gate** (`StageTransitionValidator`) —
+  **modify** — reads one regular blob from the request's canonical-main OID and refuses only an
+  exact absence as `SPEC_FILE_MISSING`; an unreadable evidence source has a
+  distinct unverifiable verdict.
+- **Convergence-report gate** (`StageTransitionValidator`) — **modify** — reads
+  the report from the same canonical ref as its spec and refuses symlink, tree,
+  and submodule entries as unverifiable rather than filesystem evidence.
+- **Merged-PR gate** (`StageTransitionValidator`) — **pass-through** — retains
+  the existing GitHub and merge-ancestry checks while sharing the same
+  `canonicalMainRef` field used by the spec gates.
+- **Production dependency completeness** (`StageTransitionContext`) — **add** —
+  assembles every validator dependency in one factory, resolves GitHub through
+  an absolute launchd-safe binary path, selects a fork's parent repository,
+  queries the live remote head, and throws a typed wiring error if assembly is incomplete.
+
+---
+
+## 1. Over-block
+
+An artifact that exists only as an uncommitted or branch-only working-tree file
+is no longer accepted by the live Projects API. That is intentional: project
+stage state is durable and shared, so the claimed evidence must exist on the
+canonical ref rather than on whichever checkout happens to serve the request.
+Git symlinks, trees, and submodules at an artifact path are also refused even if
+they ultimately expose markdown bytes; only regular blobs qualify as durable
+spec evidence. No other legitimate input shape was identified.
+
+---
+
+## 2. Under-block
+
+The reader performs a read-only live remote-head query but does not fetch
+objects during an API request. If the live head's object is not already present
+in the local object store, validation is explicitly unverifiable until normal
+repository synchronization catches up. A repository whose canonical branch is
+not named `main` is likewise unverifiable under this Project Scope contract.
+This change also deliberately does not invent verification
+for `taskFlowRecordId`, because no TaskFlow store exists in this subsystem; the
+approved-to-building gate still checks only that an identifier is present.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The Git plumbing belongs in a production context factory, while the validator
+owns stage-domain meanings such as missing, unverifiable, and approved. One
+reader returning text or exact absence replaces the prior split existence and
+frontmatter filesystem reads, eliminating time-of-check and evidence-world
+drift. The route now supplies project inputs to the factory rather than
+reimplementing infrastructure dependencies beside domain fields.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP. Reshape the design. Brittle detectors must not own block authority.
+
+None of those message-judgment boxes describes this authority. The stage gate
+is the document's explicit hard-invariant exception: it verifies enumerable
+artifact facts, not conversational meaning or inferred intent. Exact Git-tree
+absence, a regular-blob mode, deterministic frontmatter fields, and merge
+ancestry are valid structural blockers. The change reduces false authority by
+separating “absent” from “could not inspect” and never lets an infrastructure
+refusal masquerade as a domain fact.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No static heuristic is added at a competing-signals decision point. Repository
+entry type, exact absence, YAML fields, and Git ancestry are enumerable
+invariants named by the approved Project Scope spec. There are no competing
+liveness, ownership, recency, or urgency signals to arbitrate inside this gate.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** markdown/frontmatter validation runs only after the canonical
+  blob is read. An unreadable ref cannot be shadowed by a misleading missing or
+  malformed-spec verdict.
+- **Double-fire:** the factory is called once per advance request and performs
+  read-only Git/GitHub operations; no adjacent component acts on the read.
+- **Races:** one live `ls-remote` result is memoized as an immutable commit OID
+  for the request. Both `ls-tree` and `cat-file` resolve content-addressed
+  objects from that snapshot, so spec and report checks cannot span moving heads.
+- **Feedback loops:** no state is written by evidence resolution. Successful
+  validation feeds the existing Initiative Tracker update exactly once.
+- **Existing merge gate:** PR state and merge ancestry retain their prior
+  behavior, but the ancestry ref and artifact ref now come from the same
+  context field.
+
+---
+
+## 6. External surfaces
+
+The Projects API can now advance an item whose spec is present on live canonical main
+but absent from the serving checkout. Failures caused by unavailable Git
+evidence return a distinct 409 unverifiable code; missing production wiring is
+a 500 wiring error rather than a plausible project refusal. Existing successful
+response shapes and persisted project records do not change. No external API is
+mutated, no new database or ledger is introduced, and no user-facing notice or
+operator action is added.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design:** each machine confirms the same remote head but reads
+the Git object store belonging to the project's configured local repository,
+because object availability is machine-specific. The durable project stage
+continues to use the existing Initiative Tracker replication behavior; this
+change creates no new durable state. It emits no user-facing notices, so
+one-voice gating is not needed, and it generates no URLs. On topic transfer, no
+new state can strand because the only new operation is a read against the target
+repository configured for the serving machine.
+
+---
+
+## 8. Rollback cost
+
+This is a pure code and documentation change. Rollback is a revert followed by
+a patch release. There is no data migration, no agent-state repair, and no
+credential or external-system cleanup. During rollback propagation, stale
+checkouts would again produce false missing-spec refusals; no durable data would
+be corrupted.
+
+---
+
+## Conclusion
+
+The review found one intentional compatibility boundary: branch-only draft
+files no longer qualify as durable project-stage evidence. The independent pass
+also found and drove three corrections before trace signing: canonical resolution
+moved inside the factory and off bare `gh`; live remote freshness now resolves to
+one immutable OID; and factory construction moved inside the route's structured
+error boundary. Central assembly plus exact absence/unverifiable
+separation closes the observed split-world wiring class without expanding into
+the unrelated TaskFlow-store gap. The required independent second pass concurs;
+the change is clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Codex independent reviewer (`stage_validator_review`)
+**Independent read of the artifact:** Concur with the review.
+
+All three initial concerns are resolved: canonical resolution is factory-owned
+and launchd-safe; live remote main is pinned to one immutable OID while failures
+remain unverifiable; and factory construction is inside the structured wiring
+error boundary. Path safety and exact-absence semantics remain sound.
+
+---
+
+## Evidence pointers
+
+- Live before-state from the mentor report: item 7 returned
+  `SPEC_FILE_MISSING` even though its spec existed on local `origin/main` and in
+  none of the 39 checked-out worktrees.
+- `tests/unit/StageTransitionContext.test.ts` proves the canonical blob is read
+  after the checked-out file is removed and distinguishes exact absence.
+- `tests/unit/StageTransitionValidator.test.ts` proves missing wiring and
+  unverifiable evidence cannot become `SPEC_FILE_MISSING`.
+- `tests/integration/projects-api.test.ts` exercises the production factory
+  through the actual Projects API route.
+- Focused validation: 109 tests green; package completeness: 7 tests green;
+  build, lint, release-fragment validation, and pre-push gate green.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller change — not applicable.


### PR DESCRIPTION
## Summary

- read project-stage transition evidence from one live, immutable snapshot of the canonical repository's `main` ref
- centralize production validator wiring in a single context factory
- distinguish exact absence from unavailable/unverifiable evidence
- make fork behavior resolve to the canonical parent repository
- document the governing invariant and add an ELI16 companion

## Root cause

This is the third occurrence of the same production-context wiring failure class: a validator with correct local logic was assembled against a stale or semantically different evidence source. The fix therefore removes the ad hoc assembly seam instead of patching another call site.

## Design

The request-scoped context factory resolves the canonical repository and current `main` OID, memoizes that immutable snapshot, and supplies both spec/report reads and merge-base validation from it. A missing blob is reported as missing only when the canonical snapshot is reachable and the path is exactly absent; resolver, network, or object failures produce an explicit unverifiable result.

No task-flow identifier or persistence model was introduced or changed.

## Validation

- 145 focused tests passed
- TypeScript build passed
- typecheck passed
- full lint passed in the commit gate
- package completeness: 7/7
- release-fragment validation passed
- live canonical resolver returned the same immutable OID across repeated reads
- independent reviewer re-reviewed the revision and concurred that all three initial concerns were resolved

## ELI16 — why one official snapshot matters

Imagine checking whether a school project is ready by looking at papers on one student's desk. Those papers might be old even if the official shared folder has newer versions. The validator was doing the software equivalent: it could inspect a stale checkout and confidently say required evidence was missing.

Now each validation request first identifies the official repository, takes one snapshot of its current `main` branch, and reads every required document and comparison from that same snapshot. If the official source cannot be reached, the system says “I couldn't verify it” instead of pretending the file does not exist. All production routes use the same wiring factory, so a future caller cannot quietly reintroduce the stale-desk behavior.

## UX Impact

Who sees this: operators advancing a project through the project API. The first-contact user-visible behavior is unchanged for valid transitions, but an internal assembly defect now returns the concrete error string `stage validator wiring failure` instead of misreporting missing evidence or an invalid merge. Unreachable canonical evidence is also described as unverifiable rather than absent.
