### PR TITLE
fix(parallel-work): the running flag never found a live session

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T16-00-17-895Z-parallel-work-running-flag-wiring.json
+++ b/.instar/instar-dev-decisions/2026-08-14T16-00-17-895Z-parallel-work-running-flag-wiring.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-14T16:00:17.895Z",
+  "slug": "parallel-work-running-flag-wiring",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 54,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/ParallelActivityIndex.ts",
+      "src/server/AgentServer.ts"
+    ],
+    "addedLines": 48,
+    "deletedLines": 6
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/parallel-work-running-flag-wiring.eli16.md
+++ b/docs/specs/parallel-work-running-flag-wiring.eli16.md
@@ -1,0 +1,37 @@
+# Parallel-work awareness: the "is anyone else working on this?" answer was always no
+
+> The one-line version: the surface an agent is told to check before starting work, so it doesn't duplicate what another of its conversations is already doing, has reported "nothing is running anywhere" since it shipped — including while the agent asking was itself running.
+
+## The problem in one breath
+
+Each conversation topic gets a row in a cross-topic index: what it is focused on, and whether a session is live on it right now. The live flag is the point — it is what turns a list of past topics into "here is what is happening at this moment."
+
+That flag was computed by looking for a topic number attached to each running session. Sessions do not carry one. They never have: the record has an identifier, a name, a terminal session name, a working directory — and nothing naming the conversation. So the search found nothing every time, for every topic, and the flag came back "not running" for all of them permanently.
+
+The count of running topics on that surface has been zero for its entire life.
+
+## What already exists
+
+- **The index itself is correct.** It enumerates topics, works out each one's focus, extracts distinguishing keywords, and asks a supplied helper whether each topic is live. Its own tests pass and always did.
+- **The correct link already exists elsewhere.** The web view that lists sessions resolves each one's conversation from the terminal session name, through the messaging registry. That resolution works and is used every day.
+- **Guidance that points at this surface.** The agent handbook describes it as the antidote to self-blindness and says to glance at it before starting substantial new work in a topic.
+
+## What this adds
+
+**The live flag is now resolved the same way everything else resolves it** — from the terminal session name, through the messaging registry — instead of from a field that does not exist.
+
+The resolution is lifted into a small, separately testable helper, and the tests feed it session records shaped like the real ones: a terminal session name and no conversation number. That shape is the whole point. The index's existing tests supply a stand-in for the live check, so they were never able to notice that the real one could not work.
+
+A session the registry cannot place is still not counted, and one that fails to resolve does not prevent the others from being found.
+
+## Why it went unnoticed
+
+The faulty lookup was written behind a type assertion — a note to the compiler saying "trust me, these records have a conversation number." They do not, and because the assertion was there, the compiler had no reason to complain. A promise made to the compiler that nothing checks is the same shape as a guarantee written in a comment that nothing enforces.
+
+The failure was also invisible from the outside: an empty result and "nothing is running" look identical. There was no error, no warning, and no way to tell the difference without knowing what the answer should have been.
+
+## The safeguards
+
+**A genuine zero still reads as zero.** If nothing is running, or no session can be placed, the answer is still an empty set. Tests pin both, and they pass with the old behaviour as well as the new — which is what makes them a check on the fix rather than an echo of it.
+
+**Nothing is invented.** A session whose conversation cannot be identified is left out rather than guessed at. The flag only ever becomes true from a real, resolved link.

--- a/docs/specs/parallel-work-running-flag-wiring.side-effects.md
+++ b/docs/specs/parallel-work-running-flag-wiring.side-effects.md
@@ -1,0 +1,82 @@
+# Side-Effects Review — parallel-work `running` flag: wire it to the real topic source
+
+**Version / slug:** `parallel-work-running-flag-wiring`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent)`
+**Second-pass reviewer:** `not required (Tier 1, read-only observability surface, no authority)`
+
+## Summary of the change
+
+`GET /parallel-work/activities` reports a `running` flag per topic. `AgentServer.ts` built the running set as:
+
+```ts
+for (const s of options.sessionManager.listRunningSessions() as Array<{ topicId?: number | null }>) {
+  if (typeof s.topicId === 'number') ids.add(s.topicId);
+}
+```
+
+`Session` (`types.ts:45-155`) declares NO topic field, and nothing attaches one at runtime (all 13 `.topicId =` assignments in `src/` are on commitments, jobs, manifests or apprenticeship refs). So the guard was always false, the set always empty, and `running` was false for every topic since the surface shipped — `runningCount` a permanent zero. The topic↔session link lives in the messaging adapter's registry keyed on the tmux session name, which is exactly how `GET /sessions` derives `platformId`. The resolution is extracted to an exported pure helper `runningTopicIds(sessions, resolveTopic)` in `ParallelActivityIndex.ts`; `AgentServer` supplies `options.telegram.getTopicForSession`. The false cast is deleted. Six wiring-integrity tests added.
+
+## Decision-point inventory
+
+No decision point is added or removed. One is **repaired**: "does this topic have a live session?" previously had one reachable outcome (always false). It now has two. The index's own logic, focus derivation, tag extraction and enumeration are untouched.
+
+## 1. Over-block
+
+Could this report running where it should not? The realistic over-report is inventing a topic for an unplaceable session. Guarded: a session is counted only when the registry returns a finite number; `null`/`undefined`/`NaN`/missing tmux name are all skipped, each pinned by a test. A control asserts an empty session list still yields an empty set — a real zero stays zero.
+
+## 2. Under-block
+
+Could it under-report? The previous behaviour WAS total under-report. Remaining surface: a live session whose topic the adapter cannot resolve (e.g. a non-Telegram session) is not counted — correct, since no conversation is bound to it. A resolver that throws for one session no longer blinds the rest (previously moot, since nothing was ever found).
+
+## 3. Level-of-abstraction fit
+
+The helper sits in `ParallelActivityIndex.ts` because that module owns the concept the flag expresses, and because a pure function is the only level at which the WIRING can be tested. The bug was never in the index — its own tests inject a stub `isRunning` and passed throughout — so a test at the index level structurally cannot catch it. `AgentServer` keeps ownership of WHICH resolver to supply.
+
+## 4. Signal vs authority compliance
+
+**Signal only, and read-only.** `/parallel-work/activities` is an observability surface: per CLAUDE.md it "never gates". Nothing consumes `running` to block, spawn, kill, or route. The ParallelWorkSentinel that reads the index is explicitly observe-only and emits an in-process nudge with no listener wired. No authority is created or changed.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No judgment point introduced. A registry lookup plus `Number.isFinite` — deterministic, no heuristic, no model call, no threshold.
+
+## 5. Interactions
+
+Blast radius measured, not assumed. `runningTopicIds` is new and has exactly two importers: `AgentServer.ts` and the unit test. The `ParallelActivityIndex` constructor signature is unchanged, so both construction sites keep working — including `src/commands/server.ts:24682`, which never supplied `isRunning` and continues to report `running:false` for its own instance (that instance backs a different consumer and is out of scope here; noted rather than silently changed). Consumers of the flag: `ParallelWorkSentinel` / `ParallelWorkOverlap` (observe-only) and `PoolActivityView` (`?scope=pool`), which recomputes `runningCount` from the same rows and therefore corrects with it.
+
+## 6. External surfaces
+
+None. No network call, no new file, no persisted state, no credential, no telemetry, no new route. The change reads an already-loaded in-memory registry.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No new operator-visible text. The visible effect is that `running` and `runningCount` become true when they are true. No paths, no internal field names, no stack traces.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+The `?scope=pool` view composes local rows with replica-derived remote rows and recomputes `runningCount` from them, so this correction flows through unchanged. A peer still running the old code contributes its own (always-false) rows until it updates — a staleness property of the existing replica design, not introduced here.
+
+## 8. Rollback cost
+
+Very low. Two source files, one test file, one commit; no migration, no persisted state, no config flag, no signature change to any existing export.
+
+## Conclusion
+
+Ship. The change repairs a read-only coherence surface that has reported a false constant since it shipped, adds no authority, and is guarded in both directions by tests that fail against the old wiring and pass against a genuine zero.
+
+## Second-pass review (if required)
+
+Not required — Tier 1. `classify-tier.mjs` matched no safety-invariant pattern for either in-scope file; no new route, no exported class, no config key.
+
+## Evidence pointers
+
+- Defect confirmed on the LIVE server before any edit: `/parallel-work/activities` returned `count: 91, runningCount: 0` with `running:false` for topic 29723 — while that topic's session was confirmed live two independent ways (`GET /sessions` and `tmux ls`).
+- Root cause confirmed in source: `Session` declares neither `topicId` nor `platformId` (grep counts 0 and 0 across `types.ts:45-155`); the live API records carry `platformId` with `topicId: undefined`, keys printed rather than assumed.
+- Negative control executed: reverting the helper to read `s.topicId` fails 2 of the 12 tests while BOTH controls still pass — proving the controls are checks, not echoes. Source restored byte-identical (sha + size 8,331 verified).
+- `tsc --noEmit` exit 0; `tests/unit/parallel-activity-index.test.ts` 12/12 (was 7).
+- Note on scope of `tsc`: `tsconfig` excludes `tests/`, so the typecheck says nothing about the test file; the suite run is the evidence for it.
+
+## Class-Closure Declaration (display-only mirror)
+
+Class: "a lookup that can never find what it is looking for, reporting success." Closed here for the parallel-work `running` flag. It does NOT claim the class is closed repo-wide; in particular, other `as Array<{...}>` casts asserting fields a type does not declare were not audited, and that pattern is what allowed this one to ship.

--- a/src/core/ParallelActivityIndex.ts
+++ b/src/core/ParallelActivityIndex.ts
@@ -42,6 +42,43 @@ const STOPWORDS = new Set([
  * names, camelCase/kebab/snake words, and rare ≥4-char words — minus boilerplate. Bare
  * generic words are dropped so two topics that merely both say "fix the test" don't match.
  */
+/**
+ * Which topics currently have a live session, resolved the SAME way the HTTP
+ * layer resolves a session's topic: from the tmux session name, through the
+ * messaging adapter's registry.
+ *
+ * Earned 2026-08-14. The caller in AgentServer read `s.topicId` off the running
+ * sessions, behind the cast `as Array<{ topicId?: number | null }>`. A `Session`
+ * declares NO topic field at all (see types.ts) and nothing attaches one at
+ * runtime — so the guard `typeof s.topicId === 'number'` was ALWAYS false, the
+ * set was ALWAYS empty, and `running` came back false for every topic forever.
+ * The cast is what let it ship: it asserted a field the type does not have, so
+ * the compiler could never object.
+ *
+ * The index's own unit tests passed throughout, because they inject a stub
+ * `isRunning`. That is why this lives here as a pure, directly-testable
+ * function rather than inline at the wiring site: the bug was in the WIRING,
+ * and only a test that feeds it real-shaped Session objects can catch it.
+ */
+export function runningTopicIds(
+  sessions: ReadonlyArray<{ tmuxSession?: string | null }>,
+  resolveTopic: (tmuxSession: string) => number | null | undefined,
+): Set<number> {
+  const ids = new Set<number>();
+  for (const s of sessions) {
+    const name = typeof s?.tmuxSession === 'string' ? s.tmuxSession : '';
+    if (!name) continue;
+    let topicId: number | null | undefined;
+    try {
+      topicId = resolveTopic(name);
+    } catch {
+      continue; // one unresolvable session must not blind the whole set
+    }
+    if (typeof topicId === 'number' && Number.isFinite(topicId)) ids.add(topicId);
+  }
+  return ids;
+}
+
 export function extractTags(text: string): string[] {
   const out = new Set<string>();
   if (!text) return [];

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -177,7 +177,7 @@ import { setDecisionQualityMachineId } from '../core/decisionQualityTypes.js';
 import { TokenLedgerPoller } from '../monitoring/TokenLedgerPoller.js';
 import { ResourceLedger } from '../monitoring/ResourceLedger.js';
 import { ResourceLedgerPoller } from '../monitoring/ResourceLedgerPoller.js';
-import { ParallelActivityIndex } from '../core/ParallelActivityIndex.js';
+import { ParallelActivityIndex, runningTopicIds } from '../core/ParallelActivityIndex.js';
 import { ParallelWorkSentinel } from '../monitoring/ParallelWorkSentinel.js';
 import { ResourceSampler } from '../monitoring/ResourceSampler.js';
 import { ProcessFootprintMonitor, defaultListProcesses } from '../monitoring/ProcessFootprintMonitor.js';
@@ -1219,13 +1219,18 @@ export class AgentServer {
     if (options.config.stateDir) {
       try {
         const runningTopics = (): Set<number> => {
-          const ids = new Set<number>();
+          // A Session carries no topic field — the topic<->session link lives in
+          // the messaging adapter's registry, keyed on the tmux session name.
+          // This is the SAME resolution GET /sessions uses to attach platformId.
+          // Reading `s.topicId` here (behind a cast asserting a field the type
+          // does not declare) made this set permanently empty, so `running` was
+          // false for every topic since it shipped. See runningTopicIds().
           try {
-            for (const s of options.sessionManager.listRunningSessions() as Array<{ topicId?: number | null }>) {
-              if (typeof s.topicId === 'number') ids.add(s.topicId);
-            }
+            const resolve = (name: string): number | null | undefined =>
+              options.telegram?.getTopicForSession?.(name);
+            return runningTopicIds(options.sessionManager.listRunningSessions(), resolve);
           } catch { /* best-effort */ }
-          return ids;
+          return new Set<number>();
         };
         this.parallelActivityIndex = new ParallelActivityIndex({
           stateDir: options.config.stateDir,

--- a/tests/unit/parallel-activity-index.test.ts
+++ b/tests/unit/parallel-activity-index.test.ts
@@ -14,7 +14,9 @@ import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import {
   ParallelActivityIndex,
   extractTags,
+  runningTopicIds,
 } from '../../src/core/ParallelActivityIndex.js';
+import type { Session } from '../../src/core/types.js';
 import type { EstablishedRef } from '../../src/core/TopicIntent.js';
 
 function ref(partial: Partial<EstablishedRef> & { kind: EstablishedRef['kind']; text: string }): EstablishedRef {
@@ -122,4 +124,57 @@ describe('ParallelActivityIndex', () => {
     expect(t.focus).toBe('investigating the lifeline restart loop');
     expect(t.tags).toContain('investigating');
   });
+});
+
+// ── runningTopicIds — the WIRING, not the index ───────────────────────────
+// Earned 2026-08-14. The index's `running` flag was correct and its tests
+// passed, because they inject a stub `isRunning`. Production wired an
+// `isRunning` that read `s.topicId` off the live sessions — a field a Session
+// does not declare and nothing sets — behind a cast that asserted it existed.
+// The set was therefore ALWAYS empty and every topic reported running:false
+// since the surface shipped. These tests feed REAL-SHAPED Session objects, so
+// they fail if the resolution ever goes back to reading a field off a Session.
+
+describe('runningTopicIds (wiring integrity)', () => {
+  /** A Session shaped like the real thing: a tmux name, and NO topic field. */
+  const session = (tmuxSession: string): Session =>
+    ({ id: tmuxSession, name: tmuxSession, status: 'running', tmuxSession, startedAt: '' } as unknown as Session);
+
+  it('THE DEFECT: resolves the topic from the tmux name — a Session carries no topic field', () => {
+    const sessions = [session('echo-llm-pathway'), session('echo-observer')];
+    const registry: Record<string, number> = { 'echo-llm-pathway': 29723, 'echo-observer': 36966 };
+    const ids = runningTopicIds(sessions, (n) => registry[n] ?? null);
+    // The old wiring produced an EMPTY set here, because these objects have no
+    // `topicId` — which is exactly what a real Session looks like.
+    expect([...ids].sort((a, b) => a - b)).toEqual([29723, 36966]);
+  });
+
+  it('CONTROL: a session the registry cannot place is NOT counted (no invented topics)', () => {
+    const ids = runningTopicIds([session('job-health-check'), session('bob-server')], () => null);
+    expect(ids.size).toBe(0);
+  });
+
+  it('CONTROL: an empty session list yields an empty set — a real zero stays zero', () => {
+    expect(runningTopicIds([], () => 29723).size).toBe(0);
+  });
+
+  it('one unresolvable session does not blind the rest', () => {
+    const ids = runningTopicIds(
+      [session('a'), session('boom'), session('c')],
+      (n) => {
+        if (n === 'boom') throw new Error('registry read failed');
+        return n === 'a' ? 1 : 2;
+      },
+    );
+    expect([...ids].sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  it('ignores sessions with no tmux name and non-finite topic ids', () => {
+    const ids = runningTopicIds(
+      [{ tmuxSession: '' }, { tmuxSession: null }, session('nan')],
+      () => Number.NaN,
+    );
+    expect(ids.size).toBe(0);
+  });
+
 });

--- a/upgrades/next/parallel-work-running-flag-wiring.md
+++ b/upgrades/next/parallel-work-running-flag-wiring.md
@@ -1,0 +1,25 @@
+## What Changed
+
+The cross-topic awareness view has reported that nothing is running anywhere since it shipped — including while the agent reading it was itself running.
+
+- **The live-session flag now resolves each conversation the same way everything else does**, from the terminal session name through the messaging registry. It previously looked for a conversation number attached to each running session; sessions have never carried one, so the search found nothing every time, for every topic.
+- **The count of active topics on that view was a permanent zero.** There was no error and no warning: an empty result and "nothing is running" are indistinguishable from outside.
+- **A faulty type assertion is removed.** The lookup was written behind a note telling the compiler those records had a conversation number. They do not, and the assertion is why nothing objected.
+- **The resolution is now separately testable**, with tests that feed it records shaped like real sessions. The view's existing tests supply a stand-in for the live check, so they could never notice that the real one could not work.
+- **A session that cannot be placed is still not counted**, and one that fails to resolve no longer prevents the others from being found.
+
+## What to Tell Your User
+
+Each conversation gets a row in a shared view showing what it is focused on and whether it is active right now. That "active right now" column is the point — it is what tells one conversation that another is already working on something, so the same job is not done twice.
+
+It has been answering "nothing is active" for every conversation, always. Nothing looked broken, because an empty answer and a genuinely quiet system look exactly the same.
+
+It now answers truthfully. If you have asked why two conversations sometimes duplicated each other's work, this is one reason the safeguard against it could not help.
+
+## Summary of New Capabilities
+
+None. This repairs an existing read-only view. No new command, route, setting, or behaviour, and nothing gates on the corrected value.
+
+## Evidence
+
+The fault was confirmed on the running system before any change: the view reported ninety-one conversations and zero active, including the conversation whose own session was confirmed live two independent ways. The cause was then confirmed in the source, where the session record is shown to declare no conversation field at all and nothing attaches one. Proven in both directions: restoring the old lookup fails two of the twelve tests, while both deliberate control tests continue to pass — those exist to catch the opposite error, inventing activity where there is none, and they hold before and after. Source restored byte-identical after the check, typecheck clean, twelve of twelve tests passing, up from seven.


### PR DESCRIPTION
## ELI16 — the "is anyone else working on this?" answer was always no

Each conversation topic gets a row in a cross-topic view: what it is focused on, and whether a session is live on it right now. That live column is the point — it is what tells one conversation that another is already working on something, so the same job isn't done twice. The agent handbook calls it *"the antidote to self-blindness"* and says to check it before starting substantial new work.

It has answered **"nothing is running anywhere"** for every topic since it shipped — including while the agent reading it was itself running.

The flag was computed by looking for a topic number attached to each running session. Sessions have never carried one. So the search found nothing, every time, for every topic, and `runningCount` was a permanent zero. Nothing looked broken, because an empty result and a genuinely quiet system are indistinguishable from outside.

## Confirmed live before any edit

```
GET /parallel-work/activities → count: 91, runningCount: 0
  topic 29723 → running: false
```

…while topic 29723's session was confirmed running **two independent ways** (`GET /sessions` and `tmux ls`).

## Root cause

```ts
for (const s of options.sessionManager.listRunningSessions() as Array<{ topicId?: number | null }>) {
  if (typeof s.topicId === 'number') ids.add(s.topicId);
}
```

- `Session` (`types.ts:45-155`) declares **neither `topicId` nor `platformId`** — measured, 0 and 0.
- Nothing attaches one at runtime: all 13 `.topicId =` assignments in `src/` are on commitments, jobs, manifests or apprenticeship refs — never a Session.
- The live API's records carry `platformId` with `topicId: undefined` (keys printed, not assumed).

So the guard was always false and the set always empty. **The cast is what let it ship** — it asserted a field the type does not declare, so the compiler could never object. A promise made to the compiler that nothing checks is the same shape as a guarantee in a comment that nothing enforces.

## The fix

The real topic↔session link lives in the messaging adapter's registry keyed on the tmux session name — the same resolution `GET /sessions` already uses to attach `platformId`. The cast is deleted and the resolution extracted to an exported pure `runningTopicIds(sessions, resolveTopic)`.

**Why extracted rather than fixed inline:** the index's own tests inject a stub `isRunning` and passed throughout — they structurally cannot catch a broken *wiring*. The new tests feed **real-shaped Session objects** (tmux name, no topic field), which is the only shape that fails against the old code.

## Proven in both directions

| | old wiring | with fix |
|---|---|---|
| resolves topics from real-shaped Sessions | **FAILS** | passes |
| one unresolvable session doesn't blind the rest | **FAILS** | passes |
| **CONTROL — an unplaceable session is not counted** | **passes** | **passes** |
| **CONTROL — an empty session list stays empty** | **passes** | **passes** |

Reverting the helper to read `s.topicId` gives **2 failed / 10 passed**, with both controls among the passers — so they are checks, not echoes. Source restored byte-identical (sha + 8,331 bytes).

## Verification

- `tsc --noEmit` exit 0 · `tests/unit/parallel-activity-index.test.ts` **12/12** (was 7).
- Note: `tsconfig` excludes `tests/`, so the typecheck says nothing about the test file — the suite run is its evidence.
- Read-only surface; per CLAUDE.md it "never gates". `ParallelWorkSentinel` is observe-only; `?scope=pool` recomputes `runningCount` from the same rows and corrects with it.
- Tier 1 — `riskFloor=1`, no safety-invariant match, no new route, no exported class, no config key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
