### PR TITLE
docs(spec): record the operator approval the area-audit-ratchet spec already had

### DIFF
--- a/docs/specs/standards-area-audit-ratchet.md
+++ b/docs/specs/standards-area-audit-ratchet.md
@@ -6,6 +6,8 @@ parent-principle: "Structure beats Willpower"
 eli16-overview: "standards-area-audit-ratchet.eli16.md"
 lessons-engaged: "Structure beats Willpower; Iterative Audit to Convergence; Verify the State, Not Its Symbol; Honest Denominators; Probe the Concept, Not the Name"
 approved: true
+approved-by: "echo (standing operator mandate, Justin, topic 29723)"
+approved-date: "2026-08-01"
 review-convergence: "2026-08-01T07:31:10.091Z"
 review-iterations: 6
 review-completed-at: "2026-08-01T07:31:10.091Z"


### PR DESCRIPTION
## ELI16 — a finished piece of work could not be recorded as finished, because nobody had written down who approved its plan

A spec for this project was written, argued over six times, reviewed by a second AI model, and marked approved. Then the work it described was built and merged into the codebase a day ago.

But the record still says that work hasn't started. The reason is one missing line: the spec says "approved: true" without saying **who** approved it or **when**. The checker that lets an item move forward wants all three, gets two, and refuses.

So this PR writes down the approval that already happened — naming me, and citing the standing permission Justin gave me for this project in writing. Two lines of text. Nothing about the code changes; the code has been running since yesterday. This only lets the record catch up with it.

## What

Adds `approved-by` / `approved-date` to `docs/specs/standards-area-audit-ratchet.md`. Two lines, docs only.

## Why

The spec already carries `approved: true` plus a 6-iteration cross-model convergence record. It does **not** carry `approved-by` / `approved-date`, so the project stage gate refuses `spec-converged -> approved` with `APPROVED_BY_MISSING`.

That blocks project `convergence-towards-coherence` items **5** and **6** from recording work that already merged in **#1819** (`48ab7c6a0`, 2026-08-01T08:11:49Z). The record says `outline`; the work is in main.

## Authority

Justin's standing mandate, topic 29723:

> standing mandate: echo may approve specs for the convergence project, topic 29723

This spec's own Operator-intent section opens *"Round 2, Tier 3 items 5 and 6 ask for a converging audit on a cadence per fundamental area..."* — it names the project's items, so the mandate applies directly rather than by extension.

## Note on shape

No inline comment on the `approved:` line. An inline comment there is swallowed into the value and voids the approval — the parser now strips them, but the shape is worth not reproducing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
