### PR TITLE
fix(lint): headless-launch funnel guard followed the name, not the function

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T21-12-47-383Z-headless-launch-lint-alias.json
+++ b/.instar/instar-dev-decisions/2026-08-14T21-12-47-383Z-headless-launch-lint-alias.json
@@ -1,0 +1,35 @@
+{
+  "ts": "2026-08-14T21:12:47.383Z",
+  "slug": "headless-launch-lint-alias",
+  "suggestedTier": 2,
+  "declaredTier": null,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 371,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-unfunneled-headless-launch.js"
+    ],
+    "addedLines": 331,
+    "deletedLines": 40
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      1874,
+      1875,
+      1876,
+      1877
+    ],
+    "notes": "Present since the lint was written: it identified its target by matching the literal name 'buildHeadlessLaunch' per line, so any renaming defeated it. Surfaced by a peer audit that classed it DEFEATABLE and SAFETY-FLOOR, and reproduced end-to-end against the shipped check before any edit. Same defect class as the four prior closures (unbounded-llm-spawn x2, credential-write, telegram-egress) — the fourth of the audit's 25."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "No self-triggered action added or modified. This is a build-time lint script; it emits no restart/swap/respawn/spawn/notify/retry/kill. The words 'spawn' and 'launch' appear only in prose describing the funnel the lint guards."
+  },
+  "verdict": "blocked"
+}

--- a/.instar/instar-dev-decisions/2026-08-14T21-13-03-882Z-headless-launch-lint-alias.json
+++ b/.instar/instar-dev-decisions/2026-08-14T21-13-03-882Z-headless-launch-lint-alias.json
@@ -1,0 +1,35 @@
+{
+  "ts": "2026-08-14T21:13:03.882Z",
+  "slug": "headless-launch-lint-alias",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 371,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-unfunneled-headless-launch.js"
+    ],
+    "addedLines": 331,
+    "deletedLines": 40
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      1874,
+      1875,
+      1876,
+      1877
+    ],
+    "notes": "Present since the lint was written: it identified its target by matching the literal name 'buildHeadlessLaunch' per line, so any renaming defeated it. Surfaced by a peer audit that classed it DEFEATABLE and SAFETY-FLOOR, and reproduced end-to-end against the shipped check before any edit. Same defect class as the four prior closures (unbounded-llm-spawn x2, credential-write, telegram-egress) — the fourth of the audit's 25."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "No self-triggered action added or modified. This is a build-time lint script; it emits no restart/swap/respawn/spawn/notify/retry/kill. The words 'spawn' and 'launch' appear only in prose describing the funnel the lint guards."
+  },
+  "verdict": "pass"
+}

--- a/.instar/instar-dev-decisions/2026-08-14T21-14-08-688Z-headless-launch-lint-alias.json
+++ b/.instar/instar-dev-decisions/2026-08-14T21-14-08-688Z-headless-launch-lint-alias.json
@@ -1,0 +1,35 @@
+{
+  "ts": "2026-08-14T21:14:08.688Z",
+  "slug": "headless-launch-lint-alias",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 371,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-unfunneled-headless-launch.js"
+    ],
+    "addedLines": 331,
+    "deletedLines": 40
+  },
+  "causalAutopsy": {
+    "origin": "latent",
+    "relatedPrs": [
+      1874,
+      1875,
+      1876,
+      1877
+    ],
+    "notes": "Present since the lint was written: it identified its target by matching the literal name 'buildHeadlessLaunch' per line, so any renaming defeated it. Surfaced by a peer audit that classed it DEFEATABLE and SAFETY-FLOOR, and reproduced end-to-end against the shipped check before any edit. Same defect class as the four prior closures (unbounded-llm-spawn x2, credential-write, telegram-egress) — the fourth of the audit's 25."
+  },
+  "classClosure": {
+    "defectClass": "unbounded-self-action",
+    "closure": "n/a",
+    "reason": "No self-triggered action added or modified. This is a build-time lint script; it emits no restart/swap/respawn/spawn/notify/retry/kill. The words 'spawn' and 'launch' appear only in prose describing the funnel the lint guards."
+  },
+  "verdict": "pass"
+}

--- a/docs/specs/headless-launch-lint-alias.eli16.md
+++ b/docs/specs/headless-launch-lint-alias.eli16.md
@@ -1,0 +1,45 @@
+# The spawn-funnel guard could be walked past by renaming its target
+
+> The one-line version: the check that keeps every background subprocess going through one door only knew the door's name — so anyone who put a second nameplate on it walked straight past.
+
+## The problem in one breath
+
+Every headless subprocess this agent spawns is supposed to go through a single function. That funnel is where the resource and control decisions live — including the one that keeps those spawns off a metered credit pot that fails hard when it drains.
+
+A check enforces it, by refusing any file outside a short closed list to mention the builder's name.
+
+Mentioning the name is not the only way to reach it. A file on the list could hand the same function out under a different name, and any file could then call *that* — no forbidden name anywhere, and a real non-funnel spawn path.
+
+This was not a theory. Adding one line to a listed file and calling the new name from another left a working bypass in the real codebase while the check printed **clean**.
+
+## What already exists
+
+- **One funnel**, where the spawn decision is made.
+- **A closed list** of four files allowed to name the builder — the definition, the funnel, one deliberately-isolated path, and the check itself.
+- **A rule** that treats even importing the name as a violation, because there is no legitimate consumer outside the funnel.
+
+## What this adds
+
+**The check now follows the function, not just its name.**
+
+Two halves. *Inside a file*, a name that has been passed along — imported under a new label, pulled out of a bundle, copied to another variable, reached through a bracket with the text split in half — is followed until nothing new turns up. *Across files*, the short closed list is read to find any name it hands out that leads back to the builder, and those names are then guarded wherever they are imported.
+
+That second half is what makes it work: the list is closed and small, so reading it is cheap, and a name can only be minted there.
+
+## The safeguard that mattered more than the fix
+
+This check refuses commits. A version that flagged correct code would be switched off within a day, which is worse than the hole.
+
+So the widening is deliberately narrow. Only a plain re-labelling or a one-line pass-through counts as handing the function out. A listed file that does *real work* around the builder is not — because that is exactly what the funnel itself looks like, and counting it would flag every ordinary spawn in the codebase.
+
+Ten tests push the other way: a comment is not a call, a similar-looking name is not the same name, an unrelated copy is not absorbed, a locally-written function that happens to share a name is not the funnel's, the same name from an unrelated file is not either, and the real funnel is not mistaken for a handout.
+
+## How it was checked
+
+Proven in both directions, and one direction corrected the other. Removing the cross-file half fails exactly the cross-file tests. Deliberately widening the handout rule to "anything that touches the builder" fails exactly the control that guards against the flood.
+
+Removing the text-splitting defence failed **nothing** — the first attempt at that test used a form that a different rule already caught, so it proved nothing about the line it was meant to cover. Rewritten to three forms with nothing else to catch them, it fails properly. A test that passes for the wrong reason is indistinguishable from coverage until something depends on it.
+
+Four remaining gaps are named in the check's own header and pinned by tests asserting they are still open, so they read as decisions rather than oversights.
+
+The real codebase passes cleanly before and after.

--- a/docs/specs/headless-launch-lint-alias.side-effects.md
+++ b/docs/specs/headless-launch-lint-alias.side-effects.md
@@ -1,0 +1,93 @@
+# Side-Effects Review — headless-launch funnel lint: alias resolution
+
+**Version / slug:** `headless-launch-lint-alias`
+**Date:** `2026-08-14`
+**Author:** `Echo (instar agent, laptop)`
+**Second-pass reviewer:** `peer audit — classed this check DEFEATABLE and SAFETY-FLOOR`
+
+## Summary of the change
+
+`scripts/lint-no-unfunneled-headless-launch.js` refuses any reference to `buildHeadlessLaunch` outside a closed four-entry allowlist. It located its target by matching that literal name per line, so the audit's stated bypass held: *"Export a wrapper or alias from an allowlisted module, then call makeHeadlessLaunch(...) elsewhere; the non-funnel launch path is real, but the name is gone."*
+
+This adds two resolution layers. **Local:** bindings resolve to a fixpoint — aliased import, `{ X: Alias }` destructure, `const C = X` re-binding, namespace member, and computed access over a collapsed concatenation. **Cross-module:** the CLOSED allowlist is parsed (via the TypeScript AST) for names it hands out that resolve to the builder — direct re-bindings, renamed re-exports, and single-statement pass-through wrappers, to a fixpoint across files — and those names are guarded at any non-allowlisted importer. Detection is extracted into exported pure functions and the CLI body is guarded behind a direct-invocation check.
+
+## Decision-point inventory
+
+No decision point added or removed. One is widened at its input: "does this file reach the headless builder?" The allowlist, the funnel location, the import-is-a-violation rule, the message text for the canonical name, and the exit contract are unchanged.
+
+## 1. Over-block
+
+**The dominant risk, and the reason the fix is narrower than it could be.** This lint blocks commits; a check that flags correct code gets switched off, which is a worse outcome than the hole.
+
+The sharp failure mode was concrete: the funnel itself (`SessionManager.spawnSession`) calls the builder. Had "exported function that references the builder" counted as a handout, every ordinary spawn callsite in `src/` would have been flagged. So only a DIRECT re-binding or a single-statement pass-through counts.
+
+Second bound: a derived alias name is guarded only when **imported from the module that mints it** (specifier basename matched against the minting file). A locally-defined function of the same name is never absorbed. The canonical name keeps its shipped any-reference semantic.
+
+Ten opposite-direction controls pin this, including the two that would have caught the flood: a real-work exported function is not an alias, and the LIVE allowlist mints no alias today (asserted against the actual tree, so a future refactor that accidentally creates one is visible). Decisive: **the real repo lints CLEAN before and after, exit 0 both ways.**
+
+## 2. Under-block
+
+Four residuals, named in the header and pinned by tests asserting they are NOT caught:
+
+- A **non-pass-through wrapper** in an allowlisted module (two statements, not one). The direct price of the over-block bound above. Closing it needs a "does this do real work" judgment a commit-blocking lint should not be making.
+- A **runtime-computed member** (`m[process.env.K]`) — not statically readable.
+- **Re-assignment after declaration** — caught at the assignment line, not at the later call. Partial, not absent.
+- A consumer importing an alias through a **barrel**. Mitigated structurally: the barrel is not allowlisted, so re-exporting the alias through it fails the lint at the barrel. The chain cannot be built without tripping this first.
+
+## 3. Level-of-abstraction fit
+
+Alias-export discovery uses the TS AST because precision matters most there and the inputs are four known TS files; per-file detection stays text-based because the scan set includes `.sh`, which no TS parser reads. Both are exported so they can be driven with fixtures rather than only end-to-end. The direct-invocation guard belongs at the module boundary.
+
+## 4. Signal vs authority compliance
+
+The lint IS authority — it fails a commit — unchanged in kind and scope. Only what it can see is widened. The tree passes clean, so no new blocking condition is introduced.
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+None. Deterministic AST predicates, regex forms, and bounded fixpoints (10 passes). No heuristic, model call, or threshold.
+
+## 5. Interactions
+
+Blast radius: one script. New dependency on `typescript`, already a devDependency and already imported by `scripts/lint-telegram-egress-boundary.mjs` in the same lint chain. The new exports have exactly one importer (the new test). The module previously had one `process.exit(1)` path and **no guard** — importing it would have run the full repo walk and could have killed a test run; the guard closes that. `package.json` invocation unchanged. The pre-existing `tests/unit/lint-no-unfunneled-headless-launch.test.ts` passes untouched, including its allowlist-closure assertion.
+
+## 6. External surfaces
+
+None. No network, persisted state, credential, telemetry, or route. It reads source at lint time exactly as before — this change touches the CHECK, never the spawn path.
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+The canonical-name message and the clean-summary line are unchanged. Alias violations get a distinct message naming the resolved symbol and the module that handed it out, so the reader is not left guessing why an unremarkable-looking name was refused.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+No issue identified — build-time check, no shared state.
+
+## 8. Rollback cost
+
+Very low. One script, one new test file, one commit; no migration, persisted state, or config flag.
+
+## Evidence pointers
+
+- **Bypass reproduced against the shipped check before any edit**, positive control caught in the same run: the audit's cross-module alias → 0 hits; namespace + split-literal computed access → 0 hits; aliased import → import line caught, CALL SITE blind; plain import+call → caught. Reproduced **end-to-end in the real tree**: one appended line in the allowlisted `src/core/frameworkSessionLaunch.ts` plus a new `src/core` consumer left a live non-funnel launch path while the script printed `clean`, exit 0.
+- **Three semantic mutations, three precise reds.** Neutering cross-module seeding fails exactly the 2 cross-module tests (26 pass). Widening the wrapper rule to "any exported function touching the builder" fails exactly the 1 real-work control (27 pass). Removing the per-line concatenation collapse fails exactly the 3 non-binding computed forms (28 pass).
+- **One mutation initially failed to red, and that was the finding.** The first computed-access test used `const s = m['a'+'b'](…)`, which the BINDING rule already catches — so it proved nothing about the line it was written for. Rewritten to three forms with no binding to catch them (returned, bare statement, object property), the mutation reds properly. A test passing for the wrong reason is indistinguishable from coverage until something depends on it.
+- Source restored **byte-identical** after every mutation (sha256 `273c44ba…` before and after each).
+- Real repo: `node scripts/lint-no-unfunneled-headless-launch.js` → `clean`, exit 0 BEFORE and AFTER. Full `npm run lint` chain exit 0; `tsc --noEmit` clean.
+- 39/39 across the new evasion suite and the pre-existing lint test.
+
+## Class-Closure Declaration
+
+Class: **"a lint that identifies its target by matching a NAME as literal text is defeated by ordinary renaming."**
+
+**Closed for THIS lint:** local binding chains to a fixpoint (aliased import, destructure, re-binding, namespace member, computed access over a split literal), and cross-module names minted by the closed allowlist as direct re-bindings, renamed re-exports, or single-statement pass-through wrappers.
+
+**NOT closed — stated so it is not read as more than it is:**
+- A non-pass-through wrapper in an allowlisted module. **Deliberate**, and the direct cost of not flagging the funnel itself.
+- A runtime-computed member.
+- Re-assignment after declaration at the CALL site (the assignment is caught).
+- A consumer importing through a barrel — though the barrel itself fails, so the chain cannot be built silently.
+- **Cross-module resolution is scoped to the ALLOWLIST only.** A name minted in some other non-allowlisted module is not traced; that module would have to reference the canonical name, which fails.
+
+**NOT closed repo-wide.** This is the 4th of the peer audit's 25 defeatable checks (per the tally quoted in the previous closure, PR #1877). By that count 21 remain, 14 of them classed SAFETY-FLOOR. I have not independently re-verified the audit's list, so treat the remaining count as inherited, not measured.
+
+**NOT attempted:** the funnel's own runtime behaviour. This lint proves nobody reaches the builder outside the funnel; it proves nothing about whether the funnel makes the right spawn decision once reached.

--- a/scripts/lint-no-unfunneled-headless-launch.js
+++ b/scripts/lint-no-unfunneled-headless-launch.js
@@ -14,22 +14,79 @@
  *
  * Rule: outside the allowlist below, no source file may reference
  * `buildHeadlessLaunch` (import OR call — an import is the bypass's first
- * commit, flag it at the door).
+ * commit, flag it at the door), NOR any name an allowlisted module hands out
+ * that resolves to it.
+ *
+ * ── Evasion resistance (2026-08-14) ──────────────────────────────────────
+ * A peer audit classed this check DEFEATABLE and SAFETY-FLOOR, with this
+ * bypass stated verbatim: "Export a wrapper or alias from an allowlisted
+ * module, then call makeHeadlessLaunch(...) elsewhere; the non-funnel launch
+ * path is real, but the name is gone."
+ *
+ * Both halves were reproduced against the shipped check before this change,
+ * with a positive control caught in the same run:
+ *
+ *   // in src/core/frameworkSessionLaunch.ts — ALLOWLISTED, so free
+ *   export const makeHeadlessLaunch = buildHeadlessLaunch;
+ *   // anywhere else — shipped lint said "clean", exit 0
+ *   import { makeHeadlessLaunch } from './frameworkSessionLaunch.js';
+ *   makeHeadlessLaunch(fw, opts);
+ *
+ *   import * as m from './frameworkSessionLaunch.js';   // computed + split literal
+ *   const fn = m['buildHeadless' + 'Launch'];
+ *   fn(fw, opts);
+ *
+ * The first was reproduced end-to-end in the real tree: a live non-funnel
+ * launch path existed while this script printed `clean`.
+ *
+ * The close has two parts. Locally, bindings resolve to a fixpoint (aliased
+ * import, `{ X: Alias }` destructure, `const C = X` re-binding, namespace
+ * member, computed access over a collapsed concatenation). Across modules,
+ * the CLOSED allowlist is parsed for names it hands out that resolve to the
+ * builder, and those names are guarded at any non-allowlisted importer.
+ *
+ * ── What this deliberately does NOT classify as an alias ─────────────────
+ * Only a DIRECT re-binding (`export const X = buildHeadlessLaunch`,
+ * `export { buildHeadlessLaunch as X }`) or a PASS-THROUGH wrapper (a single
+ * `return buildHeadlessLaunch(...)`) counts. An exported function that does
+ * real work around the builder is NOT an alias — that is precisely the shape
+ * of the funnel itself, so treating it as one would flag every caller of
+ * `SessionManager.spawnSession()`. This check blocks commits; a widening that
+ * flags correct code is worse than the hole, because a noisy check gets
+ * switched off. The boundary is drawn there on purpose.
+ *
+ * ── Residuals, named rather than left to be discovered ───────────────────
+ *   - A NON-pass-through wrapper in an allowlisted module (two statements
+ *     instead of one) is not an alias. This is the price of the rule above.
+ *   - A computed member resolved at RUNTIME (`m[process.env.K]`) cannot be
+ *     read statically.
+ *   - Re-assignment after declaration (`let mk; mk = buildHeadlessLaunch;`)
+ *     is caught at the ASSIGNMENT, not at the later call.
+ *   - A consumer importing an alias through a BARREL is not itself checked —
+ *     but the barrel is not allowlisted, so re-exporting the alias through it
+ *     fails here first; the chain cannot be built without tripping this.
+ * All four are pinned by tests asserting exactly this, so the boundary is
+ * documented rather than assumed.
  *
  * Exit codes: 0 — clean; 1 — at least one violation.
  *
  * Usage:
  *   node scripts/lint-no-unfunneled-headless-launch.js            # full repo
  *   node scripts/lint-no-unfunneled-headless-launch.js --staged   # staged files
+ *   node scripts/lint-no-unfunneled-headless-launch.js <file…>    # explicit files (tests)
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = path.resolve(path.dirname(__filename), '..');
+
+/** The one name the funnel is built on. Every other guarded name derives from it. */
+export const CANONICAL = 'buildHeadlessLaunch';
 
 // ── Allowlist (closed). Adding an entry requires review of WHY the callsite
 //    cannot route through SessionManager.spawnSession() (where the
@@ -51,11 +108,233 @@ const ALLOWLIST = new Set([
 const SCAN_DIRS = ['src', 'scripts', 'templates'];
 const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs', '.sh']);
 
-const PATTERNS = [
-  // Any reference — import, re-export, or call. An import IS the violation:
-  // there is no legitimate non-funnel consumer of the headless builder.
-  /\bbuildHeadlessLaunch\b/,
-];
+const VIOLATION_MSG =
+  `direct ${CANONICAL} reference outside the subscription-path funnel. ` +
+  `Spawn through SessionManager.spawnSession() (which carries the June-15 reroute), ` +
+  `or add an allowlist entry here with a billing-accountability justification.`;
+
+const aliasMsg = (name, from) =>
+  `'${name}' resolves to ${CANONICAL} (handed out by ${from}) — reaching the headless ` +
+  `builder under another name is the same bypass of the subscription-path funnel. ` +
+  `Spawn through SessionManager.spawnSession(), or add an allowlist entry here with a ` +
+  `billing-accountability justification.`;
+
+/** Comment lines are documentation, not a bypass — code cannot call through one. */
+export function isCommentLine(line) {
+  const t = line.trimStart();
+  return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*') || t.startsWith('#');
+}
+
+/**
+ * Collapse simple adjacent string concatenation so `'A' + 'B'` reads as `AB`.
+ * Applied PER LINE so reported line numbers stay exact.
+ */
+export function collapseConcatenation(text) {
+  let out = text;
+  for (let i = 0; i < 5; i++) {
+    const next = out.replace(/(['"`])\s*\+\s*(['"`])/g, '');
+    if (next === out) break;
+    out = next;
+  }
+  return out;
+}
+
+const basenameKey = (p) => path.basename(p).replace(/\.(ts|tsx|js|mjs|cjs)$/, '');
+
+// ── Cross-module: what names does the closed allowlist hand out? ──────────
+
+/** Is this expression the guarded builder itself (identifier or namespace member)? */
+function denotesGuarded(node, known) {
+  if (!node) return false;
+  if (ts.isIdentifier(node)) return known.has(node.text);
+  if (ts.isPropertyAccessExpression(node)) return known.has(node.name.text);
+  if (ts.isElementAccessExpression(node)) {
+    const a = node.argumentExpression;
+    return !!a && ts.isStringLiteralLike(a) && known.has(a.text);
+  }
+  if (ts.isParenthesizedExpression(node)) return denotesGuarded(node.expression, known);
+  if (ts.isAsExpression(node) || ts.isTypeAssertionExpression?.(node)) {
+    return denotesGuarded(node.expression, known);
+  }
+  return false;
+}
+
+/** A body that is nothing but `return <guarded>(...)` — a pass-through wrapper. */
+function isPassThroughBody(body, known) {
+  if (!body) return false;
+  if (ts.isCallExpression(body)) return denotesGuarded(body.expression, known); // arrow shorthand
+  if (!ts.isBlock(body) || body.statements.length !== 1) return false;
+  const only = body.statements[0];
+  if (!ts.isReturnStatement(only) || !only.expression) return false;
+  return ts.isCallExpression(only.expression) && denotesGuarded(only.expression.expression, known);
+}
+
+const isExported = (node) =>
+  !!node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+
+/**
+ * Names each allowlisted module hands out that resolve to the builder.
+ *
+ * `sources` is [{ path, content }]. Returns Map<aliasName, sourcePath>, run to
+ * a fixpoint across files so an allowlisted module re-exporting ANOTHER
+ * allowlisted module's alias closes too.
+ */
+export function collectFunnelAliasExports(sources) {
+  const aliases = new Map();
+  for (let pass = 0; pass < 10; pass++) {
+    const before = aliases.size;
+    for (const { path: p, content } of sources) {
+      let sf;
+      try {
+        sf = ts.createSourceFile(p, content, ts.ScriptTarget.Latest, true);
+      } catch {
+        continue;
+      }
+      // Names bound to the builder INSIDE this module, to a fixpoint.
+      const known = new Set([CANONICAL, ...aliases.keys()]);
+      for (let inner = 0; inner < 10; inner++) {
+        const size = known.size;
+        const seed = (n) => {
+          if (ts.isImportSpecifier(n) && known.has((n.propertyName ?? n.name).text)) {
+            known.add(n.name.text);
+          }
+          if (ts.isVariableDeclaration(n) && ts.isIdentifier(n.name) && denotesGuarded(n.initializer, known)) {
+            known.add(n.name.text);
+          }
+          ts.forEachChild(n, seed);
+        };
+        ts.forEachChild(sf, seed);
+        if (known.size === size) break;
+      }
+
+      const record = (name) => {
+        if (name && name !== CANONICAL && !aliases.has(name)) aliases.set(name, p);
+      };
+      const visit = (n) => {
+        // export const X = <guarded>;   /  export const X = (...) => <guarded>(...)
+        if (ts.isVariableStatement(n) && isExported(n)) {
+          for (const d of n.declarationList.declarations) {
+            if (!ts.isIdentifier(d.name) || !d.initializer) continue;
+            if (denotesGuarded(d.initializer, known)) record(d.name.text);
+            else if (
+              (ts.isArrowFunction(d.initializer) || ts.isFunctionExpression(d.initializer)) &&
+              isPassThroughBody(d.initializer.body, known)
+            ) record(d.name.text);
+          }
+        }
+        // export function X(...) { return <guarded>(...); }
+        if (ts.isFunctionDeclaration(n) && isExported(n) && n.name && isPassThroughBody(n.body, known)) {
+          record(n.name.text);
+        }
+        // export { A as B };  /  export { A as B } from '...';
+        if (ts.isExportDeclaration(n) && n.exportClause && ts.isNamedExports(n.exportClause)) {
+          for (const el of n.exportClause.elements) {
+            if (known.has((el.propertyName ?? el.name).text)) record(el.name.text);
+          }
+        }
+        ts.forEachChild(n, visit);
+      };
+      ts.forEachChild(sf, visit);
+    }
+    if (aliases.size === before) break;
+  }
+  return aliases;
+}
+
+// ── Per-file: local bindings, resolved to a fixpoint ─────────────────────
+
+/** Named specifiers imported (or re-exported) in `content`, with their offsets. */
+function importSpecifiers(content) {
+  const out = [];
+  const re = /(?:import|export)\s*(?:type\s+)?(?:[\w$]+\s*,\s*)?\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g;
+  for (const m of content.matchAll(re)) {
+    const body = m[1];
+    const bodyStart = m.index + m[0].indexOf('{') + 1;
+    for (const spec of body.split(',')) {
+      const t = spec.trim();
+      if (!t) continue;
+      const parts = t.replace(/^type\s+/, '').split(/\s+as\s+/);
+      const imported = parts[0].trim();
+      const local = (parts[1] ?? parts[0]).trim();
+      if (!/^[A-Za-z_$][\w$]*$/.test(imported)) continue;
+      out.push({ imported, local, from: m[2], offset: bodyStart + body.indexOf(t) });
+    }
+  }
+  return out;
+}
+
+const lineOf = (content, offset) => content.slice(0, offset).split('\n').length;
+
+/**
+ * Local names in `content` bound to something guarded, to a fixpoint.
+ *
+ * Seeds are the canonical name plus any allowlist-exported alias that is
+ * actually IMPORTED here from the module that hands it out — a locally
+ * DEFINED function of the same name is not absorbed, which is what keeps this
+ * from flagging unrelated code.
+ */
+export function collectLocalBindings(content, aliasExports = new Map()) {
+  const names = new Set([CANONICAL]);
+  const seededAliases = [];
+  for (const spec of importSpecifiers(content)) {
+    const owner = aliasExports.get(spec.imported);
+    if (owner && basenameKey(spec.from) === basenameKey(owner)) {
+      names.add(spec.local);
+      seededAliases.push({ ...spec, owner });
+    }
+  }
+  // Local re-binding chains, incl. destructures, namespace members and
+  // computed access over a collapsed concatenation.
+  for (let pass = 0; pass < 10; pass++) {
+    const before = names.size;
+    for (const known of [...names]) {
+      const esc = known.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const forms = [
+        // import { known as alias }  /  const { known: alias } = …
+        new RegExp(`\\b${esc}\\s*(?:as|:)\\s*([A-Za-z_$][\\w$]*)`, 'g'),
+        // const alias = known;  /  const alias = ns.known;  /  const alias = ns['known'];
+        new RegExp(`\\b(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*(?:[\\w$.]*\\.)?${esc}\\s*[;,\\n)]`, 'g'),
+        new RegExp(`\\b(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*[\\w$.]*\\[\\s*['"\`]${esc}['"\`]\\s*\\]`, 'g'),
+      ];
+      for (const re of forms) {
+        for (const m of collapseConcatenation(content).matchAll(re)) names.add(m[1]);
+      }
+    }
+    if (names.size === before) break;
+  }
+  return { names, seededAliases };
+}
+
+/**
+ * Violations in `content`, as { line, msg }. Exported so the rules can be
+ * driven with fixtures rather than only end-to-end over the tree.
+ */
+export function findHeadlessLaunchViolations(content, aliasExports = new Map()) {
+  const hits = [];
+  const { names, seededAliases } = collectLocalBindings(content, aliasExports);
+  // A guarded alias arriving by import is a violation AT THE DOOR, reported
+  // against the import even though the name itself is unremarkable.
+  const importLines = new Set();
+  for (const spec of seededAliases) {
+    const line = lineOf(content, spec.offset);
+    importLines.add(line);
+    hits.push({ line, msg: aliasMsg(spec.imported, path.basename(spec.owner)) });
+  }
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (isCommentLine(lines[i])) continue;
+    if (importLines.has(i + 1)) continue;
+    const line = collapseConcatenation(lines[i]);
+    for (const name of names) {
+      const esc = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      if (new RegExp(`\\b${esc}\\b`).test(line) || new RegExp(`['"\`]${esc}['"\`]`).test(line)) {
+        hits.push({ line: i + 1, msg: name === CANONICAL ? VIOLATION_MSG : aliasMsg(name, 'the funnel') });
+        break;
+      }
+    }
+  }
+  return hits.sort((a, b) => a.line - b.line);
+}
 
 function listFiles() {
   const staged = process.argv.includes('--staged');
@@ -87,42 +366,54 @@ function listFiles() {
   return files;
 }
 
-let violations = 0;
-for (const rel of listFiles()) {
-  const normalized = rel.split(path.sep).join('/');
-  if (ALLOWLIST.has(normalized)) continue;
-  if (!EXTENSIONS.has(path.extname(normalized))) continue;
-  // Explicit args may be absolute (e.g. the lint's own self-test sandbox);
-  // repo-walk entries are always ROOT-relative.
-  const full = path.isAbsolute(normalized) ? normalized : path.join(ROOT, normalized);
-  let content;
-  try {
-    content = fs.readFileSync(full, 'utf-8');
-  } catch {
-    continue;
-  }
-  const lines = content.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    // Comment-only mentions are documentation, not a bypass — code can't
-    // call through a comment. (`//`, `*`, `/*` line starts and `#` for .sh.)
-    const trimmed = lines[i].trimStart();
-    if (/^(\/\/|\*|\/\*|#)/.test(trimmed)) continue;
-    for (const pattern of PATTERNS) {
-      if (pattern.test(lines[i])) {
-        console.error(
-          `${normalized}:${i + 1} — direct buildHeadlessLaunch reference outside the subscription-path funnel. ` +
-          `Spawn through SessionManager.spawnSession() (which carries the June-15 reroute), ` +
-          `or add an allowlist entry here with a billing-accountability justification.`,
-        );
-        violations++;
-      }
+/** Read the allowlisted SOURCE modules — the only places an alias can be minted. */
+export function readAllowlistSources(root = ROOT) {
+  const sources = [];
+  for (const rel of ALLOWLIST) {
+    if (!rel.startsWith('src/')) continue; // the lint script itself is not an alias source
+    try {
+      sources.push({ path: rel, content: fs.readFileSync(path.join(root, rel), 'utf-8') });
+    } catch {
+      /* a missing allowlist entry is the allowlist test's problem, not this scan's */
     }
   }
+  return sources;
 }
 
-if (violations > 0) {
-  console.error(`\nlint-no-unfunneled-headless-launch: ${violations} violation(s). ` +
-    `See docs/specs/june15-headless-spawn-reroute.md (finding F5).`);
-  process.exit(1);
+// ── CLI body ─────────────────────────────────────────────────────────────
+// Guarded so the exported detectors can be imported by tests WITHOUT running
+// the scan: this module calls process.exit(1) on a violation, so an unguarded
+// import would kill any test run the moment the repo had one. Same pattern as
+// lint-no-unfunneled-credential-write.js and lint-telegram-egress-boundary.mjs.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
+  const aliasExports = collectFunnelAliasExports(readAllowlistSources());
+  let violations = 0;
+  for (const rel of listFiles()) {
+    const normalized = rel.split(path.sep).join('/');
+    if (ALLOWLIST.has(normalized)) continue;
+    if (!EXTENSIONS.has(path.extname(normalized))) continue;
+    // Explicit args may be absolute (e.g. the lint's own self-test sandbox);
+    // repo-walk entries are always ROOT-relative.
+    const full = path.isAbsolute(normalized) ? normalized : path.join(ROOT, normalized);
+    let content;
+    try {
+      content = fs.readFileSync(full, 'utf-8');
+    } catch {
+      continue;
+    }
+    for (const hit of findHeadlessLaunchViolations(content, aliasExports)) {
+      console.error(`${normalized}:${hit.line} — ${hit.msg}`);
+      violations++;
+    }
+  }
+
+  if (violations > 0) {
+    console.error(`\nlint-no-unfunneled-headless-launch: ${violations} violation(s). ` +
+      `See docs/specs/june15-headless-spawn-reroute.md (finding F5).`);
+    process.exit(1);
+  }
+  console.log('lint-no-unfunneled-headless-launch: clean');
 }
-console.log('lint-no-unfunneled-headless-launch: clean');

--- a/tests/unit/headless-launch-lint-evasions.test.ts
+++ b/tests/unit/headless-launch-lint-evasions.test.ts
@@ -1,0 +1,370 @@
+/**
+ * lint-no-unfunneled-headless-launch — evasion resistance.
+ *
+ * This lint guards a SAFETY FLOOR: the headless-launch funnel is the
+ * resource/control boundary for spawned subprocesses, and the June-15 reroute
+ * that keeps those spawns off the SDK credit pot lives behind it
+ * (docs/specs/june15-headless-spawn-reroute.md, finding F5).
+ *
+ * A peer audit classed the check DEFEATABLE by ordinary renaming, stating the
+ * bypass verbatim: "Export a wrapper or alias from an allowlisted module, then
+ * call makeHeadlessLaunch(...) elsewhere; the non-funnel launch path is real,
+ * but the name is gone."
+ *
+ * Reproduced against the SHIPPED check before this change, with a positive
+ * control caught in the same run:
+ *
+ *   BYPASS B (the audit's, cross-module)  — 0 hits, `clean`, exit 0
+ *   BYPASS C (namespace + split literal)  — 0 hits, `clean`, exit 0
+ *   BYPASS A (aliased import)             — import line caught, CALL SITE blind
+ *   positive control (plain import+call)  — caught, both lines
+ *
+ * B was additionally reproduced end-to-end in the real tree: appending
+ * `export const makeHeadlessLaunch = buildHeadlessLaunch;` to the ALLOWLISTED
+ * src/core/frameworkSessionLaunch.ts and calling that name from a new
+ * src/core file left a live non-funnel launch path while the script printed
+ * `clean`.
+ *
+ * The detectors are driven DIRECTLY here rather than only via the CLI's exit
+ * code — a lint that CRASHES also exits 1, so exit-code-only assertions cannot
+ * tell "caught it" from "died on startup". The CLI cases below assert on
+ * stderr CONTENT for the same reason.
+ *
+ * The second half of this file is not optional. This lint blocks commits, so a
+ * widening that flags correct code is worse than the hole: a noisy check gets
+ * switched off. Every control below is a shape that MUST stay clean.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  CANONICAL,
+  collapseConcatenation,
+  collectFunnelAliasExports,
+  collectLocalBindings,
+  findHeadlessLaunchViolations,
+  readAllowlistSources,
+  // @ts-expect-error — plain .js lint script, no type declarations
+} from '../../scripts/lint-no-unfunneled-headless-launch.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const LINT_SCRIPT = path.join(REPO_ROOT, 'scripts', 'lint-no-unfunneled-headless-launch.js');
+
+/** The allowlisted module that hands the alias out, as the bypass has it. */
+const FUNNEL_MODULE = 'src/core/frameworkSessionLaunch.ts';
+const aliasFrom = (body: string) =>
+  collectFunnelAliasExports([{ path: FUNNEL_MODULE, content: body }]) as Map<string, string>;
+
+const NO_ALIASES = new Map<string, string>();
+
+function runLint(...args: string[]): { code: number; stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync('node', [LINT_SCRIPT, ...args], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { code: e.status ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Direction 1 — the bypasses are caught
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('collectFunnelAliasExports — what the closed allowlist hands out', () => {
+  it('finds a direct re-binding export (the audit bypass, alias form)', () => {
+    const aliases = aliasFrom(`export const makeHeadlessLaunch = ${CANONICAL};`);
+    expect(aliases.get('makeHeadlessLaunch')).toBe(FUNNEL_MODULE);
+  });
+
+  it('finds a renamed re-export', () => {
+    expect(aliasFrom(`export { ${CANONICAL} as mkLaunch };`).has('mkLaunch')).toBe(true);
+  });
+
+  it('finds a pass-through wrapper (the audit bypass, wrapper form)', () => {
+    const src = `export function makeHeadlessLaunch(fw, o) { return ${CANONICAL}(fw, o); }`;
+    expect(aliasFrom(src).has('makeHeadlessLaunch')).toBe(true);
+  });
+
+  it('finds an arrow pass-through', () => {
+    expect(aliasFrom(`export const mk = (fw, o) => ${CANONICAL}(fw, o);`).has('mk')).toBe(true);
+  });
+
+  it('closes to a fixpoint: an alias of an alias', () => {
+    const src = [`const inner = ${CANONICAL};`, 'const outer = inner;', 'export const mk = outer;'].join('\n');
+    expect(aliasFrom(src).has('mk')).toBe(true);
+  });
+
+  it('closes across modules: one allowlisted module re-exporting another\'s alias', () => {
+    const aliases = collectFunnelAliasExports([
+      { path: FUNNEL_MODULE, content: `export const mkA = ${CANONICAL};` },
+      { path: 'src/core/SessionManager.ts', content: `import { mkA } from './frameworkSessionLaunch.js';\nexport const mkB = mkA;` },
+    ]) as Map<string, string>;
+    expect(aliases.has('mkA')).toBe(true);
+    expect(aliases.has('mkB')).toBe(true);
+  });
+});
+
+describe('findHeadlessLaunchViolations — the reproduced bypasses', () => {
+  it('CONTROL: the plain form is still caught, at import AND call', () => {
+    const src = [
+      `import { ${CANONICAL} } from '../core/frameworkSessionLaunch.js';`,
+      `export const s = ${CANONICAL}(fw, o);`,
+    ].join('\n');
+    expect(findHeadlessLaunchViolations(src, NO_ALIASES)).toHaveLength(2);
+  });
+
+  it('BYPASS A: an ALIASED import — the call site was blind, now caught', () => {
+    const src = [
+      `import { ${CANONICAL} as mkLaunch } from '../core/frameworkSessionLaunch.js';`,
+      'export const s = mkLaunch(fw, o);',
+    ].join('\n');
+    const hits = findHeadlessLaunchViolations(src, NO_ALIASES);
+    // Confirmed EVADING at line 2 before this change (the import line alone caught).
+    expect(hits.map((h: { line: number }) => h.line)).toEqual([1, 2]);
+  });
+
+  it('BYPASS B: the audit\'s verbatim cross-module alias — was 0 hits', () => {
+    const aliases = aliasFrom(`export const makeHeadlessLaunch = ${CANONICAL};`);
+    const src = [
+      "import { makeHeadlessLaunch } from '../core/frameworkSessionLaunch.js';",
+      'export const s = makeHeadlessLaunch(fw, o);',
+    ].join('\n');
+    const hits = findHeadlessLaunchViolations(src, aliases);
+    // Confirmed EVADING (zero hits, exit 0) before this change.
+    expect(hits).toHaveLength(2);
+    expect(hits[0].msg).toContain('resolves to buildHeadlessLaunch');
+  });
+
+  it('BYPASS C: namespace import + computed access over a SPLIT literal — was 0 hits', () => {
+    const src = [
+      "import * as m from '../core/frameworkSessionLaunch.js';",
+      "const fn = m['buildHeadless' + 'Launch'];",
+      'export const s = fn(fw, o);',
+    ].join('\n');
+    const hits = findHeadlessLaunchViolations(src, NO_ALIASES);
+    // Confirmed EVADING (zero hits, exit 0) before this change.
+    expect(hits.map((h: { line: number }) => h.line)).toEqual([2, 3]);
+  });
+
+  it.each([
+    ['returned', `export function f() { return m['buildHeadless' + 'Launch'](fw, o); }`],
+    ['bare statement', `m['buildHeadless' + 'Launch'](fw, o);`],
+    ['object property', `export const reg = { launch: m['buildHeadless' + 'Launch'] };`],
+  ])('a computed call over a split literal, NOT in a binding: %s', (_label, body) => {
+    // Found by mutation, twice. Removing the per-line concatenation collapse
+    // left the whole suite green: every computed case written as
+    // `const x = m['a'+'b'](…)` is caught by the BINDING rule instead, so it
+    // proves nothing about that line. These three have no binding to catch
+    // them, and are the only cases that actually red when it is removed.
+    const src = ["import * as m from '../core/frameworkSessionLaunch.js';", body].join('\n');
+    expect(findHeadlessLaunchViolations(src, NO_ALIASES).map((h: { line: number }) => h.line)).toEqual([2]);
+  });
+
+  it('a re-binding CHAIN off an alias import closes too', () => {
+    const aliases = aliasFrom(`export const makeHeadlessLaunch = ${CANONICAL};`);
+    const src = [
+      "import { makeHeadlessLaunch } from '../core/frameworkSessionLaunch.js';",
+      'const a = makeHeadlessLaunch;',
+      'const b = a;',
+      'export const s = b(fw, o);',
+    ].join('\n');
+    expect(findHeadlessLaunchViolations(src, aliases)).toHaveLength(4);
+  });
+
+  it('a { X: alias } destructure off a dynamic import is caught', () => {
+    const src = [
+      `const { ${CANONICAL}: mk } = await import('../core/frameworkSessionLaunch.js');`,
+      'export const s = mk(fw, o);',
+    ].join('\n');
+    expect(findHeadlessLaunchViolations(src, NO_ALIASES)).toHaveLength(2);
+  });
+
+  it('a namespace MEMBER re-binding is caught', () => {
+    const src = [
+      "import * as m from '../core/frameworkSessionLaunch.js';",
+      `const mk = m.${CANONICAL};`,
+      'export const s = mk(fw, o);',
+    ].join('\n');
+    expect(findHeadlessLaunchViolations(src, NO_ALIASES)).toHaveLength(2);
+  });
+});
+
+describe('collapseConcatenation', () => {
+  it('folds a split literal so computed access cannot hide the name', () => {
+    expect(collapseConcatenation(`m['buildHeadless' + 'Launch']`)).toContain(CANONICAL);
+  });
+
+  it('folds a chain', () => {
+    expect(collapseConcatenation(`m['build' + 'Headless' + 'Lau' + 'nch']`)).toContain(CANONICAL);
+  });
+
+  it('CONTROL: leaves unrelated text alone', () => {
+    const out = collapseConcatenation(`const s = 'spawn' + 'Session';`);
+    expect(out).toContain('spawnSession');
+    expect(out).not.toContain(CANONICAL);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Direction 2 — OPPOSITE-DIRECTION CONTROLS. Correct code must stay clean.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('CONTROLS — shapes that must NOT be flagged', () => {
+  it('a comment is not a call', () => {
+    const src = [
+      `// model tiers resolve per-framework inside ${CANONICAL}`,
+      ` * see ${CANONICAL} for the headless spec`,
+      `/* ${CANONICAL} is the builder */`,
+      `# shell comment about ${CANONICAL}`,
+      'export const x = 1;',
+    ].join('\n');
+    expect(findHeadlessLaunchViolations(src, NO_ALIASES)).toHaveLength(0);
+  });
+
+  it('an unrelated similar NAME is not the symbol', () => {
+    const src = [
+      'export const a = buildHeadlessLaunchTelemetry(x);',
+      'export const b = rebuildHeadlessLaunch(x);',
+      'export const c = makeHeadlessLaunchers(x);',
+      'export const d = buildHeadlessLaunch2(x);',
+    ].join('\n');
+    expect(findHeadlessLaunchViolations(src, aliasFrom(`export const makeHeadlessLaunch = ${CANONICAL};`))).toHaveLength(0);
+  });
+
+  it('an unrelated RE-BINDING is not absorbed', () => {
+    const src = ['const mk = somethingElse;', 'const mk2 = mk;', 'export const s = mk2(fw);'].join('\n');
+    expect(findHeadlessLaunchViolations(src, NO_ALIASES)).toHaveLength(0);
+    expect([...(collectLocalBindings(src, NO_ALIASES) as { names: Set<string> }).names]).toEqual([CANONICAL]);
+  });
+
+  it('a LOCALLY DEFINED function that happens to share an alias name is not the funnel\'s', () => {
+    // The sharpest false positive available: the alias set is global to the
+    // repo, so a same-named local helper must not be absorbed. Only a name
+    // IMPORTED from the module that hands it out counts.
+    const aliases = aliasFrom(`export const makeHeadlessLaunch = ${CANONICAL};`);
+    const src = [
+      'function makeHeadlessLaunch(a, b) { return { a, b }; }',
+      'export const s = makeHeadlessLaunch(1, 2);',
+    ].join('\n');
+    expect(findHeadlessLaunchViolations(src, aliases)).toHaveLength(0);
+  });
+
+  it('the same alias name imported from an UNRELATED module is not the funnel\'s', () => {
+    const aliases = aliasFrom(`export const makeHeadlessLaunch = ${CANONICAL};`);
+    const src = [
+      "import { makeHeadlessLaunch } from './someUnrelatedHelper.js';",
+      'export const s = makeHeadlessLaunch(fw, o);',
+    ].join('\n');
+    expect(findHeadlessLaunchViolations(src, aliases)).toHaveLength(0);
+  });
+
+  it('a REAL-WORK exported function in an allowlisted module is NOT an alias', () => {
+    // This is the control that keeps the fix from becoming a false-positive
+    // storm: the funnel itself calls the builder. If "any exported function
+    // that touches it" counted, every caller of spawnSession() would be
+    // flagged, and the check would be switched off within a day.
+    const src = [
+      'export async function spawnSession(o) {',
+      '  const gate = await checkQuota(o);',
+      '  if (!gate.ok) return null;',
+      `  const spec = ${CANONICAL}(o.framework, o);`,
+      '  return launch(spec);',
+      '}',
+    ].join('\n');
+    expect([...aliasFrom(src).keys()]).toEqual([]);
+  });
+
+  it('the LIVE allowlist mints no alias today — spawnSession is not absorbed', () => {
+    const aliases = collectFunnelAliasExports(readAllowlistSources(REPO_ROOT)) as Map<string, string>;
+    expect([...aliases.keys()]).toEqual([]);
+  });
+
+  it('an ordinary spawn through the funnel stays clean', () => {
+    const src = [
+      "import { SessionManager } from '../core/SessionManager.js';",
+      'export const s = await sessionManager.spawnSession({ framework: fw });',
+    ].join('\n');
+    expect(findHeadlessLaunchViolations(src, NO_ALIASES)).toHaveLength(0);
+  });
+
+  it('a whole real source file with no reference is clean', () => {
+    const real = fs.readFileSync(path.join(REPO_ROOT, 'src/core/StateManager.ts'), 'utf-8');
+    expect(findHeadlessLaunchViolations(real, NO_ALIASES)).toHaveLength(0);
+  });
+});
+
+describe('RESIDUALS — pinned as still open, so the boundary is documented not assumed', () => {
+  it('a NON-pass-through wrapper in an allowlisted module is not an alias', () => {
+    // Deliberate, and the price of the control above: two statements instead
+    // of one puts it on the funnel's side of the line. Closing it needs a
+    // "does this do real work" judgment that a lint blocking commits should
+    // not be making. Pinned so a future reader sees a decision, not a miss.
+    const src = `export function mk(fw, o) { const x = ${CANONICAL}(fw, o); return x; }`;
+    expect([...aliasFrom(src).keys()]).toEqual([]);
+  });
+
+  it('a computed member built at RUNTIME is not resolvable', () => {
+    const src = [
+      "import * as m from '../core/frameworkSessionLaunch.js';",
+      'const mk = m[process.env.K];',
+      'export const s = mk(fw, o);',
+    ].join('\n');
+    expect(findHeadlessLaunchViolations(src, NO_ALIASES)).toHaveLength(0);
+  });
+
+  it('re-assignment after declaration is caught at the assignment, NOT at the call', () => {
+    const hits = findHeadlessLaunchViolations(
+      ['let mk;', `mk = ${CANONICAL};`, 'export const s = mk(fw, o);'].join('\n'),
+      NO_ALIASES,
+    );
+    expect(hits.map((h: { line: number }) => h.line)).toEqual([2]); // line 3 is not reached
+  });
+
+  it('a BARREL re-export breaks the chain at the barrel — worth knowing', () => {
+    // The barrel is not allowlisted, so re-exporting the alias through it is
+    // itself a violation. A consumer importing from the barrel is not checked,
+    // but the chain cannot be built without failing here first.
+    const aliases = aliasFrom(`export const makeHeadlessLaunch = ${CANONICAL};`);
+    const barrel = "export { makeHeadlessLaunch } from './frameworkSessionLaunch.js';";
+    expect(findHeadlessLaunchViolations(barrel, aliases)).toHaveLength(1);
+  });
+});
+
+describe('an IMPORT is deliberately a violation here (not a widening)', () => {
+  it('flags the import even with no call, by the shipped rule', () => {
+    // Unlike its sibling lints, this check treats the import itself as the
+    // violation: there is no legitimate non-funnel consumer of the headless
+    // builder, so the door is the right place to stop it. Asserted so the
+    // semantic is deliberate rather than incidental.
+    const src = `import { ${CANONICAL} } from '../core/frameworkSessionLaunch.js';`;
+    expect(findHeadlessLaunchViolations(src, NO_ALIASES)).toHaveLength(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// End-to-end: the CLI, asserted on OUTPUT (a crash also exits 1)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('CLI', () => {
+  it('the real tree is clean, and says so on stdout', () => {
+    const r = runLint();
+    expect(r.stderr).toBe('');
+    expect(r.stdout).toContain('lint-no-unfunneled-headless-launch: clean');
+    expect(r.code).toBe(0);
+  });
+
+  it('importing the detectors does NOT run the scan (direct-invocation guard)', () => {
+    // Without the guard, importing this module would run the walk and could
+    // process.exit(1), killing the whole test run the moment the repo had a
+    // violation. Proven by importing it and observing we are still alive.
+    expect(typeof findHeadlessLaunchViolations).toBe('function');
+    expect(typeof collectFunnelAliasExports).toBe('function');
+  });
+});

--- a/upgrades/next/headless-launch-lint-alias.md
+++ b/upgrades/next/headless-launch-lint-alias.md
@@ -1,0 +1,27 @@
+## What Changed
+
+The check that keeps every headless subprocess going through a single funnel identified that funnel by its name alone, so putting a second nameplate on it walked straight past.
+
+- **A listed file could hand the builder out under another name**, and any file could then call that name — no forbidden text anywhere, and a real non-funnel spawn path. Reproduced in the real codebase before the fix: one appended line plus one new consumer left a working bypass while the check printed **clean**.
+- **The check now follows the function, not just its name.** Inside a file, a name passed along — relabelled on import, pulled out of a bundle, copied to a variable, reached through a bracket with the text split in half — is followed until nothing new turns up. Across files, the short closed list is read for any name it hands out that leads back to the builder, and those names are guarded wherever they are imported.
+- **The widening is deliberately narrow, and that was the harder half.** Only a plain re-labelling or a one-line pass-through counts as handing the builder out. A listed file that does real work around it does not — because that is exactly what the funnel itself looks like, and counting it would have flagged every ordinary spawn in the codebase.
+- **Four remaining gaps are named in the check's own header** and pinned by tests asserting they are still open, so they read as decisions rather than oversights.
+- **Nothing new is forbidden**, and the codebase passes cleanly before and after.
+
+## What to Tell Your User
+
+Every background process this agent starts is supposed to go through one door, because that door is where the limits are decided. A check enforced it — but only by looking for the door's name, so anyone who gave the door a second name got past without it noticing. That was real, not hypothetical: it was demonstrated on the live codebase while the check reported everything fine.
+
+It now follows the door itself rather than the label on it. The care went into not over-correcting: a check that blocks work has to stay quiet about correct work, or someone turns it off, and then it guards nothing at all.
+
+## Summary of New Capabilities
+
+None. This widens what an existing check can see. No new command, route, setting, or rule.
+
+## Evidence
+
+Proven in both directions. Three deliberate mutations produce three precise failures: removing the cross-file resolution fails exactly the cross-file tests, widening the handout rule fails exactly the control that guards against flagging correct code, and removing the text-splitting defence fails exactly the three forms that depend on it.
+
+That third one is worth recording, because it failed to fail the first time. The original test used a shape a different rule already caught, so it proved nothing about the line it was written for and would have shipped as false coverage. It was rewritten to three shapes with nothing else to catch them. A test that passes for the wrong reason is indistinguishable from real coverage until something depends on it.
+
+Ten opposite-direction controls hold the other side, including two that would have caught the over-correction: a real-work function in a listed file is not treated as a handout, and the live list is asserted to hand out nothing today, so a future refactor that accidentally creates one becomes visible. The source was restored byte-identical after every mutation, the real codebase lints clean before and after, and the module is now safe to import — it previously had an unguarded exit path that would have stopped a test run the moment the codebase had a violation.


### PR DESCRIPTION
## ELI16 — the spawn-funnel guard could be walked past by renaming its target

Every headless subprocess this agent spawns is supposed to go through a single function. That funnel is where the resource and control decisions live — including the one that keeps those spawns off a metered credit pot that fails hard when it drains.

A check enforces it, by refusing any file outside a short closed list to mention the builder's name.

Mentioning the name is not the only way to reach it. A file **on the list** could hand the same function out under a different name, and any file could then call *that* — no forbidden name anywhere, and a real non-funnel spawn path.

The check now follows the function, not just its name. Inside a file, a name that has been passed along — relabelled on import, pulled out of a bundle, copied to a variable, reached through a bracket with the text split in half — is followed until nothing new turns up. Across files, the short closed list is read for any name it hands out that leads back to the builder, and those names are guarded wherever they are imported.

The harder half was **not over-correcting**. This check refuses commits, and a version that flagged correct code would be switched off within a day — which is worse than the hole. So only a plain re-labelling or a one-line pass-through counts as handing the function out. A listed file that does *real work* around the builder does not, because that is exactly what the funnel itself looks like.

Full write-up: `docs/specs/headless-launch-lint-alias.eli16.md`.

---

## The bypass, reproduced before any edit

A peer audit classed `lint-no-unfunneled-headless-launch` **DEFEATABLE** and **SAFETY-FLOOR**, stating the bypass verbatim:

> Export a wrapper or alias from an allowlisted module, then call `makeHeadlessLaunch(...)` elsewhere; the non-funnel launch path is real, but the name is gone.

Run against the **shipped** check, positive control caught in the same run:

| form | shipped check |
|---|---|
| plain `import { buildHeadlessLaunch }` + call — *positive control* | caught, both lines |
| aliased import `{ buildHeadlessLaunch as mk }`, then `mk(...)` | import caught, **CALL SITE blind** |
| cross-module alias (the audit's, verbatim) | **0 hits** |
| namespace + computed access over `'buildHeadless' + 'Launch'` | **0 hits** |

Then **end-to-end in the real tree**: appending one line to the allowlisted `src/core/frameworkSessionLaunch.ts`

```ts
export const makeHeadlessLaunch = buildHeadlessLaunch;
```

and calling that name from a new `src/core` file left a live non-funnel launch path while the script printed `lint-no-unfunneled-headless-launch: clean`, **exit 0**. With the fix, the same plant is caught at both the import and the call.

## Proven in both directions

Three semantic mutations, three precise reds — the tests fail for the right reason, not on a missing import:

| mutation | result |
|---|---|
| neuter cross-module alias seeding | fails **exactly** the 2 cross-module tests (26 pass) |
| widen the wrapper rule to "any exported fn touching the builder" | fails **exactly** the 1 real-work control (27 pass) |
| remove the per-line concatenation collapse | fails **exactly** the 3 non-binding computed forms (28 pass) |

Source restored **byte-identical** after each (sha256 `273c44ba…` before and after).

**One mutation initially failed to red, and that was the finding.** The first computed-access test used `const s = m['a'+'b'](…)`, which the *binding* rule already catches — so it proved nothing about the line it was written for and would have shipped as false coverage. Rewritten to three forms with nothing else to catch them (returned, bare statement, object property), it reds properly.

## Over-block controls (the half that matters more)

Ten controls, including the two that would have caught a false-positive flood: a real-work exported function is not an alias, and the **live** allowlist is asserted to mint none today — so a future refactor that accidentally creates one becomes visible. Also pinned: comments, similar-looking names, unrelated re-bindings, a locally-defined function sharing an alias name, and the same name imported from an unrelated module.

**Real repo lints CLEAN before and after** — `node scripts/lint-no-unfunneled-headless-launch.js` → exit 0 both ways. Full `npm run lint` chain exit 0, `tsc --noEmit` clean, 39/39 tests.

The CLI body is now behind a direct-invocation guard: it had one unguarded `process.exit(1)`, so importing it in a test would have killed the run.

---

## Class-Closure Declaration

Class: **"a lint that identifies its target by matching a NAME as literal text is defeated by ordinary renaming."**

**Closed for THIS lint:** local binding chains to a fixpoint (aliased import, destructure, re-binding, namespace member, computed access over a split literal), and cross-module names minted by the closed allowlist as direct re-bindings, renamed re-exports, or single-statement pass-through wrappers.

**What I did NOT close — stated so this is not read as more than it is:**

- **A non-pass-through wrapper in an allowlisted module.** Two statements instead of one, and it is not classified as an alias. **Deliberate** — it is the direct price of not flagging the funnel itself. Closing it needs a "does this do real work" judgment a commit-blocking lint should not be making.
- **A runtime-computed member** (`m[process.env.K]`) — not statically readable.
- **Re-assignment after declaration** — caught at the assignment line, blind at the later call. Partial, not absent.
- **A consumer importing an alias through a barrel.** Mitigated but not closed: the barrel is not allowlisted, so re-exporting the alias through it fails the lint *at the barrel*, and the chain cannot be built silently.
- **Cross-module resolution is scoped to the ALLOWLIST only.** A name minted in some other non-allowlisted module is not traced — though that module would have to name the builder, which fails.
- **Repo-wide: not closed.** This is the 4th of the peer audit's 25 defeatable checks. Per the tally quoted in the previous closure (#1877), **21 remain, 14 of them classed SAFETY-FLOOR.** I have not independently re-verified that list, so treat the remaining count as inherited, not measured.
- **Not attempted:** the funnel's own runtime behaviour. This proves nobody reaches the builder outside the funnel; it proves nothing about whether the funnel makes the right decision once reached.

All four residuals are named in the lint's header **and pinned by tests asserting they are still open**, so they read as decisions rather than oversights.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
