### PR TITLE
fix(parallel-work): the wiring invariant was blind to aliased constructions

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T17-29-35-635Z-parallel-index-alias-aware.json
+++ b/.instar/instar-dev-decisions/2026-08-14T17-29-35-635Z-parallel-index-alias-aware.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T17:29:35.635Z",
+  "slug": "parallel-index-alias-aware",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 44,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts"
+    ],
+    "addedLines": 40,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/parallel-index-alias-aware.eli16.md
+++ b/docs/specs/parallel-index-alias-aware.eli16.md
@@ -1,0 +1,37 @@
+# The guard I shipped this morning was blind to renaming
+
+> The one-line version: a check written to catch a missing argument matched the class by its *name*, so two places that import it under a different name were invisible to it — including one feeding the component that decides where work runs.
+
+## The problem in one breath
+
+Earlier today a check was added that reads the source and fails if any construction of a particular class forgets a required argument. It passed. It was also wrong.
+
+It looked for the class by the literal text of its name. Two places in the codebase import that class and immediately rename it locally — a perfectly ordinary thing to do — and construct it under the new name. The check never saw them. Both omit the argument.
+
+So the guard reported "every construction supplies it" while two did not. A check that matches a name as text is blind to renaming, which is the same shape of fault it was written to catch.
+
+## What already exists
+
+- **The class** answers "does this conversation have a live session right now?" via an optional helper. When the helper is absent the answer defaults to "no" for everything, and an omitted argument is indistinguishable from a genuinely quiet system.
+- **Two constructions were fixed today** — one supplied a broken helper, the other supplied none.
+- **The check** added alongside the second fix, to stop a third place forgetting.
+
+## What this adds
+
+**The check now resolves every local name the class is bound to**, then looks for constructions under each. Renaming it on import no longer hides a construction site.
+
+**The two hidden sites are wired.** One matters immediately: it feeds a read named "active conversations on this machine" into the component that decides where work should run — so that component could never see an active conversation. The other reads only a conversation's focus today and does not consume the live flag, but it is wired anyway, because leaving it unwired means a future reader of that field silently inherits a wrong answer.
+
+## How this was found
+
+Not by me. A peer agent was given a bounded audit — find optional dependencies whose default is indistinguishable from a real answer — with a hard requirement to prove its search could actually find a known example before reporting any result. It resolved the class through the type system rather than matching its name as text, and found four construction sites where my check found two.
+
+That method is better than mine, and the fix adopts the lesson rather than patching around it.
+
+## The safeguards
+
+**A test that would have failed before this change.** It constructs the class under a renamed import and asserts the check finds it. Run against yesterday's version of the check, it fails.
+
+**The existing controls stay.** One proves the search finds constructions at all, one proves it detects a missing argument, one proves its scanner survives nested brackets and inline functions. A structural check that silently matched nothing would pass forever and prove nothing — which is precisely how the blind version passed.
+
+**Failure stays safe.** Both newly-wired lookups fall back to "not running" if they throw, which is the same value the missing argument produced. A hint about where work is running must never break the thing reading it.

--- a/docs/specs/parallel-index-alias-aware.side-effects.md
+++ b/docs/specs/parallel-index-alias-aware.side-effects.md
@@ -1,0 +1,82 @@
+# Side-Effects Review — alias-aware wiring invariant + the two hidden construction sites
+
+**Version / slug:** `parallel-index-alias-aware`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent)`
+**Second-pass reviewer:** `peer audit by instar-codey (optional-dep-default-audit, 2026-08-14) — this change originates from its finding`
+
+## Summary of the change
+
+PR #1871 added `tests/unit/parallel-activity-index-wiring.test.ts`, asserting every `new ParallelActivityIndex(` in `src/` supplies `isRunning`. It scanned for the LITERAL class name and therefore missed two sites that bind the class under an alias:
+
+```ts
+const { ParallelActivityIndex: AHParallelActivityIndex } = await import(...)  // server.ts:14893
+const ahActivityIndex = new AHParallelActivityIndex({ stateDir });            // :14896 — no isRunning
+const { ParallelActivityIndex: SOActivityIndex } = await import(...)          // :15630
+const soActivityIndex = new SOActivityIndex({ stateDir });                    // :15631 — no isRunning
+```
+
+The invariant PASSED in CI against a tree containing both. This change makes it resolve every local binding of the class before scanning, and wires `isRunning` at both sites. Found by `instar-codey`'s optional-dependency audit, which resolved the class through the TypeScript checker instead of matching its name as text.
+
+## Decision-point inventory
+
+No decision point is added or removed. One is **repaired at two further sites**: "does this topic have a live session?" The `SOActivityIndex` instance feeds `SeamlessOrchestratorEngine.reads.activeTopicsOnThisMachine`, which maps `running: a.running` — so that read could never report an active topic. The `AHParallelActivityIndex` instance consumes only `topicId`/`focus` today; wiring it is prophylactic, stated as such.
+
+## 1. Over-block
+
+Could a topic now be reported running when it is not? Only if the resolver mis-places a session; `runningTopicIds` counts only finite registry results, pinned by tests from PR #1870. The orchestrator is dryRun-first by config (`soDryRun = soCfg.dryRun !== false`), so even a wrong `true` changes a hint, not an action.
+
+## 2. Under-block
+
+The previous behaviour WAS the under-report at both sites. Residual: a live session whose topic the messaging registry cannot resolve stays false — correct, since no conversation is bound to it.
+
+## 3. Level-of-abstraction fit
+
+The wiring belongs at each construction site (only the bootstrap knows the resolver). The invariant belongs in a source-reading test, because an omitted constructor argument is not observable from behaviour — the default and the true answer are the same value. The alias resolution belongs inside that test's extractor, since the blindness was in HOW it identified the class, not in what it asserted.
+
+## 4. Signal vs authority compliance
+
+**Signal only.** `SeamlessOrchestratorEngine` is dryRun-first and the work-queue urgency is advisory. Nothing here gates, spawns, kills, or routes; no exit code, route, or authority changes.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+None introduced. A registry lookup plus `Number.isFinite`; the test performs string/paren analysis. No heuristic, model call, or threshold.
+
+## 5. Interactions
+
+Blast radius measured: `runningTopicIds` gains two importers, both in `src/commands/server.ts`, joining `AgentServer.ts` and the two tests. The `ParallelActivityIndex` constructor signature is unchanged. All four `src/` construction sites now supply `isRunning`; the invariant enforces it under any local name.
+
+## 6. External surfaces
+
+None. No network call, new file at runtime, persisted state, credential, telemetry, or route.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No new operator-visible text. The invariant's failure names the offending file, unchanged.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+`SeamlessOrchestratorEngine` reasons about placement across machines, so a permanently-false `activeTopicsOnThisMachine` was a cross-machine coherence defect specifically. Correcting it makes the orchestrator's own input truthful; it remains dryRun-first and gates nothing.
+
+## 8. Rollback cost
+
+Very low. One source file, one test file, one commit; no migration, persisted state, config flag, or signature change.
+
+## Conclusion
+
+Ship. It repairs a guard that was blind in the same way as the defect it guards, closes the two construction sites that blindness hid, and the more consequential of the two feeds the placement orchestrator.
+
+## Second-pass review
+
+**This change IS the second pass**, performed by a peer agent rather than by me. `instar-codey`'s `optional-dep-default-audit` (tree `codey-audit-readonly`, commit `7e50a3f82`) reported 9 confirmed-unwired optional-dependency surfaces; item 1 is this one, and its "Positive Control" section states plainly that `ParallelActivityIndex.isRunning` "does **not** come back ALL-WIRED if 'every construction site in src/' is applied literally." I verified both sites in source myself before acting.
+
+## Evidence pointers
+
+- The blindness is demonstrated, not argued: on the pre-change tree the existing invariant passes **4/4** while two unwired aliased sites exist. After making it alias-aware it FAILS, naming `commands/server.ts` twice. After wiring, **5/5**.
+- Consumption verified in source: `activeTopicsOnThisMachine: () => soActivityIndex.activities(Date.now()).map((a) => ({ ..., running: a.running }))`.
+- A new test constructs the class under a renamed import and asserts the extractor finds it — it fails against the previous extractor.
+- `tsc --noEmit` exit 0; 10/10 across the wiring suite and the no-silent-fallbacks ratchet (both new catches carry `@silent-fallback-ok` with reasons; the baseline is NOT raised).
+
+## Class-Closure Declaration (display-only mirror)
+
+Class: "a structural check that identifies its target by name and is therefore blind to renaming." Closed for this invariant only. **It is NOT closed generally** — other source-reading lints in this repo may match identifiers as text and were not audited here. Codey's audit also lists 8 further confirmed-unwired optional dependencies (`nicknameFor`, `purposeFor`, `ConversationRegistry.isJournalFsyncDisabled`, `ActiveWorkSilenceSentinel.isCleanIdlePrompt`, `TelemetryHeartbeat.agentCountFn`, `SessionManager.spawnAccountResolver`, `WriteAdmission.nicknameOf`/`selfNickname`) which this change does NOT address.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -14890,10 +14890,28 @@ export async function startServer(options: StartOptions): Promise<void> {
                 autonomousRunRemainingForTopic,
                 readAutonomousRunMarkers,
               } = await import('../core/AutonomousSessions.js');
-              const { ParallelActivityIndex: AHParallelActivityIndex } = await import('../core/ParallelActivityIndex.js');
+              const { ParallelActivityIndex: AHParallelActivityIndex, runningTopicIds: ahRunningTopicIds } = await import('../core/ParallelActivityIndex.js');
               // Own ParallelActivityIndex (focus source) — fetched ONCE per tick
               // and indexed by topic inside the deps closure.
-              const ahActivityIndex = new AHParallelActivityIndex({ stateDir: config.stateDir });
+              // Wired even though this caller reads only topicId/focus today: an
+              // omitted `isRunning` is indistinguishable from "nothing is running",
+              // so a future consumer of `running` here would inherit a silent false.
+              const ahActivityIndex = new AHParallelActivityIndex({
+                stateDir: config.stateDir,
+                isRunning: (topicId) => {
+                  try {
+                    return ahRunningTopicIds(
+                      sessionManager.listRunningSessions(),
+                      (name) => telegram?.getTopicForSession?.(name),
+                    ).has(topicId);
+                  } catch {
+                    // @silent-fallback-ok: `false` is the pre-existing value for an
+                    // unresolvable topic — the same value the optional dependency
+                    // defaults to — and this index feeds a focus lookup, never a gate.
+                    return false;
+                  }
+                },
+              });
               const ahRunStateStore = new AutonomousHeartbeatRunStateStore(
                 path.join(config.stateDir, 'state', 'autonomous-heartbeat.json'),
               );
@@ -15627,8 +15645,26 @@ export async function startServer(options: StartOptions): Promise<void> {
           const { OrchestratorActuator } = await import('../core/OrchestratorActuator.js');
           const { OrchestratorPoller } = await import('../monitoring/OrchestratorPoller.js');
           const { OscillationBreaker } = await import('../core/OscillationBreaker.js');
-          const { ParallelActivityIndex: SOActivityIndex } = await import('../core/ParallelActivityIndex.js');
-          const soActivityIndex = new SOActivityIndex({ stateDir: config.stateDir });
+          const { ParallelActivityIndex: SOActivityIndex, runningTopicIds: soRunningTopicIds } = await import('../core/ParallelActivityIndex.js');
+          // MUST be wired: `reads.activeTopicsOnThisMachine` below maps `running:
+          // a.running` into SeamlessOrchestratorEngine. Unwired, a read literally
+          // named "activeTopicsOnThisMachine" could never see an active topic.
+          const soActivityIndex = new SOActivityIndex({
+            stateDir: config.stateDir,
+            isRunning: (topicId) => {
+              try {
+                return soRunningTopicIds(
+                  sessionManager.listRunningSessions(),
+                  (name) => telegram?.getTopicForSession?.(name),
+                ).has(topicId);
+              } catch {
+                // @silent-fallback-ok: `false` is the pre-existing value for an
+                // unresolvable topic, and the orchestrator is dryRun-first; a
+                // placement hint must never break the poller that reads it.
+                return false;
+              }
+            },
+          });
           const soBreaker = new OscillationBreaker({
             oscillationWindowMs: soNum(soCfg.oscillationWindowMs, 3_600_000),
             blacklistTtlMs: soNum(soCfg.blacklistTtlMs, 86_400_000),

--- a/tests/unit/parallel-activity-index-wiring.test.ts
+++ b/tests/unit/parallel-activity-index-wiring.test.ts
@@ -35,13 +35,40 @@ function sourceFiles(dir: string, out: string[] = []): string[] {
 }
 
 /**
- * Extract the argument text of each `new ParallelActivityIndex(` occurrence by
- * scanning forward with paren depth — a regex cannot survive the nested object
- * literals and arrow bodies these arguments contain.
+ * Every LOCAL name `ParallelActivityIndex` is bound to in this file.
+ *
+ * Earned 2026-08-14, hours after the first version of this test merged: the
+ * original scanned for the literal `new ParallelActivityIndex(` and therefore
+ * PASSED against a tree containing two unwired sites, because both bind the
+ * class under an alias:
+ *
+ *   const { ParallelActivityIndex: SOActivityIndex } = await import(...)
+ *   const soActivityIndex = new SOActivityIndex({ stateDir })   // no isRunning
+ *
+ * A structural check that matches a name as TEXT is blind to renaming — which
+ * is the same shape as the defect it exists to catch. Found by a peer agent
+ * auditing with the TypeScript checker instead of string matching.
+ */
+export function localBindings(source: string): string[] {
+  const names = new Set<string>(['ParallelActivityIndex']);
+  // `{ ParallelActivityIndex: Alias }` in an import or a destructured await import.
+  for (const m of source.matchAll(/ParallelActivityIndex\s*:\s*([A-Za-z_$][\w$]*)/g)) {
+    names.add(m[1]);
+  }
+  return [...names];
+}
+
+/**
+ * Extract the argument text of each construction of the class — under ANY local
+ * name it is bound to — by scanning forward with paren depth. A regex cannot
+ * survive the nested object literals and arrow bodies these arguments contain.
  */
 export function constructionArgs(source: string): string[] {
+  return localBindings(source).flatMap((name) => argsForNeedle(source, `new ${name}(`));
+}
+
+function argsForNeedle(source: string, needle: string): string[] {
   const out: string[] = [];
-  const needle = 'new ParallelActivityIndex(';
   let i = source.indexOf(needle);
   while (i !== -1) {
     let depth = 0;
@@ -79,6 +106,17 @@ describe('ParallelActivityIndex construction sites (wiring invariant)', () => {
     );
     expect(args).toHaveLength(1);
     expect(args[0]).not.toMatch(/isRunning/);
+  });
+
+  it('THE SECOND DEFECT: an ALIASED construction is found (it was invisible before)', () => {
+    const src = [
+      "const { ParallelActivityIndex: SOActivityIndex } = await import('../core/ParallelActivityIndex.js');",
+      'const soActivityIndex = new SOActivityIndex({ stateDir: config.stateDir });',
+    ].join('\n');
+    expect(localBindings(src)).toContain('SOActivityIndex');
+    const args = constructionArgs(src);
+    expect(args).toHaveLength(1);
+    expect(args[0]).not.toMatch(/isRunning/); // and it is correctly reported as missing
   });
 
   it('CONTROL: the extractor survives nested parens and arrow bodies', () => {

--- a/upgrades/next/parallel-index-alias-aware.md
+++ b/upgrades/next/parallel-index-alias-aware.md
@@ -1,0 +1,26 @@
+## What Changed
+
+The check added earlier today to stop a required argument being forgotten was itself blind to renaming — and two places it could not see had forgotten it.
+
+- **The check matched the class by the literal text of its name.** Two places import that class and rename it locally, which is ordinary, and construct it under the new name. It never saw them, and reported that every construction was correct while two were not.
+- **It now resolves every local name the class is bound to** before scanning, so renaming on import no longer hides a construction site.
+- **Both hidden places are wired.** One matters immediately: it feeds a read named "active conversations on this machine" into the component that decides where work runs, so that component could never see an active conversation. The other reads only a conversation's focus today, and is wired anyway so a future reader cannot silently inherit a wrong answer.
+- **Failure stays safe.** Both lookups fall back to "not running" if they throw — the same value the missing argument produced.
+
+## What to Tell Your User
+
+A safeguard was added this morning to make sure a particular setting is never left out. It passed, and it was wrong: it looked for the thing by name, and two places refer to it by a different name locally. Both had left the setting out.
+
+One of them feeds the part that decides which machine should pick up work, through a reading described as "which conversations are active here" — which was always empty. That is now correct.
+
+The lesson is the one the safeguard existed to teach, turned on the safeguard itself: something that checks by matching a name can be defeated by renaming, and looks entirely healthy while it happens.
+
+## Summary of New Capabilities
+
+None. This corrects a test's target resolution and supplies an existing setting at two further places. No new command, route, setting, or behaviour, and nothing gates on the corrected values.
+
+## Evidence
+
+Demonstrated rather than argued: on the tree before this change, the existing check passes every one of its assertions while two unsupplied sites exist. Made name-aware, it fails and names the file twice; with both sites supplied, it passes again. A new test constructs the class under a renamed import and asserts the check finds it — that test fails against the previous version. Typecheck clean and ten of ten tests passing across the check and the project's silent-failure ratchet, whose allowance was not raised: both new fallbacks carry an explicit marker and a written reason.
+
+This was found by a second agent running an independent audit, which resolved the class through the type system instead of matching its name. It found four construction sites where the original check found two.


### PR DESCRIPTION
## ELI16 — the guard I shipped this morning was blind to renaming

PR #1871 (merged a few hours ago) added a test asserting that **every** construction of `ParallelActivityIndex` in `src/` supplies `isRunning`. It passed 4/4. It was also wrong.

It scanned for the **literal** class name. Two sites bind the class under an alias — an ordinary thing to do — and construct it under the new name:

```ts
const { ParallelActivityIndex: SOActivityIndex } = await import('../core/ParallelActivityIndex.js');
const soActivityIndex = new SOActivityIndex({ stateDir: config.stateDir });   // no isRunning
```

Both omit the argument. **A structural check that identifies its target by NAME is blind to renaming — the same shape as the defect it exists to guard.**

## The consequential one

`src/commands/server.ts:15631` feeds `SeamlessOrchestratorEngine`:

```ts
activeTopicsOnThisMachine: () => soActivityIndex.activities(Date.now()).map((a) => ({
  topic: a.topicId, focus: a.focus ?? '', lastActivityMs: a.updatedAt ?? 0, running: a.running,
})),
```

A read literally named **`activeTopicsOnThisMachine`**, feeding the component that reasons about where work should run — fed by an index that could never report a topic active. The other site (`:14896`) consumes only `topicId`/`focus` today and is wired prophylactically, stated as such.

## How it was found — not by me

`instar-codey` ran an independent optional-dependency audit (read-only checkout, commit `7e50a3f82`) with a hard requirement: prove the sweep can find a known example before reporting anything. It resolved the class **through the TypeScript checker** rather than matching its name as text, and found **four** construction sites where my test found two. Its Positive Control section says so outright:

> "Important result: it does **not** come back ALL-WIRED if 'every construction site in `src/`' is applied literally."

I verified both sites in source myself before acting. The fix adopts the lesson rather than patching around it.

## Proven in both directions

| | before this change | after |
|---|---|---|
| invariant on a tree with 2 unwired aliased sites | **passes 4/4 (the bug)** | **FAILS**, names `commands/server.ts` twice |
| aliased construction is detected | **not detected** | detected |
| both sites wired → invariant green | — | **5/5** |
| CONTROL: sweep finds construction sites | passes | passes |
| CONTROL: detects a site missing the argument | passes | passes |
| CONTROL: extractor survives nested parens / arrow bodies | passes | passes |

A new test constructs the class under a renamed import and asserts the extractor finds it — it fails against the previous extractor.

## Verification

- `tsc --noEmit` exit 0 · **10/10** across the wiring suite and the `no-silent-fallbacks` ratchet.
- Both new catches carry `@silent-fallback-ok` with written reasons. **The ratchet baseline is not raised.**
- Failure falls back to not-running — the same value the missing argument produced. The orchestrator is dryRun-first; a placement hint must never break the poller reading it.
- Tier 1 — `riskFloor=1`, no safety-invariant match, no new route/exported class/config key.

**Not closed:** Codey's audit lists 8 further confirmed-unwired optional dependencies (`nicknameFor`, `purposeFor`, `ConversationRegistry.isJournalFsyncDisabled`, `ActiveWorkSilenceSentinel.isCleanIdlePrompt`, `TelemetryHeartbeat.agentCountFn`, `SessionManager.spawnAccountResolver`, `WriteAdmission.nicknameOf`/`selfNickname`). This PR does **not** address them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
