### PR TITLE
Preserve Attention episodes across restarts

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-01T20-58-16-300Z-attention-episode-continuity.json
+++ b/.instar/instar-dev-decisions/2026-08-01T20-58-16-300Z-attention-episode-continuity.json
@@ -1,0 +1,40 @@
+{
+  "ts": "2026-08-01T20:58:16.300Z",
+  "slug": "attention-episode-continuity",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported durable lifecycle subsystem"
+  ],
+  "belowFloor": false,
+  "files": 4,
+  "loc": 259,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/AttentionConditionStore.ts",
+      "src/core/RopeRecoveryProber.ts",
+      "src/core/StaleOwnerReleaseEngine.ts"
+    ],
+    "addedLines": 254,
+    "deletedLines": 5
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The stale-owner and rope-recovery producers used process-local timestamps as episode identity. Restarting erased their active maps, so an unchanged condition was misclassified as a recurrence and emitted another Attention row without positive recovery evidence."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/AttentionConditionStore.test.ts",
+      "howCaught": "The restart-continuity ratchet proves the notification loop converges under an indefinitely active condition: reconstructing the durable store must retain the same episode ID and produce no second raise, while explicit clear followed by recurrence must mint exactly the next episode."
+    },
+    "prNumber": 1828,
+    "component": "AttentionConditionStore"
+  },
+  "verdict": "pass"
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -136,6 +136,7 @@ import { buildGuardInventory, buildHeartbeatPostureBlock } from '../monitoring/g
 import { readAcceptedFallbacks, scopeAcceptedFallbacks } from '../monitoring/guardAcceptedFallbacks.js';
 import { createGuardPostureProbes } from '../monitoring/probes/GuardPostureProbe.js';
 import { GuardPostureStore } from '../core/GuardPostureStore.js';
+import { AttentionConditionStore } from '../core/AttentionConditionStore.js';
 import { isPeerUrlAllowedForCredentials } from '../server/peerUrlGuard.js';
 import { formatWatchdogUserMessage } from '../monitoring/watchdog-notifications.js';
 import { StallTriageNurse } from '../monitoring/StallTriageNurse.js';
@@ -3655,6 +3656,10 @@ export async function startServer(options: StartOptions): Promise<void> {
   // must remain visible to GET /guards as diverged-pending-restart.
   const bootGuardConfigSnapshot = resolveGuardConfigSnapshot(config.projectDir);
   ensureStateDir(config.stateDir);
+  const attentionConditionStore = new AttentionConditionStore({
+    filePath: path.join(config.stateDir, 'state', 'attention-conditions.json'),
+    logger: (message) => console.warn(pc.yellow(message)),
+  });
 
   // Identity context is additive and survives agent moves. Validate its
   // persisted directory before any subsystem can derive hooks, locks, or
@@ -5699,6 +5704,8 @@ export async function startServer(options: StartOptions): Promise<void> {
                   }
                 },
                 logger: (m) => console.log(pc.dim(`  ${m}`)),
+                observeAttentionCondition: (identity) => attentionConditionStore.observe(identity),
+                clearAttentionCondition: (identity) => { attentionConditionStore.clear(identity); },
               },
               {
                 dryRun: probeDryRun,
@@ -20568,6 +20575,8 @@ export async function startServer(options: StartOptions): Promise<void> {
               raiseAttention: (item) => {
                 try { _meshAttentionRaise?.(item); } catch { /* attention raise is best-effort; the trace already recorded the escalation */ }
               },
+              observeAttentionCondition: (identity) => attentionConditionStore.observe(identity),
+              clearAttentionConditionsForSubject: (producer, subject) => { attentionConditionStore.clearSubject(producer, subject); },
               logger: (m) => console.log(pc.dim(`  ${m}`)),
             });
           }

--- a/src/core/AttentionConditionStore.ts
+++ b/src/core/AttentionConditionStore.ts
@@ -1,0 +1,177 @@
+/**
+ * Durable lifecycle identity for level-triggered Attention conditions.
+ *
+ * Producers describe semantic identity; this store owns episode numbering.
+ * Re-observing an active condition (including after a process restart) reuses
+ * the current item id. Only an explicit positive-evidence clear permits a later
+ * observation to mint a new episode id.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface AttentionConditionIdentity {
+  producer: string;
+  conditionType: string;
+  subject: string;
+  scope?: string;
+}
+
+export interface AttentionConditionObservation {
+  itemId: string;
+  episode: number;
+  shouldRaise: boolean;
+}
+
+interface AttentionConditionRecord {
+  key: string;
+  producer: string;
+  conditionType: string;
+  subject: string;
+  scope: string;
+  active: boolean;
+  episode: number;
+  itemId: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  clearedAt?: string;
+}
+
+interface AttentionConditionFile {
+  version: 1;
+  conditions: Record<string, AttentionConditionRecord>;
+}
+
+export interface AttentionConditionStoreDeps {
+  filePath: string;
+  now?: () => number;
+  logger?: (message: string) => void;
+}
+
+const MAX_RECORDS = 2_000;
+
+function segment(value: string): string {
+  return encodeURIComponent(value.trim() || 'unknown');
+}
+
+export function attentionConditionKey(identity: AttentionConditionIdentity): string {
+  return [
+    segment(identity.producer),
+    segment(identity.conditionType),
+    segment(identity.subject),
+    segment(identity.scope ?? 'global'),
+  ].join(':');
+}
+
+export class AttentionConditionStore {
+  private readonly d: AttentionConditionStoreDeps;
+  private readonly conditions = new Map<string, AttentionConditionRecord>();
+
+  constructor(deps: AttentionConditionStoreDeps) {
+    this.d = deps;
+    this.load();
+  }
+
+  observe(identity: AttentionConditionIdentity): AttentionConditionObservation {
+    const key = attentionConditionKey(identity);
+    const now = new Date((this.d.now ?? Date.now)()).toISOString();
+    const current = this.conditions.get(key);
+    if (current?.active) {
+      current.lastSeenAt = now;
+      this.persist();
+      return { itemId: current.itemId, episode: current.episode, shouldRaise: false };
+    }
+
+    const episode = (current?.episode ?? 0) + 1;
+    const itemId = `${key}:ep-${episode}`;
+    const next: AttentionConditionRecord = {
+      key,
+      producer: identity.producer,
+      conditionType: identity.conditionType,
+      subject: identity.subject,
+      scope: identity.scope ?? 'global',
+      active: true,
+      episode,
+      itemId,
+      firstSeenAt: current?.firstSeenAt ?? now,
+      lastSeenAt: now,
+    };
+    this.conditions.set(key, next);
+    this.prune();
+    this.persist();
+    return { itemId, episode, shouldRaise: true };
+  }
+
+  clear(identity: AttentionConditionIdentity): boolean {
+    const key = attentionConditionKey(identity);
+    const current = this.conditions.get(key);
+    if (!current?.active) return false;
+    current.active = false;
+    current.clearedAt = new Date((this.d.now ?? Date.now)()).toISOString();
+    this.persist();
+    return true;
+  }
+
+  clearSubject(producer: string, subject: string): number {
+    const now = new Date((this.d.now ?? Date.now)()).toISOString();
+    let cleared = 0;
+    for (const record of this.conditions.values()) {
+      if (record.producer !== producer || record.subject !== subject || !record.active) continue;
+      record.active = false;
+      record.clearedAt = now;
+      cleared++;
+    }
+    if (cleared > 0) this.persist();
+    return cleared;
+  }
+
+  private load(): void {
+    try {
+      const raw = JSON.parse(fs.readFileSync(this.d.filePath, 'utf8')) as Partial<AttentionConditionFile>;
+      if (raw.version !== 1 || !raw.conditions || typeof raw.conditions !== 'object') return;
+      for (const [key, value] of Object.entries(raw.conditions)) {
+        if (!value || typeof value !== 'object') continue;
+        const record = value as AttentionConditionRecord;
+        if (
+          record.key !== key || typeof record.producer !== 'string' ||
+          typeof record.conditionType !== 'string' || typeof record.subject !== 'string' ||
+          typeof record.scope !== 'string' || typeof record.active !== 'boolean' ||
+          !Number.isSafeInteger(record.episode) || record.episode < 1 ||
+          typeof record.itemId !== 'string' || typeof record.firstSeenAt !== 'string' ||
+          typeof record.lastSeenAt !== 'string'
+        ) continue;
+        this.conditions.set(key, record);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        this.d.logger?.(`[AttentionConditionStore] unreadable state ignored: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+
+  private prune(): void {
+    if (this.conditions.size <= MAX_RECORDS) return;
+    const inactive = [...this.conditions.values()]
+      .filter((record) => !record.active)
+      .sort((a, b) => Date.parse(a.lastSeenAt) - Date.parse(b.lastSeenAt));
+    for (const record of inactive) {
+      if (this.conditions.size <= MAX_RECORDS) break;
+      this.conditions.delete(record.key);
+    }
+  }
+
+  private persist(): void {
+    try {
+      fs.mkdirSync(path.dirname(this.d.filePath), { recursive: true });
+      const file: AttentionConditionFile = {
+        version: 1,
+        conditions: Object.fromEntries(this.conditions),
+      };
+      const tmp = `${this.d.filePath}.${process.pid}.tmp`;
+      fs.writeFileSync(tmp, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+      fs.renameSync(tmp, this.d.filePath);
+    } catch (err) {
+      this.d.logger?.(`[AttentionConditionStore] state write failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}

--- a/src/core/AttentionConditionStore.ts
+++ b/src/core/AttentionConditionStore.ts
@@ -46,6 +46,7 @@ export interface AttentionConditionStoreDeps {
   filePath: string;
   now?: () => number;
   logger?: (message: string) => void;
+  maxRecords?: number;
 }
 
 const MAX_RECORDS = 2_000;
@@ -82,6 +83,15 @@ export class AttentionConditionStore {
       return { itemId: current.itemId, episode: current.episode, shouldRaise: false };
     }
 
+    if (!current && !this.makeRoomForNewRecord()) {
+      // Capacity degradation stays restart-idempotent: exact-id Attention
+      // dedupe still prevents a flood, while the loud log makes lost recurrence
+      // counting visible. Never evict an ACTIVE condition to admit a new one.
+      const itemId = `${key}:capacity`;
+      this.d.logger?.(`[AttentionConditionStore] capacity reached; using stable degraded id ${itemId}`);
+      return { itemId, episode: 1, shouldRaise: true };
+    }
+
     const episode = (current?.episode ?? 0) + 1;
     const itemId = `${key}:ep-${episode}`;
     const next: AttentionConditionRecord = {
@@ -97,7 +107,6 @@ export class AttentionConditionStore {
       lastSeenAt: now,
     };
     this.conditions.set(key, next);
-    this.prune();
     this.persist();
     return { itemId, episode, shouldRaise: true };
   }
@@ -149,15 +158,17 @@ export class AttentionConditionStore {
     }
   }
 
-  private prune(): void {
-    if (this.conditions.size <= MAX_RECORDS) return;
+  private makeRoomForNewRecord(): boolean {
+    const limit = Math.max(1, Math.floor(this.d.maxRecords ?? MAX_RECORDS));
+    if (this.conditions.size < limit) return true;
     const inactive = [...this.conditions.values()]
       .filter((record) => !record.active)
       .sort((a, b) => Date.parse(a.lastSeenAt) - Date.parse(b.lastSeenAt));
     for (const record of inactive) {
-      if (this.conditions.size <= MAX_RECORDS) break;
+      if (this.conditions.size < limit) break;
       this.conditions.delete(record.key);
     }
+    return this.conditions.size < limit;
   }
 
   private persist(): void {

--- a/src/core/RopeRecoveryProber.ts
+++ b/src/core/RopeRecoveryProber.ts
@@ -33,6 +33,7 @@
 
 import type { PeerEndpointResolver, RopeHealthSnapshotRow } from './PeerEndpointResolver.js';
 import type { MeshEndpoint } from './types.js';
+import type { AttentionConditionIdentity, AttentionConditionObservation } from './AttentionConditionStore.js';
 
 /** Same base as the resolver's own probe backoff — the failure path widens from here. */
 export const PROBE_BACKOFF_BASE_MS = 5_000;
@@ -91,6 +92,10 @@ export interface RopeRecoveryProberDeps {
     | 'probe-sent' | 'probe-success' | 'probe-failure' | 'rope-recovered'
     | 'exhaustion-trip' | 'slow-alive-floor'
     | 'dry-run-would-probe' | 'dry-run-would-close') => void;
+  /** Durable condition lifecycle. When present, process restarts cannot mint a
+   *  new Attention episode while the same rope condition remains active. */
+  observeAttentionCondition?: (identity: AttentionConditionIdentity) => AttentionConditionObservation;
+  clearAttentionCondition?: (identity: AttentionConditionIdentity) => void;
   now?: () => number;
   logger?: (msg: string) => void;
 }
@@ -208,6 +213,8 @@ export class RopeRecoveryProber {
         st.lastClosedAt = nowMs;
         st.lastClosedProbeFailures = st.episode.probeFailures;
         this.log(`episode close ${row.peer}/${row.kind} (lastKnownGood reclaimed)`);
+        this.d.clearAttentionCondition?.(this.conditionIdentity('slow-alive', row.peer, row.kind));
+        this.d.clearAttentionCondition?.(this.conditionIdentity('exhausted', row.peer, row.kind));
         st.episode = null;
       }
 
@@ -294,8 +301,10 @@ export class RopeRecoveryProber {
         // bar — drop to floor cadence + the same escalate-once posture.
         ep.escalatedSlowAlive = true;
         this.d.recordMetric?.('slow-alive-floor');
+        const condition = this.observeCondition('slow-alive', peer, kind);
+        if (condition?.shouldRaise === false) return;
         this.escalate(
-          `rope-probe-slow-alive:${peer}:${kind}:${ep.openedAt}`,
+          condition?.itemId ?? `rope-probe-slow-alive:${peer}:${kind}:${ep.openedAt}`,
           `Mesh rope ${kind} answers probes but stays demoted`,
           `The ${kind} rope to ${this.peerName(peer)} has answered ${ep.unreclaimedSuccesses} consecutive recovery probes but has not reclaimed preferred status — latency above the reclaim bar. Probing continues at the floor cadence.`,
           'informational', peer, kind,
@@ -316,8 +325,10 @@ export class RopeRecoveryProber {
         this.d.recordMetric?.('exhaustion-trip');
         if (!ep.escalatedExhaust) {
           ep.escalatedExhaust = true; // escalate ONCE per (peer, kind, episode)
+          const condition = this.observeCondition('exhausted', peer, kind);
+          if (condition?.shouldRaise === false) return;
           this.escalate(
-            `rope-probe-exhausted:${peer}:${kind}:${ep.openedAt}`,
+            condition?.itemId ?? `rope-probe-exhausted:${peer}:${kind}:${ep.openedAt}`,
             `Mesh rope ${kind} not recovering`,
             `The ${kind} rope to ${this.peerName(peer)} has failed ${ep.probeFailures} recovery probes; probing continues at the floor rate (${Math.round(this.cfg.floorMs / 60000)} min).`,
             'actionable', peer, kind,
@@ -325,6 +336,14 @@ export class RopeRecoveryProber {
         }
       }
     }
+  }
+
+  private conditionIdentity(conditionType: 'slow-alive' | 'exhausted', peer: string, kind: MeshEndpoint['kind']): AttentionConditionIdentity {
+    return { producer: 'rope-recovery-probe', conditionType, subject: peer, scope: kind };
+  }
+
+  private observeCondition(conditionType: 'slow-alive' | 'exhausted', peer: string, kind: MeshEndpoint['kind']): AttentionConditionObservation | undefined {
+    return this.d.observeAttentionCondition?.(this.conditionIdentity(conditionType, peer, kind));
   }
 
   /** Nickname-first peer naming for escalation bodies (contract: rope KIND +

--- a/src/core/StaleOwnerReleaseEngine.ts
+++ b/src/core/StaleOwnerReleaseEngine.ts
@@ -49,6 +49,7 @@
 
 import type { SessionOwnershipRecord } from './SessionOwnership.js';
 import type { MergedClaimAnnotation } from './TopicClaimAnnotationStore.js';
+import type { AttentionConditionIdentity, AttentionConditionObservation } from './AttentionConditionStore.js';
 
 /** Config subtree: multiMachine.sessionPool.staleOwnerRelease (§5). */
 export interface StaleOwnerReleaseConfig {
@@ -219,6 +220,10 @@ export interface StaleOwnerReleaseDeps {
   trace: (entry: StaleOwnerTraceEntry) => void;
   /** Raise ONE deduped attention item (episode-keyed; P17-coalesced pool-wide). */
   raiseAttention: (item: StaleOwnerAttentionItem) => void;
+  /** Durable condition lifecycle. Wiring owns ids; this producer owns semantic
+   *  identity and positive-evidence clears. */
+  observeAttentionCondition?: (identity: AttentionConditionIdentity) => AttentionConditionObservation;
+  clearAttentionConditionsForSubject?: (producer: string, subject: string) => void;
   now?: () => number;
   monotonicNow?: () => number;
   logger?: (msg: string) => void;
@@ -370,6 +375,14 @@ export class StaleOwnerReleaseEngine {
       list.push(r);
       topicsByOwner.set(r.ownerMachineId, list);
     }
+    // Reconcile durable condition state even after a process restart erased the
+    // in-memory episode map. An owner with no live topic cannot still have a
+    // stranded-topic condition; this is positive structural clear evidence.
+    for (const machine of machines) {
+      if (machine.machineId !== self && !topicsByOwner.has(machine.machineId)) {
+        this.d.clearAttentionConditionsForSubject?.('stale-owner-release', machine.machineId);
+      }
+    }
 
     const holdsLease = this.d.holdsLease();
     const online = machines.filter((m) => m.online).length;
@@ -382,6 +395,10 @@ export class StaleOwnerReleaseEngine {
 
       // Healthy owner → close-episode bookkeeping and move on.
       if (ownerOnline) {
+        // A fresh authenticated online observation is positive evidence that
+        // any prior stale-owner Attention condition cleared. The engine keeps
+        // its longer calm window for claim-state bookkeeping independently.
+        this.d.clearAttentionConditionsForSubject?.('stale-owner-release', owner);
         const ep = this.episodes.get(owner);
         if (ep) {
           if (ep.healthySinceMono === null) ep.healthySinceMono = nowMono;
@@ -501,7 +518,10 @@ export class StaleOwnerReleaseEngine {
 
     // Prune episodes for owners that no longer own any live topic.
     for (const owner of [...this.episodes.keys()]) {
-      if (!topicsByOwner.has(owner)) this.episodes.delete(owner);
+      if (!topicsByOwner.has(owner)) {
+        this.episodes.delete(owner);
+        this.d.clearAttentionConditionsForSubject?.('stale-owner-release', owner);
+      }
     }
   }
 
@@ -754,11 +774,13 @@ export class StaleOwnerReleaseEngine {
       const ceiling = cfg.ambiguityCeilingMultiple * cfg.deathEvidenceMs;
       if (!ep.escalated && nowMono - ep.ambiguitySinceMono >= ceiling) {
         ep.escalated = true;
+        const condition = this.observeCondition('ambiguity', owner);
+        if (condition?.shouldRaise === false) return;
         this.counters.escalations++;
         this.trace({ type: 'ambiguity-escalated', owner, episodeId: ep.episodeId });
         try {
           this.d.raiseAttention({
-            id: `stale-owner:${ep.episodeId}`,
+            id: condition?.itemId ?? `stale-owner:${ep.episodeId}`,
             title: `Topic(s) look stranded on ${owner} — I can't prove the owner's state`,
             body:
               `Machine ${owner} has been offline past the evidence window but the death evidence stays ambiguous ` +
@@ -776,7 +798,9 @@ export class StaleOwnerReleaseEngine {
 
   private p19GiveUp(owner: string, ep: OwnerEpisode, topic: string | undefined, detail: string): void {
     // Loud give-up, ONE deduped attention item (the resurrection-cap mirror).
-    const key = `stale-owner-giveup:${ep.episodeId}${topic ? `:${topic}` : ''}`;
+    const condition = this.observeCondition('giveup', owner, topic ?? 'owner');
+    if (condition?.shouldRaise === false) return;
+    const key = condition?.itemId ?? `stale-owner-giveup:${ep.episodeId}${topic ? `:${topic}` : ''}`;
     if (this.evidenceClasses[key]) return; // once per episode(+topic)
     this.evidenceClasses[key] = 1;
     this.counters.p19GiveUps++;
@@ -790,6 +814,15 @@ export class StaleOwnerReleaseEngine {
         sourceContext: `stale-owner-release:${owner}`,
       });
     } catch { /* best-effort */ }
+  }
+
+  private observeCondition(conditionType: 'ambiguity' | 'giveup', owner: string, scope = 'owner'): AttentionConditionObservation | undefined {
+    return this.d.observeAttentionCondition?.({
+      producer: 'stale-owner-release',
+      conditionType,
+      subject: owner,
+      scope,
+    });
   }
 
   /** §2.9 status surface (assembled per tick, never stale on early return). */

--- a/tests/unit/AttentionConditionStore.test.ts
+++ b/tests/unit/AttentionConditionStore.test.ts
@@ -18,7 +18,7 @@ function harness() {
   dirs.push(dir);
   const filePath = path.join(dir, 'conditions.json');
   const clock = { now: Date.parse('2026-08-01T20:00:00Z') };
-  const create = () => new AttentionConditionStore({ filePath, now: () => clock.now });
+  const create = (maxRecords?: number) => new AttentionConditionStore({ filePath, now: () => clock.now, maxRecords });
   return { filePath, clock, create };
 }
 
@@ -63,5 +63,17 @@ describe('AttentionConditionStore', () => {
     expect(store.clearSubject(identity.producer, identity.subject)).toBe(2);
     expect(store.observe(identity).episode).toBe(2);
     expect(store.observe({ ...identity, subject: 'peer-b' })).toEqual({ ...sibling, shouldRaise: false });
+  });
+
+  it('never evicts an active condition when the durable record cap is full', () => {
+    const h = harness();
+    const store = h.create(1);
+    const first = store.observe(identity);
+    const overflowIdentity = { ...identity, subject: 'peer-b' };
+    const overflow = store.observe(overflowIdentity);
+
+    expect(overflow.itemId).toContain(':capacity');
+    expect(store.observe(identity)).toEqual({ ...first, shouldRaise: false });
+    expect(Object.keys(JSON.parse(fs.readFileSync(h.filePath, 'utf8')).conditions)).toHaveLength(1);
   });
 });

--- a/tests/unit/AttentionConditionStore.test.ts
+++ b/tests/unit/AttentionConditionStore.test.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AttentionConditionStore, type AttentionConditionIdentity } from '../../src/core/AttentionConditionStore.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'AttentionConditionStore.test cleanup' });
+  }
+});
+
+function harness() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'attention-condition-'));
+  dirs.push(dir);
+  const filePath = path.join(dir, 'conditions.json');
+  const clock = { now: Date.parse('2026-08-01T20:00:00Z') };
+  const create = () => new AttentionConditionStore({ filePath, now: () => clock.now });
+  return { filePath, clock, create };
+}
+
+const identity: AttentionConditionIdentity = {
+  producer: 'stale-owner-release',
+  conditionType: 'ambiguity',
+  subject: 'peer-a',
+  scope: 'owner',
+};
+
+describe('AttentionConditionStore', () => {
+  it('reuses one active episode across process reconstruction', () => {
+    const h = harness();
+    const first = h.create().observe(identity);
+    expect(first.shouldRaise).toBe(true);
+
+    h.clock.now += 60_000;
+    const afterRestart = h.create().observe(identity);
+    expect(afterRestart).toEqual({ itemId: first.itemId, episode: 1, shouldRaise: false });
+  });
+
+  it('mints a new episode only after an explicit clear', () => {
+    const h = harness();
+    const store = h.create();
+    const first = store.observe(identity);
+    expect(store.clear(identity)).toBe(true);
+
+    h.clock.now += 60_000;
+    const recurrence = h.create().observe(identity);
+    expect(recurrence.shouldRaise).toBe(true);
+    expect(recurrence.episode).toBe(2);
+    expect(recurrence.itemId).not.toBe(first.itemId);
+  });
+
+  it('clears every active condition for one producer and subject without touching siblings', () => {
+    const h = harness();
+    const store = h.create();
+    store.observe(identity);
+    store.observe({ ...identity, conditionType: 'giveup', scope: '700' });
+    const sibling = store.observe({ ...identity, subject: 'peer-b' });
+
+    expect(store.clearSubject(identity.producer, identity.subject)).toBe(2);
+    expect(store.observe(identity).episode).toBe(2);
+    expect(store.observe({ ...identity, subject: 'peer-b' })).toEqual({ ...sibling, shouldRaise: false });
+  });
+});

--- a/tests/unit/RopeRecoveryProber.test.ts
+++ b/tests/unit/RopeRecoveryProber.test.ts
@@ -33,7 +33,7 @@ interface Harness {
   run: (durationMs: number, stepMs?: number) => Promise<void>;
 }
 
-function boot(opts: { dryRun?: boolean; floorMs?: number; exhaustAttempts?: number; midIntervalMs?: number; maxUnreclaimedSuccesses?: number; reopenEpisodeWindowMs?: number; nicknameOf?: (m: string) => string | null } = {}): Harness {
+function boot(opts: { dryRun?: boolean; floorMs?: number; exhaustAttempts?: number; midIntervalMs?: number; maxUnreclaimedSuccesses?: number; reopenEpisodeWindowMs?: number; nicknameOf?: (m: string) => string | null; observeAttentionCondition?: import('../../src/core/RopeRecoveryProber.js').RopeRecoveryProberDeps['observeAttentionCondition']; clearAttentionCondition?: import('../../src/core/RopeRecoveryProber.js').RopeRecoveryProberDeps['clearAttentionCondition'] } = {}): Harness {
   const clock = { t: 1_000_000 };
   const resolver = new PeerEndpointResolver({
     config: {
@@ -73,6 +73,8 @@ function boot(opts: { dryRun?: boolean; floorMs?: number; exhaustAttempts?: numb
       nicknameOf: opts.nicknameOf,
       now: () => clock.t,
       logger: (m) => logs.push(m),
+      observeAttentionCondition: opts.observeAttentionCondition,
+      clearAttentionCondition: opts.clearAttentionCondition,
     },
     {
       dryRun: opts.dryRun ?? false,
@@ -242,6 +244,21 @@ describe('RopeRecoveryProber — probe-layer cadence (R-r3-2)', () => {
     inFlightResolve!({ typedSuccess: true, detail: 'ok', latencyMs: 5 });
     await new Promise((r) => setImmediate(r));
     expect(prober.isInFlight(PEER, KIND)).toBe(false);
+  });
+});
+
+describe('RopeRecoveryProber — durable Attention condition identity', () => {
+  it('does not raise a second slow-alive item when durable state says the condition is still active', async () => {
+    const h = boot({
+      dryRun: true,
+      midIntervalMs: 1,
+      maxUnreclaimedSuccesses: 1,
+      observeAttentionCondition: () => ({ itemId: 'rope:slow:peer-1:tailscale:ep-1', episode: 1, shouldRaise: false }),
+    });
+    killRope(h);
+    h.setProbeResult({ typedSuccess: true });
+    await h.tick();
+    expect(h.attention).toHaveLength(0);
   });
 });
 

--- a/tests/unit/StaleOwnerReleaseEngine.test.ts
+++ b/tests/unit/StaleOwnerReleaseEngine.test.ts
@@ -56,6 +56,8 @@ interface HarnessOpts {
   durableHeartbeatMs?: number | null;
   claimLands?: boolean;
   cfg?: Partial<StaleOwnerReleaseConfig>;
+  observeAttentionCondition?: StaleOwnerReleaseDeps['observeAttentionCondition'];
+  clearAttentionConditionsForSubject?: StaleOwnerReleaseDeps['clearAttentionConditionsForSubject'];
 }
 
 /**
@@ -143,6 +145,8 @@ function makeHarness(opts: HarnessOpts = {}) {
     },
     trace: (e) => traces.push(e),
     raiseAttention: (i) => attention.push(i),
+    observeAttentionCondition: opts.observeAttentionCondition,
+    clearAttentionConditionsForSubject: opts.clearAttentionConditionsForSubject,
     now: () => wall,
     monotonicNow: () => mono,
   };
@@ -441,6 +445,36 @@ describe('StaleOwnerReleaseEngine — honesty surfaces (§2.6)', () => {
     const items = h.attention.filter((a) => a.id.startsWith('stale-owner:'));
     expect(items).toHaveLength(1); // ONE deduped per-episode item
     expect(h.engine.status().counters.escalations).toBe(1);
+  });
+
+  it('does not raise a new item when durable state says the ambiguity condition survived a restart', async () => {
+    const h = makeHarness({
+      probeResult: 'error',
+      observeAttentionCondition: () => ({ itemId: 'stale-owner-release:ambiguity:m_owner:owner:ep-1', episode: 1, shouldRaise: false }),
+    });
+    h.engine.tick();
+    h.advance(DEFAULT_STALE_OWNER_RELEASE_CONFIG.deathEvidenceMs + 5_000);
+    await h.tickSettled(2);
+    for (let i = 0; i < 5; i++) {
+      h.advance(DEFAULT_STALE_OWNER_RELEASE_CONFIG.deathEvidenceMs);
+      await h.tickSettled(1);
+    }
+    expect(h.attention).toHaveLength(0);
+    expect(h.engine.status().counters.escalations).toBe(0);
+  });
+
+  it('clears durable stale-owner conditions on positive online evidence', () => {
+    const clears: Array<{ producer: string; subject: string }> = [];
+    const h = makeHarness({
+      machines: [
+        { machineId: SELF, online: true, observerLastSeenMs: 1_000_000 },
+        { machineId: THIRD, online: true, observerLastSeenMs: 1_000_000 },
+        { machineId: OWNER, online: true, observerLastSeenMs: 1_000_000 },
+      ],
+      clearAttentionConditionsForSubject: (producer, subject) => { clears.push({ producer, subject }); },
+    });
+    h.engine.tick();
+    expect(clears).toContainEqual({ producer: 'stale-owner-release', subject: OWNER });
   });
 
   it('probe-loop-bounded-p19: consecutive probe errors open the breaker + ONE give-up item', async () => {

--- a/upgrades/next/attention-condition-episode-continuity.md
+++ b/upgrades/next/attention-condition-episode-continuity.md
@@ -42,4 +42,4 @@ condition later returns, that recurrence is still surfaced as a new episode.
   and authenticated online evidence clears the condition.
 - Rope-prober tests prove a continuing durable slow-alive condition emits no
   second item.
-- The focused 53-test suite, repository lint suite, and TypeScript build pass.
+- The focused 54-test suite, repository lint suite, and TypeScript build pass.

--- a/upgrades/next/attention-condition-episode-continuity.md
+++ b/upgrades/next/attention-condition-episode-continuity.md
@@ -1,0 +1,45 @@
+# Attention conditions survive process restarts without becoming fake episodes
+
+<!-- bump: patch -->
+
+## What Changed
+
+Stale-owner and rope-recovery notices now use a small durable condition-lifecycle
+store. The producers declare structural identity and positive recovery evidence;
+the store owns episode numbering.
+
+Restarting the server while a condition is still active therefore reuses the
+current Attention episode instead of adding a new row. A later observation only
+gets a new episode after the producer has positively observed recovery: the
+owner is online or no longer owns a live topic, or the rope has reclaimed
+`lastKnownGood`.
+
+Safety and actuation state are unchanged. Stale-owner claim fencing and rope
+probe cadence remain process-local and keep their existing conservative reset
+behavior; only operator-notice lifecycle is made durable.
+
+## What to Tell Your User
+
+Restarting or updating an agent will no longer make an ongoing stranded-owner or
+slow-recovering-network condition look like a brand-new incident. One active
+condition stays one queue episode. If the system verifies recovery and the same
+condition later returns, that recurrence is still surfaced as a new episode.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|------------|
+| Restart-stable Attention episodes for stale owners and recovery probes | Automatic; no configuration or operator action required |
+| Honest recurrence after verified recovery | Automatic when the producer observes its positive clear condition |
+
+## Evidence
+
+- The durable-store tests reconstruct the store between observations and prove
+  that an active condition keeps one item ID across the simulated restart.
+- A clear followed by a new observation increments the episode and produces a
+  new item ID.
+- Stale-owner tests prove a continuing durable condition emits no second item,
+  and authenticated online evidence clears the condition.
+- Rope-prober tests prove a continuing durable slow-alive condition emits no
+  second item.
+- The focused 53-test suite, repository lint suite, and TypeScript build pass.

--- a/upgrades/side-effects/attention-condition-episode-continuity.md
+++ b/upgrades/side-effects/attention-condition-episode-continuity.md
@@ -1,0 +1,132 @@
+# Side-Effects Review — Durable Attention condition episodes
+
+**Version / slug:** `attention-condition-episode-continuity`
+**Date:** `2026-08-01`
+**Author:** `Instar Agent (instar-codey)`
+
+## Summary of the change
+
+Two operator-notice producers previously treated process memory as episode
+authority. `StaleOwnerReleaseEngine` keyed ambiguity notices by an in-memory
+episode timestamp, and `RopeRecoveryProber` did the same for slow-alive and
+exhausted ropes. A server restart erased those maps. If the underlying level was
+still unhealthy, the next process opened a fresh episode without observing a
+clear, creating duplicate Attention rows.
+
+`AttentionConditionStore` now persists structural identity, active/cleared
+state, and an episode counter. Producers own semantic identity and clear
+evidence; wiring only provides the shared store. Re-observation while active is
+suppressed. Clear followed by recurrence increments the episode.
+
+## Decision-point inventory
+
+- Stale-owner evidence and claim decisions — **pass-through** — unchanged.
+- Rope health, probe cadence, exhaustion, and recovery decisions —
+  **pass-through** — unchanged.
+- Attention episode identity — **modified** — derived from producer, condition
+  type, subject, and scope, with durable episode numbering.
+- Condition clear — **modified** — only positive producer evidence clears:
+  authenticated owner-online/no-live-topic for stale-owner, and
+  `lastKnownGood` reclaim for a rope.
+
+## 1. Over-block
+
+The new store never blocks claims, probes, recovery, or user actions. It can
+only suppress a second operator notice for a condition already recorded active.
+
+Identity retains the distinctions that matter:
+
+- stale-owner ambiguity and give-up are different condition types;
+- per-topic give-ups keep topic scope;
+- rope slow-alive and exhaustion are different condition types;
+- peer and rope kind remain separate subjects/scopes.
+
+## 2. Under-block
+
+The store is machine-local. Two machines observing the same pool condition can
+still create their own rows; pool-wide identity belongs to the broader Attention
+condition model and is not claimed here.
+
+Historical duplicate rows are not rewritten. The first post-upgrade observation
+creates one store-owned episode alongside legacy rows; later restarts reuse it.
+
+If the state file is unreadable or cannot be written, the producer continues and
+the failure is logged. This preserves the safety/liveness paths at the cost of
+falling back toward the former duplicate-notice behavior after another restart.
+
+## 3. Level-of-abstraction fit
+
+The producer supplies semantic identity and positive clear evidence. The shared
+store, not composition wiring or rendered text, owns episode numbering. This is
+the same structural boundary required for the eventual condition-oriented
+Attention chokepoint, without migrating unrelated emitters in this patch.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No block/allow or actuation authority is added.
+
+The store is idempotency and lifecycle bookkeeping for an existing signal. It
+cannot make an owner stale, declare a rope dead, claim a topic, or send a probe.
+
+## 4b. Judgment-point check
+
+No heuristic decides whether two rendered messages look similar. Identity is an
+enumerated tuple authored at the branch that knows the condition, and clears are
+existing positive runtime facts. No LLM or competing-signal judgment is added.
+
+## 5. Interactions
+
+- **Shadowing:** The Attention store still owns row creation and exact-ID
+  idempotence. `AttentionConditionStore` owns the earlier question of whether a
+  new semantic episode exists.
+- **Double-fire:** The lifecycle record is persisted before the existing raise
+  callback runs, so a synchronous restart cannot mint another episode.
+- **Races:** The server single-instance guard leaves one local writer. Atomic
+  rename prevents torn state reads after a crash.
+- **Feedback loops:** Condition state does not feed stale-owner evidence, claim
+  annotations, resolver health, or probe scheduling.
+
+## 6. External surfaces
+
+The user-visible effect is fewer duplicate queue rows after upgrades and server
+restarts. A genuine clear-and-recur remains visible under a new `ep-N` item ID.
+No endpoint, permission, secret, dependency, or configuration surface changes.
+
+## 6b. Operator-surface quality
+
+No dashboard or form changes. Existing Attention rows, statuses, and actions
+remain compatible.
+
+## 7. Multi-machine posture
+
+The lifecycle file is local because the two producer instances and their source
+evidence are local. The condition tuple includes machine/peer subjects where
+appropriate. Pool-wide coalescing is explicitly not claimed.
+
+The file is bounded to 2,000 records; inactive oldest records are pruned first.
+Active records are never pruned to satisfy the cap, because forgetting an active
+condition recreates the exact restart-duplication defect.
+
+## 8. Rollback cost
+
+Rollback is code-only. The new JSON file becomes inert and can remain on disk;
+older versions do not read it. Existing Attention rows remain ordinary rows.
+
+## Conclusion
+
+The fix changes the false boundary directly: a process restart is no longer an
+Attention episode transition. Recovery evidence, not process incarnation, is
+what permits recurrence.
+
+## Evidence pointers
+
+- Focused unit suite: 53 passing.
+- Repository lint suite: passing.
+- TypeScript build: passing.
+
+## Class-Closure Declaration
+
+No prompt, hook, skill, config, or standards artifact is fixed. The change is a
+runtime lifecycle correction in two existing deterministic producers.

--- a/upgrades/side-effects/attention-condition-episode-continuity.md
+++ b/upgrades/side-effects/attention-condition-episode-continuity.md
@@ -107,7 +107,10 @@ appropriate. Pool-wide coalescing is explicitly not claimed.
 
 The file is bounded to 2,000 records; inactive oldest records are pruned first.
 Active records are never pruned to satisfy the cap, because forgetting an active
-condition recreates the exact restart-duplication defect.
+condition recreates the exact restart-duplication defect. If all 2,000 records
+are active, a new condition uses a deterministic capacity-degraded ID without
+entering the file; exact-ID Attention dedupe still bounds restart repetition,
+and the loss of recurrence counting is logged.
 
 ## 8. Rollback cost
 
@@ -122,7 +125,7 @@ what permits recurrence.
 
 ## Evidence pointers
 
-- Focused unit suite: 53 passing.
+- Focused unit suite: 54 passing.
 - Repository lint suite: passing.
 - TypeScript build: passing.
 


### PR DESCRIPTION
## Description

A server restart currently erases the in-memory episode maps used by stale-owner release and rope recovery. If the underlying condition remains unhealthy, the next process mints a new timestamp-based Attention ID even though no recovery was observed. This PR adds a bounded durable condition store. Producers declare structural identity and positive clear evidence; the store owns episode numbering. Re-observation while active reuses the episode, and only a clear followed by recurrence mints the next one.

The stale-owner claim fence, evidence bar, rope health authority, and probe cadence are unchanged. This patch changes operator-notice lifecycle only.

## ELI16

Imagine a smoke alarm that forgets it was already ringing whenever its batteries are changed. After every battery change it writes “new fire” in your notebook, even though the same smoke never stopped. That is what server restarts were doing here: one ongoing stranded-owner or slow-network condition became several queue rows.

The new store remembers that the condition is still active across restarts. It starts a new incident only after the system has positively seen recovery and the problem later returns. This keeps one ongoing problem as one episode without hiding genuine recurrences.

## UX Impact

The operator who reads the Attention queue sees fewer duplicate rows after upgrades and server restarts. The first contact remains the existing notice, including the exact string “Topic(s) look stranded on” for stale-owner ambiguity or “Mesh rope” for rope recovery. A genuine recurrence after verified recovery still appears as a new episode.

The durable lifecycle state added by the composition path is named `attention-conditions.json`. It is internal and is not displayed to the operator; the visible change remains fewer duplicate Attention rows.

No settings, dashboard actions, permissions, or endpoints change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Root Cause and Evidence

The current open stale-owner rows correlate exactly with server boots: their episode timestamps begin seconds after boot and their Attention rows appear about 566–569 seconds later, matching the ambiguity ceiling. The rope history contains repeated lan/cloudflare episodes opened at the same millisecond during restart churn. Neither producer persists its episode map.

The new lifecycle store uses the tuple producer + condition type + subject + scope, never rendered text or process time. Active state is persisted atomically and bounded to 2,000 records, pruning inactive oldest records first.

## Validation

- Full `npm test` suite: passed.
- Focused lifecycle suite: 54 tests passed.
- `npm run lint`: passed.
- `npm run build`: passed.
- `git diff --check`: passed.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My code follows the project's style (TypeScript strict mode)
- [x] I have added tests for my changes (if applicable)
- [x] `npm test` passes locally
- [x] `npm run build` passes locally
- [x] I have updated documentation (if applicable)
