### PR TITLE
fix(lint): journal actuation ban now sees dynamic import and require

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T22-05-37-182Z-journal-actuation-ban-load-forms.json
+++ b/.instar/instar-dev-decisions/2026-08-14T22-05-37-182Z-journal-actuation-ban-load-forms.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T22:05:37.182Z",
+  "slug": "journal-actuation-ban-load-forms",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 126,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-journal-actuation-ban.js"
+    ],
+    "addedLines": 116,
+    "deletedLines": 10
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/journal-actuation-ban-load-forms.eli16.md
+++ b/docs/specs/journal-actuation-ban-load-forms.eli16.md
@@ -1,0 +1,99 @@
+# ELI16 — the journal ban that only knew one way to say "import"
+
+## The rule being protected
+
+Instar keeps a **journal** — a log of things that happened, copied between your machines. Copies arrive on a
+heartbeat, so a copy is always a little bit behind reality. That is fine for answering questions ("what happened
+to this conversation?") and dangerous for making decisions.
+
+The dangerous case is concrete. Suppose a part of the system that can **kill a session** reads the copied journal,
+sees "session closed", and acts on it — but that entry is thirty seconds stale and the session is alive and
+working. It kills live work. Or the reverse: it sees no session and starts a second one, and now the same
+conversation runs twice on two machines. Those are real incidents Instar has had, and the journal exists to help
+diagnose them. If the journal caused them instead, it would be worse than useless.
+
+So the spec has a rule (§3.9): anything that can **kill, spawn, place, transfer, or reap** may *write* to the
+journal, but may never *read* it. Read the live system instead. To make that rule mechanical rather than a thing
+people remember, the reader lives in its own file, and a lint fails the build if one of those modules imports it.
+
+## What was broken
+
+The lint looked for the word `from`:
+
+```js
+/from\s+['"]…CoherenceJournalReader…['"]/
+```
+
+That matches `import { X } from '…Reader.js'`. But JavaScript has two other ways to load a module, and **neither
+uses the word `from`**:
+
+```js
+const mod = await import('…Reader.js');   // dynamic import
+const mod = require('…Reader.js');        // require
+```
+
+Both load the reader completely. Both walked straight past the guard. I appended a dynamic import to a real
+listed actuator and ran the shipped lint: it printed `clean`. Another agent, Codey, found the same hole
+independently while auditing about twenty of these checks, and ranked this one **first** by how much damage its
+defeat would do — precisely because the failure is false kills and duplicate sessions.
+
+This is not an exotic bypass. `await import(...)` is ordinary, and the codebase uses it constantly to avoid
+loading heavy modules at startup. Someone could defeat this guard by accident, while writing perfectly normal
+code, and nothing would tell them.
+
+## What changed
+
+The check now recognises all three loading forms. Three smaller things came with it, and two of them make the
+lint *less* likely to complain, not more:
+
+1. **Comments are removed before checking.** Otherwise, widening the pattern would make it illegal to *write
+   about* the rule — a comment saying "never `await import('…Reader.js')` here" would itself fail the build. The
+   stripper understands quotes, so a `//` inside a string is not mistaken for a comment, and it preserves line
+   numbers so error messages still point at the right line.
+2. **`import type` is now allowed.** TypeScript's `import type` disappears entirely when the code compiles — it
+   borrows a *shape*, not the actual reader — so it cannot act on stale data. The old pattern flagged it. There
+   is a real file in the tree doing exactly this legitimately.
+3. **A listed file that no longer exists is now an error.** The old code skipped missing files silently, so
+   renaming a guarded module quietly removed it from the ban and the lint still reported clean.
+
+## The bug I put in myself, and caught
+
+My first attempt tried to *discover* actuators automatically instead of using a hand-written list. I tested it by
+pointing it at another copy of the repo, and it said `clean`. That looked like good news. The path I gave it did
+not exist — it had scanned zero files and reported success. A "clean" result over nothing looks identical to a
+genuinely clean result, which makes it the most misleading output a checker can produce. The lint now refuses to
+give a verdict at all if there is no source directory to scan.
+
+## What I did NOT fix, and why
+
+The list of guarded modules is still written by hand, so a brand-new actuator is not covered until someone adds
+it. I built the automatic version, ran it against the real code, and threw it away, because it flagged nine
+places and **every single one was wrong**:
+
+- Files with names like `readReaperPeerText` and `reaperPoolHealth` — code that *reports on* the reaper, not code
+  that reaps. "Reaper" there is a noun, not an action, and reporting code reading the journal is exactly what the
+  journal is for.
+- The 22,000-line file that wires the whole server together. Every module's abilities pass through it, so calling
+  the file as a whole "an actuator" is meaningless.
+- A file whose only sin was the `import type` described above.
+
+This lint blocks commits. A guard that stops correct work is more expensive than one with a known, written-down
+gap — especially when the gap was a deliberate design choice recorded when the check was first built. So it stays
+hand-maintained, the limit is stated plainly at the top of the file instead of being quietly implied, and a test
+pins the gap so that if anyone ever closes it properly, that test fails and tells them to update the docs.
+
+## How you know it works
+
+Every new assertion was run against the *old* lint first to prove it could fail: five of the thirteen tests fail
+without the fix, and the eight control tests — writer imports are fine, comments are fine, reporting modules are
+fine — pass with and without it, which is what makes them controls rather than decoration. Against the real
+repository the lint reports clean and blocks nothing.
+
+## One thing for a human to decide
+
+While the discarded auto-discovery was running, it pointed at five places in the server file that load the
+journal reader dynamically. One of them builds ownership records for conversations *from the copied journal* —
+which then influences where sessions are placed. It is deliberate, documented, and it double-checks its input
+against live data first. Whether §3.9 permits it is a genuine question about what the rule means, not something a
+lint should decide, so it is written up and handed to the operator rather than quietly changed or quietly
+ignored.

--- a/scripts/lint-journal-actuation-ban.js
+++ b/scripts/lint-journal-actuation-ban.js
@@ -12,8 +12,37 @@
  * separate module from the writer so this ban has a precise import target —
  * actuators MAY hold the writer (they emit), they may never read.
  *
- * Guardrail, not proof (a consumer could re-read the JSONL by hand); the
- * declared §3.9 duty is the authority, this catches the direct pattern.
+ * ── 2026-08-14: the header used to declare TWO limitations. One is now closed,
+ * one is NOT, and pretending otherwise would be the worse outcome.
+ *
+ * CLOSED — "this catches the direct pattern". The match required the `from`
+ * keyword, so `await import(...)` and `require(...)` walked straight past it.
+ * Reproduced against the shipped lint on a REAL listed actuator: it reported
+ * "clean". Now every module-loading form is matched, comments are stripped
+ * first (so a §3.9 reference in prose can never be a violation), and a
+ * runtime-erased `import type` is correctly NOT a violation.
+ *
+ * NOT CLOSED — "grow this list when a new actuator class lands". The population
+ * is still curated by hand. Automatic discovery was BUILT, MEASURED AGAINST THIS
+ * TREE, AND REJECTED on the evidence: inferring "is this an actuator?" from
+ * declared names flagged nine sites in three files, and every one was a
+ * granularity or part-of-speech error rather than a §3.9 breach —
+ *   · `src/server/routes.ts` matched on `readReaperPeerText`, `isReaperSnapshot`,
+ *     `reaperPoolHealth`: "reaper" as a NOUN in code that REPORTS ON the reaper,
+ *     which is exactly the correct-code case (a reporting surface may read).
+ *   · `src/commands/server.ts` is the 22k-line composition root — every module's
+ *     authority is wired through it, so any file-level verdict on it is wrong in
+ *     one direction or the other.
+ *   · `src/core/WorkingSetPull.ts` matched a runtime-erased `import type`.
+ * A guard that blocks commits must not rest on a heuristic with that error rate;
+ * over-blocking correct code is the more expensive failure here. What IS closed
+ * mechanically is the STALENESS half: a curated entry that no longer exists on
+ * disk means an actuator was renamed or moved and silently fell off the ban —
+ * that is now a hard failure instead of a skipped line.
+ *
+ * Still a guardrail, not a proof: a determined consumer can re-read the JSONL by
+ * hand or reach the reader through a re-export. The declared §3.9 duty is the
+ * authority; this catches the mechanical patterns.
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -27,7 +56,8 @@ const ROOT = process.argv.includes('--root')
 /**
  * Actuator modules: anything holding kill/spawn/place/transfer/reap authority.
  * Grow this list when a new actuator class lands — adding here is cheap;
- * debugging a journal-driven double-kill is not.
+ * debugging a journal-driven double-kill is not. See the header for why this
+ * stays curated rather than inferred.
  */
 const ACTUATOR_FILES = [
   'src/core/SessionManager.ts',
@@ -40,17 +70,93 @@ const ACTUATOR_FILES = [
   'src/lifeline/ServerSupervisor.ts',
 ];
 
-const READER_IMPORT = /from\s+['"][^'"]*CoherenceJournalReader(\.js)?['"]/;
+/**
+ * Every way a module can LOAD the reader at runtime. The old pattern required
+ * `from`, which is precisely the token a dynamic import does not have.
+ */
+const LOADS_READER =
+  /(?:\bfrom\s+|\bimport\s*\(\s*|\brequire\s*\(\s*)['"][^'"]*CoherenceJournalReader(?:\.js)?['"]/;
+
+/**
+ * `import type { X } from '…Reader.js'` is erased at compile time — it creates
+ * no runtime coupling and therefore cannot act on stale data. Borrowing a TYPE
+ * from the reader is legal; holding the reader is not. A MIXED import such as
+ * `import { type A, CoherenceJournalReader }` does not match this and is still
+ * caught, which is correct — it pulls in the runtime binding.
+ */
+const TYPE_ONLY_IMPORT = /^\s*import\s+type\s/;
+
+/**
+ * Blank out comments, preserving length and line count so reported line numbers
+ * stay true. Quote-aware, so a `//` inside a string literal is not mistaken for
+ * a comment. This is what keeps "the reader named in a comment" legal no matter
+ * how wide the load-matching gets.
+ */
+function stripComments(src) {
+  const out = src.split('');
+  let i = 0;
+  let state = 'code'; // code | line | block | single | double | tick
+  while (i < src.length) {
+    const c = src[i];
+    const d = src[i + 1];
+    if (state === 'code') {
+      if (c === '/' && d === '/') { state = 'line'; out[i] = ' '; out[i + 1] = ' '; i += 2; continue; }
+      if (c === '/' && d === '*') { state = 'block'; out[i] = ' '; out[i + 1] = ' '; i += 2; continue; }
+      if (c === "'") state = 'single';
+      else if (c === '"') state = 'double';
+      else if (c === '`') state = 'tick';
+      i++; continue;
+    }
+    if (state === 'line') {
+      if (c === '\n') { state = 'code'; i++; continue; }
+      out[i] = ' '; i++; continue;
+    }
+    if (state === 'block') {
+      if (c === '*' && d === '/') { state = 'code'; out[i] = ' '; out[i + 1] = ' '; i += 2; continue; }
+      if (c !== '\n') out[i] = ' ';
+      i++; continue;
+    }
+    // inside a string literal: honour escapes, then look for the closing quote
+    if (c === '\\') { i += 2; continue; }
+    if ((state === 'single' && c === "'") || (state === 'double' && c === '"') || (state === 'tick' && c === '`')) {
+      state = 'code';
+    }
+    i++;
+  }
+  return out.join('');
+}
+
+/**
+ * A lint that reports "clean" because it scanned NOTHING is worse than no lint:
+ * absence is the cheapest result to obtain, and it is indistinguishable from a
+ * genuinely clean tree. Refuse to render a verdict on a root with no src/.
+ */
+if (!fs.existsSync(path.join(ROOT, 'src'))) {
+  console.error(`lint-journal-actuation-ban: no src/ under ${ROOT} — scanned nothing, so no verdict.`);
+  process.exit(2);
+}
 
 const violations = [];
+
 for (const rel of ACTUATOR_FILES) {
   const file = path.join(ROOT, rel);
-  if (!fs.existsSync(file)) continue;
-  const lines = fs.readFileSync(file, 'utf-8').split('\n');
+
+  // The staleness half of the declared-population gap: a curated actuator that
+  // is no longer here was renamed or moved, and silently left the ban behind.
+  if (!fs.existsSync(file)) {
+    violations.push(
+      `${rel}: listed actuator is missing from the tree — renamed or moved? It has silently left the §3.9 ban. Update ACTUATOR_FILES.`,
+    );
+    continue;
+  }
+
+  const lines = stripComments(fs.readFileSync(file, 'utf-8')).split('\n');
   for (let i = 0; i < lines.length; i++) {
-    if (READER_IMPORT.test(lines[i])) {
-      violations.push(`${rel}:${i + 1}: actuator imports the journal READER (forbidden by §3.9 — the journal answers questions, live systems decide)`);
-    }
+    if (!LOADS_READER.test(lines[i])) continue;
+    if (TYPE_ONLY_IMPORT.test(lines[i])) continue;
+    violations.push(
+      `${rel}:${i + 1}: actuator loads the journal READER (forbidden by §3.9 — the journal answers questions, live systems decide)`,
+    );
   }
 }
 
@@ -60,4 +166,4 @@ if (violations.length > 0) {
   console.error('\nReplicated journal data is stale by construction. Read the live store instead.');
   process.exit(1);
 }
-console.log(`lint-journal-actuation-ban: clean (${ACTUATOR_FILES.length} actuator modules, none import the reader)`);
+console.log(`lint-journal-actuation-ban: clean (${ACTUATOR_FILES.length} actuator modules, none load the reader)`);

--- a/tests/unit/journal-actuation-ban-lint.test.ts
+++ b/tests/unit/journal-actuation-ban-lint.test.ts
@@ -1,0 +1,199 @@
+// safe-git-allow: test fixture cleanup uses fs.rmSync on mkdtemp dirs only.
+/**
+ * lint-journal-actuation-ban — one declared limitation closed, one measured and left open.
+ *
+ * COHERENCE-JOURNAL-SPEC §3.9: no actuator (kill / spawn / place / transfer / reap)
+ * may READ the replicated journal. Replicated data is stale by construction, so an
+ * actuator trusting a replica's "session closed" can kill or double-place against
+ * reality — the journal would CAUSE the duplicate-session incidents it diagnoses.
+ *
+ * The shipped check declared BOTH of its gaps in its own header, honestly:
+ *   "Guardrail, not proof … this catches the direct pattern"
+ *   "Grow this list when a new actuator class lands"
+ *
+ * DEFECT 1 — CLOSED. Reproduced against the SHIPPED lint before any edit: a dynamic
+ * `await import('…CoherenceJournalReader.js')` appended to a REAL listed actuator
+ * (src/core/SessionManager.ts) reported "clean", because the match required the
+ * `from` keyword that import() lacks. CONTROL: the plain static import in the same
+ * file → CAUGHT. The probe could say yes, which is what makes the EVADES verdict
+ * mean anything.
+ *
+ * DEFECT 2 — MEASURED, AND DELIBERATELY LEFT OPEN. Automatic discovery of actuators
+ * by declared-name shape was built and run against the real tree: it flagged nine
+ * sites in three files and every one was a part-of-speech or granularity error, not
+ * a §3.9 breach (see the lint header for the three, with names). This lint blocks
+ * commits, so over-blocking correct code is the more expensive failure — a
+ * reporting surface reading the journal is CORRECT. The STALENESS half is closable
+ * mechanically and is closed: a curated entry that vanished from the tree was
+ * renamed and silently left the ban.
+ *
+ * Driven as a SUBPROCESS against a temp `--root`, never by importing the module:
+ * this lint runs its scan at module scope and calls process.exit(), so importing it
+ * would kill the test run the moment the repo had a real violation. Exit code alone
+ * is never the assertion — a crash also exits 1 — so every violation case asserts on
+ * the REPORTED TEXT as well.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const LINT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../scripts/lint-journal-actuation-ban.js',
+);
+
+/** Mirrors ACTUATOR_FILES. Every one must exist or the staleness check fires. */
+const CURATED = [
+  'src/core/SessionManager.ts',
+  'src/core/SessionRouter.ts',
+  'src/core/SessionOwnershipRegistry.ts',
+  'src/monitoring/SessionWatchdog.ts',
+  'src/monitoring/SessionMonitor.ts',
+  'src/core/SessionMaintenanceRunner.ts',
+  'src/core/AutonomousSessions.ts',
+  'src/lifeline/ServerSupervisor.ts',
+];
+
+let root: string;
+
+/** Write a file under the temp root, creating parents. */
+const put = (rel: string, body: string): void => {
+  const p = path.join(root, rel);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, body, 'utf8');
+};
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'jab-'));
+  // Seed every curated actuator as innocuous. A test that cares about one
+  // overwrites it; the staleness test deletes one on purpose.
+  for (const rel of CURATED) put(rel, 'export const noop = () => {};\n');
+});
+afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+/** Run the lint against the temp root. Returns BOTH status and output — never one alone. */
+const run = (): { status: number; out: string } => {
+  try {
+    const out = execFileSync('node', [LINT, '--root', root], { encoding: 'utf8', stdio: 'pipe' });
+    return { status: 0, out };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return { status: err.status ?? -1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+};
+
+/** A violation must EXIT 1 **and** name the offending file — a crash also exits 1. */
+const expectCaught = (r: { status: number; out: string }, rel: string): void => {
+  expect(r.status, `expected a violation exit; output was:\n${r.out}`).toBe(1);
+  expect(r.out, 'exited 1 WITHOUT naming the file — it probably crashed').toContain(rel);
+};
+
+const READER = "'../monitoring/CoherenceJournalReader.js'";
+
+describe('DEFECT 1 — every way a module can load the reader', () => {
+  it('CONTROL: a clean tree passes, and says so', () => {
+    const r = run();
+    expect(r.status, r.out).toBe(0);
+    expect(r.out).toContain('clean');
+  });
+
+  it('CONTROL: the plain STATIC import is caught (this is what already worked)', () => {
+    put('src/core/SessionManager.ts', `import { CoherenceJournalReader } from ${READER};\nexport const kill = () => CoherenceJournalReader;\n`);
+    expectCaught(run(), 'src/core/SessionManager.ts');
+  });
+
+  it('a DYNAMIC import in a listed actuator is caught (was "clean")', () => {
+    put('src/core/SessionManager.ts', `export async function read() { return await import(${READER}); }\n`);
+    expectCaught(run(), 'src/core/SessionManager.ts');
+  });
+
+  it('require() of the reader is caught', () => {
+    put('src/core/SessionManager.ts', `const r = require(${READER});\nexport const kill = () => r;\n`);
+    expectCaught(run(), 'src/core/SessionManager.ts');
+  });
+
+  // ── The opposite direction. This lint BLOCKS commits, so a guard that flags correct
+  //    code is the more expensive failure — two withdrawals earlier in this window came
+  //    from exactly that over-tightening. These must pass under the fix.
+  it('CONTROL: an actuator importing the WRITER is not flagged — actuators may emit', () => {
+    put('src/core/SessionManager.ts', "import { CoherenceJournalWriter } from '../monitoring/CoherenceJournalWriter.js';\nexport const kill = () => CoherenceJournalWriter;\n");
+    const r = run();
+    expect(r.status, `writer import must not be flagged; output:\n${r.out}`).toBe(0);
+  });
+
+  it('CONTROL: the reader named only in a COMMENT is not flagged', () => {
+    put('src/core/SessionManager.ts', `// never import ${READER} here — §3.9\nexport const kill = () => {};\n`);
+    expect(run().status).toBe(0);
+  });
+
+  it('CONTROL: a block comment mentioning a dynamic import of the reader is not flagged', () => {
+    put('src/core/SessionManager.ts', `/*\n * Do not: await import(${READER})\n */\nexport const kill = () => {};\n`);
+    const r = run();
+    expect(r.status, `prose describing the ban must not BE a violation; output:\n${r.out}`).toBe(0);
+  });
+
+  it('CONTROL: `import type` is not flagged — it is erased, so it cannot act on stale data', () => {
+    put('src/core/SessionManager.ts', `import type { OwnAutonomousRuns } from ${READER};\nexport const kill = (_r: OwnAutonomousRuns) => {};\n`);
+    const r = run();
+    expect(r.status, `a type-only import creates no runtime coupling; output:\n${r.out}`).toBe(0);
+  });
+
+  it('a MIXED import that pulls the runtime binding alongside a type IS caught', () => {
+    put('src/core/SessionManager.ts', `import { type OwnAutonomousRuns, CoherenceJournalReader } from ${READER};\nexport const kill = () => CoherenceJournalReader;\n`);
+    expectCaught(run(), 'src/core/SessionManager.ts');
+  });
+
+  it('CONTROL: a NON-actuator module may read the journal — that is the whole point', () => {
+    put('src/server/CoherenceRoutes.ts', `import { CoherenceJournalReader } from ${READER};\nexport const read = () => CoherenceJournalReader;\n`);
+    expect(run().status, 'a reporting surface reading the journal is CORRECT').toBe(0);
+  });
+});
+
+describe('DEFECT 2 — the declared population', () => {
+  it('a curated actuator that VANISHED from the tree is a violation, not a skipped line', () => {
+    // The mechanically-closable half: `if (!existsSync) continue` meant a renamed
+    // actuator silently left the ban and the lint still reported clean.
+    fs.rmSync(path.join(root, 'src/core/SessionRouter.ts'));
+    expectCaught(run(), 'src/core/SessionRouter.ts');
+  });
+
+  it('KNOWN GAP: a NEW actuator not on the curated list is NOT caught', () => {
+    // Pinned deliberately, not by omission. Discovery-by-name-shape was built and
+    // measured against the real tree: nine flags across three files, all part-of-speech
+    // or granularity errors ("reaper" as a noun in reporting code; the 22k-line
+    // composition root; a runtime-erased `import type`). Closing this needs an
+    // authoritative actuator population, not a heuristic. If someone closes it, this
+    // test SHOULD fail — that is the signal to delete it.
+    put('src/core/SessionEvictor.ts', `import { CoherenceJournalReader } from ${READER};\nexport function reapSessions() { return new CoherenceJournalReader(); }\n`);
+    expect(run().status, 'if this now fails, the gap was closed — update the header and delete this test').toBe(0);
+  });
+});
+
+describe('the lint must not render a verdict on a tree it did not scan', () => {
+  it('a root with no src/ EXITS NON-ZERO instead of reporting clean', () => {
+    // Found by pointing the fixed lint at a path that did not exist: it walked
+    // nothing and printed "clean". Absence is the cheapest result to obtain, and a
+    // clean verdict over zero files is indistinguishable from a genuinely clean tree.
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'jab-empty-'));
+    try {
+      let status = 0;
+      let out = '';
+      try {
+        out = execFileSync('node', [LINT, '--root', empty], { encoding: 'utf8', stdio: 'pipe' });
+      } catch (e) {
+        const err = e as { status?: number; stdout?: string; stderr?: string };
+        status = err.status ?? -1;
+        out = `${err.stdout ?? ''}${err.stderr ?? ''}`;
+      }
+      expect(status, `scanned nothing but exited ${status}; output:\n${out}`).not.toBe(0);
+      expect(out).toContain('scanned nothing');
+      expect(out).not.toContain('clean');
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/upgrades/next/journal-actuation-ban-load-forms.md
+++ b/upgrades/next/journal-actuation-ban-load-forms.md
@@ -1,0 +1,51 @@
+<!-- internal-only -->
+
+# journal-actuation-ban: every load form, and the staleness half of the population
+
+Developer tooling only — a CI lint. No runtime path, no route, no config key, no user-visible surface, so this
+fragment takes the internal-only lane.
+
+## What Changed
+
+`scripts/lint-journal-actuation-ban.js` enforces COHERENCE-JOURNAL-SPEC §3.9: no actuator (kill / spawn / place /
+transfer / reap) may import the journal READER, because replicated journal data is stale by construction and an
+actuator trusting it can kill live work or double-place a conversation.
+
+The check matched `/from\s+['"]…CoherenceJournalReader…['"]/`, which requires the `from` keyword. `await
+import(…)` and `require(…)` do not have it, so both loaded the reader straight past the ban. Reproduced against
+the shipped lint on a real listed actuator (`src/core/SessionManager.ts`): it printed `clean`. instar-codey
+reproduced the same evasion independently and ranked this lint first of ~20 by consequence-of-defeat.
+
+- All three load forms now match.
+- Comments are stripped (quote-aware, line-preserving) before matching, so prose describing the ban can never
+  itself be a violation.
+- `import type` is now exempt — it is erased at compile time, so it cannot act on stale data. The old pattern
+  flagged it, and a live file in the tree has that shape legitimately.
+- A curated actuator that has vanished from the tree is now a violation instead of a silently skipped line: a
+  renamed module used to leave the ban without a word.
+- A root with no `src/` exits 2 instead of printing `clean` over zero files.
+
+Deliberately NOT changed: the curated actuator list. Automatic discovery by declared-name shape was built and
+measured against this tree — nine flags across three files, every one a part-of-speech or granularity error
+("reaper" as a noun in reporting code; the 22k-line composition root; an `import type`). This lint blocks
+commits, so over-blocking correct code is the more expensive failure, and the enumerated list is the original
+converged design decision. The limit is now stated plainly in the header and pinned by a test that fails if
+anyone closes it properly.
+
+## Evidence
+
+- `tests/unit/journal-actuation-ban-lint.test.ts` — 13/13 green.
+- Negative control: with the shipped lint restored, exactly 5 of 13 fail (dynamic import, `require`,
+  `import type`, vanished-curated-file, rootless-tree) and all 8 controls still pass — controls should pass both
+  ways, which is what makes them controls.
+- Real-tree verdict: `node scripts/lint-journal-actuation-ban.js` → `clean (8 actuator modules, none load the
+  reader)`, exit 0. All eight curated actuators verified present, none referencing the reader.
+- Full `npm run lint` chain green; `tests/unit/lint-chain-completeness.test.ts` 3/3.
+- Side-effects review: `upgrades/side-effects/journal-actuation-ban-load-forms.md`.
+- ELI16: `docs/specs/journal-actuation-ban-load-forms.eli16.md`.
+
+**Raised separately, not actioned here:** `src/commands/server.ts:20853` wires `OwnershipApplier`, which
+materializes durable topic ownership from the REPLICATED placement journal (it does validate `transferTo`
+against the live known-machine set first, and is specified in
+`docs/specs/ownership-applier-meshself-ordering-fix.md`). Whether §3.9 permits a validated read like that is a
+spec question, not a lint decision; it is on the operator's attention queue. The shipped lint does not flag it.

--- a/upgrades/side-effects/journal-actuation-ban-load-forms.md
+++ b/upgrades/side-effects/journal-actuation-ban-load-forms.md
@@ -1,0 +1,127 @@
+# Side-Effects Review — journal-actuation-ban: every load form, and the staleness half of the population
+
+**Version / slug:** `journal-actuation-ban-load-forms`
+**Date:** `2026-08-14`
+**Author:** `echo`
+**Second-pass reviewer:** `not required — Tier 1 (classifyTier: suggestedTier 1, riskFloor 1, no reasons). No spec change: COHERENCE-JOURNAL-SPEC §3.9 is unmodified; this makes the existing ban see load forms it already forbade.`
+
+## Summary of the change
+
+`scripts/lint-journal-actuation-ban.js` enforced §3.9 with `/from\s+['"]…CoherenceJournalReader…['"]/`. That
+requires the `from` keyword, which `await import(…)` and `require(…)` do not have, so both walked past the ban.
+Reproduced against the shipped lint on a REAL listed actuator (`src/core/SessionManager.ts`): it reported
+`clean`. Independently reproduced by instar-codey, who ranked this lint #1 of ~20 by consequence-of-defeat.
+
+Now: all three load forms are matched; comments are stripped (quote-aware, length- and line-preserving) before
+matching, so prose describing the ban is never a violation; a runtime-erased `import type` is correctly NOT a
+violation; a curated actuator that has vanished from the tree is a violation instead of a skipped line; and a
+root with no `src/` exits 2 rather than printing `clean`.
+
+The declared-population gap ("grow this list when a new actuator class lands") is **left open deliberately** —
+see §2.
+
+## Decision-point inventory
+
+- `LOADS_READER` — WIDEN — now matches `from` / `import(` / `require(`. CI-time only; never runtime.
+- `TYPE_ONLY_IMPORT` — ADD — narrows: `import type` is exempt (erased at compile time).
+- comment stripping — ADD — narrows: commented text cannot be a violation.
+- missing curated file — CHANGE — was `continue` (silent), now a violation.
+- root without `src/` — ADD — exit 2, no verdict.
+- No runtime block/allow decisions added or modified. This script runs in `npm run lint` and CI only.
+
+## 1. Over-block
+
+The widened matcher can only fire on the eight curated actuator files, so the blast radius is those eight.
+Verified against the real tree: none of the eight so much as mentions `CoherenceJournalReader`, and the lint
+exits 0. Two narrowings actively REDUCE over-block versus the shipped version: `import type` (which the old
+regex flagged — `src/core/WorkingSetPull.ts` is a live example of that shape) and comment stripping.
+
+The one new way to fail a build that is not a §3.9 breach: renaming a curated actuator without updating
+`ACTUATOR_FILES`. That is intended — a renamed actuator silently leaving the ban is the failure this closes —
+and the message names the file and the fix.
+
+## 2. Under-block
+
+**Automatic discovery of actuators was built, measured against this tree, and REJECTED.** Inferring "is this an
+actuator?" from declared names (functions, classes, filename) flagged nine sites across three files, and every
+one was a part-of-speech or granularity error rather than a §3.9 breach:
+
+- `src/server/routes.ts` — matched `readReaperPeerText`, `isReaperSnapshot`, `reaperPoolHealth`: "reaper" as a
+  NOUN in code that REPORTS ON the reaper. A reporting surface reading the journal is correct code.
+- `src/commands/server.ts` — the 22k-line composition root. Every module's authority is wired through it, so any
+  file-level verdict on it is wrong in one direction or the other.
+- `src/core/WorkingSetPull.ts` — a runtime-erased `import type`.
+
+This lint blocks commits, so over-blocking correct code is the more expensive failure. The enumerated-list shape
+is also the ORIGINAL converged design decision, stated in `upgrades/side-effects/coherence-journal-p1-2.md`:
+"The enumerated-list shape is deliberate: growable, reviewable." Closing it needs an authoritative actuator
+population, not a heuristic; `src/testing/selfActionRegistry.ts` (`modelsPath`, kept complete by
+`lint-no-unregistered-self-action.js`) is the closest candidate but is a superset in KIND — spend-alert
+emitters and sweeps are self-actions, not §3.9 session actuators. Left open, named in the header, and pinned by
+a test that will fail if someone closes it.
+
+Still evadable, unchanged from before: a hand-rolled JSONL read, or reaching the reader through a re-export.
+The §3.9 duty remains the authority.
+
+## 3. Level-of-abstraction fit
+
+Line-level regex over comment-stripped source, on an enumerated file list. Same layer as the shipped check —
+no AST, no type information, no new dependency. The comment stripper is the only added machinery, and it exists
+so the matcher can widen without making §3.9 prose illegal.
+
+## 4. Signal vs authority compliance
+
+Unchanged and reinforced. The lint is a CI guard, not a runtime authority; it forbids actuators from HOLDING the
+reader, which is what keeps replicated journal data signal rather than authority. Nothing here reads the journal
+at runtime.
+
+## 5. Interactions
+
+- `npm run lint` chain (`package.json:31`) — position unchanged; `tests/unit/lint-chain-completeness.test.ts`
+  passes (3/3).
+- Husky pre-commit / CI run the same chain. Exit 2 on a rootless tree is new; the repo root always has `src/`,
+  and the only caller passing `--root` is this test.
+- No source module, route, config key, or state file is touched.
+
+## 6. External surfaces
+
+None. No HTTP route, no config key, no user-visible message, no CLAUDE.md template change (the lint is
+developer-facing tooling, not an agent capability). Agent Awareness Standard does not apply.
+
+## 7. Rollback cost
+
+`git revert` of one script plus one test file. No migration, no state, no deployed artifact. The lint is
+stateless and runs from source.
+
+## Conclusion
+
+Ship. One real evasion closed with a negative control proving each assertion fails without the fix; two
+narrowings that reduce false positives below the shipped baseline; one silent-failure mode of my own making
+(clean verdict over zero files) caught and closed before it shipped.
+
+## Second-pass review (if required)
+
+Not required at Tier 1. Independent corroboration of DEFECT 1 exists regardless: instar-codey reproduced the
+dynamic-import evasion separately and ranked this lint first of ~20 by consequence-of-defeat, and recommended
+exactly the scope taken here — "low FP risk if limited to actuator files and comment-stripped `import()`,
+`require()`… Do not ban writer imports."
+
+## Evidence pointers
+
+- `tests/unit/journal-actuation-ban-lint.test.ts` — 13/13 green with the fix.
+- Negative control: with the shipped lint restored, exactly 5 of the 13 fail (dynamic import, `require`,
+  `import type`, vanished-curated-file, rootless-tree) and all 8 controls still pass — controls should pass
+  both ways, which is what makes them controls.
+- Real-tree verdict: `node scripts/lint-journal-actuation-ban.js` → `clean (8 actuator modules, none load the
+  reader)`, exit 0.
+- `upgrades/side-effects/coherence-journal-p1-2.md` — the original converged decision to enumerate.
+
+## Finding raised separately (NOT fixed here)
+
+Discovery, before it was rejected, surfaced five `await import('../core/CoherenceJournalReader.js')` sites in
+`src/commands/server.ts`. One (`:20853`) wires `OwnershipApplier`, which materializes durable topic ownership
+FROM the replicated placement journal — replicated data feeding an ownership decision that placement and
+session routing then act on. It is deliberate and specified (`docs/specs/ownership-applier-meshself-ordering-fix.md`)
+and validates `transferTo` against the live known-machine set before materializing. Whether §3.9 permits it is a
+spec question with real consequence, and it is not mine to settle inside a lint change. Raised to the operator;
+deliberately NOT actioned here, and the lint does not flag it.


### PR DESCRIPTION
## What this fixes

`lint-journal-actuation-ban` enforces COHERENCE-JOURNAL-SPEC §3.9 — no actuator (kill / spawn / place / transfer / reap) may import the journal READER, because replicated journal data is stale by construction and an actuator trusting it can kill live work or double-place a conversation.

It matched `/from\s+['"]…CoherenceJournalReader…['"]/`. That requires the `from` keyword, which `await import(…)` and `require(…)` do not have — **both loaded the reader straight past the ban.** Reproduced against the shipped lint on a real listed actuator (`src/core/SessionManager.ts`): it printed `clean`.

instar-codey reproduced the same evasion independently while auditing ~20 rename-defeatable lints, and ranked this one **first by consequence-of-defeat**, recommending exactly this scope: *"low FP risk if limited to actuator files and comment-stripped `import()`, `require()` … Do not ban writer imports."*

## ELI16

Instar copies a journal between your machines, and copies arrive on a heartbeat, so a copy is always slightly behind reality. That is fine for answering questions and dangerous for making decisions. If something that can kill a session reads a stale copy saying "session closed", it kills live work; if it sees no session, it starts a second one and the same conversation runs twice. So the rule is: anything that can kill, spawn, place, transfer or reap may WRITE to the journal but must never READ it — read the live system instead. A lint enforces that by failing the build if one of those modules imports the reader file.

The lint only knew one way to say "import": the word `from`. But JavaScript has two others, `await import(...)` and `require(...)`, and neither uses that word. Both walked past the guard completely. This is not an exotic bypass — `await import(...)` is ordinary, and this codebase uses it constantly to avoid loading heavy modules at startup, so someone could defeat this guard by accident while writing perfectly normal code and nothing would tell them.

Now all three forms are recognised. Three smaller changes came with it, and two make the lint *less* likely to complain: comments are stripped first (otherwise widening the pattern would make it illegal to write a comment *about* the rule), and `import type` is exempt (it vanishes when the code compiles, so it cannot act on stale data — the old pattern flagged it, and a real file does this legitimately). The third: a listed file that no longer exists is now an error rather than a silently skipped line, because renaming a guarded module used to quietly remove it from the ban.

Full version: `docs/specs/journal-actuation-ban-load-forms.eli16.md`.

## The bug I introduced, and caught before it shipped

My first attempt discovered actuators automatically instead of using the hand-written list. I tested it against another checkout and it reported `clean` — which looked like good news. **The path did not exist.** It had scanned zero files and reported success. A clean verdict over nothing is indistinguishable from a genuinely clean tree, which makes it the most misleading output a checker can produce. The lint now exits 2 rather than render a verdict on a tree it did not scan, and a test pins that.

## What I did NOT close, deliberately

The curated actuator list stays hand-maintained. Automatic discovery **was built and measured against this tree**, and rejected on the evidence — nine flags across three files, every one a part-of-speech or granularity error:

| File | Why it matched | Why it is wrong |
|---|---|---|
| `src/server/routes.ts` | `readReaperPeerText`, `isReaperSnapshot`, `reaperPoolHealth` | "reaper" as a **noun**, in code that *reports on* the reaper. A reporting surface reading the journal is correct — it is the whole point. |
| `src/commands/server.ts` | `spawnSessionForTopic`, `killWarmSessionByName` | The 22k-line composition root. Every module's authority is wired through it, so a file-level verdict is wrong in one direction or the other. |
| `src/core/WorkingSetPull.ts` | `import type { OwnAutonomousRuns }` | Runtime-erased. Now exempt. |

This lint blocks commits, so over-blocking correct code is the more expensive failure. The enumerated shape is also the **original converged design decision** — `upgrades/side-effects/coherence-journal-p1-2.md` states it: *"The enumerated-list shape is deliberate: growable, reviewable."* Closing it needs an authoritative actuator population, not a heuristic; `src/testing/selfActionRegistry.ts` is the nearest candidate but is a superset in kind (spend-alert emitters and sweeps are self-actions, not §3.9 session actuators).

So the limitation is now **stated plainly in the header instead of implied**, and pinned by a test that fails if anyone closes it properly — the signal to update the docs rather than a silent divergence.

## Evidence

- `tests/unit/journal-actuation-ban-lint.test.ts` — **13/13 green.**
- **Negative control:** with the shipped lint restored, **exactly 5 of 13 fail** (dynamic import, `require`, `import type`, vanished-curated-file, rootless-tree) and **all 8 controls still pass** — controls should pass both ways, which is what makes them controls rather than decoration.
- Real-tree verdict: `clean (8 actuator modules, none load the reader)`, exit 0. All eight curated actuators verified present; none references the reader in any form.
- Full `npm run lint` chain green; `lint-chain-completeness` 3/3; pre-push suite + path-scoped e2e gate green.
- Tier **1**, declared (signal said 2 on size alone; riskFloor 1, no reasons). Of 116 added lines, 58 are prose and 52 executable, ~35 of those the comment stripper. CI-only tooling: no runtime path, no state, no route, no config key, no user surface.

## Raised separately, NOT actioned here

Discovery, before it was discarded, pointed at `src/commands/server.ts:20853` — `OwnershipApplier`, which materializes durable topic ownership **from the replicated placement journal**, which placement and routing then act on. It is deliberate, specified (`docs/specs/ownership-applier-meshself-ordering-fix.md`), and validates `transferTo` against the live known-machine set before materializing. Whether §3.9 permits a validated read like that is a spec question with real consequence, not something a lint change should settle in passing. It is on the operator's attention queue. **The shipped lint does not flag it — behaviour for that file is unchanged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
