### PR TITLE
fix: catch split literal messaging gates

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-14T23-45-32-134Z-lint-split-key-messaging-gate.json
+++ b/.instar/instar-dev-decisions/2026-08-14T23-45-32-134Z-lint-split-key-messaging-gate.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-14T23:45:32.134Z",
+  "slug": "lint-split-key-messaging-gate",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 154,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-unreachable-messaging-gate.js"
+    ],
+    "addedLines": 150,
+    "deletedLines": 4
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/eli16/lint-split-key-messaging-gate.eli16.md
+++ b/docs/eli16/lint-split-key-messaging-gate.eli16.md
@@ -1,0 +1,37 @@
+# Split Messaging Gate Lint - Plain-English Overview
+
+The one-line version: the build lint that catches permanently-off `messaging.*` feature switches now also catches the same key when it is written as two literal string pieces joined with `+`.
+
+## The Problem
+
+Instar has a lint named `lint-no-unreachable-messaging-gate`. Its job is narrow but important: if code asks LiveConfig for a key under `messaging.*` with a default of `false`, that feature can be structurally impossible to turn on from the normal top-level config shape. That is especially risky because default-off features are often safety, delivery, or follow-through systems. The code may look guarded and configurable while the actual key path leaves it dark forever.
+
+The shipped lint caught the plain form:
+
+```ts
+liveConfig.get('messaging.actionClaim.enabled', false)
+```
+
+It did not catch an equivalent split-literal form:
+
+```ts
+liveConfig.get('messaging.' + 'actionClaim.enabled', false)
+```
+
+That means a source edit could accidentally or intentionally spell the same unreachable key in a way the lint could not see.
+
+## What This Adds
+
+The scanner now parses the first argument to `.get(...)` when that argument is made only of string literals joined by `+`. It folds those literal pieces into one key before applying the existing rule. If the folded key starts with `messaging.` and the default argument remains the literal `false`, the lint reports the line.
+
+The scope is deliberately small. It does not evaluate variables, function calls, computed values, or template expressions like `` `messaging.${name}` ``. Those cases are not constant literals, so the lint leaves them alone instead of guessing.
+
+## Safeguards
+
+The old whole-literal behavior still works. A non-messaging key such as `monitoring.burnDetection.enabled` still does not report. A key mentioned only in a comment is ignored. A messaging key with a `true` default still does not report, because the bug being guarded is specifically a default-off feature staying unenableable.
+
+The change is implemented in the lint script and tested directly through `scanText`, so the failure mode is visible before touching the real tree. The shipped lint produced zero hits on the split-key reproduction, which is recorded as one reproduction failure. After the fix, the same reproduction reports the offending line and the real repository scan is clean.
+
+## What You Need To Decide
+
+This PR asks whether literal-only folding is the right size of protection for this bug class. It closes the reproduced bypass without turning the lint into a broad JavaScript evaluator.

--- a/scripts/lint-no-unreachable-messaging-gate.js
+++ b/scripts/lint-no-unreachable-messaging-gate.js
@@ -42,14 +42,160 @@ export const UNREACHABLE_OFF_GATE =
 
 const SUPPRESS = /lint-allow-messaging-gate\s*:/;
 
+function stripCommentsPreserveLines(text) {
+  let out = '';
+  let inBlock = false;
+  let quote = null;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (inBlock) {
+      if (ch === '*' && next === '/') {
+        out += '  ';
+        i += 1;
+        inBlock = false;
+      } else {
+        out += ch === '\n' ? '\n' : ' ';
+      }
+      continue;
+    }
+
+    if (quote) {
+      out += ch;
+      if (ch === '\\' && i + 1 < text.length) {
+        out += text[i + 1];
+        i += 1;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === '/' && next === '/') {
+      out += '  ';
+      i += 1;
+      while (i + 1 < text.length && text[i + 1] !== '\n') {
+        out += ' ';
+        i += 1;
+      }
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      out += '  ';
+      i += 1;
+      inBlock = true;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') quote = ch;
+    out += ch;
+  }
+
+  return out;
+}
+
+function skipWs(s, i) {
+  while (i < s.length && /\s/.test(s[i])) i += 1;
+  return i;
+}
+
+function parseStringLiteral(s, start) {
+  const quote = s[start];
+  if (quote !== "'" && quote !== '"' && quote !== '`') return null;
+
+  let value = '';
+  for (let i = start + 1; i < s.length; i += 1) {
+    const ch = s[i];
+    if (ch === '\\' && i + 1 < s.length) {
+      value += s[i + 1];
+      i += 1;
+      continue;
+    }
+    if (quote === '`' && ch === '$' && s[i + 1] === '{') return null;
+    if (ch === quote) return { value, end: i + 1 };
+    value += ch;
+  }
+  return null;
+}
+
+function parseLiteralConcat(s, start) {
+  let i = skipWs(s, start);
+  let parsed = parseStringLiteral(s, i);
+  if (!parsed) return null;
+
+  let value = parsed.value;
+  i = skipWs(s, parsed.end);
+  while (s[i] === '+') {
+    i = skipWs(s, i + 1);
+    parsed = parseStringLiteral(s, i);
+    if (!parsed) return null;
+    value += parsed.value;
+    i = skipWs(s, parsed.end);
+  }
+
+  return { value, end: i };
+}
+
+function getCallArgStartAt(s, start) {
+  if (!s.startsWith('.get', start)) return null;
+  if (/[$_\p{ID_Continue}]/u.test(s[start + 4] ?? '')) return null;
+
+  let i = skipWs(s, start + 4);
+  if (s[i] === '<') {
+    const close = s.indexOf('>', i + 1);
+    if (close === -1) return null;
+    i = skipWs(s, close + 1);
+  }
+  if (s[i] !== '(') return null;
+  return i + 1;
+}
+
+function lineHasUnreachableOffGate(line) {
+  let quote = null;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (quote) {
+      if (ch === '\\' && i + 1 < line.length) {
+        i += 1;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      continue;
+    }
+
+    const firstArgStart = getCallArgStartAt(line, i);
+    if (firstArgStart === null) continue;
+
+    const firstArg = parseLiteralConcat(line, firstArgStart);
+    if (!firstArg || !firstArg.value.startsWith('messaging.')) continue;
+
+    let j = skipWs(line, firstArg.end);
+    if (line[j] !== ',') continue;
+    j = skipWs(line, j + 1);
+    if (line.startsWith('false', j) && !/[$_\p{ID_Continue}]/u.test(line[j + 5] ?? '')) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Scan raw source text; return 1-indexed line numbers of un-suppressed offenders. */
 export function scanText(text) {
-  const lines = text.split('\n');
+  const lines = stripCommentsPreserveLines(text).split('\n');
+  const originalLines = text.split('\n');
   const hits = [];
   lines.forEach((line, i) => {
-    if (!UNREACHABLE_OFF_GATE.test(line)) return;
-    if (SUPPRESS.test(line)) return;
-    if (i > 0 && SUPPRESS.test(lines[i - 1])) return;
+    if (!lineHasUnreachableOffGate(line)) return;
+    if (SUPPRESS.test(originalLines[i])) return;
+    if (i > 0 && SUPPRESS.test(originalLines[i - 1])) return;
     hits.push(i + 1);
   });
   return hits;

--- a/tests/unit/lint-no-unreachable-messaging-gate.test.ts
+++ b/tests/unit/lint-no-unreachable-messaging-gate.test.ts
@@ -19,8 +19,18 @@ describe('lint-no-unreachable-messaging-gate detector', () => {
     expect(scanText(`x.get('messaging.bar.baz', false)`)).toEqual([1]);
   });
 
+  it('flags literal-concatenated messaging keys with a false default', () => {
+    const src = `const enabled = liveConfig.get('messaging.' + 'actionClaim.enabled', false);`;
+    expect(scanText(src)).toEqual([1]);
+  });
+
   it('does NOT flag a default-TRUE messaging gate (unreachable just means it stays on)', () => {
     const src = `const on = liveConfig.get('messaging.outboundAdvisory.enabled', true) ?? true;`;
+    expect(scanText(src)).toEqual([]);
+  });
+
+  it('does NOT flag a literal-concatenated default-TRUE messaging gate', () => {
+    const src = `const on = liveConfig.get('messaging.' + 'outboundAdvisory.enabled', true) ?? true;`;
     expect(scanText(src)).toEqual([]);
   });
 
@@ -31,6 +41,31 @@ describe('lint-no-unreachable-messaging-gate detector', () => {
 
   it('does NOT flag a non-messaging default-off gate', () => {
     const src = `const on = liveConfig.get('monitoring.burnDetection.enabled', false);`;
+    expect(scanText(src)).toEqual([]);
+  });
+
+  it('does NOT flag literal-concatenated non-messaging keys with a false default', () => {
+    const src = `const on = liveConfig.get('monitoring.' + 'burnDetection.enabled', false);`;
+    expect(scanText(src)).toEqual([]);
+  });
+
+  it('does NOT fold non-literal concatenated messaging keys', () => {
+    const src = `const on = liveConfig.get('messaging.' + featureKey, false);`;
+    expect(scanText(src)).toEqual([]);
+  });
+
+  it('does NOT fold template expressions', () => {
+    const src = 'const on = liveConfig.get(`messaging.${featureKey}`, false);';
+    expect(scanText(src)).toEqual([]);
+  });
+
+  it('does NOT flag messaging keys mentioned only in comments', () => {
+    const src = `// liveConfig.get('messaging.actionClaim.enabled', false)`;
+    expect(scanText(src)).toEqual([]);
+  });
+
+  it('does NOT flag messaging gate examples inside string literals', () => {
+    const src = `const example = "liveConfig.get('messaging.' + 'actionClaim.enabled', false)";`;
     expect(scanText(src)).toEqual([]);
   });
 

--- a/upgrades/next/lint-split-key-messaging-gate.md
+++ b/upgrades/next/lint-split-key-messaging-gate.md
@@ -1,0 +1,11 @@
+<!-- bump: patch -->
+<!-- internal-only -->
+
+## What Changed
+
+- Strengthened the unreachable messaging gate lint so it detects default-off `messaging.*` LiveConfig keys built from literal string concatenation.
+
+## Evidence
+
+- `npx vitest run tests/unit/lint-no-unreachable-messaging-gate.test.ts`
+- `node scripts/lint-no-unreachable-messaging-gate.js`

--- a/upgrades/side-effects/lint-split-key-messaging-gate.md
+++ b/upgrades/side-effects/lint-split-key-messaging-gate.md
@@ -1,0 +1,117 @@
+# Side-Effects Review - Split-Key Messaging Gate Lint
+
+**Version / slug:** `lint-split-key-messaging-gate`
+**Date:** `2026-08-14`
+**Author:** `Instar-codey`
+**Second-pass reviewer:** `Locke`
+
+## Summary of the change
+
+This change strengthens `scripts/lint-no-unreachable-messaging-gate.js` so the existing unreachable default-off `messaging.*` LiveConfig lint also recognizes first-argument string literals joined with `+`, for example `liveConfig.get('messaging.' + 'actionClaim.enabled', false)`. The focused unit test file `tests/unit/lint-no-unreachable-messaging-gate.test.ts` now covers the reproduced split-key miss and the required controls. The release fragment is `upgrades/next/lint-split-key-messaging-gate.md`. Build location was a fresh worktree at `.worktrees/codey-lint-split-key-messaging-gate` on `JKHeadley/instar`, version `1.3.1146`, branched from current `origin/main`.
+
+## Decision-point inventory
+
+- `scripts/lint-no-unreachable-messaging-gate.js` - modify - build-time decision that flags source lines where `LiveConfig.get` uses a `messaging.*` key with literal `false` default.
+- Release note internal-only classification - pass-through - this is a script/test/docs-only change with no shipped `src/` runtime surface.
+
+---
+
+## 1. Over-block
+
+The main legitimate input risk is a dynamic backtick template such as `` liveConfig.get(`messaging.${featureKey}`, false) `` being treated as a constant key. The implementation rejects template expressions during literal parsing, and the unit suite includes that negative control. Second-pass review also found that the first implementation could flag a `.get(...)` example embedded inside another string literal; the scanner now only recognizes `.get` tokens outside ordinary string literal text, and a regression test covers `const example = "liveConfig.get('messaging.' + 'actionClaim.enabled', false)"`. A literal-concat non-messaging key such as `liveConfig.get('monitoring.' + 'burnDetection.enabled', false)` is explicitly covered and remains accepted. A default-true split key remains accepted because the lint is specifically about default-off gates staying unreachable.
+
+---
+
+## 2. Under-block
+
+The lint still misses non-literal construction such as `liveConfig.get('messaging.' + featureKey, false)` or helper-returned keys. That is intentional for this change: widening into dataflow or general expression evaluation would raise false-positive risk and would be a different guard. The known reproduced bypass is literal-plus-literal construction, and that class is now covered.
+
+---
+
+## 3. Level-of-abstraction fit
+
+This is the right layer for the fix. The problem is a static source spelling that hides an unreachable configuration key. A build lint can catch the enumerable literal shape cheaply before release. A runtime gate would be later, noisier, and would still allow dead code to ship. The implementation uses a narrow scanner rather than general JavaScript evaluation, which fits the lint's existing design.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No - this change produces a signal consumed by an existing smart gate.
+- [ ] No - this change has no block/allow surface.
+- [ ] Yes - but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [x] Yes, but over a hard enumerable source invariant rather than a competing-signals judgment point.
+
+This lint has blocking authority in the build, but it is not deciding from brittle runtime context. It enforces a concrete invariant: a literal `messaging.*` config key with literal `false` default is unreachable through the expected top-level config surface. The new part only folds literal string pieces before applying that same invariant.
+
+---
+
+## 4b. Judgment-point check (Judgment Within Floors standard)
+
+No new static heuristic at a competing-signals decision point. The domain is enumerable source text: literal string values, `+` separators, and the literal `false` default. There are no live signals such as ownership, urgency, recency, or user intent to arbitrate.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** This replaces the prior single-regex detection path inside the same lint. It does not run before another checker or suppress another result.
+- **Double-fire:** One line produces one hit through `scanText`; the scanner returns line numbers as before.
+- **Races:** No shared runtime state. The script reads the source tree and exits.
+- **Feedback loops:** No feedback loop. The output feeds developer/build action only.
+
+---
+
+## 6. External surfaces
+
+No user-facing runtime surface changes. Other agents and users only see the effect when developing Instar: split-literal unreachable messaging gates fail the lint. No external service calls, no persistent state changes, no generated URLs, no timing dependency, and no operator-facing action surface.
+
+---
+
+## 6b. Operator-surface quality (Operator-Surface Quality standard)
+
+No operator surface - not applicable.
+
+---
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+Machine-local by design: this is a source-tree lint that runs in the checkout performing the build. It holds no durable agent state, emits no user-facing notices, and generates no URLs. Multi-machine coherence is handled by committing the script/tests/release notes to git so every machine receives the same lint behavior after update.
+
+---
+
+## 8. Rollback cost
+
+Pure code/test/docs change. Rollback is a hot-fix revert of the lint parser and its tests plus the release fragment. No data migration, no agent state repair, and no user-visible runtime regression during rollback.
+
+---
+
+## Conclusion
+
+The review narrowed the implementation to literal-only first-argument folding, added a negative test for template expressions, and resolved second-pass's string-example false-positive concern by scanning for `.get` only outside string literal text. The change is clear to ship with the known caveat that dynamic key construction remains out of scope for this lint.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `Locke`
+**Independent read of the artifact:** `concern, resolved`
+
+Initial concern: the first implementation scanned for `.get` across preserved string contents, so a non-executed example string such as `const example = "liveConfig.get('messaging.' + 'actionClaim.enabled', false)"` could be reported. Resolution: `lineHasUnreachableOffGate` now locates `.get` only while outside string literal text, and `tests/unit/lint-no-unreachable-messaging-gate.test.ts` includes the example-string negative control. Dynamic concatenation and template expressions remained out of scope as intended.
+
+---
+
+## Evidence pointers
+
+- Shipped-lint reproduction before the fix: split key returned `hits: []`, counted as `failureCount: 1`.
+- After fix direct probe: split key returns `hits: [1]`.
+- Focused suite: `npx vitest run tests/unit/lint-no-unreachable-messaging-gate.test.ts` passed `15/15` after the second-pass fix.
+- Real tree: `node scripts/lint-no-unreachable-messaging-gate.js` exited clean with no existing flags.
+- Full lint: `npm run lint` exited clean.
+- Full push suite: `npm run test:push` ran 44,154 tests; 44,121 passed, 27 skipped, 3 todo, and 3 failed. Two failures were live Gemini e2e tests requiring absent `GEMINI_API_KEY`; the third feedback-drain ordering failure reran green in isolation.
+
+---
+
+## Class-Closure Declaration (display-only mirror)
+
+No agent-authored-artifact defect - not applicable. This fixes a source-code lint detection gap and adds direct regression tests for the reproduced shape.


### PR DESCRIPTION
## ELI16 — Split messaging gate lint

The build lint that catches permanently-off `messaging.*` feature switches now also catches the same key when it is written as two literal string pieces joined with `+`. A key like `liveConfig.get('messaging.' + 'actionClaim.enabled', false)` used to look equivalent to the already-banned whole string form, but the shipped scanner returned no hits. That matters because `messaging` is array-shaped in real installs, so a default-off child key under `messaging.*` can be structurally impossible to turn on.

This PR keeps the fix deliberately narrow. It only folds first-argument string literals joined by `+`, preserves the existing literal `false` default condition, and leaves dynamic concatenation or template expressions alone instead of guessing. A second-pass review caught one false-positive risk: examples embedded inside ordinary string literals. The scanner now recognizes `.get(...)` only when that token appears outside string literal text, while still parsing string literals inside the actual call arguments.

## What changed

Strengthens `scripts/lint-no-unreachable-messaging-gate.js` so the unreachable default-off `messaging.*` LiveConfig lint folds first-argument string literals joined with `+` before applying the existing `false` default check.

Scope is intentionally narrow: literal string concatenation only. Dynamic concatenation and template expressions are not folded. The scanner now also ignores `.get(...)` examples embedded inside non-code string literal text.

## Reproduction

Against the shipped lint, this reproduction returned no hits:

```js
liveConfig.get('messaging.' + 'actionClaim.enabled', false)
```

Recorded failure count: `1` (`hits: []`, expected a flagged line).

After the fix, the same probe returns `hits: [1]`.

## Controls

- Whole literal `messaging.*` key with `false` default still flags.
- Split literal `messaging.*` key with `false` default flags.
- Non-messaging key does not flag.
- Comment-only mention does not flag.
- Default-true messaging key does not flag.
- Dynamic concatenation and template expressions do not fold.
- Embedded example string does not flag.

## Real-tree result

`node scripts/lint-no-unreachable-messaging-gate.js` is clean against the real tree. No existing legitimate code was flagged.

## Validation

- `npx vitest run tests/unit/lint-no-unreachable-messaging-gate.test.ts` - passed `15/15`.
- Direct after-fix probe - split key `hits: [1]`, embedded example string `[]`.
- `node scripts/lint-no-unreachable-messaging-gate.js` - clean.
- `npm run lint` - passed.
- `node scripts/pre-push-gate.js` - passed, with existing package-version warning.
- `npm run test:smoke` - passed affected set `15/15`.
- `git diff --check HEAD~1 HEAD` - clean.
- `npm run test:push` - ran the full push suite: `44,121` passed, `27` skipped, `3` todo, `3` failed. The failures were two live Gemini e2e tests requiring absent `GEMINI_API_KEY`, plus one unrelated feedback-drain ordering assertion that reran green in isolation.

## Release notes

Adds an internal-only patch fragment under `upgrades/next/`. No shipped `src/` runtime surface is touched.
