### PR TITLE
docs(spec): record the existing operator approval in the fields the gate reads

### DIFF
--- a/docs/specs/audit-convergence-enforcement.md
+++ b/docs/specs/audit-convergence-enforcement.md
@@ -16,6 +16,8 @@ frontloaded-decisions: 16
 cheap-to-change-tags: 2
 contested-then-cleared: 2
 approved: true  # operator authenticated preapproval, topic 11960, 2026-07-11 ("you have my preapproval for any decisions needed")
+approved-by: "Justin (operator preapproval, topic 11960)"
+approved-date: "2026-07-11"
 ---
 
 # Audit-Convergence Enforcement


### PR DESCRIPTION
## ELI16 — the approval was already there; the checker was looking in the wrong place

A spec in this repo has to be approved before the project record can move it forward. This one WAS
approved — back on 2026-07-11, by the operator, over Telegram. Whoever recorded it wrote it as a
note next to the word `approved`, like scribbling "OK'd by Justin, July 11" in the margin.

The automatic checker doesn't read margins. It reads two specific labelled boxes, `approved-by` and
`approved-date`, and those boxes were empty. So the checker said "this has never been approved" and
refused to let the item advance — while the approval sat one line away in plain English.

This change copies what the margin note already says into the two boxes. Nothing new is being
approved and nobody's authority is being invented: both values are lifted from the note that was
already in the file.

Worth knowing: this rescues one spec, not the pile. Of 504 approved specs on main, 204 are missing
that field, and only 9 have a recoverable note like this one. The rest genuinely need a decision.

## The approval already existed; the gate could not read it

`docs/specs/audit-convergence-enforcement.md` carries its operator approval as a YAML **comment** on the `approved:` line:

```yaml
approved: true  # operator authenticated preapproval, topic 11960, 2026-07-11 ("you have my preapproval for any decisions needed")
```

`StageTransitionValidator` reads `approved-by` and `approved-date` as front-matter **fields**. An approval recorded in a comment is invisible to it, so the corresponding project item stops at `409 APPROVED_BY_MISSING` and cannot leave `spec-converged` — even though the work it describes merged as #1818.

**This PR transcribes the approval that already exists into the fields the validator reads.** Both values come from the comment already in the file; no new approval is asserted:

- `approved-by: "Justin (operator preapproval, topic 11960)"`
- `approved-date: "2026-07-11"`

### Scope, measured before generalising

This is **not** a widespread rescue. Measured on `main` at the time of writing: **504 specs marked `approved: true`, 204 missing `approved-by`, and only 9 of those carry a recoverable approval note in a comment** — about 4%. The other ~195 have no such record and are a separate question.

### The underlying defect, for the record

The gate validates `approved-by` as *a non-empty string* — no registry match, no signature, no identity check of any kind. So it cannot distinguish an operator's approval from anyone else's, and it simultaneously fails to see an operator approval that is genuinely present three characters away. Whether that gate should become a real approval control, or be named honestly for what it is, is worth deciding on its own merits.

Authorised by standing mandate, topic 29723.
