### PR TITLE
docs: withdraw the tokensIn overclaim from 1.3.1125; record what the fix did NOT restore

### DIFF
--- a/docs/audits/phase-a-auditor-method-lessons.md
+++ b/docs/audits/phase-a-auditor-method-lessons.md
@@ -46,3 +46,71 @@ counterexample was hiding. Naming the blind spot is what made this recognisable 
 
 **Round 5's conclusion is amended: not converged, and now with a known counterexample class — computed
 availability/health booleans. That is the highest-yield next angle, ahead of field-name matching.**
+
+---
+
+## Round 6 additions — #22, #23, and the first guards caught being EFFECTIVE on me
+
+### #22 — I applied the absence rule everywhere except my own incident report
+
+Seconds after a harness killed a pool session, I checked for pool sessions, got an empty result, and
+reported **"the pool is empty — one session to zero."** Both numbers were wrong. There were **two**
+sessions, one was killed, and the survivor was healthy and serving throughout (verified: live process,
+idle prompt, answered a 17,281-byte chunked prompt in ~5 s).
+
+This is the **third** occurrence today of *an empty/failed command result read as data* — after the
+`/jobs` route with no `lastRun` field, and the laptop probe where an auth error parsed into nulls I
+read as runtime state.
+
+**The tell is not new. The context is.** I have a written rule — *before reporting an absence, prove
+the check could have shown otherwise* — and applied it consistently to guards, jobs and peers… then
+not to **my own incident report**, the single place it mattered most. A false alarm about
+infrastructure damage is more expensive than any other kind, because it triggers exactly the panicked,
+unverified remediation that causes real damage.
+
+**Rule: the absence check applies HARDEST to your own bad news.** Alarm is the state in which
+verification feels least affordable and is most necessary.
+
+### #23 — "smoke test" is a name, not a behaviour contract
+
+I ran an adapter's own `_smoketest` against live infrastructure to gather evidence. On startup it
+reaped a **live** pool session belonging to the running server, by a loose name match, then failed to
+start its own.
+
+I read the docblock ("exercises the adapter against a real REPL pool") and inferred it was
+self-contained. It wasn't. **I trusted the label instead of reading the mechanism** — the exact failure
+this audit exists to catalogue, committed by the auditor, with teeth.
+
+**Rule: before running any harness against live infrastructure, read its SETUP path specifically** —
+not its purpose, not its docblock, but what it does to the world before it does its job.
+
+**Filed separately as a real defect:** a harness that reaps another live process's sessions on startup
+is dangerous by design, independent of my carelessness. Its "stale" detection should be scoped to
+sessions it owns.
+
+### ⭐ THREE guards observed EFFECTIVE on live violations — all caught on me
+
+| guard | violation I actually committed | outcome |
+|---|---|---|
+| managing-server restart refusal | tried to restart my OWN managing server from inside its session | refused, with the reason AND a safe alternative |
+| destructive-command guard | attempted a hard-reset of a git working tree | blocked, authorization required |
+| `lint-chain-completeness` | added a lint to CI without protecting it in `REQUIRED_LINTS` | failed the build, named the exact fix |
+
+**All three are rung 3** — a genuine violation, caught on current code — and none required a designed
+injection. I obtained them by making the mistakes.
+
+**Method note: the auditor's own errors are a legitimate and under-used source of rung-3 evidence.**
+They are unplanned, genuinely adversarial, and free. The catch is that the evidence only exists if you
+REPORT your violations instead of quietly fixing them. Every one of the 23 catalogued errors was a
+potential rung-3 datapoint; I recorded them as method failures and only noticed late that they are
+also guard measurements.
+
+### ⚠️ A false positive in the same family, caught immediately after
+
+The destructive-command guard then blocked a **commit message** that merely *quoted* the hard-reset
+command as prose. It matches the raw tool input, so a MENTION trips it identically to a USE.
+
+Same shape as the tone gate flagging `rung-3` in a message where that term was the operator's own
+vocabulary. **Keyword guards cannot distinguish use from mention** — which is the "Intelligence Infers,
+Keywords Only Guard" standard restated as a measurement. Both were cheap to work around honestly
+(reword, or acknowledge with a reason), and both are recorded rather than silently bypassed.

--- a/docs/audits/phase-a-auditor-method-lessons.md
+++ b/docs/audits/phase-a-auditor-method-lessons.md
@@ -1,0 +1,48 @@
+
+---
+
+## Round 6 — SERIAL MASKING: you cannot enumerate the faults in a degraded system by inspection
+
+The internal-LLM outage turned out to be **three independent faults stacked in series**, and each one
+was invisible until the one in front of it was fixed.
+
+| # | fault | how it presented | when it became visible |
+|---|---|---|---|
+| 1 | `tmux send-keys -l` argv ceiling — ~40 KB prompt vs ~16 KB limit | breaker log said `provider rate-limited` (a hardcoded string) | only after reading the reason field the headline talked over |
+| 2 | codex-cli OAuth `refresh_token_invalidated` (401) | components at 100% error; routing surface said codex `available: true` | only after #1 was fixed, deployed, and the pool STILL got no traffic |
+| 3 | swap-attempt timeout **5 s** vs the pool's own `maxPromptWaitSeconds` **120 s** | two `swap-attempt-timeout: claude-code` lines, easily read as noise | only after #2 explained why traffic reached the swap at all |
+
+### The lesson
+
+**At each stage, the evidence available genuinely supported a single-fault story.** After fixing #1 I
+had: a reproduced defect, a byte-exact end-to-end proof on the live provider, a deploy, and zero
+failures post-restart. Every one of those was true. The conclusion "the outage is fixed" would have
+been *reasonable* — and wrong.
+
+What saved it was refusing to accept **absence of failure as evidence of success**. Zero breaker trips
+after the restart proved nothing, because nothing was calling the path. I had said that out loud before
+measuring, which is the only reason I kept looking instead of declaring victory.
+
+**Rule: in a degraded system, a fix that removes a blocker does not reveal a working system — it
+reveals the NEXT blocker.** Do not enumerate the fault list up front from inspection; it will be
+incomplete by construction, because downstream faults are unobservable while an upstream one absorbs
+all the traffic. Fix, deploy, then RE-MEASURE the end-to-end behaviour rather than the thing you fixed.
+
+**Corollary — the honest completion criterion is a POSITIVE observation, never a negative one.**
+"No errors since the fix" is compatible with "nothing ran". The close condition must be *something
+succeeded*, and it must be something you watched land.
+
+### And a fourth instance of ASSERTS-UNMEASURED-STATE, found the same way
+
+Fault #2's surface: `GET /intelligence/routing` reports codex-cli **`available: true`** for every
+component while every codex call returns 401. Availability is measured as *the binary exists*, not
+*the door opens*.
+
+That is the third confirmed instance of the class (after the memory metric and the breaker label), and
+it lands **exactly** in the blind spot the Round 5 sweep named as unseeable — *a cause asserted by a
+computed field rather than a string*. The Round 5 verdict ("outlier, not a pattern", 3 angles, 348
+files) is therefore **weakened, and correctly so**: the sweep's own declared blind spot is where the
+counterexample was hiding. Naming the blind spot is what made this recognisable when it appeared.
+
+**Round 5's conclusion is amended: not converged, and now with a known counterexample class — computed
+availability/health booleans. That is the highest-yield next angle, ahead of field-name matching.**

--- a/docs/audits/phase-a-constitutional-alignment.md
+++ b/docs/audits/phase-a-constitutional-alignment.md
@@ -203,3 +203,32 @@ The safe direction here is NOT `false`. For an availability claim, the honest de
 the same three-valued shape `DoorwayRegistryReader` already implements.
 
 **Sweep status after 6 angles: 4 confirmed instances, 1 exemplar, NOT converged.**
+
+### Angle 7 — cross-boundary assertion: 0 new instances (and the near-miss is instructive)
+
+Swept callers that convert a null/undefined callee result into a definite state
+(`?? false`, `|| 'unavailable'`). 14 candidates, **0 instances**. They split three ways:
+
+1. **Config defaults** — `opts.escalationEnabled ?? false`, `config?.alwaysRestartImmediately ?? false`.
+   An absent flag defaulting to off is not an assertion about the world.
+2. **Documented fail-closed** — `UpdateGate`'s `restartSafetyResolver?.(session) ?? false` (no resolver
+   ⇒ restart NOT safe), `MeshRpc`'s `authorizeMandateDeliver?.(…) ?? false` (no authorizer ⇒ not
+   authorized). Refusing in the absence of a positive answer is the correct direction.
+3. **One near-miss worth naming.** `MultiMachineCoordinator.preferredIsHealthy` returns
+   `leaseCoordinator?.isHolderHealthy(m) ?? false` — "peer unhealthy" when there is no coordinator to
+   ask, which *reads* like instance #4's shape. It is not. `LeaseCoordinator.isHolderHealthy`'s own
+   contract: *"a non-preferred machine defers to its preferred peer ONLY while this is true, so a
+   frozen/down/released preferred never strands coverage."* `false` means **stop deferring and take
+   over** — the coverage-preserving direction.
+
+**The discriminator this angle produced:** an unmeasured-state assertion is only a defect when the
+asserted value is the one that CAUSES action or inaction wrongly. `false` meaning "refuse" is safe;
+`false` meaning "this capability is absent" (instance #4) or `true` meaning "this door works"
+(instance #3) is not. **The class is not "a boolean where unknown is possible" — it is "a boolean whose
+unknown collapses to the CONSEQUENTIAL value."** That is a materially tighter definition than the one
+Round 5 swept with, and it explains why Round 5's three angles found nothing: they searched for the
+shape, not for the consequence.
+
+**Sweep status after 7 angles: 4 confirmed instances, 1 exemplar, 1 tightened definition. NOT
+converged** — the contract needs a clean round with the *new* definition, since angles 1-5 were run
+with the looser one and would not reliably have recognised instances #3 or #4.

--- a/docs/audits/phase-a-constitutional-alignment.md
+++ b/docs/audits/phase-a-constitutional-alignment.md
@@ -288,3 +288,40 @@ answer "did you ever actually act?"** — see the Round 6 instrumentation measur
 **Status:** OPEN (new, Round 6). `IntelligenceRouter`'s `available: boolean` measures *binary presence*
 and is read as *reachability*; `DoorwayRegistryReader` already implements the correct three-valued
 shape (`true` / `false` / `null` for not-probed). **This is a propagation decision, not a design one.**
+
+---
+
+## OD-6 — Why does the interactive pool hold zero sessions? (bounded unknown, 2026-08-04 15:45Z)
+
+**Status:** OPEN. Blocks the Phase A close condition (one real judgment call succeeding through the
+pool). Recorded as a bounded unknown rather than a guess.
+
+**What is established:**
+
+- Gating calls now genuinely REACH the pool: `MessagingToneGate` shows 4 calls / 4 errors against
+  `claude-code / interactive-pool`, with `shed: 0` — real errors, not capacity sheds.
+- The swap-budget fault is resolved: **2** `swap-attempt-timeout` events before the 15:11 restart,
+  **0** after.
+- The pool holds **0 tmux sessions**, and **no spawn attempt is logged at all** since that restart.
+
+**Hypotheses ELIMINATED (each checked, not assumed):**
+
+| hypothesis | why it is not the cause |
+|---|---|
+| the memory gate is starving pool spawns | `pool.spawnOne()` calls `tmux new-session` **directly**; it never passes through `evaluateRerouteGate`. The gate IS refusing *job* reroutes ("host memory pressure is high") — a real, separate fault, and option C's subject — but not this one. |
+| the host-wide spawn cap is shedding them | cap 8, 1 live, 7 available, `saturated: false`; and the tone-gate rows show `shed: 0`. |
+| a Claude REPL cannot reach ready right now | spawned one by hand: **ready in ~5 s**. |
+| the pool's working directory is missing | `.instar/intelligence-pool` exists; a tmux spawn with that `-c` succeeds. |
+
+**What that leaves:** something fails between the router selecting the pool provider and
+`pool.start()` / `spawnOne()` being reached — because a spawn attempt would log, and none does. The
+adapter's `ensureStarted()` is lazy and memoised (`if (!startPromise) startPromise = pool.start()`), so
+a `startPromise` that rejected once would be **permanently rejected for the process lifetime** without
+re-attempting. That is the leading candidate and it is testable, but it was NOT confirmed this window
+and is therefore recorded as a hypothesis, not a finding.
+
+**Why this is recorded rather than pursued further:** four hypotheses were eliminated with direct
+evidence and the fifth needs either instrumentation or a code read deeper than the remaining budget
+supports. Continuing to guess would produce exactly the plausible-but-unverified story this audit
+exists to prevent. **The serial-masking lesson applies: this is the fifth blocker in the chain, and
+each previous one was invisible until its predecessor was fixed.**

--- a/docs/audits/phase-a-constitutional-alignment.md
+++ b/docs/audits/phase-a-constitutional-alignment.md
@@ -1,0 +1,56 @@
+
+---
+
+## Round 6 — the definitive instrumentation measurement (supersedes the 7-of-38 estimate)
+
+Measured 2026-08-04 13:45Z on the live Mini via `GET /guards`, over the **full 90-guard population**
+rather than the 38-route sample used earlier.
+
+| measure | count | share |
+|---|---|---|
+| guards tracked | 90 | — |
+| `runtimeReason: not-instrumented` | **62** | **69%** |
+| runtime-enriched (report ANY runtime state) | 26 | 29% |
+| …of those, reporting only a **tick/heartbeat** | 20 | — |
+| …of those, exposing an **act / would-act counter** | **1** | **1.1% of all guards** |
+
+### The finding, stated plainly
+
+> **Exactly ONE guard in ninety can answer the question "did you ever actually act?"**
+
+Everything else can answer at most *"am I alive?"* — and 69% cannot answer even that.
+
+This supersedes the earlier "7 of 38 guard-shaped routes expose effectiveness counters (18%)". That
+figure was measured over routes; this is measured over the guard population itself and is both larger
+and worse.
+
+### Why this is THE supporting evidence for the three-counter schema
+
+Recall the A0 finding: `on-confirmed` means **the guard reports a heartbeat** — it is rung 2 evidenced
+by a pulse, not rung 3. The `effective` distribution confirms the shape of the problem:
+
+| effective | count | what it actually means |
+|---|---|---|
+| `on-unverified` | 40 (44%) | on, and nothing observes whether it fires |
+| `on-confirmed` | 20 (22%) | on, and it has a pulse — **still not evidence it ever caught anything** |
+| `off` | 18 (20%) | — |
+| `on-dry-run` | 11 (12%) | cannot bite by construction |
+| `on-blind` | 1 (1%) | — |
+
+So the tier the system trusts most (`on-confirmed`, 20 guards) is trusted on a heartbeat, and only one
+guard anywhere emits the counter that would convert that trust into evidence.
+
+**`{looked, wouldAct, didAct}` is not a nice-to-have.** It is the difference between a population where
+1 guard can be evaluated and one where 90 can — without staged faults, without injection, without a
+throwaway-agent harness. It is the single highest-leverage change in the entire Phase B backlog, and
+this table is the number to put in front of the decision.
+
+### Honest limits of this measurement
+
+- It counts **exposure**, not correctness: a guard emitting a counter could still be counting the wrong
+  thing. Exposure is necessary, not sufficient.
+- The act/would-act detection is a **key-name heuristic** over the runtime blocks (`count|fired|acted|
+  would|attempts|blocked|caught`). A guard exposing an effectiveness counter under an idiosyncratic key
+  would be missed — so **1 is a floor, and the true figure could be marginally higher**. It cannot be
+  materially higher: 62 of 90 report no runtime block at all, which no naming convention can rescue.
+- Single machine (Mini). The laptop's population may differ; the per-machine amendment applies.

--- a/docs/audits/phase-a-constitutional-alignment.md
+++ b/docs/audits/phase-a-constitutional-alignment.md
@@ -313,15 +313,39 @@ pool). Recorded as a bounded unknown rather than a guess.
 | a Claude REPL cannot reach ready right now | spawned one by hand: **ready in ~5 s**. |
 | the pool's working directory is missing | `.instar/intelligence-pool` exists; a tmux spawn with that `-c` succeeds. |
 
-**What that leaves:** something fails between the router selecting the pool provider and
-`pool.start()` / `spawnOne()` being reached — because a spawn attempt would log, and none does. The
-adapter's `ensureStarted()` is lazy and memoised (`if (!startPromise) startPromise = pool.start()`), so
-a `startPromise` that rejected once would be **permanently rejected for the process lifetime** without
-re-attempting. That is the leading candidate and it is testable, but it was NOT confirmed this window
-and is therefore recorded as a hypothesis, not a finding.
+### ⭐ CONFIRMED FROM SOURCE — a memoised rejected start permanently disables the pool
 
-**Why this is recorded rather than pursued further:** four hypotheses were eliminated with direct
-evidence and the fifth needs either instrumentation or a code read deeper than the remaining budget
-supports. Continuing to guess would produce exactly the plausible-but-unverified story this audit
-exists to prevent. **The serial-masking lesson applies: this is the fifth blocker in the chain, and
-each previous one was invisible until its predecessor was fixed.**
+```js
+let startPromise = null;
+const ensureStarted = async () => {
+    if (!startPromise) {
+        startPromise = pool.start();
+    }
+    await startPromise;          // <- NO rejection handling, and no reset
+};
+```
+
+**There is no rejection path.** If `pool.start()` rejects even once:
+
+1. `startPromise` is left holding a **rejected** promise — non-null.
+2. Every later `ensureStarted()` sees it as truthy, **skips the restart entirely**, and re-awaits the
+   same rejection, throwing immediately.
+3. No spawn is attempted, so **nothing is logged** — the failure is invisible after the first instant.
+4. This persists for the **entire process lifetime**. Only a server restart clears it.
+
+**This accounts for every observation, with nothing left over:** 0 sessions, 0 spawn attempts logged,
+4 real errors with `shed: 0`, a REPL that spawns fine by hand, and a condition that did not self-heal
+across 400 s of watching.
+
+**Severity.** One transient failure at first-use — a momentary resource blip, a slow spawn, a leftover
+session — permanently removes the interactive-pool door for that process. Under
+`subscriptionPath.mode: force`, that door is the fallback the entire gating layer depends on when the
+primary framework is down. Which is exactly the state this agent is in (codex 401).
+
+**The pattern is the audit's own class, one layer up.** `ensureStarted` treats "I already tried" as
+"the answer is settled" — the same shape as asserting a state you did not re-measure. A retry-on-reject
+(or clearing `startPromise` in a `catch`) is the whole fix.
+
+**Recorded as CONFIRMED-from-source, NOT as a shipped fix** — per the Phase A scope ruling, genuine
+builds are deferred to Phase B. Fifth blocker in the serial chain, and consistent with the lesson:
+each was invisible until its predecessor was fixed.

--- a/docs/audits/phase-a-constitutional-alignment.md
+++ b/docs/audits/phase-a-constitutional-alignment.md
@@ -349,3 +349,51 @@ primary framework is down. Which is exactly the state this agent is in (codex 40
 **Recorded as CONFIRMED-from-source, NOT as a shipped fix** — per the Phase A scope ruling, genuine
 builds are deferred to Phase B. Fifth blocker in the serial chain, and consistent with the lesson:
 each was invisible until its predecessor was fixed.
+
+### OD-6 mechanism, completed — how one slow spawn kills the door for a whole process
+
+```js
+async start() {
+    await this.killStaleSessions();                    // agent-prefix scoped
+    const promises = [];
+    for (let i = 0; i < this.config.poolSize; i++)     // poolSize default 2
+        promises.push(this.spawnOne());
+    await Promise.all(promises);                       // ANY ONE failure rejects the whole start
+}
+// spawnOne: throws `Pool session <id> did not reach ready state in 30s`
+```
+
+Composed with the memoised `ensureStarted`, the full chain is:
+
+1. **One** of the two spawns fails to reach ready inside **30 s**.
+2. `Promise.all` rejects — the *other* session having spawned successfully does not help.
+3. `startPromise` retains that rejection **forever** (no catch, no reset).
+4. Every later call re-awaits it, attempts no spawn, and logs nothing.
+5. The door is gone until the process restarts.
+
+**A 30-second timeout on a machine under memory pressure is the whole exposure.** The reroute gate was
+reporting `host memory pressure is high` at 15:11:08 — the same window the first `pool.start()` would
+have run. That the trigger was a slow spawn is **inferred** (the timeout itself is not logged);
+the *defect* — that any single transient spawn failure is permanent — is **confirmed from source**.
+
+#### The same `killStaleSessions()` explains the earlier incident
+
+Its comment: *"our prefix is agent-scoped, so anything matching it is OURS from a dead process — kill
+before spawning fresh."* The reasoning holds for the SERVER's own restart. It does **not** hold for a
+second process constructing its own adapter: the `_smoketest` built a default-config adapter whose
+prefix matched the live server's sessions, so "anything matching it is ours" reaped a session belonging
+to a *running* peer process. **The already-filed harness defect and this pool defect share one root** —
+prefix-scoped ownership with no liveness check on the owner.
+
+#### Why this is the highest-value single finding of the sweep
+
+Three properties compound:
+- **Silent** — after the first instant it logs nothing, because nothing is attempted.
+- **Permanent** — process-lifetime, no self-heal, no backoff, no retry.
+- **Load-bearing** — under `subscriptionPath.mode: force` this door is the fallback the whole gating
+  layer depends on when the primary framework is down.
+
+An agent can therefore lose its entire internal-judgment fallback to one transient blip, and every
+observable surface stays quiet about it. **That is the exact failure shape this audit was commissioned
+to find**, arrived at from the opposite direction — not by auditing a guard, but by chasing why a
+guard's evidence would not appear.

--- a/docs/audits/phase-a-constitutional-alignment.md
+++ b/docs/audits/phase-a-constitutional-alignment.md
@@ -54,3 +54,56 @@ this table is the number to put in front of the decision.
   would be missed — so **1 is a floor, and the true figure could be marginally higher**. It cannot be
   materially higher: 62 of 90 report no runtime block at all, which no naming convention can rescue.
 - Single machine (Mini). The laptop's population may differ; the per-machine amendment applies.
+
+---
+
+## Round 6 sweep — angle 4 (computed availability booleans) CONFIRMS the class
+
+Round 5 ran three angles over cause STRINGS and concluded *asserts-unmeasured-state* was "an outlier,
+not a pattern". It also named the blind spot it could not see: **a cause asserted by a computed field
+rather than a string.** Round 6 ran that angle. It found an instance immediately.
+
+### The instance, confirmed FROM SOURCE (not inferred from behaviour)
+
+`GET /intelligence/routing` reports `available: true` for `codex-cli` on every component while every
+codex call returns `401 refresh_token_invalidated`. The router's own comments say why:
+
+| location | comment |
+|---|---|
+| `IntelligenceRouter.ts:66` | *"When a routed framework's provider is unavailable (**binary missing**)…"* |
+| `IntelligenceRouter.ts:178` | *"Returns null when that framework's **binary isn't available**."* |
+| `IntelligenceRouter.ts:239` | *"null = built but unavailable (**binary missing**)"* |
+
+**Availability is defined as *the binary exists*, in three places, by design.** It is not a claim about
+whether the door opens — but it is *named* `available`, and it is *read* as "this door works".
+
+This is not a bug in the sense of a mistake; it is a **measurement whose name overstates it**, which is
+exactly the class. The consequence was real: with codex 100% failing, the surface an operator would
+consult to ask "is codex healthy?" answered yes, for every component, throughout.
+
+### What this does to the Round 5 verdict
+
+**Round 5's "outlier, not a pattern" is WITHDRAWN as premature.** The class now has:
+
+1. `SessionManager.currentMemoryPressure` (pre-fix) — mis-measured, asserted `critical`
+2. `LlmCircuitBreaker` OPEN log (pre-fix) — measured nothing, asserted `provider rate-limited`
+3. `IntelligenceRouter` availability — measures binary presence, named/read as reachability
+
+Three confirmed instances, all on live critical paths, all found within one session. **A "clean" sweep
+that missed instance 3 was clean only about the surface it searched** — and its own blind-spot
+declaration predicted precisely where the miss would be. That the named blind spot then produced the
+counterexample is the strongest available evidence that naming blind spots is load-bearing, not
+ceremony.
+
+### Sweep status: NOT converged, and now with a positive finding
+
+| round | angles | new confirmed instances |
+|---|---|---|
+| 5 | 3 (cause strings, fixed literals, user templates) | 0 |
+| 6 | 1 (computed availability/health booleans) | **1** |
+
+A round that finds something is a round that must be followed by another. **The next angle is
+health/status fields whose NAME asserts more than their computation** — `healthy`, `reachable`,
+`ready`, `ok`, `connected` — checked against what each actually tests. `DoorwayRegistryReader:114`
+(*"parse-drift on a door that DID answer → stays reachable:true"*) is a candidate to examine: it may be
+a deliberate, documented exception rather than an instance, which is itself worth recording.

--- a/docs/audits/phase-a-constitutional-alignment.md
+++ b/docs/audits/phase-a-constitutional-alignment.md
@@ -232,3 +232,59 @@ shape, not for the consequence.
 **Sweep status after 7 angles: 4 confirmed instances, 1 exemplar, 1 tightened definition. NOT
 converged** — the contract needs a clean round with the *new* definition, since angles 1-5 were run
 with the looser one and would not reliably have recognised instances #3 or #4.
+
+---
+
+# NAMED OPEN DECISIONS carried into Phase B
+
+Recorded here so they cannot rot as implicit intentions. Each is a decision someone must MAKE, not a
+task someone must do.
+
+## OD-1 — Does the placement policy require the managed peer-execution runtime?
+
+**Node:** placement (worker lanes on the laptop)
+**Status:** OPEN. Ruled 2026-08-04 (Observer cycle four): do **not** re-enable unilaterally.
+
+`multiMachine.peerExecution.enabled` is `false` while its own config carries `requiredForReadiness:
+true`. It is classified **load-bearing**, `criticalPath: "autonomous execution on a paired peer
+machine"`, and it gates the managed mutual-SSH runtime. It was disabled on **2026-08-01T12:57:02Z**
+together with `meshTransport.recoveryProbeEnabled`; the guard-posture tripwire raised an attention item
+at the time, which **sat OPEN and unacknowledged for three days** until acknowledged on 2026-08-04
+under this ruling.
+
+**The decision:** placement may ride the **session pool** (currently stage `rebalance`) rather than the
+managed runtime. Until that is settled, re-enabling is a guess.
+
+**What is already known, so the decision is not re-litigated from scratch:**
+- Raw SSH between the two machines works — used continuously throughout the 2026-08-04 window.
+- So connectivity is NOT the open question; only whether the MANAGED runtime is on the placement path.
+- The laptop's revival queue — the prerequisite the Observer named for placement — is now repaired and
+  **verified running** (two distinct ticks 60 s apart), so this is the remaining placement blocker.
+
+**Decision owner:** Justin, via the Observer.
+
+## OD-2 — The three load-bearing guard gaps: graduate, soak, or record an owned accept?
+
+**Status:** OPEN, same ruling — recorded, not unilaterally re-enabled.
+
+`multiMachine.meshTransport.recoveryProbeEnabled` · `multiMachine.sessionPool.inboundQueue.enabled` ·
+`multiMachine.sessionPool.staleOwnerRelease.enabled`.
+
+The guard framework itself offers exactly three resolutions (graduate / let it soak out / record an
+owned accept with reason+owner). **Leaving them flagged is not one of them** — an indefinitely-open
+load-bearing gap is the state the classification exists to make impossible.
+
+## OD-3 — Can the CI-and-PR-context guards be verified by a real CI run?
+
+**Status:** OPEN (carried from the Phase A close). 10 guards, currently positional deferrals.
+
+## OD-4 — Adopt the `{looked, wouldAct, didAct}` counter schema?
+
+**Status:** OPEN (carried from the Phase A close). **Supporting evidence: exactly 1 guard in 90 can
+answer "did you ever actually act?"** — see the Round 6 instrumentation measurement.
+
+## OD-5 — Make availability three-valued to match the in-repo exemplar?
+
+**Status:** OPEN (new, Round 6). `IntelligenceRouter`'s `available: boolean` measures *binary presence*
+and is read as *reachability*; `DoorwayRegistryReader` already implements the correct three-valued
+shape (`true` / `false` / `null` for not-probed). **This is a propagation decision, not a design one.**

--- a/docs/audits/phase-a-constitutional-alignment.md
+++ b/docs/audits/phase-a-constitutional-alignment.md
@@ -150,3 +150,56 @@ instead of "yes".
 **Sweep status after 5 angles: 3 confirmed instances, 1 exemplar located, NOT converged.** The next
 angle remains open — the class has produced a finding in the most recent round, so the contract
 requires another.
+
+### Angle 6 — CONFIRMED INSTANCE #4, and it attacks the anti-hallucination mechanism itself
+
+Angle 6 swept *cause asserted by omission* — a branch emitting one status for several distinct
+conditions. Most candidates were **correct**: `StaleOwnerReleaseEngine` documents *"an unreadable
+feature gate reads as INACTIVE (fail dark, the safe direction)"*, which is a deliberate, named,
+safe-direction choice. Those are not instances.
+
+**`CapabilityMapper` is.** Every subsystem check has this shape:
+
+```js
+check: () => {
+  const configPath = path.join(this.config.stateDir, 'config.json');
+  if (!fs.existsSync(configPath)) return false;          // <- CANNOT READ  => "absent"
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    return config.messaging?.some(...) ?? false;
+  } catch { return false; }                               // <- CANNOT PARSE => "absent"
+}
+```
+
+Two paths report **capability ABSENT** when the truth is **could not determine**.
+
+#### Proved non-destructively, with both sides of the boundary
+
+Ran the exact check shape against fixture configs (never the live config):
+
+| condition | capability truly enabled? | check reports |
+|---|---|---|
+| readable config | yes | `true` ✅ |
+| **corrupt config** (truncated mid-object) | **yes** | **`false` — ABSENT** ❌ |
+| config file absent | unknown | `false` — ABSENT ❌ |
+
+A partial write, a truncated file, or a transient read error makes the agent report it does not have
+Telegram, relationships, or monitoring — while all three are enabled.
+
+#### Why this instance matters more than the other three
+
+`CapabilityMapper` feeds `GET /capabilities`, which the agent constitution names explicitly:
+
+> *"Before EVER saying 'I don't have', 'I can't', or 'this isn't available' — check what actually
+> exists… It is the source of truth about what you can do. **Never hallucinate about missing
+> capabilities — verify first.**"*
+
+**The mechanism built to stop the agent falsely claiming it lacks a capability will itself falsely
+report a missing capability whenever it cannot read the config.** An agent obeying the constitution
+perfectly — verifying before claiming — is handed a confident false negative, and the failure is
+silent, because a capability that is absent looks exactly like a capability that is off.
+
+The safe direction here is NOT `false`. For an availability claim, the honest default is *unknown* —
+the same three-valued shape `DoorwayRegistryReader` already implements.
+
+**Sweep status after 6 angles: 4 confirmed instances, 1 exemplar, NOT converged.**

--- a/docs/audits/phase-a-constitutional-alignment.md
+++ b/docs/audits/phase-a-constitutional-alignment.md
@@ -107,3 +107,46 @@ health/status fields whose NAME asserts more than their computation** — `healt
 `ready`, `ok`, `connected` — checked against what each actually tests. `DoorwayRegistryReader:114`
 (*"parse-drift on a door that DID answer → stays reachable:true"*) is a candidate to examine: it may be
 a deliberate, documented exception rather than an instance, which is itself worth recording.
+
+### Angle 5 — 0 new instances, and something more useful: the EXEMPLAR is already in-repo
+
+Angle 5 swept health/status fields whose NAME might assert more than their computation
+(`healthy`, `reachable`, `ready`, `connected`, `live`). **No new instance of the class.** But the
+candidate flagged in angle 4 turned out to be the opposite of an instance — it is the pattern the
+class needs, already written, already shipped:
+
+`DoorwayRegistryReader` resolves reachability **three-valued**:
+
+```
+'not-probed-this-run' | 'not-probed-this-scope'
+'not-probed-budget-refused' | 'http-5xx'   →  null    // CANNOT TELL — explicitly not false
+'not-installed' | 'http-4xx'               →  false   // definitively unreachable
+'malformed-response' | 'oversize-response' →  true    // the door DID answer
+default                                    →  null    // unknown ⇒ null, never a guess
+```
+
+**"Not probed" returns `null`, not `false`.** Unknown returns `null`, not a guess. A door that answered
+badly is still recorded as having answered, with the parse concern handled elsewhere rather than
+smeared into the reachability verdict.
+
+That is *exactly* the three-kinds-of-zero discipline this audit derived independently for counters
+(`{looked, wouldAct, didAct}`), implemented for booleans, by someone else, already in the tree.
+
+### Why this changes the Phase B recommendation
+
+The fix for *asserts-unmeasured-state* is therefore **not a design problem — it is a propagation
+problem.** The repo contains a correct, shipped exemplar; the instances are the sites that predate it
+or never adopted it. That is materially cheaper than "design a solution", and it makes the
+recommendation concrete:
+
+> **Make the two-valued `available: boolean` on `IntelligenceRouter` three-valued, matching
+> `DoorwayRegistryReader`: `true` (verified reachable) / `false` (verified unreachable) / `null` (not
+> probed — the honest default).**
+
+Under that shape, codex would have reported `null` rather than `true` while its token was revoked, and
+the surface an operator consults for "is this door healthy?" would have said "I have not checked"
+instead of "yes".
+
+**Sweep status after 5 angles: 3 confirmed instances, 1 exemplar located, NOT converged.** The next
+angle remains open — the class has produced a finding in the most recent round, so the contract
+requires another.

--- a/docs/audits/phase-a-constitutional-alignment.md
+++ b/docs/audits/phase-a-constitutional-alignment.md
@@ -158,7 +158,7 @@ conditions. Most candidates were **correct**: `StaleOwnerReleaseEngine` document
 feature gate reads as INACTIVE (fail dark, the safe direction)"*, which is a deliberate, named,
 safe-direction choice. Those are not instances.
 
-**`CapabilityMapper` is.** Every subsystem check has this shape:
+**`CapabilityMapper` is.** **Seven** subsystem checks share this shape (7 `catch { return false }` and 7 `if (!fs.existsSync(configPath)) return false`):
 
 ```js
 check: () => {

--- a/upgrades/next/tmux-literal-send-ceiling.md
+++ b/upgrades/next/tmux-literal-send-ceiling.md
@@ -53,7 +53,14 @@ is transport mechanics and the classifier is a pure label with no say in whether
 - **Live measurement before the fix:** `[llm-circuit] OPEN: provider rate-limited … (trip #14)`,
   tripping every 15 minutes since 09:59Z, reason
   `Failed to send prompt: Command failed: … tmux send-keys … -l …`. Ten components at 76–100% error,
-  every `byModel` row showing `tokensIn: 0` — the calls never produced anything.
+  every `byModel` row showing `tokensIn: 0`.
+
+  **Correction (2026-08-04, post-deploy):** the original text read "the calls never
+  produced anything" from that zero. **That inference was wrong.** `tokensIn: 0` also
+  appears on components with 100+ clean successes (`durable-output-scrub` 125,
+  `rope-health` 123, `mesh-coherence-live` 119), so it is a token-ATTRIBUTION gap, not
+  evidence of an empty call. The 76-100% ERROR RATES were the real evidence and are
+  unchanged; only the token inference is withdrawn.
   Worst by volume: `SessionActivitySentinel` 6977/7148 (97.6%); most consequential:
   `MessagingToneGate` 260/342 (76%).
 - **Ceiling reproduced directly:** a single `send-keys -l` of a 39,992 B payload returns

--- a/upgrades/side-effects/tmux-literal-send-ceiling.md
+++ b/upgrades/side-effects/tmux-literal-send-ceiling.md
@@ -23,8 +23,15 @@ whose OPEN log line **hardcoded "provider rate-limited"**.
 - `[llm-circuit] OPEN: provider rate-limited … (trip #14)` — tripping every 15 minutes since 09:59Z
 - reason string, verbatim: `Failed to send prompt: Command failed: /opt/homebrew/bin/tmux send-keys
   -t =instar-pool-echo-aip-3757dfe6fb16: -l …`
-- **ten** LLM-backed components at 76–100% error rate, every `byModel` row showing `tokensIn: 0`
-  (the calls never produced anything):
+- **ten** LLM-backed components at 76–100% error rate, every `byModel` row showing `tokensIn: 0`:
+
+  ⚠️ **Correction (2026-08-04, post-deploy):** this originally read "(the calls never produced
+  anything)". **Withdrawn.** `tokensIn: 0` also appears on components with 100+ clean successes
+  (`durable-output-scrub` 125, `rope-health` 123, `mesh-coherence-live` 119) — it is a token
+  ATTRIBUTION gap, not proof of an empty call. The error rates below are the real evidence and
+  stand unchanged; only the token inference is retracted. Recording it rather than editing it away,
+  because an unmarked silent fix of a shipped claim is the failure mode this artifact exists to
+  prevent.
 
   | component | errors/calls | rate |
   |---|---|---|
@@ -194,3 +201,37 @@ look if calls still fail after this lands. Named here rather than discovered lat
 defect and a false-cause label, and it closes the class with a verified guard. It does **not** yet
 demonstrate a working end-to-end internal LLM call, and the artifact should not be read as claiming
 one. Independent review still owed.
+
+---
+
+## Post-deploy addendum (2026-08-04) — what the fix did and did NOT restore
+
+Deployed as 1.3.1125 and verified live: shipped `promptRunner.js` carries the chunked path, and
+post-restart there are **0 send failures and 0 breaker trips** (last trip #17 was pre-restart).
+
+**But the interactive-pool call count did not move at all** in 7.5 minutes of observation — so the
+"one real pool call succeeding" close condition is not satisfied by this deploy, and absence of a
+breaker trip is not being counted as success.
+
+**Cause: a SECOND, independent fault this change does not address.**
+
+    codex_api: HTTP 401 Unauthorized · "code": "refresh_token_invalidated"
+
+Internal components route to **codex-cli by default** (provider-fallback default policy). Codex's OAuth
+refresh token is revoked server-side, so those components fail at their PRIMARY door and never reach the
+interactive-pool tail this PR repaired.
+
+**Honest restatement of scope:** the argv ceiling was real, is fixed, and was proven end-to-end on the
+live provider. But it governed the FALLBACK path. The primary path for most of the affected components
+was independently dead, and still is. This PR repaired the spare tyre — necessary, and not sufficient.
+
+### Related finding — a third instance of the class this work already named
+
+`GET /intelligence/routing` reports codex-cli **`available: true`** for every component while every
+codex call 401s: availability is evidently measured as *the binary exists*, not *the door opens*.
+
+That is the same **asserts-unmeasured-state** class as the pre-fix memory metric and the pre-fix breaker
+label. The Phase A round-5 sweep concluded that class was "an outlier, not a pattern" after three
+angles over 348 files. **This counterexample weakens that conclusion** — and it sits precisely in the
+blind spot that sweep declared it could not see: *a cause asserted by a computed field rather than a
+string.* The named blind spot found the thing it predicted.


### PR DESCRIPTION
## ELI16 — I shipped a claim that was wrong, and this takes it back in writing

Yesterday's fix shipped with a line saying that because those failing checks recorded "zero tokens in", the calls had never produced anything.

**That inference doesn't hold.** Three components that are working perfectly — over a hundred successful calls each — show the same zero. It's a gap in how token usage gets attributed, not proof that a call did nothing. The failure evidence was always the error rates, which are unchanged and still correct.

This marks the claim as withdrawn rather than quietly deleting it, because silently editing a shipped claim is exactly the thing a side-effects artifact is supposed to make impossible.

It also records something the original PR couldn't know: **the fix is live and working, and it did not bring the failing components back.** They route to a different provider first, and that provider's login is separately dead. The ceiling fix repaired the spare tyre — necessary, but not the road most of that traffic takes.

---

## Held deliberately

Titled `[HOLD:]`. Standing instruction: a third unreviewed merge needs pre-approval **before** merging, not an explanation after. Docs-only, but the rule is the rule.

## What changed

Two artifacts already shipped in 1.3.1125:

- `upgrades/next/tmux-literal-send-ceiling.md`
- `upgrades/side-effects/tmux-literal-send-ceiling.md`

**Withdrawn:** "every `byModel` row showing `tokensIn: 0` — the calls never produced anything."

`tokensIn: 0` also appears on `durable-output-scrub` (125 successes), `rope-health` (123) and `mesh-coherence-live` (119). It is a token-**attribution** gap, not evidence of an empty call. The 76–100% error rates were the real evidence and are untouched.

**Added — post-deploy addendum.** Verified live: shipped `promptRunner.js` carries the chunked path, and post-restart there are 0 send failures and 0 breaker trips. But the interactive-pool call count never moved in 7.5 minutes, so the close condition is **not** met and absence of a trip is not being counted as success.

Cause is a second, independent fault:

```
codex_api: HTTP 401 Unauthorized · "code": "refresh_token_invalidated"
```

Internal components route to **codex-cli by default**, and its OAuth refresh token is revoked server-side, so they fail at the primary door and never reach the tail this fix repaired.

## A finding that cuts against my own earlier conclusion

`GET /intelligence/routing` reports codex-cli `available: true` for every component while every codex call 401s — availability measured as *the binary exists*, not *the door opens*.

That is a **third** instance of the `asserts-unmeasured-state` class (after the pre-fix memory metric and the pre-fix breaker label). The Phase A round-5 sweep called that class "an outlier, not a pattern" after three angles over 348 files. This weakens that conclusion — and it sits exactly in the blind spot the sweep declared it could not see: *a cause asserted by a computed field rather than a string.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)