### PR TITLE
fix(ci-failures): a check we could not read is not a check with no failures

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T15-21-02-523Z-ci-failures-absence-is-not-zero.json
+++ b/.instar/instar-dev-decisions/2026-08-14T15-21-02-523Z-ci-failures-absence-is-not-zero.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T15:21:02.523Z",
+  "slug": "ci-failures-absence-is-not-zero",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 56,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/devCiFailures.ts"
+    ],
+    "addedLines": 49,
+    "deletedLines": 7
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/ci-failures-absence-is-not-zero.eli16.md
+++ b/docs/specs/ci-failures-absence-is-not-zero.eli16.md
@@ -1,0 +1,37 @@
+# CI failures: a check we could not read is not a check with nothing wrong
+
+> The one-line version: the tool that tells you what broke on a red pull request could announce "these failures are probably a build or lint problem, not a test problem" after failing to read a single one of them.
+
+## The problem in one breath
+
+When a pull request goes red, this command asks GitHub for each failed check and prints the exact test failures inside it. For each check it fetches a list of annotations — the file, the line, the assertion that failed.
+
+If that fetch failed, the command quietly skipped that check and moved on. If it failed for every check, the command printed a conclusion: *"The failed checks have no test-level annotations — likely a build/lint/type step."*
+
+That sentence is a diagnosis of what went wrong, produced from information that never arrived. It tells the reader to stop looking for a failing test — which is the one thing they came here to find.
+
+## What already exists
+
+- **A hardened boundary.** The code that talks to GitHub was deliberately written so that empty output cannot be mistaken for an empty answer: it parses strictly and raises an error instead of quietly producing nothing.
+- **Two careful callers.** The step that resolves the pull request, and the step that lists its failed checks, both report the reason plainly and stop with an error code when they cannot read.
+- **A stated guarantee.** The file's own documentation said, in as many words, that there is no path on which a failed read renders as a clean one.
+
+## What this adds
+
+**The guarantee is now true.** It was not. The third caller — the one that fetches annotations per check — caught its errors and continued in silence, exactly the case the guarantee denied. Three things change:
+
+- **A failed read is recorded, not swallowed.** Skipping the rest would be worse, since one hiccup should not lose every other check, so it still continues — but it now remembers which checks it could not read.
+- **The incomplete listing says so**, even when some failures were found. A partial read that looks complete is the more dangerous of the two, because the reader has results and no reason to doubt them.
+- **The conclusion is withheld when nothing was read.** If no check could be read at all, the command says their nature is unknown rather than guessing at it. When annotations genuinely come back empty, the original wording is unchanged.
+
+A reply that is not a list at all — nothing, a bare word, an object — is also treated as absence rather than as zero findings.
+
+## The safeguards
+
+**A genuine "no annotations" still gets the original answer.** This is the important one. Plenty of real failures are build or lint steps with no test-level annotations, and that diagnosis is correct and useful for them. There is a test that fails if that message ever stops appearing for a genuinely empty result — without it, a guard that fired on every run would look identical on the broken case and be wrong on every healthy one.
+
+**Nothing becomes an error.** This command is a diagnostic, never a gate. It still returns success in every case it did before; only what it prints has changed.
+
+## Why it matters
+
+This command exists for the situation where the usual tools come back empty — its own documentation recommends it for exactly that. A tool people reach for when they cannot see must never be the one that reports a confident answer it did not earn.

--- a/docs/specs/ci-failures-absence-is-not-zero.side-effects.md
+++ b/docs/specs/ci-failures-absence-is-not-zero.side-effects.md
@@ -1,0 +1,73 @@
+# Side-Effects Review — ci-failures: a failed read is not "no annotations"
+
+**Version / slug:** `ci-failures-absence-is-not-zero`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent)`
+**Second-pass reviewer:** `not required (Tier 1, advisory dev CLI, no authority surface)`
+
+## Summary of the change
+
+`instar dev:ci-failures <pr>` prints a red PR's test-level failure annotations. Its `gh` boundary is deliberately hardened (`JSON.parse(stdout)` with no `|| 'null'`), and its SHA and check-list callers both report and exit 1 on failure. The per-check ANNOTATIONS caller did neither: `catch { continue; }` swallowed the error, so an unreadable check became indistinguishable from a check with no annotations. When every read failed, `total === 0` and the command printed *"The failed checks have no test-level annotations — likely a build/lint/type step"* — a diagnosis of the failure's NATURE asserted from data never received. The file's own docblock claimed "there is no path on which a failed read renders as a clean one"; that claim was false for this caller. Changes: track unread checks, report the gap (even when other failures WERE found), withhold the diagnosis when nothing was read, treat a non-array reply as absence, and correct the docblock. Plus a new `tests/unit/dev-ci-failures.test.ts` (the command had none).
+
+## Decision-point inventory
+
+One decision point is **modified, not added**: "what do zero printed failure lines mean?" It previously had one outcome (no annotations exist → diagnose as a build/lint step). It now has two, split on whether the reads succeeded — read-and-empty keeps the original diagnosis; not-read reports UNKNOWN. No decision point is added or removed, and the failure-extraction logic (`extractFailureLines`) is untouched.
+
+## 1. Over-block
+
+Could this refuse where it should permit? It cannot refuse anything — the command returns 0 on every path it did before, including all new ones. The realistic analogue is over-WARNING: emitting "annotations NOT read" on a healthy run, which would train readers to ignore it. Guarded by a dedicated control test asserting that a genuine `[]` reply produces the original message, no UNKNOWN, and no warning. `[]` is an array, so it never enters the unread path.
+
+## 2. Under-block
+
+Could this permit where it should refuse? The previous behaviour WAS the under-report: silence became a confident diagnosis. Remaining surface: a well-formed array whose ENTRIES are malformed still flows into `extractFailureLines`, which drops entries lacking a `failure` level or a message. That is pre-existing and unchanged — an annotation list that arrives and contains nothing actionable is genuinely "no test-level annotations".
+
+## 3. Level-of-abstraction fit
+
+The tracking sits in the loop that performs the read (the only place that knows a read failed) and the reporting sits at the summary (the only place that knows the totals). Pushing the check into `extractFailureLines` would have been wrong: that function is pure and receives an array, so by the time it runs the absence is already lost.
+
+## 4. Signal vs authority compliance
+
+**Signal only.** The command is a diagnostic and explicitly not a gate — its own RULE 3.1 rationale says so and it returns 0 even when it finds failures. It gains no authority: no exit code changes, nothing is blocked, retried, or escalated. The new warning goes to stderr so it cannot corrupt stdout parsing.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No judgment point is introduced. `Array.isArray()` and a length comparison are deterministic; no heuristic, model call, or tunable threshold.
+
+## 5. Interactions
+
+Blast radius measured, not assumed: `devCiFailures` is imported by `src/cli.ts` (the `dev:ci-failures` subcommand) and by the new test only. `extractFailureLines` is exported and unchanged. No scheduler, sentinel, gate, or route consumes it. The `CiFailuresDeps` interface is unchanged, so injected implementations keep working; one that previously returned a non-array now surfaces as a reported gap instead of a silent zero, which is the intended behaviour change.
+
+## 6. External surfaces
+
+The `gh` CLI only. No new invocation, flag, endpoint, credential, or network call — the change is purely in how an existing reply is interpreted and reported. No file written, no state persisted, no telemetry.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+New text is plain English and names the concrete gap: `⚠ Annotations NOT read for N of M failed check(s): <names>. Their failures are NOT included below — this listing is incomplete.` and `No annotations could be read for any failed check — their nature is UNKNOWN, not "no test failures".` Check NAMES come from the GitHub API and are already printed elsewhere by this command. No paths from the authoring machine, no stack traces, no internal field names.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+No issue identified. A local developer CLI with no shared state, lease, replication, or cross-machine surface.
+
+## 8. Rollback cost
+
+Very low. One source file plus one new test file, one commit, no migration, no persisted state, no config flag. Reverting restores the previous output exactly.
+
+## Conclusion
+
+Ship. The change removes a false diagnosis from an advisory instrument, adds no authority, changes no exit code, and is guarded in both directions.
+
+## Second-pass review (if required)
+
+Not required — Tier 1. `classify-tier.mjs` matched no safety-invariant pattern for `src/commands/devCiFailures.ts`; the in-scope change is one file (tests are out of scope per the gate's own `inScope()`).
+
+## Evidence pointers
+
+- Defect verified in source before any edit: `catch { continue; }` at the annotations caller, with the unconditional `total === 0` diagnosis below it and zero occurrences of any degrade flag in the file (against a control of 7 in the sibling `devClaimCheck.ts`).
+- Found by auditing the class-closure loop left open by `claimcheck-absence-is-not-zero`, which stated the class was NOT closed repo-wide. A pattern sweep over `src/` for awaited-expression `?? []` coercions returned exactly two sites; the other (`PeerVisibilityGuard.ts:198`) is an OPTIONAL-DEPENDENCY default carrying an explicit `@silent-fallback-ok` annotation and its spec reference, and is correct as written.
+- Negative control executed: reverting the source change fails 3 of 5 tests while the CONTROL test still passes (2 passed) — proving the control is load-bearing rather than an echo of the fix. Source restored byte-identical (sha + size 9,751 verified).
+- `tsc --noEmit` exit 0; `tests/unit/dev-ci-failures.test.ts` 5/5 (file newly created — the command had no tests).
+
+## Class-Closure Declaration (display-only mirror)
+
+Class: "a lookup that returns nothing rendered as a confident answer." With this change the class is closed at BOTH `src/commands/dev*` sites that exhibited it. The `src/`-wide sweep for awaited `?? []` coercions now returns one remaining site, reviewed and correct by design. This does NOT claim the class is closed for every shape it can take (e.g. `|| []` on a non-awaited external value, or object-shaped absences); only the audited pattern is closed.

--- a/src/commands/devCiFailures.ts
+++ b/src/commands/devCiFailures.ts
@@ -86,9 +86,17 @@ export function extractFailureLines(annotations: CiAnnotation[]): string[] {
  *   caveat. A non-zero `gh` exit rejects with the captured stderr; empty or
  *   malformed stdout throws inside JSON.parse and rejects as "gh returned
  *   non-JSON" (note there is no `|| \'null\'` default here, so empty output
- *   cannot degrade into a successful-looking empty result); and every caller
- *   catches, writes the reason via out.error, and returns exit 1. There is no
- *   path on which a failed read renders as a clean one.
+ *   cannot degrade into a successful-looking empty result).
+ *
+ *   The two SHA/check-list callers catch, write the reason via out.error, and
+ *   return exit 1. The per-check ANNOTATIONS caller deliberately does not — one
+ *   endpoint hiccup must not lose the other checks — so it records the check in
+ *   `unread` and the run reports the gap instead. This paragraph previously
+ *   claimed "there is no path on which a failed read renders as a clean one";
+ *   that was FALSE for the annotations caller, which swallowed the error and
+ *   let the zero-case message diagnose the failure's nature ("likely a
+ *   build/lint/type step") from data it never received. A read that failed and
+ *   a check with no annotations are now distinct outcomes.
  */
 function defaultDeps(): CiFailuresDeps {
   return {
@@ -160,12 +168,28 @@ export async function runDevCiFailures(opts: DevCiFailuresOptions): Promise<numb
   //    the node-20/node-22 shard pairs that report the identical failure).
   const seen = new Set<string>();
   let total = 0;
+  // Checks whose annotation read did not produce a usable list. A read that
+  // failed is NOT a check with no annotations, and the two must not collapse:
+  // the zero-case message below diagnoses the FAILURE'S NATURE ("likely a
+  // build/lint/type step"), which is an assertion about data we did not get.
+  const unread: string[] = [];
   for (const check of failed) {
     let annotations: CiAnnotation[] = [];
     try {
-      annotations = ((await deps.ghJson(['api', `repos/${repo}/check-runs/${check.id}/annotations`])) as CiAnnotation[]) ?? [];
+      const raw = await deps.ghJson(['api', `repos/${repo}/check-runs/${check.id}/annotations`]);
+      // The annotations endpoint returns a JSON array; zero annotations is `[]`,
+      // never absent. Anything else is absence of data, not absence of findings.
+      if (!Array.isArray(raw)) {
+        unread.push(check.name);
+        continue;
+      }
+      annotations = raw as CiAnnotation[];
     } catch {
-      continue; // annotations endpoint hiccup for one check — keep going
+      // Keep going across the other checks (one endpoint hiccup must not lose
+      // the rest), but RECORD it — the docblock's "no path renders a failed
+      // read as a clean one" was false here until this line existed.
+      unread.push(check.name);
+      continue;
     }
     for (const line of extractFailureLines(annotations)) {
       if (seen.has(line)) continue;
@@ -175,11 +199,29 @@ export async function runDevCiFailures(opts: DevCiFailuresOptions): Promise<numb
     }
   }
 
+  // An unread check is reported EVEN WHEN failures were found — otherwise a
+  // partial read looks complete, and the caller stops looking at the checks
+  // whose annotations never arrived.
+  if (unread.length > 0) {
+    out.error(
+      pc.yellow(
+        `\n⚠ Annotations NOT read for ${unread.length} of ${failed.length} failed check(s): ${unread.join(', ')}.\n` +
+          'Their failures are NOT included below — this listing is incomplete.\n',
+      ),
+    );
+  }
+
   if (total === 0) {
     out.write(
       pc.yellow(
-        '\nThe failed checks have no test-level annotations — likely a build/lint/type step.\n' +
-          'Open the run in the browser, or check the step output directly.\n',
+        unread.length === failed.length
+          ? // Every read failed: we know nothing about these checks. Diagnosing the
+            // failure as "likely a build/lint step" here would assert the nature of
+            // data we never received.
+            '\nNo annotations could be read for any failed check — their nature is UNKNOWN, not "no test failures".\n' +
+              'Open the run in the browser, or check the step output directly.\n'
+          : '\nThe failed checks have no test-level annotations — likely a build/lint/type step.\n' +
+              'Open the run in the browser, or check the step output directly.\n',
       ),
     );
   }

--- a/tests/unit/dev-ci-failures.test.ts
+++ b/tests/unit/dev-ci-failures.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `instar dev:ci-failures` — a red PR's failure annotations.
+ *
+ * The load-bearing distinction: a check whose annotations could NOT BE READ is
+ * not a check with NO annotations. The zero-case message diagnoses the failure's
+ * NATURE ("likely a build/lint/type step"), so collapsing the two makes the tool
+ * assert something about data it never received — and this command exists
+ * precisely for the case where other tooling comes back empty.
+ *
+ * The `gh` boundary is injected — no network.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  extractFailureLines,
+  runDevCiFailures,
+  type CiAnnotation,
+  type CiFailuresOutput,
+} from '../../src/commands/devCiFailures.js';
+
+function capture(): { out: string[]; err: string[]; output: CiFailuresOutput } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { out, err, output: { write: (t) => out.push(t), error: (t) => err.push(t) } };
+}
+
+const FAILURE: CiAnnotation = {
+  path: 'tests/unit/foo.test.ts',
+  start_line: 42,
+  annotation_level: 'failure',
+  message: 'expected 1 to be 2',
+};
+
+/** A deps stub whose annotations call behaves per-check. */
+function deps(annotationsFor: (checkId: number) => unknown | Promise<unknown>) {
+  return {
+    ghJson: async (args: string[]): Promise<unknown> => {
+      if (args[0] === 'pr') return { headRefOid: 'abcdef1234567890' };
+      if (args[1]?.includes('/check-runs?')) {
+        return {
+          check_runs: [
+            { id: 1, name: 'Unit Tests (node 20)', conclusion: 'failure' },
+            { id: 2, name: 'Unit Tests (node 22)', conclusion: 'failure' },
+          ],
+        };
+      }
+      const m = args[1]?.match(/check-runs\/(\d+)\/annotations/);
+      return annotationsFor(Number(m?.[1] ?? 0));
+    },
+  };
+}
+
+describe('extractFailureLines', () => {
+  it('keeps real failures and drops runner noise', () => {
+    const lines = extractFailureLines([
+      FAILURE,
+      { path: '.github/workflows/ci.yml', annotation_level: 'failure', message: 'runner noise' },
+      { path: 'x.ts', annotation_level: 'warning', message: 'a warning' },
+      { path: 'y.ts', annotation_level: 'failure', message: 'Process completed with exit code 1.' },
+    ]);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('tests/unit/foo.test.ts:42');
+  });
+});
+
+describe('runDevCiFailures — a failed read is not "no failures"', () => {
+  it('THE DEFECT: every annotations read throws → says UNKNOWN, never "likely a build/lint step"', async () => {
+    const { out, err, output } = capture();
+    const code = await runDevCiFailures({
+      pr: '1868',
+      output,
+      deps: deps(() => {
+        throw new Error('annotations endpoint 502');
+      }),
+    });
+    expect(code).toBe(0); // diagnostic, never a gate
+    const stdout = out.join('\n');
+    // It must NOT diagnose the nature of failures it could not see.
+    expect(stdout).not.toContain('likely a build/lint/type step');
+    expect(stdout).toMatch(/UNKNOWN/);
+    // And it must name which checks went unread, on stderr.
+    expect(err.join('\n')).toMatch(/Annotations NOT read for 2 of 2/);
+  });
+
+  it('CONTROL: genuine empty annotations still give the original build/lint diagnosis', async () => {
+    const { out, err, output } = capture();
+    const code = await runDevCiFailures({ pr: '1868', output, deps: deps(() => []) });
+    expect(code).toBe(0);
+    // This half passes BOTH before and after the change. Without it, a guard that
+    // always fired would look identical on the defect case and be wrong on every
+    // genuinely-annotation-free run.
+    expect(out.join('\n')).toContain('likely a build/lint/type step');
+    expect(out.join('\n')).not.toMatch(/UNKNOWN/);
+    expect(err.join('\n')).not.toMatch(/NOT read/);
+  });
+
+  it('a PARTIAL read prints the failures it has AND says the listing is incomplete', async () => {
+    const { out, err, output } = capture();
+    await runDevCiFailures({
+      pr: '1868',
+      output,
+      deps: deps((id) => {
+        if (id === 1) return [FAILURE];
+        throw new Error('502');
+      }),
+    });
+    // The failure it could read is reported…
+    expect(out.join('\n')).toContain('tests/unit/foo.test.ts:42');
+    // …and the gap is NOT hidden by the presence of findings.
+    expect(err.join('\n')).toMatch(/Annotations NOT read for 1 of 2/);
+    expect(err.join('\n')).toContain('Unit Tests (node 22)');
+  });
+
+  it('a non-array reply is absence of data, not zero annotations', async () => {
+    for (const shape of [null, undefined, {}, 'oops', 42]) {
+      const { out, err, output } = capture();
+      await runDevCiFailures({ pr: '1868', output, deps: deps(() => shape) });
+      expect(out.join('\n'), `shape ${JSON.stringify(shape)}`).not.toContain('likely a build/lint/type step');
+      expect(err.join('\n'), `shape ${JSON.stringify(shape)}`).toMatch(/Annotations NOT read for 2 of 2/);
+    }
+  });
+});

--- a/upgrades/next/ci-failures-absence-is-not-zero.md
+++ b/upgrades/next/ci-failures-absence-is-not-zero.md
@@ -1,0 +1,25 @@
+## What Changed
+
+The command that prints a red pull request's failing tests could announce a conclusion about failures it never managed to read.
+
+- **A check whose annotations could not be fetched is no longer treated as a check with nothing to report.** The fetch error was caught and skipped in silence, so an unreadable check and a genuinely clean one looked identical.
+- **When nothing could be read at all, the tool no longer diagnoses the cause.** It previously said the failures were "likely a build or lint step" — an assertion about the nature of information that never arrived. It now says their nature is unknown.
+- **A partial read announces that it is partial**, even when some failures were found. A listing that looks complete but is not is the more dangerous case, because the reader has results and no reason to doubt them.
+- **A reply that is not a list** — nothing at all, a bare word, an object — is treated as absence rather than as zero findings.
+- **The file's own stated guarantee is now true.** Its documentation claimed no failed read could render as a clean one. That was accurate for two of its three callers and false for the third.
+
+## What to Tell Your User
+
+When a pull request goes red, this tool fetches each failed check and prints the exact test that broke. If those fetches failed, it used to skip them quietly and then tell you the problem was probably a build or lint issue rather than a test — advice produced without having read anything. That points you away from the one thing you were looking for.
+
+It now distinguishes "I read this and there was nothing" from "I could not read this." The first still gets the original, useful answer. The second says so plainly and names which checks it could not see.
+
+This matters because the tool is recommended precisely for the situation where other ways of looking come back empty. Something you reach for when you cannot see must not be the thing that sounds certain without cause.
+
+## Summary of New Capabilities
+
+None. This removes a false conclusion from an existing diagnostic command and adds its first tests. No new command, flag, route, setting, or exit code.
+
+## Evidence
+
+The defect was verified in source before any edit, and was found by following up an explicit note on an earlier change which recorded that this class of bug had been closed at one place only and not audited elsewhere. A sweep across the source found exactly two remaining candidates; one is this defect and the other is a deliberate default for an optional dependency, documented as such and correct. Proven in both directions: reverting the change fails three of the five new tests while a deliberate control test continues to pass. That control exists to catch the opposite mistake — warning on healthy runs — and holds both before and after. Source restored byte-identical after the check, typecheck clean, five of five tests passing in a file that previously had none.


### PR DESCRIPTION
## ELI16 — a check we could not read is not a check with nothing wrong

When a pull request goes red, this command asks GitHub for each failed check and prints the exact test failures inside it — the file, the line, the assertion.

If that fetch failed, the command quietly skipped the check and moved on. If it failed for *every* check, it printed a conclusion: **"The failed checks have no test-level annotations — likely a build/lint/type step."**

That sentence is a diagnosis of what went wrong, produced from information that never arrived. It tells the reader to stop looking for a failing test — the one thing they came here to find. And this command is recommended for exactly the case where other tooling comes back empty, so a tool people reach for when they cannot see must not be the one that sounds certain without cause.

It now distinguishes "I read this and there was nothing" from "I could not read this." The first still gets the original, useful answer; the second says so and names the checks it could not see.

## The defect, and why it is sharper than its sibling

The `gh` boundary here was **deliberately hardened** against the absence-as-zero bug — `JSON.parse(stdout)` with no `|| 'null'`, so empty output throws. The SHA and check-list callers both report and exit 1.

The annotations caller did neither:

```ts
} catch {
  continue; // annotations endpoint hiccup for one check — keep going
}
```

No reason written, no degrade flag (the file had **zero**, against 7 in the sibling `devClaimCheck.ts`). So an unreadable check and a check with genuinely no annotations became the same thing, and `total === 0` produced the confident diagnosis.

**The file's own docblock claimed:** *"There is no path on which a failed read renders as a clean one."* True for two of its three callers, false for this one. That claim is now correct rather than aspirational.

## The fix

- Unread checks are **recorded**, not swallowed — the loop still continues (one hiccup must not lose the others).
- The gap is reported **even when other failures were found**. A partial listing that looks complete is the more dangerous case: the reader has results and no reason to doubt them.
- The diagnosis is **withheld** when nothing was read: *"their nature is UNKNOWN, not 'no test failures'."*
- A non-array reply (nothing, a bare word, an object) is absence, not zero.

## Proven in both directions

| | unfixed | with fix |
|---|---|---|
| every read throws → says UNKNOWN, not "build/lint step" | **FAILS** | passes |
| partial read → prints failures **and** flags incompleteness | **FAILS** | passes |
| non-array shapes are absence | **FAILS** | passes |
| **CONTROL — a genuine `[]` keeps the original build/lint diagnosis** | **passes** | **passes** |

Negative control run for real: reverting the source gives **3 failed / 2 passed**, with the control among the passers — so it is a guard, not an echo of the fix. Source restored byte-identical (sha + 9,751 bytes verified).

## How it was found

By following the class-closure declaration on #1867, which stated the class was closed at **one site only** and not audited repo-wide. A sweep for awaited-expression `?? []` coercions in `src/` returned exactly two: this one, and `PeerVisibilityGuard.ts:198` — an *optional-dependency* default carrying an explicit `@silent-fallback-ok` annotation and its spec reference, correct as written and left alone.

## Verification

- `tsc --noEmit` exit 0 · `tests/unit/dev-ci-failures.test.ts` **5/5** (the command had **no tests** before this).
- Branched from `origin/main`, own installed dependency set.
- Tier 1 — `riskFloor=1`, no safety-invariant match, one in-scope file, no new route, no exit-code change. The gate's size heuristic suggested 2 on LOC; **216 prior decisions in this repo share the declared-1 / suggested-2 / floor-1 shape**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
