### PR TITLE
fix(lint): close the two same-file spawn-lint evasions found by sabotage

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T19-17-10-296Z-spawn-lint-local-rebinding.json
+++ b/.instar/instar-dev-decisions/2026-08-14T19-17-10-296Z-spawn-lint-local-rebinding.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T19:17:10.296Z",
+  "slug": "spawn-lint-local-rebinding",
+  "suggestedTier": 1,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 25,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-unbounded-llm-spawn.js"
+    ],
+    "addedLines": 23,
+    "deletedLines": 2
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/spawn-lint-local-rebinding.eli16.md
+++ b/docs/specs/spawn-lint-local-rebinding.eli16.md
@@ -1,0 +1,40 @@
+# Two more ways past the runaway-process guard, found by trying to break it
+
+> The one-line version: after hardening the check against renamed imports, a peer agent attacked it and got past it twice more — with a plain local variable and with bracket access — and both are closed here.
+
+## The problem in one breath
+
+Earlier today the check that stops an uncapped AI process being created outside its safety limit was hardened: it now works out every local name a class is imported under, instead of matching one literal name.
+
+Then a second agent was asked to break it, and did. Two of the ways past are entirely local to a single file, which is exactly the ground the hardening claimed to cover:
+
+- assign the class to a variable and construct from the variable;
+- reach the class out of an imported module with bracket notation instead of a dot.
+
+The first is probably the easiest bypass anyone could write. It was not anticipated.
+
+## What already exists
+
+- **The limit itself** and the single approved path where it is installed.
+- **The check**, now aware of renamed imports and dot-qualified module access.
+- **A written statement of what it still misses**, which said only that chains crossing module boundaries could slip through.
+
+## What this adds
+
+**A variable holding the class is now treated as the class.** Chains are followed to a fixed point, so assigning it along several times cannot walk out of the set.
+
+**Bracket access is recognised** alongside dot access.
+
+**The written statement of remaining gaps is corrected.** It previously named one kind of miss and there were three: the two above, plus the cross-module chains. Two of the three were inside what the earlier statement implied was covered, so leaving it unchanged would have left a claim on record that was narrower than the truth.
+
+## The safeguards
+
+**Six tests in the opposite direction**, including a new one: assigning some *unrelated* symbol to a variable and constructing from it is not flagged. Without that, a rule that treated every variable as suspicious would pass every bypass test and fail on ordinary code.
+
+**One test pins a gap deliberately left open.** A chain crossing module boundaries still gets past, because this check reads one file at a time and cannot follow a symbol exported onward from somewhere else. That test asserts it is *not* caught — so nobody later mistakes the boundary for an oversight, and if someone closes it properly the test will fail and be updated on purpose.
+
+**The codebase passes cleanly before and after**, so no new work is created for anyone.
+
+## Why it is worth saying who found it
+
+The bypasses were not found by re-reading the fix. They were found by someone else being asked, explicitly, to break it — and told that an evasion would be worth more than a clean report. A review that can only confirm is not a review.

--- a/docs/specs/spawn-lint-local-rebinding.side-effects.md
+++ b/docs/specs/spawn-lint-local-rebinding.side-effects.md
@@ -1,0 +1,78 @@
+# Side-Effects Review — spawn-cap lint: local re-binding + computed access
+
+**Version / slug:** `spawn-lint-local-rebinding`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent)`
+**Second-pass reviewer:** `instar-codey — this change exists BECAUSE its sabotage pass broke PR #1874`
+
+## Summary of the change
+
+PR #1874 made `lint-no-unbounded-llm-spawn` resolve local bindings (`as Alias`, `{ Cls: Alias }`) and recognise `new ns.Cls(`. A peer sabotage pass then found **5 evasions, of which 2 are SAME-FILE** — inside the ground that fix claimed:
+
+```ts
+import { ClaudeCliIntelligenceProvider } from './core.js';
+const C = ClaudeCliIntelligenceProvider; new C({});      // plain re-binding
+import * as Providers from './core.js';
+new Providers['ClaudeCliIntelligenceProvider']({});      // computed access
+```
+
+This resolves `const|let|var Alias = <knownName>` to a **fixpoint** (so chains close) and adds the computed-access form. It also CORRECTS PR #1874's class-closure declaration, which named only cross-module re-export chains and therefore understated the gap.
+
+## Decision-point inventory
+
+No decision point added or removed. The same one is widened at its input again: "is this line a spawn-capable construction?" Forbidden set, allowlist, message and exit contract unchanged.
+
+## 1. Over-block
+
+This is the live risk: treating a variable as the class could flag innocent code. Bounded three ways — the re-binding regex requires the right-hand side to be a name ALREADY in the resolved set (seeded only from the provider classes and their import aliases); resolution is per-file, so a name in one file cannot taint another; and a dedicated control asserts `const C = SomethingElse; new C({})` is NOT flagged. Empirically: **the real repo lints clean before and after** (exit 0 both ways).
+
+The fixpoint loop is bounded to 10 passes and exits early when the set stops growing, so a pathological file cannot spin it.
+
+## 2. Under-block
+
+Three of the five evasions remain, all cross-module: a re-export chain, a double alias across two hops, and a namespace import of a re-export barrel. Per-file text resolution cannot follow a symbol re-exported from another module; closing that needs a cross-module symbol graph and is out of scope. **A test pins this open gap explicitly** so the boundary is documented rather than assumed.
+
+## 3. Level-of-abstraction fit
+
+Unchanged from #1874: binding resolution belongs in the lint, and lives in exported pure functions so fixtures can drive it. The sabotage snippets are used verbatim as fixtures — the reviewer's inputs become the regression tests.
+
+## 4. Signal vs authority compliance
+
+The lint is authority (it fails a commit), unchanged in kind and scope. This changes only what it can see; the tree passes clean, so no new blocking condition.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+None. Deterministic regex/fixpoint resolution; no heuristic, model call, or threshold.
+
+## 5. Interactions
+
+Blast radius unchanged from #1874: one script, exported functions with a single test importer, CLI body still guarded behind the direct-invocation check. `package.json` invocations and `tests/unit/lint-chain-completeness.test.ts` unaffected.
+
+## 6. External surfaces
+
+None. No network, persisted state, credential, telemetry, or route.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+Violation text unchanged.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+No issue identified — build-time check, no shared state.
+
+## 8. Rollback cost
+
+Very low. One script, one test file, one commit; no migration or config.
+
+## Evidence pointers
+
+- The two evasions are the peer's verbatim snippets, reproduced as fixtures.
+- Negative control executed: reverting BOTH new patterns fails 4 tests / passes 13 — the 13 including all six opposite-direction controls and the pinned known-gap test. Source restored byte-identical (sha + 9,214 bytes).
+- Real repo lints CLEAN before and after (exit 0 both ways).
+- 17/17 in `tests/unit/spawn-lint-alias-aware.test.ts` (was 11).
+
+## Class-Closure Declaration (display-only mirror) — CORRECTING PR #1874
+
+PR #1874 declared: *"still evades: a construction reached through a re-export chain."* That was **incomplete**. The sabotage pass found FIVE evasions: three cross-module (re-export chain, double alias across two hops, namespace import of a re-export barrel) and **two same-file** (local re-binding, computed access) which the per-file approach should have covered and did not.
+
+This change closes the two same-file ones. **The three cross-module evasions remain open, are named individually here rather than as one category, and are pinned by a test.** Closing them requires cross-module symbol resolution, which this lint does not do. 24 of Codey's 25 defeatable checks are still untouched.

--- a/scripts/lint-no-unbounded-llm-spawn.js
+++ b/scripts/lint-no-unbounded-llm-spawn.js
@@ -81,12 +81,29 @@ const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs']);
 // Found by a peer-agent audit for checks defeatable by renaming. Resolve the
 // local bindings FIRST, then match constructions under any of them.
 
-/** Every local name a provider class is bound to in this file, plus namespace forms. */
+/** Every local name a provider class is bound to in this file, plus namespace forms.
+ *
+ *  Widened 2026-08-14 after a peer-agent SABOTAGE pass against the first version
+ *  found two SAME-FILE evasions the alias resolution missed:
+ *    const C = ClaudeCliIntelligenceProvider; new C({});   // plain re-binding
+ *    new Providers['ClaudeCliIntelligenceProvider']({});    // computed access
+ *  The first is probably the easiest bypass of all to write. Re-binding is
+ *  resolved to a FIXPOINT so chains (`const C = Cls; const D = C;`) close too. */
 export function localProviderBindings(content, cls) {
   const names = new Set([cls]);
   // `import { Cls as Alias }` and `const { Cls: Alias } = await import(...)`
   for (const m of content.matchAll(new RegExp(`\\b${cls}\\s+as\\s+([A-Za-z_$][\\w$]*)`, 'g'))) names.add(m[1]);
   for (const m of content.matchAll(new RegExp(`\\b${cls}\\s*:\\s*([A-Za-z_$][\\w$]*)`, 'g'))) names.add(m[1]);
+  // `const|let|var Alias = <knownName>;` — plain re-binding, resolved to a
+  // fixpoint so a chain of re-bindings cannot walk out of the set.
+  for (let pass = 0; pass < 10; pass++) {
+    const before = names.size;
+    for (const known of [...names]) {
+      const re = new RegExp(`\\b(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*${known}\\s*[;,\\n]`, 'g');
+      for (const m of content.matchAll(re)) names.add(m[1]);
+    }
+    if (names.size === before) break;
+  }
   return [...names];
 }
 
@@ -108,7 +125,11 @@ export function findProviderConstructions(content, classes = PROVIDER_CLASSES) {
       const bare = names.some((n) => new RegExp(`\\bnew\\s+${n}\\s*\\(`).test(lines[i]));
       // `new <ns>.<Cls>(` — a namespace import the bare form cannot see.
       const viaNs = new RegExp(`\\bnew\\s+[A-Za-z_$][\\w$]*\\.${cls}\\s*\\(`).test(lines[i]);
-      if (bare || viaNs) { hits.push({ line: i + 1, cls }); break; }
+      // `new <ns>['<Cls>'](` — computed access; found by sabotage 2026-08-14.
+      const viaComputed = new RegExp(
+        `\\bnew\\s+[A-Za-z_$][\\w$]*\\s*\\[\\s*['"\`]${cls}['"\`]\\s*\\]\\s*\\(`,
+      ).test(lines[i]);
+      if (bare || viaNs || viaComputed) { hits.push({ line: i + 1, cls }); break; }
     }
   }
   return hits;

--- a/tests/unit/spawn-lint-alias-aware.test.ts
+++ b/tests/unit/spawn-lint-alias-aware.test.ts
@@ -85,6 +85,57 @@ describe('findProviderConstructions — the bypasses', () => {
     expect(findProviderConstructions(src)).toHaveLength(1);
   });
 
+  // ── Found by a peer-agent SABOTAGE pass against the first version of this
+  //    fix (2026-08-14). Both are SAME-FILE — squarely inside what the per-file
+  //    approach claimed to close — and I had anticipated neither. The PR's
+  //    class-closure declaration said only "re-export chains still evade",
+  //    which covered three of the five evasions found and understated the gap.
+  //    Snippets below are Codey's verbatim.
+
+  it('SABOTAGE: a local re-binding — `const C = Cls; new C()` — is caught', () => {
+    const src = [
+      `import { ${CLS} } from './core.js';`,
+      `const C = ${CLS};`,
+      'const p = new C({});',
+    ].join('\n');
+    expect(findProviderConstructions(src)).toHaveLength(1);
+  });
+
+  it('SABOTAGE: a CHAIN of re-bindings cannot walk out of the set', () => {
+    const src = [
+      `import { ${CLS} } from './core.js';`,
+      `const C = ${CLS};`,
+      'const D = C;',
+      'const p = new D({});',
+    ].join('\n');
+    expect(findProviderConstructions(src)).toHaveLength(1);
+  });
+
+  it('SABOTAGE: computed namespace access — `new NS[\'Cls\']()` — is caught', () => {
+    const src = [
+      "import * as Providers from './core.js';",
+      `const p = new Providers['${CLS}']({});`,
+    ].join('\n');
+    expect(findProviderConstructions(src)).toHaveLength(1);
+  });
+
+  it('SABOTAGE: an aliased re-binding of an aliased import is caught', () => {
+    const src = [
+      `import { ${CLS} as Provider } from './core.js';`,
+      'const Spawner = Provider;',
+      'const p = new Spawner({});',
+    ].join('\n');
+    expect(findProviderConstructions(src)).toHaveLength(1);
+  });
+
+  it('KNOWN GAP, pinned honestly: a cross-module re-export chain still EVADES', () => {
+    // Per-file text resolution cannot follow `export { Cls as X } from '...'`
+    // in another module. Stated in PR #1874 and NOT closed here — this test
+    // documents the boundary so a future reader does not assume otherwise.
+    const consumer = ["import { X } from './reexport-a.js';", 'const p = new X({});'].join('\n');
+    expect(findProviderConstructions(consumer)).toEqual([]);
+  });
+
   // ── The other direction. Without these, a detector that flagged everything
   //    would pass every test above and be useless on a healthy tree.
   it('CONTROL: an IMPORT alone is not a construction', () => {
@@ -103,5 +154,10 @@ describe('findProviderConstructions — the bypasses', () => {
 
   it('CONTROL: a bare identical-name variable is not a construction', () => {
     expect(findProviderConstructions(`const ${CLS} = 1;`)).toEqual([]);
+  });
+
+  it('CONTROL: re-binding an UNRELATED symbol is not flagged', () => {
+    const src = ['const C = SomethingElse;', 'const p = new C({});'].join('\n');
+    expect(findProviderConstructions(src)).toEqual([]);
   });
 });

--- a/upgrades/next/spawn-lint-local-rebinding.md
+++ b/upgrades/next/spawn-lint-local-rebinding.md
@@ -1,0 +1,25 @@
+## What Changed
+
+After hardening the runaway-process guard against renamed imports this morning, a second agent was asked to break it — and got past it twice more.
+
+- **Assigning the class to a variable and building from the variable** slipped through. That is probably the simplest bypass anyone could write, and it was not anticipated.
+- **Reaching the class out of a module with bracket notation** instead of a dot also slipped through.
+- **Both are now recognised.** Variable assignments are followed to a fixed point, so passing the class along several times cannot walk out of the set.
+- **The written statement of what the guard still misses has been corrected.** It named one kind of gap; there were three. Two of them were inside the ground the earlier fix implied was covered, so leaving that statement unchanged would have left a claim on record narrower than the truth.
+- **No new work.** The same constructions are forbidden as before, the codebase passes cleanly before and after.
+
+## What to Tell Your User
+
+This morning's fix made the guard understand renamed imports. It was then attacked on purpose, and two more ways past turned up — both of them ordinary code, both inside a single file, which is exactly what that fix claimed to have handled.
+
+Those are closed. Three ways past remain, all involving a class passed onward through several modules; closing those needs the check to follow symbols across files, which it does not do. That limit is now written down and pinned by a test, so nobody later mistakes it for an oversight.
+
+Worth noting how this was found: not by re-reading the fix, but by asking someone else to break it and telling them plainly that finding a hole would be more useful than a clean report. A review that can only confirm is not a review.
+
+## Summary of New Capabilities
+
+None. This widens what an existing check can see and corrects a written claim about its limits. No new command, route, setting, or rule.
+
+## Evidence
+
+The two bypasses are the reviewer's own snippets, reproduced verbatim as tests. Proven in both directions: reverting both additions fails four tests while thirteen still pass — those thirteen including all six deliberate opposite-direction controls and a test that pins the remaining cross-module gap as still open. Among the controls is a new one specifically for this change: assigning an unrelated symbol to a variable and building from it is not flagged, because a rule that treated every variable as suspicious would pass every bypass test and fail on ordinary code. The real codebase passes cleanly before and after; source restored byte-identical after the check.


### PR DESCRIPTION
## ELI16 — two more ways past the runaway-process guard, found by trying to break it

PR #1874 (merged this afternoon) made the spawn-cap lint resolve import aliases and recognise `new ns.Cls(`. I then asked a peer agent to **break it**, and told it plainly that an evasion would be worth more to me than a clean bill of health.

It found **5 evasions. Two are SAME-FILE** — inside exactly the ground #1874 claimed to cover:

```ts
import { ClaudeCliIntelligenceProvider } from './core.js';
const C = ClaudeCliIntelligenceProvider;
new C({});                                            // plain re-binding

import * as Providers from './core.js';
new Providers['ClaudeCliIntelligenceProvider']({});    // computed access
```

The first is probably the easiest bypass anyone could write. **I did not anticipate it.**

## The fix

- **Re-binding resolves to a fixpoint** (bounded to 10 passes, early-exit when the set stops growing), so `const C = Cls; const D = C; new D()` cannot walk out of the set.
- **Computed access** is matched alongside dot access.

## This also corrects a claim I left on main

#1874's class-closure declaration said only: *"still evades: a construction reached through a re-export chain."* That named **one** gap when there were **three**, and two of them were same-file. The corrected declaration names all three cross-module evasions individually — re-export chain, double alias across two hops, namespace import of a re-export barrel — and **a test pins the open gap**, asserting it is *not* caught, so the boundary is documented rather than mistaken for an oversight later.

## Proven in both directions

| | both additions reverted | with fix |
|---|---|---|
| `const C = Cls; new C()` | **FAILS** | passes |
| chain `const C = Cls; const D = C;` | **FAILS** | passes |
| `new NS['Cls']()` | **FAILS** | passes |
| aliased re-binding of an aliased import | **FAILS** | passes |
| CONTROL: import alone / comment / similar name / bare variable | pass | pass |
| **CONTROL (new): `const C = SomethingElse; new C({})` not flagged** | pass | pass |
| KNOWN GAP pinned: cross-module re-export still evades | pass | pass |

**4 failed / 13 passed** when reverted — the 13 including all six opposite-direction controls and the pinned gap. Source restored byte-identical (sha + 9,214 bytes).

## Over-block is bounded three ways

Treating a variable as the class is the real risk here, since a lint blocks commits:
1. the re-binding right-hand side must **already be in the resolved set** (seeded only from the provider classes and their import aliases);
2. resolution is **per-file**, so a name in one file cannot taint another;
3. a dedicated control asserts an unrelated re-binding is not flagged.

Empirically: **the real repo lints clean before and after** (exit 0 both ways) — no false positives, no new work.

## Still open, named individually

Three cross-module evasions remain (re-export chain, double alias across two hops, namespace import of a re-export barrel). Per-file text resolution cannot follow a symbol re-exported from another module; closing them needs a cross-module symbol graph. 24 of the peer audit's 25 defeatable checks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
