### PR TITLE
fix(worktree): the repo-resolution failure names its remedy

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T14-38-44-427Z-worktree-repo-error-names-remedy.json
+++ b/.instar/instar-dev-decisions/2026-08-14T14-38-44-427Z-worktree-repo-error-names-remedy.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-14T14:38:44.427Z",
+  "slug": "worktree-repo-error-names-remedy",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 16,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/cli.ts",
+      "src/core/InstarWorktreeManager.ts"
+    ],
+    "addedLines": 15,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/worktree-repo-error-names-remedy.eli16.md
+++ b/docs/specs/worktree-repo-error-names-remedy.eli16.md
@@ -1,0 +1,34 @@
+# Worktree create: the error that blocked you now tells you how to unblock
+
+> The one-line version: `instar worktree create` could fail with a perfectly honest explanation of what went wrong and no mention of the one setting that fixes it — so the person it blocked went around the command instead of using it.
+
+## The problem in one breath
+
+`instar worktree create` needs to find your instar checkout. It looks in several places in order, and if none of them is a valid checkout it stops and lists every place it tried and exactly why each one failed. That part is good — it never guesses, and it never pretends to have found something it did not.
+
+What it never said is what to do about it. The very first place it looks is a setting called `INSTAR_REPO`, which exists precisely so you can point it at a checkout in an unusual location. That setting appeared nowhere in the failure message. So someone whose checkout lives somewhere the defaults do not cover reads a complete diagnosis, learns nothing about the remedy, and concludes the command cannot help them.
+
+## What already exists
+
+- **An ordered search** for your checkout: the `INSTAR_REPO` setting, then the directory you are standing in, then the agent's home, then two default locations.
+- **A genuinely honest failure.** Every candidate is listed with the real reason it was rejected — not a repo, does not exist, remote not recognised. Nothing is silently swallowed.
+- **Integrity checks** on whatever it does find, so a lookalike directory cannot be passed off as your checkout.
+- **A documented escape hatch.** `INSTAR_REPO` is written up in the worktree convention spec — just not anywhere the failing command points you.
+
+## What this adds
+
+**The failure now names its remedy.** After the same list of candidates and reasons, the message says plainly: run this from inside your checkout, or point `INSTAR_REPO` at it, with an example. Nothing is removed — the diagnosis is kept word for word and the remedy is added after it.
+
+The command's own help text now describes how the checkout is located, in the same place it already described how the agent's home is located. Those two were asymmetric: one resolution path was documented in detail, the other not at all.
+
+## Why it matters
+
+This is not a cosmetic wording change. The worktree command exists to enforce a safety convention: worktrees must live inside the agent's own home, because that is the one location the operating system sandbox cannot revoke while a session is running. The command also sets a per-worktree identity, shares the installed packages, and excludes the tree from the system file indexer.
+
+When the command refuses and does not say how to proceed, the natural next move is to create the worktree by hand with plain git — which silently skips all of that. That is exactly what happened on 2026-08-14, and it is why this change exists. An error that does not name its remedy pushes people around the very safeguard the tool was written to provide.
+
+## The safeguards
+
+**The diagnosis is preserved, not replaced.** There is a deliberate second test whose only job is to fail if the candidate list or the per-candidate reasons ever go missing. It passes both before and after this change. Making an error message friendlier by deleting the detail a reader needs would be a worse outcome than the problem being fixed.
+
+**No behaviour changes.** The same checkouts are found, the same ones are rejected, the same integrity checks apply. Only the text of the failure and the text of the help are different.

--- a/docs/specs/worktree-repo-error-names-remedy.side-effects.md
+++ b/docs/specs/worktree-repo-error-names-remedy.side-effects.md
@@ -1,0 +1,74 @@
+# Side-Effects Review — worktree create: the failure names its remedy
+
+**Version / slug:** `worktree-repo-error-names-remedy`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent)`
+**Second-pass reviewer:** `not required (Tier 1, operator-surface text only, no behaviour change)`
+
+## Summary of the change
+
+`resolveInstarRepo` (`src/core/InstarWorktreeManager.ts`) consults an ordered candidate chain — `INSTAR_REPO`, CWD, `INSTAR_AGENT_HOME`, then two default checkout locations — and throws when none passes integrity validation. The throw enumerated every candidate and its rejection reason, which is honest and diagnostic, but never named `INSTAR_REPO` — the FIRST candidate it consults and the documented escape hatch for a checkout in a non-default location. The remedy is now appended to that message, and `src/cli.ts`'s `worktree create` description gains a sentence describing repo resolution (it already described agent-home resolution in detail). Two tests are added. No behaviour changes: the same candidates are tried in the same order, the same integrity checks apply, the same inputs succeed and fail.
+
+## Decision-point inventory
+
+**No decision point is added, removed, or modified.** The candidate chain, the ordering, the integrity validation, and the success/failure boundary are all untouched. This change alters the TEXT emitted on an already-existing failure path, plus a CLI help string.
+
+## 1. Over-block
+
+Could this refuse where it should permit? No — the change cannot cause a refusal. It only executes on a path that has already decided to throw. Every candidate that resolved before this change resolves after it, verified by the existing 49-test suite passing unchanged.
+
+## 2. Under-block
+
+Could this permit where it should refuse? No. Nothing is loosened; no new candidate is admitted and no validation is skipped. A reader following the new advice sets `INSTAR_REPO`, and that path is then subject to exactly the same integrity validation it always was — the guidance routes an operator to a checked input, never around a check.
+
+## 3. Level-of-abstraction fit
+
+The remedy belongs in the throw, not in the CLI catch-block, because `resolveInstarRepo` is the function that knows the candidate chain — it is the only layer that can state which inputs it consults. The CLI's `catch` prints `err.message` verbatim, so the guidance surfaces without the CLI needing to duplicate knowledge it does not own. The help-text sentence is separately in the right place: it documents the command's inputs before the operator runs it.
+
+## 4. Signal vs authority compliance
+
+**Signal only, and strictly less than that** — this is operator-facing prose on an existing failure. It gains no authority: it does not gate, permit, block, retry, or change an exit code. The command's exit behaviour is byte-for-byte identical.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No judgment point is introduced. There is no heuristic, model call, threshold, or classification — the change is two string literals.
+
+## 5. Interactions
+
+Blast radius measured, not assumed. `resolveInstarRepo` is consumed by `createWorktree` in the same module and re-exported through `src/commands/worktree.ts` to `src/cli.ts`. `AgentWorktreeDetector` deliberately does NOT use it (it resolves via its own chain, documented at `AgentWorktreeDetector.ts:423`), so the detector is unaffected. Callers that match on the error message: the existing suite matches `/no candidate passed integrity validation/`, which is preserved verbatim as the message's opening clause — a prefix match, so appending cannot break it. Verified by the suite passing.
+
+## 6. External surfaces
+
+None. No network call, no new file, no state written, no credential, no telemetry, no config key. The only outputs are a thrown `Error.message` and a Commander description string.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+This change IS an operator-surface fix, so the bar applies to itself. The appended text is plain English, names the setting exactly as it must be typed, and gives a concrete example using a placeholder path (`/path/to/instar`) rather than any real machine path. It contains no stack trace, no internal field name, and no absolute path from the authoring machine. It is appended after the diagnostics so the specific reasons stay first, where a reader looking for "why" finds them without scrolling past advice.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+No issue identified. This is a local developer CLI path with no shared state, no lease, no replication, and no cross-machine surface.
+
+## 8. Rollback cost
+
+Very low. Two source files, one commit, no migration, no persisted state, no config flag. Reverting restores the previous message exactly; nothing downstream records anything that depends on the new text.
+
+## Conclusion
+
+Ship. The change fixes an operator-surface defect with a measured real-world cost, adds no authority, alters no behaviour, and is guarded by a test that fails if the diagnostics it appends to are ever lost.
+
+## Second-pass review (if required)
+
+Not required — Tier 1. `classify-tier.mjs` matched none of the safety-invariant patterns for either in-scope file, and the in-scope change is 16 LOC across 2 files (tests are out of scope per the gate's own `inScope()` definition: `src/`, `scripts/`, `.husky/`, `skills/`).
+
+## Evidence pointers
+
+- Defect reproduced before any edit: `resolveInstarRepo` from a non-repo CWD with no env set throws a message listing three candidates and their reasons, containing zero occurrences of `INSTAR_REPO`.
+- The source file was confirmed BYTE-IDENTICAL to `main` (40,979 bytes both) before editing, so the defect is live on mainline and not an artifact of a local branch.
+- Negative control executed: reverting the source change makes the new `THE DEFECT` test FAIL (1 failed / 50 passed) while the `CONTROL` test still PASSES — proving the control is load-bearing on the diagnostics rather than merely echoing the fix. Source restored byte-identical (sha + size 41,860 verified).
+- `tsc --noEmit` exit 0; `tests/unit/InstarWorktreeManager.test.ts` 51/51 (was 49).
+- Verified in a dedicated worktree checked out from `origin/main` on its own installed dependency set, not inherited from another tree.
+
+## Class-Closure Declaration (display-only mirror)
+
+Class: "an honest error that does not name its remedy, so the operator routes around the safeguard." This change closes it for `resolveInstarRepo` only. It does NOT claim to close the class repo-wide — other thrown errors naming a failed lookup without its escape hatch may exist and were not audited here.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -563,6 +563,9 @@ worktreeCmd
     'Create a git worktree of the shared instar repo inside the agent home ' +
       '(~/.instar/agents/<agent>/.worktrees/<slug>). Agent home is resolved from ' +
       'INSTAR_AGENT_HOME (set by the agent launcher) or by walking up from the CWD. ' +
+      'The instar repo itself is resolved from INSTAR_REPO, then the CWD, then ' +
+      'INSTAR_AGENT_HOME, then the default checkout locations — so run this from inside ' +
+      'your checkout, or set INSTAR_REPO when it lives elsewhere. ' +
       'Caveat: GIT_AUTHOR_NAME / GIT_COMMITTER_EMAIL in the environment override the ' +
       "per-worktree identity this command sets — agents that need attribution must avoid exporting those vars.",
   )

--- a/src/core/InstarWorktreeManager.ts
+++ b/src/core/InstarWorktreeManager.ts
@@ -346,8 +346,19 @@ export function resolveInstarRepo(opts: ResolveInstarRepoOptions = {}): Resolved
     failures.push(`  - ${candidate}: ${result.error}`);
   }
 
+  // Name the remedy, not just the failure. INSTAR_REPO is the FIRST candidate
+  // consulted above, yet it appeared nowhere in this message — so an operator
+  // whose checkout lives outside the default locations (and whose CWD is not
+  // inside it) had no way to learn the escape hatch exists from the error that
+  // blocked them. Earned 2026-08-14: that silence sent an agent around this
+  // command to a raw `git worktree add`, skipping every safety property the
+  // convention exists to provide (jailed destination, per-worktree identity,
+  // shared node_modules, indexer exclusion). The diagnostics above are kept
+  // verbatim; the remedy is appended, never substituted for them.
   throw new Error(
-    `instar repo: no candidate passed integrity validation. Tried:\n${failures.join('\n')}`,
+    `instar repo: no candidate passed integrity validation. Tried:\n${failures.join('\n')}\n\n` +
+      'To fix: run this command from inside your instar checkout, or point INSTAR_REPO at it ' +
+      '(for example: INSTAR_REPO=/path/to/instar instar worktree create <branch>).',
   );
 }
 

--- a/tests/unit/InstarWorktreeManager.test.ts
+++ b/tests/unit/InstarWorktreeManager.test.ts
@@ -327,6 +327,55 @@ describe('resolveInstarRepo', () => {
     ).toThrow(/no candidate passed integrity validation/);
   });
 
+  // ── The failure must name its remedy, not only its diagnosis ──────────
+  // Earned 2026-08-14: an agent whose checkout lives outside the default
+  // locations ran this from its agent home, got an honest but remedyless
+  // error, and went around the command to a raw `git worktree add` — skipping
+  // every safety property the worktree convention exists to provide.
+
+  it('THE DEFECT: the failure names INSTAR_REPO, the escape hatch it already consults', () => {
+    const elsewhere = fs.mkdtempSync(path.join(tmp, 'elsewhere-'));
+    let msg = '';
+    try {
+      resolveInstarRepo({
+        env: {},
+        cwd: elsewhere,
+        fallbackChain: [],
+        urlAllowlist: DEFAULT_INSTAR_REPO_URL_ALLOWLIST,
+      });
+    } catch (err) {
+      msg = (err as Error).message;
+    }
+    // INSTAR_REPO is the FIRST candidate resolveInstarRepo consults, yet the
+    // operator blocked by this error could not learn that from the error.
+    expect(msg).toMatch(/INSTAR_REPO/);
+    // And the remedy must be actionable, not merely a variable name.
+    expect(msg).toMatch(/run this command from inside your instar checkout/i);
+  });
+
+  it('CONTROL: the remedy is APPENDED — every candidate and its reason survive', () => {
+    const notRepo = fs.mkdtempSync(path.join(tmp, 'notrepo-'));
+    const elsewhere = fs.mkdtempSync(path.join(tmp, 'elsewhere-'));
+    let msg = '';
+    try {
+      resolveInstarRepo({
+        env: { INSTAR_REPO: notRepo },
+        cwd: elsewhere,
+        fallbackChain: [],
+        urlAllowlist: DEFAULT_INSTAR_REPO_URL_ALLOWLIST,
+      });
+    } catch (err) {
+      msg = (err as Error).message;
+    }
+    // This half passes BOTH before and after the change. It is the guard against
+    // "improving" an error by replacing its diagnostics with advice: the reader
+    // still needs to see which paths were tried and why each one failed.
+    expect(msg).toContain('no candidate passed integrity validation');
+    expect(msg).toContain(notRepo);
+    expect(msg).toContain(elsewhere);
+    expect(msg).toMatch(/not a git repo/);
+  });
+
   it('rejects when remote.origin.url is unset', () => {
     const repo = makeRepo();
     const elsewhere = fs.mkdtempSync(path.join(tmp, 'elsewhere-'));

--- a/upgrades/next/worktree-repo-error-names-remedy.md
+++ b/upgrades/next/worktree-repo-error-names-remedy.md
@@ -1,0 +1,22 @@
+## What Changed
+
+When `instar worktree create` cannot locate your instar checkout, the failure now names the remedy instead of only the diagnosis.
+
+- **The error names the setting that fixes it.** The first place the command looks is the `INSTAR_REPO` setting, but that name appeared nowhere in the failure — so someone whose checkout lives outside the default locations had no way to learn the escape hatch existed from the message that blocked them.
+- **The diagnosis is kept in full.** Every candidate location and the exact reason each was rejected still comes first, word for word. The remedy is appended after it, never substituted for it.
+- **The command's help now describes how the checkout is located**, matching the detail it already gave for how the agent's home is located. Those two were asymmetric.
+- **No behaviour change.** The same locations are searched in the same order, the same integrity checks apply, and the same inputs succeed and fail.
+
+## What to Tell Your User
+
+Creating an isolated working copy has to find your source checkout first. When it could not, it explained precisely what it had tried and why each attempt failed — and stopped there, without mentioning the one setting that points it somewhere else. The natural response to that is to give up on the command and make the working copy by hand, which quietly skips the protections the command provides: putting it in the one place the system cannot revoke access to mid-session, giving it its own identity, sharing installed packages, and keeping it out of the system file indexer.
+
+It now tells you how to proceed. The detailed explanation of what failed still comes first, because that is what you need in order to understand the situation; the suggestion follows it.
+
+## Summary of New Capabilities
+
+None. This improves the wording of an existing failure and an existing help description. No new command, flag, route, setting, or behaviour.
+
+## Evidence
+
+The defect was reproduced before any edit, and the source file was confirmed byte-identical to the mainline copy first, so this is a live defect rather than a local artifact. Proven in both directions: reverting the change makes the new test fail while a second, deliberate control test continues to pass. That control exists to catch the opposite mistake — making an error friendlier by deleting the detail a reader needs — and it holds both before and after. Typecheck clean and 51 of 51 tests passing in the affected suite, up from 49, verified in a dedicated working copy checked out from the mainline on its own installed dependencies rather than inherited from another tree.


### PR DESCRIPTION
## ELI16 — the error that blocked you now tells you how to unblock

`instar worktree create` has to find your instar checkout before it can do anything. It looks in several places in order, and when none of them is a valid checkout it stops and lists every place it tried and exactly why each one failed. That part is good — it never guesses and never pretends to have found something it did not.

What it never said is what to do about it. The very first place it looks is a setting called `INSTAR_REPO`, which exists precisely so you can point it at a checkout in an unusual location — and that name appeared nowhere in the failure. So someone whose checkout lives outside the defaults reads a complete diagnosis, learns nothing about the remedy, and concludes the command cannot help them.

That is not cosmetic. This command enforces a safety convention: worktrees must live inside the agent home, the one place the macOS sandbox cannot revoke mid-session. It also sets a per-worktree git identity, shares `node_modules`, and excludes the tree from Spotlight. When it refuses without naming a way forward, the natural next move is a raw `git worktree add` — which silently skips all of that. That is exactly what happened on 2026-08-14, and it is why this change exists.

## The defect

`resolveInstarRepo` consults an ordered chain — `INSTAR_REPO` → CWD → `INSTAR_AGENT_HOME` → two default locations — and throws when none passes integrity validation. Reproduced from a non-repo CWD with no env set:

```
instar repo: no candidate passed integrity validation. Tried:
  - <cwd>: not a git repo (fatal: not a git repository ...)
  - ~/Documents/Projects/instar: path does not exist
  - ~/instar: path does not exist
```

Zero occurrences of `INSTAR_REPO` — the first candidate it consults.

## The fix

- **The remedy is appended**, never substituted: the same candidate list and the same per-candidate reasons come first, verbatim, then "run this from inside your instar checkout, or point `INSTAR_REPO` at it" with an example.
- **`src/cli.ts`'s create description now documents repo resolution**, which it already did in detail for agent-home resolution. The two were asymmetric.

No behaviour change: same candidates, same order, same integrity checks, same successes and failures.

## Proven in both directions

| | unfixed | with fix |
|---|---|---|
| `THE DEFECT`: the failure names `INSTAR_REPO` and an actionable step | **FAILS** | passes |
| `CONTROL`: candidate list + per-candidate reasons survive | **passes** | **passes** |

The control is the load-bearing half. It exists to catch the opposite mistake — making an error "friendlier" by deleting the detail a reader needs — and it passes under **both**, so it is a guard rather than an echo of the fix. Negative control run for real: reverting the source change gives 1 failed / 50 passed. Source restored byte-identical afterwards (sha + size 41,860 verified).

## Verification

- Source confirmed **byte-identical to `main`** (40,979 bytes both) before editing — the defect is live on mainline, not a local-branch artifact.
- `tsc --noEmit` exit 0 · `tests/unit/InstarWorktreeManager.test.ts` **51/51** (was 49).
- Verified in a dedicated worktree checked out from `origin/main` on its own installed dependency set, not inherited from another tree.
- Tier 1 — the pre-commit gate's own classifier independently computed `suggestedTier=1 (size=1, riskFloor=1, 16 LOC across 2 file(s))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
