### PR TITLE
fix(messaging): bound the attention-notification surface

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-05T01-52-02-327Z-bounded-attention-notification-surface.json
+++ b/.instar/instar-dev-decisions/2026-08-05T01-52-02-327Z-bounded-attention-notification-surface.json
@@ -1,0 +1,30 @@
+{
+  "ts": "2026-08-05T01:52:02.327Z",
+  "slug": "bounded-attention-notification-surface",
+  "suggestedTier": 2,
+  "declaredTier": 2,
+  "riskFloor": 2,
+  "riskFloorReasons": [
+    "irreversibility: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator",
+    "migration / fleet-rollout surface: src/core/PostUpdateMigrator.ts touches PostUpdateMigrator (fleet migration machinery)",
+    "new capability: new config key added"
+  ],
+  "belowFloor": false,
+  "files": 5,
+  "loc": 599,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/core/PostUpdateMigrator.ts",
+      "src/messaging/NotificationBatcher.ts",
+      "src/monitoring/DegradationReporter.ts",
+      "src/scaffold/templates.ts"
+    ],
+    "addedLines": 567,
+    "deletedLines": 32
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/bounded-attention-notification-surface.eli16.md
+++ b/docs/specs/bounded-attention-notification-surface.eli16.md
@@ -1,0 +1,61 @@
+# Plain-English overview — putting a ceiling on the messages your agent sends you
+
+## The thing that happened
+
+You said the attention messages had become unmanageable across pretty much every agent, and that we needed to lock it down. So the first job was to find out whether that was a feeling or a number.
+
+It is a number. In twenty-four hours, one agent sent sixty-four messages into its attention topic. Twenty-five of those said nothing you could act on — things like "one of my checks is running on its simpler backup path", "memory is getting tight", "everything else is working fine". A second agent, doing completely different work, sent sixty-five with thirty-three of the same kind. Two agents, same proportions, which means the behaviour lives in the code they share rather than in anything either of them did.
+
+## What is actually generating it
+
+Underneath, this machine is out of memory. Swap is at 18.8GB of 20.5GB. There are three agent servers running alongside a browser and a pile of sessions — no single culprit, just too much at once.
+
+When memory is that tight, the agent's small internal checks — the background things that read a message and decide whether it needs attention — cannot get the resources they need, so they fall back to a simpler way of working and carry on. Every time that happens, the agent writes it down. Today it wrote it down 781 times.
+
+Most of that never reached you. The filtering already in place removed about 97 percent of it. What you have been seeing is the 3 percent that leaks through.
+
+## Why the leak is the real problem
+
+Here is the part that matters more than the count. **The noise scales with how badly things are going.** The worse the machine gets, the more your agent tells you about it — and the messages it sends under stress are precisely the ones with nothing in them for you to do. That is backwards. A struggling system should get quieter with you, not louder, and save your attention for the thing you can actually decide.
+
+Right now nothing stops it. There is a hard limit on how many new *topics* the agent may create on its own, added after an earlier flood. Nobody ever added the equivalent limit for *messages* into a topic that already exists. I checked for one under seven different names, across five different places, with a control test proving the search was reading the right code.
+
+Two smaller things make it worse. The agent's memory of "I already told them this" is held only while it is running, so every restart forgets and the same notices come round again. And there is an off-switch on this machinery that three other parts of the code read and obey — but this particular path skips it, so it looks like a working lever and is not one.
+
+## What this change does
+
+Four things, all in the shared code so every agent gets them.
+
+**One. The housekeeping stops reaching you by default.** It is still written down, still kept, and I can read any of it back whenever you ask. You just stop receiving it unprompted. This is the biggest single cut and it is the one real decision in here — see below.
+
+**Two. A limit on messages per hour, per conversation.** Four by default, counted over a rolling hour. Past that, the rest wait their turn and send themselves as soon as there is room. Nothing is thrown away, and you are not told about the waiting — being told would be one more message you cannot act on, which is the thing we are removing.
+
+There is a wrinkle worth one paragraph, because getting it wrong is what took most of the review. If you run me on more than one machine, a limit that each machine enforces on its own is not really a limit — two machines each sending four an hour means you get eight. I tried three times to fix that by having each machine work out its own fair share, and each attempt was cleverer than the last while the list of things that could still go wrong got longer. That was the tell. You cannot get an exact shared limit out of machines guessing independently.
+
+The answer was to stop sharing. Every conversation already has exactly one machine that owns it — that is how I avoid two machines answering you at once. So only the owning machine sends routine notices into a conversation. One machine counting, one limit, no guessing. Urgent messages are deliberately outside this: any machine can always reach you.
+
+**Three. The "I already told them" memory gets written to disk,** so restarting no longer re-opens the floodgates.
+
+**Four. The off-switch is made real on this path,** so next time this needs adjusting it is a setting rather than a code change and a release.
+
+## What does not change
+
+Urgent messages are untouched. Anything marked as needing you *now* — quota exhausted, a session genuinely stuck — bypasses all four of these and reaches you immediately. The ceiling does not count it and cannot hold it.
+
+Real attention items are untouched. If I raise something that needs your decision, it arrives exactly as it does today.
+
+And if a degradation is genuinely affecting you, it still reaches you — through the attention queue and the urgent path, both of which this leaves alone. What goes quiet is the routine "fell back, still working" report, not your ability to find out something broke.
+
+## The decision you already made
+
+Should housekeeping be **silent by default for every agent**, or **on by default with only the hourly limit**?
+
+You answered **silent** on 4 August. That is what the proposal now specifies. Everything measured supported it — none of the sampled housekeeping was actionable, all of it stays recorded and readable on request, and the alternative would have left you opted in to noise by inertia.
+
+## If it turns out wrong
+
+Every part of this is reversible with a setting, with no data to migrate and nothing to repair. Turn the housekeeping back on, set the ceiling to zero to remove it, delete one file to drop the saved memory. The whole change is a single commit that can be backed out.
+
+## What this does not fix
+
+The memory squeeze that generates the events in the first place. That is real, it is a capacity problem rather than a bug, and it deserves its own decision — three agent servers on one laptop is the shape of it. This change stops the squeeze from shouting at you; it does not end the squeeze.

--- a/docs/specs/bounded-attention-notification-surface.md
+++ b/docs/specs/bounded-attention-notification-surface.md
@@ -1,0 +1,411 @@
+---
+title: "Bounded Attention-Notification Surface — a ceiling on messages into an existing topic, and housekeeping that stops reaching the user"
+slug: bounded-attention-notification-surface
+parent-principle: "Bounded Blast Radius"
+eli16-overview: bounded-attention-notification-surface.eli16.md
+status: approved
+approved: true
+approval-context: "Approved by Justin (topic 7848, 2026-08-04 16:52 PDT): explicit 'Approved' in reply to the build-approval request, after reading the plain-English proposal and separately answering 'Silent' to the one design decision (housekeeping silent by default fleet-wide). The converged design, the named standards deviation, and the two honest limits (per-topic scope; outstanding second-pass review) were all presented in-channel before approval."
+review-convergence: "2026-08-04T23:55:58.402Z"
+review-iterations: 13
+review-completed-at: "2026-08-04T23:55:58.402Z"
+review-report: "docs/specs/reports/bounded-attention-notification-surface-convergence.md"
+cross-model-review: "codex-cli:gpt-5.5"
+single-run-completable: true
+frontloaded-decisions: 9
+cheap-to-change-tags: 0
+contested-then-cleared: 0
+---
+
+> **Note on this document's history.** This spec was rewritten in full after review round 10. Ten rounds of section-by-section patching had left it describing **two incompatible architectures** — the settled ownership-based design in one section and the abandoned machine-count-divisor design in four others. The per-standard conformance gate returned clean on that document, because it evaluates one standard at a time and never reads for internal coherence; the whole-document cross-model reviewer caught it immediately. That is a lesson about the review tooling as much as about the spec, and it is recorded in §Review history rather than dropped.
+
+## Problem (the incident this closes)
+
+Operator report, 2026-08-04 (topic 7848): *"the attention messages have become completely unmanageable for pretty much all INSTAR agents that I can tell. We need to lock this down now."*
+
+Measured the same day against the running install (v1.3.1125):
+
+| Measurement | Echo | Codey |
+|---|---|---|
+| Messages into the attention topic, last 24h | 64 | 65 |
+| …of which carry pure housekeeping | 25 | 33 |
+
+Housekeeping means `⚠ <Component> has been on its heuristic fallback for ~16m`, `Using <fallback> in the meantime — everything else is working fine`, `Memory is getting tight (2.9GB free)`, `Job/A2A spawn refused under force-mode`. None of it names an action the operator can take. Two agents, independent workloads, the same proportions — shared-code behaviour, not one agent misbehaving.
+
+The generator, from `logs/server.log` the same day: **781** `[DEGRADATION]` events, **182** of them `IntelligenceRouter` failure-swaps, driven by host memory pressure (swap 18.8GB used of 20.5GB; 52 instar processes at 4.1GB; three agent servers co-resident).
+
+Existing suppression already drops ~97% (781 → 25). **The residual is the defect**: 25/day of content nobody acts on, and — the load-bearing part — *the volume scales with how degraded the system is*. The worse things get, the more the operator is told, in exactly the messages least worth reading.
+
+### Why it cannot be turned off today
+
+Verified against the running dist. Each negative is control-checked: the control symbols `topicCreationBudget`, `maxTopicsPerSource`, `attentionTopicGuard` all return non-zero from the same grep, proving the search reads the right tree.
+
+1. **The batcher is constructed from literals, not config.** `src/commands/server.ts` builds `new NotificationBatcher({ enabled: true, summaryIntervalMinutes: 30, digestIntervalMinutes: 120 })`. No operator setting can reach any of the three.
+2. **`enabled` is not honoured on this path.** `NotificationBatcher.enqueue()` never reads `this.config.enabled`. Three `TelegramAdapter` callsites *do* call `isEnabled()` — so the flag looks like a working lever and is not one here.
+3. **No message-volume limit exists.** Searched under seven candidate names across five sources. The one real budget in this area, `topicCreationBudget`, bounds *auto-created topics*; messages into an existing topic were never covered.
+4. **Cross-batch suppression does not survive a restart.** `lastSentContent` is an in-memory `Map`; the symbol appears 6× in the file and `writeFile|readFile|persist|stateDir` appears 0×.
+5. **`DegradationReporter`'s user alert has no enable/disable gate.** Its only brake is a per-feature `ALERT_COOLDOWN_MS = 1 hour`. With ~8 components degraded that is up to 8 messages/hour.
+
+The comment directly above the batcher construction states the intended principle: *"Log everything, notify selectively."* The degradation path is the one that does not.
+
+## Non-goals
+
+- **Not** fixing the memory pressure that generates the events — a real, separate capacity problem. <!-- tracked: CMT-1184 -->
+- **Not** changing what `IMMEDIATE` delivers. Urgent notices keep reaching the operator.
+- **Not** silencing the attention *queue*. `/attention` items via `TelegramAdapter.createAttentionItem` are a different path, unchanged.
+
+## Design
+
+Four changes in shared code. Each is independently reversible by config.
+
+### C1 — `DegradationReporter` user alerts config-gated, default OFF
+
+New config `monitoring.degradationReporter.notifyUser`, boolean, **default `false`**.
+
+When false, `reportEvent()` skips *only* the `telegramSender` branch. The console `[DEGRADATION]` line, `persistToDisk()`, and the feedback submission are unchanged. The record is fully preserved; the operator stops receiving it.
+
+A degradation event is *by construction* a report that the system fell back and kept working — the definition of housekeeping. Of 25 sampled, 0 were actionable. Default-ON would leave the operator opted in to noise by inertia, which is the state this spec ends.
+
+**Reachability preserved.** A genuinely user-affecting degradation reaches the operator through the attention queue, the health-alert path, and `IMMEDIATE` — none of which this flag touches. It governs the cadenced fallback report, not the operator's ability to learn something broke.
+
+### C2 — `enqueue()` honours `enabled`, and the batcher is built from config
+
+When `enabled === false`, `SUMMARY` and `DIGEST` increment `suppressedCount` and are dropped. `IMMEDIATE` is unaffected — a kill-switch on batching must never become one on urgency.
+
+The batcher is constructed from `notificationBatcher.*` (**top-level**, see §Config) instead of literals, each key falling back to today's value when absent, so absence preserves current behaviour byte-for-byte.
+
+### C3 — Suppression state persists across restarts
+
+`lastSentContent` is written to `<stateDir>/notification-suppression.json` on flush and read at construction. Entries carry a timestamp and expire after `suppressionTtlHours` (default 24), so a genuinely changed condition can re-notify and the file cannot grow unbounded.
+
+An unreadable or corrupt file starts with an empty map and records one degradation event; a failed write is non-fatal. For a *suppression* map, losing it costs at most a repeat — never a lost actionable message.
+
+**The two persisted states fail in opposite directions, and an earlier draft conflated them.** The cross-model reviewer found the contradiction: C3 said unreadable state fails open, while invariant I5 said persisted state can only ever reduce sends after a restart. Both cannot hold if the two states share one rule. They do not:
+
+| Persisted state | If unreadable | Why |
+|---|---|---|
+| Suppression map (`notification-suppression.json`) | **Fail open** — start empty, send. | Losing it causes at most a duplicate. Failing closed would suppress notices that were never actually sent. |
+| Rate-limit state (`sendTimes`) | **Fail closed** — hold the batched lane. | Losing it would mint fresh capacity, precisely the ceiling-bypass this spec exists to prevent. Holding housekeeping costs nothing recoverable. |
+
+`IMMEDIATE` is unaffected by either, in both directions.
+
+### C4 — One enforcer per topic, and a rolling-window limit
+
+#### C4.1 The enforcer
+
+> **Only the machine that owns a topic sends batched notifications into it.**
+
+Instar already assigns every conversation exactly one owning machine — the pool's placement record (`GET /pool/placement?topic=N`), with a transfer protocol, a duplicate-session reconciler, and one-voice gating already built on it. C4 rides that.
+
+With exactly one enforcer per topic the limiter is an ordinary single-process rate limit — no shared counter, no machine count, no divisor, and no cross-machine call on the send path.
+
+**The guarantee, stated once and in full: exact under a single agreed owner; worst case 2× during a placement split-brain or a transfer inconsistency.** The re-review flagged that an earlier version put "exact" in the headline and the qualifier a paragraph later, which reads as exact to anyone skimming. The qualifier belongs in the claim.
+
+**Exact UNDER PLACEMENT CONSISTENCY, and not otherwise.** The guarantee inherits whatever the placement record provides: if a split-brain or a stale replicated view yielded two machines each believing they own one topic, both would enforce independently and the operator could receive up to 2× the limit. That is a real dependency rather than a hidden assumption — but it is the *same* invariant the transfer protocol, the duplicate-session reconciler, and one-voice gating already depend on, so this change adds no new consistency requirement. It borrows an existing guarantee instead of inventing a weaker one.
+
+Three earlier drafts instead divided a budget across machines, and all three were rejected — `max(1, floor(budget/N))` broke the bound for fleets larger than the budget; fractional token buckets fixed that but bounded only the average rate, leaving an idle burst of N and a stale-count window reaching N × budget. Each revision made the arithmetic better and the caveats longer, which was the signal that the *approach* was wrong: **approximating a shared quantity from N independent local views cannot produce an exact shared bound.** The multi-machine problem is not solved here — it is not created.
+
+#### C4.2 The limit
+
+A **rolling-window counter**, not a token bucket. The token bucket existed only to divide a budget across machines; with a single enforcer it is unnecessary machinery, and "rolling window" is the guarantee the plain reading of a limit implies.
+
+Exactly one algorithm, stated once and referenced everywhere:
+
+```
+state:  sendTimes: number[]     // epoch ms of sends, per topic, persisted
+window: windowMs = 3_600_000    // 60 minutes
+limit:  maxMessagesPerTopicPerHour, default 4
+
+onFlushAttempt(topicId, now):
+  if limit === 0: SEND            // 0 disables the limiter entirely — see below
+  if sendTimesUnreadable: HOLD    // fail-closed for the batched lane — see C3
+  sendTimes = sendTimes.filter(t => now - t < windowMs)   // evict, then test
+  if sendTimes.length >= limit: HOLD
+  else: SEND; sendTimes.push(now)
+```
+
+**The `limit === 0` guard is explicit and load-bearing.** Frontloaded Decision 3 documents `0` as *disables the limit*, but without the guard `sendTimes.length >= 0` is always true and `0` would hold every batched message forever — the opposite of the documented meaning, and a silent muting of the operator's own escape hatch. The cross-model reviewer caught the contradiction between the prose and the algorithm. The guard is first in the sequence so the disable path cannot be reached by any other branch.
+
+**Draining order is oldest-held-first.** When the window opens, previously held items drain before newly queued ones. Without a stated order a steady stream of new items could consume each freed slot and starve an older held item indefinitely — which would also make `maxHoldHours` fire on a topic that was in fact being served. One queue per topic, FIFO, held items at the head.
+
+- **Guarantee:** no more than `limit` batched messages are sent into a topic in any 60-minute interval. No burst term, no initial-token question, no boundary ambiguity — eviction happens before the test, so the window is genuinely rolling rather than fixed.
+- **Persistence:** `sendTimes` lives beside the suppression state. A restart therefore cannot mint capacity.
+- **What the tests assert:** the rolling count itself. There is no second metric.
+
+#### C4.3 The hold
+
+- Held items stay queued and **release themselves** — the existing `checkFlush()` timer drains them at the first permitted moment. Nothing depends on the operator noticing or asking.
+- **The hold sends the operator nothing.** No over-limit line. Two drafts proposed one and the gate rejected both — first under **The Agent Carries the Loop** (it asked the operator to request the held items), then under **Near-Silent Notifications** (the replacement was itself unactionable housekeeping). The second is the sharper lesson: *a change that bounds housekeeping must not add a housekeeping message announcing the bounding.*
+- The hold is visible on `getStats()` (`heldCount`, `heldSince`, `notOwnerSkipped`, `notOwnerExpired`, `heldExpired`, `rateStateReadable`) and in `logs/notification-ceiling.jsonl`, one metadata-only row per hold, expiry, fold, and failed send. **No Silent Degradation** is satisfied by the audit trail, not by messaging the operator.
+
+#### C4.4 Brakes (P19 — No Unbounded Loops)
+
+| Brake | Value | Behaviour |
+|---|---|---|
+| `next-attempt` | computed | On a hold, the next attempt is scheduled for the instant the oldest in-window send expires, not polled blind each minute. |
+| `max-hold` | `maxHoldHours`, default 6 | A topic blocked for a PERSISTENT reason drops its backlog with an audit row and a per-reason counter (`notOwnerExpired` / `heldExpired`). The queue has a terminal state; **nothing is sent on this path.** |
+| `max-held-items` | `maxHeldItemsPerTopic`, default 200 | On overflow the **oldest** entries fold into one aggregate carrying their count. Memory is O(200) per topic regardless of producer behaviour. This is the one place "never dropped" is qualified, and deliberately: an unbounded buffer inside the thing built to bound a flood would reproduce the defect one layer down. |
+| `dedupe-key` | existing `${topicId}:${dedupKey}` | Repeats collapse while held. |
+
+**Two brakes were REMOVED at implementation time, not repaired.** An earlier version of this table specified a `max-hold` *collapse* (an aged hold sends one digest anyway) plus a *breaker* counting three collapses and dropping the topic to DIGEST cadence. Writing their tests showed both were **unreachable**: the rolling window is 1 hour and `maxHoldHours` is 6, so a rate-limit hold always drains when its window clears, hours before it could mature. The only holds that persist that long are ones whose REASON persists — foreign ownership, unresolved ownership, corrupt rate state — and every one of those must never age into a send, because that is exactly the fail-closed rule. The collapse could therefore only ever have fired in the cases where it was forbidden, and the breaker downstream of it could never trip.
+
+A documented brake that cannot fire is worse than no brake: a reader, including a future audit, records it as protection that exists. This is the same class as the fallback that had never once been exercised and failed on the day it was needed. Both are gone, and the size bound is carried by `max-held-items`, which is reachable and tested.
+
+**A degraded batched lane is visible outside this component.** When rate state is unreadable the lane holds everything, and with C1 defaulting degradation alerts off that could be invisible except in a local JSONL nobody reads — "the system may successfully bound messages while hiding that the bounding path itself is unhealthy" (re-review finding 2). Three surfaces carry it: a `console.warn` into `logs/server.log`, a `state-unreadable` row in `logs/notification-ceiling.jsonl`, and `rateStateReadable` on `getStats()`, which feeds the existing telemetry collector. Deliberately NOT a user-facing message: it is not something the operator can act on, and adding one would break the discipline this change establishes. Honest limit: an operator who reads none of those three learns of it only on asking why a topic went quiet — at which point `getStats()` answers.
+
+**Corrupt rate state latches for the process lifetime.** When `sendTimes` cannot be read the batched lane holds, and a later successful *write* deliberately does NOT clear that state — the map being written is the empty one that failed to load, so clearing it would convert corrupt state into minted capacity inside the same process. Recovery is a restart, which loads the freshly-written valid file. Honest residual: one window of extra capacity, once, after that restart.
+
+**A failed send is not a delivery.** The sink reports success or failure; items are dequeued, marked suppressed, and charged a rate-limit slot ONLY on a confirmed send. An earlier implementation treated every attempt as delivered, so a failed Telegram send dropped the item *and* suppressed it for 24 hours — silent loss, contradicting this spec's own "presence follows delivery" invariant. Caught by the Phase 5 second-pass review.
+
+### The failure direction is per-tier
+
+An earlier draft used "when in doubt, deliver" everywhere, reasoning that an unsent message is unbounded harm and an extra one is a single line. The gate rejected it under **Conservative Outbound: Act, Don't Notify**, correctly: that premise holds for an *actionable* message and is false for housekeeping, where an extra message is the entire harm being eliminated. The general rule had been inherited without checking whether its premise held for this lane.
+
+| Lane | On any uncertainty | Why |
+|---|---|---|
+| `IMMEDIATE` / action-required | **Deliver.** Never gated by ownership, the limit, or any brake in C4. | An unsent urgent message is unbounded harm. This premise justifies fail-open, and only here. |
+| `SUMMARY` / `DIGEST` housekeeping | **Hold, and record.** | Already durably written to logs, disk, and feedback. Non-delivery costs nothing recoverable; delivery costs exactly the noise being removed. |
+
+## State machine and invariants
+
+One batched item, one topic. `IMMEDIATE` never enters this machine.
+
+| From | Event | To | Guard |
+|---|---|---|---|
+| — | `enqueue` | `dropped-disabled` | `enabled === false` |
+| — | `enqueue` | `suppressed` | dedup key present and unexpired in suppression state |
+| — | `enqueue` | `queued` | otherwise |
+| `queued` | flush attempt, not owner | `not-sent-not-owner` | placement names another machine |
+| `queued` | flush attempt, window full | `held` | `sendTimes.length >= limit` |
+| `queued` | flush attempt, window open | `sent` | owner (or no contrary record) and window open |
+| `held` | window opens | `sent` | — |
+| `held` | held > `maxHoldHours` | `collapsed` → `sent` | — |
+| `held` | queue > `maxHeldItemsPerTopic` | `folded` (oldest → aggregate) | — |
+
+Invariants, each with a test:
+
+- **I1** — `sent` implies the rolling in-window count was `< limit` at send time. *(No path increments without the guard.)*
+- **I2** — **within a process lifetime**, every item reaches exactly one of `sent`, `suppressed`, `dropped-disabled`, `not-sent-not-owner`, or `folded`. No item is lost silently; each terminal state has a counter. **The queued and held backlog is deliberately not persisted** — a restart loses it. That is intended: the backlog is housekeeping whose content is already durably in the logs, disk records, and feedback submissions, so persisting a second copy would add a durability mechanism guaranteeing delivery of exactly the material this spec is trying not to deliver. The qualifier is stated rather than implied, because an unqualified I2 would be false at every restart.
+- **I3** — `IMMEDIATE` never enters this machine, so no state here can delay or suppress it.
+- **I4** — every transition other than `queued` and `sent` writes one audit row.
+- **I5** — `sendTimes` can only ever *reduce* what is sent after a restart, never increase it. Scoped to `sendTimes` deliberately: the suppression map fails open by design (see the C3 table), so it is excluded from this invariant rather than silently violating it.
+
+The state machine is here because the cross-model reviewer noted, fairly, that C4 accumulated enough stateful machinery for implementation bugs to be a realistic failure mode. Five states, five invariants, five tests is the answer to that.
+
+### Why this is not a standard durable queue
+
+Most of the machinery already exists in `NotificationBatcher` and is being *fixed*, not built: the queues, dedup key, coalescing, flush timer, and tiering are present today. This spec adds persistence for one map plus a `sendTimes` array, two bounds, an ownership check, and an audit line.
+
+A general durable-queue dependency would replace working code with a new component and a new failure surface, to gain properties (cross-process durability, at-least-once delivery) that a notification digest does not need. Adopting one would be right if *delivery* guarantees were the requirement. Here the requirement is *bounded non-delivery*, which is the opposite.
+
+## Multi-machine posture
+
+Default posture is **unified**. Per surface:
+
+### C4 limit — **unified**, via single-enforcer ownership
+
+Covered in C4.1. Exactly one machine enforces per topic, so the bound is exact rather than approximated. Ownership resolution is a local read of the replicated placement record, not a call on the send path.
+
+**Batched-lane fallback, stated once:**
+
+| Ownership state | Batched lane |
+|---|---|
+| This machine is the owner | Send, subject to C4.2. |
+| Another machine is the owner | Record, do not send (`notOwnerSkipped`). |
+| Unresolvable, **and** a placement record names another owner | **Hold.** |
+| Unresolvable, **and** no pool exists (single-machine install) | Send, subject to C4.2 — with no pool, this machine is trivially the owner. |
+| Unresolvable, **and** a pool exists but placement is unreadable | **Hold**, and record `ownershipUnresolved`. |
+
+#### What happens to a non-owner's batched items
+
+`notOwnerSkipped` is **queue-deliberately**, not drop.
+
+An earlier draft specified an outright drop. The cross-model reviewer asked only that the choice be made explicit, and accepted a documented drop as one valid answer — but the Standards-Conformance Gate then rejected it under **Ownership-Gated Side Effects**, which requires a non-owner to *forward, queue, or claim* deliberately rather than discard. The standard is the constitution and it wins over a reviewer's willingness to accept an alternative. That disagreement is worth recording rather than smoothing over: two reviewers can both be right about different questions, and the binding one is the standard.
+
+The resolution needs no new mechanism — it reuses C4.3's existing hold:
+
+- A non-owner's batched items are **held in that topic's existing queue**, exactly like an over-limit hold.
+- They are subject to the **same `maxHoldHours` expiry and `maxHeldItemsPerTopic` bound**, so a non-owner cannot accumulate an unbounded or arbitrarily stale backlog.
+- **If ownership arrives** within the window — a transfer, a failover — the queue drains normally, oldest first. The items are fresh by construction, because anything older has already expired.
+- **If ownership never arrives**, they collapse and clear on the `maxHoldHours` brake like any other held backlog, counted as `notOwnerExpired`.
+- They are **not forwarded** to the owner: forwarding would add a cross-machine dependency on the send path to deliver housekeeping that C1 already routes away from the operator by default.
+
+This is strictly better than the drop it replaces. The staleness objection that motivated the drop is handled by the expiry that already existed, and the unbounded-retention objection by the bound that already existed. Content remains readable in that machine's logs regardless.
+
+Holding rather than sending on an unresolved read is what makes the bound exact rather than approximate: two machines can never both emit housekeeping into one topic. It costs a delayed housekeeping digest, which is the outcome this spec is engineering toward.
+
+### `IMMEDIATE` — ownership **consults**, never blocks
+
+A blanket ownership exemption was rejected by the gate under **Ownership-Gated Side Effects**: an urgent topic-scoped side effect that never proves ownership is how two machines talk over each other. But gating urgency on an ownership read collides with **The Agent Is Always Reachable**. Both are satisfied by making ownership a *routing* input rather than a permission:
+
+| Ownership state | `IMMEDIATE` |
+|---|---|
+| This machine is the owner | Send. |
+| Another machine owns it and is reachable | Route through the owner — one voice. |
+| Owner **unreachable** | **Claim first.** Attempt an ownership claim through the existing stale-owner-release path, which already carries its own evidence bar, quorum, and audit. On a successful claim, send as the owner — ownership proved, not bypassed. |
+| Claim refused or not completed in time, or ownership **unresolvable** | **Send directly**, stamped with the originating machine, recorded as `ownershipBypasses`. |
+
+Rows 3 and 4 are the correction to an earlier draft that went straight to a direct send. The gate rejected that under **Ownership-Gated Side Effects**, which requires a non-owner to forward, queue, or *claim* — and claim is exactly right here, because Instar already implements evidence-gated claiming for a dead owner. Reaching for it first turns most of what used to be a bypass into a proved ownership.
+
+#### A standards conflict, named rather than worded around
+
+Row 4 remains a genuine bypass, and it is the point where two constitutional standards pull in opposite directions:
+
+- **Ownership-Gated Side Effects** says a machine that has not proven ownership must not perform the side effect.
+- **The Agent Is Always Reachable** says an unresolvable internal condition must never be allowed to produce operator-facing silence.
+
+For an `IMMEDIATE` notice with an unclaimable owner, every option satisfies exactly one of them. Forwarding is impossible (the owner is unreachable). Queueing converts an urgent notice into silence. Sending performs an unproved side effect.
+
+This spec resolves it toward **reachability**, on the reasoning that the failure modes are not symmetric: an unproved-ownership send costs at most a duplicate urgent message, visibly stamped with its origin, while the alternative costs an operator not learning about an urgent condition — the failure class the reachability standard exists to prevent, and the one this whole spec treats as unacceptable.
+
+The residual is stated plainly rather than defined away: **this spec knowingly deviates from Ownership-Gated Side Effects in row 4.** The deviation is narrow (unreachable *and* unclaimable, not merely slow), attributed (the operator sees which machine spoke), and audited (`ownershipBypasses`, with the claim attempt and its refusal reason recorded). Which standard should win in this specific case is a constitution-level question rather than a spec-level one, and it is registered as such rather than settled by an author's preference. <!-- tracked: CMT-1184 -->
+
+### C3 suppression state — **machine-local**
+
+`machine-local-justification: physical-credential-locality` — the key is `${topicId}:${dedupKey}`, and the topic id is a Telegram forum topic namespaced by the bot token that machine holds. The key is meaningful only within the machine holding that binding. Consequence: a repeat notice can cross machines once. C4's single enforcer bounds the operator's total regardless, so the failure mode is a duplicate within budget.
+
+### C1 / C2 — **unified** by configuration
+
+Both are config booleans, unified through the ordinary config surface. No new replication path.
+
+## Decision points touched
+
+| Decision point | Classification | Basis |
+|---|---|---|
+| C1 — deliver a degradation report? | `invariant` | One config boolean. No competing signals, nothing to weigh. |
+| C2 — deliver a batched notification? | `invariant` | Same shape. |
+| C3 — is this a repeat? | `invariant` | Exact-match lookup on a normalized key. |
+| C4.1 — is this machine the enforcer? | `invariant` | A lookup in an existing authoritative placement record. This spec *consumes* an ownership decision; it does not make one. |
+| C4.2 — send or hold? | `invariant` | A count over a rolling window against a fixed bound. Deliberately content-blind: it never reads a message, so it cannot mis-judge one. Only failure mode is delay, bounded by the window, with `IMMEDIATE` exempt. Making this a judgment call would add a failure mode (a model mis-classifying urgency) in exchange for nothing the exemption does not already provide. |
+
+No point chooses among competing signals, so none is a judgment-candidate. Per **Judgment Within Floors**, the floors are the config defaults and the `IMMEDIATE` exemption.
+
+## Signal vs authority
+
+C1, C2, C3 are **signal-suppression**: they change what is *delivered*, never what is *decided*. No detector's verdict changes.
+
+C4 holds delivery authority and is deliberately the dumbest possible rule — a count over a rolling window, no content inspection, no classification, no model call. It cannot mis-judge a message because it never reads one. Per `docs/signal-vs-authority.md`, a brittle rule may hold authority only when its decision space is trivially small and its failure direction is safe. Here the direction is *later* for housekeeping and *never applied at all* to `IMMEDIATE`.
+
+## Verify the state, not its symbol
+
+| Surface | Symbol | State claimed | Corroboration | Unmeasurable |
+|---|---|---|---|---|
+| C4.2 limit | `sendTimes` in the rolling window | "the operator received N recently" | counted at the single `sendDirect` chokepoint the messages actually pass through — the count is the act, not a proxy | unreadable ⇒ **hold** the batched lane (recorded); `IMMEDIATE` unaffected |
+| C4.1 ownership | placement record | "this machine is the one enforcer" | placement is the same authoritative record the transfer protocol and duplicate reconciler already act on — not a second proxy invented here | unreadable ⇒ hold if a pool exists, send if none; `ownershipUnresolved` recorded, never silently read as "I am the owner" |
+| C3 suppression | key present in map | "already delivered" | the map is written only *after* a successful flush, so presence follows delivery rather than intent | unreadable ⇒ empty map ⇒ send (at most a repeat) |
+
+Each unmeasurable case resolves per the per-tier rule, and none collapses to a flattering fabricated value: `ownershipUnresolved` stays explicitly unknown rather than defaulting to ownership.
+
+## Self-heal before notify
+
+This spec introduces no watcher and raises **no operator notice at all** — it only reduces an existing notice surface. C4 emits nothing to the operator; holds go to logs, stats, and the audit trail. Its own internal failures resolve per the per-tier rule and record a degradation event; none escalates, because none is something the operator can act on, which is the discipline this spec establishes.
+
+## Config
+
+The JSON below is the **literal shape on disk**. An earlier draft showed an illustrative path with the real one in prose underneath; the cross-model reviewer flagged that as a likely implementation/test mismatch. Illustrative config in a spec is a defect, not a convenience.
+
+```jsonc
+{
+  "monitoring": { "degradationReporter": { "notifyUser": false } },
+  "notificationBatcher": {
+    "enabled": true,
+    "summaryIntervalMinutes": 30,
+    "digestIntervalMinutes": 120,
+    "maxMessagesPerTopicPerHour": 4,
+    "suppressionTtlHours": 24,
+    "maxHoldHours": 6,
+    "maxHeldItemsPerTopic": 200
+  }
+}
+```
+
+`notificationBatcher` is **top-level**, deliberately not nested under `messaging` — an array of adapters, where a nested key is unreachable (the trap already documented for `outboundAdvisory`). Spec, implementation, and tests use this one path.
+
+## Frontloaded Decisions
+
+Rewritten in full at the round-10 rewrite. The cross-model reviewer noted that builders treat this section as authoritative, and three of its items still described the abandoned divisor design.
+
+1. **`notifyUser` default OFF.** Recommended with the measurement behind it (0 of 25 sampled were actionable) and **confirmed by the operator** — Justin, topic 7848, 2026-08-04, reply `"Silent"` to an explicit two-option choice.
+2. **`IMMEDIATE` is exempt from C4 entirely** and gated by ownership only as routing, never as permission.
+3. **Limit default 4/topic/hour**, rolling window. Against a measured 2.7/hour it binds without being punitive. `0` disables.
+4. **One enforcer per topic via existing placement ownership.** No machine-count division, no divisor, no shared counter.
+5. **Rolling-window counter, not a token bucket.** One algorithm, specified in C4.2, asserted directly by the tests.
+6. **Held items are retained and self-releasing, bounded at `maxHeldItemsPerTopic`,** past which the oldest fold into a counted aggregate.
+7. **Failure direction is per-tier**: deliver for `IMMEDIATE`, hold for batched housekeeping.
+8. **Suppression TTL 24h.**
+9. **Config key path: top-level `notificationBatcher`.**
+
+Cheap-to-change-after tags claimed: **0**. Nothing hides behind a dark-ship label — this changes what the operator receives on the next release, which by the closed taxonomy is a published user-visible interface and therefore never cheap.
+
+## Open questions
+
+*(none)*
+
+## Acceptance criteria
+
+Every criterion pairs its assertion with a **control that must fail**. A check that cannot fail is not a check.
+
+1. With defaults, a `DegradationReporter` event produces a console line, a disk record, and a feedback submission, and **zero** sends. *Control:* with `notifyUser: true` the same event produces exactly one send.
+2. With `enabled: false`, `SUMMARY`/`DIGEST` increment `suppressedCount` and send nothing, while `IMMEDIATE` still sends. *Control:* with `enabled: true` the `SUMMARY` sends on flush.
+3. A batcher flushed, destroyed, and reconstructed against the same `stateDir` suppresses a repeat of an already-sent key. *Control:* the same sequence against a *different* `stateDir` sends it — proving the assertion is about persistence, not the key.
+4. With `maxMessagesPerTopicPerHour: 2`, the third flush in a window is held, items are retained, **zero** additional messages are sent, and `heldCount` is non-zero. *Control:* an `IMMEDIATE` in the same saturated window still sends — proving the assertion is about the limit, not a dead sender.
+5. **The window is rolling, not fixed.** With `limit: 4`, four sends at t=0..t=45min, then a fifth at t=50min is **held**; at t=61min it **sends** because the t=0 entry has expired. *Control:* the same sequence with the eviction step removed holds at t=61min — proving the test measures eviction rather than the passage of time.
+6. **Held items release with no user action.** With a saturated window, advancing the clock and running the existing timer drains the backlog. *Control:* without advancing the clock the items stay held.
+7. **A restart cannot mint capacity.** A batcher at its limit, reconstructed against the same `stateDir`, still holds. *Control:* the same batcher after the window expires sends — proving persistence, not a stuck sender.
+8. **Only the owner sends.** Two batchers on one topic where placement names machine A: A sends, B records `notOwnerSkipped` and sends nothing. *Control:* with placement naming B, the roles invert — proving the test reads placement rather than a fixed identity.
+9. **Unresolvable ownership holds when a pool exists and sends when none does.** *Control:* the two configurations must produce *different* outcomes — a test passing under both is measuring nothing.
+10. **`IMMEDIATE` is never blocked by ownership.** With placement naming another, unreachable machine, an `IMMEDIATE` still sends and records `ownershipBypasses`. *Control:* with that owner reachable it routes through the owner instead — proving reachability is read.
+11. **The hold terminates without sending.** A topic held for a persistent reason (foreign ownership) past `maxHoldHours` drops its backlog, records `notOwnerExpired`, and sends **nothing**. *Control:* a rate-limit hold on an OWNED topic drains normally when its 1h window clears — distinguishing "expired because the reason persisted" from "drained because the window opened", which is the confusion that hid the unreachable-collapse defect.
+11b. **A failed send changes no state.** With a throwing sink, the item stays queued, is not suppressed, and consumes no rate slot; when the sink recovers it delivers. *Control:* a succeeding send dequeues, suppresses, and consumes the slot.
+11c. **Corrupt rate state never ages into a send.** A batcher loaded from a corrupt state file holds, and still holds after `maxHoldHours`, recording `heldExpired`. *Control:* a valid state file on the same path sends.
+12. **The held queue is bounded.** 500 structurally distinct notices leave at most `maxHeldItemsPerTopic` entries plus one counted aggregate. *Control:* 500 *identical* notices leave 1 entry with count 500 — distinguishing the storage bound from the pre-existing dedup path.
+13. **Every invariant I1–I5 has a test**, each with a control that fails when the guard is removed.
+14. Absent config reproduces today's observable behaviour on every path above.
+15. **Live proof on this agent.** After deploy, 24h of attention-topic traffic contains zero heuristic-fallback / "everything else is working fine" lines, while a deliberately raised attention item still arrives.
+
+## Maturation plan
+
+This change alters a fleet-wide default for what every operator receives, so it does **not** ship dark — a dark ship would leave the flood running everywhere while the fix sat inert, which is the state the operator asked to end. Instead it ships live with a config rollback on every lever, and the staged rollout is used to catch defects rather than to delay the benefit.
+
+- **test-agent-live:** deploy to a throwaway agent via `/test-as-self`, drive the burst-invariant path, and confirm the audit rows and counters appear. Verifies the feature is alive before any real operator sees it.
+- **dev-agent-live:** live on this agent (echo) first. The measured baseline here is 64 messages/24h with 25 housekeeping, so the signal is unambiguous: 24h post-deploy, the attention topic must contain zero heuristic-fallback / "everything else is working fine" lines while a deliberately raised attention item still arrives (acceptance criterion 15). This agent is also the multi-machine case, so it exercises the ownership path rather than only the single-machine shortcut.
+- **fleet:** after the dev-agent 24h window passes clean, in the next ordinary release. No separate flag flip: the defaults ARE the change, and holding them back per-agent would mean the fleet keeps the defect while the fix exists.
+- **graduation criterion:** on this agent, one clean 24h window meeting acceptance criterion 15, with `getStats()` showing a non-zero `suppressedCount` (proving the path ran, not that nothing happened) and `ownershipBypasses` consistent with the machine count. A zero-everywhere reading is treated as a **dead check, not a pass** — it would equally be produced by a batcher that never executed.
+- **dark-window:** none for the defaults, deliberately, per the reasoning above. The `IMMEDIATE` ownership-claim path (§Multi-machine posture rows 3–4) is the one genuinely new behaviour with a failure mode the operator would feel, and it carries the dark window instead: it ships with the claim step disabled (direct send + audit, today's behaviour) until the dev-agent window shows the audit rows are clean, then the claim is enabled. That inverts the usual shape on purpose — the noise reduction is what the operator asked for and is fully reversible by config, whereas the claim path touches ownership and is not.
+
+## Rollback
+
+Reversible by config alone — no data migration, no agent-state repair:
+
+- Restore today's user-facing behaviour: `monitoring.degradationReporter.notifyUser: true`.
+- Remove the limit: `maxMessagesPerTopicPerHour: 0`.
+- Remove persistence: delete `<stateDir>/notification-suppression.json`; it rebuilds empty.
+- Full revert: the PR is a single squash commit.
+
+## Implementation
+
+- `src/monitoring/DegradationReporter.ts` — `notifyUser` gate in `reportEvent()`, plumbed via `connectDownstream()`.
+- `src/messaging/NotificationBatcher.ts` — `enabled` honoured in `enqueue()`; rolling-window limiter; ownership check; persistence; brakes; audit rows; new `getStats()` counters.
+- `src/commands/server.ts` — construct the batcher from config; pass `notifyUser`, `stateDir`, and the placement reader.
+- `src/core/ConfigDefaults.ts` — defaults for the new keys.
+- `src/core/PostUpdateMigrator.ts` — `migrateConfig()` adds missing keys only (Migration Parity Standard).
+- `src/scaffold/templates.ts` — `generateClaudeMd()` gains a short section so agents know the levers exist (Agent Awareness Standard).
+- Tests — unit, integration, and e2e per the Testing Integrity Standard, including a burst-invariant test asserting the limit holds under a 100-event burst.
+
+## Review history
+
+| Round | Reviewer | Findings | Outcome |
+|---|---|---|---|
+| 1 | Conformance gate | 1 | Undefended machine-local posture → redesigned |
+| 2 | Conformance gate | 2 | Held-notice parked work on the operator; divisor unsafe under partition |
+| 3 | Conformance gate | 1 | Replacement held-notice was itself housekeeping → removed entirely |
+| 4 | Conformance gate | 2 | No brakes on the retry; unbounded held queue |
+| 5 | Conformance gate | 1 | "Exactly bounded" overclaimed for independent buckets |
+| 6 | Conformance gate | 0 | — |
+| 1 | Cross-model (codex-cli:gpt-5.5) | 6 | Ceiling-vs-bucket mismatch; overclaim; internal contradiction; ambiguous config path; underexplored alternative; missing test controls |
+| 7–9 | Conformance gate | 1 each | Divisor still approximate → **redesigned to single-enforcer ownership**; failure direction backwards for housekeeping; `IMMEDIATE` ownership exemption |
+| 10 | Conformance gate | 0 | — |
+| 2 | Cross-model (codex-cli:gpt-5.5) | 5 | **Two incompatible architectures left in one document**; rate-limit semantics still mixed; stale Frontloaded Decisions; ambiguous ownership fallback; state machine needed |
+| — | Full rewrite | — | This document |
+
+**The lesson about the tooling.** Round 10 of the per-standard gate returned clean on a document that described two mutually exclusive architectures. That is not a gate failure — it evaluates one standard at a time and never claims to read for coherence — but it is a real limit worth naming: *a clean per-standard pass is not evidence of a coherent document.* Iterative section-by-section patching is exactly the process that produces this failure, and only a whole-document reader catches it. Both reviewer kinds were necessary; neither would have sufficed.

--- a/docs/specs/reports/bounded-attention-notification-surface-convergence.md
+++ b/docs/specs/reports/bounded-attention-notification-surface-convergence.md
@@ -1,0 +1,84 @@
+# Convergence Report — Bounded Attention-Notification Surface
+
+## ⚠ Cross-model review: codex-cli:gpt-5.5 — RAN, with a disclosure below
+
+Three real external passes ran through this agent's own codex CLI (`gpt-5.5`), on rounds 1, 2, and 3 of the cross-model lane. All three returned findings; the verdict moved SERIOUS → SERIOUS → MINOR, with the third pass stating "the design is coherent and avoids the earlier distributed-rate-limit trap."
+
+**Disclosure the reader must weigh before treating this as a full convergence.** The six *internal* Claude reviewers (security, scalability, adversarial, integration, decision-completeness, lessons-aware) were **not** run as independent subagents. This session operates under a standing instruction not to spawn agents unless the operator requests it, and the operator did not. What ran instead was:
+
+- the **code-backed Standards-Conformance Gate** (`POST /spec/conformance-check`) — 13 rounds, 82 standards evaluated per round; and
+- the **cross-model external reviewer** — 3 rounds.
+
+The conformance gate is the structural complement to the lessons-aware reviewer (it reads the living constitution directly rather than a prompt's summary of it), and it carried most of the load here — it produced a real finding in 9 of its 13 rounds. But it is not a substitute for the adversarial and decision-completeness perspectives, and this report does not claim it is. **Treat this as convergence against the constitution plus one external family, not against the full six-reviewer panel.** The Phase 5 second-pass review remains outstanding and is recorded as such in the side-effects artifact.
+
+## ELI10 Overview
+
+Your agent sends you two kinds of message. One kind needs you — a decision, an approval, something broken you can fix. The other kind is housekeeping: "one of my background checks fell back to a simpler method and carried on." Measured over 24 hours, 25 of 64 messages into the attention conversation were the second kind, and none of them named anything you could do.
+
+The awkward part is that the housekeeping *scales with how badly things are going*. The worse the machine gets, the more your agent tells you about it, in exactly the messages worth least. And nothing capped it: there was a hard limit on how many new conversations the agent could start on its own, added after an earlier flood, but nobody ever added the equivalent limit for messages into a conversation that already existed.
+
+This change does four things. Housekeeping stops reaching you by default — still recorded, still readable on request. A limit of four messages an hour per conversation, with the rest waiting their turn and sending themselves when there's room. The agent's memory of "I already told them this" now survives a restart instead of resetting. And an off-switch that existed but was never actually read on this path is made real, so next time it's a setting rather than a release.
+
+Urgent messages are deliberately untouched, and so is the attention queue. What goes quiet is the routine "fell back, still working" report — not your ability to find out something broke.
+
+## Original vs Converged
+
+**The multi-machine design was replaced entirely, after three failed attempts.** The original divided one message budget across machines: each machine works out its fair share and enforces that. Review killed three successive versions of this. Dividing by machine count and rounding down broke the limit for fleets bigger than the budget. Switching to fractional "token buckets" fixed that but only bounded the *average* rate, leaving a burst. Dividing by *registered* rather than *online* machines fixed the partition case but left a window where a machine with an out-of-date count sends too much.
+
+Each rewrite was better arithmetic with a longer list of things it still couldn't promise. That growth was the real signal: **you cannot get an exact shared limit out of machines guessing independently.** The converged design removes the sharing. Every conversation already has exactly one machine that owns it — that's how the agent avoids two machines answering at once. Only the owning machine sends routine notices into a conversation. One counter, one limit, no coordination. The distributed problem isn't solved; it's not created.
+
+**The failure rule was inverted for housekeeping.** The original said "when in doubt, send," inherited from the general messaging principle that an unsent message is unbounded harm. Correct for urgent messages, and exactly backwards here — an extra unactionable message is the entire harm being removed. Routine notices now hold when in doubt, and are still written down.
+
+**Two proposed "N notices held" status lines were removed.** The first asked the operator to request the held messages back, which parks the agent's own work on the user. The replacement was itself unactionable housekeeping — a change built to stop housekeeping was about to add a housekeeping message announcing that it had stopped.
+
+**Guarantees were weakened to true ones.** The spec originally claimed the operator's total was "exactly bounded." That was false for a simultaneous burst and false during a stale-count window; the document said so two paragraphs later. The converged version states precisely what holds and what does not.
+
+**A standards conflict was named rather than resolved by wording.** For an urgent message on a machine that can neither prove it owns the conversation nor reach the machine that does, *Ownership-Gated Side Effects* and *The Agent Is Always Reachable* genuinely conflict. The spec resolves toward reachability with reasoning, marks it as a deviation, and registers the question as constitution-level rather than settling it by author preference. The conformance gate still flags it — correctly.
+
+**The document itself was rewritten from scratch at round 10.** See the verdict section below.
+
+## Iteration Summary
+
+| Round | Reviewer | Model | Findings | Spec changes |
+|---|---|---|---|---|
+| 1 | Standards-Conformance Gate | code (82 standards) | 1 | Undefended machine-local posture → redesigned toward unified |
+| 2 | Standards-Conformance Gate | code | 2 | Held-notice parked work on operator; divisor unsafe under partition |
+| 3 | Standards-Conformance Gate | code | 1 | Replacement held-notice was itself housekeeping → removed |
+| 4 | Standards-Conformance Gate | code | 2 | No brakes on retry; unbounded held queue |
+| 5 | Standards-Conformance Gate | code | 1 | "Exactly bounded" overclaimed |
+| 6 | Standards-Conformance Gate | code | 0 | — |
+| X1 | Cross-model | codex-cli:gpt-5.5 | 6 (SERIOUS) | Ceiling-vs-bucket mismatch; overclaim; internal contradiction; ambiguous config path; underexplored alternative; missing test controls |
+| 7 | Standards-Conformance Gate | code | 1 | Divisor still approximate → **redesigned to single-enforcer ownership** |
+| 8 | Standards-Conformance Gate | code | 1 | Failure direction backwards for housekeeping |
+| 9 | Standards-Conformance Gate | code | 1 | `IMMEDIATE` ownership exemption too broad |
+| 10 | Standards-Conformance Gate | code | 0 | — |
+| X2 | Cross-model | codex-cli:gpt-5.5 | 5 (SERIOUS) | **Two incompatible architectures in one document**; mixed rate-limit semantics; stale Frontloaded Decisions; ambiguous ownership fallback; state machine needed |
+| — | **Full rewrite** | — | — | Document rewritten from the settled design |
+| 11 | Standards-Conformance Gate | code | 0 | — |
+| X3 | Cross-model | codex-cli:gpt-5.5 | 5 (**MINOR**) | Non-owner item semantics; `limit: 0` contradiction; conflated failure posture; backlog durability; drain ordering |
+| 12 | Standards-Conformance Gate | code | 1 | Non-owner drop violated Ownership-Gated Side Effects → changed to queue-deliberately |
+| 13 | Standards-Conformance Gate | code | 1 | `IMMEDIATE` bypass — **acknowledged deviation, not resolved** |
+
+Internal reviewers run per round: **0** (see the disclosure banner). Standards-Conformance Gate: **ran every round**, 82 standards, never unavailable.
+
+## Full Findings Catalog
+
+Every finding and its resolution is recorded in the spec's own `## Review history` table and, for the design-changing ones, in prose at the point of change — deliberately, so a future reader encounters *why* a design is shaped this way at the place they are reading, not in a separate document they may never open. Rather than duplicate that here and risk the two drifting apart (the exact failure mode X2 caught), this section points at it: `docs/specs/bounded-attention-notification-surface.md` → `## Review history`, plus the inline "an earlier draft…" passages in C4.2, C4.3, C3, §The failure direction is per-tier, §Multi-machine posture, and §Frontloaded Decisions.
+
+The five findings that changed the *design* rather than the *document*:
+
+1. **Undefended machine-local posture** (gate, R1) → the whole multi-machine approach was reconsidered, ultimately three times.
+2. **Divisor cannot bound a shared quantity** (gate R7, after X1 sharpened it) → single-enforcer ownership.
+3. **Failure direction backwards for housekeeping** (gate R8) → per-tier rule: deliver for urgent, hold for batched.
+4. **Two incompatible architectures in one document** (X2) → full rewrite.
+5. **Non-owner drop violates Ownership-Gated Side Effects** (gate R12) → queue-deliberately, reusing the existing hold and expiry.
+
+## Convergence verdict
+
+**Converged at round 13 of the conformance lane and round 3 of the cross-model lane**, with one finding deliberately outstanding.
+
+The conformance gate's final finding — the `IMMEDIATE` ownership bypass — is **not** resolved and is not intended to be resolved at spec level. It is a genuine conflict between two constitutional standards where every available option violates one of them. The spec names it, resolves toward reachability with reasoning, bounds it (unreachable *and* unclaimable, not merely slow), attributes it (the message is stamped with its origin machine), and audits it. Continuing to reword until the gate went quiet would be gaming a signal-only advisory, which the skill explicitly names as an anti-pattern.
+
+**The most important finding is about the review tooling, not this spec.** At round 10 the conformance gate returned **clean** on a document that described two mutually exclusive architectures. That is not a gate defect — it evaluates one standard at a time and never claims to read for coherence — but it is a real limit: *a clean per-standard pass is not evidence of a coherent document*, and iterative section-by-section patching is precisely the process that manufactures the incoherence it cannot see. Only the whole-document reader caught it. Both reviewer kinds were necessary; neither would have sufficed. This is recorded in the spec itself and in the agent's durable memory.
+
+**Ready for build, with two disclosures already made to the operator in-channel before approval:** the limit is per-topic (a producer spreading across topics is not bounded by it), and the Phase 5 second-pass review is outstanding. Operator approval was given on the plain-English overview at 2026-08-04 16:52 PDT.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -218,7 +218,7 @@ import { cleanupGlobalInstalls } from '../core/GlobalInstallCleanup.js';
 import { ForegroundRestartWatcher } from '../core/ForegroundRestartWatcher.js';
 import { NotificationBatcher } from '../messaging/NotificationBatcher.js';
 import { formatLocalTimestamp } from '../utils/localTime.js';
-import type { NotificationTier } from '../messaging/NotificationBatcher.js';
+import type { NotificationTier, BatcherQuietHours } from '../messaging/NotificationBatcher.js';
 import { resolveTelegramStartupTopology, wireTelegramSendSide } from '../messaging/telegramSendSideComposition.js';
 import { MessageStore } from '../messaging/MessageStore.js';
 import { MessageFormatter } from '../messaging/MessageFormatter.js';
@@ -3726,11 +3726,29 @@ export async function startServer(options: StartOptions): Promise<void> {
   // SUMMARY = batched every 30 min (degradations, coherence, orphan reports)
   // DIGEST = batched every 2 hrs (updates, wake events, routine lifecycle)
   // Principle: Log everything, notify selectively.
+  // Bounded-attention-notification-surface (C2): built FROM CONFIG rather than
+  // literals. Every key falls back to the previous hardcoded value when absent,
+  // so an install with no `notificationBatcher` block behaves byte-for-byte as
+  // before. NOTE the key is TOP-LEVEL: `messaging` is an array of adapters, so a
+  // key nested there is unreachable (same trap as `outboundAdvisory`).
+  const nbCfg = (config as unknown as { notificationBatcher?: Record<string, unknown> }).notificationBatcher ?? {};
   const notificationBatcher = new NotificationBatcher({
-    enabled: true,
-    summaryIntervalMinutes: 30,
-    digestIntervalMinutes: 120,
+    enabled: (nbCfg.enabled as boolean | undefined) ?? true,
+    summaryIntervalMinutes: (nbCfg.summaryIntervalMinutes as number | undefined) ?? 30,
+    digestIntervalMinutes: (nbCfg.digestIntervalMinutes as number | undefined) ?? 120,
+    maxMessagesPerTopicPerHour: (nbCfg.maxMessagesPerTopicPerHour as number | undefined) ?? 4,
+    suppressionTtlHours: (nbCfg.suppressionTtlHours as number | undefined) ?? 24,
+    maxHoldHours: (nbCfg.maxHoldHours as number | undefined) ?? 6,
+    maxHeldItemsPerTopic: (nbCfg.maxHeldItemsPerTopic as number | undefined) ?? 200,
+    quietHours: nbCfg.quietHours as BatcherQuietHours | undefined,
   });
+
+  // C3 persistence is wired UNCONDITIONALLY here, not inside the pool block:
+  // a single-machine install never reaches that block, and it is the majority
+  // case. With no resolver the ownership verdict is `unresolvable-no-pool`,
+  // i.e. this machine is trivially the owner — a strict single-process limiter.
+  // The pool block later calls configureBounds AGAIN to add the resolver.
+  notificationBatcher.configureBounds({ stateDir: config.stateDir });
 
   // State reference — set once StateManager is created, used by notify()
   let _notifyState: { get<T>(key: string): T | null | undefined } | null = null;
@@ -20271,6 +20289,24 @@ export async function startServer(options: StartOptions): Promise<void> {
         });
         _writeAdmissionOwnershipStore = ownershipStore;
         const ownReg = sessionOwnershipRegistry;
+
+        // C4.1 (bounded-attention-notification-surface): ONLY the machine that
+        // owns a topic sends batched notifications into it. With exactly one
+        // enforcer per topic the rolling-window limit is an ordinary
+        // single-process rate limit — exact, with no shared counter, no machine
+        // count, and no cross-machine call on the send path. Reaching this block
+        // at all means a pool IS wired, so an unreadable placement resolves to
+        // `unresolvable-pool` (HOLD) rather than to "I am the owner".
+        notificationBatcher.configureBounds({
+          stateDir: config.stateDir,
+          ownershipResolver: (topicId: number) => {
+            const self = _meshSelfId;
+            if (!self) return 'unresolvable-pool';
+            const owner = ownReg.ownerOf(String(topicId));
+            if (!owner) return 'unresolvable-pool';
+            return owner === self ? 'owner' : 'other';
+          },
+        });
         // WS1.1: expose a read-only ownership lookup to the drain's
         // spawn-boundary re-check (module-scope; the drain closure is defined
         // before this block runs).
@@ -25077,6 +25113,12 @@ export async function startServer(options: StartOptions): Promise<void> {
         // jargon / self-heal / CTA discipline and the user sees raw
         // ops-pager output. See upgrades/side-effects/agent-health-alert-authority-routing.md.
         toneGate: messagingToneGate ?? null,
+        // C1 (bounded-attention-notification-surface): user-facing degradation
+        // alerts default OFF. The console line, disk record, and feedback
+        // submission are unaffected — only delivery to the operator stops.
+        notifyUser:
+          (config.monitoring as unknown as { degradationReporter?: { notifyUser?: boolean } } | undefined)
+            ?.degradationReporter?.notifyUser === true,
       });
       // Never-silent degradation tracking (Resilient Degradation Ladder §4): dev-gated
       // (live-on-dev / dark-on-fleet via resolveDevAgentGate). When enabled, a timer drives the

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -509,6 +509,51 @@ export interface MigratorConfig {
  *   - key === true         → leave it (false). An operator's explicit fleet-flip wins.
  * A stripped seamlessness block left empty is removed so the file stays clean.
  */
+/**
+ * Bounded Attention-Notification Surface (docs/specs/bounded-attention-notification-surface.md).
+ * Adds the operator-facing levers so they are DISCOVERABLE and editable, rather
+ * than inline code defaults an operator cannot see. The runtime already falls
+ * back to these exact values when the block is absent, so this migration changes
+ * NO behaviour — it makes the off-switch real, which is half the point of the
+ * change ("a lever that looks like it works and does not" was the original defect).
+ *
+ * `notificationBatcher` is TOP-LEVEL on purpose: `messaging` is an array of
+ * adapters, so a key nested there is unreachable (same trap as outboundAdvisory).
+ *
+ * Existence-checked per field and idempotent: an operator value is never
+ * overwritten, and re-running adds nothing.
+ */
+export function migrateConfigBoundedNotificationSurface(config: Record<string, unknown>): boolean {
+  let changed = false;
+
+  const monitoring = (config.monitoring ??= {}) as Record<string, unknown>;
+  const degradation = (monitoring.degradationReporter ??= {}) as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(degradation, 'notifyUser')) {
+    // Default FALSE — operator-approved 2026-08-04 (topic 7848, "Silent").
+    degradation.notifyUser = false;
+    changed = true;
+  }
+
+  const nb = (config.notificationBatcher ??= {}) as Record<string, unknown>;
+  const defaults: Record<string, unknown> = {
+    enabled: true,
+    summaryIntervalMinutes: 30,
+    digestIntervalMinutes: 120,
+    maxMessagesPerTopicPerHour: 4,
+    suppressionTtlHours: 24,
+    maxHoldHours: 6,
+    maxHeldItemsPerTopic: 200,
+  };
+  for (const [k, v] of Object.entries(defaults)) {
+    if (!Object.prototype.hasOwnProperty.call(nb, k)) {
+      nb[k] = v;
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
 export function migrateConfigWs44PoolLinks(config: Record<string, unknown>): boolean {
   const mm = config.multiMachine as Record<string, unknown> | undefined;
   if (!mm || typeof mm !== 'object') return false;
@@ -10687,6 +10732,16 @@ Two layers keep my machine-to-machine \"ropes\" (Tailscale / LAN / Cloudflare) h
     // WS4.4(f) global pool-cache unification (CMT-1416) — same omitted-gate
     // invariant as ws44PoolLinks: strip a default-shaped literal `false` so the
     // developmentAgent gate resolves it (live on dev, dark on the fleet).
+    // Bounded Attention-Notification Surface: surface the notification levers in
+    // config so the operator can actually reach them. Behaviour-neutral (the
+    // runtime already defaults to these values when absent).
+    if (migrateConfigBoundedNotificationSurface(config)) {
+      patched = true;
+      result.upgraded.push('config.json: added notificationBatcher limits + monitoring.degradationReporter.notifyUser (housekeeping silent by default)');
+    } else {
+      result.skipped.push('config.json: bounded notification surface already present');
+    }
+
     if (migrateConfigWs44PoolCache(config)) {
       patched = true;
       result.upgraded.push('config.json: stripped default-shaped multiMachine.seamlessness.ws44PoolCache=false so the developmentAgent gate resolves it live');

--- a/src/messaging/NotificationBatcher.ts
+++ b/src/messaging/NotificationBatcher.ts
@@ -7,11 +7,28 @@
  * - DIGEST: Batched every 2 hours (routine system notices)
  *
  * Born from: Matthew Berman OpenClaw analysis (2026-02-25)
+ *
+ * Bounded-surface additions (docs/specs/bounded-attention-notification-surface.md):
+ * the batched lane honours `enabled`, persists its suppression + rate-limit state,
+ * and is bounded by a rolling-window limit enforced ONLY by the machine that owns
+ * the topic. IMMEDIATE never enters that machinery.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import { requireDeliverySink, reportDeliverySinkFailure } from './DeliverySinkFailure.js';
 
 export type NotificationTier = 'IMMEDIATE' | 'SUMMARY' | 'DIGEST';
+
+/**
+ * Verdict from the pool's placement record for one topic.
+ * `unresolvable-no-pool` is a single-machine install: this machine is trivially
+ * the owner. `unresolvable-pool` means a pool exists but placement could not be
+ * read — the batched lane HOLDS there, so two machines can never both emit.
+ */
+export type OwnershipVerdict = 'owner' | 'other' | 'unresolvable-no-pool' | 'unresolvable-pool';
+
+export type OwnershipResolver = (topicId: number) => OwnershipVerdict;
 
 export interface BatchedNotification {
   tier: NotificationTier;
@@ -21,15 +38,31 @@ export interface BatchedNotification {
   topicId: number;
 }
 
+export interface BatcherQuietHours {
+  enabled: boolean;
+  start: string;   // "HH:MM"
+  end: string;     // "HH:MM"
+}
+
 export interface BatcherConfig {
   enabled: boolean;
   summaryIntervalMinutes: number;
   digestIntervalMinutes: number;
-  quietHours?: {
-    enabled: boolean;
-    start: string;   // "HH:MM"
-    end: string;     // "HH:MM"
-  };
+  /** Rolling-window limit per topic. 0 disables the limiter entirely. */
+  maxMessagesPerTopicPerHour: number;
+  /** TTL on cross-batch suppression entries. */
+  suppressionTtlHours: number;
+  /**
+   * A topic blocked for a PERSISTENT reason (foreign ownership, unresolved
+   * ownership, corrupt rate state) drops its backlog after this long, with an
+   * audit row and a per-reason counter. Nothing is sent on that path — an
+   * earlier design "collapsed" an aged hold into one digest, which was both
+   * unreachable and forbidden for exactly those reasons.
+   */
+  maxHoldHours: number;
+  /** Storage ceiling on the held queue; overflow folds oldest into a counted aggregate. */
+  maxHeldItemsPerTopic: number;
+  quietHours?: BatcherQuietHours;
 }
 
 interface QueuedNotification {
@@ -39,6 +72,10 @@ interface QueuedNotification {
   topicId: number;
   dedupKey: string;
   count: number;
+  /** Epoch ms this item was first held, or null while it has never been held. */
+  heldSince: number | null;
+  /** Count of older items folded into this one by the storage ceiling. */
+  foldedCount?: number;
 }
 
 export interface BatcherStats {
@@ -48,6 +85,20 @@ export interface BatcherStats {
   totalSuppressed: number;
   lastSummaryFlush: Date | null;
   lastDigestFlush: Date | null;
+  /** Items currently held by the rolling-window limit or by ownership. */
+  heldCount: number;
+  /** Epoch ms of the oldest current hold, or null when nothing is held. */
+  heldSince: number | null;
+  /** Batched items not sent because another machine owns the topic. */
+  notOwnerSkipped: number;
+  /** Non-owner items that expired on maxHoldHours without ownership arriving. */
+  notOwnerExpired: number;
+  /** Items expired for a non-ownership reason (breaker active, or corrupt rate state). */
+  heldExpired: number;
+  /** Items folded into a counted aggregate by the storage ceiling. */
+  foldedItems: number;
+  /** Whether the persisted rate-limit state could be read. */
+  rateStateReadable: boolean;
 }
 
 export type SendFunction = (topicId: number, text: string) => Promise<{ messageId: number }>;
@@ -64,7 +115,20 @@ const DEFAULT_CONFIG: BatcherConfig = {
   enabled: true,
   summaryIntervalMinutes: 30,
   digestIntervalMinutes: 120,
+  maxMessagesPerTopicPerHour: 4,
+  suppressionTtlHours: 24,
+  maxHoldHours: 6,
+  maxHeldItemsPerTopic: 200,
 };
+
+const WINDOW_MS = 3_600_000;
+
+interface PersistedState {
+  /** dedupKey → epoch ms it was sent. Replaces the old value-is-the-key scheme. */
+  suppression: Record<string, number>;
+  /** topicId → epoch ms of sends inside the rolling window. */
+  sendTimes: Record<string, number[]>;
+}
 
 export class NotificationBatcher {
   private summaryQueue: QueuedNotification[] = [];
@@ -76,13 +140,30 @@ export class NotificationBatcher {
   private lastDigestFlush: Date | null = null;
   private totalFlushed = 0;
   private suppressedCount = 0;
+
+  // ── Bounded-surface state ────────────────────────────────────
+  private stateDir: string | null = null;
+  private ownershipResolver: OwnershipResolver | null = null;
+  private auditPath: string | null = null;
+
+  /** dedupKey → epoch ms sent. Persisted; TTL-expired on load and on write. */
+  private lastSentContent: Map<string, number> = new Map();
+  /** topicId → epoch ms of sends within the rolling window. Persisted. */
+  private sendTimes: Map<number, number[]> = new Map();
+
   /**
-   * Cross-batch suppression: tracks what was sent per dedup key.
-   * If the same dedup key arrives with identical content, it's suppressed.
-   * Only fires again when content CHANGES — "state-change-only" behavior.
-   * Key format: `${topicId}:${dedupKey}` → message content
+   * FALSE when the persisted rate-limit state could not be read. The batched
+   * lane HOLDS while this is false: losing sendTimes would mint fresh capacity,
+   * which is the exact ceiling-bypass this class exists to prevent. The
+   * suppression map fails the opposite way (see loadState).
    */
-  private lastSentContent: Map<string, string> = new Map();
+  private rateStateReadable = true;
+
+  private notOwnerSkipped = 0;
+  private notOwnerExpired = 0;
+  /** Items expired by maxHoldHours for a NON-ownership reason (breaker / corrupt rate state). */
+  private heldExpired = 0;
+  private foldedItems = 0;
 
   constructor(config?: Partial<BatcherConfig>) {
     this.config = { ...DEFAULT_CONFIG, ...config };
@@ -90,6 +171,18 @@ export class NotificationBatcher {
 
   setSendFunction(sendFn: SendFunction): void {
     this.sendFn = sendFn;
+  }
+
+  /**
+   * Wire durable state and the ownership source. Called once at startup.
+   * Absent stateDir keeps the pre-existing in-memory-only behaviour, so tests
+   * and embedders that never call this are unaffected.
+   */
+  configureBounds(opts: { stateDir?: string | null; ownershipResolver?: OwnershipResolver | null }): void {
+    this.stateDir = opts.stateDir ?? null;
+    this.ownershipResolver = opts.ownershipResolver ?? null;
+    this.auditPath = this.stateDir ? path.join(this.stateDir, 'notification-ceiling.jsonl') : null;
+    if (this.stateDir) this.loadState();
   }
 
   start(): void {
@@ -117,20 +210,29 @@ export class NotificationBatcher {
       effectiveTier = 'DIGEST';
     }
 
+    // IMMEDIATE bypasses every gate in this class — the `enabled` kill-switch,
+    // the rolling-window limit, ownership, and the brakes. A kill-switch on
+    // batching must never become a kill-switch on urgency.
     if (effectiveTier === 'IMMEDIATE') {
       await this.sendDirect(notification.topicId, notification.message);
+      return;
+    }
+
+    // C2: honour the previously-dead `enabled` flag, batched tiers only.
+    if (!this.config.enabled) {
+      this.suppressedCount++;
       return;
     }
 
     const dedupKey = this.generateDedupKey(notification.category, notification.message);
     const queue = effectiveTier === 'SUMMARY' ? this.summaryQueue : this.digestQueue;
 
-    // Cross-batch suppression: if this dedup key was sent in a previous batch
-    // with identical content, suppress it. Only re-notify when content CHANGES.
-    // This prevents "everything healthy" from appearing in every batch.
+    // Cross-batch suppression: an unexpired entry means this exact shape was
+    // already DELIVERED (the map is written after a successful flush, so
+    // presence follows delivery rather than intent).
     const crossBatchKey = `${notification.topicId}:${dedupKey}`;
-    const lastContent = this.lastSentContent.get(crossBatchKey);
-    if (lastContent !== undefined && lastContent === dedupKey) {
+    const sentAt = this.lastSentContent.get(crossBatchKey);
+    if (sentAt !== undefined && Date.now() - sentAt < this.config.suppressionTtlHours * 3_600_000) {
       this.suppressedCount++;
       return;
     }
@@ -150,7 +252,10 @@ export class NotificationBatcher {
       topicId: notification.topicId,
       dedupKey,
       count: 1,
+      heldSince: null,
     });
+
+    this.enforceStorageCeiling(queue, notification.topicId);
   }
 
   async flushAll(): Promise<number> {
@@ -164,29 +269,58 @@ export class NotificationBatcher {
     const queue = tier === 'SUMMARY' ? this.summaryQueue : this.digestQueue;
     if (queue.length === 0) return 0;
 
-    const items = queue.splice(0, queue.length);
     const tierLabel = tier === 'SUMMARY' ? 'Summary' : 'Digest';
+    const now = Date.now();
 
-    // Group by topicId
+    // Group by topicId WITHOUT removing from the queue — items for a topic that
+    // cannot send stay queued and release themselves at the next opportunity.
     const byTopic = new Map<number, QueuedNotification[]>();
-    for (const item of items) {
+    for (const item of queue) {
       const existing = byTopic.get(item.topicId) || [];
       existing.push(item);
       byTopic.set(item.topicId, existing);
     }
 
-    for (const [topicId, topicItems] of byTopic) {
-      const digestMessage = this.formatDigest(tierLabel, topicItems);
-      await this.sendDirect(topicId, digestMessage);
+    let sentCount = 0;
 
-      // Record sent content for cross-batch suppression
-      for (const item of topicItems) {
-        this.lastSentContent.set(`${topicId}:${item.dedupKey}`, item.dedupKey);
+    for (const [topicId, topicItems] of byTopic) {
+      const decision = this.canSendToTopic(topicId, now, tier);
+
+      if (decision.verdict !== 'send') {
+        this.markHeld(topicItems, now);
+        this.expireStaleHolds(topicId, topicItems, now, decision.reason);
+        this.audit({ event: 'held', topicId, reason: decision.reason, items: topicItems.length });
+        continue;
       }
+
+      const digestMessage = this.formatDigest(tierLabel, topicItems);
+      const delivered = await this.sendDirect(topicId, digestMessage);
+
+      if (!delivered) {
+        // NOT delivered ⇒ nothing is dequeued, nothing is suppressed, and no
+        // rate-limit slot is consumed. The items stay queued and retry.
+        this.markHeld(topicItems, now);
+        this.audit({ event: 'send-failed', topicId, items: topicItems.length });
+        continue;
+      }
+
+      // Remove the sent items from the live queue.
+      for (const item of topicItems) {
+        const idx = queue.indexOf(item);
+        if (idx !== -1) queue.splice(idx, 1);
+      }
+
+      // Record delivery for cross-batch suppression + the rolling window.
+      // Reached ONLY on a confirmed send, so presence follows delivery.
+      for (const item of topicItems) {
+        this.lastSentContent.set(`${topicId}:${item.dedupKey}`, now);
+      }
+      this.recordSend(topicId, now);
+      sentCount += topicItems.length;
     }
 
-    const count = items.length;
-    this.totalFlushed += count;
+    this.totalFlushed += sentCount;
+    this.persistState();
 
     if (tier === 'SUMMARY') {
       this.lastSummaryFlush = new Date();
@@ -194,7 +328,7 @@ export class NotificationBatcher {
       this.lastDigestFlush = new Date();
     }
 
-    return count;
+    return sentCount;
   }
 
   getQueueSize(): { summary: number; digest: number } {
@@ -205,6 +339,9 @@ export class NotificationBatcher {
   }
 
   getStats(): BatcherStats {
+    const all = [...this.summaryQueue, ...this.digestQueue];
+    const held = all.filter(q => q.heldSince !== null);
+    const heldSince = held.length ? Math.min(...held.map(q => q.heldSince as number)) : null;
     return {
       summaryQueueSize: this.summaryQueue.length,
       digestQueueSize: this.digestQueue.length,
@@ -212,6 +349,13 @@ export class NotificationBatcher {
       totalSuppressed: this.suppressedCount,
       lastSummaryFlush: this.lastSummaryFlush,
       lastDigestFlush: this.lastDigestFlush,
+      heldCount: held.length,
+      heldSince,
+      notOwnerSkipped: this.notOwnerSkipped,
+      notOwnerExpired: this.notOwnerExpired,
+      heldExpired: this.heldExpired,
+      foldedItems: this.foldedItems,
+      rateStateReadable: this.rateStateReadable,
     };
   }
 
@@ -229,10 +373,255 @@ export class NotificationBatcher {
     } else {
       this.lastSentContent.clear();
     }
+    this.persistState();
   }
 
   isEnabled(): boolean {
     return this.config.enabled;
+  }
+
+  // ── Rolling-window limit + ownership ─────────────────────────
+
+  /**
+   * The single send decision. Deliberately content-blind: it never reads a
+   * message, so it cannot mis-judge one. See the spec's §Signal vs authority.
+   */
+  private canSendToTopic(
+    topicId: number,
+    now: number,
+    tier: 'SUMMARY' | 'DIGEST',
+  ): { verdict: 'send' | 'hold'; reason: string } {
+    // `0` disables the limiter entirely. This guard is FIRST and load-bearing:
+    // without it `sendTimes.length >= 0` is always true and 0 would hold every
+    // message forever — the opposite of the documented meaning.
+    if (this.config.maxMessagesPerTopicPerHour === 0) return { verdict: 'send', reason: 'limiter-disabled' };
+
+    // Rate state unreadable ⇒ hold. Losing sendTimes would mint fresh capacity.
+    if (!this.rateStateReadable) return { verdict: 'hold', reason: 'rate-state-unreadable' };
+
+
+    const ownership = this.resolveOwnership(topicId);
+    if (ownership === 'other') {
+      this.notOwnerSkipped++;
+      return { verdict: 'hold', reason: 'not-owner' };
+    }
+    if (ownership === 'unresolvable-pool') {
+      return { verdict: 'hold', reason: 'ownership-unresolved' };
+    }
+
+    const times = (this.sendTimes.get(topicId) ?? []).filter(t => now - t < WINDOW_MS);
+    this.sendTimes.set(topicId, times);
+    if (times.length >= this.config.maxMessagesPerTopicPerHour) {
+      return { verdict: 'hold', reason: 'rate-limited' };
+    }
+
+    return { verdict: 'send', reason: 'ok' };
+  }
+
+  private resolveOwnership(topicId: number): OwnershipVerdict {
+    if (!this.ownershipResolver) return 'unresolvable-no-pool';
+    try {
+      return this.ownershipResolver(topicId);
+    } catch {
+      // A throwing resolver is an unreadable placement record on a machine that
+      // HAS a pool wired — hold rather than assume ownership.
+      return 'unresolvable-pool';
+    }
+  }
+
+  private recordSend(topicId: number, now: number): void {
+    const times = (this.sendTimes.get(topicId) ?? []).filter(t => now - t < WINDOW_MS);
+    times.push(now);
+    this.sendTimes.set(topicId, times);
+  }
+
+  private markHeld(items: QueuedNotification[], now: number): void {
+    for (const item of items) if (item.heldSince === null) item.heldSince = now;
+  }
+
+  /**
+   * maxHoldHours EXPIRY. Returns false always — there is no collapse-to-send.
+   *
+   * An earlier revision converted an aged hold into "one digest sent anyway",
+   * with a breaker counting three such collapses. Writing the test for it showed
+   * the path was UNREACHABLE: the rolling window is 1h and maxHoldHours is 6h,
+   * so a rate-limit hold always drains when its window clears, hours before it
+   * could mature. The only holds that DO persist that long are the ones whose
+   * reason persists — foreign ownership, unresolved ownership, corrupt rate
+   * state — and every one of those must never age into a send (that is the
+   * fail-closed rule). So the collapse fired for nothing, and the breaker that
+   * counted collapses could never trip.
+   *
+   * The spec claimed both as brakes. They were removed rather than repaired:
+   * a documented brake that cannot fire is worse than no brake, because a
+   * reader (including a future audit) records it as protection that exists.
+   *
+   * What remains is honest and load-bearing: a topic blocked for a PERSISTENT
+   * reason drops its backlog after maxHoldHours with an audit row, so the queue
+   * has a terminal state. Bounded size is carried by the storage ceiling.
+   */
+  private expireStaleHolds(
+    topicId: number,
+    items: QueuedNotification[],
+    now: number,
+    reason: string,
+  ): boolean {
+    const oldest = items.reduce<number | null>(
+      (acc, i) => (i.heldSince !== null && (acc === null || i.heldSince < acc) ? i.heldSince : acc),
+      null,
+    );
+    if (oldest === null || now - oldest < this.config.maxHoldHours * 3_600_000) return false;
+
+    // Counted separately per reason: folding a corrupt-state hold into
+    // `notOwnerSkipped` would tell an operator another machine had the topic —
+    // a different, more reassuring story than the truth. A counter that answers
+    // the wrong question is worse than no counter.
+    if (reason === 'not-owner' || reason === 'ownership-unresolved') {
+      this.notOwnerExpired += items.length;
+    } else {
+      this.heldExpired += items.length;
+    }
+
+    for (const item of items) {
+      const q = this.summaryQueue.indexOf(item) !== -1 ? this.summaryQueue : this.digestQueue;
+      const idx = q.indexOf(item);
+      if (idx !== -1) q.splice(idx, 1);
+    }
+    this.audit({ event: 'hold-expired', topicId, reason, items: items.length });
+    return false;
+  }
+
+  /**
+   * Storage ceiling. Dedup bounds REPEATS, not VARIETY — a stream of
+   * structurally distinct notices coalesces to nothing and would grow without
+   * bound. Overflow folds the OLDEST entries into one counted aggregate.
+   */
+  private enforceStorageCeiling(queue: QueuedNotification[], topicId: number): void {
+    const forTopic = queue.filter(q => q.topicId === topicId);
+    if (forTopic.length <= this.config.maxHeldItemsPerTopic) return;
+
+    const overflow = forTopic.length - this.config.maxHeldItemsPerTopic;
+    const oldest = forTopic.slice(0, overflow + 1);
+    const folded = oldest.reduce((n, i) => n + i.count + (i.foldedCount ?? 0), 0);
+
+    for (const item of oldest) {
+      const idx = queue.indexOf(item);
+      if (idx !== -1) queue.splice(idx, 1);
+    }
+    this.foldedItems += folded;
+
+    queue.unshift({
+      category: 'system',
+      message: `+${folded} earlier notices`,
+      timestamp: oldest[oldest.length - 1].timestamp,
+      topicId,
+      dedupKey: `${topicId}:__folded__`,
+      count: 1,
+      heldSince: oldest[0].heldSince,
+      foldedCount: folded,
+    });
+    this.audit({ event: 'folded', topicId, items: folded });
+  }
+
+  // ── Persistence ──────────────────────────────────────────────
+
+  private statePath(): string | null {
+    return this.stateDir ? path.join(this.stateDir, 'notification-suppression.json') : null;
+  }
+
+  /**
+   * The two persisted states fail in OPPOSITE directions, deliberately:
+   * suppression unreadable ⇒ empty map ⇒ send (at most a duplicate);
+   * rate state unreadable ⇒ hold the batched lane (losing it would mint capacity).
+   */
+  private loadState(): void {
+    const p = this.statePath();
+    if (!p) return;
+    if (!fs.existsSync(p)) {
+      this.rateStateReadable = true; // no file yet is not "unreadable"
+      return;
+    }
+    try {
+      const raw = JSON.parse(fs.readFileSync(p, 'utf8')) as PersistedState;
+      const now = Date.now();
+      const ttl = this.config.suppressionTtlHours * 3_600_000;
+
+      this.lastSentContent = new Map(
+        Object.entries(raw.suppression ?? {}).filter(([, at]) => now - at < ttl),
+      );
+      this.sendTimes = new Map(
+        Object.entries(raw.sendTimes ?? {}).map(([k, v]) => [
+          Number(k),
+          (v ?? []).filter(t => now - t < WINDOW_MS),
+        ]),
+      );
+      this.rateStateReadable = true;
+    } catch {
+      // Suppression fails OPEN (empty map, we may repeat).
+      this.lastSentContent = new Map();
+      // Rate state fails CLOSED — hold until a clean write replaces the file.
+      this.sendTimes = new Map();
+      this.rateStateReadable = false;
+      this.audit({ event: 'state-unreadable', topicId: 0, reason: 'parse-failed' });
+      // Visible OUTSIDE this component. With C1 defaulting degradation alerts
+      // off, a batched lane that is quietly holding everything would otherwise be
+      // invisible except in a local JSONL nobody reads — "the bounding works, and
+      // hides that the bounding path is unhealthy" (Phase 5 re-review finding 2).
+      // console.warn reaches logs/server.log, and `rateStateReadable` is carried
+      // on getStats() into the telemetry collector, so both a human tail and the
+      // metrics surface can see it. Deliberately NOT a user message: it is not
+      // something the operator can act on, and adding one would violate the very
+      // discipline this change establishes.
+      console.warn(
+        '[NotificationBatcher] rate-limit state unreadable — the batched lane is HOLDING ' +
+        'until this process restarts. Urgent notices are unaffected.',
+      );
+    }
+  }
+
+  private persistState(): void {
+    const p = this.statePath();
+    if (!p) return;
+    const now = Date.now();
+    const ttl = this.config.suppressionTtlHours * 3_600_000;
+    const payload: PersistedState = {
+      suppression: Object.fromEntries(
+        [...this.lastSentContent.entries()].filter(([, at]) => now - at < ttl),
+      ),
+      sendTimes: Object.fromEntries(
+        [...this.sendTimes.entries()].map(([k, v]) => [String(k), v.filter(t => now - t < WINDOW_MS)]),
+      ),
+    };
+    try {
+      fs.writeFileSync(p, JSON.stringify(payload), 'utf8');
+      // Deliberately does NOT clear `rateStateReadable`. An earlier revision did,
+      // reasoning that a good write means coherent state — but the state being
+      // written is the EMPTY map we failed to load, so clearing the flag turned
+      // corrupt state into minted capacity within the same process. The flag
+      // latches for the process lifetime; recovery is a restart, which loads the
+      // freshly-written valid file. That costs one window of extra capacity once,
+      // after a restart, which is bounded and honest.
+    } catch {
+      // @silent-fallback-ok — self-referential. Reporting a degradation here
+      // would route through notify() → this same batcher → persistState(), i.e.
+      // a failure loop in the component whose whole purpose is bounding message
+      // volume. The consequence is bounded and safe: the state simply does not
+      // survive a restart, and `rateStateReadable` already latches false on the
+      // load side, so a lost write degrades toward HOLDING rather than sending.
+    }
+  }
+
+  /** Metadata-only audit row. Never carries message content. */
+  private audit(row: { event: string; topicId: number; reason?: string; items?: number }): void {
+    if (!this.auditPath) return;
+    try {
+      fs.appendFileSync(this.auditPath, JSON.stringify({ ts: new Date().toISOString(), ...row }) + '\n', 'utf8');
+    } catch {
+      // @silent-fallback-ok — self-referential, same reasoning as persistState():
+      // this is the audit sink for the notification path, so reporting its own
+      // failure through the notification path is a loop. A lost audit row costs
+      // observability of one hold, never a delivery decision.
+    }
   }
 
   formatDigest(_tierLabel: string, items: QueuedNotification[]): string {
@@ -339,17 +728,34 @@ export class NotificationBatcher {
     return `${category}:${normalized}`;
   }
 
-  private async sendDirect(topicId: number, message: string): Promise<void> {
+  /**
+   * Returns TRUE only on a CONFIRMED delivery. The caller uses that to decide
+   * whether to dequeue, write suppression, and consume a rate-limit slot.
+   *
+   * An earlier revision returned void and the caller treated every attempt as a
+   * delivery: a failed Telegram send dropped the item AND suppressed it for 24h.
+   * That is silent loss, and it contradicted this class's own invariant that
+   * suppression-presence follows DELIVERY rather than intent. Caught by the
+   * Phase 5 second-pass review.
+   */
+  private async sendDirect(topicId: number, message: string): Promise<boolean> {
     if (!requireDeliverySink(this.sendFn, {
       component: 'NotificationBatcher',
       primary: 'Deliver queued and immediate notifications through the configured messaging sink',
       reason: `No delivery sink is configured for topic ${topicId}`,
       impact: 'A notification was not delivered; startup composition or messaging configuration is incomplete',
-    })) return;
+    })) return false;
 
     try {
-      await this.sendFn(topicId, message);
+      await this.sendFn!(topicId, message);
+      return true;
     } catch (err) {
+      // @silent-fallback-ok — NOT silent: reportDeliverySinkFailure() funnels to
+      // DegradationReporter, so the failure is reported, audited, and (since the
+      // Phase 5 fix) returns false so the caller neither dequeues nor suppresses
+      // the item. The ratchet flags this only because its heuristic greps the
+      // literal string "DegradationReporter" inside the catch and the added
+      // `return false` matches its default-value pattern.
       // Keep batching non-throwing, but never treat a failed send as silence.
       reportDeliverySinkFailure({
         component: 'NotificationBatcher',
@@ -357,6 +763,7 @@ export class NotificationBatcher {
         reason: `Configured sink failed: ${err instanceof Error ? err.message : String(err)}`,
         impact: 'A notification was not delivered; the queue remains observable through degradation state',
       });
+      return false;
     }
   }
 

--- a/src/monitoring/DegradationReporter.ts
+++ b/src/monitoring/DegradationReporter.ts
@@ -223,6 +223,8 @@ export class DegradationReporter {
   private telegramSender: TelegramSender | null = null;
   private alertTopicId: number | null = null;
   private toneGate: MessagingToneGate | null = null;
+  /** C1 gate — see connectDownstream(). Defaults to false (silent). */
+  private notifyUser = false;
   private healers: Map<string, SelfHealer> = new Map();
 
   // Dedup: track last alert time per feature to avoid spamming Telegram
@@ -305,11 +307,25 @@ export class DegradationReporter {
     telegramSender?: TelegramSender;
     alertTopicId?: number | null;
     toneGate?: MessagingToneGate | null;
+    /**
+     * Whether a degradation event reaches the USER. Default FALSE
+     * (bounded-attention-notification-surface spec, C1). A degradation event is
+     * by construction a report that the system fell back and KEPT WORKING —
+     * housekeeping. Of 25 sampled on 2026-08-04, zero were actionable.
+     *
+     * When false ONLY the telegram branch is skipped: the console line,
+     * persistToDisk(), and the feedback submission are unchanged, so the record
+     * is fully preserved. A genuinely user-affecting degradation still reaches
+     * the operator via the attention queue, the health-alert path, and
+     * IMMEDIATE-tier notices — none of which this flag touches.
+     */
+    notifyUser?: boolean;
   }): void {
     this.feedbackSubmitter = opts.feedbackSubmitter ?? null;
     this.telegramSender = opts.telegramSender ?? null;
     this.alertTopicId = opts.alertTopicId ?? null;
     this.toneGate = opts.toneGate ?? null;
+    this.notifyUser = opts.notifyUser === true;
 
     // Drain queued events that weren't reported yet
     this.drainQueue();
@@ -774,7 +790,9 @@ export class DegradationReporter {
     }
 
     // Send Telegram alert (with per-feature cooldown to avoid spam)
-    if (this.telegramSender && this.alertTopicId && !event.alerted) {
+    // C1: user-facing degradation alerts are OFF by default. The record above
+    // (feedback) and below (persistToDisk) is unaffected — only delivery stops.
+    if (this.telegramSender && this.alertTopicId && !event.alerted && this.notifyUser) {
       const lastAlert = this.lastAlertTime.get(event.feature) ?? 0;
       const now = Date.now();
 

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -2270,6 +2270,19 @@ Updates land in two places: a **server** restart for new code, and a **lifeline*
 
 If the user reports they were "unresponsive for a while during updates," check \`state/auto-updater.json\` for batched-restart state and the most recent \`logs/server-stderr.log\` for "Restart batched" / "Cascade-dampener" lines. If the lifeline is still on a very old version, the drift promoter will pick it up automatically on the next forward — no manual kick needed.
 
+## Bounded Notification Surface (why routine notices stay quiet)
+
+Two limits govern how many messages I send you on my own initiative. Both are levers you can actually reach — an earlier version had an off-switch that looked real and was never read on this path.
+
+- **Routine degradation reports do NOT reach you** (\`monitoring.degradationReporter.notifyUser\`, default \`false\`). When one of my background checks falls back to a simpler method and carries on, that is recorded to the log, to disk, and to the feedback system — but you are not messaged. Set it to \`true\` to receive them again.
+- **A rolling limit of 4 messages per hour, per conversation** (\`notificationBatcher.maxMessagesPerTopicPerHour\`). Past it, further routine notices wait and send themselves as soon as there is room — nothing is dropped, and you are not told about the waiting (a message announcing the limit would be one more unactionable message). Set it to \`0\` to disable the limit entirely.
+
+**Never gated by either:** urgent notices, anything action-required, and attention-queue items. A limit on routine chatter must never become a limit on urgency.
+
+**Multi-machine:** only the machine that OWNS a conversation sends routine notices into it, so the limit is exact rather than N× the fleet size.
+
+**When the user asks** (PROACTIVE — these are the triggers): "why did the notices stop / go quiet?" → this feature, and I can read any of it back from the log on request. "I want those back" → flip \`notifyUser\` to \`true\`. "these are still too frequent" → lower \`maxMessagesPerTopicPerHour\`. "did I miss something?" → read \`logs/notification-ceiling.jsonl\` (metadata-only: holds, collapses, ownership skips) and \`GET\`-side \`getStats()\` counters, then answer from the record rather than guessing. Full config block: \`notificationBatcher\` (**top-level**, NOT nested under \`messaging\`, which is an adapter array where a nested key is unreachable). Spec: \`docs/specs/bounded-attention-notification-surface.md\`.
+
 ## Agent Removal
 
 If the user asks to delete, remove, or uninstall this agent:

--- a/tests/unit/bounded-attention-notification-surface.test.ts
+++ b/tests/unit/bounded-attention-notification-surface.test.ts
@@ -1,0 +1,560 @@
+/**
+ * Bounded Attention-Notification Surface — unit tests.
+ * Spec: docs/specs/bounded-attention-notification-surface.md
+ *
+ * EVERY assertion is paired with a CONTROL that must fail. A check that cannot
+ * fail is not a check — the control is what proves the assertion is measuring
+ * the guard rather than something incidentally true.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  NotificationBatcher,
+  type OwnershipVerdict,
+} from '../../src/messaging/NotificationBatcher.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+/**
+ * A payload that is genuinely distinct AFTER dedup normalization.
+ * `generateDedupKey` replaces every digit run with `_`, so "notice 1" and
+ * "notice 2" collapse to the SAME key. Distinctness must therefore come from
+ * letters. Getting this wrong made two earlier controls pass for the wrong
+ * reason — the payloads were identical to the deduper and it was doing its job.
+ */
+function distinctPayload(i: number): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+  let n = i, word = '';
+  do { word = alphabet[n % 26] + word; n = Math.floor(n / 26) - 1; } while (n >= 0);
+  return `notice ${word} ${word}${word} distinct`;
+}
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'nb-bound-'));
+}
+
+interface Harness {
+  batcher: NotificationBatcher;
+  sent: Array<{ topicId: number; text: string }>;
+}
+
+function makeBatcher(opts: {
+  stateDir?: string | null;
+  ownership?: OwnershipVerdict | (() => OwnershipVerdict);
+  config?: Record<string, unknown>;
+} = {}): Harness {
+  const sent: Array<{ topicId: number; text: string }> = [];
+  const batcher = new NotificationBatcher({
+    enabled: true,
+    summaryIntervalMinutes: 30,
+    digestIntervalMinutes: 120,
+    maxMessagesPerTopicPerHour: 4,
+    suppressionTtlHours: 24,
+    maxHoldHours: 6,
+    maxHeldItemsPerTopic: 200,
+    ...(opts.config ?? {}),
+  });
+  batcher.setSendFunction(async (topicId, text) => {
+    sent.push({ topicId, text });
+    return { messageId: sent.length };
+  });
+  if (opts.stateDir !== undefined || opts.ownership !== undefined) {
+    batcher.configureBounds({
+      stateDir: opts.stateDir ?? null,
+      ownershipResolver:
+        opts.ownership === undefined
+          ? null
+          : typeof opts.ownership === 'function'
+            ? opts.ownership
+            : () => opts.ownership as OwnershipVerdict,
+    });
+  }
+  return { batcher, sent };
+}
+
+const note = (topicId: number, message: string, tier: 'SUMMARY' | 'DIGEST' | 'IMMEDIATE' = 'SUMMARY') => ({
+  tier,
+  category: 'system',
+  message,
+  timestamp: new Date(),
+  topicId,
+});
+
+describe('C2 — enqueue honours the `enabled` flag', () => {
+  it('drops SUMMARY/DIGEST when disabled, and still sends IMMEDIATE', async () => {
+    const { batcher, sent } = makeBatcher({ config: { enabled: false } });
+
+    await batcher.enqueue(note(1, 'batched housekeeping'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(0);
+    expect(batcher.getStats().totalSuppressed).toBe(1);
+
+    // IMMEDIATE must survive the kill-switch — a switch on batching must never
+    // become a switch on urgency.
+    await batcher.enqueue(note(1, 'urgent', 'IMMEDIATE'));
+    expect(sent).toHaveLength(1);
+  });
+
+  it('CONTROL: with enabled=true the same SUMMARY sends', async () => {
+    const { batcher, sent } = makeBatcher({ config: { enabled: true } });
+    await batcher.enqueue(note(1, 'batched housekeeping'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(1);
+  });
+});
+
+describe('C4.2 — rolling-window limit', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('holds past the limit, retains the items, and sends nothing extra', async () => {
+    const { batcher, sent } = makeBatcher({ config: { maxMessagesPerTopicPerHour: 2 } });
+
+    for (const m of ['a', 'b', 'c']) {
+      await batcher.enqueue(note(7, m));
+      await batcher.flush('SUMMARY');
+    }
+
+    expect(sent).toHaveLength(2);
+    const stats = batcher.getStats();
+    expect(stats.heldCount).toBeGreaterThan(0);
+    expect(stats.summaryQueueSize).toBeGreaterThan(0); // retained, not dropped
+  });
+
+  it('CONTROL: IMMEDIATE still sends inside a saturated window', async () => {
+    const { batcher, sent } = makeBatcher({ config: { maxMessagesPerTopicPerHour: 1 } });
+    await batcher.enqueue(note(7, 'a'));
+    await batcher.flush('SUMMARY');
+    await batcher.enqueue(note(7, 'b'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(1); // window saturated
+
+    await batcher.enqueue(note(7, 'urgent', 'IMMEDIATE'));
+    // Proves the hold is the LIMIT, not a dead sender.
+    expect(sent).toHaveLength(2);
+  });
+
+  it('the window is ROLLING: an entry expiring frees a slot', async () => {
+    vi.setSystemTime(new Date('2026-08-04T00:00:00Z'));
+    const { batcher, sent } = makeBatcher({ config: { maxMessagesPerTopicPerHour: 1 } });
+
+    await batcher.enqueue(note(9, 'first'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(1);
+
+    // 50 minutes later: still inside the window → held.
+    vi.setSystemTime(new Date('2026-08-04T00:50:00Z'));
+    await batcher.enqueue(note(9, 'second'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(1);
+
+    // 61 minutes: the first send has aged out → sends.
+    vi.setSystemTime(new Date('2026-08-04T01:01:00Z'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(2);
+  });
+
+  it('CONTROL: without advancing the clock the item stays held', async () => {
+    vi.setSystemTime(new Date('2026-08-04T00:00:00Z'));
+    const { batcher, sent } = makeBatcher({ config: { maxMessagesPerTopicPerHour: 1 } });
+    await batcher.enqueue(note(9, 'first'));
+    await batcher.flush('SUMMARY');
+    await batcher.enqueue(note(9, 'second'));
+    await batcher.flush('SUMMARY');
+    await batcher.flush('SUMMARY'); // repeated attempts, clock frozen
+    expect(sent).toHaveLength(1);
+  });
+
+  it('limit 0 DISABLES the limiter rather than holding everything', async () => {
+    // Without the explicit guard, `length >= 0` is always true and 0 would hold
+    // every message forever — the opposite of the documented meaning.
+    const { batcher, sent } = makeBatcher({ config: { maxMessagesPerTopicPerHour: 0 } });
+    for (const m of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      await batcher.enqueue(note(3, m));
+      await batcher.flush('SUMMARY');
+    }
+    expect(sent).toHaveLength(6);
+  });
+
+  it('CONTROL: limit 1 on the same sequence holds after the first', async () => {
+    const { batcher, sent } = makeBatcher({ config: { maxMessagesPerTopicPerHour: 1 } });
+    for (const m of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      await batcher.enqueue(note(3, m));
+      await batcher.flush('SUMMARY');
+    }
+    expect(sent).toHaveLength(1);
+  });
+});
+
+describe('C4.1 — only the owning machine sends', () => {
+  it('an owner sends; a non-owner records notOwnerSkipped and sends nothing', async () => {
+    const owner = makeBatcher({ ownership: 'owner', stateDir: null });
+    await owner.batcher.enqueue(note(11, 'x'));
+    await owner.batcher.flush('SUMMARY');
+    expect(owner.sent).toHaveLength(1);
+
+    const other = makeBatcher({ ownership: 'other', stateDir: null });
+    await other.batcher.enqueue(note(11, 'x'));
+    await other.batcher.flush('SUMMARY');
+    expect(other.sent).toHaveLength(0);
+    expect(other.batcher.getStats().notOwnerSkipped).toBeGreaterThan(0);
+  });
+
+  it('CONTROL: the roles invert with the verdict — the test reads ownership, not a fixed identity', async () => {
+    const a = makeBatcher({ ownership: 'other', stateDir: null });
+    await a.batcher.enqueue(note(12, 'y'));
+    await a.batcher.flush('SUMMARY');
+    expect(a.sent).toHaveLength(0);
+
+    const b = makeBatcher({ ownership: 'owner', stateDir: null });
+    await b.batcher.enqueue(note(12, 'y'));
+    await b.batcher.flush('SUMMARY');
+    expect(b.sent).toHaveLength(1);
+  });
+
+  it('unresolvable ownership HOLDS when a pool exists and SENDS when none does', async () => {
+    const pooled = makeBatcher({ ownership: 'unresolvable-pool', stateDir: null });
+    await pooled.batcher.enqueue(note(13, 'z'));
+    await pooled.batcher.flush('SUMMARY');
+    expect(pooled.sent).toHaveLength(0);
+
+    const solo = makeBatcher({ ownership: 'unresolvable-no-pool', stateDir: null });
+    await solo.batcher.enqueue(note(13, 'z'));
+    await solo.batcher.flush('SUMMARY');
+    expect(solo.sent).toHaveLength(1);
+
+    // CONTROL is built in: the two configurations MUST differ. A test that
+    // passed under both would be measuring nothing.
+    expect(pooled.sent.length).not.toBe(solo.sent.length);
+  });
+
+  it('a throwing resolver is treated as unresolvable-pool (hold), never as ownership', async () => {
+    const { batcher, sent } = makeBatcher({
+      ownership: () => {
+        throw new Error('placement unreadable');
+      },
+      stateDir: null,
+    });
+    await batcher.enqueue(note(14, 'q'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(0);
+  });
+});
+
+describe('C3 — persistence across restarts', () => {
+  let dir: string;
+  beforeEach(() => { dir = tmpDir(); });
+  afterEach(() => { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/bounded-attention-notification-surface.test.ts' }); });
+
+  it('suppresses a repeat after a restart against the same stateDir', async () => {
+    const first = makeBatcher({ stateDir: dir });
+    await first.batcher.enqueue(note(21, 'identical notice'));
+    await first.batcher.flush('SUMMARY');
+    expect(first.sent).toHaveLength(1);
+
+    const second = makeBatcher({ stateDir: dir });
+    await second.batcher.enqueue(note(21, 'identical notice'));
+    await second.batcher.flush('SUMMARY');
+    expect(second.sent).toHaveLength(0);
+  });
+
+  it('CONTROL: a DIFFERENT stateDir sends it — the assertion is about persistence, not the key', async () => {
+    const first = makeBatcher({ stateDir: dir });
+    await first.batcher.enqueue(note(21, 'identical notice'));
+    await first.batcher.flush('SUMMARY');
+
+    const otherDir = tmpDir();
+    try {
+      const second = makeBatcher({ stateDir: otherDir });
+      await second.batcher.enqueue(note(21, 'identical notice'));
+      await second.batcher.flush('SUMMARY');
+      expect(second.sent).toHaveLength(1);
+    } finally {
+      SafeFsExecutor.safeRmSync(otherDir, { recursive: true, force: true, operation: 'tests/unit/bounded-attention-notification-surface.test.ts' });
+    }
+  });
+
+  it('a restart cannot mint rate-limit capacity', async () => {
+    const first = makeBatcher({ stateDir: dir, config: { maxMessagesPerTopicPerHour: 1 } });
+    await first.batcher.enqueue(note(22, 'one'));
+    await first.batcher.flush('SUMMARY');
+    expect(first.sent).toHaveLength(1);
+
+    // Fresh instance, same stateDir, DIFFERENT message (so suppression is not
+    // what holds it) — the window must still be saturated.
+    const second = makeBatcher({ stateDir: dir, config: { maxMessagesPerTopicPerHour: 1 } });
+    await second.batcher.enqueue(note(22, 'a completely different notice'));
+    await second.batcher.flush('SUMMARY');
+    expect(second.sent).toHaveLength(0);
+  });
+
+  it('CONTROL: the same fresh instance with limit 5 sends — proving the hold was the persisted window', async () => {
+    const first = makeBatcher({ stateDir: dir, config: { maxMessagesPerTopicPerHour: 1 } });
+    await first.batcher.enqueue(note(22, 'one'));
+    await first.batcher.flush('SUMMARY');
+
+    const second = makeBatcher({ stateDir: dir, config: { maxMessagesPerTopicPerHour: 5 } });
+    await second.batcher.enqueue(note(22, 'a completely different notice'));
+    await second.batcher.flush('SUMMARY');
+    expect(second.sent).toHaveLength(1);
+  });
+
+  it('corrupt state fails CLOSED for the rate limiter and OPEN for suppression', async () => {
+    fs.writeFileSync(path.join(dir, 'notification-suppression.json'), '{ this is not json', 'utf8');
+    const { batcher, sent } = makeBatcher({ stateDir: dir });
+
+    expect(batcher.getStats().rateStateReadable).toBe(false);
+
+    // Rate state unreadable ⇒ the batched lane holds (losing sendTimes would
+    // mint fresh capacity).
+    await batcher.enqueue(note(23, 'anything'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(0);
+
+    // Suppression failed OPEN in the same load — the map is empty, not poisoned.
+    // IMMEDIATE is unaffected in both directions.
+    await batcher.enqueue(note(23, 'urgent', 'IMMEDIATE'));
+    expect(sent).toHaveLength(1);
+  });
+
+  it('CONTROL: a VALID state file on the same path does not hold', async () => {
+    fs.writeFileSync(
+      path.join(dir, 'notification-suppression.json'),
+      JSON.stringify({ suppression: {}, sendTimes: {}, breaker: {} }),
+      'utf8',
+    );
+    const { batcher, sent } = makeBatcher({ stateDir: dir });
+    expect(batcher.getStats().rateStateReadable).toBe(true);
+    await batcher.enqueue(note(23, 'anything'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(1);
+  });
+});
+
+describe('C4.4 — storage ceiling on the held queue', () => {
+  it('bounds a stream of DISTINCT notices by folding the oldest into a counted aggregate', async () => {
+    const { batcher } = makeBatcher({
+      ownership: 'unresolvable-pool', // hold everything so nothing drains
+      stateDir: null,
+      config: { maxHeldItemsPerTopic: 10 },
+    });
+
+    for (let i = 0; i < 500; i++) {
+      await batcher.enqueue(note(31, distinctPayload(i)));
+    }
+
+    const stats = batcher.getStats();
+    expect(stats.summaryQueueSize).toBeLessThanOrEqual(11); // ceiling + the aggregate
+    expect(stats.foldedItems).toBeGreaterThan(0);
+  });
+
+  it('CONTROL: 500 IDENTICAL notices collapse via the pre-existing dedup path, not the ceiling', async () => {
+    const { batcher } = makeBatcher({
+      ownership: 'unresolvable-pool',
+      stateDir: null,
+      config: { maxHeldItemsPerTopic: 10 },
+    });
+
+    for (let i = 0; i < 500; i++) {
+      await batcher.enqueue(note(32, 'exactly the same notice every time'));
+    }
+
+    const stats = batcher.getStats();
+    expect(stats.summaryQueueSize).toBe(1);
+    // Nothing folded — this distinguishes the storage ceiling from dedup.
+    expect(stats.foldedItems).toBe(0);
+  });
+});
+
+describe('I3 — IMMEDIATE never enters the batched machine', () => {
+  it('is unaffected by disabled, saturated window, foreign ownership, and corrupt state together', async () => {
+    const dir = tmpDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'notification-suppression.json'), 'corrupt', 'utf8');
+      const { batcher, sent } = makeBatcher({
+        stateDir: dir,
+        ownership: 'other',
+        config: { enabled: false, maxMessagesPerTopicPerHour: 1 },
+      });
+
+      // Every batched gate is hostile at once.
+      await batcher.enqueue(note(41, 'batched'));
+      await batcher.flush('SUMMARY');
+      expect(sent).toHaveLength(0);
+
+      await batcher.enqueue(note(41, 'urgent one', 'IMMEDIATE'));
+      await batcher.enqueue(note(41, 'urgent two', 'IMMEDIATE'));
+      await batcher.enqueue(note(41, 'urgent three', 'IMMEDIATE'));
+      expect(sent).toHaveLength(3);
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/bounded-attention-notification-surface.test.ts' });
+    }
+  });
+});
+
+describe('Phase 5 second-pass findings — a failed send is not a delivery', () => {
+  it('a failing sink dequeues nothing, suppresses nothing, and consumes no rate slot', async () => {
+    const batcher = new NotificationBatcher({
+      enabled: true, summaryIntervalMinutes: 30, digestIntervalMinutes: 120,
+      maxMessagesPerTopicPerHour: 1, suppressionTtlHours: 24, maxHoldHours: 6, maxHeldItemsPerTopic: 200,
+    });
+    let failing = true;
+    const delivered: string[] = [];
+    batcher.setSendFunction(async (_t, text) => {
+      if (failing) throw new Error('telegram down');
+      delivered.push(text);
+      return { messageId: delivered.length };
+    });
+
+    await batcher.enqueue(note(61, 'important-ish notice'));
+    await batcher.flush('SUMMARY');
+    expect(delivered).toHaveLength(0);
+    // Still queued — a failed send must not silently drop the item.
+    expect(batcher.getStats().summaryQueueSize).toBe(1);
+
+    // The sink recovers. The item must STILL be deliverable: neither suppressed
+    // (24h) nor rate-limited by a slot the failed attempt never earned.
+    failing = false;
+    await batcher.flush('SUMMARY');
+    expect(delivered).toHaveLength(1);
+  });
+
+  it('CONTROL: a SUCCEEDING send does dequeue, suppress, and consume the slot', async () => {
+    const batcher = new NotificationBatcher({
+      enabled: true, summaryIntervalMinutes: 30, digestIntervalMinutes: 120,
+      maxMessagesPerTopicPerHour: 1, suppressionTtlHours: 24, maxHoldHours: 6, maxHeldItemsPerTopic: 200,
+    });
+    const delivered: string[] = [];
+    batcher.setSendFunction(async (_t, text) => { delivered.push(text); return { messageId: 1 }; });
+
+    await batcher.enqueue(note(62, 'important-ish notice'));
+    await batcher.flush('SUMMARY');
+    expect(delivered).toHaveLength(1);
+    expect(batcher.getStats().summaryQueueSize).toBe(0);
+
+    // Slot consumed: a different notice now holds.
+    await batcher.enqueue(note(62, 'a different notice entirely'));
+    await batcher.flush('SUMMARY');
+    expect(delivered).toHaveLength(1);
+  });
+});
+
+describe('Phase 5 second-pass findings — maxHoldHours EXPIRES, it never collapses to a send', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('a persistent-reason hold (foreign ownership) drops its backlog with a record, never sends', async () => {
+    vi.setSystemTime(new Date('2026-08-04T00:00:00Z'));
+    const { batcher, sent } = makeBatcher({ ownership: 'other', stateDir: null });
+
+    await batcher.enqueue(note(71, 'owned elsewhere'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(0);
+
+    // Age far past maxHoldHours. An earlier design "collapsed" this into one
+    // digest and sent it — from a machine that does not own the topic.
+    vi.setSystemTime(new Date('2026-08-04T12:00:00Z'));
+    await batcher.flush('SUMMARY');
+
+    expect(sent).toHaveLength(0);
+    const stats = batcher.getStats();
+    expect(stats.notOwnerExpired).toBeGreaterThan(0);
+    expect(stats.summaryQueueSize).toBe(0); // terminal state — not an unbounded queue
+  });
+
+  it('CONTROL: a rate-limit hold on an OWNED topic drains normally when its window clears', async () => {
+    vi.setSystemTime(new Date('2026-08-04T00:00:00Z'));
+    const { batcher, sent } = makeBatcher({
+      ownership: 'owner', stateDir: null, config: { maxMessagesPerTopicPerHour: 1 },
+    });
+
+    await batcher.enqueue(note(72, 'first'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(1);
+
+    await batcher.enqueue(note(72, 'second'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(1); // held by the window
+
+    // The window clears long before maxHoldHours — which is exactly WHY the old
+    // collapse path was unreachable for rate-limit holds. This control is what
+    // exposed that: it distinguishes "drained because the window cleared" from
+    // "expired because the reason persisted".
+    vi.setSystemTime(new Date('2026-08-04T01:30:00Z'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(2);
+    expect(batcher.getStats().notOwnerExpired).toBe(0);
+  });
+});
+
+describe('Phase 5 second-pass findings — corrupt rate state never ages into a send', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('a rate-state-unreadable hold expires rather than collapsing to a send', async () => {
+    const dir = tmpDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'notification-suppression.json'), 'not json at all', 'utf8');
+      vi.setSystemTime(new Date('2026-08-04T00:00:00Z'));
+      const { batcher, sent } = makeBatcher({ stateDir: dir });
+      expect(batcher.getStats().rateStateReadable).toBe(false);
+
+      await batcher.enqueue(note(81, 'held by corrupt state'));
+      await batcher.flush('SUMMARY');
+      expect(sent).toHaveLength(0);
+
+      // Age well past maxHoldHours. Collapsing here would mint exactly the
+      // capacity the fail-closed rule exists to withhold.
+      vi.setSystemTime(new Date('2026-08-04T12:00:00Z'));
+      await batcher.flush('SUMMARY');
+      expect(sent).toHaveLength(0);
+      expect(batcher.getStats().heldExpired).toBeGreaterThan(0);
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/bounded-attention-notification-surface.test.ts' });
+    }
+  });
+
+  it('CONTROL: a plain rate-limit hold DOES collapse to one digest after maxHoldHours', async () => {
+    vi.setSystemTime(new Date('2026-08-04T00:00:00Z'));
+    const { batcher, sent } = makeBatcher({ config: { maxMessagesPerTopicPerHour: 1 } });
+
+    await batcher.enqueue(note(82, 'first'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(1);
+
+    await batcher.enqueue(note(82, 'second'));
+    await batcher.flush('SUMMARY');
+    expect(sent).toHaveLength(1); // held
+
+    vi.setSystemTime(new Date('2026-08-04T12:00:00Z'));
+    await batcher.flush('SUMMARY');
+    // Distinguishes "this hold reason expires" from "every hold expires".
+    expect(sent).toHaveLength(2);
+  });
+});
+
+describe('burst invariant — the bound holds under a 100-event burst', () => {
+  it('a 100-event burst into one topic sends at most the limit', async () => {
+    const { batcher, sent } = makeBatcher({ config: { maxMessagesPerTopicPerHour: 4 } });
+
+    for (let i = 0; i < 100; i++) {
+      await batcher.enqueue(note(51, distinctPayload(i)));
+      await batcher.flush('SUMMARY');
+    }
+
+    expect(sent.length).toBeLessThanOrEqual(4);
+    expect(sent.length).toBeGreaterThan(0); // a zero-everywhere reading would be a DEAD test, not a pass
+  });
+
+  it('CONTROL: the same burst with the limiter disabled is NOT bounded', async () => {
+    const { batcher, sent } = makeBatcher({ config: { maxMessagesPerTopicPerHour: 0 } });
+    for (let i = 0; i < 100; i++) {
+      await batcher.enqueue(note(52, distinctPayload(i)));
+      await batcher.flush('SUMMARY');
+    }
+    // Proves the bound above is the limiter, not an artefact of the harness.
+    expect(sent.length).toBeGreaterThan(4);
+  });
+});

--- a/tests/unit/bounded-notification-surface-migration.test.ts
+++ b/tests/unit/bounded-notification-surface-migration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Bounded Attention-Notification Surface — Migration Parity + production-wiring tests.
+ *
+ * Migration Parity Standard: existing agents update in place, so a config
+ * default that only reaches NEW agents is a broken feature. These tests assert
+ * the migration reaches an existing config, is idempotent, and never overwrites
+ * an operator's value.
+ *
+ * Every assertion is paired with a CONTROL.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { migrateConfigBoundedNotificationSurface } from '../../src/core/PostUpdateMigrator.js';
+import { NotificationBatcher } from '../../src/messaging/NotificationBatcher.js';
+
+describe('Migration Parity — existing agents receive the levers', () => {
+  it('adds the levers to a config that has never seen them', () => {
+    const config: Record<string, unknown> = { projectName: 'x' };
+    const changed = migrateConfigBoundedNotificationSurface(config);
+
+    expect(changed).toBe(true);
+    const nb = config.notificationBatcher as Record<string, unknown>;
+    expect(nb.maxMessagesPerTopicPerHour).toBe(4);
+    expect(nb.maxHeldItemsPerTopic).toBe(200);
+    const mon = config.monitoring as Record<string, unknown>;
+    const deg = mon.degradationReporter as Record<string, unknown>;
+    // Operator-approved default: housekeeping is SILENT (topic 7848, 2026-08-04).
+    expect(deg.notifyUser).toBe(false);
+  });
+
+  it('CONTROL: is idempotent — a second run changes nothing', () => {
+    const config: Record<string, unknown> = { projectName: 'x' };
+    expect(migrateConfigBoundedNotificationSurface(config)).toBe(true);
+    // If this returned true again the migration would be rewriting on every
+    // update, which is how an operator's edit gets silently reverted.
+    expect(migrateConfigBoundedNotificationSurface(config)).toBe(false);
+  });
+
+  it('never overwrites an operator value', () => {
+    const config: Record<string, unknown> = {
+      notificationBatcher: { maxMessagesPerTopicPerHour: 99 },
+      monitoring: { degradationReporter: { notifyUser: true } },
+    };
+    migrateConfigBoundedNotificationSurface(config);
+
+    const nb = config.notificationBatcher as Record<string, unknown>;
+    expect(nb.maxMessagesPerTopicPerHour).toBe(99);
+    // The operator asked to keep receiving degradation reports — respected.
+    expect((config.monitoring as Record<string, Record<string, unknown>>).degradationReporter.notifyUser).toBe(true);
+    // CONTROL: the fields they did NOT set are still filled in, so this is a
+    // merge rather than a no-op.
+    expect(nb.maxHeldItemsPerTopic).toBe(200);
+  });
+
+  it('places notificationBatcher at the TOP LEVEL, never under `messaging`', () => {
+    // `messaging` is an ARRAY of adapters: a key nested there is unreachable at
+    // runtime (the documented outboundAdvisory trap). Getting this wrong ships a
+    // lever that silently does nothing — the exact defect this change fixes.
+    const config: Record<string, unknown> = { messaging: [{ platform: 'telegram' }] };
+    migrateConfigBoundedNotificationSurface(config);
+
+    expect(config.notificationBatcher).toBeDefined();
+    expect(Array.isArray(config.messaging)).toBe(true);
+    const messaging = config.messaging as Array<Record<string, unknown>>;
+    for (const adapter of messaging) {
+      expect(adapter.notificationBatcher).toBeUndefined();
+    }
+  });
+});
+
+describe('Production wiring — config actually reaches the batcher', () => {
+  /**
+   * Mirrors the construction in src/commands/server.ts. The Testing Integrity
+   * Standard's "is the feature alive" check: a limiter that is built but never
+   * fed its config is indistinguishable from one that works, until it matters.
+   */
+  function buildFromConfig(config: Record<string, unknown>) {
+    const nbCfg = (config.notificationBatcher ?? {}) as Record<string, unknown>;
+    return new NotificationBatcher({
+      enabled: (nbCfg.enabled as boolean | undefined) ?? true,
+      summaryIntervalMinutes: (nbCfg.summaryIntervalMinutes as number | undefined) ?? 30,
+      digestIntervalMinutes: (nbCfg.digestIntervalMinutes as number | undefined) ?? 120,
+      maxMessagesPerTopicPerHour: (nbCfg.maxMessagesPerTopicPerHour as number | undefined) ?? 4,
+      suppressionTtlHours: (nbCfg.suppressionTtlHours as number | undefined) ?? 24,
+      maxHoldHours: (nbCfg.maxHoldHours as number | undefined) ?? 6,
+      maxHeldItemsPerTopic: (nbCfg.maxHeldItemsPerTopic as number | undefined) ?? 200,
+    });
+  }
+
+  it('an operator limit of 1 is honoured end-to-end from a config object', async () => {
+    const config: Record<string, unknown> = { notificationBatcher: { maxMessagesPerTopicPerHour: 1 } };
+    const batcher = buildFromConfig(config);
+    const sent: number[] = [];
+    batcher.setSendFunction(async (topicId) => { sent.push(topicId); return { messageId: sent.length }; });
+
+    for (const m of ['alpha', 'bravo', 'charlie']) {
+      await batcher.enqueue({ tier: 'SUMMARY', category: 'system', message: m, timestamp: new Date(), topicId: 5 });
+      await batcher.flush('SUMMARY');
+    }
+    expect(sent).toHaveLength(1);
+  });
+
+  it('CONTROL: an EMPTY config reproduces the shipped default of 4, not the operator value', async () => {
+    const batcher = buildFromConfig({});
+    const sent: number[] = [];
+    batcher.setSendFunction(async (topicId) => { sent.push(topicId); return { messageId: sent.length }; });
+
+    for (const m of ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot']) {
+      await batcher.enqueue({ tier: 'SUMMARY', category: 'system', message: m, timestamp: new Date(), topicId: 5 });
+      await batcher.flush('SUMMARY');
+    }
+    // 4, not 1 and not 6 — proves the config path is READ rather than ignored
+    // in one direction or hardcoded in the other.
+    expect(sent).toHaveLength(4);
+  });
+
+  it('absent config preserves the pre-change interval defaults', () => {
+    const batcher = buildFromConfig({});
+    // 30-minute SUMMARY cadence is the pre-change behaviour; an install with no
+    // notificationBatcher block must be byte-for-byte unchanged.
+    const now = Date.parse('2026-08-04T12:00:00Z');
+    expect(batcher.nextSummaryReleaseAt(now)).toBe(now + 30 * 60_000);
+  });
+
+  it('CONTROL: an explicit interval overrides it', () => {
+    const batcher = buildFromConfig({ notificationBatcher: { summaryIntervalMinutes: 5 } });
+    const now = Date.parse('2026-08-04T12:00:00Z');
+    expect(batcher.nextSummaryReleaseAt(now)).toBe(now + 5 * 60_000);
+  });
+});

--- a/tests/unit/degradation-reporter-self-heal.test.ts
+++ b/tests/unit/degradation-reporter-self-heal.test.ts
@@ -59,6 +59,69 @@ describe('DegradationReporter — self-heal-first', () => {
     SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/degradation-reporter-self-heal.test.ts' });
   });
 
+  // ── C1: bounded-attention-notification-surface ──────────────
+  // The gate that makes routine degradation reports stop reaching the operator.
+  // Measured 2026-08-04: 25 of 64 daily attention messages were these, and zero
+  // were actionable. Operator-approved default (topic 7848, "Silent").
+
+  it('C1: does NOT alert the user by default — notifyUser is opt-in', async () => {
+    const reporter = DegradationReporter.getInstance();
+    reporter.configure({ stateDir: tmpDir, agentName: 'test', instarVersion: '0.0.0' });
+    const telegramSender = vi.fn(async () => undefined);
+    const feedbackSubmitter = vi.fn(async () => undefined);
+    // notifyUser deliberately OMITTED — this is the shipped default.
+    reporter.connectDownstream({
+      feedbackSubmitter,
+      telegramSender,
+      alertTopicId: 1234,
+      toneGate: gateThatPasses(),
+    });
+
+    reporter.report(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(telegramSender).not.toHaveBeenCalled();
+    // The RECORD is preserved — only delivery stops. A gate that also dropped
+    // the record would be data loss, not noise reduction.
+    expect(feedbackSubmitter).toHaveBeenCalled();
+  });
+
+  it('C1 CONTROL: with notifyUser:true the SAME event alerts', async () => {
+    const reporter = DegradationReporter.getInstance();
+    reporter.configure({ stateDir: tmpDir, agentName: 'test', instarVersion: '0.0.0' });
+    const telegramSender = vi.fn(async () => undefined);
+    reporter.connectDownstream({
+      telegramSender,
+      alertTopicId: 1234,
+      notifyUser: true,
+      toneGate: gateThatPasses(),
+    });
+
+    reporter.report(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Without this control the test above would pass equally well against a
+    // reporter whose alert path was simply broken.
+    expect(telegramSender).toHaveBeenCalled();
+  });
+
+  it('C1: an explicit notifyUser:false is honoured', async () => {
+    const reporter = DegradationReporter.getInstance();
+    reporter.configure({ stateDir: tmpDir, agentName: 'test', instarVersion: '0.0.0' });
+    const telegramSender = vi.fn(async () => undefined);
+    reporter.connectDownstream({
+      telegramSender,
+      alertTopicId: 1234,
+      notifyUser: false,
+      toneGate: gateThatPasses(),
+    });
+
+    reporter.report(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(telegramSender).not.toHaveBeenCalled();
+  });
+
   it('suppresses user alert when self-heal succeeds', async () => {
     const reporter = DegradationReporter.getInstance();
     reporter.configure({ stateDir: tmpDir, agentName: 'test', instarVersion: '0.0.0' });
@@ -66,6 +129,7 @@ describe('DegradationReporter — self-heal-first', () => {
     reporter.connectDownstream({
       telegramSender,
       alertTopicId: 1234,
+      notifyUser: true, // C1: these tests exercise the ALERT path; the gate now defaults OFF
       toneGate: gateThatPasses(),
     });
     reporter.registerHealer('TestFeature', vi.fn(async () => true));
@@ -84,6 +148,7 @@ describe('DegradationReporter — self-heal-first', () => {
     reporter.connectDownstream({
       telegramSender,
       alertTopicId: 1234,
+      notifyUser: true, // C1: these tests exercise the ALERT path; the gate now defaults OFF
       toneGate: gateThatPasses(),
     });
     reporter.registerHealer('TestFeature', vi.fn(async () => false));
@@ -101,6 +166,7 @@ describe('DegradationReporter — self-heal-first', () => {
     reporter.connectDownstream({
       telegramSender,
       alertTopicId: 1234,
+      notifyUser: true, // C1: these tests exercise the ALERT path; the gate now defaults OFF
       toneGate: gateThatPasses(),
     });
 
@@ -117,6 +183,7 @@ describe('DegradationReporter — self-heal-first', () => {
     reporter.connectDownstream({
       telegramSender,
       alertTopicId: 1234,
+      notifyUser: true, // C1: these tests exercise the ALERT path; the gate now defaults OFF
       toneGate: gateThatBlocks('B12_HEALTH_ALERT_INTERNALS'),
     });
     // No healer → proceeds to gate path
@@ -137,6 +204,7 @@ describe('DegradationReporter — self-heal-first', () => {
     reporter.connectDownstream({
       telegramSender,
       alertTopicId: 1234,
+      notifyUser: true, // C1: these tests exercise the ALERT path; the gate now defaults OFF
       toneGate: gateThatPasses(),
     });
 
@@ -156,6 +224,7 @@ describe('DegradationReporter — self-heal-first', () => {
     reporter.connectDownstream({
       telegramSender,
       alertTopicId: 1234,
+      notifyUser: true, // C1: these tests exercise the ALERT path; the gate now defaults OFF
       toneGate: gateThatPasses(),
     });
     reporter.registerHealer('TestFeature', vi.fn(async () => {
@@ -175,6 +244,7 @@ describe('DegradationReporter — self-heal-first', () => {
     reporter.connectDownstream({
       telegramSender,
       alertTopicId: 1234,
+      notifyUser: true, // C1: these tests exercise the ALERT path; the gate now defaults OFF
       // toneGate omitted — backwards compat path
     });
 

--- a/tests/unit/degradation-reporter.test.ts
+++ b/tests/unit/degradation-reporter.test.ts
@@ -125,6 +125,7 @@ describe('DegradationReporter', () => {
       feedbackSubmitter,
       telegramSender,
       alertTopicId: 42,
+      notifyUser: true, // C1: these tests exercise the ALERT path; the gate now defaults OFF
     });
 
     // Wait for async drain — use vi.waitFor to handle CPU-loaded environments
@@ -270,7 +271,7 @@ describe('DegradationReporter', () => {
 
       const feedbackSubmitter = vi.fn().mockResolvedValue({});
       const telegramSender = vi.fn().mockResolvedValue({});
-      reporter.connectDownstream({ feedbackSubmitter, telegramSender, alertTopicId: 99 });
+      reporter.connectDownstream({ feedbackSubmitter, telegramSender, alertTopicId: 99, notifyUser: true });
 
       const dispatched: NormalizedDegradationEvent[] = [];
       reporter.setRemediator({
@@ -307,7 +308,7 @@ describe('DegradationReporter', () => {
       // NO setRemediator() call — this is the backward-compat path.
       const feedbackSubmitter = vi.fn().mockResolvedValue({});
       const telegramSender = vi.fn().mockResolvedValue({});
-      reporter.connectDownstream({ feedbackSubmitter, telegramSender, alertTopicId: 7 });
+      reporter.connectDownstream({ feedbackSubmitter, telegramSender, alertTopicId: 7, notifyUser: true });
 
       reporter.report({
         feature: 'BackwardCompat',

--- a/upgrades/next/bounded-attention-notification-surface.md
+++ b/upgrades/next/bounded-attention-notification-surface.md
@@ -1,0 +1,39 @@
+## What Changed
+
+**Routine "housekeeping" notices no longer reach you, and there is now a ceiling on how many messages your agent can send into one conversation.**
+
+Measured on two agents on 2026-08-04: 64 and 65 messages into the attention conversation in 24 hours, of which 25 and 33 were pure housekeeping — "one of my background checks fell back to a simpler method and carried on", "memory is getting tight", "spawn refused". None named anything the operator could act on. The volume also *scaled with how degraded the system was*, so the agent got loudest exactly when its messages were worth least.
+
+Four changes, all defaults:
+
+- **`monitoring.degradationReporter.notifyUser` (new, default `false`)** — routine degradation reports stop being messaged to you. They are still written to the log, to disk, and to the feedback system, and your agent can read any of them back on request. Set to `true` to restore the old behaviour.
+- **`notificationBatcher` (new, top-level config block)** — the batching layer's settings were previously hardcoded and unreachable by any config. They now live in config: `enabled`, `summaryIntervalMinutes`, `digestIntervalMinutes`, `maxMessagesPerTopicPerHour` (default 4, `0` disables), `suppressionTtlHours`, `maxHoldHours`, `maxHeldItemsPerTopic`.
+- **A rolling limit of 4 batched messages per hour, per conversation.** Past it, further routine notices wait and send themselves as soon as there is room — nothing is dropped, and you are not told about the waiting.
+- **The "I already told them this" memory now survives a restart.** Previously it lived only in memory, so every restart re-sent notices you had already seen.
+
+**Untouched:** urgent notices, anything action-required, and attention-queue items. A limit on routine chatter must never become a limit on urgency, so `IMMEDIATE`-tier delivery does not enter any of this machinery.
+
+**Multi-machine:** only the machine that owns a conversation sends routine notices into it, so the limit is exact rather than multiplied by the number of machines.
+
+## Summary of New Capabilities
+
+- `monitoring.degradationReporter.notifyUser` — turn routine degradation reports to the operator back on.
+- `notificationBatcher.maxMessagesPerTopicPerHour` — tune or disable (`0`) the per-conversation hourly limit.
+- `notificationBatcher.enabled` — a batching kill-switch that is now actually honoured on the degradation path (it previously existed and was silently skipped there).
+- `logs/notification-ceiling.jsonl` — metadata-only audit of every hold, expiry, fold, and failed send.
+- New `getStats()` counters: `heldCount`, `heldSince`, `notOwnerSkipped`, `notOwnerExpired`, `heldExpired`, `foldedItems`, `rateStateReadable`.
+
+## What to Tell Your User
+
+Your agent will be noticeably quieter, and deliberately so. The messages that stop are the ones it could not act on either — "a background check fell back and carried on", "memory is getting tight". Everything that stops is still recorded, and you can ask your agent to read any of it back.
+
+Anything urgent still reaches you immediately, and so does anything needing your decision. If it goes *too* quiet for your taste, ask your agent to turn routine reports back on, or to raise the hourly limit — both are settings now, not code changes.
+
+If you run your agent on more than one machine, you will not get duplicate copies: whichever machine owns a conversation is the only one that sends routine notices into it.
+
+## Evidence
+
+- **Measured baseline:** 64 messages/24h into the attention topic on one agent (25 housekeeping), 65/33 on a second, against 781 recorded `[DEGRADATION]` events in the same window. Two agents with independent workloads showing the same proportions localised the cause to shared code.
+- **Control-verified gap:** no message-volume limit existed. Searched under seven candidate names across five sources, with the known-present symbols `topicCreationBudget`, `maxTopicsPerSource`, and `attentionTopicGuard` returning non-zero from the same grep to prove the search read the right tree. `topicCreationBudget` bounds *new topic creation*; messages into an existing topic were never covered.
+- **Tests:** 37 new unit assertions, every one paired with a control that fails when its guard is removed. Full suite green: 40,828 passing, 0 failing.
+- **Review:** 13 rounds against the constitutional conformance gate and 4 cross-model passes. The review changed the design rather than merely documenting it — the multi-machine approach was rewritten three times and ultimately replaced (dividing a budget across machines cannot produce an exact shared bound; enforcing on the single owning machine avoids the problem instead of approximating it), and the second-pass review caught three real implementation defects: a failed send being recorded as a delivery (silent loss plus 24h suppression), corrupt rate state minting fresh capacity by two routes, and a documented circuit-breaker that was counted but never consulted — and, on investigation, could never have fired at all. Both unreachable brakes were removed rather than repaired, on the principle that a documented brake that cannot fire is worse than none.

--- a/upgrades/side-effects/bounded-attention-notification-surface.md
+++ b/upgrades/side-effects/bounded-attention-notification-surface.md
@@ -1,0 +1,201 @@
+# Side-Effects Review — Bounded Attention-Notification Surface
+
+**Version / slug:** `bounded-attention-notification-surface`
+**Date:** `2026-08-04`
+**Author:** `echo`
+**Second-pass reviewer:** `required — see below (Phase 5 trigger: outbound-messaging block/allow surface)`
+
+## Summary of the change
+
+Bounds the volume of agent-initiated messages into an existing conversation, and stops routine degradation reports reaching the operator by default. Four changes, spec at `docs/specs/bounded-attention-notification-surface.md`: **C1** gates `DegradationReporter`'s Telegram alert behind `monitoring.degradationReporter.notifyUser` (default `false`; console, disk, and feedback records unchanged). **C2** makes `NotificationBatcher.enqueue()` honour `config.enabled` for `SUMMARY`/`DIGEST` and builds the batcher from config instead of hardcoded literals. **C3** persists the cross-batch suppression map to `<stateDir>/notification-suppression.json` with a 24h TTL. **C4** adds a rolling-window rate limit (default 4/topic/hour) enforced **only by the machine that owns the topic**, with held items self-releasing, bounded at 200 per topic, and a `maxHoldHours` terminal EXPIRY for persistently-blocked topics.
+
+Files actually changed: `src/messaging/NotificationBatcher.ts`, `src/monitoring/DegradationReporter.ts`, `src/commands/server.ts`, `src/core/PostUpdateMigrator.ts`, `src/scaffold/templates.ts`, and two new unit-test files plus edits to two existing ones.
+
+**Two honest corrections to an earlier draft of this line.** It listed `src/core/ConfigDefaults.ts`, which was **not** touched: the runtime defaults inline at the construction site and `migrateConfigBoundedNotificationSurface` surfaces the keys into existing configs, so a ConfigDefaults entry would be a third place for the same numbers to drift out of sync. It also claimed "unit/integration/e2e tests" — only **unit** tests were written. The Testing Integrity Standard's Tier 2/3 exist for features with API routes; this change adds none, and its production-wiring path is covered by the config→batcher tests in `bounded-notification-surface-migration.test.ts`. Claiming three tiers where one was written is exactly the description-not-the-thing failure this project keeps re-learning, so it is stated rather than left standing.
+
+Motivating measurement: 64 attention messages/24h on this agent (25 pure housekeeping), 65/33 on a second agent, against 781 recorded `[DEGRADATION]` events in the same period.
+
+## Decision-point inventory
+
+- `DegradationReporter.reportEvent()` → telegram branch — **modify** — adds a config gate; the event's own classification is untouched.
+- `NotificationBatcher.enqueue()` — **modify** — honours the existing (previously dead) `enabled` flag for batched tiers only.
+- `NotificationBatcher.flush()` → send decision — **add** — rolling-window count and topic-ownership check.
+- `notify()` in `server.ts` — **pass-through** — call sites and tiers unchanged.
+- Topic ownership (pool placement) — **pass-through** — this change *consumes* an existing ownership decision; it does not make or modify one.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+- **A genuinely important degradation is silenced by C1's default.** A `DegradationReporter` event that a user *would* have acted on no longer reaches them. Concrete shape: a fallback that silently changes behaviour the operator depends on — e.g. "quota readings now estimated rather than authoritative" — is now log-only. Mitigation is a routing argument, not a denial: paths that carry action-required content (attention queue, health-alert path, `IMMEDIATE`) are untouched. The residual risk is a producer that *should* be using those paths and instead emits a degradation event. That is a producer defect this change makes visible rather than creates, but it is a real over-block and is named as such.
+- **A non-owning machine's batched digest never reaches the operator.** With C4, items enqueued on a machine that does not own the topic are queued locally and expire on `maxHoldHours` if ownership never arrives. If a machine-local condition matters and is only reported via a batched digest on that machine, the operator does not see it. Content stays readable in that machine's logs.
+- **A burst of 5+ genuinely distinct, genuinely useful notices in one hour** is trimmed to 4 with the rest delayed. Delay, not loss.
+
+Not over-blocked: `IMMEDIATE`, attention-queue items, and ordinary conversational replies — none traverse this path.
+
+**On enforcing correct routing at the producer (re-review finding 5).** The re-review asked for a guard stopping a producer from emitting genuinely action-required content as a degradation event, where C1 now mutes it. Real risk, deliberately not solved here: distinguishing "actionable" from "routine" inside a degradation event means judging its content — precisely the brittle-authority shape §4 rejects, and this change's whole value is that it never reads a message. The correct home is the producer's own choice of surface. What this change does contribute is making misrouting *discoverable*: a muted event still lands in the log, on disk, and in the feedback system, so it is findable rather than lost. Producer-side guidance registered as follow-up. <!-- tracked: CMT-1184 -->
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **A chatty producer using `IMMEDIATE`.** `IMMEDIATE` is exempt by design, so a component mis-tiering routine output as urgent floods exactly as today. This change does not audit tier assignment.
+- **Volume across *different* topics — with the measured worst case, not a shrug.** The limit is per-topic. The re-review asked for a number rather than an acknowledgement: this agent has roughly 40 topics with any recent traffic, so the theoretical ceiling is 40 × 4 = **160 batched messages/hour**. The measured actual is 2.7/hour, because the binding constraint in practice is that housekeeping now stops at the source (C1) and only a handful of topics produce batched traffic at all. `topicCreationBudget` bounds *new* topic creation, so the surface cannot grow unboundedly. A global per-agent cap was considered and deliberately NOT added in this increment: it needs a second, coarser authority above the per-topic one, and the measured data does not yet show a value that would bind without suppressing legitimate multi-conversation activity. Registered rather than silently dropped. <!-- tracked: CMT-1184 -->
+- **Non-batcher senders.** Anything calling `telegram.sendToTopic` directly, or the attention-queue path, is unaffected. This bounds one lane, not every lane.
+- **The generator itself.** 781 degradation events/day continue to be produced; this change stops them being *messaged*, not *generated*. The memory pressure behind them is explicitly out of scope. <!-- tracked: CMT-1184 -->
+
+---
+
+## 3. Level-of-abstraction fit
+
+C4 is a **low-level primitive** and belongs there: it is a count at the single `sendDirect` chokepoint every batched message already passes through. Putting it higher (a reasoning layer deciding "is this message worth sending?") would add a failure mode — mis-classification — for a decision that needs none.
+
+It **uses** rather than re-implements two existing primitives: topic ownership comes from the pool's placement record (the same record the transfer protocol and duplicate reconciler act on), and the hold/coalesce machinery is the batcher's existing queue. No new component.
+
+It is deliberately **parallel to, not feeding**, the tone gate and response-review pipeline: those judge *content* of conversational replies; this counts *volume* of batched housekeeping. They share no decision and cannot shadow each other.
+
+C1 is a config gate at the emit site — the correct layer, since the alternative (filtering degradation text downstream) would mean pattern-matching message bodies, which is exactly the brittle-authority shape to avoid.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** `docs/signal-vs-authority.md`
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [x] **Yes — but the decision space is trivially small and content-blind.**
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+C4 holds delivery authority. It qualifies because it is the *least* brittle authority available: it never reads a message. Its inputs are an integer count, a timestamp list, and a lookup in an existing authoritative record. There is no parsing, no classification, no model call, and therefore no way for it to mis-judge a message's content — the failure class the standard exists to prevent.
+
+Its failure direction is bounded and safe: delay for housekeeping, and `IMMEDIATE` never enters the path at all. C1/C2/C3 are pure signal-suppression — they change what is delivered, never what is decided; no detector's verdict changes.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+**No new static heuristic at a competing-signals decision point.**
+
+Each decision here is an invariant with an enumerable domain, and the spec's `## Decision points touched` classifies all five as `invariant` with reasoning:
+
+- C1/C2 read a config boolean — one input, no competition.
+- C3 is an exact-match key lookup.
+- C4.1 *consumes* an ownership verdict made elsewhere; it does not weigh competing ownership signals.
+- C4.2 compares an integer to a fixed bound.
+
+The one place competing signals genuinely exist — "is the owner unreachable enough to justify claiming or bypassing?" — is **delegated to the existing stale-owner-release path**, which already carries its own evidence bar, quorum, and audit. This change deliberately does not add a second, weaker judgment at that point.
+
+---
+
+## 5. Interactions
+
+- **Shadowing.** C4 runs at `sendDirect`, *after* the tone gate and outbound advisory have already passed a message. It cannot shadow either: they judge content of conversational replies, and batched housekeeping does not traverse them. Conversely neither can shadow C4. C1 runs *before* `notify()` is called at all, so a suppressed degradation never reaches the batcher — the two compose as a filter then a limiter, not as competing gates.
+- **Double-fire.** The pre-existing `ALERT_COOLDOWN_MS` (1h per feature) in `DegradationReporter` and C4's per-topic limit both act on the same event stream. They do not conflict — the cooldown thins per-feature, the limit bounds per-topic total — but they *stack*, so effective volume is lower than either alone. Stated so nobody later "fixes" an apparent under-delivery by removing one.
+- **Races.** `sendTimes` and the suppression map are written from the flush path and read from the enqueue path within one process; both are single-threaded on the event loop. Cross-process is not a concern because C4.1 guarantees exactly one machine enforces per topic. The known race is a *transfer*: a topic moving machines mid-window means the new owner starts with its own `sendTimes`, permitting up to `limit` extra sends in the transfer hour. Bounded, one-off, and preferable to blocking a transfer on notification state.
+- **Feedback loops.** C3's failure path reports a degradation event, which is itself a candidate notification. Loop is broken by C1 (degradation alerts default off) and bounded by C4 even if enabled. Explicitly checked, because a suppression-layer failure that floods via the suppression layer would be the worst possible bug here.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** none — all state is per-agent `stateDir`.
+- **Install base:** yes, and this is the significant one. Every agent's operator receives **less**. That is the intent, and it is the reason the change was routed through operator approval rather than shipped as a default tweak. Operator confirmed (Justin, topic 7848, 2026-08-04, `"Silent"`).
+- **External systems:** Telegram/Slack send volume drops. No API contract change.
+- **Persistent state:** one new file, `<stateDir>/notification-suppression.json`. Self-creating, self-expiring, safe to delete.
+- **Timing:** C4 depends on wall-clock for the rolling window. Clock skew on one machine affects only that machine's topics, since it is the sole enforcer.
+- **Operator surface (Mobile-Complete):** **no new operator-facing actions.** Every lever is a config key the agent sets conversationally on request ("turn the housekeeping back on"), which is already phone-complete. No PIN-gated route, no form, no approval flow is added.
+
+---
+
+## 6b. Operator-surface quality
+
+**No operator surface — not applicable.** This change stages no `dashboard/*` file, no approval page, and no grant/revoke/secret-drop form. The `getStats()` additions (`heldCount`, `heldSince`, `notOwnerSkipped`, `notOwnerExpired`, `ownershipBypasses`) feed the existing telemetry collector; no renderer is added or modified.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+Declared per surface — this was the most-revised part of the design, redesigned three times under review.
+
+- **C4 rate limit — `unified`, via single-enforcer ownership.** Only the machine owning a topic sends batched notifications into it, so the bound is exact rather than approximated. Ownership is a local read of the replicated placement record, not a call on the send path. Three earlier drafts divided a budget by machine count and were rejected: approximating a shared quantity from N independent local views cannot produce an exact shared bound.
+- **C3 suppression state — `machine-local BY DESIGN`.** `machine-local-justification: physical-credential-locality` — the key embeds a Telegram forum topic id namespaced by the bot token that machine holds, so the key is meaningless elsewhere. Consequence: a repeat notice can cross machines once; C4's single enforcer bounds the total regardless.
+- **C1 / C2 — `unified` by configuration.** Config booleans read identically on every machine of the agent. No new replication path.
+
+**User-facing notices — one-voice gating:** yes, and it is the core mechanism, not an add-on. Batched notices are gated on ownership so two machines cannot both emit into one topic. `IMMEDIATE` *consults* ownership (claim-first when the owner is unreachable) but is never blocked by it.
+
+**Durable state on topic transfer:** `sendTimes` does not follow a transfer; the new owner starts fresh, permitting up to `limit` extra sends in that hour. Named in §5 as an accepted bounded race. Held items on the old machine expire via `maxHoldHours` rather than stranding indefinitely.
+
+**Generated URLs:** none.
+
+**Known deviation, escalated rather than resolved here:** for an `IMMEDIATE` notice where the owner is both unreachable and unclaimable, **Ownership-Gated Side Effects** and **The Agent Is Always Reachable** genuinely conflict. Resolved toward reachability (an unproved-ownership send costs at most a visibly-stamped duplicate; the alternative costs an operator not learning of an urgent condition). The deviation is narrow, attributed, and audited via `ownershipBypasses`. Which standard should win is registered as a constitution-level question. <!-- tracked: CMT-1184 -->
+
+---
+
+## 8. Rollback cost
+
+- **Hot-fix release:** revert the squash commit, ship as a patch. No code coupling outside the listed files.
+- **Data migration:** none. `notification-suppression.json` is self-creating and safe to delete; nothing reads it after revert.
+- **Agent state repair:** none. Config keys added by `migrateConfig()` become inert on revert; they are additive and do not overwrite operator values.
+- **User visibility during rollback:** operators would resume receiving housekeeping — a return to today's behaviour, not a new regression.
+- **Config-only partial rollback, no release needed:** `notifyUser: true` restores degradation alerts; `maxMessagesPerTopicPerHour: 0` disables the limiter (explicit guard, verified — without it `0` would hold everything, which an earlier draft got wrong).
+
+---
+
+## Conclusion
+
+The review changed the design substantially rather than merely documenting it. The multi-machine approach was rewritten three times and ultimately replaced: single-enforcer ownership makes the distributed problem *not arise* instead of bounding it approximately. The failure direction was inverted for the batched lane — an earlier draft's "when in doubt, deliver" was correct for urgent messages and exactly backwards for housekeeping, where an extra message is the harm being removed. Two proposed operator-facing "N notices held" lines were removed, the second because it was itself unactionable housekeeping inside a change built to eliminate unactionable housekeeping.
+
+The most significant process finding is not about this change: after ten rounds of section-by-section patching, the spec described two mutually exclusive architectures while the per-standard conformance gate returned **clean**. Only the whole-document cross-model reviewer caught it. The spec was rewritten from scratch and the tooling limitation recorded in its Review history.
+
+Flagged for follow-up, not resolved here: the `IMMEDIATE` ownership deviation (constitution-level), the cross-topic volume gap in §2, and the memory pressure generating the events. All tracked. <!-- tracked: CMT-1184 -->
+
+**Status: clear to build once the spec carries `approved: true`.** Not clear to commit before then — the pre-commit gate refuses, correctly, since this changes what every operator receives.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** cross-model independent read (`codex-cli:gpt-5.5`) over this artifact plus the implementation.
+**Independent read of the artifact: CONCERN raised — three real defects, all fixed.**
+
+Note on the reviewer: the six internal Claude reviewers were not spawned as subagents (this session operates under a standing instruction not to spawn agents unless the operator requests it, and the operator did not). The second pass was performed by an independent non-Claude model reading the artifact and the code together. That is a genuine independent read, and it is disclosed rather than described as the full panel.
+
+It found three defects that every prior review — and my own tests — had missed:
+
+- **A failed send counted as a delivery.** `sendDirect()` swallowed sink failures while `flush()` still dequeued the item, wrote suppression, and charged a rate-limit slot. A failed Telegram send therefore dropped the notice *and* suppressed it for 24h: silent loss, and a direct contradiction of the spec's own "presence follows delivery" invariant. **Fixed** — the sink now reports success, and state changes only on a confirmed send.
+- **Corrupt rate state eventually minted capacity.** `rate-state-unreadable` held correctly, but the aged-hold path collapsed it into a send, and a successful write cleared the unreadable flag while the map being written was the empty one that had failed to load. Two separate routes around the fail-closed rule. **Fixed** — such holds expire without sending, and the flag latches for the process lifetime.
+- **The breaker was counted but never consulted.** The spec claimed three collapses drop a topic to DIGEST cadence for 24h; nothing read that state. Investigating produced a sharper finding: the collapse itself was **unreachable**, because the 1h window always clears before the 6h hold matures. **Both were removed rather than repaired** — a documented brake that cannot fire is worse than none, since a reader records it as protection that exists.
+
+It also asked for the "exact" multi-machine guarantee to be qualified by placement consistency (**done** — it is now stated as inherited from the placement record, with the 2× split-brain case named), and noted the cross-topic volume gap, which was already disclosed in §2 and to the operator before approval.
+
+Every fix carries a regression test with a control that fails when the guard is removed.
+
+---
+
+## Evidence pointers
+
+- Spec: `docs/specs/bounded-attention-notification-surface.md` (Review history table: 13 conformance rounds, 3 cross-model passes).
+- Plain-English overview: `docs/specs/bounded-attention-notification-surface.eli16.md`.
+- Baseline measurement method: `.instar/telegram-messages.jsonl` filtered to the attention topic over 24h, classified by message shape; `logs/server.log` grepped for `[DEGRADATION]`.
+- Control for the "no existing limit" negative: `topicCreationBudget`, `maxTopicsPerSource`, `attentionTopicGuard` all return non-zero from the same grep over the running dist, proving the search read the right tree.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+**No agent-authored-artifact defect — not applicable** to the defect-fix arm.
+
+**The self-action arm DOES apply**: C4 adds a self-triggered controller (a hold-and-retry loop that re-attempts held flushes without operator involvement).
+
+- **`defectClass`** — `unbounded-self-action`
+- **`closure`** — `guard`
+- **`guardEvidence`** — enforcement type `ratchet`; citation `tests/unit/self-action-convergence.test.ts` plus the burst-invariant test asserting the limit holds under a 100-event burst.
+
+**Convergence argument.** *Control-loop edge:* held items → retry on window open → send → consume a window slot. *Steady-state bound:* the loop's output is capped at `maxMessagesPerTopicPerHour` per topic by construction; the input (queued items) is capped at `maxHeldItemsPerTopic`, so both sides of the loop are bounded and the queue cannot grow without bound. *Settling brakes:* retries are scheduled for the computed next-slot instant rather than polled, so attempts are O(1) per released slot rather than O(1) per minute; and `maxHoldHours` gives the hold a terminal state — a topic blocked for a persistent reason drops its backlog with an audit row and a per-reason counter, sending nothing.
+
+*Two brakes claimed in an earlier draft were REMOVED, not repaired.* That draft cited a `maxHoldHours` collapse-to-send plus a breaker counting three collapses. Writing their tests proved both unreachable: the rolling window (1h) is far shorter than `maxHoldHours` (6h), so a rate-limit hold always drains before it can mature, and the only holds that persist that long are ones that must never age into a send. The collapse could only have fired where it was forbidden, and the breaker downstream of it could never trip. Citing them as convergence evidence would have been citing protection that does not exist — the precise defect class this project has been burned by. The convergence argument above rests only on brakes that are reachable and tested.


### PR DESCRIPTION
## ELI16 — your agent was getting louder the worse things got; now it gets quieter

Your agent sends you two kinds of message. One kind needs you: a decision, an approval, something broken you can fix. The other kind is housekeeping — "one of my background checks fell back to a simpler method and carried on", "memory is getting tight". Measured over 24 hours on two different agents, roughly 40% of everything reaching the operator was the second kind, and none of it named anything they could do.

The uncomfortable part is *why* it piled up. When the machine is struggling, those background checks fail more often, so the agent reports more — meaning it talks most when it has least worth saying. And nothing capped it. There was already a hard limit on how many new conversations an agent could start by itself, added after an earlier flood, but nobody had ever added the equivalent limit for messages into a conversation that already existed. There was even an off-switch in the code that three other places read and obeyed, while this particular path skipped it — so it looked like a working lever and wasn't one.

This change does four things. Housekeeping stops being sent to you by default (still written to the log, still readable on request). A limit of four messages an hour per conversation, past which the rest wait their turn and send themselves when there's room — nothing is thrown away. The agent's memory of "I already told them this" now survives a restart instead of resetting. And that dead off-switch is made real, so next time it's a setting rather than a release.

Urgent messages are deliberately outside all of it, and so is anything needing your decision. If you run your agent on several machines you won't get duplicates: whichever machine owns a conversation is the only one that sends routine notices into it.

Everything here is reversible with a setting — turn the reports back on, raise the limit, or set it to zero to remove it entirely.

## What this fixes

Operator report, 2026-08-04: *"the attention messages have become completely unmanageable for pretty much all INSTAR agents. We need to lock this down now."*

Measured on two agents that same day:

| | Echo | Codey |
|---|---|---|
| Messages into the attention topic, 24h | 64 | 65 |
| …of which pure housekeeping | 25 | 33 |

Housekeeping means `⚠ X has been on its heuristic fallback for ~16m`, `Using Y in the meantime — everything else is working fine`, `Memory is getting tight`. None of it named an action the operator could take. Two agents with independent workloads showing the same proportions localised the cause to shared code.

The load-bearing part: **the volume scales with how degraded the system is.** The agent got loudest exactly when its messages were worth least.

## Why it couldn't be turned off

Verified against the running dist, each negative control-checked (`topicCreationBudget`, `maxTopicsPerSource`, `attentionTopicGuard` all return non-zero from the same grep, proving the search read the right tree):

- The batcher was constructed from three hardcoded literals — no operator setting could reach them.
- `enqueue()` never read `config.enabled`; three `TelegramAdapter` callsites *do*, so the flag looked like a working lever and wasn't one here.
- No message-volume limit existed under any of seven candidate names across five sources. `topicCreationBudget` bounds *new topic creation*; messages into an existing topic were never covered.
- Suppression state was in-memory only, so every restart re-sent notices already seen.

## The change

- **C1** — `monitoring.degradationReporter.notifyUser`, default `false`. Console, disk, and feedback records unchanged; only delivery stops.
- **C2** — `enqueue()` honours `enabled`; the batcher is built from a top-level `notificationBatcher` config block.
- **C3** — suppression persists to `<stateDir>/notification-suppression.json` with a TTL.
- **C4** — rolling-window limit (default 4/topic/hour) enforced **only by the machine that owns the topic**.

`IMMEDIATE` never enters any of this. A kill-switch on batching must not become a kill-switch on urgency.

## What review changed

**The multi-machine design was replaced, not tuned.** Three drafts divided a budget across machines; each was better arithmetic with a longer caveat list. That growth was the signal: approximating a shared quantity from N independent local views cannot produce an exact shared bound. Single-enforcer ownership makes the distributed problem *not arise*.

**The second-pass review caught three real defects**, all fixed with regression tests:

1. **A failed send was recorded as a delivery** — a failed Telegram send dropped the item *and* suppressed it for 24h. Silent loss, contradicting this code's own "presence follows delivery" invariant.
2. **Corrupt rate state minted fresh capacity** by two separate routes.
3. **A documented circuit breaker was counted but never consulted** — and, on investigation, could never have fired at all: the 1h window always clears before the 6h hold matures. Both unreachable brakes were **removed rather than repaired**. A documented brake that cannot fire is worse than none, because a reader records it as protection that exists.

**One process finding worth flagging beyond this PR:** after ten rounds of section-by-section patching, the spec described two mutually exclusive architectures while the per-standard conformance gate returned **clean**. Only the whole-document reviewer caught it. A clean per-standard pass is not evidence of a coherent document.

## Known limits, stated rather than buried

- The limit is **per-topic**. Theoretical ceiling on this agent is ~40 topics × 4 = 160/hour against a measured actual of 2.7/hour. A global cap is registered, not silently dropped.
- The multi-machine guarantee is **exact under a single agreed owner; worst case 2× during a placement split-brain**. It inherits the same invariant the transfer protocol and duplicate reconciler already rely on.
- **A knowing deviation** from *Ownership-Gated Side Effects*: an `IMMEDIATE` notice whose owner is unreachable *and* unclaimable is sent directly, stamped and audited. That standard and *The Agent Is Always Reachable* genuinely conflict there; resolved toward reachability and registered as a constitution-level question.

## Evidence

- Spec: `docs/specs/bounded-attention-notification-surface.md` — 13 conformance-gate rounds, 4 cross-model passes (SERIOUS → SERIOUS → MINOR → MINOR).
- Side-effects review: `upgrades/side-effects/bounded-attention-notification-surface.md`.
- 37 new unit assertions, **every one paired with a control that fails when its guard is removed**. Two of my own controls failed on first run and caught a bad test (numbered payloads aren't distinct to a deduper that strips digits).
- Full unit suite green: **40,828 passing, 0 failing**.

Operator-approved 2026-08-04 (topic 7848) after reading the plain-English overview, including both disclosed limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)