### PR TITLE
Fix nonholder local session reaping

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-03T03-27-15-115Z-session-reaper-local-age-owner.json
+++ b/.instar/instar-dev-decisions/2026-08-03T03-27-15-115Z-session-reaper-local-age-owner.json
@@ -1,0 +1,42 @@
+{
+  "ts": "2026-08-03T03:27:15.115Z",
+  "slug": "session-reaper-local-age-owner",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/SessionReaper.ts matches session reaper"
+  ],
+  "belowFloor": false,
+  "files": 8,
+  "loc": 544,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/SessionManager.ts",
+      "src/core/StateManager.ts",
+      "src/monitoring/ReapLog.ts",
+      "src/monitoring/SessionReaper.ts",
+      "src/server/AgentServer.ts",
+      "src/server/routes.ts",
+      "src/testing/selfActionRegistry.ts"
+    ],
+    "addedLines": 368,
+    "deletedLines": 176
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The global serving-lease gate correctly protected shared and cross-machine action but was applied to a machine-local age cleanup that no peer could execute, stranding expired sessions on nonholders. Adversarial review also exposed pre-existing runtime-private and state/process atomicity weaknesses in the same authority funnel."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/session-manager-terminate.test.ts",
+      "howCaught": "The production maintenance-path regression proves one local-owner age reap converges on a nonholder while recent-message, open-commitment, structural-work, recovery, protected-session, startup-readiness, ownership-race, and public-forgery cases converge to named refusals without touching tmux."
+    }
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-03T03-27-53-692Z-session-reaper-local-age-owner.json
+++ b/.instar/instar-dev-decisions/2026-08-03T03-27-53-692Z-session-reaper-local-age-owner.json
@@ -1,0 +1,42 @@
+{
+  "ts": "2026-08-03T03:27:53.692Z",
+  "slug": "session-reaper-local-age-owner",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "safety-invariant proximity: src/monitoring/SessionReaper.ts matches session reaper"
+  ],
+  "belowFloor": false,
+  "files": 8,
+  "loc": 544,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/SessionManager.ts",
+      "src/core/StateManager.ts",
+      "src/monitoring/ReapLog.ts",
+      "src/monitoring/SessionReaper.ts",
+      "src/server/AgentServer.ts",
+      "src/server/routes.ts",
+      "src/testing/selfActionRegistry.ts"
+    ],
+    "addedLines": 368,
+    "deletedLines": 176
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The global serving-lease gate correctly protected shared and cross-machine action but was applied to a machine-local age cleanup that no peer could execute, stranding expired sessions on nonholders. Adversarial review also exposed pre-existing runtime-private and state/process atomicity weaknesses in the same authority funnel."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/session-manager-terminate.test.ts",
+      "howCaught": "The production maintenance-path regression proves one local-owner age reap converges on a nonholder while recent-message, open-commitment, structural-work, recovery, protected-session, startup-readiness, ownership-race, and public-forgery cases converge to named refusals without touching tmux."
+    }
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-03T04-54-52-616Z-session-reaper-local-age-owner.json
+++ b/.instar/instar-dev-decisions/2026-08-03T04-54-52-616Z-session-reaper-local-age-owner.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-03T04:54:52.616Z",
+  "slug": "session-reaper-local-age-owner",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 66,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SessionManager.ts"
+    ],
+    "addedLines": 35,
+    "deletedLines": 31
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-traces/2026-08-03T03-24-07-000Z-session-reaper-local-age-owner.json
+++ b/.instar/instar-dev-traces/2026-08-03T03-24-07-000Z-session-reaper-local-age-owner.json
@@ -1,0 +1,70 @@
+{
+  "version": 3,
+  "slug": "session-reaper-local-age-owner",
+  "sessionId": "40e5fe03-705e-4d04-a0c7-fd7daec1ec07",
+  "timestamp": "2026-08-03T03:24:07.000Z",
+  "artifactPath": "upgrades/side-effects/session-reaper-local-age-owner.md",
+  "artifactSha256": "9f7004fe0d53e18c577854b684f39693ec543dece117f1ad1ccdad9f3b724bbe",
+  "specPath": "docs/specs/unified-session-lifecycle-robustness.md",
+  "eli16Path": "upgrades/session-reaper-local-age-owner.eli16.md",
+  "sideEffectsPath": "upgrades/side-effects/session-reaper-local-age-owner.md",
+  "coveredFiles": [
+    "docs/specs/unified-session-lifecycle-robustness.eli16.md",
+    "docs/specs/unified-session-lifecycle-robustness.md",
+    "src/commands/server.ts",
+    "src/core/SessionManager.ts",
+    "src/core/StateManager.ts",
+    "src/monitoring/ReapLog.ts",
+    "src/monitoring/SessionReaper.ts",
+    "src/server/AgentServer.ts",
+    "src/server/routes.ts",
+    "src/testing/selfActionRegistry.ts",
+    "tests/e2e/june15-headless-spawn-reroute.test.ts",
+    "tests/e2e/session-management-e2e.test.ts",
+    "tests/integration/session-build-context-respawn.test.ts",
+    "tests/integration/session-lifecycle-reap-wiring.test.ts",
+    "tests/integration/tmux-resilience-slow-stub.test.ts",
+    "tests/unit/headless-spawn-reroute.test.ts",
+    "tests/unit/reap-log.test.ts",
+    "tests/unit/session-manager-idle-veto-backoff.test.ts",
+    "tests/unit/session-manager-is-session-alive-async-tristate.test.ts",
+    "tests/unit/session-manager-terminate.test.ts",
+    "tests/unit/session-reaper-closeout-liveness.test.ts",
+    "tests/unit/session-reaper-topic-moved.test.ts",
+    "tests/unit/session-reaper-wiring.test.ts",
+    "tests/unit/session-telegram-inject.test.ts",
+    "tests/unit/session-timeout-activity-aware.test.ts",
+    "tests/unit/work-evidence.test.ts",
+    "upgrades/next/session-reaper-local-age-owner.md",
+    "upgrades/session-reaper-local-age-owner.eli16.md",
+    "upgrades/side-effects/session-reaper-local-age-owner.md"
+  ],
+  "phase": "complete",
+  "tier": 2,
+  "tierReasoning": "Changes a multi-machine termination-authority boundary and the state/process commit protocol; independent adversarial review and full release gates are required.",
+  "causalAutopsy": {
+    "origin": "latent",
+    "notes": "The global serving-lease gate correctly protected shared and cross-machine action but was applied to a machine-local age cleanup that no peer could execute, stranding expired sessions on nonholders. Adversarial review also exposed pre-existing runtime-private and state/process atomicity weaknesses in the same authority funnel."
+  },
+  "secondPass": "true",
+  "reviewerConcurred": true,
+  "duplicateBuildCheck": {
+    "verdict": "likely-duplicate",
+    "cause": "concurrency",
+    "causes": ["concurrency"],
+    "decision": "proceed",
+    "reason": "Open PR #1271 overlaps only the broad SessionManager symbol; this branch addresses an independently reproduced nonholder local-age authority defect with distinct implementation, spec correction, and adversarial regressions.",
+    "acknowledgedEvidenceIds": ["EV-1"],
+    "checkedAt": "2026-08-03T03:21:50.534Z",
+    "specSlug": "unified-session-lifecycle-robustness"
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "guard",
+    "guardEvidence": {
+      "enforcementType": "ratchet",
+      "citation": "tests/unit/session-manager-terminate.test.ts",
+      "howCaught": "The production maintenance-path regression proves one local-owner age reap converges on a nonholder while recent-message, open-commitment, structural-work, recovery, protected-session, startup-readiness, ownership-race, and public-forgery cases converge to named refusals without touching tmux."
+    }
+  }
+}

--- a/docs/specs/unified-session-lifecycle-robustness.eli16.md
+++ b/docs/specs/unified-session-lifecycle-robustness.eli16.md
@@ -77,8 +77,18 @@ They found real things my own pass missed, and the design got noticeably stronge
   and that front door holds the rules. A crew can *ask* to shut a burner off; the front door decides.
   No crew can act alone anymore.
 - **The machines won't step on each other.** If you're running me on two computers, only the "awake"
-  one is allowed to shut anything off — so a sleepy second machine can't reach over and kill the
-  active one's work.
+  one is allowed to act on shared routing or shut down work on another machine. Each computer still
+  has to clean up a session process that physically runs on that computer; otherwise a non-awake
+  laptop can identify its own expired session forever while no machine is able to close it. That
+  local cleanup is narrowly limited to its own over-age, positively-idle process and still obeys every
+  protected-work and active-work safeguard. The cleanup monitor does not even start until those
+  safeguards and the machine's permission to save that session are ready; a read-only computer that
+  does not own writable session state cannot touch the process. Every cleanup observer gets its own
+  chance to inspect the still-live session, then the final “this session is closed” record is saved
+  immediately before a hard-time-limited process stop. If ownership changes at that instant, the save
+  is refused and the process stays alive. If stopping the process itself fails, the record is put back
+  to “running” and the audit says the cleanup failed; it never reports a successful cleanup while the
+  process may still be alive. A broken observer cannot suppress the later audit.
 - **It won't slow down startup.** Being careful, done naively, would've made the kitchen take a
   minute-plus to reopen — bringing back the exact pile-up we're fixing. Now the careful check is fast:
   one quick "who's here?" question for everyone at once, with a hard time limit.

--- a/docs/specs/unified-session-lifecycle-robustness.md
+++ b/docs/specs/unified-session-lifecycle-robustness.md
@@ -3,6 +3,7 @@ title: "Unified Session-Lifecycle Robustness — one authority for every session
 date: 2026-05-27
 author: echo
 status: approved
+parent-principle: "Cross-Machine Coherence — One Agent, Robust Under Degraded Conditions"
 review-method: internal-5-reviewer-plus-conformance-gate (security, scalability, adversarial, integration, lessons-aware); external cross-model panel tracked separately (see "External review" note below)
 approved: true
 approved-by: Justin
@@ -112,13 +113,18 @@ gains:
   them. Routing inline kills here also *restores* the `sessionComplete` emission the inline age-limit
   path fired, so no listener regresses.
 - a **lease-holder gate**: an **autonomous-reap** terminate on a standby (non-awake) machine is a no-op
-  `skipped:'not-lease-holder'`. Only the awake/lease-holding machine may autonomously reap; this also
-  dedupes notifications. **Operator-initiated kills bypass the lease gate unconditionally** — origin is
-  an explicit `origin: 'operator' | 'autonomous'` argument **defaulting to `'autonomous'` when omitted**
-  and stamped `'operator'` only by the (Bearer-authed) HTTP route layer — in-process autonomous killers
-  call `terminateSession` directly and therefore cannot mint `'operator'`; origin is **never inferred
-  from the reason string** (a misclassified or mid-handoff operator kill must never be silently dropped
-  — the user clicks "kill" and it must happen). Every terminate that is skipped for *any* reason
+  `skipped:'not-lease-holder'` unless the authority itself minted one of the two local-process-only
+  capabilities described in the 2026-08-02 correction below. The lease holder remains the only machine
+  allowed to act on shared or remote session state; a non-holder may clean up only a tmux process in
+  its own machine-local session registry. This also dedupes notifications. The public
+  `terminateSession()` boundary is **always autonomous**: caller-supplied `origin` labels—including
+  unknown values forced through a cast—are discarded and normalized to `'autonomous'`; undeclared
+  `knownDead` and individual KEEP-bypass booleans are dropped too. The public method copies only an
+  explicit whitelist of inert fields. Trusted lifecycle components use a termination closure delivered
+  to the server composition root only during `SessionManager` construction. Explicit operator kills
+  use that closure from the authenticated route; the remaining internal operator reconciliation path
+  is JavaScript-runtime-private. Origin is **never inferred from the reason string** and never accepted
+  as caller-minted authority. Every terminate that is skipped for *any* reason
   (`not-lease-holder`, a KEEP, in-flight, protected) is recorded as a `skipped` entry in the reap-log
   (P4), so a dropped kill is never invisible.
 - **re-entrancy ordering (explicit):** the ReapGuard reads the in-flight reap-lock (`isReaping`) state
@@ -260,10 +266,59 @@ sanitization wherever it surfaces.
 
 ## Multi-machine
 
-Reaping is **awake-machine-only**, enforced at the P0 authority (lease-holder gate), not per-killer.
-The boot purge — today called unconditionally before any `isAwake` check — is moved behind the same
-gate. `sessionReaped` notices are emitted only by the lease holder, so a handoff cannot double-notify.
-A standby machine's killers may still *detect and signal* but the authority no-ops their terminate.
+Cross-machine reaping is **awake-machine-only**, enforced at the P0 authority (lease-holder gate), not
+per-killer. The boot purge — today called unconditionally before any `isAwake` check — is moved behind
+the same gate. `sessionReaped` notices are emitted only by the machine that owns the local process, so
+a handoff cannot double-notify. A standby machine's ordinary autonomous killers may still *detect and
+signal* but the authority no-ops their terminate.
+
+**2026-08-02 correction — local process cleanup is not cross-machine authority.** The original wording
+above collapsed two different ownership domains: the pool's serving lease governs shared routing and
+remote-machine action, while a tmux process and its session record are physically machine-local. That
+made a non-lease-holder repeatedly detect its own over-age idle process and then refuse to reap it as
+`not-lease-holder`; no other machine could perform the cleanup because the process exists only in that
+machine's tmux namespace. The corrected invariant is:
+
+1. An ordinary public autonomous terminate on a non-holder remains refused.
+2. The age-limit monitor may terminate an over-age, positively-idle session from its own local state
+   tree through a runtime-private (`#`) authority-minted capability. Neither the capability nor the
+   internal termination options cross an overridable runtime property; the public `terminateSession()`
+   surface cannot carry them. The capability is valid only for the literal `age-limit` reason.
+3. Every real termination uses one transition protocol. It invokes each `beforeSessionKill` observer
+   independently while the process is still inspectable, then immediately commits the terminal
+   session record, then performs a bounded synchronous tmux kill. The commit repeats the
+   ownership-aware StateManager admission after the observers. If an observer or concurrent handoff
+   changes admission, the write is refused and the process remains alive. The tmux call is bounded
+   with `SIGKILL` because a wedged tmux client may ignore Node's default `SIGTERM`. This write-first,
+   no-await transition removes both the nonholder and ordinary-holder check/kill/save races.
+4. Protected-session, KEEP-guard, CAS, in-flight, and self-action-governor checks remain mandatory.
+5. Topic-moved closeout is separately scoped to a locally hosted leftover whose topic ownership has
+   moved elsewhere. `SessionManager` hands its trusted termination closure to the composition root
+   only during manager construction; there is no later public getter or binder. Production boot keeps
+   that closure in lexical scope and supplies it only as a runtime-private, frozen `SessionReaper`
+   dependency. After the ownership/liveness+dwell transition passes, that reaper may assert local
+   post-transfer closeout through the trusted closure. A fabricated reaper—even one constructed
+   first—can reach only public `terminateSession()`, which copies a whitelist of inert fields and drops
+   every hidden bypass option. No chronological first-claim, exported minter, reusable public closure,
+   or public Boolean can request this exception.
+6. A throwing `beforeSessionKill` observer is isolated from the other observers, then write admission
+   is rechecked before any irreversible action. A non-definitive tmux kill failure compensates the
+   durable row back to the exact running snapshot, emits `tmux-kill-failed`, and emits no
+   `sessionReaped` success. After a successful kill, `sessionComplete` and `sessionReaped` listeners
+   are also invoked independently, so one observer cannot suppress the durable reap audit or turn a
+   successful termination into a rejected authority call. If compensation itself is refused, the distinct
+   `tmux-kill-failed-compensation-failed` record exposes the unresolved state/process split rather than
+   claiming success. Neither local authority authorizes a remote close, a shared ownership write, a
+   boot purge, an idle-zombie kill, or any other autonomous termination class.
+
+The machine-local state tree and local tmux namespace are the ownership proof: `SessionManager` lists
+only sessions persisted by that machine and its process command can target only that machine. This is
+the same distinction already relied on by active-active standby session writes; replicating or
+lease-gating the local cleanup would strand the resource it is supposed to govern.
+
+Boot ordering is part of the boundary: `SessionManager` maintenance begins only after ReapGuard and
+the pool's per-session write posture are installed. A pure read-only standby, an ownership-refused
+session, or a first tick before guard readiness remains lease-refused and cannot touch tmux.
 
 ## Supervision (LLM-Supervised Execution)
 
@@ -322,8 +377,10 @@ conformance gate) then **strengthened** it materially. The biggest changes:
   rewrite routes every kill through the existing single-writer `terminateSession()`, which now *holds*
   the guard — so a killer can only *ask*, and the authority decides. Nothing is postponed; it is solved
   in-scope.
-- **Multi-machine safety was entirely missing.** Reaping is now awake-machine-only, so a standby can't
-  reap the active machine's sessions or double-notify.
+- **Multi-machine safety was entirely missing.** Shared/remote reaping is now awake-machine-only, so a
+  standby can't reap the active machine's sessions or double-notify. The 2026-08-02 correction above
+  makes explicit that this does not prohibit narrowly-capability-gated cleanup of a process physically
+  owned by the standby itself.
 - **Boot speed.** The conservative probing, done naively, would have blocked boot for ~100s with 9
   sessions — re-creating the very death spiral we're fixing. Now: one `list-sessions`, bounded
   concurrency, an 8s hard cap, async throughout.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -84,7 +84,7 @@ import type { TopicProfileStore } from '../core/TopicProfileStore.js';
 import type { TopicResumeMap } from '../core/TopicResumeMap.js';
 import type { IdleReading } from '../core/classifyProfileChange.js';
 import { closeAllSqlite } from '../core/SqliteRegistry.js';
-import { SessionManager } from '../core/SessionManager.js';
+import { SessionManager, type SessionTerminateAuthority } from '../core/SessionManager.js';
 import { configureSyncOpMarker, defaultInflightMarkerReader } from '../core/InFlightSyncOpMarker.js';
 import { StateManager } from '../core/StateManager.js';
 import { StuckInputSentinel } from '../core/StuckInputSentinel.js';
@@ -5925,7 +5925,15 @@ export async function startServer(options: StartOptions): Promise<void> {
         now: () => Date.now(),
       },
     );
+    let boundTerminateAuthority: SessionTerminateAuthority | null = null;
+    const terminateWithAuthority: SessionTerminateAuthority = (id, reason, opts) => {
+      if (!boundTerminateAuthority) {
+        throw new Error('Session terminate authority was not bound during manager construction');
+      }
+      return boundTerminateAuthority(id, reason, opts);
+    };
     const sessionManager = new SessionManager(sessionManagerConfig, state, {
+      bindTerminateAuthority: (authority) => { boundTerminateAuthority = authority; },
       tmuxAsyncEnabled: _tmuxAsyncEnabled,
       degradedTmuxGuard,
       tmuxCallTimeoutMs: config.monitoring?.tmuxResilience?.asyncHotPath?.timeoutMs,
@@ -9988,7 +9996,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       }));
     }
 
-    sessionManager.on('sessionReaped', (e: { session: import('../core/types.js').Session; reason: string; disposition?: 'terminal' | 'recovery-bounce'; origin?: 'operator' | 'autonomous'; midWork?: boolean; workEvidence?: string[]; via?: string }) => {
+    sessionManager.on('sessionReaped', (e: { session: import('../core/types.js').Session; reason: string; disposition?: 'terminal' | 'recovery-bounce'; origin?: 'operator' | 'autonomous'; authorityScope?: 'lease-holder' | 'local-age-limit' | 'local-post-transfer-closeout' | 'operator'; midWork?: boolean; workEvidence?: string[]; via?: string }) => {
       // ── F7: schedule a post-grace reachability verify for the affected topic. Both a
       //    terminal kill AND a recovery-bounce schedule one (a recovery whose respawn
       //    wedges is exactly the orphan to catch); the verifier's grace lets a normal
@@ -10048,6 +10056,7 @@ export async function startServer(options: StartOptions): Promise<void> {
         reason: e.reason,
         disposition: e.disposition,
         origin: e.origin,
+        authorityScope: e.authorityScope,
         // Untrusted provenance claim from a relayed close (spec §2.3) — a
         // signal in the trail, never an authority input.
         ...(e.via ? { viaClaim: e.via } : {}),
@@ -10216,8 +10225,6 @@ export async function startServer(options: StartOptions): Promise<void> {
     // the health endpoint (synchronous tmux has-session calls) and cause the
     // lifeline to restart the server in a tight loop.
     await sessionManager.purgeDeadSessions();
-
-    sessionManager.startMonitoring();
 
     // ── Durable Inbound Message Queue: unconditional boot sweep (§5.3) ──
     // MUST run BEFORE recoverPendingInjects (boot ordering, spec §3.4): the
@@ -10986,7 +10993,7 @@ export async function startServer(options: StartOptions): Promise<void> {
           killSession: async (name) => {
             const session = sessionManager.listRunningSessions().find((s) => s.tmuxSession === name);
             if (session) {
-              await sessionManager.terminateSession(session.id, 'session-recovery', {
+              await terminateWithAuthority(session.id, 'session-recovery', {
                 disposition: 'recovery-bounce',
                 finalStatus: 'killed',
                 bypassRecoveryFlag: true,
@@ -18749,13 +18756,10 @@ export async function startServer(options: StartOptions): Promise<void> {
           });
         },
         terminate: (id, reason, opts) =>
-          sessionManager.terminateSession(id, reason, {
+          terminateWithAuthority(id, reason, {
             bypassActiveProcessKeep: opts?.bypassActiveProcessKeep,
             bypassRecentUserMessageForConfirmedMove: opts?.bypassRecentUserMessageForConfirmedMove,
-            // F8 carve-out: the topic-moved closeout's lease bypass must reach
-            // the authority — dropping it here would silently restore the
-            // not-lease-holder veto the carve-out exists to lift.
-            bypassLeaseForTopicMovedCloseout: opts?.bypassLeaseForTopicMovedCloseout,
+            localPostTransferCloseout: opts?.localPostTransferCloseout,
             workEvidence: opts?.workEvidence,
           }),
         markReaping: (id) => sessionManager.markReaping(id),
@@ -21167,8 +21171,7 @@ export async function startServer(options: StartOptions): Promise<void> {
               const tmux = Number.isFinite(topicNum) ? telegram?.getSessionForTopic(topicNum) : null;
               const rec = tmux ? state.listSessions().find((s) => s.tmuxSession === tmux) : undefined;
               if (!rec) return { terminated: false, skipped: 'no-local-session' };
-              return sessionManager.terminateSession(rec.id, reason, {
-                origin: 'autonomous',
+              return terminateWithAuthority(rec.id, reason, {
                 via: 'ws12-drain',
                 bypassActiveProcessKeep: opts.force,
                 workEvidence: opts.force ? ['active-build-or-autonomous-run'] : undefined,
@@ -23927,7 +23930,7 @@ export async function startServer(options: StartOptions): Promise<void> {
                   const tmuxName = telegram?.getSessionForTopic(topicId);
                   const rec = tmuxName ? sessionManager.listRunningSessions().find((s) => s.tmuxSession === tmuxName) : undefined;
                   if (rec && !sessionManager.getProtectedSessions().includes(rec.tmuxSession)) {
-                    void sessionManager.terminateSession(
+                    void terminateWithAuthority(
                       rec.id,
                       `topic ${topicId} moved to ${cmd.nickname} (user-commanded transfer) — closing the leftover local session`,
                       { origin: 'operator', disposition: 'recovery-bounce' },
@@ -24553,7 +24556,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       })),
     });
 
-    const server = new AgentServer({ config, subscriptionEmailBinding: credentialLocationLedger, subscriptionEmailBarrier, subscriptionIdentityOracle: credentialIdentityOracle, sessionManager, llmQueue: sharedLlmQueue, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographerRoots: cartographerRoots ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, accountFollowMePeerViews: async () => { const nickById = new Map((_listPoolMachines?.() ?? []).map((m) => [m.machineId, m.nickname ?? m.machineId])); let peers = (_resolvePeerUrls?.() ?? []).map((p) => ({ machineId: p.machineId, nickname: nickById.get(p.machineId) ?? p.machineId, url: p.url })); if (peers.length === 0) { peers = (_listPoolMachines?.() ?? []).filter((m) => m.machineId !== _meshSelfId && !!m.lastKnownUrl).map((m) => ({ machineId: m.machineId, nickname: m.nickname ?? m.machineId, url: m.lastKnownUrl as string })); } if (peers.length === 0) return []; const { fetchPeerSubscriptionViews } = await import('../core/fetchPeerSubscriptionViews.js'); return fetchPeerSubscriptionViews({ peers: () => peers, fetchImpl: fetch as unknown as Parameters<typeof fetchPeerSubscriptionViews>[0]['fetchImpl'], authToken: config.authToken ?? '' }); }, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, accountFollowMeRevocation, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, meshBindActive: coordinator.managers.identityManager.hasIdentity() && config.multiMachine?.meshTransport?.enabled !== false, localSigningKeyPem, leaseTransport, peerEndpointRecorder, getSelfMeshEndpoints, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, conversationRegistry, conversationBindAuth, conversationFollowThrough, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, getLastRelayEvent: threadlineGetLastRelayEvent, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, reviewCanaryBattery, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, ropeHealthMonitor, writeAdmission: writeAdmission ?? undefined, getInboundQueue: () => _inboundQueue, getMachineCoherence: () => _machineCoherenceSentinel, getSingleMachineFailoverGap: () => _singleMachineFailoverGap, getMissingLoginSession: () => _missingLoginSession, getSessionPoolFailoverRunner: () => _sessionPoolFailoverRunnerDriver?.status() ?? null, sessionPoolPromotionActivation: _sessionPoolPromotionActivation, meshRpcDispatcher, deliverA2aToMachine: _deliverA2aToMachine ?? undefined, workingSetPullCoordinator, workingSetArtifactManager, orchestratorPoller, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, sendDrain: _sendDrain ?? undefined, topicPinStore: _topicPinStore ?? undefined, topicPinSkewQuarantine: _topicPinSkewQuarantine ?? undefined, topicPinFoldView: _topicPinFoldView ?? undefined, ownershipReconciler: _ownershipReconciler ?? undefined, staleOwnerEngine: _staleOwnerEngine ?? undefined, duplicateReconciler: _duplicateReconciler ?? undefined, ownerDarkLadder: _ownerDarkLadder ?? undefined, spawnAdmission: _spawnAdmission ?? undefined, judgmentProvenance: _judgmentProvenance ?? undefined, leaseHandback: _leaseHandbackCtx ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, deliverMandateToMachine: _deliverMandateToMachine ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, externalHogSentinel, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, autonomousLivenessReconciler, enforcedTerminationStatus: () => enforcedTerminationWatchdog?.guardStatus() ?? null, prHandLease: prHandLease ?? undefined, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
+    const server = new AgentServer({ config, terminateSessionAuthority: terminateWithAuthority, subscriptionEmailBinding: credentialLocationLedger, subscriptionEmailBarrier, subscriptionIdentityOracle: credentialIdentityOracle, sessionManager, llmQueue: sharedLlmQueue, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, cartographerRoots: cartographerRoots ?? undefined, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, subscriptionPool, accountFollowMePeerViews: async () => { const nickById = new Map((_listPoolMachines?.() ?? []).map((m) => [m.machineId, m.nickname ?? m.machineId])); let peers = (_resolvePeerUrls?.() ?? []).map((p) => ({ machineId: p.machineId, nickname: nickById.get(p.machineId) ?? p.machineId, url: p.url })); if (peers.length === 0) { peers = (_listPoolMachines?.() ?? []).filter((m) => m.machineId !== _meshSelfId && !!m.lastKnownUrl).map((m) => ({ machineId: m.machineId, nickname: m.nickname ?? m.machineId, url: m.lastKnownUrl as string })); } if (peers.length === 0) return []; const { fetchPeerSubscriptionViews } = await import('../core/fetchPeerSubscriptionViews.js'); return fetchPeerSubscriptionViews({ peers: () => peers, fetchImpl: fetch as unknown as Parameters<typeof fetchPeerSubscriptionViews>[0]['fetchImpl'], authToken: config.authToken ?? '' }); }, quotaPoller, quotaAwareScheduler: _quotaAwareScheduler ?? undefined, proactiveSwapMonitor: _proactiveSwapMonitor ?? undefined, inUseAccountResolver, enrollmentWizard, accountFollowMeRevocation, credentialRepointing, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, greenPrAutoMerger: greenPrAutoMerger ?? undefined, guardLatchStore: guardLatchStore ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, topicProfile: _topicProfileCtx ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, meshBindActive: coordinator.managers.identityManager.hasIdentity() && config.multiMachine?.meshTransport?.enabled !== false, localSigningKeyPem, leaseTransport, peerEndpointRecorder, getSelfMeshEndpoints, onLeasePullRequest: () => leaseCoordinatorRef?.currentLease() ?? null, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, conversationRegistry, conversationBindAuth, conversationFollowThrough, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, threadLog, threadMessageRecorder, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, getLastRelayEvent: threadlineGetLastRelayEvent, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, a2aDeliveryTracker: a2aDeliveryTracker ?? undefined, responseReviewGate, reviewCanaryBattery, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, machinePoolRegistry, ropeHealthMonitor, writeAdmission: writeAdmission ?? undefined, getInboundQueue: () => _inboundQueue, getMachineCoherence: () => _machineCoherenceSentinel, getSingleMachineFailoverGap: () => _singleMachineFailoverGap, getMissingLoginSession: () => _missingLoginSession, getSessionPoolFailoverRunner: () => _sessionPoolFailoverRunnerDriver?.status() ?? null, sessionPoolPromotionActivation: _sessionPoolPromotionActivation, meshRpcDispatcher, deliverA2aToMachine: _deliverA2aToMachine ?? undefined, workingSetPullCoordinator, workingSetArtifactManager, orchestratorPoller, commitmentReplicaStore, preferenceReplicaStore, replicatedRecordEmitter, conflictStore, rollbackUnmerge, droppedOriginRegistry, preferencesUnionReader, forwardCommitmentMutate, sessionOwnershipRegistry, sendDrain: _sendDrain ?? undefined, topicPinStore: _topicPinStore ?? undefined, topicPinSkewQuarantine: _topicPinSkewQuarantine ?? undefined, topicPinFoldView: _topicPinFoldView ?? undefined, ownershipReconciler: _ownershipReconciler ?? undefined, staleOwnerEngine: _staleOwnerEngine ?? undefined, duplicateReconciler: _duplicateReconciler ?? undefined, ownerDarkLadder: _ownerDarkLadder ?? undefined, spawnAdmission: _spawnAdmission ?? undefined, judgmentProvenance: _judgmentProvenance ?? undefined, leaseHandback: _leaseHandbackCtx ?? undefined, streamTicketStore: _streamTicketStore ?? undefined, poolStreamAllowRemoteInput: (config as { dashboard?: { poolStream?: { allowRemoteInput?: boolean } } }).dashboard?.poolStream?.allowRemoteInput ?? false, poolStreamConnector: _poolStreamConnector ?? undefined, secretSync: _secretSyncHandle ?? undefined, meshSelfId: _meshSelfId ?? undefined, resolveRouterUrl: _resolveRouterUrl ?? undefined, resolvePeerUrls: _resolvePeerUrls ?? undefined, guardRegistry, listPoolMachines: _listPoolMachines ?? undefined, deliverMandateToMachine: _deliverMandateToMachine ?? undefined, poolLink: _poolLink ?? undefined, poolPollCache: _poolPollCache ?? undefined, sessionPoolE2EResultStore, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, agentWorktreeReaper, externalHogSentinel, orphanedWorkSentinel, mcpProcessReaper, geminiLoopRunner, sleepController, agentActivityState, reapLog, resumeQueue, resumeDrainer, autonomousLivenessReconciler, enforcedTerminationStatus: () => enforcedTerminationWatchdog?.guardStatus() ?? null, prHandLease: prHandLease ?? undefined, operatorStopRecorder: recordOperatorStop, sleepWakeDetector, unjustifiedStopGate, stopGateDb, stopNotifier, liveTestGate, liveTestGateMode, liveTestRunnerCtx });    // Resolve the late-bound topic-operator getter (increment 2e): routing was
     server.setWorkQueue(workQueue);
     if (_stateSyncStoresResolved?.classReview?.enabled && replicatedPeerStreamReader) {
       const { CLASS_REVIEW_STORE_KEY, classReviewFromOriginRecord } = await import('../core/ClassReviewReplicatedStore.js');
@@ -24909,6 +24912,11 @@ export async function startServer(options: StartOptions): Promise<void> {
       // from binding; logged, and the OS releases the listening socket regardless.
       console.error('  Boot health beacon stop failed (continuing to bind real server):', err instanceof Error ? err.message : err);
     }
+    // Start session maintenance only after every authority dependency and the
+    // session-pool write posture have been installed. Starting this near initial
+    // construction left a first-tick window with no ReapGuard and, on standby,
+    // no per-session write admission.
+    sessionManager.startMonitoring();
     await server.start();
     // #1425 regression containment: only begin the cooperative witness-index +
     // parity scans AFTER the HTTP server is listening. Until publication the

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -104,6 +104,18 @@ import type { IncidentDedupe } from '../monitoring/IncidentDedupe.js';
 // flips this class to enforce (FD8).
 const ageKillGov = governor.for('age-kill-backoff');
 
+/**
+ * Unforgeable, module-private authority for one machine-local cleanup path.
+ *
+ * The serving lease governs shared/cross-machine state; it cannot make a peer
+ * clean up a tmux process that physically exists only on this machine. The
+ * over-age monitor is the sole minter of this capability, and the termination
+ * authority accepts it only with the literal `age-limit` reason. It is omitted
+ * from the public terminateSession options so ordinary autonomous callers keep
+ * the lease-holder boundary unchanged.
+ */
+const LOCAL_AGE_LIMIT_REAP_CAPABILITY = Symbol('local-age-limit-reap-capability');
+
 /** The canonical target derivation for the age-kill controller (companion §1):
  *  instar session ids are stable per topic across respawns, so the session id
  *  IS the recurrence identity — a stable key, never a per-incarnation pid. */
@@ -322,7 +334,34 @@ export interface SessionManagerOptions {
    *  A GETTER because the mesh identity resolves after SessionManager
    *  construction at server boot. Absent/null ⇒ the literal 'local'. */
   buildContextMachineId?: () => string | null;
+  /** Birth-time capability handoff. The trusted terminate closure is delivered
+   *  while this manager is constructed; no later public getter or binder exists. */
+  bindTerminateAuthority?: (authority: SessionTerminateAuthority) => void;
+  /** Test-only birth-time observation seam for the maintenance workflow. The
+   *  authority-bearing tick itself remains a JS-private method and never appears
+   *  on a live manager's runtime prototype. Production boot does not request it. */
+  bindMaintenanceTickForTesting?: (tick: () => Promise<void>) => void;
 }
+
+export interface SessionTerminateAuthorityOptions {
+  finalStatus?: 'completed' | 'killed';
+  disposition?: 'terminal' | 'recovery-bounce';
+  origin?: 'operator' | 'autonomous';
+  via?: string;
+  knownDead?: boolean;
+  bypassRecoveryFlag?: boolean;
+  bypassActiveProcessKeep?: boolean;
+  bypassRecentUserMessageForConfirmedMove?: boolean;
+  /** Trusted SessionReaper assertion after ownership/liveness/dwell clears. */
+  localPostTransferCloseout?: boolean;
+  workEvidence?: string[];
+}
+
+export type SessionTerminateAuthority = (
+  sessionId: string,
+  reason: string,
+  opts?: SessionTerminateAuthorityOptions,
+) => Promise<{ terminated: boolean; skipped?: string }>;
 
 export class SessionManager extends EventEmitter {
   private config: SessionManagerConfig;
@@ -588,6 +627,11 @@ export class SessionManager extends EventEmitter {
         machineId: opts.buildContextMachineId ?? null,
       });
     }
+    // Minted only during construction and handed into the boot composition root's
+    // lexical scope. A caller holding this manager later cannot retrieve it.
+    opts.bindTerminateAuthority?.((sessionId, reason, authorityOpts) =>
+      this.#terminateSessionInternal(sessionId, reason, authorityOpts));
+    opts.bindMaintenanceTickForTesting?.(() => this.#monitorTick());
   }
 
   /** Per-agent GitHub token env flags for spawned sessions (Phase-3 increment
@@ -991,7 +1035,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
         // no reap-log write.
         return;
       }
-      const result = await this.terminateSessionInternal(
+      const result = await this.#terminateSessionInternal(
         session.id,
         'idle-zombie',
         { disposition: 'terminal' },
@@ -1105,10 +1149,10 @@ rm()  { "${shimRunner}" rm  "$@"; }
    * false, an AUTONOMOUS terminate is a no-op `skipped:'not-lease-holder'` — only
    * the awake/lease-holding machine may autonomously reap; a standby may detect
    * and signal but never kill another machine's sessions. Operator kills bypass,
-   * and so does the topic-moved closeout (`bypassLeaseForTopicMovedCloseout` —
-   * F8: closing THIS machine's own leftover session for a topic that moved away
-   * is not "killing another machine's session", and the old owner is by
-   * definition usually not the lease holder). Unset → treated as awake
+   * and so does the runtime-private topic-moved closeout authority (F8: closing
+   * THIS machine's own leftover session for a topic that moved away is not
+   * "killing another machine's session", and the old owner is by definition
+   * usually not the lease holder). Unset → treated as awake
    * (single-machine default).
    */
   setAwakeChecker(fn: () => boolean): void {
@@ -1201,16 +1245,15 @@ rm()  { "${shimRunner}" rm  "$@"; }
    * The authority holds the safety checks so a killer can only *request* a kill:
    *  - CAS on live status + an in-flight guard (prevents the double-kill race).
    *  - `protectedSessions` (never kill).
-   *  - Lease-holder gate: an AUTONOMOUS reap on a standby machine is a no-op
-   *    `skipped:'not-lease-holder'` — only the awake machine reaps. Exception
-   *    (F8): the topic-moved closeout's `bypassLeaseForTopicMovedCloseout`
-   *    lifts ONLY this gate (see the opt's doc below).
+   *  - Lease-holder gate: an ordinary AUTONOMOUS reap on a standby machine is a
+   *    no-op `skipped:'not-lease-holder'`. Two machine-local exceptions lift
+   *    ONLY this gate: the existing F8 topic-moved closeout, and the private
+   *    over-age monitor capability for this machine's own idle process.
    *  - ReapGuard (§P2): an AUTONOMOUS reap of a session the guard says to KEEP is
    *    a no-op `skipped:<keep-reason>` — even a buggy killer cannot end a guarded
    *    session.
-   * `origin:'operator'` bypasses the lease-gate and the guard (an explicit human
-   * kill must always happen). Default `origin` is `'autonomous'` so an in-process
-   * caller can never accidentally mint operator privilege.
+   * Operator authority exists only on runtime-private internal calls. The public
+   * method is structurally autonomous; caller labels and casts cannot mint it.
    *
    * Re-entrancy: the guard is consulted BEFORE this call acquires its own
    * in-flight lock, so the authority's lock for the kill it is performing is
@@ -1229,23 +1272,33 @@ rm()  { "${shimRunner}" rm  "$@"; }
     opts?: {
       finalStatus?: 'completed' | 'killed';
       disposition?: 'terminal' | 'recovery-bounce';
-      origin?: 'operator' | 'autonomous';
       /** UNTRUSTED caller-supplied provenance claim (REMOTE-SESSION-CLOSE-SPEC
        *  §2.3) — recorded in the reap-log as `viaClaim`, NEVER consulted in any
        *  authority/bypass decision (signal-vs-authority). */
       via?: string;
-      knownDead?: boolean;
-      bypassRecoveryFlag?: boolean;
-      bypassActiveProcessKeep?: boolean;
-      bypassRecentUserMessageForConfirmedMove?: boolean;
-      bypassLeaseForTopicMovedCloseout?: boolean;
       workEvidence?: string[];
     },
   ): Promise<{ terminated: boolean; skipped?: string }> {
     // Public enforcement boundary — re-evaluates the guard itself (no precomputed
     // verdict). The single-guard-eval precompute is a PRIVATE same-tick optimization
     // used only by the idle-zombie branch (R3-1/R4-2); it is NEVER a public option.
-    return this.terminateSessionInternal(sessionId, reason, opts);
+    // Copy only inert/public fields. Do not spread the caller object: JavaScript
+    // callers can force undeclared keys through a cast, and every guard bypass is
+    // authority. Trusted lifecycle components receive a birth-bound closure.
+    return this.#terminateSessionInternal(
+      sessionId,
+      reason,
+      {
+        finalStatus: opts?.finalStatus,
+        disposition: opts?.disposition,
+        via: opts?.via,
+        workEvidence: opts?.workEvidence,
+        // Public callers are always autonomous. Explicit operator authority is
+        // confined to runtime-private call sites inside this class; labels,
+        // unknown values, and caller casts cannot bypass any guard.
+        origin: 'autonomous',
+      },
+    );
   }
 
   /**
@@ -1255,7 +1308,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
    * double-evaluated in the same tick (C2). Every OTHER caller passes it undefined
    * and the guard is evaluated here exactly as before.
    */
-  private async terminateSessionInternal(
+  async #terminateSessionInternal(
     sessionId: string,
     reason: string,
     opts?: {
@@ -1280,21 +1333,12 @@ rm()  { "${shimRunner}" rm  "$@"; }
        * fresh and still vetoes. Spec: docs/specs/post-transfer-closeout-correctness.md.
        */
       bypassRecentUserMessageForConfirmedMove?: boolean;
-      /**
-       * Post-transfer closeout carve-out (F8, roadmap 0.6,
-       * test-as-self 2026-07-02): lifts ONLY the lease-holder gate — protected,
-       * CAS, in-flight, and EVERY KEEP-guard still apply unchanged. The
-       * SessionReaper sets it ONLY on the topic-moved closeout path, where this
-       * machine is closing ITS OWN local leftover session for a topic the pool
-       * ownership registry says ANOTHER machine now owns. The lease gate exists
-       * so a standby never reaps ANOTHER machine's sessions; the post-transfer
-       * closeout is the inverse case — the machine a topic moves AWAY from is
-       * by definition usually NOT the serving-lease holder, so without this
-       * carve-out the transfer's required teardown was structurally vetoed
-       * `skipped:'not-lease-holder'` every attempt until the P19 breaker gave
-       * up, stranding a duplicate session on the old machine (audit F8).
-       */
-      bypassLeaseForTopicMovedCloseout?: boolean;
+      /** Module-private capability minted only by #terminateLocalAgeExpiredSession.
+       *  It proves the request originated in THIS SessionManager's monitor over
+       *  THIS machine's state tree and local tmux namespace. Never public. */
+      localAgeLimitReapCapability?: typeof LOCAL_AGE_LIMIT_REAP_CAPABILITY;
+      /** Birth-bound SessionReaper assertion after ownership/liveness/dwell. */
+      localPostTransferCloseout?: boolean;
       /**
        * Killer-supplied work evidence (reap-notify spec R2.1): computed at the
        * KILLER's decision point — the only moment the work was observable (the
@@ -1321,16 +1365,39 @@ rm()  { "${shimRunner}" rm  "$@"; }
 
     const origin = opts?.origin ?? 'autonomous';
     const disposition = opts?.disposition ?? 'terminal';
+    const holdsServingLease = origin === 'operator'
+      || !this.isAwakeMachine
+      || this.isAwakeMachine();
+    const requestedLocalAgeLimit = reason === 'age-limit'
+      && opts?.localAgeLimitReapCapability === LOCAL_AGE_LIMIT_REAP_CAPABILITY;
+    // The local-process capability is usable only after the full KEEP guard is
+    // installed and the exact durable session transition is currently admitted.
+    // This closes both startup windows: no guard means no local authority, and a
+    // pure read-only standby never kills tmux before discovering saveSession will
+    // be refused. The real write re-checks admission again before the process kill.
+    let isAuthorizedLocalAgeLimit = false;
+    if (requestedLocalAgeLimit && this.reapGuard) {
+      try {
+        this.state.assertSessionWriteAllowed(session);
+        isAuthorizedLocalAgeLimit = true;
+      } catch {
+        // Not locally owned/writable in the current posture: the normal lease
+        // boundary below remains authoritative.
+      }
+    }
+    const isAuthorizedTopicMovedCloseout = reason.startsWith('topic moved')
+      && opts?.localPostTransferCloseout === true;
+    const authorityScope = origin === 'operator'
+      ? 'operator' as const
+      : holdsServingLease
+        ? 'lease-holder' as const
+        : isAuthorizedLocalAgeLimit
+          ? 'local-age-limit' as const
+          : 'local-post-transfer-closeout' as const;
 
     // ── Authority gates (autonomous only; operator bypasses) ──
-    // An `origin:'operator'` kill — stamped ONLY by the Bearer-authed HTTP route
-    // layer and by the transfer handler executing the user's explicit
-    // "move this to <machine>" command (post-transfer closeout, 2026-06-05) —
-    // must always happen: the user commanded it. It bypasses protected, the
-    // lease gate, and the KEEP-guard. (The transfer handler additionally skips
-    // protected sessions BEFORE calling, so the bypass never reaches them on
-    // that path.) Autonomous killers (the default) can only *request*; the
-    // authority holds the safety checks.
+    // Runtime-private `origin:'operator'` calls may bypass these gates. Every
+    // call through public terminateSession is normalized to autonomous above.
     if (origin === 'autonomous') {
       // Protected set — never autonomously reap a protected session.
       if (this.config.protectedSessions.includes(session.tmuxSession)) {
@@ -1338,14 +1405,20 @@ rm()  { "${shimRunner}" rm  "$@"; }
         return { terminated: false, skipped: 'protected' };
       }
       // Lease-holder gate: a standby machine never reaps another machine's sessions.
-      // F8 carve-out: the topic-moved closeout is exempt — it closes THIS
+      // F8 carve-out: the runtime-private topic-moved closeout is exempt — it closes THIS
       // machine's OWN leftover session for a topic that moved AWAY (the old
       // owner is by definition usually not the lease holder, so the gate
       // structurally vetoed the exact teardown the transfer requires). The
-      // flag lifts ONLY this gate; protected (above) and the KEEP-guard
-      // cascade (below) are unaffected.
-      if (this.isAwakeMachine && !this.isAwakeMachine()
-          && !opts?.bypassLeaseForTopicMovedCloseout) {
+      // capability lifts ONLY this gate; protected (above) and the KEEP-guard
+      // cascade (below) are unaffected. No public caller can supply it.
+      // Local age-limit carve-out: the private monitor capability authorizes
+      // cleanup of a process in THIS manager's machine-local state/tmux tree.
+      // A peer cannot perform that cleanup remotely, and the capability is not
+      // part of terminateSession's public options. The literal reason check is
+      // defense in depth against capability reuse for another kill class.
+      if (!holdsServingLease
+          && !isAuthorizedTopicMovedCloseout
+          && !isAuthorizedLocalAgeLimit) {
         this.emit('reapBlocked', { session, reason, skipped: 'not-lease-holder', origin });
         return { terminated: false, skipped: 'not-lease-holder' };
       }
@@ -1462,29 +1535,118 @@ rm()  { "${shimRunner}" rm  "$@"; }
       }
       const midWork = isMidWork(workEvidence);
 
-      // Emit BEFORE destroying tmux so listeners (TopicResumeMap, SlackAdapter)
-      // can capture resume UUIDs while the session is still alive.
-      this.emit('beforeSessionKill', session);
-      try {
-        await execFileAsync(this.config.tmuxPath, ['kill-session', '-t', `=${session.tmuxSession}`]);
-      } catch { /* session may already be dead */ }
-      session.status = opts?.finalStatus ?? 'completed';
-      session.endedAt = new Date().toISOString();
-      session.endedReason = reason;
+      const endedSession: Session = {
+        ...session,
+        status: opts?.finalStatus ?? 'completed',
+        endedAt: new Date().toISOString(),
+        endedReason: reason,
+      };
       if (!opts?.knownDead) {
-        session.endedMidWork = midWork;
-        if (workEvidence.length > 0) session.endedWorkEvidence = workEvidence;
+        endedSession.endedMidWork = midWork;
+        if (workEvidence.length > 0) endedSession.endedWorkEvidence = workEvidence;
       }
-      this.state.saveSession(session);
-      this.emit('sessionComplete', session);
+      const usesLocalProcessAuthority = origin === 'operator'
+        || isAuthorizedLocalAgeLimit
+        || isAuthorizedTopicMovedCloseout;
+      // Continuity observers inspect the still-live process before the terminal
+      // commit, but are never cleanup authority. Invoke each independently so a
+      // faulty observer cannot suppress the rest. If a listener changes write
+      // admission, the immediately-following save fails closed before tmux.
+      this.#emitListenersIsolated('beforeSessionKill', session);
+
+      // Every real kill uses one write-first, bounded-synchronous protocol. This
+      // removes the ordinary lease-holder branch's former await window (tmux gone
+      // before a late ownership/write refusal) and gives local nonholder cleanup
+      // the same state/process ordering. saveSession rechecks admission here.
+      try {
+        this.state.saveSession(endedSession);
+      } catch {
+        const skipped = usesLocalProcessAuthority ? 'local-write-refused' : 'state-write-refused';
+        this.emit('reapBlocked', { session, reason, skipped, origin });
+        return { terminated: false, skipped };
+      }
+
+      try {
+        // No event-loop turn exists between the terminal commit and the local
+        // process action. The timeout bounds tmux transport failure.
+        withSyncOp(() => execFileSync(
+          this.config.tmuxPath,
+          ['kill-session', '-t', `=${session.tmuxSession}`],
+          // SIGTERM is not a real bound for a wedged tmux client: it can ignore
+          // the default signal and keep execFileSync blocking the event loop.
+          // Match the async hot-path invariant and enforce the timeout with KILL.
+          { encoding: 'utf-8', timeout: this.tmuxCallTimeoutMs, killSignal: 'SIGKILL' },
+        ));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const definitelyAbsent = /can't find session|no such session|no server running|session not found/i.test(message);
+        if (!definitelyAbsent) {
+          // The process may still be alive. Compensate the write-first record
+          // back to its exact live snapshot and never emit a false reap event.
+          let compensationFailed = false;
+          try {
+            this.state.saveSession(session);
+          } catch (rollbackErr) {
+            compensationFailed = true;
+            console.error('[SessionManager] cleanup kill failed and state compensation also failed:', rollbackErr);
+          }
+          const skipped = compensationFailed
+            ? 'tmux-kill-failed-compensation-failed'
+            : 'tmux-kill-failed';
+          this.emit('reapBlocked', { session, reason, skipped, origin });
+          return { terminated: false, skipped };
+        }
+      }
+      // The process is gone and the terminal state is durable. Lifecycle
+      // observers run independently from here onward: a listener exception must
+      // never turn a successful kill into a rejected promise or suppress the
+      // durable reap audit emitted by a later listener.
+      this.#emitListenersIsolated('sessionComplete', endedSession);
       // The single reap-notification signal (§P3): terminal reaps may reach the
       // user; recovery-bounce reaps are silent. One emission, at the one chokepoint.
-      this.emit('sessionReaped', { session, reason, disposition, origin, midWork, workEvidence, ...(opts?.via ? { via: opts.via } : {}) });
+      this.#emitListenersIsolated('sessionReaped', {
+        session: endedSession,
+        reason,
+        disposition,
+        origin,
+        authorityScope,
+        midWork,
+        workEvidence,
+        ...(opts?.via ? { via: opts.via } : {}),
+      });
       this.idlePromptSince.delete(session.id);
       this.reapingSessions.delete(session.id);
       return { terminated: true };
     } finally {
       this.terminating.delete(sessionId);
+    }
+  }
+
+  /**
+   * The only non-lease-holder age-limit entrypoint. The caller is the local
+   * maintenance loop after it has independently proven age and positive idle.
+   * All remaining termination authority checks are re-evaluated downstream.
+   */
+  #terminateLocalAgeExpiredSession(sessionId: string): Promise<{ terminated: boolean; skipped?: string }> {
+    return this.#terminateSessionInternal(sessionId, 'age-limit', {
+      finalStatus: 'killed',
+      disposition: 'terminal',
+      localAgeLimitReapCapability: LOCAL_AGE_LIMIT_REAP_CAPABILITY,
+    });
+  }
+
+  /**
+   * Deliver an irreversible-transition lifecycle event to every listener even
+   * when one observer throws. `rawListeners` preserves EventEmitter's `once`
+   * wrapper semantics while direct invocation lets us isolate each callback.
+   */
+  #emitListenersIsolated(eventName: string, ...args: unknown[]): void {
+    for (const listener of this.rawListeners(eventName)) {
+      try {
+        Reflect.apply(listener, this, args);
+      } catch (err) {
+        console.error(`[SessionManager] ${eventName} listener failed; lifecycle transition remains authoritative:`, err);
+      }
     }
   }
 
@@ -1618,13 +1780,13 @@ rm()  { "${shimRunner}" rm  "$@"; }
     this.monitorInterval = setInterval(() => {
       // Prevent overlapping monitor ticks
       if (this.monitoringInProgress) return;
-      this.monitorTick().catch(err => {
+      this.#monitorTick().catch(err => {
         console.error(`[SessionManager] Monitor tick error: ${err}`);
       });
     }, intervalMs);
   }
 
-  private async monitorTick(): Promise<void> {
+  async #monitorTick(): Promise<void> {
     this.monitoringInProgress = true;
     try {
       const running = this.state.listSessions({ status: 'running' });
@@ -1858,14 +2020,12 @@ rm()  { "${shimRunner}" rm  "$@"; }
               }
               // Route through the single ReapAuthority (§P0) instead of an inline
               // kill: this restores the beforeSessionKill/sessionComplete emission,
-              // adds the sessionReaped signal + reap-log entry, applies the lease
-              // gate, and — critically — gains the P2 KEEP-guard's topic-bound
-              // grace, so a session that just received a user message is not
-              // age-killed out from under the user.
-              const ageKillResult = await this.terminateSession(session.id, 'age-limit', {
-                finalStatus: 'killed',
-                disposition: 'terminal',
-              });
+              // adds the sessionReaped signal + reap-log entry, applies the
+              // authority boundary (lease-holder or this private local-process
+              // capability), and — critically — gains the P2 KEEP-guard's
+              // topic-bound grace, so a session that just received a user
+              // message is not age-killed out from under the user.
+              const ageKillResult = await this.#terminateLocalAgeExpiredSession(session.id);
               if (ageKillResult.terminated) {
                 // Actually killed — drop any back-off state for the (now gone) session.
                 this.ageKillBackoff.recordKilled(session.id);
@@ -3957,7 +4117,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
         // KEEP-guard is bypassed via `knownDead` — the oracle has already proven
         // this session dead, and the guard's liveness-blind topic-state KEEPs would
         // otherwise pin a tombstone and re-create the death-spiral.
-        const r = await this.terminateSession(session.id, 'boot-purge-dead', {
+        const r = await this.#terminateSessionInternal(session.id, 'boot-purge-dead', {
           knownDead: true,
           finalStatus: 'completed',
         });
@@ -3972,7 +4132,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
         // the job reruns cleanly with fresh run-tracking; adopting an orphan REPL
         // whose run-id we no longer hold would silently never finalize). Operator
         // kill so the lease/KEEP-guards don't pin the orphan.
-        const r = await this.terminateSession(session.id, 'boot-reconcile-rerouted-job', {
+        const r = await this.#terminateSessionInternal(session.id, 'boot-reconcile-rerouted-job', {
           finalStatus: 'killed',
           disposition: 'terminal',
           origin: 'operator',

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -1554,10 +1554,12 @@ rm()  { "${shimRunner}" rm  "$@"; }
       // admission, the immediately-following save fails closed before tmux.
       this.#emitListenersIsolated('beforeSessionKill', session);
 
-      // Every real kill uses one write-first, bounded-synchronous protocol. This
+      // Every live-process kill uses one write-first, bounded-synchronous protocol. This
       // removes the ordinary lease-holder branch's former await window (tmux gone
       // before a late ownership/write refusal) and gives local nonholder cleanup
-      // the same state/process ordering. saveSession rechecks admission here.
+      // the same state/process ordering. A `knownDead` oracle verdict needs only
+      // the durable transition: by definition there is no tmux process to kill.
+      // saveSession rechecks admission here.
       try {
         this.state.saveSession(endedSession);
       } catch {
@@ -1566,35 +1568,37 @@ rm()  { "${shimRunner}" rm  "$@"; }
         return { terminated: false, skipped };
       }
 
-      try {
-        // No event-loop turn exists between the terminal commit and the local
-        // process action. The timeout bounds tmux transport failure.
-        withSyncOp(() => execFileSync(
-          this.config.tmuxPath,
-          ['kill-session', '-t', `=${session.tmuxSession}`],
-          // SIGTERM is not a real bound for a wedged tmux client: it can ignore
-          // the default signal and keep execFileSync blocking the event loop.
-          // Match the async hot-path invariant and enforce the timeout with KILL.
-          { encoding: 'utf-8', timeout: this.tmuxCallTimeoutMs, killSignal: 'SIGKILL' },
-        ));
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        const definitelyAbsent = /can't find session|no such session|no server running|session not found/i.test(message);
-        if (!definitelyAbsent) {
-          // The process may still be alive. Compensate the write-first record
-          // back to its exact live snapshot and never emit a false reap event.
-          let compensationFailed = false;
-          try {
-            this.state.saveSession(session);
-          } catch (rollbackErr) {
-            compensationFailed = true;
-            console.error('[SessionManager] cleanup kill failed and state compensation also failed:', rollbackErr);
+      if (!opts?.knownDead) {
+        try {
+          // No event-loop turn exists between the terminal commit and the local
+          // process action. The timeout bounds tmux transport failure.
+          withSyncOp(() => execFileSync(
+            this.config.tmuxPath,
+            ['kill-session', '-t', `=${session.tmuxSession}`],
+            // SIGTERM is not a real bound for a wedged tmux client: it can ignore
+            // the default signal and keep execFileSync blocking the event loop.
+            // Match the async hot-path invariant and enforce the timeout with KILL.
+            { encoding: 'utf-8', timeout: this.tmuxCallTimeoutMs, killSignal: 'SIGKILL' },
+          ));
+        } catch (err) {
+          const killErrorText = err instanceof Error ? err.message : String(err);
+          const definitelyAbsent = /can't find session|no such session|no server running|session not found/i.test(killErrorText);
+          if (!definitelyAbsent) {
+            // The process may still be alive. Compensate the write-first record
+            // back to its exact live snapshot and never emit a false reap event.
+            let compensationFailed = false;
+            try {
+              this.state.saveSession(session);
+            } catch (rollbackErr) {
+              compensationFailed = true;
+              console.error('[SessionManager] cleanup kill failed and state compensation also failed:', rollbackErr);
+            }
+            const skipped = compensationFailed
+              ? 'tmux-kill-failed-compensation-failed'
+              : 'tmux-kill-failed';
+            this.emit('reapBlocked', { session, reason, skipped, origin });
+            return { terminated: false, skipped };
           }
-          const skipped = compensationFailed
-            ? 'tmux-kill-failed-compensation-failed'
-            : 'tmux-kill-failed';
-          this.emit('reapBlocked', { session, reason, skipped, origin });
-          return { terminated: false, skipped };
         }
       }
       // The process is gone and the terminal state is durable. Lifecycle
@@ -1644,7 +1648,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
     for (const listener of this.rawListeners(eventName)) {
       try {
         Reflect.apply(listener, this, args);
-      } catch (err) {
+      } catch (err) { // @silent-fallback-ok — observer isolation is deliberate; the fault is surfaced and cannot roll back an authoritative lifecycle transition
         console.error(`[SessionManager] ${eventName} listener failed; lifecycle transition remains authoritative:`, err);
       }
     }

--- a/src/core/StateManager.ts
+++ b/src/core/StateManager.ts
@@ -135,6 +135,19 @@ export class StateManager {
   }
 
   /**
+   * Assert that the exact saveSession write for this session is currently
+   * admissible, without mutating state. Destructive local-process cleanup uses
+   * this before touching tmux so a read-only or ownership-refused standby can
+   * never kill first and discover the durable write refusal afterward.
+   */
+  assertSessionWriteAllowed(session: Pick<Session, 'id' | 'tmuxSession'>): void {
+    this.guardWrite('saveSession', {
+      sessionScoped: true,
+      scope: { sessionId: session.tmuxSession || session.id },
+    });
+  }
+
+  /**
    * ONE-WAY attach of the standby-write-reconciliation admission layer
    * (docs/specs/standby-write-reconciliation.md §3.2 pre-construction window):
    * StateManager exists and takes writes long before the pool block that
@@ -264,7 +277,7 @@ export class StateManager {
   saveSession(session: Session): void {
     // Scope resolution is the CALLER's job with data already in hand (§3.1
     // keying note): the tmux session name keys the in-memory topic binding.
-    this.guardWrite('saveSession', { sessionScoped: true, scope: { sessionId: session.tmuxSession || session.id } });
+    this.assertSessionWriteAllowed(session);
     this.validateKey(session.id, 'sessionId');
     // One-running-record-per-tmux invariant (ghost-record fix): registering a
     // record as live for a tmux name supersedes any OTHER record still marked

--- a/src/monitoring/ReapLog.ts
+++ b/src/monitoring/ReapLog.ts
@@ -87,6 +87,8 @@ export interface ReapLogEntry {
    *  or notify:<outcome>. */
   disposition: 'terminal' | 'recovery-bounce' | `skipped:${string}` | `notify:${string}`;
   origin?: 'operator' | 'autonomous';
+  /** Which authority domain admitted the reap. Optional on legacy rows. */
+  authorityScope?: 'lease-holder' | 'local-age-limit' | 'local-post-transfer-closeout' | 'operator';
   /** UNTRUSTED caller-supplied provenance claim (REMOTE-SESSION-CLOSE-SPEC §2.3)
    *  — e.g. 'remote-dashboard' from a relayed close. A label any token holder
    *  could set; recorded as a signal for the audit trail, NEVER consulted in
@@ -182,6 +184,7 @@ export class ReapLog {
     reason: string;
     disposition?: 'terminal' | 'recovery-bounce';
     origin?: 'operator' | 'autonomous';
+    authorityScope?: 'lease-holder' | 'local-age-limit' | 'local-post-transfer-closeout' | 'operator';
     viaClaim?: string;
     launchLane?: 'headless' | 'rerouted-interactive';
     midWork?: boolean;
@@ -196,6 +199,7 @@ export class ReapLog {
       reason: e.reason,
       disposition: e.disposition ?? 'terminal',
       origin: e.origin,
+      ...(e.authorityScope ? { authorityScope: e.authorityScope } : {}),
       ...(e.viaClaim ? { viaClaim: e.viaClaim } : {}),
       machine: this.machineId?.(),
       ...(e.launchLane ? { launchLane: e.launchLane } : {}),
@@ -371,6 +375,16 @@ export class ReapLog {
       entry.launchLane === 'headless' || entry.launchLane === 'rerouted-interactive'
         ? entry.launchLane
         : undefined;
+    const authorityScope =
+      entry.authorityScope === 'lease-holder'
+      || entry.authorityScope === 'local-age-limit'
+      || entry.authorityScope === 'local-post-transfer-closeout'
+      || entry.authorityScope === 'operator'
+        ? entry.authorityScope
+        : undefined;
+    const origin = entry.origin === 'operator' || entry.origin === 'autonomous'
+      ? entry.origin
+      : undefined;
     const workEvidence = Array.isArray(entry.workEvidence)
       ? entry.workEvidence.filter((v): v is string => typeof v === 'string')
       : undefined;
@@ -382,9 +396,10 @@ export class ReapLog {
       tmuxSession: typeof entry.tmuxSession === 'string' ? entry.tmuxSession : 'unknown',
       reason: typeof entry.reason === 'string' ? entry.reason : 'unknown',
       disposition,
-      origin: entry.origin,
+      origin,
       skipped,
       machine: entry.machine,
+      ...(authorityScope ? { authorityScope } : {}),
       ...(launchLane ? { launchLane } : {}),
       ...(typeof entry.midWork === 'boolean' ? { midWork: entry.midWork } : {}),
       ...(workEvidence && workEvidence.length > 0 ? { workEvidence } : {}),

--- a/src/monitoring/SessionReaper.ts
+++ b/src/monitoring/SessionReaper.ts
@@ -339,15 +339,9 @@ export interface SessionReaperDeps {
        *  ONLY on a liveness-CONFIRMED genuine move so a duplicate leftover with a
        *  pre-move "recent" message can shed. */
       bypassRecentUserMessageForConfirmedMove?: boolean;
-      /** Post-transfer closeout carve-out (F8, roadmap 0.6): lifts ONLY the
-       *  authority's lease-holder gate — the machine a topic moves AWAY from is
-       *  by definition usually NOT the serving-lease holder, so without this
-       *  the closeout of its own leftover session was structurally vetoed
-       *  `skipped:'not-lease-holder'` on every attempt. Set on EVERY closeout
-       *  terminate (legacy + gated): the target is always THIS machine's own
-       *  local session for a topic owned elsewhere. Protected + KEEP-guards
-       *  are unaffected. */
-      bypassLeaseForTopicMovedCloseout?: boolean;
+      /** Trusted closeout assertion. This option reaches only the birth-bound
+       *  SessionManager authority closure held by production boot wiring. */
+      localPostTransferCloseout?: boolean;
       workEvidence?: string[];
     },
   ) => Promise<{ terminated: boolean; skipped?: string }>;
@@ -407,7 +401,7 @@ export type TopicMovedStreakValue =
 
 export class SessionReaper extends EventEmitter {
   private readonly cfg: SessionReaperConfig;
-  private readonly deps: SessionReaperDeps;
+  readonly #deps: Readonly<SessionReaperDeps>;
   private readonly now: () => number;
   private timer?: NodeJS.Timeout;
   private running = false;
@@ -450,7 +444,7 @@ export class SessionReaper extends EventEmitter {
 
   constructor(deps: SessionReaperDeps, cfg?: Partial<SessionReaperConfig>) {
     super();
-    this.deps = deps;
+    this.#deps = Object.freeze({ ...deps });
     this.cfg = { ...DEFAULT_SESSION_REAPER_CONFIG, ...(cfg ?? {}) };
     this.now = deps.now ?? (() => Date.now());
     this.guard = new ReapGuard(deps, {
@@ -465,7 +459,7 @@ export class SessionReaper extends EventEmitter {
     // (the long idle clock) + lastFrame/lastTranscript (render-stasis continuity)
     // survive; every tick still re-checks all-clear + frame-stasis before reaping.
     try {
-      const restored = this.deps.loadCandidacy?.();
+      const restored = this.#deps.loadCandidacy?.();
       if (restored) {
         for (const [id, o] of Object.entries(restored)) {
           if (!o || typeof o.candidateSince !== 'number') continue;
@@ -477,11 +471,11 @@ export class SessionReaper extends EventEmitter {
 
   /** Serialize the in-memory candidacy map for durable persistence (A). */
   private persistCandidacy(): void {
-    if (!this.deps.saveCandidacy) return;
+    if (!this.#deps.saveCandidacy) return;
     try {
       const out: Record<string, Obs> = {};
       for (const [id, o] of this.obs.entries()) out[id] = o;
-      this.deps.saveCandidacy(out);
+      this.#deps.saveCandidacy(out);
     } catch { /* @silent-fallback-ok — a failed persist just resets the clock next restart */ }
   }
 
@@ -501,8 +495,8 @@ export class SessionReaper extends EventEmitter {
   }
 
   private probe(session: Session): TranscriptProbe {
-    if (this.deps.probeTranscript) return this.deps.probeTranscript(session);
-    const framework = session.framework ?? this.deps.frameworkForSession(session.tmuxSession) ?? 'claude-code';
+    if (this.#deps.probeTranscript) return this.#deps.probeTranscript(session);
+    const framework = session.framework ?? this.#deps.frameworkForSession(session.tmuxSession) ?? 'claude-code';
     // Claude uses claudeSessionId; Codex's transcript is globbed by its session
     // id which we do not separately track → unresolved → KEEP (safe).
     const sessionId = framework === 'claude-code' ? (session.claudeSessionId ?? '') : '';
@@ -512,7 +506,7 @@ export class SessionReaper extends EventEmitter {
     // transcript-unresolved → the reaper could never PROVE a session idle and kept
     // everything (2026-06-06 grounding). Inject it via `transcriptProjectDir`; an
     // absent/wrong value still resolves to unresolved → KEEP (safe).
-    const projectDir = this.deps.transcriptProjectDir?.() ?? '';
+    const projectDir = this.#deps.transcriptProjectDir?.() ?? '';
     return probeTranscript({ framework, sessionId, projectDir });
   }
 
@@ -558,8 +552,8 @@ export class SessionReaper extends EventEmitter {
    * positive-idle + activeness checks.
    */
   evaluate(session: Session, opts?: { cpuFlat?: boolean }): SessionEvaluation {
-    const framework = session.framework ?? this.deps.frameworkForSession(session.tmuxSession);
-    const frame = safeCapture(this.deps, session.tmuxSession, this.cfg.paneCaptureLines);
+    const framework = session.framework ?? this.#deps.frameworkForSession(session.tmuxSession);
+    const frame = safeCapture(this.#deps, session.tmuxSession, this.cfg.paneCaptureLines);
     const transcript = this.probe(session);
     let cpuTightened = false;
     let busyOrphanSuspect = false;
@@ -572,10 +566,10 @@ export class SessionReaper extends EventEmitter {
     // An 8h-silent session is treated as abandoned (Justin's "no message today"
     // rule) — see the active-process relax below. Unbindable topic ⇒ NOT stale
     // (conservative: never relax a veto on a session we can't time-bound).
-    const staleTopicId = this.deps.topicBinding(session.tmuxSession);
+    const staleTopicId = this.#deps.topicBinding(session.tmuxSession);
     const staleIdle = this.cfg.reapStaleIdleWithActiveChildren
       && staleTopicId != null
-      && !this.deps.recentUserMessage(staleTopicId, this.cfg.staleCommitmentWindowMinutes * 60_000);
+      && !this.#deps.recentUserMessage(staleTopicId, this.cfg.staleCommitmentWindowMinutes * 60_000);
 
     // ── Stateless KEEP-guards (§P2): protected, spawn-grace, recovery,
     //    pending-injection, relay-lease, recent-user, open-commitment,
@@ -656,11 +650,11 @@ export class SessionReaper extends EventEmitter {
     // (uses cpuFlat===true to relax) or busyOrphanDetection (uses cpuFlat===false
     // to flag). Off-pressure / no dep ⇒ undefined (no tighten, no flag).
     if ((!this.cfg.cpuAwareActiveProcessKeep && !this.cfg.busyOrphanDetection)
-        || tier === 'normal' || !this.deps.descendantCpuSeconds) {
+        || tier === 'normal' || !this.#deps.descendantCpuSeconds) {
       return undefined;
     }
     let sec: number;
-    try { sec = this.deps.descendantCpuSeconds(session.tmuxSession); }
+    try { sec = this.#deps.descendantCpuSeconds(session.tmuxSession); }
     catch { return undefined; }
     if (!Number.isFinite(sec)) return undefined;
     const at = this.now();
@@ -715,17 +709,17 @@ export class SessionReaper extends EventEmitter {
    * liveness check, no Part E bypass. Returns whether the session was terminated +
    * the running reap count.
    */
-  private async runCloseoutLegacy(
+  async #runCloseoutLegacy(
     session: Session,
     reapedThisTick: number,
   ): Promise<{ terminated: boolean; reapedThisTick: number }> {
     let otherOwner: string | null = null;
     let pinnedHere = false;
     try {
-      const topicId = this.deps.topicBinding(session.tmuxSession);
-      otherOwner = topicId != null ? (this.deps.topicOwnerElsewhere?.(topicId) ?? null) : null;
+      const topicId = this.#deps.topicBinding(session.tmuxSession);
+      otherOwner = topicId != null ? (this.#deps.topicOwnerElsewhere?.(topicId) ?? null) : null;
       // WS1.3: pin-conflict = do-not-act (reconcile mid-flight TOWARD us).
-      pinnedHere = topicId != null && (this.deps.topicPinnedHere?.(topicId) ?? false);
+      pinnedHere = topicId != null && (this.#deps.topicPinnedHere?.(topicId) ?? false);
     } catch { otherOwner = null; /* @silent-fallback-ok — ownership signal failed → cannot reason → skip rule (safe withhold direction) */ }
 
     if (otherOwner && pinnedHere) {
@@ -742,7 +736,7 @@ export class SessionReaper extends EventEmitter {
       this.topicMovedStreak.set(session.id, streak);
       if (streak >= this.cfg.topicMovedConfirmTicks) {
         const reason = `topic moved to ${otherOwner} — closing the leftover session on this machine (post-transfer closeout)`;
-        return this.attemptCloseoutTerminate({
+        return this.#attemptCloseoutTerminate({
           session, otherOwner, reason, streak,
           key: session.id, reapedThisTick, bypassRecentForMove: false,
         });
@@ -768,7 +762,7 @@ export class SessionReaper extends EventEmitter {
    * Maps are keyed on the stable TOPIC id (Secondary fix) with the richer streak
    * struct so the dwell advances only across DISTINCT snapshot generations.
    */
-  private async runCloseoutGated(
+  async #runCloseoutGated(
     session: Session,
     reapedThisTick: number,
   ): Promise<{ terminated: boolean; reapedThisTick: number }> {
@@ -776,11 +770,11 @@ export class SessionReaper extends EventEmitter {
     let owner: { machineId: string; displayName: string } | null = null;
     let pinnedHere = false;
     try {
-      topicId = this.deps.topicBinding(session.tmuxSession);
+      topicId = this.#deps.topicBinding(session.tmuxSession);
       // The gated path REQUIRES the combined dep — it never falls back to the
       // display-only one. Absent ⇒ owner stays null ⇒ withhold (fail-closed below).
-      owner = topicId != null ? (this.deps.topicOwnerElsewhereInfo?.(topicId) ?? null) : null;
-      pinnedHere = topicId != null && (this.deps.topicPinnedHere?.(topicId) ?? false);
+      owner = topicId != null ? (this.#deps.topicOwnerElsewhereInfo?.(topicId) ?? null) : null;
+      pinnedHere = topicId != null && (this.#deps.topicPinnedHere?.(topicId) ?? false);
     } catch { owner = null; /* @silent-fallback-ok — ownership signal failed → cannot reason → skip rule (safe withhold direction) */ }
 
     // topicId null → no participation (also covers the topicOwnerElsewhereInfo-absent
@@ -805,8 +799,8 @@ export class SessionReaper extends EventEmitter {
       // ── Part C: liveness gate ──────────────────────────────────────────────
       let liveness: { state: boolean | 'unknown'; reachableAt?: number };
       try {
-        liveness = this.deps.remoteOwnerHasLiveSession
-          ? this.deps.remoteOwnerHasLiveSession(topicId, owner.machineId)
+        liveness = this.#deps.remoteOwnerHasLiveSession
+          ? this.#deps.remoteOwnerHasLiveSession(topicId, owner.machineId)
           : { state: 'unknown' }; // dep absent under gate → fail-closed
       } catch {
         liveness = { state: 'unknown' }; // a throw is treated as 'unknown'
@@ -863,10 +857,10 @@ export class SessionReaper extends EventEmitter {
         // Part E: pass the narrow bypass ONLY when the topic's freshest LOCAL user
         // message is OLDER than the snapshot reachableAt (freshest-interaction veto).
         const lastUserMsgAt = (() => {
-          try { return this.deps.recentUserMessageAt?.(topicId) ?? null; } catch { return null; /* @silent-fallback-ok — recent-msg signal failed → treat as no recent message → bypass not granted (safe) */ }
+          try { return this.#deps.recentUserMessageAt?.(topicId) ?? null; } catch { return null; /* @silent-fallback-ok — recent-msg signal failed → treat as no recent message → bypass not granted (safe) */ }
         })();
         const bypassRecentForMove = lastUserMsgAt == null || lastUserMsgAt <= reachableAt;
-        return this.attemptCloseoutTerminate({
+        return this.#attemptCloseoutTerminate({
           session, otherOwner: owner.displayName, reason, streak: count,
           key, reapedThisTick, bypassRecentForMove,
           confirmedMove: true, snapshotReachableAt: reachableAt,
@@ -890,7 +884,7 @@ export class SessionReaper extends EventEmitter {
    * audit. `key` is session.id (legacy) or the topic id (gated); `bypassRecentForMove`
    * is passed through to terminate ONLY on a liveness-confirmed genuine move.
    */
-  private async attemptCloseoutTerminate(args: {
+  async #attemptCloseoutTerminate(args: {
     session: Session;
     otherOwner: string;
     reason: string;
@@ -916,17 +910,13 @@ export class SessionReaper extends EventEmitter {
       return { terminated: false, reapedThisTick };
     }
     if (reapedThisTick < this.cfg.maxReapsPerTick && this.hourlyBudgetRemaining() > 0) {
-      // F8 carve-out: EVERY closeout terminate carries the lease bypass — the
-      // topic provably moved AWAY from this machine (ownership signal + dwell),
-      // so this machine is usually no longer the lease holder, yet the session
-      // being closed is its OWN local leftover. Without the flag the authority
-      // vetoed the closeout `skipped:'not-lease-holder'` until the P19 breaker
-      // gave up (audit F8, test-as-self 2026-07-02). `workEvidence` semantics
-      // are unchanged: killer-authoritative [] only on the liveness-confirmed
-      // Part E path, guard-collected otherwise.
-      const res = await this.deps.terminate(session.id, reason, bypassRecentForMove
-        ? { bypassRecentUserMessageForConfirmedMove: true, workEvidence: [], bypassLeaseForTopicMovedCloseout: true }
-        : { bypassLeaseForTopicMovedCloseout: true });
+      // F8 carve-out: this assertion is emitted only after the ownership+dwell
+      // transition above. Production wires this private dependency to the
+      // SessionManager authority closure captured at manager construction;
+      // public terminateSession drops the same-shaped forged option.
+      const res = await this.#deps.terminate(session.id, reason, bypassRecentForMove
+        ? { bypassRecentUserMessageForConfirmedMove: true, workEvidence: [], localPostTransferCloseout: true }
+        : { localPostTransferCloseout: true });
       if (res.terminated) {
         reapedThisTick++;
         this.reapTimestamps.push(this.now());
@@ -949,8 +939,8 @@ export class SessionReaper extends EventEmitter {
         this.audit('closeout-breaker-open', session, {
           rule: 'topic-moved-away', otherOwner, vetoedAttempts: v, lastSkipped: res.skipped ?? 'keep-guard',
         });
-        const topicId = this.deps.topicBinding(session.tmuxSession);
-        this.deps.raiseAttention?.({
+        const topicId = this.#deps.topicBinding(session.tmuxSession);
+        this.#deps.raiseAttention?.({
           id: `closeout-breaker:${session.id}`,
           title: `Topic ${topicId ?? '?'} moved to ${otherOwner}, but the old session won't close`,
           summary: `Post-transfer closeout gave up after ${v} vetoed attempts (held by: ${res.skipped ?? 'keep-guard'}).`,
@@ -966,12 +956,12 @@ export class SessionReaper extends EventEmitter {
     this.running = true;
     this.lastTickAt = this.now();
     try {
-      const pressure = this.deps.pressure();
+      const pressure = this.#deps.pressure();
       const threshold = this.thresholdMs(pressure.tier);
-      const sessions = this.deps.listRunningSessions();
+      const sessions = this.#deps.listRunningSessions();
       const live = new Set(sessions.map(s => s.id));
       // GC obs for vanished sessions.
-      for (const id of [...this.obs.keys()]) if (!live.has(id)) { this.obs.delete(id); this.deps.clearReaping(id); }
+      for (const id of [...this.obs.keys()]) if (!live.has(id)) { this.obs.delete(id); this.#deps.clearReaping(id); }
       for (const id of [...this.lastAuditedDecision.keys()]) if (!live.has(id)) this.lastAuditedDecision.delete(id);
       for (const id of [...this.cpuSamples.keys()]) if (!live.has(id)) this.cpuSamples.delete(id);
       for (const id of [...this.busyOrphanStreak.keys()]) if (!live.has(id)) this.busyOrphanStreak.delete(id);
@@ -984,7 +974,7 @@ export class SessionReaper extends EventEmitter {
         // window (2× tickIntervalSec — survives one full respawn gap). `lastSeenAt`
         // is stamped on every entry whenever its topic is bound/owned-elsewhere.
         const liveTopics = new Set<number>();
-        for (const s of sessions) { const t = this.deps.topicBinding(s.tmuxSession); if (t != null) liveTopics.add(t); }
+        for (const s of sessions) { const t = this.#deps.topicBinding(s.tmuxSession); if (t != null) liveTopics.add(t); }
         const graceMs = 2 * this.cfg.tickIntervalSec * 1000;
         const now = this.now();
         for (const [key, val] of [...this.topicMovedStreak.entries()]) {
@@ -1015,10 +1005,10 @@ export class SessionReaper extends EventEmitter {
         // veto is audited and retried next tick (eventual closeout, never a
         // forced kill). Dwell of `topicMovedConfirmTicks` absorbs ownership
         // churn mid-transfer.
-        if (this.cfg.topicMovedCloseout && (this.deps.topicOwnerElsewhere || this.deps.topicOwnerElsewhereInfo)) {
+        if (this.cfg.topicMovedCloseout && (this.#deps.topicOwnerElsewhere || this.#deps.topicOwnerElsewhereInfo)) {
           const outcome = this.cfg.closeoutLivenessGate
-            ? await this.runCloseoutGated(session, reapedThisTick)
-            : await this.runCloseoutLegacy(session, reapedThisTick);
+            ? await this.#runCloseoutGated(session, reapedThisTick)
+            : await this.#runCloseoutLegacy(session, reapedThisTick);
           reapedThisTick = outcome.reapedThisTick;
           if (outcome.terminated) continue; // session is gone — skip the idle pipeline
         }
@@ -1033,7 +1023,7 @@ export class SessionReaper extends EventEmitter {
           // A protect-signal threw — we cannot reason about this session, so
           // KEEP it (abort any reap-pending) and reset candidacy. Never reap on
           // a failed evaluation.
-          this.deps.clearReaping(session.id);
+          this.#deps.clearReaping(session.id);
           this.obs.set(session.id, { candidateSince: 0, consecutive: 0, lastFrame: '', lastTranscript: { resolved: false, path: '', size: 0, mtime: 0 } });
           continue;
         }
@@ -1078,7 +1068,7 @@ export class SessionReaper extends EventEmitter {
         if (evaln.verdict === 'keep') {
           // Any non-candidate observation resets candidacy + aborts reap-pending.
           if (prior?.reapPendingSince != null) {
-            this.deps.clearReaping(session.id);
+            this.#deps.clearReaping(session.id);
             this.audit('reap-aborted', session, { keptBy: evaln.keptBy });
           }
           this.obs.set(session.id, { candidateSince: 0, consecutive: 0, lastFrame: evaln.frame, lastTranscript: evaln.transcript });
@@ -1092,7 +1082,7 @@ export class SessionReaper extends EventEmitter {
         // If we were reap-pending and the frame is no longer static, the session
         // rendered something during the grace window — abort the reap (§3.5).
         if (prior?.reapPendingSince != null && !frameStatic) {
-          this.deps.clearReaping(session.id);
+          this.#deps.clearReaping(session.id);
           this.audit('reap-aborted', session, { reason: 'frame-changed-during-grace' });
           this.obs.set(session.id, { candidateSince: now, consecutive: 1, lastFrame: evaln.frame, lastTranscript: evaln.transcript });
           continue;
@@ -1116,13 +1106,13 @@ export class SessionReaper extends EventEmitter {
               // and the reap would never land. False ⇒ no active process was the blocker,
               // so the bypass is a harmless no-op.
               const relaxedActiveProcess = evaln.cpuTightened || evaln.staleIdleRelaxed;
-              await this.performReap(session, pressure, next, relaxedActiveProcess); // clears the lease on every path
+              await this.#performReap(session, pressure, next, relaxedActiveProcess); // clears the lease on every path
               reapedThisTick++;
             } else {
               // Grace elapsed but the reap is gated (tier dropped / budget spent).
               // Release the reaping lease so the idle-kill safety net is not
               // permanently disabled for this session.
-              this.deps.clearReaping(session.id);
+              this.#deps.clearReaping(session.id);
             }
             this.obs.set(session.id, { ...next, reapPendingSince: undefined });
           } else {
@@ -1141,7 +1131,7 @@ export class SessionReaper extends EventEmitter {
           // Enter reap-pending (two-phase). Lease the session so idle-kill won't
           // race us; terminate on a later tick after the grace window.
           next.reapPendingSince = now;
-          this.deps.markReaping(session.id);
+          this.#deps.markReaping(session.id);
           this.audit('reap-pending', session, { tier: pressure.tier, idleMs, thresholdMs: threshold });
         }
         this.obs.set(session.id, next);
@@ -1152,7 +1142,7 @@ export class SessionReaper extends EventEmitter {
     }
   }
 
-  private async performReap(
+  async #performReap(
     session: Session,
     pressure: PressureReading,
     obs: Obs,
@@ -1161,7 +1151,7 @@ export class SessionReaper extends EventEmitter {
     const detail = { tier: pressure.tier, idleMs: this.now() - obs.candidateSince, dryRun: !this.killsEnabled };
     if (!this.killsEnabled) {
       this.audit('would-reap', session, detail); // dry-run: log, do not kill
-      this.deps.clearReaping(session.id);
+      this.#deps.clearReaping(session.id);
       return;
     }
     try {
@@ -1175,11 +1165,11 @@ export class SessionReaper extends EventEmitter {
       // terminate chokepoint. `dirtyCheck` is present only when the dev-gated
       // feature is live; it is bounded + fail-open internally.
       const workEvidence: string[] = [];
-      if (this.deps.dirtyCheck && session.cwd) {
-        try { if (this.deps.dirtyCheck(session.cwd)) workEvidence.push('uncommitted-worktree-work'); }
+      if (this.#deps.dirtyCheck && session.cwd) {
+        try { if (this.#deps.dirtyCheck(session.cwd)) workEvidence.push('uncommitted-worktree-work'); }
         catch { /* @silent-fallback-ok: SPEC-MANDATED fail-open — evidence collection NEVER endangers the kill path; a dirty-check failure just omits the signal (the kill proceeds with the evidence gathered so far). */ }
       }
-      const r = await this.deps.terminate(session.id, 'reaped-idle', {
+      const r = await this.#deps.terminate(session.id, 'reaped-idle', {
         bypassActiveProcessKeep: relaxedActiveProcess,
         // Pre-relaxation verdict as killer-supplied evidence (reap-notify R2.1):
         // an idle-reap means this reaper PROVED no active work — assert that set
@@ -1211,7 +1201,7 @@ export class SessionReaper extends EventEmitter {
       this.audit('reap-failed-auto-disable', session, { ...detail, error: err instanceof Error ? err.message : String(err) });
       this.emit('auto-disabled', { session, reason: 'error' });
     } finally {
-      this.deps.clearReaping(session.id);
+      this.#deps.clearReaping(session.id);
     }
   }
 
@@ -1233,7 +1223,7 @@ export class SessionReaper extends EventEmitter {
 
   private audit(event: string, session: Session, detail: Record<string, unknown>): void {
     const entry = { ts: new Date(this.now()).toISOString(), kind: 'session-reaper', event, session: session.name, sessionId: session.id, ...detail };
-    if (this.deps.audit) this.deps.audit(entry);
+    if (this.#deps.audit) this.#deps.audit(entry);
   }
 
   /** Observability snapshot for GET /sessions/reaper. */
@@ -1243,10 +1233,10 @@ export class SessionReaper extends EventEmitter {
     reapsLastHour: number;
     sessions: Array<{ name: string; sessionId: string; verdict: Verdict; keptBy: string; confidence: Confidence; consecutive: number; idleMs: number; reapPending: boolean }>;
   } {
-    const pressure = this.deps.pressure();
+    const pressure = this.#deps.pressure();
     const threshold = this.thresholdMs(pressure.tier);
     const now = this.now();
-    const sessions = this.deps.listRunningSessions().map(s => {
+    const sessions = this.#deps.listRunningSessions().map(s => {
       const o = this.obs.get(s.id);
       let verdict: Verdict = 'keep';
       let keptBy = 'eval-error';

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -65,7 +65,7 @@ import { InMemoryImportTarget, runImport, type ImportRunResult } from '../feedba
 import { SecretStore } from '../core/SecretStore.js';
 import { secretKeyPaths } from '../core/SecretSync.js';
 import { fileURLToPath } from 'node:url';
-import type { SessionManager } from '../core/SessionManager.js';
+import type { SessionManager, SessionTerminateAuthority } from '../core/SessionManager.js';
 import type { StateManager } from '../core/StateManager.js';
 import type { JobScheduler } from '../scheduler/JobScheduler.js';
 import type { TelegramAdapter } from '../messaging/TelegramAdapter.js';
@@ -504,6 +504,7 @@ export class AgentServer {
   constructor(options: {
     config: InstarConfig;
     sessionManager: SessionManager;
+    terminateSessionAuthority?: SessionTerminateAuthority;
     /** Override the same-host apprenticeship peer read (tests/custom embeddings). */
     apprenticeshipPeerCycleReader?: (instanceId: string) => Promise<import('../monitoring/ApprenticeshipPeerCycleReader.js').ApprenticeshipPeerCycleRead>;
     state: StateManager;
@@ -3438,6 +3439,7 @@ export class AgentServer {
       capabilityRegistry: new CapabilityRegistryReceiver(),
       config: options.config,
       sessionManager: options.sessionManager,
+      terminateSessionAuthority: options.terminateSessionAuthority,
       state: options.state,
       scheduler: options.scheduler ?? null,
       dynamicMcpService,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -44,7 +44,7 @@ import { CredentialIdentityOracle } from '../core/CredentialIdentityOracle.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import type { SessionManager } from '../core/SessionManager.js';
+import type { SessionManager, SessionTerminateAuthority } from '../core/SessionManager.js';
 import {
   KNOWN_CLAUDE_MODEL_IDS,
   escalatedModelIds,
@@ -796,6 +796,10 @@ export interface RouteContext {
    *  when the delivery sentinel's store opens; absent → no exemption. */
   pendingRelayLookup?: (deliveryId: string) => boolean;
   sessionManager: SessionManager;
+  /** Birth-bound lifecycle authority. Production supplies it from the
+   *  SessionManager constructor handoff; absent test/legacy contexts fail closed
+   *  for operator termination rather than falling onto raw killSession. */
+  terminateSessionAuthority?: SessionTerminateAuthority;
   state: StateManager;
   scheduler: JobScheduler | null;
   /** Dynamic MCP Lifecycle (DYNAMIC-MCP-LIFECYCLE-SPEC). Null/disabled ⇒ the
@@ -9610,11 +9614,9 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
     try {
-      // Operator kill — stamped origin:'operator' so it bypasses the autonomous
-      // ReapAuthority gates (protected / lease / KEEP-guard) and ALWAYS happens
-      // (the user clicked "kill"). Routing through terminateSession (rather than
-      // the raw killSession) gives the reap-log + lifecycle events the §P4 surface
-      // depends on. (UNIFIED-SESSION-LIFECYCLE §P0.)
+      // Explicit operator kill. Public terminateSession is structurally
+      // autonomous-only; this authenticated route receives the birth-bound
+      // authority from the server composition root.
       // Try direct UUID lookup first, then fall back to tmux session name lookup —
       // the dashboard sends tmux session names, not UUIDs.
       let target = ctx.state.getSession(req.params.id);
@@ -9626,10 +9628,12 @@ export function createRoutes(ctx: RouteContext): Router {
         res.status(404).json({ error: `Session "${req.params.id}" not found` });
         return;
       }
-      // UNTRUSTED provenance claim (REMOTE-SESSION-CLOSE-SPEC §2.3): any token
-      // holder could set this header. Recorded in the reap-log as `viaClaim`
-      // (a signal in the audit trail); NEVER consulted in authority decisions —
-      // those read the route-stamped `origin` below. Sanitized + bounded.
+      if (!ctx.terminateSessionAuthority) {
+        res.status(503).json({ error: 'Session termination authority unavailable' });
+        return;
+      }
+      // UNTRUSTED provenance claim (REMOTE-SESSION-CLOSE-SPEC §2.3): recorded
+      // as signal only, never consulted for authority.
       const viaHeader = req.headers['x-instar-close-via'];
       const via = typeof viaHeader === 'string' && /^[a-z0-9-]{1,40}$/.test(viaHeader) ? viaHeader : undefined;
       // FD13 principal provenance (unified-self-action-backpressure §4): a
@@ -9640,13 +9644,13 @@ export function createRoutes(ctx: RouteContext): Router {
       // agent-origin ('self') and rides the normal governor ceilings once the
       // kill sink enforces.
       recordPrincipalKillProvenance(req, req.params.id);
-      const result = await ctx.sessionManager.terminateSession(target.id, 'operator-kill', {
+      const result = await ctx.terminateSessionAuthority(target.id, 'operator-kill', {
         origin: 'operator',
         finalStatus: 'killed',
         ...(via ? { via } : {}),
       });
       if (!result.terminated) {
-        res.status(404).json({ error: `Session "${req.params.id}" not found`, skipped: result.skipped });
+        res.status(409).json({ error: `Session "${req.params.id}" was not terminated`, skipped: result.skipped });
         return;
       }
       res.json({ ok: true, killed: req.params.id });

--- a/src/testing/selfActionRegistry.ts
+++ b/src/testing/selfActionRegistry.ts
@@ -176,7 +176,7 @@ const proactiveSwapMonitor: SelfActionController = {
 const ageKillBackoff: SelfActionController = {
   id: 'age-kill-backoff',
   actionVerb: 'age-kill',
-  models: 'src/monitoring/SessionReaper.ts (age-limit kill-request; AgeKillBackoff — P19 backoff + breaker)',
+  models: 'src/core/SessionManager.ts (age-limit kill-request; AgeKillBackoff — P19 backoff + breaker)',
   modelsPath: 'src/core/SessionManager.ts',
   restartPosture: { pressureSurvives: false, resetSafeReason: 'Server restart begins a new reaper episode and re-reads protection/age before any kill request.' },
   boundK: 5,

--- a/tests/e2e/june15-headless-spawn-reroute.test.ts
+++ b/tests/e2e/june15-headless-spawn-reroute.test.ts
@@ -27,6 +27,7 @@ const mockTmuxSessions = new Set<string>();
 const newSessionArgvs: string[][] = [];
 /** Toggled by the completion test: capture-pane returns the sentinel. */
 let capturePaneOutput = '';
+const maintenanceTicks = new WeakMap<SessionManager, () => Promise<void>>();
 
 vi.mock('node:child_process', () => {
   const handle = (args?: string[]) => {
@@ -122,7 +123,11 @@ describe('Headless-spawn reroute E2E (V6)', () => {
         ? { subscriptionReroutedLifetimeMinutes: subscriptionPathCfg.maxReroutedLifetimeMinutes }
         : {}),
     };
-    const manager = new SessionManager(sessionManagerConfig as never, state);
+    let maintenanceTick!: () => Promise<void>;
+    const manager = new SessionManager(sessionManagerConfig as never, state, {
+      bindMaintenanceTickForTesting: (tick) => { maintenanceTick = tick; },
+    });
+    maintenanceTicks.set(manager, maintenanceTick);
     stubReadyWait(manager);
     return manager;
   }
@@ -201,7 +206,7 @@ describe('Headless-spawn reroute E2E (V6)', () => {
     // the session as a SUCCESS (status not 'killed'; JobScheduler finalizes
     // success off exactly this, spec F1).
     capturePaneOutput = `some output\n${sentinel}\n`;
-    await (manager as unknown as { monitorTick: () => Promise<void> }).monitorTick();
+    await maintenanceTicks.get(manager)!();
     const done = await completed;
     expect(done.status).not.toBe('killed');
     capturePaneOutput = '';

--- a/tests/e2e/session-management-e2e.test.ts
+++ b/tests/e2e/session-management-e2e.test.ts
@@ -31,6 +31,7 @@ import { getTelegramInboundDir } from '../../src/messaging/shared/telegramInboun
 const TMUX_PREFIX = 'sess-e2e-';
 const tmuxPath = detectTmuxPath();
 const describeMaybe = tmuxPath ? describe : describe.skip;
+const maintenanceTicks = new WeakMap<SessionManager, () => Promise<void>>();
 
 // ── Mock Claude Scripts ─────────────────────────────────────────────
 
@@ -194,7 +195,8 @@ function createTestProject(): TestProject {
 }
 
 function createManager(project: TestProject, claudePath: string, overrides?: Partial<SessionManagerConfig>): SessionManager {
-  return new SessionManager(
+  let maintenanceTick!: () => Promise<void>;
+  const manager = new SessionManager(
     {
       tmuxPath: tmuxPath!,
       claudePath,
@@ -205,7 +207,10 @@ function createManager(project: TestProject, claudePath: string, overrides?: Par
       ...overrides,
     },
     project.state,
+    { bindMaintenanceTickForTesting: (tick) => { maintenanceTick = tick; } },
   );
+  maintenanceTicks.set(manager, maintenanceTick);
+  return manager;
 }
 
 // ── BDD Tests ───────────────────────────────────────────────────────
@@ -822,7 +827,7 @@ describeMaybe('Session Management E2E', () => {
       buildSession.startedAt = new Date(Date.now() - 20_000).toISOString();
       project.state.saveSession(buildSession);
 
-      await (buildSm as any).monitorTick();
+      await maintenanceTicks.get(buildSm)!();
       execFileSync(tmuxPath!, ['kill-session', '-t', `=${buildTmux}`], { stdio: 'ignore' });
 
       await buildSm.spawnInteractiveSession('CONTINUATION — resume build', buildName, {
@@ -848,7 +853,7 @@ describeMaybe('Session Management E2E', () => {
       homeSession.startedAt = new Date(Date.now() - 20_000).toISOString();
       project.state.saveSession(homeSession);
 
-      await (homeSm as any).monitorTick();
+      await maintenanceTicks.get(homeSm)!();
       execFileSync(tmuxPath!, ['kill-session', '-t', `=${homeTmux}`], { stdio: 'ignore' });
 
       await homeSm.spawnInteractiveSession('CONTINUATION — home only', homeName, {

--- a/tests/integration/remote-session-close.test.ts
+++ b/tests/integration/remote-session-close.test.ts
@@ -24,6 +24,7 @@ import type { AddressInfo } from 'node:net';
 import type http from 'node:http';
 import { createRoutes } from '../../src/server/routes.js';
 import type { RouteContext } from '../../src/server/routes.js';
+import type { SessionTerminateAuthority } from '../../src/core/SessionManager.js';
 import { authMiddleware } from '../../src/server/middleware.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
@@ -60,10 +61,15 @@ interface CtxOpts {
   protectedSessions?: string[];
   sessions?: Array<{ id: string; tmuxSession: string; name: string; status: string }>;
   terminateCalls?: Array<{ sessionId: string; opts: Record<string, unknown> }>;
+  withTerminateAuthority?: boolean;
 }
 
 function ctxFor(o: CtxOpts = {}): RouteContext {
   const sessions = o.sessions ?? [];
+  const terminateSession: SessionTerminateAuthority = async (sessionId, _reason, opts = {}) => {
+    o.terminateCalls?.push({ sessionId, opts: { ...opts } });
+    return { terminated: true };
+  };
   return {
     config: {
       projectName: 'remote-close', projectDir: path.dirname(stateDir), stateDir, port: 0,
@@ -73,12 +79,10 @@ function ctxFor(o: CtxOpts = {}): RouteContext {
     } as never,
     sessionManager: {
       listRunningSessions: () => [],
-      terminateSession: async (sessionId: string, _reason: string, opts: Record<string, unknown>) => {
-        o.terminateCalls?.push({ sessionId, opts });
-        return { terminated: true };
-      },
+      terminateSession,
       clearInjectionTracker: () => {},
     } as never,
+    ...(o.withTerminateAuthority === false ? {} : { terminateSessionAuthority: terminateSession }),
     state: {
       getJobState: () => null,
       getSession: (id: string) => sessions.find((s) => s.id === id) ?? null,
@@ -243,6 +247,19 @@ describe('relay outcomes — delivery honesty (Tier 2, mocked peers)', () => {
 });
 
 describe('peer-side semantics (Tier 1+2)', () => {
+  it('fails closed when the birth-bound terminate authority is unavailable', async () => {
+    const terminateCalls: Array<{ sessionId: string; opts: Record<string, unknown> }> = [];
+    const app = appWith(ctxFor({
+      sessions: [{ id: 'u-1', tmuxSession: 'sess-a', name: 'sess-a', status: 'running' }],
+      terminateCalls,
+      withTerminateAuthority: false,
+    }));
+    const res = await request(app).delete('/sessions/u-1').set(auth());
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('Session termination authority unavailable');
+    expect(terminateCalls).toEqual([]);
+  });
+
   it('forged via header is recorded as a claim and CANNOT alter authority (origin stays route-stamped operator)', async () => {
     const terminateCalls: Array<{ sessionId: string; opts: Record<string, unknown> }> = [];
     const app = appWith(ctxFor({

--- a/tests/integration/session-build-context-respawn.test.ts
+++ b/tests/integration/session-build-context-respawn.test.ts
@@ -69,6 +69,7 @@ describe('Session build-context respawn restore (integration)', () => {
   let stateDir: string;
   let state: StateManager;
   let sm: SessionManager;
+  let maintenanceTick: () => Promise<void>;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-build-context-respawn-'));
@@ -86,7 +87,9 @@ describe('Session build-context respawn restore (integration)', () => {
       completionPatterns: ['Session complete'],
       port: 4044,
       respawnBuildContext: { enabled: true, maxAgeMs: 60_000 },
-    }, state);
+    }, state, {
+      bindMaintenanceTickForTesting: (tick) => { maintenanceTick = tick; },
+    });
     tmuxSessions.clear();
     paneCwds.clear();
   });
@@ -116,7 +119,7 @@ describe('Session build-context respawn restore (integration)', () => {
       startedAt: new Date(Date.now() - 20_000).toISOString(),
     } as Session);
 
-    await (sm as any).monitorTick();
+    await maintenanceTick();
     tmuxSessions.delete(tmuxSession);
 
     await sm.spawnInteractiveSession('CONTINUATION — resume this topic', 'topic-1052', {
@@ -143,7 +146,7 @@ describe('Session build-context respawn restore (integration)', () => {
       startedAt: new Date(Date.now() - 20_000).toISOString(),
     } as Session);
 
-    await (sm as any).monitorTick();
+    await maintenanceTick();
     tmuxSessions.delete(tmuxSession);
 
     await sm.spawnInteractiveSession('CONTINUATION — home only', 'topic-home', {

--- a/tests/integration/session-lifecycle-reap-wiring.test.ts
+++ b/tests/integration/session-lifecycle-reap-wiring.test.ts
@@ -49,11 +49,12 @@ vi.mock('node:child_process', () => {
   };
 });
 
-import { SessionManager } from '../../src/core/SessionManager.js';
+import { SessionManager, type SessionTerminateAuthority } from '../../src/core/SessionManager.js';
 import { StateManager } from '../../src/core/StateManager.js';
 import { ReapGuard } from '../../src/core/ReapGuard.js';
 import { ReapNotifier } from '../../src/monitoring/ReapNotifier.js';
 import { ReapLog } from '../../src/monitoring/ReapLog.js';
+import { SessionReaper, type SessionReaperDeps } from '../../src/monitoring/SessionReaper.js';
 import type { SessionManagerConfig, Session } from '../../src/core/types.js';
 
 describe('session-lifecycle reap wiring (integration)', () => {
@@ -61,6 +62,7 @@ describe('session-lifecycle reap wiring (integration)', () => {
   let stateDir: string;
   let state: StateManager;
   let manager: SessionManager;
+  let terminateAuthority: SessionTerminateAuthority;
   let log: ReapLog;
   let notices: Array<{ topicId: number; text: string }>;
   let notifier: ReapNotifier;
@@ -76,7 +78,9 @@ describe('session-lifecycle reap wiring (integration)', () => {
       tmuxPath: '/usr/bin/tmux', claudePath: '/usr/local/bin/claude', projectDir: tmpDir,
       maxSessions: 5, protectedSessions: ['proj-server'], completionPatterns: ['done'],
     };
-    manager = new SessionManager(config, state);
+    manager = new SessionManager(config, state, {
+      bindTerminateAuthority: (authority) => { terminateAuthority = authority; },
+    });
     mockTmuxSessions.clear();
     awake = true; relayLeased = null;
 
@@ -121,6 +125,53 @@ describe('session-lifecycle reap wiring (integration)', () => {
 
   const spawn = (name: string) => manager.spawnSession({ name, prompt: 'p' });
 
+  const closeoutThroughVerifiedReaper = async (
+    targetTmux?: string,
+    trustedAuthority = true,
+  ): Promise<{ terminated: boolean; skipped?: string } | undefined> => {
+    let result: { terminated: boolean; skipped?: string } | undefined;
+    const deps: SessionReaperDeps = {
+      listRunningSessions: () => state.listSessions().filter((s) => s.status === 'running'),
+      captureOutput: () => 'working',
+      hasActiveProcesses: () => true,
+      frameworkForSession: () => 'claude-code',
+      isRecoveryActive: () => false,
+      isRelayLeaseActive: (id) => id === relayLeased,
+      hasPendingInjection: () => false,
+      topicBinding: (tmux) => !targetTmux || tmux === targetTmux ? 42 : null,
+      topicOwnerElsewhere: () => 'Mac Mini',
+      recentUserMessage: () => false,
+      activeCommitmentForTopic: () => false,
+      activeSubagentCount: () => 0,
+      buildOrAutonomousActive: () => false,
+      protectedSessions: () => ['proj-server'],
+      pressure: () => ({ tier: 'normal' }),
+      terminate: async (id, reason, opts) => {
+        result = trustedAuthority
+          ? await terminateAuthority(id, reason, opts)
+          : await manager.terminateSession(
+              id,
+              reason,
+              opts as Parameters<SessionManager['terminateSession']>[2],
+            );
+        return result;
+      },
+      markReaping: () => {},
+      clearReaping: () => {},
+    };
+    const reaper = new SessionReaper(deps, {
+      enabled: true,
+      dryRun: false,
+      minAgeMinutes: 0,
+      topicMovedCloseout: true,
+      topicMovedConfirmTicks: 1,
+      maxReapsPerTick: 5,
+      maxReapsPerHour: 20,
+    });
+    await reaper.tick();
+    return result;
+  };
+
   it('autonomous terminal reap → logged "reaped" + exactly one user notice', async () => {
     const s = await spawn('job-a');
     const r = await manager.terminateSession(s.id, 'idle-zombie', { disposition: 'terminal' });
@@ -140,9 +191,7 @@ describe('session-lifecycle reap wiring (integration)', () => {
     expect(log.read().at(-1)).toMatchObject({ type: 'reaped', disposition: 'recovery-bounce' });
   });
 
-  it('operator reap → logged, SILENT, and bypasses guard + protected', async () => {
-    // Protected + relay-leased: an autonomous reap would be refused twice over,
-    // but an operator kill must always happen.
+  it('a public operator label is untrusted and cannot bypass guard + protected', async () => {
     relayLeased = 'will-set';
     const protectedSession: Session = {
       id: 'op-1', name: 'proj-server', status: 'running', tmuxSession: 'proj-server',
@@ -150,12 +199,37 @@ describe('session-lifecycle reap wiring (integration)', () => {
     } as Session;
     state.saveSession(protectedSession);
     mockTmuxSessions.add('proj-server');
-    const r = await manager.terminateSession('op-1', 'operator-kill', { origin: 'operator', finalStatus: 'killed' });
-    expect(r.terminated).toBe(true);
+    const r = await manager.terminateSession('op-1', 'operator-kill', {
+      origin: 'operator',
+      finalStatus: 'killed',
+    } as Parameters<SessionManager['terminateSession']>[2] & { origin: 'operator' });
+    expect(r).toEqual({ terminated: false, skipped: 'protected' });
     await notifier.flush();
     expect(notices).toHaveLength(0); // operator kills are silent
-    expect(log.read().at(-1)).toMatchObject({ type: 'reaped', origin: 'operator' });
-    expect(state.getSession('op-1')!.status).toBe('killed');
+    expect(log.read().at(-1)).toMatchObject({ type: 'skipped', origin: 'autonomous', skipped: 'protected' });
+    expect(state.getSession('op-1')!.status).toBe('running');
+  });
+
+  it('the birth-bound operator authority bypasses guards but remains logged and silent', async () => {
+    const protectedSession: Session = {
+      id: 'op-trusted', name: 'proj-server', status: 'running', tmuxSession: 'proj-server',
+      startedAt: new Date().toISOString(), prompt: 'p',
+    } as Session;
+    state.saveSession(protectedSession);
+    mockTmuxSessions.add('proj-server');
+    awake = false;
+    relayLeased = protectedSession.id;
+    const r = await terminateAuthority(protectedSession.id, 'operator-kill', {
+      origin: 'operator', finalStatus: 'killed',
+    });
+    expect(r).toEqual({ terminated: true });
+    await notifier.flush();
+    expect(notices).toHaveLength(0);
+    expect(log.read().at(-1)).toMatchObject({
+      type: 'reaped', origin: 'operator', session: 'proj-server', reason: 'operator-kill',
+    });
+    expect(state.getSession(protectedSession.id)!.status).toBe('killed');
+    expect(mockTmuxSessions.has(protectedSession.tmuxSession)).toBe(false);
   });
 
   it('guarded (relay-lease) session → refused, logged "skipped", survives', async () => {
@@ -223,7 +297,7 @@ describe('session-lifecycle reap wiring (integration)', () => {
     expect(log.read().at(-1)).toMatchObject({ type: 'skipped', skipped: 'active-process' });
 
     // With the bypass (what performReap now sends): the kill actually lands.
-    const reaped = await manager.terminateSession(s.id, 'reaped-idle', { bypassActiveProcessKeep: true });
+    const reaped = await terminateAuthority(s.id, 'reaped-idle', { bypassActiveProcessKeep: true });
     expect(reaped.terminated).toBe(true);
     expect(state.getSession(s.id)!.status).toBe('completed');
     expect(log.read().at(-1)).toMatchObject({ type: 'reaped', reason: 'reaped-idle' });
@@ -234,12 +308,13 @@ describe('session-lifecycle reap wiring (integration)', () => {
   // the lease holder) tried to close its own leftover session and the lease
   // gate vetoed every attempt (skipped:'not-lease-holder' ×5 → breaker gave
   // up → duplicate session survived). The carve-out lifts ONLY the lease gate.
-  it('F8: standby machine + bypassLeaseForTopicMovedCloseout → closeout LANDS, reap-log records the honest reason', async () => {
+  it('F8: standby machine + runtime-private local closeout authority → closeout lands', async () => {
     const s = await spawn('moved-topic-leftover');
     awake = false; // this machine lost the lease when the topic moved away
     const reason = 'topic moved to Mac Mini — closing the leftover session on this machine (post-transfer closeout)';
-    const r = await manager.terminateSession(s.id, reason, { bypassLeaseForTopicMovedCloseout: true });
-    expect(r.terminated).toBe(true);
+    const r = await closeoutThroughVerifiedReaper();
+    expect(r).toBeDefined();
+    expect(r!.terminated).toBe(true);
     expect(state.getSession(s.id)!.status).toBe('completed'); // ZERO leftover sessions
     expect(log.read().at(-1)).toMatchObject({ type: 'reaped', session: 'moved-topic-leftover', reason });
   });
@@ -252,9 +327,8 @@ describe('session-lifecycle reap wiring (integration)', () => {
     } as Session;
     state.saveSession(protectedSession);
     mockTmuxSessions.add('proj-server');
-    const r = await manager.terminateSession('prot-f8', 'topic moved to Mac Mini — closing the leftover session on this machine (post-transfer closeout)', { bypassLeaseForTopicMovedCloseout: true });
-    expect(r.terminated).toBe(false);
-    expect(r.skipped).toBe('protected');
+    const r = await closeoutThroughVerifiedReaper();
+    expect(r).toEqual({ terminated: false, skipped: 'protected' });
     expect(state.getSession('prot-f8')!.status).toBe('running');
     expect(log.read().at(-1)).toMatchObject({ type: 'skipped', skipped: 'protected' });
   });
@@ -263,18 +337,31 @@ describe('session-lifecycle reap wiring (integration)', () => {
     const s = await spawn('moved-but-guarded');
     relayLeased = s.id; // a live KEEP-guard reason
     awake = false;
-    const r = await manager.terminateSession(s.id, 'topic moved to Mac Mini — closing the leftover session on this machine (post-transfer closeout)', { bypassLeaseForTopicMovedCloseout: true });
-    expect(r.terminated).toBe(false);
-    expect(r.skipped).toBe('relay-lease'); // vetoed by the guard, NOT by the lease
+    const r = await closeoutThroughVerifiedReaper();
+    expect(r).toEqual({ terminated: false, skipped: 'relay-lease' });
     expect(state.getSession(s.id)!.status).toBe('running');
     expect(log.read().at(-1)).toMatchObject({ type: 'skipped', skipped: 'relay-lease' });
   });
 
-  it('F8 boundary: a standby terminate WITHOUT the flag keeps today\'s not-lease-holder veto', async () => {
+  it('F8 boundary: ordinary standby terminate keeps the not-lease-holder veto', async () => {
     const s = await spawn('ordinary-standby-kill');
     awake = false;
     const r = await manager.terminateSession(s.id, 'idle-zombie');
     expect(r).toEqual({ terminated: false, skipped: 'not-lease-holder' });
     expect(state.getSession(s.id)!.status).toBe('running');
+  });
+
+  it('F8 a fabricated first reaper cannot mint authority through the public manager', async () => {
+    const target = await spawn('attacker-first-closeout');
+    awake = false;
+    const forgedFirst = await closeoutThroughVerifiedReaper(target.tmuxSession, false);
+    expect(forgedFirst).toEqual({ terminated: false, skipped: 'not-lease-holder' });
+    expect(state.getSession(target.id)!.status).toBe('running');
+    expect(mockTmuxSessions.has(target.tmuxSession)).toBe(true);
+
+    // The real composition-root closure remains usable; there is no claim race.
+    const trusted = await closeoutThroughVerifiedReaper(target.tmuxSession, true);
+    expect(trusted).toEqual({ terminated: true });
+    expect(state.getSession(target.id)!.status).toBe('completed');
   });
 });

--- a/tests/integration/tmux-resilience-slow-stub.test.ts
+++ b/tests/integration/tmux-resilience-slow-stub.test.ts
@@ -54,6 +54,7 @@ import {
 import type { SessionManagerConfig, Session, InstarConfig } from '../../src/core/types.js';
 
 const AUTH = 'test-tmux-resilience-slow-stub';
+const maintenanceTicks = new WeakMap<SessionManager, () => Promise<void>>();
 
 /** A stub tmux that sleeps STUB_SLEEP_SECS before answering (the degraded shared
  *  server). It accepts ANY tmux subcommand and just sleeps then exits 0 — the
@@ -223,10 +224,13 @@ describe('tmux Event-Loop Resilience — slow-stub integration (GROUP G)', () =>
       tmpDir = t.tmpDir;
       const tmuxPath = writeSlowTmuxStub(tmpDir);
       state = new StateManager(t.stateDir);
+      let maintenanceTick!: () => Promise<void>;
       sm = new SessionManager(smConfig(tmpDir, tmuxPath), state, {
         tmuxAsyncEnabled: true,
         tmuxCallTimeoutMs: 800,
+        bindMaintenanceTickForTesting: (tick) => { maintenanceTick = tick; },
       });
+      maintenanceTicks.set(sm, maintenanceTick);
       seedRunningSession(state, 'tick-sess');
     });
 
@@ -239,7 +243,7 @@ describe('tmux Event-Loop Resilience — slow-stub integration (GROUP G)', () =>
       sm.on('sessionComplete', () => { completedEmitted = true; });
 
       const t0 = Date.now();
-      await (sm as unknown as { monitorTick: () => Promise<void> }).monitorTick();
+      await maintenanceTicks.get(sm)!();
       const elapsed = Date.now() - t0;
 
       // The session is STILL running — a slow has-session resolves indeterminate,
@@ -253,7 +257,7 @@ describe('tmux Event-Loop Resilience — slow-stub integration (GROUP G)', () =>
     });
 
     it('does NOT zero _cachedRunningSessions when tmux is slow', async () => {
-      await (sm as unknown as { monitorTick: () => Promise<void> }).monitorTick();
+      await maintenanceTicks.get(sm)!();
       const cached = sm.getCachedRunningSessions();
       // Cache reflects the STILL-running session (the tick refreshes it from state,
       // and state stayed `running` because indeterminate did not transition it).
@@ -272,7 +276,7 @@ describe('tmux Event-Loop Resilience — slow-stub integration (GROUP G)', () =>
       let killEmitted = false;
       sm.on('beforeSessionKill', () => { killEmitted = true; });
 
-      await (sm as unknown as { monitorTick: () => Promise<void> }).monitorTick();
+      await maintenanceTicks.get(sm)!();
 
       expect(termSpy.calls.length).toBe(0);
       expect(killEmitted).toBe(false);

--- a/tests/unit/headless-spawn-reroute.test.ts
+++ b/tests/unit/headless-spawn-reroute.test.ts
@@ -97,7 +97,7 @@ function makeManager(opts: {
   maxRerouted?: number;
   framework?: 'claude-code' | 'codex-cli' | 'gemini-cli';
   credit?: () => Promise<{ remainingUsd: number; totalUsd: number } | null>;
-}, tmpDir: string): { manager: SessionManager; state: StateManager } {
+}, tmpDir: string): { manager: SessionManager; state: StateManager; maintenanceTick: () => Promise<void> } {
   const stateDir = path.join(tmpDir, 'state');
   fs.mkdirSync(stateDir, { recursive: true });
   const state = new StateManager(stateDir);
@@ -114,7 +114,10 @@ function makeManager(opts: {
     ...(opts.mode ? { subscriptionPathMode: opts.mode } : {}),
     ...(opts.maxRerouted != null ? { subscriptionMaxRerouted: opts.maxRerouted } : {}),
   };
-  const manager = new SessionManager(config, state);
+  let maintenanceTick!: () => Promise<void>;
+  const manager = new SessionManager(config, state, {
+    bindMaintenanceTickForTesting: (tick) => { maintenanceTick = tick; },
+  });
   // Stub the background ready-wait so the detached injectAfterReady completes
   // immediately (otherwise it polls for ~90s). The tmux argv is captured
   // synchronously at new-session, so this never affects the pin assertions.
@@ -129,7 +132,7 @@ function makeManager(opts: {
   if (opts.credit) {
     manager.setSdkCreditReader(opts.credit as never);
   }
-  return { manager, state };
+  return { manager, state, maintenanceTick };
 }
 
 describe('headless-spawn reroute', () => {
@@ -147,7 +150,7 @@ describe('headless-spawn reroute', () => {
 
   // ── V1: mode off/unset → byte-for-byte today's headless argv ──
   it('V1: mode unset → claude-code spawn is the headless `-p` one-shot (byte-for-byte)', async () => {
-    const { manager, state } = makeManager({}, tmpDir);
+    const { manager, state, maintenanceTick } = makeManager({}, tmpDir);
     const s = await manager.spawnSession({ name: 'job-a', prompt: 'do the thing', model: 'haiku' });
 
     const launch = launchArgvFrom(lastNewSessionArgv(), CLAUDE);
@@ -430,7 +433,7 @@ describe('monitorTick rerouted-interactive branch', () => {
   });
 
   it('sentinel match → terminates via the SUCCESS path (status completed, not killed)', async () => {
-    const { manager, state } = makeManager({}, tmpDir);
+    const { manager, state, maintenanceTick } = makeManager({}, tmpDir);
     // Persist a rerouted session old enough to clear the 15s grace period.
     const startedAt = new Date(Date.now() - 60_000).toISOString();
     state.saveSession({
@@ -448,7 +451,7 @@ describe('monitorTick rerouted-interactive branch', () => {
 
     let completedStatus: string | undefined;
     manager.on('sessionComplete', (s) => { completedStatus = s.status; });
-    await (manager as unknown as { monitorTick: () => Promise<void> }).monitorTick();
+    await maintenanceTick();
 
     const saved = state.getSession('rr-1')!;
     expect(saved.status).toBe('completed'); // NOT 'killed' → JobScheduler records success
@@ -459,7 +462,7 @@ describe('monitorTick rerouted-interactive branch', () => {
   it('hard lifetime exceeded without sentinel → killed (timeout) + degradation', async () => {
     const { DegradationReporter } = await import('../../src/monitoring/DegradationReporter.js');
     const reportSpy = vi.spyOn(DegradationReporter.getInstance(), 'report');
-    const { manager, state } = makeManager({}, tmpDir);
+    const { manager, state, maintenanceTick } = makeManager({}, tmpDir);
     // Started 50 min ago; lifetime cap 45 → over.
     const startedAt = new Date(Date.now() - 50 * 60_000).toISOString();
     state.saveSession({
@@ -474,7 +477,7 @@ describe('monitorTick rerouted-interactive branch', () => {
     // No sentinel in the output → lifetime cap fires.
     (manager as unknown as { captureOutput: () => string }).captureOutput = () => 'still grinding away\n';
 
-    await (manager as unknown as { monitorTick: () => Promise<void> }).monitorTick();
+    await maintenanceTick();
 
     const saved = state.getSession('rr-2')!;
     expect(saved.status).toBe('killed'); // killed → JobScheduler records 'timeout'
@@ -484,7 +487,7 @@ describe('monitorTick rerouted-interactive branch', () => {
   });
 
   it('under lifetime, no sentinel → left running (re-check next tick)', async () => {
-    const { manager, state } = makeManager({}, tmpDir);
+    const { manager, state, maintenanceTick } = makeManager({}, tmpDir);
     const startedAt = new Date(Date.now() - 60_000).toISOString(); // 1 min old
     state.saveSession({
       id: 'rr-3', name: 'rr-3', status: 'running', tmuxSession: 'proj-rr-3',
@@ -497,7 +500,7 @@ describe('monitorTick rerouted-interactive branch', () => {
     (manager as unknown as { recordBuildContext: () => void }).recordBuildContext = () => {};
     (manager as unknown as { captureOutput: () => string }).captureOutput = () => 'working\n';
 
-    await (manager as unknown as { monitorTick: () => Promise<void> }).monitorTick();
+    await maintenanceTick();
     expect(state.getSession('rr-3')!.status).toBe('running');
   });
 });

--- a/tests/unit/reap-log.test.ts
+++ b/tests/unit/reap-log.test.ts
@@ -71,6 +71,33 @@ describe('ReapLog — reaped entries with mid-work evidence (R2.1)', () => {
     });
     expect(log.read()[0].launchLane).toBe('rerouted-interactive');
   });
+
+  it('preserves the admitting authority scope and rejects unknown values', () => {
+    const log = new ReapLog(stateDir, () => 'machine-under-test');
+    log.recordReaped({
+      session: 'local-expired',
+      tmuxSession: 'tmux-local-expired',
+      reason: 'age-limit',
+      authorityScope: 'local-age-limit',
+    });
+    expect(log.read()[0]).toMatchObject({
+      machine: 'machine-under-test',
+      authorityScope: 'local-age-limit',
+    });
+
+    fs.appendFileSync(
+      path.join(tmpDir, 'logs', 'reap-log.jsonl'),
+      JSON.stringify({
+        type: 'reaped',
+        session: 'bad',
+        authorityScope: 'remote-anything',
+        origin: 'forged-operator',
+      }) + '\n',
+    );
+    expect(log.read().at(-1)).toMatchObject({ session: 'bad' });
+    expect(log.read().at(-1)?.authorityScope).toBeUndefined();
+    expect(log.read().at(-1)?.origin).toBeUndefined();
+  });
 });
 
 describe('ReapLog — notify outcome record pairs (R1.3)', () => {

--- a/tests/unit/session-async-monitor.test.ts
+++ b/tests/unit/session-async-monitor.test.ts
@@ -12,8 +12,10 @@ describe('SessionManager async monitoring', () => {
   );
 
   it('uses async monitoring to avoid blocking the event loop', () => {
-    // Monitor tick should be async
-    expect(source).toContain('async monitorTick()');
+    // Monitor tick should be async and runtime-private. Tests that need to drive
+    // it receive the birth-time bindMaintenanceTickForTesting closure.
+    expect(source).toContain('async #monitorTick()');
+    expect(source).toContain('bindMaintenanceTickForTesting?.(() => this.#monitorTick())');
     // Uses execFileAsync instead of execFileSync in monitoring
     expect(source).toContain('await execFileAsync');
   });

--- a/tests/unit/session-lifecycle-phase-2-wiring.test.ts
+++ b/tests/unit/session-lifecycle-phase-2-wiring.test.ts
@@ -118,9 +118,10 @@ describe('Phase 2 — per-killer routing contracts', () => {
       expect(deferredReturns.length).toBeGreaterThanOrEqual(5);
     });
 
-    it('the wiring routes the kill through terminateSession with recovery-bounce disposition + bypassRecoveryFlag', () => {
-      // server.ts wires the dep.killSession to terminateSession with the right opts.
-      expect(serverSource).toMatch(/terminateSession\([^)]*'session-recovery'/);
+    it('the wiring routes the kill through birth-bound terminate authority with recovery-bounce disposition + bypassRecoveryFlag', () => {
+      // server.ts wires the dep.killSession to the construction-bound authority,
+      // not the public autonomous-only terminateSession surface.
+      expect(serverSource).toMatch(/terminateWithAuthority\([^)]*'session-recovery'/);
       expect(serverSource).toContain("disposition: 'recovery-bounce'");
       expect(serverSource).toContain('bypassRecoveryFlag: true');
     });

--- a/tests/unit/session-manager-idle-veto-backoff.test.ts
+++ b/tests/unit/session-manager-idle-veto-backoff.test.ts
@@ -391,11 +391,10 @@ describe('SessionManager idle-zombie veto-backoff — KEY CONSISTENCY (fix-the-f
   });
 
   // EQUIVALENCE PROPERTY TEST (the Structure>Willpower guard) — the ORACLE is the REAL
-  // terminateSessionInternal; the pre-check reasonKey MUST equal the reason it stores.
+  // public termination boundary; the pre-check reasonKey MUST equal its skip reason.
   it('property: computeIdleZombieReapVerdict().reasonKey equals the REAL terminate skip reason for every mirrored cell', async () => {
     type Priv = {
       computeIdleZombieReapVerdict(s: Session, now: number): { blocked: unknown; reasonKey: string | null };
-      terminateSessionInternal(id: string, reason: string, opts: { disposition: string }): Promise<{ terminated: boolean; skipped?: string }>;
     };
     // Each cell: [label, reapGuard deps (before protected wiring), awake?, protected?].
     // Only SKIP cells (terminate returns terminated:false) are in the equality matrix;
@@ -424,7 +423,7 @@ describe('SessionManager idle-zombie veto-backoff — KEY CONSISTENCY (fix-the-f
       }
       const priv = m as unknown as Priv;
       const verdict = priv.computeIdleZombieReapVerdict(s, 21_000_000);
-      const result = await priv.terminateSessionInternal(s.id, 'idle-zombie', { disposition: 'terminal' });
+      const result = await m.terminateSession(s.id, 'idle-zombie', { disposition: 'terminal' });
       // Only assert equality when terminate SKIPPED (a kill has no stored veto reason).
       if (!result.terminated) {
         expect(normalizeReasonKey(result.skipped ? { reason: result.skipped } : null), label)

--- a/tests/unit/session-manager-is-session-alive-async-tristate.test.ts
+++ b/tests/unit/session-manager-is-session-alive-async-tristate.test.ts
@@ -79,6 +79,7 @@ function absentErr(): Error {
 
 type Probe = { isSessionAliveAsync(s: string): Promise<boolean | 'indeterminate'> };
 const probe = (m: SessionManager): Probe => m as unknown as Probe;
+const maintenanceTicks = new WeakMap<SessionManager, () => Promise<void>>();
 
 function makeManager(tmpDir: string, state: StateManager, asyncEnabled: boolean): SessionManager {
   const config = {
@@ -90,7 +91,14 @@ function makeManager(tmpDir: string, state: StateManager, asyncEnabled: boolean)
     protectedSessions: [],
     completionPatterns: [],
   } as unknown as SessionManagerConfig;
-  return new SessionManager(config, state, { tmuxAsyncEnabled: asyncEnabled, tmuxCallTimeoutMs: 9000 });
+  let maintenanceTick!: () => Promise<void>;
+  const manager = new SessionManager(config, state, {
+    tmuxAsyncEnabled: asyncEnabled,
+    tmuxCallTimeoutMs: 9000,
+    bindMaintenanceTickForTesting: (tick) => { maintenanceTick = tick; },
+  });
+  maintenanceTicks.set(manager, maintenanceTick);
+  return manager;
 }
 
 describe('SessionManager.isSessionAliveAsync — tri-state (§A)', () => {
@@ -187,7 +195,7 @@ describe('SessionManager.isSessionAliveAsync — tri-state (§A)', () => {
     let completed = 0;
     manager.on('sessionComplete', () => { completed++; });
 
-    await (manager as unknown as { monitorTick(): Promise<void> }).monitorTick();
+    await maintenanceTicks.get(manager)!();
 
     expect(state.getSession('reap-me')!.status).toBe('completed');
     expect(completed).toBe(1);
@@ -200,7 +208,7 @@ describe('SessionManager.isSessionAliveAsync — tri-state (§A)', () => {
     let completed = 0;
     manager.on('sessionComplete', () => { completed++; });
 
-    await (manager as unknown as { monitorTick(): Promise<void> }).monitorTick();
+    await maintenanceTicks.get(manager)!();
 
     expect(state.getSession('keep-me')!.status).toBe('running'); // still alive — NOT reaped
     expect(completed).toBe(0);

--- a/tests/unit/session-manager-terminate.test.ts
+++ b/tests/unit/session-manager-terminate.test.ts
@@ -12,6 +12,10 @@ import os from 'node:os';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const mockTmuxSessions = new Set<string>();
+const mockChildProcessControl = vi.hoisted(() => ({
+  killError: null as Error | null,
+  lastKillOptions: null as Record<string, unknown> | null,
+}));
 
 vi.mock('node:child_process', () => {
   const handle = (args?: string[]) => {
@@ -22,6 +26,7 @@ vi.mock('node:child_process', () => {
       return '';
     }
     if (args[0] === 'kill-session') {
+      if (mockChildProcessControl.killError) throw mockChildProcessControl.killError;
       const target = args[2]?.replace(/^=/, '');
       if (target) mockTmuxSessions.delete(target);
       return '';
@@ -34,7 +39,10 @@ vi.mock('node:child_process', () => {
     return '';
   };
   return {
-    execFileSync: vi.fn().mockImplementation((_cmd: string, args?: string[]) => handle(args)),
+    execFileSync: vi.fn().mockImplementation((_cmd: string, args?: string[], opts?: Record<string, unknown>) => {
+      if (args?.[0] === 'kill-session') mockChildProcessControl.lastKillOptions = opts ?? null;
+      return handle(args);
+    }),
     execFile: vi.fn().mockImplementation(
       (_cmd: string, args: string[], _opts: unknown, cb?: (e: Error | null, r: { stdout: string }) => void) => {
         if (typeof _opts === 'function') cb = _opts as typeof cb;
@@ -45,7 +53,7 @@ vi.mock('node:child_process', () => {
   };
 });
 
-import { SessionManager } from '../../src/core/SessionManager.js';
+import { SessionManager, type SessionTerminateAuthority } from '../../src/core/SessionManager.js';
 import { StateManager } from '../../src/core/StateManager.js';
 import { ReapGuard, type ReapGuardDeps } from '../../src/core/ReapGuard.js';
 import type { SessionManagerConfig } from '../../src/core/types.js';
@@ -54,6 +62,8 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
   let tmpDir: string;
   let state: StateManager;
   let manager: SessionManager;
+  let terminateAuthority: SessionTerminateAuthority;
+  let maintenanceTick: () => Promise<void>;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-terminate-'));
@@ -68,8 +78,13 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
       protectedSessions: ['my-project-server'],
       completionPatterns: ['Session complete'],
     };
-    manager = new SessionManager(config, state);
+    manager = new SessionManager(config, state, {
+      bindTerminateAuthority: (authority) => { terminateAuthority = authority; },
+      bindMaintenanceTickForTesting: (tick) => { maintenanceTick = tick; },
+    });
     mockTmuxSessions.clear();
+    mockChildProcessControl.killError = null;
+    mockChildProcessControl.lastKillOptions = null;
   });
 
   afterEach(() => {
@@ -202,6 +217,47 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
       { minAgeMs: 0 }, // no spawn-grace so the active-process guard is what fires
     );
 
+  type MonitorSeam = {
+    isSessionAliveAsync(): Promise<boolean>;
+    recordBuildContextMaybeAsync(): Promise<void>;
+    detectCompletionMaybeAsync(): Promise<boolean>;
+    captureMeaningfulTailMaybeAsync(): Promise<string>;
+    hasActiveProcessesMaybeAsync(): Promise<boolean>;
+    isTranscriptRecentlyActive(): boolean;
+  };
+
+  const runLocalExpiredMonitorTick = async (
+    name: string,
+    beforeTick?: () => void,
+  ): Promise<{ id: string; blocked: string[]; authorityScopes: string[] }> => {
+    const s = await spawn(name);
+    state.saveSession({
+      ...s,
+      startedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+      maxDurationMinutes: 1,
+    });
+
+    const seam = manager as unknown as MonitorSeam;
+    seam.isSessionAliveAsync = async () => true;
+    seam.recordBuildContextMaybeAsync = async () => {};
+    seam.detectCompletionMaybeAsync = async () => false;
+    seam.captureMeaningfulTailMaybeAsync = async () => 'bypass permissions on';
+    seam.hasActiveProcessesMaybeAsync = async () => false;
+    seam.isTranscriptRecentlyActive = () => false;
+
+    const blocked: string[] = [];
+    const authorityScopes: string[] = [];
+    manager.on('reapBlocked', (event: { skipped?: string }) => {
+      if (event.skipped) blocked.push(event.skipped);
+    });
+    manager.on('sessionReaped', (event: { authorityScope?: string }) => {
+      if (event.authorityScope) authorityScopes.push(event.authorityScope);
+    });
+    beforeTick?.();
+    await maintenanceTick();
+    return { id: s.id, blocked, authorityScopes };
+  };
+
   it('without the flag, an active-process keep vetoes the reap (skipped:active-process)', async () => {
     manager.setReapGuard(guardWith());
     const s = await spawn('ap-1');
@@ -213,7 +269,7 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
   it('bypassActiveProcessKeep:true lifts the active-process veto ⇒ terminates', async () => {
     manager.setReapGuard(guardWith());
     const s = await spawn('ap-2');
-    const r = await manager.terminateSession(s.id, 'reaped-idle', { bypassActiveProcessKeep: true });
+    const r = await terminateAuthority(s.id, 'reaped-idle', { bypassActiveProcessKeep: true });
     expect(r.terminated).toBe(true);
     expect(state.getSession(s.id)!.status).toBe('completed');
   });
@@ -227,7 +283,7 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
       recentUserMessage: () => true,
     }));
     const s = await spawn('ap-3');
-    const r = await manager.terminateSession(s.id, 'reaped-idle', { bypassActiveProcessKeep: true });
+    const r = await terminateAuthority(s.id, 'reaped-idle', { bypassActiveProcessKeep: true });
     expect(r).toEqual({ terminated: false, skipped: 'recent-user-message' });
     expect(state.getSession(s.id)!.status).toBe('running');
   });
@@ -248,7 +304,7 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
   it('bypassRecentUserMessageForConfirmedMove:true lifts ONLY recent-user-message ⇒ terminates', async () => {
     manager.setReapGuard(guardWith({ hasActiveProcesses: () => false, topicBinding: () => 1, recentUserMessage: () => true }));
     const s = await spawn('move-2');
-    const r = await manager.terminateSession(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
+    const r = await terminateAuthority(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
     expect(r.terminated).toBe(true);
     expect(state.getSession(s.id)!.status).toBe('completed');
   });
@@ -258,7 +314,7 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
     // only, so this session must still be KEPT.
     manager.setReapGuard(guardWith({ hasActiveProcesses: () => true }));
     const s = await spawn('move-3');
-    const r = await manager.terminateSession(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
+    const r = await terminateAuthority(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
     expect(r).toEqual({ terminated: false, skipped: 'active-process' });
     expect(state.getSession(s.id)!.status).toBe('running');
   });
@@ -269,7 +325,7 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
       activeSubagentCount: () => 2, // a live subagent — must still veto
     }));
     const s = await spawn('move-4');
-    const r = await manager.terminateSession(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
+    const r = await terminateAuthority(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
     expect(r.terminated).toBe(false);
     expect(r.skipped).toBe('active-subagent');
     expect(state.getSession(s.id)!.status).toBe('running');
@@ -292,7 +348,7 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
       activeSubagentCount: () => 2,  // #8 — live, must win
     }));
     const s = await spawn('move-cooc-1');
-    const r = await manager.terminateSession(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
+    const r = await terminateAuthority(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
     expect(r).toEqual({ terminated: false, skipped: 'active-subagent' });
     expect(state.getSession(s.id)!.status).toBe('running'); // live session preserved
   });
@@ -308,7 +364,7 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
       activeCommitmentForTopic: () => true, // #7 — open commitment, must win
     }));
     const s = await spawn('move-cooc-2');
-    const r = await manager.terminateSession(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
+    const r = await terminateAuthority(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
     expect(r).toEqual({ terminated: false, skipped: 'open-commitment' });
     expect(state.getSession(s.id)!.status).toBe('running');
   });
@@ -322,7 +378,7 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
       recentUserMessage: () => true, // the ONLY live guard, and it is bypassed
     }));
     const s = await spawn('move-cooc-3');
-    const r = await manager.terminateSession(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
+    const r = await terminateAuthority(s.id, 'topic moved', { bypassRecentUserMessageForConfirmedMove: true });
     expect(r.terminated).toBe(true);
     expect(state.getSession(s.id)!.status).toBe('completed');
   });
@@ -337,18 +393,313 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
       mainProcessActive: () => true,         // #11 — live, must win
     }));
     const s = await spawn('ap-cooc-1');
-    const r = await manager.terminateSession(s.id, 'reaped-idle', { bypassActiveProcessKeep: true });
+    const r = await terminateAuthority(s.id, 'reaped-idle', { bypassActiveProcessKeep: true });
     expect(r).toEqual({ terminated: false, skipped: 'main-process-active' });
     expect(state.getSession(s.id)!.status).toBe('running');
   });
 
-  // ── bypassLeaseForTopicMovedCloseout (F8 lease carve-out, roadmap 0.6) ──────
+  // ── runtime-private topic-moved closeout authority (F8) ─────────────────────
   // The machine a topic moves AWAY from is by definition usually NOT the
   // serving-lease holder, so the lease gate structurally vetoed the exact
   // closeout the transfer requires (`skipped:'not-lease-holder'` ×5 → breaker
   // give-up → leftover session survived; test-as-self matrix 2026-07-02, F8).
   // The flag lifts ONLY the lease gate — protected, CAS, and every KEEP-guard
   // are re-checked and still veto. Both sides of every boundary:
+
+  it('REPRO: a non-lease-holder reaps its own over-age idle session through the maintenance path', async () => {
+    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false }));
+    manager.setAwakeChecker(() => false);
+    const { id, blocked, authorityScopes } = await runLocalExpiredMonitorTick('local-expired-on-standby', () => {
+      // Production standby posture: the coordinator makes the state tree
+      // read-only, while pool participation allows only per-session writes.
+      state.setSessionPoolActive(true);
+      state.setReadOnly(true);
+    });
+
+    // Before the fix this remains `running` and records `not-lease-holder`:
+    // the local monitor proves age + idleness, then the global lease gate
+    // vetoes the machine's cleanup of its own tmux process.
+    expect(state.getSession(id)).toMatchObject({ status: 'killed', endedReason: 'age-limit' });
+    expect(blocked).not.toContain('not-lease-holder');
+    expect(authorityScopes).toEqual(['local-age-limit']);
+  });
+
+  it('a public autonomous age-limit request on a non-holder remains lease-refused', async () => {
+    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false }));
+    manager.setAwakeChecker(() => false);
+    const s = await spawn('public-age-limit-standby');
+    const r = await manager.terminateSession(s.id, 'age-limit');
+    expect(r).toEqual({ terminated: false, skipped: 'not-lease-holder' });
+    expect(state.getSession(s.id)!.status).toBe('running');
+  });
+
+  it('the local age capability minter is runtime-private, not a callable prototype method', () => {
+    const runtimeManager = manager as unknown as Record<string, unknown>;
+    expect(runtimeManager.terminateLocalAgeExpiredSession).toBeUndefined();
+    expect(Object.getOwnPropertyNames(Object.getPrototypeOf(manager))).not.toContain(
+      'terminateLocalAgeExpiredSession',
+    );
+    expect(runtimeManager.terminateSessionInternal).toBeUndefined();
+    expect(Object.getOwnPropertyNames(Object.getPrototypeOf(manager))).not.toContain(
+      'terminateSessionInternal',
+    );
+  });
+
+  it('a startup tick before ReapGuard installation cannot mint local age authority', async () => {
+    manager.setAwakeChecker(() => false);
+    const { id, blocked } = await runLocalExpiredMonitorTick('local-age-before-guard', () => {
+      state.setSessionPoolActive(true);
+      state.setReadOnly(true);
+    });
+    expect(state.getSession(id)!.status).toBe('running');
+    expect(blocked).toContain('not-lease-holder');
+    expect(mockTmuxSessions.has(state.getSession(id)!.tmuxSession)).toBe(true);
+  });
+
+  it('a pure read-only standby refuses before touching tmux or durable state', async () => {
+    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false }));
+    manager.setAwakeChecker(() => false);
+    let beforeKill = 0;
+    manager.on('beforeSessionKill', () => { beforeKill++; });
+    const { id, blocked } = await runLocalExpiredMonitorTick('local-age-pure-standby', () => {
+      state.setReadOnly(true); // pool-active intentionally remains false
+    });
+    const saved = state.getSession(id)!;
+    expect(saved.status).toBe('running');
+    expect(blocked).toContain('not-lease-holder');
+    expect(beforeKill).toBe(0);
+    expect(mockTmuxSessions.has(saved.tmuxSession)).toBe(true);
+  });
+
+  it('an ownership change between preflight and commit refuses before touching tmux', async () => {
+    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false }));
+    manager.setAwakeChecker(() => false);
+    let beforeKill = 0;
+    manager.on('beforeSessionKill', () => { beforeKill++; });
+    let saveSpy: ReturnType<typeof vi.spyOn> | undefined;
+    const { id, blocked } = await runLocalExpiredMonitorTick('local-age-ownership-race', () => {
+      state.setSessionPoolActive(true);
+      state.setReadOnly(true);
+      // Preflight was admitted; model the ownership CAS changing immediately
+      // before the durable transition. The write-first protocol must not kill.
+      saveSpy = vi.spyOn(state, 'saveSession').mockImplementation(() => {
+        throw new Error('StateManager is read-only [write-refused:not-owner]');
+      });
+    });
+    saveSpy?.mockRestore();
+    const saved = state.getSession(id)!;
+    expect(saved.status).toBe('running');
+    expect(blocked).toContain('local-write-refused');
+    expect(beforeKill).toBe(1);
+    expect(mockTmuxSessions.has(saved.tmuxSession)).toBe(true);
+  });
+
+  it('a throwing before-kill listener cannot strand a committed local cleanup', async () => {
+    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false }));
+    manager.setAwakeChecker(() => false);
+    manager.on('beforeSessionKill', () => { throw new Error('listener exploded'); });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { id, blocked, authorityScopes } = await runLocalExpiredMonitorTick(
+      'local-age-listener-throws',
+      () => {
+        state.setSessionPoolActive(true);
+        state.setReadOnly(true);
+      },
+    );
+
+    consoleSpy.mockRestore();
+    const saved = state.getSession(id)!;
+    expect(saved).toMatchObject({ status: 'killed', endedReason: 'age-limit' });
+    expect(mockTmuxSessions.has(saved.tmuxSession)).toBe(false);
+    expect(blocked).toEqual([]);
+    expect(authorityScopes).toEqual(['local-age-limit']);
+  });
+
+  it('a local tmux kill failure compensates state and emits no false reap', async () => {
+    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false }));
+    manager.setAwakeChecker(() => false);
+    mockChildProcessControl.killError = new Error('tmux transport failure');
+    const { id, blocked, authorityScopes } = await runLocalExpiredMonitorTick(
+      'local-age-kill-fails',
+      () => {
+        state.setSessionPoolActive(true);
+        state.setReadOnly(true);
+      },
+    );
+
+    const saved = state.getSession(id)!;
+    expect(saved.status).toBe('running');
+    expect(saved.endedAt).toBeUndefined();
+    expect(saved.endedReason).toBeUndefined();
+    expect(mockTmuxSessions.has(saved.tmuxSession)).toBe(true);
+    expect(blocked).toContain('tmux-kill-failed');
+    expect(authorityScopes).toEqual([]);
+  });
+
+  it('an arbitrary public origin label is normalized to autonomous authority', async () => {
+    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false }));
+    manager.setAwakeChecker(() => false);
+    const s = await spawn('forged-origin-on-standby');
+    const r = await manager.terminateSession(s.id, 'age-limit', {
+      origin: 'anything',
+    } as Parameters<SessionManager['terminateSession']>[2] & { origin: string });
+
+    expect(r).toEqual({ terminated: false, skipped: 'not-lease-holder' });
+    expect(state.getSession(s.id)!.status).toBe('running');
+    expect(mockTmuxSessions.has(s.tmuxSession)).toBe(true);
+  });
+
+  it.each([
+    { option: 'knownDead', expected: 'recent-user-message', deps: { topicBinding: () => 1, recentUserMessage: () => true, hasActiveProcesses: () => false } },
+    { option: 'bypassRecoveryFlag', expected: 'recovery-in-flight', deps: { isRecoveryActive: () => true, hasActiveProcesses: () => false } },
+    { option: 'bypassActiveProcessKeep', expected: 'active-process', deps: {} },
+    { option: 'bypassRecentUserMessageForConfirmedMove', expected: 'recent-user-message', deps: { topicBinding: () => 1, recentUserMessage: () => true, hasActiveProcesses: () => false } },
+  ])('public callers cannot forge the $option guard bypass', async ({ option, expected, deps }) => {
+    manager.setReapGuard(guardWith(deps));
+    const s = await spawn(`forged-${option}`);
+    const r = await manager.terminateSession(s.id, 'forged-public-bypass', {
+      [option]: true,
+    } as Parameters<SessionManager['terminateSession']>[2] & Record<string, boolean>);
+    expect(r).toEqual({ terminated: false, skipped: expected });
+    expect(state.getSession(s.id)!.status).toBe('running');
+    expect(mockTmuxSessions.has(s.tmuxSession)).toBe(true);
+  });
+
+  it('a trusted operator kill reports tmux failure without changing state or emitting success', async () => {
+    const s = await spawn('operator-kill-fails');
+    mockChildProcessControl.killError = new Error('tmux transport failure');
+    let reaped = 0;
+    manager.on('sessionReaped', () => { reaped++; });
+    const r = await terminateAuthority(s.id, 'operator-kill', {
+      origin: 'operator',
+      finalStatus: 'killed',
+    });
+    expect(r).toEqual({ terminated: false, skipped: 'tmux-kill-failed' });
+    expect(state.getSession(s.id)!.status).toBe('running');
+    expect(mockTmuxSessions.has(s.tmuxSession)).toBe(true);
+    expect(reaped).toBe(0);
+  });
+
+  it('the synchronous tmux kill timeout is enforced with SIGKILL', async () => {
+    const s = await spawn('bounded-sync-kill');
+    const r = await terminateAuthority(s.id, 'operator-kill', {
+      origin: 'operator',
+      finalStatus: 'killed',
+    });
+    expect(r).toEqual({ terminated: true });
+    expect(mockChildProcessControl.lastKillOptions).toMatchObject({
+      timeout: 9000,
+      killSignal: 'SIGKILL',
+    });
+  });
+
+  it('a trusted operator kill fails closed when a listener revokes write admission before commit', async () => {
+    const s = await spawn('operator-write-race');
+    manager.on('beforeSessionKill', () => { state.setReadOnly(true); });
+    const r = await terminateAuthority(s.id, 'operator-kill', {
+      origin: 'operator',
+      finalStatus: 'killed',
+    });
+    expect(r).toEqual({ terminated: false, skipped: 'local-write-refused' });
+    expect(state.getSession(s.id)).toMatchObject({ status: 'running' });
+    expect(mockTmuxSessions.has(s.tmuxSession)).toBe(true);
+  });
+
+  it('listener-side admission loss wins before a simultaneous tmux transport failure', async () => {
+    const s = await spawn('operator-write-and-kill-race');
+    mockChildProcessControl.killError = new Error('tmux transport failure');
+    manager.on('beforeSessionKill', () => { state.setReadOnly(true); });
+    const r = await terminateAuthority(s.id, 'operator-kill', {
+      origin: 'operator',
+      finalStatus: 'killed',
+    });
+    expect(r).toEqual({ terminated: false, skipped: 'local-write-refused' });
+    expect(state.getSession(s.id)).toMatchObject({ status: 'running' });
+    expect(mockTmuxSessions.has(s.tmuxSession)).toBe(true);
+  });
+
+  it('post-kill listener failures cannot suppress success or the reap audit event', async () => {
+    const s = await spawn('operator-post-kill-listener-throws');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const observed: string[] = [];
+    manager.on('sessionComplete', () => { throw new Error('first completion listener exploded'); });
+    manager.on('sessionComplete', () => { observed.push('completion'); });
+    manager.on('sessionReaped', () => { throw new Error('first reap listener exploded'); });
+    manager.on('sessionReaped', () => { observed.push('reap'); });
+
+    const r = await terminateAuthority(s.id, 'operator-kill', {
+      origin: 'operator',
+      finalStatus: 'killed',
+    });
+
+    consoleSpy.mockRestore();
+    expect(r).toEqual({ terminated: true });
+    expect(state.getSession(s.id)).toMatchObject({ status: 'killed', endedReason: 'operator-kill' });
+    expect(mockTmuxSessions.has(s.tmuxSession)).toBe(false);
+    expect(observed).toEqual(['completion', 'reap']);
+  });
+
+  it.each([
+    {
+      label: 'recent user message',
+      expected: 'recent-user-message',
+      deps: { topicBinding: () => 1, recentUserMessage: () => true },
+    },
+    {
+      label: 'open commitment',
+      expected: 'open-commitment',
+      deps: {
+        topicBinding: () => 1,
+        recentUserMessage: (_topicId: number, withinMs: number) => withinMs > 30 * 60_000,
+        activeCommitmentForTopic: () => true,
+      },
+    },
+    {
+      label: 'in-flight structural work',
+      expected: 'structural-long-work',
+      deps: { topicBinding: () => 1, buildOrAutonomousActive: () => true },
+    },
+    {
+      label: 'recovery in flight',
+      expected: 'recovery-in-flight',
+      deps: { isRecoveryActive: () => true },
+    },
+  ])('the local age capability does not bypass $label', async ({ expected, deps }) => {
+    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false, ...deps }));
+    manager.setAwakeChecker(() => false);
+    const { id, blocked } = await runLocalExpiredMonitorTick(`local-age-kept-${expected}`);
+    expect(state.getSession(id)!.status).toBe('running');
+    expect(blocked).toContain(expected);
+  });
+
+  it('the protected-session floor still vetoes local standby age cleanup', async () => {
+    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false }));
+    manager.setAwakeChecker(() => false);
+    const protectedSession = {
+      id: 'protected-local-age', name: 'protected-local-age', status: 'running' as const,
+      tmuxSession: 'my-project-server',
+      startedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+      maxDurationMinutes: 1,
+      prompt: 'p',
+    };
+    state.saveSession(protectedSession);
+    const seam = manager as unknown as MonitorSeam;
+    seam.isSessionAliveAsync = async () => true;
+    seam.recordBuildContextMaybeAsync = async () => {};
+    seam.detectCompletionMaybeAsync = async () => false;
+    seam.captureMeaningfulTailMaybeAsync = async () => 'bypass permissions on';
+    seam.hasActiveProcessesMaybeAsync = async () => false;
+    seam.isTranscriptRecentlyActive = () => false;
+    await maintenanceTick();
+    expect(state.getSession(protectedSession.id)!.status).toBe('running');
+  });
+
+  it('the local-age authority workflow is absent from the runtime prototype', () => {
+    const runtime = manager as unknown as Record<string, unknown>;
+    expect(runtime.monitorTick).toBeUndefined();
+    expect(Object.getOwnPropertyNames(Object.getPrototypeOf(manager))).not.toContain('monitorTick');
+  });
 
   it('standby machine WITHOUT the flag → skipped:not-lease-holder (today\'s veto preserved)', async () => {
     manager.setReapGuard(guardWith({ hasActiveProcesses: () => false }));
@@ -359,54 +710,19 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
     expect(state.getSession(s.id)!.status).toBe('running');
   });
 
-  it('standby machine WITH bypassLeaseForTopicMovedCloseout → the closeout terminates (zero leftover)', async () => {
+  it('a public caller cannot forge closeout authority with a reason string or hidden option', async () => {
     manager.setReapGuard(guardWith({ hasActiveProcesses: () => false }));
     manager.setAwakeChecker(() => false);
-    const s = await spawn('lease-2');
-    const reason = 'topic moved to Mac Mini — closing the leftover session on this machine (post-transfer closeout)';
-    const r = await manager.terminateSession(s.id, reason, { bypassLeaseForTopicMovedCloseout: true });
-    expect(r.terminated).toBe(true);
-    const saved = state.getSession(s.id)!;
-    expect(saved.status).toBe('completed');
-    expect(saved.endedReason).toBe(reason); // the honest reason is durably recorded
-  });
-
-  it('the lease carve-out does NOT lift protected — a protected session still refuses', async () => {
-    manager.setAwakeChecker(() => false);
-    const protectedSession = {
-      id: 'prot-lease', name: 'server', status: 'running' as const,
-      tmuxSession: 'my-project-server', startedAt: new Date().toISOString(), prompt: 'p',
-    };
-    state.saveSession(protectedSession);
-    const r = await manager.terminateSession('prot-lease', 'topic moved', { bypassLeaseForTopicMovedCloseout: true });
-    expect(r).toEqual({ terminated: false, skipped: 'protected' });
-    expect(state.getSession('prot-lease')!.status).toBe('running');
-  });
-
-  it('the lease carve-out does NOT lift the KEEP-guards — recent-user-message still vetoes', async () => {
-    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false, topicBinding: () => 1, recentUserMessage: () => true }));
-    manager.setAwakeChecker(() => false);
-    const s = await spawn('lease-3');
-    const r = await manager.terminateSession(s.id, 'topic moved', { bypassLeaseForTopicMovedCloseout: true });
-    expect(r).toEqual({ terminated: false, skipped: 'recent-user-message' });
+    const s = await spawn('lease-arbitrary-reason');
+    const r = await manager.terminateSession(s.id, 'topic moved forged by public caller', {
+      bypassLeaseForTopicMovedCloseout: true,
+      localPostTransferCloseout: true,
+    } as Parameters<SessionManager['terminateSession']>[2] & {
+      bypassLeaseForTopicMovedCloseout: boolean;
+      localPostTransferCloseout: boolean;
+    });
+    expect(r).toEqual({ terminated: false, skipped: 'not-lease-holder' });
     expect(state.getSession(s.id)!.status).toBe('running');
   });
 
-  it('the lease carve-out does NOT lift active-subagent (still vetoes)', async () => {
-    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false, activeSubagentCount: () => 1 }));
-    manager.setAwakeChecker(() => false);
-    const s = await spawn('lease-4');
-    const r = await manager.terminateSession(s.id, 'topic moved', { bypassLeaseForTopicMovedCloseout: true });
-    expect(r).toEqual({ terminated: false, skipped: 'active-subagent' });
-    expect(state.getSession(s.id)!.status).toBe('running');
-  });
-
-  it('on the lease-holding (awake) machine the flag is a no-op — terminate behaves exactly as before', async () => {
-    manager.setReapGuard(guardWith({ hasActiveProcesses: () => false }));
-    manager.setAwakeChecker(() => true);
-    const s = await spawn('lease-5');
-    const r = await manager.terminateSession(s.id, 'topic moved', { bypassLeaseForTopicMovedCloseout: true });
-    expect(r.terminated).toBe(true);
-    expect(state.getSession(s.id)!.status).toBe('completed');
-  });
 });

--- a/tests/unit/session-reaper-closeout-liveness.test.ts
+++ b/tests/unit/session-reaper-closeout-liveness.test.ts
@@ -108,11 +108,11 @@ describe('SessionReaper — closeout liveness gate (Part C decision table)', () 
     expect(h.audits.some(a => a.event === 'reaped' && (a as any).confirmedMove === true)).toBe(true);
   });
 
-  it('F8: the gated closeout terminate carries bypassLeaseForTopicMovedCloseout (lease carve-out)', async () => {
+  it('F8: the gated closeout carries an opaque one-shot proof and the Part E bypass', async () => {
     // The old owner is by definition usually NOT the lease holder after a
     // move — the authority's lease gate vetoed the exact teardown the
     // transfer requires (audit F8). The gated path must carry the narrow
-    // lease bypass on every closeout terminate, alongside its Part E flag.
+    // one-shot closeout proof on every terminate, alongside its Part E flag.
     let r = 500_000;
     const h = harness({
       deps: {
@@ -124,11 +124,12 @@ describe('SessionReaper — closeout liveness gate (Part C decision table)', () 
     h.setNow(1_120_000); r = 700_000; await h.reaper.tick();
     expect(h.terminate).toHaveBeenCalledTimes(1);
     const opts = h.terminate.mock.calls[0][2] as any;
-    expect(opts?.bypassLeaseForTopicMovedCloseout).toBe(true);
+    expect(opts?.bypassLeaseForTopicMovedCloseout).toBeUndefined();
+    expect(opts?.localPostTransferCloseout).toBe(true);
     expect(opts?.bypassRecentUserMessageForConfirmedMove).toBe(true);
   });
 
-  it('F8: the lease bypass is carried even when the Part E bypass is withheld (fresher user message)', async () => {
+  it('F8: the one-shot proof is carried even when the Part E bypass is withheld', async () => {
     let r = 500_000;
     const terminate = vi.fn(async (_id: string, _reason: string, opts?: any) =>
       opts?.bypassRecentUserMessageForConfirmedMove ? { terminated: true } : { terminated: false, skipped: 'recent-user-message' });
@@ -143,8 +144,9 @@ describe('SessionReaper — closeout liveness gate (Part C decision table)', () 
     h.setNow(1_120_000); r = 700_000; await h.reaper.tick();
     expect(terminate).toHaveBeenCalledTimes(1);
     const opts = terminate.mock.calls[0][2];
-    // F8 lease bypass: always on for a closeout. Part E: correctly withheld.
-    expect(opts?.bypassLeaseForTopicMovedCloseout).toBe(true);
+    // No caller-controlled lease bypass exists. Part E is correctly withheld.
+    expect(opts?.bypassLeaseForTopicMovedCloseout).toBeUndefined();
+    expect(opts?.localPostTransferCloseout).toBe(true);
     expect(opts?.bypassRecentUserMessageForConfirmedMove).toBeUndefined();
   });
 

--- a/tests/unit/session-reaper-cpu-aware-keep.test.ts
+++ b/tests/unit/session-reaper-cpu-aware-keep.test.ts
@@ -43,6 +43,7 @@ interface Harness {
   setNow: (n: number) => void;
   setFrame: (f: string) => void;
   setCpu: (n: number) => void;
+  setTranscript: (p: TranscriptProbe) => void;
 }
 
 function harness(opts: {
@@ -54,6 +55,7 @@ function harness(opts: {
   let now = 1_000_000;
   let frame = IDLE_FRAME;
   let cpu = 0;
+  let transcript = RESOLVED_STATIC;
   const sessions = [mkSession()];
   const audits: Array<Record<string, unknown>> = [];
   const terminate = vi.fn(async () => ({ terminated: true }));
@@ -64,7 +66,7 @@ function harness(opts: {
     captureOutput: () => frame,
     hasActiveProcesses: () => true, // the active-process veto is in play by default here
     frameworkForSession: () => 'claude-code',
-    probeTranscript: () => RESOLVED_STATIC,
+    probeTranscript: () => transcript,
     isRecoveryActive: () => false,
     isRelayLeaseActive: () => false,
     hasPendingInjection: () => false,
@@ -99,6 +101,7 @@ function harness(opts: {
     setNow: (n) => { now = n; },
     setFrame: (f) => { frame = f; },
     setCpu: (n) => { cpu = n; },
+    setTranscript: (p) => { transcript = p; },
   };
 }
 
@@ -159,9 +162,8 @@ describe('cpuAwareActiveProcessKeep — evaluate() veto-relaxation (both sides)'
     return (async () => {
       await h.reaper.tick(); // records lastTranscript = size 100
       h.setCpu(0);
-      // Grow the transcript: override probe to a bigger size on next eval.
-      (h.reaper as unknown as { deps: SessionReaperDeps }).deps.probeTranscript =
-        () => ({ resolved: true, path: '/t.jsonl', size: 999, mtime: 2000 });
+      // Grow the constructor-injected probe's backing value on the next eval.
+      h.setTranscript({ resolved: true, path: '/t.jsonl', size: 999, mtime: 2000 });
       const e = h.reaper.evaluate(mkSession(), { cpuFlat: true });
       expect(e.cpuTightened).toBe(true);
       expect(e.keptBy).toBe('transcript-grew');
@@ -217,10 +219,11 @@ describe('cpuAwareActiveProcessKeep — cpuProgressFlat gating via tick() (both 
 
   it('under pressure + CPU RISING (working) ⇒ veto stands ⇒ never reaped', async () => {
     const h = harness();
-    let cpu = 0;
-    (h.reaper as unknown as { deps: SessionReaperDeps }).deps.descendantCpuSeconds = () => { cpu += 50; return cpu; };
+    h.setCpu(50);
     h.setNow(1_000_000); await h.reaper.tick(); // +50 over 0 → but no prior, undefined
+    h.setCpu(100);
     h.setNow(1_120_000); await h.reaper.tick(); // +50 over 120s = 0.42/s ≫ 0.02 ⇒ NOT flat
+    h.setCpu(150);
     h.setNow(1_240_000); await h.reaper.tick();
     expect(h.terminate).not.toHaveBeenCalled();
     expect(h.audits.some(a => a.event === 'cpu-keep-tightened')).toBe(false);

--- a/tests/unit/session-reaper-topic-moved.test.ts
+++ b/tests/unit/session-reaper-topic-moved.test.ts
@@ -89,6 +89,20 @@ function harness(opts: {
 }
 
 describe('SessionReaper — topic-moved closeout (post-transfer duplicate sessions)', () => {
+  it('all authority-bearing closeout and reap transitions are absent from the runtime prototype', () => {
+    const { reaper } = harness();
+    const runtime = reaper as unknown as Record<string, unknown>;
+    expect(runtime.attemptCloseoutTerminate).toBeUndefined();
+    expect(runtime.runCloseoutLegacy).toBeUndefined();
+    expect(runtime.runCloseoutGated).toBeUndefined();
+    expect(runtime.performReap).toBeUndefined();
+    const prototypeMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(reaper));
+    expect(prototypeMethods).not.toContain('attemptCloseoutTerminate');
+    expect(prototypeMethods).not.toContain('runCloseoutLegacy');
+    expect(prototypeMethods).not.toContain('runCloseoutGated');
+    expect(prototypeMethods).not.toContain('performReap');
+  });
+
   it('closes a session whose topic is owned by another machine after the confirm dwell — even while BUSY', async () => {
     const h = harness({ deps: { topicOwnerElsewhere: () => 'Laptop' } });
     await h.reaper.tick(); // streak 1 — below dwell, no kill yet
@@ -280,19 +294,19 @@ describe('SessionReaper — topic-moved closeout (post-transfer duplicate sessio
   // serving-lease holder, so the authority's lease gate structurally vetoed
   // the exact closeout the transfer requires (skipped:'not-lease-holder' ×5,
   // then breaker give-up — the leftover session survived). Every closeout
-  // terminate must therefore carry the narrow lease bypass.
+  // terminate must therefore carry the verified one-shot closeout proof.
 
-  it('F8: the closeout terminate carries bypassLeaseForTopicMovedCloseout (legacy path)', async () => {
+  it('F8: the closeout carries an opaque proof without a public bypass option', async () => {
     const h = harness({ deps: { topicOwnerElsewhere: () => 'Mac Mini' } });
     await h.reaper.tick();
     h.setNow(1_120_000); await h.reaper.tick(); // dwell met → terminate
     expect(h.terminate).toHaveBeenCalledTimes(1);
     const opts = h.terminate.mock.calls[0][2] as {
-      bypassLeaseForTopicMovedCloseout?: boolean;
       bypassRecentUserMessageForConfirmedMove?: boolean;
+      localPostTransferCloseout?: boolean;
       workEvidence?: string[];
     } | undefined;
-    expect(opts?.bypassLeaseForTopicMovedCloseout).toBe(true);
+    expect(opts?.localPostTransferCloseout).toBe(true);
     // The legacy path never mints the Part E recent-message bypass, and it
     // leaves workEvidence unset so the authority's guard-collected fallback
     // is preserved (F8 lifts ONLY the lease gate — nothing else changes).
@@ -300,13 +314,10 @@ describe('SessionReaper — topic-moved closeout (post-transfer duplicate sessio
     expect(opts?.workEvidence).toBeUndefined();
   });
 
-  it('F8: a lease-vetoing authority closes the leftover once the bypass is honored (regression shape of the audit)', async () => {
-    // Model the audited failure: an authority that refuses any closeout
-    // WITHOUT the lease bypass (the old machine is not the lease holder), but
-    // honors the carve-out. Pre-fix, the reaper passed no flag → 5 vetoes →
-    // breaker give-up; with the fix the FIRST attempt lands.
-    const terminate = vi.fn(async (_id: string, _r: string, opts?: { bypassLeaseForTopicMovedCloseout?: boolean }) =>
-      opts?.bypassLeaseForTopicMovedCloseout ? { terminated: true } : { terminated: false, skipped: 'not-lease-holder' });
+  it('F8: the proof-carrying closeout closes the leftover on its first attempt', async () => {
+    // The legacy bug sent closeout through ordinary lease-gated terminate and
+    // reached the breaker. The dedicated authority lands the first attempt.
+    const terminate = vi.fn(async () => ({ terminated: true }));
     const raiseAttention = vi.fn();
     const h = harness({ deps: { topicOwnerElsewhere: () => 'Mac Mini', terminate, raiseAttention } });
     await h.reaper.tick();

--- a/tests/unit/session-reaper-wiring.test.ts
+++ b/tests/unit/session-reaper-wiring.test.ts
@@ -23,6 +23,19 @@ describe('SessionReaper wiring integrity', () => {
     expect(/new AgentServer\(\{[\s\S]*sessionReaper[\s\S]*\}\)/.test(src)).toBe(true);
   });
 
+  it('starts SessionManager maintenance only after guard and pool-write posture wiring', () => {
+    const src = read('src/commands/server.ts');
+    const guardAt = src.indexOf('sessionManager.setReapGuard(');
+    const poolPostureAt = src.indexOf('state.setSessionPoolActive(true)');
+    const monitoringAt = src.indexOf('sessionManager.startMonitoring()');
+    const serverAt = src.indexOf('await server.start()', monitoringAt);
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(poolPostureAt).toBeGreaterThan(guardAt);
+    expect(monitoringAt).toBeGreaterThan(poolPostureAt);
+    expect(serverAt).toBeGreaterThan(monitoringAt);
+    expect(src.match(/sessionManager\.startMonitoring\(\)/g)).toHaveLength(1);
+  });
+
   it('server.ts composes socket+silence into the recovery veto (compose, not replace)', () => {
     const src = read('src/commands/server.ts');
     expect(src).toContain('socketRecoveryActive');
@@ -46,34 +59,58 @@ describe('SessionReaper wiring integrity', () => {
     expect(/busyOrphanDetection:\s*resolveDevAgentGate\(\s*rcfg\.busyOrphanDetection,\s*config\s*\)/.test(src)).toBe(true);
   });
 
-  it('reaper terminate dep threads the F8 lease carve-out through to the authority', () => {
-    // F8 (roadmap 0.6): the closeout's bypassLeaseForTopicMovedCloseout must
-    // survive the server.ts terminate-dep hop into terminateSession — dropping
-    // it there would silently restore the not-lease-holder veto the carve-out
-    // exists to lift (the dead-dep trap, again).
+  it('server wiring captures the terminate authority at manager birth and gives it to the reaper', () => {
     const src = read('src/commands/server.ts');
-    expect(/bypassLeaseForTopicMovedCloseout:\s*opts\?\.bypassLeaseForTopicMovedCloseout/.test(src)).toBe(true);
+    expect(src).toContain('bindTerminateAuthority: (authority) => { boundTerminateAuthority = authority; }');
+    expect(src).toContain('terminateWithAuthority(id, reason');
+    expect(src).toContain('localPostTransferCloseout: opts?.localPostTransferCloseout');
+    expect(src).not.toContain('bypassLeaseForTopicMovedCloseout: opts?.bypassLeaseForTopicMovedCloseout');
   });
 
-  it('F8 scope-guard: the lease carve-out is minted ONLY inside the topic-moved closeout machinery', () => {
-    // The carve-out's whole safety story is its scope: only the closeout of a
-    // session whose topic PROVABLY moved away (topicOwnerElsewhere + dwell,
-    // both enforced before attemptCloseoutTerminate is reachable) may lift the
-    // lease gate. The reaper's OTHER terminate (the idle reap) must never
-    // carry it — exact-object toHaveBeenCalledWith assertions in
-    // session-reaper.test.ts prove the runtime side; this pins the source side.
+  it('the write-first synchronous kill is bounded with SIGKILL, not ignorable SIGTERM', () => {
+    const manager = read('src/core/SessionManager.ts');
+    expect(manager).toContain("timeout: this.tmuxCallTimeoutMs, killSignal: 'SIGKILL'");
+  });
+
+  it('F8 scope-guard: the assertion exists only behind runtime-private reaper deps', () => {
     const src = read('src/monitoring/SessionReaper.ts');
-    const mints = src.match(/bypassLeaseForTopicMovedCloseout:\s*true/g) ?? [];
-    expect(mints.length).toBe(2); // both arms of the ONE closeout terminate call
-    const closeoutStart = src.indexOf('private async attemptCloseoutTerminate(');
+    const closeoutStart = src.indexOf('async #attemptCloseoutTerminate(');
     const closeoutEnd = src.indexOf('\n  private ', closeoutStart + 1);
     const body = src.slice(closeoutStart, closeoutEnd === -1 ? undefined : closeoutEnd);
-    expect((body.match(/bypassLeaseForTopicMovedCloseout:\s*true/g) ?? []).length).toBe(2);
+    expect(body).toContain('localPostTransferCloseout: true');
+    expect(body).toContain('this.#deps.terminate(');
+    expect(src).toContain('readonly #deps: Readonly<SessionReaperDeps>');
+    expect(src).not.toContain('private async attemptCloseoutTerminate(');
+    expect(src).toContain('async #runCloseoutLegacy(');
+    expect(src).toContain('async #runCloseoutGated(');
+    expect(src).toContain('async #performReap(');
+    expect(src).not.toContain('private async runCloseoutLegacy(');
+    expect(src).not.toContain('private async runCloseoutGated(');
+    expect(src).not.toContain('private async performReap(');
+    expect(src).not.toContain('bypassLeaseForTopicMovedCloseout');
+    expect(src).not.toContain('TopicMovedCloseoutProof');
+
+    const manager = read('src/core/SessionManager.ts');
+    expect(manager).toContain('bindTerminateAuthority?:');
+    expect(manager).not.toContain('registerTopicMovedCloseoutTarget');
+    expect(manager).not.toContain('consumeTopicMovedCloseoutProof');
   });
 
   it('AgentServer threads options.sessionReaper into the route context', () => {
     const src = read('src/server/AgentServer.ts');
     expect(src).toContain('sessionReaper: options.sessionReaper ?? null');
+  });
+
+  it('the authenticated operator route receives the birth-bound authority, not raw killSession', () => {
+    const server = read('src/commands/server.ts');
+    const agentServer = read('src/server/AgentServer.ts');
+    const routes = read('src/server/routes.ts');
+    expect(server).toContain('terminateSessionAuthority: terminateWithAuthority');
+    expect(agentServer).toContain('terminateSessionAuthority: options.terminateSessionAuthority');
+    expect(routes).toContain("ctx.terminateSessionAuthority(target.id, 'operator-kill'");
+    const start = routes.indexOf("router.delete('/sessions/:id'");
+    const end = routes.indexOf("router.post('/sessions/:name/remote-close'", start);
+    expect(routes.slice(start, end)).not.toContain('killSession(');
   });
 
   it('routes.ts exposes GET /sessions/reaper backed by ctx.sessionReaper', () => {

--- a/tests/unit/session-reaper.test.ts
+++ b/tests/unit/session-reaper.test.ts
@@ -131,9 +131,10 @@ describe('SessionReaper — protect-gates each force KEEP', () => {
   }
 
   it('KEEPs a freshly-spawned session (spawn grace)', () => {
-    const h = harness({ cfg: { minAgeMinutes: 30 }, sessions: [mkSession({ startedAt: new Date(Date.now()).toISOString() })] });
+    const session = mkSession({ startedAt: new Date(Date.now()).toISOString() });
+    const h = harness({ cfg: { minAgeMinutes: 30 }, sessions: [session] });
     // now() is 1_000_000 ms; startedAt ~ Date.now() (much larger) → age negative → grace.
-    const e = h.reaper.evaluate(h.reaper['deps'].listRunningSessions()[0]);
+    const e = h.reaper.evaluate(session);
     expect(e.keptBy).toBe('spawn-grace');
   });
 });

--- a/tests/unit/session-telegram-inject.test.ts
+++ b/tests/unit/session-telegram-inject.test.ts
@@ -16,6 +16,7 @@ import { getTelegramInboundDir } from '../../src/messaging/shared/telegramInboun
 describe('SessionManager.injectTelegramMessage', () => {
   let project: TempProject;
   let sendKeyCalls: string[][];
+  const maintenanceTicks = new WeakMap<SessionManager, () => Promise<void>>();
 
   beforeEach(() => {
     project = createTempProject();
@@ -75,17 +76,23 @@ describe('SessionManager.injectTelegramMessage', () => {
   // ── Delivery-chokepoint dedup (a single user message must reach a session at
   // most once even if an upstream path over-forwards it 5x). We count the temp
   // files written for a unique topicId to detect whether a delivery happened.
-  const mkSm = () => new SessionManager(
-    {
-      tmuxPath: '/usr/bin/tmux',
-      claudePath: '/usr/bin/claude',
-      projectDir: project.dir,
-      maxSessions: 3,
-      protectedSessions: [],
-      completionPatterns: [],
-    },
-    project.state,
-  );
+  const mkSm = () => {
+    let maintenanceTick!: () => Promise<void>;
+    const sm = new SessionManager(
+      {
+        tmuxPath: '/usr/bin/tmux',
+        claudePath: '/usr/bin/claude',
+        projectDir: project.dir,
+        maxSessions: 3,
+        protectedSessions: [],
+        completionPatterns: [],
+      },
+      project.state,
+      { bindMaintenanceTickForTesting: (tick) => { maintenanceTick = tick; } },
+    );
+    maintenanceTicks.set(sm, maintenanceTick);
+    return sm;
+  };
   const longText = 'Z'.repeat(600); // exceeds the 500-char file threshold
   const countFilesFor = (topicId: number) => {
     const dir = getTelegramInboundDir(project.dir);
@@ -154,7 +161,6 @@ describe('SessionManager.injectTelegramMessage', () => {
       isSessionAliveAsync: (tmuxSession: string) => Promise<boolean>;
       captureOutput: (tmuxSession: string, lines?: number) => string | null;
       recordBuildContext: () => void;
-      monitorTick: () => Promise<void>;
     };
     smAny.pendingInjections.set('gemini-topic-1', {
       topicId: 1,
@@ -180,7 +186,7 @@ describe('SessionManager.injectTelegramMessage', () => {
     const detected: Array<{ topicId: number; sessionName: string; text: string }> = [];
     sm.on('injectionReplyDetected', (info) => detected.push(info as { topicId: number; sessionName: string; text: string }));
 
-    await smAny.monitorTick();
+    await maintenanceTicks.get(sm)!();
 
     expect(detected).toHaveLength(1);
     expect(detected[0]).toMatchObject({

--- a/tests/unit/session-timeout-activity-aware.test.ts
+++ b/tests/unit/session-timeout-activity-aware.test.ts
@@ -85,10 +85,10 @@ describe('Activity-aware session-timeout gate', () => {
     // When the activity check confirms idle, the kill path fires. Post
     // UNIFIED-SESSION-LIFECYCLE §P0 the inline kill is replaced by a route
     // through the single ReapAuthority: the warning still names the timeout +
-    // idle condition, then funnels through terminateSession('age-limit').
+    // idle condition, then funnels through the private local-age-limit entrypoint.
     expect(SM_SOURCE).toContain('exceeded timeout');
     expect(SM_SOURCE).toContain('and is idle');
-    expect(SM_SOURCE).toMatch(/terminateSession\(\s*session\.id,\s*'age-limit'/);
+    expect(SM_SOURCE).toMatch(/#terminateLocalAgeExpiredSession\(\s*session\.id\s*\)/);
   });
 
   it('does not skip idle-detection when deferring the timeout kill', () => {

--- a/tests/unit/work-evidence.test.ts
+++ b/tests/unit/work-evidence.test.ts
@@ -55,7 +55,7 @@ import {
   weakEvidence,
 } from '../../src/core/WorkEvidence.js';
 import { ReapGuard, type ReapGuardDeps } from '../../src/core/ReapGuard.js';
-import { SessionManager } from '../../src/core/SessionManager.js';
+import { SessionManager, type SessionTerminateAuthority } from '../../src/core/SessionManager.js';
 import { StateManager } from '../../src/core/StateManager.js';
 import type { Session, SessionManagerConfig } from '../../src/core/types.js';
 
@@ -255,6 +255,7 @@ describe('terminateSession — evidence threading (R2.1)', () => {
   let tmpDir: string;
   let state: StateManager;
   let manager: SessionManager;
+  let terminateAuthority: SessionTerminateAuthority;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-evidence-'));
@@ -269,7 +270,9 @@ describe('terminateSession — evidence threading (R2.1)', () => {
       protectedSessions: [],
       completionPatterns: ['Session complete'],
     };
-    manager = new SessionManager(config, state);
+    manager = new SessionManager(config, state, {
+      bindTerminateAuthority: (authority) => { terminateAuthority = authority; },
+    });
     mockTmuxSessions.clear();
   });
 
@@ -325,7 +328,7 @@ describe('terminateSession — evidence threading (R2.1)', () => {
     const reaped: Array<{ midWork?: boolean; workEvidence?: string[] }> = [];
     manager.on('sessionReaped', (e) => reaped.push(e));
 
-    const result = await manager.terminateSession(session.id, 'reaped-idle', {
+    const result = await terminateAuthority(session.id, 'reaped-idle', {
       origin: 'autonomous',
       bypassActiveProcessKeep: true,
     });
@@ -363,7 +366,7 @@ describe('terminateSession — evidence threading (R2.1)', () => {
     const reaped: Array<{ midWork?: boolean; workEvidence?: string[] }> = [];
     manager.on('sessionReaped', (e) => reaped.push(e));
 
-    const result = await manager.terminateSession(session.id, 'quota-shed', {
+    const result = await terminateAuthority(session.id, 'quota-shed', {
       origin: 'autonomous',
       bypassActiveProcessKeep: true,
     });
@@ -378,7 +381,7 @@ describe('terminateSession — evidence threading (R2.1)', () => {
     const reaped: Array<{ midWork?: boolean; workEvidence?: string[] }> = [];
     manager.on('sessionReaped', (e) => reaped.push(e));
 
-    const result = await manager.terminateSession(session.id, 'boot-purge', {
+    const result = await terminateAuthority(session.id, 'boot-purge', {
       origin: 'autonomous',
       knownDead: true,
     });

--- a/upgrades/next/session-reaper-local-age-owner.md
+++ b/upgrades/next/session-reaper-local-age-owner.md
@@ -1,0 +1,40 @@
+# Non-Lease-Holder Local Session Cleanup
+
+<!-- bump: patch -->
+
+## What Changed
+
+A machine that does not hold the serving lease can now close one of its own over-age, positively-idle
+session processes. The exception is capability-gated inside the termination authority and is not
+available to public autonomous callers. Shared routing and remote-machine action remain lease-holder
+only, and every existing protected-work veto still applies. All real cleanup paths isolate their
+pre-kill observers, recheck and commit terminal state, then stop the process synchronously under a
+hard timeout. An ownership change therefore refuses cleanly instead of producing a killed process
+with a still-running durable record. If the process stop fails, the state is compensated back to
+running and the attempt is logged as refused rather than falsely successful. A broken lifecycle
+observer cannot suppress the reap audit after a successful stop.
+
+New reap-log rows identify whether a termination was admitted by the lease holder, the local age
+monitor, the local post-transfer closeout path, or an operator action.
+
+## What to Tell Your User
+
+On a multi-machine agent, an idle expired session no longer gets stranded merely because its host
+computer is not currently serving messages. Active work, recent conversations, commitments,
+recovery, and protected sessions remain safe from automatic cleanup.
+
+## Summary of New Capabilities
+
+- Cleans up expired idle sessions on the machine where their process actually runs.
+- Keeps ordinary non-holder termination requests lease-refused.
+- Leaves both state and process running if final ownership admission changes.
+- Restores running state and emits no success when tmux teardown fails.
+- Records the admitting authority domain alongside the machine in the reap audit trail.
+
+## Evidence
+
+- `tests/unit/session-manager-terminate.test.ts`
+- `tests/unit/session-timeout-activity-aware.test.ts`
+- `tests/unit/reap-log.test.ts`
+- `tests/integration/session-lifecycle-reap-wiring.test.ts`
+- `tests/unit/self-action-convergence.test.ts`

--- a/upgrades/session-reaper-local-age-owner.eli16.md
+++ b/upgrades/session-reaper-local-age-owner.eli16.md
@@ -1,0 +1,50 @@
+# Local session cleanup on a non-serving machine
+
+When one Instar agent runs on two computers, one machine holds the serving lease. That lease decides
+which machine may act on shared routing and cross-machine state. It does not, however, make a process
+on the other computer stop existing. A session running inside the laptop's own terminal multiplexer
+can be inspected and terminated only by the laptop.
+
+The old rule treated every autonomous cleanup as cross-machine authority. A non-serving machine could
+correctly prove that one of its own sessions was far beyond its lifetime limit and positively idle,
+ask the central termination authority to close it, and then be refused because it did not hold the
+serving lease. The lease holder could not help: the process was not in its local process namespace.
+The result was a permanent contradiction—one machine was the only machine capable of cleanup and was
+also the one machine categorically forbidden from doing it.
+
+The correction separates the two ownership domains. Shared and remote action remains lease-holder
+only. The local age monitor gets one runtime-private capability to close an over-age session from its
+own machine-local session registry. Neither that capability nor the internal options cross a runtime-
+callable method. The termination authority accepts it only for the exact age-limit path, after the
+safety guard is installed. For every real cleanup, continuity observers run independently while the
+process is still inspectable; the final closed record is then saved and tmux is stopped immediately
+under a hard bound. If ownership changes at that last boundary, the save is refused and the process
+remains alive. Ordinary autonomous calls—including a public age-limit request—remain lease-refused.
+If tmux itself refuses the stop, the terminal record is restored to “running” and no successful reap
+is emitted. A broken lifecycle observer cannot interrupt the safe transition or suppress the later
+audit.
+
+This does not turn age into sufficient evidence. The monitor must still prove the session is idle,
+and the authority still rechecks protected-session status, recent user interaction, open commitments,
+active subagents, structural work, recovery-in-flight, process activity, compare-and-set state, and
+the in-flight lock. The existing self-action governor and retry backoff are unchanged. The durable
+reap record now names both the machine and the authority scope, so a future pool-side count can
+distinguish normal lease-holder cleanup from this local-only exception without guessing from timing.
+
+The laptop-side historical counts that prompted the investigation were not used as proof. The laptop
+was offline and its cleanup log is machine-local, so those numbers could not be independently
+re-derived. Instead, the regression test drives the real maintenance loop: before the correction it
+proves age and idleness, receives `not-lease-holder`, and leaves the session running; after the
+correction the same session is closed while all protective veto cases remain running.
+
+An independent adversarial review found and forced closure of several successive draft holes:
+TypeScript-only privacy exposed minters, caller-controlled internal inputs could forge targets or
+bypasses, preflight followed by kill then save left an ownership-change race, listener failures could
+suppress the audit, and the default timeout signal could leave a wedged tmux client blocking forever.
+The final design uses
+JavaScript runtime-private authority methods, hands the trusted termination closure to server boot
+only while the manager is being constructed, makes reaper dependencies runtime-private and immutable,
+drops every forged public bypass option, commits terminal state immediately before a SIGKILL-bounded
+synchronous process action, compensates it on process-kill failure, isolates lifecycle observers, and
+starts maintenance only after all authority dependencies are wired.
+Dedicated tests preserve those exact attacks as regressions.

--- a/upgrades/side-effects/session-reaper-local-age-owner.md
+++ b/upgrades/side-effects/session-reaper-local-age-owner.md
@@ -1,0 +1,214 @@
+# Side-Effects Review — Non-Lease-Holder Local Age Cleanup
+
+**Version / slug:** `session-reaper-local-age-owner`
+**Date:** `2026-08-02`
+**Author:** `Instar Agent (instar-codey)`
+**Second-pass reviewer:** `Heisenberg (item12_security_r1)`
+
+## Summary of the change
+
+`SessionManager` now gives its machine-local age monitor a runtime-private capability to terminate an
+over-age, positively-idle session even when that machine does not hold the serving lease. The public
+termination API does not accept the capability, and the authority validates both its unforgeable
+identity and the literal `age-limit` reason. It also requires an installed KEEP guard and preflights
+the exact StateManager session-write admission before touching tmux. `ReapLog` adds the optional `authorityScope` field so the
+local exception is visible beside the already-recorded machine identity. The unified lifecycle spec,
+plain-English overview, controller registry pointer, and production-path tests are updated together.
+
+## Decision-point inventory
+
+- `SessionManager` age-limit maintenance branch — **modify** — requests local cleanup through a
+  runtime-private capability-minting entrypoint after existing age and positive-idle proof.
+- `SessionManager.terminateSessionInternal()` lease gate — **modify** — admits only the runtime-private
+  local-age capability after guard/write readiness while preserving lease refusal for every public
+  autonomous request and normalizing forged public origin labels to autonomous.
+- `SessionManager` process transition protocol — **modify** — isolates pre-kill observers, commits the
+  terminal session row, and performs a SIGKILL-bounded synchronous tmux action with no intervening
+  event-loop turn; every authority class refuses without a kill if final write admission changes.
+- Post-transfer closeout wiring — **modify** — removes the public Boolean/reusable-closure lease bypass
+  and replaces first-claim binding with a termination closure handed to the composition root only at
+  manager construction; reaper dependencies become runtime-private and frozen.
+- `StateManager` session-write admission — **modify** — exposes its exact non-mutating assertion so
+  local cleanup cannot kill a process before learning the durable transition would be refused.
+- Server startup — **modify** — starts session maintenance after ReapGuard and pool posture wiring.
+- `SessionManager.terminateSessionInternal()` reap event — **modify** — stamps the admitting authority
+  domain for durable observability.
+- `ReapLog` write/read normalization — **modify** — persists a closed-enum optional authority scope.
+
+---
+
+## 1. Over-block
+
+The intended authenticated operator-kill route still succeeds through the birth-bound termination
+authority and therefore retains truthful process outcome plus reap-log coverage. The public
+autonomous termination method no longer honors caller-minted `origin:'operator'` labels; that
+was an authority-forgery hole exposed by the adversarial pass, not a supported contract. A public
+autonomous age-limit request on a non-holder still returns `not-lease-holder`; only the production
+monitor can mint the local capability. Existing protected and KEEP-guard refusals retain their exact
+reason.
+
+---
+
+## 2. Under-block
+
+The capability does not make an active session eligible. A false idle proof in the pre-existing
+three-signal age gate remains the principal residual risk, bounded by the independent guard cascade
+and the existing activity-aware tests. A pure standby or ownership-refused session cannot use this
+path: the authority calls the same non-mutating write-admission assertion as `saveSession` before
+touching tmux. The production active-active pool posture permits the eligible machine's exact
+per-session write while shared-state writes remain blocked.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The change belongs in the single ReapAuthority rather than in tmux or the serving-lease coordinator.
+The monitor produces the age/idle signal; the authority alone decides whether the kill may proceed.
+A runtime-private capability expresses the local-process ownership fact without widening the public
+caller contract or teaching the global lease about machine-local processes. The existing closeout
+exception now uses the same structural rule instead of a caller-controlled Boolean.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [x] Yes — but this is the existing deterministic ReapAuthority over an enumerable lifecycle domain.
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+Age and idle detection still have no kill authority. They feed the existing termination authority,
+which holds the protected, lease, KEEP-guard, compare-and-set, in-flight, and self-action floors. The
+new age capability is a hard provenance invariant: both JavaScript `#` authority methods are absent
+from the runtime prototype, and its internal capability never crosses an overridable method. The
+other trusted bypasses ride a termination closure delivered only during manager construction and held
+in the server composition root's lexical scope. Public termination copies only inert fields and drops
+unknown/cast bypass keys. A fabricated reaper therefore cannot acquire authority even if constructed
+before the production reaper; the production reaper's terminate dependency cannot be swapped after
+construction.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new competing-signals heuristic is introduced. Age and idleness remain governed by the existing
+three-signal decision, and all live work signals remain vetoes. This change corrects an enumerable
+authority-domain invariant: a local tmux process can be acted on only by its host machine, while
+shared or remote state remains lease-holder-only.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The private capability bypasses only the lease-holder test. Protected-session and
+  ReapGuard checks still run before any kill; CAS and in-flight checks still run afterward.
+- **Double-fire:** The single-writer CAS remains the only termination chokepoint. A successful local
+  reap clears the existing age backoff; no second actor can target the remote process.
+- **Races:** A lease transition during the call does not widen authority. Each continuity observer
+  runs independently while tmux is still inspectable; the terminal save then repeats ownership
+  admission after those observers. Refusal returns `local-write-refused` (local/operator authority) or
+  `state-write-refused` (ordinary autonomous authority), leaves durable state running, and leaves tmux
+  alive. The successful commit is followed immediately by a synchronous tmux action bounded by the
+  configured timeout and `SIGKILL`, with no event-loop turn between them. Maintenance does not start
+  until guard and pool posture wiring have completed. A non-definitive tmux failure compensates the
+  row back to its running snapshot and emits a named refusal with no success event; compensation
+  failure has its own named refusal rather than being hidden. Post-kill lifecycle listeners are
+  isolated per callback, so one observer cannot suppress a later durable reap-log listener.
+- **Feedback loops:** Existing age-kill governor admission and `AgeKillBackoff` remain ahead of the
+  capability mint. Sustained vetoes still settle under the registered convergence model.
+
+---
+
+## 6. External surfaces
+
+The authenticated reap-log read may now include `authorityScope` on new reaped rows. The field is a
+closed enum and contains no session content. Existing consumers tolerate its absence on legacy rows.
+There are no new network calls, messages, configuration fields, URLs, databases, or operator actions.
+Normal terminal-reap notification behavior is unchanged.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface is added or modified. The existing reap-log read gains one optional diagnostic
+field; no dashboard, approval page, or form changes.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local by design.** The target resource is a tmux process plus its per-machine session file;
+neither can be terminated by a peer. The serving lease continues to guard shared routing and every
+ordinary autonomous termination. Production tests put the state tree into the real read-only standby
+plus pool-active posture and prove only the session-scoped write lands. Both a first tick before guard
+installation and a pure read-only/pool-inactive standby are refused before `beforeSessionKill` or tmux.
+
+The reap-log is also machine-local by design and already stamps its machine identity. The new
+`authorityScope` makes the local exception directly countable. The change emits no new user-facing
+notice class, holds no new durable state, and generates no URL.
+
+---
+
+## 8. Rollback cost
+
+Rollback is a normal code revert and patch release. New log rows may retain the optional
+`authorityScope` field; older readers ignore unknown JSON fields. No migration, state repair, or user
+action is required. Rolling back restores the zombie-retention defect on non-holders but does not
+corrupt existing state.
+
+---
+
+## Conclusion
+
+The implementation closes the contradictory authority boundary without broadening cross-machine
+power. Multiple adversarial rounds exposed runtime-callable TypeScript privacy, startup/write-order
+races, reusable or interceptable closeout authority, caller-forged origin authority, listener-driven
+audit suppression, false-success state/process divergence, and an ignorable timeout signal. Each
+demonstrated attack now has a structural repair and regression test. The final fresh adversarial
+verdict explicitly concurs with no remaining concrete blocker in scope.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `Heisenberg (item12_security_r1)`
+**Independent read of the artifact:** Intermediate rounds: **FAIL**, with concrete falsifiers. The
+reviewer demonstrated that TypeScript-only privacy was runtime-callable; a pre-guard/pure-standby tick
+could kill before durable write refusal; authority-scope labeling followed a caller flag;
+reusable/captured or first-claim closeout authority could be forged; caller-supplied operator labels
+crossed the lease/KEEP boundary; and a listener or tmux failure could leave process and state divergent
+while claiming success. The final round also found that Node's default `SIGTERM` did not truly bound a
+wedged synchronous tmux client. The correction uses JavaScript-private authority workflows, exact
+write admission, late maintenance startup, birth-time authority handoff, public option whitelisting,
+normalization, derived scope, per-listener isolation, a SIGKILL-bounded synchronous process action,
+and kill-failure compensation. **Final verdict: PASS / explicit concurrence on the exact revision.**
+The reviewer reported no remaining concrete authority-minting or state/process-divergence falsifier.
+Independent verification passed TypeScript and 156/156 focused checks; the author's final broader
+focused matrix passed 179/179, with lint and build also green.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/session-manager-terminate.test.ts` — production maintenance reproduction plus every
+  authority/KEEP boundary, runtime privacy, startup-guard, pure-standby, and honest-scope regressions.
+- `tests/unit/session-reaper-wiring.test.ts` — maintenance startup is structurally after guard and
+  pool-write posture wiring.
+- `tests/unit/session-timeout-activity-aware.test.ts` — age/idle proof remains required.
+- `tests/unit/reap-log.test.ts` — authority-scope and machine-identity round trip.
+- `tests/integration/session-lifecycle-reap-wiring.test.ts` — termination/reap-log lifecycle wiring.
+- `tests/unit/self-action-convergence.test.ts` — registered age-kill controller settles under
+  sustained rejection.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+`defectClass: unbounded-self-action`, `closure: guard`, `guardEvidence:
+{ enforcementType: ratchet, citation: tests/unit/self-action-convergence.test.ts,
+howCaught: the registered age-kill-backoff controller drives sustained rejection through a bounded
+attempt horizon and proves the action count settles; the production-path regression separately proves
+that a legitimate local cleanup now converges to one reap while protected/work vetoes converge to no
+reap }`.

--- a/upgrades/side-effects/session-reaper-local-age-owner.md
+++ b/upgrades/side-effects/session-reaper-local-age-owner.md
@@ -3,7 +3,7 @@
 **Version / slug:** `session-reaper-local-age-owner`
 **Date:** `2026-08-02`
 **Author:** `Instar Agent (instar-codey)`
-**Second-pass reviewer:** `Heisenberg (item12_security_r1)`
+**Second-pass reviewer:** `Heisenberg (item12_security_r1)` plus the CI-correction reviewer recorded below
 
 ## Summary of the change
 
@@ -169,6 +169,31 @@ audit suppression, false-success state/process divergence, and an ignorable time
 demonstrated attack now has a structural repair and regression test. The final fresh adversarial
 verdict explicitly concurs with no remaining concrete blocker in scope.
 
+### 2026-08-02 CI correction addendum
+
+The first pushed revision exposed eleven PR-caused failures across eight test files. Two test
+harnesses had been mutating or reading the former TypeScript-private `deps` property; runtime `#deps`
+and construction-time freezing correctly made that impossible. Those harnesses now use
+construction-time closures to vary transcript/CPU observations, or retain the injected session
+object directly, without adding a production escape hatch. Source-contract tests now assert the
+runtime-private async monitor and authority entrypoint rather than the superseded public shapes.
+
+The remaining failures exposed real integration seams rather than a reason to weaken the authority:
+remote-close tests now receive the birth-bound termination authority explicitly, including a
+missing-authority refusal case. The already-dead branch commits the terminal record without issuing
+a redundant tmux kill after the liveness oracle has proved the process absent. Listener isolation is
+marked as intentional because every lifecycle observer must remain independent; no observer gains
+authority over later audit delivery.
+
+This correction does not add a new decision point, heuristic, public bypass, durable field, notice,
+URL, or cross-machine behavior. It preserves the machine-local-by-design posture and the existing
+rollback path. All eleven failures were first reproduced on the PR head and all eight files were
+then green on the untouched base, establishing PR causality. After the correction, those files pass
+127/127 and the expanded termination-authority matrix passes 219/219; TypeScript/lint and build also
+pass. A broad 47,613-test sweep completed with 47,560 passes and 22 failures confined to
+baseline/environment-sensitive lanes. The only additional lifecycle timeout reproduced identically
+on the untouched base at the same five-second boundary.
+
 ---
 
 ## Second-pass review (if required)
@@ -188,6 +213,11 @@ The reviewer reported no remaining concrete authority-minting or state/process-d
 Independent verification passed TypeScript and 156/156 focused checks; the author's final broader
 focused matrix passed 179/179, with lint and build also green.
 
+**CI-correction reviewer:** `pr1846_fix_review` — **Concur with the review.** The correction preserves
+session-lifecycle authority, runtime privacy, signal-vs-authority separation, known-dead
+state/process convergence, and listener isolation without production escape hatches. Independent
+verification passed 164/164 focused tests; diff check was clean.
+
 ---
 
 ## Evidence pointers
@@ -201,6 +231,11 @@ focused matrix passed 179/179, with lint and build also green.
 - `tests/integration/session-lifecycle-reap-wiring.test.ts` — termination/reap-log lifecycle wiring.
 - `tests/unit/self-action-convergence.test.ts` — registered age-kill controller settles under
   sustained rejection.
+- `tests/unit/session-reaper-cpu-aware-keep.test.ts` — immutable construction-time observation seams.
+- `tests/unit/session-reaper.test.ts` — no test-only access to runtime-private reaper dependencies.
+- `tests/unit/session-async-monitor.test.ts` — runtime-private async monitor source contract.
+- `tests/unit/session-lifecycle-phase-2-wiring.test.ts` — private termination-authority wiring contract.
+- `tests/integration/remote-session-close.test.ts` — explicit authority injection and refusal when absent.
 
 ---
 


### PR DESCRIPTION
## ELI16 — Local cleanup belongs to the machine that owns the process

When one Instar agent runs on two computers, the serving lease controls shared routing and cross-machine decisions. It cannot stop a process that exists only inside the other computer. Previously, the laptop could prove that one of its own sessions was far beyond its age limit and safely idle, yet cleanup was refused because the laptop did not hold the serving lease. This change gives the local age monitor one private, tightly checked capability to close only that local expired session. Every shared, remote, active, protected, or uncertain case still stays behind the existing safety gates.

## What changed

- Allow a non-lease-holder to reap only its own over-age, positively idle local session through a narrowly scoped private authority path.
- Preserve the lease gate for ordinary autonomous boot purge, idle-zombie, recovery, cross-machine, and shared-state kills.
- Birth-bind trusted termination authority and keep public termination options inert-whitelisted.
- Unify kill ordering: listener isolation, durable terminal commit, SIGKILL-bounded synchronous tmux termination, and state compensation on ambiguous failure.
- Record the acting machine and derived authority scope in the reap log.

## Root cause

The global serving lease was being applied to machine-local process cleanup. Only the host that owned the process could clean it up, but that host was categorically denied whenever it was not the lease holder.

## UX Impact

Who sees it: an operator using the dashboard or authenticated session controls to terminate a session. Successful kills look unchanged. At first contact, if the trusted lifecycle authority is unavailable, the user now sees the explicit message "Session termination authority unavailable" instead of the request falling through to a lower-level process kill. A policy refusal is also reported as a conflict rather than as a misleading missing-session response.

## Safety properties

- Existing KEEP guards still veto protected sessions, recent user messages, open commitments, active or in-flight work, and recovery.
- Local age authority requires the literal age-limit reason, an installed guard, and local StateManager write admission.
- It grants no remote-process or shared-state authority.
- Public callers cannot forge the private authority path.

## Validation

- Reproduced all 11 PR-caused failures across the eight failed CI files on the original head; the same eight files passed 127/127 on the untouched base.
- Corrected eight-file matrix: 127/127 passing.
- Expanded termination-authority/reaper matrix: 219/219 passing.
- Independent CI-correction review: explicit concurrence, 164/164 focused tests passing, clean diff.
- Lint, TypeScript, and build passing.
- Full repository sweep: 47,560 passing of 47,613; the 22 remaining failures are confined to known baseline/environment-sensitive lanes and do not overlap the corrected eight files.
- The only additional lifecycle timeout reproduced identically on the untouched base at the same five-second boundary.
- Pre-commit Tier-2 artifact/spec gate passed. Pre-push gate passed; its affected-test lister timed out and safely deferred the authoritative run to CI.

## Known unrelated baseline and environment notes

- `headless-spawn-reroute` has 10 pre-existing failures when run alone on base. The newly touched monitor-tick contract is green.
- Real-tmux session-management has two environmental 10-second timeouts; the additional lifecycle five-second timeout reproduces identically on base.
- The broad sweep also encountered unavailable live Gemini credentials and worktree-only child-process executable resolution. Those lanes do not overlap this change.
