### PR TITLE
fix(lint): spawn-cap lint was defeatable by renaming an import

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T18-51-31-879Z-spawn-lint-alias-aware.json
+++ b/.instar/instar-dev-decisions/2026-08-14T18-51-31-879Z-spawn-lint-alias-aware.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T18:51:31.879Z",
+  "slug": "spawn-lint-alias-aware",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 80,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-unbounded-llm-spawn.js"
+    ],
+    "addedLines": 64,
+    "deletedLines": 16
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/spawn-lint-alias-aware.eli16.md
+++ b/docs/specs/spawn-lint-alias-aware.eli16.md
@@ -1,0 +1,40 @@
+# The runaway-process guard could be walked past by renaming an import
+
+> The one-line version: the check that stops an uncapped AI process being created outside its safety limit looked for the class by name, so writing `import { X as Y }` and then using `Y` made a real violation invisible.
+
+## The problem in one breath
+
+In June this system spawned somewhere between 230 and 289 AI processes at once and ran the machine out of memory. The fix was a hard limit on how many can exist simultaneously, plus a check that refuses any construction of a process-spawning class outside the limited path.
+
+That check finds its targets by matching the class name as literal text. Two entirely ordinary ways of importing a class defeat it:
+
+- rename it on import and use the new name;
+- import the whole module and reach the class through it.
+
+Either produces a real, uncapped construction that the check cannot see. Nothing is broken today — the check reports the codebase clean, and it genuinely is — but the guard has a hole the moment someone writes ordinary code.
+
+## What already exists
+
+- **The limit itself**, a counter shared across every process on the machine, which makes new spawns wait and then shed rather than pile up.
+- **The single approved path** for building one of these, where the limit is installed.
+- **This check**, in the standard set that runs before every commit and in continuous integration, with a closed list of places allowed to bypass the approved path.
+
+## What this adds
+
+**The check now works out every local name the class is bound to in a file before looking for constructions**, and separately recognises the module-qualified form. Renaming on import no longer hides anything.
+
+**The detection is now a separate, importable function**, so it can be tested directly with fixtures rather than only by running the whole check over the whole codebase.
+
+**The command body is guarded so importing it does not run it.** Without that, importing the detector in a test would run the check — and because it stops the process when it finds a violation, a single real violation would have killed the test run rather than reporting a failure.
+
+## The safeguards
+
+**Four tests in the opposite direction**, and they are the point. An import on its own is not a construction. A comment mentioning the class is not a construction. A differently-named class is not flagged. A plain variable sharing the name is not flagged. Without these, a detector that flagged everything would pass every test about catching bypasses and be useless on a healthy codebase.
+
+**Proven against the old behaviour.** Restricted back to name-only matching, five tests fail and six still pass — the six being the plain case and the four opposite-direction controls. That is what makes them guards rather than echoes of the change.
+
+**No new rule.** The same constructions are forbidden as before; more of them are now visible. The codebase passes cleanly both before and after, so this adds no work to anyone today.
+
+## Why this one first
+
+A peer agent's audit found twenty-five checks with this same weakness. This one was taken first because it guards a safety limit rather than a convention, and because the failure it prevents has already happened once.

--- a/docs/specs/spawn-lint-alias-aware.side-effects.md
+++ b/docs/specs/spawn-lint-alias-aware.side-effects.md
@@ -1,0 +1,73 @@
+# Side-Effects Review — lint-no-unbounded-llm-spawn: alias + namespace awareness
+
+**Version / slug:** `spawn-lint-alias-aware`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent)`
+**Second-pass reviewer:** `originates from instar-codey's lint-name-matching-audit (finding #1 of 25)`
+
+## Summary of the change
+
+`scripts/lint-no-unbounded-llm-spawn.js` enforces §P1 of `docs/specs/forkbomb-prevention-simple.md`: every spawn-capable LLM-CLI provider must be constructed through `buildIntelligenceProvider()`, where the host-wide spawn cap is installed (added after the 2026-06-20 OOM: ~230-289 concurrent spawns, ~90-115GB). It located targets with `new RegExp(\`\\bnew\\s+${cls}\\s*\\(\`)` — the class NAME as literal text. Two ordinary import styles defeat that:
+
+```ts
+import { ClaudeCliIntelligenceProvider as Provider } from '...'; new Provider(...)
+import * as mod from '...';                                     new mod.ClaudeCliIntelligenceProvider(...)
+```
+
+Both are real uncapped constructions and both were invisible. This resolves local bindings first (`as Alias`, `{ Cls: Alias }`) and adds the namespace-qualified form, extracts detection into two exported pure functions, and guards the CLI body behind a direct-invocation check.
+
+## Decision-point inventory
+
+No decision point added or removed. One is **widened at its input**: "is this line a spawn-capable construction?" The forbidden set, the allowlist, the message and the exit contract are unchanged — strictly more real constructions are now visible to the same rule.
+
+## 1. Over-block
+
+Could this now flag legitimate code? That is the live risk, since a lint blocks commits. Four opposite-direction controls pin it: an import alone is not a construction; a comment mentioning the class is not; an unrelated similarly-named class is not; a bare variable of the same name is not. And the decisive empirical check — **the real repo lints CLEAN both before and after** — so this adds zero work to anyone today. Binding resolution is per-file, so an alias in one file cannot flag a same-named symbol in another.
+
+## 2. Under-block
+
+The previous behaviour WAS the under-block. Remaining surface, stated: a construction reached through a re-export chain (`export { X as Y } from '...'` in module A, imported from A elsewhere) still evades, because resolution is per-file text, not a cross-module symbol graph. Codey's audit makes the same point about the general class. Narrowed, not closed.
+
+## 3. Level-of-abstraction fit
+
+Binding resolution belongs in the lint (it owns "what counts as this class here"). Extracting it to exported functions is what makes the rule testable with fixtures instead of only end-to-end over the tree — the same move as `runningTopicIds` in PR #1870, for the same reason: the failure was in HOW the target was identified.
+
+## 4. Signal vs authority compliance
+
+The lint IS authority — it fails a commit. That authority is unchanged in kind and scope: same rule, same allowlist, same exit codes. This changes what the existing authority can SEE. No new blocking condition is introduced, and the tree passes clean.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No judgment point. Deterministic regex/binding resolution; no heuristic, model call, or threshold.
+
+## 5. Interactions
+
+Blast radius measured. The module was previously import-unsafe: its CLI body ran at module scope and calls `process.exit(1)` on violation, so ANY importer would have run the scan and could have killed the process. It now has zero importers besides the new test, and the guard makes importing safe. `package.json` invokes it unchanged (lint chain + `lint:no-unbounded-llm-spawn[:staged]`), and `tests/unit/lint-chain-completeness.test.ts` — which asserts the lint is in the chain — still passes.
+
+## 6. External surfaces
+
+None. No network, persisted state, credential, telemetry, or route. Reads source files at lint time exactly as before.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+Violation text unchanged (path:line, why, and the two remedies). No new operator-visible strings.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+No issue identified. A build-time check; no shared state, lease, or replication.
+
+## 8. Rollback cost
+
+Very low. One script, one new test file, one commit; no migration, persisted state, or config flag. Reverting restores the previous matching exactly.
+
+## Evidence pointers
+
+- Blindness confirmed in source before any edit: `PATTERNS = PROVIDER_CLASSES.map((cls) => new RegExp(\`\\bnew\\s+${cls}\\s*\\(\`))`, tested per line — `\bnew\s+Cls` cannot match across a `mod.` qualifier, and an alias replaces the name entirely.
+- Negative control executed: restricted to name-only matching with the namespace form disabled, **5 tests fail / 6 pass** — the 6 being the plain-construction case and all four opposite-direction controls. Source restored byte-identical (sha + 8,036 bytes).
+- The real repo lints CLEAN before and after (`node scripts/lint-no-unbounded-llm-spawn.js` exit 0 both ways) — no false positives introduced.
+- Import-safety verified in both modes: run as a CLI it prints `clean` and exits 0; imported by the test it does NOT run the scan.
+- 11/11 in `tests/unit/spawn-lint-alias-aware.test.ts`.
+
+## Class-Closure Declaration (display-only mirror)
+
+Class: "a check that identifies its target by name and is therefore defeatable by renaming." Closed for THIS lint, for aliasing and namespace qualification. **NOT closed** for re-export chains (stated above), and **NOT closed repo-wide** — Codey's audit counts 25 defeatable checks; this is one, chosen first because it guards a safety floor rather than a convention. The remaining 24 are untouched.

--- a/scripts/lint-no-unbounded-llm-spawn.js
+++ b/scripts/lint-no-unbounded-llm-spawn.js
@@ -66,7 +66,53 @@ const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs']);
 // `new <ProviderClass>(` — the construction. An IMPORT of the class is fine
 // (the factory imports them); only a direct `new …(` outside the funnel is a
 // bypass.
-const PATTERNS = PROVIDER_CLASSES.map((cls) => new RegExp(`\\bnew\\s+${cls}\\s*\\(`));
+//
+// ALIAS + NAMESPACE AWARE (2026-08-14). The original matched the class NAME as
+// literal text, so two ordinary import styles walked straight past a SAFETY
+// floor — the spawn cap added after the 2026-06-20 OOM fork-bomb:
+//
+//   import { ClaudeCliIntelligenceProvider as Provider } from '...';
+//   new Provider(...)                       // real uncapped construction, invisible
+//
+//   import * as mod from '...';
+//   new mod.ClaudeCliIntelligenceProvider(...)   // also invisible: `\bnew\s+Cls`
+//                                                // cannot match across `mod.`
+//
+// Found by a peer-agent audit for checks defeatable by renaming. Resolve the
+// local bindings FIRST, then match constructions under any of them.
+
+/** Every local name a provider class is bound to in this file, plus namespace forms. */
+export function localProviderBindings(content, cls) {
+  const names = new Set([cls]);
+  // `import { Cls as Alias }` and `const { Cls: Alias } = await import(...)`
+  for (const m of content.matchAll(new RegExp(`\\b${cls}\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g'))) names.add(m[1]);
+  for (const m of content.matchAll(new RegExp(`\\b${cls}\\s*:\\s*([A-Za-z_$][\\w$]*)`, 'g'))) names.add(m[1]);
+  return [...names];
+}
+
+/**
+ * Line numbers (1-based) in `content` that construct a spawn-capable provider,
+ * under ANY local binding or namespace qualifier. Comment-only lines excluded.
+ */
+export function findProviderConstructions(content, classes = PROVIDER_CLASSES) {
+  const hits = [];
+  const lines = content.split('\n');
+  const perClass = classes.map((cls) => ({
+    cls,
+    names: localProviderBindings(content, cls),
+  }));
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trimStart();
+    if (/^(\/\/|\*|\/\*|#)/.test(trimmed)) continue;
+    for (const { cls, names } of perClass) {
+      const bare = names.some((n) => new RegExp(`\\bnew\\s+${n}\\s*\\(`).test(lines[i]));
+      // `new <ns>.<Cls>(` — a namespace import the bare form cannot see.
+      const viaNs = new RegExp(`\\bnew\\s+[A-Za-z_$][\\w$]*\\.${cls}\\s*\\(`).test(lines[i]);
+      if (bare || viaNs) { hits.push({ line: i + 1, cls }); break; }
+    }
+  }
+  return hits;
+}
 
 function listFiles() {
   const staged = process.argv.includes('--staged');
@@ -96,6 +142,15 @@ function listFiles() {
   return files;
 }
 
+// ── CLI body ─────────────────────────────────────────────────────────────
+// Guarded so the exported detector above can be imported by tests WITHOUT
+// running the scan — this module calls process.exit(1) on a violation, so an
+// unguarded import would kill any test run the moment the repo had one.
+// Same pattern as scripts/eli16-pr-description-check.mjs.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
 let violations = 0;
 for (const rel of listFiles()) {
   const normalized = rel.split(path.sep).join('/');
@@ -111,21 +166,13 @@ for (const rel of listFiles()) {
   } catch {
     continue;
   }
-  const lines = content.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    // Comment-only mentions are documentation, not a construction.
-    const trimmed = lines[i].trimStart();
-    if (/^(\/\/|\*|\/\*|#)/.test(trimmed)) continue;
-    for (const pattern of PATTERNS) {
-      if (pattern.test(lines[i])) {
-        console.error(
-          `${normalized}:${i + 1} — direct LLM-CLI provider construction outside the spawn-cap funnel. ` +
-          `Build it through buildIntelligenceProvider() (which installs the host-wide spawn cap + circuit breaker), ` +
-          `or add an allowlist entry here with a spawn-bounding justification.`,
-        );
-        violations++;
-      }
-    }
+  for (const hit of findProviderConstructions(content)) {
+    console.error(
+      `${normalized}:${hit.line} — direct LLM-CLI provider construction outside the spawn-cap funnel. ` +
+      `Build it through buildIntelligenceProvider() (which installs the host-wide spawn cap + circuit breaker), ` +
+      `or add an allowlist entry here with a spawn-bounding justification.`,
+    );
+    violations++;
   }
 }
 
@@ -135,3 +182,4 @@ if (violations > 0) {
   process.exit(1);
 }
 console.log('lint-no-unbounded-llm-spawn: clean');
+}

--- a/tests/unit/spawn-lint-alias-aware.test.ts
+++ b/tests/unit/spawn-lint-alias-aware.test.ts
@@ -1,0 +1,107 @@
+/**
+ * lint-no-unbounded-llm-spawn — alias + namespace awareness.
+ *
+ * This lint guards a SAFETY floor: the host-wide spawn cap added after the
+ * 2026-06-20 OOM fork-bomb (~230-289 concurrent LLM spawns, ~90-115GB). It
+ * exists to stop a provider being constructed outside the capped funnel.
+ *
+ * It located its targets by matching the class NAME as literal text, so two
+ * ordinary import styles walked straight past it:
+ *
+ *   import { ClaudeCliIntelligenceProvider as Provider } from '...';
+ *   new Provider(...)                             // real, uncapped, invisible
+ *
+ *   import * as mod from '...';
+ *   new mod.ClaudeCliIntelligenceProvider(...)    // `\bnew\s+Cls` cannot match
+ *                                                 // across the `mod.`
+ *
+ * Found by a peer-agent audit for checks defeatable by renaming (the same class
+ * of blindness fixed in PR #1872 for the ParallelActivityIndex invariant).
+ *
+ * These tests drive the detector DIRECTLY rather than asserting on the CLI's
+ * exit code: a lint that CRASHES also exits 1, so an exit-code-only assertion
+ * cannot tell "caught the violation" from "died on startup" (earned 2026-08-14,
+ * round 7 — 11 of 15 assertions in another suite had that hole).
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  findProviderConstructions,
+  localProviderBindings,
+  // @ts-expect-error — plain .js lint script, no type declarations
+} from '../../scripts/lint-no-unbounded-llm-spawn.js';
+
+const CLS = 'ClaudeCliIntelligenceProvider';
+
+describe('localProviderBindings', () => {
+  it('always includes the canonical name', () => {
+    expect(localProviderBindings('const x = 1;', CLS)).toContain(CLS);
+  });
+
+  it('resolves `import { Cls as Alias }`', () => {
+    const src = `import { ${CLS} as Provider } from '../core/x.js';`;
+    expect(localProviderBindings(src, CLS)).toContain('Provider');
+  });
+
+  it('resolves `const { Cls: Alias } = await import(...)`', () => {
+    const src = `const { ${CLS}: P } = await import('../core/x.js');`;
+    expect(localProviderBindings(src, CLS)).toContain('P');
+  });
+});
+
+describe('findProviderConstructions — the bypasses', () => {
+  it('CONTROL: catches the plain construction (the case that always worked)', () => {
+    const hits = findProviderConstructions(`const p = new ${CLS}({});`);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].cls).toBe(CLS);
+  });
+
+  it('THE BYPASS: catches an ALIASED construction', () => {
+    const src = [
+      `import { ${CLS} as Provider } from '../core/x.js';`,
+      'const p = new Provider({});',
+    ].join('\n');
+    const hits = findProviderConstructions(src);
+    // Before this change: zero hits — a real uncapped spawn construction.
+    expect(hits).toHaveLength(1);
+    expect(hits[0].line).toBe(2);
+  });
+
+  it('THE BYPASS: catches a NAMESPACE construction', () => {
+    const src = [
+      "import * as mod from '../core/x.js';",
+      `const p = new mod.${CLS}({});`,
+    ].join('\n');
+    const hits = findProviderConstructions(src);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].line).toBe(2);
+  });
+
+  it('THE BYPASS: catches a destructured dynamic import under a new name', () => {
+    const src = [
+      `const { ${CLS}: Spawner } = await import('../core/x.js');`,
+      'const p = new Spawner({});',
+    ].join('\n');
+    expect(findProviderConstructions(src)).toHaveLength(1);
+  });
+
+  // ── The other direction. Without these, a detector that flagged everything
+  //    would pass every test above and be useless on a healthy tree.
+  it('CONTROL: an IMPORT alone is not a construction', () => {
+    const src = `import { ${CLS} as Provider } from '../core/x.js';`;
+    expect(findProviderConstructions(src)).toEqual([]);
+  });
+
+  it('CONTROL: a comment mentioning the class is not a construction', () => {
+    const src = [`// new ${CLS}({}) — documentation only`, ` * new ${CLS}({})`].join('\n');
+    expect(findProviderConstructions(src)).toEqual([]);
+  });
+
+  it('CONTROL: an unrelated class with a similar name is not flagged', () => {
+    expect(findProviderConstructions('const p = new SomeOtherProvider({});')).toEqual([]);
+  });
+
+  it('CONTROL: a bare identical-name variable is not a construction', () => {
+    expect(findProviderConstructions(`const ${CLS} = 1;`)).toEqual([]);
+  });
+});

--- a/upgrades/next/spawn-lint-alias-aware.md
+++ b/upgrades/next/spawn-lint-alias-aware.md
@@ -1,0 +1,25 @@
+## What Changed
+
+The check that stops an uncapped AI process being created outside its safety limit could be walked past by renaming an import.
+
+- **It matched the class by its name as literal text.** Two ordinary import styles defeat that: rename it on import and use the new name, or import the whole module and reach the class through it. Either is a real, uncapped construction that the check could not see.
+- **It now works out every local name the class is bound to** in a file before looking for constructions, and separately recognises the module-qualified form.
+- **The detection is now a separate importable function**, so it can be tested with small fixtures rather than only by running the whole check over the whole codebase.
+- **Importing it no longer runs it.** The command body stops the process when it finds a violation, so importing the detector in a test would have killed the test run the moment the codebase had one.
+- **No new rule and no new work.** The same constructions are forbidden as before; more of them are visible. The codebase passes cleanly both before and after.
+
+## What to Tell Your User
+
+In June this system created somewhere between two and three hundred AI processes at once and ran the machine out of memory. The fix was a hard ceiling, plus a check that refuses any code creating one of those processes outside the ceilinged path.
+
+That check looked for the thing by name, and renaming something on import is completely ordinary — so a real violation could sit there in plain sight and the check would report everything fine. Nothing was actually wrong today; the hole was in the guard, not the code it guards.
+
+It now recognises the renamed and module-qualified forms. This was chosen first out of twenty-five checks with the same weakness, because it guards a safety limit rather than a convention, and because the failure it prevents has already happened once.
+
+## Summary of New Capabilities
+
+None. This widens what an existing check can see. No new command, route, setting, or rule, and no new violations are introduced.
+
+## Evidence
+
+The blindness was confirmed in the check's own source before any change: it built a pattern from the class name and tested it line by line, which cannot match across a module qualifier and matches nothing at all once the name is replaced by an alias. Proven in both directions — restricted back to name-only matching, five tests fail and six still pass, those six being the plain case and four deliberate opposite-direction controls: an import alone is not a construction, a comment mentioning the class is not, a differently-named class is not flagged, and a plain variable sharing the name is not. Without those, something that flagged everything would pass every test about catching bypasses and be useless on a healthy codebase. The real codebase passes cleanly before and after, so no false positives were introduced. Import-safety verified in both modes. Source restored byte-identical after the check.


### PR DESCRIPTION
## ELI16 — the runaway-process guard could be walked past by renaming an import

In June this system spawned ~230-289 AI processes at once and ran the machine out of memory. The fix was a host-wide spawn cap plus a lint refusing any spawn-capable provider construction outside the capped funnel (`docs/specs/forkbomb-prevention-simple.md` §P1).

That lint located its targets by matching the class **name as literal text**:

```js
const PATTERNS = PROVIDER_CLASSES.map((cls) => new RegExp(`\\bnew\\s+${cls}\\s*\\(`));
```

Two entirely ordinary import styles defeat it:

```ts
import { ClaudeCliIntelligenceProvider as Provider } from '...';
new Provider(...)                              // real, uncapped, invisible

import * as mod from '...';
new mod.ClaudeCliIntelligenceProvider(...)     // `\bnew\s+Cls` cannot match across `mod.`
```

Nothing is wrong in the tree today — it lints clean, and genuinely is clean. **The hole was in the guard, not in what it guards.**

## The fix

- Resolve every **local binding** of the class first (`as Alias`, `{ Cls: Alias }`), then match constructions under any of them; plus the namespace-qualified form.
- Detection extracted to two **exported pure functions**, so the rule is testable with fixtures rather than only end-to-end over the tree — the same move as `runningTopicIds` in #1870, for the same reason: the failure was in *how the target was identified*.
- **The CLI body is guarded behind a direct-invocation check.** It calls `process.exit(1)` on violation, so an unguarded import would have killed any test run the moment the repo had one. Verified both modes: as a CLI it prints `clean` / exit 0; imported, it does not run the scan.

## Proven in both directions

| | name-only (old) | with fix |
|---|---|---|
| catches an ALIASED construction | **FAILS** | passes |
| catches a NAMESPACE construction | **FAILS** | passes |
| catches a destructured dynamic import under a new name | **FAILS** | passes |
| resolves `as Alias` / `{ Cls: Alias }` bindings | **FAILS** ×2 | passes |
| CONTROL: plain construction still caught | passes | passes |
| CONTROL: an import alone is **not** a construction | passes | passes |
| CONTROL: a comment mentioning the class is **not** | passes | passes |
| CONTROL: a similarly-named class is **not** flagged | passes | passes |
| CONTROL: a bare variable of the same name is **not** flagged | passes | passes |

Under the old behaviour: **5 failed / 6 passed** — the 6 being the plain case and all four opposite-direction controls. Those four are the point: a detector that flagged everything would pass every bypass test above and be useless on a healthy tree. Source restored byte-identical (sha + 8,036 bytes).

## No new rule, no new work

Same forbidden set, same allowlist, same message, same exit contract — only what the existing authority can *see* is widened. **The real repo lints CLEAN before and after** (exit 0 both ways), so this introduces no false positives and no new blocking condition.

## Scope, stated

- **Still evades:** a construction reached through a re-export chain, since resolution is per-file text rather than a cross-module symbol graph. Narrowed, not closed.
- `instar-codey`'s lint-name-matching audit counts **25** defeatable checks. This is **one** — taken first because it guards a safety floor rather than a convention, and because the failure it prevents has already happened once. The other 24 are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
