### PR TITLE
Retain bounded evidence for unknown mutual SSH failures

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-03T03-37-16-288Z-mutual-ssh-failure-evidence.json
+++ b/.instar/instar-dev-decisions/2026-08-03T03-37-16-288Z-mutual-ssh-failure-evidence.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-03T03:37:16.288Z",
+  "slug": "mutual-ssh-failure-evidence",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 160,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/MutualSshHealthController.ts",
+      "src/core/MutualSshRuntime.ts"
+    ],
+    "addedLines": 140,
+    "deletedLines": 20
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/mutual-ssh-failure-evidence.eli16.md
+++ b/docs/eli16/mutual-ssh-failure-evidence.eli16.md
@@ -1,0 +1,40 @@
+# ELI16 — Keep the clue when mutual SSH setup fails
+
+Instar can connect two machines belonging to the same agent over a dedicated SSH
+channel. During setup, several things can fail: the local listener might not
+start, the machines might not exchange their connection descriptions, a standing
+key might not install, or a later reachability probe might fail.
+
+The existing code turns each error into a short category such as timeout, port
+collision, or admission refused. Categories are useful because they are stable,
+but they are not the whole diagnosis. If an error did not contain one of the
+classifier's known phrases, the code saved only the category “unknown.” The
+original error had already been caught, but its message was discarded. The live
+status could therefore prove setup was genuinely blocked while giving the
+operator no clue about the cause.
+
+This fix keeps both pieces. The old category remains exactly as it was, and a
+second field keeps a short, cleaned copy of the original error message. The
+cleaning happens before the detail reaches a status, audit, or notification
+surface. It removes known credential shapes, private and public SSH key
+material, home-directory identity, IP addresses, and hostnames identified in
+SSH/DNS endpoint contexts. That context requirement matters: ordinary dotted
+JavaScript names such as `fs.readFileSync` and filenames such as `package.json`
+remain useful diagnostic evidence instead of being mistaken for machines.
+It also removes control characters and stops at 512 characters. The failure
+class is still computed from the original message, so privacy cleaning cannot
+silently change which category the system chooses.
+
+The test creates a listener failure that deliberately matches no existing
+category. Before the fix, the received state contains a false listener, a
+blocked enrollment state, and the single word unknown—with no failure object.
+After the fix, the same reproduction contains unknown plus a diagnostic detail.
+The test embeds a fake machine hostname and fake private key in the thrown error,
+then proves neither survives into that detail and proves the size bound holds.
+
+This does not make SSH enrollment more permissive or more restrictive. It does
+not add a category to fit today's incident. It does not change retries, circuit
+breakers, readiness, key installation, peer execution, or routing. On a healthy
+single-machine agent, the status remains unchanged and does not gain an empty
+diagnostic field. The only new behavior is that when a real caught failure is
+already being surfaced, its safe evidence is no longer thrown away.

--- a/src/core/MutualSshHealthController.ts
+++ b/src/core/MutualSshHealthController.ts
@@ -1,4 +1,6 @@
+import { isIP } from 'node:net';
 import type { DirectionalSshProof, MutualSshVerifier, SshProbeTarget } from './MutualSshVerifier.js';
+import { scrubForStore } from './durableSecretScrub.js';
 
 export type MutualSshFailureClass = 'connect-refused' | 'timeout' | 'host-key-changed' | 'admission-refused' | 'identity-mismatch' | 'firewall-denied' | 'vpn-route-unavailable' | 'system-sleep' | 'port-collision' | 'unknown';
 
@@ -9,19 +11,26 @@ export interface MutualSshPairHealth {
   state: 'verified' | 'repairing' | 'blocked';
   proof?: DirectionalSshProof;
   lastFailureClass?: MutualSshFailureClass;
+  lastFailureDetail?: string;
   attempts: number;
   breakerOpenUntil?: string;
+}
+
+export interface CapturedMutualSshFailure {
+  failureClass: MutualSshFailureClass;
+  /** Bounded, credential- and endpoint-scrubbed evidence from the thrown value. */
+  detail: string;
 }
 
 export interface MutualSshRepairHooks {
   refreshAdvert(target: SshProbeTarget): Promise<void>;
   reconcileAdmission(target: SshProbeTarget): Promise<void>;
   rotateSourceKey(target: SshProbeTarget): Promise<void>;
-  notifySecurity(target: SshProbeTarget, failure: MutualSshFailureClass): Promise<void>;
-  notifyExhausted(target: SshProbeTarget, failure: MutualSshFailureClass): Promise<void>;
+  notifySecurity(target: SshProbeTarget, failure: MutualSshFailureClass, detail: string): Promise<void>;
+  notifyExhausted(target: SshProbeTarget, failure: MutualSshFailureClass, detail: string): Promise<void>;
 }
 
-interface PairState { proof?: DirectionalSshProof; failures: number[]; attempts: number; failure?: MutualSshFailureClass; breakerUntil?: number }
+interface PairState { proof?: DirectionalSshProof; failures: number[]; attempts: number; failure?: CapturedMutualSshFailure; breakerUntil?: number }
 
 /** Bounded detector/remediator. It emits proof signals and never chooses routing. */
 /* @self-action-controller: mutual-ssh-repair-sweep */
@@ -59,14 +68,18 @@ export class MutualSshHealthController {
           // @silent-fallback-ok — a failed bounded probe is the controller's
           // expected input: it is classified, retained in health state, and
           // ultimately surfaced through notifyExhausted/notifySecurity.
-          current.failure = classifyMutualSshFailure(error);
-          if (current.failure === 'host-key-changed') { await this.hooks.notifySecurity(target, current.failure); break; }
+          current.failure = captureMutualSshFailure(error);
+          if (current.failure.failureClass === 'host-key-changed') {
+            await this.hooks.notifySecurity(target, current.failure.failureClass, current.failure.detail);
+            break;
+          }
           if (attempt < 4) await delay(Math.min(8_000, 250 * (2 ** (attempt - 1))));
         }
       }
       current.failures.push(now);
       if (current.failures.length >= 3) current.breakerUntil = now + 15 * 60_000;
-      await this.hooks.notifyExhausted(target, current.failure ?? 'unknown');
+      const failure = current.failure ?? captureMutualSshFailure(new Error('mutual-ssh-probe-failed-without-error'));
+      await this.hooks.notifyExhausted(target, failure.failureClass, failure.detail);
       this.state.set(key, current);
       return null;
     } finally { this.running -= 1; }
@@ -80,7 +93,9 @@ export class MutualSshHealthController {
       return {
         sourceMachineId: target.sourceMachineId, targetMachineId: target.targetMachineId, mutual,
         state: mutual ? 'verified' : state.attempts > 0 ? 'repairing' : 'blocked', proof: state.proof,
-        lastFailureClass: state.failure, attempts: state.attempts,
+        lastFailureClass: state.failure?.failureClass,
+        lastFailureDetail: state.failure?.detail,
+        attempts: state.attempts,
         breakerOpenUntil: state.breakerUntil ? new Date(state.breakerUntil).toISOString() : undefined,
       };
     });
@@ -104,6 +119,55 @@ export function classifyMutualSshFailure(error: unknown): MutualSshFailureClass 
   if (message.includes('identity')) return 'identity-mismatch';
   if (hasAny(message, ['econnrefused', 'connect'])) return 'connect-refused';
   return 'unknown';
+}
+
+const MUTUAL_SSH_FAILURE_DETAIL_MAX_CHARS = 512;
+const MUTUAL_SSH_FAILURE_DETAIL_SCRUB_LIMIT = 16_384;
+const SSH_PUBLIC_KEY_RE = /\b(?:ssh-(?:ed25519|rsa|dss)|ecdsa-sha2-nistp(?:256|384|521))\s+[A-Za-z0-9+/=]{16,}(?:\s+\S+)?/gi;
+const HOME_PATH_RE = /\/(?:Users|home)\/[^/\s]+/g;
+const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
+const IPV6_CANDIDATE_RE = /(?<![A-Za-z0-9])(\[?[0-9A-Fa-f:.]*:[0-9A-Fa-f:.]*(?:%[A-Za-z0-9_.-]+)?\]?)(?![A-Za-z0-9])/g;
+const HOST_LABEL_PATTERN = '[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?';
+const HOST_TOKEN_PATTERN = `${HOST_LABEL_PATTERN}(?:\\.${HOST_LABEL_PATTERN})*`;
+const DNS_FAILURE_HOST_RE = new RegExp(`(\\b(?:getaddrinfo\\s+)?(?:ENOTFOUND|EAI_AGAIN)\\s+)(${HOST_TOKEN_PATTERN})\\b`, 'gi');
+const LABELED_HOST_RE = new RegExp(`(\\b(?:host(?:name)?|endpoint|destination|server)\\s*[=:]\\s*)(${HOST_TOKEN_PATTERN})\\b`, 'gi');
+const CONNECT_TO_HOST_RE = new RegExp(`(\\b(?:connect(?:ing|ed)?\\s+to(?:\\s+host)?|could not resolve hostname)\\s+)(${HOST_TOKEN_PATTERN})\\b`, 'gi');
+const PRIVATE_HOSTNAME_RE = new RegExp(`\\b${HOST_TOKEN_PATTERN}\\.(?:internal|local|lan|home\\.arpa|ts\\.net)\\b`, 'gi');
+const SSH_USER_HOST_RE = new RegExp(`(\\b[a-z_][a-z0-9_-]*@)(${HOST_TOKEN_PATTERN})\\b`, 'gi');
+
+/**
+ * Retain the thrown evidence without exposing endpoint identity or key material.
+ * Classification deliberately runs over the original value; scrubbing affects
+ * only the operator-facing detail and can never broaden the match table.
+ */
+export function captureMutualSshFailure(error: unknown): CapturedMutualSshFailure {
+  const raw = error instanceof Error ? error.message : String(error);
+  const source = raw.length > 0 ? raw : '<empty error message>';
+  let detail = scrubForStore(source, { maxBytes: MUTUAL_SSH_FAILURE_DETAIL_SCRUB_LIMIT }).text;
+  detail = detail
+    .replace(SSH_PUBLIC_KEY_RE, '[REDACTED:ssh-key]')
+    .replace(HOME_PATH_RE, '<HOME>')
+    .replace(IPV4_RE, '[REDACTED:address]')
+    .replace(IPV6_CANDIDATE_RE, (whole) => isIpv6Literal(whole) ? '[REDACTED:address]' : whole)
+    .replace(DNS_FAILURE_HOST_RE, '$1[REDACTED:hostname]')
+    .replace(LABELED_HOST_RE, '$1[REDACTED:hostname]')
+    .replace(CONNECT_TO_HOST_RE, '$1[REDACTED:hostname]')
+    .replace(PRIVATE_HOSTNAME_RE, '[REDACTED:hostname]')
+    .replace(SSH_USER_HOST_RE, '$1[REDACTED:hostname]')
+    .replace(/[\u0000-\u001f\u007f]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (detail.length === 0) detail = '<empty error detail after scrubbing>';
+  if (detail.length > MUTUAL_SSH_FAILURE_DETAIL_MAX_CHARS) {
+    detail = `${detail.slice(0, MUTUAL_SSH_FAILURE_DETAIL_MAX_CHARS - 1)}…`;
+  }
+  return { failureClass: classifyMutualSshFailure(error), detail };
+}
+function isIpv6Literal(value: string): boolean {
+  let candidate = value.startsWith('[') && value.endsWith(']') ? value.slice(1, -1) : value;
+  const zone = candidate.indexOf('%');
+  if (zone >= 0) candidate = candidate.slice(0, zone);
+  return isIP(candidate) === 6;
 }
 function hasAny(value: string, needles: readonly string[]): boolean { return needles.some(needle => value.includes(needle)); }
 function delay(ms: number): Promise<void> { return new Promise(resolve => setTimeout(resolve, ms)); }

--- a/src/core/MutualSshRuntime.ts
+++ b/src/core/MutualSshRuntime.ts
@@ -4,7 +4,12 @@ import { createHash, randomUUID } from 'node:crypto';
 import { MachineSshIdentity, type MachineSshIdentityRecord } from './MachineSshIdentity.js';
 import { MachineSshEndpoint } from './MachineSshEndpoint.js';
 import { MutualSshVerifier, canonicalDirectionalSshProof, type DirectionalSshProof, type SshProbeTarget } from './MutualSshVerifier.js';
-import { MutualSshHealthController, classifyMutualSshFailure, type MutualSshPairHealth } from './MutualSshHealthController.js';
+import {
+  MutualSshHealthController,
+  captureMutualSshFailure,
+  type MutualSshFailureClass,
+  type MutualSshPairHealth,
+} from './MutualSshHealthController.js';
 import { MutualSshProbeScheduler } from './MutualSshProbeScheduler.js';
 import { SshPeerAdmissionStore } from './SshPeerAdmissionStore.js';
 import { SshHostKeyLifecycle, canonicalHostKeyProposal } from './SshHostKeyLifecycle.js';
@@ -49,6 +54,43 @@ export type MutualSshWireCommand =
 
 interface StoredProofs { version: 1; proofs: DirectionalSshProof[] }
 
+interface CapturedBootstrapFailure {
+  reason: string;
+  failureClass: MutualSshFailureClass;
+  detail: string;
+}
+
+interface NamedBootstrapFailure {
+  reason: string;
+}
+
+type BootstrapFailure = CapturedBootstrapFailure | NamedBootstrapFailure;
+
+export type MutualSshBootstrapFailureStatus = BootstrapFailure & { machineId: string };
+
+function capturedBootstrapFailure(error: unknown, prefix?: string): CapturedBootstrapFailure {
+  const captured = captureMutualSshFailure(error);
+  return {
+    reason: prefix ? `${prefix}:${captured.failureClass}` : captured.failureClass,
+    failureClass: captured.failureClass,
+    detail: captured.detail,
+  };
+}
+
+export interface MutualSshRuntimeStatus {
+  enabled: true;
+  dryRun: boolean;
+  listener: boolean;
+  readinessRequired: boolean;
+  ready: boolean;
+  enrollmentState: 'paired' | 'ssh-bootstrap' | 'ssh-bootstrap-blocked' | 'ssh-proving' | 'ready';
+  blockedReasons: string[];
+  directions: MutualSshPairHealth[];
+  pairs: Array<{ machines: string[]; mutual: boolean; standingKeyInstalled: boolean; standingReachable: boolean }>;
+  /** Present only when caught bootstrap errors exist, preserving healthy/single-machine output. */
+  bootstrapFailures?: MutualSshBootstrapFailureStatus[];
+}
+
 /** Production coordinator for endpoint lifecycle, signed adverts, directional probes and rollback. */
 export class MutualSshRuntime {
   private readonly identityManager: MachineSshIdentity;
@@ -63,7 +105,7 @@ export class MutualSshRuntime {
   private readonly candidateAdverts = new Map<string, SshBootstrapAdvert>();
   private readonly hostKeys = new Map<string, SshHostKeyLifecycle>();
   private readonly proofs = new Map<string, DirectionalSshProof>();
-  private readonly bootstrapFailures = new Map<string, string>();
+  private readonly bootstrapFailures = new Map<string, BootstrapFailure>();
   private readonly knownPeers = new Set<string>();
   private timer: NodeJS.Timeout | null = null;
   private hostOverlapTimer: NodeJS.Timeout | null = null;
@@ -93,8 +135,8 @@ export class MutualSshRuntime {
         target.expectedSourceClientKeyFingerprint = MachineSshIdentity.fingerprint(this.identity.clientPublicKey);
         await this.exchangeAdvert(target.targetMachineId);
       },
-      notifySecurity: async target => this.d.notifySecurity?.({ type: 'host-key-change', target: target.targetMachineId }),
-      notifyExhausted: async (target, failure) => this.audit({ type: 'repair-exhausted', target: target.targetMachineId, failure }),
+      notifySecurity: async (target, _failure, detail) => this.d.notifySecurity?.({ type: 'host-key-change', target: target.targetMachineId, detail }),
+      notifyExhausted: async (target, failure, detail) => this.audit({ type: 'repair-exhausted', target: target.targetMachineId, failure, detail }),
     }, concurrency);
     this.proofFile = path.join(d.stateDir, 'machine-ssh', 'directional-proofs.json');
     this.peerAuthorizedKeys = d.peerExecution ? new PeerAuthorizedKeys(d.peerExecution.agentHome, d.peerExecution.dryRun) : null;
@@ -143,7 +185,7 @@ export class MutualSshRuntime {
         catch (error) {
           // @silent-fallback-ok — an advert exchange failure is retained as a
           // named readiness blocker and retried on the next bounded sweep.
-          this.bootstrapFailures.set(peer.machineId, classifyMutualSshFailure(error));
+          this.bootstrapFailures.set(peer.machineId, capturedBootstrapFailure(error));
         }
       }
       if (this.d.dryRun) { this.audit({ type: 'dry-run', wouldProbe: peers.length }); return; }
@@ -204,7 +246,7 @@ export class MutualSshRuntime {
     }
   }
 
-  status(): { enabled: true; dryRun: boolean; listener: boolean; readinessRequired: boolean; ready: boolean; enrollmentState: 'paired' | 'ssh-bootstrap' | 'ssh-bootstrap-blocked' | 'ssh-proving' | 'ready'; blockedReasons: string[]; directions: MutualSshPairHealth[]; pairs: Array<{ machines: string[]; mutual: boolean; standingKeyInstalled: boolean; standingReachable: boolean }> } {
+  status(): MutualSshRuntimeStatus {
     const targets = this.d.listPeers().flatMap(peer => { const target = this.targetFor(peer); return target ? [target] : []; });
     const directions = this.controller.health(targets).map(row => ({ ...row, proof: this.proofs.get(this.key(row.sourceMachineId, row.targetMachineId)) ?? row.proof }));
     const pairs = this.d.listPeers().map(peer => {
@@ -219,7 +261,7 @@ export class MutualSshRuntime {
       }));
       let standingKeyInstalled = false;
       try { standingKeyInstalled = Boolean(advert && this.peerAuthorizedKeys?.has(this.authorizedKey(advert))); }
-      catch (error) { this.bootstrapFailures.set(peer.machineId, `standing-key-store:${classifyMutualSshFailure(error)}`); }
+      catch (error) { this.bootstrapFailures.set(peer.machineId, capturedBootstrapFailure(error, 'standing-key-store')); }
       return {
         machines: [this.d.selfMachineId, peer.machineId],
         mutual,
@@ -235,10 +277,24 @@ export class MutualSshRuntime {
     const standingReady = !standingRequired || pairs.every(pair => pair.mutual && pair.standingKeyInstalled && pair.standingReachable);
     const combinedReadinessRequired = readinessRequired || standingRequired;
     const ready = !combinedReadinessRequired || (proofReady && standingReady);
-    const blockedReasons = [...this.bootstrapFailures.values()];
+    const blockedReasons = [...this.bootstrapFailures.values()].map(failure => failure.reason);
     if (standingRequired) for (const pair of pairs) if (!pair.mutual || !pair.standingKeyInstalled || !pair.standingReachable) blockedReasons.push(`standing-key-unreachable:${pair.machines[1]}`);
     const enrollmentState = this.stopped || peerCount === 0 ? 'ready' : this.bootstrapFailures.size > 0 || (combinedReadinessRequired && !standingReady) ? 'ssh-bootstrap-blocked' : this.d.dryRun || this.adverts.size < peerCount || !this.endpoint ? 'ssh-bootstrap' : proofReady ? 'ready' : 'ssh-proving';
-    return { enabled: true, dryRun: this.d.dryRun, listener: this.endpoint !== null, readinessRequired: combinedReadinessRequired, ready, enrollmentState, blockedReasons: [...new Set(blockedReasons)].sort(), directions, pairs };
+    const capturedFailures = [...this.bootstrapFailures.entries()]
+      .flatMap(([machineId, failure]) => 'detail' in failure ? [{ machineId, ...failure }] : [])
+      .sort((a, b) => a.machineId.localeCompare(b.machineId) || a.reason.localeCompare(b.reason));
+    return {
+      enabled: true,
+      dryRun: this.d.dryRun,
+      listener: this.endpoint !== null,
+      readinessRequired: combinedReadinessRequired,
+      ready,
+      enrollmentState,
+      blockedReasons: [...new Set(blockedReasons)].sort(),
+      directions,
+      pairs,
+      ...(capturedFailures.length > 0 ? { bootstrapFailures: capturedFailures } : {}),
+    };
   }
 
   revoke(machineId: string): void {
@@ -292,7 +348,7 @@ export class MutualSshRuntime {
       });
       this.endpoint = null;
       this.listen = null;
-      this.bootstrapFailures.set(this.d.selfMachineId, classifyMutualSshFailure(error));
+      this.bootstrapFailures.set(this.d.selfMachineId, capturedBootstrapFailure(error));
     }
   }
 
@@ -425,7 +481,7 @@ export class MutualSshRuntime {
       if (result.changed) this.audit({ type: 'peer-authorized-key-reconciled', machineId, pairingEpoch: advert.pairingEpoch, clientKeyGeneration: advert.clientKeyGeneration, dryRun: result.dryRun });
       this.bootstrapFailures.delete(machineId);
     } catch (error) {
-      this.bootstrapFailures.set(machineId, `standing-key-store:${classifyMutualSshFailure(error)}`);
+      this.bootstrapFailures.set(machineId, capturedBootstrapFailure(error, 'standing-key-store'));
     }
   }
 
@@ -434,7 +490,7 @@ export class MutualSshRuntime {
     const advert = this.adverts.get(machineId);
     if (!advert?.standingSsh) {
       this.standingEvidence.delete(machineId);
-      this.bootstrapFailures.set(machineId, 'standing-ssh-endpoint-missing');
+      this.bootstrapFailures.set(machineId, { reason: 'standing-ssh-endpoint-missing' });
       return;
     }
     try {
@@ -446,7 +502,7 @@ export class MutualSshRuntime {
       this.bootstrapFailures.delete(machineId);
     } catch (error) {
       this.standingEvidence.delete(machineId);
-      this.bootstrapFailures.set(machineId, `standing-ssh:${classifyMutualSshFailure(error)}`);
+      this.bootstrapFailures.set(machineId, capturedBootstrapFailure(error, 'standing-ssh'));
     }
   }
 

--- a/tests/unit/mutual-ssh-autobootstrap.test.ts
+++ b/tests/unit/mutual-ssh-autobootstrap.test.ts
@@ -69,6 +69,11 @@ describe('mutual SSH bootstrap security invariants', () => {
     await controller.check(target);
     expect(verifier.probe).toHaveBeenCalledTimes(4);
     expect(hooks.notifyExhausted).toHaveBeenCalledOnce();
+    expect(hooks.notifyExhausted).toHaveBeenCalledWith(target, 'connect-refused', 'ECONNREFUSED');
+    expect(controller.health([target])[0]).toMatchObject({
+      lastFailureClass: 'connect-refused',
+      lastFailureDetail: 'ECONNREFUSED',
+    });
   }, 15_000);
 
   it('covers all 90 ten-machine directions within the full timeout-path budget without starvation', async () => {

--- a/tests/unit/mutual-ssh-hardening.test.ts
+++ b/tests/unit/mutual-ssh-hardening.test.ts
@@ -12,7 +12,7 @@ import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { MutualSshRuntime, type MutualSshPeer } from '../../src/core/MutualSshRuntime.js';
 import { canonicalSshBootstrapAdvert, type SshBootstrapAdvert } from '../../src/core/SshBootstrapAdvert.js';
 import { canonicalDirectionalSshProof } from '../../src/core/MutualSshVerifier.js';
-import { classifyMutualSshFailure } from '../../src/core/MutualSshHealthController.js';
+import { captureMutualSshFailure, classifyMutualSshFailure } from '../../src/core/MutualSshHealthController.js';
 import { MachineSshIdentity } from '../../src/core/MachineSshIdentity.js';
 import { MachineSshEndpoint } from '../../src/core/MachineSshEndpoint.js';
 
@@ -149,6 +149,7 @@ describe('mutual SSH hardened lifecycle', () => {
     const first = new MutualSshRuntime(deps('self-boot-1'));
     await first.start();
     expect(first.status()).toMatchObject({ enrollmentState: 'ready', readinessRequired: true, ready: true });
+    expect(first.status()).not.toHaveProperty('bootstrapFailures');
     peers.push({ machineId: 'source', pairingEpoch: 7, machineFingerprint: 'source-fp', endpoints: [] });
     expect(first.status()).toMatchObject({ enrollmentState: 'ssh-bootstrap', readinessRequired: true, ready: false });
     const unsignedAdvert: Omit<SshBootstrapAdvert, 'machineSignature'> = {
@@ -185,6 +186,80 @@ describe('mutual SSH hardened lifecycle', () => {
     expect(classifyMutualSshFailure(new Error('EACCES firewall'))).toBe('firewall-denied');
     expect(classifyMutualSshFailure(new Error('ENETUNREACH from VPN route'))).toBe('vpn-route-unavailable');
     expect(classifyMutualSshFailure(new Error('system-sleep detected'))).toBe('system-sleep');
+  });
+
+  it('scrubs endpoint-shaped hosts without destroying dotted JavaScript diagnostics', () => {
+    for (const diagnostic of [
+      'Cannot find module.exports in package.json',
+      'TypeError: fs.readFileSync is not a function',
+      'failed reading MutualSshRuntime.ts at line 42',
+      'connect ECONNREFUSED, retry via socket.connect',
+    ]) {
+      expect(captureMutualSshFailure(new Error(diagnostic)).detail).toBe(diagnostic);
+    }
+
+    const failure = new Error('bootstrap exploded at echo-laptop.internal; getaddrinfo ENOTFOUND echo-laptop; route vanished at [fe80::1]');
+    expect(classifyMutualSshFailure(failure)).toBe('unknown');
+    const captured = captureMutualSshFailure(failure);
+    expect(captured.detail).toContain('[REDACTED:hostname]');
+    expect(captured.detail).toContain('[REDACTED:address]');
+    expect(captured.detail).not.toContain('echo-laptop');
+    expect(captured.detail).not.toContain('fe80::1');
+    expect(captureMutualSshFailure(new Error('\u0000 \n\t')).detail).toBe('<empty error detail after scrubbing>');
+  });
+
+  it('surfaces bounded scrubbed evidence when endpoint bootstrap classification is unknown', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-ssh-unknown-bootstrap-'));
+    roots.push(root);
+    const publicKeyMaterial = `ssh-ed25519 ${'B'.repeat(64)} echo-laptop.internal`;
+    const privateKey = `-----BEGIN OPENSSH PRIVATE KEY-----\n${'A'.repeat(96)}\n-----END OPENSSH PRIVATE KEY-----`;
+    const failure = new Error(`bootstrap exploded at echo-laptop.internal while reading module.exports in package.json using ${publicKeyMaterial} and ${privateKey} ${'diagnostic '.repeat(80)}`);
+    expect(classifyMutualSshFailure(failure)).toBe('unknown');
+    const listen = vi.spyOn(MachineSshEndpoint.prototype, 'listen').mockRejectedValue(failure);
+    const runtime = new MutualSshRuntime({
+      stateDir: root,
+      agentId: 'agent',
+      selfMachineId: 'self',
+      selfMachineFingerprint: 'self-fp',
+      observerBootId: 'self-boot',
+      bindHost: '127.0.0.1',
+      bindPort: 0,
+      dryRun: false,
+      requiredForReadiness: true,
+      listPeers: () => [{ machineId: 'peer', pairingEpoch: 1, machineFingerprint: 'peer-fp', endpoints: [] }],
+      send: async () => ({}),
+      sign: () => 'x'.repeat(64),
+      verify: () => true,
+    });
+
+    try {
+      await runtime.start();
+      const status = runtime.status();
+      expect(status).toMatchObject({
+        enrollmentState: 'ssh-bootstrap-blocked',
+        listener: false,
+        blockedReasons: ['unknown'],
+        bootstrapFailures: [{
+          machineId: 'self',
+          reason: 'unknown',
+          failureClass: 'unknown',
+          detail: expect.stringContaining('bootstrap exploded'),
+        }],
+      });
+      const detail = status.bootstrapFailures?.[0]?.detail ?? '';
+      expect(detail).toContain('[REDACTED:hostname]');
+      expect(detail).toContain('[REDACTED:ssh-key]');
+      expect(detail).toContain('[REDACTED:pem-private-key]');
+      expect(detail).toContain('module.exports');
+      expect(detail).toContain('package.json');
+      expect(detail).not.toContain('echo-laptop.internal');
+      expect(detail).not.toContain('B'.repeat(64));
+      expect(detail).not.toContain('BEGIN OPENSSH PRIVATE KEY');
+      expect(detail.length).toBeLessThanOrEqual(512);
+    } finally {
+      await runtime.rollback();
+      listen.mockRestore();
+    }
   });
 
   it('refuses non-CGNAT public 100/8 binds and leaves personal SSH byte-identical through rollback', async () => {

--- a/upgrades/next/mutual-ssh-failure-evidence.md
+++ b/upgrades/next/mutual-ssh-failure-evidence.md
@@ -1,0 +1,47 @@
+# Mutual SSH failure evidence
+
+<!-- bump: patch -->
+
+## What Changed
+
+Mutual SSH enrollment now retains a structured failure record whenever an
+endpoint, advert exchange, standing-key write, or standing-access probe throws.
+The record keeps the existing failure class and adds the original error detail
+after a deterministic privacy pass and a 512-character bound. The privacy pass
+removes known credential shapes, private and public SSH key material, home
+directory identities, IP addresses, and hostnames identified in SSH/DNS
+endpoint contexts. Dotted JavaScript identifiers and filenames remain visible
+rather than being mistaken for machines.
+
+The classifier table is unchanged. Existing blocked-reason strings and
+readiness calculations are unchanged. Healthy status responses, including the
+single-machine case, do not gain an empty field; the new diagnostic array is
+present only when caught failure evidence exists.
+
+## What to Tell Your User
+
+- “When secure machine-to-machine setup hits an error Instar does not recognize,
+  its status now keeps a safe diagnostic clue instead of reducing everything to
+  the word unknown.”
+- “Machine names and SSH key material are removed before that clue is shown, and
+  the clue has a strict size limit.”
+- “This does not change whether secure access is enabled or ready; it only makes
+  a real setup failure diagnosable.”
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|------------|
+| Safe mutual SSH failure evidence | Read the existing mutual SSH status surface when enrollment is blocked |
+| Unknown-class diagnosis without a new classifier rule | Use the attached bounded detail to identify the real cause |
+
+## Evidence
+
+The regression test first failed on the unmodified source with the exact live
+shape: listener false, enrollment blocked, and a single unknown reason with no
+failure record. After the change, the same forced unknown listener failure
+surfaces its class plus a detail while removing a fixture hostname and a fixture
+private key, preserving dotted JavaScript diagnostics, redacting IPv4/IPv6 and
+bare/dotted endpoint identities, and enforcing the 512-character bound. Both
+mutual SSH unit suites pass together: 18 tests across the hardened lifecycle and bootstrap security
+invariants. TypeScript no-emit checking also passes.

--- a/upgrades/side-effects/mutual-ssh-failure-evidence.md
+++ b/upgrades/side-effects/mutual-ssh-failure-evidence.md
@@ -1,0 +1,170 @@
+# Side-Effects Review — Mutual SSH failure evidence
+
+**Version / slug:** `mutual-ssh-failure-evidence`
+**Date:** `2026-08-02`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `/root/ssh_failure_review` (concurred after fixes)
+
+## Summary of the change
+
+`src/core/MutualSshHealthController.ts` now captures every classified SSH
+failure as a class plus a bounded, privacy-scrubbed detail. `src/core/MutualSshRuntime.ts`
+retains that object for caught bootstrap failures and adds it to the existing
+status surface only when evidence exists. Existing blocked-reason strings,
+retry behavior, and readiness calculations are preserved.
+
+## Decision-point inventory
+
+- `classifyMutualSshFailure` — pass-through — the existing classifier and every
+  match rule remain byte-identical; the change retains evidence beside its result.
+- `MutualSshRuntime.status` readiness projection — pass-through — the existing
+  readiness and enrollment-state expressions are unchanged.
+- Failure-detail privacy transform — add — deterministic structural scrubbing
+  controls what evidence may cross the operator-facing status/audit boundary.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block is not applicable. The change does not
+reject a bootstrap, advert, key, proof, or peer-execution input.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block is not applicable. Privacy scrubbing is a
+separate under-redaction risk: novel endpoint encodings may not match the
+contextual patterns. Known credential shapes and SSH key material are scrubbed
+first; IPv4, IPv6, DNS-failure hostnames, private-network suffixes, and labeled
+SSH endpoints are covered; and the detail is bounded. The status already names
+the machine associated with the failure. This change does not claim arbitrary
+secret detection.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Evidence capture belongs beside the existing classifier because every caller
+needs the same invariant: a class summarizes the error and never replaces it.
+The helper reuses the shared durable-secret scrubber rather than creating a new
+credential-pattern list, then applies SSH-specific endpoint/key removals that the
+generic scrubber does not own. Runtime status remains the projection layer; it
+does not learn new classification logic.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The substring classifier remains a diagnostic signal. This change neither
+grants it new authority nor uses the retained detail to alter readiness,
+routing, admission, or peer execution.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. The new logic is
+a structural information-disclosure bound over an already-caught error; its
+domain is a fixed safety invariant, not a judgment among live signals.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none. Classification occurs on the original thrown value before
+  the detail is scrubbed, so scrubbing cannot shadow an existing class match.
+- **Double-fire:** none. One caught error produces one retained object at the
+  same call site that previously stored one string.
+- **Races:** map keys and deletion/retry points are unchanged. A later successful
+  bootstrap still deletes the same machine-keyed failure entry.
+- **Feedback loops:** none. The detail is observational and never feeds the
+  classifier, retry controller, readiness expression, or peer-execution gate.
+
+---
+
+## 6. External surfaces
+
+The existing mutual SSH status gains an optional `bootstrapFailures` array only
+when caught evidence exists. Repair-direction health can now include
+`lastFailureDetail`, and the existing exhaustion/security callbacks receive the
+same scrubbed detail. No database or file format changes. No new operator action,
+notification channel, route, timing dependency, or external service is added.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No dashboard, approval, grant, revoke, or form surface is touched. The existing
+machine-readable status remains the diagnostic surface, so this section is not
+applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN:** a listener or SSH bootstrap error is a physical
+truth about the machine on which it occurred. The existing per-machine status
+continues to own it; this change does not replicate a local error as if it were a
+peer's observation. It emits no user-facing notice, holds no durable state that
+can strand on topic transfer, and generates no URL. Pool-level tooling may read
+each machine's existing status, but no merged authority is introduced here.
+
+---
+
+## 8. Rollback cost
+
+Pure code and response-shape addition. Revert the source and test changes and
+ship the next patch. No data migration, key rotation, agent-state repair, or
+operator action is required. During rollback, unknown failures return to the old
+less-diagnostic string-only surface.
+
+---
+
+## Conclusion
+
+The design preserves every existing authority boundary and retry/readiness
+behavior while closing the evidence-loss seam. The main residual is ordinary
+best-effort redaction coverage, bounded by the shared credential scrubber,
+contextual SSH-specific patterns, the strict length limit, and a failing-before
+privacy regression. The independent reviewer concurred after the initial
+privacy findings were fixed.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `/root/ssh_failure_review`
+**Independent read of the artifact:** Initial read found broad dotted-token
+redaction, missing bare-host/IPv6 coverage, an empty-detail edge case, and a
+repair-controller coverage gap. The implementation now uses contextual endpoint
+patterns, covers bare DNS failures and IPv6, guarantees a nonempty detail, and
+asserts controller projection/callback detail. On re-review, the reviewer ran
+the focused 18-test lane and TypeScript no-emit check, confirmed every finding
+closed, and concurred with no remaining material issue.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/mutual-ssh-hardening.test.ts` — listener-failure reproduction,
+  unknown-class evidence, contextual hostname/IP/private-key scrubbing, dotted
+  JavaScript identifier preservation, size bound, and healthy single-machine
+  compatibility.
+- `tests/unit/mutual-ssh-autobootstrap.test.ts` — repair-controller regression
+  suite.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable. This is an ordinary runtime
+source defect, not a prompt, hook, configuration, skill, standards-text, or
+self-triggered-controller class-closure change.


### PR DESCRIPTION
## ELI16 — Keep the clue when secure machine setup fails

When two machines try to establish secure access, a failure is assigned a short category so the system can react consistently. Before this change, any failure that did not match the category list became “unknown,” and the actual error message was thrown away. That left the operator knowing only that setup failed, not why. This change keeps a short, privacy-scrubbed copy of the original error beside the category, so an unfamiliar failure remains diagnosable without exposing machine names or SSH key material.

## Summary

- retain a structured failure record for endpoint, advert, standing-key, and standing-access failures
- keep the legacy blocked-reason strings and readiness calculation unchanged
- add bounded scrubbed detail to repair-controller health and exhaustion/security notifications
- do not add or widen any failure classification rule

## Root cause

`MutualSshRuntime.bootstrapFailures` stored only the return value from `classifyMutualSshFailure(error)`. The classifier's fallback is `unknown`, so the caught error text ceased to exist before the status surface was built.

## Failing-before proof

The new regression was run against the unmodified source first. A forced listener failure that deliberately matched no class produced:

```json
{
  "listener": false,
  "enrollmentState": "ssh-bootstrap-blocked",
  "blockedReasons": ["unknown"]
}
```

The assertion failed because no failure-evidence object existed. With this change, the same reproduction retains `failureClass: "unknown"` plus a bounded `detail`.

## Privacy and compatibility

The detail passes through the shared durable-secret scrubber, then removes SSH public-key material, home-directory identity, IPv4/IPv6 addresses, and hostnames identified in SSH/DNS endpoint contexts. Context is load-bearing: the regression proves dotted JavaScript identifiers and filenames such as `module.exports`, `fs.readFileSync`, and `package.json` survive, while a dotted private hostname, a bare `ENOTFOUND` hostname, an IPv6 endpoint, SSH public-key material, and PEM private-key material do not. Detail is flattened, nonempty, and capped at 512 characters.

Healthy status responses do not gain an empty field. Single-machine readiness behavior and output remain unchanged. The new `bootstrapFailures` array is emitted only when caught bootstrap evidence exists.

## Validation

- failing-before reproduction observed on the unmodified source
- 18/18 mutual SSH tests pass across both focused suites
- 48/48 affected pre-push smoke tests pass
- TypeScript and the complete repository lint battery pass
- pre-push structural gate passes
- independent security/correctness re-review concurs with no material issue
- audited decision record, ELI16 explanation, side-effects artifact, and release-note fragment included

This restores a diagnosis that was being destroyed; it does not itself unblock peer execution. The retained evidence is the prerequisite for diagnosing that substrate failure.
