### PR TITLE
fix(silence-sentinel): A2(b) clean-idle-prompt check was never wired

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T17-56-35-622Z-silence-sentinel-clean-idle-wiring.json
+++ b/.instar/instar-dev-decisions/2026-08-14T17-56-35-622Z-silence-sentinel-clean-idle-wiring.json
@@ -1,0 +1,23 @@
+{
+  "ts": "2026-08-14T17:56:35.622Z",
+  "slug": "silence-sentinel-clean-idle-wiring",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 2,
+  "loc": 16,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/commands/server.ts",
+      "src/monitoring/sentinelWiring.ts"
+    ],
+    "addedLines": 15,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/silence-sentinel-clean-idle-wiring.eli16.md
+++ b/docs/specs/silence-sentinel-clean-idle-wiring.eli16.md
@@ -1,0 +1,35 @@
+# The "it's just finished, leave it alone" check was never plugged in
+
+> The one-line version: before telling you a session is stuck, the watchdog is supposed to check three things — one of them was never connected, so a session sitting quietly at a finished prompt was reported as frozen.
+
+## The problem in one breath
+
+When a session goes quiet, a watchdog re-reads its live screen before saying anything, and stays silent if any of three things is true: the screen shows work in progress, a helper task is still running, or **the screen is just a finished prompt waiting for input**.
+
+That third check asks a question the watchdog was never given a way to answer. The answer defaults to "no, it isn't a finished prompt", and nothing anywhere supplied a real one — the setting appears exactly twice in the entire codebase: where it is declared, and where it is read.
+
+So a session that had simply finished its turn and was waiting was treated as a corroborated freeze, and escalated to the operator as one.
+
+## What already exists
+
+- **The watchdog**, which was deliberately reworked so it would stop making confident claims about sessions it could not see into.
+- **Two of the three checks, properly connected** — "is it visibly working" and "does it have a live helper task".
+- **A shared list of what a finished prompt looks like**, already used by two other parts of the system, and carrying a note saying to use it rather than keep a private copy that can drift apart.
+
+## What this adds
+
+**The third check is connected**, using that shared list rather than a new private copy. A session at a finished prompt is now recognised as finished and quietly left alone, which is what the design always said should happen.
+
+The plumbing had a hole in it: the helper that assembles the watchdog's dependencies did not accept this one, so even a caller wanting to supply it had nowhere to put it. It accepts and forwards it now.
+
+## Why it went unnoticed
+
+The default answer — "no, not a finished prompt" — is a perfectly plausible real answer. There is no error and no warning; a missing connection and a genuinely-not-idle session produce the same value. The tests for this area supply their own stand-ins for these checks, so they never noticed the real one was absent.
+
+It was found by a second agent auditing for exactly this pattern: settings that are optional, default to something believable, and are never supplied.
+
+## The safeguards
+
+**A test that fails without the fix.** It asks the assembler for the dependency and checks a real function comes back. Removing the forwarding makes it fail; a second test asserts that when nothing is supplied the value stays absent, so the documented default still governs rather than being faked.
+
+**Nothing is suppressed that shouldn't be.** The check only recognises the specific appearance of a finished prompt. A session showing anything else still escalates exactly as before — this narrows a false alarm, it does not quieten the watchdog.

--- a/docs/specs/silence-sentinel-clean-idle-wiring.side-effects.md
+++ b/docs/specs/silence-sentinel-clean-idle-wiring.side-effects.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — ActiveWorkSilenceSentinel A2(b) clean-idle wiring
+
+**Version / slug:** `silence-sentinel-clean-idle-wiring`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent)`
+**Second-pass reviewer:** `originates from instar-codey's optional-dep-default-audit (finding #5)`
+
+## Summary of the change
+
+`ActiveWorkSilenceSentinel` corroborates before escalating (HONEST-PROGRESS-MESSAGING A2): A2(a) live-frame "still working", A2(b) clean idle prompt, A2(c) live sub-agent. A2(b) reads `this.deps.isCleanIdlePrompt?.(frame, sessionName) ?? false`. That dep appeared exactly TWICE in `src/` — its declaration (`ActiveWorkSilenceSentinel.ts:102`) and its one use (`:390`). `buildActiveWorkSilenceDeps` neither accepted nor forwarded it, so no caller could supply it. **A2(b) was inert: a session at a finished prompt fell through to `proceedEscalation`** — a false "stuck" notice to the operator. This adds the option to the builder, forwards it, and supplies it in `server.ts` from the SHARED `IDLE_PROMPT_PATTERNS` export.
+
+## Decision-point inventory
+
+One decision point is **repaired, not added**: "is this quiet session actually wedged?" It had three intended corroborations and only two reachable. No new decision point; A2(a) and A2(c) untouched; escalation thresholds and cadence unchanged.
+
+## 1. Over-block
+
+Could this now suppress a REAL wedge? Only if a genuinely wedged frame matches the idle-prompt patterns. Those patterns are the narrow, shared set already trusted by `SessionManager`'s monitor loop and `ModelSwapService`'s swap-readiness check — the same source of truth, per that export's own docblock ("not a parallel copy that can drift"). A frame showing anything else still escalates. A control test asserts an omitted dep stays `undefined` so the sentinel's `?? false` default governs rather than being faked true.
+
+## 2. Under-block
+
+The previous behaviour WAS the over-escalation. Residual: a session wedged AT an idle prompt (rare — that is a finished turn by definition) is now cleared rather than escalated. That is the documented intent of A2(b); the paused-tracker flag is the other guard on that path.
+
+## 3. Level-of-abstraction fit
+
+The predicate is supplied at the bootstrap (only it can reach the shared patterns and the config), forwarded by the deps builder (which owns the sentinel's dependency surface), and consumed in the sentinel (which owns the corroboration order). The alternative — importing patterns inside the sentinel — would have created the parallel copy the export explicitly warns against.
+
+## 4. Signal vs authority compliance
+
+**Signal only.** The sentinel notifies; it does not kill or gate. This change makes it notify LESS in one specific, documented case. No exit code, route, or authority changes.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new judgment point. A substring match against a code-defined shared constant — deterministic, no model call, no threshold.
+
+## 5. Interactions
+
+Blast radius measured: `buildActiveWorkSilenceDeps` gains one optional field, so every existing caller compiles and behaves identically (absent ⇒ `undefined` ⇒ the pre-existing `?? false`). `IDLE_PROMPT_PATTERNS` gains one importer (`server.ts`), joining `SessionManager` and `ModelSwapService`. `PresenceProxy.ts:426` keeps its OWN local copy of idle patterns — the drift the shared export warns about; noted, NOT changed here.
+
+## 6. External surfaces
+
+None. No network call, file, persisted state, credential, telemetry, or route.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+The operator-visible effect is FEWER false "session may be stuck" messages. No new text.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+No issue identified. Per-machine sentinel over local tmux frames; no shared state, lease, or replication.
+
+## 8. Rollback cost
+
+Very low. Two source files, one test file, one commit; no migration, persisted state, config flag, or breaking signature change (the new option is optional).
+
+## Conclusion
+
+Ship. It reconnects a documented corroboration branch that has been inert, reduces false operator alarms, uses the canonical pattern source rather than a copy, and is guarded in both directions.
+
+## Evidence pointers
+
+- Inertness verified by count, not inference: `isCleanIdlePrompt` occurs exactly 2× in `src/` (declaration + use), against a control of `looksActivelyWorking` at 22×.
+- The escalation path it bypasses read in source: `if (cleanIdle) { clear(); emit('recovered'); return; }` immediately above `proceedEscalation(... honestAskMessage ...)`.
+- Negative control executed: removing the builder's forwarding line makes the new `THE DEFECT` test FAIL (1 failed / 41 passed) while the CONTROL passes. Source restored byte-identical (sha + 24,881 bytes).
+- `tsc --noEmit` exit 0; `tests/unit/monitoring/sentinelWiring.test.ts` 42/42 (was 40).
+
+## Class-Closure Declaration (display-only mirror)
+
+Class: "an optional dependency whose default is indistinguishable from a real answer." Closed for `ActiveWorkSilenceSentinel.isCleanIdlePrompt`. **NOT closed** for the other 7 surfaces in Codey's audit (`ParallelActivityIndex.nicknameFor`/`purposeFor`, `ConversationRegistry.isJournalFsyncDisabled`, `TelemetryHeartbeat.agentCountFn`, `SessionManager.spawnAccountResolver`, `WriteAdmission.nicknameOf`/`selfNickname`), nor for `PresenceProxy`'s parallel idle-pattern copy.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -85,7 +85,7 @@ import type { TopicProfileStore } from '../core/TopicProfileStore.js';
 import type { TopicResumeMap } from '../core/TopicResumeMap.js';
 import type { IdleReading } from '../core/classifyProfileChange.js';
 import { closeAllSqlite } from '../core/SqliteRegistry.js';
-import { SessionManager, type SessionTerminateAuthority } from '../core/SessionManager.js';
+import { SessionManager, type SessionTerminateAuthority, IDLE_PROMPT_PATTERNS } from '../core/SessionManager.js';
 import { configureSyncOpMarker, defaultInflightMarkerReader } from '../core/InFlightSyncOpMarker.js';
 import { StateManager } from '../core/StateManager.js';
 import { StuckInputSentinel } from '../core/StuckInputSentinel.js';
@@ -12760,6 +12760,13 @@ export async function startServer(options: StartOptions): Promise<void> {
             // Operator ask (2026-06-09): silence/recovery notices land in the
             // STALLED session's OWN topic, not the consolidated lifeline feed.
             getTopicForSession: (name) => telegram?.getTopicForSession(name),
+            // A2(b): a finished turn sitting at a clean prompt is NOT a wedge.
+            // Unwired, the sentinel defaults this to false and escalates such a
+            // session as a "genuine freeze" — a false stuck-notice to the
+            // operator. Uses the SHARED IDLE_PROMPT_PATTERNS export rather than a
+            // parallel copy, per its own docblock.
+            isCleanIdlePrompt: (frame: string) =>
+              IDLE_PROMPT_PATTERNS.some((pat) => frame.includes(pat)),
             deliverToTopic: async (topicId, text) => {
               try {
                 const resp = await fetch(`http://localhost:${config.port}/telegram/reply/${topicId}`, {

--- a/src/monitoring/sentinelWiring.ts
+++ b/src/monitoring/sentinelWiring.ts
@@ -315,6 +315,12 @@ export function buildActiveWorkSilenceDeps(opts: {
   /** HONEST-PROGRESS-MESSAGING A1/A2 — capture the session's CURRENT live frame
    *  for corroboration before escalating. */
   captureFrame?: (sessionName: string) => string | null;
+  /** A2(b) — is the live frame a CLEAN IDLE PROMPT (a finished turn, not a
+   *  wedge)? Without this the sentinel's A2(b) branch is inert: the sentinel
+   *  defaults it to `false`, so a session sitting at a finished prompt escalates
+   *  as a "genuine freeze". Supply it from the SHARED IDLE_PROMPT_PATTERNS, not
+   *  a parallel copy (see the export docblock on SessionManager.ts). */
+  isCleanIdlePrompt?: (frame: string, sessionName: string) => boolean;
   /** A2(c) — does the session have a live sub-agent (SubagentTracker)? */
   hasActiveSubagents?: (sessionName: string) => boolean;
   /** Resolve the framework so the live-frame "generating now" check is accurate. */
@@ -347,6 +353,7 @@ export function buildActiveWorkSilenceDeps(opts: {
     looksActivelyWorking: opts.captureFrame
       ? (frame, sessionName) => looksGeneratingNow(frame, opts.frameworkForSession?.(sessionName))
       : undefined,
+    isCleanIdlePrompt: opts.isCleanIdlePrompt,
     hasActiveSubagents: opts.hasActiveSubagents,
     recordEvent: opts.recordEvent,
   };

--- a/tests/unit/monitoring/sentinelWiring.test.ts
+++ b/tests/unit/monitoring/sentinelWiring.test.ts
@@ -348,6 +348,39 @@ describe('OutputActivityTracker — change detection + active/idle filtering', (
 });
 
 describe('buildActiveWorkSilenceDeps — wiring integrity', () => {
+  // ── A2(b): the clean-idle-prompt branch ──────────────────────────────
+  // Earned 2026-08-14 (found by a peer agent's optional-dependency audit).
+  // `isCleanIdlePrompt` is optional on the sentinel and defaults to `false`
+  // (`this.deps.isCleanIdlePrompt?.(frame, name) ?? false`). The builder did
+  // not accept OR forward it, and nothing in src/ supplied it — it appeared
+  // exactly twice in the whole tree: its declaration and its one use. So the
+  // A2(b) branch was inert and a session sitting at a FINISHED prompt
+  // escalated as a "genuine freeze": a false stuck-notice to the operator.
+  // This file exists to catch exactly that shape and did not, because the
+  // dep was never in the builder's surface to be checked.
+
+  it('THE DEFECT: forwards isCleanIdlePrompt (A2(b) was inert — dropped by the builder)', () => {
+    const tracker = new OutputActivityTracker();
+    const surface = makeSurface({});
+    const deps = buildActiveWorkSilenceDeps({
+      tracker, sessions: surface, escalate: async () => {},
+      isCleanIdlePrompt: (frame) => frame.includes('bypass permissions on'),
+    });
+    // Before this change the builder had no such option and returned nothing here.
+    expect(typeof deps.isCleanIdlePrompt).toBe('function');
+    expect(deps.isCleanIdlePrompt!('… bypass permissions on', 'sess')).toBe(true);
+    expect(deps.isCleanIdlePrompt!('working… esc to interrupt', 'sess')).toBe(false);
+  });
+
+  it('CONTROL: omitted stays undefined — the sentinel default still applies', () => {
+    const tracker = new OutputActivityTracker();
+    const surface = makeSurface({});
+    const deps = buildActiveWorkSilenceDeps({ tracker, sessions: surface, escalate: async () => {} });
+    // Not fabricated: an unsupplied optional dep must remain absent, so the
+    // sentinel's documented `?? false` default is what governs.
+    expect(deps.isCleanIdlePrompt).toBeUndefined();
+  });
+
   it('listSessions delegates to the tracker snapshot', () => {
     const surface = makeSurface({ output: '⠹ working', sessions: [{ tmuxSession: 'agent-1' }] });
     const tracker = new OutputActivityTracker(surface);

--- a/upgrades/next/silence-sentinel-clean-idle-wiring.md
+++ b/upgrades/next/silence-sentinel-clean-idle-wiring.md
@@ -1,0 +1,25 @@
+## What Changed
+
+Before telling you a session may be stuck, the watchdog checks three things and stays quiet if any is true. One of the three was never connected.
+
+- **"Is it just sitting at a finished prompt?" could never be answered.** The setting that answers it appears exactly twice in the whole codebase — where it is declared and where it is read — and nothing supplied it. The answer defaulted to "no".
+- **So a session that had simply finished its turn was reported as a corroborated freeze**, and escalated to the operator as one.
+- **The plumbing had a hole**: the helper that assembles the watchdog's dependencies did not accept this one, so even a caller wanting to supply it had nowhere to put it. It accepts and forwards it now.
+- **It uses the shared description of a finished prompt**, already relied on by two other parts of the system, rather than a private copy — that shared list carries a note asking callers to do exactly this.
+- **Nothing else is quietened.** A session showing anything other than a finished prompt escalates exactly as before.
+
+## What to Tell Your User
+
+When a session goes quiet, I re-read its screen before saying anything, and I am supposed to stay silent if it is simply finished and waiting for you. That particular check was never wired up, so "finished and waiting" looked identical to "frozen", and you would have been told a session might be stuck when it had merely completed its turn.
+
+That check now works. You should see fewer false alarms of that specific kind, and no change to genuine ones.
+
+## Summary of New Capabilities
+
+None. This reconnects an existing check. No new command, route, setting, or behaviour, and the watchdog's thresholds and cadence are untouched.
+
+## Evidence
+
+Confirmed by counting rather than inferring: the setting occurs twice in the source — its declaration and its single use — against a comparison check that occurs twenty-two times. The escalation path it was meant to prevent was read directly in the code, sitting immediately above the branch that reports a genuine freeze. Proven in both directions: removing the forwarding makes the new test fail, while a second control test asserts that when nothing is supplied the value stays absent, so the documented default still governs rather than being faked. Source restored byte-identical after the check, typecheck clean, forty-two of forty-two tests passing, up from forty.
+
+Found by a second agent auditing for settings that are optional, default to something believable, and are never supplied.


### PR DESCRIPTION
## ELI16 — the "it's just finished, leave it alone" check was never plugged in

Before telling the operator a session may be stuck, `ActiveWorkSilenceSentinel` re-reads the live frame and stays silent if any of three things is true: A2(a) it's visibly working, **A2(b) it's a clean idle prompt**, A2(c) a sub-agent is live.

A2(b) asks a question the sentinel was never given a way to answer:

```ts
cleanIdle = this.deps.isCleanIdlePrompt?.(frame, sessionName) ?? false;
if (cleanIdle) { this.clear(sessionName); this.emit('recovered', sessionName); return; }
// Corroborated wedge: ... This is a genuine freeze.
this.proceedEscalation(sessionName, this.honestAskMessage(sessionName));
```

`isCleanIdlePrompt` appears **exactly twice in all of `src/`** — its declaration (`:102`) and that one use (`:390`). Control: the sibling `looksActivelyWorking` appears 22 times. And `buildActiveWorkSilenceDeps` neither accepted **nor forwarded** it, so no caller *could* supply one.

**So A2(b) was inert, and a session sitting at a finished prompt escalated as a "genuine freeze"** — a false stuck-notice to the operator, from the sentinel specifically reworked to stop making confident claims about sessions it cannot see into.

## The fix

- The builder accepts and forwards `isCleanIdlePrompt`.
- `server.ts` supplies it from the **shared** `IDLE_PROMPT_PATTERNS` export — whose own docblock says to use it "not a parallel copy that can drift". (`PresenceProxy.ts:426` keeps a local copy — that drift is noted, **not** changed here.)

## Proven in both directions

| | forwarding removed | with fix |
|---|---|---|
| `THE DEFECT`: builder forwards `isCleanIdlePrompt` | **FAILS** | passes |
| `CONTROL`: omitted dep stays `undefined` | passes | passes |

The control is load-bearing: an unsupplied optional dep must stay absent so the sentinel's documented `?? false` default governs rather than being faked true. Negative control run for real — 1 failed / 41 passed; source restored byte-identical (sha + 24,881 bytes).

## What is NOT suppressed

Only the narrow, shared idle-prompt shape clears. Any other frame escalates exactly as before — this removes a specific false alarm, it does not quieten the watchdog. Thresholds and cadence untouched. Signal-only: the sentinel notifies, it never kills or gates.

## Verification

- `tsc --noEmit` exit 0 · `tests/unit/monitoring/sentinelWiring.test.ts` **42/42** (was 40).
- Blast radius: the new builder option is optional, so every existing caller compiles and behaves identically (absent ⇒ the pre-existing `?? false`).
- Tier 1 — the gate's classifier independently computed `suggestedTier=1 (size=1, riskFloor=1, 16 LOC across 2 files)`.

## How it was found

`instar-codey`'s optional-dependency audit, finding #5 — a sweep for dependencies that are optional, default to a *plausible* value, and are never supplied. **7 of its 9 findings remain unaddressed** by this PR (`ParallelActivityIndex.nicknameFor`/`purposeFor`, `ConversationRegistry.isJournalFsyncDisabled`, `TelemetryHeartbeat.agentCountFn`, `SessionManager.spawnAccountResolver`, `WriteAdmission.nicknameOf`/`selfNickname`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
