### PR TITLE
Harden LLM HTTP lint constant folding

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T22-19-53-818Z-llm-http-constant-folding.json
+++ b/.instar/instar-dev-decisions/2026-08-14T22-19-53-818Z-llm-http-constant-folding.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T22:19:53.818Z",
+  "slug": "llm-http-constant-folding",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 160,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-direct-llm-http.js"
+    ],
+    "addedLines": 159,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/llm-http-constant-folding.eli16.md
+++ b/docs/eli16/llm-http-constant-folding.eli16.md
@@ -1,0 +1,35 @@
+# LLM HTTP lint constant folding — Plain-English Overview
+
+> The one-line version: the lint that blocks raw LLM provider HTTP calls now catches URLs split across constant string pieces, so a second spelling of the same forbidden endpoint no longer slips past the build.
+
+## The problem in one breath
+
+Raw HTTP calls to LLM providers are not just another fetch. They bypass the routing layer that records attribution, burn, and quota policy, so a hidden direct call can spend the operator's money and send data out without the central controls seeing it.
+
+The shipped lint caught `api.anthropic.com` when the host appeared as one string. It missed the same URL when the host was split into constant pieces, for example `'api.' + 'anthropic.com/v1/messages'`. That meant a callsite could avoid the guard without changing behavior.
+
+## What already exists
+
+- **The central provider path** — the normal route for LLM calls, where attribution and quota controls live.
+- **The direct HTTP lint** — a build-time guard that scans production source for provider hosts outside the approved provider files.
+- **The allowlist distinction** — OAuth/profile/usage metadata endpoints remain accepted in the files that legitimately read account metadata instead of performing inference.
+
+## What this adds
+
+The lint now folds adjacent constant string and no-expression template literals joined by `+` before checking for known LLM provider hosts. It stays deliberately narrow: only literal-plus-literal chains are evaluated. Once a variable, function call, or template expression enters the URL construction, the lint stops rather than guessing.
+
+## The safeguards
+
+**Prevents the known bypass.** A split host like `'https://api.' + 'anthropic.com/v1/messages'` now fails the same way the unsplit string fails.
+
+**Preserves the metadata distinction.** The existing allowlisted and grandfathered files keep their current treatment, so OAuth/profile/usage metadata readers are not newly blocked just because the scanner got better at recognizing constant strings.
+
+**Avoids broad source inference.** The fix does not attempt automatic actuator discovery, dataflow, or semantic endpoint classification. That broader shape was expected to create false positives; this change only evaluates constant URL literals.
+
+## What ships when
+
+This PR ships the lint hardening, focused tests that fail against the old lint, a clean scan of the real tree, and the instar-dev trace artifacts needed for release.
+
+## What you actually need to decide
+
+The PR asks whether this narrow constant-folding guard is the right build-time protection for the known split-host LLM HTTP bypass.

--- a/scripts/lint-no-direct-llm-http.js
+++ b/scripts/lint-no-direct-llm-http.js
@@ -98,6 +98,162 @@ const FORBIDDEN_PATTERNS = [
 
 const EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs']);
 
+function lineForOffset(text, offset) {
+  let line = 1;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === '\n') line++;
+  }
+  return line;
+}
+
+function stripCommentsPreserveLayout(text) {
+  let out = '';
+  let i = 0;
+  let quote = null;
+  let escaped = false;
+
+  while (i < text.length) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (quote) {
+      out += ch;
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      out += ch;
+      i++;
+      continue;
+    }
+
+    if (ch === '/' && next === '/') {
+      out += '  ';
+      i += 2;
+      while (i < text.length && text[i] !== '\n') {
+        out += ' ';
+        i++;
+      }
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      out += '  ';
+      i += 2;
+      while (i < text.length) {
+        if (text[i] === '*' && text[i + 1] === '/') {
+          out += '  ';
+          i += 2;
+          break;
+        }
+        out += text[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return out;
+}
+
+function skipWhitespace(text, index) {
+  while (index < text.length && /\s/.test(text[index])) index++;
+  return index;
+}
+
+function readStringLiteral(text, start) {
+  const quote = text[start];
+  if (quote !== '"' && quote !== "'" && quote !== '`') return null;
+
+  let value = '';
+  let i = start + 1;
+  let escaped = false;
+  while (i < text.length) {
+    const ch = text[i];
+    if (escaped) {
+      value += ch;
+      escaped = false;
+      i++;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      i++;
+      continue;
+    }
+    if (quote === '`' && ch === '$' && text[i + 1] === '{') {
+      return null;
+    }
+    if (ch === quote) {
+      return { value, end: i + 1 };
+    }
+    value += ch;
+    i++;
+  }
+
+  return null;
+}
+
+function findFoldedStringViolations(text, rel) {
+  const stripped = stripCommentsPreserveLayout(text);
+  const violations = [];
+
+  for (let i = 0; i < stripped.length; i++) {
+    const first = readStringLiteral(stripped, i);
+    if (!first) continue;
+
+    let cursor = skipWhitespace(stripped, first.end);
+    if (stripped[cursor] !== '+') {
+      i = first.end - 1;
+      continue;
+    }
+
+    const parts = [first.value];
+    let end = first.end;
+    let literalCount = 1;
+    while (stripped[cursor] === '+') {
+      const nextStart = skipWhitespace(stripped, cursor + 1);
+      const nextString = readStringLiteral(stripped, nextStart);
+      if (!nextString) break;
+      parts.push(nextString.value);
+      literalCount++;
+      end = nextString.end;
+      cursor = skipWhitespace(stripped, nextString.end);
+    }
+
+    if (literalCount > 1) {
+      const folded = parts.join('');
+      const line = lineForOffset(stripped, i);
+      for (const pat of FORBIDDEN_PATTERNS) {
+        if (folded.includes(pat)) {
+          violations.push({
+            file: rel,
+            line,
+            pattern: pat,
+            text: folded.slice(0, 200),
+            folded: true,
+          });
+        }
+      }
+      i = end - 1;
+    }
+  }
+
+  return violations;
+}
+
 function readGitignoreDirs() {
   // Skip node_modules, dist, .instar/worktrees, etc.
   return new Set(['node_modules', 'dist', 'build', '.instar', '.git', '.next', 'coverage']);
@@ -168,6 +324,7 @@ function checkFile(file) {
       }
     }
   }
+  violations.push(...findFoldedStringViolations(text, rel));
   return violations;
 }
 
@@ -184,7 +341,8 @@ function main() {
   console.error('src/core/ClaudeCliIntelligenceProvider.ts so the burn-detection system can');
   console.error('attribute it. See docs/specs/token-burn-detection-and-self-heal.md Phase 1.\n');
   for (const v of all) {
-    console.error(`  ${v.file}:${v.line} — contains "${v.pattern}"`);
+    const reason = v.folded ? `folds to "${v.pattern}"` : `contains "${v.pattern}"`;
+    console.error(`  ${v.file}:${v.line} — ${reason}`);
     console.error(`    ${v.text}`);
   }
   process.exit(1);

--- a/tests/unit/burn-detection-phase-1.test.ts
+++ b/tests/unit/burn-detection-phase-1.test.ts
@@ -198,6 +198,80 @@ describe('lint-no-direct-llm-http', () => {
     }
   });
 
+  it('rejects a synthetic violation with a split Anthropic host literal', () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-lint-'));
+    const fakeViolation = path.join(tmpdir, 'BadSplitAnthropic.ts');
+    fs.writeFileSync(
+      fakeViolation,
+      [
+        'export async function bad() {',
+        "  const url = 'https://api.' + 'anthropic.com/v1/messages';",
+        "  return fetch(url, { method: 'POST' });",
+        '}',
+        '',
+      ].join('\n'),
+    );
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [path.join(ROOT, 'scripts/lint-no-direct-llm-http.js'), fakeViolation],
+        { cwd: ROOT, encoding: 'utf-8' },
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('api.anthropic.com');
+    } finally {
+      SafeFsExecutor.safeRmSync(tmpdir, { recursive: true, force: true, operation: 'tests/unit/burn-detection-phase-1.test.ts:lint-split-anthropic' });
+    }
+  });
+
+  it('rejects synthetic violations with split OpenAI and Google host literals', () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-lint-'));
+    const fakeViolation = path.join(tmpdir, 'BadSplitProviders.ts');
+    fs.writeFileSync(
+      fakeViolation,
+      [
+        'export const openai = "https://api." + "openai.com/v1/chat/completions";',
+        'export const google = `https://generativelanguage.` + `googleapis.com/v1beta/models`;',
+        '',
+      ].join('\n'),
+    );
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [path.join(ROOT, 'scripts/lint-no-direct-llm-http.js'), fakeViolation],
+        { cwd: ROOT, encoding: 'utf-8' },
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('api.openai.com');
+      expect(result.stderr).toContain('generativelanguage.googleapis.com');
+    } finally {
+      SafeFsExecutor.safeRmSync(tmpdir, { recursive: true, force: true, operation: 'tests/unit/burn-detection-phase-1.test.ts:lint-split-providers' });
+    }
+  });
+
+  it('does not fold dynamic URL construction', () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-lint-'));
+    const dynamicUrl = path.join(tmpdir, 'DynamicUrl.ts');
+    fs.writeFileSync(
+      dynamicUrl,
+      [
+        "const providerHost = 'anthropic.com';",
+        "export const url = 'https://api.' + providerHost + '/v1/messages';",
+        '',
+      ].join('\n'),
+    );
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [path.join(ROOT, 'scripts/lint-no-direct-llm-http.js'), dynamicUrl],
+        { cwd: ROOT, encoding: 'utf-8' },
+      );
+      expect(result.status).toBe(0);
+    } finally {
+      SafeFsExecutor.safeRmSync(tmpdir, { recursive: true, force: true, operation: 'tests/unit/burn-detection-phase-1.test.ts:lint-dynamic-url' });
+    }
+  });
+
   it('accepts the IntelligenceProvider chokepoint files (allowlist works)', () => {
     const result = spawnSync(
       process.execPath,

--- a/upgrades/next/llm-http-constant-folding.md
+++ b/upgrades/next/llm-http-constant-folding.md
@@ -1,0 +1,13 @@
+<!-- internal-only -->
+
+# LLM HTTP lint catches split provider hosts
+
+## What Changed
+
+`scripts/lint-no-direct-llm-http.js` now folds adjacent constant string and no-expression template literals before checking for direct LLM provider hosts. A raw provider URL split as `'https://api.' + 'anthropic.com/v1/messages'` now fails the same build lint as the unsplit host.
+
+The scope is deliberately narrow: literal-plus-literal URL construction only. Dynamic URL construction is not guessed at, and the existing file-level distinction for OAuth/profile/usage metadata endpoints remains unchanged.
+
+## Evidence
+
+Negative control against the shipped lint: the focused unit file failed 2 tests, both new split-host rejection cases. After the fix, `tests/unit/burn-detection-phase-1.test.ts` passes 20/20, and `node scripts/lint-no-direct-llm-http.js` exits clean against the real tree.

--- a/upgrades/side-effects/llm-http-constant-folding.md
+++ b/upgrades/side-effects/llm-http-constant-folding.md
@@ -1,0 +1,82 @@
+# Side-Effects Review — LLM HTTP lint constant folding
+
+**Version / slug:** `llm-http-constant-folding`
+**Date:** `2026-08-14`
+**Author:** `Instar-codey`
+**Tier:** 1 (one lint script plus focused unit coverage; no runtime code, route, config, migration, or persistence change)
+**Second-pass reviewer:** `not required — CI/pre-commit lint hardening only; no runtime outbound message or session lifecycle decision`
+
+## Summary of the change
+
+`scripts/lint-no-direct-llm-http.js` now folds adjacent constant string and no-expression template literals joined by `+` before checking for known LLM provider hosts. This closes the reproduced split-host bypass (`'api.' + 'anthropic.com/v1/messages'`) while keeping scope at literal URL construction only. `tests/unit/burn-detection-phase-1.test.ts` adds red/green coverage for split Anthropic, OpenAI, and Google host literals plus a non-folded dynamic construction control.
+
+Build location re-grounding: work was built in fresh worktree `/Users/justin_instar_1/.instar/agents/instar-codey/.worktrees/agent-llm-http-constant-folding` from current `JKHeadley/main` (`4731ec6a90356ed319454a996b4eb72edcf38ab2`), created through `npx -y instar@1.3.1144 worktree create ... --base origin/main` after the local wrapper lacked an installed package. Remote verified as `origin https://github.com/JKHeadley/instar.git`; package version verified as `1.3.1144`.
+
+## Decision-point inventory
+
+- `scripts/lint-no-direct-llm-http.js` — modify — build-time block/allow decision for direct provider HTTP references outside the provider chokepoint and named metadata exceptions.
+
+## 1. Over-block
+
+The new over-block risk is a benign constant string in production source that names a provider host across literal pieces without making a call. That is the same policy as the existing unsplit-host lint: production source outside the allowlist should not carry raw provider host literals because they become copyable direct-call paths. The real-tree scan after the fix was clean.
+
+OAuth/profile/usage metadata readers keep their existing allowlist/grandfather treatment; this change did not add endpoint-level bans that would collapse metadata reads into inference calls.
+
+## 2. Under-block
+
+The lint still misses dynamic construction, such as `'https://api.' + providerHost + '/v1/messages'`, computed arrays joined into a host, decoded strings, or runtime config that points at a provider endpoint. That is intentional for this PR: automatic discovery/dataflow was the high-false-positive direction. The closure here is constant URL literals, not semantic HTTP-call proof.
+
+## 3. Level-of-abstraction fit
+
+Correct layer: this is a deterministic CI lint in the existing `lint-no-*` family. The protected invariant is "new production raw LLM provider host literals outside the chokepoint require review." The lower-level primitive is a string-literal scanner, not an authority over runtime user intent.
+
+## 4. Signal vs authority compliance
+
+Reference: [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md).
+
+This change holds blocking authority with brittle logic, but it is a build-time hard invariant/safety guard, not a conversational judgment point. The lint blocks source code containing direct provider endpoint literals outside reviewed locations, analogous to a safety guard on data egress and spend attribution. It does not decide whether a user message is appropriate or whether an agent action should proceed at runtime.
+
+## 4b. Judgment-point check
+
+No new static heuristic at a competing-signals decision point. The input is source text and an enumerated provider-host list; there are no live competing signals such as urgency, recency, ownership, or liveness.
+
+## 5. Interactions
+
+- **Shadowing:** It runs inside the existing `npm run lint` chain. It may fail before later lints, as before; no downstream lint depends on side effects from this script.
+- **Double-fire:** `lint-llm-attribution.js` and other provider-path checks may catch related defects, but this one reports direct HTTP host literals specifically. Duplicate CI failures are acceptable because they point at the same source change.
+- **Races:** No shared state. It reads files and exits.
+- **Feedback loops:** None.
+
+## 6. External surfaces
+
+No runtime external surface changes. Other agents and users only see this as a stricter build/pre-commit/CI failure when source contains a newly-recognized split provider URL. No Telegram, Slack, GitHub API, dashboard, database, ledger, or generated URL behavior changes. No operator-facing action is added.
+
+## 6b. Operator-surface quality
+
+No operator surface — not applicable.
+
+## 7. Multi-machine posture
+
+Machine-local by design: this is a repository lint run independently in each checkout/CI runner. It emits no user-facing notices, holds no durable state, and generates no URLs. Multi-machine consistency comes from the shared git commit containing the lint and tests.
+
+## 8. Rollback cost
+
+Pure code/test/docs change. Rollback is a hot-fix revert of the lint folding helper and tests. No data migration, no agent state repair, and no user-visible runtime regression while rollback propagates.
+
+## Conclusion
+
+The real-tree scan stayed clean and the negative control failed for the intended old-lint cases, so the scoped constant-folding fix is clear to ship. No broader automatic actuator discovery or dynamic URL dataflow was added.
+
+## Second-pass review
+
+Not required.
+
+## Evidence pointers
+
+- Old-lint focused run: `npx vitest run tests/unit/burn-detection-phase-1.test.ts` failed 2 of 20 tests, specifically the two new split-host rejection tests.
+- Fixed targeted run: `npx vitest run tests/unit/burn-detection-phase-1.test.ts` passed 20/20.
+- Fixed real-tree scan: `node scripts/lint-no-direct-llm-http.js` exited 0.
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect — not applicable.


### PR DESCRIPTION
## Summary

Hardens `scripts/lint-no-direct-llm-http.js` so direct provider URLs split across constant string pieces are folded before matching known LLM provider hosts. This closes the reproduced bypass shape:

```ts
const url = 'https://api.' + 'anthropic.com/v1/messages';
fetch(url, { method: 'POST' });
```

The scope is deliberately narrow: adjacent string literals and no-expression template literals joined by `+`. Dynamic URL construction is not guessed at, and the existing allowlist/grandfather distinction for OAuth/profile/usage metadata endpoint files is unchanged.

## ELI16 — split URLs should not bypass the LLM spend guard

Raw LLM provider HTTP calls are special because they can spend the operator's money and send data outside the reviewed routing path. The existing build check caught a forbidden provider host when it appeared as one string, but it missed the same host when the code split it into constant pieces like `'api.' + 'anthropic.com'`.

This PR teaches that build check to join only obvious constant string pieces before it looks for provider hosts. It does not try to understand every dynamic URL a program could build, and it keeps the existing carveouts for legitimate account metadata readers such as OAuth profile and usage checks. The practical result is narrow: the known split-host bypass now fails CI, while the real source tree still scans clean.

## Why

Raw provider HTTP skips the central routing chokepoint. That is the operator's wallet and unreviewed data egress: these calls can bypass routing, burn attribution, and central quota policy.

## Negative Control

Against the shipped lint on current `origin/main`, the focused test file failed 2 of 20 tests: both new split-host rejection tests failed because the old lint exited 0. The dynamic construction control passed, confirming the intended scope.

## Instar-Dev Trace

Declared Tier 1: one CI lint script, focused tests, ELI16, side-effects, and release-note fragment; no runtime route, config, persistence, migration, or operator surface change.

Build location was a fresh worktree from current `origin/main` (`4731ec6a90356ed319454a996b4eb72edcf38ab2`) under this agent's `.worktrees` directory. Package version verified: `1.3.1144`.

## Validation

- `npx vitest run tests/unit/burn-detection-phase-1.test.ts` failed before the fix: 2 intended split-host cases failed against old lint.
- `npx vitest run tests/unit/burn-detection-phase-1.test.ts` passed after the fix: 20/20.
- `node scripts/lint-no-direct-llm-http.js` exited 0 against the real tree after the fix.
- `npm run lint` passed.
- Pre-push smoke passed 20/20. First push attempt timed out waiting for a stuck external suite-lane holder; retry ran the same hook with `INSTAR_HOST_TEST_SEMAPHORE=off` so hooks and smoke still executed.
