### PR TITLE
Add bounded reach for undated actions

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-02T03-32-55-519Z-undated-action-resurfacer.json
+++ b/.instar/instar-dev-decisions/2026-08-02T03-32-55-519Z-undated-action-resurfacer.json
@@ -1,0 +1,42 @@
+{
+  "ts": "2026-08-02T03:32:55.519Z",
+  "slug": "undated-action-resurfacer",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": true,
+  "files": 9,
+  "loc": 1101,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/config/ConfigDefaults.ts",
+      "src/core/devGatedFeatures.ts",
+      "src/core/types.ts",
+      "src/data/state-coherence-registry.json",
+      "src/monitoring/UndatedActionResurfacer.ts",
+      "src/server/AgentServer.ts",
+      "src/server/routes.ts",
+      "src/testing/selfActionRegistry.ts"
+    ],
+    "addedLines": 1099,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "Under an indefinitely non-empty backlog, reconstruction must preserve the durable four-hour global rate floor and each unchanged target must stop after three raises; the production controller also fails closed on pool-owner disagreement and stops at a fixed byte ceiling."
+    },
+    "component": "UndatedActionResurfacer"
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-02T04-04-00-179Z-undated-action-resurfacer.json
+++ b/.instar/instar-dev-decisions/2026-08-02T04-04-00-179Z-undated-action-resurfacer.json
@@ -1,0 +1,33 @@
+{
+  "ts": "2026-08-02T04:04:00.179Z",
+  "slug": "undated-action-resurfacer",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 57,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/monitoring/UndatedActionResurfacer.ts",
+      "src/server/AgentServer.ts"
+    ],
+    "addedLines": 40,
+    "deletedLines": 17
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/self-action-convergence.test.ts",
+      "howCaught": "Under an indefinitely non-empty backlog, reconstruction must preserve the durable four-hour global rate floor and each unchanged target must stop after three raises; the production controller also fails closed on pool-owner disagreement and stops at a fixed byte ceiling."
+    },
+    "prNumber": 1832,
+    "component": "UndatedActionResurfacer"
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/undated-action-resurfacer.eli16.md
+++ b/docs/specs/undated-action-resurfacer.eli16.md
@@ -48,6 +48,12 @@ failing.
 The four-hour cadence is stored, not just held by a process timer. Restarting the agent or repeatedly
 requesting another pass cannot squeeze extra items into the window.
 
+A live sizing snapshot found that the newest part of the currently unresolved group is about ten
+times denser than the rate at which unchanged rows can reach the three-reminder terminal. That does
+not prove how quickly new rows arrive, because rows already resolved are absent. It does show why this
+feature is a safe reach mechanism rather than a drain; rollout must measure both arrivals and exits
+before choosing the next lever.
+
 ## What it deliberately cannot do
 
 It never marks anything done, never cancels anything, never changes a priority, and never decides an
@@ -73,7 +79,12 @@ pretend otherwise.
 
 **It only covers high and critical items to start.** Medium and low undated items are a bigger group,
 and adding them later is straightforward — but the measured damage is in the important ones, so that
-is where it starts.
+is where it starts. Old stores use several spellings for those levels, so `HIGH`, `high`,
+`CRITICAL`, `critical`, and the older top-priority word `urgent` are treated consistently.
+
+**The 30-day high-priority shortcut is not helping today.** No currently pending row has survived
+that long; the older rows in the store are already cancelled or completed. The shortcut remains as a
+guard for a different future population, while dry-run metrics must show whether it ever activates.
 
 **Multiple machines do not trade this history back and forth.** One stable machine owns the ledger,
 and it may run the cadence only while it also holds the serving lease. Every registered machine's

--- a/docs/specs/undated-action-resurfacer.eli16.md
+++ b/docs/specs/undated-action-resurfacer.eli16.md
@@ -39,15 +39,24 @@ digest of them — would bury the very surface it's supposed to help. Your agent
 built specifically to stop that kind of flood, and it exists because that mistake has been made
 before.
 
-One at a time won't clear the backlog, and it isn't meant to. It means **no item can sit forever
-untouched**. Six a day, oldest first, and the worst case is bounded by arithmetic rather than by
-someone choosing a threshold correctly.
+One at a time won't clear the backlog, and it isn't meant to. It means the oldest items keep getting
+a path back while the list stays finite and does not grow faster than the cadence can serve it. If
+new important items arrive faster than six a day, newer rows can still wait indefinitely. The
+unconditional guarantee is the flood bound; the pool-size metric shows when the reach assumption is
+failing.
+
+The four-hour cadence is stored, not just held by a process timer. Restarting the agent or repeatedly
+requesting another pass cannot squeeze extra items into the window.
 
 ## What it deliberately cannot do
 
 It never marks anything done, never cancels anything, never changes a priority, and never decides an
 item doesn't matter. It brings one thing back into view and says nothing else. Every judgment stays
 with you.
+
+An item whose author explicitly recorded “I cannot give this an honest due date” still qualifies.
+That explanation makes the missing date deliberate; it does not make the action permanently
+invisible.
 
 ## How you'd know it's working
 
@@ -57,16 +66,23 @@ so the choice can be checked against a real 581-item backlog before it says anyt
 
 ## The honest limits
 
-**It does not clear the pile.** 581 items, one per run, is not a drain — it's a guarantee that nothing
-sits forever. Clearing what has already accumulated is separate work and this doesn't pretend
-otherwise.
+**It does not clear the pile.** 581 items, one per run, is not a drain. It gives the oldest important
+rows a path back only while the eligible set stays finite, arrivals stay below the service rate, and
+the scheduler keeps running. Clearing what has already accumulated is separate work and this doesn't
+pretend otherwise.
 
 **It only covers high and critical items to start.** Medium and low undated items are a bigger group,
 and adding them later is straightforward — but the measured damage is in the important ones, so that
 is where it starts.
 
-**One design question is genuinely open**, and it's written down as open rather than guessed: if you
-run your agent on more than one machine, both could bring back the same item unless they share a
-record of what's already been raised. There are two reasonable answers and the smaller one is probably
-right — but "probably right" is exactly how features get shipped machine-blind, so it gets decided
-before it gets built, not after.
+**Multiple machines do not trade this history back and forth.** One stable machine owns the ledger,
+and it may run the cadence only while it also holds the serving lease. Every registered machine's
+latest authenticated heartbeat must agree on that owner first; missing or conflicting local settings
+stop every machine before either can act, rather than letting two empty ledgers both claim authority.
+If service moves elsewhere, resurfacing pauses; when service returns, the same cooldown and
+raise-count history resumes. This gives up
+availability during a handoff so a new machine cannot quietly treat old reminders as new.
+
+**Its own history cannot grow forever.** The ledger stops at four megabytes and raises one stable
+capacity warning instead of deleting action evidence or silently continuing without a trustworthy
+cooldown.

--- a/docs/specs/undated-action-resurfacer.md
+++ b/docs/specs/undated-action-resurfacer.md
@@ -63,7 +63,7 @@ feature**, not a safeguard bolted to it.
 
 | element | rule |
 |---|---|
-| eligible | `status: pending`, no `dueBy`, priority `high` or `critical`, **including rows carrying an explicit `followThroughOptOutReason`** |
+| eligible | `status: pending`, no `dueBy`, priority `high` or `critical`, **including rows carrying an explicit `followThroughOptOutReason`**. The durable store predates the lowercase TypeScript union, so comparisons are case-insensitive and legacy `urgent` is the critical/top-priority alias. |
 | selection | **weighted lanes, not strict tiers**: 3 of every 4 runs draw the oldest eligible `critical`; the 4th draws the oldest eligible `high`. A lane with nothing eligible yields to the other. **Plus a max-age override**: any `high` older than 30 days enters the critical lane. Ties by action id. Excludes anything inside its cooldown. |
 | volume | **ONE per run. Never a digest, never a batch.** |
 | cooldown | an action re-surfaced is ineligible for 14 days, recorded durably |
@@ -75,6 +75,20 @@ feature**, not a safeguard bolted to it.
 One-per-run makes a flood **arithmetically impossible** — that part is unconditional, and it is the
 property the bound exists for. A bound that depends on a threshold being tuned correctly fails the
 first time the backlog grows; a bound of one does not.
+
+**Pre-live sizing observation, 2026-08-01.** The currently unresolved eligible cohort has a
+creation-age density of about 21.4 rows/day over its newest seven days (28.4/day over fourteen and
+20.3/day over thirty), while the default cadence emits at most six raises/day and can move at most two
+unchanged rows/day into the three-raise terminal after the pipeline fills. The seven-day density is
+roughly 10.7× that terminal capacity, confirming that this mechanism is reach, not drainage. This is
+not a historical intake measure: rows already completed, cancelled, dated, or reprioritized are
+absent from the snapshot. Live rollout must measure actual arrivals and exits before choosing between
+intake reduction, faster disposition, or a separately bounded backlog-remediation path.
+
+The 30-day high-priority promotion is also a future guard, not a currently active lane: the same
+measurement found zero pending actions older than 30 days. The store is not young—520 rows exceed
+that age—but 515 are cancelled and 5 completed. This does not justify deleting the override; it means
+the dry-run must report whether the lane remains inert rather than crediting it with current reach.
 
 **The creation-time opt-out is not a resurfacing opt-out.** A recorded
 `followThroughOptOutReason` explains why the author deliberately chose not to assign a due date. It
@@ -347,6 +361,12 @@ the future path if uninterrupted multi-machine cadence becomes worth the additio
 | 7 | Rollout | Ships **dark**, then dry-run (logs the row it WOULD raise), then live. The dry-run stage is the real test: it proves the selection is sane against a 581-row backlog before anything is raised. |
 | 8 | Explicit follow-through opt-out | Does **not** affect eligibility. It records why no due date was chosen; it never grants invisibility from the undated-action path. |
 
+### 5.1 Implementation surfaces
+
+The authenticated health read is `GET /evolution/actions/undated-resurfacer`. The authenticated,
+cadence-bounded manual trigger is `POST /evolution/actions/undated-resurfacer/pass`. Both use the same
+production controller and durable cadence; the pass operation is not a bypass around the run floor.
+
 ## 6. Open questions
 
 *(none)*
@@ -367,6 +387,10 @@ the future path if uninterrupted multi-machine cadence becomes worth the additio
   **Disposing of the existing 581 requires a bounded one-off review**, which is separate work with a
   separate flood profile. Shipping this and declaring Close the Loop solved would be exactly the
   overclaim this project keeps catching.
+- **Measuring arrivals and exits** — the pre-live open-cohort density is around 20–28 rows/day across
+  the sampled age windows, far above the bounded terminal rate, but it is not historical intake.
+  Rollout must measure creation and resolution events before deciding whether creation defaults,
+  faster disposition, or bounded triage is the honest lever.
 
 ## 8. What "done" means
 

--- a/docs/specs/undated-action-resurfacer.md
+++ b/docs/specs/undated-action-resurfacer.md
@@ -63,7 +63,7 @@ feature**, not a safeguard bolted to it.
 
 | element | rule |
 |---|---|
-| eligible | `status: pending`, no `dueBy`, priority `high` or `critical` |
+| eligible | `status: pending`, no `dueBy`, priority `high` or `critical`, **including rows carrying an explicit `followThroughOptOutReason`** |
 | selection | **weighted lanes, not strict tiers**: 3 of every 4 runs draw the oldest eligible `critical`; the 4th draws the oldest eligible `high`. A lane with nothing eligible yields to the other. **Plus a max-age override**: any `high` older than 30 days enters the critical lane. Ties by action id. Excludes anything inside its cooldown. |
 | volume | **ONE per run. Never a digest, never a batch.** |
 | cooldown | an action re-surfaced is ineligible for 14 days, recorded durably |
@@ -75,6 +75,18 @@ feature**, not a safeguard bolted to it.
 One-per-run makes a flood **arithmetically impossible** — that part is unconditional, and it is the
 property the bound exists for. A bound that depends on a threshold being tuned correctly fails the
 first time the backlog grows; a bound of one does not.
+
+**The creation-time opt-out is not a resurfacing opt-out.** A recorded
+`followThroughOptOutReason` explains why the author deliberately chose not to assign a due date. It
+does not authorize permanent invisibility, and excluding those rows would create a first-class escape
+hatch around this component. Eligibility therefore ignores that field. This distinction matters for
+NEW actions as much as for the measured stock: the creation gate makes omission explicit, while this
+component keeps the resulting undated row reachable.
+
+**The cadence is durable, not merely a process timer.** The ledger records each run and refuses a new
+one until the four-hour interval has elapsed. Startup, a manual pass, and an overlapping invocation all
+share that same floor. Otherwise a restart loop or a repeatedly called pass endpoint could emit one
+item per process start while still claiming “one per run,” turning a syntactic bound into a flood.
 
 **What it guarantees, stated at the strength it actually has.** Eventual surfacing is NOT
 unconditional. It holds only while: the eligible set is finite and not growing faster than one per
@@ -123,11 +135,13 @@ single attention item at HIGH, subject to the same one-per-run bound and its own
 That is the consumer. It is deliberately one threshold and one item — a second flood surface built to
 watch the first would be absurd.
 
-**Concurrency, designed rather than asserted.** Lease-holder-only (§4) prevents cross-machine
-duplication; it does not prevent two overlapping scheduler invocations on the SAME holder. The claim
-step is therefore a conditional write: the `pending-emit` append succeeds only if no unretired entry
-for that action id exists. A losing racer selects nothing and exits — it does not fall through to the
-next candidate, because a run that emits two rows is no longer one-per-run.
+**Concurrency, designed rather than asserted.** The stable-state-owner + serving-lease conjunction
+(§4) prevents a lease handoff from changing ledger authority; it does not prevent two overlapping
+scheduler processes on that SAME owner. Every reconcile, retry claim, cadence check, selection, and
+`pending-emit` append therefore runs under one inter-process ledger lock. Delivery happens only after
+the lock is released, against the durable claim, and state ownership + serving lease are re-checked
+immediately before the external emit. A losing invocation exits; it does not fall through to the next
+candidate, because a run that emits two rows is no longer one-per-run.
 
 ## 2.1 What it meters — the whole loop, not the raise
 
@@ -158,8 +172,11 @@ actions change status at no better a rate than unraised ones of comparable age a
 component is **not working** and its removal is the correct response — not a tuning pass. A
 re-surfacer that is ignored is a notifier, and this project has enough of those.
 
-**Where it lands:** the existing per-feature metrics surface. No new store — a component this small
-introducing its own observability substrate would be its own incoherence.
+**Where it lands:** fired/no-op/error events use the existing per-feature metrics surface. The health
+read exposes the control ledger's own projection — owner/lease block reason, last attempt, run,
+unexpected run error, pool/cooldown counts, pending/failed/abandoned claims, disposition-alert state,
+per-action raise and age state, and delayed outcomes by status. There is no second observation-only
+store: the same ledger that enforces cooldown is the evidence source.
 
 ## 2.2 The ledger — a state model, not "recorded durably"
 
@@ -185,7 +202,8 @@ mechanism's problem, and two paths must never both own one row).
 
 **Append-only events, derived state — because the table above mixes them.** `raiseCount`,
 `disposition` and retirement are field-LIKE, which an append-only log cannot hold directly. The store
-is an event stream (`raised`, `emitted`, `reset`, `retired`, `disposition-set`); the table above is
+is an event stream (`run`, `pending-emit`, `emitted`, `claim-abandoned`, `reset`, `retired`,
+`disposition-set`, outcome and disposition-alert claim events); the table above is
 the PROJECTION derived by folding those events per action id. The projection may be cached, and it is
 always reconstructible from the events — so a corrupt cache is a rebuild rather than a data loss.
 
@@ -205,12 +223,24 @@ than one run interval is REPLAYED.** When the two failure directions are "says s
 itself about which one it chose.
 
 **"A duplicate is harmless" is an assertion, so it is replaced by a mechanism.** Each raise carries a
-stable idempotency key — `resurface:{actionId}:{raiseCount}` — and the attention queue's existing
-dedupe consumes it, so a replay of an item the queue already accepted collapses rather than appearing
-twice. That matters because the destination is the surface this component exists to protect: an
+stable idempotency key — `resurface:{actionId}:s{series}:{raiseCount}` — and the attention queue's
+existing dedupe consumes it, so a replay of an item the queue already accepted collapses rather than
+appearing twice. A meaningful edit durably increments `series`: its first new raise therefore cannot
+be swallowed by the permanent Attention id from an earlier series. That matters because the
+destination is the surface this component exists to protect: an
 attention queue that amplifies duplicates is the flood failure arriving through the back door.
 **Replay is bounded**: three attempts, then the entry is marked `emit-failed` and counted in the §2.1
-metrics — a poison row must not retry forever, and it must not vanish either.
+metrics — a poison row must not retry forever, and it must not vanish either. The aggregate
+disposition alert uses the same three-attempt terminal and consumes its 14-day cooldown on terminal
+failure; clearing a failed claim must not immediately mint another retry budget for the same unchanged
+aggregate.
+
+**Storage is bounded too.** The active ledger has a hard 4 MiB ceiling, below the repository's
+whole-file synchronous-read limit. The writer refuses before crossing it; it does not truncate an
+un-acted row or rewrite the append-only history. Capacity refusal emits one stable-id HIGH Attention
+item and the health read exposes the byte count, ceiling, and exceeded state. This is deliberately a
+loud stop: silently deleting old cooldown/disposition evidence would let forgotten rows re-enter as
+new, while an unbounded ledger would turn a long-running agent into a slow storage failure.
 
 ## 2.3 Why not `nextReviewAt` on the action itself
 
@@ -258,7 +288,7 @@ of ownership.
 | Decision point | classification |
 |---|---|
 | which actions are eligible | `invariant` — a field test over recorded values, no judgment |
-| which one is selected | `invariant` — oldest `createdAt`, deterministic tie-break by id |
+| which one is selected | `invariant` — the fixed 3:1 critical/high lane schedule plus the 30-day high max-age override, then oldest `createdAt`, with a deterministic tie-break by id |
 | how many per run | `invariant` — exactly one, not tunable |
 | when it stops | `invariant` — 3 re-surfacings, counted durably |
 
@@ -268,25 +298,41 @@ is that its behaviour is completely predictable, so a flood cannot arise from a 
 
 ## 4. Multi-machine posture
 
-**Posture: `machine-local`** — `machine-local-justification: operator-ratified-exception` pending, and
-**this is the spec's one genuinely open design question**, deliberately surfaced rather than answered
-by assertion.
+**Posture: stable-owner machine-local.**
 
-The action store is per-agent, and the re-surfacing cooldown is state about *what this agent has
-already raised*. Two machines re-surfacing from a shared backlog would double-raise unless the
-cooldown replicates.
+machine-local-justification: hardware-bound-resource — the ledger is keyed by that machine's local
+action ids and describes its local EvolutionManager queue; the queue and its cooldown history are one
+owner-bound resource and cannot be moved independently without changing identity.
 
-**DECIDED: option 1 — run on the serving-lease holder only.**
+The controller is allowed to act only when that SAME stable owner also holds the serving lease.
 
-1. **Lease-holder only** ← chosen. No replication, and it inherits an existing single-writer
-   guarantee rather than inventing one. A standby machine runs nothing, so double-raising is
-   impossible by construction rather than by reconciliation.
-2. Replicate the cooldown ledger — correct under partition, and more machinery than a
-   one-row-per-run component justifies.
+**Lease ownership alone is insufficient.** An earlier draft said the current lease holder could own a
+machine-local ledger. After a handoff the new holder has an empty ledger, so its first run can repeat a
+row still cooling down on the old holder and reset the three-raise terminal. Stable Attention ids do
+not repair that: the Attention store is also owner-local, and suppressing one visible duplicate would
+still leave split outcome and terminal state.
 
-**The cost of option 1, stated:** if no machine holds the lease, nothing re-surfaces. That is
-acceptable because a pool with no lease-holder has larger problems than a stale backlog, and the
-`eligible` metric (§2.1) will show the gap rather than hide it.
+**DECIDED: pool-agreed stable ledger owner AND serving lease.** On a multi-machine agent each machine
+advertises its explicit `stateOwnerMachineId` proposal in its authenticated capacity heartbeat. The
+local value is never authority by itself. A pass requires all three predicates:
+
+1. every registered pool member's latest authenticated advert carries the same non-empty owner id;
+2. this machine is that stable ledger owner; and
+3. this machine currently holds the serving lease.
+
+A handoff away from the ledger owner therefore PAUSES resurfacing. A handback resumes from the same
+cooldown, retry, outcome, and disposition history. A non-owner does not create a run event, claim, or
+Attention item. If an advert is missing or two local configs disagree, every machine remains readable
+but refuses with `state-owner-unconfigured`; the health projection includes the agreement posture and
+disagreeing participants. That is an honest coverage gap, not a fresh local ledger. Offline registered
+peers remain in the check through their last authenticated advert: otherwise each side of a partition
+could call its one-member local view "agreement." After a process restart with no last-known peer
+advert, resurfacing pauses until authenticated presence restores it.
+
+**The cost, stated:** this is safe under handoff but not highly available. If the stable owner is
+offline or the lease sits elsewhere, nothing re-surfaces. Reassigning the state owner requires moving
+the ledger with it; automatic owner migration is deliberately not claimed. Replicating this ledger is
+the future path if uninterrupted multi-machine cadence becomes worth the additional protocol.
 
 ## 5. Frontloaded decisions
 
@@ -297,16 +343,17 @@ acceptable because a pool with no lease-holder has larger problems than a stale 
 | 3 | Destination | The existing attention queue at the action's own priority. No new topic, no new surface. |
 | 4 | Cooldown | 14 days, durable. Short enough that a genuinely stuck item returns; long enough that one run cannot chase the same row. |
 | 5 | Stop condition | 3 re-surfacings without a status change, then a single terminal note. |
-| 6 | Authority | None. It never mutates an action. |
+| 6 | Authority | Deterministic delivery-policy authority over eligibility, cadence, and Attention delivery; **no semantic authority** to mutate or dispose an action. |
 | 7 | Rollout | Ships **dark**, then dry-run (logs the row it WOULD raise), then live. The dry-run stage is the real test: it proves the selection is sane against a 581-row backlog before anything is raised. |
+| 8 | Explicit follow-through opt-out | Does **not** affect eligibility. It records why no due date was chosen; it never grants invisibility from the undated-action path. |
 
 ## 6. Open questions
 
 *(none)*
 
-> §4's multi-machine choice was described in an earlier draft as "the spec's one genuinely open
-> question" while this section said none — a straight contradiction. It is now DECIDED in §4 (option 1,
-> lease-holder only), so neither section is parked on anyone.
+> §4's multi-machine choice was described in an earlier draft as "lease-holder only." Adversarial
+> review overturned it because a lease chooses an actor but does not move local cooldown state. The
+> stable-owner + lease conjunction is now the decided v1 posture.
 
 ## 7. Deferred work
 
@@ -330,17 +377,19 @@ acceptable because a pool with no lease-holder has larger problems than a stale 
 | tier | what it must cover here |
 |---|---|
 | **Unit** | the pure selection rule with real inputs: priority-tier-before-age, tie-break by id, cooldown exclusion, count-reset on a non-status edit, terminal transition at the third raise, retirement when a row gains a `dueBy`. |
-| **Integration** | the ledger + emit path end to end: two-phase `pending-emit` → emit → confirm, replay of a `pending-emit` left by a simulated crash, the conditional-write claim under two overlapping runs, and the `needs-disposition` threshold raising exactly one item. |
-| **E2E lifecycle** | the production initialization path — the component is CONSTRUCTED, wired to the real action store and the real attention queue, and a run selects and raises against them. **This is the tier that would have caught a reaper reporting "0 reclaimable" beside 39GB**, because it is the only one that proves the thing is reachable rather than merely correct. |
+| **Integration** | the ledger + emit path end to end: two-phase `pending-emit` → emit → confirm, replay of a `pending-emit` left by a simulated crash, the conditional-write claim under two overlapping runs, the `needs-disposition` threshold raising exactly one item, a reset through the real `TelegramAdapter` dedupe store, and a growth burst proving the file refuses at its byte ceiling without truncation. |
+| **E2E lifecycle** | the production initialization path — the component is CONSTRUCTED, wired to the real action-store implementation and the production Attention delegation seam, and a run selects and delegates a raise. The external Telegram transport is deliberately replaced by a capture adapter in this tier; real Attention persistence/dedupe semantics are covered by integration, while live transport evidence remains a rollout gate. **This is the tier that would have caught a reaper reporting "0 reclaimable" beside 39GB**, because it proves the thing is reachable rather than merely correct. |
 
 **Wiring integrity is required explicitly**, per the same standard: assert the injected action-store
 reader and attention emitter are neither null nor no-ops and delegate to the real implementations. A
 component whose emitter is a stub passes every unit and integration test above while raising nothing —
 the exact shape this whole spec exists to prevent, reproduced inside its own test suite.
 
-**2. Live evidence** — a command and its output showing a specific, real, previously-invisible action
-raised. The two cases in §0 are the natural candidates: both undated, both old, both demonstrably
-unreachable before.
+**2. Live evidence — required for rollout completion, not claimed by a draft code PR.** A command and
+its output must show a specific, real, previously-invisible action raised. The two cases in §0 are the
+natural candidates: both undated, both old, both demonstrably unreachable before. Until the dark →
+dry-run → live maturation reaches that observation, the implementation may be code-complete and under
+draft review, but the feature is not "done" under this section.
 
 **Why both, stated because picking one is the tempting shortcut:** a fixture test proves the logic is
 what I wrote down; it cannot prove the component is reachable, wired, and pointed at the real store —

--- a/site/src/content/docs/reference/api.md
+++ b/site/src/content/docs/reference/api.md
@@ -73,6 +73,8 @@ The Instar server exposes a REST API on `localhost:4040` (configurable). All end
 | GET | `/evolution/actions` | List action items |
 | POST | `/evolution/actions` | Create an action item |
 | GET | `/evolution/actions/overdue` | List overdue actions |
+| GET | `/evolution/actions/undated-resurfacer` | Read the bounded undated-action resurfacer's health and durable cadence state |
+| POST | `/evolution/actions/undated-resurfacer/pass` | Trigger one authenticated pass without bypassing its durable cadence floor |
 | PATCH | `/evolution/actions/:id` | Update action status |
 
 ## Memory & Search

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -19812,7 +19812,7 @@ export async function startServer(options: StartOptions): Promise<void> {
                 // WS1.1 capability advertisement (spec invariant 5): a bounded
                 // fixed-size summary, never an inventory. Reported live each
                 // heartbeat so a queue going dark withdraws the capability.
-                seamlessnessFlags: { ws11DeliverReceive: !!_inboundQueue, ws12DrainReceive: !!_drainRunner, ws44PoolLinks: !!_poolLink, ws44PoolCache: !!_poolPollCache, ws43JournalLease: resolveDevAgentGate(config.multiMachine?.seamlessness?.ws43JournalLease, config) && (config.multiMachine?.seamlessness?.ws43JournalLeaseDryRun ?? !resolveDevAgentGate(undefined, config)) !== true, stateSyncReceive: selfStateSyncReceive() },
+                seamlessnessFlags: { ws11DeliverReceive: !!_inboundQueue, ws12DrainReceive: !!_drainRunner, ws44PoolLinks: !!_poolLink, ws44PoolCache: !!_poolPollCache, ws43JournalLease: resolveDevAgentGate(config.multiMachine?.seamlessness?.ws43JournalLease, config) && (config.multiMachine?.seamlessness?.ws43JournalLeaseDryRun ?? !resolveDevAgentGate(undefined, config)) !== true, stateSyncReceive: selfStateSyncReceive(), undatedActionStateOwnerMachineId: config.evolutionActions?.undatedResurfacer?.stateOwnerMachineId?.trim() || null },
                 // Machine-coherence advert (machine-coherence-guard §3.2).
                 // Emission is UNCONDITIONAL (M3, normative): it ships live with
                 // the code, regardless of the sentinel's dev-gate/enabled/dryRun

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -989,6 +989,21 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       sweepIntervalMs: 21600000,
       dryRun: true,
     },
+    // Reaches the high/critical actions the dated overdue checker cannot see.
+    // `enabled` is intentionally omitted: resolveDevAgentGate makes the
+    // development agent the soak surface while the fleet stays dark. Emission
+    // remains dry-run-first until an explicit promotion. On a multi-machine
+    // agent, an explicit owner proposal must agree across every registered pool
+    // member's latest authenticated heartbeat; absence or disagreement blocks.
+    undatedResurfacer: {
+      dryRun: true,
+      runIntervalMs: 14_400_000,
+      cooldownMs: 1_209_600_000,
+      maxHighAgeMs: 2_592_000_000,
+      maxRaises: 3,
+      dispositionThreshold: 10,
+      maxLedgerBytes: 4_194_304,
+    },
   },
   // Spec-review standards-conformance gate (rung-3 normative slice). Default-on:
   // the gate reads docs/STANDARDS-REGISTRY.md and signals possible standard

--- a/src/core/devGatedFeatures.ts
+++ b/src/core/devGatedFeatures.ts
@@ -44,6 +44,12 @@ export interface DevGatedFeature {
 
 export const DEV_GATED_FEATURES: DevGatedFeature[] = [
   {
+    name: 'undatedActionResurfacer',
+    configPath: 'evolutionActions.undatedResurfacer.enabled',
+    description: 'Bounded resurfacing for pending high/critical evolution actions that have no due date.',
+    justification: 'Ships dryRun:true: the development agent exercises the real action-store selection, durable ledger, pool-agreed-state-owner + serving-lease gate, and metrics while emitting no Attention item. A handoff away from the ledger owner pauses rather than resetting cooldown state; missing or divergent latest authenticated owner adverts from any registered peer refuse visibly. Live mode is structurally capped at one idempotent item per four-hour run with a 14-day per-row cooldown and three-raise terminal disposition rung; no LLM, spend, action mutation, or unbounded retry.',
+  },
+  {
     name: 'feedbackFactoryProcessing',
     configPath: 'feedbackFactory.processing.enabled',
     description: 'Canonical feedback clustering pass over the operated store.',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2231,7 +2231,7 @@ export interface MachineCapacity {
    *  non-participant for every gated workstream (the conservative side —
    *  senders never forward to a peer that cannot durably receive; the journal
    *  applier's silently-drop-unknown-kinds behavior is the named skew-failure
-   *  mode this gate prevents). Fixed-size booleans only — never an inventory. */
+   *  mode this gate prevents). Fixed-size values only — never an inventory. */
   seamlessnessFlags?: {
     /** This machine can durably RECEIVE forwarded inbound messages (the
      *  'deliverMessage' receiver handler + live durable queue). */
@@ -2260,6 +2260,11 @@ export interface MachineCapacity {
      *  Advertised only when the dark ws44PoolCache flag resolved on; ABSENT/false
      *  → the surfaces fan out per-route (today's behavior). */
     ws44PoolCache?: boolean;
+    /** Proposed stable owner for the undated-action cooldown ledger. This is
+     *  NOT authority by itself: the controller engages only when every registered
+     *  pool member's latest authenticated heartbeat advertises the same machine id. `null`
+     *  means deliberately unconfigured and therefore fail-closed. */
+    undatedActionStateOwnerMachineId?: string | null;
     /** WS2 replicated-store foundation (§10.2 capability advert). Per-store
      *  receive capability: `stateSyncReceive[store] === true` means this machine
      *  can durably RECEIVE + apply that store's replicated journal kind. ABSENT
@@ -3386,6 +3391,27 @@ export interface InstarConfig {
   };
   evolutionActions?: {
     autoExpiry?: EvolutionManagerConfig['autoExpiry'];
+    /**
+     * Bounded resurfacing for pending high/critical actions with no dueBy.
+     * `enabled` is dev-gated when omitted; user-facing emission remains
+     * dry-run-first until deliberately promoted.
+     */
+    undatedResurfacer?: {
+      enabled?: boolean;
+      dryRun?: boolean;
+      runIntervalMs?: number;
+      cooldownMs?: number;
+      maxHighAgeMs?: number;
+      maxRaises?: number;
+      dispositionThreshold?: number;
+      maxLedgerBytes?: number;
+      /**
+       * Proposed stable owner of the machine-local cooldown ledger on a
+       * multi-machine agent. Every registered pool member's latest authenticated
+       * advert must carry the same proposal; absence or disagreement fails closed.
+       */
+      stateOwnerMachineId?: string;
+    };
   };
   /**
    * Apprenticeship-program gates (docs/specs/framework-stall-coverage-matrix.md

--- a/src/data/state-coherence-registry.json
+++ b/src/data/state-coherence-registry.json
@@ -5,6 +5,25 @@
   "sourceDoc": "docs/specs/STATE-COHERENCE-REGISTRY.md",
   "entries": [
     {
+      "category": "undated-action-resurfacer-ledger",
+      "description": "Pool-agreed stable-owner event ledger for undated high/critical action cooldown, delivery claims, outcome observation, and terminal disposition. It is keyed to one machine's local action-id namespace and may act only when every registered pool member's latest authenticated advert agrees on that owner and the same owner holds the serving lease; missing or divergent adverts and handoffs away pause instead of starting a fresh ledger.",
+      "scope": "machine-local",
+      "freshness": "live",
+      "conflictShape": "append-only",
+      "transport": "none",
+      "paths": [
+        "state/undated-action-resurfacer.jsonl"
+      ],
+      "grandfathered": false,
+      "retention": {
+        "class": "fixed-byte-ceiling",
+        "access": "whole-sync",
+        "maxBytes": 4194304,
+        "keepSegments": 0,
+        "note": "The writer refuses before crossing 4 MiB and emits one stable-id HIGH Attention item instead of dropping an unacted action or rewriting the append-only history. At this ceiling whole-file reads remain below the repository's 8 MiB synchronous-read limit."
+      }
+    },
+    {
       "category": "worktree-enumeration-failure-history",
       "description": "Restart-surviving failure count and last-failure time for the two local worktree guards; the current pass outcome intentionally remains process-local.",
       "scope": "machine-local",

--- a/src/monitoring/UndatedActionResurfacer.ts
+++ b/src/monitoring/UndatedActionResurfacer.ts
@@ -1,0 +1,892 @@
+/**
+ * UndatedActionResurfacer — bounded reach for the evolution-action backlog.
+ *
+ * The existing overdue checker can only see actions with `dueBy`. This component
+ * deliberately owns the complementary population: pending, high/critical actions
+ * with no due date. It emits at most ONE Attention item per run and never mutates
+ * the action itself.
+ *
+ * Durable state is an append-only event stream owned by one pool-agreed stable
+ * machine. That owner may act only while it also holds the serving lease. A
+ * `pending-emit` claim
+ * is written under an inter-process lock before Attention delivery; overlapping
+ * invocations therefore see the claim and select nothing. Delivery uses a stable
+ * idempotency key, then appends `emitted`. A crash on either side is replayed,
+ * bounded to three attempts, without silently losing the row.
+ */
+/* @self-action-controller: undated-action-resurfacer */
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import lockfile from 'proper-lockfile';
+import type { ActionItem } from '../core/types.js';
+
+export interface UndatedActionAttention {
+  id: string;
+  title: string;
+  summary: string;
+  description: string;
+  category: string;
+  priority: 'URGENT' | 'HIGH' | 'NORMAL' | 'LOW';
+  sourceContext: string;
+}
+
+export interface UndatedActionResurfacerConfig {
+  enabled: boolean;
+  dryRun: boolean;
+  runIntervalMs?: number;
+  cooldownMs?: number;
+  maxHighAgeMs?: number;
+  maxRaises?: number;
+  dispositionThreshold?: number;
+  maxLedgerBytes?: number;
+}
+
+export interface UndatedActionResurfacerDeps {
+  stateDir: string;
+  listActions: () => ActionItem[];
+  emitAttention: (item: UndatedActionAttention) => Promise<unknown>;
+  holdsLease: () => boolean;
+  /**
+   * The cooldown ledger has one stable machine owner. On a multi-machine agent,
+   * a serving-lease handoff must pause this controller unless the lease lands on
+   * that owner; otherwise the new holder would start from an empty local ledger
+   * and silently reset cooldown/raise-count state.
+   */
+  stateAuthority?: () => UndatedActionStateAuthority;
+  recordMetric?: (outcome: 'fired' | 'noop' | 'error', verdictId?: string) => void;
+  now?: () => number;
+}
+
+export interface UndatedActionStateAuthority {
+  mode: 'single-machine' | 'stable-owner' | 'unconfigured';
+  selfMachineId: string;
+  ownerMachineId: string | null;
+  ownsState: boolean;
+  agreement?: 'single-machine' | 'pool-agreed' | 'missing' | 'disagreed';
+  participantMachineIds?: string[];
+  disagreeingMachineIds?: string[];
+}
+
+export interface UndatedActionOwnerAdvert {
+  machineId: string;
+  online: boolean;
+  proposedOwnerMachineId?: string | null;
+}
+
+/**
+ * A local config value is only a proposal. It becomes authority after every
+ * registered pool member's latest authenticated advert carries the same value.
+ * Missing or divergent adverts fail closed, which prevents two machines with
+ * divergent local config from each treating their empty local ledger as canonical.
+ */
+export function resolveUndatedActionStateAuthority(
+  selfMachineId: string,
+  proposedOwnerMachineId: string | null | undefined,
+  pool: UndatedActionOwnerAdvert[],
+): UndatedActionStateAuthority {
+  // Deliberately include offline registered peers. If each side of a partition
+  // considered only its locally-online set, two divergent configs could each
+  // declare a one-member "agreement." A last-known advert is safe for this
+  // stable binding; a peer with no received advert keeps the feature paused.
+  const participants = pool;
+  const participantMachineIds = participants.map((machine) => machine.machineId).sort();
+  const proposed = proposedOwnerMachineId?.trim() || null;
+  const selfPresent = participants.some((machine) => machine.machineId === selfMachineId);
+  const ownerKnown = proposed !== null && pool.some((machine) => machine.machineId === proposed);
+  const missing = participants.filter((machine) => !machine.proposedOwnerMachineId).map((machine) => machine.machineId);
+  const disagreed = proposed
+    ? participants.filter((machine) => machine.proposedOwnerMachineId && machine.proposedOwnerMachineId !== proposed).map((machine) => machine.machineId)
+    : [];
+  if (!proposed || !selfPresent || !ownerKnown || missing.length > 0) {
+    return {
+      mode: 'unconfigured', selfMachineId, ownerMachineId: null, ownsState: false,
+      agreement: 'missing', participantMachineIds,
+      disagreeingMachineIds: [...new Set([...missing, ...(!selfPresent ? [selfMachineId] : [])])].sort(),
+    };
+  }
+  if (disagreed.length > 0) {
+    return {
+      mode: 'unconfigured', selfMachineId, ownerMachineId: null, ownsState: false,
+      agreement: 'disagreed', participantMachineIds, disagreeingMachineIds: disagreed.sort(),
+    };
+  }
+  return {
+    mode: 'stable-owner', selfMachineId, ownerMachineId: proposed,
+    ownsState: selfMachineId === proposed,
+    agreement: 'pool-agreed', participantMachineIds, disagreeingMachineIds: [],
+  };
+}
+
+type ObservedAction = {
+  status: ActionItem['status'];
+  priority: ActionItem['priority'];
+  dueBy: string | null;
+  createdAt: string;
+  contentSha256: string;
+};
+
+type LedgerEvent =
+  | { type: 'run'; at: string; runIndex: number; dryRun: boolean; eligible: number; skippedCooldown: number; selectedActionId: string | null }
+  | { type: 'pending-emit'; at: string; claimId: string; actionId: string; series: number; raiseCount: number; idempotencyKey: string; attempt: number; observed: ObservedAction }
+  | { type: 'emit-attempt-failed'; at: string; claimId: string; attempt: number; error: string }
+  | { type: 'emitted'; at: string; claimId: string }
+  | { type: 'emit-failed'; at: string; claimId: string; attempts: number }
+  | { type: 'claim-abandoned'; at: string; claimId: string; actionId: string; reason: 'missing' | 'left-pending' | 'dated' | 'priority-changed' | 'content-changed' }
+  | { type: 'reset'; at: string; actionId: string; series: number; observed: ObservedAction }
+  | { type: 'retired'; at: string; actionId: string; reason: 'left-pending' | 'dated' | 'missing' }
+  | { type: 'disposition-set'; at: string; actionId: string }
+  | { type: 'pending-disposition-alert'; at: string; claimId: string; idempotencyKey: string; count: number; attempt: number }
+  | { type: 'disposition-alert-attempt-failed'; at: string; claimId: string; attempt: number; error: string }
+  | { type: 'disposition-alert-emitted'; at: string; claimId: string; idempotencyKey: string; count: number }
+  | { type: 'disposition-alert-failed'; at: string; claimId: string; attempts: number }
+  | { type: 'outcome-observed'; at: string; actionId: string; claimId: string; statusAtRaise: ActionItem['status']; statusAt14d: ActionItem['status'] | 'missing' };
+
+export interface UndatedActionProjection {
+  actionId: string;
+  series: number;
+  firstRaisedAt: string | null;
+  lastRaisedAt: string | null;
+  lastEngagedAt: string | null;
+  raiseCount: number;
+  disposition: 'needs-disposition' | null;
+  observed: ObservedAction | null;
+  pendingClaim: Extract<LedgerEvent, { type: 'pending-emit' }> | null;
+  failedClaim: boolean;
+  retired: boolean;
+  outcomeObservedClaims: Set<string>;
+}
+
+export interface UndatedActionRunResult {
+  ran: boolean;
+  reason?: 'disabled' | 'state-owner-unconfigured' | 'not-state-owner' | 'not-lease-holder' | 'authority-lost' | 'overlap' | 'cadence' | 'ledger-capacity' | 'ledger-confirm-failed' | 'no-eligible' | 'dry-run' | 'emitted' | 'emit-failed' | 'replayed' | 'disposition-alert';
+  eligible: number;
+  skippedCooldown: number;
+  selectedActionId: string | null;
+  wouldEmit?: UndatedActionAttention;
+}
+
+export interface UndatedActionResurfacerStatus {
+  enabled: boolean;
+  dryRun: boolean;
+  operational: boolean;
+  blockedReason: 'disabled' | 'state-owner-unconfigured' | 'not-state-owner' | 'not-lease-holder' | null;
+  stateAuthority: UndatedActionStateAuthority;
+  holdsLease: boolean;
+  ledgerReadable: boolean;
+  ledgerError: string | null;
+  lastRunError: string | null;
+  runIntervalMs: number;
+  cooldownMs: number;
+  totalRuns: number;
+  lastRun: Extract<LedgerEvent, { type: 'run' }> | null;
+  pendingClaims: number;
+  failedClaims: number;
+  abandonedClaims: number;
+  pendingDispositionAlerts: number;
+  failedDispositionAlerts: number;
+  needsDisposition: number;
+  raisedActions: number;
+  outcomesObserved: number;
+  outcomesByStatus: Record<string, number>;
+  lastOutcome: Extract<LedgerEvent, { type: 'outcome-observed' }> | null;
+  actionStates: Array<{
+    actionId: string;
+    firstRaisedAt: string | null;
+    lastRaisedAt: string | null;
+    ageAtFirstRaiseDays: number | null;
+    raiseCount: number;
+    disposition: UndatedActionProjection['disposition'];
+    pendingClaim: boolean;
+    failedClaim: boolean;
+    retired: boolean;
+    lastOutcomeStatus: ActionItem['status'] | 'missing' | null;
+  }>;
+  lastAttempt: { at: string; ran: boolean; reason: UndatedActionRunResult['reason'] | 'run-error' } | null;
+  ledgerBytes: number;
+  maxLedgerBytes: number;
+  capacityExceeded: boolean;
+}
+
+const DEFAULT_INTERVAL_MS = 4 * 60 * 60_000;
+const DEFAULT_COOLDOWN_MS = 14 * 24 * 60 * 60_000;
+const DEFAULT_MAX_HIGH_AGE_MS = 30 * 24 * 60 * 60_000;
+const DEFAULT_MAX_RAISES = 3;
+const DEFAULT_DISPOSITION_THRESHOLD = 10;
+const DEFAULT_MAX_LEDGER_BYTES = 4 * 1024 * 1024;
+const LOCK_OPTIONS = { stale: 30_000, retries: { retries: 3, factor: 1, minTimeout: 20, maxTimeout: 50 } } as const;
+
+function iso(ms: number): string { return new Date(ms).toISOString(); }
+
+class LedgerCapacityError extends Error {
+  constructor() { super('undated-action-resurfacer-ledger-capacity'); }
+}
+
+function actionContentSha(action: ActionItem): string {
+  return crypto.createHash('sha256')
+    .update(JSON.stringify([action.title, action.description, action.commitTo ?? null, action.tags ?? []]))
+    .digest('hex');
+}
+
+function observe(action: ActionItem): ObservedAction {
+  return {
+    status: action.status,
+    priority: action.priority,
+    dueBy: action.dueBy ?? null,
+    createdAt: action.createdAt,
+    contentSha256: actionContentSha(action),
+  };
+}
+
+function sameObserved(a: ObservedAction | null, b: ObservedAction): boolean {
+  return !!a && a.status === b.status && a.priority === b.priority && a.dueBy === b.dueBy && a.createdAt === b.createdAt && a.contentSha256 === b.contentSha256;
+}
+
+function emptyProjection(actionId: string): UndatedActionProjection {
+  return {
+    actionId,
+    series: 1,
+    firstRaisedAt: null,
+    lastRaisedAt: null,
+    lastEngagedAt: null,
+    raiseCount: 0,
+    disposition: null,
+    observed: null,
+    pendingClaim: null,
+    failedClaim: false,
+    retired: false,
+    outcomeObservedClaims: new Set(),
+  };
+}
+
+export function foldUndatedActionEvents(events: LedgerEvent[]): {
+  runs: Array<Extract<LedgerEvent, { type: 'run' }>>;
+  actions: Map<string, UndatedActionProjection>;
+  lastDispositionAlertAt: string | null;
+  pendingDispositionAlert: Extract<LedgerEvent, { type: 'pending-disposition-alert' }> | null;
+} {
+  const runs: Array<Extract<LedgerEvent, { type: 'run' }>> = [];
+  const actions = new Map<string, UndatedActionProjection>();
+  const claims = new Map<string, Extract<LedgerEvent, { type: 'pending-emit' }>>();
+  let lastDispositionAlertAt: string | null = null;
+  let pendingDispositionAlert: Extract<LedgerEvent, { type: 'pending-disposition-alert' }> | null = null;
+  const get = (id: string): UndatedActionProjection => {
+    const existing = actions.get(id);
+    if (existing) return existing;
+    const made = emptyProjection(id);
+    actions.set(id, made);
+    return made;
+  };
+  for (const event of events) {
+    if (event.type === 'run') { runs.push(event); continue; }
+    if (event.type === 'pending-disposition-alert') { pendingDispositionAlert = event; continue; }
+    if (event.type === 'disposition-alert-emitted') {
+      lastDispositionAlertAt = event.at;
+      if (pendingDispositionAlert?.claimId === event.claimId) pendingDispositionAlert = null;
+      continue;
+    }
+    if (event.type === 'disposition-alert-failed') {
+      // A terminal transport failure must consume the aggregate alert's cooldown
+      // just like a successful delivery. Otherwise clearing the pending claim
+      // makes the same unchanged aggregate immediately eligible for a fresh
+      // three-attempt claim, turning a bounded retry into an endless loop.
+      lastDispositionAlertAt = event.at;
+      if (pendingDispositionAlert?.claimId === event.claimId) pendingDispositionAlert = null;
+      continue;
+    }
+    if (event.type === 'disposition-alert-attempt-failed') continue;
+    if (event.type === 'pending-emit') {
+      const p = get(event.actionId);
+      p.pendingClaim = event;
+      p.failedClaim = false;
+      p.observed = event.observed;
+      p.retired = false;
+      claims.set(event.claimId, event);
+      continue;
+    }
+    if (event.type === 'reset') {
+      const p = get(event.actionId);
+      p.series = event.series;
+      p.firstRaisedAt = null;
+      p.lastRaisedAt = null;
+      p.lastEngagedAt = event.at;
+      p.raiseCount = 0;
+      p.disposition = null;
+      p.observed = event.observed;
+      p.pendingClaim = null;
+      p.failedClaim = false;
+      p.retired = false;
+      continue;
+    }
+    if (event.type === 'retired') {
+      const p = get(event.actionId);
+      p.retired = true;
+      p.pendingClaim = null;
+      continue;
+    }
+    if (event.type === 'disposition-set') {
+      get(event.actionId).disposition = 'needs-disposition';
+      continue;
+    }
+    if (event.type === 'outcome-observed') {
+      get(event.actionId).outcomeObservedClaims.add(event.claimId);
+      continue;
+    }
+    if (event.type === 'claim-abandoned') {
+      const p = get(event.actionId);
+      if (p.pendingClaim?.claimId === event.claimId) p.pendingClaim = null;
+      continue;
+    }
+    const claim = claims.get(event.claimId);
+    if (!claim) continue;
+    const p = get(claim.actionId);
+    if (event.type === 'emitted') {
+      p.pendingClaim = null;
+      p.failedClaim = false;
+      p.firstRaisedAt ??= event.at;
+      p.lastRaisedAt = event.at;
+      p.lastEngagedAt = event.at;
+      p.raiseCount = Math.max(p.raiseCount, claim.raiseCount);
+      p.observed = claim.observed;
+    } else if (event.type === 'emit-failed') {
+      p.pendingClaim = null;
+      p.failedClaim = true;
+    }
+  }
+  return { runs, actions, lastDispositionAlertAt, pendingDispositionAlert };
+}
+
+export function selectUndatedAction(
+  actions: ActionItem[],
+  projections: Map<string, UndatedActionProjection>,
+  runIndex: number,
+  nowMs: number,
+  cooldownMs = DEFAULT_COOLDOWN_MS,
+  maxHighAgeMs = DEFAULT_MAX_HIGH_AGE_MS,
+): { selected: ActionItem | null; eligible: number; skippedCooldown: number } {
+  let skippedCooldown = 0;
+  const eligible: ActionItem[] = [];
+  for (const action of actions) {
+    if (action.status !== 'pending' || action.dueBy || !['high', 'critical'].includes(action.priority)) continue;
+    const p = projections.get(action.id);
+    if (p?.pendingClaim || p?.failedClaim || p?.disposition === 'needs-disposition') continue;
+    const anchor = p?.lastEngagedAt ? Date.parse(p.lastEngagedAt) : 0;
+    if (anchor && nowMs - anchor < cooldownMs) { skippedCooldown += 1; continue; }
+    eligible.push(action);
+  }
+  const lane = runIndex % 4 === 0 ? 'high' : 'critical';
+  const isAgedHigh = (a: ActionItem) => a.priority === 'high' && nowMs - Date.parse(a.createdAt) >= maxHighAgeMs;
+  const critical = eligible.filter((a) => a.priority === 'critical' || isAgedHigh(a));
+  const high = eligible.filter((a) => a.priority === 'high' && !isAgedHigh(a));
+  const pool = lane === 'critical' ? (critical.length ? critical : high) : (high.length ? high : critical);
+  pool.sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt) || a.id.localeCompare(b.id));
+  return { selected: pool[0] ?? null, eligible: eligible.length, skippedCooldown };
+}
+
+export class UndatedActionResurfacer {
+  private readonly ledgerPath: string;
+  private readonly lockTarget: string;
+  private readonly now: () => number;
+  private readonly intervalMs: number;
+  private readonly cooldownMs: number;
+  private readonly maxHighAgeMs: number;
+  private readonly maxRaises: number;
+  private readonly dispositionThreshold: number;
+  private readonly maxLedgerBytes: number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private inFlight = false;
+  private lastLedgerError: string | null = null;
+  private lastRunError: string | null = null;
+  private capacityHit = false;
+  private lastAttempt: UndatedActionResurfacerStatus['lastAttempt'] = null;
+
+  constructor(private readonly config: UndatedActionResurfacerConfig, private readonly deps: UndatedActionResurfacerDeps) {
+    this.now = deps.now ?? (() => Date.now());
+    this.intervalMs = Math.max(60_000, config.runIntervalMs ?? DEFAULT_INTERVAL_MS);
+    this.cooldownMs = Math.max(60_000, config.cooldownMs ?? DEFAULT_COOLDOWN_MS);
+    this.maxHighAgeMs = Math.max(60_000, config.maxHighAgeMs ?? DEFAULT_MAX_HIGH_AGE_MS);
+    this.maxRaises = Math.max(1, config.maxRaises ?? DEFAULT_MAX_RAISES);
+    this.dispositionThreshold = Math.max(1, config.dispositionThreshold ?? DEFAULT_DISPOSITION_THRESHOLD);
+    this.maxLedgerBytes = Math.max(1_024, config.maxLedgerBytes ?? DEFAULT_MAX_LEDGER_BYTES);
+    const dir = path.join(deps.stateDir, 'state');
+    fs.mkdirSync(dir, { recursive: true });
+    this.ledgerPath = path.join(dir, 'undated-action-resurfacer.jsonl');
+    this.lockTarget = path.join(dir, 'undated-action-resurfacer.lock-target');
+    if (!fs.existsSync(this.ledgerPath)) fs.writeFileSync(this.ledgerPath, '', { mode: 0o600 });
+    if (!fs.existsSync(this.lockTarget)) fs.writeFileSync(this.lockTarget, '', { mode: 0o600 });
+  }
+
+  start(): void {
+    if (!this.config.enabled || this.timer) return;
+    void this.run().catch(() => undefined);
+    this.timer = setInterval(() => { void this.run().catch(() => undefined); }, this.intervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  private stateAuthority(): UndatedActionStateAuthority {
+    try {
+      return this.deps.stateAuthority?.() ?? {
+        mode: 'single-machine',
+        selfMachineId: 'single-machine',
+        ownerMachineId: 'single-machine',
+        ownsState: true,
+      };
+    } catch {
+      return {
+        mode: 'unconfigured',
+        selfMachineId: 'unknown',
+        ownerMachineId: null,
+        ownsState: false,
+      };
+    }
+  }
+
+  private leaseHeld(): boolean {
+    try { return this.deps.holdsLease(); } catch { return false; }
+  }
+
+  private authorityBlock(): 'state-owner-unconfigured' | 'not-state-owner' | 'not-lease-holder' | null {
+    const authority = this.stateAuthority();
+    if (authority.mode === 'unconfigured' || !authority.ownerMachineId) return 'state-owner-unconfigured';
+    if (!authority.ownsState) return 'not-state-owner';
+    if (!this.leaseHeld()) return 'not-lease-holder';
+    return null;
+  }
+
+  private complete(result: UndatedActionRunResult): UndatedActionRunResult {
+    this.lastRunError = null;
+    this.lastAttempt = { at: iso(this.now()), ran: result.ran, reason: result.reason };
+    return result;
+  }
+
+  private async withLedgerLock<T>(fn: () => T | Promise<T>): Promise<T> {
+    const release = await lockfile.lock(this.lockTarget, LOCK_OPTIONS);
+    try { return await fn(); } finally { await release(); }
+  }
+
+  private readEvents(): LedgerEvent[] {
+    try {
+      const text = fs.readFileSync(this.ledgerPath, 'utf8');
+      const events: LedgerEvent[] = [];
+      for (const line of text.split('\n')) {
+        if (!line.trim()) continue;
+        events.push(JSON.parse(line) as LedgerEvent);
+      }
+      this.lastLedgerError = null;
+      return events;
+    } catch (err) {
+      this.lastLedgerError = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+  }
+
+  private append(event: LedgerEvent): void {
+    const line = `${JSON.stringify(event)}\n`;
+    if (fs.statSync(this.ledgerPath).size + Buffer.byteLength(line, 'utf8') > this.maxLedgerBytes) {
+      this.capacityHit = true;
+      throw new LedgerCapacityError();
+    }
+    fs.appendFileSync(this.ledgerPath, line, { encoding: 'utf8', mode: 0o600 });
+  }
+
+  private capacityAlert(): UndatedActionAttention {
+    return {
+      id: 'undated-actions:ledger-capacity',
+      title: 'Undated-action resurfacing paused at its storage ceiling',
+      summary: 'The bounded resurfacing ledger reached its byte ceiling, so the component stopped before losing or corrupting actionable state.',
+      description: 'Review and compact the undated-action resurfacing ledger before resuming this cadence. No action was mutated or silently dropped.',
+      category: 'evolution-action-resurfacing',
+      priority: 'HIGH',
+      sourceContext: 'undated-action-resurfacer',
+    };
+  }
+
+  private attentionFor(action: ActionItem, series: number, raiseCount: number): UndatedActionAttention {
+    const ageDays = Math.max(0, Math.floor((this.now() - Date.parse(action.createdAt)) / 86_400_000));
+    return {
+      id: `resurface:${action.id}:s${series}:${raiseCount}`,
+      title: `Undated action needs review: ${action.id}`,
+      summary: `${action.id} has remained ${action.priority} and undated for ${ageDays} day${ageDays === 1 ? '' : 's'}: ${action.title}`,
+      description: `Priority: ${action.priority}\nAge: ${ageDays} days\nAction: ${action.title}\n\nThis is informational. Work it, cancel it with a reason, give it a due date, or split it if it is too large to move.`,
+      category: 'evolution-action-resurfacing',
+      priority: action.priority === 'critical' ? 'URGENT' : 'HIGH',
+      sourceContext: 'undated-action-resurfacer',
+    };
+  }
+
+  private async emitClaim(claim: Extract<LedgerEvent, { type: 'pending-emit' }>, action: ActionItem, replayed: boolean): Promise<UndatedActionRunResult> {
+    if (this.authorityBlock() !== null) {
+      this.deps.recordMetric?.('noop', action.id);
+      return this.complete({ ran: false, reason: 'authority-lost', eligible: 1, skippedCooldown: 0, selectedActionId: action.id });
+    }
+    const item = { ...this.attentionFor(action, claim.series, claim.raiseCount), id: claim.idempotencyKey };
+    try {
+      await this.deps.emitAttention(item);
+    } catch (err) {
+      const attempt = claim.attempt;
+      const at = iso(this.now());
+      await this.withLedgerLock(() => {
+        this.append({ type: 'emit-attempt-failed', at, claimId: claim.claimId, attempt, error: err instanceof Error ? err.message.slice(0, 300) : String(err).slice(0, 300) });
+        if (attempt >= 3) this.append({ type: 'emit-failed', at, claimId: claim.claimId, attempts: attempt });
+      });
+      this.deps.recordMetric?.('error', action.id);
+      return this.complete({ ran: true, reason: 'emit-failed', eligible: 1, skippedCooldown: 0, selectedActionId: action.id });
+    }
+    try {
+      const at = iso(this.now());
+      await this.withLedgerLock(() => {
+        this.append({ type: 'emitted', at, claimId: claim.claimId });
+        if (claim.raiseCount >= this.maxRaises) this.append({ type: 'disposition-set', at, actionId: action.id });
+      });
+      this.deps.recordMetric?.('fired', action.id);
+      return this.complete({ ran: true, reason: replayed ? 'replayed' : 'emitted', eligible: 1, skippedCooldown: 0, selectedActionId: action.id });
+    } catch (err) {
+      this.lastLedgerError = err instanceof Error ? err.message : String(err);
+      this.deps.recordMetric?.('error', action.id);
+      return this.complete({ ran: true, reason: 'ledger-confirm-failed', eligible: 1, skippedCooldown: 0, selectedActionId: action.id });
+    }
+  }
+
+  private preparePendingReplay(events: LedgerEvent[], actions: ActionItem[]): {
+    claim: Extract<LedgerEvent, { type: 'pending-emit' }>;
+    action: ActionItem;
+  } | null {
+    const folded = foldUndatedActionEvents(events);
+    const nowMs = this.now();
+    for (const p of folded.actions.values()) {
+      const claim = p.pendingClaim;
+      if (!claim || nowMs - Date.parse(claim.at) < this.intervalMs) continue;
+      const action = actions.find((a) => a.id === claim.actionId);
+      if (!action) {
+        this.append({ type: 'claim-abandoned', at: iso(nowMs), claimId: claim.claimId, actionId: claim.actionId, reason: 'missing' });
+        this.append({ type: 'retired', at: iso(nowMs), actionId: claim.actionId, reason: 'missing' });
+        continue;
+      }
+      if (action.status !== 'pending') {
+        this.append({ type: 'claim-abandoned', at: iso(nowMs), claimId: claim.claimId, actionId: claim.actionId, reason: 'left-pending' });
+        this.append({ type: 'retired', at: iso(nowMs), actionId: claim.actionId, reason: 'left-pending' });
+        continue;
+      }
+      if (action.dueBy) {
+        this.append({ type: 'claim-abandoned', at: iso(nowMs), claimId: claim.claimId, actionId: claim.actionId, reason: 'dated' });
+        this.append({ type: 'retired', at: iso(nowMs), actionId: claim.actionId, reason: 'dated' });
+        continue;
+      }
+      if (!['high', 'critical'].includes(action.priority)) {
+        this.append({ type: 'claim-abandoned', at: iso(nowMs), claimId: claim.claimId, actionId: claim.actionId, reason: 'priority-changed' });
+        this.append({ type: 'reset', at: iso(nowMs), actionId: claim.actionId, series: p.series + 1, observed: observe(action) });
+        continue;
+      }
+      const current = observe(action);
+      if (!sameObserved(claim.observed, current)) {
+        this.append({ type: 'claim-abandoned', at: iso(nowMs), claimId: claim.claimId, actionId: claim.actionId, reason: 'content-changed' });
+        this.append({ type: 'reset', at: iso(nowMs), actionId: claim.actionId, series: p.series + 1, observed: current });
+        continue;
+      }
+      const failures = events.filter((e) => e.type === 'emit-attempt-failed' && e.claimId === claim.claimId).length;
+      const retry = { ...claim, at: iso(nowMs), attempt: failures + 1 };
+      this.append(retry);
+      return { claim: retry, action };
+    }
+    return null;
+  }
+
+  private async emitDispositionClaim(
+    claim: Extract<LedgerEvent, { type: 'pending-disposition-alert' }>,
+    replayed: boolean,
+  ): Promise<UndatedActionRunResult> {
+    if (this.authorityBlock() !== null) {
+      this.deps.recordMetric?.('noop', 'needs-disposition');
+      return this.complete({ ran: false, reason: 'authority-lost', eligible: 0, skippedCooldown: 0, selectedActionId: null });
+    }
+    const alert = this.dispositionAlert(claim.count, claim.idempotencyKey);
+    try {
+      await this.deps.emitAttention(alert);
+    } catch (err) {
+      await this.withLedgerLock(() => {
+        this.append({
+          type: 'disposition-alert-attempt-failed', at: iso(this.now()), claimId: claim.claimId,
+          attempt: claim.attempt, error: err instanceof Error ? err.message.slice(0, 300) : String(err).slice(0, 300),
+        });
+        if (claim.attempt >= 3) this.append({ type: 'disposition-alert-failed', at: iso(this.now()), claimId: claim.claimId, attempts: claim.attempt });
+      });
+      this.deps.recordMetric?.('error', 'needs-disposition');
+      return this.complete({ ran: true, reason: 'emit-failed', eligible: 0, skippedCooldown: 0, selectedActionId: null });
+    }
+    try {
+      await this.withLedgerLock(() => this.append({
+        type: 'disposition-alert-emitted', at: iso(this.now()), claimId: claim.claimId,
+        idempotencyKey: claim.idempotencyKey, count: claim.count,
+      }));
+      this.deps.recordMetric?.('fired', 'needs-disposition');
+      return this.complete({ ran: true, reason: replayed ? 'replayed' : 'disposition-alert', eligible: 0, skippedCooldown: 0, selectedActionId: null });
+    } catch (err) {
+      this.lastLedgerError = err instanceof Error ? err.message : String(err);
+      this.deps.recordMetric?.('error', 'needs-disposition');
+      return this.complete({ ran: true, reason: 'ledger-confirm-failed', eligible: 0, skippedCooldown: 0, selectedActionId: null });
+    }
+  }
+
+  private prepareDispositionReplay(events: LedgerEvent[]): Extract<LedgerEvent, { type: 'pending-disposition-alert' }> | null {
+    const pending = foldUndatedActionEvents(events).pendingDispositionAlert;
+    if (!pending || this.now() - Date.parse(pending.at) < this.intervalMs) return null;
+    const failures = events.filter((e) => e.type === 'disposition-alert-attempt-failed' && e.claimId === pending.claimId).length;
+    const retry = { ...pending, at: iso(this.now()), attempt: failures + 1 };
+    this.append(retry);
+    return retry;
+  }
+
+  private reconcile(events: LedgerEvent[], actions: ActionItem[]): void {
+    const folded = foldUndatedActionEvents(events);
+    const byId = new Map(actions.map((a) => [a.id, a]));
+    const nowMs = this.now();
+    // Observe EACH confirmed delivery claim independently of the current action
+    // projection. A later content reset is a new delivery series, but it must not
+    // erase the already-scheduled outcome sample for a prior emitted claim.
+    const claims = new Map<string, Extract<LedgerEvent, { type: 'pending-emit' }>>();
+    for (const event of events) if (event.type === 'pending-emit') claims.set(event.claimId, event);
+    const observedClaims = new Set(
+      events.filter((event): event is Extract<LedgerEvent, { type: 'outcome-observed' }> => event.type === 'outcome-observed')
+        .map((event) => event.claimId),
+    );
+    for (const event of events) {
+      if (event.type !== 'emitted' || observedClaims.has(event.claimId)) continue;
+      if (nowMs - Date.parse(event.at) < this.cooldownMs) continue;
+      const claim = claims.get(event.claimId);
+      if (!claim) continue;
+      this.append({
+        type: 'outcome-observed', at: iso(nowMs), actionId: claim.actionId,
+        claimId: claim.claimId, statusAtRaise: claim.observed.status,
+        statusAt14d: byId.get(claim.actionId)?.status ?? 'missing',
+      });
+      observedClaims.add(event.claimId);
+    }
+    for (const [id, p] of folded.actions) {
+      if (p.pendingClaim) continue;
+      const action = byId.get(id);
+      // Retirement removes the row from resurfacing, but not from delayed
+      // outcome observation. A row completed or dated before the observation
+      // window must still produce statusAt+14d when that window arrives.
+      if (p.retired) continue;
+      if (!action) { this.append({ type: 'retired', at: iso(nowMs), actionId: id, reason: 'missing' }); continue; }
+      if (action.status !== 'pending') { this.append({ type: 'retired', at: iso(nowMs), actionId: id, reason: 'left-pending' }); continue; }
+      if (action.dueBy) { this.append({ type: 'retired', at: iso(nowMs), actionId: id, reason: 'dated' }); continue; }
+      const current = observe(action);
+      if (p.observed && !sameObserved(p.observed, current)) this.append({ type: 'reset', at: iso(nowMs), actionId: id, series: p.series + 1, observed: current });
+    }
+  }
+
+  private dispositionAlert(count: number, id = `undated-actions:needs-disposition:${Math.floor(this.now() / this.cooldownMs)}`): UndatedActionAttention {
+    return {
+      id,
+      title: 'Undated actions need disposition',
+      summary: `${count} undated high-priority actions have been resurfaced three times without meaningful movement.`,
+      description: 'These rows now need an explicit disposition: work, cancel with a reason, assign a due date, or split the action.',
+      category: 'evolution-action-resurfacing',
+      priority: 'HIGH',
+      sourceContext: 'undated-action-resurfacer',
+    };
+  }
+
+  async run(): Promise<UndatedActionRunResult> {
+    if (!this.config.enabled) return this.complete({ ran: false, reason: 'disabled', eligible: 0, skippedCooldown: 0, selectedActionId: null });
+    const blocked = this.authorityBlock();
+    if (blocked) return this.complete({ ran: false, reason: blocked, eligible: 0, skippedCooldown: 0, selectedActionId: null });
+    if (this.inFlight) return this.complete({ ran: false, reason: 'overlap', eligible: 0, skippedCooldown: 0, selectedActionId: null });
+    this.inFlight = true;
+    try {
+      const actions = this.deps.listActions();
+      const prepared = await this.withLedgerLock(() => {
+        let events = this.readEvents();
+        this.reconcile(events, actions);
+        events = this.readEvents();
+
+        const actionReplay = this.preparePendingReplay(events, actions);
+        if (actionReplay) return { kind: 'action' as const, ...actionReplay, replayed: true };
+        events = this.readEvents();
+        const dispositionReplay = this.prepareDispositionReplay(events);
+        if (dispositionReplay) return { kind: 'disposition' as const, claim: dispositionReplay, replayed: true };
+        events = this.readEvents();
+
+        const folded = foldUndatedActionEvents(events);
+        const lastRunAt = folded.runs.at(-1)?.at;
+        if (lastRunAt && this.now() - Date.parse(lastRunAt) < this.intervalMs) {
+          this.deps.recordMetric?.('noop');
+          return { kind: 'result' as const, result: this.complete({ ran: false, reason: 'cadence', eligible: 0, skippedCooldown: 0, selectedActionId: null }) };
+        }
+        const needsDisposition = [...folded.actions.values()].filter((p) => p.disposition === 'needs-disposition' && !p.retired).length;
+        const alertDue = !folded.pendingDispositionAlert
+          && needsDisposition > this.dispositionThreshold
+          && (!folded.lastDispositionAlertAt || this.now() - Date.parse(folded.lastDispositionAlertAt) >= this.cooldownMs);
+        if (alertDue) {
+          const alert = this.dispositionAlert(needsDisposition);
+          const runIndex = folded.runs.length + 1;
+          this.append({ type: 'run', at: iso(this.now()), runIndex, dryRun: this.config.dryRun, eligible: 0, skippedCooldown: 0, selectedActionId: null });
+          if (this.config.dryRun) {
+            this.deps.recordMetric?.('noop', 'needs-disposition');
+            return { kind: 'result' as const, result: this.complete({ ran: true, reason: 'dry-run', eligible: 0, skippedCooldown: 0, selectedActionId: null, wouldEmit: alert }) };
+          }
+          const claim: Extract<LedgerEvent, { type: 'pending-disposition-alert' }> = {
+            type: 'pending-disposition-alert', at: iso(this.now()), claimId: crypto.randomUUID(),
+            idempotencyKey: alert.id, count: needsDisposition, attempt: 1,
+          };
+          this.append(claim);
+          return { kind: 'disposition' as const, claim, replayed: false };
+        }
+        const runIndex = folded.runs.length + 1;
+        const pick = selectUndatedAction(actions, folded.actions, runIndex, this.now(), this.cooldownMs, this.maxHighAgeMs);
+        const selected = pick.selected;
+        const eligible = pick.eligible;
+        const skippedCooldown = pick.skippedCooldown;
+        this.append({ type: 'run', at: iso(this.now()), runIndex, dryRun: this.config.dryRun, eligible, skippedCooldown, selectedActionId: selected?.id ?? null });
+        if (!selected) {
+          this.deps.recordMetric?.('noop');
+          return { kind: 'result' as const, result: this.complete({ ran: true, reason: 'no-eligible', eligible, skippedCooldown, selectedActionId: null }) };
+        }
+        const p = folded.actions.get(selected.id);
+        const series = p?.series ?? 1;
+        const raiseCount = (p?.raiseCount ?? 0) + 1;
+        const wouldEmit = this.attentionFor(selected, series, raiseCount);
+        if (this.config.dryRun) {
+          this.deps.recordMetric?.('noop', selected.id);
+          return { kind: 'result' as const, result: this.complete({ ran: true, reason: 'dry-run', eligible, skippedCooldown, selectedActionId: selected.id, wouldEmit }) };
+        }
+        const claim: Extract<LedgerEvent, { type: 'pending-emit' }> = {
+          type: 'pending-emit',
+          at: iso(this.now()),
+          claimId: crypto.randomUUID(),
+          actionId: selected.id,
+          series,
+          raiseCount,
+          idempotencyKey: wouldEmit.id,
+          attempt: 1,
+          observed: observe(selected),
+        };
+        this.append(claim);
+        return { kind: 'action' as const, claim, action: selected, replayed: false };
+      });
+
+      if (prepared.kind === 'result') return prepared.result;
+      if (prepared.kind === 'disposition') return this.emitDispositionClaim(prepared.claim, prepared.replayed);
+      return this.emitClaim(prepared.claim, prepared.action, prepared.replayed);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.lastLedgerError = message;
+      this.deps.recordMetric?.('error');
+      if (err instanceof LedgerCapacityError) {
+        if (this.authorityBlock() === null) {
+          try { await this.deps.emitAttention(this.capacityAlert()); } catch { /* stable Attention id dedupes retries once delivery recovers */ }
+        }
+        return this.complete({ ran: false, reason: 'ledger-capacity', eligible: 0, skippedCooldown: 0, selectedActionId: null });
+      }
+      this.lastRunError = message;
+      this.lastAttempt = { at: iso(this.now()), ran: false, reason: 'run-error' };
+      throw err;
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  status(): UndatedActionResurfacerStatus {
+    const stateAuthority = this.stateAuthority();
+    const holdsLease = this.leaseHeld();
+    const blockedReason = !this.config.enabled ? 'disabled' : this.authorityBlock();
+    try {
+      const events = this.readEvents();
+      const folded = foldUndatedActionEvents(events);
+      const ledgerBytes = fs.statSync(this.ledgerPath).size;
+      const capacityExceeded = this.capacityHit || ledgerBytes >= this.maxLedgerBytes;
+      const outcomes = events.filter((event): event is Extract<LedgerEvent, { type: 'outcome-observed' }> => event.type === 'outcome-observed');
+      const outcomesByStatus: Record<string, number> = {};
+      for (const outcome of outcomes) outcomesByStatus[outcome.statusAt14d] = (outcomesByStatus[outcome.statusAt14d] ?? 0) + 1;
+      const lastOutcomeByAction = new Map<string, Extract<LedgerEvent, { type: 'outcome-observed' }>>();
+      for (const outcome of outcomes) lastOutcomeByAction.set(outcome.actionId, outcome);
+      const actionStates = [...folded.actions.values()]
+        .map((projection) => {
+          const createdAt = projection.observed?.createdAt ? Date.parse(projection.observed.createdAt) : Number.NaN;
+          const firstRaisedAt = projection.firstRaisedAt ? Date.parse(projection.firstRaisedAt) : Number.NaN;
+          return {
+            actionId: projection.actionId,
+            firstRaisedAt: projection.firstRaisedAt,
+            lastRaisedAt: projection.lastRaisedAt,
+            ageAtFirstRaiseDays: Number.isFinite(createdAt) && Number.isFinite(firstRaisedAt)
+              ? Math.max(0, Math.floor((firstRaisedAt - createdAt) / 86_400_000))
+              : null,
+            raiseCount: projection.raiseCount,
+            disposition: projection.disposition,
+            pendingClaim: !!projection.pendingClaim,
+            failedClaim: projection.failedClaim,
+            retired: projection.retired,
+            lastOutcomeStatus: lastOutcomeByAction.get(projection.actionId)?.statusAt14d ?? null,
+          };
+        })
+        .sort((a, b) => a.actionId.localeCompare(b.actionId));
+      return {
+        enabled: this.config.enabled,
+        dryRun: this.config.dryRun,
+        operational: blockedReason === null && !capacityExceeded,
+        blockedReason,
+        stateAuthority,
+        holdsLease,
+        ledgerReadable: true,
+        ledgerError: null,
+        lastRunError: this.lastRunError,
+        runIntervalMs: this.intervalMs,
+        cooldownMs: this.cooldownMs,
+        totalRuns: folded.runs.length,
+        lastRun: folded.runs.at(-1) ?? null,
+        pendingClaims: [...folded.actions.values()].filter((p) => !!p.pendingClaim).length,
+        failedClaims: events.filter((event) => event.type === 'emit-failed').length,
+        abandonedClaims: events.filter((event) => event.type === 'claim-abandoned').length,
+        pendingDispositionAlerts: folded.pendingDispositionAlert ? 1 : 0,
+        failedDispositionAlerts: events.filter((event) => event.type === 'disposition-alert-failed').length,
+        needsDisposition: [...folded.actions.values()].filter((p) => p.disposition === 'needs-disposition' && !p.retired).length,
+        raisedActions: [...folded.actions.values()].filter((p) => p.raiseCount > 0).length,
+        outcomesObserved: outcomes.length,
+        outcomesByStatus,
+        lastOutcome: outcomes.at(-1) ?? null,
+        actionStates,
+        lastAttempt: this.lastAttempt,
+        ledgerBytes,
+        maxLedgerBytes: this.maxLedgerBytes,
+        capacityExceeded,
+      };
+    } catch {
+      return {
+        enabled: this.config.enabled,
+        dryRun: this.config.dryRun,
+        operational: false,
+        blockedReason,
+        stateAuthority,
+        holdsLease,
+        ledgerReadable: false,
+        ledgerError: this.lastLedgerError ?? 'ledger-unreadable',
+        lastRunError: this.lastRunError,
+        runIntervalMs: this.intervalMs,
+        cooldownMs: this.cooldownMs,
+        totalRuns: 0,
+        lastRun: null,
+        pendingClaims: 0,
+        failedClaims: 0,
+        abandonedClaims: 0,
+        pendingDispositionAlerts: 0,
+        failedDispositionAlerts: 0,
+        needsDisposition: 0,
+        raisedActions: 0,
+        outcomesObserved: 0,
+        outcomesByStatus: {},
+        lastOutcome: null,
+        actionStates: [],
+        lastAttempt: this.lastAttempt,
+        ledgerBytes: 0,
+        maxLedgerBytes: this.maxLedgerBytes,
+        capacityExceeded: this.capacityHit || this.lastLedgerError === 'undated-action-resurfacer-ledger-capacity',
+      };
+    }
+  }
+}

--- a/src/monitoring/UndatedActionResurfacer.ts
+++ b/src/monitoring/UndatedActionResurfacer.ts
@@ -8,8 +8,8 @@
  *
  * Durable state is an append-only event stream owned by one pool-agreed stable
  * machine. That owner may act only while it also holds the serving lease. A
- * `pending-emit` claim
- * is written under an inter-process lock before Attention delivery; overlapping
+ * `pending-emit` claim is written under an inter-process lock before Attention
+ * delivery; overlapping
  * invocations therefore see the claim and select nothing. Delivery uses a stable
  * idempotency key, then appends `emitted`. A crash on either side is replayed,
  * bounded to three attempts, without silently losing the row.
@@ -231,7 +231,10 @@ function actionContentSha(action: ActionItem): string {
 function observe(action: ActionItem): ObservedAction {
   return {
     status: action.status,
-    priority: action.priority,
+    // Runtime stores predate ActionItem's lowercase union. Preserve semantic
+    // identity across legacy `urgent`/uppercase spellings instead of resetting
+    // a raise series when only the representation changes.
+    priority: eligiblePriority(action.priority) ?? action.priority,
     dueBy: action.dueBy ?? null,
     createdAt: action.createdAt,
     contentSha256: actionContentSha(action),
@@ -240,6 +243,20 @@ function observe(action: ActionItem): ObservedAction {
 
 function sameObserved(a: ObservedAction | null, b: ObservedAction): boolean {
   return !!a && a.status === b.status && a.priority === b.priority && a.dueBy === b.dueBy && a.createdAt === b.createdAt && a.contentSha256 === b.contentSha256;
+}
+
+/**
+ * ActionItem's canonical type is lowercase critical/high, but durable stores
+ * predate that contract and contain uppercase values plus the legacy top-tier
+ * spelling `urgent`. Normalize at the runtime boundary so typed callers and
+ * historical JSON rows share one eligibility rule.
+ */
+function eligiblePriority(priority: unknown): 'critical' | 'high' | null {
+  if (typeof priority !== 'string') return null;
+  const normalized = priority.trim().toLowerCase();
+  if (normalized === 'urgent' || normalized === 'critical') return 'critical';
+  if (normalized === 'high') return 'high';
+  return null;
 }
 
 function emptyProjection(actionId: string): UndatedActionProjection {
@@ -367,7 +384,7 @@ export function selectUndatedAction(
   let skippedCooldown = 0;
   const eligible: ActionItem[] = [];
   for (const action of actions) {
-    if (action.status !== 'pending' || action.dueBy || !['high', 'critical'].includes(action.priority)) continue;
+    if (action.status !== 'pending' || action.dueBy || !eligiblePriority(action.priority)) continue;
     const p = projections.get(action.id);
     if (p?.pendingClaim || p?.failedClaim || p?.disposition === 'needs-disposition') continue;
     const anchor = p?.lastEngagedAt ? Date.parse(p.lastEngagedAt) : 0;
@@ -375,9 +392,9 @@ export function selectUndatedAction(
     eligible.push(action);
   }
   const lane = runIndex % 4 === 0 ? 'high' : 'critical';
-  const isAgedHigh = (a: ActionItem) => a.priority === 'high' && nowMs - Date.parse(a.createdAt) >= maxHighAgeMs;
-  const critical = eligible.filter((a) => a.priority === 'critical' || isAgedHigh(a));
-  const high = eligible.filter((a) => a.priority === 'high' && !isAgedHigh(a));
+  const isAgedHigh = (a: ActionItem) => eligiblePriority(a.priority) === 'high' && nowMs - Date.parse(a.createdAt) >= maxHighAgeMs;
+  const critical = eligible.filter((a) => eligiblePriority(a.priority) === 'critical' || isAgedHigh(a));
+  const high = eligible.filter((a) => eligiblePriority(a.priority) === 'high' && !isAgedHigh(a));
   const pool = lane === 'critical' ? (critical.length ? critical : high) : (high.length ? high : critical);
   pool.sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt) || a.id.localeCompare(b.id));
   return { selected: pool[0] ?? null, eligible: eligible.length, skippedCooldown };
@@ -418,8 +435,14 @@ export class UndatedActionResurfacer {
 
   start(): void {
     if (!this.config.enabled || this.timer) return;
+    // @silent-fallback-ok: run() records lastRunError + error metrics before it
+    // rejects; this boundary only prevents a background promise rejection.
     void this.run().catch(() => undefined);
-    this.timer = setInterval(() => { void this.run().catch(() => undefined); }, this.intervalMs);
+    this.timer = setInterval(() => {
+      // @silent-fallback-ok: same observable run-error boundary as startup;
+      // the next bounded interval retries without crashing the server.
+      void this.run().catch(() => undefined);
+    }, this.intervalMs);
     this.timer.unref?.();
   }
 
@@ -436,7 +459,7 @@ export class UndatedActionResurfacer {
         ownerMachineId: 'single-machine',
         ownsState: true,
       };
-    } catch {
+    } catch { // @silent-fallback-ok: authority-read uncertainty fails closed and is exposed as state-owner-unconfigured.
       return {
         mode: 'unconfigured',
         selfMachineId: 'unknown',
@@ -447,7 +470,7 @@ export class UndatedActionResurfacer {
   }
 
   private leaseHeld(): boolean {
-    try { return this.deps.holdsLease(); } catch { return false; }
+    try { return this.deps.holdsLease(); } catch { return false; /* @silent-fallback-ok: lease-read uncertainty fails closed and status reports not-held. */ }
   }
 
   private authorityBlock(): 'state-owner-unconfigured' | 'not-state-owner' | 'not-lease-holder' | null {
@@ -479,7 +502,7 @@ export class UndatedActionResurfacer {
       }
       this.lastLedgerError = null;
       return events;
-    } catch (err) {
+    } catch (err) { // @silent-fallback-ok: ledger-read failure is recorded, rethrown, and exposed by the run boundary.
       this.lastLedgerError = err instanceof Error ? err.message : String(err);
       throw err;
     }
@@ -514,7 +537,7 @@ export class UndatedActionResurfacer {
       summary: `${action.id} has remained ${action.priority} and undated for ${ageDays} day${ageDays === 1 ? '' : 's'}: ${action.title}`,
       description: `Priority: ${action.priority}\nAge: ${ageDays} days\nAction: ${action.title}\n\nThis is informational. Work it, cancel it with a reason, give it a due date, or split it if it is too large to move.`,
       category: 'evolution-action-resurfacing',
-      priority: action.priority === 'critical' ? 'URGENT' : 'HIGH',
+      priority: eligiblePriority(action.priority) === 'critical' ? 'URGENT' : 'HIGH',
       sourceContext: 'undated-action-resurfacer',
     };
   }
@@ -577,7 +600,7 @@ export class UndatedActionResurfacer {
         this.append({ type: 'retired', at: iso(nowMs), actionId: claim.actionId, reason: 'dated' });
         continue;
       }
-      if (!['high', 'critical'].includes(action.priority)) {
+      if (!eligiblePriority(action.priority)) {
         this.append({ type: 'claim-abandoned', at: iso(nowMs), claimId: claim.claimId, actionId: claim.actionId, reason: 'priority-changed' });
         this.append({ type: 'reset', at: iso(nowMs), actionId: claim.actionId, series: p.series + 1, observed: observe(action) });
         continue;
@@ -607,7 +630,7 @@ export class UndatedActionResurfacer {
     const alert = this.dispositionAlert(claim.count, claim.idempotencyKey);
     try {
       await this.deps.emitAttention(alert);
-    } catch (err) {
+    } catch (err) { // @silent-fallback-ok: the transport failure is durably attempted, metered, and returned as emit-failed.
       await this.withLedgerLock(() => {
         this.append({
           type: 'disposition-alert-attempt-failed', at: iso(this.now()), claimId: claim.claimId,
@@ -625,7 +648,7 @@ export class UndatedActionResurfacer {
       }));
       this.deps.recordMetric?.('fired', 'needs-disposition');
       return this.complete({ ran: true, reason: replayed ? 'replayed' : 'disposition-alert', eligible: 0, skippedCooldown: 0, selectedActionId: null });
-    } catch (err) {
+    } catch (err) { // @silent-fallback-ok: the failed confirmation is exposed in status, metrics, and the returned result.
       this.lastLedgerError = err instanceof Error ? err.message : String(err);
       this.deps.recordMetric?.('error', 'needs-disposition');
       return this.complete({ ran: true, reason: 'ledger-confirm-failed', eligible: 0, skippedCooldown: 0, selectedActionId: null });

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -1751,7 +1751,7 @@ export class AgentServer {
           },
         );
         this.undatedActionResurfacer.start();
-      } catch (err) {
+      } catch (err) { // @silent-fallback-ok: warning + null make the authenticated status route return an honest unavailable posture.
         console.warn('[instar] undated-action-resurfacer init failed (non-fatal):', err);
         this.undatedActionResurfacer = null;
       }
@@ -5547,7 +5547,7 @@ export class AgentServer {
    * Closes keep-alive connections after a timeout to prevent hanging.
    */
   async stop(): Promise<void> {
-    try { this.undatedActionResurfacer?.stop(); } catch { /* best-effort */ }
+    try { this.undatedActionResurfacer?.stop(); } catch { /* @silent-fallback-ok: shutdown continues after a timer-cleanup fault */ }
     this.undatedActionResurfacer = null;
     if (this.claimObservationHousekeeperTimer) {
       clearInterval(this.claimObservationHousekeeperTimer);

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -82,6 +82,7 @@ import type { TelegraphService } from '../publishing/TelegraphService.js';
 import type { PrivateViewer } from '../publishing/PrivateViewer.js';
 import type { TunnelManager } from '../tunnel/TunnelManager.js';
 import type { EvolutionManager } from '../core/EvolutionManager.js';
+import { UndatedActionResurfacer, resolveUndatedActionStateAuthority } from '../monitoring/UndatedActionResurfacer.js';
 import type { SessionWatchdog } from '../monitoring/SessionWatchdog.js';
 import type { StallTriageNurse } from '../monitoring/StallTriageNurse.js';
 import type { MultiMachineCoordinator } from '../core/MultiMachineCoordinator.js';
@@ -318,6 +319,7 @@ export class AgentServer {
   private toneGate: import('../core/MessagingToneGate.js').MessagingToneGate | null = null;
   private tokenLedger: TokenLedger | null = null;
   private featureMetricsLedger: FeatureMetricsLedger | null = null;
+  private undatedActionResurfacer: UndatedActionResurfacer | null = null;
   private blockerLifecycleService: BlockerLifecycleService | null = null;
   /** Benchmark-Divergence Detector analyzer (benchmark-divergence-detector FD8) — null when the ledger failed. */
   private benchmarkDivergenceAnalyzer: BenchmarkDivergenceAnalyzer | null = null;
@@ -1691,6 +1693,67 @@ export class AgentServer {
       } catch (err) {
         console.warn('[instar] feature-metrics-ledger init failed (non-fatal):', err);
         this.featureMetricsLedger = null;
+      }
+    }
+
+    // Close-the-Loop action reach: the dated overdue checker cannot see pending
+    // high/critical actions without dueBy. Construct the complementary bounded
+    // resurfacer against the REAL EvolutionManager + Attention queue after the
+    // metrics ledger, so even the immediate dry-run pass is observable. The
+    // development agent is the soak surface; fleet agents stay dark.
+    const undatedCfg = options.config.evolutionActions?.undatedResurfacer;
+    if (
+      options.evolution &&
+      options.telegram &&
+      options.config.stateDir &&
+      resolveDevAgentGate(undatedCfg?.enabled, options.config)
+    ) {
+      try {
+        this.undatedActionResurfacer = new UndatedActionResurfacer(
+          {
+            enabled: true,
+            dryRun: undatedCfg?.dryRun !== false,
+            runIntervalMs: undatedCfg?.runIntervalMs,
+            cooldownMs: undatedCfg?.cooldownMs,
+            maxHighAgeMs: undatedCfg?.maxHighAgeMs,
+            maxRaises: undatedCfg?.maxRaises,
+            dispositionThreshold: undatedCfg?.dispositionThreshold,
+            maxLedgerBytes: undatedCfg?.maxLedgerBytes,
+          },
+          {
+            stateDir: options.config.stateDir,
+            listActions: () => options.evolution!.listActions(),
+            emitAttention: (item) => options.telegram!.createAttentionItem(item),
+            holdsLease: () => options.coordinator?.enabled ? options.coordinator.holdsLease() : true,
+            stateAuthority: () => {
+              if (!options.coordinator?.enabled) {
+                return {
+                  mode: 'single-machine' as const,
+                  selfMachineId: options.meshSelfId ?? 'single-machine',
+                  ownerMachineId: options.meshSelfId ?? 'single-machine',
+                  ownsState: true,
+                  agreement: 'single-machine' as const,
+                };
+              }
+              const selfMachineId = options.meshSelfId ?? 'unknown';
+              const pool = options.machinePoolRegistry?.getCapacities() ?? [];
+              return resolveUndatedActionStateAuthority(
+                selfMachineId,
+                undatedCfg?.stateOwnerMachineId,
+                pool.map((machine) => ({
+                  machineId: machine.machineId,
+                  online: machine.online,
+                  proposedOwnerMachineId: machine.seamlessnessFlags?.undatedActionStateOwnerMachineId,
+                })),
+              );
+            },
+            recordMetric: (outcome, verdictId) => this.featureMetricsLedger?.recordEvent('undated-action-resurfacer', outcome, verdictId),
+          },
+        );
+        this.undatedActionResurfacer.start();
+      } catch (err) {
+        console.warn('[instar] undated-action-resurfacer init failed (non-fatal):', err);
+        this.undatedActionResurfacer = null;
       }
     }
 
@@ -3393,6 +3456,7 @@ export class AgentServer {
       viewer: options.viewer ?? null,
       tunnel: options.tunnel ?? null,
       evolution: options.evolution ?? null,
+      undatedActionResurfacer: this.undatedActionResurfacer,
       watchdog: options.watchdog ?? null,
       triageNurse: options.triageNurse ?? null,
       topicMemory: options.topicMemory ?? null,
@@ -5483,6 +5547,8 @@ export class AgentServer {
    * Closes keep-alive connections after a timeout to prevent hanging.
    */
   async stop(): Promise<void> {
+    try { this.undatedActionResurfacer?.stop(); } catch { /* best-effort */ }
+    this.undatedActionResurfacer = null;
     if (this.claimObservationHousekeeperTimer) {
       clearInterval(this.claimObservationHousekeeperTimer);
       this.claimObservationHousekeeperTimer = null;

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1104,6 +1104,8 @@ export interface RouteContext {
    *  transcripts). Null when stateDir is unavailable. */
   tokenLedger: import('../monitoring/TokenLedger.js').TokenLedger | null;
   featureMetricsLedger: import('../monitoring/FeatureMetricsLedger.js').FeatureMetricsLedger | null;
+  /** Bounded action-only Close-the-Loop reach for undated high/critical actions. */
+  undatedActionResurfacer?: import('../monitoring/UndatedActionResurfacer.js').UndatedActionResurfacer | null;
   blockerLifecycleService?: import('../monitoring/BlockerLifecycleService.js').BlockerLifecycleService | null;
   /** Benchmark-Divergence Detector analyzer (benchmark-divergence-detector FD8/FD10)
    *  — backs GET /benchmark-divergence (+pool), POST /benchmark-divergence/analyze,
@@ -22340,6 +22342,29 @@ document.getElementById('mcpForm').addEventListener('submit', async function (e)
   router.get('/evolution/actions/overdue', (_req, res) => {
     if (!ctx.evolution) { res.json({ overdue: [] }); return; }
     res.json({ overdue: ctx.evolution.getOverdueActions() });
+  });
+
+  /** Readable proof that the undated-action cadence is constructed and healthy. */
+  router.get('/evolution/actions/undated-resurfacer', (_req, res) => {
+    if (!ctx.undatedActionResurfacer) {
+      res.status(503).json({ enabled: false, error: 'undated-action-resurfacer-not-constructed' });
+      return;
+    }
+    res.json(ctx.undatedActionResurfacer.status());
+  });
+
+  /** Run one bounded pass. The component enforces stable owner, lease, and overlap gates. */
+  router.post('/evolution/actions/undated-resurfacer/pass', async (_req, res) => {
+    if (!ctx.undatedActionResurfacer) {
+      res.status(503).json({ enabled: false, error: 'undated-action-resurfacer-not-constructed' });
+      return;
+    }
+    try {
+      const result = await ctx.undatedActionResurfacer.run();
+      res.status(result.ran ? 200 : 409).json(result);
+    } catch (err) {
+      res.status(503).json({ error: 'undated-action-resurfacer-run-failed', detail: err instanceof Error ? err.message : String(err) });
+    }
   });
 
   router.post('/evolution/actions', (req, res) => {

--- a/src/testing/selfActionRegistry.ts
+++ b/src/testing/selfActionRegistry.ts
@@ -952,6 +952,53 @@ const checkInReminderPass: SelfActionController = {
   },
 };
 
+/**
+ * undated-action-resurfacer — bounded Attention reach for action rows that the
+ * due-date checker cannot see. The backlog can remain non-empty indefinitely,
+ * so this is an Eternal Sentinel rather than a controller that truthfully
+ * settles to zero. Its durable run ledger enforces a hard four-hour rate floor
+ * across process reconstruction; each row additionally cools down for 14 days
+ * and exits the loop after three unchanged raises. On a multi-machine agent the
+ * pool-agreed stable ledger owner must also hold the serving lease, so a handoff
+ * or divergent local owner config cannot reset either brake by constructing fresh
+ * local state.
+ */
+const undatedActionResurfacer: SelfActionController = {
+  id: 'undated-action-resurfacer',
+  actionVerb: 'undated-action-notify',
+  models: 'src/monitoring/UndatedActionResurfacer.ts (pool-agreed stable owner + serving lease + durable global cadence + per-row cooldown + three-raise disposition terminal)',
+  modelsPath: 'src/monitoring/UndatedActionResurfacer.ts',
+  delegatedGiveUp: 'the pool-agreed stable-owner ledger and serving-lease conjunction, durable three-raise needs-disposition terminal for each unchanged action, and four-hour global cadence floor',
+  boundK: Number.POSITIVE_INFINITY,
+  perTargetBoundK: 3,
+  ticks: 48,
+  tickMs: 60 * 60_000,
+  eternalSentinel: {
+    reason: 'An undated high-priority backlog can remain non-empty indefinitely; oldest-row reach must continue at a fixed, non-accumulating cadence.',
+    rateFloorMs: 4 * 60 * 60_000,
+  },
+  restartPosture: {
+    pressureSurvives: true,
+    restartUnderPressure(f, sink) {
+      return undatedActionResurfacer.makeUnderPressure(f, sink);
+    },
+  },
+  makeUnderPressure(f, sink) {
+    const KEY = 'undated-action-last-run-at';
+    const RATE_FLOOR_MS = 4 * 60 * 60_000;
+    return {
+      tick() {
+        sink.considered += 1;
+        const lastRunAt = f.durableState.get(KEY) as number | undefined;
+        if (lastRunAt !== undefined && f.clock.nowMs() - lastRunAt < RATE_FLOOR_MS) return;
+        f.durableState.set(KEY, f.clock.nowMs());
+        sink.emitTimesMs.push(f.clock.nowMs());
+        sink.emit({ verb: 'undated-action-notify', target: `oldest-eligible-${sink.count}` });
+      },
+    };
+  },
+};
+
 export const SELF_ACTION_CONTROLLERS: SelfActionController[] = [
   evolutionActionExpirySweep,
   spendReconSweep,
@@ -965,6 +1012,7 @@ export const SELF_ACTION_CONTROLLERS: SelfActionController[] = [
   externalHogKillBreaker,
   meteredReserveExpirySweep,
   checkInReminderPass,
+  undatedActionResurfacer,
   spendStalePriceAlert,
   ownerDarkNotice,
   duplicateConvergeWrite,

--- a/tests/e2e/undated-action-resurfacer-lifecycle.test.ts
+++ b/tests/e2e/undated-action-resurfacer-lifecycle.test.ts
@@ -1,0 +1,63 @@
+/** Production-path proof: AgentServer constructs the resurfacer with the real
+ * EvolutionManager action reader and exposes its readable cadence state. */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import request from 'supertest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { EvolutionManager } from '../../src/core/EvolutionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { createMockSessionManager } from '../helpers/setup.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { InstarConfig } from '../../src/core/types.js';
+
+describe('UndatedActionResurfacer production lifecycle', () => {
+  let dir: string;
+  let server: AgentServer;
+  const raisedAttentionIds: string[] = [];
+
+  beforeAll(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'undated-e2e-'));
+    const stateDir = path.join(dir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'state', 'jobs'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), '{}');
+    const evolution = new EvolutionManager({ stateDir });
+    evolution.addAction({
+      title: 'Previously invisible action', description: 'No due date exists on this stock row', priority: 'critical',
+      followThroughOptOutReason: 'Legacy stock row retained for bounded explicit review.',
+    });
+    const telegram = { createAttentionItem: async (item: { id: string }) => { raisedAttentionIds.push(item.id); return item; } };
+    const config: InstarConfig = {
+      projectName: 'undated-e2e', projectDir: dir, stateDir, port: 0,
+      developmentAgent: true,
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 1, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5_000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 }, messaging: [], monitoring: {}, updates: {},
+      evolutionActions: { undatedResurfacer: { dryRun: false, runIntervalMs: 60_000 } },
+    };
+    const sessionManager = createMockSessionManager() as any;
+    sessionManager.on = () => undefined;
+    server = new AgentServer({ config, sessionManager, state: new StateManager(stateDir), evolution, telegram: telegram as any });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/e2e/undated-action-resurfacer-lifecycle.test.ts' });
+  });
+
+  it('is constructed, reads the real action store, and delegates to the production Attention seam', async () => {
+    const res = await request(server.getApp()).get('/evolution/actions/undated-resurfacer');
+    expect(res.status).toBe(200);
+    expect(res.body.enabled).toBe(true);
+    expect(res.body.dryRun).toBe(false);
+    expect(res.body.operational).toBe(true);
+    expect(res.body.stateAuthority.mode).toBe('single-machine');
+    expect(res.body.ledgerReadable).toBe(true);
+    expect(res.body.totalRuns).toBeGreaterThanOrEqual(1);
+    expect(res.body.lastRun.selectedActionId).toBe('ACT-001');
+    expect(raisedAttentionIds).toEqual(['resurface:ACT-001:s1:1']);
+  });
+});

--- a/tests/integration/peer-presence-roundtrip.test.ts
+++ b/tests/integration/peer-presence-roundtrip.test.ts
@@ -61,7 +61,11 @@ describe('PeerPresencePuller → /mesh/rpc round-trip marks a credential-less pe
       machineId: 'MINI',
       selfReportedLastSeen: new Date().toISOString(),
       loadAvg: 1.5,
-      seamlessnessFlags: { ws11DeliverReceive: true, stateSyncReceive: { learnings: true, knowledge: true } },
+      seamlessnessFlags: {
+        ws11DeliverReceive: true,
+        stateSyncReceive: { learnings: true, knowledge: true },
+        undatedActionStateOwnerMachineId: 'MINI',
+      },
     });
 
     // MINI's signed /mesh/rpc dispatcher — answers session-status with its capacity.
@@ -144,12 +148,14 @@ describe('PeerPresencePuller → /mesh/rpc round-trip marks a credential-less pe
     expect(cap?.online).toBe(true);
     // The peer's receive advert landed over signed HTTP — the load-bearing proof.
     expect(cap?.seamlessnessFlags?.stateSyncReceive).toEqual({ learnings: true, knowledge: true });
+    expect(cap?.seamlessnessFlags?.undatedActionStateOwnerMachineId).toBe('MINI');
 
     // The 30s sparse liveness echo (refreshPool's `{machineId,selfReportedLastSeen}`) must
     // NOT wipe the pulled advert — otherwise the gate flaps back to "cannot receive".
     laptopRegistry.recordHeartbeat({ machineId: 'MINI', selfReportedLastSeen: new Date().toISOString() });
     cap = laptopRegistry.getCapacity('MINI');
     expect(cap?.seamlessnessFlags?.stateSyncReceive).toEqual({ learnings: true, knowledge: true });
+    expect(cap?.seamlessnessFlags?.undatedActionStateOwnerMachineId).toBe('MINI');
   });
 
   it('an unreachable peer is NOT marked online (the puller swallows the transport error)', async () => {

--- a/tests/integration/undated-action-resurfacer-routes.test.ts
+++ b/tests/integration/undated-action-resurfacer-routes.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { UndatedActionResurfacer } from '../../src/monitoring/UndatedActionResurfacer.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of dirs.splice(0)) SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/undated-action-resurfacer-routes.test.ts' });
+});
+
+function appWith(resurfacer: UndatedActionResurfacer | null): express.Express {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'undated-routes-'));
+  dirs.push(dir);
+  const ctx = {
+    config: { projectName: 'test', projectDir: dir, stateDir: path.join(dir, '.instar'), port: 0, sessions: {}, scheduler: {} },
+    sessionManager: { listRunningSessions: () => [] },
+    state: { getJobState: () => null, getSession: () => null, listSessions: () => [] },
+    tokenLedger: null,
+    undatedActionResurfacer: resurfacer,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+describe('undated action resurfacer routes', () => {
+  it('returns an honest 503 when production construction is absent', async () => {
+    const res = await request(appWith(null)).get('/evolution/actions/undated-resurfacer');
+    expect(res.status).toBe(503);
+    expect(res.body.enabled).toBe(false);
+  });
+
+  it('exposes ledger health and drives one dry-run pass', async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'undated-engine-'));
+    dirs.push(stateDir);
+    const resurfacer = new UndatedActionResurfacer(
+      { enabled: true, dryRun: true },
+      {
+        stateDir,
+        listActions: () => [{ id: 'ACT-007', title: 'Old invisible row', description: 'Needs review', priority: 'critical', status: 'pending', createdAt: '2026-06-01T00:00:00.000Z' }],
+        emitAttention: async () => { throw new Error('dry-run must not emit'); },
+        holdsLease: () => true,
+        now: () => Date.parse('2026-08-01T00:00:00.000Z'),
+      },
+    );
+    const app = appWith(resurfacer);
+    const pass = await request(app).post('/evolution/actions/undated-resurfacer/pass');
+    expect(pass.status).toBe(200);
+    expect(pass.body.reason).toBe('dry-run');
+    expect(pass.body.selectedActionId).toBe('ACT-007');
+    const status = await request(app).get('/evolution/actions/undated-resurfacer');
+    expect(status.status).toBe(200);
+    expect(status.body.ledgerReadable).toBe(true);
+    expect(status.body.lastRunError).toBeNull();
+    expect(status.body.operational).toBe(true);
+    expect(status.body.blockedReason).toBeNull();
+    expect(status.body.stateAuthority.mode).toBe('single-machine');
+    expect(status.body.totalRuns).toBe(1);
+    expect(status.body.lastRun.selectedActionId).toBe('ACT-007');
+    expect(status.body.lastAttempt.reason).toBe('dry-run');
+  });
+
+  it('refuses at the on-disk byte ceiling and raises one stable capacity signal without truncating history', async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'undated-capacity-'));
+    dirs.push(stateDir);
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const attentionIds: string[] = [];
+    const rows = Array.from({ length: 20 }, (_, i) => ({
+      id: `ACT-${String(i + 1).padStart(3, '0')}`,
+      title: `Capacity row ${i + 1}`,
+      description: 'Bounded growth fixture',
+      priority: 'critical' as const,
+      status: 'pending' as const,
+      createdAt: new Date(Date.parse('2026-06-01T00:00:00.000Z') + i * 1_000).toISOString(),
+    }));
+    const resurfacer = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, runIntervalMs: 60_000, cooldownMs: 86_400_000, maxLedgerBytes: 2_048 },
+      {
+        stateDir,
+        listActions: () => rows,
+        emitAttention: async (item) => { attentionIds.push(item.id); },
+        holdsLease: () => true,
+        now: () => now,
+      },
+    );
+    let reason: string | undefined;
+    for (let i = 0; i < rows.length && reason !== 'ledger-capacity'; i++) {
+      reason = (await resurfacer.run()).reason;
+      now += 61_000;
+    }
+    expect(reason).toBe('ledger-capacity');
+    expect(attentionIds).toContain('undated-actions:ledger-capacity');
+    expect(resurfacer.status()).toMatchObject({ operational: false, capacityExceeded: true });
+    expect(fs.statSync(path.join(stateDir, 'state', 'undated-action-resurfacer.jsonl')).size).toBeLessThanOrEqual(2_048);
+  });
+
+  it('uses a new durable series identity after reset under the real Attention dedupe store', async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'undated-real-attention-'));
+    dirs.push(stateDir);
+    const adapter = new TelegramAdapter(
+      { token: 'test-token-123', chatId: '-100123456', pollIntervalMs: 100 },
+      stateDir,
+    );
+    let thread = 7_000;
+    vi.spyOn(adapter as unknown as { apiCall: (method: string, params: Record<string, unknown>) => Promise<unknown> }, 'apiCall')
+      .mockImplementation(async (method: string) => method === 'createForumTopic'
+        ? { message_thread_id: ++thread, name: 'Attention' }
+        : { message_id: ++thread, ok: true });
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const row = { id: 'ACT-001', title: 'Original title', description: 'Needs review', priority: 'critical' as const, status: 'pending' as const, createdAt: '2026-06-01T00:00:00.000Z' };
+    const resurfacer = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, runIntervalMs: 60_000, cooldownMs: 60_000 },
+      {
+        stateDir, listActions: () => [row], holdsLease: () => true, now: () => now,
+        emitAttention: (item) => adapter.createAttentionItem(item),
+      },
+    );
+    try {
+      expect((await resurfacer.run()).reason).toBe('emitted');
+      row.title = 'Meaningfully revised title';
+      now += 61_000;
+      expect((await resurfacer.run()).reason).toBe('no-eligible');
+      now += 61_000;
+      expect((await resurfacer.run()).reason).toBe('emitted');
+
+      const ids = adapter.getAttentionItems()
+        .filter((item) => item.category === 'evolution-action-resurfacing')
+        .map((item) => item.id)
+        .sort();
+      expect(ids).toEqual(['resurface:ACT-001:s1:1', 'resurface:ACT-001:s2:1']);
+    } finally {
+      await adapter.stop();
+    }
+  });
+});

--- a/tests/unit/UndatedActionResurfacer.test.ts
+++ b/tests/unit/UndatedActionResurfacer.test.ts
@@ -1,0 +1,551 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { ActionItem } from '../../src/core/types.js';
+import {
+  UndatedActionResurfacer,
+  resolveUndatedActionStateAuthority,
+  selectUndatedAction,
+  type UndatedActionProjection,
+} from '../../src/monitoring/UndatedActionResurfacer.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const made: string[] = [];
+afterEach(() => {
+  for (const dir of made.splice(0)) SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/UndatedActionResurfacer.test.ts' });
+});
+
+function temp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'undated-actions-'));
+  made.push(dir);
+  return dir;
+}
+
+function action(id: string, priority: ActionItem['priority'], createdAt: string, extra: Partial<ActionItem> = {}): ActionItem {
+  return { id, title: `title ${id}`, description: `description ${id}`, priority, status: 'pending', createdAt, ...extra };
+}
+
+function projection(id: string, lastEngagedAt: string): UndatedActionProjection {
+  return {
+    actionId: id, series: 1, firstRaisedAt: lastEngagedAt, lastRaisedAt: lastEngagedAt, lastEngagedAt,
+    raiseCount: 1, disposition: null, observed: null, pendingClaim: null,
+    failedClaim: false, retired: false, outcomeObservedClaims: new Set(),
+  };
+}
+
+describe('selectUndatedAction', () => {
+  const now = Date.parse('2026-08-01T00:00:00.000Z');
+
+  it('uses 3 critical lanes then 1 high lane, with stable age/id ordering', () => {
+    const rows = [
+      action('ACT-003', 'critical', '2026-07-20T00:00:00.000Z'),
+      action('ACT-002', 'critical', '2026-07-20T00:00:00.000Z'),
+      action('ACT-001', 'high', '2026-07-21T00:00:00.000Z'),
+    ];
+    expect(selectUndatedAction(rows, new Map(), 1, now).selected?.id).toBe('ACT-002');
+    expect(selectUndatedAction(rows, new Map(), 2, now).selected?.id).toBe('ACT-002');
+    expect(selectUndatedAction(rows, new Map(), 3, now).selected?.id).toBe('ACT-002');
+    expect(selectUndatedAction(rows, new Map(), 4, now).selected?.id).toBe('ACT-001');
+  });
+
+  it('promotes a high action older than 30 days into the critical lane', () => {
+    const rows = [
+      action('ACT-001', 'critical', '2026-07-20T00:00:00.000Z'),
+      action('ACT-002', 'high', '2026-06-01T00:00:00.000Z'),
+    ];
+    expect(selectUndatedAction(rows, new Map(), 1, now).selected?.id).toBe('ACT-002');
+  });
+
+  it('keeps an explicit follow-through opt-out reachable', () => {
+    const row = action('ACT-001', 'critical', '2026-07-20T00:00:00.000Z', {
+      followThroughOptOutReason: 'No honest due date was available at filing time.',
+    });
+    expect(selectUndatedAction([row], new Map(), 1, now).selected?.id).toBe('ACT-001');
+  });
+
+  it('excludes dated, non-pending, low/medium, terminal, pending-claim, and cooldown rows', () => {
+    const recent = new Map<string, UndatedActionProjection>([['ACT-001', projection('ACT-001', '2026-07-31T00:00:00.000Z')]]);
+    const rows = [
+      action('ACT-001', 'critical', '2026-07-01T00:00:00.000Z'),
+      action('ACT-002', 'critical', '2026-07-01T00:00:00.000Z', { dueBy: '2026-09-01T00:00:00.000Z' }),
+      action('ACT-003', 'critical', '2026-07-01T00:00:00.000Z', { status: 'completed' }),
+      action('ACT-004', 'medium', '2026-07-01T00:00:00.000Z'),
+    ];
+    const out = selectUndatedAction(rows, recent, 1, now);
+    expect(out.selected).toBeNull();
+    expect(out.skippedCooldown).toBe(1);
+  });
+});
+
+describe('UndatedActionResurfacer durable lifecycle', () => {
+  it('binds multi-machine state to one pool-agreed stable owner across a serving-lease handoff', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    let aHoldsLease = true;
+    const emitted: string[] = [];
+    const dirA = temp();
+    const dirB = temp();
+    const rows = [action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z')];
+    const owner = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, runIntervalMs: 60_000, cooldownMs: 120_000 },
+      {
+        stateDir: dirA, listActions: () => rows, emitAttention: async (item) => { emitted.push(item.id); },
+        holdsLease: () => aHoldsLease, now: () => now,
+        stateAuthority: () => ({ mode: 'stable-owner', selfMachineId: 'machine-a', ownerMachineId: 'machine-a', ownsState: true }),
+      },
+    );
+    const newHolder = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, runIntervalMs: 60_000, cooldownMs: 120_000 },
+      {
+        stateDir: dirB, listActions: () => rows, emitAttention: async (item) => { emitted.push(item.id); },
+        holdsLease: () => !aHoldsLease, now: () => now,
+        stateAuthority: () => ({ mode: 'stable-owner', selfMachineId: 'machine-b', ownerMachineId: 'machine-a', ownsState: false }),
+      },
+    );
+
+    expect((await owner.run()).reason).toBe('emitted');
+    aHoldsLease = false;
+    now += 61_000;
+    expect((await newHolder.run()).reason).toBe('not-state-owner');
+    expect(newHolder.status().totalRuns).toBe(0);
+    aHoldsLease = true;
+    expect((await owner.run()).reason).toBe('no-eligible');
+    expect(owner.status().lastRun?.skippedCooldown).toBe(1);
+    expect(emitted).toEqual(['resurface:ACT-001:s1:1']);
+  });
+
+  it('fails closed through handoff and handback when local owner proposals diverge', async () => {
+    let holder: 'machine-a' | 'machine-b' = 'machine-a';
+    const emitted: string[] = [];
+    const rows = [action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z')];
+    const adverts = [
+      { machineId: 'machine-a', online: true, proposedOwnerMachineId: 'machine-a' },
+      { machineId: 'machine-b', online: true, proposedOwnerMachineId: 'machine-b' },
+    ];
+    const machine = (selfMachineId: string, proposedOwnerMachineId: string) => new UndatedActionResurfacer(
+      { enabled: true, dryRun: false },
+      {
+        stateDir: temp(), listActions: () => rows,
+        emitAttention: async (item) => { emitted.push(item.id); },
+        holdsLease: () => holder === selfMachineId,
+        stateAuthority: () => resolveUndatedActionStateAuthority(selfMachineId, proposedOwnerMachineId, adverts),
+      },
+    );
+    const a = machine('machine-a', 'machine-a');
+    const b = machine('machine-b', 'machine-b');
+
+    expect((await a.run()).reason).toBe('state-owner-unconfigured');
+    holder = 'machine-b';
+    expect((await b.run()).reason).toBe('state-owner-unconfigured');
+    holder = 'machine-a';
+    expect((await a.run()).reason).toBe('state-owner-unconfigured');
+    expect(a.status().stateAuthority).toMatchObject({ agreement: 'disagreed', disagreeingMachineIds: ['machine-b'] });
+    expect(b.status().stateAuthority).toMatchObject({ agreement: 'disagreed', disagreeingMachineIds: ['machine-a'] });
+    expect(emitted).toEqual([]);
+  });
+
+  it('accepts a stable owner only after every registered pool member advertises agreement', () => {
+    const pool = [
+      { machineId: 'machine-a', online: true, proposedOwnerMachineId: 'machine-a' },
+      { machineId: 'machine-b', online: true, proposedOwnerMachineId: 'machine-a' },
+    ];
+    expect(resolveUndatedActionStateAuthority('machine-a', 'machine-a', pool)).toMatchObject({
+      mode: 'stable-owner', agreement: 'pool-agreed', ownsState: true,
+    });
+    expect(resolveUndatedActionStateAuthority('machine-b', 'machine-a', pool)).toMatchObject({
+      mode: 'stable-owner', agreement: 'pool-agreed', ownsState: false,
+    });
+    expect(resolveUndatedActionStateAuthority('machine-a', 'machine-a', [
+      pool[0], { machineId: 'machine-b', online: true, proposedOwnerMachineId: null },
+    ])).toMatchObject({ mode: 'unconfigured', agreement: 'missing' });
+    expect(resolveUndatedActionStateAuthority('machine-a', 'machine-a', [
+      pool[0], { machineId: 'machine-b', online: false, proposedOwnerMachineId: 'machine-b' },
+    ])).toMatchObject({ mode: 'unconfigured', agreement: 'disagreed' });
+  });
+
+  it('refuses a multi-machine run with no stable state owner configured', async () => {
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false },
+      {
+        stateDir: temp(), listActions: () => [action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z')],
+        emitAttention: async () => undefined, holdsLease: () => true,
+        stateAuthority: () => ({ mode: 'unconfigured', selfMachineId: 'machine-a', ownerMachineId: null, ownsState: false }),
+      },
+    );
+    expect((await r.run()).reason).toBe('state-owner-unconfigured');
+    expect(r.status()).toMatchObject({ operational: false, blockedReason: 'state-owner-unconfigured', totalRuns: 0 });
+  });
+
+  it('keeps an unexpected run failure visible in status', async () => {
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false },
+      {
+        stateDir: temp(),
+        listActions: () => { throw new Error('action store unavailable'); },
+        emitAttention: async () => undefined,
+        holdsLease: () => true,
+      },
+    );
+    await expect(r.run()).rejects.toThrow('action store unavailable');
+    expect(r.status()).toMatchObject({
+      lastRunError: 'action store unavailable',
+      lastAttempt: { ran: false, reason: 'run-error' },
+    });
+  });
+
+  it('re-checks state ownership and lease immediately before external emission', async () => {
+    let ownsState = true;
+    let called = false;
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false },
+      {
+        stateDir: temp(),
+        listActions: () => {
+          ownsState = false; // simulates authority changing after the entry check
+          return [action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z')];
+        },
+        emitAttention: async () => { called = true; }, holdsLease: () => true,
+        stateAuthority: () => ({ mode: 'stable-owner', selfMachineId: 'machine-a', ownerMachineId: 'machine-a', ownsState }),
+      },
+    );
+    expect((await r.run()).reason).toBe('authority-lost');
+    expect(called).toBe(false);
+    expect(r.status().pendingClaims).toBe(1);
+  });
+
+  it('emits at most one row, records cooldown, and reaches needs-disposition on the third unchanged raise', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const rows = [
+      action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z'),
+      action('ACT-002', 'critical', '2026-06-02T00:00:00.000Z'),
+    ];
+    const emitted: string[] = [];
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, cooldownMs: 120_000, runIntervalMs: 60_000, maxRaises: 3 },
+      { stateDir: temp(), listActions: () => rows, emitAttention: async (i) => { emitted.push(i.id); }, holdsLease: () => true, now: () => now },
+    );
+
+    expect((await r.run()).selectedActionId).toBe('ACT-001');
+    expect(emitted).toEqual(['resurface:ACT-001:s1:1']);
+    // The next critical candidate can move, but the first row is cooling down.
+    now += 61_000;
+    expect((await r.run()).selectedActionId).toBe('ACT-002');
+    expect(emitted).toHaveLength(2);
+    now += 61_000;
+    await r.run(); // ACT-001 raise 2
+    now += 61_000;
+    await r.run(); // ACT-002 raise 2
+    now += 61_000;
+    await r.run(); // ACT-001 raise 3
+    expect(emitted.filter((id) => id.startsWith('resurface:ACT-001:'))).toEqual([
+      'resurface:ACT-001:s1:1', 'resurface:ACT-001:s1:2', 'resurface:ACT-001:s1:3',
+    ]);
+    expect(r.status().needsDisposition).toBe(1);
+  });
+
+  it('two instances sharing the ledger cannot emit two rows during an overlapping run', async () => {
+    const dir = temp();
+    const rows = [action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z')];
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const emitted: string[] = [];
+    const deps = { stateDir: dir, listActions: () => rows, holdsLease: () => true, now: () => Date.parse('2026-08-01T00:00:00.000Z') };
+    const first = new UndatedActionResurfacer({ enabled: true, dryRun: false }, { ...deps, emitAttention: async (i) => { emitted.push(i.id); await held; } });
+    const second = new UndatedActionResurfacer({ enabled: true, dryRun: false }, { ...deps, emitAttention: async (i) => { emitted.push(i.id); } });
+    const p1 = first.run();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const p2 = await second.run();
+    expect(p2.reason).toBe('cadence');
+    expect(emitted).toEqual(['resurface:ACT-001:s1:1']);
+    release();
+    await p1;
+  });
+
+  it('keeps the global cadence floor across reconstruction', async () => {
+    const dir = temp();
+    const emitted: string[] = [];
+    const deps = {
+      stateDir: dir,
+      listActions: () => [
+        action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z'),
+        action('ACT-002', 'critical', '2026-06-02T00:00:00.000Z'),
+      ],
+      holdsLease: () => true,
+      now: () => Date.parse('2026-08-01T00:00:00.000Z'),
+      emitAttention: async (i: { id: string }) => { emitted.push(i.id); },
+    };
+    const first = new UndatedActionResurfacer({ enabled: true, dryRun: false, runIntervalMs: 60_000 }, deps);
+    expect((await first.run()).reason).toBe('emitted');
+    const reconstructed = new UndatedActionResurfacer({ enabled: true, dryRun: false, runIntervalMs: 60_000 }, deps);
+    expect((await reconstructed.run()).reason).toBe('cadence');
+    expect(emitted).toEqual(['resurface:ACT-001:s1:1']);
+  });
+
+  it('replays a failed pending emit with the same idempotency key after one interval', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const ids: string[] = [];
+    let fail = true;
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, runIntervalMs: 60_000 },
+      {
+        stateDir: temp(), listActions: () => [action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z')], holdsLease: () => true, now: () => now,
+        emitAttention: async (i) => { ids.push(i.id); if (fail) throw new Error('simulated transport crash'); },
+      },
+    );
+    expect((await r.run()).reason).toBe('emit-failed');
+    fail = false;
+    now += 61_000;
+    expect((await r.run()).reason).toBe('replayed');
+    expect(ids).toEqual(['resurface:ACT-001:s1:1', 'resurface:ACT-001:s1:1']);
+    expect(r.status().pendingClaims).toBe(0);
+  });
+
+  it('abandons a stale pending claim instead of emitting after the action changes', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const row = action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z');
+    const ids: string[] = [];
+    let fail = true;
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, runIntervalMs: 60_000 },
+      {
+        stateDir: temp(), listActions: () => [row], holdsLease: () => true, now: () => now,
+        emitAttention: async (item) => { ids.push(item.id); if (fail) throw new Error('first transport failure'); },
+      },
+    );
+    expect((await r.run()).reason).toBe('emit-failed');
+    row.title = 'meaningfully revised before retry';
+    fail = false;
+    now += 61_000;
+    expect((await r.run()).reason).toBe('no-eligible');
+    expect(ids).toEqual(['resurface:ACT-001:s1:1']);
+    expect(r.status()).toMatchObject({ pendingClaims: 0, abandonedClaims: 1 });
+  });
+
+  it('bounds a persistently failing delivery at three attempts', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const ids: string[] = [];
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, runIntervalMs: 60_000 },
+      {
+        stateDir: temp(), listActions: () => [action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z')], holdsLease: () => true, now: () => now,
+        emitAttention: async (i) => { ids.push(i.id); throw new Error('still unavailable'); },
+      },
+    );
+    expect((await r.run()).reason).toBe('emit-failed');
+    now += 61_000;
+    expect((await r.run()).reason).toBe('emit-failed');
+    now += 61_000;
+    expect((await r.run()).reason).toBe('emit-failed');
+    expect(ids).toEqual(['resurface:ACT-001:s1:1', 'resurface:ACT-001:s1:1', 'resurface:ACT-001:s1:1']);
+    expect(r.status().pendingClaims).toBe(0);
+    expect((await r.run()).reason).toBe('no-eligible');
+  });
+
+  it('resets the raise series after a meaningful content change', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const row = action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z');
+    const ids: string[] = [];
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, cooldownMs: 60_000, runIntervalMs: 60_000 },
+      { stateDir: temp(), listActions: () => [row], holdsLease: () => true, now: () => now, emitAttention: async (i) => { ids.push(i.id); } },
+    );
+    await r.run();
+    row.title = 'materially revised action';
+    now += 61_000;
+    expect((await r.run()).reason).toBe('no-eligible');
+    now += 61_000;
+    expect((await r.run()).reason).toBe('emitted');
+    expect(ids).toEqual(['resurface:ACT-001:s1:1', 'resurface:ACT-001:s2:1']);
+  });
+
+  it('keeps a prior emitted claim scheduled for outcome observation across a meaningful edit', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const row = action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z');
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, cooldownMs: 120_000, runIntervalMs: 60_000 },
+      { stateDir: temp(), listActions: () => [row], holdsLease: () => true, now: () => now, emitAttention: async () => undefined },
+    );
+    await r.run();
+    row.title = 'meaningful edit before the outcome window';
+    now += 61_000;
+    await r.run();
+    expect(r.status().outcomesObserved).toBe(0);
+
+    now += 61_000;
+    await r.run();
+    expect(r.status()).toMatchObject({
+      outcomesObserved: 1,
+      lastOutcome: { actionId: 'ACT-001', statusAt14d: 'pending' },
+    });
+  });
+
+  it('records the delayed outcome before retiring an action that left pending', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const row = action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z');
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, cooldownMs: 60_000, runIntervalMs: 60_000 },
+      { stateDir: temp(), listActions: () => [row], holdsLease: () => true, now: () => now, emitAttention: async () => undefined },
+    );
+    await r.run();
+    row.status = 'completed';
+    now += 61_000;
+    expect((await r.run()).reason).toBe('no-eligible');
+    expect(r.status()).toMatchObject({
+      outcomesObserved: 1,
+      outcomesByStatus: { completed: 1 },
+      lastOutcome: { actionId: 'ACT-001', statusAt14d: 'completed' },
+      actionStates: [{ actionId: 'ACT-001', ageAtFirstRaiseDays: 61, lastOutcomeStatus: 'completed', retired: true }],
+    });
+  });
+
+  it('observes the delayed outcome even when the action retired before the observation window', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const row = action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z');
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, cooldownMs: 120_000, runIntervalMs: 60_000 },
+      { stateDir: temp(), listActions: () => [row], holdsLease: () => true, now: () => now, emitAttention: async () => undefined },
+    );
+    await r.run();
+    row.status = 'completed';
+    now += 61_000;
+    await r.run();
+    expect(r.status()).toMatchObject({ outcomesObserved: 0, actionStates: [{ retired: true }] });
+
+    now += 61_000;
+    await r.run();
+    expect(r.status()).toMatchObject({
+      outcomesObserved: 1,
+      outcomesByStatus: { completed: 1 },
+      lastOutcome: { actionId: 'ACT-001', statusAt14d: 'completed' },
+      actionStates: [{ retired: true, lastOutcomeStatus: 'completed' }],
+    });
+  });
+
+  it('retires a raised row when it gains a due date', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const row = action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z');
+    const ids: string[] = [];
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, cooldownMs: 60_000, runIntervalMs: 60_000 },
+      { stateDir: temp(), listActions: () => [row], holdsLease: () => true, now: () => now, emitAttention: async (i) => { ids.push(i.id); } },
+    );
+    await r.run();
+    row.dueBy = '2026-08-05T00:00:00.000Z';
+    now += 61_000;
+    expect((await r.run()).reason).toBe('no-eligible');
+    now += 61_000;
+    expect((await r.run()).reason).toBe('no-eligible');
+    expect(ids).toEqual(['resurface:ACT-001:s1:1']);
+  });
+
+  it('emits one bounded aggregate alert when the disposition threshold is exceeded', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const ids: string[] = [];
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, runIntervalMs: 60_000, maxRaises: 1, dispositionThreshold: 1 },
+      {
+        stateDir: temp(),
+        listActions: () => [
+          action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z'),
+          action('ACT-002', 'critical', '2026-06-02T00:00:00.000Z'),
+        ],
+        holdsLease: () => true,
+        now: () => now,
+        emitAttention: async (i) => { ids.push(i.id); },
+      },
+    );
+    await r.run();
+    now += 61_000;
+    await r.run();
+    now += 61_000;
+    expect((await r.run()).reason).toBe('disposition-alert');
+    expect(ids).toHaveLength(3);
+    expect(ids[2]).toMatch(/^undated-actions:needs-disposition:/);
+  });
+
+  it('claims and retries the aggregate disposition alert with one stable identity', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    let failAggregate = true;
+    const ids: string[] = [];
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, runIntervalMs: 60_000, maxRaises: 1, dispositionThreshold: 1 },
+      {
+        stateDir: temp(),
+        listActions: () => [
+          action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z'),
+          action('ACT-002', 'critical', '2026-06-02T00:00:00.000Z'),
+        ],
+        holdsLease: () => true,
+        now: () => now,
+        emitAttention: async (item) => {
+          ids.push(item.id);
+          if (item.id.startsWith('undated-actions:needs-disposition:') && failAggregate) throw new Error('aggregate transport failure');
+        },
+      },
+    );
+    await r.run();
+    now += 61_000;
+    await r.run();
+    now += 61_000;
+    expect((await r.run()).reason).toBe('emit-failed');
+    expect(r.status().pendingDispositionAlerts).toBe(1);
+    failAggregate = false;
+    now += 61_000;
+    expect((await r.run()).reason).toBe('replayed');
+    const aggregateIds = ids.filter((id) => id.startsWith('undated-actions:needs-disposition:'));
+    expect(aggregateIds).toHaveLength(2);
+    expect(new Set(aggregateIds).size).toBe(1);
+    expect(r.status()).toMatchObject({ pendingDispositionAlerts: 0, failedDispositionAlerts: 0 });
+  });
+
+  it('does not mint a fresh aggregate claim immediately after terminal retry failure', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const aggregateIds: string[] = [];
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, runIntervalMs: 60_000, cooldownMs: 86_400_000, maxRaises: 1, dispositionThreshold: 1 },
+      {
+        stateDir: temp(),
+        listActions: () => [
+          action('ACT-001', 'critical', '2026-06-01T00:00:00.000Z'),
+          action('ACT-002', 'critical', '2026-06-02T00:00:00.000Z'),
+        ],
+        holdsLease: () => true,
+        now: () => now,
+        emitAttention: async (item) => {
+          if (item.id.startsWith('undated-actions:needs-disposition:')) {
+            aggregateIds.push(item.id);
+            throw new Error('persistent aggregate transport failure');
+          }
+        },
+      },
+    );
+    await r.run();
+    now += 61_000;
+    await r.run();
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      now += 61_000;
+      expect((await r.run()).reason).toBe('emit-failed');
+    }
+    expect(aggregateIds).toHaveLength(3);
+    expect(new Set(aggregateIds).size).toBe(1);
+    expect(r.status()).toMatchObject({ pendingDispositionAlerts: 0, failedDispositionAlerts: 1 });
+
+    now += 61_000;
+    expect((await r.run()).reason).not.toBe('emit-failed');
+    expect(aggregateIds).toHaveLength(3);
+  });
+
+  it('dry-run exercises real selection without writing a claim or calling Attention', async () => {
+    let called = false;
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: true },
+      { stateDir: temp(), listActions: () => [action('ACT-009', 'high', '2026-06-01T00:00:00.000Z')], emitAttention: async () => { called = true; }, holdsLease: () => true, now: () => Date.parse('2026-08-01T00:00:00.000Z') },
+    );
+    const out = await r.run();
+    expect(out.reason).toBe('dry-run');
+    expect(out.selectedActionId).toBe('ACT-009');
+    expect(out.wouldEmit?.id).toBe('resurface:ACT-009:s1:1');
+    expect(called).toBe(false);
+    expect(r.status().pendingClaims).toBe(0);
+  });
+});

--- a/tests/unit/UndatedActionResurfacer.test.ts
+++ b/tests/unit/UndatedActionResurfacer.test.ts
@@ -64,6 +64,22 @@ describe('selectUndatedAction', () => {
     expect(selectUndatedAction([row], new Map(), 1, now).selected?.id).toBe('ACT-001');
   });
 
+  it('normalizes legacy urgent and uppercase high priorities at the durable-store boundary', () => {
+    const urgent = { ...action('ACT-948', 'critical', '2026-07-20T00:00:00.000Z'), priority: 'urgent' } as unknown as ActionItem;
+    const uppercaseHigh = { ...action('ACT-956', 'high', '2026-07-21T00:00:00.000Z'), priority: 'HIGH' } as unknown as ActionItem;
+    const normal = { ...action('ACT-957', 'medium', '2026-07-19T00:00:00.000Z'), priority: 'NORMAL' } as unknown as ActionItem;
+    const rows = [uppercaseHigh, normal, urgent];
+
+    expect(selectUndatedAction(rows, new Map(), 1, now)).toMatchObject({
+      eligible: 2,
+      selected: { id: 'ACT-948' },
+    });
+    expect(selectUndatedAction(rows, new Map(), 4, now)).toMatchObject({
+      eligible: 2,
+      selected: { id: 'ACT-956' },
+    });
+  });
+
   it('excludes dated, non-pending, low/medium, terminal, pending-claim, and cooldown rows', () => {
     const recent = new Map<string, UndatedActionProjection>([['ACT-001', projection('ACT-001', '2026-07-31T00:00:00.000Z')]]);
     const rows = [
@@ -79,6 +95,40 @@ describe('selectUndatedAction', () => {
 });
 
 describe('UndatedActionResurfacer durable lifecycle', () => {
+  it('maps a legacy urgent row to an URGENT Attention item', async () => {
+    const row = { ...action('ACT-948', 'critical', '2026-06-01T00:00:00.000Z'), priority: 'urgent' } as unknown as ActionItem;
+    const emitted: Array<{ id: string; priority: string }> = [];
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false },
+      {
+        stateDir: temp(), listActions: () => [row], holdsLease: () => true,
+        emitAttention: async ({ id, priority }) => { emitted.push({ id, priority }); },
+      },
+    );
+
+    expect((await r.run()).reason).toBe('emitted');
+    expect(emitted).toEqual([{ id: 'resurface:ACT-948:s1:1', priority: 'URGENT' }]);
+  });
+
+  it('keeps one raise series when only a legacy priority spelling changes', async () => {
+    let now = Date.parse('2026-08-01T00:00:00.000Z');
+    const row = { ...action('ACT-948', 'critical', '2026-06-01T00:00:00.000Z'), priority: 'urgent' } as unknown as ActionItem;
+    const ids: string[] = [];
+    const r = new UndatedActionResurfacer(
+      { enabled: true, dryRun: false, cooldownMs: 60_000, runIntervalMs: 60_000 },
+      {
+        stateDir: temp(), listActions: () => [row], holdsLease: () => true, now: () => now,
+        emitAttention: async ({ id }) => { ids.push(id); },
+      },
+    );
+
+    expect((await r.run()).reason).toBe('emitted');
+    (row as unknown as { priority: string }).priority = 'CRITICAL';
+    now += 61_000;
+    expect((await r.run()).reason).toBe('emitted');
+    expect(ids).toEqual(['resurface:ACT-948:s1:1', 'resurface:ACT-948:s1:2']);
+  });
+
   it('binds multi-machine state to one pool-agreed stable owner across a serving-lease handoff', async () => {
     let now = Date.parse('2026-08-01T00:00:00.000Z');
     let aHoldsLease = true;

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -438,7 +438,9 @@ describe('lint-dev-agent-dark-gate', () => {
       '976': 'mentee.enabled',
       // evolutionActions.autoExpiry adds a 10-line fleet-on/dry-run-first block;
       // no dark row is added, and every later attribution shifts by +10.
-      '1046': 'prGate.classClosure.enabled',
+      // undatedResurfacer adds a further 15-line dev-gated block that omits
+      // `enabled`, so it also shifts later rows without adding a dark default.
+      '1061': 'prGate.classClosure.enabled',
       // +21 lines below: spec #3's multiMachine.seamlessOrchestrator dev-gated
       // sub-block (docs/specs/llm-seamlessness-orchestrator.md) was inserted at the
       // TOP of the multiMachine block; it OMITS `enabled` (rides resolveDevAgentGate),
@@ -447,17 +449,17 @@ describe('lint-dev-agent-dark-gate', () => {
       // multiMachine. It has no `enabled: false` literal and therefore shifts
       // every subsequent attribution without changing the audited path set.
       // ACT-897 peerExecution adds an 8-line dev-gated dry-run block.
-      '1150': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
-      '1154': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
-      '1161': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
-      '1171': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
-      '1408': 'multiMachine.sessionPool.enabled',
+      '1165': 'multiMachine.leaseSelfHeal.staleHolderTakeover.enabled',
+      '1169': 'multiMachine.leaseSelfHeal.silentStandbyRelinquish.enabled',
+      '1176': 'multiMachine.leaseSelfHeal.soloCaptainHold.enabled',
+      '1186': 'multiMachine.leaseSelfHeal.preferredCaptainHandback.enabled',
+      '1423': 'multiMachine.sessionPool.enabled',
       // #1367's moveIntent dev-gated sub-block was inserted under sessionPool
       // (docs/specs/nickname-move-intent-llm-rebuild.md); it OMITS `enabled` (rides
       // resolveDevAgentGate), adds no map row, and shifts the subsequent lines.
-      '1459': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
-      '1469': 'multiMachine.sessionPool.inboundQueue.enabled',
-      '1498': 'multiMachine.sessionPool.holdForStability.enabled',
+      '1474': 'multiMachine.sessionPool.ownershipCheckedSpawn.enabled',
+      '1484': 'multiMachine.sessionPool.inboundQueue.enabled',
+      '1513': 'multiMachine.sessionPool.holdForStability.enabled',
       // replicated-journal-compaction adds a 5-line compaction default block
       // above stateSync. It uses `run:false` (not an `enabled` gate), so the
       // attributed path set is unchanged and the four rows below shift by +5.
@@ -471,7 +473,7 @@ describe('lint-dev-agent-dark-gate', () => {
       // +32 lines, no `enabled:` literals) shift the cartographer rows below.
       // +15 below the #1561 baseline: this row is BELOW the failoverRunner insert,
       // so it carries both the +10 (missingLogin) and +15 (failoverRunner) shifts.
-      '1759': 'multiMachine.stateSync.threadlinePairing.enabled',
+      '1774': 'multiMachine.stateSync.threadlinePairing.enabled',
       // commitment-auto-expiry (2026-07-10): a 6-line `commitments.autoExpiry`
       // default sub-block was inserted above `promiseBeacon`/`cartographer`.
       // Its `enabled: true` literal is an explicit fleet-on default, not a dark
@@ -480,9 +482,9 @@ describe('lint-dev-agent-dark-gate', () => {
       // PromiseBeacon's four-line default-silent user-output boundary adds no
       // `enabled:` row, so only the three cartographer rows below it shift +4.
       // Below the failoverRunner insert → both +10 (missingLogin) and +15 shifts.
-      '1943': 'cartographer.freshnessSweep.enabled',
-      '1988': 'cartographer.conformanceAudit.llmEnrichment.enabled',
-      '2013': 'cartographer.subtreeNav.llmRerank.enabled',
+      '1958': 'cartographer.freshnessSweep.enabled',
+      '2003': 'cartographer.conformanceAudit.llmEnrichment.enabled',
+      '2028': 'cartographer.subtreeNav.llmRerank.enabled',
     };
     const actual = attributeRealConfigDefaults();
     expect(actual).toEqual(EXPECTED);

--- a/upgrades/next/undated-action-resurfacer.md
+++ b/upgrades/next/undated-action-resurfacer.md
@@ -23,7 +23,8 @@ still depends on the scheduler running and arrivals staying below the service ra
 ## Summary of New Capabilities
 
 - Deterministically selects one oldest eligible action through balanced critical
-  and high-priority lanes, including actions with an explicit no-date reason.
+  and high-priority lanes, including actions with an explicit no-date reason and
+  legacy durable-store spellings such as uppercase `HIGH` and top-tier `urgent`.
 - Persists cooldown, delivery, outcome, retry, and terminal-disposition evidence
   across restarts.
 - Exposes a health read and a bounded manual pass through the existing evolution
@@ -46,3 +47,8 @@ still depends on the scheduler running and arrivals staying below the service ra
   deliberately left to the dark → dry-run → live rollout gate.
 - The self-action convergence ratchet models the durable four-hour rate floor
   across repeated reconstruction.
+- A pre-live snapshot records that the currently unresolved cohort's seven-day
+  creation-age density is roughly 10.7 times the steady-state terminal capacity
+  and that the 30-day high-priority promotion currently has no pending inputs.
+  The density is not historical intake; the feature remains flood-bounded reach,
+  not backlog drainage.

--- a/upgrades/next/undated-action-resurfacer.md
+++ b/upgrades/next/undated-action-resurfacer.md
@@ -1,0 +1,48 @@
+<!-- bump: minor -->
+
+## What Changed
+
+Instar now has bounded reach for pending high- and critical-priority evolution
+actions that have no due date. The development agent exercises the production
+selection, durable ledger, stable-owner-plus-lease gate, and metrics in dry-run mode by default;
+other agents remain dark until explicitly enabled.
+
+Each live pass can surface at most one action. A durable four-hour global cadence,
+14-day per-action cooldown, three-raise disposition terminal, stable delivery id,
+three-attempt retry cap, and 4 MiB ledger ceiling prevent restarts, overlapping
+passes, transport failures, and storage growth from turning the feature into a
+notification or retry flood.
+
+## What to Tell Your User
+
+Important actions without honest due dates now have a bounded path back into view.
+Instar can bring one old, high-priority action back for review at a controlled pace
+without changing, completing, or cancelling the action on its own. Eventual reach
+still depends on the scheduler running and arrivals staying below the service rate.
+
+## Summary of New Capabilities
+
+- Deterministically selects one oldest eligible action through balanced critical
+  and high-priority lanes, including actions with an explicit no-date reason.
+- Persists cooldown, delivery, outcome, retry, and terminal-disposition evidence
+  across restarts.
+- Exposes a health read and a bounded manual pass through the existing evolution
+  action service.
+- On a multi-machine agent, requires every registered peer's latest authenticated
+  advert to agree on one stable owner, and pauses during a handoff away from it
+  instead of resetting history.
+- Records whether a surfaced action changed state after one cooldown period.
+- Ships development-live but dry-run-first; live Attention delivery requires an
+  explicit rollout decision.
+
+## Evidence
+
+- Unit coverage pins lane weighting, age override, cooldown, explicit opt-out
+  reach, reset, retirement, retries, cadence reconstruction, and terminal state.
+- Integration coverage pins the read/run routes, real Attention dedupe behavior,
+  and the on-disk growth ceiling.
+- Lifecycle coverage boots the real server path, reads the real action store, and
+  proves delegation to the production Attention seam; live transport evidence is
+  deliberately left to the dark → dry-run → live rollout gate.
+- The self-action convergence ratchet models the durable four-hour rate floor
+  across repeated reconstruction.

--- a/upgrades/side-effects/undated-action-resurfacer.md
+++ b/upgrades/side-effects/undated-action-resurfacer.md
@@ -1,0 +1,229 @@
+# Side-Effects Review — Undated Action Resurfacer
+
+**Version / slug:** `undated-action-resurfacer`
+**Date:** `2026-08-01`
+**Author:** Instar-codey
+**Driving spec:** `docs/specs/undated-action-resurfacer.md`
+**Second-pass reviewer:** Codex independent reviewer
+**Review posture:** reviewed against production wiring, failure paths,
+bounded accumulation, signal-vs-authority, and self-action convergence
+
+## Summary
+
+Adds the action half of Close-the-Loop reach through a dedicated monitor, server
+wiring, two authenticated evolution-action routes, a state-coherence registry
+entry, and layered tests. The existing overdue checker keeps owning dated
+actions. This component owns only pending, undated, high/critical actions and
+surfaces at most one Attention item per durable four-hour cadence. It never
+mutates an action.
+
+## Decision-point inventory
+
+- eligibility — **invariant** — recorded status, due date, and priority only;
+- selection — **invariant** — fixed 3:1 lanes, 30-day high-priority override,
+  oldest creation time, then id;
+- delivery — **invariant** — durable claim, stable id, emit, confirmation;
+- terminal state — **invariant** — three unchanged raises require disposition;
+- semantic disposition — **external authority** — a human or acting agent may
+  work, cancel with reason, date, or split; the resurfacer cannot choose.
+
+## 1. Over-block
+
+The durable global cadence means a manual pass immediately after startup returns
+without selecting another row. That is deliberate: a manual endpoint or restart
+loop must not compress a four-hour scheduler into a flood. Pending rows with a
+due date, lower priority, an active claim, a failed terminal claim, cooldown, or
+needs-disposition state are excluded. A content, priority, or due-date edit resets
+the raise series and restarts cooldown so active human engagement is not mistaken
+for neglect.
+
+At the 4 MiB ledger ceiling, the component refuses before appending. This pauses
+reach until the ledger is reviewed rather than discarding actionable history.
+
+## 2. Under-block
+
+One item per four hours cannot drain the measured stock quickly, and the spec
+states that explicitly. This is continuous reach, not backlog remediation.
+Eventual surfacing depends on bounded eligible growth and a running scheduler.
+
+The pool-agreed stable-owner ledger trades availability for coherent cooldown
+state. When the serving lease moves away from that owner, resurfacing pauses even though another
+machine is serving. If any registered peer's latest authenticated advert omits
+or disagrees on the owner proposal, it refuses visibly. A handback resumes the
+original ledger; automatic state-owner migration is not claimed.
+
+At storage capacity, the stable warning relies on the existing Attention dedupe
+because the full ledger cannot safely persist a new warning marker. Repeated failed
+deliveries can therefore be attempted again, but they keep one stable id and the
+component remains stopped.
+
+## 3. Level-of-abstraction fit
+
+Selection and event folding live in a dedicated monitoring component. AgentServer
+owns construction against the real action store, Attention destination, feature
+metrics, and serving lease. Routes expose only status and one bounded pass. The
+existing dated checker and action schema are unchanged.
+
+## 4. Signal vs authority
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Decision-point answer:** yes. Eligibility, cadence, retry, capacity, and
+ownership checks constrain whether the component may emit a signal. They are
+enumerable transport and control-loop invariants, not judgments about what an
+action means.
+
+The component has deterministic delivery-policy authority: it decides whether and
+when an eligible recorded row may produce an Attention item, including cadence,
+retry, ownership, and capacity gates. Its emitted content is informational and it
+has no semantic disposition authority: it never completes, cancels, reprioritizes,
+dates, or splits an action. All selectors and brakes are deterministic invariants;
+no model judgment is smuggled into the controller.
+
+It therefore has no brittle semantic block authority. The only output is a
+review signal delivered to Attention. Stable ids and duplicate suppression are
+transport idempotency mechanics, an explicit exception in the governing
+principle, while the owner/lease conjunction protects a single local ledger.
+
+The recurring-notice self-heal rule does not apply as a first-detection repair
+gate here: an undated action awaiting a disposition is not a recoverable machine
+degradation, and choosing or performing its work is precisely the authority this
+component is forbidden to assume. Its bounded handoff is the intended effect.
+
+## 4b. Judgment-point check
+
+No new static heuristic is placed at a competing-signals judgment point. The
+fixed lane schedule orders rows inside an explicitly enumerated eligible set;
+the stable-owner, lease, cooldown, retry, and byte-ceiling checks are mechanical
+safety floors. None chooses whether the underlying action should be performed.
+
+## 5. Interactions
+
+- Dated actions remain exclusively owned by the overdue checker.
+- Explicit creation-time follow-through opt-out remains eligible; it explains the
+  missing date and does not grant permanent invisibility.
+- Attention receives stable ids for ordinary raises, replay, aggregate disposition,
+  and capacity refusal. Ordinary ids include a durable series generation so retry
+  dedupes while a meaningful-edit reset cannot be suppressed by an earlier item.
+- Feature metrics record fired, no-op, and error outcomes. The health read projects
+  owner/lease blocking, last attempt/run, pool/cooldown counts, pending/failed/
+  abandoned delivery claims, aggregate-alert claims, per-action raise/age state,
+  and delayed outcomes by status from the append-only control ledger.
+- The self-action registry declares this as an Eternal Sentinel with a durable
+  four-hour rate floor and a three-raise per-target terminal.
+- Initialization occurs after feature-metrics construction, and stop clears the
+  cadence timer.
+- Every confirmed delivery claim keeps its own delayed outcome schedule independent
+  of the current projection, so completion, dating, or a meaningful-edit reset
+  cannot erase the sample.
+
+## 6. External surfaces
+
+Two authenticated evolution-action service operations are added: a readable
+health/status operation and a one-pass trigger. The only user-visible live effect
+is an Attention item; default development rollout is dry-run and fleet rollout is
+dark. No action content is sent to a new service, and no new topic is created.
+
+No operator-facing form, dashboard renderer, approval flow, or raw-input action
+is added. The bounded pass is an authenticated agent-service operation and can be
+invoked conversationally by the agent; it does not require the operator to use a
+laptop or enter structured data.
+
+## 6b. Operator-surface quality
+
+No operator surface is changed, so the four operator-surface quality criteria
+are not applicable. The user-visible artifact remains an ordinary Attention item
+in plain language.
+
+## 7. Multi-machine posture
+
+Pool-agreed stable-owner machine-local. The ledger is bound to one configured
+machine's local action-id namespace, but a local config value is only a proposal:
+every registered pool member's latest authenticated heartbeat must advertise the
+same owner. Missing or divergent adverts fail closed. The agreed owner may run
+only while it also holds the serving lease. A handoff to a different machine pauses rather than
+constructing fresh cooldown state; a handback resumes the original ledger. No
+credential, URL, action mutation, or cooldown event is replicated by this feature.
+
+It emits user-facing notices only while the stable ledger owner also holds the
+serving lease, so it retains one voice. Durable state intentionally remains with
+that owner and a lease handoff pauses the feature; no generated URLs exist.
+
+### Bounded accumulation
+
+The ledger is registered with a fixed 4 MiB ceiling and whole-file access below
+the repository's 8 MiB synchronous-read limit. The writer refuses before the
+ceiling, preserves old actionable evidence, exposes capacity health, and emits a
+stable high-priority capacity signal. The integration growth burst asserts the
+file stays within the configured test ceiling.
+
+## 8. Rollback cost
+
+Disable the feature or revert the construction, routes, component, registry row,
+and tests. The ledger is additive local state ignored by older versions. No action
+schema or action record requires migration or repair. Existing Attention items
+remain ordinary resolvable queue entries.
+
+Rollback is a normal hot-fix release: disable the feature immediately or revert
+the runtime wiring in the next patch. The additive ledger needs no migration and
+may remain on disk for a later re-enable; no action-store repair is required.
+
+## Conclusion
+
+The review changed the design materially before publication: lease-holder-only
+state was replaced by a pool-agreed stable owner plus serving lease, reset series
+received distinct Attention identities, every emitted claim retained its own
+outcome schedule, aggregate failure now consumes its retry budget instead of
+renewing forever, and capacity makes health non-operational rather than merely
+setting a side flag. The independent re-review concurs that all six concerns are
+closed. The change is suitable for draft review while rollout remains dry-run-first
+and fleet-dark.
+
+## Second-pass review
+
+The independent reviewer requested changes after finding three publication blockers:
+
+- reset reused `resurface:{actionId}:1`, which the permanent Attention id store
+  could suppress even though the ledger recorded a new series;
+- the proposed stable owner was derived from potentially divergent local config,
+  so two machines could each declare their empty local ledger canonical; and
+- a meaningful edit reset the current projection and could erase the pending
+  delayed outcome sample for an earlier confirmed delivery.
+
+The implementation now assigns each reset a durable series generation, requires
+unanimous latest owner adverts from all registered authenticated pool members,
+and schedules outcomes per confirmed claim rather than per current projection.
+The authority and live-evidence wording was also narrowed: this is delivery-policy authority
+without action-disposition authority, and live transport evidence remains a
+rollout gate rather than a draft-PR claim.
+
+**Reviewer status:** **CONCUR.** The independent reviewer verified that all six
+prior blockers are closed in code, tests, and claims. Its focused run passed 34
+tests across the unit, real-Attention integration, authenticated peer-presence
+integration, and production lifecycle tiers.
+
+## Evidence
+
+- Focused unit, integration, lifecycle, development-gate, and self-action
+  convergence suites are green; the exact command and counts belong in the PR
+  verification record rather than a claim that can go stale in this artifact.
+- Failure paths cover overlapping instances, restart cadence, transport replay,
+  terminal retry without budget renewal, meaningful-edit reset through the real
+  Attention dedupe store, divergent multi-machine owner proposals across handoff
+  and handback, dated/completed retirement, per-claim delayed outcomes across
+  reset, aggregate disposition, and storage refusal.
+
+## Class-Closure Declaration
+
+**Class:** `unbounded-self-action` · **Closure:** `guard` · **Enforcement:** ratchet
+**Citation:** `tests/unit/self-action-convergence.test.ts`
+**How caught:** under an indefinitely non-empty backlog, the ratchet reconstructs
+the controller under sustained pressure and rejects any implementation that loses
+the durable four-hour global rate floor or exceeds the three-raise per-target
+brake; the live controller adds the same stable-owner/lease conjunction and a
+fixed storage ceiling.
+
+Registered as `undated-action-resurfacer`. Under indefinitely non-empty backlog
+pressure, emission is an explicit Eternal Sentinel bounded by a durable four-hour
+rate floor; reconstruction reads the same run ledger, per-row raises stop after
+three unchanged passes, and the capacity ceiling stops storage growth loudly.

--- a/upgrades/side-effects/undated-action-resurfacer.md
+++ b/upgrades/side-effects/undated-action-resurfacer.md
@@ -13,8 +13,9 @@ bounded accumulation, signal-vs-authority, and self-action convergence
 Adds the action half of Close-the-Loop reach through a dedicated monitor, server
 wiring, two authenticated evolution-action routes, a state-coherence registry
 entry, and layered tests. The existing overdue checker keeps owning dated
-actions. This component owns only pending, undated, high/critical actions and
-surfaces at most one Attention item per durable four-hour cadence. It never
+actions. This component owns only pending, undated, high/critical actions
+(including case-normalized historical spellings and legacy top-tier `urgent`)
+and surfaces at most one Attention item per durable four-hour cadence. It never
 mutates an action.
 
 ## Decision-point inventory
@@ -45,6 +46,18 @@ reach until the ledger is reviewed rather than discarding actionable history.
 One item per four hours cannot drain the measured stock quickly, and the spec
 states that explicitly. This is continuous reach, not backlog remediation.
 Eventual surfacing depends on bounded eligible growth and a running scheduler.
+
+The pre-live snapshot measured about 21.4 rows/day of creation-age density in the
+newest seven days of the currently unresolved eligible cohort, against a
+steady-state ceiling of two rows/day reaching the three-raise terminal, a 10.7×
+ratio. This is not historical intake because resolved, dated, and reprioritized
+rows are absent. It is recorded as open-pressure evidence, not reclassified as a
+defect; live arrival and exit rates are required before choosing the next lever.
+
+The 30-day high-to-critical override currently promotes no row: zero pending
+actions are older than 30 days, while the 520 older stored rows are 515 cancelled
+and 5 completed. The implementation keeps the future starvation brake and makes
+no claim that it contributes to present-day throughput.
 
 The pool-agreed stable-owner ledger trades availability for coherent cooldown
 state. When the serving lease moves away from that owner, resurfacing pauses even though another
@@ -102,6 +115,9 @@ safety floors. None chooses whether the underlying action should be performed.
 - Dated actions remain exclusively owned by the overdue checker.
 - Explicit creation-time follow-through opt-out remains eligible; it explains the
   missing date and does not grant permanent invisibility.
+- The runtime boundary case-normalizes stored priority values and maps legacy
+  `urgent` to the critical lane and URGENT Attention severity. Regression tests
+  cover the exact live-store spellings that exposed the mismatch.
 - Attention receives stable ids for ordinary raises, replay, aggregate disposition,
   and capacity refusal. Ordinary ids include a durable series generation so retry
   dedupes while a meaningful-edit reset cannot be suppressed by an earlier item.
@@ -119,10 +135,12 @@ safety floors. None chooses whether the underlying action should be performed.
 
 ## 6. External surfaces
 
-Two authenticated evolution-action service operations are added: a readable
-health/status operation and a one-pass trigger. The only user-visible live effect
-is an Attention item; default development rollout is dry-run and fleet rollout is
-dark. No action content is sent to a new service, and no new topic is created.
+Two authenticated evolution-action service operations are added: the readable
+health/status operation `GET /evolution/actions/undated-resurfacer` and the
+one-pass trigger `POST /evolution/actions/undated-resurfacer/pass`. The only
+user-visible live effect is an Attention item; default development rollout is
+dry-run and fleet rollout is dark. No action content is sent to a new service,
+and no new topic is created.
 
 No operator-facing form, dashboard renderer, approval flow, or raw-input action
 is added. The bounded pass is an authenticated agent-service operation and can be
@@ -175,9 +193,11 @@ state was replaced by a pool-agreed stable owner plus serving lease, reset serie
 received distinct Attention identities, every emitted claim retained its own
 outcome schedule, aggregate failure now consumes its retry budget instead of
 renewing forever, and capacity makes health non-operational rather than merely
-setting a side flag. The independent re-review concurs that all six concerns are
-closed. The change is suitable for draft review while rollout remains dry-run-first
-and fleet-dark.
+setting a side flag. A later live-data review also found the typed/runtime
+priority mismatch; case normalization and `urgent` compatibility now close it,
+while the measured cadence gap and inactive age lane are recorded without
+silently changing policy. The change is suitable for draft review while rollout
+remains dry-run-first and fleet-dark.
 
 ## Second-pass review
 
@@ -201,6 +221,14 @@ rollout gate rather than a draft-PR claim.
 prior blockers are closed in code, tests, and claims. Its focused run passed 34
 tests across the unit, real-Attention integration, authenticated peer-presence
 integration, and production lifecycle tiers.
+
+A follow-up review of the live-data delta initially withheld concurrence for two
+reasons: the creation-age density of the currently unresolved cohort had been
+overstated as historical intake, and representation-only priority changes were
+normalized in code without a regression pinning series continuity. The claims
+now name the snapshot and its survivor bias, rollout reserves actual arrival/exit
+measurement, and the regression proves `urgent` → `CRITICAL` continues at
+`s1:2`. **Follow-up reviewer status: CONCUR.**
 
 ## Evidence
 


### PR DESCRIPTION
## Description

- Adds bounded reach for pending important evolution actions with no due date: one deterministic candidate per durable cadence, a per-action cooldown, and a three-raise disposition terminal.
- Uses two-phase delivery claims, retry-stable Attention identities, durable reset generations, per-confirmed-claim outcome sampling, and a fixed ledger ceiling.
- Makes multi-machine state authority fail closed: every registered peer's latest authenticated advert must agree on one stable ledger owner, and that owner must also hold the serving lease.
- Normalizes historical durable-store priorities case-insensitively and treats legacy `urgent` as the critical/top-priority lane, closing the live-data miss found after draft review.
- Documents the authenticated status/pass routes and records the measured cadence and inactive 30-day lane as rollout constraints, without silently changing the flood-bounded policy.

## ELI16

The agent has a long list of important things it noticed but never gave a date. Its old reminder only understands dated work, so most of that list can disappear from view even though the entries still exist. This change brings back one old important entry at a controlled pace, then waits before showing that entry again. It never marks the work done, cancels it, changes its importance, or invents a date. On installations with more than one machine, it pauses unless every machine agrees which one owns the reminder history, so moving service cannot erase the waiting period or make the same item look new. It starts in a preview mode so the choices can be checked before any reminder is shown.

## UX Impact

Who sees it: the agent operator sees an ordinary Attention item only after the feature is deliberately promoted from dry-run to live; maintainers can inspect its authenticated health read during rollout. The user-visible first contact is a plain-language Attention item titled “Undated action needs review: …”, containing the action id, age, priority, and title without proposing a decision. The first API-visible contact is `/evolution/actions/undated-resurfacer`, which reports whether the component is enabled, dry-running, blocked on machine agreement, or operating normally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Risk and rollout

- Development-agent enabled but dry-run by default; fleet remains dark.
- Live emission is bounded to one item per four-hour cadence, with a 14-day row cooldown, three delivery attempts, three unchanged raises, and a 4 MiB ledger ceiling.
- Missing/divergent pool-owner adverts or a serving-lease handoff away from the stable owner pause the feature rather than resetting state.
- Live transport evidence remains an explicit rollout gate and is not claimed by this draft PR.
- The currently unresolved cohort's seven-day creation-age density is about 21.4 rows/day versus a steady-state ceiling of two unchanged rows/day reaching terminal. This is not historical intake because already resolved rows are absent; it is recorded as open-pressure evidence, and the feature claims bounded reach rather than backlog drainage.

## Verification

- 66 targeted checks passed across selection/durable lifecycle, real Attention persistence and dedupe, authenticated routes, peer-presence agreement, production lifecycle, development gating, and silent-fallback enforcement.
- The documentation coverage route floor passes at 55% with both new operations documented.
- Repository lint passed.
- TypeScript build passed.
- Independent review approved the three-clause bar; the one live-data defect it found is fixed and regression-covered here.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My code follows the project's style (TypeScript strict mode)
- [x] I have added tests for my changes
- [x] Focused tests pass locally
- [x] `npm run build` passes locally
- [x] I have updated documentation
