### PR TITLE
docs(spec): DRAFT — wire the worktree reaper to the repo that owns the worktrees

### DIFF
--- a/docs/specs/worktree-reaper-repo-wiring.eli16.md
+++ b/docs/specs/worktree-reaper-repo-wiring.eli16.md
@@ -1,0 +1,76 @@
+# ELI16 — the housekeeper that was handed the wrong address
+
+## The job
+
+Every time I build something, I make a separate working copy of the codebase. They accumulate — each one is a
+full source tree, hundreds of megabytes. So there is a background housekeeper whose job is to spot the ones
+that are finished (the work is merged, nothing uncommitted, nothing running inside) and reclaim the space.
+
+## What went wrong
+
+To list working copies you have to ask a **repository**. The housekeeper was handed my home directory, which
+is not a repository — the actual repository lives in a subfolder. So every attempt came back "that isn't a
+repository", and it reclaimed nothing. Ninety-eight times in a row, while 45 working copies grew to **27
+gigabytes**.
+
+The same wrong address is given to a second watcher, the one that notices when a build died leaving unsaved
+work behind. It has been equally blind.
+
+## The part that already worked, and deserves saying
+
+The housekeeper's status **does not lie about this**. It reports "I could not look" and pointedly refuses to
+give a number, because — in the words of a comment in its own source — *"the check could not run" and "there
+is nothing to reclaim" are the same bytes to a reader and opposite facts.*
+
+That honesty was added last month, after this exact thing happened with 73 working copies. It is the only
+reason anyone noticed this time. What was fixed then was the **reporting**. What was never fixed was the
+**wrong address**, which is what this change is for.
+
+## The fix
+
+A working copy contains a small file naming the repository it belongs to. So instead of being told an address,
+the housekeeper can ask its own working copies where they came from. That ability was built and merged
+separately, deliberately switched off, with nothing calling it. This change is the part that plugs it in.
+
+If the answer cannot be worked out, it falls back to exactly what it does today — so an agent where this makes
+no difference sees no difference.
+
+## Why this needs a person to approve it
+
+Two reasons, and the second is the honest one.
+
+First, this hands a new address to a background process that has permission to **delete directories**. The
+rules about *what* it may delete are untouched — merged, clean, nothing running — so a wrong address cannot
+make it delete something in use. But it decides which set of things it looks at, and that deserves a second
+pair of eyes.
+
+Second: **my own first attempt at this got it wrong.** I wrote it so that it asked every agent on the machine
+rather than just me — and when I actually ran it, my agent resolved to *a different agent's repository*. That
+is worse than the original bug, because "I don't know" makes something skip, while a confident wrong answer
+makes it act. I caught it by running it and printing the answers side by side, not by reading my own code.
+"This is easy to get wrong" is not a caution I am adding for form's sake; it is what my first draft actually
+did.
+
+The automated check would have let me ship this without any of this paperwork. I asked for the heavier path
+because of that measured mistake, not because a rule required it.
+
+## Something I found and did not fix
+
+While checking, I noticed the health display has a state meaning "this guard cannot see" — and a guard in
+trial mode can never reach it, because trial mode is checked first. So a guard that is both in trial mode and
+blind is displayed simply as "in trial mode". The blindness is there, but one level down.
+
+That matters because trial mode is exactly when you are supposed to be finding out whether the guard works
+before you switch it on. A guard blind for its whole trial looks like a clean trial.
+
+I have not changed it. The person who wrote that line knew — there is a comment accepting the same trade for a
+different signal — and reordering it would change how guards are classified everywhere, possibly setting off
+new alerts on other machines. That is a decision for the operator, so it is written up as a question rather
+than smuggled in with the fix.
+
+## What is not covered
+
+This agent's working copies turn out to belong to **two** different clones of the same project — 29 to one, 17
+to the other. The housekeeper only understands one repository at a time, so it will handle the larger group
+and still not see the smaller one. Better than nothing at all, and not everything, which is why it is written
+down here rather than left to be discovered later.

--- a/docs/specs/worktree-reaper-repo-wiring.md
+++ b/docs/specs/worktree-reaper-repo-wiring.md
@@ -27,8 +27,33 @@ enumerationError: git -C /Users/<user>/.instar/agents/echo worktree list --porce
                   → fatal: not a git repository (or any of the parent directories): .git
 ```
 
-45 worktrees under that agent home. **27 GB.** Ninety-eight consecutive passes, none of which enumerated
-anything.
+46 worktrees under that agent home, **27 GB** total. Ninety-eight consecutive passes, none of which
+enumerated anything.
+
+### 1a. What that failure actually costs — measured, after I overstated it
+
+I first wrote this up as "45 worktrees and 27 GB unreclaimed," which is the total on disk and is **not** what
+a working reaper would reclaim. Measured across all 46:
+
+| state | count | reaper's disposition |
+|---|---|---|
+| clean, branch merged (incl. squash-merged PRs) | **14** | reclaim-eligible |
+| clean, genuinely unmerged | 12 | kept — by design |
+| uncommitted changes | 17 | kept — never reaped |
+| detached HEAD | 3 | kept |
+
+So the honest cost of the blind reaper is roughly **14 worktrees, on the order of 8 GB** — not 27 GB. The
+other 32 are work-in-progress and unmerged branches that the reaper protects on purpose; that is the guard
+working, not failing.
+
+Worth recording how I got the number wrong twice: my first pass tested "is HEAD an ancestor of origin/main"
+and returned **3**, because that test cannot see a squash-merged branch — and squash-merge is a normal path
+here. Adding merged-PR state (which is precisely what the reaper's own `githubMergeCheck` does, and which I
+had ignored while measuring the thing it exists for) moved it to 14. The overstatement and the
+understatement had the same root: quoting a number before checking what it implied.
+
+The defect is real and worth fixing at 14 worktrees. It is not worth fixing on a 27 GB claim, and a spec that
+opens with an inflated number invites the reviewer to discount everything after it.
 
 `src/commands/server.ts` constructs both consumers with `instarRepo: config.projectDir`. On this layout
 `projectDir` **is the agent home**, and an agent home is not a git repo — the worktrees belong to

--- a/docs/specs/worktree-reaper-repo-wiring.md
+++ b/docs/specs/worktree-reaper-repo-wiring.md
@@ -1,0 +1,157 @@
+---
+title: "Wire the worktree reaper and orphaned-work sentinel to the repo that owns the worktrees: Spec"
+slug: "worktree-reaper-repo-wiring"
+author: "echo"
+parent-principle: "Enabled Is Not Running — a guard that cannot look must not read as a guard that looked and found nothing"
+eli16-overview: "worktree-reaper-repo-wiring.eli16.md"
+status: "draft"
+review-convergence: null
+review-iterations: 0
+approved: false
+approved-by: "NOT APPROVED — awaiting operator. This spec exists because the change is Tier 2 by my own declaration: runtime code feeding a guard with delete authority. I am not self-approving it, and the tier signal (riskFloor 1) would have let me ship it as Tier 1 without this document."
+parent-spec: "AGENT-WORKTREE-CONVENTION-SPEC.md (where worktrees live); the AgentWorktreeReaper's own honest-reporting contract (enumerationOk / reclaimable:null, 2026-07-29)"
+commitment: "CMT-1306"
+---
+
+# Wire the worktree reaper to the repo that owns the worktrees
+
+## 1. The observed failure
+
+On a live development agent, 2026-08-14, `GET /worktrees/agent-reaper`:
+
+```
+enabled: true, dryRun: true, reapedLastPass: 0, worktrees: []
+enumerationOk: FALSE
+enumerationFailures: 98
+enumerationError: git -C /Users/<user>/.instar/agents/echo worktree list --porcelain
+                  → fatal: not a git repository (or any of the parent directories): .git
+```
+
+45 worktrees under that agent home. **27 GB.** Ninety-eight consecutive passes, none of which enumerated
+anything.
+
+`src/commands/server.ts` constructs both consumers with `instarRepo: config.projectDir`. On this layout
+`projectDir` **is the agent home**, and an agent home is not a git repo — the worktrees belong to
+`<agent_home>/.dev/instar` (and, here, also `<agent_home>/.build/instar`). The same wiring is used by
+`OrphanedWorkSentinel`, which therefore has the same blind spot.
+
+**This already happened once.** The reaper's own source records it:
+
+> *"That collapse is what let a mis-wired repo path sit behind a clean bill of health while real worktrees
+> accumulated (2026-07-29: the reaper reported `reclaimable: 0` against 73 worktrees because
+> `git -C <path> worktree list` was failing outright)."*
+
+The fix that shipped then was the **honest reporting** (`enumerationOk: false` + `reclaimable: null`), and it
+works — it is the only reason this was found. The mis-wired path itself was never corrected. Sixteen days
+later the same wiring is failing 98 times. *The loop was closed on the symptom and left open on the cause.*
+
+## 2. What is already merged (not in scope here)
+
+PR #1882 landed the mechanism, inert:
+
+- `parseWorktreeGitPointer(contents)` — a linked worktree's `.git` is a FILE naming its owning repo.
+- `discoverInstarRepoFromWorktrees(roots, {maxWorktrees})` — reads those pointers, returns owning repos
+  ordered by how many worktrees name each. No subprocess.
+- `ResolveDetectorRepoOptions.worktreeRoots` — inert unless a caller passes its own root.
+
+Nothing calls it. That was deliberate: the consuming half is this spec.
+
+## 3. The proposed change
+
+In `src/commands/server.ts`, resolve once and use for both consumers:
+
+```ts
+const _agentWorktreeRepo =
+  resolveDetectorInstarRepo({ worktreeRoots: [_agentWorktreesDir] }) ?? config.projectDir;
+```
+
+- `AgentWorktreeReaper` — `instarRepo: _agentWorktreeRepo`
+- `OrphanedWorkSentinel` — `instarRepo: _agentWorktreeRepo`
+
+`config.projectDir` remains the fallback, so the ordinary layout (where `projectDir` IS the repo) is
+unchanged, and an agent where discovery finds nothing behaves exactly as today.
+
+## 4. Why this is Tier 2 and not Tier 1
+
+The classifier says `riskFloor: 1` — no safety-invariant path is touched — so this could have shipped as a
+Tier 1 declaration. I am declaring Tier 2 on consequence:
+
+1. It is runtime code feeding a guard that **deletes directories**.
+2. **My own first draft of this exact resolution produced a wrong answer on the real machine.** It defaulted
+   discovery to `enumerateSafeRoots()`, which spans every agent home; measured, `echo` resolved to
+   `instar-codey`'s repo. "Easy to get wrong" is not a worry here — it is the observed behaviour of my first
+   attempt. That is the single strongest argument for a second pair of eyes.
+
+## 5. Safety analysis
+
+**The reclaim predicates are untouched.** The reaper only reclaims worktrees that are merged + clean + not in
+use, with a per-path breaker; none of that changes. What changes is which repo it asks. A wrong answer
+therefore cannot cause an unsafe reclaim of a *dirty* or *in-use* worktree — it can only cause it to look at
+the wrong set.
+
+**Cross-agent misresolution is closed by construction:** there is no default root; a caller must name its own,
+documented on the option and pinned by a test.
+
+**Every unresolvable case yields null,** and null falls back to today's behaviour: a full clone under
+`.worktrees/`, a malformed pointer, a submodule gitdir, a missing `.git`, an unreadable file, a missing root.
+Candidates are still integrity-validated by `resolveInstarRepo` before use.
+
+**Declared limitation — partial coverage.** One agent's `.worktrees/` can hold worktrees of more than one
+clone of the same upstream (measured here: 29 owned by `.build/instar`, 17 by `.dev/instar`). Discovery
+returns both, most-owned first; a single-repo consumer takes `[0]` and therefore sees the **largest coherent
+set, not all of them**. This is an improvement over enumerating nothing and it is not full coverage. Closing
+it means teaching the reaper to iterate several repos, which changes its contract — explicitly out of scope
+here and named rather than implied.
+
+## 6. Open question for the operator (§6a) — blindness is masked during dry-run
+
+Found while verifying the above, and I have NOT acted on it.
+
+`guardPostureView` classification order:
+
+```
+} else if (dryRun && configEnabled === true) { effective = 'on-dry-run'; }
+else if (stale)                              { effective = 'on-stale'; }
+else if (verdictUnknown === true)            { effective = 'on-blind'; }   // unreachable while dryRun
+```
+
+The codebase **has** an `on-blind` state for exactly "the guard cannot see." A dry-run guard can never reach
+it. Our reaper is dry-run AND blind, so `/guards` headlines it `on-dry-run`, `divergence: none`, with the
+blindness only in a nested `runtime` field.
+
+Once **armed** (`dryRun:false`), a blind guard IS correctly classified `on-blind` — so the masking is specific
+to the soak period, which is precisely when you are meant to be learning whether the guard works before you
+arm it. A guard blind through its entire soak produces a clean-looking soak and is then armed on that
+evidence. That is how 98 failures stayed quiet.
+
+**Fair reading of the existing code:** the author knew and accepted it — the comment on that line says
+*"stale stays visible in the runtime block."* Teeth and sight are orthogonal, so I think this is worth
+changing, but reordering would alter classification fleet-wide and could raise new alerts on other agents.
+**That is an operator decision, not mine**, and it is why it is a question in this spec rather than a diff.
+
+## 7. Test plan (all three tiers)
+
+- **Unit** — already merged with the mechanism: 14 tests incl. the cross-agent misresolution and every
+  "must return don't-know" case.
+- **Unit (new)** — the resolution helper used by the server wiring: given a fixture agent home whose
+  worktrees point at a repo, the resolved value is that repo; given none, it is `config.projectDir`.
+- **Integration** — `GET /worktrees/agent-reaper` reports `enumerationOk: true` on a fixture where the
+  worktrees' owning repo is not `projectDir`. This is the test that would have failed for 98 passes.
+- **E2E** — the reaper's guard row reaches `on-dry-run` with **no** `verdictUnknown` on that fixture.
+
+The integration test is the important one: it asserts the guard can *look*, which is the property that was
+missing and which no existing test covered.
+
+## 8. Rollback
+
+Revert one hunk in `src/commands/server.ts`. No migration, no state, no persisted artifact. The mechanism it
+calls is already merged and inert, so reverting the wiring restores today's behaviour exactly.
+
+## 9. What I want from the operator
+
+1. Approve (or reject) the wiring in §3.
+2. A ruling on §6a — reorder so blindness is not masked by dry-run, or leave it and accept the nested-field
+   reporting.
+
+Nothing else is blocked on you: the mechanism is merged, the tests are written, and the reaper remains in
+dry-run either way.


### PR DESCRIPTION
**NOT APPROVED — draft for your review.** Tracked as CMT-1306.

## The failure

`GET /worktrees/agent-reaper` on a live agent: `enumerationOk: false`, **98 consecutive enumeration failures**, `git -C <agent home> worktree list --porcelain → fatal: not a git repository`. Both `AgentWorktreeReaper` and `OrphanedWorkSentinel` are wired with `instarRepo: config.projectDir`, which on this layout is the agent home — not a repo. The worktrees belong to `<agent_home>/.dev/instar`.

**This already happened.** The reaper's own source records a 73-worktree instance on 2026-07-29. The fix that shipped then was the honest reporting (`enumerationOk` / `reclaimable: null`) — it works, and it is the only reason I found this. The mis-wired path was never corrected.

## ELI16

Every time I build something I make a separate working copy of the codebase. They pile up — each is a full source tree. A background housekeeper is supposed to spot the finished ones (work merged, nothing uncommitted, nothing running inside) and reclaim the space.

To list working copies you have to ask a **repository**. This housekeeper was handed my home directory, which is not a repository — the real one lives in a subfolder. So every attempt came back "that isn't a repository" and it reclaimed nothing, ninety-eight times running. The same wrong address is given to a second watcher, the one that notices when a build died leaving unsaved work behind. It has been equally blind.

The part that already worked deserves saying: the housekeeper's status **does not lie**. It reports "I could not look" and refuses to give a number, because — in a comment in its own source — *"the check could not run" and "there is nothing to reclaim" are the same bytes to a reader and opposite facts.* That honesty was added last month after this happened with 73 working copies, and it is the only reason anyone noticed this time. What got fixed then was the reporting. What was never fixed was the wrong address.

The fix: a working copy contains a small file naming the repository it came from, so the housekeeper can ask its own working copies instead of being told an address. That ability is already merged and switched off (#1882); this spec is the part that plugs it in, with a fallback to today's behaviour when the answer cannot be worked out.

Why a person has to approve it: it hands a new address to a background process that can **delete directories**. The rules about what it may delete are untouched — merged, clean, nothing running — so a wrong address cannot make it delete something in use; it only changes which set it looks at. But **my own first attempt at this got it wrong**: I wrote it to ask every agent on the machine rather than just me, and when I ran it my agent resolved to *a different agent's repository*. That is worse than the original bug, because "I don't know" makes something skip while a confident wrong answer makes it act. The automated check would have let me ship this with no spec at all; I asked for the heavier path because of that measured mistake, not because a rule required it.

Full version: `docs/specs/worktree-reaper-repo-wiring.eli16.md`.

## What it actually costs — I overstated this first

I opened the draft with "45 worktrees and 27 GB unreclaimed." That is the total on disk, not what a working reaper would reclaim. Measured across all 46:

| state | count | reaper's disposition |
|---|---|---|
| clean, branch merged (incl. squash-merged PRs) | **14** | reclaim-eligible |
| clean, genuinely unmerged | 12 | kept — by design |
| uncommitted changes | 17 | kept — never reaped |
| detached HEAD | 3 | kept |

Honest cost: **~14 worktrees, order 8 GB** — not 27 GB. The other 32 are work-in-progress and unmerged branches the reaper protects on purpose.

I got it wrong twice in opposite directions. My first measurement asked "is HEAD an ancestor of origin/main" → **3**, which cannot see a squash-merged branch, and squash-merge is a normal path here. Adding merged-PR state — precisely what the reaper's own `githubMergeCheck` does, and which I had ignored while measuring the thing it exists for — moved it to 14. Both errors had one root: quoting a number before checking what it implied.

## Why this is Tier 2 by my declaration, not the classifier's

The signal says `riskFloor: 1` and would have allowed shipping it as Tier 1 with no spec. I declared Tier 2 because it is runtime code feeding a guard with **delete authority**, and my own first draft of this exact resolution produced a wrong answer on the real machine (see ELI16 above). "Easy to get wrong" here is measured, not assumed.

The mechanism is already merged and inert (#1882). This spec is only the consuming wiring.

## One question I deliberately did not decide (§6a)

`guardPostureView` tests `dryRun` **before** `on-blind`, so a guard that is both toothless and sightless headlines as `on-dry-run` with blindness only in a nested field. Once armed it IS classified `on-blind` — so the masking is specific to the soak period, which is exactly when you are meant to learn whether the guard works before arming it.

The author knew (a comment accepts the same trade for staleness), and reordering would change classification fleet-wide and could raise new alerts on other agents. **That is your call, not mine.**

## What I want

1. Approve or reject the wiring (§3).
2. Rule on §6a.

Nothing is blocked on you meanwhile: the mechanism is merged, tests written, reaper stays in dry-run either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
