### PR TITLE
fix(work-queue): wire isRunning at the second ParallelActivityIndex site

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T16-30-45-310Z-parallel-index-wiring-invariant.json
+++ b/.instar/instar-dev-decisions/2026-08-14T16-30-45-310Z-parallel-index-wiring-invariant.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T16:30:45.310Z",
+  "slug": "parallel-index-wiring-invariant",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 22,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts"
+    ],
+    "addedLines": 20,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-14T16-47-12-665Z-parallel-index-wiring-invariant.json
+++ b/.instar/instar-dev-decisions/2026-08-14T16-47-12-665Z-parallel-index-wiring-invariant.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T16:47:12.665Z",
+  "slug": "parallel-index-wiring-invariant",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 7,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts"
+    ],
+    "addedLines": 6,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-14T16-47-35-330Z-parallel-index-wiring-invariant.json
+++ b/.instar/instar-dev-decisions/2026-08-14T16-47-35-330Z-parallel-index-wiring-invariant.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T16:47:35.330Z",
+  "slug": "parallel-index-wiring-invariant",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 7,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts"
+    ],
+    "addedLines": 6,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-14T16-48-21-949Z-parallel-index-wiring-invariant.json
+++ b/.instar/instar-dev-decisions/2026-08-14T16-48-21-949Z-parallel-index-wiring-invariant.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T16:48:21.949Z",
+  "slug": "parallel-index-wiring-invariant",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 7,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts"
+    ],
+    "addedLines": 6,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/parallel-index-wiring-invariant.eli16.md
+++ b/docs/specs/parallel-index-wiring-invariant.eli16.md
@@ -1,0 +1,37 @@
+# The second place that forgot to ask "is this topic live?"
+
+> The one-line version: the same live-session flag that was broken in the cross-topic view is also unwired in the work queue, so a conversation with a session running on it could never be ranked above a dormant one — and now a test refuses to let any future place forget.
+
+## The problem in one breath
+
+The helper that answers "does this topic have a live session?" is an optional argument. When it is not supplied, the answer defaults to "no" for everything. No error, no warning — an omitted argument and a genuinely quiet system produce the same output.
+
+It was omitted in the work queue's copy. That queue scores each conversation's urgency, and a live one is meant to score seventy against a dormant one's forty. Because the answer was always "no", every conversation scored forty. The higher score was unreachable.
+
+This is the second instance of the same root cause in an hour. The first was the cross-topic view, where the helper WAS supplied but looked for a field that does not exist. Same silent default, two different ways of arriving at it.
+
+## What already exists
+
+- **A correct helper**, added when the first instance was fixed: it resolves a conversation from the terminal session name through the messaging registry, with tests covering it.
+- **A work queue** that gathers pending items from several sources — commitments, improvement actions, feedback, and conversations — and scores each for urgency.
+- **A view** whose live column now works, after the first fix.
+
+## What this adds
+
+**The work queue's copy is wired to the same helper**, so a conversation with a live session can now actually reach the higher urgency.
+
+**And a test that reads the source and fails if any construction of that helper's owner omits the argument.** This is the part meant to outlast the change. Two places forgot within an hour; a third would have been silent in exactly the same way. The test names the offending file, so the next person sees what to fix rather than a bare failure.
+
+## Why a source-reading test, unusually
+
+Normally a test should exercise behaviour, not inspect text. Here the defect *is* a missing argument, and the failure it causes is invisible from the outside: the wrong answer and the right answer are the same value. Behaviour tests could not see it — the existing ones pass a stand-in for the very thing that was missing, which is precisely why they never noticed.
+
+So the check is deliberately structural, and it carries its own controls: one proving it finds construction sites at all, one proving it can detect a missing argument, and one proving its scanner survives nested brackets and inline functions. Without those, a check that silently matched nothing would pass forever and prove nothing — the same failure it exists to prevent.
+
+## The safeguards
+
+**Nothing changes about how urgency is used.** The scores and their meaning are untouched; only the input becomes truthful.
+
+**Failure stays safe, and the fallback is declared rather than hidden.** If the lookup throws, the answer falls back to "not running" and the queue keeps working — a ranking hint must never be able to break the queue it ranks.
+
+The project keeps a running count of places that swallow an error quietly, and refuses to let that count grow. This change tripped it, which was the count doing its job. Rather than raise the allowance, the fallback carries an explicit marker and a written reason: "not running" is the same answer the missing argument produced anyway, and reporting a degradation here would fire on every pass for any session that is not a chat conversation. The declaration is the point — a silent fallback that is written down stops being silent.

--- a/docs/specs/parallel-index-wiring-invariant.side-effects.md
+++ b/docs/specs/parallel-index-wiring-invariant.side-effects.md
@@ -1,0 +1,83 @@
+# Side-Effects Review — ParallelActivityIndex wiring invariant (second construction site)
+
+**Version / slug:** `parallel-index-wiring-invariant`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent)`
+**Second-pass reviewer:** `not required (Tier 1, read-only scoring input, no authority)`
+
+## Summary of the change
+
+`ParallelActivityIndex.opts.isRunning` is optional and defaults to `false` (`this.opts.isRunning?.(topicId) ?? false`). There are two construction sites. `AgentServer.ts` supplies one (repaired in PR #1870). `src/commands/server.ts:24682` supplied NONE, so its `activities()` reported `running:false` for every topic — and the `WorkQueueRegistry` `topics` source scores `urgency: a.running ? 70 : 40`, pinning every conversation at 40 with 70 unreachable. This wires that site to the same `runningTopicIds` helper, and adds `tests/unit/parallel-activity-index-wiring.test.ts`: a structural invariant asserting EVERY `new ParallelActivityIndex(` in `src/` supplies `isRunning`.
+
+## Decision-point inventory
+
+No decision point added or removed. One is **repaired**: "is this topic live, for urgency scoring?" previously had one reachable outcome (always false); it now has two. The urgency values (70/40), their meaning, and every other WorkQueueRegistry source are untouched.
+
+## 1. Over-block
+
+Could a topic be scored 70 when it should be 40? Only if the resolver wrongly places a session. `runningTopicIds` counts a session only when the registry returns a finite number; `null`/`undefined`/`NaN`/missing tmux name are skipped, each pinned by tests from PR #1870. This is a scoring hint on an advisory queue, so even a wrong 70 reorders a list — it blocks nothing.
+
+## 2. Under-block
+
+The previous behaviour WAS the total under-report. Remaining surface: a live session whose topic the adapter cannot resolve stays at 40 — correct, since no conversation is bound to it.
+
+## 3. Level-of-abstraction fit
+
+The wiring belongs at the construction site (only the bootstrap knows which resolver to supply); the invariant belongs in a test that reads construction sites, because a missing constructor argument is not observable from behaviour — the omitted-argument default and the true answer are the same value. The existing behaviour tests inject a stub `isRunning`, which is exactly why they could not catch either instance.
+
+## 4. Signal vs authority compliance
+
+**Signal only.** `WorkQueueRegistry` supplies an advisory ordered list; nothing here gates, spawns, kills, or routes. No exit code, route, or authority changes.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+None introduced. A registry lookup plus `Number.isFinite`, and a source-text presence check in a test. No heuristic, model call, or threshold.
+
+## 5. Interactions
+
+Blast radius measured: `runningTopicIds` gains one importer (`src/commands/server.ts`), joining `AgentServer.ts` and the two test files. The `ParallelActivityIndex` constructor signature is unchanged. The only consumer of this instance's `running` is the `topics` urgency expression at `server.ts:24704`. `sessionManager` (declared `:5955`) and `telegram` (`:7276`) are both in scope at the construction site — verified, since both are passed by name to the `AgentServer` construction below it.
+
+## 6. External surfaces
+
+None. No network call, new file at runtime, persisted state, credential, telemetry, or route. The new test reads files from `src/` at test time only.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No new operator-visible text. The invariant's failure message names the offending file (`construction sites without isRunning: commands/server.ts`) so a future violation is actionable rather than a bare assertion diff.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+No issue identified. Local scoring input; no shared state, lease, or replication.
+
+## 8. Rollback cost
+
+Very low. One source file plus one new test file, one commit, no migration, no persisted state, no config flag, no signature change.
+
+## Conclusion
+
+Ship. It repairs the second instance of a silent optional-dependency default and leaves behind a check that fails for any future construction site that forgets — the structural half, not just the fix.
+
+## Second-pass review (if required)
+
+Not required — Tier 1. `classify-tier.mjs` matched no safety-invariant pattern for `src/commands/server.ts`; no new route, exported class, or config key.
+
+## Evidence pointers
+
+- Defect verified in source before any edit: `server.ts:24682` constructed with `{ stateDir }` only, and its sole consumer at `:24704` reads `a.running ? 70 : 40`.
+- Root cause is shared with PR #1870: `isRunning` is optional with a `?? false` default, so an omitted argument is indistinguishable from "nothing is running".
+- Negative control executed: reverting the wiring makes the invariant test FAIL and NAME the file (`commands/server.ts`), while its three controls still pass. Source restored byte-identical (sha + size 1,524,401 verified).
+- The invariant carries its own controls: the sweep finds construction sites (non-zero), it detects a site missing `isRunning`, and its paren-depth extractor survives nested parens and arrow bodies — so it cannot silently match nothing.
+- `tsc --noEmit` exit 0; 16/16 across both parallel-activity suites, in a dedicated worktree on main's dependency set.
+
+## Declared silent fallback (no-silent-fallbacks ratchet)
+
+The `catch` returns `false` and carries `@silent-fallback-ok` with its reason. The ratchet
+(`tests/unit/no-silent-fallbacks.test.ts`, BASELINE 495) FAILED on the first CI run at 496 — correctly,
+since the change added a swallowing catch. The baseline was NOT raised. `false` is the same value the
+omitted optional dependency produced, so this is the pre-existing behaviour for an unresolvable topic
+rather than a new hidden heuristic; a DegradationReporter call here would fire every pass for any
+non-Telegram session, and a ranking hint must never break the queue it ranks.
+
+## Class-Closure Declaration (display-only mirror)
+
+Class: "an optional dependency whose default is indistinguishable from a real answer." Closed for `ParallelActivityIndex.isRunning` at BOTH construction sites, and future sites are now guarded by the invariant. It does NOT claim closure for other optional-dependency defaults in the codebase (e.g. `?? []` enrichment defaults), which were not audited here.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -24675,11 +24675,34 @@ export async function startServer(options: StartOptions): Promise<void> {
     } catch (err) { /* @silent-fallback-ok: fleet-dark optional observer; failure is logged and adds no authority */ console.warn('[AutonomousThroughputFloor] init failed:', (err as Error).message); }
     const { WorkQueueRegistry } = await import('../core/WorkQueue.js');
     const { FeedbackProcessingService, resolveCanonicalStoreDir } = await import('../feedback-factory/processing/FeedbackProcessingService.js');
-    const { ParallelActivityIndex } = await import('../core/ParallelActivityIndex.js');
+    const { ParallelActivityIndex, runningTopicIds } = await import('../core/ParallelActivityIndex.js');
     const ageDays = (value: string | undefined): number => value ? Math.max(0, (Date.now() - Date.parse(value)) / 86_400_000) : 0;
     const feedbackStoreDir = resolveCanonicalStoreDir(config);
     const feedbackReader = feedbackStoreDir ? new FeedbackProcessingService({ dataDir: feedbackStoreDir }) : null;
-    const topicActivityIndex = new ParallelActivityIndex({ stateDir: config.stateDir });
+    // `isRunning` must be wired here too, not only on the AgentServer instance.
+    // The work queue below scores a topic `a.running ? 70 : 40`, so an unwired
+    // predicate silently pins EVERY topic at 40 — a topic with a live session
+    // could never outrank a dormant one. Same resolution AgentServer uses: a
+    // Session carries no topic field; the link lives in the messaging adapter's
+    // registry, keyed on the tmux session name.
+    const topicActivityIndex = new ParallelActivityIndex({
+      stateDir: config.stateDir,
+      isRunning: (topicId) => {
+        try {
+          return runningTopicIds(
+            sessionManager.listRunningSessions(),
+            (name) => telegram?.getTopicForSession?.(name),
+          ).has(topicId);
+        } catch {
+          // @silent-fallback-ok: this is a scoring HINT on an advisory queue, and
+          // `false` is the pre-existing behaviour for an unresolvable topic — the
+          // same value the optional dependency defaults to. Reporting a
+          // degradation here would fire on every tick for a non-Telegram session,
+          // and a ranking hint must never be able to break the queue it ranks.
+          return false;
+        }
+      },
+    });
     const workQueue = new WorkQueueRegistry({
       commitments: () => (commitmentTracker?.getActive() ?? []).map((c) => ({
         id: c.id, source: 'commitment' as const, sourceRef: c.id, title: c.userRequest,

--- a/tests/unit/parallel-activity-index-wiring.test.ts
+++ b/tests/unit/parallel-activity-index-wiring.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Structural wiring invariant: EVERY `new ParallelActivityIndex(...)` in src/
+ * must supply `isRunning`.
+ *
+ * Earned 2026-08-14, twice in one hour:
+ *  1. AgentServer supplied one, but it read `s.topicId` off Sessions — a field
+ *     a Session does not declare — so it never returned true (fixed: PR #1870).
+ *  2. `src/commands/server.ts` supplied NONE at all. `isRunning` is optional
+ *     (`this.opts.isRunning?.(topicId) ?? false`), so an omitted predicate is
+ *     indistinguishable from "nothing is running" — and the work queue scores
+ *     topics `a.running ? 70 : 40`, so every topic was pinned at 40 forever.
+ *
+ * A default of `false` on an optional dependency is silent by construction: no
+ * error, no warning, and the wrong answer looks exactly like the right one.
+ * The only thing that can catch an omitted argument is a check that reads the
+ * construction sites — so this test does that, and fails for any FUTURE site
+ * that forgets, not just the two that did.
+ */
+
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../src');
+
+/** Every .ts file under src/. */
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) sourceFiles(p, out);
+    else if (e.name.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Extract the argument text of each `new ParallelActivityIndex(` occurrence by
+ * scanning forward with paren depth — a regex cannot survive the nested object
+ * literals and arrow bodies these arguments contain.
+ */
+export function constructionArgs(source: string): string[] {
+  const out: string[] = [];
+  const needle = 'new ParallelActivityIndex(';
+  let i = source.indexOf(needle);
+  while (i !== -1) {
+    let depth = 0;
+    let j = i + needle.length - 1; // at the '('
+    let start = j + 1;
+    for (; j < source.length; j++) {
+      const c = source[j];
+      if (c === '(') depth++;
+      else if (c === ')') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    out.push(source.slice(start, j));
+    i = source.indexOf(needle, j);
+  }
+  return out;
+}
+
+describe('ParallelActivityIndex construction sites (wiring invariant)', () => {
+  const files = sourceFiles(SRC);
+
+  it('CONTROL: the sweep actually finds construction sites', () => {
+    const total = files.reduce(
+      (n, f) => n + constructionArgs(fs.readFileSync(f, 'utf8')).length,
+      0,
+    );
+    // If this is 0 the invariant below is vacuous — a check that cannot fail.
+    expect(total).toBeGreaterThan(0);
+  });
+
+  it('CONTROL: the extractor detects a site MISSING isRunning', () => {
+    const args = constructionArgs(
+      'const x = new ParallelActivityIndex({ stateDir: dir });',
+    );
+    expect(args).toHaveLength(1);
+    expect(args[0]).not.toMatch(/isRunning/);
+  });
+
+  it('CONTROL: the extractor survives nested parens and arrow bodies', () => {
+    const args = constructionArgs(
+      'new ParallelActivityIndex({ stateDir: d, isRunning: (t) => f(g(t)).has(t) })',
+    );
+    expect(args).toHaveLength(1);
+    expect(args[0]).toMatch(/isRunning/);
+  });
+
+  it('every construction site in src/ supplies isRunning', () => {
+    const missing: string[] = [];
+    for (const f of files) {
+      for (const args of constructionArgs(fs.readFileSync(f, 'utf8'))) {
+        if (!/\bisRunning\b/.test(args)) missing.push(path.relative(SRC, f));
+      }
+    }
+    expect(missing, `construction sites without isRunning: ${missing.join(', ')}`).toEqual([]);
+  });
+});

--- a/upgrades/next/parallel-index-wiring-invariant.md
+++ b/upgrades/next/parallel-index-wiring-invariant.md
@@ -1,0 +1,23 @@
+## What Changed
+
+The same "is this conversation live right now?" answer that was broken in the cross-topic view is also unwired in the work queue — and now a test stops any future place forgetting it.
+
+- **The work queue's copy never asked the question.** The helper that answers it is an optional argument; when it is omitted the answer defaults to "no" for everything, with no error and no warning.
+- **So every conversation scored the same urgency.** The queue is meant to rank a conversation with a live session above a dormant one. Because the answer was always "no", the higher rank was unreachable.
+- **This is the second instance of one root cause in an hour.** The first was the cross-topic view, where the answer was supplied but looked for a field that does not exist. Same silent default, arrived at two different ways.
+- **A structural check now reads the source and fails if any place constructs this without supplying the answer**, naming the file so the fix is obvious. Two places forgot within an hour; a third would have failed exactly as quietly.
+- **Failure stays safe.** If the lookup errors, the answer falls back to "not running" and the queue keeps working.
+
+## What to Tell Your User
+
+There is an internal list that ranks what deserves attention, and a conversation you are actively working in is supposed to rank above one that has been quiet for days. It never did — the part that checks whether a conversation is active was never plugged in, so everything looked equally dormant.
+
+Nothing appeared broken, because "no conversations are active" and "we forgot to check" produce exactly the same answer. That is the whole difficulty with this kind of fault, and it is why the fix comes with a check that refuses to let it recur silently somewhere new.
+
+## Summary of New Capabilities
+
+None. This repairs an input to existing ranking and adds a test. No new command, route, setting, or behaviour, and nothing gates on the corrected value.
+
+## Evidence
+
+The fault was confirmed in the source before any change: the construction supplied only a directory, and its one consumer scores a live conversation at seventy against forty. Proven in both directions — reverting the wiring makes the new check fail and name the offending file, while its three own controls continue to pass. Those controls exist because a structural check that silently matched nothing would pass forever and prove nothing: one proves it finds construction sites at all, one proves it can detect a missing argument, and one proves its scanner survives nested brackets and inline functions. Source restored byte-identical after the check, typecheck clean, sixteen of sixteen tests passing across both related suites, verified in a dedicated working copy on the mainline dependency set.


### PR DESCRIPTION
## ELI16 — the second place that forgot to ask "is this topic live?"

The helper that answers *"does this topic have a live session?"* is an **optional** argument, defaulting to `false`:

```ts
running: this.opts.isRunning?.(topicId) ?? false
```

When it is omitted, every topic answers "not running" — with no error and no warning. An omitted argument and a genuinely quiet system produce **the same value**, which is why neither instance of this was visible from the outside.

There are two construction sites. `AgentServer` supplies one (repaired in #1870, where the supplied predicate read a field a `Session` does not declare). **`src/commands/server.ts:24682` supplied none at all** — and its one consumer scores urgency:

```ts
urgency: a.running ? 70 : 40
```

So every conversation was pinned at 40 and **70 was unreachable**. A topic you are actively working in could never outrank one dormant for days.

## The structural half

Two places forgot the same argument within an hour. A third would have failed exactly as quietly, so the fix ships with a test that reads **every** `new ParallelActivityIndex(` in `src/` and fails if one omits `isRunning`, naming the offending file.

**Why a source-reading test, unusually:** the defect *is* a missing argument, and its effect is invisible to behaviour tests — the wrong answer and the right answer are the same value. The existing suite injects a stub `isRunning`, which is precisely why it caught neither instance.

So the invariant carries **its own controls**, because a structural check that silently matched nothing would pass forever and prove nothing:
- the sweep finds construction sites at all (non-zero),
- it detects a site *missing* `isRunning`,
- its paren-depth extractor survives nested parens and arrow bodies (a regex cannot).

## Proven in both directions

| | wiring reverted | with fix |
|---|---|---|
| every construction site supplies `isRunning` | **FAILS** — names `commands/server.ts` | passes |
| CONTROL: sweep finds construction sites | passes | passes |
| CONTROL: detects a site missing the argument | passes | passes |
| CONTROL: extractor survives nested parens | passes | passes |

Source restored byte-identical after the mutation (sha + 1,524,401 bytes).

## Verification

- `sessionManager` (`:5955`) and `telegram` (`:7276`) verified in scope at the construction site — both are passed by name to the `AgentServer` construction just below it.
- Failure falls back to not-running: a scoring hint must never break the queue it scores.
- `tsc --noEmit` exit 0 · **16/16** across `parallel-activity-index` + the new wiring suite.
- Built in a **dedicated** worktree on main's dependency set — deliberately not the checkout a peer agent was concurrently auditing.
- Tier 1 — the gate's own classifier independently computed `suggestedTier=1 (size=1, riskFloor=1, 22 LOC across 1 file)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
