### PR TITLE
fix(multi-machine): publish the lease-derived poll intent on every reconcile

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-04T01-30-30-741Z-lease-poll-intent-republish.json
+++ b/.instar/instar-dev-decisions/2026-08-04T01-30-30-741Z-lease-poll-intent-republish.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-04T01:30:30.741Z",
+  "slug": "lease-poll-intent-republish",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 80,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/MultiMachineCoordinator.ts"
+    ],
+    "addedLines": 67,
+    "deletedLines": 13
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/lease-poll-intent-republish.eli16.md
+++ b/docs/specs/lease-poll-intent-republish.eli16.md
@@ -1,0 +1,68 @@
+# A machine in charge was telling itself it was the standby — plain-English overview
+
+## What this changes, in one sentence
+
+When one agent runs on two machines, exactly one of them is supposed to answer Telegram. The machine in charge was leaving a note for its own messenger saying "you are the standby, do not answer" — and never correcting it once it worked out that it was, in fact, in charge. This change makes it correct that note every time it checks.
+
+## What already exists
+
+Instar runs an agent across more than one machine. To stop both machines answering the same Telegram messages twice, there is a "lease": a numbered badge that exactly one machine holds at a time. The machine holding it is `awake`; the other is `standby`.
+
+The part that actually talks to Telegram is a separate process called the lifeline. It does not hold the badge itself — the server does. So the server writes a small note on disk saying "you should be answering" or "you should not", and the lifeline reads that note and follows it. That note is called the poll intent.
+
+Two safety habits already exist around the note, and both stay exactly as they are:
+
+- At startup, before the server knows whether it holds the badge, it writes the **cautious** answer — "you are the standby, do not answer". That way a leftover note from a previous run can never make a machine start answering when it should not.
+- The lifeline **ignores** a note that is too old, or one written by a server process that is no longer running. An ignored note means "no opinion", and the lifeline just keeps doing whatever it was doing.
+
+## What was actually wrong
+
+The server only ever replaced that cautious startup note when its role **changed** — standby becoming awake, or the reverse.
+
+But a machine remembers what it was before it restarted. So a machine that was already in charge, restarts, and is still in charge, never *changes* role. There is no transition. The replacement never happens, and the cautious "you are the standby" note stays on disk permanently — on the machine that genuinely holds the badge.
+
+There is a second, quieter half. Because the note was only rewritten on a change, on a machine whose role was steady the note simply got older and older, until it passed the age limit and the lifeline started ignoring it entirely.
+
+So the note was either wrong or ignored. It was almost never both correct and listened to.
+
+## What this was actually doing to a live agent
+
+This was measured, not theorised. On a two-machine agent, in the same second and at the same badge number, the server reported "this machine is in charge" while the note beside it said "this machine is the standby, do not answer".
+
+Because the feature that makes the lifeline obey the note currently ships switched off, the lifeline ignored it and tried to answer Telegram anyway — while the other machine was already answering. Telegram refuses the second asker. That happened 812 times. After enough refusals the lifeline concluded it was stuck, shut itself down to be restarted, and took the server down with it — 260 times, roughly every ten minutes for eight hours. Every restart also took that agent's dashboard offline.
+
+Switching the feature on made it worse in a different direction: the lifeline then **obeyed** the wrong note and muted the machine that was supposed to be answering.
+
+## The second thing that was wrong, which we only found by testing the real startup
+
+There was a second fault sitting right beside the first, and it would have defeated the fix on its own.
+
+The cautious "you are the standby" note was being written at the **end** of startup — after the code had already worked out whether this machine holds the badge. So it was not standing in for a decision not yet made. It was landing on top of the decision that had just been made, and erasing it.
+
+This one is worth dwelling on because of how it was found. The obvious fix — publish the note every time, not only on a change — passes a test that pokes the function directly. It does **not** fix the machine, because startup immediately overwrites the corrected note. It only showed up because a test was written that runs the real startup sequence end to end. Without that test, this would have shipped green and changed nothing in production.
+
+Both faults are fixed. The cautious note now goes first, where it was always meant to be.
+
+## What is new
+
+The server now writes the note **every time it checks its role**, not only when the role changes; and the cautious startup note is written **before** the role is worked out rather than after. The note therefore always says what the badge actually says, and it stays recent enough for the lifeline to trust.
+
+To avoid writing a file on every single check, an unchanged note is only rewritten every 30 seconds. The lifeline ignores notes older than 90 seconds, so 30 leaves a three-times margin. If the note's contents change — the role flips, or the badge number moves — it is written immediately, without waiting.
+
+## The safeguards, in plain terms
+
+- **The cautious startup note is untouched.** A machine still says "do not answer" before it knows anything.
+- **The lifeline's protections are untouched.** It still ignores a note that is too old or written by a dead process.
+- **Nothing new gets the power to block anything.** This only fixes the accuracy of a piece of information. The decision to answer or not still belongs to the same code as before, still behind the same off-by-default switch.
+- **Everything that only happens on a real role change still only happens on a real role change** — the audit entry, the promote/demote signals, the flap protection. Those were deliberately left where they were.
+- **A failed write is retried** on the next check rather than being recorded as done.
+
+## Why this matters beyond the one agent it broke
+
+The plan on record is to switch the "obey the note" behaviour on for every agent, once a live two-machine test proves it works. This was that test, and it failed. Switched on as it stood, every machine that restarted while in charge would have quietly muted its own Telegram — the exact silence the whole feature was built to prevent.
+
+## What you actually need to decide
+
+Whether this fix goes in as written. The change is two functions in one file plus tests. If it turns out wrong, reverting the commit restores the previous behaviour completely — the note is regenerated at runtime, so there is nothing to migrate and no state to repair.
+
+One thing to remember separately: the agent that was broken by this is currently running with a blunt manual setting that tells it never to answer Telegram from that machine. That has to be removed once this fix is deployed, or it will override the corrected behaviour. It is recorded on the attention queue rather than carried in anyone's memory.

--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -112,6 +112,13 @@ const DEFAULT_LEASE_PULL_INTERVAL_MS = 5_000;
 const RENEW_SAFETY_FACTOR = 0.5;
 const MIN_RENEW_INTERVAL_MS = 5_000;
 const MAX_RENEW_INTERVAL_MS = 60_000;
+/**
+ * B1 — how often an UNCHANGED lease-derived poll intent is rewritten so its `ts`
+ * stays inside the consumer's staleness bound (TelegramLifeline reads it with
+ * `maxStaleMs: 90_000`; past that the record is treated as "no current opinion").
+ * 30s leaves a 3× margin while keeping the write off every lease tick.
+ */
+const POLL_INTENT_REFRESH_MS = 30_000;
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -195,6 +202,13 @@ export class MultiMachineCoordinator extends EventEmitter {
    * from one left by a prior incarnation of this server.
    */
   private readonly bootId = `${process.pid}-${process.hrtime.bigint().toString(36)}`;
+  /**
+   * B1 — throttle state for the per-reconcile poll-intent republish. `key` is the
+   * last SUCCESSFULLY written `shouldPoll|role|leaseEpoch`; the timestamp is when
+   * that write landed. See `publishLeasePollIntent`.
+   */
+  private lastPollIntentKey: string | null = null;
+  private lastPollIntentWriteMs = 0;
   /** Integrated-Being v1 — tracks whether we've already emitted the
    *  per-machine-ledger warning this boot. Spec §Multi-machine. */
   private integratedBeingWarningEmitted: boolean = false;
@@ -863,21 +877,50 @@ export class MultiMachineCoordinator extends EventEmitter {
    * is off. Guarded: a write failure is logged once, never thrown into the
    * caller's hot path (the intent file is advisory; a missed write degrades to the
    * lifeline's "no current opinion" → hold, the safe direction).
+   *
+   * Returns true only when a record was actually written, so the throttling
+   * wrapper never records a skip-window off a failed write. EVERY successful
+   * write updates the throttle state here (not in the wrapper) so a direct
+   * caller — e.g. the boot default in `initializeLease` — can never leave the
+   * cached key describing something other than what is actually on disk.
    */
-  private writeLeasePollIntent(shouldPoll: boolean, role: MachineRole): void {
-    if (!this.pollFollowsLeaseEnabled() || !this.leaseCoordinator) return;
+  private writeLeasePollIntent(shouldPoll: boolean, role: MachineRole): boolean {
+    if (!this.pollFollowsLeaseEnabled() || !this.leaseCoordinator) return false;
+    const normalizedRole: MachineRole = role === 'awake' ? 'awake' : 'standby';
+    const epoch = this.leaseCoordinator.currentEpoch();
     try {
       writePollIntent(this.config.stateDir, {
         shouldPoll,
-        leaseEpoch: this.leaseCoordinator.currentEpoch(),
-        role: role === 'awake' ? 'awake' : 'standby',
+        leaseEpoch: epoch,
+        role: normalizedRole,
         serverPid: process.pid,
         bootId: this.bootId,
         ts: Date.now(),
       });
+      this.lastPollIntentKey = `${shouldPoll}|${normalizedRole}|${epoch}`;
+      this.lastPollIntentWriteMs = Date.now();
+      return true;
     } catch (err) {
       console.log(`[MultiMachine] [poll-intent] write failed (non-fatal): ${(err as Error).message}`);
+      return false;
     }
+  }
+
+  /**
+   * B1 — republish the lease-derived poll intent from `reconcileRoleToLease`,
+   * throttled. Writes when the intent CHANGES (shouldPoll / role / lease epoch) or
+   * when the last successful write is older than `POLL_INTENT_REFRESH_MS`, so a
+   * steady role stays comfortably inside the consumer's staleness bound without a
+   * file write on every lease tick. The throttle state is recorded by
+   * `writeLeasePollIntent` on a write that actually landed — a failed write
+   * retries on the next reconcile rather than being treated as delivered.
+   */
+  private publishLeasePollIntent(shouldPoll: boolean, role: MachineRole): void {
+    if (!this.pollFollowsLeaseEnabled() || !this.leaseCoordinator) return;
+    const key = `${shouldPoll}|${role === 'awake' ? 'awake' : 'standby'}|${this.leaseCoordinator.currentEpoch()}`;
+    const unchanged = key === this.lastPollIntentKey;
+    if (unchanged && Date.now() - this.lastPollIntentWriteMs < POLL_INTENT_REFRESH_MS) return;
+    this.writeLeasePollIntent(shouldPoll, role);
   }
 
   /**
@@ -1121,6 +1164,14 @@ export class MultiMachineCoordinator extends EventEmitter {
       // two-machine mesh, 2026-05-28). Read-only, so it runs before EVERY branch below: the
       // observe-only and defer-preferred decisions read the same lease view and benefit equally.
       this.leaseCoordinator.primeFromDurable();
+    // B1 — publish the SAFE default (shouldPoll:false / mute) BEFORE any branch
+    // below reconciles, so a stale prior-boot {shouldPoll:true} can't resurrect a
+    // poller in the window before the real role is known. This MUST precede the
+    // reconcile: written afterwards it overwrites the decision it was meant to
+    // stand in for, which is exactly what it used to do — every branch here ends
+    // in `reconcileRoleToLease`, so the tail write clobbered the truth and left a
+    // lease HOLDER published as `standby / do-not-poll`.
+    this.writeLeasePollIntent(false, 'standby');
     if (this.isLeaseObserveOnly) {
       // Silent standby: do NOT acquire — only observe the primary's lease.
       this.reconcileRoleToLease('lease-init-observe-only');
@@ -1139,10 +1190,6 @@ export class MultiMachineCoordinator extends EventEmitter {
     // B3 — keep the held lease fresh (renew before it lapses) so the epoch stops
     // climbing. No-op unless resilientRenew resolves on (dev-gate).
     this.startLeaseRenewTimer();
-    // B1 — at boot the role isn't yet reconciled; publish the SAFE default
-    // (shouldPoll:false / mute) so a stale prior-boot {shouldPoll:true} can't
-    // resurrect a poller before the first reconcile decides the real role.
-    this.writeLeasePollIntent(false, 'standby');
   }
 
   /**
@@ -1250,6 +1297,18 @@ export class MultiMachineCoordinator extends EventEmitter {
     if (!this.leaseCoordinator || !this._identity) return;
     const holds = this.leaseCoordinator.holdsLease();
     const desired: MachineRole = holds ? 'awake' : 'standby';
+    // B1 — publish the lease-derived poll intent on EVERY reconcile, ABOVE the
+    // no-transition early-return. `_role` is restored from the machine registry at
+    // startup, so a machine that was already awake before a restart re-enters
+    // reconcile with `desired === this._role` and returns here. Publishing below
+    // the early-return therefore left `initializeLease()`'s safe boot default
+    // ({shouldPoll:false, role:'standby'}) standing as the PERMANENT published
+    // intent for a machine that actually holds the lease — the lifeline then
+    // either fought for the poll (dry-run: 409 conflict loop) or muted the
+    // rightful holder (live). Publishing here also refreshes `ts` inside the
+    // consumer's staleness bound (TelegramLifeline: maxStaleMs 90_000), so a
+    // steady role reads as a live opinion instead of decaying to "no opinion".
+    this.publishLeasePollIntent(holds, desired);
     if (desired === this._role) return;
     const oldRole = this._role;
     this._role = desired;
@@ -1271,11 +1330,6 @@ export class MultiMachineCoordinator extends EventEmitter {
     if (holds) this.emit('promote');
     else this.emit('demote');
     console.log(`[MultiMachine] Lease reconcile → ${desired} (${reason})`);
-    // B1 — publish the lease-derived poll intent for the lifeline (shouldPoll =
-    // awake). No-op unless pollFollowsLease resolves on. Nothing consumes it yet
-    // (the lifeline reconcile loop is the next increment), so this is a safe,
-    // observe-only producer — it cannot change ingress.
-    this.writeLeasePollIntent(holds, desired);
     // B2 — feed the flap circuit-breaker on every REAL role transition (this is
     // past the `desired === this._role` early-return, so it counts only true
     // flips). Observe/dry-run: log the would-latch; applying the deterministic

--- a/tests/unit/MultiMachineCoordinator-pollIntentRepublish.test.ts
+++ b/tests/unit/MultiMachineCoordinator-pollIntentRepublish.test.ts
@@ -1,0 +1,341 @@
+/**
+ * B1 (multimachine-lease-poll-robustness) — lease-derived poll-intent republish.
+ *
+ * REGRESSION THIS LOCKS IN (observed live on a two-machine agent, v1.3.1122):
+ * `_role` is restored from the machine registry at startup, so a machine that was
+ * already `awake` before a restart re-enters `reconcileRoleToLease` with
+ * `desired === this._role` and hits the no-transition early-return. The publish
+ * used to sit BELOW that return, so `initializeLease()`'s safe boot default
+ * (`{shouldPoll:false, role:'standby'}`) stayed as the PERMANENT published intent
+ * for a machine that actually holds the lease — measured in production as
+ * `/health` reporting `role:awake, holdsLease:true` while the intent file said
+ * `role:standby, shouldPoll:false` at the SAME lease epoch, in the same second.
+ *
+ * Downstream harm: the lifeline either fought for the poll (dry-run → Telegram 409
+ * conflict loop → `conflict409Stuck` self-restart → server restart every ~10 min)
+ * or, once the lever went live, muted the rightful holder outright.
+ *
+ * Second failure mode covered here: the record was only ever written on a role
+ * TRANSITION, so on a steady role its `ts` aged past the consumer's
+ * `maxStaleMs: 90_000` bound and `effectivePollIntent` degraded it to "no
+ * current opinion".
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { MultiMachineCoordinator } from '../../src/core/MultiMachineCoordinator.js';
+import { MachineIdentityManager } from '../../src/core/MachineIdentity.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { readPollIntent } from '../../src/core/pollIntent.js';
+import { FencedLease, type LeaseCrypto } from '../../src/core/FencedLease.js';
+import { LeaseCoordinator, type LeaseTransport } from '../../src/core/LeaseCoordinator.js';
+import { LocalLeaseStore } from '../../src/core/LocalLeaseStore.js';
+
+function tempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mmc-pollintent-'));
+}
+
+function seedIdentity(stateDir: string, machineId: string) {
+  const identity = {
+    machineId,
+    signingPublicKey: 'k1',
+    encryptionPublicKey: 'k2',
+    name: 'machine-a',
+    platform: 'test',
+    createdAt: new Date().toISOString(),
+    capabilities: ['sessions'],
+  };
+  fs.mkdirSync(path.join(stateDir, 'machine'), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'machine', 'identity.json'), JSON.stringify(identity));
+  return identity;
+}
+
+/**
+ * Build a coordinator whose in-memory role is ALREADY `registryRole` (the
+ * production restart path — the registry remembers what this machine was), with a
+ * stub lease coordinator whose holdsLease/currentEpoch the test drives directly.
+ */
+function makeCoord(
+  dir: string,
+  opts: { registryRole: 'awake' | 'standby'; holds: boolean; epoch?: number; pollFollowsLease?: unknown },
+) {
+  const machineId = `m_${crypto.randomBytes(8).toString('hex')}`;
+  const identity = seedIdentity(dir, machineId);
+  const mgr = new MachineIdentityManager(dir);
+  mgr.registerMachine(identity as any, opts.registryRole);
+  const state = new StateManager(dir);
+  const coord = new MultiMachineCoordinator(state, {
+    stateDir: dir,
+    multiMachine: {
+      pollFollowsLease: opts.pollFollowsLease ?? { enabled: true, dryRun: true },
+    } as any,
+  });
+  coord.start();
+  const c = coord as any;
+  // `start()` runs a startup-failover promotion when no heartbeat file exists, so
+  // pin the in-memory role to the value the machine registry would have restored.
+  // That restored role is the whole point of the regression: it is what makes
+  // `desired === this._role` true on the first reconcile after a restart.
+  c._role = opts.registryRole;
+  // Minimal lease stub — this suite is about what reconcile PUBLISHES, not about
+  // lease acquisition (covered by the FencedLease / LeaseCoordinator suites).
+  const stub = {
+    holds: opts.holds,
+    epoch: opts.epoch ?? 7,
+    holdsLease() { return this.holds; },
+    currentEpoch() { return this.epoch; },
+  };
+  c.leaseCoordinator = stub;
+  return { coord, c, stub, machineId };
+}
+
+describe('MultiMachineCoordinator B1 — poll-intent republish', () => {
+  let dir: string;
+  beforeEach(() => { dir = tempDir(); });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'pollIntentRepublish:afterEach' });
+  });
+
+  it('publishes shouldPoll:true for a lease HOLDER whose role did not transition (the regression)', () => {
+    // Registry says awake + lease held ⇒ desired === _role ⇒ the old code
+    // early-returned and never replaced the standby boot default.
+    const { coord, c } = makeCoord(dir, { registryRole: 'awake', holds: true });
+    expect(c._role).toBe('awake'); // precondition: no transition will occur
+
+    c.reconcileRoleToLease('test');
+
+    const rec = readPollIntent(dir);
+    expect(rec).not.toBeNull();
+    expect(rec!.shouldPoll).toBe(true);
+    expect(rec!.role).toBe('awake');
+    expect(rec!.leaseEpoch).toBe(7);
+    coord.stop();
+  });
+
+  it('publishes shouldPoll:false for a NON-holder whose role did not transition', () => {
+    const { coord, c } = makeCoord(dir, { registryRole: 'standby', holds: false });
+    expect(c._role).toBe('standby');
+
+    c.reconcileRoleToLease('test');
+
+    const rec = readPollIntent(dir);
+    expect(rec).not.toBeNull();
+    expect(rec!.shouldPoll).toBe(false);
+    expect(rec!.role).toBe('standby');
+    coord.stop();
+  });
+
+  it('refreshes a STEADY role once the refresh window elapses, and throttles inside it', () => {
+    const { coord, c } = makeCoord(dir, { registryRole: 'awake', holds: true });
+    // Count real writes rather than comparing `ts`: two reconciles in the same
+    // millisecond produce an identical timestamp, so `ts` cannot distinguish
+    // "rewritten" from "skipped" — a control that could not fail.
+    const spy = vi.spyOn(c, 'writeLeasePollIntent');
+
+    c.reconcileRoleToLease('tick-1');
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Inside the refresh window with an unchanged intent ⇒ throttled, no rewrite.
+    c.reconcileRoleToLease('tick-2');
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Past the window ⇒ rewritten, so `ts` stays inside the consumer's 90s bound.
+    c.lastPollIntentWriteMs = Date.now() - (31_000);
+    c.reconcileRoleToLease('tick-3');
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(readPollIntent(dir)!.shouldPoll).toBe(true);
+    spy.mockRestore();
+    coord.stop();
+  });
+
+  it('retries on the next reconcile when a write FAILS (no skip-window off a failure)', () => {
+    const { coord, c } = makeCoord(dir, { registryRole: 'awake', holds: true });
+    const spy = vi.spyOn(c, 'writeLeasePollIntent').mockReturnValueOnce(false);
+
+    c.reconcileRoleToLease('tick-1');   // write fails ⇒ throttle state must NOT advance
+    c.reconcileRoleToLease('tick-2');   // immediately retried, not skipped
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    spy.mockRestore();
+    coord.stop();
+  });
+
+  it('publishes IMMEDIATELY on a lease-epoch change even inside the refresh window', () => {
+    const { coord, c, stub } = makeCoord(dir, { registryRole: 'awake', holds: true, epoch: 7 });
+    c.reconcileRoleToLease('tick-1');
+    expect(readPollIntent(dir)!.leaseEpoch).toBe(7);
+
+    stub.epoch = 8; // fenced epoch moved — the intent must not lag behind it
+    c.reconcileRoleToLease('tick-2');
+    expect(readPollIntent(dir)!.leaseEpoch).toBe(8);
+    coord.stop();
+  });
+
+  it('writes NOTHING when the pollFollowsLease gate is explicitly off', () => {
+    const { coord, c } = makeCoord(dir, {
+      registryRole: 'awake',
+      holds: true,
+      pollFollowsLease: { enabled: false },
+    });
+
+    c.reconcileRoleToLease('test');
+
+    expect(readPollIntent(dir)).toBeNull();
+    coord.stop();
+  });
+
+  it('still fires the transition-only side effects on a REAL role change', () => {
+    // Registry says standby, lease is held ⇒ genuine standby→awake transition.
+    const { coord, c } = makeCoord(dir, { registryRole: 'standby', holds: true });
+    const events: string[] = [];
+    coord.on('roleChange', (from: string, to: string) => events.push(`roleChange:${from}->${to}`));
+    coord.on('promote', () => events.push('promote'));
+
+    c.reconcileRoleToLease('test');
+
+    expect(events).toContain('roleChange:standby->awake');
+    expect(events).toContain('promote');
+    expect(c._role).toBe('awake');
+    expect(readPollIntent(dir)!.shouldPoll).toBe(true);
+    coord.stop();
+  });
+
+  it('REAL boot path: initializeLease writes the standby default, the first reconcile replaces it', async () => {
+    // The stubbed tests above prove the publish runs; this one proves the whole
+    // production sequence lands correctly — a real FencedLease/LeaseCoordinator,
+    // the real `initializeLease()` the server calls at boot, and the real
+    // acquisition. Without it the suite could pass while the boot default still
+    // won in production, which is exactly the shape of the defect.
+    const machineId = `m_${crypto.randomBytes(8).toString('hex')}`;
+    const identity = seedIdentity(dir, machineId);
+    const mgr = new MachineIdentityManager(dir);
+    mgr.registerMachine(identity as any, 'awake'); // registry-restored role, as after a restart
+    const keys = crypto.generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    const cryptoIface: LeaseCrypto = {
+      selfMachineId: machineId,
+      sign: (c) => crypto.sign(null, Buffer.from(c), keys.privateKey).toString('base64'),
+      verify: (c, sig) => {
+        try { return crypto.verify(null, Buffer.from(c), keys.publicKey, Buffer.from(sig, 'base64')); } catch { return false; }
+      },
+    };
+    const tunnel: LeaseTransport = {
+      broadcast: async () => true,
+      observed: () => ({ lease: null, lastNonceByHolder: {} }),
+      isReachable: () => true,
+      pullAllPeers: async () => {},
+    };
+    const lc = new LeaseCoordinator({
+      lease: new FencedLease(cryptoIface, { leaseTtlMs: 60_000, failoverThresholdMs: 15 * 60_000 }),
+      store: new LocalLeaseStore({ filePath: path.join(dir, 'lease-local.json') }),
+      tunnel,
+      presumedDeadHolders: () => new Set(),
+    });
+    const state = new StateManager(dir);
+    const coord = new MultiMachineCoordinator(state, {
+      stateDir: dir,
+      multiMachine: { pollFollowsLease: { enabled: true, dryRun: true } } as any,
+    });
+    coord.start();
+    coord.attachLeaseCoordinator(lc);
+    const c = coord as any;
+    c._role = 'awake'; // registry-restored, as production does after a restart
+
+    // `initializeLease()` writes the safe default, then acquires, then reconciles.
+    await coord.initializeLease();
+
+    // END STATE is what matters: this machine genuinely holds the lease, so the
+    // record the lifeline will read must say so. Two separate defects had to be
+    // fixed for this to hold — the reconcile publishing only on a transition
+    // (there is none: the registry already said awake), and the safe boot default
+    // being written AFTER that reconcile, clobbering the decision it stands in for.
+    expect(lc.holdsLease()).toBe(true);
+    expect(c._role).toBe('awake');
+    const afterBoot = readPollIntent(dir);
+    expect(afterBoot).not.toBeNull();
+    expect(afterBoot!.shouldPoll).toBe(true);
+    expect(afterBoot!.role).toBe('awake');
+    expect(afterBoot!.leaseEpoch).toBe(lc.currentEpoch());
+
+    // And a later steady-state reconcile must not regress it.
+    c.lastPollIntentWriteMs = Date.now() - 31_000;
+    c.reconcileRoleToLease('post-boot-tick');
+    const after = readPollIntent(dir)!;
+    expect(after.shouldPoll).toBe(true);
+    expect(after.role).toBe('awake');
+    coord.stop();
+  });
+
+  it('REAL boot path: a machine that does NOT acquire is left muted (safe default preserved)', async () => {
+    // The counterpart to the test above — the safe default must still win when the
+    // boot path does not end up holding the lease, or the ordering fix would have
+    // traded one silent failure for the opposite one (a standby told to poll).
+    const machineId = `m_${crypto.randomBytes(8).toString('hex')}`;
+    const identity = seedIdentity(dir, machineId);
+    const mgr = new MachineIdentityManager(dir);
+    mgr.registerMachine(identity as any, 'standby');
+    const keys = crypto.generateKeyPairSync('ed25519', {
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    const cryptoIface: LeaseCrypto = {
+      selfMachineId: machineId,
+      sign: (c) => crypto.sign(null, Buffer.from(c), keys.privateKey).toString('base64'),
+      verify: (c, sig) => {
+        try { return crypto.verify(null, Buffer.from(c), keys.publicKey, Buffer.from(sig, 'base64')); } catch { return false; }
+      },
+    };
+    const tunnel: LeaseTransport = {
+      broadcast: async () => true,
+      observed: () => ({ lease: null, lastNonceByHolder: {} }),
+      isReachable: () => true,
+      pullAllPeers: async () => {},
+    };
+    const lc = new LeaseCoordinator({
+      lease: new FencedLease(cryptoIface, { leaseTtlMs: 60_000, failoverThresholdMs: 15 * 60_000 }),
+      store: new LocalLeaseStore({ filePath: path.join(dir, 'lease-local.json') }),
+      tunnel,
+      presumedDeadHolders: () => new Set(),
+    });
+    const state = new StateManager(dir);
+    const coord = new MultiMachineCoordinator(state, {
+      stateDir: dir,
+      multiMachine: {
+        pollFollowsLease: { enabled: true, dryRun: true },
+        // Silent-standby branch: observe the primary's lease, never acquire.
+        leaseSelfHeal: { leaseRole: 'observe-only' },
+      } as any,
+    });
+    coord.start();
+    coord.attachLeaseCoordinator(lc);
+
+    await coord.initializeLease();
+
+    expect(lc.holdsLease()).toBe(false);
+    const rec = readPollIntent(dir)!;
+    expect(rec.shouldPoll).toBe(false);
+    expect(rec.role).toBe('standby');
+    coord.stop();
+  });
+
+  it('does NOT re-fire transition-only side effects when the role is steady', () => {
+    const { coord, c } = makeCoord(dir, { registryRole: 'awake', holds: true });
+    const events: string[] = [];
+    coord.on('roleChange', () => events.push('roleChange'));
+    coord.on('promote', () => events.push('promote'));
+
+    c.reconcileRoleToLease('tick-1');
+    c.lastPollIntentWriteMs = Date.now() - 31_000;
+    c.reconcileRoleToLease('tick-2');
+
+    expect(events).toEqual([]); // publish is per-reconcile; transitions are not
+    expect(readPollIntent(dir)!.shouldPoll).toBe(true);
+    coord.stop();
+  });
+});

--- a/upgrades/next/lease-poll-intent-republish.md
+++ b/upgrades/next/lease-poll-intent-republish.md
@@ -1,0 +1,92 @@
+<!-- bump: patch -->
+
+## What Changed
+
+On a multi-machine agent, the server publishes a small record telling its
+Lifeline process whether THIS machine should own the Telegram poll. That record
+was only rewritten when the machine's role actually changed. Because a machine's
+role is restored from the machine registry at startup, a machine that was
+already `awake` before a restart comes back, reconciles, finds nothing changed,
+and returns early — leaving the cautious boot default (`standby` /
+`shouldPoll:false`) standing permanently on the machine that genuinely holds the
+fenced lease. A second failure rode along: written only on transitions, the
+record aged past the Lifeline's 90-second freshness bound on a steady role and
+was discarded as "no current opinion".
+
+A second, independent defect in the same path is fixed with it. The "safe boot
+default" (`standby` / `shouldPoll:false`) was written at the END of
+`initializeLease()` — but every branch above it already ends in a role
+reconcile, so the default did not stand in for an unmade decision, it
+OVERWROTE the decision made three lines earlier. On its own that is enough to
+leave a lease HOLDER published as `standby / do-not-poll` for the life of the
+process. The default write now precedes the branch, matching the ordering its
+own comment describes.
+
+The lease-derived poll intent is now published on every role reconcile rather
+than only on a transition, so it always reflects `holdsLease()` and stays inside
+the consumer's freshness bound. An unchanged intent is rewritten at most once
+every 30 seconds (a 3× margin under the 90-second bound); a changed role or a
+moved lease epoch publishes immediately. A write that fails no longer records a
+skip-window, so it is retried on the next reconcile instead of being treated as
+delivered.
+
+Everything that should happen only on a genuine role change still happens only
+on a genuine role change — the `role_transition` audit entry, the
+promote/demote events, and the flap circuit-breaker were deliberately left
+below the early-return.
+
+## What to Tell Your User
+
+- **The machine in charge no longer tells itself it is the standby:** "When I
+  run on more than one machine, the one holding the badge now reports that
+  correctly to its own messenger instead of leaving a startup placeholder in
+  place."
+- **Why this mattered:** "With the placeholder standing, my messenger either
+  fought the other machine for the Telegram line — colliding, deciding it was
+  stuck, and restarting roughly every ten minutes — or, with the follow-the-lease
+  behaviour switched on, muted the machine that was supposed to be answering."
+- **Nothing changes on a single-machine setup:** "A single machine is always the
+  one in charge, so there was never a second poller to collide with."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|---|---|
+| The poll intent reflects the live fenced lease rather than a boot placeholder | Automatic — no configuration. Applies wherever `multiMachine.pollFollowsLease` resolves on |
+| The poll intent stays inside the consumer's freshness bound on a steady role | Automatic — an unchanged record is refreshed every 30s; a changed one publishes immediately |
+| A failed intent write is retried rather than recorded as delivered | Automatic — the throttle window only advances on a write that actually landed |
+
+## Evidence
+
+Measured live on a two-machine agent (v1.3.1122) before the fix: `/health →
+multiMachine.syncStatus` reported `role:awake, holdsLease:true,
+leaseEpoch:21302` in the same second that `state/telegram-poll-intent.json`
+reported `role:standby, shouldPoll:false` at that same epoch. Sampling the
+record at 10-second intervals showed its age climbing 84.5s → 155.0s across an
+80-second window with no rewrite — past the consumer's 90s bound. Downstream on
+that agent: 812 × `Telegram 409 Conflict — another bot instance is polling`,
+260 × `TelegramLifeline.selfRestart: conflict409Stuck`, and a server restart
+roughly every ten minutes for about eight hours.
+
+New unit coverage in
+`tests/unit/MultiMachineCoordinator-pollIntentRepublish.test.ts` (10 tests):
+holder-with-no-transition publishes `shouldPoll:true` (the regression),
+non-holder publishes `shouldPoll:false`, steady-role refresh past the window
+with throttling inside it, a failed write retried on the next reconcile,
+immediate publish on a lease-epoch change, no write when the gate is explicitly
+off, transition-only side effects still firing on a real change and NOT firing
+on a steady role, plus two tests that run the REAL boot path with a live
+FencedLease/LeaseCoordinator — a machine that acquires ends up published as
+`awake / shouldPoll:true`, and a machine on the observe-only branch that never
+acquires is left muted. Verified as a control that 7 of the 10 fail against
+`origin/main` — the headline regression failing with `expected null not to be
+null` (no record written at all) rather than a missing-symbol error; the 3 that
+pass pre-fix are the gate-off, real-transition, and never-acquires guards, which
+are expected to hold either way.
+
+The second defect was found BY the real-boot-path test, not by reading: with
+only the early-return fixed, that test failed with the on-disk record reading
+`{shouldPoll:false, role:'standby'}` while the in-process throttle key read
+`true|awake|1` — the correct value had been written and then overwritten by the
+boot default. Shipping the early-return fix alone would have produced a green
+stubbed suite and an unchanged production failure.

--- a/upgrades/side-effects/lease-poll-intent-republish.md
+++ b/upgrades/side-effects/lease-poll-intent-republish.md
@@ -1,0 +1,163 @@
+# Side-Effects Review — lease-derived poll intent is republished on every reconcile
+
+**Version / slug:** `lease-poll-intent-republish`
+**Date:** `2026-08-03`
+**Author:** `echo`
+**Second-pass reviewer:** `not required` (see §Second-pass — no block/allow surface added; the change is confined to a signal producer)
+
+## Summary of the change
+
+`MultiMachineCoordinator.reconcileRoleToLease()` published the lease-derived poll intent (`state/telegram-poll-intent.json`) only on a genuine role TRANSITION, because the `writeLeasePollIntent(holds, desired)` call sat below the `if (desired === this._role) return;` early-return. `_role` is restored from the machine registry at startup, so a machine that was already `awake` before a restart re-enters reconcile with `desired === this._role`, returns early, and never replaces `initializeLease()`'s safe boot default `{shouldPoll:false, role:'standby'}`. The published intent for a machine that genuinely holds the lease therefore stayed `standby / do-not-poll` permanently. A second failure mode rode along: because the record was written only on transitions, on a steady role its `ts` aged past the consumer's `maxStaleMs: 90_000` bound and `effectivePollIntent` degraded it to "no current opinion".
+
+This change moves the publish ABOVE the early-return so it runs on every reconcile, and adds a throttling wrapper (`publishLeasePollIntent`) that writes when the intent changes (`shouldPoll | role | leaseEpoch`) or when the last SUCCESSFUL write is older than `POLL_INTENT_REFRESH_MS` (30s — a 3× margin inside the consumer's 90s bound). `writeLeasePollIntent` now returns whether a record actually landed, so a failed write never records a skip-window.
+
+**A SECOND defect was found while building the real-boot-path test, and is fixed here too.** `initializeLease()` wrote its "safe boot default" (`writeLeasePollIntent(false, 'standby')`) at the very END of the method — but every branch above it already ends in `reconcileRoleToLease(...)`. The default therefore did not stand in for an unmade decision; it OVERWROTE the decision that had just been made three lines earlier. Its own comment ("at boot the role isn't yet reconciled … before the first reconcile decides the real role") describes the intended ordering, which the code did not have. On its own this defect is sufficient to leave a lease HOLDER published as `standby / do-not-poll` for the life of the process, so fixing only the early-return would have produced a change that passes a stubbed unit test and still fails in production. The default write is moved to before the branch.
+
+Files touched: `src/core/MultiMachineCoordinator.ts`, `tests/unit/MultiMachineCoordinator-pollIntentRepublish.test.ts` (new).
+
+## Decision-point inventory
+
+- `MultiMachineCoordinator.reconcileRoleToLease` (poll-intent publish) — **modify** — publishes on every reconcile instead of transitions only; the transition-only side effects below the early-return are untouched.
+- `MultiMachineCoordinator.initializeLease` (safe boot default) — **modify** — the default write moves from after the acquire/reconcile branch to before it. Same value written, same purpose; the ordering now matches the stated intent.
+- `MultiMachineCoordinator.writeLeasePollIntent` — **modify** — now returns `boolean` (write landed) instead of `void`, and records the throttle state on every successful write. No behavioral change to what it writes.
+- `MultiMachineCoordinator.publishLeasePollIntent` — **add** — throttling wrapper, no decision authority.
+- `TelegramLifeline.reconcilePolling` (the CONSUMER, which owns the start/stop authority) — **pass-through** — unmodified. It keeps its own freshness gate, dead-writer gate, operator override, debounce, and the `pollFollowsLease.dryRun` gate.
+
+---
+
+## 1. Over-block
+
+**No block/allow surface — over-block not applicable.** This change writes an advisory record. It has no reject path. The only actor that acts on the record is `TelegramLifeline.reconcilePolling`, which is unmodified.
+
+The nearest analogue worth stating: the change can now cause the lifeline to STOP polling on a machine where, pre-change, it would have kept polling — but only when the machine genuinely does not hold the lease AND `pollFollowsLease.dryRun` is explicitly `false`. That is the intended contract, not an over-block: the record now reports the fenced lease truthfully instead of reporting a stale boot default.
+
+---
+
+## 2. Under-block
+
+**No block/allow surface — under-block not applicable.**
+
+Failure modes this change does NOT address, stated explicitly so they are not assumed fixed:
+
+- **A lifeline whose 409 counter never resets.** The production incident that surfaced this defect also showed `conflict409Stuck` firing after a single 409 in a fresh boot cycle, because the boot path starts polling (stale-connection flush → `Telegram polling active`) before the first `reconcilePolling` tick can mute it. Fixing the publisher removes the CAUSE of the dual-poll on a correctly-leased pair, but a lifeline that starts polling at boot and only reconciles 15s later still has a window. Not in scope here and not claimed fixed. <!-- tracked: ATT-poll-intent-standby-forever-20260803 -->
+- **`nobodyPollingRecovery` shipping in dryRun.** If the lease is held by a machine that is down, nothing currently actuates a recovery. Unchanged by this. <!-- tracked: ATT-poll-intent-standby-forever-20260803 -->
+- **A machine whose `_role` and the fenced lease disagree for a reason other than the missing republish.** This change makes the PUBLISHED record follow `holdsLease()` directly, so it is now independent of `_role` drift — but it does not repair `_role` itself.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Right layer. The coordinator is the only component that owns the fenced lease, so it is the only component that can answer "should this machine own the Telegram poll?". The record is the existing, purpose-built IPC surface between the server (which knows the lease) and the lifeline (which owns the socket), and it already carries the integrity fields (`serverPid`, `bootId`, `ts`) the consumer needs.
+
+A lower layer (the lifeline asking Telegram, or reading the lease file itself) would duplicate lease parsing in a second process and reintroduce exactly the split-truth this record exists to prevent. A higher layer (a new arbiter service) is unwarranted for a one-boolean handoff.
+
+No smarter gate exists that this should feed instead — the consumer IS the gate, and it already receives this signal.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No — this change produces a signal consumed by an existing smart gate.**
+
+The coordinator is a detector here: it reports a fact it alone holds (do I hold the fenced lease, at which epoch). It gains no blocking power from this change. The authority over polling remains `decidePollAction` inside `TelegramLifeline`, which combines this signal with the operator override (`pollOverride` / `telegramPolling:false`), the local 409 observation, the start debounce, and the `peerPresumedGone` conservatism — and is itself gated behind `pollFollowsLease.dryRun`.
+
+The defect being fixed is, in signal-vs-authority terms, a detector reporting a value it never measured: the safe boot default is a placeholder standing in for an unmeasured role, and it was being consumed as though it were a measurement. Making the detector report the measured value is the compliant direction.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new heuristic at a competing-signals decision point. The published value is a direct, deterministic read of a single authoritative signal — `leaseCoordinator.holdsLease()` — not a weighing of competing signals. The place where signals genuinely compete (lease intent vs local 409 vs operator override vs debounce) is `decidePollAction`, which is unchanged.
+
+The only new constant, `POLL_INTENT_REFRESH_MS`, is a write-amplification throttle, not a decision threshold: it never changes WHAT is published, only how often an unchanged value is rewritten, and it is derived from the consumer's existing `maxStaleMs` bound (30s vs 90s) rather than tuned.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the publish now runs BEFORE the early-return, so it executes on strictly more paths than before. It cannot shadow anything — it writes a file and returns; no control flow depends on its result. Nothing that previously ran still fails to run. The reverse shadowing is what the second defect WAS: the boot default shadowed the reconcile's decision by writing after it. Moving it before the branch removes that, and the "does NOT acquire ⇒ left muted" test is the control proving the safe default still wins on the branch where no decision is made.
+- **Throttle vs direct writers:** the throttle cache is now updated inside `writeLeasePollIntent` rather than in the wrapper, so a direct caller (the boot default) can never leave the cached key describing something other than what is on disk. Without this, the boot default would write `standby` while the cache still read `awake`, and the next reconcile would consider itself unchanged and skip the correcting write for up to 30s — the exact interaction that made the first draft of the real-boot-path test fail.
+- **Double-fire:** on a genuine transition the publish runs once (from the new call above the early-return); the old call below the early-return was REMOVED, so there is no double write. Verified by the transition test asserting one write plus one `roleChange`/`promote` pair.
+- **Races:** `writePollIntent` is atomic (tmp + rename), so the lifeline never reads a torn record — unchanged. The reconcile is single-threaded per process and already guarded by `leaseTicking`. The throttle fields are process-local and only mutated inside reconcile.
+- **Feedback loops:** the record feeds the lifeline, which starts/stops polling, which changes the local 409 observation, which feeds `decidePollAction`. This change does not add a loop — it makes the existing one's input correct. The relevant risk (a machine flipping poll on/off repeatedly) is bounded by the existing start-debounce and by `POLL_INTENT_REFRESH_MS` throttling of unchanged values; a genuine flip publishes immediately, which is required for correctness (a lagging record is what caused the incident).
+- **Churn breaker (B2):** deliberately left below the early-return so it still counts only true flips. Covered by the "does NOT re-fire transition-only side effects when the role is steady" test.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** none — the record is per-agent under that agent's `stateDir`.
+- **Other users of the install base:** the change is inert unless `pollFollowsLease` resolves on. It ships dev-gated; on the fleet the guard resolves off and `writeLeasePollIntent` returns early, writing nothing. No fleet-visible change on this commit.
+- **External systems:** no direct calls. Indirectly, on an agent with `pollFollowsLease.dryRun:false`, Telegram sees one long-poll instead of two competing ones — which is the intended end state and strictly fewer 409s.
+- **Persistent state:** `state/telegram-poll-intent.json` only. Same schema, same fields, same atomic write. Written more often (bounded to once per 30s per unchanged value). No migration: the record is regenerated at runtime and readers already tolerate a missing/stale/corrupt file by treating it as "no opinion".
+- **Timing / runtime conditions:** the throttle uses wall-clock `Date.now()`. A backwards clock step could delay a refresh by up to the step size; the consumer's response to a too-old record is "no opinion → hold", the safe direction, so a clock anomaly degrades to today's behavior rather than to a wrong action.
+- **Operator surface (Mobile-Complete Operator Actions):** no operator-facing action added or changed. The existing levers (`pollOverride`, `telegramPolling`) are untouched.
+
+---
+
+## 6b. Operator-surface quality
+
+**Not applicable** — this change touches no dashboard renderer, approval surface, notification body, or operator-facing markup. No operator-facing text is added or modified.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN.** The record answers a question that MUST differ per machine: "should THIS machine own the Telegram poll?" Exactly one machine may answer yes at a time, so replicating the record would be actively wrong — a replicated `shouldPoll:true` landing on a standby is precisely the dual-poll failure the fenced lease exists to prevent. The cross-machine coordination is carried by the fenced lease itself (already replicated via `LeaseCoordinator` / the mesh transports), and the record is the machine-local projection of that shared truth into a sibling process.
+
+- **User-facing notices:** none emitted. No one-voice gating needed.
+- **Durable state on topic transfer:** the record is not topic-scoped and holds no per-topic state, so it cannot strand on a transfer. It is regenerated from the lease on the next reconcile on whichever machine holds it.
+- **Generated URLs:** none.
+
+Worth naming explicitly: this defect is itself a multi-machine defect that a single-machine install can never surface (a single machine short-circuits to `awake` and there is no second poller to conflict with). The evidence for this review came from a live two-machine pair, which is the graduation gate the parent spec names for B1/B5.
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the commit and ship as the next patch. One function plus one constant plus two fields.
+- **Data migration:** none. The record is advisory and regenerated at runtime; readers already treat missing/stale as "no opinion".
+- **Agent state repair:** none. No agent needs notifying or resetting.
+- **User visibility:** none during the rollback window on the fleet (the guard resolves off there). On a dev agent with the gate on, reverting restores the previous behavior exactly: the boot default stands and the lifeline holds or fights, as before.
+
+---
+
+## Conclusion
+
+The review changed the design twice. First, `writeLeasePollIntent` was changed to return a success boolean so the throttle can never record a skip-window off a write that failed — without that, a transient write failure would have suppressed retries for 30s, and the consumer would have aged into "no opinion" for a reason the code believed it had handled.
+
+Second and more importantly: writing a test that runs the REAL boot path, rather than only the stubbed reconcile, surfaced a second independent defect — the safe boot default being written after the reconcile it was meant to precede. Shipping the early-return fix alone would have produced a green unit suite and an unchanged production failure. That is worth recording as the reason the extra test existed: the stubbed tests could not have caught it, because they never ran `initializeLease()`. The throttle-cache ownership move (into `writeLeasePollIntent`) came out of the same test failing a second time for a different reason.
+
+Third, §2 forced an explicit statement of what this does NOT fix: the lifeline's boot-time poll-before-first-reconcile window and the dry-run `nobodyPollingRecovery` are both still open, both tracked on the attention item, and neither is claimed closed by this commit.
+
+The change complies with signal-vs-authority: it corrects a detector's output and adds no authority. It is inert on the fleet (dev-gated producer) and its whole risk surface is confined to agents that have explicitly enabled `pollFollowsLease`.
+
+---
+
+## Second-pass review
+
+**Not required.** Phase 5 triggers on changes that touch block/allow decisions on messaging or dispatch, session lifecycle, or anything named sentinel/guard/gate/watchdog. This change adds no block/allow surface and modifies no gate: it is confined to the producer side of an advisory record, and the consuming gate (`decidePollAction`) is untouched. The one adjacent trigger word — the lifeline's poll authority — is explicitly out of the diff.
+
+Recorded for the reviewer's benefit if this judgment is revisited: the argument rests on the diff containing no change to `TelegramLifeline`, which is verifiable from the commit's file list.
+
+---
+
+## Evidence pointers
+
+- Live measurement (instar-codey, Mac Mini, 2026-08-03 17:34 PDT, v1.3.1122): `/health → multiMachine.syncStatus` reporting `role:awake, holdsLease:true, leaseEpoch:21302` in the same second that `state/telegram-poll-intent.json` reported `role:standby, shouldPoll:false, leaseEpoch:21302`.
+- Staleness half: the same record's age sampled at 10s intervals climbed 84.5s → 155.0s across an 80s window with no rewrite, i.e. past the consumer's 90s bound.
+- Downstream harm on that agent: 812 × `Telegram 409 Conflict — another bot instance is polling`, 260 × `TelegramLifeline.selfRestart: conflict409Stuck`, server restarting every ~10 min for ~8h.
+- Pre-fix test control: with `src/core/MultiMachineCoordinator.ts` reverted to `origin/main`, the headline regression test fails with `expected null not to be null` (no record written at all) — the right reason, not a missing-symbol error. 7 of 10 tests in the new file fail pre-fix; the 3 that pass are the gate-off guard, the real-transition guard, and the observe-only "does NOT acquire ⇒ left muted" guard, all of which are expected to hold either way.
+- Second defect, found by the real-boot-path test rather than by reading: with only the early-return fixed, that test failed with the record on disk reading `{shouldPoll:false, role:'standby'}` while the in-process throttle key read `true|awake|1` — i.e. the correct value had been written and then overwritten by the boot default at the tail of `initializeLease()`. That divergence between the cache and the file is what identified the clobber.
+- Attention item carrying the fleet risk and the mitigation that must be removed after deploy: `ATT-poll-intent-standby-forever-20260803`.
+
+---
+
+## Class-Closure Declaration
+
+**Not applicable on both triggers, stated explicitly rather than omitted.**
+
+1. **Agent-authored-artifact defect?** No. The defect is in hand-written TypeScript (`MultiMachineCoordinator.ts`), not in an LLM prompt, hook, config, skill, or standards text.
+2. **Self-triggered controller added or modified?** No. `reconcileRoleToLease` is an existing control loop driven by the existing lease tick; this change adds no new loop, monitor, sentinel, reaper, scheduler, or recovery path, and fires no restart / swap / respawn / spawn / notify / retry / re-drive / kill. The throttle strictly REDUCES the action rate of an existing loop (a file write) and cannot increase it: an unchanged value is written at most once per `POLL_INTENT_REFRESH_MS`, and a changed value at most once per reconcile tick, which is the loop's own bound.


### PR DESCRIPTION
## ELI16 — a machine in charge was telling itself it was the standby

When one agent runs on two machines, exactly one of them is supposed to answer Telegram. The server knows which one it is; the part that actually talks to Telegram is a separate process, so the server leaves it a note on disk saying "you should be answering" or "you should not".

The machine in charge was leaving itself the note that says **"you are the standby, do not answer"** — and never correcting it. Two separate mistakes caused that, and either one alone was enough.

First, the note was only replaced when the machine's role **changed**. But a machine remembers what it was before it restarted, so one that was already in charge, restarts, and is still in charge never *changes* role — no change, no replacement, and the cautious startup note stays forever. On top of that, because the note was only rewritten on a change, it just got older and older until the messenger started ignoring it as out of date. So the note was either wrong or discarded, and almost never both correct and listened to.

Second — and we only found this by writing a test that runs the real startup rather than calling the function directly — the cautious "you are the standby" note was written at the **end** of startup, after the code had already worked out who was in charge. It was not standing in for a decision not yet made. It was landing on top of the decision just made and erasing it. Fixing only the first mistake gives you a green test suite and a machine that behaves exactly as badly as before.

Both are fixed: the note is now corrected on every check, and the cautious startup note goes first, where its own comment always said it should.

Why it matters beyond the one agent it broke: the "obey the note" behaviour ships switched off, and the plan is to switch it on everywhere once a live two-machine test proves it works. This outage was that test, and it failed. Switched on as it stood, every machine that restarted while in charge would have quietly muted its own Telegram — the exact silence the feature exists to prevent.

## What this fixes

A machine that **holds** the fenced lease was publishing `standby / do-not-poll` to its own lifeline — permanently. Two independent defects, either one sufficient on its own:

**1. The republish sat below the no-transition early-return.**
`reconcileRoleToLease()` called `writeLeasePollIntent(holds, desired)` *after* `if (desired === this._role) return;`. `_role` is restored from the machine registry at startup, so a machine that was already `awake` before a restart re-enters reconcile with no transition, returns early, and never replaces `initializeLease()`'s boot default. Publishing only on transitions also meant the record aged past the consumer's `maxStaleMs: 90_000` bound on a steady role, degrading it to "no current opinion".

**2. The safe boot default was written *after* the decision it stands in for.**
`initializeLease()` wrote `writeLeasePollIntent(false, 'standby')` at the very end of the method — but every branch above it already ends in `reconcileRoleToLease(...)`. So it did not stand in for an unmade decision; it overwrote the decision made three lines earlier. Its own comment ("at boot the role isn't yet reconciled … before the first reconcile decides the real role") describes the ordering the code did not have.

Defect 2 was found **by the test that runs the real boot path**, not by reading the diff. With only defect 1 fixed, the stubbed tests were green and production was unchanged.

## The change

- Publish the lease-derived intent on **every** reconcile, above the early-return.
- Throttled: writes on change (`shouldPoll | role | leaseEpoch`), or when the last **successful** write is older than `POLL_INTENT_REFRESH_MS` (30s — a 3× margin inside the consumer's 90s bound).
- Move the boot default **before** the acquire/reconcile branch.
- `writeLeasePollIntent` returns whether the write landed and owns the throttle state, so a direct caller can never leave the cache describing something other than what is on disk, and a failed write retries on the next reconcile instead of recording a skip-window.
- Transition-only side effects (`role_transition` audit, promote/demote events, churn breaker) deliberately stay below the early-return.

## Evidence (measured, not inferred)

Live on a two-machine agent at v1.3.1122, **same second, same lease epoch 21302**:

| surface | says |
|---|---|
| `GET /health → multiMachine.syncStatus` | `role: awake, holdsLease: true` |
| `state/telegram-poll-intent.json` | `role: standby, shouldPoll: false` |

The record's age climbed 84.5s → 155.0s across an 80s sample with no rewrite — past the consumer's 90s bound.

Downstream on that agent: **812** × `Telegram 409 Conflict — another bot instance is polling`, **260** × `TelegramLifeline.selfRestart: conflict409Stuck`, and a server restart roughly every ten minutes for about eight hours, taking its dashboard down each time.

## Why this matters beyond the one agent

`pollFollowsLease` ships dark, and `docs/specs/multimachine-lease-poll-robustness.md` names a **live two-host proof** as the graduation gate for B1/B5. This outage was that proof, unintentionally, and it failed. Graduating the lever with these defects present would make every restarted lease holder publish — and then obey — "standby / do-not-poll": silent Telegram ingress loss on the awake machine, the exact failure the feature exists to prevent.

## Tests

10 new unit tests in `tests/unit/MultiMachineCoordinator-pollIntentRepublish.test.ts`, including two that drive the **real** boot path with a live `FencedLease`/`LeaseCoordinator`:

- holder with no transition publishes `shouldPoll: true` (the regression)
- non-holder with no transition publishes `shouldPoll: false`
- steady role refreshes past the window, throttled inside it
- a failed write retries on the next reconcile
- lease-epoch change publishes immediately, inside the window
- nothing written when the gate is explicitly off
- transition-only side effects still fire on a real change, and do **not** fire on a steady role
- real boot path: a machine that acquires ends up published `awake / shouldPoll: true`
- real boot path: a machine on the observe-only branch that never acquires is left muted

**Control:** 7 of the 10 fail against `origin/main`. The headline regression fails with `expected null not to be null` (no record written at all) — the right reason, not a missing-symbol error. The 3 that pass pre-fix are the gate-off, real-transition, and never-acquires guards, which are expected to hold either way.

## Not claimed fixed

- The lifeline's boot-time **poll-before-first-reconcile window** (it starts polling at boot and reconciles 15s later). This removes the *cause* of dual-poll on a correctly-leased pair, not that window.
- `nobodyPollingRecovery` still ships `dryRun: true`.

Both tracked on attention item `ATT-poll-intent-standby-forever-20260803`, along with the blunt `multiMachine.telegramPolling: false` currently containing the affected agent — **that must be removed once this deploys**, or it will override the corrected behaviour.

## Rollback

Revert the commit. The intent record is advisory and regenerated at runtime; readers already treat missing/stale as "no opinion". No migration, no state repair, and no fleet-visible change during the rollback window (the producer is dev-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9cUeMPUhTEenNbRcv1upa
