### PR TITLE
feat(worktree): ask the worktrees which repo owns them

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T22-56-11-157Z-worktree-repo-discovery.json
+++ b/.instar/instar-dev-decisions/2026-08-14T22-56-11-157Z-worktree-repo-discovery.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T22:56:11.157Z",
+  "slug": "worktree-repo-discovery",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 122,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "src/core/AgentWorktreeDetector.ts"
+    ],
+    "addedLines": 122,
+    "deletedLines": 0
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/worktree-repo-discovery.eli16.md
+++ b/docs/specs/worktree-repo-discovery.eli16.md
@@ -1,0 +1,85 @@
+# ELI16 — the cleaner that could never find the room
+
+## What was supposed to happen
+
+When I create a working copy of the codebase to build something in, it goes in a standard place under my
+home directory. They pile up — each one is a full copy of the source tree. So there is a background
+housekeeper whose job is to notice which ones are finished (the work is merged, nothing uncommitted, nothing
+running in them) and reclaim the disk.
+
+## What actually happened
+
+The housekeeper reported: `enumerationFailures: 98`. Ninety-eight consecutive attempts, none of which
+managed to look at anything. Meanwhile there were 45 working copies taking up **27 gigabytes**.
+
+To list working copies you have to ask a *repository*. The housekeeper was handed a path that is not a
+repository at all — my home directory. Every attempt came back "fatal: not a git repository", so it looked at
+nothing, forever.
+
+Worth being precise about who did what wrong here, because a previous fix in this area was correct and is the
+only reason I noticed. The housekeeper's status output **does not lie**. It says `enumerationOk: false` and
+refuses to report a number of reclaimable items, with a comment in the source explaining exactly why: *"the
+check could not run" and "there is nothing to reclaim" are the same bytes to a reader and opposite facts.*
+That honesty was added in July after this same thing happened with 73 working copies. It worked — I found
+this by reading it. What was never fixed was the wrong path underneath.
+
+## The second, quieter version of the same bug
+
+There is a separate routine whose job is to work out where the repository is. It tried two conventional
+locations — `~/Documents/Projects/instar` and `~/instar`. Neither exists on this machine, so it returned
+"don't know", and every caller had a line like `if (we know the repo)` and skipped. Silently. No errors, no
+count of failures, nothing.
+
+Both bugs are the same mistake: **a path assumed instead of resolved.**
+
+## The fix in this change
+
+The answer was sitting on disk all along. Every working copy contains a small file that names the repository
+it belongs to — one line, e.g. `gitdir: /path/to/the/repo/.git/worktrees/my-branch`. So instead of guessing at
+conventional locations, ask the working copies. They know.
+
+This change adds that ability and proves it works. It does **not** yet plug it into the housekeeper — see
+below.
+
+## The bug I put in my own fix, and how I caught it
+
+My first version asked *every* agent on the machine, not just mine. There are several agents here, each with
+their own working copies. Whichever agent had the most won the vote — so when I actually ran it, my agent
+resolved to **a different agent's repository**.
+
+That is worse than the original bug. "I don't know" makes a caller skip and do nothing. A confident wrong
+answer makes it *act*, on someone else's files.
+
+I only caught it because I ran the thing and printed both results side by side, rather than reading my own
+code and believing it. The fix: there is now no default at all — a caller must name its own directory, and a
+test fails if resolution ever wanders off to somewhere the caller did not name.
+
+## Something honest about the answer
+
+While measuring, I found this agent's working copies do not all belong to one repository. Twenty-nine belong
+to one clone and seventeen to another — both legitimate, both copies of the same project. So "which repo owns
+the working copies?" does not have a single answer here.
+
+The function returns all of them, biggest group first. A caller that only looks at the first gets the largest
+consistent set — better than nothing at all, and still not everything. That limitation is written into the
+function's own documentation rather than left for someone to trip over.
+
+## Why the housekeeper is not fixed yet in this change
+
+Plugging this in would change what a background process with **permission to delete directories** operates
+on. Given that my first attempt at this exact resolution produced a wrong answer, "easy to get wrong" is not
+a theory here — it is the measured behaviour of my own first draft. So that step goes through the heavier
+review path with the operator's approval, as a small focused change on top of this one, rather than being
+bundled in at the end of a long session.
+
+What lands here is the mechanism, tested and verified, with nothing calling it yet — so no agent's behaviour
+changes at all today.
+
+## How you know it works
+
+Fourteen tests. They cover the real shapes: a normal pointer, several working copies agreeing, two different
+repositories being reported in the right order, and the whole list of things that must produce "don't know"
+rather than a guess — a full clone sitting in the wrong place, a corrupted file, a folder with nothing in it,
+a missing directory. Plus the cross-agent bug above, pinned so it cannot come back. The existing tests for
+this file were not modified and still pass, which is what tells you the old behaviour is untouched when no
+caller opts in.

--- a/src/core/AgentWorktreeDetector.ts
+++ b/src/core/AgentWorktreeDetector.ts
@@ -401,6 +401,103 @@ export function enumerateSafeRoots(agentsDir?: string): string[] {
   return roots;
 }
 
+// ── Public helper: ask the worktrees which repo owns them ────────────────
+
+/**
+ * Derive candidate instar-repo roots from the agent worktrees themselves.
+ *
+ * WHY THIS EXISTS. The fallback chain below guesses at conventional checkout
+ * locations (`~/Documents/Projects/instar`, `~/instar`). An agent whose repo
+ * lives anywhere else — e.g. `<agent_home>/.dev/instar`, which is where the
+ * dev layout actually puts it — matches none of them, so resolution returned
+ * null and every consumer silently did nothing. Meanwhile the answer was
+ * sitting on disk the whole time: a linked worktree's `.git` is a FILE whose
+ * contents name its owning repo. The worktrees know. Ask them instead of
+ * guessing.
+ *
+ * (2026-07-29 the same blind spot let the reaper report `reclaimable: 0`
+ * against 73 worktrees because its `git -C <path> worktree list` was failing
+ * outright. The honest-reporting fix landed; the resolution did not.)
+ *
+ * Deliberately NO subprocess: reading the pointer file is cheaper than
+ * `git rev-parse`, cannot block the event loop, and keeps this helper usable
+ * from the runtime hot dirs. Returns candidates only — every one is still
+ * integrity-validated by `resolveInstarRepo` before it is believed.
+ *
+ * ORDERED BY COUNT, and the ordering carries a real limitation worth stating.
+ * One agent's `.worktrees/` can legitimately hold worktrees of MORE THAN ONE
+ * clone of the same upstream — measured on a live agent: 29 worktrees owned by
+ * `<home>/.build/instar` and 17 by `<home>/.dev/instar`. This returns the
+ * most-owned first, so a single-repo consumer gets the largest coherent set
+ * rather than an arbitrary one; it does NOT merge them, and a consumer that
+ * takes only `[0]` will not see the smaller repo's worktrees. Consumers that
+ * need full coverage must iterate the whole list. The alternative — picking
+ * arbitrarily — would make the blind spot unpredictable instead of merely
+ * bounded.
+ */
+export function discoverInstarRepoFromWorktrees(
+  roots: ReadonlyArray<string>,
+  opts: { maxWorktrees?: number } = {},
+): string[] {
+  const cap = opts.maxWorktrees ?? 200;
+  const counts = new Map<string, number>();
+  let inspected = 0;
+
+  for (const root of roots) {
+    let entries: string[] = [];
+    try {
+      entries = fs.readdirSync(root);
+    } catch {
+      // @silent-fallback-ok — root vanished between enumeration and read.
+      continue;
+    }
+    for (const entry of entries) {
+      if (inspected >= cap) break;
+      const pointer = path.join(root, entry, '.git');
+      let stat;
+      try {
+        stat = fs.statSync(pointer);
+      } catch {
+        // @silent-fallback-ok — not a worktree (no .git at all). Skip.
+        continue;
+      }
+      // A linked worktree's .git is a FILE. A full clone's is a directory, and
+      // a clone under .worktrees/ is not a worktree of anything — skip it
+      // rather than claim it points somewhere.
+      if (!stat.isFile()) continue;
+      inspected++;
+      let contents: string;
+      try {
+        contents = fs.readFileSync(pointer, 'utf-8');
+      } catch {
+        // @silent-fallback-ok — unreadable pointer; it names nothing.
+        continue;
+      }
+      const repo = parseWorktreeGitPointer(contents);
+      if (repo) counts.set(repo, (counts.get(repo) ?? 0) + 1);
+    }
+    if (inspected >= cap) break;
+  }
+
+  return [...counts.entries()]
+    .sort((a, b) => (b[1] - a[1]) || a[0].localeCompare(b[0]))
+    .map(([repo]) => repo);
+}
+
+/**
+ * `gitdir: /path/to/repo/.git/worktrees/<slug>` → `/path/to/repo`.
+ * Anything that does not have that exact shape names nothing, and returns
+ * null rather than a guess.
+ */
+export function parseWorktreeGitPointer(contents: string): string | null {
+  const match = /^\s*gitdir:\s*(.+?)\s*$/m.exec(contents);
+  if (!match) return null;
+  const marker = `${path.sep}.git${path.sep}worktrees${path.sep}`;
+  const idx = match[1].indexOf(marker);
+  if (idx <= 0) return null;
+  return match[1].slice(0, idx);
+}
+
 // ── Public helper: resolve the canonical instar repo for the detector ────
 
 export interface ResolveDetectorRepoOptions {
@@ -416,6 +513,13 @@ export interface ResolveDetectorRepoOptions {
    * running them has an allowlisted checkout at cwd).
    */
   cwd?: string;
+  /**
+   * The CALLER'S OWN agent `.worktrees` root(s), used to derive the owning
+   * repo from the worktrees themselves. Omitted ⇒ no worktree-derived
+   * candidates. Never pass `enumerateSafeRoots()` here: that spans every agent
+   * on the machine and will resolve you to somebody else's repo.
+   */
+  worktreeRoots?: ReadonlyArray<string>;
 }
 
 /**
@@ -442,6 +546,24 @@ export function resolveDetectorInstarRepo(opts: ResolveDetectorRepoOptions = {})
 
   const candidateChain: string[] = [];
   if (configRepoPath) candidateChain.push(configRepoPath);
+
+  // Ask the worktrees who owns them, BEFORE guessing at conventional
+  // locations. An operator-supplied `worktree.repoPath` still wins — this only
+  // ever gets consulted where the deterministic answer was absent, which is
+  // exactly where resolution used to return null.
+  //
+  // THE CALLER MUST NAME ITS OWN ROOT. There is deliberately no default here,
+  // and `enumerateSafeRoots()` is deliberately NOT it: that helper enumerates
+  // EVERY agent on the machine, so defaulting to it resolved this agent to a
+  // DIFFERENT agent's repo — whichever one happened to own the most worktrees.
+  // (Measured, not hypothesised: with the default in place, echo resolved to
+  // instar-codey's repo.) A confident wrong repo is worse than the null this
+  // change exists to remove, so absent an explicit root we add no candidate
+  // and the pre-existing chain applies unchanged.
+  for (const repo of discoverInstarRepoFromWorktrees(opts.worktreeRoots ?? [])) {
+    if (!candidateChain.includes(repo)) candidateChain.push(repo);
+  }
+
   if (opts.fallbackChain) {
     candidateChain.push(...opts.fallbackChain);
   } else {

--- a/tests/unit/agent-worktree-repo-discovery.test.ts
+++ b/tests/unit/agent-worktree-repo-discovery.test.ts
@@ -1,0 +1,184 @@
+// safe-git-allow: test fixture cleanup uses fs.rmSync on mkdtemp dirs only.
+/**
+ * Resolving the instar repo by ASKING THE WORKTREES instead of guessing.
+ *
+ * The observed failure, on a real agent, 2026-08-14:
+ *   GET /worktrees/agent-reaper → enumerationOk: false, enumerationFailures: 98,
+ *   "git -C <agent home> worktree list --porcelain → fatal: not a git repository"
+ *   …while 45 worktrees and 27 GB sat under that agent home.
+ *
+ * Two independent blind spots produced it, and BOTH are the same mistake — a
+ * path assumed rather than resolved:
+ *   · the reaper was wired to `config.projectDir`, which is the agent home and
+ *     is not a git repo at all;
+ *   · `resolveDetectorInstarRepo` guessed at `~/Documents/Projects/instar` and
+ *     `~/instar`, neither of which exists on that machine, so it returned null
+ *     and the detector's `if (repo)` guard silently skipped every tick.
+ *
+ * The answer was on disk the whole time: a linked worktree's `.git` is a FILE
+ * naming its owning repo. These tests pin that the worktrees are believed, and
+ * — just as importantly — that a malformed or non-worktree entry names nothing
+ * rather than producing a confident wrong path.
+ *
+ * This is the same defect class the reaper's own header records for 2026-07-29
+ * ("reclaimable: 0 against 73 worktrees"). That fix made the failure VISIBLE;
+ * this one makes resolution actually work.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  discoverInstarRepoFromWorktrees,
+  parseWorktreeGitPointer,
+  resolveDetectorInstarRepo,
+} from '../../src/core/AgentWorktreeDetector.js';
+
+let tmp: string;
+
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wtdisc-')); });
+afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+/** Create a worktree-shaped dir whose `.git` FILE points at `repo`. */
+const makeWorktree = (root: string, slug: string, repo: string): void => {
+  const dir = path.join(root, slug);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.git'),
+    `gitdir: ${path.join(repo, '.git', 'worktrees', slug)}\n`,
+    'utf8',
+  );
+};
+
+describe('parseWorktreeGitPointer', () => {
+  it('reads the owning repo out of a real pointer', () => {
+    const p = `gitdir: ${path.join('/Users/x/.instar/agents/echo/.dev/instar', '.git', 'worktrees', 'my-slug')}\n`;
+    expect(parseWorktreeGitPointer(p)).toBe('/Users/x/.instar/agents/echo/.dev/instar');
+  });
+
+  it('a trailing newline and leading spaces do not change the answer', () => {
+    const p = `  gitdir:   ${path.join('/repo', '.git', 'worktrees', 's')}   \n\n`;
+    expect(parseWorktreeGitPointer(p)).toBe('/repo');
+  });
+
+  // ── Naming nothing is the correct answer for anything unrecognised. A
+  //    confident wrong repo path is what produced the 98 failures.
+  it('CONTROL: content with no gitdir line names nothing', () => {
+    expect(parseWorktreeGitPointer('ref: refs/heads/main\n')).toBeNull();
+  });
+
+  it('CONTROL: a gitdir that is not a worktree pointer names nothing', () => {
+    // A plain submodule/alternate gitdir has no /.git/worktrees/ segment.
+    expect(parseWorktreeGitPointer('gitdir: /repo/.git/modules/sub\n')).toBeNull();
+  });
+
+  it('CONTROL: empty content names nothing', () => {
+    expect(parseWorktreeGitPointer('')).toBeNull();
+  });
+});
+
+describe('discoverInstarRepoFromWorktrees', () => {
+  it('finds the repo that the worktrees actually belong to', () => {
+    const roots = path.join(tmp, '.worktrees');
+    const repo = path.join(tmp, '.dev', 'instar');
+    makeWorktree(roots, 'alpha', repo);
+    makeWorktree(roots, 'beta', repo);
+    expect(discoverInstarRepoFromWorktrees([roots])).toEqual([repo]);
+  });
+
+  /**
+   * NOT a hypothetical. On the agent that surfaced this, `.worktrees/` holds
+   * worktrees of TWO legitimate clones of the same upstream — 29 owned by
+   * `<home>/.build/instar` and 17 by `<home>/.dev/instar`. Both are returned,
+   * most-owned first, and the caller decides. A single-repo consumer therefore
+   * gets the LARGEST coherent set instead of an arbitrary one — which is an
+   * improvement over enumerating nothing, and still not full coverage.
+   */
+  it('several owning repos are all returned, most-owned first', () => {
+    const roots = path.join(tmp, '.worktrees');
+    const bigger = path.join(tmp, 'build-repo');
+    const smaller = path.join(tmp, 'dev-repo');
+    makeWorktree(roots, 'a', bigger);
+    makeWorktree(roots, 'b', bigger);
+    makeWorktree(roots, 'c', smaller);
+    const found = discoverInstarRepoFromWorktrees([roots]);
+    expect(found[0], 'the most-owned repo leads').toBe(bigger);
+    expect(found, 'the smaller repo is NOT dropped — it is the caller\'s to use').toContain(smaller);
+    expect(found).toHaveLength(2);
+  });
+
+  it('reads across several agent roots', () => {
+    const r1 = path.join(tmp, 'agentA', '.worktrees');
+    const r2 = path.join(tmp, 'agentB', '.worktrees');
+    const repo = path.join(tmp, 'shared-repo');
+    makeWorktree(r1, 'a', repo);
+    makeWorktree(r2, 'b', repo);
+    expect(discoverInstarRepoFromWorktrees([r1, r2])).toEqual([repo]);
+  });
+
+  it('CONTROL: no roots, missing roots, and empty roots all yield nothing', () => {
+    expect(discoverInstarRepoFromWorktrees([])).toEqual([]);
+    expect(discoverInstarRepoFromWorktrees([path.join(tmp, 'does-not-exist')])).toEqual([]);
+    const empty = path.join(tmp, 'empty');
+    fs.mkdirSync(empty, { recursive: true });
+    expect(discoverInstarRepoFromWorktrees([empty])).toEqual([]);
+  });
+
+  it('CONTROL: a full clone under .worktrees is skipped — its .git is a DIRECTORY', () => {
+    // A clone sitting in the worktrees area is not a worktree OF anything, and
+    // must not be mistaken for a pointer to itself.
+    const roots = path.join(tmp, '.worktrees');
+    fs.mkdirSync(path.join(roots, 'a-clone', '.git'), { recursive: true });
+    expect(discoverInstarRepoFromWorktrees([roots])).toEqual([]);
+  });
+
+  it('CONTROL: a malformed pointer is skipped without throwing, and the good one still wins', () => {
+    const roots = path.join(tmp, '.worktrees');
+    const repo = path.join(tmp, 'good-repo');
+    fs.mkdirSync(path.join(roots, 'broken'), { recursive: true });
+    fs.writeFileSync(path.join(roots, 'broken', '.git'), 'total nonsense\n', 'utf8');
+    makeWorktree(roots, 'ok', repo);
+    expect(discoverInstarRepoFromWorktrees([roots])).toEqual([repo]);
+  });
+
+  it('CONTROL: a directory with no .git at all is skipped', () => {
+    const roots = path.join(tmp, '.worktrees');
+    fs.mkdirSync(path.join(roots, 'just-a-folder'), { recursive: true });
+    expect(discoverInstarRepoFromWorktrees([roots])).toEqual([]);
+  });
+
+  /**
+   * The hazard my own first version shipped, caught by isolating the variable
+   * rather than by reading the code.
+   *
+   * The first draft defaulted the discovery roots to `enumerateSafeRoots()`,
+   * which enumerates EVERY agent home on the machine. Run on the real box, the
+   * agent asking the question (echo) resolved to a DIFFERENT agent's repo —
+   * whichever owned the most worktrees — because the vote was taken across all
+   * of them. That is a confident wrong path, strictly worse than the null this
+   * change removes: null makes a consumer skip, a wrong repo makes it act.
+   */
+  it('resolution takes NO worktree candidate unless the caller names its own root', () => {
+    const roots = path.join(tmp, 'someone-elses', '.worktrees');
+    makeWorktree(roots, 'a', path.join(tmp, 'someone-elses-repo'));
+    // No worktreeRoots passed and a cwd that is not a checkout: the pre-existing
+    // chain applies and finds nothing. Crucially it does NOT go hunting.
+    const resolved = resolveDetectorInstarRepo({
+      cwd: tmp,
+      configPath: path.join(tmp, 'no-such-config.json'),
+      fallbackChain: [],
+    });
+    expect(resolved, 'must not resolve to a repo the caller never named').toBeNull();
+  });
+
+  it('is bounded — it stops inspecting after the cap', () => {
+    // 45 worktrees is a real number on the agent that surfaced this; the walk
+    // must not grow without limit as that number does.
+    const roots = path.join(tmp, '.worktrees');
+    const repo = path.join(tmp, 'repo');
+    for (let i = 0; i < 12; i++) makeWorktree(roots, `w${i}`, repo);
+    expect(discoverInstarRepoFromWorktrees([roots], { maxWorktrees: 3 })).toEqual([repo]);
+    expect(discoverInstarRepoFromWorktrees([roots], { maxWorktrees: 0 })).toEqual([]);
+  });
+});

--- a/upgrades/next/worktree-repo-discovery.md
+++ b/upgrades/next/worktree-repo-discovery.md
@@ -1,0 +1,69 @@
+# Ask the worktrees which repo owns them
+
+Internal mechanism with **no caller yet**. It ships in `src/`, so it is not internal-only lane material even
+though no agent's behaviour changes — that distinction is the gate's, and it is the right one: shipped
+runtime code is shipped whether or not anything calls it today.
+
+## What to Tell Your User
+
+Nothing changes for you in this release. This adds an internal ability — working out which repository a set
+of working copies belongs to by asking the working copies themselves — and deliberately does not plug it in
+anywhere yet.
+
+It exists because the background housekeeper that reclaims finished working copies had been handed a path
+that is not a repository, so it failed to look 98 times in a row while 27 GB of finished copies accumulated.
+Wiring this in is a separate change that needs review before it goes near anything with permission to delete
+directories.
+
+## Summary of New Capabilities
+
+None that you can use. No new command, endpoint, setting, or behaviour. Two internal helper functions and one
+opt-in parameter that nothing passes yet.
+
+## What Changed
+
+Adds to `src/core/AgentWorktreeDetector.ts`:
+
+- `parseWorktreeGitPointer(contents)` — `gitdir: /repo/.git/worktrees/<slug>` → `/repo`; null for anything
+  that is not exactly that shape.
+- `discoverInstarRepoFromWorktrees(roots, {maxWorktrees})` — reads each worktree's `.git` pointer FILE under
+  the given roots and returns owning repo roots, ordered by how many worktrees name each. No subprocess:
+  reading the pointer is cheaper than `git rev-parse`, cannot block the event loop, and keeps the helper
+  usable from the runtime hot dirs.
+- `ResolveDetectorRepoOptions.worktreeRoots` — when a caller passes ITS OWN `.worktrees` root(s), discovered
+  repos join the candidate chain after the operator-supplied `worktree.repoPath` and before the
+  conventional-location guesses. Omitted ⇒ no candidates ⇒ byte-identical behaviour.
+
+**Why.** On a live agent: `GET /worktrees/agent-reaper` reported `enumerationOk: false`,
+`enumerationFailures: 98`, `git -C <agent home> worktree list --porcelain → fatal: not a git repository`,
+with 45 worktrees and 27 GB unreclaimed. Separately `resolveDetectorInstarRepo` guessed at
+`~/Documents/Projects/instar` and `~/instar`; neither exists there, so it returned null and callers guarded
+with `if (repo)` skipped silently. Both are the same mistake — a path assumed rather than resolved — while a
+linked worktree's `.git` file names its owner outright.
+
+**A misresolution caught during development, now pinned.** The first draft defaulted discovery to
+`enumerateSafeRoots()`, which spans EVERY agent home on the machine; measured on the real box, `echo`
+resolved to `instar-codey`'s repo. A confident wrong repo is worse than null — null makes a consumer skip, a
+wrong repo makes it act. There is now no default: a caller must name its own root.
+
+**Declared limitation.** One agent's `.worktrees/` can legitimately hold worktrees of more than one clone of
+the same upstream (measured: 29 owned by `<home>/.build/instar`, 17 by `<home>/.dev/instar`). Both are
+returned, most-owned first, unmerged; a consumer taking only `[0]` gets the largest coherent set, not full
+coverage. Stated in the function's doc comment.
+
+**Held back deliberately:** pointing `AgentWorktreeReaper` and `OrphanedWorkSentinel` at the resolved repo
+instead of `config.projectDir`. That is runtime code feeding a guard with delete authority, and the
+misresolution above is evidence that getting it wrong is easy — so it goes through the Tier 2 spec +
+operator-approval path as a small focused follow-up, registered as a commitment.
+
+## Evidence
+
+- `tests/unit/agent-worktree-repo-discovery.test.ts` — 14/14 green.
+- Existing detector suites unmodified and green (`AgentWorktreeDetector`, `-attention-wireup`,
+  `WorktreeEnumerationFailureStore`) — 19/19 — which is what shows the old path is untouched when no caller
+  opts in.
+- `npm run lint` chain green; `tsc --noEmit` clean.
+- Real-machine measurement: with the caller's own root, discovery returns both repos in count order; with no
+  root, resolution returns null exactly as before.
+- Side-effects: `upgrades/side-effects/worktree-repo-discovery.md` · ELI16:
+  `docs/specs/worktree-repo-discovery.eli16.md`.

--- a/upgrades/side-effects/worktree-repo-discovery.md
+++ b/upgrades/side-effects/worktree-repo-discovery.md
@@ -1,0 +1,124 @@
+# Side-Effects Review — ask the worktrees which repo owns them
+
+**Version / slug:** `worktree-repo-discovery`
+**Date:** `2026-08-14`
+**Author:** `echo`
+**Second-pass reviewer:** `not required — Tier 1: pure addition with NO caller, therefore no runtime behaviour change on any agent. The consuming wiring is deliberately NOT in this change (see "What is deliberately not here").`
+
+## Summary of the change
+
+Adds two exported helpers to `src/core/AgentWorktreeDetector.ts` and one option on
+`resolveDetectorInstarRepo`:
+
+- `parseWorktreeGitPointer(contents)` — `gitdir: /repo/.git/worktrees/<slug>` → `/repo`, or null for anything
+  that is not exactly that shape.
+- `discoverInstarRepoFromWorktrees(roots, {maxWorktrees})` — reads each worktree's `.git` POINTER FILE under
+  the given roots and returns the owning repo roots, ordered by how many worktrees name each.
+- `ResolveDetectorRepoOptions.worktreeRoots` — when a caller passes ITS OWN `.worktrees` root(s), the
+  discovered repos join the candidate chain after the operator-supplied `worktree.repoPath` and before the
+  conventional-location guesses. Omitted ⇒ no candidates ⇒ byte-identical behaviour.
+
+**Nothing calls it yet.** This lands the mechanism, verified, with the consuming wiring held back.
+
+## Why it exists (observed, not hypothesised)
+
+On a live agent, 2026-08-14: `GET /worktrees/agent-reaper` reported `enumerationOk: false`,
+`enumerationFailures: 98`, error `git -C <agent home> worktree list --porcelain → fatal: not a git
+repository` — while 45 worktrees and **27 GB** sat under that agent home.
+
+Two blind spots, both a path assumed rather than resolved. `resolveDetectorInstarRepo` guessed at
+`~/Documents/Projects/instar` and `~/instar`; neither exists there, so it returned null and the detector's
+`if (repo)` guard silently skipped every tick. Separately the reaper was wired to `config.projectDir`, which
+on that layout is the agent home and is not a repo at all.
+
+The answer was on disk the whole time: a linked worktree's `.git` is a file naming its owning repo. This is
+also the same defect class the reaper's own header records for 2026-07-29 — *"the reaper reported
+`reclaimable: 0` against 73 worktrees because `git -C <path> worktree list` was failing outright."* That fix
+made the failure VISIBLE (`enumerationOk` / `reclaimable: null`), which is how this was found; it did not make
+resolution work.
+
+## Decision-point inventory
+
+- `parseWorktreeGitPointer` — ADD — pure function; returns null on anything unrecognised.
+- `discoverInstarRepoFromWorktrees` — ADD — filesystem reads only, bounded by `maxWorktrees` (default 200).
+- `ResolveDetectorRepoOptions.worktreeRoots` — ADD — inert unless passed.
+- No runtime block/allow decision added or modified. No caller changed.
+
+## 1. Over-block
+
+Not applicable in the gate sense (nothing is blocked), but the analogous failure is **naming a wrong repo**,
+and one real instance was caught during development and is now pinned by a test:
+
+The first draft defaulted the discovery roots to `enumerateSafeRoots()`. That helper enumerates EVERY agent
+home on the machine, so the agent asking the question resolved to a **different agent's repo** — whichever
+owned the most worktrees. Measured on the real box: `echo` resolved to `instar-codey/repo`. A confident wrong
+repo is strictly worse than the null this change removes — null makes a consumer skip, a wrong repo makes it
+act. The API now has NO default: a caller must name its own root, documented on the option itself, and a test
+asserts resolution takes no worktree candidate when none is named.
+
+Other non-answers all return null/empty rather than a guess: a full clone under `.worktrees/` (its `.git` is a
+directory, not a pointer), a malformed pointer, a submodule gitdir with no `/.git/worktrees/` segment, a
+directory with no `.git`, an unreadable file, a missing root.
+
+## 2. Under-block
+
+**One agent's `.worktrees/` can legitimately hold worktrees of MORE THAN ONE clone of the same upstream.**
+Measured on the agent that surfaced this: 29 worktrees owned by `<home>/.build/instar` and 17 by
+`<home>/.dev/instar`. The helper returns BOTH, most-owned first; it does not merge them. A single-repo
+consumer that takes only `[0]` therefore gets the largest coherent set and still will not see the smaller
+repo's worktrees. That is an improvement over enumerating nothing and it is not full coverage — stated in the
+function's own doc comment rather than left to be discovered.
+
+Also unchanged: `resolveInstarRepo` still integrity-validates every candidate, so a discovered path that is
+not a valid instar repo is rejected exactly as before.
+
+## 3. Level-of-abstraction fit
+
+Filesystem reads in a module that already does filesystem enumeration (`enumerateSafeRoots` next door).
+**Deliberately no subprocess** — reading the pointer file is cheaper than `git rev-parse`, cannot block the
+event loop, and keeps the helper usable from the runtime hot dirs where `lint-no-blocking-process-scans`
+applies.
+
+## 4. Signal vs authority compliance
+
+The helper produces CANDIDATES, never an authority. Every candidate is still validated by `resolveInstarRepo`
+before anything believes it. An operator-supplied `worktree.repoPath` continues to win outright.
+
+## 5. Interactions
+
+- `resolveDetectorInstarRepo()` with no `worktreeRoots` is byte-identical to before — verified by the existing
+  detector suites (19/19 green, unmodified).
+- No consumer passes `worktreeRoots` in this change, so no runtime path changes on any agent.
+
+## 6. External surfaces
+
+None. No HTTP route, no config key, no user-visible message. Not an agent capability, so the Agent Awareness
+Standard does not apply.
+
+## 7. Rollback cost
+
+`git revert` of one source file plus one test file. No migration, no state, no deployed artifact, and — since
+nothing calls it — no behaviour to restore.
+
+## What is deliberately NOT here, and why
+
+The consuming wiring (pointing `AgentWorktreeReaper` and `OrphanedWorkSentinel` at the resolved repo instead
+of `config.projectDir`) is **held back for a Tier 2 spec + operator approval.** It is runtime code feeding a
+guard with delete authority, and the cross-agent misresolution above is direct evidence that getting
+resolution wrong here is easy. Landing the mechanism first makes that follow-up a small, focused, individually
+reviewable diff. It is registered as a commitment, not an intention.
+
+## Conclusion
+
+Ship. Verified mechanism, zero runtime effect, one real misresolution caught during development and pinned by
+a test.
+
+## Evidence pointers
+
+- `tests/unit/agent-worktree-repo-discovery.test.ts` — 14/14 green.
+- Existing detector suites unmodified and green: `AgentWorktreeDetector`, `-attention-wireup`,
+  `WorktreeEnumerationFailureStore` — 19/19.
+- Full `npm run lint` chain green; `tsc --noEmit` clean.
+- Real-machine measurement: with the caller's own root, discovery returns
+  `[<home>/.build/instar, <home>/.dev/instar]` (29 and 17 worktrees respectively); with no root, resolution
+  returns null exactly as before.


### PR DESCRIPTION
## What this is

Two helpers plus one inert option that let a caller work out which repo owns a set of worktrees **by asking the worktrees**, instead of guessing at conventional checkout locations.

**Nothing calls it.** The consuming wiring is deliberately held back (see the last section). The existing detector suites are unmodified and green (19/19) — that, not my assertion, is the evidence that no agent's behaviour changes.

## Why — observed, not hypothesised

On a live agent today, `GET /worktrees/agent-reaper`:

```
enabled: true, dryRun: true, reapedLastPass: 0, worktrees: []
enumerationOk: FALSE
enumerationFailures: 98
enumerationError: git -C <agent home> worktree list --porcelain → fatal: not a git repository
```

45 worktrees. **27 GB.** Ninety-eight consecutive attempts, none of which managed to look at anything.

Two blind spots, both the same mistake — *a path assumed rather than resolved*:

- The reaper was wired to `config.projectDir`, which on this layout is the agent home and is not a git repo at all.
- `resolveDetectorInstarRepo` guessed at `~/Documents/Projects/instar` and `~/instar`. Neither exists there, so it returned null and callers guarded by `if (repo)` skipped **silently** — no error, no counter, nothing.

Meanwhile a linked worktree's `.git` is a file that names its owning repo outright. The answer was on disk the whole time.

**Credit where it belongs.** The reaper's status output does not lie, and that is the only reason I found this. It reports `enumerationOk: false` and refuses to give a reclaimable count, with this in its source:

> *"the check could not run" and "there is nothing to reclaim" are the same bytes to a reader and opposite facts … (2026-07-29: the reaper reported `reclaimable: 0` against 73 worktrees because `git -C <path> worktree list` was failing outright).*

That honest-shape fix landed in July and works. **The mis-wired path it was diagnosing was never fixed.** Sixteen days later, same wiring, 98 failures. The loop was closed on the symptom and left open on the cause.

## ELI16

Working copies of the codebase pile up — each is a full source tree. A background housekeeper reclaims the finished ones (merged, nothing uncommitted, nothing running). To list working copies you must ask a *repository*; this one was handed a path that is not a repository, so it looked at nothing, 98 times, while 27 GB accumulated.

The fix is to stop guessing. Every working copy contains a one-line file naming the repository it belongs to. Ask the working copies — they know.

**The bug I put in my own fix.** My first version asked *every* agent on this machine, not just mine. Several agents live here, each with their own working copies, and whichever had the most won the vote — so when I actually ran it, my agent resolved to **a different agent's repository**. That is worse than the original bug: "I don't know" makes a caller skip, a confident wrong answer makes it *act*, on someone else's files. I caught it only because I printed before-and-after side by side instead of reading my own code and believing it. There is now no default at all — a caller must name its own directory, and a test fails if resolution ever wanders somewhere the caller did not name.

My first attempt to check this couldn't have caught anything, either: vitest's working directory *is* a valid checkout, so the resolver short-circuited and printed the same answer for both arms. I had to force a non-repo working directory to isolate the variable.

Full version: `docs/specs/worktree-repo-discovery.eli16.md`.

## A limitation found by measuring, not reasoning

This agent's `.worktrees/` holds worktrees of **two** legitimate clones of the same upstream — 29 owned by `<home>/.build/instar`, 17 by `<home>/.dev/instar`. So "which repo owns the worktrees" has no single answer here.

The helper returns **both**, most-owned first, unmerged. A single-repo consumer taking `[0]` gets the largest coherent set — an improvement over enumerating nothing, and **not** full coverage. That is stated in the function's own doc comment rather than left to be discovered.

## Everything that must return "don't know" rather than a guess

A full clone sitting under `.worktrees/` (its `.git` is a directory, not a pointer) · a malformed pointer · a submodule gitdir with no `/.git/worktrees/` segment · a directory with no `.git` · an unreadable file · a missing root · no roots at all. Each has a test.

No subprocess anywhere: reading the pointer file is cheaper than `git rev-parse`, cannot block the event loop, and keeps the helper usable from the runtime hot dirs.

## Evidence

- `tests/unit/agent-worktree-repo-discovery.test.ts` — **14/14 green.**
- Existing detector suites unmodified and green (`AgentWorktreeDetector`, `-attention-wireup`, `WorktreeEnumerationFailureStore`) — **19/19** — the evidence that the old path is untouched when no caller opts in.
- `npm run lint` chain green; `tsc --noEmit` clean.
- Real-machine measurement: with the caller's own root, discovery returns both repos in count order; with no root, resolution returns null exactly as before.

## What is deliberately NOT here

Pointing `AgentWorktreeReaper` and `OrphanedWorkSentinel` at the resolved repo instead of `config.projectDir`.

The tier signal said Tier 2 on **size** with riskFloor 1 — so by the classifier alone I could have declared Tier 1 and shipped it whole. I split it on my own judgment: that is runtime code feeding a guard with **delete authority**, and my own first draft of this exact resolution produced a wrong answer on the real machine. "Easy to get wrong" is not a worry here, it is measured.

So the wiring goes through the Tier 2 spec + operator approval path as a small, focused, individually reviewable diff on top of this one. Registered as **CMT-1306** (`owner: agent`, `blockedOn: user-authorization`, `actionClass: tier2-spec-approval`) — a durable commitment, not an intention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
