### PR TITLE
feat: add verified Cartographer root authority

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-02T08-43-07-485Z-cartographer-verified-root-authority.json
+++ b/.instar/instar-dev-decisions/2026-08-02T08-43-07-485Z-cartographer-verified-root-authority.json
@@ -1,0 +1,25 @@
+{
+  "ts": "2026-08-02T08:43:07.485Z",
+  "slug": "cartographer-verified-root-authority",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 735,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CartographerRootAuthority.ts",
+      "src/core/CartographerTree.ts"
+    ],
+    "addedLines": 734,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-02T08-58-19-661Z-cartographer-verified-root-authority.json
+++ b/.instar/instar-dev-decisions/2026-08-02T08-58-19-661Z-cartographer-verified-root-authority.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-02T08:58:19.661Z",
+  "slug": "cartographer-verified-root-authority",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CartographerRootAuthority.ts"
+    ],
+    "addedLines": 1,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-02T08-59-15-485Z-cartographer-verified-root-authority.json
+++ b/.instar/instar-dev-decisions/2026-08-02T08-59-15-485Z-cartographer-verified-root-authority.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-02T08:59:15.485Z",
+  "slug": "cartographer-verified-root-authority",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CartographerRootAuthority.ts"
+    ],
+    "addedLines": 1,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-02T09-00-04-027Z-cartographer-verified-root-authority.json
+++ b/.instar/instar-dev-decisions/2026-08-02T09-00-04-027Z-cartographer-verified-root-authority.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-02T09:00:04.027Z",
+  "slug": "cartographer-verified-root-authority",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 2,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/CartographerRootAuthority.ts"
+    ],
+    "addedLines": 1,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/cartographer-doc-tree-schema.eli16.md
+++ b/docs/specs/cartographer-doc-tree-schema.eli16.md
@@ -70,3 +70,13 @@ node. None of these change *what* the map is — only how it's tuned.
 Nothing visible yet — this is foundation. On its own it's an empty, structure-only
 map. It becomes useful when the next specs fill in the notes and start using them.
 It ships turned off until then.
+
+## Verified-root foundation
+
+Before project-aware navigation can trust this map, Cartographer also needs to
+prove which code checkout it is mapping. The first root-authority slice adds that
+checkpoint without connecting it to live navigation yet: an explicitly selected
+project can be matched to its repository and exact revision, contradictory
+evidence is refused, and a checkout without readable Git identity may keep its
+free structural map but cannot spend money writing trusted descriptions. A
+separate follow-up connects the checkpoint to the live reader and writer.

--- a/src/core/CartographerRootAuthority.ts
+++ b/src/core/CartographerRootAuthority.ts
@@ -332,7 +332,7 @@ function readGit(cwd: string, args: readonly string[]): string | null {
     }).trim();
     return value || null;
   } catch {
-    return null;
+    return null; /* @silent-fallback-ok — unreadable Git evidence becomes a required structured authority decision */
   }
 }
 

--- a/src/core/CartographerRootAuthority.ts
+++ b/src/core/CartographerRootAuthority.ts
@@ -1,0 +1,722 @@
+/**
+ * CartographerRootAuthority — inert root-selection and verification substrate.
+ *
+ * This module deliberately does not wire itself into Cartographer routes or the
+ * freshness sweep. It separates three questions that the old projectDir
+ * singleton collapsed:
+ *
+ *   1. Which root did a provenance-bearing source select?
+ *   2. What repository identity and revision are actually present there?
+ *   3. Which operations are safe at the resulting trust level?
+ *
+ * A selected directory without a readable Git HEAD remains useful for the
+ * zero-cost structural hierarchy, but it is never eligible for paid authoring.
+ * Contradictory evidence (for example an expected-remote mismatch) refuses the
+ * root entirely. PR 11B-2 is the consumer boundary that will apply this contract
+ * to live navigation, reporting, and authoring.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { SafeGitExecutor } from './SafeGitExecutor.js';
+
+export type CartographerRootKind =
+  'agent-home' | 'active-project-checkout' | 'instar-source-checkout';
+
+export type CartographerRootProvenance =
+  | { source: 'agent-home'; agentName: string }
+  | { source: 'server-project'; projectName: string }
+  | { source: 'topic-binding'; topicId: number; projectName: string }
+  | { source: 'operator-binding'; bindingId: string; projectName: string };
+
+export interface CartographerRootCandidate {
+  kind: CartographerRootKind;
+  requestedPath: string;
+  provenance: CartographerRootProvenance;
+  /** Optional repository anchor supplied by the provenance source. */
+  expectedRemote?: string;
+  /** Optional exact revision anchor, primarily used for revalidation. */
+  expectedRevision?: string;
+}
+
+export type CartographerRootSelectionRequest =
+  | {
+      kind: 'agent-home';
+      agentHome: string;
+      agentName: string;
+    }
+  | {
+      kind: 'active-project-checkout';
+      standalone: boolean;
+      serverProject?: {
+        projectDir: string;
+        projectName: string;
+        gitRemote?: string;
+      };
+      topicBinding?: {
+        topicId: number;
+        projectDir: string;
+        projectName: string;
+        gitRemote?: string;
+      };
+    }
+  | {
+      kind: 'instar-source-checkout';
+      binding: {
+        bindingId: string;
+        projectDir: string;
+        projectName: string;
+        gitRemote: string;
+      };
+    };
+
+export type CartographerRootSelectionResult =
+  | { ok: true; candidate: CartographerRootCandidate }
+  | {
+      ok: false;
+      code:
+        | 'topic-binding-required'
+        | 'server-project-required'
+        | 'instar-source-binding-required';
+      message: string;
+    };
+
+export type CartographerRootTrust = 'verified' | 'structural-only' | 'refused';
+
+export type CartographerRootReason =
+  | 'verified'
+  | 'path-missing'
+  | 'path-not-directory'
+  | 'canonicalize-failed'
+  | 'git-root-unreadable'
+  | 'candidate-not-git-root'
+  | 'head-unreadable'
+  | 'instar-source-expectation-missing'
+  | 'remote-unreadable'
+  | 'remote-mismatch'
+  | 'revision-mismatch'
+  | 'root-identity-mismatch';
+
+export interface CartographerRootIdentity {
+  /** Stable for this checked-out root across revisions. */
+  rootId: string;
+  /** Stable repository identity derived from an anchored remote or common Git dir. */
+  repositoryId: string | null;
+  kind: CartographerRootKind;
+  canonicalPath: string;
+  gitTopLevel: string | null;
+  remoteUrl: string | null;
+  revision: string | null;
+  /** Safe, opaque namespace for stateDir/cartographer/roots/<namespace>. */
+  stateNamespace: string;
+}
+
+export interface CartographerRootAssessment {
+  candidate: CartographerRootCandidate;
+  trust: CartographerRootTrust;
+  reason: CartographerRootReason;
+  identity: CartographerRootIdentity | null;
+  /** Structural population is zero-egress and survives missing Git identity. */
+  structuralPopulationAllowed: boolean;
+  /** Paid authoring requires a verified project/source checkout and exact readable revision. */
+  paidAuthoringAllowed: boolean;
+}
+
+export interface CartographerRootDecisionSignals {
+  pathState: 'unreadable' | 'file' | 'directory';
+  canonicalPath: string | null;
+  gitTopLevel: string | null;
+  expectedRemote: string | null;
+  observedRemotes: string[];
+  expectedRevision: string | null;
+  observedRevision: string | null;
+}
+
+/**
+ * Structured evidence emitted for every authority outcome. The recorder is a
+ * required dependency: a live consumer cannot obtain an allow/degrade/refuse
+ * result without also accepting responsibility for its decision trail.
+ */
+export interface CartographerRootDecision {
+  schemaVersion: 1;
+  decidedAt: string;
+  operation: 'assess' | 'revalidate';
+  context: { candidate: CartographerRootCandidate };
+  signals: CartographerRootDecisionSignals;
+  rule: CartographerRootReason | 'revalidation-not-applicable';
+  outcome: {
+    trust: CartographerRootTrust;
+    structuralPopulationAllowed: boolean;
+    paidAuthoringAllowed: boolean;
+    rootId: string | null;
+    stateNamespace: string | null;
+  };
+}
+
+export interface CartographerRootAuthorityOptions {
+  /** Must durably record in a live consumer. Throwing prevents an unlogged outcome. */
+  recordDecision: (decision: CartographerRootDecision) => void;
+  now?: () => Date;
+}
+
+const GIT_OP = 'cartographer-root-authority';
+
+/**
+ * Select a candidate only from an explicit, typed provenance source.
+ *
+ * In particular, a standalone active-project request never falls back to the
+ * agent home. That fallback is the wrong-root failure this contract exists to
+ * remove. Instar source is explicit-only: directory scanning and marker files
+ * may corroborate an identity later, but can never select it.
+ */
+export function selectCartographerRootCandidate(
+  request: CartographerRootSelectionRequest,
+): CartographerRootSelectionResult {
+  if (request.kind === 'agent-home') {
+    return {
+      ok: true,
+      candidate: {
+        kind: request.kind,
+        requestedPath: request.agentHome,
+        provenance: { source: 'agent-home', agentName: request.agentName },
+      },
+    };
+  }
+
+  if (request.kind === 'instar-source-checkout') {
+    if (!request.binding?.projectDir || !request.binding.gitRemote) {
+      return {
+        ok: false,
+        code: 'instar-source-binding-required',
+        message:
+          'Instar source selection requires an explicit binding with a repository anchor',
+      };
+    }
+    return {
+      ok: true,
+      candidate: {
+        kind: request.kind,
+        requestedPath: request.binding.projectDir,
+        provenance: {
+          source: 'operator-binding',
+          bindingId: request.binding.bindingId,
+          projectName: request.binding.projectName,
+        },
+        expectedRemote: request.binding.gitRemote,
+      },
+    };
+  }
+
+  if (request.topicBinding) {
+    return {
+      ok: true,
+      candidate: {
+        kind: request.kind,
+        requestedPath: request.topicBinding.projectDir,
+        provenance: {
+          source: 'topic-binding',
+          topicId: request.topicBinding.topicId,
+          projectName: request.topicBinding.projectName,
+        },
+        expectedRemote: request.topicBinding.gitRemote,
+      },
+    };
+  }
+
+  if (request.standalone) {
+    return {
+      ok: false,
+      code: 'topic-binding-required',
+      message:
+        'A standalone active-project root requires a topic-project binding',
+    };
+  }
+
+  if (!request.serverProject) {
+    return {
+      ok: false,
+      code: 'server-project-required',
+      message:
+        'A project-bound active-project root requires the server project declaration',
+    };
+  }
+
+  return {
+    ok: true,
+    candidate: {
+      kind: request.kind,
+      requestedPath: request.serverProject.projectDir,
+      provenance: {
+        source: 'server-project',
+        projectName: request.serverProject.projectName,
+      },
+      expectedRemote: request.serverProject.gitRemote,
+    },
+  };
+}
+
+/** Normalize common HTTPS, SSH, and scp-like Git remote spellings for identity comparison. */
+export function normalizeCartographerGitRemote(raw: string): string {
+  let value = raw.trim();
+  while (value.endsWith('/')) value = value.slice(0, -1);
+  if (/\.git$/i.test(value)) value = value.slice(0, -4);
+
+  const normalizePath = (host: string, rawPath: string): string => {
+    const clean = rawPath
+      .replace(/^\/+/, '')
+      .replace(/\.git$/i, '')
+      .replace(/\/+$/, '');
+    // github.com documents repository URLs as case-insensitive. Preserve path
+    // case everywhere else: folding an unknown forge's path can collapse two
+    // genuinely different repositories into one trusted identity.
+    return host === 'github.com' ? clean.toLowerCase() : clean;
+  };
+
+  const scp = value.match(/^(?:[^@/]+@)?([^:/]+):(.+)$/);
+  if (scp && !value.includes('://')) {
+    const host = scp[1].toLowerCase();
+    return `${host}/${normalizePath(host, scp[2])}`;
+  }
+
+  try {
+    const parsed = new URL(value);
+    const host = parsed.hostname.toLowerCase();
+    const pathname = normalizePath(host, parsed.pathname);
+    if (parsed.protocol === 'file:') return `file:${pathname}`;
+    const defaultPort =
+      (parsed.protocol === 'ssh:' && parsed.port === '22') ||
+      (parsed.protocol === 'git:' && parsed.port === '9418') ||
+      (parsed.protocol === 'http:' && parsed.port === '80') ||
+      (parsed.protocol === 'https:' && parsed.port === '443');
+    const authority =
+      parsed.port && !defaultPort ? `${host}:${parsed.port}` : host;
+    return `${authority}/${pathname}`;
+  } catch {
+    // Unknown syntax is not safe to case-fold. Equality remains available for
+    // byte-equivalent anchors without manufacturing false equivalence.
+    return value;
+  }
+}
+
+function digest(value: string, length = 24): string {
+  return crypto
+    .createHash('sha256')
+    .update(value, 'utf8')
+    .digest('hex')
+    .slice(0, length);
+}
+
+function provenanceKey(provenance: CartographerRootProvenance): string {
+  switch (provenance.source) {
+    case 'agent-home':
+      return `agent-home:${provenance.agentName}`;
+    case 'server-project':
+      return `server-project:${provenance.projectName}`;
+    case 'topic-binding':
+      return `topic-binding:${provenance.topicId}:${provenance.projectName}`;
+    case 'operator-binding':
+      return `operator-binding:${provenance.bindingId}:${provenance.projectName}`;
+  }
+}
+
+function readGit(cwd: string, args: readonly string[]): string | null {
+  try {
+    // Root verification must work against the Instar source checkout itself.
+    // SafeGitExecutor keeps this opt-in narrow: only its closed read-tier verb
+    // allowlist bypasses SourceTreeGuard; a destructive/differently-shaped call
+    // still cannot pass through this option.
+    const value = SafeGitExecutor.readSync(args, {
+      cwd,
+      operation: GIT_OP,
+      sourceTreeReadOk: true,
+    }).trim();
+    return value || null;
+  } catch {
+    return null;
+  }
+}
+
+function readRemotes(
+  cwd: string,
+): Array<{ name: string; url: string; normalized: string }> {
+  // `remote -v` is on SafeGitExecutor's source-tree read-tier allowlist, while
+  // arbitrary config access intentionally is not. Parse fetch identities only:
+  // a push-only URL proves write destination, not which repository was checked out.
+  const raw = readGit(cwd, ['remote', '-v']);
+  if (!raw) return [];
+  const remotes: Array<{ name: string; url: string; normalized: string }> = [];
+  for (const line of raw.split('\n')) {
+    const match = line.match(/^(\S+)\s+(.+?)\s+\(fetch\)$/);
+    if (!match) continue;
+    const url = match[2].trim();
+    if (!url) continue;
+    remotes.push({
+      name: match[1],
+      url,
+      normalized: normalizeCartographerGitRemote(url),
+    });
+  }
+  return remotes;
+}
+
+function canonicalCommonGitDir(cwd: string): string | null {
+  const raw = readGit(cwd, ['rev-parse', '--git-common-dir']);
+  if (!raw) return null;
+  const absolute = path.isAbsolute(raw) ? raw : path.resolve(cwd, raw);
+  try {
+    return fs.realpathSync(absolute);
+  } catch {
+    return path.resolve(absolute);
+  }
+}
+
+function identityFor(input: {
+  candidate: CartographerRootCandidate;
+  canonicalPath: string;
+  gitTopLevel: string | null;
+  remoteUrl: string | null;
+  commonGitDir: string | null;
+  revision: string | null;
+}): CartographerRootIdentity {
+  const remoteIdentity = input.remoteUrl
+    ? `remote:${normalizeCartographerGitRemote(input.remoteUrl)}`
+    : null;
+  const repositoryBasis =
+    remoteIdentity ??
+    (input.commonGitDir ? `common-git-dir:${input.commonGitDir}` : null);
+  const repositoryId = repositoryBasis ? digest(repositoryBasis) : null;
+  const rootBasis = repositoryId
+    ? `${input.candidate.kind}\0${repositoryId}\0${input.canonicalPath}`
+    : `${input.candidate.kind}\0structural\0${provenanceKey(input.candidate.provenance)}\0${input.canonicalPath}`;
+  const rootId = digest(rootBasis);
+  return {
+    rootId,
+    repositoryId,
+    kind: input.candidate.kind,
+    canonicalPath: input.canonicalPath,
+    gitTopLevel: input.gitTopLevel,
+    remoteUrl: input.remoteUrl,
+    revision: input.revision,
+    stateNamespace: `root-${rootId}`,
+  };
+}
+
+function refused(
+  candidate: CartographerRootCandidate,
+  reason: CartographerRootReason,
+  identity: CartographerRootIdentity | null = null,
+): CartographerRootAssessment {
+  return {
+    candidate,
+    trust: 'refused',
+    reason,
+    identity,
+    structuralPopulationAllowed: false,
+    paidAuthoringAllowed: false,
+  };
+}
+
+function structuralOnly(
+  candidate: CartographerRootCandidate,
+  reason: CartographerRootReason,
+  identity: CartographerRootIdentity,
+): CartographerRootAssessment {
+  return {
+    candidate,
+    trust: 'structural-only',
+    reason,
+    identity,
+    structuralPopulationAllowed: true,
+    paidAuthoringAllowed: false,
+  };
+}
+
+export class CartographerRootAuthority {
+  private readonly recordDecision: (decision: CartographerRootDecision) => void;
+  private readonly now: () => Date;
+
+  constructor(options: CartographerRootAuthorityOptions) {
+    this.recordDecision = options.recordDecision;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  private decide(
+    assessment: CartographerRootAssessment,
+    operation: 'assess' | 'revalidate',
+    signals: CartographerRootDecisionSignals,
+    rule: CartographerRootDecision['rule'] = assessment.reason,
+  ): CartographerRootAssessment {
+    // Do not return an authority outcome if its required audit sink fails. That
+    // keeps the future live consumer from silently acting on an unlogged trust
+    // decision and makes recorder availability part of the authority contract.
+    this.recordDecision({
+      schemaVersion: 1,
+      decidedAt: this.now().toISOString(),
+      operation,
+      context: {
+        candidate: {
+          ...assessment.candidate,
+          provenance: { ...assessment.candidate.provenance },
+        },
+      },
+      signals: { ...signals, observedRemotes: [...signals.observedRemotes] },
+      rule,
+      outcome: {
+        trust: assessment.trust,
+        structuralPopulationAllowed: assessment.structuralPopulationAllowed,
+        paidAuthoringAllowed: assessment.paidAuthoringAllowed,
+        rootId: assessment.identity?.rootId ?? null,
+        stateNamespace: assessment.identity?.stateNamespace ?? null,
+      },
+    });
+    return assessment;
+  }
+
+  private evaluate(
+    candidate: CartographerRootCandidate,
+    operation: 'assess' | 'revalidate',
+    expectedRootId?: string,
+  ): CartographerRootAssessment {
+    const signals: CartographerRootDecisionSignals = {
+      pathState: 'unreadable',
+      canonicalPath: null,
+      gitTopLevel: null,
+      expectedRemote: candidate.expectedRemote
+        ? normalizeCartographerGitRemote(candidate.expectedRemote)
+        : null,
+      observedRemotes: [],
+      expectedRevision: candidate.expectedRevision ?? null,
+      observedRevision: null,
+    };
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(candidate.requestedPath);
+    } catch {
+      return this.decide(
+        refused(candidate, 'path-missing'),
+        operation,
+        signals,
+      );
+    }
+    signals.pathState = stat.isDirectory() ? 'directory' : 'file';
+    if (!stat.isDirectory()) {
+      return this.decide(
+        refused(candidate, 'path-not-directory'),
+        operation,
+        signals,
+      );
+    }
+
+    let canonicalPath: string;
+    try {
+      canonicalPath = fs.realpathSync(candidate.requestedPath);
+    } catch {
+      return this.decide(
+        refused(candidate, 'canonicalize-failed'),
+        operation,
+        signals,
+      );
+    }
+    signals.canonicalPath = canonicalPath;
+
+    const rawTopLevel = readGit(canonicalPath, [
+      'rev-parse',
+      '--show-toplevel',
+    ]);
+    if (!rawTopLevel) {
+      return this.decide(
+        structuralOnly(
+          candidate,
+          'git-root-unreadable',
+          identityFor({
+            candidate,
+            canonicalPath,
+            gitTopLevel: null,
+            remoteUrl: null,
+            commonGitDir: null,
+            revision: null,
+          }),
+        ),
+        operation,
+        signals,
+      );
+    }
+
+    let gitTopLevel: string;
+    try {
+      gitTopLevel = fs.realpathSync(rawTopLevel);
+    } catch {
+      return this.decide(
+        structuralOnly(
+          candidate,
+          'git-root-unreadable',
+          identityFor({
+            candidate,
+            canonicalPath,
+            gitTopLevel: null,
+            remoteUrl: null,
+            commonGitDir: null,
+            revision: null,
+          }),
+        ),
+        operation,
+        signals,
+      );
+    }
+    signals.gitTopLevel = gitTopLevel;
+
+    if (gitTopLevel !== canonicalPath) {
+      return this.decide(
+        refused(
+          candidate,
+          'candidate-not-git-root',
+          identityFor({
+            candidate,
+            canonicalPath,
+            gitTopLevel,
+            remoteUrl: null,
+            commonGitDir: canonicalCommonGitDir(gitTopLevel),
+            revision: null,
+          }),
+        ),
+        operation,
+        signals,
+      );
+    }
+
+    const remotes = readRemotes(canonicalPath);
+    signals.observedRemotes = remotes.map((remote) => remote.normalized);
+    const expectedRemote = signals.expectedRemote;
+    const matchedRemote = expectedRemote
+      ? (remotes.find((remote) => remote.normalized === expectedRemote) ?? null)
+      : (remotes.find((remote) => remote.name === 'origin') ??
+        remotes[0] ??
+        null);
+    const commonGitDir = canonicalCommonGitDir(canonicalPath);
+    const revision = readGit(canonicalPath, ['rev-parse', 'HEAD']);
+    signals.observedRevision = revision;
+
+    const provisionalIdentity = identityFor({
+      candidate,
+      canonicalPath,
+      gitTopLevel,
+      remoteUrl: matchedRemote?.url ?? null,
+      commonGitDir,
+      revision,
+    });
+
+    if (candidate.kind === 'instar-source-checkout' && !expectedRemote) {
+      return this.decide(
+        structuralOnly(
+          candidate,
+          'instar-source-expectation-missing',
+          provisionalIdentity,
+        ),
+        operation,
+        signals,
+      );
+    }
+    if (expectedRemote && remotes.length === 0) {
+      return this.decide(
+        structuralOnly(candidate, 'remote-unreadable', provisionalIdentity),
+        operation,
+        signals,
+      );
+    }
+    if (expectedRemote && !matchedRemote) {
+      const actualIdentity = identityFor({
+        candidate,
+        canonicalPath,
+        gitTopLevel,
+        remoteUrl:
+          remotes.find((remote) => remote.name === 'origin')?.url ??
+          remotes[0]?.url ??
+          null,
+        commonGitDir,
+        revision,
+      });
+      return this.decide(
+        refused(candidate, 'remote-mismatch', actualIdentity),
+        operation,
+        signals,
+      );
+    }
+    if (!revision) {
+      return this.decide(
+        structuralOnly(candidate, 'head-unreadable', provisionalIdentity),
+        operation,
+        signals,
+      );
+    }
+    if (candidate.expectedRevision && revision !== candidate.expectedRevision) {
+      return this.decide(
+        refused(candidate, 'revision-mismatch', provisionalIdentity),
+        operation,
+        signals,
+      );
+    }
+    if (expectedRootId && provisionalIdentity.rootId !== expectedRootId) {
+      return this.decide(
+        refused(candidate, 'root-identity-mismatch', provisionalIdentity),
+        operation,
+        signals,
+      );
+    }
+
+    return this.decide(
+      {
+        candidate,
+        trust: 'verified',
+        reason: 'verified',
+        identity: provisionalIdentity,
+        structuralPopulationAllowed: true,
+        // Agent home is an identity/state container, not an active project. Even
+        // when it is itself a valid Git repository, selecting it explicitly must
+        // not authorize the noisy-home paid sweep that exposed this failure.
+        paidAuthoringAllowed: candidate.kind !== 'agent-home',
+      },
+      operation,
+      signals,
+    );
+  }
+
+  assess(candidate: CartographerRootCandidate): CartographerRootAssessment {
+    return this.evaluate(candidate, 'assess');
+  }
+
+  /** Revalidate the same root identity and exact revision before a trusted operation. */
+  revalidate(
+    assessment: CartographerRootAssessment,
+  ): CartographerRootAssessment {
+    if (assessment.trust !== 'verified' || !assessment.identity?.revision) {
+      return this.decide(
+        assessment,
+        'revalidate',
+        {
+          pathState: assessment.identity ? 'directory' : 'unreadable',
+          canonicalPath: assessment.identity?.canonicalPath ?? null,
+          gitTopLevel: assessment.identity?.gitTopLevel ?? null,
+          expectedRemote: assessment.candidate.expectedRemote
+            ? normalizeCartographerGitRemote(
+                assessment.candidate.expectedRemote,
+              )
+            : null,
+          observedRemotes: assessment.identity?.remoteUrl
+            ? [normalizeCartographerGitRemote(assessment.identity.remoteUrl)]
+            : [],
+          expectedRevision: assessment.identity?.revision ?? null,
+          observedRevision: assessment.identity?.revision ?? null,
+        },
+        'revalidation-not-applicable',
+      );
+    }
+    return this.evaluate(
+      {
+        ...assessment.candidate,
+        expectedRevision: assessment.identity.revision,
+      },
+      'revalidate',
+      assessment.identity.rootId,
+    );
+  }
+}

--- a/src/core/CartographerTree.ts
+++ b/src/core/CartographerTree.ts
@@ -128,6 +128,12 @@ export interface CartographerConfig {
   projectDir: string;
   /** Instar state directory (cartographer state nests under here). */
   stateDir: string;
+  /**
+   * Optional verified-root namespace. When supplied, state is isolated under
+   * cartographer/roots/<namespace>. Omitted preserves the legacy singleton path
+   * exactly; PR 11B-1 adds the inert storage substrate without changing callers.
+   */
+  stateNamespace?: string;
   /** Hard cap on descent depth (default 12). */
   maxDepth?: number;
   /** File extensions that become leaf nodes (default ts/js/mjs/cjs). */
@@ -157,7 +163,12 @@ export class CartographerTree {
 
   constructor(config: CartographerConfig) {
     this.projectDir = config.projectDir;
-    this.cartoDir = path.join(config.stateDir, 'cartographer');
+    if (config.stateNamespace !== undefined && !/^root-[a-f0-9]{24}$/.test(config.stateNamespace)) {
+      throw new Error('Invalid Cartographer state namespace');
+    }
+    this.cartoDir = config.stateNamespace
+      ? path.join(config.stateDir, 'cartographer', 'roots', config.stateNamespace)
+      : path.join(config.stateDir, 'cartographer');
     this.nodesDir = path.join(this.cartoDir, 'nodes');
     this.indexPath = path.join(this.cartoDir, 'index.json');
     this.maxDepth = config.maxDepth ?? DEFAULT_MAX_DEPTH;

--- a/tests/unit/cartographer-root-authority.test.ts
+++ b/tests/unit/cartographer-root-authority.test.ts
@@ -1,0 +1,577 @@
+// safe-git-allow: test fixture setup uses local temporary repositories only.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CartographerTree } from '../../src/core/CartographerTree.js';
+import {
+  CartographerRootAuthority,
+  normalizeCartographerGitRemote,
+  selectCartographerRootCandidate,
+  type CartographerRootCandidate,
+  type CartographerRootDecision,
+} from '../../src/core/CartographerRootAuthority.js';
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'Cartographer Test',
+  GIT_AUTHOR_EMAIL: 'cartographer@test.local',
+  GIT_COMMITTER_NAME: 'Cartographer Test',
+  GIT_COMMITTER_EMAIL: 'cartographer@test.local',
+};
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    env: GIT_ENV,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function createRepo(
+  parent: string,
+  name: string,
+  remote?: string,
+  commit = true,
+): string {
+  const repo = path.join(parent, name);
+  fs.mkdirSync(path.join(repo, 'src'), { recursive: true });
+  git(repo, 'init', '-q', '-b', 'main');
+  if (remote) git(repo, 'remote', 'add', 'origin', remote);
+  fs.writeFileSync(
+    path.join(repo, 'src', `${name}.ts`),
+    `export const ${name.replace(/\W/g, '_')} = true;\n`,
+  );
+  if (commit) {
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-q', '-m', 'fixture');
+  }
+  return repo;
+}
+
+function activeCandidate(
+  projectDir: string,
+  expectedRemote?: string,
+): CartographerRootCandidate {
+  return {
+    kind: 'active-project-checkout',
+    requestedPath: projectDir,
+    provenance: {
+      source: 'topic-binding',
+      topicId: 776,
+      projectName: 'fixture',
+    },
+    expectedRemote,
+  };
+}
+
+function createAuthority(
+  decisions: CartographerRootDecision[] = [],
+): CartographerRootAuthority {
+  return new CartographerRootAuthority({
+    recordDecision: (decision) => decisions.push(decision),
+    now: () => new Date('2026-08-02T08:00:00.000Z'),
+  });
+}
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cartographer-root-authority-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('selectCartographerRootCandidate', () => {
+  it('requires a topic binding for a standalone active-project root', () => {
+    const selected = selectCartographerRootCandidate({
+      kind: 'active-project-checkout',
+      standalone: true,
+      serverProject: {
+        projectDir: path.join(tmp, 'agent-home'),
+        projectName: 'agent-home',
+      },
+    });
+
+    expect(selected).toEqual(
+      expect.objectContaining({
+        ok: false,
+        code: 'topic-binding-required',
+      }),
+    );
+  });
+
+  it('selects the topic-bound checkout and never falls back to a noisy agent home', () => {
+    const agentHome = path.join(tmp, 'agent-home');
+    fs.mkdirSync(path.join(agentHome, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(agentHome, 'src', 'StaleLookalike.ts'),
+      'export const stale = true;\n',
+    );
+    fs.writeFileSync(path.join(agentHome, 'screenshot.png'), 'noise');
+    const project = createRepo(
+      tmp,
+      'trusted-project',
+      'https://github.com/example/trusted-project.git',
+    );
+
+    const selected = selectCartographerRootCandidate({
+      kind: 'active-project-checkout',
+      standalone: true,
+      serverProject: { projectDir: agentHome, projectName: 'agent-home' },
+      topicBinding: {
+        topicId: 776,
+        projectDir: project,
+        projectName: 'trusted-project',
+        gitRemote: 'git@github.com:example/trusted-project.git',
+      },
+    });
+
+    expect(selected).toEqual({
+      ok: true,
+      candidate: {
+        kind: 'active-project-checkout',
+        requestedPath: project,
+        provenance: {
+          source: 'topic-binding',
+          topicId: 776,
+          projectName: 'trusted-project',
+        },
+        expectedRemote: 'git@github.com:example/trusted-project.git',
+      },
+    });
+  });
+
+  it('uses the declared server project for a project-bound agent', () => {
+    const project = createRepo(tmp, 'project-bound');
+    const selected = selectCartographerRootCandidate({
+      kind: 'active-project-checkout',
+      standalone: false,
+      serverProject: { projectDir: project, projectName: 'project-bound' },
+    });
+
+    expect(selected).toMatchObject({
+      ok: true,
+      candidate: {
+        requestedPath: project,
+        provenance: { source: 'server-project', projectName: 'project-bound' },
+      },
+    });
+  });
+
+  it('requires an explicit repository-anchored binding for Instar source', () => {
+    const selected = selectCartographerRootCandidate({
+      kind: 'instar-source-checkout',
+      binding: {
+        bindingId: 'instar-source',
+        projectDir: path.join(tmp, 'instar'),
+        projectName: 'instar',
+        gitRemote: '',
+      },
+    });
+
+    expect(selected).toMatchObject({
+      ok: false,
+      code: 'instar-source-binding-required',
+    });
+  });
+});
+
+describe('CartographerRootAuthority', () => {
+  it('normalizes equivalent HTTPS, SSH, and scp-like remote identities', () => {
+    expect(
+      normalizeCartographerGitRemote('https://github.com/Example/Repo.git/'),
+    ).toBe('github.com/example/repo');
+    expect(
+      normalizeCartographerGitRemote('ssh://git@github.com/Example/Repo.git'),
+    ).toBe('github.com/example/repo');
+    expect(
+      normalizeCartographerGitRemote('git@github.com:Example/Repo.git'),
+    ).toBe('github.com/example/repo');
+  });
+
+  it('preserves non-default ports and case-sensitive paths on unknown forges', () => {
+    expect(
+      normalizeCartographerGitRemote(
+        'ssh://git@git.example.com:8443/Org/Repo.git',
+      ),
+    ).toBe('git.example.com:8443/Org/Repo');
+    expect(
+      normalizeCartographerGitRemote(
+        'ssh://git@git.example.com:9443/Org/Repo.git',
+      ),
+    ).toBe('git.example.com:9443/Org/Repo');
+    expect(
+      normalizeCartographerGitRemote('https://git.example.com/Org/Repo.git'),
+    ).not.toBe(
+      normalizeCartographerGitRemote('https://git.example.com/org/repo.git'),
+    );
+  });
+
+  it('verifies canonical Git identity and the exact readable revision', () => {
+    const remote = 'https://github.com/example/project.git';
+    const repo = createRepo(tmp, 'verified', remote);
+    const authority = createAuthority();
+    const assessment = authority.assess(
+      activeCandidate(repo, 'git@github.com:example/project.git'),
+    );
+
+    expect(assessment).toMatchObject({
+      trust: 'verified',
+      reason: 'verified',
+      structuralPopulationAllowed: true,
+      paidAuthoringAllowed: true,
+      identity: {
+        canonicalPath: fs.realpathSync(repo),
+        gitTopLevel: fs.realpathSync(repo),
+        remoteUrl: remote,
+        revision: git(repo, 'rev-parse', 'HEAD'),
+      },
+    });
+    expect(assessment.identity?.rootId).toMatch(/^[a-f0-9]{24}$/);
+    expect(assessment.identity?.repositoryId).toMatch(/^[a-f0-9]{24}$/);
+    expect(assessment.identity?.stateNamespace).toBe(
+      `root-${assessment.identity?.rootId}`,
+    );
+  });
+
+  it('verifies an Instar source-signature checkout through the source-tree safety guard', () => {
+    const remote = 'https://github.com/JKHeadley/instar.git';
+    const repo = createRepo(tmp, 'instar-source', remote, false);
+    fs.mkdirSync(path.join(repo, 'src', 'core'), { recursive: true });
+    fs.writeFileSync(
+      path.join(repo, 'package.json'),
+      JSON.stringify({ name: 'instar', version: '1.0.0' }),
+    );
+    fs.writeFileSync(path.join(repo, 'tsconfig.json'), '{}\n');
+    fs.writeFileSync(
+      path.join(repo, 'src', 'core', 'GitSync.ts'),
+      'export class GitSync {}\n',
+    );
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-q', '-m', 'instar source signature');
+
+    const assessment = createAuthority().assess({
+      kind: 'instar-source-checkout',
+      requestedPath: repo,
+      provenance: {
+        source: 'operator-binding',
+        bindingId: 'instar-source',
+        projectName: 'instar',
+      },
+      expectedRemote: 'git@github.com:JKHeadley/instar.git',
+    });
+
+    expect(assessment).toMatchObject({
+      trust: 'verified',
+      reason: 'verified',
+      structuralPopulationAllowed: true,
+      paidAuthoringAllowed: true,
+      identity: {
+        canonicalPath: fs.realpathSync(repo),
+        remoteUrl: remote,
+        revision: git(repo, 'rev-parse', 'HEAD'),
+      },
+    });
+  });
+
+  it('keeps an unborn or unreadable HEAD structural-only instead of erasing the hierarchy', () => {
+    const repo = createRepo(tmp, 'unborn', undefined, false);
+    const authority = createAuthority();
+    const assessment = authority.assess(activeCandidate(repo));
+
+    expect(assessment).toMatchObject({
+      trust: 'structural-only',
+      reason: 'head-unreadable',
+      structuralPopulationAllowed: true,
+      paidAuthoringAllowed: false,
+      identity: {
+        canonicalPath: fs.realpathSync(repo),
+        revision: null,
+      },
+    });
+    expect(assessment.identity?.repositoryId).not.toBeNull();
+
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-q', '-m', 'first readable head');
+    const verified = authority.assess(activeCandidate(repo));
+    expect(verified.trust).toBe('verified');
+    expect(verified.identity?.stateNamespace).toBe(
+      assessment.identity?.stateNamespace,
+    );
+  });
+
+  it('never authorizes paid project summarization for the agent-home root kind', () => {
+    const home = createRepo(tmp, 'agent-home');
+    const selected = selectCartographerRootCandidate({
+      kind: 'agent-home',
+      agentHome: home,
+      agentName: 'echo',
+    });
+    expect(selected.ok).toBe(true);
+    if (!selected.ok) return;
+
+    const assessment = createAuthority().assess(selected.candidate);
+    expect(assessment).toMatchObject({
+      trust: 'verified',
+      structuralPopulationAllowed: true,
+      paidAuthoringAllowed: false,
+      identity: { kind: 'agent-home' },
+    });
+  });
+
+  it('allows structural population for a provenance-selected non-Git directory', () => {
+    const project = path.join(tmp, 'non-git');
+    fs.mkdirSync(path.join(project, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(project, 'src', 'OnlyStructure.ts'),
+      'export const structure = true;\n',
+    );
+    const assessment = createAuthority().assess(activeCandidate(project));
+
+    expect(assessment).toMatchObject({
+      trust: 'structural-only',
+      reason: 'git-root-unreadable',
+      structuralPopulationAllowed: true,
+      paidAuthoringAllowed: false,
+      identity: { revision: null, repositoryId: null },
+    });
+  });
+
+  it('refuses a stale lookalike whose repository identity contradicts the binding', () => {
+    const stale = createRepo(
+      tmp,
+      'stale-lookalike',
+      'https://github.com/example/agent-backup.git',
+    );
+    fs.writeFileSync(
+      path.join(stale, 'src', 'LooksLikeInstar.ts'),
+      'export const plausible = true;\n',
+    );
+    const assessment = createAuthority().assess({
+      kind: 'instar-source-checkout',
+      requestedPath: stale,
+      provenance: {
+        source: 'operator-binding',
+        bindingId: 'instar-source',
+        projectName: 'instar',
+      },
+      expectedRemote: 'https://github.com/JKHeadley/instar.git',
+    });
+
+    expect(assessment).toMatchObject({
+      trust: 'refused',
+      reason: 'remote-mismatch',
+      structuralPopulationAllowed: false,
+      paidAuthoringAllowed: false,
+    });
+  });
+
+  it('refuses remote anchors that differ only by an explicit port', () => {
+    const stale = createRepo(
+      tmp,
+      'ported-lookalike',
+      'ssh://git@git.example.com:8443/Org/Repo.git',
+    );
+    const decisions: CartographerRootDecision[] = [];
+    const assessment = createAuthority(decisions).assess(
+      activeCandidate(stale, 'ssh://git@git.example.com:9443/Org/Repo.git'),
+    );
+
+    expect(assessment).toMatchObject({
+      trust: 'refused',
+      reason: 'remote-mismatch',
+    });
+    expect(decisions[0]).toMatchObject({
+      rule: 'remote-mismatch',
+      signals: {
+        expectedRemote: 'git.example.com:9443/Org/Repo',
+        observedRemotes: ['git.example.com:8443/Org/Repo'],
+      },
+      outcome: { trust: 'refused', paidAuthoringAllowed: false },
+    });
+  });
+
+  it('refuses a plausible subdirectory because the selected root is not the Git top level', () => {
+    const repo = createRepo(tmp, 'outer');
+    const nested = path.join(repo, 'src');
+    const assessment = createAuthority().assess(activeCandidate(nested));
+    expect(assessment).toMatchObject({
+      trust: 'refused',
+      reason: 'candidate-not-git-root',
+    });
+  });
+
+  it('revalidation refuses revision drift before a trusted operation', () => {
+    const repo = createRepo(tmp, 'drift');
+    const authority = createAuthority();
+    const first = authority.assess(activeCandidate(repo));
+    expect(first.trust).toBe('verified');
+
+    fs.writeFileSync(
+      path.join(repo, 'src', 'later.ts'),
+      'export const later = true;\n',
+    );
+    git(repo, 'add', '-A');
+    git(repo, 'commit', '-q', '-m', 'advance');
+
+    const next = authority.revalidate(first);
+    expect(next).toMatchObject({
+      trust: 'refused',
+      reason: 'revision-mismatch',
+      paidAuthoringAllowed: false,
+    });
+    expect(next.identity?.rootId).toBe(first.identity?.rootId);
+    expect(next.identity?.stateNamespace).toBe(first.identity?.stateNamespace);
+  });
+
+  it('assigns distinct stable state namespaces to two verified roots', () => {
+    const remote = 'https://github.com/example/shared.git';
+    const projectA = createRepo(tmp, 'project-a', remote);
+    const projectB = createRepo(tmp, 'project-b', remote);
+    const authority = createAuthority();
+    const a = authority.assess(activeCandidate(projectA, remote));
+    const b = authority.assess(activeCandidate(projectB, remote));
+
+    expect(a.trust).toBe('verified');
+    expect(b.trust).toBe('verified');
+    expect(a.identity?.repositoryId).toBe(b.identity?.repositoryId);
+    expect(a.identity?.rootId).not.toBe(b.identity?.rootId);
+    expect(a.identity?.stateNamespace).not.toBe(b.identity?.stateNamespace);
+  });
+
+  it('records structured signals, applied rule, and outcome for every decision', () => {
+    const project = createRepo(
+      tmp,
+      'audited',
+      'https://github.com/example/audited.git',
+    );
+    const decisions: CartographerRootDecision[] = [];
+    const assessment = createAuthority(decisions).assess(
+      activeCandidate(project, 'git@github.com:example/audited.git'),
+    );
+
+    expect(assessment.trust).toBe('verified');
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      schemaVersion: 1,
+      decidedAt: '2026-08-02T08:00:00.000Z',
+      operation: 'assess',
+      context: { candidate: { requestedPath: project } },
+      signals: {
+        pathState: 'directory',
+        canonicalPath: fs.realpathSync(project),
+        gitTopLevel: fs.realpathSync(project),
+        expectedRemote: 'github.com/example/audited',
+        observedRemotes: ['github.com/example/audited'],
+        observedRevision: assessment.identity?.revision,
+      },
+      rule: 'verified',
+      outcome: {
+        trust: 'verified',
+        structuralPopulationAllowed: true,
+        paidAuthoringAllowed: true,
+        rootId: assessment.identity?.rootId,
+        stateNamespace: assessment.identity?.stateNamespace,
+      },
+    });
+  });
+
+  it('does not return an authority outcome when its required recorder fails', () => {
+    const project = createRepo(tmp, 'unlogged');
+    const authority = new CartographerRootAuthority({
+      recordDecision: () => {
+        throw new Error('decision audit unavailable');
+      },
+    });
+
+    expect(() => authority.assess(activeCandidate(project))).toThrow(
+      'decision audit unavailable',
+    );
+  });
+});
+
+describe('CartographerTree verified-root storage namespaces', () => {
+  it('isolates two project indexes inside one agent state directory', () => {
+    const projectA = createRepo(tmp, 'alpha');
+    const projectB = createRepo(tmp, 'beta');
+    const stateDir = path.join(tmp, 'agent-state');
+    const authority = createAuthority();
+    const a = authority.assess(activeCandidate(projectA));
+    const b = authority.assess(activeCandidate(projectB));
+    expect(a.identity).not.toBeNull();
+    expect(b.identity).not.toBeNull();
+
+    const treeA = new CartographerTree({
+      projectDir: projectA,
+      stateDir,
+      stateNamespace: a.identity!.stateNamespace,
+    });
+    const treeB = new CartographerTree({
+      projectDir: projectB,
+      stateDir,
+      stateNamespace: b.identity!.stateNamespace,
+    });
+    treeA.scaffold();
+    treeB.scaffold();
+
+    expect(treeA.getNode('src/alpha.ts')).not.toBeNull();
+    expect(treeA.getNode('src/beta.ts')).toBeNull();
+    expect(treeB.getNode('src/beta.ts')).not.toBeNull();
+    expect(treeB.getNode('src/alpha.ts')).toBeNull();
+    expect(
+      fs.existsSync(
+        path.join(
+          stateDir,
+          'cartographer',
+          'roots',
+          a.identity!.stateNamespace,
+          'index.json',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          stateDir,
+          'cartographer',
+          'roots',
+          b.identity!.stateNamespace,
+          'index.json',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects a namespace that could escape the root-state directory', () => {
+    const project = createRepo(tmp, 'escape');
+    expect(
+      () =>
+        new CartographerTree({
+          projectDir: project,
+          stateDir: path.join(tmp, 'state'),
+          stateNamespace: '../escape',
+        }),
+    ).toThrow('Invalid Cartographer state namespace');
+    expect(
+      () =>
+        new CartographerTree({
+          projectDir: project,
+          stateDir: path.join(tmp, 'state'),
+          stateNamespace: '',
+        }),
+    ).toThrow('Invalid Cartographer state namespace');
+    expect(
+      () =>
+        new CartographerTree({
+          projectDir: project,
+          stateDir: path.join(tmp, 'state'),
+          stateNamespace: 'plausible-but-unverified',
+        }),
+    ).toThrow('Invalid Cartographer state namespace');
+  });
+});

--- a/upgrades/next/cartographer-verified-root-authority.md
+++ b/upgrades/next/cartographer-verified-root-authority.md
@@ -1,0 +1,45 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+Cartographer now has an inert verified-root authority that separates explicit
+root selection from repository verification and paid authoring permission. It
+distinguishes the agent home, the active project checkout, and the Instar source
+checkout; records the canonical path, remote identity, and exact revision; and
+refuses contradictory repository evidence. A selected root without a readable
+Git revision remains eligible for structural hierarchy maintenance but cannot
+authorize paid semantic work.
+
+Cartographer state can also be isolated by an authority-minted root namespace,
+preventing two verified projects from sharing one index. Existing runtime
+behavior and the legacy state location remain unchanged until the live consumer
+lands separately.
+
+## What to Tell Your User
+
+- “This release lays the verified-root foundation for project-aware
+  Cartographer navigation. It does not change live navigation yet.”
+- “Structural project maps remain available when Git revision information is
+  unavailable, while paid authoring stays withheld until the root is verified.”
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Explicit root selection by provenance | Available to the upcoming live Cartographer consumer |
+| Canonical repository and revision verification | Automatic whenever the new authority is invoked |
+| Structural-only degradation for missing Git identity | Automatic; paid authoring remains off |
+| Per-root Cartographer state isolation | Supply an authority-minted root namespace when constructing a tree |
+| Structured trust-decision evidence | Bind the required recorder to a durable machine-local log |
+
+## Evidence
+
+Twenty focused root-authority tests and fourteen legacy tree tests cover noisy
+agent homes, real Instar source-tree verification, stale lookalikes, explicit
+port mismatches, missing Git revisions, revision drift, namespace isolation,
+structured decision evidence, and fail-closed recorder behavior. The full
+Cartographer unit set passes 121 checks. TypeScript, repository lint, build, and
+diff validation also pass, and an independent second-pass reviewer concurred
+after all trust-boundary findings were fixed.

--- a/upgrades/side-effects/cartographer-verified-root-authority.md
+++ b/upgrades/side-effects/cartographer-verified-root-authority.md
@@ -1,0 +1,149 @@
+# Side-Effects Review — Cartographer Verified Root Authority
+
+**Version / slug:** `cartographer-verified-root-authority`
+**Date:** `2026-08-02`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `Plato (item11b1_second_pass) — concurred after fixes`
+
+## Summary of the change
+
+This change adds the inert first half of Item 11B: a typed Cartographer root selector and verifier, plus optional per-root Cartographer state isolation. It distinguishes agent home, active-project checkout, and Instar-source checkout; selects only from explicit provenance; derives canonical Git identity and exact revision; preserves zero-cost structural population when Git HEAD is unreadable; and withholds paid-authoring eligibility unless the selected project/source root is verified. `CartographerTree` keeps its legacy storage path unless a verified-root namespace is supplied. Live navigation, health, and sweep behavior are unchanged in this PR.
+
+## Decision-point inventory
+
+- `selectCartographerRootCandidate` — **add** — chooses a candidate from an explicit typed source; a standalone active-project request without a topic binding is refused instead of falling back to agent home.
+- `CartographerRootAuthority.assess` — **add** — deterministically classifies a selected root as verified, structural-only, or refused from canonical filesystem and Git facts, and cannot return a result unless its required structured decision recorder accepts the evidence/rule/outcome row.
+- `CartographerRootAuthority.revalidate` — **add** — checks that repository identity and revision still match immediately before a future trusted operation.
+- `CartographerTree` state namespace validation — **add** — accepts only authority-shaped opaque namespaces and otherwise preserves the legacy singleton path.
+- Live Cartographer routes and sweep startup — **pass-through** — unchanged and still use the existing singleton in this inert PR.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+- A standalone agent with a correct active project but no topic binding cannot select that project through this authority. This is intentional: accepting the server's agent-home directory as an implicit substitute is the observed failure mode. The corrective action is to establish provenance, not guess.
+- A repository selected with an expected remote but with no readable configured remote becomes structural-only, so paid authoring is withheld even if the path is actually correct. This is a deliberate cost/trust floor; zero-cost hierarchy maintenance remains available.
+- A selected subdirectory of a valid Git checkout is refused because it is not the checkout top level. Monorepo subproject roots therefore need a future explicit repository-subroot identity design rather than silently inheriting the parent checkout's identity.
+- Agent home is never eligible for paid Cartographer authoring, even when agent home is itself a valid Git repository. This prevents the noisy-home sweep. Any future desire to semantically summarize agent-owned state needs a separately reviewed purpose and population contract.
+
+No live request is blocked by this PR because the new authority is not wired to routes yet.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- A full checkout at an older revision of the correct remote is still a verified identity at that exact revision unless the provenance source supplies an expected revision. The authority reports the revision honestly and supports an exact revision anchor; PR 11B-2 must revalidate before authoring and expose the selected revision. The known-present query is the semantic ground-truth control rather than treating remote identity as content correctness.
+- Git remote identity is not a defense against a malicious local administrator rewriting repository configuration. This contract addresses accidental wrong-root and stale-lookalike selection, not host compromise.
+- Repository identity does not establish that authored summaries are semantically correct. Summary validation and re-grounding remain separate Cartographer responsibilities.
+- A non-Git directory can still receive a structural-only hierarchy. It cannot become trusted or authorize paid authoring, but its path inventory may still be noisy. PR 11B-2 must label that posture and avoid presenting it as verified knowledge.
+- Remote normalization folds repository-path case only for `github.com`, where equivalent HTTPS/SSH/scp spellings require it. Unknown/self-hosted forges preserve path case, and non-default ports are identity-bearing. This may conservatively refuse two spellings that a particular forge treats as equivalent; it avoids the unsafe inverse of collapsing distinct repositories.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. Candidate selection and repository verification live in a dedicated core authority rather than inside navigation scoring, route formatting, sweep polling, or a configuration directory knob. Existing topic-project bindings remain the provenance source; `SafeGitExecutor` remains the only Git subprocess funnel; `CartographerTree` receives only an opaque storage namespace and does not decide which root deserves it.
+
+The authority is deliberately inert in 11B-1. This keeps root-verification correctness independently falsifiable before 11B-2 changes any live consumer. Reporting, reading, and authoring will be wired together in 11B-2 so the system cannot report one root while operating on another.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP. Reshape the design.
+- [x] Yes — deterministic policy authority over enumerable structural invariants (constrained-domain exception).
+
+None of those stock message-judgment boxes describes this constrained domain exactly. The change adds a deterministic authority over enumerable filesystem/Git invariants, which `docs/signal-vs-authority.md` permits for domains whose valid inputs can be enumerated. It never judges message meaning, user intent, or competing conversational signals. Canonical path, Git top level, configured remote, and exact revision are structured evidence; contradictory identity is refused, missing proof degrades to structural-only, and zero-cost structural observation remains separate from paid-authoring permission. The authority returns a structured trust status and reason for the future consumer to report.
+
+The authority also requires a recorder dependency and emits, for every assessment or revalidation, the provenance-bearing candidate context, normalized expected and observed root signals, the applied rule, and the allow/degrade/refuse outcome. Recorder failure propagates before the outcome is returned. Because 11B-1 has no live consumer, it adds the required and tested contract; 11B-2 must bind it to the machine-local durable decision log at the single live construction seam.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+This adds no static heuristic at a competing-signals judgment point. Root identity is a constrained invariant domain: a selected directory exists or does not, is or is not the Git top level, has a readable exact revision or does not, and matches an explicit repository anchor or contradicts it. Missing evidence degrades trust rather than being balanced against conversational context.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** no live check is shadowed in 11B-1. Existing routes, population, health, inline refresh, and sweep startup still receive the legacy singleton tree.
+- **Double-fire:** no background process or route is added. The authority is called only by tests in this PR.
+- **Races:** namespaced state is opt-in and unused by live code. Future consumers must revalidate directly before paid authoring so a HEAD change between initial selection and use becomes a refusal.
+- **Feedback loops:** none. The assessment reads filesystem/Git facts and writes no authority state.
+- **Existing infrastructure:** Git reads use `SafeGitExecutor`'s closed source-tree read-tier allowance, so the authority can inspect an Instar checkout without weakening destructive source-tree protection. Fetch remotes are read with the allowlisted `git remote -v` rather than general Git-config access. Topic bindings are modeled as provenance inputs rather than duplicated in a new configuration store; omitted namespaces preserve the existing Cartographer storage location byte-for-byte.
+- **Decision observability:** every authority outcome passes through one structured recorder chokepoint. Missing/broken recording fails the call instead of returning an unobservable trust decision; the live durable sink is deliberately deferred to the 11B-2 consumer seam because this PR has no runtime construction.
+- **MAINTAIN clause:** an unreadable or unborn HEAD produces structural-only eligibility rather than refusal. Its repository-based namespace stays stable when the first HEAD becomes readable, preserving the every-boot hierarchy maintenance path that 11B-2 will exercise live.
+
+---
+
+## 6. External surfaces
+
+There is no live external surface in 11B-1. No route response, dashboard, Telegram behavior, sweep setting, egress path, or user action changes. The new exported core types, required authority decision-recorder contract, and optional tree constructor field are internal developer surfaces. Persistent namespaced directories are created only in tests because no runtime caller supplies a namespace yet.
+
+**Operator surface:** no operator-facing action is added. Topic bindings remain the existing operator provenance surface; 11B-1 neither adds nor changes its UI/API behavior.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface — not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** A Cartographer root assessment describes a checkout on one machine: canonical paths, Git worktree roots, configured remotes, and HEAD revisions can legitimately differ across machines. Each machine must resolve and verify its own root from the topic/project provenance available there. Cartographer indexes also mirror machine-local checkout contents and belong in per-machine state; moving a topic to another machine should cause that machine to select and populate its own verified root rather than replicate an index built against a different filesystem.
+
+This PR emits no user-facing notices, creates no replicated durable records, and generates no URLs. The future pool-wide question is “which root did this machine use?”, answered by 11B-2's per-response identity reporting rather than by pretending all machines share a path or revision.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the new authority module and the optional namespace constructor support.
+- **Data migration:** none in 11B-1; live callers never use the namespaced path.
+- **Agent state repair:** none. Existing Cartographer state stays at the legacy location and remains untouched.
+- **User visibility:** none during rollback because live behavior is unchanged.
+
+---
+
+## Conclusion
+
+The review supports shipping 11B-1 as an inert substrate after independent review closes. It caused six hardenings before commit: agent-home remains ineligible for paid authoring even when Git-valid; an unreadable HEAD explicitly preserves structural-only maintenance; the tree accepts only authority-shaped state namespaces rather than an arbitrary directory label; Instar-source verification uses the Git funnel's closed read-tier allowance instead of being silently downgraded by the source-tree guard; non-default remote ports and unknown-forge path case remain identity-bearing; and every deterministic trust outcome requires structured decision recording. The known limitations are explicit: identity is not semantic correctness, older same-remote revisions require reporting/ground-truth controls, and monorepo subroots are intentionally not inferred.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Plato (`item11b1_second_pass`)
+**Independent read of the artifact:** initial review found three blockers: real Instar source trees were silently downgraded by `SourceTreeGuard`; remote normalization collapsed distinct explicit ports and unknown-forge path case; and the authority had no required structured decision log. After the fixes, the reviewer concurred: the real Instar worktree verifies with exact revision and remote, port/case distinctions are preserved, and every authority result passes through fail-closed structured recording. The reviewer independently reran the focused suite (34/34) and typecheck.
+
+---
+
+## Evidence pointers
+
+- Focused authority and legacy storage tests: 34/34 passing.
+- Broader Cartographer unit suite: 121/121 passing after the final reviewer-fix delta.
+- Full repository lint: passing.
+- TypeScript build: passing.
+- Real Git fixtures cover noisy agent home, stale remote-mismatched lookalike, explicit-port identity mismatch, source-guard-positive Instar checkout, missing HEAD, revision drift, namespace isolation, traversal-shaped namespace refusal, structured decision evidence, and recorder-failure fail-closed behavior.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect and no self-triggered controller — not applicable.

--- a/upgrades/side-effects/cartographer-verified-root-authority.md
+++ b/upgrades/side-effects/cartographer-verified-root-authority.md
@@ -86,6 +86,7 @@ This adds no static heuristic at a competing-signals judgment point. Root identi
 - **Feedback loops:** none. The assessment reads filesystem/Git facts and writes no authority state.
 - **Existing infrastructure:** Git reads use `SafeGitExecutor`'s closed source-tree read-tier allowance, so the authority can inspect an Instar checkout without weakening destructive source-tree protection. Fetch remotes are read with the allowlisted `git remote -v` rather than general Git-config access. Topic bindings are modeled as provenance inputs rather than duplicated in a new configuration store; omitted namespaces preserve the existing Cartographer storage location byte-for-byte.
 - **Decision observability:** every authority outcome passes through one structured recorder chokepoint. Missing/broken recording fails the call instead of returning an unobservable trust decision; the live durable sink is deliberately deferred to the 11B-2 consumer seam because this PR has no runtime construction.
+- **Git-read degradation:** the Git helper's null return is explicitly exempted from the silent-fallback scanner because null is not an unreported substitute here: it becomes structured authority evidence and every resulting structural-only/refused decision must be recorded. The scanner exemption changes no behavior.
 - **MAINTAIN clause:** an unreadable or unborn HEAD produces structural-only eligibility rather than refusal. Its repository-based namespace stays stable when the first HEAD becomes readable, preserving the every-boot hierarchy maintenance path that 11B-2 will exercise live.
 
 ---
@@ -123,7 +124,7 @@ This PR emits no user-facing notices, creates no replicated durable records, and
 
 ## Conclusion
 
-The review supports shipping 11B-1 as an inert substrate after independent review closes. It caused six hardenings before commit: agent-home remains ineligible for paid authoring even when Git-valid; an unreadable HEAD explicitly preserves structural-only maintenance; the tree accepts only authority-shaped state namespaces rather than an arbitrary directory label; Instar-source verification uses the Git funnel's closed read-tier allowance instead of being silently downgraded by the source-tree guard; non-default remote ports and unknown-forge path case remain identity-bearing; and every deterministic trust outcome requires structured decision recording. The known limitations are explicit: identity is not semantic correctness, older same-remote revisions require reporting/ground-truth controls, and monorepo subroots are intentionally not inferred.
+The review supports shipping 11B-1 as an inert substrate after independent review closes. It caused seven hardenings before merge: agent-home remains ineligible for paid authoring even when Git-valid; an unreadable HEAD explicitly preserves structural-only maintenance; the tree accepts only authority-shaped state namespaces rather than an arbitrary directory label; Instar-source verification uses the Git funnel's closed read-tier allowance instead of being silently downgraded by the source-tree guard; non-default remote ports and unknown-forge path case remain identity-bearing; every deterministic trust outcome requires structured decision recording; and the Git-read degradation is explicitly classified for the repository's no-silent-fallback ratchet instead of increasing its baseline. The known limitations are explicit: identity is not semantic correctness, older same-remote revisions require reporting/ground-truth controls, and monorepo subroots are intentionally not inferred.
 
 ---
 
@@ -137,6 +138,7 @@ The review supports shipping 11B-1 as an inert substrate after independent revie
 ## Evidence pointers
 
 - Focused authority and legacy storage tests: 34/34 passing.
+- No-silent-fallback ratchet plus the focused authority/storage set: 39/39 passing after CI exposed the missing classification annotation.
 - Broader Cartographer unit suite: 121/121 passing after the final reviewer-fix delta.
 - Full repository lint: passing.
 - TypeScript build: passing.


### PR DESCRIPTION
## Summary

Adds the inert first half of Item 11B: a typed Cartographer root-selection and verification authority plus opt-in per-root state isolation.

- selects agent home, active project, or Instar source only from typed provenance
- verifies canonical Git top level, normalized repository identity, and exact revision
- preserves structural-only population when Git HEAD or remote evidence is unreadable
- refuses contradictory remote, nested-root, revision-drift, and root-identity evidence
- keeps agent home ineligible for paid Cartographer authoring
- requires structured decision recording and returns no outcome if the recorder fails
- isolates Cartographer indexes behind authority-minted opaque root namespaces
- leaves every live Cartographer route, sweep, and legacy state path unchanged

## ELI16 — Cartographer now checks the address before trusting a code map

Think of Cartographer as a mapmaker sent to describe a building. Before this change, its future project-aware work had no single trusted way to prove which building it was standing in. This PR adds that address check: it records who selected the folder, confirms the repository and exact revision when possible, and refuses evidence that points to a different building. If Git cannot identify a revision, Cartographer may still draw the free structural floor plan, but it cannot spend money writing trusted descriptions. Nothing live uses this new checkpoint yet; wiring it into navigation comes in the separate 11B-2 PR.

## Why

Cartographer's singleton project directory could let the system report, read, or eventually author against the wrong tree. This PR establishes the dormant trust and storage contract first, so it is independently falsifiable before any live consumer can claim the new identity.

The follow-up 11B-2 PR will wire selection, reporting, navigation, refusal, authoring revalidation, and durable decision logging at one consumer boundary.

## Trust-boundary hardening

Independent second-pass review found and closed three blockers before commit:

1. real Instar source trees were silently downgraded by the source-tree guard
2. remote normalization collapsed distinct explicit ports and unknown-forge path case
3. authority outcomes lacked a required structured decision trail

The final design uses SafeGitExecutor's closed source-tree read tier, preserves identity-bearing ports and case, and makes recording fail closed.

## MAINTAIN contract

An unborn or unreadable HEAD remains structural-only rather than refused, and its state namespace stays stable when the first revision becomes readable. The live every-boot population and fresh-ratio assertions remain explicitly assigned to 11B-2, where runtime behavior changes.

## Validation

- 34/34 focused root-authority and legacy tree tests
- 121/121 complete Cartographer unit tests
- 196/196 affected pre-push smoke tests
- TypeScript check
- repository lint
- production build
- diff validation
- independent second-pass reviewer concurrence

Duplicate-build review was dispositioned as proceed: the open overlap touches only the broad substrate spec's scaffold target, not this PR's root-authority or CartographerTree seams.
