### PR TITLE
fix(yaml): strip inline comments from frontmatter scalars

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-01T18-11-14-042Z-safeyaml-inline-comments.json
+++ b/.instar/instar-dev-decisions/2026-08-01T18-11-14-042Z-safeyaml-inline-comments.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-01T18:11:14.042Z",
+  "slug": "safeyaml-inline-comments",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 39,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SafeYaml.ts"
+    ],
+    "addedLines": 37,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-01T18-11-48-841Z-safeyaml-inline-comments.json
+++ b/.instar/instar-dev-decisions/2026-08-01T18-11-48-841Z-safeyaml-inline-comments.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-01T18:11:48.841Z",
+  "slug": "safeyaml-inline-comments",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 39,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SafeYaml.ts"
+    ],
+    "addedLines": 37,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/safeyaml-inline-comments.eli16.md
+++ b/docs/specs/safeyaml-inline-comments.eli16.md
@@ -1,0 +1,97 @@
+# YAML Inline Comments — Plain-English Overview
+
+## The problem in one breath
+
+Instar specs carry a little block of settings at the top of the file, and one of those
+settings is `approved: true`. Several gates read that setting to decide whether a spec has
+been signed off. If you write a note on that same line explaining *who* approved it and
+*when* — the most natural thing in the world to do — the gate stops seeing the spec as
+approved at all. **The comment that records the approval is what voids it.**
+
+## What already exists
+
+Instar reads those settings blocks with a small, deliberately narrow YAML parser
+(`src/core/SafeYaml.ts`). It was written to avoid pulling in a large third-party YAML
+library for what is a handful of simple key/value lines, and that trade-off is still the
+right one. It handles booleans, numbers, strings, and simple lists.
+
+What it did not handle was a comment at the end of a line. Real YAML lets you write:
+
+```yaml
+approved: true  # operator preapproval, topic 11960, 2026-07-11
+```
+
+and the value is the boolean `true`, with everything after the `#` discarded as a note for
+humans. Instar's parser kept the whole rest of the line, so the value became the *string*
+`"true  # operator preapproval, topic 11960, 2026-07-11"`.
+
+That string is not `true`. Every gate that checks `approved === true` — correctly, and
+exactly as designed — concluded the spec was not approved. The file visibly says
+`approved: true` on screen, so the failure reads as a mystery: the gate insists the flag is
+missing while you are looking straight at it.
+
+## What this adds
+
+One helper function, `stripInlineComment`, and two call sites that use it.
+
+Before a value is interpreted, a trailing comment is removed. That is the whole change —
+about 39 lines including its explanatory comment.
+
+## The new pieces
+
+**`stripInlineComment(raw)`** walks the value one character at a time and cuts at the first
+`#` that begins a comment. It is applied in two places, because the same defect exists in
+both: ordinary values (`key: value  # note`) and list items (`- item  # note`).
+
+The interesting part is what it deliberately does *not* cut, because YAML's rule is
+narrower than "remove everything after a `#`":
+
+- A `#` that is **not preceded by a space** is part of the value, not a comment. So
+  `url: http://host/page#section` keeps its fragment intact.
+- A `#` **inside quotes** is content. So `title: "sharp # sign"` is left alone.
+
+Both of those would be silent data corruption if we got them wrong — quietly truncating
+someone's URL or title — which is why the conservative half of the behaviour is tested just
+as heavily as the fix itself.
+
+## The safeguards
+
+**Prevents the fix from eating real data.** Five of the thirteen new tests exist purely to
+assert that things which are *not* comments survive untouched: URL fragments, `#` inside
+double quotes, `#` inside single quotes, a `#` with no space before it, and values with no
+comment at all. These five pass both before and after the change — they are regression
+guards, not proof of the fix.
+
+**Prevents the fix from being fake.** The other eight tests fail against the old parser and
+pass against the new one. That was verified by reverting the source, re-running the suite,
+and confirming 8 failures — a test that passes without the fix would prove nothing.
+
+**Prevents the same defect from surviving in its sibling.** The identical bug existed for
+list items. Fixing only the value case would have left the class half-open, so both call
+sites are fixed and both are tested.
+
+## What ships when
+
+This ships immediately and on by default. There is no flag and no dark period, for one
+reason: today's behaviour is unambiguously a bug, and no correct spec can be relying on an
+approval flag being silently ignored. Anything currently mis-parsing starts parsing
+correctly.
+
+The visible effect is that a small number of specs — nine on `main` at the time of writing,
+out of 522 carrying an `approved:` line — stop being invisibly unapproved. Those nine are
+not random: they are the specs whose approvals were documented most carefully, which is
+what made this worth fixing rather than working around.
+
+## What you actually need to decide
+
+Nothing, unless you disagree with the conservative rule.
+
+The one judgement call is what counts as a comment. This change follows the YAML
+specification: a `#` starts a comment when it is at the start of the value or preceded by
+whitespace, and never inside quotes. The alternative — stripping every `#` — would be
+simpler and would corrupt URLs, so it was rejected.
+
+If you would rather see the nine affected specs edited by hand instead of the parser fixed,
+that is a legitimate call and this change can be reverted with no cleanup. It is not the
+recommendation, because hand-editing fixes nine files while the parser fix closes the class
+for every spec written from now on.

--- a/src/core/SafeYaml.ts
+++ b/src/core/SafeYaml.ts
@@ -120,7 +120,7 @@ export function parseSafeYaml(input: string): FrontmatterResult | FrontmatterErr
       if (seqLines.length > 0 && seqLines.length === childLines.filter((l) => l.trim()).length) {
         const arr: string[] = [];
         for (const sl of seqLines) {
-          const item = sl.replace(/^\s*-\s+/, '').trim();
+          const item = stripInlineComment(sl.replace(/^\s*-\s+/, '').trim()).trim();
           const v = parseScalar(item);
           if (typeof v !== 'string' && typeof v !== 'number' && typeof v !== 'boolean') {
             return { ok: false, error: `unsupported sequence item at "${key}"` };
@@ -152,10 +152,45 @@ export function parseSafeYaml(input: string): FrontmatterResult | FrontmatterErr
   return { ok: true, data };
 }
 
+/**
+ * Strip a YAML inline comment from a scalar value.
+ *
+ * YAML starts a comment at a `#` that is at the start of the value or preceded
+ * by whitespace, and never inside a quoted scalar. Before this existed, the
+ * parser kept the whole rest of the line, so
+ *
+ *   approved: true  # operator preapproval, topic 11960
+ *
+ * parsed as the STRING `"true  # operator preapproval, topic 11960"`, and every
+ * gate testing `data.approved === true` silently concluded the spec was NOT
+ * approved. The comment that RECORDED the approval was what voided it.
+ *
+ * Deliberately conservative — a `#` not preceded by whitespace is part of the
+ * value (`url: http://host/p#frag`), and a `#` inside quotes is content.
+ */
+function stripInlineComment(raw: string): string {
+  let inStr: string | null = null;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inStr) {
+      if (ch === inStr) inStr = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      inStr = ch;
+      continue;
+    }
+    if (ch === '#' && (i === 0 || /\s/.test(raw[i - 1]))) {
+      return raw.slice(0, i).replace(/\s+$/, '');
+    }
+  }
+  return raw;
+}
+
 function parseInlineValue(
   raw: string
 ): { ok: true; value: unknown } | { ok: false; error: string } {
-  const trimmed = raw.trim();
+  const trimmed = stripInlineComment(raw.trim()).trim();
   if (trimmed.startsWith('!')) {
     return { ok: false, error: 'YAML tags are not permitted' };
   }

--- a/tests/unit/SafeYaml-inline-comments.test.ts
+++ b/tests/unit/SafeYaml-inline-comments.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { parseSafeYaml, extractFrontmatter } from '../../src/core/SafeYaml.js';
+
+function data(yaml: string): Record<string, unknown> {
+  const r = parseSafeYaml(yaml);
+  if (!r.ok) throw new Error(`parse failed: ${r.error}`);
+  return r.data;
+}
+
+describe('SafeYaml inline comments', () => {
+  // The defect this closes: a spec whose approval was DOCUMENTED on the
+  // `approved:` line parsed as a string, so every gate testing
+  // `data.approved === true` concluded the spec was not approved. The comment
+  // that recorded the approval was what voided it.
+  it('parses a boolean carrying an inline comment as a boolean', () => {
+    const d = data('approved: true  # operator preapproval, topic 11960, 2026-07-11');
+    expect(d.approved).toBe(true);
+    expect(typeof d.approved).toBe('boolean');
+  });
+
+  it('parses false with an inline comment as false, not a truthy string', () => {
+    const d = data('enabled: false # ships dark');
+    expect(d.enabled).toBe(false);
+  });
+
+  it('parses a number carrying an inline comment as a number', () => {
+    const d = data('rounds: 3  # converged');
+    expect(d.rounds).toBe(3);
+  });
+
+  it('strips the comment from an unquoted string value', () => {
+    const d = data('audit: llm-accountability  # tracks ACT-562');
+    expect(d.audit).toBe('llm-accountability');
+  });
+
+  // The conservative half. A `#` is only a comment when it starts the value or
+  // follows whitespace, and never inside quotes. These must NOT be stripped.
+  it('keeps a # that is part of the value (no preceding whitespace)', () => {
+    const d = data('url: http://host/path#fragment');
+    expect(d.url).toBe('http://host/path#fragment');
+  });
+
+  it('keeps a # inside a double-quoted scalar', () => {
+    const d = data('title: "sharp # sign"');
+    expect(d.title).toBe('sharp # sign');
+  });
+
+  it('keeps a # inside a single-quoted scalar', () => {
+    const d = data("title: 'sharp # sign'");
+    expect(d.title).toBe('sharp # sign');
+  });
+
+  it('strips a comment that follows a quoted scalar', () => {
+    const d = data('approved-by: "Justin (operator preapproval)"  # transcribed');
+    expect(d['approved-by']).toBe('Justin (operator preapproval)');
+  });
+
+  it('strips a comment after a flow sequence but keeps # inside its elements', () => {
+    const d = data('tags: [alpha, "b # c"]  # trailing note');
+    expect(d.tags).toEqual(['alpha', 'b # c']);
+  });
+
+  // Same class, second site: block-sequence items carry the identical defect.
+  it('strips inline comments from block-sequence items', () => {
+    const d = data(['tags:', '  - alpha  # first', '  - beta'].join('\n'));
+    expect(d.tags).toEqual(['alpha', 'beta']);
+  });
+
+  it('leaves values without comments byte-identical', () => {
+    const d = data(['approved: true', 'audit: plain-value', 'rounds: 3'].join('\n'));
+    expect(d).toEqual({ approved: true, audit: 'plain-value', rounds: 3 });
+  });
+
+  it('applies through extractFrontmatter, the path the gates actually use', () => {
+    const src = ['---', 'approved: true  # topic 11960', 'approved-date: "2026-07-11"', '---', '# Body'].join(
+      '\n'
+    );
+    const { frontmatter } = extractFrontmatter(src);
+    expect(frontmatter?.approved).toBe(true);
+    expect(frontmatter?.['approved-date']).toBe('2026-07-11');
+  });
+
+  it('still treats a whole-line comment as a comment, not a key', () => {
+    const d = data(['# a leading note', 'approved: true'].join('\n'));
+    expect(d).toEqual({ approved: true });
+  });
+});

--- a/upgrades/next/safeyaml-inline-comments.md
+++ b/upgrades/next/safeyaml-inline-comments.md
@@ -1,0 +1,32 @@
+# Upgrade Guide — vNEXT
+
+<!-- internal-only -->
+<!-- bump: patch -->
+
+## What Changed
+
+A spec whose approval was documented on the `approved:` line was silently unapproved. The frontmatter parser did not strip YAML inline comments, so
+
+```yaml
+approved: true  # operator authenticated preapproval, topic 11960, 2026-07-11
+```
+
+parsed as the **string** `"true  # operator authenticated preapproval, topic 11960, 2026-07-11"`. Every consumer testing `data.approved === true` — `StageTransitionValidator` above all — correctly concluded the flag was not `true` and refused the transition with `APPROVED_FLAG_MISSING`, on a file that visibly reads `approved: true`. The comment that recorded the approval was what voided it.
+
+This adds `stripInlineComment()` in `src/core/SafeYaml.ts`, applied at **both** sites that interpret a scalar: `parseInlineValue` (`key: value  # note`) and the block-sequence item path (`- item  # note`). The identical defect existed in both; fixing only the one that surfaced would have left the class half-open.
+
+The stripping is deliberately conservative, following the YAML rule rather than a looser one: a `#` begins a comment only at value-start or when preceded by whitespace, and never inside quotes. So `url: http://host/page#section` and `title: "sharp # sign"` are untouched. An earlier sketch cut at the first `#` unconditionally, which would have silently truncated URLs — that boundary is now the explicitly-tested half of the change.
+
+Ordering note: the strip runs *before* the tag / anchor / flow-sequence checks in `parseInlineValue`, so `tags: [a, b]  # note` no longer fails the `endsWith(']')` test and fall through to being read as a plain string. It cannot shadow the security rejections, because a value that *starts* with `!`, `&` or `*` is unaffected by comment-stripping.
+
+Measured on `main` (53c2140b): 559 specs carry frontmatter, 522 carry an `approved:` line, and **9 of those carry an inline comment on it** — 1.7%. Those nine are not a random sample; they are the specs whose approvals were documented most carefully, which is what makes the failure mode worth closing at the parser rather than by hand-editing nine files.
+
+## Evidence
+
+- **The bug, reproduced against the shipped parser before fixing:** loading `parseSafeYaml` from the installed dist and parsing `docs/specs/audit-convergence-enforcement.md` returned `approved` as `typeof string`, with `=== true` false, so the gate's verdict was `APPROVED_FLAG_MISSING`.
+- **The fix, proved end-to-end on that same real file:** `approved` now parses as `true` (`typeof boolean`), with `approved-by` and `approved-date` intact — it passes the approved-flag gate it previously failed.
+- **Test falsification, not assumption:** 13 new cases in `tests/unit/SafeYaml-inline-comments.test.ts`. Reverting `src/core/SafeYaml.ts` to its pre-change state and re-running gives **8 failed / 5 passed**. The 5 that pass either way are the conservative guards (URL fragment, `#` in double quotes, `#` in single quotes, `#` with no preceding space, no-comment values) — they prove existing behaviour is unchanged, and a test that passed without the fix would have proved nothing.
+- **Every downstream consumer re-run green:** `StageTransitionValidator` (53), `ProjectRoundRunner` (27), `PlanDocParser` (9), `ProjectAutoAdvancePoller` (10), `convergence-gate-consistency` (23), `projects-advance-mergebase-wiring` (5), `spec-review-publish` (11) — **138 passed, 0 failed**.
+- **`npx tsc --noEmit`** — clean.
+
+Known limitation, flagged rather than fixed: escaped quotes inside a quoted scalar (`desc: 'it''s # here'`) would mis-track quote state. `parseScalar` already does no escape processing — it slices the outer quotes verbatim — so this is a pre-existing property of the deliberately narrow schema, not a regression, and no spec in the tree uses that shape.

--- a/upgrades/next/safeyaml-inline-comments.md
+++ b/upgrades/next/safeyaml-inline-comments.md
@@ -1,6 +1,5 @@
 # Upgrade Guide — vNEXT
 
-<!-- internal-only -->
 <!-- bump: patch -->
 
 ## What Changed
@@ -20,6 +19,25 @@ The stripping is deliberately conservative, following the YAML rule rather than 
 Ordering note: the strip runs *before* the tag / anchor / flow-sequence checks in `parseInlineValue`, so `tags: [a, b]  # note` no longer fails the `endsWith(']')` test and fall through to being read as a plain string. It cannot shadow the security rejections, because a value that *starts* with `!`, `&` or `*` is unaffected by comment-stripping.
 
 Measured on `main` (53c2140b): 559 specs carry frontmatter, 522 carry an `approved:` line, and **9 of those carry an inline comment on it** — 1.7%. Those nine are not a random sample; they are the specs whose approvals were documented most carefully, which is what makes the failure mode worth closing at the parser rather than by hand-editing nine files.
+
+
+## What to Tell Your User
+
+Nothing changes in how you work with me, and there is nothing for you to do.
+
+If you have ever approved a design document by marking it approved and writing a short note on the same line saying who approved it and when, that note quietly cancelled the approval. The part of me that checks for approvals read the whole line as text instead of reading the yes-or-no answer, so it decided the document was never approved. The document said approved on screen and the checker disagreed, which made it look like nothing was wrong anywhere.
+
+Nine documents were sitting in that state. They were not a random nine out of the five hundred that carry an approval mark. They were the ones where somebody took the trouble to record who approved it and when, which is the careful thing to do and was exactly what broke them.
+
+That is now fixed, so those approvals count again and any future one written the same way will work. A note written next to a setting no longer swallows the setting.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| An approval marked with an explanatory note on the same line now counts as a real approval | Nothing to do — write the note however reads best, it no longer cancels the setting |
+| Notes written beside any setting in a document header are ignored rather than swallowing the value | Nothing to do — applies to every setting, not only approvals |
+
 
 ## Evidence
 

--- a/upgrades/side-effects/safeyaml-inline-comments.md
+++ b/upgrades/side-effects/safeyaml-inline-comments.md
@@ -1,0 +1,180 @@
+# Side-Effects Review — YAML inline comments in frontmatter values
+
+**Version / slug:** `safeyaml-inline-comments`
+**Date:** `2026-08-01`
+**Author:** `Echo (instar-dev agent)`
+**Second-pass reviewer:** `not required (Tier 1)`
+
+## Summary of the change
+
+`src/core/SafeYaml.ts` did not strip YAML inline comments, so `approved: true  # operator
+preapproval, topic 11960` parsed as the STRING `"true  # operator preapproval, topic 11960"`
+rather than the boolean `true`. Every consumer testing `data.approved === true` therefore
+concluded the spec was NOT approved — on a file that visibly reads `approved: true`. This
+adds one helper, `stripInlineComment`, applied at the two sites where a scalar is
+interpreted: `parseInlineValue` (`key: value  # note`) and the block-sequence item path
+(`- item  # note`). Files touched: `src/core/SafeYaml.ts` (+39 LOC incl. its explanatory
+comment) and a new `tests/unit/SafeYaml-inline-comments.test.ts` (13 cases).
+
+## Decision-point inventory
+
+The parser itself makes no policy decision — it produces the values that decision points
+read. It is upstream of three consumers, all pass-through here:
+
+- `StageTransitionValidator` (`data.approved !== true` → `APPROVED_FLAG_MISSING`) — pass-through — receives a boolean where it previously received a string; its own logic is unchanged.
+- `PlanDocParser` — pass-through — no approval surface; reads plan frontmatter.
+- `ProjectRoundRunner` — pass-through — reads convergence/round frontmatter.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+None — the change removes characters from a value, it never rejects a document. The
+equivalent risk is *over-stripping*: silently truncating a value that legitimately contains
+`#`. Two concrete shapes were identified and are explicitly preserved:
+
+- `url: http://host/page#section` — a `#` with no preceding whitespace is part of the value. Truncating here would corrupt a URL to `http://host/page` with no error.
+- `title: "sharp # sign"` and `title: 'sharp # sign'` — a `#` inside quotes is content.
+
+Both are covered by tests that pass before AND after the change (regression guards).
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **Escaped quotes inside quoted scalars.** `desc: 'it''s # not a comment'` — the scanner treats the doubled `''` as close-then-open and would mis-track quote state. The pre-existing `parseScalar` does no escape processing either (it slices the outer quotes verbatim), so this is a pre-existing limitation of the narrow schema, not a new one. No spec in the tree uses escaped quotes in frontmatter.
+- **A `#` preceded by a tab inside an otherwise unquoted value** is treated as a comment start (`/\s/` matches tab). That matches YAML.
+- **Multi-line block scalars (`|`, `>`)** are untouched: comments are not stripped from block-scalar bodies. That is correct — inside a block scalar, `#` is literal content.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. This is a **primitive** (a parser producing values), not a detector and not
+an authority. The alternative placements are both worse: fixing it in
+`StageTransitionValidator` would patch one consumer and leave `PlanDocParser` and
+`ProjectRoundRunner` mis-parsing the same files, and fixing it at each call site would be
+the "fixing one instance of a class is not fixing the class" anti-pattern. The fix belongs
+where the value is produced, which is why both scalar-producing sites in the parser are
+patched rather than only the one that surfaced the bug.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The parser holds no blocking authority. It returns `Record<string, unknown>` and every
+caller wraps it in its own schema validator. The change makes an existing authority
+(`StageTransitionValidator`) receive *correct input*; it does not add, move, or weaken any
+authority. Notably it does not make the gate more permissive in spirit — the gate's rule
+("frontmatter must carry `approved: true`") is unchanged, and a spec without an approval
+flag is still refused exactly as before.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. There are no competing live
+signals here: "where does a YAML comment begin?" is an **enumerable invariant** fixed by the
+YAML specification (a `#` at value-start or preceded by whitespace, outside quotes), not a
+judgement call that varies with context. It is named directly in the helper's doc comment.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** `stripInlineComment` runs FIRST in `parseInlineValue`, before the tag (`!`), anchor (`&`/`*`), flow-sequence (`[...]`) and flow-map (`{...}`) checks. This ordering is deliberate and was verified: a trailing comment after a flow sequence (`tags: [a, b]  # note`) would otherwise fail the `endsWith(']')` test and be mis-parsed as a plain string. It cannot shadow the security rejections — a value that *starts* with `!`, `&` or `*` is unaffected by comment-stripping, so tags and anchors are still rejected.
+- **Double-fire:** none. The helper is pure, has no side effects, and is called exactly once per scalar.
+- **Races:** none. Pure function, no shared or persistent state.
+- **Feedback loops:** none. Parsing does not feed back into any system that parses.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** no. Parsing is per-process and in-memory.
+- **Install base:** yes, but only in the corrective direction — nine specs on `main` (of 522 carrying an `approved:` line) currently mis-parse and will begin parsing correctly. No spec can be depending on its approval flag being silently ignored.
+- **External systems:** none.
+- **Persistent state:** none written. The parser reads files and returns values; it never writes.
+- **Timing / runtime conditions:** none.
+- **Operator surface (Mobile-Complete Operator Actions):** no operator-facing actions added or touched.
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable. No dashboard renderer, approval page, or grant/secret
+form is touched by this change.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**machine-local BY DESIGN**, and the reason is that there is no state to place: this is a
+pure function over a string, evaluated independently on whichever machine happens to read
+the file. The *inputs* (spec files) are already replicated by git, so every machine parses
+identical bytes and — after this change — reaches identical values. Before the change every
+machine also agreed, on the wrong answer; the change makes them agree on the right one.
+
+Explicitly: it emits **no** user-facing notices (no one-voice gating needed), holds **no**
+durable state (nothing to strand on topic transfer), and generates **no** URLs (nothing to
+survive a machine boundary).
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the commit, ship as the next patch. The change is one file plus one test file.
+- **Data migration:** none. No persistent state is written or migrated.
+- **Agent state repair:** none. No agent needs notifying or resetting.
+- **User visibility:** during a rollback window the nine affected specs would return to reading as unapproved — i.e. back to today's behaviour. No new regression is introduced by rolling back.
+
+Honest total: pure code change, revert-and-patch, no cleanup.
+
+## Conclusion
+
+The review changed the shape of the fix twice. First, the initial patch touched only
+`parseInlineValue`; the level-of-abstraction question surfaced that block-sequence items
+carry the identical defect, so the second call site was added and tested. Second, the
+over-block question forced the conservative rule to be stated precisely — an early sketch
+stripped from the first `#` unconditionally, which would have silently truncated
+`http://host/page#section`. That is now the explicitly-tested boundary.
+
+The one residual limitation is escaped quotes inside quoted scalars (§2), which is
+pre-existing in `parseScalar` and unreached by any spec in the tree. Flagged, not fixed —
+widening escape handling is a larger change to the narrow-schema trade-off and does not
+belong in a Tier-1 fix.
+
+Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** not required — Tier 1 (39 LOC, one file, no decision-point surface, no
+persistent state, revert-and-patch rollback).
+
+---
+
+## Evidence pointers
+
+- `tests/unit/SafeYaml-inline-comments.test.ts` — 13 cases; 8 fail against the pre-change parser, 5 (the conservative guards) pass both before and after. Falsification run: source reverted via `git stash`, suite re-run, 8 failed / 5 passed confirmed.
+- Downstream consumers re-run green: `StageTransitionValidator` (53), `ProjectRoundRunner` (27), `PlanDocParser` (9), `ProjectAutoAdvancePoller` (10), `convergence-gate-consistency` (23), `projects-advance-mergebase-wiring` (5), `spec-review-publish` (11) — 138 passed, 0 failed.
+- `npx tsc --noEmit` — clean.
+- End-to-end on the real blocked file: `docs/specs/audit-convergence-enforcement.md` now yields `approved: true` (boolean) with `approved-by` and `approved-date` intact, so it passes the approved-flag gate it previously failed.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable. The defect is in ordinary source
+(`src/core/SafeYaml.ts`), not in an LLM prompt, hook, config, skill, or standards text, and
+the change adds no self-triggered controller (no loop, monitor, sentinel, reaper, scheduler,
+or recovery path — the helper is a pure string function with no scheduling surface).


### PR DESCRIPTION
## ELI16 — a note written next to an approval was cancelling the approval

Instar specs carry a small settings block at the top, and one setting is `approved: true`. Several gates read it to decide whether a spec has been signed off.

If you write a note on that same line explaining *who* approved it and *when* — the natural thing to do — the gate stops seeing the spec as approved at all. The parser kept the whole rest of the line, so the value became the **string** `"true  # operator preapproval, topic 11960, 2026-07-11"` instead of the boolean `true`. Every consumer testing `data.approved === true` then correctly concluded the flag was not `true`, and refused with `APPROVED_FLAG_MISSING` — on a file that visibly reads `approved: true`.

**The comment that records the approval is what voids it.** Nine specs on `main` are in that state, out of 522 carrying an `approved:` line. They are not a random nine: they are the ones whose approvals were documented most carefully.

## What changed

One helper, `stripInlineComment()`, applied at **both** sites that interpret a scalar:

- `parseInlineValue` — `key: value  # note`
- the block-sequence item path — `- item  # note`

The identical defect existed in both. Fixing only the one that surfaced would have left the class half-open.

## The conservative half (the part worth reviewing)

Following the YAML rule rather than a looser one: a `#` begins a comment only at value-start or when preceded by whitespace, and **never** inside quotes. So these are deliberately untouched:

| input | stays |
|---|---|
| `url: http://host/page#section` | full URL — `#` has no preceding space |
| `title: "sharp # sign"` | `#` inside double quotes is content |
| `title: 'sharp # sign'` | `#` inside single quotes is content |
| `value#nospace` | part of the value |

An earlier sketch cut at the first `#` unconditionally, which would have silently truncated URLs. That boundary is now the explicitly-tested half of the change.

**Ordering:** the strip runs *before* the tag / anchor / flow-sequence checks, so `tags: [a, b]  # note` no longer fails the `endsWith(']')` test and fall through to being read as a plain string. It cannot shadow the security rejections — a value that *starts* with `!`, `&` or `*` is unaffected by comment-stripping.

## Evidence

- **Falsified, not assumed.** 13 new tests. Reverting `src/core/SafeYaml.ts` and re-running gives **8 failed / 5 passed**. The 5 that pass either way are the conservative guards above — a test that passed without the fix would prove nothing.
- **End-to-end on the real blocked file.** `docs/specs/audit-convergence-enforcement.md` now yields `approved: true` (boolean) with `approved-by` and `approved-date` intact — it passes the gate it previously failed.
- **Every downstream consumer re-run green:** StageTransitionValidator (53), ProjectRoundRunner (27), PlanDocParser (9), ProjectAutoAdvancePoller (10), convergence-gate-consistency (23), projects-advance-mergebase-wiring (5), spec-review-publish (11) — **138 passed, 0 failed**.
- `npx tsc --noEmit` — clean.

## Known limitation, flagged not fixed

Escaped quotes inside a quoted scalar (`desc: 'it''s # here'`) would mis-track quote state. `parseScalar` already does no escape processing — it slices the outer quotes verbatim — so this is a pre-existing property of the deliberately narrow schema, not a regression. No spec in the tree uses that shape.

Tier 1 (39 LOC, one file, no decision-point surface, no persistent state, rollback is revert-and-patch).
