### PR TITLE
Audit standards area model to convergence

### DIFF
--- a/.github/workflows/standards-area-audit-cadence.yml
+++ b/.github/workflows/standards-area-audit-cadence.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Publish cadence summary
         if: always()
         run: |
-          node -e 'const fs=require("fs");const r=JSON.parse(fs.readFileSync(".instar/standards-coverage.json","utf8"));const due=r.cadence?.dueAreas??[];fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,`## Standards area audit cadence\n\n${due.length?`Review due for ${due.length} area(s) (nonblocking); see the marker-owned issue for escaped names.`:"No area review is due."}\n`);'
+          node -e 'const fs=require("fs");const r=JSON.parse(fs.readFileSync(".instar/standards-coverage.json","utf8"));const due=r.cadence?.dueAreas??[];const modelDue=r.cadence?.areaModelReviewDue===true;fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,`## Standards area audit cadence\n\n${due.length?`Content review due for ${due.length} area(s). `:""}${modelDue?"Area-list adequacy review is due. ":""}${!due.length&&!modelDue?"No area review is due.":"These are nonblocking resurfacing signals; see the marker-owned issue."}\n`);'
       - name: Maintain nonblocking review-due issue
         if: always()
         uses: actions/github-script@v7
@@ -40,6 +40,7 @@ jobs:
             const fs = require('fs');
             const report = JSON.parse(fs.readFileSync('.instar/standards-coverage.json', 'utf8'));
             const due = report.cadence?.dueAreas ?? [];
+            const modelDue = report.cadence?.areaModelReviewDue === true;
             const title = '[Standards] Fundamental-area audit review due';
             const marker = '<!-- standards-area-audit-cadence:v1 -->';
             const safeArea = area => String(area)
@@ -62,14 +63,25 @@ jobs:
               issue.title === title &&
               issue.body?.startsWith(`${marker}\n`)
             );
-            if (due.length > 0) {
+            if (due.length > 0 || modelDue) {
               const body = [
                 marker,
-                'The weekly nonblocking cadence found fundamental areas whose semantic review is due:',
+                'The weekly nonblocking cadence found a standards-area review that is due:',
                 '',
-                ...due.map(area => `- ${safeArea(area)}`),
+                ...(due.length > 0 ? [
+                  'Family content reviews:',
+                  ...due.map(area => `- ${safeArea(area)}`),
+                  '',
+                ] : []),
+                ...(modelDue ? [
+                  'Area-list adequacy review:',
+                  '- Audit whether the current family set is still the right decomposition of fundamental areas.',
+                  '- Run that semantic review to convergence and record explicit keep / add / split / merge / retire dispositions.',
+                  '- The deterministic checker validates the record and its evidence; it never chooses a disposition.',
+                  '',
+                ] : []),
                 '',
-                `This is a resurfacing signal, not a correctness veto. CI continues to block only stale content evidence and ratio-floor regressions.`,
+                `Elapsed review age is a resurfacing signal, not a correctness veto. CI blocks missing or invalid evidence, changed family bytes or family sets, and ratio-floor regressions.`,
                 `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               ].join('\n');
               if (existing) {

--- a/.instar/instar-dev-decisions/2026-08-02T02-29-32-021Z-standards-area-model-adequacy.json
+++ b/.instar/instar-dev-decisions/2026-08-02T02-29-32-021Z-standards-area-model-adequacy.json
@@ -1,0 +1,31 @@
+{
+  "ts": "2026-08-02T02:29:32.021Z",
+  "slug": "standards-area-model-adequacy",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 329,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/standards-coverage.mjs"
+    ],
+    "addedLines": 327,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "claim-vs-evidence",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/standards-coverage-ratchet.test.ts",
+      "howCaught": "Removing the area-model record fails the live check, and presenting family-content evidence to the model-record path is rejected, so content proof cannot masquerade as proof that the area model was reconsidered."
+    },
+    "component": "standards-coverage"
+  },
+  "verdict": "pass"
+}

--- a/docs/audits/standards-area-model-adequacy.md
+++ b/docs/audits/standards-area-model-adequacy.md
@@ -1,0 +1,58 @@
+---
+audit: "standards-area-model-adequacy"
+target-pattern: "Whether the current Standards Registry family set remains an adequate decomposition of the rule-bearing corpus, with an explicit keep / add / split / merge / retire disposition for every review."
+search-surface: "All six family sections and all 82 rule-bearing articles; family cohesion, boundary overlap, scale, orphan clusters, and plausible add / split / merge / retire alternatives."
+standing-guard: "tests/unit/standards-coverage-ratchet.test.ts"
+blind-spot-class: "list-integrity-without-adequacy-review"
+standard-response-kind: "no-change"
+standard-response-ref: "docs/STANDARDS-REGISTRY.md"
+standard-response-article-id: "iterative-audit-to-convergence"
+standard-response-article: "Iterative Audit to Convergence"
+standard-response-rationale: "The constitution already requires iterative convergence; the escaped blind spot was that family-byte integrity never required a fresh adequacy judgment about the family model itself."
+converged: "2026-08-02T02:17:22.219Z"
+rounds: "2"
+standard-response-digest: "5505039f748ca3861ec2d399966503a57b5080138e073a3d87b7f31683b37c47"
+meta-artifact-at: "2026-08-02T02:17:22.219Z"
+meta-artifact-digest: "c26b03969d973b4f92eb71b030685e45ae9ed755a37d8bbc304383e6e6ea7cad"
+---
+
+# Standards area-model adequacy audit
+
+This audit reviews the family list as a model, not merely the bytes inside each
+family. It asks whether every current family should be kept, split, merged, or
+retired and whether any missing family should be added. The deterministic guard
+validates the evidence shape and binds it to this converged report; it does not
+make these semantic choices.
+
+## Meta-insight
+
+How it arose: The first area ratchet made every known family exact and reviewable, but a list can remain byte-perfect while its decomposition grows obsolete. Treating the list as fixed would reproduce the stored-and-never-revisited failure at one level higher.
+Why prior controls missed it: They proved that known family names and contents had not changed without evidence. They did not require a reviewer to reconsider the names, boundaries, omissions, or continued usefulness of the family set itself.
+
+## Round 1
+
+Search angles: Read all 82 rule-bearing articles under the six parsed H2 family sections; compared each article's subject with its containing family; checked each family for internal cohesion, repeated boundary confusion, disproportionate scale, and orphan articles; then forced a keep / add / split / merge / retire decision rather than accepting the inherited list by default.
+Surface delta: Initial full-corpus sweep. The review surface expanded from six content hashes to the six family identities, all cross-family boundaries, and the possibility of an absent seventh family.
+
+| location | behavior | bucket | disposition |
+|----------|----------|--------|-------------|
+| docs/STANDARDS-REGISTRY.md:47 | The Root contains one generative principle from which the remaining standards derive. Its singleton size is intentional; merging it would erase the distinction between constitutional source and implementing framework. | keep | accepted:keep The Root as the distinct generative source; split, merge, and retire would all reduce explanatory precision |
+| docs/STANDARDS-REGISTRY.md:58 | The Fractal defines the self-hosting framework identity and recursive development stance. It is related to Building but answers what the framework is, not how an implementation is engineered. | keep | accepted:keep The Fractal because its identity-level boundary remains distinct from implementation discipline |
+| docs/STANDARDS-REGISTRY.md:78 | The Substrate groups model-level truths such as context, attention, memory, authority, uncertainty, and emergence. Its breadth is high, but these are mutually entangled constraints below feature construction rather than stable standalone domains. | keep | accepted:keep The Substrate; candidate splits would create ambiguous homes for cross-cutting model truths |
+| docs/STANDARDS-REGISTRY.md:287 | Building groups engineering mechanics, verification, observability, failure handling, and maintainability. The articles share the question of how a capability is made dependable before release. | keep | accepted:keep Building; splitting quality, operations, and implementation would fragment standards that deliberately span those mechanics |
+| docs/STANDARDS-REGISTRY.md:581 | Shipping covers the evidence-to-rollout lifecycle, live completeness, and truthful delivery. It remains separable from Building because a well-built capability can still be incompletely or dishonestly shipped. | keep | accepted:keep Shipping as the delivery boundary; merging it into Building would hide the implementation-to-live transition |
+| docs/STANDARDS-REGISTRY.md:631 | Interaction covers the agent's external surface: user communication, consent, delegation, publishing, and relationships. It is coherent around effects that cross the system boundary. | keep | accepted:keep Interaction; its outward authority and communication concerns remain distinct from internal mechanics |
+| docs/STANDARDS-REGISTRY.md:47 | Every rule-bearing article maps meaningfully to one of the six families. Candidate additions for security, governance, memory, or operations recur as cross-cutting concerns inside existing families rather than as orphan clusters with a cleaner independent boundary. | add | accepted:add no new family; the full-corpus sweep found no recurrent orphan cluster that would improve the decomposition |
+
+New findings this round: 7
+
+## Round 2
+
+Search angles: Re-read the corpus from boundary inversions rather than inherited headings: attempted Root+Fractal and Building+Shipping merges; attempted Substrate, Building, and Interaction splits; tested retirement of each singleton or narrow family; and tried adding security, governance, memory, operations, and agent-identity families. For every candidate, sampled articles on both sides of the proposed boundary and asked whether the move reduced ambiguous classification.
+Surface delta: The second sweep introduced no new family or boundary defect. Each plausible alternative mapped back to a Round-1 decision: merges erased a useful level or lifecycle boundary, splits increased cross-cutting ambiguity, retirements lost a distinct concept, and additions duplicated concerns already distributed by level and effect.
+
+New findings this round: 0
+
+## Convergence status (honest)
+
+CONVERGED after 2 rounds. Round 1 made seven explicit model dispositions: keep all six current families and add no new family. Round 2 attacked those decisions through the strongest split, merge, retire, and add alternatives and found no new defect or unresolved design question. The present outcome is therefore keep: The Root, The Fractal, The Substrate, Building, Shipping, and Interaction; add: none; split: none; merge: none; retire: none. This is a current semantic judgment, not an eternal taxonomy. The standing guard requires a fresh, convergence-stamped adequacy record and invalidates it when the parsed family set changes, while elapsed age remains a review signal so the judgment can be revisited without letting deterministic code choose the answer.

--- a/docs/audits/standards-area-model-audit-2026-08-01.json
+++ b/docs/audits/standards-area-model-audit-2026-08-01.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": 1,
+  "scope": "area-model-adequacy",
+  "reviewedAt": "2026-08-02T02:17:22.219Z",
+  "reviewers": [
+    "instar-codey"
+  ],
+  "findingDisposition": {
+    "noUnresolvedDesign": true,
+    "resolvedFindings": 7
+  },
+  "reviewedActions": [
+    "keep",
+    "add",
+    "split",
+    "merge",
+    "retire"
+  ],
+  "convergenceReport": "docs/audits/standards-area-model-adequacy.md",
+  "convergenceSha256": "b1b4d61ac2ff197cad8d8228209c129e16c86feff63a80790f79ecc370e6043d",
+  "currentAreas": {
+    "Building": {
+      "disposition": "keep",
+      "rationale": "Engineering, verification, observability, and maintainability remain coherent around making capabilities dependable before release."
+    },
+    "Interaction": {
+      "disposition": "keep",
+      "rationale": "User communication, consent, delegation, publishing, and relationships remain coherent around effects that cross the system boundary."
+    },
+    "Shipping": {
+      "disposition": "keep",
+      "rationale": "Evidence, rollout, live completeness, and truthful delivery remain a distinct lifecycle boundary after implementation."
+    },
+    "The Fractal": {
+      "disposition": "keep",
+      "rationale": "The self-hosting framework identity answers what the framework is and remains distinct from implementation discipline."
+    },
+    "The Root": {
+      "disposition": "keep",
+      "rationale": "The single generative principle remains distinct from both the framework identity and its implementing standards."
+    },
+    "The Substrate": {
+      "disposition": "keep",
+      "rationale": "Context, attention, memory, authority, uncertainty, and emergence remain entangled model-level constraints rather than clean standalone domains."
+    }
+  },
+  "additions": []
+}

--- a/docs/standards-registry-area-model-audit.json
+++ b/docs/standards-registry-area-model-audit.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "lastAuditedAt": "2026-08-02T02:17:22.219Z",
+  "auditRef": "docs/audits/standards-area-model-audit-2026-08-01.json",
+  "auditSha256": "d3674e70e303beae6e541519c55c46dff8043056204d5b13256950f64d4eaf46",
+  "areaSetSha256": "0f2117ae2e8539d22bd58f239a1302ff35ad4dc4daf8b2968a6b9cbded304b30"
+}

--- a/scripts/standards-coverage.mjs
+++ b/scripts/standards-coverage.mjs
@@ -34,6 +34,7 @@
  *   node scripts/standards-coverage.mjs --record-area-audit=all --audit-ref=docs/audits/review.json
  *   node scripts/standards-coverage.mjs --record-area-audit="The Root" --audit-ref=docs/audits/review.json
  *   node scripts/standards-coverage.mjs --record-area-audit=all --admit-new-areas --audit-ref=docs/audits/review.json
+ *   node scripts/standards-coverage.mjs --record-area-model-audit --audit-ref=docs/audits/model-review.json
  *   node scripts/standards-coverage.mjs --allow-partial-registry # explicit non-CI partial checkout
  *
  * Floors (env override):
@@ -53,6 +54,7 @@ import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 import { articleIds, parseRegistryStructure } from './standards-registry-article-core.mjs';
+import { parseFrontmatter, validateAuditReport } from './write-audit-convergence.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const args = new Set(process.argv.slice(2));
@@ -63,6 +65,7 @@ const RECORD_AREA_ARG = [...args].find((arg) => arg.startsWith('--record-area-au
 const RECORD_AREA = RECORD_AREA_ARG?.slice('--record-area-audit='.length) ?? null;
 const AUDIT_REF_ARG = [...args].find((arg) => arg.startsWith('--audit-ref='));
 const AUDIT_REF = AUDIT_REF_ARG?.slice('--audit-ref='.length) ?? null;
+const RECORD_AREA_MODEL = args.has('--record-area-model-audit');
 const ALLOW_PARTIAL_REGISTRY = args.has('--allow-partial-registry');
 const ADMIT_NEW_AREAS = args.has('--admit-new-areas');
 
@@ -75,6 +78,7 @@ function resolveRoot() {
 const ROOT = resolveRoot();
 const REGISTRY_PATH = path.join(ROOT, 'docs', 'STANDARDS-REGISTRY.md');
 const AREA_AUDITS_PATH = path.join(ROOT, 'docs', 'standards-registry-area-audits.json');
+const AREA_MODEL_AUDIT_PATH = path.join(ROOT, 'docs', 'standards-registry-area-model-audit.json');
 const CI_WORKFLOW_PATH = path.join(ROOT, '.github', 'workflows', 'ci.yml');
 const OUT_PATH = path.join(ROOT, '.instar', 'standards-coverage.json');
 
@@ -336,6 +340,11 @@ function classifyFileGuard(ref) {
 
 const AREA_AUDIT_SCHEMA_VERSION = 2;
 const AUDIT_EVIDENCE_SCHEMA_VERSION = 1;
+const AREA_MODEL_AUDIT_SCHEMA_VERSION = 1;
+const AREA_MODEL_EVIDENCE_SCHEMA_VERSION = 1;
+const AREA_MODEL_SCOPE = 'area-model-adequacy';
+const AREA_MODEL_ACTIONS = ['keep', 'add', 'split', 'merge', 'retire'];
+const CURRENT_AREA_DISPOSITIONS = new Set(['keep', 'split', 'merge', 'retire']);
 const AREA_AUDIT_KEYS = [
   'lastAuditedAt', 'auditRef', 'auditSha256', 'areaSha256', 'refResolutionFloor',
 ];
@@ -406,6 +415,10 @@ function canonicalText(value) {
 
 function textSha256(value) {
   return crypto.createHash('sha256').update(canonicalText(value)).digest('hex');
+}
+
+function areaSetSha256(areaNames) {
+  return textSha256(`standards-area-model-v1\n${[...areaNames].sort().join('\n')}\n`);
 }
 
 function validateRootSelfWiring() {
@@ -616,6 +629,222 @@ function readAuditEvidence(ref) {
     evidence,
     errors,
   };
+}
+
+function canonicalAreaModelEvidence(value) {
+  const currentAreas = nullObject();
+  const sourceAreas = isPlainObject(value?.currentAreas) ? value.currentAreas : nullObject();
+  for (const area of Object.keys(sourceAreas).sort()) {
+    currentAreas[area] = {
+      disposition: sourceAreas[area]?.disposition,
+      rationale: sourceAreas[area]?.rationale,
+    };
+  }
+  const additions = Array.isArray(value?.additions)
+    ? [...value.additions]
+      .map((entry) => ({ name: entry?.name, rationale: entry?.rationale }))
+      .sort((left, right) => String(left.name).localeCompare(String(right.name)))
+    : value?.additions;
+  return {
+    schemaVersion: value?.schemaVersion,
+    scope: value?.scope,
+    reviewedAt: value?.reviewedAt,
+    reviewers: value?.reviewers,
+    findingDisposition: value?.findingDisposition,
+    reviewedActions: value?.reviewedActions,
+    convergenceReport: value?.convergenceReport,
+    convergenceSha256: value?.convergenceSha256,
+    currentAreas,
+    additions,
+  };
+}
+
+function serializeAreaModelEvidence(value) {
+  return JSON.stringify(canonicalAreaModelEvidence(value), null, 2) + '\n';
+}
+
+function readAreaModelEvidence(ref, expectedAreas) {
+  const resolved = resolveJailedRegularFile(ref, 'docs/audits', '.json');
+  const refError = typeof resolved === 'string' ? auditRefError(ref) : null;
+  if (refError) return { bytes: null, sha256: null, evidence: null, errors: [refError] };
+  let bytes;
+  try { bytes = fs.readFileSync(resolved.fullPath, 'utf-8'); } catch {
+    return { bytes: null, sha256: null, evidence: null, errors: ['cannot be read'] };
+  }
+  let evidence;
+  try { evidence = JSON.parse(bytes); } catch {
+    return { bytes, sha256: null, evidence: null, errors: ['is not valid JSON'] };
+  }
+  const errors = [];
+  if (canonicalText(bytes) !== serializeAreaModelEvidence(evidence)) errors.push('is not in canonical form');
+  const topKeys = isPlainObject(evidence) ? Object.keys(evidence).sort() : [];
+  const expectedTopKeys = [
+    'additions', 'convergenceReport', 'convergenceSha256', 'currentAreas',
+    'findingDisposition', 'reviewedActions', 'reviewedAt', 'reviewers',
+    'schemaVersion', 'scope',
+  ];
+  if (!isPlainObject(evidence) || evidence.schemaVersion !== AREA_MODEL_EVIDENCE_SCHEMA_VERSION) {
+    errors.push(`must use schemaVersion ${AREA_MODEL_EVIDENCE_SCHEMA_VERSION}`);
+  }
+  if (JSON.stringify(topKeys) !== JSON.stringify(expectedTopKeys)) {
+    errors.push(`must contain exactly ${expectedTopKeys.join(', ')}`);
+  }
+  if (evidence?.scope !== AREA_MODEL_SCOPE) errors.push(`scope must be ${AREA_MODEL_SCOPE}`);
+  if (!canonicalTimestamp(evidence?.reviewedAt)) errors.push('has invalid reviewedAt');
+  if (!Array.isArray(evidence?.reviewers) || evidence.reviewers.length === 0 ||
+    evidence.reviewers.some((reviewer) => typeof reviewer !== 'string' ||
+      !/^[a-z0-9][a-z0-9:._/-]{1,119}$/i.test(reviewer)) ||
+    new Set(evidence.reviewers).size !== evidence.reviewers.length) {
+    errors.push('must name one or more unique reviewers');
+  }
+  const findingDisposition = evidence?.findingDisposition;
+  if (!isPlainObject(findingDisposition) ||
+    JSON.stringify(Object.keys(findingDisposition).sort()) !== JSON.stringify(['noUnresolvedDesign', 'resolvedFindings']) ||
+    findingDisposition.noUnresolvedDesign !== true ||
+    !Number.isSafeInteger(findingDisposition.resolvedFindings) || findingDisposition.resolvedFindings < 0) {
+    errors.push('must declare findingDisposition { noUnresolvedDesign: true, resolvedFindings: nonnegative integer }');
+  }
+  if (!Array.isArray(evidence?.reviewedActions) ||
+    JSON.stringify(evidence.reviewedActions) !== JSON.stringify(AREA_MODEL_ACTIONS)) {
+    errors.push(`reviewedActions must be exactly ${AREA_MODEL_ACTIONS.join(', ')}`);
+  }
+
+  const expected = [...expectedAreas].sort();
+  const actual = isPlainObject(evidence?.currentAreas) ? Object.keys(evidence.currentAreas).sort() : [];
+  if (!isPlainObject(evidence?.currentAreas)) errors.push('must contain a currentAreas object');
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    errors.push(`currentAreas must exactly cover the parsed family set (expected: ${expected.join(', ') || 'none'})`);
+  }
+  for (const area of actual) {
+    const entry = evidence.currentAreas[area];
+    if (!isPlainObject(entry) ||
+      JSON.stringify(Object.keys(entry).sort()) !== JSON.stringify(['disposition', 'rationale']) ||
+      !CURRENT_AREA_DISPOSITIONS.has(entry.disposition) ||
+      typeof entry.rationale !== 'string' || entry.rationale.trim().length < 24 || entry.rationale.length > 1000) {
+      errors.push(`currentAreas entry for ${area} must carry a keep/split/merge/retire disposition and a 24-1000 character rationale`);
+    }
+  }
+  if (!Array.isArray(evidence?.additions)) {
+    errors.push('additions must be an array (empty is the explicit no-add disposition)');
+  } else {
+    const seen = new Set();
+    for (const addition of evidence.additions) {
+      if (!isPlainObject(addition) ||
+        JSON.stringify(Object.keys(addition).sort()) !== JSON.stringify(['name', 'rationale']) ||
+        typeof addition.name !== 'string' || addition.name.trim() !== addition.name ||
+        addition.name.length < 2 || addition.name.length > 120 || seen.has(addition.name) ||
+        expected.includes(addition.name) ||
+        typeof addition.rationale !== 'string' || addition.rationale.trim().length < 24 || addition.rationale.length > 1000) {
+        errors.push('each additions entry must name one unique non-current area with a 24-1000 character rationale');
+        break;
+      }
+      seen.add(addition.name);
+    }
+  }
+
+  const reportRef = evidence?.convergenceReport;
+  const resolvedReport = resolveJailedRegularFile(reportRef, 'docs/audits', '.md');
+  let reportBytes = null;
+  if (typeof resolvedReport === 'string') {
+    errors.push('must name an existing regular convergenceReport under docs/audits/');
+  } else {
+    try { reportBytes = fs.readFileSync(resolvedReport.fullPath, 'utf-8'); } catch {
+      errors.push('convergenceReport cannot be read');
+    }
+  }
+  if (typeof evidence?.convergenceSha256 !== 'string' || !SHA256_RE.test(evidence.convergenceSha256)) {
+    errors.push('has invalid convergenceSha256');
+  } else if (reportBytes !== null && textSha256(reportBytes) !== evidence.convergenceSha256) {
+    errors.push('convergenceReport bytes changed');
+  }
+  if (reportBytes !== null) {
+    const reportText = canonicalText(reportBytes);
+    let convergence;
+    try {
+      convergence = validateAuditReport(reportText, {
+        root: ROOT,
+        basenameSlug: path.basename(reportRef, '.md'),
+        requiredStandardsRef: 'docs/STANDARDS-REGISTRY.md',
+        standardEvidence: { responseChanged: false },
+      });
+    } catch (error) {
+      convergence = { ok: false, reason: error instanceof Error ? error.message : String(error) };
+    }
+    if (!convergence.ok) {
+      errors.push(`convergenceReport has not earned convergence: ${convergence.reason}`);
+    } else {
+      const resolvedFindings = convergence.rounds.reduce((sum, round) => sum + round.rows.length, 0);
+      if (findingDisposition?.resolvedFindings !== resolvedFindings) {
+        errors.push(`findingDisposition resolvedFindings must equal the convergenceReport ledger count (${resolvedFindings})`);
+      }
+      try {
+        const convergedAt = parseFrontmatter(reportText).fields.converged;
+        if (convergedAt !== evidence.reviewedAt) {
+          errors.push('reviewedAt must equal the convergenceReport earned timestamp');
+        }
+      } catch {
+        errors.push('convergenceReport frontmatter cannot be read');
+      }
+    }
+  }
+  return { bytes, sha256: textSha256(bytes), evidence, errors };
+}
+
+function canonicalAreaModelAuditRecord(value) {
+  return {
+    schemaVersion: value?.schemaVersion,
+    lastAuditedAt: value?.lastAuditedAt,
+    auditRef: value?.auditRef,
+    auditSha256: value?.auditSha256,
+    areaSetSha256: value?.areaSetSha256,
+  };
+}
+
+function serializeAreaModelAuditRecord(value) {
+  return JSON.stringify(canonicalAreaModelAuditRecord(value), null, 2) + '\n';
+}
+
+function loadAreaModelAudit(expectedAreas) {
+  let raw;
+  try { raw = fs.readFileSync(AREA_MODEL_AUDIT_PATH, 'utf-8'); } catch {
+    return { record: null, errors: ['area model adequacy audit record is missing'] };
+  }
+  let record;
+  try { record = JSON.parse(raw); } catch {
+    return { record: null, errors: ['area model adequacy audit record is not valid JSON'] };
+  }
+  const errors = [];
+  const keys = isPlainObject(record) ? Object.keys(record).sort() : [];
+  const expectedKeys = ['areaSetSha256', 'auditRef', 'auditSha256', 'lastAuditedAt', 'schemaVersion'];
+  if (!isPlainObject(record) || record.schemaVersion !== AREA_MODEL_AUDIT_SCHEMA_VERSION ||
+    JSON.stringify(keys) !== JSON.stringify(expectedKeys)) {
+    errors.push(`area model adequacy audit record must use schemaVersion ${AREA_MODEL_AUDIT_SCHEMA_VERSION} and exact keys`);
+  }
+  if (!canonicalTimestamp(record?.lastAuditedAt)) {
+    errors.push('area model adequacy audit record has invalid lastAuditedAt');
+  } else if (Date.parse(record.lastAuditedAt) > Date.now() + 5 * 60_000) {
+    errors.push('area model adequacy audit record has a future lastAuditedAt');
+  }
+  const evidence = readAreaModelEvidence(record?.auditRef, expectedAreas);
+  for (const error of evidence.errors) errors.push(`area model adequacy auditRef ${error}`);
+  if (typeof record?.auditSha256 !== 'string' || !SHA256_RE.test(record.auditSha256)) {
+    errors.push('area model adequacy audit record has invalid auditSha256');
+  } else if (evidence.sha256 && record.auditSha256 !== evidence.sha256) {
+    errors.push('area model adequacy audit artifact changed');
+  }
+  const currentAreaSetSha256 = areaSetSha256(expectedAreas);
+  if (typeof record?.areaSetSha256 !== 'string' || !SHA256_RE.test(record.areaSetSha256)) {
+    errors.push('area model adequacy audit record has invalid areaSetSha256');
+  } else if (record.areaSetSha256 !== currentAreaSetSha256) {
+    errors.push('area model adequacy audit is stale for the current family set');
+  }
+  if (evidence.evidence?.reviewedAt !== record?.lastAuditedAt) {
+    errors.push('area model adequacy audit reviewedAt does not match lastAuditedAt');
+  }
+  if (isPlainObject(record) && canonicalText(raw) !== serializeAreaModelAuditRecord(record)) {
+    errors.push('area model adequacy audit record is not in canonical form');
+  }
+  return { record, evidence, currentAreaSetSha256, errors };
 }
 
 function loadAreaAuditLedger(expectedAreas) {
@@ -852,6 +1081,18 @@ function compute() {
         totalAreas: 0,
         errors: ALLOW_PARTIAL_REGISTRY ? [] : ['standards registry missing (use --allow-partial-registry only for a deliberate partial checkout)'],
       },
+      areaModelAudit: {
+        status: 'not-assessed',
+        path: path.relative(ROOT, AREA_MODEL_AUDIT_PATH),
+        schemaVersion: AREA_MODEL_AUDIT_SCHEMA_VERSION,
+        currentAreaSetSha256: null,
+        auditedAreaSetSha256: null,
+        auditCurrent: false,
+        lastAuditedAt: null,
+        auditRef: null,
+        errors: [],
+      },
+      cadence: { reviewAfterDays: 90, dueAreas: [], areaModelReviewDue: false, blocking: false },
       enforcementScope: {
         recognizedHeadings: [...ENFORCEMENT_SECTION_HEADINGS],
         excludedProvenanceHeadings: [...EXCLUDED_PROVENANCE_SECTION_HEADINGS],
@@ -922,6 +1163,7 @@ function compute() {
   const enforcedRatio = total === 0 ? 1 : Number((enforced / total).toFixed(4));
   const areaNames = [...areaTallies.keys()].sort();
   const loadedAreaAudits = loadAreaAuditLedger(areaNames);
+  const loadedAreaModelAudit = loadAreaModelAudit(areaNames);
   const baseComparison = compareLedgerToBase(loadedAreaAudits.ledger);
   const rootSelfWiring = ALLOW_PARTIAL_REGISTRY
     ? { status: 'not-assessed', errors: [] }
@@ -975,6 +1217,13 @@ function compute() {
       return !Number.isFinite(audited) || nowMs - audited >= reviewAfterDays * 86_400_000;
     })
     .map(([area]) => area);
+  const modelLastAuditedMs = Date.parse(loadedAreaModelAudit.record?.lastAuditedAt ?? '');
+  const areaModelReviewDue = !Number.isFinite(modelLastAuditedMs) ||
+    nowMs - modelLastAuditedMs >= reviewAfterDays * 86_400_000;
+  const modelRecord = loadedAreaModelAudit.record;
+  const currentAreaSetSha256 = loadedAreaModelAudit.currentAreaSetSha256 ?? areaSetSha256(areaNames);
+  const modelAuditCurrent = loadedAreaModelAudit.errors.length === 0 &&
+    modelRecord?.areaSetSha256 === currentAreaSetSha256;
   return {
     generatedAt: new Date().toISOString(),
     registryFound: true,
@@ -989,7 +1238,18 @@ function compute() {
       protectedBaseStatus: baseComparison.status,
       errors: areaAuditErrors,
     },
-    cadence: { reviewAfterDays, dueAreas, blocking: false },
+    areaModelAudit: {
+      status: loadedAreaModelAudit.errors.length === 0 ? 'current' : 'invalid',
+      path: path.relative(ROOT, AREA_MODEL_AUDIT_PATH),
+      schemaVersion: AREA_MODEL_AUDIT_SCHEMA_VERSION,
+      currentAreaSetSha256,
+      auditedAreaSetSha256: typeof modelRecord?.areaSetSha256 === 'string' ? modelRecord.areaSetSha256 : null,
+      auditCurrent: modelAuditCurrent,
+      lastAuditedAt: typeof modelRecord?.lastAuditedAt === 'string' ? modelRecord.lastAuditedAt : null,
+      auditRef: typeof modelRecord?.auditRef === 'string' ? modelRecord.auditRef : null,
+      errors: loadedAreaModelAudit.errors,
+    },
+    cadence: { reviewAfterDays, dueAreas, areaModelReviewDue, blocking: false },
     falseClaimCount: falseClaims.length, falseClaims,
     danglingCount, danglingByStandard,
   };
@@ -1102,6 +1362,58 @@ function recordAreaAudit(report, selection, auditRef) {
   fs.renameSync(tmp, AREA_AUDITS_PATH);
 }
 
+function readAreaModelAuditForRecord() {
+  if (!fs.existsSync(AREA_MODEL_AUDIT_PATH)) return null;
+  let raw;
+  let record;
+  try {
+    raw = fs.readFileSync(AREA_MODEL_AUDIT_PATH, 'utf-8');
+    record = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`refusing to overwrite an unreadable area model audit record: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const keys = isPlainObject(record) ? Object.keys(record).sort() : [];
+  const expectedKeys = ['areaSetSha256', 'auditRef', 'auditSha256', 'lastAuditedAt', 'schemaVersion'];
+  if (!isPlainObject(record) || record.schemaVersion !== AREA_MODEL_AUDIT_SCHEMA_VERSION ||
+    JSON.stringify(keys) !== JSON.stringify(expectedKeys) ||
+    !canonicalTimestamp(record.lastAuditedAt) ||
+    typeof record.auditRef !== 'string' ||
+    typeof record.auditSha256 !== 'string' || !SHA256_RE.test(record.auditSha256) ||
+    typeof record.areaSetSha256 !== 'string' || !SHA256_RE.test(record.areaSetSha256) ||
+    canonicalText(raw) !== serializeAreaModelAuditRecord(record)) {
+    throw new Error('refusing to overwrite an invalid area model audit record');
+  }
+  return record;
+}
+
+function recordAreaModelAudit(report, auditRef) {
+  if (!report.registryFound) throw new Error('cannot record an area model audit because the standards registry is absent');
+  const currentAreas = Object.keys(report.areas).sort();
+  const evidence = readAreaModelEvidence(auditRef, currentAreas);
+  if (evidence.errors.length > 0) {
+    throw new Error(`--audit-ref areaModelReview ${evidence.errors.join('; ')}`);
+  }
+  const prior = readAreaModelAuditForRecord();
+  const lastAuditedAt = evidence.evidence.reviewedAt;
+  if (Date.parse(lastAuditedAt) > Date.now() + 5 * 60_000) {
+    throw new Error('area model lastAuditedAt may not be more than five minutes in the future');
+  }
+  if (prior && Date.parse(lastAuditedAt) < Date.parse(prior.lastAuditedAt)) {
+    throw new Error('area model lastAuditedAt may not move backward');
+  }
+  const next = {
+    schemaVersion: AREA_MODEL_AUDIT_SCHEMA_VERSION,
+    lastAuditedAt,
+    auditRef,
+    auditSha256: evidence.sha256,
+    areaSetSha256: areaSetSha256(currentAreas),
+  };
+  const tmp = `${AREA_MODEL_AUDIT_PATH}.tmp-${process.pid}-${crypto.randomBytes(6).toString('hex')}`;
+  fs.mkdirSync(path.dirname(AREA_MODEL_AUDIT_PATH), { recursive: true });
+  fs.writeFileSync(tmp, serializeAreaModelAuditRecord(next), { flag: 'wx' });
+  fs.renameSync(tmp, AREA_MODEL_AUDIT_PATH);
+}
+
 function main() {
   let report = compute();
   if (RECORD_AREA_ARG !== undefined) {
@@ -1110,6 +1422,15 @@ function main() {
       report = compute();
     } catch (error) {
       process.stderr.write(`❌ standards-coverage record failed: ${error instanceof Error ? error.message : String(error)}\n`);
+      process.exit(1);
+    }
+  }
+  if (RECORD_AREA_MODEL) {
+    try {
+      recordAreaModelAudit(report, AUDIT_REF);
+      report = compute();
+    } catch (error) {
+      process.stderr.write(`❌ standards-coverage area-model record failed: ${error instanceof Error ? error.message : String(error)}\n`);
       process.exit(1);
     }
   }
@@ -1152,6 +1473,9 @@ function main() {
     for (const error of report.areaAudit.errors) {
       console.error(`[standards-coverage] AREA AUDIT — ${error}`);
     }
+    for (const error of report.areaModelAudit.errors) {
+      console.error(`[standards-coverage] AREA MODEL AUDIT — ${error}`);
+    }
     for (const fc of report.falseClaims) {
       console.error(`[standards-coverage] FALSE CLAIM — "${fc.standard}" asserts running machinery (${fc.claims.map((c) => `"${c}"`).join(', ')}) but names no resolvable guard.`);
     }
@@ -1164,6 +1488,7 @@ function main() {
       failures.push(`enforced ratio ${aggregateEnforced}/${report.total} (${report.enforcedRatio}) < floor ${FLOORS.enforcedRatio}`);
     }
     for (const error of report.areaAudit.errors) failures.push(error);
+    for (const error of report.areaModelAudit.errors) failures.push(error);
     for (const [area, measurement] of Object.entries(report.areas)) {
       if (ratioBelowFloor(measurement.enforced, measurement.total, measurement.refResolutionFloor)) {
         failures.push(
@@ -1191,7 +1516,7 @@ function main() {
     if (failures.length > 0) {
       process.stderr.write('\n❌ standards-coverage check failed:\n');
       for (const f of failures) process.stderr.write(`  - ${f}\n`);
-      process.stderr.write('\nFix: build a guard for an unguarded standard, record the changed family audit without lowering its floor, repair a dangling reference, classify each unknown article heading, or resolve a false claim whose prose asserts unnamed machinery.\n');
+      process.stderr.write('\nFix: build a guard for an unguarded standard, record the changed family audit without lowering its floor, record a converged area-model adequacy review, repair a dangling reference, classify each unknown article heading, or resolve a false claim whose prose asserts unnamed machinery.\n');
       process.exit(1);
     }
     if (!QUIET) console.error('✅ standards-coverage check passed.');

--- a/tests/unit/standards-coverage-ratchet.test.ts
+++ b/tests/unit/standards-coverage-ratchet.test.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { computeCoverage } from '../../src/core/StandardsEnforcementAuditor.js';
 import { parseRegistryStructure } from '../../scripts/standards-registry-article-core.mjs';
+import { stampConverged, validateAuditReport } from '../../scripts/write-audit-convergence.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT = path.resolve(__dirname, '../../scripts/standards-coverage.mjs');
@@ -62,11 +63,89 @@ function writeAuditEvidence(
   }, null, 2)}\n`);
 }
 
+function writeAreaModelEvidence(
+  ref = 'docs/audits/family-model-review.json',
+  reviewedAt = '2000-01-01T00:00:00.000Z',
+): void {
+  const report = JSON.parse(runScript(['--json'])) as {
+    areas: Record<string, { currentAreaSha256: string }>;
+  };
+  const slug = `family-model-review-${auditCounter}`;
+  const reportRef = `docs/audits/${slug}.md`;
+  const draft = [
+    '---',
+    `audit: "${slug}"`,
+    'target-pattern: "Whether the current Standards Registry family set remains an adequate decomposition of fundamental areas."',
+    'search-surface: "Every current family, every standard heading, and the add/split/merge/retire alternative space."',
+    'exemption: "one-time-human-review — Fixture-only semantic review with production structure exercised by the unit test."',
+    'blind-spot-class: "list-integrity-without-adequacy-review"',
+    'standard-response-kind: "no-change"',
+    'standard-response-ref: "docs/STANDARDS-REGISTRY.md"',
+    'standard-response-article-id: "iterative-audit-to-convergence"',
+    'standard-response-article: "Iterative Audit to Convergence"',
+    'standard-response-rationale: "The constitution already requires convergence; this fixture exercises the missing evidence-binding structure."',
+    '---',
+    '',
+    '# Fixture area-model adequacy audit',
+    '',
+    '## Meta-insight',
+    '',
+    'How it arose: Per-family content review was mistaken for review of whether the family list itself remains adequate.',
+    'Why prior controls missed it: Exact set integrity can prove that a list stayed unchanged without asking whether its decomposition is still right.',
+    '',
+    '## Round 1',
+    '',
+    'Search angles: by family cohesion, cross-family overlap, and missing-area candidates.',
+    'Surface delta: initial fixture review of the complete current family set.',
+    '',
+    '| location | behavior | bucket | disposition |',
+    '|---|---|---|---|',
+    '| docs/STANDARDS-REGISTRY.md:1 | Current fixture family set received an explicit adequacy disposition. | keep | accepted:fixture family remains distinct and complete for this structural test |',
+    '',
+    'New findings this round: 1',
+    '',
+    '## Round 2',
+    '',
+    'Search angles: repeat the complete family-set review from the alternative-action direction.',
+    'Surface delta: no new family, split, merge, or retirement candidate emerged.',
+    '',
+    'New findings this round: 0',
+    '',
+  ].join('\n');
+  const validation = validateAuditReport(draft, {
+    root: repo,
+    basenameSlug: slug,
+    standardEvidence: { responseChanged: false },
+    allowDerivedStale: true,
+  });
+  if (!validation.ok) throw new Error(`invalid model-audit fixture: ${validation.reason}`);
+  const stamped = stampConverged(draft, validation.rounds.length, reviewedAt);
+  write(reportRef, stamped);
+  write(ref, `${JSON.stringify({
+    schemaVersion: 1,
+    scope: 'area-model-adequacy',
+    reviewedAt,
+    reviewers: ['fixture-reviewer'],
+    findingDisposition: { noUnresolvedDesign: true, resolvedFindings: 1 },
+    reviewedActions: ['keep', 'add', 'split', 'merge', 'retire'],
+    convergenceReport: reportRef,
+    convergenceSha256: crypto.createHash('sha256').update(stamped).digest('hex'),
+    currentAreas: Object.fromEntries(Object.keys(report.areas).sort().map((area) => [area, {
+      disposition: 'keep',
+      rationale: `${area} remains a distinct, coherent fixture family after the complete alternative-action review.`,
+    }])),
+    additions: [],
+  }, null, 2)}\n`);
+}
+
 function refreshAreaAudits(floor?: number): void {
   auditCounter += 1;
   const auditRef = `docs/audits/family-review-${auditCounter}.json`;
   writeAuditEvidence(auditRef);
   runScript(['--record-area-audit=all', '--admit-new-areas', `--audit-ref=${auditRef}`, '--quiet']);
+  const modelAuditRef = `docs/audits/family-model-review-${auditCounter}.json`;
+  writeAreaModelEvidence(modelAuditRef);
+  runScript(['--record-area-model-audit', `--audit-ref=${modelAuditRef}`, '--quiet']);
   if (floor === undefined) return;
   const auditPath = path.join(repo, 'docs', 'standards-registry-area-audits.json');
   const ledger = JSON.parse(fs.readFileSync(auditPath, 'utf-8')) as {
@@ -392,6 +471,21 @@ describe('standards-coverage ratchet script', () => {
     expect(runCheck().code).toBe(0);
   });
 
+  it('FAILS when the family set has no converged area-model adequacy audit', () => {
+    fs.rmSync(path.join(repo, 'docs', 'standards-registry-area-model-audit.json'));
+
+    const result = runCheck();
+    expect(result.code).toBe(1);
+    expect(result.out).toContain('area model adequacy audit record is missing');
+  });
+
+  it('does not accept a family-content review as an area-model adequacy review', () => {
+    writeAuditEvidence('docs/audits/content-only-review.json');
+    expect(() => runScript([
+      '--record-area-model-audit', '--audit-ref=docs/audits/content-only-review.json', '--quiet',
+    ])).toThrow(/areaModelReview/);
+  });
+
   it('binds each audit record to immutable family evidence', () => {
     fs.appendFileSync(path.join(repo, 'docs/audits/family-review-1.json'), '\n');
     expect(runCheck().out).toContain('audit artifact changed');
@@ -554,7 +648,10 @@ describe('standards-coverage ratchet script', () => {
     expect(crlf.areas.Building.currentAreaSha256).toBe(lf.areas.Building.currentAreaSha256);
     for (const rel of [
       'docs/standards-registry-area-audits.json',
+      'docs/standards-registry-area-model-audit.json',
       'docs/audits/family-review-1.json',
+      'docs/audits/family-model-review-1.json',
+      'docs/audits/family-model-review-1.md',
       'docs/specs/reports/family-review.md',
     ]) {
       const full = path.join(repo, rel);
@@ -707,6 +804,7 @@ describe('standards-coverage ratchet script', () => {
       total: number;
       enforcedRatio: number;
       areaAudit: { status: string; currentCount: number; totalAreas: number; errors: string[] };
+      areaModelAudit: { status: string; currentAreaSetSha256: string; auditCurrent: boolean };
       areas: Record<string, {
         total: number;
         enforced: number;
@@ -725,6 +823,10 @@ describe('standards-coverage ratchet script', () => {
     expect(report.areaAudit).toEqual(expect.objectContaining({
       status: 'current', currentCount: 6, totalAreas: 6, errors: [],
     }));
+    expect(report.areaModelAudit).toEqual(expect.objectContaining({
+      status: 'current', auditCurrent: true,
+    }));
+    expect(report.areaModelAudit.currentAreaSetSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(report.areas['The Root']).toEqual(expect.objectContaining({
       total: 1,
       enforced: 1,
@@ -744,6 +846,7 @@ describe('standards-coverage ratchet script', () => {
     expect(workflow).toContain("issue.user?.login === 'github-actions[bot]'");
     expect(workflow).toContain('issue.body?.startsWith(`${marker}\\n`)');
     expect(workflow).not.toContain('issue.body?.includes(marker)');
+    expect(workflow).toContain('keep / add / split / merge / retire');
   });
 
   // ── FALSE-CLAIM DETECTION (2026-07-31) ────────────────────────────────────

--- a/tests/unit/standards-coverage-ratchet.test.ts
+++ b/tests/unit/standards-coverage-ratchet.test.ts
@@ -66,10 +66,28 @@ function writeAuditEvidence(
 function writeAreaModelEvidence(
   ref = 'docs/audits/family-model-review.json',
   reviewedAt = '2000-01-01T00:00:00.000Z',
+  options: {
+    dispositions?: Record<string, 'keep' | 'split' | 'merge' | 'retire'>;
+    additions?: Array<{ name: string; rationale: string }>;
+  } = {},
 ): void {
   const report = JSON.parse(runScript(['--json'])) as {
     areas: Record<string, { currentAreaSha256: string }>;
   };
+  const areaNames = Object.keys(report.areas).sort();
+  const dispositions = options.dispositions ?? {};
+  const additions = options.additions ?? [];
+  const dispositionFor = (area: string): 'keep' | 'split' | 'merge' | 'retire' =>
+    Object.hasOwn(dispositions, area) ? dispositions[area] : 'keep';
+  const ledgerRows = [
+    ...areaNames.map((area) => {
+      const disposition = dispositionFor(area);
+      return `| docs/STANDARDS-REGISTRY.md:1 | ${area} received an explicit ${disposition} disposition in the fixture adequacy review. | ${disposition} | accepted:${area} fixture disposition is structurally valid |`;
+    }),
+    ...additions.map((addition) =>
+      `| docs/STANDARDS-REGISTRY.md:1 | ${addition.name} was considered as an explicit addition to the fixture area model. | add | accepted:${addition.rationale} |`,
+    ),
+  ];
   const slug = `family-model-review-${auditCounter}`;
   const reportRef = `docs/audits/${slug}.md`;
   const draft = [
@@ -100,9 +118,9 @@ function writeAreaModelEvidence(
     '',
     '| location | behavior | bucket | disposition |',
     '|---|---|---|---|',
-    '| docs/STANDARDS-REGISTRY.md:1 | Current fixture family set received an explicit adequacy disposition. | keep | accepted:fixture family remains distinct and complete for this structural test |',
+    ...ledgerRows,
     '',
-    'New findings this round: 1',
+    `New findings this round: ${ledgerRows.length}`,
     '',
     '## Round 2',
     '',
@@ -126,15 +144,15 @@ function writeAreaModelEvidence(
     scope: 'area-model-adequacy',
     reviewedAt,
     reviewers: ['fixture-reviewer'],
-    findingDisposition: { noUnresolvedDesign: true, resolvedFindings: 1 },
+    findingDisposition: { noUnresolvedDesign: true, resolvedFindings: ledgerRows.length },
     reviewedActions: ['keep', 'add', 'split', 'merge', 'retire'],
     convergenceReport: reportRef,
     convergenceSha256: crypto.createHash('sha256').update(stamped).digest('hex'),
-    currentAreas: Object.fromEntries(Object.keys(report.areas).sort().map((area) => [area, {
-      disposition: 'keep',
-      rationale: `${area} remains a distinct, coherent fixture family after the complete alternative-action review.`,
+    currentAreas: Object.fromEntries(areaNames.map((area) => [area, {
+      disposition: dispositionFor(area),
+      rationale: `${area} received an explicit ${dispositionFor(area)} disposition after the complete fixture alternative-action review.`,
     }])),
-    additions: [],
+    additions,
   }, null, 2)}\n`);
 }
 
@@ -484,6 +502,35 @@ describe('standards-coverage ratchet script', () => {
     expect(() => runScript([
       '--record-area-model-audit', '--audit-ref=docs/audits/content-only-review.json', '--quiet',
     ])).toThrow(/areaModelReview/);
+  });
+
+  it('accepts an explicit retire disposition for a current family', () => {
+    auditCounter += 1;
+    const auditRef = 'docs/audits/retire-model-review.json';
+    writeAreaModelEvidence(auditRef, '2000-01-01T00:00:00.000Z', {
+      dispositions: { Building: 'retire' },
+    });
+
+    expect(() => runScript([
+      '--record-area-model-audit', `--audit-ref=${auditRef}`, '--quiet',
+    ])).not.toThrow();
+    expect(runCheck().code).toBe(0);
+  });
+
+  it('accepts an explicit non-empty addition disposition', () => {
+    auditCounter += 1;
+    const auditRef = 'docs/audits/add-model-review.json';
+    writeAreaModelEvidence(auditRef, '2000-01-01T00:00:00.000Z', {
+      additions: [{
+        name: 'Stewardship',
+        rationale: 'The fixture review found a distinct candidate area that merits explicit admission.',
+      }],
+    });
+
+    expect(() => runScript([
+      '--record-area-model-audit', `--audit-ref=${auditRef}`, '--quiet',
+    ])).not.toThrow();
+    expect(runCheck().code).toBe(0);
   });
 
   it('binds each audit record to immutable family evidence', () => {

--- a/upgrades/eli16/standards-area-model-adequacy.md
+++ b/upgrades/eli16/standards-area-model-adequacy.md
@@ -1,0 +1,33 @@
+# Fundamental areas are now reviewed as a living model
+
+Instar's Standards Registry is organized into six families. The existing audit
+mechanism already did an important job: it remembered the exact contents of each
+family, noticed when those contents changed, and prevented one large family's
+coverage score from hiding a regression in a smaller family.
+
+That still left a level above the contents unaudited. A perfectly preserved list
+can be the wrong list. For example, two families might gradually overlap, one
+might become too broad and need splitting, or a new cluster of standards might
+deserve its own family. Checking that the six familiar names are unchanged does
+not answer any of those questions.
+
+This change adds a separate area-model adequacy review. A reviewer must examine
+the whole family decomposition to convergence and record an explicit decision
+for every current family: keep, split, merge, or retire. The review must also
+state whether a new family should be added. The evidence is bound to the exact
+convergence report and the exact current family set, so an ordinary content
+review cannot be reused as proof that the model itself was reconsidered.
+
+The first real review used two independent search angles over all 82 standards.
+It kept all six current families and found no family to add, split, merge, or
+retire. That result is intentionally described as a current judgment, not a
+permanent taxonomy.
+
+The weekly cadence now resurfaces this model-level review after 90 days alongside
+the existing family-content reminders. Age remains a reminder rather than a CI
+veto. CI does block when the required evidence is missing, malformed, detached
+from its converged report, or stale because the family set changed. The checker
+only verifies those closed structural facts; it never chooses the semantic
+dispositions. This preserves the right split: deterministic machinery makes the
+review impossible to forget, while a reasoning reviewer remains responsible for
+deciding whether the fundamental areas are still adequate.

--- a/upgrades/next/standards-area-model-adequacy.md
+++ b/upgrades/next/standards-area-model-adequacy.md
@@ -1,0 +1,21 @@
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+The Standards Registry audit now treats the fundamental-area list as a living
+model. A separate convergence-bound record requires explicit keep, add, split,
+merge, and retire consideration, while the weekly cadence resurfaces model
+adequacy independently from per-family content age. The deterministic checker
+validates evidence and exact family-set integrity but does not make semantic
+taxonomy decisions.
+
+## Evidence
+
+- A fail-before proof showed the prior checker accepted a missing model review
+  and could not distinguish family-content evidence from area-model evidence.
+- The focused standards-coverage suite passes all 33 cases, including missing
+  evidence, wrong evidence kind, exact family-set binding, and live-repository
+  coverage.
+- The initial whole-corpus review earned convergence after two rounds with all
+  six current families kept and no additions, splits, merges, or retirements.

--- a/upgrades/side-effects/standards-area-model-adequacy.md
+++ b/upgrades/side-effects/standards-area-model-adequacy.md
@@ -1,0 +1,192 @@
+# Side-Effects Review — Standards area-model adequacy audit
+
+**Version / slug:** `standards-area-model-adequacy`
+**Date:** `2026-08-01`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required — repository-only governance data and CI structure; no runtime, messaging, session, coherence, or self-triggered controller path`
+
+## Summary of the change
+
+This change adds a separate evidence lifecycle for periodically reconsidering
+whether the Standards Registry's family list is still adequate. The coverage
+script now validates a canonical model-review artifact, its earned convergence
+report, explicit keep/add/split/merge/retire consideration, the exact parsed
+family set, byte hashes, and timestamps. The weekly workflow resurfaces this
+review independently from family-content reviews. The initial two-round audit,
+record, tests, ELI16, and internal-only release fragment ship atomically. No
+runtime `src` file changes.
+
+## Decision-point inventory
+
+- **Area-model evidence validity** — add — a closed repository invariant blocks
+  CI when the record is missing, malformed, byte-detached, unconverged, or stale
+  for the parsed family set.
+- **Semantic area disposition** — pass-through — reviewers choose keep, add,
+  split, merge, and retire outcomes; deterministic code never chooses them.
+- **Review-age cadence** — modify — a 90-day model-review due signal joins the
+  existing content-review signal without gaining blocking authority.
+- **Scheduled issue lifecycle** — modify — the existing single marker-owned
+  GitHub issue includes whichever content or model review is due.
+
+---
+
+## 1. Over-block
+
+A legitimate registry change that adds, renames, or removes a family now fails
+until a convergence-bound area-model review explicitly covers the new exact set.
+That is intentional: the former behavior let a taxonomy change land with only a
+content attestation. Formatting or wording changes inside a convergence report
+also stale its evidence hash and require re-recording. Ordinary per-family
+content evidence is deliberately rejected as model evidence even when its date
+and reviewers are valid.
+
+Elapsed age does not block. A repository with an unchanged but old review stays
+green and receives the existing advisory issue instead, avoiding a calendar wall
+that could veto unrelated work.
+
+---
+
+## 2. Under-block
+
+The checker cannot prove that a rationale is intellectually good or that a
+reviewer explored every meaningful alternative. It proves that all current
+families have one allowed disposition, additions are explicit, all five actions
+were reviewed, the evidence matches an earned convergence report, and no design
+finding remains open. Semantic adequacy remains reasoning authority in the
+review report.
+
+The 90-day interval is a resurfacing cadence, not proof that the model becomes
+wrong on day 91. Conversely, a poor but structurally valid no-change judgment can
+pass; that is the irreducible judgment boundary and is made visible rather than
+silently delegated to code.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The change extends the existing standards-coverage script and existing scheduled
+issue instead of inventing a parallel taxonomy service or runtime controller.
+Per-family byte review and family-model adequacy remain separate evidence kinds
+because they answer different questions and must not substitute for one another.
+The shared convergence validator owns the review-process proof; the coverage
+script only binds that proof to the exact family set and declared dispositions.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No brittle semantic detector holds blocking authority.
+
+CI authority is limited to closed, enumerable facts: exact keys, allowed enums,
+canonical timestamps, jailed regular-file references, hashes, earned convergence,
+ledger count agreement, and exact family-set equality. The fallible question —
+whether an area should actually be kept, added, split, merged, or retired — is
+not scored or selected by the checker. Review age remains a signal consumed by
+the existing advisory issue lifecycle.
+
+---
+
+## 4b. Judgment-point check
+
+No static heuristic is added at a competing-signals decision point. Structural
+evidence validity is an enumerable invariant. Area-model adequacy is explicitly a
+judgment point, and the mechanism preserves it as reviewer authority rather than
+encoding proxy rules such as family size or keyword counts.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** model errors are additive to aggregate coverage, per-family
+  floors, content freshness, dangling references, unknown headings, and false
+  claims; none suppresses reporting of another.
+- **Double-fire:** the same marker-owned cadence issue carries both content and
+  model due states, so simultaneous due dates update one issue rather than open
+  competing notices.
+- **Races:** normal report/check modes are read-only. Record mode writes the
+  single model record through a unique temporary file and atomic rename.
+- **Feedback loops:** the due issue never changes registry or evidence state and
+  therefore cannot make its own condition green.
+- **Evidence separation:** a content-review artifact fails the model schema, so
+  existing family audits cannot accidentally satisfy the new obligation.
+
+---
+
+## 6. External surfaces
+
+GitHub Actions gains additional summary and issue text inside the existing
+weekly standards cadence. No new issue class, API, credential, user message,
+dashboard action, runtime configuration, database, or agent-home state is added.
+The model record and evidence are committed repository data. There are no
+operator-facing actions; the review is performed through the normal repository
+change surface.
+
+---
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture
+
+**Replicated through Git.** The checker, family list, convergence report,
+evidence, and canonical record ship in one commit. Every machine on the same
+commit derives the same family-set and byte hashes. The scheduled notice is
+repository-scoped GitHub state and already has one marker-owned voice. The
+change emits no user-facing notices, holds no topic-scoped durable state, and
+generates no URLs.
+
+---
+
+## 8. Rollback cost
+
+Rollback is one repository revert: remove the script/workflow/test changes and
+the model record/evidence/report. Older code ignores the new JSON files, so no
+data migration or agent state repair is needed. If the cadence issue is open,
+the older workflow will update or close it according to content-review state.
+There is no runtime propagation window because no shipped runtime code changes.
+
+---
+
+## Conclusion
+
+The review preserves the decisive boundary: structure makes area-model review
+unforgettable and non-substitutable, while semantic taxonomy remains a converged
+human/agent judgment. The change is isolated to repository governance, composes
+with the prior area ratchet, has a clean Git rollback, and is clear to ship after
+the focused and repository-wide checks remain green.
+
+---
+
+## Second-pass review
+
+**Reviewer:** not required
+**Independent read of the artifact:** not required
+
+No runtime controller or block/allow path over messages, sessions, dispatch,
+coherence, trust, or recovery changes. The only veto is closed repository
+evidence integrity, and semantic choices remain outside deterministic authority.
+
+---
+
+## Evidence pointers
+
+- `docs/audits/standards-area-model-adequacy.md`
+- `docs/audits/standards-area-model-audit-2026-08-01.json`
+- `docs/standards-registry-area-model-audit.json`
+- `tests/unit/standards-coverage-ratchet.test.ts`
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: claim-vs-evidence`, `closure: guard`, `guardEvidence:
+{enforcementType: ratchet, citation:
+tests/unit/standards-coverage-ratchet.test.ts, howCaught: removing the area-model
+record fails the live check, and presenting content-only evidence to the model
+record path is rejected, so exact family-content proof can no longer masquerade
+as proof that the area model itself was reconsidered}`.


### PR DESCRIPTION
## ELI16 — The standards list now has to prove it is still the right list

We already checked that every standards area was reviewed and that its contents had not silently changed. This adds a separate recurring review of the list itself: reviewers must explicitly decide whether each area should stay, be split, be merged, or be retired, and whether any new area should be added. The checker verifies that this human judgment happened and is tied to the exact current list; it never makes the judgment itself.

## What changed

- Add a separate, periodic adequacy audit for the standards area model itself.
- Require explicit `keep`, `add`, `split`, `merge`, and `retire` dispositions, while keeping semantic judgment outside the deterministic checker.
- Bind the evidence to the exact current area set, canonical hashes, reviewers, a regular converging-audit report, and its earned convergence stamp.
- Extend the weekly cadence issue to distinguish content review from area-model review.
- Record the initial two-round converged audit: keep all six current areas; add/split/merge/retire none for this review.

## Why

ACT-1714 closed per-area coverage and exact family/content integrity, but that could still preserve a fixed list forever. Content integrity is not evidence that the list remains adequate. This closes the missing meta-review loop without introducing a functional-domain taxonomy or allowing code to make the semantic decision.

## Verification

- 75 targeted standards/convergence tests passed
- 35 affected standards-ratchet cases passed independently
- accepted retire and non-empty addition evidence paths are covered
- lint passed (baseline report-only warnings unchanged)
- build passed (expected local signing-key warning unchanged)
- upgrade-guide, standards coverage, and audit-convergence checks passed
- workflow YAML and embedded script syntax parsed successfully

The local repository-wide attempt was not used as a green claim: the isolated script-suppressed install lacks native database bindings, and unrelated machine-sensitive session tests also failed/timed out. Canonical CI is the isolated full-suite authority.

Tracks ACT-1714.

