### PR TITLE
Item 11B-2: make Cartographer project-root aware

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-02T11-05-56-460Z-cartographer-project-aware-navigation.json
+++ b/.instar/instar-dev-decisions/2026-08-02T11-05-56-460Z-cartographer-project-aware-navigation.json
@@ -1,0 +1,39 @@
+{
+  "ts": "2026-08-02T11:05:56.460Z",
+  "slug": "cartographer-project-aware-navigation",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "new capability: new route (router.<verb>() added",
+    "new capability: new exported class / subsystem added"
+  ],
+  "belowFloor": false,
+  "files": 7,
+  "loc": 864,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/CartographerNavigator.ts",
+      "src/core/CartographerRootRegistry.ts",
+      "src/core/CartographerSweepEngine.ts",
+      "src/core/ScopeVerifier.ts",
+      "src/server/AgentServer.ts",
+      "src/server/routes.ts"
+    ],
+    "addedLines": 759,
+    "deletedLines": 105
+  },
+  "causalAutopsy": null,
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/cartographer-sweep-engine.test.ts",
+      "howCaught": "The existing poller-to-sweep control loop retains finite per-pass node and spend bounds; sustained root-authority refusal performs zero writes and the zero-progress breaker settles the loop instead of minting new allowance."
+    }
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/cartographer-doc-tree-schema.eli16.md
+++ b/docs/specs/cartographer-doc-tree-schema.eli16.md
@@ -74,9 +74,16 @@ It ships turned off until then.
 ## Verified-root foundation
 
 Before project-aware navigation can trust this map, Cartographer also needs to
-prove which code checkout it is mapping. The first root-authority slice adds that
-checkpoint without connecting it to live navigation yet: an explicitly selected
-project can be matched to its repository and exact revision, contradictory
-evidence is refused, and a checkout without readable Git identity may keep its
-free structural map but cannot spend money writing trusted descriptions. A
-separate follow-up connects the checkpoint to the live reader and writer.
+prove which code checkout it is mapping. The verified-root authority now sits in
+the live path: a topic selects its bound project, that checkout is matched to its
+repository and exact revision, and the same selected tree supplies the response,
+navigation result, and any permitted summary write. A standalone request with no
+topic binding is refused instead of quietly mapping the agent's noisy home.
+
+Each response identifies the selected root, revision, provenance, and verification
+state. Two topics bound to different projects receive isolated maps. If Git has an
+unborn or unreadable HEAD, the free structural map still refreshes at boot and is
+reported as structural-only with unknown freshness; paid summary writing stays
+off. Before inline or background authoring, Cartographer checks the pinned revision
+again. A checkout that moved since the map was selected is refused rather than
+letting a report about one revision authorize writing against another.

--- a/site/src/content/docs/architecture/under-the-hood.md
+++ b/site/src/content/docs/architecture/under-the-hood.md
@@ -113,6 +113,15 @@ Checks for new versions every 30 minutes. When an update is found, it coalesces 
 ### GitSyncManager
 Automatic git-based state synchronization for multi-machine setups. Debounces commits (30 seconds), runs a full sync cycle every 30 minutes, and has multi-stage conflict resolution: programmatic merging for simple cases, LLM-powered resolution for complex ones, human escalation as a last resort.
 
+### CartographerRootRegistry
+The project-identity boundary for Cartographer. `CartographerRootRegistry` resolves
+each topic through its explicit project binding, keeps a separate map namespace per
+checkout, and supplies one root/report pair to navigation, health, and authoring.
+`CartographerRootAuthority` verifies the canonical repository and exact revision;
+missing proof permits only the free structural map, while contradictory or drifted
+proof refuses paid writes. Every eligible bound root is repopulated at boot, and
+the machine-local evidence log and inactive cache set remain bounded.
+
 ### CoherenceJournal
 The multi-machine "diary" writer (P1 of the coherence initiative). Each machine appends per-kind event streams — topic placement (with the reason it moved), session open/close/reap, autonomous runs with their artifact paths — so "what happened where, and where are the files?" is answerable from local disk. Emits are non-blocking memory hand-offs (a background flusher owns all disk I/O), crash repairs are counted, restores-from-backup are detected via incarnation tokens, and a strict per-kind schema keeps free text and secrets out. Signal-only by design: nothing ever kills, spawns, or moves anything based on journal data — the companion `CoherenceJournalReader` (a deliberately separate module, so a lint can ban actuators from importing it) serves the merged bounded read view behind `GET /coherence/journal`. Ships dark; per-kind retention keeps placement history effectively forever.
 

--- a/site/src/content/docs/features/cartographer.md
+++ b/site/src/content/docs/features/cartographer.md
@@ -25,6 +25,23 @@ shared directory skip-set lives in `skipDirs`. Read surfaces:
 - `GET /cartographer/stale` — nodes whose summary has drifted from the code.
 - `GET /cartographer/health` — node count, authored count, staleness + freshness backlog.
 
+### Verified project roots (`CartographerRootAuthority`, `CartographerRootRegistry`)
+
+On a standalone agent, Cartographer no longer assumes the agent's home directory is
+the project a request means. `CartographerRootRegistry` resolves the request's topic
+through the existing project binding, asks `CartographerRootAuthority` to verify the
+checkout's canonical repository identity and exact revision, and opens an isolated
+tree namespace for that root. Every Cartographer response reports that selected
+identity and revision, so the tree being described is the tree that was actually
+read. A request without an unambiguous topic binding is refused instead of falling
+back to a noisy or stale checkout.
+
+Structural population remains free and runs for every eligible bound root at boot.
+If a checkout has no readable Git revision yet, it receives a structural-only tree
+but cannot authorize paid summaries. Inline refreshes and the background sweep
+revalidate the pinned revision before trusted writes; revision drift stops the write
+rather than letting evidence about one checkout authorize another.
+
 ## Spec #2 — The freshness sweep (`CartographerSweepEngine`, `CartographerSweepPoller`)
 
 A fresh tree is all "never-authored," and as code changes summaries rot. The
@@ -106,15 +123,17 @@ before a downstream sub-agent reads it. Read surface:
 
 | Layer | Core modules | Read surface |
 |-------|-------------|--------------|
-| Doc-tree (spec #1) | `CartographerTree`, `skipDirs` | `/cartographer/tree`, `/cartographer/node`, `/cartographer/stale`, `/cartographer/health` |
+| Doc-tree + verified roots (spec #1 / Item 11B) | `CartographerTree`, `CartographerRootAuthority`, `CartographerRootRegistry`, `skipDirs` | `/cartographer/tree`, `/cartographer/node`, `/cartographer/stale`, `/cartographer/health` |
 | Freshness sweep (spec #2) | `CartographerSweepEngine`, `CartographerSweepPoller`, `HostPressureSampler`, `cartographerSummary` | `/cartographer/node/refresh` |
 | Conformance audit (spec #3) | `StandardsRegistryParser`, `StandardEnforcementExtractor`, `StandardsEnforcementAuditor` | `/conformance/coverage`, `/conformance/coverage/health` |
 | Subtree navigation (spec #5) | `CartographerNavigator` | `/cartographer/navigate` |
 
-`CartographerTree` is the substrate every layer reads; `CartographerSweepEngine`
-authors against it; `StandardsEnforcementAuditor` audits the constitution's
-enforcement, never the code itself; `CartographerNavigator` scopes a sub-agent to the
-relevant subtree. All are observe-only — they inform, they never block.
+`CartographerTree` is the substrate every layer reads; `CartographerRootRegistry`
+selects its verified project namespace; `CartographerSweepEngine` authors against
+it; `StandardsEnforcementAuditor` audits the constitution's enforcement, never the
+code itself; `CartographerNavigator` scopes a sub-agent to the relevant subtree.
+The root authority can refuse an ambiguous or drifted trusted operation; the
+conformance and navigation layers remain observe-only.
 
 ## Enabling
 

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -188,8 +188,7 @@ import { decryptFromSync, encryptForSync } from '../core/SecretStore.js';
 import { createPrivateKey, createPublicKey, createHash, randomBytes, randomInt } from 'node:crypto';
 import { sign as signEd25519, verify as verifyEd25519 } from '../core/MachineIdentity.js';
 import { ProjectMapper } from '../core/ProjectMapper.js';
-import { CartographerTree } from '../core/CartographerTree.js';
-import { populateCartographer } from '../core/cartographerPopulation.js';
+import { CartographerRootRegistry } from '../core/CartographerRootRegistry.js';
 import { CapabilityMapper } from '../core/CapabilityMapper.js';
 import { ScopeVerifier } from '../core/ScopeVerifier.js';
 import { ContextHierarchy, checkDeclaredIdentityDirectory } from '../core/ContextHierarchy.js';
@@ -15291,6 +15290,15 @@ export async function startServer(options: StartOptions): Promise<void> {
     sleepWakeDetector.start();
 
     // Project Map + Coherence Gate — spatial awareness and pre-action verification
+    // ScopeVerifier is constructed before Cartographer because its persisted topic
+    // bindings are now the typed provenance source for every live root selection.
+    const scopeVerifier = new ScopeVerifier({
+      projectDir: config.projectDir,
+      stateDir: config.stateDir,
+      projectName: config.projectName,
+    });
+    scopeVerifier.loadTopicBindings();
+
     const projectMapper = new ProjectMapper({ projectDir: config.projectDir, stateDir: config.stateDir });
     try {
       projectMapper.generateAndSave();
@@ -15307,43 +15315,64 @@ export async function startServer(options: StartOptions): Promise<void> {
       (config as { cartographer?: { enabled?: boolean } }).cartographer?.enabled,
       config,
     );
-    const cartographer = cartographerEnabled
-      ? new CartographerTree({ projectDir: config.projectDir, stateDir: config.stateDir })
+    const fsCfg = (config as { cartographer?: { freshnessSweep?: Record<string, unknown> } }).cartographer?.freshnessSweep;
+    const cartographerNum = (v: unknown, d: number): number => (
+      typeof v === 'number' && Number.isFinite(v) ? v : d
+    );
+    const cartographerRoots = cartographerEnabled
+      ? new CartographerRootRegistry({
+          agentType: config.agentType === 'standalone' ? 'standalone' : 'project-bound',
+          agentHome: config.projectDir,
+          agentName: config.projectName,
+          stateDir: config.stateDir,
+          ...(config.agentType === 'standalone'
+            ? {}
+            : {
+                serverProject: {
+                  projectDir: config.projectDir,
+                  projectName: config.projectName,
+                },
+              }),
+          // ScopeVerifier owns the live map; this accessor avoids synchronous
+          // disk reads while still following route-driven binding updates.
+          topicBindings: () => scopeVerifier.currentTopicBindings(),
+          population: {
+            config: {
+              scaffoldChunkNodes: cartographerNum(fsCfg?.scaffoldChunkNodes, 500),
+              detectTimeoutMs: cartographerNum(fsCfg?.detectTimeoutMs, 120000),
+              detectWorkerHeapMb: cartographerNum(fsCfg?.detectWorkerHeapMb, 1536),
+              maxIndexBytes: cartographerNum(fsCfg?.maxIndexBytes, 200 * 1024 * 1024),
+              snapshotSampleMax: cartographerNum(fsCfg?.snapshotSampleMax, 500),
+              gitMaxBuffer: cartographerNum(fsCfg?.gitMaxBuffer, 64 * 1024 * 1024),
+              graceMs: cartographerNum(fsCfg?.cadenceMs, 600000) * 2,
+            },
+          },
+          log: (message) => console.log(pc.yellow(`  ${message}`)),
+        })
       : null;
-    if (cartographer) console.log(pc.green('  Cartographer doc-tree enabled'));
+    if (cartographerRoots) console.log(pc.green('  Cartographer verified-root registry enabled'));
 
     // Zero-cost structural population is independent of the optional summary
     // author sweep. Refresh at every boot so newly-added/removed paths join the
     // hierarchy, then run aggregate-only detect in a worker and publish the
     // snapshot that /tree?format=compact + /health serve. No router, LLM, egress,
     // or freshnessSweep.enabled mutation occurs on this path.
-    const cartographerPopulationReady: Promise<void> | null = cartographer
-      ? (() => {
-          const fsCfg = (config as { cartographer?: { freshnessSweep?: Record<string, unknown> } }).cartographer?.freshnessSweep;
-          const num = (v: unknown, d: number): number => (typeof v === 'number' && Number.isFinite(v) ? v : d);
-          return populateCartographer({
-            tree: cartographer,
-            config: {
-              scaffoldChunkNodes: num(fsCfg?.scaffoldChunkNodes, 500),
-              detectTimeoutMs: num(fsCfg?.detectTimeoutMs, 120000),
-              detectWorkerHeapMb: num(fsCfg?.detectWorkerHeapMb, 1536),
-              maxIndexBytes: num(fsCfg?.maxIndexBytes, 200 * 1024 * 1024),
-              snapshotSampleMax: num(fsCfg?.snapshotSampleMax, 500),
-              gitMaxBuffer: num(fsCfg?.gitMaxBuffer, 64 * 1024 * 1024),
-              graceMs: num(fsCfg?.cadenceMs, 600000) * 2,
-            },
-          }).then((r) => {
-            if (r.refused) {
-              console.log(pc.yellow(`  Cartographer population snapshot refused (${r.detectStatus}); retries next boot`));
-            } else {
-              console.log(pc.gray(`  Cartographer hierarchy populated (${r.nodeCount} nodes)`));
+    const cartographerPopulationReady: Promise<void> | null = cartographerRoots
+      ? cartographerRoots.populateOnBoot()
+          .then((results) => {
+            for (const result of results) {
+              if (result.refused) {
+                console.log(pc.yellow(`  Cartographer population snapshot refused (${result.detectStatus}); retries next boot`));
+              } else {
+                console.log(pc.gray(`  Cartographer hierarchy populated (${result.nodeCount} nodes, ${result.rootAuthority.verificationState})`));
+              }
             }
-          }).catch((err: unknown) => {
+          })
+          .catch((err: unknown) => {
             // @silent-fallback-ok — scaffold is atomic and boot remains available;
             // prior snapshot/index stay readable and the next boot retries.
             console.log(pc.yellow(`  Cartographer population incomplete (retries next boot): ${err instanceof Error ? err.message : String(err)}`));
-          });
-        })()
+          })
       : null;
 
     // Cartographer doc-freshness sweep (spec #2). In-process poller that authors
@@ -15357,13 +15386,19 @@ export async function startServer(options: StartOptions): Promise<void> {
     // routing is an unrouted provider the sweep refuses to start (it could not enforce
     // off-Claude) — that cost-protecting probe is UNCHANGED.
     let cartographerSweepPoller: import('../monitoring/CartographerSweepPoller.js').CartographerSweepPoller | null = null;
-    if (cartographer) {
-      const fsCfg = (config as {
+    if (cartographerRoots) {
+      const paidFsCfg = (config as {
         cartographer?: { freshnessSweep?: Record<string, unknown> & { enabled?: boolean; egressAcknowledged?: boolean } };
       }).cartographer?.freshnessSweep;
       const num = (v: unknown, d: number): number => (typeof v === 'number' && Number.isFinite(v) ? v : d);
-      if (fsCfg?.enabled && sharedLlmQueue) {
-        const routerLike =
+      if (paidFsCfg?.enabled && sharedLlmQueue) {
+        const backgroundResolution = cartographerRoots.resolve();
+        if (!backgroundResolution.ok) {
+          console.log(pc.yellow(`  Cartographer sweep: NOT started (root authority ${backgroundResolution.reason})`));
+        } else {
+          const cartographer = backgroundResolution.root.tree;
+          const fsCfg = paidFsCfg;
+          const routerLike =
           sharedIntelligence &&
           typeof (sharedIntelligence as { for?: unknown }).for === 'function' &&
           typeof (sharedIntelligence as { defaultFramework?: unknown }).defaultFramework === 'string'
@@ -15408,6 +15443,12 @@ export async function startServer(options: StartOptions): Promise<void> {
             }),
             // Author ONLY on the lease holder (multi-machine N× burn fix); single-machine ⇒ always holder.
             holdsLease: () => (leaseCoordinatorRef ? leaseCoordinatorRef.holdsLease() : true),
+            authorizePaidAuthoring: () => {
+              const decision = cartographerRoots.authorizePaidAuthoring(backgroundResolution.root);
+              return decision.ok
+                ? { ok: true as const }
+                : { ok: false as const, reason: decision.reason };
+            },
             config: {
               maxNodesPerPass: num(fsCfg.maxNodesPerPass, 25),
               maxCentsPerPass: num(fsCfg.maxCentsPerPass, 25),
@@ -15448,6 +15489,7 @@ export async function startServer(options: StartOptions): Promise<void> {
             cartographerSweepPoller?.start();
             console.log(pc.green('  Cartographer doc-freshness sweep enabled (off-Claude, lease-gated)'));
           });
+        }
         }
       }
     }
@@ -15608,14 +15650,6 @@ export async function startServer(options: StartOptions): Promise<void> {
       // @silent-fallback-ok — capability map non-critical at startup
       console.error(`  Capability map generation failed (non-critical): ${err.message}`);
     });
-
-    const scopeVerifier = new ScopeVerifier({
-      projectDir: config.projectDir,
-      stateDir: config.stateDir,
-      projectName: config.projectName,
-    });
-    // Load any persisted topic-project bindings
-    scopeVerifier.loadTopicBindings();
 
     // Context Hierarchy — tiered context loading for session efficiency
     const contextHierarchy = new ContextHierarchy({
@@ -24530,7 +24564,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       })),
     });
 
-    const server = new AgentServer({ config, subscriptionEmailBinding: credentialLocationLedger, subscriptionEmailBarrier, subscriptionIdentityOracle: credentialIdentityOracle, sessionManager, llmQueue: sharedLlmQueue, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographer: cartographer ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, accountFollowMePeerViews: async () => { const nickById = new Map((_listPoolMachines?.() ?? []).map((m) => [m.machineId, m.nickname ?? m.machineId])); let peers = (_resolvePeerUrls?.() ?? []).map((p) => ({ machineId: p.machineId, nickname: nickById.get(p.machineId) ?? p.machineId, url: p.url })); if (peers.length === 0) { peers = (_listPoolMachines?.() ?? []).filter((m) => m.machineId !== _meshSelfId && !!m.lastKnownUrl).map((m) => ({ machineId: m.machineId, nickname: m.nickname ?? m.machineId, url: m.lastKnownUrl as string })); } if (peers.length === 0) return []; const { fetchPeerSubscriptionViews } = await import('../core/fetchPeerSubscriptionViews.js'); return fetchPeerSubscriptionViews({ peers: () => peers, fetchImpl: fetch as unknown as Parameters<typeof fetchPeerSubscriptionViews>[0]['fetchImpl'], authToken: config.authToken ?? '' }); }, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, accountFollowMeRevocation, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, meshBindActive: coordinator.managers.identityManager.hasIdentity() && config.multiMachine?.meshTransport?.enabled !== false, localSigningKeyPem, leaseTransport, peerEndpointRecorder, getSelfMeshEndpoints, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, conversationRegistry, conversationBindAuth, conversationFollowThrough, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, getLastRelayEvent: threadlineGetLastRelayEvent, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, reviewCanaryBattery, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, ropeHealthMonitor, writeAdmission: writeAdmission ?? undefined, getInboundQueue: () => _inboundQueue, getMachineCoherence: () => _machineCoherenceSentinel, getSingleMachineFailoverGap: () => _singleMachineFailoverGap, getMissingLoginSession: () => _missingLoginSession, getSessionPoolFailoverRunner: () => _sessionPoolFailoverRunnerDriver?.status() ?? null, sessionPoolPromotionActivation: _sessionPoolPromotionActivation, meshRpcDispatcher, deliverA2aToMachine: _deliverA2aToMachine ?? undefined, workingSetPullCoordinator, workingSetArtifactManager, orchestratorPoller, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, sendDrain: _sendDrain ?? undefined, topicPinStore: _topicPinStore ?? undefined, topicPinSkewQuarantine: _topicPinSkewQuarantine ?? undefined, topicPinFoldView: _topicPinFoldView ?? undefined, ownershipReconciler: _ownershipReconciler ?? undefined, staleOwnerEngine: _staleOwnerEngine ?? undefined, duplicateReconciler: _duplicateReconciler ?? undefined, ownerDarkLadder: _ownerDarkLadder ?? undefined, spawnAdmission: _spawnAdmission ?? undefined, judgmentProvenance: _judgmentProvenance ?? undefined, leaseHandback: _leaseHandbackCtx ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, deliverMandateToMachine: _deliverMandateToMachine ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, externalHogSentinel, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, autonomousLivenessReconciler, enforcedTerminationStatus: () => enforcedTerminationWatchdog?.guardStatus() ?? null, prHandLease: prHandLease ?? undefined, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
+    const server = new AgentServer({ config, subscriptionEmailBinding: credentialLocationLedger, subscriptionEmailBarrier, subscriptionIdentityOracle: credentialIdentityOracle, sessionManager, llmQueue: sharedLlmQueue, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographerRoots: cartographerRoots ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, accountFollowMePeerViews: async () => { const nickById = new Map((_listPoolMachines?.() ?? []).map((m) => [m.machineId, m.nickname ?? m.machineId])); let peers = (_resolvePeerUrls?.() ?? []).map((p) => ({ machineId: p.machineId, nickname: nickById.get(p.machineId) ?? p.machineId, url: p.url })); if (peers.length === 0) { peers = (_listPoolMachines?.() ?? []).filter((m) => m.machineId !== _meshSelfId && !!m.lastKnownUrl).map((m) => ({ machineId: m.machineId, nickname: m.nickname ?? m.machineId, url: m.lastKnownUrl as string })); } if (peers.length === 0) return []; const { fetchPeerSubscriptionViews } = await import('../core/fetchPeerSubscriptionViews.js'); return fetchPeerSubscriptionViews({ peers: () => peers, fetchImpl: fetch as unknown as Parameters<typeof fetchPeerSubscriptionViews>[0]['fetchImpl'], authToken: config.authToken ?? '' }); }, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, accountFollowMeRevocation, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, meshBindActive: coordinator.managers.identityManager.hasIdentity() && config.multiMachine?.meshTransport?.enabled !== false, localSigningKeyPem, leaseTransport, peerEndpointRecorder, getSelfMeshEndpoints, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, conversationRegistry, conversationBindAuth, conversationFollowThrough, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, getLastRelayEvent: threadlineGetLastRelayEvent, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, reviewCanaryBattery, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, ropeHealthMonitor, writeAdmission: writeAdmission ?? undefined, getInboundQueue: () => _inboundQueue, getMachineCoherence: () => _machineCoherenceSentinel, getSingleMachineFailoverGap: () => _singleMachineFailoverGap, getMissingLoginSession: () => _missingLoginSession, getSessionPoolFailoverRunner: () => _sessionPoolFailoverRunnerDriver?.status() ?? null, sessionPoolPromotionActivation: _sessionPoolPromotionActivation, meshRpcDispatcher, deliverA2aToMachine: _deliverA2aToMachine ?? undefined, workingSetPullCoordinator, workingSetArtifactManager, orchestratorPoller, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, sendDrain: _sendDrain ?? undefined, topicPinStore: _topicPinStore ?? undefined, topicPinSkewQuarantine: _topicPinSkewQuarantine ?? undefined, topicPinFoldView: _topicPinFoldView ?? undefined, ownershipReconciler: _ownershipReconciler ?? undefined, staleOwnerEngine: _staleOwnerEngine ?? undefined, duplicateReconciler: _duplicateReconciler ?? undefined, ownerDarkLadder: _ownerDarkLadder ?? undefined, spawnAdmission: _spawnAdmission ?? undefined, judgmentProvenance: _judgmentProvenance ?? undefined, leaseHandback: _leaseHandbackCtx ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, deliverMandateToMachine: _deliverMandateToMachine ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, externalHogSentinel, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, autonomousLivenessReconciler, enforcedTerminationStatus: () => enforcedTerminationWatchdog?.guardStatus() ?? null, prHandLease: prHandLease ?? undefined, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
     server.setWorkQueue(workQueue);
     if (_stateSyncStoresResolved?.classReview?.enabled && replicatedPeerStreamReader) {
       const { CLASS_REVIEW_STORE_KEY, classReviewFromOriginRecord } = await import('../core/ClassReviewReplicatedStore.js');

--- a/src/core/CartographerNavigator.ts
+++ b/src/core/CartographerNavigator.ts
@@ -210,6 +210,8 @@ function provisionalDirScore(query: string, dirNode: CartographerNode, descendan
 interface VisitedRecord {
   node: CartographerNode;
   depth: number;
+  /** Path-only augmented score used to decide whether a directory is worth descending toward. */
+  provisionalScore: number;
   /** The score used for RANKING the `scored` set. For a leaf == its own score; for a dir == max(own, fold-up). */
   finalScore: number;
   /**
@@ -326,7 +328,7 @@ export function navigate(
     const myVisitedChildren: string[] = [];
     let maxChildFinal = 0;
 
-    for (const { node: child, ownScore } of scoredChildren) {
+    for (const { node: child, ownScore, provisional } of scoredChildren) {
       if (nodesVisited >= o.maxNodesVisited) {
         truncated = true;
         break;
@@ -350,6 +352,7 @@ export function navigate(
       visited.set(child.path, {
         node: child,
         depth: depth + 1,
+        provisionalScore: provisional,
         finalScore,
         // A leaf seeds the relevant set on its OWN score; a dir never does (it must
         // collapse to become a relevant path).
@@ -372,6 +375,7 @@ export function navigate(
   visited.set('', {
     node: root,
     depth: 0,
+    provisionalScore: rootMaxChild,
     finalScore: rootMaxChild * 0.9,
     selfRelevant: false,     // root is never emitted as a relevant scope
     countsForCollapse: false,
@@ -413,9 +417,14 @@ export function navigate(
   }
 
   // ── Assemble the scored manifest ───────────────────────────────────────────
-  // Emit every visited node (excluding root) ranked by finalScore, capped at maxResults.
+  // Emit only relevant visited nodes (excluding root) ranked by finalScore,
+  // capped at maxResults. Zero/under-threshold siblings are traversal evidence,
+  // not navigation results; returning them leaks unrelated scope into a consumer.
   const allScored = [...visited.entries()]
-    .filter(([p]) => p !== '')
+    .filter(([p, rec]) => p !== '' && (
+      rec.finalScore > o.minScore
+      || (rec.node.kind === 'dir' && rec.provisionalScore > o.minScore)
+    ))
     .map(([, rec]) => rec)
     .sort((a, b) => b.finalScore - a.finalScore || a.node.path.localeCompare(b.node.path));
   if (allScored.length > o.maxResults) truncated = true;

--- a/src/core/CartographerRootRegistry.ts
+++ b/src/core/CartographerRootRegistry.ts
@@ -1,0 +1,409 @@
+/**
+ * Live Cartographer consumer for verified-root authority.
+ *
+ * One resolved entry binds the authority assessment, isolated tree, reporting
+ * metadata, zero-cost boot population, and paid-authoring revalidation. Routes
+ * must resolve once and keep that entry for the entire operation.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { CartographerTree } from './CartographerTree.js';
+import {
+  CartographerRootAuthority,
+  selectCartographerRootCandidate,
+  type CartographerRootAssessment,
+  type CartographerRootCandidate,
+  type CartographerRootDecision,
+  type CartographerRootProvenance,
+  type CartographerRootSelectionResult,
+} from './CartographerRootAuthority.js';
+import {
+  populateCartographer,
+  type CartographerPopulationConfig,
+  type CartographerPopulationResult,
+  type CartographerPopulationDeps,
+} from './cartographerPopulation.js';
+import type { TopicProjectBinding } from './ScopeVerifier.js';
+import type { AgentType } from './types.js';
+import { SafeFsExecutor } from './SafeFsExecutor.js';
+
+export interface CartographerRootReport {
+  rootId: string;
+  repositoryId: string | null;
+  kind: 'agent-home' | 'active-project-checkout' | 'instar-source-checkout';
+  canonicalPath: string;
+  revision: string | null;
+  provenance: CartographerRootProvenance;
+  verificationState: 'verified' | 'structural-only';
+  verificationReason: CartographerRootAssessment['reason'];
+  structuralPopulationAllowed: boolean;
+  paidAuthoringAllowed: boolean;
+}
+
+export interface CartographerResolvedRoot {
+  tree: CartographerTree;
+  assessment: CartographerRootAssessment;
+  report: CartographerRootReport;
+}
+
+export type CartographerRootResolution =
+  | { ok: true; root: CartographerResolvedRoot }
+  | {
+      ok: false;
+      reason: string;
+      message: string;
+      report?: Omit<CartographerRootReport, 'verificationState'> & {
+        verificationState: 'refused';
+      };
+    };
+
+export type CartographerAuthoringDecision =
+  | { ok: true; root: CartographerResolvedRoot }
+  | { ok: false; reason: string; message: string };
+
+export interface CartographerBootPopulationResult extends CartographerPopulationResult {
+  rootAuthority: CartographerRootReport;
+}
+
+export interface CartographerRootRegistryOptions {
+  agentType: AgentType;
+  agentHome: string;
+  agentName: string;
+  stateDir: string;
+  serverProject?: {
+    projectDir: string;
+    projectName: string;
+    gitRemote?: string;
+  };
+  topicBindings: () => Record<string, TopicProjectBinding>;
+  population?: {
+    config?: CartographerPopulationConfig;
+    onYield?: CartographerPopulationDeps['onYield'];
+    /** Test seam only. Production always omits this and uses the real worker. */
+    runDetectWorker?: CartographerPopulationDeps['runDetectWorker'];
+  };
+  decisionLogPath?: string;
+  /** Active decision-log ceiling. Default 5 MiB. */
+  decisionLogMaxBytes?: number;
+  /** Rotated archives retained. Default 2. */
+  decisionLogKeepArchives?: number;
+  now?: () => Date;
+  log?: (message: string) => void;
+}
+
+interface CachedResolution {
+  signature: string;
+  root: CartographerResolvedRoot;
+}
+
+type RuntimeDecision =
+  | CartographerRootDecision
+  | {
+      schemaVersion: 1;
+      decidedAt: string;
+      operation: 'select';
+      context: { topicId: number | null; standalone: boolean };
+      rule: string;
+      outcome: { trust: 'refused' };
+    };
+
+function reportFor(
+  assessment: CartographerRootAssessment,
+): CartographerRootReport | null {
+  const identity = assessment.identity;
+  if (!identity || assessment.trust === 'refused') return null;
+  return {
+    rootId: identity.rootId,
+    repositoryId: identity.repositoryId,
+    kind: identity.kind,
+    canonicalPath: identity.canonicalPath,
+    revision: identity.revision,
+    provenance: { ...assessment.candidate.provenance },
+    verificationState: assessment.trust,
+    verificationReason: assessment.reason,
+    structuralPopulationAllowed: assessment.structuralPopulationAllowed,
+    paidAuthoringAllowed: assessment.paidAuthoringAllowed,
+  };
+}
+
+function refusedReport(
+  assessment: CartographerRootAssessment,
+): CartographerRootResolution & { ok: false } {
+  const identity = assessment.identity;
+  const report = identity
+    ? {
+        rootId: identity.rootId,
+        repositoryId: identity.repositoryId,
+        kind: identity.kind,
+        canonicalPath: identity.canonicalPath,
+        revision: identity.revision,
+        provenance: { ...assessment.candidate.provenance },
+        verificationState: 'refused' as const,
+        verificationReason: assessment.reason,
+        structuralPopulationAllowed: false,
+        paidAuthoringAllowed: false,
+      }
+    : undefined;
+  return {
+    ok: false,
+    reason: assessment.reason,
+    message: `Cartographer root authority refused the selected root (${assessment.reason})`,
+    ...(report ? { report } : {}),
+  };
+}
+
+/**
+ * Registry lifetime is one server boot. Assessments therefore pin the exact
+ * revision that produced the current hierarchy; paid writes revalidate against
+ * that pin instead of silently adopting a later HEAD.
+ */
+export class CartographerRootRegistry {
+  private readonly options: CartographerRootRegistryOptions;
+  private readonly authority: CartographerRootAuthority;
+  private readonly decisionLogPath: string;
+  private readonly decisionLogMaxBytes: number;
+  private readonly decisionLogKeepArchives: number;
+  private readonly now: () => Date;
+  private readonly log: (message: string) => void;
+  private readonly cachedBySelection = new Map<string, CachedResolution>();
+  private readonly treesByRootId = new Map<string, CartographerTree>();
+
+  constructor(options: CartographerRootRegistryOptions) {
+    this.options = options;
+    this.now = options.now ?? (() => new Date());
+    this.log = options.log ?? (() => {});
+    this.decisionLogPath = options.decisionLogPath
+      ?? path.join(options.stateDir, 'cartographer', 'root-authority-decisions.jsonl');
+    this.decisionLogMaxBytes = options.decisionLogMaxBytes && options.decisionLogMaxBytes > 0
+      ? options.decisionLogMaxBytes
+      : 5 * 1024 * 1024;
+    this.decisionLogKeepArchives = options.decisionLogKeepArchives !== undefined
+      && options.decisionLogKeepArchives >= 0
+      ? Math.floor(options.decisionLogKeepArchives)
+      : 2;
+    this.authority = new CartographerRootAuthority({
+      now: this.now,
+      recordDecision: (decision) => this.recordDecision(decision),
+    });
+  }
+
+  private recordDecision(decision: RuntimeDecision): void {
+    fs.mkdirSync(path.dirname(this.decisionLogPath), { recursive: true });
+    let activeBytes = 0;
+    try {
+      activeBytes = fs.statSync(this.decisionLogPath).size;
+    } catch {
+      // @silent-fallback-ok — a missing active log starts at zero; any other
+      // append failure still propagates below and fails the authority outcome.
+    }
+    if (activeBytes > this.decisionLogMaxBytes) {
+      const operation = 'cartographer root-authority decision-log rotation';
+      const oldest = `${this.decisionLogPath}.${this.decisionLogKeepArchives}`;
+      if (this.decisionLogKeepArchives > 0 && fs.existsSync(oldest)) {
+        SafeFsExecutor.safeUnlinkSync(oldest, { operation });
+      }
+      for (let index = this.decisionLogKeepArchives - 1; index >= 1; index -= 1) {
+        const from = `${this.decisionLogPath}.${index}`;
+        if (fs.existsSync(from)) fs.renameSync(from, `${this.decisionLogPath}.${index + 1}`);
+      }
+      if (this.decisionLogKeepArchives > 0) {
+        fs.renameSync(this.decisionLogPath, `${this.decisionLogPath}.1`);
+      } else {
+        SafeFsExecutor.safeUnlinkSync(this.decisionLogPath, { operation });
+      }
+    }
+    fs.appendFileSync(this.decisionLogPath, `${JSON.stringify(decision)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+  }
+
+  private select(topicId?: number): CartographerRootSelectionResult {
+    const binding = topicId === undefined
+      ? undefined
+      : this.options.topicBindings()[String(topicId)];
+    return selectCartographerRootCandidate({
+      kind: 'active-project-checkout',
+      standalone: this.options.agentType === 'standalone',
+      ...(this.options.serverProject ? { serverProject: this.options.serverProject } : {}),
+      ...(binding && topicId !== undefined
+        ? {
+            topicBinding: {
+              topicId,
+              projectDir: binding.projectDir,
+              projectName: binding.projectName,
+              ...(binding.gitRemote ? { gitRemote: binding.gitRemote } : {}),
+            },
+          }
+        : {}),
+    });
+  }
+
+  private selectionSignature(candidate: CartographerRootCandidate): string {
+    return JSON.stringify({
+      kind: candidate.kind,
+      requestedPath: candidate.requestedPath,
+      provenance: candidate.provenance,
+      expectedRemote: candidate.expectedRemote ?? null,
+    });
+  }
+
+  resolve(topicId?: number): CartographerRootResolution {
+    const selection = this.select(topicId);
+    if (!selection.ok) {
+      try {
+        this.recordDecision({
+          schemaVersion: 1,
+          decidedAt: this.now().toISOString(),
+          operation: 'select',
+          context: {
+            topicId: topicId ?? null,
+            standalone: this.options.agentType === 'standalone',
+          },
+          rule: selection.code,
+          outcome: { trust: 'refused' },
+        });
+      } catch (error) {
+        return {
+          ok: false,
+          reason: 'decision-recording-failed',
+          message: error instanceof Error ? error.message : String(error),
+        };
+      }
+      return { ok: false, reason: selection.code, message: selection.message };
+    }
+
+    const signature = this.selectionSignature(selection.candidate);
+    const cached = this.cachedBySelection.get(signature);
+    if (cached) return { ok: true, root: cached.root };
+
+    let assessment: CartographerRootAssessment;
+    try {
+      assessment = this.authority.assess(selection.candidate);
+    } catch (error) {
+      return {
+        ok: false,
+        reason: 'decision-recording-failed',
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+    if (!assessment.structuralPopulationAllowed || assessment.trust === 'refused') {
+      return refusedReport(assessment);
+    }
+    const report = reportFor(assessment);
+    if (!report) {
+      return {
+        ok: false,
+        reason: 'identity-unavailable',
+        message: 'Cartographer root authority did not mint a usable root identity',
+      };
+    }
+    let tree = this.treesByRootId.get(report.rootId);
+    if (!tree) {
+      tree = new CartographerTree({
+        projectDir: report.canonicalPath,
+        stateDir: this.options.stateDir,
+        stateNamespace: report.rootId.startsWith('root-')
+          ? report.rootId
+          : `root-${report.rootId}`,
+      });
+      this.treesByRootId.set(report.rootId, tree);
+    }
+    const root = { tree, assessment, report };
+    this.cachedBySelection.set(signature, { signature, root });
+    return { ok: true, root };
+  }
+
+  authorizePaidAuthoring(root: CartographerResolvedRoot): CartographerAuthoringDecision {
+    let revalidated: CartographerRootAssessment;
+    try {
+      revalidated = this.authority.revalidate(root.assessment);
+    } catch (error) {
+      return {
+        ok: false,
+        reason: 'decision-recording-failed',
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+    if (
+      revalidated.trust !== 'verified'
+      || !revalidated.paidAuthoringAllowed
+      || revalidated.identity?.rootId !== root.report.rootId
+      || revalidated.identity?.revision !== root.report.revision
+    ) {
+      return {
+        ok: false,
+        reason: revalidated.reason,
+        message: `Cartographer paid authoring refused (${revalidated.reason})`,
+      };
+    }
+    return { ok: true, root };
+  }
+
+  /**
+   * Per-root trees are regenerable caches, not history. At boot, remove only
+   * authority-shaped namespaces no longer selected by any live binding so old
+   * topic churn cannot accumulate an unbounded archive of project maps.
+   */
+  private pruneInactiveRootCaches(activeNamespaces: Set<string>): void {
+    const rootsDir = path.join(this.options.stateDir, 'cartographer', 'roots');
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(rootsDir, { withFileTypes: true });
+    } catch {
+      return; // no root cache directory yet
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !/^root-[a-f0-9]{24}$/.test(entry.name)) continue;
+      if (activeNamespaces.has(entry.name)) continue;
+      const target = path.join(rootsDir, entry.name);
+      try {
+        SafeFsExecutor.safeRmSync(target, {
+          recursive: true,
+          force: true,
+          operation: 'prune inactive Cartographer root cache at boot',
+        });
+      } catch (error) {
+        this.log(`[cartographer-roots] inactive cache prune failed (${entry.name}): ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  }
+
+  /** Enumerate all explicit live roots and rebuild each hierarchy once per boot. */
+  async populateOnBoot(): Promise<CartographerBootPopulationResult[]> {
+    const topicIds = Object.keys(this.options.topicBindings())
+      .map((raw) => Number(raw))
+      .filter((value) => Number.isInteger(value) && value > 0)
+      .sort((a, b) => a - b);
+    const requests: Array<number | undefined> = this.options.agentType === 'standalone'
+      ? topicIds
+      : [undefined, ...topicIds];
+    const roots = new Map<string, CartographerResolvedRoot>();
+    for (const topicId of requests) {
+      const resolved = this.resolve(topicId);
+      if (resolved.ok) roots.set(resolved.root.report.rootId, resolved.root);
+    }
+    // An empty set can mean a temporarily unreadable/corrupt binding registry.
+    // Never turn uncertainty into delete-all; prune only when at least one live
+    // root positively selected and can anchor the keep set.
+    if (roots.size > 0) {
+      this.pruneInactiveRootCaches(new Set(
+        [...roots.values()].map((root) => `root-${root.report.rootId}`),
+      ));
+    }
+
+    const results: CartographerBootPopulationResult[] = [];
+    for (const root of roots.values()) {
+      const result = await populateCartographer({
+        tree: root.tree,
+        ...(this.options.population?.config ? { config: this.options.population.config } : {}),
+        ...(this.options.population?.onYield ? { onYield: this.options.population.onYield } : {}),
+        ...(this.options.population?.runDetectWorker
+          ? { runDetectWorker: this.options.population.runDetectWorker }
+          : {}),
+      });
+      results.push({ ...result, rootAuthority: root.report });
+    }
+    return results;
+  }
+}

--- a/src/core/CartographerSweepEngine.ts
+++ b/src/core/CartographerSweepEngine.ts
@@ -126,6 +126,15 @@ export class SweepAbortedError extends Error {
   }
 }
 
+class SweepAuthorityRefusedError extends Error {
+  readonly reason: string;
+  constructor(reason: string) {
+    super(`cartographer root authority refused (${reason})`);
+    this.name = 'SweepAuthorityRefusedError';
+    this.reason = reason;
+  }
+}
+
 export interface SweepLlmQueueLike {
   enqueue(
     lane: 'interactive' | 'background',
@@ -142,6 +151,13 @@ export interface SweepEngineDeps {
   pressure: () => PressureReading;
   /** Author ONLY when this returns true (lease holder). Single-machine ⇒ () => true. */
   holdsLease: () => boolean;
+  /**
+   * Revalidate the authority-pinned root before any paid/background path begins.
+   * Omitted only by isolated legacy tests; production wiring supplies it.
+   */
+  authorizePaidAuthoring: () =>
+    | { ok: true }
+    | { ok: false; reason: string };
   config: SweepEngineConfig;
   stateDir: string;
   now?: () => number;
@@ -245,6 +261,19 @@ export class CartographerSweepEngine {
       return { ...base, reason: 'not-lease-holder' };
     }
 
+    // Root authority precedes both routing and detect. A stale/mismatched root
+    // must spend nothing and must not inspect one tree while reporting another.
+    const authority = this.d.authorizePaidAuthoring();
+    if (!authority.ok) {
+      this.log(`[cartographer-sweep] refusing to author: root authority ${authority.reason}`);
+      return {
+        ...base,
+        refused: true,
+        refusalReason: authority.reason,
+        reason: 'authority-refused',
+      };
+    }
+
     // Routing probe — the L5 canary. Refuse rather than silently burn Claude.
     const probe = this.probeRouting();
     if (!probe.ok) {
@@ -265,6 +294,22 @@ export class CartographerSweepEngine {
       return {
         ...base, refused: true, refusalReason: detect.refusalReason, reason,
         candidateCount: detect.staleTotal, detectStatus: this.detectStatus(detect),
+        detectDurationMs: detect.durationMs,
+      };
+    }
+
+    // Detect may run for minutes in a worker. Revalidate again after that await,
+    // before the first paid call, so a HEAD move during detect cannot inherit the
+    // authority result sampled at pass admission.
+    const postDetectAuthority = this.d.authorizePaidAuthoring();
+    if (!postDetectAuthority.ok) {
+      return {
+        ...base,
+        refused: true,
+        refusalReason: postDetectAuthority.reason,
+        reason: 'authority-refused',
+        candidateCount: detect.staleTotal,
+        detectStatus: this.detectStatus(detect),
         detectDurationMs: detect.durationMs,
       };
     }
@@ -331,6 +376,17 @@ export class CartographerSweepEngine {
         continue;
       }
 
+      // Each LLM call yields the event loop and may overlap an external checkout
+      // update. Revalidate the pinned revision immediately before every paid or
+      // fingerprint-authoring operation, not merely once per pass.
+      const nodeAuthority = this.d.authorizePaidAuthoring();
+      if (!nodeAuthority.ok) {
+        result.refused = true;
+        result.refusalReason = nodeAuthority.reason;
+        result.reason = 'authority-refused';
+        break;
+      }
+
       try {
         const outcome = await this.authorNode(node, framework, deltas);
         switch (outcome.kind) {
@@ -358,6 +414,12 @@ export class CartographerSweepEngine {
             break;
         }
       } catch (err) {
+        if (err instanceof SweepAuthorityRefusedError) {
+          result.refused = true;
+          result.refusalReason = err.reason;
+          result.reason = 'authority-refused';
+          break;
+        }
         if (this.isAbort(err)) {
           // Backpressure, NOT failure: leave status, don't count the breaker, retry next quiet tick.
           result.abortedBackpressure = true;
@@ -378,7 +440,14 @@ export class CartographerSweepEngine {
     if (!curtail && !result.abortedBackpressure &&
         result.centsSpent + cfg.estCentsPerAuthor <= cfg.maxCentsPerPass &&
         result.authored + result.fingerprintRefreshed < cfg.maxNodesPerPass) {
-      result.revalidated = await this.revalidateSample(detect.revalidationSample, framework, result, deltas);
+      const sampleAuthority = this.d.authorizePaidAuthoring();
+      if (sampleAuthority.ok) {
+        result.revalidated = await this.revalidateSample(detect.revalidationSample, framework, result, deltas);
+      } else {
+        result.refused = true;
+        result.refusalReason = sampleAuthority.reason;
+        result.reason = 'authority-refused';
+      }
     }
 
     // Author-phase index write (b): ONE off-thread re-read+apply+write of the
@@ -512,6 +581,7 @@ export class CartographerSweepEngine {
       const coveredSymbols = extractCodeSymbols(read.content);
       const prompt = this.buildLeafPrompt(node.path, read.content, read.truncated);
       const summary = await this.callAuthor(prompt);
+      this.requirePaidAuthority();
       return this.persistAuthored(node, summary, coveredSymbols, framework, deltas, {
         modelTier: 'light', truncated: read.truncated,
       });
@@ -537,6 +607,7 @@ export class CartographerSweepEngine {
     const coveredSymbols = extractCodeSymbols(coveredText);
     const prompt = this.buildDirPrompt(node.path, childSummaries, children.map((c) => basename(c.path)));
     const summary = await this.callAuthor(prompt);
+    this.requirePaidAuthority();
     return this.persistAuthored(node, summary, coveredSymbols, framework, deltas, {
       modelTier: 'light', childDigestHash: digest,
     });
@@ -595,6 +666,12 @@ export class CartographerSweepEngine {
     );
   }
 
+  /** Close the LLM-await TOCTOU window immediately before a summary write. */
+  private requirePaidAuthority(): void {
+    const authority = this.d.authorizePaidAuthoring();
+    if (!authority.ok) throw new SweepAuthorityRefusedError(authority.reason);
+  }
+
   // ── re-validation sample (fresh ≠ correct) ──────────────────────────────────
 
   private async revalidateSample(
@@ -609,6 +686,13 @@ export class CartographerSweepEngine {
     let n = 0;
     for (const p of samplePaths) {
       if (result.centsSpent + this.d.config.estCentsPerAuthor > this.d.config.maxCentsPerPass) break;
+      const authority = this.d.authorizePaidAuthoring();
+      if (!authority.ok) {
+        result.refused = true;
+        result.refusalReason = authority.reason;
+        result.reason = 'authority-refused';
+        break;
+      }
       const node = this.d.tree.getNode(p);
       if (!node) continue;
       try {
@@ -618,6 +702,12 @@ export class CartographerSweepEngine {
           result.centsSpent += this.d.config.estCentsPerAuthor;
         }
       } catch (err) {
+        if (err instanceof SweepAuthorityRefusedError) {
+          result.refused = true;
+          result.refusalReason = err.reason;
+          result.reason = 'authority-refused';
+          break;
+        }
         if (this.isAbort(err)) break;
         // a failed re-validation is non-fatal; leave the node as-is.
       }

--- a/src/core/ScopeVerifier.ts
+++ b/src/core/ScopeVerifier.ts
@@ -226,6 +226,11 @@ export class ScopeVerifier {
     return this.config.topicProjects?.[String(topicId)] ?? null;
   }
 
+  /** Current in-memory binding map; no filesystem read on request paths. */
+  currentTopicBindings(): Record<string, TopicProjectBinding> {
+    return this.config.topicProjects ?? (this.config.topicProjects = {});
+  }
+
   /**
    * Register a topic-to-project binding.
    */
@@ -251,7 +256,10 @@ export class ScopeVerifier {
     } catch {
       // @silent-fallback-ok — corrupt bindings, empty map
     }
-    return {};
+    // Keep one live object so consumers can retain a read-only reference while
+    // setTopicBinding mutates and persists that same map.
+    this.config.topicProjects = {};
+    return this.config.topicProjects;
   }
 
   /**

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -525,6 +525,8 @@ export class AgentServer {
     topicMemory?: TopicMemory;
     feedbackAnomalyDetector?: FeedbackAnomalyDetector;
     projectMapper?: import('../core/ProjectMapper.js').ProjectMapper;
+    cartographerRoots?: import('../core/CartographerRootRegistry.js').CartographerRootRegistry;
+    /** @deprecated Isolated test compatibility; production uses cartographerRoots. */
     cartographer?: import('../core/CartographerTree.js').CartographerTree;
     coherenceGate?: import('../core/ScopeVerifier.js').ScopeVerifier;
     contextHierarchy?: import('../core/ContextHierarchy.js').ContextHierarchy;
@@ -3462,6 +3464,7 @@ export class AgentServer {
       topicMemory: options.topicMemory ?? null,
       feedbackAnomalyDetector: options.feedbackAnomalyDetector ?? null,
       projectMapper: options.projectMapper ?? null,
+      cartographerRoots: options.cartographerRoots ?? null,
       cartographer: options.cartographer ?? null,
       coherenceGate: options.coherenceGate ?? null,
       contextHierarchy: options.contextHierarchy ?? null,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -286,6 +286,11 @@ import type { TopicMemory } from '../memory/TopicMemory.js';
 import type { FeedbackAnomalyDetector } from '../monitoring/FeedbackAnomalyDetector.js';
 import type { ProjectMapper } from '../core/ProjectMapper.js';
 import type { CartographerTree } from '../core/CartographerTree.js';
+import type {
+  CartographerRootRegistry,
+  CartographerRootReport,
+  CartographerResolvedRoot,
+} from '../core/CartographerRootRegistry.js';
 import { verifyMergedItemsViaGit, resolveCanonicalMainRef } from '../core/ProjectRoundExecution.js';
 import type { ProjectDriftChecker } from '../core/ProjectDriftChecker.js';
 import type { ScopeVerifier } from '../core/ScopeVerifier.js';
@@ -818,6 +823,9 @@ export interface RouteContext {
   topicMemory: TopicMemory | null;
   feedbackAnomalyDetector: FeedbackAnomalyDetector | null;
   projectMapper: ProjectMapper | null;
+  /** Authority-backed live consumer. Production Cartographer routes use this. */
+  cartographerRoots?: CartographerRootRegistry | null;
+  /** @deprecated Legacy test seam; production must pass cartographerRoots. */
   cartographer?: CartographerTree | null;
   coherenceGate: ScopeVerifier | null;
   contextHierarchy: ContextHierarchy | null;
@@ -7119,14 +7127,98 @@ export function createRoutes(ctx: RouteContext): Router {
   // The Slice-5 callsite lint forbids loadIndex/staleNodes/freshnessHealth/scaffold
   // here, so this regression cannot return by accident.
 
+  interface CartographerRouteRoot {
+    tree: CartographerTree;
+    rootAuthority?: CartographerRootReport;
+    resolvedRoot?: CartographerResolvedRoot;
+  }
+
+  const cartographerTopicId = (
+    req: ExpressRequest,
+  ): number | null | undefined => {
+    const raw = req.method === 'POST'
+      ? ((req.body as { topicId?: unknown } | undefined)?.topicId ?? req.query.topicId)
+      : req.query.topicId;
+    if (raw === undefined) return undefined;
+    const value = typeof raw === 'number'
+      ? raw
+      : typeof raw === 'string'
+        ? Number(raw)
+        : NaN;
+    return Number.isInteger(value) && value > 0 ? value : null;
+  };
+
+  /** Resolve once per operation so reporting, reads, and writes cannot diverge. */
+  const cartographerRouteRoot = (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    paidAuthoring = false,
+  ): CartographerRouteRoot | null => {
+    if (ctx.cartographerRoots) {
+      const topicId = cartographerTopicId(req);
+      if (topicId === null) {
+        res.status(400).json({ error: 'invalid topicId' });
+        return null;
+      }
+      const resolved = ctx.cartographerRoots.resolve(topicId);
+      if (!resolved.ok) {
+        res.status(409).json({
+          error: 'cartographer-root-refused',
+          reason: resolved.reason,
+          ...(resolved.report ? { rootAuthority: resolved.report } : {}),
+        });
+        return null;
+      }
+      if (paidAuthoring) {
+        const authorized = ctx.cartographerRoots.authorizePaidAuthoring(resolved.root);
+        if (!authorized.ok) {
+          res.status(409).json({
+            error: 'cartographer-authoring-refused',
+            reason: authorized.reason,
+            rootAuthority: resolved.root.report,
+          });
+          return null;
+        }
+      }
+      return {
+        tree: resolved.root.tree,
+        rootAuthority: resolved.root.report,
+        resolvedRoot: resolved.root,
+      };
+    }
+    // Compatibility for existing isolated route tests. AgentServer production
+    // wiring no longer supplies this singleton. It is read-only: paid authoring
+    // without a live authority is always refused.
+    if (ctx.cartographer) {
+      if (paidAuthoring) {
+        res.status(409).json({
+          error: 'cartographer-authoring-refused',
+          reason: 'root-authority-absent',
+        });
+        return null;
+      }
+      return { tree: ctx.cartographer };
+    }
+    res.status(503).json({ error: 'Cartographer not enabled' });
+    return null;
+  };
+
+  const withCartographerAuthority = <T extends Record<string, unknown>>(
+    payload: T,
+    root: CartographerRouteRoot,
+  ): T & { rootAuthority?: CartographerRootReport } => (
+    root.rootAuthority ? { ...payload, rootAuthority: root.rootAuthority } : payload
+  );
+
   /** Snapshot-enum + provenance, computed cheaply (one `git rev-parse --short HEAD`). */
   const cartoSnapshotMeta = (
     snap: import('../core/cartographerDetect.js').CartographerSnapshot | null,
+    tree: CartographerTree,
   ): { snapshot: 'present' | 'absent' | 'detect-failing'; snapshotStale: boolean; ageMs: number | null; headMoved: boolean; lastDetectStatus: string | null; lastDetectAt: string | null; headSha: string | null } => {
     if (!snap) {
       return { snapshot: 'absent', snapshotStale: true, ageMs: null, headMoved: false, lastDetectStatus: null, lastDetectAt: null, headSha: null };
     }
-    const currentHead = ctx.cartographer ? ctx.cartographer.currentHeadShort() : null;
+    const currentHead = tree.currentHeadShort();
     const headMoved = snap.headSha != null && currentHead != null && snap.headSha !== currentHead;
     const ageMs = snap.generatedAt ? Math.max(0, Date.now() - Date.parse(snap.generatedAt)) : null;
     // `structural-only` is a usable, current filesystem snapshot from a root
@@ -7145,42 +7237,44 @@ export function createRoutes(ctx: RouteContext): Router {
   };
 
   router.get('/cartographer/tree', (req, res) => {
-    if (!ctx.cartographer) { res.status(503).json({ error: 'Cartographer not enabled' }); return; }
-    const snap = ctx.cartographer.readSnapshot();
+    const root = cartographerRouteRoot(req, res);
+    if (!root) return;
+    const snap = root.tree.readSnapshot();
     if (req.query.format === 'compact') {
       // Cheap: nodeCount + generatedAt from the snapshot (no index parse).
-      res.json({
+      res.json(withCartographerAuthority({
         root: '',
         generatedAt: snap?.generatedAt ?? null,
         nodeCount: snap?.counts.nodeCount ?? 0,
         indexState: snap ? 'built' : 'not-built',
-        ...cartoSnapshotMeta(snap),
-      });
+        ...cartoSnapshotMeta(snap, root.tree),
+      }, root));
       return;
     }
     // Full index: byte-bounded so a huge tree never triggers the 67MB sync parse.
     const fsCfg = (ctx.config as { cartographer?: { freshnessSweep?: { maxRequestNodes?: number } } }).cartographer?.freshnessSweep;
     const maxRequestNodes = typeof fsCfg?.maxRequestNodes === 'number' ? fsCfg.maxRequestNodes : 50000;
     const byteCeiling = maxRequestNodes * 512; // generous per-entry estimate
-    const loaded = ctx.cartographer.loadIndexBounded(byteCeiling);
+    const loaded = root.tree.loadIndexBounded(byteCeiling);
     if (loaded.state === 'not-built') {
-      res.json({ root: '', generatedAt: null, nodeCount: 0, indexState: 'not-built', ...cartoSnapshotMeta(snap) });
+      res.json(withCartographerAuthority({ root: '', generatedAt: null, nodeCount: 0, indexState: 'not-built', ...cartoSnapshotMeta(snap, root.tree) }, root));
       return;
     }
     if (loaded.state === 'too-large') {
-      res.json({
+      res.json(withCartographerAuthority({
         indexState: 'too-large-for-request',
         nodeCount: snap?.counts.nodeCount ?? null,
         guidance: 'index too large to serve whole; use GET /cartographer/navigate?query=... for a bounded subtree',
-        ...cartoSnapshotMeta(snap),
-      });
+        ...cartoSnapshotMeta(snap, root.tree),
+      }, root));
       return;
     }
-    res.json(loaded.index);
+    res.json(withCartographerAuthority(loaded.index as unknown as Record<string, unknown>, root));
   });
 
   router.get('/cartographer/node', (req, res) => {
-    if (!ctx.cartographer) { res.status(503).json({ error: 'Cartographer not enabled' }); return; }
+    const root = cartographerRouteRoot(req, res);
+    if (!root) return;
     const p = typeof req.query.path === 'string' ? req.query.path : '';
     // Validate: repo-relative, no leading slash, no `..` segment. The validated
     // path indexes the in-memory node store — it never builds a filesystem path.
@@ -7188,17 +7282,18 @@ export function createRoutes(ctx: RouteContext): Router {
       res.status(400).json({ error: 'invalid path' }); return;
     }
     // getNode reads ONE node file (O(1)) — no index parse, no scaffold preamble.
-    const node = ctx.cartographer.getNode(p);
-    if (!node) { res.status(404).json({ error: 'no such node', indexState: ctx.cartographer.readSnapshot() ? 'built' : 'not-built' }); return; }
-    res.json(node);
+    const node = root.tree.getNode(p);
+    if (!node) { res.status(404).json(withCartographerAuthority({ error: 'no such node', indexState: root.tree.readSnapshot() ? 'built' : 'not-built' }, root)); return; }
+    res.json(withCartographerAuthority(node as unknown as Record<string, unknown>, root));
   });
 
-  router.get('/cartographer/stale', (_req, res) => {
-    if (!ctx.cartographer) { res.status(503).json({ error: 'Cartographer not enabled' }); return; }
-    const snap = ctx.cartographer.readSnapshot();
-    const meta = cartoSnapshotMeta(snap);
+  router.get('/cartographer/stale', (req, res) => {
+    const root = cartographerRouteRoot(req, res);
+    if (!root) return;
+    const snap = root.tree.readSnapshot();
+    const meta = cartoSnapshotMeta(snap, root.tree);
     if (!snap) {
-      res.json({ count: 0, nodes: [], total: 0, truncated: false, ...meta });
+      res.json(withCartographerAuthority({ count: 0, nodes: [], total: 0, truncated: false, ...meta }, root));
       return;
     }
     // Serve the bounded, secret-filtered sample with the honest total + truncation.
@@ -7207,21 +7302,22 @@ export function createRoutes(ctx: RouteContext): Router {
         : s === 'stale' ? 'code changed since the summary was authored'
           : s === 'path-gone' ? 'covered path no longer in HEAD' : '';
     const nodes = snap.staleSample.map((e) => ({ path: e.path, status: e.status, reason: reasonFor(e.status) }));
-    res.json({ count: nodes.length, nodes, total: snap.staleTotal, truncated: snap.staleSampleTruncated, ...meta });
+    res.json(withCartographerAuthority({ count: nodes.length, nodes, total: snap.staleTotal, truncated: snap.staleSampleTruncated, ...meta }, root));
   });
 
-  router.get('/cartographer/health', (_req, res) => {
-    if (!ctx.cartographer) { res.status(503).json({ error: 'Cartographer not enabled' }); return; }
+  router.get('/cartographer/health', (req, res) => {
+    const root = cartographerRouteRoot(req, res);
+    if (!root) return;
     const sweepCfg = (ctx.config as { cartographer?: { freshnessSweep?: { enabled?: boolean; cadenceMs?: number } } })
       .cartographer?.freshnessSweep;
-    const snap = ctx.cartographer.readSnapshot();
-    const meta = cartoSnapshotMeta(snap);
+    const snap = root.tree.readSnapshot();
+    const meta = cartoSnapshotMeta(snap, root.tree);
     // fix instar#1069: the entire freshness block is served from the SNAPSHOT — the
     // route never calls health()/freshnessHealth() (the request-thread starvers).
     // Legacy field names/semantics are preserved (additive contract); new fields
     // carry snapshot provenance so a stale/failing detect is visible on the route.
     if (!snap) {
-      res.json({
+      res.json(withCartographerAuthority({
         enabled: true,
         nodeCount: 0, authoredCount: 0, neverAuthoredCount: 0, staleCount: 0, generatedAt: null,
         freshness: {
@@ -7230,10 +7326,10 @@ export function createRoutes(ctx: RouteContext): Router {
         },
         sweepEnabled: sweepCfg?.enabled === true,
         ...meta,
-      });
+      }, root));
       return;
     }
-    res.json({
+    res.json(withCartographerAuthority({
       enabled: true,
       // Legacy health() fields, sourced from the snapshot:
       nodeCount: snap.counts.nodeCount,
@@ -7245,7 +7341,7 @@ export function createRoutes(ctx: RouteContext): Router {
       freshness: snap.freshness,
       sweepEnabled: sweepCfg?.enabled === true,
       ...meta,
-    });
+    }, root));
   });
 
   // Tier-1 (inline opportunistic) write route (spec #2 — doc-freshness). The ONE
@@ -7257,7 +7353,8 @@ export function createRoutes(ctx: RouteContext): Router {
   // instruction-shaped-content neutralization, and a modest write-rate bound.
   const cartoRefreshLog: number[] = [];
   router.post('/cartographer/node/refresh', (req, res) => {
-    if (!ctx.cartographer) { res.status(503).json({ error: 'Cartographer not enabled' }); return; }
+    const root = cartographerRouteRoot(req, res, true);
+    if (!root) return;
     const sweepCfg = (ctx.config as {
       cartographer?: { freshnessSweep?: { enabled?: boolean; minSummaryChars?: number; maxSummaryChars?: number; maxLeafBytes?: number } };
     }).cartographer?.freshnessSweep;
@@ -7284,17 +7381,17 @@ export function createRoutes(ctx: RouteContext): Router {
 
     // fix instar#1069: no lazy scaffold()/loadIndex() preamble — getNode is a single
     // node-file read. An un-scaffolded node 400s (boot population builds the index).
-    const node = ctx.cartographer.getNode(p);
+    const node = root.tree.getNode(p);
     if (!node) { res.status(400).json({ error: 'no such node — only an existing scaffolded node can be refreshed' }); return; }
 
     const { text: neutralized } = neutralizeInstructionShapedContent(summaryRaw);
     // Covered symbols: leaf → committed content; dir → child summaries + basenames.
     let coveredSymbols: Set<string>;
     if (node.kind === 'file') {
-      const read = ctx.cartographer.committedContent(p, sweepCfg.maxLeafBytes ?? 24576);
+      const read = root.tree.committedContent(p, sweepCfg.maxLeafBytes ?? 24576);
       coveredSymbols = extractCodeSymbols(read?.content ?? '');
     } else {
-      const children = ctx.cartographer.getChildren(p);
+      const children = root.tree.getChildren(p);
       const basename = (s: string) => { const i = s.lastIndexOf('/'); return i >= 0 ? s.slice(i + 1) : s; };
       coveredSymbols = extractCodeSymbols(
         children.map((c) => c.summary).join('\n') + '\n' + children.map((c) => basename(c.path)).join(' '),
@@ -7308,12 +7405,12 @@ export function createRoutes(ctx: RouteContext): Router {
     });
     if (!validation.ok) { res.status(400).json({ error: validation.reason }); return; }
 
-    ctx.cartographer.setSummary(p, neutralized.trim(), {
+    root.tree.setSummary(p, neutralized.trim(), {
       provenance: { source: 'inline-agent' },
       meta: { lastAuthoredBy: 'inline-agent', confidence: 'medium' },
     });
     cartoRefreshLog.push(nowMs);
-    res.json({ refreshed: true, path: p, status: ctx.cartographer.computeStaleness(p) });
+    res.json(withCartographerAuthority({ refreshed: true, path: p, status: root.tree.computeStaleness(p) }, root));
   });
 
   // Subtree Navigation (cartographer-subtree-nav spec #5). Given a query, the
@@ -7324,7 +7421,8 @@ export function createRoutes(ctx: RouteContext): Router {
   // from the request — paths are PRODUCED, never taken — so there is no traversal
   // surface; only `query` (length-bounded) + the numeric bounds are validated.
   router.get('/cartographer/navigate', (req, res) => {
-    if (!ctx.cartographer) { res.status(503).json({ error: 'Cartographer not enabled' }); return; }
+    const root = cartographerRouteRoot(req, res);
+    if (!root) return;
 
     const query = typeof req.query.query === 'string' ? req.query.query : '';
     if (!query || query.trim().length === 0) { res.status(400).json({ error: 'missing query' }); return; }
@@ -7355,7 +7453,7 @@ export function createRoutes(ctx: RouteContext): Router {
     // fix instar#1069: no lazy scaffold()/loadIndex() preamble — the navigator is
     // bounded (maxNodesVisited) and returns an empty manifest when the root node is
     // absent (index not built yet); the boot-path scaffold builds it off-request.
-    const manifest = cartographerNavigate(ctx.cartographer, query, {
+    const manifest = cartographerNavigate(root.tree, query, {
       maxDepth: maxDepthOverride ?? navCfg.maxDepth,
       branchingFactor: navCfg.branchingFactor,
       maxNodesVisited: navCfg.maxNodesVisited,
@@ -7363,32 +7461,33 @@ export function createRoutes(ctx: RouteContext): Router {
       minScore: navCfg.minScore,
       collapseFraction: navCfg.collapseFraction,
     });
-    res.json(manifest);
+    res.json(withCartographerAuthority(manifest as unknown as Record<string, unknown>, root));
   });
 
   // Standards Enforcement-Coverage Audit (cartographer-conformance-audit spec #3).
   // For each constitutional standard in docs/STANDARDS-REGISTRY.md, verify whether
   // the structural guard its prose NAMES actually exists on disk, classify each
   // standard's enforcement strength, and surface the gaps + dangling refs.
-  // Deterministic, observe-only, NON-gating. Gated behind BOTH ctx.cartographer
+  // Deterministic, observe-only, NON-gating. Gated behind Cartographer
   // (cartographer.enabled) AND config.cartographer.conformanceAudit.enabled === true.
   // Owner-Bearer (the auth middleware) + the X-Instar-Request:1 intent header (the
   // honest control per the spec's security note — there is no PIN-scope primitive).
-  // Lazily computes over config.projectDir + the on-disk registry; caches by inputHash
+  // Lazily computes over the authority-selected root + the on-disk registry; caches by inputHash
   // so an unchanged registry+repo short-circuits (the pass is deterministic + cheap).
-  const conformanceGate = (req: ExpressRequest, res: ExpressResponse): boolean => {
-    if (!ctx.cartographer) { res.status(503).json({ error: 'Cartographer not enabled' }); return false; }
+  const conformanceGate = (req: ExpressRequest, res: ExpressResponse): CartographerRouteRoot | null => {
+    const root = cartographerRouteRoot(req, res);
+    if (!root) return null;
     const cfg = (ctx.config as { cartographer?: { conformanceAudit?: { enabled?: boolean } } })
       .cartographer?.conformanceAudit;
-    if (!resolveDevAgentGate(cfg?.enabled, ctx.config)) { res.status(503).json({ error: 'Conformance audit not enabled' }); return false; }
+    if (!resolveDevAgentGate(cfg?.enabled, ctx.config)) { res.status(503).json({ error: 'Conformance audit not enabled' }); return null; }
     if (req.headers['x-instar-request'] !== '1') {
       res.status(403).json({ error: 'GET /conformance/coverage requires the X-Instar-Request: 1 intent header' });
-      return false;
+      return null;
     }
-    return true;
+    return root;
   };
-  let conformanceCache: StandardsCoverageReport | null = null;
-  const conformanceReport = (): StandardsCoverageReport => {
+  const conformanceCache = new Map<string, StandardsCoverageReport>();
+  const conformanceReport = (root: CartographerRouteRoot): StandardsCoverageReport => {
     // The registry path comes from the resolver — NEVER built here. Until
     // 2026-07-26 this line was `path.join(ctx.config.projectDir, 'docs',
     // 'STANDARDS-REGISTRY.md')`, the agent-home SNAPSHOT, which is written once at
@@ -7418,20 +7517,21 @@ export function createRoutes(ctx: RouteContext): Router {
     const report = computeStandardsCoverage(
       {
         registryPath: resolution.path,
-        projectDir: ctx.config.projectDir,
+        projectDir: root.tree.projectDirPath(),
         registryMarkdown: resolution.markdown,
         integrity: resolution.integrity,
       },
-      conformanceCache,
+      conformanceCache.get(root.rootAuthority?.rootId ?? root.tree.projectDirPath()) ?? null,
     );
-    conformanceCache = report;
+    conformanceCache.set(root.rootAuthority?.rootId ?? root.tree.projectDirPath(), report);
     return report;
   };
 
   router.get('/conformance/coverage', (req, res) => {
-    if (!conformanceGate(req, res)) return;
+    const root = conformanceGate(req, res);
+    if (!root) return;
     let report: StandardsCoverageReport;
-    try { report = conformanceReport(); }
+    try { report = conformanceReport(root); }
     catch (err) { res.status(500).json({ error: 'coverage compute failed', detail: err instanceof Error ? err.message : String(err) }); return; }
 
     let standards = report.standards;
@@ -7443,7 +7543,7 @@ export function createRoutes(ctx: RouteContext): Router {
     if (status === 'gap') standards = standards.filter((s) => s.enforcementKind === 'documented-only');
     if (status === 'dangling') standards = standards.filter((s) => s.danglingRefs.length > 0);
 
-    res.json({
+    res.json(withCartographerAuthority({
       generatedAt: report.generatedAt,
       // Derived once, in `deriveCoverageClientFlags` — see that function for what each
       // flag means and why a single boolean could not carry it.
@@ -7451,13 +7551,14 @@ export function createRoutes(ctx: RouteContext): Router {
       summary: report.summary,
       count: standards.length,
       standards,
-    });
+    }, root));
   });
 
   router.get('/conformance/coverage/health', (req, res) => {
-    if (!conformanceGate(req, res)) return;
+    const root = conformanceGate(req, res);
+    if (!root) return;
     let report: StandardsCoverageReport;
-    try { report = conformanceReport(); }
+    try { report = conformanceReport(root); }
     catch (err) { res.status(500).json({ error: 'coverage compute failed', detail: err instanceof Error ? err.message : String(err) }); return; }
     // `converged` means ONLY "the deterministic pass is stable" — re-running on
     // unchanged inputs is byte-identical. It has never meant "the standards are
@@ -7466,7 +7567,7 @@ export function createRoutes(ctx: RouteContext): Router {
     // registry fragment, and the agent reading it drew the wrong conclusion twice
     // in one day, then quoted it to the operator. The meaning now travels with the
     // field, and the trustworthiness of the ratio travels beside it.
-    res.json({
+    res.json(withCartographerAuthority({
       enabled: true,
       generatedAt: report.generatedAt,
       converged: true,
@@ -7481,7 +7582,7 @@ export function createRoutes(ctx: RouteContext): Router {
       // expectation that does not exist yet — so a stale-but-coherent registry now reads
       // 'unverified' with the reason attached instead of asserting trust it never earned.
       ...report.summary,
-    });
+    }, root));
   });
 
   router.post('/project-map/refresh', (_req, res) => {

--- a/tests/e2e/cartographer-dev-gate-lifecycle.test.ts
+++ b/tests/e2e/cartographer-dev-gate-lifecycle.test.ts
@@ -134,7 +134,8 @@ describe('Cartographer dev-gate — feature is alive (Tier 3 E2E, production ini
 
   it('production server wiring invokes zero-cost population before the optional sweep starts', () => {
     const serverSource = fs.readFileSync(path.join(process.cwd(), 'src', 'commands', 'server.ts'), 'utf8');
-    expect(serverSource).toContain('populateCartographer({');
+    expect(serverSource).toContain('new CartographerRootRegistry({');
+    expect(serverSource).toContain('cartographerRoots.populateOnBoot()');
     expect(serverSource).toContain('cartographerPopulationReady ?? Promise.resolve()');
   });
 

--- a/tests/e2e/cartographer-freshness-lifecycle.test.ts
+++ b/tests/e2e/cartographer-freshness-lifecycle.test.ts
@@ -26,6 +26,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { CartographerTree } from '../../src/core/CartographerTree.js';
+import type { CartographerRootRegistry } from '../../src/core/CartographerRootRegistry.js';
 import {
   CartographerSweepEngine,
   type SweepEngineConfig,
@@ -129,6 +130,7 @@ function engineFor(t: CartographerTree, router: SweepRouterLike): CartographerSw
     llmQueue: queueStub(),
     pressure: normalPressure,
     holdsLease: () => true,
+    authorizePaidAuthoring: () => ({ ok: true }),
     config: sweepConfig(),
     stateDir,
   });
@@ -202,6 +204,23 @@ describe('Cartographer doc-freshness sweep — feature is alive (Tier 3 E2E)', (
 
   // ── PART B — the spec #2 routes are alive (200, not 503) through the server ──
   function app(carto: CartographerTree): express.Express {
+    const cartographerRoots = {
+      resolve: () => ({
+        ok: true,
+        root: {
+          tree: carto,
+          assessment: {},
+          report: {
+            rootId: 'test-root', repositoryId: 'test-repository',
+            kind: 'active-project-checkout', canonicalPath: repo, revision: 'test-revision',
+            provenance: { source: 'server-project', projectName: 't' },
+            verificationState: 'verified', verificationReason: 'verified',
+            structuralPopulationAllowed: true, paidAuthoringAllowed: true,
+          },
+        },
+      }),
+      authorizePaidAuthoring: () => ({ ok: true }),
+    } as unknown as CartographerRootRegistry;
     const a = express();
     a.use(express.json());
     a.use(authMiddleware(() => AUTH, 'test'));
@@ -215,7 +234,7 @@ describe('Cartographer doc-freshness sweep — feature is alive (Tier 3 E2E)', (
           freshnessSweep: { enabled: true, egressAcknowledged: true, minSummaryChars: 10, maxSummaryChars: 600, maxLeafBytes: 24576 },
         },
       } as unknown as RouteContext['config'],
-      cartographer: carto,
+      cartographerRoots,
       startTime: new Date(),
     } as unknown as RouteContext));
     return a;

--- a/tests/integration/cartographer-eventloop-worker.test.ts
+++ b/tests/integration/cartographer-eventloop-worker.test.ts
@@ -99,7 +99,7 @@ function engineFor(t: CartographerTree, over: Partial<SweepEngineConfig> = {}): 
   };
   return new CartographerSweepEngine({
     tree: t, router: routerStub, llmQueue: queueStub, pressure: normalPressure,
-    holdsLease: () => true, config, stateDir,
+    holdsLease: () => true, authorizePaidAuthoring: () => ({ ok: true }), config, stateDir,
   });
 }
 

--- a/tests/integration/cartographer-refresh-route.test.ts
+++ b/tests/integration/cartographer-refresh-route.test.ts
@@ -20,6 +20,7 @@ import { execFileSync } from 'node:child_process';
 import { createRoutes, type RouteContext } from '../../src/server/routes.js';
 import { authMiddleware } from '../../src/server/middleware.js';
 import { CartographerTree } from '../../src/core/CartographerTree.js';
+import type { CartographerRootRegistry } from '../../src/core/CartographerRootRegistry.js';
 
 const AUTH = 'test-bearer-token';
 
@@ -58,6 +59,25 @@ afterEach(() => {
 // the second gate (POST refresh) is open. minSummaryChars kept small so realistic
 // short summaries clear the floor.
 function ctxWith(cartographer: CartographerTree | null, sweepEnabled: boolean): RouteContext {
+  const cartographerRoots = cartographer
+    ? ({
+        resolve: () => ({
+          ok: true,
+          root: {
+            tree: cartographer,
+            assessment: {},
+            report: {
+              rootId: 'test-root', repositoryId: 'test-repository',
+              kind: 'active-project-checkout', canonicalPath: repo, revision: 'test-revision',
+              provenance: { source: 'server-project', projectName: 't' },
+              verificationState: 'verified', verificationReason: 'verified',
+              structuralPopulationAllowed: true, paidAuthoringAllowed: true,
+            },
+          },
+        }),
+        authorizePaidAuthoring: () => ({ ok: true }),
+      } as unknown as CartographerRootRegistry)
+    : null;
   return {
     config: {
       projectName: 't',
@@ -72,7 +92,7 @@ function ctxWith(cartographer: CartographerTree | null, sweepEnabled: boolean): 
         freshnessSweep: { enabled: sweepEnabled, minSummaryChars: 10, maxSummaryChars: 600, maxLeafBytes: 24576 },
       },
     } as any,
-    cartographer,
+    cartographerRoots,
     startTime: new Date(),
   } as unknown as RouteContext;
 }
@@ -104,6 +124,25 @@ describe('POST /cartographer/node/refresh (Tier 2 integration)', () => {
       request(appWith(null)).post('/cartographer/node/refresh'),
     ).send({ path: 'src/Sample.ts', summary: 'Implements uniqueSampleSymbol for the sample.' });
     expect(res.status).toBe(503);
+  });
+
+  it('refuses inline paid authoring when root authority is absent', async () => {
+    const legacyTree = scaffoldedTree();
+    const legacy = express();
+    legacy.use(express.json());
+    legacy.use(authMiddleware(() => AUTH, 'test'));
+    legacy.use('/', createRoutes({
+      ...ctxWith(null, true),
+      cartographer: legacyTree,
+      cartographerRoots: null,
+    }));
+    const res = await bearer(request(legacy).post('/cartographer/node/refresh'))
+      .send({ path: 'src/Sample.ts', summary: 'Implements uniqueSampleSymbol for the sample.' });
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      error: 'cartographer-authoring-refused',
+      reason: 'root-authority-absent',
+    });
   });
 
   it('503 when freshnessSweep is disabled (cartographer enabled, sweep off)', async () => {

--- a/tests/integration/cartographer-root-registry.test.ts
+++ b/tests/integration/cartographer-root-registry.test.ts
@@ -1,0 +1,286 @@
+// safe-git-allow: fixture repositories use git only to create/read controlled revisions.
+/**
+ * 11B-2 acceptance boundary: live Cartographer root selection, reporting, reads,
+ * population, and authoring all travel through one verified-root registry.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { authMiddleware } from '../../src/server/middleware.js';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { runDetect } from '../../src/core/cartographerDetect.js';
+import { CartographerRootRegistry } from '../../src/core/CartographerRootRegistry.js';
+import type { TopicProjectBinding } from '../../src/core/ScopeVerifier.js';
+
+const AUTH = 'root-registry-test-token';
+const tempRoots: string[] = [];
+
+function tempDir(label: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), label));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'root-test',
+      GIT_AUTHOR_EMAIL: 'root@test.invalid',
+      GIT_COMMITTER_NAME: 'root-test',
+      GIT_COMMITTER_EMAIL: 'root@test.invalid',
+    },
+  }).trim();
+}
+
+function makeRepo(label: string, target: string, sibling: string, distractors = 0): string {
+  const repo = tempDir(label);
+  git(repo, ['init', '-q', '-b', 'main']);
+  fs.mkdirSync(path.join(repo, 'src', 'controls'), { recursive: true });
+  fs.writeFileSync(path.join(repo, 'src', 'controls', `${target}.ts`), `export class ${target} {}\n`);
+  fs.writeFileSync(path.join(repo, 'src', 'controls', `${sibling}.ts`), `export class ${sibling} {}\n`);
+  const noise = path.join(repo, 'src', 'noise');
+  fs.mkdirSync(noise, { recursive: true });
+  for (let i = 0; i < distractors; i += 1) {
+    fs.writeFileSync(path.join(noise, `Distractor${String(i).padStart(3, '0')}.ts`), `export const distraction${i} = ${i};\n`);
+  }
+  git(repo, ['add', '-A']);
+  git(repo, ['commit', '-q', '-m', 'fixture']);
+  return repo;
+}
+
+function inlineDetect() {
+  return async (input: Parameters<typeof runDetect>[0]) => ({
+    ok: true,
+    result: await runDetect(input),
+    durationMs: 0,
+  });
+}
+
+function registry(options: {
+  agentHome: string;
+  stateDir: string;
+  bindings: Record<string, TopicProjectBinding>;
+}): CartographerRootRegistry {
+  return new CartographerRootRegistry({
+    agentType: 'standalone',
+    agentHome: options.agentHome,
+    agentName: 'root-test-agent',
+    stateDir: options.stateDir,
+    topicBindings: () => options.bindings,
+    population: { runDetectWorker: inlineDetect() },
+  });
+}
+
+function app(roots: CartographerRootRegistry, projectDir: string, stateDir: string): express.Express {
+  const instance = express();
+  instance.use(express.json());
+  instance.use(authMiddleware(() => AUTH, 'test'));
+  instance.use('/', createRoutes({
+    config: {
+      projectName: 'root-test-agent', projectDir, stateDir, port: 0,
+      authToken: AUTH, agentType: 'standalone', sessions: {}, scheduler: {},
+      cartographer: {
+        enabled: true,
+        freshnessSweep: {
+          enabled: true, minSummaryChars: 10, maxSummaryChars: 600, maxLeafBytes: 24576,
+        },
+        subtreeNav: { maxNodesVisited: 200 },
+      },
+    } as never,
+    cartographerRoots: roots,
+    startTime: new Date(),
+  } as unknown as RouteContext));
+  return instance;
+}
+
+const bearer = (test: request.Test): request.Test => test.set('Authorization', `Bearer ${AUTH}`);
+
+afterEach(() => {
+  for (const dir of tempRoots.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('CartographerRootRegistry live boundary', () => {
+  it('keeps two verified topics isolated at the existing 200-node navigation ceiling', async () => {
+    const agentHome = tempDir('carto-noisy-home-');
+    const stateDir = path.join(agentHome, '.instar');
+    fs.mkdirSync(path.join(agentHome, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(agentHome, 'src', 'TopicAUniqueControl.ts'), 'stale lookalike\n');
+    const projectA = makeRepo('carto-topic-a-', 'TopicAUniqueControl', 'CompletelySeparateAlphaSibling', 220);
+    const projectB = makeRepo('carto-topic-b-', 'TopicBUniqueControl', 'CompletelySeparateBetaSibling', 220);
+    const bindings: Record<string, TopicProjectBinding> = {
+      '101': { projectName: 'project-a', projectDir: projectA },
+      '202': { projectName: 'project-b', projectDir: projectB },
+    };
+    const roots = registry({ agentHome, stateDir, bindings });
+    await roots.populateOnBoot();
+    const server = app(roots, agentHome, stateDir);
+
+    const a = await bearer(request(server).get('/cartographer/navigate'))
+      .query({ topicId: 101, query: 'TopicAUniqueControl' });
+    expect(a.status).toBe(200);
+    expect(a.body.nodesVisited).toBeLessThanOrEqual(200);
+    expect(a.body.rootAuthority).toMatchObject({
+      verificationState: 'verified',
+      kind: 'active-project-checkout',
+      provenance: { source: 'topic-binding', topicId: 101, projectName: 'project-a' },
+      revision: git(projectA, ['rev-parse', 'HEAD']),
+    });
+    const aPayload = JSON.stringify(a.body);
+    const aScoredPaths = (a.body.scored as Array<{ path: string }>).map((node) => node.path);
+    expect(aScoredPaths).toContain('src/controls/TopicAUniqueControl.ts');
+    expect(aScoredPaths).not.toContain('src/controls/CompletelySeparateAlphaSibling.ts');
+    expect(aScoredPaths).not.toContain('src/TopicAUniqueControl.ts');
+    expect(aPayload).not.toContain('CompletelySeparateAlphaSibling.ts');
+    expect(aPayload).not.toContain('TopicBUniqueControl.ts');
+    expect(a.body.rootAuthority.canonicalPath).toBe(fs.realpathSync(projectA));
+
+    const b = await bearer(request(server).get('/cartographer/navigate'))
+      .query({ topicId: 202, query: 'TopicBUniqueControl' });
+    expect(b.status).toBe(200);
+    expect(b.body.rootAuthority).toMatchObject({
+      verificationState: 'verified',
+      provenance: { source: 'topic-binding', topicId: 202, projectName: 'project-b' },
+      revision: git(projectB, ['rev-parse', 'HEAD']),
+    });
+    const bPayload = JSON.stringify(b.body);
+    const bScoredPaths = (b.body.scored as Array<{ path: string }>).map((node) => node.path);
+    expect(bScoredPaths).toContain('src/controls/TopicBUniqueControl.ts');
+    expect(bScoredPaths).not.toContain('src/controls/CompletelySeparateBetaSibling.ts');
+    expect(bScoredPaths).not.toContain('src/TopicAUniqueControl.ts');
+    expect(bPayload).not.toContain('CompletelySeparateBetaSibling.ts');
+    expect(bPayload).not.toContain('TopicAUniqueControl.ts');
+    expect(b.body.rootAuthority.rootId).not.toBe(a.body.rootAuthority.rootId);
+  });
+
+  it('refuses an ambiguous standalone read instead of falling back to the noisy agent home', async () => {
+    const agentHome = tempDir('carto-ambiguous-home-');
+    const stateDir = path.join(agentHome, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    const roots = registry({ agentHome, stateDir, bindings: {} });
+
+    const response = await bearer(request(app(roots, agentHome, stateDir)).get('/cartographer/health'));
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      error: 'cartographer-root-refused',
+      reason: 'topic-binding-required',
+    });
+    const decisions = fs.readFileSync(
+      path.join(stateDir, 'cartographer', 'root-authority-decisions.jsonl'),
+      'utf8',
+    ).trim().split('\n').map((line) => JSON.parse(line));
+    expect(decisions.at(-1)).toMatchObject({
+      operation: 'select',
+      rule: 'topic-binding-required',
+      outcome: { trust: 'refused' },
+    });
+  });
+
+  it('keeps the durable authority decision trail under a fixed rotation bound', () => {
+    const agentHome = tempDir('carto-bounded-log-home-');
+    const stateDir = path.join(agentHome, '.instar');
+    const roots = new CartographerRootRegistry({
+      agentType: 'standalone', agentHome, agentName: 'root-test-agent', stateDir,
+      topicBindings: () => ({}),
+      decisionLogMaxBytes: 200,
+      decisionLogKeepArchives: 1,
+    });
+    for (let index = 0; index < 8; index += 1) roots.resolve();
+
+    const log = path.join(stateDir, 'cartographer', 'root-authority-decisions.jsonl');
+    expect(fs.existsSync(log)).toBe(true);
+    expect(fs.existsSync(`${log}.1`)).toBe(true);
+    expect(fs.existsSync(`${log}.2`)).toBe(false);
+    expect(fs.statSync(log).size + fs.statSync(`${log}.1`).size).toBeLessThan(2_000);
+  });
+
+  it('population re-runs EVERY BOOT under new authority: second.nodeCount === first.nodeCount + 1', async () => {
+    const agentHome = tempDir('carto-reboot-home-');
+    const stateDir = path.join(agentHome, '.instar');
+    const project = makeRepo('carto-reboot-project-', 'FirstBootNode', 'ExistingSibling');
+    const bindings = { '303': { projectName: 'reboot-project', projectDir: project } };
+
+    const firstRegistry = registry({ agentHome, stateDir, bindings });
+    const [first] = await firstRegistry.populateOnBoot();
+    const inactiveCache = path.join(
+      stateDir, 'cartographer', 'roots', 'root-ffffffffffffffffffffffff',
+    );
+    fs.mkdirSync(inactiveCache, { recursive: true });
+    fs.writeFileSync(path.join(inactiveCache, 'stale-cache-marker'), 'regenerable');
+    fs.writeFileSync(path.join(project, 'src', 'controls', 'SecondBootNode.ts'), 'export const secondBootNode = true;\n');
+    const secondRegistry = registry({ agentHome, stateDir, bindings });
+    const [second] = await secondRegistry.populateOnBoot();
+
+    expect(second.nodeCount).toBe(first.nodeCount + 1);
+    expect(secondRegistry.resolve(303).ok && secondRegistry.resolve(303).root.tree.getNode('src/controls/SecondBootNode.ts')).not.toBeNull();
+    expect(fs.existsSync(inactiveCache)).toBe(false);
+  });
+
+  it('does not turn an empty binding view into delete-all cache pruning', async () => {
+    const agentHome = tempDir('carto-empty-bindings-home-');
+    const stateDir = path.join(agentHome, '.instar');
+    const existingCache = path.join(
+      stateDir, 'cartographer', 'roots', 'root-eeeeeeeeeeeeeeeeeeeeeeee',
+    );
+    fs.mkdirSync(existingCache, { recursive: true });
+    fs.writeFileSync(path.join(existingCache, 'uncertain-cache-marker'), 'retain under uncertainty');
+
+    const roots = registry({ agentHome, stateDir, bindings: {} });
+    expect(await roots.populateOnBoot()).toEqual([]);
+    expect(fs.existsSync(existingCache)).toBe(true);
+  });
+
+  it('a bound root with no readable Git HEAD publishes structural-only with freshRatio null', async () => {
+    const agentHome = tempDir('carto-structural-home-');
+    const stateDir = path.join(agentHome, '.instar');
+    const project = tempDir('carto-structural-project-');
+    git(project, ['init', '-q', '-b', 'main']);
+    fs.mkdirSync(path.join(project, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(project, 'src', 'StructuralOnly.ts'), 'export const structuralOnly = true;\n');
+    const bindings = { '404': { projectName: 'structural-project', projectDir: project } };
+    const roots = registry({ agentHome, stateDir, bindings });
+    await roots.populateOnBoot();
+
+    const response = await bearer(request(app(roots, agentHome, stateDir)).get('/cartographer/health'))
+      .query({ topicId: 404 });
+    expect(response.status).toBe(200);
+    expect(response.body.rootAuthority).toMatchObject({
+      verificationState: 'structural-only',
+      verificationReason: 'head-unreadable',
+      revision: null,
+      provenance: { source: 'topic-binding', topicId: 404 },
+    });
+    expect(response.body.nodeCount).toBeGreaterThan(0);
+    expect(response.body.freshness.freshRatio).toBeNull();
+  });
+
+  it('refuses inline authoring after the authority-pinned revision drifts', async () => {
+    const agentHome = tempDir('carto-author-home-');
+    const stateDir = path.join(agentHome, '.instar');
+    const project = makeRepo('carto-author-project-', 'PinnedRevisionSymbol', 'OtherSymbol');
+    const bindings = { '505': { projectName: 'author-project', projectDir: project } };
+    const roots = registry({ agentHome, stateDir, bindings });
+    await roots.populateOnBoot();
+    fs.writeFileSync(path.join(project, 'src', 'RevisionMoved.ts'), 'export const revisionMoved = true;\n');
+    git(project, ['add', '-A']);
+    git(project, ['commit', '-q', '-m', 'move head']);
+
+    const response = await bearer(request(app(roots, agentHome, stateDir)).post('/cartographer/node/refresh'))
+      .send({
+        topicId: 505,
+        path: 'src/controls/PinnedRevisionSymbol.ts',
+        summary: 'Implements PinnedRevisionSymbol for the authority test.',
+      });
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      error: 'cartographer-authoring-refused',
+      reason: 'revision-mismatch',
+    });
+  });
+});

--- a/tests/unit/cartographer-sweep-engine.test.ts
+++ b/tests/unit/cartographer-sweep-engine.test.ts
@@ -118,6 +118,7 @@ describe('CartographerSweepEngine.probeRouting', () => {
     const engine = new CartographerSweepEngine({
       tree: t, router: routerStub({ framework: 'claude-code', evaluate: () => 'x' }),
       llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig(), stateDir,
     });
     const probe = engine.probeRouting();
@@ -129,6 +130,7 @@ describe('CartographerSweepEngine.probeRouting', () => {
     const engine = new CartographerSweepEngine({
       tree: t, router: routerStub({ framework: 'claude-code', evaluate: () => 'x' }),
       llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig({ allowClaudeFallback: true }), stateDir,
     });
     expect(engine.probeRouting().ok).toBe(true);
@@ -139,6 +141,7 @@ describe('CartographerSweepEngine.probeRouting', () => {
     const engine = new CartographerSweepEngine({
       tree: t, router: routerStub({ framework: 'codex-cli', available: false, evaluate: () => 'x' }),
       llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig(), stateDir,
     });
     expect(engine.probeRouting().ok).toBe(false);
@@ -155,6 +158,7 @@ describe('CartographerSweepEngine.runPass — authoring', () => {
     });
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig(), stateDir,
     });
     const r = await engine.runPass();
@@ -172,6 +176,7 @@ describe('CartographerSweepEngine.runPass — authoring', () => {
     const router = routerStub({ evaluate: () => 'Implements computeWidgetTotal here.' });
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => false,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig(), stateDir,
     });
     const r = await engine.runPass();
@@ -185,12 +190,59 @@ describe('CartographerSweepEngine.runPass — authoring', () => {
     const router = routerStub({ framework: 'claude-code', evaluate: () => 'x' });
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig(), stateDir,
     });
     const r = await engine.runPass();
     expect(r.refused).toBe(true);
     expect(r.authored).toBe(0);
     expect(router.calls.length).toBe(0);
+  });
+
+  it('refuses background paid authoring before routing when root authority is stale', async () => {
+    const t = tree(); t.scaffold();
+    const router = routerStub({ evaluate: () => 'Implements computeWidgetTotal here.' });
+    const engine = new CartographerSweepEngine({
+      tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: false, reason: 'revision-mismatch' }),
+      config: defaultConfig(), stateDir,
+    });
+    const r = await engine.runPass();
+    expect(r).toMatchObject({
+      ranAuthorPath: false,
+      refused: true,
+      refusalReason: 'revision-mismatch',
+      authored: 0,
+      reason: 'authority-refused',
+    });
+    expect(router.calls).toEqual([]);
+    expect(t.getNode('src/core/Widget.ts')?.summary).toBe('');
+  });
+
+  it('revalidates after detect and refuses when revision authority drifts during the worker await', async () => {
+    const t = tree(); t.scaffold();
+    const router = routerStub({ evaluate: () => 'Implements computeWidgetTotal here.' });
+    let authorityChecks = 0;
+    const engine = new CartographerSweepEngine({
+      tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => {
+        authorityChecks += 1;
+        return authorityChecks === 1
+          ? { ok: true }
+          : { ok: false, reason: 'revision-mismatch' };
+      },
+      config: defaultConfig(), stateDir,
+    });
+    const r = await engine.runPass();
+    expect(r).toMatchObject({
+      ranAuthorPath: false,
+      refused: true,
+      refusalReason: 'revision-mismatch',
+      authored: 0,
+      reason: 'authority-refused',
+    });
+    expect(authorityChecks).toBe(2);
+    expect(router.calls).toEqual([]);
   });
 });
 
@@ -200,6 +252,7 @@ describe('CartographerSweepEngine — deterministic quality bar', () => {
     const router = routerStub({ evaluate: () => 'This module does some general work and stuff.' });
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig(), stateDir,
     });
     const r = await engine.runPass();
@@ -220,6 +273,7 @@ describe('CartographerSweepEngine — ordering (children before parents)', () =>
     });
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig(), stateDir,
     });
     await engine.runPass();
@@ -243,6 +297,7 @@ describe('CartographerSweepEngine — dir re-author amplification guard', () => 
     });
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig(), stateDir,
     });
     await engine.runPass(); // everything authored
@@ -270,6 +325,7 @@ describe('CartographerSweepEngine — per-pass bounds', () => {
     const router = routerStub({ evaluate: (p) => p.includes('Widget.ts') ? 'Implements computeWidgetTotal here.' : 'Implements bootstrapApp here.' });
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig({ maxNodesPerPass: 1 }), stateDir,
     });
     const r = await engine.runPass();
@@ -282,6 +338,7 @@ describe('CartographerSweepEngine — per-pass bounds', () => {
     const router = routerStub({ evaluate: (p) => p.includes('Widget.ts') ? 'Implements computeWidgetTotal here.' : 'Implements bootstrapApp here.' });
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig({ estCentsPerAuthor: 10, maxCentsPerPass: 10 }), stateDir,
     });
     const r = await engine.runPass();
@@ -297,6 +354,7 @@ describe('CartographerSweepEngine — secrets egress', () => {
     const router = routerStub({ evaluate: () => 'Implements computeWidgetTotal here.' });
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig(), stateDir,
     });
     await engine.runPass();
@@ -311,6 +369,7 @@ describe('CartographerSweepEngine — quarantine', () => {
     const router = routerStub({ evaluate: () => 'no symbols here just prose words' });
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig({ nodeFailQuarantineThreshold: 2 }), stateDir,
     });
     await engine.runPass();
@@ -330,6 +389,7 @@ describe('CartographerSweepEngine — abort is backpressure, not failure', () =>
       tree: t, router,
       llmQueue: { enqueue: () => { throw new SweepAbortedError(); } },
       pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig(), stateDir,
     });
     const r = await engine.runPass();
@@ -346,6 +406,7 @@ describe('CartographerSweepEngine — fresh != correct (re-validation sample)', 
     const router = routerStub({ evaluate: (p) => p.includes('Widget.ts') ? 'Implements computeWidgetTotal here.' : 'Implements bootstrapApp here.' });
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig(), stateDir,
     });
     await engine.runPass(); // author everything
@@ -353,6 +414,7 @@ describe('CartographerSweepEngine — fresh != correct (re-validation sample)', 
     // Second pass: no candidates (all fresh) but the sample should re-examine fresh nodes.
     const engine2 = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig({ revalidateSamplePerPass: 2 }), stateDir,
     });
     const r = await engine2.runPass();
@@ -371,6 +433,7 @@ describe('CartographerSweepEngine — idempotent cursor', () => {
     fs.writeFileSync(path.join(cursorDir, 'cartographer-sweep-cursor.json'), '{not json');
     const engine = new CartographerSweepEngine({
       tree: t, router, llmQueue: queueStub(), pressure: normalPressure, holdsLease: () => true,
+      authorizePaidAuthoring: () => ({ ok: true }),
       config: defaultConfig({ maxNodesPerPass: 2 }), stateDir,
     });
     const r = await engine.runPass();

--- a/tests/unit/cartographer-sweep-poller-breaker.test.ts
+++ b/tests/unit/cartographer-sweep-poller-breaker.test.ts
@@ -57,7 +57,7 @@ describe('CartographerSweepPoller — a detect refusal trips the breaker (fix in
       maxDeferredPasses: 5, revalidateSamplePerPass: 0, minNodesUnderPressure: 3,
       detectInWorker: false, maxIndexBytes: 1, // every detect refuses detect-index-too-large
     };
-    const engine = new CartographerSweepEngine({ tree: t, router, llmQueue: queue, pressure, holdsLease: () => true, config, stateDir });
+    const engine = new CartographerSweepEngine({ tree: t, router, llmQueue: queue, pressure, holdsLease: () => true, authorizePaidAuthoring: () => ({ ok: true }), config, stateDir });
 
     // Sanity: one pass refuses (not "no-candidates").
     const r = await engine.runPass();

--- a/tests/unit/cartographer-sweep-routing.test.ts
+++ b/tests/unit/cartographer-sweep-routing.test.ts
@@ -83,7 +83,7 @@ describe('off-Claude routing — real IntelligenceRouter', () => {
       buildProvider: () => null,
     });
     const engine = new CartographerSweepEngine({
-      tree: t, router, llmQueue: queue, pressure: () => ({ tier: 'normal' }), holdsLease: () => true, config: cfg(), stateDir,
+      tree: t, router, llmQueue: queue, pressure: () => ({ tier: 'normal' }), holdsLease: () => true, authorizePaidAuthoring: () => ({ ok: true }), config: cfg(), stateDir,
     });
     const r = await engine.runPass();
     expect(r.refused).toBe(true);
@@ -101,7 +101,7 @@ describe('off-Claude routing — real IntelligenceRouter', () => {
       buildProvider: () => null, // codex binary missing
     });
     const engine = new CartographerSweepEngine({
-      tree: t, router, llmQueue: queue, pressure: () => ({ tier: 'normal' }), holdsLease: () => true, config: cfg(), stateDir,
+      tree: t, router, llmQueue: queue, pressure: () => ({ tier: 'normal' }), holdsLease: () => true, authorizePaidAuthoring: () => ({ ok: true }), config: cfg(), stateDir,
     });
     const r = await engine.runPass();
     expect(r.refused).toBe(true);
@@ -120,7 +120,7 @@ describe('off-Claude routing — real IntelligenceRouter', () => {
       buildProvider: (fw) => (fw === 'codex-cli' ? codex : null),
     });
     const engine = new CartographerSweepEngine({
-      tree: t, router, llmQueue: queue, pressure: () => ({ tier: 'normal' }), holdsLease: () => true, config: cfg(), stateDir,
+      tree: t, router, llmQueue: queue, pressure: () => ({ tier: 'normal' }), holdsLease: () => true, authorizePaidAuthoring: () => ({ ok: true }), config: cfg(), stateDir,
     });
     const r = await engine.runPass();
     expect(r.authored).toBeGreaterThan(0);

--- a/upgrades/next/cartographer-project-aware-navigation.md
+++ b/upgrades/next/cartographer-project-aware-navigation.md
@@ -1,0 +1,61 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+Cartographer's verified-root authority now controls the live reader and writer.
+On standalone agents, Cartographer resolves the active project from the request's
+topic binding instead of falling back to the agent home. Project-bound agents use
+their declared server project when no topic override is present. Each verified
+root receives isolated Cartographer state.
+
+Tree, node, stale, health, navigation, and conformance responses now use one
+selected root for the whole operation. Authority-backed responses include the
+root identity, canonical checkout, exact revision, provenance, verification
+state, and authoring eligibility. Standalone requests without a usable topic
+binding are refused explicitly.
+
+Zero-cost structural population runs for every eligible bound root on every
+server boot. An unborn or unreadable Git HEAD degrades to a structural-only map
+with unknown freshness rather than losing navigation entirely. Inline and
+background paid authoring require a verified, revision-matching root; the
+background path revalidates after detection, before each operation, and after a
+model response before it writes.
+
+## What to Tell Your User
+
+- “Cartographer navigation now follows the project bound to the current topic,
+  so two project topics cannot accidentally share one map.”
+- “Navigation and health show which checkout and revision they came from.”
+- “A project with no readable Git revision still gets a structural map, but no
+  paid descriptions are written until its revision can be verified.”
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Topic-aware Cartographer reads | Include `topicId` on Cartographer requests from a standalone agent |
+| Cross-project state isolation | Automatic for every authority-selected root |
+| Root/revision reporting | Read the additive `rootAuthority` response field |
+| Explicit ambiguous-root refusal | Automatic when a standalone request lacks a valid topic binding |
+| Revision-safe inline/background authoring | Automatic; drift refuses before a trusted write |
+| Structural-only unborn-HEAD maps | Automatic; `verificationState` is `structural-only` and `freshRatio` is `null` |
+| Durable decision evidence | Recorded locally with fixed-size rotation under Cartographer state |
+
+## Compatibility Notes
+
+Standalone API callers that previously omitted a topic and implicitly read the
+agent-home map now receive an explicit refusal and must provide a bound topic.
+The navigation visit ceiling remains 200. The paid freshness sweep remains behind
+its existing opt-in setting; this change does not enable it.
+
+## Evidence
+
+The acceptance fixture contains a noisy standalone home, two verified project
+bindings, more than 200 nodes per project, unique controls, and unrelated
+siblings. Mirrored topic queries prove the registry is not sticky and exclude the
+other project, sibling, and stale-home tree. Lifecycle controls prove population
+runs again on the next boot and that an unborn HEAD publishes a non-empty
+structural-only snapshot with null freshness. Separate route and sweep controls
+prove missing, structural-only, and revision-drifted authority cannot author.

--- a/upgrades/side-effects/cartographer-project-aware-navigation.md
+++ b/upgrades/side-effects/cartographer-project-aware-navigation.md
@@ -1,0 +1,189 @@
+# Side-Effects Review — Cartographer Project-Aware Navigation
+
+**Version / slug:** `cartographer-project-aware-navigation`
+**Date:** `2026-08-02`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** not required by the `instar-dev` trigger list; independent PR review pending
+
+## Summary
+
+This change is the live Item 11B-2 consumer boundary. It replaces production's
+single `config.projectDir` Cartographer tree with a registry that selects roots
+from existing topic/project provenance, assesses them through
+`CartographerRootAuthority`, isolates their state, populates every eligible root
+at boot, reports the selected identity, and revalidates before paid writes. One
+resolved object supplies reporting, reads, navigation, and authoring for each
+operation, preventing a report/read split.
+
+## Decision-point inventory
+
+- `CartographerRootRegistry.resolve` — **add** — selects, assesses, caches for one
+  boot, mints the isolated tree, and records the decision durably.
+- `CartographerRootRegistry.authorizePaidAuthoring` — **add** — revalidates the
+  root identity and boot-pinned revision before a trusted write.
+- `CartographerRootRegistry.populateOnBoot` — **add** — enumerates explicit
+  bindings (plus the declared project for project-bound agents), deduplicates
+  identities, and structurally populates each eligible root.
+- Cartographer route resolver — **replace** — resolves once per request; all
+  Cartographer and conformance reads use the resulting tree and response report.
+- Inline refresh — **tighten** — requires live root authority; the legacy
+  singleton is read-only and cannot authorize a write.
+- Background sweep — **tighten** — requires an unambiguous root and revalidates
+  before/after every awaited authoring boundary.
+- Navigator result filter — **tighten** — visited zero-score siblings remain in
+  traversal accounting but are no longer returned as navigation results.
+
+## 1. Over-block
+
+- Standalone callers that omit `topicId` now receive `409` with
+  `topic-binding-required`; they no longer read or author against agent home.
+  This is the intended removal of the observed wrong-root fallback.
+- A topic binding to a missing, nested, remote-mismatched, or revision-mismatched
+  checkout is refused. A legitimate checkout with stale binding metadata must be
+  corrected at the binding rather than guessed around.
+- An unborn/unreadable HEAD cannot use inline or background summary authoring,
+  even if its structural files are useful. The structural map remains available.
+- Background sweep on a standalone agent has no request topic and therefore does
+  not start. This change does not invent a global “current topic” or pick one of
+  several bindings.
+
+## 2. Under-block and known limits
+
+- A topic binding without `gitRemote` can verify from the checkout's observed
+  remote or common Git directory. The binding is still the selection authority;
+  host compromise and forged local Git configuration are out of scope.
+- Root identity is not semantic correctness. The known-present query control
+  proves the selected tree contains the intended target at the unchanged
+  200-node ceiling; summary quality remains separately governed.
+- A binding added after boot resolves to the correct isolated root immediately,
+  but its first structural population is guaranteed at the next boot. Until then
+  read routes honestly return `indexState: not-built` rather than falling back.
+- Per-root index directories are regenerable caches, not history. At boot the
+  registry removes only authority-shaped namespaces that no live binding selects,
+  and only after at least one current root positively verifies. An empty/corrupt
+  binding view never becomes delete-all. Unrelated files and active root caches are
+  untouched. A failed prune is reported and does not block current-root population.
+
+## 3. Level-of-abstraction fit
+
+The registry is the single live consumer of the typed authority. Routes do not
+reimplement Git verification, and `CartographerTree` still knows only a canonical
+project directory and opaque authority namespace. Existing `ScopeVerifier`
+topic bindings remain the provenance registry; no bare directory config knob or
+second binding store was added.
+
+## 4. Signal vs authority
+
+This is deterministic authority over enumerable filesystem/Git invariants, not
+a brittle judgment over conversational meaning. Explicit selection, canonical
+path, repository identity, revision, and equality are mechanically testable.
+Missing proof degrades to structural-only; contradictory proof refuses. Every
+assessment and revalidation is recorded before its outcome may be used.
+
+The live decision log is local, mode-restricted, and bounded: a 5 MiB active file
+plus two rotated archives. Rotation failure propagates through the required
+recorder and fails the authority outcome closed.
+
+## 4b. Judgment-point check
+
+No competing-signals judgment is delegated to static logic here. Root selection,
+canonical repository identity, exact revision, and equality are enumerable hard
+invariants. Missing proof produces the explicitly weaker structural-only posture;
+contradictory proof refuses. The mechanism does not interpret conversational
+intent, rank plausible projects, or override an explicit binding with a guess.
+
+## 5. Interactions and races
+
+- **Shadowing:** production passes only `cartographerRoots`; the old singleton is
+  retained solely as a read-only isolated-test compatibility seam.
+- **Double-fire:** boot population deduplicates by authority root identity, so two
+  topics bound to one checkout rebuild one tree, not two.
+- **Accumulation:** the decision trail has a fixed active/archive byte bound, and
+  inactive namespaced root caches are pruned at boot. Active cache cardinality is
+  the current binding set rather than an append-only history of past topics.
+- **Read/report split:** each route resolves once and passes the same tree/report
+  pair through snapshot, node, health, navigation, conformance, and response code.
+- **Revision races:** assessments pin one revision for the boot lifetime. Inline
+  writes revalidate synchronously before work. The sweep revalidates at admission,
+  after worker detection, before each node, and after every model await before
+  persistence. A mid-pass refusal retains prior valid work and stops further work.
+- **Main-thread work:** request paths perform cached selection and O(1) tree reads;
+  topic bindings are read from `ScopeVerifier`'s live in-memory map. Structural
+  scans remain chunked boot work and detect remains worker-backed.
+- **Cost:** population has no router, queue, model, or egress dependency. Paid
+  sweep configuration is not enabled or mutated by this change.
+
+## 6. External and operator surfaces
+
+Authenticated Cartographer responses gain additive `rootAuthority` metadata.
+Standalone callers must provide a valid topic id. Existing topic-binding APIs are
+the operator control; no new setting or UI is required. Decision rows contain
+local canonical paths and Git identity, so they stay machine-local and are not
+published or replicated.
+
+## 6b. Operator-surface quality
+
+No dashboard, approval, grant, destructive-action, or new configuration surface
+is introduced. The only operator-visible change is honest additive provenance on
+existing authenticated responses and an explicit refusal for ambiguous standalone
+requests. Errors use stable reason codes and do not expose raw stacks or ask the
+operator to repair filesystem state manually.
+
+## 7. Multi-machine posture
+
+Machine-local by design. Canonical paths, worktrees, revisions, indexes, and
+decision logs describe one machine's checkout. A topic moved to another machine
+is re-selected and populated from that machine's binding and filesystem. The
+response's root identity/revision provides honest per-machine provenance rather
+than asserting a fleet-global path. This change emits no user notices, creates no
+URLs, and replicates no canonical-path evidence. Its durable cache and decision
+evidence are machine-local and regenerable; moving a topic does not strand user
+state because bindings and repository contents remain the source, while the new
+machine rebuilds its own namespace on boot.
+
+## 8. Rollback and data
+
+Rollback restores the legacy singleton wiring. Existing legacy Cartographer state
+is untouched, so it becomes readable again immediately. New active namespaced root
+directories and the bounded authority log are regenerable machine-local cache and
+evidence; rollback need not delete them. Inactive authority-shaped caches are
+removed only during a later authority-enabled boot. No user content, repository file, topic
+binding, paid-sweep flag, or Git state is migrated.
+
+## Conclusion
+
+The intended compatibility break is narrow and explicit: ambiguous standalone
+requests stop falling back to agent home. The highest-risk boundary—paid writing
+against a different or moved checkout—is fail-closed at both inline and background
+seams. Structural-only degradation, cross-topic isolation, unchanged navigation
+ceiling, decision-log bounds, and every-boot refresh all have executable controls.
+
+## Class-Closure Declaration
+
+`defectClass: unbounded-self-action`, `closure: guard`, `guardEvidence: {
+enforcementType: ratchet, citation: tests/unit/cartographer-sweep-engine.test.ts,
+howCaught: the existing Cartographer poller-to-sweep control-loop edge keeps its
+per-pass node and spend bounds, lease check, idle cadence, and zero-progress
+breaker; this change adds root-authority refusal before every paid boundary, so
+sustained stale authority performs zero writes and settles by opening the existing
+breaker rather than minting new allowance }`.
+
+The engine tests pin both per-pass ceilings and refusal before admission, after
+detection, before node work, and after an awaited model result before persistence.
+`tests/unit/cartographer-sweep-poller-breaker.test.ts` drives repeated refused
+passes and proves the breaker opens. The standing controller convergence ratchet
+remains `tests/unit/self-action-convergence.test.ts`; this increment adds no new
+cadence, retry edge, notification, or recursive trigger.
+
+## Evidence pointers
+
+- Complete Cartographer authority/routes/navigation/sweep/lifecycle matrix:
+  190/190 passing across all 20 Cartographer test files after final hardening.
+- Repository-wide aggregate: 47,469 passing assertions. All 16 non-external
+  failures from the ambient run passed on a controlled 83/83 rerun; the two
+  remaining live-Gemini assertions require a metered credential this host
+  deliberately does not have and were not armed for this change.
+- Full repository lint and TypeScript typecheck: passing.
+- Production build: passing (the known no-local-signing-key transition remains
+  an explicit warning, not a build failure).
+- `git diff --check`: passing.


### PR DESCRIPTION
## What

Implements Item 11B-2 on top of merged PR #1835:

- replaces the production Cartographer singleton with a topic/project-aware root registry
- selects only from explicit topic/project provenance and isolates state per verified root
- populates every eligible bound root on every boot
- reports the exact selected root identity, revision, trust posture, and decision provenance
- requires a topic for standalone reads instead of falling back to noisy agent home
- revalidates root authority before inline and background paid authoring, including after awaited model boundaries
- keeps structural-only population available when Git revision proof is unavailable
- removes zero-score siblings from navigation results while preserving the 200-node visitation ceiling
- bounds and rotates the machine-local authority decision log and conservatively prunes inactive root caches

## ELI16 — what this changes

Cartographer is Instar's map of a code project: it knows which files exist, what they do, and whether their descriptions are stale. Before this change, the live server still had one global map chosen from its startup directory. That could make two project topics share the same map, or let a request quietly inspect the agent's noisy home directory instead of the project the user meant.

Now each request follows the project explicitly bound to its topic. Cartographer verifies which repository and revision it selected, keeps that project's map separate from other projects, and reports the selection in its response. If a new checkout does not have a readable Git revision yet, users still get the free structural map, but the system will not spend money writing trusted descriptions. If the checkout moves after selection, paid writing stops instead of writing against the wrong code. Nothing enables the paid sweep automatically.

## Why

Production still consumed one `config.projectDir` tree after 11B-1 made verified root authority available. That left reporting, navigation, and paid summary authoring able to operate on agent home or another stale checkout. This increment makes the typed authority the single live consumer boundary, so each request resolves one tree/report pair and paid writes fail closed when identity or revision drifts.

## UX Impact

Who sees it: users and integrations reading Cartographer endpoints on standalone agents with topic-bound projects.

First contact and user-visible behavior: responses now identify the selected project root and revision. A request with no usable topic binding receives the exact reason code `cartographer-root-refused` instead of silently reading the agent-home map. Existing correctly bound requests keep the same endpoint shapes plus additive root provenance; no dashboard form or destructive action is added.

## Compatibility and operator impact

- authenticated Cartographer responses gain additive `rootAuthority` metadata
- ambiguous standalone requests now return an explicit topic-binding refusal
- existing topic bindings remain the only operator provenance surface; no new setting or UI is introduced
- new indexes and decision evidence are bounded, machine-local, and regenerable
- paid sweep remains opt-in and is not enabled by this PR
- rollback restores the legacy singleton; no user content, bindings, Git state, or paid-sweep configuration is migrated

## Verification

- 190/190 across all 20 Cartographer authority, route, navigation, sweep, integration, and lifecycle test files
- repository-wide aggregate: 47,469 passing assertions
- all 16 non-external failures from the ambient aggregate passed on a controlled 83/83 rerun
- the remaining two failures are live Gemini smokes on a host with the binary installed but no metered credential; this change deliberately did not arm that doorway
- full lint and TypeScript typecheck pass
- production build passes (known local signing-key warning only)
- upgrade-guide check and whitespace check pass
- commit gate accepted the Tier-2 trace and self-action convergence declaration
- pre-push affected-test listing timed out and deferred to CI, which is the authoritative remote gate

## Review state

Independent adversarial review completed by Echo at exact head `68c063f044ae1f0f8687c0f90bdfbc6063b5da44`; verdict: **APPROVE** against acceptance bars written before this implementation existed.

- B1, B2, B4, and B8 met
- B3 intentionally not met and remains explicitly scoped out: root identity is not semantic-summary correctness
- the reviewer sampled roughly 30–40% of the 2,418-line diff and explicitly did not claim exhaustive coverage outside the root registry, route authority wrapper, paid-permission trace, B2/B4 assertions, CI rollup, and scoping documentation

This records an authenticated agent-channel review handoff; it does not impersonate a GitHub-native review submission. The local instar-dev trigger list did not require a dedicated second-pass subagent for this surface.