### PR TITLE
fix(lint): telegram-egress check now resolves fetch aliases it had admitted missing

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T20-08-22-876Z-telegram-egress-lint-alias.json
+++ b/.instar/instar-dev-decisions/2026-08-14T20-08-22-876Z-telegram-egress-lint-alias.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T20:08:22.876Z",
+  "slug": "telegram-egress-lint-alias",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 79,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-telegram-egress-boundary.mjs"
+    ],
+    "addedLines": 68,
+    "deletedLines": 11
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/telegram-egress-lint-alias.eli16.md
+++ b/docs/specs/telegram-egress-lint-alias.eli16.md
@@ -1,0 +1,33 @@
+# The messaging-door guard closed the gap it had already admitted to
+
+> The one-line version: the check that proves only one file can talk to Telegram said in its own header that renaming the network call would defeat it — and now it doesn't.
+
+## The problem in one breath
+
+All outgoing Telegram traffic must pass through a single file, which inspects what is being sent before sending it. A check proves nothing else reaches the network on a Telegram address.
+
+It recognised the network call written several ways, but not one: assign the call to a variable first, then call the variable. Its own header said so plainly — that catching it "needs alias resolution this does not do" — and scoped its stated claim to match.
+
+That honesty is unusual and worth keeping. It is also still a hole, in a door that carries the credential for the whole messaging channel.
+
+## What already exists
+
+- **One file** allowed to reach Telegram, which runs a visibility check before every send.
+- **The check**, which already understood several ways of writing the call, including reaching it as a property and calling it indirectly through the standard indirection helpers.
+- **A written statement of its own limits**, including this gap and two others.
+
+## What this adds
+
+**A network call assigned to a variable is now recognised**, followed through chains of assignment to a fixed point.
+
+This is done on the parsed structure of the file rather than by matching text. The file is already parsed, and a declaration whose value *is* the network call is unambiguous — where searching for the text `= fetch` would also match a property with that name on some unrelated object.
+
+**The header's statement of limits is corrected.** It said this was not covered; it now is, and three narrower things are named in its place: reassigning after declaration, receiving the call as a function argument, and importing a wrapper from another file. Leaving the old wording would have left a false statement in the one place a reader goes to learn what the check is worth.
+
+## The safeguards
+
+**Four tests push the other way**, and they matter more than usual because this check blocks work: an unrelated assignment is not absorbed, a property whose name merely differs is not absorbed, a file with no reference at all yields nothing, and the *word* "fetch" as a piece of text is not a binding. A resolver that absorbed every declaration would pass every test about catching the gap and flag correct code everywhere.
+
+**Two tests pin the remaining gaps deliberately** — asserting they are *not* caught, so the boundary is documented rather than mistaken for an oversight. If someone closes them properly, those tests fail and get updated on purpose.
+
+**Proven in both directions**: with the resolution removed, three tests fail and six pass — the six being those four controls and the two pinned gaps. The codebase passes cleanly before and after.

--- a/docs/specs/telegram-egress-lint-alias.side-effects.md
+++ b/docs/specs/telegram-egress-lint-alias.side-effects.md
@@ -1,0 +1,68 @@
+# Side-Effects Review — telegram-egress lint: fetch alias resolution
+
+**Version / slug:** `telegram-egress-lint-alias`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent)`
+**Second-pass reviewer:** `instar-codey — ranked this #2 of the remaining 24 by consequence`
+
+## Summary of the change
+
+`scripts/lint-telegram-egress-boundary.mjs` proves exactly one file may `fetch` a Telegram Bot API URL. Its recogniser handled bare `fetch`, `x.fetch`, `fetch.call/apply` and `x['fetch']`, and its header named the remaining gap explicitly: *"a fetch bound to a DIFFERENT name (`const send = fetch; send(url)`) […] needs alias resolution this does not do."* This adds `collectFetchAliases(sf)` — an AST pass collecting variable declarations whose initialiser IS the fetch function, resolved to a fixpoint — threads the alias set through `isFetchCall`/`isFetchTarget`, guards the CLI body behind a direct-invocation check, and **corrects both places in the header that stated the gap as open**.
+
+## Decision-point inventory
+
+No decision point added or removed. One is widened at its input: "is this call a fetch?" The door location, the guard requirement, the URL recogniser and the exit contract are unchanged.
+
+## 1. Over-block
+
+The dominant risk: this lint blocks commits, so a resolver that over-matched would flag correct code across `src/`. Bounded by construction — a name is bound only when a variable declaration's initialiser satisfies `isFetchTarget` (the identifier `fetch`, or a property access whose final name is `fetch`), seeded from nothing else; the fixpoint only grows through names already bound; and resolution is per-file. Four opposite-direction controls pin it (unrelated initialiser, differently-named property, no-reference file, the string `'fetch'`). Decisive: **the real repo lints CLEAN before and after**.
+
+Chosen deliberately over a text scan for `= fetch`, which would also match a property named `fetch` on an unrelated object — the AST distinguishes them and was already available since the file is parsed.
+
+## 2. Under-block
+
+Three residuals, now named in the header in place of the one it previously named: re-assignment after declaration (`let send; send = fetch;`), a fetch arriving as a function PARAMETER, and a wrapper imported from another module. All need flow or cross-module analysis this check does not do. **Two are pinned by tests asserting they are NOT caught**, so the boundary is documented rather than assumed.
+
+## 3. Level-of-abstraction fit
+
+Alias collection belongs beside the other AST recognisers in the lint, and is exported so it can be driven with fixtures rather than only end-to-end. The CLI guard belongs at the module boundary.
+
+## 4. Signal vs authority compliance
+
+The lint IS authority — it fails a commit — unchanged in kind and scope. Only what it can see is widened; the tree passes clean, so no new blocking condition.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+None. Deterministic AST predicates and a bounded fixpoint. No heuristic, model call, or threshold.
+
+## 5. Interactions
+
+Blast radius: one script. The new export has exactly one importer (the new test). The module previously had FOUR `process.exit(1)` paths and no guard, so any importer would have run the full scan and could have killed the process — the guard closes that. `package.json` invocation unchanged; `tests/unit/telegram-egress-boundary.test.ts` tests the DOOR, not the lint, and is unaffected.
+
+## 6. External surfaces
+
+None. No network, persisted state, credential, telemetry, or route. It reads source at lint time exactly as before — this change touches the CHECK, never the egress path.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+Violation and clean-summary text unchanged.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+No issue identified — build-time check, no shared state.
+
+## 8. Rollback cost
+
+Very low. One script, one new test file, one commit; no migration, persisted state, or config flag.
+
+## Evidence pointers
+
+- The gap was not discovered by me — the lint's own header declared it, at two separate places, and both are corrected here rather than left stating something now false.
+- Negative control executed: making `collectFetchAliases` return an empty set fails **3 tests / passes 6** — the 6 being all four over-match controls and both pinned known-gaps. Source restored byte-identical (sha + 14,818 bytes).
+- Real repo lints CLEAN before and after (exit 0 both ways).
+- Import-safety verified both modes: as a CLI it prints its clean summary and exits 0; imported, it does not run the scan.
+- 9/9 in `tests/unit/telegram-egress-lint-alias.test.ts`.
+
+## Class-Closure Declaration (display-only mirror)
+
+Class: "a check defeatable by binding its target to another name." Closed for THIS lint for local variable declarations, followed to a fixpoint. **NOT closed** for re-assignment after declaration, parameters, or cross-module wrappers — all three named in the header and two pinned by tests. **NOT closed repo-wide**: this is the 3rd of the peer audit's 25 defeatable checks; 22 remain, 14 of them classed SAFETY-FLOOR.

--- a/scripts/lint-telegram-egress-boundary.mjs
+++ b/scripts/lint-telegram-egress-boundary.mjs
@@ -23,8 +23,10 @@
  * WHAT IT DOES NOT PROVE, stated because the previous version's claims outran its analysis:
  *   - It resolves a URL through a LOCAL declaration or a local helper only. A Bot API URL assembled
  *     in another module and imported would not be recognised.
- *   - It does not follow a `fetch` reference stored in a variable and called indirectly.
- *   Both are narrower than the gaps they replace, and both are named here rather than discovered.
+ *   - It follows a `fetch` stored in a LOCAL variable declaration (added 2026-08-14), but NOT one
+ *     re-assigned after declaration, arriving as a function parameter, or imported as a wrapper from
+ *     another module.
+ *   All are narrower than the gaps they replace, and all are named here rather than discovered.
  *
  * WHERE THIS ENDS AND THE TESTS BEGIN — established by sabotage, not by assumption. Breaking the
  * door's OWN url-to-method recogniser (so it silently skips the check on every send) leaves this lint
@@ -109,18 +111,25 @@ function denotesBotApiUrl(node, sf) {
  * invisible to a lint whose headline claim is "exactly one file". A property access whose final name
  * is `fetch` counts too.
  *
- * Still NOT covered, said plainly rather than left for the next reading to find: a fetch bound to a
- * DIFFERENT name (`const send = fetch; send(url)`) or reached through a computed member. Catching
- * those needs alias resolution this does not do. The claim below is written to match this scope.
+ * Alias resolution ADDED 2026-08-14 (a peer-agent audit ranked this check #2 of 25 defeatable by
+ * renaming, and this header had honestly named its own gap): a fetch bound to a DIFFERENT name
+ * (`const send = fetch; send(url)`) is now caught, resolved on the AST via collectFetchAliases and
+ * followed to a fixpoint so `const a = fetch; const b = a;` closes too. A computed member on a
+ * string literal (`x['fetch']`) was already covered.
+ *
+ * Still NOT covered, said plainly rather than left for the next reading to find: re-assignment after
+ * declaration, a fetch arriving as a function PARAMETER, and a wrapper imported from another module.
+ * Those need flow and cross-module analysis this does not do. The claim below is written to match
+ * this scope.
  */
-function isFetchCall(n) {
+function isFetchCall(n, aliases = EMPTY_ALIASES) {
   if (!ts.isCallExpression(n)) return false;
   const e = n.expression;
-  if (ts.isIdentifier(e)) return e.text === 'fetch';
+  if (ts.isIdentifier(e)) return e.text === 'fetch' || aliases.has(e.text);
   if (ts.isPropertyAccessExpression(e)) {
     // `fetch.call(...)` / `fetch.apply(...)` are direct invocations of fetch, and `x['fetch']` is a
     // property access spelled differently (pass 40 F3).
-    if (e.name.text === 'call' || e.name.text === 'apply') return isFetchTarget(e.expression);
+    if (e.name.text === 'call' || e.name.text === 'apply') return isFetchTarget(e.expression, aliases);
     return e.name.text === 'fetch';
   }
   if (ts.isElementAccessExpression(e)) {
@@ -131,12 +140,57 @@ function isFetchCall(n) {
 }
 
 /** Is this expression the `fetch` function itself (for `.call`/`.apply` forms)? */
-function isFetchTarget(e) {
-  if (ts.isIdentifier(e)) return e.text === 'fetch';
+function isFetchTarget(e, aliases = EMPTY_ALIASES) {
+  if (ts.isIdentifier(e)) return e.text === 'fetch' || aliases.has(e.text);
   if (ts.isPropertyAccessExpression(e)) return e.name.text === 'fetch';
   return false;
 }
 
+const EMPTY_ALIASES = new Set();
+
+/**
+ * Local names bound to `fetch` in this file, resolved to a fixpoint so a chain
+ * (`const a = fetch; const b = a;`) closes too.
+ *
+ * This closes the gap the header above named plainly and left open: a fetch
+ * bound to a DIFFERENT name. Done on the AST rather than by text, because the
+ * file is already parsed — a variable declaration whose initialiser IS the
+ * fetch function is unambiguous, where a regex over `= fetch` would also match
+ * a property called fetch on an unrelated object.
+ *
+ * Deliberately NOT resolved: re-assignment after declaration, parameters, and
+ * imports of a wrapper from another module. Those need flow/cross-module
+ * analysis; the claim stays scoped to what is actually checked.
+ */
+export function collectFetchAliases(sf) {
+  const names = new Set();
+  const decls = [];
+  const walkNode = (n) => {
+    if (ts.isVariableDeclaration(n) && n.initializer && ts.isIdentifier(n.name)) {
+      decls.push([n.name.text, n.initializer]);
+    }
+    ts.forEachChild(n, walkNode);
+  };
+  walkNode(sf);
+  for (let pass = 0; pass < 10; pass++) {
+    const before = names.size;
+    for (const [name, init] of decls) {
+      if (isFetchTarget(init, names)) names.add(name);
+    }
+    if (names.size === before) break;
+  }
+  return names;
+}
+
+// ── CLI body ─────────────────────────────────────────────────────────────
+// Guarded so collectFetchAliases can be imported by tests WITHOUT running the
+// scan: this module has four process.exit(1) paths, so an unguarded import
+// would kill any test run the moment the repo had a violation. Same pattern as
+// scripts/eli16-pr-description-check.mjs.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
 const violations = [];
 let doorSeen = false;
 
@@ -147,9 +201,10 @@ for (const file of walk(SRC)) {
   if (!text.toLowerCase().includes('api.telegram.org')) continue;
   const sf = parse(file, text);
   const isDoor = path.resolve(file) === DOOR;
+  const aliases = collectFetchAliases(sf);
 
   const visit = (n) => {
-    if (isFetchCall(n) && ts.isCallExpression(n)) {
+    if (isFetchCall(n, aliases) && ts.isCallExpression(n)) {
       if (denotesBotApiUrl(n.arguments[0], sf)) {
         if (isDoor) doorSeen = true;
         else {
@@ -254,3 +309,5 @@ console.log(
   'lint-telegram-egress-boundary: clean — Telegram Bot API egress is confined to '
   + 'src/messaging/telegram-egress.ts, which checks the serialised body before sending.',
 );
+
+}

--- a/tests/unit/telegram-egress-lint-alias.test.ts
+++ b/tests/unit/telegram-egress-lint-alias.test.ts
@@ -1,0 +1,76 @@
+/**
+ * lint-telegram-egress-boundary — fetch alias resolution.
+ *
+ * The lint proves "exactly one file may call fetch on a Telegram Bot API URL".
+ * Its own header named the gap plainly rather than hiding it:
+ *
+ *   "Still NOT covered […]: a fetch bound to a DIFFERENT name
+ *    (`const send = fetch; send(url)`) […]. Catching those needs alias
+ *    resolution this does not do."
+ *
+ * A peer-agent audit ranked this #2 of 25 checks defeatable by renaming, on the
+ * grounds that this door carries the bot token. The gap is now closed on the
+ * AST — the file is already parsed, and a variable declaration whose initialiser
+ * IS the fetch function is unambiguous, where a regex over `= fetch` would also
+ * match a property named fetch on an unrelated object.
+ *
+ * Driven directly rather than through the CLI's exit code: this lint has four
+ * process.exit(1) paths, so an exit-code assertion cannot distinguish "caught
+ * the violation" from "died on startup".
+ */
+
+import { describe, expect, it } from 'vitest';
+import ts from 'typescript';
+// @ts-expect-error — plain .mjs lint script, no type declarations
+import { collectFetchAliases } from '../../scripts/lint-telegram-egress-boundary.mjs';
+
+const sf = (src: string): ts.SourceFile =>
+  ts.createSourceFile('probe.ts', src, ts.ScriptTarget.Latest, true);
+
+const names = (src: string): string[] => [...collectFetchAliases(sf(src))];
+
+describe('collectFetchAliases — the gap the header named', () => {
+  it('THE GAP: `const send = fetch` binds an alias', () => {
+    expect(names('const send = fetch;')).toContain('send');
+  });
+
+  it('a CHAIN of bindings resolves to a fixpoint', () => {
+    expect(names('const a = fetch;\nconst b = a;\nconst c = b;')).toEqual(
+      expect.arrayContaining(['a', 'b', 'c']),
+    );
+  });
+
+  it('binds a property-access form too (`const f = globalThis.fetch`)', () => {
+    expect(names('const f = globalThis.fetch;')).toContain('f');
+  });
+
+  // ── The other direction. A resolver that absorbed every declaration would
+  //    pass every test above and flag correct code everywhere — and this lint
+  //    blocks commits, so over-matching is the more expensive failure.
+  it('CONTROL: an unrelated initialiser is NOT bound', () => {
+    expect(names('const send = somethingElse;')).not.toContain('send');
+  });
+
+  it('CONTROL: a property that merely ends in a different name is NOT bound', () => {
+    expect(names('const f = obj.notFetch;')).not.toContain('f');
+  });
+
+  it('CONTROL: a file with no fetch reference yields an empty set', () => {
+    expect(names('const a = 1;\nconst b = a;')).toEqual([]);
+  });
+
+  it('CONTROL: a string literal "fetch" is not a binding', () => {
+    expect(names("const send = 'fetch';")).not.toContain('send');
+  });
+
+  // Scope, pinned so the boundary is documented rather than assumed. These are
+  // named in the lint header as still-open; if someone closes them properly,
+  // these tests fail and get updated deliberately.
+  it('KNOWN GAP: a re-assignment after declaration is NOT followed', () => {
+    expect(names('let send;\nsend = fetch;')).not.toContain('send');
+  });
+
+  it('KNOWN GAP: a fetch arriving as a PARAMETER is NOT followed', () => {
+    expect(names('function go(send) { send(url); }')).not.toContain('send');
+  });
+});

--- a/upgrades/next/telegram-egress-lint-alias.md
+++ b/upgrades/next/telegram-egress-lint-alias.md
@@ -1,0 +1,23 @@
+## What Changed
+
+The check that proves only one file can talk to Telegram had already admitted, in its own header, that renaming the network call would defeat it. That gap is now closed.
+
+- **Assigning the network call to a variable and calling the variable** was not recognised. The check's own documentation said so plainly and scoped its stated claim to match — honest, and still a hole in a door that carries the credential for the whole messaging channel.
+- **It is now recognised**, followed through chains of assignment to a fixed point.
+- **Done on the parsed structure of the file, not by matching text.** The file is already parsed, and a declaration whose value *is* the network call is unambiguous — searching for the text would also match a property with that name on an unrelated object.
+- **The header's statement of limits is corrected.** It named this gap as open; three narrower ones are named in its place. Leaving the old wording would have left a false statement in the one place a reader looks to learn what the check is worth.
+- **Nothing new is forbidden**, and the codebase passes cleanly before and after.
+
+## What to Tell Your User
+
+Everything sent to Telegram has to go through one file, which looks at the message before it goes out. A check proves nothing else can reach the network on a Telegram address.
+
+It recognised that call written several ways, but not the simplest disguise: put it in a variable first. The check said so about itself, which is better than pretending otherwise, but it was still a way around a door that holds the messaging credential. It is closed now, and the three narrower ways still open are written down where the next reader will find them.
+
+## Summary of New Capabilities
+
+None. This widens what an existing check can see and corrects its written description of its own limits. No new command, route, setting, or rule.
+
+## Evidence
+
+The gap was not discovered by anyone — the check declared it, in two separate places, and both are corrected here rather than left stating something now false. Proven in both directions: with the resolution removed, three tests fail and six pass, and those six are exactly the four deliberate opposite-direction controls plus two tests that pin the remaining gaps as still open. Those controls matter more than usual because this check blocks work: an unrelated assignment is not absorbed, a property whose name merely differs is not absorbed, a file with no reference yields nothing, and the word itself as a piece of text is not a binding. The real codebase passes cleanly before and after, source restored byte-identical after the check, and the module is now safe to import — it previously had four exit paths and no guard, so importing it in a test would have stopped the test run the moment the codebase had a violation.


### PR DESCRIPTION
## ELI16 — the messaging-door guard closed the gap it had already admitted to

`lint-telegram-egress-boundary` proves exactly one file may `fetch` a Telegram Bot API URL. Its header named its own gap, plainly:

> *"Still NOT covered, said plainly rather than left for the next reading to find: a fetch bound to a DIFFERENT name (`const send = fetch; send(url)`) […]. Catching those needs alias resolution this does not do. The claim below is written to match this scope."*

That honesty is unusual and worth keeping — the check scoped its stated claim to what it actually verified. It was also still a hole in a door that carries the bot token. Peer triage ranked it **#2 of 25** by consequence.

## The fix

`collectFetchAliases(sf)` collects variable declarations whose initialiser **is** the fetch function and resolves them to a fixpoint (`const a = fetch; const b = a;`), threaded through `isFetchCall` / `isFetchTarget`.

**Done on the AST, not by text.** The file is already parsed, and a declaration whose value *is* fetch is unambiguous — a regex over `= fetch` would also match a property named `fetch` on an unrelated object.

## Both header statements are corrected

The gap was declared in **two** places — the recogniser comment and the `WHAT IT DOES NOT PROVE` list. Both now say what is true, with three narrower residuals named in place of the one they named before: re-assignment after declaration, a fetch arriving as a **parameter**, and a cross-module wrapper. Leaving the old wording would have left a false statement in the one place a reader goes to learn what this check is worth.

**Two of the three are pinned by tests asserting they are NOT caught** — so the boundary is documented rather than mistaken for an oversight, and closing one properly will fail its test and be updated deliberately.

## Proven in both directions

| | resolution removed | with fix |
|---|---|---|
| `const send = fetch` binds an alias | **FAILS** | passes |
| a chain resolves to a fixpoint | **FAILS** | passes |
| `const f = globalThis.fetch` binds | **FAILS** | passes |
| CONTROL: unrelated initialiser not bound | passes | passes |
| CONTROL: differently-named property not bound | passes | passes |
| CONTROL: no-reference file yields empty | passes | passes |
| CONTROL: the string `'fetch'` is not a binding | passes | passes |
| KNOWN GAP pinned: re-assignment not followed | passes | passes |
| KNOWN GAP pinned: parameter not followed | passes | passes |

**3 failed / 6 passed** when reverted — the 6 being all four over-match controls and both pinned gaps. Source restored byte-identical (sha + 14,818 bytes).

## Over-block is the dominant risk, and is bounded by construction

This lint **blocks commits**. A name binds only when a declaration's initialiser satisfies `isFetchTarget`; the fixpoint grows only through already-bound names; resolution is per-file. **The real repo lints CLEAN before and after** (exit 0 both ways).

## Import safety

The module had **four** `process.exit(1)` paths and no guard, so any importer would have run the full scan and could have killed the process. The CLI body is now guarded behind a direct-invocation check — verified both modes: as a CLI it prints its clean summary and exits 0; imported, it does not scan.

3rd of the peer audit's 25; **22 remain, 14 classed SAFETY-FLOOR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
