### PR TITLE
fix(sessions): read real available memory in currentMemoryPressure — the macos-memory-pressure-metric sibling

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-04T06-03-26-349Z-memory-pressure-metric-sibling.json
+++ b/.instar/instar-dev-decisions/2026-08-04T06-03-26-349Z-memory-pressure-metric-sibling.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-04T06:03:26.349Z",
+  "slug": "memory-pressure-metric-sibling",
+  "suggestedTier": 1,
+  "declaredTier": 2,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 30,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/SessionManager.ts"
+    ],
+    "addedLines": 22,
+    "deletedLines": 8
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -54,6 +54,7 @@ export interface SessionDiagnostics {
   suggestions: string[];
 }
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+import { hostFreeMemPct, type MemReadDeps } from '../monitoring/hostMemoryPressure.js';
 import { detectRateLimited, nextIdleThrottleAction, RATE_LIMIT_SETTLED_CAPTURE_LINES, type ThrottleSettleState } from '../monitoring/rateLimitDetection.js';
 import { classifyIdleError } from './IdleErrorClassifier.js';
 import { InputGuard, type TopicBinding } from './InputGuard.js';
@@ -2310,11 +2311,18 @@ rm()  { "${shimRunner}" rm  "$@"; }
    * pre-spawn gate and the diagnostics surface read ONE definition of pressure.
    * The reroute gate refuses to hold a fresh ~200-500MB REPL when the host is
    * already 'high'/'critical' — the 2026-06-05 laptop-meltdown class.
+   *
+   * Reads the CORRECTED available-memory percentage (free + inactive + purgeable
+   * on macOS via vm_stat; MemAvailable on Linux) via `hostFreeMemPct` — NOT
+   * `os.freemem()`, which on macOS reports only raw free pages (~2.7% on a
+   * healthy 17GB host) and therefore pinned this method at 'critical'
+   * PERMANENTLY, so force-mode `evaluateRerouteGate` threw on every job spawn.
+   * Spec: macos-memory-pressure-metric (the sibling the original fix missed —
+   * SessionReaper/HostPressureSampler were corrected, this caller was not).
+   * Thresholds are unchanged; only the measurement source moved.
    */
-  private currentMemoryPressure(): MemoryPressure {
-    const totalMem = os.totalmem();
-    const freeMem = os.freemem();
-    const usedPercent = Math.round(((totalMem - freeMem) / totalMem) * 100);
+  private currentMemoryPressure(deps: MemReadDeps = {}): MemoryPressure {
+    const usedPercent = Math.round(100 - hostFreeMemPct(deps));
     if (usedPercent >= 90) return 'critical';
     if (usedPercent >= 75) return 'high';
     if (usedPercent >= 60) return 'moderate';
@@ -4206,11 +4214,17 @@ rm()  { "${shimRunner}" rm  "$@"; }
 
     const staleSessions = sessions.filter(s => s.isStale);
 
-    // Memory pressure assessment
+    // Memory pressure assessment. Reads the CORRECTED available-memory figure
+    // (free + inactive + purgeable on macOS via vm_stat; MemAvailable on Linux)
+    // — NOT os.freemem(), which counts only raw free pages and would report a
+    // healthy host at ~97% used. Kept in step with currentMemoryPressure() below
+    // so the reported PERCENTAGE and the reported TIER cannot contradict each
+    // other (pre-fix this surface could show "97% used" beside tier 'low').
+    // Spec: macos-memory-pressure-metric.
     const totalMem = os.totalmem();
-    const freeMem = os.freemem();
-    const usedPercent = Math.round(((totalMem - freeMem) / totalMem) * 100);
-    const freeMemMB = Math.round(freeMem / 1048576);
+    const freePct = hostFreeMemPct();
+    const usedPercent = Math.round(100 - freePct);
+    const freeMemMB = Math.round((totalMem * (freePct / 100)) / 1048576);
     const totalMemMB = Math.round(totalMem / 1048576);
 
     // Shared with the reroute pre-spawn gate (june15-headless-spawn-reroute O2)

--- a/tests/unit/session-manager-memory-pressure-sibling.test.ts
+++ b/tests/unit/session-manager-memory-pressure-sibling.test.ts
@@ -1,0 +1,185 @@
+/**
+ * SessionManager.currentMemoryPressure — the macos-memory-pressure-metric SIBLING.
+ *
+ * THE BUG (2026-08-04): the original macos-memory-pressure-metric fix corrected
+ * SessionReaper/HostPressureSampler to read REAL available memory via
+ * `hostFreeMemPct` (free + inactive + purgeable on macOS via vm_stat), and its
+ * shipped comment warns against `os.freemem()` BY NAME. SessionManager's own
+ * `currentMemoryPressure()` was never converted — it still computed
+ * `(totalmem - os.freemem()) / totalmem`.
+ *
+ * On macOS `os.freemem()` reports only raw free pages (~2.7% on a healthy 17GB
+ * host), so that method returned 'critical' PERMANENTLY. Under
+ * `subscriptionPath.mode: 'force'`, `evaluateRerouteGate()` THROWS on elevated
+ * pressure — so every job spawn was refused. Measured on the live Mini before
+ * this fix: 20 of 27 enabled jobs failing, `health-check` and
+ * `commitment-detection` at 421 consecutive failures each, with the identical
+ * error `Reroute refused (force-mode): host memory pressure is critical`.
+ *
+ * WHY IT STAYED INVISIBLE: tests/unit/headless-spawn-reroute.test.ts stubs
+ * `currentMemoryPressure` out entirely, with the comment that the real gate
+ * "made this suite fail on loaded dev machines". It was not a loaded dev
+ * machine — it was this defect, encountered, rationalised, and stubbed over.
+ * These tests exercise the real method so it can fail for the real reason.
+ *
+ * Both sides of the decision boundary are covered (Testing Integrity Standard):
+ * a healthy-but-low-free host must NOT read elevated, and a genuinely exhausted
+ * host must still read 'critical'. A fix that simply always returned 'low' would
+ * pass the first test and fail the second.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: () => '',
+  execFile: (_c: string, _a: string[], cb: (e: null, o: { stdout: string }) => void) =>
+    cb(null, { stdout: '' }),
+}));
+
+import { SessionManager, type SessionManagerConfig } from '../../src/core/SessionManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { MemReadDeps } from '../../src/monitoring/hostMemoryPressure.js';
+
+/**
+ * A realistic macOS `vm_stat` for a HEALTHY host: almost no "Pages free", but
+ * ample reclaimable inactive + purgeable. This is the exact shape that made
+ * os.freemem() read ~critical. Mirrors the fixture in host-memory-pressure.test.ts.
+ * free+inactive+purgeable = 10k+1.5M+800k = 2.31M of 5.11M pages ≈ 45% available.
+ */
+const VM_STAT_HEALTHY_LOW_FREE = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                               10000.
+Pages active:                           2000000.
+Pages inactive:                         1500000.
+Pages wired down:                        500000.
+Pages purgeable:                         800000.
+Pages occupied by compressor:            300000.
+`;
+
+/** A genuinely exhausted host: almost nothing free OR reclaimable. */
+const VM_STAT_GENUINELY_EXHAUSTED = `Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                                5000.
+Pages active:                           4500000.
+Pages inactive:                           20000.
+Pages wired down:                        500000.
+Pages purgeable:                           5000.
+Pages occupied by compressor:              5000.
+`;
+
+const macDeps = (vmStat: string): MemReadDeps => ({
+  platform: 'darwin',
+  vmStat: () => vmStat,
+  totalmem: () => 5_110_000 * 16384,
+});
+
+function makeManager(tmpDir: string, mode?: 'off' | 'auto' | 'force'): SessionManager {
+  const stateDir = path.join(tmpDir, 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  const config: SessionManagerConfig = {
+    tmuxPath: '/usr/bin/tmux',
+    claudePath: '/usr/local/bin/claude',
+    projectName: 'proj',
+    projectDir: tmpDir,
+    maxSessions: 10,
+    protectedSessions: [],
+    completionPatterns: ['has been automatically paused'],
+    ...(mode ? { subscriptionPathMode: mode } : {}),
+  };
+  return new SessionManager(config, new StateManager(stateDir));
+}
+
+type PressureProbe = { currentMemoryPressure: (deps?: MemReadDeps) => string };
+type GateProbe = { evaluateRerouteGate: (name: string) => { allow: boolean } };
+
+describe('SessionManager.currentMemoryPressure — macos-memory-pressure-metric sibling', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-mem-sibling-'));
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/session-manager-memory-pressure-sibling.test.ts',
+    });
+  });
+
+  it('a HEALTHY macOS host with tiny free pages does NOT read as elevated', () => {
+    const manager = makeManager(tmpDir);
+    const tier = (manager as unknown as PressureProbe)
+      .currentMemoryPressure(macDeps(VM_STAT_HEALTHY_LOW_FREE));
+
+    // Against the pre-fix code this is 'critical' (os.freemem sees ~0.2% free).
+    expect(tier).not.toBe('critical');
+    expect(tier).not.toBe('high');
+    expect(tier).toBe('low');
+  });
+
+  it('a GENUINELY exhausted host still reads critical (the guard keeps its teeth)', () => {
+    const manager = makeManager(tmpDir);
+    const tier = (manager as unknown as PressureProbe)
+      .currentMemoryPressure(macDeps(VM_STAT_GENUINELY_EXHAUSTED));
+
+    expect(tier).toBe('critical');
+  });
+
+  it('force-mode reroute gate ALLOWS a spawn on a healthy-but-low-free host', () => {
+    const manager = makeManager(tmpDir, 'force');
+    // Pin the pressure read to the healthy fixture, leaving the gate's own logic intact.
+    (manager as unknown as PressureProbe).currentMemoryPressure = () =>
+      (makeManager(tmpDir) as unknown as PressureProbe)
+        .currentMemoryPressure(macDeps(VM_STAT_HEALTHY_LOW_FREE));
+
+    // Pre-fix this threw `Reroute refused (force-mode): host memory pressure is critical`
+    // — the exact error that killed 20 of 27 jobs on the live Mini.
+    expect(() => (manager as unknown as GateProbe).evaluateRerouteGate('job-health-check'))
+      .not.toThrow();
+    expect((manager as unknown as GateProbe).evaluateRerouteGate('job-health-check').allow).toBe(true);
+  });
+
+  it('force-mode reroute gate STILL refuses when the host is genuinely exhausted', () => {
+    const manager = makeManager(tmpDir, 'force');
+    (manager as unknown as PressureProbe).currentMemoryPressure = () =>
+      (makeManager(tmpDir) as unknown as PressureProbe)
+        .currentMemoryPressure(macDeps(VM_STAT_GENUINELY_EXHAUSTED));
+
+    expect(() => (manager as unknown as GateProbe).evaluateRerouteGate('job-health-check'))
+      .toThrow(/memory pressure is critical/);
+  });
+
+  it('diagnostics percentage and tier cannot contradict each other', () => {
+    // Pre-fix, getSessionDiagnostics computed usedPercent from os.freemem() while
+    // taking the TIER from currentMemoryPressure() — so once the tier was fixed the
+    // surface could report "97% used" beside tier 'low'. Both now read one source.
+    const manager = makeManager(tmpDir);
+    const diag = (manager as unknown as {
+      getSessionDiagnostics: () => { memoryPressure: string; usedPercent: number };
+    }).getSessionDiagnostics();
+
+    const tierForPercent =
+      diag.usedPercent >= 90 ? 'critical'
+      : diag.usedPercent >= 75 ? 'high'
+      : diag.usedPercent >= 60 ? 'moderate'
+      : 'low';
+    expect(diag.memoryPressure).toBe(tierForPercent);
+  });
+
+  it('thresholds are unchanged — only the measurement source moved', () => {
+    const manager = makeManager(tmpDir);
+    const probe = manager as unknown as PressureProbe;
+    // hostFreeMemPct is clamped 0..100; drive the tiers directly through it.
+    const at = (freePct: number) =>
+      probe.currentMemoryPressure({
+        platform: 'linux',
+        procMeminfo: () => `MemTotal: 1000000 kB\nMemAvailable: ${Math.round(freePct * 10000)} kB\n`,
+        totalmem: () => 1000000 * 1024,
+      });
+    expect(at(5)).toBe('critical');   // 95% used
+    expect(at(20)).toBe('high');      // 80% used
+    expect(at(35)).toBe('moderate');  // 65% used
+    expect(at(60)).toBe('low');       // 40% used
+  });
+});

--- a/upgrades/next/memory-pressure-metric-sibling.md
+++ b/upgrades/next/memory-pressure-metric-sibling.md
@@ -1,0 +1,70 @@
+# Scheduled jobs no longer refused on a healthy Mac
+
+## What Changed
+
+`SessionManager.currentMemoryPressure()` now reads real available memory via `hostFreeMemPct()`
+(free + inactive + purgeable through `vm_stat` on macOS; `MemAvailable` on Linux) instead of raw
+`os.freemem()`.
+
+On macOS `os.freemem()` counts only "Pages free" — **0.46 GB of 17 GB (2.7%)** on a completely healthy
+host. The method therefore computed 97% used and returned **`critical` permanently**. Under
+`subscriptionPath.mode: 'force'`, `evaluateRerouteGate()` throws on elevated pressure, so **every job
+spawn was refused**.
+
+The corrected helper already existed in-package and is used by `SessionReaper` / `HostPressureSampler`;
+its comment warns against `os.freemem()` by name. The 2026-06-26 `macos-memory-pressure-metric` fix
+converted those two callers and missed this one. **Thresholds (90/75/60) are unchanged — only the
+measurement source moved.**
+
+`getSessionDiagnostics()`'s memory block moves to the same source, so the reported percentage and the
+reported tier can no longer contradict each other (before, that surface could show "97% used" next to
+tier `low`).
+
+Two other `os.freemem()` callsites (`src/server/routes.ts`, `src/monitoring/HealthChecker.ts`) already
+prefer `MemoryPressureMonitor`'s `vm_stat` state and fall back only when it is absent — reviewed and
+correct as-is, deliberately untouched.
+
+## What to Tell Your User
+
+If your scheduled jobs stopped running and every failure said the machine was out of memory, this is the
+fix — and the machine was almost certainly fine the whole time.
+
+On a Mac, the figure being used counted only completely untouched memory. Macs deliberately use spare
+memory as cache, so that number sits near zero on a perfectly healthy machine. Your agent read it as
+"97% used, critical" and refused to start any scheduled job.
+
+On the machine where this was found, **20 of 27 enabled jobs were dead — the health check and the
+commitment tracker had each failed 421 times in a row**, going back more than two days, while the machine
+had ample memory free. A second machine with 137 GB of memory and 21 GB genuinely free was being rated
+under pressure by the same calculation.
+
+Your agent now reads memory the way the operating system itself reports it. Nothing about *when* it
+protects you has changed — a genuinely loaded machine still refuses new work at exactly the same
+thresholds. It just no longer believes a healthy machine is full.
+
+You may also notice memory figures in session diagnostics drop substantially on macOS. That is the
+correction, not a regression.
+
+## Summary of New Capabilities
+
+No new capabilities — this is a correctness fix to an existing guard. The guard keeps its authority and
+its thresholds; only the number it reads is corrected.
+
+## Evidence
+
+- **Live measurement before the fix:** 20 of 27 enabled jobs failing, all with
+  `Reroute refused (force-mode): host memory pressure is critical`; `health-check` and
+  `commitment-detection` at **421 consecutive failures** each.
+- **Three readings of the same machine, same second:** raw `os.freemem()` → 2.7% free → `critical`;
+  the reaper's corrected reading → 16.3% free → `normal`; macOS `memory_pressure` → 38% free.
+- **Reproduced on a second machine:** 137 GB total, 21 GB genuinely free → raw metric rated it `high`.
+- **New tests:** `tests/unit/session-manager-memory-pressure-sibling.test.ts` (6).
+  **Control run — 3 of 6 fail against pre-fix code for the right reasons**, including
+  `expected [Function] to not throw but 'Error: Reroute refused (force-mode): …' was thrown`, the exact
+  production error. The other 3 pass either way **by design**: they pin that a genuinely exhausted host
+  still reads `critical` and is still refused, so an "always return low" regression cannot pass.
+- **Green:** 48/48 across the new suite plus `host-memory-pressure.test.ts` (16) and
+  `headless-spawn-reroute.test.ts` (26). `tsc --noEmit` clean; full lint suite clean.
+- **Side-effects review:** `upgrades/side-effects/memory-pressure-metric-sibling.md`.
+- **Spec:** `docs/specs/macos-memory-pressure-metric.md` (converged 2026-06-26, approved) — this ships
+  the caller that spec's original fix did not convert.

--- a/upgrades/side-effects/memory-pressure-metric-sibling.md
+++ b/upgrades/side-effects/memory-pressure-metric-sibling.md
@@ -1,0 +1,108 @@
+# Side-effects review — macos-memory-pressure-metric SIBLING (SessionManager)
+
+**Change:** `SessionManager.currentMemoryPressure()` and `getSessionDiagnostics()`'s memory block now read
+the corrected available-memory figure via `hostFreeMemPct()` instead of raw `os.freemem()`.
+**Spec:** `docs/specs/macos-memory-pressure-metric.md` (converged 2026-06-26, `approved: true`) — this is
+the caller that spec's original fix did not convert.
+**Author:** echo · **Date:** 2026-08-04
+**Sanction:** architect review 2026-08-04, under Justin's plan-scoped approval of 2026-08-03 20:21 PDT
+(relayed 20:23). Escalated to Phase A critical path because it starves the grading job that answers rung 3.
+
+## What was wrong
+
+`os.freemem()` on macOS counts only "Pages free". On a healthy 17 GB Mini it reports **0.46 GB (2.7%)**,
+so `currentMemoryPressure()` computed 97% used and returned **`critical` permanently**. Under
+`subscriptionPath.mode: 'force'`, `evaluateRerouteGate()` **throws** on elevated pressure — so every job
+spawn was refused.
+
+**Measured on the live host before the fix:**
+- 20 of 27 enabled jobs failing, all with `Reroute refused (force-mode): host memory pressure is critical`
+- `health-check` and `commitment-detection` at **421 consecutive failures** each, going back ≥2 days
+- three readings of the same machine, same second: **raw 2.7% free → `critical`** · reaper (corrected)
+  **16.3% free → `normal`** · macOS `memory_pressure` **38% free**
+- the same defect on the laptop: **137 GB RAM, 21 GB genuinely free → raw metric says `high`**
+
+The corrected helper already existed in-package (`hostFreeMemPct`, used by
+`HostPressureSampler`/`SessionReaper`) and its shipped comment warns against `os.freemem()` **by name**.
+The reaper was fixed; this caller was not.
+
+## The 8 questions
+
+**1. Over-block — what legitimate inputs does this reject that it shouldn't?**
+None introduced; this change *removes* an over-block. Pre-fix the gate rejected **every** force-mode spawn
+on macOS regardless of real conditions. Post-fix it rejects only genuinely elevated hosts. Thresholds
+(90/75/60) are byte-identical — only the measurement source moved.
+
+**2. Under-block — what failure modes does this still miss?**
+The gate now trusts `hostFreeMemPct`, so it inherits that helper's limits: on an unrecognised platform it
+falls back to `os.freemem()`-equivalent behaviour, and `vm_stat` parse failure degrades to the same. That
+is the pre-existing, already-reviewed behaviour of the 2026-06-26 fix, not new exposure. **Genuinely
+exhausted hosts still read `critical` — covered by a dedicated test so a "just return low" regression
+cannot pass.**
+
+**3. Level-of-abstraction fit.**
+Correct layer. `currentMemoryPressure()` is the single definition of the pressure tier shared by the
+reroute gate and the diagnostics surface (deliberately extracted in june15-headless-spawn-reroute PR2/O2).
+Fixing it here fixes both consumers at once. The alternative — patching each caller — is what produced
+this sibling in the first place.
+
+**4. Signal vs authority compliance.** (`docs/signal-vs-authority.md`)
+**Compliant, and it is the point of the change.** `currentMemoryPressure()` is a **detector**: it produces
+a signal (`MemoryPressure` tier). `evaluateRerouteGate()` is the **authority** that decides. The defect was
+a detector emitting a *false signal* to a correct authority. This change corrects the detector's
+measurement and **adds no authority, moves no authority, and changes no threshold**. No new blocking logic
+is introduced anywhere.
+
+**5. Interactions — shadowing, double-fire, races.**
+Two other `os.freemem()` callsites exist (`src/server/routes.ts:3743`, `src/monitoring/HealthChecker.ts:217`).
+**Both were inspected and both already compensate** — each prefers `MemoryPressureMonitor`'s vm_stat-based
+state and only falls back to `os.freemem()` when the monitor is absent, with a comment saying why. They are
+correct as-is and are deliberately **not** touched. No shadowing: the reroute gate is the only consumer of
+the tier for spawn decisions, and the diagnostics surface is read-only.
+
+⚠️ **Interaction worth naming:** `tests/unit/headless-spawn-reroute.test.ts` **stubs `currentMemoryPressure`
+to `'normal'`**, with the comment that the real gate *"made this suite fail on loaded dev machines."* It was
+not a loaded dev machine — **it was this defect, encountered, rationalised, and stubbed over**, which is why
+CI never caught it. The stub is left in place (those tests assert reroute control-flow, not pressure) but
+the new suite exercises the real method so it can now fail for the real reason.
+
+**6. External surfaces.**
+`getSessionDiagnostics()` payload changes: `usedPercent` and `freeMemMB` now report real available memory.
+On macOS these numbers will **drop substantially** (e.g. 97% → ~40% used) — that is the correction, not a
+regression. Pre-fix, once the tier was fixed alone, the surface could have reported **"97% used" beside tier
+`low`**; both now read one source and a test pins that they cannot contradict. No timing or conversation-state
+dependence.
+
+**7. Multi-machine posture (Cross-Machine Coherence).**
+**Machine-local BY DESIGN — correctly so.** Host memory pressure is a property of the physical machine; a
+reading must never be replicated or proxied from a peer. Verified the defect independently on **both**
+machines (Mini: raw `critical` vs corrected `normal`; laptop: raw `high` vs corrected `normal` with 21 GB
+free). The fix therefore lands on both, and each machine keeps reading its own memory. No replication path,
+no merged read, no cross-machine state. **This also removes a latent block on the ratified placement policy:**
+worker lanes are to run on the laptop, and the same gate would have refused spawns there too.
+
+**8. Rollback cost.**
+Trivial. Revert the commit — no data migration, no agent-state repair, no persisted format change. The
+change is confined to two computations inside one file plus one new test file. A hot-fix release restores
+prior behaviour exactly (including, if anyone wants it, the permanent-`critical` bug).
+
+## Testing
+
+New: `tests/unit/session-manager-memory-pressure-sibling.test.ts` (6 tests).
+
+**Control run — 3 of 6 fail against pre-fix code, each for the right reason** (verified by stashing the
+source change and re-running):
+- `expected 'critical' not to be 'critical'` — the defect itself
+- `expected [Function] to not throw but 'Error: Reroute refused (force-mode): …' was thrown` — **the exact
+  production error that killed 20 jobs**
+- `expected 'critical' to be 'high'` — the Linux threshold path also mis-tiered
+
+The other 3 pass either way **by design** — they are the guards proving the fix does not simply always
+return `low` (genuinely-exhausted host still `critical`; gate still refuses it; diagnostics self-consistent).
+
+Green: 48/48 across the new suite + `host-memory-pressure.test.ts` (16) + `headless-spawn-reroute.test.ts`
+(26). `tsc --noEmit` clean.
+
+## Second-pass review
+
+Required (touches a **gate**). See appended section below.


### PR DESCRIPTION
## ELI16 — what this is, in plain English

If your scheduled jobs stopped running and every failure said the machine was out of memory, this is the fix — and the machine was almost certainly fine the whole time.

On a Mac, the figure being used counted only *completely untouched* memory. Macs deliberately use spare memory as cache, so that number sits near zero on a perfectly healthy machine — **0.46 GB of 17 GB (2.7%)** on the host where this was found. The code read that as "97% used → critical" and, under force-mode, **refused every job spawn**.

On that machine, **20 of 27 enabled jobs were dead** — `health-check` and `commitment-detection` had each failed **421 times in a row**, for more than two days, while the machine had ample memory. A second machine with **137 GB of RAM and 21 GB genuinely free** was rated `high` by the same calculation.

The corrected helper already existed in this package and is used by `SessionReaper` / `HostPressureSampler`; **its comment warns against `os.freemem()` by name.** The 2026-06-26 `macos-memory-pressure-metric` fix converted those two callers and missed this one. This PR ships the sibling.

**Nothing about *when* the guard protects you changes.** Thresholds (90/75/60) are byte-identical — only the number being measured is corrected.

## What changed

- `SessionManager.currentMemoryPressure()` reads `hostFreeMemPct()` (free + inactive + purgeable via `vm_stat` on macOS; `MemAvailable` on Linux) instead of raw `os.freemem()`.
- `getSessionDiagnostics()`'s memory block uses the same source, so the reported **percentage** and the reported **tier** can no longer contradict each other (pre-fix that surface could show "97% used" beside tier `low`).
- Two other `os.freemem()` callsites (`src/server/routes.ts`, `src/monitoring/HealthChecker.ts`) already prefer `MemoryPressureMonitor`'s `vm_stat` state and fall back only when it is absent — reviewed, correct as-is, **deliberately untouched**.

## Signal vs authority

`currentMemoryPressure()` is a **detector** (produces a tier); `evaluateRerouteGate()` is the **authority** (decides). The defect was a detector emitting a *false signal* to a correct authority. This change corrects the measurement and **adds no authority, moves no authority, changes no threshold**.

## Evidence

Three readings of the same machine, **same second**:

| source | reading | verdict |
|---|---|---|
| raw `os.freemem()` | 2.7% free | **critical** |
| reaper (already corrected) | 16.3% free | **normal** |
| macOS `memory_pressure` | 38% free | healthy |

**Control run — 3 of 6 new tests fail against pre-fix code, each for the right reason:**
- `expected 'critical' not to be 'critical'` — the defect itself
- `expected [Function] to not throw but 'Error: Reroute refused (force-mode): ...' was thrown` — **the exact production error**
- `expected 'critical' to be 'high'` — the Linux threshold path also mis-tiered

The other **3 pass either way by design** — they pin that a genuinely exhausted host still reads `critical` and is still refused, so an "always return `low`" regression cannot pass.

Green: **48/48** across the new suite + `host-memory-pressure.test.ts` (16) + `headless-spawn-reroute.test.ts` (26). `tsc --noEmit` clean, full lint suite clean.

## Why it stayed invisible

`tests/unit/headless-spawn-reroute.test.ts` **stubs `currentMemoryPressure` out**, with the comment that the real gate *"made this suite fail on loaded dev machines."* It was not a loaded dev machine — **it was this defect, encountered, rationalised, and stubbed over**, which is why CI never caught it. The stub stays (those tests assert reroute control-flow, not pressure); the new suite exercises the real method so it can fail for the real reason.

## Review focus

The place I most want attacked: `getSessionDiagnostics()` now derives `freeMemMB` as `totalMem * (freePct/100)` rather than from a direct byte reading. That is a *derived* figure — if `hostFreeMemPct` and `os.totalmem()` ever disagree about what "total" means on some platform, that number drifts. I judged consistency-with-the-tier more valuable than byte-exactness, but it is a real trade and worth a second opinion.

Spec: `docs/specs/macos-memory-pressure-metric.md` (converged 2026-06-26, approved).
Side-effects review: `upgrades/side-effects/memory-pressure-metric-sibling.md`.
