### PR TITLE
Stop credential rebalancer attention duplication

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-01T19-36-30-790Z-credential-rebalancer-stable-attention.json
+++ b/.instar/instar-dev-decisions/2026-08-01T19-36-30-790Z-credential-rebalancer-stable-attention.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2026-08-01T19:36:30.790Z",
+  "slug": "credential-rebalancer-stable-attention",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 3,
+  "loc": 89,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/CredentialRebalancer.ts",
+      "src/core/CredentialRebalancerPolicy.ts"
+    ],
+    "addedLines": 74,
+    "deletedLines": 15
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -13226,7 +13226,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     // loop and actuates via the SAME gated swap executor. isEnabled mirrors the location gate
     // (dev-gate-resolved AND the §2.10 env-token gate), and the executor's own dryRun keeps it a
     // dry-run dogfood on a dev agent (full decision loop + audit, ZERO writes) until dryRun:false.
-    const { CredentialRebalancer } = await import('../core/CredentialRebalancer.js');
+    const { CredentialRebalancer, credentialRebalancerAttentionId } = await import('../core/CredentialRebalancer.js');
     const { mapSlots: credMapSlots, mapAccounts: credMapAccounts, resolveRebalancerConfig: credResolveBalancerConfig, computeBusynessBySlot: credComputeBusyness } =
       await import('../core/CredentialRebalancerSnapshot.js');
     const CRED_DEFAULT_SLOT = '~/.claude';
@@ -13269,10 +13269,10 @@ export async function startServer(options: StartOptions): Promise<void> {
           });
         } catch { /* @silent-fallback-ok: degradation report is best-effort observability; a throwing reporter must never break the dark/dry-run pass */ }
       },
-      emitAttention: (m) => {
+      emitAttention: (notice) => {
         void credentialAuditEmit.attention({
-          id: `credential-rebalancer-${credentialLocationLedger.version}`,
-          title: 'Credential rebalancer', summary: m, category: 'credential-repointing', priority: 'NORMAL',
+          id: credentialRebalancerAttentionId(notice, credentialLocationLedger.version),
+          title: 'Credential rebalancer', summary: notice.message, category: 'credential-repointing', priority: 'NORMAL',
         });
       },
     });

--- a/src/core/CredentialRebalancer.ts
+++ b/src/core/CredentialRebalancer.ts
@@ -30,6 +30,8 @@
  * wiring (the setInterval pass) + the live `GET /credentials/rebalancer` status are B3b.
  */
 
+import { createHash } from 'node:crypto';
+
 import {
   decidePass,
   type RebalancePassInput,
@@ -37,6 +39,7 @@ import {
   type AccountState,
   type SlotState,
   type SwapDecision,
+  type RebalancerAttentionNotice,
 } from './CredentialRebalancerPolicy.js';
 
 export interface RebalancerResolvedConfig {
@@ -72,7 +75,7 @@ export interface CredentialRebalancerDeps {
   /** Optional sinks. */
   emitAudit?: (record: PassAudit) => void;
   emitDegraded?: (message: string) => void;
-  emitAttention?: (message: string) => void;
+  emitAttention?: (notice: RebalancerAttentionNotice) => void;
   now?: () => number;
 }
 
@@ -95,6 +98,22 @@ export interface RebalancerStatus {
   /** Count of pairs/tenants currently under cooldown (for the status surface). */
   cooldownPairs: number;
   cooldownTenants: number;
+}
+
+/**
+ * Derive the legacy Attention row id from structural condition identity. The
+ * slot is hashed only to keep the externally persisted id bounded; it remains
+ * the semantic subject. Episode notices without a condition retain the prior
+ * ledger-version identity until the shared condition/episode API replaces this
+ * narrow bridge.
+ */
+export function credentialRebalancerAttentionId(
+  notice: RebalancerAttentionNotice,
+  ledgerVersion: number,
+): string {
+  if (!notice.condition) return `credential-rebalancer-${ledgerVersion}`;
+  const slotDigest = createHash('sha256').update(notice.condition.slot).digest('hex');
+  return `credential-rebalancer:${notice.condition.type}:${slotDigest}`;
 }
 
 function sortedPair(a: string, b: string): string {
@@ -163,7 +182,7 @@ export class CredentialRebalancer {
 
     const result = decidePass(input);
     for (const m of result.degraded) this.deps.emitDegraded?.(m);
-    for (const m of result.attention) this.deps.emitAttention?.(m);
+    for (const notice of result.attention) this.deps.emitAttention?.(notice);
 
     const dryRun = this.deps.isDryRun();
     const actuated: PassAudit['actuated'] = [];
@@ -198,7 +217,7 @@ export class CredentialRebalancer {
     const audit: PassAudit = {
       at, enabled: true, dryRun,
       decisions: result.decisions, actuated,
-      degraded: result.degraded, attention: result.attention,
+      degraded: result.degraded, attention: result.attention.map((notice) => notice.message),
       noActuationReason: result.noActuationReason,
       breakerOpen: this.breakerOpen,
     };

--- a/src/core/CredentialRebalancerPolicy.ts
+++ b/src/core/CredentialRebalancerPolicy.ts
@@ -125,13 +125,36 @@ export interface SwapDecision {
   reason: string;
 }
 
+export type RebalancerAttentionCondition =
+  | 'default-oracle-unavailable'
+  | 'default-no-healthy-rescue'
+  | 'wall-override-budget-exhausted'
+  | 'critical-no-rescue-target'
+  | 'no-rescue-target';
+
+/**
+ * An operator-facing notice from the pure policy. Persistent conditions carry
+ * their structural identity next to the decision that discovered them; the
+ * composition root must not recover identity from rendered text or invent it
+ * from a changing ledger version. One-off episode notices deliberately omit
+ * `condition` and retain the legacy per-episode identity until the shared
+ * Attention condition model lands.
+ */
+export interface RebalancerAttentionNotice {
+  message: string;
+  condition?: {
+    type: RebalancerAttentionCondition;
+    slot: string;
+  };
+}
+
 export interface PassResult {
   /** 0..maxForcedSwapsPerPass decisions (normal objectives emit ≤1; wall-override may emit more). */
   decisions: SwapDecision[];
   /** DegradationReporter-bound entries (terminal "stuck" states). */
   degraded: string[];
   /** Attention-queue-bound entries (operator-surfaced terminal states). */
-  attention: string[];
+  attention: RebalancerAttentionNotice[];
   /** Human reason when zero decisions were made (for the audited no-op pass). */
   noActuationReason?: string;
 }
@@ -163,7 +186,7 @@ function targetVerifiedRecent(slot: SlotState, now: number, auditCadenceMs: numb
 export function decidePass(input: RebalancePassInput): PassResult {
   const { now, slots, accounts, cooldowns, config, auditCadenceMs } = input;
   const degraded: string[] = [];
-  const attention: string[] = [];
+  const attention: RebalancerAttentionNotice[] = [];
 
   const accById = new Map(accounts.map((a) => [a.accountId, a]));
 
@@ -214,7 +237,9 @@ export function decidePass(input: RebalancePassInput): PassResult {
               reason: `default slot ${defaultSlot.slot} is ${defaultSlot.quarantined ? 'quarantined' : 'dead (' + (defTenant?.status ?? 'no-tenant') + ')'}; dealing healthy verified ${healthy.tenantAccountId} in to keep manual claude working`,
             }],
             degraded: [],
-            attention: [`default slot ${defaultSlot.slot} was ${defaultSlot.quarantined ? 'quarantined' : 'dead'} — rescued with ${healthy.tenantAccountId}; the displaced credential is parked and needs re-auth/re-probe`],
+            attention: [{
+              message: `default slot ${defaultSlot.slot} was ${defaultSlot.quarantined ? 'quarantined' : 'dead'} — rescued with ${healthy.tenantAccountId}; the displaced credential is parked and needs re-auth/re-probe`,
+            }],
           };
         }
         // Correlated-oracle-outage floor: NO slot is currently oracle-verifiable (an
@@ -226,7 +251,10 @@ export function decidePass(input: RebalancePassInput): PassResult {
           return {
             decisions: [],
             degraded: ['no slot is oracle-verifiable — default-slot eviction suspended (correlated-outage floor)'],
-            attention: [`oracle unavailable for every slot; ${defaultSlot.slot} preserved at its last-known-good${defaultSlot.lastKnownGoodAccountId ? ' (' + defaultSlot.lastKnownGoodAccountId + ')' : ''} — NOT certified live; no eviction until the oracle returns`],
+            attention: [{
+              message: `oracle unavailable for every slot; ${defaultSlot.slot} preserved at its last-known-good${defaultSlot.lastKnownGoodAccountId ? ' (' + defaultSlot.lastKnownGoodAccountId + ')' : ''} — NOT certified live; no eviction until the oracle returns`,
+              condition: { type: 'default-oracle-unavailable', slot: defaultSlot.slot },
+            }],
             noActuationReason: 'correlated oracle outage — default preserved at last-known-good, no eviction',
           };
         }
@@ -234,7 +262,10 @@ export function decidePass(input: RebalancePassInput): PassResult {
         return {
           decisions: [],
           degraded: [],
-          attention: [`default slot ${defaultSlot.slot} is dead/quarantined and no healthy verified tenant is available to rescue it`],
+          attention: [{
+            message: `default slot ${defaultSlot.slot} is dead/quarantined and no healthy verified tenant is available to rescue it`,
+            condition: { type: 'default-no-healthy-rescue', slot: defaultSlot.slot },
+          }],
           noActuationReason: 'default slot dead but no eligible healthy tenant to deal in',
         };
       }
@@ -269,7 +300,10 @@ export function decidePass(input: RebalancePassInput): PassResult {
     if (forcedThisPass >= config.maxForcedSwapsPerPass) break;
     if (overridesLeft <= 0) {
       degraded.push('wall-override budget exhausted — no durable rescue available');
-      attention.push(`wall-override budget exhausted for slot ${w.slot.slot} — a thrashing tenant the rescue can't durably help`);
+      attention.push({
+        message: `wall-override budget exhausted for slot ${w.slot.slot} — a thrashing tenant the rescue can't durably help`,
+        condition: { type: 'wall-override-budget-exhausted', slot: w.slot.slot },
+      });
       break;
     }
     // Fresh-data gate: act on a NEW critical reading only (the tenant's quota must be newer
@@ -279,7 +313,10 @@ export function decidePass(input: RebalancePassInput): PassResult {
 
     const target = rescueTargets.find((t) => !actedSlots.has(t.slot.slot) && t.slot.slot !== w.slot.slot && !actedTenants.has(t.acc.accountId));
     if (!target) {
-      attention.push(`no eligible non-walling rescue target for critical slot ${w.slot.slot}`);
+      attention.push({
+        message: `no eligible non-walling rescue target for critical slot ${w.slot.slot}`,
+        condition: { type: 'critical-no-rescue-target', slot: w.slot.slot },
+      });
       continue;
     }
     decisions.push({
@@ -327,7 +364,10 @@ export function decidePass(input: RebalancePassInput): PassResult {
   for (const w of walling.filter((x) => x.util < config.criticalPct)) {
     const target = rescueTargets.find((t) => t.slot.slot !== w.slot.slot);
     if (!target) {
-      attention.push(`no eligible non-walling rescue target for slot ${w.slot.slot}`);
+      attention.push({
+        message: `no eligible non-walling rescue target for slot ${w.slot.slot}`,
+        condition: { type: 'no-rescue-target', slot: w.slot.slot },
+      });
       break;
     }
     if (!cooldownOk(w.slot.slot, target.slot.slot, w.acc.accountId, target.acc.accountId)) continue;

--- a/tests/unit/credential-rebalancer-policy.test.ts
+++ b/tests/unit/credential-rebalancer-policy.test.ts
@@ -92,7 +92,7 @@ describe('decidePass — eligibility', () => {
       accounts: [acc({ accountId: 'A', fiveHrPct: 90 }), acc({ accountId: 'B', fiveHrPct: 5 })],
     }));
     expect(r.decisions).toEqual([]);
-    expect(r.attention.some((a) => /no eligible.*rescue target/.test(a))).toBe(true);
+    expect(r.attention.some((a) => /no eligible.*rescue target/.test(a.message))).toBe(true);
   });
 });
 
@@ -176,7 +176,11 @@ describe('decidePass — wall-override (critical mark)', () => {
     }));
     expect(r.decisions).toEqual([]);
     expect(r.degraded.some((d) => /budget exhausted/.test(d))).toBe(true);
-    expect(r.attention.some((a) => /budget exhausted/.test(a))).toBe(true);
+    expect(r.attention.some((a) => /budget exhausted/.test(a.message))).toBe(true);
+    expect(r.attention[0]?.condition).toEqual({
+      type: 'wall-override-budget-exhausted',
+      slot: 's1',
+    });
   });
 
   it('emits at most maxForcedSwapsPerPass forced swaps when multiple slots are critical', () => {
@@ -208,7 +212,11 @@ describe('decidePass — wall-override (critical mark)', () => {
       ],
     }));
     expect(r.decisions).toEqual([]);
-    expect(r.attention.some((a) => /no eligible non-walling rescue target/.test(a))).toBe(true);
+    expect(r.attention.some((a) => /no eligible non-walling rescue target/.test(a.message))).toBe(true);
+    expect(r.attention[0]?.condition).toEqual({
+      type: 'critical-no-rescue-target',
+      slot: 's1',
+    });
   });
 });
 
@@ -294,7 +302,7 @@ describe('decidePass — objective 0: dead/quarantined-default eviction', () => 
     expect(r.decisions[0].objective).toBe('default-eviction');
     expect(r.decisions[0].targetSlot).toBe('~/.claude');
     expect(r.decisions[0].sourceSlot).toBe('s2');
-    expect(r.attention.some((a) => /parked|needs re-auth/.test(a))).toBe(true);
+    expect(r.attention.some((a) => /parked|needs re-auth/.test(a.message))).toBe(true);
   });
 
   it('rescues a QUARANTINED default slot too (not just needs-reauth)', () => {
@@ -321,7 +329,7 @@ describe('decidePass — objective 0: dead/quarantined-default eviction', () => 
     }));
     expect(r.decisions).toEqual([]);
     expect(r.degraded.some((d) => /correlated-outage floor/.test(d))).toBe(true);
-    expect(r.attention.some((a) => /last-known-good|NOT certified live/.test(a))).toBe(true);
+    expect(r.attention.some((a) => /last-known-good|NOT certified live/.test(a.message))).toBe(true);
   });
 
   it('dead default but no healthy tenant available → surface, no action', () => {
@@ -334,7 +342,7 @@ describe('decidePass — objective 0: dead/quarantined-default eviction', () => 
       accounts: [acc({ accountId: 'D', status: 'disabled' }), acc({ accountId: 'B', status: 'needs-reauth' })],
     }));
     expect(r.decisions).toEqual([]);
-    expect(r.attention.some((a) => /no healthy verified tenant/.test(a))).toBe(true);
+    expect(r.attention.some((a) => /no healthy verified tenant/.test(a.message))).toBe(true);
   });
 
   it('does nothing special when the default slot is healthy (normal objectives run)', () => {

--- a/tests/unit/credential-rebalancer.test.ts
+++ b/tests/unit/credential-rebalancer.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { CredentialRebalancer, type CredentialRebalancerDeps, type RebalancerResolvedConfig } from '../../src/core/CredentialRebalancer.js';
+import { CredentialRebalancer, credentialRebalancerAttentionId, type CredentialRebalancerDeps, type RebalancerResolvedConfig } from '../../src/core/CredentialRebalancer.js';
 import type { SlotState, AccountState } from '../../src/core/CredentialRebalancerPolicy.js';
 
 const RESOLVED: RebalancerResolvedConfig = {
@@ -131,5 +131,55 @@ describe('CredentialRebalancer — status surface', () => {
     expect(st.enabled).toBe(true);
     expect(st.lastPass).not.toBeNull();
     expect(st.breaker.threshold).toBe(3);
+  });
+});
+
+describe('CredentialRebalancer — persistent attention identity', () => {
+  it('emits the same structural condition on repeated passes', async () => {
+    const clock = { t: 10_000_000 };
+    const notices: Parameters<NonNullable<CredentialRebalancerDeps['emitAttention']>>[0][] = [];
+    const r = new CredentialRebalancer(makeDeps({
+      clock,
+      listAccounts: () => [
+        acc({ accountId: 'A', fiveHrPct: 97, measuredAt: clock.t }),
+        acc({ accountId: 'B', fiveHrPct: 96, measuredAt: clock.t }),
+      ],
+      emitAttention: (notice) => notices.push(notice),
+    }));
+
+    await r.tick();
+    clock.t += 60_000;
+    await r.tick();
+
+    expect(notices).toHaveLength(4);
+    expect(credentialRebalancerAttentionId(notices[0], 10))
+      .toBe(credentialRebalancerAttentionId(notices[2], 11));
+    expect(credentialRebalancerAttentionId(notices[1], 10))
+      .toBe(credentialRebalancerAttentionId(notices[3], 11));
+  });
+
+  it('keeps one id for the same condition and slot across ledger versions', () => {
+    const notice = {
+      message: 'no eligible non-walling rescue target for critical slot ~/.claude-dawn',
+      condition: { type: 'critical-no-rescue-target' as const, slot: '~/.claude-dawn' },
+    };
+    expect(credentialRebalancerAttentionId(notice, 10))
+      .toBe(credentialRebalancerAttentionId(notice, 11));
+  });
+
+  it('keeps different slots and condition types distinct', () => {
+    const base = {
+      message: 'no eligible rescue target',
+      condition: { type: 'critical-no-rescue-target' as const, slot: '~/.claude-dawn' },
+    };
+    const otherSlot = { ...base, condition: { ...base.condition, slot: '~/.claude-dusk' } };
+    const nonCritical = {
+      ...base,
+      condition: { type: 'no-rescue-target' as const, slot: base.condition.slot },
+    };
+    expect(credentialRebalancerAttentionId(base, 10))
+      .not.toBe(credentialRebalancerAttentionId(otherSlot, 10));
+    expect(credentialRebalancerAttentionId(base, 10))
+      .not.toBe(credentialRebalancerAttentionId(nonCritical, 10));
   });
 });

--- a/upgrades/next/credential-rebalancer-stable-attention.md
+++ b/upgrades/next/credential-rebalancer-stable-attention.md
@@ -1,0 +1,35 @@
+# Credential rebalancer stops duplicating persistent Attention items
+
+<!-- bump: patch -->
+
+## What Changed
+
+Persistent credential-rebalancer conditions now carry structural identity from
+the policy that detects them. Their durable Attention item identity is derived
+from the condition type and affected slot, rather than from the credential
+ledger's changing version.
+
+Repeated passes observing the same condition therefore reuse the existing
+Attention item. Different slots and different condition types remain distinct.
+One-off rebalancer episode notices retain their previous behavior while the
+shared Attention condition model is developed separately.
+
+## What to Tell Your User
+
+The credential rebalancer will no longer keep adding duplicate queue items while
+the same slot remains without an eligible rescue target. The first item remains
+visible and actionable; later checks reuse it instead of filling the queue.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|------------|
+| Stable credential-rebalancer condition items | Automatic whenever the rebalancer observes a persistent slot condition |
+
+## Evidence
+
+- The policy tests prove persistent notices carry their condition type and slot.
+- The orchestrator tests prove repeated passes and changing ledger versions
+  derive the same item identity for the same condition.
+- Different slots and condition types derive different identities.
+- Credential route lifecycle tests, the repository lint suite, and the build pass.

--- a/upgrades/side-effects/credential-rebalancer-stable-attention.md
+++ b/upgrades/side-effects/credential-rebalancer-stable-attention.md
@@ -1,0 +1,192 @@
+# Side-Effects Review — Credential rebalancer stable Attention identity
+
+**Version / slug:** `credential-rebalancer-stable-attention`
+**Date:** `2026-08-01`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `Gauss (integration review)`
+
+## Summary of the change
+
+The credential-rebalancer policy now attaches a typed condition and affected
+slot to its persistent operator notices. The orchestrator preserves those
+structured notices, while one canonical helper derives the bounded durable
+Attention ID from condition type and a hash of the slot. The server wiring only
+forwards that derived ID and the rendered message. This stops a changing
+credential-ledger version from creating a new item on every pass. One-off rescue
+episode notices retain their previous ledger-version identity. The public status
+surface remains string-compatible.
+
+## Decision-point inventory
+
+- `CredentialRebalancerPolicy` notice classification — **modified** — persistent
+  states are marked as conditions; the successful default-slot rescue remains a
+  one-off episode notice.
+- Credential rebalancer Attention identity derivation — **modified** — the
+  mechanical idempotency key uses structural condition identity instead of a
+  changing ledger version.
+- Swap, cooldown, breaker, eligibility, and priority decisions — **pass-through**
+  — unchanged.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block is not applicable. The change only determines
+whether repeated observations address an existing Attention row.
+
+The identity retains both condition type and slot, so a critical no-target state
+does not suppress a noncritical no-target state, and two slots do not suppress
+one another.
+
+---
+
+## 2. Under-block
+
+This patch bounds repeated persistent notices from the credential rebalancer on
+one machine. It does not provide observe/clear/reopen metadata, update the
+existing row's latest text, or repair other Attention identity-minting adapters.
+Those class-wide requirements are recorded in feedback `fb-153fcd40-d85`.
+
+Because the current store deduplicates solely by ID, a structurally keyed item
+that an operator marks done will not automatically reopen if the condition later
+clears and recurs. That is the deliberate limit of this stop-bleeding patch: it
+prevents unbounded emission now, while explicit clear/recurrence lifecycle
+belongs to the tracked shared condition model. The operator can still reopen the
+existing item manually.
+
+The successful default-slot rescue notice intentionally retains its existing
+per-ledger-version episode behavior because it describes an actuation episode,
+not a persistent condition.
+
+The pool read currently coalesces normal-priority items using a broader source or
+category-and-title key. That existing behavior can still collapse distinct
+rebalancer conditions in a pool-wide view; it is part of the same tracked
+class-wide identity work and is not made worse by this local-store fix.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The policy owns the semantic fact that a notice describes a persistent condition,
+because it has the condition type and slot before rendering. The composition root
+no longer parses text or invents condition identity. The canonical helper is a
+narrow compatibility bridge to the current ID-keyed Attention store. Its input
+already has the tuple the future shared condition boundary will consume, so this
+patch does not entrench title/summary hashing or wiring-authored identity.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The policy's existing detection and actuation authority are unchanged. ID reuse is
+transport idempotency over an explicitly declared condition, one of the principle's
+mechanical exceptions; it makes no judgment about whether the condition is valid.
+
+---
+
+## 4b. Judgment-point check
+
+No static heuristic is added at a competing-signals decision point. Condition
+type and slot are direct outputs of an enumerable deterministic policy branch.
+The slot hash only bounds storage representation and does not influence policy.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The existing Attention store still owns exact-ID idempotence.
+  This patch supplies it a stable ID; it does not add a parallel dedupe layer.
+- **Double-fire:** After deployment, each persistent condition and slot may add
+  one new structurally keyed item alongside historical ledger-version items.
+  Subsequent passes reuse the new item. Historical rows are not mutated.
+- **Races:** Concurrent passes deriving the same ID converge on the existing
+  store's ID check. No new mutable state or read-modify-write sequence is added.
+- **Feedback loops:** Notice identity does not feed quota readings, eligibility,
+  cooldowns, or swap decisions.
+
+---
+
+## 6. External surfaces
+
+The visible change is a quieter operator queue: repeated passes no longer add a
+new item and Telegram message for the same rebalancer condition and slot. The
+first structurally keyed item remains visible. No new operator action, endpoint,
+URL, permission, or external dependency is introduced.
+
+Persistent state remains backward compatible. Existing rows keep their IDs;
+the first post-upgrade observation creates the new stable row, and later
+observations reuse it.
+
+---
+
+## 6b. Operator-surface quality
+
+No dashboard, form, renderer, or operator action surface is changed. Not
+applicable.
+
+---
+
+## 7. Multi-machine posture
+
+**Machine-local by design:** credential slots, local credential assignments, and
+their quota readings describe one host. Each host therefore owns its local
+condition row. The Attention pool read remains the existing proxied/merged view;
+this patch does not introduce replication or a new durable store.
+
+The feature emits user-facing notices. Existing pool-read coalescing and Telegram
+routing remain responsible for cross-machine presentation; this patch only bounds
+repetition within each owner machine. It holds no topic-transfer state and
+generates no URLs.
+
+---
+
+## 8. Rollback cost
+
+Rollback is a code-only patch release. Reverting restores ledger-version IDs.
+No data migration or agent-state repair is required. The structurally keyed rows
+already written remain ordinary readable Attention items; they do not prevent a
+rollback or require deletion.
+
+---
+
+## Conclusion
+
+The review kept the repair at the correct semantic boundary: the policy declares
+condition identity, the compatibility helper derives a bounded ID, and wiring
+cannot recover identity from rendered text. The change removes the measured
+per-pass fan-out without altering rebalancing decisions or queue-wide semantics.
+The residual class-wide and pool-view gaps are durably tracked. The independent
+second pass found no additional concern.
+
+---
+
+## Second-pass review
+
+**Reviewer:** Gauss
+**Independent read of the artifact:** concur
+
+The stable key preserves condition type and affected slot, avoids cross-slot or
+cross-type collapse, keeps legacy identity for one-off episodes, and preserves
+the public audit/status shape. The review also confirmed that the artifact
+accurately discloses pool-view coalescing and the missing clear/reopen lifecycle.
+
+---
+
+## Evidence pointers
+
+- Focused policy, orchestrator, and live credential-route suite: 40 passing.
+- Repository lint suite: passing.
+- TypeScript build and release-fragment invariants: passing.
+
+---
+
+## Class-Closure Declaration
+
+No agent-authored prompt, hook, config, skill, or standards artifact is fixed.
+The rebalancer's cadence, actuation edge, bounds, and settling brakes are unchanged;
+only the ID of its existing Attention emission is modified. Self-action
+convergence classification is therefore not changed by this patch.


### PR DESCRIPTION
## What changed

- Give persistent CredentialRebalancer attention conditions a stable structural identity based on condition type and affected credential slot.
- Preserve ledger-version identities for successful one-off rescue episodes.
- Keep the public audit/status surfaces string-compatible while carrying structured identity internally.
- Add regression coverage for repeated passes, cross-slot separation, cross-condition separation, and legacy episode behavior.

## Why

The server previously derived every rebalancer Attention ID from the credential-ledger version. A persistent unhealthy slot therefore minted a new queue item whenever the ledger advanced, even though the underlying condition had not changed. The live queue was still growing at roughly 27 items per day after manual cleanup.

## User and developer impact

Repeated observations of the same persistent rebalancer condition now update the same machine-local Attention item instead of forking. Different slots and different condition types remain distinct. Historical duplicate rows are not rewritten.

This is deliberately the narrow case-1 containment. The shared identity chokepoint and full observe/clear/reopen lifecycle remain follow-up work under feedback `fb-153fcd40-d85`.

## UX Impact

Who sees it: operators viewing the Attention queue. What the user sees changes only in repetition: recurring notices titled `Credential rebalancer` for the same condition and slot reuse one queue item instead of appearing as new copies. First contact, title, summary text, priority, and category are unchanged.

## ELI16 — One persistent slot problem now stays one queue item

One sick credential slot was creating a fresh alert every time the credential ledger changed, even though it was still the same problem. The alert now uses the problem type plus the affected slot as its identity, so repeated checks land on one item. Different slots and different problems still stay separate.

There is one known boundary: if an operator marks that stable item done, a later recurrence does not automatically reopen it yet. Manual reopen still works; automatic clear-and-reopen belongs to the broader lifecycle work already tracked.

## Checks

- 40/40 focused credential-rebalancer policy, orchestration, and live-route tests
- 70/70 affected pre-push smoke tests
- TypeScript build
- Repository lint and invariants
- Independent identity/idempotency review: concurred

## What to Tell Your User

The rebalancer will stop filling the queue with copies of the same persistent slot problem. Existing duplicates remain untouched, and a resolved item will not yet reopen automatically if the condition returns later.

## Summary of New Capabilities

| Capability | How to use |
|---|---|
| Persistent rebalancer notices reuse a stable queue identity | Automatic; no configuration needed |
| Separate slots and condition types remain independently visible | Automatic; identity includes both dimensions |
| One-off successful rescue episodes retain their historical behavior | Automatic; no public API change |
