### PR TITLE
fix(lint): topic-creation guard resolves the method name

### DIFF
--- a/.instar/instar-dev-decisions/2026-08-15T00-25-46-326Z-topic-creation-lint-resolution.json
+++ b/.instar/instar-dev-decisions/2026-08-15T00-25-46-326Z-topic-creation-lint-resolution.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2026-08-15T00:25:46.326Z",
+  "slug": "topic-creation-lint-resolution",
+  "suggestedTier": 2,
+  "declaredTier": 1,
+  "riskFloor": 1,
+  "riskFloorReasons": [],
+  "belowFloor": false,
+  "files": 1,
+  "loc": 148,
+  "scope": {
+    "basis": "staged-in-scope-additions-plus-deletions",
+    "files": [
+      "scripts/lint-no-unfunneled-topic-creation.js"
+    ],
+    "addedLines": 123,
+    "deletedLines": 25
+  },
+  "causalAutopsy": null,
+  "classClosure": null,
+  "verdict": "pass"
+}

--- a/docs/specs/topic-creation-lint-resolution.eli16.md
+++ b/docs/specs/topic-creation-lint-resolution.eli16.md
@@ -1,0 +1,86 @@
+# ELI16 — the flood guard that could be switched off by naming a string
+
+## What it protects
+
+Instar can create its own Telegram topics — those separate threads you see for alerts, updates and
+so on. Left unbounded, a single buggy feature can create hundreds of them and bury the useful ones.
+That has actually happened three times, most memorably when a detector gave every one of its notices
+a slightly different label and so slipped past the per-source limit.
+
+The final defence against that is a single place in the code where topics are born, which counts them
+and refuses once a budget is spent. A check runs on every build to make sure nobody calls the Telegram
+API directly and goes around that counter.
+
+## What was wrong
+
+The check looked for the Telegram method name written out as text, right next to the call:
+
+```js
+apiCall("createForumTopic", { name: "..." })
+```
+
+Which means it saw nothing at all here:
+
+```js
+const M = "createForumTopic";
+apiCall(M, { name: "..." });
+```
+
+Same call. Same Telegram API. Same flood. Invisible to the check.
+
+Two more spellings did the same thing: gluing the name together from two pieces
+(`"createForum" + "Topic"`), and passing the named constant to the alternative form of the call.
+
+**Nothing about any of that is sneaky, and that is the point.** Pulling a repeated string into a named
+constant is ordinary tidying — the sort of thing you do to make code *nicer*. Someone could step
+around a safety floor while cleaning up, and the build would say "clean".
+
+I measured this before changing anything: a known-bad call the check *does* catch, run in the same
+pass, so I could prove the test itself worked. It caught the plain form and missed all three others.
+
+## What changed
+
+Before applying its rules, the check now works out what the method name actually is: it follows a
+named constant back to the text it holds, and glues together pieces of text that sit next to each
+other. The rules themselves are untouched — they just see through one level of naming.
+
+## Why it won't start failing builds it shouldn't
+
+This check blocks commits, so wrongly flagging correct code would cost more than the hole it closes —
+a noisy check gets switched off, and then it protects nothing. Six things are deliberate, each with a
+test:
+
+1. **A constant holding something else is fine.** Only the actual method name counts.
+2. **A name that never reaches a call is fine.** Holding the text is not the same as calling with it.
+3. **An ambiguous name is left alone.** If the same name is set to two different things in one file,
+   it is treated as unresolvable rather than guessed at — guessing wrong fails someone's build.
+4. **It never invents text.** `"createForum" + suffix` stays unresolved, because working out what
+   `suffix` holds would take real analysis and the answer would be a guess.
+5. **A longer name that merely starts the same way is fine** — a different Telegram method is a
+   different method.
+6. **Substitution happens only at the two places the rules look**, never everywhere, so an unrelated
+   line mentioning the same value is untouched.
+
+It also only ever looks within a single file, so one file's names can never affect another's.
+
+## What it still can't see, stated plainly
+
+- A name imported from **another file**.
+- A name built at runtime from a variable, a function call, or a template.
+- Anything needing real dataflow analysis.
+
+Those need a different kind of tool. Guessing at them would flag correct code.
+
+## One more thing this fixes, quietly
+
+Running this check used to be all-or-nothing: importing it to test its internals would run the whole
+repository scan and, on the first real violation, kill the process — taking the test run with it. Three
+other checks hit exactly that this week. It now only runs the scan when you run it directly, which is
+what makes the tests above possible at all.
+
+## How you know it works
+
+The tests were written first and run against the old behaviour: **five of the eighteen fail** without
+this change. The other thirteen pass either way — those are the controls, and most of them exist purely
+to prove the check stays quiet where it should. Against the real codebase it reports clean both before
+and after, so nothing that exists today is newly blocked.

--- a/scripts/lint-no-unfunneled-topic-creation.js
+++ b/scripts/lint-no-unfunneled-topic-creation.js
@@ -64,6 +64,86 @@ const PATTERNS = [
   /method\s*:\s*['"`]createForumTopic['"`]/,
 ];
 
+// ── Name resolution (added 2026-08-15) ────────────────────────────────────
+// The three patterns above each require `createForumTopic` as a string
+// LITERAL adjacent to the seam. Measured against the shipped lint, all three
+// of these reach the Bot API and NONE were caught:
+//
+//   const M = 'createForumTopic'; apiCall(M, {...});
+//   apiCall('createForum' + 'Topic', {...});
+//   const M = 'createForumTopic'; ({ method: M, ... });
+//
+// None of that is evasive — lifting a repeated string into a named constant
+// is ordinary tidying. Someone could step around the notification-flood
+// ceiling while making code NICER, and this lint would say `clean`. So the
+// method name is RESOLVED before the existing rules are applied; the rules
+// themselves are unchanged, they simply see through one level of naming.
+//
+// Deliberately NOT a parser. Everything below is bounded, per-file, and
+// fails toward NOT flagging, because this lint blocks commits and a check
+// that flags correct code gets switched off — which would cost more than the
+// hole it closes.
+
+const METHOD = 'createForumTopic';
+
+/**
+ * Fold ADJACENT string literals only: `'a' + 'b'` -> `'ab'`.
+ * Never invents text and never folds across an identifier, so
+ * `'createForum' + suffix` stays unresolved rather than guessed at.
+ */
+export function foldAdjacentLiterals(text) {
+  let out = text;
+  for (let i = 0; i < 5; i++) {
+    const next = out.replace(
+      /(['"`])([^'"`\n]*)\1\s*\+\s*(['"`])([^'"`\n]*)\3/g,
+      (_m, q, a, _q2, b) => `${q}${a}${b}${q}`,
+    );
+    if (next === out) break;
+    out = next;
+  }
+  return out;
+}
+
+/**
+ * Identifiers bound to a string literal (after folding) in THIS file.
+ * An identifier bound more than once to DIFFERENT values is UNRESOLVABLE and
+ * is dropped, so an ambiguous name can never be substituted into a match.
+ */
+export function collectStringConsts(lines) {
+  const seen = new Map();
+  const conflicting = new Set();
+  const DECL = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*([^;]+)/;
+  for (const line of lines) {
+    const m = DECL.exec(line);
+    if (!m) continue;
+    const name = m[1];
+    const folded = foldAdjacentLiterals(m[2].trim());
+    const lit = /^(['"`])([^'"`\n]*)\1\s*$/.exec(folded);
+    if (!lit) continue;
+    const value = lit[2];
+    if (seen.has(name) && seen.get(name) !== value) conflicting.add(name);
+    else seen.set(name, value);
+  }
+  for (const name of conflicting) seen.delete(name);
+  return seen;
+}
+
+/**
+ * Produce a view of one line with the method name resolved, for matching only.
+ * Substitution happens ONLY in the two seam positions the rules look at —
+ * never globally — so an unrelated identifier sharing a value is untouched.
+ */
+export function resolveLine(line, consts) {
+  let out = foldAdjacentLiterals(line);
+  out = out.replace(/(apiCall\(\s*)([A-Za-z_$][\w$]*)/g, (m, head, name) =>
+    consts.get(name) === METHOD ? `${head}'${METHOD}'` : m,
+  );
+  out = out.replace(/(method\s*:\s*)([A-Za-z_$][\w$]*)/g, (m, head, name) =>
+    consts.get(name) === METHOD ? `${head}'${METHOD}'` : m,
+  );
+  return out;
+}
+
 function listFiles() {
   const staged = process.argv.includes('--staged');
   if (staged) {
@@ -94,36 +174,54 @@ function listFiles() {
   return files;
 }
 
-let violations = 0;
-for (const rel of listFiles()) {
-  const normalized = rel.split(path.sep).join('/');
-  if (ALLOWLIST.has(normalized)) continue;
-  if (!EXTENSIONS.has(path.extname(normalized))) continue;
-  const full = path.join(ROOT, normalized);
-  let content;
-  try {
-    content = fs.readFileSync(full, 'utf-8');
-  } catch {
-    continue;
-  }
+export function scanFile(normalized, content) {
   const lines = content.split('\n');
+  const consts = collectStringConsts(lines);
+  const hits = [];
   for (let i = 0; i < lines.length; i++) {
+    const resolved = resolveLine(lines[i], consts);
     for (const pattern of PATTERNS) {
-      if (pattern.test(lines[i])) {
-        console.error(
-          `${normalized}:${i + 1} — raw createForumTopic invocation outside the budgeted funnel. ` +
-          `Route through TelegramAdapter.createForumTopic / findOrCreateForumTopic (declare an origin/label), ` +
-          `or add an allowlist entry here with a bounded-volume justification.`,
-        );
-        violations++;
-      }
+      if (pattern.test(resolved)) hits.push({ file: normalized, line: i + 1 });
     }
   }
+  return hits;
 }
 
-if (violations > 0) {
-  console.error(`\nlint-no-unfunneled-topic-creation: ${violations} violation(s). ` +
-    `See docs/STANDARDS-REGISTRY.md "Bounded Notification Surface".`);
-  process.exit(1);
+function runLint() {
+  let violations = 0;
+  for (const rel of listFiles()) {
+    const normalized = rel.split(path.sep).join('/');
+    if (ALLOWLIST.has(normalized)) continue;
+    if (!EXTENSIONS.has(path.extname(normalized))) continue;
+    const full = path.join(ROOT, normalized);
+    let content;
+    try {
+      content = fs.readFileSync(full, 'utf-8');
+    } catch {
+      continue;
+    }
+    for (const hit of scanFile(normalized, content)) {
+      console.error(
+        `${hit.file}:${hit.line} — raw createForumTopic invocation outside the budgeted funnel. ` +
+        `Route through TelegramAdapter.createForumTopic / findOrCreateForumTopic (declare an origin/label), ` +
+        `or add an allowlist entry here with a bounded-volume justification.`,
+      );
+      violations++;
+    }
+  }
+
+  if (violations > 0) {
+    console.error(`\nlint-no-unfunneled-topic-creation: ${violations} violation(s). ` +
+      `See docs/STANDARDS-REGISTRY.md "Bounded Notification Surface".`);
+    process.exit(1);
+  }
+  console.log('lint-no-unfunneled-topic-creation: clean');
 }
-console.log('lint-no-unfunneled-topic-creation: clean');
+
+// DIRECT-INVOCATION GUARD. Without this, importing this module to unit-test the
+// resolution helpers runs the whole repo scan — and calls process.exit(1) the
+// moment the repo has a real violation, killing the test runner. Three other
+// lints hit exactly that this window; the guard is the same fix.
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename);
+if (invokedDirectly) runLint();

--- a/tests/unit/topic-creation-lint-resolution.test.ts
+++ b/tests/unit/topic-creation-lint-resolution.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  foldAdjacentLiterals,
+  collectStringConsts,
+  resolveLine,
+  scanFile,
+} from '../../scripts/lint-no-unfunneled-topic-creation.js';
+
+/**
+ * `lint-no-unfunneled-topic-creation` guards the Bounded Notification Surface —
+ * the last-resort budget on automatically-created Telegram topics, added after
+ * the THIRD topic-spam incident. Its three rules each required `createForumTopic`
+ * as a string LITERAL adjacent to the seam, so lifting the name into a named
+ * constant walked straight past a safety floor while making the code tidier.
+ *
+ * THE DEFECT tests fail against the shipped lint. The CONTROL tests pass against
+ * BOTH, which is what makes them controls rather than echoes: this lint blocks
+ * commits, so a version that flags correct code would be worse than the hole.
+ *
+ * These tests can only import this module because it now carries a
+ * direct-invocation guard. Without it, importing runs the whole repo scan and
+ * calls process.exit(1) on the first real violation, killing the test run.
+ */
+
+const CATCHABLE = (src: string) => scanFile('src/probe.ts', src).length > 0;
+
+describe('THE DEFECT — a resolved name reaches the Bot API unseen', () => {
+  it('catches a method name lifted into a local const', () => {
+    expect(
+      CATCHABLE('const M = "createForumTopic";\nawait apiCall(M, { name: "x" });\n'),
+    ).toBe(true);
+  });
+
+  it('catches a method name split across a literal concatenation', () => {
+    expect(CATCHABLE('await apiCall("createForum" + "Topic", { name: "x" });\n')).toBe(true);
+  });
+
+  it('catches a const reaching the hand-rolled `method:` param', () => {
+    expect(
+      CATCHABLE('const M = "createForumTopic";\nconst p = { method: M, name: "x" };\n'),
+    ).toBe(true);
+  });
+
+  it('catches let and var bindings, not only const', () => {
+    expect(CATCHABLE('let M = "createForumTopic";\napiCall(M, {});\n')).toBe(true);
+    expect(CATCHABLE('var M = "createForumTopic";\napiCall(M, {});\n')).toBe(true);
+  });
+
+  it('resolves a const declared AFTER its use — the scan is per file, not per line', () => {
+    expect(CATCHABLE('apiCall(M, {});\nconst M = "createForumTopic";\n')).toBe(true);
+  });
+});
+
+describe('CONTROL — the plain forms the shipped lint already caught still fire', () => {
+  it('still catches the bare literal', () => {
+    expect(CATCHABLE('await apiCall("createForumTopic", { name: "x" });\n')).toBe(true);
+  });
+
+  it('still catches the raw Bot-API URL form', () => {
+    expect(CATCHABLE('const u = "https://api.telegram.org/bot123/createForumTopic";\n')).toBe(true);
+  });
+
+  it('still catches the literal `method:` param', () => {
+    expect(CATCHABLE('const p = { method: "createForumTopic" };\n')).toBe(true);
+  });
+});
+
+describe('CONTROL — correct code stays legal (over-block is the dominant risk)', () => {
+  it('does not flag a const bound to a different method', () => {
+    expect(CATCHABLE('const M = "sendMessage";\napiCall(M, {});\n')).toBe(false);
+  });
+
+  it('does not flag an identifier that never reaches a seam', () => {
+    expect(CATCHABLE('const M = "createForumTopic";\nexport const label = M.length;\n')).toBe(false);
+  });
+
+  it('does not flag an identifier bound twice to DIFFERENT values — unresolvable', () => {
+    // Ambiguity must fail toward NOT flagging. Substituting either value would
+    // be a guess, and a guess that fails a build is the expensive direction.
+    expect(
+      CATCHABLE('const M = "createForumTopic";\nlet M = "sendMessage";\napiCall(M, {});\n'),
+    ).toBe(false);
+  });
+
+  it('does not fold a concatenation that involves an identifier', () => {
+    // `'createForum' + suffix` is not resolvable without dataflow. Folding it
+    // would mean inventing text the source never contains.
+    expect(CATCHABLE('apiCall("createForum" + suffix, {});\n')).toBe(false);
+  });
+
+  it('does not flag a longer name that merely starts with the method', () => {
+    expect(CATCHABLE('const M = "createForumTopicIconStickers";\napiCall(M, {});\n')).toBe(false);
+  });
+
+  it('does not substitute globally — only at the two seam positions', () => {
+    // An unrelated call taking the same identifier must not become a violation
+    // just because the value matches somewhere else in the file.
+    expect(CATCHABLE('const M = "createForumTopic";\nlogger.debug(M);\n')).toBe(false);
+  });
+});
+
+describe('the resolution primitives, pinned directly', () => {
+  it('folds only ADJACENT literals and invents no text', () => {
+    expect(foldAdjacentLiterals('"a" + "b"')).toContain('ab');
+    expect(foldAdjacentLiterals('"a" + b')).toBe('"a" + b');
+  });
+
+  it('drops an identifier with conflicting bindings rather than picking one', () => {
+    const consts = collectStringConsts(['const M = "one";', 'const M = "two";']);
+    expect(consts.has('M')).toBe(false);
+  });
+
+  it('keeps an identifier bound twice to the SAME value', () => {
+    const consts = collectStringConsts(['const M = "one";', 'const M = "one";']);
+    expect(consts.get('M')).toBe('one');
+  });
+
+  it('leaves a line untouched when nothing resolves', () => {
+    const line = 'apiCall(unknownIdent, {});';
+    expect(resolveLine(line, collectStringConsts([]))).toBe(line);
+  });
+});

--- a/upgrades/next/topic-creation-lint-resolution.md
+++ b/upgrades/next/topic-creation-lint-resolution.md
@@ -1,0 +1,62 @@
+# Upgrade Guide — vNEXT
+
+<!-- assembled-by: assemble-next-md -->
+<!-- bump: patch -->
+
+## What Changed
+
+`scripts/lint-no-unfunneled-topic-creation.js` now resolves the Telegram method name before applying
+its rules.
+
+That lint enforces the **Bounded Notification Surface** standard — the last-resort budget on
+automatically-created forum topics, added after the third topic-spam incident. Its three patterns each
+required `createForumTopic` as a string LITERAL adjacent to the seam, so all three of these reached the
+Bot API uncounted while the build reported `clean`:
+
+```js
+const M = 'createForumTopic'; apiCall(M, { name: 'x' });
+apiCall('createForum' + 'Topic', { name: 'x' });
+const M = 'createForumTopic'; ({ method: M, name: 'x' });
+```
+
+Measured against the shipped lint with a positive control (the bare literal) firing in the same run:
+control caught, all three EVADE.
+
+None of that is evasive — lifting a repeated string into a named constant is ordinary tidying. Someone
+could step around a notification-flood ceiling while making code *nicer*, and nothing would say a word.
+
+Added: `foldAdjacentLiterals` (folds `'a' + 'b'` only, never across an identifier),
+`collectStringConsts` (per-file identifier → literal; an identifier bound twice to different values is
+dropped as unresolvable), `resolveLine` (substitutes ONLY at the two seam positions), and `scanFile`
+(extracted so matching is testable). `PATTERNS`, `ALLOWLIST` and the violation message are unchanged.
+
+Also added: a **direct-invocation guard**. Importing this module previously ran the whole repo scan and
+called `process.exit(1)` on the first real violation, killing the importing process — which is why its
+internals had never been unit-tested. Three other lints hit the same hazard this week.
+
+## What to Tell Your User
+
+Nothing changes for you. A build-time check that stops features from creating unlimited Telegram topics
+could be walked past by giving a string a name first — an ordinary bit of tidying, not a trick. It now
+sees through that. Nothing you use behaves differently; a category of notification flood just got harder
+to ship by accident.
+
+## Summary of New Capabilities
+
+None. No new command, endpoint, setting, or runtime behaviour. A CI guard that was defeatable by a local
+constant is no longer defeatable by one.
+
+## Evidence
+
+- `tests/unit/topic-creation-lint-resolution.test.ts` — 18/18 green.
+- **Negative control: 5 of 18 fail** against the shipped matching behaviour; the other 13 pass both ways
+  and are the controls. Source restored byte-exact afterwards (sha match, zero markers left).
+- Six anti-over-block controls, because this lint blocks commits: a const bound elsewhere, an identifier
+  that never reaches a seam, an identifier with conflicting bindings, a concatenation involving an
+  identifier, a longer look-alike method name, and seam-local (not global) substitution.
+- Real tree: `exit 0` before AND after — no new flags on existing code.
+- Full `npm run lint` chain green (57 steps); lint-chain membership verified explicitly rather than
+  inferred from a `package.json` reference.
+- **Declared open in the source:** cross-module names, runtime-built names, and anything needing
+  dataflow. Also named: the lint does not strip comments, which is pre-existing and neither fixed nor
+  worsened here.

--- a/upgrades/side-effects/topic-creation-lint-resolution.md
+++ b/upgrades/side-effects/topic-creation-lint-resolution.md
@@ -1,0 +1,135 @@
+# Side-Effects Review — topic-creation guard resolves the method name
+
+**Version / slug:** `topic-creation-lint-resolution`
+**Date:** `2026-08-15`
+**Author:** `echo`
+**Second-pass reviewer:** `not required — Tier 1 (CI-only lint script; no runtime path). The rule is unchanged; the check now resolves one level of naming before applying the rules it already had.`
+
+## Summary of the change
+
+`scripts/lint-no-unfunneled-topic-creation.js` enforces the **Bounded Notification Surface** standard —
+the last-resort budget on automatically-created forum topics, added after the THIRD topic-spam incident
+(2026-06-05). All three of its patterns required `createForumTopic` as a string LITERAL adjacent to the
+seam, so a resolved name walked past a safety floor.
+
+Measured against the shipped lint, with a positive control (the bare literal) firing in the same run:
+
+| form | shipped |
+|---|---|
+| `apiCall("createForumTopic", …)` — POSITIVE CONTROL | exit 1 (caught) |
+| `const M = "createForumTopic"; apiCall(M, …)` | **exit 0 — EVADES** |
+| `apiCall("createForum" + "Topic", …)` | **exit 0 — EVADES** |
+| `const M = "createForumTopic"; { method: M }` | **exit 0 — EVADES** |
+
+The method name is now RESOLVED before the existing patterns are applied. The patterns are byte-identical;
+only what they can see changed.
+
+## Decision-point inventory
+
+- `foldAdjacentLiterals(text)` — ADD — folds `'a' + 'b'` only; never folds across an identifier.
+- `collectStringConsts(lines)` — ADD — per-file identifier → string-literal map; an identifier bound twice
+  to DIFFERENT values is dropped as unresolvable.
+- `resolveLine(line, consts)` — ADD — substitutes ONLY at the two seam positions (`apiCall(` and `method:`).
+- `scanFile(normalized, content)` — ADD — extracted so the matching behaviour is testable without the CLI.
+- Direct-invocation guard — ADD — the scan runs only when the script is invoked directly.
+- `PATTERNS`, `ALLOWLIST`, `SCAN_DIRS`, `EXTENSIONS`, the violation message and exit codes — UNCHANGED.
+- No runtime block/allow decision added or modified. CI-time only.
+
+## 1. Over-block
+
+The failure that matters. This lint blocks commits, and a check that flags correct code gets switched
+off — which would cost more than the hole it closes. Six controls, each with a test, all passing under
+BOTH the old and new behaviour:
+
+- **A const bound to a different method** (`"sendMessage"`) is not flagged.
+- **An identifier that never reaches a seam** is not flagged — holding the value is not calling with it.
+- **An identifier bound twice to different values** is unresolvable and never substituted. Ambiguity
+  fails toward NOT flagging, because a guess that fails someone's build is the expensive direction.
+- **A concatenation involving an identifier** (`"createForum" + suffix`) is left unresolved. Folding it
+  would mean inventing text the source does not contain.
+- **A longer name starting with the method** (`createForumTopicIconStickers`) is not flagged — the
+  existing quote-delimited patterns already bound this, and resolution preserves it.
+- **Substitution is seam-local, not global** — an unrelated `logger.debug(M)` is untouched.
+
+Resolution is per-file by construction: one file's names cannot affect another's.
+
+**Verified against the real tree: exit 0 before AND after.** No new flags on existing code.
+
+## 2. Under-block
+
+Stated in the source rather than implied:
+
+- **Cross-module names** — a method name imported from another file is not followed.
+- **Runtime-built names** — from a variable, a function call, or a template literal.
+- **Anything needing dataflow** to resolve.
+
+Guessing at those would over-match.
+
+**One residual I want named rather than absorbed:** the lint does not strip comments, so a comment
+containing the literal form is flagged. That is PRE-EXISTING behaviour (it is why this script is on its
+own allowlist), and this change neither fixes nor worsens it — resolution runs on the same lines the
+patterns already ran on. I am not changing it here because loosening a flood guard to be tidier is the
+wrong direction, and doing it unrequested is the unrequested-tightening mistake in reverse.
+
+## 3. Level-of-abstraction fit
+
+Same layer as the existing check — line-oriented regex over raw source, no AST, no type information, no
+new dependency. The resolution map is the minimum needed to answer "what method name is at this seam?"
+without climbing to a parser.
+
+## 4. Signal vs authority compliance
+
+Unchanged. A CI guard, not a runtime authority. It pushes callers toward the budgeted funnel; the
+allowlist still exempts the funnel itself, the lifeline's fixed-cardinality system topic, and the
+setup-wizard doc string.
+
+## 5. Interactions
+
+- `npm run lint` chain — membership verified explicitly (the script is in the `lint` chain CI runs, not
+  merely referenced by a standalone entry); full chain exit 0 across 57 steps.
+- The direct-invocation guard changes import behaviour from "runs the repo scan and may exit(1)" to
+  "exports only". Nothing imported this module before, so no caller changes.
+- No source module, route, config key, or state file touched.
+
+## 6. External surfaces
+
+None. Developer tooling, not an agent capability; the Agent Awareness Standard does not apply.
+
+## 7. Multi-machine posture (Cross-Machine Coherence)
+
+**Machine-local BY DESIGN, and it is the correct posture — not an unexamined assumption.** This is a
+CI-time source scan with no runtime surface: it reads files in one checkout and exits. It holds no
+durable state, emits no user-facing notice, generates no URL, and makes no runtime decision, so there
+is nothing to replicate, nothing to merge on read, and nothing that could strand on a topic transfer.
+
+Every machine that runs the lint runs it over its own checkout of the same tracked source and reaches
+the same verdict — determinism comes from the source tree, not from coordination. Resolution is
+explicitly per-file, so it cannot even depend on the rest of the checkout, let alone another machine.
+
+Worth stating because the audit that added this question found ~20 features shipped machine-blind: the
+thing that makes THIS one genuinely local is that its input is version-controlled and its output is an
+exit code, not that I could not think of a cross-machine concern.
+
+## 8. Rollback cost
+
+`git revert` of one script plus the added test file. No migration, no state, no deployed artifact.
+
+## Conclusion
+
+Ship. Three evasions closed on a safety floor, six anti-over-block controls added, real tree verified
+clean in both directions, and the import hazard that blocked testing it removed.
+
+## Evidence pointers
+
+- `tests/unit/topic-creation-lint-resolution.test.ts` — **18/18 green**.
+- **Negative control: 5 of 18 fail** against the shipped matching behaviour (local const, concatenation,
+  `method:` const, let/var bindings, const-declared-after-use). The other 13 pass both ways — which is
+  what makes them controls. Source restored byte-exact after the mutation (sha match, 0 markers left).
+- Reproduced by hand FIRST with a positive control firing in the same run; the control is what makes the
+  three EVADES verdicts mean anything.
+- Real-tree verdict: `node scripts/lint-no-unfunneled-topic-creation.js` → exit 0, before and after.
+- Full `npm run lint` chain green, 57 steps.
+- Tier **1** declared: risk floor 1 (no safety-invariant path match — verified with two directional
+  controls, `SessionReaper.ts` → floor 2 with its reason named, `devClaimCheck.ts` → floor 1). The size
+  heuristic suggests 2 on added LOC alone; stated openly rather than left silent, since the tier I chose
+  is the one that lets the change through.


### PR DESCRIPTION
## What this fixes

`lint-no-unfunneled-topic-creation` enforces the **Bounded Notification Surface** standard — the
last-resort budget on automatically-created forum topics, added after the THIRD topic-spam incident
(2026-06-05). All three of its patterns required `createForumTopic` as a string **literal adjacent to
the seam**, so a resolved name walked straight past a safety floor:

```js
const M = 'createForumTopic'; apiCall(M, { name: 'x' });      // exit 0 — EVADES
apiCall('createForum' + 'Topic', { name: 'x' });               // exit 0 — EVADES
const M = 'createForumTopic'; ({ method: M, name: 'x' });      // exit 0 — EVADES
```

Measured against the shipped lint with a **positive control** (the bare literal) firing in the same
run — the control is what makes the three EVADES verdicts mean anything.

None of that is evasive. Lifting a repeated string into a named constant is ordinary tidying, so
someone could step around a notification-flood ceiling while making code *nicer*, and the build would
report `clean`.

The method name is now resolved before the existing rules run. `PATTERNS`, `ALLOWLIST` and the
violation message are **unchanged** — only what the rules can see changed.

## ELI16

Instar can create its own Telegram topics — the separate threads you see for alerts and updates. Left
unbounded, one buggy feature can create hundreds of them and bury everything useful. That has actually
happened three times, most memorably when a detector gave every notice a slightly different label and
so slipped past the per-source limit.

The final defence is a single place in the code where topics are born, which counts them and refuses
once a budget is spent. A build check makes sure nobody calls Telegram directly and goes around that
counter.

The check looked for the Telegram method name written out as text, right next to the call. So it saw
nothing at all when the name was put in a named constant first — same call, same API, same flood,
invisible. Two other spellings did the same: gluing the name together from two pieces, and passing the
constant to the alternative form of the call.

Nothing about that is sneaky, and that is the point: pulling a repeated string into a named constant is
the sort of thing you do to make code nicer. Someone could step around a safety floor while cleaning
up, and the build would say "clean".

Now the check works out what the name actually is before applying its rules. It follows a named
constant back to the text it holds, and glues together pieces of text that sit next to each other.

Because this check blocks commits, wrongly flagging correct code would cost more than the hole it
closes — a noisy check gets switched off, and then it protects nothing. So: a constant holding a
different method is fine; a name that never reaches a call is fine; a name set to two different things
in one file is treated as unresolvable rather than guessed at; it never invents text, so
`'createForum' + suffix` stays alone; a longer look-alike method name is fine; and substitution happens
only at the two places the rules look, never everywhere. It also only ever looks within one file.

It still can't see a name imported from another file, or one built at runtime from a variable or
template — those need real dataflow analysis, and guessing would flag correct code.

Full version: `docs/specs/topic-creation-lint-resolution.eli16.md`.

## One thing this fixes quietly

Importing this module used to run the entire repo scan and call `process.exit(1)` on the first real
violation — killing the importing process. That is why its internals had never been unit-tested. It now
scans only when invoked directly. **Three other lints hit exactly this hazard this week**, and a peer
agent's sweep of 144 modules found the direct-invocation guard is already the established convention
here (40 export-bearing modules call `process.exit`, all guarded) — so these were the outliers, not a
systemic gap.

## What it still can't see, stated in the source

Cross-module names · runtime-built names (variable, call, template) · anything needing dataflow.

**One residual I want named rather than absorbed:** the lint does not strip comments, so a comment
containing the literal form is flagged. That is **pre-existing** behaviour — it is why this script sits
on its own allowlist — and this change neither fixes nor worsens it, since resolution runs on the same
lines the patterns already ran on. Not changed here: loosening a flood guard to be tidier is the wrong
direction, and doing it unrequested is its own mistake.

## Evidence

- `tests/unit/topic-creation-lint-resolution.test.ts` — **18/18 green**.
- **Negative control: 5 of 18 fail** against the shipped matching behaviour (local const, concatenation,
  `method:` const, let/var bindings, const-declared-after-use). The other 13 pass **both ways**, which is
  what makes them controls rather than echoes. Source restored **byte-exact** after the mutation (sha
  match, zero markers left).
- **Six anti-over-block controls**, because this lint blocks commits: a const bound elsewhere; an
  identifier that never reaches a seam; an identifier with **conflicting bindings** (unresolvable →
  never substituted, because a guess that fails someone's build is the expensive direction); a
  concatenation involving an identifier; a longer look-alike method name; and seam-local rather than
  global substitution.
- **Real tree: `exit 0` before AND after** — no new flags on existing code.
- Full `npm run lint` chain green (57 steps). Chain membership verified **explicitly** rather than
  inferred from a `package.json` reference — a script can be referenced only as a standalone entry and
  never enter the chain CI runs.
- Tier **1** declared. Risk floor 1, verified with two directional controls (`SessionReaper.ts` → floor 2
  with its reason named; `devClaimCheck.ts` → floor 1). The gate's own signal agreed: `riskFloor=1`. The
  size heuristic suggests 2 on added LOC alone — stated openly, since the tier I choose is the one that
  lets my own change through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
