### PR TITLE
fix(lint): dev-agent gate check follows a local alias

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T23-46-43-700Z-dev-agent-gate-alias.json
+++ b/.instar/instar-dev-decisions/2026-08-14T23-46-43-700Z-dev-agent-gate-alias.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T23:46:43.700Z",
+  "slug": "dev-agent-gate-alias",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 46,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-dev-agent-dark-gate.js"
+    ],
+    "addedLines": 45,
+    "deletedLines": 1
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/dev-agent-gate-alias.eli16.md
+++ b/docs/specs/dev-agent-gate-alias.eli16.md
@@ -1,0 +1,78 @@
+# ELI16 — the check that only recognised one way of saying it
+
+## The rule
+
+Some features are supposed to be live on a **development** agent and dark everywhere else, so they get
+exercised before they reach the fleet. There is one shared helper that answers "is this a development
+agent?", and everything is supposed to route through it.
+
+If people hand-roll that decision themselves instead, the answer drifts — different code makes the call
+differently, and features that were supposed to be exercised on a dev box quietly aren't. So a lint fails
+the build when it sees the decision made by hand.
+
+## What it was looking for
+
+Exactly this shape:
+
+```ts
+const enabled = cfg?.enabled ?? !!config.developmentAgent;
+```
+
+The `??` means "use the explicit setting if there is one, otherwise fall back to whether this is a
+development agent". The lint looked for `developmentAgent` written immediately after the `??`.
+
+## What it missed
+
+You do not have to write it there:
+
+```ts
+const da = config.developmentAgent;
+return enabled ?? !!da;
+```
+
+Same decision, made by hand, in the same file — invisible to the check, because the words
+`developmentAgent` and `??` are now on different lines.
+
+Nothing about that is sneaky. Pulling a value into a named variable is ordinary tidying, which is what
+makes it worth closing: someone could step around this guard while making the code nicer, and nothing
+would say a word.
+
+Worth being fair to whoever wrote it: the lint's own header said plainly that it could not catch aliases.
+That was honest and it was true. It is closed now because the specific shape that actually shows up is
+cheap to catch — not because the warning was wrong.
+
+## What changed
+
+Before checking a line, the lint now reads the file for any local variable that was set from
+`config.developmentAgent`, and then treats `?? !!thatVariable` the same as the direct form.
+
+## Why it won't start failing builds it shouldn't
+
+This lint fails builds, so wrongly flagging good code is worse than missing a case. Four things are
+deliberate, each with a test:
+
+1. **Only that value counts.** A variable set from anything else is fine.
+2. **Whole words only.** `config.developmentAgentName` is a different thing and isn't flagged — the same
+   boundary that already applied when written directly.
+3. **Reading the flag is still allowed.** `const da = config.developmentAgent; return da ? "dev" : "fleet"`
+   is untouched. Using the value is fine; hand-rolling the *fallback decision* is what's banned.
+4. **Comments don't count.** The lint already ignored commented-out code, and the new alias-reading uses
+   the same stripped view, so a commented declaration binds nothing.
+
+Aliases are also read per file, so one file's variable can never affect another's.
+
+## What it still can't see, stated plainly
+
+- A **helper function** that wraps the check (`isDevAgent(config)`).
+- An alias imported from **another file**.
+- Anything needing real dataflow analysis to work out.
+
+Guessing at those would flag correct code. So the original warning is narrowed rather than deleted: it can
+no longer catch *arbitrary* aliases, having gained the ordinary local one.
+
+## How you know it works
+
+The tests were written before the fix and run against the old lint first: three of the thirty-one fail
+without the change. The other twenty-eight — including four new ones that exist purely to prove it stays
+quiet where it should — pass either way. Against the real codebase the lint reports clean, so nothing that
+exists today is newly blocked.

--- a/scripts/lint-dev-agent-dark-gate.js
+++ b/scripts/lint-dev-agent-dark-gate.js
@@ -72,6 +72,49 @@ const FUNNEL_ALLOWLIST = new Set([
 // in the spec's Layer-1 "misses" row.)
 const HANDROLLED_GATE =
   /\?\?\s*(?:!{1,2}\s*|Boolean\s*\(\s*)?[A-Za-z_$][\w$.?]*(?:\.developmentAgent\b|\[\s*['"]developmentAgent['"]\s*\])/;
+
+// ── 2026-08-14: the gate value does not have to be spelled at the `??`. ──
+// The matcher above requires `.developmentAgent` LITERALLY after the `??`, so
+// lifting it into a local const first walks past it while resolving the gate by
+// hand exactly as before:
+//     const da = config.developmentAgent;
+//     return enabled ?? !!da;              // exit 0 against the old matcher
+// The header's declared limit ("cannot catch arbitrary aliases/wrapper helpers")
+// was honest; this closes the LOCAL-CONST half of it, which is the shape a
+// rename-defeat audit actually reproduced.
+//
+// Deliberately NOT closed, so it stays stated rather than implied: wrapper
+// helpers (`isDevAgent(config)`), cross-module aliases, and any value that needs
+// dataflow to resolve. Guessing at those would over-match, and this lint fails
+// builds — flagging correct code is the more expensive error here.
+//
+// Scope-bounded on purpose: an alias binds only within its own file, so the map
+// is rebuilt per file and never leaks between them.
+const ALIAS_DECL =
+  /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::\s*[^=]+?)?=\s*[A-Za-z_$][\w$.?]*(?:\.developmentAgent\b|\[\s*['"]developmentAgent['"]\s*\])/;
+
+/**
+ * Local identifiers bound to `<expr>.developmentAgent` in THIS file.
+ * `config.developmentAgentName` does not qualify — the `\b` keeps the boundary
+ * through the alias exactly as it holds at the direct callsite.
+ */
+function collectDevAgentAliases(lines) {
+  const names = new Set();
+  for (const line of lines) {
+    const code = codeOnly(line);
+    if (code === null) continue;
+    const m = ALIAS_DECL.exec(code);
+    if (m) names.add(m[1]);
+  }
+  return names;
+}
+
+/** `?? [!! | Boolean(] <alias>` — the aliased spelling of the same hand-rolled gate. */
+function aliasGateMatcher(names) {
+  if (names.size === 0) return null;
+  const alts = [...names].join('|');
+  return new RegExp(`\\?\\?\\s*(?:!{1,2}\\s*|Boolean\\s*\\(\\s*)?(?:${alts})\\b`);
+}
 // A comment referencing the gate convention (for assertion B).
 const GATE_MARKER = /developmentAgent/i;
 const GATE_MARKER_QUALIFIER = /\b(dark|gate)\b/i;
@@ -171,10 +214,11 @@ for (const file of resolveTargets()) {
 
   // ── Assertion A: funnel ──
   if (!FUNNEL_ALLOWLIST.has(rel)) {
+    const aliasGate = aliasGateMatcher(collectDevAgentAliases(lines));
     lines.forEach((line, i) => {
       const code = codeOnly(line);
       if (code === null) return;
-      if (HANDROLLED_GATE.test(code)) {
+      if (HANDROLLED_GATE.test(code) || (aliasGate !== null && aliasGate.test(code))) {
         violations.push({
           file: rel, line: i + 1, kind: 'A: hand-rolled gate',
           text: line.trim(),

--- a/tests/unit/lint-dev-agent-dark-gate.test.ts
+++ b/tests/unit/lint-dev-agent-dark-gate.test.ts
@@ -632,3 +632,95 @@ describe('lint-dev-agent-dark-gate', () => {
     }
   });
 });
+
+/**
+ * Assertion A: the gate value does not have to be spelled at the `??`.
+ *
+ * The shipped matcher requires `.developmentAgent` (or `['developmentAgent']`)
+ * LITERALLY after the `??`. Lifting it into a local const first walks past it —
+ * while resolving the gate by hand exactly as before. The header declared this
+ * limit honestly ("cannot catch arbitrary aliases/wrapper helpers"); instar-codey
+ * reproduced it while auditing rename-defeatable checks:
+ *
+ *     const da = config.developmentAgent;
+ *     return enabled ?? !!da;          // exit 0 against the shipped lint
+ *
+ * Measured before any edit, with a positive control: the direct form exits 1, the
+ * aliased form exits 0. The control firing is what makes the evasion verdict mean
+ * something.
+ *
+ * Scope is deliberately the one instar-codey scoped — LOCAL constant aliases of
+ * `<expr>.developmentAgent` feeding a `??`. Not wrapper helpers, not dataflow,
+ * not cross-module. This lint fails builds, so over-matching is the more
+ * expensive error.
+ */
+describe('Assertion A — the gate value one step away', () => {
+  const withFixture = (body: string, run: (file: string) => void): void => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'darkgate-alias-'));
+    const f = path.join(dir, 'someFeature.ts');
+    fs.writeFileSync(f, body);
+    try { run(f); } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/lint-dev-agent-dark-gate.test.ts' });
+    }
+  };
+
+  it('DEFECT: a local const alias of config.developmentAgent is caught', () => {
+    withFixture(
+      'export function f(cfg, config) {\n  const da = config.developmentAgent;\n  const enabled = cfg?.enabled ?? !!da;\n  return enabled;\n}\n',
+      (f) => {
+        const { code, out } = runLint([f]);
+        expect(code, `expected a violation; output was:\n${out}`).toBe(1);
+        expect(out).toContain('A: hand-rolled gate');
+      },
+    );
+  });
+
+  it('DEFECT: the bracket-access alias is caught too', () => {
+    withFixture(
+      "export function f(cfg, config) {\n  const da = config['developmentAgent'];\n  return cfg?.enabled ?? !!da;\n}\n",
+      (f) => expect(runLint([f]).code).toBe(1),
+    );
+  });
+
+  it('DEFECT: Boolean(alias) is caught, matching the direct form it mirrors', () => {
+    withFixture(
+      'export function f(cfg, config) {\n  const da = config.developmentAgent;\n  return cfg?.enabled ?? Boolean(da);\n}\n',
+      (f) => expect(runLint([f]).code).toBe(1),
+    );
+  });
+
+  // ── The other direction. This lint fails builds; flagging correct code costs more.
+  it('CONTROL: an alias of something ELSE is not flagged', () => {
+    withFixture(
+      'export function f(cfg, config) {\n  const other = config.somethingElse;\n  return cfg?.enabled ?? !!other;\n}\n',
+      (f) => {
+        const { code, out } = runLint([f]);
+        expect(code, `only a developmentAgent alias is a hand-rolled gate; output:\n${out}`).toBe(0);
+      },
+    );
+  });
+
+  it('CONTROL: a comment describing the aliased pattern is not flagged', () => {
+    withFixture(
+      '// e.g. const da = config.developmentAgent; enabled ?? !!da  (dev-gate)\nexport const x = 1;\n',
+      (f) => expect(runLint([f]).code).toBe(0),
+    );
+  });
+
+  it('CONTROL: a name that merely LOOKS like the gate is not flagged', () => {
+    // `developmentAgentName` is not `developmentAgent`; the boundary must hold
+    // through the alias just as it does at the direct callsite.
+    withFixture(
+      'export function f(cfg, config) {\n  const da = config.developmentAgentName;\n  return cfg?.enabled ?? !!da;\n}\n',
+      (f) => expect(runLint([f]).code).toBe(0),
+    );
+  });
+
+  it('CONTROL: an alias never used at a `??` is not flagged', () => {
+    // Reading the flag is legal. Resolving the GATE by hand is what is banned.
+    withFixture(
+      'export function f(config) {\n  const da = config.developmentAgent;\n  return da ? "dev" : "fleet";\n}\n',
+      (f) => expect(runLint([f]).code).toBe(0),
+    );
+  });
+});

--- a/upgrades/next/dev-agent-gate-alias.md
+++ b/upgrades/next/dev-agent-gate-alias.md
@@ -1,0 +1,42 @@
+<!-- internal-only -->
+
+# dev-agent gate check follows a local alias
+
+Developer tooling only — a CI lint. No runtime path, no route, no config key, no user-visible surface, so
+this fragment takes the internal-only lane.
+
+## What Changed
+
+`scripts/lint-dev-agent-dark-gate.js` assertion A bans hand-rolled dev-agent gate resolution outside
+`resolveDevAgentGate`. The matcher required `.developmentAgent` **literally after the `??`**, so lifting the
+value into a local const first walked past it while resolving the gate by hand exactly as before:
+
+```ts
+const da = config.developmentAgent;
+return enabled ?? !!da;          // exit 0 against the shipped lint
+```
+
+instar-codey reproduced this while auditing rename-defeatable checks and pre-scoped the remedy ("low FP for
+simple local alias folding around `developmentAgent` feeding `??`"). That is the scope implemented: local
+`const`/`let`/`var` aliases, collected per file, matched at `?? [!!|Boolean(] <alias>`.
+
+The lint's header already declared this limit ("cannot catch arbitrary aliases/wrapper helpers"). It is
+closed for the shape that actually occurs; the declaration was honest, not wrong.
+
+Four controls keep it from failing correct builds, each with a test: only a `developmentAgent` binding
+counts; matching is whole-word so `developmentAgentName` is untouched; an alias never used at a `??` is
+legal (reading the flag is fine — hand-rolling the fallback is what is banned); and a commented-out
+declaration binds nothing.
+
+Still not caught, stated in the source: wrapper helpers, cross-module aliases, and anything needing
+dataflow. Guessing at those would over-match a build-failing lint.
+
+## Evidence
+
+- `tests/unit/lint-dev-agent-dark-gate.test.ts` — **31/31 green** (24 existing + 7 added).
+- Negative control: tests written BEFORE the fix, run against the shipped lint — **3 of 31 fail** (const
+  alias, bracket-access alias, `Boolean(alias)`). The other 28 pass both ways.
+- Reproduced by hand first with a positive control: direct form exits 1, aliased form exits 0.
+- Real-tree verdict: `node scripts/lint-dev-agent-dark-gate.js` → exit 0, no new flags.
+- Full `npm run lint` chain green.
+- Side-effects: `upgrades/side-effects/dev-agent-gate-alias.md` · ELI16: `docs/specs/dev-agent-gate-alias.eli16.md`.

--- a/upgrades/side-effects/dev-agent-gate-alias.md
+++ b/upgrades/side-effects/dev-agent-gate-alias.md
@@ -1,0 +1,104 @@
+# Side-Effects Review — dev-agent gate check follows a local alias
+
+**Version / slug:** `dev-agent-gate-alias`
+**Date:** `2026-08-14`
+**Author:** `echo`
+**Second-pass reviewer:** `not required — Tier 1 (CI-only lint script; no runtime path). The rule is unchanged; the check now recognises one more spelling of the thing it already forbids.`
+
+## Summary of the change
+
+`scripts/lint-dev-agent-dark-gate.js` assertion A bans hand-rolled dev-agent gate resolution — anything
+resolving `enabled ?? !!<x>.developmentAgent` outside `resolveDevAgentGate`. The matcher required
+`.developmentAgent` (or `['developmentAgent']`) **literally after the `??`**, so lifting the value into a
+local const first walked past it while resolving the gate by hand exactly as before:
+
+```ts
+const da = config.developmentAgent;
+return enabled ?? !!da;          // exit 0 against the shipped lint
+```
+
+instar-codey reproduced this while auditing rename-defeatable checks and scoped the remedy: *"low for
+simple local alias folding around `developmentAgent` feeding `??`."* That is the scope implemented — local
+`const`/`let`/`var` aliases only, rebuilt per file.
+
+The lint's header **already declared this limit** ("cannot catch arbitrary aliases/wrapper helpers"). Like
+the journal-actuation ban earlier today, it is closed because the declared gap is cheap to close for the
+shape that actually occurs, not because the declaration was dishonest.
+
+## Decision-point inventory
+
+- `collectDevAgentAliases(lines)` — ADD — per-file identifiers bound to `<expr>.developmentAgent`.
+- `aliasGateMatcher(names)` — ADD — `?? [!!|Boolean(] <alias>`; returns null when there are no aliases, so
+  a file without one is byte-identical to before.
+- Assertion A predicate — WIDEN — `HANDROLLED_GATE || aliasGate`.
+- Assertions B and C, the funnel allowlist, the comment-stripping (`codeOnly`), and the marker logic are
+  untouched.
+- No runtime block/allow decision added or modified. CI-time only.
+
+## 1. Over-block
+
+The failure that matters: this lint fails builds, so flagging correct code costs more than missing a case.
+Four controls, each with a test:
+
+- **An alias of something else** (`config.somethingElse`) is not flagged — only `developmentAgent` binds.
+- **A look-alike name** (`config.developmentAgentName`) is not flagged: the `\b` holds through the alias
+  exactly as it holds at the direct callsite.
+- **An alias never used at a `??`** is not flagged. *Reading* the flag is legal; resolving the GATE by hand
+  is what is banned, and that distinction is preserved.
+- **A comment describing the aliased pattern** is not flagged — `codeOnly` already strips comments and the
+  alias collector runs on the same stripped lines, so a commented-out declaration binds nothing.
+
+Scope is per-file by construction: aliases cannot leak between files.
+
+Verified against the real tree: exit 0 — the widened check introduces **no new flags on existing code**.
+
+## 2. Under-block
+
+Stated in the source rather than implied:
+
+- **Wrapper helpers** (`isDevAgent(config)`) — still invisible.
+- **Cross-module aliases** — an alias exported from another file is not followed.
+- **Anything needing dataflow** to resolve.
+
+Guessing at those would over-match. The header's original claim is narrowed, not erased: it now cannot
+catch *arbitrary* aliases, having gained the local-const case.
+
+## 3. Level-of-abstraction fit
+
+Same layer as the existing check — line-oriented regex over comment-stripped source, no AST, no type
+information, no new dependency. The alias map is the minimum needed to answer "what value is at this
+`??`?" without climbing to a parser.
+
+## 4. Signal vs authority compliance
+
+Unchanged. A CI guard, not a runtime authority. It pushes callers toward `resolveDevAgentGate`; the funnel
+allowlist still exempts the funnel itself.
+
+## 5. Interactions
+
+- `npm run lint` chain — position unchanged; full chain green.
+- Assertions B/C unaffected; their env-fixture tests pass untouched.
+- No source module, route, config key, or state file touched.
+
+## 6. External surfaces
+
+None. Developer tooling, not an agent capability; the Agent Awareness Standard does not apply.
+
+## 7. Rollback cost
+
+`git revert` of one script plus the appended tests. No migration, no state, no deployed artifact.
+
+## Conclusion
+
+Ship. One evasion closed at the scope a peer's audit recommended, four anti-over-block controls added, real
+tree verified clean.
+
+## Evidence pointers
+
+- `tests/unit/lint-dev-agent-dark-gate.test.ts` — **31/31 green** (24 existing + 7 added).
+- Negative control: tests written BEFORE the fix and run against the shipped lint — **3 of 31 fail** (const
+  alias, bracket-access alias, `Boolean(alias)`); the four new controls and all 24 existing tests pass both
+  ways, which is what makes them controls.
+- Reproduced by hand first, with a positive control: the direct form exits 1, the aliased form exits 0.
+- Real-tree verdict: `node scripts/lint-dev-agent-dark-gate.js` → exit 0.
+- Full `npm run lint` chain green.


### PR DESCRIPTION
## What this fixes

`lint-dev-agent-dark-gate` assertion A bans hand-rolled dev-agent gate resolution — anything resolving `enabled ?? !!<x>.developmentAgent` outside `resolveDevAgentGate`. It matched `.developmentAgent` (or `['developmentAgent']`) **literally after the `??`**, so lifting the value into a local const first walked past it while making the same decision by hand:

```ts
const da = config.developmentAgent;
return enabled ?? !!da;          // exit 0 against the shipped lint
```

instar-codey reproduced this while auditing ~20 rename-defeatable checks and pre-scoped the remedy: *"low FP risk for simple local alias folding around `developmentAgent` feeding `??`."* That is exactly the scope implemented.

**The header already declared this limit** — *"cannot catch arbitrary aliases/wrapper helpers"* — and that declaration was honest. It is closed for the shape that actually occurs, and narrowed rather than deleted.

## ELI16

Some features are meant to be live on a **development** agent and dark everywhere else, so they get exercised before reaching the fleet. One shared helper answers "is this a development agent?", and everything is supposed to route through it. If people hand-roll that decision, the answer drifts and features that were supposed to be exercised quietly aren't — so a lint fails the build when it sees the decision made by hand.

It was looking for exactly `enabled ?? !!config.developmentAgent` — the flag written immediately after the `??`. But you don't have to write it there. Put it in a variable first and the words `developmentAgent` and `??` end up on different lines, invisible to the check, while the code does precisely the same thing.

Nothing about that is sneaky, which is what makes it worth closing: pulling a value into a named variable is ordinary tidying. Someone could step around this guard while making code *nicer*, and nothing would say a word.

Now the lint reads the file for any local variable set from `config.developmentAgent` and treats `?? !!thatVariable` the same as the direct form.

It won't start failing builds it shouldn't, and four things are deliberate: only that value counts (a variable set from anything else is fine); matching is whole-word, so `config.developmentAgentName` is a different thing; **reading** the flag stays legal — `const da = config.developmentAgent; return da ? "dev" : "fleet"` is untouched, because using the value is fine and hand-rolling the *fallback decision* is what's banned; and commented-out code binds nothing. Aliases are read per file, so one file's variable can never affect another's.

Full version: `docs/specs/dev-agent-gate-alias.eli16.md`.

## What it still can't see, stated in the source

A **helper function** wrapping the check (`isDevAgent(config)`) · an alias imported from **another file** · anything needing real dataflow. Guessing at those would flag correct code, and this lint fails builds.

## Evidence

- `tests/unit/lint-dev-agent-dark-gate.test.ts` — **31/31 green** (24 existing + 7 added).
- Reproduced by hand FIRST, with a positive control: the direct form exits 1, the aliased form exits 0. The control firing is what makes the evasion verdict mean anything.
- **Negative control:** tests written before the fix and run against the shipped lint — **3 of 31 fail** (const alias, bracket-access alias, `Boolean(alias)`). The other 28, including the four new anti-over-block controls, pass both ways — which is what makes them controls.
- Real-tree verdict: `node scripts/lint-dev-agent-dark-gate.js` → exit 0, **no new flags on existing code**.
- Full `npm run lint` chain green.
- Tier **1** declared: CI-only tooling, 46 in-scope LOC, no runtime path, state, route, config key or user surface; worst case is a build that blocks or fails to block, revertible by reverting one script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
