### PR TITLE
fix(lint): credential-write guard was disarmed by splitting a string literal

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T19-41-32-871Z-credential-write-lint-evasions.json
+++ b/.instar/instar-dev-decisions/2026-08-14T19-41-32-871Z-credential-write-lint-evasions.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T19:41:32.871Z",
+  "slug": "credential-write-lint-evasions",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 109,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-unfunneled-credential-write.js"
+    ],
+    "addedLines": 90,
+    "deletedLines": 19
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/credential-write-lint-evasions.eli16.md
+++ b/docs/specs/credential-write-lint-evasions.eli16.md
@@ -1,0 +1,39 @@
+# The credential-write guard could be switched off by splitting a string
+
+> The one-line version: the rule that stops secrets being written outside the approved path only armed itself when it spotted a particular name written out in full, so writing that name in two halves turned the whole rule off.
+
+## The problem in one breath
+
+Every write of the Claude credential is supposed to go through one controlled path. A check enforces that, and part of it watches for raw writes straight to the system keychain.
+
+To avoid complaining about the *other* keychain stores this system uses — which are legitimate and have nothing to do with this credential — that part only arms itself when the file mentions the specific service name in full. That scoping is sensible. It is also the whole weakness: assign the name in two pieces and join them, and the rule never arms at all.
+
+Two smaller ways past existed alongside it: assign the credential store to a variable and write through the variable, or reach the write method with bracket notation instead of a dot. All three were confirmed getting past the check before this change.
+
+## What already exists
+
+- **One controlled path** for credential writes, holding a lock so two writers cannot interleave.
+- **The check**, in the standard set that runs before every commit and in continuous integration.
+- **A deliberate narrowing** so the other, unrelated keychain stores never trip it.
+
+## What this adds
+
+**Split strings are joined back together before the check decides whether to arm.** Writing the name in two pieces, or several, no longer disables the rule.
+
+**A variable holding the credential store is treated as the store**, following assignments to a fixed point.
+
+**Bracket access is recognised** alongside dot access, for both the store write and the credential-writing method.
+
+**The detection is now a separate importable function**, so it can be tested with small examples, and the command body is guarded so importing it does not run it — without that, importing it in a test would stop the test run the moment the codebase had a real violation.
+
+## The safeguards, and why they matter more here than usual
+
+Widening a rule that blocks commits risks the opposite failure: flagging correct code everywhere. That would be worse than the hole, because the fastest way to get rid of a noisy check is to switch it off.
+
+So five tests push the other way. A different keychain service is not flagged. A raw keychain write with no mention of the guarded service is not flagged. An unrelated store's write is not flagged. An unrelated variable assignment is not absorbed. Comments are not violations.
+
+**Proven in both directions:** restored to the old behaviour, seven tests fail and seven pass — and the seven that pass are exactly those five controls plus the plain cases. That is what makes them guards rather than echoes of the change. The real codebase passes cleanly before and after, so no new work is created.
+
+## How it was found
+
+A peer agent audited every check of this kind for defeat-by-renaming, classified twenty-five as defeatable, and ranked them by consequence. This one was its top recommendation, because the thing behind it is a secret.

--- a/docs/specs/credential-write-lint-evasions.side-effects.md
+++ b/docs/specs/credential-write-lint-evasions.side-effects.md
@@ -1,0 +1,81 @@
+# Side-Effects Review — credential-write lint: concatenation, re-binding, computed access
+
+**Version / slug:** `credential-write-lint-evasions`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent)`
+**Second-pass reviewer:** `instar-codey — ranked this #1 of the remaining 24 by consequence`
+
+## Summary of the change
+
+`scripts/lint-no-unfunneled-credential-write.js` enforces spec §2.2: every Claude credential write must route through `CredentialWriteFunnel.withSlotLock`. Its raw-keychain rule is GATED on `content.includes('Claude Code-credentials')` — a deliberate narrowing so the other, distinct-service vaults (WorktreeKeyVault, SecretStore, GlobalSecretStore, RemediationKeyVault) never false-positive. That gate is also the weakness. Three evasions were reproduced against the shipped lint before any edit:
+
+```ts
+const SVC = 'Claude Code' + '-credentials';                 // gate never arms
+execFileSync('security', ['add-generic-password', '-s', SVC]);
+const store = defaultCredentialStore; store.write(p);       // re-bound receiver
+provider['writeCredentials'](p);                            // computed access
+```
+
+Fix: fold simple string concatenation before the gate decides; resolve `defaultCredentialStore` re-bindings to a fixpoint; match computed access for both the store write and `writeCredentials`. Detection extracted to three exported pure functions; the CLI body guarded behind a direct-invocation check.
+
+## Decision-point inventory
+
+No decision point added or removed. Two are widened at their inputs: "does this file target the guarded service?" (now concatenation-tolerant) and "is this line a credential write?" (now alias/computed-aware). The funnel requirement, allowlist, messages and exit contract are unchanged.
+
+## 1. Over-block — the dominant risk here
+
+This lint blocks commits, and the gate it widens exists specifically to protect unrelated vaults. Widening it badly would trade a missed violation for noise on correct code, and a noisy check gets disabled. Bounded four ways:
+- concatenation folding only joins ADJACENT string literals (`'A' + 'B'`); it invents no text and cannot synthesise the service name from unrelated pieces;
+- the re-binding right-hand side must already be in the resolved set, seeded solely from `defaultCredentialStore`;
+- resolution is per-file, so a name in one file cannot taint another;
+- **five opposite-direction controls** pin it: a different keychain service, a raw keychain write with no guarded-service reference, an unrelated `.write(`, an unrelated re-binding, and comments.
+
+Empirically decisive: **the real repo lints CLEAN before and after** (exit 0 both ways).
+
+## 2. Under-block
+
+Residuals, stated rather than implied: a service name assembled through a template literal with an interpolated variable, or imported as a constant from another module, still disarms the gate — both need value resolution this per-file text check does not do. Cross-module re-export of the store is likewise unresolved, consistent with the same limit named in PR #1875.
+
+## 3. Level-of-abstraction fit
+
+Detection belongs in the lint (it owns what counts as a credential write); extracting it to exported functions is what makes the rules drivable with fixtures instead of only end-to-end. Same move, same reason, as PRs #1870/#1874.
+
+## 4. Signal vs authority compliance
+
+The lint IS authority — it fails a commit — and that authority is unchanged in kind and scope. Only what it can see is widened, and the tree passes clean, so no new blocking condition is introduced.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+None. Deterministic string folding, fixpoint name resolution, and regex matching. No heuristic, model call, or threshold.
+
+## 5. Interactions
+
+Blast radius: one script. The new exports have exactly one importer (the new test). The CLI body was previously import-unsafe — it calls `process.exit(1)` on violation, so any importer would have run the scan and could have killed the process; the guard closes that. `package.json` invocations unchanged; `tests/unit/lint-chain-completeness.test.ts` still passes.
+
+## 6. External surfaces
+
+None. No network, persisted state, credential read/write, telemetry, or route. It reads source files at lint time exactly as before — notably, this change touches a credential-adjacent LINT, never a credential path.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+Violation text unchanged (path:line, why, and the two remedies).
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+No issue identified — build-time check, no shared state, lease, or replication.
+
+## 8. Rollback cost
+
+Very low. One script, one new test file, one commit; no migration, persisted state, or config flag.
+
+## Evidence pointers
+
+- All three evasions REPRODUCED against the shipped lint before any edit, with a positive control caught in the same run: `EVADES bypass1/2/3`, `CAUGHT control`.
+- Negative control executed: reverting concat-folding, re-binding resolution and the computed form fails **7 tests / passes 7** — the 7 passers being all five opposite-direction controls plus the plain forms. Source restored byte-identical (sha + 10,567 bytes).
+- Real repo lints CLEAN before and after (exit 0 both ways).
+- Import-safety verified in both modes: as a CLI it prints `clean` and exits 0; imported, it does not run the scan.
+- 14/14 in `tests/unit/credential-write-lint-evasions.test.ts`.
+
+## Class-Closure Declaration (display-only mirror)
+
+Class: "a check defeatable by renaming or by splitting the literal it keys on." Closed for THIS lint for adjacent-literal concatenation, local re-binding (to a fixpoint), and computed access. **NOT closed** for: a template-literal service name with an interpolated variable; a service constant imported from another module; cross-module re-export of the store. **NOT closed repo-wide** — this is the 2nd of the peer audit's 25 defeatable checks (after `lint-no-unbounded-llm-spawn`); 23 remain, of which its triage classes 15 as SAFETY-FLOOR.

--- a/scripts/lint-no-unfunneled-credential-write.js
+++ b/scripts/lint-no-unfunneled-credential-write.js
@@ -86,6 +86,83 @@ const PATTERNS = [
 // services) are never false-positived.
 const RAW_KEYCHAIN_WRITE = /add-generic-password/;
 
+// ── Evasion-resistant detection (2026-08-14) ─────────────────────────────
+// A peer-agent audit classified this check DEFEATABLE by ordinary renaming,
+// and three bypasses were then reproduced against it:
+//
+//   const SVC = 'Claude Code' + '-credentials';         // concatenated service
+//   execFileSync('security', ['add-generic-password', '-s', SVC]);
+//   const store = defaultCredentialStore; store.write(p);  // re-bound receiver
+//   provider['writeCredentials'](p);                       // computed access
+//
+// The first is the sharpest: the raw-keychain rule is GATED on the literal
+// service string appearing in the file, so splitting it across a concatenation
+// switches the whole rule off. That gate exists to avoid false-positiving the
+// other, distinct-service vaults, so it is narrowed rather than removed.
+
+/** Collapse simple adjacent string concatenation so `'A' + 'B'` reads as `AB`. */
+export function collapseConcatenation(content) {
+  // `'A' + 'B'` / "A" + "B" / mixed quotes → `AB`. Repeated to fold chains.
+  let out = content;
+  for (let i = 0; i < 5; i++) {
+    const next = out.replace(/(['"])\s*\+\s*(['"])/g, '');
+    if (next === out) break;
+    out = next;
+  }
+  return out;
+}
+
+/** Local names bound to `defaultCredentialStore`, resolved to a fixpoint. */
+export function credentialStoreBindings(content) {
+  const names = new Set(['defaultCredentialStore']);
+  for (let pass = 0; pass < 10; pass++) {
+    const before = names.size;
+    for (const known of [...names]) {
+      const re = new RegExp(`\\b(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*${known}\\s*[;,\\n]`, 'g');
+      for (const m of content.matchAll(re)) names.add(m[1]);
+    }
+    if (names.size === before) break;
+  }
+  return [...names];
+}
+
+/**
+ * Violations in `content`, as { line, msg }. Exported so the rules can be
+ * driven with fixtures rather than only end-to-end over the tree.
+ */
+export function findCredentialWriteViolations(content) {
+  const hits = [];
+  // Concatenation-tolerant: a split service literal no longer disarms the rule.
+  const targetsGuardedService = collapseConcatenation(content).includes(GUARDED_SERVICE);
+  const storeNames = credentialStoreBindings(content);
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (isCommentLine(line)) continue;
+    // Re-bound receiver + computed access on the store write.
+    for (const n of storeNames) {
+      if (new RegExp(`\\b${n}\\s*\\.\\s*write\\s*\\(`).test(line)
+        || new RegExp(`\\b${n}\\s*\\[\\s*['"\`]write['"\`]\\s*\\]\\s*\\(`).test(line)) {
+        hits.push({ line: i + 1, msg: PATTERNS[0].msg });
+        break;
+      }
+    }
+    // `.writeCredentials(` and its computed form.
+    if (/\.writeCredentials\s*\(/.test(line)
+      || /\[\s*['"`]writeCredentials['"`]\s*\]\s*\(/.test(line)) {
+      hits.push({ line: i + 1, msg: PATTERNS[1].msg });
+    }
+    if (targetsGuardedService && RAW_KEYCHAIN_WRITE.test(line)) {
+      hits.push({
+        line: i + 1,
+        msg: `raw 'add-generic-password' to the ${GUARDED_SERVICE} service outside the funnel. `
+          + `Route the write through CredentialWriteFunnel.withSlotLock, or add an allowlist entry here with a justification.`,
+      });
+    }
+  }
+  return hits;
+}
+
 function isCommentLine(line) {
   const t = line.trim();
   return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*') || t.startsWith('#');
@@ -118,6 +195,15 @@ function listFiles() {
   return files;
 }
 
+// ── CLI body ─────────────────────────────────────────────────────────────
+// Guarded so the exported detector can be imported by tests WITHOUT running the
+// scan: this module calls process.exit(1) on a violation, so an unguarded
+// import would kill any test run the moment the repo had one. Same pattern as
+// scripts/eli16-pr-description-check.mjs and lint-no-unbounded-llm-spawn.js.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
 let violations = 0;
 for (const rel of listFiles()) {
   const normalized = rel.split(path.sep).join('/');
@@ -130,25 +216,9 @@ for (const rel of listFiles()) {
   } catch {
     continue;
   }
-  const fileTargetsGuardedService = content.includes(GUARDED_SERVICE);
-  const lines = content.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (isCommentLine(line)) continue;
-    for (const { re, msg } of PATTERNS) {
-      if (re.test(line)) {
-        console.error(`${normalized}:${i + 1} — ${msg}`);
-        violations++;
-      }
-    }
-    if (fileTargetsGuardedService && RAW_KEYCHAIN_WRITE.test(line)) {
-      console.error(
-        `${normalized}:${i + 1} — raw 'add-generic-password' to the ${GUARDED_SERVICE} service outside ` +
-        `the funnel. Route the write through CredentialWriteFunnel.withSlotLock, or add an allowlist entry ` +
-        `here with a justification.`,
-      );
-      violations++;
-    }
+  for (const hit of findCredentialWriteViolations(content)) {
+    console.error(`${normalized}:${hit.line} — ${hit.msg}`);
+    violations++;
   }
 }
 
@@ -160,3 +230,4 @@ if (violations > 0) {
   process.exit(1);
 }
 console.log('lint-no-unfunneled-credential-write: clean');
+}

--- a/tests/unit/credential-write-lint-evasions.test.ts
+++ b/tests/unit/credential-write-lint-evasions.test.ts
@@ -1,0 +1,121 @@
+/**
+ * lint-no-unfunneled-credential-write — evasion resistance.
+ *
+ * This lint guards a credential path: every Claude credential write must go
+ * through CredentialWriteFunnel.withSlotLock (spec §2.2). A peer-agent audit
+ * classified it DEFEATABLE by ordinary renaming; three bypasses were then
+ * reproduced against it, all confirmed EVADING before this change:
+ *
+ *   const SVC = 'Claude Code' + '-credentials';            // concatenated service
+ *   execFileSync('security', ['add-generic-password', '-s', SVC]);
+ *   const store = defaultCredentialStore; store.write(p);  // re-bound receiver
+ *   provider['writeCredentials'](p);                       // computed access
+ *
+ * The first is the sharpest: the raw-keychain rule is GATED on the literal
+ * service string appearing in the file, so splitting it across a concatenation
+ * switches the entire rule off.
+ *
+ * The detector is driven DIRECTLY here rather than via the CLI's exit code —
+ * a lint that CRASHES also exits 1, so exit-code-only assertions cannot tell
+ * "caught it" from "died on startup".
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  collapseConcatenation,
+  credentialStoreBindings,
+  findCredentialWriteViolations,
+  // @ts-expect-error — plain .js lint script, no type declarations
+} from '../../scripts/lint-no-unfunneled-credential-write.js';
+
+const SERVICE = 'Claude Code-credentials';
+
+describe('collapseConcatenation', () => {
+  it('folds a split literal so the service gate cannot be disarmed', () => {
+    expect(collapseConcatenation(`const S = 'Claude Code' + '-credentials';`)).toContain(SERVICE);
+  });
+
+  it('folds a chain of concatenations', () => {
+    expect(collapseConcatenation(`const S = 'Claude' + ' Code' + '-credent' + 'ials';`)).toContain(SERVICE);
+  });
+
+  it('CONTROL: leaves unrelated text alone', () => {
+    const src = `const S = 'WorktreeKeyVault';`;
+    expect(collapseConcatenation(src)).toContain('WorktreeKeyVault');
+    expect(collapseConcatenation(src)).not.toContain(SERVICE);
+  });
+});
+
+describe('credentialStoreBindings', () => {
+  it('resolves a re-binding, and a chain of them, to a fixpoint', () => {
+    const src = ['const store = defaultCredentialStore;', 'const s2 = store;'].join('\n');
+    const names = credentialStoreBindings(src);
+    expect(names).toContain('store');
+    expect(names).toContain('s2');
+  });
+
+  it('CONTROL: an unrelated re-binding is not absorbed', () => {
+    expect(credentialStoreBindings('const store = somethingElse;')).not.toContain('store');
+  });
+});
+
+describe('findCredentialWriteViolations — the three bypasses', () => {
+  it('CONTROL: the plain forms are still caught', () => {
+    expect(findCredentialWriteViolations('defaultCredentialStore.write(p);')).toHaveLength(1);
+    expect(findCredentialWriteViolations('provider.writeCredentials(p);')).toHaveLength(1);
+    expect(
+      findCredentialWriteViolations(
+        [`const svc = '${SERVICE}';`, "execFileSync('security', ['add-generic-password', '-s', svc]);"].join('\n'),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('BYPASS 1: a CONCATENATED service literal no longer disarms the keychain rule', () => {
+    const src = [
+      `const SVC = 'Claude Code' + '-credentials';`,
+      "execFileSync('security', ['add-generic-password', '-s', SVC]);",
+    ].join('\n');
+    // Confirmed EVADING before this change.
+    expect(findCredentialWriteViolations(src)).toHaveLength(1);
+  });
+
+  it('BYPASS 2: a RE-BOUND credential store is caught', () => {
+    const src = ['const store = defaultCredentialStore;', 'store.write(payload);'].join('\n');
+    expect(findCredentialWriteViolations(src)).toHaveLength(1);
+  });
+
+  it('BYPASS 3: COMPUTED access to writeCredentials is caught', () => {
+    expect(findCredentialWriteViolations("provider['writeCredentials'](payload);")).toHaveLength(1);
+  });
+
+  it('BYPASS 2b: computed write on a re-bound store is caught', () => {
+    const src = ['const store = defaultCredentialStore;', "store['write'](payload);"].join('\n');
+    expect(findCredentialWriteViolations(src)).toHaveLength(1);
+  });
+
+  // ── The other direction. This gate exists to keep the OTHER keychain vaults
+  //    from tripping the rule; widening it without these would swap a missed
+  //    violation for a wall of false ones on unrelated, correct code.
+  it('CONTROL: a DIFFERENT keychain service is NOT flagged', () => {
+    const src = [
+      `const svc = 'WorktreeKeyVault';`,
+      "execFileSync('security', ['add-generic-password', '-s', svc]);",
+    ].join('\n');
+    expect(findCredentialWriteViolations(src)).toEqual([]);
+  });
+
+  it('CONTROL: a raw keychain write with no guarded-service reference is NOT flagged', () => {
+    expect(
+      findCredentialWriteViolations("execFileSync('security', ['add-generic-password', '-s', other]);"),
+    ).toEqual([]);
+  });
+
+  it('CONTROL: an unrelated .write( is not flagged', () => {
+    expect(findCredentialWriteViolations('someOtherStore.write(p);')).toEqual([]);
+  });
+
+  it('CONTROL: comments are not violations', () => {
+    const src = ['// defaultCredentialStore.write(p);', ' * provider.writeCredentials(p);'].join('\n');
+    expect(findCredentialWriteViolations(src)).toEqual([]);
+  });
+});

--- a/upgrades/next/credential-write-lint-evasions.md
+++ b/upgrades/next/credential-write-lint-evasions.md
@@ -1,0 +1,27 @@
+## What Changed
+
+The rule that stops secrets being written outside the approved path could be switched off by writing one name in two halves.
+
+- **The raw-keychain part of the check only arms itself when it sees a particular service name written out in full.** That narrowing is deliberate — it keeps the other, unrelated keychain stores from being flagged — but it means splitting the name across a join turned the entire rule off.
+- **Two smaller ways past existed too**: assign the credential store to a variable and write through the variable, or reach the write method with bracket notation instead of a dot.
+- **All three were confirmed getting past the check before this change**, with a known-caught example passing in the same run to prove the probe worked.
+- **All three are now closed.** Split strings are joined before the check decides whether to arm, variables holding the store are followed to a fixed point, and bracket access is recognised.
+- **Nothing new is forbidden.** The same writes are disallowed as before; more of them are visible, and the codebase passes cleanly before and after.
+
+## What to Tell Your User
+
+Every write of the stored Claude credential is meant to go through a single controlled path, and a check enforces it. To avoid complaining about unrelated keychain entries, part of that check only switched on when it recognised a specific name spelled out in full — so spelling it in two pieces made the check ignore the file completely.
+
+Nothing was actually being written unsafely; the hole was in the guard. It is closed, along with two smaller ones.
+
+The care here went into the opposite risk. Widening a rule that blocks work can flood people with false complaints about correct code, and the quickest way to silence a noisy check is to switch it off. So five deliberate tests confirm the things that must *not* be flagged still are not, and the whole codebase passes cleanly before and after.
+
+## Summary of New Capabilities
+
+None. This widens what an existing check can see. No new command, route, setting, or rule.
+
+## Evidence
+
+The three bypasses were reproduced against the shipped check before any change, alongside a known-caught example in the same run to prove the probe could detect anything at all. Proven in both directions: restored to the old behaviour, seven tests fail and seven pass — and the seven that pass are exactly the five opposite-direction controls plus the plain cases, which is what makes them guards rather than echoes. Those controls check that a different keychain service is not flagged, that a raw keychain write with no reference to the guarded service is not flagged, that an unrelated store's write is not flagged, that an unrelated variable assignment is not absorbed, and that comments are not violations. The real codebase passes cleanly before and after, and the source was restored byte-identical after the check.
+
+Remaining gaps are named rather than implied: a service name built through a template with a variable in it, or imported as a constant from another file, still disarms the rule — both need value resolution this check does not do.


### PR DESCRIPTION
## ELI16 — the credential-write guard could be switched off by splitting a string

Every Claude credential write must route through `CredentialWriteFunnel.withSlotLock` (spec §2.2). Part of that check watches for raw writes straight to the system keychain — and it **arms itself only when the file mentions the service name in full**:

```js
const fileTargetsGuardedService = content.includes('Claude Code-credentials');
```

That narrowing is deliberate and correct: it stops the *other* keychain vaults (WorktreeKeyVault, SecretStore, GlobalSecretStore, RemediationKeyVault) from being false-positived. It is also the weakness — split the name across a join and the rule never arms at all.

**Three evasions, all reproduced against the shipped lint before any edit** (with a positive control CAUGHT in the same run):

```ts
const SVC = 'Claude Code' + '-credentials';                 // gate never arms
execFileSync('security', ['add-generic-password', '-s', SVC]);
const store = defaultCredentialStore; store.write(p);       // re-bound receiver
provider['writeCredentials'](p);                            // computed access
```

Nothing is being written unsafely today — the hole was in the guard, not in what it guards.

## The fix

- **Adjacent string concatenation is folded** before the gate decides whether to arm.
- **`defaultCredentialStore` re-bindings resolve to a fixpoint**, so chains cannot walk out of the set.
- **Computed access** is matched for both the store write and `writeCredentials`.
- Detection extracted to exported pure functions; **CLI body guarded** behind a direct-invocation check (it calls `process.exit(1)`, so an unguarded import would kill a test run the moment the repo had a violation).

## Over-block is the dominant risk here, and is bounded four ways

This lint **blocks commits**, and the gate it widens exists to protect unrelated vaults. Trading a missed violation for noise on correct code would be worse than the hole — the fastest way to kill a noisy check is to disable it. So:

1. folding joins only **adjacent literals**; it invents no text and cannot synthesise the service name from unrelated pieces;
2. the re-binding right-hand side must **already be in the resolved set**, seeded solely from `defaultCredentialStore`;
3. resolution is **per-file**;
4. **five opposite-direction controls**: a different keychain service, a raw keychain write with no guarded-service reference, an unrelated `.write(`, an unrelated re-binding, and comments.

**Decisive:** the real repo lints **CLEAN before and after** (exit 0 both ways).

## Proven in both directions

Reverting concat-folding, re-binding resolution and the computed form: **7 failed / 7 passed** — and the 7 passers are exactly those five controls plus the plain forms. That is what makes them guards rather than echoes. Source restored byte-identical (sha + 10,567 bytes). 14/14 with the fix.

## Not closed — named, not implied

A service name built via a template literal with an interpolated variable, or imported as a constant from another module, still disarms the gate; so does cross-module re-export of the store. All need value resolution this per-file text check does not do.

This is the **2nd of 25** defeatable checks from `instar-codey`'s audit — its **#1 by consequence**, because the thing behind this one is a secret. 23 remain, 15 of them classed SAFETY-FLOOR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
