### PR TITLE
Fix guard tripwire manifest coverage

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-01T12-24-09-456Z-guard-posture-manifest-coverage.json
+++ b/.instar/instar-dev-decisions/2026-08-01T12-24-09-456Z-guard-posture-manifest-coverage.json
@@ -1,0 +1,27 @@
+{
+  "ts": "2026-08-01T12:24:09.456Z",
+  "slug": "guard-posture-manifest-coverage",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 258,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/monitoring/GuardPostureTripwire.ts",
+      "src/monitoring/guardPosture.ts",
+      "src/monitoring/guardPostureView.ts"
+    ],
+    "addedLines": 210,
+    "deletedLines": 48
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3649,6 +3649,11 @@ function setupServerLog(stateDir: string): void {
 
 export async function startServer(options: StartOptions): Promise<void> {
   const config = loadConfig(options.dir);
+  // Capture the guard substrate at the boot-config boundary, BEFORE the
+  // PostUpdateMigrator or any later startup path can rewrite config.json.
+  // The tripwire persists what THIS process booted from; later disk changes
+  // must remain visible to GET /guards as diverged-pending-restart.
+  const bootGuardConfigSnapshot = resolveGuardConfigSnapshot(config.projectDir);
   ensureStateDir(config.stateDir);
 
   // Identity context is additive and survives agent moves. Validate its
@@ -7612,8 +7617,8 @@ export async function startServer(options: StartOptions): Promise<void> {
     }
 
     // GuardPostureTripwire — a disabled guard is itself an incident.
-    // Runs once per server boot. Compares the resolved guard posture (every
-    // monitoring.* enabled flag + scheduler.enabled) against the persisted
+    // Runs once per server boot. Compares the complete resolved guard posture
+    // (generic config extraction UNION the static guard manifest) against the persisted
     // posture from the previous boot; any enabled→disabled transition gets a
     // loud log line + a logs/guard-posture.jsonl breadcrumb + ONE aggregated
     // HIGH Attention item (the 2026-06-05 meltdown load-shed batch-flipped
@@ -7624,7 +7629,11 @@ export async function startServer(options: StartOptions): Promise<void> {
     try {
       const tripwire = await import('../monitoring/GuardPostureTripwire.js');
       const postureResult = await tripwire.runGuardPostureTripwire({
-        config,
+        // Use the defaults/dev-gate-resolved disk substrate captured immediately
+        // after loadConfig. If that read degraded, the already-loaded config is
+        // still safer than dropping the detector entirely.
+        config: bootGuardConfigSnapshot.readError ? config : bootGuardConfigSnapshot.resolved,
+        defaultConfig: bootGuardConfigSnapshot.defaults,
         stateDir: config.stateDir,
         logsDir: path.join(config.stateDir, '..', 'logs'),
         emitAttention: telegram
@@ -7642,15 +7651,31 @@ export async function startServer(options: StartOptions): Promise<void> {
           : undefined,
       });
       if (postureResult.disabled.length > 0) {
+        const transitioned = postureResult.disabled.length - postureResult.newlyTrackedDisabled.length;
         console.log(pc.yellow(
-          `  Guard-posture tripwire: ${postureResult.disabled.length} guard(s) DISABLED since last boot ` +
+          `  Guard-posture tripwire: ${postureResult.disabled.length}/${postureResult.coverage.watched} ` +
+            `watched guard posture incident(s) ` +
+            `(${transitioned} disabled since last boot, ` +
+            `${postureResult.newlyTrackedDisabled.length} newly watched default-ON guard(s) found OFF) ` +
             `(${postureResult.disabled.join(', ')}) — ` +
             `${postureResult.attentionEmitted ? 'Attention item raised' : 'breadcrumb only (no Telegram)'}`,
         ));
       } else if (postureResult.firstBoot) {
-        console.log(pc.green('  Guard-posture tripwire: baseline recorded'));
+        console.log(pc.green(
+          `  Guard-posture tripwire: baseline recorded (${postureResult.coverage.watched} watched guards)`,
+        ));
+      } else if (postureResult.enabled.length > 0) {
+        const transitioned = postureResult.enabled.length - postureResult.newlyTrackedEnabled.length;
+        console.log(pc.green(
+          `  Guard-posture tripwire: ${postureResult.enabled.length}/${postureResult.coverage.watched} ` +
+            `watched guard enablement event(s) ` +
+            `(${transitioned} enabled since last boot, ` +
+            `${postureResult.newlyTrackedEnabled.length} newly watched default-OFF guard(s) found ON)`,
+        ));
       } else {
-        console.log(pc.green('  Guard-posture tripwire: posture unchanged'));
+        console.log(pc.green(
+          `  Guard-posture tripwire: posture unchanged (${postureResult.coverage.watched} watched guards)`,
+        ));
       }
     } catch (err) {
       console.log(pc.yellow(

--- a/src/monitoring/GuardPostureTripwire.ts
+++ b/src/monitoring/GuardPostureTripwire.ts
@@ -34,11 +34,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import {
+  buildCompleteGuardPosture,
   COST_INCREASING_ENABLE_KEYS,
   diffGuardPosture,
   extractGuardPosture,
   guardPostureSnapshotPath,
   type GuardPosture,
+  type GuardPostureBootSnapshot,
+  type GuardPostureCoverage,
   type GuardPostureDiff,
 } from './guardPosture.js';
 
@@ -46,8 +49,8 @@ import {
 // (GUARD-POSTURE-ENDPOINT-SPEC §2.1 single-funnel rule: one definition of
 // "what is a guard", consumed by both this tripwire and GET /guards).
 // Re-exported here so existing importers keep working unchanged.
-export { COST_INCREASING_ENABLE_KEYS, diffGuardPosture, extractGuardPosture };
-export type { GuardPosture, GuardPostureDiff };
+export { buildCompleteGuardPosture, COST_INCREASING_ENABLE_KEYS, diffGuardPosture, extractGuardPosture };
+export type { GuardPosture, GuardPostureCoverage, GuardPostureDiff };
 
 export interface AttentionItemInput {
   id: string;
@@ -62,6 +65,9 @@ export interface AttentionItemInput {
 export interface GuardPostureTripwireOpts {
   /** The RESOLVED config object the server is booting with. */
   config: unknown;
+  /** Resolved defaults for the same agent. Used when a guard is newly enrolled
+   *  so a pre-existing default-ON/config-OFF posture is not silently baselined. */
+  defaultConfig?: unknown;
   /** Agent state dir (`<projectDir>/.instar`) — snapshot lives at `state/guard-posture.json`. */
   stateDir: string;
   /** Logs dir (`<projectDir>/logs`) — breadcrumb lives at `guard-posture.jsonl`. */
@@ -78,15 +84,15 @@ export interface GuardPostureTripwireResult {
   firstBoot: boolean;
   disabled: string[];
   enabled: string[];
+  newlyTrackedDisabled: string[];
+  newlyTrackedEnabled: string[];
+  coverage: GuardPostureCoverage;
   attentionEmitted: boolean;
   /** Non-fatal error message when the tripwire degraded (never throws). */
   error?: string;
 }
 
-interface Snapshot {
-  ts: string;
-  posture: GuardPosture;
-}
+type Snapshot = GuardPostureBootSnapshot;
 
 const snapshotPath = guardPostureSnapshotPath;
 
@@ -104,11 +110,17 @@ export async function runGuardPostureTripwire(
     firstBoot: false,
     disabled: [],
     enabled: [],
+    newlyTrackedDisabled: [],
+    newlyTrackedEnabled: [],
+    coverage: { watched: 0, configDerived: 0, manifestDeclared: 0, overlap: 0 },
     attentionEmitted: false,
   };
 
   try {
-    const posture = extractGuardPosture(opts.config);
+    const complete = buildCompleteGuardPosture(opts.config);
+    const posture = complete.posture;
+    result.coverage = complete.coverage;
+    const defaultPosture = buildCompleteGuardPosture(opts.defaultConfig).posture;
     const snapPath = snapshotPath(opts.stateDir);
 
     let prev: Snapshot | null = null;
@@ -127,19 +139,32 @@ export async function runGuardPostureTripwire(
     // Persist the new snapshot FIRST so even an emit failure below leaves the
     // baseline current (no repeat alarms for the same transition next boot).
     fs.mkdirSync(path.dirname(snapPath), { recursive: true });
+    const snapshot: Snapshot = { ts: now.toISOString(), posture, coverage: complete.coverage };
     /* state-registry: guard-posture-snapshot */
-    fs.writeFileSync(snapPath, JSON.stringify({ ts: now.toISOString(), posture } satisfies Snapshot, null, 2));
+    fs.writeFileSync(snapPath, JSON.stringify(snapshot, null, 2));
 
     if (!prev) {
       result.firstBoot = true;
-      log(`[guard-posture] baseline recorded (${Object.keys(posture).length} guards)`);
+      log(
+        `[guard-posture] baseline recorded (watching ${complete.coverage.watched} guards: ` +
+        `${complete.coverage.configDerived} config-derived + ${complete.coverage.manifestDeclared} manifest ` +
+        `- ${complete.coverage.overlap} overlap)`,
+      );
       return result;
     }
 
-    const diff = diffGuardPosture(prev.posture, posture);
+    const diff = diffGuardPosture(prev.posture, posture, defaultPosture);
     result.disabled = diff.disabled;
     result.enabled = diff.enabled;
+    result.newlyTrackedDisabled = diff.newlyTrackedDisabled;
+    result.newlyTrackedEnabled = diff.newlyTrackedEnabled;
     if (diff.disabled.length === 0 && diff.enabled.length === 0) return result;
+
+    log(
+      `[guard-posture] posture incidents detected across ${complete.coverage.watched} watched guards ` +
+      `(disabled=${diff.disabled.length}/${complete.coverage.watched}, ` +
+      `enabled=${diff.enabled.length}/${complete.coverage.watched})`,
+    );
 
     // Breadcrumb — one aggregated row per boot that saw transitions.
     try {
@@ -151,25 +176,45 @@ export async function runGuardPostureTripwire(
           kind: 'guard-posture-change',
           disabled: diff.disabled,
           enabled: diff.enabled,
+          newlyTrackedDisabled: diff.newlyTrackedDisabled,
+          newlyTrackedEnabled: diff.newlyTrackedEnabled,
           prevTs: prev.ts,
+          previousWatched: prev.coverage?.watched ?? Object.keys(prev.posture).length,
+          coverage: complete.coverage,
         }) + '\n',
       );
     } catch (err) {
       result.error = `breadcrumb append failed: ${err instanceof Error ? err.message : String(err)}`;
     }
 
-    for (const key of diff.enabled) log(`[guard-posture] guard re-enabled since last boot: ${key}`);
-    for (const key of diff.disabled) log(`[guard-posture] ⚠ GUARD DISABLED since last boot: ${key}`);
+    const newlyEnabled = new Set(diff.newlyTrackedEnabled);
+    const newlyDisabled = new Set(diff.newlyTrackedDisabled);
+    for (const key of diff.enabled) {
+      log(newlyEnabled.has(key)
+        ? `[guard-posture] newly watched default-OFF guard found ON: ${key}`
+        : `[guard-posture] guard re-enabled since last boot: ${key}`);
+    }
+    for (const key of diff.disabled) {
+      log(newlyDisabled.has(key)
+        ? `[guard-posture] ⚠ newly watched default-ON guard found OFF: ${key}`
+        : `[guard-posture] ⚠ GUARD DISABLED since last boot: ${key}`);
+    }
 
     if (diff.disabled.length > 0 && opts.emitAttention) {
       const list = diff.disabled.join(', ');
+      const existingDisabled = diff.disabled.filter(k => !diff.newlyTrackedDisabled.includes(k));
+      const transitionText = existingDisabled.length > 0
+        ? `${existingDisabled.join(', ')} were ON at the previous server boot and are OFF now. `
+        : '';
+      const enrollmentText = diff.newlyTrackedDisabled.length > 0
+        ? `${diff.newlyTrackedDisabled.join(', ')} are newly watched and are OFF against their resolved ON default. `
+        : '';
       try {
         await opts.emitAttention({
           id: `guard-posture-disabled:${now.toISOString().slice(0, 10)}:${diff.disabled.join(',')}`,
-          title: `${diff.disabled.length} monitoring guard(s) disabled since last boot`,
+          title: `${diff.disabled.length} of ${complete.coverage.watched} watched guard(s) disabled`,
           summary:
-            `These guards were ON at the previous server boot and are OFF now: ${list}. ` +
-            `Nothing in instar code flips these flags — this was a config edit. ` +
+            `Disabled guards: ${list}. ${transitionText}${enrollmentText}` +
             `If it was deliberate (e.g. load-shedding), acknowledge this item; otherwise re-enable them in .instar/config.json. ` +
             `History: logs/guard-posture.jsonl.`,
           category: 'monitoring',
@@ -189,12 +234,20 @@ export async function runGuardPostureTripwire(
     const costIncreasing = diff.enabled.filter(k => COST_INCREASING_ENABLE_KEYS.has(k));
     if (costIncreasing.length > 0 && opts.emitAttention) {
       const list = costIncreasing.join(', ');
+      const newlyTrackedCost = costIncreasing.filter(k => newlyEnabled.has(k));
+      const transitionedCost = costIncreasing.filter(k => !newlyEnabled.has(k));
+      const transitionedCostText = transitionedCost.length > 0
+        ? `${transitionedCost.join(', ')} were OFF at the previous server boot and are ON now. `
+        : '';
+      const newlyTrackedCostText = newlyTrackedCost.length > 0
+        ? `${newlyTrackedCost.join(', ')} are newly watched and are ON against their resolved OFF default. `
+        : '';
       try {
         await opts.emitAttention({
           id: `guard-posture-cost-enable:${now.toISOString().slice(0, 10)}:${costIncreasing.join(',')}`,
-          title: `Cost-increasing feature enabled since last boot`,
+          title: `${costIncreasing.length} of ${complete.coverage.watched} watched cost-increasing feature(s) enabled`,
           summary:
-            `These cost-increasing flags were OFF at the previous server boot and are ON now: ${list}. ` +
+            `Enabled cost-increasing flags: ${list}. ${transitionedCostText}${newlyTrackedCostText}` +
             `Model-tier escalation routes eligible work to the ultra model (~2x cost). ` +
             `If this was deliberate, acknowledge this item; otherwise flip it back in .instar/config.json. ` +
             `History: logs/guard-posture.jsonl.`,

--- a/src/monitoring/guardPosture.ts
+++ b/src/monitoring/guardPosture.ts
@@ -19,6 +19,10 @@ import path from 'node:path';
 import { getInitDefaults, type AgentType } from '../config/ConfigDefaults.js';
 import { resolveDevAgentGate } from '../core/devAgentGate.js';
 import { DEV_GATED_FEATURES, getConfigByPath } from '../core/devGatedFeatures.js';
+import {
+  GUARD_MANIFEST,
+  type GuardManifestEntry,
+} from './guardManifest.js';
 
 export type GuardPosture = Record<string, boolean>;
 
@@ -27,6 +31,24 @@ export interface GuardPostureDiff {
   disabled: string[];
   /** Guards that were disabled last boot and are enabled now. */
   enabled: string[];
+  /** Newly enrolled keys whose current value is OFF against an ON default. */
+  newlyTrackedDisabled: string[];
+  /** Newly enrolled keys whose current value is ON against an OFF default. */
+  newlyTrackedEnabled: string[];
+}
+
+/** Auditable denominator for the posture substrate. The arithmetic invariant is
+ *  configDerived + manifestDeclared - overlap === watched. */
+export interface GuardPostureCoverage {
+  watched: number;
+  configDerived: number;
+  manifestDeclared: number;
+  overlap: number;
+}
+
+export interface CompleteGuardPosture {
+  posture: GuardPosture;
+  coverage: GuardPostureCoverage;
 }
 
 /** Posture keys whose false→true transition is COST-INCREASING and must be
@@ -131,19 +153,87 @@ export function extractGuardPosture(config: unknown): GuardPosture {
 }
 
 /**
- * Diff two postures. Only keys present in BOTH snapshots can transition —
- * a key appearing for the first time (new feature) or vanishing (config
- * cleanup) is a shape change, not a guard flip, and raises nothing.
+ * Build the COMPLETE boot/read posture from the same substrate as GET /guards:
+ * generic config extraction UNION the static manifest.
+ *
+ * Manifest value precedence deliberately matches buildGuardInventory's historic
+ * behavior: an extractor-derived value wins, then the manifest configPath, then
+ * the declared default. Consequently a default-ON guard absent from config is
+ * represented as ON; writing an explicit false produces an observable flip.
  */
-export function diffGuardPosture(prev: GuardPosture, cur: GuardPosture): GuardPostureDiff {
+export function buildCompleteGuardPosture(
+  config: unknown,
+  manifest: readonly GuardManifestEntry[] = GUARD_MANIFEST,
+): CompleteGuardPosture {
+  const extracted = extractGuardPosture(config);
+  const configObject = config && typeof config === 'object' && !Array.isArray(config)
+    ? config as Record<string, unknown>
+    : {};
+  const manifestMap = new Map<string, GuardManifestEntry>();
+  for (const entry of manifest) manifestMap.set(entry.key, entry);
+
+  const watchedKeys = [...new Set([...Object.keys(extracted), ...manifestMap.keys()])].sort();
+  const posture: GuardPosture = {};
+  let overlap = 0;
+  for (const key of watchedKeys) {
+    const entry = manifestMap.get(key);
+    if (entry && key in extracted) overlap++;
+
+    let enabled = extracted[key];
+    if (typeof enabled !== 'boolean' && entry?.configPath) {
+      const configured = getConfigByPath(configObject, entry.configPath);
+      if (typeof configured === 'boolean') enabled = configured;
+    }
+    if (typeof enabled !== 'boolean' && entry) enabled = entry.defaultEnabled;
+
+    // Every key came from either the boolean-only extractor or a manifest
+    // entry with a boolean default, so this branch is only a defensive guard.
+    if (typeof enabled === 'boolean') posture[key] = enabled;
+  }
+
+  return {
+    posture,
+    coverage: {
+      watched: Object.keys(posture).length,
+      configDerived: Object.keys(extracted).length,
+      manifestDeclared: manifestMap.size,
+      overlap,
+    },
+  };
+}
+
+/**
+ * Diff two postures. Existing keys compare boot-to-boot. A newly enrolled key
+ * normally remains a shape change; when a resolved default posture is supplied,
+ * however, its current value is compared with that default. This makes a tripwire
+ * inventory expansion fail visible instead of silently blessing a pre-existing
+ * default-ON/config-OFF guard as the new baseline.
+ */
+export function diffGuardPosture(
+  prev: GuardPosture,
+  cur: GuardPosture,
+  defaultPosture?: GuardPosture,
+): GuardPostureDiff {
   const disabled: string[] = [];
   const enabled: string[] = [];
+  const newlyTrackedDisabled: string[] = [];
+  const newlyTrackedEnabled: string[] = [];
   for (const key of Object.keys(cur).sort()) {
-    if (!(key in prev)) continue;
-    if (prev[key] === true && cur[key] === false) disabled.push(key);
-    else if (prev[key] === false && cur[key] === true) enabled.push(key);
+    if (key in prev) {
+      if (prev[key] === true && cur[key] === false) disabled.push(key);
+      else if (prev[key] === false && cur[key] === true) enabled.push(key);
+      continue;
+    }
+    if (!defaultPosture || !(key in defaultPosture)) continue;
+    if (defaultPosture[key] === true && cur[key] === false) {
+      disabled.push(key);
+      newlyTrackedDisabled.push(key);
+    } else if (defaultPosture[key] === false && cur[key] === true) {
+      enabled.push(key);
+      newlyTrackedEnabled.push(key);
+    }
   }
-  return { disabled, enabled };
+  return { disabled, enabled, newlyTrackedDisabled, newlyTrackedEnabled };
 }
 
 // ── Boot snapshot (written by the tripwire at every boot, read by /guards
@@ -152,6 +242,8 @@ export function diffGuardPosture(prev: GuardPosture, cur: GuardPosture): GuardPo
 export interface GuardPostureBootSnapshot {
   ts: string;
   posture: GuardPosture;
+  /** Optional for backward compatibility with pre-denominator snapshots. */
+  coverage?: GuardPostureCoverage;
 }
 
 export function guardPostureSnapshotPath(stateDir: string): string {

--- a/src/monitoring/guardPostureView.ts
+++ b/src/monitoring/guardPostureView.ts
@@ -18,7 +18,7 @@ import {
 import type { AcceptedFallbackRecord, ScopedAcceptedFallbacks } from './guardAcceptedFallbacks.js';
 import { getConfigByPath } from '../core/devGatedFeatures.js';
 import {
-  extractGuardPosture,
+  buildCompleteGuardPosture,
   type GuardPostureBootSnapshot,
   type ResolvedGuardConfigSnapshot,
 } from './guardPosture.js';
@@ -369,30 +369,22 @@ export function buildGuardInventory(opts: {
   acceptedFallbacks?: ScopedAcceptedFallbacks;
 }): GuardInventoryResult {
   const now = opts.now ?? Date.now();
-  const extractedCurrent = extractGuardPosture(opts.snapshot.resolved);
-  const extractedDefaults = extractGuardPosture(opts.snapshot.defaults);
+  // The endpoint and boot tripwire consume this exact same union builder.
+  // Keeping key/value assembly in one funnel prevents the 36-of-90 split where
+  // /guards knew the manifest but the transition detector did not.
+  const currentPosture = buildCompleteGuardPosture(opts.snapshot.resolved).posture;
+  const defaultPosture = buildCompleteGuardPosture(opts.snapshot.defaults).posture;
   const manifestMap = new Map<string, GuardManifestEntry>();
   for (const entry of GUARD_MANIFEST) manifestMap.set(entry.key, entry);
 
-  const keys = [...new Set([...Object.keys(extractedCurrent), ...manifestMap.keys()])].sort();
+  const keys = Object.keys(currentPosture).sort();
 
   const guards: GuardRow[] = [];
   for (const key of keys) {
     const manifest = manifestMap.get(key);
 
-    let configEnabled = asBool(extractedCurrent[key]);
-    let defaultEnabled = asBool(extractedDefaults[key]);
-    if (configEnabled === undefined && manifest?.configPath) {
-      configEnabled = asBool(getConfigByPath(opts.snapshot.resolved, manifest.configPath));
-    }
-    if (defaultEnabled === undefined && manifest?.configPath) {
-      defaultEnabled = asBool(getConfigByPath(opts.snapshot.defaults, manifest.configPath));
-    }
-    if (defaultEnabled === undefined && manifest) defaultEnabled = manifest.defaultEnabled;
-    // The resolved snapshot normally contains every default key (defaults are
-    // merged in), but a degraded/partial snapshot must still yield the
-    // default-resolved state — a guard can never drop out of the inventory.
-    if (configEnabled === undefined) configEnabled = defaultEnabled;
+    const configEnabled = asBool(currentPosture[key]);
+    const defaultEnabled = asBool(defaultPosture[key]);
 
     const configDryRun = manifest?.dryRunConfigPath
       ? asBool(getConfigByPath(opts.snapshot.resolved, manifest.dryRunConfigPath))

--- a/tests/e2e/guard-posture-tripwire-lifecycle.test.ts
+++ b/tests/e2e/guard-posture-tripwire-lifecycle.test.ts
@@ -86,6 +86,21 @@ describe('GuardPostureTripwire E2E — WIRED into server.ts (dead-code guard)', 
     expect(block).toContain('createAttentionItem');
   });
 
+  it('captures the resolved substrate immediately after loadConfig and before migration', () => {
+    const loadIndex = serverSrc.indexOf('const config = loadConfig(options.dir)');
+    const captureIndex = serverSrc.indexOf(
+      'const bootGuardConfigSnapshot = resolveGuardConfigSnapshot(config.projectDir)',
+    );
+    const migrationIndex = serverSrc.indexOf('new PostUpdateMigrator(', captureIndex);
+    expect(loadIndex).toBeGreaterThan(-1);
+    expect(captureIndex).toBeGreaterThan(loadIndex);
+    expect(migrationIndex).toBeGreaterThan(captureIndex);
+
+    const block = serverSrc.slice(serverSrc.indexOf('GuardPostureTripwire'));
+    expect(block).toContain('defaultConfig: bootGuardConfigSnapshot.defaults');
+    expect(block).not.toContain('const guardConfigSnapshot = resolveGuardConfigSnapshot');
+  });
+
   it('server.ts surfaces a disabled-guard boot line', () => {
     expect(serverSrc).toContain('Guard-posture tripwire');
   });

--- a/tests/unit/guardPosture-modelTier.test.ts
+++ b/tests/unit/guardPosture-modelTier.test.ts
@@ -43,7 +43,7 @@ describe('extractGuardPosture — models.tierEscalation', () => {
 
 describe('runGuardPostureTripwire — escalation flips', () => {
   let dir: string;
-  const emitted: Array<{ id: string; title: string; priority: string }> = [];
+  const emitted: Array<{ id: string; title: string; summary: string; priority: string }> = [];
 
   beforeEach(() => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-gpt-mte-'));
@@ -62,7 +62,7 @@ describe('runGuardPostureTripwire — escalation flips', () => {
     stateDir: dir,
     logsDir: path.join(dir, 'logs'),
     log: () => {},
-    emitAttention: async (item: { id: string; title: string; priority: string }) => {
+    emitAttention: async (item: { id: string; title: string; summary: string; priority: string }) => {
       emitted.push(item);
     },
   });
@@ -81,6 +81,23 @@ describe('runGuardPostureTripwire — escalation flips', () => {
     const r = await runGuardPostureTripwire(opts({ models: { tierEscalation: { enabled: true, dryRun: false } } }));
     expect(r.disabled).toContain('models.tierEscalation.dryRun');
     expect(emitted.some(e => e.id.includes('guard-posture-disabled'))).toBe(true);
+  });
+
+  it('newly enrolled cost enablement is described as default deviation, not a prior-boot flip', async () => {
+    fs.mkdirSync(path.join(dir, 'state'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'state', 'guard-posture.json'),
+      JSON.stringify({ ts: '2026-07-31T00:00:00.000Z', posture: { 'scheduler.enabled': true } }),
+    );
+    const r = await runGuardPostureTripwire({
+      ...opts({ models: { tierEscalation: { enabled: true, dryRun: true } } }),
+      defaultConfig: { models: { tierEscalation: { enabled: false, dryRun: true } } },
+    });
+
+    expect(r.newlyTrackedEnabled).toContain('models.tierEscalation.enabled');
+    const costItem = emitted.find(e => e.id.includes('guard-posture-cost-enable'));
+    expect(costItem?.summary).toContain('newly watched');
+    expect(costItem?.summary).not.toContain('previous server boot');
   });
 
   it('no flip ⇒ nothing emitted', async () => {

--- a/tests/unit/monitoring/GuardPostureTripwire.test.ts
+++ b/tests/unit/monitoring/GuardPostureTripwire.test.ts
@@ -13,11 +13,15 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  buildCompleteGuardPosture,
   extractGuardPosture,
   diffGuardPosture,
   runGuardPostureTripwire,
   type AttentionItemInput,
 } from '../../../src/monitoring/GuardPostureTripwire.js';
+import { resolveGuardConfigSnapshot } from '../../../src/monitoring/guardPosture.js';
+import { buildGuardInventory } from '../../../src/monitoring/guardPostureView.js';
+import { GuardRegistry } from '../../../src/monitoring/GuardRegistry.js';
 import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
 
 // The shape of the real incident config (2026-06-05): mixed dict-with-enabled
@@ -68,6 +72,25 @@ describe('extractGuardPosture', () => {
     expect(extractGuardPosture(null)).toEqual({});
     expect(extractGuardPosture('nope')).toEqual({});
     expect(extractGuardPosture({})).toEqual({});
+  });
+});
+
+describe('buildCompleteGuardPosture', () => {
+  it('unions manifest guards outside monitoring into the watched posture', () => {
+    const complete = buildCompleteGuardPosture({
+      monitoring: {},
+      multiMachine: {
+        peerExecution: { enabled: false },
+        meshTransport: { recoveryProbeEnabled: false },
+      },
+    });
+
+    expect(complete.posture['multiMachine.peerExecution.enabled']).toBe(false);
+    expect(complete.posture['multiMachine.meshTransport.recoveryProbeEnabled']).toBe(false);
+    expect(complete.coverage.watched).toBe(Object.keys(complete.posture).length);
+    expect(
+      complete.coverage.configDerived + complete.coverage.manifestDeclared - complete.coverage.overlap,
+    ).toBe(complete.coverage.watched);
   });
 });
 
@@ -137,6 +160,34 @@ describe('runGuardPostureTripwire', () => {
     expect(snapshot().posture['scheduler.enabled']).toBe(true);
   });
 
+  it('persists exactly the same key set that GET /guards inventories', async () => {
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({
+      developmentAgent: true,
+      monitoring: { watchdog: { enabled: true } },
+      multiMachine: {
+        peerExecution: { enabled: false },
+        meshTransport: { recoveryProbeEnabled: false },
+      },
+    }));
+    const resolved = resolveGuardConfigSnapshot(dir);
+    const r = await runGuardPostureTripwire({
+      config: resolved.resolved,
+      defaultConfig: resolved.defaults,
+      stateDir,
+      logsDir,
+      log: () => {},
+    });
+    const inventory = buildGuardInventory({
+      snapshot: resolved,
+      bootSnapshot: null,
+      registry: new GuardRegistry(),
+    });
+
+    expect(Object.keys(snapshot().posture).sort()).toEqual(inventory.guards.map(g => g.key));
+    expect(r.coverage.watched).toBe(inventory.guards.length);
+  });
+
   it('the incident shape: batch flip → ONE aggregated attention item + one breadcrumb row', async () => {
     await runGuardPostureTripwire({ config: CONFIG_BEFORE, stateDir, logsDir, emitAttention: emit, log: () => {} });
     const r = await runGuardPostureTripwire({
@@ -154,6 +205,57 @@ describe('runGuardPostureTripwire', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].kind).toBe('guard-posture-change');
     expect(rows[0].disabled).toContain('monitoring.contextWedgeSentinel.enabled');
+    expect(rows[0].coverage.watched).toBe(r.coverage.watched);
+    expect(emitted[0].title).toContain(`of ${r.coverage.watched}`);
+  });
+
+  it('inventory expansion compares newly watched guards with resolved defaults', async () => {
+    // Simulate a pre-fix 36-key snapshot: neither non-monitoring manifest key
+    // existed, even though both were explicitly OFF in config.
+    fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, 'state', 'guard-posture.json'),
+      JSON.stringify({ ts: '2026-07-31T00:00:00.000Z', posture: { 'scheduler.enabled': true } }),
+    );
+
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({
+      developmentAgent: true,
+      multiMachine: {
+        peerExecution: { enabled: false },
+        meshTransport: { recoveryProbeEnabled: false },
+      },
+    }));
+    const resolved = resolveGuardConfigSnapshot(dir);
+    const currentPosture = buildCompleteGuardPosture(resolved.resolved).posture;
+    const defaultPosture = buildCompleteGuardPosture(resolved.defaults).posture;
+    expect(currentPosture['multiMachine.peerExecution.enabled']).toBe(false);
+    expect(defaultPosture['multiMachine.peerExecution.enabled']).toBe(true);
+    expect(currentPosture['multiMachine.meshTransport.recoveryProbeEnabled']).toBe(false);
+    expect(defaultPosture['multiMachine.meshTransport.recoveryProbeEnabled']).toBe(true);
+
+    const logLines: string[] = [];
+    const r = await runGuardPostureTripwire({
+      config: resolved.resolved,
+      defaultConfig: resolved.defaults,
+      stateDir,
+      logsDir,
+      emitAttention: emit,
+      log: (line) => { logLines.push(line); },
+    });
+
+    expect(r.disabled).toEqual([
+      'multiMachine.meshTransport.recoveryProbeEnabled',
+      'multiMachine.peerExecution.enabled',
+    ]);
+    expect(r.newlyTrackedDisabled).toEqual(r.disabled);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].title).toBe(`2 of ${r.coverage.watched} watched guard(s) disabled`);
+    expect(emitted[0].summary).toContain('newly watched');
+    expect(logLines.some(line => line.includes('newly watched default-ON guard found OFF'))).toBe(true);
+    expect(logLines.filter(line => line.includes('multiMachine.peerExecution.enabled')).join('\n'))
+      .not.toContain('since last boot');
+    expect(breadcrumbs()[0].previousWatched).toBe(1);
+    expect(snapshot().posture['multiMachine.peerExecution.enabled']).toBe(false);
   });
 
   it('no repeat alarm: the same disabled posture on the NEXT boot raises nothing (transition-based)', async () => {

--- a/upgrades/next/guard-posture-manifest-coverage.md
+++ b/upgrades/next/guard-posture-manifest-coverage.md
@@ -1,0 +1,24 @@
+# Upgrade Guide — vNEXT
+<!-- bump: patch -->
+
+## What Changed
+
+Fixed the boot-time guard tripwire so it watches the same complete guard inventory as the Guards read surface. The tripwire now combines config-derived guards with the static guard manifest, records an explicit watched denominator, and carries that denominator into boot logs, transition breadcrumbs, and Attention items.
+
+The first upgraded boot handles old narrower snapshots safely. A newly watched guard is compared with its resolved default: a guard that defaults on but is explicitly off is reported instead of silently becoming the new baseline. Later boots remain transition-based, so the same posture does not repeatedly alert.
+
+## What to Tell Your User
+
+The safety tripwire now watches every declared guard it can enumerate, including guards outside the monitoring section. Its reports also say how many guards were examined, so a partial inventory cannot masquerade as a complete check.
+
+## Summary of New Capabilities
+
+- Boot-time guard checks and the Guards inventory now share one complete posture builder.
+- Older narrow snapshots are upgraded without hiding existing default-on protections that are off.
+- Guard transition records and alerts include their watched denominator.
+
+## Evidence
+
+- The measured failure shape was 36 watched keys against a 90-row Guards inventory; 54 declared guards were absent from the boot snapshot.
+- A focused migration test starts with a legacy snapshot lacking the two reported multi-machine guards, resolves their development-agent defaults to on while config explicitly sets them off, and proves both enter one denominator-aware alert and breadcrumb.
+- Guard endpoint, load-bearing, tripwire, snapshot, model-tier, and accepted-fallback suites pass together (95 focused assertions), along with TypeScript type-checking, the full repository lint suite, and the production build.

--- a/upgrades/side-effects/guard-posture-manifest-coverage.md
+++ b/upgrades/side-effects/guard-posture-manifest-coverage.md
@@ -1,0 +1,127 @@
+# Side-Effects Review — Complete boot guard-posture coverage
+
+**Version / slug:** `guard-posture-manifest-coverage`
+**Date:** `2026-08-01`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `guard_posture_review`
+
+## Summary of the change
+
+The boot-time GuardPostureTripwire previously persisted only the generic config extractor while GET /guards independently unioned that extractor with the 72-entry static guard manifest. On the measured agent this produced 36 watched keys against 90 inventory rows, leaving 54 declared guards outside transition detection. This change adds one shared `buildCompleteGuardPosture` funnel in `guardPosture.ts`, uses it from both the tripwire and `buildGuardInventory`, captures current and default config through the endpoint's existing one-read resolver immediately after `loadConfig` and before any startup migrator can rewrite disk, migrates old narrow snapshots by comparing newly enrolled keys with their resolved defaults, and records coverage arithmetic in snapshots, breadcrumbs, logs, results, and Attention text.
+
+## Decision-point inventory
+
+- `buildCompleteGuardPosture` — **add** — deterministically assembles config-derived keys union manifest keys and resolves each boolean with extractor → manifest config path → manifest default precedence.
+- `diffGuardPosture` — **modify** — existing keys still compare boot-to-boot; newly enrolled keys compare against a supplied resolved default posture so an old snapshot cannot silently bless a default-on/config-off guard.
+- `runGuardPostureTripwire` — **modify** — remains a signal-only boot detector, but consumes the complete posture, persists denominator metadata, and includes enrollment deviations in its existing aggregated signal surfaces.
+- `buildGuardInventory` — **modify** — consumes the shared complete posture instead of independently rebuilding the same union.
+- GuardPostureProbe and all guard runtime authorities — **pass-through** — their classification, persistence threshold, episode lifecycle, accept-fallback semantics, and actuation authority are unchanged.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block is not applicable. The tripwire never prevents boot, edits config, re-enables a guard, or constrains an operator action. A deliberately disabled default-on guard can produce a HIGH Attention item, but that item is an observation with an acknowledge path, not a refusal.
+
+The old-snapshot enrollment rule is deliberately narrow: only a boolean mismatch against the resolved default becomes a transition signal. A newly declared key whose current value equals its default is merely enrolled and produces no alert.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block is not applicable. Detection still has two honest boundaries:
+
+1. A guard with neither a manifest entry nor an extractor-visible config key remains invisible to both the tripwire and GET /guards. This change makes the two surfaces equal; it does not claim their union is metaphysically complete. The existing manifest lint remains the class-level mechanism for preventing shipped guard components from falling outside that boundary.
+2. First-ever boot with no prior snapshot preserves the existing baseline-without-alert behavior. Default deviations remain visible to GET /guards and its cadenced GuardPostureProbe, while the tripwire begins transition detection from the new complete baseline. The special default comparison applies only when a prior, narrower snapshot proves this is an inventory migration rather than a brand-new installation.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The union belongs in `guardPosture.ts`, the module already documented as the single definition of guard posture. The static manifest has no runtime ordering dependency, and the runtime registry contributes enrichment only after the key set is assembled. Importing the manifest into the shared posture builder removes the producer/consumer split without coupling boot detection to request-time registry state.
+
+Resolved current and default values come from `resolveGuardConfigSnapshot`, the same substrate GET /guards already uses. This is essential for dev-gated guards: on a development agent, an omitted gate defaults on, while an explicit false remains off. Reading only the manifest's fleet default would miss exactly that default-on/config-off case.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by existing operator surfaces.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The deterministic comparison owns no authority. It writes an audit breadcrumb, logs the observed transition, and may create one aggregated Attention item. It never blocks boot or changes posture. The operator remains the authority who acknowledges a deliberate disable or asks the agent to restore protection.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic is added at a competing-signals judgment point. Boolean posture equality and set union are enumerable invariants. The only new classification—newly enrolled current value differs from its resolved default—is the same mechanical default-deviation fact GET /guards already derives, reused to prevent an inventory migration from erasing evidence.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the tripwire still runs at boot before the SystemReviewer probes. Its complete snapshot improves later disk-versus-boot divergence for manifest-only keys; it does not suppress probe classification.
+- **Double-fire:** the existing architecture intentionally has complementary transition-at-boot and persistent-steady-state tracks. On the first upgraded boot, an already-persistent default deviation may create one enrollment Attention item and later remain eligible for the probe's separately episode-deduped persistent anomaly item. This is bounded to the migration boot on the tripwire side because the complete snapshot is written before emission and the same posture cannot fire again. Within each track aggregation remains one item, never one item per guard.
+- **Races:** the resolved substrate is captured immediately after `loadConfig`, before PostUpdateMigrator or another startup writer can change config.json. The later tripwire therefore records what this process booted from, while a migration-time disk change remains visible to GET /guards as pending restart. Snapshot persistence remains first within the detector: even if breadcrumb or Attention emission fails, the complete baseline advances and the next boot does not replay the same transition. GET /guards reads either the old snapshot (missing keys honestly report snapshot-unavailable) or the completed JSON file after the synchronous write; no partial in-memory state is shared.
+- **Feedback loops:** neither logs, breadcrumbs, nor Attention acknowledgement feed a value back into posture extraction. The accepted-fallback system affects only the separate load-bearing-gap classification and is unchanged.
+- **Compatibility:** coverage metadata is optional when reading old snapshots. Existing consumers continue to read `ts` and `posture`; new breadcrumb fields are additive JSON members.
+
+---
+
+## 6. External surfaces
+
+Operators may see more accurate boot Attention items for guards that were previously outside the tripwire, and every boot/transition log now names the watched denominator. The local snapshot gains an optional `coverage` object; transition JSONL rows gain `coverage`, `previousWatched`, and newly-tracked key lists. There is no API schema change to GET /guards, no new route, no external network call, and no new operator action.
+
+The snapshot remains machine-local operational state. Rollback code ignores additive JSON fields. Attention content continues to use the existing queue and can be completed from the phone-visible dashboard/Telegram surfaces; no laptop-only workflow is introduced.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No dashboard renderer, approval form, grant surface, or destructive control changes. The touched operator surface is text-only Attention/log output. It leads with the actionable fact (“N of M watched guards disabled”), uses human-readable denominator language, keeps raw guard keys as supporting identifiers, and introduces no destructive action. Existing Attention items already render at phone width.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** Each machine's boot tripwire observes that machine's resolved config and its own previous boot snapshot. A cross-machine union would be incorrect because guard enablement, development-agent defaults, and boot transitions can legitimately differ by machine. Pool-wide posture remains served by the existing heartbeat and GET /guards scope machinery; this change does not alter it.
+
+The tripwire can emit a user-facing notice from each machine, as it already could for config-extracted guards. Attention IDs remain machine-local through each agent server's queue; no new one-voice election is added because the fact is specifically “this machine's boot posture changed,” not a pool-global judgment. State is machine-local and should not follow topic transfer. No URLs are generated.
+
+---
+
+## 8. Rollback cost
+
+Rollback is a code-only patch revert. Old code will ignore the additive `coverage` member in the snapshot and additive fields in historical JSONL rows. It will resume watching only the narrow extractor set on subsequent boots; no database migration, state rewrite, operator reset, or credential rotation is needed. Reverting would restore the visibility defect, so rollback should be followed by a corrected patch rather than treated as a safe steady state.
+
+---
+
+## Conclusion
+
+The change closes the measured producer/consumer coverage gap at the shared inventory layer, preserves signal-only authority, makes migration semantics explicit, and makes coverage auditable everywhere the tripwire reports. The remaining discovery limit is stated rather than hidden. The independent review caught and caused two material corrections before ship: moving boot evidence capture ahead of startup migration, and separating enrollment-deviation wording from real boot-to-boot transitions. Focused tests cover the exact two default-on/config-off multi-machine guards, legacy-snapshot enrollment, denominator propagation, no-repeat behavior, endpoint compatibility, and build/lint health. The revised change is clear to ship.
+
+---
+
+## Second-pass review (required: guard-related change)
+
+**Reviewer:** `guard_posture_review`
+**Independent read of the artifact:** Concur. The resolved posture is captured immediately after `loadConfig` and before any startup config writer, preserving restart-divergence truth; existing transitions and newly enrolled default deviations use distinct operator wording; the shared union builder gives the tripwire and GET /guards identical keys; and old-snapshot compatibility, dev-gated defaults, denominator arithmetic, one-fire migration behavior, signal-only authority, and machine-local posture remain intact. The reviewer ran 61 focused tests plus typecheck and the guard-manifest lint.
+
+---
+
+## Evidence pointers
+
+- Unit and E2E tripwire lifecycle, including boot-capture ordering and enrollment wording: `tests/unit/monitoring/GuardPostureTripwire.test.ts`, `tests/unit/guardPosture-modelTier.test.ts`, `tests/e2e/guard-posture-tripwire-lifecycle.test.ts`
+- GET /guards and load-bearing compatibility: `tests/e2e/guards-endpoint-lifecycle.test.ts`, `tests/e2e/guards-loadbearing-lifecycle.test.ts`, `tests/integration/guards-route.test.ts`, `tests/integration/guards-accept-fallback-route.test.ts`
+- Static/build: `npm run lint`, `npm run build`, and `npx tsc --noEmit` pass.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered actuation controller change — not applicable. This repairs runtime inventory composition in a signal-only detector. The recurrence guard is the shared `buildCompleteGuardPosture` funnel consumed by both the tripwire and GET /guards, pinned by the focused union and server-wiring lifecycle tests.


### PR DESCRIPTION
## Summary

- make the boot tripwire and GET /guards consume one shared config-plus-manifest posture builder
- enroll all manifest guards, including non-monitoring and nested guards, in the persisted boot snapshot
- compare newly enrolled keys against resolved defaults so old narrow snapshots do not bless existing default-on/config-off deviations
- include watched-denominator arithmetic in snapshots, breadcrumbs, logs, server summaries, and Attention items
- preserve true boot evidence by capturing the resolved substrate before any startup migration can rewrite config

## Root cause

The steady-state endpoint assembled extractor keys union the static guard manifest, while the boot tripwire persisted only the narrow extractor. On the measured machine that was 36 watched keys versus 90 inventory rows, excluding 54 guards and 11 of 13 load-bearing guards. The tripwire also emitted counts without disclosing its watched denominator.

## Design

A single shared builder now applies the endpoint's existing precedence: extractor value, then manifest config path, then declared default. Both the endpoint and tripwire consume that result. Coverage records config-derived, manifest-declared, overlap, and watched counts.

For an old snapshot missing a newly watched key, the first upgraded boot compares current state with the resolved default. This makes a default-on guard found off visible once. It is labeled as an enrollment deviation, never falsely described as a change since the previous boot. The complete snapshot is written before signal emission, preserving no-repeat behavior.

The boot substrate is captured immediately after runtime config loading and before PostUpdateMigrator. Later disk rewrites therefore remain visible as pending-restart divergence instead of contaminating the historical boot record.

## Validation

- 95 focused unit, integration, and E2E assertions passed
- exact persisted-tripwire-key-set equals GET /guards inventory test passed
- the two reported dev-gated multi-machine guards resolve default ON/current OFF and enter one denominator-aware enrollment alert
- boot capture ordering and enrollment wording regression tests passed
- TypeScript typecheck passed
- full repository lint passed
- production build passed
- contributor preflight passed
- independent guard-focused review raised two concerns; both were fixed and the reviewer concurred on revision two

## ELI16

The safety dashboard already knew about 90 guards, but the boot alarm was only checking 36 because the two paths built their lists differently. They now use the same list-making function. When an upgraded agent discovers a guard that was missing from the old alarm list, it checks that guard against what should normally be on instead of silently accepting whatever it finds. Every report also says how many guards were checked.

## UX Impact

Who sees it: Operators whose agent restarts after upgrading.

What the user sees: A newly watched default-on guard found off is reported once as a posture incident, with the exact denominator-aware phrase `watched guard posture incident(s)`. Real boot-to-boot transitions remain separately labeled.

First contact: The first upgraded boot is the only new contact point and clearly names the watched population; unchanged posture remains quiet and no new action, route, or blocking authority is introduced.

