### PR TITLE
fix(claim-check): absence of gh data is not "no claims found"

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T14-02-43-665Z-claimcheck-absence-is-not-zero.json
+++ b/.instar/instar-dev-decisions/2026-08-14T14-02-43-665Z-claimcheck-absence-is-not-zero.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T14:02:43.665Z",
+  "slug": "claimcheck-absence-is-not-zero",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 37,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/devClaimCheck.ts"
+    ],
+    "addedLines": 32,
+    "deletedLines": 5
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/claimcheck-absence-is-not-zero.eli16.md
+++ b/docs/specs/claimcheck-absence-is-not-zero.eli16.md
@@ -1,0 +1,36 @@
+# Claim-check: absence of data is not "nobody claims these files" — Plain-English Overview
+
+> The one-line version: the tool that warns you when another agent is already editing your files could report a cheerful "all clear" after learning nothing at all, and now it says "I could not check" instead.
+
+## The problem in one breath
+
+Before an agent starts editing files, it can run a claim check that asks GitHub whether any open or recently-merged pull request already touches those same files. The point is to stop two agents rewriting each other's work. But when the GitHub query came back with **no output at all** — no error, just nothing — the tool treated that as "no pull requests touch these files" and printed a green tick. Silence and "nobody is here" looked identical, and the reassuring one was chosen.
+
+## What already exists
+
+- **The claim check itself** — takes a list of files you plan to edit, asks GitHub for open and recent pull requests, and lists any that overlap. Advisory: it prints warnings, it does not stop you.
+- **A loud failure path** — if the GitHub command genuinely errors (not installed, no network, not logged in), the tool already says so plainly: *"PR overlap NOT checked; spec scan only."* That part worked correctly.
+- **A separate spec scan** — matches keywords against design documents, so even with GitHub unavailable you still get partial information.
+- **A strict mode** — used by automation, which exits non-zero when overlaps are found or when the check could not be completed.
+
+## What this adds
+
+**The tool now distinguishes "I asked and the answer was none" from "I asked and got nothing back."** GitHub's JSON mode always returns a real answer — zero results is an empty list, two characters long, never an empty response. So an empty response on an otherwise successful call means the answer never arrived. The tool now treats that as unknown and routes it into the same loud "could not check" message the error path already used, instead of quietly turning it into zero.
+
+Secondary changes:
+
+- The same protection applies to any reply that is not a list at all — a stray object, a bare word, nothing. Previously all of these collapsed into "no claims."
+- Both queries are covered, the open pull requests **and** the recently-merged ones. Guarding only the first would have left the identical bug one line lower.
+- The check sits at two places: at the boundary that talks to GitHub, and at the point where the answer is consumed — so it holds even when the GitHub call is swapped out, as it is in tests.
+
+## The safeguards
+
+**A genuine "nothing found" still reports success.** This is the important one. A guard that shouted on every run would be useless, and indistinguishable from a correct guard whenever the bug is present. A real empty list still prints the green all-clear, and there is a test that fails if that ever stops being true.
+
+**No new reporting channel.** The existing warning line was already correct and already loud; it simply was never reached on this path. Rather than inventing a second way to complain, absence is routed into the message that was always meant to carry it.
+
+**Advisory stays advisory.** Nothing here blocks a commit or changes an exit code on the normal path. Strict mode continues to refuse to bless a claim space it could not actually see, which it already did for errors and now also does for silence.
+
+## Why it matters
+
+This tool exists to prevent two agents editing the same files at the same time. A false "all clear" is not a cosmetic wart — it is the exact collision the tool was built to prevent, delivered with a green tick and the confidence of a completed check.

--- a/docs/specs/claimcheck-absence-is-not-zero.side-effects.md
+++ b/docs/specs/claimcheck-absence-is-not-zero.side-effects.md
@@ -1,0 +1,73 @@
+# Side-Effects Review — claim-check: absence of data is not zero results
+
+**Version / slug:** `claimcheck-absence-is-not-zero`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent)`
+**Second-pass reviewer:** `not required (Tier 1, advisory dev CLI, no authority surface)`
+
+## Summary of the change
+
+`instar dev:claim-check` asks GitHub which open/recently-merged PRs touch the files an agent is about to edit. `defaultGhJson` parsed `stdout || 'null'`, so **empty stdout on a zero exit** produced `null`; the caller then did `… as ClaimPr[] ?? []`, converting absence into an empty PR list. Nothing threw, so `ghDegraded` stayed null and the command printed a green `✓ No claims found` having learned nothing. Two files change: `src/commands/devClaimCheck.ts` (reject empty stdout at the gh boundary; add `asPrList()` which throws on any non-array, applied to BOTH the open and merged queries) and `tests/unit/dev-claim-check.test.ts` (+4 cases). Absence is routed into the pre-existing loud degrade path rather than a new channel.
+
+## Decision-point inventory
+
+One decision point is touched, and it is **modified, not added**: "did the claim check learn anything?" Previously that decision had two outcomes (error → degrade; anything else → trust the list). It now has three inputs collapsing to the same two outcomes — error → degrade, **absence → degrade**, real array → trust. No decision point is added or removed. The advisory verdict itself (overlap vs no overlap) is untouched.
+
+## 1. Over-block
+
+Could this refuse where it should permit? The realistic over-block is treating a genuine empty result as absence, which would make the tool cry "could not check" on every clean run and train readers to ignore it. Explicitly guarded: `gh … --json <fields>` emits `[]` for zero results, and `Array.isArray([])` is true, so a real zero passes straight through. A dedicated test (`CONTROL: a GENUINE zero (gh returns []) still prints the green all-clear`) fails if that ever regresses. This is advisory output, not a gate, so even a wrong degrade costs a warning line, never a blocked action.
+
+## 2. Under-block
+
+Could this permit where it should refuse? The previous behaviour WAS the under-block: absence permitted a confident all-clear. Remaining under-block surface: a gh reply that is a well-formed array of the wrong shape (e.g. missing `files`) still passes. That was already handled — `findPrOverlaps` treats a PR with no `files` as simply no overlap, with an existing test. Not widened here.
+
+## 3. Level-of-abstraction fit
+
+The guard sits at the data boundary (is this a list?) rather than in the reporting layer (should I print green?). That is the right level: the reporting logic already keys off `ghDegraded`, which is exactly the "I could not check" concept. Pushing the check up into the printer would have duplicated the concept; pushing it down into `gh` argument construction would not have covered injected implementations.
+
+## 4. Signal vs authority compliance
+
+This is **signal only**. The command is advisory: it prints and returns 0 on the normal path. It gains no authority over commits, pushes, or any agent action. Strict mode's existing behaviour (exit 1 when the claim space could not be verified) is unchanged in kind — it already did this for errors; silence now reaches the same code path. No new blocking authority is created anywhere.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No judgment point is introduced. `Array.isArray()` is a deterministic type test with no heuristic, no model call, and no tunable threshold. There is nothing here for a floor to constrain.
+
+## 5. Interactions
+
+Blast radius measured, not assumed: exactly two importers of `devClaimCheck` — `src/cli.ts` (the `dev:claim-check` subcommand) and the unit test. No scheduler, sentinel, gate, or route consumes it. `asPrList` is module-private. The `ClaimCheckDeps.ghJson` interface signature is unchanged, so any existing injected implementation keeps working; an implementation that previously returned `null` now surfaces as a loud degrade instead of a silent zero, which is the intended behaviour change.
+
+## 6. External surfaces
+
+The only external surface is the `gh` CLI. No new invocation, flag, network call, or credential is introduced — the change is purely in how an existing reply is interpreted. No new files are written, no state is persisted, no telemetry is emitted.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+The operator-visible text is the pre-existing line `⚠ gh unavailable (<reason>) — PR overlap NOT checked; spec scan only.` The new reason strings are plain English and name the actual condition: `gh exited 0 but produced no output — PR overlap is UNKNOWN, not zero.` and `gh returned no usable <open|merged>-PR list (<what arrived>) — PR overlap is UNKNOWN, not zero.` No raw paths, no stack traces, no internal field names.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+No issue identified. This is a local developer CLI with no shared state, no lease, no replication, and no cross-machine surface. It reads from GitHub and prints to the terminal of whichever machine invoked it.
+
+## 8. Rollback cost
+
+Very low. Two files, one commit, no migration, no persisted state, no config flag. Reverting restores the previous behaviour exactly; nothing downstream will have recorded anything that depends on the new semantics.
+
+## Conclusion
+
+Ship. The change narrows a false-negative in an advisory instrument, is guarded in both directions by tests, adds no authority, and touches nothing beyond one CLI command and its test.
+
+## Second-pass review (if required)
+
+Not required — Tier 1, advisory surface, no authority or safety-invariant path (`classify-tier.mjs` matched none of the 10 safety-invariant patterns for this file).
+
+## Evidence pointers
+
+- Defect verified in source before any edit: `defaultGhJson` `JSON.parse(stdout || 'null')` + caller `?? []`, with the green-tick branch gated on `total === 0 && !ghDegraded`.
+- Negative control executed: reverting `asPrList` to the old `?? []` semantics makes **3 of the 4** new tests fail; restoring makes them pass. Source restored byte-identical (sha + size verified, zero markers left).
+- Positive control: the genuine-`[]` case passes under BOTH old and new semantics, proving the guard distinguishes absence from zero rather than always firing.
+- Verified on main's dependency set in a dedicated worktree: `tsc --noEmit` exit 0; `tests/unit/dev-claim-check.test.ts` 14/14 (was 10).
+
+## Class-Closure Declaration (display-only mirror)
+
+Class: "a lookup that returns nothing rendered as a confident zero." This change closes it at both call sites in this command and at the gh boundary. It does NOT claim to close the class repo-wide — other `?? []` coercions over external data may exist and were not audited here.

--- a/src/commands/devClaimCheck.ts
+++ b/src/commands/devClaimCheck.ts
@@ -177,8 +177,16 @@ function defaultGhJson(args: string[]): Promise<unknown> {
   return new Promise((resolve, reject) => {
     execFile('gh', args, { maxBuffer: 32 * 1024 * 1024, timeout: 30_000 }, (err, stdout) => {
       if (err) return reject(err);
+      // `gh … --json <fields>` ALWAYS emits JSON — zero results is the two-byte array `[]`, never
+      // an empty string. So empty stdout on a ZERO EXIT is absence of data, not absence of PRs.
+      // The old code did `JSON.parse(stdout || 'null')`, which turned that into `null` and let the
+      // caller coerce it to `[]` — a confident "no claims" built out of nothing.
+      const raw = (stdout ?? '').trim();
+      if (raw === '') {
+        return reject(new Error('gh exited 0 but produced no output — PR overlap is UNKNOWN, not zero.'));
+      }
       try {
-        resolve(JSON.parse(stdout || 'null'));
+        resolve(JSON.parse(raw));
       } catch (parseErr) {
         reject(parseErr instanceof Error ? parseErr : new Error(String(parseErr)));
       }
@@ -189,6 +197,25 @@ function defaultGhJson(args: string[]): Promise<unknown> {
 function isoDaysAgo(days: number): string {
   const d = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
   return d.toISOString().slice(0, 10);
+}
+
+/**
+ * A `gh --json` call that SUCCEEDS must still hand back a JSON ARRAY.
+ *
+ * Anything else — `null` from empty stdout, an object, a string — is ABSENCE OF DATA, and coercing
+ * it to `[]` makes "we learned nothing" indistinguishable from "nobody claims these paths". That is
+ * the whole defect: this tool exists to tell an agent whether a sibling already owns the files it is
+ * about to touch, so a false "✓ No claims found" is exactly the two-agents-one-branch collision it
+ * is supposed to prevent.
+ *
+ * Throwing here routes absence into the EXISTING degrade path, which is already loud, rather than
+ * inventing a second reporting channel. A genuine zero — `[]` — passes straight through, which is
+ * what keeps this a guard rather than a permanent alarm.
+ */
+function asPrList(value: unknown, label: 'open' | 'merged'): ClaimPr[] {
+  if (Array.isArray(value)) return value as ClaimPr[];
+  const got = value === null || value === undefined ? 'no output' : typeof value;
+  throw new Error(`gh returned no usable ${label}-PR list (${got}) — PR overlap is UNKNOWN, not zero.`);
 }
 
 /**
@@ -215,13 +242,13 @@ export async function runDevClaimCheck(options: DevClaimCheckOptions): Promise<n
   let ghDegraded: string | null = null;
   if (options.paths.length > 0) {
     try {
-      openPrs = (await ghJson([
+      openPrs = asPrList(await ghJson([
         'pr', 'list', '--repo', repo, '--state', 'open', '--limit', '100', '--json', fields,
-      ])) as ClaimPr[] ?? [];
-      mergedPrs = (await ghJson([
+      ]), 'open');
+      mergedPrs = asPrList(await ghJson([
         'pr', 'list', '--repo', repo, '--state', 'merged', '--limit', '50', '--json', fields,
         '--search', `merged:>=${isoDaysAgo(mergedDays)}`,
-      ])) as ClaimPr[] ?? [];
+      ]), 'merged');
     } catch (err) {
       // Advisory tool: a network/gh failure degrades to spec-scan-only, LOUDLY.
       ghDegraded = err instanceof Error ? err.message : String(err);

--- a/tests/unit/dev-claim-check.test.ts
+++ b/tests/unit/dev-claim-check.test.ts
@@ -126,4 +126,76 @@ describe('runDevClaimCheck', () => {
     expect(code).toBe(2);
     expect(err.join('\n')).toContain('Nothing to check');
   });
+
+  /**
+   * ACT-1469 — gh SUCCEEDING with no usable output must not read as "nobody claims these paths".
+   *
+   * The old code did `JSON.parse(stdout || 'null')` and then `… as ClaimPr[] ?? []`, so empty
+   * stdout on a ZERO EXIT became an empty PR list, nothing threw, `ghDegraded` stayed null, and the
+   * tool printed a GREEN "✓ No claims found" having learned nothing. The error path was already
+   * loud; its success-with-no-data sibling was wide open.
+   *
+   * Coverage note, stated rather than implied: these drive the CALLER guard through the injectable
+   * `ghJson` seam, which is the layer that protects every implementation. The matching change inside
+   * `defaultGhJson` (empty stdout → reject) is defence-in-depth on the real `gh` boundary and is
+   * exercised only indirectly — it turns absence into the throw that the degrade test above pins.
+   */
+  it('THE DEFECT: gh returns nothing on success → degrades LOUDLY, never a green all-clear', async () => {
+    const { out, err, output } = capture();
+    // `null` is exactly what `JSON.parse(stdout || 'null')` produced from empty stdout.
+    const deps = { ghJson: async () => null as unknown, readSpecs: () => [] };
+    const code = await runDevClaimCheck({ paths: ['src/core/Config.ts'], output, deps });
+
+    expect(err.join('\n')).toContain('PR overlap NOT checked');
+    // The assertion that would have failed before the fix: no confident zero.
+    expect(out.join('\n')).not.toContain('No claims found');
+    expect(code).toBe(0); // advisory
+    // strict refuses to bless a claim space it could not see
+    expect(await runDevClaimCheck({ paths: ['src/core/Config.ts'], strict: true, output: capture().output, deps })).toBe(1);
+  });
+
+  it('CONTROL: a GENUINE zero (gh returns []) still prints the green all-clear', async () => {
+    // Without this the fix could be a guard that always fires — indistinguishable from a correct
+    // one on the defect case, and wrong on every real clean run.
+    const { out, err, output } = capture();
+    const code = await runDevClaimCheck({
+      paths: ['src/core/Config.ts'],
+      output,
+      deps: { ghJson: async () => [], readSpecs: () => [] },
+    });
+    expect(code).toBe(0);
+    expect(out.join('\n')).toContain('No claims found');
+    expect(err.join('\n')).not.toContain('PR overlap NOT checked');
+  });
+
+  it('a non-array shape (object/string) is absence of data, not zero results', async () => {
+    for (const shape of [{ prs: [] } as unknown, 'null' as unknown, undefined as unknown]) {
+      const { out, err, output } = capture();
+      const code = await runDevClaimCheck({
+        paths: ['src/core/Config.ts'],
+        output,
+        deps: { ghJson: async () => shape, readSpecs: () => [] },
+      });
+      expect(code).toBe(0);
+      expect(err.join('\n')).toContain('PR overlap NOT checked');
+      expect(out.join('\n')).not.toContain('No claims found');
+    }
+  });
+
+  it('the MERGED call is guarded too, not just the open one', async () => {
+    // Both call sites must be covered — guarding only the first would leave the second able to
+    // coerce absence into zero, which is the same defect one line down.
+    const { out, err, output } = capture();
+    const code = await runDevClaimCheck({
+      paths: ['src/core/Config.ts'],
+      output,
+      deps: {
+        ghJson: async (args) => (args.includes('open') ? [] : (null as unknown)),
+        readSpecs: () => [],
+      },
+    });
+    expect(code).toBe(0);
+    expect(err.join('\n')).toContain('PR overlap NOT checked');
+    expect(out.join('\n')).not.toContain('No claims found');
+  });
 });

--- a/upgrades/next/claimcheck-absence-is-not-zero.md
+++ b/upgrades/next/claimcheck-absence-is-not-zero.md
@@ -1,0 +1,22 @@
+## What Changed
+
+The pre-build claim check could report a clean "no claims found" after learning nothing at all.
+
+- **Empty output from GitHub is now treated as unknown, not as zero results.** The gh boundary parsed empty stdout into a null value on a zero exit, and the caller coerced that into an empty pull-request list. Nothing threw, so the degrade flag stayed clear and the all-clear branch fired.
+- **Both queries are guarded** — the open pull requests and the recently-merged ones. Guarding only the first would have left the identical defect one line lower.
+- **Any non-list reply degrades** — an object, a bare string, nothing at all. Previously every one of these collapsed into "no claims".
+- **Absence routes into the existing loud warning** rather than a new reporting channel. That warning was already correct; it simply was never reached on this path.
+
+## What to Tell Your User
+
+Before an agent edits files, it can check whether another agent already has open work touching the same files. When that check could not reach GitHub properly, it used to print a green all-clear instead of admitting it had not checked — which is exactly the collision the check exists to prevent, delivered with a tick.
+
+It now says plainly that the overlap was not checked, and strict callers refuse to bless a claim space they could not see. A genuinely clean run still prints the green all-clear, so this is not a new source of noise.
+
+## Summary of New Capabilities
+
+None. This narrows a false-negative in an existing advisory command; no new command, flag, route, or setting.
+
+## Evidence
+
+Defect verified in source before any edit, then proven in both directions: reverting the guard to the old coercion makes three of the four new tests fail, and restoring it makes them pass. The fourth is the control — a genuinely empty result still prints the green all-clear under both old and new behaviour, which is what makes this a guard rather than a permanent alarm. Source restored byte-identical after the mutation, with sha and size verified and no markers left behind. Typecheck clean and 14 of 14 tests passing in the claim-check suite, up from 10, verified in a dedicated worktree on the mainline dependency set rather than inherited from another tree.


### PR DESCRIPTION
## ELI16 — the "all clear" that had checked nothing

Before an agent starts editing files, it can run a claim check that asks GitHub whether any open or recently-merged pull request already touches those same files. The point is to stop two agents rewriting each other's work.

But when the GitHub query came back with **no output at all** — no error, just nothing — the tool treated that as "no pull requests touch these files" and printed a green tick. Silence and "nobody is here" looked identical, and the reassuring one was chosen.

It now tells them apart. GitHub's JSON mode always returns a real answer: zero results is an empty list, two characters long, never an empty response. So empty output on an otherwise successful call means the answer never arrived — that is now reported as "I could not check", through the same loud warning the genuine-error path already used, instead of being quietly turned into a zero.

The safeguard that matters: **a genuinely empty result still prints the green all-clear.** A guard that shouted on every run would be useless, and would look identical to a correct one whenever the bug is present. There is a test that fails if that ever stops being true.

## The defect

`instar dev:claim-check` exists to tell an agent whether a sibling already owns the files it is about to touch. It could print a green `✓ No claims found` after learning nothing at all.

`defaultGhJson` did `JSON.parse(stdout || 'null')`, so **empty stdout on a zero exit** became `null` and threw nothing. The caller did `(await ghJson(...)) as ClaimPr[] ?? []`, converting *absence of data* into *zero results*, leaving `ghDegraded` null — so the all-clear branch fired.

The error path was already loud (`⚠ gh unavailable … PR overlap NOT checked`). Its success-with-no-output sibling was wide open — one branch guarded, the other not.

**Why it matters beyond tidiness:** a false all-clear here produces exactly the two-agents-one-branch collision this tool was built to prevent.

## The fix, at two layers

The `gh` boundary is injectable, so the guard sits at both ends:

- **`defaultGhJson` rejects empty stdout.** `gh … --json <fields>` always emits JSON — zero results is the two-byte array `[]`, never an empty string. Silence is absence.
- **`asPrList()` throws on any non-array**, applied to **both** the open and the merged query. Guarding only the first would leave the identical defect one line down.

Absence routes into the **existing** loud degrade path rather than a new reporting channel.

## Proven in both directions

| | old `?? []` | with fix |
|---|---|---|
| gh returns nothing on success | **FAILS** | passes |
| non-array shapes (object / string / undefined) | **FAILS** | passes |
| the merged call site, not just the open one | **FAILS** | passes |
| **CONTROL — a genuine zero `[]` still prints the green all-clear** | **passes** | **passes** |

Three of the four new tests fail against the unfixed code. The control passes under **both**, which is what makes this a guard rather than a permanent alarm — without it, a guard that always fires would look identical on the defect case and be wrong on every clean run.

Mutation applied and reverted during verification; source restored byte-identical (sha + size verified, zero markers left).

## Verification

- `tsc --noEmit` exit 0
- `tests/unit/dev-claim-check.test.ts` — **14/14** (was 10)
- Verified in a dedicated worktree on the mainline dependency set, not inherited from another tree
- Blast radius measured: exactly two importers — `src/cli.ts` and the unit test

Tier 1 (advisory dev CLI; no authority gate, secret, or safety-invariant path). The pre-commit gate's own classifier independently computed `riskFloor=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

